### PR TITLE
Add control-plane self-repair quota contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,11 @@ the next automatic turn. It can also return user todos, agent todos, gate
 prompts, waiting evidence, health blockers, safe-bypass hints,
 `heartbeat_recommendation`, post-handoff `delivery_batch_scale`, and
 outcome-floor `delivery_outcome` / `post_handoff_outcome_gap_streak` signals.
+Registry entries can also expose per-goal `control_plane` policy. For example,
+`control_plane.self_repair.enabled=true` lets `quota should-run` return a
+bounded `decision=self_repair` contract for repairable control-plane stalls;
+missing policy defaults off, so other goals keep their normal skip or wait
+behavior.
 If it returns a `gate_prompt` or `operator_question`, the target heartbeat
 should proactively ask that concrete user/controller gate. If open user todos
 are present, do not call the turn "no new user action" while they remain open;

--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -67,6 +67,13 @@ Registry entries may declare the same policy directly:
   "quota": {
     "compute": 0.5,
     "window_hours": 24
+  },
+  "control_plane": {
+    "self_repair": {
+      "enabled": false,
+      "allow_health_blocker_repair": false,
+      "allow_waiting_projection_repair": false
+    }
   }
 }
 ```
@@ -115,6 +122,27 @@ Quota is applied after hard gates:
 
 This keeps the model small. Quota does not become a second permission system.
 
+## Control Plane Settings
+
+Registry entries can carry per-goal `control_plane` policy alongside quota.
+These settings are the control surface for behavior that would otherwise be
+tempting to encode in a heartbeat prompt.
+
+Current self-repair settings:
+
+- `control_plane.self_repair.enabled`: default `false`.
+- `control_plane.self_repair.allow_health_blocker_repair`: when enabled, a goal
+  may spend one bounded turn repairing Goal Harness health or contract blockers
+  that prevent normal delivery.
+- `control_plane.self_repair.allow_waiting_projection_repair`: when enabled, a
+  goal in `state=waiting` with no concrete waiting owner but with a current
+  action or agent backlog may spend one bounded turn repairing the projection or
+  writing back the concrete blocker.
+
+Self-repair is deliberately opt-in per goal. A short heartbeat can read the
+machine contract from `quota should-run`, but ordinary goals without this
+registry policy stay in their existing skip, waiting, or health-blocked lanes.
+
 ## Allocation Contract
 
 `quota plan` reports an advisory next automatic turn. It does not grant
@@ -149,6 +177,13 @@ produce the required ranker/cross-domain evidence artifact named by
 `quota.must_advance`, or to write back the concrete blocker that prevents that
 artifact. Surface-only summary/queue/contract propagation and synthetic-only
 test chains remain blocked.
+When `control_plane.self_repair.enabled=true` and the selected goal is stalled
+by a repairable control-plane condition, `quota should-run` may instead return
+`decision=self_repair`, `self_repair_allowed=true`, `stall_self_repair`, and an
+`effective_action` such as `control_plane_health_repair` or
+`control_plane_projection_repair`. This makes "repair the control plane" a
+machine-readable bounded action for the selected goal, not a prompt-specific
+branch. Spend is allowed only after validation and durable writeback.
 
 ## Compute States
 
@@ -246,9 +281,11 @@ JSON or Markdown decision:
 }
 ```
 
-Only `state=eligible` returns `should_run=true`. Known goals that are gated, in
-focus wait, waiting, throttled, paused, or health-blocked return `ok=true` only
-when the status export itself is healthy, but still return `should_run=false`.
+Only `state=eligible`, outcome-floor recovery safe-bypass, or registry-enabled
+control-plane self-repair returns `should_run=true`. Known goals that are
+gated, in focus wait, waiting, throttled, paused, or health-blocked return
+`ok=true` only when the status export itself is healthy, but otherwise return
+`should_run=false`.
 `safe_bypass_allowed=true` is not permission to clear the gate; it only says the
 agent can spend a bounded turn on independent read-only steering/analysis.
 For `state=operator_gate`, `quota should-run` should also surface
@@ -349,6 +386,9 @@ Post-turn accounting protocol:
   `safe_bypass_kind=outcome_floor_recovery`, spend only after validated
   ranker/cross-domain evidence or concrete blocker writeback, not for another
   surface-only report.
+- if `should_run=true` with `effective_action=control_plane_health_repair` or
+  `control_plane_projection_repair`, append one spend event only after the
+  control-plane projection or blocker writeback is validated.
 
 ## Slot Spend Event Contract
 
@@ -395,6 +435,9 @@ Validation rule:
 - write only after a fresh `quota should-run` returned `should_run=true`, or
   after it returned `safe_bypass_allowed=true` and the agent completed one
   bounded safe-bypass step;
+- for `effective_action=control_plane_health_repair` or
+  `control_plane_projection_repair`, treat the spend as control-plane
+  self-repair accounting, not ordinary delivery;
 - `slots` must be positive, and `after.spent_slots` must equal
   `before.spent_slots + slots`;
 - if `after.spent_slots >= after.allowed_slots`, `after.state` should be

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -83,6 +83,11 @@ hint for generic lifecycle cases such as first read-only map runs and quiet
 mapped no-ops. Project-specific policy should still come from the registry,
 active state, adapter output, or boundary rules rather than ad hoc scheduler
 prompt branches.
+Registry entries may also declare compact `control_plane` settings. These
+settings are per-goal policy, not global prompt text. By default
+`control_plane.self_repair.enabled=false`; only registry-enabled goals can turn
+health or waiting-projection stalls into a `quota should-run` self-repair
+machine contract.
 When the selected attention item is project-asset backed, the per-goal guard
 also carries compact `handoff_readiness` with `handoff_status` and
 `post_handoff_run_seen`. Heartbeat jobs can therefore tell whether the selected
@@ -548,7 +553,9 @@ Item fields:
   `execution_profile`, the project-level delivery floor created by
   `goal-harness connect`, and `orchestration`, the compact projection of
   registry `spawn_policy` with `mode`, `spawn_allowed`, `max_children`, and
-  optional `allowed_domains`. This is the first-screen project asset surface for
+  optional `allowed_domains`. They may also include `control_plane`, the
+  compact per-goal policy projection for settings such as self-repair. This is
+  the first-screen project asset surface for
   agents and dashboards; it lets consumers avoid reconstructing owner, gate,
   next action, stop condition, todo counts, compute state, and latest validation
   from scattered fields. It also keeps delivery-floor and
@@ -601,6 +608,11 @@ Item fields:
   compute share (`1.0`, `0.5`, `0.3`, or `0`), eligibility, recent spend, and
   a public-safe reason without exposing private evidence. See
   [quota-allocation.md](quota-allocation.md).
+- `control_plane`: optional compact registry policy for this goal. Current
+  settings include `self_repair.enabled`,
+  `self_repair.allow_health_blocker_repair`, and
+  `self_repair.allow_waiting_projection_repair`. Missing settings mean default
+  off, so ordinary goals remain in their existing skip/wait lanes.
 - `user_todos`: optional checkbox summary parsed from the active state's
   `## User Todo ...` / `## Owner Review Reading Queue` section. Dashboard
   consumers should render the first unfinished item as the human-facing next
@@ -721,6 +733,14 @@ that generic lifecycle hint before inventing local automation behavior:
 once, while `mapped_noop_if_unchanged` returns a quiet no-op without another
 dry-run or quota spend if no new instruction, evidence, todo, stale source, or
 safe handoff exists.
+When a registry-enabled goal has `control_plane.self_repair.enabled=true`,
+`quota should-run` may return `decision=self_repair`,
+`self_repair_allowed=true`, `stall_self_repair`, and an `effective_action` such
+as `control_plane_health_repair` or `control_plane_projection_repair`. This is
+the machine-readable stall-repair contract for short heartbeats: repair the
+control-plane projection or write back the concrete blocker, validate, record a
+durable event, then spend once. Goals without that registry policy must not get
+this lane by default.
 When the payload includes `decision_freshness_warning`, the goal may still be
 eligible, but sampled reward/gate state for that same goal is stale or has newer
 events after it. Executors should not reuse that old decision as authority until

--- a/examples/quota-contract-smoke.py
+++ b/examples/quota-contract-smoke.py
@@ -90,6 +90,31 @@ def main() -> int:
     )
     assert_contains(
         quota_doc,
+        "Registry entries can carry per-goal `control_plane` policy alongside quota",
+        label="quota doc",
+    )
+    assert_contains(
+        quota_doc,
+        "`control_plane.self_repair.enabled`: default `false`",
+        label="quota doc",
+    )
+    assert_contains(
+        quota_doc,
+        "`decision=self_repair`, `self_repair_allowed=true`, `stall_self_repair`",
+        label="quota doc",
+    )
+    assert_contains(
+        quota_doc,
+        "`control_plane_projection_repair`",
+        label="quota doc",
+    )
+    assert_contains(
+        quota_doc,
+        "ordinary goals without this registry policy stay in their existing skip, waiting, or health-blocked lanes",
+        label="quota doc",
+    )
+    assert_contains(
+        quota_doc,
         "Connected delivery goals also include `goal_boundary`",
         label="quota doc",
     )
@@ -193,6 +218,11 @@ def main() -> int:
         "spend only after validated ranker/cross-domain evidence or concrete blocker writeback",
         label="quota doc",
     )
+    assert_contains(
+        quota_doc,
+        "if `should_run=true` with `effective_action=control_plane_health_repair` or `control_plane_projection_repair`",
+        label="quota doc",
+    )
 
     assert_contains(
         readme,
@@ -207,6 +237,16 @@ def main() -> int:
     assert_contains(
         readme,
         "operator-gated, focus-waiting, waiting, throttled, paused, and health-blocked goals stay out of the eligible lane",
+        label="README",
+    )
+    assert_contains(
+        readme,
+        "`control_plane.self_repair.enabled=true` lets `quota should-run` return a bounded `decision=self_repair` contract",
+        label="README",
+    )
+    assert_contains(
+        readme,
+        "missing policy defaults off",
         label="README",
     )
     assert_contains(
@@ -271,6 +311,16 @@ def main() -> int:
     )
     assert_contains(
         status_contract,
+        "Registry entries may also declare compact `control_plane` settings",
+        label="status contract",
+    )
+    assert_contains(
+        status_contract,
+        "By default `control_plane.self_repair.enabled=false`",
+        label="status contract",
+    )
+    assert_contains(
+        status_contract,
         "Scripts should treat `summary.next_automatic_turn` in the quota-plan JSON as advisory",
         label="status contract",
     )
@@ -326,6 +376,16 @@ def main() -> int:
     )
     assert_contains(
         status_contract,
+        "`control_plane`: optional compact registry policy for this goal",
+        label="status contract",
+    )
+    assert_contains(
+        status_contract,
+        "`self_repair.allow_waiting_projection_repair`",
+        label="status contract",
+    )
+    assert_contains(
+        status_contract,
         "`operator_gate_resume_contract`",
         label="status contract",
     )
@@ -342,6 +402,16 @@ def main() -> int:
     assert_contains(
         status_contract,
         "must not carry the whole repository state back to the old gate",
+        label="status contract",
+    )
+    assert_contains(
+        status_contract,
+        "`decision=self_repair`, `self_repair_allowed=true`, `stall_self_repair`",
+        label="status contract",
+    )
+    assert_contains(
+        status_contract,
+        "Goals without that registry policy must not get this lane by default",
         label="status contract",
     )
 

--- a/examples/quota-plan-smoke.py
+++ b/examples/quota-plan-smoke.py
@@ -783,6 +783,126 @@ def assert_outcome_floor_recovery_should_run() -> None:
     assert "outcome-floor recovery safe-bypass" in spend_event["quota_event"]["reason_summary"], spend_event
 
 
+def assert_control_plane_health_self_repair_should_run() -> None:
+    goal_id = "goal-harness-meta"
+    meta_goal = goal(goal_id, compute=1.0)
+    meta_goal["control_plane"] = {"self_repair": {"enabled": True}}
+    meta_item = attention(goal_id, compute=1.0)
+    health_item = {
+        "goal_id": "goal-harness-contract",
+        "status": "contract_check_failed",
+        "waiting_on": "codex",
+        "severity": "high",
+        "recommended_action": "fix contract errors before advancing goal adapters",
+        "source": "contract",
+    }
+    payload = {
+        "ok": False,
+        "registry": "./fixtures/registry.json",
+        "runtime_root": "./fixtures/runtime",
+        "goal_count": 1,
+        "run_count": 1,
+        "attention_queue": {"items": [health_item, meta_item]},
+        "run_history": {"goals": [meta_goal]},
+    }
+    decision = build_quota_should_run(payload, goal_id=goal_id)
+    markdown = render_quota_should_run_markdown(decision)
+    preview = build_quota_slot_preview(payload, goal_id=goal_id, slots=1)
+    spend_event = build_quota_slot_spend_event(preview, source="heartbeat")
+
+    assert decision["ok"] is True, decision
+    assert decision["status_health_ok"] is False, decision
+    assert decision["decision"] == "self_repair", decision
+    assert decision["should_run"] is True, decision
+    assert decision["normal_delivery_allowed"] is False, decision
+    assert decision["self_repair_allowed"] is True, decision
+    assert decision["effective_action"] == "control_plane_health_repair", decision
+    assert decision["heartbeat_recommendation"]["recommended_mode"] == "repair_control_plane_health", decision
+    assert decision["stall_self_repair"]["trigger"] == "health_blocker", decision
+    assert decision["stall_self_repair"]["blocking_health_items"][0]["goal_id"] == "goal-harness-contract", decision
+    assert decision["control_plane"]["self_repair"]["enabled"] is True, decision
+    assert "decision: `self_repair`" in markdown, markdown
+    assert "self_repair_allowed: `True`" in markdown, markdown
+    assert "stall_self_repair: trigger=health_blocker" in markdown, markdown
+    assert preview["ok"] is True, preview
+    assert preview["self_repair_spend"] is True, preview
+    assert preview["before"]["effective_action"] == "control_plane_health_repair", preview
+    assert "control-plane self-repair" in spend_event["health_check"], spend_event
+    assert "control-plane self-repair" in spend_event["quota_event"]["reason_summary"], spend_event
+
+
+def assert_control_plane_self_repair_default_off() -> None:
+    goal_id = "ordinary-goal"
+    ordinary_goal = goal(goal_id, compute=1.0)
+    ordinary_item = attention(goal_id, compute=1.0)
+    health_item = {
+        "goal_id": "goal-harness-contract",
+        "status": "contract_check_failed",
+        "waiting_on": "codex",
+        "severity": "high",
+        "recommended_action": "fix contract errors before advancing goal adapters",
+        "source": "contract",
+    }
+    payload = {
+        "ok": False,
+        "registry": "./fixtures/registry.json",
+        "runtime_root": "./fixtures/runtime",
+        "goal_count": 1,
+        "run_count": 1,
+        "attention_queue": {"items": [health_item, ordinary_item]},
+        "run_history": {"goals": [ordinary_goal]},
+    }
+    decision = build_quota_should_run(payload, goal_id=goal_id)
+
+    assert decision["ok"] is False, decision
+    assert decision["decision"] == "skip", decision
+    assert decision["should_run"] is False, decision
+    assert decision["self_repair_allowed"] is False, decision
+    assert decision["effective_action"] == "quota_skip", decision
+    assert "stall_self_repair" not in decision, decision
+
+
+def assert_control_plane_waiting_projection_self_repair_should_run() -> None:
+    goal_id = "goal-harness-meta"
+    meta_goal = goal(goal_id, compute=1.0)
+    meta_goal["control_plane"] = {"self_repair": {"enabled": True}}
+    meta_item = attention(goal_id, compute=1.0, state="waiting", waiting_on="")
+    meta_item["status"] = "state_refreshed"
+    meta_item["recommended_action"] = "continue gate-independent product hardening"
+    meta_item["project_asset"] = {
+        "owner": "codex",
+        "gate": "none",
+        "next_action": "continue gate-independent product hardening",
+        "stop_condition": "stop if the repair needs user approval",
+    }
+    payload = {
+        "ok": True,
+        "registry": "./fixtures/registry.json",
+        "runtime_root": "./fixtures/runtime",
+        "goal_count": 1,
+        "run_count": 1,
+        "attention_queue": {"items": [meta_item]},
+        "run_history": {"goals": [meta_goal]},
+    }
+    decision = build_quota_should_run(payload, goal_id=goal_id)
+    markdown = render_quota_should_run_markdown(decision)
+    preview = build_quota_slot_preview(payload, goal_id=goal_id, slots=1)
+    spend_event = build_quota_slot_spend_event(preview, source="heartbeat")
+
+    assert decision["ok"] is True, decision
+    assert decision["decision"] == "self_repair", decision
+    assert decision["should_run"] is True, decision
+    assert decision["state"] == "waiting", decision
+    assert decision["waiting_on"] == "none", decision
+    assert decision["self_repair_allowed"] is True, decision
+    assert decision["effective_action"] == "control_plane_projection_repair", decision
+    assert decision["heartbeat_recommendation"]["recommended_mode"] == "repair_waiting_projection", decision
+    assert decision["stall_self_repair"]["trigger"] == "waiting_without_owner_projection", decision
+    assert "stall_self_repair: trigger=waiting_without_owner_projection" in markdown, markdown
+    assert preview["self_repair_spend"] is True, preview
+    assert "control-plane self-repair" in spend_event["health_check"], spend_event
+
+
 def assert_attention_queue_overrides_stale_run_history() -> None:
     stale_goal = goal("queue-authority", compute=1.0)
     stale_goal["status"] = "operator_gate_deferred"
@@ -1222,6 +1342,9 @@ def main() -> int:
     assert_operator_gate_should_run(status_payload)
     assert_focus_wait_should_run()
     assert_outcome_floor_recovery_should_run()
+    assert_control_plane_health_self_repair_should_run()
+    assert_control_plane_self_repair_default_off()
+    assert_control_plane_waiting_projection_self_repair_should_run()
     assert_attention_queue_overrides_stale_run_history()
     assert_project_asset_backed_no_evidence_should_run()
     assert_heartbeat_recommendation_lifecycle()

--- a/examples/registry.example.json
+++ b/examples/registry.example.json
@@ -121,6 +121,13 @@
       "quota": {
         "compute": 0.5,
         "window_hours": 24
+      },
+      "control_plane": {
+        "self_repair": {
+          "enabled": false,
+          "allow_health_blocker_repair": false,
+          "allow_waiting_projection_repair": false
+        }
       }
     }
   ]

--- a/goal_harness/control_plane.py
+++ b/goal_harness/control_plane.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+SELF_REPAIR_MODES = {
+    "health_blocker_repair": "allow_health_blocker_repair",
+    "waiting_projection_repair": "allow_waiting_projection_repair",
+}
+
+
+def _flag(value: Any, *, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    return default
+
+
+def compact_control_plane_policy(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    compact: dict[str, Any] = {}
+    self_repair = value.get("self_repair") if isinstance(value.get("self_repair"), dict) else {}
+    if self_repair:
+        enabled = _flag(self_repair.get("enabled"), default=False)
+        compact["self_repair"] = {
+            "enabled": enabled,
+            "allow_health_blocker_repair": _flag(
+                self_repair.get("allow_health_blocker_repair"),
+                default=enabled,
+            ),
+            "allow_waiting_projection_repair": _flag(
+                self_repair.get("allow_waiting_projection_repair"),
+                default=enabled,
+            ),
+        }
+    return compact
+
+
+def control_plane_self_repair_allows(policy: Any, mode: str) -> bool:
+    compact = compact_control_plane_policy(policy)
+    self_repair = compact.get("self_repair") if isinstance(compact.get("self_repair"), dict) else {}
+    if self_repair.get("enabled") is not True:
+        return False
+    flag_name = SELF_REPAIR_MODES.get(mode)
+    if not flag_name:
+        return False
+    return self_repair.get(flag_name) is True
+
+
+def control_plane_policy_summary(policy: Any) -> str:
+    compact = compact_control_plane_policy(policy)
+    self_repair = compact.get("self_repair") if isinstance(compact.get("self_repair"), dict) else {}
+    if not self_repair:
+        return "self_repair=default_off"
+    enabled = "on" if self_repair.get("enabled") else "off"
+    health = "health" if self_repair.get("allow_health_blocker_repair") else "no-health"
+    waiting = "waiting" if self_repair.get("allow_waiting_projection_repair") else "no-waiting"
+    return f"self_repair={enabled}:{health},{waiting}"

--- a/goal_harness/history.py
+++ b/goal_harness/history.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any
 
 from .authority import goal_authority_registry_summary
+from .control_plane import compact_control_plane_policy
 from .execution_profile import compact_execution_profile
 from .quota import goal_quota_with_spend_ledger
 from .registry import read_json, registry_goals
@@ -133,6 +134,7 @@ def collect_history(
             "coordination": meta.get("coordination") if isinstance(meta.get("coordination"), dict) else None,
             "spawn_policy": meta.get("spawn_policy") if isinstance(meta.get("spawn_policy"), dict) else None,
             "execution_profile": compact_execution_profile(meta.get("execution_profile")) if registry_member else None,
+            "control_plane": compact_control_plane_policy(meta.get("control_plane")) if registry_member else None,
             "guards": meta.get("guards") if isinstance(meta.get("guards"), list) else [],
             "next_probe": meta.get("next_probe") if registry_member else None,
             "authority_registry": goal_authority_registry_summary(meta) if registry_member else None,

--- a/goal_harness/quota.py
+++ b/goal_harness/quota.py
@@ -7,6 +7,11 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
+from .control_plane import (
+    compact_control_plane_policy,
+    control_plane_policy_summary,
+    control_plane_self_repair_allows,
+)
 from .execution_profile import (
     execution_profile_outcome_floor,
     execution_profile_summary,
@@ -61,6 +66,18 @@ POST_HANDOFF_RUN_COMPACT_FIELDS = (
     "health_check",
     "json_exists",
     "markdown_exists",
+)
+SELF_REPAIR_SPEND_ACTIONS = {
+    "control_plane_health_repair",
+    "control_plane_projection_repair",
+}
+STALL_HEALTH_ITEM_COMPACT_FIELDS = (
+    "goal_id",
+    "status",
+    "waiting_on",
+    "severity",
+    "source",
+    "recommended_action",
 )
 DECISION_FRESHNESS_WARNING_ITEM_LIMIT = 3
 
@@ -655,6 +672,78 @@ def _has_lifecycle_marker(*values: Any, marker: str) -> bool:
     return False
 
 
+def _compact_health_items(items: list[Any], *, limit: int = 3) -> list[dict[str, Any]]:
+    compact: list[dict[str, Any]] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        payload = {field: item.get(field) for field in STALL_HEALTH_ITEM_COMPACT_FIELDS if item.get(field)}
+        if payload:
+            compact.append(payload)
+        if len(compact) >= limit:
+            break
+    return compact
+
+
+def _stall_self_repair_hint(
+    item: dict[str, Any],
+    *,
+    state: str,
+    plan_ok: bool,
+    health_items: list[Any],
+    user_todo_summary: dict[str, Any] | None,
+    agent_todo_summary: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    control_plane = compact_control_plane_policy(item.get("control_plane"))
+    if not control_plane:
+        return None
+
+    if not plan_ok and control_plane_self_repair_allows(control_plane, "health_blocker_repair"):
+        blockers = _compact_health_items(health_items)
+        if blockers:
+            return {
+                "source": "quota.should-run",
+                "trigger": "health_blocker",
+                "recommended_mode": "repair_control_plane_health",
+                "effective_action": "control_plane_health_repair",
+                "allowed": True,
+                "notify": "DONT_NOTIFY",
+                "reason": "status or contract health blocks normal delivery; spend one bounded turn on control-plane repair instead of quiet spinning",
+                "repair_focus": "inspect the compact health blocker, repair registry/status/contract projection or public-boundary scan scope, validate, write a durable event, then spend once",
+                "spend_policy": "append exactly one heartbeat spend only after the health blocker is repaired, validated, and written back",
+                "control_plane": control_plane,
+                "blocking_health_items": blockers,
+            }
+
+    waiting_on = str(item.get("waiting_on") or "")
+    has_user_todos = _open_todo_count(user_todo_summary) > 0
+    has_agent_todos = _open_todo_count(agent_todo_summary) > 0
+    has_next_action = bool(str(item.get("recommended_action") or "").strip())
+    has_project_asset = isinstance(item.get("project_asset"), dict)
+    unknown_waiting_owner = waiting_on in {"", "none", "unknown", "null"}
+    if (
+        control_plane_self_repair_allows(control_plane, "waiting_projection_repair")
+        and state == "waiting"
+        and unknown_waiting_owner
+        and not has_user_todos
+        and (has_next_action or has_agent_todos or has_project_asset)
+    ):
+        return {
+            "source": "quota.should-run",
+            "trigger": "waiting_without_owner_projection",
+            "recommended_mode": "repair_waiting_projection",
+            "effective_action": "control_plane_projection_repair",
+            "allowed": True,
+            "notify": "DONT_NOTIFY",
+            "reason": "goal is waiting without a concrete owner/evidence gate while current action or agent backlog exists",
+            "repair_focus": "rebase from registry, active state, status, and run history; either project waiting_on=codex for safe agent work or write the concrete user/controller/evidence blocker",
+            "spend_policy": "append exactly one heartbeat spend only after the projection or blocker writeback is validated",
+            "control_plane": control_plane,
+        }
+
+    return None
+
+
 def _heartbeat_recommendation(
     item: dict[str, Any],
     *,
@@ -663,6 +752,7 @@ def _heartbeat_recommendation(
     should_run: bool,
     user_todo_summary: dict[str, Any] | None,
     agent_todo_summary: dict[str, Any] | None,
+    stall_self_repair: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     status = str(item.get("status") or "")
     waiting_on = str(item.get("waiting_on") or "")
@@ -687,6 +777,15 @@ def _heartbeat_recommendation(
             "notify": "NOTIFY",
             "spend_policy": "do not append quota spend while asking the operator gate",
             "reason": "operator gate blocks the gated delivery path",
+        }
+    if stall_self_repair and stall_self_repair.get("allowed"):
+        return {
+            **base,
+            "recommended_mode": stall_self_repair.get("recommended_mode") or "repair_control_plane_stall",
+            "notify": stall_self_repair.get("notify") or "DONT_NOTIFY",
+            "spend_policy": stall_self_repair.get("spend_policy") or base["spend_policy"],
+            "reason": stall_self_repair.get("reason") or "control-plane stall requires bounded repair",
+            "repair_focus": stall_self_repair.get("repair_focus"),
         }
     if state in {"focus_wait", "waiting"} and has_user_todos:
         return {
@@ -810,6 +909,11 @@ def build_quota_plan(status_payload: dict[str, Any], *, mode: str = "status") ->
         lifecycle_phase = attention.get("lifecycle_phase") or goal.get("lifecycle_phase")
         lifecycle_flags = attention.get("lifecycle_flags") or goal.get("lifecycle_flags")
         status = attention.get("status") or goal.get("status")
+        control_plane = (
+            compact_control_plane_policy(attention.get("control_plane"))
+            or compact_control_plane_policy(project_asset.get("control_plane"))
+            or compact_control_plane_policy(goal.get("control_plane"))
+        )
         raw_quota = attention.get("quota") if isinstance(attention.get("quota"), dict) else goal.get("quota")
         if project_asset_quota:
             raw_quota_base = raw_quota if isinstance(raw_quota, dict) else {}
@@ -861,6 +965,8 @@ def build_quota_plan(status_payload: dict[str, Any], *, mode: str = "status") ->
             "latest_run_generated_at": latest.get("generated_at"),
             "quota": quota,
         }
+        if control_plane:
+            item["control_plane"] = control_plane
         if project_asset:
             item["project_asset"] = project_asset
             item["project_asset_source"] = "project_asset"
@@ -1017,15 +1123,24 @@ def _recovery_delivery_allowed(quota: dict[str, Any], *, plan_ok: bool) -> bool:
 
 def _effective_action(
     *,
-    should_run: bool,
+    normal_delivery_allowed: bool,
     recovery_delivery_allowed: bool,
+    self_repair_allowed: bool,
+    stall_self_repair: dict[str, Any] | None,
     state: str,
     quota: dict[str, Any],
 ) -> str:
-    if should_run:
+    if normal_delivery_allowed:
         return "normal_run"
     if recovery_delivery_allowed:
         return "outcome_floor_recovery"
+    if self_repair_allowed:
+        repair_action = (
+            stall_self_repair.get("effective_action")
+            if isinstance(stall_self_repair, dict)
+            else None
+        )
+        return str(repair_action or "control_plane_repair")
     if state == "operator_gate":
         return "operator_gate_notify"
     if state == "blocked_health":
@@ -1058,13 +1173,6 @@ def build_quota_should_run(status_payload: dict[str, Any], *, goal_id: str) -> d
         state = str(quota.get("state") or "unknown")
         normal_delivery_allowed = bool(plan.get("ok")) and state == "eligible"
         recovery_allowed = _recovery_delivery_allowed(quota, plan_ok=bool(plan.get("ok")))
-        should_run = bool(normal_delivery_allowed or recovery_allowed)
-        effective_action = _effective_action(
-            should_run=normal_delivery_allowed,
-            recovery_delivery_allowed=recovery_allowed,
-            state=state,
-            quota=quota,
-        )
         reason = str(quota.get("reason") or "quota state is not eligible")
         if not plan.get("ok"):
             reason = "status or contract health is not ok; skip automatic compute"
@@ -1075,17 +1183,49 @@ def build_quota_should_run(status_payload: dict[str, Any], *, goal_id: str) -> d
         agent_todo_summary = _summarize_project_asset_todos(
             project_asset.get("agent_todos") if project_asset else None
         ) or _summarize_user_todos(item.get("agent_todos"))
+        stall_self_repair = _stall_self_repair_hint(
+            item,
+            state=state,
+            plan_ok=bool(plan.get("ok")),
+            health_items=health_items,
+            user_todo_summary=user_todo_summary,
+            agent_todo_summary=agent_todo_summary,
+        )
+        self_repair_allowed = bool(stall_self_repair and stall_self_repair.get("allowed"))
+        should_run = bool(normal_delivery_allowed or recovery_allowed or self_repair_allowed)
+        effective_action = _effective_action(
+            normal_delivery_allowed=normal_delivery_allowed,
+            recovery_delivery_allowed=recovery_allowed,
+            self_repair_allowed=self_repair_allowed,
+            stall_self_repair=stall_self_repair,
+            state=state,
+            quota=quota,
+        )
         payload = {
-            "ok": bool(plan.get("ok")),
+            "ok": bool(plan.get("ok")) or self_repair_allowed,
+            "status_health_ok": bool(plan.get("ok")),
             "mode": "should-run",
             "goal_id": safe_goal_id,
-            "decision": "run" if normal_delivery_allowed else "safe_bypass_recovery" if recovery_allowed else "skip",
+            "decision": (
+                "run"
+                if normal_delivery_allowed
+                else "safe_bypass_recovery"
+                if recovery_allowed
+                else "self_repair"
+                if self_repair_allowed
+                else "skip"
+            ),
             "should_run": should_run,
             "normal_delivery_allowed": normal_delivery_allowed,
             "recovery_delivery_allowed": recovery_allowed,
+            "self_repair_allowed": self_repair_allowed,
             "effective_action": effective_action,
             "actionable_by_codex": bool(should_run or recovery_allowed),
-            "reason": reason,
+            "reason": (
+                str(stall_self_repair.get("reason"))
+                if self_repair_allowed and isinstance(stall_self_repair, dict)
+                else reason
+            ),
             "quota": quota,
             "state": state,
             "blocked_action_scope": quota.get("blocked_action_scope"),
@@ -1108,11 +1248,17 @@ def build_quota_should_run(status_payload: dict[str, Any], *, goal_id: str) -> d
                 should_run=should_run,
                 user_todo_summary=user_todo_summary,
                 agent_todo_summary=agent_todo_summary,
+                stall_self_repair=stall_self_repair,
             ),
             "goal_boundary": _goal_boundary(item),
             "plan_summary": plan.get("summary"),
             "todo_write_hint": _todo_write_hint(safe_goal_id),
         }
+        control_plane = compact_control_plane_policy(item.get("control_plane"))
+        if control_plane:
+            payload["control_plane"] = control_plane
+        if stall_self_repair:
+            payload["stall_self_repair"] = stall_self_repair
         if item.get("operator_question"):
             payload["operator_question"] = item.get("operator_question")
         if item.get("missing_gates"):
@@ -1229,6 +1375,7 @@ def build_quota_slot_preview(
         )
         and before.get("safe_bypass_allowed") is True
     )
+    self_repair_spend = before.get("effective_action") in SELF_REPAIR_SPEND_ACTIONS
     if not before.get("ok") or (not before.get("should_run") and not safe_bypass_spend):
         return {
             "ok": False,
@@ -1298,6 +1445,7 @@ def build_quota_slot_preview(
             "so the visible total can stay flat if an older spend expires."
         ),
         "safe_bypass_spend": safe_bypass_spend,
+        "self_repair_spend": self_repair_spend,
     }
 
 
@@ -1308,6 +1456,7 @@ def _compact_quota_decision(decision: dict[str, Any]) -> dict[str, Any]:
         "normal_delivery_allowed": bool(decision.get("normal_delivery_allowed")),
         "recovery_delivery_allowed": bool(decision.get("recovery_delivery_allowed")),
         "effective_action": decision.get("effective_action"),
+        "self_repair_allowed": bool(decision.get("self_repair_allowed")),
         "state": str(decision.get("state") or ""),
         "safe_bypass_allowed": bool(decision.get("safe_bypass_allowed")),
         "safe_bypass_kind": decision.get("safe_bypass_kind"),
@@ -1340,7 +1489,16 @@ def build_quota_slot_spend_event(
         before_compact.get("spent_slots"), default=0
     ) + slots:
         raise ValueError("after.spent_slots must equal before.spent_slots + slots")
-    eligible_spend = before_compact["should_run"] is True and before_compact["state"] == "eligible"
+    self_repair_spend = (
+        before_compact["should_run"] is True
+        and before_compact["effective_action"] in SELF_REPAIR_SPEND_ACTIONS
+        and before_compact["self_repair_allowed"] is True
+    )
+    eligible_spend = (
+        before_compact["should_run"] is True
+        and before_compact["state"] == "eligible"
+        and not self_repair_spend
+    )
     safe_bypass_spend = (
         (
             before_compact["state"] == "operator_gate"
@@ -1349,8 +1507,8 @@ def build_quota_slot_spend_event(
         )
         and before_compact["safe_bypass_allowed"] is True
     )
-    if not eligible_spend and not safe_bypass_spend:
-        raise ValueError("quota slot spend requires an eligible or safe-bypass quota should-run decision")
+    if not eligible_spend and not safe_bypass_spend and not self_repair_spend:
+        raise ValueError("quota slot spend requires an eligible, safe-bypass, or control-plane self-repair quota should-run decision")
 
     return {
         "generated_at": generated_at or _now_local(),
@@ -1363,7 +1521,11 @@ def build_quota_slot_spend_event(
             else (
                 "quota outcome-floor recovery safe-bypass; quota slot spend event public-safe"
                 if before_compact.get("effective_action") == "outcome_floor_recovery"
-                else "quota safe-bypass operator gate; quota slot spend event public-safe"
+                else (
+                    "quota control-plane self-repair; quota slot spend event public-safe"
+                    if self_repair_spend
+                    else "quota safe-bypass operator gate; quota slot spend event public-safe"
+                )
             )
         ),
         "quota_event": {
@@ -1376,7 +1538,11 @@ def build_quota_slot_spend_event(
                 else (
                     f"{slots} automatic agent slot(s) completed as outcome-floor recovery safe-bypass work"
                     if before_compact.get("effective_action") == "outcome_floor_recovery"
-                    else f"{slots} automatic agent slot(s) completed as safe-bypass work under an operator gate"
+                    else (
+                        f"{slots} automatic agent slot(s) completed as control-plane self-repair work"
+                        if self_repair_spend
+                        else f"{slots} automatic agent slot(s) completed as safe-bypass work under an operator gate"
+                    )
                 )
             ),
             "before": before_compact,
@@ -1529,6 +1695,9 @@ def render_quota_markdown(payload: dict[str, Any]) -> str:
                 lines.append(f"  - reason: {reason}")
             if action:
                 lines.append(f"  - action: {action}")
+            control_plane = item.get("control_plane") if isinstance(item.get("control_plane"), dict) else None
+            if control_plane:
+                lines.append(f"  - control_plane: {control_plane_policy_summary(control_plane)}")
             if item.get("agent_command"):
                 lines.append(f"  - agent_command: `{item.get('agent_command')}`")
             if item.get("next_handoff_condition"):
@@ -1592,6 +1761,7 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
         f"- should_run: `{payload.get('should_run')}`",
         f"- normal_delivery_allowed: `{payload.get('normal_delivery_allowed')}`",
         f"- recovery_delivery_allowed: `{payload.get('recovery_delivery_allowed')}`",
+        f"- self_repair_allowed: `{payload.get('self_repair_allowed')}`",
         f"- effective_action: `{payload.get('effective_action')}`",
         f"- actionable_by_codex: `{payload.get('actionable_by_codex')}`",
         f"- state: `{payload.get('state')}`",
@@ -1607,6 +1777,9 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
     )
     if execution_profile:
         lines.append(f"- execution_profile: {execution_profile_summary(execution_profile)}")
+    control_plane = payload.get("control_plane") if isinstance(payload.get("control_plane"), dict) else None
+    if control_plane:
+        lines.append(f"- control_plane: {control_plane_policy_summary(control_plane)}")
 
     def append_todo_summary(label: str, summary: dict[str, Any]) -> None:
         lines.append(
@@ -1717,6 +1890,35 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
             lines.append(f"- heartbeat_spend_policy: {heartbeat_recommendation.get('spend_policy')}")
         if heartbeat_recommendation.get("reason"):
             lines.append(f"- heartbeat_reason: {heartbeat_recommendation.get('reason')}")
+    stall_self_repair = (
+        payload.get("stall_self_repair")
+        if isinstance(payload.get("stall_self_repair"), dict)
+        else {}
+    )
+    if stall_self_repair:
+        lines.append(
+            "- stall_self_repair: "
+            f"trigger={stall_self_repair.get('trigger')} "
+            f"mode={stall_self_repair.get('recommended_mode')} "
+            f"action={stall_self_repair.get('effective_action')}"
+        )
+        if stall_self_repair.get("repair_focus"):
+            lines.append(f"- stall_repair_focus: {stall_self_repair.get('repair_focus')}")
+        blockers = (
+            stall_self_repair.get("blocking_health_items")
+            if isinstance(stall_self_repair.get("blocking_health_items"), list)
+            else []
+        )
+        for blocker in blockers[:3]:
+            if not isinstance(blocker, dict):
+                continue
+            lines.append(
+                "- stall_health_blocker: "
+                f"goal={blocker.get('goal_id')} "
+                f"status={blocker.get('status')} "
+                f"waiting_on={blocker.get('waiting_on')} "
+                f"action={blocker.get('recommended_action')}"
+            )
     if payload.get("safe_bypass_allowed"):
         lines.append(f"- safe_bypass_allowed: `{payload.get('safe_bypass_allowed')}`")
     if payload.get("safe_bypass_kind"):

--- a/goal_harness/registry.py
+++ b/goal_harness/registry.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any
 
 from .authority import authority_registry_summary
+from .control_plane import compact_control_plane_policy, control_plane_policy_summary
 from .execution_profile import compact_execution_profile, execution_profile_summary
 from .orchestration import compact_orchestration_policy, orchestration_policy_summary
 from .quota import goal_quota_config
@@ -88,6 +89,7 @@ def inspect_registry(path: Path) -> dict[str, Any]:
         spawn_policy = raw_goal.get("spawn_policy") if isinstance(raw_goal.get("spawn_policy"), dict) else {}
         orchestration = compact_orchestration_policy(spawn_policy)
         execution_profile = compact_execution_profile(raw_goal.get("execution_profile"))
+        control_plane = compact_control_plane_policy(raw_goal.get("control_plane"))
         authority_sources = raw_goal.get("authority_sources")
         if not isinstance(authority_sources, list):
             authority_sources = []
@@ -140,6 +142,7 @@ def inspect_registry(path: Path) -> dict[str, Any]:
                 "orchestration_mode": orchestration.get("mode"),
                 "spawn_allowed": spawn_policy.get("allowed"),
                 "max_children": spawn_policy.get("max_children"),
+                "control_plane": control_plane,
                 "next_probe": raw_goal.get("next_probe"),
                 "guards": raw_goal.get("guards") or [],
             }
@@ -214,6 +217,16 @@ def render_registry_markdown(payload: dict[str, Any]) -> str:
             if execution_profile
             else ""
         )
+        control_plane = (
+            goal.get("control_plane")
+            if isinstance(goal.get("control_plane"), dict)
+            else None
+        )
+        control_plane_suffix = (
+            f" control_plane={control_plane_policy_summary(control_plane)}"
+            if control_plane
+            else ""
+        )
         lines.append(
             "| "
             f"`{goal.get('id')}` | "
@@ -225,7 +238,7 @@ def render_registry_markdown(payload: dict[str, Any]) -> str:
             f"{goal.get('repo_goal_count')} | "
             f"{goal.get('state_file_exists')} | "
             f"{spawn} | "
-            f"{adapter}{authority_suffix}{quota_suffix}{execution_suffix} | "
+            f"{adapter}{authority_suffix}{quota_suffix}{execution_suffix}{control_plane_suffix} | "
             f"{next_probe} |"
         )
 

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import re
 from typing import Any
 
+from .control_plane import compact_control_plane_policy, control_plane_policy_summary
 from .contract import check_contract
 from .doctor import (
     PROMOTION_READINESS_CLASSIFICATIONS,
@@ -1561,6 +1562,9 @@ def build_attention_queue(
             continue
         item = goal_attention(goal)
         if item:
+            control_plane = compact_control_plane_policy(goal.get("control_plane"))
+            if control_plane:
+                item["control_plane"] = control_plane
             goal_latest_runs = goal.get("latest_runs") if isinstance(goal.get("latest_runs"), list) else []
             enrich_project_asset(
                 item,
@@ -1577,6 +1581,8 @@ def build_attention_queue(
                     else None
                 ),
             )
+            if control_plane and isinstance(item.get("project_asset"), dict):
+                item["project_asset"]["control_plane"] = control_plane
             if goal.get("registry_member"):
                 item.update(active_state_todo_fields(goal))
                 item["quota"] = quota_status(
@@ -2863,6 +2869,9 @@ def render_status_markdown(payload: dict[str, Any]) -> str:
                 f"slots={quota.get('spent_slots')}/{quota.get('allowed_slots')} "
                 f"reason={quota.get('reason')}"
             )
+        control_plane = item.get("control_plane") if isinstance(item.get("control_plane"), dict) else None
+        if control_plane:
+            lines.append(f"  - control_plane: {control_plane_policy_summary(control_plane)}")
         operator_question = item.get("operator_question")
         agent_command = item.get("agent_command")
         if operator_question:


### PR DESCRIPTION
## Summary
- Add a registry-projected `control_plane` policy surface for per-goal self-repair settings.
- Teach `quota should-run` to return `decision=self_repair` with `stall_self_repair` only when that selected goal opts in.
- Allow quota spend accounting for validated control-plane self-repair and document the default-off contract.

## Validation
- `python3 examples/run-smokes.py`
- `python3 -m goal_harness.cli --format json check --scan-root .`
- `python3 -m py_compile goal_harness/*.py examples/render-status-dashboard.py`
- `git diff --check`

## Boundary
- Public examples keep self-repair default off.
- Local opt-in was applied only to `goal-harness-meta` via ignored local/global registry state; other managed threads remain default off.