### PR TITLE
Add active-user treatment preflight

### DIFF
--- a/examples/terminal-bench-active-user-assisted-treatment-preflight-smoke.py
+++ b/examples/terminal-bench-active-user-assisted-treatment-preflight-smoke.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""Smoke-test active-user assisted Terminal-Bench treatment preflight."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from goal_harness.status import collect_status  # noqa: E402
+
+
+TOPIC_DIR = REPO_ROOT / "docs" / "research" / "long-horizon-agent-benchmarks"
+DOC = TOPIC_DIR / "active-user-assisted-pilot-v0.md"
+README = TOPIC_DIR / "README.md"
+
+GOAL_ID = "terminal-bench-active-user-assisted-treatment-preflight-fixture"
+BENCHMARK_ID = "terminal-bench@2.0"
+TASK_ID = "train-fasttext"
+RUN_MODE = "codex_goal_harness_active_user_assisted_treatment_preflight"
+WORKER_MODE = "codex_goal_harness_cli"
+CLASSIFICATION = "terminal_bench_active_user_assisted_treatment_preflight_v0"
+FIRST_BLOCKER = "missing_simulator_to_worker_injection_channel"
+
+FORBIDDEN_TEXT = [
+    "/" + "Users/",
+    "/" + "tmp/",
+    ".local/benchmark-runs",
+    "OPENAI" + "_API_KEY=",
+    "ARK" + "_API_KEY=",
+    "ARK" + "_BASE_URL=",
+    "DOUBAO" + "_MODEL=",
+    "CODEX" + "_AUTH_JSON_PATH=",
+    "fixture-active-user-preflight-value",
+    "auth.json" + "\":",
+    "raw" + "_thread",
+    "session" + "_history",
+    "lark" + "office",
+    "fei" + "shu.cn",
+    "sk-" + "example",
+    "tok" + "en=",
+    "-----BEGIN",
+]
+
+REQUIRED_DOC_SNIPPETS = [
+    "Active User Assisted Pilot V0",
+    "active_user_assisted_pilot_v0",
+    "active_user_simulator_injection_v0",
+    "operator_simulator_run_v0",
+    "assisted-collaboration claims",
+    "cannot be used as an official Terminal-Bench score",
+    "python3 examples/active-user-assisted-pilot-smoke.py",
+]
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_fixture(root: Path) -> tuple[Path, Path]:
+    project = root / "project"
+    runtime = root / "runtime"
+    state_file = f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    registry_path = project / ".goal-harness" / "registry.json"
+
+    (project / Path(state_file).parent).mkdir(parents=True, exist_ok=True)
+    (project / state_file).write_text(
+        "---\n"
+        "status: active-read-only\n"
+        "updated_at: 2026-06-10T00:00:00+00:00\n"
+        "---\n\n"
+        "# Terminal-Bench Active User Assisted Treatment Preflight Fixture\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] Build the active-user assisted treatment preflight.\n",
+        encoding="utf-8",
+    )
+    write_json(
+        registry_path,
+        {
+            "schema_version": 1,
+            "updated_at": "2026-06-10T00:00:00+00:00",
+            "common_runtime_root": str(runtime),
+            "goals": [
+                {
+                    "id": GOAL_ID,
+                    "domain": "goal-harness-platform",
+                    "status": "active-read-only",
+                    "state_file": state_file,
+                    "repo": str(project),
+                    "adapter": {
+                        "kind": "harness_self_improvement",
+                        "status": "connected-read-only",
+                    },
+                    "heartbeat": {
+                        "enabled": True,
+                    },
+                }
+            ],
+        },
+    )
+    return registry_path, runtime
+
+
+def write_fake_command(bin_dir: Path, name: str) -> None:
+    path = bin_dir / name
+    path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def write_fake_surface_commands(root: Path) -> Path:
+    bin_dir = root / "fake-bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    for name in ("uvx", "docker", "colima", "codex"):
+        write_fake_command(bin_dir, name)
+    return bin_dir
+
+
+def run_cli(args: list[str], *, env: dict[str, str], check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "goal_harness.cli", *args],
+        cwd=REPO_ROOT,
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+    )
+
+
+def run_cli_json(args: list[str], *, env: dict[str, str]) -> dict[str, Any]:
+    result = run_cli(args, env=env)
+    payload = json.loads(result.stdout)
+    assert isinstance(payload, dict), payload
+    return payload
+
+
+def common_args(registry_path: Path, runtime: Path) -> list[str]:
+    return [
+        "--registry",
+        str(registry_path),
+        "--runtime-root",
+        str(runtime),
+        "--format",
+        "json",
+        "benchmark",
+        "run",
+        "terminal-bench",
+        "--goal-id",
+        GOAL_ID,
+        "--mode",
+        "codex-goal-harness",
+        "--dataset",
+        BENCHMARK_ID,
+        "--include-task-name",
+        TASK_ID,
+        "--preflight-guard",
+        "--active-cli-bridge",
+        "--active-user-assisted-treatment",
+        "--no-global-sync",
+    ]
+
+
+def assert_public_safe(payload: object) -> None:
+    text = json.dumps(payload, sort_keys=True) if not isinstance(payload, str) else payload
+    leaked = [marker for marker in FORBIDDEN_TEXT if marker in text]
+    assert not leaked, leaked
+    assert len(text) < 26000, len(text)
+
+
+def assert_doc_contract() -> None:
+    text = DOC.read_text(encoding="utf-8")
+    compact_text = " ".join(text.split())
+    readme = README.read_text(encoding="utf-8")
+    missing = [snippet for snippet in REQUIRED_DOC_SNIPPETS if snippet not in compact_text]
+    assert not missing, missing
+    assert "active-user-assisted-pilot-v0.md" in readme, readme
+    assert_public_safe(text)
+
+
+def assert_preflight_guard(guard: dict[str, Any]) -> None:
+    assert guard["schema_version"] == CLASSIFICATION, guard
+    assert guard["first_blocker"] == FIRST_BLOCKER, guard
+    assert guard["active_cli_bridge_enabled"] is True, guard
+    assert guard["active_user_assisted_treatment"] is True, guard
+    assert guard["simulator_setting"] == "deterministic_scripted_user", guard
+    assert guard["simulator_to_worker_injection_channel_available"] is False, guard
+    assert guard["interactive_user_message_injection_checked"] is True, guard
+    assert guard["initial_prompt_only_is_not_active_intervention"] is True, guard
+    assert guard["no_oracle_audit_required"] is True, guard
+    assert guard["assisted_score_kept_separate_from_official"] is True, guard
+    assert guard["claim_requires_worker_cli_calls"] is True, guard
+    assert guard["required_worker_goal_harness_cli_call_total_min"] == 1, guard
+
+
+def assert_active_user_preflight(preflight: dict[str, Any]) -> None:
+    assert preflight["schema_version"] == CLASSIFICATION, preflight
+    assert preflight["pilot_schema_version"] == "active_user_assisted_pilot_v0", preflight
+    assert preflight["active_injection_schema_version"] == "active_user_simulator_injection_v0", preflight
+    assert preflight["operator_simulator_run_schema_version"] == "operator_simulator_run_v0", preflight
+    assert preflight["simulator_setting"] == "deterministic_scripted_user", preflight
+    assert preflight["proactive_intervention_allowed"] is True, preflight
+    assert preflight["directive_feedback_allowed"] is True, preflight
+    assert preflight["artificial_mildness_required"] is False, preflight
+    assert preflight["frequency_budget_required"] is True, preflight
+    assert preflight["visibility_policy_required"] is True, preflight
+    assert preflight["no_oracle_audit_required"] is True, preflight
+    assert preflight["assisted_collaboration_claim_allowed"] is True, preflight
+    assert preflight["official_score_claim_allowed"] is False, preflight
+    assert preflight["leaderboard_claim_allowed"] is False, preflight
+    assert (
+        preflight["next_step"]
+        == "add_or_select_runner_surface_that_can_inject_user_messages_during_worker_run"
+    ), preflight
+    channel = preflight["simulator_to_worker_injection_channel"]
+    assert channel["schema_version"] == "terminal_bench_active_user_simulator_injection_channel_v0", channel
+    assert channel["channel_available"] is False, channel
+    assert channel["first_blocker"] == FIRST_BLOCKER, channel
+    assert channel["required_capability"] == "inject_user_message_during_codex_worker_run", channel
+    assert channel["current_agent_surface"] == "single_super_run_instruction_call", channel
+    assert channel["initial_prompt_only_is_not_active_intervention"] is True, channel
+    assert channel["no_user_message_injected"] is True, channel
+    assert channel["model_api_invoked"] is False, channel
+    assert channel["raw_transcript_recorded"] is False, channel
+
+
+def assert_payload(payload: dict[str, Any], *, appended: bool) -> None:
+    assert payload["ok"] is True, payload
+    assert payload["appended"] is appended, payload
+    assert payload["dry_run"] is (not appended), payload
+    assert payload["classification"] == CLASSIFICATION, payload
+    assert "inject user messages during the Codex worker run" in payload["recommended_action"], payload
+
+    cli = payload["benchmark_cli"]
+    assert cli["benchmark"] == "terminal-bench", cli
+    assert cli["mode"] == "codex-goal-harness", cli
+    assert cli["preflight_guard"] is True, cli
+    assert cli["active_cli_bridge"] is True, cli
+    assert cli["active_user_assisted_treatment"] is True, cli
+    assert cli["real_runner_invoked"] is False, cli
+    assert cli["real_codex_invoked"] is False, cli
+    assert cli["auth_values_read"] is False, cli
+
+    event = payload["benchmark_run"]
+    assert event["schema_version"] == "benchmark_run_v0", event
+    assert event["source_runner"] == "goal_harness_terminal_bench_active_user_assisted_treatment_preflight", event
+    assert event["benchmark_id"] == BENCHMARK_ID, event
+    assert event["mode"] == RUN_MODE, event
+    assert event["worker_mode"] == WORKER_MODE, event
+    assert event["first_blocker"] == FIRST_BLOCKER, event
+    assert event["real_run"] is False, event
+    assert event["submit_eligible"] is False, event
+    assert event["official_task_score"]["kind"] == "not_run", event
+    assert event["goal_harness_worker_cli_bridge_available"] is True, event
+    assert event["goal_harness_worker_cli_bridge_trace_observed"] is False, event
+    assert event["planned_worker_goal_harness_cli_call_total"] == 2, event
+    assert event["worker_goal_harness_cli_call_total"] == 0, event
+    assert event["assisted_collaboration_claim_allowed"] is True, event
+    assert event["official_score_claim_allowed"] is False, event
+    assert event["active_user_simulator_injection_channel_available"] is False, event
+    assert event["validation"]["all_passed"] is True, event
+    assert event["validation"]["failed_checks"] == [], event
+    assert event["validation"]["active_user_assisted_treatment_preflight"] is True, event
+    assert event["validation"]["active_user_simulator_contract_checked"] is True, event
+    assert event["validation"]["simulator_to_worker_injection_channel_checked"] is True, event
+    assert event["validation"]["missing_simulator_to_worker_injection_channel_recorded"] is True, event
+    assert event["validation"]["no_real_user_message_injected"] is True, event
+    assert event["validation"]["no_model_backed_simulator_invoked"] is True, event
+    assert event["validation"]["no_oracle_audit_required"] is True, event
+    assert event["validation"]["assisted_score_kept_separate_from_official"] is True, event
+
+    counters = event["interaction_counters"]
+    assert counters["goal_harness_cli_calls"]["total"] == 0, counters
+    assert counters["case_result_writeback"] == "not_observed_active_user_assisted_treatment_preflight", counters
+    assert counters["counter_trust_level"] == "active_user_assisted_treatment_preflight_no_injection_channel", counters
+    assert_preflight_guard(event["preflight_guard"])
+    assert_active_user_preflight(event["active_user_assisted_treatment_preflight"])
+    assert_public_safe(payload)
+
+
+def assert_status_projection(registry_path: Path, runtime: Path) -> None:
+    status = collect_status(
+        registry_path=registry_path,
+        runtime_root_override=str(runtime),
+        scan_roots=[],
+        limit=5,
+    )
+    assert status["ok"], status
+    latest = status["run_history"]["goals"][0]["latest_runs"][0]
+    summary = latest["benchmark_run_summary"]
+    assert summary["mode"] == RUN_MODE, summary
+    assert summary["worker_mode"] == WORKER_MODE, summary
+    assert summary["benchmark_id"] == BENCHMARK_ID, summary
+    assert summary["first_blocker"] == FIRST_BLOCKER, summary
+    assert summary["assisted_collaboration_claim_allowed"] is True, summary
+    assert summary["official_score_claim_allowed"] is False, summary
+    assert summary["active_user_simulator_injection_channel_available"] is False, summary
+    assert_preflight_guard(summary["preflight_guard"])
+    assert_active_user_preflight(summary["active_user_assisted_treatment_preflight"])
+    assert_public_safe(summary)
+
+
+def assert_help_exposes_active_user_flag() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "goal_harness.cli",
+            "benchmark",
+            "run",
+            "terminal-bench",
+            "--help",
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert "--active-user-assisted-treatment" in result.stdout, result.stdout
+
+
+def main() -> None:
+    assert_doc_contract()
+    assert_help_exposes_active_user_flag()
+    with tempfile.TemporaryDirectory(
+        prefix="terminal-bench-active-user-treatment-preflight-"
+    ) as tmp:
+        root = Path(tmp)
+        registry_path, runtime = write_fixture(root)
+        fake_bin = write_fake_surface_commands(root)
+        env = {
+            **os.environ,
+            "PATH": f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}",
+            "CODEX_FORCE_AUTH_JSON": "fixture-active-user-preflight-value",
+        }
+        dry_payload = run_cli_json(common_args(registry_path, runtime), env=env)
+        assert_payload(dry_payload, appended=False)
+
+        execute_payload = run_cli_json(
+            common_args(registry_path, runtime)
+            + [
+                "--delivery-batch-scale",
+                "single_surface",
+                "--delivery-outcome",
+                "outcome_progress",
+                "--execute",
+            ],
+            env=env,
+        )
+        assert_payload(execute_payload, appended=True)
+        assert_status_projection(registry_path, runtime)
+
+    print(
+        "terminal-bench-active-user-assisted-treatment-preflight-smoke ok "
+        f"mode={RUN_MODE} first_blocker={FIRST_BLOCKER}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/goal_harness/benchmark.py
+++ b/goal_harness/benchmark.py
@@ -40,6 +40,15 @@ TERMINAL_BENCH_PREFLIGHT_MODE = "goal_harness_managed_codex_real_run_preflight_g
 TERMINAL_BENCH_CODEX_GOAL_HARNESS_PREFLIGHT_MODE = (
     "codex_goal_harness_no_upload_preflight_guard"
 )
+TERMINAL_BENCH_ACTIVE_USER_ASSISTED_TREATMENT_PREFLIGHT_MODE = (
+    "codex_goal_harness_active_user_assisted_treatment_preflight"
+)
+TERMINAL_BENCH_ACTIVE_USER_ASSISTED_TREATMENT_PREFLIGHT_SCHEMA = (
+    "terminal_bench_active_user_assisted_treatment_preflight_v0"
+)
+TERMINAL_BENCH_ACTIVE_USER_SIMULATOR_INJECTION_CHANNEL_SCHEMA = (
+    "terminal_bench_active_user_simulator_injection_channel_v0"
+)
 TERMINAL_BENCH_HARDENED_CODEX_BASELINE_PREFLIGHT_MODE = (
     "hardened_codex_baseline_preflight_guard"
 )
@@ -2361,6 +2370,7 @@ def build_terminal_bench_benchmark_run(
     cli_bridge_trace: dict[str, Any] | None = None,
     worker_cli_bridge_fixture: bool = False,
     active_cli_bridge_preflight: bool = False,
+    active_user_assisted_treatment_preflight: bool = False,
     timeout_multiplier: float | None = None,
     agent_timeout_multiplier: float | None = None,
     verifier_timeout_multiplier: float | None = None,
@@ -2413,6 +2423,16 @@ def build_terminal_bench_benchmark_run(
         raise ValueError("--active-cli-bridge cannot be combined with --cli-bridge-contract")
     if active_cli_bridge_preflight and worker_cli_bridge_fixture:
         raise ValueError("--active-cli-bridge cannot be combined with --worker-cli-bridge-fixture")
+    if active_user_assisted_treatment_preflight and mode != "codex-goal-harness":
+        raise ValueError("--active-user-assisted-treatment is only supported for codex-goal-harness")
+    if active_user_assisted_treatment_preflight and not preflight_guard:
+        raise ValueError("--active-user-assisted-treatment requires --preflight-guard")
+    if active_user_assisted_treatment_preflight and not active_cli_bridge_preflight:
+        raise ValueError("--active-user-assisted-treatment requires --active-cli-bridge")
+    if active_user_assisted_treatment_preflight and worker_cli_bridge_fixture:
+        raise ValueError("--active-user-assisted-treatment cannot be combined with --worker-cli-bridge-fixture")
+    if active_user_assisted_treatment_preflight and cli_bridge_contract:
+        raise ValueError("--active-user-assisted-treatment cannot be combined with --cli-bridge-contract")
     if active_cli_bridge_preflight and agent_timeout_multiplier is None:
         agent_timeout_multiplier = (
             TERMINAL_BENCH_PRIVATE_EXTENDED_AGENT_TIMEOUT_MULTIPLIER
@@ -2450,7 +2470,9 @@ def build_terminal_bench_benchmark_run(
         surface = preflight_surface or collect_terminal_bench_managed_preflight_surface()
         first_blocker = _managed_preflight_first_blocker(surface)
         event_mode = (
-            "codex_goal_harness_active_cli_bridge_preflight"
+            TERMINAL_BENCH_ACTIVE_USER_ASSISTED_TREATMENT_PREFLIGHT_MODE
+            if active_user_assisted_treatment_preflight
+            else "codex_goal_harness_active_cli_bridge_preflight"
             if active_cli_bridge_preflight and mode == "codex-goal-harness"
             else TERMINAL_BENCH_CODEX_GOAL_HARNESS_PREFLIGHT_MODE
             if mode == "codex-goal-harness"
@@ -2459,7 +2481,9 @@ def build_terminal_bench_benchmark_run(
             else TERMINAL_BENCH_PREFLIGHT_MODE
         )
         trace_publicness = (
-            "public_codex_goal_harness_active_cli_bridge_preflight"
+            "public_active_user_assisted_treatment_preflight"
+            if active_user_assisted_treatment_preflight
+            else "public_codex_goal_harness_active_cli_bridge_preflight"
             if active_cli_bridge_preflight and mode == "codex-goal-harness"
             else "public_codex_goal_harness_no_upload_preflight_guard"
             if mode == "codex-goal-harness"
@@ -2471,7 +2495,11 @@ def build_terminal_bench_benchmark_run(
             **contract,
             "event_mode": event_mode,
             "trace_publicness": trace_publicness,
-            "first_blocker": first_blocker,
+            "first_blocker": (
+                "missing_simulator_to_worker_injection_channel"
+                if active_user_assisted_treatment_preflight
+                else first_blocker
+            ),
         }
     fake_result: dict[str, Any] = {}
     if fake_worker and mode == "codex-goal-harness":
@@ -2523,6 +2551,15 @@ def build_terminal_bench_benchmark_run(
         validation["worker_cli_bridge_command_preview_checked"] = True
         validation["worker_cli_bridge_trace_required_before_claim"] = True
         validation["no_worker_cli_calls_observed_in_preflight"] = True
+    if active_user_assisted_treatment_preflight:
+        validation["active_user_assisted_treatment_preflight"] = True
+        validation["active_user_simulator_contract_checked"] = True
+        validation["simulator_to_worker_injection_channel_checked"] = True
+        validation["missing_simulator_to_worker_injection_channel_recorded"] = True
+        validation["no_real_user_message_injected"] = True
+        validation["no_model_backed_simulator_invoked"] = True
+        validation["no_oracle_audit_required"] = True
+        validation["assisted_score_kept_separate_from_official"] = True
     if preflight_guard:
         validation["preflight_guard"] = True
         validation["auth_values_not_read"] = True
@@ -2630,6 +2667,8 @@ def build_terminal_bench_benchmark_run(
                 else
                 "worker_goal_harness_writeback"
                 if fake_worker
+                else "not_observed_active_user_assisted_treatment_preflight"
+                if active_user_assisted_treatment_preflight
                 else "not_observed_active_cli_bridge_preflight"
                 if active_cli_bridge_preflight
                 else "not_observed_prompt_only_no_cli_bridge"
@@ -2647,6 +2686,8 @@ def build_terminal_bench_benchmark_run(
                 else
                 "fake_worker_fixture_observed"
                 if fake_worker
+                else "active_user_assisted_treatment_preflight_no_injection_channel"
+                if active_user_assisted_treatment_preflight
                 else "active_bridge_preflight_no_worker_trace"
                 if active_cli_bridge_preflight
                 else "preflight_prompt_only_no_cli_bridge"
@@ -2741,7 +2782,8 @@ def build_terminal_bench_benchmark_run(
                 "uses_private_runner_env": True,
                 "preflight_surface": surface,
                 "first_blocker": first_blocker,
-                "ready": first_blocker == "ready_for_private_managed_no_upload_pilot_review",
+                "ready": first_blocker == "ready_for_private_managed_no_upload_pilot_review"
+                and not active_user_assisted_treatment_preflight,
             }
         )
 
@@ -2965,6 +3007,38 @@ def build_terminal_bench_benchmark_run(
         if active_cli_bridge_preflight
         else 0
     )
+    if active_user_assisted_treatment_preflight:
+        benchmark_run["active_user_assisted_treatment_preflight"] = {
+            "schema_version": TERMINAL_BENCH_ACTIVE_USER_ASSISTED_TREATMENT_PREFLIGHT_SCHEMA,
+            "pilot_schema_version": "active_user_assisted_pilot_v0",
+            "active_injection_schema_version": "active_user_simulator_injection_v0",
+            "operator_simulator_run_schema_version": "operator_simulator_run_v0",
+            "simulator_setting": "deterministic_scripted_user",
+            "proactive_intervention_allowed": True,
+            "directive_feedback_allowed": True,
+            "artificial_mildness_required": False,
+            "frequency_budget_required": True,
+            "visibility_policy_required": True,
+            "no_oracle_audit_required": True,
+            "assisted_collaboration_claim_allowed": True,
+            "official_score_claim_allowed": False,
+            "leaderboard_claim_allowed": False,
+            "simulator_to_worker_injection_channel": {
+                "schema_version": TERMINAL_BENCH_ACTIVE_USER_SIMULATOR_INJECTION_CHANNEL_SCHEMA,
+                "channel_available": False,
+                "first_blocker": "missing_simulator_to_worker_injection_channel",
+                "required_capability": "inject_user_message_during_codex_worker_run",
+                "current_agent_surface": "single_super_run_instruction_call",
+                "initial_prompt_only_is_not_active_intervention": True,
+                "no_user_message_injected": True,
+                "model_api_invoked": False,
+                "raw_transcript_recorded": False,
+            },
+            "next_step": "add_or_select_runner_surface_that_can_inject_user_messages_during_worker_run",
+        }
+        benchmark_run["assisted_collaboration_claim_allowed"] = True
+        benchmark_run["official_score_claim_allowed"] = False
+        benchmark_run["active_user_simulator_injection_channel_available"] = False
     if mode == "codex-goal-harness":
         benchmark_run["goal_harness_access_packet"] = {
             "schema_version": TERMINAL_BENCH_GOAL_HARNESS_ACCESS_PACKET_VERSION,
@@ -3091,19 +3165,25 @@ def build_terminal_bench_benchmark_run(
     if preflight_guard:
         if mode == "codex-goal-harness":
             benchmark_run["source_runner"] = (
-                "goal_harness_terminal_bench_codex_goal_harness_active_cli_bridge_preflight"
+                "goal_harness_terminal_bench_active_user_assisted_treatment_preflight"
+                if active_user_assisted_treatment_preflight
+                else "goal_harness_terminal_bench_codex_goal_harness_active_cli_bridge_preflight"
                 if active_cli_bridge_preflight
                 else "goal_harness_terminal_bench_codex_goal_harness_no_upload_preflight_guard"
             )
             benchmark_run["evidence_files"] = [
                 (
-                    "doc:terminal-bench-codex-goal-harness-active-cli-bridge-v0.md"
+                    "doc:active-user-assisted-pilot-v0.md"
+                    if active_user_assisted_treatment_preflight
+                    else "doc:terminal-bench-codex-goal-harness-active-cli-bridge-v0.md"
                     if active_cli_bridge_preflight
                     else "doc:terminal-bench-codex-goal-harness-preflight-guard-v0.md"
                 ),
                 "doc:terminal-bench-codex-goal-harness-custom-agent-v0.md",
                 (
-                    "smoke:terminal-bench-codex-goal-harness-active-cli-bridge-smoke.py"
+                    "smoke:terminal-bench-active-user-assisted-treatment-preflight-smoke.py"
+                    if active_user_assisted_treatment_preflight
+                    else "smoke:terminal-bench-codex-goal-harness-active-cli-bridge-smoke.py"
                     if active_cli_bridge_preflight
                     else "smoke:terminal-bench-codex-goal-harness-preflight-guard-smoke.py"
                 ),
@@ -3111,12 +3191,18 @@ def build_terminal_bench_benchmark_run(
             benchmark_run["resume_or_inspect_commands"] = [
                 (
                     "goal-harness benchmark run terminal-bench --mode codex-goal-harness "
+                    "--preflight-guard --active-cli-bridge --active-user-assisted-treatment"
+                    if active_user_assisted_treatment_preflight
+                    else "goal-harness benchmark run terminal-bench --mode codex-goal-harness "
                     "--preflight-guard --active-cli-bridge"
                     if active_cli_bridge_preflight
                     else "goal-harness benchmark run terminal-bench --mode codex-goal-harness --preflight-guard"
                 ),
                 (
                     "goal-harness benchmark run terminal-bench --mode codex-goal-harness "
+                    "--preflight-guard --active-cli-bridge --active-user-assisted-treatment --execute"
+                    if active_user_assisted_treatment_preflight
+                    else "goal-harness benchmark run terminal-bench --mode codex-goal-harness "
                     "--preflight-guard --active-cli-bridge --execute"
                     if active_cli_bridge_preflight
                     else "goal-harness benchmark run terminal-bench --mode codex-goal-harness --preflight-guard --execute"
@@ -3148,7 +3234,9 @@ def build_terminal_bench_benchmark_run(
             ]
         benchmark_run["preflight_guard"] = {
             "schema_version": (
-                "terminal_bench_codex_goal_harness_active_cli_bridge_preflight_v0"
+                TERMINAL_BENCH_ACTIVE_USER_ASSISTED_TREATMENT_PREFLIGHT_SCHEMA
+                if active_user_assisted_treatment_preflight
+                else "terminal_bench_codex_goal_harness_active_cli_bridge_preflight_v0"
                 if active_cli_bridge_preflight and mode == "codex-goal-harness"
                 else
                 "terminal_bench_codex_goal_harness_preflight_guard_v0"
@@ -3236,6 +3324,18 @@ def build_terminal_bench_benchmark_run(
                     "uplift_claim_allowed": False,
                 }
             )
+            if active_user_assisted_treatment_preflight:
+                benchmark_run["preflight_guard"].update(
+                    {
+                        "active_user_assisted_treatment": True,
+                        "simulator_setting": "deterministic_scripted_user",
+                        "simulator_to_worker_injection_channel_available": False,
+                        "interactive_user_message_injection_checked": True,
+                        "initial_prompt_only_is_not_active_intervention": True,
+                        "no_oracle_audit_required": True,
+                        "assisted_score_kept_separate_from_official": True,
+                    }
+                )
         if active_cli_bridge_preflight:
             benchmark_run["goal_harness_cli_bridge_surface"] = (
                 TERMINAL_BENCH_CODEX_WORKER_CLI_BRIDGE_SURFACE
@@ -3268,9 +3368,12 @@ def terminal_bench_recommended_action(
     cli_bridge_contract: bool = False,
     worker_cli_bridge_fixture: bool = False,
     active_cli_bridge_preflight: bool = False,
+    active_user_assisted_treatment_preflight: bool = False,
 ) -> str:
     if mode == "hardened-codex":
         return "run hardened-codex baseline and codex-goal-harness treatment in parallel on the same hard task; do not launch bare-codex"
+    if active_user_assisted_treatment_preflight:
+        return "add or select a runner channel that can inject user messages during the Codex worker run before launching real active-user assisted treatment"
     if active_cli_bridge_preflight:
         return "run the private no-upload codex-goal-harness sample repeat with active worker Goal Harness CLI bridge, then require nonzero worker_goal_harness_cli_calls before any in-case use claim"
     if worker_cli_bridge_fixture:

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -859,6 +859,15 @@ def main(argv: list[str] | None = None) -> int:
             "requires worker-side CLI call counters before any in-case use claim."
         ),
     )
+    benchmark_run_parser.add_argument(
+        "--active-user-assisted-treatment",
+        action="store_true",
+        help=(
+            "With codex-goal-harness --preflight-guard --active-cli-bridge, build "
+            "the active-user assisted treatment preflight contract. This does not "
+            "run Harbor, Codex, a simulator, or inject user messages."
+        ),
+    )
     benchmark_run_parser.add_argument("--classification")
     benchmark_run_parser.add_argument("--recommended-action")
     benchmark_run_parser.add_argument(
@@ -1589,6 +1598,9 @@ def main(argv: list[str] | None = None) -> int:
                     "terminal_bench_harbor_runner_result_ingest_v0"
                     if args.harbor_job_dir
                     else
+                    "terminal_bench_active_user_assisted_treatment_preflight_v0"
+                    if args.active_user_assisted_treatment
+                    else
                     "terminal_bench_codex_goal_harness_active_cli_bridge_preflight_v0"
                     if args.active_cli_bridge
                     else
@@ -1630,6 +1642,7 @@ def main(argv: list[str] | None = None) -> int:
                     or args.cli_bridge_contract
                     or args.worker_cli_bridge_fixture
                     or args.active_cli_bridge
+                    or args.active_user_assisted_treatment
                 ):
                     raise ValueError(
                         "--harbor-job-dir cannot be combined with fixture or preflight flags"
@@ -1684,6 +1697,9 @@ def main(argv: list[str] | None = None) -> int:
                         cli_bridge_trace=cli_bridge_trace,
                         worker_cli_bridge_fixture=bool(args.worker_cli_bridge_fixture),
                         active_cli_bridge_preflight=bool(args.active_cli_bridge),
+                        active_user_assisted_treatment_preflight=bool(
+                            args.active_user_assisted_treatment
+                        ),
                         timeout_multiplier=args.timeout_multiplier,
                         agent_timeout_multiplier=args.agent_timeout_multiplier,
                         verifier_timeout_multiplier=args.verifier_timeout_multiplier,
@@ -1720,6 +1736,9 @@ def main(argv: list[str] | None = None) -> int:
                         cli_bridge_contract=bool(args.cli_bridge_contract),
                         worker_cli_bridge_fixture=bool(args.worker_cli_bridge_fixture),
                         active_cli_bridge_preflight=bool(args.active_cli_bridge),
+                        active_user_assisted_treatment_preflight=bool(
+                            args.active_user_assisted_treatment
+                        ),
                         )
                     ),
                     delivery_batch_scale=args.delivery_batch_scale,
@@ -1736,6 +1755,9 @@ def main(argv: list[str] | None = None) -> int:
                     "cli_bridge_contract": bool(args.cli_bridge_contract),
                     "worker_cli_bridge_fixture": bool(args.worker_cli_bridge_fixture),
                     "active_cli_bridge": bool(args.active_cli_bridge),
+                    "active_user_assisted_treatment": bool(
+                        args.active_user_assisted_treatment
+                    ),
                     "harbor_job_result_ingested": bool(args.harbor_job_dir),
                     "timeout_multiplier_preview_requested": (
                         timeout_multiplier_preview_requested
@@ -1775,6 +1797,9 @@ def main(argv: list[str] | None = None) -> int:
                     "goal_id": args.goal_id,
                     "classification": args.classification
                     or (
+                        "terminal_bench_active_user_assisted_treatment_preflight_v0"
+                        if getattr(args, "active_user_assisted_treatment", False)
+                        else
                         "terminal_bench_codex_goal_harness_worker_cli_bridge_fixture_v0"
                         if getattr(args, "worker_cli_bridge_fixture", False)
                         else

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -527,6 +527,7 @@ def _compact_benchmark_preflight_guard(value: Any) -> dict[str, Any]:
         "first_blocker",
         "goal_harness_mode_kwarg",
         "runner_binary_resolution_policy",
+        "simulator_setting",
     ):
         text = public_safe_compact_text(value.get(field), limit=120)
         if text:
@@ -545,6 +546,12 @@ def _compact_benchmark_preflight_guard(value: Any) -> dict[str, Any]:
         "claim_requires_worker_cli_calls",
         "real_interface_use_observed",
         "uplift_claim_allowed",
+        "active_user_assisted_treatment",
+        "simulator_to_worker_injection_channel_available",
+        "interactive_user_message_injection_checked",
+        "initial_prompt_only_is_not_active_intervention",
+        "no_oracle_audit_required",
+        "assisted_score_kept_separate_from_official",
         "uvx_cli_present",
         "uvx_version_probe_ok",
         "docker_cli_present",
@@ -563,6 +570,66 @@ def _compact_benchmark_preflight_guard(value: Any) -> dict[str, Any]:
     for field in ("required_worker_goal_harness_cli_call_total_min",):
         if isinstance(value.get(field), int) and not isinstance(value.get(field), bool):
             compact[field] = value[field]
+    return compact
+
+
+def _compact_active_user_assisted_treatment_preflight(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+
+    compact: dict[str, Any] = {}
+    for field in (
+        "schema_version",
+        "pilot_schema_version",
+        "active_injection_schema_version",
+        "operator_simulator_run_schema_version",
+        "simulator_setting",
+        "next_step",
+    ):
+        text = public_safe_compact_text(value.get(field), limit=140)
+        if text:
+            compact[field] = text
+    for field in (
+        "proactive_intervention_allowed",
+        "directive_feedback_allowed",
+        "artificial_mildness_required",
+        "frequency_budget_required",
+        "visibility_policy_required",
+        "no_oracle_audit_required",
+        "assisted_collaboration_claim_allowed",
+        "official_score_claim_allowed",
+        "leaderboard_claim_allowed",
+    ):
+        if isinstance(value.get(field), bool):
+            compact[field] = value[field]
+
+    channel = (
+        value.get("simulator_to_worker_injection_channel")
+        if isinstance(value.get("simulator_to_worker_injection_channel"), dict)
+        else {}
+    )
+    compact_channel: dict[str, Any] = {}
+    for field in (
+        "schema_version",
+        "first_blocker",
+        "required_capability",
+        "current_agent_surface",
+    ):
+        text = public_safe_compact_text(channel.get(field), limit=140)
+        if text:
+            compact_channel[field] = text
+    for field in (
+        "channel_available",
+        "initial_prompt_only_is_not_active_intervention",
+        "no_user_message_injected",
+        "model_api_invoked",
+        "raw_transcript_recorded",
+    ):
+        if isinstance(channel.get(field), bool):
+            compact_channel[field] = channel[field]
+    if compact_channel:
+        compact["simulator_to_worker_injection_channel"] = compact_channel
+
     return compact
 
 
@@ -820,6 +887,9 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
         "goal_harness_cli_bridge_trace_observed",
         "goal_harness_worker_cli_bridge_available",
         "goal_harness_worker_cli_bridge_trace_observed",
+        "assisted_collaboration_claim_allowed",
+        "official_score_claim_allowed",
+        "active_user_simulator_injection_channel_available",
     ):
         if isinstance(source.get(field), bool):
             compact[field] = source.get(field)
@@ -913,6 +983,12 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
     if preflight_guard:
         compact["preflight_guard"] = preflight_guard
 
+    active_user_preflight = _compact_active_user_assisted_treatment_preflight(
+        source.get("active_user_assisted_treatment_preflight")
+    )
+    if active_user_preflight:
+        compact["active_user_assisted_treatment_preflight"] = active_user_preflight
+
     claim_gate = _compact_benchmark_claim_gate(source.get("claim_gate"))
     if claim_gate:
         compact["claim_gate"] = claim_gate
@@ -936,10 +1012,23 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
             for key, value in validation.items()
             if isinstance(key, str) and isinstance(value, bool) and not value
         ][:MAX_BENCHMARK_RUN_LIST_ITEMS]
-        compact["validation"] = {
+        compact_validation: dict[str, Any] = {
             "all_passed": not failed and all(bool(value) for value in validation.values() if isinstance(value, bool)),
             "failed_checks": failed,
         }
+        for field in (
+            "active_user_assisted_treatment_preflight",
+            "active_user_simulator_contract_checked",
+            "simulator_to_worker_injection_channel_checked",
+            "missing_simulator_to_worker_injection_channel_recorded",
+            "no_real_user_message_injected",
+            "no_model_backed_simulator_invoked",
+            "no_oracle_audit_required",
+            "assisted_score_kept_separate_from_official",
+        ):
+            if isinstance(validation.get(field), bool):
+                compact_validation[field] = validation[field]
+        compact["validation"] = compact_validation
 
     trials: list[dict[str, Any]] = []
     for trial in source.get("trials") or []:


### PR DESCRIPTION
## Summary
- add a codex-goal-harness active-user assisted treatment preflight mode gated behind --preflight-guard --active-cli-bridge
- record the current blocker as missing_simulator_to_worker_injection_channel instead of pretending a real assisted run happened
- project the active-user preflight contract through status and add a public-safe smoke covering CLI dry-run, execute append, and status projection

## Validation
- python3 -m py_compile goal_harness/benchmark.py goal_harness/cli.py goal_harness/status.py examples/terminal-bench-active-user-assisted-treatment-preflight-smoke.py
- python3 examples/terminal-bench-active-user-assisted-treatment-preflight-smoke.py
- python3 examples/terminal-bench-codex-goal-harness-active-cli-bridge-smoke.py
- python3 examples/terminal-bench-codex-goal-harness-preflight-guard-smoke.py
- python3 examples/active-user-assisted-pilot-append-cli-smoke.py
- python3 examples/run-smokes.py
- python3 -m goal_harness.cli --registry "/Users/bytedance/.codex/goal-harness/registry.global.json" --format json check --limit 5
- git diff --check