### PR TITLE
Add benchmark run ledger drift check

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger-v0.md
@@ -58,6 +58,24 @@ PYTHONPATH=<goal-harness-repo> python3 -m goal_harness.cli \
   --execute
 ```
 
+Closeout agents should also run the compact drift check before deciding a case
+is fully recorded:
+
+```bash
+PYTHONPATH=<goal-harness-repo> python3 -m goal_harness.cli \
+  benchmark run-ledger-check \
+  --goal-id goal-harness-meta \
+  --history-limit 500
+```
+
+The check compares recent compact `benchmark_run_v0` run-history events against
+`benchmark-run-ledger.json`. It reports `benchmark_run_ledger_drift_v0` with
+missing compact run rows and `run-ledger-upsert` catch-up command templates.
+It is read-only and compact-only: it does not open raw logs, task text,
+trajectories, Docker, model APIs, uploads, or verifier output. This is the
+default posthoc guard for missed closeout writeback across Terminal-Bench,
+SkillsBench, and future benchmark adapters.
+
 If a case never reaches `benchmark_run_v0` but the post-launch compact poller
 has produced a terminal compact failure marker, upsert that marker directly
 instead of faking an official score:

--- a/examples/benchmark-run-ledger-smoke.py
+++ b/examples/benchmark-run-ledger-smoke.py
@@ -1128,6 +1128,148 @@ def test_cli_compact_run_json_updates_run_ledger() -> None:
         assert (root / "visible-ledger.md").exists(), "CLI should render markdown"
 
 
+def test_cli_run_ledger_check_reports_and_clears_history_drift() -> None:
+    with tempfile.TemporaryDirectory(prefix="benchmark-run-ledger-drift-cli-") as tmp:
+        root = Path(tmp)
+        registry_path, runtime = write_registry(root)
+        ledger_path = root / "visible-ledger.json"
+        compact_path = root / "compact-run.json"
+        write_json(
+            compact_path,
+            {
+                "schema_version": "benchmark_run_v0",
+                "benchmark_id": "terminal-bench@2.0",
+                "job_name": "terminal_bench_2_0_drift_fixture_codex_goal_mode_baseline",
+                "mode": "codex_goal_mode_baseline",
+                "official_task_score": {
+                    "kind": "harbor_verifier_reward",
+                    "value": 0.0,
+                    "passed": False,
+                },
+                "score_failure_attribution": "none",
+                "trials": [
+                    {
+                        "task_id": "drift-fixture",
+                        "exception_type": "AgentTimeoutError",
+                    }
+                ],
+            },
+        )
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "goal_harness.cli",
+                "--registry",
+                str(registry_path),
+                "--runtime-root",
+                str(runtime),
+                "--format",
+                "json",
+                "history",
+                "append-benchmark-run",
+                "--goal-id",
+                GOAL_ID,
+                "--benchmark-run-json",
+                str(compact_path),
+                "--execute",
+                "--no-global-sync",
+            ],
+            cwd=REPO_ROOT,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        check_result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "goal_harness.cli",
+                "--registry",
+                str(registry_path),
+                "--runtime-root",
+                str(runtime),
+                "--format",
+                "json",
+                "benchmark",
+                "run-ledger-check",
+                "--goal-id",
+                GOAL_ID,
+                "--run-ledger-path",
+                str(ledger_path),
+                "--history-limit",
+                "20",
+            ],
+            cwd=REPO_ROOT,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        check_payload = json.loads(check_result.stdout)
+        drift = check_payload["benchmark_run_ledger_drift"]
+        assert drift["schema_version"] == "benchmark_run_ledger_drift_v0", drift
+        assert drift["drift_detected"] is True, drift
+        assert drift["missing_ledger_run_count"] == 1, drift
+        assert drift["missing_runs"][0]["case_id"] == "drift-fixture", drift
+        assert drift["read_boundary"]["raw_logs_read"] is False, drift
+        assert drift["read_boundary"]["trajectory_read"] is False, drift
+
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "goal_harness.cli",
+                "--registry",
+                str(registry_path),
+                "--runtime-root",
+                str(runtime),
+                "--format",
+                "json",
+                "benchmark",
+                "run-ledger-upsert",
+                "--benchmark-run-json",
+                str(compact_path),
+                "--run-ledger-path",
+                str(ledger_path),
+                "--execute",
+            ],
+            cwd=REPO_ROOT,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        clean_result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "goal_harness.cli",
+                "--registry",
+                str(registry_path),
+                "--runtime-root",
+                str(runtime),
+                "--format",
+                "json",
+                "benchmark",
+                "run-ledger-check",
+                "--goal-id",
+                GOAL_ID,
+                "--run-ledger-path",
+                str(ledger_path),
+                "--history-limit",
+                "20",
+            ],
+            cwd=REPO_ROOT,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        clean_payload = json.loads(clean_result.stdout)
+        clean_drift = clean_payload["benchmark_run_ledger_drift"]
+        assert clean_drift["drift_detected"] is False, clean_drift
+        assert clean_drift["missing_ledger_run_count"] == 0, clean_drift
+        assert clean_drift["matched_history_run_count"] == 1, clean_drift
+
+
 def test_cli_post_launch_json_updates_run_ledger() -> None:
     with tempfile.TemporaryDirectory(prefix="benchmark-run-ledger-post-launch-cli-") as tmp:
         root = Path(tmp)
@@ -1202,5 +1344,6 @@ if __name__ == "__main__":
     test_ledger_ingests_post_launch_ended_active_marker()
     test_cli_harbor_ingest_updates_run_ledger()
     test_cli_compact_run_json_updates_run_ledger()
+    test_cli_run_ledger_check_reports_and_clears_history_drift()
     test_cli_post_launch_json_updates_run_ledger()
     print("benchmark-run-ledger-smoke: ok")

--- a/goal_harness/benchmark_ledger.py
+++ b/goal_harness/benchmark_ledger.py
@@ -1908,3 +1908,148 @@ def update_benchmark_run_ledger(
             entry["case_id"]
         ]["latest_decision"],
     }
+
+
+def _ledger_entry_signature(entry: dict[str, Any]) -> tuple[str, ...]:
+    return (
+        _compact_text(entry.get("benchmark_id"), limit=120),
+        _compact_text(entry.get("case_id"), limit=160),
+        _compact_text(entry.get("arm_id"), limit=120),
+        _compact_text(entry.get("mode"), limit=120),
+        _compact_text(entry.get("job_name"), limit=160),
+        _compact_text(entry.get("score_status"), limit=80),
+        _compact_text(entry.get("official_score"), limit=80),
+        _compact_text(entry.get("failure_class"), limit=120),
+    )
+
+
+def _iter_ledger_runs(ledger: dict[str, Any]) -> list[dict[str, Any]]:
+    runs: list[dict[str, Any]] = []
+    benchmarks = ledger.get("benchmarks") if isinstance(ledger.get("benchmarks"), dict) else {}
+    for benchmark in benchmarks.values():
+        if not isinstance(benchmark, dict):
+            continue
+        cases = benchmark.get("cases") if isinstance(benchmark.get("cases"), dict) else {}
+        for case in cases.values():
+            if not isinstance(case, dict):
+                continue
+            for run in case.get("runs") or []:
+                if isinstance(run, dict):
+                    runs.append(run)
+    return runs
+
+
+def _history_benchmark_run(record: dict[str, Any]) -> dict[str, Any] | None:
+    if record.get("schema_version") == "benchmark_run_v0":
+        return record
+    nested = record.get("benchmark_run")
+    if isinstance(nested, dict) and nested.get("schema_version") == "benchmark_run_v0":
+        return nested
+    return None
+
+
+def check_benchmark_run_ledger_drift(
+    *,
+    history_records: list[dict[str, Any]],
+    ledger: dict[str, Any],
+    ledger_path: str | Path | None = None,
+    limit: int = 20,
+    cwd: Path | None = None,
+) -> dict[str, Any]:
+    """Compare compact benchmark_run_v0 history events with the public run ledger."""
+
+    normalized_ledger = _normalize_benchmark_run_ledger(dict(ledger))
+    ledger_runs = _iter_ledger_runs(normalized_ledger)
+    ledger_run_ids = {
+        _compact_text(run.get("run_id"), limit=80)
+        for run in ledger_runs
+        if _compact_text(run.get("run_id"), limit=80)
+    }
+    ledger_signatures = {_ledger_entry_signature(run) for run in ledger_runs}
+
+    checked_history_run_count = 0
+    terminal_history_run_count = 0
+    matched_count = 0
+    non_terminal_skipped_count = 0
+    missing: list[dict[str, Any]] = []
+    for record in history_records:
+        if not isinstance(record, dict):
+            continue
+        benchmark_run = _history_benchmark_run(record)
+        if not benchmark_run:
+            continue
+        checked_history_run_count += 1
+        entry = build_benchmark_run_ledger_entry(
+            benchmark_run,
+            compact_artifact_ref=record.get("json_path")
+            if isinstance(record.get("json_path"), str)
+            else None,
+            recorded_at=record.get("generated_at")
+            if isinstance(record.get("generated_at"), str)
+            else None,
+            cwd=cwd,
+        )
+        if not _entry_is_public_ledger_closeout(entry):
+            non_terminal_skipped_count += 1
+            continue
+        terminal_history_run_count += 1
+        run_id = _compact_text(entry.get("run_id"), limit=80)
+        signature = _ledger_entry_signature(entry)
+        if run_id in ledger_run_ids or signature in ledger_signatures:
+            matched_count += 1
+            continue
+        catch_up = "goal-harness benchmark run-ledger-upsert --benchmark-run-json <compact-benchmark-run-v0.json>"
+        if ledger_path:
+            ledger_ref_path = Path(ledger_path)
+            ledger_ref = (
+                "<benchmark-run-ledger.json>"
+                if ledger_ref_path.is_absolute()
+                else ledger_ref_path.as_posix()
+            )
+            catch_up += f" --run-ledger-path {ledger_ref}"
+        if entry.get("run_group_id"):
+            catch_up += f" --run-group-id {entry['run_group_id']}"
+        if entry.get("arm_id"):
+            catch_up += f" --arm-id {entry['arm_id']}"
+        catch_up += " --execute"
+        missing.append(
+            {
+                "run_id": run_id,
+                "generated_at": _compact_text(record.get("generated_at"), limit=80),
+                "benchmark_id": entry.get("benchmark_id"),
+                "case_id": entry.get("case_id"),
+                "arm_id": entry.get("arm_id"),
+                "mode": entry.get("mode"),
+                "job_name": entry.get("job_name"),
+                "score_status": entry.get("score_status"),
+                "official_score": entry.get("official_score"),
+                "failure_class": entry.get("failure_class"),
+                "catch_up_command_template": catch_up,
+            }
+        )
+
+    limited_missing = missing[: max(0, limit)]
+    return {
+        "schema_version": "benchmark_run_ledger_drift_v0",
+        "ok": True,
+        "drift_detected": bool(missing),
+        "ledger_schema_version": normalized_ledger.get("schema_version"),
+        "ledger_run_count": len(ledger_runs),
+        "checked_history_run_count": checked_history_run_count,
+        "terminal_history_run_count": terminal_history_run_count,
+        "matched_history_run_count": matched_count,
+        "non_terminal_skipped_count": non_terminal_skipped_count,
+        "missing_ledger_run_count": len(missing),
+        "missing_runs": limited_missing,
+        "truncated": len(missing) > len(limited_missing),
+        "limit": limit,
+        "read_boundary": {
+            "compact_only": True,
+            "raw_logs_read": False,
+            "task_text_read": False,
+            "trajectory_read": False,
+            "docker_invoked": False,
+            "model_api_invoked": False,
+            "upload_invoked": False,
+        },
+    }

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -107,6 +107,8 @@ from .benchmark_adapters.terminal_bench import (
 )
 from .benchmark_ledger import (
     BENCHMARK_RUN_LEDGER_DEFAULT_PATH,
+    check_benchmark_run_ledger_drift,
+    load_benchmark_run_ledger,
     update_benchmark_run_ledger,
 )
 from .benchmark_core import (
@@ -333,6 +335,52 @@ def render_benchmark_run_ledger_upsert_markdown(payload: dict[str, object]) -> s
         f"- raw logs read: `{read_boundary.get('raw_logs_read')}`",
         f"- task text read: `{read_boundary.get('task_text_read')}`",
     ]
+    if payload.get("error"):
+        lines.append(f"- error: {payload.get('error')}")
+    return "\n".join(lines) + "\n"
+
+
+def render_benchmark_run_ledger_check_markdown(payload: dict[str, object]) -> str:
+    drift = (
+        payload.get("benchmark_run_ledger_drift")
+        if isinstance(payload.get("benchmark_run_ledger_drift"), dict)
+        else {}
+    )
+    lines = [
+        "# Benchmark Run Ledger Drift Check",
+        "",
+        f"- ok: `{payload.get('ok')}`",
+        f"- drift_detected: `{drift.get('drift_detected')}`",
+        f"- checked_history_run_count: `{drift.get('checked_history_run_count')}`",
+        f"- terminal_history_run_count: `{drift.get('terminal_history_run_count')}`",
+        f"- matched_history_run_count: `{drift.get('matched_history_run_count')}`",
+        f"- missing_ledger_run_count: `{drift.get('missing_ledger_run_count')}`",
+        f"- non_terminal_skipped_count: `{drift.get('non_terminal_skipped_count')}`",
+        f"- ledger_run_count: `{drift.get('ledger_run_count')}`",
+    ]
+    missing_runs = drift.get("missing_runs") if isinstance(drift.get("missing_runs"), list) else []
+    if missing_runs:
+        lines.extend(
+            [
+                "",
+                "## Missing Compact Runs",
+                "",
+                "| Benchmark | Case | Arm | Score | Failure | Catch-up |",
+                "| --- | --- | --- | --- | --- | --- |",
+            ]
+        )
+        for run in missing_runs:
+            if not isinstance(run, dict):
+                continue
+            lines.append(
+                "| "
+                f"`{run.get('benchmark_id')}` | "
+                f"`{run.get('case_id')}` | "
+                f"`{run.get('arm_id')}` | "
+                f"`{run.get('official_score')}` | "
+                f"`{run.get('failure_class')}` | "
+                f"`{run.get('catch_up_command_template')}` |"
+            )
     if payload.get("error"):
         lines.append(f"- error: {payload.get('error')}")
     return "\n".join(lines) + "\n"
@@ -2571,6 +2619,35 @@ def main(argv: list[str] | None = None) -> int:
         "--execute",
         action="store_true",
         help="Write the benchmark run ledger update.",
+    )
+    benchmark_run_ledger_check_parser = benchmark_sub.add_parser(
+        "run-ledger-check",
+        help=(
+            "Compare compact benchmark_run_v0 run history with the public "
+            "benchmark_run_ledger_v0. This reads compact history only."
+        ),
+    )
+    benchmark_run_ledger_check_parser.add_argument(
+        "--goal-id",
+        required=True,
+        help="Goal id whose compact benchmark run history should be checked.",
+    )
+    benchmark_run_ledger_check_parser.add_argument(
+        "--run-ledger-path",
+        default=str(BENCHMARK_RUN_LEDGER_DEFAULT_PATH),
+        help="Path to benchmark_run_ledger_v0 JSON.",
+    )
+    benchmark_run_ledger_check_parser.add_argument(
+        "--history-limit",
+        type=int,
+        default=500,
+        help="Maximum recent compact run-history rows to compare.",
+    )
+    benchmark_run_ledger_check_parser.add_argument(
+        "--limit",
+        type=int,
+        default=20,
+        help="Maximum missing rows to include in output.",
     )
 
     agentissue_runner_flow_parser = benchmark_sub.add_parser(
@@ -7146,6 +7223,62 @@ def main(argv: list[str] | None = None) -> int:
                 lambda value: render_codex_app_parity_posthoc_check_markdown(
                     value["codex_app_parity_posthoc_check"]
                 ),
+            )
+            return 0 if payload.get("ok") else 1
+        if args.benchmark_command == "run-ledger-check":
+            try:
+                history_payload = collect_history(
+                    registry_path=registry_path,
+                    runtime_root=resolve_runtime_root(
+                        load_registry(registry_path),
+                        args.runtime_root,
+                    ),
+                    goal_id=args.goal_id,
+                    limit=max(0, int(args.history_limit)),
+                )
+                ledger = load_benchmark_run_ledger(args.run_ledger_path)
+                drift = check_benchmark_run_ledger_drift(
+                    history_records=[
+                        run
+                        for run in history_payload.get("runs", [])
+                        if isinstance(run, dict)
+                    ],
+                    ledger=ledger,
+                    ledger_path=args.run_ledger_path,
+                    limit=max(0, int(args.limit)),
+                    cwd=Path.cwd(),
+                )
+                payload = {
+                    "ok": True,
+                    "goal_id": args.goal_id,
+                    "history_limit": args.history_limit,
+                    "benchmark_run_ledger_drift": drift,
+                    "read_boundary": drift.get("read_boundary"),
+                }
+            except Exception as exc:
+                payload = {
+                    "ok": False,
+                    "goal_id": args.goal_id,
+                    "benchmark_run_ledger_drift": {
+                        "schema_version": "benchmark_run_ledger_drift_v0",
+                        "ok": False,
+                        "drift_detected": False,
+                    },
+                    "read_boundary": {
+                        "compact_only": True,
+                        "raw_logs_read": False,
+                        "task_text_read": False,
+                        "trajectory_read": False,
+                        "docker_invoked": False,
+                        "model_api_invoked": False,
+                        "upload_invoked": False,
+                    },
+                    "error": str(exc),
+                }
+            print_payload(
+                payload,
+                args.format,
+                render_benchmark_run_ledger_check_markdown,
             )
             return 0 if payload.get("ok") else 1
         if args.benchmark_command == "run-ledger-upsert":


### PR DESCRIPTION
## Summary
- add a compact run-history vs benchmark-run-ledger drift checker
- expose it as `goal-harness benchmark run-ledger-check`
- document the posthoc closeout guard and cover missing/cleared drift in the existing ledger smoke

## Validation
- `python3 -m py_compile goal_harness/benchmark_ledger.py goal_harness/cli.py examples/benchmark-run-ledger-smoke.py`
- `python3 examples/benchmark-run-ledger-smoke.py`
- `goal-harness --format json benchmark run-ledger-check --goal-id goal-harness-meta --history-limit 80 --limit 5`
- `goal-harness check --scan-path goal_harness --scan-path docs --scan-path examples` (passes with existing duplicate-index warning)
- `git diff --check --cached`

## Boundary
- compact run history and public ledger only
- no raw logs, task text, trajectories, verifier output, Docker, model API calls, uploads, credentials, or local private benchmark artifacts included