### PR TITLE
Extract doctor CLI command module

### DIFF
--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -117,6 +117,7 @@ from .benchmark_core import (
 )
 from .configure_goal import configure_goal, render_configure_goal_markdown
 from .contract import check_contract, render_contract_markdown
+from .cli_commands import handle_doctor_command, register_doctor_command
 from .demo import (
     DEFAULT_DEMO_AGENT_TODO,
     DEFAULT_DEMO_GOAL_ID,
@@ -126,7 +127,6 @@ from .demo import (
     render_demo_markdown,
     run_demo,
 )
-from .doctor import collect_doctor, render_doctor_markdown
 from .execution_profile import DEFAULT_EXECUTION_PROFILE
 from .feedback import append_human_reward, compact_reward, render_reward_markdown
 from .global_registry import render_global_sync_markdown, sync_project_registry_to_global
@@ -1701,7 +1701,7 @@ def main(argv: list[str] | None = None) -> int:
     demo_parser.add_argument("--user-todo", default=DEFAULT_DEMO_USER_TODO)
     demo_parser.add_argument("--agent-todo", default=DEFAULT_DEMO_AGENT_TODO)
 
-    sub.add_parser("doctor", help="Diagnose local CLI installation, PATH, wrapper, and import health.")
+    register_doctor_command(sub)
 
     worker_bridge_parser = sub.add_parser(
         "worker-bridge",
@@ -5049,9 +5049,7 @@ def main(argv: list[str] | None = None) -> int:
         return 0 if payload.get("ok") else 1
 
     if args.command == "doctor":
-        payload = collect_doctor()
-        print_payload(payload, args.format, render_doctor_markdown)
-        return 0 if payload.get("ok") else 1
+        return handle_doctor_command(args, print_payload)
 
     if args.command == "worker-bridge":
         if args.worker_bridge_command not in (

--- a/goal_harness/cli_commands/__init__.py
+++ b/goal_harness/cli_commands/__init__.py
@@ -1,0 +1,16 @@
+"""Modular CLI command registrations.
+
+Command modules expose two small functions:
+
+- ``register_*_command(subparsers)`` wires argparse for one command group.
+- ``handle_*_command(args, print_payload)`` executes the parsed command.
+
+The top-level CLI keeps global options, registry fallback, and dispatch order.
+"""
+
+from .doctor import handle_doctor_command, register_doctor_command
+
+__all__ = [
+    "handle_doctor_command",
+    "register_doctor_command",
+]

--- a/goal_harness/cli_commands/doctor.py
+++ b/goal_harness/cli_commands/doctor.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+
+from ..doctor import collect_doctor, render_doctor_markdown
+
+
+PrintPayload = Callable[
+    [dict[str, object], str, Callable[[dict[str, object]], str]],
+    None,
+]
+
+
+def register_doctor_command(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser:
+    return subparsers.add_parser(
+        "doctor",
+        help="Diagnose local CLI installation, PATH, wrapper, and import health.",
+    )
+
+
+def handle_doctor_command(args: argparse.Namespace, print_payload: PrintPayload) -> int:
+    payload = collect_doctor()
+    print_payload(payload, args.format, render_doctor_markdown)
+    return 0 if payload.get("ok") else 1

--- a/regression/README.md
+++ b/regression/README.md
@@ -20,6 +20,16 @@ Docker, private prompts, raw trajectories, raw logs, verifier tails, or local
 credential material. Keep real-agent paths as explicit per-file opt-ins.
 
 ```bash
+python3 regression/cli-command-module-contract.py
+```
+
+Runs a contract-only compatibility check for the first modular CLI command
+seam. It imports `goal_harness.cli_commands`, then verifies the old public
+`python -m goal_harness.cli --format json doctor` invocation still returns a
+successful JSON payload after `doctor` registration/handling moves out of the
+top-level `cli.py` file.
+
+```bash
 python3 regression/blocked-priority-fallback-contract.py
 ```
 

--- a/regression/cli-command-module-contract.py
+++ b/regression/cli-command-module-contract.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Regression for the first modular CLI command seam.
+
+This protects the initial extraction from ``goal_harness.cli`` into
+``goal_harness.cli_commands``. The old public invocation should keep working
+while command registration/handling moves behind a small module contract.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def main() -> int:
+    sys.path.insert(0, str(REPO_ROOT))
+    from goal_harness.cli_commands import handle_doctor_command, register_doctor_command
+
+    assert callable(register_doctor_command)
+    assert callable(handle_doctor_command)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "goal_harness.cli",
+            "--format",
+            "json",
+            "doctor",
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = json.loads(result.stdout)
+    assert isinstance(payload, dict), payload
+    assert payload.get("ok") is True, payload
+    assert "checks" in payload, payload
+    print("cli-command-module-contract-regression ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/regression/run-regressions.py
+++ b/regression/run-regressions.py
@@ -20,6 +20,10 @@ class Regression:
 
 CONTRACT_ONLY_REGRESSIONS = (
     Regression(
+        path="regression/cli-command-module-contract.py",
+        description="modular CLI command seam preserves the public doctor invocation",
+    ),
+    Regression(
         path="regression/blocked-priority-fallback-contract.py",
         description="blocked P0 work stays visible while safe fallback work proceeds",
     ),


### PR DESCRIPTION
## Summary
- introduce goal_harness.cli_commands as the command-module seam for future CLI modularization
- migrate the low-risk doctor command registration/handler out of top-level cli.py
- add a contract-only regression proving the old python -m goal_harness.cli --format json doctor invocation still works

## Validation
- python3 regression/cli-command-module-contract.py
- python3 -m py_compile goal_harness/cli.py goal_harness/cli_commands/__init__.py goal_harness/cli_commands/doctor.py regression/cli-command-module-contract.py regression/run-regressions.py
- python3 regression/run-regressions.py
- git diff --check
- goal-harness check (passes with existing duplicate-index warning)

## Safety
- staged explicit pathspecs only
- no raw benchmark logs, trajectories, verifier tails, credentials, private prompts, local state, or generated logs added