### PR TITLE
Respect stage-deferred heartbeats in upgrade plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,11 @@ If the plan reports unknown or stale prompt digests, update those managed
 heartbeat automations/controller clients before running `scripts/install-local.sh`
 for default promotion. This keeps connected projects from continuing on stale
 prompt branches after the local default version changes.
+Goals whose adapter stage is still `planned` or whose registry attention status
+is `stage_deferred_not_installed` are reported separately under
+`stage_deferred_heartbeats`; they do not count as unknown/stale managed
+heartbeats and should not be installed until the operator explicitly authorizes
+that project stage.
 Each generated prompt summary also includes `interface_budget` fields
 (`mode`, `budget_char_count`, `max_chars`, and `within_budget`) so the local
 upgrade path can catch prompt bloat from the same machine contract that

--- a/examples/upgrade-plan-smoke.py
+++ b/examples/upgrade-plan-smoke.py
@@ -17,6 +17,7 @@ from goal_harness.upgrade import build_upgrade_plan, render_upgrade_plan_markdow
 
 
 GOAL_ID = "upgrade-plan-goal"
+DEFERRED_GOAL_ID = "planned-main-control"
 
 
 def write_fixture(root: Path) -> tuple[Path, Path]:
@@ -50,6 +51,17 @@ def write_fixture(root: Path) -> tuple[Path, Path]:
                         "state_file": f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md",
                         "adapter": {"kind": "generic_project_goal_v0", "status": "connected"},
                         "quota": {"compute": 1.0, "window_hours": 24},
+                    },
+                    {
+                        "id": DEFERRED_GOAL_ID,
+                        "domain": "fixture",
+                        "status": "planned-high-complexity",
+                        "attention_status": "stage_deferred_not_installed",
+                        "recommended_action": "Do not install this heartbeat until the operator authorizes the stage.",
+                        "repo": str(project),
+                        "state_file": f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md",
+                        "adapter": {"kind": "planned_read_only_map_v0", "status": "planned"},
+                        "quota": {"compute": 1.0, "window_hours": 24},
                     }
                 ],
             },
@@ -67,9 +79,15 @@ def assert_unknown_manifest_blocks_promotion(registry_path: Path) -> dict:
     assert payload["ok"] is True, payload
     assert payload["prompt_modes"] == ["thin"], payload
     assert payload["summary"]["managed_goal_count"] == 1, payload
+    assert payload["summary"]["stage_deferred_goal_count"] == 1, payload
     assert payload["summary"]["unknown_prompt_count"] == 1, payload
     assert payload["summary"]["ready_for_default_promotion"] is False, payload
+    deferred = payload["stage_deferred_heartbeats"][0]
+    assert deferred["goal_id"] == DEFERRED_GOAL_ID, payload
+    assert deferred["requires_update"] is False, payload
+    assert deferred["attention_status"] == "stage_deferred_not_installed", payload
     goal = payload["managed_heartbeats"][0]
+    assert goal["goal_id"] == GOAL_ID, payload
     assert goal["state_file_exists"] is True, payload
     thin_prompt = goal["generated_prompts"]["thin"]
     assert thin_prompt["within_interface_budget"] is True, payload
@@ -78,6 +96,9 @@ def assert_unknown_manifest_blocks_promotion(registry_path: Path) -> dict:
     assert goal["installed_prompts"]["thin"]["status"] == "unknown", payload
     markdown = render_upgrade_plan_markdown(payload)
     assert "ready_for_default_promotion: `False`" in markdown, markdown
+    assert "stage_deferred_goal_count: `1`" in markdown, markdown
+    assert "## Stage Deferred Heartbeats" in markdown, markdown
+    assert DEFERRED_GOAL_ID in markdown, markdown
     return payload
 
 
@@ -111,6 +132,7 @@ def assert_matching_manifest_is_ready(registry_path: Path, manifest_path: Path, 
     assert payload["summary"]["stale_prompt_count"] == 0, payload
     assert payload["summary"]["current_prompt_count"] == 1, payload
     assert payload["summary"]["not_installed_prompt_count"] == 0, payload
+    assert payload["summary"]["stage_deferred_goal_count"] == 1, payload
     assert payload["summary"]["ready_for_default_promotion"] is True, payload
     assert payload["managed_heartbeats"][0]["installed_prompts"]["thin"]["status"] == "current", payload
 
@@ -143,6 +165,7 @@ def assert_not_installed_manifest_is_ready(registry_path: Path, manifest_path: P
     assert payload["summary"]["stale_prompt_count"] == 0, payload
     assert payload["summary"]["current_prompt_count"] == 0, payload
     assert payload["summary"]["not_installed_prompt_count"] == 1, payload
+    assert payload["summary"]["stage_deferred_goal_count"] == 1, payload
     assert payload["summary"]["ready_for_default_promotion"] is True, payload
     installed = payload["managed_heartbeats"][0]["installed_prompts"]["thin"]
     assert payload["managed_heartbeats"][0]["requires_update"] is False, payload
@@ -151,12 +174,29 @@ def assert_not_installed_manifest_is_ready(registry_path: Path, manifest_path: P
     assert installed["installed"] is False, payload
 
 
+def assert_stage_deferred_selection_is_not_upgrade_work(registry_path: Path) -> None:
+    payload = build_upgrade_plan(
+        registry_path=registry_path,
+        cli_bin="goal-harness",
+        goal_ids=[DEFERRED_GOAL_ID],
+    )
+    assert payload["summary"]["managed_goal_count"] == 0, payload
+    assert payload["summary"]["unknown_prompt_count"] == 0, payload
+    assert payload["summary"]["stale_prompt_count"] == 0, payload
+    assert payload["summary"]["stage_deferred_goal_count"] == 1, payload
+    assert payload["managed_heartbeats"] == [], payload
+    assert payload["stage_deferred_heartbeats"][0]["goal_id"] == DEFERRED_GOAL_ID, payload
+    assert payload["stage_deferred_heartbeats"][0]["requires_update"] is False, payload
+    assert "stage-deferred" in payload["recommended_action"], payload
+
+
 def main() -> int:
     with tempfile.TemporaryDirectory(prefix="goal-harness-upgrade-plan-smoke-") as raw_tmp:
         registry_path, manifest_path = write_fixture(Path(raw_tmp))
         first_payload = assert_unknown_manifest_blocks_promotion(registry_path)
         assert_matching_manifest_is_ready(registry_path, manifest_path, first_payload)
         assert_not_installed_manifest_is_ready(registry_path, manifest_path)
+        assert_stage_deferred_selection_is_not_upgrade_work(registry_path)
     print("upgrade-plan-smoke ok")
     return 0
 

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -885,6 +885,7 @@ def main(argv: list[str] | None = None) -> int:
                     "stale_prompt_count": 0,
                     "unknown_prompt_count": 0,
                     "not_installed_prompt_count": 0,
+                    "stage_deferred_goal_count": 0,
                     "ready_for_default_promotion": False,
                 },
                 "recommended_action": "fix upgrade-plan collection before default promotion",

--- a/goal_harness/upgrade.py
+++ b/goal_harness/upgrade.py
@@ -12,6 +12,12 @@ from .registry import registry_goals, resolve_state_file
 
 
 DEFAULT_UPGRADE_MODES = ("thin",)
+STAGE_DEFERRED_ATTENTION_STATUSES = {
+    "stage_deferred_not_installed",
+}
+STAGE_DEFERRED_ADAPTER_STATUSES = {
+    "planned",
+}
 
 
 def prompt_digest(text: str) -> str:
@@ -101,6 +107,45 @@ def index_installed_entries(entries: list[dict[str, Any]]) -> dict[tuple[str, st
     return indexed
 
 
+def goal_adapter(goal: dict[str, Any]) -> dict[str, Any]:
+    adapter = goal.get("adapter")
+    return adapter if isinstance(adapter, dict) else {}
+
+
+def goal_adapter_status(goal: dict[str, Any]) -> str:
+    return str(goal_adapter(goal).get("status") or "")
+
+
+def goal_adapter_kind(goal: dict[str, Any]) -> str | None:
+    kind = goal_adapter(goal).get("kind")
+    return str(kind) if kind else None
+
+
+def goal_is_stage_deferred(goal: dict[str, Any]) -> bool:
+    attention_status = str(goal.get("attention_status") or "").replace("-", "_").lower()
+    if attention_status in STAGE_DEFERRED_ATTENTION_STATUSES:
+        return True
+    adapter_status = goal_adapter_status(goal).replace("-", "_").lower()
+    return adapter_status in STAGE_DEFERRED_ADAPTER_STATUSES
+
+
+def stage_deferred_goal_summary(goal: dict[str, Any], state_file: Path | None) -> dict[str, Any]:
+    return {
+        "goal_id": str(goal.get("id") or ""),
+        "adapter_kind": goal_adapter_kind(goal),
+        "adapter_status": goal_adapter_status(goal) or None,
+        "status": goal.get("status"),
+        "attention_status": goal.get("attention_status"),
+        "repo": str(Path(str(goal.get("repo") or ".")).expanduser()),
+        "state_file": str(state_file) if state_file else None,
+        "state_file_exists": bool(state_file and state_file.exists()),
+        "requires_update": False,
+        "deferred_reason": "stage_deferred_until_operator_authorizes_heartbeat",
+        "recommended_action": goal.get("recommended_action")
+        or "do not install or update this heartbeat until the operator authorizes the stage",
+    }
+
+
 def build_upgrade_plan(
     *,
     registry_path: Path,
@@ -124,6 +169,7 @@ def build_upgrade_plan(
     manifest = load_installed_manifest(installed_manifest)
     installed_by_key = index_installed_entries(manifest["entries"])
     managed: list[dict[str, Any]] = []
+    deferred: list[dict[str, Any]] = []
 
     for goal in registry_goals(registry):
         goal_id = str(goal.get("id") or "")
@@ -131,6 +177,9 @@ def build_upgrade_plan(
             continue
         repo = Path(str(goal.get("repo") or ".")).expanduser()
         state_file = resolve_state_file(repo, goal.get("state_file"))
+        if goal_is_stage_deferred(goal):
+            deferred.append(stage_deferred_goal_summary(goal, state_file))
+            continue
         prompt_summaries: dict[str, dict[str, Any]] = {}
         installed: dict[str, dict[str, Any]] = {}
         for mode in selected_modes:
@@ -167,8 +216,8 @@ def build_upgrade_plan(
         managed.append(
             {
                 "goal_id": goal_id,
-                "adapter_kind": (goal.get("adapter") or {}).get("kind") if isinstance(goal.get("adapter"), dict) else None,
-                "adapter_status": (goal.get("adapter") or {}).get("status") if isinstance(goal.get("adapter"), dict) else None,
+                "adapter_kind": goal_adapter_kind(goal),
+                "adapter_status": goal_adapter_status(goal) or None,
                 "repo": str(repo),
                 "state_file": str(state_file) if state_file else None,
                 "state_file_exists": bool(state_file and state_file.exists()),
@@ -203,6 +252,14 @@ def build_upgrade_plan(
         if installed["status"] == "not_installed"
     )
     ready = bool(managed) and unknown == 0 and stale == 0
+    if ready:
+        recommended_action = "promotion propagation is complete"
+    elif managed:
+        recommended_action = "refresh installed heartbeat automations/controller clients before default promotion"
+    elif deferred:
+        recommended_action = "selected heartbeats are stage-deferred; do not install until the operator authorizes that stage"
+    else:
+        recommended_action = "no registry-managed heartbeats matched the upgrade plan selection"
     return {
         "ok": True,
         "mode": "upgrade-plan",
@@ -217,12 +274,12 @@ def build_upgrade_plan(
             "stale_prompt_count": stale,
             "unknown_prompt_count": unknown,
             "not_installed_prompt_count": not_installed,
+            "stage_deferred_goal_count": len(deferred),
             "ready_for_default_promotion": ready,
         },
         "managed_heartbeats": managed,
-        "recommended_action": "promotion propagation is complete"
-        if ready
-        else "refresh installed heartbeat automations/controller clients before default promotion",
+        "stage_deferred_heartbeats": deferred,
+        "recommended_action": recommended_action,
     }
 
 
@@ -242,6 +299,7 @@ def render_upgrade_plan_markdown(payload: dict[str, Any]) -> str:
         f"- stale_prompt_count: `{summary.get('stale_prompt_count')}`",
         f"- unknown_prompt_count: `{summary.get('unknown_prompt_count')}`",
         f"- not_installed_prompt_count: `{summary.get('not_installed_prompt_count')}`",
+        f"- stage_deferred_goal_count: `{summary.get('stage_deferred_goal_count')}`",
         f"- recommended_action: `{payload.get('recommended_action')}`",
     ]
     manifest = payload.get("installed_manifest") if isinstance(payload.get("installed_manifest"), dict) else {}
@@ -276,4 +334,14 @@ def render_upgrade_plan_markdown(payload: dict[str, Any]) -> str:
                 f"  prompts: `{'; '.join(prompt_parts)}`",
             ]
         )
+    deferred = payload.get("stage_deferred_heartbeats") or []
+    if deferred:
+        lines.extend(["", "## Stage Deferred Heartbeats", ""])
+        for goal in deferred:
+            if not isinstance(goal, dict):
+                continue
+            lines.append(
+                f"- `{goal.get('goal_id')}` adapter=`{goal.get('adapter_kind')}:{goal.get('adapter_status')}` "
+                f"attention_status=`{goal.get('attention_status')}` requires_update=`{goal.get('requires_update')}`"
+            )
     return "\n".join(lines) + "\n"


### PR DESCRIPTION
## Summary
- keep planned / stage-deferred goals out of managed heartbeat upgrade pressure
- expose them separately as stage_deferred_heartbeats with requires_update=false
- document the boundary and add upgrade-plan smoke coverage

## Validation
- python3 -m py_compile goal_harness/upgrade.py goal_harness/cli.py examples/upgrade-plan-smoke.py
- python3 examples/upgrade-plan-smoke.py
- goal-harness-canary --format json --registry "/Users/bytedance/.codex/goal-harness/registry.global.json" upgrade-plan --mode thin --goal-id agent-harness-main-control
- goal-harness-canary --format json --registry "/Users/bytedance/.codex/goal-harness/registry.global.json" upgrade-plan --mode thin --goal-id premium-ui-ai-search-rec-migration
- goal-harness-canary --format json --registry "/Users/bytedance/.codex/goal-harness/registry.global.json" upgrade-plan --mode thin
- git diff --check
- goal-harness-canary --format json check --scan-root .

## Boundary
- staged diff sensitive scan found no credential-like strings or local private paths