### PR TITLE
Normalize Harbor ingest timestamps

### DIFF
--- a/examples/terminal-bench-harbor-runner-ingest-smoke.py
+++ b/examples/terminal-bench-harbor-runner-ingest-smoke.py
@@ -15,7 +15,10 @@ import sys
 
 sys.path.insert(0, str(REPO_ROOT))
 
-from goal_harness.benchmark import build_terminal_bench_harbor_result_benchmark_run  # noqa: E402
+from goal_harness.benchmark import (  # noqa: E402
+    _iso_duration_seconds,
+    build_terminal_bench_harbor_result_benchmark_run,
+)
 from goal_harness.status import compact_benchmark_run  # noqa: E402
 
 GOAL_ID = "terminal-bench-harbor-runner-ingest-fixture"
@@ -655,6 +658,11 @@ def assert_public_safe(payload: dict) -> None:
 
 
 def main() -> None:
+    assert _iso_duration_seconds(
+        "2026-06-10T17:50:00",
+        "2026-06-10T17:50:03+00:00",
+    ) == 3.0
+
     with tempfile.TemporaryDirectory(prefix="goal-harness-harbor-runner-ingest-") as tmp:
         payload = build_terminal_bench_harbor_result_benchmark_run(write_fixture(Path(tmp)))
 

--- a/goal_harness/benchmark.py
+++ b/goal_harness/benchmark.py
@@ -6,7 +6,7 @@ import shlex
 import shutil
 import subprocess
 import tempfile
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -607,6 +607,10 @@ def _iso_duration_seconds(started_at: str | None, finished_at: str | None) -> fl
         finish = datetime.fromisoformat(finished_at.replace("Z", "+00:00"))
     except ValueError:
         return None
+    if start.tzinfo is None:
+        start = start.replace(tzinfo=timezone.utc)
+    if finish.tzinfo is None:
+        finish = finish.replace(tzinfo=timezone.utc)
     return max(0.0, (finish - start).total_seconds())
 
 


### PR DESCRIPTION
## Summary
- normalize naive Harbor ISO timestamps to UTC before computing compact wall time
- cover mixed naive/aware timestamp ingestion with the Harbor runner ingest smoke
- unblock compact ingestion of pending or partial treatment runs that mix timestamp formats

## Validation
- python3 examples/terminal-bench-harbor-runner-ingest-smoke.py
- python3 -m py_compile goal_harness/benchmark.py
- goal-harness-canary benchmark run terminal-bench --harbor-job-dir <private-treatment-job> --dry-run
- goal-harness-canary check
- git diff --check