### PR TITLE
Support external ALE launch specs

### DIFF
--- a/examples/agents-last-exam-local-launch-packet-smoke.py
+++ b/examples/agents-last-exam-local-launch-packet-smoke.py
@@ -179,6 +179,7 @@ def assert_no_execution(payload: dict[str, object]) -> None:
     assert isinstance(spec, dict)
     assert spec["content_read"] is False
     assert spec["source_root_path_recorded"] is False
+    assert spec["external_root_path_recorded"] is False
     case_state = payload["case_state_init_contract"]
     assert isinstance(case_state, dict)
     assert (
@@ -229,6 +230,31 @@ def run_fixture_smoke() -> None:
         assert payload["runner"]["python_module_available"] is True
         assert payload["experiment_spec"]["exists"] is True
         assert_no_execution(payload)
+
+        external_spec_root = Path(tmp) / "goal-harness-ale-wrapper"
+        external_spec_root.mkdir()
+        (external_spec_root / "host_codex_spec.yaml").write_text(
+            "name: host_codex_fixture\n",
+            encoding="utf-8",
+        )
+        external_spec = build_agents_last_exam_local_launch_packet(
+            source_root=str(source_root),
+            experiment_spec_root=str(external_spec_root),
+            experiment_spec_relative_path="host_codex_spec.yaml",
+            selected_task_id="computing_math/os_log_permission_guard_v1",
+            runner_binary="python3",
+            runner_python_module="ale_run",
+            runner_command_label="python-m-ale-run",
+            operator_authorized=True,
+            allow_public_task_material=True,
+            image_metadata=ready_image_metadata(),
+            alternate_image_metadata=blocked_image_metadata(),
+        )
+        assert external_spec["ready"] is True
+        assert external_spec["experiment_spec"]["exists"] is True
+        assert external_spec["experiment_spec"]["root_kind"] == "external_spec_root"
+        assert external_spec["experiment_spec"]["external_root_declared"] is True
+        assert_no_execution(external_spec)
 
         fresh_required = build_agents_last_exam_local_launch_packet(
             source_root=str(source_root),
@@ -287,6 +313,12 @@ def run_cli_smoke() -> None:
     tmp = tempfile.mkdtemp()
     try:
         source_root = make_source_root(Path(tmp))
+        external_spec_root = Path(tmp) / "goal-harness-ale-wrapper"
+        external_spec_root.mkdir()
+        (external_spec_root / "host_codex_spec.yaml").write_text(
+            "name: host_codex_fixture\n",
+            encoding="utf-8",
+        )
         base_cmd = [
             sys.executable,
             "-m",
@@ -322,6 +354,28 @@ def run_cli_smoke() -> None:
         assert payload["first_blocker"] == "docker_probe_disabled"
         assert payload["experiment_spec"]["exists"] is True
         assert_no_execution(payload)
+
+        external_cmd = [
+            *base_cmd[: base_cmd.index("--experiment-spec") + 2],
+            "--experiment-spec-root",
+            str(external_spec_root),
+            *base_cmd[base_cmd.index("--experiment-spec") + 2 :],
+        ]
+        spec_index = external_cmd.index("--experiment-spec") + 1
+        external_cmd[spec_index] = "host_codex_spec.yaml"
+        external_result = subprocess.run(
+            external_cmd,
+            cwd=REPO_ROOT,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        external_payload = json.loads(external_result.stdout)
+        assert external_payload["ok"] is True
+        assert external_payload["experiment_spec"]["root_kind"] == "external_spec_root"
+        assert external_payload["experiment_spec"]["external_root_declared"] is True
+        assert external_payload["experiment_spec"]["exists"] is True
+        assert_no_execution(external_payload)
 
         fresh_required = subprocess.run(
             [*base_cmd, "--require-upstream-current"],

--- a/goal_harness/benchmark_adapters/agents_last_exam.py
+++ b/goal_harness/benchmark_adapters/agents_last_exam.py
@@ -3178,15 +3178,20 @@ def build_agents_last_exam_candidate_task_data_scan(
 def _agents_last_exam_relative_file_probe(
     source_root: str | None,
     relative_path: str | None,
+    *,
+    file_root: str | None = None,
 ) -> dict[str, Any]:
     label = _agents_last_exam_public_id(relative_path, limit=160)
+    root_kind = "external_spec_root" if file_root else "source_root"
     if not relative_path:
         return {
             "relative_path": None,
             "declared": False,
             "exists": False,
             "first_blocker": "experiment_spec_missing",
+            "root_kind": root_kind,
             "source_root_path_recorded": False,
+            "external_root_path_recorded": False,
         }
     text = relative_path.replace("\\", "/").strip()
     parts = [part for part in text.split("/") if part]
@@ -3198,18 +3203,23 @@ def _agents_last_exam_relative_file_probe(
             "declared": True,
             "exists": False,
             "first_blocker": "experiment_spec_relative_path_not_public_safe",
+            "root_kind": root_kind,
             "source_root_path_recorded": False,
+            "external_root_path_recorded": False,
         }
-    if not source_root:
+    probe_root = file_root or source_root
+    if not probe_root:
         return {
             "relative_path": label,
             "declared": True,
             "exists": False,
-            "first_blocker": "source_root_missing",
+            "first_blocker": f"{root_kind}_missing",
+            "root_kind": root_kind,
             "source_root_path_recorded": False,
+            "external_root_path_recorded": False,
         }
     try:
-        source_path = Path(source_root).expanduser()
+        source_path = Path(probe_root).expanduser()
     except (OSError, RuntimeError):
         source_path = None
     if source_path is None or not source_path.is_dir():
@@ -3217,8 +3227,10 @@ def _agents_last_exam_relative_file_probe(
             "relative_path": label,
             "declared": True,
             "exists": False,
-            "first_blocker": "source_root_not_available",
+            "first_blocker": f"{root_kind}_not_available",
+            "root_kind": root_kind,
             "source_root_path_recorded": False,
+            "external_root_path_recorded": False,
         }
     candidate = source_path.joinpath(*parts)
     try:
@@ -3235,13 +3247,16 @@ def _agents_last_exam_relative_file_probe(
         "declared": True,
         "exists": exists,
         "first_blocker": None if exists else "experiment_spec_file_missing",
+        "root_kind": root_kind,
         "source_root_path_recorded": False,
+        "external_root_path_recorded": False,
     }
 
 def build_agents_last_exam_local_launch_packet(
     *,
     source_root: str | None,
     experiment_spec_relative_path: str | None,
+    experiment_spec_root: str | None = None,
     selected_task_id: str | None = None,
     expected_repo_url: str = AGENTS_LAST_EXAM_DEFAULT_REPO_URL,
     snapshot: str = AGENTS_LAST_EXAM_DEFAULT_SNAPSHOT,
@@ -3287,6 +3302,7 @@ def build_agents_last_exam_local_launch_packet(
     spec_probe = _agents_last_exam_relative_file_probe(
         source_root,
         experiment_spec_relative_path,
+        file_root=experiment_spec_root,
     )
     blockers: list[str] = []
     if source_readiness.get("ready") is not True:
@@ -3358,7 +3374,10 @@ def build_agents_last_exam_local_launch_packet(
             "declared": spec_probe.get("declared") is True,
             "exists": spec_probe.get("exists") is True,
             "content_read": False,
+            "root_kind": spec_probe.get("root_kind"),
+            "external_root_declared": bool(experiment_spec_root),
             "source_root_path_recorded": False,
+            "external_root_path_recorded": False,
         },
         "launch_packet": {
             "mode": "no_execution_launch_packet",

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -3298,7 +3298,17 @@ def main(argv: list[str] | None = None) -> int:
     ale_local_launch_packet_parser.add_argument(
         "--experiment-spec",
         required=True,
-        help="Public relative path to the ALE experiment spec under source root.",
+        help=(
+            "Public relative path to the ALE experiment spec under source root "
+            "or --experiment-spec-root."
+        ),
+    )
+    ale_local_launch_packet_parser.add_argument(
+        "--experiment-spec-root",
+        help=(
+            "Optional external spec root for Goal Harness wrapper specs. The "
+            "path is probed for existence only and never recorded."
+        ),
     )
     ale_local_launch_packet_parser.add_argument(
         "--selected-task-id",
@@ -5991,6 +6001,7 @@ def main(argv: list[str] | None = None) -> int:
                 payload = build_agents_last_exam_local_launch_packet(
                     source_root=args.source_root,
                     experiment_spec_relative_path=args.experiment_spec,
+                    experiment_spec_root=args.experiment_spec_root,
                     selected_task_id=args.selected_task_id,
                     expected_repo_url=args.expected_repo_url,
                     snapshot=args.snapshot,


### PR DESCRIPTION
## Summary
- allow ALE launch packets to validate an experiment spec from an external wrapper root instead of requiring the spec inside the upstream ALE checkout
- keep the probe public-safe: relative spec path only, existence check only, no spec content read, no local path recording
- cover API and CLI paths in the focused ALE launch-packet smoke

## Validation
- python3 examples/agents-last-exam-local-launch-packet-smoke.py
- python3 examples/agents-last-exam-local-source-readiness-smoke.py
- python3 examples/agents-last-exam-task-material-readiness-smoke.py
- python3 examples/agents-last-exam-validation-run-gate-smoke.py
- python3 -m py_compile goal_harness/benchmark_adapters/agents_last_exam.py goal_harness/cli.py examples/agents-last-exam-local-launch-packet-smoke.py
- git diff --check -- goal_harness/benchmark_adapters/agents_last_exam.py goal_harness/cli.py examples/agents-last-exam-local-launch-packet-smoke.py

## Excluded
- docs/interaction-pattern-catalog.md has pre-existing/unrelated local changes and is not part of this PR
- no .local state, raw benchmark logs, task text, trajectories, credential values, or local absolute paths are committed
- no benchmark job/model/container was launched by this PR
