### PR TITLE
Add benchmark comparison decision note

### DIFF
--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -1474,6 +1474,17 @@ default and accepts only a compact `benchmark_comparison_v0` JSON object; it
 does not discover result pairs from runner directories, parse raw task
 artifacts, invoke benchmark runners, or infer leaderboard claims.
 
+When `benchmark_comparison_summary` is present, status may also include
+`benchmark_comparison_decision_note`. This is a compact consumer-facing note,
+not a new benchmark event. It maps the paired deltas into report-ready
+`claim_boundary` and `next_decision` hints: whether the evidence is
+readiness-only, control-plane-only, an official-score candidate, failure
+analysis, or still boundary-gated; which claims are allowed; which claims are
+forbidden; and the minimum next evidence. The note must preserve official-score
+delta versus control-plane delta separation and must not authorize real
+benchmark execution, model-backed simulator work, private traces, or
+leaderboard claims.
+
 ## Promotion Readiness Summary
 
 `promotion_readiness_summary` is an optional release-control projection over the

--- a/examples/benchmark-run-v0-append-cli-smoke.py
+++ b/examples/benchmark-run-v0-append-cli-smoke.py
@@ -446,6 +446,17 @@ def main() -> None:
         assert "raw_thread_path" not in comparison_summary, comparison_summary
         assert "raw_log_path" not in json.dumps(comparison_summary, sort_keys=True), comparison_summary
         assert_no_private_surface(comparison_summary)
+        decision_note = comparison_run["benchmark_comparison_decision_note"]
+        assert decision_note["schema_version"] == "benchmark_comparison_decision_note_v0", decision_note
+        assert decision_note["source_schema_version"] == "benchmark_comparison_v0", decision_note
+        assert decision_note["decision"] == "continue", decision_note
+        assert decision_note["evidence_layer"] == "control_plane_only", decision_note
+        assert decision_note["official_task_score_delta"] == 0.0, decision_note
+        assert decision_note["control_plane_score_delta"] == 0.143, decision_note
+        assert "control-plane delta improved while official score delta stayed zero" in decision_note["may_claim"], decision_note
+        assert "official leaderboard uplift" in decision_note["must_not_claim"], decision_note
+        assert decision_note["report_section_hint"] == ["claim_boundary", "next_decision"], decision_note
+        assert_no_private_surface(decision_note)
 
         index_records = [
             json.loads(line)
@@ -462,6 +473,8 @@ def main() -> None:
         assert "comparison=mini_control_plane_repair_v0_ab" in handoff, handoff
         assert "official_delta=0.0" in handoff, handoff
         assert "control_delta=0.143" in handoff, handoff
+        assert "decision=continue" in handoff, handoff
+        assert "layer=control_plane_only" in handoff, handoff
         assert_no_private_surface({"handoff": handoff})
         assert status["event_ledger_summary"]["totals"]["benchmark_runs_24h"] == 1, status
         assert_no_private_surface(summary)

--- a/goal_harness/review_packet.py
+++ b/goal_harness/review_packet.py
@@ -367,8 +367,20 @@ def handoff_followthrough_summary(item: dict[str, Any] | None) -> str | None:
         if benchmark_comparison.get("both_success") is not None:
             comparison_parts.append(f"both_success={benchmark_comparison.get('both_success')}")
         benchmark_comparison_text = "; " + ", ".join(comparison_parts)
+    benchmark_decision = (
+        latest_run.get("benchmark_comparison_decision_note")
+        if isinstance(latest_run.get("benchmark_comparison_decision_note"), dict)
+        else {}
+    )
+    benchmark_decision_text = ""
+    if benchmark_decision:
+        decision_parts = [
+            f"decision={benchmark_decision.get('decision') or 'unknown'}",
+            f"layer={benchmark_decision.get('evidence_layer') or 'unknown'}",
+        ]
+        benchmark_decision_text = "; " + ", ".join(decision_parts)
     return compact_packet_text(
-        f"post_handoff_run={classification}, scale={scale}{streak_text}{suffix}{benchmark_text}{benchmark_result_text}{benchmark_comparison_text}",
+        f"post_handoff_run={classification}, scale={scale}{streak_text}{suffix}{benchmark_text}{benchmark_result_text}{benchmark_comparison_text}{benchmark_decision_text}",
         limit=260,
     )
 

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -82,6 +82,7 @@ EVENT_LEDGER_PROXY_NOTE = "append-only run-history projection; compact event-cla
 BENCHMARK_RUN_SCHEMA_VERSION = "benchmark_run_v0"
 BENCHMARK_RESULT_SCHEMA_VERSION = "benchmark_result_v0"
 BENCHMARK_COMPARISON_SCHEMA_VERSION = "benchmark_comparison_v0"
+BENCHMARK_COMPARISON_DECISION_SCHEMA_VERSION = "benchmark_comparison_decision_note_v0"
 CONTROL_PLANE_SCORE_SCHEMA_VERSION = "control_plane_score_core_v0"
 CONTROL_PLANE_SCORE_COMPONENTS = (
     "restartability",
@@ -691,6 +692,95 @@ def compact_benchmark_comparison(run: dict[str, Any]) -> dict[str, Any] | None:
     if set(compact.keys()) == {"schema_version"}:
         return None
     return compact
+
+
+def _comparison_delta_number(value: Any) -> float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    try:
+        if isinstance(value, str) and value.strip():
+            return float(value)
+    except ValueError:
+        return None
+    return None
+
+
+def benchmark_comparison_decision_note(comparison: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(comparison, dict) or comparison.get("schema_version") != BENCHMARK_COMPARISON_SCHEMA_VERSION:
+        return None
+
+    official_delta = _comparison_delta_number(comparison.get("official_task_score_delta"))
+    control_delta = _comparison_delta_number(comparison.get("control_plane_score_delta"))
+    symbolic_official = (
+        comparison.get("official_task_score_delta")
+        if isinstance(comparison.get("official_task_score_delta"), str)
+        else None
+    )
+    both_success = comparison.get("both_success") if isinstance(comparison.get("both_success"), bool) else None
+    submit_ready = comparison.get("ready_to_submit_leaderboard")
+    real_ready = comparison.get("ready_to_run_real_benchmark")
+
+    evidence_layer = "comparison_summary"
+    decision = "repeat"
+    minimum_next_evidence = "repeat the paired comparison or record a blocker"
+    may_claim = ["compact paired comparison is available"]
+    must_not_claim = ["official leaderboard uplift"]
+
+    if symbolic_official == "not_applicable_readiness_only":
+        evidence_layer = "readiness_only"
+        decision = "continue"
+        minimum_next_evidence = "record no-submit setup evidence before any real benchmark run"
+        may_claim.append("readiness boundary is documented")
+        must_not_claim.append("benchmark pass/fail or score uplift")
+    elif official_delta == 0 and control_delta is not None and control_delta > 0:
+        evidence_layer = "control_plane_only"
+        decision = "continue"
+        minimum_next_evidence = "convert the control-plane delta into a report note or repeat on an official-runner-compatible output"
+        may_claim.append("control-plane delta improved while official score delta stayed zero")
+        must_not_claim.append("benchmark pass/fail improvement from control-plane-only evidence")
+    elif official_delta is not None and official_delta > 0:
+        evidence_layer = "official_score_candidate"
+        decision = "defer" if submit_ready is not True else "broaden"
+        minimum_next_evidence = "verify benchmark protocol, submit eligibility, and side-effect audit before claiming official uplift"
+        may_claim.append("official score candidate exists")
+        must_not_claim.append("official uplift before protocol and submit-eligibility verification")
+    elif both_success is False:
+        evidence_layer = "failure_analysis"
+        decision = "repeat"
+        minimum_next_evidence = "attribute the failed scenario before broadening"
+        may_claim.append("paired comparison found a failure needing attribution")
+    elif real_ready is False:
+        evidence_layer = "boundary_guarded"
+        decision = "defer"
+        minimum_next_evidence = "resolve real-run readiness blockers before execution"
+        may_claim.append("real benchmark execution remains gated")
+
+    note: dict[str, Any] = {
+        "schema_version": BENCHMARK_COMPARISON_DECISION_SCHEMA_VERSION,
+        "source_schema_version": BENCHMARK_COMPARISON_SCHEMA_VERSION,
+        "decision": decision,
+        "evidence_layer": evidence_layer,
+        "minimum_next_evidence": minimum_next_evidence,
+        "stop_condition": "stop before real benchmark execution, model-backed simulator work, private traces, or leaderboard claims without explicit approval",
+        "may_claim": may_claim[:MAX_BENCHMARK_RUN_LIST_ITEMS],
+        "must_not_claim": must_not_claim[:MAX_BENCHMARK_RUN_LIST_ITEMS],
+        "report_section_hint": ["claim_boundary", "next_decision"],
+    }
+    for field in ("task_id", "comparison_id"):
+        value = public_safe_compact_text(comparison.get(field), limit=140)
+        if value:
+            note[field] = value
+    if official_delta is not None:
+        note["official_task_score_delta"] = official_delta
+    elif symbolic_official:
+        note["official_task_score_delta"] = symbolic_official
+    if control_delta is not None:
+        note["control_plane_score_delta"] = control_delta
+    elif isinstance(comparison.get("control_plane_score_delta"), str):
+        note["control_plane_score_delta"] = public_safe_compact_text(comparison.get("control_plane_score_delta"), limit=120)
+    return note
 
 
 def parse_state_frontmatter(state_text: str) -> dict[str, str]:
@@ -1670,6 +1760,9 @@ def compact_post_handoff_run(run: dict[str, Any], profile: dict[str, Any] | None
     benchmark_comparison = compact_benchmark_comparison(run)
     if benchmark_comparison:
         compact["benchmark_comparison_summary"] = benchmark_comparison
+        decision_note = benchmark_comparison_decision_note(benchmark_comparison)
+        if decision_note:
+            compact["benchmark_comparison_decision_note"] = decision_note
     return compact
 
 
@@ -2920,6 +3013,9 @@ def compact_run(run: dict[str, Any]) -> dict[str, Any]:
     benchmark_comparison = compact_benchmark_comparison(run)
     if benchmark_comparison:
         compact["benchmark_comparison_summary"] = benchmark_comparison
+        decision_note = benchmark_comparison_decision_note(benchmark_comparison)
+        if decision_note:
+            compact["benchmark_comparison_decision_note"] = decision_note
     return compact
 
 


### PR DESCRIPTION
## Summary
- derive a compact benchmark_comparison_decision_note from benchmark_comparison_summary
- expose the decision/layer in review-packet handoff text
- document the note as a consumer-facing claim-boundary and next-decision hint

## Validation
- python3 examples/benchmark-run-v0-append-cli-smoke.py
- python3 examples/benchmark-run-v0-status-projection-smoke.py
- python3 examples/review-packet-cli-smoke.py
- python3 examples/benchmark-experiment-report-template-smoke.py
- python3 examples/status-markdown-smoke.py
- python3 examples/run-smokes.py
- goal-harness-canary check
- git diff --check
- added-line sensitive marker scan