### PR TITLE
Add long-horizon paper runner dossier

### DIFF
--- a/docs/authority-source-registration.md
+++ b/docs/authority-source-registration.md
@@ -71,3 +71,38 @@ the existing authority-registry projection.
 - Do not read or summarize the source body as part of registration. This command
   records the source contract; later project-specific work decides whether a
   source can be read.
+
+## Importing A Doc Registry
+
+`goal-harness import-doc-registry-authority` imports the authority contract from
+a DOC_REGISTRY-style YAML file without copying the raw document body or the raw
+registry path into the stored payload. It reads only:
+
+- `default_entry_docs`;
+- `topic_authority`;
+- `status_definitions`;
+- `version` and `updated_at`.
+
+The raw `DOC_REGISTRY.yaml` path is hashed as `source_ref_sha256`. The local
+registry receives a `doc_registry_authority_import_v0` material entry with
+`default_entry_count`, `topic_authority_count`, `status_definition_count`, and
+small samples for local operator orientation. Shared global sync keeps the usual
+compact authority/material counts.
+
+```bash
+goal-harness import-doc-registry-authority \
+  --goal-id example-goal \
+  --source-id external-doc-registry \
+  --doc-registry-path ../external-project/docs/meta/DOC_REGISTRY.yaml \
+  --role external_doc_authority \
+  --freshness current \
+  --boundary private_redacted \
+  --topic external_doc_registry \
+  --import-topic-prefix external_ \
+  --max-imported-topics 50 \
+  --dry-run
+```
+
+Use `--topic` for a small hand-picked local topic key, and
+`--import-topic-prefix` only when the importing goal should route a bounded set
+of external registry topics through its own authority map.

--- a/docs/research/long-horizon-agent-benchmarks/README.md
+++ b/docs/research/long-horizon-agent-benchmarks/README.md
@@ -26,6 +26,9 @@ work still belongs in the existing code, examples, and contract documents:
 
 - `roadmap.md`: benchmark selection, passive baseline, operator-simulator, and
   publication-readiness roadmap.
+- `paper-runner-dossier.md`: first evidence-backed ranking of benchmark papers,
+  runner surfaces, Codex compatibility signals, and the next Terminal-Bench
+  probe slice.
 
 ## Relationship To Goal Harness Work
 

--- a/docs/research/long-horizon-agent-benchmarks/paper-runner-dossier.md
+++ b/docs/research/long-horizon-agent-benchmarks/paper-runner-dossier.md
@@ -1,0 +1,225 @@
+# Paper And Runner Dossier
+
+Checked at: 2026-06-07T17:48:00+08:00.
+
+This dossier ranks candidate long-horizon agent benchmarks for Goal Harness
+research. It is a research artifact, not a product implementation plan. Any
+Goal Harness feature discovered here should be split into normal product code,
+examples, or contract docs outside this topic folder.
+
+## Current Recommendation
+
+Use Terminal-Bench 2.0 as the first official-runner probe, then SWE-Marathon as
+the first heavy long-horizon software-engineering probe.
+
+The reason is pragmatic. Terminal-Bench has an open runner, Docker-style
+terminal tasks, verified leaderboard entries, and visible Codex/Codex-adjacent
+agent rows. It is the fastest way to test whether a passive Goal Harness wrapper
+can add restartability, state truth, event ledgers, and failure attribution
+without changing the official scoring protocol.
+
+SWE-Marathon is closer to the user's paper-level ambition because the tasks are
+explicitly ultra-long software-engineering work, but it is heavier: the public
+repo uses a Harbor fork, task execution is likely expensive, and some log
+access is gated by external credentials. It should be the second lane after the
+Terminal-Bench wrapper boundary is understood.
+
+## Ranking
+
+| Rank | Candidate | Use | Why |
+| --- | --- | --- | --- |
+| 1 | Terminal-Bench 2.0 | First official-runner probe | Open benchmark repo, terminal task model, verified leaderboard, visible Codex entries, and a protocol that already treats agent tools as part of the scored system. |
+| 2 | SWE-Marathon | First heavy SWE probe | Strongest fit for hours-to-days software-engineering work; public repo and 20 ultra-long tasks, but setup and cost are heavier. |
+| 3 | LongCLI-Bench | Paper hypothesis and failure-analysis source | Directly studies long-horizon CLI programming, step-level failures, and human-agent collaboration gains; runner openness still needs verification before it becomes an execution lane. |
+| 4 | WildClawBench | Native-runtime comparison lane | Promising because it evaluates real CLI harnesses including Codex-style harnesses in reproducible containers, but it is very new and needs protocol/code review. |
+| 5 | HORIZON / METR-style signals | Diagnostic and positioning signal | Useful to explain long-horizon degradation and compare across domains, but currently better as a leaderboard/diagnostic reference than as the first runnable Goal Harness integration. |
+| 6 | SWE-EVO / RoadmapBench / LongDS-Bench | Watchlist | Useful for breadth and paper framing after one official runner works. |
+| 7 | Tau-style suites | Simulator research only | Valuable for user-simulator design, but not the headline long-horizon engineering benchmark. |
+
+## Source Notes
+
+### Terminal-Bench 2.0
+
+Evidence:
+
+- Official Epoch page describes a task as an instruction, Docker environment,
+  and test script, and says models are paired with agent tools such as Claude
+  Code, OpenAI Codex CLI, Terminus, and Goose.
+- Terminal-Bench paper presents 89 hard terminal-environment tasks with
+  verification tests and reports frontier models and agents below 65 percent.
+- Official leaderboard page for `terminal-bench@2.0` shows verified GPT-5.3
+  Codex rows including Simple Codex and Terminus 2.
+- GitHub repo describes Terminal-Bench as evaluating real-world end-to-end
+  terminal tasks autonomously.
+
+Fit for Goal Harness:
+
+- Strong first target for passive Goal Harness because the benchmark already
+  separates agent tool/scaffold from model.
+- Goal Harness can wrap around run setup, event ledger, restart state,
+  validation evidence, and failure attribution while preserving official task
+  scoring.
+- The benchmark explicitly forbids timeout/resource modification in leaderboard
+  submissions, so Goal Harness integration must avoid changing resource budget
+  or task files.
+
+Open questions:
+
+- Determine whether a passive wrapper can be submitted as a custom agent or
+  must be used only for local A/B studies.
+- Check whether Harbor's custom-agent path can launch Codex CLI directly or
+  needs a small adapter.
+
+Sources:
+
+- https://epoch.ai/benchmarks/terminal-bench/
+- https://arxiv.org/abs/2601.11868
+- https://www.tbench.ai/leaderboard/terminal-bench/2.0
+- https://github.com/harbor-framework/terminal-bench
+
+### SWE-Marathon
+
+Evidence:
+
+- Public repo asks whether agents can complete ultra-long-horizon software
+  work.
+- Repo uses a Harbor fork, includes tasks, rubrics, scripts, and Apache 2.0
+  licensing.
+- Hugging Face dataset page says there are 20 ultra-long software-engineering
+  tasks, each with a containerized environment, precise instruction,
+  comprehensive tests, and an oracle/reference solution.
+- Dataset page says tasks are intended for evaluating agents on realistic
+  long-horizon hours-to-days software-engineering tasks end-to-end in a
+  sandboxed environment.
+
+Fit for Goal Harness:
+
+- Strongest research target once Terminal-Bench wrapper mechanics are known.
+- Directly tests multi-hour/multi-day continuation, state handoff, validation
+  discipline, and restartability.
+- Likely a good paper target because Goal Harness's thesis is about reducing
+  coordination load and preserving durable state over long projects.
+
+Risks:
+
+- Higher cost and wall-clock time.
+- Public repo's sample command shows Claude Code; Codex CLI compatibility needs
+  runner inspection before making claims.
+- Some trajectory-log access requires external credentials, so early work
+  should use public task files and local dry-runs only.
+
+Sources:
+
+- https://github.com/abundant-ai/swe-marathon
+- https://www.swe-marathon.org/
+- https://huggingface.co/datasets/rdesai2/swe-marathon
+
+### LongCLI-Bench
+
+Evidence:
+
+- ArXiv paper introduces 20 long-horizon CLI programming tasks from computer
+  science assignments and real-world workflows.
+- It covers from-scratch implementation, feature addition, bug fixing, and
+  refactoring.
+- It reports state-of-the-art pass rates below 20 percent, with many tasks
+  stalling before 30 percent completion.
+- It finds human-agent collaboration through plan injection and interactive
+  guidance improves outcomes, which aligns with Goal Harness's supervised
+  long-horizon thesis.
+
+Fit for Goal Harness:
+
+- Excellent source for paper framing and failure taxonomy.
+- Useful for designing operator-simulator experiments because it explicitly
+  discusses collaborative guidance.
+
+Risk:
+
+- Runner/code availability and Codex CLI baseline need verification before it
+  becomes an execution target.
+
+Source:
+
+- https://arxiv.org/abs/2602.14337
+
+### WildClawBench
+
+Evidence:
+
+- ArXiv paper frames the gap as existing benchmarks being too synthetic,
+  short-horizon, mock-service based, or final-answer oriented.
+- It contains 60 human-authored tasks with roughly 8 minutes average wall time
+  and more than 20 tool calls.
+- It runs in reproducible Docker containers hosting actual CLI harnesses such
+  as OpenClaw, Claude Code, Codex, or Hermes Agent.
+- It reports harness choice alone can shift one model by up to 18 points.
+
+Fit for Goal Harness:
+
+- Useful after Terminal-Bench because it emphasizes native runtime and harness
+  effects, which is exactly where Goal Harness should claim value.
+
+Risk:
+
+- Very new; code, scoring, and leaderboard stability need review before a
+  serious run.
+
+Source:
+
+- https://arxiv.org/abs/2605.10912
+
+### HORIZON / METR-style Signals
+
+Evidence:
+
+- HORIZON paper studies long-horizon failure behavior across domains and uses
+  trajectory-grounded failure attribution.
+- HORIZON site presents itself as a live ranking for frontier models and agents
+  on long-horizon software engineering, with METR-Horizon as the primary signal
+  and Terminal-Bench plus SWE-style benchmarks as secondary signals.
+
+Fit for Goal Harness:
+
+- Use as a positioning and diagnostic source, not first runner.
+- The failure-attribution angle is useful for Goal Harness result reports.
+
+Sources:
+
+- https://arxiv.org/abs/2604.11978
+- https://horizonbench.org/
+
+### LongDS-Bench
+
+Evidence:
+
+- ArXiv paper introduces long-horizon, multi-turn data analysis tasks requiring
+  agents to maintain, update, restore, and compose evolving analytical states.
+- It reports performance degradation over late turns and argues the bottleneck
+  is maintaining correct analytical state rather than merely increasing steps.
+
+Fit for Goal Harness:
+
+- Watchlist for state-truth research after engineering benchmark lanes run.
+- Relevant to Goal Harness because it isolates state maintenance failures.
+
+Source:
+
+- https://arxiv.org/abs/2605.30434
+
+## First Execution Slice
+
+The next bounded implementation/research slice should be:
+
+1. Inspect Terminal-Bench's Harbor runner and custom-agent path.
+2. Determine whether Codex CLI can run as an official custom agent, or whether
+   Goal Harness must run a local-only passive A/B wrapper first.
+3. Write a `terminal_bench_probe_v0` note with:
+   - command attempted or dry-run command;
+   - runner version/source;
+   - resource/scoring boundary;
+   - allowed passive logging surface;
+   - whether official leaderboard submission remains valid;
+   - next stop condition.
+
+Do not start SWE-Marathon until the Terminal-Bench wrapper boundary is known.

--- a/examples/import-doc-registry-authority-smoke.py
+++ b/examples/import-doc-registry-authority-smoke.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Smoke-test importing a DOC_REGISTRY summary as authority context."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GOAL_ID = "doc-registry-authority-import-goal"
+SOURCE_ID = "external-doc-registry"
+DOC = REPO_ROOT / "docs" / "authority-source-registration.md"
+
+
+def write_fixture(root: Path) -> tuple[Path, Path, Path, Path]:
+    project = root / "project"
+    runtime = root / "runtime"
+    state_file = ".codex/goals/doc-registry-authority-import-goal/ACTIVE_GOAL_STATE.md"
+    registry = project / ".goal-harness" / "registry.json"
+    doc_registry = project / "external" / "DOC_REGISTRY.yaml"
+    (project / Path(state_file).parent).mkdir(parents=True, exist_ok=True)
+    (project / state_file).write_text(
+        "---\n"
+        "status: active\n"
+        "updated_at: 2026-01-01T00:00:00+00:00\n"
+        "---\n\n"
+        "# Doc Registry Authority Import Goal\n",
+        encoding="utf-8",
+    )
+    doc_registry.parent.mkdir(parents=True, exist_ok=True)
+    doc_registry.write_text(
+        "version: 1\n"
+        "updated_at: 2026-06-07\n"
+        "purpose: >-\n"
+        "  Fixture registry.\n"
+        "status_definitions:\n"
+        "  active: Current authority.\n"
+        "  deprecated: Old authority.\n"
+        "default_entry_docs:\n"
+        "  - docs/TODO.md\n"
+        "  - docs/meta/DOC_REGISTRY.yaml\n"
+        "  - docs/SYSTEM_DESIGN.md\n"
+        "topic_authority:\n"
+        "  current_priority: docs/TODO.md\n"
+        "  benchmark_landscape: docs/research/BENCHMARKS.md\n"
+        "  codex_cli_usage: docs/research/CODEX_CLI.md\n",
+        encoding="utf-8",
+    )
+    registry.parent.mkdir(parents=True, exist_ok=True)
+    registry.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "doc-registry-authority-import",
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": state_file,
+                        "requires_authority_registry": True,
+                        "authority_sources": [],
+                        "authority_registry": {
+                            "path": "docs/meta/DOC_REGISTRY.yaml",
+                            "read_status": "not_read",
+                            "topic_authority": {"existing_topic": "existing-source"},
+                        },
+                        "adapter": {
+                            "kind": "fixture_connected_readonly_v0",
+                            "status": "connected-read-only",
+                        },
+                    }
+                ],
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return registry, runtime, project, doc_registry
+
+
+def run_cli(registry: Path, runtime: Path, *args: str) -> dict[str, Any]:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "goal_harness.cli",
+            "--format",
+            "json",
+            "--registry",
+            str(registry),
+            "--runtime-root",
+            str(runtime),
+            *args,
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    payload = json.loads(result.stdout)
+    assert isinstance(payload, dict), payload
+    return payload
+
+
+def import_args(doc_registry: Path, *, dry_run: bool = False) -> list[str]:
+    args = [
+        "import-doc-registry-authority",
+        "--goal-id",
+        GOAL_ID,
+        "--source-id",
+        SOURCE_ID,
+        "--doc-registry-path",
+        str(doc_registry),
+        "--role",
+        "external_doc_authority",
+        "--freshness",
+        "current",
+        "--owner-status",
+        "owner_review_not_required",
+        "--gate-status",
+        "readable",
+        "--boundary",
+        "private_redacted",
+        "--conflict-rule",
+        "imported registry informs external project context",
+        "--topic",
+        "external_doc_registry",
+        "--import-topic-prefix",
+        "external_",
+        "--max-imported-topics",
+        "2",
+    ]
+    if dry_run:
+        args.append("--dry-run")
+    return args
+
+
+def assert_doc_contract() -> None:
+    text = DOC.read_text(encoding="utf-8")
+    for marker in (
+        "import-doc-registry-authority",
+        "doc_registry_authority_import_v0",
+        "default_entry_count",
+        "topic_authority_count",
+        "raw `DOC_REGISTRY.yaml` path is hashed",
+    ):
+        assert marker in text, marker
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="goal-harness-doc-registry-authority-") as raw_tmp:
+        registry, runtime, _project, doc_registry = write_fixture(Path(raw_tmp))
+        before = registry.read_text(encoding="utf-8")
+        dry = run_cli(registry, runtime, *import_args(doc_registry, dry_run=True))
+        assert dry["ok"] is True, dry
+        assert dry["dry_run"] is True, dry
+        assert dry["written"] is False, dry
+        assert dry["entry"]["source_ref_sha256"] == hashlib.sha256(str(doc_registry).encode("utf-8")).hexdigest(), dry
+        assert registry.read_text(encoding="utf-8") == before, "dry-run must not mutate registry"
+
+        written = run_cli(registry, runtime, *import_args(doc_registry))
+        assert written["ok"] is True, written
+        assert written["written"] is True, written
+        assert written["global_sync"]["wrote"] is True, written
+
+        registry_text = registry.read_text(encoding="utf-8")
+        assert str(doc_registry) not in registry_text, registry_text
+        payload = json.loads(registry_text)
+        goal = payload["goals"][0]
+        material = goal["authority_registry"]["project_materials"][SOURCE_ID]
+        assert material["schema_version"] == "doc_registry_authority_import_v0", material
+        assert material["default_entry_count"] == 3, material
+        assert material["topic_authority_count"] == 3, material
+        assert material["status_definition_count"] == 2, material
+        assert material["imported_topic_count"] == 3, material
+        assert material["imported_topic_truncated"] is True, material
+        topics = goal["authority_registry"]["topic_authority"]
+        assert topics["existing_topic"] == "existing-source", topics
+        assert topics["external_doc_registry"] == SOURCE_ID, topics
+        assert topics["external_current_priority"] == SOURCE_ID, topics
+        assert topics["external_benchmark_landscape"] == SOURCE_ID, topics
+        assert "external_codex_cli_usage" not in topics, topics
+
+        global_path = Path(written["global_sync"]["global_registry"])
+        global_text = global_path.read_text(encoding="utf-8")
+        assert str(doc_registry) not in global_text, global_text
+        global_goal = json.loads(global_text)["goals"][0]
+        assert "authority_sources" not in global_goal, global_goal
+        summary = global_goal["authority_registry"]
+        assert summary["project_material_count"] == 1, summary
+        assert summary["project_material_current_authority_count"] == 1, summary
+        assert summary["topic_authority_count"] == 4, summary
+
+    assert_doc_contract()
+    print("import-doc-registry-authority-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/long-horizon-paper-runner-dossier-smoke.py
+++ b/examples/long-horizon-paper-runner-dossier-smoke.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Smoke-test the long-horizon paper and runner dossier."""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DOSSIER = (
+    REPO_ROOT
+    / "docs"
+    / "research"
+    / "long-horizon-agent-benchmarks"
+    / "paper-runner-dossier.md"
+)
+
+
+REQUIRED_SNIPPETS = [
+    "Use Terminal-Bench 2.0 as the first official-runner probe",
+    "first heavy long-horizon software-engineering probe",
+    "Terminal-Bench 2.0",
+    "SWE-Marathon",
+    "LongCLI-Bench",
+    "WildClawBench",
+    "HORIZON / METR-style signals",
+    "LongDS-Bench",
+    "Tau-style suites",
+    "Codex CLI",
+    "Simple Codex",
+    "Do not start SWE-Marathon until the Terminal-Bench wrapper boundary is known.",
+    "terminal_bench_probe_v0",
+    "https://epoch.ai/benchmarks/terminal-bench/",
+    "https://arxiv.org/abs/2601.11868",
+    "https://www.tbench.ai/leaderboard/terminal-bench/2.0",
+    "https://github.com/harbor-framework/terminal-bench",
+    "https://github.com/abundant-ai/swe-marathon",
+    "https://huggingface.co/datasets/rdesai2/swe-marathon",
+    "https://arxiv.org/abs/2602.14337",
+    "https://arxiv.org/abs/2605.10912",
+    "https://arxiv.org/abs/2604.11978",
+    "https://horizonbench.org/",
+    "https://arxiv.org/abs/2605.30434",
+]
+
+
+def main() -> None:
+    text = DOSSIER.read_text(encoding="utf-8")
+    missing = [snippet for snippet in REQUIRED_SNIPPETS if snippet not in text]
+    assert not missing, missing
+    assert text.count("|") >= 20
+    assert text.count("Sources:") >= 3
+    print("long-horizon-paper-runner-dossier-smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/goal_harness/authority.py
+++ b/goal_harness/authority.py
@@ -12,6 +12,7 @@ from urllib.parse import urlparse
 
 
 AUTHORITY_SOURCE_REGISTRATION_VERSION = "authority_source_registration_v0"
+DOC_REGISTRY_AUTHORITY_IMPORT_VERSION = "doc_registry_authority_import_v0"
 AUTHORITY_SOURCE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,79}$")
 AUTHORITY_SOURCE_BOUNDARIES = {"public", "local_private", "private_redacted"}
 PRIVATE_TEXT_PATTERNS = (
@@ -231,6 +232,100 @@ def render_authority_source_markdown(payload: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def _strip_yaml_scalar(value: str) -> str:
+    text = value.strip()
+    if not text:
+        return ""
+    if text in {">", ">-", "|", "|-"}:
+        return ""
+    if (text.startswith('"') and text.endswith('"')) or (text.startswith("'") and text.endswith("'")):
+        return text[1:-1]
+    return text
+
+
+def read_doc_registry_contract(doc_registry_path: Path) -> dict[str, Any]:
+    """Read the public-safe contract surface from a DOC_REGISTRY-like YAML file."""
+
+    path = doc_registry_path.expanduser()
+    text = path.read_text(encoding="utf-8")
+    result: dict[str, Any] = {
+        "version": None,
+        "updated_at": None,
+        "default_entry_docs": [],
+        "topic_authority": {},
+        "status_definition_count": 0,
+    }
+    current_section: str | None = None
+    status_definition_count = 0
+    in_status_definitions = False
+    for raw_line in text.splitlines():
+        if not raw_line.strip() or raw_line.lstrip().startswith("#"):
+            continue
+        indent = len(raw_line) - len(raw_line.lstrip(" "))
+        stripped = raw_line.strip()
+        if indent == 0 and ":" in stripped:
+            key, raw_value = stripped.split(":", 1)
+            key = key.strip()
+            value = _strip_yaml_scalar(raw_value)
+            current_section = key
+            in_status_definitions = key == "status_definitions"
+            if key in {"version", "updated_at"} and value:
+                result[key] = value
+            continue
+        if current_section == "default_entry_docs" and stripped.startswith("- "):
+            entry = _strip_yaml_scalar(stripped[2:])
+            if entry:
+                result["default_entry_docs"].append(entry)
+            continue
+        if current_section == "topic_authority" and ":" in stripped:
+            key, raw_value = stripped.split(":", 1)
+            topic = _strip_yaml_scalar(key)
+            authority = _strip_yaml_scalar(raw_value)
+            if topic and authority:
+                result["topic_authority"][topic] = authority
+            continue
+        if in_status_definitions and indent > 0 and ":" in stripped:
+            key, _raw_value = stripped.split(":", 1)
+            if _strip_yaml_scalar(key):
+                status_definition_count += 1
+    result["status_definition_count"] = status_definition_count
+    return result
+
+
+def render_doc_registry_authority_import_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Goal Harness Doc Registry Authority Import",
+        "",
+        f"- ok: `{payload.get('ok')}`",
+        f"- dry_run: `{payload.get('dry_run')}`",
+        f"- written: `{payload.get('written')}`",
+        f"- goal_id: `{payload.get('goal_id')}`",
+        f"- source_id: `{payload.get('source_id')}`",
+    ]
+    if payload.get("error"):
+        lines.append(f"- error: {payload.get('error')}")
+        return "\n".join(lines)
+    entry = payload.get("entry") if isinstance(payload.get("entry"), dict) else {}
+    lines.extend(
+        [
+            f"- source_ref_redacted: `{entry.get('source_ref_redacted')}`",
+            f"- source_ref_kind: `{entry.get('source_ref_kind')}`",
+            f"- boundary: `{entry.get('boundary')}`",
+            f"- freshness: `{entry.get('freshness')}`",
+            f"- default_entry_count: `{entry.get('default_entry_count')}`",
+            f"- topic_authority_count: `{entry.get('topic_authority_count')}`",
+            f"- imported_topic_count: `{entry.get('imported_topic_count')}`",
+            f"- authority_registry_path: `{payload.get('authority_registry_path')}`",
+            f"- project_material_count: `{payload.get('authority_registry_summary', {}).get('project_material_count') if isinstance(payload.get('authority_registry_summary'), dict) else None}`",
+            f"- global_sync_wrote: `{payload.get('global_sync', {}).get('wrote') if isinstance(payload.get('global_sync'), dict) else None}`",
+            "",
+            "## Write Effect",
+            str(payload.get("write_effect") or ""),
+        ]
+    )
+    return "\n".join(lines)
+
+
 def register_authority_source(
     *,
     registry_path: Path,
@@ -342,6 +437,158 @@ def register_authority_source(
         "authority_registry_summary": summary,
         "write_effect": write_effect,
         "raw_source_ref_stored": False,
+    }
+
+
+def import_doc_registry_authority(
+    *,
+    registry_path: Path,
+    goal_id: str,
+    source_id: str,
+    doc_registry_path: Path,
+    source_kind: str,
+    role: str,
+    freshness: str,
+    owner_status: str | None,
+    gate_status: str | None,
+    boundary: str,
+    revision: str | None,
+    conflict_rule: str | None,
+    topics: list[str],
+    import_topic_prefix: str | None,
+    max_imported_topics: int,
+    dry_run: bool,
+) -> dict[str, Any]:
+    if max_imported_topics < 0:
+        raise ValueError("max_imported_topics must be non-negative")
+    registry_path = registry_path.expanduser()
+    doc_registry_path = doc_registry_path.expanduser()
+    contract = read_doc_registry_contract(doc_registry_path)
+    registry = read_json(registry_path)
+    goal_index = find_goal_index(registry, goal_id)
+    updated_registry = copy.deepcopy(registry)
+    goals = updated_registry.get("goals")
+    if not isinstance(goals, list) or not isinstance(goals[goal_index], dict):
+        raise ValueError("registry goal entry must be an object")
+    goal = goals[goal_index]
+    registered_at = now_local()
+    entry = compact_registered_authority_source(
+        source_id=source_id,
+        source_ref=str(doc_registry_path),
+        source_kind=source_kind,
+        role=role,
+        freshness=freshness,
+        owner_status=owner_status,
+        gate_status=gate_status,
+        boundary=boundary,
+        revision=revision or str(contract.get("updated_at") or ""),
+        conflict_rule=conflict_rule,
+        registered_at=registered_at,
+    )
+    entry["schema_version"] = DOC_REGISTRY_AUTHORITY_IMPORT_VERSION
+    default_entries = [str(item) for item in contract.get("default_entry_docs") or []]
+    topic_authority = contract.get("topic_authority") if isinstance(contract.get("topic_authority"), dict) else {}
+    imported_topics: dict[str, str] = {}
+    if import_topic_prefix:
+        prefix = public_safe_optional("import_topic_prefix", import_topic_prefix) or ""
+        for topic in list(topic_authority.keys())[:max_imported_topics]:
+            local_topic = f"{prefix}{topic}"
+            public_safe_optional("imported_topic", local_topic)
+            imported_topics[local_topic] = entry["id"]
+    for topic in topics:
+        topic_text = public_safe_optional("topic", topic)
+        if topic_text:
+            imported_topics[topic_text] = entry["id"]
+    entry.update(
+        {
+            "registry_version": contract.get("version"),
+            "registry_updated_at": contract.get("updated_at"),
+            "default_entry_count": len(default_entries),
+            "topic_authority_count": len(topic_authority),
+            "status_definition_count": int(contract.get("status_definition_count") or 0),
+            "default_entry_sample": default_entries[:8],
+            "topic_sample": list(topic_authority.keys())[:12],
+            "imported_topic_count": len(imported_topics),
+            "imported_topic_prefix": import_topic_prefix,
+            "imported_topic_truncated": bool(import_topic_prefix and len(topic_authority) > max_imported_topics),
+        }
+    )
+
+    authority_registry = goal.get("authority_registry") if isinstance(goal.get("authority_registry"), dict) else {}
+    authority_registry = dict(authority_registry)
+    materials = normalize_project_materials(authority_registry.get("project_materials"))
+    previous_entry = materials.get(entry["id"])
+    materials[str(entry["id"])] = dict(entry)
+    authority_registry["project_materials"] = materials
+    authority_registry.setdefault("read_status", "registered")
+    if imported_topics:
+        topic_map = normalize_topic_authority(authority_registry.get("topic_authority"))
+        topic_map.update(imported_topics)
+        authority_registry["topic_authority"] = topic_map
+    goal["authority_registry"] = authority_registry
+
+    authority_sources = goal.get("authority_sources")
+    if not isinstance(authority_sources, list):
+        authority_sources = []
+    compact_source = {
+        key: entry[key]
+        for key in (
+            "schema_version",
+            "id",
+            "role",
+            "source_kind",
+            "freshness",
+            "boundary",
+            "source_ref_kind",
+            "source_ref_sha256",
+            "source_ref_redacted",
+            "owner_status",
+            "gate_status",
+            "revision",
+            "conflict_rule",
+            "registered_at",
+            "default_entry_count",
+            "topic_authority_count",
+            "imported_topic_count",
+        )
+        if key in entry
+    }
+    authority_sources = [
+        item
+        for item in authority_sources
+        if not (isinstance(item, dict) and str(item.get("id") or item.get("source_id") or "") == entry["id"])
+    ]
+    authority_sources.append(compact_source)
+    goal["authority_sources"] = authority_sources
+
+    updated_registry["updated_at"] = registered_at
+    summary = compact_authority_registry(goal, project=Path(str(goal.get("repo"))).expanduser() if goal.get("repo") else None)
+    summary.pop("default_entries", None)
+    if not dry_run:
+        write_json(registry_path, updated_registry)
+
+    action = "would import" if dry_run else "imported"
+    write_effect = (
+        f"{action} DOC_REGISTRY summary into goal `{goal_id}` "
+        f"authority_registry.project_materials[{entry['id']}] with "
+        f"{len(default_entries)} default entries and {len(topic_authority)} topic mappings; "
+        "raw doc_registry_path is hashed and not stored"
+    )
+    if previous_entry:
+        write_effect += "; previous entry with the same source_id is replaced"
+    return {
+        "ok": True,
+        "dry_run": dry_run,
+        "written": not dry_run,
+        "registry": str(registry_path),
+        "goal_id": goal_id,
+        "source_id": entry["id"],
+        "entry": entry,
+        "authority_registry_path": "authority_registry.project_materials",
+        "authority_registry_summary": summary,
+        "write_effect": write_effect,
+        "raw_doc_registry_path_stored": False,
+        "imported_topics": imported_topics,
     }
 
 

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -7,7 +7,9 @@ from pathlib import Path
 
 from .authority import (
     AUTHORITY_SOURCE_BOUNDARIES,
+    import_doc_registry_authority,
     register_authority_source,
+    render_doc_registry_authority_import_markdown,
     render_authority_source_markdown,
 )
 from .bootstrap import (
@@ -646,6 +648,67 @@ def main(argv: list[str] | None = None) -> int:
         help="Do not refresh the shared global registry after writing the local source registry.",
     )
 
+    doc_registry_authority_parser = sub.add_parser(
+        "import-doc-registry-authority",
+        help="Import a redacted DOC_REGISTRY summary as a local authority/material source.",
+    )
+    doc_registry_authority_parser.add_argument(
+        "--goal-id", required=True, help="Goal id whose local registry should be updated."
+    )
+    doc_registry_authority_parser.add_argument("--source-id", required=True, help="Stable local source id.")
+    doc_registry_authority_parser.add_argument(
+        "--doc-registry-path",
+        required=True,
+        help="Local DOC_REGISTRY.yaml path to read. The raw path is hashed and not stored.",
+    )
+    doc_registry_authority_parser.add_argument(
+        "--source-kind",
+        default="doc_registry",
+        help="Public-safe source kind. Defaults to doc_registry.",
+    )
+    doc_registry_authority_parser.add_argument(
+        "--role",
+        default="external_doc_authority_registry",
+        help="Public-safe material role. Defaults to external_doc_authority_registry.",
+    )
+    doc_registry_authority_parser.add_argument(
+        "--freshness",
+        default="current",
+        help="Public-safe freshness state. Defaults to current.",
+    )
+    doc_registry_authority_parser.add_argument("--owner-status", help="Optional public-safe owner/review status.")
+    doc_registry_authority_parser.add_argument("--gate-status", help="Optional public-safe gate status.")
+    doc_registry_authority_parser.add_argument(
+        "--boundary",
+        choices=sorted(AUTHORITY_SOURCE_BOUNDARIES),
+        default="private_redacted",
+        help="Public/private boundary for this source. Defaults to private_redacted.",
+    )
+    doc_registry_authority_parser.add_argument("--revision", help="Optional public-safe revision label.")
+    doc_registry_authority_parser.add_argument("--conflict-rule", help="Optional public-safe conflict rule.")
+    doc_registry_authority_parser.add_argument(
+        "--topic",
+        action="append",
+        default=[],
+        help="Additional local topic_authority key to map to this source id. Repeatable.",
+    )
+    doc_registry_authority_parser.add_argument(
+        "--import-topic-prefix",
+        help="Prefix imported DOC_REGISTRY topic keys with this value before mapping them to the source id.",
+    )
+    doc_registry_authority_parser.add_argument(
+        "--max-imported-topics",
+        type=int,
+        default=50,
+        help="Maximum DOC_REGISTRY topics to map when --import-topic-prefix is set. Defaults to 50.",
+    )
+    doc_registry_authority_parser.add_argument("--dry-run", action="store_true", help="Preview without writing.")
+    doc_registry_authority_parser.add_argument(
+        "--no-global-sync",
+        action="store_true",
+        help="Do not refresh the shared global registry after writing the local source registry.",
+    )
+
     check_parser = sub.add_parser("check", help="Run a read-only contract and public/private boundary check.")
     check_parser.add_argument("--scan-root", default=".", help="Public files to scan for obvious private material.")
     check_parser.add_argument(
@@ -1233,6 +1296,52 @@ def main(argv: list[str] | None = None) -> int:
                 "error": str(exc),
             }
         print_payload(payload, args.format, render_authority_source_markdown)
+        return 0 if payload.get("ok") else 1
+
+    if args.command == "import-doc-registry-authority":
+        try:
+            payload = import_doc_registry_authority(
+                registry_path=registry_path,
+                goal_id=args.goal_id,
+                source_id=args.source_id,
+                doc_registry_path=Path(args.doc_registry_path),
+                source_kind=args.source_kind,
+                role=args.role,
+                freshness=args.freshness,
+                owner_status=args.owner_status,
+                gate_status=args.gate_status,
+                boundary=args.boundary,
+                revision=args.revision,
+                conflict_rule=args.conflict_rule,
+                topics=list(args.topic or []),
+                import_topic_prefix=args.import_topic_prefix,
+                max_imported_topics=int(args.max_imported_topics),
+                dry_run=bool(args.dry_run),
+            )
+            if not bool(args.no_global_sync):
+                if args.dry_run:
+                    payload["global_sync"] = {"enabled": True, "dry_run": True, "wrote": False}
+                else:
+                    payload["global_sync"] = sync_project_registry_to_global(
+                        registry_path=registry_path,
+                        runtime_root_override=args.runtime_root,
+                        goal_id=args.goal_id,
+                        dry_run=False,
+                    )
+            else:
+                payload["global_sync"] = {"enabled": False}
+        except Exception as exc:
+            payload = {
+                "ok": False,
+                "registry": str(registry_path),
+                "runtime_root": args.runtime_root,
+                "goal_id": args.goal_id,
+                "source_id": getattr(args, "source_id", None),
+                "written": False,
+                "dry_run": bool(getattr(args, "dry_run", False)),
+                "error": str(exc),
+            }
+        print_payload(payload, args.format, render_doc_registry_authority_import_markdown)
         return 0 if payload.get("ok") else 1
 
     if args.command == "check":


### PR DESCRIPTION
## Summary
- add the first evidence-backed long-horizon benchmark paper and runner dossier
- rank Terminal-Bench 2.0, SWE-Marathon, LongCLI-Bench, WildClawBench, HORIZON-style signals, LongDS, and tau-style suites
- add a smoke test that locks the selected first execution slice and source coverage
- add `import-doc-registry-authority` so external DOC_REGISTRY-style authority maps can be registered as redacted local material sources
- register the local agent-harness DOC_REGISTRY into the ignored Goal Harness meta registry/global compact projection without storing the raw path

## Validation
- python3 examples/long-horizon-paper-runner-dossier-smoke.py
- python3 examples/long-horizon-agent-benchmark-roadmap-smoke.py
- python3 examples/import-doc-registry-authority-smoke.py
- python3 examples/register-authority-source-smoke.py
- python3 examples/project-map-smoke.py
- python3 examples/platform-migration-material-registry-smoke.py
- python3 -m py_compile goal_harness/authority.py goal_harness/cli.py
- git diff --check
- goal-harness check --scan-path docs/research/long-horizon-agent-benchmarks --scan-path examples/long-horizon-paper-runner-dossier-smoke.py --limit 50
- goal-harness check --scan-path docs/authority-source-registration.md --scan-path goal_harness/authority.py --scan-path goal_harness/cli.py --scan-path examples/import-doc-registry-authority-smoke.py --limit 50
- sensitive-info keyword scan on changed files
- verified local agent-harness DOC_REGISTRY import stores sha256 only and global registry omits raw path/authority_sources