### PR TITLE
Add safe history index duplicate repair

### DIFF
--- a/examples/history-index-duplicate-inspection-smoke.py
+++ b/examples/history-index-duplicate-inspection-smoke.py
@@ -45,6 +45,24 @@ def write_index_fixture(root: Path, goal_id: str, duplicate_kind: str) -> None:
         ]
     elif duplicate_kind == "plain_duplicate":
         rows = [base, dict(base)]
+    elif duplicate_kind == "structured_artifact_collision":
+        rows = [
+            {
+                **base,
+                "classification": "benchmark_run_v0",
+                "health_check": "benchmark_run_v0 compact event public-safe",
+                "benchmark_run": {
+                    "schema_version": "benchmark_run_v0",
+                    "mode": "codex_goal_harness",
+                    "official_task_score": {"kind": "fixture"},
+                },
+            },
+            {
+                **base,
+                "classification": "benchmark_run_v0",
+                "health_check": "state_file 1/1; registry_goal 1/1; authority_sources 0",
+            },
+        ]
     elif duplicate_kind == "artifact_identity_collision":
         rows = [
             {**base, "classification": "benchmark_run_v0", "health_check": "benchmark_run_v0 compact event public-safe"},
@@ -67,6 +85,7 @@ def write_registry(root: Path) -> Path:
     for goal_id, kind in (
         ("reward-overlay-goal", "reward_overlay"),
         ("plain-duplicate-goal", "plain_duplicate"),
+        ("structured-artifact-goal", "structured_artifact_collision"),
         ("artifact-collision-goal", "artifact_identity_collision"),
     ):
         state_file = project / ".codex" / "goals" / goal_id / "ACTIVE_GOAL_STATE.md"
@@ -125,16 +144,52 @@ def main() -> None:
         registry_path = write_registry(Path(raw_tmp))
         payload = run_cli(registry_path, "history", "inspect-index-duplicates", "--limit", "10")
         assert payload["ok"] is True, payload
-        assert payload["duplicate_group_count"] == 3, payload
-        assert payload["duplicate_row_count"] == 3, payload
+        assert payload["duplicate_group_count"] == 4, payload
+        assert payload["duplicate_row_count"] == 4, payload
         by_goal = {group["goal_id"]: group for group in payload["groups"]}
         assert by_goal["reward-overlay-goal"]["duplicate_kind"] == "reward_overlay", payload
         assert by_goal["reward-overlay-goal"]["severity"] == "info", payload
         assert by_goal["plain-duplicate-goal"]["duplicate_kind"] == "plain_duplicate", payload
         assert by_goal["plain-duplicate-goal"]["severity"] == "warning", payload
+        assert by_goal["structured-artifact-goal"]["duplicate_kind"] == "artifact_identity_collision", payload
         assert by_goal["artifact-collision-goal"]["duplicate_kind"] == "artifact_identity_collision", payload
         assert by_goal["artifact-collision-goal"]["classifications"] == ["benchmark_run_v0", "state_refreshed"], payload
         assert payload["groups"][0]["severity"] == "warning", payload
+
+        repair_preview = run_cli(registry_path, "history", "repair-index-duplicates", "--limit", "10")
+        assert repair_preview["ok"] is True, repair_preview
+        assert repair_preview["dry_run"] is True, repair_preview
+        assert repair_preview["repaired"] is False, repair_preview
+        assert repair_preview["removed_row_count"] == 2, repair_preview
+        assert repair_preview["preserved_reward_overlay_rows"] == 1, repair_preview
+        assert repair_preview["unrepaired_group_count"] == 1, repair_preview
+        repair_actions = {group["goal_id"]: group["action"] for group in repair_preview["groups"]}
+        assert repair_actions["reward-overlay-goal"] == "preserve_reward_overlay", repair_preview
+        assert repair_actions["plain-duplicate-goal"] == "drop_plain_duplicate_rows", repair_preview
+        assert repair_actions["structured-artifact-goal"] == "keep_structured_artifact_row", repair_preview
+        assert repair_actions["artifact-collision-goal"] == "blocked_artifact_identity_collision", repair_preview
+
+        repair_execute = run_cli(
+            registry_path,
+            "history",
+            "repair-index-duplicates",
+            "--limit",
+            "10",
+            "--execute",
+        )
+        assert repair_execute["ok"] is True, repair_execute
+        assert repair_execute["dry_run"] is False, repair_execute
+        assert repair_execute["repaired"] is True, repair_execute
+        assert repair_execute["removed_row_count"] == 2, repair_execute
+
+        after_repair = run_cli(registry_path, "history", "inspect-index-duplicates", "--limit", "10")
+        assert after_repair["ok"] is True, after_repair
+        assert after_repair["duplicate_group_count"] == 2, after_repair
+        after_by_goal = {group["goal_id"]: group for group in after_repair["groups"]}
+        assert "plain-duplicate-goal" not in after_by_goal, after_repair
+        assert "structured-artifact-goal" not in after_by_goal, after_repair
+        assert after_by_goal["reward-overlay-goal"]["duplicate_kind"] == "reward_overlay", after_repair
+        assert after_by_goal["artifact-collision-goal"]["duplicate_kind"] == "artifact_identity_collision", after_repair
 
         filtered = run_cli(
             registry_path,

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -55,6 +55,7 @@ from .history import (
     collect_history,
     inspect_index_duplicates,
     load_registry,
+    repair_index_duplicates,
     render_active_user_assisted_pilot_append_markdown,
     render_benchmark_comparison_append_markdown,
     render_benchmark_experiment_report_append_markdown,
@@ -62,6 +63,7 @@ from .history import (
     render_benchmark_run_append_markdown,
     render_history_markdown,
     render_index_duplicate_inspection_markdown,
+    render_index_duplicate_repair_markdown,
 )
 from .operator_gate import (
     DEFAULT_OPERATOR_GATE,
@@ -818,11 +820,12 @@ def main(argv: list[str] | None = None) -> int:
             "append-benchmark-report",
             "append-active-user-assisted-pilot",
             "inspect-index-duplicates",
+            "repair-index-duplicates",
         ],
         help=(
             "Append a compact benchmark_run_v0, benchmark_result_v0, benchmark_comparison_v0, "
-            "benchmark_experiment_report_v0, or active_user_assisted_pilot_v0 event; or inspect "
-            "duplicate run-index identities without writing runtime state."
+            "benchmark_experiment_report_v0, or active_user_assisted_pilot_v0 event; inspect "
+            "duplicate run-index identities; or repair safe duplicate index rows."
         ),
     )
     history_parser.add_argument("--goal-id", help="Only show one goal.")
@@ -863,7 +866,7 @@ def main(argv: list[str] | None = None) -> int:
         help="Optional delivery outcome label for the run index.",
     )
     history_parser.add_argument("--dry-run", action="store_true", help="Preview append without writing. This is the default.")
-    history_parser.add_argument("--execute", action="store_true", help="Append the compact benchmark event.")
+    history_parser.add_argument("--execute", action="store_true", help="Append or repair. Without this flag, history write actions are dry-run previews.")
     history_parser.add_argument("--no-global-sync", action="store_true", help="Skip global registry sync after append.")
 
     benchmark_parser = sub.add_parser(
@@ -1998,6 +2001,29 @@ def main(argv: list[str] | None = None) -> int:
                     "error": str(exc),
                 }
             print_payload(payload, args.format, render_index_duplicate_inspection_markdown)
+            return 0 if payload.get("ok") else 1
+
+        if args.history_action == "repair-index-duplicates":
+            try:
+                payload = repair_index_duplicates(
+                    registry_path=registry_path,
+                    runtime_root_override=args.runtime_root,
+                    goal_id=args.goal_id,
+                    limit=args.limit,
+                    execute=bool(args.execute),
+                )
+            except Exception as exc:
+                registry = load_registry(registry_path)
+                runtime_root = resolve_runtime_root(registry, args.runtime_root)
+                payload = {
+                    "ok": False,
+                    "dry_run": not bool(args.execute),
+                    "registry": str(registry_path),
+                    "runtime_root": str(runtime_root),
+                    "goal_filter": args.goal_id,
+                    "error": str(exc),
+                }
+            print_payload(payload, args.format, render_index_duplicate_repair_markdown)
             return 0 if payload.get("ok") else 1
 
         if args.history_action == "append-benchmark-run":

--- a/goal_harness/history.py
+++ b/goal_harness/history.py
@@ -687,6 +687,229 @@ def inspect_index_duplicates(
     }
 
 
+STRUCTURED_INDEX_KEYS = (
+    "benchmark_run",
+    "benchmark_result",
+    "benchmark_comparison",
+    "benchmark_experiment_report",
+    "active_user_assisted_pilot",
+)
+
+
+def _index_identity(record: dict[str, Any]) -> tuple[str, str, str]:
+    return (
+        str(record.get("generated_at") or ""),
+        str(record.get("json_path") or ""),
+        str(record.get("markdown_path") or ""),
+    )
+
+
+def _has_structured_index_payload(record: dict[str, Any]) -> bool:
+    return any(isinstance(record.get(key), dict) for key in STRUCTURED_INDEX_KEYS)
+
+
+def _duplicate_repair_decision(records: list[tuple[int, dict[str, Any]]]) -> dict[str, Any]:
+    line_numbers = [line_number for line_number, _ in records]
+    reward_records = sum(1 for _, record in records if isinstance(record.get("human_reward"), dict))
+    normalized = [
+        {record_key: value for record_key, value in record.items() if record_key != "human_reward"}
+        for _, record in records
+    ]
+    normalized_keys = {json.dumps(record, sort_keys=True, ensure_ascii=False) for record in normalized}
+    classifications = {str(record.get("classification") or "") for _, record in records}
+    health_checks = {str(record.get("health_check") or "") for _, record in records}
+
+    if reward_records and len(normalized_keys) == 1:
+        return {
+            "action": "preserve_reward_overlay",
+            "repairable": False,
+            "line_numbers": line_numbers,
+            "kept_line_numbers": line_numbers,
+            "removed_line_numbers": [],
+            "reason": "reward overlay rows are intentionally merged by status checks",
+        }
+
+    if len(normalized_keys) == 1:
+        return {
+            "action": "drop_plain_duplicate_rows",
+            "repairable": True,
+            "line_numbers": line_numbers,
+            "kept_line_numbers": [line_numbers[0]],
+            "removed_line_numbers": line_numbers[1:],
+            "reason": "duplicate rows are byte-equivalent after reward fields are ignored",
+        }
+
+    structured_rows = [
+        (line_number, record)
+        for line_number, record in records
+        if _has_structured_index_payload(record)
+    ]
+    if (
+        len(structured_rows) == 1
+        and len(classifications) == 1
+        and len(health_checks) > 1
+        and all(
+            (
+                _has_structured_index_payload(record)
+                or all(key not in record for key in STRUCTURED_INDEX_KEYS)
+            )
+            for _, record in records
+        )
+    ):
+        kept_line = structured_rows[0][0]
+        return {
+            "action": "keep_structured_artifact_row",
+            "repairable": True,
+            "line_numbers": line_numbers,
+            "kept_line_numbers": [kept_line],
+            "removed_line_numbers": [line_number for line_number in line_numbers if line_number != kept_line],
+            "reason": "one row carries the compact structured artifact payload and siblings only repeat the artifact identity",
+        }
+
+    return {
+        "action": "blocked_artifact_identity_collision",
+        "repairable": False,
+        "line_numbers": line_numbers,
+        "kept_line_numbers": line_numbers,
+        "removed_line_numbers": [],
+        "reason": "artifact identity collision is not auto-repairable without reviewed merge semantics",
+    }
+
+
+def repair_index_duplicates(
+    *,
+    registry_path: Path,
+    runtime_root_override: str | None,
+    goal_id: str | None,
+    limit: int,
+    execute: bool,
+) -> dict[str, Any]:
+    registry = load_registry(registry_path)
+    runtime_root = resolve_runtime_root(registry, runtime_root_override)
+    checked_goal_count = 0
+    raw_index_records = 0
+    removed_row_count = 0
+    preserved_reward_overlay_rows = 0
+    unrepaired_group_count = 0
+    groups: list[dict[str, Any]] = []
+
+    for current_goal_id in discover_goal_ids(runtime_root, registry, goal_id):
+        checked_goal_count += 1
+        index_path = runtime_root / "goals" / current_goal_id / "runs" / "index.jsonl"
+        if not index_path.exists():
+            continue
+
+        raw_lines = index_path.read_text(encoding="utf-8").splitlines()
+        grouped: dict[tuple[str, str, str], list[tuple[int, dict[str, Any]]]] = {}
+        for line_number, line in enumerate(raw_lines, start=1):
+            if not line.strip():
+                continue
+            raw_index_records += 1
+            try:
+                item = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(item, dict):
+                continue
+            grouped.setdefault(_index_identity(item), []).append((line_number, item))
+
+        remove_lines: set[int] = set()
+        for records in grouped.values():
+            if len(records) <= 1:
+                continue
+            decision = _duplicate_repair_decision(records)
+            removed_lines = list(decision.get("removed_line_numbers") or [])
+            if decision.get("action") == "preserve_reward_overlay":
+                preserved_reward_overlay_rows += len(records) - 1
+            elif decision.get("repairable"):
+                remove_lines.update(int(line_number) for line_number in removed_lines)
+                removed_row_count += len(removed_lines)
+            else:
+                unrepaired_group_count += 1
+
+            first_record = records[0][1]
+            groups.append(
+                {
+                    "goal_id": current_goal_id,
+                    "index_path": str(index_path),
+                    "generated_at": first_record.get("generated_at"),
+                    "json_path": first_record.get("json_path"),
+                    "markdown_path": first_record.get("markdown_path"),
+                    "action": decision.get("action"),
+                    "repairable": decision.get("repairable"),
+                    "line_numbers": decision.get("line_numbers"),
+                    "kept_line_numbers": decision.get("kept_line_numbers"),
+                    "removed_line_numbers": removed_lines,
+                    "reason": decision.get("reason"),
+                }
+            )
+
+        if execute and remove_lines:
+            rewritten = [
+                line
+                for line_number, line in enumerate(raw_lines, start=1)
+                if line_number not in remove_lines
+            ]
+            tmp_path = index_path.with_suffix(index_path.suffix + ".tmp")
+            tmp_path.write_text("".join(line + "\n" for line in rewritten), encoding="utf-8")
+            tmp_path.replace(index_path)
+
+    limited_groups = groups[: max(0, limit)]
+    return {
+        "ok": True,
+        "dry_run": not execute,
+        "repaired": bool(execute and removed_row_count),
+        "registry": str(registry_path),
+        "runtime_root": str(runtime_root),
+        "goal_filter": goal_id,
+        "checked_goal_count": checked_goal_count,
+        "raw_index_records": raw_index_records,
+        "removed_row_count": removed_row_count,
+        "preserved_reward_overlay_rows": preserved_reward_overlay_rows,
+        "unrepaired_group_count": unrepaired_group_count,
+        "groups": limited_groups,
+        "truncated": len(groups) > len(limited_groups),
+        "limit": limit,
+    }
+
+
+def render_index_duplicate_repair_markdown(payload: dict[str, Any]) -> str:
+    if not payload.get("ok"):
+        return "# Goal Harness Index Duplicate Repair\n\n- ok: `False`\n- error: " + str(payload.get("error"))
+
+    lines = [
+        "# Goal Harness Index Duplicate Repair",
+        "",
+        f"- dry_run: `{payload.get('dry_run')}`",
+        f"- repaired: `{payload.get('repaired')}`",
+        f"- runtime_root: `{payload.get('runtime_root')}`",
+        f"- registry: `{payload.get('registry')}`",
+        f"- goal_filter: `{payload.get('goal_filter')}`",
+        f"- checked_goals: `{payload.get('checked_goal_count')}`",
+        f"- raw_index_records: `{payload.get('raw_index_records')}`",
+        f"- removed_rows: `{payload.get('removed_row_count')}`",
+        f"- preserved_reward_overlay_rows: `{payload.get('preserved_reward_overlay_rows')}`",
+        f"- unrepaired_groups: `{payload.get('unrepaired_group_count')}`",
+        f"- truncated: `{payload.get('truncated')}`",
+        "",
+        "| goal | generated_at | action | repairable | kept | removed | reason |",
+        "| --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for group in payload.get("groups") or []:
+        reason = str(group.get("reason") or "").replace("|", "\\|")
+        lines.append(
+            "| "
+            f"`{group.get('goal_id')}` | "
+            f"`{group.get('generated_at')}` | "
+            f"`{group.get('action')}` | "
+            f"`{group.get('repairable')}` | "
+            f"`{group.get('kept_line_numbers')}` | "
+            f"`{group.get('removed_line_numbers')}` | "
+            f"{reason} |"
+        )
+    return "\n".join(lines)
+
+
 def render_history_markdown(payload: dict[str, Any]) -> str:
     if not payload.get("ok"):
         return "# Goal Harness Run History\n\n- ok: `False`\n- error: " + str(payload.get("error"))


### PR DESCRIPTION
## Summary
- add `history repair-index-duplicates` as a dry-run-by-default repair path for safe run-index duplicate rows
- preserve reward-overlay rows, drop plain duplicates, and keep the single structured artifact row for conservative metadata-only collisions
- extend the duplicate-index smoke to cover preview, execute, preserved overlays, and blocked ambiguous collisions

## Validation
- `python3 examples/history-index-duplicate-inspection-smoke.py`
- `python3 examples/contract-reward-overlay-smoke.py`
- `python3 -m py_compile goal_harness/history.py goal_harness/cli.py`
- `git diff --check`
- live `goal-harness check` after local runtime repair: 0 warnings
