### PR TITLE
Add AgentIssue Codex CLI runner flow

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/README.md
+++ b/docs/research/long-horizon-agent-benchmarks/README.md
@@ -171,6 +171,69 @@ work still belongs in the existing code, examples, and contract documents:
   Last Exam to the benchmark backlog. It records the Xiaohongshu discovery
   signal, verifies the arXiv and public GitHub surfaces, and keeps ALE behind
   the current Terminal-Bench paired pilot until an adapter dossier exists.
+- `agentissue-bench-codex-cli-runner-contract-v0.md`: runner contract that
+  replaces ad hoc agent execution with a Codex CLI benchmark flow for
+  AgentIssue-Bench. It records that no official Codex CLI AgentIssue-Bench
+  metric was found, freezes other benchmark candidates, and defines the
+  correct runner sequence: fetch public issue context, pull one selected image,
+  extract the container's buggy source, initialize a local git baseline, run
+  host-local `codex exec --ephemeral` in that source tree, write
+  `Patches/lagent_239/attempt.patch`, evaluate the same single tag, and reduce
+  only compact hash/count/status evidence.
+- `agentissue-bench-codex-cli-runner-flow-plan-v0.md`: no-execution command
+  flow plan for the same selected tag. It turns the runner contract into
+  deterministic host-Codex and single-tag Docker command shapes with absolute
+  private-job-root placeholders, explicit phase ordering, compact reducer
+  fields, and stop rules before Codex/model execution, Docker starts, auth
+  sync, all-tag helpers, uploads, submits, public ranking paths, raw artifacts,
+  fixed/oracle material, or current-HEAD patch generation.
+- `agentissue-bench-codex-cli-runner-dry-run-wrapper-v0.md`: CLI
+  materialization of that flow as
+  `goal-harness benchmark agentissue-codex-runner-flow --tag lagent_239`.
+  It defaults to dry-run and `--execute` appends only compact no-run
+  `benchmark_run_v0` readiness, while still avoiding Codex/model execution,
+  Docker starts, auth sync, patch generation/evaluation, uploads, submits,
+  public ranking paths, raw artifacts, fixed/oracle material, or current-HEAD
+  patch generation.
+- `agentissue-bench-codex-cli-runner-synthetic-staging-v0.md`: opt-in
+  `--synthetic-staging-root` fixture for the same CLI wrapper. It creates only
+  synthetic private-job-root placeholders for `context/prompt.md`, extracted
+  source, `Patches/lagent_239/attempt.patch` parent placement,
+  `runner-flow-plan.public.json`, and `benchmark_run.compact.json`, while still
+  avoiding real AgentIssue task material, Codex/model execution, Docker starts,
+  auth sync, patch generation/evaluation, uploads, submits, public ranking
+  paths, raw artifacts, fixed/oracle material, or current-HEAD patch
+  generation.
+- `agentissue-bench-codex-cli-runner-execution-gate-v0.md`: guarded
+  no-execute `--execution-gate-root` packet for `lagent_239`. It materializes
+  the synthetic staging files plus `execution-gate.public.json`, rendering the
+  selected-container source extraction, private git baseline, host-local
+  `codex exec --ephemeral`, patch export, and selected-tag eval command shapes
+  while keeping real AgentIssue task material, Codex/model execution, Docker
+  pull/start, auth sync, patch generation/evaluation, uploads, submits, public
+  ranking paths, raw artifacts, fixed/oracle material, and current-HEAD patch
+  generation behind a future run-specific gate.
+- `agentissue-bench-codex-cli-runner-first-run-handoff-v0.md`: no-execute
+  `--first-run-handoff-root` packet for `lagent_239`. It materializes the
+  execution gate plus `first-run-handoff.public.json` and
+  `first-run-handoff.md`, naming the exact command shape, private artifact
+  boundary, expected compact outputs, budget/auth boundary, and safety
+  checklist for a later operator-triggered e2e run without running Codex,
+  Docker, source extraction, patch generation/evaluation, uploads, submits, or
+  public ranking paths.
+- `agentissue-bench-codex-cli-runner-pr-ready-packet-v0.md`: public-safe
+  consolidation packet for the full `lagent_239` runner-flow chain. It ties
+  together the contract, flow plan, dry-run wrapper, synthetic staging,
+  execution gate, first-run handoff, and seven matching smokes into one
+  reviewable route while preserving no-run/no-upload/no-submit/no-public-ranking
+  boundaries.
+- `agentissue-bench-codex-cli-runner-publication-change-set-v0.md`: staging
+  and review packet for publishing only the AgentIssue runner-flow change set.
+  It lists the eight docs and eight smokes that should move together, marks
+  `goal_harness/benchmark.py`, `goal_harness/cli.py`, and this README as mixed
+  tracked files that need hunk-level staging, and excludes unrelated benchmark
+  lanes, runtime state, credentials, raw artifacts, uploads, submits, and
+  public ranking paths.
 - `terminal-bench-cli-dry-run-fake-worker-v0.md`: public CLI skeleton for
   `goal-harness benchmark run terminal-bench`. The command defaults to dry-run,
   exposes `hardened-codex`, `codex-goal-harness`, passive observation, and

--- a/docs/research/long-horizon-agent-benchmarks/README.md
+++ b/docs/research/long-horizon-agent-benchmarks/README.md
@@ -221,15 +221,21 @@ work still belongs in the existing code, examples, and contract documents:
   checklist for a later operator-triggered e2e run without running Codex,
   Docker, source extraction, patch generation/evaluation, uploads, submits, or
   public ranking paths.
+- `agentissue-bench-codex-cli-runner-workflow-check-v0.md`: no-execute
+  `--workflow-check-root` packet for `lagent_239`. It materializes the
+  first-run handoff plus `workflow-check.public.json`, checking phase order,
+  host-Codex auth isolation, no worker network/Docker access, patch-source
+  provenance, selected-tag eval boundaries, and compact/public artifact
+  allowlists before any later operator-triggered e2e run.
 - `agentissue-bench-codex-cli-runner-pr-ready-packet-v0.md`: public-safe
   consolidation packet for the full `lagent_239` runner-flow chain. It ties
   together the contract, flow plan, dry-run wrapper, synthetic staging,
-  execution gate, first-run handoff, and seven matching smokes into one
-  reviewable route while preserving no-run/no-upload/no-submit/no-public-ranking
-  boundaries.
+  execution gate, first-run handoff, workflow check, and eight matching smokes
+  into one reviewable route while preserving no-run/no-upload/no-submit/
+  no-public-ranking boundaries.
 - `agentissue-bench-codex-cli-runner-publication-change-set-v0.md`: staging
   and review packet for publishing only the AgentIssue runner-flow change set.
-  It lists the eight docs and eight smokes that should move together, marks
+  It lists the nine docs and nine smokes that should move together, marks
   `goal_harness/benchmark.py`, `goal_harness/cli.py`, and this README as mixed
   tracked files that need hunk-level staging, and excludes unrelated benchmark
   lanes, runtime state, credentials, raw artifacts, uploads, submits, and

--- a/docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-contract-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-contract-v0.md
@@ -1,0 +1,206 @@
+# AgentIssue-Bench Codex CLI Runner Contract V0
+
+Date: 2026-06-12
+
+## Scope
+
+This packet replaces ad hoc agent execution with a Codex CLI benchmark runner
+contract for AgentIssue-Bench.
+
+The current focus is deliberately narrow:
+
+```text
+only_active_benchmark=agentissue-bench
+initial_tag=lagent_239
+no_other_benchmarks_until=agentissue_codex_cli_runner_e2e_clean
+```
+
+Other benchmark candidates remain frozen until this runner can execute one
+clean AgentIssue-Bench single-tag loop end to end.
+
+## Official Codex CLI Metric
+
+No official AgentIssue-Bench Codex CLI metric was found in the current public
+leaderboard or official repository scan.
+
+The official public leaderboard currently lists:
+
+```text
+AutoCodeRover + Claude 3.5 Sonnet: 4.67%
+Agentless + Claude 3.5 Sonnet: 4.00%
+Agentless + GPT-4o: 3.33%
+SWE-agent + Claude 3.5 Sonnet: 2.00%
+AutoCodeRover + GPT-4o: 1.33%
+SWE-agent + GPT-4o: 0.67%
+```
+
+So any Codex CLI result from this repo should be labeled as a local no-upload
+Codex CLI reproduction result, not an official leaderboard metric.
+
+Sources checked:
+
+- https://alfin06.github.io/AgentIssue-Bench-Leaderboard/
+- https://github.com/alfin06/AgentIssue-Bench
+
+## Runner Principle
+
+Codex CLI must run against the benchmark buggy snapshot, not the latest public
+repository HEAD.
+
+The failed exploratory pilot showed why: a patch generated against current
+`InternLM/lagent` HEAD can apply cleanly in the selected container yet still
+fail the container oracle, because the benchmark tests a different buggy
+snapshot. The runner must therefore extract the buggy source from the selected
+container, initialize a local git baseline, and only then call Codex CLI.
+
+## Execution Flow
+
+### 1. Prepare Isolated Job
+
+Create a private job root with:
+
+```text
+context/
+source/
+buggy-source/
+Patches/lagent_239/
+logs/
+reduced/
+```
+
+The job root is private/local. Public writeback may include only counts, hashes,
+status labels, and reduced scores.
+
+### 2. Fetch Public Issue Context
+
+Fetch the selected public issue and comments into the private job root.
+
+Public artifacts may record:
+
+- issue URL;
+- title/body/comment lengths;
+- hashes;
+- timestamps;
+- comment count.
+
+Public artifacts must not reproduce raw issue text.
+
+### 3. Pull Only The Selected Image
+
+Pull only:
+
+```text
+alfin06/agentissue-bench:lagent_239
+```
+
+Do not call official all-tag helper scripts. Do not run global Docker cleanup.
+
+### 4. Extract Buggy Source
+
+Use a selected-tag container to copy the benchmark buggy source to the host
+private job root.
+
+Required policy:
+
+- copy only the buggy source tree needed for patch generation;
+- do not copy fixed source, hidden references, or result artifacts;
+- initialize a local git baseline in the extracted source;
+- do not use current public repository HEAD as the patch-generation source.
+
+### 5. Run Codex CLI As Patch Worker
+
+Invoke host-local Codex CLI only after buggy-source extraction:
+
+```text
+codex exec --ephemeral --ignore-rules --sandbox workspace-write \
+  --cd <buggy-source> \
+  --add-dir <job-root> \
+  --output-last-message <job-root>/codex-last-message.txt \
+  <prompt-file>
+```
+
+Worker constraints:
+
+- Codex auth stays local-only;
+- never sync `~/.codex`;
+- never mount credentials into Docker;
+- worker does not use Docker;
+- worker does not use network;
+- worker does not read fixed diff or oracle material;
+- worker leaves source changes unstaged.
+
+### 6. Write Attempt Patch
+
+After Codex exits, write:
+
+```text
+Patches/lagent_239/attempt.patch
+```
+
+from the extracted buggy-source git diff.
+
+Public writeback may include patch hash, bytes, changed-file count, and hunk
+count. It must not include patch content.
+
+### 7. Evaluate Single Tag
+
+Evaluate only the generated patch against the selected image:
+
+```text
+docker run --platform linux/amd64 --rm --entrypoint bash \
+  -v <patch-dir>:/patches:ro \
+  alfin06/agentissue-bench:lagent_239 \
+  -c '<apply_patch_and_test_patched>'
+```
+
+Do not pass API keys or `.env` values to this container. Do not use official
+helpers that scan all tags or require model/search credentials.
+
+### 8. Compact Reducer
+
+Write compact private-to-public reduction:
+
+```text
+tag
+image_digest
+patch_sha256
+patch_bytes
+exit_code
+resolved
+duration_seconds
+log_sha256
+no_upload
+no_submit
+no_public_ranking_path
+```
+
+Raw logs, patch content, local paths, raw issue text, trajectories, screenshots,
+credentials, and command argv stay private.
+
+## Stop Rules
+
+Stop the runner before public writeback if any of these happens:
+
+- Codex auth or credentials would be copied to a shared host or container;
+- the worker would run on current public HEAD instead of benchmark buggy
+  source;
+- the worker would read fixed diff, hidden references, or oracle material
+  before patch generation;
+- official helper scripts would run all tags, global cleanup, credential
+  prompts, upload, submit, or public ranking paths;
+- compact reducer cannot separate patch/log hashes from raw content.
+
+## Validation
+
+```bash
+python3 examples/agentissue-bench-codex-cli-runner-contract-smoke.py
+python3 -m py_compile examples/agentissue-bench-codex-cli-runner-contract-smoke.py
+goal-harness check \
+  --scan-path examples/agentissue-bench-codex-cli-runner-contract-smoke.py \
+  --scan-path docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-contract-v0.md \
+  --scan-path docs/research/long-horizon-agent-benchmarks/README.md
+git diff --check \
+  docs/research/long-horizon-agent-benchmarks/README.md \
+  docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-contract-v0.md \
+  examples/agentissue-bench-codex-cli-runner-contract-smoke.py
+```

--- a/docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-dry-run-wrapper-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-dry-run-wrapper-v0.md
@@ -1,0 +1,99 @@
+# AgentIssue-Bench Codex CLI Runner Dry-Run Wrapper V0
+
+Date: 2026-06-12
+
+## Scope
+
+This packet materializes the `lagent_239` AgentIssue-Bench Codex CLI runner
+flow as a Goal Harness CLI wrapper:
+
+```bash
+goal-harness benchmark agentissue-codex-runner-flow \
+  --goal-id goal-harness-meta \
+  --tag lagent_239
+```
+
+The command defaults to dry-run. Passing `--execute` appends only a compact
+`benchmark_run_v0` readiness event; it still does not invoke Codex CLI, a model
+API, Docker, official all-tag helpers, uploads, submit, public ranking paths,
+or patch generation.
+
+## Runner Shape
+
+The wrapper renders one selected-tag plan:
+
+```text
+benchmark=agentissue-bench
+selected_tag=lagent_239
+selected_image=alfin06/agentissue-bench:lagent_239
+mode=agentissue_codex_cli_runner_dry_run_wrapper
+```
+
+The rendered phase order is:
+
+1. prepare a private job root;
+2. write public issue context into private `context/`;
+3. opt-in pull of only the selected image;
+4. opt-in extraction of the selected container's buggy source;
+5. initialize a git baseline in the extracted source;
+6. opt-in host-local `codex exec` from that extracted source;
+7. write `Patches/lagent_239/attempt.patch` from that git diff;
+8. opt-in selected-tag eval;
+9. reduce compact public evidence.
+
+The default wrapper step stops before every opt-in execution phase. It exists
+so future workers can verify command rendering and state writeback before a
+private run.
+
+## Command Rendering
+
+The host Codex patch worker shape is:
+
+```text
+codex exec --ephemeral --ignore-rules --sandbox workspace-write \
+  --cd <abs-private-job-root>/buggy-source \
+  --add-dir <abs-private-job-root> \
+  --output-last-message <abs-private-job-root>/codex-last-message.txt \
+  <abs-private-job-root>/context/prompt.md
+```
+
+The selected-tag eval shape is:
+
+```text
+docker run --platform linux/amd64 --rm --entrypoint bash \
+  -v <abs-private-job-root>/Patches/lagent_239:/patches:ro \
+  alfin06/agentissue-bench:lagent_239 \
+  -c <apply_patch_and_test_patched>
+```
+
+Both shapes are placeholders. The wrapper records that `codex_cli_invoked`,
+`model_api_invoked`, `docker_container_started`, `patch_generated`, and
+`patch_evaluated` are all false.
+
+## Output
+
+The CLI output includes:
+
+- the append payload from `append_benchmark_run`;
+- `benchmark_cli`, recording that no runner, Codex, Docker, auth read, upload,
+  submit, or leaderboard action occurred;
+- `agentissue_runner_flow`, recording command shapes, staging placeholders,
+  stop rules, and reducer boundaries;
+- a compact `benchmark_run_v0` with `official_task_score.kind` set to
+  `agentissue_bench_single_tag_container_eval_not_run`.
+
+This packet does not claim an official AgentIssue-Bench score or Codex CLI
+success rate.
+
+## Validation
+
+```bash
+python3 examples/agentissue-bench-codex-cli-runner-dry-run-wrapper-smoke.py
+python3 -m py_compile examples/agentissue-bench-codex-cli-runner-dry-run-wrapper-smoke.py
+goal-harness check \
+  --scan-path goal_harness/benchmark.py \
+  --scan-path goal_harness/cli.py \
+  --scan-path examples/agentissue-bench-codex-cli-runner-dry-run-wrapper-smoke.py \
+  --scan-path docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-dry-run-wrapper-v0.md \
+  --scan-path docs/research/long-horizon-agent-benchmarks/README.md
+```

--- a/docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-execution-gate-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-execution-gate-v0.md
@@ -1,0 +1,94 @@
+# AgentIssue-Bench Codex CLI Runner Execution Gate V0
+
+Date: 2026-06-13
+
+## Scope
+
+This packet adds the next no-execute gate for the selected
+AgentIssue-Bench tag:
+
+```bash
+goal-harness benchmark agentissue-codex-runner-flow \
+  --goal-id goal-harness-meta \
+  --tag lagent_239 \
+  --execution-gate-root <private-gate-root>
+```
+
+The command materializes the existing synthetic staging files plus
+`execution-gate.public.json`. It still does not run Codex CLI, a model API,
+Docker, source extraction, git baseline creation, patch generation, patch
+evaluation, upload, submit, or public ranking paths. Passing `--execute`
+appends only a compact no-run `benchmark_run_v0` readiness event.
+
+`--execution-gate-root` and `--synthetic-staging-root` are mutually exclusive
+so a worker cannot accidentally split one selected tag across two private job
+roots.
+
+## Gate Shape
+
+The gate records only command shapes and relative-path placements.
+
+Source extraction shape:
+
+```text
+docker image inspect alfin06/agentissue-bench:lagent_239
+docker create --name <tmp-agentissue-lagent-239-container> alfin06/agentissue-bench:lagent_239
+docker cp <tmp-agentissue-lagent-239-container>:/workspace/. <abs-private-job-root>/buggy-source
+docker rm <tmp-agentissue-lagent-239-container>
+```
+
+Private git baseline shape:
+
+```text
+git -C <abs-private-job-root>/buggy-source init
+git -C <abs-private-job-root>/buggy-source add .
+git -C <abs-private-job-root>/buggy-source commit -m agentissue-bench-buggy-source-baseline
+```
+
+Host Codex patch-worker shape remains:
+
+```text
+codex exec --ephemeral --ignore-rules --sandbox workspace-write \
+  --cd <abs-private-job-root>/buggy-source \
+  --add-dir <abs-private-job-root> \
+  --output-last-message <abs-private-job-root>/codex-last-message.txt \
+  <abs-private-job-root>/context/prompt.md
+```
+
+Patch export placement remains:
+
+```text
+Patches/lagent_239/attempt.patch
+```
+
+## Compact Event
+
+The compact event uses:
+
+```text
+mode=agentissue_codex_cli_runner_execution_gate
+first_blocker=execution_gate_only_no_real_case
+real_run=false
+submit_eligible=false
+leaderboard_evidence=false
+```
+
+Validation fields assert that the selected-container extraction commands,
+private git baseline commands, host Codex command, and attempt-patch placement
+are rendered, and that future execution still requires a run-specific opt-in.
+
+## Validation
+
+```bash
+python3 examples/agentissue-bench-codex-cli-runner-execution-gate-smoke.py
+python3 -m py_compile \
+  goal_harness/benchmark.py \
+  goal_harness/cli.py \
+  examples/agentissue-bench-codex-cli-runner-execution-gate-smoke.py
+goal-harness check \
+  --scan-path goal_harness/benchmark.py \
+  --scan-path goal_harness/cli.py \
+  --scan-path examples/agentissue-bench-codex-cli-runner-execution-gate-smoke.py \
+  --scan-path docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-execution-gate-v0.md \
+  --scan-path docs/research/long-horizon-agent-benchmarks/README.md
+```

--- a/docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-first-run-handoff-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-first-run-handoff-v0.md
@@ -1,0 +1,82 @@
+# AgentIssue-Bench Codex CLI Runner First-Run Handoff V0
+
+Date: 2026-06-13
+
+## Scope
+
+This packet turns the guarded `lagent_239` execution gate into a no-execute
+first-run handoff surface:
+
+```bash
+goal-harness benchmark agentissue-codex-runner-flow \
+  --goal-id goal-harness-meta \
+  --tag lagent_239 \
+  --first-run-handoff-root <private-gate-root>
+```
+
+The command materializes the synthetic staging files, `execution-gate.public.json`,
+`first-run-handoff.public.json`, `first-run-handoff.md`, and
+`benchmark_run.compact.json`. It still does not run Codex CLI, a model API,
+Docker, source extraction, git baseline creation, patch generation, patch
+evaluation, upload, submit, or public ranking paths. Passing `--execute`
+appends only a compact no-run `benchmark_run_v0` handoff event.
+
+`--first-run-handoff-root`, `--execution-gate-root`, and
+`--synthetic-staging-root` are mutually exclusive so one selected tag has one
+private packet root.
+
+## Packet Shape
+
+The handoff packet records the command shape:
+
+```text
+goal-harness benchmark agentissue-codex-runner-flow --goal-id <goal-id> --tag lagent_239 --execution-gate-root <private-gate-root> --delivery-batch-scale multi_surface --delivery-outcome outcome_progress --execute
+```
+
+It records a private artifact boundary:
+
+```text
+public: runner-flow-plan.public.json, execution-gate.public.json, first-run-handoff.public.json, first-run-handoff.md, benchmark_run.compact.json
+private: context/, buggy-source/, Patches/lagent_239/
+```
+
+It records budget/auth safety:
+
+```text
+codex auth values read=false
+codex home synced=false
+model budget spent by packet=false
+shared remote host receives codex auth=false
+```
+
+## Compact Event
+
+The compact event uses:
+
+```text
+mode=agentissue_codex_cli_runner_first_run_handoff_packet
+first_blocker=first_run_handoff_only_no_real_case
+real_run=false
+submit_eligible=false
+leaderboard_evidence=false
+```
+
+Validation fields assert that the command shape, private artifact boundary,
+expected compact outputs, budget/auth boundary, and safety checklist are
+rendered, while all real execution flags remain false.
+
+## Validation
+
+```bash
+python3 examples/agentissue-bench-codex-cli-runner-first-run-handoff-smoke.py
+python3 -m py_compile \
+  goal_harness/benchmark.py \
+  goal_harness/cli.py \
+  examples/agentissue-bench-codex-cli-runner-first-run-handoff-smoke.py
+goal-harness check \
+  --scan-path goal_harness/benchmark.py \
+  --scan-path goal_harness/cli.py \
+  --scan-path examples/agentissue-bench-codex-cli-runner-first-run-handoff-smoke.py \
+  --scan-path docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-first-run-handoff-v0.md \
+  --scan-path docs/research/long-horizon-agent-benchmarks/README.md
+```

--- a/docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-flow-plan-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-flow-plan-v0.md
@@ -1,0 +1,124 @@
+# AgentIssue-Bench Codex CLI Runner Flow Plan V0
+
+Date: 2026-06-12
+
+## Scope
+
+This packet turns the AgentIssue-Bench `lagent_239` runner contract into a
+deterministic command-flow plan without executing the benchmark.
+
+It is deliberately narrower than a live pilot:
+
+```text
+benchmark=agentissue-bench
+selected_tag=lagent_239
+dry_run_plan_only=true
+real_execution_done=false
+```
+
+No Codex CLI prompt, model API call, Docker pull, container start, patch
+generation, patch evaluation, upload, submit, public ranking path, credential
+read, or raw artifact read happened in this step.
+
+## Flow
+
+The runner flow is fixed to one tag and one private job root:
+
+1. prepare a private job root;
+2. fetch public issue context into the private `context/` area;
+3. pull only `alfin06/agentissue-bench:lagent_239`;
+4. extract the selected container's benchmark buggy source;
+5. initialize a local git baseline in that extracted source;
+6. run host-local Codex CLI from the extracted source;
+7. write `Patches/lagent_239/attempt.patch` from that git diff;
+8. evaluate only `alfin06/agentissue-bench:lagent_239`;
+9. reduce compact hash/count/status evidence.
+
+The key invariant is source alignment: Codex CLI must patch the benchmark buggy
+snapshot, not current public `InternLM/lagent` HEAD.
+
+## Command Shapes
+
+The Codex patch worker shape is:
+
+```text
+codex exec --ephemeral --ignore-rules --sandbox workspace-write \
+  --cd <abs-private-job-root>/buggy-source \
+  --add-dir <abs-private-job-root> \
+  --output-last-message <abs-private-job-root>/codex-last-message.txt \
+  <abs-private-job-root>/context/prompt.md
+```
+
+Runner constraints:
+
+- the command runs on the host, not in Docker;
+- all runner paths must be absolute in the private job root;
+- Codex home/auth is not copied;
+- the worker does not use Docker;
+- the worker does not use network;
+- the worker does not read fixed diff or oracle material.
+
+The single-tag evaluation shape is:
+
+```text
+docker run --platform linux/amd64 --rm --entrypoint bash \
+  -v <abs-private-job-root>/Patches/lagent_239:/patches:ro \
+  alfin06/agentissue-bench:lagent_239 \
+  -c <apply_patch_and_test_patched>
+```
+
+Runner constraints:
+
+- do not use official helpers that scan all tags;
+- do not pass credentials into Docker;
+- do not upload, submit, or touch public ranking paths;
+- do not publish patch content or raw logs.
+
+## Public Reducer
+
+Only these reduced fields may leave the private job root:
+
+```text
+tag
+image_digest
+patch_sha256
+patch_bytes
+changed_file_count
+hunk_count
+exit_code
+resolved
+duration_seconds
+log_sha256
+no_upload
+no_submit
+no_public_ranking_path
+```
+
+Raw issue text, patch content, raw logs, absolute paths, trajectories,
+screenshots, credentials, hidden references, and fixed/oracle material stay
+private.
+
+## Output
+
+The smoke fixture emits:
+
+- `agentissue_bench_codex_cli_runner_flow_plan_v0`;
+- compact `benchmark_run_v0` with `real_run=false`;
+- compact `benchmark_result_v0` with `official_task_score.status=not_run`;
+- a next action to materialize this flow in the private job root or write a
+  compact blocker.
+
+## Validation
+
+```bash
+python3 examples/agentissue-bench-codex-cli-runner-flow-smoke.py
+python3 -m py_compile examples/agentissue-bench-codex-cli-runner-flow-smoke.py
+goal-harness check \
+  --scan-path examples/agentissue-bench-codex-cli-runner-flow-smoke.py \
+  --scan-path docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-flow-plan-v0.md \
+  --scan-path docs/research/long-horizon-agent-benchmarks/README.md
+git diff --check \
+  docs/research/long-horizon-agent-benchmarks/README.md \
+  docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-flow-plan-v0.md \
+  examples/agentissue-bench-codex-cli-runner-flow-smoke.py
+```

--- a/docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-pr-ready-packet-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-pr-ready-packet-v0.md
@@ -1,0 +1,96 @@
+# AgentIssue-Bench Codex CLI Runner PR-Ready Packet V0
+
+Date: 2026-06-13
+
+## Scope
+
+This packet consolidates the AgentIssue-Bench `lagent_239` Codex CLI runner
+route into one public-safe review surface. It does not run Codex, Docker, a
+model API, source extraction, patch generation, patch evaluation, upload,
+submit, or public ranking paths.
+
+The route is intentionally single-benchmark and single-tag:
+
+```text
+benchmark=agentissue-bench
+selected_tag=lagent_239
+selected_image=alfin06/agentissue-bench:lagent_239
+real_run=false
+submit_eligible=false
+leaderboard_evidence=false
+```
+
+## Consolidated Artifacts
+
+The PR-ready packet is complete only when these public artifacts move together:
+
+```text
+docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-contract-v0.md
+docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-flow-plan-v0.md
+docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-dry-run-wrapper-v0.md
+docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-synthetic-staging-v0.md
+docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-execution-gate-v0.md
+docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-first-run-handoff-v0.md
+docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-pr-ready-packet-v0.md
+```
+
+And these public smokes:
+
+```text
+examples/agentissue-bench-codex-cli-runner-contract-smoke.py
+examples/agentissue-bench-codex-cli-runner-flow-smoke.py
+examples/agentissue-bench-codex-cli-runner-dry-run-wrapper-smoke.py
+examples/agentissue-bench-codex-cli-runner-synthetic-staging-smoke.py
+examples/agentissue-bench-codex-cli-runner-execution-gate-smoke.py
+examples/agentissue-bench-codex-cli-runner-first-run-handoff-smoke.py
+examples/agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py
+```
+
+## Route Summary
+
+The route narrows from high-level contract to no-execute handoff:
+
+```text
+contract -> flow plan -> dry-run wrapper -> synthetic staging -> execution gate -> first-run handoff -> PR-ready packet
+```
+
+The CLI surfaces are:
+
+```text
+goal-harness benchmark agentissue-codex-runner-flow --tag lagent_239
+goal-harness benchmark agentissue-codex-runner-flow --tag lagent_239 --synthetic-staging-root <private-root>
+goal-harness benchmark agentissue-codex-runner-flow --tag lagent_239 --execution-gate-root <private-root>
+goal-harness benchmark agentissue-codex-runner-flow --tag lagent_239 --first-run-handoff-root <private-root>
+```
+
+All root options are mutually exclusive. They materialize public-safe packet
+shapes only; root paths are not recorded in public payloads.
+
+## Public Boundary
+
+The public boundary for this route is:
+
+```text
+allowed public evidence: schema/mode, selected tag, selected image label, command shape, relative file names, compact validation booleans, hash/count/status field names
+forbidden public evidence: issue body, patch content, raw logs, trajectories, screenshots, local absolute paths, auth files, token names, API keys, fixed/oracle material
+```
+
+The later e2e run remains separate from this PR-ready packet. A later operator
+can use the first-run handoff checklist to trigger a real run, but that is not
+part of this packet.
+
+## Validation
+
+```bash
+python3 examples/agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py
+python3 -m py_compile \
+  goal_harness/benchmark.py \
+  goal_harness/cli.py \
+  examples/agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py
+goal-harness check \
+  --scan-path goal_harness/benchmark.py \
+  --scan-path goal_harness/cli.py \
+  --scan-path examples/agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py \
+  --scan-path docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-pr-ready-packet-v0.md \
+  --scan-path docs/research/long-horizon-agent-benchmarks/README.md
+```

--- a/docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-pr-ready-packet-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-pr-ready-packet-v0.md
@@ -31,6 +31,7 @@ docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-dr
 docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-synthetic-staging-v0.md
 docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-execution-gate-v0.md
 docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-first-run-handoff-v0.md
+docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-workflow-check-v0.md
 docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-pr-ready-packet-v0.md
 ```
 
@@ -43,6 +44,7 @@ examples/agentissue-bench-codex-cli-runner-dry-run-wrapper-smoke.py
 examples/agentissue-bench-codex-cli-runner-synthetic-staging-smoke.py
 examples/agentissue-bench-codex-cli-runner-execution-gate-smoke.py
 examples/agentissue-bench-codex-cli-runner-first-run-handoff-smoke.py
+examples/agentissue-bench-codex-cli-runner-workflow-check-smoke.py
 examples/agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py
 ```
 
@@ -51,7 +53,7 @@ examples/agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py
 The route narrows from high-level contract to no-execute handoff:
 
 ```text
-contract -> flow plan -> dry-run wrapper -> synthetic staging -> execution gate -> first-run handoff -> PR-ready packet
+contract -> flow plan -> dry-run wrapper -> synthetic staging -> execution gate -> first-run handoff -> workflow check -> PR-ready packet
 ```
 
 The CLI surfaces are:
@@ -61,6 +63,7 @@ goal-harness benchmark agentissue-codex-runner-flow --tag lagent_239
 goal-harness benchmark agentissue-codex-runner-flow --tag lagent_239 --synthetic-staging-root <private-root>
 goal-harness benchmark agentissue-codex-runner-flow --tag lagent_239 --execution-gate-root <private-root>
 goal-harness benchmark agentissue-codex-runner-flow --tag lagent_239 --first-run-handoff-root <private-root>
+goal-harness benchmark agentissue-codex-runner-flow --tag lagent_239 --workflow-check-root <private-root>
 ```
 
 All root options are mutually exclusive. They materialize public-safe packet
@@ -76,8 +79,8 @@ forbidden public evidence: issue body, patch content, raw logs, trajectories, sc
 ```
 
 The later e2e run remains separate from this PR-ready packet. A later operator
-can use the first-run handoff checklist to trigger a real run, but that is not
-part of this packet.
+can use the workflow check plus first-run handoff checklist before triggering a
+real run, but that real run is not part of this packet.
 
 ## Validation
 

--- a/docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-publication-change-set-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-publication-change-set-v0.md
@@ -1,0 +1,168 @@
+# AgentIssue-Bench Codex CLI Runner Publication Change Set V0
+
+Date: 2026-06-13
+
+## Scope
+
+This packet defines the publication boundary for the AgentIssue-Bench
+`lagent_239` Codex CLI runner flow. It is a staging and review contract, not a
+benchmark execution packet. It does not run Codex, Docker, model APIs, source
+extraction, patch generation, patch evaluation, upload, submit, or public
+ranking paths.
+
+The publication change set is intentionally single-benchmark and single-tag:
+
+```text
+benchmark=agentissue-bench
+selected_tag=lagent_239
+selected_image=alfin06/agentissue-bench:lagent_239
+real_run=false
+submit_eligible=false
+leaderboard_evidence=false
+```
+
+## Include In The Change Set
+
+Stage these new public docs together:
+
+```text
+docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-contract-v0.md
+docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-flow-plan-v0.md
+docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-dry-run-wrapper-v0.md
+docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-synthetic-staging-v0.md
+docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-execution-gate-v0.md
+docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-first-run-handoff-v0.md
+docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-pr-ready-packet-v0.md
+docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-publication-change-set-v0.md
+```
+
+Stage these new public smokes together:
+
+```text
+examples/agentissue-bench-codex-cli-runner-contract-smoke.py
+examples/agentissue-bench-codex-cli-runner-flow-smoke.py
+examples/agentissue-bench-codex-cli-runner-dry-run-wrapper-smoke.py
+examples/agentissue-bench-codex-cli-runner-synthetic-staging-smoke.py
+examples/agentissue-bench-codex-cli-runner-execution-gate-smoke.py
+examples/agentissue-bench-codex-cli-runner-first-run-handoff-smoke.py
+examples/agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py
+examples/agentissue-bench-codex-cli-runner-publication-change-set-smoke.py
+```
+
+Stage only the AgentIssue hunks from these mixed tracked files:
+
+```text
+goal_harness/benchmark.py
+goal_harness/cli.py
+goal_harness/status.py
+docs/research/long-horizon-agent-benchmarks/README.md
+```
+
+These files currently contain unrelated dirty hunks from other benchmark lanes,
+so do not stage them with a whole-file `git add`. Use hunk-level staging or an
+equivalent cached patch that selects only the AgentIssue runner-flow symbols,
+CLI command, compact `read_boundary` preservation, README bullets, and
+smoke/doc index entries. In a clean PR worktree based directly on `origin/main`,
+these same hunks may appear as whole-file staged changes because no unrelated
+local hunks are present.
+
+## Mixed-File Hunk Boundaries
+
+The source hunks that belong to this change set are identified by these public
+symbols and command strings:
+
+```text
+AGENTISSUE_BENCHMARK_ID
+AGENTISSUE_CODEX_CLI_RUNNER_WRAPPER_SCHEMA_VERSION
+AGENTISSUE_CODEX_CLI_RUNNER_SYNTHETIC_STAGING_SCHEMA_VERSION
+AGENTISSUE_CODEX_CLI_RUNNER_EXECUTION_GATE_SCHEMA_VERSION
+AGENTISSUE_CODEX_CLI_RUNNER_FIRST_RUN_HANDOFF_SCHEMA_VERSION
+build_agentissue_codex_cli_runner_wrapper
+materialize_agentissue_codex_cli_runner_synthetic_staging
+materialize_agentissue_codex_cli_runner_execution_gate
+materialize_agentissue_codex_cli_runner_first_run_handoff
+agentissue-codex-runner-flow
+--synthetic-staging-root
+--execution-gate-root
+--first-run-handoff-root
+read_boundary
+```
+
+The README hunks that belong to this change set are the eight
+`agentissue-bench-codex-cli-runner-*` bullets. Earlier
+`agentissue-bench-lagent239-*` research packets are useful historical evidence,
+but they are not part of this runner-flow publication change set.
+
+## Exclude From The Change Set
+
+Do not stage unrelated benchmark exploration, remote-GPU route work, ALE
+readiness work, SWE-Bench Pro packets, PerfBench packets, APEX packets,
+TheAgentCompany packets, local runtime state, run history, credentials, raw
+artifacts, private job roots, or generated temporary staging directories.
+
+The publication change set must not include:
+
+```text
+.local/
+.goal-harness/
+~/.codex/
+trajectory.json
+screenshot.png
+raw issue body
+raw patch content
+raw logs
+credential values
+API keys
+uploads
+submits
+public ranking paths
+```
+
+## Validation Before Commit Or PR
+
+Run the full runner-flow smoke chain:
+
+```bash
+python3 examples/agentissue-bench-codex-cli-runner-contract-smoke.py &&
+python3 examples/agentissue-bench-codex-cli-runner-flow-smoke.py &&
+python3 examples/agentissue-bench-codex-cli-runner-dry-run-wrapper-smoke.py &&
+python3 examples/agentissue-bench-codex-cli-runner-synthetic-staging-smoke.py &&
+python3 examples/agentissue-bench-codex-cli-runner-execution-gate-smoke.py &&
+python3 examples/agentissue-bench-codex-cli-runner-first-run-handoff-smoke.py &&
+python3 examples/agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py &&
+python3 examples/agentissue-bench-codex-cli-runner-publication-change-set-smoke.py
+```
+
+Then compile and scan only the publication surfaces:
+
+```bash
+python3 -m py_compile \
+  goal_harness/benchmark.py \
+  goal_harness/cli.py \
+  goal_harness/status.py \
+  examples/agentissue-bench-codex-cli-runner-contract-smoke.py \
+  examples/agentissue-bench-codex-cli-runner-flow-smoke.py \
+  examples/agentissue-bench-codex-cli-runner-dry-run-wrapper-smoke.py \
+  examples/agentissue-bench-codex-cli-runner-synthetic-staging-smoke.py \
+  examples/agentissue-bench-codex-cli-runner-execution-gate-smoke.py \
+  examples/agentissue-bench-codex-cli-runner-first-run-handoff-smoke.py \
+  examples/agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py \
+  examples/agentissue-bench-codex-cli-runner-publication-change-set-smoke.py
+
+goal-harness check \
+  --scan-path goal_harness/benchmark.py \
+  --scan-path goal_harness/cli.py \
+  --scan-path goal_harness/status.py \
+  --scan-path docs/research/long-horizon-agent-benchmarks/README.md \
+  --scan-path docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-contract-v0.md \
+  --scan-path docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-flow-plan-v0.md \
+  --scan-path docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-dry-run-wrapper-v0.md \
+  --scan-path docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-synthetic-staging-v0.md \
+  --scan-path docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-execution-gate-v0.md \
+  --scan-path docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-first-run-handoff-v0.md \
+  --scan-path docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-pr-ready-packet-v0.md \
+  --scan-path docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-publication-change-set-v0.md
+```
+
+Commit or PR creation may proceed only after the hunk-level staged diff shows
+no unrelated benchmark lanes and the public/private scan stays clean.

--- a/docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-publication-change-set-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-publication-change-set-v0.md
@@ -32,6 +32,7 @@ docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-dr
 docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-synthetic-staging-v0.md
 docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-execution-gate-v0.md
 docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-first-run-handoff-v0.md
+docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-workflow-check-v0.md
 docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-pr-ready-packet-v0.md
 docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-publication-change-set-v0.md
 ```
@@ -45,6 +46,7 @@ examples/agentissue-bench-codex-cli-runner-dry-run-wrapper-smoke.py
 examples/agentissue-bench-codex-cli-runner-synthetic-staging-smoke.py
 examples/agentissue-bench-codex-cli-runner-execution-gate-smoke.py
 examples/agentissue-bench-codex-cli-runner-first-run-handoff-smoke.py
+examples/agentissue-bench-codex-cli-runner-workflow-check-smoke.py
 examples/agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py
 examples/agentissue-bench-codex-cli-runner-publication-change-set-smoke.py
 ```
@@ -77,18 +79,21 @@ AGENTISSUE_CODEX_CLI_RUNNER_WRAPPER_SCHEMA_VERSION
 AGENTISSUE_CODEX_CLI_RUNNER_SYNTHETIC_STAGING_SCHEMA_VERSION
 AGENTISSUE_CODEX_CLI_RUNNER_EXECUTION_GATE_SCHEMA_VERSION
 AGENTISSUE_CODEX_CLI_RUNNER_FIRST_RUN_HANDOFF_SCHEMA_VERSION
+AGENTISSUE_CODEX_CLI_RUNNER_WORKFLOW_CHECK_SCHEMA_VERSION
 build_agentissue_codex_cli_runner_wrapper
 materialize_agentissue_codex_cli_runner_synthetic_staging
 materialize_agentissue_codex_cli_runner_execution_gate
 materialize_agentissue_codex_cli_runner_first_run_handoff
+materialize_agentissue_codex_cli_runner_workflow_check
 agentissue-codex-runner-flow
 --synthetic-staging-root
 --execution-gate-root
 --first-run-handoff-root
+--workflow-check-root
 read_boundary
 ```
 
-The README hunks that belong to this change set are the eight
+The README hunks that belong to this change set are the nine
 `agentissue-bench-codex-cli-runner-*` bullets. Earlier
 `agentissue-bench-lagent239-*` research packets are useful historical evidence,
 but they are not part of this runner-flow publication change set.
@@ -129,6 +134,7 @@ python3 examples/agentissue-bench-codex-cli-runner-dry-run-wrapper-smoke.py &&
 python3 examples/agentissue-bench-codex-cli-runner-synthetic-staging-smoke.py &&
 python3 examples/agentissue-bench-codex-cli-runner-execution-gate-smoke.py &&
 python3 examples/agentissue-bench-codex-cli-runner-first-run-handoff-smoke.py &&
+python3 examples/agentissue-bench-codex-cli-runner-workflow-check-smoke.py &&
 python3 examples/agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py &&
 python3 examples/agentissue-bench-codex-cli-runner-publication-change-set-smoke.py
 ```
@@ -146,6 +152,7 @@ python3 -m py_compile \
   examples/agentissue-bench-codex-cli-runner-synthetic-staging-smoke.py \
   examples/agentissue-bench-codex-cli-runner-execution-gate-smoke.py \
   examples/agentissue-bench-codex-cli-runner-first-run-handoff-smoke.py \
+  examples/agentissue-bench-codex-cli-runner-workflow-check-smoke.py \
   examples/agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py \
   examples/agentissue-bench-codex-cli-runner-publication-change-set-smoke.py
 
@@ -160,6 +167,7 @@ goal-harness check \
   --scan-path docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-synthetic-staging-v0.md \
   --scan-path docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-execution-gate-v0.md \
   --scan-path docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-first-run-handoff-v0.md \
+  --scan-path docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-workflow-check-v0.md \
   --scan-path docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-pr-ready-packet-v0.md \
   --scan-path docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-publication-change-set-v0.md
 ```

--- a/docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-synthetic-staging-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-synthetic-staging-v0.md
@@ -1,0 +1,84 @@
+# AgentIssue-Bench Codex CLI Runner Synthetic Staging V0
+
+Date: 2026-06-13
+
+## Scope
+
+This packet extends the `lagent_239` AgentIssue-Bench Codex CLI runner flow
+with an opt-in synthetic private job-root fixture:
+
+```bash
+goal-harness benchmark agentissue-codex-runner-flow \
+  --goal-id goal-harness-meta \
+  --tag lagent_239 \
+  --synthetic-staging-root <private-job-root>
+```
+
+The fixture creates only placeholders. It does not invoke Codex CLI, a model
+API, Docker, official helpers, uploads, submit, public ranking paths, real
+task material, patch generation, or patch evaluation. Passing `--execute`
+still only appends a compact no-run `benchmark_run_v0` readiness event.
+
+## Materialized Shape
+
+The synthetic root contains:
+
+```text
+context/prompt.md
+buggy-source/.gitkeep
+Patches/lagent_239/.gitkeep
+runner-flow-plan.public.json
+benchmark_run.compact.json
+```
+
+`context/prompt.md` is a synthetic placeholder and names the expected patch
+output slot:
+
+```text
+Patches/lagent_239/attempt.patch
+```
+
+`runner-flow-plan.public.json` records only relative paths, command
+placeholders, stop rules, and no-execution boundary flags. It does not record
+the private staging-root path.
+
+`benchmark_run.compact.json` uses:
+
+```text
+mode=agentissue_codex_cli_runner_synthetic_staging_fixture
+first_blocker=synthetic_staging_only_no_real_case
+real_run=false
+submit_eligible=false
+leaderboard_evidence=false
+```
+
+## Why This Exists
+
+The previous wrapper proved command rendering and compact append behavior. This
+fixture proves the next layer that a real runner will need before any execution:
+
+1. private job-root directory creation;
+2. prompt-path rendering;
+3. extracted-source workspace placeholder;
+4. `Patches/lagent_239/attempt.patch` parent placement;
+5. compact reducer file naming.
+
+It intentionally stops before selected-container source extraction and before
+host-local `codex exec`. The next step is a separate guarded opt-in gate for
+real source extraction and host-Codex patch production.
+
+## Validation
+
+```bash
+python3 examples/agentissue-bench-codex-cli-runner-synthetic-staging-smoke.py
+python3 -m py_compile \
+  goal_harness/benchmark.py \
+  goal_harness/cli.py \
+  examples/agentissue-bench-codex-cli-runner-synthetic-staging-smoke.py
+goal-harness check \
+  --scan-path goal_harness/benchmark.py \
+  --scan-path goal_harness/cli.py \
+  --scan-path examples/agentissue-bench-codex-cli-runner-synthetic-staging-smoke.py \
+  --scan-path docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-synthetic-staging-v0.md \
+  --scan-path docs/research/long-horizon-agent-benchmarks/README.md
+```

--- a/docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-workflow-check-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-workflow-check-v0.md
@@ -1,0 +1,56 @@
+# AgentIssue-Bench Codex CLI Runner Workflow Check V0
+
+This packet adds one no-execute workflow invariant check for the selected
+AgentIssue-Bench tag `lagent_239`:
+
+```bash
+goal-harness benchmark agentissue-codex-runner-flow \
+  --goal-id <goal-id> \
+  --tag lagent_239 \
+  --workflow-check-root <private-check-root>
+```
+
+The command materializes the first-run handoff packet plus
+`workflow-check.public.json`. It reads only the public/compact files it just
+created inside the selected private root:
+
+```text
+runner-flow-plan.public.json
+execution-gate.public.json
+first-run-handoff.public.json
+workflow-check.public.json
+benchmark_run.compact.json
+```
+
+## Checked Invariants
+
+`workflow-check.public.json` records boolean checks for the pre-run workflow:
+
+- one selected tag and one selected image across runner plan, execution gate,
+  and handoff packet;
+- `source_extracted_before_codex`: selected-container source extraction is
+  planned before host-local `codex exec --ephemeral`;
+- `host_codex_auth_not_synced`: Codex auth stays on the host and no Codex home
+  is synced to a shared host;
+- the Codex worker has no network or Docker access in the rendered command
+  contract;
+- `Patches/lagent_239/attempt.patch` is produced from the extracted source git
+  diff rather than current public HEAD or fixed/oracle material;
+- selected-tag eval disables upload, submit, and public ranking paths;
+- public outputs are limited to public/compact JSON and Markdown packets.
+
+The packet is still no-run. It does not pull or start Docker, invoke Codex,
+call a model API, extract source, initialize git, generate or evaluate a patch,
+read credentials, sync auth material, upload, submit, touch public ranking
+paths, publish raw issue/task/patch/log/trajectory material, use destructive
+git, or take production action.
+
+## Validation
+
+```bash
+python3 examples/agentissue-bench-codex-cli-runner-workflow-check-smoke.py
+python3 -m py_compile examples/agentissue-bench-codex-cli-runner-workflow-check-smoke.py
+goal-harness check \
+  --scan-path examples/agentissue-bench-codex-cli-runner-workflow-check-smoke.py \
+  --scan-path docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-workflow-check-v0.md
+```

--- a/examples/agentissue-bench-codex-cli-runner-contract-smoke.py
+++ b/examples/agentissue-bench-codex-cli-runner-contract-smoke.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Smoke-test the AgentIssue-Bench Codex CLI runner contract."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+SCHEMA_VERSION = "agentissue_bench_codex_cli_runner_contract_v0"
+BENCHMARK_ID = "agentissue-bench"
+SELECTED_TAG = "lagent_239"
+IMAGE = "alfin06/agentissue-bench:lagent_239"
+ISSUE_URL = "https://github.com/InternLM/lagent/issues/239"
+LEADERBOARD_URL = "https://alfin06.github.io/AgentIssue-Bench-Leaderboard/"
+OFFICIAL_REPO = "https://github.com/alfin06/AgentIssue-Bench"
+
+FORBIDDEN_KEYS = {
+    "api_key",
+    "access_token",
+    "authorization",
+    "codex_auth",
+    "credential",
+    "environment",
+    "file_content",
+    "fixed_diff",
+    "gold_material",
+    "local_path",
+    "password",
+    "patch_content",
+    "raw_log",
+    "raw_output",
+    "raw_patch",
+    "screenshot",
+    "session",
+    "solution",
+    "test_body",
+    "trajectory",
+}
+FORBIDDEN_TEXT = (
+    "/" + "Users/",
+    "~/.codex",
+    ".codex/auth.json",
+    "CODEX_ACCESS_TOKEN",
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GOOGLE_API_KEY",
+    "show_diff",
+)
+
+
+def key_paths(value: Any, *, prefix: str = "") -> list[str]:
+    if isinstance(value, dict):
+        paths: list[str] = []
+        for key, child in value.items():
+            path = f"{prefix}.{key}" if prefix else str(key)
+            paths.append(path)
+            paths.extend(key_paths(child, prefix=path))
+        return paths
+    if isinstance(value, list):
+        paths = []
+        for index, child in enumerate(value):
+            paths.extend(key_paths(child, prefix=f"{prefix}[{index}]"))
+        return paths
+    return []
+
+
+def leaf(path: str) -> str:
+    segment = path.rsplit(".", 1)[-1]
+    if "[" in segment:
+        segment = segment.split("[", 1)[0]
+    return segment.lower()
+
+
+def build_contract() -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "benchmark_id": BENCHMARK_ID,
+        "official_metric_status": {
+            "codex_cli_official_metric_found": False,
+            "official_leaderboard_url": LEADERBOARD_URL,
+            "official_repo": OFFICIAL_REPO,
+            "official_leaderboard_rows_checked": [
+                "AutoCodeRover + Claude 3.5 Sonnet",
+                "Agentless + Claude 3.5 Sonnet",
+                "Agentless + GPT-4o",
+                "SWE-agent + Claude 3.5 Sonnet",
+                "AutoCodeRover + GPT-4o",
+                "SWE-agent + GPT-4o",
+            ],
+            "codex_cli_row_present": False,
+        },
+        "active_scope": {
+            "only_active_benchmark": BENCHMARK_ID,
+            "initial_tag": SELECTED_TAG,
+            "expand_tags_after_single_tag_runner_passes": True,
+            "no_other_benchmarks_until": "agentissue_codex_cli_runner_e2e_clean",
+        },
+        "runner_phases": [
+            {
+                "phase": "prepare_isolated_job",
+                "runner_owned": True,
+                "public_writeback": "counts_hashes_status_only",
+                "copy_codex_home": False,
+            },
+            {
+                "phase": "fetch_public_issue_context",
+                "issue_url": ISSUE_URL,
+                "raw_issue_context_allowed_private": True,
+                "raw_issue_context_public": False,
+            },
+            {
+                "phase": "pull_selected_image",
+                "image": IMAGE,
+                "single_tag_only": True,
+                "all_tag_loop_allowed": False,
+            },
+            {
+                "phase": "extract_buggy_source_from_container",
+                "source": "container_buggy_snapshot",
+                "host_git_baseline_required": True,
+                "use_current_public_head_for_patch_generation": False,
+            },
+            {
+                "phase": "run_codex_cli_patch_worker",
+                "command_template": (
+                    "codex exec --ephemeral --ignore-rules --sandbox workspace-write "
+                    "--cd <buggy-source> --add-dir <job-root> --output-last-message "
+                    "<job-root>/codex-last-message.txt <prompt-file>"
+                ),
+                "codex_auth_local_only": True,
+                "copy_codex_home": False,
+                "worker_network_allowed": False,
+                "worker_docker_allowed": False,
+                "worker_reads_fixed_diff": False,
+            },
+            {
+                "phase": "write_attempt_patch",
+                "patch_output": "Patches/lagent_239/attempt.patch",
+                "patch_content_public": False,
+                "patch_hash_public": True,
+            },
+            {
+                "phase": "single_tag_container_eval",
+                "command_template": (
+                    "docker run --platform linux/amd64 --rm --entrypoint bash "
+                    "-v <patch-dir>:/patches:ro alfin06/agentissue-bench:lagent_239 "
+                    "-c '<apply_patch_and_test_patched>'"
+                ),
+                "official_helper_scripts_used": False,
+                "docker_env_credentials": False,
+                "upload": False,
+                "submit": False,
+                "public_ranking_path": False,
+            },
+            {
+                "phase": "compact_reducer",
+                "allowed_public_fields": [
+                    "tag",
+                    "image_digest",
+                    "patch_sha256",
+                    "patch_bytes",
+                    "exit_code",
+                    "resolved",
+                    "duration_seconds",
+                    "log_sha256",
+                    "no_upload",
+                    "no_submit",
+                ],
+                "raw_log_public": False,
+            },
+        ],
+        "stop_rules": {
+            "do_not_run_manual_agent_worker": True,
+            "do_not_use_current_head_as_patch_source": True,
+            "do_not_read_fixed_diff_before_patch_generation": True,
+            "do_not_run_official_all_tag_helpers": True,
+            "do_not_sync_codex_auth_to_shared_host_or_container": True,
+            "do_not_publish_raw_patch_or_logs": True,
+        },
+    }
+
+
+def assert_public_safe(payload: dict[str, Any]) -> None:
+    bad_keys = [path for path in key_paths(payload) if leaf(path) in FORBIDDEN_KEYS]
+    assert not bad_keys, bad_keys
+    rendered = json.dumps(payload, sort_keys=True)
+    leaked = [marker for marker in FORBIDDEN_TEXT if marker in rendered]
+    assert not leaked, leaked
+
+
+def run_smoke() -> dict[str, Any]:
+    contract = build_contract()
+    phases = {item["phase"]: item for item in contract["runner_phases"]}
+    assert contract["schema_version"] == SCHEMA_VERSION, contract
+    assert contract["official_metric_status"]["codex_cli_official_metric_found"] is False, contract
+    assert contract["official_metric_status"]["codex_cli_row_present"] is False, contract
+    assert contract["active_scope"]["only_active_benchmark"] == BENCHMARK_ID, contract
+    assert contract["active_scope"]["initial_tag"] == SELECTED_TAG, contract
+    assert phases["extract_buggy_source_from_container"]["host_git_baseline_required"] is True, contract
+    assert phases["extract_buggy_source_from_container"]["use_current_public_head_for_patch_generation"] is False
+    assert phases["run_codex_cli_patch_worker"]["codex_auth_local_only"] is True, contract
+    assert phases["run_codex_cli_patch_worker"]["copy_codex_home"] is False, contract
+    assert phases["run_codex_cli_patch_worker"]["worker_reads_fixed_diff"] is False, contract
+    assert phases["single_tag_container_eval"]["official_helper_scripts_used"] is False, contract
+    assert phases["single_tag_container_eval"]["docker_env_credentials"] is False, contract
+    assert phases["single_tag_container_eval"]["upload"] is False, contract
+    assert contract["stop_rules"]["do_not_run_manual_agent_worker"] is True, contract
+    assert contract["stop_rules"]["do_not_use_current_head_as_patch_source"] is True, contract
+    assert contract["stop_rules"]["do_not_read_fixed_diff_before_patch_generation"] is True, contract
+    assert_public_safe(contract)
+    return {
+        "ok": True,
+        "classification": SCHEMA_VERSION,
+        "contract": contract,
+        "official_codex_cli_metric_found": False,
+        "only_active_benchmark": BENCHMARK_ID,
+        "initial_tag": SELECTED_TAG,
+    }
+
+
+def main() -> None:
+    print(json.dumps(run_smoke(), indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/agentissue-bench-codex-cli-runner-dry-run-wrapper-smoke.py
+++ b/examples/agentissue-bench-codex-cli-runner-dry-run-wrapper-smoke.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""Smoke-test the AgentIssue-Bench Codex CLI runner dry-run wrapper."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from goal_harness.status import collect_status  # noqa: E402
+
+
+TOPIC_DIR = REPO_ROOT / "docs" / "research" / "long-horizon-agent-benchmarks"
+DOC = TOPIC_DIR / "agentissue-bench-codex-cli-runner-dry-run-wrapper-v0.md"
+README = TOPIC_DIR / "README.md"
+
+GOAL_ID = "agentissue-runner-wrapper-fixture"
+BENCHMARK_ID = "agentissue-bench"
+SELECTED_TAG = "lagent_239"
+RUN_MODE = "agentissue_codex_cli_runner_dry_run_wrapper"
+CLASSIFICATION = "agentissue_bench_codex_cli_runner_dry_run_wrapper_v0"
+
+REQUIRED_DOC_SNIPPETS = [
+    "AgentIssue-Bench Codex CLI Runner Dry-Run Wrapper V0",
+    "goal-harness benchmark agentissue-codex-runner-flow",
+    "--tag lagent_239",
+    "benchmark_run_v0",
+    "codex_cli_invoked",
+    "docker_container_started",
+    "agentissue_bench_single_tag_container_eval_not_run",
+    "python3 examples/agentissue-bench-codex-cli-runner-dry-run-wrapper-smoke.py",
+]
+
+FORBIDDEN_TEXT = [
+    "/" + "Users/",
+    "~/.codex",
+    ".codex/auth.json",
+    "OPENAI" + "_API_KEY",
+    "ANTHROPIC" + "_API_KEY",
+    "GOOGLE" + "_API_KEY",
+    "CODEX" + "_ACCESS_TOKEN",
+    "raw" + "_issue_body:",
+    "raw" + "_patch:",
+    "raw" + "_log:",
+    "trajectory.json",
+    "screenshot",
+    "show_diff",
+]
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_fixture(root: Path) -> tuple[Path, Path]:
+    project = root / "project"
+    runtime = root / "runtime"
+    state_file = f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    registry_path = project / ".goal-harness" / "registry.json"
+
+    (project / Path(state_file).parent).mkdir(parents=True, exist_ok=True)
+    (project / state_file).write_text(
+        "---\n"
+        "status: active-read-only\n"
+        "updated_at: 2026-06-12T00:00:00+00:00\n"
+        "---\n\n"
+        "# AgentIssue Runner Wrapper Fixture\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] Render the AgentIssue-Bench Codex CLI runner wrapper.\n",
+        encoding="utf-8",
+    )
+    write_json(
+        registry_path,
+        {
+            "schema_version": 1,
+            "updated_at": "2026-06-12T00:00:00+00:00",
+            "common_runtime_root": str(runtime),
+            "goals": [
+                {
+                    "id": GOAL_ID,
+                    "domain": "goal-harness-platform",
+                    "status": "active-read-only",
+                    "state_file": state_file,
+                    "repo": str(project),
+                    "adapter": {
+                        "kind": "harness_self_improvement",
+                        "status": "connected-read-only",
+                    },
+                    "heartbeat": {
+                        "enabled": True,
+                    },
+                }
+            ],
+        },
+    )
+    return registry_path, runtime
+
+
+def run_cli(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "goal_harness.cli", *args],
+        cwd=REPO_ROOT,
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def run_cli_json(args: list[str]) -> dict[str, Any]:
+    result = run_cli(args)
+    payload = json.loads(result.stdout)
+    assert isinstance(payload, dict), payload
+    return payload
+
+
+def common_args(registry_path: Path, runtime: Path) -> list[str]:
+    return [
+        "--registry",
+        str(registry_path),
+        "--runtime-root",
+        str(runtime),
+        "--format",
+        "json",
+        "benchmark",
+        "agentissue-codex-runner-flow",
+        "--goal-id",
+        GOAL_ID,
+        "--tag",
+        SELECTED_TAG,
+        "--no-global-sync",
+    ]
+
+
+def assert_no_forbidden_text(payload: dict[str, Any]) -> None:
+    text = json.dumps(payload, sort_keys=True)
+    leaked = [marker for marker in FORBIDDEN_TEXT if marker in text]
+    assert not leaked, leaked
+    assert len(text) < 26000, len(text)
+
+
+def assert_doc_contract() -> None:
+    text = DOC.read_text(encoding="utf-8")
+    readme = README.read_text(encoding="utf-8")
+    missing = [snippet for snippet in REQUIRED_DOC_SNIPPETS if snippet not in text]
+    assert not missing, missing
+    assert "agentissue-bench-codex-cli-runner-dry-run-wrapper-v0.md" in readme, readme
+    leaked = [marker for marker in FORBIDDEN_TEXT if marker in text]
+    assert not leaked, leaked
+
+
+def assert_payload(payload: dict[str, Any], *, appended: bool) -> None:
+    assert payload["ok"] is True, payload
+    assert payload["appended"] is appended, payload
+    assert payload["dry_run"] is (not appended), payload
+    assert payload["classification"] == CLASSIFICATION, payload
+
+    cli = payload["benchmark_cli"]
+    assert cli["benchmark"] == BENCHMARK_ID, cli
+    assert cli["command"] == "agentissue-codex-runner-flow", cli
+    assert cli["tag"] == SELECTED_TAG, cli
+    assert cli["dry_run_default"] is True, cli
+    assert cli["real_runner_invoked"] is False, cli
+    assert cli["real_codex_invoked"] is False, cli
+    assert cli["real_docker_invoked"] is False, cli
+    assert cli["model_api_invoked"] is False, cli
+    assert cli["auth_values_read"] is False, cli
+
+    wrapper = payload["agentissue_runner_flow"]
+    assert wrapper["schema_version"] == CLASSIFICATION, wrapper
+    assert wrapper["selected_tag"] == SELECTED_TAG, wrapper
+    assert wrapper["dry_run_default"] is True, wrapper
+    assert wrapper["real_execution_done"] is False, wrapper
+    assert wrapper["single_tag_only"] is True, wrapper
+    phases = wrapper["staging_plan"]["phase_order"]
+    assert phases.index("extract_buggy_source_from_selected_container_opt_in") < phases.index(
+        "run_host_local_codex_cli_patch_worker_opt_in"
+    ), phases
+    assert phases.index("run_host_local_codex_cli_patch_worker_opt_in") < phases.index(
+        "write_attempt_patch_from_buggy_source_git_diff"
+    ), phases
+    assert wrapper["commands"]["codex_patch_worker"]["argv"][0] == "codex", wrapper
+    assert "--ephemeral" in wrapper["commands"]["codex_patch_worker"]["argv"], wrapper
+    assert wrapper["commands"]["codex_patch_worker"]["auth_material_synced"] is False, wrapper
+    assert wrapper["commands"]["single_tag_eval"]["argv"][0] == "docker", wrapper
+    assert wrapper["commands"]["single_tag_eval"]["official_all_tag_helper_allowed"] is False, wrapper
+    assert wrapper["execution_boundary"]["codex_cli_invoked"] is False, wrapper
+    assert wrapper["execution_boundary"]["model_api_invoked"] is False, wrapper
+    assert wrapper["execution_boundary"]["docker_container_started"] is False, wrapper
+    assert wrapper["execution_boundary"]["patch_generated"] is False, wrapper
+
+    event = payload["benchmark_run"]
+    assert event["schema_version"] == "benchmark_run_v0", event
+    assert event["source_runner"] == "goal_harness_agentissue_codex_cli_runner", event
+    assert event["benchmark_id"] == BENCHMARK_ID, event
+    assert event["mode"] == RUN_MODE, event
+    assert event["first_blocker"] == "dry_run_wrapper_only_no_real_case", event
+    assert event["real_run"] is False, event
+    assert event["submit_eligible"] is False, event
+    assert event["leaderboard_evidence"] is False, event
+    assert event["official_task_score"]["kind"] == (
+        "agentissue_bench_single_tag_container_eval_not_run"
+    ), event
+    assert event["progress"]["n_total_trials"] == 1, event
+    assert event["progress"]["n_pending_trials"] == 1, event
+    assert event["metrics"]["cost_usd"] == 0, event
+    assert event["validation"]["all_passed"] is True, event
+    assert event["validation"]["failed_checks"] == [], event
+    assert event["read_boundary"]["compact_only"] is True, event
+    assert event["read_boundary"]["docker_invoked"] is False, event
+    assert event["read_boundary"]["model_api_invoked"] is False, event
+    assert_no_forbidden_text(wrapper)
+    assert_no_forbidden_text(event)
+    assert_no_forbidden_text(cli)
+
+
+def assert_status_projection(registry_path: Path, runtime: Path) -> None:
+    status = collect_status(
+        registry_path=registry_path,
+        runtime_root_override=str(runtime),
+        scan_roots=[],
+        limit=5,
+    )
+    assert status["ok"], status
+    latest = status["run_history"]["goals"][0]["latest_runs"][0]
+    summary = latest["benchmark_run_summary"]
+    assert summary["mode"] == RUN_MODE, summary
+    assert summary["benchmark_id"] == BENCHMARK_ID, summary
+    assert summary["progress"]["n_total_trials"] == 1, summary
+    assert summary["validation"]["all_passed"] is True, summary
+    assert status["event_ledger_summary"]["totals"]["benchmark_runs_24h"] == 1, status
+    assert_no_forbidden_text(summary)
+
+
+def assert_other_tags_rejected(registry_path: Path, runtime: Path) -> None:
+    args = common_args(registry_path, runtime)
+    tag_index = args.index("--tag") + 1
+    args[tag_index] = "other_001"
+    result = run_cli(args, check=False)
+    assert result.returncode == 1, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False, payload
+    assert "only supports selected tag" in payload["error"], payload
+
+
+def main() -> None:
+    assert_doc_contract()
+    with tempfile.TemporaryDirectory(prefix="agentissue-runner-wrapper-") as tmp:
+        registry_path, runtime = write_fixture(Path(tmp))
+        dry_payload = run_cli_json(common_args(registry_path, runtime))
+        assert_payload(dry_payload, appended=False)
+
+        execute_payload = run_cli_json(
+            common_args(registry_path, runtime)
+            + [
+                "--delivery-batch-scale",
+                "multi_surface",
+                "--delivery-outcome",
+                "outcome_progress",
+                "--execute",
+            ]
+        )
+        assert_payload(execute_payload, appended=True)
+        assert_status_projection(registry_path, runtime)
+        assert_other_tags_rejected(registry_path, runtime)
+
+    print(
+        "agentissue-bench-codex-cli-runner-dry-run-wrapper-smoke ok "
+        f"mode={RUN_MODE} appended=True real_run=False"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/agentissue-bench-codex-cli-runner-execution-gate-smoke.py
+++ b/examples/agentissue-bench-codex-cli-runner-execution-gate-smoke.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Smoke-test AgentIssue-Bench Codex CLI runner execution gate."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from goal_harness.status import collect_status  # noqa: E402
+
+
+TOPIC_DIR = REPO_ROOT / "docs" / "research" / "long-horizon-agent-benchmarks"
+DOC = TOPIC_DIR / "agentissue-bench-codex-cli-runner-execution-gate-v0.md"
+README = TOPIC_DIR / "README.md"
+
+GOAL_ID = "agentissue-runner-execution-gate-fixture"
+BENCHMARK_ID = "agentissue-bench"
+SELECTED_TAG = "lagent_239"
+RUN_MODE = "agentissue_codex_cli_runner_execution_gate"
+CLASSIFICATION = "agentissue_bench_codex_cli_runner_execution_gate_v0"
+
+REQUIRED_DOC_SNIPPETS = [
+    "AgentIssue-Bench Codex CLI Runner Execution Gate V0",
+    "--execution-gate-root",
+    "execution-gate.public.json",
+    "docker create",
+    "git -C",
+    "codex exec --ephemeral",
+    "python3 examples/agentissue-bench-codex-cli-runner-execution-gate-smoke.py",
+]
+
+FORBIDDEN_TEXT = [
+    "/" + "Users/",
+    "~/.codex",
+    ".codex/auth.json",
+    "OPENAI" + "_API_KEY",
+    "ANTHROPIC" + "_API_KEY",
+    "GOOGLE" + "_API_KEY",
+    "CODEX" + "_ACCESS_TOKEN",
+    "raw" + "_issue_body:",
+    "raw" + "_patch:",
+    "raw" + "_log:",
+    "trajectory.json",
+]
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_fixture(root: Path) -> tuple[Path, Path, Path]:
+    project = root / "project"
+    runtime = root / "runtime"
+    gate_root = root / "private-gate-root"
+    state_file = f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    registry_path = project / ".goal-harness" / "registry.json"
+
+    (project / Path(state_file).parent).mkdir(parents=True, exist_ok=True)
+    (project / state_file).write_text(
+        "---\n"
+        "status: active-read-only\n"
+        "updated_at: 2026-06-12T00:00:00+00:00\n"
+        "---\n\n"
+        "# AgentIssue Runner Execution Gate Fixture\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] Materialize AgentIssue no-execute execution gate.\n",
+        encoding="utf-8",
+    )
+    write_json(
+        registry_path,
+        {
+            "schema_version": 1,
+            "updated_at": "2026-06-12T00:00:00+00:00",
+            "common_runtime_root": str(runtime),
+            "goals": [
+                {
+                    "id": GOAL_ID,
+                    "domain": "goal-harness-platform",
+                    "status": "active-read-only",
+                    "state_file": state_file,
+                    "repo": str(project),
+                    "adapter": {
+                        "kind": "harness_self_improvement",
+                        "status": "connected-read-only",
+                    },
+                    "heartbeat": {
+                        "enabled": True,
+                    },
+                }
+            ],
+        },
+    )
+    return registry_path, runtime, gate_root
+
+
+def run_cli(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "goal_harness.cli", *args],
+        cwd=REPO_ROOT,
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def run_cli_json(args: list[str]) -> dict[str, Any]:
+    result = run_cli(args)
+    payload = json.loads(result.stdout)
+    assert isinstance(payload, dict), payload
+    return payload
+
+
+def common_args(registry_path: Path, runtime: Path, gate_root: Path) -> list[str]:
+    return [
+        "--registry",
+        str(registry_path),
+        "--runtime-root",
+        str(runtime),
+        "--format",
+        "json",
+        "benchmark",
+        "agentissue-codex-runner-flow",
+        "--goal-id",
+        GOAL_ID,
+        "--tag",
+        SELECTED_TAG,
+        "--execution-gate-root",
+        str(gate_root),
+        "--no-global-sync",
+    ]
+
+
+def assert_no_forbidden_text(payload: dict[str, Any]) -> None:
+    text = json.dumps(payload, sort_keys=True)
+    leaked = [marker for marker in FORBIDDEN_TEXT if marker in text]
+    assert not leaked, leaked
+    assert len(text) < 42000, len(text)
+
+
+def assert_doc_contract() -> None:
+    text = DOC.read_text(encoding="utf-8")
+    readme = README.read_text(encoding="utf-8")
+    missing = [snippet for snippet in REQUIRED_DOC_SNIPPETS if snippet not in text]
+    assert not missing, missing
+    assert "agentissue-bench-codex-cli-runner-execution-gate-v0.md" in readme, readme
+    leaked = [marker for marker in FORBIDDEN_TEXT if marker in text]
+    assert not leaked, leaked
+
+
+def assert_gate_files(gate_root: Path) -> None:
+    expected_paths = [
+        "context/prompt.md",
+        "buggy-source/.gitkeep",
+        "Patches/lagent_239/.gitkeep",
+        "runner-flow-plan.public.json",
+        "benchmark_run.compact.json",
+        "execution-gate.public.json",
+    ]
+    missing = [rel for rel in expected_paths if not (gate_root / rel).exists()]
+    assert not missing, missing
+
+    gate = json.loads((gate_root / "execution-gate.public.json").read_text(encoding="utf-8"))
+    assert gate["schema_version"] == CLASSIFICATION, gate
+    assert gate["path_recorded"] is False, gate
+    assert gate["default_mode"] == "no_execute", gate
+    assert gate["future_opt_in_required"] is True, gate
+    assert gate["relative_paths"]["attempt_patch"] == "Patches/lagent_239/attempt.patch", gate
+    assert gate["source_extraction_gate"]["commands"]["create_selected_container"][0] == "docker", gate
+    assert gate["private_git_baseline_gate"]["commands"]["init"][0] == "git", gate
+    assert gate["host_codex_gate"]["command"]["argv"][0] == "codex", gate
+    assert gate["host_codex_gate"]["command"]["auth_material_synced"] is False, gate
+    assert gate["source_extraction_gate"]["docker_invoked"] is False, gate
+
+    local_run = json.loads((gate_root / "benchmark_run.compact.json").read_text(encoding="utf-8"))
+    assert local_run["schema_version"] == "benchmark_run_v0", local_run
+    assert local_run["mode"] == RUN_MODE, local_run
+    assert local_run["validation"]["execution_gate_materialized"] is True, local_run
+
+
+def assert_payload(payload: dict[str, Any], *, appended: bool) -> None:
+    assert payload["ok"] is True, payload
+    assert payload["appended"] is appended, payload
+    assert payload["dry_run"] is (not appended), payload
+    assert payload["classification"] == CLASSIFICATION, payload
+
+    cli = payload["benchmark_cli"]
+    assert cli["benchmark"] == BENCHMARK_ID, cli
+    assert cli["command"] == "agentissue-codex-runner-flow", cli
+    assert cli["tag"] == SELECTED_TAG, cli
+    assert cli["synthetic_staging_materialized"] is False, cli
+    assert cli["execution_gate_materialized"] is True, cli
+    assert cli["execution_gate_root_path_recorded"] is False, cli
+    assert cli["real_runner_invoked"] is False, cli
+    assert cli["real_codex_invoked"] is False, cli
+    assert cli["real_docker_invoked"] is False, cli
+    assert cli["model_api_invoked"] is False, cli
+    assert cli["auth_values_read"] is False, cli
+
+    gate = payload["agentissue_execution_gate"]
+    assert gate["schema_version"] == CLASSIFICATION, gate
+    assert gate["ready"] is True, gate
+    assert gate["materialized"] is True, gate
+    assert gate["path_recorded"] is False, gate
+    assert gate["gate_root_path_recorded"] is False, gate
+    assert gate["gate_relative_path"] == "execution-gate.public.json", gate
+    assert gate["attempt_patch_relative_path"] == "Patches/lagent_239/attempt.patch", gate
+    assert gate["gate_checks"]["future_execution_opt_in_required"] is True, gate
+    assert gate["execution_boundary"]["codex_cli_invoked"] is False, gate
+    assert gate["execution_boundary"]["docker_container_started"] is False, gate
+    assert gate["execution_boundary"]["source_extracted"] is False, gate
+
+    event = payload["benchmark_run"]
+    assert event["schema_version"] == "benchmark_run_v0", event
+    assert event["benchmark_id"] == BENCHMARK_ID, event
+    assert event["mode"] == RUN_MODE, event
+    assert event["first_blocker"] == "execution_gate_only_no_real_case", event
+    assert event["real_run"] is False, event
+    assert event["submit_eligible"] is False, event
+    assert event["leaderboard_evidence"] is False, event
+    assert event["validation"]["all_passed"] is True, event
+    assert event["validation"]["failed_checks"] == [], event
+    assert event["read_boundary"]["compact_only"] is True, event
+    assert event["read_boundary"]["docker_invoked"] is False, event
+    assert event["read_boundary"]["model_api_invoked"] is False, event
+    assert "execution-gate.public.json" in event["evidence_files"], event
+    assert_no_forbidden_text(gate)
+    assert_no_forbidden_text(event)
+    assert_no_forbidden_text(cli)
+
+
+def assert_status_projection(registry_path: Path, runtime: Path) -> None:
+    status = collect_status(
+        registry_path=registry_path,
+        runtime_root_override=str(runtime),
+        scan_roots=[],
+        limit=5,
+    )
+    assert status["ok"], status
+    latest = status["run_history"]["goals"][0]["latest_runs"][0]
+    summary = latest["benchmark_run_summary"]
+    assert summary["mode"] == RUN_MODE, summary
+    assert summary["benchmark_id"] == BENCHMARK_ID, summary
+    assert summary["validation"]["all_passed"] is True, summary
+    assert status["event_ledger_summary"]["totals"]["benchmark_runs_24h"] == 1, status
+    assert_no_forbidden_text(summary)
+
+
+def assert_other_tags_rejected(registry_path: Path, runtime: Path, gate_root: Path) -> None:
+    args = common_args(registry_path, runtime, gate_root)
+    tag_index = args.index("--tag") + 1
+    args[tag_index] = "other_001"
+    result = run_cli(args, check=False)
+    assert result.returncode == 1, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False, payload
+    assert "only supports selected tag" in payload["error"], payload
+
+
+def assert_roots_are_mutually_exclusive(registry_path: Path, runtime: Path, gate_root: Path) -> None:
+    args = common_args(registry_path, runtime, gate_root) + [
+        "--synthetic-staging-root",
+        str(gate_root / "other-root"),
+    ]
+    result = run_cli(args, check=False)
+    assert result.returncode == 1, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False, payload
+    assert "not both" in payload["error"], payload
+
+
+def main() -> None:
+    assert_doc_contract()
+    with tempfile.TemporaryDirectory(prefix="agentissue-runner-execution-gate-") as tmp:
+        registry_path, runtime, gate_root = write_fixture(Path(tmp))
+        dry_payload = run_cli_json(common_args(registry_path, runtime, gate_root))
+        assert_payload(dry_payload, appended=False)
+        assert_gate_files(gate_root)
+
+        execute_payload = run_cli_json(
+            common_args(registry_path, runtime, gate_root)
+            + [
+                "--delivery-batch-scale",
+                "multi_surface",
+                "--delivery-outcome",
+                "outcome_progress",
+                "--execute",
+            ]
+        )
+        assert_payload(execute_payload, appended=True)
+        assert_gate_files(gate_root)
+        assert_status_projection(registry_path, runtime)
+        assert_other_tags_rejected(registry_path, runtime, gate_root / "other")
+        assert_roots_are_mutually_exclusive(registry_path, runtime, gate_root / "mutual")
+
+    print(
+        "agentissue-bench-codex-cli-runner-execution-gate-smoke ok "
+        f"mode={RUN_MODE} appended=True real_run=False"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/agentissue-bench-codex-cli-runner-first-run-handoff-smoke.py
+++ b/examples/agentissue-bench-codex-cli-runner-first-run-handoff-smoke.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""Smoke-test AgentIssue-Bench Codex CLI runner first-run handoff packet."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from goal_harness.status import collect_status  # noqa: E402
+
+
+TOPIC_DIR = REPO_ROOT / "docs" / "research" / "long-horizon-agent-benchmarks"
+DOC = TOPIC_DIR / "agentissue-bench-codex-cli-runner-first-run-handoff-v0.md"
+README = TOPIC_DIR / "README.md"
+
+GOAL_ID = "agentissue-runner-first-run-handoff-fixture"
+BENCHMARK_ID = "agentissue-bench"
+SELECTED_TAG = "lagent_239"
+RUN_MODE = "agentissue_codex_cli_runner_first_run_handoff_packet"
+CLASSIFICATION = "agentissue_bench_codex_cli_runner_first_run_handoff_v0"
+
+REQUIRED_DOC_SNIPPETS = [
+    "AgentIssue-Bench Codex CLI Runner First-Run Handoff V0",
+    "--first-run-handoff-root",
+    "first-run-handoff.public.json",
+    "first-run-handoff.md",
+    "codex auth values read=false",
+    "python3 examples/agentissue-bench-codex-cli-runner-first-run-handoff-smoke.py",
+]
+
+FORBIDDEN_TEXT = [
+    "/" + "Users/",
+    "~/.codex",
+    ".codex/auth.json",
+    "OPENAI" + "_API_KEY",
+    "ANTHROPIC" + "_API_KEY",
+    "GOOGLE" + "_API_KEY",
+    "CODEX" + "_ACCESS_TOKEN",
+    "raw" + "_issue_body:",
+    "raw" + "_patch:",
+    "raw" + "_log:",
+    "trajectory.json",
+]
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_fixture(root: Path) -> tuple[Path, Path, Path]:
+    project = root / "project"
+    runtime = root / "runtime"
+    handoff_root = root / "private-handoff-root"
+    state_file = f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    registry_path = project / ".goal-harness" / "registry.json"
+
+    (project / Path(state_file).parent).mkdir(parents=True, exist_ok=True)
+    (project / state_file).write_text(
+        "---\n"
+        "status: active-read-only\n"
+        "updated_at: 2026-06-13T00:00:00+00:00\n"
+        "---\n\n"
+        "# AgentIssue Runner First-Run Handoff Fixture\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] Build AgentIssue no-execute first-run handoff packet.\n",
+        encoding="utf-8",
+    )
+    write_json(
+        registry_path,
+        {
+            "schema_version": 1,
+            "updated_at": "2026-06-13T00:00:00+00:00",
+            "common_runtime_root": str(runtime),
+            "goals": [
+                {
+                    "id": GOAL_ID,
+                    "domain": "goal-harness-platform",
+                    "status": "active-read-only",
+                    "state_file": state_file,
+                    "repo": str(project),
+                    "adapter": {
+                        "kind": "harness_self_improvement",
+                        "status": "connected-read-only",
+                    },
+                    "heartbeat": {"enabled": True},
+                }
+            ],
+        },
+    )
+    return registry_path, runtime, handoff_root
+
+
+def run_cli(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "goal_harness.cli", *args],
+        cwd=REPO_ROOT,
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def run_cli_json(args: list[str]) -> dict[str, Any]:
+    result = run_cli(args)
+    payload = json.loads(result.stdout)
+    assert isinstance(payload, dict), payload
+    return payload
+
+
+def common_args(registry_path: Path, runtime: Path, handoff_root: Path) -> list[str]:
+    return [
+        "--registry",
+        str(registry_path),
+        "--runtime-root",
+        str(runtime),
+        "--format",
+        "json",
+        "benchmark",
+        "agentissue-codex-runner-flow",
+        "--goal-id",
+        GOAL_ID,
+        "--tag",
+        SELECTED_TAG,
+        "--first-run-handoff-root",
+        str(handoff_root),
+        "--no-global-sync",
+    ]
+
+
+def assert_no_forbidden_text(payload: dict[str, Any]) -> None:
+    text = json.dumps(payload, sort_keys=True)
+    leaked = [marker for marker in FORBIDDEN_TEXT if marker in text]
+    assert not leaked, leaked
+    assert len(text) < 52000, len(text)
+
+
+def assert_doc_contract() -> None:
+    text = DOC.read_text(encoding="utf-8")
+    readme = README.read_text(encoding="utf-8")
+    missing = [snippet for snippet in REQUIRED_DOC_SNIPPETS if snippet not in text]
+    assert not missing, missing
+    assert "agentissue-bench-codex-cli-runner-first-run-handoff-v0.md" in readme, readme
+    leaked = [marker for marker in FORBIDDEN_TEXT if marker in text]
+    assert not leaked, leaked
+
+
+def assert_handoff_files(handoff_root: Path) -> None:
+    expected_paths = [
+        "context/prompt.md",
+        "buggy-source/.gitkeep",
+        "Patches/lagent_239/.gitkeep",
+        "runner-flow-plan.public.json",
+        "execution-gate.public.json",
+        "first-run-handoff.public.json",
+        "first-run-handoff.md",
+        "benchmark_run.compact.json",
+    ]
+    missing = [rel for rel in expected_paths if not (handoff_root / rel).exists()]
+    assert not missing, missing
+
+    handoff = json.loads((handoff_root / "first-run-handoff.public.json").read_text(encoding="utf-8"))
+    assert handoff["schema_version"] == CLASSIFICATION, handoff
+    assert handoff["default_mode"] == "no_execute", handoff
+    assert handoff["path_recorded"] is False, handoff
+    assert handoff["exact_command_shape"]["runs_real_benchmark"] is False, handoff
+    assert handoff["budget_auth_boundary"]["codex_auth_values_read"] is False, handoff
+    assert handoff["budget_auth_boundary"]["codex_home_synced"] is False, handoff
+    assert handoff["no_execute_assertions"]["codex_cli_invoked"] is False, handoff
+    assert handoff["no_execute_assertions"]["docker_container_started"] is False, handoff
+
+    markdown = (handoff_root / "first-run-handoff.md").read_text(encoding="utf-8")
+    assert "This packet is no-execute" in markdown, markdown
+    assert "Codex auth stays on the host" in markdown, markdown
+
+    local_run = json.loads((handoff_root / "benchmark_run.compact.json").read_text(encoding="utf-8"))
+    assert local_run["schema_version"] == "benchmark_run_v0", local_run
+    assert local_run["mode"] == RUN_MODE, local_run
+    assert local_run["validation"]["first_run_handoff_materialized"] is True, local_run
+
+
+def assert_payload(payload: dict[str, Any], *, appended: bool) -> None:
+    assert payload["ok"] is True, payload
+    assert payload["appended"] is appended, payload
+    assert payload["dry_run"] is (not appended), payload
+    assert payload["classification"] == CLASSIFICATION, payload
+
+    cli = payload["benchmark_cli"]
+    assert cli["benchmark"] == BENCHMARK_ID, cli
+    assert cli["command"] == "agentissue-codex-runner-flow", cli
+    assert cli["tag"] == SELECTED_TAG, cli
+    assert cli["synthetic_staging_materialized"] is False, cli
+    assert cli["execution_gate_materialized"] is False, cli
+    assert cli["first_run_handoff_materialized"] is True, cli
+    assert cli["first_run_handoff_root_path_recorded"] is False, cli
+    assert cli["real_codex_invoked"] is False, cli
+    assert cli["real_docker_invoked"] is False, cli
+    assert cli["auth_values_read"] is False, cli
+
+    handoff = payload["agentissue_first_run_handoff"]
+    assert handoff["schema_version"] == CLASSIFICATION, handoff
+    assert handoff["ready"] is True, handoff
+    assert handoff["materialized"] is True, handoff
+    assert handoff["path_recorded"] is False, handoff
+    assert handoff["handoff_relative_path"] == "first-run-handoff.public.json", handoff
+    assert handoff["handoff_markdown_relative_path"] == "first-run-handoff.md", handoff
+    assert handoff["handoff_checks"]["exact_command_shape_rendered"] is True, handoff
+    assert handoff["handoff_checks"]["budget_auth_boundary_declared"] is True, handoff
+    assert handoff["execution_boundary"]["codex_cli_invoked"] is False, handoff
+    assert handoff["execution_boundary"]["docker_container_started"] is False, handoff
+
+    event = payload["benchmark_run"]
+    assert event["schema_version"] == "benchmark_run_v0", event
+    assert event["benchmark_id"] == BENCHMARK_ID, event
+    assert event["mode"] == RUN_MODE, event
+    assert event["first_blocker"] == "first_run_handoff_only_no_real_case", event
+    assert event["real_run"] is False, event
+    assert event["submit_eligible"] is False, event
+    assert event["leaderboard_evidence"] is False, event
+    assert event["validation"]["all_passed"] is True, event
+    assert "first-run-handoff.public.json" in event["evidence_files"], event
+    assert "first-run-handoff.md" in event["evidence_files"], event
+    assert_no_forbidden_text(handoff)
+    assert_no_forbidden_text(event)
+    assert_no_forbidden_text(cli)
+
+
+def assert_status_projection(registry_path: Path, runtime: Path) -> None:
+    status = collect_status(
+        registry_path=registry_path,
+        runtime_root_override=str(runtime),
+        scan_roots=[],
+        limit=5,
+    )
+    assert status["ok"], status
+    latest = status["run_history"]["goals"][0]["latest_runs"][0]
+    summary = latest["benchmark_run_summary"]
+    assert summary["mode"] == RUN_MODE, summary
+    assert summary["benchmark_id"] == BENCHMARK_ID, summary
+    assert summary["validation"]["all_passed"] is True, summary
+    assert_no_forbidden_text(summary)
+
+
+def assert_roots_are_mutually_exclusive(registry_path: Path, runtime: Path, handoff_root: Path) -> None:
+    args = common_args(registry_path, runtime, handoff_root) + [
+        "--execution-gate-root",
+        str(handoff_root / "other-root"),
+    ]
+    result = run_cli(args, check=False)
+    assert result.returncode == 1, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False, payload
+    assert "at most one" in payload["error"], payload
+
+
+def main() -> None:
+    assert_doc_contract()
+    with tempfile.TemporaryDirectory(prefix="agentissue-runner-first-run-handoff-") as tmp:
+        registry_path, runtime, handoff_root = write_fixture(Path(tmp))
+        dry_payload = run_cli_json(common_args(registry_path, runtime, handoff_root))
+        assert_payload(dry_payload, appended=False)
+        assert_handoff_files(handoff_root)
+
+        execute_payload = run_cli_json(
+            common_args(registry_path, runtime, handoff_root)
+            + [
+                "--delivery-batch-scale",
+                "multi_surface",
+                "--delivery-outcome",
+                "outcome_progress",
+                "--execute",
+            ]
+        )
+        assert_payload(execute_payload, appended=True)
+        assert_handoff_files(handoff_root)
+        assert_status_projection(registry_path, runtime)
+        assert_roots_are_mutually_exclusive(registry_path, runtime, handoff_root / "mutual")
+
+    print(
+        "agentissue-bench-codex-cli-runner-first-run-handoff-smoke ok "
+        f"mode={RUN_MODE} appended=True real_run=False"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/agentissue-bench-codex-cli-runner-flow-smoke.py
+++ b/examples/agentissue-bench-codex-cli-runner-flow-smoke.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""Smoke-test the AgentIssue-Bench Codex CLI runner flow plan."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+SCHEMA_VERSION = "agentissue_bench_codex_cli_runner_flow_plan_v0"
+RUN_SCHEMA = "benchmark_run_v0"
+RESULT_SCHEMA = "benchmark_result_v0"
+CONTROL_SCORE_SCHEMA = "control_plane_score_core_v0"
+BENCHMARK_ID = "agentissue-bench"
+SELECTED_TAG = "lagent_239"
+IMAGE = "alfin06/agentissue-bench:lagent_239"
+PATCH_RELATIVE_PATH = "Patches/lagent_239/attempt.patch"
+
+CONTROL_PLANE_SCORE_COMPONENTS = (
+    "restartability",
+    "stale_state_avoidance",
+    "evidence_discipline",
+    "boundary_safety",
+    "writeback_quality",
+    "gate_compliance",
+    "failure_attribution",
+    "overhead",
+)
+
+FORBIDDEN_KEYS = {
+    "access_token",
+    "api_key",
+    "authorization",
+    "codex_auth",
+    "credential",
+    "environment",
+    "file_content",
+    "fixed_diff",
+    "gold_material",
+    "local_path",
+    "password",
+    "patch_content",
+    "raw_issue_body",
+    "raw_issue_title",
+    "raw_log",
+    "raw_output",
+    "raw_patch",
+    "screenshot",
+    "session",
+    "solution",
+    "test_body",
+    "trajectory",
+}
+FORBIDDEN_TEXT = (
+    "/" + "Users/",
+    "~/.codex",
+    ".codex/auth.json",
+    "CODEX_ACCESS_TOKEN",
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GOOGLE_API_KEY",
+    "show_diff",
+)
+
+
+def key_paths(value: Any, *, prefix: str = "") -> list[str]:
+    if isinstance(value, dict):
+        paths: list[str] = []
+        for key, child in value.items():
+            path = f"{prefix}.{key}" if prefix else str(key)
+            paths.append(path)
+            paths.extend(key_paths(child, prefix=path))
+        return paths
+    if isinstance(value, list):
+        paths = []
+        for index, child in enumerate(value):
+            paths.extend(key_paths(child, prefix=f"{prefix}[{index}]"))
+        return paths
+    return []
+
+
+def leaf(path: str) -> str:
+    segment = path.rsplit(".", 1)[-1]
+    if "[" in segment:
+        segment = segment.split("[", 1)[0]
+    return segment.lower()
+
+
+def build_runner_flow_plan() -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "benchmark_id": BENCHMARK_ID,
+        "selected_tag": SELECTED_TAG,
+        "dry_run_plan_only": True,
+        "real_execution_done": False,
+        "single_tag_only": True,
+        "active_scope": {
+            "only_active_benchmark": BENCHMARK_ID,
+            "only_active_task": SELECTED_TAG,
+            "no_other_benchmarks_until": "agentissue_codex_cli_runner_e2e_clean",
+        },
+        "private_workspace_contract": {
+            "job_root_placeholder": "<abs-private-job-root>",
+            "buggy_source_placeholder": "<abs-private-job-root>/buggy-source",
+            "patch_dir_placeholder": "<abs-private-job-root>/Patches/lagent_239",
+            "prompt_file_placeholder": "<abs-private-job-root>/context/prompt.md",
+            "last_message_placeholder": "<abs-private-job-root>/codex-last-message.txt",
+            "absolute_paths_required": True,
+            "record_absolute_paths_publicly": False,
+        },
+        "phase_order": [
+            "prepare_private_job_root",
+            "fetch_public_issue_context_to_private_context",
+            "pull_selected_image",
+            "extract_buggy_source_from_selected_container",
+            "initialize_git_baseline_in_buggy_source",
+            "run_host_local_codex_cli_patch_worker",
+            "write_attempt_patch_from_buggy_source_git_diff",
+            "evaluate_selected_tag_container",
+            "reduce_compact_evidence",
+        ],
+        "commands": {
+            "codex_patch_worker": {
+                "command_shape": [
+                    "codex",
+                    "exec",
+                    "--ephemeral",
+                    "--ignore-rules",
+                    "--sandbox",
+                    "workspace-write",
+                    "--cd",
+                    "<abs-private-job-root>/buggy-source",
+                    "--add-dir",
+                    "<abs-private-job-root>",
+                    "--output-last-message",
+                    "<abs-private-job-root>/codex-last-message.txt",
+                    "<abs-private-job-root>/context/prompt.md",
+                ],
+                "runs_on_host": True,
+                "runs_after_buggy_source_extraction": True,
+                "copy_codex_home": False,
+                "worker_network_allowed": False,
+                "worker_docker_allowed": False,
+                "worker_reads_fixed_diff": False,
+            },
+            "patch_export": {
+                "input_source": "<abs-private-job-root>/buggy-source git diff",
+                "output_relative_path": PATCH_RELATIVE_PATH,
+                "patch_content_public": False,
+                "patch_hash_public": True,
+            },
+            "single_tag_eval": {
+                "command_shape": [
+                    "docker",
+                    "run",
+                    "--platform",
+                    "linux/amd64",
+                    "--rm",
+                    "--entrypoint",
+                    "bash",
+                    "-v",
+                    "<abs-private-job-root>/Patches/lagent_239:/patches:ro",
+                    IMAGE,
+                    "-c",
+                    "<apply_patch_and_test_patched>",
+                ],
+                "official_helper_scripts_used": False,
+                "all_tag_loop_allowed": False,
+                "docker_env_credentials": False,
+                "upload": False,
+                "submit": False,
+                "public_ranking_path": False,
+            },
+        },
+        "reducer_contract": {
+            "allowed_public_fields": [
+                "tag",
+                "image_digest",
+                "patch_sha256",
+                "patch_bytes",
+                "changed_file_count",
+                "hunk_count",
+                "exit_code",
+                "resolved",
+                "duration_seconds",
+                "log_sha256",
+                "no_upload",
+                "no_submit",
+                "no_public_ranking_path",
+            ],
+            "raw_issue_text_public": False,
+            "raw_patch_public": False,
+            "raw_log_public": False,
+            "absolute_paths_public": False,
+        },
+        "no_execution_boundary": {
+            "codex_cli_invoked": False,
+            "model_api_invoked": False,
+            "docker_image_pulled": False,
+            "docker_container_started": False,
+            "patch_generated": False,
+            "patch_evaluated": False,
+        },
+        "stop_rules": {
+            "stop_before_codex_auth_sync": True,
+            "stop_before_current_head_patch_source": True,
+            "stop_before_fixed_diff_or_oracle_read": True,
+            "stop_before_all_tag_helpers": True,
+            "stop_before_upload_submit_or_public_ranking": True,
+            "stop_before_raw_artifact_publication": True,
+        },
+    }
+
+
+def reduce_to_benchmark_run(plan: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "schema_version": RUN_SCHEMA,
+        "source_runner": BENCHMARK_ID,
+        "benchmark_id": BENCHMARK_ID,
+        "mode": "lagent239_codex_cli_runner_flow_plan_no_execution",
+        "real_run": False,
+        "dry_run": True,
+        "task_selector_kind": "selected_public_tag",
+        "task_selector_hash": plan["selected_tag"],
+        "progress": {
+            "n_total_trials": 1,
+            "n_completed_trials": 0,
+            "n_errored_trials": 0,
+            "n_running_trials": 0,
+            "n_pending_trials": 1,
+            "n_cancelled_trials": 0,
+            "n_retries": 0,
+        },
+        "validation": {
+            "runner_flow_plan_built": True,
+            "single_tag_only": True,
+            "absolute_paths_required": True,
+            "uses_benchmark_buggy_source": True,
+            "no_current_public_head_patch_source": True,
+            "no_codex_cli_invoked": True,
+            "no_model_api_invoked": True,
+            "no_docker_container_started": True,
+            "no_patch_content_public": True,
+            "no_upload": True,
+            "no_submit": True,
+            "no_public_ranking_path": True,
+        },
+        "trials": [
+            {
+                "task_hash": plan["selected_tag"],
+                "runner_status": "planned",
+                "resolved": None,
+                "docker_image": IMAGE,
+            }
+        ],
+    }
+
+
+def reduce_to_benchmark_result(plan: dict[str, Any]) -> dict[str, Any]:
+    components = {
+        "restartability": 1.0,
+        "stale_state_avoidance": 1.0,
+        "evidence_discipline": 1.0,
+        "boundary_safety": 1.0,
+        "writeback_quality": 0.875,
+        "gate_compliance": 1.0,
+        "failure_attribution": 0.875,
+        "overhead": 0.875,
+    }
+    value = sum(components.values()) / len(components)
+    return {
+        "schema_version": RESULT_SCHEMA,
+        "task_id": "agentissue_bench_lagent_239",
+        "scenario_id": "lagent239_codex_cli_runner_flow_plan_no_execution",
+        "worker_mode": "trusted_local_codex_cli_runner_plan",
+        "harness_identity": "goal_harness",
+        "terminal_state": "runner_flow_plan_ready_before_execution",
+        "official_task_score": {
+            "kind": "agentissue_bench_single_tag_container_eval",
+            "status": "not_run",
+            "resolved": None,
+            "value": None,
+        },
+        "control_plane_score": {
+            "schema_version": CONTROL_SCORE_SCHEMA,
+            "kind": "core_v0",
+            "aggregation": "unweighted_mean",
+            "value": round(value, 6),
+            "components": components,
+            "component_order": list(CONTROL_PLANE_SCORE_COMPONENTS),
+        },
+        "validation_pass_count": 18,
+        "validation_fail_count": 0,
+        "forbidden_access_count": 0,
+        "claim_boundary": {
+            "single_tag_local_eval_claim_allowed": False,
+            "official_leaderboard_claim_allowed": False,
+            "control_plane_score_claim_allowed": True,
+        },
+        "failure_attribution_labels": [
+            "no_execution_plan_only",
+            "runner_flow_requires_private_materialization",
+        ],
+        "recommended_next_action": "materialize_agentissue_lagent239_runner_flow_in_private_job_root_or_write_blocker",
+    }
+
+
+def assert_public_safe(payload: dict[str, Any]) -> None:
+    bad_keys = [path for path in key_paths(payload) if leaf(path) in FORBIDDEN_KEYS]
+    assert not bad_keys, bad_keys
+    rendered = json.dumps(payload, sort_keys=True)
+    leaked = [marker for marker in FORBIDDEN_TEXT if marker in rendered]
+    assert not leaked, leaked
+
+
+def run_smoke() -> dict[str, Any]:
+    plan = build_runner_flow_plan()
+    run_event = reduce_to_benchmark_run(plan)
+    result_event = reduce_to_benchmark_result(plan)
+    phases = plan["phase_order"]
+    commands = plan["commands"]
+
+    assert plan["schema_version"] == SCHEMA_VERSION, plan
+    assert plan["dry_run_plan_only"] is True, plan
+    assert plan["real_execution_done"] is False, plan
+    assert plan["single_tag_only"] is True, plan
+    assert plan["active_scope"]["only_active_benchmark"] == BENCHMARK_ID, plan
+    assert plan["active_scope"]["only_active_task"] == SELECTED_TAG, plan
+    assert phases.index("extract_buggy_source_from_selected_container") < phases.index(
+        "run_host_local_codex_cli_patch_worker"
+    ), plan
+    assert phases.index("run_host_local_codex_cli_patch_worker") < phases.index(
+        "write_attempt_patch_from_buggy_source_git_diff"
+    ), plan
+    assert commands["codex_patch_worker"]["command_shape"][0] == "codex", plan
+    assert "--ephemeral" in commands["codex_patch_worker"]["command_shape"], plan
+    assert "--add-dir" in commands["codex_patch_worker"]["command_shape"], plan
+    assert "--output-last-message" in commands["codex_patch_worker"]["command_shape"], plan
+    assert commands["codex_patch_worker"]["copy_codex_home"] is False, plan
+    assert commands["codex_patch_worker"]["worker_reads_fixed_diff"] is False, plan
+    assert commands["single_tag_eval"]["command_shape"][0] == "docker", plan
+    assert commands["single_tag_eval"]["official_helper_scripts_used"] is False, plan
+    assert commands["single_tag_eval"]["all_tag_loop_allowed"] is False, plan
+    assert commands["single_tag_eval"]["docker_env_credentials"] is False, plan
+    assert commands["single_tag_eval"]["upload"] is False, plan
+    assert commands["single_tag_eval"]["submit"] is False, plan
+    assert plan["no_execution_boundary"]["codex_cli_invoked"] is False, plan
+    assert plan["no_execution_boundary"]["docker_container_started"] is False, plan
+    assert run_event["schema_version"] == RUN_SCHEMA, run_event
+    assert run_event["real_run"] is False, run_event
+    assert run_event["validation"]["uses_benchmark_buggy_source"] is True, run_event
+    assert run_event["validation"]["no_current_public_head_patch_source"] is True, run_event
+    assert run_event["validation"]["no_codex_cli_invoked"] is True, run_event
+    assert run_event["validation"]["no_docker_container_started"] is True, run_event
+    assert result_event["schema_version"] == RESULT_SCHEMA, result_event
+    assert result_event["official_task_score"]["status"] == "not_run", result_event
+    assert result_event["claim_boundary"]["official_leaderboard_claim_allowed"] is False, result_event
+    assert_public_safe(plan)
+    assert_public_safe(run_event)
+    assert_public_safe(result_event)
+    return {
+        "ok": True,
+        "classification": SCHEMA_VERSION,
+        "runner_flow_plan": plan,
+        "benchmark_run": run_event,
+        "benchmark_result": result_event,
+        "only_active_benchmark": BENCHMARK_ID,
+        "only_active_task": SELECTED_TAG,
+        "real_execution_done": False,
+        "recommended_next_action": result_event["recommended_next_action"],
+    }
+
+
+def main() -> None:
+    print(json.dumps(run_smoke(), indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py
+++ b/examples/agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py
@@ -20,6 +20,7 @@ DOCS = [
     "agentissue-bench-codex-cli-runner-synthetic-staging-v0.md",
     "agentissue-bench-codex-cli-runner-execution-gate-v0.md",
     "agentissue-bench-codex-cli-runner-first-run-handoff-v0.md",
+    "agentissue-bench-codex-cli-runner-workflow-check-v0.md",
     "agentissue-bench-codex-cli-runner-pr-ready-packet-v0.md",
 ]
 
@@ -30,15 +31,17 @@ SMOKES = [
     "agentissue-bench-codex-cli-runner-synthetic-staging-smoke.py",
     "agentissue-bench-codex-cli-runner-execution-gate-smoke.py",
     "agentissue-bench-codex-cli-runner-first-run-handoff-smoke.py",
+    "agentissue-bench-codex-cli-runner-workflow-check-smoke.py",
     "agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py",
 ]
 
 REQUIRED_PACKET_SNIPPETS = [
     "AgentIssue-Bench Codex CLI Runner PR-Ready Packet V0",
-    "contract -> flow plan -> dry-run wrapper -> synthetic staging -> execution gate -> first-run handoff -> PR-ready packet",
+    "contract -> flow plan -> dry-run wrapper -> synthetic staging -> execution gate -> first-run handoff -> workflow check -> PR-ready packet",
     "--synthetic-staging-root",
     "--execution-gate-root",
     "--first-run-handoff-root",
+    "--workflow-check-root",
     "real_run=false",
     "submit_eligible=false",
     "leaderboard_evidence=false",
@@ -49,10 +52,13 @@ REQUIRED_SOURCE_SNIPPETS = [
     "AGENTISSUE_CODEX_CLI_RUNNER_SYNTHETIC_STAGING_SCHEMA_VERSION",
     "AGENTISSUE_CODEX_CLI_RUNNER_EXECUTION_GATE_SCHEMA_VERSION",
     "AGENTISSUE_CODEX_CLI_RUNNER_FIRST_RUN_HANDOFF_SCHEMA_VERSION",
+    "AGENTISSUE_CODEX_CLI_RUNNER_WORKFLOW_CHECK_SCHEMA_VERSION",
     "materialize_agentissue_codex_cli_runner_synthetic_staging",
     "materialize_agentissue_codex_cli_runner_execution_gate",
     "materialize_agentissue_codex_cli_runner_first_run_handoff",
+    "materialize_agentissue_codex_cli_runner_workflow_check",
     "--first-run-handoff-root",
+    "--workflow-check-root",
 ]
 
 FORBIDDEN_TEXT = [
@@ -121,7 +127,7 @@ def main() -> None:
     assert_public_boundary()
     print(
         "agentissue-bench-codex-cli-runner-pr-ready-packet-smoke ok "
-        "docs=7 smokes=7 real_run=False"
+        "docs=8 smokes=8 real_run=False"
     )
 
 

--- a/examples/agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py
+++ b/examples/agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Smoke-test the AgentIssue-Bench Codex CLI runner PR-ready packet."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TOPIC_DIR = REPO_ROOT / "docs" / "research" / "long-horizon-agent-benchmarks"
+README = TOPIC_DIR / "README.md"
+BENCHMARK = REPO_ROOT / "goal_harness" / "benchmark.py"
+CLI = REPO_ROOT / "goal_harness" / "cli.py"
+
+DOCS = [
+    "agentissue-bench-codex-cli-runner-contract-v0.md",
+    "agentissue-bench-codex-cli-runner-flow-plan-v0.md",
+    "agentissue-bench-codex-cli-runner-dry-run-wrapper-v0.md",
+    "agentissue-bench-codex-cli-runner-synthetic-staging-v0.md",
+    "agentissue-bench-codex-cli-runner-execution-gate-v0.md",
+    "agentissue-bench-codex-cli-runner-first-run-handoff-v0.md",
+    "agentissue-bench-codex-cli-runner-pr-ready-packet-v0.md",
+]
+
+SMOKES = [
+    "agentissue-bench-codex-cli-runner-contract-smoke.py",
+    "agentissue-bench-codex-cli-runner-flow-smoke.py",
+    "agentissue-bench-codex-cli-runner-dry-run-wrapper-smoke.py",
+    "agentissue-bench-codex-cli-runner-synthetic-staging-smoke.py",
+    "agentissue-bench-codex-cli-runner-execution-gate-smoke.py",
+    "agentissue-bench-codex-cli-runner-first-run-handoff-smoke.py",
+    "agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py",
+]
+
+REQUIRED_PACKET_SNIPPETS = [
+    "AgentIssue-Bench Codex CLI Runner PR-Ready Packet V0",
+    "contract -> flow plan -> dry-run wrapper -> synthetic staging -> execution gate -> first-run handoff -> PR-ready packet",
+    "--synthetic-staging-root",
+    "--execution-gate-root",
+    "--first-run-handoff-root",
+    "real_run=false",
+    "submit_eligible=false",
+    "leaderboard_evidence=false",
+]
+
+REQUIRED_SOURCE_SNIPPETS = [
+    "AGENTISSUE_CODEX_CLI_RUNNER_WRAPPER_SCHEMA_VERSION",
+    "AGENTISSUE_CODEX_CLI_RUNNER_SYNTHETIC_STAGING_SCHEMA_VERSION",
+    "AGENTISSUE_CODEX_CLI_RUNNER_EXECUTION_GATE_SCHEMA_VERSION",
+    "AGENTISSUE_CODEX_CLI_RUNNER_FIRST_RUN_HANDOFF_SCHEMA_VERSION",
+    "materialize_agentissue_codex_cli_runner_synthetic_staging",
+    "materialize_agentissue_codex_cli_runner_execution_gate",
+    "materialize_agentissue_codex_cli_runner_first_run_handoff",
+    "--first-run-handoff-root",
+]
+
+FORBIDDEN_TEXT = [
+    "/" + "Users/",
+    ".codex/auth.json",
+    "OPENAI" + "_API_KEY",
+    "ANTHROPIC" + "_API_KEY",
+    "GOOGLE" + "_API_KEY",
+    "CODEX" + "_ACCESS_TOKEN",
+    "raw" + "_issue_body:",
+    "raw" + "_patch:",
+    "raw" + "_log:",
+    "trajectory.json",
+    "screenshot.png",
+]
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def assert_exists() -> None:
+    missing_docs = [name for name in DOCS if not (TOPIC_DIR / name).exists()]
+    missing_smokes = [name for name in SMOKES if not (REPO_ROOT / "examples" / name).exists()]
+    assert not missing_docs, missing_docs
+    assert not missing_smokes, missing_smokes
+
+
+def assert_readme_indexed() -> None:
+    text = read(README)
+    missing = [name for name in DOCS if name not in text]
+    assert not missing, missing
+
+
+def assert_packet_contract() -> None:
+    packet = read(TOPIC_DIR / "agentissue-bench-codex-cli-runner-pr-ready-packet-v0.md")
+    missing = [snippet for snippet in REQUIRED_PACKET_SNIPPETS if snippet not in packet]
+    assert not missing, missing
+    assert packet.count("agentissue-bench-codex-cli-runner-") >= len(DOCS), packet
+    assert packet.count("examples/agentissue-bench-codex-cli-runner-") >= len(SMOKES), packet
+
+
+def assert_source_contract() -> None:
+    source = read(BENCHMARK) + "\n" + read(CLI)
+    missing = [snippet for snippet in REQUIRED_SOURCE_SNIPPETS if snippet not in source]
+    assert not missing, missing
+    assert source.count("real_codex_invoked") >= 1, "missing Codex no-run flag"
+    assert source.count("real_docker_invoked") >= 1, "missing Docker no-run flag"
+    assert "agentissue-codex-runner-flow accepts at most one root option, not both" in source
+
+
+def assert_public_boundary() -> None:
+    public_text = "\n".join(read(TOPIC_DIR / name) for name in DOCS)
+    leaked = [marker for marker in FORBIDDEN_TEXT if marker in public_text]
+    assert not leaked, leaked
+    assert "<private-root>" in public_text or "<private-gate-root>" in public_text
+    assert "<abs-private-job-root>" in public_text
+    assert not re.search(r"/var/folders/|/tmp/agentissue|/home/[^<]", public_text), "local path leak"
+
+
+def main() -> None:
+    assert_exists()
+    assert_readme_indexed()
+    assert_packet_contract()
+    assert_source_contract()
+    assert_public_boundary()
+    print(
+        "agentissue-bench-codex-cli-runner-pr-ready-packet-smoke ok "
+        "docs=7 smokes=7 real_run=False"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/agentissue-bench-codex-cli-runner-publication-change-set-smoke.py
+++ b/examples/agentissue-bench-codex-cli-runner-publication-change-set-smoke.py
@@ -21,6 +21,7 @@ DOCS = [
     "agentissue-bench-codex-cli-runner-synthetic-staging-v0.md",
     "agentissue-bench-codex-cli-runner-execution-gate-v0.md",
     "agentissue-bench-codex-cli-runner-first-run-handoff-v0.md",
+    "agentissue-bench-codex-cli-runner-workflow-check-v0.md",
     "agentissue-bench-codex-cli-runner-pr-ready-packet-v0.md",
     "agentissue-bench-codex-cli-runner-publication-change-set-v0.md",
 ]
@@ -32,6 +33,7 @@ SMOKES = [
     "agentissue-bench-codex-cli-runner-synthetic-staging-smoke.py",
     "agentissue-bench-codex-cli-runner-execution-gate-smoke.py",
     "agentissue-bench-codex-cli-runner-first-run-handoff-smoke.py",
+    "agentissue-bench-codex-cli-runner-workflow-check-smoke.py",
     "agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py",
     "agentissue-bench-codex-cli-runner-publication-change-set-smoke.py",
 ]
@@ -49,14 +51,17 @@ REQUIRED_SOURCE_SNIPPETS = [
     "AGENTISSUE_CODEX_CLI_RUNNER_SYNTHETIC_STAGING_SCHEMA_VERSION",
     "AGENTISSUE_CODEX_CLI_RUNNER_EXECUTION_GATE_SCHEMA_VERSION",
     "AGENTISSUE_CODEX_CLI_RUNNER_FIRST_RUN_HANDOFF_SCHEMA_VERSION",
+    "AGENTISSUE_CODEX_CLI_RUNNER_WORKFLOW_CHECK_SCHEMA_VERSION",
     "build_agentissue_codex_cli_runner_wrapper",
     "materialize_agentissue_codex_cli_runner_synthetic_staging",
     "materialize_agentissue_codex_cli_runner_execution_gate",
     "materialize_agentissue_codex_cli_runner_first_run_handoff",
+    "materialize_agentissue_codex_cli_runner_workflow_check",
     "agentissue-codex-runner-flow",
     "--synthetic-staging-root",
     "--execution-gate-root",
     "--first-run-handoff-root",
+    "--workflow-check-root",
     "read_boundary",
 ]
 
@@ -82,6 +87,7 @@ def git_diff_name_only() -> set[str] | None:
     for diff_args in (
         ["git", "diff", "--name-only", "--"],
         ["git", "diff", "--cached", "--name-only", "--"],
+        ["git", "diff", "--name-only", "origin/main", "--"],
     ):
         result = subprocess.run(
             diff_args + MIXED_TRACKED_FILES,
@@ -153,7 +159,7 @@ def main() -> None:
     assert_public_boundary()
     print(
         "agentissue-bench-codex-cli-runner-publication-change-set-smoke ok "
-        "docs=8 smokes=8 mixed_files=4 real_run=False"
+        "docs=9 smokes=9 mixed_files=4 real_run=False"
     )
 
 

--- a/examples/agentissue-bench-codex-cli-runner-publication-change-set-smoke.py
+++ b/examples/agentissue-bench-codex-cli-runner-publication-change-set-smoke.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Smoke-test the AgentIssue-Bench runner publication change-set packet."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TOPIC_DIR = REPO_ROOT / "docs" / "research" / "long-horizon-agent-benchmarks"
+README = TOPIC_DIR / "README.md"
+PACKET = TOPIC_DIR / "agentissue-bench-codex-cli-runner-publication-change-set-v0.md"
+BENCHMARK = REPO_ROOT / "goal_harness" / "benchmark.py"
+CLI = REPO_ROOT / "goal_harness" / "cli.py"
+
+DOCS = [
+    "agentissue-bench-codex-cli-runner-contract-v0.md",
+    "agentissue-bench-codex-cli-runner-flow-plan-v0.md",
+    "agentissue-bench-codex-cli-runner-dry-run-wrapper-v0.md",
+    "agentissue-bench-codex-cli-runner-synthetic-staging-v0.md",
+    "agentissue-bench-codex-cli-runner-execution-gate-v0.md",
+    "agentissue-bench-codex-cli-runner-first-run-handoff-v0.md",
+    "agentissue-bench-codex-cli-runner-pr-ready-packet-v0.md",
+    "agentissue-bench-codex-cli-runner-publication-change-set-v0.md",
+]
+
+SMOKES = [
+    "agentissue-bench-codex-cli-runner-contract-smoke.py",
+    "agentissue-bench-codex-cli-runner-flow-smoke.py",
+    "agentissue-bench-codex-cli-runner-dry-run-wrapper-smoke.py",
+    "agentissue-bench-codex-cli-runner-synthetic-staging-smoke.py",
+    "agentissue-bench-codex-cli-runner-execution-gate-smoke.py",
+    "agentissue-bench-codex-cli-runner-first-run-handoff-smoke.py",
+    "agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py",
+    "agentissue-bench-codex-cli-runner-publication-change-set-smoke.py",
+]
+
+MIXED_TRACKED_FILES = [
+    "goal_harness/benchmark.py",
+    "goal_harness/cli.py",
+    "goal_harness/status.py",
+    "docs/research/long-horizon-agent-benchmarks/README.md",
+]
+
+REQUIRED_SOURCE_SNIPPETS = [
+    "AGENTISSUE_BENCHMARK_ID",
+    "AGENTISSUE_CODEX_CLI_RUNNER_WRAPPER_SCHEMA_VERSION",
+    "AGENTISSUE_CODEX_CLI_RUNNER_SYNTHETIC_STAGING_SCHEMA_VERSION",
+    "AGENTISSUE_CODEX_CLI_RUNNER_EXECUTION_GATE_SCHEMA_VERSION",
+    "AGENTISSUE_CODEX_CLI_RUNNER_FIRST_RUN_HANDOFF_SCHEMA_VERSION",
+    "build_agentissue_codex_cli_runner_wrapper",
+    "materialize_agentissue_codex_cli_runner_synthetic_staging",
+    "materialize_agentissue_codex_cli_runner_execution_gate",
+    "materialize_agentissue_codex_cli_runner_first_run_handoff",
+    "agentissue-codex-runner-flow",
+    "--synthetic-staging-root",
+    "--execution-gate-root",
+    "--first-run-handoff-root",
+    "read_boundary",
+]
+
+FORBIDDEN_PACKET_TEXT = [
+    "/" + "Users/",
+    ".codex/auth.json",
+    "OPENAI" + "_API_KEY",
+    "ANTHROPIC" + "_API_KEY",
+    "GOOGLE" + "_API_KEY",
+    "CODEX" + "_ACCESS_TOKEN",
+    "raw_issue_body:",
+    "raw_patch:",
+    "raw_log:",
+]
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def git_diff_name_only() -> set[str] | None:
+    changed: set[str] = set()
+    for diff_args in (
+        ["git", "diff", "--name-only", "--"],
+        ["git", "diff", "--cached", "--name-only", "--"],
+    ):
+        result = subprocess.run(
+            diff_args + MIXED_TRACKED_FILES,
+            cwd=REPO_ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        if result.returncode != 0:
+            return None
+        changed.update(line.strip() for line in result.stdout.splitlines() if line.strip())
+    return changed
+
+
+def assert_packet_exists_and_indexed() -> None:
+    assert PACKET.exists(), PACKET
+    readme = read(README)
+    assert PACKET.name in readme
+
+
+def assert_include_lists() -> None:
+    packet = read(PACKET)
+    missing_docs = [name for name in DOCS if name not in packet]
+    missing_smokes = [name for name in SMOKES if name not in packet]
+    missing_mixed = [name for name in MIXED_TRACKED_FILES if name not in packet]
+    assert not missing_docs, missing_docs
+    assert not missing_smokes, missing_smokes
+    assert not missing_mixed, missing_mixed
+    assert "do not stage them with a whole-file `git add`" in packet
+    assert "hunk-level staging" in packet
+    assert "not part of this runner-flow publication change set" in packet
+
+
+def assert_source_and_readme_contract() -> None:
+    source = read(BENCHMARK) + "\n" + read(CLI)
+    missing = [snippet for snippet in REQUIRED_SOURCE_SNIPPETS if snippet not in source]
+    assert not missing, missing
+    readme = read(README)
+    for name in DOCS:
+        assert name in readme, name
+    assert readme.count("agentissue-bench-codex-cli-runner-") >= len(DOCS)
+
+
+def assert_mixed_files_are_detected() -> None:
+    changed = git_diff_name_only()
+    if changed is None or not changed:
+        missing_paths = [name for name in MIXED_TRACKED_FILES if not (REPO_ROOT / name).exists()]
+        assert not missing_paths, missing_paths
+        return
+    missing = [name for name in MIXED_TRACKED_FILES if name not in changed]
+    assert not missing, missing
+
+
+def assert_public_boundary() -> None:
+    packet = read(PACKET)
+    leaked = [marker for marker in FORBIDDEN_PACKET_TEXT if marker in packet]
+    assert not leaked, leaked
+    assert "real_run=false" in packet
+    assert "submit_eligible=false" in packet
+    assert "leaderboard_evidence=false" in packet
+    assert "Codex, Docker, model APIs" in packet
+
+
+def main() -> None:
+    assert_packet_exists_and_indexed()
+    assert_include_lists()
+    assert_source_and_readme_contract()
+    assert_mixed_files_are_detected()
+    assert_public_boundary()
+    print(
+        "agentissue-bench-codex-cli-runner-publication-change-set-smoke ok "
+        "docs=8 smokes=8 mixed_files=4 real_run=False"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/agentissue-bench-codex-cli-runner-synthetic-staging-smoke.py
+++ b/examples/agentissue-bench-codex-cli-runner-synthetic-staging-smoke.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Smoke-test AgentIssue-Bench Codex CLI runner synthetic staging."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from goal_harness.status import collect_status  # noqa: E402
+
+
+TOPIC_DIR = REPO_ROOT / "docs" / "research" / "long-horizon-agent-benchmarks"
+DOC = TOPIC_DIR / "agentissue-bench-codex-cli-runner-synthetic-staging-v0.md"
+README = TOPIC_DIR / "README.md"
+
+GOAL_ID = "agentissue-runner-staging-fixture"
+BENCHMARK_ID = "agentissue-bench"
+SELECTED_TAG = "lagent_239"
+RUN_MODE = "agentissue_codex_cli_runner_synthetic_staging_fixture"
+CLASSIFICATION = "agentissue_bench_codex_cli_runner_synthetic_staging_v0"
+
+REQUIRED_DOC_SNIPPETS = [
+    "AgentIssue-Bench Codex CLI Runner Synthetic Staging V0",
+    "--synthetic-staging-root",
+    "context/prompt.md",
+    "Patches/lagent_239/attempt.patch",
+    "benchmark_run.compact.json",
+    "runner-flow-plan.public.json",
+    "python3 examples/agentissue-bench-codex-cli-runner-synthetic-staging-smoke.py",
+]
+
+FORBIDDEN_TEXT = [
+    "/" + "Users/",
+    "~/.codex",
+    ".codex/auth.json",
+    "OPENAI" + "_API_KEY",
+    "ANTHROPIC" + "_API_KEY",
+    "GOOGLE" + "_API_KEY",
+    "CODEX" + "_ACCESS_TOKEN",
+    "real issue statement body",
+    "raw" + "_issue_body:",
+    "raw" + "_patch:",
+    "raw" + "_log:",
+    "trajectory.json",
+    "screenshot",
+]
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_fixture(root: Path) -> tuple[Path, Path, Path]:
+    project = root / "project"
+    runtime = root / "runtime"
+    staging_root = root / "private-job-root"
+    state_file = f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    registry_path = project / ".goal-harness" / "registry.json"
+
+    (project / Path(state_file).parent).mkdir(parents=True, exist_ok=True)
+    (project / state_file).write_text(
+        "---\n"
+        "status: active-read-only\n"
+        "updated_at: 2026-06-12T00:00:00+00:00\n"
+        "---\n\n"
+        "# AgentIssue Runner Staging Fixture\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] Materialize synthetic AgentIssue runner staging.\n",
+        encoding="utf-8",
+    )
+    write_json(
+        registry_path,
+        {
+            "schema_version": 1,
+            "updated_at": "2026-06-12T00:00:00+00:00",
+            "common_runtime_root": str(runtime),
+            "goals": [
+                {
+                    "id": GOAL_ID,
+                    "domain": "goal-harness-platform",
+                    "status": "active-read-only",
+                    "state_file": state_file,
+                    "repo": str(project),
+                    "adapter": {
+                        "kind": "harness_self_improvement",
+                        "status": "connected-read-only",
+                    },
+                    "heartbeat": {
+                        "enabled": True,
+                    },
+                }
+            ],
+        },
+    )
+    return registry_path, runtime, staging_root
+
+
+def run_cli(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "goal_harness.cli", *args],
+        cwd=REPO_ROOT,
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def run_cli_json(args: list[str]) -> dict[str, Any]:
+    result = run_cli(args)
+    payload = json.loads(result.stdout)
+    assert isinstance(payload, dict), payload
+    return payload
+
+
+def common_args(registry_path: Path, runtime: Path, staging_root: Path) -> list[str]:
+    return [
+        "--registry",
+        str(registry_path),
+        "--runtime-root",
+        str(runtime),
+        "--format",
+        "json",
+        "benchmark",
+        "agentissue-codex-runner-flow",
+        "--goal-id",
+        GOAL_ID,
+        "--tag",
+        SELECTED_TAG,
+        "--synthetic-staging-root",
+        str(staging_root),
+        "--no-global-sync",
+    ]
+
+
+def assert_no_forbidden_text(payload: dict[str, Any]) -> None:
+    text = json.dumps(payload, sort_keys=True)
+    leaked = [marker for marker in FORBIDDEN_TEXT if marker in text]
+    assert not leaked, leaked
+    assert len(text) < 34000, len(text)
+
+
+def assert_doc_contract() -> None:
+    text = DOC.read_text(encoding="utf-8")
+    readme = README.read_text(encoding="utf-8")
+    missing = [snippet for snippet in REQUIRED_DOC_SNIPPETS if snippet not in text]
+    assert not missing, missing
+    assert "agentissue-bench-codex-cli-runner-synthetic-staging-v0.md" in readme, readme
+    leaked = [marker for marker in FORBIDDEN_TEXT if marker in text]
+    assert not leaked, leaked
+
+
+def assert_staging_files(staging_root: Path) -> None:
+    expected_paths = [
+        "context/prompt.md",
+        "buggy-source/.gitkeep",
+        "Patches/lagent_239/.gitkeep",
+        "runner-flow-plan.public.json",
+        "benchmark_run.compact.json",
+    ]
+    missing = [rel for rel in expected_paths if not (staging_root / rel).exists()]
+    assert not missing, missing
+
+    prompt = (staging_root / "context" / "prompt.md").read_text(encoding="utf-8")
+    assert "Synthetic AgentIssue-Bench lagent_239 Prompt Placeholder" in prompt, prompt
+    assert "Patches/lagent_239/attempt.patch" in prompt, prompt
+    assert "raw_issue_body" not in prompt, prompt
+
+    runner_plan = json.loads((staging_root / "runner-flow-plan.public.json").read_text(encoding="utf-8"))
+    assert runner_plan["schema_version"] == CLASSIFICATION, runner_plan
+    assert runner_plan["path_recorded"] is False, runner_plan
+    assert runner_plan["relative_paths"]["prompt"] == "context/prompt.md", runner_plan
+    assert runner_plan["relative_paths"]["expected_patch"] == "Patches/lagent_239/attempt.patch", runner_plan
+
+    local_run = json.loads((staging_root / "benchmark_run.compact.json").read_text(encoding="utf-8"))
+    assert local_run["schema_version"] == "benchmark_run_v0", local_run
+    assert local_run["mode"] == RUN_MODE, local_run
+    assert local_run["validation"]["synthetic_private_job_root_materialized"] is True, local_run
+
+
+def assert_payload(payload: dict[str, Any], *, appended: bool) -> None:
+    assert payload["ok"] is True, payload
+    assert payload["appended"] is appended, payload
+    assert payload["dry_run"] is (not appended), payload
+    assert payload["classification"] == CLASSIFICATION, payload
+
+    cli = payload["benchmark_cli"]
+    assert cli["benchmark"] == BENCHMARK_ID, cli
+    assert cli["command"] == "agentissue-codex-runner-flow", cli
+    assert cli["tag"] == SELECTED_TAG, cli
+    assert cli["synthetic_staging_materialized"] is True, cli
+    assert cli["synthetic_staging_root_path_recorded"] is False, cli
+    assert cli["real_runner_invoked"] is False, cli
+    assert cli["real_codex_invoked"] is False, cli
+    assert cli["real_docker_invoked"] is False, cli
+    assert cli["model_api_invoked"] is False, cli
+    assert cli["auth_values_read"] is False, cli
+
+    staging = payload["agentissue_synthetic_staging"]
+    assert staging["schema_version"] == CLASSIFICATION, staging
+    assert staging["ready"] is True, staging
+    assert staging["materialized"] is True, staging
+    assert staging["path_recorded"] is False, staging
+    assert staging["staging_root_path_recorded"] is False, staging
+    assert staging["prompt_relative_path"] == "context/prompt.md", staging
+    assert staging["expected_patch_relative_path"] == "Patches/lagent_239/attempt.patch", staging
+    assert staging["compact_run_relative_path"] == "benchmark_run.compact.json", staging
+    assert staging["runner_plan_relative_path"] == "runner-flow-plan.public.json", staging
+    assert staging["execution_boundary"]["codex_cli_invoked"] is False, staging
+    assert staging["execution_boundary"]["docker_container_started"] is False, staging
+
+    event = payload["benchmark_run"]
+    assert event["schema_version"] == "benchmark_run_v0", event
+    assert event["benchmark_id"] == BENCHMARK_ID, event
+    assert event["mode"] == RUN_MODE, event
+    assert event["first_blocker"] == "synthetic_staging_only_no_real_case", event
+    assert event["real_run"] is False, event
+    assert event["submit_eligible"] is False, event
+    assert event["leaderboard_evidence"] is False, event
+    assert event["official_task_score"]["kind"] == (
+        "agentissue_bench_single_tag_container_eval_not_run"
+    ), event
+    assert event["validation"]["all_passed"] is True, event
+    assert event["validation"]["failed_checks"] == [], event
+    assert event["read_boundary"]["compact_only"] is True, event
+    assert event["read_boundary"]["docker_invoked"] is False, event
+    assert event["read_boundary"]["model_api_invoked"] is False, event
+    assert_no_forbidden_text(staging)
+    assert_no_forbidden_text(event)
+    assert_no_forbidden_text(cli)
+
+
+def assert_status_projection(registry_path: Path, runtime: Path) -> None:
+    status = collect_status(
+        registry_path=registry_path,
+        runtime_root_override=str(runtime),
+        scan_roots=[],
+        limit=5,
+    )
+    assert status["ok"], status
+    latest = status["run_history"]["goals"][0]["latest_runs"][0]
+    summary = latest["benchmark_run_summary"]
+    assert summary["mode"] == RUN_MODE, summary
+    assert summary["benchmark_id"] == BENCHMARK_ID, summary
+    assert summary["validation"]["all_passed"] is True, summary
+    assert status["event_ledger_summary"]["totals"]["benchmark_runs_24h"] == 1, status
+    assert_no_forbidden_text(summary)
+
+
+def assert_other_tags_rejected(registry_path: Path, runtime: Path, staging_root: Path) -> None:
+    args = common_args(registry_path, runtime, staging_root)
+    tag_index = args.index("--tag") + 1
+    args[tag_index] = "other_001"
+    result = run_cli(args, check=False)
+    assert result.returncode == 1, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False, payload
+    assert "only supports selected tag" in payload["error"], payload
+
+
+def main() -> None:
+    assert_doc_contract()
+    with tempfile.TemporaryDirectory(prefix="agentissue-runner-staging-") as tmp:
+        registry_path, runtime, staging_root = write_fixture(Path(tmp))
+        dry_payload = run_cli_json(common_args(registry_path, runtime, staging_root))
+        assert_payload(dry_payload, appended=False)
+        assert_staging_files(staging_root)
+
+        execute_payload = run_cli_json(
+            common_args(registry_path, runtime, staging_root)
+            + [
+                "--delivery-batch-scale",
+                "multi_surface",
+                "--delivery-outcome",
+                "outcome_progress",
+                "--execute",
+            ]
+        )
+        assert_payload(execute_payload, appended=True)
+        assert_staging_files(staging_root)
+        assert_status_projection(registry_path, runtime)
+        assert_other_tags_rejected(registry_path, runtime, staging_root / "other")
+
+    print(
+        "agentissue-bench-codex-cli-runner-synthetic-staging-smoke ok "
+        f"mode={RUN_MODE} appended=True real_run=False"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/agentissue-bench-codex-cli-runner-workflow-check-smoke.py
+++ b/examples/agentissue-bench-codex-cli-runner-workflow-check-smoke.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""Smoke-test AgentIssue-Bench Codex CLI runner workflow check packet."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from goal_harness.status import collect_status  # noqa: E402
+
+
+TOPIC_DIR = REPO_ROOT / "docs" / "research" / "long-horizon-agent-benchmarks"
+DOC = TOPIC_DIR / "agentissue-bench-codex-cli-runner-workflow-check-v0.md"
+README = TOPIC_DIR / "README.md"
+
+GOAL_ID = "agentissue-runner-workflow-check-fixture"
+BENCHMARK_ID = "agentissue-bench"
+SELECTED_TAG = "lagent_239"
+RUN_MODE = "agentissue_codex_cli_runner_workflow_check_packet"
+CLASSIFICATION = "agentissue_bench_codex_cli_runner_workflow_check_v0"
+
+REQUIRED_DOC_SNIPPETS = [
+    "AgentIssue-Bench Codex CLI Runner Workflow Check V0",
+    "--workflow-check-root",
+    "workflow-check.public.json",
+    "source_extracted_before_codex",
+    "host_codex_auth_not_synced",
+    "python3 examples/agentissue-bench-codex-cli-runner-workflow-check-smoke.py",
+]
+
+FORBIDDEN_TEXT = [
+    "/" + "Users/",
+    "~/.codex",
+    ".codex/auth.json",
+    "OPENAI" + "_API_KEY",
+    "ANTHROPIC" + "_API_KEY",
+    "GOOGLE" + "_API_KEY",
+    "CODEX" + "_ACCESS_TOKEN",
+    "raw" + "_issue_body:",
+    "raw" + "_patch:",
+    "raw" + "_log:",
+    "trajectory.json",
+]
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_fixture(root: Path) -> tuple[Path, Path, Path]:
+    project = root / "project"
+    runtime = root / "runtime"
+    workflow_root = root / "private-workflow-root"
+    state_file = f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    registry_path = project / ".goal-harness" / "registry.json"
+
+    (project / Path(state_file).parent).mkdir(parents=True, exist_ok=True)
+    (project / state_file).write_text(
+        "---\n"
+        "status: active-read-only\n"
+        "updated_at: 2026-06-13T00:00:00+00:00\n"
+        "---\n\n"
+        "# AgentIssue Runner Workflow Check Fixture\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] Build AgentIssue no-execute workflow check packet.\n",
+        encoding="utf-8",
+    )
+    write_json(
+        registry_path,
+        {
+            "schema_version": 1,
+            "updated_at": "2026-06-13T00:00:00+00:00",
+            "common_runtime_root": str(runtime),
+            "goals": [
+                {
+                    "id": GOAL_ID,
+                    "domain": "goal-harness-platform",
+                    "status": "active-read-only",
+                    "state_file": state_file,
+                    "repo": str(project),
+                    "adapter": {
+                        "kind": "harness_self_improvement",
+                        "status": "connected-read-only",
+                    },
+                    "heartbeat": {"enabled": True},
+                }
+            ],
+        },
+    )
+    return registry_path, runtime, workflow_root
+
+
+def run_cli(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "goal_harness.cli", *args],
+        cwd=REPO_ROOT,
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def run_cli_json(args: list[str]) -> dict[str, Any]:
+    result = run_cli(args)
+    payload = json.loads(result.stdout)
+    assert isinstance(payload, dict), payload
+    return payload
+
+
+def common_args(registry_path: Path, runtime: Path, workflow_root: Path) -> list[str]:
+    return [
+        "--registry",
+        str(registry_path),
+        "--runtime-root",
+        str(runtime),
+        "--format",
+        "json",
+        "benchmark",
+        "agentissue-codex-runner-flow",
+        "--goal-id",
+        GOAL_ID,
+        "--tag",
+        SELECTED_TAG,
+        "--workflow-check-root",
+        str(workflow_root),
+        "--no-global-sync",
+    ]
+
+
+def assert_no_forbidden_text(payload: dict[str, Any]) -> None:
+    text = json.dumps(payload, sort_keys=True)
+    leaked = [marker for marker in FORBIDDEN_TEXT if marker in text]
+    assert not leaked, leaked
+    assert len(text) < 70000, len(text)
+
+
+def assert_doc_contract() -> None:
+    text = DOC.read_text(encoding="utf-8")
+    readme = README.read_text(encoding="utf-8")
+    missing = [snippet for snippet in REQUIRED_DOC_SNIPPETS if snippet not in text]
+    assert not missing, missing
+    assert "agentissue-bench-codex-cli-runner-workflow-check-v0.md" in readme, readme
+    leaked = [marker for marker in FORBIDDEN_TEXT if marker in text]
+    assert not leaked, leaked
+
+
+def assert_workflow_files(workflow_root: Path) -> None:
+    expected_paths = [
+        "context/prompt.md",
+        "buggy-source/.gitkeep",
+        "Patches/lagent_239/.gitkeep",
+        "runner-flow-plan.public.json",
+        "execution-gate.public.json",
+        "first-run-handoff.public.json",
+        "first-run-handoff.md",
+        "workflow-check.public.json",
+        "benchmark_run.compact.json",
+    ]
+    missing = [rel for rel in expected_paths if not (workflow_root / rel).exists()]
+    assert not missing, missing
+
+    workflow = json.loads((workflow_root / "workflow-check.public.json").read_text(encoding="utf-8"))
+    assert workflow["schema_version"] == CLASSIFICATION, workflow
+    assert workflow["ready"] is True, workflow
+    assert workflow["path_recorded"] is False, workflow
+    assert workflow["default_mode"] == "no_execute", workflow
+    assert workflow["failed_checks"] == [], workflow
+    checks = workflow["workflow_checks"]
+    for key in [
+        "single_selected_tag",
+        "selected_image_consistent",
+        "source_extracted_before_codex",
+        "host_codex_uses_ephemeral",
+        "host_codex_auth_not_synced",
+        "worker_no_network_or_docker",
+        "patch_from_buggy_source_git_diff",
+        "attempt_patch_relative_path",
+        "single_tag_eval_no_upload_submit",
+        "single_tag_eval_no_public_ranking",
+        "no_execute_packet",
+        "public_files_compact_or_public",
+        "private_dirs_not_public_artifacts",
+    ]:
+        assert checks[key] is True, (key, workflow)
+    assert workflow["execution_boundary"]["codex_cli_invoked"] is False, workflow
+    assert workflow["execution_boundary"]["docker_container_started"] is False, workflow
+
+    local_run = json.loads((workflow_root / "benchmark_run.compact.json").read_text(encoding="utf-8"))
+    assert local_run["schema_version"] == "benchmark_run_v0", local_run
+    assert local_run["mode"] == RUN_MODE, local_run
+    assert local_run["validation"]["workflow_check_materialized"] is True, local_run
+    assert local_run["validation"]["workflow_check_all_passed"] is True, local_run
+
+
+def assert_payload(payload: dict[str, Any], *, appended: bool) -> None:
+    assert payload["ok"] is True, payload
+    assert payload["appended"] is appended, payload
+    assert payload["dry_run"] is (not appended), payload
+    assert payload["classification"] == CLASSIFICATION, payload
+
+    cli = payload["benchmark_cli"]
+    assert cli["benchmark"] == BENCHMARK_ID, cli
+    assert cli["command"] == "agentissue-codex-runner-flow", cli
+    assert cli["tag"] == SELECTED_TAG, cli
+    assert cli["workflow_check_materialized"] is True, cli
+    assert cli["workflow_check_root_path_recorded"] is False, cli
+    assert cli["real_codex_invoked"] is False, cli
+    assert cli["real_docker_invoked"] is False, cli
+    assert cli["auth_values_read"] is False, cli
+
+    workflow = payload["agentissue_workflow_check"]
+    assert workflow["schema_version"] == CLASSIFICATION, workflow
+    assert workflow["ready"] is True, workflow
+    assert workflow["workflow_check_relative_path"] == "workflow-check.public.json", workflow
+    assert workflow["failed_checks"] == [], workflow
+    assert workflow["workflow_checks"]["source_extracted_before_codex"] is True, workflow
+    assert workflow["workflow_checks"]["host_codex_auth_not_synced"] is True, workflow
+    assert workflow["execution_boundary"]["codex_cli_invoked"] is False, workflow
+    assert workflow["execution_boundary"]["docker_container_started"] is False, workflow
+
+    event = payload["benchmark_run"]
+    assert event["schema_version"] == "benchmark_run_v0", event
+    assert event["benchmark_id"] == BENCHMARK_ID, event
+    assert event["mode"] == RUN_MODE, event
+    assert event["first_blocker"] == "workflow_check_only_no_real_case", event
+    assert event["real_run"] is False, event
+    assert event["submit_eligible"] is False, event
+    assert event["leaderboard_evidence"] is False, event
+    assert event["validation"]["all_passed"] is True, event
+    assert "workflow-check.public.json" in event["evidence_files"], event
+    assert_no_forbidden_text(workflow)
+    assert_no_forbidden_text(event)
+    assert_no_forbidden_text(cli)
+
+
+def assert_status_projection(registry_path: Path, runtime: Path) -> None:
+    status = collect_status(
+        registry_path=registry_path,
+        runtime_root_override=str(runtime),
+        scan_roots=[],
+        limit=5,
+    )
+    assert status["ok"], status
+    latest = status["run_history"]["goals"][0]["latest_runs"][0]
+    summary = latest["benchmark_run_summary"]
+    assert summary["mode"] == RUN_MODE, summary
+    assert summary["benchmark_id"] == BENCHMARK_ID, summary
+    assert summary["validation"]["all_passed"] is True, summary
+    assert_no_forbidden_text(summary)
+
+
+def assert_roots_are_mutually_exclusive(registry_path: Path, runtime: Path, workflow_root: Path) -> None:
+    args = common_args(registry_path, runtime, workflow_root) + [
+        "--first-run-handoff-root",
+        str(workflow_root / "other-root"),
+    ]
+    result = run_cli(args, check=False)
+    assert result.returncode == 1, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False, payload
+    assert "at most one" in payload["error"], payload
+
+
+def main() -> None:
+    assert_doc_contract()
+    with tempfile.TemporaryDirectory(prefix="agentissue-runner-workflow-check-") as tmp:
+        registry_path, runtime, workflow_root = write_fixture(Path(tmp))
+        dry_payload = run_cli_json(common_args(registry_path, runtime, workflow_root))
+        assert_payload(dry_payload, appended=False)
+        assert_workflow_files(workflow_root)
+
+        execute_payload = run_cli_json(
+            common_args(registry_path, runtime, workflow_root)
+            + [
+                "--delivery-batch-scale",
+                "multi_surface",
+                "--delivery-outcome",
+                "outcome_progress",
+                "--execute",
+            ]
+        )
+        assert_payload(execute_payload, appended=True)
+        assert_workflow_files(workflow_root)
+        assert_status_projection(registry_path, runtime)
+        assert_roots_are_mutually_exclusive(registry_path, runtime, workflow_root / "mutual")
+
+    print(
+        "agentissue-bench-codex-cli-runner-workflow-check-smoke ok "
+        f"mode={RUN_MODE} appended=True real_run=False"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/goal_harness/benchmark.py
+++ b/goal_harness/benchmark.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shlex
 import shutil
 import subprocess
@@ -190,6 +191,37 @@ AGENTS_LAST_EXAM_RAW_SURFACES_EXCLUDED = (
     "origin_log",
     "output",
 )
+AGENTISSUE_BENCHMARK_ID = "agentissue-bench"
+AGENTISSUE_CODEX_CLI_RUNNER_WRAPPER_SCHEMA_VERSION = (
+    "agentissue_bench_codex_cli_runner_dry_run_wrapper_v0"
+)
+AGENTISSUE_CODEX_CLI_RUNNER_BENCHMARK_RUN_MODE = (
+    "agentissue_codex_cli_runner_dry_run_wrapper"
+)
+AGENTISSUE_CODEX_CLI_RUNNER_SYNTHETIC_STAGING_SCHEMA_VERSION = (
+    "agentissue_bench_codex_cli_runner_synthetic_staging_v0"
+)
+AGENTISSUE_CODEX_CLI_RUNNER_SYNTHETIC_STAGING_MODE = (
+    "agentissue_codex_cli_runner_synthetic_staging_fixture"
+)
+AGENTISSUE_CODEX_CLI_RUNNER_EXECUTION_GATE_SCHEMA_VERSION = (
+    "agentissue_bench_codex_cli_runner_execution_gate_v0"
+)
+AGENTISSUE_CODEX_CLI_RUNNER_EXECUTION_GATE_MODE = (
+    "agentissue_codex_cli_runner_execution_gate"
+)
+AGENTISSUE_CODEX_CLI_RUNNER_FIRST_RUN_HANDOFF_SCHEMA_VERSION = (
+    "agentissue_bench_codex_cli_runner_first_run_handoff_v0"
+)
+AGENTISSUE_CODEX_CLI_RUNNER_FIRST_RUN_HANDOFF_MODE = (
+    "agentissue_codex_cli_runner_first_run_handoff_packet"
+)
+AGENTISSUE_CODEX_CLI_RUNNER_SOURCE_RUNNER = (
+    "goal_harness_agentissue_codex_cli_runner"
+)
+AGENTISSUE_DEFAULT_TAG = "lagent_239"
+AGENTISSUE_DEFAULT_IMAGE = "alfin06/agentissue-bench:lagent_239"
+AGENTISSUE_PATCH_RELATIVE_PATH = "Patches/lagent_239/attempt.patch"
 BENCHMARK_PUBLIC_ARTIFACT_SUFFIXES = (
     ".compact.json",
     ".public.json",
@@ -290,6 +322,888 @@ def filter_public_benchmark_artifact_paths(
         },
     }
 
+
+
+def _agentissue_public_label(value: Any, *, limit: int = 120) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError("agentissue label is required")
+    if not re.fullmatch(r"[A-Za-z0-9_.:-]{1,120}", text):
+        raise ValueError("agentissue label must be public-safe")
+    return text[:limit]
+
+
+def build_agentissue_codex_cli_runner_wrapper(
+    *,
+    selected_tag: str = AGENTISSUE_DEFAULT_TAG,
+    codex_binary: str = "codex",
+    docker_binary: str = "docker",
+    job_root_placeholder: str = "<abs-private-job-root>",
+) -> dict[str, Any]:
+    """Build a dry-run-default AgentIssue-Bench Codex CLI runner wrapper.
+
+    The wrapper deliberately renders command and staging shapes only. It never
+    calls Codex, Docker, model APIs, or benchmark helpers; callers that append
+    the embedded benchmark_run_v0 are recording readiness, not a task score.
+    """
+
+    tag = _agentissue_public_label(selected_tag)
+    if tag != AGENTISSUE_DEFAULT_TAG:
+        raise ValueError(
+            "agentissue Codex runner wrapper currently only supports selected tag lagent_239"
+        )
+    codex = _agentissue_public_label(codex_binary, limit=80)
+    docker = _agentissue_public_label(docker_binary, limit=80)
+    image = AGENTISSUE_DEFAULT_IMAGE
+    buggy_source = f"{job_root_placeholder}/buggy-source"
+    context_dir = f"{job_root_placeholder}/context"
+    patch_dir = f"{job_root_placeholder}/Patches/lagent_239"
+    prompt_path = f"{context_dir}/prompt.md"
+    last_message = f"{job_root_placeholder}/codex-last-message.txt"
+    compact_run_path = f"{job_root_placeholder}/benchmark_run.compact.json"
+
+    phase_order = [
+        "prepare_private_job_root",
+        "write_public_issue_context_to_private_context",
+        "pull_selected_image_opt_in",
+        "extract_buggy_source_from_selected_container_opt_in",
+        "initialize_git_baseline_in_buggy_source",
+        "run_host_local_codex_cli_patch_worker_opt_in",
+        "write_attempt_patch_from_buggy_source_git_diff",
+        "evaluate_selected_tag_container_opt_in",
+        "reduce_compact_public_evidence",
+    ]
+    codex_argv = [
+        codex,
+        "exec",
+        "--ephemeral",
+        "--ignore-rules",
+        "--sandbox",
+        "workspace-write",
+        "--cd",
+        buggy_source,
+        "--add-dir",
+        job_root_placeholder,
+        "--output-last-message",
+        last_message,
+        prompt_path,
+    ]
+    eval_argv = [
+        docker,
+        "run",
+        "--platform",
+        "linux/amd64",
+        "--rm",
+        "--entrypoint",
+        "bash",
+        "-v",
+        f"{patch_dir}:/patches:ro",
+        image,
+        "-c",
+        "<apply_patch_and_test_patched>",
+    ]
+    wrapper = {
+        "schema_version": AGENTISSUE_CODEX_CLI_RUNNER_WRAPPER_SCHEMA_VERSION,
+        "benchmark_id": AGENTISSUE_BENCHMARK_ID,
+        "selected_tag": tag,
+        "selected_image": image,
+        "dry_run_default": True,
+        "real_execution_done": False,
+        "single_tag_only": True,
+        "staging_plan": {
+            "private_job_root_placeholder": job_root_placeholder,
+            "path_recorded": False,
+            "buggy_source_placeholder": buggy_source,
+            "context_dir_placeholder": context_dir,
+            "patch_dir_placeholder": patch_dir,
+            "prompt_path_placeholder": prompt_path,
+            "last_message_placeholder": last_message,
+            "compact_run_placeholder": compact_run_path,
+            "phase_order": phase_order,
+        },
+        "commands": {
+            "codex_patch_worker": {
+                "argv": codex_argv,
+                "runs_on_host": True,
+                "runs_after_buggy_source_extraction": True,
+                "copy_codex_home": False,
+                "auth_material_synced": False,
+                "worker_network_allowed": False,
+                "worker_docker_allowed": False,
+                "reads_fixed_diff_or_oracle": False,
+                "execute_by_default": False,
+            },
+            "patch_export": {
+                "input_source": "buggy_source_git_diff",
+                "output_relative_path": AGENTISSUE_PATCH_RELATIVE_PATH,
+                "raw_patch_public": False,
+                "patch_hash_public": True,
+            },
+            "single_tag_eval": {
+                "argv": eval_argv,
+                "official_all_tag_helper_allowed": False,
+                "docker_env_credentials": False,
+                "upload": False,
+                "submit": False,
+                "public_ranking_path": False,
+                "execute_by_default": False,
+            },
+        },
+        "execution_boundary": {
+            "codex_cli_invoked": False,
+            "model_api_invoked": False,
+            "docker_image_pulled": False,
+            "docker_container_started": False,
+            "patch_generated": False,
+            "patch_evaluated": False,
+            "raw_issue_text_read": False,
+            "raw_patch_recorded": False,
+            "raw_log_recorded": False,
+            "credential_values_recorded": False,
+        },
+        "reducer_contract": {
+            "allowed_public_fields": [
+                "tag",
+                "image_digest",
+                "patch_sha256",
+                "patch_bytes",
+                "changed_file_count",
+                "hunk_count",
+                "exit_code",
+                "resolved",
+                "duration_seconds",
+                "log_sha256",
+                "no_upload",
+                "no_submit",
+                "no_public_ranking_path",
+            ],
+            "raw_issue_text_public": False,
+            "raw_patch_public": False,
+            "raw_log_public": False,
+            "absolute_paths_public": False,
+        },
+        "stop_rules": {
+            "stop_before_codex_auth_sync": True,
+            "stop_before_current_head_patch_source": True,
+            "stop_before_fixed_diff_or_oracle_read": True,
+            "stop_before_all_tag_helpers": True,
+            "stop_before_upload_submit_or_public_ranking": True,
+            "stop_before_raw_artifact_publication": True,
+            "stop_before_destructive_git_or_production": True,
+        },
+    }
+    benchmark_run = {
+        "schema_version": "benchmark_run_v0",
+        "source_runner": AGENTISSUE_CODEX_CLI_RUNNER_SOURCE_RUNNER,
+        "benchmark_id": AGENTISSUE_BENCHMARK_ID,
+        "job_name": "agentissue_lagent_239_codex_cli_runner_dry_run",
+        "mode": AGENTISSUE_CODEX_CLI_RUNNER_BENCHMARK_RUN_MODE,
+        "worker_mode": "trusted_host_codex_cli_dry_run_wrapper",
+        "trace_publicness": "compact_public_no_issue_text_no_patch_no_logs",
+        "first_blocker": "dry_run_wrapper_only_no_real_case",
+        "score_failure_attribution": "not_run_wrapper_readiness_only",
+        "real_run": False,
+        "submit_eligible": False,
+        "leaderboard_evidence": False,
+        "official_score_comparable_to_native_codex": False,
+        "official_score_claim_allowed": False,
+        "control_plane_score_applicable": True,
+        "official_task_score": {
+            "kind": "agentissue_bench_single_tag_container_eval_not_run",
+            "status": "not_run",
+            "value": None,
+            "resolved": None,
+        },
+        "progress": {
+            "n_total_trials": 1,
+            "n_completed_trials": 0,
+            "n_errored_trials": 0,
+            "n_running_trials": 0,
+            "n_pending_trials": 1,
+            "n_cancelled_trials": 0,
+            "n_retries": 0,
+        },
+        "metrics": {
+            "input_tokens": 0,
+            "cache_tokens": 0,
+            "output_tokens": 0,
+            "cost_usd": 0,
+        },
+        "validation": {
+            "runner_wrapper_built": True,
+            "dry_run_default": True,
+            "single_tag_only": True,
+            "absolute_private_job_root_placeholders": True,
+            "buggy_source_before_codex_patch": True,
+            "patch_from_buggy_source_git_diff": True,
+            "selected_tag_eval_only": True,
+            "compact_reducer_declared": True,
+            "no_codex_cli_invoked": True,
+            "no_model_api_invoked": True,
+            "no_docker_container_started": True,
+            "no_patch_generated": True,
+            "no_patch_evaluated": True,
+            "no_auth_material_sync": True,
+            "no_current_public_head_patch_source": True,
+            "no_fixed_diff_or_oracle_read": True,
+            "no_upload": True,
+            "no_submit": True,
+            "no_public_ranking_path": True,
+        },
+        "trials": [
+            {
+                "task_id": tag,
+                "trial_name": tag,
+                "source": "selected_public_tag",
+                "exception_type": "dry_run_wrapper_only_no_real_case",
+                "trajectory_present": False,
+                "artifact_manifest_present": False,
+                "trial_result_present": False,
+            }
+        ],
+        "failure_attribution_labels": [
+            "no_execution_wrapper_only",
+            "ready_for_synthetic_job_root_staging",
+        ],
+        "evidence_files": [
+            "benchmark_run.compact.json",
+            "runner-flow-plan.public.json",
+        ],
+        "stop_conditions": [
+            "codex_auth_sync_requested",
+            "current_head_patch_source_requested",
+            "fixed_diff_or_oracle_requested",
+            "all_tag_helper_requested",
+            "upload_submit_or_public_ranking_requested",
+            "raw_artifact_publication_requested",
+        ],
+        "read_boundary": {
+            "compact_only": True,
+            "raw_artifacts_read": False,
+            "task_text_read": False,
+            "trajectory_read": False,
+            "local_paths_recorded": False,
+            "docker_invoked": False,
+            "model_api_invoked": False,
+            "upload_invoked": False,
+        },
+    }
+    return {
+        **wrapper,
+        "benchmark_run": benchmark_run,
+        "recommended_next_action": (
+            "run this wrapper against a synthetic private job root, then gate any real "
+            "Codex/Docker execution behind explicit opt-in"
+        ),
+    }
+
+
+def materialize_agentissue_codex_cli_runner_synthetic_staging(
+    staging_root: str | Path,
+    *,
+    selected_tag: str = AGENTISSUE_DEFAULT_TAG,
+    codex_binary: str = "codex",
+    docker_binary: str = "docker",
+) -> dict[str, Any]:
+    """Create a synthetic AgentIssue runner job root without real task material."""
+
+    tag = _agentissue_public_label(selected_tag)
+    if tag != AGENTISSUE_DEFAULT_TAG:
+        raise ValueError(
+            "agentissue Codex runner synthetic staging currently only supports selected tag lagent_239"
+        )
+    root = Path(staging_root).expanduser()
+    if not str(root):
+        raise ValueError("synthetic staging root is required")
+
+    wrapper = build_agentissue_codex_cli_runner_wrapper(
+        selected_tag=tag,
+        codex_binary=codex_binary,
+        docker_binary=docker_binary,
+    )
+    context_dir = root / "context"
+    buggy_source_dir = root / "buggy-source"
+    patch_dir = root / "Patches" / tag
+    prompt_path = context_dir / "prompt.md"
+    runner_plan_path = root / "runner-flow-plan.public.json"
+    compact_run_path = root / "benchmark_run.compact.json"
+
+    prompt_text = (
+        "# Synthetic AgentIssue-Bench lagent_239 Prompt Placeholder\n\n"
+        "This fixture contains no real issue statement, source diff, test patch, "
+        "expected patch, auth value, trajectory, screenshot, or raw log.\n\n"
+        f"Expected patch output path: {AGENTISSUE_PATCH_RELATIVE_PATH}\n\n"
+        "Run boundary: do not invoke Codex, Docker, model APIs, upload, submit, "
+        "or public ranking paths from this fixture.\n"
+    )
+    benchmark_run = json.loads(json.dumps(wrapper["benchmark_run"]))
+    benchmark_run.update(
+        {
+            "job_name": "agentissue_lagent_239_codex_cli_runner_synthetic_staging",
+            "mode": AGENTISSUE_CODEX_CLI_RUNNER_SYNTHETIC_STAGING_MODE,
+            "worker_mode": "trusted_host_codex_cli_synthetic_staging_fixture",
+            "first_blocker": "synthetic_staging_only_no_real_case",
+            "score_failure_attribution": "not_run_synthetic_staging_only",
+            "failure_attribution_labels": [
+                "synthetic_staging_fixture_only",
+                "ready_for_guarded_private_source_extraction_gate",
+            ],
+            "evidence_files": [
+                "benchmark_run.compact.json",
+                "runner-flow-plan.public.json",
+            ],
+        }
+    )
+    benchmark_run["validation"].update(
+        {
+            "synthetic_private_job_root_materialized": True,
+            "context_dir_created": True,
+            "buggy_source_dir_created": True,
+            "patch_dir_created": True,
+            "prompt_placeholder_written": True,
+            "prompt_path_rendered": True,
+            "patch_output_parent_reserved": True,
+            "compact_run_filename_reserved": True,
+            "runner_flow_plan_public_json_written": True,
+            "no_absolute_paths_public": True,
+        }
+    )
+    for trial in benchmark_run.get("trials") or []:
+        if isinstance(trial, dict):
+            trial["exception_type"] = "synthetic_staging_only_no_real_case"
+
+    runner_plan = {
+        "schema_version": AGENTISSUE_CODEX_CLI_RUNNER_SYNTHETIC_STAGING_SCHEMA_VERSION,
+        "benchmark_id": AGENTISSUE_BENCHMARK_ID,
+        "selected_tag": tag,
+        "selected_image": AGENTISSUE_DEFAULT_IMAGE,
+        "path_recorded": False,
+        "relative_paths": {
+            "context_dir": "context",
+            "buggy_source_dir": "buggy-source",
+            "patch_dir": "Patches/lagent_239",
+            "prompt": "context/prompt.md",
+            "expected_patch": AGENTISSUE_PATCH_RELATIVE_PATH,
+            "compact_run": "benchmark_run.compact.json",
+            "runner_plan": "runner-flow-plan.public.json",
+        },
+        "command_placeholders": wrapper["commands"],
+        "execution_boundary": wrapper["execution_boundary"],
+        "stop_rules": wrapper["stop_rules"],
+    }
+
+    context_dir.mkdir(parents=True, exist_ok=True)
+    buggy_source_dir.mkdir(parents=True, exist_ok=True)
+    patch_dir.mkdir(parents=True, exist_ok=True)
+    prompt_path.write_text(prompt_text, encoding="utf-8")
+    (buggy_source_dir / ".gitkeep").write_text("", encoding="utf-8")
+    (patch_dir / ".gitkeep").write_text("", encoding="utf-8")
+    runner_plan_path.write_text(
+        json.dumps(runner_plan, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    compact_run_path.write_text(
+        json.dumps(benchmark_run, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    created_relative_paths = [
+        "context/",
+        "context/prompt.md",
+        "buggy-source/",
+        "buggy-source/.gitkeep",
+        "Patches/lagent_239/",
+        "Patches/lagent_239/.gitkeep",
+        "runner-flow-plan.public.json",
+        "benchmark_run.compact.json",
+    ]
+    return {
+        "schema_version": AGENTISSUE_CODEX_CLI_RUNNER_SYNTHETIC_STAGING_SCHEMA_VERSION,
+        "benchmark_id": AGENTISSUE_BENCHMARK_ID,
+        "selected_tag": tag,
+        "selected_image": AGENTISSUE_DEFAULT_IMAGE,
+        "ready": True,
+        "materialized": True,
+        "path_recorded": False,
+        "staging_root_path_recorded": False,
+        "created_relative_paths": created_relative_paths,
+        "prompt_relative_path": "context/prompt.md",
+        "expected_patch_relative_path": AGENTISSUE_PATCH_RELATIVE_PATH,
+        "compact_run_relative_path": "benchmark_run.compact.json",
+        "runner_plan_relative_path": "runner-flow-plan.public.json",
+        "command_rendering_checks": {
+            "codex_argv_uses_prompt_placeholder": True,
+            "codex_argv_uses_buggy_source_placeholder": True,
+            "eval_argv_uses_selected_image": True,
+            "patch_output_parent_reserved": True,
+            "compact_reducer_filename_reserved": True,
+        },
+        "execution_boundary": {
+            "codex_cli_invoked": False,
+            "model_api_invoked": False,
+            "docker_image_pulled": False,
+            "docker_container_started": False,
+            "patch_generated": False,
+            "patch_evaluated": False,
+            "raw_issue_text_read": False,
+            "raw_patch_recorded": False,
+            "raw_log_recorded": False,
+            "credential_values_recorded": False,
+        },
+        "benchmark_run": benchmark_run,
+        "recommended_next_action": (
+            "add a guarded opt-in real-source extraction and host-Codex execution "
+            "gate for lagent_239, still defaulting to no-execute"
+        ),
+    }
+
+
+def materialize_agentissue_codex_cli_runner_execution_gate(
+    gate_root: str | Path,
+    *,
+    selected_tag: str = AGENTISSUE_DEFAULT_TAG,
+    codex_binary: str = "codex",
+    docker_binary: str = "docker",
+) -> dict[str, Any]:
+    """Create a no-execute gate packet for the first real AgentIssue runner step."""
+
+    tag = _agentissue_public_label(selected_tag)
+    if tag != AGENTISSUE_DEFAULT_TAG:
+        raise ValueError(
+            "agentissue Codex runner execution gate currently only supports selected tag lagent_239"
+        )
+    root = Path(gate_root).expanduser()
+    staging = materialize_agentissue_codex_cli_runner_synthetic_staging(
+        root,
+        selected_tag=tag,
+        codex_binary=codex_binary,
+        docker_binary=docker_binary,
+    )
+    wrapper = build_agentissue_codex_cli_runner_wrapper(
+        selected_tag=tag,
+        codex_binary=codex_binary,
+        docker_binary=docker_binary,
+    )
+    docker = _agentissue_public_label(docker_binary, limit=80)
+    image = AGENTISSUE_DEFAULT_IMAGE
+    container_label = "<tmp-agentissue-lagent-239-container>"
+    job_root = "<abs-private-job-root>"
+    buggy_source = f"{job_root}/buggy-source"
+    patch_path = f"{job_root}/{AGENTISSUE_PATCH_RELATIVE_PATH}"
+    gate_path = root / "execution-gate.public.json"
+    compact_run_path = root / "benchmark_run.compact.json"
+
+    extraction_commands = {
+        "inspect_selected_image": [docker, "image", "inspect", image],
+        "create_selected_container": [
+            docker,
+            "create",
+            "--name",
+            container_label,
+            image,
+        ],
+        "copy_buggy_source": [
+            docker,
+            "cp",
+            f"{container_label}:/workspace/.",
+            buggy_source,
+        ],
+        "remove_selected_container": [docker, "rm", container_label],
+    }
+    git_baseline_commands = {
+        "init": ["git", "-C", buggy_source, "init"],
+        "add": ["git", "-C", buggy_source, "add", "."],
+        "commit": [
+            "git",
+            "-C",
+            buggy_source,
+            "commit",
+            "-m",
+            "agentissue-bench-buggy-source-baseline",
+        ],
+    }
+    patch_export = {
+        "input_source": "buggy_source_git_diff",
+        "command_shape": f"git -C {buggy_source} diff --binary > {patch_path}",
+        "output_relative_path": AGENTISSUE_PATCH_RELATIVE_PATH,
+    }
+    gate = {
+        "schema_version": AGENTISSUE_CODEX_CLI_RUNNER_EXECUTION_GATE_SCHEMA_VERSION,
+        "benchmark_id": AGENTISSUE_BENCHMARK_ID,
+        "selected_tag": tag,
+        "selected_image": image,
+        "path_recorded": False,
+        "default_mode": "no_execute",
+        "future_opt_in_required": True,
+        "single_tag_only": True,
+        "relative_paths": {
+            "context_prompt": "context/prompt.md",
+            "buggy_source_dir": "buggy-source",
+            "attempt_patch": AGENTISSUE_PATCH_RELATIVE_PATH,
+            "execution_gate": "execution-gate.public.json",
+            "compact_run": "benchmark_run.compact.json",
+        },
+        "source_extraction_gate": {
+            "commands": extraction_commands,
+            "selected_container_only": True,
+            "execute_by_default": False,
+            "docker_invoked": False,
+            "docker_pull_or_start_allowed": False,
+        },
+        "private_git_baseline_gate": {
+            "commands": git_baseline_commands,
+            "execute_by_default": False,
+            "destructive_git": False,
+        },
+        "host_codex_gate": {
+            "command": wrapper["commands"]["codex_patch_worker"],
+            "execute_by_default": False,
+            "codex_cli_invoked": False,
+            "auth_material_synced": False,
+        },
+        "patch_output_gate": patch_export,
+        "eval_gate": wrapper["commands"]["single_tag_eval"],
+        "stop_rules": {
+            **wrapper["stop_rules"],
+            "stop_before_real_source_extraction_without_future_gate": True,
+            "stop_before_host_codex_execution_without_future_gate": True,
+        },
+    }
+
+    benchmark_run = json.loads(json.dumps(staging["benchmark_run"]))
+    benchmark_run.update(
+        {
+            "job_name": "agentissue_lagent_239_codex_cli_runner_execution_gate",
+            "mode": AGENTISSUE_CODEX_CLI_RUNNER_EXECUTION_GATE_MODE,
+            "worker_mode": "trusted_host_codex_cli_no_execute_gate",
+            "first_blocker": "execution_gate_only_no_real_case",
+            "score_failure_attribution": "not_run_execution_gate_only",
+            "failure_attribution_labels": [
+                "execution_gate_fixture_only",
+                "ready_for_future_run_specific_opt_in",
+            ],
+            "evidence_files": [
+                "execution-gate.public.json",
+                "benchmark_run.compact.json",
+                "runner-flow-plan.public.json",
+            ],
+        }
+    )
+    benchmark_run["validation"].update(
+        {
+            "execution_gate_materialized": True,
+            "synthetic_staging_reused": True,
+            "selected_container_source_extraction_commands_rendered": True,
+            "private_git_baseline_commands_rendered": True,
+            "host_codex_command_readiness_rendered": True,
+            "attempt_patch_output_placement_checked": True,
+            "compact_run_filename_checked": True,
+            "future_execution_opt_in_required": True,
+            "no_real_source_extraction": True,
+            "no_real_codex_execution": True,
+            "no_docker_pull_or_start": True,
+            "no_auth_sync_to_shared_host": True,
+            "no_fixed_diff_or_oracle_read": True,
+        }
+    )
+    for trial in benchmark_run.get("trials") or []:
+        if isinstance(trial, dict):
+            trial["exception_type"] = "execution_gate_only_no_real_case"
+
+    gate_path.write_text(
+        json.dumps(gate, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    compact_run_path.write_text(
+        json.dumps(benchmark_run, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return {
+        "schema_version": AGENTISSUE_CODEX_CLI_RUNNER_EXECUTION_GATE_SCHEMA_VERSION,
+        "benchmark_id": AGENTISSUE_BENCHMARK_ID,
+        "selected_tag": tag,
+        "selected_image": image,
+        "ready": True,
+        "materialized": True,
+        "path_recorded": False,
+        "gate_root_path_recorded": False,
+        "synthetic_staging": {
+            "schema_version": staging["schema_version"],
+            "ready": staging["ready"],
+            "created_relative_paths": staging["created_relative_paths"],
+            "path_recorded": False,
+        },
+        "created_relative_paths": [
+            *staging["created_relative_paths"],
+            "execution-gate.public.json",
+        ],
+        "gate_relative_path": "execution-gate.public.json",
+        "compact_run_relative_path": "benchmark_run.compact.json",
+        "attempt_patch_relative_path": AGENTISSUE_PATCH_RELATIVE_PATH,
+        "gate_checks": {
+            "selected_container_source_extraction_commands_rendered": True,
+            "private_git_baseline_commands_rendered": True,
+            "host_codex_command_readiness_rendered": True,
+            "attempt_patch_output_placement_checked": True,
+            "future_execution_opt_in_required": True,
+        },
+        "execution_boundary": {
+            "codex_cli_invoked": False,
+            "model_api_invoked": False,
+            "docker_image_pulled": False,
+            "docker_container_started": False,
+            "source_extracted": False,
+            "git_baseline_created": False,
+            "patch_generated": False,
+            "patch_evaluated": False,
+            "credential_values_recorded": False,
+            "auth_material_synced": False,
+        },
+        "benchmark_run": benchmark_run,
+        "recommended_next_action": (
+            "build a no-execute first-run handoff packet for lagent_239"
+        ),
+    }
+
+
+def materialize_agentissue_codex_cli_runner_first_run_handoff(
+    handoff_root: str | Path,
+    *,
+    selected_tag: str = AGENTISSUE_DEFAULT_TAG,
+    codex_binary: str = "codex",
+    docker_binary: str = "docker",
+) -> dict[str, Any]:
+    """Create a no-execute first-run handoff packet for AgentIssue lagent_239."""
+
+    tag = _agentissue_public_label(selected_tag)
+    if tag != AGENTISSUE_DEFAULT_TAG:
+        raise ValueError(
+            "agentissue Codex runner first-run handoff currently only supports selected tag lagent_239"
+        )
+    root = Path(handoff_root).expanduser()
+    gate = materialize_agentissue_codex_cli_runner_execution_gate(
+        root,
+        selected_tag=tag,
+        codex_binary=codex_binary,
+        docker_binary=docker_binary,
+    )
+    handoff_path = root / "first-run-handoff.public.json"
+    handoff_markdown_path = root / "first-run-handoff.md"
+    compact_run_path = root / "benchmark_run.compact.json"
+
+    no_execute_cli_argv = [
+        "goal-harness",
+        "benchmark",
+        "agentissue-codex-runner-flow",
+        "--goal-id",
+        "<goal-id>",
+        "--tag",
+        tag,
+        "--execution-gate-root",
+        "<private-gate-root>",
+        "--delivery-batch-scale",
+        "multi_surface",
+        "--delivery-outcome",
+        "outcome_progress",
+        "--execute",
+    ]
+    safety_checklist = [
+        {
+            "item": "private_job_root_selected",
+            "required_before_later_e2e": True,
+            "satisfied_by_this_packet": False,
+        },
+        {
+            "item": "codex_auth_stays_on_host",
+            "required_before_later_e2e": True,
+            "satisfied_by_this_packet": True,
+        },
+        {
+            "item": "no_codex_home_sync_to_shared_host",
+            "required_before_later_e2e": True,
+            "satisfied_by_this_packet": True,
+        },
+        {
+            "item": "selected_container_source_extraction_planned",
+            "required_before_later_e2e": True,
+            "satisfied_by_this_packet": False,
+        },
+        {
+            "item": "attempt_patch_compact_reducer_planned",
+            "required_before_later_e2e": True,
+            "satisfied_by_this_packet": True,
+        },
+        {
+            "item": "upload_submit_public_ranking_disabled",
+            "required_before_later_e2e": True,
+            "satisfied_by_this_packet": True,
+        },
+    ]
+    handoff = {
+        "schema_version": AGENTISSUE_CODEX_CLI_RUNNER_FIRST_RUN_HANDOFF_SCHEMA_VERSION,
+        "benchmark_id": AGENTISSUE_BENCHMARK_ID,
+        "selected_tag": tag,
+        "selected_image": AGENTISSUE_DEFAULT_IMAGE,
+        "path_recorded": False,
+        "default_mode": "no_execute",
+        "later_operator_triggered_e2e": True,
+        "real_run_done": False,
+        "exact_command_shape": {
+            "argv": no_execute_cli_argv,
+            "runs_real_benchmark": False,
+            "appends_compact_no_run_event": True,
+        },
+        "private_artifact_boundary": {
+            "root_placeholder": "<private-gate-root>",
+            "root_path_recorded": False,
+            "public_relative_files": [
+                "runner-flow-plan.public.json",
+                "execution-gate.public.json",
+                "first-run-handoff.public.json",
+                "first-run-handoff.md",
+                "benchmark_run.compact.json",
+            ],
+            "private_relative_dirs": [
+                "context/",
+                "buggy-source/",
+                "Patches/lagent_239/",
+            ],
+            "raw_artifacts_public": False,
+            "absolute_paths_public": False,
+        },
+        "expected_compact_outputs": {
+            "benchmark_run_mode": AGENTISSUE_CODEX_CLI_RUNNER_FIRST_RUN_HANDOFF_MODE,
+            "compact_run": "benchmark_run.compact.json",
+            "history_event": "benchmark_run_v0",
+            "official_score_claim_allowed": False,
+            "submit_eligible": False,
+            "leaderboard_evidence": False,
+        },
+        "budget_auth_boundary": {
+            "codex_auth_values_read": False,
+            "codex_home_synced": False,
+            "model_api_invoked": False,
+            "model_budget_spent_by_packet": False,
+            "docker_invoked_by_packet": False,
+            "shared_remote_host_receives_codex_auth": False,
+        },
+        "safety_checklist": safety_checklist,
+        "no_execute_assertions": {
+            "source_extracted": False,
+            "codex_cli_invoked": False,
+            "docker_container_started": False,
+            "patch_generated": False,
+            "patch_evaluated": False,
+            "upload": False,
+            "submit": False,
+            "public_ranking_path": False,
+            "destructive_git": False,
+            "production_action": False,
+        },
+    }
+    handoff_markdown = (
+        "# AgentIssue-Bench lagent_239 First-Run Handoff\n\n"
+        "This packet is no-execute. It names the command shape, private artifact "
+        "boundary, compact outputs, budget/auth boundary, and safety checklist "
+        "for a later operator-triggered e2e run.\n\n"
+        "## Command Shape\n\n"
+        "```text\n"
+        + " ".join(no_execute_cli_argv)
+        + "\n```\n\n"
+        "## Boundary\n\n"
+        "- Codex auth stays on the host and is not copied to a shared machine.\n"
+        "- Public files are limited to `*.public.json`, `*.compact.json`, and this packet.\n"
+        "- No source extraction, Docker start, Codex invocation, patch generation, "
+        "evaluation, upload, submit, public ranking, destructive git, or production "
+        "action is performed by this packet.\n"
+    )
+
+    benchmark_run = json.loads(json.dumps(gate["benchmark_run"]))
+    benchmark_run.update(
+        {
+            "job_name": "agentissue_lagent_239_codex_cli_runner_first_run_handoff",
+            "mode": AGENTISSUE_CODEX_CLI_RUNNER_FIRST_RUN_HANDOFF_MODE,
+            "worker_mode": "trusted_host_codex_cli_no_execute_first_run_handoff",
+            "first_blocker": "first_run_handoff_only_no_real_case",
+            "score_failure_attribution": "not_run_first_run_handoff_only",
+            "failure_attribution_labels": [
+                "first_run_handoff_packet_only",
+                "ready_for_later_operator_triggered_e2e_run",
+            ],
+            "evidence_files": [
+                "first-run-handoff.public.json",
+                "first-run-handoff.md",
+                "execution-gate.public.json",
+                "benchmark_run.compact.json",
+                "runner-flow-plan.public.json",
+            ],
+        }
+    )
+    benchmark_run["validation"].update(
+        {
+            "first_run_handoff_materialized": True,
+            "exact_command_shape_rendered": True,
+            "private_artifact_boundary_declared": True,
+            "expected_compact_outputs_declared": True,
+            "budget_auth_boundary_declared": True,
+            "safety_checklist_declared": True,
+            "no_execute_packet": True,
+            "no_codex_auth_value_read": True,
+            "no_codex_home_sync": True,
+            "no_model_budget_spent_by_packet": True,
+        }
+    )
+    for trial in benchmark_run.get("trials") or []:
+        if isinstance(trial, dict):
+            trial["exception_type"] = "first_run_handoff_only_no_real_case"
+
+    handoff_path.write_text(
+        json.dumps(handoff, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    handoff_markdown_path.write_text(handoff_markdown, encoding="utf-8")
+    compact_run_path.write_text(
+        json.dumps(benchmark_run, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return {
+        "schema_version": AGENTISSUE_CODEX_CLI_RUNNER_FIRST_RUN_HANDOFF_SCHEMA_VERSION,
+        "benchmark_id": AGENTISSUE_BENCHMARK_ID,
+        "selected_tag": tag,
+        "selected_image": AGENTISSUE_DEFAULT_IMAGE,
+        "ready": True,
+        "materialized": True,
+        "path_recorded": False,
+        "handoff_root_path_recorded": False,
+        "execution_gate": {
+            "schema_version": gate["schema_version"],
+            "ready": gate["ready"],
+            "gate_relative_path": gate["gate_relative_path"],
+            "path_recorded": False,
+        },
+        "created_relative_paths": [
+            *gate["created_relative_paths"],
+            "first-run-handoff.public.json",
+            "first-run-handoff.md",
+        ],
+        "handoff_relative_path": "first-run-handoff.public.json",
+        "handoff_markdown_relative_path": "first-run-handoff.md",
+        "compact_run_relative_path": "benchmark_run.compact.json",
+        "handoff_checks": {
+            "exact_command_shape_rendered": True,
+            "private_artifact_boundary_declared": True,
+            "expected_compact_outputs_declared": True,
+            "budget_auth_boundary_declared": True,
+            "safety_checklist_declared": True,
+            "later_operator_triggered_e2e": True,
+        },
+        "execution_boundary": handoff["no_execute_assertions"],
+        "benchmark_run": benchmark_run,
+        "recommended_next_action": (
+            "use the no-execute first-run handoff packet as the checklist for a "
+            "later operator-triggered AgentIssue-Bench lagent_239 e2e run"
+        ),
+    }
 
 def _claim_review_numeric(value: Any) -> float | None:
     if value is None or isinstance(value, bool):

--- a/goal_harness/benchmark.py
+++ b/goal_harness/benchmark.py
@@ -216,6 +216,12 @@ AGENTISSUE_CODEX_CLI_RUNNER_FIRST_RUN_HANDOFF_SCHEMA_VERSION = (
 AGENTISSUE_CODEX_CLI_RUNNER_FIRST_RUN_HANDOFF_MODE = (
     "agentissue_codex_cli_runner_first_run_handoff_packet"
 )
+AGENTISSUE_CODEX_CLI_RUNNER_WORKFLOW_CHECK_SCHEMA_VERSION = (
+    "agentissue_bench_codex_cli_runner_workflow_check_v0"
+)
+AGENTISSUE_CODEX_CLI_RUNNER_WORKFLOW_CHECK_MODE = (
+    "agentissue_codex_cli_runner_workflow_check_packet"
+)
 AGENTISSUE_CODEX_CLI_RUNNER_SOURCE_RUNNER = (
     "goal_harness_agentissue_codex_cli_runner"
 )
@@ -1202,6 +1208,191 @@ def materialize_agentissue_codex_cli_runner_first_run_handoff(
         "recommended_next_action": (
             "use the no-execute first-run handoff packet as the checklist for a "
             "later operator-triggered AgentIssue-Bench lagent_239 e2e run"
+        ),
+    }
+
+
+def materialize_agentissue_codex_cli_runner_workflow_check(
+    workflow_check_root: str | Path,
+    *,
+    selected_tag: str = AGENTISSUE_DEFAULT_TAG,
+    codex_binary: str = "codex",
+    docker_binary: str = "docker",
+) -> dict[str, Any]:
+    """Create a no-execute workflow check packet for AgentIssue lagent_239."""
+
+    tag = _agentissue_public_label(selected_tag)
+    if tag != AGENTISSUE_DEFAULT_TAG:
+        raise ValueError(
+            "agentissue Codex runner workflow check currently only supports selected tag lagent_239"
+        )
+    root = Path(workflow_check_root).expanduser()
+    handoff = materialize_agentissue_codex_cli_runner_first_run_handoff(
+        root,
+        selected_tag=tag,
+        codex_binary=codex_binary,
+        docker_binary=docker_binary,
+    )
+    runner_plan_path = root / "runner-flow-plan.public.json"
+    gate_path = root / "execution-gate.public.json"
+    handoff_path = root / "first-run-handoff.public.json"
+    workflow_path = root / "workflow-check.public.json"
+    compact_run_path = root / "benchmark_run.compact.json"
+
+    runner_plan = json.loads(runner_plan_path.read_text(encoding="utf-8"))
+    gate = json.loads(gate_path.read_text(encoding="utf-8"))
+    handoff_public = json.loads(handoff_path.read_text(encoding="utf-8"))
+
+    codex_command = runner_plan["command_placeholders"]["codex_patch_worker"]
+    eval_command = runner_plan["command_placeholders"]["single_tag_eval"]
+    patch_export = runner_plan["command_placeholders"]["patch_export"]
+    budget_auth = handoff_public["budget_auth_boundary"]
+    no_execute = handoff_public["no_execute_assertions"]
+    required_public_files = [
+        "runner-flow-plan.public.json",
+        "execution-gate.public.json",
+        "first-run-handoff.public.json",
+        "first-run-handoff.md",
+        "workflow-check.public.json",
+        "benchmark_run.compact.json",
+    ]
+    required_private_dirs = [
+        "context/",
+        "buggy-source/",
+        "Patches/lagent_239/",
+    ]
+    checks = {
+        "single_selected_tag": runner_plan["selected_tag"] == gate["selected_tag"] == handoff_public["selected_tag"] == tag,
+        "selected_image_consistent": runner_plan["selected_image"] == gate["selected_image"] == handoff_public["selected_image"],
+        "source_extracted_before_codex": bool(codex_command.get("runs_after_buggy_source_extraction")),
+        "host_codex_uses_ephemeral": "--ephemeral" in codex_command.get("argv", []),
+        "host_codex_auth_not_synced": codex_command.get("auth_material_synced") is False and budget_auth["codex_home_synced"] is False,
+        "worker_no_network_or_docker": codex_command.get("worker_network_allowed") is False and codex_command.get("worker_docker_allowed") is False,
+        "patch_from_buggy_source_git_diff": patch_export["input_source"] == "buggy_source_git_diff",
+        "attempt_patch_relative_path": patch_export["output_relative_path"] == AGENTISSUE_PATCH_RELATIVE_PATH,
+        "single_tag_eval_no_upload_submit": eval_command["upload"] is False and eval_command["submit"] is False,
+        "single_tag_eval_no_public_ranking": eval_command["public_ranking_path"] is False,
+        "no_execute_packet": all(value is False for value in no_execute.values()),
+        "public_files_compact_or_public": all(
+            path.endswith((".public.json", ".compact.json", ".md"))
+            for path in required_public_files
+        ),
+        "private_dirs_not_public_artifacts": all(path.endswith("/") for path in required_private_dirs),
+    }
+    failed_checks = [name for name, passed in checks.items() if not passed]
+    workflow_check = {
+        "schema_version": AGENTISSUE_CODEX_CLI_RUNNER_WORKFLOW_CHECK_SCHEMA_VERSION,
+        "benchmark_id": AGENTISSUE_BENCHMARK_ID,
+        "selected_tag": tag,
+        "selected_image": AGENTISSUE_DEFAULT_IMAGE,
+        "ready": not failed_checks,
+        "materialized": True,
+        "path_recorded": False,
+        "default_mode": "no_execute",
+        "input_packets": {
+            "runner_plan": "runner-flow-plan.public.json",
+            "execution_gate": "execution-gate.public.json",
+            "first_run_handoff": "first-run-handoff.public.json",
+        },
+        "required_public_files": required_public_files,
+        "required_private_dirs": required_private_dirs,
+        "workflow_checks": checks,
+        "failed_checks": failed_checks,
+        "execution_boundary": {
+            "codex_cli_invoked": False,
+            "model_api_invoked": False,
+            "docker_image_pulled": False,
+            "docker_container_started": False,
+            "source_extracted": False,
+            "git_baseline_created": False,
+            "patch_generated": False,
+            "patch_evaluated": False,
+            "credential_values_recorded": False,
+            "auth_material_synced": False,
+            "upload": False,
+            "submit": False,
+            "public_ranking_path": False,
+        },
+        "stop_before_later_e2e_unless": [
+            "private_job_root_selected",
+            "operator_explicitly_triggers_real_run",
+            "runner_artifact_reducer_writes_compact_public_result",
+        ],
+    }
+
+    benchmark_run = json.loads(json.dumps(handoff["benchmark_run"]))
+    benchmark_run.update(
+        {
+            "job_name": "agentissue_lagent_239_codex_cli_runner_workflow_check",
+            "mode": AGENTISSUE_CODEX_CLI_RUNNER_WORKFLOW_CHECK_MODE,
+            "worker_mode": "trusted_host_codex_cli_no_execute_workflow_check",
+            "first_blocker": "workflow_check_only_no_real_case",
+            "score_failure_attribution": "not_run_workflow_check_only",
+            "failure_attribution_labels": [
+                "workflow_check_packet_only",
+                "ready_for_later_operator_triggered_e2e_run"
+                if not failed_checks
+                else "workflow_check_failed_before_real_run",
+            ],
+            "evidence_files": required_public_files,
+        }
+    )
+    benchmark_run["validation"].update(
+        {
+            "workflow_check_materialized": True,
+            "workflow_check_all_passed": not failed_checks,
+            "workflow_check_failed_checks": failed_checks,
+            "single_selected_tag": checks["single_selected_tag"],
+            "selected_image_consistent": checks["selected_image_consistent"],
+            "source_extracted_before_codex": checks["source_extracted_before_codex"],
+            "host_codex_uses_ephemeral": checks["host_codex_uses_ephemeral"],
+            "host_codex_auth_not_synced": checks["host_codex_auth_not_synced"],
+            "worker_no_network_or_docker": checks["worker_no_network_or_docker"],
+            "patch_from_buggy_source_git_diff": checks["patch_from_buggy_source_git_diff"],
+            "single_tag_eval_no_upload_submit": checks["single_tag_eval_no_upload_submit"],
+            "single_tag_eval_no_public_ranking": checks["single_tag_eval_no_public_ranking"],
+        }
+    )
+    for trial in benchmark_run.get("trials") or []:
+        if isinstance(trial, dict):
+            trial["exception_type"] = "workflow_check_only_no_real_case"
+
+    workflow_path.write_text(
+        json.dumps(workflow_check, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    compact_run_path.write_text(
+        json.dumps(benchmark_run, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return {
+        "schema_version": AGENTISSUE_CODEX_CLI_RUNNER_WORKFLOW_CHECK_SCHEMA_VERSION,
+        "benchmark_id": AGENTISSUE_BENCHMARK_ID,
+        "selected_tag": tag,
+        "selected_image": AGENTISSUE_DEFAULT_IMAGE,
+        "ready": not failed_checks,
+        "materialized": True,
+        "path_recorded": False,
+        "workflow_check_root_path_recorded": False,
+        "first_run_handoff": {
+            "schema_version": handoff["schema_version"],
+            "ready": handoff["ready"],
+            "handoff_relative_path": handoff["handoff_relative_path"],
+            "path_recorded": False,
+        },
+        "created_relative_paths": [
+            *handoff["created_relative_paths"],
+            "workflow-check.public.json",
+        ],
+        "workflow_check_relative_path": "workflow-check.public.json",
+        "compact_run_relative_path": "benchmark_run.compact.json",
+        "workflow_checks": checks,
+        "failed_checks": failed_checks,
+        "execution_boundary": workflow_check["execution_boundary"],
+        "benchmark_run": benchmark_run,
+        "recommended_next_action": (
+            "use workflow-check.public.json as the pre-run invariant packet before "
+            "any later operator-triggered AgentIssue-Bench lagent_239 e2e run"
         ),
     }
 

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -19,6 +19,16 @@ from .bootstrap import (
     render_bootstrap_markdown,
 )
 from .benchmark import (
+    AGENTISSUE_BENCHMARK_ID,
+    AGENTISSUE_CODEX_CLI_RUNNER_EXECUTION_GATE_SCHEMA_VERSION,
+    AGENTISSUE_CODEX_CLI_RUNNER_FIRST_RUN_HANDOFF_SCHEMA_VERSION,
+    AGENTISSUE_CODEX_CLI_RUNNER_SYNTHETIC_STAGING_SCHEMA_VERSION,
+    AGENTISSUE_CODEX_CLI_RUNNER_WRAPPER_SCHEMA_VERSION,
+    AGENTISSUE_DEFAULT_TAG,
+    build_agentissue_codex_cli_runner_wrapper,
+    materialize_agentissue_codex_cli_runner_execution_gate,
+    materialize_agentissue_codex_cli_runner_first_run_handoff,
+    materialize_agentissue_codex_cli_runner_synthetic_staging,
     TERMINAL_BENCH_DEFAULT_DATASET,
     TERMINAL_BENCH_DEFAULT_MODEL,
     TERMINAL_BENCH_DEFAULT_TASK,
@@ -1271,6 +1281,84 @@ def main(argv: list[str] | None = None) -> int:
     benchmark_run_parser.add_argument("--execute", action="store_true", help="Append the compact fixture event.")
     benchmark_run_parser.add_argument("--no-global-sync", action="store_true", help="Skip global registry sync after append.")
 
+    agentissue_runner_flow_parser = benchmark_sub.add_parser(
+        "agentissue-codex-runner-flow",
+        help=(
+            "Render or append the AgentIssue-Bench lagent_239 Codex CLI runner "
+            "dry-run wrapper. No Codex, Docker, model API, upload, or submit is run."
+        ),
+    )
+    add_subcommand_format(agentissue_runner_flow_parser)
+    agentissue_runner_flow_parser.add_argument("--goal-id", required=True, help="Goal id for dry-run/append context.")
+    agentissue_runner_flow_parser.add_argument(
+        "--tag",
+        default=AGENTISSUE_DEFAULT_TAG,
+        help="Selected public AgentIssue-Bench tag. Currently only lagent_239 is supported.",
+    )
+    agentissue_runner_flow_parser.add_argument(
+        "--codex-binary",
+        default="codex",
+        help="Public command label for host-local Codex CLI command rendering.",
+    )
+    agentissue_runner_flow_parser.add_argument(
+        "--docker-binary",
+        default="docker",
+        help="Public command label for selected-tag Docker eval command rendering.",
+    )
+    agentissue_runner_flow_parser.add_argument(
+        "--synthetic-staging-root",
+        help=(
+            "Materialize a synthetic private job root at PATH with placeholder "
+            "prompt, patch-output parent, and compact reducer files. Still no "
+            "Codex, Docker, model API, upload, submit, or real task material."
+        ),
+    )
+    agentissue_runner_flow_parser.add_argument(
+        "--execution-gate-root",
+        help=(
+            "Materialize a guarded no-execute real-source/host-Codex gate at "
+            "PATH. It renders selected-container source extraction, private git "
+            "baseline, host Codex, patch export, and eval command shapes without "
+            "running Codex, Docker, model APIs, upload, submit, or real task material."
+        ),
+    )
+    agentissue_runner_flow_parser.add_argument(
+        "--first-run-handoff-root",
+        help=(
+            "Materialize a no-execute first-run handoff packet at PATH. It "
+            "includes the execution gate plus public handoff JSON/Markdown with "
+            "command shape, private artifact boundary, compact outputs, and "
+            "budget/auth safety checks."
+        ),
+    )
+    agentissue_runner_flow_parser.add_argument("--classification")
+    agentissue_runner_flow_parser.add_argument("--recommended-action")
+    agentissue_runner_flow_parser.add_argument(
+        "--delivery-batch-scale",
+        choices=DELIVERY_BATCH_SCALE_CHOICES,
+        help="Optional delivery scale label for the run index.",
+    )
+    agentissue_runner_flow_parser.add_argument(
+        "--delivery-outcome",
+        choices=DELIVERY_OUTCOME_CHOICES,
+        help="Optional delivery outcome label for the run index.",
+    )
+    agentissue_runner_flow_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview append without writing. This is the default.",
+    )
+    agentissue_runner_flow_parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Append the compact no-run wrapper readiness event.",
+    )
+    agentissue_runner_flow_parser.add_argument(
+        "--no-global-sync",
+        action="store_true",
+        help="Skip global registry sync after append.",
+    )
+
     benchmark_artifact_filter_parser = benchmark_sub.add_parser(
         "classify-artifacts",
         help=(
@@ -2198,6 +2286,161 @@ def main(argv: list[str] | None = None) -> int:
         return 0 if payload.get("ok") else 1
 
     if args.command == "benchmark":
+        if args.benchmark_command == "agentissue-codex-runner-flow":
+            classification = (
+                args.classification
+                or (
+                    AGENTISSUE_CODEX_CLI_RUNNER_FIRST_RUN_HANDOFF_SCHEMA_VERSION
+                    if args.first_run_handoff_root
+                    else (
+                        AGENTISSUE_CODEX_CLI_RUNNER_EXECUTION_GATE_SCHEMA_VERSION
+                        if args.execution_gate_root
+                        else (
+                            AGENTISSUE_CODEX_CLI_RUNNER_SYNTHETIC_STAGING_SCHEMA_VERSION
+                            if args.synthetic_staging_root
+                            else AGENTISSUE_CODEX_CLI_RUNNER_WRAPPER_SCHEMA_VERSION
+                        )
+                    )
+                )
+            )
+            try:
+                if args.dry_run and args.execute:
+                    raise ValueError(
+                        "agentissue-codex-runner-flow accepts either --dry-run or --execute, not both"
+                    )
+                selected_roots = [
+                    value
+                    for value in (
+                        args.synthetic_staging_root,
+                        args.execution_gate_root,
+                        args.first_run_handoff_root,
+                    )
+                    if value
+                ]
+                if len(selected_roots) > 1:
+                    raise ValueError(
+                        "agentissue-codex-runner-flow accepts at most one root option, not both: --synthetic-staging-root, --execution-gate-root, or --first-run-handoff-root"
+                    )
+                wrapper = build_agentissue_codex_cli_runner_wrapper(
+                    selected_tag=args.tag,
+                    codex_binary=args.codex_binary,
+                    docker_binary=args.docker_binary,
+                )
+                synthetic_staging = None
+                execution_gate = None
+                first_run_handoff = None
+                benchmark_run_source = wrapper["benchmark_run"]
+                if args.first_run_handoff_root:
+                    first_run_handoff = (
+                        materialize_agentissue_codex_cli_runner_first_run_handoff(
+                            args.first_run_handoff_root,
+                            selected_tag=args.tag,
+                            codex_binary=args.codex_binary,
+                            docker_binary=args.docker_binary,
+                        )
+                    )
+                    benchmark_run_source = first_run_handoff["benchmark_run"]
+                elif args.execution_gate_root:
+                    execution_gate = materialize_agentissue_codex_cli_runner_execution_gate(
+                        args.execution_gate_root,
+                        selected_tag=args.tag,
+                        codex_binary=args.codex_binary,
+                        docker_binary=args.docker_binary,
+                    )
+                    benchmark_run_source = execution_gate["benchmark_run"]
+                elif args.synthetic_staging_root:
+                    synthetic_staging = (
+                        materialize_agentissue_codex_cli_runner_synthetic_staging(
+                            args.synthetic_staging_root,
+                            selected_tag=args.tag,
+                            codex_binary=args.codex_binary,
+                            docker_binary=args.docker_binary,
+                        )
+                    )
+                    benchmark_run_source = synthetic_staging["benchmark_run"]
+                benchmark_run = compact_benchmark_run(benchmark_run_source)
+                if not benchmark_run:
+                    raise ValueError(
+                        "agentissue Codex runner wrapper did not produce a compactable benchmark_run_v0"
+                    )
+                dry_run = not bool(args.execute)
+                payload = append_benchmark_run(
+                    registry_path=registry_path,
+                    runtime_root_override=args.runtime_root,
+                    goal_id=args.goal_id,
+                    benchmark_run=benchmark_run,
+                    classification=classification,
+                    recommended_action=args.recommended_action
+                    or (
+                        first_run_handoff["recommended_next_action"]
+                        if first_run_handoff
+                        else (
+                            execution_gate["recommended_next_action"]
+                            if execution_gate
+                            else (
+                                synthetic_staging["recommended_next_action"]
+                                if synthetic_staging
+                                else wrapper["recommended_next_action"]
+                            )
+                        )
+                    ),
+                    delivery_batch_scale=args.delivery_batch_scale,
+                    delivery_outcome=args.delivery_outcome,
+                    dry_run=dry_run,
+                )
+                payload["benchmark_cli"] = {
+                    "benchmark": AGENTISSUE_BENCHMARK_ID,
+                    "command": "agentissue-codex-runner-flow",
+                    "tag": args.tag,
+                    "dry_run_default": True,
+                    "real_runner_invoked": False,
+                    "real_codex_invoked": False,
+                    "real_docker_invoked": False,
+                    "model_api_invoked": False,
+                    "auth_values_read": False,
+                    "submit_eligible": False,
+                    "leaderboard_evidence": False,
+                    "synthetic_staging_materialized": bool(synthetic_staging),
+                    "synthetic_staging_root_path_recorded": False,
+                    "execution_gate_materialized": bool(execution_gate),
+                    "execution_gate_root_path_recorded": False,
+                    "first_run_handoff_materialized": bool(first_run_handoff),
+                    "first_run_handoff_root_path_recorded": False,
+                }
+                payload["agentissue_runner_flow"] = wrapper
+                if synthetic_staging:
+                    payload["agentissue_synthetic_staging"] = synthetic_staging
+                if execution_gate:
+                    payload["agentissue_execution_gate"] = execution_gate
+                if first_run_handoff:
+                    payload["agentissue_first_run_handoff"] = first_run_handoff
+                if args.no_global_sync:
+                    payload["global_sync"] = {
+                        "ok": True,
+                        "dry_run": dry_run,
+                        "skipped": True,
+                        "reason": "disabled by --no-global-sync",
+                    }
+                else:
+                    payload["global_sync"] = sync_project_registry_to_global(
+                        registry_path=registry_path,
+                        runtime_root_override=args.runtime_root,
+                        goal_id=args.goal_id,
+                        dry_run=dry_run,
+                    )
+            except Exception as exc:
+                payload = {
+                    "ok": False,
+                    "dry_run": not bool(getattr(args, "execute", False)),
+                    "appended": False,
+                    "registry": str(registry_path),
+                    "runtime_root": args.runtime_root,
+                    "goal_id": args.goal_id,
+                    "classification": classification,
+                    "error": str(exc),
+                }
+            print_payload(payload, args.format, render_benchmark_run_append_markdown)
+            return 0 if payload.get("ok") else 1
         if args.benchmark_command == "classify-artifacts":
             payload = filter_public_benchmark_artifact_paths(args.artifact_paths)
             print_payload(

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -23,12 +23,14 @@ from .benchmark import (
     AGENTISSUE_CODEX_CLI_RUNNER_EXECUTION_GATE_SCHEMA_VERSION,
     AGENTISSUE_CODEX_CLI_RUNNER_FIRST_RUN_HANDOFF_SCHEMA_VERSION,
     AGENTISSUE_CODEX_CLI_RUNNER_SYNTHETIC_STAGING_SCHEMA_VERSION,
+    AGENTISSUE_CODEX_CLI_RUNNER_WORKFLOW_CHECK_SCHEMA_VERSION,
     AGENTISSUE_CODEX_CLI_RUNNER_WRAPPER_SCHEMA_VERSION,
     AGENTISSUE_DEFAULT_TAG,
     build_agentissue_codex_cli_runner_wrapper,
     materialize_agentissue_codex_cli_runner_execution_gate,
     materialize_agentissue_codex_cli_runner_first_run_handoff,
     materialize_agentissue_codex_cli_runner_synthetic_staging,
+    materialize_agentissue_codex_cli_runner_workflow_check,
     TERMINAL_BENCH_DEFAULT_DATASET,
     TERMINAL_BENCH_DEFAULT_MODEL,
     TERMINAL_BENCH_DEFAULT_TASK,
@@ -1331,6 +1333,15 @@ def main(argv: list[str] | None = None) -> int:
             "budget/auth safety checks."
         ),
     )
+    agentissue_runner_flow_parser.add_argument(
+        "--workflow-check-root",
+        help=(
+            "Materialize a no-execute workflow invariant check packet at PATH. "
+            "It includes the first-run handoff plus workflow-check.public.json "
+            "for phase, auth, artifact, and stop-rule checks without running "
+            "Codex, Docker, model APIs, upload, submit, or real task material."
+        ),
+    )
     agentissue_runner_flow_parser.add_argument("--classification")
     agentissue_runner_flow_parser.add_argument("--recommended-action")
     agentissue_runner_flow_parser.add_argument(
@@ -2290,15 +2301,19 @@ def main(argv: list[str] | None = None) -> int:
             classification = (
                 args.classification
                 or (
-                    AGENTISSUE_CODEX_CLI_RUNNER_FIRST_RUN_HANDOFF_SCHEMA_VERSION
-                    if args.first_run_handoff_root
+                    AGENTISSUE_CODEX_CLI_RUNNER_WORKFLOW_CHECK_SCHEMA_VERSION
+                    if args.workflow_check_root
                     else (
-                        AGENTISSUE_CODEX_CLI_RUNNER_EXECUTION_GATE_SCHEMA_VERSION
-                        if args.execution_gate_root
+                        AGENTISSUE_CODEX_CLI_RUNNER_FIRST_RUN_HANDOFF_SCHEMA_VERSION
+                        if args.first_run_handoff_root
                         else (
-                            AGENTISSUE_CODEX_CLI_RUNNER_SYNTHETIC_STAGING_SCHEMA_VERSION
-                            if args.synthetic_staging_root
-                            else AGENTISSUE_CODEX_CLI_RUNNER_WRAPPER_SCHEMA_VERSION
+                            AGENTISSUE_CODEX_CLI_RUNNER_EXECUTION_GATE_SCHEMA_VERSION
+                            if args.execution_gate_root
+                            else (
+                                AGENTISSUE_CODEX_CLI_RUNNER_SYNTHETIC_STAGING_SCHEMA_VERSION
+                                if args.synthetic_staging_root
+                                else AGENTISSUE_CODEX_CLI_RUNNER_WRAPPER_SCHEMA_VERSION
+                            )
                         )
                     )
                 )
@@ -2314,12 +2329,13 @@ def main(argv: list[str] | None = None) -> int:
                         args.synthetic_staging_root,
                         args.execution_gate_root,
                         args.first_run_handoff_root,
+                        args.workflow_check_root,
                     )
                     if value
                 ]
                 if len(selected_roots) > 1:
                     raise ValueError(
-                        "agentissue-codex-runner-flow accepts at most one root option, not both: --synthetic-staging-root, --execution-gate-root, or --first-run-handoff-root"
+                        "agentissue-codex-runner-flow accepts at most one root option, not both: --synthetic-staging-root, --execution-gate-root, --first-run-handoff-root, or --workflow-check-root"
                     )
                 wrapper = build_agentissue_codex_cli_runner_wrapper(
                     selected_tag=args.tag,
@@ -2329,8 +2345,17 @@ def main(argv: list[str] | None = None) -> int:
                 synthetic_staging = None
                 execution_gate = None
                 first_run_handoff = None
+                workflow_check = None
                 benchmark_run_source = wrapper["benchmark_run"]
-                if args.first_run_handoff_root:
+                if args.workflow_check_root:
+                    workflow_check = materialize_agentissue_codex_cli_runner_workflow_check(
+                        args.workflow_check_root,
+                        selected_tag=args.tag,
+                        codex_binary=args.codex_binary,
+                        docker_binary=args.docker_binary,
+                    )
+                    benchmark_run_source = workflow_check["benchmark_run"]
+                elif args.first_run_handoff_root:
                     first_run_handoff = (
                         materialize_agentissue_codex_cli_runner_first_run_handoff(
                             args.first_run_handoff_root,
@@ -2372,15 +2397,19 @@ def main(argv: list[str] | None = None) -> int:
                     classification=classification,
                     recommended_action=args.recommended_action
                     or (
-                        first_run_handoff["recommended_next_action"]
-                        if first_run_handoff
+                        workflow_check["recommended_next_action"]
+                        if workflow_check
                         else (
-                            execution_gate["recommended_next_action"]
-                            if execution_gate
+                            first_run_handoff["recommended_next_action"]
+                            if first_run_handoff
                             else (
-                                synthetic_staging["recommended_next_action"]
-                                if synthetic_staging
-                                else wrapper["recommended_next_action"]
+                                execution_gate["recommended_next_action"]
+                                if execution_gate
+                                else (
+                                    synthetic_staging["recommended_next_action"]
+                                    if synthetic_staging
+                                    else wrapper["recommended_next_action"]
+                                )
                             )
                         )
                     ),
@@ -2406,6 +2435,8 @@ def main(argv: list[str] | None = None) -> int:
                     "execution_gate_root_path_recorded": False,
                     "first_run_handoff_materialized": bool(first_run_handoff),
                     "first_run_handoff_root_path_recorded": False,
+                    "workflow_check_materialized": bool(workflow_check),
+                    "workflow_check_root_path_recorded": False,
                 }
                 payload["agentissue_runner_flow"] = wrapper
                 if synthetic_staging:
@@ -2414,6 +2445,8 @@ def main(argv: list[str] | None = None) -> int:
                     payload["agentissue_execution_gate"] = execution_gate
                 if first_run_handoff:
                     payload["agentissue_first_run_handoff"] = first_run_handoff
+                if workflow_check:
+                    payload["agentissue_workflow_check"] = workflow_check
                 if args.no_global_sync:
                     payload["global_sync"] = {
                         "ok": True,

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -1369,6 +1369,24 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
         if values:
             compact[field] = values
 
+    read_boundary = source.get("read_boundary")
+    if isinstance(read_boundary, dict):
+        compact_boundary: dict[str, bool] = {}
+        for field in (
+            "compact_only",
+            "raw_artifacts_read",
+            "task_text_read",
+            "trajectory_read",
+            "local_paths_recorded",
+            "docker_invoked",
+            "model_api_invoked",
+            "upload_invoked",
+        ):
+            if isinstance(read_boundary.get(field), bool):
+                compact_boundary[field] = read_boundary[field]
+        if compact_boundary:
+            compact["read_boundary"] = compact_boundary
+
     if set(compact.keys()) == {"schema_version"}:
         return None
     return compact


### PR DESCRIPTION
## Summary
- add a single-benchmark AgentIssue-Bench `lagent_239` Codex CLI runner-flow entry point
- add dry-run wrapper, synthetic staging, no-execute execution gate, and first-run handoff packets
- preserve compact `read_boundary` evidence so no-run events keep public-safe boundary proof

## Boundary
- no real Codex CLI benchmark worker was run
- no Docker image/container execution, model API call, upload, submit, or public ranking path was run
- no raw issue body, raw patch, raw logs, credentials, local runtime state, or private job-root paths are published
- PR is scoped to AgentIssue-Bench only; unrelated benchmark lanes were excluded

## Validation
- `python3 -m py_compile goal_harness/benchmark.py goal_harness/cli.py goal_harness/status.py`
- `python3 examples/agentissue-bench-codex-cli-runner-*-smoke.py`
- cached path whitelist and unrelated benchmark keyword scan clean
- `PYTHONPATH=$WT python3 -m goal_harness.cli check ...` over 20 publication files: errors=0 warnings=0 checks=6, public boundary scan clean
