### PR TITLE
Add quota scheduler fairness smoke

### DIFF
--- a/examples/quota-plan-smoke.py
+++ b/examples/quota-plan-smoke.py
@@ -558,6 +558,86 @@ def assert_plan_shape(plan: dict, markdown: str | None = None) -> None:
         assert markdown.index("`full-speed`") < markdown.index("`half-speed`") < markdown.index("`near-limit-half`") < markdown.index("`low-speed`"), markdown
 
 
+def assert_scheduler_advisory_does_not_override_goal_should_run() -> None:
+    meta_id = "goal-harness-meta"
+    tiger_id = "tiger-team-maiduidui-regauc"
+    side_bypass_id = "agent-harness-side-bypass"
+    gated_id = "owner-gated"
+    meta_goal = goal(meta_id, compute=0.5)
+    tiger_goal = goal(tiger_id, compute=1.0)
+    side_bypass_goal = goal(side_bypass_id, compute=0.8)
+    gated_goal = goal(gated_id, compute=1.0)
+
+    meta_item = attention(meta_id, compute=0.5)
+    meta_item["recommended_action"] = "advance one gate-independent Goal Harness backlog item"
+    meta_item["agent_todos"] = {
+        "source_section": "Agent Todo",
+        "total_count": 2,
+        "open_count": 2,
+        "done_count": 0,
+        "items": [
+            {
+                "index": 1,
+                "done": False,
+                "text": "Add scheduler/fairness regression coverage for automatic turn ordering.",
+            },
+            {
+                "index": 2,
+                "done": False,
+                "text": "Project sub-agent run history into status.",
+            },
+        ],
+    }
+    tiger_item = attention(tiger_id, compute=1.0)
+    tiger_item["recommended_action"] = "continue authorized evaluation monitoring"
+    side_bypass_item = attention(side_bypass_id, compute=0.8, state="focus_wait")
+    side_bypass_item["lifecycle_phase"] = "focus_wait"
+    side_bypass_item["lifecycle_flags"] = ["continuation_boundary"]
+    gated_item = attention(
+        gated_id,
+        compute=1.0,
+        state="operator_gate",
+        waiting_on="user_or_controller",
+    )
+    payload = {
+        "ok": True,
+        "registry": "./fixtures/registry.json",
+        "runtime_root": "./fixtures/runtime",
+        "goal_count": 4,
+        "run_count": 4,
+        "attention_queue": {"items": [meta_item, tiger_item, side_bypass_item, gated_item]},
+        "run_history": {"goals": [meta_goal, tiger_goal, side_bypass_goal, gated_goal]},
+    }
+
+    plan = build_quota_plan(payload, mode="plan")
+    meta_decision = build_quota_should_run(payload, goal_id=meta_id)
+    meta_markdown = render_quota_should_run_markdown(meta_decision)
+    side_bypass_decision = build_quota_should_run(payload, goal_id=side_bypass_id)
+    gated_decision = build_quota_should_run(payload, goal_id=gated_id)
+
+    assert [item["goal_id"] for item in plan["groups"]["operator_gate"]] == [gated_id], plan
+    assert [item["goal_id"] for item in plan["groups"]["focus_wait"]] == [side_bypass_id], plan
+    assert [item["goal_id"] for item in plan["groups"]["eligible"]] == [tiger_id, meta_id], plan
+    assert plan["summary"]["next_automatic_turn"] == tiger_id, plan
+    assert plan["next_automatic_turn"]["goal_id"] == tiger_id, plan
+
+    assert meta_decision["decision"] == "run", meta_decision
+    assert meta_decision["should_run"] is True, meta_decision
+    assert meta_decision["normal_delivery_allowed"] is True, meta_decision
+    assert meta_decision["state"] == "eligible", meta_decision
+    assert meta_decision["plan_summary"]["next_automatic_turn"] == tiger_id, meta_decision
+    assert meta_decision["execution_obligation"]["must_attempt_work"] is True, meta_decision
+    assert meta_decision["execution_obligation"]["notify_is_execution_gate"] is False, meta_decision
+    assert meta_decision["agent_todo_summary"]["open_count"] == 2, meta_decision
+    assert "agent_todo_next[1]: Add scheduler/fairness regression coverage" in meta_markdown, meta_markdown
+    assert "execution_obligation: must_attempt_work=True" in meta_markdown, meta_markdown
+
+    assert side_bypass_decision["should_run"] is False, side_bypass_decision
+    assert side_bypass_decision["state"] == "focus_wait", side_bypass_decision
+    assert gated_decision["should_run"] is False, gated_decision
+    assert gated_decision["state"] == "operator_gate", gated_decision
+
+
 def assert_default_quota_is_duty_cycle() -> None:
     full = goal_quota_config({"quota": {"compute": 1.0, "window_hours": 24}})
     half = goal_quota_config({"quota": {"compute": 0.5, "window_hours": 24}})
@@ -1465,6 +1545,7 @@ def main() -> int:
     plan = build_quota_plan(status_payload, mode="plan")
     markdown = render_quota_markdown(plan)
     assert_plan_shape(plan, markdown)
+    assert_scheduler_advisory_does_not_override_goal_should_run()
     assert_throttled_should_run(status_payload)
     assert_operator_gate_should_run(status_payload)
     assert_focus_wait_should_run()


### PR DESCRIPTION
## Summary
- add a quota-plan smoke fixture covering operator_gate, focus_wait, and eligible scheduler ordering together
- assert global next_automatic_turn remains advisory and does not override per-goal should-run for goal-harness-meta with open agent todos
- assert sibling focus_wait/operator_gate goals remain blocked while meta still has a Codex-actionable turn

## Validation
- python3 -m py_compile examples/quota-plan-smoke.py goal_harness/quota.py
- python3 examples/quota-plan-smoke.py
- python3 examples/status-markdown-smoke.py
- PYTHONPATH=. python3 -m goal_harness.cli check --scan-root .
- python3 examples/run-smokes.py (39 smoke scripts)

## Sensitive scan
- git diff --cached sensitive-pattern scan: clean
