### PR TITLE
Project wider agent todo backlogs in quota

### DIFF
--- a/examples/todo-first-open-summary-smoke.py
+++ b/examples/todo-first-open-summary-smoke.py
@@ -64,6 +64,8 @@ def build_truncated_todo_group() -> dict:
     assert group["first_open_items"][0]["source_section"] == "Agent Todo", group
     assert str(group["first_open_items"][0]["todo_id"]).startswith("todo_"), group
     assert [item["index"] for item in group["first_open_items"]] == [17, 14, 15], group
+    assert [item["index"] for item in group["backlog_items"]] == [17, 14, 15, 16], group
+    assert [item["index"] for item in group["executable_backlog_items"]] == [17, 14, 15, 16], group
     return group
 
 
@@ -91,6 +93,7 @@ def parse_multiline_deep_open_todo() -> dict:
     assert group["first_open_items"][0]["text"] == APPENDED_P0_TODO, group
     assert group["first_open_items"][0]["title"] == "Select the next material-ready benchmark case after compact review.", group
     assert [item["index"] for item in group["first_open_items"]] == [17, 14, 15], group
+    assert [item["index"] for item in group["backlog_items"]] == [17, 14, 15, 16], group
     return group
 
 
@@ -201,6 +204,8 @@ def main() -> int:
     assert asset_summary["next"] == APPENDED_P0_TODO, asset_summary
     assert asset_summary["next_index"] == 17, asset_summary
     assert [item["index"] for item in asset_summary["items"]] == [17, 14, 15, 16], asset_summary
+    assert [item["index"] for item in asset_summary["backlog_items"]] == [17, 14, 15, 16], asset_summary
+    assert [item["index"] for item in asset_summary["executable_backlog_items"]] == [17, 14, 15, 16], asset_summary
     assert asset_summary["items"][0]["priority"] == "P0", asset_summary
     assert asset_summary["items"][0]["status"] == "open", asset_summary
     assert asset_summary["items"][0]["todo_id"] == agent_todos["first_open_items"][0]["todo_id"], asset_summary
@@ -261,10 +266,13 @@ def main() -> int:
     assert agent_summary["first_open_items"][0]["status"] == "open", decision
     assert agent_summary["first_open_items"][0]["todo_id"] == agent_todos["first_open_items"][0]["todo_id"], decision
     assert [item["index"] for item in agent_summary["first_open_items"]] == [17, 14, 15], decision
+    assert [item["index"] for item in agent_summary["backlog_items"]] == [17, 14, 15, 16], decision
+    assert [item["index"] for item in agent_summary["executable_backlog_items"]] == [17, 14, 15, 16], decision
     markdown = render_quota_should_run_markdown(decision)
     assert f"agent_todo_next[17]: {APPENDED_P0_TODO}" in markdown, markdown
     assert f"agent_todo_next[14]: {OPEN_TODO}" in markdown, markdown
     assert f"agent_todo_next[15]: {SECOND_OPEN_TODO}" in markdown, markdown
+    assert f"agent_todo_backlog[16]: {THIRD_OPEN_TODO}" in markdown, markdown
     packet = build_review_packet(status_payload, goal_id=GOAL_ID, action_kind="codex")
     assert packet["agent_todo_items"] == [
         APPENDED_P0_TODO,

--- a/goal_harness/quota.py
+++ b/goal_harness/quota.py
@@ -125,6 +125,7 @@ EXTERNAL_EVIDENCE_OBSERVATION_SCHEMA_VERSION = "external_evidence_observation_ob
 INTERACTION_CONTRACT_SCHEMA_VERSION = "goal_harness_interaction_contract_v0"
 PROTOCOL_ACTION_PACKET_SCHEMA_VERSION = "protocol_action_packet_v0"
 AUTOMATION_LIVENESS_SCHEMA_VERSION = "automation_liveness_v0"
+TODO_BACKLOG_ITEM_LIMIT = 8
 EXTERNAL_EVIDENCE_OBSERVE_PATTERNS = (
     re.compile(
         r"(?i)\b(?:poll(?:ing)?|observ(?:e|ing)|watch(?:ing)?|await(?:ing)?|wait\s+for|monitor(?:ing)?)\b.*\b"
@@ -881,6 +882,34 @@ def _compact_todo_summary_item(item: dict[str, Any], *, text: str | None = None)
     return compact
 
 
+def _todo_summary_source_items(value: dict[str, Any]) -> list[dict[str, Any]]:
+    source_keys = (
+        "first_open_items",
+        "backlog_items",
+        "items",
+    )
+    open_items: list[dict[str, Any]] = []
+    for key in source_keys:
+        source_items = value.get(key) if isinstance(value.get(key), list) else []
+        for item in source_items:
+            if not isinstance(item, dict) or item.get("done") is True:
+                continue
+            text = str(item.get("text") or "").strip()
+            if not text:
+                continue
+            duplicate = any(
+                existing.get("todo_id") == item.get("todo_id")
+                if item.get("todo_id") and existing.get("todo_id")
+                else existing.get("index") == item.get("index")
+                and str(existing.get("text") or "").strip() == text
+                for existing in open_items
+            )
+            if duplicate:
+                continue
+            open_items.append(_compact_todo_summary_item(item, text=text))
+    return open_items
+
+
 def _is_user_gate_todo_item(item: dict[str, Any]) -> bool:
     if _todo_task_class(item) == TODO_TASK_CLASS_USER_GATE:
         return True
@@ -893,33 +922,7 @@ def _is_user_gate_todo_item(item: dict[str, Any]) -> bool:
 def _summarize_user_todos(value: Any) -> dict[str, Any] | None:
     if not isinstance(value, dict):
         return None
-    items = value.get("items") if isinstance(value.get("items"), list) else []
-    open_items: list[dict[str, Any]] = []
-    first_open_items = (
-        value.get("first_open_items")
-        if isinstance(value.get("first_open_items"), list)
-        else []
-    )
-    for item in first_open_items:
-        if not isinstance(item, dict) or item.get("done") is True:
-            continue
-        text = str(item.get("text") or "").strip()
-        if not text:
-            continue
-        open_items.append(_compact_todo_summary_item(item, text=text))
-    for item in items:
-        if not isinstance(item, dict) or item.get("done") is True:
-            continue
-        text = str(item.get("text") or "").strip()
-        if not text:
-            continue
-        duplicate = any(
-            existing.get("index") == item.get("index") and existing.get("text") == text
-            for existing in open_items
-        )
-        if duplicate:
-            continue
-        open_items.append(_compact_todo_summary_item(item, text=text))
+    open_items = _todo_summary_source_items(value)
     executable_items = [
         item
         for item in open_items
@@ -947,6 +950,8 @@ def _summarize_user_todos(value: Any) -> dict[str, Any] | None:
         "first_executable_items": executable_items[:3],
         "gate_open_items": gate_items[:3],
         "monitor_open_items": monitor_items,
+        "backlog_items": open_items[:TODO_BACKLOG_ITEM_LIMIT],
+        "executable_backlog_items": executable_items[:TODO_BACKLOG_ITEM_LIMIT],
     }
 
 
@@ -961,15 +966,7 @@ def _summarize_project_asset_todos(value: Any) -> dict[str, Any] | None:
     ):
         return _summarize_user_todos(value)
 
-    open_items: list[dict[str, Any]] = []
-    items = value.get("items") if isinstance(value.get("items"), list) else []
-    for item in items:
-        if not isinstance(item, dict) or item.get("done") is True:
-            continue
-        text = str(item.get("text") or "").strip()
-        if not text:
-            continue
-        open_items.append(_compact_todo_summary_item(item, text=text))
+    open_items = _todo_summary_source_items(value)
     if not open_items:
         next_text = str(value.get("next") or "").strip()
         next_index = value.get("next_index", 1)
@@ -996,6 +993,8 @@ def _summarize_project_asset_todos(value: Any) -> dict[str, Any] | None:
         "first_open_items": open_items[:3],
         "first_executable_items": executable_items[:3],
         "monitor_open_items": monitor_items,
+        "backlog_items": open_items[:TODO_BACKLOG_ITEM_LIMIT],
+        "executable_backlog_items": executable_items[:TODO_BACKLOG_ITEM_LIMIT],
     }
 
 
@@ -4625,6 +4624,32 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
             index = todo.get("index")
             suffix = f"[{index}]" if index is not None else ""
             lines.append(f"- {label}_next{suffix}: {text}")
+        first_keys = {
+            (
+                str(todo.get("todo_id") or ""),
+                todo.get("index"),
+                str(todo.get("text") or "").strip(),
+            )
+            for todo in first_open
+            if isinstance(todo, dict)
+        }
+        backlog = summary.get("backlog_items") if isinstance(summary.get("backlog_items"), list) else []
+        extra_count = 0
+        for todo in backlog:
+            if not isinstance(todo, dict):
+                continue
+            text = str(todo.get("text") or "").strip()
+            if not text:
+                continue
+            key = (str(todo.get("todo_id") or ""), todo.get("index"), text)
+            if key in first_keys:
+                continue
+            index = todo.get("index")
+            suffix = f"[{index}]" if index is not None else ""
+            lines.append(f"- {label}_backlog{suffix}: {text}")
+            extra_count += 1
+            if extra_count >= 5:
+                break
 
     if quota:
         lines.append(

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -315,6 +315,7 @@ AGENT_TODO_HEADER_MARKERS = (
 MAX_STATUS_TODOS_PER_ROLE = 12
 MAX_ACTIVE_DONE_TODOS_BEFORE_ARCHIVE = MAX_STATUS_TODOS_PER_ROLE
 MAX_PROJECT_ASSET_TODO_ITEMS = 3
+MAX_PROJECT_ASSET_TODO_BACKLOG_ITEMS = 8
 MAX_DEPENDENCY_BLOCKERS = 4
 MAX_AUTONOMOUS_BACKLOG_CANDIDATES = 6
 MAX_SUBAGENT_ACTIVITY_ITEMS = 5
@@ -3694,6 +3695,14 @@ def compact_todo_group(
         "monitor_open_items": [
             compact_todo_item(item) for item in monitor_items
         ],
+        "backlog_items": [
+            compact_todo_item(item)
+            for item in projected_open_items[:MAX_PROJECT_ASSET_TODO_BACKLOG_ITEMS]
+        ],
+        "executable_backlog_items": [
+            compact_todo_item(item)
+            for item in executable_items[:MAX_PROJECT_ASSET_TODO_BACKLOG_ITEMS]
+        ],
         "items": budgeted_items[:MAX_STATUS_TODOS_PER_ROLE],
     }
 
@@ -4216,12 +4225,28 @@ def project_asset_todo_summary(todos: dict[str, Any] | None) -> dict[str, Any] |
         "done": todos.get("done_count", 0),
         "total": todos.get("total_count", 0),
     }
-    open_items = open_todo_items(todos)
+    open_items = open_todo_items(todos, limit=MAX_STATUS_TODOS_PER_ROLE)
     if open_items:
         summary["items"] = open_items
         summary["next"] = open_items[0]["text"]
         if open_items[0].get("index") is not None:
             summary["next_index"] = open_items[0].get("index")
+    backlog_items = open_todo_items(todos, limit=MAX_PROJECT_ASSET_TODO_BACKLOG_ITEMS)
+    if backlog_items:
+        summary["backlog_items"] = backlog_items
+        executable_backlog_items = [
+            item
+            for item in backlog_items
+            if todo_item_is_actionable_open(item)
+            if normalize_todo_task_class(
+                item.get("task_class"),
+                text=str(item.get("text") or ""),
+                action_kind=item.get("action_kind"),
+            )
+            == TODO_TASK_CLASS_ADVANCEMENT
+        ]
+        if executable_backlog_items:
+            summary["executable_backlog_items"] = executable_backlog_items
     return summary
 
 
@@ -4275,28 +4300,6 @@ def attach_dependency_blockers(items: list[dict[str, Any]]) -> None:
         blockers = dependency_blocker_summary(items, current_goal_id=goal_id)
         if blockers:
             item["dependency_blockers"] = blockers
-
-
-def open_todo_items(todos: dict[str, Any] | None) -> list[dict[str, Any]]:
-    if not isinstance(todos, dict):
-        return []
-    items: list[dict[str, Any]] = []
-    seen: set[tuple[Any, str]] = set()
-    for source_items in (todos.get("first_open_items"), todos.get("items")):
-        if not isinstance(source_items, list):
-            continue
-        for todo in source_items:
-            if not isinstance(todo, dict) or todo.get("done"):
-                continue
-            text = str(todo.get("text") or "").strip()
-            if not text:
-                continue
-            key = (todo.get("index"), text)
-            if key in seen:
-                continue
-            seen.add(key)
-            items.append(todo)
-    return sorted(items, key=todo_projection_sort_key)
 
 
 def first_open_todo_item(todos: dict[str, Any] | None) -> dict[str, Any] | None:


### PR DESCRIPTION
## Summary
- add bounded `backlog_items` and `executable_backlog_items` projections for agent/user todo summaries
- keep existing `first_open_items` / `first_executable_items` three-item compatibility fields intact
- render only non-duplicate backlog extras in quota markdown so executor context is wider without repeating first-screen items
- remove the shadowing duplicate `open_todo_items` definition in `status.py`

## Validation
- `python3 examples/todo-first-open-summary-smoke.py`
- `python3 examples/work-lane-contract-smoke.py`
- `python3 examples/protocol-action-packet-smoke.py`
- `python3 -m py_compile goal_harness/status.py goal_harness/quota.py examples/todo-first-open-summary-smoke.py`
- `git diff --check`
- `goal-harness check` (passes with existing historical duplicate-index warning)

## Public/private boundary
- staged only `goal_harness/status.py`, `goal_harness/quota.py`, and `examples/todo-first-open-summary-smoke.py`
- no `.local`, raw benchmark logs, trajectories, verifier output, credentials, or private docs included
- sensitive-marker scan only hit existing source-code token field names/regexes

## Residual risk
- compact JSON payload is slightly wider for todo summaries, capped at 8 backlog items; first-screen compatibility fields remain unchanged.