### PR TITLE
Add Goal Harness self-repair skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,16 @@ Benchmark smokes must never require raw task text, raw trajectories, raw logs,
 verifier output tails, credentials, uploads, leaderboard submissions, or local
 private artifact paths.
 
+## Goal Harness Self-Repair
+
+When Goal Harness behavior is surprising, too small, contradictory, or called
+out by the user as likely wrong, use the project skill
+`skills/goal-harness-self-repair/SKILL.md`. Treat recurring mistakes as product
+or process gaps: update the skill, interaction docs, active-state projection,
+or focused smoke so the lesson is durable. Do not resolve self-repair by
+lowering gates, guessing around contradictory payloads, or committing private
+logs and local state.
+
 ## Benchmark Smoke Classification
 
 Use this classification when cleaning or reviewing benchmark-related changes:

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ The installer creates:
 
 - `~/.local/bin/goal-harness`, pointing at a stable local release snapshot;
 - `~/.local/bin/goal-harness-canary`, pointing at the live checkout;
-- the `goal-harness-project` Codex skill under `~/.codex/skills`.
+- the Goal Harness Codex skills under `~/.codex/skills`.
 
 Use the canary wrapper for one or two selected controllers before promoting a
 checkout to the default local release.

--- a/examples/heartbeat-prompt-smoke.py
+++ b/examples/heartbeat-prompt-smoke.py
@@ -206,7 +206,8 @@ def main() -> int:
     thin_task = normalized(str(thin_payload["task_body"]))
     for phrase in (
         "Advance `public-heartbeat-goal` from /tmp/public-heartbeat-goal/ACTIVE_GOAL_STATE.md",
-        "Use `goal-harness-project` skill when available",
+        "Use skills: `goal-harness-project`; if surprising/tiny/contradictory",
+        "`goal-harness-self-repair`",
         "Goal Harness CLI is source of truth",
         "registry/global quota truth",
         "active state, status/run history, repo state",

--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -86,6 +86,7 @@ def main() -> int:
         assert f"- canary executable: {bin_dir / 'goal-harness-canary'}" in install.stdout, install.stdout
         assert f"- skill: {codex_home / 'skills' / 'goal-harness-doc-registry'}" in install.stdout, install.stdout
         assert f"- skill: {codex_home / 'skills' / 'goal-harness-project'}" in install.stdout, install.stdout
+        assert f"- skill: {codex_home / 'skills' / 'goal-harness-self-repair'}" in install.stdout, install.stdout
 
         wrapper = bin_dir / "goal-harness"
         assert wrapper.is_symlink(), wrapper
@@ -138,6 +139,28 @@ def main() -> int:
             "goal-harness --registry .goal-harness/registry.json register-authority-source",
         ):
             assert phrase in doc_registry_text, phrase
+        self_repair_skill = codex_home / "skills" / "goal-harness-self-repair" / "SKILL.md"
+        self_repair_text = " ".join(self_repair_skill.read_text(encoding="utf-8").split())
+        for phrase in (
+            "Build a compact evidence packet",
+            "references/repair-patterns.md",
+            "Repair at the lowest durable layer",
+            "Do not solve contradictory payloads by guessing",
+        ):
+            assert phrase in self_repair_text, phrase
+        self_repair_patterns = (
+            codex_home
+            / "skills"
+            / "goal-harness-self-repair"
+            / "references"
+            / "repair-patterns.md"
+        )
+        self_repair_patterns_text = self_repair_patterns.read_text(encoding="utf-8")
+        assert "`boundary_projection_gap`" in self_repair_patterns_text, self_repair_patterns_text
+        assert "`tiny_turn_under_delivery`" in self_repair_patterns_text, self_repair_patterns_text
+        assert (
+            codex_home / "skills" / "goal-harness-self-repair" / "agents" / "openai.yaml"
+        ).is_file()
 
         cli_env = {**env, "PATH": f"{bin_dir}:{env['PATH']}"}
         runtime_run_dir = home / ".codex" / "goal-harness" / "goals" / "goal-harness-meta" / "runs"
@@ -166,6 +189,8 @@ def main() -> int:
         assert doctor_payload["skills"]["goal-harness-project"]["required_phrases"] is True, doctor_payload
         assert doctor_payload["skills"]["goal-harness-doc-registry"]["exists"] is True, doctor_payload
         assert doctor_payload["skills"]["goal-harness-doc-registry"]["required_phrases"] is True, doctor_payload
+        assert doctor_payload["skills"]["goal-harness-self-repair"]["exists"] is True, doctor_payload
+        assert doctor_payload["skills"]["goal-harness-self-repair"]["required_phrases"] is True, doctor_payload
         provenance = doctor_payload["release_provenance"]
         assert provenance["default_release"]["root"] == str(release_root), provenance
         assert provenance["default_release"]["release_id"] == release_root.name, provenance
@@ -204,7 +229,11 @@ def main() -> int:
             text=True,
         ).stdout
         assert "installed_skill_delivery_hints: `True`" in doctor_markdown, doctor_markdown
-        assert "installed_required_skills: `goal-harness-doc-registry,goal-harness-project`" in doctor_markdown, doctor_markdown
+        assert (
+            "installed_required_skills: "
+            "`goal-harness-doc-registry,goal-harness-project,goal-harness-self-repair`"
+            in doctor_markdown
+        ), doctor_markdown
         assert "canary_realpath:" in doctor_markdown, doctor_markdown
         assert "release_root:" in doctor_markdown, doctor_markdown
         assert "## Release Provenance" in doctor_markdown, doctor_markdown

--- a/goal_harness/doctor.py
+++ b/goal_harness/doctor.py
@@ -26,6 +26,11 @@ REQUIRED_INSTALLED_SKILL_PHRASES = {
         "use `.goal-harness/registry.json` as the project-local doc registry",
         "not a substitute for project-local authority registration",
     ),
+    "goal-harness-self-repair": (
+        "Build a compact evidence packet",
+        "references/repair-patterns.md",
+        "Repair at the lowest durable layer",
+    ),
 }
 
 

--- a/goal_harness/heartbeat_prompt.py
+++ b/goal_harness/heartbeat_prompt.py
@@ -518,8 +518,8 @@ def render_thin_heartbeat_task_body(
     )
     return f"""Advance `{goal_id}` from {active_state}.
 
-Use `goal-harness-project` skill when available. Keep prompt thin: Goal Harness
-CLI is source of truth.
+Use skills: `goal-harness-project`; if surprising/tiny/contradictory,
+`goal-harness-self-repair`. Goal Harness CLI is source of truth.
 
 Inspect registry/global quota truth, active state, status/run history, repo
 state. Run `quota should-run`; follow `interaction_contract`. If

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -119,7 +119,7 @@ if [[ "$install_skill" != "0" && -d "$skills_source" ]]; then
     skill_target="$skills_dir/$skill_name"
     rm -rf "$skill_target"
     mkdir -p "$skill_target"
-    cp "$skill_source/SKILL.md" "$skill_target/SKILL.md"
+    cp -R "$skill_source"/. "$skill_target"/
     skill_line="${skill_line}- skill: $skill_target"$'\n'
   done < <(find "$skills_source" -mindepth 1 -maxdepth 1 -type d -print | sort)
   skill_line="${skill_line%$'\n'}"

--- a/skills/goal-harness-self-repair/SKILL.md
+++ b/skills/goal-harness-self-repair/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: goal-harness-self-repair
+description: Diagnose and repair Goal Harness control-plane drift or agent behavior drift. Use when a Goal Harness task makes unexpectedly small progress, follows a stale or contradictory recommended_action, ignores a higher-priority blocked item while doing fallback work, reports vague owner/user gates, loses todo projection, misaligns benchmark treatment with the real product path, mixes temporary artifacts into commits, or when the user asks for root-cause analysis, self-repair, or why the harness/agent behaved unexpectedly.
+---
+
+# Goal Harness Self Repair
+
+Use this skill to turn a surprising Goal Harness behavior into a durable fix,
+not only an apology or a one-off explanation.
+
+## Repair Loop
+
+1. **Pause delivery selection.** Do not spend quota or continue adapter work
+   until the control-plane facts explain why that work is valid.
+2. **Build a compact evidence packet.** Prefer structured surfaces:
+
+   ```bash
+   git status --short --branch
+   goal-harness --format json status --goal-id <goal-id>
+   goal-harness --format json quota should-run --goal-id <goal-id>
+   goal-harness --format json history --goal-id <goal-id> --limit 5
+   ```
+
+   Also inspect the project-local registry and
+   `.codex/goals/<goal-id>/ACTIVE_GOAL_STATE.md` when relevant. Use the shared
+   global registry for heartbeat/quota truth.
+3. **Classify the failure.** Read
+   `references/repair-patterns.md` and match the symptoms to a known pattern.
+   If no pattern fits, add one after the fix.
+4. **Assign the responsible layer.** Separate:
+   - agent behavior mistake;
+   - state projection or quota payload bug;
+   - active-state authoring gap;
+   - benchmark harness mismatch;
+   - docs/process hygiene gap.
+5. **Repair at the lowest durable layer.**
+   - If it is a one-off agent mistake, write back the correct state/todo and
+     continue with a larger bounded batch.
+   - If the machine projection misled the agent, fix CLI/status/quota
+     projection and add a focused smoke.
+   - If a design rule is missing, update the interaction model or todo list
+     before implementing broad behavior.
+   - If benchmark evidence is not attributable, add posthoc trace/parity
+     checks before claiming uplift or regression.
+6. **Validate before resuming.** Run the smallest smoke or CLI check that would
+   have caught the issue, plus `goal-harness check` on changed public surfaces
+   when docs/contracts changed.
+7. **Write back the lesson.** Update active goal state, docs, contributor
+   tasks, or this skill so the same failure mode is visible next time.
+
+## Evidence Discipline
+
+- Do not read or commit raw private logs, trajectories, verifier output,
+  credentials, internal links, or production material.
+- Do not solve contradictory payloads by guessing. If `recommended_action`,
+  `goal_boundary.write_scope`, todos, and interaction contract disagree, treat
+  that as a projection bug or state authoring bug first.
+- Do not let fallback work hide the primary blocker. When a higher-priority
+  path is gated but safe fallback is valid, report both the concrete gate and
+  the fallback progress.
+- Do not let tiny safe steps become the default. If several recent turns are
+  short or surface-only, run a steering audit and increase the next bounded
+  batch size unless a real gate blocks it.
+
+## Reference Routes
+
+- For known symptom-to-repair mappings, read
+  `references/repair-patterns.md`.
+- For user/agent/state channel semantics, read
+  `../../docs/state-interaction-model.md` and
+  `../../docs/interaction-pattern-catalog.md`.
+- For quota and heartbeat decisions, read
+  `../../docs/quota-allocation.md` and
+  `../../docs/heartbeat-automation-prompt.md`.
+- For commit/PR hygiene failures, read `../../AGENTS.md`.

--- a/skills/goal-harness-self-repair/agents/openai.yaml
+++ b/skills/goal-harness-self-repair/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Goal Harness Self Repair"
+  short_description: "Diagnose and repair Goal Harness control-plane drift"
+  default_prompt: "Use the Goal Harness self-repair workflow to diagnose the current stuck or surprising project state, identify the likely control-plane gap, and propose or implement the smallest durable repair."

--- a/skills/goal-harness-self-repair/references/repair-patterns.md
+++ b/skills/goal-harness-self-repair/references/repair-patterns.md
@@ -1,0 +1,41 @@
+# Goal Harness Self-Repair Patterns
+
+Use this file as a compact diagnosis table. Add a row whenever a real incident
+teaches a reusable control-plane lesson.
+
+| Pattern | Symptoms | Evidence To Read | Likely Root | Durable Repair |
+| --- | --- | --- | --- | --- |
+| `state_projection_gap` | `quota should-run` says `should_run=true` or `must_attempt=true`, but user and agent open todo counts are both zero while `Next Action` still contains executable work. | quota payload, active state `## Agent Todo`, `## User Todo`, `Next Action`, `refresh-state` warnings. | Active state prose has drifted away from machine todo projection. | Expand executable prose into `- [ ]` agent todos, add refresh-state warning/smoke if projection missed it. |
+| `user_todo_projection_gap` | `interaction_contract.user_channel.action_required=true` or open user todos exist, but heartbeat/final message only says "owner gate" or does not name the concrete decision. | quota payload `interaction_contract`, `user_todo_summary`, active state user todos, recent final messages. | User-channel projection or agent final-response rule is too vague. | Fix prompt/projection so required user todo/question is surfaced; only say "具体 user todo 未投影" when action is required but absent. |
+| `normal_no_user_todo_misflagged` | `action_required=false` and user open count is zero, but the agent reports a state projection fault. | quota payload and user todo summary. | Rule over-applied the "todo not projected" fallback. | Allow "无用户待办/无需通知"; update heartbeat/prompt smoke if needed. |
+| `blocked_priority_fallback_hidden` | A core P0 path is user-gated, safe P1/P2 fallback runs, but the user is not told what blocked the P0 path. | quota `safe_bypass_allowed`, active priority stack, final heartbeat text. | Fallback execution hid the higher-priority blocked item. | Report concrete blocker plus fallback progress; expose `blocked_priority_fallback` in state/payload if missing. |
+| `boundary_projection_gap` | `recommended_action` asks for work in a scope that is absent from `goal_boundary.write_scope`, such as runner edits blocked by repo-only scope. | quota `recommended_action`, `goal_boundary.write_scope`, authority/owner decision records. | Checkpointed owner decision did not project into current write boundary. | Repair boundary projection or ask controller/user; do not consume repo-only handoff steps that cannot touch the needed scope. |
+| `stale_recommended_action` | The agent repeats "launch or preflight" after the active state or evidence already narrowed the next action. | latest active state, quota payload timestamp/content, recent history rows. | Recommended action was not regenerated from the newest state. | Refresh state, update recommender/projection tests, and write an exact next action. |
+| `tiny_turn_under_delivery` | Many heartbeats make only one small doc/prose edit despite quota permitting a coherent batch. | recent history durations, active priority stack, user feedback, todo completion rate. | Agent optimized for avoiding mistakes rather than delivering a bounded batch. | Run steering audit, choose a larger verifiable batch, and record why it remains within boundary. Consider cadence/budget policy updates if repeated. |
+| `benchmark_product_path_mismatch` | Treatment uses a surrogate state file or prompt route that differs from the real Codex App + Goal Harness path, making uplift attribution unstable. | benchmark runner inputs, per-call Codex CLI transcript, state file paths, installed skill/prompt snapshot. | Benchmark route drifted from product route. | Add posthoc parity checks for state path, CLI interaction trace, heartbeat/state/skill inputs, and protocol version before claiming result. |
+| `reward_feedback_leak` | Later benchmark rounds receive verifier tail, pass/fail, or reward details that one arm should not see. | benchmark prompt/continuation logs, compact ledger, verifier wrapper. | Evaluation loop leaked reward signal. | Record per-round reward privately for metrics, but do not feed it to agents unless the experiment explicitly studies feedback. |
+| `commit_hygiene_drift` | Broad commit includes temporary smokes, raw logs, local state, or unrelated docs. | `git status`, `git diff --stat`, `git ls-files --others --exclude-standard`, AGENTS.md. | Worktree was staged by chronology rather than reviewer logic. | Use explicit pathspecs, split commits, keep only durable smokes, and update AGENTS/skill if the failure mode recurs. |
+| `docs_surface_sprawl` | Root docs become hard for contributors to navigate; research/drafts/history compete with stable contracts. | `docs/README.md`, root docs count, docs governance smoke. | Documentation lacks audience and lifecycle ownership. | Move archive/outreach/research/reference material into indexed subdirs and keep new docs linked from an index. |
+
+## Minimal Evidence Packet
+
+For most repairs, capture:
+
+```text
+goal_id:
+observed_surprise:
+quota_state:
+interaction_contract:
+user_todo_open_count:
+agent_todo_open_count:
+recommended_action:
+goal_boundary_write_scope:
+active_state_next_action:
+recent_history_summary:
+responsible_layer:
+repair:
+validation:
+```
+
+Keep this packet compact and public-safe. Store only summaries in public docs;
+raw logs and private traces stay in ignored local paths.


### PR DESCRIPTION
## Summary
- add a project-specific `goal-harness-self-repair` Codex skill with a compact repair loop and reusable failure-pattern matrix
- document in AGENTS.md that surprising/tiny/contradictory Goal Harness behavior should trigger this skill and be repaired durably
- install full skill directories so references/agents metadata are preserved, and teach doctor/heartbeat about the self-repair skill

## Validation
- python3 /Users/bytedance/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/goal-harness-self-repair
- python3 examples/heartbeat-prompt-smoke.py
- python3 examples/install-local-smoke.py
- python3 -m py_compile goal_harness/doctor.py goal_harness/heartbeat_prompt.py examples/install-local-smoke.py examples/heartbeat-prompt-smoke.py
- git diff --check
- goal-harness check --scan-path AGENTS.md --scan-path README.md --scan-path skills/goal-harness-self-repair --scan-path scripts/install-local.sh --scan-path goal_harness/doctor.py --scan-path goal_harness/heartbeat_prompt.py --scan-path examples/install-local-smoke.py --scan-path examples/heartbeat-prompt-smoke.py

## Notes
- goal-harness check reports the existing goal-harness-meta duplicate-index warning; public boundary scan is clean.
- No raw private logs, trajectories, credentials, internal links, or local state were added.
