### PR TITLE
Add Terminal-Bench task material readiness guard

### DIFF
--- a/examples/terminal-bench-private-runner-env-guard-smoke.py
+++ b/examples/terminal-bench-private-runner-env-guard-smoke.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 from pathlib import Path
 
 
@@ -17,6 +18,7 @@ from goal_harness.benchmark import (  # noqa: E402
     build_terminal_bench_managed_harbor_command,
     build_terminal_bench_private_runner_env,
     build_terminal_bench_private_runner_launch,
+    build_terminal_bench_task_material_readiness,
     normalize_terminal_bench_private_runner_invocation,
     resolve_terminal_bench_runner_binary,
     summarize_terminal_bench_private_runner_launch,
@@ -33,6 +35,50 @@ def expect_raises(callable_obj, needle: str) -> None:
 
 
 def main() -> None:
+    with tempfile.TemporaryDirectory(prefix="goal-harness-task-material-") as tmp:
+        dataset = Path(tmp) / "terminal-bench-local"
+        good_task = dataset / "good-task"
+        good_task.mkdir(parents=True)
+        (good_task / "task.toml").write_text('version = "1.0"\n', encoding="utf-8")
+        (good_task / "instruction.md").write_text("fixture instruction\n", encoding="utf-8")
+        bad_task = dataset / "bad-task"
+        bad_task.mkdir(parents=True)
+        (bad_task / "task.toml").write_text('version = "1.0"\n', encoding="utf-8")
+
+        good_material = build_terminal_bench_task_material_readiness(
+            dataset=str(dataset),
+            task_id="good-task",
+        )
+        assert good_material["checked"] is True, good_material
+        assert good_material["ready"] is True, good_material
+        assert good_material["status"] == "ready", good_material
+        assert good_material["raw_paths_recorded"] is False, good_material
+
+        bad_material = build_terminal_bench_task_material_readiness(
+            dataset=str(dataset),
+            task_id="bad-task",
+        )
+        assert bad_material["checked"] is True, bad_material
+        assert bad_material["ready"] is False, bad_material
+        assert bad_material["first_blocker"] == "task_material_missing_instruction_md", bad_material
+
+        bad_launch = build_terminal_bench_private_runner_launch(
+            dataset=str(dataset),
+            task_id="bad-task",
+            jobs_dir="<private-jobs-dir>",
+            job_name="terminal_bench_bad_material_env_guard_smoke",
+            goal_harness_mode="codex_goal_harness",
+            goal_harness_goal_id="goal-harness-meta",
+            goal_harness_cli_bridge_enabled=True,
+        )
+        assert bad_launch["first_blocker"] == "task_material_missing_instruction_md", bad_launch
+        assert bad_launch["ready"] is False, bad_launch
+        bad_summary = summarize_terminal_bench_private_runner_launch(bad_launch)
+        assert bad_summary["task_material_readiness_checked"] is True, bad_summary
+        assert bad_summary["task_material_ready"] is False, bad_summary
+        assert bad_summary["task_material_first_blocker"] == "task_material_missing_instruction_md", bad_summary
+        assert bad_summary["raw_paths_recorded"] is False, bad_summary
+
     previous = os.environ.get("CODEX_FORCE_AUTH_JSON")
     os.environ["CODEX_FORCE_AUTH_JSON"] = "****"
     try:

--- a/goal_harness/benchmark.py
+++ b/goal_harness/benchmark.py
@@ -68,6 +68,9 @@ TERMINAL_BENCH_ACTIVE_USER_SIMULATOR_INJECTION_CHANNEL_SCHEMA = (
 TERMINAL_BENCH_ACTIVE_USER_PRIVATE_LAUNCHER_PLAN_SCHEMA = (
     "terminal_bench_active_user_private_launcher_plan_v0"
 )
+TERMINAL_BENCH_TASK_MATERIAL_READINESS_SCHEMA = (
+    "terminal_bench_task_material_readiness_v0"
+)
 TERMINAL_BENCH_ACTIVE_USER_SIMULATOR_SETTING = "codex_cli_user_simulator"
 TERMINAL_BENCH_ACTIVE_USER_SIMULATOR_INJECTION_FIRST_BLOCKER = (
     "missing_simulator_to_worker_injection_channel"
@@ -1504,6 +1507,92 @@ def _private_runner_command_kwargs(command_kwargs: dict[str, Any]) -> dict[str, 
     return resolved
 
 
+def build_terminal_bench_task_material_readiness(
+    *,
+    dataset: str = TERMINAL_BENCH_DEFAULT_DATASET,
+    task_id: str | None = TERMINAL_BENCH_DEFAULT_TASK,
+    harbor_task_cache_root: str | Path | None = None,
+) -> dict[str, Any]:
+    """Return a public-safe readiness summary for selected task material.
+
+    This deliberately checks only file presence, not task prompt contents. It is
+    scoped to Terminal-Bench/Harbor launch safety: unknown or not-yet-cached
+    material is reported as non-blocking, while cached material that is missing
+    core files can block a private launch before spending a worker trial.
+    """
+
+    task_label = str(task_id or "")
+    dataset_label = str(dataset or "")
+    if not task_label:
+        return {
+            "schema_version": TERMINAL_BENCH_TASK_MATERIAL_READINESS_SCHEMA,
+            "dataset": dataset_label,
+            "task_id": "",
+            "checked": False,
+            "ready": None,
+            "status": "not_checked_batch_or_no_task_selected",
+            "first_blocker": "",
+            "candidate_count": 0,
+            "instruction_md_present_count": 0,
+            "task_toml_present_count": 0,
+            "raw_paths_recorded": False,
+        }
+
+    candidates: list[Path] = []
+    dataset_path = Path(dataset_label).expanduser()
+    if dataset_path.exists() and dataset_path.is_dir():
+        local_candidate = dataset_path / task_label
+        if local_candidate.exists() and local_candidate.is_dir():
+            candidates.append(local_candidate)
+    else:
+        cache_root = Path(
+            harbor_task_cache_root
+            or os.environ.get("GOAL_HARNESS_HARBOR_TASK_CACHE_ROOT", "")
+            or Path("~/.cache/harbor/tasks").expanduser()
+        )
+        if cache_root.exists() and cache_root.is_dir():
+            candidates.extend(
+                sorted(
+                    path
+                    for path in cache_root.glob(f"*/{task_label}")
+                    if path.exists() and path.is_dir()
+                )
+            )
+
+    instruction_count = sum(1 for path in candidates if (path / "instruction.md").exists())
+    task_toml_count = sum(1 for path in candidates if (path / "task.toml").exists())
+    if not candidates:
+        status = "not_cached_or_not_locally_resolved"
+        first_blocker = ""
+        ready: bool | None = None
+    elif instruction_count > 0 and task_toml_count > 0:
+        status = "ready"
+        first_blocker = ""
+        ready = True
+    elif instruction_count == 0:
+        status = "missing_instruction_md"
+        first_blocker = "task_material_missing_instruction_md"
+        ready = False
+    else:
+        status = "missing_task_toml"
+        first_blocker = "task_material_missing_task_toml"
+        ready = False
+
+    return {
+        "schema_version": TERMINAL_BENCH_TASK_MATERIAL_READINESS_SCHEMA,
+        "dataset": dataset_label,
+        "task_id": task_label,
+        "checked": bool(candidates),
+        "ready": ready,
+        "status": status,
+        "first_blocker": first_blocker,
+        "candidate_count": len(candidates),
+        "instruction_md_present_count": instruction_count,
+        "task_toml_present_count": task_toml_count,
+        "raw_paths_recorded": False,
+    }
+
+
 def build_terminal_bench_private_runner_launch(**command_kwargs: Any) -> dict[str, Any]:
     """Build the real private Harbor launch argv together with its env.
 
@@ -1556,13 +1645,24 @@ def build_terminal_bench_private_runner_launch(**command_kwargs: Any) -> dict[st
     else:
         raise ValueError(f"unsupported private runner launch mode: {mode}")
     surface = collect_terminal_bench_managed_preflight_surface(env=env)
+    material_readiness = build_terminal_bench_task_material_readiness(
+        dataset=str(resolved_command_kwargs.get("dataset", TERMINAL_BENCH_DEFAULT_DATASET)),
+        task_id=resolved_command_kwargs.get("task_id", TERMINAL_BENCH_DEFAULT_TASK),
+    )
     first_blocker = _managed_preflight_first_blocker(surface)
+    if (
+        first_blocker == "ready_for_private_managed_no_upload_pilot_review"
+        and material_readiness.get("checked") is True
+        and material_readiness.get("ready") is False
+    ):
+        first_blocker = str(material_readiness.get("first_blocker") or "task_material_not_ready")
     return {
         "schema_version": "terminal_bench_private_runner_launch_v0",
         "argv": argv,
         "env": env,
         "uses_private_runner_env": True,
         "preflight_surface": surface,
+        "task_material_readiness": material_readiness,
         "first_blocker": first_blocker,
         "ready": first_blocker == "ready_for_private_managed_no_upload_pilot_review",
     }
@@ -1583,6 +1683,11 @@ def summarize_terminal_bench_private_runner_launch(
     boundary = (
         preflight_surface.get("boundary")
         if isinstance(preflight_surface.get("boundary"), dict)
+        else {}
+    )
+    task_material = (
+        launch.get("task_material_readiness")
+        if isinstance(launch.get("task_material_readiness"), dict)
         else {}
     )
     path_value = env.get("PATH") if isinstance(env.get("PATH"), str) else ""
@@ -1637,6 +1742,21 @@ def summarize_terminal_bench_private_runner_launch(
         "env_path_present": bool(path_value),
         "env_probe_path_coverage": probe_coverage,
         "env_probe_path_coverage_count": sum(1 for ready in probe_coverage.values() if ready),
+        "task_material_readiness_status": str(task_material.get("status") or ""),
+        "task_material_first_blocker": str(task_material.get("first_blocker") or ""),
+        "task_material_readiness_checked": task_material.get("checked") is True,
+        "task_material_ready": (
+            task_material.get("ready") is True
+            if task_material.get("checked") is True
+            else None
+        ),
+        "task_material_candidate_count": int(task_material.get("candidate_count") or 0),
+        "task_material_instruction_md_present_count": int(
+            task_material.get("instruction_md_present_count") or 0
+        ),
+        "task_material_task_toml_present_count": int(
+            task_material.get("task_toml_present_count") or 0
+        ),
         "auth_surface_names_present": auth_names_present,
         "auth_values_recorded": False,
         "raw_env_recorded": False,

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -849,7 +849,14 @@ def _compact_benchmark_private_runner_launch(value: Any) -> dict[str, Any]:
         return {}
 
     compact: dict[str, Any] = {}
-    for field in ("schema_version", "launch_schema_version", "first_blocker", "argv_binary_name"):
+    for field in (
+        "schema_version",
+        "launch_schema_version",
+        "first_blocker",
+        "argv_binary_name",
+        "task_material_readiness_status",
+        "task_material_first_blocker",
+    ):
         text = public_safe_compact_text(value.get(field), limit=120)
         if text:
             compact[field] = text
@@ -866,15 +873,23 @@ def _compact_benchmark_private_runner_launch(value: Any) -> dict[str, Any]:
         "agent_import_path_present",
         "goal_harness_agent_kwargs_present",
         "goal_harness_worker_bridge_requested",
+        "task_material_readiness_checked",
+        "task_material_ready",
         "auth_values_recorded",
         "raw_env_recorded",
         "raw_paths_recorded",
     ):
         if isinstance(value.get(field), bool):
             compact[field] = value[field]
-    count = value.get("env_probe_path_coverage_count")
-    if isinstance(count, int) and not isinstance(count, bool):
-        compact["env_probe_path_coverage_count"] = count
+    for field in (
+        "env_probe_path_coverage_count",
+        "task_material_candidate_count",
+        "task_material_instruction_md_present_count",
+        "task_material_task_toml_present_count",
+    ):
+        count = value.get(field)
+        if isinstance(count, int) and not isinstance(count, bool):
+            compact[field] = count
     active_user_mount_count = value.get("active_user_writable_mount_count")
     if isinstance(active_user_mount_count, int) and not isinstance(active_user_mount_count, bool):
         compact["active_user_writable_mount_count"] = active_user_mount_count


### PR DESCRIPTION
## Summary
- add a Terminal-Bench/Harbor-specific task_material_readiness preflight that only checks local file presence
- block launches only when a resolved local task is explicitly missing required material such as instruction.md
- expose compact private launch/preflight fields without recording raw task paths or reading task prompt text

## Validation
- python3 examples/terminal-bench-private-runner-env-guard-smoke.py
- python3 examples/terminal-bench-codex-goal-harness-active-cli-bridge-smoke.py
- python3 -m py_compile goal_harness/benchmark.py goal_harness/status.py
- goal-harness check
- goal-harness doctor
- goal-harness-canary doctor
- installed local release and verified qemu-startup blocks on task_material_missing_instruction_md while llm-inference-batching-scheduler stays ready