### PR TITLE
Add no-submit benchmark approval packet

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/README.md
+++ b/docs/research/long-horizon-agent-benchmarks/README.md
@@ -84,6 +84,12 @@ work still belongs in the existing code, examples, and contract documents:
   command boundaries, submit eligibility, future event shape, and hard stop
   conditions without running Terminal-Bench, Harbor, Docker, Codex/model APIs,
   cloud sandboxes, paid compute, or leaderboard upload paths.
+- `terminal-bench-no-submit-approval-packet-v0.md`: smallest
+  `terminal_bench_no_submit_approval_packet_v0` operator packet for a future
+  no-submit setup check, listing exact candidate commands, forbidden surfaces,
+  public artifact shapes, side-effect budgets, stop conditions, and compact
+  `benchmark_run_v0` / `benchmark_result_v0` ingestion rules without executing
+  the runner path.
 
 ## Relationship To Goal Harness Work
 

--- a/docs/research/long-horizon-agent-benchmarks/terminal-bench-no-submit-approval-packet-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/terminal-bench-no-submit-approval-packet-v0.md
@@ -1,0 +1,146 @@
+# Terminal-Bench No-Submit Approval Packet V0
+
+Checked at: 2026-06-08T02:44:00+08:00.
+
+This packet is the smallest operator-approval shape for a future
+Terminal-Bench or Harbor no-submit runner setup check. It is not approval by
+itself. It does not run Terminal-Bench, Harbor, Docker, Codex, model APIs,
+cloud sandboxes, paid compute, or leaderboard upload paths.
+
+## Purpose
+
+The packet answers one operator question:
+
+If a future agent asks to verify Terminal-Bench or Harbor setup without
+submitting or executing benchmark tasks, what exact surfaces may it touch, what
+must remain forbidden, what artifacts should it leave, and how would those
+artifacts later enter compact `benchmark_run_v0` and `benchmark_result_v0`
+history rows?
+
+The expected packet schema is `terminal_bench_no_submit_approval_packet_v0`.
+The packet is a gate artifact, not a runner output. Current state must remain:
+
+- `packet_id = terminal_bench_no_submit_setup_check_packet_v0`
+- `benchmark_id = terminal-bench@2.0`
+- `approval_state = requested`
+- `execution_authorized = false`
+- `submit_eligible = false`
+- `real_run = false`
+
+## Allowed Before Approval
+
+Only local validation of this packet is allowed before an operator approves the
+future setup check:
+
+```bash
+python3 examples/terminal-bench-no-submit-approval-packet-smoke.py
+```
+
+## Candidate Commands After Approval
+
+If the operator approves this no-submit setup check, the candidate command set
+is limited to these exact shapes:
+
+```bash
+git ls-remote https://github.com/laude-institute/harbor HEAD
+git ls-remote https://github.com/harbor-framework/terminal-bench HEAD
+harbor --help
+tb --help
+goal-harness history append-benchmark-run --benchmark-run-json <benchmark-run-v0.json>
+goal-harness history append-benchmark-result --benchmark-result-json <benchmark-result-v0.json>
+```
+
+The `harbor --help` and `tb --help` checks are allowed only as CLI surface
+inspection after approval. They must not be replaced by `harbor run`, `tb run`,
+or any command that starts a benchmark task, sandbox, agent, evaluator, or
+submission path.
+
+The Goal Harness append commands are allowed only after a compact public-safe
+JSON object exists. They must not ingest raw runner logs, private traces, host
+absolute paths, raw session histories, credentials, or local artifact paths.
+
+## Forbidden Surfaces
+
+Stop before:
+
+- executing `harbor run`, `tb run`, `codex exec`, or a custom agent wrapper;
+- starting Docker, a container runtime, or any cloud sandbox;
+- invoking Codex, a model API, paid compute, or an external evaluator;
+- uploading, submitting, or preparing a leaderboard trace;
+- modifying official tasks, prompts, tests, timeouts, resources, scoring, or
+  runner code;
+- copying credentials, host absolute paths, private runner logs, internal docs,
+  raw Codex session JSONL, raw thread history, or private traces into public
+  artifacts;
+- claiming official pass/fail, reward, accuracy, leaderboard uplift, or paper
+  evidence.
+
+## Side-Effect Budget
+
+| Surface | Before approval | After approval for this packet |
+| --- | --- | --- |
+| Local packet smoke | Allowed | Allowed |
+| Public git metadata | Forbidden | Allowed for the two exact `git ls-remote` commands |
+| CLI help text | Forbidden | Allowed for `harbor --help` and `tb --help` only |
+| Docker or containers | Forbidden | Forbidden |
+| Codex CLI or model APIs | Forbidden | Forbidden |
+| Cloud or paid compute | Forbidden | Forbidden |
+| Leaderboard upload | Forbidden | Forbidden |
+| Official task mutation | Forbidden | Forbidden |
+
+## Expected Public Artifacts
+
+After an approved no-submit setup check, the agent may produce only compact
+public-safe artifacts:
+
+- `terminal_bench_no_submit_setup_check_v0.json`
+- `benchmark_run_v0` shell for `bare_codex_cli_no_submit_setup`
+- `benchmark_run_v0` shell for `passive_goal_harness_wrapper_no_submit_setup`
+- optional `benchmark_result_v0` readiness shell with
+  `official_task_score.kind = not_run`
+
+The artifacts may contain public repository names, inspected public commits,
+command-shape labels, no-submit mode names, and stop-condition checks. They must
+not contain raw runner logs, local paths, credentials, private traces, task
+outputs, official scores, or leaderboard eligibility claims.
+
+## Ingestion Plan
+
+The future no-submit setup check enters Goal Harness only as compact history:
+
+1. A `benchmark_run_v0` row records each no-submit setup mode with
+   `runner_mode = setup_check_no_submit`, `real_run = false`,
+   `submit_eligible = false`, and `trace_publicness =
+   public_no_submit_setup_check`.
+2. A `benchmark_result_v0` row may be appended only if it remains
+   readiness-only with `terminal_state = readiness_only` and
+   `official_task_score.kind = not_run`.
+3. The comparison or report lane may cite this packet only as approval-boundary
+   evidence. It must not promote the row into official benchmark evidence.
+
+## Stop Conditions
+
+Stop and ask the operator again if:
+
+- any command needs a runner execution, Docker, model call, cloud sandbox, paid
+  compute, or external evaluator;
+- any command would write outside compact public-safe Goal Harness history;
+- any artifact would include a host absolute path, credential, private trace,
+  raw log, or raw session history;
+- the benchmark terms, Harbor protocol, Terminal-Bench protocol, or submission
+  eligibility are ambiguous;
+- an agent wants to claim official score, pass/fail, reward, accuracy,
+  leaderboard uplift, or paper-ready evidence.
+
+## Smoke
+
+The deterministic smoke is:
+
+```bash
+python3 examples/terminal-bench-no-submit-approval-packet-smoke.py
+```
+
+It constructs a compact
+`terminal_bench_no_submit_approval_packet_v0` payload and asserts that the
+current packet does not authorize execution, submission, Docker, Codex/model
+APIs, cloud or paid compute, private traces, raw logs, or leaderboard claims.

--- a/examples/terminal-bench-no-submit-approval-packet-smoke.py
+++ b/examples/terminal-bench-no-submit-approval-packet-smoke.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Smoke-test the Terminal-Bench no-submit approval packet contract."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TOPIC_DIR = REPO_ROOT / "docs" / "research" / "long-horizon-agent-benchmarks"
+NOTE = TOPIC_DIR / "terminal-bench-no-submit-approval-packet-v0.md"
+README = TOPIC_DIR / "README.md"
+
+SCHEMA = "terminal_bench_no_submit_approval_packet_v0"
+PACKET_ID = "terminal_bench_no_submit_setup_check_packet_v0"
+BENCHMARK_ID = "terminal-bench@2.0"
+
+PRE_APPROVAL_COMMANDS = [
+    "python3 examples/terminal-bench-no-submit-approval-packet-smoke.py",
+]
+
+CANDIDATE_AFTER_APPROVAL_COMMANDS = [
+    "git ls-remote https://github.com/laude-institute/harbor HEAD",
+    "git ls-remote https://github.com/harbor-framework/terminal-bench HEAD",
+    "harbor --help",
+    "tb --help",
+    "goal-harness history append-benchmark-run --benchmark-run-json <benchmark-run-v0.json>",
+    "goal-harness history append-benchmark-result --benchmark-result-json <benchmark-result-v0.json>",
+]
+
+FORBIDDEN_SURFACES = [
+    "harbor_run",
+    "tb_run",
+    "codex_exec",
+    "custom_agent_wrapper",
+    "docker",
+    "container_runtime",
+    "cloud_sandbox",
+    "model_api",
+    "paid_compute",
+    "external_evaluator",
+    "leaderboard_upload",
+    "official_runner_mutation",
+    "raw_runner_log",
+    "private_trace",
+    "host_absolute_path",
+    "credential",
+    "raw_agent_session_trace",
+    "official_score_claim",
+]
+
+EXPECTED_PUBLIC_ARTIFACTS = [
+    "terminal_bench_no_submit_setup_check_v0.json",
+    "benchmark_run_v0:bare_codex_cli_no_submit_setup",
+    "benchmark_run_v0:passive_goal_harness_wrapper_no_submit_setup",
+    "benchmark_result_v0:readiness_only_not_run",
+]
+
+REQUIRED_DOC_SNIPPETS = [
+    "Terminal-Bench No-Submit Approval Packet V0",
+    SCHEMA,
+    PACKET_ID,
+    BENCHMARK_ID,
+    "Allowed Before Approval",
+    "Candidate Commands After Approval",
+    "Forbidden Surfaces",
+    "Side-Effect Budget",
+    "Expected Public Artifacts",
+    "Ingestion Plan",
+    "benchmark_run_v0",
+    "benchmark_result_v0",
+    "approval_state = requested",
+    "execution_authorized = false",
+    "submit_eligible = false",
+    "real_run = false",
+    "git ls-remote https://github.com/laude-institute/harbor HEAD",
+    "git ls-remote https://github.com/harbor-framework/terminal-bench HEAD",
+    "harbor --help",
+    "tb --help",
+    "official_task_score.kind = not_run",
+]
+
+FORBIDDEN_TEXT = [
+    "/" + "Users/",
+    "/" + "tmp/",
+    "OPENAI" + "_API_KEY",
+    "ANTHROPIC" + "_API_KEY",
+    "DAYTONA" + "_API_KEY",
+    "lark" + "office",
+    "fei" + "shu.cn",
+    "raw" + "_thread",
+    "session" + "_history",
+    "s" + "k-" + "example",
+]
+
+
+def approval_packet() -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA,
+        "packet_id": PACKET_ID,
+        "benchmark_id": BENCHMARK_ID,
+        "approval_state": "requested",
+        "execution_authorized": False,
+        "submit_eligible": False,
+        "real_run": False,
+        "decision_scope": "terminal_bench_or_harbor_no_submit_setup_check",
+        "allowed_before_approval": PRE_APPROVAL_COMMANDS,
+        "candidate_after_approval_commands": CANDIDATE_AFTER_APPROVAL_COMMANDS,
+        "forbidden_surfaces": FORBIDDEN_SURFACES,
+        "side_effect_budget": {
+            "public_git_metadata_after_approval": True,
+            "cli_help_after_approval": True,
+            "docker": False,
+            "codex_cli": False,
+            "model_api": False,
+            "cloud_sandbox": False,
+            "paid_compute": False,
+            "leaderboard_upload": False,
+            "official_runner_mutation": False,
+        },
+        "expected_public_artifacts": EXPECTED_PUBLIC_ARTIFACTS,
+        "ingestion_plan": [
+            {
+                "schema_version": "benchmark_run_v0",
+                "scenario_id": "bare_codex_cli_no_submit_setup",
+                "runner_mode": "setup_check_no_submit",
+                "real_run": False,
+                "submit_eligible": False,
+                "trace_publicness": "public_no_submit_setup_check",
+            },
+            {
+                "schema_version": "benchmark_run_v0",
+                "scenario_id": "passive_goal_harness_wrapper_no_submit_setup",
+                "runner_mode": "setup_check_no_submit",
+                "real_run": False,
+                "submit_eligible": False,
+                "trace_publicness": "public_no_submit_setup_check",
+            },
+            {
+                "schema_version": "benchmark_result_v0",
+                "scenario_id": "terminal_bench_no_submit_readiness",
+                "terminal_state": "readiness_only",
+                "official_task_score": {"kind": "not_run", "value": None},
+                "claim_boundary": "approval_boundary_only_not_official_evidence",
+            },
+        ],
+        "stop_conditions": [
+            "stop_before_runner_execution",
+            "stop_before_docker_or_container_runtime",
+            "stop_before_codex_or_model_api",
+            "stop_before_cloud_or_paid_compute",
+            "stop_before_external_evaluator",
+            "stop_before_leaderboard_upload",
+            "stop_before_private_trace_or_raw_log_ingest",
+            "stop_before_official_score_or_uplift_claim",
+        ],
+    }
+
+
+def assert_doc_contract() -> None:
+    text = NOTE.read_text(encoding="utf-8")
+    readme = README.read_text(encoding="utf-8")
+
+    missing = [snippet for snippet in REQUIRED_DOC_SNIPPETS if snippet not in text]
+    assert not missing, missing
+    assert "terminal-bench-no-submit-approval-packet-v0.md" in readme, readme
+    assert SCHEMA in readme, readme
+
+    leaked = [marker for marker in FORBIDDEN_TEXT if marker in text]
+    assert not leaked, leaked
+
+
+def assert_public_safe(payload: dict[str, Any]) -> None:
+    text = json.dumps(payload, sort_keys=True)
+    leaked = [marker for marker in FORBIDDEN_TEXT if marker in text]
+    assert not leaked, leaked
+    assert len(text) < 10000, len(text)
+
+
+def assert_packet_contract(payload: dict[str, Any]) -> None:
+    assert payload["schema_version"] == SCHEMA, payload
+    assert payload["packet_id"] == PACKET_ID, payload
+    assert payload["benchmark_id"] == BENCHMARK_ID, payload
+    assert payload["approval_state"] == "requested", payload
+    assert payload["execution_authorized"] is False, payload
+    assert payload["submit_eligible"] is False, payload
+    assert payload["real_run"] is False, payload
+
+    assert payload["allowed_before_approval"] == PRE_APPROVAL_COMMANDS, payload
+    assert payload["candidate_after_approval_commands"] == CANDIDATE_AFTER_APPROVAL_COMMANDS, payload
+    assert set(payload["forbidden_surfaces"]) == set(FORBIDDEN_SURFACES), payload
+    assert set(payload["expected_public_artifacts"]) == set(EXPECTED_PUBLIC_ARTIFACTS), payload
+
+    side_effect_budget = payload["side_effect_budget"]
+    assert side_effect_budget["public_git_metadata_after_approval"] is True, payload
+    assert side_effect_budget["cli_help_after_approval"] is True, payload
+    assert side_effect_budget["docker"] is False, payload
+    assert side_effect_budget["codex_cli"] is False, payload
+    assert side_effect_budget["model_api"] is False, payload
+    assert side_effect_budget["cloud_sandbox"] is False, payload
+    assert side_effect_budget["paid_compute"] is False, payload
+    assert side_effect_budget["leaderboard_upload"] is False, payload
+    assert side_effect_budget["official_runner_mutation"] is False, payload
+
+    run_rows = [row for row in payload["ingestion_plan"] if row["schema_version"] == "benchmark_run_v0"]
+    result_rows = [
+        row for row in payload["ingestion_plan"] if row["schema_version"] == "benchmark_result_v0"
+    ]
+    assert len(run_rows) == 2, payload
+    assert len(result_rows) == 1, payload
+    assert all(row["runner_mode"] == "setup_check_no_submit" for row in run_rows), payload
+    assert all(row["real_run"] is False for row in run_rows), payload
+    assert all(row["submit_eligible"] is False for row in run_rows), payload
+    assert result_rows[0]["terminal_state"] == "readiness_only", payload
+    assert result_rows[0]["official_task_score"] == {"kind": "not_run", "value": None}, payload
+    assert result_rows[0]["claim_boundary"] == "approval_boundary_only_not_official_evidence", payload
+
+    forbidden_command_fragments = ["harbor run", "tb run", "codex exec", "--agent-import-path"]
+    command_text = "\n".join(payload["candidate_after_approval_commands"])
+    assert not any(fragment in command_text for fragment in forbidden_command_fragments), payload
+    assert_public_safe(payload)
+
+
+def main() -> None:
+    assert_doc_contract()
+    payload = approval_packet()
+    assert_packet_contract(payload)
+    print(
+        "terminal-bench-no-submit-approval-packet-smoke ok "
+        f"commands={len(payload['candidate_after_approval_commands'])} "
+        f"artifacts={len(payload['expected_public_artifacts'])} "
+        f"authorized={payload['execution_authorized']}"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a local-only Terminal-Bench/Harbor no-submit approval packet
- list exact candidate commands, forbidden surfaces, side-effect budgets, public artifacts, stop conditions, and benchmark_run_v0 / benchmark_result_v0 ingestion rules
- add a deterministic smoke proving the packet remains unapproved, no-submit, and public-safe

## Validation
- python3 examples/terminal-bench-no-submit-approval-packet-smoke.py
- python3 examples/terminal-bench-no-submit-boundary-probe-smoke.py
- python3 examples/terminal-bench-official-pilot-readiness-smoke.py
- python3 -m py_compile examples/terminal-bench-no-submit-approval-packet-smoke.py
- python3 examples/run-smokes.py
- goal-harness-canary check
- git diff --check
- precommit/cached sensitive marker scans

No Terminal-Bench, Harbor runner execution, Docker, Codex/model API, cloud sandbox, paid compute, private trace, raw runner log, or leaderboard path was invoked.