### PR TITLE
Add checkpointed boundary authority projection

### DIFF
--- a/docs/dreaming-exploration-lane.md
+++ b/docs/dreaming-exploration-lane.md
@@ -73,6 +73,27 @@ Default permissions are intentionally narrow:
 The output of dreaming is a proposal, warning, or candidate patch plan. The
 operator or project controller decides whether it becomes normal project work.
 
+## Relationship To Replanning
+
+Dreaming and autonomous replanning are control-plane planning lanes. They are
+allowed to repair the execution track, summarize cross-run patterns, and create
+reviewable options. They must not silently become the task policy that decides
+how the project agent solves the current implementation problem.
+
+Use this boundary:
+
+| Lane | Output authority | Typical output | Promotion path |
+| --- | --- | --- | --- |
+| Delivery agent policy | Executes within the current authorized boundary. | Implementation plan, debug strategy, validation choice, bounded patch. | Writes validated work events and active-state updates after delivery. |
+| Autonomous replan | Bounded control-plane obligation when execution is stuck or stale. | Split/retire/add todo, request blocker writeback, ask for operator decision, name next validation command and stop condition. | Writes control-plane state only after validation, or routes to user/controller gate. |
+| Dreaming / exploration | Advisory proposal by default. | Refactor warning, memory consolidation, option comparison, archive suggestion, risk note. | Enters operator/controller review before becoming normal delivery work or active project truth. |
+
+The question for any planning output is whether it is `authority` or
+`proposal`. Guard and freshness outputs can be authority-like control signals;
+dreaming outputs are proposals unless a later operator/controller decision
+promotes them. This keeps Goal Harness from becoming a second brittle agent
+while still letting it maintain the long-horizon execution track.
+
 ## Run Record Shape
 
 Dreaming runs should be visible but not mixed with delivery runs:

--- a/docs/interaction-pattern-catalog.md
+++ b/docs/interaction-pattern-catalog.md
@@ -270,13 +270,32 @@ user/controller gate. The agent should not execute the write, and should not
 spend turns on repo-only handoff if the real blocker is missing scope
 projection.
 
+Only structured checkpointed authority can extend the runtime boundary. A
+historical approval written in prose is not enough. The registry may carry
+`coordination.checkpointed_boundary_authority[]` entries with:
+
+- `schema_version=checkpointed_boundary_authority_v0`;
+- `write_scope`;
+- `source` or equivalent public-safe provenance;
+- `recorded_at`;
+- optional `expires_at`;
+- `decision=approve` and active status.
+
+Fresh approved entries are compiled into `goal_boundary.write_scope` and
+exposed under `goal_boundary.checkpointed_boundary_authority`. Expired,
+rejected, missing-provenance, or missing-timestamp entries remain visible only
+as diagnostics; they do not authorize writes.
+
 **Visual Model**
 
 ```mermaid
 flowchart TD
   A["selected action"] --> S{"requires write scope?"}
   S -->|"no"| E["execute if otherwise safe"]
-  S -->|"yes"| B{"scope in goal_boundary.write_scope?"}
+  S -->|"yes"| C{"fresh checkpointed authority?"}
+  C -->|"yes"| P["compile authority into goal_boundary.write_scope"]
+  C -->|"no"| B{"scope already in explicit write_scope?"}
+  P --> B
   B -->|"yes"| E
   B -->|"no"| R["boundary projection repair or user/controller gate"]
 ```
@@ -290,6 +309,7 @@ the checkpointed decision.
 **Validation**
 
 - `examples/quota-action-scope-guard-smoke.py`;
+- `examples/configure-goal-smoke.py`;
 - `docs/state-interaction-model.md` checkpointed decision sections.
 
 ## IP-006 Outcome Floor Recovery

--- a/docs/research/long-horizon-agent-benchmarks/roadmap.md
+++ b/docs/research/long-horizon-agent-benchmarks/roadmap.md
@@ -280,6 +280,14 @@ meta-step that re-reads authority, run history, benchmark evidence, open todos,
 and recent failures, then decides whether to keep the current todo, split it,
 add a new todo, retire stale work, or request an operator decision.
 
+This is control-plane planning, not task-policy planning. The refresh may
+repair the execution track when the project stops converting intent into
+evidence, but the worker model still owns belief synthesis and the concrete
+implementation/debug strategy inside the authorized boundary. Goal Harness can
+say "this todo is stale; split it and validate the next slice with command X."
+It should not silently decide the semantic solution to the task or rewrite
+project direction as if a dreaming or replan proposal were already approved.
+
 Initial trigger conditions:
 
 - **Periodic research review:** every 20-30 visible turns or durable run events
@@ -310,6 +318,15 @@ This mechanism is part of the benchmark program itself: one result dimension is
 whether Goal Harness can autonomously maintain a useful research agenda over
 many turns without drifting into prompt-only planning or waiting for the user to
 restate the strategy.
+
+Planning outputs should carry their authority level:
+
+| Authority level | Meaning | Default consumer behavior |
+| --- | --- | --- |
+| `control_signal` | A guard, quota, freshness, or safety fact that constrains the next run. | Obey before delivery or ask the user/controller if blocked. |
+| `bounded_replan_obligation` | A required control-plane repair slice, such as todo split, blocker writeback, or state rebase. | Execute one validated repair slice, then write back or record why blocked. |
+| `proposal` | A dreaming/exploration/research suggestion that may improve future work. | Route to operator/controller review before making it active project truth. |
+| `agent_policy_choice` | A concrete task-solving strategy chosen from current belief. | Belongs to the worker inside the current authorized boundary. |
 
 ## Goal Harness Integration
 

--- a/docs/reward-gate-direct-write-contract.md
+++ b/docs/reward-gate-direct-write-contract.md
@@ -32,6 +32,21 @@ write is enabled:
 Unknown fields and private-looking text must be rejected instead of silently
 ignored.
 
+## Run-Bound Overlay
+
+A run-bound overlay is a compact append-only annotation attached to one exact
+run index row. It is "run-bound" because its target is a specific run, usually
+identified by `goal_id` plus `run_generated_at` / run path. It is an "overlay"
+because it annotates that prior run without rewriting the original run payload,
+active goal state, or every future decision.
+
+For `human_reward`, the overlay records the operator's judgment of that exact
+run or route outcome: decision label, reward value, reason summary, follow-up,
+and timestamp. Later status, dashboard, and controller-readiness projections may
+summarize the overlay, but the run-bound overlay remains the durable source of
+truth. It does not grant write-control, production access, public submission
+permission, or permission to skip a fresh registry/state/quota read.
+
 ## Human Reward
 
 `human_reward` judges one exact run or route outcome. The canonical writer is

--- a/docs/state-interaction-model.md
+++ b/docs/state-interaction-model.md
@@ -316,6 +316,44 @@ flowchart TB
   Runs --> Observation
 ```
 
+### Agent Loop Adapter Depth
+
+Deep agent-loop integration is an upper bound, not a prerequisite. Goal
+Harness must still add value when the worker is a black-box CLI, hosted agent,
+benchmark runner, or third-party loop that cannot be modified. The control
+plane should therefore support three adapter depths:
+
+| Mode | When available | Goal Harness responsibilities |
+| --- | --- | --- |
+| `in_loop` | The worker can call Goal Harness APIs or tools during its own loop. | Inject observation packets, expose freshness/gate/quota checks before actions, require writeback after validated transitions, and let the worker use current status as first-class context. |
+| `wrapper` | Goal Harness can launch or wrap the worker command, prompt, workspace, or environment, but cannot alter the internal loop. | Run pre-flight status/freshness checks, prepend or mount a compact state packet, guard high-risk external actions where hooks exist, collect stdout/artifacts/diffs, and reduce the result into durable events. |
+| `passive_posthoc` | Goal Harness cannot launch or intercept the worker; it can only inspect observable outputs after the fact. | Read repo diffs, logs, run artifacts, benchmark outputs, or user notes; classify work/evidence/blocker/decision targets; append compact events; and produce restart packets for the next run. |
+
+The invariant across all three depths is the same: Goal Harness produces and
+validates control-plane context around the agent loop, whether or not the loop
+natively cooperates. If the loop cannot be trusted to stop on a boundary, the
+boundary must move outward to the wrapper, submit path, PR gate, benchmark
+upload, cloud job launcher, production command, or operator approval surface.
+
+```mermaid
+flowchart LR
+  Status["status / quota / freshness"] --> Preflight["pre-flight packet"]
+  Preflight --> Worker["black-box or cooperative agent loop"]
+  Worker --> Artifacts["diffs, logs, stdout, artifacts, tests"]
+  Artifacts --> Reducer["post-run reducer"]
+  Reducer --> Events["durable events and overlays"]
+  Events --> Restart["restart packet"]
+  Restart --> Preflight
+  Status --> Guard["external gate for risky actions"]
+  Guard -->|"approve, block, or ask user"| Worker
+```
+
+This makes passive and wrapper modes first-class product surfaces, not
+fallbacks. The passive baseline should prove that even a non-cooperative worker
+gets better restartability, stale-state avoidance, evidence discipline, and
+reward attribution from Goal Harness before deeper agent-loop cooperation is
+treated as required.
+
 ## State Stores
 
 | Store | Owner | Reader | Writer | Purpose |

--- a/docs/state-interaction-model.md
+++ b/docs/state-interaction-model.md
@@ -210,6 +210,112 @@ This keeps the user's role high-value: the user resolves real boundaries and
 reward judgments, while Goal Harness prevents the agent from stalling on
 routine routing choices.
 
+## Agentic RL Boundary Model
+
+Goal Harness should be the external control plane around an agentic RL-style
+worker, not the policy itself. Its job is to turn partial, long-running project
+history into a current, auditable observation packet. The model's job is to
+turn that packet plus the live workspace context into an internal belief state
+and choose the next bounded action.
+
+The runtime split is:
+
+```text
+observation_t = project(
+  registry,
+  active_goal_state,
+  event_ledger,
+  run_history,
+  todos,
+  gates,
+  quota,
+  authority_sources,
+  decision_freshness
+)
+
+belief_t = model.update(
+  observation_t,
+  system_prompt,
+  current_thread_context,
+  current_tool_observations,
+  model_memory,
+  uncertainty
+)
+
+action_t = model.policy(belief_t)
+checked_action_t = goal_harness.guard(action_t, observation_t)
+event_or_reward_t+1 = append_after_validation(checked_action_t, outcome_t)
+```
+
+In this model, `event replay` is input material for `observation_t`, and
+`human_reward` is a later evaluation signal. Neither one is the model's full
+execution state. The execution state is the model's current belief, which is
+allowed to be richer than the Goal Harness projection but must not silently
+override Goal Harness boundaries, authority, freshness warnings, or user gates.
+
+| Layer | Owns | Must not own |
+| --- | --- | --- |
+| Goal Harness control plane | Durable facts, event ledger, active-state projection, authority source registration, decision freshness, quota, gates, restartability, public/private boundary checks, run-bound reward overlays. | Semantic planning, hidden preference learning, task-specific policy, unrecorded approvals, or model-internal belief. |
+| Agentic model / executor | Belief synthesis, uncertainty handling, action selection, semantic rebase of old decisions against current evidence, bounded implementation, validation choice, and asking the user when ambiguity is real. | Durable source of truth, implicit write authorization, permanent user preference storage outside goal events, or treating chat memory as stronger than current status. |
+| Human/operator | Reward, approval, private-material access, production/destructive/external-resource decisions, and high-level tradeoff judgment. | Routine public reads, ordinary local validation, or reconstructing current state by hand when Goal Harness can project it. |
+
+This keeps checkpointed decisions narrow. A checkpointed approval, reward, or
+resume contract is an audit anchor with a validity check, not an instruction to
+replay the old chat. Before a worker reuses it, Goal Harness should indicate
+whether the decision point needs a rebase against current registry, active
+state, quota, policy, repo/run status, and newer evidence. The model then
+interprets whether the old decision still applies, asks the user if the answer
+is ambiguous, and records the resulting transition as a new event.
+
+For write authority, the checkpoint must become a boundary projection before
+execution. `coordination.checkpointed_boundary_authority[]` is the compact
+machine shape for this projection: fresh approved entries with public-safe
+provenance, `recorded_at`, and `write_scope` compile into
+`goal_boundary.write_scope`. Prose in a handoff, chat memory, or an old
+approval run can motivate the agent to repair the projection, but it does not
+grant write authority by itself. If a selected todo declares
+`required_write_scopes` and the compiled boundary does not cover them,
+`quota should-run` must route to `boundary_projection_repair` or a concrete
+user/controller gate instead of letting the agent perform the protected write.
+
+```mermaid
+flowchart TB
+  subgraph Harness["Goal Harness control plane"]
+    Registry["Registry and authority sources"]
+    ActiveState["Active goal state"]
+    Ledger["Append-only event ledger"]
+    Runs["Run history and overlays"]
+    Gates["Gates, quota, freshness"]
+    Observation["Compact observation packet"]
+  end
+
+  subgraph Model["Agentic model / executor"]
+    Belief["belief_t: awareness of current task"]
+    Policy["policy(belief_t)"]
+    Action["bounded action proposal"]
+  end
+
+  subgraph Operator["Human/operator"]
+    Approval["approval or deferral"]
+    Reward["run-bound human_reward overlay"]
+  end
+
+  Registry --> Observation
+  ActiveState --> Observation
+  Ledger --> Observation
+  Runs --> Observation
+  Gates --> Observation
+  Observation --> Belief
+  Belief --> Policy
+  Policy --> Action
+  Action --> Gates
+  Gates -->|"allowed or needs rebase/user gate"| Action
+  Action -->|"validated work, blocker, evidence"| Ledger
+  Approval --> Ledger
+  Reward --> Runs
+  Runs --> Observation
+```
+
 ## State Stores
 
 | Store | Owner | Reader | Writer | Purpose |

--- a/examples/configure-goal-smoke.py
+++ b/examples/configure-goal-smoke.py
@@ -106,12 +106,20 @@ def main() -> int:
             "validation",
             "--waiting-on",
             "user_or_controller",
+            "--boundary-authority-scope",
+            "docs/**",
+            "--boundary-authority-source",
+            "operator_gate_resume_contract_v0:fixture",
+            "--boundary-authority-decision-id",
+            "gate-fixture-1",
         ))
         assert dry["ok"] is True, dry
         assert dry["dry_run"] is True, dry
         assert dry["changed"] is True, dry
         assert "waiting_on" in dry["changed_fields"], dry
+        assert "checkpointed_boundary_authority" in dry["changed_fields"], dry
         assert dry["after"]["waiting_on"] == "user_or_controller", dry
+        assert dry["after"]["checkpointed_boundary_authority"]["active_write_scope"] == ["docs/**"], dry
         assert dry["written"] is False, dry
         assert registry_path.read_text(encoding="utf-8") == original
 
@@ -134,6 +142,12 @@ def main() -> int:
             "docs,validation",
             "--waiting-on",
             "user_or_controller",
+            "--boundary-authority-scope",
+            "docs/**",
+            "--boundary-authority-source",
+            "operator_gate_resume_contract_v0:fixture",
+            "--boundary-authority-decision-id",
+            "gate-fixture-1",
             "--execute",
         ))
         assert applied["ok"] is True, applied
@@ -149,6 +163,11 @@ def main() -> int:
         assert goal["spawn_policy"]["max_children"] == 2, goal
         assert goal["spawn_policy"]["allowed_domains"] == ["docs", "validation"], goal
         assert goal["waiting_on"] == "user_or_controller", goal
+        authority = goal["coordination"]["checkpointed_boundary_authority"][0]
+        assert authority["schema_version"] == "checkpointed_boundary_authority_v0", authority
+        assert authority["write_scope"] == ["docs/**"], authority
+        assert authority["source"] == "operator_gate_resume_contract_v0:fixture", authority
+        assert authority["decision_id"] == "gate-fixture-1", authority
 
         no_change = payload(run_cli(
             registry_path,
@@ -173,6 +192,19 @@ def main() -> int:
         assert cleared["changed"] is True, cleared
         assert "waiting_on" in cleared["changed_fields"], cleared
         assert "waiting_on" not in goal_from_registry(registry_path), cleared
+
+        authority_cleared = payload(run_cli(
+            registry_path,
+            "configure-goal",
+            "--goal-id",
+            GOAL_ID,
+            "--clear-boundary-authority",
+            "--execute",
+        ))
+        assert authority_cleared["ok"] is True, authority_cleared
+        assert authority_cleared["changed"] is True, authority_cleared
+        assert "checkpointed_boundary_authority" in authority_cleared["changed_fields"], authority_cleared
+        assert "checkpointed_boundary_authority" not in goal_from_registry(registry_path)["coordination"], authority_cleared
 
         invalid = payload(run_cli(
             registry_path,

--- a/examples/quota-action-scope-guard-smoke.py
+++ b/examples/quota-action-scope-guard-smoke.py
@@ -11,6 +11,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from goal_harness.boundary_authority import build_checkpointed_boundary_authority_entry  # noqa: E402
 from goal_harness.quota import build_quota_should_run, render_quota_should_run_markdown  # noqa: E402
 from goal_harness.status import compact_todo_group, project_asset_todo_summary  # noqa: E402
 from goal_harness.todo_contract import format_todo_metadata_line, parse_todo_metadata_line  # noqa: E402
@@ -20,7 +21,11 @@ GOAL_ID = "action-scope-guard-fixture"
 TODO_TEXT = "Patch the runner adapter after the checkpointed owner decision is projected."
 
 
-def status_payload(*, allowed_scopes: list[str]) -> dict:
+def status_payload(
+    *,
+    allowed_scopes: list[str],
+    checkpointed_boundary_authority: list[dict] | None = None,
+) -> dict:
     todo = {
         "index": 1,
         "done": False,
@@ -77,6 +82,7 @@ def status_payload(*, allowed_scopes: list[str]) -> dict:
                     "coordination": {
                         "write_scope": allowed_scopes,
                         "requires_parent_approval": ["publish", "production-action"],
+                        "checkpointed_boundary_authority": checkpointed_boundary_authority or [],
                     },
                     "latest_runs": [],
                 }
@@ -158,10 +164,61 @@ def assert_allowed_scope_remains_runnable() -> None:
     assert payload["goal_boundary"]["write_scope"] == ["runners/**", "docs/**"], payload
 
 
+def assert_checkpointed_authority_compiles_into_goal_boundary() -> None:
+    authority = build_checkpointed_boundary_authority_entry(
+        write_scopes=["runners/**"],
+        source="operator_gate_resume_contract_v0:fixture",
+        decision_id="gate-fixture-1",
+        recorded_at="2026-06-17T00:00:00+00:00",
+    )
+    payload = build_quota_should_run(
+        status_payload(
+            allowed_scopes=["docs/**"],
+            checkpointed_boundary_authority=[authority],
+        ),
+        goal_id=GOAL_ID,
+    )
+    assert payload["should_run"] is True, payload
+    assert payload["normal_delivery_allowed"] is True, payload
+    assert payload["effective_action"] == "normal_run", payload
+    boundary = payload["goal_boundary"]
+    assert boundary["write_scope"] == ["docs/**", "runners/**"], boundary
+    assert boundary["checkpointed_boundary_authority"]["active_count"] == 1, boundary
+    assert boundary["checkpointed_boundary_authority"]["active_write_scope"] == ["runners/**"], boundary
+    assert "boundary_projection_gap" not in payload, payload
+
+
+def assert_expired_checkpointed_authority_does_not_authorize_write() -> None:
+    expired_authority = build_checkpointed_boundary_authority_entry(
+        write_scopes=["runners/**"],
+        source="operator_gate_resume_contract_v0:expired-fixture",
+        decision_id="gate-expired-1",
+        recorded_at="2026-06-17T00:00:00+00:00",
+        expires_at="2000-01-01T00:00:00+00:00",
+    )
+    payload = build_quota_should_run(
+        status_payload(
+            allowed_scopes=["docs/**"],
+            checkpointed_boundary_authority=[expired_authority],
+        ),
+        goal_id=GOAL_ID,
+    )
+    assert payload["normal_delivery_allowed"] is False, payload
+    assert payload["effective_action"] == "boundary_projection_repair", payload
+    gap = payload["boundary_projection_gap"]
+    assert gap["missing_write_scopes"] == ["runners/openviking/**"], gap
+    assert gap["checkpointed_boundary_authority"]["inactive_count"] == 1, gap
+    candidates = gap["inactive_authority_candidates"]
+    assert candidates[0]["decision_id"] == "gate-expired-1", candidates
+    assert "expired" in candidates[0]["inactive_reasons"], candidates
+
+
 def main() -> int:
     assert_required_write_scope_metadata_roundtrip()
     assert_missing_scope_repairs_boundary()
     assert_allowed_scope_remains_runnable()
+    assert_checkpointed_authority_compiles_into_goal_boundary()
+    assert_expired_checkpointed_authority_does_not_authorize_write()
     print("quota-action-scope-guard-smoke ok")
     return 0
 

--- a/goal_harness/boundary_authority.py
+++ b/goal_harness/boundary_authority.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from typing import Any
+
+from .todo_contract import normalize_required_write_scopes
+
+
+CHECKPOINTED_BOUNDARY_AUTHORITY_SCHEMA_VERSION = "checkpointed_boundary_authority_v0"
+ACTIVE_BOUNDARY_AUTHORITY_STATUSES = {"active", "approved"}
+BOUNDARY_AUTHORITY_DECISIONS = {"approve", "reject", "defer"}
+PRIVATE_TEXT_PATTERNS = (
+    re.compile(r"/" + r"Users/"),
+    re.compile(r"/" + r"ext_data/"),
+    re.compile("la" + "rk" + "office", re.I),
+    re.compile("docs" + r"\." + "internal", re.I),
+    re.compile(r"\bt-20\d{12}-[a-z0-9]+\b"),
+    re.compile(r"\b" + "Bear" + r"er\b", re.I),
+    re.compile(r"\b" + "Author" + r"ization\b", re.I),
+    re.compile(r"\b" + "tok" + r"en\s*=", re.I),
+    re.compile(r"\b" + "pass" + r"word\b", re.I),
+    re.compile(r"\b" + "sec" + r"ret\b", re.I),
+)
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc).astimezone()
+
+
+def _parse_timestamp(value: Any) -> datetime | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _validate_public_safe_text(label: str, value: str | None) -> None:
+    if not value:
+        return
+    for pattern in PRIVATE_TEXT_PATTERNS:
+        if pattern.search(value):
+            raise ValueError(f"{label} contains a private-looking value; keep raw evidence in private payloads")
+
+
+def _clean_text(value: Any, *, limit: int = 180) -> str | None:
+    text = " ".join(str(value or "").strip().split())
+    if not text:
+        return None
+    _validate_public_safe_text("checkpointed_boundary_authority", text)
+    return text[:limit]
+
+
+def build_checkpointed_boundary_authority_entry(
+    *,
+    write_scopes: list[str],
+    source: str,
+    decision_id: str | None = None,
+    recorded_at: str | None = None,
+    expires_at: str | None = None,
+    decision: str = "approve",
+    status: str = "active",
+) -> dict[str, Any]:
+    scopes = normalize_required_write_scopes(write_scopes)
+    if not scopes:
+        raise ValueError("boundary authority requires at least one public-safe write scope")
+    normalized_decision = str(decision or "").strip().lower()
+    if normalized_decision not in BOUNDARY_AUTHORITY_DECISIONS:
+        raise ValueError(
+            "boundary authority decision must be one of: "
+            + ", ".join(sorted(BOUNDARY_AUTHORITY_DECISIONS))
+        )
+    normalized_source = _clean_text(source)
+    if not normalized_source:
+        raise ValueError("boundary authority source is required")
+    normalized_decision_id = _clean_text(decision_id, limit=120)
+    normalized_status = str(status or "active").strip().lower() or "active"
+    recorded = str(recorded_at or _now().replace(microsecond=0).isoformat()).strip()
+    if not _parse_timestamp(recorded):
+        raise ValueError("boundary authority recorded_at must be an ISO timestamp")
+    entry: dict[str, Any] = {
+        "schema_version": CHECKPOINTED_BOUNDARY_AUTHORITY_SCHEMA_VERSION,
+        "status": normalized_status,
+        "decision": normalized_decision,
+        "write_scope": scopes,
+        "source": normalized_source,
+        "recorded_at": recorded,
+    }
+    if normalized_decision_id:
+        entry["decision_id"] = normalized_decision_id
+    if expires_at:
+        if not _parse_timestamp(expires_at):
+            raise ValueError("boundary authority expires_at must be an ISO timestamp")
+        entry["expires_at"] = str(expires_at).strip()
+    return entry
+
+
+def normalize_checkpointed_boundary_authority_entries(
+    value: Any,
+    *,
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    current_time = now or _now()
+    entries: list[dict[str, Any]] = []
+    for raw in value:
+        if not isinstance(raw, dict):
+            continue
+        scopes = normalize_required_write_scopes(
+            raw.get("write_scope")
+            or raw.get("write_scopes")
+            or raw.get("scope")
+            or raw.get("scopes")
+        )
+        decision = str(raw.get("decision") or raw.get("operator_decision") or "approve").strip().lower()
+        if decision not in BOUNDARY_AUTHORITY_DECISIONS:
+            decision = "defer"
+        status = str(raw.get("status") or "active").strip().lower() or "active"
+        source = _clean_text(raw.get("source") or raw.get("provenance") or raw.get("reason_summary"))
+        decision_id = _clean_text(raw.get("decision_id") or raw.get("run_id") or raw.get("gate_id"), limit=120)
+        recorded_at = str(raw.get("recorded_at") or raw.get("decision_at") or "").strip()
+        expires_at = str(raw.get("expires_at") or raw.get("fresh_until") or "").strip()
+        recorded = _parse_timestamp(recorded_at)
+        expires = _parse_timestamp(expires_at)
+        inactive_reasons: list[str] = []
+        if not scopes:
+            inactive_reasons.append("missing_write_scope")
+        if not source:
+            inactive_reasons.append("missing_provenance")
+        if not recorded:
+            inactive_reasons.append("missing_recorded_at")
+        if status not in ACTIVE_BOUNDARY_AUTHORITY_STATUSES:
+            inactive_reasons.append("inactive_status")
+        if decision != "approve":
+            inactive_reasons.append("decision_not_approved")
+        if expires and expires < current_time:
+            inactive_reasons.append("expired")
+        entry: dict[str, Any] = {
+            "schema_version": CHECKPOINTED_BOUNDARY_AUTHORITY_SCHEMA_VERSION,
+            "status": status,
+            "decision": decision,
+            "write_scope": scopes,
+            "source": source,
+            "recorded_at": recorded_at or None,
+            "expires_at": expires_at or None,
+            "freshness": "expired" if "expired" in inactive_reasons else "fresh",
+            "active": not inactive_reasons,
+        }
+        if decision_id:
+            entry["decision_id"] = decision_id
+        if inactive_reasons:
+            entry["inactive_reasons"] = inactive_reasons
+        entries.append({key: payload for key, payload in entry.items() if payload is not None})
+    return entries
+
+
+def checkpointed_boundary_authority_summary(coordination: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(coordination, dict):
+        return None
+    entries = normalize_checkpointed_boundary_authority_entries(
+        coordination.get("checkpointed_boundary_authority")
+    )
+    if not entries:
+        return None
+    active_entries = [entry for entry in entries if entry.get("active") is True]
+    active_scopes: list[str] = []
+    for entry in active_entries:
+        for scope in normalize_required_write_scopes(entry.get("write_scope")):
+            if scope not in active_scopes:
+                active_scopes.append(scope)
+    return {
+        "schema_version": CHECKPOINTED_BOUNDARY_AUTHORITY_SCHEMA_VERSION,
+        "active_count": len(active_entries),
+        "inactive_count": len(entries) - len(active_entries),
+        "active_write_scope": active_scopes,
+        "entries": entries,
+    }

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -2220,6 +2220,36 @@ def main(argv: list[str] | None = None) -> int:
         help="Remove the registry waiting_on override.",
     )
     configure_goal_parser.add_argument(
+        "--boundary-authority-scope",
+        action="append",
+        default=None,
+        help=(
+            "Checkpointed write scope approved by an operator/controller decision. "
+            "Repeatable; comma-separated values are also accepted."
+        ),
+    )
+    configure_goal_parser.add_argument(
+        "--boundary-authority-source",
+        help="Public-safe provenance for the checkpointed boundary authority.",
+    )
+    configure_goal_parser.add_argument(
+        "--boundary-authority-decision-id",
+        help="Public-safe decision/run/gate id for the checkpointed boundary authority.",
+    )
+    configure_goal_parser.add_argument(
+        "--boundary-authority-recorded-at",
+        help="ISO timestamp for the checkpointed decision. Defaults to now.",
+    )
+    configure_goal_parser.add_argument(
+        "--boundary-authority-expires-at",
+        help="Optional ISO timestamp after which the checkpointed authority is no longer fresh.",
+    )
+    configure_goal_parser.add_argument(
+        "--clear-boundary-authority",
+        action="store_true",
+        help="Clear coordination.checkpointed_boundary_authority.",
+    )
+    configure_goal_parser.add_argument(
         "--execute",
         action="store_true",
         help="Write the registry. Without this flag, configure-goal is a dry-run preview.",
@@ -5297,6 +5327,12 @@ def main(argv: list[str] | None = None) -> int:
                 clear_allowed_domains=bool(args.clear_allowed_domains),
                 waiting_on=args.waiting_on,
                 clear_waiting_on=bool(args.clear_waiting_on),
+                boundary_authority_scopes=args.boundary_authority_scope,
+                boundary_authority_source=args.boundary_authority_source,
+                boundary_authority_decision_id=args.boundary_authority_decision_id,
+                boundary_authority_recorded_at=args.boundary_authority_recorded_at,
+                boundary_authority_expires_at=args.boundary_authority_expires_at,
+                clear_boundary_authority=bool(args.clear_boundary_authority),
                 execute=bool(args.execute),
             )
         except Exception as exc:

--- a/goal_harness/configure_goal.py
+++ b/goal_harness/configure_goal.py
@@ -6,6 +6,10 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from .boundary_authority import (
+    build_checkpointed_boundary_authority_entry,
+    checkpointed_boundary_authority_summary,
+)
 from .control_plane import compact_control_plane_policy, control_plane_policy_summary
 from .orchestration import compact_orchestration_policy, orchestration_policy_summary
 from .quota import goal_quota_config
@@ -56,6 +60,7 @@ def _settings_summary(goal: dict[str, Any]) -> dict[str, Any]:
     quota = goal_quota_config(goal)
     control_plane = compact_control_plane_policy(goal.get("control_plane"))
     orchestration = compact_orchestration_policy(goal.get("spawn_policy"))
+    coordination = goal.get("coordination") if isinstance(goal.get("coordination"), dict) else {}
     return {
         "quota": {
             "compute": quota.get("compute"),
@@ -64,6 +69,7 @@ def _settings_summary(goal: dict[str, Any]) -> dict[str, Any]:
         "control_plane": control_plane,
         "orchestration": orchestration,
         "waiting_on": goal.get("waiting_on"),
+        "checkpointed_boundary_authority": checkpointed_boundary_authority_summary(coordination),
     }
 
 
@@ -92,6 +98,12 @@ def configure_goal(
     clear_allowed_domains: bool = False,
     waiting_on: str | None = None,
     clear_waiting_on: bool = False,
+    boundary_authority_scopes: list[str] | None = None,
+    boundary_authority_source: str | None = None,
+    boundary_authority_decision_id: str | None = None,
+    boundary_authority_recorded_at: str | None = None,
+    boundary_authority_expires_at: str | None = None,
+    clear_boundary_authority: bool = False,
     execute: bool = False,
 ) -> dict[str, Any]:
     if not registry_path.exists():
@@ -100,6 +112,18 @@ def configure_goal(
         raise ValueError("--clear-allowed-domains cannot be combined with --allowed-domain")
     if clear_waiting_on and waiting_on:
         raise ValueError("--clear-waiting-on cannot be combined with --waiting-on")
+    adding_boundary_authority = any(
+        value
+        for value in (
+            boundary_authority_scopes,
+            boundary_authority_source,
+            boundary_authority_decision_id,
+            boundary_authority_recorded_at,
+            boundary_authority_expires_at,
+        )
+    )
+    if clear_boundary_authority and adding_boundary_authority:
+        raise ValueError("--clear-boundary-authority cannot be combined with boundary authority fields")
     if waiting_on and waiting_on not in WAITING_ON_CHOICES:
         raise ValueError("--waiting-on must be one of: " + ", ".join(WAITING_ON_CHOICES))
 
@@ -165,6 +189,26 @@ def configure_goal(
         goal["waiting_on"] = waiting_on
     elif clear_waiting_on:
         goal.pop("waiting_on", None)
+
+    if clear_boundary_authority or adding_boundary_authority:
+        coordination = goal.get("coordination") if isinstance(goal.get("coordination"), dict) else {}
+        if clear_boundary_authority:
+            coordination.pop("checkpointed_boundary_authority", None)
+        if adding_boundary_authority:
+            entry = build_checkpointed_boundary_authority_entry(
+                write_scopes=boundary_authority_scopes or [],
+                source=boundary_authority_source or "",
+                decision_id=boundary_authority_decision_id,
+                recorded_at=boundary_authority_recorded_at,
+                expires_at=boundary_authority_expires_at,
+            )
+            entries = (
+                coordination.get("checkpointed_boundary_authority")
+                if isinstance(coordination.get("checkpointed_boundary_authority"), list)
+                else []
+            )
+            coordination["checkpointed_boundary_authority"] = [*entries, entry]
+        goal["coordination"] = coordination
 
     after = _settings_summary(goal)
     changed_fields = _changed_fields(before, after)

--- a/goal_harness/quota.py
+++ b/goal_harness/quota.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
+from .boundary_authority import checkpointed_boundary_authority_summary
 from .control_plane import (
     compact_control_plane_policy,
     control_plane_policy_summary,
@@ -1739,8 +1740,19 @@ def _goal_boundary(goal: dict[str, Any], item: dict[str, Any] | None = None) -> 
         if isinstance(coordination.get("requires_parent_approval"), list)
         else []
     )
-    if write_scope:
-        boundary["write_scope"] = [str(value) for value in write_scope if str(value).strip()]
+    normalized_write_scope: list[str] = []
+    for value in write_scope:
+        scope = str(value).strip()
+        if scope and scope not in normalized_write_scope:
+            normalized_write_scope.append(scope)
+    boundary_authority = checkpointed_boundary_authority_summary(coordination)
+    if boundary_authority:
+        for scope in normalize_required_write_scopes(boundary_authority.get("active_write_scope")):
+            if scope not in normalized_write_scope:
+                normalized_write_scope.append(scope)
+        boundary["checkpointed_boundary_authority"] = boundary_authority
+    if normalized_write_scope:
+        boundary["write_scope"] = normalized_write_scope
     if requires_approval:
         boundary["requires_parent_approval"] = [
             str(value) for value in requires_approval if str(value).strip()
@@ -2163,7 +2175,12 @@ def _boundary_projection_repair_hint(
     if not missing_scopes:
         return None
     selected_text = _protocol_action_text(selected.get("text"), limit=220)
-    return {
+    boundary_authority = (
+        boundary.get("checkpointed_boundary_authority")
+        if isinstance(boundary.get("checkpointed_boundary_authority"), dict)
+        else None
+    )
+    repair: dict[str, Any] = {
         "source": "quota.should-run",
         "trigger": "required_write_scope_missing_from_goal_boundary",
         "recommended_mode": "repair_boundary_projection",
@@ -2194,6 +2211,37 @@ def _boundary_projection_repair_hint(
         },
         "selected_todo_text": selected_text,
     }
+    if boundary_authority:
+        repair["checkpointed_boundary_authority"] = {
+            "schema_version": boundary_authority.get("schema_version"),
+            "active_count": boundary_authority.get("active_count"),
+            "inactive_count": boundary_authority.get("inactive_count"),
+            "active_write_scope": boundary_authority.get("active_write_scope"),
+        }
+        inactive_candidates = []
+        for entry in boundary_authority.get("entries") or []:
+            if not isinstance(entry, dict) or entry.get("active") is True:
+                continue
+            scopes = normalize_required_write_scopes(entry.get("write_scope"))
+            if any(_write_scope_allowed(scope, scopes) for scope in missing_scopes):
+                inactive_candidates.append(
+                    {
+                        key: entry.get(key)
+                        for key in (
+                            "decision_id",
+                            "source",
+                            "recorded_at",
+                            "expires_at",
+                            "freshness",
+                            "inactive_reasons",
+                            "write_scope",
+                        )
+                        if entry.get(key) is not None
+                    }
+                )
+        if inactive_candidates:
+            repair["inactive_authority_candidates"] = inactive_candidates[:3]
+    return repair
 
 
 def _control_plane_post_handoff_observation_hint(item: dict[str, Any]) -> dict[str, Any] | None:

--- a/goal_harness/status_server.py
+++ b/goal_harness/status_server.py
@@ -49,6 +49,12 @@ CONFIGURE_GOAL_REQUEST_FIELDS = {
     "max_children",
     "allowed_domains",
     "clear_allowed_domains",
+    "boundary_authority_scopes",
+    "boundary_authority_source",
+    "boundary_authority_decision_id",
+    "boundary_authority_recorded_at",
+    "boundary_authority_expires_at",
+    "clear_boundary_authority",
 }
 CONFIGURE_GOAL_APPLY_FIELDS = CONFIGURE_GOAL_REQUEST_FIELDS | {"preview_id"}
 
@@ -293,6 +299,9 @@ class StatusRequestHandler(BaseHTTPRequestHandler):
         allowed_domains = body.get("allowed_domains")
         if allowed_domains is not None and not isinstance(allowed_domains, list):
             raise ValueError("allowed_domains must be a list of strings")
+        boundary_authority_scopes = body.get("boundary_authority_scopes")
+        if boundary_authority_scopes is not None and not isinstance(boundary_authority_scopes, list):
+            raise ValueError("boundary_authority_scopes must be a list of strings")
         return {
             "goal_id": goal_id,
             "quota_compute": body.get("quota_compute"),
@@ -305,6 +314,16 @@ class StatusRequestHandler(BaseHTTPRequestHandler):
             "max_children": body.get("max_children"),
             "allowed_domains": [str(item) for item in allowed_domains] if allowed_domains is not None else None,
             "clear_allowed_domains": bool(body.get("clear_allowed_domains", False)),
+            "boundary_authority_scopes": (
+                [str(item) for item in boundary_authority_scopes]
+                if boundary_authority_scopes is not None
+                else None
+            ),
+            "boundary_authority_source": body.get("boundary_authority_source"),
+            "boundary_authority_decision_id": body.get("boundary_authority_decision_id"),
+            "boundary_authority_recorded_at": body.get("boundary_authority_recorded_at"),
+            "boundary_authority_expires_at": body.get("boundary_authority_expires_at"),
+            "clear_boundary_authority": bool(body.get("clear_boundary_authority", False)),
         }
 
     def _configure_goal_payload(self, body: dict[str, Any], *, apply: bool, execute: bool) -> dict[str, Any]:
@@ -322,6 +341,12 @@ class StatusRequestHandler(BaseHTTPRequestHandler):
             max_children=values["max_children"],
             allowed_domains=values["allowed_domains"],
             clear_allowed_domains=values["clear_allowed_domains"],
+            boundary_authority_scopes=values["boundary_authority_scopes"],
+            boundary_authority_source=values["boundary_authority_source"],
+            boundary_authority_decision_id=values["boundary_authority_decision_id"],
+            boundary_authority_recorded_at=values["boundary_authority_recorded_at"],
+            boundary_authority_expires_at=values["boundary_authority_expires_at"],
+            clear_boundary_authority=values["clear_boundary_authority"],
             execute=execute,
         )
 


### PR DESCRIPTION
## Summary
- Add checkpointed boundary authority so approved operator/controller decisions can compile into `quota should-run` write scope with provenance, freshness, and expiry checks.
- Surface boundary projection repair diagnostics when a recommended action needs a scope that has only stale or incomplete authority.
- Add configure-goal API/CLI flags plus focused smokes for apply/clear and quota projection behavior.
- Document the control-plane contract in the interaction model, reward-gate contract, and interaction pattern catalog.

## Commit grouping
- `4015c17` runtime/API behavior: boundary authority normalization, quota projection, configure-goal CLI/API.
- `6d18ccd` docs and focused validation for checkpointed authority.
- `f1ec3b7` adapter-depth design note.
- `3e97303` planning authority level docs.

## Validation
- `python3 examples/configure-goal-smoke.py`
- `python3 examples/quota-action-scope-guard-smoke.py`
- `python3 -m py_compile goal_harness/boundary_authority.py goal_harness/configure_goal.py goal_harness/quota.py goal_harness/cli.py goal_harness/status_server.py`
- `git diff --check`
- `goal-harness check --scan-path goal_harness --scan-path docs --scan-path examples` passed with existing duplicate-index warning for `goal-harness-meta`.

## Known residual risk
- `python3 examples/run-smokes.py` still fails on the existing `examples/agentissue-bench-codex-cli-runner-publication-change-set-smoke.py` branch-diff assumption: any PR touching `goal_harness/cli.py` is treated as if it must also change agentissue benchmark runner files. This batch changes CLI for `configure-goal`, so the focused smokes above are the relevant validation.

## Excluded artifacts
- No `.local`, `.goal-harness`, raw benchmark logs, trajectories, verifier tails, credentials, production environment details, or local absolute paths are included.
