### PR TITLE
Add AgentIssue target-runner handoff packet

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/README.md
+++ b/docs/research/long-horizon-agent-benchmarks/README.md
@@ -234,16 +234,22 @@ work still belongs in the existing code, examples, and contract documents:
   real-run blockers: private job root selection, explicit real-run trigger,
   selected-container source extraction, private git baseline, and host-local
   Codex execution from the extracted buggy source.
+- `agentissue-bench-codex-cli-runner-target-handoff-v0.md`: no-execute
+  `--target-runner-handoff-root` packet for `lagent_239`. It materializes the
+  run-specific gate plus `target-runner-handoff.public.json` and
+  `target-runner-handoff.md`, turning the gate packet into a compact
+  target-runner checklist for a separate benchmark execution thread while
+  keeping the meta heartbeat no-execute/no-upload.
 - `agentissue-bench-codex-cli-runner-pr-ready-packet-v0.md`: public-safe
   consolidation packet for the full `lagent_239` runner-flow chain. It ties
   together the contract, flow plan, dry-run wrapper, synthetic staging,
-  execution gate, first-run handoff, workflow check, run-specific gate, and
-  nine matching smokes into one reviewable route while preserving no-run/
-  no-upload/no-submit/
+  execution gate, first-run handoff, workflow check, run-specific gate,
+  target-runner handoff, and ten matching smokes into one reviewable route
+  while preserving no-run/no-upload/no-submit/
   no-public-ranking boundaries.
 - `agentissue-bench-codex-cli-runner-publication-change-set-v0.md`: staging
   and review packet for publishing only the AgentIssue runner-flow change set.
-  It lists the ten docs and ten smokes that should move together, marks
+  It lists the eleven docs and eleven smokes that should move together, marks
   `goal_harness/benchmark.py`, `goal_harness/cli.py`, and this README as mixed
   tracked files that need hunk-level staging, and excludes unrelated benchmark
   lanes, runtime state, credentials, raw artifacts, uploads, submits, and

--- a/docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-pr-ready-packet-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-pr-ready-packet-v0.md
@@ -33,6 +33,7 @@ docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-ex
 docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-first-run-handoff-v0.md
 docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-workflow-check-v0.md
 docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-run-gate-v0.md
+docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-target-handoff-v0.md
 docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-pr-ready-packet-v0.md
 ```
 
@@ -47,6 +48,7 @@ examples/agentissue-bench-codex-cli-runner-execution-gate-smoke.py
 examples/agentissue-bench-codex-cli-runner-first-run-handoff-smoke.py
 examples/agentissue-bench-codex-cli-runner-workflow-check-smoke.py
 examples/agentissue-bench-codex-cli-runner-run-gate-smoke.py
+examples/agentissue-bench-codex-cli-runner-target-handoff-smoke.py
 examples/agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py
 ```
 
@@ -55,7 +57,7 @@ examples/agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py
 The route narrows from high-level contract to no-execute handoff:
 
 ```text
-contract -> flow plan -> dry-run wrapper -> synthetic staging -> execution gate -> first-run handoff -> workflow check -> run-specific gate -> PR-ready packet
+contract -> flow plan -> dry-run wrapper -> synthetic staging -> execution gate -> first-run handoff -> workflow check -> run-specific gate -> target-runner handoff -> PR-ready packet
 ```
 
 The CLI surfaces are:
@@ -67,6 +69,7 @@ goal-harness benchmark agentissue-codex-runner-flow --tag lagent_239 --execution
 goal-harness benchmark agentissue-codex-runner-flow --tag lagent_239 --first-run-handoff-root <private-root>
 goal-harness benchmark agentissue-codex-runner-flow --tag lagent_239 --workflow-check-root <private-root>
 goal-harness benchmark agentissue-codex-runner-flow --tag lagent_239 --run-gate-root <private-root>
+goal-harness benchmark agentissue-codex-runner-flow --tag lagent_239 --target-runner-handoff-root <private-root>
 ```
 
 All root options are mutually exclusive. They materialize public-safe packet
@@ -81,9 +84,10 @@ allowed public evidence: schema/mode, selected tag, selected image label, comman
 forbidden public evidence: issue body, patch content, raw logs, trajectories, screenshots, local absolute paths, auth files, token names, API keys, fixed/oracle material
 ```
 
-The later e2e run remains separate from this PR-ready packet. A later operator
-can use the workflow check plus first-run handoff checklist before triggering a
-real run, but that real run is not part of this packet.
+The later e2e run remains separate from this PR-ready packet. A separate
+benchmark execution thread can use the target-runner handoff plus run-specific
+gate checklist before triggering a real run, but that real run is not part of
+this packet.
 
 ## Validation
 

--- a/docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-publication-change-set-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-publication-change-set-v0.md
@@ -34,6 +34,7 @@ docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-ex
 docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-first-run-handoff-v0.md
 docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-workflow-check-v0.md
 docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-run-gate-v0.md
+docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-target-handoff-v0.md
 docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-pr-ready-packet-v0.md
 docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-publication-change-set-v0.md
 ```
@@ -49,6 +50,7 @@ examples/agentissue-bench-codex-cli-runner-execution-gate-smoke.py
 examples/agentissue-bench-codex-cli-runner-first-run-handoff-smoke.py
 examples/agentissue-bench-codex-cli-runner-workflow-check-smoke.py
 examples/agentissue-bench-codex-cli-runner-run-gate-smoke.py
+examples/agentissue-bench-codex-cli-runner-target-handoff-smoke.py
 examples/agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py
 examples/agentissue-bench-codex-cli-runner-publication-change-set-smoke.py
 ```
@@ -83,22 +85,25 @@ AGENTISSUE_CODEX_CLI_RUNNER_EXECUTION_GATE_SCHEMA_VERSION
 AGENTISSUE_CODEX_CLI_RUNNER_FIRST_RUN_HANDOFF_SCHEMA_VERSION
 AGENTISSUE_CODEX_CLI_RUNNER_WORKFLOW_CHECK_SCHEMA_VERSION
 AGENTISSUE_CODEX_CLI_RUNNER_RUN_GATE_SCHEMA_VERSION
+AGENTISSUE_CODEX_CLI_RUNNER_TARGET_HANDOFF_SCHEMA_VERSION
 build_agentissue_codex_cli_runner_wrapper
 materialize_agentissue_codex_cli_runner_synthetic_staging
 materialize_agentissue_codex_cli_runner_execution_gate
 materialize_agentissue_codex_cli_runner_first_run_handoff
 materialize_agentissue_codex_cli_runner_workflow_check
 materialize_agentissue_codex_cli_runner_run_gate
+materialize_agentissue_codex_cli_runner_target_handoff
 agentissue-codex-runner-flow
 --synthetic-staging-root
 --execution-gate-root
 --first-run-handoff-root
 --workflow-check-root
 --run-gate-root
+--target-runner-handoff-root
 read_boundary
 ```
 
-The README hunks that belong to this change set are the ten
+The README hunks that belong to this change set are the eleven
 `agentissue-bench-codex-cli-runner-*` bullets. Earlier
 `agentissue-bench-lagent239-*` research packets are useful historical evidence,
 but they are not part of this runner-flow publication change set.
@@ -141,6 +146,7 @@ python3 examples/agentissue-bench-codex-cli-runner-execution-gate-smoke.py &&
 python3 examples/agentissue-bench-codex-cli-runner-first-run-handoff-smoke.py &&
 python3 examples/agentissue-bench-codex-cli-runner-workflow-check-smoke.py &&
 python3 examples/agentissue-bench-codex-cli-runner-run-gate-smoke.py &&
+python3 examples/agentissue-bench-codex-cli-runner-target-handoff-smoke.py &&
 python3 examples/agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py &&
 python3 examples/agentissue-bench-codex-cli-runner-publication-change-set-smoke.py
 ```
@@ -160,6 +166,7 @@ python3 -m py_compile \
   examples/agentissue-bench-codex-cli-runner-first-run-handoff-smoke.py \
   examples/agentissue-bench-codex-cli-runner-workflow-check-smoke.py \
   examples/agentissue-bench-codex-cli-runner-run-gate-smoke.py \
+  examples/agentissue-bench-codex-cli-runner-target-handoff-smoke.py \
   examples/agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py \
   examples/agentissue-bench-codex-cli-runner-publication-change-set-smoke.py
 
@@ -176,6 +183,7 @@ goal-harness check \
   --scan-path docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-first-run-handoff-v0.md \
   --scan-path docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-workflow-check-v0.md \
   --scan-path docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-run-gate-v0.md \
+  --scan-path docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-target-handoff-v0.md \
   --scan-path docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-pr-ready-packet-v0.md \
   --scan-path docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-publication-change-set-v0.md
 ```

--- a/docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-target-handoff-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-target-handoff-v0.md
@@ -1,0 +1,60 @@
+# AgentIssue-Bench Codex CLI Runner Target Handoff V0
+
+This packet adds one no-execute target-runner handoff for the selected
+AgentIssue-Bench tag `lagent_239`:
+
+```bash
+goal-harness benchmark agentissue-codex-runner-flow \
+  --goal-id <goal-id> \
+  --tag lagent_239 \
+  --target-runner-handoff-root <private-handoff-root>
+```
+
+The command materializes the run-specific gate plus
+`target-runner-handoff.public.json` and `target-runner-handoff.md`. It is a
+handoff packet for a separate benchmark execution thread, not a benchmark run
+and not permission for the meta heartbeat thread to execute.
+
+## Execution Boundary
+
+The packet records:
+
+- `handoff_target=separate_benchmark_execution_thread`
+- `meta_heartbeat_must_not_execute=true`
+- `real_run_authorized_by_packet=false`
+- `ready_for_real_run=false`
+
+The target execution thread must satisfy the run-specific gate before any real
+run: private job root selection, explicit real-run trigger, selected-container
+source extraction, private git baseline, host-local `codex exec --ephemeral`
+from the extracted buggy source, attempt-patch export, selected-tag eval with
+no upload/submit/ranking path, compact public reducer, and host-local Codex auth
+isolation.
+
+## Public Boundary
+
+The packet is still no-run. It does not pull or start Docker, invoke Codex,
+call a model API, extract source, initialize git, generate or evaluate a patch,
+read credentials, sync auth material, upload, submit, touch public ranking
+paths, publish raw issue/task/patch/log/transcript material, use destructive
+git, or take production action.
+
+Allowed public artifacts are limited to relative-path public/compact JSON and
+Markdown handoff packets:
+
+- `benchmark_run.compact.json`
+- `run-specific-gate.public.json`
+- `target-runner-handoff.public.json`
+- `target-runner-handoff.md`
+
+Private execution artifacts must be reduced before any public writeback.
+
+## Validation
+
+```bash
+python3 examples/agentissue-bench-codex-cli-runner-target-handoff-smoke.py
+python3 -m py_compile examples/agentissue-bench-codex-cli-runner-target-handoff-smoke.py
+goal-harness check \
+  --scan-path examples/agentissue-bench-codex-cli-runner-target-handoff-smoke.py \
+  --scan-path docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-target-handoff-v0.md
+```

--- a/examples/agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py
+++ b/examples/agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py
@@ -22,6 +22,7 @@ DOCS = [
     "agentissue-bench-codex-cli-runner-first-run-handoff-v0.md",
     "agentissue-bench-codex-cli-runner-workflow-check-v0.md",
     "agentissue-bench-codex-cli-runner-run-gate-v0.md",
+    "agentissue-bench-codex-cli-runner-target-handoff-v0.md",
     "agentissue-bench-codex-cli-runner-pr-ready-packet-v0.md",
 ]
 
@@ -34,17 +35,19 @@ SMOKES = [
     "agentissue-bench-codex-cli-runner-first-run-handoff-smoke.py",
     "agentissue-bench-codex-cli-runner-workflow-check-smoke.py",
     "agentissue-bench-codex-cli-runner-run-gate-smoke.py",
+    "agentissue-bench-codex-cli-runner-target-handoff-smoke.py",
     "agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py",
 ]
 
 REQUIRED_PACKET_SNIPPETS = [
     "AgentIssue-Bench Codex CLI Runner PR-Ready Packet V0",
-    "contract -> flow plan -> dry-run wrapper -> synthetic staging -> execution gate -> first-run handoff -> workflow check -> run-specific gate -> PR-ready packet",
+    "contract -> flow plan -> dry-run wrapper -> synthetic staging -> execution gate -> first-run handoff -> workflow check -> run-specific gate -> target-runner handoff -> PR-ready packet",
     "--synthetic-staging-root",
     "--execution-gate-root",
     "--first-run-handoff-root",
     "--workflow-check-root",
     "--run-gate-root",
+    "--target-runner-handoff-root",
     "real_run=false",
     "submit_eligible=false",
     "leaderboard_evidence=false",
@@ -57,14 +60,17 @@ REQUIRED_SOURCE_SNIPPETS = [
     "AGENTISSUE_CODEX_CLI_RUNNER_FIRST_RUN_HANDOFF_SCHEMA_VERSION",
     "AGENTISSUE_CODEX_CLI_RUNNER_WORKFLOW_CHECK_SCHEMA_VERSION",
     "AGENTISSUE_CODEX_CLI_RUNNER_RUN_GATE_SCHEMA_VERSION",
+    "AGENTISSUE_CODEX_CLI_RUNNER_TARGET_HANDOFF_SCHEMA_VERSION",
     "materialize_agentissue_codex_cli_runner_synthetic_staging",
     "materialize_agentissue_codex_cli_runner_execution_gate",
     "materialize_agentissue_codex_cli_runner_first_run_handoff",
     "materialize_agentissue_codex_cli_runner_workflow_check",
     "materialize_agentissue_codex_cli_runner_run_gate",
+    "materialize_agentissue_codex_cli_runner_target_handoff",
     "--first-run-handoff-root",
     "--workflow-check-root",
     "--run-gate-root",
+    "--target-runner-handoff-root",
 ]
 
 FORBIDDEN_TEXT = [
@@ -133,7 +139,7 @@ def main() -> None:
     assert_public_boundary()
     print(
         "agentissue-bench-codex-cli-runner-pr-ready-packet-smoke ok "
-        "docs=9 smokes=9 real_run=False"
+        "docs=10 smokes=10 real_run=False"
     )
 
 

--- a/examples/agentissue-bench-codex-cli-runner-publication-change-set-smoke.py
+++ b/examples/agentissue-bench-codex-cli-runner-publication-change-set-smoke.py
@@ -23,6 +23,7 @@ DOCS = [
     "agentissue-bench-codex-cli-runner-first-run-handoff-v0.md",
     "agentissue-bench-codex-cli-runner-workflow-check-v0.md",
     "agentissue-bench-codex-cli-runner-run-gate-v0.md",
+    "agentissue-bench-codex-cli-runner-target-handoff-v0.md",
     "agentissue-bench-codex-cli-runner-pr-ready-packet-v0.md",
     "agentissue-bench-codex-cli-runner-publication-change-set-v0.md",
 ]
@@ -36,6 +37,7 @@ SMOKES = [
     "agentissue-bench-codex-cli-runner-first-run-handoff-smoke.py",
     "agentissue-bench-codex-cli-runner-workflow-check-smoke.py",
     "agentissue-bench-codex-cli-runner-run-gate-smoke.py",
+    "agentissue-bench-codex-cli-runner-target-handoff-smoke.py",
     "agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py",
     "agentissue-bench-codex-cli-runner-publication-change-set-smoke.py",
 ]
@@ -55,18 +57,21 @@ REQUIRED_SOURCE_SNIPPETS = [
     "AGENTISSUE_CODEX_CLI_RUNNER_FIRST_RUN_HANDOFF_SCHEMA_VERSION",
     "AGENTISSUE_CODEX_CLI_RUNNER_WORKFLOW_CHECK_SCHEMA_VERSION",
     "AGENTISSUE_CODEX_CLI_RUNNER_RUN_GATE_SCHEMA_VERSION",
+    "AGENTISSUE_CODEX_CLI_RUNNER_TARGET_HANDOFF_SCHEMA_VERSION",
     "build_agentissue_codex_cli_runner_wrapper",
     "materialize_agentissue_codex_cli_runner_synthetic_staging",
     "materialize_agentissue_codex_cli_runner_execution_gate",
     "materialize_agentissue_codex_cli_runner_first_run_handoff",
     "materialize_agentissue_codex_cli_runner_workflow_check",
     "materialize_agentissue_codex_cli_runner_run_gate",
+    "materialize_agentissue_codex_cli_runner_target_handoff",
     "agentissue-codex-runner-flow",
     "--synthetic-staging-root",
     "--execution-gate-root",
     "--first-run-handoff-root",
     "--workflow-check-root",
     "--run-gate-root",
+    "--target-runner-handoff-root",
     "read_boundary",
 ]
 
@@ -167,7 +172,7 @@ def main() -> None:
     assert_public_boundary()
     print(
         "agentissue-bench-codex-cli-runner-publication-change-set-smoke ok "
-        "docs=10 smokes=10 mixed_files_subset_documented real_run=False"
+        "docs=11 smokes=11 mixed_files_subset_documented real_run=False"
     )
 
 

--- a/examples/agentissue-bench-codex-cli-runner-target-handoff-smoke.py
+++ b/examples/agentissue-bench-codex-cli-runner-target-handoff-smoke.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Smoke-test AgentIssue-Bench Codex CLI runner target handoff packet."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from goal_harness.status import collect_status  # noqa: E402
+
+
+TOPIC_DIR = REPO_ROOT / "docs" / "research" / "long-horizon-agent-benchmarks"
+DOC = TOPIC_DIR / "agentissue-bench-codex-cli-runner-target-handoff-v0.md"
+README = TOPIC_DIR / "README.md"
+
+GOAL_ID = "agentissue-runner-target-handoff-fixture"
+BENCHMARK_ID = "agentissue-bench"
+SELECTED_TAG = "lagent_239"
+RUN_MODE = "agentissue_codex_cli_runner_target_handoff_packet"
+CLASSIFICATION = "agentissue_bench_codex_cli_runner_target_handoff_v0"
+
+REQUIRED_DOC_SNIPPETS = [
+    "AgentIssue-Bench Codex CLI Runner Target Handoff V0",
+    "--target-runner-handoff-root",
+    "target-runner-handoff.public.json",
+    "handoff_target=separate_benchmark_execution_thread",
+    "meta_heartbeat_must_not_execute=true",
+    "real_run_authorized_by_packet=false",
+    "python3 examples/agentissue-bench-codex-cli-runner-target-handoff-smoke.py",
+]
+
+FORBIDDEN_TEXT = [
+    "/" + "Users/",
+    "~/.codex",
+    ".codex/auth.json",
+    "OPENAI" + "_API_KEY",
+    "ANTHROPIC" + "_API_KEY",
+    "GOOGLE" + "_API_KEY",
+    "CODEX" + "_ACCESS_TOKEN",
+    "raw" + "_issue_body:",
+    "raw" + "_patch:",
+    "raw" + "_log:",
+    "trajectory.json",
+    "screenshot.png",
+]
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_fixture(root: Path) -> tuple[Path, Path, Path]:
+    project = root / "project"
+    runtime = root / "runtime"
+    handoff_root = root / "private-target-handoff-root"
+    state_file = f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    registry_path = project / ".goal-harness" / "registry.json"
+
+    (project / Path(state_file).parent).mkdir(parents=True, exist_ok=True)
+    (project / state_file).write_text(
+        "---\n"
+        "status: active-read-only\n"
+        "updated_at: 2026-06-13T00:00:00+00:00\n"
+        "---\n\n"
+        "# AgentIssue Runner Target Handoff Fixture\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] Build AgentIssue target-runner handoff packet.\n",
+        encoding="utf-8",
+    )
+    write_json(
+        registry_path,
+        {
+            "schema_version": 1,
+            "updated_at": "2026-06-13T00:00:00+00:00",
+            "common_runtime_root": str(runtime),
+            "goals": [
+                {
+                    "id": GOAL_ID,
+                    "domain": "goal-harness-platform",
+                    "status": "active-read-only",
+                    "state_file": state_file,
+                    "repo": str(project),
+                    "adapter": {
+                        "kind": "harness_self_improvement",
+                        "status": "connected-read-only",
+                    },
+                    "heartbeat": {"enabled": True},
+                }
+            ],
+        },
+    )
+    return registry_path, runtime, handoff_root
+
+
+def run_cli(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "goal_harness.cli", *args],
+        cwd=REPO_ROOT,
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def run_cli_json(args: list[str]) -> dict[str, Any]:
+    result = run_cli(args)
+    payload = json.loads(result.stdout)
+    assert isinstance(payload, dict), payload
+    return payload
+
+
+def common_args(registry_path: Path, runtime: Path, handoff_root: Path) -> list[str]:
+    return [
+        "--registry",
+        str(registry_path),
+        "--runtime-root",
+        str(runtime),
+        "--format",
+        "json",
+        "benchmark",
+        "agentissue-codex-runner-flow",
+        "--goal-id",
+        GOAL_ID,
+        "--tag",
+        SELECTED_TAG,
+        "--target-runner-handoff-root",
+        str(handoff_root),
+        "--no-global-sync",
+    ]
+
+
+def assert_no_forbidden_text(payload: dict[str, Any]) -> None:
+    text = json.dumps(payload, sort_keys=True)
+    leaked = [marker for marker in FORBIDDEN_TEXT if marker in text]
+    assert not leaked, leaked
+    assert len(text) < 110000, len(text)
+
+
+def assert_doc_contract() -> None:
+    text = DOC.read_text(encoding="utf-8")
+    readme = README.read_text(encoding="utf-8")
+    missing = [snippet for snippet in REQUIRED_DOC_SNIPPETS if snippet not in text]
+    assert not missing, missing
+    assert "agentissue-bench-codex-cli-runner-target-handoff-v0.md" in readme, readme
+    leaked = [marker for marker in FORBIDDEN_TEXT if marker in text]
+    assert not leaked, leaked
+
+
+def assert_handoff_files(handoff_root: Path) -> None:
+    expected_paths = [
+        "context/prompt.md",
+        "buggy-source/.gitkeep",
+        "Patches/lagent_239/.gitkeep",
+        "runner-flow-plan.public.json",
+        "execution-gate.public.json",
+        "first-run-handoff.public.json",
+        "first-run-handoff.md",
+        "workflow-check.public.json",
+        "run-specific-gate.public.json",
+        "run-specific-gate.md",
+        "target-runner-handoff.public.json",
+        "target-runner-handoff.md",
+        "benchmark_run.compact.json",
+    ]
+    missing = [rel for rel in expected_paths if not (handoff_root / rel).exists()]
+    assert not missing, missing
+
+    handoff = json.loads(
+        (handoff_root / "target-runner-handoff.public.json").read_text(encoding="utf-8")
+    )
+    assert handoff["schema_version"] == CLASSIFICATION, handoff
+    assert handoff["path_recorded"] is False, handoff
+    assert handoff["handoff_target"] == "separate_benchmark_execution_thread", handoff
+    assert handoff["meta_heartbeat_must_not_execute"] is True, handoff
+    assert handoff["real_run_authorized_by_packet"] is False, handoff
+    assert handoff["ready_for_real_run"] is False, handoff
+    assert handoff["credential_boundary"]["host_codex_auth_local_only"] is True, handoff
+    assert handoff["credential_boundary"]["shared_remote_host_receives_codex_auth"] is False, handoff
+    assert handoff["public_output_contract"]["raw_logs_public"] is False, handoff
+    assert handoff["execution_boundary"]["codex_cli_invoked"] is False, handoff
+    assert handoff["execution_boundary"]["docker_container_started"] is False, handoff
+    assert handoff["execution_boundary"]["target_runner_executed"] is False, handoff
+    assert "do_not_execute_in_meta_heartbeat_thread" in handoff["stop_conditions"], handoff
+    for required in [
+        "private_job_root_selected",
+        "operator_explicit_real_run_trigger",
+        "selected_container_source_extracted",
+        "private_git_baseline_created_before_codex",
+        "host_codex_exec_ephemeral_from_buggy_source",
+        "attempt_patch_reducer_configured",
+        "selected_tag_eval_no_upload_submit_ranking",
+        "compact_public_reducer_enabled",
+        "host_codex_auth_local_only",
+    ]:
+        assert required in handoff["target_runner_prerequisites"], (required, handoff)
+
+    local_run = json.loads((handoff_root / "benchmark_run.compact.json").read_text(encoding="utf-8"))
+    assert local_run["schema_version"] == "benchmark_run_v0", local_run
+    assert local_run["mode"] == RUN_MODE, local_run
+    assert local_run["validation"]["target_runner_handoff_materialized"] is True, local_run
+    assert local_run["validation"]["meta_heartbeat_must_not_execute"] is True, local_run
+    assert local_run["validation"]["target_runner_executed"] is False, local_run
+    assert local_run["first_blocker"] == "target_handoff_packet_only_no_meta_execution", local_run
+
+
+def assert_payload(payload: dict[str, Any], *, appended: bool) -> None:
+    assert payload["ok"] is True, payload
+    assert payload["appended"] is appended, payload
+    assert payload["dry_run"] is (not appended), payload
+    assert payload["classification"] == CLASSIFICATION, payload
+
+    cli = payload["benchmark_cli"]
+    assert cli["benchmark"] == BENCHMARK_ID, cli
+    assert cli["command"] == "agentissue-codex-runner-flow", cli
+    assert cli["tag"] == SELECTED_TAG, cli
+    assert cli["target_handoff_materialized"] is True, cli
+    assert cli["target_handoff_root_path_recorded"] is False, cli
+    assert cli["real_runner_invoked"] is False, cli
+    assert cli["real_codex_invoked"] is False, cli
+    assert cli["real_docker_invoked"] is False, cli
+    assert cli["auth_values_read"] is False, cli
+    assert cli["submit_eligible"] is False, cli
+    assert cli["leaderboard_evidence"] is False, cli
+
+    handoff = payload["agentissue_target_handoff"]
+    assert handoff["schema_version"] == CLASSIFICATION, handoff
+    assert handoff["handoff_target"] == "separate_benchmark_execution_thread", handoff
+    assert handoff["ready_for_real_run"] is False, handoff
+    assert handoff["real_run_authorized_by_packet"] is False, handoff
+    assert "target-runner-handoff.public.json" in handoff["created_relative_paths"], handoff
+    assert handoff["execution_boundary"]["codex_cli_invoked"] is False, handoff
+
+    event = payload["benchmark_run"]
+    assert event["schema_version"] == "benchmark_run_v0", event
+    assert event["benchmark_id"] == BENCHMARK_ID, event
+    assert event["mode"] == RUN_MODE, event
+    assert event["first_blocker"] == "target_handoff_packet_only_no_meta_execution", event
+    assert event["real_run"] is False, event
+    assert event["submit_eligible"] is False, event
+    assert event["leaderboard_evidence"] is False, event
+    assert "target-runner-handoff.public.json" in event["evidence_files"], event
+    assert_no_forbidden_text(handoff)
+    assert_no_forbidden_text(event)
+    assert_no_forbidden_text(cli)
+
+
+def assert_status_projection(registry_path: Path, runtime: Path) -> None:
+    status = collect_status(
+        registry_path=registry_path,
+        runtime_root_override=str(runtime),
+        scan_roots=[],
+        limit=5,
+    )
+    assert status["ok"], status
+    latest = status["run_history"]["goals"][0]["latest_runs"][0]
+    summary = latest["benchmark_run_summary"]
+    assert summary["mode"] == RUN_MODE, summary
+    assert summary["benchmark_id"] == BENCHMARK_ID, summary
+    assert summary["first_blocker"] == "target_handoff_packet_only_no_meta_execution", summary
+    assert_no_forbidden_text(summary)
+
+
+def assert_roots_are_mutually_exclusive(
+    registry_path: Path, runtime: Path, handoff_root: Path
+) -> None:
+    args = common_args(registry_path, runtime, handoff_root) + [
+        "--run-gate-root",
+        str(handoff_root / "other-root"),
+    ]
+    result = run_cli(args, check=False)
+    assert result.returncode == 1, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False, payload
+    assert "at most one" in payload["error"], payload
+
+
+def main() -> None:
+    assert_doc_contract()
+    with tempfile.TemporaryDirectory(prefix="agentissue-runner-target-handoff-") as tmp:
+        registry_path, runtime, handoff_root = write_fixture(Path(tmp))
+        dry_payload = run_cli_json(common_args(registry_path, runtime, handoff_root))
+        assert_payload(dry_payload, appended=False)
+        assert_handoff_files(handoff_root)
+
+        execute_payload = run_cli_json(
+            common_args(registry_path, runtime, handoff_root)
+            + [
+                "--delivery-batch-scale",
+                "multi_surface",
+                "--delivery-outcome",
+                "outcome_progress",
+                "--execute",
+            ]
+        )
+        assert_payload(execute_payload, appended=True)
+        assert_handoff_files(handoff_root)
+        assert_status_projection(registry_path, runtime)
+        assert_roots_are_mutually_exclusive(registry_path, runtime, handoff_root / "mutual")
+
+    print(
+        "agentissue-bench-codex-cli-runner-target-handoff-smoke ok "
+        f"mode={RUN_MODE} appended=True real_run=False"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/goal_harness/benchmark.py
+++ b/goal_harness/benchmark.py
@@ -228,6 +228,12 @@ AGENTISSUE_CODEX_CLI_RUNNER_RUN_GATE_SCHEMA_VERSION = (
 AGENTISSUE_CODEX_CLI_RUNNER_RUN_GATE_MODE = (
     "agentissue_codex_cli_runner_run_gate_packet"
 )
+AGENTISSUE_CODEX_CLI_RUNNER_TARGET_HANDOFF_SCHEMA_VERSION = (
+    "agentissue_bench_codex_cli_runner_target_handoff_v0"
+)
+AGENTISSUE_CODEX_CLI_RUNNER_TARGET_HANDOFF_MODE = (
+    "agentissue_codex_cli_runner_target_handoff_packet"
+)
 AGENTISSUE_CODEX_CLI_RUNNER_SOURCE_RUNNER = (
     "goal_harness_agentissue_codex_cli_runner"
 )
@@ -1700,6 +1706,276 @@ def materialize_agentissue_codex_cli_runner_run_gate(
         "recommended_next_action": (
             "review run-specific gate packet before any later real no-upload "
             "AgentIssue-Bench lagent_239 Docker/Codex execution"
+        ),
+    }
+
+def materialize_agentissue_codex_cli_runner_target_handoff(
+    target_handoff_root: str | Path,
+    *,
+    selected_tag: str = AGENTISSUE_DEFAULT_TAG,
+    codex_binary: str = "codex",
+    docker_binary: str = "docker",
+) -> dict[str, Any]:
+    """Create a no-execute target-runner handoff packet for AgentIssue lagent_239."""
+
+    tag = _agentissue_public_label(selected_tag)
+    if tag != AGENTISSUE_DEFAULT_TAG:
+        raise ValueError(
+            "agentissue Codex runner target handoff currently only supports selected tag lagent_239"
+        )
+    root = Path(target_handoff_root).expanduser()
+    run_gate = materialize_agentissue_codex_cli_runner_run_gate(
+        root,
+        selected_tag=tag,
+        codex_binary=codex_binary,
+        docker_binary=docker_binary,
+    )
+    run_gate_path = root / "run-specific-gate.public.json"
+    target_handoff_path = root / "target-runner-handoff.public.json"
+    target_handoff_markdown_path = root / "target-runner-handoff.md"
+    compact_run_path = root / "benchmark_run.compact.json"
+
+    run_gate_public = json.loads(run_gate_path.read_text(encoding="utf-8"))
+    command_sources = run_gate_public["rendered_command_sources"]
+    gate_item_ids = [
+        item["id"] for item in run_gate_public["owner_agent_gate_items"]
+    ]
+    required_before_execution = [
+        "private_job_root_selected",
+        "operator_explicit_real_run_trigger",
+        "selected_container_source_extracted",
+        "private_git_baseline_created_before_codex",
+        "host_codex_exec_ephemeral_from_buggy_source",
+        "attempt_patch_reducer_configured",
+        "selected_tag_eval_no_upload_submit_ranking",
+        "compact_public_reducer_enabled",
+        "host_codex_auth_local_only",
+    ]
+    missing_from_gate = [
+        gate_id for gate_id in required_before_execution if gate_id not in gate_item_ids
+    ]
+    no_execute_boundary = {
+        **run_gate_public["execution_boundary"],
+        "target_thread_started": False,
+        "target_runner_executed": False,
+        "benchmark_execution_authorized_by_packet": False,
+    }
+    target_handoff = {
+        "schema_version": AGENTISSUE_CODEX_CLI_RUNNER_TARGET_HANDOFF_SCHEMA_VERSION,
+        "benchmark_id": AGENTISSUE_BENCHMARK_ID,
+        "selected_tag": tag,
+        "selected_image": AGENTISSUE_DEFAULT_IMAGE,
+        "default_mode": "no_execute",
+        "materialized": True,
+        "path_recorded": False,
+        "target_handoff_root_path_recorded": False,
+        "handoff_target": "separate_benchmark_execution_thread",
+        "meta_heartbeat_must_not_execute": True,
+        "real_run_authorized_by_packet": False,
+        "ready_for_real_run": False,
+        "ready_for_separate_execution_thread_after_gate_satisfied": (
+            not missing_from_gate
+        ),
+        "source_packets": {
+            "runner_plan": "runner-flow-plan.public.json",
+            "execution_gate": "execution-gate.public.json",
+            "first_run_handoff": "first-run-handoff.public.json",
+            "workflow_check": "workflow-check.public.json",
+            "run_gate": "run-specific-gate.public.json",
+        },
+        "target_runner_prerequisites": required_before_execution,
+        "missing_from_run_gate": missing_from_gate,
+        "execution_thread_checklist": [
+            {
+                "phase": "select_private_job_root",
+                "required": True,
+                "public_packet_only": False,
+                "private_state_allowed_in_execution_thread": True,
+                "meta_thread_must_not_run": True,
+            },
+            {
+                "phase": "extract_selected_container_buggy_source",
+                "required": True,
+                "command_shape_source": "run-specific-gate.public.json:rendered_command_sources.source_extraction_gate",
+                "commands": command_sources["source_extraction_gate"],
+            },
+            {
+                "phase": "create_private_git_baseline",
+                "required": True,
+                "command_shape_source": "run-specific-gate.public.json:rendered_command_sources.private_git_baseline_gate",
+                "commands": command_sources["private_git_baseline_gate"],
+            },
+            {
+                "phase": "run_host_codex_exec_ephemeral_from_buggy_source",
+                "required": True,
+                "command_shape_source": "run-specific-gate.public.json:rendered_command_sources.host_codex_gate",
+                "command": command_sources["host_codex_gate"],
+                "auth_boundary": "host_local_only_no_auth_sync",
+            },
+            {
+                "phase": "export_attempt_patch_from_buggy_source_git_diff",
+                "required": True,
+                "command_shape_source": "run-specific-gate.public.json:rendered_command_sources.patch_output_gate",
+                "output_relative_path": AGENTISSUE_PATCH_RELATIVE_PATH,
+                "patch_content_public": False,
+            },
+            {
+                "phase": "run_selected_tag_eval_no_upload_submit_ranking",
+                "required": True,
+                "command_shape_source": "run-specific-gate.public.json:rendered_command_sources.eval_gate",
+                "upload": False,
+                "submit": False,
+                "public_ranking_path": False,
+            },
+            {
+                "phase": "reduce_to_compact_public_result",
+                "required": True,
+                "public_outputs": [
+                    "benchmark_run.compact.json",
+                    "target-runner-handoff.public.json",
+                ],
+                "private_outputs_not_public": [
+                    AGENTISSUE_PATCH_RELATIVE_PATH,
+                    "raw logs",
+                    "task material",
+                    "model transcript",
+                    "screenshots",
+                    "credentials",
+                ],
+            },
+        ],
+        "public_output_contract": {
+            "allowed_public_relative_files": [
+                "target-runner-handoff.public.json",
+                "target-runner-handoff.md",
+                *run_gate_public["public_artifact_policy"][
+                    "allowed_public_relative_files"
+                ],
+            ],
+            "raw_task_material_public": False,
+            "patch_content_public": False,
+            "raw_logs_public": False,
+            "trajectories_public": False,
+            "screenshots_public": False,
+            "absolute_paths_public": False,
+            "credential_values_public": False,
+        },
+        "credential_boundary": {
+            "codex_auth_values_read_by_packet": False,
+            "codex_home_synced": False,
+            "shared_remote_host_receives_codex_auth": False,
+            "host_codex_auth_local_only": True,
+        },
+        "execution_boundary": no_execute_boundary,
+        "stop_conditions": [
+            "do_not_execute_in_meta_heartbeat_thread",
+            *run_gate_public["stop_conditions"],
+            "public_handoff_contains_raw_task_patch_log_transcript_screenshot_auth_or_absolute_path",
+        ],
+    }
+    markdown = (
+        "# AgentIssue-Bench lagent_239 Target-Runner Handoff\n\n"
+        "This packet is no-execute. It is a compact public handoff for a "
+        "separate benchmark execution thread, not permission for the meta "
+        "heartbeat thread to run the benchmark.\n\n"
+        "## Target\n\n"
+        "- handoff target: separate benchmark execution thread\n"
+        "- meta heartbeat must not execute Codex, Docker, model APIs, source "
+        "extraction, patch generation, eval, upload, submit, or ranking paths\n"
+        "- real_run_authorized_by_packet=false\n\n"
+        "## Required Gates\n\n"
+        + "\n".join(f"- {gate_id}" for gate_id in required_before_execution)
+        + "\n\n## Public Outputs\n\n"
+        "- benchmark_run.compact.json\n"
+        "- run-specific-gate.public.json\n"
+        "- target-runner-handoff.public.json\n"
+        "- target-runner-handoff.md\n\n"
+        "Private execution artifacts stay private and must be reduced before "
+        "any public writeback.\n"
+    )
+
+    benchmark_run = json.loads(json.dumps(run_gate["benchmark_run"]))
+    benchmark_run.update(
+        {
+            "job_name": "agentissue_lagent_239_codex_cli_runner_target_handoff",
+            "mode": AGENTISSUE_CODEX_CLI_RUNNER_TARGET_HANDOFF_MODE,
+            "worker_mode": "trusted_host_codex_cli_no_execute_target_handoff",
+            "first_blocker": "target_handoff_packet_only_no_meta_execution",
+            "score_failure_attribution": "not_run_target_handoff_only",
+            "failure_attribution_labels": [
+                "target_runner_handoff_packet_only",
+                "ready_for_separate_execution_thread_after_gate_satisfied",
+            ],
+            "evidence_files": target_handoff["public_output_contract"][
+                "allowed_public_relative_files"
+            ],
+        }
+    )
+    benchmark_run["validation"].update(
+        {
+            "target_runner_handoff_materialized": True,
+            "handoff_target_declared": True,
+            "meta_heartbeat_must_not_execute": True,
+            "target_runner_prerequisites_declared": True,
+            "real_run_authorized_by_packet": False,
+            "target_thread_started": False,
+            "target_runner_executed": False,
+            "no_upload_submit_or_public_ranking": True,
+            "no_auth_sync_to_shared_host": True,
+            "public_output_contract_declared": True,
+            "ready_for_separate_execution_thread_after_gate_satisfied": (
+                not missing_from_gate
+            ),
+        }
+    )
+    for trial in benchmark_run.get("trials") or []:
+        if isinstance(trial, dict):
+            trial["exception_type"] = "target_handoff_packet_only_no_real_case"
+
+    target_handoff_path.write_text(
+        json.dumps(target_handoff, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    target_handoff_markdown_path.write_text(markdown, encoding="utf-8")
+    compact_run_path.write_text(
+        json.dumps(benchmark_run, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return {
+        "schema_version": AGENTISSUE_CODEX_CLI_RUNNER_TARGET_HANDOFF_SCHEMA_VERSION,
+        "benchmark_id": AGENTISSUE_BENCHMARK_ID,
+        "selected_tag": tag,
+        "selected_image": AGENTISSUE_DEFAULT_IMAGE,
+        "handoff_target": "separate_benchmark_execution_thread",
+        "ready_for_real_run": False,
+        "ready_for_separate_execution_thread_after_gate_satisfied": (
+            not missing_from_gate
+        ),
+        "materialized": True,
+        "path_recorded": False,
+        "target_handoff_root_path_recorded": False,
+        "real_run_authorized_by_packet": False,
+        "run_gate": {
+            "schema_version": run_gate["schema_version"],
+            "ready_for_operator_review": run_gate["ready_for_operator_review"],
+            "ready_for_real_run": run_gate["ready_for_real_run"],
+            "run_gate_relative_path": run_gate["run_gate_relative_path"],
+            "path_recorded": False,
+        },
+        "created_relative_paths": [
+            *run_gate["created_relative_paths"],
+            "target-runner-handoff.public.json",
+            "target-runner-handoff.md",
+        ],
+        "target_handoff_relative_path": "target-runner-handoff.public.json",
+        "target_handoff_markdown_relative_path": "target-runner-handoff.md",
+        "compact_run_relative_path": "benchmark_run.compact.json",
+        "execution_boundary": target_handoff["execution_boundary"],
+        "target_runner_prerequisites": required_before_execution,
+        "benchmark_run": benchmark_run,
+        "recommended_next_action": (
+            "hand off target-runner packet to a separate benchmark execution "
+            "thread; keep meta heartbeat no-execute/no-upload"
         ),
     }
 

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -24,6 +24,7 @@ from .benchmark import (
     AGENTISSUE_CODEX_CLI_RUNNER_FIRST_RUN_HANDOFF_SCHEMA_VERSION,
     AGENTISSUE_CODEX_CLI_RUNNER_RUN_GATE_SCHEMA_VERSION,
     AGENTISSUE_CODEX_CLI_RUNNER_SYNTHETIC_STAGING_SCHEMA_VERSION,
+    AGENTISSUE_CODEX_CLI_RUNNER_TARGET_HANDOFF_SCHEMA_VERSION,
     AGENTISSUE_CODEX_CLI_RUNNER_WORKFLOW_CHECK_SCHEMA_VERSION,
     AGENTISSUE_CODEX_CLI_RUNNER_WRAPPER_SCHEMA_VERSION,
     AGENTISSUE_DEFAULT_TAG,
@@ -32,6 +33,7 @@ from .benchmark import (
     materialize_agentissue_codex_cli_runner_first_run_handoff,
     materialize_agentissue_codex_cli_runner_run_gate,
     materialize_agentissue_codex_cli_runner_synthetic_staging,
+    materialize_agentissue_codex_cli_runner_target_handoff,
     materialize_agentissue_codex_cli_runner_workflow_check,
     TERMINAL_BENCH_DEFAULT_DATASET,
     TERMINAL_BENCH_DEFAULT_MODEL,
@@ -1353,6 +1355,15 @@ def main(argv: list[str] | None = None) -> int:
             "model APIs, upload, submit, or real task material."
         ),
     )
+    agentissue_runner_flow_parser.add_argument(
+        "--target-runner-handoff-root",
+        help=(
+            "Materialize a no-execute target-runner handoff packet at PATH. It "
+            "includes the run-specific gate plus a compact checklist for a "
+            "separate benchmark execution thread without running Codex, Docker, "
+            "model APIs, upload, submit, ranking paths, or real task material."
+        ),
+    )
     agentissue_runner_flow_parser.add_argument("--classification")
     agentissue_runner_flow_parser.add_argument("--recommended-action")
     agentissue_runner_flow_parser.add_argument(
@@ -2312,21 +2323,25 @@ def main(argv: list[str] | None = None) -> int:
             classification = (
                 args.classification
                 or (
-                    AGENTISSUE_CODEX_CLI_RUNNER_WORKFLOW_CHECK_SCHEMA_VERSION
-                    if args.workflow_check_root
+                    AGENTISSUE_CODEX_CLI_RUNNER_TARGET_HANDOFF_SCHEMA_VERSION
+                    if args.target_runner_handoff_root
                     else (
-                        AGENTISSUE_CODEX_CLI_RUNNER_RUN_GATE_SCHEMA_VERSION
-                        if args.run_gate_root
+                        AGENTISSUE_CODEX_CLI_RUNNER_WORKFLOW_CHECK_SCHEMA_VERSION
+                        if args.workflow_check_root
                         else (
-                            AGENTISSUE_CODEX_CLI_RUNNER_FIRST_RUN_HANDOFF_SCHEMA_VERSION
-                            if args.first_run_handoff_root
+                            AGENTISSUE_CODEX_CLI_RUNNER_RUN_GATE_SCHEMA_VERSION
+                            if args.run_gate_root
                             else (
-                                AGENTISSUE_CODEX_CLI_RUNNER_EXECUTION_GATE_SCHEMA_VERSION
-                                if args.execution_gate_root
+                                AGENTISSUE_CODEX_CLI_RUNNER_FIRST_RUN_HANDOFF_SCHEMA_VERSION
+                                if args.first_run_handoff_root
                                 else (
-                                    AGENTISSUE_CODEX_CLI_RUNNER_SYNTHETIC_STAGING_SCHEMA_VERSION
-                                    if args.synthetic_staging_root
-                                    else AGENTISSUE_CODEX_CLI_RUNNER_WRAPPER_SCHEMA_VERSION
+                                    AGENTISSUE_CODEX_CLI_RUNNER_EXECUTION_GATE_SCHEMA_VERSION
+                                    if args.execution_gate_root
+                                    else (
+                                        AGENTISSUE_CODEX_CLI_RUNNER_SYNTHETIC_STAGING_SCHEMA_VERSION
+                                        if args.synthetic_staging_root
+                                        else AGENTISSUE_CODEX_CLI_RUNNER_WRAPPER_SCHEMA_VERSION
+                                    )
                                 )
                             )
                         )
@@ -2346,12 +2361,13 @@ def main(argv: list[str] | None = None) -> int:
                         args.first_run_handoff_root,
                         args.workflow_check_root,
                         args.run_gate_root,
+                        args.target_runner_handoff_root,
                     )
                     if value
                 ]
                 if len(selected_roots) > 1:
                     raise ValueError(
-                        "agentissue-codex-runner-flow accepts at most one root option, not both: --synthetic-staging-root, --execution-gate-root, --first-run-handoff-root, --workflow-check-root, or --run-gate-root"
+                        "agentissue-codex-runner-flow accepts at most one root option, not both: --synthetic-staging-root, --execution-gate-root, --first-run-handoff-root, --workflow-check-root, --run-gate-root, or --target-runner-handoff-root"
                     )
                 wrapper = build_agentissue_codex_cli_runner_wrapper(
                     selected_tag=args.tag,
@@ -2363,8 +2379,17 @@ def main(argv: list[str] | None = None) -> int:
                 first_run_handoff = None
                 workflow_check = None
                 run_gate = None
+                target_handoff = None
                 benchmark_run_source = wrapper["benchmark_run"]
-                if args.run_gate_root:
+                if args.target_runner_handoff_root:
+                    target_handoff = materialize_agentissue_codex_cli_runner_target_handoff(
+                        args.target_runner_handoff_root,
+                        selected_tag=args.tag,
+                        codex_binary=args.codex_binary,
+                        docker_binary=args.docker_binary,
+                    )
+                    benchmark_run_source = target_handoff["benchmark_run"]
+                elif args.run_gate_root:
                     run_gate = materialize_agentissue_codex_cli_runner_run_gate(
                         args.run_gate_root,
                         selected_tag=args.tag,
@@ -2422,21 +2447,25 @@ def main(argv: list[str] | None = None) -> int:
                     classification=classification,
                     recommended_action=args.recommended_action
                     or (
-                        run_gate["recommended_next_action"]
-                        if run_gate
+                        target_handoff["recommended_next_action"]
+                        if target_handoff
                         else (
-                            workflow_check["recommended_next_action"]
-                            if workflow_check
+                            run_gate["recommended_next_action"]
+                            if run_gate
                             else (
-                                first_run_handoff["recommended_next_action"]
-                                if first_run_handoff
+                                workflow_check["recommended_next_action"]
+                                if workflow_check
                                 else (
-                                    execution_gate["recommended_next_action"]
-                                    if execution_gate
+                                    first_run_handoff["recommended_next_action"]
+                                    if first_run_handoff
                                     else (
-                                        synthetic_staging["recommended_next_action"]
-                                        if synthetic_staging
-                                        else wrapper["recommended_next_action"]
+                                        execution_gate["recommended_next_action"]
+                                        if execution_gate
+                                        else (
+                                            synthetic_staging["recommended_next_action"]
+                                            if synthetic_staging
+                                            else wrapper["recommended_next_action"]
+                                        )
                                     )
                                 )
                             )
@@ -2468,6 +2497,8 @@ def main(argv: list[str] | None = None) -> int:
                     "workflow_check_root_path_recorded": False,
                     "run_gate_materialized": bool(run_gate),
                     "run_gate_root_path_recorded": False,
+                    "target_handoff_materialized": bool(target_handoff),
+                    "target_handoff_root_path_recorded": False,
                 }
                 payload["agentissue_runner_flow"] = wrapper
                 if synthetic_staging:
@@ -2480,6 +2511,8 @@ def main(argv: list[str] | None = None) -> int:
                     payload["agentissue_workflow_check"] = workflow_check
                 if run_gate:
                     payload["agentissue_run_gate"] = run_gate
+                if target_handoff:
+                    payload["agentissue_target_handoff"] = target_handoff
                 if args.no_global_sync:
                     payload["global_sync"] = {
                         "ok": True,


### PR DESCRIPTION
## Summary
- add a no-execute AgentIssue target-runner handoff materializer and CLI option `--target-runner-handoff-root`
- document the target handoff packet and fold it into PR-ready/publication packets
- add a target-handoff smoke and update aggregate smokes to require the new surface

## Validation
- `python3 -m py_compile goal_harness/benchmark.py goal_harness/cli.py goal_harness/status.py examples/agentissue-bench-codex-cli-runner-*.py`
- full 11-script AgentIssue runner-flow smoke chain through `agentissue-bench-codex-cli-runner-publication-change-set-smoke.py`
- `python3 -m goal_harness.cli check --scan-path ...` over changed public surfaces
- `git diff --check` and `git diff --cached --check`

No Codex, Docker, model API, upload, submit, public ranking path, or real task material is executed by this packet.