### PR TITLE
Add local upgrade propagation plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,29 @@ installer stderr:
 goal-harness promotion-gate --format json
 ```
 
+Promotion readiness is necessary but not sufficient when connected Codex App
+heartbeats are installed. Before making a canary checkout the machine default,
+also generate the local upgrade propagation plan:
+
+```bash
+goal-harness upgrade-plan --format json
+```
+
+This command inventories registry-managed controller goals, regenerates the
+brief/compact heartbeat prompts from the candidate CLI contract, and compares
+them with an optional installed automation manifest:
+
+```bash
+goal-harness upgrade-plan \
+  --installed-manifest ~/.codex/goal-harness/installed-heartbeats.json \
+  --format json
+```
+
+If the plan reports unknown or stale prompt digests, update those managed
+heartbeat automations/controller clients before running `scripts/install-local.sh`
+for default promotion. This keeps connected projects from continuing on stale
+prompt branches after the local default version changes.
+
 If a project shell cannot find or run the command, `goal-harness doctor`
 reports PATH, wrapper, release snapshot, canary wrapper, installed skill
 delivery-hint, Python import health, release provenance, and the latest
@@ -588,6 +611,7 @@ reward                  append run-bound human reward
 todo                    add user or agent todos
 quota                   inspect or account for automatic agent turns
 heartbeat-prompt        generate Codex App heartbeat task bodies
+upgrade-plan            plan local default-upgrade heartbeat propagation
 review-packet           package a CLI-visible handoff packet
 serve-status            serve local status JSON for the dashboard
 archive-runtime         archive obsolete runtime-only goal history

--- a/examples/upgrade-plan-smoke.py
+++ b/examples/upgrade-plan-smoke.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Smoke-test local default upgrade propagation planning."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from goal_harness.upgrade import build_upgrade_plan, render_upgrade_plan_markdown  # noqa: E402
+
+
+GOAL_ID = "upgrade-plan-goal"
+
+
+def write_fixture(root: Path) -> tuple[Path, Path]:
+    project = root / "project"
+    runtime = root / "runtime"
+    state_file = project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+    state_file.parent.mkdir(parents=True)
+    state_file.write_text(
+        "---\n"
+        "status: active\n"
+        "updated_at: 2026-01-01T00:00:00+00:00\n"
+        "---\n\n"
+        "## Next Action\n\n"
+        "- Keep the fixture heartbeat prompt current.\n",
+        encoding="utf-8",
+    )
+    registry_path = project / ".goal-harness" / "registry.json"
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "fixture",
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md",
+                        "adapter": {"kind": "generic_project_goal_v0", "status": "connected"},
+                        "quota": {"compute": 1.0, "window_hours": 24},
+                    }
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return registry_path, root / "installed-heartbeats.json"
+
+
+def assert_unknown_manifest_blocks_promotion(registry_path: Path) -> dict:
+    payload = build_upgrade_plan(registry_path=registry_path, modes=["brief"], cli_bin="goal-harness")
+    assert payload["ok"] is True, payload
+    assert payload["summary"]["managed_goal_count"] == 1, payload
+    assert payload["summary"]["unknown_prompt_count"] == 1, payload
+    assert payload["summary"]["ready_for_default_promotion"] is False, payload
+    goal = payload["managed_heartbeats"][0]
+    assert goal["state_file_exists"] is True, payload
+    assert goal["installed_prompts"]["brief"]["status"] == "unknown", payload
+    markdown = render_upgrade_plan_markdown(payload)
+    assert "ready_for_default_promotion: `False`" in markdown, markdown
+    return payload
+
+
+def assert_matching_manifest_is_ready(registry_path: Path, manifest_path: Path, first_payload: dict) -> None:
+    goal = first_payload["managed_heartbeats"][0]
+    prompt_sha = goal["generated_prompts"]["brief"]["sha256"]
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "automations": [
+                    {
+                        "automation_id": "fixture-heartbeat",
+                        "goal_id": GOAL_ID,
+                        "mode": "brief",
+                        "prompt_sha256": prompt_sha,
+                    }
+                ]
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    payload = build_upgrade_plan(
+        registry_path=registry_path,
+        installed_manifest=manifest_path,
+        modes=["brief"],
+        cli_bin="goal-harness",
+    )
+    assert payload["summary"]["unknown_prompt_count"] == 0, payload
+    assert payload["summary"]["stale_prompt_count"] == 0, payload
+    assert payload["summary"]["current_prompt_count"] == 1, payload
+    assert payload["summary"]["ready_for_default_promotion"] is True, payload
+    assert payload["managed_heartbeats"][0]["installed_prompts"]["brief"]["status"] == "current", payload
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="goal-harness-upgrade-plan-smoke-") as raw_tmp:
+        registry_path, manifest_path = write_fixture(Path(raw_tmp))
+        first_payload = assert_unknown_manifest_blocks_promotion(registry_path)
+        assert_matching_manifest_is_ready(registry_path, manifest_path, first_payload)
+    print("upgrade-plan-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -73,6 +73,7 @@ from .status_server import (
     serve_status,
 )
 from .todos import add_goal_todo, render_todo_markdown
+from .upgrade import build_upgrade_plan, render_upgrade_plan_markdown
 
 
 def print_payload(payload: dict[str, object], fmt: str, markdown_renderer) -> None:
@@ -313,6 +314,28 @@ def main(argv: list[str] | None = None) -> int:
     sub.add_parser(
         "promotion-gate",
         help="Emit a compact machine-readable canary promotion readiness gate result.",
+    )
+
+    upgrade_plan_parser = sub.add_parser(
+        "upgrade-plan",
+        help="Plan local default upgrade propagation for managed heartbeat automations.",
+    )
+    upgrade_plan_parser.add_argument("--goal-id", action="append", default=[], help="Only include one goal id. Repeatable.")
+    upgrade_plan_parser.add_argument(
+        "--installed-manifest",
+        help="Optional JSON manifest of installed automations with goal_id, mode, automation_id, and prompt_sha256/task_body.",
+    )
+    upgrade_plan_parser.add_argument(
+        "--cli-bin",
+        default="goal-harness",
+        help="CLI command embedded in generated heartbeat prompts for the promoted default.",
+    )
+    upgrade_plan_parser.add_argument(
+        "--mode",
+        action="append",
+        choices=["brief", "compact"],
+        default=[],
+        help="Prompt mode to compare. Repeatable; defaults to brief and compact.",
     )
 
     sub.add_parser("registry", help="Inspect registry goals and adapter declarations.")
@@ -770,6 +793,35 @@ def main(argv: list[str] | None = None) -> int:
                 "recommended_action": "fix promotion readiness gate collection before promotion",
             }
         print_payload(payload, args.format, render_promotion_gate_markdown)
+        return 0 if payload.get("ok") else 1
+
+    if args.command == "upgrade-plan":
+        try:
+            payload = build_upgrade_plan(
+                registry_path=registry_path,
+                runtime_root_override=args.runtime_root,
+                installed_manifest=Path(args.installed_manifest).expanduser() if args.installed_manifest else None,
+                cli_bin=args.cli_bin,
+                modes=args.mode or None,
+                goal_ids=args.goal_id or None,
+            )
+        except Exception as exc:
+            payload = {
+                "ok": False,
+                "mode": "upgrade-plan",
+                "registry": str(registry_path),
+                "runtime_root": args.runtime_root,
+                "error": str(exc),
+                "summary": {
+                    "managed_goal_count": 0,
+                    "current_prompt_count": 0,
+                    "stale_prompt_count": 0,
+                    "unknown_prompt_count": 0,
+                    "ready_for_default_promotion": False,
+                },
+                "recommended_action": "fix upgrade-plan collection before default promotion",
+            }
+        print_payload(payload, args.format, render_upgrade_plan_markdown)
         return 0 if payload.get("ok") else 1
 
     if args.command == "registry":

--- a/goal_harness/upgrade.py
+++ b/goal_harness/upgrade.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from .heartbeat_prompt import build_heartbeat_prompt
+from .history import load_registry
+from .paths import DEFAULT_RUNTIME_ROOT, global_registry_path, resolve_runtime_root
+from .registry import registry_goals, resolve_state_file
+
+
+DEFAULT_UPGRADE_MODES = ("brief", "compact")
+
+
+def prompt_digest(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def prompt_summary(prompt: dict[str, Any], mode: str) -> dict[str, Any]:
+    task_body = str(prompt.get("task_body") or "")
+    return {
+        "mode": mode,
+        "sha256": prompt_digest(task_body),
+        "char_count": len(task_body),
+        "line_count": len(task_body.splitlines()),
+        "command": prompt.get("expanded_prompt_command")
+        if mode == "full"
+        else prompt.get("compact_prompt_command")
+        if mode == "compact"
+        else f"{prompt.get('cli_bin')} heartbeat-prompt --brief --goal-id {prompt.get('goal_id')}",
+    }
+
+
+def load_installed_manifest(path: Path | None) -> dict[str, Any]:
+    if path is None:
+        return {
+            "available": False,
+            "path": None,
+            "entries": [],
+            "reason": "no installed automation manifest provided",
+        }
+    if not path.exists():
+        return {
+            "available": False,
+            "path": str(path),
+            "entries": [],
+            "reason": "installed automation manifest does not exist",
+        }
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(raw, list):
+        entries = raw
+    elif isinstance(raw, dict):
+        entries = raw.get("automations") or raw.get("entries") or []
+    else:
+        entries = []
+    return {
+        "available": True,
+        "path": str(path),
+        "entries": [entry for entry in entries if isinstance(entry, dict)],
+    }
+
+
+def installed_entry_digest(entry: dict[str, Any]) -> str | None:
+    for key in ("prompt_sha256", "task_body_sha256", "sha256"):
+        value = entry.get(key)
+        if value:
+            return str(value)
+    task_body = entry.get("task_body")
+    if isinstance(task_body, str):
+        return prompt_digest(task_body)
+    return None
+
+
+def entry_key(entry: dict[str, Any]) -> tuple[str, str]:
+    return str(entry.get("goal_id") or ""), str(entry.get("mode") or "brief")
+
+
+def index_installed_entries(entries: list[dict[str, Any]]) -> dict[tuple[str, str], dict[str, Any]]:
+    indexed: dict[tuple[str, str], dict[str, Any]] = {}
+    for entry in entries:
+        goal_id, mode = entry_key(entry)
+        if goal_id:
+            indexed[(goal_id, mode)] = entry
+    return indexed
+
+
+def build_upgrade_plan(
+    *,
+    registry_path: Path,
+    runtime_root_override: str | None = None,
+    installed_manifest: Path | None = None,
+    cli_bin: str = "goal-harness",
+    modes: list[str] | tuple[str, ...] | None = None,
+    goal_ids: list[str] | tuple[str, ...] | None = None,
+) -> dict[str, Any]:
+    registry = load_registry(registry_path)
+    runtime_root = resolve_runtime_root(registry, runtime_root_override)
+    if not registry_path.exists():
+        fallback = global_registry_path(runtime_root or DEFAULT_RUNTIME_ROOT)
+        if fallback.exists():
+            registry_path = fallback
+            registry = load_registry(registry_path)
+            runtime_root = resolve_runtime_root(registry, runtime_root_override)
+
+    selected_modes = tuple(modes or DEFAULT_UPGRADE_MODES)
+    selected_goal_ids = set(goal_ids or [])
+    manifest = load_installed_manifest(installed_manifest)
+    installed_by_key = index_installed_entries(manifest["entries"])
+    managed: list[dict[str, Any]] = []
+
+    for goal in registry_goals(registry):
+        goal_id = str(goal.get("id") or "")
+        if selected_goal_ids and goal_id not in selected_goal_ids:
+            continue
+        repo = Path(str(goal.get("repo") or ".")).expanduser()
+        state_file = resolve_state_file(repo, goal.get("state_file"))
+        prompt_summaries: dict[str, dict[str, Any]] = {}
+        installed: dict[str, dict[str, Any]] = {}
+        for mode in selected_modes:
+            prompt = build_heartbeat_prompt(
+                goal_id=goal_id,
+                active_state=None,
+                active_state_source="registry",
+                resolved_active_state=state_file,
+                compact=mode == "compact",
+                brief=mode == "brief",
+                cli_bin=cli_bin,
+            )
+            summary = prompt_summary(prompt, mode)
+            prompt_summaries[mode] = summary
+            entry = installed_by_key.get((goal_id, mode))
+            expected_digest = str(summary.get("sha256") or "")
+            actual_digest = installed_entry_digest(entry) if entry else None
+            status = "unknown"
+            if entry:
+                status = "current" if actual_digest == expected_digest else "stale"
+            installed[mode] = {
+                "status": status,
+                "requires_update": status != "current",
+                "automation_id": entry.get("automation_id") if entry else None,
+                "prompt_sha256": actual_digest,
+                "expected_sha256": expected_digest,
+            }
+
+        mode_statuses = [item["status"] for item in installed.values()]
+        managed.append(
+            {
+                "goal_id": goal_id,
+                "adapter_kind": (goal.get("adapter") or {}).get("kind") if isinstance(goal.get("adapter"), dict) else None,
+                "adapter_status": (goal.get("adapter") or {}).get("status") if isinstance(goal.get("adapter"), dict) else None,
+                "repo": str(repo),
+                "state_file": str(state_file) if state_file else None,
+                "state_file_exists": bool(state_file and state_file.exists()),
+                "generated_prompts": prompt_summaries,
+                "installed_prompts": installed,
+                "requires_update": any(status != "current" for status in mode_statuses),
+            }
+        )
+
+    unknown = sum(
+        1
+        for goal in managed
+        for installed in goal["installed_prompts"].values()
+        if installed["status"] == "unknown"
+    )
+    stale = sum(
+        1
+        for goal in managed
+        for installed in goal["installed_prompts"].values()
+        if installed["status"] == "stale"
+    )
+    current = sum(
+        1
+        for goal in managed
+        for installed in goal["installed_prompts"].values()
+        if installed["status"] == "current"
+    )
+    ready = bool(managed) and unknown == 0 and stale == 0
+    return {
+        "ok": True,
+        "mode": "upgrade-plan",
+        "registry": str(registry_path),
+        "runtime_root": str(runtime_root),
+        "cli_bin": cli_bin,
+        "prompt_modes": list(selected_modes),
+        "installed_manifest": manifest,
+        "summary": {
+            "managed_goal_count": len(managed),
+            "current_prompt_count": current,
+            "stale_prompt_count": stale,
+            "unknown_prompt_count": unknown,
+            "ready_for_default_promotion": ready,
+        },
+        "managed_heartbeats": managed,
+        "recommended_action": "promotion propagation is complete"
+        if ready
+        else "refresh installed heartbeat automations/controller clients before default promotion",
+    }
+
+
+def render_upgrade_plan_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary") if isinstance(payload.get("summary"), dict) else {}
+    lines = [
+        "# Goal Harness Upgrade Plan",
+        "",
+        f"- ok: `{payload.get('ok')}`",
+        f"- registry: `{payload.get('registry')}`",
+        f"- runtime_root: `{payload.get('runtime_root')}`",
+        f"- cli_bin: `{payload.get('cli_bin')}`",
+        f"- prompt_modes: `{', '.join(payload.get('prompt_modes') or [])}`",
+        f"- ready_for_default_promotion: `{summary.get('ready_for_default_promotion')}`",
+        f"- managed_goal_count: `{summary.get('managed_goal_count')}`",
+        f"- current_prompt_count: `{summary.get('current_prompt_count')}`",
+        f"- stale_prompt_count: `{summary.get('stale_prompt_count')}`",
+        f"- unknown_prompt_count: `{summary.get('unknown_prompt_count')}`",
+        f"- recommended_action: `{payload.get('recommended_action')}`",
+    ]
+    manifest = payload.get("installed_manifest") if isinstance(payload.get("installed_manifest"), dict) else {}
+    lines.extend(
+        [
+            "",
+            "## Installed Manifest",
+            "",
+            f"- available: `{manifest.get('available')}`",
+            f"- path: `{manifest.get('path')}`",
+            f"- reason: `{manifest.get('reason')}`",
+        ]
+    )
+    lines.extend(["", "## Managed Heartbeats", ""])
+    for goal in payload.get("managed_heartbeats") or []:
+        installed = goal.get("installed_prompts") if isinstance(goal.get("installed_prompts"), dict) else {}
+        generated = goal.get("generated_prompts") if isinstance(goal.get("generated_prompts"), dict) else {}
+        status_parts = []
+        for mode, status in installed.items():
+            if isinstance(status, dict):
+                status_parts.append(f"{mode}={status.get('status')}")
+        prompt_parts = []
+        for mode, prompt in generated.items():
+            if isinstance(prompt, dict):
+                prompt_parts.append(
+                    f"{mode}:sha={str(prompt.get('sha256') or '')[:12]} chars={prompt.get('char_count')}"
+                )
+        lines.extend(
+            [
+                f"- `{goal.get('goal_id')}` state_file_exists=`{goal.get('state_file_exists')}` "
+                f"requires_update=`{goal.get('requires_update')}` installed=`{', '.join(status_parts)}`",
+                f"  prompts: `{'; '.join(prompt_parts)}`",
+            ]
+        )
+    return "\n".join(lines) + "\n"


### PR DESCRIPTION
## Summary
- add `goal-harness upgrade-plan` to generate a machine-readable local default-upgrade propagation plan
- inventory registry-managed heartbeat/controller goals and regenerate brief/compact prompt digests from the candidate CLI contract
- compare generated prompt digests with an optional installed automation manifest so stale/unknown managed heartbeats block default promotion
- document the upgrade-plan step in the install/promotion flow

## Validation
- `python3 -m py_compile goal_harness/upgrade.py goal_harness/cli.py`
- `python3 examples/upgrade-plan-smoke.py`
- `python3 -m goal_harness.cli --format json upgrade-plan --goal-id goal-harness-meta --mode brief`
- `git diff --check`
- `goal-harness-canary check --scan-path goal_harness/upgrade.py --scan-path goal_harness/cli.py --scan-path examples/upgrade-plan-smoke.py --scan-path README.md`
- staged diff sensitive scan for added lines and full cached diff

## Boundary
This is a read-only planning surface. It does not mutate Codex App automations yet; it produces the contract future automation-update tooling should consume before `scripts/install-local.sh` promotes a new default release.
