### PR TITLE
Add Terminal-Bench no-submit boundary probe

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/README.md
+++ b/docs/research/long-horizon-agent-benchmarks/README.md
@@ -45,6 +45,11 @@ work still belongs in the existing code, examples, and contract documents:
   `benchmark_result_v0` comparison shell and control-plane checklist before any
   real Terminal-Bench, Docker, Codex/model API, cloud, paid compute, or
   leaderboard path.
+- `terminal-bench-no-submit-boundary-probe-v0.md`: local-only
+  `runner_boundary_probe_v0` contract that records runner identity, planned
+  command boundaries, submit eligibility, future event shape, and hard stop
+  conditions without running Terminal-Bench, Harbor, Docker, Codex/model APIs,
+  cloud sandboxes, paid compute, or leaderboard upload paths.
 
 ## Relationship To Goal Harness Work
 

--- a/docs/research/long-horizon-agent-benchmarks/paper-runner-dossier.md
+++ b/docs/research/long-horizon-agent-benchmarks/paper-runner-dossier.md
@@ -368,8 +368,8 @@ Use this packet as the gate before any real execution:
 | --- | --- |
 | Pilot benchmark | `terminal-bench@2.0` through Harbor or another official Terminal-Bench 2.0 path. |
 | Executor target | Native Codex CLI if the official custom-agent/import path can launch it; otherwise local passive Goal Harness wrapper for A/B measurement only. |
-| Required prior artifact | `terminal_bench_probe_v0` and `passive-baseline-protocol-v0.md` are the current public-safe setup/protocol artifacts. |
-| First allowed action | A no-submit setup/readiness probe that records runner source, runner version or commit, agent command boundary, task id or sample split, and exact stop condition. |
+| Required prior artifact | `terminal_bench_probe_v0`, `passive-baseline-protocol-v0.md`, and `terminal-bench-official-pilot-readiness-v0.md` are the current public-safe setup/protocol artifacts. |
+| First allowed action | A no-submit boundary probe that records runner source, runner version or commit, agent command boundary, submit eligibility, future event shape, and exact stop condition. |
 | First forbidden action | Running a real Terminal-Bench task, starting Docker, invoking Codex/model APIs, using cloud sandboxes, or uploading leaderboard traces without explicit authorization. |
 | Official score fields | Benchmark-native pass/fail or accuracy, task id or split, repetitions, model/agent tuple, runner source, and whether the run is submit-eligible. |
 | Goal Harness score fields | restartability, stale-state avoidance, event-ledger completeness, evidence discipline, boundary safety, writeback quality, failure attribution, and overhead. |
@@ -381,15 +381,24 @@ decision trace proving whether Goal Harness can collect comparable control-plane
 evidence around the official runner. Do not start SWE-Marathon until the
 Terminal-Bench wrapper boundary is known.
 
+## Current No-Submit Boundary Probe
+
+The next public-safe probe is `terminal-bench-no-submit-boundary-probe-v0.md`.
+It emits a `runner_boundary_probe_v0` payload: public runner identity, planned
+mode boundaries for `bare_codex_cli` and `passive_goal_harness_wrapper`, hard
+`submit_eligible = false` / `real_run = false` flags, and the future
+`benchmark_run_v0` plus `benchmark_result_v0` event shape. This is a no-submit
+boundary probe, not task evidence.
+
 ## Next Execution Slice
 
 The next bounded implementation/research slice should be:
 
-1. Add a local-only readiness probe fixture for
-   `terminal_bench_official_pilot_decision_packet_v0`.
-2. Prove the fixture can emit a compact `benchmark_result_v0` comparison shell
-   without running Terminal-Bench, Docker, Codex, model APIs, cloud sandboxes,
-   or leaderboard upload paths.
+1. Keep the no-submit boundary probe smoke-backed and current with the inspected
+   runner boundary.
+2. If explicit authorization arrives, perform a no-submit runner setup check
+   that records source/version/task placeholder/command boundary, then stop
+   before any real task execution.
 3. Keep SWE-Marathon, RoadmapBench, SWE-EVO, ALE-Bench, OSWorld, WebArena,
    TheAgentCompany, RALPHBench, and tau-style suites as ranked follow-up lanes
    until the first Terminal-Bench official-pilot boundary is validated.

--- a/docs/research/long-horizon-agent-benchmarks/terminal-bench-no-submit-boundary-probe-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/terminal-bench-no-submit-boundary-probe-v0.md
@@ -1,0 +1,81 @@
+# Terminal-Bench No-Submit Boundary Probe V0
+
+Checked at: 2026-06-07T23:25:00+08:00.
+
+This note turns the Terminal-Bench official-pilot readiness shell into a
+no-submit runner-boundary probe. It is still local-only: it does not run
+Terminal-Bench, Harbor, Docker, Codex, model APIs, cloud sandboxes, paid
+compute, or leaderboard upload paths.
+
+## Purpose
+
+The probe answers one question before any real benchmark work:
+
+Can Goal Harness record the public runner identity, planned agent command
+boundary, submit eligibility, expected output surface, and stop conditions for a
+Terminal-Bench pilot without crossing the execution boundary?
+
+The expected payload schema is `runner_boundary_probe_v0`. It feeds future
+`benchmark_run_v0` and `benchmark_result_v0` events, but it is not itself task
+evidence and must keep all official score fields as `not_run`.
+
+## Allowed Now
+
+- Record public runner candidates and inspected public commits.
+- Record command templates with placeholders such as `<model>` and
+  `<private-output-dir>`.
+- Record the two comparison modes: `bare_codex_cli` and
+  `passive_goal_harness_wrapper`.
+- Record the expected passive output files for future `benchmark_run_v0`
+  ingestion.
+- Record that every command template is `execution_authorized = false`,
+  `submit_eligible = false`, and `real_run = false`.
+
+## Forbidden Now
+
+Stop before:
+
+- executing `harbor run`, `tb run`, `codex exec`, or any custom agent wrapper;
+- starting Docker or any cloud sandbox;
+- invoking a model API, paid compute, or external evaluator;
+- using upload or leaderboard submission paths;
+- changing official task files, prompts, tests, timeouts, resources, scoring, or
+  runner code;
+- copying credentials, host absolute paths, private runner logs, internal docs,
+  raw Codex session JSONL, or raw thread history into public artifacts;
+- claiming official pass/fail, reward, accuracy, or leaderboard uplift.
+
+## Payload Contract
+
+Every no-submit boundary probe should contain:
+
+| Field | Rule |
+| --- | --- |
+| `schema_version` | `runner_boundary_probe_v0`. |
+| `decision_id` | `terminal_bench_official_pilot_decision_packet_v0`. |
+| `benchmark_id` | `terminal-bench@2.0`. |
+| `probe_state` | `no_submit_boundary_only`. |
+| `real_run` | `false`. |
+| `submit_eligible` | `false`. |
+| `trace_publicness` | `public_boundary_probe_only`. |
+| `runner_sources` | Public runner name, role, repo URL, and inspected commit. |
+| `mode_boundaries` | One entry each for `bare_codex_cli` and `passive_goal_harness_wrapper`. |
+| `expected_future_events` | `benchmark_run_v0` per mode and one `benchmark_result_v0` comparison. |
+| `stop_conditions` | All forbidden surfaces listed above. |
+
+`passive_goal_harness_wrapper` means Goal Harness reads already-produced
+official runner outputs after a validated run exists. It does not mean a custom
+agent wrapper is authorized. The custom `--agent-import-path` path remains a
+later local-only experiment gate.
+
+## Smoke
+
+The deterministic smoke is:
+
+```bash
+python3 examples/terminal-bench-no-submit-boundary-probe-smoke.py
+```
+
+It constructs a compact public-safe `runner_boundary_probe_v0` payload and
+asserts that no command is authorized, no submit path is enabled, no real run is
+claimed, and no private surface marker appears in the payload or this note.

--- a/examples/terminal-bench-no-submit-boundary-probe-smoke.py
+++ b/examples/terminal-bench-no-submit-boundary-probe-smoke.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Smoke-test the Terminal-Bench no-submit boundary probe contract."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TOPIC_DIR = REPO_ROOT / "docs" / "research" / "long-horizon-agent-benchmarks"
+NOTE = TOPIC_DIR / "terminal-bench-no-submit-boundary-probe-v0.md"
+README = TOPIC_DIR / "README.md"
+DOSSIER = TOPIC_DIR / "paper-runner-dossier.md"
+
+SCHEMA = "runner_boundary_probe_v0"
+DECISION_ID = "terminal_bench_official_pilot_decision_packet_v0"
+BENCHMARK_ID = "terminal-bench@2.0"
+
+STOP_CONDITIONS = [
+    "do_not_execute_harbor_run",
+    "do_not_execute_tb_run",
+    "do_not_execute_codex_exec",
+    "do_not_execute_custom_agent_wrapper",
+    "do_not_start_docker",
+    "do_not_use_cloud_sandbox",
+    "do_not_invoke_model_api",
+    "do_not_use_paid_compute",
+    "do_not_upload_or_submit_leaderboard_trace",
+    "do_not_modify_official_tasks_timeouts_resources_or_scoring",
+    "do_not_copy_credentials_host_paths_private_logs_or_raw_sessions",
+    "do_not_claim_official_pass_fail_reward_accuracy_or_uplift",
+]
+
+REQUIRED_DOC_SNIPPETS = [
+    "Terminal-Bench No-Submit Boundary Probe V0",
+    SCHEMA,
+    DECISION_ID,
+    BENCHMARK_ID,
+    "no-submit runner-boundary probe",
+    "Allowed Now",
+    "Forbidden Now",
+    "benchmark_run_v0",
+    "benchmark_result_v0",
+    "bare_codex_cli",
+    "passive_goal_harness_wrapper",
+    "execution_authorized = false",
+    "submit_eligible = false",
+    "real_run = false",
+    "public_boundary_probe_only",
+    "custom `--agent-import-path` path remains a",
+]
+
+FORBIDDEN_TEXT = [
+    "/" + "Users/",
+    "/" + "tmp/",
+    "OPENAI" + "_API_KEY",
+    "ANTHROPIC" + "_API_KEY",
+    "DAYTONA" + "_API_KEY",
+    "lark" + "office",
+    "fei" + "shu.cn",
+    "raw" + "_thread",
+    "session" + "_history",
+    "s" + "k-" + "example",
+]
+
+
+def probe_payload() -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA,
+        "decision_id": DECISION_ID,
+        "benchmark_id": BENCHMARK_ID,
+        "probe_state": "no_submit_boundary_only",
+        "real_run": False,
+        "submit_eligible": False,
+        "trace_publicness": "public_boundary_probe_only",
+        "runner_sources": [
+            {
+                "name": "harbor",
+                "role": "terminal_bench_2_official_runner_candidate",
+                "source_kind": "public_repository",
+                "repo_url": "https://github.com/laude-institute/harbor",
+                "inspected_commit": "8cfac6ad91c5c566ff14040cc4acbfe94ad42356",
+            },
+            {
+                "name": "terminal-bench",
+                "role": "legacy_tb_runner_compatibility_candidate",
+                "source_kind": "public_repository",
+                "repo_url": "https://github.com/harbor-framework/terminal-bench",
+                "inspected_commit": "1a6ffa9674b571da0ed040c470cb40c4d85f9b9b",
+            },
+        ],
+        "mode_boundaries": [
+            {
+                "mode": "bare_codex_cli",
+                "runner": "harbor",
+                "agent_surface": "built_in_codex_agent",
+                "command_template": (
+                    "harbor run --dataset terminal-bench@2.0 --agent codex "
+                    "--model <model> --n-concurrent 1 --jobs-dir <private-output-dir>"
+                ),
+                "execution_authorized": False,
+                "submit_eligible": False,
+                "real_run": False,
+                "expected_future_event": "benchmark_run_v0",
+            },
+            {
+                "mode": "passive_goal_harness_wrapper",
+                "runner": "harbor",
+                "agent_surface": "passive_observer_after_official_outputs_exist",
+                "command_template": "goal-harness history append-benchmark-run --benchmark-run-json <benchmark-run-v0.json>",
+                "execution_authorized": False,
+                "submit_eligible": False,
+                "real_run": False,
+                "expected_future_event": "benchmark_run_v0",
+            },
+        ],
+        "custom_agent_boundary": {
+            "surface": "--agent-import-path",
+            "state": "deferred_local_only_experiment_gate",
+            "execution_authorized": False,
+            "submit_eligible": False,
+        },
+        "expected_future_events": [
+            "benchmark_run_v0:bare_codex_cli",
+            "benchmark_run_v0:passive_goal_harness_wrapper",
+            "benchmark_result_v0:paired_comparison",
+        ],
+        "official_task_score": {
+            "kind": "not_run",
+            "value": None,
+        },
+        "side_effect_budget": {
+            "docker": False,
+            "codex_cli": False,
+            "model_api": False,
+            "cloud_sandbox": False,
+            "paid_compute": False,
+            "leaderboard_upload": False,
+            "official_runner_mutation": False,
+        },
+        "stop_conditions": STOP_CONDITIONS,
+    }
+
+
+def assert_doc_contract() -> None:
+    text = NOTE.read_text(encoding="utf-8")
+    readme = README.read_text(encoding="utf-8")
+    dossier = DOSSIER.read_text(encoding="utf-8")
+
+    missing = [snippet for snippet in REQUIRED_DOC_SNIPPETS if snippet not in text]
+    assert not missing, missing
+
+    assert "terminal-bench-no-submit-boundary-probe-v0.md" in readme
+    assert "runner_boundary_probe_v0" in dossier
+    assert "no-submit boundary probe" in dossier
+
+    leaked = [marker for marker in FORBIDDEN_TEXT if marker in text]
+    assert not leaked, leaked
+
+
+def assert_public_safe(payload: dict[str, Any]) -> None:
+    text = json.dumps(payload, sort_keys=True)
+    leaked = [marker for marker in FORBIDDEN_TEXT if marker in text]
+    assert not leaked, leaked
+    assert len(text) < 9000, len(text)
+
+
+def assert_payload_contract(payload: dict[str, Any]) -> None:
+    assert payload["schema_version"] == SCHEMA, payload
+    assert payload["decision_id"] == DECISION_ID, payload
+    assert payload["benchmark_id"] == BENCHMARK_ID, payload
+    assert payload["probe_state"] == "no_submit_boundary_only", payload
+    assert payload["real_run"] is False, payload
+    assert payload["submit_eligible"] is False, payload
+    assert payload["trace_publicness"] == "public_boundary_probe_only", payload
+    assert payload["official_task_score"] == {"kind": "not_run", "value": None}, payload
+    assert {source["source_kind"] for source in payload["runner_sources"]} == {"public_repository"}, payload
+    assert {source["name"] for source in payload["runner_sources"]} == {"harbor", "terminal-bench"}, payload
+
+    boundaries = {item["mode"]: item for item in payload["mode_boundaries"]}
+    assert set(boundaries) == {"bare_codex_cli", "passive_goal_harness_wrapper"}, payload
+    assert all(item["execution_authorized"] is False for item in boundaries.values()), payload
+    assert all(item["submit_eligible"] is False for item in boundaries.values()), payload
+    assert all(item["real_run"] is False for item in boundaries.values()), payload
+    assert all(item["expected_future_event"] == "benchmark_run_v0" for item in boundaries.values()), payload
+    assert payload["custom_agent_boundary"]["execution_authorized"] is False, payload
+    assert payload["custom_agent_boundary"]["submit_eligible"] is False, payload
+
+    assert set(payload["stop_conditions"]) == set(STOP_CONDITIONS), payload
+    assert all(value is False for value in payload["side_effect_budget"].values()), payload
+    assert "benchmark_result_v0:paired_comparison" in payload["expected_future_events"], payload
+    assert_public_safe(payload)
+
+
+def main() -> None:
+    assert_doc_contract()
+    payload = probe_payload()
+    assert_payload_contract(payload)
+    print(
+        "terminal-bench-no-submit-boundary-probe-smoke ok "
+        f"sources={len(payload['runner_sources'])} modes={len(payload['mode_boundaries'])} "
+        f"real_run={payload['real_run']} submit={payload['submit_eligible']}"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a Terminal-Bench no-submit runner-boundary probe contract for `runner_boundary_probe_v0`
- add a deterministic smoke that asserts `real_run=false`, `submit_eligible=false`, and all benchmark execution surfaces remain disabled
- update the long-horizon benchmark README and dossier so the next slice no longer points at the older readiness-only step

## Validation
- `python3 examples/terminal-bench-no-submit-boundary-probe-smoke.py`
- `python3 examples/terminal-bench-official-pilot-readiness-smoke.py`
- `python3 examples/long-horizon-paper-runner-dossier-smoke.py`
- `python3 examples/benchmark-run-v0-harbor-ingest-smoke.py`
- `python3 examples/benchmark-run-v0-append-cli-smoke.py`
- `python3 examples/run-smokes.py` (62 smokes)
- `env PATH="$HOME/.local/bin:$PATH" goal-harness-canary check`
- `git diff --check`
- staged sensitive marker scan for local paths, credential-like markers, private doc URLs, raw thread/session history

## Boundary
This PR does not run Terminal-Bench, Harbor, Docker, Codex/model APIs, cloud sandboxes, paid compute, or leaderboard upload paths.