### PR TITLE
Add benchmark core adapter seam

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/benchmark-core-adapter-contract-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-core-adapter-contract-v0.md
@@ -1,0 +1,42 @@
+# Benchmark Core Adapter Contract v0
+
+Goal Harness benchmark code should use a small shared core plus
+benchmark-specific adapters, following the pattern used by Inspect AI, Inspect
+Evals, BrowserGym, and AgentLab.
+
+## Shared Core
+
+The control plane should only depend on these adapter-neutral concepts:
+
+- `BenchmarkAdapter`: `preflight -> launch -> observe -> ingest -> classify -> ledger`.
+- Canonical lifecycle:
+  `process_started -> runner_accepted_args -> job_root_materialized -> trial_started -> worker_started -> result_written -> verifier_scored`.
+- Round rewards: per-round official scalar stored offline, with
+  `first_success_round`, `best_reward_round`, and final-round fields.
+
+`process_started` alone must not count as entering a benchmark case. Case entry
+starts at `job_root_materialized` or later.
+
+## Adapter Boundary
+
+Benchmark-specific code belongs behind adapters:
+
+- Terminal-Bench: Harbor launch/materialization, Docker/job-root observation,
+  verifier closeout, no-upload gates.
+- SkillsBench: ACP/BaseUser runner, product-mode case state, round reward
+  reduction, setup blocker attribution.
+- ALE: local Docker/source readiness, large-image gate, launch packet.
+
+The shared ledger should consume only adapter-neutral lifecycle, score, route,
+failure, and trace summaries. Raw task text, trajectories, verifier output,
+private paths, credentials, and benchmark logs remain outside public artifacts.
+
+## First Extraction Slice
+
+The first refactor should keep runtime behavior stable:
+
+1. Add the shared `benchmark_core` package.
+2. Project existing lifecycle state into canonical lifecycle fields.
+3. Add a focused smoke that proves `process_started` is not case entry.
+4. Move one mature adapter slice next, starting with SkillsBench reducer/route
+   contracts before adding more benchmark features.

--- a/examples/benchmark-core-adapter-contract-smoke.py
+++ b/examples/benchmark-core-adapter-contract-smoke.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Smoke-test the shared benchmark_core adapter contract."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from goal_harness.benchmark import build_benchmark_lifecycle_state  # noqa: E402
+from goal_harness.benchmark_core import (  # noqa: E402
+    AdapterClassification,
+    BenchmarkAdapter,
+    BenchmarkRequest,
+    IngestResult,
+    LaunchResult,
+    LedgerUpdate,
+    Observation,
+    PreflightResult,
+    RunHandle,
+    canonical_lifecycle,
+    summarize_round_rewards,
+)
+
+
+class FixtureAdapter:
+    id = "fixture"
+
+    def preflight(self, request: BenchmarkRequest) -> PreflightResult:
+        return PreflightResult(ok=bool(request.case_id), payload={"ready": True})
+
+    def launch(self, request: BenchmarkRequest) -> LaunchResult:
+        return LaunchResult(
+            process_started=True,
+            handle=RunHandle(run_id="fixture-run", external_id=request.case_id),
+        )
+
+    def observe(self, handle: RunHandle) -> Observation:
+        return Observation(
+            lifecycle=canonical_lifecycle(
+                process_started=True,
+                runner_accepted_args=True,
+                job_root_materialized=True,
+            )
+        )
+
+    def ingest(self, artifact: str) -> IngestResult:
+        return IngestResult(
+            benchmark_run={
+                "schema_version": "benchmark_run_v0",
+                "benchmark_id": "fixture@v0",
+                "task_id": artifact,
+                "official_score": 1.0,
+            }
+        )
+
+    def classify(self, run: IngestResult) -> AdapterClassification:
+        return AdapterClassification(
+            decision="passed",
+            payload={"score": run.benchmark_run["official_score"]},
+        )
+
+    def ledger(self, run: IngestResult) -> LedgerUpdate:
+        return LedgerUpdate(written=True, payload={"case_id": run.benchmark_run["task_id"]})
+
+
+def assert_adapter(adapter: BenchmarkAdapter) -> None:
+    request = BenchmarkRequest(
+        benchmark_id="fixture@v0",
+        case_id="case-a",
+        route="product-mode",
+        max_rounds=5,
+    )
+    assert adapter.preflight(request).ok is True
+    launch = adapter.launch(request)
+    assert launch.process_started is True
+    assert launch.handle is not None
+    observed = adapter.observe(launch.handle)
+    assert observed.lifecycle["current_phase"] == "job_root_materialized", observed
+    assert observed.lifecycle["entered_benchmark_case"] is True, observed
+    run = adapter.ingest("case-a")
+    assert adapter.ledger(run).written is True
+
+
+def test_process_started_is_not_case_entry() -> None:
+    lifecycle = canonical_lifecycle(process_started=True)
+    assert lifecycle["current_phase"] == "process_started", lifecycle
+    assert lifecycle["entered_benchmark_case"] is False, lifecycle
+    assert lifecycle["case_attempt_countable"] is False, lifecycle
+    assert lifecycle["next_required_phase"] == "runner_accepted_args", lifecycle
+
+
+def test_existing_lifecycle_builder_projects_canonical_state() -> None:
+    state = build_benchmark_lifecycle_state(
+        preflight={"schema_version": "fixture_preflight_v0", "ready": True},
+        launch={"schema_version": "fixture_launch_v0", "process_started": True},
+        post_launch_materialization={
+            "schema_version": "fixture_post_launch_v0",
+            "ready_for_launch_state": True,
+            "ready_for_compact_result_ingest": False,
+        },
+    )
+    canonical = state["canonical_lifecycle"]
+    assert canonical["current_phase"] == "job_root_materialized", state
+    assert canonical["entered_benchmark_case"] is True, state
+    assert state["gates"]["launch_state_countable"] is True, state
+
+
+def test_round_reward_summary_prefers_best_score() -> None:
+    summary = summarize_round_rewards(
+        [
+            {"agent_round": 1, "reward": 0.25},
+            {"agent_round": 2, "reward": 1.0, "passed": True},
+            {"agent_round": 3, "reward": 0.0},
+        ]
+    )
+    assert summary["first_success_round"] == 2, summary
+    assert summary["best_reward_round"] == 2, summary
+    assert summary["best_round_reward"] == 1.0, summary
+    assert summary["final_round"] == 3, summary
+    assert summary["final_round_reward"] == 0.0, summary
+    assert summary["best_round_is_final"] is False, summary
+
+
+def main() -> int:
+    assert_adapter(FixtureAdapter())
+    test_process_started_is_not_case_entry()
+    test_existing_lifecycle_builder_projects_canonical_state()
+    test_round_reward_summary_prefers_best_score()
+    print("benchmark-core-adapter-contract-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/goal_harness/benchmark.py
+++ b/goal_harness/benchmark.py
@@ -42,6 +42,10 @@ from .benchmark_case_state import (
     benchmark_case_active_state_path,
     benchmark_case_goal_id,
 )
+from .benchmark_core import (
+    BENCHMARK_LIFECYCLE_STATE_SCHEMA_VERSION,
+    canonical_lifecycle,
+)
 
 
 TERMINAL_BENCH_MODES = (
@@ -82,7 +86,6 @@ BENCHMARK_ATTEMPT_LEARNING_GATE_SCHEMA_VERSION = (
 BENCHMARK_ADAPTER_KWARG_ABSORPTION_REVIEW_SCHEMA_VERSION = (
     "benchmark_adapter_kwarg_absorption_review_v0"
 )
-BENCHMARK_LIFECYCLE_STATE_SCHEMA_VERSION = "benchmark_lifecycle_state_v0"
 BENCHMARK_VERIFIER_ATTRIBUTION_REVIEW_SCHEMA_VERSION = (
     "benchmark_verifier_attribution_review_v0"
 )
@@ -6999,6 +7002,32 @@ def build_benchmark_lifecycle_state(
         process_launched = True
         materialized = True
         compact_ready = True
+    verifier_scored = False
+    if isinstance(benchmark_run, dict):
+        verifier_scored = any(
+            isinstance(benchmark_run.get(field), (int, float))
+            and not isinstance(benchmark_run.get(field), bool)
+            for field in (
+                "official_score",
+                "official_task_score",
+                "score",
+            )
+        )
+        if not verifier_scored:
+            for trial in benchmark_run.get("trials") or []:
+                if not isinstance(trial, dict):
+                    continue
+                if any(
+                    isinstance(trial.get(field), (int, float))
+                    and not isinstance(trial.get(field), bool)
+                    for field in (
+                        "official_score",
+                        "official_task_score",
+                        "score",
+                    )
+                ):
+                    verifier_scored = True
+                    break
     paired_compared = (
         _benchmark_lifecycle_schema(benchmark_comparison)
         == "benchmark_comparison_v0"
@@ -7102,6 +7131,15 @@ def build_benchmark_lifecycle_state(
     if result_ingested and environment_setup_probe_completed:
         current_phase = "environment_setup_probe_completed"
         next_required_transition = "case_repeat_decision"
+    canonical = canonical_lifecycle(
+        process_started=process_launched,
+        runner_accepted_args=process_launched,
+        job_root_materialized=materialized,
+        trial_started=compact_ready or result_ingested,
+        worker_started=result_ingested,
+        result_written=result_ingested,
+        verifier_scored=verifier_scored,
+    )
 
     routing = (
         learning_ledger.get("routing")
@@ -7139,6 +7177,7 @@ def build_benchmark_lifecycle_state(
     return {
         "schema_version": BENCHMARK_LIFECYCLE_STATE_SCHEMA_VERSION,
         "current_phase": current_phase,
+        "canonical_lifecycle": canonical,
         "achieved_transitions": achieved,
         "next_required_transition": next_required_transition,
         "first_blocker": first_blocker,

--- a/goal_harness/benchmark_core/__init__.py
+++ b/goal_harness/benchmark_core/__init__.py
@@ -1,0 +1,45 @@
+"""Shared benchmark harness contracts.
+
+This package is intentionally small: benchmark-specific launchers should live
+in adapters, while the control plane consumes these common shapes.
+"""
+
+from .adapter import (
+    AdapterClassification,
+    BenchmarkAdapter,
+    BenchmarkRequest,
+    IngestResult,
+    LaunchResult,
+    LedgerUpdate,
+    Observation,
+    PreflightResult,
+    RunHandle,
+)
+from .lifecycle import (
+    BENCHMARK_CANONICAL_LIFECYCLE_SCHEMA_VERSION,
+    BENCHMARK_LIFECYCLE_STATE_SCHEMA_VERSION,
+    CANONICAL_LIFECYCLE_PHASES,
+    BenchmarkLifecyclePhase,
+    canonical_lifecycle,
+)
+from .rounds import RoundReward, compact_round_rewards, summarize_round_rewards
+
+__all__ = [
+    "AdapterClassification",
+    "BENCHMARK_CANONICAL_LIFECYCLE_SCHEMA_VERSION",
+    "BENCHMARK_LIFECYCLE_STATE_SCHEMA_VERSION",
+    "BenchmarkAdapter",
+    "BenchmarkLifecyclePhase",
+    "BenchmarkRequest",
+    "CANONICAL_LIFECYCLE_PHASES",
+    "IngestResult",
+    "LaunchResult",
+    "LedgerUpdate",
+    "Observation",
+    "PreflightResult",
+    "RoundReward",
+    "RunHandle",
+    "canonical_lifecycle",
+    "compact_round_rewards",
+    "summarize_round_rewards",
+]

--- a/goal_harness/benchmark_core/adapter.py
+++ b/goal_harness/benchmark_core/adapter.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+
+@dataclass(frozen=True)
+class BenchmarkRequest:
+    """Adapter-neutral request for a benchmark case run."""
+
+    benchmark_id: str
+    case_id: str
+    route: str
+    arm_id: str = ""
+    max_rounds: int | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class PreflightResult:
+    ok: bool
+    payload: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class RunHandle:
+    run_id: str
+    external_id: str = ""
+    payload: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class LaunchResult:
+    process_started: bool
+    handle: RunHandle | None = None
+    payload: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class Observation:
+    lifecycle: dict[str, Any] = field(default_factory=dict)
+    payload: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class IngestResult:
+    benchmark_run: dict[str, Any] = field(default_factory=dict)
+    payload: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class AdapterClassification:
+    decision: str
+    payload: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class LedgerUpdate:
+    written: bool
+    payload: dict[str, Any] = field(default_factory=dict)
+
+
+class BenchmarkAdapter(Protocol):
+    """Minimal control-plane interface implemented by benchmark adapters."""
+
+    id: str
+
+    def preflight(self, request: BenchmarkRequest) -> PreflightResult:
+        ...
+
+    def launch(self, request: BenchmarkRequest) -> LaunchResult:
+        ...
+
+    def observe(self, handle: RunHandle) -> Observation:
+        ...
+
+    def ingest(self, artifact: str) -> IngestResult:
+        ...
+
+    def classify(self, run: IngestResult) -> AdapterClassification:
+        ...
+
+    def ledger(self, run: IngestResult) -> LedgerUpdate:
+        ...

--- a/goal_harness/benchmark_core/lifecycle.py
+++ b/goal_harness/benchmark_core/lifecycle.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+
+BENCHMARK_LIFECYCLE_STATE_SCHEMA_VERSION = "benchmark_lifecycle_state_v0"
+BENCHMARK_CANONICAL_LIFECYCLE_SCHEMA_VERSION = "benchmark_canonical_lifecycle_v0"
+
+
+class BenchmarkLifecyclePhase(str, Enum):
+    NOT_STARTED = "not_started"
+    PROCESS_STARTED = "process_started"
+    RUNNER_ACCEPTED_ARGS = "runner_accepted_args"
+    JOB_ROOT_MATERIALIZED = "job_root_materialized"
+    TRIAL_STARTED = "trial_started"
+    WORKER_STARTED = "worker_started"
+    RESULT_WRITTEN = "result_written"
+    VERIFIER_SCORED = "verifier_scored"
+
+
+CANONICAL_LIFECYCLE_PHASES = tuple(phase.value for phase in BenchmarkLifecyclePhase)
+CASE_ENTRY_PHASES = {
+    BenchmarkLifecyclePhase.JOB_ROOT_MATERIALIZED.value,
+    BenchmarkLifecyclePhase.TRIAL_STARTED.value,
+    BenchmarkLifecyclePhase.WORKER_STARTED.value,
+    BenchmarkLifecyclePhase.RESULT_WRITTEN.value,
+    BenchmarkLifecyclePhase.VERIFIER_SCORED.value,
+}
+
+
+def _coerce_flags(flags: dict[str, Any]) -> dict[str, bool]:
+    coerced: dict[str, bool] = {}
+    previous = True
+    for phase in CANONICAL_LIFECYCLE_PHASES:
+        if phase == BenchmarkLifecyclePhase.NOT_STARTED.value:
+            continue
+        ready = bool(flags.get(phase))
+        coerced[phase] = bool(previous and ready)
+        previous = coerced[phase]
+    return coerced
+
+
+def canonical_lifecycle(**flags: Any) -> dict[str, Any]:
+    """Return an adapter-neutral lifecycle projection.
+
+    `process_started` is intentionally not enough to enter a benchmark case.
+    Control-plane accounting should only treat the case as entered once the
+    job root materializes or a later phase is observed.
+    """
+
+    ready = _coerce_flags(flags)
+    phase = BenchmarkLifecyclePhase.NOT_STARTED.value
+    for candidate in CANONICAL_LIFECYCLE_PHASES[1:]:
+        if ready.get(candidate):
+            phase = candidate
+        else:
+            break
+    entered_case = phase in CASE_ENTRY_PHASES
+    next_required_phase = ""
+    for candidate in CANONICAL_LIFECYCLE_PHASES[1:]:
+        if not ready.get(candidate):
+            next_required_phase = candidate
+            break
+    return {
+        "schema_version": BENCHMARK_CANONICAL_LIFECYCLE_SCHEMA_VERSION,
+        "current_phase": phase,
+        "entered_benchmark_case": entered_case,
+        "case_attempt_countable": entered_case,
+        "next_required_phase": next_required_phase,
+        "phase_ready": ready,
+    }

--- a/goal_harness/benchmark_core/rounds.py
+++ b/goal_harness/benchmark_core/rounds.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class RoundReward:
+    agent_round: int
+    reward: float | None = None
+    passed: bool | None = None
+    reward_present: bool = True
+
+
+def compact_round_rewards(records: list[Any]) -> list[dict[str, Any]]:
+    compact: list[dict[str, Any]] = []
+    for record in records:
+        if not isinstance(record, dict):
+            continue
+        agent_round = record.get("agent_round")
+        if not isinstance(agent_round, int) or isinstance(agent_round, bool):
+            continue
+        if agent_round <= 0:
+            continue
+        item: dict[str, Any] = {"agent_round": agent_round}
+        reward = record.get("reward")
+        if isinstance(reward, (int, float)) and not isinstance(reward, bool):
+            item["reward"] = float(reward)
+            item["reward_present"] = True
+        elif record.get("reward_present") is False:
+            item["reward_present"] = False
+        if isinstance(record.get("passed"), bool):
+            item["passed"] = record["passed"]
+        elif "reward" in item:
+            item["passed"] = item["reward"] >= 1
+        compact.append(item)
+    return sorted(compact, key=lambda item: item["agent_round"])
+
+
+def summarize_round_rewards(records: list[Any]) -> dict[str, Any]:
+    compact = compact_round_rewards(records)
+    numeric = [item for item in compact if isinstance(item.get("reward"), float)]
+    first_success_round = None
+    for item in compact:
+        if item.get("passed") is True:
+            first_success_round = item["agent_round"]
+            break
+    if not numeric:
+        return {
+            "round_rewards": compact,
+            "round_reward_count": len(compact),
+            "first_success_round": first_success_round,
+        }
+    final = numeric[-1]
+    best = max(numeric, key=lambda item: (item["reward"], -item["agent_round"]))
+    return {
+        "round_rewards": compact,
+        "round_reward_count": len(compact),
+        "first_success_round": first_success_round,
+        "final_round": final["agent_round"],
+        "final_round_reward": final["reward"],
+        "final_round_passed": final.get("passed"),
+        "best_reward_round": best["agent_round"],
+        "best_round_reward": best["reward"],
+        "best_round_passed": best.get("passed"),
+        "best_round_is_final": best["agent_round"] == final["agent_round"],
+    }


### PR DESCRIPTION
## Summary
- add a small benchmark_core package with adapter protocol, canonical lifecycle, and round-reward helpers
- project existing benchmark lifecycle output into canonical lifecycle fields so process_started no longer implies benchmark case entry
- document the adapter seam and add a focused smoke for the contract

## Validation
- python3 -m py_compile goal_harness/benchmark_core/__init__.py goal_harness/benchmark_core/adapter.py goal_harness/benchmark_core/lifecycle.py goal_harness/benchmark_core/rounds.py goal_harness/benchmark.py examples/benchmark-core-adapter-contract-smoke.py examples/benchmark-lifecycle-state-smoke.py
- python3 examples/benchmark-core-adapter-contract-smoke.py
- python3 examples/benchmark-lifecycle-state-smoke.py
- goal-harness check --scan-path goal_harness/benchmark_core --scan-path goal_harness/benchmark.py --scan-path examples/benchmark-core-adapter-contract-smoke.py --scan-path examples/benchmark-lifecycle-state-smoke.py --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-core-adapter-contract-v0.md
- git diff --cached --check

## Excluded
- no .local state or external research clones
- no raw benchmark logs, trajectories, verifier output, credentials, or private paths
- no new benchmark runs or temporary smoke/probe scripts

## Residual risk
- this intentionally does not move SkillsBench/Terminal-Bench/ALE adapter code yet; it creates the small shared contract for the next extraction PR.