### PR TITLE
Add Terminal-Bench current protocol coverage

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/benchmark-case-analysis.json
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-case-analysis.json
@@ -3074,5 +3074,97 @@
     "trajectory_recorded": false,
     "update_rule": "add one case analysis record after compact result ingest and benchmark-run-ledger update"
   },
-  "updated_at": "2026-06-17T21:05:00+08:00"
+  "updated_at": "2026-06-17T22:54:46+08:00",
+  "terminal_bench_current_protocol_coverage": {
+    "schema_version": "terminal_bench_current_protocol_coverage_v0",
+    "source_ledger": "benchmark-run-ledger.json",
+    "latest_decision_filter": "paired_baseline_solved_treatment_preserved",
+    "interpretation": "Rows here are current-protocol Terminal-Bench cases where both baseline and treatment reached official 1.0. They are success-preservation/non-regression guards, not uplift claims. Historical positive or runner-blocked evidence remains in case notes only.",
+    "rows": [
+      {
+        "benchmark_id": "terminal-bench@2.0",
+        "case_id": "cobol-modernization",
+        "baseline_run_id": "5d2bb1d5974a",
+        "treatment_run_id": "a14ad9487f8a",
+        "baseline_official_score": 1,
+        "treatment_official_score": 1,
+        "official_score_delta": 0.0,
+        "decision": "paired_baseline_solved_treatment_preserved",
+        "claimable_uplift": false,
+        "main_table_role": "current_protocol_baseline_solved_non_regression_guard",
+        "case_analysis_status": "coverage_row_only_no_deep_case_note_yet",
+        "legacy_evidence_status": "no_legacy_positive_promoted"
+      },
+      {
+        "benchmark_id": "terminal-bench@2.0",
+        "case_id": "git-multibranch",
+        "baseline_run_id": "af14bc3210c8",
+        "treatment_run_id": "daf4b67ab222",
+        "baseline_official_score": 1,
+        "treatment_official_score": 1,
+        "official_score_delta": 0.0,
+        "decision": "paired_baseline_solved_treatment_preserved",
+        "claimable_uplift": false,
+        "main_table_role": "current_protocol_baseline_solved_non_regression_guard",
+        "case_analysis_status": "coverage_row_only_no_deep_case_note_yet",
+        "legacy_evidence_status": "no_legacy_positive_promoted"
+      },
+      {
+        "benchmark_id": "terminal-bench@2.0",
+        "case_id": "large-scale-text-editing",
+        "baseline_run_id": "52105cdfe282",
+        "treatment_run_id": "01cd5e4bf562",
+        "baseline_official_score": 1,
+        "treatment_official_score": 1,
+        "official_score_delta": 0.0,
+        "decision": "paired_baseline_solved_treatment_preserved",
+        "claimable_uplift": false,
+        "main_table_role": "current_protocol_baseline_solved_non_regression_guard",
+        "case_analysis_status": "coverage_row_only_no_deep_case_note_yet",
+        "legacy_evidence_status": "no_legacy_positive_promoted"
+      },
+      {
+        "benchmark_id": "terminal-bench@2.0",
+        "case_id": "multi-source-data-merger",
+        "baseline_run_id": "37d3587daf12",
+        "treatment_run_id": "76cbfb57f1ea",
+        "baseline_official_score": 1,
+        "treatment_official_score": 1,
+        "official_score_delta": 0.0,
+        "decision": "paired_baseline_solved_treatment_preserved",
+        "claimable_uplift": false,
+        "main_table_role": "current_protocol_baseline_solved_non_regression_guard",
+        "case_analysis_status": "case_record_has_legacy_positive_plus_current_protocol_recheck",
+        "legacy_evidence_status": "legacy_positive_preserved_not_current_uplift"
+      },
+      {
+        "benchmark_id": "terminal-bench@2.0",
+        "case_id": "nginx-request-logging",
+        "baseline_run_id": "c9e583310242",
+        "treatment_run_id": "2a6a46cfb953",
+        "baseline_official_score": 1,
+        "treatment_official_score": 1,
+        "official_score_delta": 0.0,
+        "decision": "paired_baseline_solved_treatment_preserved",
+        "claimable_uplift": false,
+        "main_table_role": "current_protocol_baseline_solved_non_regression_guard",
+        "case_analysis_status": "case_record_current_protocol_baseline_solved_with_legacy_runner_asset",
+        "legacy_evidence_status": "legacy_runner_materialization_asset_preserved"
+      },
+      {
+        "benchmark_id": "terminal-bench@2.0",
+        "case_id": "regex-log",
+        "baseline_run_id": "a9503b70072d",
+        "treatment_run_id": "5926107e45f4",
+        "baseline_official_score": 1,
+        "treatment_official_score": 1,
+        "official_score_delta": 0.0,
+        "decision": "paired_baseline_solved_treatment_preserved",
+        "claimable_uplift": false,
+        "main_table_role": "current_protocol_baseline_solved_non_regression_guard",
+        "case_analysis_status": "coverage_row_only_no_deep_case_note_yet",
+        "legacy_evidence_status": "no_legacy_positive_promoted"
+      }
+    ]
+  }
 }

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-case-analysis.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-case-analysis.md
@@ -7,7 +7,7 @@ It is intentionally separate from `benchmark-run-ledger.md`. The run ledger
 records compact attempts and scores; this file records why a result matters.
 
 - schema_version: `benchmark_case_analysis_v0`
-- updated_at: `2026-06-17T21:05:00+08:00`
+- updated_at: `2026-06-17T22:54:46+08:00`
 - machine_source: `benchmark-case-analysis.json`
 
 ## Summary
@@ -44,6 +44,21 @@ current main-table uplift until a current-protocol rerun closes.
 | `skillsbench@1.1` | `travel-planning` | baseline-solved control asset | `1.0` | n/a | n/a | `baseline_passed_not_current_treatment_priority` |
 | `skillsbench@1.1` | `setup-fuzzing-py` | setup blocker asset | missing | n/a | n/a | `baseline_runner_or_setup_repair_required` |
 | `skillsbench@1.1` | `adaptive-cruise-control` | setup blocker asset | missing | n/a | n/a | `baseline_runner_or_setup_repair_required` |
+
+## Terminal-Bench Current-Protocol Coverage
+
+These rows are generated from the latest compact ledger decisions. They are
+current-protocol success-preservation guards: both baseline and treatment
+score `1.0`, so none of them should be counted as current uplift.
+
+| Case | Baseline | Treatment | Delta | Role | Case Analysis Status |
+| --- | --- | --- | --- | --- | --- |
+| `cobol-modernization` | `1` (`5d2bb1d5974a`) | `1` (`a14ad9487f8a`) | `0.0` | `current_protocol_baseline_solved_non_regression_guard` | `coverage_row_only_no_deep_case_note_yet` |
+| `git-multibranch` | `1` (`af14bc3210c8`) | `1` (`daf4b67ab222`) | `0.0` | `current_protocol_baseline_solved_non_regression_guard` | `coverage_row_only_no_deep_case_note_yet` |
+| `large-scale-text-editing` | `1` (`52105cdfe282`) | `1` (`01cd5e4bf562`) | `0.0` | `current_protocol_baseline_solved_non_regression_guard` | `coverage_row_only_no_deep_case_note_yet` |
+| `multi-source-data-merger` | `1` (`37d3587daf12`) | `1` (`76cbfb57f1ea`) | `0.0` | `current_protocol_baseline_solved_non_regression_guard` | `case_record_has_legacy_positive_plus_current_protocol_recheck` |
+| `nginx-request-logging` | `1` (`c9e583310242`) | `1` (`2a6a46cfb953`) | `0.0` | `current_protocol_baseline_solved_non_regression_guard` | `case_record_current_protocol_baseline_solved_with_legacy_runner_asset` |
+| `regex-log` | `1` (`a9503b70072d`) | `1` (`5926107e45f4`) | `0.0` | `current_protocol_baseline_solved_non_regression_guard` | `coverage_row_only_no_deep_case_note_yet` |
 
 ## Treatment Policy Control Set
 

--- a/examples/benchmark-case-analysis-smoke.py
+++ b/examples/benchmark-case-analysis-smoke.py
@@ -17,6 +17,7 @@ ANALYSIS_JSON = (
     / "benchmark-case-analysis.json"
 )
 ANALYSIS_MD = ANALYSIS_JSON.with_suffix(".md")
+LEDGER_JSON = ANALYSIS_JSON.with_name("benchmark-run-ledger.json")
 
 
 FORBIDDEN_PATTERNS = [
@@ -34,6 +35,7 @@ def assert_public_safe(text: str) -> None:
 
 def test_case_analysis_json() -> None:
     payload = json.loads(ANALYSIS_JSON.read_text(encoding="utf-8"))
+    ledger = json.loads(LEDGER_JSON.read_text(encoding="utf-8"))
     assert payload["schema_version"] == "benchmark_case_analysis_v0", payload
     assert payload["update_policy"]["raw_logs_recorded"] is False, payload
     assert payload["update_policy"]["raw_task_text_recorded"] is False, payload
@@ -43,6 +45,39 @@ def test_case_analysis_json() -> None:
     cases = payload.get("cases")
     assert isinstance(cases, list) and len(cases) >= 2, payload
     by_case = {(case["benchmark_id"], case["case_id"]): case for case in cases}
+    terminal_coverage = payload["terminal_bench_current_protocol_coverage"]
+    assert terminal_coverage["schema_version"] == (
+        "terminal_bench_current_protocol_coverage_v0"
+    ), terminal_coverage
+    assert terminal_coverage["latest_decision_filter"] == (
+        "paired_baseline_solved_treatment_preserved"
+    ), terminal_coverage
+    expected_terminal_cases = {
+        case_id
+        for case_id, case in ledger["benchmarks"]["terminal-bench@2.0"][
+            "cases"
+        ].items()
+        if (case.get("latest_decision") or {}).get("decision")
+        == "paired_baseline_solved_treatment_preserved"
+    }
+    coverage_by_case = {
+        row["case_id"]: row for row in terminal_coverage["rows"]
+    }
+    assert set(coverage_by_case) == expected_terminal_cases, coverage_by_case
+    for case_id, row in coverage_by_case.items():
+        latest = ledger["benchmarks"]["terminal-bench@2.0"]["cases"][case_id][
+            "latest_decision"
+        ]
+        assert row["baseline_run_id"] == latest["baseline_run_id"], row
+        assert row["treatment_run_id"] == latest["treatment_run_id"], row
+        assert row["decision"] == "paired_baseline_solved_treatment_preserved", row
+        assert row["baseline_official_score"] == 1, row
+        assert row["treatment_official_score"] == 1, row
+        assert row["official_score_delta"] == 0.0, row
+        assert row["claimable_uplift"] is False, row
+        assert row["main_table_role"] == (
+            "current_protocol_baseline_solved_non_regression_guard"
+        ), row
     uplift = by_case[("terminal-bench@2.0", "multi-source-data-merger")]
     nginx_route_canary = by_case[("terminal-bench@2.0", "nginx-request-logging")]
     skillsbench_uplift = by_case[("skillsbench@1.1", "llm-prefix-cache-replay")]
@@ -954,6 +989,13 @@ def test_case_analysis_markdown() -> None:
     assert "positive-control" in text, text
     assert "negative-control" in text, text
     assert "Treatment Policy Control Set" in text, text
+    assert "Terminal-Bench Current-Protocol Coverage" in text, text
+    assert "current-protocol success-preservation guards" in text, text
+    assert "cobol-modernization" in text, text
+    assert "git-multibranch" in text, text
+    assert "large-scale-text-editing" in text, text
+    assert "regex-log" in text, text
+    assert "current_protocol_baseline_solved_non_regression_guard" in text, text
     assert "protected files" in text, text
     assert "Interaction-count assessment" in text, text
     assert "codex_goal_mode_baseline" in text, text


### PR DESCRIPTION
## Summary
- Add a machine-readable Terminal-Bench current-protocol coverage table derived from latest ledger decisions.
- Project the same coverage into the human case-analysis doc so baseline-solved rows are not mistaken for uplift.
- Extend the case-analysis smoke to verify coverage matches the ledger.

## Validation
- python3 examples/benchmark-case-analysis-smoke.py
- python3 examples/benchmark-run-ledger-smoke.py
- goal-harness check
- git diff --check