### PR TITLE
Ignore local run logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ dist/
 .codex/goals/
 goals/**/ACTIVE_GOAL_STATE.md
 runtime/
+logs/


### PR DESCRIPTION
## Summary

- ignore repository-local `logs/` so raw run diagnostics stay out of normal git status and staging

## Validation

- `git check-ignore -v logs/goal-harness-worker-setup-diagnostic.json logs/skillsbench-manufacturing-codebook-normalization-baseline-20260615T2306CST.out`
- `git diff --check`

## Notes

- updated the local `$git-split-commit-pr` skill outside this repository to make the necessary slimming/refactor pass explicit before staging
