### PR TITLE
Add Codex CLI active-user simulator contract

### DIFF
--- a/examples/active-user-codex-simulator-contract-smoke.py
+++ b/examples/active-user-codex-simulator-contract-smoke.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Smoke-test the Codex CLI active-user simulator contract."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+FORBIDDEN_TEXT = [
+    "/" + "Users/",
+    ".local/" + "benchmark-runs",
+    "OPENAI" + "_API_KEY=",
+    "ARK" + "_API_KEY=",
+    "CODEX" + "_AUTH_JSON_PATH=",
+    "auth" + ".json" + "\":",
+    "raw" + "_thread",
+    "session" + "_history",
+    "sk-" + "example",
+    "tok" + "en=",
+    "-----BEGIN",
+]
+
+
+def assert_public_safe(payload: object) -> None:
+    text = json.dumps(payload, sort_keys=True) if not isinstance(payload, str) else payload
+    leaked = [marker for marker in FORBIDDEN_TEXT if marker in text]
+    assert not leaked, leaked
+    assert len(text) < 24000, len(text)
+
+
+def run_cli_json(args: list[str], *, check: bool = True) -> dict[str, Any]:
+    result = subprocess.run(
+        [sys.executable, "-m", "goal_harness.cli", *args],
+        cwd=REPO_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=check,
+    )
+    payload = json.loads(result.stdout)
+    assert isinstance(payload, dict), payload
+    return payload
+
+
+def simulator_output(**overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "schema_version": "goal_harness_active_user_simulator_output_v0",
+        "simulator_kind": "codex_cli",
+        "trigger": "public_progress_or_stall_signal",
+        "message": (
+            "Reproduce the public failure first, then verify the compiled "
+            "extensions and dependency versions before broad edits."
+        ),
+        "visible_evidence_basis": [
+            "public task prompt visible to worker",
+            "compact Goal Harness status and run metadata",
+        ],
+        "no_oracle_audit": {
+            "hidden_tests_visible": False,
+            "expected_solution_visible": False,
+            "benchmark_answer_key_visible": False,
+            "credential_values_visible": False,
+            "private_material_visible": False,
+            "solution_patch_visible": False,
+        },
+        "controller_authored_message": False,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def assert_contract(payload: dict[str, Any]) -> None:
+    assert payload["ok"] is True, payload
+    assert (
+        payload["schema_version"]
+        == "goal_harness_active_user_codex_cli_simulator_contract_v0"
+    ), payload
+    assert payload["simulator_kind"] == "codex_cli", payload
+    assert payload["manual_controller_feed_allowed"] is False, payload
+    assert payload["codex_cli"]["codex_bin"] == "/opt/homebrew/bin/codex", payload
+    assert "codex exec" in payload["codex_cli"]["exec_command"], payload
+    assert "active-user-simulator-output" in payload["append_validated_output_command"], payload
+    boundary = payload["claim_boundary"]
+    assert boundary["direct_codex_chat_injection"] is False, payload
+    assert boundary["controller_authored_feed_allowed"] is False, payload
+    schema = payload["simulator_output_contract"]["json_schema"]
+    assert schema["properties"]["simulator_kind"]["const"] == "codex_cli", schema
+    assert_public_safe(payload)
+
+
+def assert_intervention(payload: dict[str, Any]) -> None:
+    assert payload["ok"] is True, payload
+    assert payload["schema_version"] == "goal_harness_active_user_intervention_v0", payload
+    assert payload["channel"] == "codex_cli_user_simulator", payload
+    assert payload["simulator_kind"] == "codex_cli", payload
+    assert payload["formal_treatment_eligible"] is True, payload
+    assert payload["manual_controller_feed"] is False, payload
+    assert payload["controller_authored_message"] is False, payload
+    assert payload["oracle_free"] is True, payload
+    assert not any(payload["no_oracle_audit"].values()), payload
+    assert_public_safe(payload)
+
+
+def main() -> int:
+    from goal_harness.worker_bridge import (
+        build_active_user_codex_simulator_contract,
+        build_active_user_intervention_from_simulator_output,
+        observe_active_user_intervention_feed,
+    )
+
+    assert_contract(build_active_user_codex_simulator_contract())
+    assert_contract(
+        run_cli_json(
+            [
+                "worker-bridge",
+                "active-user-codex-simulator-contract",
+                "--format",
+                "json",
+            ]
+        )
+    )
+
+    intervention = build_active_user_intervention_from_simulator_output(
+        seq=3,
+        simulator_output=simulator_output(),
+    )
+    assert_intervention(intervention)
+
+    with tempfile.TemporaryDirectory(prefix="active-user-codex-simulator-") as tmp:
+        root = Path(tmp)
+        output_path = root / "simulator-output.json"
+        feed_path = root / "feed.jsonl"
+        output_path.write_text(json.dumps(simulator_output()), encoding="utf-8")
+        cli_intervention = run_cli_json(
+            [
+                "worker-bridge",
+                "active-user-simulator-output",
+                "--seq",
+                "4",
+                "--simulator-output-json",
+                str(output_path),
+                "--format",
+                "json",
+            ]
+        )
+        assert_intervention(cli_intervention)
+
+        jsonl = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "goal_harness.cli",
+                "worker-bridge",
+                "active-user-simulator-output",
+                "--seq",
+                "5",
+                "--simulator-output-json",
+                str(output_path),
+                "--jsonl",
+            ],
+            cwd=REPO_ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        ).stdout.strip()
+        feed_path.write_text(jsonl + "\n", encoding="utf-8")
+        observed = observe_active_user_intervention_feed(feed_path, worker_start_seq=4)
+        latest = observed["latest_intervention"]
+        assert latest["simulator_kind"] == "codex_cli", observed
+        assert latest["formal_treatment_eligible"] is True, observed
+        assert latest["manual_controller_feed"] is False, observed
+        assert_public_safe(observed)
+
+        rejected_controller = simulator_output(controller_authored_message=True)
+        output_path.write_text(json.dumps(rejected_controller), encoding="utf-8")
+        rejected = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "goal_harness.cli",
+                "worker-bridge",
+                "active-user-simulator-output",
+                "--seq",
+                "6",
+                "--simulator-output-json",
+                str(output_path),
+                "--format",
+                "json",
+            ],
+            cwd=REPO_ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        assert rejected.returncode == 1, rejected.stdout
+        rejected_payload = json.loads(rejected.stdout)
+        assert "controller-authored" in rejected_payload["error"], rejected_payload
+
+        rejected_oracle = simulator_output()
+        rejected_oracle["no_oracle_audit"]["hidden_tests_visible"] = True
+        output_path.write_text(json.dumps(rejected_oracle), encoding="utf-8")
+        rejected = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "goal_harness.cli",
+                "worker-bridge",
+                "active-user-simulator-output",
+                "--seq",
+                "7",
+                "--simulator-output-json",
+                str(output_path),
+                "--format",
+                "json",
+            ],
+            cwd=REPO_ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        assert rejected.returncode == 1, rejected.stdout
+        rejected_payload = json.loads(rejected.stdout)
+        assert "no-oracle audit" in rejected_payload["error"], rejected_payload
+
+        rejected_extra = simulator_output(secret_hint="should be rejected")
+        output_path.write_text(json.dumps(rejected_extra), encoding="utf-8")
+        rejected = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "goal_harness.cli",
+                "worker-bridge",
+                "active-user-simulator-output",
+                "--seq",
+                "8",
+                "--simulator-output-json",
+                str(output_path),
+                "--format",
+                "json",
+            ],
+            cwd=REPO_ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        assert rejected.returncode == 1, rejected.stdout
+        rejected_payload = json.loads(rejected.stdout)
+        assert "unsupported fields" in rejected_payload["error"], rejected_payload
+
+    print("active-user-codex-simulator-contract-smoke ok formal_treatment=true")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -129,10 +129,17 @@ from .worker_bridge import (
     DEFAULT_WORKER_BRIDGE_MODULE,
     DEFAULT_WORKER_BRIDGE_PYTHON_BIN,
     DEFAULT_WORKER_BRIDGE_WALL_TIME_LIMIT_SECONDS,
+    DEFAULT_ACTIVE_USER_CODEX_BIN,
+    DEFAULT_ACTIVE_USER_SIMULATOR_CONTEXT_DIR,
+    DEFAULT_ACTIVE_USER_SIMULATOR_OUTPUT_JSON,
+    DEFAULT_ACTIVE_USER_SIMULATOR_OUTPUT_SCHEMA_JSON,
+    DEFAULT_ACTIVE_USER_SIMULATOR_PROMPT_JSON,
     GOAL_HARNESS_PROJECT_ROOT_PLACEHOLDER,
     GOAL_HARNESS_RUNTIME_ROOT_PLACEHOLDER,
+    build_active_user_codex_simulator_contract,
     build_active_user_intervention,
     build_active_user_intervention_channel_contract,
+    build_active_user_intervention_from_simulator_output,
     build_worker_bridge_benchmark_run,
     build_worker_bridge_install_contract,
     build_worker_bridge_outcome,
@@ -672,6 +679,56 @@ def main(argv: list[str] | None = None) -> int:
         default=3,
         help="Maximum proactive simulator interventions per task.",
     )
+    active_user_codex_simulator_contract_parser = worker_bridge_sub.add_parser(
+        "active-user-codex-simulator-contract",
+        help="Render the formal Codex CLI active-user simulator launch contract.",
+    )
+    add_subcommand_format(active_user_codex_simulator_contract_parser)
+    active_user_codex_simulator_contract_parser.add_argument(
+        "--project-root",
+        default=GOAL_HARNESS_PROJECT_ROOT_PLACEHOLDER,
+        help="Goal Harness project root visible to the simulator launcher.",
+    )
+    active_user_codex_simulator_contract_parser.add_argument(
+        "--python-bin",
+        default=DEFAULT_WORKER_BRIDGE_PYTHON_BIN,
+        help="Python executable used to append the validated simulator output.",
+    )
+    active_user_codex_simulator_contract_parser.add_argument(
+        "--module",
+        default=DEFAULT_WORKER_BRIDGE_MODULE,
+        help="Goal Harness CLI module import path.",
+    )
+    active_user_codex_simulator_contract_parser.add_argument(
+        "--codex-bin",
+        default=DEFAULT_ACTIVE_USER_CODEX_BIN,
+        help="Codex CLI executable used for the user simulator.",
+    )
+    active_user_codex_simulator_contract_parser.add_argument(
+        "--context-dir",
+        default=DEFAULT_ACTIVE_USER_SIMULATOR_CONTEXT_DIR,
+        help="Public context directory made readable to the Codex CLI simulator.",
+    )
+    active_user_codex_simulator_contract_parser.add_argument(
+        "--prompt-json",
+        default=DEFAULT_ACTIVE_USER_SIMULATOR_PROMPT_JSON,
+        help="Prompt/context JSON file passed to Codex CLI on stdin.",
+    )
+    active_user_codex_simulator_contract_parser.add_argument(
+        "--simulator-output-json",
+        default=DEFAULT_ACTIVE_USER_SIMULATOR_OUTPUT_JSON,
+        help="Path where Codex CLI writes the simulator JSON output.",
+    )
+    active_user_codex_simulator_contract_parser.add_argument(
+        "--simulator-output-schema-json",
+        default=DEFAULT_ACTIVE_USER_SIMULATOR_OUTPUT_SCHEMA_JSON,
+        help="JSON Schema file constraining the Codex CLI simulator response.",
+    )
+    active_user_codex_simulator_contract_parser.add_argument(
+        "--feed-jsonl",
+        default=DEFAULT_WORKER_BRIDGE_ACTIVE_USER_FEED_JSONL,
+        help="Worker-visible active-user intervention feed JSONL path.",
+    )
     active_user_intervention_parser = worker_bridge_sub.add_parser(
         "active-user-intervention",
         help="Render one public-safe active-user simulator intervention event.",
@@ -695,6 +752,27 @@ def main(argv: list[str] | None = None) -> int:
         help="Mark this intervention as created before the worker start marker.",
     )
     active_user_intervention_parser.add_argument(
+        "--jsonl",
+        action="store_true",
+        help="Print compact single-line JSON for appending to an intervention feed.",
+    )
+    active_user_simulator_output_parser = worker_bridge_sub.add_parser(
+        "active-user-simulator-output",
+        help="Validate a Codex CLI simulator JSON output and render feed JSON.",
+    )
+    add_subcommand_format(active_user_simulator_output_parser)
+    active_user_simulator_output_parser.add_argument("--seq", type=int, required=True)
+    active_user_simulator_output_parser.add_argument(
+        "--simulator-output-json",
+        required=True,
+        help="Path to Codex CLI simulator JSON output, or '-' for stdin.",
+    )
+    active_user_simulator_output_parser.add_argument(
+        "--before-worker-start",
+        action="store_true",
+        help="Mark the resulting intervention as created before the worker start marker.",
+    )
+    active_user_simulator_output_parser.add_argument(
         "--jsonl",
         action="store_true",
         help="Print compact single-line JSON for appending to an intervention feed.",
@@ -1546,7 +1624,9 @@ def main(argv: list[str] | None = None) -> int:
             "outcome",
             "benchmark-run",
             "active-user-contract",
+            "active-user-codex-simulator-contract",
             "active-user-intervention",
+            "active-user-simulator-output",
             "active-user-observe",
         ):
             payload = {
@@ -1555,7 +1635,9 @@ def main(argv: list[str] | None = None) -> int:
                 "error": (
                     "worker-bridge requires a subcommand; use `contract`, "
                     "`outcome`, `benchmark-run`, `active-user-contract`, "
-                    "`active-user-intervention`, or `active-user-observe`."
+                    "`active-user-codex-simulator-contract`, "
+                    "`active-user-intervention`, `active-user-simulator-output`, "
+                    "or `active-user-observe`."
                 ),
             }
             print_payload(payload, args.format, render_worker_bridge_install_contract_markdown)
@@ -1623,12 +1705,41 @@ def main(argv: list[str] | None = None) -> int:
                     min_interval_seconds=args.min_interval_seconds,
                     max_interventions_per_task=args.max_interventions_per_task,
                 )
+            elif args.worker_bridge_command == "active-user-codex-simulator-contract":
+                payload = build_active_user_codex_simulator_contract(
+                    project_root=args.project_root,
+                    python_bin=args.python_bin,
+                    module=args.module,
+                    codex_bin=args.codex_bin,
+                    context_dir=args.context_dir,
+                    prompt_json=args.prompt_json,
+                    simulator_output_json=args.simulator_output_json,
+                    simulator_output_schema_json=args.simulator_output_schema_json,
+                    feed_jsonl=args.feed_jsonl,
+                )
             elif args.worker_bridge_command == "active-user-intervention":
                 payload = build_active_user_intervention(
                     seq=args.seq,
                     message=args.message,
                     trigger=args.trigger,
                     channel=args.channel,
+                    created_after_worker_start=not bool(args.before_worker_start),
+                )
+                if args.jsonl:
+                    print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+                    return 0
+            elif args.worker_bridge_command == "active-user-simulator-output":
+                if args.simulator_output_json == "-":
+                    simulator_output = json.loads(sys.stdin.read())
+                else:
+                    simulator_output = json.loads(
+                        Path(args.simulator_output_json).expanduser().read_text(
+                            encoding="utf-8"
+                        )
+                    )
+                payload = build_active_user_intervention_from_simulator_output(
+                    seq=args.seq,
+                    simulator_output=simulator_output,
                     created_after_worker_start=not bool(args.before_worker_start),
                 )
                 if args.jsonl:

--- a/goal_harness/worker_bridge.py
+++ b/goal_harness/worker_bridge.py
@@ -25,6 +25,13 @@ DEFAULT_WORKER_BRIDGE_ACTIVE_USER_FEED_JSONL = (
 DEFAULT_WORKER_BRIDGE_ACTIVE_USER_OBSERVATION_JSON = (
     DEFAULT_WORKER_BRIDGE_TRACE_DIR + "/goal-harness-active-user-observation.json"
 )
+DEFAULT_ACTIVE_USER_CODEX_BIN = "/opt/homebrew/bin/codex"
+DEFAULT_ACTIVE_USER_SIMULATOR_CONTEXT_DIR = "<active-user-public-context-dir>"
+DEFAULT_ACTIVE_USER_SIMULATOR_PROMPT_JSON = "<active-user-simulator-prompt.json>"
+DEFAULT_ACTIVE_USER_SIMULATOR_OUTPUT_JSON = "<active-user-simulator-output.json>"
+DEFAULT_ACTIVE_USER_SIMULATOR_OUTPUT_SCHEMA_JSON = (
+    "<active-user-simulator-output-schema.json>"
+)
 DEFAULT_WORKER_BRIDGE_PYTHON_BIN = "python3"
 DEFAULT_WORKER_BRIDGE_MODULE = "goal_harness.cli"
 WORKER_BRIDGE_PYTHON_RUNTIME_POLICY = "ensure_python3_before_worker_cli_bridge"
@@ -41,6 +48,25 @@ ACTIVE_USER_INTERVENTION_OBSERVATION_VERSION = (
 )
 ACTIVE_USER_INTERVENTION_CHANNEL_SURFACE = (
     "goal_harness_active_user_external_update_loop_v0"
+)
+ACTIVE_USER_CODEX_SIMULATOR_CONTRACT_VERSION = (
+    "goal_harness_active_user_codex_cli_simulator_contract_v0"
+)
+ACTIVE_USER_SIMULATOR_OUTPUT_VERSION = (
+    "goal_harness_active_user_simulator_output_v0"
+)
+ACTIVE_USER_SIMULATOR_ALLOWED_EVIDENCE_BASIS = (
+    "public task prompt visible to worker",
+    "worker public artifacts",
+    "compact Goal Harness status and run metadata",
+)
+ACTIVE_USER_SIMULATOR_NO_ORACLE_AUDIT_KEYS = (
+    "hidden_tests_visible",
+    "expected_solution_visible",
+    "benchmark_answer_key_visible",
+    "credential_values_visible",
+    "private_material_visible",
+    "solution_patch_visible",
 )
 DEFAULT_WORKER_BRIDGE_CLI_CALL_MINIMUM = 1
 DEFAULT_WORKER_BRIDGE_WALL_TIME_LIMIT_SECONDS = 900.0
@@ -334,6 +360,242 @@ def build_active_user_intervention_channel_contract(
     }
 
 
+def active_user_simulator_output_json_schema() -> dict[str, Any]:
+    """Return the strict JSON shape expected from a Codex CLI user simulator."""
+
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "required": [
+            "schema_version",
+            "simulator_kind",
+            "trigger",
+            "message",
+            "visible_evidence_basis",
+            "no_oracle_audit",
+            "controller_authored_message",
+        ],
+        "properties": {
+            "schema_version": {
+                "type": "string",
+                "const": ACTIVE_USER_SIMULATOR_OUTPUT_VERSION,
+            },
+            "simulator_kind": {"type": "string", "const": "codex_cli"},
+            "trigger": {"type": "string", "minLength": 1, "maxLength": 120},
+            "message": {"type": "string", "minLength": 1, "maxLength": 500},
+            "visible_evidence_basis": {
+                "type": "array",
+                "minItems": 1,
+                "uniqueItems": True,
+                "items": {
+                    "type": "string",
+                    "enum": list(ACTIVE_USER_SIMULATOR_ALLOWED_EVIDENCE_BASIS),
+                },
+            },
+            "no_oracle_audit": {
+                "type": "object",
+                "additionalProperties": False,
+                "required": list(ACTIVE_USER_SIMULATOR_NO_ORACLE_AUDIT_KEYS),
+                "properties": {
+                    key: {"type": "boolean", "const": False}
+                    for key in ACTIVE_USER_SIMULATOR_NO_ORACLE_AUDIT_KEYS
+                },
+            },
+            "controller_authored_message": {"type": "boolean", "const": False},
+        },
+    }
+
+
+def build_active_user_codex_simulator_contract(
+    *,
+    project_root: str = GOAL_HARNESS_PROJECT_ROOT_PLACEHOLDER,
+    python_bin: str = DEFAULT_WORKER_BRIDGE_PYTHON_BIN,
+    module: str = DEFAULT_WORKER_BRIDGE_MODULE,
+    codex_bin: str = DEFAULT_ACTIVE_USER_CODEX_BIN,
+    context_dir: str = DEFAULT_ACTIVE_USER_SIMULATOR_CONTEXT_DIR,
+    prompt_json: str = DEFAULT_ACTIVE_USER_SIMULATOR_PROMPT_JSON,
+    simulator_output_json: str = DEFAULT_ACTIVE_USER_SIMULATOR_OUTPUT_JSON,
+    simulator_output_schema_json: str = DEFAULT_ACTIVE_USER_SIMULATOR_OUTPUT_SCHEMA_JSON,
+    feed_jsonl: str = DEFAULT_WORKER_BRIDGE_ACTIVE_USER_FEED_JSONL,
+) -> dict[str, Any]:
+    """Build the model-backed active-user simulator launch contract.
+
+    The formal treatment path uses this contract instead of controller-written
+    feed messages: a separate Codex CLI run reads only public context, writes a
+    bounded JSON object, and Goal Harness validates it before appending to the
+    worker-visible feed.
+    """
+
+    safe_codex_bin = shlex.quote(codex_bin)
+    safe_context_dir = shlex.quote(context_dir)
+    safe_schema_json = shlex.quote(simulator_output_schema_json)
+    safe_output_json = shlex.quote(simulator_output_json)
+    safe_prompt_json = shlex.quote(prompt_json)
+    command_prefix = build_worker_bridge_command_prefix(
+        project_root=project_root,
+        python_bin=python_bin,
+        module=module,
+    )
+    codex_exec_command = (
+        f"{safe_codex_bin} exec "
+        f"--cd {safe_context_dir} "
+        "--sandbox read-only "
+        "--ask-for-approval never "
+        "--ephemeral "
+        f"--output-schema {safe_schema_json} "
+        f"--output-last-message {safe_output_json} "
+        f"- < {safe_prompt_json}"
+    )
+    append_validated_output_command = (
+        f"{command_prefix} worker-bridge active-user-simulator-output "
+        "--seq <next-seq> "
+        f"--simulator-output-json {safe_output_json} "
+        "--jsonl "
+        f">> {shlex.quote(feed_jsonl)}"
+    )
+    return {
+        "ok": True,
+        "schema_version": ACTIVE_USER_CODEX_SIMULATOR_CONTRACT_VERSION,
+        "bridge_surface": WORKER_BRIDGE_SURFACE,
+        "channel_surface": ACTIVE_USER_INTERVENTION_CHANNEL_SURFACE,
+        "simulator_kind": "codex_cli",
+        "formal_treatment_requires_model_backed_simulator": True,
+        "manual_controller_feed_allowed": False,
+        "codex_cli": {
+            "codex_bin": codex_bin,
+            "exec_command": codex_exec_command,
+            "sandbox": "read-only",
+            "approval_policy": "never",
+            "ephemeral": True,
+        },
+        "simulator_input_contract": {
+            "prompt_json": prompt_json,
+            "context_dir": context_dir,
+            "allowed_context": list(ACTIVE_USER_SIMULATOR_ALLOWED_EVIDENCE_BASIS),
+            "must_not_include": [
+                "hidden tests",
+                "expected solutions",
+                "benchmark answer keys",
+                "credentials",
+                "private project material",
+                "controller-authored intervention text",
+            ],
+        },
+        "simulator_output_contract": {
+            "schema_version": ACTIVE_USER_SIMULATOR_OUTPUT_VERSION,
+            "output_json": simulator_output_json,
+            "output_schema_json": simulator_output_schema_json,
+            "json_schema": active_user_simulator_output_json_schema(),
+        },
+        "append_validated_output_command": append_validated_output_command,
+        "claim_boundary": {
+            "official_score_claim_allowed": False,
+            "leaderboard_claim_allowed": False,
+            "assisted_collaboration_claim_allowed": True,
+            "direct_codex_chat_injection": False,
+            "worker_pull_required": True,
+            "controller_authored_feed_allowed": False,
+        },
+        "public_boundary": {
+            "raw_paths_recorded": False,
+            "raw_transcript_recorded": False,
+            "credential_values_recorded": False,
+            "no_upload": True,
+        },
+    }
+
+
+def build_active_user_intervention_from_simulator_output(
+    *,
+    seq: int,
+    simulator_output: dict[str, Any],
+    created_after_worker_start: bool = True,
+) -> dict[str, Any]:
+    """Validate a Codex CLI simulator output and convert it to feed JSON."""
+
+    if not isinstance(simulator_output, dict):
+        raise ValueError("simulator_output must be a JSON object")
+    allowed_top_level_keys = {
+        "schema_version",
+        "simulator_kind",
+        "trigger",
+        "message",
+        "visible_evidence_basis",
+        "no_oracle_audit",
+        "controller_authored_message",
+    }
+    extra_top_level_keys = [
+        key for key in simulator_output if key not in allowed_top_level_keys
+    ]
+    if extra_top_level_keys:
+        raise ValueError("simulator_output contains unsupported fields")
+    if simulator_output.get("schema_version") != ACTIVE_USER_SIMULATOR_OUTPUT_VERSION:
+        raise ValueError(
+            "simulator_output must have "
+            f"schema_version={ACTIVE_USER_SIMULATOR_OUTPUT_VERSION}"
+        )
+    if simulator_output.get("simulator_kind") != "codex_cli":
+        raise ValueError("simulator_output must have simulator_kind=codex_cli")
+    if simulator_output.get("controller_authored_message") is not False:
+        raise ValueError("simulator_output must not be controller-authored")
+
+    evidence_basis = simulator_output.get("visible_evidence_basis")
+    if not isinstance(evidence_basis, list) or not evidence_basis:
+        raise ValueError("visible_evidence_basis must be a non-empty list")
+    evidence_basis_text = [
+        _coerce_public_safe_worker_text(str(item), field="visible_evidence_basis", limit=120)
+        for item in evidence_basis
+    ]
+    invalid_basis = [
+        item
+        for item in evidence_basis_text
+        if item not in ACTIVE_USER_SIMULATOR_ALLOWED_EVIDENCE_BASIS
+    ]
+    if invalid_basis:
+        raise ValueError("visible_evidence_basis contains non-public or unsupported evidence")
+
+    audit = simulator_output.get("no_oracle_audit")
+    if not isinstance(audit, dict):
+        raise ValueError("no_oracle_audit must be an object")
+    extra_audit_keys = [
+        key for key in audit if key not in ACTIVE_USER_SIMULATOR_NO_ORACLE_AUDIT_KEYS
+    ]
+    if extra_audit_keys:
+        raise ValueError("no_oracle_audit contains unsupported fields")
+    missing_audit_keys = [
+        key for key in ACTIVE_USER_SIMULATOR_NO_ORACLE_AUDIT_KEYS if key not in audit
+    ]
+    if missing_audit_keys:
+        raise ValueError("no_oracle_audit is missing required keys")
+    leaked_audit_keys = [
+        key for key in ACTIVE_USER_SIMULATOR_NO_ORACLE_AUDIT_KEYS if audit.get(key) is not False
+    ]
+    if leaked_audit_keys:
+        raise ValueError("simulator_output failed no-oracle audit")
+
+    intervention = build_active_user_intervention(
+        seq=seq,
+        message=str(simulator_output.get("message") or ""),
+        trigger=str(simulator_output.get("trigger") or "codex_cli_simulator_public_guidance"),
+        channel="codex_cli_user_simulator",
+        created_after_worker_start=created_after_worker_start,
+    )
+    intervention.update(
+        {
+            "simulator_kind": "codex_cli",
+            "simulator_output_schema_version": ACTIVE_USER_SIMULATOR_OUTPUT_VERSION,
+            "controller_authored_message": False,
+            "formal_treatment_eligible": True,
+            "manual_controller_feed": False,
+            "visible_evidence_basis": evidence_basis_text,
+            "no_oracle_audit": {
+                key: False for key in ACTIVE_USER_SIMULATOR_NO_ORACLE_AUDIT_KEYS
+            },
+        }
+    )
+    return intervention
+
+
 def build_active_user_intervention(
     *,
     seq: int,
@@ -430,6 +692,10 @@ def observe_active_user_intervention_feed(
             "expected_solution_visible": latest.get("expected_solution_visible") is True,
             "credential_values_visible": latest.get("credential_values_visible") is True,
             "private_material_visible": latest.get("private_material_visible") is True,
+            "simulator_kind": latest.get("simulator_kind"),
+            "formal_treatment_eligible": latest.get("formal_treatment_eligible") is True,
+            "manual_controller_feed": latest.get("manual_controller_feed") is True,
+            "controller_authored_message": latest.get("controller_authored_message") is True,
         }
     return {
         "ok": True,
@@ -967,6 +1233,23 @@ def write_worker_bridge_benchmark_run_file(
 
 
 def render_worker_bridge_install_contract_markdown(payload: dict[str, Any]) -> str:
+    if payload.get("schema_version") == ACTIVE_USER_CODEX_SIMULATOR_CONTRACT_VERSION:
+        cli = payload.get("codex_cli") or {}
+        boundary = payload.get("claim_boundary") or {}
+        lines = [
+            "# Goal Harness Active User Codex Simulator Contract",
+            "",
+            f"- ok: `{payload.get('ok')}`",
+            f"- schema_version: `{payload.get('schema_version')}`",
+            f"- simulator_kind: `{payload.get('simulator_kind')}`",
+            f"- manual_controller_feed_allowed: `{payload.get('manual_controller_feed_allowed')}`",
+            f"- codex_bin: `{cli.get('codex_bin')}`",
+            f"- official_score_claim_allowed: `{boundary.get('official_score_claim_allowed')}`",
+            f"- direct_codex_chat_injection: `{boundary.get('direct_codex_chat_injection')}`",
+            f"- controller_authored_feed_allowed: `{boundary.get('controller_authored_feed_allowed')}`",
+        ]
+        return "\n".join(lines) + "\n"
+
     if payload.get("schema_version") == ACTIVE_USER_INTERVENTION_CHANNEL_CONTRACT_VERSION:
         budget = payload.get("frequency_budget") or {}
         boundary = payload.get("claim_boundary") or {}
@@ -996,6 +1279,8 @@ def render_worker_bridge_install_contract_markdown(payload: dict[str, Any]) -> s
             f"- trigger: `{payload.get('trigger')}`",
             f"- created_after_worker_start: `{payload.get('created_after_worker_start')}`",
             f"- oracle_free: `{payload.get('oracle_free')}`",
+            f"- simulator_kind: `{payload.get('simulator_kind')}`",
+            f"- formal_treatment_eligible: `{payload.get('formal_treatment_eligible')}`",
         ]
         return "\n".join(lines) + "\n"
 


### PR DESCRIPTION
## Summary
- add a formal Codex CLI active-user simulator launch contract for treatment runs
- add simulator-output validation that rejects controller-authored, extra-field, or oracle-contaminated messages before feed append
- preserve worker observation markers for formal treatment eligibility and add a focused smoke

## Validation
- python3 examples/active-user-codex-simulator-contract-smoke.py
- python3 examples/worker-bridge-active-user-feed-smoke.py
- python3 -m compileall -q goal_harness examples/active-user-codex-simulator-contract-smoke.py
- git diff --check

## Notes
- No private benchmark job artifacts, runtime state, credentials, or raw traces are committed.
- The paired build-cython-ext pilot was written back separately as baseline/manual-pilot evidence; it should not be used as an uplift claim because the baseline also solved the case with lower cost and no timeout.