### PR TITLE
Define server planning proposal contract

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -91,7 +91,9 @@ The server path should land in layers:
    todo proposals, evidence probes, and refactor warnings as advisory records.
    These queues must not execute protected work, read private material, or
    spend delivery quota without a later normal `quota should-run` decision and
-   goal-boundary approval.
+   goal-boundary approval. The compact contract is
+   `server_managed_planning_contract_v0`; see
+   [dreaming-exploration-lane.md](dreaming-exploration-lane.md).
 6. **Host adapters**: expose the same contracts through MCP, hooks, or a small
    local HTTP API for Codex-like hosts. Host adapters should route agents to
    current state and valid writes; they should not embed stale project policy or

--- a/docs/dreaming-exploration-lane.md
+++ b/docs/dreaming-exploration-lane.md
@@ -164,6 +164,39 @@ history, mutate active state, grant an `agent_command`, or spend quota. The
 preview is meant for operator/controller review before any proposal is promoted
 into ordinary delivery work.
 
+## Server-Managed Planning Semantics
+
+A future Goal Harness server may schedule dreaming/planning work, but the
+server-owned lane keeps the same authority boundary as the CLI dry run:
+
+```json
+{
+  "schema_version": "server_managed_planning_contract_v0",
+  "lane": "dreaming_planning",
+  "authority": "proposal_only_until_promoted",
+  "may_rank_candidate_todos": true,
+  "may_suggest_evidence_probes": true,
+  "may_execute_protected_actions": false,
+  "may_read_private_material": false,
+  "may_mutate_active_state": false,
+  "may_spend_delivery_quota": false,
+  "promotion_required": true,
+  "promotion_requirements": [
+    "operator_or_controller_approval",
+    "normal_quota_should_run_decision",
+    "goal_boundary_write_scope_approval",
+    "public_private_boundary_scan_for_public_artifacts"
+  ]
+}
+```
+
+The server may rank candidate todos, propose evidence probes, and emit refactor
+or memory-consolidation warnings. It may not execute a protected action, read
+private material, mutate active state, append delivery history, or spend
+delivery quota until the proposal is promoted through the normal operator,
+quota, and goal-boundary path. This keeps dreaming useful for long-horizon
+product taste while preventing it from becoming a second hidden project agent.
+
 Acceptance criterion: a project can receive a dreaming proposal without the
 project agent being interrupted, and the user can approve, reject, or defer it
 from Goal Harness.

--- a/examples/dreaming-dry-run-proposal-smoke.py
+++ b/examples/dreaming-dry-run-proposal-smoke.py
@@ -162,6 +162,23 @@ def main() -> int:
         assert preview["dreaming"]["advisory"] is True, preview
         assert preview["dreaming"]["execution_allowed"] is False, preview
         assert preview["dreaming"]["delivery_spend_allowed"] is False, preview
+        contract = payload["server_planning_contract"]
+        assert contract["schema_version"] == "server_managed_planning_contract_v0", contract
+        assert contract["authority"] == "proposal_only_until_promoted", contract
+        assert contract["may_rank_candidate_todos"] is True, contract
+        assert contract["may_suggest_evidence_probes"] is True, contract
+        assert contract["may_execute_protected_actions"] is False, contract
+        assert contract["may_read_private_material"] is False, contract
+        assert contract["may_mutate_active_state"] is False, contract
+        assert contract["may_spend_delivery_quota"] is False, contract
+        assert contract["promotion_required"] is True, contract
+        assert contract["promotion_requirements"] == [
+            "operator_or_controller_approval",
+            "normal_quota_should_run_decision",
+            "goal_boundary_write_scope_approval",
+            "public_private_boundary_scan_for_public_artifacts",
+        ], contract
+        assert preview["dreaming"]["server_planning_contract"] == contract, preview
         side_effects = payload["side_effects"]
         assert side_effects["runtime_history_appended"] is False, side_effects
         assert side_effects["active_state_mutated"] is False, side_effects

--- a/goal_harness/dreaming.py
+++ b/goal_harness/dreaming.py
@@ -12,6 +12,7 @@ from .status import (
 
 DREAMING_DRY_RUN_SCHEMA_VERSION = "dreaming_dry_run_proposal_v0"
 DREAMING_PROPOSAL_SCHEMA_VERSION = "dreaming_proposal_v0"
+SERVER_PLANNING_CONTRACT_SCHEMA_VERSION = "server_managed_planning_contract_v0"
 MAX_DREAMING_EVIDENCE_ITEMS = 5
 
 
@@ -128,6 +129,44 @@ def _proposal_summary(runs: list[dict[str, Any]], proposal_type: str) -> str:
     return f"Recent run history suggests an exploration option for operator review: {top}."
 
 
+def build_server_managed_planning_contract() -> dict[str, Any]:
+    """Return the default contract for server-managed planning proposals."""
+
+    return {
+        "schema_version": SERVER_PLANNING_CONTRACT_SCHEMA_VERSION,
+        "lane": "dreaming_planning",
+        "authority": "proposal_only_until_promoted",
+        "may_rank_candidate_todos": True,
+        "may_suggest_evidence_probes": True,
+        "may_emit_refactor_warnings": True,
+        "may_execute_protected_actions": False,
+        "may_read_private_material": False,
+        "may_mutate_active_state": False,
+        "may_append_delivery_history": False,
+        "may_spend_delivery_quota": False,
+        "promotion_required": True,
+        "promotion_requirements": [
+            "operator_or_controller_approval",
+            "normal_quota_should_run_decision",
+            "goal_boundary_write_scope_approval",
+            "public_private_boundary_scan_for_public_artifacts",
+        ],
+        "allowed_outputs": [
+            "ranked_candidate_todos",
+            "evidence_probe_suggestions",
+            "refactor_warnings",
+            "memory_consolidation_proposals",
+        ],
+        "forbidden_outputs": [
+            "agent_command",
+            "protected_action_execution",
+            "private_material_read",
+            "delivery_quota_spend",
+            "active_state_mutation_without_promotion",
+        ],
+    }
+
+
 def build_dreaming_dry_run_proposal(
     history_payload: dict[str, Any],
     *,
@@ -162,6 +201,7 @@ def build_dreaming_dry_run_proposal(
     classification = _classification_for_proposal_type(proposal_type)
     evidence_window = f"last_{len(runs)}_non_neutral_runs" if runs else "no_recent_non_neutral_runs"
     question = _operator_question(goal_id, proposal_type)
+    server_planning_contract = build_server_managed_planning_contract()
     dreaming = {
         "schema_version": DREAMING_PROPOSAL_SCHEMA_VERSION,
         "lane": "exploration",
@@ -173,6 +213,7 @@ def build_dreaming_dry_run_proposal(
         "promoted_to_delivery": False,
         "execution_allowed": False,
         "delivery_spend_allowed": False,
+        "server_planning_contract": server_planning_contract,
     }
     preview = {
         "goal_id": goal_id,
@@ -196,6 +237,7 @@ def build_dreaming_dry_run_proposal(
         "operator_question": question,
         "recommended_action": preview["recommended_action"],
         "run_record_preview": preview,
+        "server_planning_contract": server_planning_contract,
         "recent_evidence": [_compact_run(run) for run in runs[:MAX_DREAMING_EVIDENCE_ITEMS]],
         "side_effects": {
             "project_files_mutated": False,
@@ -226,6 +268,11 @@ def render_dreaming_dry_run_markdown(payload: dict[str, Any]) -> str:
         return "\n".join(lines) + "\n"
 
     side_effects = payload.get("side_effects") if isinstance(payload.get("side_effects"), dict) else {}
+    contract = (
+        payload.get("server_planning_contract")
+        if isinstance(payload.get("server_planning_contract"), dict)
+        else {}
+    )
     lines.extend(
         [
             f"- Classification: `{payload.get('classification')}`",
@@ -235,11 +282,19 @@ def render_dreaming_dry_run_markdown(payload: dict[str, Any]) -> str:
             f"- Runtime history appended: `{side_effects.get('runtime_history_appended')}`",
             f"- Active state mutated: `{side_effects.get('active_state_mutated')}`",
             f"- Quota spent: `{side_effects.get('quota_spent')}`",
-            "",
-            "## Recent Evidence",
-            "",
         ]
     )
+    if contract:
+        lines.extend(
+            [
+                f"- Planning authority: `{contract.get('authority')}`",
+                f"- May rank todos: `{contract.get('may_rank_candidate_todos')}`",
+                f"- May execute protected actions: `{contract.get('may_execute_protected_actions')}`",
+                f"- May read private material: `{contract.get('may_read_private_material')}`",
+                f"- May spend delivery quota: `{contract.get('may_spend_delivery_quota')}`",
+            ]
+        )
+    lines.extend(["", "## Recent Evidence", ""])
     evidence = payload.get("recent_evidence") if isinstance(payload.get("recent_evidence"), list) else []
     if not evidence:
         lines.append("- No recent non-neutral run evidence.")

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -5547,6 +5547,34 @@ def operator_gate_attention_fields(run: dict[str, Any] | None) -> dict[str, Any]
     return fields
 
 
+def compact_server_planning_contract(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    compact: dict[str, Any] = {}
+    for field in ("schema_version", "lane", "authority"):
+        text = public_safe_compact_text(value.get(field), limit=120)
+        if text:
+            compact[field] = text
+    for field in (
+        "may_rank_candidate_todos",
+        "may_suggest_evidence_probes",
+        "may_emit_refactor_warnings",
+        "may_execute_protected_actions",
+        "may_read_private_material",
+        "may_mutate_active_state",
+        "may_append_delivery_history",
+        "may_spend_delivery_quota",
+        "promotion_required",
+    ):
+        if isinstance(value.get(field), bool):
+            compact[field] = value[field]
+    for field in ("promotion_requirements", "allowed_outputs", "forbidden_outputs"):
+        items = public_safe_compact_list(value.get(field), limit=8)
+        if items:
+            compact[field] = items
+    return compact
+
+
 def compact_dreaming_proposal(run: dict[str, Any] | None) -> dict[str, Any] | None:
     if not isinstance(run, dict):
         return None
@@ -5566,6 +5594,9 @@ def compact_dreaming_proposal(run: dict[str, Any] | None) -> dict[str, Any] | No
         value = public_safe_compact_text(raw.get(key), limit=80)
         if value:
             proposal[key] = value
+    server_planning_contract = compact_server_planning_contract(raw.get("server_planning_contract"))
+    if server_planning_contract:
+        proposal["server_planning_contract"] = server_planning_contract
     if raw.get("requires_project_controller") is not None:
         proposal["requires_project_controller"] = bool(raw.get("requires_project_controller"))
     question = public_safe_compact_text(

--- a/regression/README.md
+++ b/regression/README.md
@@ -56,7 +56,11 @@ Runs the contract-only separation check for autonomous replan versus dreaming.
 It creates a compact `dreaming_exploration_proposal` fixture and verifies that
 status/quota surface it as an advisory user/controller gate with no
 `agent_command`, no autonomous replan obligation, no delivery permission, and
-no quota spend path.
+no quota spend path. It also verifies the compact
+`server_managed_planning_contract_v0` projection: planning may rank candidate
+todos and suggest evidence probes, but may not execute protected actions, read
+private material, mutate active state, append delivery history, or spend
+delivery quota before promotion.
 
 ```bash
 python3 regression/external-evidence-observation-real-codex.py

--- a/regression/autonomous-replan-vs-dreaming-contract.py
+++ b/regression/autonomous-replan-vs-dreaming-contract.py
@@ -108,6 +108,24 @@ def write_fixture(root: Path) -> tuple[Path, Path]:
             "proposal_type": "refactor_warning",
             "confidence": "medium",
             "requires_project_controller": True,
+            "server_planning_contract": {
+                "schema_version": "server_managed_planning_contract_v0",
+                "lane": "dreaming_planning",
+                "authority": "proposal_only_until_promoted",
+                "may_rank_candidate_todos": True,
+                "may_suggest_evidence_probes": True,
+                "may_execute_protected_actions": False,
+                "may_read_private_material": False,
+                "may_mutate_active_state": False,
+                "may_append_delivery_history": False,
+                "may_spend_delivery_quota": False,
+                "promotion_required": True,
+                "promotion_requirements": [
+                    "operator_or_controller_approval",
+                    "normal_quota_should_run_decision",
+                    "goal_boundary_write_scope_approval",
+                ],
+            },
         },
         "json_path": str(json_path),
         "markdown_path": str(markdown_path),
@@ -137,6 +155,17 @@ def main() -> int:
         assert proposal["execution_allowed"] is False, proposal
         assert proposal["delivery_spend_allowed"] is False, proposal
         assert proposal["proposal_type"] == "refactor_warning", proposal
+        planning_contract = proposal["server_planning_contract"]
+        assert planning_contract["schema_version"] == "server_managed_planning_contract_v0", proposal
+        assert planning_contract["authority"] == "proposal_only_until_promoted", proposal
+        assert planning_contract["may_rank_candidate_todos"] is True, proposal
+        assert planning_contract["may_suggest_evidence_probes"] is True, proposal
+        assert planning_contract["may_execute_protected_actions"] is False, proposal
+        assert planning_contract["may_read_private_material"] is False, proposal
+        assert planning_contract["may_mutate_active_state"] is False, proposal
+        assert planning_contract["may_append_delivery_history"] is False, proposal
+        assert planning_contract["may_spend_delivery_quota"] is False, proposal
+        assert planning_contract["promotion_required"] is True, proposal
 
         guard = run_cli("quota", "should-run", "--goal-id", GOAL_ID, registry_path=registry_path, runtime=runtime)
         assert guard["should_run"] is False, guard


### PR DESCRIPTION
## Summary
- add a compact `server_managed_planning_contract_v0` for dreaming/planning proposals
- surface that contract through dry-run payloads and compact status projection
- document server-managed planning semantics and extend the dreaming/replan regression coverage

## Validation
- `python3 -m py_compile goal_harness/dreaming.py goal_harness/status.py examples/dreaming-dry-run-proposal-smoke.py regression/autonomous-replan-vs-dreaming-contract.py`
- `python3 examples/dreaming-dry-run-proposal-smoke.py`
- `python3 regression/autonomous-replan-vs-dreaming-contract.py`
- `goal-harness check --scan-path docs/architecture.md --scan-path docs/dreaming-exploration-lane.md --scan-path examples/dreaming-dry-run-proposal-smoke.py --scan-path goal_harness/dreaming.py --scan-path goal_harness/status.py --scan-path regression/README.md --scan-path regression/autonomous-replan-vs-dreaming-contract.py` (passes with existing duplicate-index warning on goal-harness-meta)

## Boundary
- proposal-only: no agent command, no protected action execution, no private material read, no active-state mutation, no delivery quota spend before promotion
- no credentials, local runtime logs, raw trajectories, verifier output, or private paths included