### PR TITLE
Allow compact active-user observation artifacts

### DIFF
--- a/examples/benchmark-artifact-path-filter-smoke.py
+++ b/examples/benchmark-artifact-path-filter-smoke.py
@@ -20,6 +20,7 @@ PRIVATE_ROOT = "/private/example/project/.local/private-benchmark-jobs/job-a"
 PATHS = [
     f"{PRIVATE_ROOT}/paired_comparison.compact.json",
     f"{PRIVATE_ROOT}/launch_status.public.json",
+    f"{PRIVATE_ROOT}/treatment/active-user-feed/goal-harness-active-user-observation.json",
     f"{PRIVATE_ROOT}/agent/trajectory.json",
     f"{PRIVATE_ROOT}/launch_private_manifest.local.json",
     f"{PRIVATE_ROOT}/tasks/demo/instruction.md",
@@ -42,11 +43,12 @@ def main() -> None:
     payload = filter_public_benchmark_artifact_paths(PATHS)
     assert payload["schema_version"] == "benchmark_artifact_path_filter_v0", payload
     assert payload["path_recorded"] is False, payload
-    assert payload["allowed_to_read_count"] == 2, payload
+    assert payload["allowed_to_read_count"] == 3, payload
     assert payload["blocked_count"] == 3, payload
     assert payload["allowed_artifact_basenames"] == [
         "paired_comparison.compact.json",
         "launch_status.public.json",
+        "goal-harness-active-user-observation.json",
     ], payload
     assert payload["blocked_reasons"]["raw_private_surface"] == 2, payload
     assert payload["blocked_reasons"]["private_or_local_manifest"] == 1, payload
@@ -69,7 +71,7 @@ def main() -> None:
         capture_output=True,
     )
     cli_payload = json.loads(result.stdout)
-    assert cli_payload["allowed_to_read_count"] == 2, cli_payload
+    assert cli_payload["allowed_to_read_count"] == 3, cli_payload
     assert cli_payload["blocked_count"] == 3, cli_payload
     assert_no_path_leak(cli_payload)
     print("ok")

--- a/goal_harness/benchmark.py
+++ b/goal_harness/benchmark.py
@@ -197,6 +197,7 @@ BENCHMARK_PUBLIC_ARTIFACT_FILENAMES = (
     "paired_comparison.compact.json",
     "launch_status.public.json",
     "launch_summaries.public.json",
+    "goal-harness-active-user-observation.json",
 )
 BENCHMARK_RAW_PRIVATE_PATH_MARKERS = (
     "/agent/trajectory.json",


### PR DESCRIPTION
## Summary
- allow the compact Goal Harness active-user observation artifact basename through the benchmark artifact classifier
- keep feed JSONL, raw result files, logs, task text, trajectories, and private manifests blocked
- update the artifact path filter smoke to cover the new allowlisted basename

## Validation
- python3 examples/benchmark-artifact-path-filter-smoke.py
- python3 -m py_compile goal_harness/benchmark.py examples/benchmark-artifact-path-filter-smoke.py
- git diff --check
- goal-harness --format json check
- goal-harness benchmark classify-artifacts --format json <compact observation> <feed jsonl> <result json>
