### PR TITLE
Add interface budget cadence contract

### DIFF
--- a/docs/interface-budget-contract.md
+++ b/docs/interface-budget-contract.md
@@ -38,3 +38,31 @@ The regression entrypoint is:
 ```bash
 python3 examples/hot-path-interface-budget-smoke.py
 ```
+
+Cadence contract:
+
+The same smoke also emits and validates an `interface_budget_cadence` summary
+for clean drift checks. A drift-check run may record that summary in run
+history; `goal-harness status` projects it under
+`attention_queue.items[].project_asset.interface_budget_cadence`, and
+`quota should-run` mirrors the selected goal summary at top level. This lets a
+short heartbeat quiet-skip a still-fresh clean check without losing the ongoing
+guard todo.
+
+Stable cadence fields:
+
+- `checked_at`: when the hot-path budget check was run.
+- `freshness_hours`: how long the clean check remains fresh.
+- `next_check_due_at`: when the next check is due.
+- `overdue`: whether the current summary is past `next_check_due_at`.
+- `within_budget`: whether all measured hot-path surfaces fit their budgets.
+- `minimum_headroom_ratio`, `tightest_surface`, `tightest_metric`, and
+  `headroom_remaining`: compact headroom evidence for the tightest observed
+  surface.
+- `recommendation`: either `quiet_skip_until_next_check_due` or
+  `rerun_hot_path_interface_budget_smoke`.
+
+Do not add a heartbeat prompt branch for this cadence. Store exact measurements
+in run history, project only this compact decision summary, and rerun the smoke
+when `overdue=true` or when a prompt/status/quota/review-packet/dashboard
+contract changes.

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -348,6 +348,36 @@ missing `status_contract` means an older status producer; loopback dashboards
 should surface that as a daemon freshness warning rather than silently hiding
 newer panels.
 
+## Interface Budget Cadence
+
+When a run-history record includes `interface_budget_cadence`,
+`goal-harness status` projects a compact copy under
+`attention_queue.items[].project_asset.interface_budget_cadence`. For the
+selected goal, `quota should-run` also mirrors the same object at top level as
+`interface_budget_cadence`.
+
+This field is a restraint signal for heartbeat workers, not a dashboard feature
+request. It records the latest clean hot-path budget check, the tightest
+headroom observed, and when the next check is due. Fresh clean checks can
+support a quiet skip for the ongoing interface-budget guard; overdue or
+out-of-budget checks should prompt `python3
+examples/hot-path-interface-budget-smoke.py` or an equivalent explicit
+drift-check run.
+
+Stable fields:
+
+- `checked_at`
+- `freshness_hours`
+- `next_check_due_at`
+- `overdue`
+- `within_budget`
+- `surface_count`
+- `minimum_headroom_ratio`
+- `tightest_surface`
+- `tightest_metric`
+- `headroom_remaining`
+- `recommendation`
+
 ## Promotion Gate JSON
 
 `goal-harness promotion-gate --format json` is the compact machine-readable

--- a/examples/hot-path-interface-budget-smoke.py
+++ b/examples/hot-path-interface-budget-smoke.py
@@ -21,6 +21,7 @@ if str(REPO_ROOT) not in sys.path:
 
 from goal_harness.cli import review_packet_handoff_only_payload  # noqa: E402
 from goal_harness.heartbeat_prompt import build_heartbeat_prompt  # noqa: E402
+from goal_harness.interface_budget import build_interface_budget_cadence  # noqa: E402
 from goal_harness.quota import build_quota_should_run  # noqa: E402
 from goal_harness.review_packet import build_review_packet  # noqa: E402
 from goal_harness.status import collect_status  # noqa: E402
@@ -119,8 +120,14 @@ def write_registry(root: Path) -> tuple[Path, Path]:
     return registry_path, project
 
 
-def append_run(root: Path) -> None:
-    generated_at = "2026-01-01T00:05:00+00:00"
+def append_run(
+    root: Path,
+    *,
+    generated_at: str = "2026-01-01T00:05:00+00:00",
+    classification: str = "state_refreshed",
+    recommended_action: str = "Continue compact interface-budget validation.",
+    interface_budget_cadence: dict[str, Any] | None = None,
+) -> None:
     compact = generated_at.replace("-", "").replace(":", "")
     run_dir = root / "runtime" / "goals" / GOAL_ID / "runs"
     run_dir.mkdir(parents=True, exist_ok=True)
@@ -129,24 +136,26 @@ def append_run(root: Path) -> None:
     record = {
         "generated_at": generated_at,
         "goal_id": GOAL_ID,
-        "classification": "state_refreshed",
-        "recommended_action": "Continue compact interface-budget validation.",
+        "classification": classification,
+        "recommended_action": recommended_action,
         "health_check": "fixture hot-path budget run",
     }
+    if interface_budget_cadence:
+        record["interface_budget_cadence"] = interface_budget_cadence
     json_path.write_text(json.dumps(record, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
     markdown_path.write_text("# Fixture hot-path budget run\n", encoding="utf-8")
-    (run_dir / "index.jsonl").write_text(
-        json.dumps(
-            {
-                **record,
-                "json_path": str(json_path),
-                "markdown_path": str(markdown_path),
-            },
-            ensure_ascii=False,
+    with (run_dir / "index.jsonl").open("a", encoding="utf-8") as f:
+        f.write(
+            json.dumps(
+                {
+                    **record,
+                    "json_path": str(json_path),
+                    "markdown_path": str(markdown_path),
+                },
+                ensure_ascii=False,
+            )
+            + "\n"
         )
-        + "\n",
-        encoding="utf-8",
-    )
 
 
 def json_size(payload: dict[str, Any]) -> int:
@@ -209,6 +218,54 @@ def assert_contract_doc_matches_budget_table() -> None:
         assert str(budget["max_json_chars"]) in text.replace(",", "").replace("_", ""), surface
         assert str(budget["max_nested_keys"]) in text, surface
         assert str(budget["max_top_level_keys"]) in text, surface
+    for field in (
+        "interface_budget_cadence",
+        "checked_at",
+        "next_check_due_at",
+        "overdue",
+        "within_budget",
+        "minimum_headroom_ratio",
+        "quiet_skip_until_next_check_due",
+        "rerun_hot_path_interface_budget_smoke",
+    ):
+        assert field in text, field
+
+
+def assert_cadence_projection(
+    root: Path,
+    registry_path: Path,
+    project: Path,
+    cadence: dict[str, Any],
+) -> None:
+    append_run(
+        root,
+        generated_at="2099-01-01T00:10:00+00:00",
+        classification="interface_budget_cadence_check",
+        recommended_action=(
+            "Interface-budget drift check is clean; wait until the next cadence due time "
+            "unless a prompt or hot-path contract changes."
+        ),
+        interface_budget_cadence=cadence,
+    )
+    status_payload = collect_status(
+        registry_path=registry_path,
+        runtime_root_override=str(root / "runtime"),
+        scan_roots=[project],
+        limit=5,
+    )
+    items = status_payload["attention_queue"]["items"]
+    matches = [item for item in items if item.get("goal_id") == GOAL_ID]
+    assert len(matches) == 1, items
+    projected = matches[0]["project_asset"]["interface_budget_cadence"]
+    assert projected["overdue"] is False, projected
+    assert projected["within_budget"] is True, projected
+    assert projected["next_check_due_at"] == "2099-01-02T00:10:00+00:00", projected
+    assert projected["recommendation"] == "quiet_skip_until_next_check_due", projected
+
+    quota_payload = build_quota_should_run(status_payload, goal_id=GOAL_ID)
+    assert quota_payload["should_run"] is True, quota_payload
+    assert quota_payload["interface_budget_cadence"]["overdue"] is False, quota_payload
+    assert quota_payload["interface_budget_cadence"]["tightest_surface"] == cadence["tightest_surface"], quota_payload
 
 
 def main() -> int:
@@ -227,22 +284,47 @@ def main() -> int:
         handoff_payload = review_packet_handoff_only_payload(review_packet)
         heartbeat_payload = build_heartbeat_prompt(goal_id=GOAL_ID, thin=True)
 
-    assert quota_payload["should_run"] is True, quota_payload
-    assert handoff_payload["within_budget"] is True, handoff_payload
-    summaries = [
-        assert_surface("heartbeat_prompt_json", heartbeat_payload),
-        assert_surface("review_packet_handoff_only_json", handoff_payload),
-        assert_surface("quota_should_run_json", quota_payload),
-        assert_surface("dashboard_status_json", status_payload),
-    ]
-    assert_contract_doc_matches_budget_table()
+        assert quota_payload["should_run"] is True, quota_payload
+        assert handoff_payload["within_budget"] is True, handoff_payload
+        summaries = [
+            assert_surface("heartbeat_prompt_json", heartbeat_payload),
+            assert_surface("review_packet_handoff_only_json", handoff_payload),
+            assert_surface("quota_should_run_json", quota_payload),
+            assert_surface("dashboard_status_json", status_payload),
+        ]
+        cadence = build_interface_budget_cadence(
+            summaries,
+            checked_at="2099-01-01T00:10:00+00:00",
+            now="2099-01-01T01:00:00+00:00",
+            freshness_hours=24,
+        )
+        assert cadence["within_budget"] is True, cadence
+        assert cadence["overdue"] is False, cadence
+        assert cadence["surface_count"] == len(summaries), cadence
+        assert cadence["next_check_due_at"] == "2099-01-02T00:10:00+00:00", cadence
+        assert cadence["minimum_headroom_ratio"] is not None, cadence
+        stale_cadence = build_interface_budget_cadence(
+            summaries,
+            checked_at="2099-01-01T00:10:00+00:00",
+            now="2099-01-02T00:10:00+00:00",
+            freshness_hours=24,
+        )
+        assert stale_cadence["overdue"] is True, stale_cadence
+        assert stale_cadence["recommendation"] == "rerun_hot_path_interface_budget_smoke", stale_cadence
+        assert_cadence_projection(root, registry_path, project, cadence)
+        assert_contract_doc_matches_budget_table()
 
-    for summary in summaries:
+        for summary in summaries:
+            print(
+                "{surface}: owner={owner} consumer={consumer} "
+                "json_chars={json_chars}/{max_json_chars} "
+                "nested_keys={nested_keys}/{max_nested_keys} "
+                "top_level_keys={top_level_keys}/{max_top_level_keys}".format(**summary)
+            )
         print(
-            "{surface}: owner={owner} consumer={consumer} "
-            "json_chars={json_chars}/{max_json_chars} "
-            "nested_keys={nested_keys}/{max_nested_keys} "
-            "top_level_keys={top_level_keys}/{max_top_level_keys}".format(**summary)
+            "interface_budget_cadence: checked_at={checked_at} next_check_due_at={next_check_due_at} "
+            "tightest={tightest_surface}/{tightest_metric} headroom={headroom_remaining} "
+            "overdue={overdue}".format(**cadence)
         )
     print("hot-path-interface-budget-smoke ok")
     return 0

--- a/goal_harness/interface_budget.py
+++ b/goal_harness/interface_budget.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+
+DEFAULT_INTERFACE_BUDGET_FRESHNESS_HOURS = 24
+INTERFACE_BUDGET_CADENCE_SOURCE = "interface_budget_drift_check"
+
+
+def parse_timestamp(value: Any) -> datetime | None:
+    if not value:
+        return None
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+    text = str(value).strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _number(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _round_ratio(value: float | None) -> float | None:
+    if value is None:
+        return None
+    return round(value, 4)
+
+
+def _metric_headroom(surface: dict[str, Any], value_key: str, limit_key: str) -> dict[str, Any] | None:
+    value = _number(surface.get(value_key))
+    limit = _number(surface.get(limit_key))
+    if value is None or limit is None:
+        return None
+    remaining = limit - value
+    ratio = remaining / limit if limit > 0 else None
+    return {
+        "metric": value_key,
+        "value": int(value) if value.is_integer() else value,
+        "limit": int(limit) if limit.is_integer() else limit,
+        "remaining": int(remaining) if remaining.is_integer() else remaining,
+        "headroom_ratio": _round_ratio(ratio),
+        "within_budget": remaining >= 0,
+    }
+
+
+def surface_headroom(surface: dict[str, Any]) -> dict[str, Any] | None:
+    if not isinstance(surface, dict):
+        return None
+    metrics = [
+        _metric_headroom(surface, "json_chars", "max_json_chars"),
+        _metric_headroom(surface, "nested_keys", "max_nested_keys"),
+        _metric_headroom(surface, "top_level_keys", "max_top_level_keys"),
+    ]
+    metrics = [metric for metric in metrics if metric]
+    if not metrics:
+        return None
+    tightest = min(
+        metrics,
+        key=lambda metric: float(metric.get("headroom_ratio") or 0),
+    )
+    return {
+        "surface": str(surface.get("surface") or "unknown"),
+        "within_budget": all(metric.get("within_budget") is True for metric in metrics),
+        "minimum_headroom_ratio": tightest.get("headroom_ratio"),
+        "tightest_metric": tightest.get("metric"),
+        "headroom_remaining": tightest.get("remaining"),
+    }
+
+
+def build_interface_budget_cadence(
+    surfaces: list[dict[str, Any]],
+    *,
+    checked_at: str,
+    now: datetime | str | None = None,
+    freshness_hours: int = DEFAULT_INTERFACE_BUDGET_FRESHNESS_HOURS,
+) -> dict[str, Any]:
+    checked_dt = parse_timestamp(checked_at)
+    now_dt = parse_timestamp(now) if now is not None else datetime.now(timezone.utc)
+    headrooms = [
+        headroom
+        for surface in surfaces
+        if isinstance(surface, dict)
+        for headroom in [surface_headroom(surface)]
+        if headroom
+    ]
+    tightest = min(
+        headrooms,
+        key=lambda item: float(item.get("minimum_headroom_ratio") or 0),
+    ) if headrooms else None
+    next_due_dt = (
+        checked_dt + timedelta(hours=max(1, int(freshness_hours)))
+        if checked_dt is not None
+        else None
+    )
+    overdue = bool(next_due_dt and now_dt and now_dt >= next_due_dt)
+    within_budget = bool(headrooms) and all(item.get("within_budget") is True for item in headrooms)
+    recommendation = (
+        "quiet_skip_until_next_check_due"
+        if within_budget and not overdue
+        else "rerun_hot_path_interface_budget_smoke"
+    )
+    return {
+        "source": INTERFACE_BUDGET_CADENCE_SOURCE,
+        "checked_at": checked_at,
+        "freshness_hours": max(1, int(freshness_hours)),
+        "next_check_due_at": next_due_dt.isoformat() if next_due_dt else None,
+        "overdue": overdue,
+        "within_budget": within_budget,
+        "surface_count": len(headrooms),
+        "minimum_headroom_ratio": tightest.get("minimum_headroom_ratio") if tightest else None,
+        "tightest_surface": tightest.get("surface") if tightest else None,
+        "tightest_metric": tightest.get("tightest_metric") if tightest else None,
+        "headroom_remaining": tightest.get("headroom_remaining") if tightest else None,
+        "recommendation": recommendation,
+    }
+
+
+def compact_interface_budget_cadence(
+    value: dict[str, Any],
+    *,
+    now: datetime | str | None = None,
+) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+    checked_at = str(value.get("checked_at") or "").strip()
+    next_due_at = str(value.get("next_check_due_at") or "").strip()
+    checked_dt = parse_timestamp(checked_at)
+    next_due_dt = parse_timestamp(next_due_at)
+    now_dt = parse_timestamp(now) if now is not None else datetime.now(timezone.utc)
+    overdue = bool(next_due_dt and now_dt and now_dt >= next_due_dt)
+    within_budget = value.get("within_budget") is True
+    recommendation = str(value.get("recommendation") or "").strip()
+    if within_budget and not overdue:
+        recommendation = recommendation or "quiet_skip_until_next_check_due"
+    else:
+        recommendation = recommendation or "rerun_hot_path_interface_budget_smoke"
+
+    compact = {
+        "source": str(value.get("source") or INTERFACE_BUDGET_CADENCE_SOURCE),
+        "checked_at": checked_at or None,
+        "freshness_hours": value.get("freshness_hours"),
+        "next_check_due_at": next_due_at or None,
+        "overdue": overdue,
+        "within_budget": within_budget,
+        "surface_count": value.get("surface_count"),
+        "minimum_headroom_ratio": value.get("minimum_headroom_ratio"),
+        "tightest_surface": value.get("tightest_surface"),
+        "tightest_metric": value.get("tightest_metric"),
+        "headroom_remaining": value.get("headroom_remaining"),
+        "recommendation": recommendation,
+    }
+    if checked_dt is None:
+        compact["checked_at"] = checked_at or None
+    return {key: current for key, current in compact.items() if current is not None}
+
+
+def interface_budget_cadence_from_run(
+    run: dict[str, Any],
+    *,
+    now: datetime | str | None = None,
+) -> dict[str, Any] | None:
+    if not isinstance(run, dict):
+        return None
+    cadence = run.get("interface_budget_cadence")
+    if isinstance(cadence, dict):
+        compact = compact_interface_budget_cadence(cadence, now=now)
+        if compact:
+            compact["run_generated_at"] = run.get("generated_at")
+            compact["run_classification"] = run.get("classification")
+        return compact
+    surfaces = run.get("interface_budget_surfaces")
+    if isinstance(surfaces, list) and run.get("generated_at"):
+        summary = build_interface_budget_cadence(
+            [surface for surface in surfaces if isinstance(surface, dict)],
+            checked_at=str(run.get("generated_at")),
+            now=now,
+        )
+        summary["run_generated_at"] = run.get("generated_at")
+        summary["run_classification"] = run.get("classification")
+        return summary
+    return None
+
+
+def interface_budget_cadence_for_runs(
+    runs: list[dict[str, Any]],
+    *,
+    now: datetime | str | None = None,
+) -> dict[str, Any] | None:
+    for run in runs:
+        cadence = interface_budget_cadence_from_run(run, now=now)
+        if cadence:
+            return cadence
+    return None

--- a/goal_harness/quota.py
+++ b/goal_harness/quota.py
@@ -1467,6 +1467,13 @@ def build_quota_should_run(status_payload: dict[str, Any], *, goal_id: str) -> d
         )
         if backlog_warning:
             payload["backlog_hygiene_warning"] = backlog_warning
+        interface_budget_cadence = (
+            project_asset.get("interface_budget_cadence")
+            if isinstance(project_asset.get("interface_budget_cadence"), dict)
+            else None
+        )
+        if interface_budget_cadence:
+            payload["interface_budget_cadence"] = interface_budget_cadence
         decision_warning = _decision_freshness_warning(status_payload, goal_id=safe_goal_id)
         if decision_warning:
             payload["decision_freshness_warning"] = decision_warning
@@ -1986,6 +1993,23 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
         )
         if backlog_hygiene_warning.get("recommended_action"):
             lines.append(f"- backlog_hygiene_action: {backlog_hygiene_warning.get('recommended_action')}")
+    interface_budget_cadence = (
+        payload.get("interface_budget_cadence")
+        if isinstance(payload.get("interface_budget_cadence"), dict)
+        else {}
+    )
+    if interface_budget_cadence:
+        lines.append(
+            "- interface_budget_cadence: "
+            f"overdue={interface_budget_cadence.get('overdue')} "
+            f"within_budget={interface_budget_cadence.get('within_budget')} "
+            f"checked_at={interface_budget_cadence.get('checked_at')} "
+            f"next_check_due_at={interface_budget_cadence.get('next_check_due_at')} "
+            f"tightest={interface_budget_cadence.get('tightest_surface')}/"
+            f"{interface_budget_cadence.get('tightest_metric')} "
+            f"headroom={interface_budget_cadence.get('headroom_remaining')} "
+            f"recommendation={interface_budget_cadence.get('recommendation')}"
+        )
     execution_profile = (
         payload.get("execution_profile")
         if isinstance(payload.get("execution_profile"), dict)

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -22,6 +22,7 @@ from .execution_profile import (
 )
 from .handoff_budget import handoff_budget_contract
 from .history import collect_history, load_registry
+from .interface_budget import interface_budget_cadence_for_runs
 from .materials import extract_review_materials
 from .operator_gate import DEFAULT_OPERATOR_GATE, default_operator_question, normalize_operator_question
 from .orchestration import compact_orchestration_policy, orchestration_policy_summary
@@ -1215,6 +1216,7 @@ def enrich_project_asset(
     execution_profile: dict[str, Any] | None = None,
     orchestration: dict[str, Any] | None = None,
     subagent_activity: dict[str, Any] | None = None,
+    interface_budget_cadence: dict[str, Any] | None = None,
 ) -> None:
     project_asset = item.get("project_asset")
     if not isinstance(project_asset, dict):
@@ -1234,6 +1236,8 @@ def enrich_project_asset(
         project_asset["orchestration"] = compact_orchestration_policy(orchestration)
     if subagent_activity:
         project_asset["subagent_activity"] = subagent_activity
+    if interface_budget_cadence:
+        project_asset["interface_budget_cadence"] = interface_budget_cadence
     if latest_validation:
         project_asset["latest_validation"] = latest_validation
     readiness = project_asset_handoff_readiness(item, latest_runs=latest_runs)
@@ -1945,6 +1949,7 @@ def build_attention_queue(
                 item["control_plane"] = control_plane
             goal_latest_runs = goal.get("latest_runs") if isinstance(goal.get("latest_runs"), list) else []
             subagent_activity = subagent_activity_for_goal(goal)
+            interface_budget_cadence = interface_budget_cadence_for_runs(goal_latest_runs)
             projection_warning = active_state_projection_warning(goal, latest_run(goal))
             enrich_project_asset(
                 item,
@@ -1961,6 +1966,7 @@ def build_attention_queue(
                     else None
                 ),
                 subagent_activity=subagent_activity,
+                interface_budget_cadence=interface_budget_cadence,
             )
             if control_plane and isinstance(item.get("project_asset"), dict):
                 item["project_asset"]["control_plane"] = control_plane
@@ -1992,6 +1998,7 @@ def build_attention_queue(
                     quota=item.get("quota") if isinstance(item.get("quota"), dict) else None,
                     latest_runs=goal_latest_runs,
                     subagent_activity=subagent_activity,
+                    interface_budget_cadence=interface_budget_cadence,
                 )
                 guarded_quota = quota_with_handoff_outcome_floor(
                     item.get("quota") if isinstance(item.get("quota"), dict) else {},
@@ -2012,6 +2019,7 @@ def build_attention_queue(
                         quota=guarded_quota,
                         latest_runs=goal_latest_runs,
                         subagent_activity=subagent_activity,
+                        interface_budget_cadence=interface_budget_cadence,
                     )
             history_items.append(item)
 
@@ -3214,6 +3222,23 @@ def render_status_markdown(payload: dict[str, Any]) -> str:
                     f"requires_agent_todo={backlog_warning.get('requires_agent_todo')} "
                     f"evidence_count={backlog_warning.get('evidence_count')} "
                     f"source_sections={_markdown_scalar(','.join(backlog_warning.get('source_sections') or []))}"
+                )
+            interface_budget_cadence = (
+                project_asset.get("interface_budget_cadence")
+                if isinstance(project_asset.get("interface_budget_cadence"), dict)
+                else {}
+            )
+            if interface_budget_cadence:
+                lines.append(
+                    "    - interface_budget_cadence: "
+                    f"overdue={interface_budget_cadence.get('overdue')} "
+                    f"within_budget={interface_budget_cadence.get('within_budget')} "
+                    f"checked_at={_markdown_scalar(interface_budget_cadence.get('checked_at') or '')} "
+                    f"next_check_due_at={_markdown_scalar(interface_budget_cadence.get('next_check_due_at') or '')} "
+                    f"tightest={_markdown_scalar(interface_budget_cadence.get('tightest_surface') or '')}/"
+                    f"{_markdown_scalar(interface_budget_cadence.get('tightest_metric') or '')} "
+                    f"headroom={interface_budget_cadence.get('headroom_remaining')} "
+                    f"recommendation={_markdown_scalar(interface_budget_cadence.get('recommendation') or '')}"
                 )
             latest_validation = (
                 project_asset.get("latest_validation")


### PR DESCRIPTION
Summary:
- add a compact interface_budget_cadence helper for drift-check headroom, freshness, next due time, and rerun vs quiet-skip recommendation
- project cadence evidence from run history into status project_asset and quota should-run for the selected goal
- extend the hot-path interface-budget smoke and docs so the cadence contract is validated without adding heartbeat prompt branches

Validation:
- python3 -m py_compile goal_harness/interface_budget.py goal_harness/status.py goal_harness/quota.py examples/hot-path-interface-budget-smoke.py
- python3 examples/hot-path-interface-budget-smoke.py
- python3 examples/status-markdown-smoke.py
- python3 examples/quota-plan-smoke.py
- python3 examples/run-smokes.py
- python3 -m goal_harness.cli --format json check --scan-root .
- git diff --check
- staged sensitive scan found only the existing SECRET_LIKE_SURFACE_PATTERN constant references

Notes:
- no .local, runtime, registry history, credentials, or private project evidence is included