### PR TITLE
Support ALE upstream local Docker gates

### DIFF
--- a/examples/agents-last-exam-local-source-readiness-smoke.py
+++ b/examples/agents-last-exam-local-source-readiness-smoke.py
@@ -159,6 +159,35 @@ def run_fixture_smoke() -> None:
         assert current["source"]["require_upstream_current"] is True
         assert_redacted(current)
 
+        current_branch = subprocess.run(
+            ["git", "branch", "--show-current"],
+            cwd=source_root,
+            check=True,
+            text=True,
+            capture_output=True,
+        ).stdout.strip()
+        subprocess.run(
+            ["git", "checkout", "--detach", "HEAD"],
+            cwd=source_root,
+            check=True,
+            capture_output=True,
+        )
+        detached = build_agents_last_exam_local_source_readiness(
+            source_root=str(source_root),
+            require_upstream_current=True,
+        )
+        assert detached["ready"] is True
+        assert detached["source"]["upstream_ref"] == "origin__main", detached
+        assert detached["source"]["upstream_fallback_ref"] is True, detached
+        assert detached["source"]["head_matches_upstream"] is True, detached
+        assert_redacted(detached)
+        subprocess.run(
+            ["git", "checkout", current_branch],
+            cwd=source_root,
+            check=True,
+            capture_output=True,
+        )
+
         advance_origin_main_without_advancing_head(source_root)
         behind = build_agents_last_exam_local_source_readiness(
             source_root=str(source_root),

--- a/examples/agents-last-exam-task-material-readiness-smoke.py
+++ b/examples/agents-last-exam-task-material-readiness-smoke.py
@@ -307,6 +307,37 @@ def run_function_smoke() -> None:
         assert ready_baked_probe["task_data"]["baked_input_probe_ready"] is True, ready_baked_probe
         assert_public_safe(ready_baked_probe, temp_root)
 
+        missing_local = build_agents_last_exam_task_material_readiness(
+            source_root=str(source),
+            selected_task_id=TASK_ID,
+            selected_task_lists=["linux_only.txt"],
+            requires_task_data=True,
+            task_data_source="local:task-data",
+            enforce_task_data_source=True,
+        )
+        assert missing_local["ready"] is False, missing_local
+        assert (
+            missing_local["first_blocker"] == "local_task_data_directory_not_verified"
+        ), missing_local
+        assert missing_local["task_data"]["local_task_data_source"] is True, missing_local
+        assert missing_local["task_data"]["local_task_data_path_recorded"] is False, missing_local
+        assert missing_local["task_data"]["local_task_data_content_read"] is False, missing_local
+        assert_public_safe(missing_local, temp_root)
+
+        (source / "task-data").mkdir()
+        ready_local = build_agents_last_exam_task_material_readiness(
+            source_root=str(source),
+            selected_task_id=TASK_ID,
+            selected_task_lists=["linux_only.txt"],
+            requires_task_data=True,
+            task_data_source="local:task-data",
+            enforce_task_data_source=True,
+        )
+        assert ready_local["ready"] is True, ready_local
+        assert ready_local["task_data"]["local_task_data_source_safe"] is True, ready_local
+        assert ready_local["task_data"]["local_task_data_present"] is True, ready_local
+        assert_public_safe(ready_local, temp_root)
+
         official_gcs = build_agents_last_exam_task_material_readiness(
             source_root=str(source),
             selected_task_id=TASK_ID,
@@ -321,7 +352,13 @@ def run_function_smoke() -> None:
         assert official_gcs["task_data"]["gcs_sa_key_present"] is True, official_gcs
         assert_public_safe(official_gcs, temp_root)
 
-        missing_card = source / "tasks" / "computing_math" / "os_log_permission_guard_v1" / "task_card.json"
+        missing_card = (
+            source
+            / "tasks"
+            / "computing_math"
+            / "os_log_permission_guard_v1"
+            / "task_card.json"
+        )
         missing_card.unlink()
         blocked = build_agents_last_exam_task_material_readiness(
             source_root=str(source),

--- a/goal_harness/benchmark_adapters/agents_last_exam.py
+++ b/goal_harness/benchmark_adapters/agents_last_exam.py
@@ -1902,17 +1902,24 @@ def _agents_last_exam_source_git_metadata(
         git_output("remote", "get-url", "origin")
     )
     head = _agents_last_exam_public_id(git_output("rev-parse", "HEAD"), limit=80)
-    upstream_ref = _agents_last_exam_public_id(
-        git_output("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"),
-        limit=120,
+    raw_upstream_ref = git_output(
+        "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"
     )
-    upstream_head = _agents_last_exam_public_id(
-        git_output("rev-parse", "@{upstream}"),
-        limit=80,
-    )
+    raw_upstream_head = git_output("rev-parse", "@{upstream}")
+    upstream_fallback_ref = False
+    if not raw_upstream_head:
+        fallback_ref = "origin/main"
+        fallback_head = git_output("rev-parse", fallback_ref)
+        if fallback_head:
+            raw_upstream_ref = fallback_ref
+            raw_upstream_head = fallback_head
+            upstream_fallback_ref = True
+    upstream_ref = _agents_last_exam_public_id(raw_upstream_ref, limit=120)
+    upstream_head = _agents_last_exam_public_id(raw_upstream_head, limit=80)
     upstream_ahead_count: int | None = None
     upstream_behind_count: int | None = None
-    rev_counts = git_output("rev-list", "--left-right", "--count", "HEAD...@{upstream}")
+    rev_target = raw_upstream_ref or "@{upstream}"
+    rev_counts = git_output("rev-list", "--left-right", "--count", f"HEAD...{rev_target}")
     if rev_counts:
         parts = rev_counts.split()
         if len(parts) >= 2:
@@ -1930,6 +1937,7 @@ def _agents_last_exam_source_git_metadata(
         "upstream_ref": upstream_ref,
         "upstream_head": upstream_head,
         "upstream_declared": bool(upstream_ref),
+        "upstream_fallback_ref": upstream_fallback_ref,
         "head_matches_upstream": bool(head and upstream_head and head == upstream_head),
         "upstream_ahead_count": upstream_ahead_count,
         "upstream_behind_count": upstream_behind_count,
@@ -2007,6 +2015,7 @@ def build_agents_last_exam_local_source_readiness(
             "upstream_ref": git_metadata.get("upstream_ref"),
             "upstream_head": git_metadata.get("upstream_head"),
             "upstream_declared": git_metadata.get("upstream_declared") is True,
+            "upstream_fallback_ref": git_metadata.get("upstream_fallback_ref") is True,
             "head_matches_upstream": git_metadata.get("head_matches_upstream")
             is True,
             "upstream_ahead_count": git_metadata.get("upstream_ahead_count"),
@@ -2518,6 +2527,7 @@ def build_agents_last_exam_baked_task_input_scan(
 
 def _agents_last_exam_task_data_source_readiness(
     *,
+    source_root: str | None,
     requires_task_data: bool | str | None,
     task_data_source: str | None,
     baked_task_input_present: bool | None,
@@ -2530,6 +2540,37 @@ def _agents_last_exam_task_data_source_readiness(
     raw_source = task_data_source.strip() if isinstance(task_data_source, str) else ""
     source = _agents_last_exam_public_id(raw_source, limit=120)
     official_gcs_source = raw_source.startswith("gs://ale-data-public")
+    local_source_declared = raw_source.startswith("local:")
+    local_source_safe = False
+    local_source_present = False
+    if local_source_declared:
+        local_relative = raw_source[len("local:") :].strip().replace("\\", "/")
+        parts = [part for part in local_relative.split("/") if part]
+        local_source_safe = bool(
+            local_relative
+            and not local_relative.startswith("/")
+            and not local_relative.startswith("~")
+            and all(part not in {".", ".."} for part in parts)
+        )
+        try:
+            source_root_path = Path(source_root).expanduser() if source_root else None
+        except (OSError, RuntimeError):
+            source_root_path = None
+        if (
+            local_source_safe
+            and source_root_path is not None
+            and source_root_path.is_dir()
+        ):
+            candidate = source_root_path.joinpath(*parts)
+            try:
+                resolved_root = source_root_path.resolve()
+                resolved_candidate = candidate.resolve()
+                inside_root = resolved_candidate == resolved_root or (
+                    resolved_root in resolved_candidate.parents
+                )
+            except OSError:
+                inside_root = False
+            local_source_present = bool(inside_root and candidate.is_dir())
     gcs_key_declared = bool(gcs_sa_key)
     gcs_key_file_present = False
     if gcs_sa_key:
@@ -2576,6 +2617,11 @@ def _agents_last_exam_task_data_source_readiness(
         elif official_gcs_source:
             if effective_gcs_key_present is not True:
                 blockers.append("gcs_sa_key_presence_not_verified")
+        elif local_source_declared:
+            if not local_source_safe:
+                blockers.append("local_task_data_source_not_public_safe")
+            elif local_source_present is not True:
+                blockers.append("local_task_data_directory_not_verified")
         elif raw_source in {"none", "local"}:
             blockers.append("task_data_source_not_sufficient_for_required_task")
         else:
@@ -2593,6 +2639,11 @@ def _agents_last_exam_task_data_source_readiness(
         "task_data_source": source,
         "task_data_source_declared": bool(source),
         "official_gcs_source": official_gcs_source,
+        "local_task_data_source": local_source_declared,
+        "local_task_data_source_safe": local_source_safe,
+        "local_task_data_present": local_source_present,
+        "local_task_data_path_recorded": False,
+        "local_task_data_content_read": False,
         "baked_input_present": effective_baked_input_present is True,
         "baked_input_presence_declared": baked_task_input_present is not None
         or baked_probe_declared,
@@ -2690,6 +2741,7 @@ def build_agents_last_exam_task_material_readiness(
     elif int(membership.get("present_count") or 0) < 1:
         blockers.append("selected_task_not_in_public_task_lists")
     task_data = _agents_last_exam_task_data_source_readiness(
+        source_root=source_root,
         requires_task_data=requires_task_data,
         task_data_source=task_data_source,
         baked_task_input_present=baked_task_input_present,


### PR DESCRIPTION
## Summary
- teach ALE source readiness to accept detached clean worktrees pinned to origin/main, which is the shape used for upstream-current benchmark validation
- teach ALE task-material readiness to understand upstream local-Docker task_data_source values like local:task-data without reading task-data contents or recording local paths
- add focused public smokes for detached source locks and local task-data presence gates

## Validation
- python3 examples/agents-last-exam-local-source-readiness-smoke.py
- python3 examples/agents-last-exam-task-material-readiness-smoke.py
- python3 examples/agents-last-exam-validation-run-gate-smoke.py
- python3 -m py_compile goal_harness/benchmark_adapters/agents_last_exam.py examples/agents-last-exam-local-source-readiness-smoke.py examples/agents-last-exam-task-material-readiness-smoke.py
- git diff --check

## Excluded
- no .local goal state, raw benchmark logs, task text, trajectories, credential values, or local absolute paths are committed
- no benchmark job/model/container was launched by this PR
