### PR TITLE
Add active user simulator injection contract

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/README.md
+++ b/docs/research/long-horizon-agent-benchmarks/README.md
@@ -45,9 +45,9 @@ work still belongs in the existing code, examples, and contract documents:
   evidence to compact `benchmark_run_v0` history rows without operator
   simulation.
 - `operator-simulator-overlay-v0.md`: assisted operator-simulator overlay
-  protocol after the passive baseline, including comparison modes, simulator
-  matrix, visibility limits, intervention budget, failure taxonomy, and the
-  `operator_simulator_run_v0` row shape.
+  protocol after the passive baseline, including active user injection,
+  comparison modes, simulator matrix, visibility limits, intervention budget,
+  failure taxonomy, and the `operator_simulator_run_v0` row shape.
 - `benchmark-experiment-report-template-v0.md`: paper-ready
   `benchmark_experiment_report_v0` template that keeps official scores,
   passive control-plane metrics, assisted operator-simulator ablations,

--- a/docs/research/long-horizon-agent-benchmarks/operator-simulator-overlay-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/operator-simulator-overlay-v0.md
@@ -1,6 +1,6 @@
 # Operator-Simulator Overlay V0
 
-Checked at: 2026-06-07T23:45:00+08:00.
+Checked at: 2026-06-10T15:52:00+08:00.
 
 This protocol defines the Goal Harness assisted operator-simulator overlay for
 long-horizon benchmark research. It is not an official benchmark mode, not a
@@ -13,9 +13,12 @@ credible positive or negative result.
 The overlay studies supervised long-horizon execution: whether a bounded
 simulated operator can improve restartability, stale-state avoidance, evidence
 discipline, process-drift recovery, and continuation quality without acting as
-an oracle.
+an oracle. The assisted path should model a real user who may proactively
+intervene, redirect, or push the worker, not only a passive reviewer waiting for
+formal milestone submissions.
 
-The default local contract schema is `operator_simulator_overlay_v0`. A future
+The default local contract schema is `operator_simulator_overlay_v0`. The
+active intervention channel is `active_user_simulator_injection_v0`. A future
 run should emit `operator_simulator_run_v0` rows and keep them separate from
 official `benchmark_run_v0` and `benchmark_result_v0` rows.
 
@@ -27,10 +30,32 @@ Report these modes separately:
   policy changes and no simulated operator intervention.
 - `passive_goal_harness_wrapper`: Goal Harness observes and writes control
   state, but the worker receives no operator-simulator guidance.
-- `assisted_operator_simulator`: the worker may receive bounded process-level
-  interventions from the simulator under the visibility and budget rules below.
+- `assisted_operator_simulator`: the worker may receive bounded proactive
+  user-style interventions from the simulator under the visibility, frequency,
+  and no-oracle rules below.
 
 Never merge assisted-mode gains into official leaderboard scores.
+
+## Active User Injection
+
+The preferred first assisted path is active user injection. The simulator may
+send a message even when the worker did not ask for help. Messages may be
+directive, opinionated, and concrete, including strategy redirects, validation
+ordering, or stop-current-path instructions. They do not need to be artificially
+mild.
+
+Control this mode through audit and frequency, not through weak wording:
+
+- declare whether each message is proactive or worker-requested;
+- cap total interventions and proactive interventions separately;
+- require a minimum worker-event or time gap between proactive interventions;
+- record the public-visible evidence basis used for the message;
+- attach a no-oracle audit to every message;
+- label any suspected oracle leak, overguidance, or simulator-induced failure.
+
+Active injection is assisted collaboration evidence only. It may explain why an
+agent recovered from a bad path, but it must not be reported as an official
+benchmark-score improvement.
 
 ## Simulator Matrix
 
@@ -68,7 +93,9 @@ logs, local host paths, or any state forbidden by the benchmark protocol.
 Every assisted run must declare an intervention budget:
 
 - maximum simulator turns;
+- maximum proactive simulator turns;
 - maximum characters or tokens per intervention;
+- minimum worker events or elapsed time between proactive interventions;
 - allowed intervention types;
 - whether the simulator may ask a clarifying question;
 - stop condition after budget exhaustion.
@@ -77,16 +104,18 @@ Allowed intervention types are process-level only:
 
 - `plan_approval`;
 - `scope_clarification`;
+- `active_user_instruction`;
+- `strategy_redirection`;
 - `continue_or_stop_after_failed_validation`;
 - `validation_triage`;
 - `process_drift_correction`;
 - `evidence_request`;
 - `handoff_quality_check`.
 
-Forbidden intervention types include hidden-answer hints, benchmark-solution
-steps, private-data lookup, direct code patches, tool execution on behalf of
-the worker, and changes to benchmark prompts, tests, timeouts, resources,
-scoring, or upload behavior.
+Forbidden intervention types include hidden-answer hints, hidden-oracle
+solution steps, private-data lookup, direct code patches, tool execution on
+behalf of the worker, and changes to benchmark prompts, tests, timeouts,
+resources, scoring, or upload behavior.
 
 ## Failure Taxonomy
 
@@ -117,6 +146,7 @@ row with:
 - simulator setting from the matrix above;
 - visibility policy id and intervention budget;
 - intervention count and allowed-type counts;
+- proactive intervention count and frequency-budget audit;
 - official task score reference, if a benchmark run exists;
 - Goal Harness control-plane score reference;
 - failure labels and simulator-induced error count;

--- a/docs/research/long-horizon-agent-benchmarks/roadmap.md
+++ b/docs/research/long-horizon-agent-benchmarks/roadmap.md
@@ -342,8 +342,10 @@ the same or similar long-horizon task slice:
 
 - fixed operator-simulator model and intervention budget;
 - no access to hidden tests, expected solutions, or benchmark answer keys;
-- allowed interventions limited to plan approval, scope clarification,
-  continue/stop decisions, validation triage, and process-drift correction;
+- allowed interventions may be proactive user-style injections, including
+  directive strategy redirects, validation triage, continue/stop decisions, and
+  process-drift correction, as long as every message passes the no-oracle
+  visibility audit and stays within frequency and token budgets;
 - separate reporting from official leaderboard metrics;
 - comparison against native and passive control-plane modes.
 

--- a/examples/operator-simulator-overlay-smoke.py
+++ b/examples/operator-simulator-overlay-smoke.py
@@ -15,6 +15,7 @@ ROADMAP = TOPIC_DIR / "roadmap.md"
 PROTOCOL = TOPIC_DIR / "operator-simulator-overlay-v0.md"
 
 PLAN_SCHEMA = "operator_simulator_overlay_v0"
+ACTIVE_INJECTION_SCHEMA = "active_user_simulator_injection_v0"
 RUN_SCHEMA = "operator_simulator_run_v0"
 BENCHMARK_ID = "goal-harness-local-operator-simulator@v0"
 TASK_ID = "mini_control_plane_repair_v0"
@@ -60,6 +61,8 @@ FORBIDDEN_VISIBILITY = [
 ALLOWED_INTERVENTIONS = [
     "plan_approval",
     "scope_clarification",
+    "active_user_instruction",
+    "strategy_redirection",
     "continue_or_stop_after_failed_validation",
     "validation_triage",
     "process_drift_correction",
@@ -69,12 +72,28 @@ ALLOWED_INTERVENTIONS = [
 
 FORBIDDEN_INTERVENTIONS = [
     "hidden_answer_hint",
-    "benchmark_solution_steps",
+    "hidden_oracle_solution_steps",
     "private_data_lookup",
     "direct_code_patch",
     "tool_execution_on_worker_behalf",
     "benchmark_prompt_or_test_mutation",
     "timeout_resource_scoring_or_upload_change",
+]
+
+INTERVENTION_CHANNELS = [
+    "simulator_proactive_user_message",
+    "worker_requested_feedback",
+]
+
+NO_ORACLE_AUDIT_KEYS = [
+    "hidden_tests_seen",
+    "expected_solution_seen",
+    "answer_key_seen",
+    "private_material_seen",
+    "raw_forbidden_logs_seen",
+    "direct_patch_supplied",
+    "tool_executed_for_worker",
+    "benchmark_scoring_or_resource_changed",
 ]
 
 FAILURE_LABELS = [
@@ -123,6 +142,15 @@ def overlay_plan() -> dict[str, Any]:
             "leaderboard_claim_allowed": False,
             "model_backed_simulator_default": False,
         },
+        "active_injection_contract": {
+            "schema_version": ACTIVE_INJECTION_SCHEMA,
+            "default_channel": "simulator_proactive_user_message",
+            "message_style": "natural_user_feedback",
+            "proactive_intervention_allowed": True,
+            "directive_feedback_allowed": True,
+            "artificial_mildness_required": False,
+            "official_score_claim_allowed": False,
+        },
         "visibility_policy": {
             "policy_id": "public_worker_visible_state_only",
             "allowed": ALLOWED_VISIBILITY,
@@ -130,7 +158,11 @@ def overlay_plan() -> dict[str, Any]:
         },
         "intervention_budget": {
             "max_turns": 4,
+            "max_proactive_turns": 2,
             "max_chars_per_turn": 800,
+            "min_worker_events_between_proactive": 2,
+            "min_elapsed_seconds_between_proactive": 600,
+            "allowed_channels": INTERVENTION_CHANNELS,
             "allowed_types": ALLOWED_INTERVENTIONS,
             "forbidden_types": FORBIDDEN_INTERVENTIONS,
             "may_ask_clarifying_question": True,
@@ -169,14 +201,32 @@ def scripted_run_row(plan: dict[str, Any]) -> dict[str, Any]:
         "interventions": [
             {
                 "turn": 1,
-                "type": "scope_clarification",
-                "chars": 118,
+                "channel": "simulator_proactive_user_message",
+                "proactive": True,
+                "type": "active_user_instruction",
+                "message_style": "directive_user_feedback",
+                "chars": 236,
+                "worker_events_since_previous_proactive": 3,
+                "elapsed_seconds_since_previous_proactive": 900,
+                "visible_evidence_basis": [
+                    "public_task_statement",
+                    "worker_visible_validation_output",
+                    "compact_run_summary",
+                ],
+                "no_oracle_audit": {key: False for key in NO_ORACLE_AUDIT_KEYS},
                 "accepted_by_worker": True,
             },
             {
                 "turn": 2,
+                "channel": "worker_requested_feedback",
+                "proactive": False,
                 "type": "validation_triage",
                 "chars": 156,
+                "visible_evidence_basis": [
+                    "worker_visible_validation_output",
+                    "public_safe_goal_harness_state_summary",
+                ],
+                "no_oracle_audit": {key: False for key in NO_ORACLE_AUDIT_KEYS},
                 "accepted_by_worker": True,
             },
         ],
@@ -197,6 +247,12 @@ def scripted_run_row(plan: dict[str, Any]) -> dict[str, Any]:
             "cost_usd": 0.0,
         },
         "trace_publicness": "public_contract_fixture",
+        "frequency_budget_audit": {
+            "proactive_interventions": 1,
+            "max_proactive_turns": plan["intervention_budget"]["max_proactive_turns"],
+            "min_worker_events_between_proactive_satisfied": True,
+            "min_elapsed_seconds_between_proactive_satisfied": True,
+        },
         "side_effect_audit_passed": True,
     }
 
@@ -209,13 +265,18 @@ def assert_doc_contract() -> None:
     required = [
         "Operator-Simulator Overlay V0",
         PLAN_SCHEMA,
+        ACTIVE_INJECTION_SCHEMA,
         RUN_SCHEMA,
         "Comparison Modes",
+        "Active User Injection",
         "Simulator Matrix",
         "Visibility Limits",
         "Intervention Budget",
         "Failure Taxonomy",
         "deterministic_scripted_user",
+        "active_user_instruction",
+        "strategy_redirection",
+        "frequency-budget audit",
         "same_family_simulator_agent",
         "stronger_simulator_weaker_agent",
         "weaker_simulator_stronger_agent",
@@ -252,8 +313,18 @@ def assert_plan_contract(plan: dict[str, Any]) -> None:
     assert plan["preconditions"]["official_score_separation_required"] is True, plan
     assert plan["preconditions"]["leaderboard_claim_allowed"] is False, plan
     assert plan["preconditions"]["model_backed_simulator_default"] is False, plan
+    active = plan["active_injection_contract"]
+    assert active["schema_version"] == ACTIVE_INJECTION_SCHEMA, plan
+    assert active["proactive_intervention_allowed"] is True, plan
+    assert active["directive_feedback_allowed"] is True, plan
+    assert active["artificial_mildness_required"] is False, plan
+    assert active["official_score_claim_allowed"] is False, plan
     assert set(plan["visibility_policy"]["allowed"]) == set(ALLOWED_VISIBILITY), plan
     assert set(plan["visibility_policy"]["forbidden"]) == set(FORBIDDEN_VISIBILITY), plan
+    assert set(plan["intervention_budget"]["allowed_channels"]) == set(INTERVENTION_CHANNELS), plan
+    assert plan["intervention_budget"]["max_proactive_turns"] < plan["intervention_budget"]["max_turns"], plan
+    assert plan["intervention_budget"]["min_worker_events_between_proactive"] >= 1, plan
+    assert plan["intervention_budget"]["min_elapsed_seconds_between_proactive"] >= 60, plan
     assert set(plan["intervention_budget"]["allowed_types"]) == set(ALLOWED_INTERVENTIONS), plan
     assert set(plan["intervention_budget"]["forbidden_types"]) == set(FORBIDDEN_INTERVENTIONS), plan
     assert set(plan["failure_taxonomy"]) == set(FAILURE_LABELS), plan
@@ -271,8 +342,30 @@ def assert_run_contract(plan: dict[str, Any], row: dict[str, Any]) -> None:
     assert row["simulator_induced_error_count"] == 0, row
     assert row["side_effect_audit_passed"] is True, row
     assert row["trace_publicness"] == "public_contract_fixture", row
+    proactive_interventions = [item for item in row["interventions"] if item["proactive"]]
+    assert len(proactive_interventions) == row["frequency_budget_audit"]["proactive_interventions"], row
+    assert len(proactive_interventions) <= plan["intervention_budget"]["max_proactive_turns"], row
+    assert row["frequency_budget_audit"]["min_worker_events_between_proactive_satisfied"] is True, row
+    assert row["frequency_budget_audit"]["min_elapsed_seconds_between_proactive_satisfied"] is True, row
     assert all(
         intervention["type"] in plan["intervention_budget"]["allowed_types"]
+        for intervention in row["interventions"]
+    ), row
+    assert all(
+        intervention["channel"] in plan["intervention_budget"]["allowed_channels"]
+        for intervention in row["interventions"]
+    ), row
+    assert all(
+        set(intervention["visible_evidence_basis"]) <= set(plan["visibility_policy"]["allowed"])
+        for intervention in row["interventions"]
+    ), row
+    assert all(
+        set(intervention["no_oracle_audit"]) == set(NO_ORACLE_AUDIT_KEYS)
+        and not any(intervention["no_oracle_audit"].values())
+        for intervention in row["interventions"]
+    ), row
+    assert all(
+        intervention["chars"] <= plan["intervention_budget"]["max_chars_per_turn"]
         for intervention in row["interventions"]
     ), row
     assert row["overhead"]["cost_usd"] == 0.0, row
@@ -289,6 +382,7 @@ def main() -> None:
         "operator-simulator-overlay-smoke ok "
         f"settings={len(plan['simulator_settings'])} "
         f"interventions={len(row['interventions'])} "
+        f"proactive={row['frequency_budget_audit']['proactive_interventions']} "
         f"model_api={plan['side_effect_budget']['model_api']}"
     )
 

--- a/examples/serve-status-global-registry-smoke.py
+++ b/examples/serve-status-global-registry-smoke.py
@@ -112,6 +112,8 @@ def main() -> None:
             "127.0.0.1",
             "--port",
             str(port),
+            "--scan-path",
+            str(REPO_ROOT / "README.md"),
             "--limit",
             "10",
         ]


### PR DESCRIPTION
## Summary
- extend the operator-simulator overlay to support proactive active-user injections
- add deterministic smoke coverage for directive proactive feedback, frequency budgets, visible-evidence basis, and no-oracle audits
- narrow the serve-status global registry smoke to an explicit public scan path so full smokes are stable

## Validation
- python3 examples/operator-simulator-overlay-smoke.py
- python3 examples/benchmark-experiment-report-template-smoke.py
- python3 -m py_compile examples/operator-simulator-overlay-smoke.py
- python3 examples/serve-status-global-registry-smoke.py
- python3 examples/run-smokes.py
- python3 -m goal_harness.cli --registry "/Users/bytedance/.codex/goal-harness/registry.global.json" --format json check --limit 5

## Claim boundary
- No model-backed simulator run, benchmark run, Docker/cloud/paid compute, private traces, raw logs, or leaderboard upload.
- Assisted user-simulator gains remain separate from official benchmark scores.