### PR TITLE
Support active-user writable feed mounts

### DIFF
--- a/docs/worker-bridge-install-contract.md
+++ b/docs/worker-bridge-install-contract.md
@@ -43,6 +43,20 @@ The placeholder paths are public-safe. A private runner may substitute actual
 host paths at launch time, but raw substituted paths must stay out of public
 docs, status, benchmark reports, and claim artifacts.
 
+For active-user assisted treatments, the runner may add one extra writable bind
+mount for the simulator feed:
+
+```text
+source=<active-user-host-dir> target=/goal-harness-active-user read_only=false
+goal_harness_active_user_feed_jsonl=/goal-harness-active-user/goal-harness-active-user-interventions.jsonl
+goal_harness_active_user_observation_json=/goal-harness-active-user/goal-harness-active-user-observation.json
+```
+
+This mount is the host-side coordination surface for appending a post-start
+simulator intervention while the worker polls `active-user-observe`. Public
+summaries may record that the writable mount was requested and count it, but
+must not record the raw host source path.
+
 ## Runner Adapter Rule
 
 A runner adapter should translate this contract into its native worker launch

--- a/examples/terminal-bench-active-user-assisted-treatment-preflight-smoke.py
+++ b/examples/terminal-bench-active-user-assisted-treatment-preflight-smoke.py
@@ -343,6 +343,10 @@ def assert_payload(payload: dict[str, Any], *, appended: bool) -> None:
     assert event["official_score_claim_allowed"] is False, event
     assert event["active_user_simulator_injection_channel_available"] is True, event
     assert_private_launcher_plan(event["active_user_private_launcher_plan"])
+    launch_summary = event["private_runner_launch_summary"]
+    assert launch_summary["active_user_writable_mount_requested"] is True, launch_summary
+    assert launch_summary["active_user_writable_mount_count"] == 1, launch_summary
+    assert launch_summary["raw_paths_recorded"] is False, launch_summary
     assert event["validation"]["all_passed"] is True, event
     assert event["validation"]["failed_checks"] == [], event
     assert event["validation"]["active_user_assisted_treatment_preflight"] is True, event

--- a/examples/terminal-bench-codex-goal-harness-active-cli-bridge-smoke.py
+++ b/examples/terminal-bench-codex-goal-harness-active-cli-bridge-smoke.py
@@ -595,6 +595,11 @@ def assert_harbor_command_preview() -> None:
         goal_harness_mode="codex_goal_harness",
         goal_harness_cli_bridge_enabled=True,
     )
+    active_user_launch = build_terminal_bench_private_runner_launch(
+        mode="codex-goal-harness",
+        goal_harness_cli_bridge_enabled=True,
+        goal_harness_active_user_intervention_enabled=True,
+    )
     assert "--include-task-name" not in batch_launch["argv"], batch_launch["argv"]
     assert "--path" in batch_launch["argv"], batch_launch["argv"]
     batch_mounts = json.loads(batch_launch["argv"][batch_launch["argv"].index("--mounts") + 1])
@@ -609,7 +614,14 @@ def assert_harbor_command_preview() -> None:
     ]
     assert not any("<goal-harness-project-root>" in item for item in batch_agent_kwargs), batch_agent_kwargs
     assert not any("<goal-harness-runtime-root>" in item for item in batch_agent_kwargs), batch_agent_kwargs
+    active_user_mounts = json.loads(
+        active_user_launch["argv"][active_user_launch["argv"].index("--mounts") + 1]
+    )
+    assert active_user_mounts[-1]["target"] == "/goal-harness-active-user", active_user_mounts
+    assert active_user_mounts[-1]["read_only"] is False, active_user_mounts
+    assert "<active-user-host-dir>" not in json.dumps(active_user_mounts), active_user_mounts
     launch_summary = summarize_terminal_bench_private_runner_launch(launch)
+    active_user_summary = summarize_terminal_bench_private_runner_launch(active_user_launch)
     assert launch_summary["schema_version"] == "terminal_bench_private_runner_launch_summary_v0", launch_summary
     assert launch_summary["launch_schema_version"] == "terminal_bench_private_runner_launch_v0", launch_summary
     assert launch_summary["uses_private_runner_env"] is True, launch_summary
@@ -621,6 +633,10 @@ def assert_harbor_command_preview() -> None:
     assert launch_summary["auth_values_recorded"] is False, launch_summary
     assert launch_summary["raw_env_recorded"] is False, launch_summary
     assert launch_summary["raw_paths_recorded"] is False, launch_summary
+    assert active_user_summary["active_user_writable_mount_requested"] is True, active_user_summary
+    assert active_user_summary["active_user_writable_mount_count"] == 1, active_user_summary
+    assert active_user_summary["raw_paths_recorded"] is False, active_user_summary
+    assert_public_safe(active_user_summary)
     assert_public_safe(launch_summary)
     assert "goal_harness_mode=codex_goal_harness" in command, command
     assert "goal_harness_mode=codex_goal_harness" in mode_launch["argv"], mode_launch["argv"]

--- a/examples/worker-bridge-install-contract-smoke.py
+++ b/examples/worker-bridge-install-contract-smoke.py
@@ -89,6 +89,12 @@ def assert_contract(payload: dict) -> None:
         == "goal_harness_active_user_external_update_loop_v0"
     ), payload
     assert "active-user-observe" in agent_kwargs["goal_harness_active_user_observe_command"], payload
+    assert payload["active_user_external_update_mount"] == {
+        "enabled": False,
+        "target": None,
+        "read_only": None,
+        "raw_host_path_recorded": False,
+    }, payload
     assert agent_kwargs["goal_harness_benchmark_run_schema_version"] == "benchmark_run_v0", payload
     assert (
         agent_kwargs["goal_harness_benchmark_run_writeback_contract"]
@@ -128,6 +134,41 @@ def assert_contract(payload: dict) -> None:
         == "rewrite_minimal_benchmark_run_v0_and_retry_once"
     ), payload
     assert writeback["retry_policy"]["do_not_retry_with_raw_logs_or_raw_paths"] is True, payload
+
+
+def assert_active_user_writable_mount_contract() -> None:
+    from goal_harness.worker_bridge import build_worker_bridge_install_contract
+
+    payload = build_worker_bridge_install_contract(
+        active_user_host_dir="<active-user-host-dir>",
+    )
+    mounts = payload["mounts"]
+    assert mounts[-1] == {
+        "read_only": False,
+        "source": "<active-user-host-dir>",
+        "target": "/goal-harness-active-user",
+        "type": "bind",
+    }, payload
+    assert payload["active_user_external_update_mount"] == {
+        "enabled": True,
+        "target": "/goal-harness-active-user",
+        "read_only": False,
+        "raw_host_path_recorded": False,
+    }, payload
+    agent_kwargs = payload["agent_kwargs"]
+    assert (
+        agent_kwargs["goal_harness_active_user_feed_jsonl"]
+        == "/goal-harness-active-user/goal-harness-active-user-interventions.jsonl"
+    ), payload
+    assert (
+        agent_kwargs["goal_harness_active_user_observation_json"]
+        == "/goal-harness-active-user/goal-harness-active-user-observation.json"
+    ), payload
+    assert (
+        "--feed-jsonl /goal-harness-active-user/goal-harness-active-user-interventions.jsonl"
+        in agent_kwargs["goal_harness_active_user_observe_command"]
+    ), payload
+    assert_public_safe(payload)
     active_user_channel = payload["active_user_intervention_channel_contract"]
     assert (
         active_user_channel["schema_version"]
@@ -349,6 +390,11 @@ def assert_terminal_bench_adapter_consumes_contract() -> None:
         goal_harness_mode="codex_goal_harness",
         goal_harness_cli_bridge_enabled=True,
     )
+    active_user_command = build_terminal_bench_managed_harbor_command(
+        goal_harness_mode="codex_goal_harness",
+        goal_harness_cli_bridge_enabled=True,
+        goal_harness_active_user_intervention_enabled=True,
+    )
     extended_timeout_command = build_terminal_bench_managed_harbor_command(
         goal_harness_mode="codex_goal_harness",
         goal_harness_cli_bridge_enabled=True,
@@ -363,6 +409,19 @@ def assert_terminal_bench_adapter_consumes_contract() -> None:
     mounts = json.loads(command[command.index("--mounts") + 1])
     assert mounts[0]["source"] == "<goal-harness-project-root>", command
     assert mounts[1]["source"] == "<goal-harness-runtime-root>", command
+    active_user_mounts = json.loads(
+        active_user_command[active_user_command.index("--mounts") + 1]
+    )
+    assert active_user_mounts[-1] == {
+        "read_only": False,
+        "source": "<active-user-host-dir>",
+        "target": "/goal-harness-active-user",
+        "type": "bind",
+    }, active_user_mounts
+    assert (
+        "goal_harness_active_user_feed_jsonl="
+        "/goal-harness-active-user/goal-harness-active-user-interventions.jsonl"
+    ) in active_user_command, active_user_command
     assert (
         "goal_harness_command_prefix="
         "PYTHONPATH='<goal-harness-project-root>' python3 -m goal_harness.cli"
@@ -381,6 +440,7 @@ def assert_terminal_bench_adapter_consumes_contract() -> None:
 
 def main() -> int:
     assert_module_contract()
+    assert_active_user_writable_mount_contract()
     assert_cli_contract()
     assert_cli_outcome()
     assert_cli_benchmark_run()

--- a/goal_harness/benchmark.py
+++ b/goal_harness/benchmark.py
@@ -14,10 +14,12 @@ from .worker_bridge import (
     ACTIVE_USER_INTERVENTION_CHANNEL_CONTRACT_VERSION,
     ACTIVE_USER_INTERVENTION_CHANNEL_SURFACE,
     ACTIVE_USER_INTERVENTION_OBSERVATION_VERSION,
+    DEFAULT_WORKER_BRIDGE_ACTIVE_USER_MOUNT_TARGET as TERMINAL_BENCH_WORKER_BRIDGE_ACTIVE_USER_MOUNT_TARGET,
     DEFAULT_WORKER_BRIDGE_ACTIVE_USER_FEED_JSONL as TERMINAL_BENCH_WORKER_BRIDGE_ACTIVE_USER_FEED_JSONL,
     DEFAULT_WORKER_BRIDGE_ACTIVE_USER_OBSERVATION_JSON as TERMINAL_BENCH_WORKER_BRIDGE_ACTIVE_USER_OBSERVATION_JSON,
     DEFAULT_WORKER_BRIDGE_BENCHMARK_RUN_JSON as TERMINAL_BENCH_WORKER_BRIDGE_BENCHMARK_RUN_JSON,
     DEFAULT_WORKER_BRIDGE_COUNTER_TRACE_JSON as TERMINAL_BENCH_WORKER_BRIDGE_COUNTER_TRACE_JSON,
+    GOAL_HARNESS_ACTIVE_USER_HOST_DIR_PLACEHOLDER as TERMINAL_BENCH_WORKER_BRIDGE_ACTIVE_USER_HOST_DIR_PLACEHOLDER,
     GOAL_HARNESS_PROJECT_ROOT_PLACEHOLDER as TERMINAL_BENCH_WORKER_BRIDGE_PROJECT_ROOT_PLACEHOLDER,
     GOAL_HARNESS_RUNTIME_ROOT_PLACEHOLDER as TERMINAL_BENCH_WORKER_BRIDGE_RUNTIME_ROOT_PLACEHOLDER,
     WORKER_BRIDGE_BENCHMARK_RUN_FORBIDDEN_PUBLIC_FIELDS,
@@ -1460,6 +1462,10 @@ def _private_runner_goal_harness_runtime_root() -> str:
     return str(Path("~/.codex/goal-harness").expanduser())
 
 
+def _private_runner_active_user_host_dir() -> str:
+    return str(Path("~/.codex/goal-harness/active-user-feeds").expanduser())
+
+
 def _private_runner_command_kwargs(command_kwargs: dict[str, Any]) -> dict[str, Any]:
     """Resolve worker-bridge placeholders only for a real private launch."""
 
@@ -1472,6 +1478,15 @@ def _private_runner_command_kwargs(command_kwargs: dict[str, Any]) -> dict[str, 
     runtime_root = resolved.get("goal_harness_runtime_root")
     if not runtime_root or runtime_root == TERMINAL_BENCH_WORKER_BRIDGE_RUNTIME_ROOT_PLACEHOLDER:
         resolved["goal_harness_runtime_root"] = _private_runner_goal_harness_runtime_root()
+    active_user_host_dir = resolved.get("goal_harness_active_user_host_dir")
+    if resolved.get("goal_harness_active_user_intervention_enabled") and (
+        not active_user_host_dir
+        or active_user_host_dir
+        == TERMINAL_BENCH_WORKER_BRIDGE_ACTIVE_USER_HOST_DIR_PLACEHOLDER
+    ):
+        resolved["goal_harness_active_user_host_dir"] = (
+            _private_runner_active_user_host_dir()
+        )
     return resolved
 
 
@@ -1562,6 +1577,22 @@ def summarize_terminal_bench_private_runner_launch(
     goal_harness_agent_kwargs_present = any(
         str(value).startswith("goal_harness_") for value in argv
     )
+    mounts: list[Any] = []
+    mounts_text = _invocation_arg_value(argv, "--mounts")
+    if mounts_text:
+        try:
+            raw_mounts = json.loads(mounts_text)
+        except json.JSONDecodeError:
+            raw_mounts = []
+        if isinstance(raw_mounts, list):
+            mounts = raw_mounts
+    active_user_mounts = [
+        mount
+        for mount in mounts
+        if isinstance(mount, dict)
+        and mount.get("target") == TERMINAL_BENCH_WORKER_BRIDGE_ACTIVE_USER_MOUNT_TARGET
+        and mount.get("read_only") is False
+    ]
     probe_coverage = {
         "local_bin": str(Path("~/.local/bin").expanduser()) in path_value,
         "homebrew_bin": "/opt/homebrew/bin" in path_value,
@@ -1584,6 +1615,9 @@ def summarize_terminal_bench_private_runner_launch(
         "goal_harness_agent_kwargs_present": goal_harness_agent_kwargs_present,
         "goal_harness_worker_bridge_requested": "goal_harness_cli_bridge_enabled=true"
         in argv,
+        "active_user_writable_mount_requested": bool(active_user_mounts),
+        "active_user_writable_mount_count": len(active_user_mounts),
+        "active_user_writable_mount_target_present": bool(active_user_mounts),
         "no_upload_boundary": bool(boundary.get("no_upload")),
         "submit_eligible": bool(boundary.get("submit_eligible")),
         "env_path_present": bool(path_value),
@@ -2459,6 +2493,10 @@ def build_terminal_bench_managed_harbor_command(
     goal_harness_benchmark_run_json: str = (
         TERMINAL_BENCH_WORKER_BRIDGE_BENCHMARK_RUN_JSON
     ),
+    goal_harness_active_user_host_dir: str | None = None,
+    goal_harness_active_user_mount_target: str = (
+        TERMINAL_BENCH_WORKER_BRIDGE_ACTIVE_USER_MOUNT_TARGET
+    ),
     goal_harness_classification: str = "<classification>",
     goal_harness_access_packet_mode: str = (
         TERMINAL_BENCH_GOAL_HARNESS_ACCESS_PACKET_MODE_FULL
@@ -2553,12 +2591,20 @@ def build_terminal_bench_managed_harbor_command(
             raise ValueError(f"{flag} must be greater than zero")
         command.extend([flag, _format_harbor_multiplier(parsed)])
     if goal_harness_cli_bridge_enabled:
+        active_user_host_dir = None
+        if goal_harness_active_user_intervention_enabled:
+            active_user_host_dir = (
+                goal_harness_active_user_host_dir
+                or TERMINAL_BENCH_WORKER_BRIDGE_ACTIVE_USER_HOST_DIR_PLACEHOLDER
+            )
         worker_bridge = build_worker_bridge_install_contract(
             project_root=goal_harness_project_root,
             runtime_root=goal_harness_runtime_root,
             benchmark_run_json=goal_harness_benchmark_run_json,
             counter_trace_json=goal_harness_counter_trace_json,
             classification=goal_harness_classification,
+            active_user_host_dir=active_user_host_dir,
+            active_user_mount_target=goal_harness_active_user_mount_target,
         )
         agent_kwargs = worker_bridge["agent_kwargs"]
         command.extend(

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -835,6 +835,8 @@ def _compact_benchmark_private_runner_launch(value: Any) -> dict[str, Any]:
         "no_upload_boundary",
         "submit_eligible",
         "env_path_present",
+        "active_user_writable_mount_requested",
+        "active_user_writable_mount_target_present",
         "auth_values_recorded",
         "raw_env_recorded",
         "raw_paths_recorded",
@@ -844,6 +846,9 @@ def _compact_benchmark_private_runner_launch(value: Any) -> dict[str, Any]:
     count = value.get("env_probe_path_coverage_count")
     if isinstance(count, int) and not isinstance(count, bool):
         compact["env_probe_path_coverage_count"] = count
+    active_user_mount_count = value.get("active_user_writable_mount_count")
+    if isinstance(active_user_mount_count, int) and not isinstance(active_user_mount_count, bool):
+        compact["active_user_writable_mount_count"] = active_user_mount_count
     coverage = value.get("env_probe_path_coverage")
     if isinstance(coverage, dict):
         compact_coverage = {

--- a/goal_harness/worker_bridge.py
+++ b/goal_harness/worker_bridge.py
@@ -10,7 +10,9 @@ WORKER_BRIDGE_INSTALL_CONTRACT_VERSION = "goal_harness_worker_bridge_install_con
 WORKER_BRIDGE_SURFACE = "goal_harness_worker_bridge_source_mount_v0"
 GOAL_HARNESS_PROJECT_ROOT_PLACEHOLDER = "<goal-harness-project-root>"
 GOAL_HARNESS_RUNTIME_ROOT_PLACEHOLDER = "<goal-harness-runtime-root>"
+GOAL_HARNESS_ACTIVE_USER_HOST_DIR_PLACEHOLDER = "<active-user-host-dir>"
 DEFAULT_WORKER_BRIDGE_TRACE_DIR = "/logs/agent"
+DEFAULT_WORKER_BRIDGE_ACTIVE_USER_MOUNT_TARGET = "/goal-harness-active-user"
 DEFAULT_WORKER_BRIDGE_COUNTER_TRACE_JSON = (
     DEFAULT_WORKER_BRIDGE_TRACE_DIR + "/goal-harness-counter-trace.jsonl"
 )
@@ -94,10 +96,12 @@ def build_worker_bridge_mounts(
     *,
     project_root: str = GOAL_HARNESS_PROJECT_ROOT_PLACEHOLDER,
     runtime_root: str = GOAL_HARNESS_RUNTIME_ROOT_PLACEHOLDER,
+    active_user_host_dir: str | None = None,
+    active_user_mount_target: str = DEFAULT_WORKER_BRIDGE_ACTIVE_USER_MOUNT_TARGET,
 ) -> list[dict[str, Any]]:
     """Build read-only source/runtime mounts for a worker-side Goal Harness CLI."""
 
-    return [
+    mounts = [
         {
             "type": "bind",
             "source": project_root,
@@ -111,6 +115,16 @@ def build_worker_bridge_mounts(
             "read_only": True,
         },
     ]
+    if active_user_host_dir:
+        mounts.append(
+            {
+                "type": "bind",
+                "source": active_user_host_dir,
+                "target": active_user_mount_target,
+                "read_only": False,
+            }
+        )
+    return mounts
 
 
 def build_worker_bridge_command_prefix(
@@ -481,6 +495,8 @@ def build_worker_bridge_install_contract(
     benchmark_run_json: str = DEFAULT_WORKER_BRIDGE_BENCHMARK_RUN_JSON,
     counter_trace_json: str = DEFAULT_WORKER_BRIDGE_COUNTER_TRACE_JSON,
     classification: str = "<classification>",
+    active_user_host_dir: str | None = None,
+    active_user_mount_target: str = DEFAULT_WORKER_BRIDGE_ACTIVE_USER_MOUNT_TARGET,
 ) -> dict[str, Any]:
     """Build a runner-agnostic worker bridge/install contract.
 
@@ -500,6 +516,12 @@ def build_worker_bridge_install_contract(
         python_bin=python_bin,
         module=module,
     )
+    active_user_feed_jsonl = DEFAULT_WORKER_BRIDGE_ACTIVE_USER_FEED_JSONL
+    active_user_observation_json = DEFAULT_WORKER_BRIDGE_ACTIVE_USER_OBSERVATION_JSON
+    if active_user_host_dir:
+        mount_target = active_user_mount_target.rstrip("/")
+        active_user_feed_jsonl = f"{mount_target}/goal-harness-active-user-interventions.jsonl"
+        active_user_observation_json = f"{mount_target}/goal-harness-active-user-observation.json"
     benchmark_run_writeback_contract = (
         build_worker_bridge_benchmark_run_writeback_contract(
             benchmark_run_json=benchmark_run_json,
@@ -513,6 +535,8 @@ def build_worker_bridge_install_contract(
             runtime_root=runtime_root,
             python_bin=python_bin,
             module=module,
+            feed_jsonl=active_user_feed_jsonl,
+            observation_json=active_user_observation_json,
         )
     )
     return {
@@ -527,7 +551,15 @@ def build_worker_bridge_install_contract(
         "mounts": build_worker_bridge_mounts(
             project_root=project_root,
             runtime_root=runtime_root,
+            active_user_host_dir=active_user_host_dir,
+            active_user_mount_target=active_user_mount_target,
         ),
+        "active_user_external_update_mount": {
+            "enabled": bool(active_user_host_dir),
+            "target": active_user_mount_target if active_user_host_dir else None,
+            "read_only": False if active_user_host_dir else None,
+            "raw_host_path_recorded": False,
+        },
         "command_prefix": command_prefix,
         "agent_kwargs": {
             "goal_harness_command_prefix": command_prefix,


### PR DESCRIPTION
## Summary
- Add an optional writable active-user feed bind mount to the worker bridge install contract.
- Let private Terminal-Bench runner launches resolve the active-user host feed directory while keeping public previews placeholder-redacted.
- Preserve compact public-safe launch summary fields so status/preflight evidence can prove the mount exists without recording raw host paths.

## Validation
- python3 -m py_compile goal_harness/worker_bridge.py goal_harness/benchmark.py goal_harness/status.py examples/worker-bridge-install-contract-smoke.py examples/terminal-bench-codex-goal-harness-active-cli-bridge-smoke.py examples/terminal-bench-active-user-assisted-treatment-preflight-smoke.py
- python3 examples/worker-bridge-install-contract-smoke.py
- python3 examples/terminal-bench-codex-goal-harness-active-cli-bridge-smoke.py
- python3 examples/terminal-bench-active-user-assisted-treatment-preflight-smoke.py
- python3 examples/terminal-bench-active-user-assisted-observation-fixture-smoke.py
- python3 examples/benchmark-run-v0-active-user-observation-ingest-smoke.py
- python3 examples/worker-bridge-active-user-feed-smoke.py
- python3 examples/worker-bridge-active-user-after-start-observation-smoke.py
- goal-harness --format json --registry /Users/bytedance/.codex/goal-harness/registry.global.json check --scan-path /Users/bytedance/goal-harness --limit 5
- git diff --check

## Excluded
- No .local, .goal-harness, runtime history, raw worker logs, credentials, or private benchmark traces were staged.
- No Terminal-Bench upload or official score claim is included.