### PR TITLE
Project subagent activity in status

### DIFF
--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -598,7 +598,11 @@ Item fields:
   file appears newer or different from the latest run's captured state
   projection. This warning is a repair hint, not a scheduler gate: consumers
   should run `refresh-state` before trusting latest-run-derived routing, while
-  quota eligibility still comes from the quota guard.
+  quota eligibility still comes from the quota guard. When orchestration mode
+  is `multi_subagent`, project assets may also include `subagent_activity`, a
+  compact child-run projection derived from run history. It records child run
+  ids, roles, state, parent links, public-safe scope summaries, and quota-spend
+  counts for observation only; it is not a lock service or write arbiter.
   This is the first-screen project asset surface for
   agents and dashboards; it lets consumers avoid reconstructing owner, gate,
   next action, stop condition, todo counts, compute state, and latest validation
@@ -1015,6 +1019,33 @@ Goal shape:
   "index_exists": true,
   "raw_index_records": 2,
   "unique_runs": 2,
+  "subagent_activity": {
+    "source": "run_history",
+    "parent_goal_id": "complex-project-main-control",
+    "child_count": 2,
+    "visible_child_count": 2,
+    "completed_count": 1,
+    "active_count": 1,
+    "quota_spend_slots": 2,
+    "items": [
+      {
+        "run_id": "docs-map-001",
+        "goal_id": "docs-map-subagent",
+        "parent_run_id": "controller-run-001",
+        "spawned_by_goal_id": "complex-project-main-control",
+        "agent_role": "explorer",
+        "state": "completed",
+        "work_scope": [
+          "docs/**"
+        ],
+        "touched_paths": [],
+        "touched_path_count": 0,
+        "handoff_summary": "Mapped task clusters without editing files.",
+        "quota_spend_slots": 1
+      }
+    ],
+    "proxy_note": "compact child-run projection only; parent controller remains the authority for locks, writes, and merge decisions"
+  },
   "latest_runs": []
 }
 ```
@@ -1053,6 +1084,24 @@ Run shape:
   ],
   "recommended_action": "ask the target controller to opt into a read-only map before any mutation",
   "health_check": "8/8",
+  "run_id": "controller-run-001",
+  "subagents": [
+    {
+      "run_id": "docs-map-001",
+      "goal_id": "docs-map-subagent",
+      "parent_run_id": "controller-run-001",
+      "spawned_by_goal_id": "complex-project-main-control",
+      "agent_role": "explorer",
+      "state": "completed",
+      "work_scope": [
+        "docs/**"
+      ],
+      "touched_path_count": 0,
+      "handoff_summary": "Mapped task clusters without editing files.",
+      "quota_spend_slots": 1
+    }
+  ],
+  "subagent_count": 1,
   "controller_readiness": {
     "classification": "ready_for_read_only_not_decision",
     "read_only_observer_ready": true,

--- a/examples/subagent-status-projection-smoke.py
+++ b/examples/subagent-status-projection-smoke.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Smoke-test compact sub-agent run-history/status projection."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from goal_harness.status import (  # noqa: E402
+    collect_status,
+    project_asset_summary_is_public_safe,
+    render_status_markdown,
+)
+
+
+GOAL_ID = "multi-subagent-controller"
+PRIVATE_LOCAL_PATH = "/" + "Users/example/private.txt"
+
+
+def write_fixture(root: Path) -> tuple[Path, Path]:
+    project = root / "project"
+    runtime = root / "runtime"
+    state_file = f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    registry_path = project / ".goal-harness" / "registry.json"
+    run_dir = runtime / "goals" / GOAL_ID / "runs"
+
+    (project / Path(state_file).parent).mkdir(parents=True, exist_ok=True)
+    (project / state_file).write_text(
+        "---\n"
+        "status: active-read-only\n"
+        "updated_at: 2026-01-01T00:00:00+00:00\n"
+        "---\n\n"
+        "# Multi Subagent Controller\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] Observe child run projection before launching more children.\n",
+        encoding="utf-8",
+    )
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "subagent-smoke",
+                        "status": "active-read-only",
+                        "repo": str(project),
+                        "state_file": state_file,
+                        "adapter": {
+                            "kind": "harness_self_improvement",
+                            "status": "connected-read-only",
+                        },
+                        "spawn_policy": {
+                            "mode": "multi_subagent",
+                            "allowed": True,
+                            "max_children": 3,
+                            "allowed_domains": ["docs", "validation", "implementation"],
+                        },
+                        "quota": {"compute": 1.0},
+                        "authority_sources": [],
+                    }
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    run_dir.mkdir(parents=True, exist_ok=True)
+    runs = [
+        {
+            "generated_at": "2026-01-01T00:02:00+00:00",
+            "run_id": "controller-run-001",
+            "goal_id": GOAL_ID,
+            "classification": "ready_for_parallel_probe",
+            "recommended_action": "merge child evidence, then choose one bounded implementation slice",
+            "subagents": [
+                {
+                    "run_id": "docs-map-001",
+                    "goal_id": "docs-map-subagent",
+                    "parent_run_id": "controller-run-001",
+                    "spawned_by_goal_id": GOAL_ID,
+                    "agent_role": "explorer",
+                    "work_scope": ["docs/**"],
+                    "touched_paths": ["docs/status-data-contract.md", PRIVATE_LOCAL_PATH],
+                    "result_status": "completed",
+                    "quota_slots": 1,
+                    "handoff_summary": "Mapped status docs and found the projection surface.",
+                },
+                {
+                    "run_id": "validation-001",
+                    "goal_id": "validation-subagent",
+                    "parent_run_id": "controller-run-001",
+                    "spawned_by_goal_id": GOAL_ID,
+                    "agent_role": "validator",
+                    "work_scope": ["examples/**"],
+                    "result_status": "running",
+                    "quota_event": {"slots": 1},
+                    "handoff_summary": "Running focused smoke coverage.",
+                },
+            ],
+            "merge_decision": "accepted docs-map evidence; validator still running",
+        },
+        {
+            "generated_at": "2026-01-01T00:01:00+00:00",
+            "run_id": "implementation-001",
+            "goal_id": GOAL_ID,
+            "parent_run_id": "controller-run-001",
+            "spawned_by_goal_id": GOAL_ID,
+            "agent_role": "implementation",
+            "classification": "subagent_progress",
+            "result_status": "queued",
+            "work_scope": ["goal_harness/status.py"],
+            "quota_spend": 2,
+            "handoff_summary": "Waiting for controller merge decision before writing.",
+        },
+    ]
+    with (run_dir / "index.jsonl").open("w", encoding="utf-8") as f:
+        for run in runs:
+            f.write(json.dumps(run, ensure_ascii=False, sort_keys=True) + "\n")
+    return registry_path, runtime
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="goal-harness-subagent-status-") as tmp:
+        registry_path, runtime = write_fixture(Path(tmp))
+        payload = collect_status(
+            registry_path=registry_path,
+            runtime_root_override=str(runtime),
+            scan_roots=[registry_path.parent.parent],
+            limit=5,
+        )
+    markdown = render_status_markdown(payload)
+    goal = payload["run_history"]["goals"][0]
+    activity = goal["subagent_activity"]
+    queue_item = payload["attention_queue"]["items"][0]
+    project_asset = queue_item["project_asset"]
+    asset_activity = project_asset["subagent_activity"]
+    latest = goal["latest_runs"][0]
+
+    assert payload["ok"] is True, payload
+    assert activity["source"] == "run_history", activity
+    assert activity["parent_goal_id"] == GOAL_ID, activity
+    assert activity["child_count"] == 3, activity
+    assert activity["visible_child_count"] == 3, activity
+    assert activity["completed_count"] == 1, activity
+    assert activity["active_count"] == 2, activity
+    assert activity["quota_spend_slots"] == 4, activity
+    assert asset_activity == activity, (asset_activity, activity)
+    assert project_asset_summary_is_public_safe(project_asset), project_asset
+    assert latest["subagent_count"] == 2, latest
+    assert latest["subagents"][0]["run_id"] == "docs-map-001", latest
+    assert latest["subagents"][0]["parent_run_id"] == "controller-run-001", latest
+    assert latest["subagents"][0]["touched_paths"] == ["docs/status-data-contract.md"], latest
+    assert PRIVATE_LOCAL_PATH not in json.dumps(activity, ensure_ascii=False), activity
+    assert "subagent_activity: children=3 visible=3 active=2 completed=1 quota_slots=4" in markdown, markdown
+    assert "child_run: role=explorer state=completed run_id=docs-map-001 parent_run_id=controller-run-001" in markdown, markdown
+    assert "child_run: role=implementation state=queued run_id=implementation-001 parent_run_id=controller-run-001" in markdown, markdown
+
+    print("subagent-status-projection-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -163,12 +163,18 @@ PLANNED_CONTROLLER_OPT_IN_RECOMMENDED_ACTION = (
 )
 RUN_COMPACT_FIELDS = (
     "generated_at",
+    "run_id",
     "goal_id",
+    "parent_run_id",
+    "spawned_by_goal_id",
+    "agent_role",
     "classification",
     "lifecycle_phase",
     "lifecycle_flags",
     "recommended_action",
     "health_check",
+    "result_status",
+    "approval_state",
     "active_task_count",
     "active_priorities",
     "cache_check",
@@ -256,6 +262,8 @@ MAX_STATUS_TODOS_PER_ROLE = 12
 MAX_PROJECT_ASSET_TODO_ITEMS = 3
 MAX_DEPENDENCY_BLOCKERS = 4
 MAX_AUTONOMOUS_BACKLOG_CANDIDATES = 6
+MAX_SUBAGENT_ACTIVITY_ITEMS = 5
+MAX_SUBAGENT_SCOPE_ITEMS = 4
 AUTONOMOUS_PRIORITY_PATTERN = re.compile(r"^\s*\[(P[0-4][^\]]*)\]\s*(.+)$", re.IGNORECASE)
 
 
@@ -264,6 +272,28 @@ def normalize_todo_text(text: str, *, limit: int = 500) -> str:
     if len(compact) <= limit:
         return compact
     return compact[: limit - 1].rstrip() + "…"
+
+
+def public_safe_compact_text(value: Any, *, limit: int = 220) -> str | None:
+    text = normalize_todo_text(str(value or ""), limit=limit)
+    if not text:
+        return None
+    if LOCAL_PATH_SURFACE_PATTERN.search(text) or SECRET_LIKE_SURFACE_PATTERN.search(text):
+        return None
+    return text
+
+
+def public_safe_compact_list(value: Any, *, limit: int = MAX_SUBAGENT_SCOPE_ITEMS) -> list[str]:
+    values = value if isinstance(value, list) else [value] if value else []
+    result: list[str] = []
+    for item in values:
+        text = public_safe_compact_text(item, limit=160)
+        if not text:
+            continue
+        result.append(text)
+        if len(result) >= limit:
+            break
+    return result
 
 
 def parse_state_frontmatter(state_text: str) -> dict[str, str]:
@@ -651,6 +681,144 @@ def project_asset_latest_validation(run: dict[str, Any] | None) -> dict[str, Any
     return signal or None
 
 
+def _subagent_state(run: dict[str, Any]) -> str | None:
+    for field in ("result_status", "state", "status", "classification"):
+        value = public_safe_compact_text(run.get(field), limit=80)
+        if value:
+            return value
+    return None
+
+
+def _subagent_quota_spend(run: dict[str, Any]) -> int:
+    for field in ("quota_spend", "quota_slots", "spent_slots"):
+        raw = run.get(field)
+        if isinstance(raw, bool):
+            continue
+        try:
+            return max(0, int(raw))
+        except (TypeError, ValueError):
+            pass
+    quota_event = run.get("quota_event") if isinstance(run.get("quota_event"), dict) else {}
+    raw_slots = quota_event.get("slots")
+    try:
+        return max(0, int(raw_slots))
+    except (TypeError, ValueError):
+        return 0
+
+
+def compact_subagent_run(
+    raw: dict[str, Any],
+    *,
+    parent_goal_id: str | None = None,
+    parent_run_id: str | None = None,
+) -> dict[str, Any] | None:
+    if not isinstance(raw, dict):
+        return None
+    run_id = public_safe_compact_text(
+        raw.get("run_id") or raw.get("id") or raw.get("generated_at"),
+        limit=120,
+    )
+    role = public_safe_compact_text(raw.get("agent_role") or raw.get("role"), limit=80)
+    state = _subagent_state(raw)
+    if not (run_id or role or state):
+        return None
+
+    compact: dict[str, Any] = {}
+    if run_id:
+        compact["run_id"] = run_id
+    goal_id = public_safe_compact_text(raw.get("goal_id") or raw.get("id"), limit=120)
+    if goal_id:
+        compact["goal_id"] = goal_id
+    parent_run = public_safe_compact_text(raw.get("parent_run_id") or parent_run_id, limit=120)
+    if parent_run:
+        compact["parent_run_id"] = parent_run
+    spawned_by = public_safe_compact_text(raw.get("spawned_by_goal_id") or parent_goal_id, limit=120)
+    if spawned_by:
+        compact["spawned_by_goal_id"] = spawned_by
+    if role:
+        compact["agent_role"] = role
+    if state:
+        compact["state"] = state
+    for field in ("claim_id", "approval_state"):
+        value = public_safe_compact_text(raw.get(field), limit=120)
+        if value:
+            compact[field] = value
+    work_scope = public_safe_compact_list(raw.get("work_scope") or raw.get("scope"))
+    if work_scope:
+        compact["work_scope"] = work_scope
+    touched_paths = public_safe_compact_list(raw.get("touched_paths") or raw.get("changed_files"))
+    if touched_paths:
+        compact["touched_paths"] = touched_paths
+    raw_touched = raw.get("touched_paths") or raw.get("changed_files")
+    if isinstance(raw_touched, list):
+        compact["touched_path_count"] = len(raw_touched)
+    handoff = public_safe_compact_text(raw.get("handoff_summary") or raw.get("summary"), limit=260)
+    if handoff:
+        compact["handoff_summary"] = handoff
+    quota_spend = _subagent_quota_spend(raw)
+    if quota_spend:
+        compact["quota_spend_slots"] = quota_spend
+    return compact
+
+
+def subagent_activity_for_goal(goal: dict[str, Any]) -> dict[str, Any] | None:
+    if not isinstance(goal, dict):
+        return None
+    parent_goal_id = str(goal.get("id") or "")
+    latest_runs = goal.get("latest_runs") if isinstance(goal.get("latest_runs"), list) else []
+    children: list[dict[str, Any]] = []
+    seen: set[tuple[str, str, str]] = set()
+
+    def add_child(raw: dict[str, Any], *, parent_run_id: str | None = None) -> None:
+        child = compact_subagent_run(
+            raw,
+            parent_goal_id=parent_goal_id or None,
+            parent_run_id=parent_run_id,
+        )
+        if not child:
+            return
+        key = (
+            str(child.get("run_id") or ""),
+            str(child.get("goal_id") or ""),
+            str(child.get("agent_role") or ""),
+        )
+        if key in seen:
+            return
+        seen.add(key)
+        children.append(child)
+
+    for run in latest_runs:
+        if not isinstance(run, dict):
+            continue
+        parent_run_id = str(run.get("run_id") or run.get("generated_at") or "")
+        for child in run.get("subagents") or []:
+            if isinstance(child, dict):
+                add_child(child, parent_run_id=parent_run_id)
+        if run.get("parent_run_id") or run.get("spawned_by_goal_id") or run.get("agent_role"):
+            add_child(run, parent_run_id=str(run.get("parent_run_id") or ""))
+
+    if not children:
+        return None
+    limited = children[:MAX_SUBAGENT_ACTIVITY_ITEMS]
+    completed_states = {"completed", "done", "success", "passed"}
+    active_states = {"running", "active", "in_progress", "queued", "started"}
+    completed = sum(1 for child in children if str(child.get("state") or "").lower() in completed_states)
+    active = sum(1 for child in children if str(child.get("state") or "").lower() in active_states)
+    quota_spend = sum(int(child.get("quota_spend_slots") or 0) for child in children)
+    summary: dict[str, Any] = {
+        "source": "run_history",
+        "parent_goal_id": parent_goal_id,
+        "child_count": len(children),
+        "visible_child_count": len(limited),
+        "completed_count": completed,
+        "active_count": active,
+        "quota_spend_slots": quota_spend,
+        "items": limited,
+        "proxy_note": "compact child-run projection only; parent controller remains the authority for locks, writes, and merge decisions",
+    }
+    return summary
+
+
 def active_state_projection_warning(goal: dict[str, Any], current_run: dict[str, Any] | None) -> dict[str, Any] | None:
     if not isinstance(goal, dict) or not goal.get("registry_member") or not isinstance(current_run, dict):
         return None
@@ -985,6 +1153,7 @@ def enrich_project_asset(
     latest_runs: list[dict[str, Any]] | None = None,
     execution_profile: dict[str, Any] | None = None,
     orchestration: dict[str, Any] | None = None,
+    subagent_activity: dict[str, Any] | None = None,
 ) -> None:
     project_asset = item.get("project_asset")
     if not isinstance(project_asset, dict):
@@ -1002,6 +1171,8 @@ def enrich_project_asset(
         project_asset["execution_profile"] = compact_execution_profile(execution_profile)
     if orchestration is not None:
         project_asset["orchestration"] = compact_orchestration_policy(orchestration)
+    if subagent_activity:
+        project_asset["subagent_activity"] = subagent_activity
     if latest_validation:
         project_asset["latest_validation"] = latest_validation
     readiness = project_asset_handoff_readiness(item, latest_runs=latest_runs)
@@ -1706,6 +1877,7 @@ def build_attention_queue(
             if control_plane:
                 item["control_plane"] = control_plane
             goal_latest_runs = goal.get("latest_runs") if isinstance(goal.get("latest_runs"), list) else []
+            subagent_activity = subagent_activity_for_goal(goal)
             projection_warning = active_state_projection_warning(goal, latest_run(goal))
             enrich_project_asset(
                 item,
@@ -1721,6 +1893,7 @@ def build_attention_queue(
                     if isinstance(goal.get("spawn_policy"), dict)
                     else None
                 ),
+                subagent_activity=subagent_activity,
             )
             if control_plane and isinstance(item.get("project_asset"), dict):
                 item["project_asset"]["control_plane"] = control_plane
@@ -1744,6 +1917,7 @@ def build_attention_queue(
                     agent_todos=item.get("agent_todos") if isinstance(item.get("agent_todos"), dict) else None,
                     quota=item.get("quota") if isinstance(item.get("quota"), dict) else None,
                     latest_runs=goal_latest_runs,
+                    subagent_activity=subagent_activity,
                 )
                 guarded_quota = quota_with_handoff_outcome_floor(
                     item.get("quota") if isinstance(item.get("quota"), dict) else {},
@@ -1763,6 +1937,7 @@ def build_attention_queue(
                         agent_todos=item.get("agent_todos") if isinstance(item.get("agent_todos"), dict) else None,
                         quota=guarded_quota,
                         latest_runs=goal_latest_runs,
+                        subagent_activity=subagent_activity,
                     )
             history_items.append(item)
 
@@ -1961,6 +2136,25 @@ def compact_run(run: dict[str, Any]) -> dict[str, Any]:
     readiness = compact_controller_readiness(run.get("controller_readiness"))
     if readiness:
         compact["controller_readiness"] = readiness
+    merge_decision = public_safe_compact_text(run.get("merge_decision"), limit=240)
+    if merge_decision:
+        compact["merge_decision"] = merge_decision
+    subagents = [
+        child
+        for child in (
+            compact_subagent_run(
+                child_run,
+                parent_goal_id=str(run.get("goal_id") or ""),
+                parent_run_id=str(run.get("run_id") or run.get("generated_at") or ""),
+            )
+            for child_run in (run.get("subagents") or [])
+            if isinstance(child_run, dict)
+        )
+        if child
+    ]
+    if subagents:
+        compact["subagents"] = subagents[:MAX_SUBAGENT_ACTIVITY_ITEMS]
+        compact["subagent_count"] = len(subagents)
     return compact
 
 
@@ -1971,6 +2165,7 @@ def build_run_history(history: dict[str, Any]) -> dict[str, Any]:
             continue
         current_run = latest_run(goal)
         lifecycle_fields = goal_lifecycle_fields(goal, current_run)
+        subagent_activity = subagent_activity_for_goal(goal)
         goals.append(
             {
                 "id": goal.get("id"),
@@ -1990,6 +2185,7 @@ def build_run_history(history: dict[str, Any]) -> dict[str, Any]:
                 "index_exists": goal.get("index_exists"),
                 "raw_index_records": goal.get("raw_index_records"),
                 "unique_runs": goal.get("unique_runs"),
+                "subagent_activity": subagent_activity,
                 "latest_status_run": compact_run(current_run) if current_run else None,
                 "latest_runs": [
                     compact_run(run)
@@ -2852,6 +3048,31 @@ def render_status_markdown(payload: dict[str, Any]) -> str:
                     "    - orchestration: "
                     f"{_markdown_scalar(orchestration_policy_summary(asset_orchestration))}"
                 )
+            subagent_activity = (
+                project_asset.get("subagent_activity")
+                if isinstance(project_asset.get("subagent_activity"), dict)
+                else {}
+            )
+            if subagent_activity:
+                lines.append(
+                    "    - subagent_activity: "
+                    f"children={subagent_activity.get('child_count')} "
+                    f"visible={subagent_activity.get('visible_child_count')} "
+                    f"active={subagent_activity.get('active_count')} "
+                    f"completed={subagent_activity.get('completed_count')} "
+                    f"quota_slots={subagent_activity.get('quota_spend_slots')}"
+                )
+                for child in (subagent_activity.get("items") or [])[:3]:
+                    if not isinstance(child, dict):
+                        continue
+                    role = _markdown_scalar(child.get("agent_role") or "subagent")
+                    state = _markdown_scalar(child.get("state") or "unknown")
+                    run_id = _markdown_scalar(child.get("run_id") or "")
+                    parent_run_id = _markdown_scalar(child.get("parent_run_id") or "")
+                    lines.append(
+                        f"      - child_run: role={role} state={state} "
+                        f"run_id={run_id} parent_run_id={parent_run_id}"
+                    )
             asset_user_todos = (
                 project_asset.get("user_todos")
                 if isinstance(project_asset.get("user_todos"), dict)


### PR DESCRIPTION
## Summary
- add compact sub-agent activity projection from run history into run_history.goals and project_asset
- preserve child run ids, parent links, roles, state, public-safe scope summaries, touched-path counts, and quota-spend slots without introducing lock semantics
- document the status contract and add a focused subagent-status-projection smoke

## Validation
- python3 -m py_compile goal_harness/status.py examples/subagent-status-projection-smoke.py
- python3 examples/subagent-status-projection-smoke.py
- python3 examples/status-markdown-smoke.py
- PYTHONPATH=. python3 -m goal_harness.cli check --scan-root .
- python3 examples/run-smokes.py (40 smoke scripts)

## Sensitive scan
- git diff origin/main..HEAD sensitive-pattern scan: clean
