### PR TITLE
Add dashboard control-plane settings panel

### DIFF
--- a/apps/dashboard/src/data/status.ts
+++ b/apps/dashboard/src/data/status.ts
@@ -27,6 +27,23 @@ export const quotaSchema = z.object({
   };
 });
 
+export const controlPlaneSchema = z.object({
+  self_repair: z.object({
+    enabled: z.boolean().optional().default(false),
+    allow_health_blocker_repair: z.boolean().optional().default(false),
+    allow_waiting_projection_repair: z.boolean().optional().default(false),
+  }).optional().nullable(),
+}).passthrough();
+
+export const orchestrationPolicySchema = z.object({
+  mode: z.string().optional().default("default"),
+  orchestration_mode: z.string().optional().nullable(),
+  spawn_allowed: z.boolean().optional().default(false),
+  allowed: z.boolean().optional().nullable(),
+  max_children: z.number().optional().default(0),
+  allowed_domains: z.array(z.string()).optional().default([]),
+}).passthrough();
+
 export const reviewMaterialSchema = z.object({
   label: z.string().optional().nullable(),
   path: z.string(),
@@ -140,6 +157,8 @@ export const projectAssetSchema = z.object({
   user_todos: projectAssetTodoSummarySchema.optional().nullable(),
   agent_todos: projectAssetTodoSummarySchema.optional().nullable(),
   quota: quotaSchema.optional().nullable(),
+  control_plane: controlPlaneSchema.optional().nullable(),
+  orchestration: orchestrationPolicySchema.optional().nullable(),
   latest_validation: projectAssetLatestValidationSchema.optional().nullable(),
 });
 
@@ -160,6 +179,7 @@ export const queueItemSchema = z.object({
   missing_gates: z.array(z.string()).optional().default([]),
   next_handoff_condition: z.string().optional().nullable(),
   quota: quotaSchema.optional().nullable(),
+  control_plane: controlPlaneSchema.optional().nullable(),
   user_todos: todoGroupSchema.optional().nullable(),
   agent_todos: todoGroupSchema.optional().nullable(),
   dependency_blockers: dependencyBlockerSummarySchema.optional().nullable(),
@@ -295,6 +315,9 @@ export const runGoalSchema = z.object({
   adapter_status: z.string().optional().nullable(),
   authority_registry: authorityRegistrySchema.optional().nullable(),
   quota: quotaSchema.optional().nullable(),
+  control_plane: controlPlaneSchema.optional().nullable(),
+  spawn_policy: orchestrationPolicySchema.optional().nullable(),
+  orchestration: orchestrationPolicySchema.optional().nullable(),
   index_exists: z.boolean().optional().default(false),
   raw_index_records: z.number().optional().default(0),
   unique_runs: z.number().optional().default(0),
@@ -604,6 +627,8 @@ export type OperatorGateResumeContract = z.infer<typeof operatorGateResumeContra
 export type ControllerReadiness = z.infer<typeof controllerReadinessSchema>;
 export type AuthorityRegistry = z.infer<typeof authorityRegistrySchema>;
 export type ComputeQuota = z.infer<typeof quotaSchema>;
+export type ControlPlanePolicy = z.infer<typeof controlPlaneSchema>;
+export type OrchestrationPolicy = z.infer<typeof orchestrationPolicySchema>;
 export type ProjectAsset = z.infer<typeof projectAssetSchema>;
 export type ProjectAssetTodoSummary = z.infer<typeof projectAssetTodoSummarySchema>;
 export type ProjectAssetLatestValidation = z.infer<typeof projectAssetLatestValidationSchema>;

--- a/apps/dashboard/src/views/dashboard-page.tsx
+++ b/apps/dashboard/src/views/dashboard-page.tsx
@@ -37,6 +37,7 @@ import {
   QueueItem,
   AuthorityRegistry,
   ComputeQuota,
+  ControlPlanePolicy,
   ControllerReadiness,
   GlobalRegistryHealth,
   HumanReward,
@@ -47,6 +48,7 @@ import {
   RewardDryRunResponse,
   RunGoal,
   RunRecord,
+  OrchestrationPolicy,
   StatusPayload,
   ProjectAssetLatestValidation,
   ProjectAssetHandoffReadiness,
@@ -1693,6 +1695,171 @@ function QuotaChip({ quota }: { quota?: ComputeQuota | null }) {
     return null;
   }
   return <Badge variant={view.variant}>{view.label}</Badge>;
+}
+
+function controlPlaneForTarget(goal?: RunGoal, queueItem?: QueueItem): ControlPlanePolicy | null {
+  return queueItem?.control_plane ?? queueItem?.project_asset?.control_plane ?? goal?.control_plane ?? null;
+}
+
+function orchestrationForTarget(goal?: RunGoal, queueItem?: QueueItem): OrchestrationPolicy | null {
+  return queueItem?.project_asset?.orchestration ?? goal?.orchestration ?? goal?.spawn_policy ?? null;
+}
+
+function flagValue(value?: boolean | null) {
+  return value ? "on" : "off";
+}
+
+function orchestrationMode(policy?: OrchestrationPolicy | null) {
+  if (!policy) {
+    return "default";
+  }
+  const spawnAllowed = Boolean(policy.spawn_allowed || policy.allowed);
+  const maxChildren = policy.max_children ?? 0;
+  const explicitMode = policy.mode || policy.orchestration_mode || "";
+  if ((!explicitMode || explicitMode === "default") && spawnAllowed && maxChildren > 0) {
+    return "multi_subagent";
+  }
+  return explicitMode || "default";
+}
+
+function buildHeartbeatInstallView(goal?: RunGoal, queueItem?: QueueItem): {
+  badge: string;
+  detail: string;
+  variant: BadgeVariant;
+} {
+  const status = [queueItem?.status, goal?.status, goal?.adapter_status].filter(Boolean).join(" ").toLowerCase();
+  if (status.includes("not_installed")) {
+    return {
+      badge: "not installed",
+      detail: "status includes not_installed",
+      variant: "warning",
+    };
+  }
+  if (status.includes("paused")) {
+    return {
+      badge: "paused",
+      detail: "status includes paused",
+      variant: "neutral",
+    };
+  }
+  if (status.includes("stage_deferred") || status.includes("deferred")) {
+    return {
+      badge: "deferred",
+      detail: "status includes deferred",
+      variant: "warning",
+    };
+  }
+  if (queueItem || goal?.registry_member) {
+    return {
+      badge: "observed",
+      detail: queueItem?.source ? `queue source=${queueItem.source}` : "registry member observed in live status",
+      variant: "success",
+    };
+  }
+  return {
+    badge: "unknown",
+    detail: "no queue or registry heartbeat signal",
+    variant: "neutral",
+  };
+}
+
+function ControlPlaneSettingRow({
+  badge,
+  detail,
+  icon: Icon,
+  label,
+  variant,
+}: {
+  badge: string;
+  detail: string;
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  variant: BadgeVariant;
+}) {
+  return (
+    <div className="min-w-0 rounded-lg border border-slate-200 bg-white p-3 dark:border-zinc-800 dark:bg-zinc-950">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <Icon className="h-4 w-4 shrink-0 text-slate-500 dark:text-zinc-400" />
+          <span className="text-sm font-semibold text-slate-900 dark:text-zinc-100">{label}</span>
+        </div>
+        <Badge variant={variant}>{badge}</Badge>
+      </div>
+      <div className="mt-2 break-words text-xs leading-5 text-slate-500 dark:text-zinc-400">{detail}</div>
+    </div>
+  );
+}
+
+function ControlPlaneSettingsPanel({
+  goal,
+  queueItem,
+}: {
+  goal?: RunGoal;
+  queueItem?: QueueItem;
+}) {
+  const quota = queueItem?.quota ?? queueItem?.project_asset?.quota ?? goal?.quota;
+  const quotaView = buildQuotaView(quota);
+  const controlPlane = controlPlaneForTarget(goal, queueItem);
+  const selfRepair = controlPlane?.self_repair;
+  const heartbeat = buildHeartbeatInstallView(goal, queueItem);
+  const orchestration = orchestrationForTarget(goal, queueItem);
+  const mode = orchestrationMode(orchestration);
+  const domains = orchestration?.allowed_domains?.length ? `; domains=${orchestration.allowed_domains.join(",")}` : "";
+
+  const selfRepairEnabled = Boolean(selfRepair?.enabled);
+  const selfRepairBadge = selfRepair ? `self_repair ${selfRepairEnabled ? "on" : "off"}` : "self_repair default_off";
+  const selfRepairDetail = selfRepair
+    ? `health=${flagValue(selfRepair.allow_health_blocker_repair)}; waiting_projection=${flagValue(selfRepair.allow_waiting_projection_repair)}`
+    : "no per-goal self-repair override";
+  const orchestrationVariant: BadgeVariant = mode === "multi_subagent" ? "info" : "neutral";
+
+  return (
+    <div
+      className="rounded-lg border border-slate-200 bg-slate-50 p-3 dark:border-zinc-800 dark:bg-zinc-900"
+      data-testid="control-plane-settings-panel"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <Gauge className="h-4 w-4 text-slate-600 dark:text-zinc-300" />
+          <h3 className="text-sm font-semibold text-slate-950 dark:text-zinc-50">Control Plane Settings</h3>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Badge variant={selfRepairEnabled ? "success" : "neutral"}>{selfRepairEnabled ? "repair enabled" : "repair off"}</Badge>
+          <Badge variant={orchestrationVariant}>{mode}</Badge>
+        </div>
+      </div>
+      <div className="mt-3 grid gap-2 sm:grid-cols-2">
+        <ControlPlaneSettingRow
+          badge={quotaView?.label ?? "quota unknown"}
+          detail={quotaView?.shortLine ?? "quota not projected"}
+          icon={Gauge}
+          label="Compute quota"
+          variant={quotaView?.variant ?? "neutral"}
+        />
+        <ControlPlaneSettingRow
+          badge={selfRepairBadge}
+          detail={selfRepairDetail}
+          icon={ShieldCheck}
+          label="Self repair"
+          variant={selfRepairEnabled ? "success" : "neutral"}
+        />
+        <ControlPlaneSettingRow
+          badge={heartbeat.badge}
+          detail={heartbeat.detail}
+          icon={Terminal}
+          label="Heartbeat install"
+          variant={heartbeat.variant}
+        />
+        <ControlPlaneSettingRow
+          badge={mode}
+          detail={`spawn_allowed=${flagValue(Boolean(orchestration?.spawn_allowed || orchestration?.allowed))}; max_children=${orchestration?.max_children ?? 0}${domains}`}
+          icon={Bot}
+          label="Orchestration"
+          variant={orchestrationVariant}
+        />
+      </div>
+    </div>
+  );
 }
 
 type ShareGoalSpec = {
@@ -4437,6 +4604,8 @@ function RunHistoryPanel({
             registry={registry}
             runtimeRoot={runtimeRoot}
           />
+
+          <ControlPlaneSettingsPanel goal={goal} queueItem={queueItem} />
 
           <div className="grid gap-2 sm:grid-cols-4">
             <div className="rounded-lg border border-slate-200 p-3 dark:border-zinc-800">

--- a/examples/dashboard-home-browser-smoke.mjs
+++ b/examples/dashboard-home-browser-smoke.mjs
@@ -152,6 +152,19 @@ const goalSpecs = [
       { done: false, text: "统一多项目看板的 serve-status --global-registry 命令说明。" },
       { done: true, text: "已硬化 heartbeat prompt，依赖项目 todo 不再吃掉当前 goal turn。" },
     ],
+    controlPlane: {
+      self_repair: {
+        enabled: true,
+        allow_health_blocker_repair: true,
+        allow_waiting_projection_repair: true,
+      },
+    },
+    orchestration: {
+      mode: "multi_subagent",
+      spawn_allowed: true,
+      max_children: 2,
+      allowed_domains: ["docs", "validation"],
+    },
     latest: {
       generated_at: "2026-01-01T00:03:00+00:00",
       classification: "dashboard_home_chinese_operator_copy_contract",
@@ -173,6 +186,8 @@ function projectAssetFor(spec) {
     user_todos: spec.userTodos,
     agent_todos: spec.agentTodos,
     quota: spec.quota,
+    control_plane: spec.controlPlane,
+    orchestration: spec.orchestration,
     latest_validation: {
       generated_at: spec.latest.generated_at,
       classification: spec.latest.classification,
@@ -275,6 +290,7 @@ const statusFixture = {
         project_asset: projectAssetFor(spec),
         handoff_readiness: spec.handoffReadiness,
         quota: spec.quota,
+        control_plane: spec.controlPlane,
         user_todos: todoGroupFor(spec, "user"),
         agent_todos: todoGroupFor(spec, "agent"),
         dependency_blockers: spec.id === "goal-harness-meta" && sideBypassUserTodo
@@ -311,6 +327,8 @@ const statusFixture = {
       adapter_kind: "dashboard_home_fixture",
       adapter_status: "connected",
       quota: spec.quota,
+      control_plane: spec.controlPlane,
+      spawn_policy: spec.orchestration,
       index_exists: true,
       raw_index_records: 1,
       unique_runs: 1,
@@ -520,6 +538,27 @@ async function main() {
     if (url.searchParams.get("view")) {
       throw new Error(`Canonical home should not keep a view search param: ${page.url()}`);
     }
+
+    await page.goto(`${baseUrl}/?view=ops&goalId=goal-harness-meta&statusUrl=/${fixtureName}`, { waitUntil: "networkidle" });
+    await page.waitForSelector('[data-testid="control-plane-settings-panel"]', { timeout: 10_000 });
+    const settingsText = await page.locator('[data-testid="control-plane-settings-panel"]').innerText();
+    const requiredSettings = [
+      "Control Plane Settings",
+      "Quota 1",
+      "self_repair on",
+      "health=on",
+      "waiting_projection=on",
+      "Heartbeat install",
+      "observed",
+      "multi_subagent",
+      "max_children=2",
+      "domains=docs,validation",
+    ];
+    const missingSettings = requiredSettings.filter((text) => !settingsText.includes(text));
+    if (missingSettings.length) {
+      throw new Error(`Missing control-plane settings text: ${missingSettings.join(", ")}`);
+    }
+
     if (pageErrors.length) {
       throw new Error(`Dashboard page errors: ${pageErrors.join(" | ")}`);
     }


### PR DESCRIPTION
## Summary
- preserve projected control_plane and orchestration policy fields in dashboard status parsing
- add a read-only selected-goal Control Plane Settings panel for quota, self-repair, heartbeat install signal, and orchestration mode
- extend the dashboard browser smoke with a meta self-repair + multi-subagent fixture assertion

## Validation
- npm --prefix apps/dashboard run build
- npm --prefix apps/dashboard run smoke:home-browser
- python3 examples/run-smokes.py
- python3 -m goal_harness.cli --format json check --scan-root .
- git diff --check
- sensitive diff grep for local paths, credentials, tokens, and private/prod markers
