### PR TITLE
Add control-plane settings loopback API

### DIFF
--- a/apps/dashboard/src/views/dashboard-page.tsx
+++ b/apps/dashboard/src/views/dashboard-page.tsx
@@ -441,6 +441,24 @@ function buildRewardApiUrls(source: DataSource) {
   }
 }
 
+function buildControlPlaneApiUrls(source: DataSource) {
+  if (source.kind !== "url" || !/^https?:\/\//i.test(source.label)) {
+    return { dryRunUrl: null, applyUrl: null };
+  }
+  try {
+    const url = new URL(source.label);
+    const isLoopback = ["127.0.0.1", "localhost", "::1", "[::1]"].includes(url.hostname);
+    return isLoopback
+      ? {
+          dryRunUrl: `${url.origin}/control-plane/configure-goal/dry-run`,
+          applyUrl: `${url.origin}/control-plane/configure-goal/apply`,
+        }
+      : { dryRunUrl: null, applyUrl: null };
+  } catch {
+    return { dryRunUrl: null, applyUrl: null };
+  }
+}
+
 function buildReviewMaterialUrl(source: DataSource, goalId: string, material: ReviewMaterial) {
   if (source.kind !== "url" || !/^https?:\/\//i.test(source.label) || !material.path) {
     return null;
@@ -1809,6 +1827,34 @@ type ControlPlaneSettingsDraft = {
   allowedDomains: string;
 };
 
+type ConfigureGoalRequestBody = {
+  allowed_domains: string[];
+  clear_allowed_domains: boolean;
+  goal_id: string;
+  max_children: number;
+  orchestration_mode: "default" | "multi_subagent";
+  quota_compute: number;
+  quota_window_hours: number;
+  self_repair_enabled: boolean;
+  self_repair_health: boolean;
+  self_repair_waiting_projection: boolean;
+  spawn_allowed: boolean;
+};
+
+type ConfigureGoalApiResponse = {
+  ok: boolean;
+  dry_run?: boolean;
+  execute?: boolean;
+  written?: boolean;
+  changed?: boolean;
+  goal_id?: string;
+  changed_fields?: string[];
+  preview_id?: string;
+  control_plane_summary?: string;
+  orchestration_summary?: string;
+  error?: string;
+};
+
 function buildControlPlaneSettingsDraft(goal?: RunGoal, queueItem?: QueueItem): ControlPlaneSettingsDraft {
   const quota = queueItem?.quota ?? queueItem?.project_asset?.quota ?? goal?.quota;
   const controlPlane = controlPlaneForTarget(goal, queueItem);
@@ -1825,6 +1871,31 @@ function buildControlPlaneSettingsDraft(goal?: RunGoal, queueItem?: QueueItem): 
     spawnAllowed: Boolean(orchestration?.spawn_allowed || orchestration?.allowed),
     maxChildren: String(orchestration?.max_children ?? 0),
     allowedDomains: orchestration?.allowed_domains?.length ? orchestration.allowed_domains.join(", ") : "",
+  };
+}
+
+function validDraftNumber(value: string, { min }: { min: number }) {
+  const parsed = Number(value.trim());
+  return Number.isFinite(parsed) && parsed >= min;
+}
+
+function buildConfigureGoalRequestBody(draft: ControlPlaneSettingsDraft, goalId?: string): ConfigureGoalRequestBody | null {
+  if (!goalId || !validDraftNumber(draft.quotaCompute, { min: 0.000001 }) || !validDraftNumber(draft.quotaWindowHours, { min: 0.000001 }) || !validDraftNumber(draft.maxChildren, { min: 0 })) {
+    return null;
+  }
+  const domains = normalizedDomainList(draft.allowedDomains);
+  return {
+    allowed_domains: domains,
+    clear_allowed_domains: domains.length === 0,
+    goal_id: goalId,
+    max_children: Number(draft.maxChildren.trim()),
+    orchestration_mode: draft.orchestrationMode,
+    quota_compute: Number(draft.quotaCompute.trim()),
+    quota_window_hours: Number(draft.quotaWindowHours.trim()),
+    self_repair_enabled: draft.selfRepairEnabled,
+    self_repair_health: draft.selfRepairHealth,
+    self_repair_waiting_projection: draft.selfRepairWaitingProjection,
+    spawn_allowed: draft.spawnAllowed,
   };
 }
 
@@ -1884,11 +1955,17 @@ function buildConfigureGoalCommand({
 }
 
 function ControlPlaneSettingsPanel({
+  applyUrl,
+  dryRunUrl,
   goal,
+  onStatusRefresh,
   queueItem,
   registry,
 }: {
+  applyUrl: string | null;
+  dryRunUrl: string | null;
   goal?: RunGoal;
+  onStatusRefresh: () => Promise<void>;
   queueItem?: QueueItem;
   registry: string;
 }) {
@@ -1925,15 +2002,30 @@ function ControlPlaneSettingsPanel({
   );
   const [draft, setDraft] = useState(currentDraft);
   const [copyState, setCopyState] = useState<CopyState>("idle");
+  const [dryRunResult, setDryRunResult] = useState<ConfigureGoalApiResponse | null>(null);
+  const [dryRunBody, setDryRunBody] = useState<ConfigureGoalRequestBody | null>(null);
+  const [applyResult, setApplyResult] = useState<ConfigureGoalApiResponse | null>(null);
+  const [dryRunError, setDryRunError] = useState<string | null>(null);
+  const [applyError, setApplyError] = useState<string | null>(null);
+  const [isDryRunning, setIsDryRunning] = useState(false);
+  const [isApplying, setIsApplying] = useState(false);
   const dirty = JSON.stringify(draft) !== JSON.stringify(currentDraft);
   const goalId = goal?.id ?? queueItem?.goal_id;
   const dryRunCommand = buildConfigureGoalCommand({ draft, execute: false, goalId, registry });
   const applyCommand = buildConfigureGoalCommand({ draft, execute: true, goalId, registry });
+  const requestBody = buildConfigureGoalRequestBody(draft, goalId);
   const canCopy = Boolean(goalId && dirty);
+  const canDryRun = Boolean(dryRunUrl && dirty && requestBody);
+  const canApply = Boolean(applyUrl && dryRunBody && dryRunResult?.ok && dryRunResult.preview_id && !applyResult?.written);
 
   useEffect(() => {
     setDraft(currentDraft);
     setCopyState("idle");
+    setDryRunResult(null);
+    setDryRunBody(null);
+    setApplyResult(null);
+    setDryRunError(null);
+    setApplyError(null);
   }, [currentDraft]);
 
   useEffect(() => {
@@ -1951,6 +2043,61 @@ function ControlPlaneSettingsPanel({
     setCopyState((await copyTextToClipboard(command)) ? "copied" : "failed");
   }
 
+  async function runDryRunCheck() {
+    if (!dryRunUrl || !requestBody) {
+      return;
+    }
+    setIsDryRunning(true);
+    setDryRunError(null);
+    setDryRunResult(null);
+    setDryRunBody(null);
+    setApplyResult(null);
+    setApplyError(null);
+    try {
+      const response = await fetch(dryRunUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(requestBody),
+      });
+      const payload = await response.json() as ConfigureGoalApiResponse;
+      if (!response.ok || !payload.ok) {
+        throw new Error(payload.error || `HTTP ${response.status}`);
+      }
+      setDryRunResult(payload);
+      setDryRunBody(requestBody);
+    } catch (error) {
+      setDryRunError(formatStatusError(error));
+    } finally {
+      setIsDryRunning(false);
+    }
+  }
+
+  async function applySettings() {
+    if (!applyUrl || !dryRunBody || !dryRunResult?.preview_id) {
+      return;
+    }
+    setIsApplying(true);
+    setApplyError(null);
+    try {
+      const response = await fetch(applyUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...dryRunBody, preview_id: dryRunResult.preview_id }),
+      });
+      const payload = await response.json() as ConfigureGoalApiResponse;
+      if (!response.ok || !payload.ok) {
+        throw new Error(payload.error || `HTTP ${response.status}`);
+      }
+      setApplyResult(payload);
+      setDryRunResult(payload);
+      await onStatusRefresh();
+    } catch (error) {
+      setApplyError(formatStatusError(error));
+    } finally {
+      setIsApplying(false);
+    }
+  }
+
   return (
     <div
       className="rounded-lg border border-slate-200 bg-slate-50 p-3 dark:border-zinc-800 dark:bg-zinc-900"
@@ -1965,6 +2112,8 @@ function ControlPlaneSettingsPanel({
           <Badge variant={selfRepairEnabled ? "success" : "neutral"}>{selfRepairEnabled ? "repair enabled" : "repair off"}</Badge>
           <Badge variant={orchestrationVariant}>{mode}</Badge>
           <Badge variant={dirty ? "warning" : "success"}>{dirty ? "dirty" : "clean"}</Badge>
+          <Badge variant={dryRunUrl ? "info" : "neutral"}>{dryRunUrl ? "local API" : "copy only"}</Badge>
+          {applyResult?.written ? <Badge variant="success">applied</Badge> : null}
         </div>
       </div>
       <div className="mt-3 grid gap-2 sm:grid-cols-2">
@@ -2090,6 +2239,14 @@ function ControlPlaneSettingsPanel({
             <RotateCcw className="h-4 w-4" />
             Reset
           </Button>
+          <Button disabled={!canDryRun || isDryRunning} onClick={() => void runDryRunCheck()} size="sm">
+            {isDryRunning ? <RefreshCw className="h-4 w-4" /> : <ShieldCheck className="h-4 w-4" />}
+            Dry-run Check
+          </Button>
+          <Button disabled={!canApply || isApplying} onClick={() => void applySettings()} size="sm" variant="primary">
+            {isApplying ? <RefreshCw className="h-4 w-4" /> : <CheckCircle2 className="h-4 w-4" />}
+            Apply registry settings
+          </Button>
           <Button disabled={!canCopy} onClick={() => void copyCommand(dryRunCommand)} size="sm">
             <Copy className="h-4 w-4" />
             Copy dry-run
@@ -2100,7 +2257,23 @@ function ControlPlaneSettingsPanel({
           </Button>
           {copyState === "copied" ? <Badge variant="success">copied</Badge> : null}
           {copyState === "failed" ? <Badge variant="danger">copy failed</Badge> : null}
+          {dryRunError ? <Badge variant="danger">{dryRunError.slice(0, 96)}</Badge> : null}
+          {applyError ? <Badge variant="danger">{applyError.slice(0, 96)}</Badge> : null}
         </div>
+        {dryRunResult?.ok ? (
+          <div
+            className="space-y-1 rounded-md border border-emerald-200 bg-emerald-50 p-3 text-xs leading-5 text-emerald-900 dark:border-emerald-900 dark:bg-emerald-950 dark:text-emerald-100 lg:col-span-2"
+            data-testid="control-plane-settings-dry-run-result"
+          >
+            <div>
+              changed={String(Boolean(dryRunResult.changed))} · written={String(Boolean(dryRunResult.written))}
+              {dryRunResult.preview_id ? ` · preview=${dryRunResult.preview_id}` : ""}
+            </div>
+            {dryRunResult.changed_fields?.length ? <div>fields={dryRunResult.changed_fields.join(", ")}</div> : null}
+            {dryRunResult.control_plane_summary ? <div>{dryRunResult.control_plane_summary}</div> : null}
+            {dryRunResult.orchestration_summary ? <div>{dryRunResult.orchestration_summary}</div> : null}
+          </div>
+        ) : null}
         <pre
           className="overflow-x-auto whitespace-pre-wrap break-words rounded-md border border-slate-200 bg-slate-950 p-3 text-xs leading-5 text-slate-50 dark:border-zinc-800 lg:col-span-2"
           data-testid="control-plane-settings-command-preview"
@@ -4790,21 +4963,25 @@ function RewardCommandDraft({
 }
 
 function RunHistoryPanel({
+  controlPlaneApplyUrl,
+  controlPlaneDryRunUrl,
   goal,
+  onStatusRefresh,
   queueItem,
   registry,
   runtimeRoot,
   rewardDryRunUrl,
   rewardAppendUrl,
-  onStatusRefresh,
 }: {
+  controlPlaneApplyUrl: string | null;
+  controlPlaneDryRunUrl: string | null;
   goal?: RunGoal;
+  onStatusRefresh: () => Promise<void>;
   queueItem?: QueueItem;
   registry: string;
   runtimeRoot: string;
   rewardDryRunUrl: string | null;
   rewardAppendUrl: string | null;
-  onStatusRefresh: () => Promise<void>;
 }) {
   const latestRuns = goal?.latest_runs ?? [];
   const authorityCoverage = buildAuthorityCoverage({ goal, run: latestRuns[0] });
@@ -4855,7 +5032,14 @@ function RunHistoryPanel({
             runtimeRoot={runtimeRoot}
           />
 
-          <ControlPlaneSettingsPanel goal={goal} queueItem={queueItem} registry={registry} />
+          <ControlPlaneSettingsPanel
+            applyUrl={controlPlaneApplyUrl}
+            dryRunUrl={controlPlaneDryRunUrl}
+            goal={goal}
+            onStatusRefresh={onStatusRefresh}
+            queueItem={queueItem}
+            registry={registry}
+          />
 
           <div className="grid gap-2 sm:grid-cols-4">
             <div className="rounded-lg border border-slate-200 p-3 dark:border-zinc-800">
@@ -5112,6 +5296,7 @@ export function DashboardPage() {
     [runHistory.goals, queue.items],
   );
   const rewardApiUrls = useMemo(() => buildRewardApiUrls(source), [source]);
+  const controlPlaneApiUrls = useMemo(() => buildControlPlaneApiUrls(source), [source]);
 
   async function loadFromUrl(url: string) {
     const trimmed = url.trim();
@@ -5512,6 +5697,8 @@ export function DashboardPage() {
                     </Select>
                   ) : null}
                   <RunHistoryPanel
+                    controlPlaneApplyUrl={controlPlaneApiUrls.applyUrl}
+                    controlPlaneDryRunUrl={controlPlaneApiUrls.dryRunUrl}
                     goal={selectedGoal}
                     onStatusRefresh={async () => {
                       if (source.kind === "url") {

--- a/examples/control-plane-configure-api-smoke.py
+++ b/examples/control-plane-configure-api-smoke.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Smoke-test local dashboard control-plane settings dry-run/apply APIs."""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+GOAL_ID = "configure-api-smoke-goal"
+
+
+def free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def request_json(method: str, url: str, payload: dict[str, Any] | None = None, *, origin: str | None = None) -> tuple[int, dict[str, Any]]:
+    data = json.dumps(payload).encode("utf-8") if payload is not None else None
+    headers = {"Content-Type": "application/json"} if payload is not None else {}
+    if origin:
+        headers["Origin"] = origin
+    request = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=5) as response:
+            return int(response.status), json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as error:
+        return int(error.code), json.loads(error.read().decode("utf-8"))
+
+
+def wait_for_health(base_url: str) -> None:
+    deadline = time.time() + 10
+    last_error: Exception | None = None
+    while time.time() < deadline:
+        try:
+            status, payload = request_json("GET", f"{base_url}/healthz")
+            if status == 200 and payload.get("ok") is True:
+                return
+        except Exception as exc:  # noqa: BLE001 - preserve startup diagnostics.
+            last_error = exc
+        time.sleep(0.1)
+    raise RuntimeError(f"server did not become healthy: {last_error}")
+
+
+def start_server(repo_root: Path, registry: Path, runtime_root: Path, port: int, *, write_enabled: bool) -> subprocess.Popen[str]:
+    command = [
+        sys.executable,
+        "-m",
+        "goal_harness.cli",
+        "--registry",
+        str(registry),
+        "--runtime-root",
+        str(runtime_root),
+        "serve-status",
+        "--port",
+        str(port),
+        "--scan-root",
+        str(repo_root),
+    ]
+    if write_enabled:
+        command.append("--enable-control-plane-write-api")
+    server = subprocess.Popen(
+        command,
+        cwd=repo_root,
+        env={**os.environ, "PYTHONPATH": str(repo_root)},
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    wait_for_health(f"http://127.0.0.1:{port}")
+    return server
+
+
+def stop_server(server: subprocess.Popen[str]) -> None:
+    server.terminate()
+    try:
+        server.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        server.kill()
+        server.wait(timeout=5)
+
+
+def write_fixture(root: Path) -> tuple[Path, Path]:
+    runtime_root = root / "runtime"
+    project = root / "project"
+    project.mkdir(parents=True)
+    (project / "STATE.md").write_text("---\nupdated_at: 2026-01-01T00:00:00+00:00\n---\n", encoding="utf-8")
+    registry = root / "registry.json"
+    registry.write_text(
+        json.dumps(
+            {
+                "runtime_root": str(runtime_root),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "repo": str(project),
+                        "state_file": "STATE.md",
+                        "domain": "configure-api-smoke",
+                        "status": "connected-read-only",
+                        "adapter": {"kind": "smoke", "status": "connected-read-only"},
+                        "quota": {"compute": 1, "window_hours": 24},
+                        "control_plane": {
+                            "self_repair": {
+                                "enabled": False,
+                                "allow_health_blocker_repair": False,
+                                "allow_waiting_projection_repair": False,
+                            }
+                        },
+                        "spawn_policy": {
+                            "mode": "default",
+                            "allowed": False,
+                            "max_children": 0,
+                            "allowed_domains": [],
+                        },
+                    }
+                ],
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return registry, runtime_root
+
+
+def goal_from_registry(registry: Path) -> dict[str, Any]:
+    return json.loads(registry.read_text(encoding="utf-8"))["goals"][0]
+
+
+def configure_payload() -> dict[str, Any]:
+    return {
+        "goal_id": GOAL_ID,
+        "quota_compute": 0.5,
+        "quota_window_hours": 12,
+        "self_repair_enabled": True,
+        "self_repair_health": True,
+        "self_repair_waiting_projection": True,
+        "orchestration_mode": "multi_subagent",
+        "spawn_allowed": True,
+        "max_children": 2,
+        "allowed_domains": ["docs", "validation"],
+        "clear_allowed_domains": False,
+    }
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    with tempfile.TemporaryDirectory(prefix="goal-harness-configure-api-smoke-") as raw_tmp:
+        registry, runtime_root = write_fixture(Path(raw_tmp))
+        disabled_port = free_port()
+        disabled_server = start_server(repo_root, registry, runtime_root, disabled_port, write_enabled=False)
+        try:
+            base_url = f"http://127.0.0.1:{disabled_port}"
+            status, dry = request_json("POST", f"{base_url}/control-plane/configure-goal/dry-run", configure_payload())
+            assert status == 200, dry
+            assert dry["changed"] is True, dry
+            assert dry["written"] is False, dry
+            assert goal_from_registry(registry)["quota"]["compute"] == 1
+            status, blocked = request_json(
+                "POST",
+                f"{base_url}/control-plane/configure-goal/apply",
+                {**configure_payload(), "preview_id": dry["preview_id"]},
+                origin="http://127.0.0.1:5173",
+            )
+            assert status == 403, blocked
+            assert blocked["written"] is False, blocked
+        finally:
+            stop_server(disabled_server)
+
+        non_loopback = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "goal_harness.cli",
+                "--format",
+                "json",
+                "--registry",
+                str(registry),
+                "--runtime-root",
+                str(runtime_root),
+                "serve-status",
+                "--host",
+                "0.0.0.0",
+                "--port",
+                str(free_port()),
+                "--enable-control-plane-write-api",
+            ],
+            cwd=repo_root,
+            env={**os.environ, "PYTHONPATH": str(repo_root)},
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        assert non_loopback.returncode == 1, non_loopback.stdout + non_loopback.stderr
+        assert "requires a loopback" in json.loads(non_loopback.stdout)["error"], non_loopback.stdout
+
+        port = free_port()
+        server = start_server(repo_root, registry, runtime_root, port, write_enabled=True)
+        try:
+            base_url = f"http://127.0.0.1:{port}"
+            status, dry = request_json("POST", f"{base_url}/control-plane/configure-goal/dry-run", configure_payload())
+            assert status == 200, dry
+            assert dry["preview_id"], dry
+            status, stale = request_json(
+                "POST",
+                f"{base_url}/control-plane/configure-goal/apply",
+                {**configure_payload(), "preview_id": "stale-preview"},
+                origin="http://127.0.0.1:5173",
+            )
+            assert status == 409, stale
+            assert stale["written"] is False, stale
+            status, forbidden = request_json(
+                "POST",
+                f"{base_url}/control-plane/configure-goal/apply",
+                {**configure_payload(), "preview_id": dry["preview_id"]},
+                origin="https://example.com",
+            )
+            assert status == 403, forbidden
+            assert forbidden["written"] is False, forbidden
+            status, applied = request_json(
+                "POST",
+                f"{base_url}/control-plane/configure-goal/apply",
+                {**configure_payload(), "preview_id": dry["preview_id"]},
+                origin="http://127.0.0.1:5173",
+            )
+            assert status == 200, applied
+            assert applied["written"] is True, applied
+            goal = goal_from_registry(registry)
+            assert goal["quota"]["compute"] == 0.5, goal
+            assert goal["quota"]["window_hours"] == 12, goal
+            assert goal["control_plane"]["self_repair"]["enabled"] is True, goal
+            assert goal["spawn_policy"]["mode"] == "multi_subagent", goal
+            assert goal["spawn_policy"]["allowed"] is True, goal
+            assert goal["spawn_policy"]["max_children"] == 2, goal
+            assert goal["spawn_policy"]["allowed_domains"] == ["docs", "validation"], goal
+        finally:
+            stop_server(server)
+
+    print("control-plane-configure-api-smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -700,6 +700,11 @@ def main(argv: list[str] | None = None) -> int:
         help="Enable POST /reward/append on loopback only so the dashboard can append human_reward overlays.",
     )
     serve_status_parser.add_argument(
+        "--enable-control-plane-write-api",
+        action="store_true",
+        help="Enable POST /control-plane/configure-goal/apply on loopback only so the dashboard can write registry settings.",
+    )
+    serve_status_parser.add_argument(
         "--global-registry",
         action="store_true",
         help="Serve the shared global registry view even when invoked from a project directory.",
@@ -1321,6 +1326,7 @@ def main(argv: list[str] | None = None) -> int:
                 port=args.port,
                 status_path=args.path,
                 enable_reward_write_api=bool(args.enable_reward_write_api),
+                enable_control_plane_write_api=bool(args.enable_control_plane_write_api),
                 verbose=bool(args.verbose),
             )
         except Exception as exc:

--- a/goal_harness/status_server.py
+++ b/goal_harness/status_server.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 
+from .configure_goal import configure_goal
 from .feedback import append_human_reward, compact_reward
 from .history import load_registry
 from .materials import read_review_material
@@ -19,6 +20,8 @@ DEFAULT_STATUS_PORT = 8765
 DEFAULT_STATUS_PATH = "/status.json"
 DEFAULT_REWARD_DRY_RUN_PATH = "/reward/dry-run"
 DEFAULT_REWARD_APPEND_PATH = "/reward/append"
+DEFAULT_CONFIGURE_GOAL_DRY_RUN_PATH = "/control-plane/configure-goal/dry-run"
+DEFAULT_CONFIGURE_GOAL_APPLY_PATH = "/control-plane/configure-goal/apply"
 DEFAULT_REVIEW_MATERIAL_PATH = "/review-material"
 
 REWARD_REQUEST_FIELDS = {
@@ -34,6 +37,20 @@ REWARD_APPEND_FIELDS = REWARD_REQUEST_FIELDS | {
     "preview_id",
     "write_active_state_summary",
 }
+CONFIGURE_GOAL_REQUEST_FIELDS = {
+    "goal_id",
+    "quota_compute",
+    "quota_window_hours",
+    "self_repair_enabled",
+    "self_repair_health",
+    "self_repair_waiting_projection",
+    "orchestration_mode",
+    "spawn_allowed",
+    "max_children",
+    "allowed_domains",
+    "clear_allowed_domains",
+}
+CONFIGURE_GOAL_APPLY_FIELDS = CONFIGURE_GOAL_REQUEST_FIELDS | {"preview_id"}
 
 
 def is_loopback_host(host: str) -> bool:
@@ -56,6 +73,18 @@ def reward_preview_id(payload: dict[str, Any]) -> str:
     return hashlib.sha256(stable.encode("utf-8")).hexdigest()[:24]
 
 
+def configure_goal_preview_id(payload: dict[str, Any]) -> str:
+    stable_payload = {
+        "goal_id": payload.get("goal_id"),
+        "changed": payload.get("changed"),
+        "changed_fields": payload.get("changed_fields"),
+        "before": payload.get("before"),
+        "after": payload.get("after"),
+    }
+    stable = json.dumps(stable_payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(stable.encode("utf-8")).hexdigest()[:24]
+
+
 class StatusHTTPServer(ThreadingHTTPServer):
     allow_reuse_address = True
 
@@ -67,6 +96,9 @@ class StatusHTTPServer(ThreadingHTTPServer):
     reward_dry_run_path: str
     reward_append_path: str
     reward_write_enabled: bool
+    configure_goal_dry_run_path: str
+    configure_goal_apply_path: str
+    control_plane_write_enabled: bool
     verbose: bool
 
 
@@ -250,6 +282,141 @@ class StatusRequestHandler(BaseHTTPRequestHandler):
 
         self._send_json(self._compact_reward_response(payload, dry_run=False, appended=True))
 
+    def _parse_configure_goal_body(self, body: dict[str, Any], *, apply: bool) -> dict[str, Any]:
+        allowed = CONFIGURE_GOAL_APPLY_FIELDS if apply else CONFIGURE_GOAL_REQUEST_FIELDS
+        unknown = sorted(set(body) - allowed)
+        if unknown:
+            raise ValueError(f"unknown configure-goal field(s): {', '.join(unknown)}")
+        goal_id = str(body.get("goal_id") or "").strip()
+        if not goal_id:
+            raise ValueError("goal_id is required")
+        allowed_domains = body.get("allowed_domains")
+        if allowed_domains is not None and not isinstance(allowed_domains, list):
+            raise ValueError("allowed_domains must be a list of strings")
+        return {
+            "goal_id": goal_id,
+            "quota_compute": body.get("quota_compute"),
+            "quota_window_hours": body.get("quota_window_hours"),
+            "self_repair_enabled": body.get("self_repair_enabled"),
+            "self_repair_health": body.get("self_repair_health"),
+            "self_repair_waiting_projection": body.get("self_repair_waiting_projection"),
+            "orchestration_mode": body.get("orchestration_mode"),
+            "spawn_allowed": body.get("spawn_allowed"),
+            "max_children": body.get("max_children"),
+            "allowed_domains": [str(item) for item in allowed_domains] if allowed_domains is not None else None,
+            "clear_allowed_domains": bool(body.get("clear_allowed_domains", False)),
+        }
+
+    def _configure_goal_payload(self, body: dict[str, Any], *, apply: bool, execute: bool) -> dict[str, Any]:
+        values = self._parse_configure_goal_body(body, apply=apply)
+        return configure_goal(
+            registry_path=self.server.registry_path,
+            goal_id=values["goal_id"],
+            quota_compute=values["quota_compute"],
+            quota_window_hours=values["quota_window_hours"],
+            self_repair_enabled=values["self_repair_enabled"],
+            self_repair_health=values["self_repair_health"],
+            self_repair_waiting_projection=values["self_repair_waiting_projection"],
+            orchestration_mode=values["orchestration_mode"],
+            spawn_allowed=values["spawn_allowed"],
+            max_children=values["max_children"],
+            allowed_domains=values["allowed_domains"],
+            clear_allowed_domains=values["clear_allowed_domains"],
+            execute=execute,
+        )
+
+    def _compact_configure_goal_response(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "ok": True,
+            "dry_run": payload.get("dry_run"),
+            "execute": payload.get("execute"),
+            "written": payload.get("written"),
+            "changed": payload.get("changed"),
+            "goal_id": payload.get("goal_id"),
+            "changed_fields": payload.get("changed_fields"),
+            "before": payload.get("before"),
+            "after": payload.get("after"),
+            "preview_id": configure_goal_preview_id(payload),
+            "control_plane_summary": payload.get("control_plane_summary"),
+            "orchestration_summary": payload.get("orchestration_summary"),
+        }
+
+    def _handle_configure_goal_dry_run(self) -> None:
+        try:
+            payload = self._configure_goal_payload(self._read_json_body(), apply=False, execute=False)
+        except Exception as exc:  # noqa: BLE001 - preserve validation diagnostics for the local UI.
+            self._send_json(
+                {
+                    "ok": False,
+                    "dry_run": True,
+                    "execute": False,
+                    "written": False,
+                    "error": str(exc),
+                },
+                status=400,
+            )
+            return
+        self._send_json(self._compact_configure_goal_response(payload))
+
+    def _handle_configure_goal_apply(self) -> None:
+        if not self.server.control_plane_write_enabled:
+            self._send_json(
+                {
+                    "ok": False,
+                    "dry_run": False,
+                    "execute": True,
+                    "written": False,
+                    "error": "control-plane write API is not enabled; restart serve-status with --enable-control-plane-write-api",
+                },
+                status=403,
+            )
+            return
+        if not is_loopback_origin(self.headers.get("Origin")):
+            self._send_json(
+                {
+                    "ok": False,
+                    "dry_run": False,
+                    "execute": True,
+                    "written": False,
+                    "error": "control-plane apply only accepts loopback browser origins",
+                },
+                status=403,
+            )
+            return
+        try:
+            body = self._read_json_body()
+            preview_id = str(body.get("preview_id") or "").strip()
+            if not preview_id:
+                raise ValueError("preview_id is required")
+            dry_run_payload = self._configure_goal_payload(body, apply=True, execute=False)
+            expected_preview = self._compact_configure_goal_response(dry_run_payload).get("preview_id")
+            if preview_id != expected_preview:
+                self._send_json(
+                    {
+                        "ok": False,
+                        "dry_run": False,
+                        "execute": True,
+                        "written": False,
+                        "error": "stale control-plane preview; run Dry-run Check again before applying",
+                    },
+                    status=409,
+                )
+                return
+            payload = self._configure_goal_payload(body, apply=True, execute=True)
+        except Exception as exc:  # noqa: BLE001 - preserve validation diagnostics for the local UI.
+            self._send_json(
+                {
+                    "ok": False,
+                    "dry_run": False,
+                    "execute": True,
+                    "written": False,
+                    "error": str(exc),
+                },
+                status=400,
+            )
+            return
+        self._send_json(self._compact_configure_goal_response(payload))
+
     def _handle_review_material(self, query: dict[str, list[str]]) -> None:
         if not is_loopback_host(str(self.server.server_address[0])):
             self._send_json(
@@ -308,8 +475,13 @@ class StatusRequestHandler(BaseHTTPRequestHandler):
                     "status_url": self.server.status_path,
                     "reward_dry_run_url": self.server.reward_dry_run_path,
                     "reward_append_url": self.server.reward_append_path if self.server.reward_write_enabled else None,
+                    "configure_goal_dry_run_url": self.server.configure_goal_dry_run_path,
+                    "configure_goal_apply_url": self.server.configure_goal_apply_path
+                    if self.server.control_plane_write_enabled
+                    else None,
                     "review_material_url": DEFAULT_REVIEW_MATERIAL_PATH,
                     "reward_write_enabled": self.server.reward_write_enabled,
+                    "control_plane_write_enabled": self.server.control_plane_write_enabled,
                     "health_url": "/healthz",
                 }
             )
@@ -354,12 +526,22 @@ class StatusRequestHandler(BaseHTTPRequestHandler):
         if path == self.server.reward_append_path:
             self._handle_reward_append()
             return
+        if path == self.server.configure_goal_dry_run_path:
+            self._handle_configure_goal_dry_run()
+            return
+        if path == self.server.configure_goal_apply_path:
+            self._handle_configure_goal_apply()
+            return
         self._send_json(
             {
                 "ok": False,
                 "error": f"unknown path: {path}",
                 "reward_dry_run_url": self.server.reward_dry_run_path,
                 "reward_append_url": self.server.reward_append_path if self.server.reward_write_enabled else None,
+                "configure_goal_dry_run_url": self.server.configure_goal_dry_run_path,
+                "configure_goal_apply_url": self.server.configure_goal_apply_path
+                if self.server.control_plane_write_enabled
+                else None,
             },
             status=404,
         )
@@ -386,11 +568,14 @@ def serve_status(
     port: int,
     status_path: str,
     enable_reward_write_api: bool,
+    enable_control_plane_write_api: bool,
     verbose: bool,
 ) -> None:
     normalized_path = normalize_status_path(status_path)
     if enable_reward_write_api and not is_loopback_host(host):
         raise ValueError("--enable-reward-write-api requires a loopback --host such as 127.0.0.1")
+    if enable_control_plane_write_api and not is_loopback_host(host):
+        raise ValueError("--enable-control-plane-write-api requires a loopback --host such as 127.0.0.1")
     server = StatusHTTPServer((host, port), StatusRequestHandler)
     server.registry_path = registry_path
     server.runtime_root_override = runtime_root_override
@@ -400,11 +585,17 @@ def serve_status(
     server.reward_dry_run_path = DEFAULT_REWARD_DRY_RUN_PATH
     server.reward_append_path = DEFAULT_REWARD_APPEND_PATH
     server.reward_write_enabled = enable_reward_write_api
+    server.configure_goal_dry_run_path = DEFAULT_CONFIGURE_GOAL_DRY_RUN_PATH
+    server.configure_goal_apply_path = DEFAULT_CONFIGURE_GOAL_APPLY_PATH
+    server.control_plane_write_enabled = enable_control_plane_write_api
     server.verbose = verbose
     print(f"Serving Goal Harness status at http://{host}:{port}{normalized_path}", flush=True)
     print(f"Reward dry-run: http://{host}:{port}{server.reward_dry_run_path}", flush=True)
     if enable_reward_write_api:
         print(f"Reward append: http://{host}:{port}{server.reward_append_path}", flush=True)
+    print(f"Control-plane settings dry-run: http://{host}:{port}{server.configure_goal_dry_run_path}", flush=True)
+    if enable_control_plane_write_api:
+        print(f"Control-plane settings apply: http://{host}:{port}{server.configure_goal_apply_path}", flush=True)
     print(f"Health check: http://{host}:{port}/healthz", flush=True)
     try:
         server.serve_forever()


### PR DESCRIPTION
## Summary
- add loopback `serve-status` endpoints for control-plane settings dry-run and explicit apply
- gate registry writes behind `--enable-control-plane-write-api`, loopback host/origin checks, and fresh preview ids
- wire the dashboard settings panel to local dry-run/apply while keeping copyable CLI commands as fallback
- add isolated API smoke coverage for disabled writes, stale previews, non-loopback rejection, and successful registry mutation

## Validation
- `python3 -m py_compile goal_harness/status_server.py goal_harness/cli.py goal_harness/configure_goal.py`
- `python3 examples/control-plane-configure-api-smoke.py`
- `python3 examples/configure-goal-smoke.py`
- `npm --prefix apps/dashboard run build`
- `npm --prefix apps/dashboard run smoke:home-browser`
- `python3 examples/run-smokes.py` (34 smoke scripts)
- `python3 -m goal_harness.cli --format json check --scan-root .`
- `git diff --check`
- staged sensitive-diff grep over touched public files