### PR TITLE
Add no-progress self-repair regression

### DIFF
--- a/regression/README.md
+++ b/regression/README.md
@@ -30,6 +30,15 @@ It checks that `quota should-run` keeps the blocked item user-visible with
 fallback as the agent action in the interaction contract and protocol packet.
 
 ```bash
+python3 regression/no-progress-self-repair-contract.py
+```
+
+Runs the autonomous no-progress self-repair contract. This wrapper deliberately
+reuses `examples/autonomous-replan-obligation-smoke.py` instead of copying the
+fixture: repeated no-progress signals should force an autonomous replan/self-
+repair obligation before another quiet wait.
+
+```bash
 python3 regression/external-evidence-observation-real-codex.py
 ```
 

--- a/regression/no-progress-self-repair-contract.py
+++ b/regression/no-progress-self-repair-contract.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Regression wrapper for autonomous no-progress self-repair contracts."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SMOKE_PATH = REPO_ROOT / "examples" / "autonomous-replan-obligation-smoke.py"
+
+
+def main() -> int:
+    spec = importlib.util.spec_from_file_location("autonomous_replan_obligation_smoke", SMOKE_PATH)
+    assert spec is not None and spec.loader is not None, SMOKE_PATH
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    result = module.main()
+    assert result == 0, result
+    print("no-progress-self-repair-contract-regression ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/regression/run-regressions.py
+++ b/regression/run-regressions.py
@@ -24,6 +24,10 @@ CONTRACT_ONLY_REGRESSIONS = (
         description="blocked P0 work stays visible while safe fallback work proceeds",
     ),
     Regression(
+        path="regression/no-progress-self-repair-contract.py",
+        description="two no-progress signals force autonomous self-repair before quiet waiting",
+    ),
+    Regression(
         path="regression/quota-executable-backlog-projection.py",
         description="quota selects executable backlog work over unchanged monitor context",
     ),


### PR DESCRIPTION
## Summary
- add a regression wrapper for autonomous no-progress self-repair obligations
- include it in the default contract-only regression runner
- document that the wrapper reuses the existing public smoke instead of duplicating the fixture

## Validation
- python3 regression/run-regressions.py
- python3 -m py_compile regression/no-progress-self-repair-contract.py regression/run-regressions.py
- git diff --check origin/main...HEAD
- goal-harness check (passes; existing duplicate-index warning remains)

## Boundary
- contract-only wrapper; no Codex CLI, Docker, private prompts, raw logs, trajectories, verifier output, or credential material
