### PR TITLE
Track worker submit boundary mismatches

### DIFF
--- a/examples/terminal-bench-harbor-runner-ingest-smoke.py
+++ b/examples/terminal-bench-harbor-runner-ingest-smoke.py
@@ -393,7 +393,11 @@ def write_verifier_platform_probe_failure_fixture(root: Path) -> Path:
     (trial_dir / "agent" / "trajectory.json").write_text("{}\n", encoding="utf-8")
     write_json(
         trial_dir / "agent" / "goal-harness-worker-benchmark-run.json",
-        {"schema_version": "benchmark_run_v0"},
+        {
+            "schema_version": "benchmark_run_v0",
+            "submit_eligible": True,
+            "leaderboard_evidence": False,
+        },
     )
     (trial_dir / "agent" / "goal-harness-counter-trace.jsonl").write_text(
         json.dumps({"command": "check", "ok": True}, sort_keys=True) + "\n",
@@ -849,6 +853,10 @@ def main() -> None:
     assert payload["worker_counter_trace_trial_count"] == 1, payload
     assert payload["worker_benchmark_run_file_count"] == 1, payload
     assert payload["worker_benchmark_run_schema_ok_count"] == 1, payload
+    assert payload["worker_submit_eligible_mismatch_count"] == 0, payload
+    assert (
+        payload["worker_submit_eligible_mismatch_reason"] == "none"
+    ), payload
     assert payload["pre_worker_agent_setup_failure_count"] == 1, payload
     assert payload["interaction_counters"]["goal_harness_cli_calls"]["append_benchmark_run"] == 2, payload
     assert payload["interaction_counters"]["append_benchmark_run_success_count"] == 1, payload
@@ -856,6 +864,11 @@ def main() -> None:
     assert payload["interaction_counters"]["worker_counter_trace_trial_count"] == 1, payload
     assert payload["interaction_counters"]["worker_benchmark_run_file_count"] == 1, payload
     assert payload["interaction_counters"]["worker_benchmark_run_schema_ok_count"] == 1, payload
+    assert payload["interaction_counters"]["worker_submit_eligible_mismatch_count"] == 0, payload
+    assert (
+        payload["interaction_counters"]["worker_submit_eligible_mismatch_reason"]
+        == "none"
+    ), payload
     assert payload["interaction_counters"]["pre_worker_agent_setup_failure_count"] == 1, payload
     assert payload["interaction_counters"]["case_result_writeback"] == "worker_bridge_append_benchmark_run_dry_run", payload
     overhead = payload["overhead_attribution_counters"]
@@ -878,6 +891,8 @@ def main() -> None:
     assert overhead["goal_harness_required_cli_call_total"] == 3, overhead
     assert overhead["goal_harness_optional_context_cli_call_total"] == 3, overhead
     assert overhead["append_benchmark_run_success_count"] == 1, overhead
+    assert overhead["worker_submit_eligible_mismatch_count"] == 0, overhead
+    assert overhead["worker_submit_eligible_mismatch_reason"] == "none", overhead
     assert payload["official_task_score"]["value"] == 1.0, payload
     assert payload["progress"]["n_errored_trials"] == 2, payload
     assert payload["trials"][0]["exception_type"] == "AgentTimeoutError", payload
@@ -907,11 +922,21 @@ def main() -> None:
     assert policy["expected_true_long_task_bar_met"] is False, policy
     assert policy["true_long_task_bar_met"] is False, policy
     assert payload["worker_bridge_outcome"]["runner_side_writeback_guaranteed"] is True, payload
+    assert (
+        payload["worker_bridge_outcome"]["worker_submit_eligible_mismatch_observed"]
+        is False
+    ), payload
+    assert (
+        payload["validation"]["worker_submit_eligible_matches_runner_boundary"]
+        is True
+    ), payload
     compact = compact_benchmark_run(payload)
     assert compact and compact["worker_goal_harness_cli_call_total"] == 6, compact
     assert compact["worker_counter_trace_trial_count"] == 1, compact
     assert compact["worker_benchmark_run_file_count"] == 1, compact
     assert compact["worker_benchmark_run_schema_ok_count"] == 1, compact
+    assert compact["worker_submit_eligible_mismatch_count"] == 0, compact
+    assert compact["worker_submit_eligible_mismatch_reason"] == "none", compact
     assert compact["pre_worker_agent_setup_failure_count"] == 1, compact
     assert compact["interaction_counters"]["append_benchmark_run_success_count"] == 1, compact
     assert compact["interaction_counters"]["append_benchmark_run_schema_rejected_count"] == 1, compact
@@ -925,6 +950,7 @@ def main() -> None:
     ), compact_overhead
     assert compact_overhead["goal_harness_cli_call_total"] == 6, compact_overhead
     assert compact_overhead["worker_bridge_event_count"] == 6, compact_overhead
+    assert compact_overhead["worker_submit_eligible_mismatch_count"] == 0, compact_overhead
     assert compact["trials"][0]["exception_type"] == "AgentTimeoutError", compact
     compact_setup_trial = next(
         trial for trial in compact["trials"] if trial["task_id"] == "fix-code-vulnerability"
@@ -1155,6 +1181,32 @@ def main() -> None:
     ), platform_payload
     assert platform_payload["verifier_dependency_failure_count"] == 0, platform_payload
     assert platform_payload["verifier_failure_attribution_count"] == 1, platform_payload
+    assert platform_payload["submit_eligible"] is False, platform_payload
+    assert platform_payload["worker_submit_eligible_mismatch_count"] == 1, platform_payload
+    assert (
+        platform_payload["worker_submit_eligible_mismatch_reason"]
+        == "worker_file_submit_eligible_true_under_runner_no_upload_boundary"
+    ), platform_payload
+    assert (
+        platform_payload["validation"]["worker_submit_eligible_matches_runner_boundary"]
+        is False
+    ), platform_payload
+    assert (
+        platform_payload["interaction_counters"]["worker_submit_eligible_mismatch_count"]
+        == 1
+    ), platform_payload
+    assert (
+        platform_payload["overhead_attribution_counters"][
+            "worker_submit_eligible_mismatch_count"
+        ]
+        == 1
+    ), platform_payload
+    assert (
+        platform_payload["worker_bridge_outcome"][
+            "worker_submit_eligible_mismatch_observed"
+        ]
+        is True
+    ), platform_payload
     assert "verifier_platform_probe_failure" in platform_payload[
         "failure_attribution_labels"
     ], platform_payload
@@ -1178,6 +1230,20 @@ def main() -> None:
     ), platform_compact
     assert platform_compact["verifier_dependency_failure_count"] == 0, platform_compact
     assert platform_compact["verifier_failure_attribution_count"] == 1, platform_compact
+    assert platform_compact["worker_submit_eligible_mismatch_count"] == 1, platform_compact
+    assert (
+        platform_compact["worker_submit_eligible_mismatch_reason"]
+        == "worker_file_submit_eligible_true_under_runner_no_upload_boundary"
+    ), platform_compact
+    assert "worker_submit_eligible_matches_runner_boundary" in platform_compact[
+        "validation"
+    ]["failed_checks"], platform_compact
+    assert (
+        platform_compact["worker_bridge_outcome"][
+            "worker_submit_eligible_mismatch_observed"
+        ]
+        is True
+    ), platform_compact
     assert "verifier_platform_probe_failure" in platform_compact[
         "failure_attribution_labels"
     ], platform_compact

--- a/goal_harness/benchmark.py
+++ b/goal_harness/benchmark.py
@@ -934,6 +934,7 @@ def _terminal_bench_overhead_attribution_counters(
     worker_counter_trace_trial_count: int,
     worker_benchmark_run_file_count: int,
     worker_benchmark_run_schema_ok_count: int,
+    worker_submit_eligible_mismatch_count: int,
     worker_bridge_writeback_loss_count: int,
     pre_worker_agent_setup_failure_count: int,
     codex_runtime_goal_tool_trial_count: int,
@@ -1009,6 +1010,12 @@ def _terminal_bench_overhead_attribution_counters(
         "worker_counter_trace_trial_count": worker_counter_trace_trial_count,
         "worker_benchmark_run_file_count": worker_benchmark_run_file_count,
         "worker_benchmark_run_schema_ok_count": worker_benchmark_run_schema_ok_count,
+        "worker_submit_eligible_mismatch_count": worker_submit_eligible_mismatch_count,
+        "worker_submit_eligible_mismatch_reason": (
+            "worker_file_submit_eligible_true_under_runner_no_upload_boundary"
+            if worker_submit_eligible_mismatch_count
+            else "none"
+        ),
         "worker_bridge_writeback_loss_count": worker_bridge_writeback_loss_count,
         "pre_worker_agent_setup_failure_count": pre_worker_agent_setup_failure_count,
         "codex_runtime_goal_tool_trial_count": codex_runtime_goal_tool_trial_count,
@@ -1054,6 +1061,7 @@ def build_terminal_bench_harbor_result_benchmark_run(
     job_result = _load_json_object(job_path / "result.json")
     stats = job_result.get("stats") if isinstance(job_result.get("stats"), dict) else {}
     invocation = lock.get("invocation") if isinstance(lock.get("invocation"), list) else []
+    no_upload_requested = "--upload" not in invocation and "upload" not in invocation
     lock_trials = lock.get("trials") if isinstance(lock.get("trials"), list) else []
     first_lock_trial = lock_trials[0] if lock_trials and isinstance(lock_trials[0], dict) else {}
     task_config = first_lock_trial.get("task") if isinstance(first_lock_trial.get("task"), dict) else {}
@@ -1107,6 +1115,7 @@ def build_terminal_bench_harbor_result_benchmark_run(
     worker_counter_trace_trial_count = 0
     worker_benchmark_run_file_count = 0
     worker_benchmark_run_schema_ok_count = 0
+    worker_submit_eligible_mismatch_count = 0
     pre_worker_agent_setup_failure_count = 0
     verifier_failure_attribution_count = 0
     verifier_dependency_failure_count = 0
@@ -1157,6 +1166,11 @@ def build_terminal_bench_harbor_result_benchmark_run(
             worker_benchmark_run = _load_json_object(worker_benchmark_run_path)
             if _is_compactable_benchmark_run_v0(worker_benchmark_run):
                 worker_benchmark_run_schema_ok_count += 1
+                if (
+                    no_upload_requested
+                    and worker_benchmark_run.get("submit_eligible") is True
+                ):
+                    worker_submit_eligible_mismatch_count += 1
         trial_reward_value = _numeric_reward_value(rewards)
         verifier_attribution = (
             _terminal_bench_verifier_failure_attribution(trial_dir)
@@ -1221,6 +1235,9 @@ def build_terminal_bench_harbor_result_benchmark_run(
         interaction_counters["worker_benchmark_run_schema_ok_count"] = (
             worker_benchmark_run_schema_ok_count
         )
+        interaction_counters["worker_submit_eligible_mismatch_count"] = (
+            worker_submit_eligible_mismatch_count
+        )
         interaction_counters["pre_worker_agent_setup_failure_count"] = (
             pre_worker_agent_setup_failure_count
         )
@@ -1264,12 +1281,20 @@ def build_terminal_bench_harbor_result_benchmark_run(
         )
     else:
         worker_bridge_writeback_loss_reason = "none"
+    worker_submit_eligible_mismatch_reason = (
+        "worker_file_submit_eligible_true_under_runner_no_upload_boundary"
+        if worker_submit_eligible_mismatch_count
+        else "none"
+    )
     if interaction_counters:
         interaction_counters["worker_bridge_writeback_loss_count"] = (
             worker_bridge_writeback_loss_count
         )
         interaction_counters["worker_bridge_writeback_loss_reason"] = (
             worker_bridge_writeback_loss_reason
+        )
+        interaction_counters["worker_submit_eligible_mismatch_reason"] = (
+            worker_submit_eligible_mismatch_reason
         )
     wall_time_seconds = _iso_duration_seconds(
         job_result.get("started_at"),
@@ -1291,13 +1316,12 @@ def build_terminal_bench_harbor_result_benchmark_run(
         worker_counter_trace_trial_count=worker_counter_trace_trial_count,
         worker_benchmark_run_file_count=worker_benchmark_run_file_count,
         worker_benchmark_run_schema_ok_count=worker_benchmark_run_schema_ok_count,
+        worker_submit_eligible_mismatch_count=worker_submit_eligible_mismatch_count,
         worker_bridge_writeback_loss_count=worker_bridge_writeback_loss_count,
         pre_worker_agent_setup_failure_count=pre_worker_agent_setup_failure_count,
         codex_runtime_goal_tool_trial_count=codex_runtime_goal_tool_trial_count,
         trace_publicness=trace_publicness,
     )
-    no_upload_requested = "--upload" not in invocation and "upload" not in invocation
-
     validation = {
         "job_lock_present": (job_path / "lock.json").exists(),
         "job_result_present": (job_path / "result.json").exists(),
@@ -1319,6 +1343,9 @@ def build_terminal_bench_harbor_result_benchmark_run(
         ),
         "worker_benchmark_run_present_for_traced_trials": (
             worker_benchmark_run_file_count >= worker_counter_trace_trial_count
+        ),
+        "worker_submit_eligible_matches_runner_boundary": (
+            worker_submit_eligible_mismatch_count == 0
         ),
         "pre_worker_agent_setup_failures_classified": True,
         "verifier_failure_attribution_public_safe": True,
@@ -1370,6 +1397,8 @@ def build_terminal_bench_harbor_result_benchmark_run(
         "worker_counter_trace_trial_count": worker_counter_trace_trial_count,
         "worker_benchmark_run_file_count": worker_benchmark_run_file_count,
         "worker_benchmark_run_schema_ok_count": worker_benchmark_run_schema_ok_count,
+        "worker_submit_eligible_mismatch_count": worker_submit_eligible_mismatch_count,
+        "worker_submit_eligible_mismatch_reason": worker_submit_eligible_mismatch_reason,
         "worker_bridge_writeback_loss_count": worker_bridge_writeback_loss_count,
         "worker_bridge_writeback_loss_reason": worker_bridge_writeback_loss_reason,
         "pre_worker_agent_setup_failure_count": pre_worker_agent_setup_failure_count,
@@ -1443,6 +1472,11 @@ def build_terminal_bench_harbor_result_benchmark_run(
             "worker_bridge_writeback_loss_observed": bool(
                 worker_bridge_writeback_loss_count
             ),
+            "worker_submit_eligible_mismatch_observed": bool(
+                worker_submit_eligible_mismatch_count
+            ),
+            "worker_submit_eligible_mismatch_count": worker_submit_eligible_mismatch_count,
+            "worker_submit_eligible_mismatch_reason": worker_submit_eligible_mismatch_reason,
             "worker_bridge_writeback_loss_count": worker_bridge_writeback_loss_count,
             "worker_bridge_writeback_loss_reason": worker_bridge_writeback_loss_reason,
             "worker_goal_harness_cli_call_total": worker_cli_total,

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -434,6 +434,7 @@ def _compact_benchmark_interaction_counters(value: Any) -> dict[str, Any]:
         "worker_counter_trace_trial_count",
         "worker_benchmark_run_file_count",
         "worker_benchmark_run_schema_ok_count",
+        "worker_submit_eligible_mismatch_count",
         "worker_bridge_writeback_loss_count",
         "pre_worker_agent_setup_failure_count",
         "codex_runtime_goal_tool_trial_count",
@@ -443,6 +444,7 @@ def _compact_benchmark_interaction_counters(value: Any) -> dict[str, Any]:
     for field in (
         "case_result_writeback",
         "counter_trust_level",
+        "worker_submit_eligible_mismatch_reason",
         "worker_bridge_writeback_loss_reason",
     ):
         text = public_safe_compact_text(value.get(field), limit=100)
@@ -500,6 +502,7 @@ def _compact_benchmark_overhead_attribution_counters(value: Any) -> dict[str, An
         "worker_counter_trace_trial_count",
         "worker_benchmark_run_file_count",
         "worker_benchmark_run_schema_ok_count",
+        "worker_submit_eligible_mismatch_count",
         "worker_bridge_writeback_loss_count",
         "pre_worker_agent_setup_failure_count",
         "codex_runtime_goal_tool_trial_count",
@@ -515,6 +518,11 @@ def _compact_benchmark_overhead_attribution_counters(value: Any) -> dict[str, An
         raw = value.get(field)
         if isinstance(raw, (int, float)) and not isinstance(raw, bool):
             compact[field] = raw
+
+    for field in ("worker_submit_eligible_mismatch_reason",):
+        text = public_safe_compact_text(value.get(field), limit=160)
+        if text:
+            compact[field] = text
 
     for field in ("goal_harness_cli_calls", "codex_runtime_goal_tool_calls"):
         calls = _compact_numeric_map(value.get(field))
@@ -932,6 +940,7 @@ def _compact_worker_bridge_outcome(value: Any) -> dict[str, Any]:
         "trace_publicness",
         "next_action",
         "score_failure_attribution",
+        "worker_submit_eligible_mismatch_reason",
         "worker_bridge_writeback_loss_reason",
     ):
         text = public_safe_compact_text(value.get(field), limit=160)
@@ -947,6 +956,7 @@ def _compact_worker_bridge_outcome(value: Any) -> dict[str, Any]:
         "raw_trace_recorded",
         "credential_values_recorded",
         "runner_side_writeback_guaranteed",
+        "worker_submit_eligible_mismatch_observed",
         "worker_bridge_writeback_loss_observed",
     ):
         if isinstance(value.get(field), bool):
@@ -954,6 +964,7 @@ def _compact_worker_bridge_outcome(value: Any) -> dict[str, Any]:
     for field in (
         "worker_goal_harness_cli_call_total",
         "required_worker_goal_harness_cli_call_total_min",
+        "worker_submit_eligible_mismatch_count",
         "worker_bridge_writeback_loss_count",
         "pre_worker_agent_setup_failure_count",
         "verifier_failure_attribution_count",
@@ -1078,6 +1089,7 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
         "trace_publicness",
         "first_blocker",
         "score_failure_attribution",
+        "worker_submit_eligible_mismatch_reason",
         "worker_bridge_writeback_loss_reason",
     ):
         value = public_safe_compact_text(source.get(field), limit=140)
@@ -1121,6 +1133,7 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
         "worker_counter_trace_trial_count",
         "worker_benchmark_run_file_count",
         "worker_benchmark_run_schema_ok_count",
+        "worker_submit_eligible_mismatch_count",
         "worker_bridge_writeback_loss_count",
         "pre_worker_agent_setup_failure_count",
         "verifier_failure_attribution_count",


### PR DESCRIPTION
## Summary
- detect worker benchmark-run files that claim submit_eligible=true under runner no-upload invocations
- carry the mismatch into validation, interaction counters, overhead counters, compact benchmark runs, and worker bridge outcome
- add harbor ingest smoke coverage for both no-mismatch and mismatch paths

## Validation
- python3 -m py_compile goal_harness/benchmark.py goal_harness/status.py examples/terminal-bench-harbor-runner-ingest-smoke.py
- python3 examples/terminal-bench-harbor-runner-ingest-smoke.py
- git diff --check
- goal-harness --format json check

## Boundary
- excluded .local state, private benchmark artifacts, raw task text, raw logs, trajectories, hidden tests, transcripts, and credential values
- no leaderboard upload or submit path involved