### PR TITLE
Strengthen compact blocker input regression

### DIFF
--- a/regression/README.md
+++ b/regression/README.md
@@ -48,6 +48,9 @@ checks two projection contracts:
 - explicit `waiting_on=external_evidence` goals return an
   external-evidence observation obligation with delivery disabled until the
   observation or compact blocker is written back;
+- the compact guard/prompt handed to Codex is sufficient to require
+  `compact_blocker_writeback` when no observable worker/controller handle is
+  present, while forbidding quiet no-op and benchmark execution;
 - already-launched advancement work with compact-result poll context remains a
   bounded delivery lane, with the external monitor treated as auxiliary
   context rather than a quiet no-op excuse.

--- a/regression/external-evidence-observation-real-codex.py
+++ b/regression/external-evidence-observation-real-codex.py
@@ -395,6 +395,24 @@ def assert_contract(guard: dict[str, Any]) -> None:
     assert interaction["cli_channel"]["spend_allowed_now"] is False, interaction
 
 
+def assert_compact_blocker_codex_input_contract(guard: dict[str, Any]) -> None:
+    compact = compact_guard_for_codex(guard)
+    assert compact["fixture_observed_handle_present"] is False, compact
+    assert compact["execution_obligation"]["kind"] == (
+        "external_evidence_observation_required"
+    ), compact
+    assert compact["external_evidence_observation"]["requires_observable_handle"] is True, compact
+    assert "missing worker/controller handle" in (
+        compact["external_evidence_observation"]["if_handle_missing"]
+    ), compact
+
+    prompt = codex_prompt(compact)
+    assert "compact_blocker_writeback" in prompt, prompt
+    assert "quiet_noop_allowed must be false" in prompt, prompt
+    assert "benchmark_execution_allowed must be false" in prompt, prompt
+    assert "Do not read files" in prompt, prompt
+
+
 def assert_launched_poll_contract(guard: dict[str, Any]) -> None:
     assert guard["should_run"] is True, guard
     assert guard["state"] == "eligible", guard
@@ -437,6 +455,7 @@ def main() -> int:
             runtime=runtime,
         )
         assert_contract(guard)
+        assert_compact_blocker_codex_input_contract(guard)
         launched_project, launched_runtime, launched_registry = write_launched_poll_fixture(root / "launched-poll")
         launched_guard = run_goal_harness(
             root,


### PR DESCRIPTION
## Summary
- add a contract-only assertion that the compact guard/prompt sent to Codex requires compact_blocker_writeback when no observable worker/controller handle is present
- document the compact blocker input contract in the regression suite README

## Validation
- python3 regression/run-regressions.py
- python3 -m py_compile regression/external-evidence-observation-real-codex.py regression/run-regressions.py
- git diff --check
- goal-harness check (passes with existing duplicate-index warning)

## Safety
- staged explicit pathspecs only
- no raw benchmark logs, trajectories, verifier tails, credentials, private prompts, or local state added