### PR TITLE
Fix visible todo text updates

### DIFF
--- a/examples/todo-cli-smoke.py
+++ b/examples/todo-cli-smoke.py
@@ -20,6 +20,7 @@ from goal_harness.status import parse_active_state_todos  # noqa: E402
 GOAL_ID = "todo-cli-goal"
 USER_TODO = "Review the owner decision checklist before approving delivery."
 AGENT_TODO = "Summarize the read-only evidence after the user checklist is done."
+UPDATED_AGENT_TODO = "Publish the compact evidence summary after validation passes."
 
 
 def write_fixture(root: Path) -> tuple[Path, Path]:
@@ -154,6 +155,36 @@ def main() -> int:
         assert fields["agent_todos"]["items"][0]["action_kind"] == "run_eval", fields
         assert fields["user_todos"]["source_section"] == "User Todo / Owner Review Reading Queue", fields
         assert fields["agent_todos"]["source_section"] == "Agent Todo", fields
+
+        update_payload = run_cli(
+            registry_path,
+            "todo",
+            "update",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            metadata_payload["todo_id"],
+            "--text",
+            UPDATED_AGENT_TODO,
+            "--status",
+            "done",
+            "--evidence",
+            "Validated compact evidence summary.",
+        )
+        assert update_payload["changed"] is True, update_payload
+        assert update_payload["text_changed"] is True, update_payload
+        assert update_payload["status_changed"] is True, update_payload
+        assert update_payload["todo"] == UPDATED_AGENT_TODO, update_payload
+        after_update = state_file.read_text(encoding="utf-8")
+        assert f"- [x] {UPDATED_AGENT_TODO}" in after_update, after_update
+        assert "Summarize the read-only evidence after the user" not in after_update, after_update
+        assert "status=done" in after_update, after_update
+        assert "Validated%20compact%20evidence%20summary." in after_update, after_update
+        updated_fields = parse_active_state_todos(after_update)
+        updated_agent_item = updated_fields["agent_todos"]["items"][0]
+        assert updated_agent_item["text"] == UPDATED_AGENT_TODO, updated_agent_item
+        assert updated_agent_item["status"] == "done", updated_agent_item
+        assert updated_agent_item["done"] is True, updated_agent_item
 
     print("todo-cli-smoke ok")
     return 0

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -8604,6 +8604,7 @@ def main(argv: list[str] | None = None) -> int:
                 if not args.todo_id:
                     raise ValueError("todo update requires --todo-id")
                 if not any([
+                    args.text,
                     args.status,
                     args.note,
                     args.evidence,
@@ -8612,11 +8613,12 @@ def main(argv: list[str] | None = None) -> int:
                     args.action_kind,
                     args.required_write_scopes,
                 ]):
-                    raise ValueError("todo update requires at least one of --status, --note, --evidence, --reason, --task-class, --action-kind, or --required-write-scope")
+                    raise ValueError("todo update requires at least one of --text, --status, --note, --evidence, --reason, --task-class, --action-kind, or --required-write-scope")
                 payload = update_goal_todo(
                     registry_path=registry_path,
                     goal_id=args.goal_id,
                     todo_id=args.todo_id,
+                    text=args.text,
                     status=args.status,
                     role=args.role,
                     note=args.note,

--- a/goal_harness/todos.py
+++ b/goal_harness/todos.py
@@ -362,6 +362,27 @@ def set_todo_marker(lines: list[str], block: dict[str, Any], status: str) -> boo
     return True
 
 
+def set_todo_text(lines: list[str], block: dict[str, Any], text: str, *, status: str) -> bool:
+    normalized = normalize_new_todo(text)
+    if normalize_todo_text(str(block.get("text") or "")) == normalized:
+        return False
+
+    start = int(block["start"])
+    end = int(block["end"])
+    marker = todo_marker_for_status(status)
+    replacement = f"- [{marker}] {normalized}"
+    remove_until = start + 1
+    while remove_until < end and lines[remove_until].startswith((" ", "\t")):
+        if parse_todo_metadata_line(lines[remove_until]) is not None:
+            break
+        remove_until += 1
+    removed = remove_until - start
+    lines[start:remove_until] = [replacement]
+    block["text"] = normalized
+    block["end"] = end - (removed - 1)
+    return True
+
+
 def find_todo_block(
     lines: list[str],
     *,
@@ -549,6 +570,7 @@ def apply_todo_update_to_lines(
     lines: list[str],
     *,
     todo_id: str,
+    text: str | None = None,
     status: str | None = None,
     role: str | None = None,
     note: str | None = None,
@@ -575,6 +597,9 @@ def apply_todo_update_to_lines(
     status_changed = False
     if normalized_status:
         status_changed = set_todo_marker(lines, block, normalized_status)
+    text_changed = False
+    if text is not None:
+        text_changed = set_todo_text(lines, block, text, status=target_status)
 
     updates: dict[str, Any] = {
         "todo_id": normalized_todo_id,
@@ -598,7 +623,7 @@ def apply_todo_update_to_lines(
         updates["required_write_scopes"] = required_write_scopes
     metadata_line = metadata_line_for_block(block, updates)
     semantic_metadata_changed = todo_metadata_would_change(lines, block, metadata_line)
-    if status_changed or semantic_metadata_changed:
+    if status_changed or text_changed or semantic_metadata_changed:
         updates["updated_at"] = updated_at
         metadata_line = metadata_line_for_block(block, updates)
     metadata_updated = upsert_todo_metadata(lines, block, metadata_line)
@@ -609,8 +634,9 @@ def apply_todo_update_to_lines(
         "todo_id": normalized_todo_id,
         "status": target_status,
         "status_changed": status_changed,
+        "text_changed": text_changed,
         "metadata_updated": metadata_updated,
-        "changed": status_changed or metadata_updated,
+        "changed": status_changed or text_changed or metadata_updated,
     }
 
 
@@ -619,6 +645,7 @@ def update_goal_todo(
     registry_path: Path,
     goal_id: str,
     todo_id: str,
+    text: str | None = None,
     status: str | None = None,
     role: str | None = None,
     note: str | None = None,
@@ -644,6 +671,7 @@ def update_goal_todo(
         update_result = apply_todo_update_to_lines(
             lines,
             todo_id=todo_id,
+            text=text,
             status=status,
             role=role,
             note=note,
@@ -973,5 +1001,6 @@ def render_todo_markdown(payload: dict[str, Any]) -> str:
     if payload.get("error"):
         lines.append(f"- error: {payload.get('error')}")
     elif "todo" in payload:
-        lines.extend(["", "## Todo", "", f"- [ ] {payload.get('todo')}"])
+        marker = todo_marker_for_status(payload.get("status") or TODO_STATUS_OPEN)
+        lines.extend(["", "## Todo", "", f"- [{marker}] {payload.get('todo')}"])
     return "\n".join(lines)


### PR DESCRIPTION
## Summary
- make `goal-harness todo update --text` replace the visible checkbox text, including wrapped old text
- return `text_changed` in todo lifecycle payloads and render markdown output with the actual todo status marker
- extend the existing todo CLI smoke to prove status projection sees the replacement text

## Validation
- `python3 -m py_compile goal_harness/todos.py goal_harness/cli.py examples/todo-cli-smoke.py`
- `python3 examples/todo-cli-smoke.py && python3 examples/todo-lifecycle-cli-smoke.py`
- `git diff --check --cached`
- `goal-harness check --scan-path goal_harness --scan-path examples` (passes with existing duplicate-index warning)

## Boundary
- Public runtime/API behavior plus durable smoke only
- No local active state, raw benchmark logs, trajectories, credentials, private material, or generated artifacts included