### PR TITLE
Add interrupt comparison summary smoke

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/README.md
+++ b/docs/research/long-horizon-agent-benchmarks/README.md
@@ -66,6 +66,10 @@ work still belongs in the existing code, examples, and contract documents:
   worker interruption, stale latest-run avoidance, validation failure capture,
   human-gate resume recheck, and side-effect audit before any real benchmark
   runner path.
+- `mini-control-plane-interrupt-comparison-summary-v0.md`: compact fixture-only
+  comparison between the non-interrupt and interrupt mini control-plane repair
+  modes, preserving official-score versus control-plane-score separation and
+  claim boundaries before any status/review-packet projection.
 - `terminal-bench-official-pilot-readiness-v0.md`: local-only readiness
   fixture for `terminal_bench_official_pilot_decision_packet_v0`, proving the
   `benchmark_result_v0` comparison shell and control-plane checklist before any

--- a/docs/research/long-horizon-agent-benchmarks/mini-control-plane-interrupt-comparison-summary-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/mini-control-plane-interrupt-comparison-summary-v0.md
@@ -1,0 +1,54 @@
+# Mini Control Plane Interrupt Comparison Summary V0
+
+Checked at: 2026-06-08T02:36:00+08:00
+
+## Purpose
+
+`benchmark_interrupt_comparison_summary_v0` is a compact research summary that
+compares the existing non-interrupt `mini_control_plane_repair_v0` fixture with
+the interrupt/recovery `mini_control_plane_repair_with_interrupt_v0` fixture.
+
+The summary exists to make the control-plane evidence readable without adding a
+new CLI command, status field, or benchmark runner path. It is a fixture-only
+artifact for deciding whether this interrupt evidence should later be projected
+through status or review packets.
+
+## Summary Fields
+
+- `official_task_score_delta`: remains separate from control-plane evidence and
+  should stay zero for this local deterministic pair.
+- `control_plane_score_delta`: compares the local
+  `control_plane_score_core_v0` values between the non-interrupt and interrupt
+  fixture modes.
+- `control_plane_component_deltas`: shows which components changed under
+  interrupt pressure.
+- `restart_resume_evidence`: records interrupt events, resume-after-recheck,
+  first failed phase, side-effect audit, and spend-after-validation discipline.
+- `failure_attribution`: records new labels introduced by the interrupt slice,
+  especially validation pressure.
+- `overhead`: compares wall time, writeback count, spend count, and validation
+  failures.
+- `claim_boundary`: states what the local fixture may and must not claim.
+
+## Interpretation
+
+The useful signal is not an official score uplift. The useful signal is that the
+same local task can succeed while Goal Harness records the interruption,
+stale-state trap, validation failure, human-gate resume recheck, side-effect
+audit, and spend discipline as separate control-plane evidence.
+
+If this summary becomes useful for project agents, the next product step should
+be a compact status or review-packet projection. If not, it should remain a
+research artifact and avoid expanding the hot-path interface.
+
+## Boundary
+
+No real benchmark runner, Terminal-Bench, Harbor, Docker/cloud runner,
+Codex/model API, paid compute, private trace, raw benchmark log, local artifact
+path, model-backed simulator, or leaderboard claim is involved.
+
+## Smoke
+
+```bash
+python3 examples/mini-control-plane-interrupt-comparison-summary-smoke.py
+```

--- a/examples/mini-control-plane-interrupt-comparison-summary-smoke.py
+++ b/examples/mini-control-plane-interrupt-comparison-summary-smoke.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Smoke-test a compact interrupt versus non-interrupt comparison summary."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BENCHMARK_SMOKE = REPO_ROOT / "examples" / "codex-cli-long-run-benchmark-smoke.py"
+CONTRACT_DOC = (
+    REPO_ROOT
+    / "docs"
+    / "research"
+    / "long-horizon-agent-benchmarks"
+    / "mini-control-plane-interrupt-comparison-summary-v0.md"
+)
+
+SUMMARY_SCHEMA = "benchmark_interrupt_comparison_summary_v0"
+FORBIDDEN_MARKERS = (
+    "/" + "Users/",
+    "/" + "tmp/",
+    "".join(["OPEN", "AI", "_API", "_KEY"]),
+    "".join(["ANTH", "ROPIC", "_API", "_KEY"]),
+    "_".join(["raw", "thread"]),
+    "_".join(["session", "history"]),
+    "PRIVATE_MARKER_DO_NOT_COPY",
+)
+
+
+def load_benchmark_smoke() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("codex_cli_long_run_benchmark_smoke", BENCHMARK_SMOKE)
+    assert spec is not None and spec.loader is not None, BENCHMARK_SMOKE
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def assert_public_safe(payload: Any) -> None:
+    text = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    leaked = [marker for marker in FORBIDDEN_MARKERS if marker in text]
+    assert not leaked, leaked
+
+
+def component_deltas(baseline: dict[str, Any], interrupt: dict[str, Any]) -> dict[str, float]:
+    baseline_components = baseline["control_plane_score"]["components"]
+    interrupt_components = interrupt["control_plane_score"]["components"]
+    return {
+        component: round(interrupt_components[component] - baseline_components[component], 3)
+        for component in baseline["control_plane_score"]["component_order"]
+    }
+
+
+def comparison_summary(module: ModuleType, baseline: dict[str, Any], interrupt: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "schema_version": SUMMARY_SCHEMA,
+        "task_family": module.TASK_ID,
+        "mode_pair": [baseline["scenario_id"], interrupt["scenario_id"]],
+        "baseline_task_id": baseline["task_id"],
+        "interrupt_task_id": interrupt["task_id"],
+        "official_task_score_delta": round(
+            interrupt["official_task_score"]["value"] - baseline["official_task_score"]["value"], 3
+        ),
+        "official_scores": {
+            baseline["scenario_id"]: baseline["official_task_score"],
+            interrupt["scenario_id"]: interrupt["official_task_score"],
+        },
+        "control_plane_score_delta": round(
+            interrupt["control_plane_score"]["value"] - baseline["control_plane_score"]["value"], 3
+        ),
+        "control_plane_scores": {
+            baseline["scenario_id"]: baseline["control_plane_score"],
+            interrupt["scenario_id"]: interrupt["control_plane_score"],
+        },
+        "control_plane_component_deltas": component_deltas(baseline, interrupt),
+        "restart_resume_evidence": {
+            "interrupt_events": interrupt["interrupt_events"],
+            "resume_decision_applied_after_recheck": interrupt["resume_decision_applied_after_recheck"],
+            "first_failed_phase": interrupt["first_failed_phase"],
+            "side_effect_audit_passed": interrupt["side_effect_audit_passed"],
+            "spend_after_validation_only": interrupt["spend_count"] == 1
+            and interrupt["spend_before_validation_count"] == 0,
+        },
+        "failure_attribution": {
+            "baseline_labels": baseline["failure_attribution_labels"],
+            "interrupt_labels": interrupt["failure_attribution_labels"],
+            "new_labels": sorted(
+                set(interrupt["failure_attribution_labels"]) - set(baseline["failure_attribution_labels"])
+            ),
+        },
+        "overhead": {
+            "wall_time_ms_delta": round(interrupt["wall_time_ms"] - baseline["wall_time_ms"], 3),
+            "writeback_delta": interrupt["writeback_count"] - baseline["writeback_count"],
+            "spend_delta": interrupt["spend_count"] - baseline["spend_count"],
+            "validation_fail_delta": interrupt["validation_fail_count"] - baseline["validation_fail_count"],
+        },
+        "claim_boundary": {
+            "may_claim": [
+                "local deterministic interrupt recovery was exercised",
+                "official fixture score stayed unchanged under the interrupt slice",
+                "failure attribution records validation pressure separately from task success",
+            ],
+            "must_not_claim": [
+                "official benchmark or leaderboard uplift",
+                "model-backed simulator benefit",
+                "real Terminal-Bench or Harbor runner result",
+            ],
+        },
+        "next_decision": {
+            "decision": "keep_fixture_only_until_real_runner_or_operator_simulator_evidence_exists",
+            "minimum_next_evidence": [
+                "status_or_review_packet_projection_if_agents_need_this_summary",
+                "real no-submit runner output only after explicit operator approval",
+            ],
+        },
+    }
+
+
+def assert_summary_contract(summary: dict[str, Any]) -> None:
+    assert summary["schema_version"] == SUMMARY_SCHEMA, summary
+    assert summary["mode_pair"] == ["with_goal_harness", "with_goal_harness_interrupt"], summary
+    assert summary["baseline_task_id"] == "mini_control_plane_repair_v0", summary
+    assert summary["interrupt_task_id"] == "mini_control_plane_repair_with_interrupt_v0", summary
+    assert summary["official_task_score_delta"] == 0.0, summary
+    assert summary["control_plane_score_delta"] <= 0.0, summary
+    assert set(summary["restart_resume_evidence"]["interrupt_events"]) == {
+        "worker_kill_after_partial_goal_tick_writeback",
+        "stale_latest_run_trap",
+        "forced_validation_failure_before_success",
+        "human_gate_resume_after_state_policy_quota_authority_recheck",
+    }, summary
+    assert summary["restart_resume_evidence"]["resume_decision_applied_after_recheck"] is True, summary
+    assert summary["restart_resume_evidence"]["first_failed_phase"] == "validate", summary
+    assert summary["restart_resume_evidence"]["side_effect_audit_passed"] is True, summary
+    assert summary["restart_resume_evidence"]["spend_after_validation_only"] is True, summary
+    assert "validation" in summary["failure_attribution"]["new_labels"], summary
+    assert summary["overhead"]["validation_fail_delta"] >= 1, summary
+    assert summary["overhead"]["spend_delta"] < 0, summary
+    assert "official benchmark or leaderboard uplift" in summary["claim_boundary"]["must_not_claim"], summary
+    assert_public_safe(summary)
+
+
+def assert_contract_doc() -> None:
+    text = CONTRACT_DOC.read_text(encoding="utf-8")
+    required = [
+        SUMMARY_SCHEMA,
+        "official_task_score_delta",
+        "control_plane_score_delta",
+        "restart_resume_evidence",
+        "failure_attribution",
+        "No real benchmark runner",
+    ]
+    missing = [item for item in required if item not in text]
+    assert not missing, missing
+    assert_public_safe({"contract": text})
+
+
+def main() -> int:
+    module = load_benchmark_smoke()
+    with tempfile.TemporaryDirectory(prefix="mini-control-plane-interrupt-comparison-") as raw_tmp:
+        root = Path(raw_tmp)
+        baseline_fixture = module.write_fixture(root, "with_goal_harness")
+        without_fixture = module.write_fixture(root, "without_goal_harness")
+        interrupt_fixture = module.write_fixture(root, "with_goal_harness_interrupt")
+        baseline, baseline_rows = module.run_harness_scenario(baseline_fixture)
+        without = module.run_without_harness_scenario(without_fixture)
+        interrupt, interrupt_rows = module.run_interrupt_harness_scenario(interrupt_fixture)
+        module.assert_result_contract([baseline, without], baseline_rows, module.comparison([baseline, without]))
+        module.assert_interrupt_contract(interrupt, interrupt_rows)
+        summary = comparison_summary(module, baseline, interrupt)
+
+    assert_summary_contract(summary)
+    assert_contract_doc()
+    print(
+        "mini-control-plane-interrupt-comparison-summary-smoke ok "
+        f"official_delta={summary['official_task_score_delta']} "
+        f"control_delta={summary['control_plane_score_delta']} "
+        f"events={len(summary['restart_resume_evidence']['interrupt_events'])}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a fixture-only benchmark_interrupt_comparison_summary_v0 artifact for non-interrupt versus interrupt mini control-plane repair modes
- add a targeted smoke that verifies official score stays separate from control-plane deltas, recovery evidence, validation attribution, and claim boundaries
- link the artifact from the long-horizon benchmark research README

## Validation
- python3 examples/mini-control-plane-interrupt-comparison-summary-smoke.py
- python3 examples/mini-control-plane-repair-with-interrupt-smoke.py
- python3 examples/codex-cli-long-run-benchmark-smoke.py
- python3 examples/long-horizon-agent-benchmark-roadmap-smoke.py
- python3 examples/long-horizon-paper-runner-dossier-smoke.py
- python3 -m py_compile examples/mini-control-plane-interrupt-comparison-summary-smoke.py
- python3 examples/run-smokes.py
- env PATH="$HOME/.local/bin:$PATH" goal-harness-canary check
- git diff --check
- git diff --cached --check
- sensitive keyword scans on working and cached diffs
