### PR TITLE
Fix active-user simulator schema compatibility

### DIFF
--- a/examples/worker-bridge-active-user-feed-smoke.py
+++ b/examples/worker-bridge-active-user-feed-smoke.py
@@ -118,10 +118,14 @@ def assert_observation(payload: dict[str, Any], *, observed: bool) -> None:
 
 def main() -> int:
     from goal_harness.worker_bridge import (
+        active_user_simulator_output_json_schema,
         build_active_user_intervention,
         build_active_user_intervention_channel_contract,
         observe_active_user_intervention_feed,
     )
+
+    simulator_schema = active_user_simulator_output_json_schema()
+    assert "uniqueItems" not in json.dumps(simulator_schema), simulator_schema
 
     assert_contract(build_active_user_intervention_channel_contract())
     assert_contract(
@@ -141,6 +145,11 @@ def main() -> int:
         created_after_worker_start=False,
     )
     assert_intervention(before_start, seq=0, after_start=False)
+    false_positive_regression = build_active_user_intervention(
+        seq=1,
+        message="Run the task-visible checks before editing further.",
+    )
+    assert_intervention(false_positive_regression, seq=1, after_start=True)
     after_start = run_cli_json(
         [
             "worker-bridge",
@@ -230,6 +239,31 @@ def main() -> int:
     assert rejected_payload["ok"] is False, rejected_payload
     assert "a non-public marker" in rejected_payload["error"], rejected_payload
     assert_public_safe(rejected_payload)
+
+    rejected_token_shape = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "goal_harness.cli",
+            "worker-bridge",
+            "active-user-intervention",
+            "--seq",
+            "4",
+            "--message",
+            "token shaped " + "sk-" + "exampletoken must be rejected",
+            "--format",
+            "json",
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    assert rejected_token_shape.returncode == 1, rejected_token_shape.stdout
+    rejected_token_payload = json.loads(rejected_token_shape.stdout)
+    assert rejected_token_payload["ok"] is False, rejected_token_payload
+    assert "a non-public marker" in rejected_token_payload["error"], rejected_token_payload
 
     print("worker-bridge-active-user-feed-smoke ok observed_after_worker_start=true")
     return 0

--- a/goal_harness/worker_bridge.py
+++ b/goal_harness/worker_bridge.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 import shlex
 from pathlib import Path
 from typing import Any
@@ -112,10 +113,10 @@ ACTIVE_USER_PUBLIC_TEXT_FORBIDDEN_MARKERS = (
     "Author" + "ization:",
     "Bear" + "er ",
     "-----BEGIN",
-    "sk-",
     "tok" + "en=",
     "pass" + "word=",
 )
+ACTIVE_USER_SECRET_KEY_SHAPED_RE = re.compile(r"(?<![A-Za-z0-9])sk-[A-Za-z0-9_-]{8,}")
 
 
 def build_worker_bridge_mounts(
@@ -262,6 +263,8 @@ def _coerce_public_safe_worker_text(
     if not text:
         raise ValueError(f"{field} is required")
     leaked = [marker for marker in ACTIVE_USER_PUBLIC_TEXT_FORBIDDEN_MARKERS if marker in text]
+    if ACTIVE_USER_SECRET_KEY_SHAPED_RE.search(text):
+        leaked.append("sk-token-shaped")
     if leaked:
         raise ValueError(f"{field} contains a non-public marker")
     return text[:limit].rstrip()
@@ -386,7 +389,6 @@ def active_user_simulator_output_json_schema() -> dict[str, Any]:
             "visible_evidence_basis": {
                 "type": "array",
                 "minItems": 1,
-                "uniqueItems": True,
                 "items": {
                     "type": "string",
                     "enum": list(ACTIVE_USER_SIMULATOR_ALLOWED_EVIDENCE_BASIS),


### PR DESCRIPTION
## Summary
- remove uniqueItems from the active-user simulator output JSON schema so Codex/OpenAI structured output accepts it
- keep sk- secret-shaped text blocked while avoiding false positives such as task-visible
- add smoke coverage for schema compatibility, false-positive acceptance, and token-shaped rejection

## Validation
- python3 examples/worker-bridge-active-user-feed-smoke.py
- python3 examples/terminal-bench-active-user-assisted-treatment-preflight-smoke.py
- python3 -m py_compile goal_harness/worker_bridge.py
- goal-harness check
- git diff --check HEAD~1..HEAD