### PR TITLE
Add benchmark experiment report append projection

### DIFF
--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -1485,6 +1485,21 @@ delta versus control-plane delta separation and must not authorize real
 benchmark execution, model-backed simulator work, private traces, or
 leaderboard claims.
 
+When a compact run record includes `benchmark_experiment_report_summary`, it is
+a redacted projection of `benchmark_experiment_report_v0`. The summary keeps the
+paper/report surface separate from raw benchmark execution: compact experiment
+identity, official-score eligibility, passive control-plane score hints,
+operator-simulator ablation state, claim boundary, negative-result layers, and
+next-decision fields. It must not include raw benchmark logs, local artifact
+paths, Codex session transcripts, private traces, credentials, or leaderboard
+submission artifacts.
+
+`goal-harness history append-benchmark-report --benchmark-report-json <path>` is
+the matching append path for this projection. It is dry-run by default and
+accepts only a compact `benchmark_experiment_report_v0` JSON object; it does
+not run a benchmark, invoke a model or simulator, read runner directories, parse
+private artifacts, or infer leaderboard claims.
+
 ## Promotion Readiness Summary
 
 `promotion_readiness_summary` is an optional release-control projection over the

--- a/examples/benchmark-experiment-report-append-cli-smoke.py
+++ b/examples/benchmark-experiment-report-append-cli-smoke.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Smoke-test appending compact benchmark_experiment_report_v0 events."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from goal_harness.review_packet import build_review_packet  # noqa: E402
+from goal_harness.status import collect_status  # noqa: E402
+
+
+GOAL_ID = "benchmark-report-append-cli-fixture"
+REPORT_MODULE_PATH = REPO_ROOT / "examples" / "benchmark-experiment-report-template-smoke.py"
+
+
+def load_report_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("benchmark_experiment_report_template_smoke", REPORT_MODULE_PATH)
+    assert spec is not None and spec.loader is not None, REPORT_MODULE_PATH
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def benchmark_report_event() -> dict[str, Any]:
+    module = load_report_module()
+    note = module.decision_note_payload(module.comparison_summary_payload())
+    readiness_note = module.decision_note_payload(module.readiness_summary_payload())
+    failure_note = module.decision_note_payload(module.failure_summary_payload())
+    report = module.report_payload(note, readiness_note, failure_note)
+    report["raw_log_path"] = "/" + "Users/example/private/raw.log"
+    report["local_artifact_path"] = "/" + "tmp/private/artifact.json"
+    report["negative_results"]["failed_hypotheses"][0]["private_trace_path"] = "/" + "Users/example/private/session.jsonl"
+    return report
+
+
+def write_fixture(root: Path) -> tuple[Path, Path, Path]:
+    project = root / "project"
+    runtime = root / "runtime"
+    state_file = f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    registry_path = project / ".goal-harness" / "registry.json"
+    report_path = root / "benchmark_report.json"
+
+    (project / Path(state_file).parent).mkdir(parents=True, exist_ok=True)
+    (project / state_file).write_text(
+        "---\n"
+        "status: active-read-only\n"
+        "updated_at: 2026-06-07T00:00:00+00:00\n"
+        "---\n\n"
+        "# Benchmark Report Append CLI Fixture\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] Append compact benchmark_experiment_report_v0 through the CLI.\n\n"
+        "## Next Action\n\n"
+        "- Inspect the appended benchmark report projection.\n",
+        encoding="utf-8",
+    )
+    write_json(
+        registry_path,
+        {
+            "schema_version": 1,
+            "updated_at": "2026-06-07T00:00:00+00:00",
+            "common_runtime_root": str(runtime),
+            "goals": [
+                {
+                    "id": GOAL_ID,
+                    "domain": "benchmark-report-projection",
+                    "status": "active-read-only",
+                    "repo": str(project),
+                    "state_file": state_file,
+                    "adapter": {
+                        "kind": "harness_self_improvement",
+                        "status": "connected-read-only",
+                    },
+                    "quota": {"compute": 1.0, "window_hours": 24},
+                    "authority_sources": [],
+                }
+            ],
+        },
+    )
+    write_json(report_path, benchmark_report_event())
+    return registry_path, runtime, report_path
+
+
+def run_cli(args: list[str]) -> dict[str, Any]:
+    result = subprocess.run(
+        [sys.executable, "-m", "goal_harness.cli", *args],
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    payload = json.loads(result.stdout)
+    assert isinstance(payload, dict), payload
+    return payload
+
+
+def assert_no_private_surface(summary: dict[str, Any]) -> None:
+    text = json.dumps(summary, sort_keys=True)
+    forbidden = [
+        "/" + "Users/",
+        "/" + "tmp/",
+        "OPENAI" + "_API_KEY",
+        "auth.json",
+        "sessions/",
+        "raw_log_path",
+        "local_artifact_path",
+        "private_trace_path",
+        "lark" + "office",
+        "fei" + "shu.cn",
+    ]
+    leaked = [needle for needle in forbidden if needle in text]
+    assert not leaked, leaked
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory(prefix="benchmark-report-append-") as tmp:
+        registry_path, runtime, report_path = write_fixture(Path(tmp))
+        index_path = runtime / "goals" / GOAL_ID / "runs" / "index.jsonl"
+
+        args = [
+            "--registry",
+            str(registry_path),
+            "--runtime-root",
+            str(runtime),
+            "--format",
+            "json",
+            "history",
+            "append-benchmark-report",
+            "--goal-id",
+            GOAL_ID,
+            "--benchmark-report-json",
+            str(report_path),
+            "--delivery-batch-scale",
+            "implementation",
+            "--delivery-outcome",
+            "primary_goal_outcome",
+        ]
+
+        dry_run = run_cli(args)
+        assert dry_run["ok"], dry_run
+        assert dry_run["dry_run"] is True, dry_run
+        assert dry_run["appended"] is False, dry_run
+        assert not index_path.exists(), index_path
+        assert_no_private_surface(dry_run["benchmark_experiment_report"])
+
+        appended = run_cli([*args, "--execute"])
+        assert appended["ok"], appended
+        assert appended["dry_run"] is False, appended
+        assert appended["appended"] is True, appended
+        assert index_path.exists(), index_path
+        assert_no_private_surface(appended["benchmark_experiment_report"])
+
+        index_records = [
+            json.loads(line)
+            for line in index_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        assert len(index_records) == 1, index_records
+        record = index_records[0]
+        assert record["classification"] == "benchmark_experiment_report_v0", record
+        assert record["benchmark_experiment_report"]["schema_version"] == "benchmark_experiment_report_v0", record
+        assert_no_private_surface(record["benchmark_experiment_report"])
+
+        status = collect_status(
+            registry_path=registry_path,
+            runtime_root_override=str(runtime),
+            scan_roots=[],
+            limit=10,
+        )
+        assert status["ok"], status
+        latest_runs = status["run_history"]["goals"][0]["latest_runs"]
+        report_run = next(run for run in latest_runs if run.get("classification") == "benchmark_experiment_report_v0")
+        report_summary = report_run["benchmark_experiment_report_summary"]
+        assert report_summary["schema_version"] == "benchmark_experiment_report_v0", report_summary
+        identity = report_summary["experiment_identity"]
+        assert identity["report_id"] == "mini-control-plane-repair-report-v0", report_summary
+        official = report_summary["official_score"]
+        assert official["delta"] == 0.0, official
+        assert official["submit_eligible"] is False, official
+        assert official["leaderboard_evidence"] is False, official
+        negative = report_summary["negative_results"]
+        assert negative["null_official_delta"] is True, negative
+        assert set(negative["negative_evidence_layers"]) == {"readiness_only", "failure_analysis"}, negative
+        next_decision = report_summary["next_decision"]
+        assert next_decision["decision"] == "continue", next_decision
+        assert next_decision["source_decision_note_schema"] == "benchmark_comparison_decision_note_v0", next_decision
+        boundary = report_summary["claim_boundary"]
+        assert "official leaderboard uplift" in boundary["must_not_claim"], boundary
+        assert_no_private_surface(report_summary)
+
+        packet = build_review_packet(status, goal_id=GOAL_ID)
+        handoff = packet["project_agent_handoff"]
+        assert "report=mini-control-plane-repair-report-v0" in handoff, handoff
+        assert "report_decision=continue" in handoff, handoff
+        assert "negative_layers=readiness_only,failure_analysis" in handoff, handoff
+        assert_no_private_surface({"handoff": handoff})
+
+    print("benchmark-experiment-report-append-cli-smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -37,11 +37,13 @@ from .handoff_budget import build_handoff_interface_budget
 from .heartbeat_prompt import build_heartbeat_prompt, render_heartbeat_prompt_markdown
 from .history import (
     append_benchmark_comparison,
+    append_benchmark_experiment_report,
     append_benchmark_result,
     append_benchmark_run,
     collect_history,
     load_registry,
     render_benchmark_comparison_append_markdown,
+    render_benchmark_experiment_report_append_markdown,
     render_benchmark_result_append_markdown,
     render_benchmark_run_append_markdown,
     render_history_markdown,
@@ -87,6 +89,7 @@ from .state_refresh import (
 from .status import (
     collect_status,
     compact_benchmark_comparison,
+    compact_benchmark_experiment_report,
     compact_benchmark_result,
     compact_benchmark_run,
     render_status_markdown,
@@ -459,8 +462,13 @@ def main(argv: list[str] | None = None) -> int:
     history_parser.add_argument(
         "history_action",
         nargs="?",
-        choices=["append-benchmark-run", "append-benchmark-result", "append-benchmark-comparison"],
-        help="Append a compact benchmark_run_v0, benchmark_result_v0, or benchmark_comparison_v0 event.",
+        choices=[
+            "append-benchmark-run",
+            "append-benchmark-result",
+            "append-benchmark-comparison",
+            "append-benchmark-report",
+        ],
+        help="Append a compact benchmark_run_v0, benchmark_result_v0, benchmark_comparison_v0, or benchmark_experiment_report_v0 event.",
     )
     history_parser.add_argument("--goal-id", help="Only show one goal.")
     history_parser.add_argument("--limit", type=int, default=10)
@@ -475,6 +483,10 @@ def main(argv: list[str] | None = None) -> int:
     history_parser.add_argument(
         "--benchmark-comparison-json",
         help="Path to a benchmark_comparison_v0 JSON object. Use '-' to read stdin.",
+    )
+    history_parser.add_argument(
+        "--benchmark-report-json",
+        help="Path to a benchmark_experiment_report_v0 JSON object. Use '-' to read stdin.",
     )
     history_parser.add_argument("--classification")
     history_parser.add_argument(
@@ -1303,6 +1315,69 @@ def main(argv: list[str] | None = None) -> int:
                     "error": str(exc),
                 }
             print_payload(payload, args.format, render_benchmark_comparison_append_markdown)
+            return 0 if payload.get("ok") else 1
+
+        if args.history_action == "append-benchmark-report":
+            try:
+                if args.dry_run and args.execute:
+                    raise ValueError("history append-benchmark-report accepts either --dry-run or --execute, not both")
+                if not args.goal_id:
+                    raise ValueError("history append-benchmark-report requires --goal-id")
+                if not args.benchmark_report_json:
+                    raise ValueError("history append-benchmark-report requires --benchmark-report-json")
+
+                if args.benchmark_report_json == "-":
+                    benchmark_report_input = json.loads(sys.stdin.read())
+                else:
+                    benchmark_report_input = json.loads(
+                        Path(args.benchmark_report_json).expanduser().read_text(encoding="utf-8")
+                    )
+                if not isinstance(benchmark_report_input, dict):
+                    raise ValueError("--benchmark-report-json must contain a JSON object")
+                benchmark_report = compact_benchmark_experiment_report(benchmark_report_input)
+                if not benchmark_report:
+                    raise ValueError(
+                        "--benchmark-report-json did not contain a compactable benchmark_experiment_report_v0 object"
+                    )
+
+                dry_run = not bool(args.execute)
+                payload = append_benchmark_experiment_report(
+                    registry_path=registry_path,
+                    runtime_root_override=args.runtime_root,
+                    goal_id=args.goal_id,
+                    benchmark_experiment_report=benchmark_report,
+                    classification=args.classification or "benchmark_experiment_report_v0",
+                    recommended_action=args.recommended_action,
+                    delivery_batch_scale=args.delivery_batch_scale,
+                    delivery_outcome=args.delivery_outcome,
+                    dry_run=dry_run,
+                )
+                if args.no_global_sync:
+                    payload["global_sync"] = {
+                        "ok": True,
+                        "dry_run": dry_run,
+                        "skipped": True,
+                        "reason": "disabled by --no-global-sync",
+                    }
+                else:
+                    payload["global_sync"] = sync_project_registry_to_global(
+                        registry_path=registry_path,
+                        runtime_root_override=args.runtime_root,
+                        goal_id=args.goal_id,
+                        dry_run=dry_run,
+                    )
+            except Exception as exc:
+                payload = {
+                    "ok": False,
+                    "dry_run": not bool(args.execute),
+                    "appended": False,
+                    "registry": str(registry_path),
+                    "runtime_root": args.runtime_root,
+                    "goal_id": args.goal_id,
+                    "classification": args.classification or "benchmark_experiment_report_v0",
+                    "error": str(exc),
+                }
+            print_payload(payload, args.format, render_benchmark_experiment_report_append_markdown)
             return 0 if payload.get("ok") else 1
 
         try:

--- a/goal_harness/history.py
+++ b/goal_harness/history.py
@@ -340,6 +340,79 @@ def append_benchmark_comparison(
     return payload
 
 
+def append_benchmark_experiment_report(
+    *,
+    registry_path: Path,
+    runtime_root_override: str | None,
+    goal_id: str,
+    benchmark_experiment_report: dict[str, Any],
+    classification: str = "benchmark_experiment_report_v0",
+    recommended_action: str | None = None,
+    delivery_batch_scale: str | None = None,
+    delivery_outcome: str | None = None,
+    dry_run: bool = True,
+) -> dict[str, Any]:
+    safe_goal_id = validate_goal_id_path_segment(goal_id)
+    if benchmark_experiment_report.get("schema_version") != "benchmark_experiment_report_v0":
+        raise ValueError("benchmark experiment report must have schema_version=benchmark_experiment_report_v0")
+
+    registry = load_registry(registry_path)
+    runtime_root = resolve_runtime_root(registry, runtime_root_override)
+    generated_at = now_local()
+    action = recommended_action or "inspect benchmark_experiment_report_v0 summary and continue report consumer work"
+    health_check = "benchmark_experiment_report_v0 compact event public-safe"
+
+    runs_dir = runtime_root / "goals" / safe_goal_id / "runs"
+    json_path, markdown_path = unique_run_paths(runs_dir, generated_at)
+    index_path = runs_dir / "index.jsonl"
+    record: dict[str, Any] = {
+        "generated_at": generated_at,
+        "goal_id": safe_goal_id,
+        "classification": classification,
+        "recommended_action": action,
+        "health_check": health_check,
+        "benchmark_experiment_report": benchmark_experiment_report,
+    }
+    if delivery_batch_scale:
+        record["delivery_batch_scale"] = delivery_batch_scale
+    if delivery_outcome:
+        record["delivery_outcome"] = delivery_outcome
+
+    index_record = {
+        **record,
+        "json_path": str(json_path),
+        "markdown_path": str(markdown_path),
+    }
+    payload = {
+        "ok": True,
+        "dry_run": dry_run,
+        "appended": not dry_run,
+        "registry": str(registry_path),
+        "runtime_root": str(runtime_root),
+        "goal_id": safe_goal_id,
+        "classification": classification,
+        "recommended_action": action,
+        "generated_at": generated_at,
+        "health_check": health_check,
+        "json_path": str(json_path),
+        "markdown_path": str(markdown_path),
+        "index_path": str(index_path),
+        "benchmark_experiment_report": benchmark_experiment_report,
+    }
+    if delivery_batch_scale:
+        payload["delivery_batch_scale"] = delivery_batch_scale
+    if delivery_outcome:
+        payload["delivery_outcome"] = delivery_outcome
+
+    if not dry_run:
+        runs_dir.mkdir(parents=True, exist_ok=True)
+        json_path.write_text(json.dumps(record, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        markdown_path.write_text(render_benchmark_experiment_report_append_markdown(payload) + "\n", encoding="utf-8")
+        with index_path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(index_record, ensure_ascii=False) + "\n")
+    return payload
+
+
 def latest_status_run(runs: list[dict[str, Any]]) -> dict[str, Any] | None:
     for run in runs:
         if str(run.get("classification") or "") in STATUS_NEUTRAL_CLASSIFICATIONS:
@@ -594,6 +667,70 @@ def render_benchmark_comparison_append_markdown(payload: dict[str, Any]) -> str:
                 f"- official_task_score_delta: `{benchmark_comparison.get('official_task_score_delta')}`",
                 f"- control_plane_score_delta: `{benchmark_comparison.get('control_plane_score_delta')}`",
                 f"- both_success: `{benchmark_comparison.get('both_success')}`",
+            ]
+        )
+    if payload.get("error"):
+        lines.append(f"- error: {payload.get('error')}")
+    return "\n".join(lines)
+
+
+def render_benchmark_experiment_report_append_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Goal Harness Benchmark Experiment Report Append",
+        "",
+        f"- ok: `{payload.get('ok')}`",
+        f"- dry_run: `{payload.get('dry_run')}`",
+        f"- appended: `{payload.get('appended')}`",
+        f"- goal_id: `{payload.get('goal_id')}`",
+        f"- classification: `{payload.get('classification')}`",
+        f"- generated_at: `{payload.get('generated_at')}`",
+    ]
+    if payload.get("json_path"):
+        lines.append(f"- json_path: `{payload.get('json_path')}`")
+    if payload.get("index_path"):
+        lines.append(f"- index_path: `{payload.get('index_path')}`")
+    if payload.get("recommended_action"):
+        lines.append(f"- recommended_action: {payload.get('recommended_action')}")
+    benchmark_report = (
+        payload.get("benchmark_experiment_report")
+        if isinstance(payload.get("benchmark_experiment_report"), dict)
+        else {}
+    )
+    if benchmark_report:
+        identity = (
+            benchmark_report.get("experiment_identity")
+            if isinstance(benchmark_report.get("experiment_identity"), dict)
+            else {}
+        )
+        official = (
+            benchmark_report.get("official_score")
+            if isinstance(benchmark_report.get("official_score"), dict)
+            else {}
+        )
+        negative = (
+            benchmark_report.get("negative_results")
+            if isinstance(benchmark_report.get("negative_results"), dict)
+            else {}
+        )
+        next_decision = (
+            benchmark_report.get("next_decision")
+            if isinstance(benchmark_report.get("next_decision"), dict)
+            else {}
+        )
+        lines.extend(
+            [
+                "",
+                "## Benchmark Experiment Report",
+                "",
+                f"- schema_version: `{benchmark_report.get('schema_version')}`",
+                f"- report_id: `{identity.get('report_id')}`",
+                f"- benchmark_id: `{identity.get('benchmark_id')}`",
+                f"- official_delta: `{official.get('delta')}`",
+                f"- submit_eligible: `{official.get('submit_eligible')}`",
+                f"- leaderboard_evidence: `{official.get('leaderboard_evidence')}`",
+                f"- null_official_delta: `{negative.get('null_official_delta')}`",
+                f"- negative_evidence_layers: `{negative.get('negative_evidence_layers')}`",
+                f"- next_decision: `{next_decision.get('decision')}`",
             ]
         )
     if payload.get("error"):

--- a/goal_harness/review_packet.py
+++ b/goal_harness/review_packet.py
@@ -379,8 +379,43 @@ def handoff_followthrough_summary(item: dict[str, Any] | None) -> str | None:
             f"layer={benchmark_decision.get('evidence_layer') or 'unknown'}",
         ]
         benchmark_decision_text = "; " + ", ".join(decision_parts)
+    benchmark_report = (
+        latest_run.get("benchmark_experiment_report_summary")
+        if isinstance(latest_run.get("benchmark_experiment_report_summary"), dict)
+        else {}
+    )
+    benchmark_report_text = ""
+    if benchmark_report:
+        identity = (
+            benchmark_report.get("experiment_identity")
+            if isinstance(benchmark_report.get("experiment_identity"), dict)
+            else {}
+        )
+        next_decision = (
+            benchmark_report.get("next_decision")
+            if isinstance(benchmark_report.get("next_decision"), dict)
+            else {}
+        )
+        negative = (
+            benchmark_report.get("negative_results")
+            if isinstance(benchmark_report.get("negative_results"), dict)
+            else {}
+        )
+        layers = (
+            negative.get("negative_evidence_layers")
+            if isinstance(negative.get("negative_evidence_layers"), list)
+            else []
+        )
+        report_parts = [
+            f"report={identity.get('report_id') or identity.get('task_slice') or 'unknown'}",
+        ]
+        if next_decision.get("decision"):
+            report_parts.append(f"report_decision={next_decision.get('decision')}")
+        if layers:
+            report_parts.append(f"negative_layers={','.join(str(layer) for layer in layers[:2])}")
+        benchmark_report_text = "; " + ", ".join(report_parts)
     return compact_packet_text(
-        f"post_handoff_run={classification}, scale={scale}{streak_text}{suffix}{benchmark_text}{benchmark_result_text}{benchmark_comparison_text}{benchmark_decision_text}",
+        f"post_handoff_run={classification}, scale={scale}{streak_text}{suffix}{benchmark_text}{benchmark_result_text}{benchmark_comparison_text}{benchmark_decision_text}{benchmark_report_text}",
         limit=260,
     )
 

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -83,6 +83,7 @@ BENCHMARK_RUN_SCHEMA_VERSION = "benchmark_run_v0"
 BENCHMARK_RESULT_SCHEMA_VERSION = "benchmark_result_v0"
 BENCHMARK_COMPARISON_SCHEMA_VERSION = "benchmark_comparison_v0"
 BENCHMARK_COMPARISON_DECISION_SCHEMA_VERSION = "benchmark_comparison_decision_note_v0"
+BENCHMARK_EXPERIMENT_REPORT_SCHEMA_VERSION = "benchmark_experiment_report_v0"
 CONTROL_PLANE_SCORE_SCHEMA_VERSION = "control_plane_score_core_v0"
 CONTROL_PLANE_SCORE_COMPONENTS = (
     "restartability",
@@ -781,6 +782,177 @@ def benchmark_comparison_decision_note(comparison: dict[str, Any] | None) -> dic
     elif isinstance(comparison.get("control_plane_score_delta"), str):
         note["control_plane_score_delta"] = public_safe_compact_text(comparison.get("control_plane_score_delta"), limit=120)
     return note
+
+
+def _benchmark_experiment_report_source(run: dict[str, Any]) -> dict[str, Any] | None:
+    nested = run.get("benchmark_experiment_report")
+    if isinstance(nested, dict) and nested.get("schema_version") == BENCHMARK_EXPERIMENT_REPORT_SCHEMA_VERSION:
+        return nested
+    legacy_nested = run.get("benchmark_report")
+    if isinstance(legacy_nested, dict) and legacy_nested.get("schema_version") == BENCHMARK_EXPERIMENT_REPORT_SCHEMA_VERSION:
+        return legacy_nested
+    if run.get("schema_version") == BENCHMARK_EXPERIMENT_REPORT_SCHEMA_VERSION:
+        return run
+    return None
+
+
+def compact_benchmark_experiment_report(run: dict[str, Any]) -> dict[str, Any] | None:
+    source = _benchmark_experiment_report_source(run)
+    if not source:
+        return None
+
+    compact: dict[str, Any] = {"schema_version": BENCHMARK_EXPERIMENT_REPORT_SCHEMA_VERSION}
+
+    identity = source.get("experiment_identity") if isinstance(source.get("experiment_identity"), dict) else {}
+    compact_identity: dict[str, Any] = {}
+    for field in (
+        "report_id",
+        "benchmark_id",
+        "task_slice",
+        "worker_surface",
+        "harness_identity",
+        "harness_policy_version",
+        "trace_publicness",
+    ):
+        value = public_safe_compact_text(identity.get(field), limit=140)
+        if value:
+            compact_identity[field] = value
+    if compact_identity:
+        compact["experiment_identity"] = compact_identity
+
+    official = source.get("official_score") if isinstance(source.get("official_score"), dict) else {}
+    compact_official: dict[str, Any] = {}
+    for field in ("kind", "task_id_or_split", "runner_source"):
+        value = public_safe_compact_text(official.get(field), limit=140)
+        if value:
+            compact_official[field] = value
+    compact_official.update(
+        _compact_numeric_map(
+            official,
+            keys=("native_score", "wrapped_score", "delta", "repetitions"),
+        )
+    )
+    for field in ("submit_eligible", "leaderboard_evidence"):
+        if isinstance(official.get(field), bool):
+            compact_official[field] = official.get(field)
+    if compact_official:
+        compact["official_score"] = compact_official
+
+    passive = (
+        source.get("passive_control_plane_score")
+        if isinstance(source.get("passive_control_plane_score"), dict)
+        else {}
+    )
+    compact_passive = _compact_numeric_map(
+        passive,
+        keys=(
+            "restartability",
+            "stale_state_avoidance",
+            "evidence_discipline",
+            "writeback_quality",
+            "failure_attribution",
+        ),
+    )
+    for field in ("overhead_bounded", "regression_avoidance_passed"):
+        if isinstance(passive.get(field), bool):
+            compact_passive[field] = passive.get(field)
+    passive_events = public_safe_compact_list(passive.get("source_events"), limit=MAX_BENCHMARK_RUN_LIST_ITEMS)
+    if passive_events:
+        compact_passive["source_events"] = passive_events
+    if compact_passive:
+        compact["passive_control_plane_score"] = compact_passive
+
+    simulator = (
+        source.get("operator_simulator_ablation")
+        if isinstance(source.get("operator_simulator_ablation"), dict)
+        else {}
+    )
+    compact_simulator: dict[str, Any] = {}
+    for field in ("enabled", "leaderboard_evidence"):
+        if isinstance(simulator.get(field), bool):
+            compact_simulator[field] = simulator.get(field)
+    compact_simulator.update(_compact_numeric_map(simulator, keys=("intervention_count",)))
+    reason = public_safe_compact_text(simulator.get("reason"), limit=180)
+    if reason:
+        compact_simulator["reason"] = reason
+    if compact_simulator:
+        compact["operator_simulator_ablation"] = compact_simulator
+
+    claim_boundary = source.get("claim_boundary") if isinstance(source.get("claim_boundary"), dict) else {}
+    compact_boundary: dict[str, Any] = {}
+    for field in ("may_claim", "must_not_claim"):
+        values = public_safe_compact_list(claim_boundary.get(field), limit=MAX_BENCHMARK_RUN_LIST_ITEMS)
+        if values:
+            compact_boundary[field] = values
+    for field in ("source_decision_note_schema", "source_evidence_layer"):
+        value = public_safe_compact_text(claim_boundary.get(field), limit=120)
+        if value:
+            compact_boundary[field] = value
+    if compact_boundary:
+        compact["claim_boundary"] = compact_boundary
+
+    negative = source.get("negative_results") if isinstance(source.get("negative_results"), dict) else {}
+    compact_negative: dict[str, Any] = {}
+    if isinstance(negative.get("null_official_delta"), bool):
+        compact_negative["null_official_delta"] = negative.get("null_official_delta")
+    existing_layers = public_safe_compact_list(negative.get("negative_evidence_layers"), limit=MAX_BENCHMARK_RUN_LIST_ITEMS)
+    failed_hypotheses = negative.get("failed_hypotheses") if isinstance(negative.get("failed_hypotheses"), list) else []
+    layers: list[str] = list(existing_layers)
+    for item in failed_hypotheses:
+        if not isinstance(item, dict):
+            continue
+        layer = public_safe_compact_text(item.get("evidence_layer"), limit=120)
+        if layer and layer not in layers:
+            layers.append(layer)
+        if len(layers) >= MAX_BENCHMARK_RUN_LIST_ITEMS:
+            break
+    if failed_hypotheses:
+        compact_negative["failed_hypothesis_count"] = len(failed_hypotheses)
+    elif isinstance(negative.get("failed_hypothesis_count"), int):
+        compact_negative["failed_hypothesis_count"] = negative.get("failed_hypothesis_count")
+    if layers:
+        compact_negative["negative_evidence_layers"] = layers
+    overhead_regressions = negative.get("overhead_regressions")
+    if isinstance(overhead_regressions, list):
+        compact_negative["overhead_regression_count"] = len(overhead_regressions)
+    elif isinstance(negative.get("overhead_regression_count"), int):
+        compact_negative["overhead_regression_count"] = negative.get("overhead_regression_count")
+    if compact_negative:
+        compact["negative_results"] = compact_negative
+
+    next_decision = source.get("next_decision") if isinstance(source.get("next_decision"), dict) else {}
+    compact_next: dict[str, Any] = {}
+    for field in (
+        "decision",
+        "minimum_next_evidence",
+        "stop_condition",
+        "source_decision_note_schema",
+        "readiness_decision",
+        "failure_decision",
+    ):
+        value = public_safe_compact_text(next_decision.get(field), limit=180)
+        if value:
+            compact_next[field] = value
+    if compact_next:
+        compact["next_decision"] = compact_next
+
+    report_sections = (
+        "experiment_identity",
+        "official_score",
+        "passive_control_plane_score",
+        "operator_simulator_ablation",
+        "cost_latency_overhead",
+        "failure_taxonomy",
+        "reproducibility_artifacts",
+        "claim_boundary",
+        "negative_results",
+        "next_decision",
+    )
+    compact["section_count"] = sum(1 for section in report_sections if isinstance(source.get(section), dict))
+
+    if set(compact.keys()) == {"schema_version", "section_count"}:
+        return None
+    return compact
 
 
 def parse_state_frontmatter(state_text: str) -> dict[str, str]:
@@ -1763,6 +1935,9 @@ def compact_post_handoff_run(run: dict[str, Any], profile: dict[str, Any] | None
         decision_note = benchmark_comparison_decision_note(benchmark_comparison)
         if decision_note:
             compact["benchmark_comparison_decision_note"] = decision_note
+    benchmark_report = compact_benchmark_experiment_report(run)
+    if benchmark_report:
+        compact["benchmark_experiment_report_summary"] = benchmark_report
     return compact
 
 
@@ -3016,6 +3191,9 @@ def compact_run(run: dict[str, Any]) -> dict[str, Any]:
         decision_note = benchmark_comparison_decision_note(benchmark_comparison)
         if decision_note:
             compact["benchmark_comparison_decision_note"] = decision_note
+    benchmark_report = compact_benchmark_experiment_report(run)
+    if benchmark_report:
+        compact["benchmark_experiment_report_summary"] = benchmark_report
     return compact
 
 
@@ -3134,7 +3312,12 @@ def event_ledger_event_class(run: dict[str, Any]) -> str:
     classification = str(run.get("classification") or "").lower()
     if classification == "quota_slot_spent" or isinstance(run.get("quota_event"), dict):
         return "accounting"
-    if compact_benchmark_run(run) or compact_benchmark_result(run) or compact_benchmark_comparison(run):
+    if (
+        compact_benchmark_run(run)
+        or compact_benchmark_result(run)
+        or compact_benchmark_comparison(run)
+        or compact_benchmark_experiment_report(run)
+    ):
         return "evidence"
     if (
         classification in EVENT_LEDGER_DECISION_CLASSIFICATIONS


### PR DESCRIPTION
## Summary
- add dry-run-by-default `history append-benchmark-report` for compact `benchmark_experiment_report_v0` rows
- project report summaries through status/latest-run and review-packet handoff
- document the report append contract and add deterministic smoke coverage

## Validation
- `python3 examples/benchmark-experiment-report-append-cli-smoke.py`
- `python3 examples/benchmark-experiment-report-template-smoke.py`
- `python3 examples/benchmark-run-v0-append-cli-smoke.py`
- `python3 examples/review-packet-cli-smoke.py`
- `python3 -m py_compile goal_harness/status.py goal_harness/history.py goal_harness/cli.py goal_harness/review_packet.py examples/benchmark-experiment-report-append-cli-smoke.py`
- `git diff --check`
- `python3 examples/run-smokes.py`
- `goal-harness-canary check`
- staged added-line sensitive marker scan

## Boundary
- fixture/compact projection only
- no real benchmark execution, model/simulator calls, private traces, raw runner logs, or leaderboard submission claims