### PR TITLE
Update active-user preflight for Codex simulator

### DIFF
--- a/examples/terminal-bench-active-user-assisted-treatment-preflight-smoke.py
+++ b/examples/terminal-bench-active-user-assisted-treatment-preflight-smoke.py
@@ -32,6 +32,7 @@ WORKER_MODE = "codex_goal_harness_cli"
 CLASSIFICATION = "terminal_bench_active_user_assisted_treatment_preflight_v0"
 FIRST_BLOCKER = "missing_real_assisted_worker_observation"
 LAUNCHER_PLAN_SCHEMA = "terminal_bench_active_user_private_launcher_plan_v0"
+SIMULATOR_SETTING = "codex_cli_user_simulator"
 
 FORBIDDEN_TEXT = [
     "/" + "Users/",
@@ -194,7 +195,7 @@ def assert_preflight_guard(guard: dict[str, Any]) -> None:
     assert guard["first_blocker"] == FIRST_BLOCKER, guard
     assert guard["active_cli_bridge_enabled"] is True, guard
     assert guard["active_user_assisted_treatment"] is True, guard
-    assert guard["simulator_setting"] == "deterministic_scripted_user", guard
+    assert guard["simulator_setting"] == SIMULATOR_SETTING, guard
     assert guard["simulator_to_worker_injection_channel_available"] is True, guard
     assert guard["interactive_user_message_injection_checked"] is True, guard
     assert guard["initial_prompt_only_is_not_active_intervention"] is True, guard
@@ -258,7 +259,7 @@ def assert_active_user_preflight(preflight: dict[str, Any], *, compact: bool = F
     assert preflight["pilot_schema_version"] == "active_user_assisted_pilot_v0", preflight
     assert preflight["active_injection_schema_version"] == "active_user_simulator_injection_v0", preflight
     assert preflight["operator_simulator_run_schema_version"] == "operator_simulator_run_v0", preflight
-    assert preflight["simulator_setting"] == "deterministic_scripted_user", preflight
+    assert preflight["simulator_setting"] == SIMULATOR_SETTING, preflight
     assert preflight["proactive_intervention_allowed"] is True, preflight
     assert preflight["directive_feedback_allowed"] is True, preflight
     assert preflight["artificial_mildness_required"] is False, preflight
@@ -289,15 +290,37 @@ def assert_private_launcher_plan(plan: dict[str, Any]) -> None:
     assert plan["worker_start_marker"] == "worker_start_seq", plan
     assert "goal-harness-active-user-interventions.jsonl" in plan["active_user_feed_jsonl"], plan
     assert "goal-harness-active-user-observation.json" in plan["active_user_observation_json"], plan
+    assert plan["simulator_setting"] == SIMULATOR_SETTING, plan
+    contract = plan["codex_simulator_contract"]
+    assert (
+        contract["schema_version"]
+        == "goal_harness_active_user_codex_cli_simulator_contract_v0"
+    ), plan
+    assert contract["simulator_kind"] == "codex_cli", plan
+    assert contract["manual_controller_feed_allowed"] is False, plan
+    assert contract["controller_authored_feed_allowed"] is False, plan
+    assert contract["formal_treatment_requires_model_backed_simulator"] is True, plan
+    assert "codex exec" in contract["codex_exec_command"], plan
+    assert "active-user-simulator-output" in contract["append_validated_output_command"], plan
+    assert (
+        contract["simulator_output_schema_version"]
+        == "goal_harness_active_user_simulator_output_v0"
+    ), plan
     assert plan["sequence_steps"] == [
         "launch_single_codex_goal_harness_worker_with_no_upload",
         "record_worker_start_seq_before_first_poll",
-        "append_public_safe_simulator_intervention_with_seq_gt_worker_start_seq",
+        "build_public_simulator_context_without_hidden_tests_or_solutions",
+        "run_codex_cli_user_simulator_with_output_schema",
+        "validate_codex_simulator_output_with_no_oracle_audit",
+        "append_validated_simulator_intervention_with_seq_gt_worker_start_seq",
         "worker_polls_active_user_observe_after_start",
         "ingest_worker_observation_as_non_official_collaboration_evidence",
     ], plan
     assert "worker_observation_proof_true" in plan["required_evidence"], plan
+    assert "codex_cli_simulator_output_validated" in plan["required_evidence"], plan
     assert "leaderboard_or_upload_requested" in plan["stop_conditions"], plan
+    assert "controller_authored_feed_needed" in plan["stop_conditions"], plan
+    assert "codex_simulator_output_schema_rejected" in plan["stop_conditions"], plan
     assert plan["claim_boundary"]["assisted_collaboration_claim_allowed"] is True, plan
     assert plan["claim_boundary"]["official_score_claim_allowed"] is False, plan
     assert plan["claim_boundary"]["leaderboard_claim_allowed"] is False, plan

--- a/goal_harness/benchmark.py
+++ b/goal_harness/benchmark.py
@@ -26,6 +26,7 @@ from .worker_bridge import (
     WORKER_BRIDGE_BENCHMARK_RUN_REQUIRED_TOP_LEVEL_FIELDS,
     WORKER_BRIDGE_BENCHMARK_RUN_WRITEBACK_CONTRACT_VERSION,
     WORKER_BRIDGE_SURFACE,
+    build_active_user_codex_simulator_contract,
     build_active_user_intervention,
     build_worker_bridge_install_contract,
 )
@@ -67,6 +68,7 @@ TERMINAL_BENCH_ACTIVE_USER_SIMULATOR_INJECTION_CHANNEL_SCHEMA = (
 TERMINAL_BENCH_ACTIVE_USER_PRIVATE_LAUNCHER_PLAN_SCHEMA = (
     "terminal_bench_active_user_private_launcher_plan_v0"
 )
+TERMINAL_BENCH_ACTIVE_USER_SIMULATOR_SETTING = "codex_cli_user_simulator"
 TERMINAL_BENCH_ACTIVE_USER_SIMULATOR_INJECTION_FIRST_BLOCKER = (
     "missing_simulator_to_worker_injection_channel"
 )
@@ -2051,6 +2053,9 @@ def build_terminal_bench_active_user_private_launcher_plan(
     channel = build_terminal_bench_active_user_injection_channel_probe(
         active_cli_bridge_preflight=active_cli_bridge_preflight,
     )
+    codex_simulator_contract = build_active_user_codex_simulator_contract(
+        feed_jsonl=TERMINAL_BENCH_WORKER_BRIDGE_ACTIVE_USER_FEED_JSONL,
+    )
     channel_available = bool(channel.get("channel_available"))
     first_blocker = (
         "ready_for_private_no_upload_assisted_worker_sample"
@@ -2068,15 +2073,49 @@ def build_terminal_bench_active_user_private_launcher_plan(
         "active_user_observation_json": (
             TERMINAL_BENCH_WORKER_BRIDGE_ACTIVE_USER_OBSERVATION_JSON
         ),
+        "simulator_setting": TERMINAL_BENCH_ACTIVE_USER_SIMULATOR_SETTING,
+        "codex_simulator_contract": {
+            "schema_version": codex_simulator_contract.get("schema_version"),
+            "simulator_kind": codex_simulator_contract.get("simulator_kind"),
+            "manual_controller_feed_allowed": codex_simulator_contract.get(
+                "manual_controller_feed_allowed"
+            ),
+            "formal_treatment_requires_model_backed_simulator": (
+                codex_simulator_contract.get(
+                    "formal_treatment_requires_model_backed_simulator"
+                )
+            ),
+            "codex_exec_command": (
+                (codex_simulator_contract.get("codex_cli") or {}).get(
+                    "exec_command"
+                )
+            ),
+            "append_validated_output_command": codex_simulator_contract.get(
+                "append_validated_output_command"
+            ),
+            "simulator_output_schema_version": (
+                codex_simulator_contract.get("simulator_output_contract") or {}
+            ).get("schema_version"),
+            "controller_authored_feed_allowed": (
+                (codex_simulator_contract.get("claim_boundary") or {}).get(
+                    "controller_authored_feed_allowed"
+                )
+            ),
+        },
         "sequence_steps": [
             "launch_single_codex_goal_harness_worker_with_no_upload",
             "record_worker_start_seq_before_first_poll",
-            "append_public_safe_simulator_intervention_with_seq_gt_worker_start_seq",
+            "build_public_simulator_context_without_hidden_tests_or_solutions",
+            "run_codex_cli_user_simulator_with_output_schema",
+            "validate_codex_simulator_output_with_no_oracle_audit",
+            "append_validated_simulator_intervention_with_seq_gt_worker_start_seq",
             "worker_polls_active_user_observe_after_start",
             "ingest_worker_observation_as_non_official_collaboration_evidence",
         ],
         "required_evidence": [
             "worker_start_seq_recorded",
+            "codex_cli_simulator_contract_recorded",
+            "codex_cli_simulator_output_validated",
             "post_start_intervention_seq_recorded",
             "active_user_observe_worker_cli_call_recorded",
             "worker_observation_proof_true",
@@ -2085,6 +2124,8 @@ def build_terminal_bench_active_user_private_launcher_plan(
         "stop_conditions": [
             "hidden_tests_or_expected_solution_visible",
             "credential_value_needed",
+            "controller_authored_feed_needed",
+            "codex_simulator_output_schema_rejected",
             "leaderboard_or_upload_requested",
             "raw_transcript_required",
             "worker_observation_missing",
@@ -3385,7 +3426,7 @@ def build_terminal_bench_benchmark_run(
             "pilot_schema_version": "active_user_assisted_pilot_v0",
             "active_injection_schema_version": "active_user_simulator_injection_v0",
             "operator_simulator_run_schema_version": "operator_simulator_run_v0",
-            "simulator_setting": "deterministic_scripted_user",
+            "simulator_setting": TERMINAL_BENCH_ACTIVE_USER_SIMULATOR_SETTING,
             "proactive_intervention_allowed": True,
             "directive_feedback_allowed": True,
             "artificial_mildness_required": False,
@@ -3702,7 +3743,7 @@ def build_terminal_bench_benchmark_run(
                 benchmark_run["preflight_guard"].update(
                     {
                         "active_user_assisted_treatment": True,
-                        "simulator_setting": "deterministic_scripted_user",
+                        "simulator_setting": TERMINAL_BENCH_ACTIVE_USER_SIMULATOR_SETTING,
                         "simulator_to_worker_injection_channel_available": bool(
                             injection_channel_probe.get("channel_available")
                         ),

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -696,10 +696,36 @@ def _compact_active_user_private_launcher_plan(value: Any) -> dict[str, Any]:
         "worker_start_marker",
         "active_user_feed_jsonl",
         "active_user_observation_json",
+        "simulator_setting",
     ):
         text = public_safe_compact_text(value.get(field), limit=140)
         if text:
             compact[field] = text
+    contract = (
+        value.get("codex_simulator_contract")
+        if isinstance(value.get("codex_simulator_contract"), dict)
+        else {}
+    )
+    compact_contract: dict[str, Any] = {}
+    for field in (
+        "schema_version",
+        "simulator_kind",
+        "codex_exec_command",
+        "append_validated_output_command",
+        "simulator_output_schema_version",
+    ):
+        text = public_safe_compact_text(contract.get(field), limit=500)
+        if text:
+            compact_contract[field] = text
+    for field in (
+        "manual_controller_feed_allowed",
+        "formal_treatment_requires_model_backed_simulator",
+        "controller_authored_feed_allowed",
+    ):
+        if isinstance(contract.get(field), bool):
+            compact_contract[field] = contract[field]
+    if compact_contract:
+        compact["codex_simulator_contract"] = compact_contract
     if isinstance(value.get("ready"), bool):
         compact["ready"] = value["ready"]
     for field in ("sequence_steps", "required_evidence", "stop_conditions"):


### PR DESCRIPTION
## Summary
- wire the terminal-bench active-user assisted treatment preflight to the Codex CLI user simulator contract
- record the simulator contract in the private launcher plan and public-safe status compacting
- update the preflight smoke to require validated model-backed simulator output instead of controller-authored feed

## Validation
- python3 -m compileall -q goal_harness examples/terminal-bench-active-user-assisted-treatment-preflight-smoke.py
- git diff --check
- python3 examples/terminal-bench-active-user-assisted-treatment-preflight-smoke.py
- python3 examples/active-user-codex-simulator-contract-smoke.py
- python3 examples/terminal-bench-active-user-assisted-observation-fixture-smoke.py
- python3 -m goal_harness.cli --format json benchmark run terminal-bench --goal-id goal-harness-meta --mode codex-goal-harness --preflight-guard --active-cli-bridge --active-user-assisted-treatment --dry-run