### PR TITLE
Add quota action-scope guard

### DIFF
--- a/docs/interaction-pattern-catalog.md
+++ b/docs/interaction-pattern-catalog.md
@@ -289,7 +289,7 @@ the checkpointed decision.
 
 **Validation**
 
-- future focused quota/status smoke for action-scope guard;
+- `examples/quota-action-scope-guard-smoke.py`;
 - `docs/state-interaction-model.md` checkpointed decision sections.
 
 ## IP-006 Outcome Floor Recovery

--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -232,6 +232,18 @@ unchanged monitor polls are quiet no-spend checks with `should_run=false` and
 letting it consume every eligible turn, and it keeps the hard routing rule in
 one small machine contract.
 
+Executable todos can also declare explicit write-scope requirements through
+todo metadata, for example `required_write_scopes=runner%2F%2A%2A` or the CLI
+flag `goal-harness todo add --required-write-scope runner/**`. Before normal
+delivery, `quota should-run` compares the first executable advancement todo's
+`required_write_scopes` with `goal_boundary.write_scope`. If the current
+boundary does not cover the selected scope, the guard keeps `should_run=true`
+for a bounded repair turn but sets `normal_delivery_allowed=false`,
+`effective_action=boundary_projection_repair`, and
+`blocked_action_scope=boundary_projection`. The worker must repair the
+checkpointed boundary projection, rewrite the todo inside the current boundary,
+or write a concrete user/controller gate before attempting the write.
+
 External-evidence waits have an additional CLI-level observation contract. When
 the selected goal is `state=waiting`, `waiting_on=external_evidence`, and its
 current lane is a continuous monitor, or when the active state says a

--- a/examples/quota-action-scope-guard-smoke.py
+++ b/examples/quota-action-scope-guard-smoke.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Smoke-test quota guard for required write scopes on executable todos."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from goal_harness.quota import build_quota_should_run, render_quota_should_run_markdown  # noqa: E402
+from goal_harness.status import compact_todo_group, project_asset_todo_summary  # noqa: E402
+from goal_harness.todo_contract import format_todo_metadata_line, parse_todo_metadata_line  # noqa: E402
+
+
+GOAL_ID = "action-scope-guard-fixture"
+TODO_TEXT = "Patch the runner adapter after the checkpointed owner decision is projected."
+
+
+def status_payload(*, allowed_scopes: list[str]) -> dict:
+    todo = {
+        "index": 1,
+        "done": False,
+        "status": "open",
+        "text": TODO_TEXT,
+        "task_class": "advancement_task",
+        "action_kind": "implement",
+        "required_write_scopes": ["runners/openviking/**"],
+    }
+    agent_todos = {
+        "schema_version": "todo_summary_v0",
+        "source_section": "Agent Todo",
+        "open_count": 1,
+        "done_count": 0,
+        "total_count": 1,
+        "first_open_items": [todo],
+        "first_executable_items": [todo],
+        "items": [todo],
+    }
+    return {
+        "ok": True,
+        "goal_count": 1,
+        "run_count": 0,
+        "attention_queue": {
+            "items": [
+                {
+                    "goal_id": GOAL_ID,
+                    "status": "active",
+                    "waiting_on": "codex",
+                    "severity": "action",
+                    "source": "latest_run",
+                    "recommended_action": "Execute the first agent todo only if its required scope is inside goal_boundary.",
+                    "quota": {
+                        "compute": 1.0,
+                        "window_hours": 24,
+                        "slot_minutes": 1,
+                        "allowed_slots": 1440,
+                        "spent_slots": 0,
+                        "state": "eligible",
+                        "reason": "eligible fixture",
+                    },
+                    "agent_todos": agent_todos,
+                }
+            ]
+        },
+        "run_history": {
+            "goals": [
+                {
+                    "id": GOAL_ID,
+                    "registry_member": True,
+                    "status": "active",
+                    "adapter_kind": "fixture_adapter_v0",
+                    "adapter_status": "connected",
+                    "coordination": {
+                        "write_scope": allowed_scopes,
+                        "requires_parent_approval": ["publish", "production-action"],
+                    },
+                    "latest_runs": [],
+                }
+            ]
+        },
+    }
+
+
+def assert_missing_scope_repairs_boundary() -> None:
+    payload = build_quota_should_run(
+        status_payload(allowed_scopes=["docs/**"]),
+        goal_id=GOAL_ID,
+    )
+    assert payload["should_run"] is True, payload
+    assert payload["normal_delivery_allowed"] is False, payload
+    assert payload["self_repair_allowed"] is True, payload
+    assert payload["effective_action"] == "boundary_projection_repair", payload
+    assert payload["blocked_action_scope"] == "boundary_projection", payload
+    gap = payload["boundary_projection_gap"]
+    assert gap["missing_write_scopes"] == ["runners/openviking/**"], gap
+    assert gap["allowed_write_scopes"] == ["docs/**"], gap
+    assert payload["heartbeat_recommendation"]["recommended_mode"] == "repair_boundary_projection", payload
+    assert payload["execution_obligation"]["kind"] == "boundary_projection_repair", payload
+    assert payload["execution_obligation"]["delivery_allowed"] is False, payload
+    contract = payload["interaction_contract"]
+    assert contract["mode"] == "boundary_projection_repair", contract
+    assert contract["agent_channel"]["delivery_allowed"] is False, contract
+    assert "goal_boundary.write_scope" in contract["agent_channel"]["primary_action"], contract
+    markdown = render_quota_should_run_markdown(payload)
+    assert "boundary_missing_write_scopes: runners/openviking/**" in markdown, markdown
+    assert "blocked_action_scope: `boundary_projection`" in markdown, markdown
+
+
+def assert_required_write_scope_metadata_roundtrip() -> None:
+    metadata_line = format_todo_metadata_line(
+        todo_id="todo_scope123",
+        status="open",
+        task_class="advancement_task",
+        action_kind="implement",
+        required_write_scopes=["runners/openviking/**", "docs/**"],
+    )
+    assert metadata_line is not None
+    parsed = parse_todo_metadata_line(metadata_line)
+    assert parsed is not None, metadata_line
+    assert parsed["required_write_scopes"] == ["runners/openviking/**", "docs/**"], parsed
+    group = compact_todo_group(
+        [
+            {
+                "index": 1,
+                "done": False,
+                "text": TODO_TEXT,
+                **parsed,
+            }
+        ],
+        source_section="Agent Todo",
+        role="agent",
+    )
+    assert group is not None, group
+    first = group["first_executable_items"][0]
+    assert first["required_write_scopes"] == ["runners/openviking/**", "docs/**"], first
+    asset_summary = project_asset_todo_summary(group)
+    assert asset_summary is not None, group
+    assert asset_summary["items"][0]["required_write_scopes"] == [
+        "runners/openviking/**",
+        "docs/**",
+    ], asset_summary
+
+
+def assert_allowed_scope_remains_runnable() -> None:
+    payload = build_quota_should_run(
+        status_payload(allowed_scopes=["runners/**", "docs/**"]),
+        goal_id=GOAL_ID,
+    )
+    assert payload["should_run"] is True, payload
+    assert payload["normal_delivery_allowed"] is True, payload
+    assert payload["self_repair_allowed"] is False, payload
+    assert payload["effective_action"] == "normal_run", payload
+    assert "boundary_projection_gap" not in payload, payload
+    assert payload["goal_boundary"]["write_scope"] == ["runners/**", "docs/**"], payload
+
+
+def main() -> int:
+    assert_required_write_scope_metadata_roundtrip()
+    assert_missing_scope_repairs_boundary()
+    assert_allowed_scope_remains_runnable()
+    print("quota-action-scope-guard-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -4794,6 +4794,15 @@ def main(argv: list[str] | None = None) -> int:
             "rebuild_score, compact_blocker_writeback, or monitor."
         ),
     )
+    todo_parser.add_argument(
+        "--required-write-scope",
+        dest="required_write_scopes",
+        action="append",
+        help=(
+            "For todo add/update, declare a required relative write scope such as "
+            "src/** or runners/openviking/**. Repeat for multiple scopes."
+        ),
+    )
     todo_parser.add_argument("--next-agent-todo", help="For complete/supersede, atomically add or update the next agent todo.")
     todo_parser.add_argument("--next-user-todo", help="For complete/supersede, atomically add or update the next user todo.")
     todo_parser.add_argument(
@@ -8636,6 +8645,7 @@ def main(argv: list[str] | None = None) -> int:
                     text=args.text,
                     task_class=args.task_class,
                     action_kind=args.action_kind,
+                    required_write_scopes=args.required_write_scopes,
                     project=Path(args.project).expanduser() if args.project else None,
                     state_file=Path(args.state_file).expanduser() if args.state_file else None,
                     dry_run=bool(args.dry_run),
@@ -8643,8 +8653,16 @@ def main(argv: list[str] | None = None) -> int:
             elif args.todo_command == "update":
                 if not args.todo_id:
                     raise ValueError("todo update requires --todo-id")
-                if not any([args.status, args.note, args.evidence, args.reason, args.task_class, args.action_kind]):
-                    raise ValueError("todo update requires at least one of --status, --note, --evidence, --reason, --task-class, or --action-kind")
+                if not any([
+                    args.status,
+                    args.note,
+                    args.evidence,
+                    args.reason,
+                    args.task_class,
+                    args.action_kind,
+                    args.required_write_scopes,
+                ]):
+                    raise ValueError("todo update requires at least one of --status, --note, --evidence, --reason, --task-class, --action-kind, or --required-write-scope")
                 payload = update_goal_todo(
                     registry_path=registry_path,
                     goal_id=args.goal_id,
@@ -8656,6 +8674,7 @@ def main(argv: list[str] | None = None) -> int:
                     reason=args.reason,
                     task_class=args.task_class,
                     action_kind=args.action_kind,
+                    required_write_scopes=args.required_write_scopes,
                     project=Path(args.project).expanduser() if args.project else None,
                     state_file=Path(args.state_file).expanduser() if args.state_file else None,
                     dry_run=bool(args.dry_run),

--- a/goal_harness/quota.py
+++ b/goal_harness/quota.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
+import fnmatch
 import json
 import re
 from datetime import datetime, timedelta, timezone
@@ -24,6 +25,7 @@ from .todo_contract import (
     TODO_TASK_CLASS_MONITOR,
     TODO_TASK_CLASS_USER_GATE,
     next_action_requires_advancement_text,
+    normalize_required_write_scopes,
     normalize_todo_status,
     normalize_todo_task_class,
 )
@@ -101,6 +103,7 @@ SELF_REPAIR_SPEND_ACTIONS = {
     "control_plane_health_repair",
     "control_plane_projection_repair",
     "state_projection_gap_repair",
+    "boundary_projection_repair",
 }
 STALL_HEALTH_ITEM_COMPACT_FIELDS = (
     "goal_id",
@@ -864,9 +867,15 @@ def _compact_todo_summary_item(item: dict[str, Any], *, text: str | None = None)
         "source_section",
         "task_class",
         "action_kind",
+        "required_write_scopes",
     ):
         if item.get(key) is not None:
             compact[key] = item.get(key)
+    required_write_scopes = normalize_required_write_scopes(compact.get("required_write_scopes"))
+    if required_write_scopes:
+        compact["required_write_scopes"] = required_write_scopes
+    else:
+        compact.pop("required_write_scopes", None)
     compact["task_class"] = _todo_task_class(compact)
     return compact
 
@@ -1425,6 +1434,8 @@ def _interaction_mode(payload: dict[str, Any]) -> str:
         return "monitor_quiet_skip"
     if payload.get("recovery_delivery_allowed") or effective_action == "outcome_floor_recovery":
         return "outcome_floor_recovery"
+    if effective_action == "boundary_projection_repair":
+        return "boundary_projection_repair"
     if payload.get("self_repair_allowed"):
         return "control_plane_self_repair"
     if payload.get("normal_delivery_allowed") or payload.get("should_run"):
@@ -1472,6 +1483,8 @@ def _interaction_primary_agent_action(payload: dict[str, Any], *, mode: str) -> 
         return "produce the required outcome-floor evidence artifact or write the concrete blocker"
     if mode == "control_plane_self_repair":
         return "repair the bounded control-plane/status projection fault exposed by quota"
+    if mode == "boundary_projection_repair":
+        return "repair goal_boundary.write_scope projection before attempting the selected write"
     if mode == "bounded_delivery":
         return _protocol_first_candidate_action(payload) or "advance one bounded validated segment"
     if mode == "mapped_noop_if_unchanged":
@@ -1494,7 +1507,13 @@ def _interaction_next_cli_actions(payload: dict[str, Any], *, mode: str) -> list
             f"goal-harness refresh-state --goal-id {goal_id} --classification <compact_blocker_or_transition>",
             f"goal-harness quota spend-slot --goal-id {goal_id} --slots 1 --source heartbeat --execute",
         ]
-    if mode in {"bounded_delivery", "outcome_floor_recovery", "autonomous_replan", "control_plane_self_repair"}:
+    if mode in {
+        "bounded_delivery",
+        "outcome_floor_recovery",
+        "autonomous_replan",
+        "control_plane_self_repair",
+        "boundary_projection_repair",
+    }:
         return [
             f"goal-harness refresh-state --goal-id {goal_id} --classification <validated_progress>",
             f"goal-harness quota spend-slot --goal-id {goal_id} --slots 1 --source heartbeat --execute",
@@ -1550,6 +1569,7 @@ def _interaction_contract(payload: dict[str, Any]) -> dict[str, Any]:
         "outcome_floor_recovery",
         "autonomous_replan",
         "control_plane_self_repair",
+        "boundary_projection_repair",
         "external_evidence_observation",
     }
     return {
@@ -2091,6 +2111,91 @@ def _state_projection_gap_repair_hint(
     }
 
 
+def _write_scope_allowed(required_scope: str, allowed_scopes: list[str]) -> bool:
+    required = str(required_scope or "").strip()
+    if not required:
+        return True
+    for allowed in allowed_scopes:
+        pattern = str(allowed or "").strip()
+        if not pattern:
+            continue
+        if required == pattern:
+            return True
+        if fnmatch.fnmatchcase(required, pattern):
+            return True
+    return False
+
+
+def _boundary_projection_repair_hint(
+    goal_boundary: dict[str, Any] | None,
+    agent_todo_summary: dict[str, Any] | None,
+    *,
+    candidate_should_run: bool,
+) -> dict[str, Any] | None:
+    if not candidate_should_run or not isinstance(agent_todo_summary, dict):
+        return None
+    candidate_items: list[dict[str, Any]] = []
+    for key in ("first_executable_items", "first_open_items"):
+        value = agent_todo_summary.get(key)
+        if isinstance(value, list):
+            candidate_items.extend(item for item in value if isinstance(item, dict))
+    selected: dict[str, Any] | None = None
+    for item in candidate_items:
+        if not _todo_item_is_actionable_open(item):
+            continue
+        if _todo_task_class(item) != TODO_TASK_CLASS_ADVANCEMENT:
+            continue
+        required = normalize_required_write_scopes(item.get("required_write_scopes"))
+        if required:
+            selected = item
+            break
+    if not selected:
+        return None
+
+    required_scopes = normalize_required_write_scopes(selected.get("required_write_scopes"))
+    boundary = goal_boundary if isinstance(goal_boundary, dict) else {}
+    allowed_scopes = normalize_required_write_scopes(boundary.get("write_scope"))
+    missing_scopes = [
+        scope
+        for scope in required_scopes
+        if not _write_scope_allowed(scope, allowed_scopes)
+    ]
+    if not missing_scopes:
+        return None
+    selected_text = _protocol_action_text(selected.get("text"), limit=220)
+    return {
+        "source": "quota.should-run",
+        "trigger": "required_write_scope_missing_from_goal_boundary",
+        "recommended_mode": "repair_boundary_projection",
+        "effective_action": "boundary_projection_repair",
+        "blocked_action_scope": "boundary_projection",
+        "allowed": True,
+        "notify": "DONT_NOTIFY",
+        "reason": (
+            "selected executable todo requires write scope not present in "
+            "goal_boundary.write_scope"
+        ),
+        "repair_focus": (
+            "repair the checkpointed decision projection: either add the approved "
+            "scope to goal_boundary.write_scope, rewrite the todo inside the current "
+            "boundary, or create a concrete user/controller gate"
+        ),
+        "spend_policy": (
+            "append exactly one heartbeat spend only after boundary projection repair, "
+            "todo rewrite, or blocker writeback is validated"
+        ),
+        "required_write_scopes": required_scopes,
+        "allowed_write_scopes": allowed_scopes,
+        "missing_write_scopes": missing_scopes,
+        "selected_todo": {
+            key: selected.get(key)
+            for key in ("todo_id", "index", "priority", "task_class", "action_kind")
+            if selected.get(key) is not None
+        },
+        "selected_todo_text": selected_text,
+    }
+
+
 def _control_plane_post_handoff_observation_hint(item: dict[str, Any]) -> dict[str, Any] | None:
     control_plane = compact_control_plane_policy(item.get("control_plane"))
     self_repair = (
@@ -2513,6 +2618,25 @@ def _execution_obligation(
                 "normal bounded delivery is blocked until projection is repaired"
             ),
         }
+    if should_run and recommended_mode == "repair_boundary_projection":
+        return {
+            "must_attempt_work": True,
+            "kind": "boundary_projection_repair",
+            "minimum": "one_boundary_projection_or_blocker_writeback_segment",
+            "delivery_allowed": False,
+            "notify_is_execution_gate": False,
+            "contract": "goal_boundary.write_scope",
+            "contract_obligation": (
+                "do not execute the selected write; repair goal_boundary.write_scope "
+                "projection, rewrite the selected todo within boundary, or create a "
+                "concrete user/controller gate"
+            ),
+            "spend_policy": heartbeat_recommendation.get("spend_policy"),
+            "reason": (
+                "selected executable todo requires a write scope that the current "
+                "goal_boundary does not project"
+            ),
+        }
     if should_run and work_lane_contract:
         return {
             "must_attempt_work": bool(work_lane_contract.get("must_attempt_work", should_run)),
@@ -2863,6 +2987,7 @@ def build_quota_should_run(status_payload: dict[str, Any], *, goal_id: str) -> d
         agent_todo_summary = _summarize_project_asset_todos(
             project_asset.get("agent_todos") if project_asset else None
         ) or _summarize_user_todos(item.get("agent_todos"))
+        goal_boundary = _goal_boundary(item)
         blocked_priority_fallback = _blocked_priority_fallback(agent_todo_summary)
         stall_self_repair = _stall_self_repair_hint(
             item,
@@ -2890,6 +3015,19 @@ def build_quota_should_run(status_payload: dict[str, Any], *, goal_id: str) -> d
             normal_delivery_allowed = False
             recovery_allowed = False
             reason = str(projection_gap_repair.get("reason") or reason)
+        boundary_projection_repair = _boundary_projection_repair_hint(
+            goal_boundary,
+            agent_todo_summary,
+            candidate_should_run=bool(
+                normal_delivery_allowed or recovery_allowed or self_repair_allowed
+            ),
+        )
+        if boundary_projection_repair:
+            stall_self_repair = boundary_projection_repair
+            self_repair_allowed = True
+            normal_delivery_allowed = False
+            recovery_allowed = False
+            reason = str(boundary_projection_repair.get("reason") or reason)
         should_run = bool(normal_delivery_allowed or recovery_allowed or self_repair_allowed)
         effective_action = _effective_action(
             normal_delivery_allowed=normal_delivery_allowed,
@@ -2986,7 +3124,11 @@ def build_quota_should_run(status_payload: dict[str, Any], *, goal_id: str) -> d
             ),
             "quota": quota,
             "state": state,
-            "blocked_action_scope": quota.get("blocked_action_scope"),
+            "blocked_action_scope": (
+                boundary_projection_repair.get("blocked_action_scope")
+                if boundary_projection_repair
+                else quota.get("blocked_action_scope")
+            ),
             "safe_bypass_allowed": bool(quota.get("safe_bypass_allowed")),
             "safe_bypass_kind": quota.get("safe_bypass_kind"),
             "safe_bypass_policy": quota.get("safe_bypass_policy"),
@@ -3011,7 +3153,7 @@ def build_quota_should_run(status_payload: dict[str, Any], *, goal_id: str) -> d
                 work_lane_contract=work_lane_contract,
                 external_evidence_observation=external_evidence_observation,
             ),
-            "goal_boundary": _goal_boundary(item),
+            "goal_boundary": goal_boundary,
             "plan_summary": plan.get("summary"),
             "todo_write_hint": _todo_write_hint(safe_goal_id),
         }
@@ -3026,6 +3168,8 @@ def build_quota_should_run(status_payload: dict[str, Any], *, goal_id: str) -> d
             payload["stall_self_repair"] = stall_self_repair
         if projection_gap:
             payload["state_projection_gap"] = projection_gap
+        if boundary_projection_repair:
+            payload["boundary_projection_gap"] = boundary_projection_repair
         if item.get("operator_question"):
             payload["operator_question"] = item.get("operator_question")
         if item.get("missing_gates"):
@@ -4491,6 +4635,11 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
         )
         if stall_self_repair.get("repair_focus"):
             lines.append(f"- stall_repair_focus: {stall_self_repair.get('repair_focus')}")
+        if stall_self_repair.get("missing_write_scopes"):
+            lines.append(
+                "- boundary_missing_write_scopes: "
+                f"{', '.join(str(value) for value in stall_self_repair.get('missing_write_scopes') or [])}"
+            )
         blockers = (
             stall_self_repair.get("blocking_health_items")
             if isinstance(stall_self_repair.get("blocking_health_items"), list)

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -38,6 +38,7 @@ from .todo_contract import (
     TODO_TASK_PATTERN,
     build_todo_id,
     normalize_todo_action_kind,
+    normalize_required_write_scopes,
     normalize_todo_status,
     normalize_todo_task_class,
     parse_todo_metadata_line,
@@ -3573,6 +3574,9 @@ def structured_todo_item(
     action_kind = normalize_todo_action_kind(item.get("action_kind"))
     if action_kind:
         normalized["action_kind"] = action_kind
+    required_write_scopes = normalize_required_write_scopes(item.get("required_write_scopes"))
+    if required_write_scopes:
+        normalized["required_write_scopes"] = required_write_scopes
     if priority:
         normalized["priority"] = priority
         normalized["title"] = normalize_todo_text(title)
@@ -3596,6 +3600,7 @@ def compact_todo_item(item: dict[str, Any]) -> dict[str, Any]:
         "source_section",
         "task_class",
         "action_kind",
+        "required_write_scopes",
         "note",
         "evidence",
         "reason",

--- a/goal_harness/todo_contract.py
+++ b/goal_harness/todo_contract.py
@@ -11,6 +11,7 @@ TODO_METADATA_PATTERN = re.compile(r"^\s*<!--\s*goal-harness:(?:todo\s+)?(?P<bod
 TODO_METADATA_TOKEN_PATTERN = re.compile(r"(?P<key>[a-z_][a-z0-9_-]*)=(?P<value>[^\s<>]+)")
 TODO_ACTION_KIND_PATTERN = re.compile(r"^[a-z][a-z0-9_-]{0,63}$")
 TODO_ID_PATTERN = re.compile(r"^todo_[a-z0-9_-]{3,64}$")
+TODO_WRITE_SCOPE_MAX_CHARS = 160
 
 TODO_TASK_CLASS_ADVANCEMENT = "advancement_task"
 TODO_TASK_CLASS_MONITOR = "continuous_monitor"
@@ -148,6 +149,32 @@ def normalize_todo_id(value: Any) -> str | None:
     return None
 
 
+def normalize_required_write_scopes(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple, set)):
+        raw_values = [str(item or "") for item in value]
+    else:
+        raw_values = re.split(r"[,;|]", str(value or ""))
+    scopes: list[str] = []
+    seen: set[str] = set()
+    for raw in raw_values:
+        scope = compact_todo_text(raw)
+        if not scope:
+            continue
+        if len(scope) > TODO_WRITE_SCOPE_MAX_CHARS:
+            continue
+        if scope.startswith(("/", "~")) or ".." in scope.split("/"):
+            continue
+        if re.search(r"[\s<>]", scope):
+            continue
+        if scope in seen:
+            continue
+        seen.add(scope)
+        scopes.append(scope)
+    return scopes
+
+
 def build_todo_id(
     *,
     role: Any,
@@ -204,11 +231,11 @@ def decode_metadata_value(value: Any) -> str:
     return compact_todo_text(unquote(str(value or "")))
 
 
-def parse_todo_metadata_line(line: str) -> dict[str, str] | None:
+def parse_todo_metadata_line(line: str) -> dict[str, Any] | None:
     match = TODO_METADATA_PATTERN.match(line)
     if not match:
         return None
-    metadata: dict[str, str] = {}
+    metadata: dict[str, Any] = {}
     for token in TODO_METADATA_TOKEN_PATTERN.finditer(match.group("body")):
         key = token.group("key").replace("-", "_")
         value = decode_metadata_value(token.group("value"))
@@ -228,6 +255,10 @@ def parse_todo_metadata_line(line: str) -> dict[str, str] | None:
             action_kind = normalize_todo_action_kind(value)
             if action_kind:
                 metadata["action_kind"] = action_kind
+        elif key in {"required_write_scope", "required_write_scopes"}:
+            scopes = normalize_required_write_scopes(value)
+            if scopes:
+                metadata["required_write_scopes"] = scopes
         elif key in {"note", "evidence", "reason", "completed_at", "updated_at"}:
             if value:
                 metadata[key] = value
@@ -244,6 +275,7 @@ def format_todo_metadata_line(
     status: str | None = None,
     task_class: str | None = None,
     action_kind: str | None = None,
+    required_write_scopes: Any = None,
     note: str | None = None,
     evidence: str | None = None,
     reason: str | None = None,
@@ -272,6 +304,14 @@ def format_todo_metadata_line(
         raise ValueError("todo action_kind must be a public-safe token: lowercase letters, digits, '_' or '-'")
     if normalized_action_kind:
         fields.append(f"action_kind={encode_metadata_value(normalized_action_kind)}")
+    normalized_write_scopes = normalize_required_write_scopes(required_write_scopes)
+    if required_write_scopes and not normalized_write_scopes:
+        raise ValueError("required_write_scopes must contain public-safe relative scope tokens")
+    if normalized_write_scopes:
+        fields.append(
+            "required_write_scopes="
+            f"{encode_metadata_value(','.join(normalized_write_scopes))}"
+        )
     for key, value in (
         ("note", note),
         ("evidence", evidence),

--- a/goal_harness/todos.py
+++ b/goal_harness/todos.py
@@ -17,6 +17,7 @@ from .todo_contract import (
     TODO_TASK_PATTERN,
     build_todo_id,
     format_todo_metadata_line,
+    normalize_required_write_scopes,
     normalize_todo_id,
     normalize_todo_status,
     parse_todo_metadata_line,
@@ -36,6 +37,7 @@ TODO_METADATA_FIELDS = (
     "status",
     "task_class",
     "action_kind",
+    "required_write_scopes",
     "note",
     "evidence",
     "reason",
@@ -261,12 +263,20 @@ def matching_todo_block(
     return None
 
 
-def block_metadata(block: dict[str, Any]) -> dict[str, str]:
-    return {
-        key: str(block[key])
-        for key in TODO_METADATA_FIELDS
-        if block.get(key) is not None and str(block.get(key) or "").strip()
-    }
+def block_metadata(block: dict[str, Any]) -> dict[str, Any]:
+    metadata: dict[str, Any] = {}
+    for key in TODO_METADATA_FIELDS:
+        value = block.get(key)
+        if value is None:
+            continue
+        if key == "required_write_scopes":
+            scopes = normalize_required_write_scopes(value)
+            if scopes:
+                metadata[key] = scopes
+            continue
+        if str(value or "").strip():
+            metadata[key] = str(value).strip()
+    return metadata
 
 
 def metadata_line_for_block(block: dict[str, Any], updates: dict[str, Any]) -> str | None:
@@ -276,6 +286,12 @@ def metadata_line_for_block(block: dict[str, Any], updates: dict[str, Any]) -> s
             continue
         if value is None:
             metadata.pop(key, None)
+        elif key == "required_write_scopes":
+            scopes = normalize_required_write_scopes(value)
+            if scopes:
+                metadata[key] = scopes
+            else:
+                metadata.pop(key, None)
         elif str(value).strip():
             metadata[key] = str(value).strip()
     if "todo_id" not in metadata and block.get("todo_id"):
@@ -357,6 +373,7 @@ def add_todo_to_lines(
     text: str,
     task_class: str | None = None,
     action_kind: str | None = None,
+    required_write_scopes: list[str] | None = None,
 ) -> dict[str, Any]:
     todo_text = normalize_new_todo(text)
     bounds = section_bounds(lines, role)
@@ -389,6 +406,7 @@ def add_todo_to_lines(
             status=TODO_STATUS_OPEN,
             task_class=task_class,
             action_kind=action_kind,
+            required_write_scopes=required_write_scopes,
         )
         todo_line = "\n".join([f"- [ ] {todo_text}", metadata_line] if metadata_line else [f"- [ ] {todo_text}"])
         if bounds:
@@ -404,6 +422,8 @@ def add_todo_to_lines(
             updates["task_class"] = task_class
         if action_kind:
             updates["action_kind"] = action_kind
+        if required_write_scopes is not None:
+            updates["required_write_scopes"] = required_write_scopes
         metadata_line = metadata_line_for_block(block, updates)
         metadata_updated = upsert_todo_metadata(lines, block, metadata_line)
         todo_id = str(block.get("todo_id") or "")
@@ -418,6 +438,7 @@ def add_todo_to_lines(
         "todo_id": todo_id,
         "task_class": task_class,
         "action_kind": action_kind,
+        "required_write_scopes": normalize_required_write_scopes(required_write_scopes),
     }
 
 
@@ -429,6 +450,7 @@ def add_goal_todo(
     text: str,
     task_class: str | None = None,
     action_kind: str | None = None,
+    required_write_scopes: list[str] | None = None,
     project: Path | None = None,
     state_file: Path | None = None,
     dry_run: bool = False,
@@ -456,6 +478,7 @@ def add_goal_todo(
         text=todo_text,
         task_class=task_class,
         action_kind=action_kind,
+        required_write_scopes=required_write_scopes,
     )
     added = bool(add_result["added"])
     metadata_updated = bool(add_result["metadata_updated"])
@@ -480,6 +503,7 @@ def add_goal_todo(
         "todo_id": add_result.get("todo_id"),
         "task_class": add_result.get("task_class"),
         "action_kind": add_result.get("action_kind"),
+        "required_write_scopes": add_result.get("required_write_scopes"),
         "state_file": str(resolved_state_file),
         "project": str(resolved_project) if resolved_project else None,
         "updated_at": updated_at if added or metadata_updated else None,
@@ -519,6 +543,7 @@ def apply_todo_update_to_lines(
     reason: str | None = None,
     task_class: str | None = None,
     action_kind: str | None = None,
+    required_write_scopes: list[str] | None = None,
     updated_at: str,
 ) -> dict[str, Any]:
     normalized_todo_id = normalize_todo_id(todo_id)
@@ -556,6 +581,8 @@ def apply_todo_update_to_lines(
         updates["task_class"] = task_class
     if action_kind:
         updates["action_kind"] = action_kind
+    if required_write_scopes is not None:
+        updates["required_write_scopes"] = required_write_scopes
     metadata_line = metadata_line_for_block(block, updates)
     semantic_metadata_changed = todo_metadata_would_change(lines, block, metadata_line)
     if status_changed or semantic_metadata_changed:
@@ -586,6 +613,7 @@ def update_goal_todo(
     reason: str | None = None,
     task_class: str | None = None,
     action_kind: str | None = None,
+    required_write_scopes: list[str] | None = None,
     project: Path | None = None,
     state_file: Path | None = None,
     dry_run: bool = False,
@@ -607,6 +635,7 @@ def update_goal_todo(
         reason=reason,
         task_class=task_class,
         action_kind=action_kind,
+        required_write_scopes=required_write_scopes,
         updated_at=updated_at,
     )
     changed = bool(update_result["changed"])


### PR DESCRIPTION
## Summary
- add explicit required_write_scopes todo metadata and CLI add/update support
- make quota should-run turn missing goal_boundary.write_scope coverage into boundary_projection_repair instead of normal delivery
- add a focused smoke and update public docs for the action-scope guard contract

## Commit grouping
- runtime/API + focused validation: Add quota guard for todo write scopes
- public docs: Document action-scope guard contract

## Validation
- python3 -m py_compile goal_harness/todo_contract.py goal_harness/todos.py goal_harness/status.py goal_harness/quota.py goal_harness/cli.py
- python3 examples/quota-action-scope-guard-smoke.py
- python3 examples/todo-first-open-summary-smoke.py
- python3 examples/status-markdown-smoke.py
- goal-harness check --scan-path docs/interaction-pattern-catalog.md --scan-path docs/quota-allocation.md --scan-path examples/quota-action-scope-guard-smoke.py

## Boundary scan
- scanned candidate paths for credentials/private markers/local paths/raw logs; no private artifacts staged
- goal-harness check public boundary scan clean for changed docs/smoke

## Notes
- goal-harness check still reports the pre-existing duplicate index warning for goal-harness-meta.