### PR TITLE
Write active-user observe checkpoints

### DIFF
--- a/examples/worker-bridge-active-user-after-start-observation-smoke.py
+++ b/examples/worker-bridge-active-user-after-start-observation-smoke.py
@@ -105,15 +105,21 @@ def main() -> int:
         root = Path(tmp)
         feed = root / "active-user-feed.jsonl"
         observation = root / "active-user-observation.json"
+        counter_trace = root / "counter-trace.jsonl"
+        benchmark_run = root / "worker-benchmark-run.json"
 
         contract = build_active_user_intervention_channel_contract(
             project_root=str(REPO_ROOT),
             feed_jsonl=str(feed),
             observation_json=str(observation),
+            counter_trace_json=str(counter_trace),
+            benchmark_run_json=str(benchmark_run),
         )
         assert contract["worker_start_marker"]["kind"] == "worker_start_seq", contract
         assert contract["claim_boundary"]["worker_pull_required"] is True, contract
         assert contract["claim_boundary"]["direct_codex_chat_injection"] is False, contract
+        assert "--counter-trace-json" in contract["worker_observe_command"], contract
+        assert "--benchmark-run-json" in contract["worker_observe_command"], contract
 
         access_packet = build_terminal_bench_goal_harness_access_packet(
             cli_bridge_available=True,
@@ -149,6 +155,8 @@ def main() -> int:
         )
         assert no_update["observed_after_worker_start"] is False, no_update
         assert no_update["worker_observation_proof"] is False, no_update
+        assert no_update["counter_trace_written"] is True, no_update
+        assert no_update["benchmark_run_checkpoint_written"] is True, no_update
 
         append_command = (
             contract["simulator_append_command"]
@@ -172,9 +180,29 @@ def main() -> int:
             contract["worker_observe_command"].replace("<worker-start-seq>", "1")
         )
         assert observed["observation_written"] is True, observed
+        assert observed["counter_trace_written"] is True, observed
+        assert observed["benchmark_run_checkpoint_written"] is True, observed
         assert observation.exists(), observed
+        assert counter_trace.exists(), observed
+        assert benchmark_run.exists(), observed
         assert_worker_observation(observed)
         assert_worker_observation(json.loads(observation.read_text(encoding="utf-8")))
+        trace_rows = [
+            json.loads(line)
+            for line in counter_trace.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        assert len(trace_rows) == 2, trace_rows
+        assert trace_rows[-1]["command"] == "active_user_observe", trace_rows
+        checkpoint = json.loads(benchmark_run.read_text(encoding="utf-8"))
+        assert checkpoint["schema_version"] == "benchmark_run_v0", checkpoint
+        assert checkpoint["worker_goal_harness_cli_call_total"] == 2, checkpoint
+        assert checkpoint["worker_bridge_outcome"]["worker_bridge_verified"] is True, checkpoint
+        assert (
+            checkpoint["worker_bridge_checkpoint"]["checkpoint_kind"]
+            == "active_user_observe"
+        ), checkpoint
+        assert_public_safe(checkpoint)
 
     print("worker-bridge-active-user-after-start-observation-smoke ok proof=true")
     return 0

--- a/examples/worker-bridge-active-user-feed-smoke.py
+++ b/examples/worker-bridge-active-user-feed-smoke.py
@@ -168,6 +168,8 @@ def main() -> int:
         root = Path(tmp)
         feed = root / "feed.jsonl"
         observation_path = root / "observation.json"
+        counter_trace_path = root / "counter-trace.jsonl"
+        benchmark_run_path = root / "worker-benchmark-run.json"
         feed.write_text(
             json.dumps(before_start, sort_keys=True) + "\n"
             + json.dumps(after_start, sort_keys=True)
@@ -191,14 +193,55 @@ def main() -> int:
                 "1",
                 "--observation-json",
                 str(observation_path),
+                "--counter-trace-json",
+                str(counter_trace_path),
+                "--benchmark-run-json",
+                str(benchmark_run_path),
                 "--format",
                 "json",
             ]
         )
         assert cli_observation["observation_written"] is True, cli_observation
+        assert cli_observation["counter_trace_written"] is True, cli_observation
+        assert (
+            cli_observation["benchmark_run_checkpoint_written"] is True
+        ), cli_observation
+        assert (
+            cli_observation["benchmark_run_checkpoint_schema_version"]
+            == "benchmark_run_v0"
+        ), cli_observation
         assert observation_path.exists(), cli_observation
+        assert counter_trace_path.exists(), cli_observation
+        assert benchmark_run_path.exists(), cli_observation
         assert_observation(cli_observation, observed=True)
         assert_public_safe(json.loads(observation_path.read_text(encoding="utf-8")))
+        counter_rows = [
+            json.loads(line)
+            for line in counter_trace_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        assert counter_rows == [
+            {
+                "classification": "active_user_observe_checkpoint",
+                "command": "active_user_observe",
+                "goal_id": "worker-bridge-active-user",
+                "kind": "goal_harness_cli_call",
+                "mode": "codex_goal_harness_active_worker",
+                "observed_after_worker_start": True,
+                "ok": True,
+                "worker_observation_proof": True,
+            }
+        ], counter_rows
+        checkpoint = json.loads(benchmark_run_path.read_text(encoding="utf-8"))
+        assert checkpoint["schema_version"] == "benchmark_run_v0", checkpoint
+        assert checkpoint["source_runner"] == "worker_bridge_active_user_observe", checkpoint
+        assert checkpoint["worker_goal_harness_cli_call_total"] == 1, checkpoint
+        assert checkpoint["worker_bridge_outcome"]["worker_bridge_verified"] is True, checkpoint
+        assert (
+            checkpoint["worker_bridge_checkpoint"]["checkpoint_kind"]
+            == "active_user_observe"
+        ), checkpoint
+        assert_public_safe(checkpoint)
 
         no_new_observation = run_cli_json(
             [

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -136,16 +136,21 @@ from .worker_bridge import (
     DEFAULT_ACTIVE_USER_SIMULATOR_PROMPT_JSON,
     GOAL_HARNESS_PROJECT_ROOT_PLACEHOLDER,
     GOAL_HARNESS_RUNTIME_ROOT_PLACEHOLDER,
+    append_worker_bridge_counter_trace_row,
     build_active_user_codex_simulator_contract,
     build_active_user_intervention,
     build_active_user_intervention_channel_contract,
     build_active_user_intervention_from_simulator_output,
     build_worker_bridge_benchmark_run,
+    build_worker_bridge_benchmark_run_from_counters,
     build_worker_bridge_install_contract,
+    build_worker_bridge_interaction_counters_from_trace,
     build_worker_bridge_outcome,
+    load_worker_bridge_counter_trace_file,
     observe_active_user_intervention_feed,
     render_worker_bridge_install_contract_markdown,
     write_active_user_observation_file,
+    write_worker_bridge_benchmark_run_file,
 )
 
 
@@ -668,6 +673,21 @@ def main(argv: list[str] | None = None) -> int:
         help="Worker-visible active-user observation JSON path.",
     )
     active_user_contract_parser.add_argument(
+        "--counter-trace-json",
+        default=DEFAULT_WORKER_BRIDGE_COUNTER_TRACE_JSON,
+        help="Worker-visible compact counter trace JSONL path.",
+    )
+    active_user_contract_parser.add_argument(
+        "--benchmark-run-json",
+        default=DEFAULT_WORKER_BRIDGE_BENCHMARK_RUN_JSON,
+        help="Worker-visible compact benchmark_run checkpoint JSON path.",
+    )
+    active_user_contract_parser.add_argument(
+        "--classification",
+        default="active_user_observe_checkpoint",
+        help="Compact classification label for observe checkpoints.",
+    )
+    active_user_contract_parser.add_argument(
         "--min-interval-seconds",
         type=int,
         default=300,
@@ -796,6 +816,39 @@ def main(argv: list[str] | None = None) -> int:
     active_user_observe_parser.add_argument(
         "--observation-json",
         help="Optional path to write the compact observation JSON.",
+    )
+    active_user_observe_parser.add_argument(
+        "--counter-trace-json",
+        help="Optional worker counter trace JSONL path to append active_user_observe.",
+    )
+    active_user_observe_parser.add_argument(
+        "--benchmark-run-json",
+        help="Optional compact worker benchmark_run checkpoint JSON path to write.",
+    )
+    active_user_observe_parser.add_argument(
+        "--goal-id",
+        default="worker-bridge-active-user",
+        help="Compact goal id label for optional counter/checkpoint writeback.",
+    )
+    active_user_observe_parser.add_argument(
+        "--bridge-mode",
+        default="codex_goal_harness_active_worker",
+        help="Compact worker bridge mode label for optional counter/checkpoint writeback.",
+    )
+    active_user_observe_parser.add_argument(
+        "--classification",
+        default="active_user_observe_checkpoint",
+        help="Compact classification label for optional counter/checkpoint writeback.",
+    )
+    active_user_observe_parser.add_argument(
+        "--task-id",
+        default="worker-bridge-active-user",
+        help="Compact task id label for optional benchmark_run checkpoint.",
+    )
+    active_user_observe_parser.add_argument(
+        "--trial-name",
+        default="worker-bridge-active-user-observe-checkpoint",
+        help="Compact trial name for optional benchmark_run checkpoint.",
     )
 
     promotion_gate_parser = sub.add_parser(
@@ -1711,6 +1764,9 @@ def main(argv: list[str] | None = None) -> int:
                     module=args.module,
                     feed_jsonl=args.feed_jsonl,
                     observation_json=args.observation_json,
+                    benchmark_run_json=args.benchmark_run_json,
+                    counter_trace_json=args.counter_trace_json,
+                    classification=args.classification,
                     min_interval_seconds=args.min_interval_seconds,
                     max_interventions_per_task=args.max_interventions_per_task,
                 )
@@ -1763,6 +1819,59 @@ def main(argv: list[str] | None = None) -> int:
                     payload["observation_written"] = write_active_user_observation_file(
                         args.observation_json,
                         payload,
+                    )
+                if args.counter_trace_json:
+                    payload["counter_trace_written"] = (
+                        append_worker_bridge_counter_trace_row(
+                            args.counter_trace_json,
+                            command="active_user_observe",
+                            ok=bool(payload.get("ok")),
+                            goal_id=args.goal_id,
+                            mode=args.bridge_mode,
+                            classification=args.classification,
+                            observed_after_worker_start=payload.get(
+                                "observed_after_worker_start"
+                            ),
+                            worker_observation_proof=payload.get(
+                                "worker_observation_proof"
+                            ),
+                        )
+                    )
+                if args.benchmark_run_json:
+                    trace_rows = load_worker_bridge_counter_trace_file(
+                        args.counter_trace_json
+                    )
+                    interaction_counters = (
+                        build_worker_bridge_interaction_counters_from_trace(
+                            trace_rows
+                        )
+                    )
+                    checkpoint = build_worker_bridge_benchmark_run_from_counters(
+                        interaction_counters,
+                        counter_trace_present=bool(trace_rows),
+                        source_runner="worker_bridge_active_user_observe",
+                        benchmark_id="worker-bridge-active-user@v0",
+                        job_name="goal_harness_active_user_observe_checkpoint",
+                        mode=args.bridge_mode,
+                        task_id=args.task_id,
+                        trial_name=args.trial_name,
+                    )
+                    checkpoint["worker_bridge_checkpoint"] = {
+                        "schema_version": "goal_harness_worker_bridge_checkpoint_v0",
+                        "checkpoint_kind": "active_user_observe",
+                        "interrupted": False,
+                        "trace_row_count": len(trace_rows),
+                        "raw_trace_recorded": False,
+                        "raw_paths_recorded": False,
+                    }
+                    payload["benchmark_run_checkpoint_written"] = (
+                        write_worker_bridge_benchmark_run_file(
+                            args.benchmark_run_json,
+                            checkpoint,
+                        )
+                    )
+                    payload["benchmark_run_checkpoint_schema_version"] = (
+                        checkpoint.get("schema_version")
                     )
         except Exception as exc:
             payload = {

--- a/goal_harness/worker_bridge.py
+++ b/goal_harness/worker_bridge.py
@@ -278,6 +278,9 @@ def build_active_user_intervention_channel_contract(
     module: str = DEFAULT_WORKER_BRIDGE_MODULE,
     feed_jsonl: str = DEFAULT_WORKER_BRIDGE_ACTIVE_USER_FEED_JSONL,
     observation_json: str = DEFAULT_WORKER_BRIDGE_ACTIVE_USER_OBSERVATION_JSON,
+    benchmark_run_json: str = DEFAULT_WORKER_BRIDGE_BENCHMARK_RUN_JSON,
+    counter_trace_json: str = DEFAULT_WORKER_BRIDGE_COUNTER_TRACE_JSON,
+    classification: str = "active_user_observe_checkpoint",
     min_interval_seconds: int = 300,
     max_interventions_per_task: int = 3,
 ) -> dict[str, Any]:
@@ -303,6 +306,9 @@ def build_active_user_intervention_channel_contract(
         f"--feed-jsonl {shlex.quote(feed_jsonl)} "
         "--worker-start-seq <worker-start-seq> "
         f"--observation-json {shlex.quote(observation_json)} "
+        f"--counter-trace-json {shlex.quote(counter_trace_json)} "
+        f"--benchmark-run-json {shlex.quote(benchmark_run_json)} "
+        f"--classification {shlex.quote(classification)} "
         "--format json"
     )
     simulator_append_command = (
@@ -321,6 +327,8 @@ def build_active_user_intervention_channel_contract(
         "mode": "audited_external_update_loop",
         "feed_jsonl": feed_jsonl,
         "observation_json": observation_json,
+        "benchmark_run_json": benchmark_run_json,
+        "counter_trace_json": counter_trace_json,
         "worker_observe_command": observe_command,
         "simulator_append_command": simulator_append_command,
         "worker_start_marker": {
@@ -753,6 +761,106 @@ def write_active_user_observation_file(
     return True
 
 
+def _compact_counter_trace_label(value: Any) -> str:
+    return str(value or "").strip().lower().replace("-", "_")
+
+
+def append_worker_bridge_counter_trace_row(
+    path: str | Path | None,
+    *,
+    command: str,
+    ok: bool,
+    goal_id: str,
+    mode: str,
+    classification: str,
+    observed_after_worker_start: bool | None = None,
+    worker_observation_proof: bool | None = None,
+) -> bool:
+    """Append one compact worker-side Goal Harness CLI call trace row."""
+
+    if not path:
+        return False
+    trace_path = Path(path)
+    row: dict[str, Any] = {
+        "kind": "goal_harness_cli_call",
+        "command": _compact_counter_trace_label(command),
+        "ok": bool(ok),
+        "goal_id": str(goal_id or "").strip() or "worker-bridge",
+        "mode": str(mode or "").strip() or DEFAULT_WORKER_BRIDGE_MODE,
+        "classification": (
+            str(classification or "").strip() or "worker_bridge_checkpoint"
+        ),
+    }
+    if observed_after_worker_start is not None:
+        row["observed_after_worker_start"] = bool(observed_after_worker_start)
+    if worker_observation_proof is not None:
+        row["worker_observation_proof"] = bool(worker_observation_proof)
+    try:
+        trace_path.parent.mkdir(parents=True, exist_ok=True)
+        with trace_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(row, ensure_ascii=True, sort_keys=True) + "\n")
+    except OSError:
+        return False
+    return True
+
+
+def load_worker_bridge_counter_trace_file(path: str | Path | None) -> list[dict[str, Any]]:
+    """Load compact worker-side counter trace rows, ignoring malformed rows."""
+
+    if not path:
+        return []
+    trace_path = Path(path)
+    if not trace_path.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    try:
+        for line in trace_path.read_text(encoding="utf-8").splitlines():
+            text = line.strip()
+            if not text:
+                continue
+            try:
+                row = json.loads(text)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(row, dict):
+                rows.append(row)
+    except OSError:
+        return []
+    return rows
+
+
+def build_worker_bridge_interaction_counters_from_trace(
+    trace_rows: list[dict[str, Any]] | None,
+) -> dict[str, Any]:
+    """Build generic compact interaction counters from worker bridge trace rows."""
+
+    goal_harness_cli_calls: dict[str, int] = {}
+    total = 0
+    for row in trace_rows or []:
+        if not isinstance(row, dict):
+            continue
+        kind = _compact_counter_trace_label(
+            row.get("kind") or row.get("type") or row.get("event")
+        )
+        command = _compact_counter_trace_label(row.get("command") or row.get("call"))
+        if kind and kind != "goal_harness_cli_call":
+            continue
+        if not command:
+            continue
+        total += 1
+        goal_harness_cli_calls[command] = goal_harness_cli_calls.get(command, 0) + 1
+    goal_harness_cli_calls["total"] = total
+    return {
+        "schema_version": "goal_harness_worker_bridge_interaction_counters_v0",
+        "goal_harness_cli_calls": goal_harness_cli_calls,
+        "trace_row_count": len(trace_rows or []),
+        "state_reads": goal_harness_cli_calls.get("active_user_observe", 0),
+        "state_writes": goal_harness_cli_calls.get("append_benchmark_run", 0),
+        "raw_trace_recorded": False,
+        "raw_paths_recorded": False,
+    }
+
+
 def build_worker_bridge_install_contract(
     *,
     project_root: str = GOAL_HARNESS_PROJECT_ROOT_PLACEHOLDER,
@@ -805,6 +913,9 @@ def build_worker_bridge_install_contract(
             module=module,
             feed_jsonl=active_user_feed_jsonl,
             observation_json=active_user_observation_json,
+            benchmark_run_json=benchmark_run_json,
+            counter_trace_json=counter_trace_json,
+            classification=classification,
         )
     )
     return {


### PR DESCRIPTION
## Summary
- make worker-bridge active-user-observe optionally append a compact counter trace row
- make the same observe call optionally write a compact benchmark_run checkpoint before final agent teardown
- expose checkpoint path overrides on the active-user contract CLI and cover the path in active-user smokes

## Validation
- python3 examples/worker-bridge-active-user-feed-smoke.py
- python3 examples/worker-bridge-active-user-after-start-observation-smoke.py
- python3 examples/worker-bridge-install-contract-smoke.py
- python3 examples/terminal-bench-codex-goal-harness-active-cli-bridge-smoke.py
- python3 examples/terminal-bench-codex-goal-harness-custom-agent-smoke.py
- python3 examples/terminal-bench-active-user-assisted-treatment-preflight-smoke.py
- python3 -m py_compile goal_harness/worker_bridge.py goal_harness/cli.py
- git diff --check
- goal-harness --format json check

No raw task text, private logs, trajectories, credentials, uploads, leaderboard action, or runtime state is included.