### PR TITLE
Clarify quota execution obligation

### DIFF
--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -350,6 +350,15 @@ common modes are:
   implementation/test/state batch is valid when scope and validation are clear;
   the contract is bounded, not tiny.
 
+The same response also includes `execution_obligation`, which separates worker
+execution from user-facing notification. `heartbeat_recommendation.notify`
+answers "should this heartbeat interrupt the user?", not "may the worker skip
+work?" When `execution_obligation.must_attempt_work=true`, a short heartbeat
+must attempt one bounded segment, validate it, write durable state/events, and
+spend once after successful delivery. A quiet no-op is only allowed when the
+machine contract explicitly says `must_attempt_work=false`, such as
+`mapped_noop_if_unchanged` after confirming the mapped source is unchanged.
+
 Unknown goals or status collection failures return non-zero so automations fail
 closed.
 

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -768,6 +768,15 @@ that generic lifecycle hint before inventing local automation behavior:
 once, while `mapped_noop_if_unchanged` returns a quiet no-op without another
 dry-run or quota spend if no new instruction, evidence, todo, stale source, or
 safe handoff exists.
+The payload also includes `execution_obligation`, which is the stronger worker
+contract. `heartbeat_recommendation.notify` is only a user-facing notification
+policy. It must not be interpreted as an execution gate. If
+`execution_obligation.must_attempt_work=true`, the worker should choose one
+bounded segment under `effective_action` / `goal_boundary`, validate it, write
+durable state/events, and spend once after delivery even when
+`notify=DONT_NOTIFY`. A quiet no-op requires
+`execution_obligation.must_attempt_work=false`, such as a verified
+`mapped_noop_if_unchanged` turn.
 When a registry-enabled goal has `control_plane.self_repair.enabled=true`,
 `quota should-run` may return `decision=self_repair`,
 `self_repair_allowed=true`, `stall_self_repair`, and an `effective_action` such

--- a/examples/quota-plan-smoke.py
+++ b/examples/quota-plan-smoke.py
@@ -1037,8 +1037,16 @@ def assert_project_asset_backed_no_evidence_should_run() -> None:
     assert decision["agent_todo_summary"]["first_open_items"][0]["text"] == expected_agent_todo, decision
     assert decision["goal_boundary"]["stop_condition"] == expected_stop, decision
     assert decision["heartbeat_recommendation"]["recommended_mode"] == "steering_audit_then_one_step", decision
+    assert decision["heartbeat_recommendation"]["notify"] == "DONT_NOTIFY", decision
+    assert decision["execution_obligation"]["must_attempt_work"] is True, decision
+    assert decision["execution_obligation"]["kind"] == "normal_run", decision
+    assert decision["execution_obligation"]["notify_is_execution_gate"] is False, decision
     assert "project_asset_source: project_asset" in markdown, markdown
     assert "quota: compute=1.0 slot_minutes=1 slots=0/1440" in markdown, markdown
+    assert (
+        "execution_obligation: must_attempt_work=True kind=normal_run notify_is_execution_gate=False"
+        in markdown
+    ), markdown
     assert f"goal_boundary_stop_condition: {expected_stop}" in markdown, markdown
     assert f"user_todo_next[1]: {expected_user_todo}" in markdown, markdown
     assert f"agent_todo_next[1]: {expected_agent_todo}" in markdown, markdown
@@ -1095,9 +1103,15 @@ def assert_heartbeat_recommendation_lifecycle() -> None:
     assert mapped_rec["recommended_mode"] == "mapped_noop_if_unchanged", mapped_rec
     assert mapped_rec["stop_if_unchanged"] is True, mapped_rec
     assert mapped_rec["notify"] == "DONT_NOTIFY", mapped_rec
+    assert mapped_decision["execution_obligation"]["must_attempt_work"] is False, mapped_decision
+    assert mapped_decision["execution_obligation"]["kind"] == "quiet_noop_if_unchanged", mapped_decision
     assert "do not run another dry-run" in mapped_rec["spend_policy"], mapped_rec
     assert "heartbeat_recommendation: mode=mapped_noop_if_unchanged notify=DONT_NOTIFY" in mapped_markdown
     assert "heartbeat_stop_if_unchanged: `True`" in mapped_markdown, mapped_markdown
+    assert (
+        "execution_obligation: must_attempt_work=False kind=quiet_noop_if_unchanged notify_is_execution_gate=False"
+        in mapped_markdown
+    ), mapped_markdown
 
 
 def assert_goal_boundary_in_should_run() -> None:

--- a/goal_harness/quota.py
+++ b/goal_harness/quota.py
@@ -891,6 +891,47 @@ def _heartbeat_recommendation(
     }
 
 
+def _execution_obligation(
+    *,
+    should_run: bool,
+    effective_action: str,
+    heartbeat_recommendation: dict[str, Any],
+) -> dict[str, Any]:
+    """Separate the worker execution contract from user-facing notification."""
+
+    recommended_mode = str(heartbeat_recommendation.get("recommended_mode") or "")
+    if heartbeat_recommendation.get("stop_if_unchanged"):
+        return {
+            "must_attempt_work": False,
+            "kind": "quiet_noop_if_unchanged",
+            "notify_is_execution_gate": False,
+            "reason": (
+                "this mode allows a quiet no-op only after confirming the mapped source "
+                "is unchanged and no concrete safe handoff exists"
+            ),
+        }
+    if should_run:
+        return {
+            "must_attempt_work": True,
+            "kind": effective_action or recommended_mode or "bounded_delivery",
+            "minimum": "one_bounded_segment",
+            "notify_is_execution_gate": False,
+            "reason": (
+                "should_run=true means a Codex-actionable turn exists; heartbeat notify "
+                "only controls whether to interrupt the user"
+            ),
+        }
+    return {
+        "must_attempt_work": False,
+        "kind": effective_action or recommended_mode or "skip",
+        "notify_is_execution_gate": False,
+        "reason": (
+            "should_run=false blocks delivery unless an explicit safe-bypass or "
+            "self-repair action is exposed"
+        ),
+    }
+
+
 def build_quota_plan(status_payload: dict[str, Any], *, mode: str = "status") -> dict[str, Any]:
     queue = status_payload.get("attention_queue") if isinstance(status_payload.get("attention_queue"), dict) else {}
     queue_items = queue.get("items") if isinstance(queue.get("items"), list) else []
@@ -1226,6 +1267,15 @@ def build_quota_should_run(status_payload: dict[str, Any], *, goal_id: str) -> d
             state=state,
             quota=quota,
         )
+        heartbeat_recommendation = _heartbeat_recommendation(
+            item,
+            goal_id=safe_goal_id,
+            state=state,
+            should_run=should_run,
+            user_todo_summary=user_todo_summary,
+            agent_todo_summary=agent_todo_summary,
+            stall_self_repair=stall_self_repair,
+        )
         payload = {
             "ok": bool(plan.get("ok")) or self_repair_allowed,
             "status_health_ok": bool(plan.get("ok")),
@@ -1266,14 +1316,11 @@ def build_quota_should_run(status_payload: dict[str, Any], *, goal_id: str) -> d
             "recommended_action": item.get("recommended_action"),
             "execution_profile": project_asset.get("execution_profile") if project_asset else None,
             "handoff_readiness": item.get("handoff_readiness"),
-            "heartbeat_recommendation": _heartbeat_recommendation(
-                item,
-                goal_id=safe_goal_id,
-                state=state,
+            "heartbeat_recommendation": heartbeat_recommendation,
+            "execution_obligation": _execution_obligation(
                 should_run=should_run,
-                user_todo_summary=user_todo_summary,
-                agent_todo_summary=agent_todo_summary,
-                stall_self_repair=stall_self_repair,
+                effective_action=effective_action,
+                heartbeat_recommendation=heartbeat_recommendation,
             ),
             "goal_boundary": _goal_boundary(item),
             "plan_summary": plan.get("summary"),
@@ -1927,6 +1974,20 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
             lines.append(f"- heartbeat_spend_policy: {heartbeat_recommendation.get('spend_policy')}")
         if heartbeat_recommendation.get("reason"):
             lines.append(f"- heartbeat_reason: {heartbeat_recommendation.get('reason')}")
+    execution_obligation = (
+        payload.get("execution_obligation")
+        if isinstance(payload.get("execution_obligation"), dict)
+        else {}
+    )
+    if execution_obligation:
+        lines.append(
+            "- execution_obligation: "
+            f"must_attempt_work={execution_obligation.get('must_attempt_work')} "
+            f"kind={execution_obligation.get('kind')} "
+            f"notify_is_execution_gate={execution_obligation.get('notify_is_execution_gate')}"
+        )
+        if execution_obligation.get("reason"):
+            lines.append(f"- execution_obligation_reason: {execution_obligation.get('reason')}")
     stall_self_repair = (
         payload.get("stall_self_repair")
         if isinstance(payload.get("stall_self_repair"), dict)


### PR DESCRIPTION
## Summary
- add an explicit execution_obligation contract to quota should-run responses
- make markdown show that notify is not an execution gate
- document the worker/user-notification split and add regression coverage for steering vs mapped quiet-noop modes

## Validation
- python3 -m py_compile goal_harness/quota.py examples/quota-plan-smoke.py
- python3 examples/quota-plan-smoke.py
- python3 examples/status-markdown-smoke.py
- python3 examples/run-smokes.py
- PYTHONPATH=/Users/bytedance/goal-harness python3 -m goal_harness.cli --format json check --scan-root .
- local meta should-run payload shows notify=DONT_NOTIFY with execution_obligation.must_attempt_work=true
- git diff --cached --check
- cached diff sensitive/private-boundary scan