### PR TITLE
Add benchmark current-state handoff

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/README.md
+++ b/docs/research/long-horizon-agent-benchmarks/README.md
@@ -24,6 +24,10 @@ work still belongs in the existing code, examples, and contract documents:
 
 ## Current Artifacts
 
+- `benchmark-program-current-state-handoff-v0.md`: compact current-state
+  runbook for fresh workers, summarizing the active benchmark evidence layer,
+  docs-only projection decisions, allowed next transitions, and stop
+  conditions without adding hot-path projection keys.
 - `roadmap.md`: benchmark selection, passive baseline, operator-simulator, and
   publication-readiness roadmap.
 - `paper-runner-dossier.md`: first evidence-backed ranking of benchmark papers,

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-program-current-state-handoff-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-program-current-state-handoff-v0.md
@@ -1,0 +1,89 @@
+# Benchmark Program Current-State Handoff V0
+
+Checked at: 2026-06-08T03:34:00+08:00.
+
+This handoff is the compact current-state runbook for the Goal Harness
+long-horizon benchmark research program. It tells a fresh worker what the
+current evidence means, which artifacts own the details, and which transitions
+are allowed next.
+
+It is not a benchmark result, runner setup instruction, approval, new status
+projection, review-packet field, project-asset field, or leaderboard path. It
+does not read raw logs, private traces, local artifact paths, chat history,
+worker session history, Terminal-Bench, Harbor, Docker, Codex/model APIs, cloud
+sandboxes, paid compute, external evaluators, or leaderboard upload paths.
+
+## Current State
+
+The program is still in public-safe fixture and readiness evidence:
+
+| Layer | Current state | Owner artifact |
+| --- | --- | --- |
+| Benchmark choice | Terminal-Bench 2.0 / Harbor remains the first official-runner probe candidate. | `paper-runner-dossier.md`, `terminal-bench-probe-v0.md` |
+| Official task score | No official run has been executed or claimed. | `terminal-bench-official-pilot-readiness-v0.md` |
+| Passive result shell | `benchmark_run_v0` / `benchmark_result_v0` fixtures define the future compact ingest shape. | `benchmark-run-v0-ingest.md`, `passive-baseline-protocol-v0.md` |
+| Control-plane score | `control_plane_score_core_v0` is fixture-backed and separated from official score. | `benchmark-result-control-plane-score-v0.md` |
+| Report chain | The current fixture chain is reconstructable through replay decision and restart actionability. | `benchmark-report-chain-map-v0.md`, `benchmark-history-reconstructability-v0.md`, `benchmark-restart-actionability-v0.md` |
+| Projection policy | Interrupt summary, no-submit approval packet, and restart actionability remain research/docs-only. | `mini-control-plane-interrupt-projection-decision-v0.md`, `terminal-bench-no-submit-approval-packet-projection-decision-v0.md`, `benchmark-restart-actionability-projection-decision-v0.md` |
+
+## Fresh Worker Read Order
+
+Read only these files before choosing the next benchmark action:
+
+1. `benchmark-program-current-state-handoff-v0.md` for current state and
+   allowed transitions.
+2. `benchmark-report-chain-map-v0.md` for the fixture/reporting chain.
+3. `terminal-bench-no-submit-approval-packet-v0.md` only if preparing an
+   operator question for a future no-submit setup check.
+4. `benchmark-run-v0-ingest.md` only if already-produced public official-runner
+   output exists and needs passive compact ingestion.
+
+Do not scan every research note unless one of those files points to a missing
+contract or a smoke fails.
+
+## Allowed Next Transitions
+
+Choose at most one transition:
+
+- `ask_no_submit_setup_approval`: ask the operator to approve a no-submit
+  Terminal-Bench/Harbor setup check. This is a user gate, not autonomous
+  execution.
+- `passively_ingest_existing_official_output`: if public official-runner output
+  already exists, ingest only the compact public-safe fields into
+  `benchmark_run_v0` / `benchmark_result_v0`.
+- `quiet_stop`: if neither approval nor existing official output exists, stop
+  without spending another benchmark delivery slice on re-deriving the same
+  fixture chain.
+
+Local fixture smokes may be run only to validate edits to the public research
+artifacts. They are not benchmark execution evidence.
+
+## Stop Conditions
+
+No Terminal-Bench or Harbor runner execution is authorized by this handoff.
+
+Stop before:
+
+- real Terminal-Bench or Harbor runner execution;
+- Docker, Codex/model API, cloud sandbox, paid compute, or external evaluator;
+- private traces, raw runner logs, hidden tests, task outputs, local artifact
+  paths, chat history, or worker session history;
+- operator-approval claims, setup execution, official score claims, submission,
+  upload, or leaderboard language;
+- status, review-packet, project-asset, or handoff hot-path projection changes
+  unless a projection gate from an existing decision document opens.
+
+## Projection Policy
+
+This handoff remains research/docs-only. It should not create a new status,
+review-packet, project-asset, or hot-path interface-budget key.
+
+Promote a compact projection only if a fresh worker repeatedly fails to find
+the current benchmark state through this handoff, or if passive official output
+creates a real consumer for a smaller machine-readable summary.
+
+## Smoke
+
+```bash
+python3 examples/benchmark-program-current-state-handoff-smoke.py
+```

--- a/examples/benchmark-program-current-state-handoff-smoke.py
+++ b/examples/benchmark-program-current-state-handoff-smoke.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Smoke-test the benchmark program current-state handoff boundary."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TOPIC_DIR = REPO_ROOT / "docs" / "research" / "long-horizon-agent-benchmarks"
+HANDOFF = TOPIC_DIR / "benchmark-program-current-state-handoff-v0.md"
+README = TOPIC_DIR / "README.md"
+STATUS = REPO_ROOT / "goal_harness" / "status.py"
+REVIEW_PACKET = REPO_ROOT / "goal_harness" / "review_packet.py"
+HOT_PATH_SMOKE = REPO_ROOT / "examples" / "hot-path-interface-budget-smoke.py"
+
+HANDOFF_SCHEMA = "benchmark_program_current_state_handoff_v0"
+HANDOFF_DOC_NAME = "benchmark-program-current-state-handoff-v0.md"
+REQUIRED_OWNER_DOCS = [
+    "paper-runner-dossier.md",
+    "terminal-bench-probe-v0.md",
+    "terminal-bench-official-pilot-readiness-v0.md",
+    "benchmark-run-v0-ingest.md",
+    "passive-baseline-protocol-v0.md",
+    "benchmark-result-control-plane-score-v0.md",
+    "benchmark-report-chain-map-v0.md",
+    "benchmark-history-reconstructability-v0.md",
+    "benchmark-restart-actionability-v0.md",
+    "mini-control-plane-interrupt-projection-decision-v0.md",
+    "terminal-bench-no-submit-approval-packet-projection-decision-v0.md",
+    "benchmark-restart-actionability-projection-decision-v0.md",
+    "terminal-bench-no-submit-approval-packet-v0.md",
+]
+FORBIDDEN_TEXT = [
+    "/" + "Users/",
+    "/" + "tmp/",
+    "OPEN" + "AI" + "_API" + "_KEY",
+    "ANTH" + "ROPIC" + "_API" + "_KEY",
+    "DAYTONA" + "_API" + "_KEY",
+    "lark" + "office",
+    "fei" + "shu.cn",
+    "raw" + "_thread",
+    "session" + "_history",
+]
+
+
+def assert_no_forbidden_text(text: str) -> None:
+    leaked = [marker for marker in FORBIDDEN_TEXT if marker in text]
+    assert not leaked, leaked
+
+
+def main() -> int:
+    doc = HANDOFF.read_text(encoding="utf-8")
+    readme = README.read_text(encoding="utf-8")
+    status_source = STATUS.read_text(encoding="utf-8")
+    review_source = REVIEW_PACKET.read_text(encoding="utf-8")
+    hot_path_source = HOT_PATH_SMOKE.read_text(encoding="utf-8")
+
+    required_doc_text = [
+        "Current State",
+        "Fresh Worker Read Order",
+        "Allowed Next Transitions",
+        "ask_no_submit_setup_approval",
+        "passively_ingest_existing_official_output",
+        "quiet_stop",
+        "Projection Policy",
+        "research/docs-only",
+        "No official run has been executed or claimed",
+        "No Terminal-Bench or Harbor runner execution",
+    ]
+    missing = [item for item in required_doc_text if item not in doc]
+    assert not missing, missing
+
+    missing_owner_docs = [name for name in REQUIRED_OWNER_DOCS if name not in doc]
+    assert not missing_owner_docs, missing_owner_docs
+    for name in REQUIRED_OWNER_DOCS:
+        assert (TOPIC_DIR / name).exists(), name
+
+    assert HANDOFF_DOC_NAME in readme, HANDOFF_DOC_NAME
+    assert HANDOFF_SCHEMA not in status_source, "status hot path should not project this handoff"
+    assert HANDOFF_SCHEMA not in review_source, "review-packet hot path should not project this handoff"
+    assert HANDOFF_SCHEMA not in hot_path_source, "hot-path budget should not include this handoff"
+
+    for text in (doc, readme):
+        assert_no_forbidden_text(text)
+
+    print(
+        "benchmark-program-current-state-handoff-smoke ok "
+        f"owner_docs={len(REQUIRED_OWNER_DOCS)} transitions=3 projection=docs_only"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add benchmark-program-current-state-handoff-v0 as the compact current-state runbook for fresh benchmark workers
- summarize the current evidence layer, docs-only projection decisions, allowed next transitions, and stop conditions
- add smoke coverage proving the handoff remains docs-only and does not enter status, review-packet, or hot-path interface-budget surfaces

## Validation
- python3 examples/benchmark-program-current-state-handoff-smoke.py
- python3 examples/benchmark-report-chain-map-smoke.py
- python3 examples/hot-path-interface-budget-smoke.py
- python3 -m py_compile examples/benchmark-program-current-state-handoff-smoke.py
- python3 examples/run-smokes.py
- env PATH="/Users/bytedance/.local/bin:/Users/bytedance/.cargo/bin:/Users/bytedance/.codex/tmp/arg0/codex-arg0kr5Yf6:/usr/bin:/bin:/usr/sbin:/sbin:/Applications/Codex.app/Contents/Resources" goal-harness-canary check
- git diff --check
- sensitive marker scans over new/cached public files

## Boundary
No Terminal-Bench/Harbor runner, Docker, Codex/model API, cloud/paid compute, external evaluator, private trace, raw runner log, local artifact path, approval claim, setup execution, or leaderboard path was invoked.