### PR TITLE
Reserve run artifact paths for append writers

### DIFF
--- a/examples/history-reserved-run-path-smoke.py
+++ b/examples/history-reserved-run-path-smoke.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Smoke-test reserved run paths for same-second append writers."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from goal_harness import history, state_refresh
+
+
+GOAL_ID = "reserved-run-path-fixture"
+FIXED_TIME = "2026-01-01T00:00:00+00:00"
+
+
+def write_registry(root: Path) -> Path:
+    project = root / "project"
+    runtime = root / "runtime"
+    state_file = f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    state_path = project / state_file
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        "---\n"
+        "status: reserved-run-path-fixture\n"
+        "updated_at: 2026-01-01T00:00:00+00:00\n"
+        "---\n\n"
+        "# Reserved Run Path Fixture\n\n"
+        "## Next Action\n\n"
+        "- continue reserved run path validation\n\n",
+        encoding="utf-8",
+    )
+    registry_path = project / ".goal-harness" / "registry.json"
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "reserved-run-path-fixture",
+                        "status": "active-read-only",
+                        "repo": str(project),
+                        "state_file": state_file,
+                        "adapter": {"kind": "fixture", "status": "connected-read-only"},
+                    }
+                ],
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return registry_path
+
+
+def artifact_identity(payload: dict[str, object]) -> tuple[str, str, str]:
+    return (
+        str(payload.get("generated_at") or ""),
+        str(payload.get("json_path") or ""),
+        str(payload.get("markdown_path") or ""),
+    )
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory(prefix="goal-harness-reserved-run-path-") as raw_tmp:
+        root = Path(raw_tmp)
+        registry_path = write_registry(root)
+        original_history_now = history.now_local
+        original_refresh_now = state_refresh.now_local
+        history.now_local = lambda: FIXED_TIME
+        state_refresh.now_local = lambda: FIXED_TIME
+        try:
+            payloads = [
+                history.append_benchmark_result(
+                    registry_path=registry_path,
+                    runtime_root_override=None,
+                    goal_id=GOAL_ID,
+                    benchmark_result={"schema_version": "benchmark_result_v0", "case": "fixture"},
+                    dry_run=False,
+                ),
+                history.append_benchmark_comparison(
+                    registry_path=registry_path,
+                    runtime_root_override=None,
+                    goal_id=GOAL_ID,
+                    benchmark_comparison={
+                        "schema_version": "benchmark_comparison_v0",
+                        "comparison_id": "fixture-comparison",
+                    },
+                    dry_run=False,
+                ),
+                history.append_benchmark_learning_ledger(
+                    registry_path=registry_path,
+                    runtime_root_override=None,
+                    goal_id=GOAL_ID,
+                    benchmark_learning_ledger={
+                        "schema_version": "benchmark_learning_ledger_v0",
+                        "task_id": "fixture-task",
+                    },
+                    dry_run=False,
+                ),
+                state_refresh.refresh_state_run(
+                    registry_path=registry_path,
+                    runtime_root_override=None,
+                    goal_id=GOAL_ID,
+                    project=None,
+                    state_file=None,
+                    classification="reserved_run_path_refresh",
+                    recommended_action="continue reserved run path validation",
+                    dry_run=False,
+                    sync_global=False,
+                ),
+            ]
+        finally:
+            history.now_local = original_history_now
+            state_refresh.now_local = original_refresh_now
+
+        identities = [artifact_identity(payload) for payload in payloads]
+        assert len(identities) == len(set(identities)), identities
+        assert [Path(payload["json_path"]).name for payload in payloads] == [
+            "2026-01-01T00-00-00-00-00.json",
+            "2026-01-01T00-00-00-00-00-2.json",
+            "2026-01-01T00-00-00-00-00-3.json",
+            "2026-01-01T00-00-00-00-00-4.json",
+        ], payloads
+
+        duplicate_report = history.inspect_index_duplicates(
+            registry_path=registry_path,
+            runtime_root_override=None,
+            goal_id=GOAL_ID,
+            limit=10,
+        )
+        assert duplicate_report["duplicate_group_count"] == 0, duplicate_report
+        print("history-reserved-run-path-smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/goal_harness/history.py
+++ b/goal_harness/history.py
@@ -5,7 +5,7 @@ import os
 import re
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from .authority import goal_authority_registry_summary
 from .control_plane import compact_control_plane_policy
@@ -72,6 +72,28 @@ def reserve_unique_run_paths(runs_dir: Path, generated_at: str) -> tuple[Path, P
         else:
             os.close(fd)
             return json_path, markdown_path
+
+
+def write_reserved_run_artifacts(
+    *,
+    runs_dir: Path,
+    generated_at: str,
+    record: dict[str, Any],
+    index_record: dict[str, Any],
+    payload: dict[str, Any],
+    render_markdown: Callable[[dict[str, Any]], str],
+) -> None:
+    json_path, markdown_path = reserve_unique_run_paths(runs_dir, generated_at)
+    index_path = runs_dir / "index.jsonl"
+    index_record["json_path"] = str(json_path)
+    index_record["markdown_path"] = str(markdown_path)
+    payload["json_path"] = str(json_path)
+    payload["markdown_path"] = str(markdown_path)
+    payload["index_path"] = str(index_path)
+    json_path.write_text(json.dumps(record, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    markdown_path.write_text(render_markdown(payload) + "\n", encoding="utf-8")
+    with index_path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(index_record, ensure_ascii=False) + "\n")
 
 
 def validate_goal_id_path_segment(goal_id: str) -> str:
@@ -210,15 +232,14 @@ def append_benchmark_run(
         payload["delivery_outcome"] = delivery_outcome
 
     if not dry_run:
-        json_path, markdown_path = reserve_unique_run_paths(runs_dir, generated_at)
-        index_record["json_path"] = str(json_path)
-        index_record["markdown_path"] = str(markdown_path)
-        payload["json_path"] = str(json_path)
-        payload["markdown_path"] = str(markdown_path)
-        json_path.write_text(json.dumps(record, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-        markdown_path.write_text(render_benchmark_run_append_markdown(payload) + "\n", encoding="utf-8")
-        with index_path.open("a", encoding="utf-8") as f:
-            f.write(json.dumps(index_record, ensure_ascii=False) + "\n")
+        write_reserved_run_artifacts(
+            runs_dir=runs_dir,
+            generated_at=generated_at,
+            record=record,
+            index_record=index_record,
+            payload=payload,
+            render_markdown=render_benchmark_run_append_markdown,
+        )
     return payload
 
 
@@ -287,11 +308,14 @@ def append_benchmark_result(
         payload["delivery_outcome"] = delivery_outcome
 
     if not dry_run:
-        runs_dir.mkdir(parents=True, exist_ok=True)
-        json_path.write_text(json.dumps(record, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-        markdown_path.write_text(render_benchmark_result_append_markdown(payload) + "\n", encoding="utf-8")
-        with index_path.open("a", encoding="utf-8") as f:
-            f.write(json.dumps(index_record, ensure_ascii=False) + "\n")
+        write_reserved_run_artifacts(
+            runs_dir=runs_dir,
+            generated_at=generated_at,
+            record=record,
+            index_record=index_record,
+            payload=payload,
+            render_markdown=render_benchmark_result_append_markdown,
+        )
     return payload
 
 
@@ -360,11 +384,14 @@ def append_benchmark_comparison(
         payload["delivery_outcome"] = delivery_outcome
 
     if not dry_run:
-        runs_dir.mkdir(parents=True, exist_ok=True)
-        json_path.write_text(json.dumps(record, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-        markdown_path.write_text(render_benchmark_comparison_append_markdown(payload) + "\n", encoding="utf-8")
-        with index_path.open("a", encoding="utf-8") as f:
-            f.write(json.dumps(index_record, ensure_ascii=False) + "\n")
+        write_reserved_run_artifacts(
+            runs_dir=runs_dir,
+            generated_at=generated_at,
+            record=record,
+            index_record=index_record,
+            payload=payload,
+            render_markdown=render_benchmark_comparison_append_markdown,
+        )
     return payload
 
 
@@ -433,11 +460,14 @@ def append_benchmark_learning_ledger(
         payload["delivery_outcome"] = delivery_outcome
 
     if not dry_run:
-        runs_dir.mkdir(parents=True, exist_ok=True)
-        json_path.write_text(json.dumps(record, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-        markdown_path.write_text(render_benchmark_learning_ledger_append_markdown(payload) + "\n", encoding="utf-8")
-        with index_path.open("a", encoding="utf-8") as f:
-            f.write(json.dumps(index_record, ensure_ascii=False) + "\n")
+        write_reserved_run_artifacts(
+            runs_dir=runs_dir,
+            generated_at=generated_at,
+            record=record,
+            index_record=index_record,
+            payload=payload,
+            render_markdown=render_benchmark_learning_ledger_append_markdown,
+        )
     return payload
 
 
@@ -506,11 +536,14 @@ def append_benchmark_experiment_report(
         payload["delivery_outcome"] = delivery_outcome
 
     if not dry_run:
-        runs_dir.mkdir(parents=True, exist_ok=True)
-        json_path.write_text(json.dumps(record, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-        markdown_path.write_text(render_benchmark_experiment_report_append_markdown(payload) + "\n", encoding="utf-8")
-        with index_path.open("a", encoding="utf-8") as f:
-            f.write(json.dumps(index_record, ensure_ascii=False) + "\n")
+        write_reserved_run_artifacts(
+            runs_dir=runs_dir,
+            generated_at=generated_at,
+            record=record,
+            index_record=index_record,
+            payload=payload,
+            render_markdown=render_benchmark_experiment_report_append_markdown,
+        )
     return payload
 
 
@@ -579,11 +612,14 @@ def append_active_user_assisted_pilot(
         payload["delivery_outcome"] = delivery_outcome
 
     if not dry_run:
-        runs_dir.mkdir(parents=True, exist_ok=True)
-        json_path.write_text(json.dumps(record, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-        markdown_path.write_text(render_active_user_assisted_pilot_append_markdown(payload) + "\n", encoding="utf-8")
-        with index_path.open("a", encoding="utf-8") as f:
-            f.write(json.dumps(index_record, ensure_ascii=False) + "\n")
+        write_reserved_run_artifacts(
+            runs_dir=runs_dir,
+            generated_at=generated_at,
+            record=record,
+            index_record=index_record,
+            payload=payload,
+            render_markdown=render_active_user_assisted_pilot_append_markdown,
+        )
     return payload
 
 

--- a/goal_harness/state_refresh.py
+++ b/goal_harness/state_refresh.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from .feedback import validate_public_safe_text
 from .global_registry import sync_project_registry_to_global
-from .history import load_registry, unique_run_paths
+from .history import load_registry, reserve_unique_run_paths, unique_run_paths
 from .paths import resolve_runtime_root
 from .registry import registry_goals, resolve_state_file
 from .runtime import validate_goal_id_path_segment
@@ -348,6 +348,11 @@ def refresh_state_run(
     }
     if not dry_run:
         runs_dir.mkdir(parents=True, exist_ok=True)
+        json_path, markdown_path = reserve_unique_run_paths(runs_dir, generated_at)
+        index_record["json_path"] = str(json_path)
+        index_record["markdown_path"] = str(markdown_path)
+        payload["json_path"] = str(json_path)
+        payload["markdown_path"] = str(markdown_path)
         json_path.write_text(
             json.dumps(record, ensure_ascii=False, indent=2) + "\n",
             encoding="utf-8",


### PR DESCRIPTION
## Summary
- route benchmark/result/learning/report/pilot history append writers through the atomic reserved run-path helper
- reserve refresh-state artifact paths at write time as well
- add a same-second append smoke that fixes time and verifies multiple writers do not share a json/md artifact identity

## Validation
- python3 examples/history-reserved-run-path-smoke.py
- python3 examples/history-index-duplicate-inspection-smoke.py
- python3 examples/refresh-state-unique-run-path-smoke.py
- python3 examples/benchmark-run-v0-append-cli-smoke.py
- python3 examples/benchmark-learning-ledger-smoke.py
- python3 examples/benchmark-experiment-report-append-cli-smoke.py
- python3 examples/active-user-assisted-pilot-append-cli-smoke.py
- python3 -m py_compile goal_harness/history.py goal_harness/state_refresh.py examples/history-reserved-run-path-smoke.py
- git diff --check
- goal-harness check (passes with existing historical duplicate-index warning for goal-harness-meta)

## Notes
- This prevents future same-second artifact path collisions. Existing historical artifact_identity_collision rows are intentionally not auto-deleted because repair-index-duplicates marks them as requiring reviewed merge semantics.
- Excluded private state, raw logs, trajectories, verifier output, credentials, and local benchmark artifacts.
