### PR TITLE
Clarify dashboard write daemon policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,19 @@ below the dashboard's expected version, run
 `~/goal-harness/scripts/macos-dashboard-launchagent.sh restart` so the dashboard
 does not read an older status contract from a stale daemon.
 
+The LaunchAgent status feed is read-only for control-plane registry writes by
+default. If an operator intentionally wants the dashboard Apply button to write
+per-goal control-plane settings, install or restart the LaunchAgent with the
+explicit opt-in flag:
+
+```bash
+~/goal-harness/scripts/macos-dashboard-launchagent.sh --enable-control-plane-write-api restart
+```
+
+The `status` command reports `control_plane_write_api: enabled|disabled`, and
+the dashboard reads the same `local_dashboard_api` capability from
+`/status.json`.
+
 For a one-command public demo-readiness check from the checkout:
 
 ```bash

--- a/apps/dashboard/src/data/status.ts
+++ b/apps/dashboard/src/data/status.ts
@@ -532,6 +532,19 @@ export const statusContractSchema = z.object({
   reload_hint: "scripts/macos-dashboard-launchagent.sh restart",
 });
 
+export const localDashboardApiSchema = z.object({
+  source: z.string().optional().default("serve-status"),
+  status_url: z.string().optional().nullable(),
+  health_url: z.string().optional().nullable(),
+  review_material_url: z.string().optional().nullable(),
+  reward_dry_run_url: z.string().optional().nullable(),
+  reward_append_url: z.string().optional().nullable(),
+  reward_write_enabled: z.boolean().optional().default(false),
+  configure_goal_dry_run_url: z.string().optional().nullable(),
+  configure_goal_apply_url: z.string().optional().nullable(),
+  control_plane_write_enabled: z.boolean().optional().default(false),
+}).optional().nullable();
+
 export const statusPayloadSchema = z.object({
   ok: z.boolean(),
   registry: z.string(),
@@ -539,6 +552,7 @@ export const statusPayloadSchema = z.object({
   goal_count: z.number(),
   run_count: z.number(),
   status_contract: statusContractSchema,
+  local_dashboard_api: localDashboardApiSchema,
   contract: z.object({
     ok: z.boolean(),
     summary: z.object({

--- a/apps/dashboard/src/views/dashboard-page.tsx
+++ b/apps/dashboard/src/views/dashboard-page.tsx
@@ -441,9 +441,31 @@ function buildRewardApiUrls(source: DataSource) {
   }
 }
 
-function buildControlPlaneApiUrls(source: DataSource) {
+function localApiUrl(source: DataSource, path: string | null | undefined) {
+  if (!path || source.kind !== "url" || !/^https?:\/\//i.test(source.label)) {
+    return null;
+  }
+  try {
+    const sourceUrl = new URL(source.label);
+    const targetUrl = new URL(path, sourceUrl.origin);
+    const isLoopback = ["127.0.0.1", "localhost", "::1", "[::1]"].includes(targetUrl.hostname);
+    return isLoopback ? targetUrl.toString() : null;
+  } catch {
+    return null;
+  }
+}
+
+function buildControlPlaneApiUrls(source: DataSource, payload?: StatusPayload) {
+  const localApi = payload?.local_dashboard_api;
+  if (localApi) {
+    return {
+      dryRunUrl: localApiUrl(source, localApi.configure_goal_dry_run_url),
+      applyUrl: localApiUrl(source, localApi.configure_goal_apply_url),
+      writeEnabled: Boolean(localApi.control_plane_write_enabled),
+    };
+  }
   if (source.kind !== "url" || !/^https?:\/\//i.test(source.label)) {
-    return { dryRunUrl: null, applyUrl: null };
+    return { dryRunUrl: null, applyUrl: null, writeEnabled: null };
   }
   try {
     const url = new URL(source.label);
@@ -452,10 +474,11 @@ function buildControlPlaneApiUrls(source: DataSource) {
       ? {
           dryRunUrl: `${url.origin}/control-plane/configure-goal/dry-run`,
           applyUrl: `${url.origin}/control-plane/configure-goal/apply`,
+          writeEnabled: null,
         }
-      : { dryRunUrl: null, applyUrl: null };
+      : { dryRunUrl: null, applyUrl: null, writeEnabled: null };
   } catch {
-    return { dryRunUrl: null, applyUrl: null };
+    return { dryRunUrl: null, applyUrl: null, writeEnabled: null };
   }
 }
 
@@ -1961,6 +1984,7 @@ function ControlPlaneSettingsPanel({
   onStatusRefresh,
   queueItem,
   registry,
+  writeEnabled,
 }: {
   applyUrl: string | null;
   dryRunUrl: string | null;
@@ -1968,6 +1992,7 @@ function ControlPlaneSettingsPanel({
   onStatusRefresh: () => Promise<void>;
   queueItem?: QueueItem;
   registry: string;
+  writeEnabled: boolean | null;
 }) {
   const quota = queueItem?.quota ?? queueItem?.project_asset?.quota ?? goal?.quota;
   const quotaView = buildQuotaView(quota);
@@ -2017,6 +2042,8 @@ function ControlPlaneSettingsPanel({
   const canCopy = Boolean(goalId && dirty);
   const canDryRun = Boolean(dryRunUrl && dirty && requestBody);
   const canApply = Boolean(applyUrl && dryRunBody && dryRunResult?.ok && dryRunResult.preview_id && !applyResult?.written);
+  const writeApiLabel = writeEnabled === true ? "write API on" : writeEnabled === false ? "write API off" : "write API unknown";
+  const writeApiVariant: BadgeVariant = writeEnabled === true ? "success" : writeEnabled === false ? "warning" : "neutral";
 
   useEffect(() => {
     setDraft(currentDraft);
@@ -2113,6 +2140,7 @@ function ControlPlaneSettingsPanel({
           <Badge variant={orchestrationVariant}>{mode}</Badge>
           <Badge variant={dirty ? "warning" : "success"}>{dirty ? "dirty" : "clean"}</Badge>
           <Badge variant={dryRunUrl ? "info" : "neutral"}>{dryRunUrl ? "local API" : "copy only"}</Badge>
+          <Badge variant={writeApiVariant}>{writeApiLabel}</Badge>
           {applyResult?.written ? <Badge variant="success">applied</Badge> : null}
         </div>
       </div>
@@ -4965,6 +4993,7 @@ function RewardCommandDraft({
 function RunHistoryPanel({
   controlPlaneApplyUrl,
   controlPlaneDryRunUrl,
+  controlPlaneWriteEnabled,
   goal,
   onStatusRefresh,
   queueItem,
@@ -4975,6 +5004,7 @@ function RunHistoryPanel({
 }: {
   controlPlaneApplyUrl: string | null;
   controlPlaneDryRunUrl: string | null;
+  controlPlaneWriteEnabled: boolean | null;
   goal?: RunGoal;
   onStatusRefresh: () => Promise<void>;
   queueItem?: QueueItem;
@@ -5039,6 +5069,7 @@ function RunHistoryPanel({
             onStatusRefresh={onStatusRefresh}
             queueItem={queueItem}
             registry={registry}
+            writeEnabled={controlPlaneWriteEnabled}
           />
 
           <div className="grid gap-2 sm:grid-cols-4">
@@ -5296,7 +5327,7 @@ export function DashboardPage() {
     [runHistory.goals, queue.items],
   );
   const rewardApiUrls = useMemo(() => buildRewardApiUrls(source), [source]);
-  const controlPlaneApiUrls = useMemo(() => buildControlPlaneApiUrls(source), [source]);
+  const controlPlaneApiUrls = useMemo(() => buildControlPlaneApiUrls(source, payload), [payload, source]);
 
   async function loadFromUrl(url: string) {
     const trimmed = url.trim();
@@ -5699,6 +5730,7 @@ export function DashboardPage() {
                   <RunHistoryPanel
                     controlPlaneApplyUrl={controlPlaneApiUrls.applyUrl}
                     controlPlaneDryRunUrl={controlPlaneApiUrls.dryRunUrl}
+                    controlPlaneWriteEnabled={controlPlaneApiUrls.writeEnabled}
                     goal={selectedGoal}
                     onStatusRefresh={async () => {
                       if (source.kind === "url") {

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -53,6 +53,35 @@ result with `appended=false`. It also returns the same coordination fields as
 the CLI: `active_state_summary` and `project_agent_visibility`. It does not
 mutate the run index and does not return private artifact paths.
 
+When status is served over loopback HTTP, `/status.json` also includes an
+optional `local_dashboard_api` capability block. CLI status exports may omit it
+because they are plain read-only snapshots. The block is the dashboard's machine
+contract for local write affordances:
+
+```json
+{
+  "local_dashboard_api": {
+    "source": "serve-status",
+    "reward_dry_run_url": "/reward/dry-run",
+    "reward_append_url": null,
+    "reward_write_enabled": false,
+    "configure_goal_dry_run_url": "/control-plane/configure-goal/dry-run",
+    "configure_goal_apply_url": null,
+    "control_plane_write_enabled": false
+  }
+}
+```
+
+The control-plane settings write path follows the same opt-in rule as reward
+append. By default `serve-status` validates dashboard setting drafts through
+`POST /control-plane/configure-goal/dry-run` but does not expose an apply
+capability. Starting the loopback server with
+`--enable-control-plane-write-api` exposes
+`POST /control-plane/configure-goal/apply`; the dashboard should enable Apply
+only when `local_dashboard_api.control_plane_write_enabled=true` and the apply
+URL is present. Apply requests must reuse the fresh `preview_id` from the
+dry-run response.
+
 ## Command
 
 ```bash

--- a/examples/control-plane-configure-api-smoke.py
+++ b/examples/control-plane-configure-api-smoke.py
@@ -162,6 +162,12 @@ def main() -> None:
         disabled_server = start_server(repo_root, registry, runtime_root, disabled_port, write_enabled=False)
         try:
             base_url = f"http://127.0.0.1:{disabled_port}"
+            status, status_payload = request_json("GET", f"{base_url}/status.json")
+            assert status == 200, status_payload
+            disabled_api = status_payload["local_dashboard_api"]
+            assert disabled_api["control_plane_write_enabled"] is False, disabled_api
+            assert disabled_api["configure_goal_dry_run_url"] == "/control-plane/configure-goal/dry-run", disabled_api
+            assert disabled_api["configure_goal_apply_url"] is None, disabled_api
             status, dry = request_json("POST", f"{base_url}/control-plane/configure-goal/dry-run", configure_payload())
             assert status == 200, dry
             assert dry["changed"] is True, dry
@@ -209,6 +215,11 @@ def main() -> None:
         server = start_server(repo_root, registry, runtime_root, port, write_enabled=True)
         try:
             base_url = f"http://127.0.0.1:{port}"
+            status, status_payload = request_json("GET", f"{base_url}/status.json")
+            assert status == 200, status_payload
+            enabled_api = status_payload["local_dashboard_api"]
+            assert enabled_api["control_plane_write_enabled"] is True, enabled_api
+            assert enabled_api["configure_goal_apply_url"] == "/control-plane/configure-goal/apply", enabled_api
             status, dry = request_json("POST", f"{base_url}/control-plane/configure-goal/dry-run", configure_payload())
             assert status == 200, dry
             assert dry["preview_id"], dry

--- a/examples/macos-dashboard-launchagent-status-smoke.py
+++ b/examples/macos-dashboard-launchagent-status-smoke.py
@@ -18,23 +18,28 @@ def write_executable(path: Path, body: str) -> None:
     path.chmod(0o755)
 
 
-def run_status(fake_bin: Path, home: Path, *, schema_version: int) -> str:
+def run_script(fake_bin: Path, home: Path, args: list[str], *, schema_version: int, write_enabled: bool = False, extra_env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
     env = {
         **os.environ,
         "HOME": str(home),
         "PATH": f"{fake_bin}:{os.environ.get('PATH', '')}",
         "FAKE_STATUS_CONTRACT_SCHEMA_VERSION": str(schema_version),
+        "FAKE_CONTROL_PLANE_WRITE_ENABLED": "true" if write_enabled else "false",
         "GOAL_HARNESS_STATUS_CONTRACT_MIN_VERSION": "2",
+        **(extra_env or {}),
     }
-    result = subprocess.run(
-        [str(LAUNCHAGENT_SCRIPT), "status"],
+    return subprocess.run(
+        [str(LAUNCHAGENT_SCRIPT), *args],
         cwd=REPO_ROOT,
         env=env,
         check=True,
         capture_output=True,
         text=True,
     )
-    return result.stdout
+
+
+def run_status(fake_bin: Path, home: Path, *, schema_version: int, write_enabled: bool = False) -> str:
+    return run_script(fake_bin, home, ["status"], schema_version=schema_version, write_enabled=write_enabled).stdout
 
 
 def main() -> int:
@@ -42,8 +47,11 @@ def main() -> int:
         tmp = Path(raw_tmp)
         fake_bin = tmp / "bin"
         home = tmp / "home"
+        dashboard_dist = tmp / "dashboard-dist"
         fake_bin.mkdir()
         home.mkdir()
+        dashboard_dist.mkdir()
+        (dashboard_dist / "index.html").write_text("<!doctype html><title>Goal Harness</title>\n", encoding="utf-8")
 
         write_executable(
             fake_bin / "uname",
@@ -55,15 +63,24 @@ def main() -> int:
             "if [[ \"$1\" == \"print\" ]]; then\n"
             "  exit 0\n"
             "fi\n"
+            "if [[ \"$1\" == \"bootout\" || \"$1\" == \"bootstrap\" || \"$1\" == \"kickstart\" ]]; then\n"
+            "  exit 0\n"
+            "fi\n"
             "echo \"unexpected launchctl args: $*\" >&2\n"
             "exit 2\n",
+        )
+        write_executable(
+            fake_bin / "goal-harness-canary",
+            "#!/usr/bin/env bash\n"
+            "echo goal-harness-canary \"$@\"\n",
         )
         write_executable(
             fake_bin / "curl",
             "#!/usr/bin/env bash\n"
             "version=\"${FAKE_STATUS_CONTRACT_SCHEMA_VERSION:-0}\"\n"
+            "write_enabled=\"${FAKE_CONTROL_PLANE_WRITE_ENABLED:-false}\"\n"
             "cat <<EOF\n"
-            "{\"ok\":true,\"status_contract\":{\"schema_version\":${version},\"producer\":\"goal-harness status\"}}\n"
+            "{\"ok\":true,\"status_contract\":{\"schema_version\":${version},\"producer\":\"goal-harness status\"},\"local_dashboard_api\":{\"control_plane_write_enabled\":${write_enabled}}}\n"
             "EOF\n",
         )
 
@@ -71,15 +88,34 @@ def main() -> int:
         assert "- com.goal-harness.status: loaded" in old_output, old_output
         assert "- com.goal-harness.dashboard: loaded" in old_output, old_output
         assert "- status_contract: schema_version=1 producer=goal-harness status expected>=2" in old_output, old_output
+        assert "- control_plane_write_api: disabled" in old_output, old_output
         assert "warning: status feed is using an old contract; run:" in old_output, old_output
         assert "macos-dashboard-launchagent.sh restart" in old_output, old_output
 
-        current_output = run_status(fake_bin, home, schema_version=2)
+        current_output = run_status(fake_bin, home, schema_version=2, write_enabled=True)
         assert "- status_contract: schema_version=2 producer=goal-harness status expected>=2" in current_output, current_output
+        assert "- control_plane_write_api: enabled" in current_output, current_output
+        assert "warning: control-plane registry writes are enabled" in current_output, current_output
         assert "warning: status feed is using an old contract" not in current_output, current_output
         assert "LaunchAgents:" in current_output, current_output
         assert "URLs:" in current_output, current_output
         assert "Logs:" in current_output, current_output
+
+        install_env = {"GOAL_HARNESS_DASHBOARD_DIST_DIR": str(dashboard_dist)}
+        run_script(fake_bin, home, ["install"], schema_version=2, extra_env=install_env)
+        status_plist = home / "Library" / "LaunchAgents" / "com.goal-harness.status.plist"
+        default_plist = status_plist.read_text(encoding="utf-8")
+        assert "--enable-control-plane-write-api" not in default_plist, default_plist
+
+        run_script(
+            fake_bin,
+            home,
+            ["--enable-control-plane-write-api", "restart"],
+            schema_version=2,
+            extra_env=install_env,
+        )
+        write_plist = status_plist.read_text(encoding="utf-8")
+        assert "--enable-control-plane-write-api" in write_plist, write_plist
 
     print("macos-dashboard-launchagent-status-smoke ok")
     return 0

--- a/goal_harness/status_server.py
+++ b/goal_harness/status_server.py
@@ -459,6 +459,22 @@ class StatusRequestHandler(BaseHTTPRequestHandler):
             return
         self._send_json(payload)
 
+    def _local_dashboard_api_payload(self) -> dict[str, Any]:
+        return {
+            "source": "serve-status",
+            "status_url": self.server.status_path,
+            "health_url": "/healthz",
+            "review_material_url": DEFAULT_REVIEW_MATERIAL_PATH,
+            "reward_dry_run_url": self.server.reward_dry_run_path,
+            "reward_append_url": self.server.reward_append_path if self.server.reward_write_enabled else None,
+            "reward_write_enabled": self.server.reward_write_enabled,
+            "configure_goal_dry_run_url": self.server.configure_goal_dry_run_path,
+            "configure_goal_apply_url": self.server.configure_goal_apply_path
+            if self.server.control_plane_write_enabled
+            else None,
+            "control_plane_write_enabled": self.server.control_plane_write_enabled,
+        }
+
     def do_GET(self) -> None:
         parsed_url = urlparse(self.path)
         path = parsed_url.path
@@ -472,17 +488,7 @@ class StatusRequestHandler(BaseHTTPRequestHandler):
             self._send_json(
                 {
                     "ok": True,
-                    "status_url": self.server.status_path,
-                    "reward_dry_run_url": self.server.reward_dry_run_path,
-                    "reward_append_url": self.server.reward_append_path if self.server.reward_write_enabled else None,
-                    "configure_goal_dry_run_url": self.server.configure_goal_dry_run_path,
-                    "configure_goal_apply_url": self.server.configure_goal_apply_path
-                    if self.server.control_plane_write_enabled
-                    else None,
-                    "review_material_url": DEFAULT_REVIEW_MATERIAL_PATH,
-                    "reward_write_enabled": self.server.reward_write_enabled,
-                    "control_plane_write_enabled": self.server.control_plane_write_enabled,
-                    "health_url": "/healthz",
+                    **self._local_dashboard_api_payload(),
                 }
             )
             return
@@ -504,6 +510,7 @@ class StatusRequestHandler(BaseHTTPRequestHandler):
                 scan_roots=self.server.scan_roots,
                 limit=self.server.limit,
             )
+            payload["local_dashboard_api"] = self._local_dashboard_api_payload()
         except Exception as exc:  # noqa: BLE001 - the HTTP layer should preserve diagnostics.
             self._send_json(
                 {

--- a/scripts/macos-dashboard-launchagent.sh
+++ b/scripts/macos-dashboard-launchagent.sh
@@ -21,14 +21,19 @@ status_label="$label_prefix.status"
 dashboard_label="$label_prefix.dashboard"
 status_plist="$launch_agents_dir/$status_label.plist"
 dashboard_plist="$launch_agents_dir/$dashboard_label.plist"
+control_plane_write_api_enabled=false
 
 usage() {
   cat <<EOF
-Usage: $0 install|uninstall|start|stop|restart|status
+Usage: $0 [--enable-control-plane-write-api] install|uninstall|start|stop|restart|status
 
 Installs user-level macOS LaunchAgents for:
   - Goal Harness global status feed: http://$host:$status_port/status.json
   - Goal Harness dashboard:          http://$host:$dashboard_port/
+
+Default mode is read-only for control-plane settings. Pass
+--enable-control-plane-write-api with install or restart to write that explicit
+opt-in flag into the status LaunchAgent plist.
 
 Environment overrides:
   GOAL_HARNESS_REPO_ROOT
@@ -99,11 +104,15 @@ check_inputs() {
 }
 
 write_plists() {
-  local status_command python_command path_prefix status_shell dashboard_shell
+  local status_command python_command path_prefix status_shell dashboard_shell control_plane_write_arg
   status_command="$(resolve_status_command)"
   python_command="$(resolve_python_command)"
   path_prefix="$bin_dir:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-  status_shell="export PATH=\"$(xml_escape "$path_prefix"):\$PATH\"; exec \"$(xml_escape "$status_command")\" --registry \"$(xml_escape "$registry")\" serve-status --global-registry --host \"$(xml_escape "$host")\" --port \"$(xml_escape "$status_port")\" --limit \"$(xml_escape "$status_limit")\""
+  control_plane_write_arg=""
+  if [[ "$control_plane_write_api_enabled" == "true" ]]; then
+    control_plane_write_arg=" --enable-control-plane-write-api"
+  fi
+  status_shell="export PATH=\"$(xml_escape "$path_prefix"):\$PATH\"; exec \"$(xml_escape "$status_command")\" --registry \"$(xml_escape "$registry")\" serve-status --global-registry --host \"$(xml_escape "$host")\" --port \"$(xml_escape "$status_port")\" --limit \"$(xml_escape "$status_limit")\"$control_plane_write_arg"
   dashboard_shell="export PATH=\"$(xml_escape "$path_prefix"):\$PATH\"; exec \"$(xml_escape "$python_command")\" -m http.server \"$(xml_escape "$dashboard_port")\" --bind \"$(xml_escape "$host")\" --directory \"$(xml_escape "$dashboard_dist_dir")\""
 
   mkdir -p "$launch_agents_dir" "$logs_dir"
@@ -189,20 +198,31 @@ stop_agents() {
 }
 
 print_status_contract_health() {
-  local status_url python_command version producer
+  local status_url python_command status_json version producer control_plane_write
   status_url="http://$host:$status_port/status.json"
   python_command="$(resolve_python_command 2>/dev/null || true)"
   if ! command -v curl >/dev/null 2>&1 || [[ -z "$python_command" ]]; then
     echo "- status_contract: unknown (curl or python3 unavailable)"
+    echo "- control_plane_write_api: unknown"
     return
   fi
-  version="$(curl -fsS "$status_url" 2>/dev/null | "$python_command" -c 'import json,sys; data=json.load(sys.stdin); contract=data.get("status_contract") or {}; print(contract.get("schema_version", 0))' 2>/dev/null || true)"
-  producer="$(curl -fsS "$status_url" 2>/dev/null | "$python_command" -c 'import json,sys; data=json.load(sys.stdin); contract=data.get("status_contract") or {}; print(contract.get("producer") or "unknown")' 2>/dev/null || true)"
-  if [[ -z "$version" ]]; then
+  status_json="$(curl -fsS "$status_url" 2>/dev/null || true)"
+  if [[ -z "$status_json" ]]; then
     echo "- status_contract: unavailable (status feed not reachable)"
+    echo "- control_plane_write_api: unknown"
     return
   fi
+  version="$("$python_command" -c 'import json,sys; data=json.load(sys.stdin); contract=data.get("status_contract") or {}; print(contract.get("schema_version", 0))' <<<"$status_json" 2>/dev/null || true)"
+  producer="$("$python_command" -c 'import json,sys; data=json.load(sys.stdin); contract=data.get("status_contract") or {}; print(contract.get("producer") or "unknown")' <<<"$status_json" 2>/dev/null || true)"
+  control_plane_write="$("$python_command" -c 'import json,sys; data=json.load(sys.stdin); api=data.get("local_dashboard_api") or {}; print("enabled" if api.get("control_plane_write_enabled") else "disabled")' <<<"$status_json" 2>/dev/null || true)"
+  version="${version:-0}"
+  producer="${producer:-unknown}"
+  control_plane_write="${control_plane_write:-unknown}"
   echo "- status_contract: schema_version=$version producer=$producer expected>=$status_contract_min_version"
+  echo "- control_plane_write_api: $control_plane_write"
+  if [[ "$control_plane_write" == "enabled" ]]; then
+    echo "  warning: control-plane registry writes are enabled for this local status feed"
+  fi
   if [[ "$version" =~ ^[0-9]+$ ]] && (( version < status_contract_min_version )); then
     echo "  warning: status feed is using an old contract; run: $0 restart"
   fi
@@ -274,4 +294,23 @@ main() {
   esac
 }
 
-main "$@"
+parsed_args=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --enable-control-plane-write-api)
+      control_plane_write_api_enabled=true
+      shift
+      ;;
+    --)
+      shift
+      parsed_args+=("$@")
+      break
+      ;;
+    *)
+      parsed_args+=("$1")
+      shift
+      ;;
+  esac
+done
+
+main "${parsed_args[@]}"


### PR DESCRIPTION
## Summary
- add local_dashboard_api capability projection to loopback status JSON for dashboard write affordances
- keep macOS LaunchAgent control-plane writes read-only by default, with explicit --enable-control-plane-write-api opt-in and status output
- have the dashboard consume the capability contract so Apply is disabled when the status daemon is read-only

## Validation
- python3 -m py_compile goal_harness/status_server.py goal_harness/cli.py
- python3 examples/macos-dashboard-launchagent-status-smoke.py
- python3 examples/control-plane-configure-api-smoke.py
- npm --prefix apps/dashboard run build
- npm --prefix apps/dashboard run smoke:home-browser
- python3 examples/dashboard-demo-readiness-smoke.py --skip-browser
- python3 examples/run-smokes.py
- python3 -m goal_harness.cli --format json check --scan-root .
- git diff --check
- staged sensitive diff grep