### PR TITLE
Clarify Codex CLI worker regression extension

### DIFF
--- a/docs/codex-cli-long-run-regression.md
+++ b/docs/codex-cli-long-run-regression.md
@@ -76,6 +76,21 @@ records one work event, records one spend event, and appends one JSONL row. This
 keeps the regression deterministic while leaving a clear path for replacing the
 shim action with a real Codex CLI worker later.
 
+## Real Codex CLI Worker Extension
+
+The next implementation stage should add an explicit, low-frequency runner mode
+that invokes a real Codex CLI worker against the same isolated fixture. The
+deterministic Goal Harness CLI shim remains the default public smoke so ordinary
+contract checks stay fast and reproducible. The real-worker mode should be
+opt-in, should start from an empty isolated `HOME`, and should not read real
+session history or Codex App thread state.
+
+The real-worker mode must reuse the same pass criteria as the shim: `3-5`
+bounded worker steps, one JSONL row per step, deterministic validation, durable
+writeback, and exactly one quota spend after each validated work step. If the
+worker cannot complete the sequence, the log should record the public-safe
+blocker instead of hiding the stop condition in stdout.
+
 ## Failure Criteria
 
 - Any worker reads or requires real chat/session history.

--- a/examples/codex-cli-long-run-regression-spec-smoke.py
+++ b/examples/codex-cli-long-run-regression-spec-smoke.py
@@ -31,6 +31,12 @@ REQUIRED_PHRASES = (
     "running exactly `3` isolated worker steps",
     "`status`, `quota should-run`, `refresh-state`, and",
     "leaving a clear path for replacing the shim action with a real Codex CLI worker later",
+    "The next implementation stage should add an explicit, low-frequency runner mode",
+    "The deterministic Goal Harness CLI shim remains the default public smoke",
+    "The real-worker mode should be opt-in",
+    "should not read real session history or Codex App thread state",
+    "The real-worker mode must reuse the same pass criteria as the shim",
+    "the log should record the public-safe blocker",
     "fixed session-history replay",
     "compact synthetic transcripts, not copies of real user sessions",
 )


### PR DESCRIPTION
## Summary
- document that the current long-run regression is a deterministic Goal Harness CLI shim, not the full real Codex CLI worker check
- add the next-stage real-worker extension contract: opt-in, low-frequency, isolated HOME, same 3-5 step log/writeback/spend requirements
- extend the spec smoke so this boundary stays explicit

## Validation
- python3 examples/codex-cli-long-run-regression-spec-smoke.py
- python3 examples/codex-cli-long-run-regression-runner-smoke.py
- python3 examples/run-smokes.py
- goal-harness-canary check --scan-root .
- sensitive scan over changed tracked files: only forbidden-phrase test constants matched