### PR TITLE
Project benchmark run summaries into status

### DIFF
--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -235,6 +235,8 @@ goals must stay out of the eligible lane even when they have a high
     "totals": {
       "events_24h": 2,
       "events_7d": 2,
+      "benchmark_runs_24h": 0,
+      "benchmark_runs_7d": 0,
       "by_class_24h": {
         "accounting": 1,
         "decision": 0,
@@ -1376,14 +1378,25 @@ The summary classifies sampled run records into:
 - `state`: state refresh and other compact state-projection rows;
 - `work`: remaining bounded delivery or implementation progress rows.
 
-The summary reports 24h/7d totals and per-goal counts by event class. It is a
-projection only: consumers should use it to understand what kind of facts the
-control plane has observed recently, then drill into `run_history` or the
-project-local history command for exact evidence. It must not replace append-only
-run, reward, quota, validation, artifact, blocker, or evidence events.
+The summary reports 24h/7d totals and per-goal counts by event class. It also
+reports optional `benchmark_runs_24h` and `benchmark_runs_7d` counts when
+sampled run-index records carry a compact `benchmark_run_v0` object. These
+benchmark counts are evidence projections, not official score claims.
+Consumers should use them to notice that benchmark evidence exists, then drill
+into `run_history` or the project-local history command for exact evidence. It
+must not replace append-only run, reward, quota, validation, artifact, blocker,
+or evidence events.
 Each per-goal row may also include `latest_event_class` and `latest_event_at`,
 which are compact routing hints for the dashboard, not replacements for the
 latest run record.
+
+When a compact run record includes `benchmark_run_summary`, it is a redacted
+projection of `benchmark_run_v0`: runner, benchmark id, job name, mode, agent
+summary, progress counts, token/cost metrics, validation state, up to three
+trial summaries, relative evidence categories, resume/inspect command
+templates, and stop conditions. It must not include raw Codex sessions, host
+absolute paths, credentials, private benchmark material, or leaderboard upload
+claims.
 
 ## Promotion Readiness Summary
 

--- a/examples/benchmark-run-v0-status-projection-smoke.py
+++ b/examples/benchmark-run-v0-status-projection-smoke.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Smoke-test benchmark_run_v0 projection through status and review packets."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from goal_harness.review_packet import build_review_packet  # noqa: E402
+from goal_harness.status import collect_status, render_status_markdown  # noqa: E402
+
+
+GOAL_ID = "benchmark-projection-fixture"
+BENCHMARK_ID = "terminal-bench@2.0"
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def benchmark_run_event() -> dict[str, Any]:
+    return {
+        "schema_version": "benchmark_run_v0",
+        "source_runner": "harbor",
+        "benchmark_id": BENCHMARK_ID,
+        "job_name": "terminal_bench_probe_v0_codex_builtin",
+        "mode": "passive_observer",
+        "agent": {
+            "name": "codex",
+            "model": "openai/gpt-5.1-codex-mini",
+            "kwargs_keys": ["reasoning_effort"],
+        },
+        "progress": {
+            "n_total_trials": 1,
+            "n_completed_trials": 1,
+            "n_errored_trials": 0,
+            "n_running_trials": 0,
+            "n_pending_trials": 0,
+            "n_cancelled_trials": 0,
+            "n_retries": 0,
+        },
+        "metrics": {
+            "input_tokens": 1200,
+            "cache_tokens": 100,
+            "output_tokens": 300,
+            "cost_usd": 0.42,
+        },
+        "trials": [
+            {
+                "task_id": "terminal-bench-hello",
+                "trial_name": "terminal-bench-hello__codex__attempt-1",
+                "source": BENCHMARK_ID,
+                "reward": {"reward": 1.0},
+                "metrics": {
+                    "input_tokens": 1200,
+                    "cache_tokens": 100,
+                    "output_tokens": 300,
+                    "cost_usd": 0.42,
+                },
+                "trajectory_present": True,
+                "verifier_reward_present": True,
+                "artifact_manifest_present": True,
+                "trial_result_present": True,
+            }
+        ],
+        "validation": {
+            "job_lock_present": True,
+            "job_result_present": True,
+            "trial_results_present": True,
+            "verifier_reward_present": True,
+            "agent_trajectory_recorded": True,
+            "retry_progress_consistent": True,
+            "no_leaderboard_upload_requested": True,
+            "paths_redacted": True,
+        },
+        "evidence_files": [
+            "job:lock.json",
+            "job:result.json",
+            "trial:result.json",
+            "trial:agent/trajectory.json",
+            "trial:verifier/reward.json",
+        ],
+        "resume_or_inspect_commands": [
+            "harbor job resume --job-path <job-dir>",
+            "harbor view <jobs-dir>",
+        ],
+        "stop_conditions": [
+            "do_not_run_docker_or_model_api_by_default",
+            "do_not_upload_or_submit_leaderboard",
+        ],
+    }
+
+
+def write_fixture(root: Path) -> Path:
+    project = root / "project"
+    runtime = root / "runtime"
+    state_file = f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    registry_path = project / ".goal-harness" / "registry.json"
+    run_time = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+    (project / Path(state_file).parent).mkdir(parents=True, exist_ok=True)
+    (project / state_file).write_text(
+        "---\n"
+        "status: active-read-only\n"
+        "updated_at: 2026-06-07T00:00:00+00:00\n"
+        "---\n\n"
+        "# Benchmark Projection Fixture\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] Continue passive benchmark projection without running Docker or model APIs.\n\n"
+        "## Next Action\n\n"
+        "- Inspect the benchmark_run_v0 status projection and choose the next fixture-backed slice.\n",
+        encoding="utf-8",
+    )
+    write_json(
+        registry_path,
+        {
+            "schema_version": 1,
+            "updated_at": "2026-06-07T00:00:00+00:00",
+            "common_runtime_root": str(runtime),
+            "goals": [
+                {
+                    "id": GOAL_ID,
+                    "domain": "benchmark-projection",
+                    "status": "active-read-only",
+                    "repo": str(project),
+                    "state_file": state_file,
+                    "adapter": {
+                        "kind": "harness_self_improvement",
+                        "status": "connected-read-only",
+                    },
+                    "quota": {"compute": 1.0, "window_hours": 24},
+                    "authority_sources": [],
+                }
+            ],
+        },
+    )
+
+    runs_dir = runtime / "goals" / GOAL_ID / "runs"
+    run_json = runs_dir / "benchmark-run-v0.json"
+    run_md = runs_dir / "benchmark-run-v0.md"
+    index_path = runs_dir / "index.jsonl"
+    run_record = {
+        "generated_at": run_time,
+        "goal_id": GOAL_ID,
+        "classification": "benchmark_run_v0",
+        "recommended_action": "inspect benchmark_run_v0 summary and continue passive projection work",
+        "health_check": "benchmark_run_v0 fixture public-safe",
+        "delivery_batch_scale": "implementation",
+        "delivery_outcome": "primary_goal_outcome",
+        "benchmark_run": benchmark_run_event(),
+    }
+    write_json(run_json, run_record)
+    run_md.write_text("# Benchmark Run V0 Fixture\n", encoding="utf-8")
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+    index_record = {
+        **run_record,
+        "json_path": str(run_json),
+        "markdown_path": str(run_md),
+    }
+    index_path.write_text(json.dumps(index_record, sort_keys=True) + "\n", encoding="utf-8")
+    return registry_path
+
+
+def assert_no_private_surface(summary: dict[str, Any]) -> None:
+    text = json.dumps(summary, sort_keys=True)
+    forbidden = [
+        "/" + "Users/",
+        "/" + "tmp/",
+        "OPENAI_API_KEY",
+        "auth.json",
+        "sessions/",
+        "lark" + "office",
+        "fei" + "shu.cn",
+    ]
+    leaked = [needle for needle in forbidden if needle in text]
+    assert not leaked, leaked
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory(prefix="benchmark-run-v0-status-") as tmp:
+        registry_path = write_fixture(Path(tmp))
+        status = collect_status(
+            registry_path=registry_path,
+            runtime_root_override=None,
+            scan_roots=[],
+            limit=10,
+        )
+        assert status["ok"], status
+        goal = status["run_history"]["goals"][0]
+        latest = goal["latest_runs"][0]
+        summary = latest["benchmark_run_summary"]
+        assert summary["schema_version"] == "benchmark_run_v0", summary
+        assert summary["source_runner"] == "harbor", summary
+        assert summary["benchmark_id"] == BENCHMARK_ID, summary
+        assert summary["progress"]["n_completed_trials"] == 1, summary
+        assert summary["metrics"]["cost_usd"] == 0.42, summary
+        assert summary["validation"]["all_passed"] is True, summary
+        assert summary["trials"][0]["reward"]["reward"] == 1.0, summary
+        assert_no_private_surface(summary)
+
+        event_ledger = status["event_ledger_summary"]
+        assert event_ledger["totals"]["benchmark_runs_24h"] == 1, event_ledger
+        assert event_ledger["totals"]["by_class_24h"]["evidence"] == 1, event_ledger
+        latest_benchmark = event_ledger["goals"][0]["latest_benchmark_run"]
+        assert latest_benchmark["benchmark_id"] == BENCHMARK_ID, latest_benchmark
+
+        markdown = render_status_markdown(status)
+        assert "benchmark_runs_24h=1" in markdown, markdown
+        assert "benchmark_runs_7d=1" in markdown, markdown
+
+        packet = build_review_packet(status, goal_id=GOAL_ID)
+        assert packet["ok"], packet
+        assert "benchmark=terminal-bench@2.0" in packet["project_agent_handoff"], packet["project_agent_handoff"]
+        assert "completed=1/1" in packet["project_agent_handoff"], packet["project_agent_handoff"]
+        assert "reward=1.0" in packet["project_agent_handoff"], packet["project_agent_handoff"]
+        assert_no_private_surface({"project_agent_handoff": packet["project_agent_handoff"]})
+
+    print("benchmark-run-v0-status-projection-smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/goal_harness/review_packet.py
+++ b/goal_harness/review_packet.py
@@ -303,8 +303,28 @@ def handoff_followthrough_summary(item: dict[str, Any] | None) -> str | None:
     streak = readiness.get("post_handoff_small_scale_streak")
     streak_text = f", small_streak={streak}" if isinstance(streak, int) else ""
     suffix = f", at={generated_at}" if generated_at else ""
+    benchmark = latest_run.get("benchmark_run_summary") if isinstance(latest_run.get("benchmark_run_summary"), dict) else {}
+    benchmark_text = ""
+    if benchmark:
+        progress = benchmark.get("progress") if isinstance(benchmark.get("progress"), dict) else {}
+        trials = benchmark.get("trials") if isinstance(benchmark.get("trials"), list) else []
+        reward = None
+        if trials and isinstance(trials[0], dict):
+            reward_map = trials[0].get("reward") if isinstance(trials[0].get("reward"), dict) else {}
+            reward = reward_map.get("reward")
+        benchmark_parts = [
+            f"benchmark={benchmark.get('benchmark_id') or 'unknown'}",
+            f"runner={benchmark.get('source_runner') or 'unknown'}",
+        ]
+        if progress:
+            benchmark_parts.append(
+                f"completed={progress.get('n_completed_trials', 0)}/{progress.get('n_total_trials', 0)}"
+            )
+        if reward is not None:
+            benchmark_parts.append(f"reward={reward}")
+        benchmark_text = "; " + ", ".join(benchmark_parts)
     return compact_packet_text(
-        f"post_handoff_run={classification}, scale={scale}{streak_text}{suffix}",
+        f"post_handoff_run={classification}, scale={scale}{streak_text}{suffix}{benchmark_text}",
         limit=220,
     )
 

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -79,6 +79,9 @@ EVENT_LEDGER_CLASSES = (
     "work",
 )
 EVENT_LEDGER_PROXY_NOTE = "append-only run-history projection; compact event-class counts only"
+BENCHMARK_RUN_SCHEMA_VERSION = "benchmark_run_v0"
+MAX_BENCHMARK_RUN_TRIALS = 3
+MAX_BENCHMARK_RUN_LIST_ITEMS = 5
 STATUS_CONTRACT_SCHEMA_VERSION = 2
 MINIMUM_DASHBOARD_STATUS_CONTRACT_SCHEMA_VERSION = 2
 STATUS_CONTRACT_RELOAD_HINT = "scripts/macos-dashboard-launchagent.sh restart"
@@ -312,6 +315,134 @@ def public_safe_compact_list(value: Any, *, limit: int = MAX_SUBAGENT_SCOPE_ITEM
         if len(result) >= limit:
             break
     return result
+
+
+def _compact_numeric_map(value: Any, *, keys: tuple[str, ...] | None = None) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    source = value
+    selected_keys = keys or tuple(str(key) for key in source.keys())
+    compact: dict[str, Any] = {}
+    for key in selected_keys:
+        raw = source.get(key)
+        if isinstance(raw, bool) or raw is None:
+            continue
+        if isinstance(raw, (int, float)):
+            compact[key] = raw
+            continue
+        try:
+            if isinstance(raw, str) and raw.strip():
+                compact[key] = float(raw) if "." in raw else int(raw)
+        except ValueError:
+            continue
+    return compact
+
+
+def _benchmark_run_source(run: dict[str, Any]) -> dict[str, Any] | None:
+    nested = run.get("benchmark_run")
+    if isinstance(nested, dict) and nested.get("schema_version") == BENCHMARK_RUN_SCHEMA_VERSION:
+        return nested
+    if run.get("schema_version") == BENCHMARK_RUN_SCHEMA_VERSION:
+        return run
+    return None
+
+
+def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
+    source = _benchmark_run_source(run)
+    if not source:
+        return None
+
+    compact: dict[str, Any] = {"schema_version": BENCHMARK_RUN_SCHEMA_VERSION}
+    for field in ("source_runner", "benchmark_id", "job_name", "mode"):
+        value = public_safe_compact_text(source.get(field), limit=120)
+        if value:
+            compact[field] = value
+
+    agent = source.get("agent") if isinstance(source.get("agent"), dict) else {}
+    compact_agent: dict[str, Any] = {}
+    for field in ("name", "import_path", "model"):
+        value = public_safe_compact_text(agent.get(field), limit=120)
+        if value:
+            compact_agent[field] = value
+    kwargs_keys = public_safe_compact_list(agent.get("kwargs_keys"), limit=MAX_BENCHMARK_RUN_LIST_ITEMS)
+    if kwargs_keys:
+        compact_agent["kwargs_keys"] = kwargs_keys
+    if compact_agent:
+        compact["agent"] = compact_agent
+
+    progress = _compact_numeric_map(
+        source.get("progress"),
+        keys=(
+            "n_total_trials",
+            "n_completed_trials",
+            "n_errored_trials",
+            "n_running_trials",
+            "n_pending_trials",
+            "n_cancelled_trials",
+            "n_retries",
+        ),
+    )
+    if progress:
+        compact["progress"] = progress
+
+    metrics = _compact_numeric_map(
+        source.get("metrics"),
+        keys=("input_tokens", "cache_tokens", "output_tokens", "cost_usd"),
+    )
+    if metrics:
+        compact["metrics"] = metrics
+
+    validation = source.get("validation") if isinstance(source.get("validation"), dict) else {}
+    if validation:
+        failed = [
+            str(key)
+            for key, value in validation.items()
+            if isinstance(key, str) and isinstance(value, bool) and not value
+        ][:MAX_BENCHMARK_RUN_LIST_ITEMS]
+        compact["validation"] = {
+            "all_passed": not failed and all(bool(value) for value in validation.values() if isinstance(value, bool)),
+            "failed_checks": failed,
+        }
+
+    trials: list[dict[str, Any]] = []
+    for trial in source.get("trials") or []:
+        if not isinstance(trial, dict):
+            continue
+        compact_trial: dict[str, Any] = {}
+        for field in ("task_id", "trial_name", "source", "exception_type"):
+            value = public_safe_compact_text(trial.get(field), limit=140)
+            if value:
+                compact_trial[field] = value
+        reward = _compact_numeric_map(trial.get("reward"))
+        if reward:
+            compact_trial["reward"] = reward
+        trial_metrics = _compact_numeric_map(
+            trial.get("metrics"),
+            keys=("input_tokens", "cache_tokens", "output_tokens", "cost_usd"),
+        )
+        if trial_metrics:
+            compact_trial["metrics"] = trial_metrics
+        for field in ("trajectory_present", "verifier_reward_present", "artifact_manifest_present", "trial_result_present"):
+            if isinstance(trial.get(field), bool):
+                compact_trial[field] = trial.get(field)
+        if compact_trial:
+            trials.append(compact_trial)
+            if len(trials) >= MAX_BENCHMARK_RUN_TRIALS:
+                break
+    if trials:
+        compact["trials"] = trials
+        raw_trials = source.get("trials")
+        if isinstance(raw_trials, list):
+            compact["trial_count"] = len(raw_trials)
+
+    for field in ("evidence_files", "resume_or_inspect_commands", "stop_conditions"):
+        values = public_safe_compact_list(source.get(field), limit=MAX_BENCHMARK_RUN_LIST_ITEMS)
+        if values:
+            compact[field] = values
+
+    if set(compact.keys()) == {"schema_version"}:
+        return None
+    return compact
 
 
 def parse_state_frontmatter(state_text: str) -> dict[str, str]:
@@ -1154,6 +1285,9 @@ def compact_post_handoff_run(run: dict[str, Any], profile: dict[str, Any] | None
     outcome = delivery_outcome_for_run(run, profile)
     if outcome != "not_configured":
         compact["delivery_outcome"] = outcome
+    benchmark_run = compact_benchmark_run(run)
+    if benchmark_run:
+        compact["benchmark_run_summary"] = benchmark_run
     return compact
 
 
@@ -2382,6 +2516,9 @@ def compact_run(run: dict[str, Any]) -> dict[str, Any]:
     if subagents:
         compact["subagents"] = subagents[:MAX_SUBAGENT_ACTIVITY_ITEMS]
         compact["subagent_count"] = len(subagents)
+    benchmark_run = compact_benchmark_run(run)
+    if benchmark_run:
+        compact["benchmark_run_summary"] = benchmark_run
     return compact
 
 
@@ -2486,10 +2623,13 @@ def blank_event_ledger_goal(goal_id: str) -> dict[str, Any]:
         "goal_id": goal_id,
         "events_24h": 0,
         "events_7d": 0,
+        "benchmark_runs_24h": 0,
+        "benchmark_runs_7d": 0,
         "by_class_24h": blank_event_class_counts(),
         "by_class_7d": blank_event_class_counts(),
         "latest_event_class": None,
         "latest_event_at": None,
+        "latest_benchmark_run": None,
     }
 
 
@@ -2497,6 +2637,8 @@ def event_ledger_event_class(run: dict[str, Any]) -> str:
     classification = str(run.get("classification") or "").lower()
     if classification == "quota_slot_spent" or isinstance(run.get("quota_event"), dict):
         return "accounting"
+    if compact_benchmark_run(run):
+        return "evidence"
     if (
         classification in EVENT_LEDGER_DECISION_CLASSIFICATIONS
         or "operator_gate" in classification
@@ -2538,6 +2680,8 @@ def build_event_ledger_summary(history: dict[str, Any]) -> dict[str, Any]:
     totals = {
         "events_24h": 0,
         "events_7d": 0,
+        "benchmark_runs_24h": 0,
+        "benchmark_runs_7d": 0,
         "by_class_24h": blank_event_class_counts(),
         "by_class_7d": blank_event_class_counts(),
     }
@@ -2558,17 +2702,36 @@ def build_event_ledger_summary(history: dict[str, Any]) -> dict[str, Any]:
         if latest_event_at is None or generated_at > latest_event_at:
             goal["latest_event_class"] = event_class
             goal["latest_event_at"] = generated_at.isoformat()
+        benchmark_run = compact_benchmark_run(run)
+        if benchmark_run:
+            latest_benchmark_at = parse_timestamp(
+                (goal.get("latest_benchmark_run") or {}).get("generated_at")
+                if isinstance(goal.get("latest_benchmark_run"), dict)
+                else None
+            )
+            if latest_benchmark_at is None or generated_at > latest_benchmark_at:
+                goal["latest_benchmark_run"] = {
+                    "generated_at": generated_at.isoformat(),
+                    "classification": run.get("classification"),
+                    **benchmark_run,
+                }
 
         if generated_at >= cutoff_7d:
             totals["events_7d"] += 1
             totals["by_class_7d"][event_class] += 1
             goal["events_7d"] += 1
             goal["by_class_7d"][event_class] += 1
+            if benchmark_run:
+                totals["benchmark_runs_7d"] += 1
+                goal["benchmark_runs_7d"] += 1
         if generated_at >= cutoff_24h:
             totals["events_24h"] += 1
             totals["by_class_24h"][event_class] += 1
             goal["events_24h"] += 1
             goal["by_class_24h"][event_class] += 1
+            if benchmark_run:
+                totals["benchmark_runs_24h"] += 1
+                goal["benchmark_runs_24h"] += 1
 
     goal_rows = sorted(
         goals.values(),
@@ -3013,6 +3176,8 @@ def render_status_markdown(payload: dict[str, Any]) -> str:
                 f"samples={event_ledger.get('sample_run_count')} "
                 f"events_24h={event_totals.get('events_24h')} "
                 f"events_7d={event_totals.get('events_7d')} "
+                f"benchmark_runs_24h={event_totals.get('benchmark_runs_24h', 0)} "
+                f"benchmark_runs_7d={event_totals.get('benchmark_runs_7d', 0)} "
                 f"classes_24h={_event_class_count_text(by_class_24h)} "
                 f"classes_7d={_event_class_count_text(by_class_7d)}",
             ]
@@ -3035,6 +3200,8 @@ def render_status_markdown(payload: dict[str, Any]) -> str:
                 f"`{_markdown_scalar(goal.get('goal_id') or '')}`: "
                 f"events_24h={goal.get('events_24h')} "
                 f"events_7d={goal.get('events_7d')} "
+                f"benchmark_runs_24h={goal.get('benchmark_runs_24h', 0)} "
+                f"benchmark_runs_7d={goal.get('benchmark_runs_7d', 0)} "
                 f"latest={_markdown_scalar(goal.get('latest_event_class') or '')} "
                 f"classes_24h={_event_class_count_text(goal_by_class_24h)}"
             )


### PR DESCRIPTION
## Summary
- add a compact benchmark_run_v0 projection for run-history/status consumers
- count benchmark_run_v0 evidence in event_ledger_summary without reading raw runner logs
- surface benchmark progress/reward in review-packet handoff followthrough text
- document the optional status contract fields and add a deterministic fixture smoke

## Validation
- python3 examples/benchmark-run-v0-status-projection-smoke.py
- python3 examples/benchmark-run-v0-harbor-ingest-smoke.py
- python3 examples/status-markdown-smoke.py
- python3 examples/review-packet-cli-smoke.py
- python3 examples/review-packet-smoke.py
- python3 -m py_compile goal_harness/status.py goal_harness/review_packet.py examples/benchmark-run-v0-status-projection-smoke.py
- python3 examples/run-smokes.py (55 smoke scripts)
- git diff --check
- goal-harness check --scan-path goal_harness/status.py --scan-path goal_harness/review_packet.py --scan-path docs/status-data-contract.md --scan-path examples/benchmark-run-v0-status-projection-smoke.py --limit 50
- staged sensitive keyword scan over the public diff