### PR TITLE
Add contract-only behavior regression runner

### DIFF
--- a/regression/README.md
+++ b/regression/README.md
@@ -9,6 +9,16 @@ run deliberately during release or major control-plane changes.
 
 ## Current Regressions
 
+Run all default contract-only regressions:
+
+```bash
+python3 regression/run-regressions.py
+```
+
+The default suite must stay public-safe and dependency-light: no real Codex CLI,
+Docker, private prompts, raw trajectories, raw logs, verifier tails, or local
+credential material. Keep real-agent paths as explicit per-file opt-ins.
+
 ```bash
 python3 regression/external-evidence-observation-real-codex.py
 ```
@@ -17,10 +27,11 @@ Runs the contract-only path. It creates an isolated Goal Harness fixture and
 checks two projection contracts:
 
 - explicit `waiting_on=external_evidence` goals return an
-  external-evidence observation obligation;
-- already-launched long-running work with an observable compact-result poll
-  target is treated as read-only external evidence, even when the open todo
-  still carries its original `advancement_task/run_eval` metadata.
+  external-evidence observation obligation with delivery disabled until the
+  observation or compact blocker is written back;
+- already-launched advancement work with compact-result poll context remains a
+  bounded delivery lane, with the external monitor treated as auxiliary
+  context rather than a quiet no-op excuse.
 
 ```bash
 python3 regression/quota-executable-backlog-projection.py

--- a/regression/external-evidence-observation-real-codex.py
+++ b/regression/external-evidence-observation-real-codex.py
@@ -372,38 +372,46 @@ def run_real_codex(
 
 
 def assert_contract(guard: dict[str, Any]) -> None:
-    assert guard["should_run"] is False, guard
+    assert guard["should_run"] is True, guard
     assert guard["state"] == "waiting", guard
     assert guard["waiting_on"] == "external_evidence", guard
     assert guard["effective_action"] == "external_evidence_observe", guard
+    assert guard["normal_delivery_allowed"] is False, guard
+    assert guard["actionable_by_codex"] is True, guard
     observation = guard["external_evidence_observation"]
     assert observation["required"] is True, observation
+    assert observation["kind"] == "external_evidence_monitor", observation
+    assert observation["trigger"] == "registry_waiting_on_external_evidence", observation
     assert observation["requires_observable_handle"] is True, observation
     assert guard["execution_obligation"]["must_attempt_work"] is True, guard
     assert (
         guard["execution_obligation"]["kind"]
         == "external_evidence_observation_required"
     ), guard
+    interaction = guard["interaction_contract"]
+    assert interaction["mode"] == "external_evidence_observation", interaction
+    assert interaction["agent_channel"]["delivery_allowed"] is False, interaction
+    assert interaction["agent_channel"]["quiet_noop_allowed"] is False, interaction
+    assert interaction["cli_channel"]["spend_allowed_now"] is False, interaction
 
 
 def assert_launched_poll_contract(guard: dict[str, Any]) -> None:
-    assert guard["should_run"] is False, guard
+    assert guard["should_run"] is True, guard
     assert guard["state"] == "eligible", guard
     assert guard["waiting_on"] == "codex", guard
-    assert guard["effective_action"] == "external_evidence_observe", guard
+    assert guard["effective_action"] == "normal_run", guard
     work_lane = guard["work_lane_contract"]
-    assert work_lane["lane"] == "continuous_monitor", work_lane
-    assert work_lane["monitor_kind"] == "external_evidence", work_lane
-    observation = guard["external_evidence_observation"]
-    assert observation["required"] is True, observation
-    assert observation["kind"] == "launched_external_work_monitor", observation
-    assert observation["trigger"] == "implicit_launched_external_poll", observation
-    assert observation["requires_observable_handle"] is True, observation
+    assert work_lane["lane"] == "advancement_task", work_lane
+    assert work_lane["reason_codes"] == ["open_agent_todo", "external_monitor_context"], work_lane
     assert guard["execution_obligation"]["must_attempt_work"] is True, guard
     assert (
         guard["execution_obligation"]["kind"]
-        == "external_evidence_observation_required"
+        == "work_lane_contract"
     ), guard
+    interaction = guard["interaction_contract"]
+    assert interaction["mode"] == "bounded_delivery", interaction
+    assert interaction["agent_channel"]["delivery_allowed"] is True, interaction
+    assert interaction["agent_channel"]["quiet_noop_allowed"] is False, interaction
 
 
 def assert_real_codex_decision(decision: dict[str, Any]) -> None:

--- a/regression/run-regressions.py
+++ b/regression/run-regressions.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Run Goal Harness behavior regressions in safe contract-only mode."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@dataclass(frozen=True)
+class Regression:
+    path: str
+    description: str
+
+
+CONTRACT_ONLY_REGRESSIONS = (
+    Regression(
+        path="regression/quota-executable-backlog-projection.py",
+        description="quota selects executable backlog work over unchanged monitor context",
+    ),
+    Regression(
+        path="regression/external-evidence-observation-real-codex.py",
+        description="external evidence waits require observation; launched advancement work stays bounded delivery",
+    ),
+    Regression(
+        path="regression/agentissue-lagent239-real-codex-runner.py",
+        description="AgentIssue lagent_239 runner materializes public-safe boundaries",
+    ),
+)
+
+
+def main() -> int:
+    failures: list[str] = []
+    for regression in CONTRACT_ONLY_REGRESSIONS:
+        script = REPO_ROOT / regression.path
+        print(f"==> {regression.path}: {regression.description}", flush=True)
+        result = subprocess.run([sys.executable, str(script)], cwd=REPO_ROOT)
+        if result.returncode != 0:
+            failures.append(f"{regression.path} exited {result.returncode}")
+
+    if failures:
+        for failure in failures:
+            print(f"failed: {failure}", file=sys.stderr)
+        return 1
+
+    print(f"ok: {len(CONTRACT_ONLY_REGRESSIONS)} contract-only regression(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a default contract-only runner for the behavior regression suite
- update external-evidence regression assertions to the current interaction contract: explicit external-evidence waits require observation/blocker work, while launched advancement work remains bounded delivery
- document the safe default regression entrypoint and keep real Codex/Docker paths explicit opt-ins

## Validation
- python3 regression/run-regressions.py
- python3 -m py_compile regression/run-regressions.py regression/external-evidence-observation-real-codex.py
- git diff --check origin/main...HEAD
- goal-harness check (passes; existing duplicate-index warning remains)

## Boundary
- default runner is contract-only: no Codex CLI, Docker, private prompts, raw logs, trajectories, verifier output, or credential material
