### PR TITLE
Add run index duplicate inspection

### DIFF
--- a/examples/history-index-duplicate-inspection-smoke.py
+++ b/examples/history-index-duplicate-inspection-smoke.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Smoke-test read-only duplicate run-index inspection."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def write_index_fixture(root: Path, goal_id: str, duplicate_kind: str) -> None:
+    runs_dir = root / "runtime" / "goals" / goal_id / "runs"
+    runs_dir.mkdir(parents=True)
+    json_path = runs_dir / "run.json"
+    markdown_path = runs_dir / "run.md"
+    json_path.write_text('{"ok": true}\n', encoding="utf-8")
+    markdown_path.write_text("# Run\n", encoding="utf-8")
+    base = {
+        "generated_at": "2026-01-01T00:00:00+00:00",
+        "goal_id": goal_id,
+        "classification": "state_refreshed",
+        "recommended_action": "inspect public-safe duplicate fixture",
+        "health_check": "state_file 1/1; registry_goal 1/1; authority_sources 0",
+        "json_path": str(json_path),
+        "markdown_path": str(markdown_path),
+    }
+    if duplicate_kind == "reward_overlay":
+        rows = [
+            base,
+            {
+                **base,
+                "human_reward": {
+                    "recorded_at": "2026-01-01T00:00:01+00:00",
+                    "decision": "continue",
+                    "reward": "positive",
+                    "reason_summary": "operator accepted public-safe fixture",
+                    "follow_up": "continue",
+                },
+            },
+        ]
+    elif duplicate_kind == "plain_duplicate":
+        rows = [base, dict(base)]
+    elif duplicate_kind == "artifact_identity_collision":
+        rows = [
+            {**base, "classification": "benchmark_run_v0", "health_check": "benchmark_run_v0 compact event public-safe"},
+            {**base, "classification": "state_refreshed"},
+        ]
+    else:
+        raise ValueError(duplicate_kind)
+    (runs_dir / "index.jsonl").write_text(
+        "".join(json.dumps(row, ensure_ascii=False) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
+def write_registry(root: Path) -> Path:
+    project = root / "project"
+    project.mkdir()
+    registry_path = project / ".goal-harness" / "registry.json"
+    registry_path.parent.mkdir()
+    goals = []
+    for goal_id, kind in (
+        ("reward-overlay-goal", "reward_overlay"),
+        ("plain-duplicate-goal", "plain_duplicate"),
+        ("artifact-collision-goal", "artifact_identity_collision"),
+    ):
+        state_file = project / ".codex" / "goals" / goal_id / "ACTIVE_GOAL_STATE.md"
+        state_file.parent.mkdir(parents=True, exist_ok=True)
+        state_file.write_text("---\nupdated_at: 2026-01-01T00:00:00+00:00\n---\n", encoding="utf-8")
+        write_index_fixture(root, goal_id, kind)
+        goals.append(
+            {
+                "id": goal_id,
+                "domain": "duplicate-inspection-fixture",
+                "status": "active-read-only",
+                "repo": str(project),
+                "state_file": str(state_file.relative_to(project)),
+                "adapter": {"kind": "fixture", "status": "connected-read-only"},
+            }
+        )
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "common_runtime_root": str(root / "runtime"),
+                "goals": goals,
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return registry_path
+
+
+def run_cli(registry_path: Path, *args: str) -> dict:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "goal_harness.cli",
+            "--registry",
+            str(registry_path),
+            "--format",
+            "json",
+            *args,
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory() as raw_tmp:
+        registry_path = write_registry(Path(raw_tmp))
+        payload = run_cli(registry_path, "history", "inspect-index-duplicates", "--limit", "10")
+        assert payload["ok"] is True, payload
+        assert payload["duplicate_group_count"] == 3, payload
+        assert payload["duplicate_row_count"] == 3, payload
+        by_goal = {group["goal_id"]: group for group in payload["groups"]}
+        assert by_goal["reward-overlay-goal"]["duplicate_kind"] == "reward_overlay", payload
+        assert by_goal["reward-overlay-goal"]["severity"] == "info", payload
+        assert by_goal["plain-duplicate-goal"]["duplicate_kind"] == "plain_duplicate", payload
+        assert by_goal["plain-duplicate-goal"]["severity"] == "warning", payload
+        assert by_goal["artifact-collision-goal"]["duplicate_kind"] == "artifact_identity_collision", payload
+        assert by_goal["artifact-collision-goal"]["classifications"] == ["benchmark_run_v0", "state_refreshed"], payload
+        assert payload["groups"][0]["severity"] == "warning", payload
+
+        filtered = run_cli(
+            registry_path,
+            "history",
+            "inspect-index-duplicates",
+            "--goal-id",
+            "reward-overlay-goal",
+        )
+        assert filtered["duplicate_group_count"] == 1, filtered
+        assert filtered["groups"][0]["duplicate_kind"] == "reward_overlay", filtered
+
+    print("history-index-duplicate-inspection-smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -53,6 +53,7 @@ from .history import (
     append_benchmark_result,
     append_benchmark_run,
     collect_history,
+    inspect_index_duplicates,
     load_registry,
     render_active_user_assisted_pilot_append_markdown,
     render_benchmark_comparison_append_markdown,
@@ -60,6 +61,7 @@ from .history import (
     render_benchmark_result_append_markdown,
     render_benchmark_run_append_markdown,
     render_history_markdown,
+    render_index_duplicate_inspection_markdown,
 )
 from .operator_gate import (
     DEFAULT_OPERATOR_GATE,
@@ -815,8 +817,13 @@ def main(argv: list[str] | None = None) -> int:
             "append-benchmark-comparison",
             "append-benchmark-report",
             "append-active-user-assisted-pilot",
+            "inspect-index-duplicates",
         ],
-        help="Append a compact benchmark_run_v0, benchmark_result_v0, benchmark_comparison_v0, benchmark_experiment_report_v0, or active_user_assisted_pilot_v0 event.",
+        help=(
+            "Append a compact benchmark_run_v0, benchmark_result_v0, benchmark_comparison_v0, "
+            "benchmark_experiment_report_v0, or active_user_assisted_pilot_v0 event; or inspect "
+            "duplicate run-index identities without writing runtime state."
+        ),
     )
     history_parser.add_argument("--goal-id", help="Only show one goal.")
     history_parser.add_argument("--limit", type=int, default=10)
@@ -1956,6 +1963,27 @@ def main(argv: list[str] | None = None) -> int:
             return 0 if payload.get("ok") else 1
 
     if args.command == "history":
+        if args.history_action == "inspect-index-duplicates":
+            try:
+                payload = inspect_index_duplicates(
+                    registry_path=registry_path,
+                    runtime_root_override=args.runtime_root,
+                    goal_id=args.goal_id,
+                    limit=args.limit,
+                )
+            except Exception as exc:
+                registry = load_registry(registry_path)
+                runtime_root = resolve_runtime_root(registry, args.runtime_root)
+                payload = {
+                    "ok": False,
+                    "registry": str(registry_path),
+                    "runtime_root": str(runtime_root),
+                    "goal_filter": args.goal_id,
+                    "error": str(exc),
+                }
+            print_payload(payload, args.format, render_index_duplicate_inspection_markdown)
+            return 0 if payload.get("ok") else 1
+
         if args.history_action == "append-benchmark-run":
             try:
                 if args.dry_run and args.execute:

--- a/goal_harness/history.py
+++ b/goal_harness/history.py
@@ -575,6 +575,118 @@ def collect_history(
     }
 
 
+def inspect_index_duplicates(
+    *,
+    registry_path: Path,
+    runtime_root_override: str | None,
+    goal_id: str | None,
+    limit: int,
+) -> dict[str, Any]:
+    registry = load_registry(registry_path)
+    runtime_root = resolve_runtime_root(registry, runtime_root_override)
+    groups: list[dict[str, Any]] = []
+    checked_goal_count = 0
+    raw_index_records = 0
+    duplicate_row_count = 0
+
+    for current_goal_id in discover_goal_ids(runtime_root, registry, goal_id):
+        checked_goal_count += 1
+        index_path = runtime_root / "goals" / current_goal_id / "runs" / "index.jsonl"
+        if not index_path.exists():
+            continue
+
+        grouped: dict[tuple[str, str, str], list[tuple[int, dict[str, Any]]]] = {}
+        with index_path.open(encoding="utf-8") as f:
+            for line_number, line in enumerate(f, start=1):
+                if not line.strip():
+                    continue
+                raw_index_records += 1
+                try:
+                    item = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(item, dict):
+                    continue
+                key = (
+                    str(item.get("generated_at") or ""),
+                    str(item.get("json_path") or ""),
+                    str(item.get("markdown_path") or ""),
+                )
+                grouped.setdefault(key, []).append((line_number, item))
+
+        for key, records in grouped.items():
+            if len(records) <= 1:
+                continue
+            duplicate_row_count += len(records) - 1
+            generated_at, json_path, markdown_path = key
+            normalized = [
+                {record_key: value for record_key, value in record.items() if record_key != "human_reward"}
+                for _, record in records
+            ]
+            normalized_keys = {json.dumps(record, sort_keys=True, ensure_ascii=False) for record in normalized}
+            reward_records = sum(1 for _, record in records if isinstance(record.get("human_reward"), dict))
+            classifications = sorted({str(record.get("classification") or "") for _, record in records})
+            health_checks = sorted({str(record.get("health_check") or "") for _, record in records if record.get("health_check")})
+            if reward_records and len(normalized_keys) == 1:
+                duplicate_kind = "reward_overlay"
+                severity = "info"
+                repair_hint = "no index repair needed; reward overlay rows merge into the base run"
+            elif len(normalized_keys) == 1:
+                duplicate_kind = "plain_duplicate"
+                severity = "warning"
+                repair_hint = "append-only ledger repair can archive or supersede the extra identical index row"
+            else:
+                duplicate_kind = "artifact_identity_collision"
+                severity = "warning"
+                repair_hint = (
+                    "do not delete blindly; inspect artifacts and append an explicit repair/supersede event "
+                    "or rebuild a reviewed index copy"
+                )
+            groups.append(
+                {
+                    "goal_id": current_goal_id,
+                    "index_path": str(index_path),
+                    "generated_at": generated_at,
+                    "json_path": json_path,
+                    "markdown_path": markdown_path,
+                    "json_exists": Path(json_path).exists() if json_path else False,
+                    "markdown_exists": Path(markdown_path).exists() if markdown_path else False,
+                    "line_numbers": [line_number for line_number, _ in records],
+                    "raw_rows": len(records),
+                    "duplicate_rows": len(records) - 1,
+                    "duplicate_kind": duplicate_kind,
+                    "severity": severity,
+                    "classifications": classifications,
+                    "health_checks": health_checks,
+                    "reward_overlay_rows": reward_records,
+                    "repair_hint": repair_hint,
+                }
+            )
+
+    severity_priority = {"warning": 0, "info": 1}
+    groups.sort(
+        key=lambda item: (
+            severity_priority.get(str(item.get("severity")), 99),
+            str(item.get("goal_id")),
+            str(item.get("generated_at")),
+        )
+    )
+    limited_groups = groups[: max(0, limit)]
+    return {
+        "ok": True,
+        "registry": str(registry_path),
+        "runtime_root": str(runtime_root),
+        "goal_filter": goal_id,
+        "checked_goal_count": checked_goal_count,
+        "raw_index_records": raw_index_records,
+        "duplicate_group_count": len(groups),
+        "duplicate_row_count": duplicate_row_count,
+        "groups": limited_groups,
+        "truncated": len(groups) > len(limited_groups),
+        "limit": limit,
+    }
+
+
 def render_history_markdown(payload: dict[str, Any]) -> str:
     if not payload.get("ok"):
         return "# Goal Harness Run History\n\n- ok: `False`\n- error: " + str(payload.get("error"))
@@ -612,6 +724,41 @@ def render_history_markdown(payload: dict[str, Any]) -> str:
             f"index_exists=`{goal.get('index_exists')}`, "
             f"records=`{goal.get('raw_index_records')}`, "
             f"unique_runs=`{goal.get('unique_runs')}`"
+        )
+    return "\n".join(lines)
+
+
+def render_index_duplicate_inspection_markdown(payload: dict[str, Any]) -> str:
+    if not payload.get("ok"):
+        return "# Goal Harness Index Duplicate Inspection\n\n- ok: `False`\n- error: " + str(payload.get("error"))
+
+    lines = [
+        "# Goal Harness Index Duplicate Inspection",
+        "",
+        f"- runtime_root: `{payload.get('runtime_root')}`",
+        f"- registry: `{payload.get('registry')}`",
+        f"- goal_filter: `{payload.get('goal_filter')}`",
+        f"- checked_goals: `{payload.get('checked_goal_count')}`",
+        f"- raw_index_records: `{payload.get('raw_index_records')}`",
+        f"- duplicate_groups: `{payload.get('duplicate_group_count')}`",
+        f"- duplicate_rows: `{payload.get('duplicate_row_count')}`",
+        f"- truncated: `{payload.get('truncated')}`",
+        "",
+        "| goal | generated_at | kind | severity | rows | classifications | repair_hint |",
+        "| --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for group in payload.get("groups") or []:
+        classifications = ", ".join(str(item) for item in group.get("classifications") or [])
+        hint = str(group.get("repair_hint") or "").replace("|", "\\|")
+        lines.append(
+            "| "
+            f"`{group.get('goal_id')}` | "
+            f"`{group.get('generated_at')}` | "
+            f"`{group.get('duplicate_kind')}` | "
+            f"`{group.get('severity')}` | "
+            f"`{group.get('line_numbers')}` | "
+            f"`{classifications}` | "
+            f"{hint} |"
         )
     return "\n".join(lines)
 


### PR DESCRIPTION
## Summary
- Add `history inspect-index-duplicates` as a read-only diagnostic for duplicate run-index identities.
- Classify duplicate groups as `reward_overlay`, `plain_duplicate`, or `artifact_identity_collision` with severity, line numbers, artifact existence, classifications, health checks, and repair hints.
- Add smoke coverage for all three duplicate classes and goal filtering.

## Validation
- python3 -m py_compile goal_harness/history.py goal_harness/cli.py examples/history-index-duplicate-inspection-smoke.py
- python3 examples/history-index-duplicate-inspection-smoke.py
- python3 examples/contract-reward-overlay-smoke.py
- python3 -m goal_harness.cli --format json --registry "$HOME/.codex/goal-harness/registry.global.json" history inspect-index-duplicates --goal-id goal-harness-meta --limit 5
- python3 examples/run-smokes.py (105 smoke scripts)
- git diff --check
- added diff sensitive-marker scan

## Notes
- This is intentionally read-only; it explains the existing historical duplicate warning but does not rewrite runtime history.