### PR TITLE
Route quota recommendations to executable backlog

### DIFF
--- a/examples/work-lane-contract-smoke.py
+++ b/examples/work-lane-contract-smoke.py
@@ -580,6 +580,7 @@ def assert_structured_monitor_registration_beats_action_text() -> None:
 
 
 def assert_mixed_monitor_and_advancement_routes_to_advancement() -> None:
+    executable_todo = "[P1] Add the typed task class routing smoke fixture."
     guard = build_quota_should_run(
         status_payload(
             status="typed_task_lane_planning_writeback",
@@ -593,7 +594,7 @@ def assert_mixed_monitor_and_advancement_routes_to_advancement() -> None:
                 },
                 {
                     "index": 2,
-                    "text": "[P1] Add the typed task class routing smoke fixture.",
+                    "text": executable_todo,
                     "role": "agent",
                     "status": "open",
                     "priority": "P1",
@@ -607,8 +608,62 @@ def assert_mixed_monitor_and_advancement_routes_to_advancement() -> None:
     assert lane["next_lane"] == "advancement_task", lane
     assert lane["obligation"] == "advance_one_bounded_segment", lane
     assert lane["must_attempt_work"] is True, lane
+    assert guard["recommended_action"] == executable_todo, guard
+    assert guard["interaction_contract"]["agent_channel"]["primary_action"] == executable_todo, guard
+    assert f"agent_action={executable_todo}" in guard["protocol_action_packet"]["summary"], guard
     first_items = guard["agent_todo_summary"]["first_open_items"]
     assert [item["task_class"] for item in first_items] == ["continuous_monitor", "advancement_task"], guard
+
+
+def assert_external_monitor_context_recommends_executable_backlog() -> None:
+    poll_action = (
+        "Agent: continue compact-polling Terminal-Bench train-fasttext until a "
+        "terminal compact result/trial reward appears."
+    )
+    executable_todo = (
+        "[P1] Behavior regression suite lane: maintain `regression/` as the "
+        "home for Goal Harness CLI plus real Codex CLI interaction regressions."
+    )
+    guard = build_quota_should_run(
+        status_payload(
+            status="benchmark_ledger_running_placeholder_guard",
+            next_action=poll_action,
+            agent_todo_items=[
+                {
+                    "index": 67,
+                    "text": (
+                        "[P0] [P0 monitor] Observe no-upload Terminal-Bench "
+                        "train-fasttext using compact process/result markers only."
+                    ),
+                    "role": "agent",
+                    "status": "open",
+                    "priority": "P0",
+                    "task_class": "continuous_monitor",
+                    "action_kind": "monitor",
+                },
+                {
+                    "index": 2,
+                    "text": executable_todo,
+                    "role": "agent",
+                    "status": "open",
+                    "priority": "P1",
+                    "task_class": "advancement_task",
+                },
+            ],
+        ),
+        goal_id=GOAL_ID,
+    )
+    lane = guard["work_lane_contract"]
+    assert lane["lane"] == "advancement_task", lane
+    assert lane["reason_codes"] == ["open_agent_todo", "external_monitor_context"], lane
+    assert guard["recommended_action"] == executable_todo, guard
+    assert poll_action != guard["recommended_action"], guard
+    assert guard["interaction_contract"]["agent_channel"]["primary_action"] == (
+        "[P1] Behavior regression suite lane"
+    ), guard
+    packet = guard["protocol_action_packet"]["summary"]
+    assert "lane=advancement_task" in packet, packet
+    assert "agent_action=[P1] Behavior regression suite lane" in packet, packet
 
 
 def assert_benchmark_readiness_scan_routes_to_advancement() -> None:
@@ -873,6 +928,7 @@ def main() -> int:
     assert_structured_todo_lane_registration_beats_text_fallback()
     assert_structured_monitor_registration_beats_action_text()
     assert_mixed_monitor_and_advancement_routes_to_advancement()
+    assert_external_monitor_context_recommends_executable_backlog()
     assert_benchmark_readiness_scan_routes_to_advancement()
     assert_benchmark_source_preflight_routes_to_advancement()
     assert_behavior_regression_suite_routes_to_advancement()

--- a/goal_harness/quota.py
+++ b/goal_harness/quota.py
@@ -1070,6 +1070,47 @@ def _blocked_priority_fallback(
     }
 
 
+def _first_executable_todo_text(agent_todo_summary: dict[str, Any] | None) -> str | None:
+    if not isinstance(agent_todo_summary, dict):
+        return None
+    items = (
+        agent_todo_summary.get("first_executable_items")
+        if isinstance(agent_todo_summary.get("first_executable_items"), list)
+        else []
+    )
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        if not _todo_item_is_actionable_open(item):
+            continue
+        if _todo_task_class(item) != TODO_TASK_CLASS_ADVANCEMENT:
+            continue
+        text = _protocol_action_text(item.get("text"), limit=320)
+        if text:
+            return text
+    return None
+
+
+def _selected_recommended_action(
+    item: dict[str, Any],
+    *,
+    agent_todo_summary: dict[str, Any] | None,
+    work_lane_contract: dict[str, Any] | None,
+) -> Any:
+    raw_action = item.get("recommended_action")
+    if (
+        isinstance(work_lane_contract, dict)
+        and work_lane_contract.get("lane") == "advancement_task"
+        and "open_agent_todo" in (
+            work_lane_contract.get("reason_codes")
+            if isinstance(work_lane_contract.get("reason_codes"), list)
+            else []
+        )
+    ):
+        return _first_executable_todo_text(agent_todo_summary) or raw_action
+    return raw_action
+
+
 def _todo_write_hint(goal_id: str) -> dict[str, str]:
     return {
         "rule": (
@@ -3172,7 +3213,11 @@ def build_quota_should_run(status_payload: dict[str, Any], *, goal_id: str) -> d
             "lifecycle_flags": item.get("lifecycle_flags"),
             "source": item.get("source"),
             "project_asset_source": item.get("project_asset_source"),
-            "recommended_action": item.get("recommended_action"),
+            "recommended_action": _selected_recommended_action(
+                item,
+                agent_todo_summary=agent_todo_summary,
+                work_lane_contract=work_lane_contract,
+            ),
             "execution_profile": _quota_execution_profile_summary(
                 project_asset.get("execution_profile")
             )


### PR DESCRIPTION
## Summary
- make quota should-run top-level recommended_action follow the selected executable agent todo when the work lane is advancement_task
- keep external monitor text as context rather than letting it preempt the executable backlog recommendation
- add work-lane regression coverage for mixed monitor + advancement payloads

## Validation
- python3 examples/work-lane-contract-smoke.py
- python3 -m py_compile goal_harness/quota.py examples/work-lane-contract-smoke.py
- git diff --check
- goal-harness check --scan-path goal_harness/quota.py --scan-path examples/work-lane-contract-smoke.py
- real goal-harness-meta quota should-run now projects P1 behavior regression lane as recommended_action while train-fasttext monitor remains auxiliary context

## Boundary
- staged only quota runtime projection and focused smoke
- excluded local/private benchmark jobs, raw logs, trajectories, verifier output, goal state, and credentials
- public boundary scan clean for touched files

## Residual Risk
- long-running train-fasttext still needs compact terminal/result ingestion in a later monitor turn