### PR TITLE
Warn on stale latest-run projections

### DIFF
--- a/apps/dashboard/src/data/status.ts
+++ b/apps/dashboard/src/data/status.ts
@@ -116,6 +116,19 @@ export const projectAssetLatestValidationSchema = z.object({
   summary: z.string().optional().nullable(),
 });
 
+export const staleLatestRunWarningSchema = z.object({
+  kind: z.string().optional().nullable(),
+  source: z.string().optional().nullable(),
+  severity: z.string().optional().nullable(),
+  requires_refresh_state: z.boolean().optional().default(false),
+  reason: z.string().optional().nullable(),
+  active_state_updated_at: z.string().optional().nullable(),
+  latest_run_generated_at: z.string().optional().nullable(),
+  latest_run_state_updated_at: z.string().optional().nullable(),
+  latest_run_classification: z.string().optional().nullable(),
+  recommended_action: z.string().optional().nullable(),
+});
+
 export const postHandoffRunSchema = z.object({
   generated_at: z.string().optional().nullable(),
   classification: z.string().optional().nullable(),
@@ -163,6 +176,7 @@ export const projectAssetSchema = z.object({
   control_plane: controlPlaneSchema.optional().nullable(),
   orchestration: orchestrationPolicySchema.optional().nullable(),
   latest_validation: projectAssetLatestValidationSchema.optional().nullable(),
+  stale_latest_run_warning: staleLatestRunWarningSchema.optional().nullable(),
 });
 
 export const queueItemSchema = z.object({
@@ -185,6 +199,7 @@ export const queueItemSchema = z.object({
   control_plane: controlPlaneSchema.optional().nullable(),
   user_todos: todoGroupSchema.optional().nullable(),
   agent_todos: todoGroupSchema.optional().nullable(),
+  stale_latest_run_warning: staleLatestRunWarningSchema.optional().nullable(),
   dependency_blockers: dependencyBlockerSummarySchema.optional().nullable(),
   todo_state_file: z.string().optional().nullable(),
 });

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -593,8 +593,13 @@ Item fields:
   `goal-harness connect`, and `orchestration`, the compact projection of
   registry `spawn_policy` with `mode`, `spawn_allowed`, `max_children`, and
   optional `allowed_domains`. They may also include `control_plane`, the
-  compact per-goal policy projection for settings such as self-repair. This is
-  the first-screen project asset surface for
+  compact per-goal policy projection for settings such as self-repair, and
+  `stale_latest_run_warning`, a compact warning that the current active-state
+  file appears newer or different from the latest run's captured state
+  projection. This warning is a repair hint, not a scheduler gate: consumers
+  should run `refresh-state` before trusting latest-run-derived routing, while
+  quota eligibility still comes from the quota guard.
+  This is the first-screen project asset surface for
   agents and dashboards; it lets consumers avoid reconstructing owner, gate,
   next action, stop condition, todo counts, compute state, and latest validation
   from scattered fields. It also keeps delivery-floor and
@@ -777,6 +782,11 @@ that generic lifecycle hint before inventing local automation behavior:
 once, while `mapped_noop_if_unchanged` returns a quiet no-op without another
 dry-run or quota spend if no new instruction, evidence, todo, stale source, or
 safe handoff exists.
+When the payload includes `stale_latest_run_warning`, the current active-state
+projection has moved ahead of the latest run-history snapshot. Executors should
+repair the control-plane projection with a fresh state refresh before relying on
+latest-run status, review packets, or handoff fields, but the warning alone does
+not authorize production actions or override `should_run`.
 The payload also includes `execution_obligation`, which is the stronger worker
 contract. `heartbeat_recommendation.notify` is only a user-facing notification
 policy. It must not be interpreted as an execution gate. If

--- a/examples/status-markdown-smoke.py
+++ b/examples/status-markdown-smoke.py
@@ -8,6 +8,7 @@ temporary planned read-only-map goal.
 from __future__ import annotations
 
 import json
+import hashlib
 import subprocess
 import sys
 import tempfile
@@ -27,6 +28,7 @@ from goal_harness.status import (  # noqa: E402
     render_status_markdown,
 )
 from goal_harness.quota import build_quota_should_run, render_quota_should_run_markdown  # noqa: E402
+from goal_harness.review_packet import build_review_packet  # noqa: E402
 from goal_harness.handoff_budget import PROJECT_AGENT_HANDOFF_BUDGET  # noqa: E402
 
 
@@ -624,6 +626,56 @@ def append_orphan_runtime_fixture(root: Path, *, goal_id: str, generated_at: str
             )
             + "\n"
         )
+
+
+def append_stale_state_projection_fixture(root: Path) -> None:
+    goal_id = "planned-main-control"
+    state_path = root / "project" / ".codex" / "goals" / goal_id / "ACTIVE_GOAL_STATE.md"
+    old_state_text = state_path.read_text(encoding="utf-8")
+    old_state_text = old_state_text.replace(
+        "updated_at: 2026-01-01T00:00:00+00:00",
+        "updated_at: 2026-01-01T00:01:00+00:00",
+    )
+    state_path.write_text(old_state_text, encoding="utf-8")
+    run_dir = root / "runtime" / "goals" / goal_id / "runs"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    generated_at = "2026-01-01T00:02:00+00:00"
+    compact_time = generated_at.replace("-", "").replace(":", "")
+    json_path = run_dir / f"{compact_time}-state-refreshed.json"
+    markdown_path = run_dir / f"{compact_time}-state-refreshed.md"
+    record = {
+        "generated_at": generated_at,
+        "goal_id": goal_id,
+        "classification": "state_refreshed",
+        "recommended_action": "inspect refreshed active goal state and continue",
+        "health_check": "fixture state refresh with stale later active state",
+        "state": {
+            "sha256_16": hashlib.sha256(old_state_text.encode("utf-8")).hexdigest()[:16],
+            "frontmatter": {
+                "status": "planned-high-complexity",
+                "updated_at": "2026-01-01T00:01:00+00:00",
+            },
+        },
+    }
+    json_path.write_text(json.dumps(record, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    markdown_path.write_text("# Fixture state refresh\n", encoding="utf-8")
+    with (run_dir / "index.jsonl").open("a", encoding="utf-8") as f:
+        f.write(
+            json.dumps(
+                {
+                    **record,
+                    "json_path": str(json_path),
+                    "markdown_path": str(markdown_path),
+                },
+                ensure_ascii=False,
+            )
+            + "\n"
+        )
+    new_state_text = old_state_text.replace(
+        "updated_at: 2026-01-01T00:01:00+00:00",
+        "updated_at: 2026-01-01T00:03:00+00:00",
+    )
+    state_path.write_text(new_state_text, encoding="utf-8")
 
 
 def set_registry_attention_override(registry_path: Path) -> None:
@@ -1735,6 +1787,33 @@ def assert_explicit_delivery_refresh(payload: dict, markdown: str) -> None:
     assert quota_payload["handoff_readiness"]["post_handoff_latest_run"]["delivery_outcome"] == "outcome_progress", quota_payload
 
 
+def assert_stale_latest_run_projection_warning(payload: dict, markdown: str) -> None:
+    items = payload["attention_queue"]["items"]
+    item = items[0]
+    warning = item["stale_latest_run_warning"]
+    assert warning["kind"] == "stale_latest_run_projection", warning
+    assert warning["requires_refresh_state"] is True, warning
+    assert warning["active_state_updated_at"] == "2026-01-01T00:03:00+00:00", warning
+    assert warning["latest_run_generated_at"] == "2026-01-01T00:02:00+00:00", warning
+    assert "active_state_updated_after_latest_run" in warning["reason"], warning
+    assert "active_state_digest_differs_from_latest_run_snapshot" in warning["reason"], warning
+    assert item["project_asset"]["stale_latest_run_warning"] == warning, item
+    assert "stale_latest_run_warning: requires_refresh_state=True" in markdown, markdown
+    assert "active_state_updated_at=2026-01-01T00:03:00+00:00" in markdown, markdown
+
+    quota_payload = build_quota_should_run(payload, goal_id="planned-main-control")
+    quota_warning = quota_payload["stale_latest_run_warning"]
+    assert quota_warning["requires_refresh_state"] is True, quota_payload
+    quota_markdown = render_quota_should_run_markdown(quota_payload)
+    assert "stale_latest_run_warning: requires_refresh_state=True" in quota_markdown, quota_markdown
+    assert "stale_latest_run_action: run refresh-state before trusting latest_run-derived routing" in quota_markdown, quota_markdown
+
+    packet = build_review_packet(payload, goal_id="planned-main-control", action_kind="codex")
+    assert packet["stale_latest_run_warning"]["requires_refresh_state"] is True, packet
+    assert "【状态投影警告】" in packet["packet"], packet
+    assert "先 refresh-state，再信任基于 latest_run 的路由/交接" in packet["packet"], packet
+
+
 def assert_handoff_waiting_for_post_run(item: dict, markdown: str) -> None:
     readiness = item["handoff_readiness"]
     assert readiness["ready"] is True, readiness
@@ -1885,6 +1964,11 @@ def main() -> int:
         explicit_registry_path = write_connected_delivery_registry(root)
         append_explicit_delivery_refresh(root, explicit_registry_path)
         explicit_payload, explicit_markdown = collect_fixture_status(root, explicit_registry_path)
+    with tempfile.TemporaryDirectory(prefix="goal-harness-status-stale-latest-run-") as tmp:
+        root = Path(tmp)
+        stale_projection_registry_path = write_planned_registry(root)
+        append_stale_state_projection_fixture(root)
+        stale_projection_payload, stale_projection_markdown = collect_fixture_status(root, stale_projection_registry_path)
     with tempfile.TemporaryDirectory(prefix="goal-harness-status-connected-readonly-progress-") as tmp:
         root = Path(tmp)
         readonly_registry_path = write_connected_readonly_registry(root)
@@ -2003,6 +2087,7 @@ def main() -> int:
     assert_connected_delivery_custom_run_stays_runnable(delivery_payload, delivery_markdown)
     assert_source_registry_shadow_collapses_into_live_queue_item(shadow_payload)
     assert_explicit_delivery_refresh(explicit_payload, explicit_markdown)
+    assert_stale_latest_run_projection_warning(stale_projection_payload, stale_projection_markdown)
     assert_connected_readonly_progress_run_stays_runnable(readonly_payload, readonly_markdown)
     assert_dependency_blockers_stay_separate(dependency_payload, dependency_markdown)
     assert_connected_delivery_no_baseline_small_streak(small_streak_payload, small_streak_markdown)

--- a/goal_harness/quota.py
+++ b/goal_harness/quota.py
@@ -1449,6 +1449,15 @@ def build_quota_should_run(status_payload: dict[str, Any], *, goal_id: str) -> d
         )
         if agent_todo_summary:
             payload["agent_todo_summary"] = agent_todo_summary
+        projection_warning = (
+            item.get("stale_latest_run_warning")
+            if isinstance(item.get("stale_latest_run_warning"), dict)
+            else project_asset.get("stale_latest_run_warning")
+            if isinstance(project_asset.get("stale_latest_run_warning"), dict)
+            else None
+        )
+        if projection_warning:
+            payload["stale_latest_run_warning"] = projection_warning
         decision_warning = _decision_freshness_warning(status_payload, goal_id=safe_goal_id)
         if decision_warning:
             payload["decision_freshness_warning"] = decision_warning
@@ -1939,6 +1948,21 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
     ]
     if payload.get("project_asset_source"):
         lines.append(f"- project_asset_source: {payload.get('project_asset_source')}")
+    stale_latest_run_warning = (
+        payload.get("stale_latest_run_warning")
+        if isinstance(payload.get("stale_latest_run_warning"), dict)
+        else {}
+    )
+    if stale_latest_run_warning:
+        lines.append(
+            "- stale_latest_run_warning: "
+            f"requires_refresh_state={stale_latest_run_warning.get('requires_refresh_state')} "
+            f"active_state_updated_at={stale_latest_run_warning.get('active_state_updated_at')} "
+            f"latest_run_generated_at={stale_latest_run_warning.get('latest_run_generated_at')} "
+            f"reason={stale_latest_run_warning.get('reason')}"
+        )
+        if stale_latest_run_warning.get("recommended_action"):
+            lines.append(f"- stale_latest_run_action: {stale_latest_run_warning.get('recommended_action')}")
     execution_profile = (
         payload.get("execution_profile")
         if isinstance(payload.get("execution_profile"), dict)

--- a/goal_harness/review_packet.py
+++ b/goal_harness/review_packet.py
@@ -204,6 +204,21 @@ def decision_freshness_packet_lines(warning: dict[str, Any] | None) -> list[str]
     return [redact_local_absolute_paths(line) for line in lines]
 
 
+def stale_latest_run_packet_lines(warning: dict[str, Any] | None) -> list[str]:
+    if not isinstance(warning, dict) or not warning:
+        return []
+    lines = [
+        "",
+        "【状态投影警告】",
+        "当前 active state 看起来比 latest_run 投影更新；先 refresh-state，再信任基于 latest_run 的路由/交接。",
+        "- "
+        f"active_state_updated_at={compact_packet_text(str(warning.get('active_state_updated_at') or ''), limit=80)} "
+        f"latest_run_generated_at={compact_packet_text(str(warning.get('latest_run_generated_at') or ''), limit=80)} "
+        f"reason={compact_packet_text(str(warning.get('reason') or ''), limit=120)}",
+    ]
+    return [redact_local_absolute_paths(line) for line in lines]
+
+
 def open_todo_texts(todos: Any, *, limit: int = 3) -> list[str]:
     if not isinstance(todos, dict):
         return []
@@ -750,6 +765,12 @@ def build_review_packet(
     delivery_contract_text = handoff_delivery_contract_summary(delivery_contract)
     freshness_warning = decision_freshness_warning(status_payload, goal_id)
     freshness_warning_lines = decision_freshness_packet_lines(freshness_warning)
+    stale_latest_run_warning = (
+        item.get("stale_latest_run_warning")
+        if isinstance(item, dict) and isinstance(item.get("stale_latest_run_warning"), dict)
+        else None
+    )
+    stale_latest_run_lines = stale_latest_run_packet_lines(stale_latest_run_warning)
     command = redact_local_absolute_paths(project_agent_command(status_payload, goal_id, kind, item, goal))
     approved_handoff = operator_gate_approved_handoff(item, goal)
     delivery_handoff = connected_delivery_handoff(item, goal) and kind == "codex"
@@ -796,6 +817,7 @@ def build_review_packet(
         f"摘要：{summary}",
         f"来源：{asset_source_line}",
         f"材料：{authority_summary}（仅脱敏计数；不含内部链接、路径或正文。）" if authority_summary else None,
+        *stale_latest_run_lines,
         *freshness_warning_lines,
         "",
         "【人只需判断】",
@@ -849,6 +871,7 @@ def build_review_packet(
         "handoff_delivery_contract": delivery_contract,
         "handoff_interface_budget": handoff_interface_budget,
         "decision_freshness_warning": freshness_warning,
+        "stale_latest_run_warning": stale_latest_run_warning,
         "project_asset_source": asset_source,
         "packet": "\n".join(line for line in lines if line),
     }

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections import Counter
 from datetime import datetime, timedelta, timezone
+import hashlib
 from pathlib import Path
 import re
 from typing import Any
@@ -263,6 +264,21 @@ def normalize_todo_text(text: str, *, limit: int = 500) -> str:
     if len(compact) <= limit:
         return compact
     return compact[: limit - 1].rstrip() + "…"
+
+
+def parse_state_frontmatter(state_text: str) -> dict[str, str]:
+    if not state_text.startswith("---"):
+        return {}
+    parts = state_text.split("---", 2)
+    if len(parts) < 3:
+        return {}
+    result: dict[str, str] = {}
+    for line in parts[1].splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        result[key.strip()] = value.strip().strip('"')
+    return result
 
 
 def todo_role_for_heading(heading: str) -> str | None:
@@ -633,6 +649,57 @@ def project_asset_latest_validation(run: dict[str, Any] | None) -> dict[str, Any
     if summary:
         signal["summary"] = normalize_todo_text(str(summary), limit=260)
     return signal or None
+
+
+def active_state_projection_warning(goal: dict[str, Any], current_run: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(goal, dict) or not goal.get("registry_member") or not isinstance(current_run, dict):
+        return None
+    state_path = resolve_goal_local_path(goal.get("state_file"), goal, fallback_base=Path.cwd())
+    if state_path is None or not state_path.exists():
+        return None
+    try:
+        state_text = state_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+    frontmatter = parse_state_frontmatter(state_text)
+    active_updated_at = frontmatter.get("updated_at")
+    active_digest = hashlib.sha256(state_text.encode("utf-8")).hexdigest()[:16]
+    run_state = current_run.get("state") if isinstance(current_run.get("state"), dict) else {}
+    run_frontmatter = run_state.get("frontmatter") if isinstance(run_state.get("frontmatter"), dict) else {}
+    run_state_updated_at = run_frontmatter.get("updated_at")
+    run_state_digest = str(run_state.get("sha256_16") or "")
+    latest_run_generated_at = str(current_run.get("generated_at") or "")
+
+    active_dt = parse_timestamp(active_updated_at)
+    run_state_dt = parse_timestamp(run_state_updated_at)
+    run_generated_dt = parse_timestamp(latest_run_generated_at)
+    active_newer_than_run_state = bool(active_dt and run_state_dt and active_dt > run_state_dt)
+    active_newer_than_run = bool(active_dt and run_generated_dt and active_dt > run_generated_dt)
+    digest_mismatch = bool(run_state_digest and active_digest != run_state_digest)
+    if not (active_newer_than_run_state or active_newer_than_run or digest_mismatch):
+        return None
+
+    reasons: list[str] = []
+    if active_newer_than_run:
+        reasons.append("active_state_updated_after_latest_run")
+    if active_newer_than_run_state:
+        reasons.append("active_state_updated_after_latest_run_snapshot")
+    if digest_mismatch:
+        reasons.append("active_state_digest_differs_from_latest_run_snapshot")
+
+    return {
+        "kind": "stale_latest_run_projection",
+        "source": "active_state_vs_latest_run",
+        "severity": "warning",
+        "requires_refresh_state": True,
+        "reason": ",".join(reasons),
+        "active_state_updated_at": active_updated_at,
+        "latest_run_generated_at": latest_run_generated_at,
+        "latest_run_state_updated_at": run_state_updated_at,
+        "latest_run_classification": current_run.get("classification"),
+        "recommended_action": "run refresh-state before trusting latest_run-derived routing",
+    }
 
 
 def project_asset_summary_is_public_safe(project_asset: dict[str, Any]) -> bool:
@@ -1639,6 +1706,7 @@ def build_attention_queue(
             if control_plane:
                 item["control_plane"] = control_plane
             goal_latest_runs = goal.get("latest_runs") if isinstance(goal.get("latest_runs"), list) else []
+            projection_warning = active_state_projection_warning(goal, latest_run(goal))
             enrich_project_asset(
                 item,
                 latest_validation=project_asset_latest_validation(latest_run(goal)),
@@ -1656,6 +1724,10 @@ def build_attention_queue(
             )
             if control_plane and isinstance(item.get("project_asset"), dict):
                 item["project_asset"]["control_plane"] = control_plane
+            if projection_warning:
+                item["stale_latest_run_warning"] = projection_warning
+                if isinstance(item.get("project_asset"), dict):
+                    item["project_asset"]["stale_latest_run_warning"] = projection_warning
             if goal.get("registry_member"):
                 item.update(active_state_todo_fields(goal))
                 item["quota"] = quota_status(
@@ -2822,6 +2894,19 @@ def render_status_markdown(payload: dict[str, Any]) -> str:
                     f"compute={asset_quota.get('compute')} "
                     f"state={asset_quota.get('state')} "
                     f"slots={asset_quota.get('spent_slots')}/{asset_quota.get('allowed_slots')}"
+                )
+            projection_warning = (
+                project_asset.get("stale_latest_run_warning")
+                if isinstance(project_asset.get("stale_latest_run_warning"), dict)
+                else {}
+            )
+            if projection_warning:
+                lines.append(
+                    "    - stale_latest_run_warning: "
+                    f"requires_refresh_state={projection_warning.get('requires_refresh_state')} "
+                    f"active_state_updated_at={_markdown_scalar(projection_warning.get('active_state_updated_at') or '')} "
+                    f"latest_run_generated_at={_markdown_scalar(projection_warning.get('latest_run_generated_at') or '')} "
+                    f"reason={_markdown_scalar(projection_warning.get('reason') or '')}"
                 )
             latest_validation = (
                 project_asset.get("latest_validation")


### PR DESCRIPTION
## Summary
- Add a compact stale_latest_run_warning when active-state frontmatter/digest moves ahead of the latest run snapshot
- Surface the warning through status, quota should-run, and review-packet payloads without changing quota eligibility
- Cover the warning with a fixture that mutates active state after a state_refreshed run snapshot

## Validation
- python3 examples/status-markdown-smoke.py
- python3 examples/quota-plan-smoke.py
- python3 examples/review-packet-cli-smoke.py
- python3 examples/check-public-boundary-smoke.py
- PYTHONPATH=. python3 -m goal_harness.cli check --scan-root .
- cd apps/dashboard && npm exec -- tsc --noEmit
- python3 examples/run-smokes.py

## Note
- npm --prefix apps/dashboard run build is not part of this validation because the local Vite/rolldown native binding still fails at macOS code-signature loading in node_modules; TypeScript compilation passes.
