### PR TITLE
Fix codex-goal-harness private launch defaults

### DIFF
--- a/examples/terminal-bench-codex-goal-harness-active-cli-bridge-smoke.py
+++ b/examples/terminal-bench-codex-goal-harness-active-cli-bridge-smoke.py
@@ -585,6 +585,10 @@ def assert_harbor_command_preview() -> None:
         goal_harness_mode="codex_goal_harness",
         goal_harness_cli_bridge_enabled=True,
     )
+    mode_launch = build_terminal_bench_private_runner_launch(
+        mode="codex-goal-harness",
+        goal_harness_cli_bridge_enabled=True,
+    )
     batch_launch = build_terminal_bench_private_runner_launch(
         dataset=str(REPO_ROOT / ".local" / "harbor-datasets" / "terminal-bench-sample-gh-e2e-subset"),
         task_id=None,
@@ -619,6 +623,8 @@ def assert_harbor_command_preview() -> None:
     assert launch_summary["raw_paths_recorded"] is False, launch_summary
     assert_public_safe(launch_summary)
     assert "goal_harness_mode=codex_goal_harness" in command, command
+    assert "goal_harness_mode=codex_goal_harness" in mode_launch["argv"], mode_launch["argv"]
+    assert "goal_harness_cli_bridge_enabled=true" in mode_launch["argv"], mode_launch["argv"]
     assert "goal_harness_mode=hardened_codex_baseline" in baseline_command, baseline_command
     assert "goal_harness_ablation_mode=hardened_codex_baseline" in baseline_command, baseline_command
     assert "goal_harness_access_packet_mode=none" in baseline_command, baseline_command

--- a/goal_harness/benchmark.py
+++ b/goal_harness/benchmark.py
@@ -1353,6 +1353,17 @@ def build_terminal_bench_private_runner_launch(**command_kwargs: Any) -> dict[st
             **resolved_command_kwargs,
         )
     elif mode in ("", "codex-goal-harness", "goal-harness-managed-codex"):
+        if mode == "codex-goal-harness":
+            resolved_command_kwargs.setdefault("goal_harness_mode", "codex_goal_harness")
+            resolved_command_kwargs.setdefault(
+                "job_name",
+                "terminal_bench_codex_goal_harness_pilot",
+            )
+        elif mode == "goal-harness-managed-codex":
+            resolved_command_kwargs.setdefault(
+                "goal_harness_mode",
+                "goal_harness_managed_codex",
+            )
         argv = build_terminal_bench_managed_harbor_command(
             resolve_cli_paths=True,
             **resolved_command_kwargs,


### PR DESCRIPTION
## Summary
- Fix `codex-goal-harness` private runner launch defaults so active CLI bridge runs with `goal_harness_mode=codex_goal_harness`.
- Add a regression assertion covering the private launch argv for the active CLI bridge path.

## Why
The treatment arm initially failed before worker startup because the private launch builder defaulted to `goal_harness_managed_codex` while `goal_harness_cli_bridge_enabled=true` requires `codex_goal_harness`.

## Validation
- `python3 examples/terminal-bench-codex-goal-harness-active-cli-bridge-smoke.py`
- `python3 examples/terminal-bench-managed-real-run-preflight-guard-smoke.py`
- `python3 examples/terminal-bench-private-runner-env-guard-smoke.py`
- `python3 -m py_compile goal_harness/benchmark.py examples/terminal-bench-codex-goal-harness-active-cli-bridge-smoke.py`
- `git diff --check`
- `python3 -m goal_harness.cli --registry "$HOME/.codex/goal-harness/registry.global.json" --format json check --limit 5`

Note: `goal-harness check` passed with only the known duplicate-index warning.