### PR TITLE
Add dreaming dry-run proposal command

### DIFF
--- a/docs/dreaming-exploration-lane.md
+++ b/docs/dreaming-exploration-lane.md
@@ -152,6 +152,18 @@ agent:
 4. Only after real proposals prove useful, add scheduled heartbeats or
    automation.
 
+The local-only entry point is:
+
+```bash
+goal-harness dreaming dry-run --goal-id <goal-id> --limit 20
+```
+
+This command reads compact run history through the selected registry/runtime
+root and returns an advisory `run_record_preview`. It does not append runtime
+history, mutate active state, grant an `agent_command`, or spend quota. The
+preview is meant for operator/controller review before any proposal is promoted
+into ordinary delivery work.
+
 Acceptance criterion: a project can receive a dreaming proposal without the
 project agent being interrupted, and the user can approve, reject, or defer it
 from Goal Harness.

--- a/examples/dreaming-dry-run-proposal-smoke.py
+++ b/examples/dreaming-dry-run-proposal-smoke.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Smoke-test local-only dreaming proposal generation."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GOAL_ID = "dreaming-dry-run-fixture"
+
+
+def run_cli(*args: str, registry_path: Path, runtime: Path) -> dict:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "goal_harness.cli",
+            "--registry",
+            str(registry_path),
+            "--runtime-root",
+            str(runtime),
+            "--format",
+            "json",
+            *args,
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def append_run(runs_dir: Path, *, generated_at: str, classification: str, action: str) -> None:
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    json_path = runs_dir / f"{generated_at.replace(':', '-')}.json"
+    markdown_path = runs_dir / f"{generated_at.replace(':', '-')}.md"
+    record = {
+        "generated_at": generated_at,
+        "goal_id": GOAL_ID,
+        "classification": classification,
+        "recommended_action": action,
+        "delivery_outcome": "outcome_progress",
+        "json_path": str(json_path),
+        "markdown_path": str(markdown_path),
+    }
+    json_path.write_text(json.dumps(record, sort_keys=True) + "\n", encoding="utf-8")
+    markdown_path.write_text("# Fixture Run\n", encoding="utf-8")
+    with (runs_dir / "index.jsonl").open("a", encoding="utf-8") as f:
+        f.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+def write_fixture(root: Path) -> tuple[Path, Path, Path, Path]:
+    project = root / "project"
+    runtime = root / "runtime"
+    state_file = f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    state_path = project / state_file
+    registry_path = project / ".goal-harness" / "registry.json"
+    runs_dir = runtime / "goals" / GOAL_ID / "runs"
+
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        "---\n"
+        "status: active\n"
+        "updated_at: 2026-01-01T00:00:00+00:00\n"
+        "---\n\n"
+        "# Dreaming Dry-Run Fixture\n\n"
+        "## Next Action\n\n"
+        "- Continue the selected delivery lane after operator review.\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] [P1] Keep the dry-run proposal advisory until approved.\n",
+        encoding="utf-8",
+    )
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "dreaming-dry-run-fixture",
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": state_file,
+                        "adapter": {
+                            "kind": "harness_self_improvement",
+                            "status": "connected-read-only",
+                        },
+                        "quota": {
+                            "compute": 1.0,
+                            "window_hours": 24,
+                            "allowed_slots": 5,
+                        },
+                    }
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    append_run(
+        runs_dir,
+        generated_at="2026-01-01T00:03:00+00:00",
+        classification="docs_governance_refactor_warning_merged",
+        action="A repeated docs governance refactor warning was validated.",
+    )
+    append_run(
+        runs_dir,
+        generated_at="2026-01-01T00:02:00+00:00",
+        classification="quota_slot_spent",
+        action="Spend accounting should not be evidence for dreaming proposals.",
+    )
+    append_run(
+        runs_dir,
+        generated_at="2026-01-01T00:01:00+00:00",
+        classification="docs_governance_refactor_warning_merged",
+        action="Another refactor warning points at duplicated state handling.",
+    )
+    append_run(
+        runs_dir,
+        generated_at="2026-01-01T00:00:00+00:00",
+        classification="state_contract_doc_update",
+        action="Documented state interaction model changes.",
+    )
+    return registry_path, runtime, state_path, runs_dir / "index.jsonl"
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="goal-harness-dreaming-dry-run-") as tmp:
+        registry_path, runtime, state_path, index_path = write_fixture(Path(tmp))
+        before_state = state_path.read_text(encoding="utf-8")
+        before_index = index_path.read_text(encoding="utf-8")
+
+        payload = run_cli(
+            "dreaming",
+            "dry-run",
+            "--goal-id",
+            GOAL_ID,
+            "--limit",
+            "10",
+            registry_path=registry_path,
+            runtime=runtime,
+        )
+
+        assert payload["ok"] is True, payload
+        assert payload["dry_run"] is True, payload
+        assert payload["classification"] == "dreaming_refactor_warning", payload
+        assert payload["proposal_type"] == "refactor_warning", payload
+        assert len(payload["recent_evidence"]) == 3, payload
+        preview = payload["run_record_preview"]
+        assert preview["agent_command"] is None, preview
+        assert preview["dreaming"]["advisory"] is True, preview
+        assert preview["dreaming"]["execution_allowed"] is False, preview
+        assert preview["dreaming"]["delivery_spend_allowed"] is False, preview
+        side_effects = payload["side_effects"]
+        assert side_effects["runtime_history_appended"] is False, side_effects
+        assert side_effects["active_state_mutated"] is False, side_effects
+        assert side_effects["quota_spent"] is False, side_effects
+        assert state_path.read_text(encoding="utf-8") == before_state
+        assert index_path.read_text(encoding="utf-8") == before_index
+
+    print("dreaming-dry-run-proposal-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -120,10 +120,12 @@ from .cli_commands import (
     handle_check_command,
     handle_demo_command,
     handle_doctor_command,
+    handle_dreaming_command,
     handle_new_project_prompt_command,
     handle_review_packet_command,
     handle_status_command,
     register_doctor_command,
+    register_dreaming_commands,
     register_starter_commands,
     register_status_commands,
 )
@@ -4655,6 +4657,7 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     register_status_commands(sub, add_subcommand_format)
+    register_dreaming_commands(sub, add_subcommand_format)
 
     todo_parser = sub.add_parser(
         "todo",
@@ -8429,6 +8432,15 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "review-packet":
         return handle_review_packet_command(
+            args,
+            registry_path=registry_path,
+            runtime_root_arg=args.runtime_root,
+            output_format=output_format,
+            print_payload=print_payload,
+        )
+
+    if args.command == "dreaming":
+        return handle_dreaming_command(
             args,
             registry_path=registry_path,
             runtime_root_arg=args.runtime_root,

--- a/goal_harness/cli_commands/__init__.py
+++ b/goal_harness/cli_commands/__init__.py
@@ -9,6 +9,7 @@ The top-level CLI keeps global options, registry fallback, and dispatch order.
 """
 
 from .doctor import handle_doctor_command, register_doctor_command
+from .dreaming import handle_dreaming_command, register_dreaming_commands
 from .starter import (
     handle_demo_command,
     handle_new_project_prompt_command,
@@ -25,10 +26,12 @@ __all__ = [
     "handle_check_command",
     "handle_demo_command",
     "handle_doctor_command",
+    "handle_dreaming_command",
     "handle_new_project_prompt_command",
     "handle_review_packet_command",
     "handle_status_command",
     "register_doctor_command",
+    "register_dreaming_commands",
     "register_starter_commands",
     "register_status_commands",
 ]

--- a/goal_harness/cli_commands/dreaming.py
+++ b/goal_harness/cli_commands/dreaming.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+from pathlib import Path
+
+from ..dreaming import build_dreaming_dry_run_proposal, render_dreaming_dry_run_markdown
+from ..history import collect_history, load_registry
+from ..paths import resolve_runtime_root
+
+
+PrintPayload = Callable[
+    [dict[str, object], str, Callable[[dict[str, object]], str]],
+    None,
+]
+FormatSelector = Callable[..., str]
+
+
+def register_dreaming_commands(
+    subparsers: argparse._SubParsersAction,
+    add_subcommand_format: Callable[[argparse.ArgumentParser], None],
+) -> None:
+    dreaming_parser = subparsers.add_parser(
+        "dreaming",
+        help="Build local-only advisory dreaming proposals from compact project history.",
+    )
+    dreaming_sub = dreaming_parser.add_subparsers(dest="dreaming_command", required=True)
+
+    dry_run_parser = dreaming_sub.add_parser(
+        "dry-run",
+        help="Preview a dreaming proposal without writing project truth or runtime history.",
+    )
+    add_subcommand_format(dry_run_parser)
+    dry_run_parser.add_argument("--goal-id", required=True, help="Goal id whose recent compact history to inspect.")
+    dry_run_parser.add_argument(
+        "--limit",
+        type=int,
+        default=20,
+        help="Recent compact non-neutral runs to inspect. Defaults to 20; capped at 50.",
+    )
+
+
+def handle_dreaming_command(
+    args: argparse.Namespace,
+    *,
+    registry_path: Path,
+    runtime_root_arg: str | None,
+    output_format: FormatSelector,
+    print_payload: PrintPayload,
+) -> int:
+    selected_format = output_format(args)
+    try:
+        registry = load_registry(registry_path)
+        runtime_root = resolve_runtime_root(registry, runtime_root_arg)
+        history_payload = collect_history(
+            registry_path=registry_path,
+            runtime_root=runtime_root,
+            goal_id=args.goal_id,
+            limit=max(1, min(int(args.limit), 50)),
+            include_runtime_goals=False,
+        )
+        if args.dreaming_command != "dry-run":
+            raise ValueError(f"unsupported dreaming command: {args.dreaming_command}")
+        payload = build_dreaming_dry_run_proposal(
+            history_payload,
+            goal_id=args.goal_id,
+            limit=args.limit,
+        )
+    except Exception as exc:
+        payload = {
+            "ok": False,
+            "goal_id": getattr(args, "goal_id", None),
+            "dry_run": True,
+            "error": str(exc),
+            "side_effects": {
+                "project_files_mutated": False,
+                "active_state_mutated": False,
+                "runtime_history_appended": False,
+                "quota_spent": False,
+            },
+        }
+    print_payload(payload, selected_format, render_dreaming_dry_run_markdown)
+    return 0 if payload.get("ok") else 1

--- a/goal_harness/dreaming.py
+++ b/goal_harness/dreaming.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+
+from .status import (
+    DREAMING_ADVISORY_CLASSIFICATIONS,
+    STATUS_NEUTRAL_CLASSIFICATIONS,
+    public_safe_compact_text,
+)
+
+
+DREAMING_DRY_RUN_SCHEMA_VERSION = "dreaming_dry_run_proposal_v0"
+DREAMING_PROPOSAL_SCHEMA_VERSION = "dreaming_proposal_v0"
+MAX_DREAMING_EVIDENCE_ITEMS = 5
+
+
+def _compact_run(run: dict[str, Any]) -> dict[str, Any]:
+    compact: dict[str, Any] = {}
+    for field in ("generated_at", "classification"):
+        value = public_safe_compact_text(run.get(field), limit=120)
+        if value:
+            compact[field] = value
+    action = public_safe_compact_text(
+        run.get("recommended_action") or run.get("summary") or run.get("health_check"),
+        limit=220,
+    )
+    if action:
+        compact["recommended_action"] = action
+    outcome = public_safe_compact_text(run.get("delivery_outcome"), limit=80)
+    if outcome:
+        compact["delivery_outcome"] = outcome
+    return compact
+
+
+def _goal_record(history_payload: dict[str, Any], goal_id: str) -> dict[str, Any] | None:
+    for goal in history_payload.get("goals") or []:
+        if isinstance(goal, dict) and str(goal.get("id") or "") == goal_id:
+            return goal
+    return None
+
+
+def _signal_runs(goal: dict[str, Any], limit: int) -> list[dict[str, Any]]:
+    latest_runs = goal.get("latest_runs") if isinstance(goal.get("latest_runs"), list) else []
+    signal_runs: list[dict[str, Any]] = []
+    for run in latest_runs:
+        if not isinstance(run, dict):
+            continue
+        classification = str(run.get("classification") or "")
+        if not classification:
+            continue
+        if classification in STATUS_NEUTRAL_CLASSIFICATIONS:
+            continue
+        if classification in DREAMING_ADVISORY_CLASSIFICATIONS:
+            continue
+        signal_runs.append(run)
+        if len(signal_runs) >= limit:
+            break
+    return signal_runs
+
+
+def _proposal_type(runs: list[dict[str, Any]]) -> str:
+    combined = " ".join(
+        public_safe_compact_text(
+            " ".join(
+                str(run.get(field) or "")
+                for field in (
+                    "classification",
+                    "recommended_action",
+                    "health_check",
+                    "delivery_outcome",
+                )
+            ),
+            limit=500,
+        )
+        for run in runs
+    ).lower()
+    if any(token in combined for token in ("refactor", "duplicate", "bloat", "large", "monolith", "drift")):
+        return "refactor_warning"
+    if any(token in combined for token in ("lesson", "memory", "playbook", "skill", "docs", "documentation")):
+        return "memory_consolidation"
+    if any(token in combined for token in ("archive", "obsolete", "stale")):
+        return "archive_suggestion"
+    return "exploration"
+
+
+def _classification_for_proposal_type(proposal_type: str) -> str:
+    return {
+        "refactor_warning": "dreaming_refactor_warning",
+        "memory_consolidation": "dreaming_memory_consolidation",
+        "archive_suggestion": "dreaming_archive_suggestion",
+    }.get(proposal_type, "dreaming_exploration_proposal")
+
+
+def _operator_question(goal_id: str, proposal_type: str) -> str:
+    if proposal_type == "refactor_warning":
+        return (
+            f"Should {goal_id} open a reviewed delivery todo for the repeated "
+            "refactor or state-drift warning found in recent run history?"
+        )
+    if proposal_type == "memory_consolidation":
+        return (
+            f"Should {goal_id} consolidate these repeated lessons into a "
+            "project-local playbook, skill, or active-state update?"
+        )
+    if proposal_type == "archive_suggestion":
+        return (
+            f"Should {goal_id} review whether stale or obsolete work should be "
+            "archived before the next delivery slice?"
+        )
+    return (
+        f"Should {goal_id} promote this exploration proposal into a concrete "
+        "delivery todo, defer it, or reject it?"
+    )
+
+
+def _proposal_summary(runs: list[dict[str, Any]], proposal_type: str) -> str:
+    classifications = Counter(str(run.get("classification") or "unknown") for run in runs)
+    top = ", ".join(f"{name} x{count}" for name, count in classifications.most_common(3))
+    if not top:
+        top = "no recent non-neutral run history"
+    if proposal_type == "refactor_warning":
+        return f"Recent run history suggests a possible refactor/state-drift warning: {top}."
+    if proposal_type == "memory_consolidation":
+        return f"Recent run history has repeated lessons worth consolidating: {top}."
+    if proposal_type == "archive_suggestion":
+        return f"Recent run history may contain stale work that needs archive review: {top}."
+    return f"Recent run history suggests an exploration option for operator review: {top}."
+
+
+def build_dreaming_dry_run_proposal(
+    history_payload: dict[str, Any],
+    *,
+    goal_id: str,
+    limit: int = 20,
+) -> dict[str, Any]:
+    """Build a local-only dreaming proposal preview from compact run history.
+
+    The returned payload is intentionally advisory: it does not append runtime
+    history, mutate active project truth, grant an agent command, or spend quota.
+    """
+
+    safe_limit = max(1, min(int(limit), 50))
+    goal = _goal_record(history_payload, goal_id)
+    if not goal:
+        return {
+            "ok": False,
+            "schema_version": DREAMING_DRY_RUN_SCHEMA_VERSION,
+            "goal_id": goal_id,
+            "dry_run": True,
+            "error": f"goal_id not found in history payload: {goal_id}",
+            "side_effects": {
+                "project_files_mutated": False,
+                "active_state_mutated": False,
+                "runtime_history_appended": False,
+                "quota_spent": False,
+            },
+        }
+
+    runs = _signal_runs(goal, safe_limit)
+    proposal_type = _proposal_type(runs)
+    classification = _classification_for_proposal_type(proposal_type)
+    evidence_window = f"last_{len(runs)}_non_neutral_runs" if runs else "no_recent_non_neutral_runs"
+    question = _operator_question(goal_id, proposal_type)
+    dreaming = {
+        "schema_version": DREAMING_PROPOSAL_SCHEMA_VERSION,
+        "lane": "exploration",
+        "evidence_window": evidence_window,
+        "proposal_type": proposal_type,
+        "confidence": "medium" if len(runs) >= 3 else "low",
+        "requires_project_controller": True,
+        "advisory": True,
+        "promoted_to_delivery": False,
+        "execution_allowed": False,
+        "delivery_spend_allowed": False,
+    }
+    preview = {
+        "goal_id": goal_id,
+        "classification": classification,
+        "recommended_action": (
+            "Review this advisory dreaming proposal; approve, defer, or reject "
+            "it before converting it into active project truth."
+        ),
+        "operator_question": question,
+        "agent_command": None,
+        "dreaming": dreaming,
+    }
+    return {
+        "ok": True,
+        "schema_version": DREAMING_DRY_RUN_SCHEMA_VERSION,
+        "goal_id": goal_id,
+        "dry_run": True,
+        "classification": classification,
+        "proposal_type": proposal_type,
+        "summary": _proposal_summary(runs, proposal_type),
+        "operator_question": question,
+        "recommended_action": preview["recommended_action"],
+        "run_record_preview": preview,
+        "recent_evidence": [_compact_run(run) for run in runs[:MAX_DREAMING_EVIDENCE_ITEMS]],
+        "side_effects": {
+            "project_files_mutated": False,
+            "active_state_mutated": False,
+            "runtime_history_appended": False,
+            "quota_spent": False,
+        },
+        "write_policy": {
+            "advisory": True,
+            "append_runtime_history": False,
+            "mutate_active_state": False,
+            "grant_agent_command": False,
+            "spend_quota": False,
+        },
+    }
+
+
+def render_dreaming_dry_run_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Dreaming Dry-Run Proposal",
+        "",
+        f"- Goal: `{payload.get('goal_id')}`",
+        f"- OK: `{payload.get('ok')}`",
+        f"- Dry run: `{payload.get('dry_run')}`",
+    ]
+    if payload.get("error"):
+        lines.append(f"- Error: {payload.get('error')}")
+        return "\n".join(lines) + "\n"
+
+    side_effects = payload.get("side_effects") if isinstance(payload.get("side_effects"), dict) else {}
+    lines.extend(
+        [
+            f"- Classification: `{payload.get('classification')}`",
+            f"- Proposal type: `{payload.get('proposal_type')}`",
+            f"- Summary: {payload.get('summary')}",
+            f"- Operator question: {payload.get('operator_question')}",
+            f"- Runtime history appended: `{side_effects.get('runtime_history_appended')}`",
+            f"- Active state mutated: `{side_effects.get('active_state_mutated')}`",
+            f"- Quota spent: `{side_effects.get('quota_spent')}`",
+            "",
+            "## Recent Evidence",
+            "",
+        ]
+    )
+    evidence = payload.get("recent_evidence") if isinstance(payload.get("recent_evidence"), list) else []
+    if not evidence:
+        lines.append("- No recent non-neutral run evidence.")
+    for item in evidence:
+        if not isinstance(item, dict):
+            continue
+        lines.append(
+            "- "
+            f"`{item.get('classification')}` "
+            f"{item.get('generated_at') or ''}: "
+            f"{item.get('recommended_action') or item.get('delivery_outcome') or ''}"
+        )
+    return "\n".join(lines) + "\n"


### PR DESCRIPTION
## Summary
- add a local-only `goal-harness dreaming dry-run` command that builds advisory proposal previews from compact run history
- keep the proposal explicitly non-executable: no runtime append, no active-state mutation, no agent command, no quota spend
- document the entry point and add a focused smoke for the no-write contract

## Validation
- `python3 -m py_compile goal_harness/dreaming.py goal_harness/cli_commands/dreaming.py goal_harness/cli_commands/__init__.py goal_harness/cli.py examples/dreaming-dry-run-proposal-smoke.py`
- `python3 examples/dreaming-dry-run-proposal-smoke.py`
- `python3 regression/autonomous-replan-vs-dreaming-contract.py`
- `goal-harness check --scan-path goal_harness/dreaming.py --scan-path goal_harness/cli_commands/dreaming.py --scan-path examples/dreaming-dry-run-proposal-smoke.py --scan-path docs/dreaming-exploration-lane.md` (passes with existing duplicate-index warning on goal-harness-meta)

## Boundary
- no credentials, local logs, raw trajectories, verifier output, or private paths included
- no local goal state or runtime history committed