### PR TITLE
Add autonomous replan obligation contract

### DIFF
--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -857,6 +857,17 @@ and keep only current open work plus a small recent-done tail under active
 This warning is a checklist hygiene signal only: it does not change quota
 eligibility, grant write or production permission, or supersede open user/agent
 todo blockers.
+When the payload includes `autonomous_replan_obligation`, the active state has
+public-safe evidence that the controller may be stuck in a periodic-review
+threshold, no-progress streak, repeated-action loop, phase transition, backlog
+mismatch, or evidence contradiction. Executors should treat the object as a
+machine-readable planning contract: inspect `triggers`, apply the compact
+`todo_actions` as split/add/retire guidance, run `next_validation_command` after
+the selected slice, and stop at `stop_condition`. For eligible goals without
+open user todos, `heartbeat_recommendation.recommended_mode` may become
+`autonomous_replan_required`; this is intended to keep monitor-only work from
+consuming the primary executable backlog, not to grant new private, destructive,
+production, or owner-only authority.
 The payload also includes `execution_obligation`, which is the stronger worker
 contract. `heartbeat_recommendation.notify` is only a user-facing notification
 policy. It must not be interpreted as an execution gate. If

--- a/examples/autonomous-replan-obligation-smoke.py
+++ b/examples/autonomous-replan-obligation-smoke.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Smoke-test autonomous replan obligation projection in status and quota."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GOAL_ID = "autonomous-replan-fixture"
+
+
+def run_cli(*args: str, registry_path: Path, runtime: Path) -> dict:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "goal_harness.cli",
+            "--registry",
+            str(registry_path),
+            "--runtime-root",
+            str(runtime),
+            "--format",
+            "json",
+            *args,
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def write_fixture(root: Path, *, include_replan_signals: bool) -> tuple[Path, Path]:
+    project = root / "project"
+    runtime = root / "runtime"
+    state_file = f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    state_path = project / state_file
+    registry_path = project / ".goal-harness" / "registry.json"
+
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    replan_section = ""
+    if include_replan_signals:
+        replan_section = (
+            "## Recent Progress\n\n"
+            "- no-progress streak: three eligible heartbeats repeated the same dependency observation.\n"
+            "- repeated-action loop: the same monitor-only next action appeared again.\n"
+            "- phase transition: readiness work is done and the next phase should advance planning-trigger work.\n\n"
+        )
+    todo_text = (
+        "[P1] Autonomous planning-trigger implementation slice: emit a machine-readable replan obligation."
+        if include_replan_signals
+        else "[P1] Advance the next bounded project hardening slice."
+    )
+    state_path.write_text(
+        "---\n"
+        "status: active\n"
+        "updated_at: 2026-01-01T00:00:00+00:00\n"
+        "---\n\n"
+        "# Autonomous Replan Fixture\n\n"
+        "## Next Action\n\n"
+        "- Advance the first executable agent todo after observing current state.\n\n"
+        f"{replan_section}"
+        "## Agent Todo\n\n"
+        f"- [ ] {todo_text}\n",
+        encoding="utf-8",
+    )
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "autonomous-replan-fixture",
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": state_file,
+                        "adapter": {
+                            "kind": "harness_self_improvement",
+                            "status": "connected-read-only",
+                        },
+                        "authority_sources": [],
+                        "quota": {
+                            "compute": 1.0,
+                            "window_hours": 24,
+                            "allowed_slots": 5,
+                        },
+                    }
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return registry_path, runtime
+
+
+def attention_item(status_payload: dict) -> dict:
+    items = status_payload.get("attention_queue", {}).get("items") or []
+    assert len(items) == 1, status_payload
+    return items[0]
+
+
+def assert_replan_obligation_projected() -> None:
+    with tempfile.TemporaryDirectory(prefix="goal-harness-autonomous-replan-") as tmp:
+        registry_path, runtime = write_fixture(Path(tmp), include_replan_signals=True)
+        status_payload = run_cli("status", registry_path=registry_path, runtime=runtime)
+        item = attention_item(status_payload)
+        obligation = item["project_asset"]["autonomous_replan_obligation"]
+        assert obligation["schema_version"] == "autonomous_replan_obligation_v0", obligation
+        assert obligation["required"] is True, obligation
+        assert obligation["trigger_count"] == 3, obligation
+        assert [trigger["kind"] for trigger in obligation["triggers"]] == [
+            "no_progress_streak",
+            "repeated_action_loop",
+            "phase_transition",
+        ], obligation
+        assert item["autonomous_replan_obligation"] == obligation, item
+        assert obligation["next_validation_command"] == (
+            "python3 examples/autonomous-replan-obligation-smoke.py"
+        ), obligation
+        assert obligation["todo_actions"][0]["action"] == "split", obligation
+        assert obligation["todo_actions"][1]["action"] == "add", obligation
+        assert obligation["todo_actions"][2]["action"] == "retire", obligation
+
+        guard = run_cli("quota", "should-run", "--goal-id", GOAL_ID, registry_path=registry_path, runtime=runtime)
+        assert guard["should_run"] is True, guard
+        assert guard["autonomous_replan_obligation"] == obligation, guard
+        recommendation = guard["heartbeat_recommendation"]
+        assert recommendation["recommended_mode"] == "autonomous_replan_required", recommendation
+        assert recommendation["replan_obligation"]["trigger_count"] == 3, recommendation
+        assert guard["execution_obligation"]["must_attempt_work"] is True, guard
+
+
+def assert_no_replan_obligation_without_signal() -> None:
+    with tempfile.TemporaryDirectory(prefix="goal-harness-autonomous-replan-") as tmp:
+        registry_path, runtime = write_fixture(Path(tmp), include_replan_signals=False)
+        status_payload = run_cli("status", registry_path=registry_path, runtime=runtime)
+        item = attention_item(status_payload)
+        assert "autonomous_replan_obligation" not in item, item
+        assert "autonomous_replan_obligation" not in item["project_asset"], item
+
+        guard = run_cli("quota", "should-run", "--goal-id", GOAL_ID, registry_path=registry_path, runtime=runtime)
+        assert "autonomous_replan_obligation" not in guard, guard
+        assert guard["heartbeat_recommendation"]["recommended_mode"] != "autonomous_replan_required", guard
+
+
+def main() -> int:
+    assert_replan_obligation_projected()
+    assert_no_replan_obligation_without_signal()
+    print("autonomous-replan-obligation-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/goal_harness/quota.py
+++ b/goal_harness/quota.py
@@ -873,6 +873,14 @@ def _heartbeat_recommendation(
     lifecycle_phase = item.get("lifecycle_phase")
     lifecycle_flags = item.get("lifecycle_flags")
     quota = item.get("quota") if isinstance(item.get("quota"), dict) else {}
+    project_asset = item.get("project_asset") if isinstance(item.get("project_asset"), dict) else {}
+    replan_obligation = (
+        item.get("autonomous_replan_obligation")
+        if isinstance(item.get("autonomous_replan_obligation"), dict)
+        else project_asset.get("autonomous_replan_obligation")
+        if isinstance(project_asset.get("autonomous_replan_obligation"), dict)
+        else None
+    )
     has_user_todos = _open_todo_count(user_todo_summary) > 0
     has_agent_todos = _open_todo_count(agent_todo_summary) > 0
 
@@ -933,6 +941,27 @@ def _heartbeat_recommendation(
             **base,
             "recommended_mode": "quota_skip",
             "reason": f"quota state is {state}; skip delivery compute",
+        }
+    if replan_obligation and replan_obligation.get("required") and not has_user_todos:
+        return {
+            **base,
+            "recommended_mode": "autonomous_replan_required",
+            "notify": "DONT_NOTIFY",
+            "replan_obligation": {
+                "schema_version": replan_obligation.get("schema_version"),
+                "trigger_count": replan_obligation.get("trigger_count"),
+                "triggers": replan_obligation.get("triggers") or [],
+                "next_validation_command": replan_obligation.get("next_validation_command"),
+                "stop_condition": replan_obligation.get("stop_condition"),
+            },
+            "spend_policy": (
+                "append exactly one heartbeat spend only after executing the selected "
+                "replan slice, validating it, and writing back todo split/add/retire state"
+            ),
+            "reason": (
+                "active state exposes an autonomous replan obligation; advance the "
+                "planning-trigger slice before another monitor-only or repeated action"
+            ),
         }
 
     if status == "connected_without_run" and _supports_read_only_project_map(adapter_kind):
@@ -1531,6 +1560,15 @@ def build_quota_should_run(status_payload: dict[str, Any], *, goal_id: str) -> d
         )
         if archive_warning:
             payload["completed_todo_archive_warning"] = archive_warning
+        replan_obligation = (
+            item.get("autonomous_replan_obligation")
+            if isinstance(item.get("autonomous_replan_obligation"), dict)
+            else project_asset.get("autonomous_replan_obligation")
+            if isinstance(project_asset.get("autonomous_replan_obligation"), dict)
+            else None
+        )
+        if replan_obligation:
+            payload["autonomous_replan_obligation"] = replan_obligation
         interface_budget_cadence = (
             project_asset.get("interface_budget_cadence")
             if isinstance(project_asset.get("interface_budget_cadence"), dict)
@@ -2074,6 +2112,25 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
             lines.append(
                 f"- completed_todo_archive_action: {completed_todo_archive_warning.get('recommended_action')}"
             )
+    replan_obligation = (
+        payload.get("autonomous_replan_obligation")
+        if isinstance(payload.get("autonomous_replan_obligation"), dict)
+        else {}
+    )
+    if replan_obligation:
+        trigger_kinds = [
+            str(trigger.get("kind") or "")
+            for trigger in replan_obligation.get("triggers") or []
+            if isinstance(trigger, dict) and trigger.get("kind")
+        ]
+        lines.append(
+            "- autonomous_replan_obligation: "
+            f"required={replan_obligation.get('required')} "
+            f"trigger_count={replan_obligation.get('trigger_count')} "
+            f"triggers={','.join(trigger_kinds)}"
+        )
+        if replan_obligation.get("next_validation_command"):
+            lines.append(f"- autonomous_replan_validation: `{replan_obligation.get('next_validation_command')}`")
     interface_budget_cadence = (
         payload.get("interface_budget_cadence")
         if isinstance(payload.get("interface_budget_cadence"), dict)

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -271,11 +271,51 @@ MAX_AUTONOMOUS_BACKLOG_CANDIDATES = 6
 MAX_SUBAGENT_ACTIVITY_ITEMS = 5
 MAX_SUBAGENT_SCOPE_ITEMS = 4
 MAX_BACKLOG_HYGIENE_EVIDENCE_ITEMS = 3
+MAX_AUTONOMOUS_REPLAN_TRIGGERS = 3
 AUTONOMOUS_PRIORITY_PATTERN = re.compile(r"^\s*\[(P[0-4][^\]]*)\]\s*(.+)$", re.IGNORECASE)
 BACKLOG_HYGIENE_SECTION_HEADINGS = ("Next Action", "Operating Lessons")
 BACKLOG_HYGIENE_BULLET_PATTERN = re.compile(r"^\s*(?:[-*]|\d+[.)])\s+(.+?)\s*$")
 BACKLOG_HYGIENE_HINT_PATTERN = re.compile(
     r"(?i)(?:\[p[0-4]\]|todo|backlog|follow[- ]?up|queue|audit|regression|smoke|cadence|mirror|monitor|sub-?agent|待办|回归|审计|修复|检查|推进)"
+)
+AUTONOMOUS_REPLAN_SCHEMA_VERSION = "autonomous_replan_obligation_v0"
+AUTONOMOUS_REPLAN_SECTION_HEADINGS = (
+    "Next Action",
+    "Operating Lessons",
+    "Recent Progress",
+    "Agent Todo",
+    "Codex Todo",
+    "Project Agent Todo",
+)
+AUTONOMOUS_REPLAN_TRIGGER_PATTERNS = (
+    (
+        "periodic_review",
+        re.compile(r"(?i)(?:periodic review|periodic replan|review cadence|规划复盘|周期复盘|每几十轮)"),
+    ),
+    (
+        "no_progress_streak",
+        re.compile(r"(?i)(?:no[- ]?progress|stalled?|stall streak|没有实质进展|停转|连续[^。；;]*无进展)"),
+    ),
+    (
+        "repeated_action_loop",
+        re.compile(r"(?i)(?:repeated[- ]?action|action loop|same action|looped|重复动作|循环观察|反复观察)"),
+    ),
+    (
+        "phase_transition",
+        re.compile(r"(?i)(?:phase transition|next phase|stage transition|readiness .*done|阶段切换|进入下一阶段)"),
+    ),
+    (
+        "backlog_mismatch",
+        re.compile(r"(?i)(?:backlog mismatch|todo mismatch|next action mismatch|todo.*淹没|待办.*不一致)"),
+    ),
+    (
+        "evidence_contradiction",
+        re.compile(r"(?i)(?:evidence contradiction|contradictory evidence|stale evidence|stale latest-run|证据矛盾|状态矛盾)"),
+    ),
+    (
+        "explicit_replan",
+        re.compile(r"(?i)(?:autonomous replan|replan obligation|planning[- ]?trigger|重新规划|重规划|规划触发)"),
+    ),
 )
 TODO_ARCHIVE_HEADER_MARKERS = (
     "todo archive",
@@ -639,6 +679,32 @@ def active_state_sections(state_text: str, headings: tuple[str, ...]) -> dict[st
     return sections
 
 
+def active_state_section_entries(lines: list[str]) -> list[str]:
+    entries: list[str] = []
+    current: list[str] = []
+    for line in lines:
+        bullet_match = BACKLOG_HYGIENE_BULLET_PATTERN.match(line)
+        if bullet_match:
+            if current:
+                entries.append(normalize_todo_text(" ".join(current)))
+            current = [bullet_match.group(1)]
+            continue
+        if current and line.startswith((" ", "\t")):
+            continuation = line.strip()
+            if continuation:
+                current.append(continuation)
+            continue
+        if current:
+            entries.append(normalize_todo_text(" ".join(current)))
+            current = []
+        stripped = line.strip()
+        if stripped:
+            entries.append(stripped)
+    if current:
+        entries.append(normalize_todo_text(" ".join(current)))
+    return entries
+
+
 def backlog_hygiene_warning(state_text: str, *, agent_todos: dict[str, Any] | None) -> dict[str, Any] | None:
     try:
         agent_open_count = int(agent_todos.get("open_count") or 0) if isinstance(agent_todos, dict) else 0
@@ -674,6 +740,89 @@ def backlog_hygiene_warning(state_text: str, *, agent_todos: dict[str, Any] | No
         "recommended_action": (
             "mirror durable follow-up work into Agent Todo before heartbeat scheduling relies on "
             "Next Action or Operating Lessons"
+        ),
+    }
+
+
+def autonomous_replan_obligation(
+    state_text: str,
+    *,
+    agent_todos: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    evidence: list[dict[str, Any]] = []
+    seen_kinds: set[str] = set()
+    sections = active_state_sections(state_text, AUTONOMOUS_REPLAN_SECTION_HEADINGS)
+    for section, lines in sections.items():
+        for entry in active_state_section_entries(lines):
+            text = public_safe_compact_text(entry, limit=160)
+            if not text:
+                continue
+            for kind, pattern in AUTONOMOUS_REPLAN_TRIGGER_PATTERNS:
+                if kind in seen_kinds or not pattern.search(text):
+                    continue
+                evidence.append({"kind": kind, "section": section, "text": text})
+                seen_kinds.add(kind)
+                if len(evidence) >= MAX_AUTONOMOUS_REPLAN_TRIGGERS:
+                    break
+            if len(evidence) >= MAX_AUTONOMOUS_REPLAN_TRIGGERS:
+                break
+        if len(evidence) >= MAX_AUTONOMOUS_REPLAN_TRIGGERS:
+            break
+
+    if not evidence:
+        return None
+
+    first_open: dict[str, Any] = {}
+    if isinstance(agent_todos, dict):
+        open_items = agent_todos.get("first_open_items")
+        if isinstance(open_items, list) and open_items and isinstance(open_items[0], dict):
+            first_open = open_items[0]
+
+    todo_actions: list[dict[str, Any]] = []
+    first_open_text = public_safe_compact_text(first_open.get("text"), limit=140)
+    if first_open_text:
+        action: dict[str, Any] = {
+            "action": "split",
+            "role": "agent",
+            "text": first_open_text,
+        }
+        if first_open.get("priority"):
+            action["priority"] = first_open.get("priority")
+        todo_actions.append(action)
+    todo_actions.append(
+        {
+            "action": "add",
+            "role": "agent",
+            "priority": "P1",
+            "text": (
+                "write a compact replan record naming trigger, selected next slice, "
+                "validation command, and stop condition"
+            ),
+        }
+    )
+    if any(item.get("kind") in {"no_progress_streak", "repeated_action_loop"} for item in evidence):
+        todo_actions.append(
+            {
+                "action": "retire",
+                "role": "agent",
+                "priority": "P2",
+                "text": "retire or downgrade stale monitor-only next actions after the executable replan is selected",
+            }
+        )
+
+    return {
+        "schema_version": AUTONOMOUS_REPLAN_SCHEMA_VERSION,
+        "required": True,
+        "trigger_count": len(evidence),
+        "triggers": evidence,
+        "todo_actions": todo_actions[:3],
+        "next_validation_command": "python3 examples/autonomous-replan-obligation-smoke.py",
+        "stop_condition": (
+            "stop if the replan requires private material, credentials, destructive git, "
+            "production actions, or owner-only decisions"
+        ),
+        "recommended_action": (
+            "run an autonomous replan before another monitor-only or repeated action consumes the eligible turn"
         ),
     }
 
@@ -1559,6 +1708,12 @@ def active_state_todo_fields(goal: dict[str, Any]) -> dict[str, Any]:
     )
     if archive_warning:
         fields["completed_todo_archive_warning"] = archive_warning
+    replan_obligation = autonomous_replan_obligation(
+        state_text,
+        agent_todos=fields.get("agent_todos") if isinstance(fields.get("agent_todos"), dict) else None,
+    )
+    if replan_obligation:
+        fields["autonomous_replan_obligation"] = replan_obligation
     if fields:
         fields = redacted_status_todo_fields(fields)
     return fields
@@ -2262,6 +2417,13 @@ def build_attention_queue(
                 )
                 if archive_warning and isinstance(item.get("project_asset"), dict):
                     item["project_asset"]["completed_todo_archive_warning"] = archive_warning
+                replan_obligation = (
+                    item.get("autonomous_replan_obligation")
+                    if isinstance(item.get("autonomous_replan_obligation"), dict)
+                    else None
+                )
+                if replan_obligation and isinstance(item.get("project_asset"), dict):
+                    item["project_asset"]["autonomous_replan_obligation"] = replan_obligation
                 item["quota"] = quota_status(
                     goal,
                     waiting_on=str(item.get("waiting_on") or ""),
@@ -3547,6 +3709,23 @@ def render_status_markdown(payload: dict[str, Any]) -> str:
                     f"active_done={archive_warning.get('active_done_count')} "
                     f"max_active_done={archive_warning.get('max_active_done_count')} "
                     f"archive_section={_markdown_scalar(archive_warning.get('archive_section') or '')}"
+                )
+            replan_obligation = (
+                project_asset.get("autonomous_replan_obligation")
+                if isinstance(project_asset.get("autonomous_replan_obligation"), dict)
+                else {}
+            )
+            if replan_obligation:
+                trigger_kinds = [
+                    str(trigger.get("kind") or "")
+                    for trigger in replan_obligation.get("triggers") or []
+                    if isinstance(trigger, dict) and trigger.get("kind")
+                ]
+                lines.append(
+                    "    - autonomous_replan_obligation: "
+                    f"required={replan_obligation.get('required')} "
+                    f"trigger_count={replan_obligation.get('trigger_count')} "
+                    f"triggers={_markdown_scalar(','.join(trigger_kinds))}"
                 )
             interface_budget_cadence = (
                 project_asset.get("interface_budget_cadence")


### PR DESCRIPTION
## Summary
- add autonomous_replan_obligation_v0 projection from active-state replan/stall/loop signals
- mirror the obligation through status project_asset and quota should-run, including heartbeat_recommendation mode autonomous_replan_required
- document the executor contract and add a smoke fixture covering positive and negative projection cases

## Validation
- python3 examples/autonomous-replan-obligation-smoke.py
- python3 examples/backlog-hygiene-smoke.py
- python3 -m py_compile goal_harness/status.py goal_harness/quota.py examples/autonomous-replan-obligation-smoke.py
- python3 examples/run-smokes.py (59 smoke scripts; first aggregate run hit transient reward-preview stale check, individual reward smoke and full rerun passed)
- goal-harness-canary check
- python3 examples/check-public-boundary-smoke.py
- git diff --cached --check
- added-line sensitive keyword scan: no hits for credentials, local paths, Lark URLs, or token-like values