### PR TITLE
Add ALE result report append CLI

### DIFF
--- a/examples/agents-last-exam-triage-smoke.py
+++ b/examples/agents-last-exam-triage-smoke.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+import subprocess
 import sys
 import tempfile
 from typing import Any
@@ -29,6 +30,7 @@ SCHEMA = "agents_last_exam_triage_v0"
 BENCHMARK_ID = "agents-last-exam"
 ARXIV_ID = "2606.05405"
 XHS_NOTE_ID = "6a29525a0000000022023914"
+GOAL_ID = "agents-last-exam-result-append-cli-fixture"
 
 REQUIRED_DOC_SNIPPETS = [
     "Agents' Last Exam Triage V0",
@@ -94,6 +96,25 @@ def assert_public_safe(value: Any) -> None:
     leaked = [marker for marker in FORBIDDEN_TEXT if marker in text]
     assert not leaked, leaked
     assert len(text) < 10000, len(text)
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def run_cli(args: list[str]) -> dict[str, Any]:
+    result = subprocess.run(
+        [sys.executable, "-m", "goal_harness.cli", *args],
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    payload = json.loads(result.stdout)
+    assert isinstance(payload, dict), payload
+    return payload
 
 
 def assert_doc_contract() -> None:
@@ -186,6 +207,52 @@ def write_synthetic_ale_run(root: Path) -> Path:
     return run_dir
 
 
+def write_cli_fixture(root: Path) -> tuple[Path, Path, Path]:
+    project = root / "project"
+    runtime = root / "runtime"
+    state_file = f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    registry_path = project / ".goal-harness" / "registry.json"
+    run_dir = write_synthetic_ale_run(root)
+
+    (project / Path(state_file).parent).mkdir(parents=True, exist_ok=True)
+    (project / state_file).write_text(
+        "---\n"
+        "status: active-read-only\n"
+        "updated_at: 2026-06-11T00:00:00+00:00\n"
+        "---\n\n"
+        "# Agents Last Exam Result Append CLI Fixture\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] Append compact ALE result report through the CLI.\n\n"
+        "## Next Action\n\n"
+        "- Inspect the appended compact ALE result projection.\n",
+        encoding="utf-8",
+    )
+    write_json(
+        registry_path,
+        {
+            "schema_version": 1,
+            "updated_at": "2026-06-11T00:00:00+00:00",
+            "common_runtime_root": str(runtime),
+            "goals": [
+                {
+                    "id": GOAL_ID,
+                    "domain": "benchmark-report-projection",
+                    "status": "active-read-only",
+                    "repo": str(project),
+                    "state_file": state_file,
+                    "adapter": {
+                        "kind": "harness_self_improvement",
+                        "status": "connected-read-only",
+                    },
+                    "quota": {"compute": 1.0, "window_hours": 24},
+                    "authority_sources": [],
+                }
+            ],
+        },
+    )
+    return registry_path, runtime, run_dir
+
+
 def assert_ale_result_ingest_contract() -> None:
     with tempfile.TemporaryDirectory(prefix="goal-harness-ale-ingest-") as tmp:
         run_dir = write_synthetic_ale_run(Path(tmp))
@@ -225,11 +292,76 @@ def assert_ale_result_ingest_contract() -> None:
     assert_public_safe(note)
 
 
+def assert_ale_result_append_cli() -> None:
+    with tempfile.TemporaryDirectory(prefix="goal-harness-ale-append-cli-") as tmp:
+        registry_path, runtime, run_dir = write_cli_fixture(Path(tmp))
+        index_path = runtime / "goals" / GOAL_ID / "runs" / "index.jsonl"
+        args = [
+            "--registry",
+            str(registry_path),
+            "--runtime-root",
+            str(runtime),
+            "--format",
+            "json",
+            "history",
+            "append-agents-last-exam-result-report",
+            "--goal-id",
+            GOAL_ID,
+            "--agents-last-exam-run-dir",
+            str(run_dir),
+            "--report-id",
+            "agents-last-exam-cli-append-smoke",
+            "--delivery-batch-scale",
+            "implementation",
+            "--delivery-outcome",
+            "primary_goal_outcome",
+            "--no-global-sync",
+        ]
+
+        dry_run = run_cli(args)
+        assert dry_run["ok"], dry_run
+        assert dry_run["dry_run"] is True, dry_run
+        assert dry_run["appended"] is False, dry_run
+        assert not index_path.exists(), index_path
+        assert dry_run["classification"] == "agents_last_exam_result_report_v0", dry_run
+        assert dry_run["benchmark_report_source"]["raw_surfaces_excluded"] is True, dry_run
+        assert_public_safe(dry_run["benchmark_experiment_report"])
+        assert_public_safe(dry_run["benchmark_report_source"])
+
+        appended = run_cli([*args, "--execute"])
+        assert appended["ok"], appended
+        assert appended["dry_run"] is False, appended
+        assert appended["appended"] is True, appended
+        assert index_path.exists(), index_path
+        assert appended["classification"] == "agents_last_exam_result_report_v0", appended
+        assert appended["benchmark_report_source"]["raw_surface_content_recorded"] is False, appended
+        assert_public_safe(appended["benchmark_experiment_report"])
+        assert_public_safe(appended["benchmark_report_source"])
+
+        records = [
+            json.loads(line)
+            for line in index_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        assert len(records) == 1, records
+        record = records[0]
+        assert record["classification"] == "agents_last_exam_result_report_v0", record
+        report = record["benchmark_experiment_report"]
+        assert report["schema_version"] == "benchmark_experiment_report_v0", report
+        assert report["experiment_identity"]["report_id"] == "agents-last-exam-cli-append-smoke", report
+        assert report["experiment_identity"]["benchmark_id"] == BENCHMARK_ID, report
+        assert report["official_score"]["submit_eligible"] is False, report
+        assert report["official_score"]["leaderboard_evidence"] is False, report
+        assert "single_arm_no_delta" in report["negative_results"]["negative_evidence_layers"], report
+        assert_public_safe(report)
+
+
 def main() -> None:
     assert_doc_contract()
     payload = triage_payload()
     assert_triage_payload(payload)
     assert_ale_result_ingest_contract()
+    assert_ale_result_append_cli()
     print(
         "agents-last-exam-triage-smoke ok "
         f"benchmark={payload['benchmark_id']} "

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -24,6 +24,7 @@ from .benchmark import (
     TERMINAL_BENCH_DEFAULT_TASK,
     TERMINAL_BENCH_HARDENED_CODEX_BASELINE_PREFLIGHT_MODE,
     TERMINAL_BENCH_MODES,
+    build_agents_last_exam_result_benchmark_report,
     build_terminal_bench_benchmark_run,
     build_terminal_bench_harbor_result_benchmark_run,
     collect_terminal_bench_goal_harness_cli_bridge_trace,
@@ -949,14 +950,16 @@ def main(argv: list[str] | None = None) -> int:
             "append-benchmark-result",
             "append-benchmark-comparison",
             "append-benchmark-report",
+            "append-agents-last-exam-result-report",
             "append-active-user-assisted-pilot",
             "inspect-index-duplicates",
             "repair-index-duplicates",
         ],
         help=(
             "Append a compact benchmark_run_v0, benchmark_result_v0, benchmark_comparison_v0, "
-            "benchmark_experiment_report_v0, or active_user_assisted_pilot_v0 event; inspect "
-            "duplicate run-index identities; or repair safe duplicate index rows."
+            "benchmark_experiment_report_v0, ALE compact result report, or "
+            "active_user_assisted_pilot_v0 event; inspect duplicate run-index identities; "
+            "or repair safe duplicate index rows."
         ),
     )
     history_parser.add_argument("--goal-id", help="Only show one goal.")
@@ -976,6 +979,19 @@ def main(argv: list[str] | None = None) -> int:
     history_parser.add_argument(
         "--benchmark-report-json",
         help="Path to a benchmark_experiment_report_v0 JSON object. Use '-' to read stdin.",
+    )
+    history_parser.add_argument(
+        "--agents-last-exam-run-dir",
+        help=(
+            "Path to an existing Agents' Last Exam run directory. The ingest reads "
+            "only run.json, eval_result.json, and events.jsonl; raw trajectory, "
+            "origin_log, output, task bodies, screenshots, credentials, and local "
+            "absolute paths are excluded."
+        ),
+    )
+    history_parser.add_argument(
+        "--report-id",
+        help="Optional public-safe report id for append-agents-last-exam-result-report.",
     )
     history_parser.add_argument(
         "--active-user-pilot-json",
@@ -2499,6 +2515,75 @@ def main(argv: list[str] | None = None) -> int:
                     "runtime_root": args.runtime_root,
                     "goal_id": args.goal_id,
                     "classification": args.classification or "benchmark_experiment_report_v0",
+                    "error": str(exc),
+                }
+            print_payload(payload, args.format, render_benchmark_experiment_report_append_markdown)
+            return 0 if payload.get("ok") else 1
+
+        if args.history_action == "append-agents-last-exam-result-report":
+            try:
+                if args.dry_run and args.execute:
+                    raise ValueError(
+                        "history append-agents-last-exam-result-report accepts either --dry-run or --execute, not both"
+                    )
+                if not args.goal_id:
+                    raise ValueError("history append-agents-last-exam-result-report requires --goal-id")
+                if not args.agents_last_exam_run_dir:
+                    raise ValueError(
+                        "history append-agents-last-exam-result-report requires --agents-last-exam-run-dir"
+                    )
+
+                benchmark_report_input = build_agents_last_exam_result_benchmark_report(
+                    Path(args.agents_last_exam_run_dir).expanduser(),
+                    report_id=args.report_id,
+                )
+                benchmark_report = compact_benchmark_experiment_report(benchmark_report_input)
+                if not benchmark_report:
+                    raise ValueError(
+                        "--agents-last-exam-run-dir did not produce a compactable benchmark_experiment_report_v0 object"
+                    )
+
+                dry_run = not bool(args.execute)
+                payload = append_benchmark_experiment_report(
+                    registry_path=registry_path,
+                    runtime_root_override=args.runtime_root,
+                    goal_id=args.goal_id,
+                    benchmark_experiment_report=benchmark_report,
+                    classification=args.classification or "agents_last_exam_result_report_v0",
+                    recommended_action=args.recommended_action,
+                    delivery_batch_scale=args.delivery_batch_scale,
+                    delivery_outcome=args.delivery_outcome,
+                    dry_run=dry_run,
+                )
+                payload["benchmark_report_source"] = {
+                    "kind": "agents_last_exam_run_dir",
+                    "raw_surfaces_excluded": True,
+                    "raw_surface_content_recorded": False,
+                    "local_paths_recorded": False,
+                }
+                if args.no_global_sync:
+                    payload["global_sync"] = {
+                        "ok": True,
+                        "dry_run": dry_run,
+                        "skipped": True,
+                        "reason": "disabled by --no-global-sync",
+                    }
+                else:
+                    payload["global_sync"] = sync_project_registry_to_global(
+                        registry_path=registry_path,
+                        runtime_root_override=args.runtime_root,
+                        goal_id=args.goal_id,
+                        dry_run=dry_run,
+                    )
+            except Exception as exc:
+                payload = {
+                    "ok": False,
+                    "dry_run": not bool(args.execute),
+                    "appended": False,
+                    "registry": str(registry_path),
+                    "runtime_root": args.runtime_root,
+                    "goal_id": args.goal_id,
+                    "classification": args.classification or "agents_last_exam_result_report_v0",
                     "error": str(exc),
                 }
             print_payload(payload, args.format, render_benchmark_experiment_report_append_markdown)


### PR DESCRIPTION
## Summary
- add `history append-agents-last-exam-result-report` to compact an existing ALE run directory into `benchmark_experiment_report_v0` and append it through the normal history path
- read only `run.json`, `eval_result.json`, and `events.jsonl`; raw trajectory/origin_log/output/task bodies/screenshots/credentials/local paths remain excluded
- extend the existing ALE triage smoke to cover dry-run and execute CLI append behavior

## Validation
- `python3 -m py_compile goal_harness/cli.py examples/agents-last-exam-triage-smoke.py`
- `python3 examples/agents-last-exam-triage-smoke.py`
- `python3 examples/benchmark-experiment-report-append-cli-smoke.py`
- `python3 examples/subcommand-format-smoke.py`
- `git diff --check`
- `goal-harness --format json check`

## Boundary
This is a passive ingest surface only. It does not run ALE, cloud sandboxes, model APIs, paid compute, uploads, submissions, or leaderboard actions.