### PR TITLE
Expose ALE local task-data staging gate

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/agents-last-exam-local-docker-host-codex-route-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/agents-last-exam-local-docker-host-codex-route-v0.md
@@ -56,21 +56,29 @@ The local route is allowed only when the task-data substrate is explicit:
 
 - For no-task-data canaries such as `demo/tool_smoke`, pass
   `--requires-task-data false` and keep the route no-upload/no-submit.
-- For real tasks with `requires_task_data=True`, `task_data_source` must be one
-  of:
-  - verified `baked_in_sandbox`, with baked task input presence proven by the
-    sandbox/image preflight; or
-  - `gs://ale-data-public`, with credential presence checked without recording
-    credential values or local paths.
-- `task_data_source=none`, missing task-data source, or unverified
-  `baked_in_sandbox` must block local launch.
+- For upstream-current local Docker tasks with `requires_task_data=True`,
+  prefer the upstream `configs/environments/docker.yaml` contract:
+  `task_data_source: local:task-data`. The host-side `task-data/` directory is
+  staged once from the gated Hugging Face archive
+  `agents-last-exam-data-archive` by `scripts/fetch_task_data.sh`, then copied
+  into each container with `docker cp`.
+- Public readiness artifacts may record the sanitized staging route, whether
+  `scripts/fetch_task_data.sh` exists, whether `huggingface-cli` is available,
+  whether auth was checked, and coarse disk headroom. They must not run the
+  fetch, read task-data content, inspect Hugging Face credentials, record local
+  paths, or persist archive contents.
+- Older `baked_in_sandbox` or `gs://ale-data-public` routes remain valid only
+  when the corresponding substrate is explicitly selected and proven. Do not
+  silently substitute them for upstream local Docker.
+- `task_data_source=none`, missing task-data source, missing local staging, or
+  unverified gated-data access must block local launch.
 
 Example public-safe gate:
 
 ```bash
 goal-harness benchmark ale-task-material-readiness \
-  --task-root <ale-task-root> \
-  --task-id demo/tool_smoke \
+  --source-root <ale-source-root> \
+  --selected-task-id demo/tool_smoke \
   --requires-task-data false \
   --task-data-source none \
   --enforce-task-data-source
@@ -80,16 +88,16 @@ For a formal task:
 
 ```bash
 goal-harness benchmark ale-task-material-readiness \
-  --task-root <ale-task-root> \
-  --task-id computing_math/os_log_permission_guard_v1 \
+  --source-root <ale-source-root> \
+  --selected-task-id computing_math/os_log_permission_guard_v1 \
   --requires-task-data true \
-  --task-data-source gs://ale-data-public \
-  --gcs-sa-key <credential-presence-only> \
+  --task-data-source local:task-data \
   --enforce-task-data-source
 ```
 
-The second command may check whether the credential file exists, but public
-artifacts must record only booleans and sanitized labels.
+This command may check the local staging route and tool presence, but public
+artifacts must record only booleans, sanitized labels, and coarse disk
+headroom.
 
 For a `baked_in_sandbox` candidate, prove the sandbox input directory before
 feeding the result into task-material readiness:
@@ -100,8 +108,8 @@ goal-harness benchmark ale-baked-task-input-readiness \
   --image agentslastexam/ale-kasm:latest
 
 goal-harness benchmark ale-task-material-readiness \
-  --task-root <ale-task-root> \
-  --task-id computing_math/os_log_permission_guard_v1 \
+  --source-root <ale-source-root> \
+  --selected-task-id computing_math/os_log_permission_guard_v1 \
   --requires-task-data true \
   --task-data-source baked_in_sandbox \
   --baked-task-input-readiness-json <compact-baked-input-readiness-json> \

--- a/examples/agents-last-exam-task-material-readiness-smoke.py
+++ b/examples/agents-last-exam-task-material-readiness-smoke.py
@@ -77,6 +77,13 @@ def assert_public_safe(payload: dict[str, object], temp_root: Path) -> None:
         assert task_data["credential_values_recorded"] is False
         assert task_data["local_paths_recorded"] is False
         assert task_data["gcs_sa_key_path_recorded"] is False
+        local_staging = task_data.get("local_task_data_staging")
+        if isinstance(local_staging, dict):
+            assert local_staging["credential_values_read"] is False
+            assert local_staging["credential_values_recorded"] is False
+            assert local_staging["local_paths_recorded"] is False
+            assert local_staging["task_data_content_read"] is False
+            assert local_staging["archive_content_read"] is False
 
 
 def assert_baked_probe_public_safe(payload: dict[str, object]) -> None:
@@ -320,6 +327,26 @@ def run_function_smoke() -> None:
             missing_local["first_blocker"] == "local_task_data_directory_not_verified"
         ), missing_local
         assert missing_local["task_data"]["local_task_data_source"] is True, missing_local
+        assert (
+            missing_local["task_data"]["local_task_data_staging"]["route"]
+            == "gated_huggingface_archive"
+        ), missing_local
+        assert (
+            missing_local["task_data"]["local_task_data_staging"][
+                "dataset_label"
+            ]
+            == "agents-last-exam-data-archive"
+        ), missing_local
+        assert (
+            missing_local["task_data"]["local_task_data_staging"][
+                "auth_status_checked"
+            ]
+            is False
+        ), missing_local
+        assert (
+            "local_task_data_gated_huggingface_access_not_verified"
+            in missing_local["task_data"]["local_task_data_staging"]["blockers"]
+        ), missing_local
         assert missing_local["task_data"]["local_task_data_path_recorded"] is False, missing_local
         assert missing_local["task_data"]["local_task_data_content_read"] is False, missing_local
         assert_public_safe(missing_local, temp_root)
@@ -336,6 +363,9 @@ def run_function_smoke() -> None:
         assert ready_local["ready"] is True, ready_local
         assert ready_local["task_data"]["local_task_data_source_safe"] is True, ready_local
         assert ready_local["task_data"]["local_task_data_present"] is True, ready_local
+        assert (
+            ready_local["task_data"]["local_task_data_staging"]["ready"] is True
+        ), ready_local
         assert_public_safe(ready_local, temp_root)
 
         official_gcs = build_agents_last_exam_task_material_readiness(

--- a/goal_harness/benchmark_adapters/agents_last_exam.py
+++ b/goal_harness/benchmark_adapters/agents_last_exam.py
@@ -414,6 +414,29 @@ def _agents_last_exam_disk_headroom() -> dict[str, Any]:
         "path_recorded": False,
     }
 
+def _agents_last_exam_disk_headroom_for_path(path: Path | None) -> dict[str, Any]:
+    try:
+        probe_path = path if path is not None and path.exists() else Path.cwd()
+        usage = shutil.disk_usage(probe_path)
+    except (OSError, RuntimeError):
+        return {
+            "checked": False,
+            "free_gib": None,
+            "total_gib": None,
+            "used_percent": None,
+            "path_recorded": False,
+        }
+    free_gib = usage.free / (1024**3)
+    total_gib = usage.total / (1024**3)
+    used_pct = (usage.used / usage.total * 100.0) if usage.total else 0.0
+    return {
+        "checked": True,
+        "free_gib": round(free_gib, 2),
+        "total_gib": round(total_gib, 2),
+        "used_percent": round(used_pct, 2),
+        "path_recorded": False,
+    }
+
 def build_agents_last_exam_local_preflight(
     *,
     selected_task_id: str | None = None,
@@ -2171,6 +2194,63 @@ def _agents_last_exam_bool_requirement(value: bool | str | None) -> bool | None:
         return False
     return None
 
+def _agents_last_exam_local_task_data_staging_probe(
+    *,
+    source_root_path: Path | None,
+    local_source_declared: bool,
+    local_source_safe: bool,
+    local_source_present: bool,
+) -> dict[str, Any]:
+    checked = bool(local_source_declared)
+    fetch_script_present = False
+    if source_root_path is not None and source_root_path.is_dir():
+        fetch_script_present = (
+            source_root_path / "scripts" / "fetch_task_data.sh"
+        ).is_file()
+    fetch_tool_present = shutil.which("huggingface-cli") is not None
+    disk_headroom = _agents_last_exam_disk_headroom_for_path(source_root_path)
+    documented_image_compressed_gib = 42
+    free_gib = disk_headroom.get("free_gib")
+    disk_headroom_below_documented_image = (
+        isinstance(free_gib, (int, float))
+        and free_gib < documented_image_compressed_gib
+    )
+    blockers: list[str] = []
+    if checked and local_source_safe and local_source_present is not True:
+        if not fetch_script_present:
+            blockers.append("local_task_data_fetch_script_missing")
+        if not fetch_tool_present:
+            blockers.append("local_task_data_fetch_tool_missing")
+        blockers.append("local_task_data_gated_huggingface_access_not_verified")
+        if disk_headroom_below_documented_image:
+            blockers.append(
+                "local_task_data_disk_headroom_below_documented_image_pull"
+            )
+    return {
+        "checked": checked,
+        "ready": checked and not blockers if checked else None,
+        "first_blocker": blockers[0] if blockers else None,
+        "blockers": blockers,
+        "route": "gated_huggingface_archive" if checked else None,
+        "dataset_label": "agents-last-exam-data-archive" if checked else None,
+        "archive_label": "ale-tasks-data.tar.gz" if checked else None,
+        "fetch_script_present": fetch_script_present,
+        "fetch_tool": "huggingface-cli" if checked else None,
+        "fetch_tool_present": fetch_tool_present,
+        "auth_status_checked": False,
+        "requires_approved_huggingface_access": checked,
+        "disk_headroom": disk_headroom,
+        "documented_docker_image_compressed_gib": documented_image_compressed_gib,
+        "disk_headroom_below_documented_image_pull": (
+            disk_headroom_below_documented_image
+        ),
+        "local_paths_recorded": False,
+        "credential_values_read": False,
+        "credential_values_recorded": False,
+        "task_data_content_read": False,
+        "archive_content_read": False,
+    }
+
 def build_agents_last_exam_baked_task_input_readiness(
     *,
     selected_task_id: str | None,
@@ -2543,6 +2623,7 @@ def _agents_last_exam_task_data_source_readiness(
     local_source_declared = raw_source.startswith("local:")
     local_source_safe = False
     local_source_present = False
+    source_root_path = None
     if local_source_declared:
         local_relative = raw_source[len("local:") :].strip().replace("\\", "/")
         parts = [part for part in local_relative.split("/") if part]
@@ -2571,6 +2652,12 @@ def _agents_last_exam_task_data_source_readiness(
             except OSError:
                 inside_root = False
             local_source_present = bool(inside_root and candidate.is_dir())
+    local_staging = _agents_last_exam_local_task_data_staging_probe(
+        source_root_path=source_root_path,
+        local_source_declared=local_source_declared,
+        local_source_safe=local_source_safe,
+        local_source_present=local_source_present,
+    )
     gcs_key_declared = bool(gcs_sa_key)
     gcs_key_file_present = False
     if gcs_sa_key:
@@ -2622,6 +2709,11 @@ def _agents_last_exam_task_data_source_readiness(
                 blockers.append("local_task_data_source_not_public_safe")
             elif local_source_present is not True:
                 blockers.append("local_task_data_directory_not_verified")
+                blockers.extend(
+                    blocker
+                    for blocker in local_staging.get("blockers", [])
+                    if isinstance(blocker, str)
+                )
         elif raw_source in {"none", "local"}:
             blockers.append("task_data_source_not_sufficient_for_required_task")
         else:
@@ -2642,6 +2734,7 @@ def _agents_last_exam_task_data_source_readiness(
         "local_task_data_source": local_source_declared,
         "local_task_data_source_safe": local_source_safe,
         "local_task_data_present": local_source_present,
+        "local_task_data_staging": local_staging,
         "local_task_data_path_recorded": False,
         "local_task_data_content_read": False,
         "baked_input_present": effective_baked_input_present is True,

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -180,7 +180,14 @@ from .quota import (
     spend_quota_slot,
     void_quota_slot,
 )
-from .registry import inspect_registry, registry_goals, render_registry_markdown, resolve_state_file
+from .registry import (
+    inspect_registry,
+    inspect_registry_boundary,
+    registry_goals,
+    render_registry_boundary_markdown,
+    render_registry_markdown,
+    resolve_state_file,
+)
 from .runtime import archive_runtime_goal, render_archive_runtime_markdown
 from .state_refresh import (
     DEFAULT_REFRESH_ACTION,
@@ -588,6 +595,12 @@ def render_agents_last_exam_task_material_readiness_markdown(
     decision = (
         payload.get("decision") if isinstance(payload.get("decision"), dict) else {}
     )
+    task_data = payload.get("task_data") if isinstance(payload.get("task_data"), dict) else {}
+    local_staging = (
+        task_data.get("local_task_data_staging")
+        if isinstance(task_data.get("local_task_data_staging"), dict)
+        else {}
+    )
     lines = [
         "# Agents Last Exam Task Material Readiness",
         "",
@@ -597,7 +610,8 @@ def render_agents_last_exam_task_material_readiness_markdown(
         f"- Task: `{task.get('task_id')}`",
         f"- Task dir/card/scripts: `{task.get('task_dir_available')}`/`{task.get('task_card_json_present')}`/`{task.get('scripts_dir_present')}`",
         f"- Scorer script count: `{task.get('scorer_script_count')}`",
-        f"- Task data checked/ready/source: `{(payload.get('task_data') if isinstance(payload.get('task_data'), dict) else {}).get('checked')}`/`{(payload.get('task_data') if isinstance(payload.get('task_data'), dict) else {}).get('ready')}`/`{(payload.get('task_data') if isinstance(payload.get('task_data'), dict) else {}).get('task_data_source')}`",
+        f"- Task data checked/ready/source: `{task_data.get('checked')}`/`{task_data.get('ready')}`/`{task_data.get('task_data_source')}`",
+        f"- Local task-data staging route/tool/auth checked: `{local_staging.get('route')}`/`{local_staging.get('fetch_tool_present')}`/`{local_staging.get('auth_status_checked')}`",
         f"- Public list membership checked/present: `{public_lists.get('checked')}`/`{public_lists.get('present_count')}`",
         f"- Task body/card/script content read: `{boundary.get('task_body_read')}`/`{boundary.get('task_card_content_read')}`/`{boundary.get('script_content_read')}`",
         f"- Local paths/raw output recorded: `{boundary.get('local_paths_recorded')}`/`{boundary.get('raw_output_recorded')}`",
@@ -2139,6 +2153,24 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     sub.add_parser("registry", help="Inspect registry goals and adapter declarations.")
+    registry_boundary_parser = sub.add_parser(
+        "registry-boundary",
+        help="Classify a registry file as local-only, global-local, public projection, or public fixture.",
+    )
+    registry_boundary_parser.add_argument(
+        "--path",
+        help="Registry path to classify. Defaults to the active --registry path.",
+    )
+    registry_boundary_parser.add_argument(
+        "--require-not-tracked",
+        action="store_true",
+        help="Return non-zero if the registry is tracked while publication policy disallows pushing it.",
+    )
+    registry_boundary_parser.add_argument(
+        "--require-gitignored",
+        action="store_true",
+        help="Return non-zero if the registry should be ignored but is neither ignored nor tracked.",
+    )
 
     configure_goal_parser = sub.add_parser(
         "configure-goal",
@@ -5236,6 +5268,24 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "registry":
         payload = inspect_registry(registry_path)
         print_payload(payload, args.format, render_registry_markdown)
+        return 0 if payload.get("ok") else 1
+
+    if args.command == "registry-boundary":
+        boundary_path = Path(args.path).expanduser() if args.path else registry_path
+        payload = inspect_registry_boundary(boundary_path)
+        git = payload.get("git") if isinstance(payload.get("git"), dict) else {}
+        if args.require_not_tracked and payload.get("ok") and git.get("tracked") and not payload.get(
+            "github_push_allowed"
+        ):
+            payload = dict(payload)
+            payload["ok"] = False
+            payload.setdefault("risks", []).append("registry_tracked_but_not_push_allowed")
+        if args.require_gitignored and payload.get("ok") and payload.get("should_be_gitignored"):
+            if git.get("inside_worktree") and not git.get("ignored") and not git.get("tracked"):
+                payload = dict(payload)
+                payload["ok"] = False
+                payload.setdefault("risks", []).append("registry_should_be_gitignored")
+        print_payload(payload, args.format, render_registry_boundary_markdown)
         return 0 if payload.get("ok") else 1
 
     if args.command == "configure-goal":


### PR DESCRIPTION
## Summary
- expose compact local task-data staging proof for ALE local Docker readiness
- record gated Hugging Face route/tool/auth/disk signals without fetching data, reading task content, or recording local paths
- update the ALE local Docker route note and focused smoke coverage

## Validation
- python3 examples/agents-last-exam-task-material-readiness-smoke.py
- python3 examples/agents-last-exam-validation-run-gate-smoke.py
- python3 examples/agents-last-exam-local-docker-host-codex-route-smoke.py
- goal-harness check (existing duplicate-index warning only)