### PR TITLE
Add benchmark run append CLI

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-v0-ingest.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-v0-ingest.md
@@ -71,12 +71,31 @@ The deterministic smoke is:
 
 ```bash
 python3 examples/benchmark-run-v0-harbor-ingest-smoke.py
+python3 examples/benchmark-run-v0-append-cli-smoke.py
 ```
 
 It creates a synthetic Harbor-style job directory with one completed
 Terminal-Bench trial, then parses it into `benchmark_run_v0`. The fixture writes
 only public-safe fake data and does not import Harbor, invoke Docker, call Codex,
 use model APIs, use cloud sandboxes, or upload leaderboard results.
+
+## CLI Append
+
+After a runner or parser has produced a `benchmark_run_v0` JSON object, append it
+to the normal Goal Harness run history with:
+
+```bash
+goal-harness history append-benchmark-run \
+  --goal-id <goal-id> \
+  --benchmark-run-json <benchmark-run-v0.json> \
+  --delivery-batch-scale implementation \
+  --delivery-outcome primary_goal_outcome \
+  --execute
+```
+
+Without `--execute`, the command is a dry-run preview. The command compacts the
+input before writing so status and review-packet surfaces receive a
+public-safe summary rather than raw runner logs or host paths.
 
 ## Stop Conditions
 
@@ -94,9 +113,9 @@ Stop before:
 
 ## Next Slice
 
-After this smoke exists, the next bounded product step is to decide where
-`benchmark_run_v0` should live in the normal Goal Harness history/status
-pipeline. The default should stay generic: parse runner outputs, append a
-public-safe run event, refresh state, and let status/review-packet expose the
-compact benchmark summary without adding benchmark-specific heartbeat prompt
-branches.
+After the append CLI exists, the next bounded product step is a passive baseline
+protocol: define a tiny paired-run fixture for bare Codex CLI versus passive
+Goal Harness wrapping, then have the runner write one `benchmark_run_v0` event
+through this command. Keep the fixture local and deterministic before invoking
+real Terminal-Bench, Docker, Codex, model APIs, or leaderboard upload paths,
+and keep doing this without adding benchmark-specific heartbeat prompt branches.

--- a/examples/benchmark-run-v0-append-cli-smoke.py
+++ b/examples/benchmark-run-v0-append-cli-smoke.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Smoke-test appending benchmark_run_v0 through the Goal Harness CLI."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from goal_harness.status import collect_status  # noqa: E402
+
+
+GOAL_ID = "benchmark-append-cli-fixture"
+BENCHMARK_ID = "terminal-bench@2.0"
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def benchmark_run_event() -> dict[str, Any]:
+    return {
+        "schema_version": "benchmark_run_v0",
+        "source_runner": "harbor",
+        "benchmark_id": BENCHMARK_ID,
+        "job_name": "terminal_bench_probe_v0_codex_builtin",
+        "mode": "passive_observer",
+        "agent": {
+            "name": "codex",
+            "model": "openai/gpt-5.1-codex-mini",
+            "kwargs_keys": ["reasoning_effort"],
+        },
+        "progress": {
+            "n_total_trials": 1,
+            "n_completed_trials": 1,
+            "n_errored_trials": 0,
+            "n_running_trials": 0,
+            "n_pending_trials": 0,
+            "n_cancelled_trials": 0,
+            "n_retries": 0,
+        },
+        "metrics": {
+            "input_tokens": 1234,
+            "cache_tokens": 100,
+            "output_tokens": 321,
+            "cost_usd": 0.45,
+        },
+        "trials": [
+            {
+                "task_id": "terminal-bench-hello",
+                "trial_name": "terminal-bench-hello__codex__attempt-1",
+                "source": BENCHMARK_ID,
+                "reward": {"reward": 1.0},
+                "metrics": {
+                    "input_tokens": 1234,
+                    "cache_tokens": 100,
+                    "output_tokens": 321,
+                    "cost_usd": 0.45,
+                },
+                "trajectory_present": True,
+                "verifier_reward_present": True,
+                "artifact_manifest_present": True,
+                "trial_result_present": True,
+            }
+        ],
+        "validation": {
+            "job_lock_present": True,
+            "job_result_present": True,
+            "trial_results_present": True,
+            "verifier_reward_present": True,
+            "agent_trajectory_recorded": True,
+            "retry_progress_consistent": True,
+            "no_leaderboard_upload_requested": True,
+            "paths_redacted": True,
+        },
+        "evidence_files": [
+            "job:lock.json",
+            "job:result.json",
+            "trial:result.json",
+            "trial:agent/trajectory.json",
+            "trial:verifier/reward.json",
+        ],
+        "resume_or_inspect_commands": [
+            "harbor job resume --job-path <job-dir>",
+            "harbor view <jobs-dir>",
+        ],
+        "stop_conditions": [
+            "do_not_run_docker_or_model_api_by_default",
+            "do_not_upload_or_submit_leaderboard",
+        ],
+    }
+
+
+def write_fixture(root: Path) -> tuple[Path, Path, Path]:
+    project = root / "project"
+    runtime = root / "runtime"
+    state_file = f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    registry_path = project / ".goal-harness" / "registry.json"
+    benchmark_run_path = root / "benchmark_run.json"
+
+    (project / Path(state_file).parent).mkdir(parents=True, exist_ok=True)
+    (project / state_file).write_text(
+        "---\n"
+        "status: active-read-only\n"
+        "updated_at: 2026-06-07T00:00:00+00:00\n"
+        "---\n\n"
+        "# Benchmark Append CLI Fixture\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] Append a compact benchmark_run_v0 event through the CLI.\n\n"
+        "## Next Action\n\n"
+        "- Inspect the appended benchmark_run_v0 status projection.\n",
+        encoding="utf-8",
+    )
+    write_json(
+        registry_path,
+        {
+            "schema_version": 1,
+            "updated_at": "2026-06-07T00:00:00+00:00",
+            "common_runtime_root": str(runtime),
+            "goals": [
+                {
+                    "id": GOAL_ID,
+                    "domain": "benchmark-projection",
+                    "status": "active-read-only",
+                    "repo": str(project),
+                    "state_file": state_file,
+                    "adapter": {
+                        "kind": "harness_self_improvement",
+                        "status": "connected-read-only",
+                    },
+                    "quota": {"compute": 1.0, "window_hours": 24},
+                    "authority_sources": [],
+                }
+            ],
+        },
+    )
+    write_json(benchmark_run_path, benchmark_run_event())
+    return registry_path, runtime, benchmark_run_path
+
+
+def run_cli(args: list[str]) -> dict[str, Any]:
+    result = subprocess.run(
+        [sys.executable, "-m", "goal_harness.cli", *args],
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    payload = json.loads(result.stdout)
+    assert isinstance(payload, dict), payload
+    return payload
+
+
+def assert_no_private_surface(summary: dict[str, Any]) -> None:
+    text = json.dumps(summary, sort_keys=True)
+    forbidden = [
+        "/" + "Users/",
+        "/" + "tmp/",
+        "OPENAI_API_KEY",
+        "auth.json",
+        "sessions/",
+        "lark" + "office",
+        "fei" + "shu.cn",
+    ]
+    leaked = [needle for needle in forbidden if needle in text]
+    assert not leaked, leaked
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory(prefix="benchmark-run-v0-append-") as tmp:
+        registry_path, runtime, benchmark_run_path = write_fixture(Path(tmp))
+        index_path = runtime / "goals" / GOAL_ID / "runs" / "index.jsonl"
+
+        base_args = [
+            "--registry",
+            str(registry_path),
+            "--runtime-root",
+            str(runtime),
+            "--format",
+            "json",
+            "history",
+            "append-benchmark-run",
+            "--goal-id",
+            GOAL_ID,
+            "--benchmark-run-json",
+            str(benchmark_run_path),
+            "--delivery-batch-scale",
+            "implementation",
+            "--delivery-outcome",
+            "primary_goal_outcome",
+        ]
+
+        dry_run = run_cli(base_args)
+        assert dry_run["ok"], dry_run
+        assert dry_run["dry_run"] is True, dry_run
+        assert dry_run["appended"] is False, dry_run
+        assert not index_path.exists(), index_path
+        assert_no_private_surface(dry_run["benchmark_run"])
+
+        appended = run_cli([*base_args, "--execute"])
+        assert appended["ok"], appended
+        assert appended["dry_run"] is False, appended
+        assert appended["appended"] is True, appended
+        assert index_path.exists(), index_path
+        assert_no_private_surface(appended["benchmark_run"])
+
+        index_records = [
+            json.loads(line)
+            for line in index_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        assert len(index_records) == 1, index_records
+        assert index_records[0]["classification"] == "benchmark_run_v0", index_records
+        assert index_records[0]["benchmark_run"]["schema_version"] == "benchmark_run_v0", index_records
+
+        status = collect_status(
+            registry_path=registry_path,
+            runtime_root_override=str(runtime),
+            scan_roots=[],
+            limit=10,
+        )
+        assert status["ok"], status
+        latest = status["run_history"]["goals"][0]["latest_runs"][0]
+        summary = latest["benchmark_run_summary"]
+        assert summary["benchmark_id"] == BENCHMARK_ID, summary
+        assert summary["progress"]["n_completed_trials"] == 1, summary
+        assert summary["metrics"]["cost_usd"] == 0.45, summary
+        assert summary["validation"]["all_passed"] is True, summary
+        assert status["event_ledger_summary"]["totals"]["benchmark_runs_24h"] == 1, status
+        assert_no_private_surface(summary)
+
+    print("benchmark-run-v0-append-cli-smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -35,7 +35,13 @@ from .feedback import append_human_reward, compact_reward, render_reward_markdow
 from .global_registry import render_global_sync_markdown, sync_project_registry_to_global
 from .handoff_budget import build_handoff_interface_budget
 from .heartbeat_prompt import build_heartbeat_prompt, render_heartbeat_prompt_markdown
-from .history import collect_history, load_registry, render_history_markdown
+from .history import (
+    append_benchmark_run,
+    collect_history,
+    load_registry,
+    render_benchmark_run_append_markdown,
+    render_history_markdown,
+)
 from .operator_gate import (
     DEFAULT_OPERATOR_GATE,
     OPERATOR_GATE_DECISIONS,
@@ -74,7 +80,7 @@ from .state_refresh import (
     refresh_state_run,
     render_state_refresh_markdown,
 )
-from .status import collect_status, render_status_markdown
+from .status import collect_status, compact_benchmark_run, render_status_markdown
 from .status_server import (
     DEFAULT_STATUS_HOST,
     DEFAULT_STATUS_PATH,
@@ -440,8 +446,36 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     history_parser = sub.add_parser("history", help="Read compact run history from the shared runtime root.")
+    history_parser.add_argument(
+        "history_action",
+        nargs="?",
+        choices=["append-benchmark-run"],
+        help="Use append-benchmark-run to append a compact benchmark_run_v0 event.",
+    )
     history_parser.add_argument("--goal-id", help="Only show one goal.")
     history_parser.add_argument("--limit", type=int, default=10)
+    history_parser.add_argument(
+        "--benchmark-run-json",
+        help="Path to a benchmark_run_v0 JSON object. Use '-' to read stdin.",
+    )
+    history_parser.add_argument("--classification", default="benchmark_run_v0")
+    history_parser.add_argument(
+        "--recommended-action",
+        default="inspect benchmark_run_v0 summary and continue passive benchmark work",
+    )
+    history_parser.add_argument(
+        "--delivery-batch-scale",
+        choices=DELIVERY_BATCH_SCALE_CHOICES,
+        help="Optional delivery scale label for the run index.",
+    )
+    history_parser.add_argument(
+        "--delivery-outcome",
+        choices=DELIVERY_OUTCOME_CHOICES,
+        help="Optional delivery outcome label for the run index.",
+    )
+    history_parser.add_argument("--dry-run", action="store_true", help="Preview append without writing. This is the default.")
+    history_parser.add_argument("--execute", action="store_true", help="Append the compact benchmark_run_v0 event.")
+    history_parser.add_argument("--no-global-sync", action="store_true", help="Skip global registry sync after append.")
 
     archive_runtime_parser = sub.add_parser(
         "archive-runtime",
@@ -1072,6 +1106,65 @@ def main(argv: list[str] | None = None) -> int:
         return 0 if payload.get("ok") else 1
 
     if args.command == "history":
+        if args.history_action == "append-benchmark-run":
+            try:
+                if args.dry_run and args.execute:
+                    raise ValueError("history append-benchmark-run accepts either --dry-run or --execute, not both")
+                if not args.goal_id:
+                    raise ValueError("history append-benchmark-run requires --goal-id")
+                if not args.benchmark_run_json:
+                    raise ValueError("history append-benchmark-run requires --benchmark-run-json")
+
+                if args.benchmark_run_json == "-":
+                    benchmark_run_input = json.loads(sys.stdin.read())
+                else:
+                    benchmark_run_input = json.loads(Path(args.benchmark_run_json).expanduser().read_text(encoding="utf-8"))
+                if not isinstance(benchmark_run_input, dict):
+                    raise ValueError("--benchmark-run-json must contain a JSON object")
+                benchmark_run = compact_benchmark_run(benchmark_run_input)
+                if not benchmark_run:
+                    raise ValueError("--benchmark-run-json did not contain a compactable benchmark_run_v0 object")
+
+                dry_run = not bool(args.execute)
+                payload = append_benchmark_run(
+                    registry_path=registry_path,
+                    runtime_root_override=args.runtime_root,
+                    goal_id=args.goal_id,
+                    benchmark_run=benchmark_run,
+                    classification=args.classification,
+                    recommended_action=args.recommended_action,
+                    delivery_batch_scale=args.delivery_batch_scale,
+                    delivery_outcome=args.delivery_outcome,
+                    dry_run=dry_run,
+                )
+                if args.no_global_sync:
+                    payload["global_sync"] = {
+                        "ok": True,
+                        "dry_run": dry_run,
+                        "skipped": True,
+                        "reason": "disabled by --no-global-sync",
+                    }
+                else:
+                    payload["global_sync"] = sync_project_registry_to_global(
+                        registry_path=registry_path,
+                        runtime_root_override=args.runtime_root,
+                        goal_id=args.goal_id,
+                        dry_run=dry_run,
+                    )
+            except Exception as exc:
+                payload = {
+                    "ok": False,
+                    "dry_run": not bool(args.execute),
+                    "appended": False,
+                    "registry": str(registry_path),
+                    "runtime_root": args.runtime_root,
+                    "goal_id": args.goal_id,
+                    "classification": args.classification,
+                    "error": str(exc),
+                }
+            print_payload(payload, args.format, render_benchmark_run_append_markdown)
+            return 0 if payload.get("ok") else 1
+
         try:
             registry = load_registry(registry_path)
             runtime_root = resolve_runtime_root(registry, args.runtime_root)

--- a/goal_harness/history.py
+++ b/goal_harness/history.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import json
+import re
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 from .authority import goal_authority_registry_summary
 from .control_plane import compact_control_plane_policy
 from .execution_profile import compact_execution_profile
+from .paths import resolve_runtime_root
 from .quota import goal_quota_with_spend_ledger
 from .registry import read_json, registry_goals
 
@@ -21,6 +24,25 @@ REGISTRY_ATTENTION_FIELDS = (
     "recommended_action",
     "next_handoff_condition",
 )
+
+
+def now_local() -> str:
+    return datetime.now(timezone.utc).astimezone().replace(microsecond=0).isoformat()
+
+
+def run_file_stem(generated_at: str) -> str:
+    return re.sub(r"[^0-9A-Za-z-]+", "-", generated_at).strip("-")
+
+
+def validate_goal_id_path_segment(goal_id: str) -> str:
+    value = str(goal_id or "").strip()
+    if not value:
+        raise ValueError("goal id is required")
+    if value in {".", ".."} or "/" in value or "\\" in value:
+        raise ValueError("goal id must be a single path segment")
+    if Path(value).name != value:
+        raise ValueError("goal id must not include path traversal")
+    return value
 
 
 def load_registry(path: Path) -> dict[str, Any]:
@@ -81,6 +103,81 @@ def load_index(path: Path) -> tuple[list[dict[str, Any]], int]:
                 positions[key] = len(records)
                 records.append(item)
     return records, raw_count
+
+
+def append_benchmark_run(
+    *,
+    registry_path: Path,
+    runtime_root_override: str | None,
+    goal_id: str,
+    benchmark_run: dict[str, Any],
+    classification: str = "benchmark_run_v0",
+    recommended_action: str | None = None,
+    delivery_batch_scale: str | None = None,
+    delivery_outcome: str | None = None,
+    dry_run: bool = True,
+) -> dict[str, Any]:
+    safe_goal_id = validate_goal_id_path_segment(goal_id)
+    if benchmark_run.get("schema_version") != "benchmark_run_v0":
+        raise ValueError("benchmark run must have schema_version=benchmark_run_v0")
+
+    registry = load_registry(registry_path)
+    runtime_root = resolve_runtime_root(registry, runtime_root_override)
+    generated_at = now_local()
+    action = recommended_action or "inspect benchmark_run_v0 summary and continue passive benchmark work"
+    health_check = "benchmark_run_v0 compact event public-safe"
+
+    runs_dir = runtime_root / "goals" / safe_goal_id / "runs"
+    stem = run_file_stem(generated_at)
+    json_path = runs_dir / f"{stem}.json"
+    markdown_path = runs_dir / f"{stem}.md"
+    index_path = runs_dir / "index.jsonl"
+    record: dict[str, Any] = {
+        "generated_at": generated_at,
+        "goal_id": safe_goal_id,
+        "classification": classification,
+        "recommended_action": action,
+        "health_check": health_check,
+        "benchmark_run": benchmark_run,
+    }
+    if delivery_batch_scale:
+        record["delivery_batch_scale"] = delivery_batch_scale
+    if delivery_outcome:
+        record["delivery_outcome"] = delivery_outcome
+
+    index_record = {
+        **record,
+        "json_path": str(json_path),
+        "markdown_path": str(markdown_path),
+    }
+    payload = {
+        "ok": True,
+        "dry_run": dry_run,
+        "appended": not dry_run,
+        "registry": str(registry_path),
+        "runtime_root": str(runtime_root),
+        "goal_id": safe_goal_id,
+        "classification": classification,
+        "recommended_action": action,
+        "generated_at": generated_at,
+        "health_check": health_check,
+        "json_path": str(json_path),
+        "markdown_path": str(markdown_path),
+        "index_path": str(index_path),
+        "benchmark_run": benchmark_run,
+    }
+    if delivery_batch_scale:
+        payload["delivery_batch_scale"] = delivery_batch_scale
+    if delivery_outcome:
+        payload["delivery_outcome"] = delivery_outcome
+
+    if not dry_run:
+        runs_dir.mkdir(parents=True, exist_ok=True)
+        json_path.write_text(json.dumps(record, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        markdown_path.write_text(render_benchmark_run_append_markdown(payload) + "\n", encoding="utf-8")
+        with index_path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(index_record, ensure_ascii=False) + "\n")
+    return payload
 
 
 def latest_status_run(runs: list[dict[str, Any]]) -> dict[str, Any] | None:
@@ -203,4 +300,43 @@ def render_history_markdown(payload: dict[str, Any]) -> str:
             f"records=`{goal.get('raw_index_records')}`, "
             f"unique_runs=`{goal.get('unique_runs')}`"
         )
+    return "\n".join(lines)
+
+
+def render_benchmark_run_append_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Goal Harness Benchmark Run Append",
+        "",
+        f"- ok: `{payload.get('ok')}`",
+        f"- dry_run: `{payload.get('dry_run')}`",
+        f"- appended: `{payload.get('appended')}`",
+        f"- goal_id: `{payload.get('goal_id')}`",
+        f"- classification: `{payload.get('classification')}`",
+        f"- generated_at: `{payload.get('generated_at')}`",
+    ]
+    if payload.get("json_path"):
+        lines.append(f"- json_path: `{payload.get('json_path')}`")
+    if payload.get("index_path"):
+        lines.append(f"- index_path: `{payload.get('index_path')}`")
+    if payload.get("recommended_action"):
+        lines.append(f"- recommended_action: {payload.get('recommended_action')}")
+    benchmark_run = payload.get("benchmark_run") if isinstance(payload.get("benchmark_run"), dict) else {}
+    if benchmark_run:
+        progress = benchmark_run.get("progress") if isinstance(benchmark_run.get("progress"), dict) else {}
+        metrics = benchmark_run.get("metrics") if isinstance(benchmark_run.get("metrics"), dict) else {}
+        lines.extend(
+            [
+                "",
+                "## Benchmark Run",
+                "",
+                f"- schema_version: `{benchmark_run.get('schema_version')}`",
+                f"- benchmark_id: `{benchmark_run.get('benchmark_id')}`",
+                f"- source_runner: `{benchmark_run.get('source_runner')}`",
+                f"- mode: `{benchmark_run.get('mode')}`",
+                f"- progress: completed={progress.get('n_completed_trials')} total={progress.get('n_total_trials')}",
+                f"- metrics: input_tokens={metrics.get('input_tokens')} output_tokens={metrics.get('output_tokens')} cost_usd={metrics.get('cost_usd')}",
+            ]
+        )
+    if payload.get("error"):
+        lines.append(f"- error: {payload.get('error')}")
     return "\n".join(lines)


### PR DESCRIPTION
## Summary
- add `goal-harness history append-benchmark-run` for dry-run/execute appends of compact `benchmark_run_v0` events
- add a dependency-free CLI smoke covering dry-run, execute, run-history index, status projection, and public-safe compact summaries
- update the benchmark ingestion contract with the append command and next passive baseline slice

## Validation
- `python3 -m py_compile goal_harness/history.py goal_harness/cli.py examples/benchmark-run-v0-append-cli-smoke.py`
- `python3 examples/benchmark-run-v0-append-cli-smoke.py`
- `python3 examples/benchmark-run-v0-status-projection-smoke.py`
- `python3 examples/benchmark-run-v0-harbor-ingest-smoke.py`
- `python3 examples/run-smokes.py` (56 smoke scripts)
- `git diff --check`
- `python3 -m goal_harness.cli --format json check --scan-path goal_harness/history.py --scan-path goal_harness/cli.py --scan-path examples/benchmark-run-v0-append-cli-smoke.py --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-run-v0-ingest.md`
- added-line sensitive keyword scan over changed files: no hits

## Boundary
No local active-state, runtime history, private doc path, raw session, credential, or benchmark runner output is committed.