### PR TITLE
Add passive baseline protocol smoke

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/README.md
+++ b/docs/research/long-horizon-agent-benchmarks/README.md
@@ -36,6 +36,10 @@ work still belongs in the existing code, examples, and contract documents:
 - `benchmark-run-v0-ingest.md`: first passive `benchmark_run_v0` ingestion
   contract for Harbor job outputs, with deterministic fixture coverage and no
   default Docker, model, cloud, or leaderboard execution.
+- `passive-baseline-protocol-v0.md`: paired bare Codex CLI versus passive Goal
+  Harness wrapper protocol, connecting local `benchmark_result_v0` comparison
+  evidence to compact `benchmark_run_v0` history rows without operator
+  simulation.
 
 ## Relationship To Goal Harness Work
 

--- a/docs/research/long-horizon-agent-benchmarks/passive-baseline-protocol-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/passive-baseline-protocol-v0.md
@@ -1,0 +1,122 @@
+# Passive Baseline Protocol V0
+
+Checked at: 2026-06-07T20:05:00+08:00
+
+## Purpose
+
+This protocol is the first Goal Harness baseline that answers whether the
+control plane helps without any operator simulator. It compares the same
+autonomous engineering slice in two modes:
+
+- `bare_codex_cli`: Codex CLI or a deterministic Codex-like fixture receives a
+  plain task prompt and no Goal Harness registry, quota, review packet, Goal
+  Tick output, or runtime writeback surface.
+- `passive_goal_harness_wrapper`: the same worker and task are wrapped with
+  Goal Harness state, quota, review packet, Goal Tick phases, validation
+  writeback, and run-history append support, but no simulated operator
+  intervention is allowed.
+
+The protocol is deliberately passive. It may record and validate control-plane
+events, but it must not change task prompts, benchmark tests, scoring, resource
+limits, timeouts, hidden answers, or official runner behavior. In this mode, no
+simulated operator intervention is allowed.
+
+## Fixture Order
+
+Start local and deterministic before invoking official benchmark runners:
+
+1. Run `mini_control_plane_repair_v0` with the existing deterministic worker
+   pair from `examples/codex-cli-long-run-benchmark-smoke.py`.
+2. Produce `benchmark_result_v0` for both modes and a
+   `benchmark_comparison_v0` summary.
+3. Verify both modes use the same task id, worker surface, validation contract,
+   and official-task score layer.
+4. Require the with-harness mode to improve only control-plane dimensions:
+   restartability, stale-state avoidance, continuation quality, evidence
+   discipline, writeback quality, failure attribution, or spend discipline.
+5. Append one compact `benchmark_run_v0` row per mode through
+   `goal-harness history append-benchmark-run`.
+6. Inspect status/run history for two benchmark rows and no private surface.
+
+Only after this deterministic fixture is stable should the same mode pair move
+to a real Terminal-Bench or Harbor pilot.
+
+## Required Measurements
+
+Each paired result must preserve these fields:
+
+| Field | Rule |
+| --- | --- |
+| `scenario_id` | `bare_codex_cli` or `passive_goal_harness_wrapper`. |
+| `task_id` | Same task id for both modes. |
+| `worker_surface` | Same worker class unless the experiment explicitly records an ablation. |
+| `official_task_score` | Native or deterministic task score; local fixture should keep the delta at `0`. |
+| `control_plane_score` | Goal Harness coordination score; passive wrapper may improve this. |
+| `restartability` | Whether another worker can resume from public artifacts. |
+| `stale_state_avoidance` | Whether current state beats stale latest-run or stale todo text. |
+| `continuation_quality` | Whether the next action is durable and specific. |
+| `evidence_discipline` | Whether validation/failure evidence exists outside chat. |
+| `writeback_quality` | Whether state/run history records enough context to continue. |
+| `failure_attribution` | Compact cause labels when the run fails or stalls. |
+| `overhead` | Step, wall-time, spend, and writeback overhead. |
+
+The local fixture may encode these dimensions through
+`benchmark_result_v0.control_plane_score.components`. The runtime history row
+uses compact `benchmark_run_v0` so dashboard/status can count and route it
+without reading raw benchmark logs.
+
+## Append Command
+
+For each mode:
+
+```bash
+goal-harness history append-benchmark-run \
+  --goal-id <goal-id> \
+  --benchmark-run-json <benchmark-run-v0.json> \
+  --classification benchmark_run_v0 \
+  --recommended-action "inspect passive baseline pair and continue only after both modes are present" \
+  --delivery-batch-scale implementation \
+  --delivery-outcome primary_goal_outcome \
+  --execute
+```
+
+The JSON object must already be public-safe and compactable. The append command
+will compact it again before writing. This is a control-plane observation row,
+not a benchmark submission.
+
+## Stop Conditions
+
+Stop before:
+
+- invoking real Terminal-Bench, Harbor, Docker, Codex, cloud sandboxes, model
+  APIs, or paid external compute from an automatic heartbeat;
+- using a user or operator simulator;
+- changing benchmark prompt, task, tests, timeout, resource, scoring, or upload
+  behavior;
+- claiming or implying official leaderboard uplift from this local fixture. Do
+  not claim official leaderboard improvement from passive baseline control-plane
+  evidence alone;
+- copying raw session history, private docs, credentials, local user paths,
+  internal identifiers, or raw runner logs into public artifacts.
+
+## Current Smoke
+
+The protocol smoke is:
+
+```bash
+python3 examples/passive-baseline-protocol-smoke.py
+```
+
+It writes two deterministic public-safe `benchmark_run_v0` fixtures, appends
+them through the Goal Harness history CLI, and proves status can see two
+benchmark rows without reading real runner output.
+
+The broader local A/B capability smoke remains:
+
+```bash
+python3 examples/codex-cli-long-run-benchmark-smoke.py
+```
+
+That smoke emits `benchmark_result_v0` for with/without Goal Harness and keeps
+both official-task scores equal while requiring a positive
+`control_plane_score` delta.

--- a/examples/passive-baseline-protocol-smoke.py
+++ b/examples/passive-baseline-protocol-smoke.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Smoke-test the passive baseline protocol through benchmark_run_v0 appends."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from goal_harness.status import collect_status  # noqa: E402
+
+
+TOPIC_DIR = REPO_ROOT / "docs" / "research" / "long-horizon-agent-benchmarks"
+README = TOPIC_DIR / "README.md"
+PROTOCOL = TOPIC_DIR / "passive-baseline-protocol-v0.md"
+GOAL_ID = "passive-baseline-fixture"
+TASK_ID = "mini_control_plane_repair_v0"
+BENCHMARK_ID = "goal-harness-local-passive-baseline@v0"
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def benchmark_run_event(mode: str, *, control_value: float, spend_count: int) -> dict[str, Any]:
+    return {
+        "schema_version": "benchmark_run_v0",
+        "source_runner": "goal-harness-local-fixture",
+        "benchmark_id": BENCHMARK_ID,
+        "job_name": f"{TASK_ID}__{mode}",
+        "mode": mode,
+        "agent": {
+            "name": "codex-cli-fixture",
+            "model": "deterministic-shim",
+            "kwargs_keys": ["no_operator_simulator"],
+        },
+        "progress": {
+            "n_total_trials": 1,
+            "n_completed_trials": 1,
+            "n_errored_trials": 0,
+            "n_running_trials": 0,
+            "n_pending_trials": 0,
+            "n_cancelled_trials": 0,
+            "n_retries": 0,
+        },
+        "metrics": {
+            "input_tokens": 0,
+            "cache_tokens": 0,
+            "output_tokens": 0,
+            "cost_usd": 0.0,
+        },
+        "trials": [
+            {
+                "task_id": TASK_ID,
+                "trial_name": f"{TASK_ID}__{mode}__attempt-1",
+                "source": BENCHMARK_ID,
+                "reward": {"reward": 1.0, "control_plane_score": control_value},
+                "metrics": {
+                    "input_tokens": 0,
+                    "cache_tokens": 0,
+                    "output_tokens": 0,
+                    "cost_usd": 0.0,
+                },
+                "trajectory_present": mode == "passive_goal_harness_wrapper",
+                "verifier_reward_present": True,
+                "artifact_manifest_present": True,
+                "trial_result_present": True,
+            }
+        ],
+        "validation": {
+            "same_task_pair": True,
+            "no_operator_simulator": True,
+            "official_task_score_delta_zero": True,
+            "control_plane_score_recorded": True,
+            "spend_after_validation_only": spend_count > 0 or mode == "bare_codex_cli",
+            "no_leaderboard_upload_requested": True,
+            "paths_redacted": True,
+        },
+        "evidence_files": [
+            "fixture:benchmark_result_v0",
+            "fixture:benchmark_comparison_v0",
+            "fixture:public_artifact_manifest",
+        ],
+        "resume_or_inspect_commands": [
+            "python3 examples/codex-cli-long-run-benchmark-smoke.py",
+            "goal-harness history --goal-id <goal-id> --limit 2",
+        ],
+        "stop_conditions": [
+            "do_not_invoke_real_benchmark_or_model_api_from_heartbeat",
+            "do_not_use_operator_simulator_in_passive_baseline",
+            "do_not_claim_official_leaderboard_improvement_from_local_fixture",
+        ],
+    }
+
+
+def write_fixture(root: Path) -> tuple[Path, Path, dict[str, Path]]:
+    project = root / "project"
+    runtime = root / "runtime"
+    state_file = f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    registry_path = project / ".goal-harness" / "registry.json"
+    event_paths = {
+        "bare_codex_cli": root / "bare_codex_cli.benchmark_run.json",
+        "passive_goal_harness_wrapper": root / "passive_goal_harness_wrapper.benchmark_run.json",
+    }
+
+    (project / Path(state_file).parent).mkdir(parents=True, exist_ok=True)
+    (project / state_file).write_text(
+        "---\n"
+        "status: active-read-only\n"
+        "updated_at: 2026-06-07T00:00:00+00:00\n"
+        "---\n\n"
+        "# Passive Baseline Fixture\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] Append bare and passive-wrapper benchmark_run_v0 rows.\n\n"
+        "## Next Action\n\n"
+        "- Inspect the paired passive baseline benchmark rows.\n",
+        encoding="utf-8",
+    )
+    write_json(
+        registry_path,
+        {
+            "schema_version": 1,
+            "updated_at": "2026-06-07T00:00:00+00:00",
+            "common_runtime_root": str(runtime),
+            "goals": [
+                {
+                    "id": GOAL_ID,
+                    "domain": "benchmark-projection",
+                    "status": "active-read-only",
+                    "repo": str(project),
+                    "state_file": state_file,
+                    "adapter": {
+                        "kind": "harness_self_improvement",
+                        "status": "connected-read-only",
+                    },
+                    "quota": {"compute": 1.0, "window_hours": 24},
+                    "authority_sources": [],
+                }
+            ],
+        },
+    )
+    write_json(
+        event_paths["bare_codex_cli"],
+        benchmark_run_event("bare_codex_cli", control_value=0.70, spend_count=0),
+    )
+    write_json(
+        event_paths["passive_goal_harness_wrapper"],
+        benchmark_run_event("passive_goal_harness_wrapper", control_value=0.86, spend_count=3),
+    )
+    return registry_path, runtime, event_paths
+
+
+def run_cli(args: list[str]) -> dict[str, Any]:
+    result = subprocess.run(
+        [sys.executable, "-m", "goal_harness.cli", *args],
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    payload = json.loads(result.stdout)
+    assert isinstance(payload, dict), payload
+    return payload
+
+
+def append_event(registry_path: Path, runtime: Path, mode: str, event_path: Path) -> dict[str, Any]:
+    return run_cli(
+        [
+            "--registry",
+            str(registry_path),
+            "--runtime-root",
+            str(runtime),
+            "--format",
+            "json",
+            "history",
+            "append-benchmark-run",
+            "--goal-id",
+            GOAL_ID,
+            "--benchmark-run-json",
+            str(event_path),
+            "--recommended-action",
+            "inspect passive baseline pair and continue only after both modes are present",
+            "--delivery-batch-scale",
+            "implementation",
+            "--delivery-outcome",
+            "primary_goal_outcome",
+            "--execute",
+            "--no-global-sync",
+        ]
+    )
+
+
+def assert_no_private_surface(summary: dict[str, Any]) -> None:
+    text = json.dumps(summary, sort_keys=True)
+    forbidden = [
+        "/" + "Users/",
+        "/" + "tmp/",
+        "OPENAI_API_KEY",
+        "auth.json",
+        "sessions/",
+        "lark" + "office",
+        "fei" + "shu.cn",
+    ]
+    leaked = [needle for needle in forbidden if needle in text]
+    assert not leaked, leaked
+
+
+def assert_doc_contract() -> None:
+    readme = README.read_text(encoding="utf-8")
+    doc = PROTOCOL.read_text(encoding="utf-8")
+    compact_doc = " ".join(doc.split())
+    required = [
+        "Passive Baseline Protocol V0",
+        "`bare_codex_cli`",
+        "`passive_goal_harness_wrapper`",
+        "no simulated operator intervention is allowed",
+        "`benchmark_result_v0`",
+        "`benchmark_comparison_v0`",
+        "append-benchmark-run",
+        "official-task scores equal",
+        "`control_plane_score` delta",
+        "Do not claim official leaderboard improvement",
+        "python3 examples/passive-baseline-protocol-smoke.py",
+        "python3 examples/codex-cli-long-run-benchmark-smoke.py",
+    ]
+    missing = [snippet for snippet in required if snippet not in compact_doc]
+    assert not missing, missing
+    assert "passive-baseline-protocol-v0.md" in readme, readme
+
+
+def main() -> None:
+    assert_doc_contract()
+    with tempfile.TemporaryDirectory(prefix="passive-baseline-protocol-") as tmp:
+        registry_path, runtime, event_paths = write_fixture(Path(tmp))
+        appended = [
+            append_event(registry_path, runtime, mode, path)
+            for mode, path in event_paths.items()
+        ]
+        assert all(item["ok"] and item["appended"] for item in appended), appended
+        assert {item["benchmark_run"]["mode"] for item in appended} == {
+            "bare_codex_cli",
+            "passive_goal_harness_wrapper",
+        }, appended
+
+        status = collect_status(
+            registry_path=registry_path,
+            runtime_root_override=str(runtime),
+            scan_roots=[],
+            limit=10,
+        )
+        assert status["ok"], status
+        goal = status["run_history"]["goals"][0]
+        summaries = [
+            run.get("benchmark_run_summary")
+            for run in goal["latest_runs"]
+            if isinstance(run.get("benchmark_run_summary"), dict)
+        ]
+        modes = {summary["mode"] for summary in summaries}
+        assert modes == {"bare_codex_cli", "passive_goal_harness_wrapper"}, summaries
+        assert status["event_ledger_summary"]["totals"]["benchmark_runs_24h"] == 2, status
+        for summary in summaries:
+            assert summary["benchmark_id"] == BENCHMARK_ID, summary
+            assert summary["progress"]["n_completed_trials"] == 1, summary
+            assert summary["validation"]["all_passed"] is True, summary
+            assert summary["trials"][0]["reward"]["reward"] == 1.0, summary
+            assert_no_private_surface(summary)
+
+    print("passive-baseline-protocol-smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/goal_harness/history.py
+++ b/goal_harness/history.py
@@ -34,6 +34,22 @@ def run_file_stem(generated_at: str) -> str:
     return re.sub(r"[^0-9A-Za-z-]+", "-", generated_at).strip("-")
 
 
+def unique_run_paths(runs_dir: Path, generated_at: str) -> tuple[Path, Path]:
+    stem = run_file_stem(generated_at)
+    json_path = runs_dir / f"{stem}.json"
+    markdown_path = runs_dir / f"{stem}.md"
+    if not json_path.exists() and not markdown_path.exists():
+        return json_path, markdown_path
+
+    suffix = 2
+    while True:
+        json_path = runs_dir / f"{stem}-{suffix}.json"
+        markdown_path = runs_dir / f"{stem}-{suffix}.md"
+        if not json_path.exists() and not markdown_path.exists():
+            return json_path, markdown_path
+        suffix += 1
+
+
 def validate_goal_id_path_segment(goal_id: str) -> str:
     value = str(goal_id or "").strip()
     if not value:
@@ -128,9 +144,7 @@ def append_benchmark_run(
     health_check = "benchmark_run_v0 compact event public-safe"
 
     runs_dir = runtime_root / "goals" / safe_goal_id / "runs"
-    stem = run_file_stem(generated_at)
-    json_path = runs_dir / f"{stem}.json"
-    markdown_path = runs_dir / f"{stem}.md"
+    json_path, markdown_path = unique_run_paths(runs_dir, generated_at)
     index_path = runs_dir / "index.jsonl"
     record: dict[str, Any] = {
         "generated_at": generated_at,


### PR DESCRIPTION
## Summary
- add `passive-baseline-protocol-v0.md` for bare Codex CLI versus passive Goal Harness wrapper comparisons without operator simulation
- add a deterministic smoke that appends paired `benchmark_run_v0` rows through the history CLI and proves status sees both rows
- fix same-second `benchmark_run_v0` appends by assigning unique run artifact filenames instead of overwriting the first row

## Validation
- `PATH="$HOME/.local/bin:$PATH" goal-harness doctor`
- `python3 examples/passive-baseline-protocol-smoke.py`
- `python3 examples/codex-cli-long-run-benchmark-smoke.py`
- `python3 examples/benchmark-run-v0-append-cli-smoke.py`
- `python3 examples/long-horizon-agent-benchmark-roadmap-smoke.py`
- `python3 examples/run-smokes.py` (57 smoke scripts)
- `python3 -m py_compile goal_harness/history.py examples/passive-baseline-protocol-smoke.py`
- `git diff --check`
- `python3 -m goal_harness.cli --format json check --scan-path docs/research/long-horizon-agent-benchmarks/README.md --scan-path docs/research/long-horizon-agent-benchmarks/passive-baseline-protocol-v0.md --scan-path examples/passive-baseline-protocol-smoke.py --scan-path goal_harness/history.py`
- added-line sensitive keyword scan over changed files: no hits

## Boundary
No local active-state, runtime history, private doc path, raw session, credential, real benchmark output, Docker/Codex/model invocation, or leaderboard upload path is committed.