### PR TITLE
Keep dreaming proposals advisory

### DIFF
--- a/goal_harness/quota.py
+++ b/goal_harness/quota.py
@@ -3420,6 +3420,15 @@ def build_quota_should_run(status_payload: dict[str, Any], *, goal_id: str) -> d
         )
         if replan_obligation:
             payload["autonomous_replan_obligation"] = replan_obligation
+        dreaming_proposal = (
+            item.get("dreaming_proposal")
+            if isinstance(item.get("dreaming_proposal"), dict)
+            else project_asset.get("dreaming_proposal")
+            if isinstance(project_asset.get("dreaming_proposal"), dict)
+            else None
+        )
+        if dreaming_proposal:
+            payload["dreaming_proposal"] = dreaming_proposal
         interface_budget_cadence = (
             project_asset.get("interface_budget_cadence")
             if isinstance(project_asset.get("interface_budget_cadence"), dict)

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -70,6 +70,12 @@ HANDOFF_READY_CLASSIFICATIONS = {
     "operator_gate_approved",
     "controller_opted_in_waiting_for_run",
 }
+DREAMING_ADVISORY_CLASSIFICATIONS = {
+    "dreaming_exploration_proposal",
+    "dreaming_memory_consolidation",
+    "dreaming_refactor_warning",
+    "dreaming_archive_suggestion",
+}
 USER_OR_CONTROLLER_CLASSIFICATIONS = {
     "needs_human_reward",
     "needs_controller_opt_in",
@@ -78,7 +84,7 @@ USER_OR_CONTROLLER_CLASSIFICATIONS = {
     "ready_for_user_relay",
     "operator_gate_deferred",
     "operator_gate_rejected",
-}
+} | DREAMING_ADVISORY_CLASSIFICATIONS
 REGISTRY_WAITING_ON_OVERRIDES = {
     "user_or_controller",
     "controller",
@@ -5136,6 +5142,7 @@ def attention_item(
     user_todos: dict[str, Any] | None = None,
     agent_todos: dict[str, Any] | None = None,
     todo_state_file: str | None = None,
+    dreaming_proposal: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     project_asset = build_project_asset(
         status=status,
@@ -5175,6 +5182,9 @@ def attention_item(
         item["agent_todos"] = agent_todos
     if todo_state_file:
         item["todo_state_file"] = todo_state_file
+    if dreaming_proposal:
+        item["dreaming_proposal"] = dreaming_proposal
+        item["project_asset"]["dreaming_proposal"] = dreaming_proposal
     return item
 
 
@@ -5537,6 +5547,51 @@ def operator_gate_attention_fields(run: dict[str, Any] | None) -> dict[str, Any]
     return fields
 
 
+def compact_dreaming_proposal(run: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(run, dict):
+        return None
+    classification = str(run.get("classification") or "")
+    if classification not in DREAMING_ADVISORY_CLASSIFICATIONS:
+        return None
+    raw = run.get("dreaming") if isinstance(run.get("dreaming"), dict) else {}
+    proposal: dict[str, Any] = {
+        "schema_version": "dreaming_proposal_v0",
+        "classification": classification,
+        "advisory": True,
+        "promoted_to_delivery": False,
+        "execution_allowed": False,
+        "delivery_spend_allowed": False,
+    }
+    for key in ("lane", "evidence_window", "proposal_type", "confidence"):
+        value = public_safe_compact_text(raw.get(key), limit=80)
+        if value:
+            proposal[key] = value
+    if raw.get("requires_project_controller") is not None:
+        proposal["requires_project_controller"] = bool(raw.get("requires_project_controller"))
+    question = public_safe_compact_text(
+        run.get("operator_question") or raw.get("operator_question"),
+        limit=220,
+    )
+    if question:
+        proposal["operator_question"] = question
+    return proposal
+
+
+def dreaming_attention_fields(run: dict[str, Any] | None) -> dict[str, Any]:
+    proposal = compact_dreaming_proposal(run)
+    if not proposal:
+        return {}
+    fields: dict[str, Any] = {"dreaming_proposal": proposal}
+    question = proposal.get("operator_question")
+    if question:
+        fields["operator_question"] = normalize_operator_question(
+            str(question),
+            goal_id=str((run or {}).get("goal_id") or ""),
+            gate="dreaming_proposal_review",
+        )
+    return fields
+
+
 def legacy_runtime_goal_attention(
     goal: dict[str, Any],
     current_run: dict[str, Any] | None,
@@ -5599,7 +5654,8 @@ def goal_attention(goal: dict[str, Any]) -> dict[str, Any] | None:
     current_run = latest_run(goal)
     readiness_fields = readiness_attention_fields(current_run)
     operator_gate_fields = operator_gate_attention_fields(current_run)
-    attention_fields = {**readiness_fields, **operator_gate_fields}
+    dreaming_fields = dreaming_attention_fields(current_run)
+    attention_fields = {**readiness_fields, **operator_gate_fields, **dreaming_fields}
     lifecycle_fields = goal_lifecycle_fields(goal, current_run)
 
     if goal.get("legacy_runtime_goal"):

--- a/regression/README.md
+++ b/regression/README.md
@@ -49,6 +49,16 @@ fixture: repeated no-progress signals should force an autonomous replan/self-
 repair obligation before another quiet wait.
 
 ```bash
+python3 regression/autonomous-replan-vs-dreaming-contract.py
+```
+
+Runs the contract-only separation check for autonomous replan versus dreaming.
+It creates a compact `dreaming_exploration_proposal` fixture and verifies that
+status/quota surface it as an advisory user/controller gate with no
+`agent_command`, no autonomous replan obligation, no delivery permission, and
+no quota spend path.
+
+```bash
 python3 regression/external-evidence-observation-real-codex.py
 ```
 

--- a/regression/autonomous-replan-vs-dreaming-contract.py
+++ b/regression/autonomous-replan-vs-dreaming-contract.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Regression for keeping autonomous replan separate from dreaming proposals."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GOAL_ID = "dreaming-contract-fixture"
+
+
+def run_cli(*args: str, registry_path: Path, runtime: Path) -> dict:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "goal_harness.cli",
+            "--registry",
+            str(registry_path),
+            "--runtime-root",
+            str(runtime),
+            "--format",
+            "json",
+            *args,
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def write_fixture(root: Path) -> tuple[Path, Path]:
+    project = root / "project"
+    runtime = root / "runtime"
+    state_file = f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    state_path = project / state_file
+    registry_path = project / ".goal-harness" / "registry.json"
+    runs_dir = runtime / "goals" / GOAL_ID / "runs"
+
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        "---\n"
+        "status: active\n"
+        "updated_at: 2026-01-01T00:00:00+00:00\n"
+        "---\n\n"
+        "# Dreaming Contract Fixture\n\n"
+        "## Next Action\n\n"
+        "- Continue normal delivery only after approved work is projected.\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] [P1] Continue a normal bounded delivery task if quota allows it.\n",
+        encoding="utf-8",
+    )
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "dreaming-contract-fixture",
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": state_file,
+                        "adapter": {
+                            "kind": "harness_self_improvement",
+                            "status": "connected-read-only",
+                        },
+                        "authority_sources": [],
+                        "quota": {
+                            "compute": 1.0,
+                            "window_hours": 24,
+                            "allowed_slots": 5,
+                        },
+                    }
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    generated_at = "2026-01-01T00:00:00+00:00"
+    json_path = runs_dir / "dreaming-proposal.json"
+    markdown_path = runs_dir / "dreaming-proposal.md"
+    record = {
+        "generated_at": generated_at,
+        "goal_id": GOAL_ID,
+        "classification": "dreaming_exploration_proposal",
+        "recommended_action": "Review the advisory dreaming proposal before promoting it.",
+        "operator_question": "Should this project open a delivery todo for duplicate state handling?",
+        "agent_command": "python should-not-run.py",
+        "dreaming": {
+            "lane": "exploration",
+            "evidence_window": "last_20_runs",
+            "proposal_type": "refactor_warning",
+            "confidence": "medium",
+            "requires_project_controller": True,
+        },
+        "json_path": str(json_path),
+        "markdown_path": str(markdown_path),
+    }
+    json_path.write_text(json.dumps(record, sort_keys=True) + "\n", encoding="utf-8")
+    markdown_path.write_text("# Dreaming Proposal\n", encoding="utf-8")
+    (runs_dir / "index.jsonl").write_text(json.dumps(record, sort_keys=True) + "\n", encoding="utf-8")
+    return registry_path, runtime
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="goal-harness-dreaming-contract-") as tmp:
+        registry_path, runtime = write_fixture(Path(tmp))
+
+        status_payload = run_cli("status", registry_path=registry_path, runtime=runtime)
+        items = status_payload.get("attention_queue", {}).get("items") or []
+        assert len(items) == 1, status_payload
+        item = items[0]
+        assert item["status"] == "dreaming_exploration_proposal", item
+        assert item["waiting_on"] == "user_or_controller", item
+        assert "agent_command" not in item, item
+        assert "next_safe_command" not in item["project_asset"], item
+        proposal = item["project_asset"]["dreaming_proposal"]
+        assert proposal["schema_version"] == "dreaming_proposal_v0", proposal
+        assert proposal["advisory"] is True, proposal
+        assert proposal["promoted_to_delivery"] is False, proposal
+        assert proposal["execution_allowed"] is False, proposal
+        assert proposal["delivery_spend_allowed"] is False, proposal
+        assert proposal["proposal_type"] == "refactor_warning", proposal
+
+        guard = run_cli("quota", "should-run", "--goal-id", GOAL_ID, registry_path=registry_path, runtime=runtime)
+        assert guard["should_run"] is False, guard
+        assert guard["normal_delivery_allowed"] is False, guard
+        assert guard["state"] == "operator_gate", guard
+        assert guard["effective_action"] == "operator_gate_notify", guard
+        assert guard["heartbeat_recommendation"]["recommended_mode"] == "ask_operator_gate", guard
+        assert guard["requires_user_action"] is True, guard
+        assert "agent_command" not in guard, guard
+        assert "autonomous_replan_obligation" not in guard, guard
+        assert guard["dreaming_proposal"] == proposal, guard
+
+        interaction = guard["interaction_contract"]
+        assert interaction["mode"] == "user_gate", interaction
+        assert interaction["user_channel"]["action_required"] is True, interaction
+        assert interaction["user_channel"]["notify"] == "NOTIFY", interaction
+        assert interaction["agent_channel"]["must_attempt"] is False, interaction
+        assert interaction["agent_channel"]["delivery_allowed"] is False, interaction
+        assert interaction["cli_channel"]["spend_allowed_now"] is False, interaction
+        assert interaction["cli_channel"]["spend_after_validation"] is False, interaction
+        assert interaction["cli_channel"]["next_cli_actions"] == [
+            "no quota spend for blocker-push/gate-notification"
+        ], interaction
+
+        packet = guard["protocol_action_packet"]["summary"]
+        assert "actor=user" in packet, packet
+        assert "user_action_required=true" in packet, packet
+        assert "agent_action_required=false" in packet, packet
+        assert "llm=no_api" in packet, packet
+    print("autonomous-replan-vs-dreaming-contract-regression ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/regression/run-regressions.py
+++ b/regression/run-regressions.py
@@ -32,6 +32,10 @@ CONTRACT_ONLY_REGRESSIONS = (
         description="two no-progress signals force autonomous self-repair before quiet waiting",
     ),
     Regression(
+        path="regression/autonomous-replan-vs-dreaming-contract.py",
+        description="dreaming proposals stay advisory gates while autonomous replan remains executable",
+    ),
+    Regression(
         path="regression/quota-executable-backlog-projection.py",
         description="quota selects executable backlog work over unchanged monitor context",
     ),


### PR DESCRIPTION
## Summary
- classify dreaming proposal run records as advisory user/controller gates rather than Codex delivery work
- expose compact dreaming_proposal_v0 fields through status/quota with execution_allowed=false and delivery_spend_allowed=false
- add a default contract regression proving dreaming proposals produce no agent_command, no autonomous_replan_obligation, no delivery permission, and no quota spend path

## Validation
- python3 -m py_compile goal_harness/status.py goal_harness/quota.py regression/autonomous-replan-vs-dreaming-contract.py regression/run-regressions.py
- python3 regression/autonomous-replan-vs-dreaming-contract.py
- python3 regression/run-regressions.py
- goal-harness check --scan-path goal_harness/status.py --scan-path goal_harness/quota.py --scan-path regression/autonomous-replan-vs-dreaming-contract.py --scan-path regression/run-regressions.py --scan-path regression/README.md
- git diff --check

## Excluded
- no local active state, raw benchmark logs, trajectories, verifier output, credentials, internal links, or production actions

## Residual notes
- goal-harness check still reports existing duplicate index warnings unrelated to this PR.