### PR TITLE
Route dependency observations back to primary backlog

### DIFF
--- a/examples/quota-plan-smoke.py
+++ b/examples/quota-plan-smoke.py
@@ -983,7 +983,12 @@ def assert_control_plane_waiting_projection_self_repair_should_run() -> None:
     assert "control-plane self-repair" in spend_event["health_check"], spend_event
 
 
-def post_handoff_meta_fixture(*, with_agent_todo: bool) -> dict:
+def post_handoff_meta_fixture(
+    *,
+    with_agent_todo: bool,
+    latest_classification: str = "handoff_only_budget_fields_merged",
+    agent_todo_text: str = "Keep heartbeat prompt and agent-to-CLI interaction lean as an ongoing interface-budget task.",
+) -> dict:
     goal_id = "goal-harness-meta"
     meta_goal = goal(goal_id, compute=1.0)
     meta_goal["adapter_kind"] = "harness_self_improvement"
@@ -1008,7 +1013,7 @@ def post_handoff_meta_fixture(*, with_agent_todo: bool) -> dict:
         "post_handoff_small_scale_streak": 0,
         "post_handoff_latest_run": {
             "generated_at": "2026-06-06T21:35:46+08:00",
-            "classification": "handoff_only_budget_fields_merged",
+            "classification": latest_classification,
             "delivery_batch_scale": "implementation",
             "delivery_outcome": "primary_goal_outcome",
             "health_check": "state_file 1/1; registry_goal 1/1",
@@ -1026,7 +1031,7 @@ def post_handoff_meta_fixture(*, with_agent_todo: bool) -> dict:
                 {
                     "index": 1,
                     "done": False,
-                    "text": "Keep heartbeat prompt and agent-to-CLI interaction lean as an ongoing interface-budget task.",
+                    "text": agent_todo_text,
                 }
             ],
         }
@@ -1094,6 +1099,42 @@ def assert_control_plane_post_handoff_agent_todo_stays_active() -> None:
         "execution_obligation: must_attempt_work=True kind=normal_run notify_is_execution_gate=False"
         in markdown
     ), markdown
+
+
+def assert_dependency_observation_returns_to_primary_backlog() -> None:
+    goal_id = "goal-harness-meta"
+    payload = post_handoff_meta_fixture(
+        with_agent_todo=True,
+        latest_classification="side_bypass_seed308_dependency_observed",
+        agent_todo_text="SOTA long-horizon agent paper and runner dossier.",
+    )
+    decision = build_quota_should_run(payload, goal_id=goal_id)
+    markdown = render_quota_should_run_markdown(decision)
+
+    assert decision["ok"] is True, decision
+    assert decision["decision"] == "run", decision
+    assert decision["should_run"] is True, decision
+    first_todo = decision["agent_todo_summary"]["first_open_items"][0]
+    first_todo_text = str(first_todo.get("title") or first_todo.get("text") or "")
+    assert first_todo_text.startswith("SOTA long-horizon"), decision
+    assert (
+        decision["heartbeat_recommendation"]["recommended_mode"]
+        == "advance_primary_backlog_after_dependency_observation"
+    ), decision
+    assert (
+        decision["heartbeat_recommendation"]["latest_run"]["progress_scope"]
+        == "dependency_observation"
+    ), decision
+    assert (
+        decision["heartbeat_recommendation"]["dependency_observation_cap"][
+            "latest_run_progress_scope"
+        ]
+        == "dependency_observation"
+    ), decision
+    assert "dependency_observation_cap" in markdown, markdown
+    assert "advance_primary_backlog_after_dependency_observation" in markdown, markdown
+    assert decision["execution_obligation"]["must_attempt_work"] is True, decision
+    assert decision["execution_obligation"]["kind"] == "normal_run", decision
 
 
 def assert_attention_queue_overrides_stale_run_history() -> None:
@@ -1555,6 +1596,7 @@ def main() -> int:
     assert_control_plane_waiting_projection_self_repair_should_run()
     assert_control_plane_post_handoff_observe_if_unchanged()
     assert_control_plane_post_handoff_agent_todo_stays_active()
+    assert_dependency_observation_returns_to_primary_backlog()
     assert_attention_queue_overrides_stale_run_history()
     assert_project_asset_backed_no_evidence_should_run()
     assert_heartbeat_recommendation_lifecycle()

--- a/goal_harness/quota.py
+++ b/goal_harness/quota.py
@@ -62,6 +62,7 @@ HANDOFF_READINESS_COMPACT_FIELDS = (
 POST_HANDOFF_RUN_COMPACT_FIELDS = (
     "generated_at",
     "classification",
+    "progress_scope",
     "delivery_batch_scale",
     "delivery_outcome",
     "health_check",
@@ -81,6 +82,11 @@ STALL_HEALTH_ITEM_COMPACT_FIELDS = (
     "recommended_action",
 )
 DECISION_FRESHNESS_WARNING_ITEM_LIMIT = 3
+DEPENDENCY_OBSERVATION_CLASSIFICATION_HINTS = (
+    "dependency_observed",
+    "dependency_observation",
+    "dependency_monitor",
+)
 
 
 def _now_local() -> str:
@@ -180,6 +186,16 @@ def _has_focus_wait_marker(*values: Any) -> bool:
             if marker in FOCUS_WAIT_LIFECYCLE_MARKERS:
                 return True
     return False
+
+
+def _latest_run_progress_scope(run: dict[str, Any]) -> str:
+    explicit = str(run.get("progress_scope") or "").strip()
+    if explicit:
+        return explicit
+    classification = str(run.get("classification") or "").strip().lower()
+    if any(hint in classification for hint in DEPENDENCY_OBSERVATION_CLASSIFICATION_HINTS):
+        return "dependency_observation"
+    return "primary_goal"
 
 
 def _focus_wait_quota(payload: dict[str, Any]) -> dict[str, Any]:
@@ -947,6 +963,42 @@ def _heartbeat_recommendation(
 
     post_handoff_observation = _control_plane_post_handoff_observation_hint(item)
     if post_handoff_observation and not has_user_todos:
+        latest_observed_run = (
+            post_handoff_observation.get("latest_run")
+            if isinstance(post_handoff_observation.get("latest_run"), dict)
+            else {}
+        )
+        progress_scope = _latest_run_progress_scope(latest_observed_run)
+        if isinstance(latest_observed_run, dict) and latest_observed_run:
+            latest_observed_run.setdefault("progress_scope", progress_scope)
+        if has_agent_todos and progress_scope == "dependency_observation":
+            return {
+                **base,
+                **{
+                    key: value
+                    for key, value in post_handoff_observation.items()
+                    if key != "stop_if_unchanged"
+                },
+                "recommended_mode": "advance_primary_backlog_after_dependency_observation",
+                "dependency_observation_cap": {
+                    "latest_run_progress_scope": progress_scope,
+                    "rule": (
+                        "Do not spend another consecutive meta turn mirroring dependency-only "
+                        "observation while primary agent todos remain executable."
+                    ),
+                },
+                "spend_policy": (
+                    "do not append quota spend for another dependency-only observation; "
+                    "spend only after advancing the primary agent-todo backlog, writing a "
+                    "real blocker, or recording a material dependency transition that changes "
+                    "the meta decision"
+                ),
+                "reason": (
+                    "latest post-handoff run was a dependency observation, not the meta "
+                    "primary research lane; advance the first executable agent todo instead "
+                    "of continuing dependency monitoring"
+                ),
+            }
         if has_agent_todos:
             active_observation = {
                 key: value
@@ -2167,6 +2219,16 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
             lines.append(f"- heartbeat_command: `{heartbeat_recommendation.get('command')}`")
         if heartbeat_recommendation.get("stop_if_unchanged"):
             lines.append("- heartbeat_stop_if_unchanged: `True`")
+        dependency_cap = (
+            heartbeat_recommendation.get("dependency_observation_cap")
+            if isinstance(heartbeat_recommendation.get("dependency_observation_cap"), dict)
+            else {}
+        )
+        if dependency_cap:
+            lines.append(
+                "- dependency_observation_cap: "
+                f"progress_scope={dependency_cap.get('latest_run_progress_scope')}"
+            )
         if heartbeat_recommendation.get("spend_policy"):
             lines.append(f"- heartbeat_spend_policy: {heartbeat_recommendation.get('spend_policy')}")
         if heartbeat_recommendation.get("reason"):


### PR DESCRIPTION
## Summary
- classify dependency-observation latest runs with progress_scope=dependency_observation in quota should-run
- route meta heartbeat recommendation back to the first executable primary agent todo after dependency-only observations
- add quota-plan smoke coverage for the side-bypass dependency-observed case

## Validation
- python3 examples/quota-plan-smoke.py
- python3 examples/heartbeat-prompt-smoke.py
- python3 -m py_compile goal_harness/quota.py examples/quota-plan-smoke.py
- git diff --check origin/main..HEAD
- goal-harness check --scan-path goal_harness/quota.py --scan-path examples/quota-plan-smoke.py --limit 50