### PR TITLE
Add active-user assisted pilot append support

### DIFF
--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -1547,6 +1547,24 @@ accepts only a compact `benchmark_experiment_report_v0` JSON object; it does
 not run a benchmark, invoke a model or simulator, read runner directories, parse
 private artifacts, or infer leaderboard claims.
 
+When a compact run record includes `active_user_assisted_pilot_summary`, it is a
+redacted projection of `active_user_assisted_pilot_v0`. The summary is for
+assisted-collaboration research only: compact pilot identity, failure trigger,
+active-injection contract flags, frequency budget, visibility policy,
+operator-simulator audit counts, claim boundary, and next-run decision. It must
+not include raw simulator messages, worker chat transcripts, local artifact
+paths, hidden tests, expected solutions, benchmark answer keys, private traces,
+credentials, or leaderboard submission artifacts. It must also keep the
+assisted-collaboration claim separate from official benchmark score claims.
+
+`goal-harness history append-active-user-assisted-pilot --active-user-pilot-json
+<path>` is the matching append path for this projection. It is dry-run by
+default and accepts only a compactable `active_user_assisted_pilot_v0` JSON
+object; the CLI compacts the input before writing durable history. It does not
+run a benchmark, call a model-backed simulator, read private runner artifacts,
+interact with a worker, infer hidden test results, or authorize leaderboard
+claims.
+
 When `benchmark_experiment_report_summary` is present, status may also include
 `benchmark_experiment_report_readiness_note`. This is a derived consumer note,
 not a new benchmark event or publication approval. It turns the compact report

--- a/examples/active-user-assisted-pilot-append-cli-smoke.py
+++ b/examples/active-user-assisted-pilot-append-cli-smoke.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""Smoke-test appending compact active_user_assisted_pilot_v0 events."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from goal_harness.status import collect_status  # noqa: E402
+
+
+GOAL_ID = "active-user-assisted-pilot-append-fixture"
+PILOT_SCHEMA = "active_user_assisted_pilot_v0"
+ACTIVE_INJECTION_SCHEMA = "active_user_simulator_injection_v0"
+RUN_SCHEMA = "operator_simulator_run_v0"
+
+
+NO_ORACLE_AUDIT_KEYS = [
+    "hidden_tests_seen",
+    "expected_solution_seen",
+    "answer_key_seen",
+    "private_material_seen",
+    "raw_forbidden_logs_seen",
+    "direct_patch_supplied",
+    "tool_executed_for_worker",
+    "benchmark_scoring_or_resource_changed",
+]
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def active_user_pilot_event() -> dict[str, Any]:
+    return {
+        "schema_version": PILOT_SCHEMA,
+        "pilot_id": "train-fasttext-active-user-assisted-pilot-v0",
+        "benchmark_id": "terminal-bench@2.0",
+        "task_id": "train-fasttext",
+        "trigger": {
+            "kind": "previous_compact_negative_result",
+            "failed_autonomous_modes": [
+                {"mode": "hardened_codex_baseline", "official_task_score": 0.0},
+                {"mode": "codex_goal_harness", "official_task_score": 0.0},
+            ],
+            "both_autonomous_modes_failed": True,
+            "assisted_score_kind": "not_run",
+        },
+        "active_injection_contract": {
+            "schema_version": ACTIVE_INJECTION_SCHEMA,
+            "simulator_setting": "deterministic_scripted_user",
+            "proactive_intervention_allowed": True,
+            "directive_feedback_allowed": True,
+            "artificial_mildness_required": False,
+        },
+        "frequency_budget": {
+            "max_interventions": 3,
+            "max_proactive_interventions": 2,
+            "min_worker_events_between_proactive": 2,
+            "max_chars_per_intervention": 800,
+        },
+        "visibility_policy": {
+            "policy_id": "compact_failure_and_worker_visible_state_only",
+            "allowed": [
+                "public_task_statement",
+                "compact_failure_summary",
+                "worker_visible_validation_output",
+                "public_safe_goal_harness_state_summary",
+            ],
+            "forbidden": [
+                "hidden_tests",
+                "expected_solutions",
+                "benchmark_answer_keys",
+                "private_project_material",
+                "raw_runner_logs",
+                "local_host_paths",
+            ],
+        },
+        "operator_simulator_run": {
+            "schema_version": RUN_SCHEMA,
+            "simulator_identity": {
+                "setting": "deterministic_scripted_user",
+                "model_family": "scripted",
+                "seed": "active-user-assisted-pilot-v0",
+            },
+            "interventions": [
+                {
+                    "turn": 1,
+                    "proactive": True,
+                    "type": "strategy_redirection",
+                    "chars": 312,
+                    "worker_events_since_previous_proactive": 3,
+                    "no_oracle_audit": {key: False for key in NO_ORACLE_AUDIT_KEYS},
+                    "raw_simulator_message": "This field must not survive compaction.",
+                },
+                {
+                    "turn": 2,
+                    "proactive": True,
+                    "type": "validation_triage",
+                    "chars": 241,
+                    "worker_events_since_previous_proactive": 2,
+                    "no_oracle_audit": {key: False for key in NO_ORACLE_AUDIT_KEYS},
+                },
+            ],
+            "official_task_score_reference": {
+                "kind": "not_run",
+                "value": None,
+                "reason": "deterministic assisted pilot does not execute Terminal-Bench",
+            },
+            "simulator_induced_error_count": 0,
+            "frequency_budget_audit": {
+                "proactive_interventions": 2,
+                "max_proactive_interventions": 2,
+                "min_worker_events_between_proactive_satisfied": True,
+            },
+            "side_effect_audit": {
+                "model_api": False,
+                "benchmark_run": False,
+                "docker": False,
+                "cloud_sandbox": False,
+                "paid_compute": False,
+                "private_artifact_read": False,
+                "leaderboard_upload": False,
+            },
+            "next_run_decision": {
+                "decision": "eligible_for_private_no_upload_assisted_treatment",
+                "minimum_next_evidence": "real no-upload assisted treatment with separate official score",
+                "requires_real_runner_approval": True,
+                "keep_official_scores_separate": True,
+            },
+            "raw" + "_runner_log_path": "/" + "U" + "sers/example/private/raw.log",
+        },
+        "claim_boundary": {
+            "official_score_claim_allowed": False,
+            "assisted_collaboration_claim_allowed": True,
+            "leaderboard_claim_allowed": False,
+        },
+        "local" + "_artifact_path": "/" + "t" + "mp/private/active-user-pilot.json",
+    }
+
+
+def write_fixture(root: Path) -> tuple[Path, Path, Path]:
+    project = root / "project"
+    runtime = root / "runtime"
+    state_file = f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    registry_path = project / ".goal-harness" / "registry.json"
+    pilot_path = root / "active_user_pilot.json"
+
+    (project / Path(state_file).parent).mkdir(parents=True, exist_ok=True)
+    (project / state_file).write_text(
+        "---\n"
+        "status: active-read-only\n"
+        "updated_at: 2026-06-10T00:00:00+00:00\n"
+        "---\n\n"
+        "# Active User Assisted Pilot Append Fixture\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] Append compact active_user_assisted_pilot_v0 through the CLI.\n\n"
+        "## Next Action\n\n"
+        "- Inspect the appended active-user assisted pilot projection.\n",
+        encoding="utf-8",
+    )
+    write_json(
+        registry_path,
+        {
+            "schema_version": 1,
+            "updated_at": "2026-06-10T00:00:00+00:00",
+            "common_runtime_root": str(runtime),
+            "goals": [
+                {
+                    "id": GOAL_ID,
+                    "domain": "benchmark-active-user-pilot",
+                    "status": "active-read-only",
+                    "repo": str(project),
+                    "state_file": state_file,
+                    "adapter": {
+                        "kind": "harness_self_improvement",
+                        "status": "connected-read-only",
+                    },
+                    "quota": {"compute": 1.0, "window_hours": 24},
+                    "authority_sources": [],
+                }
+            ],
+        },
+    )
+    write_json(pilot_path, active_user_pilot_event())
+    return registry_path, runtime, pilot_path
+
+
+def run_cli(args: list[str]) -> dict[str, Any]:
+    result = subprocess.run(
+        [sys.executable, "-m", "goal_harness.cli", *args],
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    payload = json.loads(result.stdout)
+    assert isinstance(payload, dict), payload
+    return payload
+
+
+def assert_no_private_surface(summary: dict[str, Any]) -> None:
+    text = json.dumps(summary, sort_keys=True)
+    forbidden = [
+        "/" + "Users/",
+        "/" + "tmp/",
+        "OPENAI" + "_API_KEY",
+        "auth" + ".json",
+        "sessions/",
+        "raw_simulator_message",
+        "raw" + "_runner_log_path",
+        "local" + "_artifact_path",
+        "hidden_tests",
+        "expected_solutions",
+        "benchmark_answer_keys",
+    ]
+    leaked = [needle for needle in forbidden if needle in text]
+    assert not leaked, leaked
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory(prefix="active-user-pilot-append-") as tmp:
+        registry_path, runtime, pilot_path = write_fixture(Path(tmp))
+        index_path = runtime / "goals" / GOAL_ID / "runs" / "index.jsonl"
+
+        args = [
+            "--registry",
+            str(registry_path),
+            "--runtime-root",
+            str(runtime),
+            "--format",
+            "json",
+            "history",
+            "append-active-user-assisted-pilot",
+            "--goal-id",
+            GOAL_ID,
+            "--active-user-pilot-json",
+            str(pilot_path),
+            "--delivery-batch-scale",
+            "implementation",
+            "--delivery-outcome",
+            "primary_goal_outcome",
+            "--no-global-sync",
+        ]
+
+        dry_run = run_cli(args)
+        assert dry_run["ok"], dry_run
+        assert dry_run["dry_run"] is True, dry_run
+        assert dry_run["appended"] is False, dry_run
+        assert not index_path.exists(), index_path
+        assert_no_private_surface(dry_run["active_user_assisted_pilot"])
+
+        appended = run_cli([*args, "--execute"])
+        assert appended["ok"], appended
+        assert appended["dry_run"] is False, appended
+        assert appended["appended"] is True, appended
+        assert index_path.exists(), index_path
+        assert_no_private_surface(appended["active_user_assisted_pilot"])
+
+        index_records = [
+            json.loads(line)
+            for line in index_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        assert len(index_records) == 1, index_records
+        record = index_records[0]
+        assert record["classification"] == PILOT_SCHEMA, record
+        assert record["active_user_assisted_pilot"]["schema_version"] == PILOT_SCHEMA, record
+        assert_no_private_surface(record["active_user_assisted_pilot"])
+
+        status = collect_status(
+            registry_path=registry_path,
+            runtime_root_override=str(runtime),
+            scan_roots=[],
+            limit=10,
+        )
+        assert status["ok"], status
+        latest_runs = status["run_history"]["goals"][0]["latest_runs"]
+        pilot_run = next(run for run in latest_runs if run.get("classification") == PILOT_SCHEMA)
+        summary = pilot_run["active_user_assisted_pilot_summary"]
+        assert summary["schema_version"] == PILOT_SCHEMA, summary
+        assert summary["pilot_id"] == "train-fasttext-active-user-assisted-pilot-v0", summary
+        assert summary["benchmark_id"] == "terminal-bench@2.0", summary
+        assert summary["task_id"] == "train-fasttext", summary
+
+        trigger = summary["trigger"]
+        assert trigger["both_autonomous_modes_failed"] is True, trigger
+        assert trigger["failed_autonomous_mode_count"] == 2, trigger
+        assert trigger["failed_autonomous_modes"] == ["hardened_codex_baseline", "codex_goal_harness"], trigger
+        assert trigger["assisted_score_kind"] == "not_run", trigger
+
+        operator = summary["operator_simulator_run"]
+        assert operator["schema_version"] == RUN_SCHEMA, operator
+        assert operator["setting"] == "deterministic_scripted_user", operator
+        assert operator["model_family"] == "scripted", operator
+        assert operator["intervention_count"] == 2, operator
+        assert operator["proactive_intervention_count"] == 2, operator
+        assert operator["no_oracle_audit_passed"] is True, operator
+        assert operator["official_task_score_kind"] == "not_run", operator
+        assert operator["simulator_induced_error_count"] == 0, operator
+        assert operator["frequency_budget_satisfied"] is True, operator
+        assert operator["side_effect_audit_passed"] is True, operator
+
+        boundary = summary["claim_boundary"]
+        assert boundary["official_score_claim_allowed"] is False, boundary
+        assert boundary["assisted_collaboration_claim_allowed"] is True, boundary
+        assert boundary["leaderboard_claim_allowed"] is False, boundary
+
+        decision = summary["next_run_decision"]
+        assert decision["decision"] == "eligible_for_private_no_upload_assisted_treatment", decision
+        assert decision["requires_real_runner_approval"] is True, decision
+        assert decision["keep_official_scores_separate"] is True, decision
+        assert_no_private_surface(summary)
+
+        print(
+            "active-user-assisted-pilot-append-cli-smoke ok "
+            f"task={summary['task_id']} "
+            f"failed_modes={trigger['failed_autonomous_mode_count']} "
+            f"proactive={operator['proactive_intervention_count']} "
+            f"official={operator['official_task_score_kind']}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -47,12 +47,14 @@ from .global_registry import render_global_sync_markdown, sync_project_registry_
 from .handoff_budget import build_handoff_interface_budget
 from .heartbeat_prompt import build_heartbeat_prompt, render_heartbeat_prompt_markdown
 from .history import (
+    append_active_user_assisted_pilot,
     append_benchmark_comparison,
     append_benchmark_experiment_report,
     append_benchmark_result,
     append_benchmark_run,
     collect_history,
     load_registry,
+    render_active_user_assisted_pilot_append_markdown,
     render_benchmark_comparison_append_markdown,
     render_benchmark_experiment_report_append_markdown,
     render_benchmark_result_append_markdown,
@@ -100,6 +102,7 @@ from .state_refresh import (
 )
 from .status import (
     collect_status,
+    compact_active_user_assisted_pilot,
     compact_benchmark_comparison,
     compact_benchmark_experiment_report,
     compact_benchmark_result,
@@ -710,8 +713,9 @@ def main(argv: list[str] | None = None) -> int:
             "append-benchmark-result",
             "append-benchmark-comparison",
             "append-benchmark-report",
+            "append-active-user-assisted-pilot",
         ],
-        help="Append a compact benchmark_run_v0, benchmark_result_v0, benchmark_comparison_v0, or benchmark_experiment_report_v0 event.",
+        help="Append a compact benchmark_run_v0, benchmark_result_v0, benchmark_comparison_v0, benchmark_experiment_report_v0, or active_user_assisted_pilot_v0 event.",
     )
     history_parser.add_argument("--goal-id", help="Only show one goal.")
     history_parser.add_argument("--limit", type=int, default=10)
@@ -730,6 +734,10 @@ def main(argv: list[str] | None = None) -> int:
     history_parser.add_argument(
         "--benchmark-report-json",
         help="Path to a benchmark_experiment_report_v0 JSON object. Use '-' to read stdin.",
+    )
+    history_parser.add_argument(
+        "--active-user-pilot-json",
+        help="Path to an active_user_assisted_pilot_v0 JSON object. Use '-' to read stdin.",
     )
     history_parser.add_argument("--classification")
     history_parser.add_argument(
@@ -2024,6 +2032,73 @@ def main(argv: list[str] | None = None) -> int:
                     "error": str(exc),
                 }
             print_payload(payload, args.format, render_benchmark_experiment_report_append_markdown)
+            return 0 if payload.get("ok") else 1
+
+        if args.history_action == "append-active-user-assisted-pilot":
+            try:
+                if args.dry_run and args.execute:
+                    raise ValueError(
+                        "history append-active-user-assisted-pilot accepts either --dry-run or --execute, not both"
+                    )
+                if not args.goal_id:
+                    raise ValueError("history append-active-user-assisted-pilot requires --goal-id")
+                if not args.active_user_pilot_json:
+                    raise ValueError(
+                        "history append-active-user-assisted-pilot requires --active-user-pilot-json"
+                    )
+
+                if args.active_user_pilot_json == "-":
+                    active_user_pilot_input = json.loads(sys.stdin.read())
+                else:
+                    active_user_pilot_input = json.loads(
+                        Path(args.active_user_pilot_json).expanduser().read_text(encoding="utf-8")
+                    )
+                if not isinstance(active_user_pilot_input, dict):
+                    raise ValueError("--active-user-pilot-json must contain a JSON object")
+                active_user_pilot = compact_active_user_assisted_pilot(active_user_pilot_input)
+                if not active_user_pilot:
+                    raise ValueError(
+                        "--active-user-pilot-json did not contain a compactable active_user_assisted_pilot_v0 object"
+                    )
+
+                dry_run = not bool(args.execute)
+                payload = append_active_user_assisted_pilot(
+                    registry_path=registry_path,
+                    runtime_root_override=args.runtime_root,
+                    goal_id=args.goal_id,
+                    active_user_assisted_pilot=active_user_pilot,
+                    classification=args.classification or "active_user_assisted_pilot_v0",
+                    recommended_action=args.recommended_action,
+                    delivery_batch_scale=args.delivery_batch_scale,
+                    delivery_outcome=args.delivery_outcome,
+                    dry_run=dry_run,
+                )
+                if args.no_global_sync:
+                    payload["global_sync"] = {
+                        "ok": True,
+                        "dry_run": dry_run,
+                        "skipped": True,
+                        "reason": "disabled by --no-global-sync",
+                    }
+                else:
+                    payload["global_sync"] = sync_project_registry_to_global(
+                        registry_path=registry_path,
+                        runtime_root_override=args.runtime_root,
+                        goal_id=args.goal_id,
+                        dry_run=dry_run,
+                    )
+            except Exception as exc:
+                payload = {
+                    "ok": False,
+                    "dry_run": not bool(args.execute),
+                    "appended": False,
+                    "registry": str(registry_path),
+                    "runtime_root": args.runtime_root,
+                    "goal_id": args.goal_id,
+                    "classification": args.classification or "active_user_assisted_pilot_v0",
+                    "error": str(exc),
+                }
+            print_payload(payload, args.format, render_active_user_assisted_pilot_append_markdown)
             return 0 if payload.get("ok") else 1
 
         try:

--- a/goal_harness/history.py
+++ b/goal_harness/history.py
@@ -413,6 +413,79 @@ def append_benchmark_experiment_report(
     return payload
 
 
+def append_active_user_assisted_pilot(
+    *,
+    registry_path: Path,
+    runtime_root_override: str | None,
+    goal_id: str,
+    active_user_assisted_pilot: dict[str, Any],
+    classification: str = "active_user_assisted_pilot_v0",
+    recommended_action: str | None = None,
+    delivery_batch_scale: str | None = None,
+    delivery_outcome: str | None = None,
+    dry_run: bool = True,
+) -> dict[str, Any]:
+    safe_goal_id = validate_goal_id_path_segment(goal_id)
+    if active_user_assisted_pilot.get("schema_version") != "active_user_assisted_pilot_v0":
+        raise ValueError("active user assisted pilot must have schema_version=active_user_assisted_pilot_v0")
+
+    registry = load_registry(registry_path)
+    runtime_root = resolve_runtime_root(registry, runtime_root_override)
+    generated_at = now_local()
+    action = recommended_action or "inspect active_user_assisted_pilot_v0 summary and decide assisted treatment next step"
+    health_check = "active_user_assisted_pilot_v0 compact event public-safe"
+
+    runs_dir = runtime_root / "goals" / safe_goal_id / "runs"
+    json_path, markdown_path = unique_run_paths(runs_dir, generated_at)
+    index_path = runs_dir / "index.jsonl"
+    record: dict[str, Any] = {
+        "generated_at": generated_at,
+        "goal_id": safe_goal_id,
+        "classification": classification,
+        "recommended_action": action,
+        "health_check": health_check,
+        "active_user_assisted_pilot": active_user_assisted_pilot,
+    }
+    if delivery_batch_scale:
+        record["delivery_batch_scale"] = delivery_batch_scale
+    if delivery_outcome:
+        record["delivery_outcome"] = delivery_outcome
+
+    index_record = {
+        **record,
+        "json_path": str(json_path),
+        "markdown_path": str(markdown_path),
+    }
+    payload = {
+        "ok": True,
+        "dry_run": dry_run,
+        "appended": not dry_run,
+        "registry": str(registry_path),
+        "runtime_root": str(runtime_root),
+        "goal_id": safe_goal_id,
+        "classification": classification,
+        "recommended_action": action,
+        "generated_at": generated_at,
+        "health_check": health_check,
+        "json_path": str(json_path),
+        "markdown_path": str(markdown_path),
+        "index_path": str(index_path),
+        "active_user_assisted_pilot": active_user_assisted_pilot,
+    }
+    if delivery_batch_scale:
+        payload["delivery_batch_scale"] = delivery_batch_scale
+    if delivery_outcome:
+        payload["delivery_outcome"] = delivery_outcome
+
+    if not dry_run:
+        runs_dir.mkdir(parents=True, exist_ok=True)
+        json_path.write_text(json.dumps(record, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        markdown_path.write_text(render_active_user_assisted_pilot_append_markdown(payload) + "\n", encoding="utf-8")
+        with index_path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(index_record, ensure_ascii=False) + "\n")
+    return payload
+
+
 def latest_status_run(runs: list[dict[str, Any]]) -> dict[str, Any] | None:
     for run in runs:
         if str(run.get("classification") or "") in STATUS_NEUTRAL_CLASSIFICATIONS:
@@ -731,6 +804,67 @@ def render_benchmark_experiment_report_append_markdown(payload: dict[str, Any]) 
                 f"- null_official_delta: `{negative.get('null_official_delta')}`",
                 f"- negative_evidence_layers: `{negative.get('negative_evidence_layers')}`",
                 f"- next_decision: `{next_decision.get('decision')}`",
+            ]
+        )
+    if payload.get("error"):
+        lines.append(f"- error: {payload.get('error')}")
+    return "\n".join(lines)
+
+
+def render_active_user_assisted_pilot_append_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Goal Harness Active User Assisted Pilot Append",
+        "",
+        f"- ok: `{payload.get('ok')}`",
+        f"- dry_run: `{payload.get('dry_run')}`",
+        f"- appended: `{payload.get('appended')}`",
+        f"- goal_id: `{payload.get('goal_id')}`",
+        f"- classification: `{payload.get('classification')}`",
+        f"- generated_at: `{payload.get('generated_at')}`",
+    ]
+    if payload.get("json_path"):
+        lines.append(f"- json_path: `{payload.get('json_path')}`")
+    if payload.get("index_path"):
+        lines.append(f"- index_path: `{payload.get('index_path')}`")
+    if payload.get("recommended_action"):
+        lines.append(f"- recommended_action: {payload.get('recommended_action')}")
+
+    pilot = (
+        payload.get("active_user_assisted_pilot")
+        if isinstance(payload.get("active_user_assisted_pilot"), dict)
+        else {}
+    )
+    if pilot:
+        trigger = pilot.get("trigger") if isinstance(pilot.get("trigger"), dict) else {}
+        operator_run = (
+            pilot.get("operator_simulator_run")
+            if isinstance(pilot.get("operator_simulator_run"), dict)
+            else {}
+        )
+        next_decision = (
+            pilot.get("next_run_decision")
+            if isinstance(pilot.get("next_run_decision"), dict)
+            else {}
+        )
+        lines.extend(
+            [
+                "",
+                "## Active User Assisted Pilot",
+                "",
+                f"- schema_version: `{pilot.get('schema_version')}`",
+                f"- pilot_id: `{pilot.get('pilot_id')}`",
+                f"- benchmark_id: `{pilot.get('benchmark_id')}`",
+                f"- task_id: `{pilot.get('task_id')}`",
+                f"- trigger_kind: `{trigger.get('kind')}`",
+                f"- failed_autonomous_mode_count: `{trigger.get('failed_autonomous_mode_count')}`",
+                f"- assisted_score_kind: `{trigger.get('assisted_score_kind')}`",
+                f"- operator_run_schema: `{operator_run.get('schema_version')}`",
+                f"- proactive_intervention_count: `{operator_run.get('proactive_intervention_count')}`",
+                f"- no_oracle_audit_passed: `{operator_run.get('no_oracle_audit_passed')}`",
+                f"- side_effect_audit_passed: `{operator_run.get('side_effect_audit_passed')}`",
+                f"- official_task_score_kind: `{operator_run.get('official_task_score_kind')}`",
+                f"- next_decision: `{next_decision.get('decision')}`",
+                f"- keep_official_scores_separate: `{next_decision.get('keep_official_scores_separate')}`",
             ]
         )
     if payload.get("error"):

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -87,6 +87,8 @@ WORKER_BRIDGE_INGEST_HEALTH_SCHEMA_VERSION = "worker_bridge_ingest_health_note_v
 BENCHMARK_EXPERIMENT_REPORT_SCHEMA_VERSION = "benchmark_experiment_report_v0"
 BENCHMARK_EXPERIMENT_REPORT_READINESS_SCHEMA_VERSION = "benchmark_experiment_report_readiness_note_v0"
 BENCHMARK_EXPERIMENT_REPORT_REPLAY_DECISION_SCHEMA_VERSION = "benchmark_experiment_report_replay_decision_v0"
+ACTIVE_USER_ASSISTED_PILOT_SCHEMA_VERSION = "active_user_assisted_pilot_v0"
+OPERATOR_SIMULATOR_RUN_SCHEMA_VERSION = "operator_simulator_run_v0"
 CONTROL_PLANE_SCORE_SCHEMA_VERSION = "control_plane_score_core_v0"
 CONTROL_PLANE_SCORE_COMPONENTS = (
     "restartability",
@@ -1676,6 +1678,186 @@ def benchmark_experiment_report_replay_decision(readiness_note: dict[str, Any] |
     return decision
 
 
+def _active_user_assisted_pilot_source(run: dict[str, Any]) -> dict[str, Any] | None:
+    nested = run.get("active_user_assisted_pilot")
+    if isinstance(nested, dict) and nested.get("schema_version") == ACTIVE_USER_ASSISTED_PILOT_SCHEMA_VERSION:
+        return nested
+    if run.get("schema_version") == ACTIVE_USER_ASSISTED_PILOT_SCHEMA_VERSION:
+        return run
+    return None
+
+
+def compact_active_user_assisted_pilot(run: dict[str, Any]) -> dict[str, Any] | None:
+    source = _active_user_assisted_pilot_source(run)
+    if not source:
+        return None
+
+    compact: dict[str, Any] = {"schema_version": ACTIVE_USER_ASSISTED_PILOT_SCHEMA_VERSION}
+    for field in ("pilot_id", "benchmark_id", "task_id"):
+        value = public_safe_compact_text(source.get(field), limit=140)
+        if value:
+            compact[field] = value
+
+    trigger = source.get("trigger") if isinstance(source.get("trigger"), dict) else {}
+    compact_trigger: dict[str, Any] = {}
+    for field in ("kind", "assisted_score_kind"):
+        value = public_safe_compact_text(trigger.get(field), limit=120)
+        if value:
+            compact_trigger[field] = value
+    if isinstance(trigger.get("both_autonomous_modes_failed"), bool):
+        compact_trigger["both_autonomous_modes_failed"] = trigger.get("both_autonomous_modes_failed")
+    failed_modes = trigger.get("failed_autonomous_modes") if isinstance(trigger.get("failed_autonomous_modes"), list) else []
+    if failed_modes:
+        compact_trigger["failed_autonomous_mode_count"] = len(failed_modes)
+        mode_names = []
+        for item in failed_modes:
+            if isinstance(item, str):
+                mode = public_safe_compact_text(item, limit=100)
+            elif isinstance(item, dict):
+                mode = public_safe_compact_text(item.get("mode"), limit=100)
+            else:
+                continue
+            if mode:
+                mode_names.append(mode)
+            if len(mode_names) >= MAX_BENCHMARK_RUN_LIST_ITEMS:
+                break
+        if mode_names:
+            compact_trigger["failed_autonomous_modes"] = mode_names
+    if compact_trigger:
+        compact["trigger"] = compact_trigger
+
+    active = source.get("active_injection_contract") if isinstance(source.get("active_injection_contract"), dict) else {}
+    compact_active: dict[str, Any] = {}
+    for field in ("schema_version", "simulator_setting"):
+        value = public_safe_compact_text(active.get(field), limit=120)
+        if value:
+            compact_active[field] = value
+    for field in ("proactive_intervention_allowed", "directive_feedback_allowed", "artificial_mildness_required"):
+        if isinstance(active.get(field), bool):
+            compact_active[field] = active.get(field)
+    if compact_active:
+        compact["active_injection_contract"] = compact_active
+
+    budget = source.get("frequency_budget") if isinstance(source.get("frequency_budget"), dict) else {}
+    compact_budget = _compact_numeric_map(
+        budget,
+        keys=(
+            "max_interventions",
+            "max_proactive_interventions",
+            "min_worker_events_between_proactive",
+            "max_chars_per_intervention",
+        ),
+    )
+    if compact_budget:
+        compact["frequency_budget"] = compact_budget
+
+    visibility = source.get("visibility_policy") if isinstance(source.get("visibility_policy"), dict) else {}
+    compact_visibility: dict[str, Any] = {}
+    policy_id = public_safe_compact_text(visibility.get("policy_id"), limit=140)
+    if policy_id:
+        compact_visibility["policy_id"] = policy_id
+    visibility_allowed_source = visibility.get("allowed")
+    if visibility_allowed_source is None:
+        visibility_allowed_source = visibility.get("allowed_visibility")
+    allowed_visibility = public_safe_compact_list(visibility_allowed_source, limit=MAX_BENCHMARK_RUN_LIST_ITEMS)
+    if allowed_visibility:
+        compact_visibility["allowed_visibility"] = allowed_visibility
+    if compact_visibility:
+        compact["visibility_policy"] = compact_visibility
+
+    operator_run = source.get("operator_simulator_run") if isinstance(source.get("operator_simulator_run"), dict) else {}
+    compact_operator: dict[str, Any] = {}
+    if operator_run.get("schema_version") == OPERATOR_SIMULATOR_RUN_SCHEMA_VERSION:
+        compact_operator["schema_version"] = OPERATOR_SIMULATOR_RUN_SCHEMA_VERSION
+    simulator_identity = (
+        operator_run.get("simulator_identity")
+        if isinstance(operator_run.get("simulator_identity"), dict)
+        else operator_run
+    )
+    for field in ("setting", "model_family", "seed"):
+        value = public_safe_compact_text(simulator_identity.get(field), limit=140)
+        if value:
+            compact_operator[field] = value
+    interventions = operator_run.get("interventions") if isinstance(operator_run.get("interventions"), list) else []
+    if interventions:
+        compact_operator["intervention_count"] = len(interventions)
+        compact_operator["proactive_intervention_count"] = sum(
+            1 for item in interventions if isinstance(item, dict) and item.get("proactive") is True
+        )
+        compact_operator["no_oracle_audit_passed"] = all(
+            isinstance(item, dict)
+            and isinstance(item.get("no_oracle_audit"), dict)
+            and not any(bool(value) for value in item["no_oracle_audit"].values())
+            for item in interventions
+        )
+    else:
+        for field in ("intervention_count", "proactive_intervention_count"):
+            if isinstance(operator_run.get(field), int):
+                compact_operator[field] = operator_run.get(field)
+        if isinstance(operator_run.get("no_oracle_audit_passed"), bool):
+            compact_operator["no_oracle_audit_passed"] = operator_run.get("no_oracle_audit_passed")
+    official = (
+        operator_run.get("official_task_score_reference")
+        if isinstance(operator_run.get("official_task_score_reference"), dict)
+        else {}
+    )
+    official_kind = public_safe_compact_text(official.get("kind"), limit=100)
+    if not official_kind:
+        official_kind = public_safe_compact_text(operator_run.get("official_task_score_kind"), limit=100)
+    if official_kind:
+        compact_operator["official_task_score_kind"] = official_kind
+    if isinstance(operator_run.get("simulator_induced_error_count"), int):
+        compact_operator["simulator_induced_error_count"] = operator_run.get("simulator_induced_error_count")
+    frequency_audit = (
+        operator_run.get("frequency_budget_audit")
+        if isinstance(operator_run.get("frequency_budget_audit"), dict)
+        else {}
+    )
+    if isinstance(frequency_audit.get("min_worker_events_between_proactive_satisfied"), bool):
+        compact_operator["frequency_budget_satisfied"] = frequency_audit.get(
+            "min_worker_events_between_proactive_satisfied"
+        )
+    elif isinstance(operator_run.get("frequency_budget_satisfied"), bool):
+        compact_operator["frequency_budget_satisfied"] = operator_run.get("frequency_budget_satisfied")
+    side_effect_audit = (
+        operator_run.get("side_effect_audit")
+        if isinstance(operator_run.get("side_effect_audit"), dict)
+        else {}
+    )
+    if side_effect_audit:
+        compact_operator["side_effect_audit_passed"] = not any(bool(value) for value in side_effect_audit.values())
+    elif isinstance(operator_run.get("side_effect_audit_passed"), bool):
+        compact_operator["side_effect_audit_passed"] = operator_run.get("side_effect_audit_passed")
+    if compact_operator:
+        compact["operator_simulator_run"] = compact_operator
+
+    claim_boundary = source.get("claim_boundary") if isinstance(source.get("claim_boundary"), dict) else {}
+    compact_boundary: dict[str, Any] = {}
+    for field in ("official_score_claim_allowed", "assisted_collaboration_claim_allowed", "leaderboard_claim_allowed"):
+        if isinstance(claim_boundary.get(field), bool):
+            compact_boundary[field] = claim_boundary.get(field)
+    if compact_boundary:
+        compact["claim_boundary"] = compact_boundary
+
+    next_decision = source.get("next_run_decision") if isinstance(source.get("next_run_decision"), dict) else {}
+    if not next_decision and isinstance(operator_run.get("next_run_decision"), dict):
+        next_decision = operator_run.get("next_run_decision")  # type: ignore[assignment]
+    compact_next: dict[str, Any] = {}
+    for field in ("decision", "minimum_next_evidence"):
+        value = public_safe_compact_text(next_decision.get(field), limit=180)
+        if value:
+            compact_next[field] = value
+    for field in ("requires_real_runner_approval", "keep_official_scores_separate"):
+        if isinstance(next_decision.get(field), bool):
+            compact_next[field] = next_decision.get(field)
+    if compact_next:
+        compact["next_run_decision"] = compact_next
+
+    if set(compact.keys()) == {"schema_version"}:
+        return None
+    return compact
+
+
 def parse_state_frontmatter(state_text: str) -> dict[str, str]:
     if not state_text.startswith("---"):
         return {}
@@ -2718,6 +2900,9 @@ def compact_post_handoff_run(run: dict[str, Any], profile: dict[str, Any] | None
             replay_decision = benchmark_experiment_report_replay_decision(readiness_note)
             if replay_decision:
                 compact["benchmark_experiment_report_replay_decision"] = replay_decision
+    active_user_pilot = compact_active_user_assisted_pilot(run)
+    if active_user_pilot:
+        compact["active_user_assisted_pilot_summary"] = active_user_pilot
     return compact
 
 
@@ -3986,6 +4171,9 @@ def compact_run(run: dict[str, Any]) -> dict[str, Any]:
             replay_decision = benchmark_experiment_report_replay_decision(readiness_note)
             if replay_decision:
                 compact["benchmark_experiment_report_replay_decision"] = replay_decision
+    active_user_pilot = compact_active_user_assisted_pilot(run)
+    if active_user_pilot:
+        compact["active_user_assisted_pilot_summary"] = active_user_pilot
     return compact
 
 
@@ -4113,6 +4301,7 @@ def event_ledger_event_class(run: dict[str, Any]) -> str:
         or compact_benchmark_result(run)
         or compact_benchmark_comparison(run)
         or compact_benchmark_experiment_report(run)
+        or compact_active_user_assisted_pilot(run)
     ):
         return "evidence"
     if (


### PR DESCRIPTION
## Summary
- add history append support for compact active_user_assisted_pilot_v0 events
- project active-user assisted pilot rows into status as public-safe summaries
- document the append/projection contract and add an isolated CLI smoke

## Validation
- python3 -m py_compile goal_harness/history.py goal_harness/status.py goal_harness/cli.py examples/active-user-assisted-pilot-append-cli-smoke.py
- python3 examples/active-user-assisted-pilot-append-cli-smoke.py
- python3 examples/active-user-assisted-pilot-smoke.py
- python3 examples/benchmark-experiment-report-append-cli-smoke.py
- python3 examples/run-smokes.py
- python3 -m goal_harness.cli --registry "/Users/bytedance/.codex/goal-harness/registry.global.json" --format json check --limit 5