### PR TITLE
Track not-installed heartbeat manifest states

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,10 @@ for default promotion. This keeps connected projects from continuing on stale
 prompt branches after the local default version changes.
 Use `--mode brief` or `--mode compact` only when an installed automation is
 intentionally using one of the larger generated contracts.
+If a registry goal has no installed heartbeat automation, record that explicitly
+in the installed manifest with `installed=false` / `status=not_installed`;
+unlisted registry goals remain `unknown` so default promotion cannot silently
+skip a managed controller.
 
 If a project shell cannot find or run the command, `goal-harness doctor`
 reports PATH, wrapper, release snapshot, canary wrapper, installed skill

--- a/examples/upgrade-plan-smoke.py
+++ b/examples/upgrade-plan-smoke.py
@@ -106,8 +106,44 @@ def assert_matching_manifest_is_ready(registry_path: Path, manifest_path: Path, 
     assert payload["summary"]["unknown_prompt_count"] == 0, payload
     assert payload["summary"]["stale_prompt_count"] == 0, payload
     assert payload["summary"]["current_prompt_count"] == 1, payload
+    assert payload["summary"]["not_installed_prompt_count"] == 0, payload
     assert payload["summary"]["ready_for_default_promotion"] is True, payload
     assert payload["managed_heartbeats"][0]["installed_prompts"]["thin"]["status"] == "current", payload
+
+
+def assert_not_installed_manifest_is_ready(registry_path: Path, manifest_path: Path) -> None:
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "automations": [
+                    {
+                        "goal_id": GOAL_ID,
+                        "mode": "thin",
+                        "installed": False,
+                        "status": "not_installed",
+                    }
+                ]
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    payload = build_upgrade_plan(
+        registry_path=registry_path,
+        installed_manifest=manifest_path,
+        cli_bin="goal-harness",
+    )
+    assert payload["summary"]["unknown_prompt_count"] == 0, payload
+    assert payload["summary"]["stale_prompt_count"] == 0, payload
+    assert payload["summary"]["current_prompt_count"] == 0, payload
+    assert payload["summary"]["not_installed_prompt_count"] == 1, payload
+    assert payload["summary"]["ready_for_default_promotion"] is True, payload
+    installed = payload["managed_heartbeats"][0]["installed_prompts"]["thin"]
+    assert installed["status"] == "not_installed", payload
+    assert installed["requires_update"] is False, payload
+    assert installed["installed"] is False, payload
 
 
 def main() -> int:
@@ -115,6 +151,7 @@ def main() -> int:
         registry_path, manifest_path = write_fixture(Path(raw_tmp))
         first_payload = assert_unknown_manifest_blocks_promotion(registry_path)
         assert_matching_manifest_is_ready(registry_path, manifest_path, first_payload)
+        assert_not_installed_manifest_is_ready(registry_path, manifest_path)
     print("upgrade-plan-smoke ok")
     return 0
 

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -823,6 +823,7 @@ def main(argv: list[str] | None = None) -> int:
                     "current_prompt_count": 0,
                     "stale_prompt_count": 0,
                     "unknown_prompt_count": 0,
+                    "not_installed_prompt_count": 0,
                     "ready_for_default_promotion": False,
                 },
                 "recommended_action": "fix upgrade-plan collection before default promotion",

--- a/goal_harness/upgrade.py
+++ b/goal_harness/upgrade.py
@@ -73,6 +73,16 @@ def installed_entry_digest(entry: dict[str, Any]) -> str | None:
     return None
 
 
+def entry_declares_not_installed(entry: dict[str, Any] | None) -> bool:
+    if not entry:
+        return False
+    status = str(entry.get("status") or "").replace("-", "_").lower()
+    if status in {"not_installed", "no_automation", "uninstalled"}:
+        return True
+    installed = entry.get("installed")
+    return installed is False
+
+
 def entry_key(entry: dict[str, Any]) -> tuple[str, str]:
     return str(entry.get("goal_id") or ""), str(entry.get("mode") or DEFAULT_UPGRADE_MODES[0])
 
@@ -133,14 +143,18 @@ def build_upgrade_plan(
             prompt_summaries[mode] = summary
             entry = installed_by_key.get((goal_id, mode))
             expected_digest = str(summary.get("sha256") or "")
-            actual_digest = installed_entry_digest(entry) if entry else None
+            not_installed = entry_declares_not_installed(entry)
+            actual_digest = None if not_installed else installed_entry_digest(entry) if entry else None
             status = "unknown"
-            if entry:
+            if not_installed:
+                status = "not_installed"
+            elif entry:
                 status = "current" if actual_digest == expected_digest else "stale"
             installed[mode] = {
                 "status": status,
-                "requires_update": status != "current",
+                "requires_update": status in {"unknown", "stale"},
                 "automation_id": entry.get("automation_id") if entry else None,
+                "installed": False if not_installed else bool(entry),
                 "prompt_sha256": actual_digest,
                 "expected_sha256": expected_digest,
             }
@@ -178,6 +192,12 @@ def build_upgrade_plan(
         for installed in goal["installed_prompts"].values()
         if installed["status"] == "current"
     )
+    not_installed = sum(
+        1
+        for goal in managed
+        for installed in goal["installed_prompts"].values()
+        if installed["status"] == "not_installed"
+    )
     ready = bool(managed) and unknown == 0 and stale == 0
     return {
         "ok": True,
@@ -192,6 +212,7 @@ def build_upgrade_plan(
             "current_prompt_count": current,
             "stale_prompt_count": stale,
             "unknown_prompt_count": unknown,
+            "not_installed_prompt_count": not_installed,
             "ready_for_default_promotion": ready,
         },
         "managed_heartbeats": managed,
@@ -216,6 +237,7 @@ def render_upgrade_plan_markdown(payload: dict[str, Any]) -> str:
         f"- current_prompt_count: `{summary.get('current_prompt_count')}`",
         f"- stale_prompt_count: `{summary.get('stale_prompt_count')}`",
         f"- unknown_prompt_count: `{summary.get('unknown_prompt_count')}`",
+        f"- not_installed_prompt_count: `{summary.get('not_installed_prompt_count')}`",
         f"- recommended_action: `{payload.get('recommended_action')}`",
     ]
     manifest = payload.get("installed_manifest") if isinstance(payload.get("installed_manifest"), dict) else {}


### PR DESCRIPTION
## Summary
- let `upgrade-plan` distinguish explicit `not_installed` heartbeat manifest entries from stale or unknown installed automations
- include `not_installed_prompt_count` in JSON/Markdown summaries and error fallback payloads
- document that registry goals without installed heartbeats should be declared with `installed=false` / `status=not_installed`
- add smoke coverage for `not_installed` entries staying promotion-ready without pretending an automation exists

## Validation
- `python3 -m py_compile goal_harness/upgrade.py goal_harness/cli.py examples/upgrade-plan-smoke.py`
- `python3 examples/upgrade-plan-smoke.py`
- `python3 examples/install-local-smoke.py`
- `python3 -m goal_harness.cli check --scan-root .`
- local installed manifest inventory now reports 5 current thin heartbeat prompts, 1 explicit not_installed goal, and ready_for_default_promotion=true

## Boundary
- staged diff scan found no local active state, automation TOML, installed manifest body, thread id, local path, or credential-shaped material
