### PR TITLE
Add benchmark comparison append projection

### DIFF
--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -1457,6 +1457,23 @@ accepts only a compact `benchmark_result_v0` JSON object; it does not discover
 or parse runner directories, task artifacts, Codex sessions, private traces, or
 leaderboard outputs.
 
+When a compact run record includes `benchmark_comparison_summary`, it is a
+redacted projection of `benchmark_comparison_v0`. The summary links paired
+`benchmark_result_v0` scenarios and exposes only compact comparison fields such
+as task/comparison id, mode pair, baseline/treatment scenario ids,
+official-task score delta, control-plane score delta, overhead/writeback/spend
+deltas, readiness booleans, compared metric names, and stop-condition labels.
+It may carry numeric deltas or public-safe symbolic deltas such as
+`not_applicable_readiness_only`. It must not include raw benchmark logs,
+changed file paths, absolute runner directories, Codex session transcripts,
+private traces, credentials, or leaderboard submission artifacts.
+
+`goal-harness history append-benchmark-comparison --benchmark-comparison-json
+<path>` is the matching append path for this projection. It is dry-run by
+default and accepts only a compact `benchmark_comparison_v0` JSON object; it
+does not discover result pairs from runner directories, parse raw task
+artifacts, invoke benchmark runners, or infer leaderboard claims.
+
 ## Promotion Readiness Summary
 
 `promotion_readiness_summary` is an optional release-control projection over the

--- a/examples/benchmark-run-v0-append-cli-smoke.py
+++ b/examples/benchmark-run-v0-append-cli-smoke.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Smoke-test appending benchmark_run_v0 through the Goal Harness CLI."""
+"""Smoke-test appending compact benchmark events through the Goal Harness CLI."""
 
 from __future__ import annotations
 
@@ -15,6 +15,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from goal_harness.review_packet import build_review_packet  # noqa: E402
 from goal_harness.status import collect_status  # noqa: E402
 
 
@@ -159,13 +160,61 @@ def benchmark_result_event() -> dict[str, Any]:
     }
 
 
-def write_fixture(root: Path) -> tuple[Path, Path, Path, Path]:
+def benchmark_comparison_event() -> dict[str, Any]:
+    return {
+        "schema_version": "benchmark_comparison_v0",
+        "task_id": "mini_control_plane_repair_v0",
+        "comparison_id": "mini_control_plane_repair_v0_ab",
+        "benchmark_id": "local-deterministic",
+        "mode_pair": ["without_goal_harness", "with_goal_harness"],
+        "baseline_scenario_id": "without_goal_harness",
+        "treatment_scenario_id": "with_goal_harness",
+        "scenario_count": 2,
+        "both_success": True,
+        "official_task_score_delta": 0.0,
+        "control_plane_score_delta": 0.143,
+        "with_goal_harness_overhead_ms": 12.5,
+        "with_goal_harness_extra_writebacks": 3,
+        "with_goal_harness_extra_spends": 3,
+        "result_refs": [
+            {
+                "scenario_id": "without_goal_harness",
+                "task_id": "mini_control_plane_repair_v0",
+                "result_id": "result_without_goal_harness",
+                "raw_log_path": "/" + "tmp/private/raw.log",
+            },
+            {
+                "scenario_id": "with_goal_harness",
+                "task_id": "mini_control_plane_repair_v0",
+                "result_id": "result_with_goal_harness",
+            },
+        ],
+        "metrics_compared": [
+            "official_task_score",
+            "control_plane_score",
+            "writeback_count",
+            "spend_count",
+        ],
+        "interrupt_fixture_markers": [
+            "worker_kill_after_partial_goal_tick_writeback",
+            "stale_latest_run_trap",
+        ],
+        "stop_conditions": [
+            "do_not_run_real_benchmark",
+            "do_not_upload_leaderboard_trace",
+        ],
+        "raw_thread_path": "/" + "Users/example/private/session.jsonl",
+    }
+
+
+def write_fixture(root: Path) -> tuple[Path, Path, Path, Path, Path]:
     project = root / "project"
     runtime = root / "runtime"
     state_file = f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
     registry_path = project / ".goal-harness" / "registry.json"
     benchmark_run_path = root / "benchmark_run.json"
     benchmark_result_path = root / "benchmark_result.json"
+    benchmark_comparison_path = root / "benchmark_comparison.json"
 
     (project / Path(state_file).parent).mkdir(parents=True, exist_ok=True)
     (project / state_file).write_text(
@@ -175,7 +224,7 @@ def write_fixture(root: Path) -> tuple[Path, Path, Path, Path]:
         "---\n\n"
         "# Benchmark Append CLI Fixture\n\n"
         "## Agent Todo\n\n"
-        "- [ ] Append compact benchmark_run_v0 and benchmark_result_v0 events through the CLI.\n\n"
+        "- [ ] Append compact benchmark_run_v0, benchmark_result_v0, and benchmark_comparison_v0 events through the CLI.\n\n"
         "## Next Action\n\n"
         "- Inspect the appended benchmark status/result projections.\n",
         encoding="utf-8",
@@ -205,7 +254,8 @@ def write_fixture(root: Path) -> tuple[Path, Path, Path, Path]:
     )
     write_json(benchmark_run_path, benchmark_run_event())
     write_json(benchmark_result_path, benchmark_result_event())
-    return registry_path, runtime, benchmark_run_path, benchmark_result_path
+    write_json(benchmark_comparison_path, benchmark_comparison_event())
+    return registry_path, runtime, benchmark_run_path, benchmark_result_path, benchmark_comparison_path
 
 
 def run_cli(args: list[str]) -> dict[str, Any]:
@@ -239,7 +289,7 @@ def assert_no_private_surface(summary: dict[str, Any]) -> None:
 
 def main() -> None:
     with tempfile.TemporaryDirectory(prefix="benchmark-run-v0-append-") as tmp:
-        registry_path, runtime, benchmark_run_path, benchmark_result_path = write_fixture(Path(tmp))
+        registry_path, runtime, benchmark_run_path, benchmark_result_path, benchmark_comparison_path = write_fixture(Path(tmp))
         index_path = runtime / "goals" / GOAL_ID / "runs" / "index.jsonl"
 
         base_args = [
@@ -339,11 +389,80 @@ def main() -> None:
         assert "changed_files" not in result_summary, result_summary
         assert_no_private_surface(result_summary)
 
+        comparison_args = [
+            "--registry",
+            str(registry_path),
+            "--runtime-root",
+            str(runtime),
+            "--format",
+            "json",
+            "history",
+            "append-benchmark-comparison",
+            "--goal-id",
+            GOAL_ID,
+            "--benchmark-comparison-json",
+            str(benchmark_comparison_path),
+            "--delivery-batch-scale",
+            "implementation",
+            "--delivery-outcome",
+            "primary_goal_outcome",
+        ]
+
+        comparison_dry_run = run_cli(comparison_args)
+        assert comparison_dry_run["ok"], comparison_dry_run
+        assert comparison_dry_run["dry_run"] is True, comparison_dry_run
+        assert comparison_dry_run["appended"] is False, comparison_dry_run
+        assert_no_private_surface(comparison_dry_run["benchmark_comparison"])
+        assert "raw_thread_path" not in comparison_dry_run["benchmark_comparison"], comparison_dry_run
+        assert "raw_log_path" not in json.dumps(comparison_dry_run["benchmark_comparison"], sort_keys=True), comparison_dry_run
+
+        comparison_appended = run_cli([*comparison_args, "--execute"])
+        assert comparison_appended["ok"], comparison_appended
+        assert comparison_appended["dry_run"] is False, comparison_appended
+        assert comparison_appended["appended"] is True, comparison_appended
+        assert_no_private_surface(comparison_appended["benchmark_comparison"])
+
         summary = run_event["benchmark_run_summary"]
         assert summary["benchmark_id"] == BENCHMARK_ID, summary
         assert summary["progress"]["n_completed_trials"] == 1, summary
         assert summary["metrics"]["cost_usd"] == 0.45, summary
         assert summary["validation"]["all_passed"] is True, summary
+        status = collect_status(
+            registry_path=registry_path,
+            runtime_root_override=str(runtime),
+            scan_roots=[],
+            limit=10,
+        )
+        assert status["ok"], status
+        latest_runs = status["run_history"]["goals"][0]["latest_runs"]
+        comparison_run = next(run for run in latest_runs if run.get("classification") == "benchmark_comparison_v0")
+        comparison_summary = comparison_run["benchmark_comparison_summary"]
+        assert comparison_summary["schema_version"] == "benchmark_comparison_v0", comparison_summary
+        assert comparison_summary["comparison_id"] == "mini_control_plane_repair_v0_ab", comparison_summary
+        assert comparison_summary["mode_pair"] == ["without_goal_harness", "with_goal_harness"], comparison_summary
+        assert comparison_summary["official_task_score_delta"] == 0.0, comparison_summary
+        assert comparison_summary["control_plane_score_delta"] == 0.143, comparison_summary
+        assert comparison_summary["both_success"] is True, comparison_summary
+        assert "raw_thread_path" not in comparison_summary, comparison_summary
+        assert "raw_log_path" not in json.dumps(comparison_summary, sort_keys=True), comparison_summary
+        assert_no_private_surface(comparison_summary)
+
+        index_records = [
+            json.loads(line)
+            for line in index_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        assert len(index_records) == 3, index_records
+        assert index_records[2]["classification"] == "benchmark_comparison_v0", index_records
+        assert "raw_thread_path" not in index_records[2]["benchmark_comparison"], index_records
+        assert "raw_log_path" not in json.dumps(index_records[2]["benchmark_comparison"], sort_keys=True), index_records
+
+        packet = build_review_packet(status, goal_id=GOAL_ID)
+        handoff = packet["project_agent_handoff"]
+        assert "comparison=mini_control_plane_repair_v0_ab" in handoff, handoff
+        assert "official_delta=0.0" in handoff, handoff
+        assert "control_delta=0.143" in handoff, handoff
+        assert_no_private_surface({"handoff": handoff})
         assert status["event_ledger_summary"]["totals"]["benchmark_runs_24h"] == 1, status
         assert_no_private_surface(summary)
 

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -36,10 +36,12 @@ from .global_registry import render_global_sync_markdown, sync_project_registry_
 from .handoff_budget import build_handoff_interface_budget
 from .heartbeat_prompt import build_heartbeat_prompt, render_heartbeat_prompt_markdown
 from .history import (
+    append_benchmark_comparison,
     append_benchmark_result,
     append_benchmark_run,
     collect_history,
     load_registry,
+    render_benchmark_comparison_append_markdown,
     render_benchmark_result_append_markdown,
     render_benchmark_run_append_markdown,
     render_history_markdown,
@@ -82,7 +84,13 @@ from .state_refresh import (
     refresh_state_run,
     render_state_refresh_markdown,
 )
-from .status import collect_status, compact_benchmark_result, compact_benchmark_run, render_status_markdown
+from .status import (
+    collect_status,
+    compact_benchmark_comparison,
+    compact_benchmark_result,
+    compact_benchmark_run,
+    render_status_markdown,
+)
 from .status_server import (
     DEFAULT_STATUS_HOST,
     DEFAULT_STATUS_PATH,
@@ -451,8 +459,8 @@ def main(argv: list[str] | None = None) -> int:
     history_parser.add_argument(
         "history_action",
         nargs="?",
-        choices=["append-benchmark-run", "append-benchmark-result"],
-        help="Append a compact benchmark_run_v0 or benchmark_result_v0 event.",
+        choices=["append-benchmark-run", "append-benchmark-result", "append-benchmark-comparison"],
+        help="Append a compact benchmark_run_v0, benchmark_result_v0, or benchmark_comparison_v0 event.",
     )
     history_parser.add_argument("--goal-id", help="Only show one goal.")
     history_parser.add_argument("--limit", type=int, default=10)
@@ -463,6 +471,10 @@ def main(argv: list[str] | None = None) -> int:
     history_parser.add_argument(
         "--benchmark-result-json",
         help="Path to a benchmark_result_v0 JSON object. Use '-' to read stdin.",
+    )
+    history_parser.add_argument(
+        "--benchmark-comparison-json",
+        help="Path to a benchmark_comparison_v0 JSON object. Use '-' to read stdin.",
     )
     history_parser.add_argument("--classification")
     history_parser.add_argument(
@@ -1228,6 +1240,69 @@ def main(argv: list[str] | None = None) -> int:
                     "error": str(exc),
                 }
             print_payload(payload, args.format, render_benchmark_result_append_markdown)
+            return 0 if payload.get("ok") else 1
+
+        if args.history_action == "append-benchmark-comparison":
+            try:
+                if args.dry_run and args.execute:
+                    raise ValueError("history append-benchmark-comparison accepts either --dry-run or --execute, not both")
+                if not args.goal_id:
+                    raise ValueError("history append-benchmark-comparison requires --goal-id")
+                if not args.benchmark_comparison_json:
+                    raise ValueError("history append-benchmark-comparison requires --benchmark-comparison-json")
+
+                if args.benchmark_comparison_json == "-":
+                    benchmark_comparison_input = json.loads(sys.stdin.read())
+                else:
+                    benchmark_comparison_input = json.loads(
+                        Path(args.benchmark_comparison_json).expanduser().read_text(encoding="utf-8")
+                    )
+                if not isinstance(benchmark_comparison_input, dict):
+                    raise ValueError("--benchmark-comparison-json must contain a JSON object")
+                benchmark_comparison = compact_benchmark_comparison(benchmark_comparison_input)
+                if not benchmark_comparison:
+                    raise ValueError(
+                        "--benchmark-comparison-json did not contain a compactable benchmark_comparison_v0 object"
+                    )
+
+                dry_run = not bool(args.execute)
+                payload = append_benchmark_comparison(
+                    registry_path=registry_path,
+                    runtime_root_override=args.runtime_root,
+                    goal_id=args.goal_id,
+                    benchmark_comparison=benchmark_comparison,
+                    classification=args.classification or "benchmark_comparison_v0",
+                    recommended_action=args.recommended_action,
+                    delivery_batch_scale=args.delivery_batch_scale,
+                    delivery_outcome=args.delivery_outcome,
+                    dry_run=dry_run,
+                )
+                if args.no_global_sync:
+                    payload["global_sync"] = {
+                        "ok": True,
+                        "dry_run": dry_run,
+                        "skipped": True,
+                        "reason": "disabled by --no-global-sync",
+                    }
+                else:
+                    payload["global_sync"] = sync_project_registry_to_global(
+                        registry_path=registry_path,
+                        runtime_root_override=args.runtime_root,
+                        goal_id=args.goal_id,
+                        dry_run=dry_run,
+                    )
+            except Exception as exc:
+                payload = {
+                    "ok": False,
+                    "dry_run": not bool(args.execute),
+                    "appended": False,
+                    "registry": str(registry_path),
+                    "runtime_root": args.runtime_root,
+                    "goal_id": args.goal_id,
+                    "classification": args.classification or "benchmark_comparison_v0",
+                    "error": str(exc),
+                }
+            print_payload(payload, args.format, render_benchmark_comparison_append_markdown)
             return 0 if payload.get("ok") else 1
 
         try:

--- a/goal_harness/history.py
+++ b/goal_harness/history.py
@@ -267,6 +267,79 @@ def append_benchmark_result(
     return payload
 
 
+def append_benchmark_comparison(
+    *,
+    registry_path: Path,
+    runtime_root_override: str | None,
+    goal_id: str,
+    benchmark_comparison: dict[str, Any],
+    classification: str = "benchmark_comparison_v0",
+    recommended_action: str | None = None,
+    delivery_batch_scale: str | None = None,
+    delivery_outcome: str | None = None,
+    dry_run: bool = True,
+) -> dict[str, Any]:
+    safe_goal_id = validate_goal_id_path_segment(goal_id)
+    if benchmark_comparison.get("schema_version") != "benchmark_comparison_v0":
+        raise ValueError("benchmark comparison must have schema_version=benchmark_comparison_v0")
+
+    registry = load_registry(registry_path)
+    runtime_root = resolve_runtime_root(registry, runtime_root_override)
+    generated_at = now_local()
+    action = recommended_action or "inspect benchmark_comparison_v0 deltas and continue benchmark analysis"
+    health_check = "benchmark_comparison_v0 compact event public-safe"
+
+    runs_dir = runtime_root / "goals" / safe_goal_id / "runs"
+    json_path, markdown_path = unique_run_paths(runs_dir, generated_at)
+    index_path = runs_dir / "index.jsonl"
+    record: dict[str, Any] = {
+        "generated_at": generated_at,
+        "goal_id": safe_goal_id,
+        "classification": classification,
+        "recommended_action": action,
+        "health_check": health_check,
+        "benchmark_comparison": benchmark_comparison,
+    }
+    if delivery_batch_scale:
+        record["delivery_batch_scale"] = delivery_batch_scale
+    if delivery_outcome:
+        record["delivery_outcome"] = delivery_outcome
+
+    index_record = {
+        **record,
+        "json_path": str(json_path),
+        "markdown_path": str(markdown_path),
+    }
+    payload = {
+        "ok": True,
+        "dry_run": dry_run,
+        "appended": not dry_run,
+        "registry": str(registry_path),
+        "runtime_root": str(runtime_root),
+        "goal_id": safe_goal_id,
+        "classification": classification,
+        "recommended_action": action,
+        "generated_at": generated_at,
+        "health_check": health_check,
+        "json_path": str(json_path),
+        "markdown_path": str(markdown_path),
+        "index_path": str(index_path),
+        "benchmark_comparison": benchmark_comparison,
+    }
+    if delivery_batch_scale:
+        payload["delivery_batch_scale"] = delivery_batch_scale
+    if delivery_outcome:
+        payload["delivery_outcome"] = delivery_outcome
+
+    if not dry_run:
+        runs_dir.mkdir(parents=True, exist_ok=True)
+        json_path.write_text(json.dumps(record, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        markdown_path.write_text(render_benchmark_comparison_append_markdown(payload) + "\n", encoding="utf-8")
+        with index_path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(index_record, ensure_ascii=False) + "\n")
+    return payload
+
+
 def latest_status_run(runs: list[dict[str, Any]]) -> dict[str, Any] | None:
     for run in runs:
         if str(run.get("classification") or "") in STATUS_NEUTRAL_CLASSIFICATIONS:
@@ -296,7 +369,14 @@ def collect_history(
     ):
         index_path = runtime_root / "goals" / current_goal_id / "runs" / "index.jsonl"
         runs, raw_count = load_index(index_path)
-        runs.sort(key=lambda item: str(item.get("generated_at") or ""), reverse=True)
+        runs = [
+            run
+            for _, run in sorted(
+                enumerate(runs),
+                key=lambda item: (str(item[1].get("generated_at") or ""), item[0]),
+                reverse=True,
+            )
+        ]
         for run in runs:
             run["goal_id"] = str(run.get("goal_id") or current_goal_id)
         all_runs.extend(runs)
@@ -473,6 +553,47 @@ def render_benchmark_result_append_markdown(payload: dict[str, Any]) -> str:
                 f"- terminal_state: `{benchmark_result.get('terminal_state')}`",
                 f"- official_task_score: kind={official.get('kind')} value={official.get('value')} passed={official.get('passed')}",
                 f"- control_plane_score: schema={control.get('schema_version')} kind={control.get('kind')} value={control.get('value')} aggregation={control.get('aggregation')}",
+            ]
+        )
+    if payload.get("error"):
+        lines.append(f"- error: {payload.get('error')}")
+    return "\n".join(lines)
+
+
+def render_benchmark_comparison_append_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Goal Harness Benchmark Comparison Append",
+        "",
+        f"- ok: `{payload.get('ok')}`",
+        f"- dry_run: `{payload.get('dry_run')}`",
+        f"- appended: `{payload.get('appended')}`",
+        f"- goal_id: `{payload.get('goal_id')}`",
+        f"- classification: `{payload.get('classification')}`",
+        f"- generated_at: `{payload.get('generated_at')}`",
+    ]
+    if payload.get("json_path"):
+        lines.append(f"- json_path: `{payload.get('json_path')}`")
+    if payload.get("index_path"):
+        lines.append(f"- index_path: `{payload.get('index_path')}`")
+    if payload.get("recommended_action"):
+        lines.append(f"- recommended_action: {payload.get('recommended_action')}")
+    benchmark_comparison = (
+        payload.get("benchmark_comparison")
+        if isinstance(payload.get("benchmark_comparison"), dict)
+        else {}
+    )
+    if benchmark_comparison:
+        lines.extend(
+            [
+                "",
+                "## Benchmark Comparison",
+                "",
+                f"- schema_version: `{benchmark_comparison.get('schema_version')}`",
+                f"- task_id: `{benchmark_comparison.get('task_id')}`",
+                f"- comparison_id: `{benchmark_comparison.get('comparison_id')}`",
+                f"- official_task_score_delta: `{benchmark_comparison.get('official_task_score_delta')}`",
+                f"- control_plane_score_delta: `{benchmark_comparison.get('control_plane_score_delta')}`",
+                f"- both_success: `{benchmark_comparison.get('both_success')}`",
             ]
         )
     if payload.get("error"):

--- a/goal_harness/review_packet.py
+++ b/goal_harness/review_packet.py
@@ -350,8 +350,25 @@ def handoff_followthrough_summary(item: dict[str, Any] | None) -> str | None:
         if control.get("schema_version"):
             result_parts.append(f"schema={control.get('schema_version')}")
         benchmark_result_text = "; " + ", ".join(result_parts)
+    benchmark_comparison = (
+        latest_run.get("benchmark_comparison_summary")
+        if isinstance(latest_run.get("benchmark_comparison_summary"), dict)
+        else {}
+    )
+    benchmark_comparison_text = ""
+    if benchmark_comparison:
+        comparison_parts = [
+            f"comparison={benchmark_comparison.get('comparison_id') or benchmark_comparison.get('task_id') or 'unknown'}",
+        ]
+        if benchmark_comparison.get("official_task_score_delta") is not None:
+            comparison_parts.append(f"official_delta={benchmark_comparison.get('official_task_score_delta')}")
+        if benchmark_comparison.get("control_plane_score_delta") is not None:
+            comparison_parts.append(f"control_delta={benchmark_comparison.get('control_plane_score_delta')}")
+        if benchmark_comparison.get("both_success") is not None:
+            comparison_parts.append(f"both_success={benchmark_comparison.get('both_success')}")
+        benchmark_comparison_text = "; " + ", ".join(comparison_parts)
     return compact_packet_text(
-        f"post_handoff_run={classification}, scale={scale}{streak_text}{suffix}{benchmark_text}{benchmark_result_text}",
+        f"post_handoff_run={classification}, scale={scale}{streak_text}{suffix}{benchmark_text}{benchmark_result_text}{benchmark_comparison_text}",
         limit=260,
     )
 

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -81,6 +81,7 @@ EVENT_LEDGER_CLASSES = (
 EVENT_LEDGER_PROXY_NOTE = "append-only run-history projection; compact event-class counts only"
 BENCHMARK_RUN_SCHEMA_VERSION = "benchmark_run_v0"
 BENCHMARK_RESULT_SCHEMA_VERSION = "benchmark_result_v0"
+BENCHMARK_COMPARISON_SCHEMA_VERSION = "benchmark_comparison_v0"
 CONTROL_PLANE_SCORE_SCHEMA_VERSION = "control_plane_score_core_v0"
 CONTROL_PLANE_SCORE_COMPONENTS = (
     "restartability",
@@ -605,6 +606,87 @@ def compact_benchmark_result(run: dict[str, Any]) -> dict[str, Any] | None:
     labels = public_safe_compact_list(source.get("failure_attribution_labels"), limit=MAX_BENCHMARK_RUN_LIST_ITEMS)
     if labels:
         compact["failure_attribution_labels"] = labels
+
+    if set(compact.keys()) == {"schema_version"}:
+        return None
+    return compact
+
+
+def _benchmark_comparison_source(run: dict[str, Any]) -> dict[str, Any] | None:
+    nested = run.get("benchmark_comparison")
+    if isinstance(nested, dict) and nested.get("schema_version") == BENCHMARK_COMPARISON_SCHEMA_VERSION:
+        return nested
+    if run.get("schema_version") == BENCHMARK_COMPARISON_SCHEMA_VERSION:
+        return run
+    return None
+
+
+def _compact_comparison_delta(value: Any) -> int | float | str | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return value
+    return public_safe_compact_text(value, limit=120)
+
+
+def compact_benchmark_comparison(run: dict[str, Any]) -> dict[str, Any] | None:
+    source = _benchmark_comparison_source(run)
+    if not source:
+        return None
+
+    compact: dict[str, Any] = {"schema_version": BENCHMARK_COMPARISON_SCHEMA_VERSION}
+    for field in ("task_id", "comparison_id", "decision_id", "benchmark_id", "baseline_scenario_id", "treatment_scenario_id", "next_action"):
+        value = public_safe_compact_text(source.get(field), limit=180)
+        if value:
+            compact[field] = value
+
+    mode_pair = public_safe_compact_list(source.get("mode_pair"), limit=MAX_BENCHMARK_RUN_LIST_ITEMS)
+    if mode_pair:
+        compact["mode_pair"] = mode_pair
+
+    for field in (
+        "scenario_count",
+        "official_task_score_delta",
+        "control_plane_score_delta",
+        "with_goal_harness_overhead_ms",
+        "with_goal_harness_extra_writebacks",
+        "with_goal_harness_extra_spends",
+        "checklist_pass_count",
+    ):
+        delta = _compact_comparison_delta(source.get(field))
+        if delta is not None:
+            compact[field] = delta
+
+    for field in (
+        "both_success",
+        "ready_to_attempt_no_submit_setup_probe",
+        "ready_to_run_real_benchmark",
+        "ready_to_submit_leaderboard",
+        "requires_explicit_authorization_for_real_execution",
+    ):
+        if isinstance(source.get(field), bool):
+            compact[field] = source.get(field)
+
+    for field in ("metrics_compared", "interrupt_fixture_markers", "stop_conditions"):
+        values = public_safe_compact_list(source.get(field), limit=MAX_BENCHMARK_RUN_LIST_ITEMS)
+        if values:
+            compact[field] = values
+
+    result_refs: list[dict[str, Any]] = []
+    for item in source.get("result_refs") or []:
+        if not isinstance(item, dict):
+            continue
+        compact_ref: dict[str, Any] = {}
+        for field in ("scenario_id", "task_id", "result_id"):
+            value = public_safe_compact_text(item.get(field), limit=140)
+            if value:
+                compact_ref[field] = value
+        if compact_ref:
+            result_refs.append(compact_ref)
+            if len(result_refs) >= MAX_BENCHMARK_RUN_LIST_ITEMS:
+                break
+    if result_refs:
+        compact["result_refs"] = result_refs
 
     if set(compact.keys()) == {"schema_version"}:
         return None
@@ -1585,6 +1667,9 @@ def compact_post_handoff_run(run: dict[str, Any], profile: dict[str, Any] | None
     benchmark_result = compact_benchmark_result(run)
     if benchmark_result:
         compact["benchmark_result_summary"] = benchmark_result
+    benchmark_comparison = compact_benchmark_comparison(run)
+    if benchmark_comparison:
+        compact["benchmark_comparison_summary"] = benchmark_comparison
     return compact
 
 
@@ -2832,6 +2917,9 @@ def compact_run(run: dict[str, Any]) -> dict[str, Any]:
     benchmark_result = compact_benchmark_result(run)
     if benchmark_result:
         compact["benchmark_result_summary"] = benchmark_result
+    benchmark_comparison = compact_benchmark_comparison(run)
+    if benchmark_comparison:
+        compact["benchmark_comparison_summary"] = benchmark_comparison
     return compact
 
 
@@ -2950,7 +3038,7 @@ def event_ledger_event_class(run: dict[str, Any]) -> str:
     classification = str(run.get("classification") or "").lower()
     if classification == "quota_slot_spent" or isinstance(run.get("quota_event"), dict):
         return "accounting"
-    if compact_benchmark_run(run) or compact_benchmark_result(run):
+    if compact_benchmark_run(run) or compact_benchmark_result(run) or compact_benchmark_comparison(run):
         return "evidence"
     if (
         classification in EVENT_LEDGER_DECISION_CLASSIFICATIONS


### PR DESCRIPTION
## Summary
- add compact benchmark_comparison_v0 append support through history CLI
- project benchmark_comparison_summary into status and review-packet handoff text
- extend the benchmark append smoke and status data contract for public-safe paired deltas

## Validation
- python3 examples/benchmark-run-v0-append-cli-smoke.py
- python3 examples/benchmark-run-v0-status-projection-smoke.py
- python3 examples/review-packet-cli-smoke.py
- python3 examples/subcommand-format-smoke.py
- python3 examples/codex-cli-long-run-benchmark-smoke.py
- python3 examples/run-smokes.py
- goal-harness-canary check
- git diff --check
- added-line sensitive marker scan