### PR TITLE
Limit autonomous replan trigger sources

### DIFF
--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -857,17 +857,19 @@ and keep only current open work plus a small recent-done tail under active
 This warning is a checklist hygiene signal only: it does not change quota
 eligibility, grant write or production permission, or supersede open user/agent
 todo blockers.
-When the payload includes `autonomous_replan_obligation`, the active state has
-public-safe evidence that the controller may be stuck in a periodic-review
-threshold, no-progress streak, repeated-action loop, phase transition, backlog
-mismatch, or evidence contradiction. Executors should treat the object as a
-machine-readable planning contract: inspect `triggers`, apply the compact
-`todo_actions` as split/add/retire guidance, run `next_validation_command` after
-the selected slice, and stop at `stop_condition`. For eligible goals without
-open user todos, `heartbeat_recommendation.recommended_mode` may become
+When the payload includes `autonomous_replan_obligation`, the active state's
+current `Next Action` or `Operating Lessons` carries public-safe evidence that
+the controller may be stuck in a periodic-review threshold, no-progress streak,
+repeated-action loop, phase transition, backlog mismatch, or evidence
+contradiction. Historical progress entries and completed todos are intentionally
+not trigger sources. Executors should treat the object as a machine-readable
+planning contract: inspect `triggers`, apply the compact `todo_actions` as
+split/add/retire guidance, run `next_validation_command` after the selected
+slice, and stop at `stop_condition`. For eligible goals without open user
+todos, `heartbeat_recommendation.recommended_mode` may become
 `autonomous_replan_required`; this is intended to keep monitor-only work from
-consuming the primary executable backlog, not to grant new private, destructive,
-production, or owner-only authority.
+consuming the primary executable backlog, not to grant new private,
+destructive, production, or owner-only authority.
 The payload also includes `execution_obligation`, which is the stronger worker
 contract. `heartbeat_recommendation.notify` is only a user-facing notification
 policy. It must not be interpreted as an execution gate. If

--- a/examples/autonomous-replan-obligation-smoke.py
+++ b/examples/autonomous-replan-obligation-smoke.py
@@ -47,10 +47,20 @@ def write_fixture(root: Path, *, include_replan_signals: bool) -> tuple[Path, Pa
     replan_section = ""
     if include_replan_signals:
         replan_section = (
-            "## Recent Progress\n\n"
+            "## Operating Lessons\n\n"
             "- no-progress streak: three eligible heartbeats repeated the same dependency observation.\n"
             "- repeated-action loop: the same monitor-only next action appeared again.\n"
             "- phase transition: readiness work is done and the next phase should advance planning-trigger work.\n\n"
+        )
+    historical_noise_section = ""
+    done_todo_line = ""
+    if not include_replan_signals:
+        historical_noise_section = (
+            "## Recent Progress\n\n"
+            "- 2026-01-01: An older no-progress streak repair was already completed.\n\n"
+        )
+        done_todo_line = (
+            "- [x] [P1] Completed autonomous planning-trigger work with a replan obligation.\n"
         )
     todo_text = (
         "[P1] Autonomous planning-trigger implementation slice: emit a machine-readable replan obligation."
@@ -66,7 +76,9 @@ def write_fixture(root: Path, *, include_replan_signals: bool) -> tuple[Path, Pa
         "## Next Action\n\n"
         "- Advance the first executable agent todo after observing current state.\n\n"
         f"{replan_section}"
+        f"{historical_noise_section}"
         "## Agent Todo\n\n"
+        f"{done_todo_line}"
         f"- [ ] {todo_text}\n",
         encoding="utf-8",
     )

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -282,10 +282,6 @@ AUTONOMOUS_REPLAN_SCHEMA_VERSION = "autonomous_replan_obligation_v0"
 AUTONOMOUS_REPLAN_SECTION_HEADINGS = (
     "Next Action",
     "Operating Lessons",
-    "Recent Progress",
-    "Agent Todo",
-    "Codex Todo",
-    "Project Agent Todo",
 )
 AUTONOMOUS_REPLAN_TRIGGER_PATTERNS = (
     (


### PR DESCRIPTION
## Summary
- limit autonomous_replan_obligation_v0 trigger sources to current Next Action and Operating Lessons
- document that historical progress entries and completed todos are not trigger sources
- extend the smoke negative case so stale Recent Progress and completed planning-trigger todos do not re-trigger the obligation

## Validation
- python3 examples/autonomous-replan-obligation-smoke.py
- python3 examples/backlog-hygiene-smoke.py
- python3 -m py_compile goal_harness/status.py examples/autonomous-replan-obligation-smoke.py
- goal-harness quota should-run --goal-id goal-harness-meta with explicit local PATH: no autonomous_replan_obligation after local active-state writeback
- python3 examples/run-smokes.py (59 smoke scripts)
- goal-harness-canary check
- git diff --check / git diff --cached --check
- added-line sensitive keyword scan: no hits for credentials, local paths, Lark URLs, or token-like values