### PR TITLE
Add benchmark report chain map

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/README.md
+++ b/docs/research/long-horizon-agent-benchmarks/README.md
@@ -49,6 +49,13 @@ work still belongs in the existing code, examples, and contract documents:
   passive control-plane metrics, assisted operator-simulator ablations,
   overhead, failure taxonomy, reproducibility artifacts, claim boundaries, and
   negative results in separate report sections.
+- `benchmark-report-chain-map-v0.md`: compact reviewer-facing chain map that
+  ties `benchmark_run_v0`, `benchmark_result_v0`, `benchmark_comparison_v0`,
+  `benchmark_comparison_decision_note_v0`,
+  `benchmark_experiment_report_v0`,
+  `benchmark_experiment_report_readiness_note_v0`, and
+  `benchmark_experiment_report_replay_decision_v0` into one fixture/status
+  handoff boundary.
 - `benchmark-result-control-plane-score-v0.md`: minimal
   `control_plane_score_core_v0` schema for `benchmark_result_v0`, separating
   official task score from restartability, stale-state avoidance, evidence

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-report-chain-map-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-report-chain-map-v0.md
@@ -1,0 +1,74 @@
+# Benchmark Report Chain Map V0
+
+Checked at: 2026-06-08T01:45:00+08:00.
+
+This map is the compact reviewer handoff for the deterministic benchmark
+reporting pipeline. It ties the existing fixture-backed event and consumer
+schemas into one chain so a future worker can continue from current evidence
+without rereading every design note.
+
+It is not a benchmark result, runner setup guide, submission plan, or new status
+schema. It only names the existing public-safe reporting order and the minimum
+handoff fields that should be visible before any larger pilot is considered.
+
+## Chain Order
+
+The chain should be read in this order:
+
+1. `benchmark_run_v0`: one compact run row per benchmark mode or fixture mode.
+2. `benchmark_result_v0`: the native task-score and control-plane score shell
+   for one scenario or comparison slice.
+3. `benchmark_comparison_v0`: the paired baseline/treatment comparison with
+   separate official-score and control-plane deltas.
+4. `benchmark_comparison_decision_note_v0`: a derived claim-boundary and
+   next-decision hint from the comparison summary.
+5. `benchmark_experiment_report_v0`: the report surface that keeps official
+   score, passive control-plane score, assisted-mode state, overhead, failures,
+   reproducibility, claim boundary, negative results, and next decision apart.
+6. `benchmark_experiment_report_readiness_note_v0`: a derived readiness and
+   authorization hint from the compact report summary.
+7. `benchmark_experiment_report_replay_decision_v0`: the smallest next-run
+   decision for fixture replay, operator review, or deferral.
+
+## Reviewer Handoff Fields
+
+A compact handoff should expose these fields before a worker decides what to do
+next:
+
+| Field | Meaning |
+| --- | --- |
+| `official_score` | Whether benchmark-native score evidence exists and whether it is eligible for official comparison. |
+| `control_plane_score` | Whether Goal Harness coordination evidence exists and which dimensions it supports. |
+| `readiness` | Whether the current report is readiness-only, control-plane-only, failure-analysis, or candidate official evidence. |
+| `authorization` | Whether the next action is fixture-only, operator-review, no-submit setup, or deferred. |
+| `replay_decision` | Whether to replay a fixture, request review, defer, or stop. |
+| `next_run_mode` | The next allowed run mode, if any, expressed without private runner state. |
+| `negative_evidence_layers` | The evidence layers that currently block stronger claims. |
+| `must_not_claim` | Claims the current evidence cannot support. |
+| `stop_condition` | The condition that prevents the next worker from escalating scope. |
+
+## Boundaries
+
+This chain map is limited to fixture, status, and review-packet contracts. It
+must not:
+
+- run a real benchmark;
+- invoke Docker, cloud sandboxes, paid compute, Codex, model APIs, or simulator
+  workers;
+- read hidden tests, expected solutions, private traces, raw runner logs,
+  local artifact paths, or raw session records;
+- upload, submit, or claim leaderboard evidence;
+- replace the benchmark's native scoring protocol;
+- create a new approval path for external execution.
+
+## Acceptance
+
+The chain is acceptable when:
+
+- the seven schema nodes above appear in order;
+- README and roadmap surfaces link this map as the reviewer-facing
+  consolidation point;
+- the status contract names the map as an explanatory handoff, not a new event;
+- smoke coverage proves the map has the required fields and boundary clauses;
+- missing fields lead to a contract or fixture repair, not to real benchmark
+  execution.

--- a/docs/research/long-horizon-agent-benchmarks/roadmap.md
+++ b/docs/research/long-horizon-agent-benchmarks/roadmap.md
@@ -391,6 +391,11 @@ limitations, and benchmark-integrity safeguards. Use
 scores, passive control-plane metrics, assisted operator-simulator ablations,
 cost/latency overhead, failure taxonomy, reproducibility artifacts, claim
 boundaries, negative results, and next decisions in separate sections.
+Use `benchmark-report-chain-map-v0.md` as the reviewer-facing consolidation
+point before larger pilots: it lists the fixture-backed order from
+`benchmark_run_v0` through `benchmark_experiment_report_replay_decision_v0`,
+the fields a worker may trust, and the boundary that keeps chain repair
+separate from external benchmark execution.
 
 ## Active Agent Todo Seed
 
@@ -431,6 +436,14 @@ boundaries, negative results, and next decisions in separate sections.
   reproducibility artifacts. Completed 2026-06-07 via
   `benchmark-experiment-report-template-v0.md` and
   `benchmark-experiment-report-template-smoke.py`.
+- [x] [P2] Add the public benchmark report chain map that consolidates
+  `benchmark_run_v0`, `benchmark_result_v0`, `benchmark_comparison_v0`,
+  `benchmark_comparison_decision_note_v0`,
+  `benchmark_experiment_report_v0`,
+  `benchmark_experiment_report_readiness_note_v0`, and
+  `benchmark_experiment_report_replay_decision_v0` into one reviewer-facing
+  handoff. Completed 2026-06-08 via `benchmark-report-chain-map-v0.md` and
+  `benchmark-report-chain-map-smoke.py`.
 
 ## Non-Goals
 

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -1519,6 +1519,14 @@ run-history report event; it does not create runner authority, execute
 benchmarks, call model APIs, enable simulator work, or authorize leaderboard
 publication.
 
+`docs/research/long-horizon-agent-benchmarks/benchmark-report-chain-map-v0.md`
+is the reviewer-facing map for this reporting chain. It names the public-safe
+order from `benchmark_run_v0` through
+`benchmark_experiment_report_replay_decision_v0` and the handoff fields a
+worker may inspect. The map is explanatory only: it does not add a status
+field, append a run-history event, or create authority to execute an external
+benchmark path.
+
 ## Promotion Readiness Summary
 
 `promotion_readiness_summary` is an optional release-control projection over the

--- a/examples/benchmark-report-chain-map-smoke.py
+++ b/examples/benchmark-report-chain-map-smoke.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Smoke-test the benchmark report chain map contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TOPIC_DIR = REPO_ROOT / "docs" / "research" / "long-horizon-agent-benchmarks"
+README = TOPIC_DIR / "README.md"
+ROADMAP = TOPIC_DIR / "roadmap.md"
+CHAIN_MAP = TOPIC_DIR / "benchmark-report-chain-map-v0.md"
+STATUS_CONTRACT = REPO_ROOT / "docs" / "status-data-contract.md"
+
+SCHEMA_CHAIN = [
+    "benchmark_run_v0",
+    "benchmark_result_v0",
+    "benchmark_comparison_v0",
+    "benchmark_comparison_decision_note_v0",
+    "benchmark_experiment_report_v0",
+    "benchmark_experiment_report_readiness_note_v0",
+    "benchmark_experiment_report_replay_decision_v0",
+]
+
+HANDOFF_FIELDS = [
+    "official_score",
+    "control_plane_score",
+    "readiness",
+    "authorization",
+    "replay_decision",
+    "next_run_mode",
+    "negative_evidence_layers",
+    "must_not_claim",
+    "stop_condition",
+]
+
+BOUNDARY_SNIPPETS = [
+    "fixture, status, and review-packet contracts",
+    "run a real benchmark",
+    "model APIs",
+    "simulator",
+    "hidden tests",
+    "expected solutions",
+    "private traces",
+    "raw runner logs",
+    "local artifact paths",
+    "raw session records",
+    "leaderboard evidence",
+    "benchmark's native scoring protocol",
+    "external execution",
+]
+
+FORBIDDEN_TEXT = [
+    "/" + "Users/",
+    "/" + "tmp/",
+    "OPENAI" + "_" + "API" + "_" + "KEY",
+    "ANTHROPIC" + "_" + "API" + "_" + "KEY",
+    "DAYTONA" + "_" + "API" + "_" + "KEY",
+    "lark" + "office",
+    "fei" + "shu.cn",
+    "raw" + "_thread",
+    "session" + "_history",
+    "sk-" + "example",
+]
+
+
+def assert_ordered_chain(text: str) -> None:
+    positions = []
+    for schema in SCHEMA_CHAIN:
+        position = text.find(schema)
+        assert position >= 0, schema
+        positions.append(position)
+    assert positions == sorted(positions), positions
+
+
+def assert_no_forbidden_text(text: str) -> None:
+    leaked = [marker for marker in FORBIDDEN_TEXT if marker in text]
+    assert not leaked, leaked
+
+
+def main() -> None:
+    text = CHAIN_MAP.read_text(encoding="utf-8")
+    readme = README.read_text(encoding="utf-8")
+    roadmap = ROADMAP.read_text(encoding="utf-8")
+    status_contract = STATUS_CONTRACT.read_text(encoding="utf-8")
+
+    assert_ordered_chain(text)
+    missing_fields = [field for field in HANDOFF_FIELDS if field not in text]
+    assert not missing_fields, missing_fields
+    missing_boundaries = [snippet for snippet in BOUNDARY_SNIPPETS if snippet not in text]
+    assert not missing_boundaries, missing_boundaries
+
+    assert "benchmark-report-chain-map-v0.md" in readme
+    assert "benchmark-report-chain-map-v0.md" in roadmap
+    assert "benchmark-report-chain-map-v0.md" in status_contract
+    assert "explanatory only" in status_contract
+    assert "does not add a status" in status_contract
+    assert "field, append a run-history event" in status_contract
+
+    for artifact_text in [text, readme, roadmap]:
+        assert_no_forbidden_text(artifact_text)
+
+    print("benchmark-report-chain-map-smoke ok")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add benchmark-report-chain-map-v0 as the compact reviewer handoff for the benchmark reporting chain
- link the chain map from the long-horizon benchmark README, roadmap, and status data contract
- add benchmark-report-chain-map-smoke to lock schema order, handoff fields, and boundary clauses

## Validation
- python3 examples/benchmark-report-chain-map-smoke.py
- python3 examples/benchmark-experiment-report-append-cli-smoke.py
- python3 examples/benchmark-experiment-report-template-smoke.py
- python3 examples/long-horizon-agent-benchmark-roadmap-smoke.py
- python3 -m py_compile examples/benchmark-report-chain-map-smoke.py
- git diff --check
- python3 examples/run-smokes.py
- goal-harness-canary check
- staged sensitive marker scan

## Boundaries
- no real benchmark execution
- no model or simulator execution
- no private traces or raw runner logs
- no leaderboard claim or submission path