### PR TITLE
Expose heartbeat prompt interface budgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,10 @@ If the plan reports unknown or stale prompt digests, update those managed
 heartbeat automations/controller clients before running `scripts/install-local.sh`
 for default promotion. This keeps connected projects from continuing on stale
 prompt branches after the local default version changes.
+Each generated prompt summary also includes `interface_budget` fields
+(`mode`, `budget_char_count`, `max_chars`, and `within_budget`) so the local
+upgrade path can catch prompt bloat from the same machine contract that
+`heartbeat-prompt --format json` exposes.
 Use `--mode brief` or `--mode compact` only when an installed automation is
 intentionally using one of the larger generated contracts.
 If a registry goal has no installed heartbeat automation, record that explicitly

--- a/docs/heartbeat-automation-prompt.md
+++ b/docs/heartbeat-automation-prompt.md
@@ -104,6 +104,13 @@ project-agnostic; if a behavior needs to be remembered across workers, write it
 to active state, run history, the registry, or a generated prompt contract
 rather than hand-editing the automation body.
 
+`goal-harness heartbeat-prompt --format json` emits an `interface_budget`
+object for the selected mode. It reports the rendered prompt's `char_count`,
+`line_count`, normalized `budget_char_count`, `max_chars`, and
+`within_budget`. `upgrade-plan --format json` carries the same budget summary
+inside each generated prompt, so local default-promotion checks can flag prompt
+bloat without parsing prose or relying on a chat thread.
+
 For gray rollout, generate the brief body through `goal-harness-canary` and pass
 `--cli-bin goal-harness-canary` so only the selected goal controller uses the
 live checkout:

--- a/examples/heartbeat-prompt-smoke.py
+++ b/examples/heartbeat-prompt-smoke.py
@@ -14,7 +14,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from goal_harness.heartbeat_prompt import build_heartbeat_prompt  # noqa: E402
+from goal_harness.heartbeat_prompt import INTERFACE_BUDGET_CHARS, build_heartbeat_prompt  # noqa: E402
 
 DOC = REPO_ROOT / "docs" / "heartbeat-automation-prompt.md"
 README = REPO_ROOT / "README.md"
@@ -22,12 +22,6 @@ INTEGRATION_DOC = REPO_ROOT / "docs" / "integration.md"
 PROJECT_SKILL = REPO_ROOT / "skills" / "goal-harness-project" / "SKILL.md"
 GOAL_ID = "public-heartbeat-goal"
 ACTIVE_STATE = Path("/tmp/public-heartbeat-goal/ACTIVE_GOAL_STATE.md")
-INTERFACE_BUDGET_CHARS = {
-    "full": 10_800,
-    "compact": 4_900,
-    "brief": 2_600,
-    "thin": 950,
-}
 PROJECT_SPECIFIC_PROMPT_LEAKS = (
     "agent-harness-side-bypass",
     "agent-harness-main-control",
@@ -56,6 +50,18 @@ def assert_prompt_budget(label: str, text: str) -> None:
     )
 
 
+def assert_interface_budget_payload(label: str, payload: dict) -> None:
+    task_body = str(payload["task_body"])
+    budget = payload.get("interface_budget")
+    assert isinstance(budget, dict), (label, payload)
+    assert budget["mode"] == label, budget
+    assert budget["char_count"] == len(task_body), budget
+    assert budget["line_count"] == len(task_body.splitlines()), budget
+    assert budget["budget_char_count"] == len(prompt_budget_text(task_body)), budget
+    assert budget["max_chars"] == INTERFACE_BUDGET_CHARS[label], budget
+    assert budget["within_budget"] is True, budget
+
+
 def assert_no_project_specific_prompt_leaks(label: str, text: str) -> None:
     for phrase in PROJECT_SPECIFIC_PROMPT_LEAKS:
         assert phrase not in text, (label, phrase)
@@ -80,6 +86,10 @@ def main() -> int:
     assert_prompt_budget("compact", str(compact_payload["task_body"]))
     assert_prompt_budget("brief", str(brief_payload["task_body"]))
     assert_prompt_budget("thin", str(thin_payload["task_body"]))
+    assert_interface_budget_payload("full", payload)
+    assert_interface_budget_payload("compact", compact_payload)
+    assert_interface_budget_payload("brief", brief_payload)
+    assert_interface_budget_payload("thin", thin_payload)
     assert_no_project_specific_prompt_leaks("full", str(payload["task_body"]))
     assert_no_project_specific_prompt_leaks("compact", str(compact_payload["task_body"]))
     assert_no_project_specific_prompt_leaks("brief", str(brief_payload["task_body"]))

--- a/examples/upgrade-plan-smoke.py
+++ b/examples/upgrade-plan-smoke.py
@@ -71,6 +71,10 @@ def assert_unknown_manifest_blocks_promotion(registry_path: Path) -> dict:
     assert payload["summary"]["ready_for_default_promotion"] is False, payload
     goal = payload["managed_heartbeats"][0]
     assert goal["state_file_exists"] is True, payload
+    thin_prompt = goal["generated_prompts"]["thin"]
+    assert thin_prompt["within_interface_budget"] is True, payload
+    assert thin_prompt["interface_budget"]["mode"] == "thin", payload
+    assert thin_prompt["interface_budget_char_count"] <= thin_prompt["interface_budget_max_chars"], payload
     assert goal["installed_prompts"]["thin"]["status"] == "unknown", payload
     markdown = render_upgrade_plan_markdown(payload)
     assert "ready_for_default_promotion: `False`" in markdown, markdown

--- a/goal_harness/heartbeat_prompt.py
+++ b/goal_harness/heartbeat_prompt.py
@@ -8,6 +8,49 @@ from .project_prompt import render_cli_preflight, render_quota_guard_command, re
 
 DEFAULT_MATERIAL_QUEUE_RULE = "Do not consume the learning material queue unless the user explicitly asks."
 DEFAULT_PERMISSION_RULE = "Do not ask for permissions when the current Codex session is already trusted."
+INTERFACE_BUDGET_CHARS = {
+    "full": 10_800,
+    "compact": 4_900,
+    "brief": 2_600,
+    "thin": 950,
+}
+
+
+def heartbeat_prompt_mode(*, compact: bool = False, brief: bool = False, thin: bool = False) -> str:
+    if thin:
+        return "thin"
+    if brief:
+        return "brief"
+    if compact:
+        return "compact"
+    return "full"
+
+
+def prompt_budget_text(text: str, *, goal_id: str, active_state: str) -> str:
+    return text.replace(goal_id, "<GOAL_ID>").replace(active_state, "<ACTIVE_STATE>")
+
+
+def build_interface_budget(
+    *,
+    task_body: str,
+    goal_id: str,
+    active_state: str,
+    compact: bool = False,
+    brief: bool = False,
+    thin: bool = False,
+) -> dict[str, Any]:
+    mode = heartbeat_prompt_mode(compact=compact, brief=brief, thin=thin)
+    budget_text = prompt_budget_text(task_body, goal_id=goal_id, active_state=active_state)
+    budget_chars = len(budget_text)
+    max_chars = INTERFACE_BUDGET_CHARS[mode]
+    return {
+        "mode": mode,
+        "char_count": len(task_body),
+        "line_count": len(task_body.splitlines()),
+        "budget_char_count": budget_chars,
+        "max_chars": max_chars,
+        "within_budget": budget_chars <= max_chars,
+    }
 
 
 def build_heartbeat_prompt(
@@ -82,6 +125,14 @@ def build_heartbeat_prompt(
         "cli_preflight": cli_preflight,
         "material_queue_rule": resolved_material_rule,
         "permission_rule": resolved_permission_rule,
+        "interface_budget": build_interface_budget(
+            task_body=task_body,
+            goal_id=goal_id,
+            active_state=active_state_text,
+            compact=compact,
+            brief=brief,
+            thin=thin,
+        ),
         "task_body": task_body,
     }
 
@@ -469,6 +520,7 @@ def render_heartbeat_prompt_markdown(payload: dict[str, Any]) -> str:
         style = "compact "
     else:
         style = ""
+    interface_budget = payload.get("interface_budget") if isinstance(payload.get("interface_budget"), dict) else {}
     return f"""# Heartbeat Automation Prompt
 
 Copy this {style}task body into a Codex App heartbeat automation.
@@ -494,4 +546,5 @@ Copy this {style}task body into a Codex App heartbeat automation.
 - quota_guard_command: `{payload.get("quota_guard_command")}`
 - quota_spend_command: `{payload.get("quota_spend_command")}`
 - cli_preflight: `{payload.get("cli_preflight")}`
+- interface_budget: mode=`{interface_budget.get("mode")}` budget_chars=`{interface_budget.get("budget_char_count")}` max_chars=`{interface_budget.get("max_chars")}` within_budget=`{interface_budget.get("within_budget")}`
 """

--- a/goal_harness/upgrade.py
+++ b/goal_harness/upgrade.py
@@ -24,11 +24,16 @@ def prompt_summary(prompt: dict[str, Any], mode: str) -> dict[str, Any]:
         command = prompt.get("expanded_prompt_command")
     else:
         command = prompt.get(f"{mode}_prompt_command")
+    interface_budget = prompt.get("interface_budget") if isinstance(prompt.get("interface_budget"), dict) else {}
     return {
         "mode": mode,
         "sha256": prompt_digest(task_body),
         "char_count": len(task_body),
         "line_count": len(task_body.splitlines()),
+        "interface_budget": interface_budget,
+        "within_interface_budget": interface_budget.get("within_budget"),
+        "interface_budget_char_count": interface_budget.get("budget_char_count"),
+        "interface_budget_max_chars": interface_budget.get("max_chars"),
         "command": command,
     }
 


### PR DESCRIPTION
## Summary
- add structured interface_budget metadata to heartbeat-prompt JSON output
- carry the same prompt budget summary through upgrade-plan generated prompt summaries
- update heartbeat/upgrade smokes and docs so prompt bloat is checked by a machine contract

## Validation
- python3 -m py_compile goal_harness/heartbeat_prompt.py goal_harness/upgrade.py examples/heartbeat-prompt-smoke.py examples/upgrade-plan-smoke.py
- python3 examples/heartbeat-prompt-smoke.py
- python3 examples/upgrade-plan-smoke.py
- python3 -m goal_harness.cli --format json heartbeat-prompt --thin --goal-id public-heartbeat-goal --active-state /tmp/public-heartbeat-goal/ACTIVE_GOAL_STATE.md
- python3 examples/run-smokes.py
- python3 -m goal_harness.cli --format json check --scan-root .
- git diff --check
- staged sensitive diff grep