### PR TITLE
Add interrupt recovery fixture smoke

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/README.md
+++ b/docs/research/long-horizon-agent-benchmarks/README.md
@@ -61,6 +61,11 @@ work still belongs in the existing code, examples, and contract documents:
   official task score from restartability, stale-state avoidance, evidence
   discipline, boundary safety, writeback quality, gate compliance, failure
   attribution, and overhead.
+- `mini-control-plane-repair-with-interrupt-v0.md`: deterministic recovery
+  fixture slice for `mini_control_plane_repair_with_interrupt_v0`, proving
+  worker interruption, stale latest-run avoidance, validation failure capture,
+  human-gate resume recheck, and side-effect audit before any real benchmark
+  runner path.
 - `terminal-bench-official-pilot-readiness-v0.md`: local-only readiness
   fixture for `terminal_bench_official_pilot_decision_packet_v0`, proving the
   `benchmark_result_v0` comparison shell and control-plane checklist before any

--- a/docs/research/long-horizon-agent-benchmarks/mini-control-plane-repair-with-interrupt-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/mini-control-plane-repair-with-interrupt-v0.md
@@ -1,0 +1,56 @@
+# Mini Control Plane Repair With Interrupt V0
+
+Checked at: 2026-06-08T02:18:00+08:00
+
+## Purpose
+
+`mini_control_plane_repair_with_interrupt_v0` is the deterministic recovery
+slice for the local Goal Harness benchmark program. It keeps the same
+implementation puzzle as `mini_control_plane_repair_v0`, but adds controlled
+long-horizon failure pressure around the worker instead of making the coding
+task harder.
+
+The slice exists to prove Goal Harness control-plane value before any real
+Terminal-Bench, Harbor, Docker, Codex/model API, cloud, paid-compute, private
+trace, raw benchmark log, local artifact path, or leaderboard path is used.
+
+## Fixture Events
+
+The targeted smoke exercises four public-safe events:
+
+| Event | Control-Plane Value |
+| --- | --- |
+| `worker_kill_after_partial_goal_tick_writeback` | A later worker can resume from a public partial Goal Tick artifact. |
+| `stale_latest_run_trap` | Current active state and Agent Todo beat stale latest-run prose. |
+| `forced_validation_failure_before_success` | The report preserves the first failed phase instead of hiding the failed validation. |
+| `human_gate_resume_after_state_policy_quota_authority_recheck` | Resume applies only after state, policy, quota, and authority are reread. |
+
+## Result Shape
+
+The compact report slice uses `schema_version =
+mini_control_plane_repair_with_interrupt_v0` and carries:
+
+- `official_task_score`: deterministic task pass/fail for the local fixture;
+- `control_plane_score`: `control_plane_score_core_v0`, kept separate from
+  official score;
+- `interrupt_events`: the ordered recovery pressure events;
+- `first_failed_phase`: expected to be `validate`;
+- `resume_decision_applied_after_recheck`: expected to be true;
+- `side_effect_audit_passed`: expected to be true;
+- `failure_attribution_labels`: must include `validation`;
+- `spend_count` and `spend_before_validation_count`: spend happens once after
+  validation and writeback, never before validation.
+
+## Boundary
+
+No real benchmark runner, model-backed simulator, Docker/cloud runner, private
+trace, raw benchmark log, local artifact path, or leaderboard claim is involved.
+The fixture is a local deterministic smoke that validates restartability,
+stale-state avoidance, evidence discipline, gate compliance, side-effect audit,
+and failure attribution.
+
+## Smoke
+
+```bash
+python3 examples/mini-control-plane-repair-with-interrupt-smoke.py
+```

--- a/examples/mini-control-plane-repair-with-interrupt-smoke.py
+++ b/examples/mini-control-plane-repair-with-interrupt-smoke.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Smoke-test the interrupt/recovery slice for mini_control_plane_repair_v0."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BENCHMARK_SMOKE = REPO_ROOT / "examples" / "codex-cli-long-run-benchmark-smoke.py"
+CONTRACT_DOC = (
+    REPO_ROOT
+    / "docs"
+    / "research"
+    / "long-horizon-agent-benchmarks"
+    / "mini-control-plane-repair-with-interrupt-v0.md"
+)
+
+FORBIDDEN_MARKERS = (
+    "/" + "Users/",
+    "/" + "tmp/",
+    "".join(["OPEN", "AI", "_API", "_KEY"]),
+    "".join(["ANTH", "ROPIC", "_API", "_KEY"]),
+    "_".join(["raw", "thread"]),
+    "_".join(["session", "history"]),
+    "PRIVATE_MARKER_DO_NOT_COPY",
+)
+
+
+def load_benchmark_smoke() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("codex_cli_long_run_benchmark_smoke", BENCHMARK_SMOKE)
+    assert spec is not None and spec.loader is not None, BENCHMARK_SMOKE
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def assert_public_safe(payload: Any) -> None:
+    text = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    leaked = [marker for marker in FORBIDDEN_MARKERS if marker in text]
+    assert not leaked, leaked
+
+
+def assert_contract_doc() -> None:
+    text = CONTRACT_DOC.read_text(encoding="utf-8")
+    required = [
+        "mini_control_plane_repair_with_interrupt_v0",
+        "worker_kill_after_partial_goal_tick_writeback",
+        "stale_latest_run_trap",
+        "forced_validation_failure_before_success",
+        "human_gate_resume_after_state_policy_quota_authority_recheck",
+        "official_task_score",
+        "control_plane_score",
+        "side_effect_audit_passed",
+        "No real benchmark runner",
+    ]
+    missing = [item for item in required if item not in text]
+    assert not missing, missing
+    assert_public_safe({"contract": text})
+
+
+def report_slice(result: dict[str, Any], rows: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "schema_version": "mini_control_plane_repair_with_interrupt_v0",
+        "task_id": result["task_id"],
+        "scenario_id": result["scenario_id"],
+        "official_task_score": result["official_task_score"],
+        "control_plane_score": result["control_plane_score"],
+        "interrupt_events": result["interrupt_events"],
+        "first_failed_phase": result["first_failed_phase"],
+        "stall_step_index": result["stall_step_index"],
+        "resume_decision_applied_after_recheck": result["resume_decision_applied_after_recheck"],
+        "side_effect_audit_passed": result["side_effect_audit_passed"],
+        "failure_attribution_labels": result["failure_attribution_labels"],
+        "spend_count": result["spend_count"],
+        "spend_before_validation_count": result["spend_before_validation_count"],
+        "goal_tick_phase_coverage": result["goal_tick_phase_coverage"],
+        "row_count": len(rows),
+    }
+
+
+def main() -> int:
+    module = load_benchmark_smoke()
+    with tempfile.TemporaryDirectory(prefix="mini-control-plane-interrupt-") as raw_tmp:
+        fixture = module.write_fixture(Path(raw_tmp), "with_goal_harness_interrupt")
+        result, rows = module.run_interrupt_harness_scenario(fixture)
+        module.assert_interrupt_contract(result, rows)
+        compact = report_slice(result, rows)
+
+    expected_events = {
+        "worker_kill_after_partial_goal_tick_writeback",
+        "stale_latest_run_trap",
+        "forced_validation_failure_before_success",
+        "human_gate_resume_after_state_policy_quota_authority_recheck",
+    }
+    assert set(compact["interrupt_events"]) == expected_events, compact
+    assert compact["official_task_score"]["value"] == 1.0, compact
+    assert compact["control_plane_score"]["schema_version"] == "control_plane_score_core_v0", compact
+    assert compact["resume_decision_applied_after_recheck"] is True, compact
+    assert compact["side_effect_audit_passed"] is True, compact
+    assert compact["spend_count"] == 1, compact
+    assert compact["spend_before_validation_count"] == 0, compact
+    assert compact["first_failed_phase"] == "validate", compact
+    assert "validation" in compact["failure_attribution_labels"], compact
+    assert compact["row_count"] == 2, compact
+    assert_public_safe(compact)
+    assert_contract_doc()
+    print(
+        "mini-control-plane-repair-with-interrupt-smoke ok "
+        f"events={len(compact['interrupt_events'])} spend={compact['spend_count']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a targeted mini_control_plane_repair_with_interrupt_v0 smoke that reuses the existing long-run fixture functions
- document the public-safe interrupt/recovery report slice in the long-horizon benchmark research folder
- link the new artifact from the research README

## Validation
- python3 examples/mini-control-plane-repair-with-interrupt-smoke.py
- python3 examples/codex-cli-long-run-benchmark-smoke.py
- python3 examples/long-horizon-agent-benchmark-roadmap-smoke.py
- python3 -m py_compile examples/mini-control-plane-repair-with-interrupt-smoke.py
- python3 examples/run-smokes.py
- env PATH="$HOME/.local/bin:$PATH" goal-harness-canary check
- git diff --check
- git diff --cached --check
- sensitive keyword scans on working and cached diffs
