### PR TITLE
Allow review-packet subcommand format flag

### DIFF
--- a/examples/review-packet-cli-smoke.py
+++ b/examples/review-packet-cli-smoke.py
@@ -890,6 +890,35 @@ def main() -> int:
             "controller handoff-only json",
             text_key="handoff_text",
         )
+        controller_handoff_subcommand_format_result = run_cli(
+            root,
+            registry_path,
+            "review-packet",
+            "--goal-id",
+            GOAL_ID,
+            "--scan-root",
+            str(root / "project"),
+            "--handoff-only",
+            "--format",
+            "json",
+        )
+        controller_handoff_subcommand_format_payload = json.loads(
+            controller_handoff_subcommand_format_result.stdout
+        )
+        assert controller_handoff_subcommand_format_payload["ok"] is True, (
+            controller_handoff_subcommand_format_payload
+        )
+        assert controller_handoff_subcommand_format_payload["handoff_only"] is True, (
+            controller_handoff_subcommand_format_payload
+        )
+        assert "packet" not in controller_handoff_subcommand_format_payload, (
+            controller_handoff_subcommand_format_payload
+        )
+        assert_handoff_interface_budget(
+            controller_handoff_subcommand_format_payload,
+            "controller handoff-only subcommand-format json",
+            text_key="handoff_text",
+        )
 
         append_operator_gate_approval_fixture(root)
         before_files = sorted(path.name for path in run_dir.iterdir())

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -634,6 +634,12 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Print only the target project-agent handoff in markdown output; JSON output returns a minimized handoff payload.",
     )
+    review_packet_parser.add_argument(
+        "--format",
+        dest="review_packet_format",
+        choices=["markdown", "json"],
+        help="Output format for review-packet. This mirrors the global --format flag and may appear after the subcommand.",
+    )
     review_packet_parser.add_argument("--limit", type=int, default=5)
 
     todo_parser = sub.add_parser(
@@ -1186,6 +1192,7 @@ def main(argv: list[str] | None = None) -> int:
         return 0 if payload.get("ok") else 1
 
     if args.command == "review-packet":
+        output_format = args.review_packet_format or args.format
         try:
             scan_roots = [Path(item).expanduser() for item in args.scan_path]
             if not scan_roots:
@@ -1210,10 +1217,10 @@ def main(argv: list[str] | None = None) -> int:
             }
         if args.handoff_only:
             payload = review_packet_handoff_only_payload(payload)
-        if args.handoff_only and args.format != "json" and payload.get("ok"):
+        if args.handoff_only and output_format != "json" and payload.get("ok"):
             print(str(payload.get("handoff_text") or ""))
         else:
-            print_payload(payload, args.format, render_review_packet_markdown)
+            print_payload(payload, output_format, render_review_packet_markdown)
         return 0 if payload.get("ok") else 1
 
     if args.command == "todo":


### PR DESCRIPTION
## Summary
- allow review-packet to accept --format markdown/json after the subcommand
- keep the existing global --format behavior unchanged
- add smoke coverage for the documented review-packet --handoff-only --format json order

## Validation
- python3 examples/review-packet-cli-smoke.py
- python3 -m py_compile goal_harness/cli.py examples/review-packet-cli-smoke.py
- python3 -m goal_harness.cli review-packet --help | rg -n -- "--format|JSON output"
- git diff --check
- python3 examples/run-smokes.py
- env PATH="/Users/bytedance/.local/bin:/Users/bytedance/.cargo/bin:/Users/bytedance/.codex/tmp/arg0/codex-arg0kr5Yf6:/usr/bin:/bin:/usr/sbin:/sbin:/Applications/Codex.app/Contents/Resources" goal-harness-canary --format json check --scan-root .

## Boundary Scan
- git diff --cached --check
- cached diff sensitive scan found no matches for AKIA/SECRET/TOKEN/PASSWORD/private-key markers or local/company path/url terms