### PR TITLE
Add automation loop heartbeat poll regression

### DIFF
--- a/examples/heartbeat-quota-flow-smoke.py
+++ b/examples/heartbeat-quota-flow-smoke.py
@@ -588,7 +588,15 @@ def main() -> int:
         assert follow_up["status"] == "state_refreshed", follow_up
         assert follow_up["quota"]["spent_slots"] == 1, follow_up
         assert follow_up["quota"]["allowed_slots"] == 2, follow_up
-        assert LONG_NEXT_ACTION_TAIL in follow_up["recommended_action"], follow_up
+        expected_action = "[P1] Run one bounded heartbeat marker and validate the compact result."
+        assert follow_up["recommended_action"] == expected_action, follow_up
+        interaction = follow_up["interaction_contract"]
+        assert interaction["agent_channel"]["primary_action"] == expected_action, interaction
+        warning = follow_up["state_action_projection_warning"]
+        assert warning["requires_state_writeback"] is True, warning
+        assert warning["selected_recommended_action"] == expected_action, warning
+        assert "executable backlog item" in warning["reason"], warning
+        assert "agent_action=" + expected_action in follow_up["protocol_action_packet"]["summary"], follow_up
         assert registry_path.read_text(encoding="utf-8") == registry_before
 
     with tempfile.TemporaryDirectory(prefix="goal-harness-heartbeat-operator-gate-") as tmp:

--- a/regression/README.md
+++ b/regression/README.md
@@ -78,6 +78,17 @@ payload exposes a state-action projection warning when the visible
 `Next Action` still points at the stale monitor action.
 
 ```bash
+python3 regression/automation-loop-heartbeat-poll-contract.py
+```
+
+Runs the automation-loop heartbeat poll contract by reusing
+`examples/heartbeat-quota-flow-smoke.py`. It checks that bounded heartbeat
+delivery only spends after validated state writeback, repeated monitor polls
+stay quiet and do not spend, compact external-evidence observation remains
+bounded, and projection warnings route stale `Next Action` text behind the
+selected executable todo.
+
+```bash
 python3 regression/external-evidence-observation-real-codex.py --real-codex
 ```
 

--- a/regression/automation-loop-heartbeat-poll-contract.py
+++ b/regression/automation-loop-heartbeat-poll-contract.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Regression wrapper for automation-loop heartbeat poll contracts.
+
+The durable behavior lives in `examples/heartbeat-quota-flow-smoke.py`.
+This wrapper makes the default regression suite cover it without duplicating
+fixtures or pulling in real Codex/Docker/model execution.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SMOKE_PATH = REPO_ROOT / "examples" / "heartbeat-quota-flow-smoke.py"
+
+
+def main() -> int:
+    spec = importlib.util.spec_from_file_location(
+        "heartbeat_quota_flow_smoke",
+        SMOKE_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"unable to load {SMOKE_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.main()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/regression/run-regressions.py
+++ b/regression/run-regressions.py
@@ -36,6 +36,10 @@ CONTRACT_ONLY_REGRESSIONS = (
         description="quota selects executable backlog work over unchanged monitor context",
     ),
     Regression(
+        path="regression/automation-loop-heartbeat-poll-contract.py",
+        description="automation heartbeat polls stay bounded, compact, and spend only after writeback",
+    ),
+    Regression(
         path="regression/external-evidence-observation-real-codex.py",
         description="external evidence waits require observation; launched advancement work stays bounded delivery",
     ),


### PR DESCRIPTION
## Summary
- Update the heartbeat quota flow smoke for the current projection contract: follow-up quota selection now uses the executable agent todo and reports stale Next Action via projection warning.
- Add a thin default regression wrapper for the automation-loop heartbeat poll contract.
- Register the wrapper in the contract-only regression suite and README.

## Validation
- python3 examples/heartbeat-quota-flow-smoke.py
- python3 regression/automation-loop-heartbeat-poll-contract.py
- python3 -m py_compile examples/heartbeat-quota-flow-smoke.py regression/automation-loop-heartbeat-poll-contract.py regression/run-regressions.py
- python3 regression/run-regressions.py
- git diff --check
- goal-harness check --scan-path examples/heartbeat-quota-flow-smoke.py --scan-path regression/automation-loop-heartbeat-poll-contract.py --scan-path regression/run-regressions.py --scan-path regression/README.md

## Excluded
- No local state, raw benchmark logs, trajectories, verifier tails, credentials, or private prompts are included.
- Real Codex/Docker paths remain explicit opt-ins, not part of the default regression suite.