### PR TITLE
Add configurable control-plane setting drafts

### DIFF
--- a/apps/dashboard/src/views/dashboard-page.tsx
+++ b/apps/dashboard/src/views/dashboard-page.tsx
@@ -1722,6 +1722,13 @@ function orchestrationMode(policy?: OrchestrationPolicy | null) {
   return explicitMode || "default";
 }
 
+function shellArg(value: string) {
+  if (/^[A-Za-z0-9_./:=@,+-]+$/.test(value)) {
+    return value;
+  }
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
 function buildHeartbeatInstallView(goal?: RunGoal, queueItem?: QueueItem): {
   badge: string;
   detail: string;
@@ -1790,12 +1797,100 @@ function ControlPlaneSettingRow({
   );
 }
 
+type ControlPlaneSettingsDraft = {
+  quotaCompute: string;
+  quotaWindowHours: string;
+  selfRepairEnabled: boolean;
+  selfRepairHealth: boolean;
+  selfRepairWaitingProjection: boolean;
+  orchestrationMode: "default" | "multi_subagent";
+  spawnAllowed: boolean;
+  maxChildren: string;
+  allowedDomains: string;
+};
+
+function buildControlPlaneSettingsDraft(goal?: RunGoal, queueItem?: QueueItem): ControlPlaneSettingsDraft {
+  const quota = queueItem?.quota ?? queueItem?.project_asset?.quota ?? goal?.quota;
+  const controlPlane = controlPlaneForTarget(goal, queueItem);
+  const selfRepair = controlPlane?.self_repair;
+  const orchestration = orchestrationForTarget(goal, queueItem);
+  const mode = orchestrationMode(orchestration);
+  return {
+    quotaCompute: String(quota?.compute ?? 1),
+    quotaWindowHours: String(quota?.window_hours ?? 24),
+    selfRepairEnabled: Boolean(selfRepair?.enabled),
+    selfRepairHealth: Boolean(selfRepair?.allow_health_blocker_repair),
+    selfRepairWaitingProjection: Boolean(selfRepair?.allow_waiting_projection_repair),
+    orchestrationMode: mode === "multi_subagent" ? "multi_subagent" : "default",
+    spawnAllowed: Boolean(orchestration?.spawn_allowed || orchestration?.allowed),
+    maxChildren: String(orchestration?.max_children ?? 0),
+    allowedDomains: orchestration?.allowed_domains?.length ? orchestration.allowed_domains.join(", ") : "",
+  };
+}
+
+function booleanFlag(enabled: boolean, positive: string) {
+  return enabled ? `--${positive}` : `--no-${positive}`;
+}
+
+function normalizedDomainList(value: string) {
+  return value.split(",").map((item) => item.trim()).filter(Boolean);
+}
+
+function buildConfigureGoalCommand({
+  draft,
+  execute,
+  goalId,
+  registry,
+}: {
+  draft: ControlPlaneSettingsDraft;
+  execute: boolean;
+  goalId?: string;
+  registry: string;
+}) {
+  if (!goalId) {
+    return "";
+  }
+  const registryArg = registry ? shellArg(registry) : "$HOME/.codex/goal-harness/registry.global.json";
+  const parts = [
+    "goal-harness",
+    "--registry",
+    registryArg,
+    "configure-goal",
+    "--goal-id",
+    shellArg(goalId),
+    "--quota-compute",
+    shellArg(draft.quotaCompute.trim() || "1"),
+    "--quota-window-hours",
+    shellArg(draft.quotaWindowHours.trim() || "24"),
+    booleanFlag(draft.selfRepairEnabled, "self-repair-enabled"),
+    booleanFlag(draft.selfRepairHealth, "self-repair-health"),
+    booleanFlag(draft.selfRepairWaitingProjection, "self-repair-waiting-projection"),
+    "--orchestration-mode",
+    draft.orchestrationMode,
+    booleanFlag(draft.spawnAllowed, "spawn-allowed"),
+    "--max-children",
+    shellArg(draft.maxChildren.trim() || "0"),
+  ];
+  for (const domain of normalizedDomainList(draft.allowedDomains)) {
+    parts.push("--allowed-domain", shellArg(domain));
+  }
+  if (!normalizedDomainList(draft.allowedDomains).length) {
+    parts.push("--clear-allowed-domains");
+  }
+  if (execute) {
+    parts.push("--execute");
+  }
+  return parts.join(" ");
+}
+
 function ControlPlaneSettingsPanel({
   goal,
   queueItem,
+  registry,
 }: {
   goal?: RunGoal;
   queueItem?: QueueItem;
+  registry: string;
 }) {
   const quota = queueItem?.quota ?? queueItem?.project_asset?.quota ?? goal?.quota;
   const quotaView = buildQuotaView(quota);
@@ -1812,6 +1907,49 @@ function ControlPlaneSettingsPanel({
     ? `health=${flagValue(selfRepair.allow_health_blocker_repair)}; waiting_projection=${flagValue(selfRepair.allow_waiting_projection_repair)}`
     : "no per-goal self-repair override";
   const orchestrationVariant: BadgeVariant = mode === "multi_subagent" ? "info" : "neutral";
+  const currentDraft = useMemo(
+    () => buildControlPlaneSettingsDraft(goal, queueItem),
+    [
+      goal?.id,
+      goal?.quota,
+      goal?.control_plane,
+      goal?.orchestration,
+      goal?.spawn_policy,
+      queueItem?.goal_id,
+      queueItem?.quota,
+      queueItem?.control_plane,
+      queueItem?.project_asset?.quota,
+      queueItem?.project_asset?.control_plane,
+      queueItem?.project_asset?.orchestration,
+    ],
+  );
+  const [draft, setDraft] = useState(currentDraft);
+  const [copyState, setCopyState] = useState<CopyState>("idle");
+  const dirty = JSON.stringify(draft) !== JSON.stringify(currentDraft);
+  const goalId = goal?.id ?? queueItem?.goal_id;
+  const dryRunCommand = buildConfigureGoalCommand({ draft, execute: false, goalId, registry });
+  const applyCommand = buildConfigureGoalCommand({ draft, execute: true, goalId, registry });
+  const canCopy = Boolean(goalId && dirty);
+
+  useEffect(() => {
+    setDraft(currentDraft);
+    setCopyState("idle");
+  }, [currentDraft]);
+
+  useEffect(() => {
+    if (copyState === "idle") {
+      return undefined;
+    }
+    const timeoutId = window.setTimeout(() => setCopyState("idle"), 1800);
+    return () => window.clearTimeout(timeoutId);
+  }, [copyState]);
+
+  async function copyCommand(command: string) {
+    if (!command) {
+      return;
+    }
+    setCopyState((await copyTextToClipboard(command)) ? "copied" : "failed");
+  }
 
   return (
     <div
@@ -1826,6 +1964,7 @@ function ControlPlaneSettingsPanel({
         <div className="flex flex-wrap gap-2">
           <Badge variant={selfRepairEnabled ? "success" : "neutral"}>{selfRepairEnabled ? "repair enabled" : "repair off"}</Badge>
           <Badge variant={orchestrationVariant}>{mode}</Badge>
+          <Badge variant={dirty ? "warning" : "success"}>{dirty ? "dirty" : "clean"}</Badge>
         </div>
       </div>
       <div className="mt-3 grid gap-2 sm:grid-cols-2">
@@ -1857,6 +1996,117 @@ function ControlPlaneSettingsPanel({
           label="Orchestration"
           variant={orchestrationVariant}
         />
+      </div>
+      <div className="mt-3 grid gap-3 rounded-lg border border-slate-200 bg-white p-3 dark:border-zinc-800 dark:bg-zinc-950 lg:grid-cols-2">
+        <label className="space-y-1 text-xs font-medium text-slate-500 dark:text-zinc-400">
+          <span>Quota compute</span>
+          <input
+            className={inputClassName}
+            data-testid="control-plane-quota-compute"
+            inputMode="decimal"
+            onChange={(event) => setDraft((value) => ({ ...value, quotaCompute: event.target.value }))}
+            value={draft.quotaCompute}
+          />
+        </label>
+        <label className="space-y-1 text-xs font-medium text-slate-500 dark:text-zinc-400">
+          <span>Quota window hours</span>
+          <input
+            className={inputClassName}
+            inputMode="decimal"
+            onChange={(event) => setDraft((value) => ({ ...value, quotaWindowHours: event.target.value }))}
+            value={draft.quotaWindowHours}
+          />
+        </label>
+        <label className="space-y-1 text-xs font-medium text-slate-500 dark:text-zinc-400">
+          <span>Orchestration mode</span>
+          <Select
+            className="w-full"
+            data-testid="control-plane-orchestration-mode"
+            onChange={(event) =>
+              setDraft((value) => ({
+                ...value,
+                orchestrationMode: event.target.value === "multi_subagent" ? "multi_subagent" : "default",
+              }))
+            }
+            value={draft.orchestrationMode}
+          >
+            <option value="default">default</option>
+            <option value="multi_subagent">multi_subagent</option>
+          </Select>
+        </label>
+        <label className="space-y-1 text-xs font-medium text-slate-500 dark:text-zinc-400">
+          <span>Max children</span>
+          <input
+            className={inputClassName}
+            inputMode="numeric"
+            onChange={(event) => setDraft((value) => ({ ...value, maxChildren: event.target.value }))}
+            value={draft.maxChildren}
+          />
+        </label>
+        <label className="block space-y-1 text-xs font-medium text-slate-500 dark:text-zinc-400 lg:col-span-2">
+          <span>Allowed domains</span>
+          <input
+            className={inputClassName}
+            onChange={(event) => setDraft((value) => ({ ...value, allowedDomains: event.target.value }))}
+            value={draft.allowedDomains}
+          />
+        </label>
+        <div className="flex flex-wrap gap-3 text-xs font-medium text-slate-600 dark:text-zinc-300 lg:col-span-2">
+          <label className="inline-flex items-center gap-2">
+            <input
+              checked={draft.selfRepairEnabled}
+              onChange={(event) => setDraft((value) => ({ ...value, selfRepairEnabled: event.target.checked }))}
+              type="checkbox"
+            />
+            self repair
+          </label>
+          <label className="inline-flex items-center gap-2">
+            <input
+              checked={draft.selfRepairHealth}
+              onChange={(event) => setDraft((value) => ({ ...value, selfRepairHealth: event.target.checked }))}
+              type="checkbox"
+            />
+            health repair
+          </label>
+          <label className="inline-flex items-center gap-2">
+            <input
+              checked={draft.selfRepairWaitingProjection}
+              onChange={(event) => setDraft((value) => ({ ...value, selfRepairWaitingProjection: event.target.checked }))}
+              type="checkbox"
+            />
+            waiting projection
+          </label>
+          <label className="inline-flex items-center gap-2">
+            <input
+              checked={draft.spawnAllowed}
+              onChange={(event) => setDraft((value) => ({ ...value, spawnAllowed: event.target.checked }))}
+              type="checkbox"
+            />
+            spawn allowed
+          </label>
+        </div>
+        <div className="flex flex-wrap items-center gap-2 lg:col-span-2">
+          <Button disabled={!dirty} onClick={() => setDraft(currentDraft)} size="sm" variant="ghost">
+            <RotateCcw className="h-4 w-4" />
+            Reset
+          </Button>
+          <Button disabled={!canCopy} onClick={() => void copyCommand(dryRunCommand)} size="sm">
+            <Copy className="h-4 w-4" />
+            Copy dry-run
+          </Button>
+          <Button disabled={!canCopy} onClick={() => void copyCommand(applyCommand)} size="sm" variant="primary">
+            <Copy className="h-4 w-4" />
+            Copy apply
+          </Button>
+          {copyState === "copied" ? <Badge variant="success">copied</Badge> : null}
+          {copyState === "failed" ? <Badge variant="danger">copy failed</Badge> : null}
+        </div>
+        <pre
+          className="overflow-x-auto whitespace-pre-wrap break-words rounded-md border border-slate-200 bg-slate-950 p-3 text-xs leading-5 text-slate-50 dark:border-zinc-800 lg:col-span-2"
+          data-testid="control-plane-settings-command-preview"
+        >
+          {dryRunCommand || "select a goal"}
+        </pre>
       </div>
     </div>
   );
@@ -4605,7 +4855,7 @@ function RunHistoryPanel({
             runtimeRoot={runtimeRoot}
           />
 
-          <ControlPlaneSettingsPanel goal={goal} queueItem={queueItem} />
+          <ControlPlaneSettingsPanel goal={goal} queueItem={queueItem} registry={registry} />
 
           <div className="grid gap-2 sm:grid-cols-4">
             <div className="rounded-lg border border-slate-200 p-3 dark:border-zinc-800">

--- a/examples/configure-goal-smoke.py
+++ b/examples/configure-goal-smoke.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Smoke-test the safe per-goal registry configuration command."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GOAL_ID = "configure-goal-fixture"
+
+
+def write_registry(root: Path) -> Path:
+    registry_path = root / "registry.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "common_runtime_root": str(root / "runtime"),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "configure-goal-smoke",
+                        "status": "active",
+                        "repo": str(root / "project"),
+                        "state_file": ".codex/goals/configure-goal-fixture/STATE.md",
+                        "adapter": {"kind": "generic_project_goal_v0", "status": "connected"},
+                        "quota": {"compute": 1, "window_hours": 24},
+                        "spawn_policy": {"mode": "default", "allowed": False, "max_children": 0},
+                        "control_plane": {
+                            "self_repair": {
+                                "enabled": False,
+                                "allow_health_blocker_repair": False,
+                                "allow_waiting_projection_repair": False,
+                            }
+                        },
+                    }
+                ],
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return registry_path
+
+
+def run_cli(registry_path: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "goal_harness.cli",
+            "--registry",
+            str(registry_path),
+            "--format",
+            "json",
+            *args,
+        ],
+        cwd=REPO_ROOT,
+        check=check,
+        text=True,
+        capture_output=True,
+    )
+
+
+def payload(result: subprocess.CompletedProcess[str]) -> dict:
+    return json.loads(result.stdout)
+
+
+def goal_from_registry(registry_path: Path) -> dict:
+    registry = json.loads(registry_path.read_text(encoding="utf-8"))
+    return registry["goals"][0]
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="goal-harness-configure-goal-smoke-") as tmp:
+        root = Path(tmp)
+        registry_path = write_registry(root)
+        original = registry_path.read_text(encoding="utf-8")
+
+        dry = payload(run_cli(
+            registry_path,
+            "configure-goal",
+            "--goal-id",
+            GOAL_ID,
+            "--quota-compute",
+            "0.5",
+            "--self-repair-enabled",
+            "--self-repair-health",
+            "--self-repair-waiting-projection",
+            "--orchestration-mode",
+            "multi_subagent",
+            "--spawn-allowed",
+            "--max-children",
+            "2",
+            "--allowed-domain",
+            "docs",
+            "--allowed-domain",
+            "validation",
+        ))
+        assert dry["ok"] is True, dry
+        assert dry["dry_run"] is True, dry
+        assert dry["changed"] is True, dry
+        assert dry["written"] is False, dry
+        assert registry_path.read_text(encoding="utf-8") == original
+
+        applied = payload(run_cli(
+            registry_path,
+            "configure-goal",
+            "--goal-id",
+            GOAL_ID,
+            "--quota-compute",
+            "0.5",
+            "--self-repair-enabled",
+            "--self-repair-health",
+            "--self-repair-waiting-projection",
+            "--orchestration-mode",
+            "multi_subagent",
+            "--spawn-allowed",
+            "--max-children",
+            "2",
+            "--allowed-domain",
+            "docs,validation",
+            "--execute",
+        ))
+        assert applied["ok"] is True, applied
+        assert applied["dry_run"] is False, applied
+        assert applied["written"] is True, applied
+        goal = goal_from_registry(registry_path)
+        assert goal["quota"]["compute"] == 0.5, goal
+        assert goal["control_plane"]["self_repair"]["enabled"] is True, goal
+        assert goal["control_plane"]["self_repair"]["allow_health_blocker_repair"] is True, goal
+        assert goal["control_plane"]["self_repair"]["allow_waiting_projection_repair"] is True, goal
+        assert goal["spawn_policy"]["mode"] == "multi_subagent", goal
+        assert goal["spawn_policy"]["allowed"] is True, goal
+        assert goal["spawn_policy"]["max_children"] == 2, goal
+        assert goal["spawn_policy"]["allowed_domains"] == ["docs", "validation"], goal
+
+        no_change = payload(run_cli(
+            registry_path,
+            "configure-goal",
+            "--goal-id",
+            GOAL_ID,
+            "--quota-compute",
+            "0.5",
+        ))
+        assert no_change["ok"] is True, no_change
+        assert no_change["changed"] is False, no_change
+
+        invalid = payload(run_cli(
+            registry_path,
+            "configure-goal",
+            "--goal-id",
+            GOAL_ID,
+            "--quota-compute",
+            "0",
+            check=False,
+        ))
+        assert invalid["ok"] is False, invalid
+        assert "greater than 0" in invalid["error"], invalid
+
+    print("configure-goal-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/dashboard-home-browser-smoke.mjs
+++ b/examples/dashboard-home-browser-smoke.mjs
@@ -558,6 +558,33 @@ async function main() {
     if (missingSettings.length) {
       throw new Error(`Missing control-plane settings text: ${missingSettings.join(", ")}`);
     }
+    await page.locator('[data-testid="control-plane-quota-compute"]').fill("1.5");
+    const updatedSettingsText = await page.locator('[data-testid="control-plane-settings-panel"]').innerText();
+    if (!updatedSettingsText.includes("dirty")) {
+      throw new Error("Control-plane settings draft did not enter dirty state after editing quota.");
+    }
+    const settingsCommand = await page.locator('[data-testid="control-plane-settings-command-preview"]').innerText();
+    const requiredCommandParts = [
+      "configure-goal",
+      "--goal-id goal-harness-meta",
+      "--quota-compute 1.5",
+      "--quota-window-hours 24",
+      "--self-repair-enabled",
+      "--self-repair-health",
+      "--self-repair-waiting-projection",
+      "--orchestration-mode multi_subagent",
+      "--spawn-allowed",
+      "--max-children 2",
+      "--allowed-domain docs",
+      "--allowed-domain validation",
+    ];
+    const missingCommandParts = requiredCommandParts.filter((text) => !settingsCommand.includes(text));
+    if (missingCommandParts.length) {
+      throw new Error(`Missing control-plane settings command text: ${missingCommandParts.join(", ")}`);
+    }
+    if (settingsCommand.includes("--execute")) {
+      throw new Error("Control-plane command preview must stay dry-run by default.");
+    }
 
     if (pageErrors.length) {
       throw new Error(`Dashboard page errors: ${pageErrors.join(" | ")}`);

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -11,6 +11,7 @@ from .bootstrap import (
     bootstrap_project,
     render_bootstrap_markdown,
 )
+from .configure_goal import configure_goal, render_configure_goal_markdown
 from .contract import check_contract, render_contract_markdown
 from .demo import (
     DEFAULT_DEMO_AGENT_TODO,
@@ -344,6 +345,60 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     sub.add_parser("registry", help="Inspect registry goals and adapter declarations.")
+
+    configure_goal_parser = sub.add_parser(
+        "configure-goal",
+        help="Preview or apply per-goal registry settings for quota, self-repair, and orchestration.",
+    )
+    configure_goal_parser.add_argument("--goal-id", required=True, help="Goal id to configure.")
+    configure_goal_parser.add_argument("--quota-compute", type=float, help="Per-goal quota compute multiplier.")
+    configure_goal_parser.add_argument("--quota-window-hours", type=float, help="Quota rolling window in hours.")
+    configure_goal_parser.add_argument(
+        "--self-repair-enabled",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Enable or disable control_plane.self_repair for this goal.",
+    )
+    configure_goal_parser.add_argument(
+        "--self-repair-health",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Enable or disable control-plane health blocker repair for this goal.",
+    )
+    configure_goal_parser.add_argument(
+        "--self-repair-waiting-projection",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Enable or disable waiting-projection repair for this goal.",
+    )
+    configure_goal_parser.add_argument(
+        "--orchestration-mode",
+        choices=["default", "multi_subagent"],
+        help="Per-goal orchestration mode.",
+    )
+    configure_goal_parser.add_argument(
+        "--spawn-allowed",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Allow or block sub-agent spawning for this goal.",
+    )
+    configure_goal_parser.add_argument("--max-children", type=int, help="Maximum child agents for orchestration.")
+    configure_goal_parser.add_argument(
+        "--allowed-domain",
+        action="append",
+        default=None,
+        help="Allowed child-agent domain. Repeatable; comma-separated values are also accepted.",
+    )
+    configure_goal_parser.add_argument(
+        "--clear-allowed-domains",
+        action="store_true",
+        help="Clear allowed child-agent domains.",
+    )
+    configure_goal_parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Write the registry. Without this flag, configure-goal is a dry-run preview.",
+    )
 
     history_parser = sub.add_parser("history", help="Read compact run history from the shared runtime root.")
     history_parser.add_argument("--goal-id", help="Only show one goal.")
@@ -834,6 +889,37 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "registry":
         payload = inspect_registry(registry_path)
         print_payload(payload, args.format, render_registry_markdown)
+        return 0 if payload.get("ok") else 1
+
+    if args.command == "configure-goal":
+        try:
+            payload = configure_goal(
+                registry_path=registry_path,
+                goal_id=args.goal_id,
+                quota_compute=args.quota_compute,
+                quota_window_hours=args.quota_window_hours,
+                self_repair_enabled=args.self_repair_enabled,
+                self_repair_health=args.self_repair_health,
+                self_repair_waiting_projection=args.self_repair_waiting_projection,
+                orchestration_mode=args.orchestration_mode,
+                spawn_allowed=args.spawn_allowed,
+                max_children=args.max_children,
+                allowed_domains=args.allowed_domain,
+                clear_allowed_domains=bool(args.clear_allowed_domains),
+                execute=bool(args.execute),
+            )
+        except Exception as exc:
+            payload = {
+                "ok": False,
+                "dry_run": not bool(args.execute),
+                "execute": bool(args.execute),
+                "registry": str(registry_path),
+                "goal_id": args.goal_id,
+                "changed": False,
+                "written": False,
+                "error": str(exc),
+            }
+        print_payload(payload, args.format, render_configure_goal_markdown)
         return 0 if payload.get("ok") else 1
 
     if args.command == "history":

--- a/goal_harness/configure_goal.py
+++ b/goal_harness/configure_goal.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from .control_plane import compact_control_plane_policy, control_plane_policy_summary
+from .orchestration import compact_orchestration_policy, orchestration_policy_summary
+from .quota import goal_quota_config
+from .registry import read_json, registry_goals
+
+
+def _now_iso() -> str:
+    return datetime.now().astimezone().replace(microsecond=0).isoformat()
+
+
+def _positive_number(value: float | None, *, field: str) -> float | None:
+    if value is None:
+        return None
+    if value <= 0:
+        raise ValueError(f"{field} must be greater than 0")
+    return float(value)
+
+
+def _non_negative_int(value: int | None, *, field: str) -> int | None:
+    if value is None:
+        return None
+    if value < 0:
+        raise ValueError(f"{field} must be greater than or equal to 0")
+    return int(value)
+
+
+def _clean_domains(values: list[str] | None) -> list[str] | None:
+    if values is None:
+        return None
+    domains: list[str] = []
+    for value in values:
+        for part in str(value).split(","):
+            domain = part.strip()
+            if domain and domain not in domains:
+                domains.append(domain)
+    return domains
+
+
+def _settings_summary(goal: dict[str, Any]) -> dict[str, Any]:
+    quota = goal_quota_config(goal)
+    control_plane = compact_control_plane_policy(goal.get("control_plane"))
+    orchestration = compact_orchestration_policy(goal.get("spawn_policy"))
+    return {
+        "quota": {
+            "compute": quota.get("compute"),
+            "window_hours": quota.get("window_hours"),
+        },
+        "control_plane": control_plane,
+        "orchestration": orchestration,
+    }
+
+
+def _changed_fields(before: dict[str, Any], after: dict[str, Any]) -> list[str]:
+    changed: list[str] = []
+    for group, before_value in before.items():
+        after_value = after.get(group)
+        if before_value != after_value:
+            changed.append(group)
+    return changed
+
+
+def configure_goal(
+    *,
+    registry_path: Path,
+    goal_id: str,
+    quota_compute: float | None = None,
+    quota_window_hours: float | None = None,
+    self_repair_enabled: bool | None = None,
+    self_repair_health: bool | None = None,
+    self_repair_waiting_projection: bool | None = None,
+    orchestration_mode: str | None = None,
+    spawn_allowed: bool | None = None,
+    max_children: int | None = None,
+    allowed_domains: list[str] | None = None,
+    clear_allowed_domains: bool = False,
+    execute: bool = False,
+) -> dict[str, Any]:
+    if not registry_path.exists():
+        raise FileNotFoundError(f"registry file does not exist: {registry_path}")
+    if clear_allowed_domains and allowed_domains:
+        raise ValueError("--clear-allowed-domains cannot be combined with --allowed-domain")
+
+    quota_compute = _positive_number(quota_compute, field="quota_compute")
+    quota_window_hours = _positive_number(quota_window_hours, field="quota_window_hours")
+    max_children = _non_negative_int(max_children, field="max_children")
+    allowed_domains = _clean_domains(allowed_domains)
+
+    payload = read_json(registry_path)
+    goals = registry_goals(payload)
+    goal = next((item for item in goals if str(item.get("id")) == goal_id), None)
+    if goal is None:
+        raise ValueError(f"goal_id not found in registry: {goal_id}")
+
+    before_goal = deepcopy(goal)
+    before = _settings_summary(before_goal)
+
+    if quota_compute is not None or quota_window_hours is not None:
+        quota = goal.get("quota") if isinstance(goal.get("quota"), dict) else {}
+        if quota_compute is not None:
+            quota["compute"] = quota_compute
+        if quota_window_hours is not None:
+            quota["window_hours"] = quota_window_hours
+        goal["quota"] = quota
+
+    if (
+        self_repair_enabled is not None
+        or self_repair_health is not None
+        or self_repair_waiting_projection is not None
+    ):
+        control_plane = goal.get("control_plane") if isinstance(goal.get("control_plane"), dict) else {}
+        self_repair = control_plane.get("self_repair") if isinstance(control_plane.get("self_repair"), dict) else {}
+        if self_repair_enabled is not None:
+            self_repair["enabled"] = self_repair_enabled
+        if self_repair_health is not None:
+            self_repair["allow_health_blocker_repair"] = self_repair_health
+        if self_repair_waiting_projection is not None:
+            self_repair["allow_waiting_projection_repair"] = self_repair_waiting_projection
+        control_plane["self_repair"] = self_repair
+        goal["control_plane"] = control_plane
+
+    if (
+        orchestration_mode is not None
+        or spawn_allowed is not None
+        or max_children is not None
+        or allowed_domains is not None
+        or clear_allowed_domains
+    ):
+        spawn_policy = goal.get("spawn_policy") if isinstance(goal.get("spawn_policy"), dict) else {}
+        if orchestration_mode is not None:
+            spawn_policy["mode"] = orchestration_mode
+        if spawn_allowed is not None:
+            spawn_policy["allowed"] = spawn_allowed
+        if max_children is not None:
+            spawn_policy["max_children"] = max_children
+        if clear_allowed_domains:
+            spawn_policy["allowed_domains"] = []
+        elif allowed_domains is not None:
+            spawn_policy["allowed_domains"] = allowed_domains
+        goal["spawn_policy"] = spawn_policy
+
+    after = _settings_summary(goal)
+    changed_fields = _changed_fields(before, after)
+    dry_run = not execute
+
+    if execute and changed_fields:
+        payload["updated_at"] = _now_iso()
+        registry_path.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+    return {
+        "ok": True,
+        "dry_run": dry_run,
+        "execute": execute,
+        "registry": str(registry_path),
+        "goal_id": goal_id,
+        "changed": bool(changed_fields),
+        "changed_fields": changed_fields,
+        "before": before,
+        "after": after,
+        "written": bool(execute and changed_fields),
+        "control_plane_summary": control_plane_policy_summary(after.get("control_plane")),
+        "orchestration_summary": orchestration_policy_summary(after.get("orchestration")),
+    }
+
+
+def render_configure_goal_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Goal Harness Goal Configuration",
+        "",
+        f"- ok: `{payload.get('ok')}`",
+        f"- dry_run: `{payload.get('dry_run')}`",
+        f"- registry: `{payload.get('registry')}`",
+        f"- goal_id: `{payload.get('goal_id')}`",
+        f"- changed: `{payload.get('changed')}`",
+        f"- written: `{payload.get('written')}`",
+    ]
+    if payload.get("error"):
+        lines.append(f"- error: {payload.get('error')}")
+        return "\n".join(lines)
+    fields = payload.get("changed_fields") or []
+    lines.append(f"- changed_fields: `{', '.join(fields) if fields else 'none'}`")
+    if payload.get("control_plane_summary"):
+        lines.append(f"- control_plane: {payload.get('control_plane_summary')}")
+    if payload.get("orchestration_summary"):
+        lines.append(f"- orchestration: {payload.get('orchestration_summary')}")
+    lines.extend(
+        [
+            "",
+            "## Before",
+            "",
+            "```json",
+            json.dumps(payload.get("before") or {}, ensure_ascii=False, indent=2),
+            "```",
+            "",
+            "## After",
+            "",
+            "```json",
+            json.dumps(payload.get("after") or {}, ensure_ascii=False, indent=2),
+            "```",
+        ]
+    )
+    return "\n".join(lines)


### PR DESCRIPTION
## Summary
- add `goal-harness configure-goal` to dry-run or explicitly apply per-goal quota, self-repair, and orchestration settings
- extend the dashboard control-plane settings panel with editable draft fields, dirty/reset state, and copyable dry-run/apply commands
- add CLI and browser smoke coverage for the safe command-preview settings flow

## Validation
- `python3 -m py_compile goal_harness/configure_goal.py goal_harness/cli.py`
- `python3 examples/configure-goal-smoke.py`
- `npm --prefix apps/dashboard run build`
- `npm --prefix apps/dashboard run smoke:home-browser`
- `python3 examples/run-smokes.py` (33 smoke scripts)
- `python3 -m goal_harness.cli --format json check --scan-root .`
- `git diff --check`
- staged sensitive-diff grep over touched public files