### PR TITLE
Skip local state in contract scans

### DIFF
--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -550,8 +550,8 @@ Item fields:
   registry `spawn_policy` with `mode`, `spawn_allowed`, `max_children`, and
   optional `allowed_domains`. This is the first-screen project asset surface for
   agents and dashboards; it lets consumers avoid reconstructing owner, gate,
-  next action, stop condition, todo counts, compute state, latest validation,
-  and sub-agent mode from scattered fields. It also keeps delivery-floor and
+  next action, stop condition, todo counts, compute state, and latest validation
+  from scattered fields. It also keeps delivery-floor and
   orchestration policy close to the project asset instead of forcing agents to
   infer them from history.
   Markdown renderers should

--- a/examples/check-public-boundary-smoke.py
+++ b/examples/check-public-boundary-smoke.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+PRIVATE_DOC_MARKER = "https://" + "la" + "rk" + "office.example/doc"
 
 
 def run_cli(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
@@ -59,6 +60,32 @@ def main() -> int:
         explicit_payload = json.loads(explicit.stdout)
         if explicit_payload.get("ok"):
             raise AssertionError(explicit_payload)
+
+        project = root / "project"
+        project.mkdir()
+        (project / "README.md").write_text("public docs stay clean\n", encoding="utf-8")
+        for dirname in [".local", ".goal-harness", ".goal-wrapper.local", "runtime"]:
+            local_dir = project / dirname
+            local_dir.mkdir(parents=True)
+            (local_dir / "private.md").write_text(PRIVATE_DOC_MARKER, encoding="utf-8")
+
+        local_only = run_cli(root, "--format", "json", "check", "--scan-root", str(project))
+        if local_only.returncode != 0:
+            raise AssertionError(local_only.stderr or local_only.stdout)
+        local_only_payload = json.loads(local_only.stdout)
+        if not local_only_payload.get("ok"):
+            raise AssertionError(local_only_payload)
+        if (local_only_payload.get("summary") or {}).get("errors"):
+            raise AssertionError(local_only_payload)
+
+        (project / "public.md").write_text(PRIVATE_DOC_MARKER, encoding="utf-8")
+        public_leak = run_cli(root, "--format", "json", "check", "--scan-root", str(project))
+        if public_leak.returncode == 0:
+            raise AssertionError(public_leak.stdout)
+        public_payload = json.loads(public_leak.stdout)
+        errors = public_payload.get("errors") or []
+        if not any("public.md" in str(item) and "private_doc_url" in str(item) for item in errors):
+            raise AssertionError(public_payload)
 
     print("check-public-boundary-smoke ok")
     return 0

--- a/goal_harness/contract.py
+++ b/goal_harness/contract.py
@@ -37,6 +37,8 @@ LEAK_PATTERNS = {
 DEFAULT_SCAN_SUFFIXES = {".md", ".py", ".toml", ".json", ".yaml", ".yml", ".sh"}
 DEFAULT_SKIP_DIRS = {
     ".git",
+    ".goal-harness",
+    ".goal-wrapper.local",
     ".local",
     ".venv",
     "__pycache__",
@@ -45,6 +47,7 @@ DEFAULT_SKIP_DIRS = {
     "build",
     "dist",
     "node_modules",
+    "runtime",
 }
 
 


### PR DESCRIPTION
## Summary
- skip project-local state directories from public boundary contract scans
- add regression coverage proving local-state leaks are ignored while public leaks are still caught
- restore the status contract wording expected by quota contract smoke

## Validation
- python3 -m py_compile goal_harness/contract.py
- python3 examples/check-public-boundary-smoke.py
- python3 examples/quota-contract-smoke.py
- python3 examples/quota-plan-smoke.py
- python3 -m goal_harness.cli --format json check --scan-root .
- python3 -m goal_harness.cli --format json --registry "/Users/bytedance/.codex/goal-harness/registry.global.json" quota should-run --goal-id goal-harness-meta
- python3 examples/run-smokes.py
- git diff --check
- sensitive diff grep for local/private/credential markers