### PR TITLE
Serialize todo active-state writes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,6 @@ dist/
 .goal-wrapper.local/
 .codex/goals/
 goals/**/ACTIVE_GOAL_STATE.md
+goals/**/ACTIVE_GOAL_STATE.md.lock
 runtime/
 logs/

--- a/examples/todo-concurrent-write-lock-smoke.py
+++ b/examples/todo-concurrent-write-lock-smoke.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Smoke-test active-state todo writers under a contended file lock."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from goal_harness.file_lock import exclusive_file_lock  # noqa: E402
+from goal_harness.status import parse_active_state_todos  # noqa: E402
+
+
+GOAL_ID = "todo-concurrent-write-lock-goal"
+CHILD_ADD_TODO = "Child add should preserve the parent todo written under lock."
+PARENT_ADD_TODO = "Parent todo written while child add waits on the lock."
+UPDATE_TARGET_TODO = "Update target todo should keep unrelated concurrent additions."
+PARENT_UPDATE_TODO = "Parent todo written while child update waits on the lock."
+
+
+def write_fixture(root: Path) -> tuple[Path, Path]:
+    project = root / "project"
+    runtime = root / "runtime"
+    state_file = project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+    registry_path = project / ".goal-harness" / "registry.json"
+    state_file.parent.mkdir(parents=True)
+    state_file.write_text(
+        "---\n"
+        "status: active\n"
+        "updated_at: 2026-01-01T00:00:00+00:00\n"
+        "---\n\n"
+        "# Active Goal State\n\n"
+        "## Objective\n\n"
+        "Exercise todo writer locking.\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] Initial visible work item.\n",
+        encoding="utf-8",
+    )
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "todo-concurrency-fixture",
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md",
+                        "adapter": {"kind": "generic_project_goal_v0", "status": "connected"},
+                        "authority_sources": [],
+                    }
+                ],
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return registry_path, state_file
+
+
+def cli_args(registry_path: Path, *args: str) -> list[str]:
+    return [
+        sys.executable,
+        "-m",
+        "goal_harness.cli",
+        "--registry",
+        str(registry_path),
+        "--format",
+        "json",
+        *args,
+    ]
+
+
+def run_cli(registry_path: Path, *args: str) -> dict[str, Any]:
+    result = subprocess.run(
+        cli_args(registry_path, *args),
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return json.loads(result.stdout)
+
+
+def start_cli(registry_path: Path, *args: str) -> subprocess.Popen[str]:
+    return subprocess.Popen(
+        cli_args(registry_path, *args),
+        cwd=REPO_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def wait_json(process: subprocess.Popen[str]) -> dict[str, Any]:
+    stdout, stderr = process.communicate(timeout=10)
+    assert process.returncode == 0, stderr
+    return json.loads(stdout)
+
+
+def assert_waiting_on_lock(process: subprocess.Popen[str], label: str) -> None:
+    time.sleep(0.35)
+    assert process.poll() is None, (
+        f"{label} process finished before the parent released the lock"
+    )
+
+
+def append_agent_todo(state_file: Path, text: str) -> None:
+    with state_file.open("a", encoding="utf-8") as file:
+        file.write(f"- [ ] {text}\n")
+
+
+def agent_items(state_file: Path) -> list[dict[str, Any]]:
+    parsed = parse_active_state_todos(state_file.read_text(encoding="utf-8"))
+    return parsed["agent_todos"]["items"]
+
+
+def find_item(state_file: Path, text: str) -> dict[str, Any]:
+    return next(item for item in agent_items(state_file) if item.get("text") == text)
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="goal-harness-todo-lock-smoke-") as tmp:
+        registry_path, state_file = write_fixture(Path(tmp))
+
+        with exclusive_file_lock(state_file):
+            add_process = start_cli(
+                registry_path,
+                "todo",
+                "add",
+                "--goal-id",
+                GOAL_ID,
+                "--role",
+                "agent",
+                "--text",
+                CHILD_ADD_TODO,
+            )
+            assert_waiting_on_lock(add_process, "todo add")
+            append_agent_todo(state_file, PARENT_ADD_TODO)
+        add_result = wait_json(add_process)
+        assert add_result["added"] is True, add_result
+        assert find_item(state_file, CHILD_ADD_TODO), state_file.read_text(encoding="utf-8")
+        assert find_item(state_file, PARENT_ADD_TODO), state_file.read_text(encoding="utf-8")
+
+        target = run_cli(
+            registry_path,
+            "todo",
+            "add",
+            "--goal-id",
+            GOAL_ID,
+            "--role",
+            "agent",
+            "--text",
+            UPDATE_TARGET_TODO,
+        )
+        target_id = target["todo_id"]
+
+        with exclusive_file_lock(state_file):
+            update_process = start_cli(
+                registry_path,
+                "todo",
+                "update",
+                "--goal-id",
+                GOAL_ID,
+                "--todo-id",
+                target_id,
+                "--status",
+                "blocked",
+                "--reason",
+                "waiting-on-concurrent-state",
+            )
+            assert_waiting_on_lock(update_process, "todo update")
+            append_agent_todo(state_file, PARENT_UPDATE_TODO)
+        update_result = wait_json(update_process)
+        assert update_result["changed"] is True, update_result
+        updated_target = find_item(state_file, UPDATE_TARGET_TODO)
+        assert updated_target["status"] == "blocked", updated_target
+        assert updated_target["reason"] == "waiting-on-concurrent-state", updated_target
+        assert find_item(state_file, PARENT_UPDATE_TODO), state_file.read_text(encoding="utf-8")
+
+    print("todo-concurrent-write-lock-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/goal_harness/file_lock.py
+++ b/goal_harness/file_lock.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+try:  # pragma: no cover - exercised on POSIX hosts in integration smokes.
+    import fcntl
+except ImportError:  # pragma: no cover
+    fcntl = None  # type: ignore[assignment]
+
+
+@contextmanager
+def exclusive_file_lock(path: Path) -> Iterator[Path]:
+    """Hold a small sibling lock file for read-modify-write file updates."""
+
+    lock_path = path.with_name(f"{path.name}.lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a", encoding="utf-8") as lock_file:
+        if fcntl is not None:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        try:
+            yield lock_path
+        finally:
+            if fcntl is not None:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)

--- a/goal_harness/todos.py
+++ b/goal_harness/todos.py
@@ -4,6 +4,7 @@ import re
 from pathlib import Path
 from typing import Any
 
+from .file_lock import exclusive_file_lock
 from .history import load_registry
 from .state_refresh import now_local, resolve_goal_state
 from .status import (
@@ -70,6 +71,27 @@ def inherit_todo_priority(next_text: str, source_text: str | None) -> str:
     if not source_priority:
         return normalized
     return f"[{source_priority}] {normalized}"
+
+
+def resolve_todo_state_path(
+    *,
+    registry_path: Path,
+    goal_id: str,
+    project: Path | None = None,
+    state_file: Path | None = None,
+) -> tuple[Path | None, Path]:
+    registry = load_registry(registry_path)
+    goal, resolved_project, resolved_state_file = resolve_goal_state(
+        registry=registry,
+        goal_id=goal_id,
+        project_override=project,
+        state_file_override=state_file,
+    )
+    if goal is None:
+        raise ValueError(f"goal {goal_id!r} is not present in the registry")
+    if not resolved_state_file.exists():
+        raise ValueError(f"active state file does not exist: {resolved_state_file}")
+    return resolved_project, resolved_state_file
 
 
 def section_bounds(lines: list[str], role: str) -> tuple[int, int, str] | None:
@@ -458,37 +480,33 @@ def add_goal_todo(
     if role not in TODO_SECTION_HEADINGS:
         raise ValueError("todo role must be one of: user, agent")
     todo_text = normalize_new_todo(text)
-    registry = load_registry(registry_path)
-    goal, resolved_project, resolved_state_file = resolve_goal_state(
-        registry=registry,
+    resolved_project, resolved_state_file = resolve_todo_state_path(
+        registry_path=registry_path,
         goal_id=goal_id,
-        project_override=project,
-        state_file_override=state_file,
+        project=project,
+        state_file=state_file,
     )
-    if goal is None:
-        raise ValueError(f"goal {goal_id!r} is not present in the registry")
-    if not resolved_state_file.exists():
-        raise ValueError(f"active state file does not exist: {resolved_state_file}")
 
-    original = resolved_state_file.read_text(encoding="utf-8")
-    lines = original.splitlines()
-    add_result = add_todo_to_lines(
-        lines,
-        role=role,
-        text=todo_text,
-        task_class=task_class,
-        action_kind=action_kind,
-        required_write_scopes=required_write_scopes,
-    )
-    added = bool(add_result["added"])
-    metadata_updated = bool(add_result["metadata_updated"])
+    with exclusive_file_lock(resolved_state_file):
+        original = resolved_state_file.read_text(encoding="utf-8")
+        lines = original.splitlines()
+        add_result = add_todo_to_lines(
+            lines,
+            role=role,
+            text=todo_text,
+            task_class=task_class,
+            action_kind=action_kind,
+            required_write_scopes=required_write_scopes,
+        )
+        added = bool(add_result["added"])
+        metadata_updated = bool(add_result["metadata_updated"])
 
-    updated_at = now_local()
-    new_text = "\n".join(lines) + ("\n" if original.endswith("\n") else "")
-    if added or metadata_updated:
-        new_text = replace_updated_at(new_text, updated_at)
-    if (added or metadata_updated) and not dry_run:
-        resolved_state_file.write_text(new_text, encoding="utf-8")
+        updated_at = now_local()
+        new_text = "\n".join(lines) + ("\n" if original.endswith("\n") else "")
+        if added or metadata_updated:
+            new_text = replace_updated_at(new_text, updated_at)
+        if (added or metadata_updated) and not dry_run:
+            resolved_state_file.write_text(new_text, encoding="utf-8")
 
     return {
         "ok": True,
@@ -517,17 +535,12 @@ def resolve_todo_state(
     project: Path | None = None,
     state_file: Path | None = None,
 ) -> tuple[Path | None, Path, str, list[str]]:
-    registry = load_registry(registry_path)
-    goal, resolved_project, resolved_state_file = resolve_goal_state(
-        registry=registry,
+    resolved_project, resolved_state_file = resolve_todo_state_path(
+        registry_path=registry_path,
         goal_id=goal_id,
-        project_override=project,
-        state_file_override=state_file,
+        project=project,
+        state_file=state_file,
     )
-    if goal is None:
-        raise ValueError(f"goal {goal_id!r} is not present in the registry")
-    if not resolved_state_file.exists():
-        raise ValueError(f"active state file does not exist: {resolved_state_file}")
     original = resolved_state_file.read_text(encoding="utf-8")
     return resolved_project, resolved_state_file, original, original.splitlines()
 
@@ -618,32 +631,35 @@ def update_goal_todo(
     state_file: Path | None = None,
     dry_run: bool = False,
 ) -> dict[str, Any]:
-    resolved_project, resolved_state_file, original, lines = resolve_todo_state(
+    resolved_project, resolved_state_file = resolve_todo_state_path(
         registry_path=registry_path,
         goal_id=goal_id,
         project=project,
         state_file=state_file,
     )
-    updated_at = now_local()
-    update_result = apply_todo_update_to_lines(
-        lines,
-        todo_id=todo_id,
-        status=status,
-        role=role,
-        note=note,
-        evidence=evidence,
-        reason=reason,
-        task_class=task_class,
-        action_kind=action_kind,
-        required_write_scopes=required_write_scopes,
-        updated_at=updated_at,
-    )
-    changed = bool(update_result["changed"])
-    new_text = "\n".join(lines) + ("\n" if original.endswith("\n") else "")
-    if changed:
-        new_text = replace_updated_at(new_text, updated_at)
-    if changed and not dry_run:
-        resolved_state_file.write_text(new_text, encoding="utf-8")
+    with exclusive_file_lock(resolved_state_file):
+        original = resolved_state_file.read_text(encoding="utf-8")
+        lines = original.splitlines()
+        updated_at = now_local()
+        update_result = apply_todo_update_to_lines(
+            lines,
+            todo_id=todo_id,
+            status=status,
+            role=role,
+            note=note,
+            evidence=evidence,
+            reason=reason,
+            task_class=task_class,
+            action_kind=action_kind,
+            required_write_scopes=required_write_scopes,
+            updated_at=updated_at,
+        )
+        changed = bool(update_result["changed"])
+        new_text = "\n".join(lines) + ("\n" if original.endswith("\n") else "")
+        if changed:
+            new_text = replace_updated_at(new_text, updated_at)
+        if changed and not dry_run:
+            resolved_state_file.write_text(new_text, encoding="utf-8")
     return {
         "ok": True,
         "dry_run": dry_run,
@@ -672,55 +688,58 @@ def complete_goal_todo(
     state_file: Path | None = None,
     dry_run: bool = False,
 ) -> dict[str, Any]:
-    resolved_project, resolved_state_file, original, lines = resolve_todo_state(
+    resolved_project, resolved_state_file = resolve_todo_state_path(
         registry_path=registry_path,
         goal_id=goal_id,
         project=project,
         state_file=state_file,
     )
-    updated_at = now_local()
-    update_result = apply_todo_update_to_lines(
-        lines,
-        todo_id=todo_id,
-        status=TODO_STATUS_DONE,
-        role=role,
-        note=note,
-        evidence=evidence,
-        updated_at=updated_at,
-    )
-    next_results: list[dict[str, Any]] = []
-    if next_agent_todo:
-        next_results.append(
-            add_todo_to_lines(
-                lines,
-                role="agent",
-                text=inherit_todo_priority(
-                    next_agent_todo,
-                    str(update_result.get("todo") or ""),
-                ),
-                task_class=next_task_class or "advancement_task",
-                action_kind=next_action_kind,
-            )
+    with exclusive_file_lock(resolved_state_file):
+        original = resolved_state_file.read_text(encoding="utf-8")
+        lines = original.splitlines()
+        updated_at = now_local()
+        update_result = apply_todo_update_to_lines(
+            lines,
+            todo_id=todo_id,
+            status=TODO_STATUS_DONE,
+            role=role,
+            note=note,
+            evidence=evidence,
+            updated_at=updated_at,
         )
-    if next_user_todo:
-        next_results.append(
-            add_todo_to_lines(
-                lines,
-                role="user",
-                text=inherit_todo_priority(
-                    next_user_todo,
-                    str(update_result.get("todo") or ""),
-                ),
-                task_class="user_gate",
+        next_results: list[dict[str, Any]] = []
+        if next_agent_todo:
+            next_results.append(
+                add_todo_to_lines(
+                    lines,
+                    role="agent",
+                    text=inherit_todo_priority(
+                        next_agent_todo,
+                        str(update_result.get("todo") or ""),
+                    ),
+                    task_class=next_task_class or "advancement_task",
+                    action_kind=next_action_kind,
+                )
             )
-        )
-    next_changed = any(item.get("added") or item.get("metadata_updated") for item in next_results)
-    changed = bool(update_result["changed"] or next_changed)
-    new_text = "\n".join(lines) + ("\n" if original.endswith("\n") else "")
-    if changed:
-        new_text = replace_updated_at(new_text, updated_at)
-    if changed and not dry_run:
-        resolved_state_file.write_text(new_text, encoding="utf-8")
+        if next_user_todo:
+            next_results.append(
+                add_todo_to_lines(
+                    lines,
+                    role="user",
+                    text=inherit_todo_priority(
+                        next_user_todo,
+                        str(update_result.get("todo") or ""),
+                    ),
+                    task_class="user_gate",
+                )
+            )
+        next_changed = any(item.get("added") or item.get("metadata_updated") for item in next_results)
+        changed = bool(update_result["changed"] or next_changed)
+        new_text = "\n".join(lines) + ("\n" if original.endswith("\n") else "")
+        if changed:
+            new_text = replace_updated_at(new_text, updated_at)
+        if changed and not dry_run:
+            resolved_state_file.write_text(new_text, encoding="utf-8")
     return {
         "ok": True,
         "dry_run": dry_run,
@@ -750,67 +769,70 @@ def supersede_goal_todo(
     state_file: Path | None = None,
     dry_run: bool = False,
 ) -> dict[str, Any]:
-    resolved_project, resolved_state_file, original, lines = resolve_todo_state(
+    resolved_project, resolved_state_file = resolve_todo_state_path(
         registry_path=registry_path,
         goal_id=goal_id,
         project=project,
         state_file=state_file,
     )
-    updated_at = now_local()
-    update_result = apply_todo_update_to_lines(
-        lines,
-        todo_id=todo_id,
-        status=TODO_STATUS_DONE,
-        role=role,
-        reason=reason,
-        note="superseded",
-        updated_at=updated_at,
-    )
-    next_results: list[dict[str, Any]] = []
-    if next_agent_todo:
-        next_results.append(
-            add_todo_to_lines(
-                lines,
-                role="agent",
-                text=inherit_todo_priority(
-                    next_agent_todo,
-                    str(update_result.get("todo") or ""),
-                ),
-                task_class=next_task_class or "advancement_task",
-                action_kind=next_action_kind,
-            )
+    with exclusive_file_lock(resolved_state_file):
+        original = resolved_state_file.read_text(encoding="utf-8")
+        lines = original.splitlines()
+        updated_at = now_local()
+        update_result = apply_todo_update_to_lines(
+            lines,
+            todo_id=todo_id,
+            status=TODO_STATUS_DONE,
+            role=role,
+            reason=reason,
+            note="superseded",
+            updated_at=updated_at,
         )
-    if next_user_todo:
-        next_results.append(
-            add_todo_to_lines(
-                lines,
-                role="user",
-                text=inherit_todo_priority(
-                    next_user_todo,
-                    str(update_result.get("todo") or ""),
-                ),
-                task_class="user_gate",
+        next_results: list[dict[str, Any]] = []
+        if next_agent_todo:
+            next_results.append(
+                add_todo_to_lines(
+                    lines,
+                    role="agent",
+                    text=inherit_todo_priority(
+                        next_agent_todo,
+                        str(update_result.get("todo") or ""),
+                    ),
+                    task_class=next_task_class or "advancement_task",
+                    action_kind=next_action_kind,
+                )
             )
-        )
-    superseded_by = next((item.get("todo_id") for item in next_results if item.get("todo_id")), None)
-    if superseded_by:
-        block_match = find_todo_block(lines, todo_id=str(update_result["todo_id"]), role=role)
-        if block_match:
-            _resolved_role, _section, _start, _end, block = block_match
-            update_result["metadata_updated"] = upsert_todo_metadata(
-                lines,
-                block,
-                metadata_line_for_block(block, {"superseded_by": superseded_by}),
-            ) or update_result["metadata_updated"]
-            update_result["superseded_by"] = superseded_by
-            update_result["changed"] = True
-    next_changed = any(item.get("added") or item.get("metadata_updated") for item in next_results)
-    changed = bool(update_result["changed"] or next_changed)
-    new_text = "\n".join(lines) + ("\n" if original.endswith("\n") else "")
-    if changed:
-        new_text = replace_updated_at(new_text, updated_at)
-    if changed and not dry_run:
-        resolved_state_file.write_text(new_text, encoding="utf-8")
+        if next_user_todo:
+            next_results.append(
+                add_todo_to_lines(
+                    lines,
+                    role="user",
+                    text=inherit_todo_priority(
+                        next_user_todo,
+                        str(update_result.get("todo") or ""),
+                    ),
+                    task_class="user_gate",
+                )
+            )
+        superseded_by = next((item.get("todo_id") for item in next_results if item.get("todo_id")), None)
+        if superseded_by:
+            block_match = find_todo_block(lines, todo_id=str(update_result["todo_id"]), role=role)
+            if block_match:
+                _resolved_role, _section, _start, _end, block = block_match
+                update_result["metadata_updated"] = upsert_todo_metadata(
+                    lines,
+                    block,
+                    metadata_line_for_block(block, {"superseded_by": superseded_by}),
+                ) or update_result["metadata_updated"]
+                update_result["superseded_by"] = superseded_by
+                update_result["changed"] = True
+        next_changed = any(item.get("added") or item.get("metadata_updated") for item in next_results)
+        changed = bool(update_result["changed"] or next_changed)
+        new_text = "\n".join(lines) + ("\n" if original.endswith("\n") else "")
+        if changed:
+            new_text = replace_updated_at(new_text, updated_at)
+        if changed and not dry_run:
+            resolved_state_file.write_text(new_text, encoding="utf-8")
     return {
         "ok": True,
         "dry_run": dry_run,
@@ -839,68 +861,64 @@ def archive_completed_todos(
         raise ValueError("todo role must be one of: user, agent")
     if max_active_done < 0:
         raise ValueError("max_active_done must be non-negative")
-    registry = load_registry(registry_path)
-    goal, resolved_project, resolved_state_file = resolve_goal_state(
-        registry=registry,
+    resolved_project, resolved_state_file = resolve_todo_state_path(
+        registry_path=registry_path,
         goal_id=goal_id,
-        project_override=project,
-        state_file_override=state_file,
+        project=project,
+        state_file=state_file,
     )
-    if goal is None:
-        raise ValueError(f"goal {goal_id!r} is not present in the registry")
-    if not resolved_state_file.exists():
-        raise ValueError(f"active state file does not exist: {resolved_state_file}")
 
-    original = resolved_state_file.read_text(encoding="utf-8")
-    lines = original.splitlines()
-    bounds = section_bounds(lines, role)
-    section = bounds[2] if bounds else TODO_SECTION_HEADINGS[role]
-    moved_blocks: list[list[str]] = []
-    active_done_count = 0
-    moved_count = 0
-    kept_done_count = 0
+    with exclusive_file_lock(resolved_state_file):
+        original = resolved_state_file.read_text(encoding="utf-8")
+        lines = original.splitlines()
+        bounds = section_bounds(lines, role)
+        section = bounds[2] if bounds else TODO_SECTION_HEADINGS[role]
+        moved_blocks: list[list[str]] = []
+        active_done_count = 0
+        moved_count = 0
+        kept_done_count = 0
 
-    if bounds:
-        blocks = todo_blocks(lines, bounds[0], bounds[1], role=role, source_section=section)
-        done_blocks = [block for block in blocks if block.get("done") is True]
-        active_done_count = len(done_blocks)
-        move_count = max(0, active_done_count - max_active_done)
-        move_starts = {int(block["start"]) for block in done_blocks[:move_count]}
-        kept_done_count = active_done_count - move_count
-        for block in done_blocks[:move_count]:
-            moved_blocks.append(lines[int(block["start"]) : int(block["end"])])
-        if move_starts:
-            new_lines: list[str] = []
-            index = 0
-            while index < len(lines):
-                if index in move_starts:
-                    matching = next(
-                        block
-                        for block in done_blocks[:move_count]
-                        if int(block["start"]) == index
-                    )
-                    index = int(matching["end"])
-                    while (
-                        new_lines
-                        and not new_lines[-1].strip()
-                        and index < len(lines)
-                        and not lines[index].strip()
-                    ):
-                        index += 1
-                    continue
-                new_lines.append(lines[index])
-                index += 1
-            lines = new_lines
-            insert_archive_blocks(lines, moved_blocks)
-            moved_count = move_count
+        if bounds:
+            blocks = todo_blocks(lines, bounds[0], bounds[1], role=role, source_section=section)
+            done_blocks = [block for block in blocks if block.get("done") is True]
+            active_done_count = len(done_blocks)
+            move_count = max(0, active_done_count - max_active_done)
+            move_starts = {int(block["start"]) for block in done_blocks[:move_count]}
+            kept_done_count = active_done_count - move_count
+            for block in done_blocks[:move_count]:
+                moved_blocks.append(lines[int(block["start"]) : int(block["end"])])
+            if move_starts:
+                new_lines: list[str] = []
+                index = 0
+                while index < len(lines):
+                    if index in move_starts:
+                        matching = next(
+                            block
+                            for block in done_blocks[:move_count]
+                            if int(block["start"]) == index
+                        )
+                        index = int(matching["end"])
+                        while (
+                            new_lines
+                            and not new_lines[-1].strip()
+                            and index < len(lines)
+                            and not lines[index].strip()
+                        ):
+                            index += 1
+                        continue
+                    new_lines.append(lines[index])
+                    index += 1
+                lines = new_lines
+                insert_archive_blocks(lines, moved_blocks)
+                moved_count = move_count
 
-    updated_at = now_local()
-    changed = moved_count > 0
-    new_text = "\n".join(lines) + ("\n" if original.endswith("\n") else "")
-    if changed:
-        new_text = replace_updated_at(new_text, updated_at)
-    if changed and not dry_run:
-        resolved_state_file.write_text(new_text, encoding="utf-8")
+        updated_at = now_local()
+        changed = moved_count > 0
+        new_text = "\n".join(lines) + ("\n" if original.endswith("\n") else "")
+        if changed:
+            new_text = replace_updated_at(new_text, updated_at)
+        if changed and not dry_run:
+            resolved_state_file.write_text(new_text, encoding="utf-8")
 
     return {
         "ok": True,


### PR DESCRIPTION
## Summary
- add a small sibling file lock for active-state read/modify/write todo operations
- route add/update/complete/supersede/archive through locked reads and writes
- add a CLI-level concurrent add/update smoke and ignore active-state lock files

## Validation
- python3 examples/todo-concurrent-write-lock-smoke.py
- python3 examples/todo-lifecycle-cli-smoke.py
- python3 examples/todo-archive-completed-smoke.py
- python3 examples/todo-cli-smoke.py
- python3 examples/todo-first-open-summary-smoke.py
- python3 -m py_compile goal_harness/file_lock.py goal_harness/todos.py examples/todo-concurrent-write-lock-smoke.py
- git diff --check origin/main...HEAD
- goal-harness check (passes; existing duplicate-index warning remains)

## Boundary
- excludes private state, raw benchmark logs, trajectories, credentials, and local artifacts
