### PR TITLE
Add benchmark artifact path filter

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/terminal-bench-cli-dry-run-fake-worker-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/terminal-bench-cli-dry-run-fake-worker-v0.md
@@ -42,7 +42,7 @@ The CLI-generated event keeps:
 | --- | --- |
 | `schema_version` | `benchmark_run_v0` |
 | `source_runner` | `goal_harness_terminal_bench_cli_skeleton` |
-| `benchmark_id` | default `terminal-bench-sample@2.0` |
+| `benchmark_id` | default `terminal-bench@2.0` |
 | `task_id` | default `build-cython-ext` |
 | `real_run` | `false` |
 | `submit_eligible` | `false` |

--- a/docs/research/long-horizon-agent-benchmarks/terminal-bench-codex-goal-harness-active-cli-bridge-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/terminal-bench-codex-goal-harness-active-cli-bridge-v0.md
@@ -172,7 +172,7 @@ passes an in-container command prefix to the Codex worker:
 ```
 
 This is the route to test before another private no-upload
-`terminal-bench-sample@2.0` repeat.
+`terminal-bench@2.0` repeat.
 
 For private local repeats, the runner must use the Goal Harness private runner
 environment, which prepends the probe PATH (`~/.local/bin`, Homebrew, and

--- a/docs/research/long-horizon-agent-benchmarks/terminal-bench-managed-codex-custom-agent-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/terminal-bench-managed-codex-custom-agent-v0.md
@@ -76,7 +76,7 @@ Run from the Goal Harness repository root, or otherwise make the repository
 package importable to the Harbor process. The command shape is:
 
 ```text
-uvx --from git+https://github.com/harbor-framework/harbor@a56546feb7d2da0b3196bbd7b05adacb72449391 harbor run --dataset terminal-bench-sample@2.0 --include-task-name build-cython-ext --agent-import-path goal_harness.terminal_bench_agent:GoalHarnessManagedCodex --model gpt-5.5 --env docker --n-attempts 1 --n-concurrent 1 --jobs-dir <private-jobs-dir> --job-name terminal_bench_sample_build_cython_ext_goal_harness_managed_codex_pilot --agent-env CODEX_FORCE_AUTH_JSON=true --agent-kwarg goal_harness_policy_version=goal_harness_terminal_bench_policy_v0 --agent-kwarg goal_harness_behavior_spec_id=terminal_bench_goal_harness_managed_codex_v0 --agent-kwarg goal_harness_ablation_mode=goal_harness_managed
+uvx --from git+https://github.com/harbor-framework/harbor@a56546feb7d2da0b3196bbd7b05adacb72449391 harbor run --dataset terminal-bench@2.0 --agent-import-path goal_harness.terminal_bench_agent:GoalHarnessManagedCodex --model gpt-5.5 --env docker --n-attempts 1 --n-concurrent 1 --jobs-dir <private-jobs-dir> --job-name terminal-bench_2_0_build_cython_ext_goal_harness_managed_codex_cli_dry_run --agent-env CODEX_FORCE_AUTH_JSON=true --agent-kwarg goal_harness_policy_version=goal_harness_terminal_bench_policy_v0 --agent-kwarg goal_harness_behavior_spec_id=terminal_bench_goal_harness_managed_codex_v0 --agent-kwarg goal_harness_mode=goal_harness_managed_codex --agent-kwarg goal_harness_goal_id=<goal-id> --agent-kwarg goal_harness_ablation_mode=goal_harness_managed --include-task-name build-cython-ext
 ```
 
 No upload, publish, share, public, private upload-visibility, or leaderboard flag
@@ -87,7 +87,7 @@ belongs in the first managed pilot. The raw jobs directory remains private.
 This custom-agent bridge may support the claim:
 
 ```text
-Harbor can import a Goal Harness managed Codex agent for the sample private
+Harbor can import a Goal Harness managed Codex agent for the official private
 no-upload Terminal-Bench pilot surface.
 ```
 
@@ -103,7 +103,7 @@ It must not support these claims yet:
 ## Next Action
 
 Run exactly one private no-upload managed Codex single-task pilot for
-`terminal-bench-sample@2.0` task `build-cython-ext`, using the custom
+`terminal-bench@2.0` task `build-cython-ext`, using the custom
 `--agent-import-path` above. If the pilot cannot start or finish, record the
 first concrete blocker as a compact `benchmark_run_v0` event without copying
 raw logs, local paths, credentials, or task artifacts into public notes.

--- a/examples/benchmark-artifact-path-filter-smoke.py
+++ b/examples/benchmark-artifact-path-filter-smoke.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Smoke-test public-safe benchmark artifact path classification."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from goal_harness.benchmark import filter_public_benchmark_artifact_paths  # noqa: E402
+
+
+PRIVATE_ROOT = "/private/example/project/.local/private-benchmark-jobs/job-a"
+PATHS = [
+    f"{PRIVATE_ROOT}/paired_comparison.compact.json",
+    f"{PRIVATE_ROOT}/launch_status.public.json",
+    f"{PRIVATE_ROOT}/agent/trajectory.json",
+    f"{PRIVATE_ROOT}/launch_private_manifest.local.json",
+    f"{PRIVATE_ROOT}/tasks/demo/instruction.md",
+]
+
+
+def assert_no_path_leak(payload: dict[str, object]) -> None:
+    rendered = json.dumps(payload, sort_keys=True)
+    forbidden = [
+        "/private/example",
+        ".local/private-benchmark-jobs",
+        "job-a/agent",
+        "tasks/demo",
+    ]
+    leaked = [item for item in forbidden if item in rendered]
+    assert not leaked, leaked
+
+
+def main() -> None:
+    payload = filter_public_benchmark_artifact_paths(PATHS)
+    assert payload["schema_version"] == "benchmark_artifact_path_filter_v0", payload
+    assert payload["path_recorded"] is False, payload
+    assert payload["allowed_to_read_count"] == 2, payload
+    assert payload["blocked_count"] == 3, payload
+    assert payload["allowed_artifact_basenames"] == [
+        "paired_comparison.compact.json",
+        "launch_status.public.json",
+    ], payload
+    assert payload["blocked_reasons"]["raw_private_surface"] == 2, payload
+    assert payload["blocked_reasons"]["private_or_local_manifest"] == 1, payload
+    assert_no_path_leak(payload)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "goal_harness.cli",
+            "--format",
+            "json",
+            "benchmark",
+            "classify-artifacts",
+            *PATHS,
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    cli_payload = json.loads(result.stdout)
+    assert cli_payload["allowed_to_read_count"] == 2, cli_payload
+    assert cli_payload["blocked_count"] == 3, cli_payload
+    assert_no_path_leak(cli_payload)
+    print("ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/terminal-bench-cli-dry-run-fake-worker-smoke.py
+++ b/examples/terminal-bench-cli-dry-run-fake-worker-smoke.py
@@ -23,7 +23,7 @@ DOC = TOPIC_DIR / "terminal-bench-cli-dry-run-fake-worker-v0.md"
 README = TOPIC_DIR / "README.md"
 
 GOAL_ID = "terminal-bench-cli-dry-run-fixture"
-BENCHMARK_ID = "terminal-bench-sample@2.0"
+BENCHMARK_ID = "terminal-bench@2.0"
 TASK_ID = "build-cython-ext"
 RUN_MODE = "goal_harness_managed_codex_fake_worker_wrapper"
 WORKER_MODE = "goal_harness_managed_codex_cli"

--- a/examples/terminal-bench-codex-goal-harness-fake-worker-smoke.py
+++ b/examples/terminal-bench-codex-goal-harness-fake-worker-smoke.py
@@ -23,7 +23,7 @@ DOC = TOPIC_DIR / "terminal-bench-codex-goal-harness-fake-worker-v0.md"
 README = TOPIC_DIR / "README.md"
 
 GOAL_ID = "terminal-bench-codex-goal-harness-fixture"
-BENCHMARK_ID = "terminal-bench-sample@2.0"
+BENCHMARK_ID = "terminal-bench@2.0"
 TASK_ID = "build-cython-ext"
 MODE = "codex-goal-harness"
 RUN_MODE = "codex_goal_harness_fake_worker_wrapper"

--- a/examples/terminal-bench-codex-goal-harness-preflight-guard-smoke.py
+++ b/examples/terminal-bench-codex-goal-harness-preflight-guard-smoke.py
@@ -25,7 +25,7 @@ DOC = TOPIC_DIR / "terminal-bench-codex-goal-harness-preflight-guard-v0.md"
 README = TOPIC_DIR / "README.md"
 
 GOAL_ID = "terminal-bench-codex-goal-harness-preflight-fixture"
-BENCHMARK_ID = "terminal-bench-sample@2.0"
+BENCHMARK_ID = "terminal-bench@2.0"
 TASK_ID = "build-cython-ext"
 RUN_MODE = "codex_goal_harness_no_upload_preflight_guard"
 WORKER_MODE = "codex_goal_harness_cli"

--- a/examples/terminal-bench-managed-codex-custom-agent-smoke.py
+++ b/examples/terminal-bench-managed-codex-custom-agent-smoke.py
@@ -202,7 +202,7 @@ def assert_command_contract() -> None:
     assert "--agent-import-path" in command, command
     assert TERMINAL_BENCH_MANAGED_AGENT_IMPORT_PATH in command, command
     assert "--agent-kwarg" in command, command
-    assert "terminal-bench-sample@2.0" in command, command
+    assert "terminal-bench@2.0" in command, command
     assert "build-cython-ext" in command, command
     assert "--upload" not in command, command
     assert "--public" not in command, command

--- a/examples/terminal-bench-managed-real-run-preflight-guard-smoke.py
+++ b/examples/terminal-bench-managed-real-run-preflight-guard-smoke.py
@@ -25,7 +25,7 @@ DOC = TOPIC_DIR / "terminal-bench-managed-real-run-preflight-guard-v0.md"
 README = TOPIC_DIR / "README.md"
 
 GOAL_ID = "terminal-bench-managed-preflight-fixture"
-BENCHMARK_ID = "terminal-bench-sample@2.0"
+BENCHMARK_ID = "terminal-bench@2.0"
 TASK_ID = "build-cython-ext"
 RUN_MODE = "goal_harness_managed_codex_real_run_preflight_guard"
 WORKER_MODE = "goal_harness_managed_codex_cli"

--- a/goal_harness/benchmark.py
+++ b/goal_harness/benchmark.py
@@ -8,7 +8,7 @@ import subprocess
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterable
 
 from .worker_bridge import (
     ACTIVE_USER_INTERVENTION_CHANNEL_CONTRACT_VERSION,
@@ -39,7 +39,7 @@ TERMINAL_BENCH_MODES = (
     "goal-harness-managed-codex",
 )
 
-TERMINAL_BENCH_DEFAULT_DATASET = "terminal-bench-sample@2.0"
+TERMINAL_BENCH_DEFAULT_DATASET = "terminal-bench@2.0"
 TERMINAL_BENCH_DEFAULT_TASK = "build-cython-ext"
 TERMINAL_BENCH_DEFAULT_MODEL = "gpt-5.5"
 TERMINAL_BENCH_HARBOR_REF = (
@@ -182,6 +182,104 @@ AGENTS_LAST_EXAM_RAW_SURFACES_EXCLUDED = (
     "origin_log",
     "output",
 )
+BENCHMARK_PUBLIC_ARTIFACT_SUFFIXES = (
+    ".compact.json",
+    ".public.json",
+)
+BENCHMARK_PUBLIC_ARTIFACT_FILENAMES = (
+    "paired_comparison.compact.json",
+    "launch_status.public.json",
+    "launch_summaries.public.json",
+)
+BENCHMARK_RAW_PRIVATE_PATH_MARKERS = (
+    "/agent/trajectory.json",
+    "/sessions/",
+    "/logs/",
+    "/raw/",
+    "trajectory.json",
+    "origin_log",
+    "instruction.md",
+    "task.md",
+)
+BENCHMARK_PRIVATE_MANIFEST_SUFFIXES = (
+    ".local.json",
+    ".private.json",
+)
+
+
+def classify_benchmark_artifact_path(path: str | Path) -> dict[str, Any]:
+    """Classify a benchmark artifact path without echoing host directories."""
+
+    normalized = str(path).replace("\\", "/").rstrip("/")
+    basename = normalized.rsplit("/", 1)[-1] if normalized else ""
+    lower_path = normalized.lower()
+    lower_basename = basename.lower()
+    public_compact_candidate = (
+        lower_basename.endswith(BENCHMARK_PUBLIC_ARTIFACT_SUFFIXES)
+        or lower_basename in BENCHMARK_PUBLIC_ARTIFACT_FILENAMES
+    )
+    raw_marker = next(
+        (marker for marker in BENCHMARK_RAW_PRIVATE_PATH_MARKERS if marker in lower_path),
+        "",
+    )
+    private_manifest = lower_basename.endswith(BENCHMARK_PRIVATE_MANIFEST_SUFFIXES)
+
+    allowed_to_read = (
+        public_compact_candidate
+        and not raw_marker
+        and not private_manifest
+    )
+    if allowed_to_read:
+        first_blocker = ""
+        recommended_action = "read only this compact/public artifact, then ingest its reduced fields"
+    elif raw_marker:
+        first_blocker = "raw_private_surface"
+        recommended_action = "do not read; use a compact/public sibling artifact or runner-side reducer"
+    elif private_manifest:
+        first_blocker = "private_or_local_manifest"
+        recommended_action = "do not read; summarize via a public compact launch summary instead"
+    else:
+        first_blocker = "not_compact_public_artifact"
+        recommended_action = "skip unless a benchmark-specific reducer explicitly whitelists it"
+
+    return {
+        "schema_version": "benchmark_artifact_path_classification_v0",
+        "path_recorded": False,
+        "basename": basename,
+        "public_compact_candidate": public_compact_candidate,
+        "private_raw_surface": bool(raw_marker or private_manifest),
+        "first_blocker": first_blocker,
+        "allowed_to_read": allowed_to_read,
+        "recommended_action": recommended_action,
+    }
+
+
+def filter_public_benchmark_artifact_paths(
+    paths: Iterable[str | Path],
+) -> dict[str, Any]:
+    classifications = [classify_benchmark_artifact_path(path) for path in paths]
+    allowed = [item for item in classifications if item["allowed_to_read"]]
+    blocked = [item for item in classifications if not item["allowed_to_read"]]
+    blocked_reasons: dict[str, int] = {}
+    for item in blocked:
+        reason = str(item.get("first_blocker") or "unknown")
+        blocked_reasons[reason] = blocked_reasons.get(reason, 0) + 1
+    return {
+        "schema_version": "benchmark_artifact_path_filter_v0",
+        "path_recorded": False,
+        "allowed_to_read_count": len(allowed),
+        "blocked_count": len(blocked),
+        "allowed_artifact_basenames": [item["basename"] for item in allowed],
+        "blocked_artifact_basenames": [item["basename"] for item in blocked],
+        "blocked_reasons": blocked_reasons,
+        "classifications": classifications,
+        "public_boundary": {
+            "full_paths_recorded": False,
+            "raw_task_text_read": False,
+            "trajectory_or_origin_log_read": False,
+            "intended_use": "preflight benchmark artifact reads before compact ingest",
+        },
+    }
 
 
 def build_terminal_bench_active_user_injection_channel_probe(
@@ -3003,7 +3101,7 @@ def build_terminal_bench_managed_harbor_command(
     task_id: str | None = TERMINAL_BENCH_DEFAULT_TASK,
     model: str = TERMINAL_BENCH_DEFAULT_MODEL,
     jobs_dir: str = "<private-jobs-dir>",
-    job_name: str = "terminal_bench_sample_build_cython_ext_goal_harness_managed_codex_pilot",
+    job_name: str | None = None,
     goal_harness_mode: str = "goal_harness_managed_codex",
     goal_harness_ablation_mode: str = "goal_harness_managed",
     goal_harness_goal_id: str = "<goal-id>",
@@ -3052,6 +3150,17 @@ def build_terminal_bench_managed_harbor_command(
         raise ValueError(
             "goal_harness_access_packet_mode must be one of: "
             + ", ".join(TERMINAL_BENCH_GOAL_HARNESS_ACCESS_PACKET_MODES)
+        )
+    if job_name is None:
+        event_mode = (
+            "goal_harness_managed_codex_cli_dry_run"
+            if goal_harness_mode == "goal_harness_managed_codex"
+            else goal_harness_mode
+        )
+        task_label = str(task_id or "all").replace("-", "_")
+        job_name = (
+            f"{dataset.replace('@', '_').replace('.', '_')}_"
+            f"{task_label}_{event_mode}"
         )
 
     command = [

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -28,6 +28,7 @@ from .benchmark import (
     build_terminal_bench_benchmark_run,
     build_terminal_bench_harbor_result_benchmark_run,
     collect_terminal_bench_goal_harness_cli_bridge_trace,
+    filter_public_benchmark_artifact_paths,
     terminal_bench_recommended_action,
 )
 from .configure_goal import configure_goal, render_configure_goal_markdown
@@ -160,6 +161,25 @@ def print_payload(payload: dict[str, object], fmt: str, markdown_renderer) -> No
         print(json.dumps(payload, ensure_ascii=False, indent=2))
     else:
         print(markdown_renderer(payload))
+
+
+def render_benchmark_artifact_path_filter_markdown(payload: dict[str, object]) -> str:
+    lines = [
+        "# Benchmark Artifact Path Filter",
+        "",
+        f"- Schema: `{payload.get('schema_version')}`",
+        f"- Allowed to read: `{payload.get('allowed_to_read_count')}`",
+        f"- Blocked: `{payload.get('blocked_count')}`",
+        f"- Full paths recorded: `{payload.get('path_recorded')}`",
+    ]
+    allowed = payload.get("allowed_artifact_basenames")
+    if isinstance(allowed, list) and allowed:
+        lines.append("- Allowed basenames: " + ", ".join(f"`{item}`" for item in allowed))
+    blocked = payload.get("blocked_reasons")
+    if isinstance(blocked, dict) and blocked:
+        reasons = ", ".join(f"`{key}`={value}" for key, value in blocked.items())
+        lines.append("- Blocked reasons: " + reasons)
+    return "\n".join(lines) + "\n"
 
 
 def add_subcommand_format(arg_parser: argparse.ArgumentParser) -> None:
@@ -1160,6 +1180,21 @@ def main(argv: list[str] | None = None) -> int:
     benchmark_run_parser.add_argument("--execute", action="store_true", help="Append the compact fixture event.")
     benchmark_run_parser.add_argument("--no-global-sync", action="store_true", help="Skip global registry sync after append.")
 
+    benchmark_artifact_filter_parser = benchmark_sub.add_parser(
+        "classify-artifacts",
+        help=(
+            "Classify benchmark artifact paths before reading them. The classifier "
+            "returns basenames and blocker reasons only; it does not read files or "
+            "echo host directories."
+        ),
+    )
+    add_subcommand_format(benchmark_artifact_filter_parser)
+    benchmark_artifact_filter_parser.add_argument(
+        "artifact_paths",
+        nargs="+",
+        help="Candidate benchmark artifact paths to classify without reading.",
+    )
+
     archive_runtime_parser = sub.add_parser(
         "archive-runtime",
         help="Move an obsolete runtime goal directory into the archive area. Defaults to dry-run.",
@@ -1993,6 +2028,14 @@ def main(argv: list[str] | None = None) -> int:
         return 0 if payload.get("ok") else 1
 
     if args.command == "benchmark":
+        if args.benchmark_command == "classify-artifacts":
+            payload = filter_public_benchmark_artifact_paths(args.artifact_paths)
+            print_payload(
+                payload,
+                output_format(args),
+                render_benchmark_artifact_path_filter_markdown,
+            )
+            return 0
         if args.benchmark_command == "run":
             try:
                 if args.dry_run and args.execute:


### PR DESCRIPTION
Summary
- Add a public-safe benchmark artifact path classifier and CLI command for preflight filtering before local artifact reads.
- Switch the Terminal-Bench default dataset to official terminal-bench@2.0 and derive default job names from dataset/task/mode.
- Update current Terminal-Bench docs and smokes for the official default.

Validation
- python3 -m py_compile goal_harness/benchmark.py goal_harness/cli.py
- python3 examples/benchmark-artifact-path-filter-smoke.py
- python3 examples/terminal-bench-cli-dry-run-fake-worker-smoke.py
- python3 examples/terminal-bench-codex-goal-harness-fake-worker-smoke.py
- python3 examples/terminal-bench-managed-codex-custom-agent-smoke.py
- python3 examples/terminal-bench-managed-real-run-preflight-guard-smoke.py
- python3 examples/terminal-bench-codex-goal-harness-preflight-guard-smoke.py
- python3 examples/terminal-bench-codex-goal-harness-active-cli-bridge-smoke.py
- goal-harness check
- git diff --check

Excluded
- Local active-state writeback and runtime history stayed ignored and were not committed.
- No private benchmark raw content, task text, logs, trajectories, credentials, uploads, Docker execution, or model calls were included.

Residual risk
- The path classifier is intentionally conservative; benchmark-specific reducers may still need explicit allowlists for non-.compact/.public artifacts.