### PR TITLE
Keep interrupt comparison summary research-only

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/README.md
+++ b/docs/research/long-horizon-agent-benchmarks/README.md
@@ -70,6 +70,10 @@ work still belongs in the existing code, examples, and contract documents:
   comparison between the non-interrupt and interrupt mini control-plane repair
   modes, preserving official-score versus control-plane-score separation and
   claim boundaries before any status/review-packet projection.
+- `mini-control-plane-interrupt-projection-decision-v0.md`: fixture-only
+  decision to keep `benchmark_interrupt_comparison_summary_v0` research-only
+  until a real consumer or passive benchmark run justifies status/review-packet
+  projection.
 - `terminal-bench-official-pilot-readiness-v0.md`: local-only readiness
   fixture for `terminal_bench_official_pilot_decision_packet_v0`, proving the
   `benchmark_result_v0` comparison shell and control-plane checklist before any

--- a/docs/research/long-horizon-agent-benchmarks/mini-control-plane-interrupt-projection-decision-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/mini-control-plane-interrupt-projection-decision-v0.md
@@ -1,0 +1,58 @@
+# Mini Control Plane Interrupt Projection Decision V0
+
+Checked at: 2026-06-08T02:41:00+08:00
+
+## Decision
+
+`benchmark_interrupt_comparison_summary_v0` remains research-only for now.
+
+Do not project it into Goal Harness status or review-packet hot paths until a
+project agent actually needs the signal outside the research folder, or until a
+real passive benchmark run produces comparable interrupt/recovery evidence.
+
+## Why
+
+- The summary is useful evidence, but it is still fixture-only.
+- The current hot-path review-packet handoff JSON has narrow remaining field
+  headroom, so adding a new top-level projection would increase interface
+  pressure without a demonstrated consumer.
+- The existing artifact already preserves the key signal: official score delta,
+  control-plane delta, restart/resume evidence, validation attribution, overhead,
+  and claim boundary.
+- Keeping it research-only reduces control-plane complexity while retaining a
+  clear upgrade path.
+
+## Projection Gate
+
+Project it only if one of these happens:
+
+- a project agent cannot reliably find or use the research artifact through the
+  current handoff chain;
+- a real no-submit runner output or passive benchmark run needs the same
+  interrupt summary shape;
+- repeated heartbeats show agents re-deriving the same interrupt comparison
+  instead of reusing this artifact.
+
+If the gate opens, project only a compact read-only shape:
+
+- `schema_version`;
+- `official_task_score_delta`;
+- `control_plane_score_delta`;
+- `restart_resume_evidence`;
+- `failure_attribution`;
+- `claim_boundary`.
+
+Do not add raw rows, changed files, private traces, local paths, benchmark logs,
+or leaderboard language.
+
+## Boundary
+
+No real benchmark runner, Terminal-Bench, Harbor, Docker/cloud runner,
+Codex/model API, paid compute, private trace, raw benchmark log, local artifact
+path, model-backed simulator, or leaderboard claim is involved.
+
+## Smoke
+
+```bash
+python3 examples/mini-control-plane-interrupt-projection-decision-smoke.py
+```

--- a/examples/mini-control-plane-interrupt-projection-decision-smoke.py
+++ b/examples/mini-control-plane-interrupt-projection-decision-smoke.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Smoke-test the interrupt comparison projection decision boundary."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TOPIC_DIR = REPO_ROOT / "docs" / "research" / "long-horizon-agent-benchmarks"
+README = TOPIC_DIR / "README.md"
+DECISION_DOC = TOPIC_DIR / "mini-control-plane-interrupt-projection-decision-v0.md"
+STATUS = REPO_ROOT / "goal_harness" / "status.py"
+REVIEW_PACKET = REPO_ROOT / "goal_harness" / "review_packet.py"
+HOT_PATH_SMOKE = REPO_ROOT / "examples" / "hot-path-interface-budget-smoke.py"
+
+SUMMARY_SCHEMA = "benchmark_interrupt_comparison_summary_v0"
+DECISION_DOC_NAME = "mini-control-plane-interrupt-projection-decision-v0.md"
+FORBIDDEN_TEXT = [
+    "/" + "Users/",
+    "/" + "tmp/",
+    "OPEN" + "AI" + "_API" + "_KEY",
+    "ANTH" + "ROPIC" + "_API" + "_KEY",
+    "lark" + "office",
+    "fei" + "shu.cn",
+    "raw" + "_thread",
+    "session" + "_history",
+]
+
+
+def assert_no_forbidden_text(text: str) -> None:
+    leaked = [marker for marker in FORBIDDEN_TEXT if marker in text]
+    assert not leaked, leaked
+
+
+def main() -> int:
+    doc = DECISION_DOC.read_text(encoding="utf-8")
+    readme = README.read_text(encoding="utf-8")
+    status_source = STATUS.read_text(encoding="utf-8")
+    review_source = REVIEW_PACKET.read_text(encoding="utf-8")
+    hot_path_smoke = HOT_PATH_SMOKE.read_text(encoding="utf-8")
+
+    required_doc_text = [
+        SUMMARY_SCHEMA,
+        "remains research-only for now",
+        "Do not project it into Goal Harness status or review-packet hot paths",
+        "Projection Gate",
+        "official_task_score_delta",
+        "control_plane_score_delta",
+        "restart_resume_evidence",
+        "failure_attribution",
+        "claim_boundary",
+        "No real benchmark runner",
+    ]
+    missing = [item for item in required_doc_text if item not in doc]
+    assert not missing, missing
+
+    assert DECISION_DOC_NAME in readme, DECISION_DOC_NAME
+    assert SUMMARY_SCHEMA not in status_source, "status hot path should not project this summary yet"
+    assert SUMMARY_SCHEMA not in review_source, "review-packet hot path should not project this summary yet"
+    assert SUMMARY_SCHEMA not in hot_path_smoke, "hot-path interface budget should not include this summary yet"
+
+    for text in (doc, readme):
+        assert_no_forbidden_text(text)
+
+    print("mini-control-plane-interrupt-projection-decision-smoke ok projection=research_only")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a smoke-backed projection decision for benchmark_interrupt_comparison_summary_v0
- keep the interrupt comparison summary research-only until a real consumer or passive benchmark run justifies projection
- verify the schema is not added to status, review-packet, or hot-path interface budget surfaces

## Validation
- python3 examples/mini-control-plane-interrupt-projection-decision-smoke.py
- python3 examples/mini-control-plane-interrupt-comparison-summary-smoke.py
- python3 examples/hot-path-interface-budget-smoke.py
- python3 -m py_compile examples/mini-control-plane-interrupt-projection-decision-smoke.py
- python3 examples/run-smokes.py
- env PATH="$HOME/.local/bin:$PATH" goal-harness-canary check
- git diff --check
- git diff --cached --check
- sensitive keyword scans on working and cached diffs
