### PR TITLE
Expose first open todo in quota summaries

### DIFF
--- a/examples/todo-first-open-summary-smoke.py
+++ b/examples/todo-first-open-summary-smoke.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Smoke-test first-open todo summaries when visible todo items are truncated."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from goal_harness.quota import build_quota_should_run, render_quota_should_run_markdown  # noqa: E402
+from goal_harness.status import (  # noqa: E402
+    compact_todo_group,
+    parse_active_state_todos,
+    project_asset_todo_summary,
+)
+
+
+GOAL_ID = "todo-first-open-summary-goal"
+OPEN_TODO = (
+    "[P1] Keep heartbeat prompt and agent-to-CLI interaction lean as an ongoing "
+    "interface-budget task."
+)
+
+
+def build_truncated_todo_group() -> dict:
+    items = [
+        {"index": index, "done": True, "text": f"Completed item {index}"}
+        for index in range(1, 14)
+    ]
+    items.append({"index": 14, "done": False, "text": OPEN_TODO})
+    group = compact_todo_group(items, source_section="Agent Todo")
+    assert group is not None, group
+    assert len(group["items"]) == 12, group
+    assert all(item["done"] for item in group["items"]), group
+    assert group["open_count"] == 1, group
+    assert group["first_open_items"][0]["index"] == 14, group
+    assert group["first_open_items"][0]["text"] == OPEN_TODO, group
+    return group
+
+
+def parse_multiline_deep_open_todo() -> dict:
+    done_lines = "\n".join(
+        f"- [x] Completed item {index}"
+        for index in range(1, 14)
+    )
+    state_text = (
+        "## Agent Todo\n\n"
+        f"{done_lines}\n"
+        "- [ ] [P1] Keep heartbeat prompt and agent-to-CLI interaction lean as an\n"
+        "  ongoing interface-budget task.\n"
+    )
+    group = parse_active_state_todos(state_text)["agent_todos"]
+    assert len(group["items"]) == 12, group
+    assert group["open_count"] == 1, group
+    assert group["first_open_items"][0]["index"] == 14, group
+    assert group["first_open_items"][0]["text"] == OPEN_TODO, group
+    return group
+
+
+def main() -> int:
+    agent_todos = build_truncated_todo_group()
+    parsed_agent_todos = parse_multiline_deep_open_todo()
+    assert parsed_agent_todos["first_open_items"] == agent_todos["first_open_items"], parsed_agent_todos
+    asset_summary = project_asset_todo_summary(agent_todos)
+    assert asset_summary is not None, agent_todos
+    assert asset_summary["open"] == 1, asset_summary
+    assert asset_summary["next"] == OPEN_TODO, asset_summary
+    assert asset_summary["next_index"] == 14, asset_summary
+
+    attention_item = {
+        "goal_id": GOAL_ID,
+        "status": "eligible_with_deep_agent_todo",
+        "waiting_on": "codex",
+        "severity": "action",
+        "source": "latest_run",
+        "recommended_action": "Use the first open agent todo as the next bounded step.",
+        "quota": {
+            "compute": 1.0,
+            "slot_minutes": 1,
+            "allowed_slots": 1440,
+            "spent_slots": 0,
+            "state": "eligible",
+            "reason": "eligible fixture",
+        },
+        "project_asset": {
+            "owner": "codex",
+            "next_action": "Use the first open agent todo as the next bounded step.",
+            "stop_condition": "stop on fixture boundary",
+            "agent_todos": asset_summary,
+            "quota": {
+                "compute": 1.0,
+                "slot_minutes": 1,
+                "allowed_slots": 1440,
+                "spent_slots": 0,
+                "state": "eligible",
+                "reason": "eligible fixture",
+            },
+        },
+        "agent_todos": agent_todos,
+    }
+    status_payload = {
+        "ok": True,
+        "attention_queue": {"items": [attention_item]},
+        "run_history": {
+            "goals": [
+                {
+                    "id": GOAL_ID,
+                    "registry_member": True,
+                    "status": "active",
+                    "quota": {"compute": 1.0, "window_hours": 24},
+                    "latest_runs": [],
+                }
+            ]
+        },
+    }
+    decision = build_quota_should_run(status_payload, goal_id=GOAL_ID)
+    assert decision["should_run"] is True, decision
+    agent_summary = decision["agent_todo_summary"]
+    assert agent_summary["open_count"] == 1, decision
+    assert agent_summary["first_open_items"][0]["index"] == 14, decision
+    assert agent_summary["first_open_items"][0]["text"] == OPEN_TODO, decision
+    markdown = render_quota_should_run_markdown(decision)
+    assert f"agent_todo_next[14]: {OPEN_TODO}" in markdown, markdown
+    print("todo-first-open-summary-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/goal_harness/quota.py
+++ b/goal_harness/quota.py
@@ -435,11 +435,34 @@ def _summarize_user_todos(value: Any) -> dict[str, Any] | None:
         return None
     items = value.get("items") if isinstance(value.get("items"), list) else []
     open_items: list[dict[str, Any]] = []
+    first_open_items = (
+        value.get("first_open_items")
+        if isinstance(value.get("first_open_items"), list)
+        else []
+    )
+    for item in first_open_items:
+        if not isinstance(item, dict) or item.get("done") is True:
+            continue
+        text = str(item.get("text") or "").strip()
+        if not text:
+            continue
+        open_items.append(
+            {
+                "index": item.get("index"),
+                "text": text,
+            }
+        )
     for item in items:
         if not isinstance(item, dict) or item.get("done") is True:
             continue
         text = str(item.get("text") or "").strip()
         if not text:
+            continue
+        duplicate = any(
+            existing.get("index") == item.get("index") and existing.get("text") == text
+            for existing in open_items
+        )
+        if duplicate:
             continue
         open_items.append(
             {
@@ -463,7 +486,8 @@ def _summarize_project_asset_todos(value: Any) -> dict[str, Any] | None:
         return _summarize_user_todos(value)
 
     next_text = str(value.get("next") or "").strip()
-    first_open_items = [{"index": 1, "text": next_text}] if next_text else []
+    next_index = value.get("next_index", 1)
+    first_open_items = [{"index": next_index, "text": next_text}] if next_text else []
     open_count = value.get("open", value.get("open_count", len(first_open_items)))
     return {
         "source_section": "project_asset",

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -279,6 +279,14 @@ def compact_todo_group(items: list[dict[str, Any]], *, source_section: str | Non
         "total_count": len(items),
         "open_count": len(open_items),
         "done_count": len(done_items),
+        "first_open_items": [
+            {
+                "index": item.get("index"),
+                "done": bool(item.get("done")),
+                "text": item.get("text"),
+            }
+            for item in open_items[:3]
+        ],
         "items": items[:MAX_STATUS_TODOS_PER_ROLE],
     }
 
@@ -317,30 +325,38 @@ def parse_active_state_todos(state_text: str, *, goal: dict[str, Any] | None = N
     role: str | None = None
     source_sections: dict[str, str | None] = {"user": None, "agent": None}
     items: dict[str, list[dict[str, Any]]] = {"user": [], "agent": []}
+    current_todo: dict[str, Any] | None = None
 
     for line in state_text.splitlines():
         if line.startswith("## "):
             heading = line.lstrip("#").strip()
             role = todo_role_for_heading(heading)
+            current_todo = None
             if role and source_sections[role] is None:
                 source_sections[role] = heading
             continue
         if role is None:
             continue
         match = TODO_TASK_PATTERN.match(line)
-        if not match:
+        if match:
+            marker, text = match.groups()
+            todo: dict[str, Any] = {
+                "index": len(items[role]) + 1,
+                "done": marker.lower() == "x",
+                "text": normalize_todo_text(text),
+            }
+            if goal is not None:
+                materials = extract_review_materials(text, goal=goal, state_path=state_path)
+                if materials:
+                    todo["review_materials"] = materials
+            items[role].append(todo)
+            current_todo = todo
             continue
-        marker, text = match.groups()
-        todo: dict[str, Any] = {
-            "index": len(items[role]) + 1,
-            "done": marker.lower() == "x",
-            "text": normalize_todo_text(text),
-        }
-        if goal is not None:
-            materials = extract_review_materials(text, goal=goal, state_path=state_path)
-            if materials:
-                todo["review_materials"] = materials
-        items[role].append(todo)
+        if current_todo is None or not line.startswith((" ", "\t")):
+            continue
+        continuation = line.strip()
+        if continuation:
+            current_todo["text"] = normalize_todo_text(f"{current_todo.get('text', '')} {continuation}")
 
     result: dict[str, Any] = {}
     user = compact_todo_group(items["user"], source_section=source_sections["user"])
@@ -404,6 +420,11 @@ def project_asset_stop_condition(
 def first_open_todo_text(todos: dict[str, Any] | None) -> str | None:
     if not isinstance(todos, dict):
         return None
+    for item in todos.get("first_open_items") or []:
+        if not isinstance(item, dict) or item.get("done"):
+            continue
+        text = normalize_todo_text(str(item.get("text") or ""), limit=220)
+        return text or None
     for item in todos.get("items") or []:
         if not isinstance(item, dict) or item.get("done"):
             continue
@@ -423,6 +444,11 @@ def project_asset_todo_summary(todos: dict[str, Any] | None) -> dict[str, Any] |
     next_item = first_open_todo_text(todos)
     if next_item:
         summary["next"] = next_item
+        first_open_items = todos.get("first_open_items")
+        if isinstance(first_open_items, list) and first_open_items:
+            first_open = first_open_items[0]
+            if isinstance(first_open, dict) and first_open.get("index") is not None:
+                summary["next_index"] = first_open.get("index")
     return summary
 
 


### PR DESCRIPTION
## Summary
- preserve the first open todo separately from the truncated visible todo list
- carry multiline todo continuations into the parsed todo text
- teach quota summaries and markdown to surface the preserved first open todo index/text

## Validation
- python3 -m py_compile goal_harness/status.py goal_harness/quota.py examples/todo-first-open-summary-smoke.py
- python3 examples/todo-first-open-summary-smoke.py
- python3 examples/user-todo-review-material-smoke.py
- python3 examples/run-smokes.py
- goal-harness-canary --format json check --scan-root .
- goal-harness-canary --format json --registry "/Users/bytedance/.codex/goal-harness/registry.global.json" quota should-run --goal-id goal-harness-meta
- git diff --cached --check
- cached diff sensitive/private-boundary scan