### PR TITLE
Fix state projection for technical gates

### DIFF
--- a/examples/state-projection-gap-smoke.py
+++ b/examples/state-projection-gap-smoke.py
@@ -90,6 +90,17 @@ def test_projection_gap_warning() -> dict:
         "- Run the trace reducer backfill.\n"
     )
     assert no_gap is None, no_gap
+
+    technical_gate_no_gap = state_projection_gap_warning(
+        "## Agent Todo\n\n"
+        "- [ ] Advance ALE split-control provider/task-data readiness.\n\n"
+        "## Next Action\n\n"
+        "- Agent: choose exactly one compact no-upload next gate among "
+        "baked-task-input scan, task-material readiness, or remote Docker "
+        "capacity proof. Keep credentials local; avoid submit and leaderboard "
+        "paths.\n"
+    )
+    assert technical_gate_no_gap is None, technical_gate_no_gap
     return gap
 
 

--- a/goal_harness/state_projection.py
+++ b/goal_harness/state_projection.py
@@ -34,9 +34,10 @@ NEXT_ACTION_EXECUTABLE_PATTERN = re.compile(
     r"拆分|补全|规划|待办)"
 )
 NEXT_ACTION_USER_WAIT_PATTERN = re.compile(
-    r"(?i)\b(?:wait(?:ing)? for|owner|user|operator|controller|approval|"
-    r"approve|decision|gate|private|credential|production|leaderboard|submit)\b|"
-    r"(?:等待|用户|人工|决策|审批|批准|确认|私有|凭证|生产|榜单|提交|owner)"
+    r"(?i)\b(?:wait(?:ing)? for|blocked by|gated by|owner|user|operator|"
+    r"controller|approval|approve|decision)\b|"
+    r"\b(?:owner|user|operator|controller)\s+(?:gate|todo|action|decision|approval)\b|"
+    r"(?:等待|用户|人工|决策|审批|批准|确认|owner)"
 )
 
 


### PR DESCRIPTION
## Summary
- narrow Next Action user-wait detection so technical gates and safety-boundary words do not require a User Todo
- add a regression covering ALE-style technical gate prose with credentials kept local and submit/leaderboard paths avoided

## Validation
- python3 -m py_compile goal_harness/state_projection.py
- python3 examples/state-projection-gap-smoke.py
- goal-harness quota should-run for goal-harness-meta returns state_projection_gap=null after the fix
- git diff --check -- goal_harness/state_projection.py examples/state-projection-gap-smoke.py

## Excluded
- .local ALE compact preflight artifacts and active goal state updates remain ignored/local only
- no raw benchmark task/log/trajectory/verifier material included