### PR TITLE
Avoid refresh-state run path collisions

### DIFF
--- a/examples/refresh-state-unique-run-path-smoke.py
+++ b/examples/refresh-state-unique-run-path-smoke.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Smoke-test refresh-state path uniqueness on same-second collisions."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import goal_harness.state_refresh as state_refresh
+
+
+GOAL_ID = "refresh-state-unique-path-goal"
+GENERATED_AT = "2026-01-01T00:00:00+00:00"
+
+
+def write_fixture(root: Path) -> tuple[Path, Path, Path]:
+    project = root / "project"
+    runtime = root / "runtime"
+    state_file = f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    state_path = project / state_file
+    registry_path = project / ".goal-harness" / "registry.json"
+    runs_dir = runtime / "goals" / GOAL_ID / "runs"
+
+    state_path.parent.mkdir(parents=True)
+    state_path.write_text(
+        "---\n"
+        "status: active-read-only\n"
+        "owner_mode: goal\n"
+        'objective: "Keep refresh-state append-only."\n'
+        "updated_at: 2026-01-01T00:00:00+00:00\n"
+        "---\n\n"
+        "# Refresh State Unique Path Goal\n\n"
+        "## Next Action\n\n"
+        "- Append a state refresh without overwriting an existing run artifact.\n\n"
+        "## Progress Ledger\n\n"
+        "- Fixture initialized.\n",
+        encoding="utf-8",
+    )
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "updated_at": GENERATED_AT,
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "refresh-state-fixture",
+                        "status": "active-read-only",
+                        "repo": str(project),
+                        "state_file": state_file,
+                        "adapter": {"kind": "fixture", "status": "connected-read-only"},
+                        "authority_sources": [],
+                    }
+                ],
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    runs_dir.mkdir(parents=True)
+    existing_json = runs_dir / "2026-01-01T00-00-00-00-00.json"
+    existing_markdown = runs_dir / "2026-01-01T00-00-00-00-00.md"
+    existing_json.write_text('{"existing": true}\n', encoding="utf-8")
+    existing_markdown.write_text("# Existing Run\n", encoding="utf-8")
+    (runs_dir / "index.jsonl").write_text(
+        json.dumps(
+            {
+                "generated_at": GENERATED_AT,
+                "goal_id": GOAL_ID,
+                "classification": "benchmark_run_v0",
+                "recommended_action": "preserve existing artifact",
+                "health_check": "benchmark_run_v0 compact event public-safe",
+                "json_path": str(existing_json),
+                "markdown_path": str(existing_markdown),
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return registry_path, runtime, project
+
+
+def main() -> None:
+    original_now_local = state_refresh.now_local
+    try:
+        state_refresh.now_local = lambda: GENERATED_AT
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            registry_path, runtime, project = write_fixture(Path(raw_tmp))
+            payload = state_refresh.refresh_state_run(
+                registry_path=registry_path,
+                runtime_root_override=str(runtime),
+                goal_id=GOAL_ID,
+                project=project,
+                state_file=None,
+                classification="state_refreshed",
+                recommended_action="append refresh-state collision-free",
+                delivery_batch_scale="single_surface",
+                delivery_outcome="outcome_progress",
+                dry_run=False,
+                sync_global=False,
+            )
+            assert payload["appended"] is True, payload
+            json_path = Path(payload["json_path"])
+            markdown_path = Path(payload["markdown_path"])
+            assert json_path.name == "2026-01-01T00-00-00-00-00-2.json", payload
+            assert markdown_path.name == "2026-01-01T00-00-00-00-00-2.md", payload
+            assert (runtime / "goals" / GOAL_ID / "runs" / "2026-01-01T00-00-00-00-00.json").read_text(
+                encoding="utf-8"
+            ) == '{"existing": true}\n'
+            records = [
+                json.loads(line)
+                for line in (runtime / "goals" / GOAL_ID / "runs" / "index.jsonl").read_text(
+                    encoding="utf-8"
+                ).splitlines()
+            ]
+            assert len(records) == 2, records
+            assert records[-1]["json_path"] == str(json_path), records[-1]
+    finally:
+        state_refresh.now_local = original_now_local
+
+    print("refresh-state-unique-run-path-smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/goal_harness/state_refresh.py
+++ b/goal_harness/state_refresh.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from .feedback import validate_public_safe_text
 from .global_registry import sync_project_registry_to_global
-from .history import load_registry
+from .history import load_registry, unique_run_paths
 from .paths import resolve_runtime_root
 from .registry import registry_goals, resolve_state_file
 from .runtime import validate_goal_id_path_segment
@@ -294,9 +294,7 @@ def refresh_state_run(
     )
 
     runs_dir = runtime_root / "goals" / safe_goal_id / "runs"
-    stem = run_file_stem(generated_at)
-    json_path = runs_dir / f"{stem}.json"
-    markdown_path = runs_dir / f"{stem}.md"
+    json_path, markdown_path = unique_run_paths(runs_dir, generated_at)
     index_path = runs_dir / "index.jsonl"
     index_record = {
         "generated_at": generated_at,


### PR DESCRIPTION
## Summary
- Reuse the shared unique run artifact allocator for refresh-state writes.
- Add a smoke that fixes now_local to an existing run timestamp and verifies refresh-state writes -2 JSON/Markdown artifacts without overwriting the original run.

## Validation
- python3 -m py_compile goal_harness/state_refresh.py examples/refresh-state-unique-run-path-smoke.py
- python3 examples/refresh-state-unique-run-path-smoke.py
- python3 examples/contract-reward-overlay-smoke.py
- python3 examples/status-markdown-smoke.py
- python3 examples/run-smokes.py (104 smoke scripts)
- git diff --check
- added diff sensitive-marker scan

## Notes
- This prevents new refresh-state same-second path collisions. The current local runtime still has a historical duplicate-index warning; this PR does not rewrite existing runtime history.