### PR TITLE
Add benchmark case routing taxonomy

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger-v0.md
@@ -136,6 +136,21 @@ Each case also has `latest_decision`, derived from the current rows:
 - `paired_result_needs_score_review`
 - `single_arm_recorded`
 
+`latest_decision` may also include `case_routing`, a compact case-history
+taxonomy used to avoid blind relaunches when the newest paired decision hides an
+older durable signal. Current routing classes include:
+
+- `case_exception_research`: a compact exception attribution asset is needed
+  before repeating the case.
+- `case_timeout_research`: one solver-timeout signal exists and needs timeout
+  context review.
+- `timeout_tier_policy_candidate`: repeated solver-timeout signals indicate the
+  case needs an explicit timeout tier or continuation-cadence decision before
+  another run.
+- `bridge_connected_no_uplift`: the Goal Harness bridge reached the worker, but
+  the official score still did not improve; reruns should analyze solution
+  quality or case fit rather than treat the route as a bridge repair.
+
 ## Boundary
 
 The ledger must not contain raw logs, task prompts, trajectories, credentials,

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
@@ -6784,6 +6784,12 @@
           "latest_decision": {
             "baseline_failure_scope": "case_or_solution",
             "baseline_run_id": "d8853f13e62c",
+            "case_routing": {
+              "class": "bridge_connected_no_uplift",
+              "evidence": "worker_bridge_connected_official_score_failure_runs=2; official_score_delta=0",
+              "next_action": "treat the bridge as connected and analyze case or solution quality; do not relaunch this case as a bridge repair",
+              "priority": "P1"
+            },
             "decision": "paired_no_score_uplift",
             "official_score_delta": 0.0,
             "treatment_failure_scope": "case_or_solution",
@@ -7324,6 +7330,12 @@
           "latest_decision": {
             "baseline_failure_scope": "case_or_solution",
             "baseline_run_id": "1e0e7327d18a",
+            "case_routing": {
+              "class": "timeout_tier_policy_candidate",
+              "evidence": "case_timeout_research_count=5",
+              "next_action": "decide the timeout tier and continuation cadence before rerunning; separate setup timeout from solver timeout evidence",
+              "priority": "P1"
+            },
             "decision": "paired_result_requires_attribution",
             "official_score_delta": 0.0,
             "treatment_failure_scope": "attribution_required",
@@ -9168,6 +9180,12 @@
           "latest_decision": {
             "baseline_failure_scope": "case_or_solution",
             "baseline_run_id": "2db3f1047704",
+            "case_routing": {
+              "class": "case_exception_research",
+              "evidence": "case_exception_research_count=3",
+              "next_action": "inspect compact exception attribution and form a case-level intervention hypothesis before rerunning this case",
+              "priority": "P1"
+            },
             "decision": "paired_no_score_uplift_exception_research_required",
             "failure_class": "agent_exception_before_solution_completion",
             "next_action": "inspect compact exception attribution and form a case-level intervention hypothesis",

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
@@ -9,48 +9,48 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 
 ## Case Decisions
 
-| Benchmark | Case | Decision | Runs |
-| --- | --- | --- | --- |
-| `skillsbench@1.1` | `3d-scan-calc` | `paired_baseline_solved_treatment_preserved` | `3` |
-| `skillsbench@1.1` | `ada-bathroom-plan-repair` | `paired_baseline_solved_treatment_preserved` | `4` |
-| `skillsbench@1.1` | `adaptive-cruise-control` | `baseline_runner_or_setup_repair_required` | `1` |
-| `skillsbench@1.1` | `azure-bgp-oscillation-route-leak` | `paired_no_score_uplift` | `10` |
-| `skillsbench@1.1` | `bike-rebalance` | `paired_baseline_solved_treatment_preserved` | `3` |
-| `skillsbench@1.1` | `citation-check` | `paired_baseline_solved_treatment_preserved` | `4` |
-| `skillsbench@1.1` | `civ6-adjacency-optimizer` | `paired_no_score_uplift` | `4` |
-| `skillsbench@1.1` | `dapt-intrusion-detection` | `paired_baseline_setup_preflight_selection_required` | `5` |
-| `skillsbench@1.1` | `debug-trl-grpo` | `paired_baseline_runner_or_setup_repair_required` | `9` |
-| `skillsbench@1.1` | `fix-build-agentops` | `baseline_runner_or_setup_repair_required` | `2` |
-| `skillsbench@1.1` | `llm-prefix-cache-replay` | `paired_baseline_runner_or_setup_repair_required` | `20` |
-| `skillsbench@1.1` | `manufacturing-codebook-normalization` | `paired_no_score_uplift` | `4` |
-| `skillsbench@1.1` | `organize-messy-files` | `paired_baseline_solved_treatment_preserved` | `3` |
-| `skillsbench@1.1` | `paratransit-routing` | `paired_treatment_improved` | `9` |
-| `skillsbench@1.1` | `pddl-airport-planning` | `paired_no_score_uplift` | `9` |
-| `skillsbench@1.1` | `react-performance-debugging` | `paired_no_score_uplift` | `4` |
-| `skillsbench@1.1` | `setup-fuzzing-py` | `baseline_runner_or_setup_repair_required` | `3` |
-| `skillsbench@1.1` | `software-dependency-audit` | `paired_no_score_uplift` | `6` |
-| `skillsbench@1.1` | `suricata-custom-exfil` | `paired_baseline_solved_treatment_preserved` | `4` |
-| `skillsbench@1.1` | `tictoc-unnecessary-abort-detection` | `baseline_runner_or_setup_repair_required` | `1` |
-| `skillsbench@1.1` | `travel-planning` | `baseline_passed_not_current_treatment_priority` | `1` |
-| `terminal-bench-worker-materialization@v0` | `nginx-request-logging` | `single_arm_recorded` | `2` |
-| `terminal-bench@2.0` | `build-cython-ext` | `baseline_passed_not_current_treatment_priority` | `5` |
-| `terminal-bench@2.0` | `cobol-modernization` | `paired_baseline_solved_treatment_preserved` | `2` |
-| `terminal-bench@2.0` | `compile-compcert` | `baseline_passed_not_current_treatment_priority` | `1` |
-| `terminal-bench@2.0` | `financial-document-processor` | `baseline_passed_not_current_treatment_priority` | `2` |
-| `terminal-bench@2.0` | `fix-code-vulnerability` | `baseline_passed_not_current_treatment_priority` | `1` |
-| `terminal-bench@2.0` | `git-multibranch` | `paired_baseline_solved_treatment_preserved` | `5` |
-| `terminal-bench@2.0` | `headless-terminal` | `paired_no_score_uplift` | `5` |
-| `terminal-bench@2.0` | `install-windows-3.11` | `paired_treatment_worker_verifier_alignment_required` | `4` |
-| `terminal-bench@2.0` | `large-scale-text-editing` | `paired_baseline_solved_treatment_preserved` | `5` |
-| `terminal-bench@2.0` | `make-doom-for-mips` | `paired_result_requires_attribution` | `9` |
-| `terminal-bench@2.0` | `merge-diff-arc-agi-task` | `baseline_passed_not_current_treatment_priority` | `1` |
-| `terminal-bench@2.0` | `mteb-retrieve` | `paired_baseline_environment_setup_repair_required` | `4` |
-| `terminal-bench@2.0` | `multi-source-data-merger` | `paired_baseline_solved_treatment_preserved` | `18` |
-| `terminal-bench@2.0` | `nginx-request-logging` | `paired_baseline_solved_treatment_preserved` | `7` |
-| `terminal-bench@2.0` | `path-tracing` | `baseline_passed_not_current_treatment_priority` | `2` |
-| `terminal-bench@2.0` | `pytorch-model-recovery` | `paired_no_score_uplift_exception_research_required` | `3` |
-| `terminal-bench@2.0` | `regex-log` | `paired_baseline_solved_treatment_preserved` | `2` |
-| `terminal-bench@2.0` | `sqlite-db-truncate` | `baseline_passed_not_current_treatment_priority` | `1` |
+| Benchmark | Case | Decision | Case Routing | Runs |
+| --- | --- | --- | --- | --- |
+| `skillsbench@1.1` | `3d-scan-calc` | `paired_baseline_solved_treatment_preserved` | - | `3` |
+| `skillsbench@1.1` | `ada-bathroom-plan-repair` | `paired_baseline_solved_treatment_preserved` | - | `4` |
+| `skillsbench@1.1` | `adaptive-cruise-control` | `baseline_runner_or_setup_repair_required` | - | `1` |
+| `skillsbench@1.1` | `azure-bgp-oscillation-route-leak` | `paired_no_score_uplift` | - | `10` |
+| `skillsbench@1.1` | `bike-rebalance` | `paired_baseline_solved_treatment_preserved` | - | `3` |
+| `skillsbench@1.1` | `citation-check` | `paired_baseline_solved_treatment_preserved` | - | `4` |
+| `skillsbench@1.1` | `civ6-adjacency-optimizer` | `paired_no_score_uplift` | - | `4` |
+| `skillsbench@1.1` | `dapt-intrusion-detection` | `paired_baseline_setup_preflight_selection_required` | - | `5` |
+| `skillsbench@1.1` | `debug-trl-grpo` | `paired_baseline_runner_or_setup_repair_required` | - | `9` |
+| `skillsbench@1.1` | `fix-build-agentops` | `baseline_runner_or_setup_repair_required` | - | `2` |
+| `skillsbench@1.1` | `llm-prefix-cache-replay` | `paired_baseline_runner_or_setup_repair_required` | - | `20` |
+| `skillsbench@1.1` | `manufacturing-codebook-normalization` | `paired_no_score_uplift` | - | `4` |
+| `skillsbench@1.1` | `organize-messy-files` | `paired_baseline_solved_treatment_preserved` | - | `3` |
+| `skillsbench@1.1` | `paratransit-routing` | `paired_treatment_improved` | - | `9` |
+| `skillsbench@1.1` | `pddl-airport-planning` | `paired_no_score_uplift` | - | `9` |
+| `skillsbench@1.1` | `react-performance-debugging` | `paired_no_score_uplift` | - | `4` |
+| `skillsbench@1.1` | `setup-fuzzing-py` | `baseline_runner_or_setup_repair_required` | - | `3` |
+| `skillsbench@1.1` | `software-dependency-audit` | `paired_no_score_uplift` | - | `6` |
+| `skillsbench@1.1` | `suricata-custom-exfil` | `paired_baseline_solved_treatment_preserved` | - | `4` |
+| `skillsbench@1.1` | `tictoc-unnecessary-abort-detection` | `baseline_runner_or_setup_repair_required` | - | `1` |
+| `skillsbench@1.1` | `travel-planning` | `baseline_passed_not_current_treatment_priority` | - | `1` |
+| `terminal-bench-worker-materialization@v0` | `nginx-request-logging` | `single_arm_recorded` | - | `2` |
+| `terminal-bench@2.0` | `build-cython-ext` | `baseline_passed_not_current_treatment_priority` | - | `5` |
+| `terminal-bench@2.0` | `cobol-modernization` | `paired_baseline_solved_treatment_preserved` | - | `2` |
+| `terminal-bench@2.0` | `compile-compcert` | `baseline_passed_not_current_treatment_priority` | - | `1` |
+| `terminal-bench@2.0` | `financial-document-processor` | `baseline_passed_not_current_treatment_priority` | - | `2` |
+| `terminal-bench@2.0` | `fix-code-vulnerability` | `baseline_passed_not_current_treatment_priority` | - | `1` |
+| `terminal-bench@2.0` | `git-multibranch` | `paired_baseline_solved_treatment_preserved` | - | `5` |
+| `terminal-bench@2.0` | `headless-terminal` | `paired_no_score_uplift` | `bridge_connected_no_uplift` | `5` |
+| `terminal-bench@2.0` | `install-windows-3.11` | `paired_treatment_worker_verifier_alignment_required` | - | `4` |
+| `terminal-bench@2.0` | `large-scale-text-editing` | `paired_baseline_solved_treatment_preserved` | - | `5` |
+| `terminal-bench@2.0` | `make-doom-for-mips` | `paired_result_requires_attribution` | `timeout_tier_policy_candidate` | `9` |
+| `terminal-bench@2.0` | `merge-diff-arc-agi-task` | `baseline_passed_not_current_treatment_priority` | - | `1` |
+| `terminal-bench@2.0` | `mteb-retrieve` | `paired_baseline_environment_setup_repair_required` | - | `4` |
+| `terminal-bench@2.0` | `multi-source-data-merger` | `paired_baseline_solved_treatment_preserved` | - | `18` |
+| `terminal-bench@2.0` | `nginx-request-logging` | `paired_baseline_solved_treatment_preserved` | - | `7` |
+| `terminal-bench@2.0` | `path-tracing` | `baseline_passed_not_current_treatment_priority` | - | `2` |
+| `terminal-bench@2.0` | `pytorch-model-recovery` | `paired_no_score_uplift_exception_research_required` | `case_exception_research` | `3` |
+| `terminal-bench@2.0` | `regex-log` | `paired_baseline_solved_treatment_preserved` | - | `2` |
+| `terminal-bench@2.0` | `sqlite-db-truncate` | `baseline_passed_not_current_treatment_priority` | - | `1` |
 
 ## Repair Backlog
 

--- a/examples/benchmark-run-ledger-smoke.py
+++ b/examples/benchmark-run-ledger-smoke.py
@@ -721,6 +721,69 @@ def test_verified_bridge_official_zero_routes_to_no_uplift_not_alignment() -> No
         assert case["latest_decision"]["baseline_failure_scope"] == "case_or_solution", case
         assert case["latest_decision"]["treatment_failure_scope"] == "case_or_solution", case
         assert case["latest_decision"]["decision"] == "paired_no_score_uplift", case
+        assert case["latest_decision"]["case_routing"]["class"] == (
+            "bridge_connected_no_uplift"
+        ), case
+        rendered = render_benchmark_run_ledger_markdown(ledger)
+        assert "`bridge_connected_no_uplift`" in rendered, rendered
+
+
+def test_repeated_case_timeout_routes_to_timeout_tier_candidate() -> None:
+    baseline = {
+        "schema_version": "benchmark_run_v0",
+        "benchmark_id": "terminal-bench@2.0",
+        "job_name": "terminal_bench_2_0_make_doom_for_mips_codex_goal_mode_baseline",
+        "mode": "codex_goal_mode_baseline",
+        "official_task_score": {
+            "kind": "harbor_verifier_reward",
+            "value": 0.0,
+            "passed": False,
+        },
+        "failure_attribution_labels": ["agent_timeout_before_solution_completion"],
+        "trials": [
+            {
+                "task_id": "make-doom-for-mips",
+                "exception_type": "none",
+            }
+        ],
+    }
+    treatment = {
+        **baseline,
+        "job_name": "terminal_bench_2_0_make_doom_for_mips_codex_goal_harness_treatment",
+        "mode": "codex_goal_harness",
+        "goal_harness_inside_case": True,
+    }
+
+    with tempfile.TemporaryDirectory(prefix="benchmark-run-ledger-timeout-tier-") as tmp:
+        root = Path(tmp)
+        ledger_path = root / "ledger.json"
+        update_benchmark_run_ledger(
+            ledger_path=ledger_path,
+            benchmark_run=baseline,
+            arm_id="baseline",
+            run_group_id="timeout-tier-ledger-smoke",
+            cwd=root,
+        )
+        update_benchmark_run_ledger(
+            ledger_path=ledger_path,
+            benchmark_run=treatment,
+            arm_id="treatment",
+            run_group_id="timeout-tier-ledger-smoke",
+            cwd=root,
+        )
+        ledger = load_benchmark_run_ledger(ledger_path)
+        case = ledger["benchmarks"]["terminal-bench@2.0"]["cases"][
+            "make-doom-for-mips"
+        ]
+        assert case["latest_decision"]["decision"] == (
+            "paired_no_score_uplift_timeout_research_required"
+        ), case
+        assert case["latest_decision"]["case_routing"]["class"] == (
+            "timeout_tier_policy_candidate"
+        ), case
+        assert case["latest_decision"]["case_routing"]["evidence"] == (
+            "case_timeout_research_count=2"
+        ), case
 
 
 def test_passed_pair_routes_to_baseline_solved_non_regression() -> None:

--- a/goal_harness/benchmark_ledger.py
+++ b/goal_harness/benchmark_ledger.py
@@ -889,6 +889,92 @@ def _repair_profile_summary(value: Any) -> str:
     return repair_class
 
 
+def _case_routing_taxonomy(
+    runs: list[dict[str, Any]],
+    decision: dict[str, Any],
+) -> dict[str, Any]:
+    """Summarize case-history routing hints that should survive latest-pair churn."""
+
+    if not runs:
+        return {}
+    repair_counts: dict[str, int] = {}
+    bridge_signal_run_count = 0
+    for run in runs:
+        repair_class = _compact_text(run.get("repair_class"), limit=120)
+        if repair_class:
+            repair_counts[repair_class] = repair_counts.get(repair_class, 0) + 1
+        failure_class = _compact_text(run.get("failure_class"), limit=120)
+        labels = _compact_list(run.get("failure_labels"), limit=20) or _compact_list(
+            run.get("failure_attribution_labels"),
+            limit=20,
+        )
+        if (
+            failure_class == "worker_bridge_connected_official_score_failure"
+            or "worker_bridge_connected_official_score_failure" in labels
+        ):
+            bridge_signal_run_count += 1
+
+    if repair_counts.get("case_exception_research", 0) > 0:
+        return {
+            "class": "case_exception_research",
+            "priority": "P1",
+            "evidence": (
+                f"case_exception_research_count="
+                f"{repair_counts['case_exception_research']}"
+            ),
+            "next_action": (
+                "inspect compact exception attribution and form a case-level "
+                "intervention hypothesis before rerunning this case"
+            ),
+        }
+
+    timeout_count = repair_counts.get("case_timeout_research", 0)
+    if timeout_count >= 2:
+        return {
+            "class": "timeout_tier_policy_candidate",
+            "priority": "P1",
+            "evidence": f"case_timeout_research_count={timeout_count}",
+            "next_action": (
+                "decide the timeout tier and continuation cadence before "
+                "rerunning; separate setup timeout from solver timeout evidence"
+            ),
+        }
+    if timeout_count == 1:
+        return {
+            "class": "case_timeout_research",
+            "priority": "P1",
+            "evidence": "case_timeout_research_count=1",
+            "next_action": (
+                "inspect compact timeout context and decide whether this case "
+                "needs a private long-horizon timeout tier"
+            ),
+        }
+
+    decision_name = _compact_text(decision.get("decision"), limit=120)
+    no_score_uplift = (
+        decision.get("official_score_delta") == 0
+        or decision_name
+        in {
+            "paired_no_score_uplift",
+            "paired_no_score_uplift_case_research_required",
+        }
+    )
+    if bridge_signal_run_count and no_score_uplift:
+        return {
+            "class": "bridge_connected_no_uplift",
+            "priority": "P1",
+            "evidence": (
+                f"worker_bridge_connected_official_score_failure_runs="
+                f"{bridge_signal_run_count}; official_score_delta=0"
+            ),
+            "next_action": (
+                "treat the bridge as connected and analyze case or solution "
+                "quality; do not relaunch this case as a bridge repair"
+            ),
+        }
+    return {}
+
+
 def _run_status(benchmark_run: dict[str, Any], score: float | int | None) -> str:
     if _source_schema(benchmark_run) == "terminal_bench_post_launch_materialization_v0":
         if benchmark_run.get("ready_for_compact_failure_marker") is True:
@@ -1389,6 +1475,12 @@ def _case_decision(case: dict[str, Any]) -> dict[str, Any]:
     latest_baseline = baselines[-1] if baselines else None
     latest_treatment = treatments[-1] if treatments else None
 
+    def with_case_routing(result: dict[str, Any]) -> dict[str, Any]:
+        routing = _case_routing_taxonomy(runs, result)
+        if routing:
+            result["case_routing"] = routing
+        return result
+
     def repair_decision(prefix: str, run: dict[str, Any]) -> dict[str, Any]:
         failure_class = _compact_text(run.get("failure_class"), limit=120)
         repair_class = _compact_text(run.get("repair_class"), limit=120)
@@ -1500,7 +1592,7 @@ def _case_decision(case: dict[str, Any]) -> dict[str, Any]:
                 }
             )
             del decision_info
-        return result
+        return with_case_routing(result)
     if latest_baseline:
         if latest_baseline.get("official_passed") is True:
             decision = "baseline_passed_not_current_treatment_priority"
@@ -1540,9 +1632,11 @@ def _case_decision(case: dict[str, Any]) -> dict[str, Any]:
                 }
             )
             del decision_info
-        return result
+        return with_case_routing(result)
     if runs:
-        return {"decision": "single_arm_recorded", "latest_run_id": runs[-1].get("run_id")}
+        return with_case_routing(
+            {"decision": "single_arm_recorded", "latest_run_id": runs[-1].get("run_id")}
+        )
     return {"decision": "no_runs_recorded"}
 
 
@@ -1594,8 +1688,8 @@ def render_benchmark_run_ledger_markdown(ledger: dict[str, Any]) -> str:
         "",
         "## Case Decisions",
         "",
-        "| Benchmark | Case | Decision | Runs |",
-        "| --- | --- | --- | --- |",
+        "| Benchmark | Case | Decision | Case Routing | Runs |",
+        "| --- | --- | --- | --- | --- |",
     ]
     benchmarks = ledger.get("benchmarks") if isinstance(ledger.get("benchmarks"), dict) else {}
     for benchmark_id in sorted(benchmarks):
@@ -1610,9 +1704,18 @@ def render_benchmark_run_ledger_markdown(ledger: dict[str, Any]) -> str:
                 if isinstance(case, dict) and isinstance(case.get("latest_decision"), dict)
                 else {}
             )
+            routing = (
+                decision.get("case_routing")
+                if isinstance(decision.get("case_routing"), dict)
+                else {}
+            )
+            routing_class = _compact_text(routing.get("class"), limit=120)
+            routing_cell = f"`{routing_class}`" if routing_class else "-"
             runs = case.get("runs", []) if isinstance(case, dict) else []
             lines.append(
-                f"| `{benchmark_id}` | `{case_id}` | `{decision.get('decision', 'unknown')}` | `{len(runs)}` |"
+                f"| `{benchmark_id}` | `{case_id}` | "
+                f"`{decision.get('decision', 'unknown')}` | "
+                f"{routing_cell} | `{len(runs)}` |"
             )
     repair_rows: list[tuple[str, str, str, str, str, str, str, str]] = []
     priority_order = {"P0": 0, "P1": 1, "P2": 2}


### PR DESCRIPTION
## Summary
- Add a case-history routing taxonomy to benchmark ledger decisions so durable signals survive latest-pair churn.
- Surface routing classes in the generated benchmark ledger table.
- Cover bridge-connected/no-uplift and repeated timeout-tier routing with focused smoke tests.

## Commit grouping
- `e1852bd`: runtime reducer, schema note, focused smoke coverage.
- `64669b6`: regenerated public benchmark ledger projections.

## Validation
- `python3 -m py_compile goal_harness/benchmark_ledger.py`
- `python3 examples/benchmark-run-ledger-smoke.py`
- `python3 examples/benchmark-case-analysis-smoke.py`
- `git diff --check`
- `goal-harness check --scan-path ...` (passes; existing duplicate-index warning remains)

## Boundary
- No raw logs, trajectories, verifier output, credentials, uploads, or absolute local paths added.
- New generated fields only use compact public-safe ledger labels and counts.