### PR TITLE
Prevent monitor-only backlog from hiding advancement next actions

### DIFF
--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -199,6 +199,12 @@ If all visible open todos are monitor-class and no open todo is hidden, the
 same contract uses `obligation=quiet_until_material_monitor_transition` and
 `must_attempt_work=false`. Hidden open todos are treated as advancement work to
 avoid false quiet no-ops from a truncated top-N todo projection.
+If the selected goal's `next_action`/`recommended_action` explicitly points to
+a planning/self-repair or advancement-class lane, monitor-only todos are not
+allowed to make the goal quiet. The contract instead uses
+`obligation=materialize_advancement_todo_or_blocker` and
+`must_attempt_work=true`, so the worker must either materialize the concrete
+advancement todo or write the blocker that prevents it.
 `heartbeat_recommendation` should then say `follow_work_lane_contract` or
 `monitor_quiet_until_material_transition` instead of encoding another
 project-specific branch. An executor may still record one material

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -138,7 +138,14 @@ For a dependency-observation projection with open agent todos, the guard sets
 one open todo is advancement-class work. If all visible open todos are
 monitor-class and no open todo is hidden, the guard sets
 `obligation=quiet_until_material_monitor_transition` and
-`must_attempt_work=false`. The heartbeat recommendation may say
+`must_attempt_work=false`. One narrow exception prevents long autonomous
+projects from stalling after finishing their last visible delivery todo: when
+the current `next_action`/`recommended_action` explicitly points at a
+planning/self-repair or advancement-class lane, monitor-only todos are promoted
+to `lane=advancement_task` with
+`obligation=materialize_advancement_todo_or_blocker`. That obligation requires
+the worker to create a concrete advancement todo or write a blocker instead of
+quietly waiting on monitors. The heartbeat recommendation may say
 `follow_work_lane_contract` or `monitor_quiet_until_material_transition`, but it
 should not restate the lane semantics; unchanged monitor polls remain quiet
 no-spend checks, while a material dependency-state transition may be written

--- a/examples/work-lane-contract-smoke.py
+++ b/examples/work-lane-contract-smoke.py
@@ -20,6 +20,7 @@ def status_payload(
     status: str,
     has_agent_todo: bool = True,
     agent_todo_items: list[dict] | None = None,
+    next_action: str = "Observe dependency state and then advance backlog if unchanged.",
 ) -> dict:
     if agent_todo_items is None:
         agent_todo_items = [
@@ -50,7 +51,7 @@ def status_payload(
                     "waiting_on": "codex",
                     "severity": "info",
                     "source": "project_asset",
-                    "recommended_action": "Observe dependency state and then advance backlog if unchanged.",
+                    "recommended_action": next_action,
                     "quota": {
                         "compute": 1.0,
                         "window_hours": 24,
@@ -61,7 +62,7 @@ def status_payload(
                         "reason": "eligible fixture",
                     },
                     "project_asset": {
-                        "next_action": "Observe dependency state and then advance backlog if unchanged.",
+                        "next_action": next_action,
                         "stop_condition": "stop on private material",
                         "agent_todos": agent_todos,
                     },
@@ -172,6 +173,49 @@ def assert_monitor_only_todo_waits_quietly() -> None:
     assert "obligation=quiet_until_material_monitor_transition" in markdown, markdown
 
 
+def assert_monitor_only_with_planning_next_action_materializes_advancement() -> None:
+    guard = build_quota_should_run(
+        status_payload(
+            status="benchmark_experiment_report_template",
+            next_action=(
+                "Post-reporting lane should route to the planning/self-repair capability lane "
+                "as the next eligible advancement turn."
+            ),
+            agent_todo_items=[
+                {
+                    "index": 1,
+                    "text": "[P2] Side-bypass dependency monitor: observe public-safe replay state transitions only.",
+                    "role": "agent",
+                    "status": "open",
+                    "priority": "P2",
+                },
+                {
+                    "index": 2,
+                    "text": "[P2] Meta canary/readiness observation lane: keep release readiness observable.",
+                    "role": "agent",
+                    "status": "open",
+                    "priority": "P2",
+                },
+            ],
+        ),
+        goal_id=GOAL_ID,
+    )
+    lane = guard["work_lane_contract"]
+    assert lane["schema_version"] == "work_lane_contract_v1", lane
+    assert lane["lane"] == "advancement_task", lane
+    assert lane["next_lane"] == "advancement_task", lane
+    assert lane["obligation"] == "materialize_advancement_todo_or_blocker", lane
+    assert lane["must_attempt_work"] is True, lane
+    assert lane["reason_codes"] == ["monitor_todo_only", "next_action_requires_advancement"], lane
+    assert "planning/self-repair" in lane["action"], lane
+    assert guard["execution_obligation"]["contract_obligation"] == lane["obligation"], guard
+    assert guard["execution_obligation"]["must_attempt_work"] is True, guard
+    markdown = render_quota_should_run_markdown(guard)
+    assert "work_lane_contract: lane=advancement_task next=advancement_task" in markdown, markdown
+    assert "obligation=materialize_advancement_todo_or_blocker" in markdown, markdown
+    assert "work_lane_reason_codes: monitor_todo_only,next_action_requires_advancement" in markdown, markdown
+
+
 def assert_mixed_monitor_and_advancement_routes_to_advancement() -> None:
     guard = build_quota_should_run(
         status_payload(
@@ -208,6 +252,7 @@ def main() -> int:
     assert_dependency_monitor_requires_advancement()
     assert_primary_status_stays_advancement_lane()
     assert_monitor_only_todo_waits_quietly()
+    assert_monitor_only_with_planning_next_action_materializes_advancement()
     assert_mixed_monitor_and_advancement_routes_to_advancement()
     print("work-lane-contract-smoke ok")
     return 0

--- a/goal_harness/quota.py
+++ b/goal_harness/quota.py
@@ -103,6 +103,14 @@ TODO_ADVANCEMENT_PATTERNS = (
     re.compile(r"(?i)(?:^|[:：]\s*)(?:implement|add|make|fix|build|wire|define|compare|run|repair|archive|publish|merge|write|attribute)\b"),
     re.compile(r"(?i)\b(?:implementation slice|validation-backed patch|smoke fixture)\b"),
 )
+NEXT_ACTION_ADVANCEMENT_HINT_PATTERNS = (
+    re.compile(r"(?i)\bplanning/self[- ]?repair\b"),
+    re.compile(r"(?i)\bplanning[- ]?self[- ]?repair\b"),
+    re.compile(r"(?i)\bself[- ]?repair capability\b"),
+    re.compile(r"(?i)\badvance(?:ment)?[- ]class\b"),
+    re.compile(r"(?i)\badvance primary backlog\b"),
+    re.compile(r"(?i)\bnext eligible advancement turn\b"),
+)
 
 
 def _now_local() -> str:
@@ -266,6 +274,19 @@ def _work_lane_contract(
                 "action": "advance the first executable agent todo or write a concrete blocker",
             }
         if monitor_only_todos:
+            if _next_action_requires_advancement(item):
+                return {
+                    "schema_version": WORK_LANE_CONTRACT_SCHEMA_VERSION,
+                    "lane": "advancement_task",
+                    "next_lane": "advancement_task",
+                    "obligation": "materialize_advancement_todo_or_blocker",
+                    "must_attempt_work": True,
+                    "reason_codes": ["monitor_todo_only", "next_action_requires_advancement"],
+                    "monitor_policy": "material_transition_only",
+                    "action": (
+                        "materialize the planning/self-repair advancement todo or write a concrete blocker"
+                    ),
+                }
             return {
                 "schema_version": WORK_LANE_CONTRACT_SCHEMA_VERSION,
                 "lane": "continuous_monitor",
@@ -877,6 +898,20 @@ def _open_todo_task_counts(summary: dict[str, Any] | None) -> dict[str, int]:
         "monitor": monitor_count,
         "hidden": hidden_count,
     }
+
+
+def _next_action_requires_advancement(item: dict[str, Any]) -> bool:
+    project_asset = item.get("project_asset") if isinstance(item.get("project_asset"), dict) else {}
+    values = (
+        project_asset.get("next_action"),
+        project_asset.get("recommended_action"),
+        item.get("next_action"),
+        item.get("recommended_action"),
+    )
+    text = " ".join(str(value or "") for value in values if str(value or "").strip())
+    if not text:
+        return False
+    return any(pattern.search(text) for pattern in NEXT_ACTION_ADVANCEMENT_HINT_PATTERNS)
 
 
 def _has_lifecycle_marker(*values: Any, marker: str) -> bool:


### PR DESCRIPTION
## Summary
- promote monitor-only open todos to an advancement work-lane only when the selected goal's next_action/recommended_action explicitly names a planning/self-repair or advancement-class lane
- add a work-lane smoke proving ordinary monitor-only todos still wait quietly while planning/self-repair next actions require materializing an advancement todo or blocker
- document the narrow exception in the quota/status contracts

## Validation
- python3 examples/work-lane-contract-smoke.py
- python3 examples/quota-plan-smoke.py
- python3 -m py_compile goal_harness/quota.py examples/work-lane-contract-smoke.py
- python3 examples/run-smokes.py
- goal-harness-canary check
- git diff --check
- cached added-line sensitive marker scan

## Boundary
No model/LLM gate, no benchmark execution, no production action, no private state files, and no broad scheduler rewrite.