### PR TITLE
Add duplicate index check hint

### DIFF
--- a/examples/contract-reward-overlay-smoke.py
+++ b/examples/contract-reward-overlay-smoke.py
@@ -115,6 +115,7 @@ def main() -> None:
         assert "reward-overlay-goal: reward overlay rows raw=2 unique=1 overlays=1" in checks, payload
         assert "reward-overlay-goal: duplicate index rows" not in warnings, payload
         assert "plain-duplicate-goal: duplicate index rows raw=2 unique=1" in warnings, payload
+        assert "goal-harness history inspect-index-duplicates --goal-id plain-duplicate-goal" in warnings, payload
         assert not any(".local/managed_doc" in item for item in payload["errors"]), payload
 
     print("contract-reward-overlay-smoke ok")

--- a/goal_harness/contract.py
+++ b/goal_harness/contract.py
@@ -102,6 +102,14 @@ def _index_duplicate_summary(index_path: Path) -> dict[str, Any]:
     }
 
 
+def _index_duplicate_warning(goal_id: object, raw: int, unique: int) -> str:
+    safe_goal_id = str(goal_id)
+    return (
+        f"{safe_goal_id}: duplicate index rows raw={raw} unique={unique}; "
+        f"inspect with `goal-harness history inspect-index-duplicates --goal-id {safe_goal_id}`"
+    )
+
+
 def iter_scan_files(scan_root: Path) -> list[Path]:
     if scan_root.is_file():
         return [scan_root]
@@ -187,14 +195,14 @@ def check_contract(
         if raw > unique:
             duplicate_summary = _index_duplicate_summary(Path(str(item.get("index_path") or "")))
             if duplicate_summary.get("unexpected_duplicate_rows"):
-                warnings.append(f"{item.get('id')}: duplicate index rows raw={raw} unique={unique}")
+                warnings.append(_index_duplicate_warning(item.get("id"), raw, unique))
             elif duplicate_summary.get("reward_overlay_rows"):
                 checks.append(
                     f"{item.get('id')}: reward overlay rows raw={raw} unique={unique} "
                     f"overlays={duplicate_summary.get('reward_overlay_rows')}"
                 )
             else:
-                warnings.append(f"{item.get('id')}: duplicate index rows raw={raw} unique={unique}")
+                warnings.append(_index_duplicate_warning(item.get("id"), raw, unique))
 
     boundary = scan_public_boundary(scan_roots)
     if boundary.get("ok"):


### PR DESCRIPTION
## Summary
- Make duplicate run-index warnings from `goal-harness check` actionable by including the read-only diagnostic command.
- Keep reward-overlay duplicate rows as check-only, not warnings.
- Extend the reward-overlay contract smoke to assert the diagnostic hint appears for ordinary duplicate warnings.

## Validation
- python3 -m py_compile goal_harness/contract.py examples/contract-reward-overlay-smoke.py
- python3 examples/contract-reward-overlay-smoke.py
- python3 -m goal_harness.cli --format json --registry "$HOME/.codex/goal-harness/registry.global.json" check --limit 5
- python3 examples/run-smokes.py (105 smoke scripts)
- git diff --check
- added diff sensitive-marker scan