### PR TITLE
Add active-user injection channel probe

### DIFF
--- a/examples/terminal-bench-active-user-assisted-treatment-preflight-smoke.py
+++ b/examples/terminal-bench-active-user-assisted-treatment-preflight-smoke.py
@@ -203,7 +203,52 @@ def assert_preflight_guard(guard: dict[str, Any]) -> None:
     assert guard["required_worker_goal_harness_cli_call_total_min"] == 1, guard
 
 
-def assert_active_user_preflight(preflight: dict[str, Any]) -> None:
+def assert_channel_probe(channel: dict[str, Any]) -> None:
+    assert channel["schema_version"] == "terminal_bench_active_user_simulator_injection_channel_v0", channel
+    assert channel["channel_available"] is False, channel
+    assert channel["first_blocker"] == FIRST_BLOCKER, channel
+    assert channel["required_capability"] == "inject_user_message_during_codex_worker_run", channel
+    assert channel["current_agent_surface"] == "single_super_run_instruction_call", channel
+    assert channel["initial_prompt_only_is_not_active_intervention"] is True, channel
+    assert channel["no_user_message_injected"] is True, channel
+    assert channel["model_api_invoked"] is False, channel
+    assert channel["raw_transcript_recorded"] is False, channel
+    assert channel["checked_channel_count"] == 3, channel
+    checked = channel["checked_channels"]
+    assert [item["channel"] for item in checked] == [
+        "initial_prompt_instruction_append",
+        "worker_goal_harness_cli_pull",
+        "interactive_worker_session_bridge",
+    ], channel
+    verdicts = {item["channel"]: item["verdict"] for item in checked}
+    assert verdicts["initial_prompt_instruction_append"] == "rejected_for_active_intervention", channel
+    assert verdicts["worker_goal_harness_cli_pull"] == "partial_worker_pull_not_user_push", channel
+    assert verdicts["interactive_worker_session_bridge"] == "required_missing", channel
+    assert channel["next_channel_requirement"] == (
+        "controller_to_worker_user_message_push_or_audited_external_update_loop"
+    ), channel
+    assert channel["minimum_next_implementation"] == (
+        "prove a worker can observe a new simulator intervention after the Codex run starts"
+    ), channel
+
+
+def assert_compact_channel_probe(channel: dict[str, Any]) -> None:
+    assert channel["schema_version"] == "terminal_bench_active_user_simulator_injection_channel_v0", channel
+    assert channel["channel_available"] is False, channel
+    assert channel["first_blocker"] == FIRST_BLOCKER, channel
+    assert channel["checked_channel_count"] == 3, channel
+    assert channel["checked_channel_names"] == [
+        "initial_prompt_instruction_append",
+        "worker_goal_harness_cli_pull",
+        "interactive_worker_session_bridge",
+    ], channel
+    assert channel["required_missing_channel"] == "interactive_worker_session_bridge", channel
+    assert channel["next_channel_requirement"] == (
+        "controller_to_worker_user_message_push_or_audited_external_update_loop"
+    ), channel
+
+
+def assert_active_user_preflight(preflight: dict[str, Any], *, compact: bool = False) -> None:
     assert preflight["schema_version"] == CLASSIFICATION, preflight
     assert preflight["pilot_schema_version"] == "active_user_assisted_pilot_v0", preflight
     assert preflight["active_injection_schema_version"] == "active_user_simulator_injection_v0", preflight
@@ -223,15 +268,10 @@ def assert_active_user_preflight(preflight: dict[str, Any]) -> None:
         == "add_or_select_runner_surface_that_can_inject_user_messages_during_worker_run"
     ), preflight
     channel = preflight["simulator_to_worker_injection_channel"]
-    assert channel["schema_version"] == "terminal_bench_active_user_simulator_injection_channel_v0", channel
-    assert channel["channel_available"] is False, channel
-    assert channel["first_blocker"] == FIRST_BLOCKER, channel
-    assert channel["required_capability"] == "inject_user_message_during_codex_worker_run", channel
-    assert channel["current_agent_surface"] == "single_super_run_instruction_call", channel
-    assert channel["initial_prompt_only_is_not_active_intervention"] is True, channel
-    assert channel["no_user_message_injected"] is True, channel
-    assert channel["model_api_invoked"] is False, channel
-    assert channel["raw_transcript_recorded"] is False, channel
+    if compact:
+        assert_compact_channel_probe(channel)
+    else:
+        assert_channel_probe(channel)
 
 
 def assert_payload(payload: dict[str, Any], *, appended: bool) -> None:
@@ -273,6 +313,7 @@ def assert_payload(payload: dict[str, Any], *, appended: bool) -> None:
     assert event["validation"]["active_user_assisted_treatment_preflight"] is True, event
     assert event["validation"]["active_user_simulator_contract_checked"] is True, event
     assert event["validation"]["simulator_to_worker_injection_channel_checked"] is True, event
+    assert event["validation"]["simulator_to_worker_injection_channel_probe_checked"] is True, event
     assert event["validation"]["missing_simulator_to_worker_injection_channel_recorded"] is True, event
     assert event["validation"]["no_real_user_message_injected"] is True, event
     assert event["validation"]["no_model_backed_simulator_invoked"] is True, event
@@ -284,7 +325,7 @@ def assert_payload(payload: dict[str, Any], *, appended: bool) -> None:
     assert counters["case_result_writeback"] == "not_observed_active_user_assisted_treatment_preflight", counters
     assert counters["counter_trust_level"] == "active_user_assisted_treatment_preflight_no_injection_channel", counters
     assert_preflight_guard(event["preflight_guard"])
-    assert_active_user_preflight(event["active_user_assisted_treatment_preflight"])
+    assert_active_user_preflight(event["active_user_assisted_treatment_preflight"], compact=True)
     assert_public_safe(payload)
 
 
@@ -306,7 +347,7 @@ def assert_status_projection(registry_path: Path, runtime: Path) -> None:
     assert summary["official_score_claim_allowed"] is False, summary
     assert summary["active_user_simulator_injection_channel_available"] is False, summary
     assert_preflight_guard(summary["preflight_guard"])
-    assert_active_user_preflight(summary["active_user_assisted_treatment_preflight"])
+    assert_active_user_preflight(summary["active_user_assisted_treatment_preflight"], compact=True)
     assert_public_safe(summary)
 
 

--- a/goal_harness/benchmark.py
+++ b/goal_harness/benchmark.py
@@ -49,6 +49,9 @@ TERMINAL_BENCH_ACTIVE_USER_ASSISTED_TREATMENT_PREFLIGHT_SCHEMA = (
 TERMINAL_BENCH_ACTIVE_USER_SIMULATOR_INJECTION_CHANNEL_SCHEMA = (
     "terminal_bench_active_user_simulator_injection_channel_v0"
 )
+TERMINAL_BENCH_ACTIVE_USER_SIMULATOR_INJECTION_FIRST_BLOCKER = (
+    "missing_simulator_to_worker_injection_channel"
+)
 TERMINAL_BENCH_HARDENED_CODEX_BASELINE_PREFLIGHT_MODE = (
     "hardened_codex_baseline_preflight_guard"
 )
@@ -135,6 +138,51 @@ TERMINAL_BENCH_GOAL_HARNESS_CLI_BRIDGE_SURFACE = (
 TERMINAL_BENCH_CODEX_WORKER_CLI_BRIDGE_SURFACE = (
     "codex_worker_goal_harness_cli_bridge_v0"
 )
+
+
+def build_terminal_bench_active_user_injection_channel_probe(
+    *,
+    active_cli_bridge_preflight: bool,
+) -> dict[str, Any]:
+    """Describe why active-user treatment cannot yet inject mid-run messages."""
+
+    checked_channels = [
+        {
+            "channel": "initial_prompt_instruction_append",
+            "available": True,
+            "verdict": "rejected_for_active_intervention",
+            "reason": "initial prompt changes start state but cannot inject user messages during the worker run",
+        },
+        {
+            "channel": "worker_goal_harness_cli_pull",
+            "available": bool(active_cli_bridge_preflight),
+            "verdict": "partial_worker_pull_not_user_push",
+            "reason": "worker can query Goal Harness state, but the simulator cannot push a fresh user turn into the active Codex run",
+        },
+        {
+            "channel": "interactive_worker_session_bridge",
+            "available": False,
+            "verdict": "required_missing",
+            "reason": "current Harbor custom agent surface invokes one Codex worker run through a single super-run instruction",
+        },
+    ]
+    return {
+        "schema_version": TERMINAL_BENCH_ACTIVE_USER_SIMULATOR_INJECTION_CHANNEL_SCHEMA,
+        "channel_available": False,
+        "first_blocker": TERMINAL_BENCH_ACTIVE_USER_SIMULATOR_INJECTION_FIRST_BLOCKER,
+        "required_capability": "inject_user_message_during_codex_worker_run",
+        "current_agent_surface": "single_super_run_instruction_call",
+        "initial_prompt_only_is_not_active_intervention": True,
+        "no_user_message_injected": True,
+        "model_api_invoked": False,
+        "raw_transcript_recorded": False,
+        "checked_channel_count": len(checked_channels),
+        "checked_channels": checked_channels,
+        "next_channel_requirement": "controller_to_worker_user_message_push_or_audited_external_update_loop",
+        "minimum_next_implementation": "prove a worker can observe a new simulator intervention after the Codex run starts",
+    }
+
+
 TERMINAL_BENCH_CODEX_AUTH_SURFACE_NAMES = (
     "CODEX_FORCE_AUTH_JSON",
     "OPENAI_API_KEY",
@@ -2496,7 +2544,7 @@ def build_terminal_bench_benchmark_run(
             "event_mode": event_mode,
             "trace_publicness": trace_publicness,
             "first_blocker": (
-                "missing_simulator_to_worker_injection_channel"
+                TERMINAL_BENCH_ACTIVE_USER_SIMULATOR_INJECTION_FIRST_BLOCKER
                 if active_user_assisted_treatment_preflight
                 else first_blocker
             ),
@@ -2555,6 +2603,7 @@ def build_terminal_bench_benchmark_run(
         validation["active_user_assisted_treatment_preflight"] = True
         validation["active_user_simulator_contract_checked"] = True
         validation["simulator_to_worker_injection_channel_checked"] = True
+        validation["simulator_to_worker_injection_channel_probe_checked"] = True
         validation["missing_simulator_to_worker_injection_channel_recorded"] = True
         validation["no_real_user_message_injected"] = True
         validation["no_model_backed_simulator_invoked"] = True
@@ -3008,6 +3057,9 @@ def build_terminal_bench_benchmark_run(
         else 0
     )
     if active_user_assisted_treatment_preflight:
+        injection_channel_probe = build_terminal_bench_active_user_injection_channel_probe(
+            active_cli_bridge_preflight=active_cli_bridge_preflight,
+        )
         benchmark_run["active_user_assisted_treatment_preflight"] = {
             "schema_version": TERMINAL_BENCH_ACTIVE_USER_ASSISTED_TREATMENT_PREFLIGHT_SCHEMA,
             "pilot_schema_version": "active_user_assisted_pilot_v0",
@@ -3023,17 +3075,7 @@ def build_terminal_bench_benchmark_run(
             "assisted_collaboration_claim_allowed": True,
             "official_score_claim_allowed": False,
             "leaderboard_claim_allowed": False,
-            "simulator_to_worker_injection_channel": {
-                "schema_version": TERMINAL_BENCH_ACTIVE_USER_SIMULATOR_INJECTION_CHANNEL_SCHEMA,
-                "channel_available": False,
-                "first_blocker": "missing_simulator_to_worker_injection_channel",
-                "required_capability": "inject_user_message_during_codex_worker_run",
-                "current_agent_surface": "single_super_run_instruction_call",
-                "initial_prompt_only_is_not_active_intervention": True,
-                "no_user_message_injected": True,
-                "model_api_invoked": False,
-                "raw_transcript_recorded": False,
-            },
+            "simulator_to_worker_injection_channel": injection_channel_probe,
             "next_step": "add_or_select_runner_surface_that_can_inject_user_messages_during_worker_run",
         }
         benchmark_run["assisted_collaboration_claim_allowed"] = True
@@ -3325,11 +3367,15 @@ def build_terminal_bench_benchmark_run(
                 }
             )
             if active_user_assisted_treatment_preflight:
+                injection_channel_probe = build_terminal_bench_active_user_injection_channel_probe(
+                    active_cli_bridge_preflight=active_cli_bridge_preflight,
+                )
                 benchmark_run["preflight_guard"].update(
                     {
                         "active_user_assisted_treatment": True,
                         "simulator_setting": "deterministic_scripted_user",
                         "simulator_to_worker_injection_channel_available": False,
+                        "simulator_to_worker_injection_channel": injection_channel_probe,
                         "interactive_user_message_injection_checked": True,
                         "initial_prompt_only_is_not_active_intervention": True,
                         "no_oracle_audit_required": True,

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -615,10 +615,49 @@ def _compact_active_user_assisted_treatment_preflight(value: Any) -> dict[str, A
         "first_blocker",
         "required_capability",
         "current_agent_surface",
+        "next_channel_requirement",
+        "minimum_next_implementation",
+        "required_missing_channel",
     ):
         text = public_safe_compact_text(channel.get(field), limit=140)
         if text:
             compact_channel[field] = text
+    if isinstance(channel.get("checked_channel_count"), int) and not isinstance(
+        channel.get("checked_channel_count"), bool
+    ):
+        compact_channel["checked_channel_count"] = channel["checked_channel_count"]
+    checked_channels = (
+        channel.get("checked_channels")
+        if isinstance(channel.get("checked_channels"), list)
+        else []
+    )
+    existing_channel_names = (
+        channel.get("checked_channel_names")
+        if isinstance(channel.get("checked_channel_names"), list)
+        else []
+    )
+    channel_names: list[str] = [
+        name
+        for name in (
+            public_safe_compact_text(item, limit=80)
+            for item in existing_channel_names
+        )
+        if name
+    ]
+    required_missing_channel = ""
+    for item in checked_channels:
+        if not isinstance(item, dict):
+            continue
+        name = public_safe_compact_text(item.get("channel"), limit=80)
+        verdict = public_safe_compact_text(item.get("verdict"), limit=80)
+        if name:
+            channel_names.append(name)
+        if verdict == "required_missing" and name and not required_missing_channel:
+            required_missing_channel = name
+    if channel_names:
+        compact_channel["checked_channel_names"] = channel_names[:5]
+    if required_missing_channel:
+        compact_channel["required_missing_channel"] = required_missing_channel
     for field in (
         "channel_available",
         "initial_prompt_only_is_not_active_intervention",
@@ -1021,6 +1060,7 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
             "active_user_assisted_treatment_preflight",
             "active_user_simulator_contract_checked",
             "simulator_to_worker_injection_channel_checked",
+            "simulator_to_worker_injection_channel_probe_checked",
             "missing_simulator_to_worker_injection_channel_recorded",
             "no_real_user_message_injected",
             "no_model_backed_simulator_invoked",


### PR DESCRIPTION
## Summary
- add a machine-readable active-user simulator injection channel probe for Terminal-Bench assisted-treatment preflight
- record the checked surfaces: initial-prompt append rejected, worker Goal Harness CLI pull partial, interactive worker session bridge missing
- preserve compact status fields for checked channel count, channel names, required missing channel, and next channel requirement

## Validation
- python3 -m py_compile goal_harness/benchmark.py goal_harness/status.py examples/terminal-bench-active-user-assisted-treatment-preflight-smoke.py
- python3 examples/terminal-bench-active-user-assisted-treatment-preflight-smoke.py
- python3 examples/benchmark-run-v0-status-projection-smoke.py
- prior full smoke pass in this slice: python3 examples/run-smokes.py

## Boundary
- no private runner execution
- no Codex worker or model API invocation
- no Docker task launch
- no raw transcript or credentials committed
- local active-state and runtime history are intentionally not committed