### PR TITLE
Expose top open agent todo projections

### DIFF
--- a/apps/dashboard/src/data/status.ts
+++ b/apps/dashboard/src/data/status.ts
@@ -68,10 +68,13 @@ export const todoGroupSchema = z.object({
 });
 
 export const projectAssetTodoSummarySchema = z.object({
+  source_section: z.string().optional().nullable(),
   open: z.number().optional().default(0),
   done: z.number().optional().default(0),
   total: z.number().optional().default(0),
   next: z.string().optional().nullable(),
+  next_index: z.number().optional().nullable(),
+  items: z.array(todoItemSchema).optional().default([]),
 });
 
 export const dependencyBlockerSchema = z.object({

--- a/apps/dashboard/src/views/dashboard-page.tsx
+++ b/apps/dashboard/src/views/dashboard-page.tsx
@@ -898,16 +898,19 @@ function todosFromProjectAssetSummary(
   }
   const next = summary.next?.trim();
   const fallbackFirstOpen = firstOpenTodo(fallback);
+  const summaryItems = (summary.items ?? []).filter((item) => !item.done && item.text?.trim());
   return {
-    source_section: fallback?.source_section ?? sourceSection,
+    source_section: summary.source_section ?? fallback?.source_section ?? sourceSection,
     total_count: summary.total ?? fallback?.total_count ?? 0,
     open_count: summary.open ?? fallback?.open_count ?? 0,
     done_count: summary.done ?? fallback?.done_count ?? 0,
     items: fallback?.items?.length
       ? fallback.items
+      : summaryItems.length
+        ? summaryItems
       : (next
           ? [{
-              index: fallbackFirstOpen?.index ?? 1,
+              index: summary.next_index ?? fallbackFirstOpen?.index ?? 1,
               done: false,
               text: next,
               review_materials: fallbackFirstOpen?.review_materials ?? [],

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -655,11 +655,16 @@ Item fields:
 - `user_todos`: optional checkbox summary parsed from the active state's
   `## User Todo ...` / `## Owner Review Reading Queue` section. Dashboard
   consumers should render the first unfinished item as the human-facing next
-  step, while keeping `recommended_action` as routing context.
+  step, while keeping `recommended_action` as routing context. The compact
+  `project_asset.user_todos` projection keeps legacy `next` / `next_index`
+  fields and may also include up to three unfinished `items` for thin workers
+  that need more than the first open todo.
 - `agent_todos`: optional checkbox summary parsed from `## Agent Todo`,
   `## Codex Todo`, or `## Project Agent Todo`. Agent-facing consumers may use
   it to choose implementation work after gates and quota allow execution; it is
-  not a user approval signal.
+  not a user approval signal. Status, quota, and review-packet projections
+  should preserve up to three unfinished agent todo items so short heartbeats do
+  not confuse "first visible item" with the whole backlog.
 - `dependency_blockers`: optional compact summary of unfinished user todos from
   other current attention-queue goals. This lets dashboards and heartbeat
   dispatchers show sibling/project dependency gates separately from the current

--- a/examples/todo-first-open-summary-smoke.py
+++ b/examples/todo-first-open-summary-smoke.py
@@ -12,6 +12,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from goal_harness.quota import build_quota_should_run, render_quota_should_run_markdown  # noqa: E402
+from goal_harness.review_packet import build_review_packet  # noqa: E402
 from goal_harness.status import (  # noqa: E402
     compact_todo_group,
     parse_active_state_todos,
@@ -24,6 +25,8 @@ OPEN_TODO = (
     "[P1] Keep heartbeat prompt and agent-to-CLI interaction lean as an ongoing "
     "interface-budget task."
 )
+SECOND_OPEN_TODO = "[P1] Add stale latest-run detection before workers trust run projections."
+THIRD_OPEN_TODO = "[P1] Reconcile outcome-floor safe-bypass incident gaps into smokes."
 
 
 def build_truncated_todo_group() -> dict:
@@ -32,13 +35,16 @@ def build_truncated_todo_group() -> dict:
         for index in range(1, 14)
     ]
     items.append({"index": 14, "done": False, "text": OPEN_TODO})
+    items.append({"index": 15, "done": False, "text": SECOND_OPEN_TODO})
+    items.append({"index": 16, "done": False, "text": THIRD_OPEN_TODO})
     group = compact_todo_group(items, source_section="Agent Todo")
     assert group is not None, group
     assert len(group["items"]) == 12, group
     assert all(item["done"] for item in group["items"]), group
-    assert group["open_count"] == 1, group
+    assert group["open_count"] == 3, group
     assert group["first_open_items"][0]["index"] == 14, group
     assert group["first_open_items"][0]["text"] == OPEN_TODO, group
+    assert [item["index"] for item in group["first_open_items"]] == [14, 15, 16], group
     return group
 
 
@@ -52,12 +58,15 @@ def parse_multiline_deep_open_todo() -> dict:
         f"{done_lines}\n"
         "- [ ] [P1] Keep heartbeat prompt and agent-to-CLI interaction lean as an\n"
         "  ongoing interface-budget task.\n"
+        f"- [ ] {SECOND_OPEN_TODO}\n"
+        f"- [ ] {THIRD_OPEN_TODO}\n"
     )
     group = parse_active_state_todos(state_text)["agent_todos"]
     assert len(group["items"]) == 12, group
-    assert group["open_count"] == 1, group
+    assert group["open_count"] == 3, group
     assert group["first_open_items"][0]["index"] == 14, group
     assert group["first_open_items"][0]["text"] == OPEN_TODO, group
+    assert [item["index"] for item in group["first_open_items"]] == [14, 15, 16], group
     return group
 
 
@@ -67,9 +76,10 @@ def main() -> int:
     assert parsed_agent_todos["first_open_items"] == agent_todos["first_open_items"], parsed_agent_todos
     asset_summary = project_asset_todo_summary(agent_todos)
     assert asset_summary is not None, agent_todos
-    assert asset_summary["open"] == 1, asset_summary
+    assert asset_summary["open"] == 3, asset_summary
     assert asset_summary["next"] == OPEN_TODO, asset_summary
     assert asset_summary["next_index"] == 14, asset_summary
+    assert [item["index"] for item in asset_summary["items"]] == [14, 15, 16], asset_summary
 
     attention_item = {
         "goal_id": GOAL_ID,
@@ -120,11 +130,17 @@ def main() -> int:
     decision = build_quota_should_run(status_payload, goal_id=GOAL_ID)
     assert decision["should_run"] is True, decision
     agent_summary = decision["agent_todo_summary"]
-    assert agent_summary["open_count"] == 1, decision
+    assert agent_summary["open_count"] == 3, decision
     assert agent_summary["first_open_items"][0]["index"] == 14, decision
     assert agent_summary["first_open_items"][0]["text"] == OPEN_TODO, decision
+    assert [item["index"] for item in agent_summary["first_open_items"]] == [14, 15, 16], decision
     markdown = render_quota_should_run_markdown(decision)
     assert f"agent_todo_next[14]: {OPEN_TODO}" in markdown, markdown
+    assert f"agent_todo_next[15]: {SECOND_OPEN_TODO}" in markdown, markdown
+    packet = build_review_packet(status_payload, goal_id=GOAL_ID, action_kind="codex")
+    assert packet["agent_todo_items"] == [OPEN_TODO, SECOND_OPEN_TODO, THIRD_OPEN_TODO], packet
+    assert f"Agent 待办：{OPEN_TODO}" in packet["project_agent_handoff"], packet
+    assert f"Agent 待办候选 2：{SECOND_OPEN_TODO}" in packet["project_agent_handoff"], packet
     print("todo-first-open-summary-smoke ok")
     return 0
 

--- a/goal_harness/quota.py
+++ b/goal_harness/quota.py
@@ -482,15 +482,29 @@ def _summarize_user_todos(value: Any) -> dict[str, Any] | None:
 def _summarize_project_asset_todos(value: Any) -> dict[str, Any] | None:
     if not isinstance(value, dict):
         return None
-    if isinstance(value.get("items"), list):
+    if isinstance(value.get("items"), list) and (
+        "total_count" in value or "open_count" in value or "done_count" in value
+    ):
         return _summarize_user_todos(value)
 
-    next_text = str(value.get("next") or "").strip()
-    next_index = value.get("next_index", 1)
-    first_open_items = [{"index": next_index, "text": next_text}] if next_text else []
+    first_open_items: list[dict[str, Any]] = []
+    items = value.get("items") if isinstance(value.get("items"), list) else []
+    for item in items:
+        if not isinstance(item, dict) or item.get("done") is True:
+            continue
+        text = str(item.get("text") or "").strip()
+        if not text:
+            continue
+        first_open_items.append({"index": item.get("index"), "text": text})
+        if len(first_open_items) >= 3:
+            break
+    if not first_open_items:
+        next_text = str(value.get("next") or "").strip()
+        next_index = value.get("next_index", 1)
+        first_open_items = [{"index": next_index, "text": next_text}] if next_text else []
     open_count = value.get("open", value.get("open_count", len(first_open_items)))
     return {
-        "source_section": "project_asset",
+        "source_section": value.get("source_section") or "project_asset",
         "total_count": value.get("total", value.get("total_count")),
         "open_count": open_count,
         "done_count": value.get("done", value.get("done_count")),

--- a/goal_harness/review_packet.py
+++ b/goal_harness/review_packet.py
@@ -204,30 +204,46 @@ def decision_freshness_packet_lines(warning: dict[str, Any] | None) -> list[str]
     return [redact_local_absolute_paths(line) for line in lines]
 
 
-def first_open_todo_text(todos: Any) -> str | None:
+def open_todo_texts(todos: Any, *, limit: int = 3) -> list[str]:
     if not isinstance(todos, dict):
-        return None
-    items = todos.get("items")
-    if not isinstance(items, list):
-        return None
+        return []
+    items = todos.get("items") if isinstance(todos.get("items"), list) else []
+    if not items and isinstance(todos.get("first_open_items"), list):
+        items = todos.get("first_open_items") or []
+    result: list[str] = []
     for item in items:
         if not isinstance(item, dict) or item.get("done"):
             continue
         text = str(item.get("text") or "").strip()
         if text:
-            return compact_packet_text(text)
-    return None
+            result.append(compact_packet_text(text))
+            if len(result) >= limit:
+                return result
+    return result
+
+
+def first_open_todo_text(todos: Any) -> str | None:
+    items = open_todo_texts(todos, limit=1)
+    return items[0] if items else None
 
 
 def todo_text_from_project_asset(item: dict[str, Any] | None, key: str) -> str | None:
+    items = todo_texts_from_project_asset(item, key, limit=1)
+    return items[0] if items else None
+
+
+def todo_texts_from_project_asset(item: dict[str, Any] | None, key: str, *, limit: int = 3) -> list[str]:
     if not isinstance(item, dict):
-        return None
+        return []
     project_asset = item.get("project_asset") if isinstance(item.get("project_asset"), dict) else {}
     summary = project_asset.get(key) if isinstance(project_asset.get(key), dict) else {}
+    summary_items = open_todo_texts(summary, limit=limit)
+    if summary_items:
+        return summary_items
     next_text = str(summary.get("next") or "").strip()
     if next_text:
-        return compact_packet_text(next_text)
-    return first_open_todo_text(item.get(key))
+        return [compact_packet_text(next_text)]
+    return open_todo_texts(item.get(key), limit=limit)
 
 
 def project_asset_source(item: dict[str, Any] | None) -> str:
@@ -584,6 +600,7 @@ def project_agent_section(
     goal_id: str,
     *,
     agent_todo_text: str | None = None,
+    agent_todo_items: list[str] | None = None,
     authority_summary: str | None = None,
     project_asset_source_text: str | None = None,
     handoff_followthrough_text: str | None = None,
@@ -594,6 +611,11 @@ def project_agent_section(
     goal_guard = target_goal_guard(goal_id)
     context_rule = agent_context_rule()
     todo_line = f"Agent 待办：{agent_todo_text}" if agent_todo_text else None
+    extra_todo_lines = [
+        f"Agent 待办候选 {index + 2}：{text}"
+        for index, text in enumerate((agent_todo_items or [])[1:3])
+        if text
+    ]
     authority_line = f"材料上下文：{authority_summary}；只用这些脱敏计数判断 freshness / owner gap，不要要求内部链接或原文。" if authority_summary else None
     source_line = f"项目资产来源：{project_asset_source_text}" if project_asset_source_text else None
     followthrough_line = f"交付观测：{handoff_followthrough_text}" if handoff_followthrough_text else None
@@ -604,6 +626,7 @@ def project_agent_section(
             context_rule,
             source_line,
             todo_line,
+            *extra_todo_lines,
             authority_line,
             followthrough_line,
             delivery_contract_line,
@@ -619,6 +642,7 @@ def project_agent_section(
             context_rule,
             source_line,
             todo_line,
+            *extra_todo_lines,
             authority_line,
             followthrough_line,
             delivery_contract_line,
@@ -634,6 +658,7 @@ def project_agent_section(
             context_rule,
             source_line,
             todo_line,
+            *extra_todo_lines,
             authority_line,
             followthrough_line,
             delivery_contract_line,
@@ -649,6 +674,7 @@ def project_agent_section(
             context_rule,
             source_line,
             todo_line,
+            *extra_todo_lines,
             authority_line,
             followthrough_line,
             delivery_contract_line,
@@ -664,6 +690,7 @@ def project_agent_section(
             context_rule,
             source_line,
             todo_line,
+            *extra_todo_lines,
             authority_line,
             followthrough_line,
             delivery_contract_line,
@@ -679,6 +706,7 @@ def project_agent_section(
             context_rule,
             source_line,
             todo_line,
+            *extra_todo_lines,
             authority_line,
             followthrough_line,
             delivery_contract_line,
@@ -712,7 +740,8 @@ def build_review_packet(
     question = str(item.get("operator_question") or prompt["question"]) if isinstance(item, dict) else prompt["question"]
     summary = str(item.get("recommended_action") or "当前状态源没有对应的 action card。") if isinstance(item, dict) else "当前状态源没有对应的 action card。"
     user_todo_text = todo_text_from_project_asset(item, "user_todos")
-    agent_todo_text = todo_text_from_project_asset(item, "agent_todos")
+    agent_todo_items = todo_texts_from_project_asset(item, "agent_todos")
+    agent_todo_text = agent_todo_items[0] if agent_todo_items else None
     asset_source = project_asset_source(item)
     asset_source_line = project_asset_source_line(asset_source)
     authority_summary = authority_material_summary(goal)
@@ -742,6 +771,7 @@ def build_review_packet(
         command,
         goal_id,
         agent_todo_text=agent_todo_text,
+        agent_todo_items=agent_todo_items,
         authority_summary=authority_summary,
         project_asset_source_text=asset_source_line,
         handoff_followthrough_text=followthrough_summary,
@@ -813,6 +843,7 @@ def build_review_packet(
         "user_todo_text": user_todo_text,
         "owner_blocker_text": owner_blocker_text,
         "agent_todo_text": agent_todo_text,
+        "agent_todo_items": agent_todo_items,
         "authority_summary": authority_summary,
         "handoff_followthrough_summary": followthrough_summary,
         "handoff_delivery_contract": delivery_contract,

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -252,6 +252,7 @@ AGENT_TODO_HEADER_MARKERS = (
     "project agent todo",
 )
 MAX_STATUS_TODOS_PER_ROLE = 12
+MAX_PROJECT_ASSET_TODO_ITEMS = 3
 MAX_DEPENDENCY_BLOCKERS = 4
 MAX_AUTONOMOUS_BACKLOG_CANDIDATES = 6
 AUTONOMOUS_PRIORITY_PATTERN = re.compile(r"^\s*\[(P[0-4][^\]]*)\]\s*(.+)$", re.IGNORECASE)
@@ -421,38 +422,63 @@ def project_asset_stop_condition(
     return "stop if the next action needs reward, gate approval, write control, or production access"
 
 
-def first_open_todo_text(todos: dict[str, Any] | None) -> str | None:
+def open_todo_items(
+    todos: dict[str, Any] | None,
+    *,
+    limit: int = MAX_PROJECT_ASSET_TODO_ITEMS,
+    text_limit: int = 220,
+) -> list[dict[str, Any]]:
     if not isinstance(todos, dict):
+        return []
+    result: list[dict[str, Any]] = []
+    seen: set[tuple[Any, str]] = set()
+    for source_items in (todos.get("first_open_items"), todos.get("items")):
+        if not isinstance(source_items, list):
+            continue
+        for item in source_items:
+            if not isinstance(item, dict) or item.get("done"):
+                continue
+            text = normalize_todo_text(str(item.get("text") or ""), limit=text_limit)
+            if not text:
+                continue
+            key = (item.get("index"), text)
+            if key in seen:
+                continue
+            seen.add(key)
+            result.append(
+                {
+                    "index": item.get("index"),
+                    "done": False,
+                    "text": text,
+                }
+            )
+            if len(result) >= limit:
+                return result
+    return result
+
+
+def first_open_todo_text(todos: dict[str, Any] | None) -> str | None:
+    items = open_todo_items(todos, limit=1)
+    if not items:
         return None
-    for item in todos.get("first_open_items") or []:
-        if not isinstance(item, dict) or item.get("done"):
-            continue
-        text = normalize_todo_text(str(item.get("text") or ""), limit=220)
-        return text or None
-    for item in todos.get("items") or []:
-        if not isinstance(item, dict) or item.get("done"):
-            continue
-        text = normalize_todo_text(str(item.get("text") or ""), limit=220)
-        return text or None
-    return None
+    return str(items[0].get("text") or "") or None
 
 
 def project_asset_todo_summary(todos: dict[str, Any] | None) -> dict[str, Any] | None:
     if not isinstance(todos, dict):
         return None
     summary: dict[str, Any] = {
+        "source_section": "project_asset",
         "open": todos.get("open_count", 0),
         "done": todos.get("done_count", 0),
         "total": todos.get("total_count", 0),
     }
-    next_item = first_open_todo_text(todos)
-    if next_item:
-        summary["next"] = next_item
-        first_open_items = todos.get("first_open_items")
-        if isinstance(first_open_items, list) and first_open_items:
-            first_open = first_open_items[0]
-            if isinstance(first_open, dict) and first_open.get("index") is not None:
-                summary["next_index"] = first_open.get("index")
+    open_items = open_todo_items(todos)
+    if open_items:
+        summary["items"] = open_items
+        summary["next"] = open_items[0]["text"]
+        if open_items[0].get("index") is not None:
+            summary["next_index"] = open_items[0].get("index")
     return summary
 
 
@@ -2773,8 +2799,18 @@ def render_status_markdown(payload: dict[str, Any]) -> str:
                 lines.append(f"    - asset_todos: {' '.join(todo_parts)}")
                 if asset_user_todos.get("next"):
                     lines.append(f"      - asset_user_todo: {_markdown_scalar(asset_user_todos.get('next') or '')}")
+                for todo in (asset_user_todos.get("items") or [])[1:3]:
+                    if isinstance(todo, dict) and todo.get("text"):
+                        index = todo.get("index")
+                        suffix = f"[{index}]" if index is not None else ""
+                        lines.append(f"      - asset_user_todo{suffix}: {_markdown_scalar(todo.get('text') or '')}")
                 if asset_agent_todos.get("next"):
                     lines.append(f"      - asset_agent_todo: {_markdown_scalar(asset_agent_todos.get('next') or '')}")
+                for todo in (asset_agent_todos.get("items") or [])[1:3]:
+                    if isinstance(todo, dict) and todo.get("text"):
+                        index = todo.get("index")
+                        suffix = f"[{index}]" if index is not None else ""
+                        lines.append(f"      - asset_agent_todo{suffix}: {_markdown_scalar(todo.get('text') or '')}")
             asset_quota = (
                 project_asset.get("quota")
                 if isinstance(project_asset.get("quota"), dict)


### PR DESCRIPTION
## Summary
- Preserve up to three unfinished todo items in compact project-asset todo projections while keeping legacy next fields
- Let quota should-run and review packets surface multiple open agent todos instead of only the first item
- Teach the dashboard status schema to consume compact todo items from project_asset summaries

## Validation
- python3 examples/todo-first-open-summary-smoke.py
- python3 examples/quota-plan-smoke.py
- python3 examples/status-markdown-smoke.py
- python3 examples/review-packet-cli-smoke.py
- python3 examples/check-public-boundary-smoke.py
- PYTHONPATH=. python3 -m goal_harness.cli check --scan-root .
- cd apps/dashboard && npm exec -- tsc --noEmit
- python3 examples/run-smokes.py

## Note
- npm --prefix apps/dashboard run build still fails locally in Vite/rolldown native binding loading due macOS code-signature mismatch in node_modules; TypeScript compilation passes before that Vite step.
