### PR TITLE
Add benchmark report replay decision

### DIFF
--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -1511,6 +1511,14 @@ exist, and it must keep raw benchmark logs, local artifact paths, private
 traces, Codex session transcripts, credentials, and submission artifacts out of
 status and review packets.
 
+Status may also derive `benchmark_experiment_report_replay_decision` from the
+readiness note. This is the smallest next-run summary a worker should need
+before deciding whether to replay a fixture, ask for operator review, or defer.
+It is intentionally a status/review-packet-only consumer of an already durable
+run-history report event; it does not create runner authority, execute
+benchmarks, call model APIs, enable simulator work, or authorize leaderboard
+publication.
+
 ## Promotion Readiness Summary
 
 `promotion_readiness_summary` is an optional release-control projection over the

--- a/examples/benchmark-experiment-report-append-cli-smoke.py
+++ b/examples/benchmark-experiment-report-append-cli-smoke.py
@@ -221,12 +221,28 @@ def main() -> None:
         assert "official leaderboard uplift" in readiness_note["must_not_claim"], readiness_note
         assert_no_private_surface(readiness_note)
 
+        replay_decision = report_run["benchmark_experiment_report_replay_decision"]
+        assert replay_decision["schema_version"] == "benchmark_experiment_report_replay_decision_v0", replay_decision
+        assert replay_decision["source_schema_version"] == "benchmark_experiment_report_readiness_note_v0", replay_decision
+        assert replay_decision["readiness"] == "negative_or_control_plane_only", replay_decision
+        assert replay_decision["authorization"] == "fixture_only", replay_decision
+        assert replay_decision["replay_decision"] == "continue_fixture_replay", replay_decision
+        assert replay_decision["next_run_mode"] == "fixture_replay", replay_decision
+        assert replay_decision["surface"] == "status_review_packet_only", replay_decision
+        assert replay_decision["report_id"] == "mini-control-plane-repair-report-v0", replay_decision
+        assert replay_decision["task_slice"] == "mini_control_plane_repair_v0", replay_decision
+        assert set(replay_decision["negative_evidence_layers"]) == {"readiness_only", "failure_analysis"}, replay_decision
+        assert "official leaderboard uplift" in replay_decision["must_not_claim"], replay_decision
+        assert_no_private_surface(replay_decision)
+
         packet = build_review_packet(status, goal_id=GOAL_ID)
         handoff = packet["project_agent_handoff"]
         assert "report=mini-control-plane-repair-report-v0" in handoff, handoff
         assert "report_decision=continue" in handoff, handoff
         assert "readiness=negative_or_control_plane_only" in handoff, handoff
         assert "next_run=fixture_only" in handoff, handoff
+        assert "replay=continue_fixture_replay" in handoff, handoff
+        assert "mode=fixture_replay" in handoff, handoff
         assert "negative_layers=readiness_only,failure_analysis" in handoff, handoff
         assert_no_private_surface({"handoff": handoff})
 

--- a/goal_harness/review_packet.py
+++ b/goal_harness/review_packet.py
@@ -391,6 +391,11 @@ def handoff_followthrough_summary(item: dict[str, Any] | None) -> str | None:
             if isinstance(latest_run.get("benchmark_experiment_report_readiness_note"), dict)
             else {}
         )
+        benchmark_report_replay = (
+            latest_run.get("benchmark_experiment_report_replay_decision")
+            if isinstance(latest_run.get("benchmark_experiment_report_replay_decision"), dict)
+            else {}
+        )
         identity = (
             benchmark_report.get("experiment_identity")
             if isinstance(benchmark_report.get("experiment_identity"), dict)
@@ -420,12 +425,16 @@ def handoff_followthrough_summary(item: dict[str, Any] | None) -> str | None:
             report_parts.append(f"readiness={benchmark_report_readiness.get('readiness')}")
         if benchmark_report_readiness.get("next_run_authorization"):
             report_parts.append(f"next_run={benchmark_report_readiness.get('next_run_authorization')}")
+        if benchmark_report_replay.get("replay_decision"):
+            report_parts.append(f"replay={benchmark_report_replay.get('replay_decision')}")
+        if benchmark_report_replay.get("next_run_mode"):
+            report_parts.append(f"mode={benchmark_report_replay.get('next_run_mode')}")
         if layers:
             report_parts.append(f"negative_layers={','.join(str(layer) for layer in layers[:2])}")
         benchmark_report_text = "; " + ", ".join(report_parts)
     return compact_packet_text(
         f"post_handoff_run={classification}, scale={scale}{streak_text}{suffix}{benchmark_text}{benchmark_result_text}{benchmark_comparison_text}{benchmark_decision_text}{benchmark_report_text}",
-        limit=320,
+        limit=380,
     )
 
 

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -85,6 +85,7 @@ BENCHMARK_COMPARISON_SCHEMA_VERSION = "benchmark_comparison_v0"
 BENCHMARK_COMPARISON_DECISION_SCHEMA_VERSION = "benchmark_comparison_decision_note_v0"
 BENCHMARK_EXPERIMENT_REPORT_SCHEMA_VERSION = "benchmark_experiment_report_v0"
 BENCHMARK_EXPERIMENT_REPORT_READINESS_SCHEMA_VERSION = "benchmark_experiment_report_readiness_note_v0"
+BENCHMARK_EXPERIMENT_REPORT_REPLAY_DECISION_SCHEMA_VERSION = "benchmark_experiment_report_replay_decision_v0"
 CONTROL_PLANE_SCORE_SCHEMA_VERSION = "control_plane_score_core_v0"
 CONTROL_PLANE_SCORE_COMPONENTS = (
     "restartability",
@@ -1043,6 +1044,70 @@ def benchmark_experiment_report_readiness_note(report: dict[str, Any] | None) ->
         if isinstance(value, bool):
             note[field] = value
     return note
+
+
+def benchmark_experiment_report_replay_decision(readiness_note: dict[str, Any] | None) -> dict[str, Any] | None:
+    if (
+        not isinstance(readiness_note, dict)
+        or readiness_note.get("schema_version") != BENCHMARK_EXPERIMENT_REPORT_READINESS_SCHEMA_VERSION
+    ):
+        return None
+
+    readiness = public_safe_compact_text(readiness_note.get("readiness"), limit=120) or "fixture_ready"
+    authorization = public_safe_compact_text(readiness_note.get("next_run_authorization"), limit=120) or "fixture_only"
+    report_decision = public_safe_compact_text(readiness_note.get("report_decision"), limit=80) or "continue"
+
+    if authorization == "fixture_only":
+        replay_decision = "continue_fixture_replay" if report_decision in {"continue", "broaden"} else "repeat_fixture_replay"
+        next_run_mode = "fixture_replay"
+    elif authorization == "requires_operator_approval":
+        replay_decision = "operator_review_required"
+        next_run_mode = "operator_review"
+    else:
+        replay_decision = "defer_until_authorized"
+        next_run_mode = "deferred"
+
+    if readiness == "assisted_mode_separate":
+        replay_decision = "separate_assisted_mode_before_replay"
+        next_run_mode = "operator_review"
+
+    minimum_next_evidence = public_safe_compact_text(
+        readiness_note.get("minimum_next_evidence"),
+        limit=180,
+    ) or "boundary-preserving replay decision evidence"
+    stop_condition = public_safe_compact_text(readiness_note.get("stop_condition"), limit=180) or (
+        "stop before real benchmark execution, model-backed simulator work, private traces, "
+        "or leaderboard claims without explicit approval"
+    )
+    negative_layers = public_safe_compact_list(
+        readiness_note.get("negative_evidence_layers"),
+        limit=MAX_BENCHMARK_RUN_LIST_ITEMS,
+    )
+    must_not_claim = public_safe_compact_list(
+        readiness_note.get("must_not_claim"),
+        limit=MAX_BENCHMARK_RUN_LIST_ITEMS,
+    )
+
+    decision: dict[str, Any] = {
+        "schema_version": BENCHMARK_EXPERIMENT_REPORT_REPLAY_DECISION_SCHEMA_VERSION,
+        "source_schema_version": BENCHMARK_EXPERIMENT_REPORT_READINESS_SCHEMA_VERSION,
+        "readiness": readiness,
+        "authorization": authorization,
+        "replay_decision": replay_decision,
+        "next_run_mode": next_run_mode,
+        "minimum_next_evidence": minimum_next_evidence,
+        "stop_condition": stop_condition,
+        "surface": "status_review_packet_only",
+    }
+    for field in ("report_id", "benchmark_id", "task_slice"):
+        value = public_safe_compact_text(readiness_note.get(field), limit=140)
+        if value:
+            decision[field] = value
+    if negative_layers:
+        decision["negative_evidence_layers"] = negative_layers
+    if must_not_claim:
+        decision["must_not_claim"] = must_not_claim
+    return decision
 
 
 def parse_state_frontmatter(state_text: str) -> dict[str, str]:
@@ -2031,6 +2096,9 @@ def compact_post_handoff_run(run: dict[str, Any], profile: dict[str, Any] | None
         readiness_note = benchmark_experiment_report_readiness_note(benchmark_report)
         if readiness_note:
             compact["benchmark_experiment_report_readiness_note"] = readiness_note
+            replay_decision = benchmark_experiment_report_replay_decision(readiness_note)
+            if replay_decision:
+                compact["benchmark_experiment_report_replay_decision"] = replay_decision
     return compact
 
 
@@ -3290,6 +3358,9 @@ def compact_run(run: dict[str, Any]) -> dict[str, Any]:
         readiness_note = benchmark_experiment_report_readiness_note(benchmark_report)
         if readiness_note:
             compact["benchmark_experiment_report_readiness_note"] = readiness_note
+            replay_decision = benchmark_experiment_report_replay_decision(readiness_note)
+            if replay_decision:
+                compact["benchmark_experiment_report_replay_decision"] = replay_decision
     return compact
 
 


### PR DESCRIPTION
## Summary
- derive benchmark_experiment_report_replay_decision from benchmark report readiness notes
- expose replay decision and next-run mode in review-packet handoff summaries
- document the status contract and extend the benchmark report append smoke

## Validation
- python3 examples/benchmark-experiment-report-append-cli-smoke.py
- python3 examples/benchmark-experiment-report-template-smoke.py
- python3 examples/review-packet-cli-smoke.py
- python3 -m py_compile goal_harness/status.py goal_harness/review_packet.py examples/benchmark-experiment-report-append-cli-smoke.py
- git diff --check
- python3 examples/run-smokes.py
- env PATH="/Users/bytedance/.local/bin:/Users/bytedance/.cargo/bin:/Users/bytedance/.codex/tmp/arg0/codex-arg0kr5Yf6:/usr/bin:/bin:/usr/sbin:/sbin:/Applications/Codex.app/Contents/Resources" goal-harness-canary check
- staged added-line sensitive marker scan: no matches