### PR TITLE
Add active-user assisted launcher plan

### DIFF
--- a/examples/terminal-bench-active-user-assisted-treatment-preflight-smoke.py
+++ b/examples/terminal-bench-active-user-assisted-treatment-preflight-smoke.py
@@ -31,6 +31,7 @@ RUN_MODE = "codex_goal_harness_active_user_assisted_treatment_preflight"
 WORKER_MODE = "codex_goal_harness_cli"
 CLASSIFICATION = "terminal_bench_active_user_assisted_treatment_preflight_v0"
 FIRST_BLOCKER = "missing_real_assisted_worker_observation"
+LAUNCHER_PLAN_SCHEMA = "terminal_bench_active_user_private_launcher_plan_v0"
 
 FORBIDDEN_TEXT = [
     "/" + "Users/",
@@ -276,6 +277,35 @@ def assert_active_user_preflight(preflight: dict[str, Any], *, compact: bool = F
         assert_compact_channel_probe(channel)
     else:
         assert_channel_probe(channel)
+    assert_private_launcher_plan(preflight["private_launcher_plan"])
+
+
+def assert_private_launcher_plan(plan: dict[str, Any]) -> None:
+    assert plan["schema_version"] == LAUNCHER_PLAN_SCHEMA, plan
+    assert plan["launch_surface"] == "private_no_upload_terminal_bench_single_worker", plan
+    assert plan["ready"] is True, plan
+    assert plan["first_blocker"] == "ready_for_private_no_upload_assisted_worker_sample", plan
+    assert plan["required_capability"] == "worker_observes_simulator_message_after_start", plan
+    assert plan["worker_start_marker"] == "worker_start_seq", plan
+    assert "goal-harness-active-user-interventions.jsonl" in plan["active_user_feed_jsonl"], plan
+    assert "goal-harness-active-user-observation.json" in plan["active_user_observation_json"], plan
+    assert plan["sequence_steps"] == [
+        "launch_single_codex_goal_harness_worker_with_no_upload",
+        "record_worker_start_seq_before_first_poll",
+        "append_public_safe_simulator_intervention_with_seq_gt_worker_start_seq",
+        "worker_polls_active_user_observe_after_start",
+        "ingest_worker_observation_as_non_official_collaboration_evidence",
+    ], plan
+    assert "worker_observation_proof_true" in plan["required_evidence"], plan
+    assert "leaderboard_or_upload_requested" in plan["stop_conditions"], plan
+    assert plan["claim_boundary"]["assisted_collaboration_claim_allowed"] is True, plan
+    assert plan["claim_boundary"]["official_score_claim_allowed"] is False, plan
+    assert plan["claim_boundary"]["leaderboard_claim_allowed"] is False, plan
+    assert plan["claim_boundary"]["official_score_must_remain_separate"] is True, plan
+    assert plan["public_boundary"]["no_upload"] is True, plan
+    assert plan["public_boundary"]["raw_paths_recorded"] is False, plan
+    assert plan["public_boundary"]["raw_transcript_recorded"] is False, plan
+    assert plan["public_boundary"]["credential_values_recorded"] is False, plan
 
 
 def assert_payload(payload: dict[str, Any], *, appended: bool) -> None:
@@ -312,6 +342,7 @@ def assert_payload(payload: dict[str, Any], *, appended: bool) -> None:
     assert event["assisted_collaboration_claim_allowed"] is True, event
     assert event["official_score_claim_allowed"] is False, event
     assert event["active_user_simulator_injection_channel_available"] is True, event
+    assert_private_launcher_plan(event["active_user_private_launcher_plan"])
     assert event["validation"]["all_passed"] is True, event
     assert event["validation"]["failed_checks"] == [], event
     assert event["validation"]["active_user_assisted_treatment_preflight"] is True, event
@@ -354,6 +385,7 @@ def assert_status_projection(registry_path: Path, runtime: Path) -> None:
     assert summary["assisted_collaboration_claim_allowed"] is True, summary
     assert summary["official_score_claim_allowed"] is False, summary
     assert summary["active_user_simulator_injection_channel_available"] is True, summary
+    assert_private_launcher_plan(summary["active_user_private_launcher_plan"])
     assert_preflight_guard(summary["preflight_guard"])
     assert_active_user_preflight(summary["active_user_assisted_treatment_preflight"], compact=True)
     assert_public_safe(summary)

--- a/goal_harness/benchmark.py
+++ b/goal_harness/benchmark.py
@@ -62,6 +62,9 @@ TERMINAL_BENCH_ACTIVE_USER_ASSISTED_OBSERVATION_FIXTURE_SCHEMA = (
 TERMINAL_BENCH_ACTIVE_USER_SIMULATOR_INJECTION_CHANNEL_SCHEMA = (
     "terminal_bench_active_user_simulator_injection_channel_v0"
 )
+TERMINAL_BENCH_ACTIVE_USER_PRIVATE_LAUNCHER_PLAN_SCHEMA = (
+    "terminal_bench_active_user_private_launcher_plan_v0"
+)
 TERMINAL_BENCH_ACTIVE_USER_SIMULATOR_INJECTION_FIRST_BLOCKER = (
     "missing_simulator_to_worker_injection_channel"
 )
@@ -1993,6 +1996,68 @@ def collect_terminal_bench_goal_harness_cli_bridge_trace(
     }
 
 
+def build_terminal_bench_active_user_private_launcher_plan(
+    *,
+    active_cli_bridge_preflight: bool,
+) -> dict[str, Any]:
+    """Describe the non-executing plan for a real private assisted sample."""
+
+    channel = build_terminal_bench_active_user_injection_channel_probe(
+        active_cli_bridge_preflight=active_cli_bridge_preflight,
+    )
+    channel_available = bool(channel.get("channel_available"))
+    first_blocker = (
+        "ready_for_private_no_upload_assisted_worker_sample"
+        if channel_available
+        else TERMINAL_BENCH_ACTIVE_USER_SIMULATOR_INJECTION_FIRST_BLOCKER
+    )
+    return {
+        "schema_version": TERMINAL_BENCH_ACTIVE_USER_PRIVATE_LAUNCHER_PLAN_SCHEMA,
+        "launch_surface": "private_no_upload_terminal_bench_single_worker",
+        "ready": channel_available,
+        "first_blocker": first_blocker,
+        "required_capability": "worker_observes_simulator_message_after_start",
+        "worker_start_marker": "worker_start_seq",
+        "active_user_feed_jsonl": TERMINAL_BENCH_WORKER_BRIDGE_ACTIVE_USER_FEED_JSONL,
+        "active_user_observation_json": (
+            TERMINAL_BENCH_WORKER_BRIDGE_ACTIVE_USER_OBSERVATION_JSON
+        ),
+        "sequence_steps": [
+            "launch_single_codex_goal_harness_worker_with_no_upload",
+            "record_worker_start_seq_before_first_poll",
+            "append_public_safe_simulator_intervention_with_seq_gt_worker_start_seq",
+            "worker_polls_active_user_observe_after_start",
+            "ingest_worker_observation_as_non_official_collaboration_evidence",
+        ],
+        "required_evidence": [
+            "worker_start_seq_recorded",
+            "post_start_intervention_seq_recorded",
+            "active_user_observe_worker_cli_call_recorded",
+            "worker_observation_proof_true",
+            "official_score_kind_not_run_or_separate",
+        ],
+        "stop_conditions": [
+            "hidden_tests_or_expected_solution_visible",
+            "credential_value_needed",
+            "leaderboard_or_upload_requested",
+            "raw_transcript_required",
+            "worker_observation_missing",
+        ],
+        "claim_boundary": {
+            "assisted_collaboration_claim_allowed": True,
+            "official_score_claim_allowed": False,
+            "leaderboard_claim_allowed": False,
+            "official_score_must_remain_separate": True,
+        },
+        "public_boundary": {
+            "no_upload": True,
+            "raw_paths_recorded": False,
+            "raw_transcript_recorded": False,
+            "credential_values_recorded": False,
+        },
+    }
+
+
 def build_terminal_bench_goal_harness_access_packet(
     *,
     mode: str = "codex_goal_harness",
@@ -3254,6 +3319,9 @@ def build_terminal_bench_benchmark_run(
         injection_channel_probe = build_terminal_bench_active_user_injection_channel_probe(
             active_cli_bridge_preflight=active_cli_bridge_preflight,
         )
+        private_launcher_plan = build_terminal_bench_active_user_private_launcher_plan(
+            active_cli_bridge_preflight=active_cli_bridge_preflight,
+        )
         benchmark_run["active_user_assisted_treatment_preflight"] = {
             "schema_version": TERMINAL_BENCH_ACTIVE_USER_ASSISTED_TREATMENT_PREFLIGHT_SCHEMA,
             "pilot_schema_version": "active_user_assisted_pilot_v0",
@@ -3270,8 +3338,10 @@ def build_terminal_bench_benchmark_run(
             "official_score_claim_allowed": False,
             "leaderboard_claim_allowed": False,
             "simulator_to_worker_injection_channel": injection_channel_probe,
+            "private_launcher_plan": private_launcher_plan,
             "next_step": injection_channel_probe["next_channel_requirement"],
         }
+        benchmark_run["active_user_private_launcher_plan"] = private_launcher_plan
         benchmark_run["assisted_collaboration_claim_allowed"] = True
         benchmark_run["official_score_claim_allowed"] = False
         benchmark_run["active_user_simulator_injection_channel_available"] = bool(

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -674,6 +674,53 @@ def _compact_active_user_assisted_treatment_preflight(value: Any) -> dict[str, A
     if compact_channel:
         compact["simulator_to_worker_injection_channel"] = compact_channel
 
+    launcher_plan = _compact_active_user_private_launcher_plan(
+        value.get("private_launcher_plan")
+    )
+    if launcher_plan:
+        compact["private_launcher_plan"] = launcher_plan
+
+    return compact
+
+
+def _compact_active_user_private_launcher_plan(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+
+    compact: dict[str, Any] = {}
+    for field in (
+        "schema_version",
+        "launch_surface",
+        "first_blocker",
+        "required_capability",
+        "worker_start_marker",
+        "active_user_feed_jsonl",
+        "active_user_observation_json",
+    ):
+        text = public_safe_compact_text(value.get(field), limit=140)
+        if text:
+            compact[field] = text
+    if isinstance(value.get("ready"), bool):
+        compact["ready"] = value["ready"]
+    for field in ("sequence_steps", "required_evidence", "stop_conditions"):
+        items = public_safe_compact_list(value.get(field), limit=8)
+        if items:
+            compact[field] = items
+    for nested_name in ("claim_boundary", "public_boundary"):
+        nested = value.get(nested_name) if isinstance(value.get(nested_name), dict) else {}
+        compact_nested: dict[str, Any] = {}
+        for key, nested_value in nested.items():
+            safe_key = public_safe_compact_text(key, limit=80)
+            if not safe_key:
+                continue
+            if isinstance(nested_value, bool):
+                compact_nested[safe_key] = nested_value
+            else:
+                text = public_safe_compact_text(nested_value, limit=120)
+                if text:
+                    compact_nested[safe_key] = text
+        if compact_nested:
+            compact[nested_name] = compact_nested
     return compact
 
 
@@ -1102,6 +1149,12 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
     )
     if active_user_preflight:
         compact["active_user_assisted_treatment_preflight"] = active_user_preflight
+
+    active_user_launcher_plan = _compact_active_user_private_launcher_plan(
+        source.get("active_user_private_launcher_plan")
+    )
+    if active_user_launcher_plan:
+        compact["active_user_private_launcher_plan"] = active_user_launcher_plan
 
     active_user_observation = _compact_active_user_observation(
         source.get("active_user_observation")


### PR DESCRIPTION
## Summary
- add a public-safe active-user private launcher plan to Terminal-Bench Goal Harness treatment preflight payloads
- project the launcher plan through compact benchmark status so the next real private no-upload run has an explicit sequence and evidence checklist
- extend the active-user treatment preflight smoke to verify claim boundaries, stop conditions, and status projection

## Validation
- python3 examples/terminal-bench-active-user-assisted-treatment-preflight-smoke.py
- python3 examples/terminal-bench-active-user-assisted-observation-fixture-smoke.py
- python3 examples/worker-bridge-active-user-after-start-observation-smoke.py
- python3 -m py_compile goal_harness/benchmark.py goal_harness/status.py
- git diff --check
- goal-harness --format json --registry /Users/bytedance/.codex/goal-harness/registry.global.json check --limit 5

No Harbor, Terminal-Bench worker, Codex model run, upload, credential read, raw transcript, or leaderboard path was invoked.