### PR TITLE
Preserve benchmark comparison claim boundaries

### DIFF
--- a/examples/benchmark-run-v0-append-cli-smoke.py
+++ b/examples/benchmark-run-v0-append-cli-smoke.py
@@ -16,7 +16,11 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from goal_harness.review_packet import build_review_packet  # noqa: E402
-from goal_harness.status import collect_status  # noqa: E402
+from goal_harness.status import (  # noqa: E402
+    benchmark_comparison_decision_note,
+    collect_status,
+    compact_benchmark_comparison,
+)
 
 
 GOAL_ID = "benchmark-append-cli-fixture"
@@ -173,9 +177,25 @@ def benchmark_comparison_event() -> dict[str, Any]:
         "both_success": True,
         "official_task_score_delta": 0.0,
         "control_plane_score_delta": 0.143,
+        "cost_delta_usd": 0.274,
         "with_goal_harness_overhead_ms": 12.5,
         "with_goal_harness_extra_writebacks": 3,
         "with_goal_harness_extra_spends": 3,
+        "failure_attribution_labels": ["verifier_platform_probe_failure"],
+        "claim_boundary": {
+            "leaderboard_claim_allowed": False,
+            "official_score_uplift_claim_allowed": False,
+            "assisted_collaboration_claim_allowed": True,
+            "raw_trace_excluded": True,
+            "credential_values_recorded": False,
+            "private_path_recorded": True,
+        },
+        "decision": {
+            "score_uplift": False,
+            "validation_enhancement_point": True,
+            "why": "Worker writeback and failure attribution improved while official score delta stayed zero.",
+            "raw_log_path": "/" + "tmp/private/raw.log",
+        },
         "result_refs": [
             {
                 "scenario_id": "without_goal_harness",
@@ -442,7 +462,19 @@ def main() -> None:
         assert comparison_summary["mode_pair"] == ["without_goal_harness", "with_goal_harness"], comparison_summary
         assert comparison_summary["official_task_score_delta"] == 0.0, comparison_summary
         assert comparison_summary["control_plane_score_delta"] == 0.143, comparison_summary
+        assert comparison_summary["cost_delta_usd"] == 0.274, comparison_summary
         assert comparison_summary["both_success"] is True, comparison_summary
+        assert comparison_summary["failure_attribution_labels"] == ["verifier_platform_probe_failure"], comparison_summary
+        assert comparison_summary["claim_boundary"] == {
+            "leaderboard_claim_allowed": False,
+            "official_score_uplift_claim_allowed": False,
+            "assisted_collaboration_claim_allowed": True,
+            "raw_trace_excluded": True,
+            "credential_values_recorded": False,
+        }, comparison_summary
+        assert comparison_summary["decision"]["score_uplift"] is False, comparison_summary
+        assert comparison_summary["decision"]["validation_enhancement_point"] is True, comparison_summary
+        assert "raw_log_path" not in json.dumps(comparison_summary["decision"], sort_keys=True), comparison_summary
         assert "raw_thread_path" not in comparison_summary, comparison_summary
         assert "raw_log_path" not in json.dumps(comparison_summary, sort_keys=True), comparison_summary
         assert_no_private_surface(comparison_summary)
@@ -453,10 +485,46 @@ def main() -> None:
         assert decision_note["evidence_layer"] == "control_plane_only", decision_note
         assert decision_note["official_task_score_delta"] == 0.0, decision_note
         assert decision_note["control_plane_score_delta"] == 0.143, decision_note
+        assert decision_note["failure_attribution_labels"] == ["verifier_platform_probe_failure"], decision_note
+        assert decision_note["validation_enhancement_point"] is True, decision_note
+        assert decision_note["score_uplift"] is False, decision_note
         assert "control-plane delta improved while official score delta stayed zero" in decision_note["may_claim"], decision_note
         assert "official leaderboard uplift" in decision_note["must_not_claim"], decision_note
         assert decision_note["report_section_hint"] == ["claim_boundary", "next_decision"], decision_note
         assert_no_private_surface(decision_note)
+
+        failure_comparison = compact_benchmark_comparison(
+            {
+                "schema_version": "benchmark_comparison_v0",
+                "task_id": "torch-tensor-parallelism",
+                "comparison_id": "torch_tensor_parallelism_failure_triage",
+                "benchmark_id": "terminal-bench@2.0",
+                "mode_pair": ["hardened_codex_baseline", "codex_goal_harness_active_user"],
+                "both_success": False,
+                "official_task_score_delta": 0.0,
+                "failure_attribution_labels": ["verifier_platform_probe_failure"],
+                "decision": {
+                    "score_uplift": False,
+                    "validation_enhancement_point": True,
+                    "why": "Treatment preserved worker writeback and failure attribution without changing official score.",
+                },
+                "claim_boundary": {
+                    "leaderboard_claim_allowed": False,
+                    "official_score_uplift_claim_allowed": False,
+                    "assisted_collaboration_claim_allowed": True,
+                    "raw_trace_excluded": True,
+                    "credential_values_recorded": False,
+                },
+            }
+        )
+        failure_note = benchmark_comparison_decision_note(failure_comparison)
+        assert failure_note["evidence_layer"] == "validation_enhancement_no_score_uplift", failure_note
+        assert failure_note["decision"] == "continue", failure_note
+        assert failure_note["failure_attribution_labels"] == ["verifier_platform_probe_failure"], failure_note
+        assert failure_note["validation_enhancement_point"] is True, failure_note
+        assert failure_note["score_uplift"] is False, failure_note
+        assert "official score uplift" in failure_note["must_not_claim"], failure_note
+        assert_no_private_surface(failure_note)
 
         index_records = [
             json.loads(line)

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -1550,6 +1550,7 @@ def compact_benchmark_comparison(run: dict[str, Any]) -> dict[str, Any] | None:
         "scenario_count",
         "official_task_score_delta",
         "control_plane_score_delta",
+        "cost_delta_usd",
         "with_goal_harness_overhead_ms",
         "with_goal_harness_extra_writebacks",
         "with_goal_harness_extra_spends",
@@ -1569,10 +1570,37 @@ def compact_benchmark_comparison(run: dict[str, Any]) -> dict[str, Any] | None:
         if isinstance(source.get(field), bool):
             compact[field] = source.get(field)
 
-    for field in ("metrics_compared", "interrupt_fixture_markers", "stop_conditions"):
+    for field in ("metrics_compared", "interrupt_fixture_markers", "stop_conditions", "failure_attribution_labels"):
         values = public_safe_compact_list(source.get(field), limit=MAX_BENCHMARK_RUN_LIST_ITEMS)
         if values:
             compact[field] = values
+
+    claim_boundary = source.get("claim_boundary")
+    if isinstance(claim_boundary, dict):
+        compact_claim_boundary: dict[str, bool] = {}
+        for field in (
+            "leaderboard_claim_allowed",
+            "official_score_uplift_claim_allowed",
+            "assisted_collaboration_claim_allowed",
+            "raw_trace_excluded",
+            "credential_values_recorded",
+        ):
+            if isinstance(claim_boundary.get(field), bool):
+                compact_claim_boundary[field] = claim_boundary[field]
+        if compact_claim_boundary:
+            compact["claim_boundary"] = compact_claim_boundary
+
+    decision = source.get("decision")
+    if isinstance(decision, dict):
+        compact_decision: dict[str, Any] = {}
+        for field in ("score_uplift", "validation_enhancement_point"):
+            if isinstance(decision.get(field), bool):
+                compact_decision[field] = decision[field]
+        why = public_safe_compact_text(decision.get("why"), limit=240)
+        if why:
+            compact_decision["why"] = why
+        if compact_decision:
+            compact["decision"] = compact_decision
 
     result_refs: list[dict[str, Any]] = []
     for item in source.get("result_refs") or []:
@@ -1622,6 +1650,21 @@ def benchmark_comparison_decision_note(comparison: dict[str, Any] | None) -> dic
     both_success = comparison.get("both_success") if isinstance(comparison.get("both_success"), bool) else None
     submit_ready = comparison.get("ready_to_submit_leaderboard")
     real_ready = comparison.get("ready_to_run_real_benchmark")
+    decision_summary = comparison.get("decision") if isinstance(comparison.get("decision"), dict) else {}
+    validation_enhancement = (
+        decision_summary.get("validation_enhancement_point")
+        if isinstance(decision_summary.get("validation_enhancement_point"), bool)
+        else None
+    )
+    score_uplift = (
+        decision_summary.get("score_uplift")
+        if isinstance(decision_summary.get("score_uplift"), bool)
+        else None
+    )
+    failure_labels = public_safe_compact_list(
+        comparison.get("failure_attribution_labels"),
+        limit=MAX_BENCHMARK_RUN_LIST_ITEMS,
+    )
 
     evidence_layer = "comparison_summary"
     decision = "repeat"
@@ -1647,6 +1690,12 @@ def benchmark_comparison_decision_note(comparison: dict[str, Any] | None) -> dic
         minimum_next_evidence = "verify benchmark protocol, submit eligibility, and side-effect audit before claiming official uplift"
         may_claim.append("official score candidate exists")
         must_not_claim.append("official uplift before protocol and submit-eligibility verification")
+    elif official_delta == 0 and validation_enhancement is True and score_uplift is False:
+        evidence_layer = "validation_enhancement_no_score_uplift"
+        decision = "continue"
+        minimum_next_evidence = "repeat on a stronger target or harden the recorded failure-attribution/writeback path"
+        may_claim.append("validation or failure-attribution evidence improved while official score delta stayed zero")
+        must_not_claim.append("official score uplift")
     elif both_success is False:
         evidence_layer = "failure_analysis"
         decision = "repeat"
@@ -1681,6 +1730,12 @@ def benchmark_comparison_decision_note(comparison: dict[str, Any] | None) -> dic
         note["control_plane_score_delta"] = control_delta
     elif isinstance(comparison.get("control_plane_score_delta"), str):
         note["control_plane_score_delta"] = public_safe_compact_text(comparison.get("control_plane_score_delta"), limit=120)
+    if failure_labels:
+        note["failure_attribution_labels"] = failure_labels
+    if validation_enhancement is not None:
+        note["validation_enhancement_point"] = validation_enhancement
+    if score_uplift is not None:
+        note["score_uplift"] = score_uplift
     return note
 
 


### PR DESCRIPTION
## Summary
- preserve public-safe benchmark comparison fields for cost delta, failure-attribution labels, claim boundary, and decision summary
- add a validation_enhancement_no_score_uplift decision branch so 0.0 score-delta evidence is not mislabeled as uplift
- extend the benchmark append smoke fixture to assert unsafe raw-log fields are pruned

## Validation
- python3 examples/benchmark-run-v0-append-cli-smoke.py
- python3 -m py_compile goal_harness/status.py examples/benchmark-run-v0-append-cli-smoke.py
- git diff --check
- goal-harness doctor
- goal-harness-canary doctor
- goal-harness --format json check

## Boundary
- no raw task text, raw logs, trajectories, hidden tests, credentials, uploads, or leaderboard claims included
