### PR TITLE
Expose Terminal-Bench worker writeback loss

### DIFF
--- a/examples/terminal-bench-harbor-runner-ingest-smoke.py
+++ b/examples/terminal-bench-harbor-runner-ingest-smoke.py
@@ -408,6 +408,104 @@ def write_verifier_platform_probe_failure_fixture(root: Path) -> Path:
     return job_dir
 
 
+def write_worker_trace_timeout_writeback_loss_fixture(root: Path) -> Path:
+    job_dir = root / "terminal_bench_sample_worker_trace_timeout_writeback_loss"
+    trial_dir = job_dir / "qemu-alpine-ssh__timeout"
+    agent = {
+        "import_path": "goal_harness.terminal_bench_agent:GoalHarnessManagedCodex",
+        "model_name": "gpt-5.5",
+        "kwargs": {
+            "goal_harness_mode": "codex_goal_harness",
+            "goal_harness_cli_bridge_enabled": True,
+            "goal_harness_active_user_intervention_enabled": True,
+        },
+    }
+    write_json(
+        job_dir / "lock.json",
+        {
+            "schema_version": 1,
+            "invocation": [
+                "harbor",
+                "run",
+                "--dataset",
+                "terminal-bench@2.0",
+                "--include-task-name",
+                "qemu-alpine-ssh",
+            ],
+            "trials": [
+                {
+                    "task": {
+                        "name": "qemu-alpine-ssh",
+                        "source": "terminal-bench",
+                    },
+                    "agent": agent,
+                }
+            ],
+        },
+    )
+    write_json(job_dir / "config.json", {"job_name": job_dir.name})
+    write_json(
+        job_dir / "result.json",
+        {
+            "started_at": "2026-06-08T19:20:00Z",
+            "updated_at": "2026-06-08T19:39:40Z",
+            "finished_at": "2026-06-08T19:39:40Z",
+            "n_total_trials": 1,
+            "stats": {
+                "n_completed_trials": 1,
+                "n_errored_trials": 1,
+                "n_running_trials": 0,
+                "n_pending_trials": 0,
+                "n_cancelled_trials": 0,
+                "n_retries": 0,
+                "n_input_tokens": 1665520,
+                "n_cache_tokens": 1587456,
+                "n_output_tokens": 7534,
+                "cost_usd": 1.410068,
+            },
+        },
+    )
+    write_json(
+        trial_dir / "result.json",
+        {
+            "task_name": "qemu-alpine-ssh",
+            "trial_name": "qemu-alpine-ssh__timeout",
+            "source": "terminal-bench",
+            "config": {"agent": agent},
+            "agent_result": {
+                "n_input_tokens": 1665520,
+                "n_cache_tokens": 1587456,
+                "n_output_tokens": 7534,
+                "cost_usd": 1.410068,
+            },
+            "verifier_result": {"rewards": {"reward": 0.0}},
+            "exception_info": {
+                "exception_type": "AgentTimeoutError",
+                "exception_message": "Agent execution timed out after 900.0 seconds",
+            },
+        },
+    )
+    (trial_dir / "agent").mkdir(parents=True, exist_ok=True)
+    (trial_dir / "agent" / "trajectory.json").write_text("{}\n", encoding="utf-8")
+    trace_rows = [
+        {"command": "active_user_observe", "ok": True},
+        {"command": "check", "ok": True},
+    ]
+    (trial_dir / "agent" / "goal-harness-counter-trace.jsonl").write_text(
+        "".join(json.dumps(row, sort_keys=True) + "\n" for row in trace_rows),
+        encoding="utf-8",
+    )
+    (trial_dir / "verifier").mkdir(parents=True, exist_ok=True)
+    (trial_dir / "verifier" / "reward.txt").write_text("0.0\n", encoding="utf-8")
+    (trial_dir / "verifier" / "test-stdout.txt").write_text(
+        "platform probe failed: unknown platform bitness\n",
+        encoding="utf-8",
+    )
+    (trial_dir / "artifacts").mkdir(parents=True, exist_ok=True)
+    write_json(trial_dir / "artifacts" / "manifest.json", {"files": ["redacted"]})
+    return job_dir
+
+
 def write_bare_codex_fixture(root: Path) -> Path:
     job_dir = root / "terminal_bench_sample_bare_codex_baseline"
     trial_dir = job_dir / "build-cython-ext__bare"
@@ -1089,6 +1187,84 @@ def main() -> None:
     ), platform_compact
     assert_public_safe(platform_payload)
     assert_public_safe(platform_compact)
+    with tempfile.TemporaryDirectory(prefix="goal-harness-harbor-timeout-writeback-loss-") as tmp:
+        writeback_loss_payload = build_terminal_bench_harbor_result_benchmark_run(
+            write_worker_trace_timeout_writeback_loss_fixture(Path(tmp))
+        )
+    assert writeback_loss_payload["official_task_score"]["value"] == 0.0, writeback_loss_payload
+    assert (
+        writeback_loss_payload["score_failure_attribution"]
+        == "verifier_platform_probe_failure"
+    ), writeback_loss_payload
+    assert writeback_loss_payload["worker_counter_trace_trial_count"] == 1, writeback_loss_payload
+    assert writeback_loss_payload["worker_benchmark_run_file_count"] == 0, writeback_loss_payload
+    assert writeback_loss_payload["worker_benchmark_run_schema_ok_count"] == 0, writeback_loss_payload
+    assert writeback_loss_payload["worker_bridge_writeback_loss_count"] == 1, writeback_loss_payload
+    assert (
+        writeback_loss_payload["worker_bridge_writeback_loss_reason"]
+        == "agent_timeout_after_worker_trace_before_benchmark_run_writeback"
+    ), writeback_loss_payload
+    writeback_loss_counters = writeback_loss_payload["interaction_counters"]
+    assert writeback_loss_counters["goal_harness_cli_calls"]["active_user_observe"] == 1, writeback_loss_counters
+    assert writeback_loss_counters["goal_harness_cli_calls"]["check"] == 1, writeback_loss_counters
+    assert writeback_loss_counters["worker_bridge_writeback_loss_count"] == 1, writeback_loss_counters
+    assert (
+        writeback_loss_counters["worker_bridge_writeback_loss_reason"]
+        == "agent_timeout_after_worker_trace_before_benchmark_run_writeback"
+    ), writeback_loss_counters
+    writeback_loss_outcome = writeback_loss_payload["worker_bridge_outcome"]
+    assert (
+        writeback_loss_outcome["runner_return_status"]
+        == "completed_with_agent_timeout"
+    ), writeback_loss_outcome
+    assert writeback_loss_outcome["worker_bridge_verified"] is True, writeback_loss_outcome
+    assert writeback_loss_outcome["worker_bridge_writeback_loss_observed"] is True, writeback_loss_outcome
+    assert writeback_loss_outcome["worker_bridge_writeback_loss_count"] == 1, writeback_loss_outcome
+    assert (
+        writeback_loss_outcome["worker_bridge_writeback_loss_reason"]
+        == "agent_timeout_after_worker_trace_before_benchmark_run_writeback"
+    ), writeback_loss_outcome
+    writeback_loss_validation = writeback_loss_payload["validation"]
+    assert (
+        writeback_loss_validation["worker_benchmark_run_file_present"] is False
+    ), writeback_loss_validation
+    assert (
+        writeback_loss_validation["worker_benchmark_run_schema_ok"] is False
+    ), writeback_loss_validation
+    assert (
+        writeback_loss_validation["worker_benchmark_run_present_for_traced_trials"]
+        is False
+    ), writeback_loss_validation
+    writeback_loss_compact = compact_benchmark_run(writeback_loss_payload)
+    assert writeback_loss_compact["validation"]["all_passed"] is False, writeback_loss_compact
+    assert "worker_benchmark_run_file_present" in writeback_loss_compact[
+        "validation"
+    ]["failed_checks"], writeback_loss_compact
+    assert writeback_loss_compact["worker_bridge_writeback_loss_count"] == 1, writeback_loss_compact
+    assert (
+        writeback_loss_compact["worker_bridge_writeback_loss_reason"]
+        == "agent_timeout_after_worker_trace_before_benchmark_run_writeback"
+    ), writeback_loss_compact
+    assert (
+        writeback_loss_compact["overhead_attribution_counters"][
+            "worker_bridge_writeback_loss_count"
+        ]
+        == 1
+    ), writeback_loss_compact
+    assert (
+        writeback_loss_compact["worker_bridge_outcome"][
+            "worker_bridge_writeback_loss_observed"
+        ]
+        is True
+    ), writeback_loss_compact
+    assert (
+        writeback_loss_compact["worker_bridge_outcome"][
+            "worker_bridge_writeback_loss_count"
+        ]
+        == 1
+    ), writeback_loss_compact
+    assert_public_safe(writeback_loss_payload)
+    assert_public_safe(writeback_loss_compact)
     print("terminal-bench-harbor-runner-ingest-smoke ok")
 
 

--- a/goal_harness/benchmark.py
+++ b/goal_harness/benchmark.py
@@ -934,6 +934,7 @@ def _terminal_bench_overhead_attribution_counters(
     worker_counter_trace_trial_count: int,
     worker_benchmark_run_file_count: int,
     worker_benchmark_run_schema_ok_count: int,
+    worker_bridge_writeback_loss_count: int,
     pre_worker_agent_setup_failure_count: int,
     codex_runtime_goal_tool_trial_count: int,
     trace_publicness: str,
@@ -1008,6 +1009,7 @@ def _terminal_bench_overhead_attribution_counters(
         "worker_counter_trace_trial_count": worker_counter_trace_trial_count,
         "worker_benchmark_run_file_count": worker_benchmark_run_file_count,
         "worker_benchmark_run_schema_ok_count": worker_benchmark_run_schema_ok_count,
+        "worker_bridge_writeback_loss_count": worker_bridge_writeback_loss_count,
         "pre_worker_agent_setup_failure_count": pre_worker_agent_setup_failure_count,
         "codex_runtime_goal_tool_trial_count": codex_runtime_goal_tool_trial_count,
         "goal_harness_cli_call_total": cli_call_total,
@@ -1247,6 +1249,28 @@ def build_terminal_bench_harbor_result_benchmark_run(
         else "pending"
     )
     official_score_status = "completed" if official_score is not None else "missing"
+    worker_bridge_writeback_loss_count = (
+        max(0, worker_counter_trace_trial_count - worker_benchmark_run_file_count)
+        if worker_bridge_required
+        else 0
+    )
+    if worker_bridge_writeback_loss_count and agent_timeout_observed:
+        worker_bridge_writeback_loss_reason = (
+            "agent_timeout_after_worker_trace_before_benchmark_run_writeback"
+        )
+    elif worker_bridge_writeback_loss_count:
+        worker_bridge_writeback_loss_reason = (
+            "worker_trace_without_benchmark_run_writeback"
+        )
+    else:
+        worker_bridge_writeback_loss_reason = "none"
+    if interaction_counters:
+        interaction_counters["worker_bridge_writeback_loss_count"] = (
+            worker_bridge_writeback_loss_count
+        )
+        interaction_counters["worker_bridge_writeback_loss_reason"] = (
+            worker_bridge_writeback_loss_reason
+        )
     wall_time_seconds = _iso_duration_seconds(
         job_result.get("started_at"),
         job_result.get("finished_at") or job_result.get("updated_at"),
@@ -1267,6 +1291,7 @@ def build_terminal_bench_harbor_result_benchmark_run(
         worker_counter_trace_trial_count=worker_counter_trace_trial_count,
         worker_benchmark_run_file_count=worker_benchmark_run_file_count,
         worker_benchmark_run_schema_ok_count=worker_benchmark_run_schema_ok_count,
+        worker_bridge_writeback_loss_count=worker_bridge_writeback_loss_count,
         pre_worker_agent_setup_failure_count=pre_worker_agent_setup_failure_count,
         codex_runtime_goal_tool_trial_count=codex_runtime_goal_tool_trial_count,
         trace_publicness=trace_publicness,
@@ -1345,6 +1370,8 @@ def build_terminal_bench_harbor_result_benchmark_run(
         "worker_counter_trace_trial_count": worker_counter_trace_trial_count,
         "worker_benchmark_run_file_count": worker_benchmark_run_file_count,
         "worker_benchmark_run_schema_ok_count": worker_benchmark_run_schema_ok_count,
+        "worker_bridge_writeback_loss_count": worker_bridge_writeback_loss_count,
+        "worker_bridge_writeback_loss_reason": worker_bridge_writeback_loss_reason,
         "pre_worker_agent_setup_failure_count": pre_worker_agent_setup_failure_count,
         "verifier_failure_attribution_count": verifier_failure_attribution_count,
         "verifier_dependency_failure_count": verifier_dependency_failure_count,
@@ -1413,6 +1440,11 @@ def build_terminal_bench_harbor_result_benchmark_run(
             "raw_trace_recorded": False,
             "credential_values_recorded": False,
             "runner_side_writeback_guaranteed": True,
+            "worker_bridge_writeback_loss_observed": bool(
+                worker_bridge_writeback_loss_count
+            ),
+            "worker_bridge_writeback_loss_count": worker_bridge_writeback_loss_count,
+            "worker_bridge_writeback_loss_reason": worker_bridge_writeback_loss_reason,
             "worker_goal_harness_cli_call_total": worker_cli_total,
             "required_worker_goal_harness_cli_call_total_min": required_worker_cli_call_min,
             "pre_worker_agent_setup_failure_count": pre_worker_agent_setup_failure_count,

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -434,12 +434,17 @@ def _compact_benchmark_interaction_counters(value: Any) -> dict[str, Any]:
         "worker_counter_trace_trial_count",
         "worker_benchmark_run_file_count",
         "worker_benchmark_run_schema_ok_count",
+        "worker_bridge_writeback_loss_count",
         "pre_worker_agent_setup_failure_count",
         "codex_runtime_goal_tool_trial_count",
     ):
         if isinstance(value.get(field), int) and not isinstance(value.get(field), bool):
             compact[field] = value[field]
-    for field in ("case_result_writeback", "counter_trust_level"):
+    for field in (
+        "case_result_writeback",
+        "counter_trust_level",
+        "worker_bridge_writeback_loss_reason",
+    ):
         text = public_safe_compact_text(value.get(field), limit=100)
         if text:
             compact[field] = text
@@ -495,6 +500,7 @@ def _compact_benchmark_overhead_attribution_counters(value: Any) -> dict[str, An
         "worker_counter_trace_trial_count",
         "worker_benchmark_run_file_count",
         "worker_benchmark_run_schema_ok_count",
+        "worker_bridge_writeback_loss_count",
         "pre_worker_agent_setup_failure_count",
         "codex_runtime_goal_tool_trial_count",
         "goal_harness_cli_call_total",
@@ -926,6 +932,7 @@ def _compact_worker_bridge_outcome(value: Any) -> dict[str, Any]:
         "trace_publicness",
         "next_action",
         "score_failure_attribution",
+        "worker_bridge_writeback_loss_reason",
     ):
         text = public_safe_compact_text(value.get(field), limit=160)
         if text:
@@ -940,12 +947,14 @@ def _compact_worker_bridge_outcome(value: Any) -> dict[str, Any]:
         "raw_trace_recorded",
         "credential_values_recorded",
         "runner_side_writeback_guaranteed",
+        "worker_bridge_writeback_loss_observed",
     ):
         if isinstance(value.get(field), bool):
             compact[field] = value[field]
     for field in (
         "worker_goal_harness_cli_call_total",
         "required_worker_goal_harness_cli_call_total_min",
+        "worker_bridge_writeback_loss_count",
         "pre_worker_agent_setup_failure_count",
         "verifier_failure_attribution_count",
         "verifier_dependency_failure_count",
@@ -1069,6 +1078,7 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
         "trace_publicness",
         "first_blocker",
         "score_failure_attribution",
+        "worker_bridge_writeback_loss_reason",
     ):
         value = public_safe_compact_text(source.get(field), limit=140)
         if value:
@@ -1111,6 +1121,7 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
         "worker_counter_trace_trial_count",
         "worker_benchmark_run_file_count",
         "worker_benchmark_run_schema_ok_count",
+        "worker_bridge_writeback_loss_count",
         "pre_worker_agent_setup_failure_count",
         "verifier_failure_attribution_count",
         "verifier_dependency_failure_count",


### PR DESCRIPTION
## Summary
- add compact worker_bridge_writeback_loss fields to Terminal-Bench Harbor ingest and status projection
- preserve timeout-after-worker-trace as a distinct failure mode instead of only failed validation checks
- add a synthetic Harbor ingest fixture for AgentTimeoutError with worker trace but missing worker benchmark-run writeback

## Validation
- python3 examples/terminal-bench-harbor-runner-ingest-smoke.py
- python3 examples/benchmark-run-v0-status-projection-smoke.py
- python3 -m py_compile goal_harness/benchmark.py goal_harness/status.py examples/terminal-bench-harbor-runner-ingest-smoke.py
- git diff --check
- goal-harness --format json check