### PR TITLE
Add periodic autonomous replan trigger

### DIFF
--- a/examples/autonomous-replan-obligation-smoke.py
+++ b/examples/autonomous-replan-obligation-smoke.py
@@ -36,11 +36,35 @@ def run_cli(*args: str, registry_path: Path, runtime: Path) -> dict:
     return json.loads(result.stdout)
 
 
+def append_run_record(runs_dir: Path, record: dict) -> None:
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    generated_at = str(record["generated_at"])
+    json_path = runs_dir / f"{generated_at.replace(':', '-')}.json"
+    markdown_path = runs_dir / f"{generated_at.replace(':', '-')}.md"
+    record = {
+        **record,
+        "goal_id": GOAL_ID,
+        "json_path": str(json_path),
+        "markdown_path": str(markdown_path),
+    }
+    json_path.write_text(json.dumps(record, sort_keys=True) + "\n", encoding="utf-8")
+    markdown_path.write_text(
+        "# Fixture Run\n\n"
+        f"- classification: `{record['classification']}`\n"
+        f"- recommended_action: {record.get('recommended_action', '')}\n",
+        encoding="utf-8",
+    )
+    with (runs_dir / "index.jsonl").open("a", encoding="utf-8") as f:
+        f.write(json.dumps(record, sort_keys=True) + "\n")
+
+
 def write_fixture(
     root: Path,
     *,
     include_replan_signals: bool,
     include_run_history_stalls: bool = False,
+    periodic_run_count: int = 0,
+    include_recent_replan_ack: bool = False,
 ) -> tuple[Path, Path]:
     project = root / "project"
     runtime = root / "runtime"
@@ -120,35 +144,50 @@ def write_fixture(
         + "\n",
         encoding="utf-8",
     )
+    if include_run_history_stalls or periodic_run_count or include_recent_replan_ack:
+        runs_dir = runtime / "goals" / GOAL_ID / "runs"
+        if include_recent_replan_ack:
+            append_run_record(
+                runs_dir,
+                {
+                    "generated_at": "2026-01-02T00:30:00+00:00",
+                    "classification": "autonomous_replan_recorded",
+                    "recommended_action": "Periodic review was recorded; continue selected next slice.",
+                    "health_check": "compact replan ack",
+                    "delivery_outcome": "outcome_progress",
+                },
+            )
+    if periodic_run_count:
+        runs_dir = runtime / "goals" / GOAL_ID / "runs"
+        for offset in range(periodic_run_count):
+            minute = periodic_run_count - offset
+            append_run_record(
+                runs_dir,
+                {
+                    "generated_at": f"2026-01-01T00:{minute:02d}:00+00:00",
+                    "classification": "benchmark_rotation_iteration",
+                    "recommended_action": f"Advance bounded benchmark/control-plane slice {minute}.",
+                    "health_check": "compact durable run event",
+                    "delivery_outcome": "outcome_progress",
+                },
+            )
     if include_run_history_stalls:
         runs_dir = runtime / "goals" / GOAL_ID / "runs"
-        runs_dir.mkdir(parents=True, exist_ok=True)
         repeated_action = "Observe dependency state; no material transition yet."
         for generated_at in (
             "2026-01-01T00:04:00+00:00",
             "2026-01-01T00:00:00+00:00",
         ):
-            json_path = runs_dir / f"{generated_at.replace(':', '-')}.json"
-            markdown_path = runs_dir / f"{generated_at.replace(':', '-')}.md"
-            record = {
-                "generated_at": generated_at,
-                "goal_id": GOAL_ID,
-                "classification": "dependency_observation_monitor",
-                "recommended_action": repeated_action,
-                "health_check": "monitor-only observation unchanged",
-                "delivery_outcome": "surface_only",
-                "json_path": str(json_path),
-                "markdown_path": str(markdown_path),
-            }
-            json_path.write_text(json.dumps(record, sort_keys=True) + "\n", encoding="utf-8")
-            markdown_path.write_text(
-                "# Fixture Run\n\n"
-                f"- classification: `{record['classification']}`\n"
-                f"- recommended_action: {record['recommended_action']}\n",
-                encoding="utf-8",
+            append_run_record(
+                runs_dir,
+                {
+                    "generated_at": generated_at,
+                    "classification": "dependency_observation_monitor",
+                    "recommended_action": repeated_action,
+                    "health_check": "monitor-only observation unchanged",
+                    "delivery_outcome": "surface_only",
+                },
             )
-            with (runs_dir / "index.jsonl").open("a", encoding="utf-8") as f:
-                f.write(json.dumps(record, sort_keys=True) + "\n")
     return registry_path, runtime
 
 
@@ -224,6 +263,84 @@ def assert_replan_obligation_projected_from_run_history() -> None:
         assert guard["automation_liveness"]["pause_allowed"] is False, guard
 
 
+def assert_periodic_replan_obligation_projected_from_run_history() -> None:
+    with tempfile.TemporaryDirectory(prefix="goal-harness-autonomous-replan-") as tmp:
+        registry_path, runtime = write_fixture(
+            Path(tmp),
+            include_replan_signals=False,
+            periodic_run_count=20,
+        )
+        status_payload = run_cli(
+            "status",
+            "--limit",
+            "30",
+            registry_path=registry_path,
+            runtime=runtime,
+        )
+        item = attention_item(status_payload)
+        obligation = item["project_asset"]["autonomous_replan_obligation"]
+        assert obligation["schema_version"] == "autonomous_replan_obligation_v0", obligation
+        assert obligation["required"] is True, obligation
+        assert obligation["trigger_count"] == 1, obligation
+        assert obligation["triggers"][0]["kind"] == "periodic_review_due", obligation
+        assert obligation["triggers"][0]["section"] == "run_history", obligation
+        assert obligation["triggers"][0]["run_count"] == 20, obligation
+        assert obligation["triggers"][0]["threshold"] == 20, obligation
+        assert obligation["guidance_actions"] == [
+            "keep",
+            "split",
+            "add",
+            "retire",
+            "ask_decision",
+        ], obligation
+        assert obligation["todo_actions"][0]["action"] == "split", obligation
+        assert obligation["todo_actions"][1]["action"] == "add", obligation
+        assert obligation["todo_actions"][2]["action"] == "ask_decision", obligation
+        assert "bounded autonomous periodic review" in obligation["recommended_action"], obligation
+
+        guard = run_cli("quota", "should-run", "--goal-id", GOAL_ID, registry_path=registry_path, runtime=runtime)
+        assert guard["should_run"] is True, guard
+        assert guard["autonomous_replan_obligation"] == obligation, guard
+        recommendation = guard["heartbeat_recommendation"]
+        assert recommendation["recommended_mode"] == "autonomous_replan_required", recommendation
+        assert guard["execution_obligation"]["kind"] == "autonomous_replan_required", guard
+        assert guard["automation_liveness"]["automation_action"] == "execute_bounded_work", guard
+
+
+def assert_no_periodic_replan_before_threshold_or_after_ack() -> None:
+    with tempfile.TemporaryDirectory(prefix="goal-harness-autonomous-replan-") as tmp:
+        registry_path, runtime = write_fixture(
+            Path(tmp),
+            include_replan_signals=False,
+            periodic_run_count=19,
+        )
+        status_payload = run_cli(
+            "status",
+            "--limit",
+            "30",
+            registry_path=registry_path,
+            runtime=runtime,
+        )
+        item = attention_item(status_payload)
+        assert "autonomous_replan_obligation" not in item, item
+        assert "autonomous_replan_obligation" not in item["project_asset"], item
+
+        guard = run_cli("quota", "should-run", "--goal-id", GOAL_ID, registry_path=registry_path, runtime=runtime)
+        assert "autonomous_replan_obligation" not in guard, guard
+        assert guard["heartbeat_recommendation"]["recommended_mode"] != "autonomous_replan_required", guard
+
+    with tempfile.TemporaryDirectory(prefix="goal-harness-autonomous-replan-") as tmp:
+        registry_path, runtime = write_fixture(
+            Path(tmp),
+            include_replan_signals=False,
+            periodic_run_count=20,
+            include_recent_replan_ack=True,
+        )
+        guard = run_cli("quota", "should-run", "--goal-id", GOAL_ID, registry_path=registry_path, runtime=runtime)
+        assert "autonomous_replan_obligation" not in guard, guard
+        assert guard["heartbeat_recommendation"]["recommended_mode"] != "autonomous_replan_required", guard
+
+
 def assert_no_replan_obligation_without_signal() -> None:
     with tempfile.TemporaryDirectory(prefix="goal-harness-autonomous-replan-") as tmp:
         registry_path, runtime = write_fixture(Path(tmp), include_replan_signals=False)
@@ -240,6 +357,8 @@ def assert_no_replan_obligation_without_signal() -> None:
 def main() -> int:
     assert_replan_obligation_projected()
     assert_replan_obligation_projected_from_run_history()
+    assert_periodic_replan_obligation_projected_from_run_history()
+    assert_no_periodic_replan_before_threshold_or_after_ack()
     assert_no_replan_obligation_without_signal()
     print("autonomous-replan-obligation-smoke ok")
     return 0

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -187,6 +187,7 @@ from .state_refresh import (
     render_state_refresh_markdown,
 )
 from .status import (
+    AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK,
     collect_status,
     compact_active_user_assisted_pilot,
     compact_benchmark_comparison,
@@ -8551,11 +8552,14 @@ def main(argv: list[str] | None = None) -> int:
             scan_roots = [Path(item).expanduser() for item in args.scan_path]
             if not scan_roots:
                 scan_roots = [Path(args.scan_root).expanduser()]
+            status_limit = max(0, args.limit)
+            if args.quota_command == "should-run":
+                status_limit = max(status_limit, AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK)
             status_payload = collect_status(
                 registry_path=registry_path,
                 runtime_root_override=args.runtime_root,
                 scan_roots=scan_roots,
-                limit=max(0, args.limit),
+                limit=status_limit,
             )
             if args.quota_command == "should-run":
                 if not args.goal_id:

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -323,6 +323,8 @@ MAX_SUBAGENT_SCOPE_ITEMS = 4
 MAX_BACKLOG_HYGIENE_EVIDENCE_ITEMS = 3
 MAX_AUTONOMOUS_REPLAN_TRIGGERS = 3
 AUTONOMOUS_REPLAN_STALL_THRESHOLD = 2
+AUTONOMOUS_REPLAN_PERIODIC_RUN_THRESHOLD = 20
+AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK = 30
 AUTONOMOUS_PRIORITY_PATTERN = re.compile(r"^\s*\[(P[0-4][^\]]*)\]\s*(.+)$", re.IGNORECASE)
 BACKLOG_HYGIENE_SECTION_HEADINGS = ("Next Action", "Operating Lessons")
 BACKLOG_HYGIENE_BULLET_PATTERN = re.compile(r"^\s*(?:[-*]|\d+[.)])\s+(.+?)\s*$")
@@ -3943,6 +3945,29 @@ def build_autonomous_replan_obligation(
                 "text": "retire or downgrade stale monitor-only next actions after the executable replan is selected",
             }
         )
+    if any(item.get("kind") in {"periodic_review", "periodic_review_due"} for item in evidence):
+        todo_actions.append(
+            {
+                "action": "ask_decision",
+                "role": "user",
+                "priority": "P2",
+                "text": (
+                    "ask the operator only if the review changes benchmark family, public claims, "
+                    "resource budget, or protected scope"
+                ),
+            }
+        )
+
+    if any(item.get("kind") in {"periodic_review", "periodic_review_due"} for item in evidence):
+        recommended_action = (
+            "run a bounded autonomous periodic review: keep, split, add, retire, or ask for "
+            "a decision; then update todos and select the next validated slice"
+        )
+    else:
+        recommended_action = (
+            "run an autonomous replan after two consecutive stalled turns before another "
+            "monitor-only or repeated action consumes the eligible turn"
+        )
 
     return {
         "schema_version": AUTONOMOUS_REPLAN_SCHEMA_VERSION,
@@ -3950,16 +3975,14 @@ def build_autonomous_replan_obligation(
         "stall_threshold": AUTONOMOUS_REPLAN_STALL_THRESHOLD,
         "trigger_count": len(evidence),
         "triggers": evidence,
+        "guidance_actions": ["keep", "split", "add", "retire", "ask_decision"],
         "todo_actions": todo_actions[:3],
         "next_validation_command": "python3 examples/autonomous-replan-obligation-smoke.py",
         "stop_condition": (
             "stop if the replan requires private material, credentials, destructive git, "
             "production actions, or owner-only decisions"
         ),
-        "recommended_action": (
-            "run an autonomous replan after two consecutive stalled turns before another "
-            "monitor-only or repeated action consumes the eligible turn"
-        ),
+        "recommended_action": recommended_action,
     }
 
 
@@ -4014,6 +4037,46 @@ def run_history_monitor_wait_already_acknowledged(
     return False
 
 
+def autonomous_replan_periodic_review_from_runs(
+    latest_runs: list[dict[str, Any]] | None,
+    *,
+    agent_todos: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    durable_runs: list[dict[str, Any]] = []
+    for run in latest_runs or []:
+        if not isinstance(run, dict):
+            continue
+        classification = str(run.get("classification") or "").strip()
+        if not classification:
+            continue
+        if AUTONOMOUS_RUN_HISTORY_REPLAN_ACK_CLASSIFICATION.search(classification):
+            break
+        if classification in AUTONOMOUS_RUN_HISTORY_NEUTRAL_CLASSIFICATIONS:
+            continue
+        durable_runs.append(run)
+        if len(durable_runs) >= AUTONOMOUS_REPLAN_PERIODIC_RUN_THRESHOLD:
+            break
+
+    if len(durable_runs) < AUTONOMOUS_REPLAN_PERIODIC_RUN_THRESHOLD:
+        return None
+
+    evidence: list[dict[str, Any]] = [
+        {
+            "kind": "periodic_review_due",
+            "section": "run_history",
+            "text": (
+                f"latest {len(durable_runs)} durable public run records since last autonomous "
+                f"replan reached periodic review threshold {AUTONOMOUS_REPLAN_PERIODIC_RUN_THRESHOLD}"
+            ),
+            "run_count": len(durable_runs),
+            "threshold": AUTONOMOUS_REPLAN_PERIODIC_RUN_THRESHOLD,
+            "latest_generated_at": str(durable_runs[0].get("generated_at") or ""),
+            "oldest_counted_generated_at": str(durable_runs[-1].get("generated_at") or ""),
+        }
+    ]
+    return build_autonomous_replan_obligation(evidence, agent_todos=agent_todos)
+
+
 def autonomous_replan_obligation_from_runs(
     latest_runs: list[dict[str, Any]] | None,
     *,
@@ -4034,7 +4097,10 @@ def autonomous_replan_obligation_from_runs(
             break
 
     if len(signals) < AUTONOMOUS_REPLAN_STALL_THRESHOLD:
-        return None
+        return autonomous_replan_periodic_review_from_runs(
+            latest_runs,
+            agent_todos=agent_todos,
+        )
 
     signatures = {str(signal.get("signature") or "") for signal in signals if signal.get("signature")}
     classifications = {
@@ -4042,13 +4108,17 @@ def autonomous_replan_obligation_from_runs(
         for signal in signals
         if signal.get("classification")
     }
+    periodic_review = autonomous_replan_periodic_review_from_runs(
+        latest_runs,
+        agent_todos=agent_todos,
+    )
     if len(signatures) > 1 and len(classifications) > 1:
-        return None
+        return periodic_review
     if classifications == {"quota_monitor_poll"} and run_history_monitor_wait_already_acknowledged(
         latest_runs,
         signal_count=len(signals),
     ):
-        return None
+        return periodic_review
 
     action = public_safe_compact_text(
         signals[0].get("recommended_action") or signals[0].get("classification"),


### PR DESCRIPTION
## Summary
- add a run-history periodic-review trigger for autonomous_replan_obligation after 20 durable public run records since the last replan ack
- expose compact guidance actions for keep/split/add/retire/ask-decision without embedding long option explanations
- let quota should-run collect enough compact history internally to see the periodic threshold while keeping raw logs/private trajectories out
- extend the existing autonomous replan smoke with threshold, below-threshold, and recent-ack cases

## Validation
- python3 -m py_compile goal_harness/status.py goal_harness/cli.py examples/autonomous-replan-obligation-smoke.py
- python3 examples/autonomous-replan-obligation-smoke.py
- python3 regression/no-progress-self-repair-contract.py
- python3 regression/run-regressions.py
- goal-harness check --scan-path goal_harness/status.py --scan-path goal_harness/cli.py --scan-path examples/autonomous-replan-obligation-smoke.py
- git diff --check

## Excluded
- no local active state, raw benchmark logs, trajectories, verifier output, credentials, or internal links

## Residual notes
- goal-harness check still reports existing duplicate index warnings unrelated to this PR.