### PR TITLE
Add typed todo lane routing

### DIFF
--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -189,15 +189,23 @@ branch. Spend is allowed only after validation and durable writeback.
 advance the selected goal. When the selected goal's current projection is a
 dependency-only observation, the payload includes `work_lane_contract` with
 `lane=continuous_monitor`. If open agent todos remain, schema
-`work_lane_contract_v1` sets `next_lane=advancement_task`,
+`work_lane_contract_v1` now classifies todo items as
+`task_class=advancement_task` or `task_class=continuous_monitor`. It sets
+`next_lane=advancement_task`,
 `obligation=advance_unless_material_monitor_transition`,
 `must_attempt_work=true`, and reason codes such as `dependency_observation` and
-`open_agent_todo`. `heartbeat_recommendation` should then say
-`follow_work_lane_contract` instead of encoding another project-specific branch.
-An executor may still record one material dependency-state transition when it
-changes the selected goal decision, but unchanged monitor polls are quiet
-no-spend checks. This keeps monitoring useful without letting it consume every
-eligible turn, and it keeps the hard routing rule in one small machine contract.
+`open_agent_todo` only when at least one open todo is advancement-class work.
+If all visible open todos are monitor-class and no open todo is hidden, the
+same contract uses `obligation=quiet_until_material_monitor_transition` and
+`must_attempt_work=false`. Hidden open todos are treated as advancement work to
+avoid false quiet no-ops from a truncated top-N todo projection.
+`heartbeat_recommendation` should then say `follow_work_lane_contract` or
+`monitor_quiet_until_material_transition` instead of encoding another
+project-specific branch. An executor may still record one material
+dependency-state transition when it changes the selected goal decision, but
+unchanged monitor polls are quiet no-spend checks. This keeps monitoring useful
+without letting it consume every eligible turn, and it keeps the hard routing
+rule in one small machine contract.
 
 ## Compute States
 

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -126,14 +126,23 @@ The same guard may include `work_lane_contract`. Schema
 `work_lane_contract_v1` is the single machine contract for monitor versus
 advancement routing. It distinguishes `lane=continuous_monitor` from
 `lane=advancement_task`, carries the next lane, and exposes one `obligation`
-string such as `advance_unless_material_monitor_transition`.
+string such as `advance_unless_material_monitor_transition`. Agent todo items
+may include `task_class=advancement_task` or
+`task_class=continuous_monitor`; legacy todo text is classified conservatively
+by the producer. Hidden open todos are treated as advancement work rather than
+as monitor-only work, so a truncated top-N todo projection cannot accidentally
+silence an executable backlog.
 For a dependency-observation projection with open agent todos, the guard sets
 `next_lane=advancement_task`, `must_attempt_work=true`, and
-`reason_codes=["dependency_observation", "open_agent_todo"]`. The heartbeat
-recommendation may say `follow_work_lane_contract`, but it should not restate
-the lane semantics; unchanged monitor polls remain quiet no-spend checks, while
-a material dependency-state transition may be written back once when it changes
-the selected goal decision.
+`reason_codes=["dependency_observation", "open_agent_todo"]` only when at least
+one open todo is advancement-class work. If all visible open todos are
+monitor-class and no open todo is hidden, the guard sets
+`obligation=quiet_until_material_monitor_transition` and
+`must_attempt_work=false`. The heartbeat recommendation may say
+`follow_work_lane_contract` or `monitor_quiet_until_material_transition`, but it
+should not restate the lane semantics; unchanged monitor polls remain quiet
+no-spend checks, while a material dependency-state transition may be written
+back once when it changes the selected goal decision.
 `handoff_readiness.handoff_interface_budget` declares the machine-readable
 budget for the minimal project-agent handoff: `mode=project_agent_handoff`,
 `max_lines=16`, and `max_chars=1800`. `goal-harness review-packet

--- a/examples/work-lane-contract-smoke.py
+++ b/examples/work-lane-contract-smoke.py
@@ -15,14 +15,14 @@ from goal_harness.quota import build_quota_should_run, render_quota_should_run_m
 GOAL_ID = "work-lane-fixture"
 
 
-def status_payload(*, status: str, has_agent_todo: bool = True) -> dict:
-    agent_todos = {
-        "schema_version": "todo_summary_v0",
-        "source_section": "Agent Todo",
-        "total_count": 1 if has_agent_todo else 0,
-        "open_count": 1 if has_agent_todo else 0,
-        "done_count": 0,
-        "first_open_items": [
+def status_payload(
+    *,
+    status: str,
+    has_agent_todo: bool = True,
+    agent_todo_items: list[dict] | None = None,
+) -> dict:
+    if agent_todo_items is None:
+        agent_todo_items = [
             {
                 "index": 1,
                 "text": "[P1] Advance the self-repair planning slice with a validation-backed patch.",
@@ -31,8 +31,14 @@ def status_payload(*, status: str, has_agent_todo: bool = True) -> dict:
                 "priority": "P1",
             }
         ]
-        if has_agent_todo
-        else [],
+    open_items = agent_todo_items if has_agent_todo else []
+    agent_todos = {
+        "schema_version": "todo_summary_v0",
+        "source_section": "Agent Todo",
+        "total_count": len(open_items),
+        "open_count": len(open_items),
+        "done_count": 0,
+        "first_open_items": open_items,
     }
     return {
         "ok": True,
@@ -125,9 +131,84 @@ def assert_primary_status_stays_advancement_lane() -> None:
     assert lane["reason_codes"] == ["open_agent_todo"], lane
 
 
+def assert_monitor_only_todo_waits_quietly() -> None:
+    guard = build_quota_should_run(
+        status_payload(
+            status="typed_task_lane_planning_writeback",
+            agent_todo_items=[
+                {
+                    "index": 1,
+                    "text": "[P2] Side-bypass dependency monitor: observe public-safe replay state transitions only.",
+                    "role": "agent",
+                    "status": "open",
+                    "priority": "P2",
+                },
+                {
+                    "index": 2,
+                    "text": "[P2] Meta canary/readiness observation lane: keep release readiness observable.",
+                    "role": "agent",
+                    "status": "open",
+                    "priority": "P2",
+                },
+            ],
+        ),
+        goal_id=GOAL_ID,
+    )
+    lane = guard["work_lane_contract"]
+    assert lane["schema_version"] == "work_lane_contract_v1", lane
+    assert lane["lane"] == "continuous_monitor", lane
+    assert lane["monitor_kind"] == "todo_monitor", lane
+    assert lane["next_lane"] == "continuous_monitor", lane
+    assert lane["obligation"] == "quiet_until_material_monitor_transition", lane
+    assert lane["must_attempt_work"] is False, lane
+    assert lane["reason_codes"] == ["monitor_todo_only"], lane
+    assert guard["heartbeat_recommendation"]["recommended_mode"] == "monitor_quiet_until_material_transition", guard
+    assert guard["execution_obligation"]["kind"] == "work_lane_contract", guard
+    assert guard["execution_obligation"]["must_attempt_work"] is False, guard
+    first_items = guard["agent_todo_summary"]["first_open_items"]
+    assert [item["task_class"] for item in first_items] == ["continuous_monitor", "continuous_monitor"], guard
+    markdown = render_quota_should_run_markdown(guard)
+    assert "work_lane_contract: lane=continuous_monitor next=continuous_monitor" in markdown, markdown
+    assert "obligation=quiet_until_material_monitor_transition" in markdown, markdown
+
+
+def assert_mixed_monitor_and_advancement_routes_to_advancement() -> None:
+    guard = build_quota_should_run(
+        status_payload(
+            status="typed_task_lane_planning_writeback",
+            agent_todo_items=[
+                {
+                    "index": 1,
+                    "text": "[P2] Side-bypass dependency monitor: observe public-safe replay state transitions only.",
+                    "role": "agent",
+                    "status": "open",
+                    "priority": "P2",
+                },
+                {
+                    "index": 2,
+                    "text": "[P1] Add the typed task class routing smoke fixture.",
+                    "role": "agent",
+                    "status": "open",
+                    "priority": "P1",
+                },
+            ],
+        ),
+        goal_id=GOAL_ID,
+    )
+    lane = guard["work_lane_contract"]
+    assert lane["lane"] == "advancement_task", lane
+    assert lane["next_lane"] == "advancement_task", lane
+    assert lane["obligation"] == "advance_one_bounded_segment", lane
+    assert lane["must_attempt_work"] is True, lane
+    first_items = guard["agent_todo_summary"]["first_open_items"]
+    assert [item["task_class"] for item in first_items] == ["continuous_monitor", "advancement_task"], guard
+
+
 def main() -> int:
     assert_dependency_monitor_requires_advancement()
     assert_primary_status_stays_advancement_lane()
+    assert_monitor_only_todo_waits_quietly()
+    assert_mixed_monitor_and_advancement_routes_to_advancement()
     print("work-lane-contract-smoke ok")
     return 0
 

--- a/goal_harness/quota.py
+++ b/goal_harness/quota.py
@@ -88,6 +88,21 @@ DEPENDENCY_OBSERVATION_CLASSIFICATION_HINTS = (
     "dependency_monitor",
 )
 WORK_LANE_CONTRACT_SCHEMA_VERSION = "work_lane_contract_v1"
+TODO_TASK_CLASS_ADVANCEMENT = "advancement_task"
+TODO_TASK_CLASS_MONITOR = "continuous_monitor"
+TODO_TASK_CLASS_VALUES = {TODO_TASK_CLASS_ADVANCEMENT, TODO_TASK_CLASS_MONITOR}
+TODO_MONITOR_PATTERNS = (
+    re.compile(r"(?i)\bdependency monitor\b"),
+    re.compile(r"(?i)\bobservation lane\b"),
+    re.compile(r"(?i)(?:^|[:：]\s*)observe\b"),
+    re.compile(r"(?i)(?:^|[:：]\s*)poll\b"),
+    re.compile(r"(?i)(?:^|[:：]\s*)watch\b"),
+    re.compile(r"(?i)\bmonitor-only\b"),
+)
+TODO_ADVANCEMENT_PATTERNS = (
+    re.compile(r"(?i)(?:^|[:：]\s*)(?:implement|add|make|fix|build|wire|define|compare|run|repair|archive|publish|merge|write|attribute)\b"),
+    re.compile(r"(?i)\b(?:implementation slice|validation-backed patch|smoke fixture)\b"),
+)
 
 
 def _now_local() -> str:
@@ -233,9 +248,13 @@ def _work_lane_contract(
     agent_todo_summary: dict[str, Any] | None,
 ) -> dict[str, Any] | None:
     progress_scope = _item_progress_scope(item)
-    has_agent_todos = _open_todo_count(agent_todo_summary) > 0
+    todo_counts = _open_todo_task_counts(agent_todo_summary)
+    has_agent_todos = todo_counts["open"] > 0
+    has_advancement_todos = todo_counts["advancement"] > 0
+    has_monitor_todos = todo_counts["monitor"] > 0
+    monitor_only_todos = has_agent_todos and has_monitor_todos and not has_advancement_todos
     if progress_scope != "dependency_observation":
-        if has_agent_todos:
+        if has_advancement_todos:
             return {
                 "schema_version": WORK_LANE_CONTRACT_SCHEMA_VERSION,
                 "lane": "advancement_task",
@@ -246,24 +265,41 @@ def _work_lane_contract(
                 "monitor_policy": "material_transition_only",
                 "action": "advance the first executable agent todo or write a concrete blocker",
             }
+        if monitor_only_todos:
+            return {
+                "schema_version": WORK_LANE_CONTRACT_SCHEMA_VERSION,
+                "lane": "continuous_monitor",
+                "monitor_kind": "todo_monitor",
+                "next_lane": "continuous_monitor",
+                "obligation": "quiet_until_material_monitor_transition",
+                "must_attempt_work": False,
+                "reason_codes": ["monitor_todo_only"],
+                "monitor_policy": "write_once_per_material_transition_else_no_spend",
+                "material_transition": (
+                    "a monitor todo may write back only material state transitions, regressions, or concrete blockers"
+                ),
+                "action": "wait quietly for material monitor evidence",
+            }
         return None
 
     reason_codes = ["dependency_observation"]
-    if has_agent_todos:
+    if has_advancement_todos:
         reason_codes.append("open_agent_todo")
+    elif monitor_only_todos:
+        reason_codes.append("monitor_todo_only")
     else:
         reason_codes.append("no_open_agent_todo")
     return {
         "schema_version": WORK_LANE_CONTRACT_SCHEMA_VERSION,
         "lane": "continuous_monitor",
         "monitor_kind": "dependency_observation",
-        "next_lane": "advancement_task" if has_agent_todos else "continuous_monitor",
+        "next_lane": "advancement_task" if has_advancement_todos else "continuous_monitor",
         "obligation": (
             "advance_unless_material_monitor_transition"
-            if has_agent_todos
+            if has_advancement_todos
             else "quiet_until_material_monitor_transition"
         ),
-        "must_attempt_work": has_agent_todos,
+        "must_attempt_work": has_advancement_todos,
         "reason_codes": reason_codes,
         "monitor_policy": "write_once_per_material_transition_else_no_spend",
         "material_transition": (
@@ -271,7 +307,7 @@ def _work_lane_contract(
         ),
         "action": (
             "advance the first executable agent todo or write a concrete blocker"
-            if has_agent_todos
+            if has_advancement_todos
             else "wait quietly for new external evidence"
         ),
     }
@@ -530,9 +566,10 @@ def _compact_todo_summary_item(item: dict[str, Any], *, text: str | None = None)
         "index": item.get("index"),
         "text": text if text is not None else item.get("text"),
     }
-    for key in ("schema_version", "todo_id", "role", "status", "priority", "title", "archive_state", "source_section"):
+    for key in ("schema_version", "todo_id", "role", "status", "priority", "title", "archive_state", "source_section", "task_class"):
         if item.get(key) is not None:
             compact[key] = item.get(key)
+    compact["task_class"] = _todo_task_class(compact)
     return compact
 
 
@@ -579,7 +616,10 @@ def _summarize_user_todos(value: Any) -> dict[str, Any] | None:
 def _summarize_project_asset_todos(value: Any) -> dict[str, Any] | None:
     if not isinstance(value, dict):
         return None
-    if isinstance(value.get("items"), list) and (
+    if (
+        isinstance(value.get("items"), list)
+        or isinstance(value.get("first_open_items"), list)
+    ) and (
         "total_count" in value or "open_count" in value or "done_count" in value
     ):
         return _summarize_user_todos(value)
@@ -798,6 +838,45 @@ def _open_todo_count(summary: dict[str, Any] | None) -> int:
         return max(0, int(summary.get("open_count") or 0))
     except (TypeError, ValueError):
         return 0
+
+
+def _todo_task_class(item: dict[str, Any]) -> str:
+    candidate = str(item.get("task_class") or "").strip()
+    if candidate in TODO_TASK_CLASS_VALUES:
+        return candidate
+    text = " ".join(
+        str(value or "")
+        for value in (item.get("title"), item.get("text"))
+        if str(value or "").strip()
+    )
+    for pattern in TODO_MONITOR_PATTERNS:
+        if pattern.search(text):
+            return TODO_TASK_CLASS_MONITOR
+    for pattern in TODO_ADVANCEMENT_PATTERNS:
+        if pattern.search(text):
+            return TODO_TASK_CLASS_ADVANCEMENT
+    return TODO_TASK_CLASS_ADVANCEMENT
+
+
+def _open_todo_task_counts(summary: dict[str, Any] | None) -> dict[str, int]:
+    open_count = _open_todo_count(summary)
+    first_open_items: list[dict[str, Any]] = []
+    if isinstance(summary, dict) and isinstance(summary.get("first_open_items"), list):
+        first_open_items = [item for item in summary["first_open_items"] if isinstance(item, dict)]
+    visible_open = min(open_count, len(first_open_items))
+    monitor_count = sum(
+        1
+        for item in first_open_items[:visible_open]
+        if _todo_task_class(item) == TODO_TASK_CLASS_MONITOR
+    )
+    hidden_count = max(0, open_count - visible_open)
+    advancement_count = visible_open - monitor_count + hidden_count
+    return {
+        "open": open_count,
+        "advancement": advancement_count,
+        "monitor": monitor_count,
+        "hidden": hidden_count,
+    }
 
 
 def _has_lifecycle_marker(*values: Any, marker: str) -> bool:
@@ -1045,6 +1124,22 @@ def _heartbeat_recommendation(
             ),
         }
         return payload
+
+    if (
+        work_lane_contract
+        and work_lane_contract.get("lane") == "continuous_monitor"
+        and work_lane_contract.get("must_attempt_work") is False
+        and not has_user_todos
+    ):
+        return {
+            **base,
+            "recommended_mode": "monitor_quiet_until_material_transition",
+            "spend_policy": (
+                "do not append quota spend until a material monitor transition, regression, "
+                "or concrete blocker is validated and written back"
+            ),
+            "reason": "all visible open agent todos are monitor-class work with no material transition to record",
+        }
 
     if (
         work_lane_contract

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -322,6 +322,21 @@ TODO_ARCHIVE_HEADER_MARKERS = (
     "待办归档",
 )
 TODO_ITEM_SCHEMA_VERSION = "todo_item_v0"
+TODO_TASK_CLASS_ADVANCEMENT = "advancement_task"
+TODO_TASK_CLASS_MONITOR = "continuous_monitor"
+TODO_TASK_CLASS_VALUES = {TODO_TASK_CLASS_ADVANCEMENT, TODO_TASK_CLASS_MONITOR}
+TODO_MONITOR_PATTERNS = (
+    re.compile(r"(?i)\bdependency monitor\b"),
+    re.compile(r"(?i)\bobservation lane\b"),
+    re.compile(r"(?i)(?:^|[:：]\s*)observe\b"),
+    re.compile(r"(?i)(?:^|[:：]\s*)poll\b"),
+    re.compile(r"(?i)(?:^|[:：]\s*)watch\b"),
+    re.compile(r"(?i)\bmonitor-only\b"),
+)
+TODO_ADVANCEMENT_PATTERNS = (
+    re.compile(r"(?i)(?:^|[:：]\s*)(?:implement|add|make|fix|build|wire|define|compare|run|repair|archive|publish|merge|write|attribute)\b"),
+    re.compile(r"(?i)\b(?:implementation slice|validation-backed patch|smoke fixture)\b"),
+)
 
 
 def normalize_todo_text(text: str, *, limit: int = 500) -> str:
@@ -514,6 +529,24 @@ def todo_priority_parts(text: str) -> tuple[str | None, str]:
     return match.group(1).strip().upper(), match.group(2).strip()
 
 
+def todo_task_class_for_text(text: str) -> str:
+    compact = normalize_todo_text(text)
+    for pattern in TODO_MONITOR_PATTERNS:
+        if pattern.search(compact):
+            return TODO_TASK_CLASS_MONITOR
+    for pattern in TODO_ADVANCEMENT_PATTERNS:
+        if pattern.search(compact):
+            return TODO_TASK_CLASS_ADVANCEMENT
+    return TODO_TASK_CLASS_ADVANCEMENT
+
+
+def normalize_todo_task_class(value: Any, *, text: str) -> str:
+    candidate = str(value or "").strip()
+    if candidate in TODO_TASK_CLASS_VALUES:
+        return candidate
+    return todo_task_class_for_text(text)
+
+
 def structured_todo_item(
     item: dict[str, Any],
     *,
@@ -536,6 +569,7 @@ def structured_todo_item(
             "archive_state": archive_state,
             "source_section": source_section,
             "text": text,
+            "task_class": normalize_todo_task_class(item.get("task_class"), text=text),
         }
     )
     if priority:
@@ -550,7 +584,7 @@ def compact_todo_item(item: dict[str, Any]) -> dict[str, Any]:
         "done": bool(item.get("done")),
         "text": item.get("text"),
     }
-    for key in ("schema_version", "todo_id", "role", "status", "priority", "title", "archive_state", "source_section"):
+    for key in ("schema_version", "todo_id", "role", "status", "priority", "title", "archive_state", "source_section", "task_class"):
         if item.get(key) is not None:
             compact[key] = item.get(key)
     return compact


### PR DESCRIPTION
## Summary
- add todo-level task_class projection for advancement_task vs continuous_monitor
- route monitor-only open todos to quiet_until_material_monitor_transition while keeping hidden open todos conservative
- extend work-lane smoke coverage and document the compact contract

## Validation
- python3 examples/work-lane-contract-smoke.py
- python3 examples/quota-plan-smoke.py
- python3 -m py_compile goal_harness/status.py goal_harness/quota.py examples/work-lane-contract-smoke.py
- python3 examples/run-smokes.py
- goal-harness-canary check
- git diff --check
- added-line sensitive keyword scan
