### PR TITLE
Expose backlog hygiene warnings

### DIFF
--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -791,6 +791,14 @@ projection has moved ahead of the latest run-history snapshot. Executors should
 repair the control-plane projection with a fresh state refresh before relying on
 latest-run status, review packets, or handoff fields, but the warning alone does
 not authorize production actions or override `should_run`.
+When the payload includes `backlog_hygiene_warning`, the active state has
+multiple public-safe durable follow-up items in `Next Action` or
+`Operating Lessons` while the active `Agent Todo` checklist has no open item.
+Executors should mirror the durable follow-up work into concrete Agent Todo
+checkboxes before heartbeat scheduling relies on those narrative sections. The
+warning is a checklist hygiene signal only: it does not change quota eligibility,
+grant write or production permission, or make a quiet no-op valid when
+`execution_obligation.must_attempt_work=true`.
 The payload also includes `execution_obligation`, which is the stronger worker
 contract. `heartbeat_recommendation.notify` is only a user-facing notification
 policy. It must not be interpreted as an execution gate. If

--- a/examples/backlog-hygiene-smoke.py
+++ b/examples/backlog-hygiene-smoke.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Smoke-test hidden backlog warnings in status and quota should-run."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GOAL_ID = "backlog-hygiene-goal"
+
+
+def run_cli(*args: str, registry_path: Path, runtime: Path) -> dict:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "goal_harness.cli",
+            "--registry",
+            str(registry_path),
+            "--runtime-root",
+            str(runtime),
+            "--format",
+            "json",
+            *args,
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def write_fixture(root: Path, *, include_agent_todo: bool) -> tuple[Path, Path]:
+    project = root / "project"
+    runtime = root / "runtime"
+    state_file = f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    state_path = project / state_file
+    registry_path = project / ".goal-harness" / "registry.json"
+
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    agent_todo_section = (
+        "\n## Agent Todo\n\n"
+        "- [ ] [P1] Mirror durable follow-up work into Agent Todo before scheduling.\n"
+        if include_agent_todo
+        else ""
+    )
+    state_path.write_text(
+        "---\n"
+        "status: active\n"
+        "updated_at: 2026-01-01T00:00:00+00:00\n"
+        "---\n\n"
+        "# Backlog Hygiene Fixture\n\n"
+        "## Next Action\n\n"
+        "- Add a backlog hygiene check for hidden long-running work.\n"
+        "- Add a source-registry regression after the hygiene check lands.\n\n"
+        "## Operating Lessons\n\n"
+        "- Keep the sub-agent audit as an explicit follow-up todo.\n"
+        f"{agent_todo_section}",
+        encoding="utf-8",
+    )
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "backlog-hygiene-fixture",
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": state_file,
+                        "adapter": {
+                            "kind": "harness_self_improvement",
+                            "status": "connected-read-only",
+                        },
+                        "authority_sources": [],
+                        "quota": {
+                            "compute": 1.0,
+                            "window_hours": 24,
+                            "allowed_slots": 5,
+                        },
+                    }
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return registry_path, runtime
+
+
+def attention_item(status_payload: dict) -> dict:
+    items = status_payload.get("attention_queue", {}).get("items") or []
+    assert len(items) == 1, status_payload
+    return items[0]
+
+
+def assert_hidden_backlog_warning() -> None:
+    with tempfile.TemporaryDirectory(prefix="goal-harness-backlog-hygiene-") as tmp:
+        registry_path, runtime = write_fixture(Path(tmp), include_agent_todo=False)
+        status_payload = run_cli("status", registry_path=registry_path, runtime=runtime)
+        item = attention_item(status_payload)
+        warning = item["project_asset"]["backlog_hygiene_warning"]
+        assert warning["kind"] == "hidden_backlog_without_agent_todo", warning
+        assert warning["requires_agent_todo"] is True, warning
+        assert warning["evidence_count"] == 3, warning
+        assert warning["source_sections"] == ["Next Action", "Operating Lessons"], warning
+        assert item["backlog_hygiene_warning"] == warning, item
+
+        guard = run_cli("quota", "should-run", "--goal-id", GOAL_ID, registry_path=registry_path, runtime=runtime)
+        assert guard["should_run"] is True, guard
+        assert guard["backlog_hygiene_warning"] == warning, guard
+        assert "agent_todo_summary" not in guard, guard
+
+
+def assert_open_agent_todo_suppresses_warning() -> None:
+    with tempfile.TemporaryDirectory(prefix="goal-harness-backlog-hygiene-") as tmp:
+        registry_path, runtime = write_fixture(Path(tmp), include_agent_todo=True)
+        status_payload = run_cli("status", registry_path=registry_path, runtime=runtime)
+        item = attention_item(status_payload)
+        assert "backlog_hygiene_warning" not in item, item
+        assert "backlog_hygiene_warning" not in item["project_asset"], item
+
+        guard = run_cli("quota", "should-run", "--goal-id", GOAL_ID, registry_path=registry_path, runtime=runtime)
+        assert "backlog_hygiene_warning" not in guard, guard
+        assert guard["agent_todo_summary"]["open_count"] == 1, guard
+
+
+def main() -> int:
+    assert_hidden_backlog_warning()
+    assert_open_agent_todo_suppresses_warning()
+    print("backlog-hygiene-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/goal_harness/quota.py
+++ b/goal_harness/quota.py
@@ -1458,6 +1458,15 @@ def build_quota_should_run(status_payload: dict[str, Any], *, goal_id: str) -> d
         )
         if projection_warning:
             payload["stale_latest_run_warning"] = projection_warning
+        backlog_warning = (
+            item.get("backlog_hygiene_warning")
+            if isinstance(item.get("backlog_hygiene_warning"), dict)
+            else project_asset.get("backlog_hygiene_warning")
+            if isinstance(project_asset.get("backlog_hygiene_warning"), dict)
+            else None
+        )
+        if backlog_warning:
+            payload["backlog_hygiene_warning"] = backlog_warning
         decision_warning = _decision_freshness_warning(status_payload, goal_id=safe_goal_id)
         if decision_warning:
             payload["decision_freshness_warning"] = decision_warning
@@ -1963,6 +1972,20 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
         )
         if stale_latest_run_warning.get("recommended_action"):
             lines.append(f"- stale_latest_run_action: {stale_latest_run_warning.get('recommended_action')}")
+    backlog_hygiene_warning = (
+        payload.get("backlog_hygiene_warning")
+        if isinstance(payload.get("backlog_hygiene_warning"), dict)
+        else {}
+    )
+    if backlog_hygiene_warning:
+        lines.append(
+            "- backlog_hygiene_warning: "
+            f"requires_agent_todo={backlog_hygiene_warning.get('requires_agent_todo')} "
+            f"evidence_count={backlog_hygiene_warning.get('evidence_count')} "
+            f"source_sections={','.join(backlog_hygiene_warning.get('source_sections') or [])}"
+        )
+        if backlog_hygiene_warning.get("recommended_action"):
+            lines.append(f"- backlog_hygiene_action: {backlog_hygiene_warning.get('recommended_action')}")
     execution_profile = (
         payload.get("execution_profile")
         if isinstance(payload.get("execution_profile"), dict)

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -244,6 +244,7 @@ LIFECYCLE_PRIORITY = (
     "run_recorded",
 )
 TODO_TASK_PATTERN = re.compile(r"^\s*[-*]\s+\[([ xX-])\]\s+(.+?)\s*$")
+SECTION_HEADING_PATTERN = re.compile(r"^##+\s+(.+?)\s*$")
 LOCAL_PATH_SURFACE_PATTERN = re.compile(r"(?<!<)/(?:Users|Volumes|var/folders|tmp|private/tmp)/[^\s`'\"<>]+")
 SECRET_LIKE_SURFACE_PATTERN = re.compile(
     r"(?i)(?:\bbearer\s+[a-z0-9._~+/=-]{16,}|(?<![a-z0-9_])(?:ak|sk)[-_=:][a-z0-9_=-]{10,}|\btoken\s*[=:]\s*[^\s`'\"<>]{12,})"
@@ -264,7 +265,13 @@ MAX_DEPENDENCY_BLOCKERS = 4
 MAX_AUTONOMOUS_BACKLOG_CANDIDATES = 6
 MAX_SUBAGENT_ACTIVITY_ITEMS = 5
 MAX_SUBAGENT_SCOPE_ITEMS = 4
+MAX_BACKLOG_HYGIENE_EVIDENCE_ITEMS = 3
 AUTONOMOUS_PRIORITY_PATTERN = re.compile(r"^\s*\[(P[0-4][^\]]*)\]\s*(.+)$", re.IGNORECASE)
+BACKLOG_HYGIENE_SECTION_HEADINGS = ("Next Action", "Operating Lessons")
+BACKLOG_HYGIENE_BULLET_PATTERN = re.compile(r"^\s*(?:[-*]|\d+[.)])\s+(.+?)\s*$")
+BACKLOG_HYGIENE_HINT_PATTERN = re.compile(
+    r"(?i)(?:\[p[0-4]\]|todo|backlog|follow[- ]?up|queue|audit|regression|smoke|cadence|mirror|monitor|sub-?agent|待办|回归|审计|修复|检查|推进)"
+)
 
 
 def normalize_todo_text(text: str, *, limit: int = 500) -> str:
@@ -417,6 +424,60 @@ def parse_active_state_todos(state_text: str, *, goal: dict[str, Any] | None = N
     if agent:
         result["agent_todos"] = agent
     return result
+
+
+def active_state_sections(state_text: str, headings: tuple[str, ...]) -> dict[str, list[str]]:
+    wanted = {heading.lower(): heading for heading in headings}
+    current: str | None = None
+    sections: dict[str, list[str]] = {heading: [] for heading in headings}
+    for line in state_text.splitlines():
+        match = SECTION_HEADING_PATTERN.match(line)
+        if match:
+            normalized = match.group(1).strip().lower()
+            current = wanted.get(normalized)
+            continue
+        if current:
+            sections[current].append(line)
+    return sections
+
+
+def backlog_hygiene_warning(state_text: str, *, agent_todos: dict[str, Any] | None) -> dict[str, Any] | None:
+    try:
+        agent_open_count = int(agent_todos.get("open_count") or 0) if isinstance(agent_todos, dict) else 0
+    except (TypeError, ValueError):
+        agent_open_count = 0
+    if agent_open_count > 0:
+        return None
+
+    evidence: list[dict[str, Any]] = []
+    sections = active_state_sections(state_text, BACKLOG_HYGIENE_SECTION_HEADINGS)
+    for section, lines in sections.items():
+        for line in lines:
+            bullet_match = BACKLOG_HYGIENE_BULLET_PATTERN.match(line)
+            if not bullet_match:
+                continue
+            text = public_safe_compact_text(bullet_match.group(1), limit=220)
+            if not text:
+                continue
+            if section.lower() == "next action" or BACKLOG_HYGIENE_HINT_PATTERN.search(text):
+                evidence.append({"section": section, "text": text})
+
+    if len(evidence) < 2:
+        return None
+
+    source_sections = sorted({str(item.get("section") or "") for item in evidence if item.get("section")})
+    return {
+        "kind": "hidden_backlog_without_agent_todo",
+        "requires_agent_todo": True,
+        "source_sections": source_sections,
+        "agent_open_count": agent_open_count,
+        "evidence_count": len(evidence),
+        "first_evidence": evidence[:MAX_BACKLOG_HYGIENE_EVIDENCE_ITEMS],
+        "recommended_action": (
+            "mirror durable follow-up work into Agent Todo before heartbeat scheduling relies on "
+            "Next Action or Operating Lessons"
+        ),
+    }
 
 
 def project_asset_owner(waiting_on: str) -> str:
@@ -1216,6 +1277,12 @@ def active_state_todo_fields(goal: dict[str, Any]) -> dict[str, Any]:
     except OSError:
         return {}
     fields = parse_active_state_todos(state_text, goal=goal, state_path=state_path)
+    warning = backlog_hygiene_warning(
+        state_text,
+        agent_todos=fields.get("agent_todos") if isinstance(fields.get("agent_todos"), dict) else None,
+    )
+    if warning:
+        fields["backlog_hygiene_warning"] = warning
     if fields:
         fields = redacted_status_todo_fields(fields)
     return fields
@@ -1903,6 +1970,13 @@ def build_attention_queue(
                     item["project_asset"]["stale_latest_run_warning"] = projection_warning
             if goal.get("registry_member"):
                 item.update(active_state_todo_fields(goal))
+                backlog_warning = (
+                    item.get("backlog_hygiene_warning")
+                    if isinstance(item.get("backlog_hygiene_warning"), dict)
+                    else None
+                )
+                if backlog_warning and isinstance(item.get("project_asset"), dict):
+                    item["project_asset"]["backlog_hygiene_warning"] = backlog_warning
                 item["quota"] = quota_status(
                     goal,
                     waiting_on=str(item.get("waiting_on") or ""),
@@ -3128,6 +3202,18 @@ def render_status_markdown(payload: dict[str, Any]) -> str:
                     f"active_state_updated_at={_markdown_scalar(projection_warning.get('active_state_updated_at') or '')} "
                     f"latest_run_generated_at={_markdown_scalar(projection_warning.get('latest_run_generated_at') or '')} "
                     f"reason={_markdown_scalar(projection_warning.get('reason') or '')}"
+                )
+            backlog_warning = (
+                project_asset.get("backlog_hygiene_warning")
+                if isinstance(project_asset.get("backlog_hygiene_warning"), dict)
+                else {}
+            )
+            if backlog_warning:
+                lines.append(
+                    "    - backlog_hygiene_warning: "
+                    f"requires_agent_todo={backlog_warning.get('requires_agent_todo')} "
+                    f"evidence_count={backlog_warning.get('evidence_count')} "
+                    f"source_sections={_markdown_scalar(','.join(backlog_warning.get('source_sections') or []))}"
                 )
             latest_validation = (
                 project_asset.get("latest_validation")


### PR DESCRIPTION
## Summary
- add a status/project_asset warning when durable follow-up work is hidden in Next Action or Operating Lessons without open Agent Todo items
- surface the warning through quota should-run and CLI markdown
- add a dependency-free smoke fixture and document the data contract

## Validation
- python3 examples/backlog-hygiene-smoke.py
- python3 -m py_compile goal_harness/status.py goal_harness/quota.py
- python3 examples/run-smokes.py
- goal-harness-canary check --scan-root .
- sensitive scan over changed tracked files: only existing regex identifiers matched