### PR TITLE
Add dreaming lane badge projection

### DIFF
--- a/docs/dreaming-exploration-lane.md
+++ b/docs/dreaming-exploration-lane.md
@@ -140,6 +140,39 @@ Goal
 This keeps project-agent work clean while still giving the user a central place
 to review broader learning and refactor requests.
 
+`goal-harness status` should expose the proposal plus a compact lane badge:
+
+```json
+{
+  "dreaming_proposal": {
+    "schema_version": "dreaming_proposal_v0",
+    "classification": "dreaming_exploration_proposal",
+    "proposal_type": "refactor_warning",
+    "advisory": true,
+    "execution_allowed": false,
+    "delivery_spend_allowed": false
+  },
+  "dreaming_lane_badge": {
+    "schema_version": "dreaming_lane_badge_v0",
+    "lane": "dreaming",
+    "label": "Dreaming",
+    "status": "dreaming_exploration_proposal",
+    "proposal_type": "refactor_warning",
+    "advisory": true,
+    "interrupts_delivery": false,
+    "review_required": true,
+    "execution_allowed": false,
+    "delivery_spend_allowed": false,
+    "promoted_to_delivery": false
+  }
+}
+```
+
+The badge intentionally carries routing facts, not the full explanation. The
+full rationale stays in `dreaming_proposal` and the run artifact, while
+dashboards and heartbeat consumers can render a separate Dreaming lane without
+mistaking the advisory proposal for delivery work.
+
 ## First Implementation Slice
 
 The first useful slice is documentation and status schema, not an autonomous

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -686,6 +686,15 @@ Item fields:
   `agent_command` is present and public-safe, `project_asset.next_safe_command`
   may repeat that command so first-screen dashboards and handoff packets can
   show the next executable local step without scanning top-level queue fields.
+  Advisory dreaming outputs may include both `dreaming_proposal` and
+  `dreaming_lane_badge`. The proposal carries compact rationale and promotion
+  requirements; the badge carries only routing facts for UI/heartbeat
+  consumers: `lane=dreaming`, `advisory=true`,
+  `interrupts_delivery=false`, `review_required=true`,
+  `execution_allowed=false`, `delivery_spend_allowed=false`, and
+  `promoted_to_delivery=false`. Consumers should render the badge as a
+  separate Dreaming lane or secondary badge and must not treat it as delivery
+  authorization.
   Markdown renderers should
   include the first unfinished user and agent todo here when available, so
   hot-path readers do not need to scan the detailed todo sections. The richer
@@ -1890,6 +1899,10 @@ A first useful UI can be built from the export alone:
 - User lane: items with `waiting_on=user_or_controller` or `controller`.
 - Codex lane: items with `waiting_on=codex`.
 - Watch lane: items with `waiting_on=external_evidence`.
+- Dreaming lane/badge: items with
+  `project_asset.dreaming_lane_badge.schema_version=dreaming_lane_badge_v0`.
+  These items are advisory review surfaces; delivery lanes continue to follow
+  quota and current owner/gate routing.
 - Health panel: contract `errors`, `warnings`, and `checks`.
 - Run detail panel: selected goal from the attention queue, compact
   classifications, authority coverage, controller readiness, health checks,

--- a/goal_harness/quota.py
+++ b/goal_harness/quota.py
@@ -3429,6 +3429,15 @@ def build_quota_should_run(status_payload: dict[str, Any], *, goal_id: str) -> d
         )
         if dreaming_proposal:
             payload["dreaming_proposal"] = dreaming_proposal
+        dreaming_lane_badge = (
+            item.get("dreaming_lane_badge")
+            if isinstance(item.get("dreaming_lane_badge"), dict)
+            else project_asset.get("dreaming_lane_badge")
+            if isinstance(project_asset.get("dreaming_lane_badge"), dict)
+            else None
+        )
+        if dreaming_lane_badge:
+            payload["dreaming_lane_badge"] = dreaming_lane_badge
         interface_budget_cadence = (
             project_asset.get("interface_budget_cadence")
             if isinstance(project_asset.get("interface_budget_cadence"), dict)

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -5183,8 +5183,12 @@ def attention_item(
     if todo_state_file:
         item["todo_state_file"] = todo_state_file
     if dreaming_proposal:
+        dreaming_lane_badge = compact_dreaming_lane_badge(dreaming_proposal)
         item["dreaming_proposal"] = dreaming_proposal
         item["project_asset"]["dreaming_proposal"] = dreaming_proposal
+        if dreaming_lane_badge:
+            item["dreaming_lane_badge"] = dreaming_lane_badge
+            item["project_asset"]["dreaming_lane_badge"] = dreaming_lane_badge
     return item
 
 
@@ -5606,6 +5610,43 @@ def compact_dreaming_proposal(run: dict[str, Any] | None) -> dict[str, Any] | No
     if question:
         proposal["operator_question"] = question
     return proposal
+
+
+def compact_dreaming_lane_badge(proposal: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(proposal, dict):
+        return None
+    classification = public_safe_compact_text(proposal.get("classification"), limit=80)
+    badge: dict[str, Any] = {
+        "schema_version": "dreaming_lane_badge_v0",
+        "lane": "dreaming",
+        "label": "Dreaming",
+        "advisory": bool(proposal.get("advisory", True)),
+        "interrupts_delivery": False,
+        "review_required": True,
+        "execution_allowed": False,
+        "delivery_spend_allowed": False,
+        "promoted_to_delivery": False,
+    }
+    if classification:
+        badge["status"] = classification
+    for field in ("proposal_type", "confidence", "evidence_window"):
+        value = public_safe_compact_text(proposal.get(field), limit=80)
+        if value:
+            badge[field] = value
+    server_contract = proposal.get("server_planning_contract")
+    if isinstance(server_contract, dict):
+        lane = public_safe_compact_text(server_contract.get("lane"), limit=80)
+        authority = public_safe_compact_text(server_contract.get("authority"), limit=120)
+        if lane or authority:
+            badge["server_planning"] = {
+                key: value
+                for key, value in {
+                    "lane": lane,
+                    "authority": authority,
+                }.items()
+                if value
+            }
+    return badge
 
 
 def dreaming_attention_fields(run: dict[str, Any] | None) -> dict[str, Any]:
@@ -7152,6 +7193,20 @@ def render_status_markdown(payload: dict[str, Any]) -> str:
             asset_next_action = _markdown_scalar(project_asset.get("next_action") or "")
             if asset_next_action:
                 lines.append(f"    - asset_next_action: {asset_next_action}")
+            dreaming_lane_badge = (
+                project_asset.get("dreaming_lane_badge")
+                if isinstance(project_asset.get("dreaming_lane_badge"), dict)
+                else {}
+            )
+            if dreaming_lane_badge:
+                lines.append(
+                    "    - dreaming_lane_badge: "
+                    f"lane={_markdown_scalar(dreaming_lane_badge.get('lane') or '')} "
+                    f"status={_markdown_scalar(dreaming_lane_badge.get('status') or '')} "
+                    f"advisory={dreaming_lane_badge.get('advisory')} "
+                    f"interrupts_delivery={dreaming_lane_badge.get('interrupts_delivery')} "
+                    f"execution_allowed={dreaming_lane_badge.get('execution_allowed')}"
+                )
             asset_execution_profile = (
                 project_asset.get("execution_profile")
                 if isinstance(project_asset.get("execution_profile"), dict)

--- a/regression/autonomous-replan-vs-dreaming-contract.py
+++ b/regression/autonomous-replan-vs-dreaming-contract.py
@@ -166,6 +166,20 @@ def main() -> int:
         assert planning_contract["may_append_delivery_history"] is False, proposal
         assert planning_contract["may_spend_delivery_quota"] is False, proposal
         assert planning_contract["promotion_required"] is True, proposal
+        lane_badge = item["project_asset"]["dreaming_lane_badge"]
+        assert item["dreaming_lane_badge"] == lane_badge, item
+        assert lane_badge["schema_version"] == "dreaming_lane_badge_v0", lane_badge
+        assert lane_badge["lane"] == "dreaming", lane_badge
+        assert lane_badge["label"] == "Dreaming", lane_badge
+        assert lane_badge["status"] == "dreaming_exploration_proposal", lane_badge
+        assert lane_badge["proposal_type"] == "refactor_warning", lane_badge
+        assert lane_badge["advisory"] is True, lane_badge
+        assert lane_badge["review_required"] is True, lane_badge
+        assert lane_badge["interrupts_delivery"] is False, lane_badge
+        assert lane_badge["execution_allowed"] is False, lane_badge
+        assert lane_badge["delivery_spend_allowed"] is False, lane_badge
+        assert lane_badge["promoted_to_delivery"] is False, lane_badge
+        assert lane_badge["server_planning"]["lane"] == "dreaming_planning", lane_badge
 
         guard = run_cli("quota", "should-run", "--goal-id", GOAL_ID, registry_path=registry_path, runtime=runtime)
         assert guard["should_run"] is False, guard
@@ -177,6 +191,7 @@ def main() -> int:
         assert "agent_command" not in guard, guard
         assert "autonomous_replan_obligation" not in guard, guard
         assert guard["dreaming_proposal"] == proposal, guard
+        assert guard["dreaming_lane_badge"] == lane_badge, guard
 
         interaction = guard["interaction_contract"]
         assert interaction["mode"] == "user_gate", interaction


### PR DESCRIPTION
## Summary
- add a compact dreaming_lane_badge projection beside dreaming_proposal in status attention items
- expose the same badge through quota should-run guard payloads
- document the status/dashboard contract and extend the dreaming-vs-replan regression

## Validation
- python3 -m py_compile goal_harness/status.py goal_harness/quota.py regression/autonomous-replan-vs-dreaming-contract.py
- python3 regression/autonomous-replan-vs-dreaming-contract.py
- git diff --check
- goal-harness check --scan-path goal_harness --scan-path docs --scan-path regression (passes with existing duplicate-index warning)

## Boundary
- staged explicit paths only
- no raw logs, local state, credentials, private links, or benchmark trajectories included