### PR TITLE
Fix registry boundary CLI backend

### DIFF
--- a/examples/registry-boundary-contract-smoke.py
+++ b/examples/registry-boundary-contract-smoke.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Smoke-test registry boundary classification and CLI import wiring."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from goal_harness.registry import inspect_registry_boundary  # noqa: E402
+
+
+def run() -> None:
+    with tempfile.TemporaryDirectory(prefix="goal-harness-registry-boundary-") as tmp:
+        root = Path(tmp)
+        subprocess.run(["git", "init"], cwd=root, check=True, capture_output=True)
+        (root / ".gitignore").write_text(".goal-harness/\n", encoding="utf-8")
+
+        local_registry = root / ".goal-harness" / "registry.json"
+        local_registry.parent.mkdir()
+        local_registry.write_text('{"goals":[]}\n', encoding="utf-8")
+        local_payload = inspect_registry_boundary(local_registry)
+        assert local_payload["ok"] is True, local_payload
+        assert local_payload["boundary_kind"] == "project_local_private_registry", local_payload
+        assert local_payload["github_push_allowed"] is False, local_payload
+        assert local_payload["should_be_gitignored"] is True, local_payload
+        assert local_payload["git"]["ignored"] is True, local_payload
+        assert local_payload["path_recorded"] is False, local_payload
+
+        public_fixture = root / "examples" / "registry.example.json"
+        public_fixture.parent.mkdir()
+        public_fixture.write_text('{"goals":[]}\n', encoding="utf-8")
+        subprocess.run(
+            ["git", "add", ".gitignore", "examples/registry.example.json"],
+            cwd=root,
+            check=True,
+            capture_output=True,
+        )
+        public_payload = inspect_registry_boundary(public_fixture)
+        assert public_payload["ok"] is True, public_payload
+        assert public_payload["boundary_kind"] == "public_fixture_registry_projection", public_payload
+        assert public_payload["github_push_allowed"] is True, public_payload
+        assert public_payload["git"]["tracked"] is True, public_payload
+
+        cli_result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "goal_harness.cli",
+                "--format",
+                "json",
+                "registry-boundary",
+                "--path",
+                str(local_registry),
+                "--require-gitignored",
+            ],
+            cwd=REPO_ROOT,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        cli_payload = json.loads(cli_result.stdout)
+        assert cli_payload["ok"] is True, cli_payload
+        assert cli_payload["path_label"] == "registry.json", cli_payload
+        rendered = json.dumps(cli_payload, sort_keys=True)
+        assert str(root) not in rendered, rendered
+
+
+if __name__ == "__main__":
+    run()
+    print("registry-boundary-contract-smoke ok")

--- a/goal_harness/registry.py
+++ b/goal_harness/registry.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import os
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -167,6 +169,136 @@ def inspect_registry(path: Path) -> dict[str, Any]:
         "problems": problems,
         "goals": inspected_goals,
     }
+
+def _registry_boundary_kind(path: Path) -> dict[str, Any]:
+    parts = path.expanduser().parts
+    name = path.name
+    if ".goal-harness" in parts:
+        return {
+            "kind": "project_local_private_registry",
+            "github_push_allowed": False,
+            "should_be_gitignored": True,
+        }
+    if name == "registry.global.json" or (
+        ".codex" in parts and "goal-harness" in parts
+    ):
+        return {
+            "kind": "global_local_private_registry",
+            "github_push_allowed": False,
+            "should_be_gitignored": True,
+        }
+    if "examples" in parts or name.endswith(".example.json"):
+        return {
+            "kind": "public_fixture_registry_projection",
+            "github_push_allowed": True,
+            "should_be_gitignored": False,
+        }
+    return {
+        "kind": "unknown_registry_boundary",
+        "github_push_allowed": False,
+        "should_be_gitignored": True,
+    }
+
+
+def _registry_git_probe(path: Path) -> dict[str, Any]:
+    probe_dir = path if path.is_dir() else path.parent
+
+    def run_git(*args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", *args],
+            cwd=probe_dir,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+
+    root = run_git("rev-parse", "--show-toplevel")
+    inside = root.returncode == 0
+    tracked = False
+    ignored = False
+    if inside:
+        root_path = Path(root.stdout.strip())
+        try:
+            rel_path = os.path.relpath(path.resolve(), root_path)
+        except (OSError, ValueError):
+            rel_path = path.name
+        tracked = (
+            subprocess.run(
+                ["git", "ls-files", "--error-unmatch", rel_path],
+                cwd=root_path,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                check=False,
+            ).returncode
+            == 0
+        )
+        ignored = (
+            subprocess.run(
+                ["git", "check-ignore", "-q", rel_path],
+                cwd=root_path,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                check=False,
+            ).returncode
+            == 0
+        )
+    return {
+        "inside_worktree": inside,
+        "tracked": tracked,
+        "ignored": ignored,
+        "worktree_root_recorded": False,
+    }
+
+
+def inspect_registry_boundary(path: Path) -> dict[str, Any]:
+    expanded = path.expanduser()
+    classification = _registry_boundary_kind(expanded)
+    git = _registry_git_probe(expanded)
+    risks: list[str] = []
+    if git.get("tracked") and not classification["github_push_allowed"]:
+        risks.append("registry_tracked_but_not_push_allowed")
+    if (
+        classification["should_be_gitignored"]
+        and git.get("inside_worktree")
+        and not git.get("ignored")
+        and not git.get("tracked")
+    ):
+        risks.append("registry_should_be_gitignored")
+    return {
+        "ok": not risks,
+        "schema_version": "goal_harness_registry_boundary_v0",
+        "path_label": expanded.name,
+        "path_recorded": False,
+        "boundary_kind": classification["kind"],
+        "github_push_allowed": classification["github_push_allowed"],
+        "should_be_gitignored": classification["should_be_gitignored"],
+        "git": git,
+        "risks": risks,
+    }
+
+
+def render_registry_boundary_markdown(payload: dict[str, Any]) -> str:
+    git = payload.get("git") if isinstance(payload.get("git"), dict) else {}
+    lines = [
+        "# Goal Harness Registry Boundary",
+        "",
+        f"- ok: `{payload.get('ok')}`",
+        f"- schema_version: `{payload.get('schema_version')}`",
+        f"- path_label: `{payload.get('path_label')}`",
+        f"- boundary_kind: `{payload.get('boundary_kind')}`",
+        f"- github_push_allowed: `{payload.get('github_push_allowed')}`",
+        f"- should_be_gitignored: `{payload.get('should_be_gitignored')}`",
+        f"- git tracked/ignored: `{git.get('tracked')}`/`{git.get('ignored')}`",
+        f"- path_recorded: `{payload.get('path_recorded')}`",
+    ]
+    risks = payload.get("risks") if isinstance(payload.get("risks"), list) else []
+    if risks:
+        lines.extend(["", "## Risks"])
+        lines.extend(f"- `{risk}`" for risk in risks)
+    return "\n".join(lines) + "\n"
 
 
 def render_registry_markdown(payload: dict[str, Any]) -> str:


### PR DESCRIPTION
## Summary
- implement the registry-boundary backend that the CLI imports
- classify project-local, global-local, and public fixture registry surfaces
- add a smoke covering the CLI import path and path-redacted boundary output

## Validation
- python3 examples/registry-boundary-contract-smoke.py
- python3 -m py_compile goal_harness/registry.py goal_harness/cli.py
- goal-harness --format json registry-boundary --require-gitignored
- python3 examples/agents-last-exam-task-material-readiness-smoke.py
- python3 examples/agents-last-exam-validation-run-gate-smoke.py
- python3 examples/agents-last-exam-local-docker-host-codex-route-smoke.py
- goal-harness check (existing duplicate-index warning only)