### PR TITLE
Add Terminal-Bench post-launch guard CLI

### DIFF
--- a/examples/terminal-bench-private-runner-env-guard-smoke.py
+++ b/examples/terminal-bench-private-runner-env-guard-smoke.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import os
+import json
+import subprocess
 import tempfile
 from pathlib import Path
 
@@ -21,8 +23,10 @@ from goal_harness.benchmark import (  # noqa: E402
     build_terminal_bench_task_material_readiness,
     normalize_terminal_bench_private_runner_invocation,
     resolve_terminal_bench_runner_binary,
+    summarize_terminal_bench_post_launch_materialization,
     summarize_terminal_bench_private_runner_launch,
 )
+from goal_harness.status import compact_benchmark_run  # noqa: E402
 
 
 def expect_raises(callable_obj, needle: str) -> None:
@@ -201,6 +205,127 @@ def main() -> None:
     assert summary["agent_import_path_present"] is True, summary
     assert summary["goal_harness_agent_kwargs_present"] is True, summary
     assert summary["goal_harness_worker_bridge_requested"] is True, summary
+
+    missing_materialization = summarize_terminal_bench_post_launch_materialization(
+        "<private-jobs-dir>",
+        job_name="terminal_bench_env_guard_smoke",
+    )
+    assert missing_materialization["checked"] is False, missing_materialization
+    assert missing_materialization["ready_for_launch_state"] is False, missing_materialization
+    assert missing_materialization["first_blocker"] == "jobs_dir_placeholder", missing_materialization
+    assert missing_materialization["raw_paths_recorded"] is False, missing_materialization
+
+    with tempfile.TemporaryDirectory(prefix="goal-harness-post-launch-") as tmp:
+        jobs_dir = Path(tmp) / "jobs"
+        job_root = jobs_dir / "terminal_bench_env_guard_smoke"
+        job_root.mkdir(parents=True)
+        job_root_pollable = summarize_terminal_bench_post_launch_materialization(
+            jobs_dir,
+            job_name="terminal_bench_env_guard_smoke",
+        )
+        assert job_root_pollable["jobs_dir_present"] is True, job_root_pollable
+        assert job_root_pollable["job_root_present"] is True, job_root_pollable
+        assert job_root_pollable["job_lock_present"] is False, job_root_pollable
+        assert job_root_pollable["ready_for_launch_state"] is False, job_root_pollable
+        assert job_root_pollable["first_blocker"] == "job_lock_missing", job_root_pollable
+
+        blocked_cli = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "goal_harness.cli",
+                "--format",
+                "json",
+                "benchmark",
+                "summarize-post-launch",
+                "terminal-bench",
+                "--jobs-dir",
+                str(jobs_dir),
+                "--job-name",
+                "terminal_bench_env_guard_smoke",
+                "--require-ready-for-launch-state",
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert blocked_cli.returncode == 1, blocked_cli.stdout + blocked_cli.stderr
+        blocked_payload = json.loads(blocked_cli.stdout)
+        assert blocked_payload["ok"] is False, blocked_payload
+        assert blocked_payload["first_blocker"] == "job_lock_missing", blocked_payload
+        assert str(jobs_dir) not in blocked_cli.stdout, blocked_cli.stdout
+
+        (job_root / "lock.json").write_text("{}\n", encoding="utf-8")
+        job_root_pollable = summarize_terminal_bench_post_launch_materialization(
+            jobs_dir,
+            job_name="terminal_bench_env_guard_smoke",
+        )
+        assert job_root_pollable["job_lock_present"] is True, job_root_pollable
+        assert job_root_pollable["ready_for_launch_state"] is True, job_root_pollable
+        assert job_root_pollable["ready_for_compact_result_ingest"] is False, job_root_pollable
+        assert job_root_pollable["first_blocker"] == "ready_for_compact_polling", job_root_pollable
+        assert job_root_pollable["raw_logs_read"] is False, job_root_pollable
+        ready_cli = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "goal_harness.cli",
+                "--format",
+                "json",
+                "benchmark",
+                "summarize-post-launch",
+                "terminal-bench",
+                "--jobs-dir",
+                str(jobs_dir),
+                "--job-name",
+                "terminal_bench_env_guard_smoke",
+                "--require-ready-for-launch-state",
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert ready_cli.returncode == 0, ready_cli.stdout + ready_cli.stderr
+        ready_payload = json.loads(ready_cli.stdout)
+        assert ready_payload["ok"] is True, ready_payload
+        assert ready_payload["ready_for_launch_state"] is True, ready_payload
+        assert ready_payload["raw_paths_recorded"] is False, ready_payload
+        assert str(jobs_dir) not in ready_cli.stdout, ready_cli.stdout
+
+        (job_root / "result.json").write_text("{}\n", encoding="utf-8")
+        trial_root = job_root / "good-task__trial"
+        trial_root.mkdir()
+        (trial_root / "result.json").write_text("{}\n", encoding="utf-8")
+        job_root_complete = summarize_terminal_bench_post_launch_materialization(
+            jobs_dir,
+            job_name="terminal_bench_env_guard_smoke",
+        )
+        assert job_root_complete["ready_for_launch_state"] is True, job_root_complete
+        assert job_root_complete["ready_for_compact_result_ingest"] is True, job_root_complete
+        assert job_root_complete["trial_result_present_count"] == 1, job_root_complete
+        assert job_root_complete["first_blocker"] == "ready_for_compact_result_ingest", job_root_complete
+
+        summary_with_materialization = summarize_terminal_bench_private_runner_launch(
+            launch,
+            post_launch_materialization=job_root_complete,
+        )
+        nested = summary_with_materialization["post_launch_materialization"]
+        assert nested["schema_version"] == "terminal_bench_post_launch_materialization_v0", nested
+        assert nested["ready_for_launch_state"] is True, nested
+        assert nested["raw_paths_recorded"] is False, nested
+        compact = compact_benchmark_run(
+            {
+                "schema_version": "benchmark_run_v0",
+                "private_runner_launch_summary": summary_with_materialization,
+            }
+        )
+        compact_nested = compact["private_runner_launch_summary"][
+            "post_launch_materialization"
+        ]
+        assert compact_nested["ready_for_launch_state"] is True, compact_nested
+        assert compact_nested["raw_paths_recorded"] is False, compact_nested
 
     baseline_launch = build_terminal_bench_private_runner_launch(
         mode="hardened-codex",

--- a/goal_harness/benchmark.py
+++ b/goal_harness/benchmark.py
@@ -75,6 +75,9 @@ TERMINAL_BENCH_ACTIVE_USER_PRIVATE_LAUNCHER_PLAN_SCHEMA = (
 TERMINAL_BENCH_TASK_MATERIAL_READINESS_SCHEMA = (
     "terminal_bench_task_material_readiness_v0"
 )
+TERMINAL_BENCH_POST_LAUNCH_MATERIALIZATION_SCHEMA = (
+    "terminal_bench_post_launch_materialization_v0"
+)
 TERMINAL_BENCH_ACTIVE_USER_SIMULATOR_SETTING = "codex_cli_user_simulator"
 TERMINAL_BENCH_ACTIVE_USER_SIMULATOR_INJECTION_FIRST_BLOCKER = (
     "missing_simulator_to_worker_injection_channel"
@@ -2568,8 +2571,92 @@ def build_terminal_bench_private_runner_launch(**command_kwargs: Any) -> dict[st
     }
 
 
+def summarize_terminal_bench_post_launch_materialization(
+    jobs_dir: str | Path,
+    *,
+    job_name: str | None = None,
+) -> dict[str, Any]:
+    """Summarize whether Harbor produced a pollable job directory after launch.
+
+    The summary intentionally records only booleans, counts, and optional job
+    basenames. It does not read logs, task text, trajectories, or file contents,
+    and it never echoes local paths.
+    """
+
+    jobs_dir_text = str(jobs_dir)
+    public_job_name = Path(str(job_name)).name if job_name else ""
+    placeholder = "<" in jobs_dir_text or ">" in jobs_dir_text
+    summary: dict[str, Any] = {
+        "schema_version": TERMINAL_BENCH_POST_LAUNCH_MATERIALIZATION_SCHEMA,
+        "checked": not placeholder,
+        "ready_for_launch_state": False,
+        "ready_for_compact_result_ingest": False,
+        "first_blocker": "jobs_dir_placeholder" if placeholder else "",
+        "job_name": public_job_name,
+        "jobs_dir_present": False,
+        "job_root_present": False,
+        "job_lock_present": False,
+        "job_result_present": False,
+        "trial_result_present_count": 0,
+        "candidate_job_root_count": 0,
+        "raw_paths_recorded": False,
+        "raw_logs_read": False,
+        "raw_task_text_read": False,
+        "trajectory_read": False,
+    }
+    if placeholder:
+        return summary
+
+    root = Path(jobs_dir).expanduser()
+    jobs_dir_present = root.is_dir()
+    summary["jobs_dir_present"] = jobs_dir_present
+    if not jobs_dir_present:
+        summary["first_blocker"] = "jobs_dir_missing"
+        return summary
+
+    if public_job_name:
+        candidates = [root / public_job_name]
+    else:
+        candidates = [path for path in sorted(root.iterdir()) if path.is_dir()]
+    existing_candidates = [path for path in candidates if path.is_dir()]
+    summary["candidate_job_root_count"] = len(existing_candidates)
+    if not existing_candidates:
+        summary["first_blocker"] = "job_root_missing"
+        return summary
+
+    job_root = existing_candidates[0]
+    lock_present = (job_root / "lock.json").is_file()
+    result_present = (job_root / "result.json").is_file()
+    trial_result_count = sum(
+        1
+        for child in job_root.iterdir()
+        if child.is_dir() and (child / "result.json").is_file()
+    )
+    summary.update(
+        {
+            "job_root_present": True,
+            "job_lock_present": lock_present,
+            "job_result_present": result_present,
+            "trial_result_present_count": trial_result_count,
+            "ready_for_launch_state": lock_present,
+            "ready_for_compact_result_ingest": (
+                result_present and trial_result_count > 0
+            ),
+        }
+    )
+    if not lock_present:
+        summary["first_blocker"] = "job_lock_missing"
+    elif not result_present or trial_result_count <= 0:
+        summary["first_blocker"] = "ready_for_compact_polling"
+    else:
+        summary["first_blocker"] = "ready_for_compact_result_ingest"
+    return summary
+
+
 def summarize_terminal_bench_private_runner_launch(
     launch: dict[str, Any],
+    *,
+    post_launch_materialization: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Return a public-safe summary of a private Harbor launch contract."""
 
@@ -2620,7 +2707,7 @@ def summarize_terminal_bench_private_runner_launch(
     auth_names_present = [
         name for name in TERMINAL_BENCH_CODEX_AUTH_SURFACE_NAMES if name in env
     ]
-    return {
+    summary = {
         "schema_version": "terminal_bench_private_runner_launch_summary_v0",
         "launch_schema_version": str(launch.get("schema_version") or ""),
         "uses_private_runner_env": launch.get("uses_private_runner_env") is True,
@@ -2663,6 +2750,16 @@ def summarize_terminal_bench_private_runner_launch(
         "raw_env_recorded": False,
         "raw_paths_recorded": False,
     }
+    materialization = (
+        post_launch_materialization
+        if isinstance(post_launch_materialization, dict)
+        else launch.get("post_launch_materialization")
+        if isinstance(launch.get("post_launch_materialization"), dict)
+        else None
+    )
+    if materialization:
+        summary["post_launch_materialization"] = materialization
+    return summary
 
 
 def normalize_terminal_bench_private_runner_invocation(

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -31,6 +31,7 @@ from .benchmark import (
     build_terminal_bench_harbor_result_benchmark_run,
     collect_terminal_bench_goal_harness_cli_bridge_trace,
     filter_public_benchmark_artifact_paths,
+    summarize_terminal_bench_post_launch_materialization,
     terminal_bench_recommended_action,
 )
 from .configure_goal import configure_goal, render_configure_goal_markdown
@@ -241,6 +242,34 @@ def render_benchmark_verifier_attribution_review_markdown(
         f"- Compact only: `{read_boundary.get('compact_only')}`",
         f"- Raw artifacts read: `{read_boundary.get('raw_artifacts_read')}`",
     ]
+    return "\n".join(lines) + "\n"
+
+
+def render_terminal_bench_post_launch_materialization_markdown(
+    payload: dict[str, object],
+) -> str:
+    lines = [
+        "# Terminal-Bench Post-Launch Materialization",
+        "",
+        f"- Schema: `{payload.get('schema_version')}`",
+        f"- Checked: `{payload.get('checked')}`",
+        f"- Ready for launch state: `{payload.get('ready_for_launch_state')}`",
+        "- Ready for compact result ingest: "
+        f"`{payload.get('ready_for_compact_result_ingest')}`",
+        f"- First blocker: `{payload.get('first_blocker')}`",
+        f"- Job name: `{payload.get('job_name')}`",
+        f"- Jobs dir present: `{payload.get('jobs_dir_present')}`",
+        f"- Job root present: `{payload.get('job_root_present')}`",
+        f"- Job lock present: `{payload.get('job_lock_present')}`",
+        f"- Job result present: `{payload.get('job_result_present')}`",
+        f"- Trial results: `{payload.get('trial_result_present_count')}`",
+        f"- Raw paths recorded: `{payload.get('raw_paths_recorded')}`",
+        f"- Raw logs read: `{payload.get('raw_logs_read')}`",
+        f"- Task text read: `{payload.get('raw_task_text_read')}`",
+        f"- Trajectory read: `{payload.get('trajectory_read')}`",
+    ]
+    if payload.get("error"):
+        lines.append(f"- Error: {payload.get('error')}")
     return "\n".join(lines) + "\n"
 
 
@@ -1257,6 +1286,42 @@ def main(argv: list[str] | None = None) -> int:
         help="Candidate benchmark artifact paths to classify without reading.",
     )
 
+    benchmark_post_launch_parser = benchmark_sub.add_parser(
+        "summarize-post-launch",
+        help=(
+            "Summarize whether a Terminal-Bench Harbor launch materialized a "
+            "pollable job directory. This records booleans, counts, and job "
+            "basenames only; it does not read logs, task text, trajectories, "
+            "Docker, model APIs, or uploads."
+        ),
+    )
+    add_subcommand_format(benchmark_post_launch_parser)
+    benchmark_post_launch_parser.add_argument(
+        "benchmark_name",
+        choices=["terminal-bench"],
+        help="Benchmark family.",
+    )
+    benchmark_post_launch_parser.add_argument(
+        "--jobs-dir",
+        required=True,
+        help=(
+            "Private Harbor jobs directory to check. The value is used only for "
+            "local filesystem probing and is not echoed in output."
+        ),
+    )
+    benchmark_post_launch_parser.add_argument(
+        "--job-name",
+        help="Expected Harbor job directory basename.",
+    )
+    benchmark_post_launch_parser.add_argument(
+        "--require-ready-for-launch-state",
+        action="store_true",
+        help=(
+            "Return non-zero unless the job root and lock.json are present. "
+            "Use this before declaring a private launch state durable."
+        ),
+    )
+
     benchmark_claim_review_parser = benchmark_sub.add_parser(
         "review-claim",
         help=(
@@ -2224,6 +2289,55 @@ def main(argv: list[str] | None = None) -> int:
                 payload,
                 output_format(args),
                 render_benchmark_verifier_attribution_review_markdown,
+            )
+            return 0 if payload.get("ok") else 1
+        if args.benchmark_command == "summarize-post-launch":
+            try:
+                if args.benchmark_name != "terminal-bench":
+                    raise ValueError("only terminal-bench is supported")
+                payload = summarize_terminal_bench_post_launch_materialization(
+                    args.jobs_dir,
+                    job_name=args.job_name,
+                )
+                ready = payload.get("ready_for_launch_state") is True
+                payload["ok"] = (
+                    ready if args.require_ready_for_launch_state else True
+                )
+                payload["require_ready_for_launch_state"] = bool(
+                    args.require_ready_for_launch_state
+                )
+                payload["read_boundary"] = {
+                    "raw_paths_recorded": False,
+                    "raw_logs_read": False,
+                    "task_text_read": False,
+                    "trajectory_read": False,
+                    "docker_invoked": False,
+                    "model_api_invoked": False,
+                    "upload_invoked": False,
+                }
+                if args.require_ready_for_launch_state and not ready:
+                    payload["error"] = (
+                        "post-launch materialization is not ready for launch state"
+                    )
+            except Exception as exc:
+                payload = {
+                    "ok": False,
+                    "schema_version": "terminal_bench_post_launch_materialization_v0",
+                    "error": str(exc),
+                    "read_boundary": {
+                        "raw_paths_recorded": False,
+                        "raw_logs_read": False,
+                        "task_text_read": False,
+                        "trajectory_read": False,
+                        "docker_invoked": False,
+                        "model_api_invoked": False,
+                        "upload_invoked": False,
+                    },
+                }
+            print_payload(
+                payload,
+                output_format(args),
+                render_terminal_bench_post_launch_materialization_markdown,
             )
             return 0 if payload.get("ok") else 1
         if args.benchmark_command == "run":

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -924,6 +924,42 @@ def _compact_benchmark_private_runner_launch(value: Any) -> dict[str, Any]:
     )
     if names:
         compact["auth_surface_names_present"] = names
+    materialization = _compact_benchmark_post_launch_materialization(
+        value.get("post_launch_materialization")
+    )
+    if materialization:
+        compact["post_launch_materialization"] = materialization
+    return compact
+
+
+def _compact_benchmark_post_launch_materialization(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+
+    compact: dict[str, Any] = {}
+    for field in ("schema_version", "first_blocker", "job_name"):
+        text = public_safe_compact_text(value.get(field), limit=140)
+        if text:
+            compact[field] = text
+    for field in (
+        "checked",
+        "ready_for_launch_state",
+        "ready_for_compact_result_ingest",
+        "jobs_dir_present",
+        "job_root_present",
+        "job_lock_present",
+        "job_result_present",
+        "raw_paths_recorded",
+        "raw_logs_read",
+        "raw_task_text_read",
+        "trajectory_read",
+    ):
+        if isinstance(value.get(field), bool):
+            compact[field] = value[field]
+    for field in ("trial_result_present_count", "candidate_job_root_count"):
+        count = value.get(field)
+        if isinstance(count, int) and not isinstance(count, bool):
+            compact[field] = count
     return compact
 
 


### PR DESCRIPTION
## Summary
- add a public-safe Terminal-Bench post-launch materialization summary
- expose `goal-harness benchmark summarize-post-launch` with a fail-closed ready gate
- extend the private runner guard smoke to verify CLI exit behavior and no path/log/task/trajectory leakage

## Validation
- `git diff --check`
- `goal-harness --format json check --scan-path goal_harness/benchmark.py --scan-path goal_harness/cli.py --scan-path goal_harness/status.py --scan-path examples/terminal-bench-private-runner-env-guard-smoke.py`
- `python3 examples/terminal-bench-private-runner-env-guard-smoke.py`
- `python3 examples/terminal-bench-codex-goal-harness-active-cli-bridge-smoke.py`
- `python3 -m py_compile goal_harness/cli.py goal_harness/benchmark.py goal_harness/status.py`
