### PR TITLE
Add work lane contract for monitor handoff

### DIFF
--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -185,6 +185,17 @@ by a repairable control-plane condition, `quota should-run` may instead return
 machine-readable bounded action for the selected goal, not a prompt-specific
 branch. Spend is allowed only after validation and durable writeback.
 
+`quota should-run` also separates long-running observation from work that should
+advance the selected goal. When the selected goal's current projection is a
+dependency-only observation, the payload includes `work_lane_contract` with
+`current_lane=continuous_monitor`. If open agent todos remain, the contract sets
+`next_lane=advancement_task`, `advancement_required=true`, and
+`heartbeat_recommendation.recommended_mode=advance_primary_backlog_after_dependency_observation`.
+An executor may still record one material dependency-state transition when it
+changes the meta decision, but unchanged monitor polls are quiet no-spend
+checks. This keeps monitoring useful without letting it consume every eligible
+turn.
+
 ## Compute States
 
 Recommended compact states:

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -122,6 +122,13 @@ also carries compact `handoff_readiness` with `handoff_status` and
 `post_handoff_run_seen`. Heartbeat jobs can therefore tell whether the selected
 goal is still waiting for a target run or has already seen post-handoff work
 without parsing the full status payload.
+The same guard may include `work_lane_contract`. The first schema is
+`work_lane_contract_v0` and distinguishes `continuous_monitor` from
+`advancement_task`. For a dependency-observation projection with open agent
+todos, the guard sets `next_lane=advancement_task` and
+`advancement_required=true`, and the heartbeat recommendation tells the
+executor to advance primary backlog or write a real blocker before spending
+another unchanged monitor-only turn.
 `handoff_readiness.handoff_interface_budget` declares the machine-readable
 budget for the minimal project-agent handoff: `mode=project_agent_handoff`,
 `max_lines=16`, and `max_chars=1800`. `goal-harness review-packet

--- a/examples/work-lane-contract-smoke.py
+++ b/examples/work-lane-contract-smoke.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Smoke-test monitor-vs-advancement lane projection in quota should-run."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from goal_harness.quota import build_quota_should_run, render_quota_should_run_markdown
+
+
+GOAL_ID = "work-lane-fixture"
+
+
+def status_payload(*, status: str, has_agent_todo: bool = True) -> dict:
+    agent_todos = {
+        "schema_version": "todo_summary_v0",
+        "source_section": "Agent Todo",
+        "total_count": 1 if has_agent_todo else 0,
+        "open_count": 1 if has_agent_todo else 0,
+        "done_count": 0,
+        "first_open_items": [
+            {
+                "index": 1,
+                "text": "[P1] Advance the self-repair planning slice with a validation-backed patch.",
+                "role": "agent",
+                "status": "open",
+                "priority": "P1",
+            }
+        ]
+        if has_agent_todo
+        else [],
+    }
+    return {
+        "ok": True,
+        "attention_queue": {
+            "items": [
+                {
+                    "goal_id": GOAL_ID,
+                    "status": status,
+                    "waiting_on": "codex",
+                    "severity": "info",
+                    "source": "project_asset",
+                    "recommended_action": "Observe dependency state and then advance backlog if unchanged.",
+                    "quota": {
+                        "compute": 1.0,
+                        "window_hours": 24,
+                        "slot_minutes": 1,
+                        "allowed_slots": 10,
+                        "spent_slots": 0,
+                        "state": "eligible",
+                        "reason": "eligible fixture",
+                    },
+                    "project_asset": {
+                        "next_action": "Observe dependency state and then advance backlog if unchanged.",
+                        "stop_condition": "stop on private material",
+                        "agent_todos": agent_todos,
+                    },
+                }
+            ]
+        },
+        "run_history": {
+            "goals": [
+                {
+                    "id": GOAL_ID,
+                    "registry_member": True,
+                    "status": status,
+                    "adapter_kind": "harness_self_improvement",
+                    "adapter_status": "connected-read-only",
+                    "quota": {
+                        "compute": 1.0,
+                        "window_hours": 24,
+                        "slot_minutes": 1,
+                        "allowed_slots": 10,
+                    },
+                }
+            ]
+        },
+    }
+
+
+def assert_dependency_monitor_requires_advancement() -> None:
+    guard = build_quota_should_run(
+        status_payload(status="side_bypass_dependency_observation"),
+        goal_id=GOAL_ID,
+    )
+    assert guard["should_run"] is True, guard
+    lane = guard["work_lane_contract"]
+    assert lane["schema_version"] == "work_lane_contract_v0", lane
+    assert lane["current_lane"] == "continuous_monitor", lane
+    assert lane["monitor_kind"] == "dependency_observation", lane
+    assert lane["next_lane"] == "advancement_task", lane
+    assert lane["advancement_required"] is True, lane
+    recommendation = guard["heartbeat_recommendation"]
+    assert recommendation["recommended_mode"] == "advance_primary_backlog_after_dependency_observation", recommendation
+    assert "dependency_observation_cap" in recommendation, recommendation
+    assert guard["execution_obligation"]["kind"] == "advance_primary_backlog_after_dependency_observation", guard
+    assert guard["execution_obligation"]["minimum"] == "one_primary_backlog_segment_or_material_transition", guard
+    assert guard["execution_obligation"]["work_lane"] == "continuous_monitor", guard
+    assert guard["execution_obligation"]["next_lane"] == "advancement_task", guard
+    markdown = render_quota_should_run_markdown(guard)
+    assert "work_lane_contract: current=continuous_monitor next=advancement_task" in markdown, markdown
+    assert "dependency_observation_cap" in markdown, markdown
+
+
+def assert_primary_status_stays_advancement_lane() -> None:
+    guard = build_quota_should_run(
+        status_payload(status="self_repair_planning_slice"),
+        goal_id=GOAL_ID,
+    )
+    assert guard["should_run"] is True, guard
+    assert guard["heartbeat_recommendation"]["recommended_mode"] == "steering_audit_then_one_step", guard
+    lane = guard["work_lane_contract"]
+    assert lane["current_lane"] == "advancement_task", lane
+    assert lane["next_lane"] == "advancement_task", lane
+    assert lane["advancement_required"] is True, lane
+
+
+def main() -> int:
+    assert_dependency_monitor_requires_advancement()
+    assert_primary_status_stays_advancement_lane()
+    print("work-lane-contract-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/goal_harness/quota.py
+++ b/goal_harness/quota.py
@@ -87,6 +87,7 @@ DEPENDENCY_OBSERVATION_CLASSIFICATION_HINTS = (
     "dependency_observation",
     "dependency_monitor",
 )
+WORK_LANE_CONTRACT_SCHEMA_VERSION = "work_lane_contract_v0"
 
 
 def _now_local() -> str:
@@ -196,6 +197,61 @@ def _latest_run_progress_scope(run: dict[str, Any]) -> str:
     if any(hint in classification for hint in DEPENDENCY_OBSERVATION_CLASSIFICATION_HINTS):
         return "dependency_observation"
     return "primary_goal"
+
+
+def _item_progress_scope(item: dict[str, Any]) -> str:
+    explicit = str(item.get("progress_scope") or "").strip()
+    if explicit:
+        return explicit
+    project_asset = item.get("project_asset") if isinstance(item.get("project_asset"), dict) else {}
+    project_explicit = str(project_asset.get("progress_scope") or "").strip()
+    if project_explicit:
+        return project_explicit
+    return _latest_run_progress_scope(
+        {
+            "classification": item.get("status") or item.get("latest_run_classification"),
+            "progress_scope": item.get("latest_run_progress_scope"),
+        }
+    )
+
+
+def _work_lane_contract(
+    item: dict[str, Any],
+    *,
+    agent_todo_summary: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    progress_scope = _item_progress_scope(item)
+    has_agent_todos = _open_todo_count(agent_todo_summary) > 0
+    if progress_scope != "dependency_observation":
+        if has_agent_todos:
+            return {
+                "schema_version": WORK_LANE_CONTRACT_SCHEMA_VERSION,
+                "current_lane": "advancement_task",
+                "next_lane": "advancement_task",
+                "monitoring_allowed": "only for a fresh blocker or material external-state transition",
+                "advancement_required": True,
+            }
+        return None
+
+    return {
+        "schema_version": WORK_LANE_CONTRACT_SCHEMA_VERSION,
+        "current_lane": "continuous_monitor",
+        "monitor_kind": "dependency_observation",
+        "next_lane": "advancement_task" if has_agent_todos else "continuous_monitor",
+        "advancement_required": has_agent_todos,
+        "monitoring_allowed": (
+            "record at most one dependency observation per material external-state transition; "
+            "unchanged monitor polls are quiet no-spend checks"
+        ),
+        "material_transition_exception": (
+            "a dependency-state transition may be written back once when it changes the meta decision"
+        ),
+        "advancement_action": (
+            "advance the first executable agent todo or write a concrete blocker"
+            if has_agent_todos
+            else "wait quietly for new external evidence"
+        ),
+    }
 
 
 def _focus_wait_quota(payload: dict[str, Any]) -> dict[str, Any]:
@@ -883,6 +939,7 @@ def _heartbeat_recommendation(
     )
     has_user_todos = _open_todo_count(user_todo_summary) > 0
     has_agent_todos = _open_todo_count(agent_todo_summary) > 0
+    work_lane_contract = _work_lane_contract(item, agent_todo_summary=agent_todo_summary)
 
     base: dict[str, Any] = {
         "source": "quota.should-run",
@@ -943,7 +1000,7 @@ def _heartbeat_recommendation(
             "reason": f"quota state is {state}; skip delivery compute",
         }
     if replan_obligation and replan_obligation.get("required") and not has_user_todos:
-        return {
+        payload = {
             **base,
             "recommended_mode": "autonomous_replan_required",
             "notify": "DONT_NOTIFY",
@@ -961,6 +1018,39 @@ def _heartbeat_recommendation(
             "reason": (
                 "active state exposes an autonomous replan obligation; advance the "
                 "planning-trigger slice before another monitor-only or repeated action"
+            ),
+        }
+        if work_lane_contract:
+            payload["work_lane_contract"] = work_lane_contract
+        return payload
+
+    if (
+        work_lane_contract
+        and work_lane_contract.get("current_lane") == "continuous_monitor"
+        and work_lane_contract.get("advancement_required") is True
+        and not has_user_todos
+    ):
+        return {
+            **base,
+            "recommended_mode": "advance_primary_backlog_after_dependency_observation",
+            "work_lane_contract": work_lane_contract,
+            "dependency_observation_cap": {
+                "latest_run_progress_scope": "dependency_observation",
+                "rule": (
+                    "Do not spend another consecutive meta turn mirroring dependency-only "
+                    "observation while primary agent todos remain executable."
+                ),
+            },
+            "spend_policy": (
+                "do not append quota spend for another dependency-only observation; "
+                "spend only after advancing the primary agent-todo backlog, writing a "
+                "real blocker, or recording a material dependency transition that changes "
+                "the meta decision"
+            ),
+            "reason": (
+                "current status is a continuous monitor lane; advance the first executable "
+                "agent todo or write a concrete blocker before spending another unchanged "
+                "dependency-observation turn"
             ),
         }
 
@@ -1081,6 +1171,11 @@ def _execution_obligation(
     """Separate the worker execution contract from user-facing notification."""
 
     recommended_mode = str(heartbeat_recommendation.get("recommended_mode") or "")
+    work_lane_contract = (
+        heartbeat_recommendation.get("work_lane_contract")
+        if isinstance(heartbeat_recommendation.get("work_lane_contract"), dict)
+        else {}
+    )
     if heartbeat_recommendation.get("stop_if_unchanged"):
         return {
             "must_attempt_work": False,
@@ -1092,16 +1187,30 @@ def _execution_obligation(
             ),
         }
     if should_run:
-        return {
+        obligation_kind = (
+            recommended_mode
+            if work_lane_contract.get("advancement_required") is True and recommended_mode
+            else effective_action or recommended_mode or "bounded_delivery"
+        )
+        payload = {
             "must_attempt_work": True,
-            "kind": effective_action or recommended_mode or "bounded_delivery",
-            "minimum": "one_bounded_segment",
+            "kind": obligation_kind,
+            "minimum": (
+                "one_primary_backlog_segment_or_material_transition"
+                if work_lane_contract.get("advancement_required") is True
+                else "one_bounded_segment"
+            ),
             "notify_is_execution_gate": False,
             "reason": (
                 "should_run=true means a Codex-actionable turn exists; heartbeat notify "
                 "only controls whether to interrupt the user"
             ),
         }
+        if work_lane_contract:
+            payload["work_lane"] = work_lane_contract.get("current_lane")
+            payload["next_lane"] = work_lane_contract.get("next_lane")
+            payload["advancement_required"] = bool(work_lane_contract.get("advancement_required"))
+        return payload
     return {
         "must_attempt_work": False,
         "kind": effective_action or recommended_mode or "skip",
@@ -1507,6 +1616,13 @@ def build_quota_should_run(status_payload: dict[str, Any], *, goal_id: str) -> d
             "plan_summary": plan.get("summary"),
             "todo_write_hint": _todo_write_hint(safe_goal_id),
         }
+        work_lane_contract = (
+            heartbeat_recommendation.get("work_lane_contract")
+            if isinstance(heartbeat_recommendation.get("work_lane_contract"), dict)
+            else _work_lane_contract(item, agent_todo_summary=agent_todo_summary)
+        )
+        if work_lane_contract:
+            payload["work_lane_contract"] = work_lane_contract
         control_plane = compact_control_plane_policy(item.get("control_plane"))
         if control_plane:
             payload["control_plane"] = control_plane
@@ -2131,6 +2247,22 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
         )
         if replan_obligation.get("next_validation_command"):
             lines.append(f"- autonomous_replan_validation: `{replan_obligation.get('next_validation_command')}`")
+    work_lane_contract = (
+        payload.get("work_lane_contract")
+        if isinstance(payload.get("work_lane_contract"), dict)
+        else {}
+    )
+    if work_lane_contract:
+        lines.append(
+            "- work_lane_contract: "
+            f"current={work_lane_contract.get('current_lane')} "
+            f"next={work_lane_contract.get('next_lane')} "
+            f"advancement_required={work_lane_contract.get('advancement_required')}"
+        )
+        if work_lane_contract.get("monitoring_allowed"):
+            lines.append(f"- work_lane_monitoring_allowed: {work_lane_contract.get('monitoring_allowed')}")
+        if work_lane_contract.get("advancement_action"):
+            lines.append(f"- work_lane_advancement_action: {work_lane_contract.get('advancement_action')}")
     interface_budget_cadence = (
         payload.get("interface_budget_cadence")
         if isinstance(payload.get("interface_budget_cadence"), dict)


### PR DESCRIPTION
## Summary
- Add work_lane_contract_v0 to quota should-run so dependency-only observations are projected as continuous_monitor lanes.
- When open agent todos remain, force next_lane=advancement_task and recommend advance_primary_backlog_after_dependency_observation.
- Document the contract and add a smoke covering monitor-to-advancement routing.

## Validation
- python3 examples/work-lane-contract-smoke.py
- python3 examples/autonomous-replan-obligation-smoke.py
- python3 examples/heartbeat-quota-flow-smoke.py
- python3 examples/quota-contract-smoke.py
- python3 examples/status-markdown-smoke.py
- python3 examples/review-packet-smoke.py
- python3 examples/run-smokes.py (60 smoke scripts)
- goal-harness-canary check
- git diff --check
- public/private boundary scan clean via canary
- local sensitive keyword scan over changed files clean

## Scope
- Public Goal Harness control-plane contract only.
- No .local/runtime/private evidence/credentials included.