### PR TITLE
Add benchmark chain handoff projection

### DIFF
--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -1525,7 +1525,10 @@ order from `benchmark_run_v0` through
 `benchmark_experiment_report_replay_decision_v0` and the handoff fields a
 worker may inspect. The map is explanatory only: it does not add a status
 field, append a run-history event, or create authority to execute an external
-benchmark path.
+benchmark path. When a latest run has a replay decision, the review-packet
+handoff follow-through summary may include
+`chain_map=benchmark-report-chain-map-v0.md` so a worker can jump from the
+compact replay decision back to the full reviewer-facing chain contract.
 
 ## Promotion Readiness Summary
 

--- a/examples/benchmark-experiment-report-append-cli-smoke.py
+++ b/examples/benchmark-experiment-report-append-cli-smoke.py
@@ -243,6 +243,7 @@ def main() -> None:
         assert "next_run=fixture_only" in handoff, handoff
         assert "replay=continue_fixture_replay" in handoff, handoff
         assert "mode=fixture_replay" in handoff, handoff
+        assert "chain_map=benchmark-report-chain-map-v0.md" in handoff, handoff
         assert "negative_layers=readiness_only,failure_analysis" in handoff, handoff
         assert_no_private_surface({"handoff": handoff})
 

--- a/goal_harness/review_packet.py
+++ b/goal_harness/review_packet.py
@@ -13,6 +13,8 @@ from .execution_profile import (
 from .handoff_budget import build_handoff_interface_budget
 
 
+BENCHMARK_REPORT_CHAIN_MAP_DOC = "benchmark-report-chain-map-v0.md"
+
 LOCAL_ABSOLUTE_PATH_PATTERN = re.compile(
     r"(^|[\s`'\"=:(])(?:/[A-Za-z0-9._-]+(?:/[^\s`'\",)]+)+|[A-Za-z]:[\\/][^\s`'\",)]+)"
 )
@@ -429,12 +431,14 @@ def handoff_followthrough_summary(item: dict[str, Any] | None) -> str | None:
             report_parts.append(f"replay={benchmark_report_replay.get('replay_decision')}")
         if benchmark_report_replay.get("next_run_mode"):
             report_parts.append(f"mode={benchmark_report_replay.get('next_run_mode')}")
+        if benchmark_report_replay:
+            report_parts.append(f"chain_map={BENCHMARK_REPORT_CHAIN_MAP_DOC}")
         if layers:
             report_parts.append(f"negative_layers={','.join(str(layer) for layer in layers[:2])}")
         benchmark_report_text = "; " + ", ".join(report_parts)
     return compact_packet_text(
         f"post_handoff_run={classification}, scale={scale}{streak_text}{suffix}{benchmark_text}{benchmark_result_text}{benchmark_comparison_text}{benchmark_decision_text}{benchmark_report_text}",
-        limit=380,
+        limit=440,
     )
 
 


### PR DESCRIPTION
## Summary
- add chain_map=benchmark-report-chain-map-v0.md to benchmark report replay handoff follow-through summaries
- keep the latest replay decision and chain-map pointer together in review-packet output
- document the handoff projection in the status data contract and lock it with the benchmark report append smoke

## Validation
- python3 examples/benchmark-experiment-report-append-cli-smoke.py
- python3 examples/benchmark-report-chain-map-smoke.py
- python3 examples/review-packet-cli-smoke.py
- python3 examples/review-packet-smoke.py
- python3 examples/hot-path-interface-budget-smoke.py
- python3 -m py_compile goal_harness/review_packet.py examples/benchmark-experiment-report-append-cli-smoke.py
- git diff --check
- python3 examples/run-smokes.py
- goal-harness-canary check
- staged sensitive marker scan

## Boundaries
- no new benchmark execution path
- no model or simulator execution
- no new status event schema
- no private traces or raw runner logs
- no leaderboard claim or submission path