### PR TITLE
Summarize installed heartbeat manifest safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,9 @@ If the plan reports unknown or stale prompt digests, update those managed
 heartbeat automations/controller clients before running `scripts/install-local.sh`
 for default promotion. This keeps connected projects from continuing on stale
 prompt branches after the local default version changes.
+The JSON `summary` includes `installed_manifest_source`,
+`installed_manifest_entry_count`, and `installed_manifest_has_task_body` so
+automation can check discovery safety without scanning every installed entry.
 Goals whose adapter stage is still `planned` or whose registry attention status
 is `stage_deferred_not_installed` are reported separately under
 `stage_deferred_heartbeats`; they do not count as unknown/stale managed

--- a/examples/upgrade-plan-smoke.py
+++ b/examples/upgrade-plan-smoke.py
@@ -83,6 +83,10 @@ def assert_unknown_manifest_blocks_promotion(registry_path: Path) -> dict:
     assert payload["summary"]["managed_goal_count"] == 1, payload
     assert payload["summary"]["stage_deferred_goal_count"] == 1, payload
     assert payload["summary"]["unknown_prompt_count"] == 1, payload
+    assert payload["summary"]["installed_manifest_available"] is False, payload
+    assert payload["summary"]["installed_manifest_source"] == "codex_app_automations", payload
+    assert payload["summary"]["installed_manifest_entry_count"] == 0, payload
+    assert payload["summary"]["installed_manifest_has_task_body"] is False, payload
     assert payload["summary"]["ready_for_default_promotion"] is False, payload
     deferred = payload["stage_deferred_heartbeats"][0]
     assert deferred["goal_id"] == DEFERRED_GOAL_ID, payload
@@ -135,6 +139,8 @@ def assert_matching_manifest_is_ready(registry_path: Path, manifest_path: Path, 
     assert payload["summary"]["current_prompt_count"] == 1, payload
     assert payload["summary"]["not_installed_prompt_count"] == 0, payload
     assert payload["summary"]["stage_deferred_goal_count"] == 1, payload
+    assert payload["summary"]["installed_manifest_entry_count"] == 1, payload
+    assert payload["summary"]["installed_manifest_has_task_body"] is False, payload
     assert payload["summary"]["ready_for_default_promotion"] is True, payload
     assert payload["managed_heartbeats"][0]["installed_prompts"]["thin"]["status"] == "current", payload
 
@@ -168,6 +174,8 @@ def assert_not_installed_manifest_is_ready(registry_path: Path, manifest_path: P
     assert payload["summary"]["current_prompt_count"] == 0, payload
     assert payload["summary"]["not_installed_prompt_count"] == 1, payload
     assert payload["summary"]["stage_deferred_goal_count"] == 1, payload
+    assert payload["summary"]["installed_manifest_entry_count"] == 1, payload
+    assert payload["summary"]["installed_manifest_has_task_body"] is False, payload
     assert payload["summary"]["ready_for_default_promotion"] is True, payload
     installed = payload["managed_heartbeats"][0]["installed_prompts"]["thin"]
     assert payload["managed_heartbeats"][0]["requires_update"] is False, payload
@@ -234,6 +242,9 @@ def assert_codex_app_automation_is_discovered(registry_path: Path, codex_home: P
     auto_entry = payload["installed_manifest"]["entries"][0]
     assert "task_body" not in auto_entry, payload
     assert auto_entry["prompt_sha256"] == expected_sha, payload
+    assert payload["summary"]["installed_manifest_entry_count"] == 1, payload
+    assert payload["summary"]["installed_manifest_task_body_count"] == 0, payload
+    assert payload["summary"]["installed_manifest_has_task_body"] is False, payload
     assert payload["summary"]["unknown_prompt_count"] == 0, payload
     assert payload["summary"]["stale_prompt_count"] == 0, payload
     assert payload["summary"]["current_prompt_count"] == 1, payload

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -891,6 +891,11 @@ def main(argv: list[str] | None = None) -> int:
                     "not_installed_prompt_count": 0,
                     "stage_deferred_goal_count": 0,
                     "ready_for_default_promotion": False,
+                    "installed_manifest_available": False,
+                    "installed_manifest_source": None,
+                    "installed_manifest_entry_count": 0,
+                    "installed_manifest_task_body_count": 0,
+                    "installed_manifest_has_task_body": False,
                 },
                 "recommended_action": "fix upgrade-plan collection before default promotion",
             }

--- a/goal_harness/upgrade.py
+++ b/goal_harness/upgrade.py
@@ -267,6 +267,8 @@ def build_upgrade_plan(
     selected_modes = tuple(modes or DEFAULT_UPGRADE_MODES)
     selected_goal_ids = set(goal_ids or [])
     manifest = load_installed_manifest(installed_manifest)
+    manifest_entries = manifest["entries"]
+    manifest_task_body_count = sum(1 for entry in manifest_entries if isinstance(entry, dict) and "task_body" in entry)
     installed_by_key = index_installed_entries(manifest["entries"])
     managed: list[dict[str, Any]] = []
     deferred: list[dict[str, Any]] = []
@@ -376,6 +378,11 @@ def build_upgrade_plan(
             "not_installed_prompt_count": not_installed,
             "stage_deferred_goal_count": len(deferred),
             "ready_for_default_promotion": ready,
+            "installed_manifest_available": manifest.get("available"),
+            "installed_manifest_source": manifest.get("source"),
+            "installed_manifest_entry_count": len(manifest_entries),
+            "installed_manifest_task_body_count": manifest_task_body_count,
+            "installed_manifest_has_task_body": manifest_task_body_count > 0,
         },
         "managed_heartbeats": managed,
         "stage_deferred_heartbeats": deferred,
@@ -400,6 +407,9 @@ def render_upgrade_plan_markdown(payload: dict[str, Any]) -> str:
         f"- unknown_prompt_count: `{summary.get('unknown_prompt_count')}`",
         f"- not_installed_prompt_count: `{summary.get('not_installed_prompt_count')}`",
         f"- stage_deferred_goal_count: `{summary.get('stage_deferred_goal_count')}`",
+        f"- installed_manifest_source: `{summary.get('installed_manifest_source')}`",
+        f"- installed_manifest_entry_count: `{summary.get('installed_manifest_entry_count')}`",
+        f"- installed_manifest_has_task_body: `{summary.get('installed_manifest_has_task_body')}`",
         f"- recommended_action: `{payload.get('recommended_action')}`",
     ]
     manifest = payload.get("installed_manifest") if isinstance(payload.get("installed_manifest"), dict) else {}


### PR DESCRIPTION
## Summary
- add installed manifest discovery source/count/task-body safety fields to upgrade-plan summary
- include the same fields in markdown and failure payloads
- extend upgrade-plan smoke coverage and README docs so automation does not need to scan installed entries

## Validation
- python3 examples/upgrade-plan-smoke.py
- python3 -m py_compile goal_harness/upgrade.py goal_harness/cli.py examples/upgrade-plan-smoke.py
- python3 -m goal_harness.cli --format json upgrade-plan --mode thin
- git diff --check
- python3 examples/run-smokes.py
- env PATH="/Users/bytedance/.local/bin:/Users/bytedance/.cargo/bin:/Users/bytedance/.codex/tmp/arg0/codex-arg0kr5Yf6:/usr/bin:/bin:/usr/sbin:/sbin:/Applications/Codex.app/Contents/Resources" goal-harness-canary --format json check --scan-root .

## Boundary Scan
- git diff --cached --check
- cached diff sensitive scan found no matches for AKIA/SECRET/TOKEN/PASSWORD/private-key markers or local/company path/url terms