### PR TITLE
Add AgentIssue run gate packet

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/README.md
+++ b/docs/research/long-horizon-agent-benchmarks/README.md
@@ -227,15 +227,23 @@ work still belongs in the existing code, examples, and contract documents:
   host-Codex auth isolation, no worker network/Docker access, patch-source
   provenance, selected-tag eval boundaries, and compact/public artifact
   allowlists before any later operator-triggered e2e run.
+- `agentissue-bench-codex-cli-runner-run-gate-v0.md`: no-execute
+  `--run-gate-root` packet for `lagent_239`. It materializes the workflow
+  check plus `run-specific-gate.public.json` and `run-specific-gate.md`,
+  separating gates already covered by public no-run packets from the remaining
+  real-run blockers: private job root selection, explicit real-run trigger,
+  selected-container source extraction, private git baseline, and host-local
+  Codex execution from the extracted buggy source.
 - `agentissue-bench-codex-cli-runner-pr-ready-packet-v0.md`: public-safe
   consolidation packet for the full `lagent_239` runner-flow chain. It ties
   together the contract, flow plan, dry-run wrapper, synthetic staging,
-  execution gate, first-run handoff, workflow check, and eight matching smokes
-  into one reviewable route while preserving no-run/no-upload/no-submit/
+  execution gate, first-run handoff, workflow check, run-specific gate, and
+  nine matching smokes into one reviewable route while preserving no-run/
+  no-upload/no-submit/
   no-public-ranking boundaries.
 - `agentissue-bench-codex-cli-runner-publication-change-set-v0.md`: staging
   and review packet for publishing only the AgentIssue runner-flow change set.
-  It lists the nine docs and nine smokes that should move together, marks
+  It lists the ten docs and ten smokes that should move together, marks
   `goal_harness/benchmark.py`, `goal_harness/cli.py`, and this README as mixed
   tracked files that need hunk-level staging, and excludes unrelated benchmark
   lanes, runtime state, credentials, raw artifacts, uploads, submits, and

--- a/docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-pr-ready-packet-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-pr-ready-packet-v0.md
@@ -32,6 +32,7 @@ docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-sy
 docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-execution-gate-v0.md
 docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-first-run-handoff-v0.md
 docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-workflow-check-v0.md
+docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-run-gate-v0.md
 docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-pr-ready-packet-v0.md
 ```
 
@@ -45,6 +46,7 @@ examples/agentissue-bench-codex-cli-runner-synthetic-staging-smoke.py
 examples/agentissue-bench-codex-cli-runner-execution-gate-smoke.py
 examples/agentissue-bench-codex-cli-runner-first-run-handoff-smoke.py
 examples/agentissue-bench-codex-cli-runner-workflow-check-smoke.py
+examples/agentissue-bench-codex-cli-runner-run-gate-smoke.py
 examples/agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py
 ```
 
@@ -53,7 +55,7 @@ examples/agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py
 The route narrows from high-level contract to no-execute handoff:
 
 ```text
-contract -> flow plan -> dry-run wrapper -> synthetic staging -> execution gate -> first-run handoff -> workflow check -> PR-ready packet
+contract -> flow plan -> dry-run wrapper -> synthetic staging -> execution gate -> first-run handoff -> workflow check -> run-specific gate -> PR-ready packet
 ```
 
 The CLI surfaces are:
@@ -64,6 +66,7 @@ goal-harness benchmark agentissue-codex-runner-flow --tag lagent_239 --synthetic
 goal-harness benchmark agentissue-codex-runner-flow --tag lagent_239 --execution-gate-root <private-root>
 goal-harness benchmark agentissue-codex-runner-flow --tag lagent_239 --first-run-handoff-root <private-root>
 goal-harness benchmark agentissue-codex-runner-flow --tag lagent_239 --workflow-check-root <private-root>
+goal-harness benchmark agentissue-codex-runner-flow --tag lagent_239 --run-gate-root <private-root>
 ```
 
 All root options are mutually exclusive. They materialize public-safe packet

--- a/docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-publication-change-set-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-publication-change-set-v0.md
@@ -33,6 +33,7 @@ docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-sy
 docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-execution-gate-v0.md
 docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-first-run-handoff-v0.md
 docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-workflow-check-v0.md
+docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-run-gate-v0.md
 docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-pr-ready-packet-v0.md
 docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-publication-change-set-v0.md
 ```
@@ -47,6 +48,7 @@ examples/agentissue-bench-codex-cli-runner-synthetic-staging-smoke.py
 examples/agentissue-bench-codex-cli-runner-execution-gate-smoke.py
 examples/agentissue-bench-codex-cli-runner-first-run-handoff-smoke.py
 examples/agentissue-bench-codex-cli-runner-workflow-check-smoke.py
+examples/agentissue-bench-codex-cli-runner-run-gate-smoke.py
 examples/agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py
 examples/agentissue-bench-codex-cli-runner-publication-change-set-smoke.py
 ```
@@ -80,20 +82,23 @@ AGENTISSUE_CODEX_CLI_RUNNER_SYNTHETIC_STAGING_SCHEMA_VERSION
 AGENTISSUE_CODEX_CLI_RUNNER_EXECUTION_GATE_SCHEMA_VERSION
 AGENTISSUE_CODEX_CLI_RUNNER_FIRST_RUN_HANDOFF_SCHEMA_VERSION
 AGENTISSUE_CODEX_CLI_RUNNER_WORKFLOW_CHECK_SCHEMA_VERSION
+AGENTISSUE_CODEX_CLI_RUNNER_RUN_GATE_SCHEMA_VERSION
 build_agentissue_codex_cli_runner_wrapper
 materialize_agentissue_codex_cli_runner_synthetic_staging
 materialize_agentissue_codex_cli_runner_execution_gate
 materialize_agentissue_codex_cli_runner_first_run_handoff
 materialize_agentissue_codex_cli_runner_workflow_check
+materialize_agentissue_codex_cli_runner_run_gate
 agentissue-codex-runner-flow
 --synthetic-staging-root
 --execution-gate-root
 --first-run-handoff-root
 --workflow-check-root
+--run-gate-root
 read_boundary
 ```
 
-The README hunks that belong to this change set are the nine
+The README hunks that belong to this change set are the ten
 `agentissue-bench-codex-cli-runner-*` bullets. Earlier
 `agentissue-bench-lagent239-*` research packets are useful historical evidence,
 but they are not part of this runner-flow publication change set.
@@ -135,6 +140,7 @@ python3 examples/agentissue-bench-codex-cli-runner-synthetic-staging-smoke.py &&
 python3 examples/agentissue-bench-codex-cli-runner-execution-gate-smoke.py &&
 python3 examples/agentissue-bench-codex-cli-runner-first-run-handoff-smoke.py &&
 python3 examples/agentissue-bench-codex-cli-runner-workflow-check-smoke.py &&
+python3 examples/agentissue-bench-codex-cli-runner-run-gate-smoke.py &&
 python3 examples/agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py &&
 python3 examples/agentissue-bench-codex-cli-runner-publication-change-set-smoke.py
 ```
@@ -153,6 +159,7 @@ python3 -m py_compile \
   examples/agentissue-bench-codex-cli-runner-execution-gate-smoke.py \
   examples/agentissue-bench-codex-cli-runner-first-run-handoff-smoke.py \
   examples/agentissue-bench-codex-cli-runner-workflow-check-smoke.py \
+  examples/agentissue-bench-codex-cli-runner-run-gate-smoke.py \
   examples/agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py \
   examples/agentissue-bench-codex-cli-runner-publication-change-set-smoke.py
 
@@ -168,6 +175,7 @@ goal-harness check \
   --scan-path docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-execution-gate-v0.md \
   --scan-path docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-first-run-handoff-v0.md \
   --scan-path docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-workflow-check-v0.md \
+  --scan-path docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-run-gate-v0.md \
   --scan-path docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-pr-ready-packet-v0.md \
   --scan-path docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-publication-change-set-v0.md
 ```

--- a/docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-run-gate-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-run-gate-v0.md
@@ -1,0 +1,50 @@
+# AgentIssue-Bench Codex CLI Runner Run Gate V0
+
+This packet adds one no-execute run-specific gate for the selected
+AgentIssue-Bench tag `lagent_239`:
+
+```bash
+goal-harness benchmark agentissue-codex-runner-flow \
+  --goal-id <goal-id> \
+  --tag lagent_239 \
+  --run-gate-root <private-gate-root>
+```
+
+The command materializes the workflow check plus
+`run-specific-gate.public.json` and `run-specific-gate.md`. It is a gate packet,
+not a benchmark run.
+
+## Gate Separation
+
+`run-specific-gate.public.json` separates gates into two groups:
+
+- already covered by no-run public packets: selected tag/image lock, host Codex
+  auth isolation, patch-output relative path, no-upload/no-submit/no-ranking
+  eval, compact/public artifact policy, and raw-artifact/auth leak stop rules;
+- still blocking a real run: private job root selection, explicit real-run
+  trigger, selected-container source extraction, private git baseline creation,
+  and host-local `codex exec --ephemeral` from the extracted buggy source.
+
+The packet records `real_run_authorized=false` and `ready_for_real_run=false`.
+It is only `ready_for_operator_review=true`.
+
+## Public Boundary
+
+The packet is still no-run. It does not pull or start Docker, invoke Codex,
+call a model API, extract source, initialize git, generate or evaluate a patch,
+read credentials, sync auth material, upload, submit, touch public ranking
+paths, publish raw issue/task/patch/log/trajectory material, use destructive
+git, or take production action.
+
+Allowed public artifacts are limited to relative-path public/compact JSON and
+Markdown gate packets.
+
+## Validation
+
+```bash
+python3 examples/agentissue-bench-codex-cli-runner-run-gate-smoke.py
+python3 -m py_compile examples/agentissue-bench-codex-cli-runner-run-gate-smoke.py
+goal-harness check \
+  --scan-path examples/agentissue-bench-codex-cli-runner-run-gate-smoke.py \
+  --scan-path docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-run-gate-v0.md
+```

--- a/examples/agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py
+++ b/examples/agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py
@@ -21,6 +21,7 @@ DOCS = [
     "agentissue-bench-codex-cli-runner-execution-gate-v0.md",
     "agentissue-bench-codex-cli-runner-first-run-handoff-v0.md",
     "agentissue-bench-codex-cli-runner-workflow-check-v0.md",
+    "agentissue-bench-codex-cli-runner-run-gate-v0.md",
     "agentissue-bench-codex-cli-runner-pr-ready-packet-v0.md",
 ]
 
@@ -32,16 +33,18 @@ SMOKES = [
     "agentissue-bench-codex-cli-runner-execution-gate-smoke.py",
     "agentissue-bench-codex-cli-runner-first-run-handoff-smoke.py",
     "agentissue-bench-codex-cli-runner-workflow-check-smoke.py",
+    "agentissue-bench-codex-cli-runner-run-gate-smoke.py",
     "agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py",
 ]
 
 REQUIRED_PACKET_SNIPPETS = [
     "AgentIssue-Bench Codex CLI Runner PR-Ready Packet V0",
-    "contract -> flow plan -> dry-run wrapper -> synthetic staging -> execution gate -> first-run handoff -> workflow check -> PR-ready packet",
+    "contract -> flow plan -> dry-run wrapper -> synthetic staging -> execution gate -> first-run handoff -> workflow check -> run-specific gate -> PR-ready packet",
     "--synthetic-staging-root",
     "--execution-gate-root",
     "--first-run-handoff-root",
     "--workflow-check-root",
+    "--run-gate-root",
     "real_run=false",
     "submit_eligible=false",
     "leaderboard_evidence=false",
@@ -53,12 +56,15 @@ REQUIRED_SOURCE_SNIPPETS = [
     "AGENTISSUE_CODEX_CLI_RUNNER_EXECUTION_GATE_SCHEMA_VERSION",
     "AGENTISSUE_CODEX_CLI_RUNNER_FIRST_RUN_HANDOFF_SCHEMA_VERSION",
     "AGENTISSUE_CODEX_CLI_RUNNER_WORKFLOW_CHECK_SCHEMA_VERSION",
+    "AGENTISSUE_CODEX_CLI_RUNNER_RUN_GATE_SCHEMA_VERSION",
     "materialize_agentissue_codex_cli_runner_synthetic_staging",
     "materialize_agentissue_codex_cli_runner_execution_gate",
     "materialize_agentissue_codex_cli_runner_first_run_handoff",
     "materialize_agentissue_codex_cli_runner_workflow_check",
+    "materialize_agentissue_codex_cli_runner_run_gate",
     "--first-run-handoff-root",
     "--workflow-check-root",
+    "--run-gate-root",
 ]
 
 FORBIDDEN_TEXT = [
@@ -127,7 +133,7 @@ def main() -> None:
     assert_public_boundary()
     print(
         "agentissue-bench-codex-cli-runner-pr-ready-packet-smoke ok "
-        "docs=8 smokes=8 real_run=False"
+        "docs=9 smokes=9 real_run=False"
     )
 
 

--- a/examples/agentissue-bench-codex-cli-runner-publication-change-set-smoke.py
+++ b/examples/agentissue-bench-codex-cli-runner-publication-change-set-smoke.py
@@ -22,6 +22,7 @@ DOCS = [
     "agentissue-bench-codex-cli-runner-execution-gate-v0.md",
     "agentissue-bench-codex-cli-runner-first-run-handoff-v0.md",
     "agentissue-bench-codex-cli-runner-workflow-check-v0.md",
+    "agentissue-bench-codex-cli-runner-run-gate-v0.md",
     "agentissue-bench-codex-cli-runner-pr-ready-packet-v0.md",
     "agentissue-bench-codex-cli-runner-publication-change-set-v0.md",
 ]
@@ -34,6 +35,7 @@ SMOKES = [
     "agentissue-bench-codex-cli-runner-execution-gate-smoke.py",
     "agentissue-bench-codex-cli-runner-first-run-handoff-smoke.py",
     "agentissue-bench-codex-cli-runner-workflow-check-smoke.py",
+    "agentissue-bench-codex-cli-runner-run-gate-smoke.py",
     "agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py",
     "agentissue-bench-codex-cli-runner-publication-change-set-smoke.py",
 ]
@@ -52,16 +54,19 @@ REQUIRED_SOURCE_SNIPPETS = [
     "AGENTISSUE_CODEX_CLI_RUNNER_EXECUTION_GATE_SCHEMA_VERSION",
     "AGENTISSUE_CODEX_CLI_RUNNER_FIRST_RUN_HANDOFF_SCHEMA_VERSION",
     "AGENTISSUE_CODEX_CLI_RUNNER_WORKFLOW_CHECK_SCHEMA_VERSION",
+    "AGENTISSUE_CODEX_CLI_RUNNER_RUN_GATE_SCHEMA_VERSION",
     "build_agentissue_codex_cli_runner_wrapper",
     "materialize_agentissue_codex_cli_runner_synthetic_staging",
     "materialize_agentissue_codex_cli_runner_execution_gate",
     "materialize_agentissue_codex_cli_runner_first_run_handoff",
     "materialize_agentissue_codex_cli_runner_workflow_check",
+    "materialize_agentissue_codex_cli_runner_run_gate",
     "agentissue-codex-runner-flow",
     "--synthetic-staging-root",
     "--execution-gate-root",
     "--first-run-handoff-root",
     "--workflow-check-root",
+    "--run-gate-root",
     "read_boundary",
 ]
 
@@ -137,8 +142,11 @@ def assert_mixed_files_are_detected() -> None:
         missing_paths = [name for name in MIXED_TRACKED_FILES if not (REPO_ROOT / name).exists()]
         assert not missing_paths, missing_paths
         return
-    missing = [name for name in MIXED_TRACKED_FILES if name not in changed]
-    assert not missing, missing
+    unexpected = [name for name in changed if name not in MIXED_TRACKED_FILES]
+    assert not unexpected, unexpected
+    assert "goal_harness/benchmark.py" in changed, changed
+    assert "goal_harness/cli.py" in changed, changed
+    assert "docs/research/long-horizon-agent-benchmarks/README.md" in changed, changed
 
 
 def assert_public_boundary() -> None:
@@ -159,7 +167,7 @@ def main() -> None:
     assert_public_boundary()
     print(
         "agentissue-bench-codex-cli-runner-publication-change-set-smoke ok "
-        "docs=9 smokes=9 mixed_files=4 real_run=False"
+        "docs=10 smokes=10 mixed_files_subset_documented real_run=False"
     )
 
 

--- a/examples/agentissue-bench-codex-cli-runner-run-gate-smoke.py
+++ b/examples/agentissue-bench-codex-cli-runner-run-gate-smoke.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Smoke-test AgentIssue-Bench Codex CLI runner run-specific gate packet."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from goal_harness.status import collect_status  # noqa: E402
+
+
+TOPIC_DIR = REPO_ROOT / "docs" / "research" / "long-horizon-agent-benchmarks"
+DOC = TOPIC_DIR / "agentissue-bench-codex-cli-runner-run-gate-v0.md"
+README = TOPIC_DIR / "README.md"
+
+GOAL_ID = "agentissue-runner-run-gate-fixture"
+BENCHMARK_ID = "agentissue-bench"
+SELECTED_TAG = "lagent_239"
+RUN_MODE = "agentissue_codex_cli_runner_run_gate_packet"
+CLASSIFICATION = "agentissue_bench_codex_cli_runner_run_gate_v0"
+
+REQUIRED_DOC_SNIPPETS = [
+    "AgentIssue-Bench Codex CLI Runner Run Gate V0",
+    "--run-gate-root",
+    "run-specific-gate.public.json",
+    "real_run_authorized=false",
+    "ready_for_real_run=false",
+    "python3 examples/agentissue-bench-codex-cli-runner-run-gate-smoke.py",
+]
+
+FORBIDDEN_TEXT = [
+    "/" + "Users/",
+    "~/.codex",
+    ".codex/auth.json",
+    "OPENAI" + "_API_KEY",
+    "ANTHROPIC" + "_API_KEY",
+    "GOOGLE" + "_API_KEY",
+    "CODEX" + "_ACCESS_TOKEN",
+    "raw" + "_issue_body:",
+    "raw" + "_patch:",
+    "raw" + "_log:",
+    "trajectory.json",
+    "screenshot.png",
+]
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_fixture(root: Path) -> tuple[Path, Path, Path]:
+    project = root / "project"
+    runtime = root / "runtime"
+    run_gate_root = root / "private-run-gate-root"
+    state_file = f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    registry_path = project / ".goal-harness" / "registry.json"
+
+    (project / Path(state_file).parent).mkdir(parents=True, exist_ok=True)
+    (project / state_file).write_text(
+        "---\n"
+        "status: active-read-only\n"
+        "updated_at: 2026-06-13T00:00:00+00:00\n"
+        "---\n\n"
+        "# AgentIssue Runner Run Gate Fixture\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] Build AgentIssue no-execute run-specific gate packet.\n",
+        encoding="utf-8",
+    )
+    write_json(
+        registry_path,
+        {
+            "schema_version": 1,
+            "updated_at": "2026-06-13T00:00:00+00:00",
+            "common_runtime_root": str(runtime),
+            "goals": [
+                {
+                    "id": GOAL_ID,
+                    "domain": "goal-harness-platform",
+                    "status": "active-read-only",
+                    "state_file": state_file,
+                    "repo": str(project),
+                    "adapter": {
+                        "kind": "harness_self_improvement",
+                        "status": "connected-read-only",
+                    },
+                    "heartbeat": {"enabled": True},
+                }
+            ],
+        },
+    )
+    return registry_path, runtime, run_gate_root
+
+
+def run_cli(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "goal_harness.cli", *args],
+        cwd=REPO_ROOT,
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def run_cli_json(args: list[str]) -> dict[str, Any]:
+    result = run_cli(args)
+    payload = json.loads(result.stdout)
+    assert isinstance(payload, dict), payload
+    return payload
+
+
+def common_args(registry_path: Path, runtime: Path, run_gate_root: Path) -> list[str]:
+    return [
+        "--registry",
+        str(registry_path),
+        "--runtime-root",
+        str(runtime),
+        "--format",
+        "json",
+        "benchmark",
+        "agentissue-codex-runner-flow",
+        "--goal-id",
+        GOAL_ID,
+        "--tag",
+        SELECTED_TAG,
+        "--run-gate-root",
+        str(run_gate_root),
+        "--no-global-sync",
+    ]
+
+
+def assert_no_forbidden_text(payload: dict[str, Any]) -> None:
+    text = json.dumps(payload, sort_keys=True)
+    leaked = [marker for marker in FORBIDDEN_TEXT if marker in text]
+    assert not leaked, leaked
+    assert len(text) < 90000, len(text)
+
+
+def assert_doc_contract() -> None:
+    text = DOC.read_text(encoding="utf-8")
+    readme = README.read_text(encoding="utf-8")
+    missing = [snippet for snippet in REQUIRED_DOC_SNIPPETS if snippet not in text]
+    assert not missing, missing
+    assert "agentissue-bench-codex-cli-runner-run-gate-v0.md" in readme, readme
+    leaked = [marker for marker in FORBIDDEN_TEXT if marker in text]
+    assert not leaked, leaked
+
+
+def assert_run_gate_files(run_gate_root: Path) -> None:
+    expected_paths = [
+        "context/prompt.md",
+        "buggy-source/.gitkeep",
+        "Patches/lagent_239/.gitkeep",
+        "runner-flow-plan.public.json",
+        "execution-gate.public.json",
+        "first-run-handoff.public.json",
+        "first-run-handoff.md",
+        "workflow-check.public.json",
+        "run-specific-gate.public.json",
+        "run-specific-gate.md",
+        "benchmark_run.compact.json",
+    ]
+    missing = [rel for rel in expected_paths if not (run_gate_root / rel).exists()]
+    assert not missing, missing
+
+    run_gate = json.loads(
+        (run_gate_root / "run-specific-gate.public.json").read_text(encoding="utf-8")
+    )
+    assert run_gate["schema_version"] == CLASSIFICATION, run_gate
+    assert run_gate["path_recorded"] is False, run_gate
+    assert run_gate["real_run_authorized"] is False, run_gate
+    assert run_gate["ready_for_real_run"] is False, run_gate
+    assert run_gate["ready_for_operator_review"] is True, run_gate
+    assert "operator_explicit_real_run_trigger" in run_gate["blocking_gate_ids"], run_gate
+    assert "private_job_root_selected" in run_gate["blocking_gate_ids"], run_gate
+    gate_ids = {item["id"] for item in run_gate["owner_agent_gate_items"]}
+    for required in [
+        "host_codex_auth_local_only",
+        "selected_container_source_extracted",
+        "private_git_baseline_created_before_codex",
+        "host_codex_exec_ephemeral_from_buggy_source",
+        "attempt_patch_reducer_configured",
+        "selected_tag_eval_no_upload_submit_ranking",
+        "compact_public_reducer_enabled",
+    ]:
+        assert required in gate_ids, (required, gate_ids)
+    assert run_gate["credential_boundary"]["host_codex_auth_local_only"] is True, run_gate
+    assert run_gate["credential_boundary"]["shared_remote_host_receives_codex_auth"] is False, run_gate
+    assert run_gate["public_artifact_policy"]["raw_logs_public"] is False, run_gate
+    assert run_gate["execution_boundary"]["codex_cli_invoked"] is False, run_gate
+    assert run_gate["execution_boundary"]["docker_container_started"] is False, run_gate
+
+    local_run = json.loads((run_gate_root / "benchmark_run.compact.json").read_text(encoding="utf-8"))
+    assert local_run["schema_version"] == "benchmark_run_v0", local_run
+    assert local_run["mode"] == RUN_MODE, local_run
+    assert local_run["validation"]["run_specific_gate_materialized"] is True, local_run
+    assert local_run["validation"]["real_run_authorized"] is False, local_run
+    assert local_run["first_blocker"] == "run_gate_packet_only_real_run_not_authorized", local_run
+
+
+def assert_payload(payload: dict[str, Any], *, appended: bool) -> None:
+    assert payload["ok"] is True, payload
+    assert payload["appended"] is appended, payload
+    assert payload["dry_run"] is (not appended), payload
+    assert payload["classification"] == CLASSIFICATION, payload
+
+    cli = payload["benchmark_cli"]
+    assert cli["benchmark"] == BENCHMARK_ID, cli
+    assert cli["command"] == "agentissue-codex-runner-flow", cli
+    assert cli["tag"] == SELECTED_TAG, cli
+    assert cli["run_gate_materialized"] is True, cli
+    assert cli["run_gate_root_path_recorded"] is False, cli
+    assert cli["real_runner_invoked"] is False, cli
+    assert cli["real_codex_invoked"] is False, cli
+    assert cli["real_docker_invoked"] is False, cli
+    assert cli["auth_values_read"] is False, cli
+
+    run_gate = payload["agentissue_run_gate"]
+    assert run_gate["schema_version"] == CLASSIFICATION, run_gate
+    assert run_gate["ready_for_operator_review"] is True, run_gate
+    assert run_gate["ready_for_real_run"] is False, run_gate
+    assert "run-specific-gate.public.json" in run_gate["created_relative_paths"], run_gate
+    assert run_gate["execution_boundary"]["codex_cli_invoked"] is False, run_gate
+
+    event = payload["benchmark_run"]
+    assert event["schema_version"] == "benchmark_run_v0", event
+    assert event["benchmark_id"] == BENCHMARK_ID, event
+    assert event["mode"] == RUN_MODE, event
+    assert event["first_blocker"] == "run_gate_packet_only_real_run_not_authorized", event
+    assert event["real_run"] is False, event
+    assert event["submit_eligible"] is False, event
+    assert event["leaderboard_evidence"] is False, event
+    assert "run-specific-gate.public.json" in event["evidence_files"], event
+    assert_no_forbidden_text(run_gate)
+    assert_no_forbidden_text(event)
+    assert_no_forbidden_text(cli)
+
+
+def assert_status_projection(registry_path: Path, runtime: Path) -> None:
+    status = collect_status(
+        registry_path=registry_path,
+        runtime_root_override=str(runtime),
+        scan_roots=[],
+        limit=5,
+    )
+    assert status["ok"], status
+    latest = status["run_history"]["goals"][0]["latest_runs"][0]
+    summary = latest["benchmark_run_summary"]
+    assert summary["mode"] == RUN_MODE, summary
+    assert summary["benchmark_id"] == BENCHMARK_ID, summary
+    assert summary["first_blocker"] == "run_gate_packet_only_real_run_not_authorized", summary
+    assert_no_forbidden_text(summary)
+
+
+def assert_roots_are_mutually_exclusive(
+    registry_path: Path, runtime: Path, run_gate_root: Path
+) -> None:
+    args = common_args(registry_path, runtime, run_gate_root) + [
+        "--workflow-check-root",
+        str(run_gate_root / "other-root"),
+    ]
+    result = run_cli(args, check=False)
+    assert result.returncode == 1, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False, payload
+    assert "at most one" in payload["error"], payload
+
+
+def main() -> None:
+    assert_doc_contract()
+    with tempfile.TemporaryDirectory(prefix="agentissue-runner-run-gate-") as tmp:
+        registry_path, runtime, run_gate_root = write_fixture(Path(tmp))
+        dry_payload = run_cli_json(common_args(registry_path, runtime, run_gate_root))
+        assert_payload(dry_payload, appended=False)
+        assert_run_gate_files(run_gate_root)
+
+        execute_payload = run_cli_json(
+            common_args(registry_path, runtime, run_gate_root)
+            + [
+                "--delivery-batch-scale",
+                "multi_surface",
+                "--delivery-outcome",
+                "outcome_progress",
+                "--execute",
+            ]
+        )
+        assert_payload(execute_payload, appended=True)
+        assert_run_gate_files(run_gate_root)
+        assert_status_projection(registry_path, runtime)
+        assert_roots_are_mutually_exclusive(registry_path, runtime, run_gate_root / "mutual")
+
+    print(
+        "agentissue-bench-codex-cli-runner-run-gate-smoke ok "
+        f"mode={RUN_MODE} appended=True real_run=False"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/goal_harness/benchmark.py
+++ b/goal_harness/benchmark.py
@@ -222,6 +222,12 @@ AGENTISSUE_CODEX_CLI_RUNNER_WORKFLOW_CHECK_SCHEMA_VERSION = (
 AGENTISSUE_CODEX_CLI_RUNNER_WORKFLOW_CHECK_MODE = (
     "agentissue_codex_cli_runner_workflow_check_packet"
 )
+AGENTISSUE_CODEX_CLI_RUNNER_RUN_GATE_SCHEMA_VERSION = (
+    "agentissue_bench_codex_cli_runner_run_gate_v0"
+)
+AGENTISSUE_CODEX_CLI_RUNNER_RUN_GATE_MODE = (
+    "agentissue_codex_cli_runner_run_gate_packet"
+)
 AGENTISSUE_CODEX_CLI_RUNNER_SOURCE_RUNNER = (
     "goal_harness_agentissue_codex_cli_runner"
 )
@@ -1393,6 +1399,307 @@ def materialize_agentissue_codex_cli_runner_workflow_check(
         "recommended_next_action": (
             "use workflow-check.public.json as the pre-run invariant packet before "
             "any later operator-triggered AgentIssue-Bench lagent_239 e2e run"
+        ),
+    }
+
+def materialize_agentissue_codex_cli_runner_run_gate(
+    run_gate_root: str | Path,
+    *,
+    selected_tag: str = AGENTISSUE_DEFAULT_TAG,
+    codex_binary: str = "codex",
+    docker_binary: str = "docker",
+) -> dict[str, Any]:
+    """Create a no-execute run-specific gate packet for AgentIssue lagent_239."""
+
+    tag = _agentissue_public_label(selected_tag)
+    if tag != AGENTISSUE_DEFAULT_TAG:
+        raise ValueError(
+            "agentissue Codex runner run-specific gate currently only supports selected tag lagent_239"
+        )
+    root = Path(run_gate_root).expanduser()
+    workflow = materialize_agentissue_codex_cli_runner_workflow_check(
+        root,
+        selected_tag=tag,
+        codex_binary=codex_binary,
+        docker_binary=docker_binary,
+    )
+    workflow_path = root / "workflow-check.public.json"
+    gate_path = root / "execution-gate.public.json"
+    handoff_path = root / "first-run-handoff.public.json"
+    run_gate_path = root / "run-specific-gate.public.json"
+    run_gate_markdown_path = root / "run-specific-gate.md"
+    compact_run_path = root / "benchmark_run.compact.json"
+
+    workflow_check = json.loads(workflow_path.read_text(encoding="utf-8"))
+    execution_gate = json.loads(gate_path.read_text(encoding="utf-8"))
+    handoff = json.loads(handoff_path.read_text(encoding="utf-8"))
+
+    gate_items = [
+        {
+            "id": "selected_tag_and_image_locked",
+            "owner": "agent",
+            "required_before_real_run": True,
+            "satisfied_by_packet": workflow_check["workflow_checks"]["single_selected_tag"]
+            and workflow_check["workflow_checks"]["selected_image_consistent"],
+            "public_evidence": "workflow-check.public.json",
+        },
+        {
+            "id": "host_codex_auth_local_only",
+            "owner": "agent",
+            "required_before_real_run": True,
+            "satisfied_by_packet": workflow_check["workflow_checks"]["host_codex_auth_not_synced"],
+            "public_evidence": "workflow-check.public.json",
+        },
+        {
+            "id": "private_job_root_selected",
+            "owner": "agent",
+            "required_before_real_run": True,
+            "satisfied_by_packet": False,
+            "stop_if_missing": True,
+        },
+        {
+            "id": "operator_explicit_real_run_trigger",
+            "owner": "owner",
+            "required_before_real_run": True,
+            "satisfied_by_packet": False,
+            "stop_if_missing": True,
+        },
+        {
+            "id": "selected_container_source_extracted",
+            "owner": "agent",
+            "required_before_real_run": True,
+            "satisfied_by_packet": False,
+            "public_command_shape": "execution-gate.public.json",
+            "stop_if_missing": True,
+        },
+        {
+            "id": "private_git_baseline_created_before_codex",
+            "owner": "agent",
+            "required_before_real_run": True,
+            "satisfied_by_packet": False,
+            "public_command_shape": "execution-gate.public.json",
+            "stop_if_missing": True,
+        },
+        {
+            "id": "host_codex_exec_ephemeral_from_buggy_source",
+            "owner": "agent",
+            "required_before_real_run": True,
+            "satisfied_by_packet": False,
+            "public_command_shape": "execution-gate.public.json",
+            "stop_if_missing": True,
+        },
+        {
+            "id": "attempt_patch_reducer_configured",
+            "owner": "agent",
+            "required_before_real_run": True,
+            "satisfied_by_packet": workflow_check["workflow_checks"]["patch_from_buggy_source_git_diff"]
+            and workflow_check["workflow_checks"]["attempt_patch_relative_path"],
+            "public_evidence": AGENTISSUE_PATCH_RELATIVE_PATH,
+        },
+        {
+            "id": "selected_tag_eval_no_upload_submit_ranking",
+            "owner": "agent",
+            "required_before_real_run": True,
+            "satisfied_by_packet": workflow_check["workflow_checks"]["single_tag_eval_no_upload_submit"]
+            and workflow_check["workflow_checks"]["single_tag_eval_no_public_ranking"],
+            "public_evidence": "workflow-check.public.json",
+        },
+        {
+            "id": "compact_public_reducer_enabled",
+            "owner": "agent",
+            "required_before_real_run": True,
+            "satisfied_by_packet": workflow_check["workflow_checks"]["public_files_compact_or_public"],
+            "public_evidence": "benchmark_run.compact.json",
+        },
+        {
+            "id": "raw_artifact_and_auth_leak_stop_rules_enabled",
+            "owner": "agent",
+            "required_before_real_run": True,
+            "satisfied_by_packet": True,
+            "stop_if_raw_task_patch_log_trajectory_screenshot_or_auth_material_public": True,
+        },
+    ]
+    blocking_gate_ids = [
+        item["id"]
+        for item in gate_items
+        if item["required_before_real_run"] and not item["satisfied_by_packet"]
+    ]
+    run_gate = {
+        "schema_version": AGENTISSUE_CODEX_CLI_RUNNER_RUN_GATE_SCHEMA_VERSION,
+        "benchmark_id": AGENTISSUE_BENCHMARK_ID,
+        "selected_tag": tag,
+        "selected_image": AGENTISSUE_DEFAULT_IMAGE,
+        "default_mode": "no_execute",
+        "materialized": True,
+        "path_recorded": False,
+        "real_run_authorized": False,
+        "ready_for_real_run": False,
+        "ready_for_operator_review": True,
+        "blocking_gate_ids": blocking_gate_ids,
+        "input_packets": {
+            "workflow_check": "workflow-check.public.json",
+            "first_run_handoff": "first-run-handoff.public.json",
+            "execution_gate": "execution-gate.public.json",
+        },
+        "owner_agent_gate_items": gate_items,
+        "phase_order": [
+            "select_private_job_root",
+            "extract_selected_container_buggy_source",
+            "create_private_git_baseline",
+            "run_host_codex_exec_ephemeral_from_buggy_source",
+            "export_attempt_patch_from_buggy_source_git_diff",
+            "run_selected_tag_eval_no_upload_submit_ranking",
+            "reduce_to_compact_public_result",
+        ],
+        "public_artifact_policy": {
+            "allowed_public_relative_files": [
+                "runner-flow-plan.public.json",
+                "execution-gate.public.json",
+                "first-run-handoff.public.json",
+                "workflow-check.public.json",
+                "run-specific-gate.public.json",
+                "run-specific-gate.md",
+                "benchmark_run.compact.json",
+            ],
+            "raw_task_material_public": False,
+            "patch_content_public": False,
+            "raw_logs_public": False,
+            "trajectories_public": False,
+            "screenshots_public": False,
+            "absolute_paths_public": False,
+            "credential_values_public": False,
+        },
+        "credential_boundary": {
+            "codex_auth_values_read_by_packet": False,
+            "codex_home_synced": False,
+            "shared_remote_host_receives_codex_auth": False,
+            "host_codex_auth_local_only": True,
+        },
+        "stop_conditions": [
+            "private_job_root_missing",
+            "operator_real_run_trigger_missing",
+            "selected_container_source_not_extracted",
+            "private_git_baseline_missing_before_codex",
+            "host_codex_not_ephemeral_or_not_from_buggy_source",
+            "attempt_patch_missing_or_not_from_buggy_source_git_diff",
+            "eval_attempts_upload_submit_or_public_ranking",
+            "public_artifact_contains_raw_task_patch_log_trajectory_screenshot_auth_or_absolute_path",
+        ],
+        "execution_boundary": {
+            **workflow_check["execution_boundary"],
+            "real_run_authorized": False,
+            "operator_trigger_recorded": False,
+        },
+        "rendered_command_sources": {
+            "source_extraction_gate": execution_gate["source_extraction_gate"]["commands"],
+            "private_git_baseline_gate": execution_gate["private_git_baseline_gate"]["commands"],
+            "host_codex_gate": execution_gate["host_codex_gate"]["command"],
+            "patch_output_gate": execution_gate["patch_output_gate"],
+            "eval_gate": execution_gate["eval_gate"],
+        },
+    }
+    markdown = (
+        "# AgentIssue-Bench lagent_239 Run-Specific Gate\n\n"
+        "This packet is no-execute. It separates the gates that are already "
+        "covered by public/compact no-run packets from the gates that still "
+        "block a real no-upload run.\n\n"
+        "## Blocking Gates\n\n"
+        + "\n".join(f"- {gate_id}" for gate_id in blocking_gate_ids)
+        + "\n\n## Public Boundary\n\n"
+        "- Codex auth stays on the host; no Codex home or auth material is synced.\n"
+        "- Public artifacts stay compact/public and relative-path only.\n"
+        "- Raw task material, patch content, raw logs, trajectories, screenshots, "
+        "credentials, and absolute private paths remain private.\n"
+    )
+
+    benchmark_run = json.loads(json.dumps(workflow["benchmark_run"]))
+    benchmark_run.update(
+        {
+            "job_name": "agentissue_lagent_239_codex_cli_runner_run_gate",
+            "mode": AGENTISSUE_CODEX_CLI_RUNNER_RUN_GATE_MODE,
+            "worker_mode": "trusted_host_codex_cli_no_execute_run_gate",
+            "first_blocker": "run_gate_packet_only_real_run_not_authorized",
+            "score_failure_attribution": "not_run_run_gate_only",
+            "failure_attribution_labels": [
+                "run_specific_gate_packet_only",
+                "real_run_blocked_until_gate_items_satisfied",
+            ],
+            "evidence_files": run_gate["public_artifact_policy"][
+                "allowed_public_relative_files"
+            ],
+        }
+    )
+    benchmark_run["validation"].update(
+        {
+            "run_specific_gate_materialized": True,
+            "owner_agent_gate_items_declared": True,
+            "blocking_gate_ids_declared": True,
+            "ready_for_operator_review": True,
+            "real_run_authorized": False,
+            "private_job_root_required": True,
+            "operator_trigger_required": True,
+            "phase_order_declared": True,
+            "credential_boundary_declared": True,
+            "public_artifact_policy_declared": True,
+            "stop_conditions_declared": True,
+            "no_execute_packet": True,
+            "no_real_source_extraction": True,
+            "no_real_codex_execution": True,
+            "no_docker_pull_or_start": True,
+            "no_auth_sync_to_shared_host": True,
+        }
+    )
+    for trial in benchmark_run.get("trials") or []:
+        if isinstance(trial, dict):
+            trial["exception_type"] = "run_gate_packet_only_no_real_case"
+
+    run_gate_path.write_text(
+        json.dumps(run_gate, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    run_gate_markdown_path.write_text(markdown, encoding="utf-8")
+    compact_run_path.write_text(
+        json.dumps(benchmark_run, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return {
+        "schema_version": AGENTISSUE_CODEX_CLI_RUNNER_RUN_GATE_SCHEMA_VERSION,
+        "benchmark_id": AGENTISSUE_BENCHMARK_ID,
+        "selected_tag": tag,
+        "selected_image": AGENTISSUE_DEFAULT_IMAGE,
+        "ready_for_operator_review": True,
+        "ready_for_real_run": False,
+        "materialized": True,
+        "path_recorded": False,
+        "run_gate_root_path_recorded": False,
+        "blocking_gate_ids": blocking_gate_ids,
+        "workflow_check": {
+            "schema_version": workflow["schema_version"],
+            "ready": workflow["ready"],
+            "workflow_check_relative_path": workflow["workflow_check_relative_path"],
+            "path_recorded": False,
+        },
+        "created_relative_paths": [
+            *workflow["created_relative_paths"],
+            "run-specific-gate.public.json",
+            "run-specific-gate.md",
+        ],
+        "run_gate_relative_path": "run-specific-gate.public.json",
+        "run_gate_markdown_relative_path": "run-specific-gate.md",
+        "compact_run_relative_path": "benchmark_run.compact.json",
+        "gate_checks": {
+            "owner_agent_gate_items_declared": True,
+            "blocking_gate_ids_declared": True,
+            "credential_boundary_declared": True,
+            "public_artifact_policy_declared": True,
+            "stop_conditions_declared": True,
+            "real_run_authorized": False,
+        },
+        "execution_boundary": run_gate["execution_boundary"],
+        "benchmark_run": benchmark_run,
+        "recommended_next_action": (
+            "review run-specific gate packet before any later real no-upload "
+            "AgentIssue-Bench lagent_239 Docker/Codex execution"
         ),
     }
 

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -22,6 +22,7 @@ from .benchmark import (
     AGENTISSUE_BENCHMARK_ID,
     AGENTISSUE_CODEX_CLI_RUNNER_EXECUTION_GATE_SCHEMA_VERSION,
     AGENTISSUE_CODEX_CLI_RUNNER_FIRST_RUN_HANDOFF_SCHEMA_VERSION,
+    AGENTISSUE_CODEX_CLI_RUNNER_RUN_GATE_SCHEMA_VERSION,
     AGENTISSUE_CODEX_CLI_RUNNER_SYNTHETIC_STAGING_SCHEMA_VERSION,
     AGENTISSUE_CODEX_CLI_RUNNER_WORKFLOW_CHECK_SCHEMA_VERSION,
     AGENTISSUE_CODEX_CLI_RUNNER_WRAPPER_SCHEMA_VERSION,
@@ -29,6 +30,7 @@ from .benchmark import (
     build_agentissue_codex_cli_runner_wrapper,
     materialize_agentissue_codex_cli_runner_execution_gate,
     materialize_agentissue_codex_cli_runner_first_run_handoff,
+    materialize_agentissue_codex_cli_runner_run_gate,
     materialize_agentissue_codex_cli_runner_synthetic_staging,
     materialize_agentissue_codex_cli_runner_workflow_check,
     TERMINAL_BENCH_DEFAULT_DATASET,
@@ -1342,6 +1344,15 @@ def main(argv: list[str] | None = None) -> int:
             "Codex, Docker, model APIs, upload, submit, or real task material."
         ),
     )
+    agentissue_runner_flow_parser.add_argument(
+        "--run-gate-root",
+        help=(
+            "Materialize a no-execute run-specific gate packet at PATH. It "
+            "includes the workflow check plus run-specific owner/agent gates "
+            "for a later no-upload lagent_239 run without running Codex, Docker, "
+            "model APIs, upload, submit, or real task material."
+        ),
+    )
     agentissue_runner_flow_parser.add_argument("--classification")
     agentissue_runner_flow_parser.add_argument("--recommended-action")
     agentissue_runner_flow_parser.add_argument(
@@ -2304,15 +2315,19 @@ def main(argv: list[str] | None = None) -> int:
                     AGENTISSUE_CODEX_CLI_RUNNER_WORKFLOW_CHECK_SCHEMA_VERSION
                     if args.workflow_check_root
                     else (
-                        AGENTISSUE_CODEX_CLI_RUNNER_FIRST_RUN_HANDOFF_SCHEMA_VERSION
-                        if args.first_run_handoff_root
+                        AGENTISSUE_CODEX_CLI_RUNNER_RUN_GATE_SCHEMA_VERSION
+                        if args.run_gate_root
                         else (
-                            AGENTISSUE_CODEX_CLI_RUNNER_EXECUTION_GATE_SCHEMA_VERSION
-                            if args.execution_gate_root
+                            AGENTISSUE_CODEX_CLI_RUNNER_FIRST_RUN_HANDOFF_SCHEMA_VERSION
+                            if args.first_run_handoff_root
                             else (
-                                AGENTISSUE_CODEX_CLI_RUNNER_SYNTHETIC_STAGING_SCHEMA_VERSION
-                                if args.synthetic_staging_root
-                                else AGENTISSUE_CODEX_CLI_RUNNER_WRAPPER_SCHEMA_VERSION
+                                AGENTISSUE_CODEX_CLI_RUNNER_EXECUTION_GATE_SCHEMA_VERSION
+                                if args.execution_gate_root
+                                else (
+                                    AGENTISSUE_CODEX_CLI_RUNNER_SYNTHETIC_STAGING_SCHEMA_VERSION
+                                    if args.synthetic_staging_root
+                                    else AGENTISSUE_CODEX_CLI_RUNNER_WRAPPER_SCHEMA_VERSION
+                                )
                             )
                         )
                     )
@@ -2330,12 +2345,13 @@ def main(argv: list[str] | None = None) -> int:
                         args.execution_gate_root,
                         args.first_run_handoff_root,
                         args.workflow_check_root,
+                        args.run_gate_root,
                     )
                     if value
                 ]
                 if len(selected_roots) > 1:
                     raise ValueError(
-                        "agentissue-codex-runner-flow accepts at most one root option, not both: --synthetic-staging-root, --execution-gate-root, --first-run-handoff-root, or --workflow-check-root"
+                        "agentissue-codex-runner-flow accepts at most one root option, not both: --synthetic-staging-root, --execution-gate-root, --first-run-handoff-root, --workflow-check-root, or --run-gate-root"
                     )
                 wrapper = build_agentissue_codex_cli_runner_wrapper(
                     selected_tag=args.tag,
@@ -2346,8 +2362,17 @@ def main(argv: list[str] | None = None) -> int:
                 execution_gate = None
                 first_run_handoff = None
                 workflow_check = None
+                run_gate = None
                 benchmark_run_source = wrapper["benchmark_run"]
-                if args.workflow_check_root:
+                if args.run_gate_root:
+                    run_gate = materialize_agentissue_codex_cli_runner_run_gate(
+                        args.run_gate_root,
+                        selected_tag=args.tag,
+                        codex_binary=args.codex_binary,
+                        docker_binary=args.docker_binary,
+                    )
+                    benchmark_run_source = run_gate["benchmark_run"]
+                elif args.workflow_check_root:
                     workflow_check = materialize_agentissue_codex_cli_runner_workflow_check(
                         args.workflow_check_root,
                         selected_tag=args.tag,
@@ -2397,18 +2422,22 @@ def main(argv: list[str] | None = None) -> int:
                     classification=classification,
                     recommended_action=args.recommended_action
                     or (
-                        workflow_check["recommended_next_action"]
-                        if workflow_check
+                        run_gate["recommended_next_action"]
+                        if run_gate
                         else (
-                            first_run_handoff["recommended_next_action"]
-                            if first_run_handoff
+                            workflow_check["recommended_next_action"]
+                            if workflow_check
                             else (
-                                execution_gate["recommended_next_action"]
-                                if execution_gate
+                                first_run_handoff["recommended_next_action"]
+                                if first_run_handoff
                                 else (
-                                    synthetic_staging["recommended_next_action"]
-                                    if synthetic_staging
-                                    else wrapper["recommended_next_action"]
+                                    execution_gate["recommended_next_action"]
+                                    if execution_gate
+                                    else (
+                                        synthetic_staging["recommended_next_action"]
+                                        if synthetic_staging
+                                        else wrapper["recommended_next_action"]
+                                    )
                                 )
                             )
                         )
@@ -2437,6 +2466,8 @@ def main(argv: list[str] | None = None) -> int:
                     "first_run_handoff_root_path_recorded": False,
                     "workflow_check_materialized": bool(workflow_check),
                     "workflow_check_root_path_recorded": False,
+                    "run_gate_materialized": bool(run_gate),
+                    "run_gate_root_path_recorded": False,
                 }
                 payload["agentissue_runner_flow"] = wrapper
                 if synthetic_staging:
@@ -2447,6 +2478,8 @@ def main(argv: list[str] | None = None) -> int:
                     payload["agentissue_first_run_handoff"] = first_run_handoff
                 if workflow_check:
                     payload["agentissue_workflow_check"] = workflow_check
+                if run_gate:
+                    payload["agentissue_run_gate"] = run_gate
                 if args.no_global_sync:
                     payload["global_sync"] = {
                         "ok": True,


### PR DESCRIPTION
## Summary

- add a no-execute `--run-gate-root` packet for AgentIssue-Bench `lagent_239`
- materialize `run-specific-gate.public.json` / `run-specific-gate.md` from the existing workflow-check chain
- update AgentIssue runner-flow README, PR-ready packet, publication packet, and smoke coverage to include the new gate

## Validation

- `python3 -m py_compile goal_harness/benchmark.py goal_harness/cli.py goal_harness/status.py examples/agentissue-bench-codex-cli-runner-*.py`
- full 10-script AgentIssue runner-flow smoke chain through `agentissue-bench-codex-cli-runner-publication-change-set-smoke.py`
- `python3 -m goal_harness.cli check ...` over the changed public surfaces, errors=0 warnings=0
- `git diff --check`

## Boundary

No Codex prompt, model API, Docker pull/start, source extraction, patch generation/evaluation, auth read/sync, upload, submit, public ranking path, raw artifact publication, destructive git, or production action is performed by this packet.
