### PR TITLE
Add benchmark result append command

### DIFF
--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -1451,6 +1451,12 @@ writeback, spend, and forbidden-access totals. It must not include changed file
 paths, raw trajectories, local artifact paths, credentials, private traces, or
 leaderboard claims.
 
+`goal-harness history append-benchmark-result --benchmark-result-json <path>`
+is the matching append path for this projection. It is dry-run by default and
+accepts only a compact `benchmark_result_v0` JSON object; it does not discover
+or parse runner directories, task artifacts, Codex sessions, private traces, or
+leaderboard outputs.
+
 ## Promotion Readiness Summary
 
 `promotion_readiness_summary` is an optional release-control projection over the

--- a/examples/benchmark-run-v0-append-cli-smoke.py
+++ b/examples/benchmark-run-v0-append-cli-smoke.py
@@ -20,6 +20,16 @@ from goal_harness.status import collect_status  # noqa: E402
 
 GOAL_ID = "benchmark-append-cli-fixture"
 BENCHMARK_ID = "terminal-bench@2.0"
+CONTROL_PLANE_SCORE_COMPONENTS = (
+    "restartability",
+    "stale_state_avoidance",
+    "evidence_discipline",
+    "boundary_safety",
+    "writeback_quality",
+    "gate_compliance",
+    "failure_attribution",
+    "overhead",
+)
 
 
 def write_json(path: Path, payload: dict[str, Any]) -> None:
@@ -100,12 +110,62 @@ def benchmark_run_event() -> dict[str, Any]:
     }
 
 
-def write_fixture(root: Path) -> tuple[Path, Path, Path]:
+def benchmark_result_event() -> dict[str, Any]:
+    components = {
+        "restartability": 1.0,
+        "stale_state_avoidance": 1.0,
+        "evidence_discipline": 1.0,
+        "boundary_safety": 1.0,
+        "writeback_quality": 1.0,
+        "gate_compliance": 1.0,
+        "failure_attribution": 1.0,
+        "overhead": 0.0,
+    }
+    return {
+        "schema_version": "benchmark_result_v0",
+        "task_id": "mini_control_plane_repair_v0",
+        "scenario_id": "with_goal_harness",
+        "worker_mode": "deterministic",
+        "harness_identity": "goal_harness",
+        "worker_surface": "deterministic_shim",
+        "terminal_state": "success",
+        "official_task_score": {"kind": "deterministic_validation", "passed": True, "value": 1.0},
+        "control_plane_score": {
+            "schema_version": "control_plane_score_core_v0",
+            "kind": "core_v0",
+            "aggregation": "unweighted_mean",
+            "value": 0.875,
+            "components": components,
+            "component_order": list(CONTROL_PLANE_SCORE_COMPONENTS),
+        },
+        "step_count": 3,
+        "wall_time_ms": 42.0,
+        "validation_pass_count": 4,
+        "validation_fail_count": 0,
+        "changed_file_count": 3,
+        "changed_files": ["src/control_plane.py", "state/ACTIVE_GOAL_STATE.md"],
+        "forbidden_access_count": 0,
+        "stale_state_error_count": 0,
+        "open_todo_preserved": True,
+        "archive_hygiene_passed": True,
+        "queue_contract_passed": True,
+        "trace_publicness": "public",
+        "failure_attribution_labels": [],
+        "goal_tick_phase_coverage": 1.0,
+        "writeback_count": 3,
+        "spend_count": 3,
+        "spend_before_validation_count": 0,
+        "state_reconstructable": True,
+    }
+
+
+def write_fixture(root: Path) -> tuple[Path, Path, Path, Path]:
     project = root / "project"
     runtime = root / "runtime"
     state_file = f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
     registry_path = project / ".goal-harness" / "registry.json"
     benchmark_run_path = root / "benchmark_run.json"
+    benchmark_result_path = root / "benchmark_result.json"
 
     (project / Path(state_file).parent).mkdir(parents=True, exist_ok=True)
     (project / state_file).write_text(
@@ -115,9 +175,9 @@ def write_fixture(root: Path) -> tuple[Path, Path, Path]:
         "---\n\n"
         "# Benchmark Append CLI Fixture\n\n"
         "## Agent Todo\n\n"
-        "- [ ] Append a compact benchmark_run_v0 event through the CLI.\n\n"
+        "- [ ] Append compact benchmark_run_v0 and benchmark_result_v0 events through the CLI.\n\n"
         "## Next Action\n\n"
-        "- Inspect the appended benchmark_run_v0 status projection.\n",
+        "- Inspect the appended benchmark status/result projections.\n",
         encoding="utf-8",
     )
     write_json(
@@ -144,7 +204,8 @@ def write_fixture(root: Path) -> tuple[Path, Path, Path]:
         },
     )
     write_json(benchmark_run_path, benchmark_run_event())
-    return registry_path, runtime, benchmark_run_path
+    write_json(benchmark_result_path, benchmark_result_event())
+    return registry_path, runtime, benchmark_run_path, benchmark_result_path
 
 
 def run_cli(args: list[str]) -> dict[str, Any]:
@@ -178,7 +239,7 @@ def assert_no_private_surface(summary: dict[str, Any]) -> None:
 
 def main() -> None:
     with tempfile.TemporaryDirectory(prefix="benchmark-run-v0-append-") as tmp:
-        registry_path, runtime, benchmark_run_path = write_fixture(Path(tmp))
+        registry_path, runtime, benchmark_run_path, benchmark_result_path = write_fixture(Path(tmp))
         index_path = runtime / "goals" / GOAL_ID / "runs" / "index.jsonl"
 
         base_args = [
@@ -214,14 +275,50 @@ def main() -> None:
         assert index_path.exists(), index_path
         assert_no_private_surface(appended["benchmark_run"])
 
+        result_args = [
+            "--registry",
+            str(registry_path),
+            "--runtime-root",
+            str(runtime),
+            "--format",
+            "json",
+            "history",
+            "append-benchmark-result",
+            "--goal-id",
+            GOAL_ID,
+            "--benchmark-result-json",
+            str(benchmark_result_path),
+            "--delivery-batch-scale",
+            "implementation",
+            "--delivery-outcome",
+            "primary_goal_outcome",
+        ]
+
+        result_dry_run = run_cli(result_args)
+        assert result_dry_run["ok"], result_dry_run
+        assert result_dry_run["dry_run"] is True, result_dry_run
+        assert result_dry_run["appended"] is False, result_dry_run
+        assert_no_private_surface(result_dry_run["benchmark_result"])
+        assert "changed_files" not in result_dry_run["benchmark_result"], result_dry_run
+
+        result_appended = run_cli([*result_args, "--execute"])
+        assert result_appended["ok"], result_appended
+        assert result_appended["dry_run"] is False, result_appended
+        assert result_appended["appended"] is True, result_appended
+        assert_no_private_surface(result_appended["benchmark_result"])
+        assert "changed_files" not in result_appended["benchmark_result"], result_appended
+
         index_records = [
             json.loads(line)
             for line in index_path.read_text(encoding="utf-8").splitlines()
             if line.strip()
         ]
-        assert len(index_records) == 1, index_records
+        assert len(index_records) == 2, index_records
         assert index_records[0]["classification"] == "benchmark_run_v0", index_records
         assert index_records[0]["benchmark_run"]["schema_version"] == "benchmark_run_v0", index_records
+        assert index_records[1]["classification"] == "benchmark_result_v0", index_records
+        assert index_records[1]["benchmark_result"]["schema_version"] == "benchmark_result_v0", index_records
+        assert "changed_files" not in index_records[1]["benchmark_result"], index_records
 
         status = collect_status(
             registry_path=registry_path,
@@ -230,8 +327,19 @@ def main() -> None:
             limit=10,
         )
         assert status["ok"], status
-        latest = status["run_history"]["goals"][0]["latest_runs"][0]
-        summary = latest["benchmark_run_summary"]
+        latest_runs = status["run_history"]["goals"][0]["latest_runs"]
+        result_run = next(run for run in latest_runs if run.get("classification") == "benchmark_result_v0")
+        run_event = next(run for run in latest_runs if run.get("classification") == "benchmark_run_v0")
+        result_summary = result_run["benchmark_result_summary"]
+        assert result_summary["schema_version"] == "benchmark_result_v0", result_summary
+        assert result_summary["official_task_score"]["value"] == 1.0, result_summary
+        assert result_summary["control_plane_score"]["schema_version"] == "control_plane_score_core_v0", result_summary
+        assert result_summary["control_plane_score"]["value"] == 0.875, result_summary
+        assert tuple(result_summary["control_plane_score"]["component_order"]) == CONTROL_PLANE_SCORE_COMPONENTS, result_summary
+        assert "changed_files" not in result_summary, result_summary
+        assert_no_private_surface(result_summary)
+
+        summary = run_event["benchmark_run_summary"]
         assert summary["benchmark_id"] == BENCHMARK_ID, summary
         assert summary["progress"]["n_completed_trials"] == 1, summary
         assert summary["metrics"]["cost_usd"] == 0.45, summary

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -36,9 +36,11 @@ from .global_registry import render_global_sync_markdown, sync_project_registry_
 from .handoff_budget import build_handoff_interface_budget
 from .heartbeat_prompt import build_heartbeat_prompt, render_heartbeat_prompt_markdown
 from .history import (
+    append_benchmark_result,
     append_benchmark_run,
     collect_history,
     load_registry,
+    render_benchmark_result_append_markdown,
     render_benchmark_run_append_markdown,
     render_history_markdown,
 )
@@ -80,7 +82,7 @@ from .state_refresh import (
     refresh_state_run,
     render_state_refresh_markdown,
 )
-from .status import collect_status, compact_benchmark_run, render_status_markdown
+from .status import collect_status, compact_benchmark_result, compact_benchmark_run, render_status_markdown
 from .status_server import (
     DEFAULT_STATUS_HOST,
     DEFAULT_STATUS_PATH,
@@ -449,8 +451,8 @@ def main(argv: list[str] | None = None) -> int:
     history_parser.add_argument(
         "history_action",
         nargs="?",
-        choices=["append-benchmark-run"],
-        help="Use append-benchmark-run to append a compact benchmark_run_v0 event.",
+        choices=["append-benchmark-run", "append-benchmark-result"],
+        help="Append a compact benchmark_run_v0 or benchmark_result_v0 event.",
     )
     history_parser.add_argument("--goal-id", help="Only show one goal.")
     history_parser.add_argument("--limit", type=int, default=10)
@@ -458,10 +460,14 @@ def main(argv: list[str] | None = None) -> int:
         "--benchmark-run-json",
         help="Path to a benchmark_run_v0 JSON object. Use '-' to read stdin.",
     )
-    history_parser.add_argument("--classification", default="benchmark_run_v0")
+    history_parser.add_argument(
+        "--benchmark-result-json",
+        help="Path to a benchmark_result_v0 JSON object. Use '-' to read stdin.",
+    )
+    history_parser.add_argument("--classification")
     history_parser.add_argument(
         "--recommended-action",
-        default="inspect benchmark_run_v0 summary and continue passive benchmark work",
+        help="Recommended next action for the compact append event.",
     )
     history_parser.add_argument(
         "--delivery-batch-scale",
@@ -474,7 +480,7 @@ def main(argv: list[str] | None = None) -> int:
         help="Optional delivery outcome label for the run index.",
     )
     history_parser.add_argument("--dry-run", action="store_true", help="Preview append without writing. This is the default.")
-    history_parser.add_argument("--execute", action="store_true", help="Append the compact benchmark_run_v0 event.")
+    history_parser.add_argument("--execute", action="store_true", help="Append the compact benchmark event.")
     history_parser.add_argument("--no-global-sync", action="store_true", help="Skip global registry sync after append.")
 
     archive_runtime_parser = sub.add_parser(
@@ -1131,7 +1137,7 @@ def main(argv: list[str] | None = None) -> int:
                     runtime_root_override=args.runtime_root,
                     goal_id=args.goal_id,
                     benchmark_run=benchmark_run,
-                    classification=args.classification,
+                    classification=args.classification or "benchmark_run_v0",
                     recommended_action=args.recommended_action,
                     delivery_batch_scale=args.delivery_batch_scale,
                     delivery_outcome=args.delivery_outcome,
@@ -1159,10 +1165,69 @@ def main(argv: list[str] | None = None) -> int:
                     "registry": str(registry_path),
                     "runtime_root": args.runtime_root,
                     "goal_id": args.goal_id,
-                    "classification": args.classification,
+                    "classification": args.classification or "benchmark_run_v0",
                     "error": str(exc),
                 }
             print_payload(payload, args.format, render_benchmark_run_append_markdown)
+            return 0 if payload.get("ok") else 1
+
+        if args.history_action == "append-benchmark-result":
+            try:
+                if args.dry_run and args.execute:
+                    raise ValueError("history append-benchmark-result accepts either --dry-run or --execute, not both")
+                if not args.goal_id:
+                    raise ValueError("history append-benchmark-result requires --goal-id")
+                if not args.benchmark_result_json:
+                    raise ValueError("history append-benchmark-result requires --benchmark-result-json")
+
+                if args.benchmark_result_json == "-":
+                    benchmark_result_input = json.loads(sys.stdin.read())
+                else:
+                    benchmark_result_input = json.loads(Path(args.benchmark_result_json).expanduser().read_text(encoding="utf-8"))
+                if not isinstance(benchmark_result_input, dict):
+                    raise ValueError("--benchmark-result-json must contain a JSON object")
+                benchmark_result = compact_benchmark_result(benchmark_result_input)
+                if not benchmark_result:
+                    raise ValueError("--benchmark-result-json did not contain a compactable benchmark_result_v0 object")
+
+                dry_run = not bool(args.execute)
+                payload = append_benchmark_result(
+                    registry_path=registry_path,
+                    runtime_root_override=args.runtime_root,
+                    goal_id=args.goal_id,
+                    benchmark_result=benchmark_result,
+                    classification=args.classification or "benchmark_result_v0",
+                    recommended_action=args.recommended_action,
+                    delivery_batch_scale=args.delivery_batch_scale,
+                    delivery_outcome=args.delivery_outcome,
+                    dry_run=dry_run,
+                )
+                if args.no_global_sync:
+                    payload["global_sync"] = {
+                        "ok": True,
+                        "dry_run": dry_run,
+                        "skipped": True,
+                        "reason": "disabled by --no-global-sync",
+                    }
+                else:
+                    payload["global_sync"] = sync_project_registry_to_global(
+                        registry_path=registry_path,
+                        runtime_root_override=args.runtime_root,
+                        goal_id=args.goal_id,
+                        dry_run=dry_run,
+                    )
+            except Exception as exc:
+                payload = {
+                    "ok": False,
+                    "dry_run": not bool(args.execute),
+                    "appended": False,
+                    "registry": str(registry_path),
+                    "runtime_root": args.runtime_root,
+                    "goal_id": args.goal_id,
+                    "classification": args.classification or "benchmark_result_v0",
+                    "error": str(exc),
+                }
+            print_payload(payload, args.format, render_benchmark_result_append_markdown)
             return 0 if payload.get("ok") else 1
 
         try:

--- a/goal_harness/history.py
+++ b/goal_harness/history.py
@@ -194,6 +194,79 @@ def append_benchmark_run(
     return payload
 
 
+def append_benchmark_result(
+    *,
+    registry_path: Path,
+    runtime_root_override: str | None,
+    goal_id: str,
+    benchmark_result: dict[str, Any],
+    classification: str = "benchmark_result_v0",
+    recommended_action: str | None = None,
+    delivery_batch_scale: str | None = None,
+    delivery_outcome: str | None = None,
+    dry_run: bool = True,
+) -> dict[str, Any]:
+    safe_goal_id = validate_goal_id_path_segment(goal_id)
+    if benchmark_result.get("schema_version") != "benchmark_result_v0":
+        raise ValueError("benchmark result must have schema_version=benchmark_result_v0")
+
+    registry = load_registry(registry_path)
+    runtime_root = resolve_runtime_root(registry, runtime_root_override)
+    generated_at = now_local()
+    action = recommended_action or "inspect benchmark_result_v0 summary and continue benchmark comparison work"
+    health_check = "benchmark_result_v0 compact event public-safe"
+
+    runs_dir = runtime_root / "goals" / safe_goal_id / "runs"
+    json_path, markdown_path = unique_run_paths(runs_dir, generated_at)
+    index_path = runs_dir / "index.jsonl"
+    record: dict[str, Any] = {
+        "generated_at": generated_at,
+        "goal_id": safe_goal_id,
+        "classification": classification,
+        "recommended_action": action,
+        "health_check": health_check,
+        "benchmark_result": benchmark_result,
+    }
+    if delivery_batch_scale:
+        record["delivery_batch_scale"] = delivery_batch_scale
+    if delivery_outcome:
+        record["delivery_outcome"] = delivery_outcome
+
+    index_record = {
+        **record,
+        "json_path": str(json_path),
+        "markdown_path": str(markdown_path),
+    }
+    payload = {
+        "ok": True,
+        "dry_run": dry_run,
+        "appended": not dry_run,
+        "registry": str(registry_path),
+        "runtime_root": str(runtime_root),
+        "goal_id": safe_goal_id,
+        "classification": classification,
+        "recommended_action": action,
+        "generated_at": generated_at,
+        "health_check": health_check,
+        "json_path": str(json_path),
+        "markdown_path": str(markdown_path),
+        "index_path": str(index_path),
+        "benchmark_result": benchmark_result,
+    }
+    if delivery_batch_scale:
+        payload["delivery_batch_scale"] = delivery_batch_scale
+    if delivery_outcome:
+        payload["delivery_outcome"] = delivery_outcome
+
+    if not dry_run:
+        runs_dir.mkdir(parents=True, exist_ok=True)
+        json_path.write_text(json.dumps(record, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        markdown_path.write_text(render_benchmark_result_append_markdown(payload) + "\n", encoding="utf-8")
+        with index_path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(index_record, ensure_ascii=False) + "\n")
+    return payload
+
+
 def latest_status_run(runs: list[dict[str, Any]]) -> dict[str, Any] | None:
     for run in runs:
         if str(run.get("classification") or "") in STATUS_NEUTRAL_CLASSIFICATIONS:
@@ -349,6 +422,57 @@ def render_benchmark_run_append_markdown(payload: dict[str, Any]) -> str:
                 f"- mode: `{benchmark_run.get('mode')}`",
                 f"- progress: completed={progress.get('n_completed_trials')} total={progress.get('n_total_trials')}",
                 f"- metrics: input_tokens={metrics.get('input_tokens')} output_tokens={metrics.get('output_tokens')} cost_usd={metrics.get('cost_usd')}",
+            ]
+        )
+    if payload.get("error"):
+        lines.append(f"- error: {payload.get('error')}")
+    return "\n".join(lines)
+
+
+def render_benchmark_result_append_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Goal Harness Benchmark Result Append",
+        "",
+        f"- ok: `{payload.get('ok')}`",
+        f"- dry_run: `{payload.get('dry_run')}`",
+        f"- appended: `{payload.get('appended')}`",
+        f"- goal_id: `{payload.get('goal_id')}`",
+        f"- classification: `{payload.get('classification')}`",
+        f"- generated_at: `{payload.get('generated_at')}`",
+    ]
+    if payload.get("json_path"):
+        lines.append(f"- json_path: `{payload.get('json_path')}`")
+    if payload.get("index_path"):
+        lines.append(f"- index_path: `{payload.get('index_path')}`")
+    if payload.get("recommended_action"):
+        lines.append(f"- recommended_action: {payload.get('recommended_action')}")
+    benchmark_result = (
+        payload.get("benchmark_result")
+        if isinstance(payload.get("benchmark_result"), dict)
+        else {}
+    )
+    if benchmark_result:
+        official = (
+            benchmark_result.get("official_task_score")
+            if isinstance(benchmark_result.get("official_task_score"), dict)
+            else {}
+        )
+        control = (
+            benchmark_result.get("control_plane_score")
+            if isinstance(benchmark_result.get("control_plane_score"), dict)
+            else {}
+        )
+        lines.extend(
+            [
+                "",
+                "## Benchmark Result",
+                "",
+                f"- schema_version: `{benchmark_result.get('schema_version')}`",
+                f"- task_id: `{benchmark_result.get('task_id')}`",
+                f"- scenario_id: `{benchmark_result.get('scenario_id')}`",
+                f"- terminal_state: `{benchmark_result.get('terminal_state')}`",
+                f"- official_task_score: kind={official.get('kind')} value={official.get('value')} passed={official.get('passed')}",
+                f"- control_plane_score: schema={control.get('schema_version')} kind={control.get('kind')} value={control.get('value')} aggregation={control.get('aggregation')}",
             ]
         )
     if payload.get("error"):


### PR DESCRIPTION
Summary:
- add history append-benchmark-result for compact benchmark_result_v0 events, dry-run by default and execute-gated
- render benchmark_result append markdown and sync through the existing status/review-packet projection path
- extend benchmark append smoke to cover benchmark_run_v0 plus benchmark_result_v0 without projecting changed_files/raw logs

Validation:
- python3 examples/benchmark-run-v0-append-cli-smoke.py
- python3 examples/benchmark-run-v0-status-projection-smoke.py
- python3 -m py_compile goal_harness/history.py goal_harness/cli.py goal_harness/status.py examples/benchmark-run-v0-append-cli-smoke.py
- python3 examples/status-markdown-smoke.py && python3 examples/review-packet-cli-smoke.py && python3 examples/subcommand-format-smoke.py
- python3 examples/codex-cli-long-run-benchmark-smoke.py && python3 examples/passive-baseline-protocol-smoke.py
- python3 examples/run-smokes.py
- env PATH="$HOME/.local/bin:$PATH" goal-harness-canary check
- git diff --check
- cached added-line sensitive marker scan

Boundary:
No raw benchmark log reader, no changed file path projection, no real Terminal-Bench/Harbor run, no Docker, no Codex/model API, no cloud/paid compute, no private trace, and no leaderboard path.