### PR TITLE
Add compact benchmark claim review

### DIFF
--- a/examples/benchmark-claim-review-smoke.py
+++ b/examples/benchmark-claim-review-smoke.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Smoke-test compact benchmark claim review."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from goal_harness.benchmark import build_benchmark_claim_review  # noqa: E402
+
+
+def comparison(delta: float, *, comparison_id: str = "fixture-pair") -> dict[str, Any]:
+    return {
+        "schema_version": "benchmark_comparison_v0",
+        "task_id": "terminal-bench@2.0/db-wal-recovery",
+        "comparison_id": comparison_id,
+        "benchmark_id": "terminal-bench@2.0",
+        "baseline_scenario_id": "hardened-codex",
+        "treatment_scenario_id": "codex-goal-harness",
+        "official_task_score_delta": delta,
+        "control_plane_score_delta": 0.75,
+        "both_success": delta == 0,
+        "claim_boundary": {
+            "leaderboard_claim_allowed": False,
+            "official_score_uplift_claim_allowed": False,
+            "assisted_collaboration_claim_allowed": True,
+            "raw_trace_excluded": True,
+        },
+    }
+
+
+def benchmark_run(
+    mode: str,
+    score: float,
+    *,
+    worker_calls: int = 0,
+    attribution: str = "none",
+    labels: list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "schema_version": "benchmark_run_v0",
+        "source_runner": "harbor",
+        "benchmark_id": "terminal-bench@2.0",
+        "job_name": f"terminal-bench-2-0-db-wal-recovery-{mode}",
+        "mode": mode,
+        "real_run": True,
+        "submit_eligible": False,
+        "leaderboard_evidence": False,
+        "official_task_score": {
+            "kind": "terminal_bench_verifier_reward",
+            "value": score,
+            "passed": score >= 1,
+        },
+        "worker_goal_harness_cli_call_total": worker_calls,
+        "worker_benchmark_run_schema_ok_count": 1 if worker_calls else 0,
+        "score_failure_attribution": attribution,
+        "failure_attribution_labels": labels or [],
+        "active_user_observation": {
+            "observed_after_worker_start": worker_calls > 0,
+        },
+        "read_boundary": {
+            "raw_artifacts_read": False,
+            "task_text_read": False,
+        },
+    }
+
+
+def test_candidate_with_baseline_attribution_caveat() -> None:
+    baseline = benchmark_run(
+        "hardened-codex",
+        0.0,
+        attribution="verifier_platform_probe_failure",
+        labels=["verifier_platform_probe_failure"],
+    )
+    treatment = benchmark_run("codex-goal-harness", 1.0, worker_calls=4)
+    payload = build_benchmark_claim_review(
+        comparison(1.0),
+        benchmark_runs=[baseline, treatment],
+    )
+    decision = payload["decision"]
+
+    assert payload["schema_version"] == "benchmark_claim_review_v0", payload
+    assert payload["official_task_score_delta"] == 1.0, payload
+    assert payload["treatment_worker_evidence"]["present"] is True, payload
+    assert payload["baseline_score_failure_attribution"] == "verifier_platform_probe_failure", payload
+    assert "baseline_failure_attribution_caveat" in decision["blockers"], payload
+    assert decision["validation_enhancement_candidate"] is True, payload
+    assert decision["clean_validation_enhancement"] is False, payload
+    assert decision["claim_strength"] == "candidate_score_recovery_needs_attribution_review", payload
+    assert payload["read_boundary"]["raw_artifacts_read"] is False, payload
+
+
+def test_loop_validation_without_score_uplift() -> None:
+    baseline = benchmark_run("hardened-codex", 1.0)
+    treatment = benchmark_run("codex-goal-harness", 1.0, worker_calls=3)
+    payload = build_benchmark_claim_review(
+        comparison(0.0, comparison_id="no-delta-pair"),
+        benchmark_runs=[baseline, treatment],
+    )
+    decision = payload["decision"]
+
+    assert decision["claim_strength"] == "loop_validation_no_score_uplift", payload
+    assert decision["validation_enhancement_candidate"] is False, payload
+    assert "no_positive_official_task_score_delta" in decision["blockers"], payload
+
+
+def test_cli_review_claim() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        comparison_path = root / "paired_comparison.compact.json"
+        baseline_path = root / "baseline.compact.json"
+        treatment_path = root / "treatment.compact.json"
+        comparison_path.write_text(json.dumps(comparison(1.0)), encoding="utf-8")
+        baseline_path.write_text(
+            json.dumps(
+                benchmark_run(
+                    "hardened-codex",
+                    0.0,
+                    attribution="verifier_platform_probe_failure",
+                    labels=["verifier_platform_probe_failure"],
+                )
+            ),
+            encoding="utf-8",
+        )
+        treatment_path.write_text(
+            json.dumps(benchmark_run("codex-goal-harness", 1.0, worker_calls=4)),
+            encoding="utf-8",
+        )
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "goal_harness.cli",
+                "--format",
+                "json",
+                "benchmark",
+                "review-claim",
+                "--benchmark-comparison-json",
+                str(comparison_path),
+                "--benchmark-run-json",
+                str(baseline_path),
+                "--benchmark-run-json",
+                str(treatment_path),
+            ],
+            cwd=REPO_ROOT,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        payload = json.loads(result.stdout)
+        assert payload["ok"] is True, payload
+        assert payload["decision"]["claim_strength"] == "candidate_score_recovery_needs_attribution_review", payload
+        assert payload["read_boundary"]["raw_artifacts_read"] is False, payload
+        assert str(root) not in result.stdout, result.stdout
+
+
+def main() -> int:
+    test_candidate_with_baseline_attribution_caveat()
+    test_loop_validation_without_score_uplift()
+    test_cli_review_claim()
+    print("benchmark-claim-review-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/goal_harness/benchmark.py
+++ b/goal_harness/benchmark.py
@@ -42,6 +42,7 @@ TERMINAL_BENCH_MODES = (
 TERMINAL_BENCH_DEFAULT_DATASET = "terminal-bench@2.0"
 TERMINAL_BENCH_DEFAULT_TASK = "build-cython-ext"
 TERMINAL_BENCH_DEFAULT_MODEL = "gpt-5.5"
+BENCHMARK_CLAIM_REVIEW_SCHEMA_VERSION = "benchmark_claim_review_v0"
 TERMINAL_BENCH_HARBOR_REF = (
     "git+https://github.com/harbor-framework/harbor@"
     "a56546feb7d2da0b3196bbd7b05adacb72449391"
@@ -278,6 +279,213 @@ def filter_public_benchmark_artifact_paths(
             "raw_task_text_read": False,
             "trajectory_or_origin_log_read": False,
             "intended_use": "preflight benchmark artifact reads before compact ingest",
+        },
+    }
+
+
+def _claim_review_numeric(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _claim_review_run_mode(run: dict[str, Any]) -> str:
+    return str(run.get("mode") or "").strip().lower().replace("_", "-")
+
+
+def _claim_review_run_score(run: dict[str, Any]) -> float | None:
+    official = run.get("official_task_score") if isinstance(run.get("official_task_score"), dict) else {}
+    return _claim_review_numeric(official.get("value"))
+
+
+def _claim_review_worker_evidence(run: dict[str, Any]) -> dict[str, Any]:
+    interaction = run.get("interaction_counters") if isinstance(run.get("interaction_counters"), dict) else {}
+    calls = interaction.get("goal_harness_cli_calls") if isinstance(interaction.get("goal_harness_cli_calls"), dict) else {}
+    worker_cli_total = run.get("worker_goal_harness_cli_call_total")
+    if not isinstance(worker_cli_total, int) or isinstance(worker_cli_total, bool):
+        worker_cli_total = calls.get("total", 0)
+    if not isinstance(worker_cli_total, int) or isinstance(worker_cli_total, bool):
+        worker_cli_total = 0
+    observation = run.get("active_user_observation") if isinstance(run.get("active_user_observation"), dict) else {}
+    worker_file_count = run.get("worker_benchmark_run_schema_ok_count")
+    if not isinstance(worker_file_count, int) or isinstance(worker_file_count, bool):
+        worker_file_count = 0
+    present = bool(
+        worker_cli_total > 0
+        or worker_file_count > 0
+        or observation.get("observed_after_worker_start")
+        or observation.get("worker_observation_proof")
+    )
+    return {
+        "worker_goal_harness_cli_call_total": worker_cli_total,
+        "worker_benchmark_run_schema_ok_count": worker_file_count,
+        "active_user_observed_after_worker_start": bool(
+            observation.get("observed_after_worker_start")
+            or observation.get("worker_observation_proof")
+        ),
+        "present": present,
+    }
+
+
+def _claim_review_failure_labels(run: dict[str, Any]) -> list[str]:
+    labels = run.get("failure_attribution_labels")
+    if not isinstance(labels, list):
+        return []
+    return [
+        str(label)
+        for label in labels
+        if isinstance(label, (str, int, float)) and not isinstance(label, bool)
+    ][:8]
+
+
+def _claim_review_score_failure_attribution(run: dict[str, Any]) -> str:
+    value = run.get("score_failure_attribution")
+    return str(value).strip() if isinstance(value, str) and value.strip() else "none"
+
+
+def _claim_review_pick_runs(
+    runs: list[dict[str, Any]],
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    baseline: dict[str, Any] | None = None
+    treatment: dict[str, Any] | None = None
+    for run in runs:
+        mode = _claim_review_run_mode(run)
+        job_name = str(run.get("job_name") or "").lower().replace("_", "-")
+        if baseline is None and (
+            "hardened-codex" in mode
+            or "bare-codex" in mode
+            or run.get("hardened_install_baseline") is True
+        ):
+            baseline = run
+        if treatment is None and (
+            "codex-goal-harness" in mode
+            or "codex-goal-harness" in job_name
+            or _claim_review_worker_evidence(run)["present"]
+        ):
+            treatment = run
+    if baseline is None and runs:
+        baseline = runs[0]
+    if treatment is None and len(runs) > 1:
+        treatment = runs[1]
+    return baseline, treatment
+
+
+def build_benchmark_claim_review(
+    benchmark_comparison: dict[str, Any],
+    *,
+    benchmark_runs: Iterable[dict[str, Any]] = (),
+) -> dict[str, Any]:
+    """Review compact benchmark evidence without reading raw artifacts."""
+
+    runs = [run for run in benchmark_runs if isinstance(run, dict)]
+    baseline, treatment = _claim_review_pick_runs(runs)
+    official_delta = _claim_review_numeric(
+        benchmark_comparison.get("official_task_score_delta")
+    )
+    if official_delta is None and baseline and treatment:
+        baseline_score = _claim_review_run_score(baseline)
+        treatment_score = _claim_review_run_score(treatment)
+        if baseline_score is not None and treatment_score is not None:
+            official_delta = treatment_score - baseline_score
+
+    treatment_evidence = _claim_review_worker_evidence(treatment) if treatment else {"present": False}
+    baseline_labels = _claim_review_failure_labels(baseline or {})
+    baseline_attribution = _claim_review_score_failure_attribution(baseline or {})
+    attribution_caveat = baseline_attribution in {
+        "verifier_platform_probe_failure",
+        "verifier_infrastructure_failure",
+        "verifier_dependency_install_failure",
+    } or any(label.startswith("verifier_") for label in baseline_labels)
+    boundary_mismatch_count = sum(
+        int(run.get("worker_submit_eligible_mismatch_count") or 0)
+        for run in runs
+        if isinstance(run.get("worker_submit_eligible_mismatch_count"), int)
+        and not isinstance(run.get("worker_submit_eligible_mismatch_count"), bool)
+    )
+
+    blockers: list[str] = []
+    if official_delta is None:
+        blockers.append("missing_official_task_score_delta")
+    elif official_delta <= 0:
+        blockers.append("no_positive_official_task_score_delta")
+    if official_delta is not None and official_delta > 0 and not treatment_evidence.get("present"):
+        blockers.append("missing_treatment_worker_goal_harness_evidence")
+    if official_delta is not None and official_delta > 0 and attribution_caveat:
+        blockers.append("baseline_failure_attribution_caveat")
+    if boundary_mismatch_count:
+        blockers.append("worker_submit_eligible_boundary_mismatch")
+
+    positive_delta = official_delta is not None and official_delta > 0
+    assisted_evidence = bool(treatment_evidence.get("present"))
+    clean_validation = positive_delta and assisted_evidence and not blockers
+    candidate_validation = positive_delta and assisted_evidence
+    if clean_validation:
+        claim_strength = "strong_goal_harness_assisted_score_recovery"
+    elif candidate_validation:
+        claim_strength = "candidate_score_recovery_needs_attribution_review"
+    elif positive_delta:
+        claim_strength = "score_delta_without_assisted_worker_evidence"
+    elif assisted_evidence:
+        claim_strength = "loop_validation_no_score_uplift"
+    else:
+        claim_strength = "no_validation_enhancement"
+
+    if "baseline_failure_attribution_caveat" in blockers:
+        next_action = (
+            "run a same-protocol reliability repeat or add finer compact "
+            "verifier-side attribution before making a clean score-recovery claim"
+        )
+    elif "missing_treatment_worker_goal_harness_evidence" in blockers:
+        next_action = "collect compact worker-visible Goal Harness evidence before claiming assisted recovery"
+    elif "worker_submit_eligible_boundary_mismatch" in blockers:
+        next_action = "normalize the compact worker submit boundary before public claim review"
+    elif clean_validation:
+        next_action = "record as clean compact score-recovery evidence while preserving no-leaderboard claim boundary"
+    else:
+        next_action = "treat as loop/attribution evidence and seek a stronger paired sample"
+
+    claim_boundary = benchmark_comparison.get("claim_boundary") if isinstance(benchmark_comparison.get("claim_boundary"), dict) else {}
+    return {
+        "schema_version": BENCHMARK_CLAIM_REVIEW_SCHEMA_VERSION,
+        "input_schema_versions": {
+            "benchmark_comparison": benchmark_comparison.get("schema_version"),
+            "benchmark_runs": [
+                run.get("schema_version") for run in runs if run.get("schema_version")
+            ],
+        },
+        "task_id": benchmark_comparison.get("task_id"),
+        "comparison_id": benchmark_comparison.get("comparison_id"),
+        "official_task_score_delta": official_delta,
+        "control_plane_score_delta": benchmark_comparison.get("control_plane_score_delta"),
+        "treatment_worker_evidence": treatment_evidence,
+        "baseline_score_failure_attribution": baseline_attribution,
+        "baseline_failure_attribution_labels": baseline_labels,
+        "boundary_mismatch_count": boundary_mismatch_count,
+        "claim_boundary": {
+            "leaderboard_claim_allowed": bool(claim_boundary.get("leaderboard_claim_allowed")),
+            "official_score_uplift_claim_allowed": bool(claim_boundary.get("official_score_uplift_claim_allowed")),
+            "assisted_collaboration_claim_allowed": bool(claim_boundary.get("assisted_collaboration_claim_allowed")),
+            "raw_trace_excluded": claim_boundary.get("raw_trace_excluded") is not False,
+        },
+        "decision": {
+            "claim_strength": claim_strength,
+            "validation_enhancement_candidate": candidate_validation,
+            "clean_validation_enhancement": clean_validation,
+            "blockers": blockers,
+            "next_action": next_action,
+        },
+        "read_boundary": {
+            "compact_only": True,
+            "raw_artifacts_read": False,
+            "task_text_read": False,
+            "local_paths_recorded": False,
         },
     }
 

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -25,6 +25,7 @@ from .benchmark import (
     TERMINAL_BENCH_HARDENED_CODEX_BASELINE_PREFLIGHT_MODE,
     TERMINAL_BENCH_MODES,
     build_agents_last_exam_result_benchmark_report,
+    build_benchmark_claim_review,
     build_terminal_bench_benchmark_run,
     build_terminal_bench_harbor_result_benchmark_run,
     collect_terminal_bench_goal_harness_cli_bridge_trace,
@@ -179,6 +180,38 @@ def render_benchmark_artifact_path_filter_markdown(payload: dict[str, object]) -
     if isinstance(blocked, dict) and blocked:
         reasons = ", ".join(f"`{key}`={value}" for key, value in blocked.items())
         lines.append("- Blocked reasons: " + reasons)
+    return "\n".join(lines) + "\n"
+
+
+def render_benchmark_claim_review_markdown(payload: dict[str, object]) -> str:
+    decision = payload.get("decision") if isinstance(payload.get("decision"), dict) else {}
+    treatment = (
+        payload.get("treatment_worker_evidence")
+        if isinstance(payload.get("treatment_worker_evidence"), dict)
+        else {}
+    )
+    read_boundary = (
+        payload.get("read_boundary")
+        if isinstance(payload.get("read_boundary"), dict)
+        else {}
+    )
+    lines = [
+        "# Benchmark Claim Review",
+        "",
+        f"- Schema: `{payload.get('schema_version')}`",
+        f"- Task: `{payload.get('task_id')}`",
+        f"- Comparison: `{payload.get('comparison_id')}`",
+        f"- Official delta: `{payload.get('official_task_score_delta')}`",
+        f"- Claim strength: `{decision.get('claim_strength')}`",
+        f"- Validation candidate: `{decision.get('validation_enhancement_candidate')}`",
+        f"- Clean validation: `{decision.get('clean_validation_enhancement')}`",
+        f"- Blockers: `{decision.get('blockers')}`",
+        f"- Next action: {decision.get('next_action')}",
+        f"- Treatment worker GH calls: `{treatment.get('worker_goal_harness_cli_call_total')}`",
+        f"- Baseline attribution: `{payload.get('baseline_score_failure_attribution')}`",
+        f"- Compact only: `{read_boundary.get('compact_only')}`",
+        f"- Raw artifacts read: `{read_boundary.get('raw_artifacts_read')}`",
+    ]
     return "\n".join(lines) + "\n"
 
 
@@ -1195,6 +1228,30 @@ def main(argv: list[str] | None = None) -> int:
         help="Candidate benchmark artifact paths to classify without reading.",
     )
 
+    benchmark_claim_review_parser = benchmark_sub.add_parser(
+        "review-claim",
+        help=(
+            "Review compact benchmark comparison/run JSON and classify claim strength. "
+            "This reads only compact JSON inputs, not raw task text, logs, traces, "
+            "Harbor job directories, Docker, model APIs, or uploads."
+        ),
+    )
+    add_subcommand_format(benchmark_claim_review_parser)
+    benchmark_claim_review_parser.add_argument(
+        "--benchmark-comparison-json",
+        required=True,
+        help="Path to a compact benchmark_comparison_v0 JSON object.",
+    )
+    benchmark_claim_review_parser.add_argument(
+        "--benchmark-run-json",
+        action="append",
+        default=[],
+        help=(
+            "Path to a compact benchmark_run_v0 JSON object. Repeat for baseline "
+            "and treatment compact run files."
+        ),
+    )
+
     archive_runtime_parser = sub.add_parser(
         "archive-runtime",
         help="Move an obsolete runtime goal directory into the archive area. Defaults to dry-run.",
@@ -2036,6 +2093,53 @@ def main(argv: list[str] | None = None) -> int:
                 render_benchmark_artifact_path_filter_markdown,
             )
             return 0
+        if args.benchmark_command == "review-claim":
+            try:
+                comparison_input = json.loads(
+                    Path(args.benchmark_comparison_json).expanduser().read_text(encoding="utf-8")
+                )
+                if not isinstance(comparison_input, dict):
+                    raise ValueError("--benchmark-comparison-json must contain a JSON object")
+                comparison = compact_benchmark_comparison(comparison_input)
+                if not comparison:
+                    raise ValueError(
+                        "--benchmark-comparison-json did not contain a compactable benchmark_comparison_v0 object"
+                    )
+                runs = []
+                for run_json in args.benchmark_run_json:
+                    run_input = json.loads(Path(run_json).expanduser().read_text(encoding="utf-8"))
+                    if not isinstance(run_input, dict):
+                        raise ValueError("--benchmark-run-json must contain JSON objects")
+                    run = compact_benchmark_run(run_input)
+                    if not run:
+                        raise ValueError(
+                            "--benchmark-run-json did not contain a compactable benchmark_run_v0 object"
+                        )
+                    runs.append(run)
+                payload = build_benchmark_claim_review(
+                    comparison,
+                    benchmark_runs=runs,
+                )
+            except Exception as exc:
+                payload = {
+                    "ok": False,
+                    "schema_version": "benchmark_claim_review_v0",
+                    "error": str(exc),
+                    "read_boundary": {
+                        "compact_only": True,
+                        "raw_artifacts_read": False,
+                        "task_text_read": False,
+                        "local_paths_recorded": False,
+                    },
+                }
+            else:
+                payload["ok"] = True
+            print_payload(
+                payload,
+                output_format(args),
+                render_benchmark_claim_review_markdown,
+            )
+            return 0 if payload.get("ok") else 1
         if args.benchmark_command == "run":
             try:
                 if args.dry_run and args.execute:


### PR DESCRIPTION
## Summary
- Add build_benchmark_claim_review for compact-only benchmark claim classification.
- Add goal-harness benchmark review-claim to review compact benchmark_comparison_v0 plus compact baseline/treatment benchmark_run_v0 files without reading raw job artifacts.
- Add smoke coverage for positive score delta with a verifier attribution caveat and for no-delta loop-validation cases.

## Validation
- python3 -m py_compile goal_harness/benchmark.py goal_harness/cli.py
- python3 examples/benchmark-claim-review-smoke.py
- python3 examples/terminal-bench-harbor-runner-ingest-smoke.py
- python3 examples/benchmark-artifact-path-filter-smoke.py
- python3 examples/benchmark-run-v0-append-cli-smoke.py
- goal-harness check
- git diff --check

## Boundary
- Reads only compact JSON inputs for claim review.
- Does not read raw task text, logs, trajectories, hidden tests, Harbor job dirs, Docker, model APIs, uploads, local active state, or runtime history.
- No private artifacts, credentials, or local absolute paths committed.
