### PR TITLE
Migrate nginx case analysis to current protocol

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/benchmark-case-analysis.json
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-case-analysis.json
@@ -97,14 +97,14 @@
       }
     },
     {
-      "analysis_id": "terminal-bench-2.0__nginx-request-logging__treatment-pass-baseline-runner-blocked",
+      "analysis_id": "terminal-bench-2.0__nginx-request-logging__baseline-solved-treatment-preserved",
       "arms": {
         "baseline": {
           "arm_id": "hardened_codex_baseline",
-          "failure_class": "worker_install_failed_agent_codex_install_nvm_node",
-          "failure_scope": "runner_or_setup",
-          "run_group_id": "terminal-bench-nginx-request-logging-hardened-blind-pair-20260616T110017CST",
-          "run_id": "890f0a8487e4",
+          "failure_class": "none",
+          "failure_scope": "passed",
+          "run_group_id": "terminal-bench-nginx-request-logging-hardened-after-materialization-fix",
+          "run_id": "c9e583310242",
           "worker_bridge_status": "not_required"
         },
         "treatment": {
@@ -120,9 +120,9 @@
         }
       },
       "benchmark_id": "terminal-bench@2.0",
-      "capability_signal": "The Goal Harness treatment arm reached official 1.0 on a real Terminal-Bench case, but the paired baseline 0.0 is attributed to Codex CLI materialization in the worker before a comparable solver attempt. This is a treatment-route pass and runner-materialization lesson, not a clean pure-solver uplift claim.",
+      "capability_signal": "After hardened baseline worker materialization was repaired, the Codex baseline also reached official 1.0 while the Goal Harness treatment preserved 1.0. The current main-table signal is therefore success preservation / non-regression, not uplift.",
       "case_id": "nginx-request-logging",
-      "classification": "runner_materialization_asset",
+      "classification": "baseline_solved_non_regression_asset",
       "compact_lifecycle_analysis": {
         "baseline_case_attempt_countable": false,
         "baseline_lifecycle_stage": "worker_codex_cli_materialization_failed_before_comparable_solver_attempt",
@@ -135,14 +135,14 @@
         "treatment_lifecycle_stage": "official_verifier_passed",
         "worker_bridge_note": "The treatment had Goal Harness access packet state but no worker CLI bridge call evidence; do not treat this as in-case CLI bridge uplift evidence."
       },
-      "control_plane_signal": "The useful control-plane signal is separation of official score delta from claim eligibility. The ledger can store the 0.0 -> 1.0 pair, while case analysis keeps the baseline runner/setup blocker from becoming a false treatment-uplift narrative.",
-      "decision": "paired_baseline_runner_or_setup_repair_required",
-      "evidence_status": "compact_pair_complete_baseline_runner_setup_blocked",
+      "control_plane_signal": "The old 0.0 -> 1.0 row remains valuable as a runner-materialization warning: before the repair, a baseline setup blocker created a false-positive score delta. The current protocol now prefers the repaired comparable baseline result.",
+      "decision": "paired_baseline_solved_treatment_preserved",
+      "evidence_status": "compact_pair_complete_after_worker_materialization_repair",
       "optimization_guidance": [
-        "Materialize a usable Codex CLI on the hardened baseline worker PATH before any same-case comparable rerun.",
-        "Keep runtime_install_extended_setup as setup-materialization evidence only; do not count it as solver progress until the pre-worker Codex preflight is ok.",
-        "Keep the treatment pass as a route-canary showing the Goal Harness treatment can complete nginx-request-logging under official scoring.",
-        "Record worker CLI bridge availability separately from access-packet presence; this treatment passed without observed worker-side Goal Harness CLI calls."
+        "Do not count nginx-request-logging as current-protocol treatment uplift; the repaired hardened baseline also passes.",
+        "Keep the legacy runner-materialization asset as a guard against false uplift claims when one arm fails before comparable solver execution.",
+        "Use this case as a Terminal-Bench success-preservation guard when changing worker setup, managed route prompts, or compact closeout policy.",
+        "Continue recording worker CLI bridge availability separately from access-packet presence; the treatment pass still has zero observed worker-side Goal Harness CLI calls."
       ],
       "public_boundary": {
         "artifact_reference_policy": "refer to compact ledger ids and run groups only",
@@ -152,25 +152,22 @@
         "verifier_output_copied": false
       },
       "routing_guidance": {
-        "next_action": "materialize Codex CLI on the hardened baseline worker PATH or provide an equivalent launcher, then rerun only after a compact fail-fast preflight proves codex --version succeeds before solver start",
-        "repeat_policy": "do_not_repeat_until_codex_cli_on_worker_path_probe_passes"
+        "next_action": "keep as a current-protocol baseline-solved non-regression guard; choose another baseline-failing case for uplift mining",
+        "repeat_policy": "repeat_only_after_worker_setup_or_managed_route_policy_change"
       },
       "scores": {
-        "baseline_official_score": 0,
-        "claimable_uplift": false,
-        "official_score_delta": 1,
-        "treatment_official_score": 1
+        "baseline_official_score": 1,
+        "treatment_official_score": 1,
+        "official_score_delta": 0,
+        "claimable_uplift": false
       },
       "stability_assessment": {
-        "end_to_end_treatment_pass": "high",
+        "current_protocol_comparability": "high",
+        "current_uplift_claim": "blocked_by_repaired_baseline_success",
+        "legacy_runner_materialization_lesson": "preserved",
         "main_confounds": [
-          "baseline worker Codex CLI materialization failed before comparable solver execution",
-          "treatment worker CLI bridge was not observed, so the pass should not be attributed to active in-case Goal Harness CLI use"
-        ],
-        "pure_solver_uplift_claim": "blocked",
-        "stabilization_needed": [
-          "make the hardened baseline worker find or receive a valid Codex CLI without runtime install failure",
-          "rerun only after compact preflight proves baseline worker materialization reached ok"
+          "treatment and repaired baseline were not launched as a single simultaneous pair, but both are compact official scored no-upload runs for the same case and current route family",
+          "treatment worker Goal Harness CLI calls remain unobserved, so the pass should not be attributed to active in-case CLI use"
         ]
       },
       "worker_materialization_probe": {
@@ -193,6 +190,72 @@
         "setup_blockers": [
           "codex_cli_not_on_path"
         ]
+      },
+      "legacy_runner_materialization_asset": {
+        "decision": "paired_baseline_runner_or_setup_repair_required",
+        "evidence_status": "compact_pair_complete_baseline_runner_setup_blocked",
+        "classification": "runner_materialization_asset",
+        "scores": {
+          "baseline_official_score": 0,
+          "claimable_uplift": false,
+          "official_score_delta": 1,
+          "treatment_official_score": 1
+        },
+        "arms": {
+          "baseline": {
+            "arm_id": "hardened_codex_baseline",
+            "failure_class": "worker_install_failed_agent_codex_install_nvm_node",
+            "failure_scope": "runner_or_setup",
+            "run_group_id": "terminal-bench-nginx-request-logging-hardened-blind-pair-20260616T110017CST",
+            "run_id": "890f0a8487e4",
+            "worker_bridge_status": "not_required"
+          },
+          "treatment": {
+            "arm_id": "codex_goal_harness_treatment",
+            "failure_class": "none",
+            "failure_scope": "passed",
+            "goal_harness_inside_case": true,
+            "run_group_id": "terminal-bench-nginx-request-logging-hardened-blind-pair-20260616T110017CST",
+            "run_id": "2a6a46cfb953",
+            "worker_bridge_status": "not_required",
+            "worker_cli_bridge_available": false,
+            "worker_goal_harness_cli_call_total": 0
+          }
+        },
+        "compact_lifecycle_analysis": {
+          "baseline_case_attempt_countable": false,
+          "baseline_lifecycle_stage": "worker_codex_cli_materialization_failed_before_comparable_solver_attempt",
+          "baseline_repair_probe_case_attempt_countable": false,
+          "baseline_repair_probe_failure": "codex_cli_not_on_path",
+          "baseline_repair_probe_run_id": "51fa05316d18",
+          "claimable_uplift": false,
+          "next_comparable_baseline_requirement": "worker_path_contains_usable_codex_cli_before_solver_start",
+          "treatment_case_attempt_countable": true,
+          "treatment_lifecycle_stage": "official_verifier_passed",
+          "worker_bridge_note": "The treatment had Goal Harness access packet state but no worker CLI bridge call evidence; do not treat this as in-case CLI bridge uplift evidence."
+        },
+        "worker_materialization_probe": {
+          "arm_id": "hardened_codex_worker_materialization_probe",
+          "benchmark_budget_countable": false,
+          "case_solution_attempted": false,
+          "compact_boundary": {
+            "raw_logs_read": false,
+            "raw_task_text_read": false,
+            "trajectory_read": false,
+            "verifier_output_read": false
+          },
+          "failure_class": "codex_cli_not_on_path",
+          "failure_scope": "runner_or_setup",
+          "interpretation": "Fail-fast require_existing_codex probe proved the current hardened baseline worker path does not contain a usable Codex CLI. Do not rerun the same baseline until the worker image or launcher materializes Codex on PATH, or switch to an explicit runtime_install_extended_setup probe and classify it as setup evidence only.",
+          "official_score": 0,
+          "run_group_id": "terminal-bench-nginx-hardened-worker-materialization-probe-20260616T111726CST",
+          "run_id": "51fa05316d18",
+          "score_status": "failed",
+          "setup_blockers": [
+            "codex_cli_not_on_path"
+          ]
+        },
+        "interpretation": "Legacy hardened baseline 0.0 plus treatment 1.0 remains a runner-materialization asset: the baseline failed before a comparable solver attempt, so the old +1.0 delta is not claimable uplift."
       }
     },
     {
@@ -3011,5 +3074,5 @@
     "trajectory_recorded": false,
     "update_rule": "add one case analysis record after compact result ingest and benchmark-run-ledger update"
   },
-  "updated_at": "2026-06-17T20:33:39+08:00"
+  "updated_at": "2026-06-17T21:05:00+08:00"
 }

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-case-analysis.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-case-analysis.md
@@ -7,7 +7,7 @@ It is intentionally separate from `benchmark-run-ledger.md`. The run ledger
 records compact attempts and scores; this file records why a result matters.
 
 - schema_version: `benchmark_case_analysis_v0`
-- updated_at: `2026-06-17T20:33:39+08:00`
+- updated_at: `2026-06-17T21:05:00+08:00`
 - machine_source: `benchmark-case-analysis.json`
 
 ## Summary
@@ -22,7 +22,7 @@ current main-table uplift until a current-protocol rerun closes.
 | Benchmark | Case | Class | Baseline | Treatment | Delta | Decision |
 | --- | --- | --- | --- | --- | --- | --- |
 | `terminal-bench@2.0` | `multi-source-data-merger` | legacy positive / current-protocol baseline-solved | `1.0` | `1.0` | `0.0` | `paired_baseline_solved_treatment_preserved` |
-| `terminal-bench@2.0` | `nginx-request-logging` | runner materialization asset | `0.0` | `1.0` | `+1.0` | `paired_baseline_runner_or_setup_repair_required` |
+| `terminal-bench@2.0` | `nginx-request-logging` | current-protocol baseline-solved / legacy runner asset | `1.0` | `1.0` | `0.0` | `paired_baseline_solved_treatment_preserved` |
 | `terminal-bench@2.0` | `make-doom-for-mips` | timeout attribution asset | `0.0` | `0.0` | `0.0` | `paired_result_requires_attribution` |
 | `terminal-bench@2.0` | `mteb-retrieve` | setup probe asset | `0.0` | `0.0` | `0.0` | `environment_setup_probe_materialized_with_exception_repeat_blocked` |
 | `terminal-bench@2.0` | `pytorch-model-recovery` | exception attribution asset | `0.0` | `0.0` | `0.0` | `paired_no_score_uplift_exception_research_required` |
@@ -438,33 +438,36 @@ Follow-up guidance:
 
 ## Case: Terminal-Bench nginx-request-logging
 
-This is a treatment-route pass plus baseline materialization blocker, not a
-clean solver-uplift case.
+This is now a current-protocol baseline-solved non-regression guard. The older
+`0.0 -> 1.0` row remains useful as a runner-materialization lesson, not as a
+main-table uplift claim.
 
 Compact evidence:
 
 - benchmark: `terminal-bench@2.0`
-- run group:
-  `terminal-bench-nginx-request-logging-hardened-blind-pair-20260616T110017CST`
 - baseline arm: `hardened_codex_baseline`
-- baseline run id: `890f0a8487e4`
-- baseline score: `0.0`
-- baseline failure: `worker_install_failed_agent_codex_install_nvm_node`
+- baseline run id: `c9e583310242`
+- baseline score: `1.0`
+- baseline failure: `none`
 - treatment arm: `codex_goal_harness_treatment`
 - treatment run id: `2a6a46cfb953`
 - treatment score: `1.0`
 - treatment failure: `none`
 - treatment worker CLI calls observed: `0`
+- legacy blocked baseline run id: `890f0a8487e4`
+- legacy blocked baseline score: `0.0`
+- legacy blocked baseline failure:
+  `worker_install_failed_agent_codex_install_nvm_node`
 - follow-up worker materialization probe run id: `51fa05316d18`
 - follow-up worker materialization probe failure: `codex_cli_not_on_path`
 
 Interpretation:
 
-The treatment arm reached official verifier pass, so it is a real route-canary
-that the Goal Harness treatment can complete `nginx-request-logging` under
-official scoring. The paired baseline, however, failed at worker Codex CLI
-materialization before a comparable solver path. That makes the raw score delta
-`+1.0`, but `claimable_uplift=false`.
+The Goal Harness treatment arm reached official verifier pass, and after the
+worker materialization route was repaired the hardened Codex baseline also
+reached official verifier pass. The current comparable conclusion is therefore
+`1.0 -> 1.0`: treatment preserved success, but there is no current-protocol
+uplift.
 
 A follow-up fail-fast worker materialization probe used the `require_existing_codex`
 repair profile and ended before solver execution with compact
@@ -472,15 +475,17 @@ repair profile and ended before solver execution with compact
 does not contain a usable Codex CLI; same-config baseline reruns would mostly
 remeasure runner setup rather than case solving.
 
-This distinction matters because the old `nginx-request-logging` record had
-the opposite shape: baseline passed and treatment timed out before worker
-setup. The useful durable signal is therefore not "Goal Harness always helps
-this case"; it is that runner/materialization state must be fixed before the
-case can be used for a fair treatment comparison.
+This distinction matters because earlier `nginx-request-logging` evidence had
+unstable runner/setup shape: at one point treatment was setup-blocked; later a
+hardened baseline was setup-blocked while treatment passed. The useful durable
+signal is therefore not "Goal Harness always helps this case"; it is that
+runner/materialization state must be fixed before the case can be used for a
+fair treatment comparison.
 
 Why it matters:
 
 - It preserves the treatment pass as a useful end-to-end route-canary.
+- It converts nginx into a current-protocol success-preservation guard.
 - It prevents a false uplift claim from a baseline worker/setup blocker.
 - It records that access-packet presence is not the same as observed
   worker-side Goal Harness CLI use.
@@ -489,11 +494,10 @@ Why it matters:
 
 Follow-up guidance:
 
-- Repair the hardened baseline Codex CLI materialization path before repeating
-  this case as a comparable baseline/treatment pair; require compact
-  `codex --version` preflight success before solver start.
-- Keep this case out of pure solver-uplift counts until baseline reaches
-  worker materialization and official scoring under the same protocol.
+- Keep this case out of pure solver-uplift counts because the repaired baseline
+  reaches worker materialization and official `1.0`.
+- Use the legacy blocked baseline as a regression guard for worker setup and
+  false-claim prevention, not as the active score comparison.
 - Continue alternating to fresh baseline-failing cases if the next goal is
   evidence breadth rather than this specific materialization repair.
 
@@ -1609,7 +1613,7 @@ Follow-up guidance:
 | --- | --- | --- |
 | Connectivity is not case success. | Terminal-Bench needed materialization and closeout repair before scores were meaningful. | Keep lifecycle stages separate: launch, materialization, trial, solver, result, verifier. |
 | Historical treatment route can help, but current-protocol claims need reruns. | `multi-source-data-merger` improved from `0.0` to `1.0` under the legacy Terminal-Bench route; under the current protocol, baseline and treatment both scored `1.0`. | Keep the treatment lane alive, but make the main table prefer current product-mode evidence over legacy uplift rows. |
-| Score delta is not automatically claimable uplift. | `nginx-request-logging` treatment scored `1.0`, but the hardened baseline `0.0` came from worker Codex materialization failure, and a follow-up probe confirmed `codex_cli_not_on_path`. | Record `claimable_uplift=false` when one arm fails before a comparable solver/verifier path; require worker-path Codex preflight before repeat. |
+| Score delta is not automatically claimable uplift. | `nginx-request-logging` once showed treatment `1.0` while the hardened baseline `0.0` came from worker Codex materialization failure; after repair, the current comparison is `1.0 -> 1.0`. | Preserve legacy blocked rows as runner lessons, but make the main table prefer repaired comparable evidence. |
 | Treatment can preserve baseline success. | `ada-bathroom-plan-repair`, `organize-messy-files`, `citation-check`, `3d-scan-calc`, and `bike-rebalance` scored `1.0` in both blind-loop arms with first_success_round=1. | Keep baseline-solved non-regression guards so treatment prompts do not damage easy wins. |
 | Baseline comparability must be repaired before uplift claims. | `bike-rebalance` first looked like a treatment-only pass because the baseline ended with `skillsbench_runner_error`; after baseline repair, the rerun also passed at `1.0`. | Treat initial runner errors as readiness evidence, not case-score deltas. |
 | Timeout policy needs phase attribution. | `make-doom-for-mips` default attempts timed out, a 2h relaunch exposed setup timeout, and setup8+2h still needed verifier attribution. | Do not treat a longer timeout as a case result unless setup, worker, solver, result, and verifier phases are compactly separated. |

--- a/examples/benchmark-case-analysis-smoke.py
+++ b/examples/benchmark-case-analysis-smoke.py
@@ -82,49 +82,65 @@ def test_case_analysis_json() -> None:
     assert current_protocol["decision"] == (
         "paired_baseline_solved_treatment_preserved"
     ), current_protocol
-    assert nginx_route_canary["classification"] == "runner_materialization_asset", (
+    assert nginx_route_canary["classification"] == (
+        "baseline_solved_non_regression_asset"
+    ), (
         nginx_route_canary
     )
     assert nginx_route_canary["decision"] == (
-        "paired_baseline_runner_or_setup_repair_required"
+        "paired_baseline_solved_treatment_preserved"
     ), nginx_route_canary
-    assert nginx_route_canary["scores"]["official_score_delta"] == 1.0, (
+    assert nginx_route_canary["scores"]["official_score_delta"] == 0, (
         nginx_route_canary
     )
     assert nginx_route_canary["scores"]["claimable_uplift"] is False, (
         nginx_route_canary
     )
-    assert nginx_route_canary["arms"]["baseline"]["run_id"] == "890f0a8487e4", (
+    assert nginx_route_canary["arms"]["baseline"]["run_id"] == "c9e583310242", (
         nginx_route_canary
     )
     assert nginx_route_canary["arms"]["treatment"]["run_id"] == "2a6a46cfb953", (
         nginx_route_canary
     )
-    assert nginx_route_canary["arms"]["baseline"]["failure_scope"] == (
-        "runner_or_setup"
-    ), nginx_route_canary
+    assert nginx_route_canary["arms"]["baseline"]["failure_scope"] == "passed", (
+        nginx_route_canary
+    )
     assert nginx_route_canary["arms"]["treatment"]["failure_scope"] == "passed", (
         nginx_route_canary
     )
-    assert nginx_route_canary["compact_lifecycle_analysis"][
+    legacy_nginx = nginx_route_canary["legacy_runner_materialization_asset"]
+    assert legacy_nginx["classification"] == "runner_materialization_asset", (
+        legacy_nginx
+    )
+    assert legacy_nginx["decision"] == (
+        "paired_baseline_runner_or_setup_repair_required"
+    ), legacy_nginx
+    assert legacy_nginx["scores"]["official_score_delta"] == 1.0, legacy_nginx
+    assert legacy_nginx["arms"]["baseline"]["run_id"] == "890f0a8487e4", (
+        legacy_nginx
+    )
+    assert legacy_nginx["arms"]["baseline"]["failure_scope"] == (
+        "runner_or_setup"
+    ), legacy_nginx
+    assert legacy_nginx["compact_lifecycle_analysis"][
         "baseline_case_attempt_countable"
-    ] is False, nginx_route_canary
-    assert nginx_route_canary["compact_lifecycle_analysis"][
+    ] is False, legacy_nginx
+    assert legacy_nginx["compact_lifecycle_analysis"][
         "claimable_uplift"
-    ] is False, nginx_route_canary
+    ] is False, legacy_nginx
     assert nginx_route_canary["arms"]["treatment"][
         "worker_goal_harness_cli_call_total"
     ] == 0, nginx_route_canary
-    nginx_probe = nginx_route_canary["worker_materialization_probe"]
+    nginx_probe = legacy_nginx["worker_materialization_probe"]
     assert nginx_probe["run_id"] == "51fa05316d18", nginx_probe
     assert nginx_probe["failure_class"] == "codex_cli_not_on_path", nginx_probe
     assert nginx_probe["case_solution_attempted"] is False, nginx_probe
     assert nginx_probe["benchmark_budget_countable"] is False, nginx_probe
-    assert nginx_route_canary["compact_lifecycle_analysis"][
+    assert legacy_nginx["compact_lifecycle_analysis"][
         "baseline_repair_probe_failure"
-    ] == "codex_cli_not_on_path", nginx_route_canary
+    ] == "codex_cli_not_on_path", legacy_nginx
     assert nginx_route_canary["routing_guidance"]["repeat_policy"] == (
-        "do_not_repeat_until_codex_cli_on_worker_path_probe_passes"
+        "repeat_only_after_worker_setup_or_managed_route_policy_change"
     ), nginx_route_canary
     assert skillsbench_uplift["classification"] == (
         "reward_feedback_positive_blind_loop_neutral_asset"


### PR DESCRIPTION
## Summary
- Update nginx-request-logging case analysis to prefer the repaired current-protocol 1.0/1.0 evidence.
- Preserve the old 0.0->1.0 runner-materialization row as a nested legacy asset rather than main-table uplift.
- Update the case-analysis smoke to lock the new interpretation.

## Validation
- python3 examples/benchmark-case-analysis-smoke.py
- python3 examples/benchmark-run-ledger-smoke.py
- goal-harness check