### PR TITLE
Project benchmark result summaries

### DIFF
--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -1440,6 +1440,17 @@ templates, and stop conditions. It must not include raw Codex sessions, host
 absolute paths, credentials, private benchmark material, or leaderboard upload
 claims.
 
+When a compact run record includes `benchmark_result_summary`, it is a redacted
+projection of `benchmark_result_v0`, not a raw benchmark log reader. The summary
+keeps `official_task_score` separate from `control_plane_score`; for
+`control_plane_score_core_v0` it preserves the fixed component order
+(`restartability`, `stale_state_avoidance`, `evidence_discipline`,
+`boundary_safety`, `writeback_quality`, `gate_compliance`,
+`failure_attribution`, `overhead`) plus compact counts such as validation,
+writeback, spend, and forbidden-access totals. It must not include changed file
+paths, raw trajectories, local artifact paths, credentials, private traces, or
+leaderboard claims.
+
 ## Promotion Readiness Summary
 
 `promotion_readiness_summary` is an optional release-control projection over the

--- a/examples/benchmark-run-v0-status-projection-smoke.py
+++ b/examples/benchmark-run-v0-status-projection-smoke.py
@@ -21,6 +21,16 @@ from goal_harness.status import collect_status, render_status_markdown  # noqa: 
 
 GOAL_ID = "benchmark-projection-fixture"
 BENCHMARK_ID = "terminal-bench@2.0"
+CONTROL_PLANE_SCORE_COMPONENTS = (
+    "restartability",
+    "stale_state_avoidance",
+    "evidence_discipline",
+    "boundary_safety",
+    "writeback_quality",
+    "gate_compliance",
+    "failure_attribution",
+    "overhead",
+)
 
 
 def write_json(path: Path, payload: dict[str, Any]) -> None:
@@ -101,6 +111,55 @@ def benchmark_run_event() -> dict[str, Any]:
     }
 
 
+def benchmark_result_event() -> dict[str, Any]:
+    components = {
+        "restartability": 1.0,
+        "stale_state_avoidance": 1.0,
+        "evidence_discipline": 1.0,
+        "boundary_safety": 1.0,
+        "writeback_quality": 1.0,
+        "gate_compliance": 1.0,
+        "failure_attribution": 1.0,
+        "overhead": 0.0,
+    }
+    return {
+        "schema_version": "benchmark_result_v0",
+        "task_id": "mini_control_plane_repair_v0",
+        "scenario_id": "with_goal_harness",
+        "worker_mode": "deterministic",
+        "harness_identity": "goal_harness",
+        "worker_surface": "deterministic_shim",
+        "terminal_state": "success",
+        "official_task_score": {"kind": "deterministic_validation", "passed": True, "value": 1.0},
+        "control_plane_score": {
+            "schema_version": "control_plane_score_core_v0",
+            "kind": "core_v0",
+            "aggregation": "unweighted_mean",
+            "value": 0.875,
+            "components": components,
+            "component_order": list(CONTROL_PLANE_SCORE_COMPONENTS),
+        },
+        "step_count": 3,
+        "wall_time_ms": 42.0,
+        "validation_pass_count": 4,
+        "validation_fail_count": 0,
+        "changed_file_count": 3,
+        "changed_files": ["src/control_plane.py", "state/ACTIVE_GOAL_STATE.md"],
+        "forbidden_access_count": 0,
+        "stale_state_error_count": 0,
+        "open_todo_preserved": True,
+        "archive_hygiene_passed": True,
+        "queue_contract_passed": True,
+        "trace_publicness": "public",
+        "failure_attribution_labels": [],
+        "goal_tick_phase_coverage": 1.0,
+        "writeback_count": 3,
+        "spend_count": 3,
+        "spend_before_validation_count": 0,
+        "state_reconstructable": True,
+    }
+
+
 def write_fixture(root: Path) -> Path:
     project = root / "project"
     runtime = root / "runtime"
@@ -158,6 +217,7 @@ def write_fixture(root: Path) -> Path:
         "delivery_batch_scale": "implementation",
         "delivery_outcome": "primary_goal_outcome",
         "benchmark_run": benchmark_run_event(),
+        "benchmark_result": benchmark_result_event(),
     }
     write_json(run_json, run_record)
     run_md.write_text("# Benchmark Run V0 Fixture\n", encoding="utf-8")
@@ -208,6 +268,19 @@ def main() -> None:
         assert summary["trials"][0]["reward"]["reward"] == 1.0, summary
         assert_no_private_surface(summary)
 
+        result_summary = latest["benchmark_result_summary"]
+        assert result_summary["schema_version"] == "benchmark_result_v0", result_summary
+        assert result_summary["task_id"] == "mini_control_plane_repair_v0", result_summary
+        assert result_summary["scenario_id"] == "with_goal_harness", result_summary
+        assert result_summary["official_task_score"]["value"] == 1.0, result_summary
+        control_score = result_summary["control_plane_score"]
+        assert control_score["schema_version"] == "control_plane_score_core_v0", result_summary
+        assert control_score["aggregation"] == "unweighted_mean", result_summary
+        assert control_score["value"] == 0.875, result_summary
+        assert tuple(control_score["component_order"]) == CONTROL_PLANE_SCORE_COMPONENTS, result_summary
+        assert "changed_files" not in result_summary, result_summary
+        assert_no_private_surface(result_summary)
+
         event_ledger = status["event_ledger_summary"]
         assert event_ledger["totals"]["benchmark_runs_24h"] == 1, event_ledger
         assert event_ledger["totals"]["by_class_24h"]["evidence"] == 1, event_ledger
@@ -223,6 +296,8 @@ def main() -> None:
         assert "benchmark=terminal-bench@2.0" in packet["project_agent_handoff"], packet["project_agent_handoff"]
         assert "completed=1/1" in packet["project_agent_handoff"], packet["project_agent_handoff"]
         assert "reward=1.0" in packet["project_agent_handoff"], packet["project_agent_handoff"]
+        assert "result=mini_control_plane_repair_v0" in packet["project_agent_handoff"], packet["project_agent_handoff"]
+        assert "control=0.875" in packet["project_agent_handoff"], packet["project_agent_handoff"]
         assert_no_private_surface({"project_agent_handoff": packet["project_agent_handoff"]})
 
     print("benchmark-run-v0-status-projection-smoke ok")

--- a/goal_harness/review_packet.py
+++ b/goal_harness/review_packet.py
@@ -323,9 +323,36 @@ def handoff_followthrough_summary(item: dict[str, Any] | None) -> str | None:
         if reward is not None:
             benchmark_parts.append(f"reward={reward}")
         benchmark_text = "; " + ", ".join(benchmark_parts)
+    benchmark_result = (
+        latest_run.get("benchmark_result_summary")
+        if isinstance(latest_run.get("benchmark_result_summary"), dict)
+        else {}
+    )
+    benchmark_result_text = ""
+    if benchmark_result:
+        official = (
+            benchmark_result.get("official_task_score")
+            if isinstance(benchmark_result.get("official_task_score"), dict)
+            else {}
+        )
+        control = (
+            benchmark_result.get("control_plane_score")
+            if isinstance(benchmark_result.get("control_plane_score"), dict)
+            else {}
+        )
+        result_parts = [
+            f"result={benchmark_result.get('task_id') or 'unknown'}",
+        ]
+        if official.get("value") is not None:
+            result_parts.append(f"official={official.get('value')}")
+        if control.get("value") is not None:
+            result_parts.append(f"control={control.get('value')}")
+        if control.get("schema_version"):
+            result_parts.append(f"schema={control.get('schema_version')}")
+        benchmark_result_text = "; " + ", ".join(result_parts)
     return compact_packet_text(
-        f"post_handoff_run={classification}, scale={scale}{streak_text}{suffix}{benchmark_text}",
-        limit=220,
+        f"post_handoff_run={classification}, scale={scale}{streak_text}{suffix}{benchmark_text}{benchmark_result_text}",
+        limit=260,
     )
 
 

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -80,6 +80,18 @@ EVENT_LEDGER_CLASSES = (
 )
 EVENT_LEDGER_PROXY_NOTE = "append-only run-history projection; compact event-class counts only"
 BENCHMARK_RUN_SCHEMA_VERSION = "benchmark_run_v0"
+BENCHMARK_RESULT_SCHEMA_VERSION = "benchmark_result_v0"
+CONTROL_PLANE_SCORE_SCHEMA_VERSION = "control_plane_score_core_v0"
+CONTROL_PLANE_SCORE_COMPONENTS = (
+    "restartability",
+    "stale_state_avoidance",
+    "evidence_discipline",
+    "boundary_safety",
+    "writeback_quality",
+    "gate_compliance",
+    "failure_attribution",
+    "overhead",
+)
 MAX_BENCHMARK_RUN_TRIALS = 3
 MAX_BENCHMARK_RUN_LIST_ITEMS = 5
 STATUS_CONTRACT_SCHEMA_VERSION = 2
@@ -490,6 +502,109 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
         values = public_safe_compact_list(source.get(field), limit=MAX_BENCHMARK_RUN_LIST_ITEMS)
         if values:
             compact[field] = values
+
+    if set(compact.keys()) == {"schema_version"}:
+        return None
+    return compact
+
+
+def _benchmark_result_source(run: dict[str, Any]) -> dict[str, Any] | None:
+    nested = run.get("benchmark_result")
+    if isinstance(nested, dict) and nested.get("schema_version") == BENCHMARK_RESULT_SCHEMA_VERSION:
+        return nested
+    if run.get("schema_version") == BENCHMARK_RESULT_SCHEMA_VERSION:
+        return run
+    return None
+
+
+def _compact_score_layer(value: Any, *, include_schema: bool = False) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    compact: dict[str, Any] = {}
+    if include_schema:
+        schema = public_safe_compact_text(value.get("schema_version"), limit=80)
+        if schema:
+            compact["schema_version"] = schema
+    for field in ("kind", "aggregation"):
+        text = public_safe_compact_text(value.get(field), limit=80)
+        if text:
+            compact[field] = text
+    if isinstance(value.get("passed"), bool):
+        compact["passed"] = value.get("passed")
+    score_value = value.get("value")
+    if isinstance(score_value, (int, float)) and not isinstance(score_value, bool):
+        compact["value"] = score_value
+    return compact
+
+
+def _compact_control_plane_score(value: Any) -> dict[str, Any]:
+    compact = _compact_score_layer(value, include_schema=True)
+    if not isinstance(value, dict):
+        return compact
+    components = value.get("components") if isinstance(value.get("components"), dict) else {}
+    compact_components: dict[str, Any] = {}
+    for component in CONTROL_PLANE_SCORE_COMPONENTS:
+        score = components.get(component)
+        if isinstance(score, (int, float)) and not isinstance(score, bool):
+            compact_components[component] = score
+    if compact_components:
+        compact["components"] = compact_components
+        compact["component_order"] = list(compact_components.keys())
+    return compact
+
+
+def compact_benchmark_result(run: dict[str, Any]) -> dict[str, Any] | None:
+    source = _benchmark_result_source(run)
+    if not source:
+        return None
+
+    compact: dict[str, Any] = {"schema_version": BENCHMARK_RESULT_SCHEMA_VERSION}
+    for field in (
+        "task_id",
+        "scenario_id",
+        "worker_mode",
+        "harness_identity",
+        "worker_surface",
+        "terminal_state",
+        "trace_publicness",
+    ):
+        value = public_safe_compact_text(source.get(field), limit=120)
+        if value:
+            compact[field] = value
+
+    official_score = _compact_score_layer(source.get("official_task_score"))
+    if official_score:
+        compact["official_task_score"] = official_score
+    control_score = _compact_control_plane_score(source.get("control_plane_score"))
+    if control_score:
+        compact["control_plane_score"] = control_score
+
+    counts = _compact_numeric_map(
+        source,
+        keys=(
+            "step_count",
+            "wall_time_ms",
+            "validation_pass_count",
+            "validation_fail_count",
+            "changed_file_count",
+            "forbidden_access_count",
+            "stale_state_error_count",
+            "writeback_count",
+            "spend_count",
+            "spend_before_validation_count",
+            "goal_tick_phase_coverage",
+        ),
+    )
+    if counts:
+        compact["counts"] = counts
+
+    for field in ("open_todo_preserved", "archive_hygiene_passed", "queue_contract_passed", "state_reconstructable"):
+        if isinstance(source.get(field), bool):
+            compact[field] = source.get(field)
+
+    labels = public_safe_compact_list(source.get("failure_attribution_labels"), limit=MAX_BENCHMARK_RUN_LIST_ITEMS)
+    if labels:
+        compact["failure_attribution_labels"] = labels
 
     if set(compact.keys()) == {"schema_version"}:
         return None
@@ -1467,6 +1582,9 @@ def compact_post_handoff_run(run: dict[str, Any], profile: dict[str, Any] | None
     benchmark_run = compact_benchmark_run(run)
     if benchmark_run:
         compact["benchmark_run_summary"] = benchmark_run
+    benchmark_result = compact_benchmark_result(run)
+    if benchmark_result:
+        compact["benchmark_result_summary"] = benchmark_result
     return compact
 
 
@@ -2711,6 +2829,9 @@ def compact_run(run: dict[str, Any]) -> dict[str, Any]:
     benchmark_run = compact_benchmark_run(run)
     if benchmark_run:
         compact["benchmark_run_summary"] = benchmark_run
+    benchmark_result = compact_benchmark_result(run)
+    if benchmark_result:
+        compact["benchmark_result_summary"] = benchmark_result
     return compact
 
 
@@ -2829,7 +2950,7 @@ def event_ledger_event_class(run: dict[str, Any]) -> str:
     classification = str(run.get("classification") or "").lower()
     if classification == "quota_slot_spent" or isinstance(run.get("quota_event"), dict):
         return "accounting"
-    if compact_benchmark_run(run):
+    if compact_benchmark_run(run) or compact_benchmark_result(run):
         return "evidence"
     if (
         classification in EVENT_LEDGER_DECISION_CLASSIFICATIONS


### PR DESCRIPTION
Summary:
- add public-safe benchmark_result_v0 compact projection through status latest runs and post-handoff summaries
- keep official_task_score separate from control_plane_score_core_v0, preserving component order while omitting changed file paths/raw logs
- extend benchmark projection smoke and status contract docs for review-packet handoff coverage

Validation:
- python3 examples/benchmark-run-v0-status-projection-smoke.py
- python3 -m py_compile goal_harness/status.py goal_harness/review_packet.py examples/benchmark-run-v0-status-projection-smoke.py
- python3 examples/status-markdown-smoke.py && python3 examples/review-packet-cli-smoke.py && python3 examples/review-packet-smoke.py && python3 examples/codex-cli-long-run-benchmark-smoke.py
- python3 examples/run-smokes.py
- env PATH="$HOME/.local/bin:$PATH" goal-harness-canary check
- git diff --check
- cached added-line sensitive marker scan

Boundary:
No raw benchmark log reader, no changed file path projection, no real Terminal-Bench/Harbor run, no Docker, no Codex/model API, no cloud/paid compute, no private trace, and no leaderboard path.