### PR TITLE
Document low-risk PR self-merge policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,20 @@ adapters, smoke tests, public docs, or commit/push workflows, use the
    mixed commits directly to `main`, unless the user explicitly asks for a
    direct `main` push.
 
+For small, low-risk PRs, maintainers may self-merge after validation when all
+of the following are true:
+
+- the PR only touches public docs, contributor metadata, or narrow cleanup;
+- the change is single-purpose and easy to review from the diff;
+- required checks or focused smokes have passed;
+- private state, raw benchmark evidence, credentials, local paths, and
+  generated logs are excluded;
+- there is no runtime behavior, benchmark adapter, permission, destructive git,
+  or public evidence-policy change that needs separate review.
+
+After self-merging, sync local `main`, leave unrelated untracked local artifacts
+alone, and continue with the next safe project batch.
+
 ## Smoke Retention Policy
 
 Keep a smoke test only when it validates a durable public behavior:


### PR DESCRIPTION
## Summary
- document when small low-risk PRs can be self-merged after validation
- define boundaries where runtime, benchmark adapter, permission, destructive git, or public evidence-policy changes still need review
- require syncing local main and leaving unrelated local artifacts alone after self-merge

## Validation
- goal-harness check --scan-path AGENTS.md
- git diff --check -- AGENTS.md
- public/private marker scan of AGENTS.md