### PR TITLE
Collapse source registry shadows in status queue

### DIFF
--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -454,7 +454,11 @@ Current finding kinds:
 
 High and action findings are also lifted into `attention_queue.items` with
 `source=global_registry`; informational scope findings stay in the global
-registry panel so local project views are not noisy.
+registry panel so local project views are not noisy. Source-registry provenance
+findings (`source_registry_missing` / `stale_source_registry`) are collapsed into
+the live quota-backed queue item for the same `goal_id` when one exists, under
+`global_registry_shadow_findings`, so stale source shadows do not become a second
+quota health blocker while the fact remains visible in `global_registry.findings`.
 
 ## Contract Health
 

--- a/examples/status-markdown-smoke.py
+++ b/examples/status-markdown-smoke.py
@@ -219,6 +219,32 @@ def write_connected_delivery_registry(root: Path) -> Path:
     return registry_path
 
 
+def write_global_source_registry_shadow(root: Path, registry_path: Path, *, goal_id: str) -> None:
+    runtime = root / "runtime"
+    local_registry = json.loads(registry_path.read_text(encoding="utf-8"))
+    goals = local_registry.get("goals") if isinstance(local_registry.get("goals"), list) else []
+    local_goal = next(goal for goal in goals if isinstance(goal, dict) and goal.get("id") == goal_id)
+    shadow_goal = dict(local_goal)
+    shadow_goal["source_registry"] = str(root / "missing-source" / "registry.json")
+    shadow_goal["synced_at"] = "2026-01-01T00:00:00+00:00"
+    runtime.mkdir(parents=True, exist_ok=True)
+    (runtime / "registry.global.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "common_runtime_root": str(runtime),
+                "goals": [shadow_goal],
+            },
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
 def write_connected_readonly_registry(root: Path) -> Path:
     project = root / "project"
     runtime = root / "runtime"
@@ -1433,6 +1459,28 @@ def assert_connected_delivery_custom_run_stays_runnable(payload: dict, markdown:
     assert "goal_boundary_orchestration: mode=multi_subagent spawn_allowed=True max_children=2" in quota_markdown, quota_markdown
 
 
+def assert_source_registry_shadow_collapses_into_live_queue_item(payload: dict) -> None:
+    registry_summary = payload["global_registry"]["summary"]
+    assert registry_summary["action"] == 1, payload["global_registry"]
+    assert "source_registry_missing" in json.dumps(payload["global_registry"], ensure_ascii=False), payload
+
+    items = payload["attention_queue"]["items"]
+    goal_items = [item for item in items if item["goal_id"] == DELIVERY_GOAL_ID]
+    assert len(goal_items) == 1, items
+    item = goal_items[0]
+    assert item["status"] == "delivery_ranker_readiness_batch", item
+    assert item["source"] == "latest_run", item
+    assert not any(queue_item["status"] == "source_registry_missing" for queue_item in items), items
+    shadows = item["global_registry_shadow_findings"]
+    assert shadows[0]["kind"] == "source_registry_missing", shadows
+    assert item["project_asset"]["global_registry_shadow_findings"]["open"] == 1, item
+
+    quota_payload = build_quota_should_run(payload, goal_id=DELIVERY_GOAL_ID)
+    assert quota_payload["should_run"] is True, quota_payload
+    assert quota_payload["state"] == "eligible", quota_payload
+    assert quota_payload["plan_summary"]["health_blockers"] == 0, quota_payload
+
+
 def assert_connected_readonly_progress_run_stays_runnable(payload: dict, markdown: str) -> None:
     items = payload["attention_queue"]["items"]
     assert len(items) == 1, items
@@ -1826,6 +1874,12 @@ def main() -> int:
         delivery_registry_path = write_connected_delivery_registry(root)
         append_connected_delivery_fixture(root, generated_at="2026-01-01T00:05:00+00:00")
         delivery_payload, delivery_markdown = collect_fixture_status(root, delivery_registry_path)
+    with tempfile.TemporaryDirectory(prefix="goal-harness-status-source-registry-shadow-") as tmp:
+        root = Path(tmp)
+        shadow_registry_path = write_connected_delivery_registry(root)
+        write_global_source_registry_shadow(root, shadow_registry_path, goal_id=DELIVERY_GOAL_ID)
+        append_connected_delivery_fixture(root, generated_at="2026-01-01T00:05:00+00:00")
+        shadow_payload, _shadow_markdown = collect_fixture_status(root, shadow_registry_path)
     with tempfile.TemporaryDirectory(prefix="goal-harness-status-explicit-refresh-scale-") as tmp:
         root = Path(tmp)
         explicit_registry_path = write_connected_delivery_registry(root)
@@ -1947,6 +2001,7 @@ def main() -> int:
     )
     assert_registry_attention_override(override_payload, override_markdown)
     assert_connected_delivery_custom_run_stays_runnable(delivery_payload, delivery_markdown)
+    assert_source_registry_shadow_collapses_into_live_queue_item(shadow_payload)
     assert_explicit_delivery_refresh(explicit_payload, explicit_markdown)
     assert_connected_readonly_progress_run_stays_runnable(readonly_payload, readonly_markdown)
     assert_dependency_blockers_stay_separate(dependency_payload, dependency_markdown)

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -153,6 +153,10 @@ CONNECTED_ADAPTER_STATUSES = {
 CONNECTED_DELIVERY_ADAPTER_STATUSES = {
     "connected-delivery",
 }
+SOURCE_REGISTRY_SHADOW_FINDINGS = {
+    "source_registry_missing",
+    "stale_source_registry",
+}
 PLANNED_CONTROLLER_OPT_IN_RECOMMENDED_ACTION = (
     "先在 Goal Harness 完成 operator 判断；同意后项目 Agent 只执行 read-only map dry-run"
 )
@@ -1013,6 +1017,36 @@ def attention_item(
     return item
 
 
+def compact_global_registry_shadow_finding(finding: dict[str, Any]) -> dict[str, Any]:
+    compact: dict[str, Any] = {
+        "kind": str(finding.get("kind") or "global_registry_finding"),
+        "severity": str(finding.get("severity") or "action"),
+        "source": "global_registry",
+    }
+    if finding.get("message"):
+        compact["message"] = str(finding.get("message"))
+    if finding.get("recommended_action"):
+        compact["recommended_action"] = str(finding.get("recommended_action"))
+    return compact
+
+
+def attach_global_registry_shadow_finding(item: dict[str, Any], finding: dict[str, Any]) -> None:
+    shadows = item.setdefault("global_registry_shadow_findings", [])
+    if isinstance(shadows, list):
+        shadows.append(compact_global_registry_shadow_finding(finding))
+    project_asset = item.get("project_asset")
+    if not isinstance(project_asset, dict):
+        return
+    summary = project_asset.setdefault("global_registry_shadow_findings", {"open": 0, "kinds": []})
+    if not isinstance(summary, dict):
+        return
+    summary["open"] = int(summary.get("open") or 0) + 1
+    kinds = summary.setdefault("kinds", [])
+    kind = str(finding.get("kind") or "global_registry_finding")
+    if isinstance(kinds, list) and kind not in kinds:
+        kinds.append(kind)
+
+
 def parse_timestamp(value: Any) -> datetime | None:
     if not value:
         return None
@@ -1556,9 +1590,10 @@ def build_attention_queue(
     history: dict[str, Any],
     global_registry: dict[str, Any],
 ) -> dict[str, Any]:
-    items: list[dict[str, Any]] = []
+    health_items: list[dict[str, Any]] = []
+    history_items: list[dict[str, Any]] = []
     if contract.get("ok") is False:
-        items.append(
+        health_items.append(
             attention_item(
                 goal_id="goal-harness-contract",
                 status="contract_check_failed",
@@ -1566,22 +1601,6 @@ def build_attention_queue(
                 severity="high",
                 recommended_action="fix contract errors before advancing goal adapters",
                 source="contract",
-            )
-        )
-    for finding in global_registry.get("findings") or []:
-        if not isinstance(finding, dict):
-            continue
-        if finding.get("severity") not in {"high", "action"}:
-            continue
-        goal_id = str(finding.get("goal_id") or "global-registry")
-        items.append(
-            attention_item(
-                goal_id=goal_id,
-                status=str(finding.get("kind") or "global_registry_finding"),
-                waiting_on="codex",
-                severity=str(finding.get("severity") or "action"),
-                recommended_action=str(finding.get("recommended_action") or "inspect global registry health"),
-                source="global_registry",
             )
         )
 
@@ -1647,8 +1666,36 @@ def build_attention_queue(
                         quota=guarded_quota,
                         latest_runs=goal_latest_runs,
                     )
-            items.append(item)
+            history_items.append(item)
 
+    live_quota_items_by_goal: dict[str, list[dict[str, Any]]] = {}
+    for item in history_items:
+        if isinstance(item.get("quota"), dict):
+            live_quota_items_by_goal.setdefault(str(item.get("goal_id") or ""), []).append(item)
+
+    for finding in global_registry.get("findings") or []:
+        if not isinstance(finding, dict):
+            continue
+        if finding.get("severity") not in {"high", "action"}:
+            continue
+        goal_id = str(finding.get("goal_id") or "global-registry")
+        live_items = live_quota_items_by_goal.get(goal_id, [])
+        if finding.get("kind") in SOURCE_REGISTRY_SHADOW_FINDINGS and live_items:
+            for item in live_items:
+                attach_global_registry_shadow_finding(item, finding)
+            continue
+        health_items.append(
+            attention_item(
+                goal_id=goal_id,
+                status=str(finding.get("kind") or "global_registry_finding"),
+                waiting_on="codex",
+                severity=str(finding.get("severity") or "action"),
+                recommended_action=str(finding.get("recommended_action") or "inspect global registry health"),
+                source="global_registry",
+            )
+        )
+
+    items = [*health_items, *history_items]
     attach_dependency_blockers(items)
     backlog_candidates = autonomous_backlog_candidates(items)
 


### PR DESCRIPTION
## Summary
- Collapse source-registry provenance findings into the live quota-backed attention item for the same goal id
- Keep the fact visible in global_registry.findings and attach a compact global_registry_shadow_findings summary to the live item
- Add a status/quota smoke proving source_registry_missing no longer becomes a duplicate health blocker

## Validation
- python3 examples/status-markdown-smoke.py
- python3 examples/quota-plan-smoke.py
- python3 examples/run-smokes.py
- PYTHONPATH=/Users/bytedance/goal-harness python3 -m goal_harness.cli check --scan-root .
- installed canary doctor plus live quota/status verification for goal-harness-meta
