### PR TITLE
Keep no-submit approval packet docs-only

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/README.md
+++ b/docs/research/long-horizon-agent-benchmarks/README.md
@@ -90,6 +90,10 @@ work still belongs in the existing code, examples, and contract documents:
   public artifact shapes, side-effect budgets, stop conditions, and compact
   `benchmark_run_v0` / `benchmark_result_v0` ingestion rules without executing
   the runner path.
+- `terminal-bench-no-submit-approval-packet-projection-decision-v0.md`:
+  fixture-only decision to keep the no-submit approval packet research/docs-only
+  until an agent consumer, approved no-submit setup check, passive wrapper, or
+  repeated re-derivation justifies a compact hot-path projection.
 
 ## Relationship To Goal Harness Work
 

--- a/docs/research/long-horizon-agent-benchmarks/terminal-bench-no-submit-approval-packet-projection-decision-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/terminal-bench-no-submit-approval-packet-projection-decision-v0.md
@@ -1,0 +1,72 @@
+# Terminal-Bench No-Submit Approval Packet Projection Decision V0
+
+Checked at: 2026-06-08T02:56:00+08:00.
+
+## Decision
+
+`terminal_bench_no_submit_approval_packet_v0` remains research/docs-only for
+now.
+
+Do not project it into Goal Harness status, review-packet, or project-asset
+handoff hot paths until a real agent consumer needs the packet outside this
+research folder, an approved no-submit setup check produces compact public
+evidence, or repeated heartbeats show agents re-deriving the same gate boundary.
+
+## Why
+
+- The packet is an operator gate artifact, not runner output or benchmark
+  evidence.
+- The packet's current state is intentionally non-executable:
+  `approval_state=requested`, `execution_authorized=false`,
+  `submit_eligible=false`, and `real_run=false`.
+- The current review-packet handoff JSON has only narrow top-level field
+  headroom. Adding another projection would spend scarce interface budget before
+  proving a project-agent consumer exists.
+- The research artifact already preserves the practical signal: exact candidate
+  command shapes, forbidden surfaces, side-effect budget, expected public
+  artifacts, stop conditions, and compact `benchmark_run_v0` /
+  `benchmark_result_v0` ingestion rules.
+- Keeping it docs-only avoids making an unapproved future setup check look like
+  a delivery approval, runner result, or leaderboard-adjacent signal.
+
+## Projection Gate
+
+Project it only if one of these happens:
+
+- a project agent cannot reliably find or use the packet through the current
+  handoff chain;
+- the operator explicitly approves a no-submit setup check and compact public
+  evidence needs to enter run history;
+- a passive benchmark wrapper or report consumer needs a compact approval-boundary
+  summary to avoid mixing readiness evidence with official score evidence;
+- repeated heartbeat turns re-create the same command/forbidden-surface list
+  instead of reusing this artifact.
+
+If the gate opens, project only a compact read-only shape:
+
+- `schema_version`;
+- `approval_state`;
+- `execution_authorized`;
+- `submit_eligible`;
+- `real_run`;
+- `candidate_command_count`;
+- `forbidden_surface_count`;
+- `expected_public_artifact_count`;
+- `claim_boundary`;
+- `next_required_operator_action`.
+
+Do not add raw commands, raw logs, private traces, host paths, local artifact
+paths, task outputs, official scores, approval claims, runner output, or
+leaderboard language.
+
+## Boundary
+
+No Terminal-Bench or Harbor runner execution, Docker, Codex/model API,
+cloud sandbox, paid compute, private trace, raw runner log, local artifact
+path, operator-approval claim, setup execution, or leaderboard path is involved.
+
+## Smoke
+
+```bash
+python3 examples/terminal-bench-no-submit-approval-packet-projection-decision-smoke.py
+```

--- a/examples/terminal-bench-no-submit-approval-packet-projection-decision-smoke.py
+++ b/examples/terminal-bench-no-submit-approval-packet-projection-decision-smoke.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Smoke-test the no-submit approval packet projection decision boundary."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TOPIC_DIR = REPO_ROOT / "docs" / "research" / "long-horizon-agent-benchmarks"
+README = TOPIC_DIR / "README.md"
+DECISION_DOC = TOPIC_DIR / "terminal-bench-no-submit-approval-packet-projection-decision-v0.md"
+PACKET_DOC = TOPIC_DIR / "terminal-bench-no-submit-approval-packet-v0.md"
+STATUS = REPO_ROOT / "goal_harness" / "status.py"
+REVIEW_PACKET = REPO_ROOT / "goal_harness" / "review_packet.py"
+HOT_PATH_SMOKE = REPO_ROOT / "examples" / "hot-path-interface-budget-smoke.py"
+
+PACKET_SCHEMA = "terminal_bench_no_submit_approval_packet_v0"
+DECISION_DOC_NAME = "terminal-bench-no-submit-approval-packet-projection-decision-v0.md"
+FORBIDDEN_TEXT = [
+    "/" + "Users/",
+    "/" + "tmp/",
+    "OPEN" + "AI" + "_API" + "_KEY",
+    "ANTH" + "ROPIC" + "_API" + "_KEY",
+    "lark" + "office",
+    "fei" + "shu.cn",
+    "raw" + "_thread",
+    "session" + "_history",
+]
+
+
+def assert_no_forbidden_text(text: str) -> None:
+    leaked = [marker for marker in FORBIDDEN_TEXT if marker in text]
+    assert not leaked, leaked
+
+
+def main() -> int:
+    doc = DECISION_DOC.read_text(encoding="utf-8")
+    packet_doc = PACKET_DOC.read_text(encoding="utf-8")
+    readme = README.read_text(encoding="utf-8")
+    status_source = STATUS.read_text(encoding="utf-8")
+    review_source = REVIEW_PACKET.read_text(encoding="utf-8")
+    hot_path_smoke = HOT_PATH_SMOKE.read_text(encoding="utf-8")
+
+    required_doc_text = [
+        PACKET_SCHEMA,
+        "remains research/docs-only",
+        "Do not project it into Goal Harness status, review-packet, or project-asset",
+        "Projection Gate",
+        "approval_state",
+        "execution_authorized",
+        "submit_eligible",
+        "real_run",
+        "candidate_command_count",
+        "forbidden_surface_count",
+        "expected_public_artifact_count",
+        "next_required_operator_action",
+        "No Terminal-Bench or Harbor runner execution",
+    ]
+    missing = [item for item in required_doc_text if item not in doc]
+    assert not missing, missing
+
+    assert PACKET_SCHEMA in packet_doc, "packet doc should still own the schema contract"
+    assert DECISION_DOC_NAME in readme, DECISION_DOC_NAME
+    assert PACKET_SCHEMA not in status_source, "status hot path should not project this packet yet"
+    assert PACKET_SCHEMA not in review_source, "review-packet hot path should not project this packet yet"
+    assert PACKET_SCHEMA not in hot_path_smoke, "hot-path interface budget should not include this packet yet"
+
+    for text in (doc, readme):
+        assert_no_forbidden_text(text)
+
+    print("terminal-bench-no-submit-approval-packet-projection-decision-smoke ok projection=docs_only")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a projection decision for terminal_bench_no_submit_approval_packet_v0
- keep the approval packet research/docs-only until a real consumer, approved setup check, passive wrapper, or repeated re-derivation justifies projection
- add a smoke proving the packet schema is not projected into status, review-packet, or hot-path interface-budget surfaces

## Validation
- python3 examples/terminal-bench-no-submit-approval-packet-projection-decision-smoke.py
- python3 examples/terminal-bench-no-submit-approval-packet-smoke.py
- python3 examples/hot-path-interface-budget-smoke.py
- python3 -m py_compile examples/terminal-bench-no-submit-approval-packet-projection-decision-smoke.py
- python3 examples/run-smokes.py
- goal-harness-canary check
- git diff --check
- precommit/cached sensitive marker scans

No Terminal-Bench/Harbor runner execution, Docker, Codex/model API, cloud sandbox, paid compute, private trace, raw runner log, local artifact path, operator-approval claim, setup execution, or leaderboard path was invoked.