### PR TITLE
Mirror handoff budget fields

### DIFF
--- a/examples/review-packet-cli-smoke.py
+++ b/examples/review-packet-cli-smoke.py
@@ -89,6 +89,14 @@ def assert_handoff_interface_budget(payload: dict[str, Any], label: str, *, text
     assert budget["within_budget"] is True, (label, budget)
 
 
+def assert_handoff_only_top_level_budget(payload: dict[str, Any], label: str) -> None:
+    budget = payload.get("handoff_interface_budget")
+    assert isinstance(budget, dict), (label, payload)
+    assert payload["line_count"] == budget["line_count"], (label, payload)
+    assert payload["char_count"] == budget["char_count"], (label, payload)
+    assert payload["within_budget"] == budget["within_budget"], (label, payload)
+
+
 def assert_status_data_contract_documents_handoff_budget() -> None:
     contract = STATUS_DATA_CONTRACT_PATH.read_text(encoding="utf-8")
     compact_contract = " ".join(contract.split())
@@ -513,6 +521,7 @@ def assert_connected_delivery_surface_loop_requires_macro_evidence() -> None:
     assert_handoff_interface_budget(payload, "connected-delivery macro evidence handoff")
     handoff_only = review_packet_handoff_only_payload(payload)
     assert_handoff_interface_budget(handoff_only, "connected-delivery handoff-only payload")
+    assert_handoff_only_top_level_budget(handoff_only, "connected-delivery handoff-only payload")
     agent_contract = handoff_only["handoff_delivery_contract"]
     assert set(agent_contract) == {"mode", "instruction", "minimum_scale", "must_include", "if_blocked"}, handoff_only
     assert agent_contract["mode"] == "expand_after_surface_progress_loop", handoff_only
@@ -890,6 +899,7 @@ def main() -> int:
             "controller handoff-only json",
             text_key="handoff_text",
         )
+        assert_handoff_only_top_level_budget(controller_handoff_payload, "controller handoff-only json")
         controller_handoff_subcommand_format_result = run_cli(
             root,
             registry_path,
@@ -918,6 +928,10 @@ def main() -> int:
             controller_handoff_subcommand_format_payload,
             "controller handoff-only subcommand-format json",
             text_key="handoff_text",
+        )
+        assert_handoff_only_top_level_budget(
+            controller_handoff_subcommand_format_payload,
+            "controller handoff-only subcommand-format json",
         )
 
         append_operator_gate_approval_fixture(root)
@@ -1050,6 +1064,7 @@ def main() -> int:
             goal_id=GOAL_ID,
         )
         assert_handoff_interface_budget(handoff_payload, "handoff-only json", text_key="handoff_text")
+        assert_handoff_only_top_level_budget(handoff_payload, "handoff-only json")
 
         after_files = sorted(path.name for path in run_dir.iterdir())
         assert after_files == before_files, "approved review-packet must not write runtime runs"

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -26,6 +26,7 @@ from .doctor import collect_doctor, render_doctor_markdown
 from .execution_profile import DEFAULT_EXECUTION_PROFILE
 from .feedback import append_human_reward, compact_reward, render_reward_markdown
 from .global_registry import render_global_sync_markdown, sync_project_registry_to_global
+from .handoff_budget import build_handoff_interface_budget
 from .heartbeat_prompt import build_heartbeat_prompt, render_heartbeat_prompt_markdown
 from .history import collect_history, load_registry, render_history_markdown
 from .operator_gate import (
@@ -121,6 +122,9 @@ def review_packet_handoff_only_payload(payload: dict[str, object]) -> dict[str, 
             "must_include": raw_contract.get("must_include"),
             "if_blocked": raw_contract.get("if_blocked"),
         }
+    handoff_budget = payload.get("handoff_interface_budget")
+    if not isinstance(handoff_budget, dict):
+        handoff_budget = build_handoff_interface_budget(handoff_text)
     result.update(
         {
             "kind": payload.get("kind"),
@@ -132,7 +136,10 @@ def review_packet_handoff_only_payload(payload: dict[str, object]) -> dict[str, 
             "operator_gate_approved_handoff": payload.get("operator_gate_approved_handoff"),
             "connected_delivery_handoff": payload.get("connected_delivery_handoff"),
             "handoff_delivery_contract": agent_contract,
-            "handoff_interface_budget": payload.get("handoff_interface_budget"),
+            "handoff_interface_budget": handoff_budget,
+            "line_count": handoff_budget.get("line_count"),
+            "char_count": handoff_budget.get("char_count"),
+            "within_budget": handoff_budget.get("within_budget"),
         }
     )
     return result


### PR DESCRIPTION
## Summary
- mirror handoff-only JSON `line_count`, `char_count`, and `within_budget` at the top level
- keep the existing `handoff_interface_budget` object as the canonical nested contract
- add review-packet CLI smoke assertions that the top-level mirrors match the nested budget

## Validation
- `python3 examples/review-packet-cli-smoke.py`
- `python3 examples/subcommand-format-smoke.py`
- `python3 -m py_compile goal_harness/cli.py examples/review-packet-cli-smoke.py`
- live `review-packet --handoff-only --format json` field check
- `python3 examples/run-smokes.py`
- `git diff --check`
- `python3 -m goal_harness.cli --format json check --scan-root .`
- cached sensitive/private-marker scan before commit
