### PR TITLE
Detect Codex app heartbeat installs in upgrade plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,10 @@ goal-harness upgrade-plan --format json
 
 This command inventories registry-managed controller goals, regenerates the
 thin installed heartbeat prompt from the candidate CLI contract, and compares it
-with an optional installed automation manifest:
+with installed automation truth. By default it auto-discovers Codex App
+heartbeat automations from `$CODEX_HOME/automations` or
+`~/.codex/automations`; pass an explicit manifest only when an external client
+needs to supply its own installed prompt hashes:
 
 ```bash
 goal-harness upgrade-plan \

--- a/examples/upgrade-plan-smoke.py
+++ b/examples/upgrade-plan-smoke.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 import tempfile
 from pathlib import Path
@@ -13,7 +14,8 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from goal_harness.upgrade import build_upgrade_plan, render_upgrade_plan_markdown  # noqa: E402
+from goal_harness.heartbeat_prompt import build_heartbeat_prompt  # noqa: E402
+from goal_harness.upgrade import build_upgrade_plan, prompt_digest, render_upgrade_plan_markdown  # noqa: E402
 
 
 GOAL_ID = "upgrade-plan-goal"
@@ -190,13 +192,75 @@ def assert_stage_deferred_selection_is_not_upgrade_work(registry_path: Path) -> 
     assert "stage-deferred" in payload["recommended_action"], payload
 
 
+def write_codex_app_automation(codex_home: Path, *, prompt: str) -> Path:
+    automation_path = codex_home / "automations" / GOAL_ID / "automation.toml"
+    automation_path.parent.mkdir(parents=True)
+    automation_path.write_text(
+        "\n".join(
+            [
+                "version = 1",
+                f'id = "{GOAL_ID}"',
+                'kind = "heartbeat"',
+                'name = "Upgrade Plan Fixture"',
+                f"prompt = {json.dumps(prompt)}",
+                'status = "ACTIVE"',
+                'rrule = "RRULE:FREQ=MINUTELY;INTERVAL=5"',
+                'target_thread_id = "fixture-thread"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return automation_path
+
+
+def assert_codex_app_automation_is_discovered(registry_path: Path, codex_home: Path, first_payload: dict) -> None:
+    rendered = build_heartbeat_prompt(
+        goal_id=GOAL_ID,
+        active_state=None,
+        active_state_source="registry",
+        thin=True,
+        cli_bin="goal-harness",
+    )["task_body"]
+    expected_sha = first_payload["managed_heartbeats"][0]["generated_prompts"]["thin"]["sha256"]
+    assert prompt_digest(rendered) == expected_sha, first_payload
+    write_codex_app_automation(
+        codex_home,
+        prompt=rendered,
+    )
+    payload = build_upgrade_plan(registry_path=registry_path, cli_bin="goal-harness")
+    assert payload["installed_manifest"]["source"] == "codex_app_automations", payload
+    assert payload["installed_manifest"]["available"] is True, payload
+    auto_entry = payload["installed_manifest"]["entries"][0]
+    assert "task_body" not in auto_entry, payload
+    assert auto_entry["prompt_sha256"] == expected_sha, payload
+    assert payload["summary"]["unknown_prompt_count"] == 0, payload
+    assert payload["summary"]["stale_prompt_count"] == 0, payload
+    assert payload["summary"]["current_prompt_count"] == 1, payload
+    installed = payload["managed_heartbeats"][0]["installed_prompts"]["thin"]
+    assert installed["status"] == "current", payload
+    assert installed["automation_id"] == GOAL_ID, payload
+    assert installed["installed"] is True, payload
+    assert payload["summary"]["ready_for_default_promotion"] is True, payload
+
+
 def main() -> int:
     with tempfile.TemporaryDirectory(prefix="goal-harness-upgrade-plan-smoke-") as raw_tmp:
-        registry_path, manifest_path = write_fixture(Path(raw_tmp))
-        first_payload = assert_unknown_manifest_blocks_promotion(registry_path)
-        assert_matching_manifest_is_ready(registry_path, manifest_path, first_payload)
-        assert_not_installed_manifest_is_ready(registry_path, manifest_path)
-        assert_stage_deferred_selection_is_not_upgrade_work(registry_path)
+        root = Path(raw_tmp)
+        old_codex_home = os.environ.get("CODEX_HOME")
+        os.environ["CODEX_HOME"] = str(root / "codex-home")
+        try:
+            registry_path, manifest_path = write_fixture(root)
+            first_payload = assert_unknown_manifest_blocks_promotion(registry_path)
+            assert_matching_manifest_is_ready(registry_path, manifest_path, first_payload)
+            assert_not_installed_manifest_is_ready(registry_path, manifest_path)
+            assert_stage_deferred_selection_is_not_upgrade_work(registry_path)
+            assert_codex_app_automation_is_discovered(registry_path, root / "codex-home", first_payload)
+        finally:
+            if old_codex_home is None:
+                os.environ.pop("CODEX_HOME", None)
+            else:
+                os.environ["CODEX_HOME"] = old_codex_home
     print("upgrade-plan-smoke ok")
     return 0
 

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -330,7 +330,11 @@ def main(argv: list[str] | None = None) -> int:
     upgrade_plan_parser.add_argument("--goal-id", action="append", default=[], help="Only include one goal id. Repeatable.")
     upgrade_plan_parser.add_argument(
         "--installed-manifest",
-        help="Optional JSON manifest of installed automations with goal_id, mode, automation_id, and prompt_sha256/task_body.",
+        help=(
+            "Optional JSON manifest of installed automations with goal_id, mode, automation_id, and "
+            "prompt_sha256/task_body. If omitted, upgrade-plan auto-discovers Codex App heartbeat "
+            "automations from $CODEX_HOME/automations or ~/.codex/automations."
+        ),
     )
     upgrade_plan_parser.add_argument(
         "--cli-bin",

--- a/goal_harness/upgrade.py
+++ b/goal_harness/upgrade.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
+import re
 from pathlib import Path
 from typing import Any
 
@@ -46,12 +48,7 @@ def prompt_summary(prompt: dict[str, Any], mode: str) -> dict[str, Any]:
 
 def load_installed_manifest(path: Path | None) -> dict[str, Any]:
     if path is None:
-        return {
-            "available": False,
-            "path": None,
-            "entries": [],
-            "reason": "no installed automation manifest provided",
-        }
+        return load_codex_app_automation_manifest()
     if not path.exists():
         return {
             "available": False,
@@ -70,6 +67,109 @@ def load_installed_manifest(path: Path | None) -> dict[str, Any]:
         "available": True,
         "path": str(path),
         "entries": [entry for entry in entries if isinstance(entry, dict)],
+    }
+
+
+def codex_home() -> Path:
+    return Path(os.environ.get("CODEX_HOME") or Path.home() / ".codex").expanduser()
+
+
+def parse_automation_toml(path: Path) -> dict[str, Any]:
+    values: dict[str, Any] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, raw_value = line.split("=", 1)
+        key = key.strip()
+        value = raw_value.strip()
+        if value.startswith('"') and value.endswith('"'):
+            try:
+                values[key] = json.loads(value)
+            except json.JSONDecodeError:
+                values[key] = value[1:-1]
+        elif value in {"true", "false"}:
+            values[key] = value == "true"
+        else:
+            try:
+                values[key] = int(value)
+            except ValueError:
+                values[key] = value
+    return values
+
+
+def infer_goal_id_from_prompt(prompt: str) -> str | None:
+    patterns = (
+        r"Advance\s+`([^`]+)`\s+from\b",
+        r"Advance\s+`([^`]+)`\s+using\b",
+        r"--goal-id\s+([A-Za-z0-9_.:-]+)",
+        r"goal_id:\s*`([^`]+)`",
+    )
+    for pattern in patterns:
+        match = re.search(pattern, prompt)
+        if match:
+            return match.group(1)
+    return None
+
+
+def infer_prompt_mode(prompt: str) -> str:
+    if "compact Goal Harness heartbeat body" in prompt:
+        return "compact"
+    if "Brief installed Goal Harness heartbeat" in prompt:
+        return "brief"
+    if "Keep the heartbeat thin." in prompt or "from the registry-declared active state" in prompt:
+        return "thin"
+    return DEFAULT_UPGRADE_MODES[0]
+
+
+def load_codex_app_automation_manifest(root: Path | None = None) -> dict[str, Any]:
+    home = root or codex_home()
+    automations_root = home / "automations"
+    if not automations_root.exists():
+        return {
+            "available": False,
+            "path": str(automations_root),
+            "entries": [],
+            "reason": "no installed automation manifest provided and Codex App automations directory does not exist",
+            "source": "codex_app_automations",
+        }
+
+    entries: list[dict[str, Any]] = []
+    for path in sorted(automations_root.glob("*/automation.toml")):
+        try:
+            automation = parse_automation_toml(path)
+        except OSError:
+            continue
+        if automation.get("kind") != "heartbeat":
+            continue
+        prompt = automation.get("prompt")
+        if not isinstance(prompt, str) or not prompt.strip():
+            continue
+        goal_id = infer_goal_id_from_prompt(prompt)
+        if not goal_id:
+            continue
+        status = str(automation.get("status") or "ACTIVE")
+        entries.append(
+            {
+                "automation_id": str(automation.get("id") or path.parent.name),
+                "goal_id": goal_id,
+                "mode": infer_prompt_mode(prompt),
+                "prompt_sha256": prompt_digest(prompt),
+                "char_count": len(prompt),
+                "line_count": len(prompt.splitlines()),
+                "status": status,
+                "installed": status.upper() != "DELETED",
+                "source": "codex_app_automation_toml",
+                "path": str(path),
+            }
+        )
+
+    return {
+        "available": True,
+        "path": str(automations_root),
+        "entries": entries,
+        "source": "codex_app_automations",
+        "reason": None if entries else "no Goal Harness heartbeat automations discovered",
     }
 
 


### PR DESCRIPTION
## Summary
- auto-discover Codex App heartbeat automations from CODEX_HOME/automations or ~/.codex/automations when no installed manifest is provided
- infer goal id and prompt mode, hash installed prompt bodies, and report current/stale/unknown without echoing full prompt text
- cover the app automation TOML path in upgrade-plan smoke and document the default discovery behavior

## Validation
- python3 examples/upgrade-plan-smoke.py
- python3 -m py_compile goal_harness/upgrade.py goal_harness/cli.py examples/upgrade-plan-smoke.py
- python3 -m goal_harness.cli --format json upgrade-plan --mode thin
- git diff --check
- python3 examples/run-smokes.py
- env PATH="/Users/bytedance/.local/bin:/Users/bytedance/.cargo/bin:/Users/bytedance/.codex/tmp/arg0/codex-arg0kr5Yf6:/usr/bin:/bin:/usr/sbin:/sbin:/Applications/Codex.app/Contents/Resources" goal-harness-canary --format json check --scan-root .

## Boundary Scan
- git diff --cached --check
- cached diff sensitive scan found no matches for AKIA/SECRET/TOKEN/PASSWORD/private-key markers or local/company path/url terms