### PR TITLE
Keep restart actionability docs-only

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/README.md
+++ b/docs/research/long-horizon-agent-benchmarks/README.md
@@ -104,6 +104,10 @@ work still belongs in the existing code, examples, and contract documents:
   bounded local fixture command or a public-safe blocker while preserving
   fixture-only authorization, no-leaderboard claims, and real-run stop
   conditions.
+- `benchmark-restart-actionability-projection-decision-v0.md`: fixture-only
+  decision to keep `benchmark_restart_actionability_v0` research/docs-only
+  until a real restarted-worker consumer, approved no-submit setup evidence, or
+  repeated re-derivation justifies a compact hot-path projection.
 
 ## Relationship To Goal Harness Work
 

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-restart-actionability-projection-decision-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-restart-actionability-projection-decision-v0.md
@@ -1,0 +1,74 @@
+# Benchmark Restart Actionability Projection Decision V0
+
+Checked at: 2026-06-08T03:28:00+08:00.
+
+## Decision
+
+`benchmark_restart_actionability_v0` remains research/docs-only for now.
+
+Do not project it into Goal Harness status, review-packet, project-asset, or
+handoff hot paths until a real restarted-worker consumer needs the signal
+outside this research folder, an approved no-submit setup check produces compact
+public evidence, or repeated heartbeats show agents re-deriving the same
+actionability boundary instead of reusing the artifact.
+
+## Why
+
+- The fixture is useful restartability evidence, but it is still fixture-only.
+- The selected action is intentionally a local smoke command, not benchmark
+  runner authorization, setup execution, official score evidence, or a
+  leaderboard-adjacent result.
+- The current active-state todo and research README already make the artifact
+  findable for the next worker without adding another top-level status or
+  review-packet field.
+- The review-packet handoff JSON has narrow top-level headroom. Adding a
+  projection now would spend scarce interface budget before proving a
+  project-agent consumer exists.
+- Keeping it docs-only avoids making a safe fixture command look like
+  permission to run Terminal-Bench, Harbor, Docker, Codex/model APIs,
+  cloud/paid compute, external evaluators, setup checks, or leaderboard paths.
+
+## Projection Gate
+
+Project it only if one of these happens:
+
+- a restarted worker cannot reliably find or use the research artifact through
+  the current active-state / research README handoff;
+- an approved no-submit setup check or passive benchmark wrapper needs a compact
+  actionability summary to avoid re-reading raw setup context;
+- a report consumer needs the actionability decision to connect reconstructed
+  history to a later public `benchmark_run_v0` / `benchmark_result_v0` row;
+- repeated heartbeat turns re-create the same command/blocker boundary instead
+  of reusing `benchmark-restart-actionability-v0.md`.
+
+If the gate opens, project only a compact read-only shape:
+
+- `schema_version`;
+- `source_schema_version`;
+- `readiness`;
+- `authorization`;
+- `replay_decision`;
+- `next_run_mode`;
+- `selected_action_kind`;
+- `selected_action_allowed`;
+- `selected_action_command_count`;
+- `blocked_external_action_count`;
+- `claim_boundary`;
+- `stop_condition`.
+
+Do not add raw commands, raw logs, private traces, host paths, local artifact
+paths, task outputs, official scores, approval claims, runner output, setup
+execution results, or leaderboard language.
+
+## Boundary
+
+No Terminal-Bench or Harbor runner execution, Docker, Codex/model API, cloud
+sandbox, paid compute, external evaluator, private trace, raw runner log, local
+artifact path, operator-approval claim, setup execution, or leaderboard path is
+involved.
+
+## Smoke
+
+```bash
+python3 examples/benchmark-restart-actionability-projection-decision-smoke.py
+```

--- a/examples/benchmark-restart-actionability-projection-decision-smoke.py
+++ b/examples/benchmark-restart-actionability-projection-decision-smoke.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Smoke-test the restart actionability projection decision boundary."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TOPIC_DIR = REPO_ROOT / "docs" / "research" / "long-horizon-agent-benchmarks"
+README = TOPIC_DIR / "README.md"
+DECISION_DOC = TOPIC_DIR / "benchmark-restart-actionability-projection-decision-v0.md"
+ACTIONABILITY_DOC = TOPIC_DIR / "benchmark-restart-actionability-v0.md"
+STATUS = REPO_ROOT / "goal_harness" / "status.py"
+REVIEW_PACKET = REPO_ROOT / "goal_harness" / "review_packet.py"
+HOT_PATH_SMOKE = REPO_ROOT / "examples" / "hot-path-interface-budget-smoke.py"
+
+ACTIONABILITY_SCHEMA = "benchmark_restart_actionability_v0"
+DECISION_DOC_NAME = "benchmark-restart-actionability-projection-decision-v0.md"
+FORBIDDEN_TEXT = [
+    "/" + "Users/",
+    "/" + "tmp/",
+    "OPEN" + "AI" + "_API" + "_KEY",
+    "ANTH" + "ROPIC" + "_API" + "_KEY",
+    "DAYTONA" + "_API" + "_KEY",
+    "lark" + "office",
+    "fei" + "shu.cn",
+    "raw" + "_thread",
+    "session" + "_history",
+]
+
+
+def assert_no_forbidden_text(text: str) -> None:
+    leaked = [marker for marker in FORBIDDEN_TEXT if marker in text]
+    assert not leaked, leaked
+
+
+def main() -> int:
+    doc = DECISION_DOC.read_text(encoding="utf-8")
+    actionability_doc = ACTIONABILITY_DOC.read_text(encoding="utf-8")
+    readme = README.read_text(encoding="utf-8")
+    status_source = STATUS.read_text(encoding="utf-8")
+    review_source = REVIEW_PACKET.read_text(encoding="utf-8")
+    hot_path_smoke = HOT_PATH_SMOKE.read_text(encoding="utf-8")
+
+    required_doc_text = [
+        ACTIONABILITY_SCHEMA,
+        "remains research/docs-only",
+        "Do not project it into Goal Harness status, review-packet, project-asset",
+        "Projection Gate",
+        "source_schema_version",
+        "selected_action_kind",
+        "selected_action_allowed",
+        "selected_action_command_count",
+        "blocked_external_action_count",
+        "claim_boundary",
+        "No Terminal-Bench or Harbor runner execution",
+    ]
+    missing = [item for item in required_doc_text if item not in doc]
+    assert not missing, missing
+
+    assert ACTIONABILITY_SCHEMA in actionability_doc, "actionability doc should own the schema"
+    assert DECISION_DOC_NAME in readme, DECISION_DOC_NAME
+    assert ACTIONABILITY_SCHEMA not in status_source, "status hot path should not project this yet"
+    assert ACTIONABILITY_SCHEMA not in review_source, "review-packet hot path should not project this yet"
+    assert ACTIONABILITY_SCHEMA not in hot_path_smoke, "hot-path interface budget should not include this yet"
+
+    for text in (doc, readme):
+        assert_no_forbidden_text(text)
+
+    print("benchmark-restart-actionability-projection-decision-smoke ok projection=docs_only")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add benchmark_restart_actionability_v0 projection decision doc
- keep restart actionability research/docs-only until a real restarted-worker consumer, approved no-submit evidence, or repeated re-derivation justifies projection
- add a smoke that verifies status, review-packet, and hot-path interface budget surfaces do not project this fixture yet

## Validation
- python3 examples/benchmark-restart-actionability-projection-decision-smoke.py
- python3 examples/benchmark-restart-actionability-smoke.py
- python3 examples/hot-path-interface-budget-smoke.py
- python3 -m py_compile examples/benchmark-restart-actionability-projection-decision-smoke.py
- python3 examples/run-smokes.py
- env PATH="/Users/bytedance/.local/bin:/Users/bytedance/.cargo/bin:/Users/bytedance/.codex/tmp/arg0/codex-arg0kr5Yf6:/usr/bin:/bin:/usr/sbin:/sbin:/Applications/Codex.app/Contents/Resources" goal-harness-canary check
- git diff --check
- sensitive marker scans over new/cached public files

## Boundary
No Terminal-Bench/Harbor runner, Docker, Codex/model API, cloud/paid compute, external evaluator, private trace, raw runner log, local artifact path, approval claim, setup execution, or leaderboard path was invoked.