### PR TITLE
Project post-handoff observation no-op contract

### DIFF
--- a/examples/quota-plan-smoke.py
+++ b/examples/quota-plan-smoke.py
@@ -903,6 +903,88 @@ def assert_control_plane_waiting_projection_self_repair_should_run() -> None:
     assert "control-plane self-repair" in spend_event["health_check"], spend_event
 
 
+def assert_control_plane_post_handoff_observe_if_unchanged() -> None:
+    goal_id = "goal-harness-meta"
+    meta_goal = goal(goal_id, compute=1.0)
+    meta_goal["adapter_kind"] = "harness_self_improvement"
+    meta_goal["adapter_status"] = "connected-read-only"
+    meta_goal["control_plane"] = {
+        "self_repair": {
+            "enabled": True,
+            "allow_health_blocker_repair": True,
+            "allow_waiting_projection_repair": True,
+        }
+    }
+    meta_item = attention(goal_id, compute=1.0)
+    meta_item["status"] = "handoff_only_budget_fields_merged"
+    meta_item["recommended_action"] = "continue the ongoing interface-budget observation loop"
+    meta_item["handoff_readiness"] = {
+        "ready": True,
+        "codex_ready": True,
+        "source": "project_asset",
+        "quota_state": "eligible",
+        "handoff_status": "post_handoff_run_seen",
+        "post_handoff_run_seen": True,
+        "post_handoff_small_scale_streak": 0,
+        "post_handoff_latest_run": {
+            "generated_at": "2026-06-06T21:35:46+08:00",
+            "classification": "handoff_only_budget_fields_merged",
+            "delivery_batch_scale": "implementation",
+            "delivery_outcome": "primary_goal_outcome",
+            "health_check": "state_file 1/1; registry_goal 1/1",
+            "json_exists": True,
+            "markdown_exists": True,
+        },
+    }
+    meta_item["agent_todos"] = {
+        "source_section": "Agent Todo",
+        "total_count": 1,
+        "open_count": 1,
+        "done_count": 0,
+        "items": [
+            {
+                "index": 1,
+                "done": False,
+                "text": "Keep heartbeat prompt and agent-to-CLI interaction lean as an ongoing interface-budget task.",
+            }
+        ],
+    }
+    payload = {
+        "ok": True,
+        "registry": "./fixtures/registry.json",
+        "runtime_root": "./fixtures/runtime",
+        "goal_count": 1,
+        "run_count": 1,
+        "attention_queue": {"items": [meta_item]},
+        "run_history": {"goals": [meta_goal]},
+    }
+
+    decision = build_quota_should_run(payload, goal_id=goal_id)
+    markdown = render_quota_should_run_markdown(decision)
+
+    assert decision["ok"] is True, decision
+    assert decision["decision"] == "run", decision
+    assert decision["should_run"] is True, decision
+    assert decision["normal_delivery_allowed"] is True, decision
+    assert decision["self_repair_allowed"] is False, decision
+    assert decision["effective_action"] == "normal_run", decision
+    assert decision["agent_todo_summary"]["open_count"] == 1, decision
+    assert (
+        decision["heartbeat_recommendation"]["recommended_mode"]
+        == "post_handoff_observe_if_unchanged"
+    ), decision
+    assert decision["heartbeat_recommendation"]["stop_if_unchanged"] is True, decision
+    assert decision["heartbeat_recommendation"]["latest_run"]["delivery_outcome"] == "primary_goal_outcome", decision
+    assert decision["execution_obligation"]["must_attempt_work"] is False, decision
+    assert decision["execution_obligation"]["kind"] == "quiet_noop_if_unchanged", decision
+    assert "post_handoff_observe_if_unchanged" in markdown, markdown
+    assert "heartbeat_stop_if_unchanged: `True`" in markdown, markdown
+    assert (
+        "execution_obligation: must_attempt_work=False kind=quiet_noop_if_unchanged notify_is_execution_gate=False"
+        in markdown
+    ), markdown
+
+
 def assert_attention_queue_overrides_stale_run_history() -> None:
     stale_goal = goal("queue-authority", compute=1.0)
     stale_goal["status"] = "operator_gate_deferred"
@@ -1359,6 +1441,7 @@ def main() -> int:
     assert_control_plane_health_self_repair_should_run()
     assert_control_plane_self_repair_default_off()
     assert_control_plane_waiting_projection_self_repair_should_run()
+    assert_control_plane_post_handoff_observe_if_unchanged()
     assert_attention_queue_overrides_stale_run_history()
     assert_project_asset_backed_no_evidence_should_run()
     assert_heartbeat_recommendation_lifecycle()

--- a/goal_harness/quota.py
+++ b/goal_harness/quota.py
@@ -769,6 +769,61 @@ def _stall_self_repair_hint(
     return None
 
 
+def _control_plane_post_handoff_observation_hint(item: dict[str, Any]) -> dict[str, Any] | None:
+    control_plane = compact_control_plane_policy(item.get("control_plane"))
+    self_repair = (
+        control_plane.get("self_repair")
+        if isinstance(control_plane.get("self_repair"), dict)
+        else {}
+    )
+    if self_repair.get("enabled") is not True:
+        return None
+    if str(item.get("adapter_kind") or "") != "harness_self_improvement":
+        return None
+    if item.get("agent_command"):
+        return None
+
+    handoff_readiness = (
+        item.get("handoff_readiness")
+        if isinstance(item.get("handoff_readiness"), dict)
+        else {}
+    )
+    latest_run = (
+        handoff_readiness.get("post_handoff_latest_run")
+        if isinstance(handoff_readiness.get("post_handoff_latest_run"), dict)
+        else {}
+    )
+    if handoff_readiness.get("post_handoff_run_seen") is not True:
+        return None
+    if str(handoff_readiness.get("handoff_status") or "") != "post_handoff_run_seen":
+        return None
+    if str(latest_run.get("delivery_outcome") or "") != "primary_goal_outcome":
+        return None
+
+    return {
+        "source": "quota.should-run",
+        "recommended_mode": "post_handoff_observe_if_unchanged",
+        "stop_if_unchanged": True,
+        "notify": "DONT_NOTIFY",
+        "reason": (
+            "control-plane self-repair is enabled and the latest post-handoff "
+            "implementation run already reached the primary outcome; inspect "
+            "registry/status/run history/repo state, then stay quiet if no new "
+            "evidence or concrete safe work is found"
+        ),
+        "spend_policy": (
+            "do not append quota spend for an unchanged post-handoff observation; "
+            "spend only after a new validated artifact, repair, or durable state "
+            "writeback advances the control-plane contract"
+        ),
+        "latest_run": {
+            key: latest_run.get(key)
+            for key in POST_HANDOFF_RUN_COMPACT_FIELDS
+            if latest_run.get(key) is not None
+        },
+    }
+
+
 def _heartbeat_recommendation(
     item: dict[str, Any],
     *,
@@ -873,6 +928,13 @@ def _heartbeat_recommendation(
             "reason": "latest compact read-only map already exists; wait for new evidence or a concrete safe action",
         }
 
+    post_handoff_observation = _control_plane_post_handoff_observation_hint(item)
+    if post_handoff_observation and not has_user_todos:
+        return {
+            **base,
+            **post_handoff_observation,
+        }
+
     if item.get("agent_command"):
         return {
             **base,
@@ -906,8 +968,8 @@ def _execution_obligation(
             "kind": "quiet_noop_if_unchanged",
             "notify_is_execution_gate": False,
             "reason": (
-                "this mode allows a quiet no-op only after confirming the mapped source "
-                "is unchanged and no concrete safe handoff exists"
+                "this mode allows a quiet no-op only after confirming the current state "
+                "source is unchanged and no concrete safe handoff exists"
             ),
         }
     if should_run:


### PR DESCRIPTION
## Summary
- add a control-plane-scoped post-handoff observation recommendation for Goal Harness self-improvement goals
- keep should-run visible while allowing short heartbeats to quiet no-op after a primary-outcome post-handoff run is unchanged
- add quota-plan smoke coverage with an ongoing agent todo still present

## Validation
- python3 -m py_compile goal_harness/quota.py examples/quota-plan-smoke.py
- python3 examples/quota-plan-smoke.py
- python3 examples/run-smokes.py
- PYTHONPATH=/Users/bytedance/goal-harness python3 -m goal_harness.cli --registry "/Users/bytedance/.codex/goal-harness/registry.global.json" --format json quota should-run --goal-id goal-harness-meta
- PYTHONPATH=/Users/bytedance/goal-harness python3 -m goal_harness.cli check --scan-root .
- git diff --check