### PR TITLE
Ensure active-user observe is runnable by workers

### DIFF
--- a/examples/terminal-bench-codex-goal-harness-custom-agent-smoke.py
+++ b/examples/terminal-bench-codex-goal-harness-custom-agent-smoke.py
@@ -217,11 +217,71 @@ def assert_prompt_and_metadata() -> None:
     assert_public_safe(prompt_only_context.metadata["goal_harness"])
 
 
+def assert_active_user_private_observe_prompt() -> None:
+    helper = helper_module()
+    module = helper.load_agent_module()
+    task = "Build the extension and make the test pass."
+    observe_command = (
+        "PYTHONPATH=/goal-harness-source python3 -m goal_harness.cli "
+        "worker-bridge active-user-observe "
+        "--feed-jsonl /goal-harness-active-user/goal-harness-active-user-interventions.jsonl "
+        "--worker-start-seq <worker-start-seq> "
+        "--observation-json /goal-harness-active-user/goal-harness-active-user-observation.json "
+        "--format json"
+    )
+    instruction = module.build_managed_terminal_bench_instruction(
+        task,
+        goal_harness_mode="codex_goal_harness",
+        goal_id="terminal-bench-active-user-fixture",
+        goal_harness_cli_bridge_enabled=True,
+        goal_harness_classification="terminal_bench_active_user_fixture_v0",
+        goal_harness_active_user_intervention_enabled=True,
+        goal_harness_active_user_feed_jsonl=(
+            "/goal-harness-active-user/goal-harness-active-user-interventions.jsonl"
+        ),
+        goal_harness_active_user_observation_json=(
+            "/goal-harness-active-user/goal-harness-active-user-observation.json"
+        ),
+        goal_harness_active_user_observe_command=observe_command,
+    )
+    assert "Active-user observe checkpoint for this case:" in instruction, instruction
+    assert "Before broad task work, run this exact command once:" in instruction, instruction
+    assert "--worker-start-seq 0" in instruction, instruction
+    assert "<worker-start-seq>" not in instruction, instruction
+    assert "<active-user-observe-command-redacted>" in instruction, instruction
+    assert "command=active_user_observe" in instruction, instruction
+    assert '"command": "active_user_observe"' in instruction, instruction
+    assert "active_user_worker_must_poll_after_start: true" in instruction, instruction
+    assert_public_safe(instruction)
+
+    counters = module.extract_goal_harness_interaction_counters_from_trace(
+        [
+            {
+                "kind": "goal_harness_cli_call",
+                "command": "active_user_observe",
+                "ok": True,
+                "goal_id": "terminal-bench-active-user-fixture",
+                "mode": "codex_goal_harness",
+                "classification": "terminal_bench_active_user_fixture_v0",
+            }
+        ],
+        prompt_policy_injected=True,
+        harness_skill_or_packet_injected=True,
+    )
+    assert counters["goal_harness_cli_calls"]["active_user_observe"] == 1, counters
+    assert counters["goal_harness_cli_calls"]["total"] == 1, counters
+    assert counters["goal_harness_state_reads"] == 1, counters
+    assert counters["goal_harness_state_writes"] == 0, counters
+    assert counters["counter_trust_level"] == "compact_trace_audited", counters
+    assert_public_safe(counters)
+
+
 def main() -> None:
     assert_doc_contract()
     assert_command_preview()
     assert_prompt_and_metadata()
-    print("terminal-bench-codex-goal-harness-custom-agent-smoke ok cli_calls=6 runtime_goal_calls=1")
+    assert_active_user_private_observe_prompt()
+    print("terminal-bench-codex-goal-harness-custom-agent-smoke ok cli_calls=6 runtime_goal_calls=1 active_user_observe=1")
 
 
 if __name__ == "__main__":

--- a/goal_harness/benchmark.py
+++ b/goal_harness/benchmark.py
@@ -132,6 +132,11 @@ TERMINAL_BENCH_GOAL_HARNESS_ACCESS_PACKET_COMMANDS = (
     "check",
     "append_benchmark_run",
 )
+TERMINAL_BENCH_GOAL_HARNESS_ACTIVE_USER_OBSERVE_COMMAND = "active_user_observe"
+TERMINAL_BENCH_GOAL_HARNESS_COUNTER_TRACE_COMMANDS = (
+    *TERMINAL_BENCH_GOAL_HARNESS_ACCESS_PACKET_COMMANDS,
+    TERMINAL_BENCH_GOAL_HARNESS_ACTIVE_USER_OBSERVE_COMMAND,
+)
 TERMINAL_BENCH_GOAL_HARNESS_CLI_BRIDGE_CALL_POLICY_VERSION = (
     "terminal_bench_goal_harness_cli_bridge_call_policy_v1"
 )
@@ -787,9 +792,16 @@ def _counter_trace_interaction_counters(
         return None
 
     observed_calls = {
-        command: 0 for command in TERMINAL_BENCH_GOAL_HARNESS_ACCESS_PACKET_COMMANDS
+        command: 0 for command in TERMINAL_BENCH_GOAL_HARNESS_COUNTER_TRACE_COMMANDS
     }
-    read_commands = {"status", "quota_should_run", "todo_list", "history", "check"}
+    read_commands = {
+        "status",
+        "quota_should_run",
+        "todo_list",
+        "history",
+        "check",
+        TERMINAL_BENCH_GOAL_HARNESS_ACTIVE_USER_OBSERVE_COMMAND,
+    }
     state_reads = 0
     state_writes = 0
     append_attempted = False
@@ -1783,7 +1795,7 @@ def build_terminal_bench_goal_harness_interaction_counters(
         **(codex_runtime_goal_tool_calls or {}),
     }
     cli_calls = {
-        command: 0 for command in TERMINAL_BENCH_GOAL_HARNESS_ACCESS_PACKET_COMMANDS
+        command: 0 for command in TERMINAL_BENCH_GOAL_HARNESS_COUNTER_TRACE_COMMANDS
     }
     cli_calls.update(goal_harness_cli_calls or {})
     return {

--- a/goal_harness/terminal_bench_agent.py
+++ b/goal_harness/terminal_bench_agent.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from pathlib import Path
 from typing import Any
 
@@ -17,9 +18,11 @@ from goal_harness.benchmark import (
     TERMINAL_BENCH_GOAL_HARNESS_ACCESS_PACKET_MODES,
     TERMINAL_BENCH_GOAL_HARNESS_ACCESS_PACKET_COMMANDS,
     TERMINAL_BENCH_GOAL_HARNESS_ACCESS_PACKET_VERSION,
+    TERMINAL_BENCH_GOAL_HARNESS_ACTIVE_USER_OBSERVE_COMMAND,
     TERMINAL_BENCH_GOAL_HARNESS_CLI_BRIDGE_CALL_POLICY_MODE,
     TERMINAL_BENCH_GOAL_HARNESS_CLI_BRIDGE_CALL_POLICY_VERSION,
     TERMINAL_BENCH_GOAL_HARNESS_CLI_BRIDGE_CONTRACT_VERSION,
+    TERMINAL_BENCH_GOAL_HARNESS_COUNTER_TRACE_COMMANDS,
     TERMINAL_BENCH_GOAL_HARNESS_CLI_BRIDGE_DEFAULT_REQUIRED_CALLS,
     TERMINAL_BENCH_GOAL_HARNESS_CLI_BRIDGE_OPTIONAL_CONTEXT_CALLS,
     TERMINAL_BENCH_GOAL_HARNESS_CLI_BRIDGE_REQUIRED_CALL_MINIMUM,
@@ -65,6 +68,71 @@ DEFAULT_GOAL_HARNESS_WORKER_REGISTRY_ARG = (
 DEFAULT_GOAL_HARNESS_WORKER_SCAN_PATH = (
     GOAL_HARNESS_PROJECT_ROOT_PLACEHOLDER + "/goal_harness/benchmark.py"
 )
+UNRESOLVED_ANGLE_PLACEHOLDER_RE = re.compile(r"<[^>\s]+>")
+
+
+def _concrete_active_user_observe_command(
+    command: str,
+    *,
+    worker_start_seq: int = 0,
+) -> str | None:
+    """Return a worker-runnable active-user observe command when it is concrete."""
+
+    text = str(command or "").strip()
+    if not text or text in {
+        "<active-user-observe-command>",
+        "<active-user-observe-command-redacted>",
+    }:
+        return None
+    text = text.replace("<worker-start-seq>", str(worker_start_seq))
+    if UNRESOLVED_ANGLE_PLACEHOLDER_RE.search(text):
+        return None
+    return text
+
+
+def build_private_active_user_observe_instruction(
+    *,
+    enabled: bool,
+    observe_command: str,
+    observation_json: str,
+    counter_trace_json: str,
+    goal_id: str,
+    mode: str,
+    classification: str,
+) -> str:
+    """Build the private worker-only active-user observe checkpoint."""
+
+    if not enabled:
+        return ""
+    concrete_command = _concrete_active_user_observe_command(
+        observe_command,
+        worker_start_seq=0,
+    )
+    if concrete_command is None:
+        return (
+            "\nActive-user observe checkpoint for this case:\n"
+            "- The active-user channel is enabled, but no runnable private observe command was provided.\n"
+            "- Do not claim active-user observation unless a concrete observe command is available and executed.\n\n"
+        )
+    trace_example = {
+        "kind": "goal_harness_cli_call",
+        "command": TERMINAL_BENCH_GOAL_HARNESS_ACTIVE_USER_OBSERVE_COMMAND,
+        "ok": True,
+        "goal_id": goal_id,
+        "mode": mode,
+        "classification": classification,
+    }
+    return (
+        "\nActive-user observe checkpoint for this case:\n"
+        "- The active-user channel is enabled. This private worker checkpoint supplies the runnable observe command; the public access packet may redact it.\n"
+        "- Before broad task work, run this exact command once:\n"
+        f"  {concrete_command}\n"
+        "- If no post-start intervention is observed, run the same observe command once more before final validation or a terminal blocker decision.\n"
+        f"- Read {observation_json} after the command. If observed_after_worker_start is true, apply only the compact latest_intervention.message and boundary fields.\n"
+        f"- Append one compact trace row to {counter_trace_json} for each observe attempt; use command={TERMINAL_BENCH_GOAL_HARNESS_ACTIVE_USER_OBSERVE_COMMAND} and public-safe fields like:\n"
+        f"  {json.dumps(trace_example, sort_keys=True)}\n"
+        "- Do not paste raw feed contents, raw paths, credentials, hidden tests, expected solutions, or transcripts into the final answer.\n\n"
+    )
 
 
 def build_managed_terminal_bench_instruction(
@@ -135,6 +203,19 @@ def build_managed_terminal_bench_instruction(
             f"{access_packet_body}\n"
             "----- END GOAL-HARNESS ACCESS PACKET -----\n\n"
         )
+    active_user_observe_instruction = build_private_active_user_observe_instruction(
+        enabled=(
+            access_packet_enabled
+            and goal_harness_cli_bridge_enabled
+            and goal_harness_active_user_intervention_enabled
+        ),
+        observe_command=goal_harness_active_user_observe_command,
+        observation_json=goal_harness_active_user_observation_json,
+        counter_trace_json=goal_harness_counter_trace_json,
+        goal_id=goal_id,
+        mode=goal_harness_mode,
+        classification=goal_harness_classification,
+    )
 
     return (
         "You are running one Terminal-Bench task under Goal Harness managed Codex mode.\n"
@@ -149,6 +230,7 @@ def build_managed_terminal_bench_instruction(
         "- If a Goal Harness CLI bridge packet is present, treat command lines as templates: replace placeholders before execution, quote paths as single argv values, and do not run commands containing unresolved angle-bracket placeholders.\n"
         "- Write the compact Goal Harness case result only after final validation and cleanup, or after a terminal blocker decision; the runner still performs guaranteed final archive writeback.\n"
         "- Treat this as a model plus harness pair; do not present it as a native Codex baseline.\n\n"
+        f"{active_user_observe_instruction}"
         f"{access_packet}"
         "Benchmark task instruction follows.\n\n"
         "----- TERMINAL-BENCH TASK -----\n"
@@ -197,7 +279,7 @@ def extract_goal_harness_interaction_counters_from_trace(
         "update_goal": 0,
     }
     goal_harness_cli_calls = {
-        command: 0 for command in TERMINAL_BENCH_GOAL_HARNESS_ACCESS_PACKET_COMMANDS
+        command: 0 for command in TERMINAL_BENCH_GOAL_HARNESS_COUNTER_TRACE_COMMANDS
     }
     state_reads = 0
     state_writes = 0
@@ -227,6 +309,8 @@ def extract_goal_harness_interaction_counters_from_trace(
             command = _compact_trace_event_text(event.get("command") or event.get("call"))
             if command in goal_harness_cli_calls:
                 goal_harness_cli_calls[command] += 1
+            if command == TERMINAL_BENCH_GOAL_HARNESS_ACTIVE_USER_OBSERVE_COMMAND:
+                state_reads += 1
             if command == "append_benchmark_run":
                 append_attempted = True
                 append_schema_rejected = append_schema_rejected or (


### PR DESCRIPTION
## Summary
- Add a private worker prompt checkpoint that supplies a runnable active-user observe command while keeping the public access packet redacted.
- Count active_user_observe rows from compact worker traces as Goal Harness CLI calls/state reads.
- Add smoke coverage for the runnable prompt command and active_user_observe trace extraction.

## Validation
- python3 -m py_compile goal_harness/benchmark.py goal_harness/terminal_bench_agent.py
- python3 examples/terminal-bench-codex-goal-harness-custom-agent-smoke.py
- python3 examples/terminal-bench-managed-codex-custom-agent-smoke.py
- python3 examples/terminal-bench-active-user-assisted-observation-fixture-smoke.py
- python3 examples/terminal-bench-goal-harness-access-packet-smoke.py
- python3 examples/terminal-bench-goal-harness-cli-bridge-contract-smoke.py
- python3 examples/worker-bridge-active-user-after-start-observation-smoke.py
- python3 examples/worker-bridge-active-user-feed-smoke.py
- python3 examples/terminal-bench-active-user-assisted-treatment-preflight-smoke.py
- python3 examples/terminal-bench-codex-goal-harness-active-cli-bridge-smoke.py
- python3 examples/benchmark-run-v0-active-user-observation-ingest-smoke.py
- python3 examples/benchmark-run-v0-append-cli-smoke.py
- python3 examples/benchmark-run-v0-harbor-ingest-smoke.py
- goal-harness check --scan-path goal_harness/terminal_bench_agent.py --scan-path goal_harness/benchmark.py --scan-path examples/terminal-bench-codex-goal-harness-custom-agent-smoke.py