### PR TITLE
Add Terminal-Bench runner boundary probe

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/README.md
+++ b/docs/research/long-horizon-agent-benchmarks/README.md
@@ -29,6 +29,10 @@ work still belongs in the existing code, examples, and contract documents:
 - `paper-runner-dossier.md`: first evidence-backed ranking of benchmark papers,
   runner surfaces, Codex compatibility signals, and the next Terminal-Bench
   probe slice.
+- `terminal-bench-probe-v0.md`: first public-safe runner-boundary probe for
+  Terminal-Bench and Harbor, including Codex CLI integration surfaces, output
+  files for passive Goal Harness ingestion, and the stop condition before paid
+  or leaderboard execution.
 
 ## Relationship To Goal Harness Work
 

--- a/docs/research/long-horizon-agent-benchmarks/terminal-bench-probe-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/terminal-bench-probe-v0.md
@@ -1,0 +1,145 @@
+# Terminal-Bench Probe V0
+
+Checked at: 2026-06-07T18:12:55+08:00
+
+## Scope
+
+This probe answers one narrow setup question for the long-horizon benchmark
+program: where can Goal Harness attach to Terminal-Bench or Harbor without
+changing official benchmark semantics?
+
+The answer is deliberately conservative. Goal Harness should first behave as a
+passive control-plane wrapper around official runner outputs. A custom agent
+wrapper is possible, but it should not be the first leaderboard-facing path.
+
+## Sources Inspected
+
+- Terminal-Bench public repository:
+  `https://github.com/harbor-framework/terminal-bench`, commit
+  `1a6ffa9674b571da0ed040c470cb40c4d85f9b9b`.
+- Harbor public repository:
+  `https://github.com/laude-institute/harbor`, commit
+  `8cfac6ad91c5c566ff14040cc4acbfe94ad42356`.
+- Current Goal Harness authority/material handoff summary for
+  `goal-harness-meta`: redacted authority context reports current
+  benchmark/material authority with no owner-review requirement and low
+  conflict risk. This was used only as a planning constraint; private source
+  paths, internal document links, and raw agent-harness material are not copied
+  here.
+
+## Runner Boundary Findings
+
+Terminal-Bench has two relevant surfaces:
+
+- The legacy `tb` package runner supports built-in agents and
+  `--agent-import-path some.module:AgentClass`. The custom class must subclass
+  Terminal-Bench `BaseAgent` and implement `perform_task(instruction, session,
+  logging_dir)`.
+- The built-in `codex` agent in the `tb` runner invokes `codex exec` inside the
+  task terminal, requires OpenAI authentication, and records token counts and a
+  `FailureMode` through the Terminal-Bench `AgentResult`.
+- The `tb` run lock records replay-affecting fields in `tb.lock`, including
+  harness version, dataset source, agent import path, model, concurrency,
+  attempts, timeout overrides, and output path.
+- Trial outputs are structured enough for passive ingestion: per-trial
+  `results.json`, command history, pane logs, agent logs, and run-level
+  `run_metadata.json` / benchmark result JSON are the first Goal Harness read
+  surface.
+
+Harbor is the current official harness path for Terminal-Bench 2.0:
+
+- Harbor README describes `harbor run --dataset terminal-bench@2.0` as the
+  official Terminal-Bench 2.0 path.
+- Harbor supports built-in `codex` plus `--agent-import-path` for custom
+  agents. Agent configs also carry model, extra env, skills, MCP config,
+  timeout overrides, and allowed host additions.
+- Harbor job outputs have a stable passive surface: job `config.json`,
+  `lock.json`, job `result.json`, per-trial `config.json`, per-trial
+  `result.json`, trial logs, agent logs, verifier logs, artifact manifests,
+  and reward files.
+- Harbor's Codex agent already converts Codex CLI session JSONL into ATIF
+  `trajectory.json`, captures token and cost metrics when available, supports
+  optional skills/MCP registration, and writes Codex stdout to agent logs.
+
+## Goal Harness Attachment Strategy
+
+Use a three-step boundary:
+
+1. Passive observer first. Read `lock.json`, `result.json`, trial
+   `result.json`, `trajectory.json`, verifier reward files, and trial logs.
+   Write a Goal Harness `benchmark_run_v0` event only after parsing and
+   validating those official outputs.
+2. Local comparison second. Run the same small official or official-like task
+   once with bare Codex CLI and once with Goal Harness passive observation,
+   without changing benchmark prompts, task files, timeouts, resources, or
+   scoring.
+3. Custom agent wrapper last. Only after passive metrics show a concrete gap,
+   consider a local-only `--agent-import-path` wrapper that subclasses the
+   runner's `BaseAgent`, delegates execution to the built-in Codex agent or the
+   Codex CLI, and adds Goal Harness state markers. Do not present this wrapper
+   as an official leaderboard agent until benchmark rules and submission
+   semantics are checked.
+
+## Candidate Local Commands
+
+Do not run these automatically in a heartbeat. They are next-step examples once
+credentials, Docker/runtime readiness, model budget, and benchmark terms are
+explicitly acceptable.
+
+For Harbor Terminal-Bench 2.0 passive observation:
+
+```bash
+harbor run \
+  --dataset terminal-bench@2.0 \
+  --agent codex \
+  --model <openai-codex-model> \
+  --n-concurrent 1 \
+  --jobs-dir <local-private-output-dir> \
+  --job-name terminal_bench_probe_v0_codex_builtin
+```
+
+For a future local-only custom wrapper probe:
+
+```bash
+harbor run \
+  --dataset terminal-bench@2.0 \
+  --agent-import-path goal_harness_terminal_bench.agent:GoalHarnessCodexAgent \
+  --model <openai-codex-model> \
+  --n-concurrent 1 \
+  --jobs-dir <local-private-output-dir> \
+  --job-name terminal_bench_probe_v0_goal_harness_wrapper
+```
+
+For the older `tb` runner compatibility path:
+
+```bash
+tb run \
+  --dataset terminal-bench-core==0.1.1 \
+  --agent codex \
+  --model <openai-codex-model> \
+  --n-concurrent 1 \
+  --output-path <local-private-output-dir> \
+  --run-id terminal_bench_probe_v0_tb_codex_builtin
+```
+
+## Stop Condition
+
+Stop before any of the following:
+
+- paid model execution or external cloud sandbox use;
+- official leaderboard submission or upload;
+- changing benchmark task files, test scripts, timeouts, resource limits, or
+  scoring;
+- copying credentials, private run logs, Codex session content, internal
+  project paths, or raw agent-harness documents into a public artifact;
+- claiming Goal Harness improves benchmark score before a paired run and a
+  public-safe `benchmark_run_v0` comparison exist.
+
+## Next Slice
+
+Implement a public-safe `benchmark_run_v0` ingestion sketch or smoke fixture for
+Harbor job outputs. The fixture should validate only official output structure:
+job lock, job result, trial result, reward/verifier evidence, agent trajectory
+presence, token/cost fields when present, retry/progress counts, and the command
+line needed to resume or inspect the run. It should not invoke Docker, Codex, a
+model API, or a leaderboard upload by default.

--- a/examples/terminal-bench-probe-smoke.py
+++ b/examples/terminal-bench-probe-smoke.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Smoke-test the Terminal-Bench runner-boundary probe note."""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+NOTE = (
+    REPO_ROOT
+    / "docs"
+    / "research"
+    / "long-horizon-agent-benchmarks"
+    / "terminal-bench-probe-v0.md"
+)
+README = (
+    REPO_ROOT
+    / "docs"
+    / "research"
+    / "long-horizon-agent-benchmarks"
+    / "README.md"
+)
+
+REQUIRED_SNIPPETS = [
+    "Terminal-Bench Probe V0",
+    "Terminal-Bench public repository",
+    "1a6ffa9674b571da0ed040c470cb40c4d85f9b9b",
+    "Harbor public repository",
+    "8cfac6ad91c5c566ff14040cc4acbfe94ad42356",
+    "redacted authority context",
+    "--agent-import-path",
+    "built-in `codex`",
+    "Codex CLI",
+    "ATIF",
+    "trajectory.json",
+    "lock.json",
+    "result.json",
+    "results.json",
+    "tb.lock",
+    "run_metadata.json",
+    "benchmark_run_v0",
+    "terminal_bench_probe_v0_codex_builtin",
+    "terminal_bench_probe_v0_goal_harness_wrapper",
+    "Do not run these automatically in a heartbeat.",
+    "Stop before any of the following",
+    "paid model execution",
+    "official leaderboard submission",
+]
+
+FORBIDDEN_SNIPPETS = [
+    "/" + "Users/",
+    "/" + "tmp/",
+    "lark" + "office",
+    "fei" + "shu.cn",
+    "wiki" + "_node_token",
+    "document" + "_id",
+    "doc" + "_url",
+    "wiki" + "_url",
+]
+
+
+def main() -> None:
+    text = NOTE.read_text(encoding="utf-8")
+    readme = README.read_text(encoding="utf-8")
+
+    missing = [snippet for snippet in REQUIRED_SNIPPETS if snippet not in text]
+    assert not missing, missing
+
+    leaked = [snippet for snippet in FORBIDDEN_SNIPPETS if snippet in text]
+    assert not leaked, leaked
+
+    assert "terminal-bench-probe-v0.md" in readme
+    assert text.count("```bash") == 3
+    assert text.count("harbor run") >= 2
+    assert text.count("tb run") >= 1
+    print("terminal-bench-probe-smoke ok")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a public-safe Terminal-Bench/Harbor runner boundary probe for the long-horizon benchmark track
- document the passive Goal Harness attachment strategy before any custom agent wrapper
- add a smoke test for required runner-boundary evidence and forbidden private-source markers

## Validation
- python3 examples/terminal-bench-probe-smoke.py
- python3 examples/long-horizon-paper-runner-dossier-smoke.py
- python3 examples/check-public-boundary-smoke.py
- git diff --check
- targeted sensitive-pattern scan over the changed public files

## Boundary
- no model/Docker/leaderboard run was executed
- no private authority source path, internal document URL, credential, or raw agent-harness material is included