### PR TITLE
Add benchmark restart actionability fixture

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/README.md
+++ b/docs/research/long-horizon-agent-benchmarks/README.md
@@ -99,6 +99,11 @@ work still belongs in the existing code, examples, and contract documents:
   control-plane-score, claim-boundary, readiness, authorization,
   replay-decision, next-run-mode, and stop-condition state without raw logs,
   private traces, local artifact paths, chat history, or extra hot-path keys.
+- `benchmark-restart-actionability-v0.md`: restarted-worker actionability
+  fixture proving a compact reconstructed decision can produce exactly one
+  bounded local fixture command or a public-safe blocker while preserving
+  fixture-only authorization, no-leaderboard claims, and real-run stop
+  conditions.
 
 ## Relationship To Goal Harness Work
 

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-restart-actionability-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-restart-actionability-v0.md
@@ -1,0 +1,108 @@
+# Benchmark Restart Actionability V0
+
+Checked at: 2026-06-08T03:25:00+08:00.
+
+This fixture consumes `benchmark_history_reconstructability_v0` and proves that
+a freshly restarted worker can turn the reconstructed public-safe benchmark
+state into exactly one bounded next command or a blocker.
+
+It is not a new status projection, review-packet field, runner setup step,
+benchmark execution, approval path, or leaderboard path. It does not read raw
+logs, private traces, local artifact paths, chat history, worker session
+history, Terminal-Bench, Harbor, Docker, Codex/model APIs, cloud sandboxes,
+paid compute, external evaluators, or leaderboard upload paths.
+
+## Purpose
+
+The useful actionability question is:
+
+Can a fresh worker resume from compact reconstructed history and select the next
+safe fixture action without re-reading stale chat context, raw benchmark logs,
+private traces, or local artifact paths?
+
+The expected fixture schema is `benchmark_restart_actionability_v0`.
+
+## Required Input
+
+The fixture accepts one reconstructed decision with schema
+`benchmark_history_reconstructability_v0`.
+
+The minimum usable input is:
+
+| Field | Required value |
+| --- | --- |
+| `readiness` | `negative_or_control_plane_only` |
+| `authorization` | `fixture_only` |
+| `replay_decision` | `continue_fixture_replay` |
+| `next_run_mode` | `fixture_replay` |
+| `raw_inputs_required` | `false` |
+| `official_score.leaderboard_evidence` | `false` |
+| `must_not_claim` | includes `official leaderboard uplift` and `real benchmark pass/fail` |
+| `stop_condition` | stops before real benchmark execution or leaderboard claims |
+
+Any stronger or less explicit condition must produce a blocker instead of a
+command.
+
+## Selected Action
+
+When the reconstructed decision preserves `fixture_only` authorization and
+`continue_fixture_replay`, the restarted-worker plan may contain exactly one
+local fixture command:
+
+```bash
+python3 examples/benchmark-history-reconstructability-smoke.py
+```
+
+The action is allowed only as `run_local_fixture_replay_smoke`. It validates the
+compact history reconstruction path, not a real benchmark, runner setup, model
+call, simulator run, official score, or leaderboard result.
+
+The plan must also carry the blocked external action list:
+
+- `terminal_bench_runner`
+- `harbor_runner`
+- `docker`
+- `codex_model_api`
+- `cloud_paid_compute`
+- `external_evaluator`
+- `leaderboard_upload`
+
+## Blocker Path
+
+If authorization is not `fixture_only`, replay decision is not
+`continue_fixture_replay`, raw inputs are required, leaderboard evidence is
+present, or the stop condition is missing, the restarted worker must emit a
+public-safe blocker.
+
+The blocker should name the failed fixture gate and preserve the same
+`must_not_claim` boundary. It must not invent an operator approval, run a setup
+probe, read private evidence, or escalate to a benchmark runner.
+
+## Failure Rules
+
+The fixture fails if:
+
+- the selected plan has more than one command;
+- the selected command is anything other than the local reconstructability
+  smoke;
+- the command appears when authorization or replay state is not fixture-only;
+- blocked external actions are omitted;
+- official score, control-plane score, claim boundary, stop condition, or
+  forbidden claims are lost;
+- the plan adds a status, dashboard, review-packet, or hot-path projection key;
+- raw logs, private traces, local artifact paths, credentials, chat history,
+  worker session history, task outputs, official leaderboard claims, or upload
+  paths appear in the plan.
+
+## Boundary
+
+No real Terminal-Bench or Harbor runner execution, Docker, Codex/model API,
+cloud sandbox, paid compute, external evaluator, private trace, raw runner log,
+local artifact path, approval claim, setup execution, or leaderboard path is
+involved.
+
+## Smoke
+
+```bash
+python3 examples/benchmark-restart-actionability-smoke.py
+```

--- a/examples/benchmark-restart-actionability-smoke.py
+++ b/examples/benchmark-restart-actionability-smoke.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Smoke-test restarted-worker actionability from compact benchmark history."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TOPIC_DIR = REPO_ROOT / "docs" / "research" / "long-horizon-agent-benchmarks"
+NOTE = TOPIC_DIR / "benchmark-restart-actionability-v0.md"
+README = TOPIC_DIR / "README.md"
+HISTORY_SMOKE = REPO_ROOT / "examples" / "benchmark-history-reconstructability-smoke.py"
+
+SCHEMA = "benchmark_restart_actionability_v0"
+SOURCE_SCHEMA = "benchmark_history_reconstructability_v0"
+FIXTURE_COMMAND = "python3 examples/benchmark-history-reconstructability-smoke.py"
+BLOCKED_EXTERNAL_ACTIONS = [
+    "terminal_bench_runner",
+    "harbor_runner",
+    "docker",
+    "codex_model_api",
+    "cloud_paid_compute",
+    "external_evaluator",
+    "leaderboard_upload",
+]
+FORBIDDEN_TEXT = [
+    "/" + "Users/",
+    "/" + "tmp/",
+    "OPEN" + "AI" + "_API" + "_KEY",
+    "ANTH" + "ROPIC" + "_API" + "_KEY",
+    "DAYTONA" + "_API" + "_KEY",
+    "lark" + "office",
+    "fei" + "shu.cn",
+    "raw" + "_thread",
+    "session" + "_history",
+    "s" + "k-" + "example",
+]
+
+
+def load_history_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("benchmark_history_fixture", HISTORY_SMOKE)
+    if spec is None or spec.loader is None:
+        raise AssertionError("history fixture import failed")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def build_action_plan(reconstructed: dict[str, Any]) -> dict[str, Any]:
+    failed_gates: list[str] = []
+    if reconstructed.get("schema_version") != SOURCE_SCHEMA:
+        failed_gates.append("source_schema")
+    if reconstructed.get("readiness") != "negative_or_control_plane_only":
+        failed_gates.append("readiness")
+    if reconstructed.get("authorization") != "fixture_only":
+        failed_gates.append("authorization")
+    if reconstructed.get("replay_decision") != "continue_fixture_replay":
+        failed_gates.append("replay_decision")
+    if reconstructed.get("next_run_mode") != "fixture_replay":
+        failed_gates.append("next_run_mode")
+    if reconstructed.get("raw_inputs_required") is not False:
+        failed_gates.append("raw_inputs_required")
+    if reconstructed.get("official_score", {}).get("leaderboard_evidence") is not False:
+        failed_gates.append("leaderboard_evidence")
+    if not reconstructed.get("stop_condition"):
+        failed_gates.append("stop_condition")
+
+    plan: dict[str, Any] = {
+        "schema_version": SCHEMA,
+        "source_schema_version": reconstructed.get("schema_version"),
+        "fresh_worker_context": "compact_public_history_only",
+        "readiness": reconstructed.get("readiness"),
+        "authorization": reconstructed.get("authorization"),
+        "replay_decision": reconstructed.get("replay_decision"),
+        "next_run_mode": reconstructed.get("next_run_mode"),
+        "official_score": reconstructed.get("official_score"),
+        "control_plane_score": reconstructed.get("control_plane_score"),
+        "claim_boundary": reconstructed.get("claim_boundary"),
+        "must_not_claim": reconstructed.get("must_not_claim", []),
+        "blocked_external_actions": BLOCKED_EXTERNAL_ACTIONS,
+        "stop_condition": reconstructed.get("stop_condition"),
+        "projection_change": "none",
+        "raw_inputs_required": False,
+    }
+
+    if failed_gates:
+        plan["selected_action"] = {
+            "kind": "blocker",
+            "allowed": False,
+            "failed_gates": failed_gates,
+            "reason": "reconstructed state is not authorized for fixture replay",
+        }
+    else:
+        plan["selected_action"] = {
+            "kind": "run_local_fixture_replay_smoke",
+            "allowed": True,
+            "command": FIXTURE_COMMAND,
+            "validates": SOURCE_SCHEMA,
+            "command_count": 1,
+        }
+    return plan
+
+
+def assert_public_safe(payload: dict[str, Any]) -> None:
+    text = json.dumps(payload, sort_keys=True)
+    leaked = [marker for marker in FORBIDDEN_TEXT if marker in text]
+    assert not leaked, leaked
+    assert len(text) < 9000, len(text)
+
+
+def assert_doc_contract() -> None:
+    doc = NOTE.read_text(encoding="utf-8")
+    readme = README.read_text(encoding="utf-8")
+    required = [
+        SCHEMA,
+        SOURCE_SCHEMA,
+        "Selected Action",
+        "Blocker Path",
+        "Failure Rules",
+        FIXTURE_COMMAND,
+        "terminal_bench_runner",
+        "harbor_runner",
+        "codex_model_api",
+        "cloud_paid_compute",
+        "No real Terminal-Bench or Harbor runner execution",
+    ]
+    missing = [item for item in required if item not in doc]
+    assert not missing, missing
+    assert "benchmark-restart-actionability-v0.md" in readme, readme
+    for text in (doc, readme):
+        leaked = [marker for marker in FORBIDDEN_TEXT if marker in text]
+        assert not leaked, leaked
+
+
+def main() -> None:
+    assert_doc_contract()
+    history = load_history_module()
+    reconstructed = history.reconstruct_next_decision(history.compact_history_rows())
+    action_plan = build_action_plan(reconstructed)
+
+    assert action_plan["schema_version"] == SCHEMA, action_plan
+    assert action_plan["source_schema_version"] == SOURCE_SCHEMA, action_plan
+    assert action_plan["fresh_worker_context"] == "compact_public_history_only", action_plan
+    assert action_plan["readiness"] == "negative_or_control_plane_only", action_plan
+    assert action_plan["authorization"] == "fixture_only", action_plan
+    assert action_plan["replay_decision"] == "continue_fixture_replay", action_plan
+    assert action_plan["next_run_mode"] == "fixture_replay", action_plan
+    assert action_plan["selected_action"] == {
+        "kind": "run_local_fixture_replay_smoke",
+        "allowed": True,
+        "command": FIXTURE_COMMAND,
+        "validates": SOURCE_SCHEMA,
+        "command_count": 1,
+    }, action_plan
+    assert action_plan["blocked_external_actions"] == BLOCKED_EXTERNAL_ACTIONS, action_plan
+    assert "official leaderboard uplift" in action_plan["must_not_claim"], action_plan
+    assert action_plan["stop_condition"] == "stop before real benchmark execution or leaderboard claims", action_plan
+    assert action_plan["projection_change"] == "none", action_plan
+
+    blocked_input = dict(reconstructed)
+    blocked_input["authorization"] = "operator_gate_required"
+    blocked_plan = build_action_plan(blocked_input)
+    assert blocked_plan["selected_action"]["kind"] == "blocker", blocked_plan
+    assert blocked_plan["selected_action"]["allowed"] is False, blocked_plan
+    assert "authorization" in blocked_plan["selected_action"]["failed_gates"], blocked_plan
+    assert "command" not in blocked_plan["selected_action"], blocked_plan
+    assert blocked_plan["must_not_claim"] == action_plan["must_not_claim"], blocked_plan
+
+    assert_public_safe({"action_plan": action_plan, "blocked_plan": blocked_plan})
+    print(
+        "benchmark-restart-actionability-smoke ok "
+        f"action={action_plan['selected_action']['kind']} "
+        f"blocked={blocked_plan['selected_action']['kind']} "
+        f"external_blocks={len(BLOCKED_EXTERNAL_ACTIONS)}"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add benchmark_restart_actionability_v0 as a restarted-worker fixture that consumes benchmark_history_reconstructability_v0
- prove fixture-only replay produces exactly one bounded local command while non-fixture authorization produces a public-safe blocker
- link the artifact from the long-horizon benchmark research index

## Validation
- python3 examples/benchmark-restart-actionability-smoke.py
- python3 examples/benchmark-history-reconstructability-smoke.py
- python3 examples/benchmark-report-chain-map-smoke.py
- python3 -m py_compile examples/benchmark-restart-actionability-smoke.py
- python3 examples/run-smokes.py
- env PATH="/Users/bytedance/.local/bin:/Users/bytedance/.cargo/bin:/Users/bytedance/.codex/tmp/arg0/codex-arg0kr5Yf6:/usr/bin:/bin:/usr/sbin:/sbin:/Applications/Codex.app/Contents/Resources" goal-harness-canary check
- git diff --check
- sensitive marker scans over new/cached public files

## Boundary
No real Terminal-Bench/Harbor runner, Docker, Codex/model API, cloud/paid compute, external evaluator, private trace, raw runner log, local artifact path, approval claim, setup execution, or leaderboard path was invoked.