### PR TITLE
Add WildClawBench benchmark route dossier

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/README.md
+++ b/docs/research/long-horizon-agent-benchmarks/README.md
@@ -35,6 +35,11 @@ work still belongs in the existing code, examples, and contract documents:
   records the upstream Mainland-China/GCP issue, and ranks SWE-Marathon,
   AgentIssue-Bench, PerfBench, SWE-Bench Pro, MLE-bench, TheAgentCompany, and
   APEX-Agents by Goal Harness leverage before any fresh quota spend.
+- `wildclawbench-dossier-20260617.md`: public-safe no-run WildClawBench route
+  dossier. It records why harness comparison and side-effect auditing are a
+  stronger next Goal Harness hypothesis source than another same-policy
+  SkillsBench rerun, while blocking any official run until setup-readiness
+  proves a local no-upload slice without unauthorized API/search/judge calls.
 - `benchmark-priority-review-20260614.md`: corrected priority review using
   Codex CLI goal mode as the baseline. It separates direct low Codex baselines,
   selected hard-subset failures, and adjacent-agent-low benchmarks that still

--- a/docs/research/long-horizon-agent-benchmarks/wildclawbench-dossier-20260617.md
+++ b/docs/research/long-horizon-agent-benchmarks/wildclawbench-dossier-20260617.md
@@ -1,0 +1,120 @@
+# WildClawBench Dossier 2026-06-17
+
+Checked at: 2026-06-17T01:18:00+08:00.
+
+This is a public-safe route dossier only. It does not run WildClawBench,
+OpenClaw, Codex, Docker, model APIs, search APIs, judge models, uploads,
+leaderboard submissions, hidden refs, raw task data, raw trajectories, logs,
+screenshots, credentials, or private artifacts.
+
+## Source Boundary
+
+Public sources consulted:
+
+- official repository: https://github.com/internlm/WildClawBench
+- project site / leaderboard: https://internlm.github.io/WildClawBench/
+- paper HTML: https://arxiv.org/html/2605.10912v1
+- paper abstract: https://arxiv.org/abs/2605.10912
+
+## What It Is
+
+WildClawBench is a native-runtime benchmark for long-horizon CLI agents. The
+released benchmark describes 60 human-authored bilingual tasks across six
+categories, with 26 multimodal tasks. The paper reports that tasks average
+roughly 8 minutes and more than 20 tool calls per run.
+
+The benchmark is unusually relevant to Goal Harness because it evaluates the
+same task suite across multiple agent harnesses: OpenClaw, Claude Code, Codex,
+and Hermes Agent. The public leaderboard also exposes a harness-comparison
+table for the same model across those harnesses.
+
+## Why It Matches Goal Harness
+
+WildClawBench tests three things Goal Harness cares about more directly than
+another same-policy SkillsBench rerun:
+
+1. Harness effects are first-class. The paper reports that switching harness
+   alone can shift a model by up to 18 points, and the site publishes per-model
+   harness comparison rows.
+2. Side effects are part of scoring. The grading stack combines deterministic
+   checks, environment-state auditing of actions and side effects, and LLM/VLM
+   judging only where semantic checks need it.
+3. The runtime is close to real agent work. Tasks run in Docker containers with
+   real tools such as shell, browser, file system, email, calendar, and
+   optional skills rather than mock APIs.
+
+This makes WildClawBench a better next hypothesis source for Goal Harness than
+continuing to mine already-classified SkillsBench controls. SkillsBench is
+still useful for prompt/round-policy regressions, but the current queue already
+has baseline-solved, neutral, positive-control, regression, and setup-blocker
+cases. WildClawBench more directly asks whether the control layer around an
+agent changes work completion, side effects, cost, and traceability.
+
+## Baseline Failure Class To Look For
+
+The useful failure class is not simply "agent gets task wrong." The Goal
+Harness-specific target is:
+
+- same model, comparable task, different harness or control layer;
+- final score differs, or side-effect auditing differs;
+- trace evidence shows stale state, weak recovery, premature stop, unsafe side
+  effect, missing artifact, or poor validation discipline;
+- Goal Harness can plausibly help through state truth, todo/replan structure,
+  compact evidence, permission gates, or restartable execution.
+
+Good first cases would be tasks where a baseline agent exits early, performs
+the wrong side effect, misses an audit requirement, or produces plausible
+output without the required artifact/state change.
+
+## No-Upload Feasibility
+
+WildClawBench is not immediately eligible for a no-upload autonomous official
+run under the current Goal Harness standing policy.
+
+Reasons:
+
+- official run examples require model API access through OpenRouter-style
+  endpoints;
+- search tasks require a Brave Search API key;
+- judge-based metrics may call a judge model;
+- data preparation may download external assets, including YouTube videos and
+  SAM3 weights;
+- official leaderboard or personal leaderboard submission paths exist and must
+  stay out of autonomous execution.
+
+Safe near-term work is therefore source/readiness only:
+
+1. pin the repository and paper version;
+2. inspect task metadata and runner scripts without task execution;
+3. identify a tiny subset that does not require search, YouTube, or judge-model
+   calls;
+4. define a compact reducer schema for harness comparison, side-effect audits,
+   cost/time, and trace category counters;
+5. stop before Docker task execution, model calls, uploads, or public claims.
+
+## Recommendation
+
+Use WildClawBench as the next benchmark route dossier, not as the next scored
+run.
+
+Recommended next step:
+
+- write a no-run setup-readiness scan for the official repository, focusing on
+  task metadata visibility, runner command shape, required external services,
+  single-task dry-run boundaries, and compact artifact schema.
+
+Do not launch a WildClawBench run until the scan identifies a task slice that
+can run locally without uploads, leaderboard submission, hidden grader leakage,
+or unauthorized API/search/judge calls.
+
+## Current Queue Decision
+
+This dossier closes the rerank question:
+
+- do not launch the matching `suricata-custom-exfil` treatment because the
+  repaired baseline passed at official `1.0` in round 1;
+- do not keep repeating same-policy SkillsBench controls without a new prompt
+  or stop-policy hypothesis;
+- keep Terminal-Bench attribution repairs separate from this lane;
+- make the next benchmark research batch a WildClawBench setup-readiness scan.
+


### PR DESCRIPTION
## Summary
- add a public-safe no-run WildClawBench route dossier
- explain why harness comparison and side-effect auditing fit Goal Harness better than another same-policy SkillsBench rerun
- update benchmark research README with the new dossier

## Validation
- goal-harness check --scan-path docs/research/long-horizon-agent-benchmarks/wildclawbench-dossier-20260617.md --scan-path docs/research/long-horizon-agent-benchmarks/README.md
- git diff --check -- docs/research/long-horizon-agent-benchmarks/wildclawbench-dossier-20260617.md docs/research/long-horizon-agent-benchmarks/README.md
- public/private marker scan of the changed docs