### PR TITLE
Add split-control readiness matrix

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/benchmark-split-control-remote-executor-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-split-control-remote-executor-v0.md
@@ -38,6 +38,14 @@ split-control gates:
 - remote node runtime missing only when a specific runner declares that it
   requires remote Node/npm.
 
+The gate is a matrix, not a single all-or-nothing flag. When at least one
+benchmark family is ready, `readiness_matrix.next_ready_batch_benchmark_ids`
+selects the bounded launch subset while `readiness_matrix.next_repair_target`
+names the first blocked family to repair. This lets the controller run a small
+parallel batch such as Terminal-Bench plus SkillsBench while ALE remains
+task-data-gated, without pretending the whole three-benchmark rotation is
+ready.
+
 ## Current Use
 
 The same route applies to the three active benchmark families:
@@ -60,4 +68,6 @@ python3 examples/benchmark-split-control-remote-executor-smoke.py
 ```
 
 The smoke asserts that missing remote Codex/Codex-ACP is non-blocking, while
-adapter, runner-tooling, and task-data blockers remain explicit.
+adapter, runner-tooling, and task-data blockers remain explicit. It also checks
+that a partial-ready route can produce a launchable subset plus a concrete
+repair target.

--- a/examples/benchmark-split-control-remote-executor-smoke.py
+++ b/examples/benchmark-split-control-remote-executor-smoke.py
@@ -142,9 +142,76 @@ def test_ready_parallel_batch_size_is_capped() -> None:
     assert_public_safe(payload)
 
 
+def test_partial_ready_subset_can_launch_without_remote_codex() -> None:
+    payload = build_split_control_remote_executor_readiness(
+        max_parallel_cases=4,
+        local_agent={
+            "codex_cli_available": True,
+            "goal_harness_available": True,
+            "codex_auth_ready": True,
+            "codex_auth_local_only": True,
+            "model_invocation_local": True,
+        },
+        remote_executor={
+            "docker_available": True,
+            "python_available": True,
+            "git_available": True,
+            "rsync_available": True,
+            "codex_available": False,
+            "codex_acp_available": False,
+        },
+        adapter_readiness={
+            "terminal-bench@2.0": {
+                "split_control_adapter_ready": True,
+                "runner_tooling_ready": True,
+                "task_data_ready": True,
+            },
+            "skillsbench@1.1": {
+                "split_control_adapter_ready": True,
+                "runner_tooling_ready": True,
+                "task_data_ready": True,
+            },
+            "agents-last-exam@local-docker": {
+                "split_control_adapter_ready": True,
+                "runner_tooling_ready": True,
+                "task_data_ready": False,
+                "known_blockers": ["ale_task_data_staging_venue_missing"],
+            },
+        },
+    )
+    assert payload["ready"] is False, payload
+    assert payload["first_blocker"] == "remote_task_data_or_image_missing", payload
+    assert payload["next_action"] == "launch bounded parallel remote-executor batch", payload
+    matrix = payload["readiness_matrix"]
+    assert matrix["has_launchable_subset"] is True, payload
+    assert matrix["ready_benchmark_ids"] == [
+        "terminal-bench@2.0",
+        "skillsbench@1.1",
+    ], payload
+    assert matrix["blocked_benchmark_ids"] == [
+        "agents-last-exam@local-docker"
+    ], payload
+    assert matrix["next_ready_batch_benchmark_ids"] == [
+        "terminal-bench@2.0",
+        "skillsbench@1.1",
+    ], payload
+    assert matrix["next_repair_target"] == {
+        "benchmark_id": "agents-last-exam@local-docker",
+        "first_blocker": "remote_task_data_or_image_missing",
+        "blockers": [
+            "remote_task_data_or_image_missing",
+            "ale_task_data_staging_venue_missing",
+        ],
+    }, payload
+    assert payload["parallel_policy"]["suggested_next_batch_size"] == 2, payload
+    assert payload["remote_executor"]["remote_agent_components_blocking"] is False, payload
+    assert_public_safe(payload)
+
+
 def main() -> int:
     test_remote_codex_is_not_required_for_split_control()
     test_ready_parallel_batch_size_is_capped()
+    test_partial_ready_subset_can_launch_without_remote_codex()
     print("benchmark-split-control-remote-executor-smoke: ok")
     return 0
 

--- a/goal_harness/benchmark_core/split_control.py
+++ b/goal_harness/benchmark_core/split_control.py
@@ -138,6 +138,28 @@ def build_split_control_remote_executor_readiness(
         )
         for benchmark_id in benchmark_ids
     ]
+    ready_benchmark_ids = [
+        item["benchmark_id"]
+        for item in statuses
+        if item["ready_for_split_control_execution"]
+    ]
+    blocked_benchmark_ids = [
+        item["benchmark_id"]
+        for item in statuses
+        if not item["ready_for_split_control_execution"]
+    ]
+    next_repair = next(
+        (
+            {
+                "benchmark_id": item["benchmark_id"],
+                "first_blocker": item["first_blocker"],
+                "blockers": item["blockers"],
+            }
+            for item in statuses
+            if not item["ready_for_split_control_execution"]
+        ),
+        None,
+    )
 
     if not local_agent_ready:
         first_blocker = "local_agent_not_ready"
@@ -154,7 +176,8 @@ def build_split_control_remote_executor_readiness(
     else:
         first_blocker = "ready_for_parallel_remote_executor_rotation"
 
-    ready_count = sum(1 for item in statuses if item["ready_for_split_control_execution"])
+    ready_count = len(ready_benchmark_ids)
+    max_parallel = max(1, int(max_parallel_cases))
     remote_agent_missing = {
         key: not _truthy(remote.get(key)) for key in REMOTE_AGENT_COMPONENT_FACTS
     }
@@ -195,9 +218,17 @@ def build_split_control_remote_executor_readiness(
             "remote_agent_components_blocking": False,
         },
         "benchmark_statuses": statuses,
+        "readiness_matrix": {
+            "ready_benchmark_ids": ready_benchmark_ids,
+            "blocked_benchmark_ids": blocked_benchmark_ids,
+            "next_ready_batch_benchmark_ids": ready_benchmark_ids[:max_parallel],
+            "next_repair_target": next_repair,
+            "has_launchable_subset": bool(ready_benchmark_ids),
+            "all_requested_benchmarks_ready": ready_count == len(statuses),
+        },
         "parallel_policy": {
-            "max_parallel_cases": max(1, int(max_parallel_cases)),
-            "suggested_next_batch_size": min(max(1, int(max_parallel_cases)), ready_count),
+            "max_parallel_cases": max_parallel,
+            "suggested_next_batch_size": min(max_parallel, ready_count),
             "parallelize_only_ready_benchmarks": True,
         },
         "boundary": {


### PR DESCRIPTION
## Summary
- extend the split-control remote executor gate with a readiness matrix: ready benchmarks, blocked benchmarks, next ready subset, and next repair target
- keep missing remote Codex/Codex-ACP non-blocking while allowing partial-ready Terminal/Skills batches to launch when ALE is still task-data-gated
- update the contract doc and smoke coverage

## Validation
- python3 examples/benchmark-split-control-remote-executor-smoke.py
- python3 -m py_compile goal_harness/benchmark_core/split_control.py examples/benchmark-split-control-remote-executor-smoke.py
- git diff --cached --check
- git diff --check
- goal-harness check

## Excluded
- no remote commands, credentials, task bodies, raw logs, trajectories, verifier output, uploads, or private/local state.