### PR TITLE
Support subcommand format aliases

### DIFF
--- a/examples/subcommand-format-smoke.py
+++ b/examples/subcommand-format-smoke.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Smoke-test documented subcommand-local --format JSON aliases."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GOAL_ID = "subcommand-format-goal"
+
+
+def write_fixture(root: Path) -> Path:
+    project = root / "project"
+    runtime = root / "runtime"
+    state_file = project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+    state_file.parent.mkdir(parents=True, exist_ok=True)
+    state_file.write_text(
+        "---\n"
+        "status: active\n"
+        "updated_at: 2026-01-01T00:00:00+00:00\n"
+        "---\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] [P1] Keep the fixture CLI handoff compact.\n\n"
+        "## Next Action\n\n"
+        "- Verify documented CLI command ordering remains runnable.\n",
+        encoding="utf-8",
+    )
+    registry_path = project / ".goal-harness" / "registry.json"
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "fixture",
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md",
+                        "adapter": {
+                            "kind": "harness_self_improvement",
+                            "status": "connected-read-only",
+                        },
+                        "quota": {"compute": 1.0, "window_hours": 24},
+                    }
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return registry_path
+
+
+def cli_json(registry_path: Path, *args: str) -> dict:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "goal_harness.cli",
+            "--registry",
+            str(registry_path),
+            *args,
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+    )
+    assert result.returncode == 0, (args, result.returncode, result.stdout, result.stderr)
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise AssertionError((args, result.stdout, result.stderr)) from exc
+    assert isinstance(payload, dict), (args, payload)
+    return payload
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="goal-harness-subcommand-format-smoke-") as raw_tmp:
+        registry_path = write_fixture(Path(raw_tmp))
+
+        heartbeat = cli_json(
+            registry_path,
+            "heartbeat-prompt",
+            "--goal-id",
+            GOAL_ID,
+            "--thin",
+            "--format",
+            "json",
+        )
+        assert heartbeat["ok"] is True, heartbeat
+        assert heartbeat["thin"] is True, heartbeat
+        assert heartbeat["interface_budget"]["mode"] == "thin", heartbeat
+
+        upgrade = cli_json(registry_path, "upgrade-plan", "--format", "json")
+        assert upgrade["ok"] is True, upgrade
+        assert upgrade["mode"] == "upgrade-plan", upgrade
+
+        promotion = cli_json(registry_path, "promotion-gate", "--format", "json")
+        assert promotion["ok"] is True, promotion
+        assert promotion["gate"] == "promotion_readiness", promotion
+
+        status = cli_json(registry_path, "status", "--format", "json", "--limit", "1")
+        assert status["ok"] is True, status
+        assert "attention_queue" in status, status
+
+        handoff = cli_json(
+            registry_path,
+            "review-packet",
+            "--goal-id",
+            GOAL_ID,
+            "--handoff-only",
+            "--format",
+            "json",
+        )
+        assert handoff["ok"] is True, handoff
+        assert handoff["handoff_only"] is True, handoff
+        assert "packet" not in handoff, handoff
+
+    print("subcommand-format-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -84,6 +84,23 @@ def print_payload(payload: dict[str, object], fmt: str, markdown_renderer) -> No
         print(markdown_renderer(payload))
 
 
+def add_subcommand_format(arg_parser: argparse.ArgumentParser) -> None:
+    arg_parser.add_argument(
+        "--format",
+        dest="subcommand_format",
+        choices=["markdown", "json"],
+        help="Output format for this subcommand. Equivalent to global --format before the command.",
+    )
+
+
+def output_format(args: argparse.Namespace, *local_dests: str) -> str:
+    for dest in (*local_dests, "subcommand_format"):
+        value = getattr(args, dest, None)
+        if value:
+            return str(value)
+    return str(args.format)
+
+
 def review_packet_handoff_only_payload(payload: dict[str, object]) -> dict[str, object]:
     result: dict[str, object] = {
         "ok": bool(payload.get("ok")),
@@ -267,6 +284,7 @@ def main(argv: list[str] | None = None) -> int:
         "heartbeat-prompt",
         help="Generate a guarded Codex App heartbeat automation task body.",
     )
+    add_subcommand_format(heartbeat_prompt_parser)
     heartbeat_prompt_parser.add_argument("--goal-id", required=True, help="Stable Goal Harness goal id.")
     heartbeat_prompt_parser.add_argument(
         "--active-state",
@@ -318,15 +336,17 @@ def main(argv: list[str] | None = None) -> int:
 
     sub.add_parser("doctor", help="Diagnose local CLI installation, PATH, wrapper, and import health.")
 
-    sub.add_parser(
+    promotion_gate_parser = sub.add_parser(
         "promotion-gate",
         help="Emit a compact machine-readable canary promotion readiness gate result.",
     )
+    add_subcommand_format(promotion_gate_parser)
 
     upgrade_plan_parser = sub.add_parser(
         "upgrade-plan",
         help="Plan local default upgrade propagation for managed heartbeat automations.",
     )
+    add_subcommand_format(upgrade_plan_parser)
     upgrade_plan_parser.add_argument("--goal-id", action="append", default=[], help="Only include one goal id. Repeatable.")
     upgrade_plan_parser.add_argument(
         "--installed-manifest",
@@ -594,6 +614,7 @@ def main(argv: list[str] | None = None) -> int:
     check_parser.add_argument("--limit", type=int, default=5)
 
     status_parser = sub.add_parser("status", help="Show a first-screen goal status and attention queue.")
+    add_subcommand_format(status_parser)
     status_parser.add_argument(
         "--scan-root",
         default=default_public_scan_root(),
@@ -822,7 +843,7 @@ def main(argv: list[str] | None = None) -> int:
                 "goal_id": args.goal_id,
                 "error": str(exc),
             }
-        print_payload(payload, args.format, render_heartbeat_prompt_markdown)
+        print_payload(payload, output_format(args), render_heartbeat_prompt_markdown)
         return 0 if payload.get("ok") else 1
 
     if args.command == "demo":
@@ -869,7 +890,7 @@ def main(argv: list[str] | None = None) -> int:
                 "error": str(exc),
                 "recommended_action": "fix promotion readiness gate collection before promotion",
             }
-        print_payload(payload, args.format, render_promotion_gate_markdown)
+        print_payload(payload, output_format(args), render_promotion_gate_markdown)
         return 0 if payload.get("ok") else 1
 
     if args.command == "upgrade-plan":
@@ -905,7 +926,7 @@ def main(argv: list[str] | None = None) -> int:
                 },
                 "recommended_action": "fix upgrade-plan collection before default promotion",
             }
-        print_payload(payload, args.format, render_upgrade_plan_markdown)
+        print_payload(payload, output_format(args), render_upgrade_plan_markdown)
         return 0 if payload.get("ok") else 1
 
     if args.command == "registry":
@@ -1188,11 +1209,11 @@ def main(argv: list[str] | None = None) -> int:
                     ],
                 },
             }
-        print_payload(payload, args.format, render_status_markdown)
+        print_payload(payload, output_format(args), render_status_markdown)
         return 0 if payload.get("ok") else 1
 
     if args.command == "review-packet":
-        output_format = args.review_packet_format or args.format
+        selected_format = output_format(args, "review_packet_format")
         try:
             scan_roots = [Path(item).expanduser() for item in args.scan_path]
             if not scan_roots:
@@ -1217,10 +1238,10 @@ def main(argv: list[str] | None = None) -> int:
             }
         if args.handoff_only:
             payload = review_packet_handoff_only_payload(payload)
-        if args.handoff_only and output_format != "json" and payload.get("ok"):
+        if args.handoff_only and selected_format != "json" and payload.get("ok"):
             print(str(payload.get("handoff_text") or ""))
         else:
-            print_payload(payload, output_format, render_review_packet_markdown)
+            print_payload(payload, selected_format, render_review_packet_markdown)
         return 0 if payload.get("ok") else 1
 
     if args.command == "todo":


### PR DESCRIPTION
## Summary
- add subcommand-local `--format markdown|json` aliases for documented control-plane commands: `heartbeat-prompt`, `upgrade-plan`, `promotion-gate`, and `status`
- keep the existing global `--format` behavior and the review-packet handoff-only format alias
- add a smoke that runs documented subcommand-local JSON ordering through the CLI

## Validation
- `python3 examples/subcommand-format-smoke.py`
- `python3 -m py_compile goal_harness/cli.py examples/subcommand-format-smoke.py`
- `python3 examples/run-smokes.py`
- `git diff --check`
- `python3 -m goal_harness.cli --format json check --scan-root .`
- cached whitespace and sensitive/private-marker scan before commit
