### PR TITLE
Expose review-packet handoff budgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,12 @@ Generate a review packet for a project agent:
 goal-harness review-packet --goal-id your-project-goal
 ```
 
+Use `--handoff-only --format json` when a controller needs to forward only the
+minimal project-agent handoff. The JSON includes `handoff_interface_budget`
+with live line/character counts and `within_budget`; status and quota guards
+publish the same max-lines/max-chars contract through
+`handoff_readiness.handoff_interface_budget`.
+
 Record an operator gate decision:
 
 ```bash

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -122,6 +122,12 @@ also carries compact `handoff_readiness` with `handoff_status` and
 `post_handoff_run_seen`. Heartbeat jobs can therefore tell whether the selected
 goal is still waiting for a target run or has already seen post-handoff work
 without parsing the full status payload.
+`handoff_readiness.handoff_interface_budget` declares the machine-readable
+budget for the minimal project-agent handoff: `mode=project_agent_handoff`,
+`max_lines=16`, and `max_chars=1800`. `goal-harness review-packet
+--handoff-only --format json` returns the same contract plus live `line_count`,
+`char_count`, and `within_budget`, so a short heartbeat can reject handoff
+bloat without carrying this rule in prompt text.
 For spend accounting, status derives `spent_slots` from compact
 `quota_slot_spent` runtime events in the current quota window. The registry
 remains the policy source for compute share and window size, not the spend

--- a/examples/review-packet-cli-smoke.py
+++ b/examples/review-packet-cli-smoke.py
@@ -18,6 +18,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from goal_harness.cli import review_packet_handoff_only_payload  # noqa: E402
+from goal_harness.handoff_budget import PROJECT_AGENT_HANDOFF_BUDGET  # noqa: E402
 from goal_harness.review_packet import build_review_packet  # noqa: E402
 
 STATUS_DATA_CONTRACT_PATH = REPO_ROOT / "docs" / "status-data-contract.md"
@@ -28,8 +29,6 @@ FOCUS_WAIT_GOAL_ID = "focus-wait-owner-blocker"
 LOCAL_ABSOLUTE_PATH_PATTERN = re.compile(
     r"(^|[\s`'\"=:(])(?:/[A-Za-z0-9._-]+(?:/[^\s`'\",)]+)+|[A-Za-z]:[\\/][^\s`'\",)]+)"
 )
-MAX_PROJECT_AGENT_HANDOFF_LINES = 16
-MAX_PROJECT_AGENT_HANDOFF_CHARS = 1800
 PROJECT_AGENT_HANDOFF_FORBIDDEN_MARKERS = (
     "【Goal Harness Review Packet】",
     "【人只需判断】",
@@ -63,8 +62,8 @@ def assert_no_local_paths(value: Any, label: str) -> None:
 
 def assert_project_agent_handoff_compact(text: str, label: str, *, goal_id: str) -> None:
     lines = text.splitlines()
-    assert len(lines) <= MAX_PROJECT_AGENT_HANDOFF_LINES, (label, len(lines), text)
-    assert len(text) <= MAX_PROJECT_AGENT_HANDOFF_CHARS, (label, len(text), text)
+    assert len(lines) <= PROJECT_AGENT_HANDOFF_BUDGET["max_lines"], (label, len(lines), text)
+    assert len(text) <= PROJECT_AGENT_HANDOFF_BUDGET["max_chars"], (label, len(text), text)
     assert text.startswith(f"目标校验：本段只适用于 goal_id=`{goal_id}`"), (label, text)
     assert "上下文规则：本段只携带最小当前指令" in text, (label, text)
     assert "不要从旧聊天或旧 packet 拼当前状态" in text, (label, text)
@@ -76,10 +75,25 @@ def assert_project_agent_handoff_compact(text: str, label: str, *, goal_id: str)
         assert marker not in text, (label, marker, text)
 
 
+def assert_handoff_interface_budget(payload: dict[str, Any], label: str, *, text_key: str = "project_agent_handoff") -> None:
+    text = str(payload.get(text_key) or "")
+    budget = payload.get("handoff_interface_budget")
+    assert isinstance(budget, dict), (label, payload)
+    assert budget["mode"] == PROJECT_AGENT_HANDOFF_BUDGET["mode"], (label, budget)
+    assert budget["max_lines"] == PROJECT_AGENT_HANDOFF_BUDGET["max_lines"], (label, budget)
+    assert budget["max_chars"] == PROJECT_AGENT_HANDOFF_BUDGET["max_chars"], (label, budget)
+    assert budget["line_count"] == len(text.splitlines()), (label, budget, text)
+    assert budget["char_count"] == len(text), (label, budget, text)
+    assert budget["within_line_budget"] is True, (label, budget)
+    assert budget["within_char_budget"] is True, (label, budget)
+    assert budget["within_budget"] is True, (label, budget)
+
+
 def assert_status_data_contract_documents_handoff_budget() -> None:
     contract = STATUS_DATA_CONTRACT_PATH.read_text(encoding="utf-8")
     compact_contract = " ".join(contract.split())
     assert "within 16 lines and 1800 characters" in compact_contract, contract
+    assert "handoff_interface_budget" in compact_contract, contract
     assert "include at most one command block" in compact_contract, contract
     assert "optional delivery contract" in compact_contract, contract
     assert "mode=expand_after_repeated_small_delivery" in compact_contract, contract
@@ -333,6 +347,7 @@ def assert_attention_queue_drives_approved_handoff_over_stale_history() -> None:
         "approved attention queue project-agent handoff",
         goal_id=GOAL_ID,
     )
+    assert_handoff_interface_budget(payload, "approved attention queue project-agent handoff")
     assert "类型：Codex" in packet, packet
     assert "来源：project_asset（owner/gate/next/stop 来自 attention_queue.project_asset）" in packet, packet
     assert "项目资产来源：project_asset（owner/gate/next/stop 来自 attention_queue.project_asset）" in packet, packet
@@ -495,7 +510,9 @@ def assert_connected_delivery_surface_loop_requires_macro_evidence() -> None:
         "connected-delivery macro evidence handoff",
         goal_id=goal_id,
     )
+    assert_handoff_interface_budget(payload, "connected-delivery macro evidence handoff")
     handoff_only = review_packet_handoff_only_payload(payload)
+    assert_handoff_interface_budget(handoff_only, "connected-delivery handoff-only payload")
     agent_contract = handoff_only["handoff_delivery_contract"]
     assert set(agent_contract) == {"mode", "instruction", "minimum_scale", "must_include", "if_blocked"}, handoff_only
     assert agent_contract["mode"] == "expand_after_surface_progress_loop", handoff_only
@@ -836,6 +853,7 @@ def main() -> int:
             "controller project-agent handoff",
             goal_id=GOAL_ID,
         )
+        assert_handoff_interface_budget(payload, "controller project-agent handoff")
         assert payload["user_todo_text"] == "Read owner review worksheet first.", payload
         assert payload["agent_todo_text"] == "Run the read-only map dry-run after owner todo resolution.", payload
         assert payload["authority_summary"] == "authority/material: topics=2, materials=4, repositories=2, owner_review_required=1, stale=1, current_authority=1, risk=low", payload
@@ -866,6 +884,11 @@ def main() -> int:
             controller_handoff_payload["handoff_text"],
             "controller handoff-only json",
             goal_id=GOAL_ID,
+        )
+        assert_handoff_interface_budget(
+            controller_handoff_payload,
+            "controller handoff-only json",
+            text_key="handoff_text",
         )
 
         append_operator_gate_approval_fixture(root)
@@ -960,6 +983,7 @@ def main() -> int:
             "approved project-agent handoff",
             goal_id=GOAL_ID,
         )
+        assert_handoff_interface_budget(approved_payload, "approved project-agent handoff")
         assert approved_payload["operator_gate_dry_run_command"] is None, approved_payload
         assert approved_payload["operator_gate_decision_commands"] == {}, approved_payload
 
@@ -996,6 +1020,7 @@ def main() -> int:
             "handoff-only json",
             goal_id=GOAL_ID,
         )
+        assert_handoff_interface_budget(handoff_payload, "handoff-only json", text_key="handoff_text")
 
         after_files = sorted(path.name for path in run_dir.iterdir())
         assert after_files == before_files, "approved review-packet must not write runtime runs"

--- a/examples/status-markdown-smoke.py
+++ b/examples/status-markdown-smoke.py
@@ -27,6 +27,7 @@ from goal_harness.status import (  # noqa: E402
     render_status_markdown,
 )
 from goal_harness.quota import build_quota_should_run, render_quota_should_run_markdown  # noqa: E402
+from goal_harness.handoff_budget import PROJECT_AGENT_HANDOFF_BUDGET  # noqa: E402
 
 
 OLD_PLANNED_ACTION = "先审阅 Goal Harness operator gate；同意后再发送项目 agent 命令"
@@ -54,6 +55,14 @@ DEPENDENCY_CURRENT_GOAL_ID = "meta-hardening-fixture"
 DEPENDENCY_BLOCKER_GOAL_ID = "dependency-owner-gate"
 DEPENDENCY_AGENT_TODO = "Continue the gate-independent P1/P2 product-hardening slice."
 DEPENDENCY_USER_TODO = "Confirm the sibling project evidence gate before its controller resumes delivery."
+
+
+def assert_handoff_budget_contract(readiness: dict, label: str) -> None:
+    budget = readiness.get("handoff_interface_budget")
+    assert isinstance(budget, dict), (label, readiness)
+    assert budget["mode"] == PROJECT_AGENT_HANDOFF_BUDGET["mode"], (label, budget)
+    assert budget["max_lines"] == PROJECT_AGENT_HANDOFF_BUDGET["max_lines"], (label, budget)
+    assert budget["max_chars"] == PROJECT_AGENT_HANDOFF_BUDGET["max_chars"], (label, budget)
 
 
 def write_planned_registry(root: Path) -> Path:
@@ -1379,7 +1388,9 @@ def assert_connected_delivery_custom_run_stays_runnable(payload: dict, markdown:
     assert readiness["post_handoff_recent_runs"][0]["delivery_outcome"] == "outcome_progress", readiness
     assert readiness["post_handoff_small_scale_streak"] == 0, readiness
     assert readiness["post_handoff_outcome_gap_streak"] == 0, readiness
+    assert_handoff_budget_contract(readiness, "connected delivery status readiness")
     assert "delivery_ranker_readiness_batch" in markdown, markdown
+    assert "handoff_interface_budget: mode=project_agent_handoff max_lines=16 max_chars=1800" in markdown, markdown
     assert "handoff_state: status=post_handoff_run_seen post_handoff_run_seen=True ready_at=" in markdown, markdown
     assert "post_handoff_run: classification=delivery_ranker_readiness_batch" in markdown, markdown
     assert "scale=multi_surface" in markdown, markdown
@@ -1414,8 +1425,10 @@ def assert_connected_delivery_custom_run_stays_runnable(payload: dict, markdown:
     ), quota_payload
     assert quota_payload["handoff_readiness"]["post_handoff_small_scale_streak"] == 0, quota_payload
     assert quota_payload["handoff_readiness"]["post_handoff_outcome_gap_streak"] == 0, quota_payload
+    assert_handoff_budget_contract(quota_payload["handoff_readiness"], "connected delivery quota readiness")
     assert quota_payload["heartbeat_recommendation"]["recommended_mode"] == "steering_audit_then_one_step", quota_payload
     quota_markdown = render_quota_should_run_markdown(quota_payload)
+    assert "- handoff_interface_budget: mode=project_agent_handoff max_lines=16 max_chars=1800" in quota_markdown, quota_markdown
     assert "execution_profile: cadence=bounded_progress_segment minimum=implementation" in quota_markdown, quota_markdown
     assert "goal_boundary_orchestration: mode=multi_subagent spawn_allowed=True max_children=2" in quota_markdown, quota_markdown
 

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -115,6 +115,7 @@ def review_packet_handoff_only_payload(payload: dict[str, object]) -> dict[str, 
             "operator_gate_approved_handoff": payload.get("operator_gate_approved_handoff"),
             "connected_delivery_handoff": payload.get("connected_delivery_handoff"),
             "handoff_delivery_contract": agent_contract,
+            "handoff_interface_budget": payload.get("handoff_interface_budget"),
         }
     )
     return result

--- a/goal_harness/handoff_budget.py
+++ b/goal_harness/handoff_budget.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+PROJECT_AGENT_HANDOFF_BUDGET = {
+    "mode": "project_agent_handoff",
+    "max_lines": 16,
+    "max_chars": 1_800,
+}
+
+
+def handoff_budget_contract() -> dict[str, Any]:
+    return dict(PROJECT_AGENT_HANDOFF_BUDGET)
+
+
+def build_handoff_interface_budget(handoff_text: str) -> dict[str, Any]:
+    budget = handoff_budget_contract()
+    line_count = len(handoff_text.splitlines())
+    char_count = len(handoff_text)
+    return {
+        **budget,
+        "line_count": line_count,
+        "char_count": char_count,
+        "within_line_budget": line_count <= int(budget["max_lines"]),
+        "within_char_budget": char_count <= int(budget["max_chars"]),
+        "within_budget": line_count <= int(budget["max_lines"]) and char_count <= int(budget["max_chars"]),
+    }

--- a/goal_harness/quota.py
+++ b/goal_harness/quota.py
@@ -57,6 +57,7 @@ HANDOFF_READINESS_COMPACT_FIELDS = (
     "post_handoff_small_scale_streak",
     "post_handoff_outcome_gap_streak",
     "next_probe",
+    "handoff_interface_budget",
 )
 POST_HANDOFF_RUN_COMPACT_FIELDS = (
     "generated_at",
@@ -1820,6 +1821,18 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
             f"source={handoff_readiness.get('source')} "
             f"quota_state={handoff_readiness.get('quota_state')}"
         )
+        interface_budget = (
+            handoff_readiness.get("handoff_interface_budget")
+            if isinstance(handoff_readiness.get("handoff_interface_budget"), dict)
+            else {}
+        )
+        if interface_budget:
+            lines.append(
+                "- handoff_interface_budget: "
+                f"mode={interface_budget.get('mode')} "
+                f"max_lines={interface_budget.get('max_lines')} "
+                f"max_chars={interface_budget.get('max_chars')}"
+            )
         lines.append(
             "- handoff_state: "
             f"status={handoff_readiness.get('handoff_status')} "

--- a/goal_harness/review_packet.py
+++ b/goal_harness/review_packet.py
@@ -10,6 +10,7 @@ from .execution_profile import (
     execution_profile_threshold,
     outcome_floor_threshold,
 )
+from .handoff_budget import build_handoff_interface_budget
 
 
 LOCAL_ABSOLUTE_PATH_PATTERN = re.compile(
@@ -748,6 +749,7 @@ def build_review_packet(
         approved_operator_gate=approved_handoff,
         connected_delivery=delivery_handoff,
     )
+    handoff_interface_budget = build_handoff_interface_budget(agent_text)
     type_label = {
         "reward": "Reward",
         "controller": "Controller",
@@ -814,6 +816,7 @@ def build_review_packet(
         "authority_summary": authority_summary,
         "handoff_followthrough_summary": followthrough_summary,
         "handoff_delivery_contract": delivery_contract,
+        "handoff_interface_budget": handoff_interface_budget,
         "decision_freshness_warning": freshness_warning,
         "project_asset_source": asset_source,
         "packet": "\n".join(line for line in lines if line),

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -19,6 +19,7 @@ from .execution_profile import (
     execution_profile_outcome_floor,
     execution_profile_summary,
 )
+from .handoff_budget import handoff_budget_contract
 from .history import collect_history, load_registry
 from .materials import extract_review_materials
 from .operator_gate import DEFAULT_OPERATOR_GATE, default_operator_question, normalize_operator_question
@@ -836,6 +837,7 @@ def project_asset_handoff_readiness(
         "codex_ready": codex_ready,
         "source": "project_asset",
         "quota_state": quota_state or "unknown",
+        "handoff_interface_budget": handoff_budget_contract(),
         "checks": checks,
     }
     readiness.update(
@@ -2736,6 +2738,18 @@ def render_status_markdown(payload: dict[str, Any]) -> str:
                     f"source={_markdown_scalar(handoff_readiness.get('source') or '')} "
                     f"quota_state={_markdown_scalar(handoff_readiness.get('quota_state') or '')}"
                 )
+                interface_budget = (
+                    handoff_readiness.get("handoff_interface_budget")
+                    if isinstance(handoff_readiness.get("handoff_interface_budget"), dict)
+                    else {}
+                )
+                if interface_budget:
+                    lines.append(
+                        "      - handoff_interface_budget: "
+                        f"mode={_markdown_scalar(interface_budget.get('mode') or '')} "
+                        f"max_lines={interface_budget.get('max_lines')} "
+                        f"max_chars={interface_budget.get('max_chars')}"
+                    )
                 checks = (
                     handoff_readiness.get("checks")
                     if isinstance(handoff_readiness.get("checks"), dict)


### PR DESCRIPTION
## Summary
- add a shared project-agent handoff budget contract for the 16-line / 1800-character handoff boundary
- expose handoff budget limits through status and quota handoff readiness
- include live handoff line/character counts and within-budget status in review-packet and handoff-only JSON

## Validation
- python3 -m py_compile goal_harness/handoff_budget.py goal_harness/review_packet.py goal_harness/status.py goal_harness/quota.py goal_harness/cli.py examples/review-packet-cli-smoke.py examples/status-markdown-smoke.py
- python3 examples/review-packet-cli-smoke.py
- python3 examples/status-markdown-smoke.py
- python3 examples/run-smokes.py
- python3 -m goal_harness.cli --format json check --scan-root .
- git diff --check
- staged sensitive diff grep for local paths / credential-shaped strings