### PR TITLE
Improve first project onboarding flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,10 +178,19 @@ Then:
    name); otherwise ask me for a one-sentence objective.
 4. Run `goal-harness connect` or `goal-harness bootstrap` for this repo with
    that goal id, objective, domain, and goal doc.
-5. Ensure `.goal-harness/` and `.codex/goals/` are ignored in this project.
-6. Run `goal-harness registry`, `goal-harness status`, and
+5. Read the `Onboarding Scan`, `Proposed Onboarding Candidates`,
+   `Accept Candidate Commands`, and `Autonomy Choice` from the connect output.
+   Briefly explain the candidate agent todos to me and ask:
+   - which candidates I accept, edit, or reject;
+   - whether `autonomous=yes`, meaning you may start the first accepted agent
+     todo after the quota guard passes.
+   Do not make me run the acceptance commands manually; run the accepted
+   `goal-harness todo add ...` commands yourself. If I choose
+   `autonomous=no`, stop after `goal-harness refresh-state`.
+6. Ensure `.goal-harness/` and `.codex/goals/` are ignored in this project.
+7. Run `goal-harness registry`, `goal-harness status`, and
    `goal-harness check --scan-root .`.
-7. Report the goal id, created files, current user todo, current agent todo,
+8. Report the goal id, created files, current user todo, current agent todo,
    and next safe action.
 
 Do not commit `.goal-harness/`, `.codex/goals/`, live ACTIVE_GOAL_STATE files,

--- a/docs/new-project-codex-prompt.md
+++ b/docs/new-project-codex-prompt.md
@@ -43,6 +43,13 @@ goal-harness new-project-prompt \
 
 请你按下面步骤推进，不要停在方案讨论：
 
+重要：`goal-harness connect` 默认会做一次快速 onboarding scan，基于 git status、
+最近 commit、顶层项目信号生成候选 agent todo。接入后不要直接开始 delivery；
+先把候选 todo 展示给我，并问我两件事：
+
+1. 接受、编辑或拒绝哪些候选 agent todo；
+2. 是否允许你从接受的 todo 开始自主推进。
+
 0. 先确认当前 shell 能调用 Goal Harness CLI；如果提示 `goal-harness`
    不在 PATH，运行本机安装脚本再继续：
 
@@ -94,6 +101,16 @@ goal-harness new-project-prompt \
 
 3. 确认 `.goal-harness/registry.json` 和
    `.codex/goals/<STABLE_GOAL_ID>/ACTIVE_GOAL_STATE.md` 已创建或更新。
+   阅读输出里的 `Onboarding Scan`、`Proposed Onboarding Candidates`、
+   `Accept Candidate Commands` 和 `Autonomy Choice`。不要让我手动执行这些命令；
+   你应当用中文简要解释候选 todo，然后询问：
+   - 接受哪些编号，是否需要改写；
+   - 是否 `autonomous=yes`，允许你在 quota guard 通过后开始执行第一个接受的
+     agent todo。
+   如果我接受候选 todo，用输出里的 `goal-harness todo add ...` 命令写入
+   agent todo；如果我允许自主推进，先运行 quota guard，再执行第一个已接受
+   agent todo。如果我不允许自主推进，只写入接受的 todo 并运行
+   `goal-harness refresh-state --goal-id <STABLE_GOAL_ID>`，然后停下来汇报。
    如果目标状态包含私有证据，把 `.goal-harness/` 和 `.codex/goals/`
    加入该项目 `.gitignore`。
    `goal-harness connect` 默认会同步到共享全局 registry；不要手动编辑其他

--- a/examples/onboarding-connect-candidates-smoke.py
+++ b/examples/onboarding-connect-candidates-smoke.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Smoke-test first-connect onboarding scan and todo candidate projection."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from goal_harness.onboarding import ONBOARDING_SCAN_SCHEMA_VERSION  # noqa: E402
+from goal_harness.status import parse_active_state_todos  # noqa: E402
+
+
+def run(*args: str, cwd: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [*args],
+        cwd=cwd,
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def run_cli(*args: str) -> dict:
+    result = subprocess.run(
+        [sys.executable, "-m", "goal_harness.cli", "--format", "json", *args],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def make_project(root: Path, name: str) -> Path:
+    project = root / name
+    project.mkdir()
+    (project / "README.md").write_text("# Fixture Project\n\nInitial goal.\n", encoding="utf-8")
+    (project / "pyproject.toml").write_text(
+        "[project]\nname = \"fixture-project\"\nversion = \"0.1.0\"\n",
+        encoding="utf-8",
+    )
+    run("git", "init", cwd=project)
+    run("git", "add", "README.md", "pyproject.toml", cwd=project)
+    run(
+        "git",
+        "-c",
+        "user.email=goal-harness-smoke@example.com",
+        "-c",
+        "user.name=Goal Harness Smoke",
+        "commit",
+        "-m",
+        "Initial fixture project",
+        cwd=project,
+    )
+    with (project / "README.md").open("a", encoding="utf-8") as f:
+        f.write("\nPending local change.\n")
+    return project
+
+
+def state_text(project: Path, goal_id: str) -> str:
+    return (project / ".codex" / "goals" / goal_id / "ACTIVE_GOAL_STATE.md").read_text(encoding="utf-8")
+
+
+def action_kinds(items: list[dict]) -> set[str]:
+    return {str(item.get("action_kind") or "") for item in items}
+
+
+def assert_default_onboarding(project: Path, runtime: Path) -> None:
+    goal_id = "onboarding-smoke-default"
+    payload = run_cli(
+        "--runtime-root",
+        str(runtime),
+        "bootstrap",
+        "--project",
+        str(project),
+        "--goal-id",
+        goal_id,
+        "--objective",
+        "Exercise onboarding candidate projection.",
+        "--goal-doc",
+        "README.md",
+        "--no-global-sync",
+    )
+    assert payload["ok"] is True, payload
+    scan = payload["onboarding_scan"]
+    assert scan["schema_version"] == ONBOARDING_SCAN_SCHEMA_VERSION, scan
+    assert scan["is_git_repo"] is True, scan
+    assert scan["status_path_count"] >= 1, scan
+    assert scan["recent_commits"], scan
+    assert "README.md" in scan["signal_files"], scan
+    assert any(item["path"] == "pyproject.toml" for item in scan["validation_signal_files"]), scan
+    assert scan["scan_policy"]["raw_file_bodies_read"] is False, scan
+    candidates = payload["onboarding_agent_todo_candidates"]
+    candidate_kinds = {candidate["action_kind"] for candidate in candidates}
+    assert "repo_status_review" in candidate_kinds, candidates
+    assert "commit_summary" in candidate_kinds, candidates
+    assert "validation_plan" in candidate_kinds, candidates
+    assert payload["onboarding_acceptance_required"] is True, payload
+    assert payload["autonomous_advance_choice_required"] is True, payload
+    assert payload["onboarding_todos_written"] is True, payload
+    assert len(payload["accept_candidate_commands"]) == len(candidates), payload
+
+    registry_path = project / ".goal-harness" / "registry.json"
+    status_payload = run_cli("--registry", str(registry_path), "status")
+    status_item = status_payload["attention_queue"]["items"][0]
+    assert "Present the onboarding scan" in status_item["recommended_action"], status_item
+    assert "Present the onboarding scan" in status_item["project_asset"]["next_action"], status_item
+    assert status_item["user_todos"]["open_count"] == 1, status_item
+    assert status_item["agent_todos"]["open_count"] == 1, status_item
+
+    quota_payload = run_cli("--registry", str(registry_path), "quota", "should-run", "--goal-id", goal_id)
+    assert quota_payload["should_run"] is True, quota_payload
+    assert quota_payload["requires_user_action"] is True, quota_payload
+    assert "Present the onboarding scan" in quota_payload["recommended_action"], quota_payload
+    assert quota_payload["user_todo_summary"]["open_count"] == 1, quota_payload
+    assert quota_payload["agent_todo_summary"]["open_count"] == 1, quota_payload
+
+    text = state_text(project, goal_id)
+    assert "## Onboarding Control" in text, text
+    assert "## Proposed Onboarding Candidates" in text, text
+    assert "Candidate agent todos: `requires user selection before delivery work`" in text, text
+    assert "Autonomous advancement: `requires an explicit user yes/no choice`" in text, text
+    assert "## User Todo / Owner Review Reading Queue" in text, text
+    assert "## Agent Todo" in text, text
+    assert "accepted numbers plus autonomous=yes/no" in text, text
+
+    todos = parse_active_state_todos(text)
+    user_items = todos.get("user_todos", {}).get("items", [])
+    agent_items = todos["agent_todos"]["items"]
+    assert len(user_items) == 1, user_items
+    assert len(agent_items) == 1, agent_items
+    assert action_kinds(user_items) == {"onboarding_decision"}, user_items
+    assert action_kinds(agent_items) == {"onboarding_todo_review"}, agent_items
+
+
+def assert_preauthorized_onboarding(project: Path, runtime: Path) -> None:
+    goal_id = "onboarding-smoke-preauth"
+    payload = run_cli(
+        "--runtime-root",
+        str(runtime),
+        "bootstrap",
+        "--project",
+        str(project),
+        "--goal-id",
+        goal_id,
+        "--objective",
+        "Exercise preauthorized onboarding candidate projection.",
+        "--goal-doc",
+        "README.md",
+        "--accept-onboarding-agent-todos",
+        "--begin-autonomous-advance",
+        "--no-global-sync",
+    )
+    assert payload["ok"] is True, payload
+    assert payload["onboarding_acceptance_required"] is False, payload
+    assert payload["autonomous_advance_choice_required"] is False, payload
+    text = state_text(project, goal_id)
+    assert "Candidate agent todos: `accepted and written into Agent Todo`" in text, text
+    assert "Autonomous advancement: `allowed after accepted agent todos and a fresh quota guard`" in text, text
+    assert "Choose which proposed onboarding agent todos" not in text, text
+
+    todos = parse_active_state_todos(text)
+    user_items = todos.get("user_todos", {}).get("items", [])
+    agent_items = todos["agent_todos"]["items"]
+    assert user_items == [], user_items
+    assert len(agent_items) == len(payload["onboarding_agent_todo_candidates"]), agent_items
+    kinds = action_kinds(agent_items)
+    assert "repo_status_review" in kinds, agent_items
+    assert "commit_summary" in kinds, agent_items
+    assert "validation_plan" in kinds, agent_items
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="goal-harness-onboarding-smoke-") as tmp:
+        root = Path(tmp)
+        runtime = root / "runtime"
+        project = make_project(root, "fixture-project")
+        assert_default_onboarding(project, runtime)
+        assert_preauthorized_onboarding(project, runtime)
+
+    print("onboarding-connect-candidates-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/goal_harness/bootstrap.py
+++ b/goal_harness/bootstrap.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import re
+import shlex
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -12,11 +13,13 @@ from .execution_profile import (
     execution_profile_summary,
 )
 from .global_registry import sync_project_registry_to_global
+from .onboarding import build_onboarding_scan
 from .orchestration import (
     DEFAULT_ORCHESTRATION_MODE,
     MULTI_SUBAGENT_ORCHESTRATION_MODE,
 )
 from .paths import DEFAULT_RUNTIME_ROOT, rel_or_abs
+from .todos import add_todo_to_lines
 
 
 DEFAULT_OBJECTIVE = "Improve this project through bounded, verified goal segments."
@@ -64,6 +67,204 @@ def render_authority_sources(project: Path, goal_doc: Path | None) -> str:
     return f"- Primary goal document: `{rel_or_abs(goal_doc, project)}`"
 
 
+def onboarding_candidates(onboarding_scan: dict[str, Any] | None) -> list[dict[str, Any]]:
+    if not isinstance(onboarding_scan, dict):
+        return []
+    candidates = onboarding_scan.get("agent_todo_candidates")
+    if not isinstance(candidates, list):
+        return []
+    return [candidate for candidate in candidates if isinstance(candidate, dict)]
+
+
+def render_onboarding_state_markdown(
+    *,
+    onboarding_scan: dict[str, Any] | None,
+    accept_onboarding_agent_todos: bool,
+    begin_autonomous_advance: bool,
+) -> str:
+    if not onboarding_scan:
+        return ""
+    scan_policy = onboarding_scan.get("scan_policy")
+    scan_policy = scan_policy if isinstance(scan_policy, dict) else {}
+    recent_commits = onboarding_scan.get("recent_commits")
+    recent_commits = recent_commits if isinstance(recent_commits, list) else []
+    signal_files = onboarding_scan.get("signal_files")
+    signal_files = signal_files if isinstance(signal_files, list) else []
+    validation_files = onboarding_scan.get("validation_signal_files")
+    validation_files = validation_files if isinstance(validation_files, list) else []
+    validation_paths = [
+        str(item.get("path"))
+        for item in validation_files
+        if isinstance(item, dict) and item.get("path")
+    ]
+    acceptance_status = (
+        "accepted and written into Agent Todo"
+        if accept_onboarding_agent_todos
+        else "requires user selection before delivery work"
+    )
+    autonomous_status = (
+        "allowed after accepted agent todos and a fresh quota guard"
+        if begin_autonomous_advance
+        else "requires an explicit user yes/no choice"
+    )
+    lines = [
+        "## Onboarding Control",
+        "",
+        "- Fast repository scan: `enabled`.",
+        f"- Scan read file bodies: `{bool(scan_policy.get('raw_file_bodies_read'))}`.",
+        f"- Git repo detected: `{bool(onboarding_scan.get('is_git_repo'))}`.",
+        f"- Local change count from `git status --short`: `{int(onboarding_scan.get('status_path_count') or 0)}`.",
+        f"- Recent commits sampled: `{len(recent_commits)}`.",
+        f"- Project signal files: `{', '.join(str(item) for item in signal_files) or 'none'}`.",
+        f"- Validation signal files: `{', '.join(validation_paths) or 'none'}`.",
+        f"- Candidate agent todos: `{acceptance_status}`.",
+        f"- Autonomous advancement: `{autonomous_status}`.",
+        "",
+        "## Proposed Onboarding Candidates",
+        "",
+    ]
+    candidates = onboarding_candidates(onboarding_scan)
+    for index, candidate in enumerate(candidates, start=1):
+        text = str(candidate.get("text") or "").strip()
+        reason = str(candidate.get("reason") or "").strip()
+        action_kind = str(candidate.get("action_kind") or "analyze").strip()
+        task_class = str(candidate.get("task_class") or "advancement_task").strip()
+        lines.append(f"{index}. {text}")
+        if reason:
+            lines.append(f"   - reason: {reason}")
+        lines.append(f"   - metadata: `{task_class}:{action_kind}`")
+    if not candidates:
+        lines.append("No candidate agent todos were generated.")
+    return "\n".join(lines)
+
+
+def onboarding_user_todo_text(
+    *,
+    acceptance_required: bool,
+    autonomous_choice_required: bool,
+) -> str | None:
+    if acceptance_required and autonomous_choice_required:
+        return (
+            "[P1] Choose which proposed onboarding agent todos to accept and whether Codex may "
+            "start autonomous advancement; reply with accepted numbers plus autonomous=yes/no."
+        )
+    if acceptance_required:
+        return (
+            "[P1] Choose which proposed onboarding agent todos to accept; autonomous advancement "
+            "is already allowed after accepted todos are written and quota permits."
+        )
+    if autonomous_choice_required:
+        return (
+            "[P1] Decide whether Codex may start autonomous advancement now that onboarding "
+            "agent todos were accepted; reply autonomous=yes/no."
+        )
+    return None
+
+
+def onboarding_agent_review_todo_text(
+    *,
+    acceptance_required: bool,
+    autonomous_choice_required: bool,
+) -> str | None:
+    if not acceptance_required and not autonomous_choice_required:
+        return None
+    if acceptance_required and autonomous_choice_required:
+        return (
+            "[P1] Present the onboarding scan, ask which candidate agent todos to accept, "
+            "and ask whether autonomous advancement may start before delivery work."
+        )
+    if acceptance_required:
+        return (
+            "[P1] Present the onboarding scan and ask which candidate agent todos to accept "
+            "before starting the pre-authorized autonomous advancement path."
+        )
+    return (
+        "[P1] Ask whether autonomous advancement may start from the accepted onboarding "
+        "agent todos before delivery work."
+    )
+
+
+def onboarding_next_action(
+    *,
+    onboarding_scan: dict[str, Any] | None,
+    accept_onboarding_agent_todos: bool,
+    begin_autonomous_advance: bool,
+) -> str:
+    if not onboarding_scan:
+        return "Run `goal-harness check` against the project registry and decide the first project-specific adapter signal."
+    if not accept_onboarding_agent_todos:
+        if begin_autonomous_advance:
+            return (
+                "Ask the user which proposed onboarding agent todos to accept; once accepted, run the quota guard "
+                "and begin the first accepted todo because autonomous advancement was pre-authorized."
+            )
+        return (
+            "Show the proposed onboarding agent todos, ask which to accept, ask whether Codex may start autonomous "
+            "advancement, then write accepted todos and refresh state before any delivery work."
+        )
+    if not begin_autonomous_advance:
+        return (
+            "Ask whether Codex may start autonomous advancement; if yes, run the quota guard and execute the first "
+            "accepted onboarding agent todo, otherwise stop after refresh-state."
+        )
+    return (
+        "Run the quota guard, execute the first accepted onboarding Agent Todo as a bounded segment, write evidence, "
+        "complete or update the todo, and refresh state."
+    )
+
+
+def apply_onboarding_todos_to_state(
+    text: str,
+    *,
+    onboarding_scan: dict[str, Any] | None,
+    accept_onboarding_agent_todos: bool,
+    begin_autonomous_advance: bool,
+) -> str:
+    if not onboarding_scan:
+        return text
+    lines = text.splitlines()
+    if accept_onboarding_agent_todos:
+        for candidate in onboarding_candidates(onboarding_scan):
+            todo_text = str(candidate.get("text") or "").strip()
+            if not todo_text:
+                continue
+            add_todo_to_lines(
+                lines,
+                role="agent",
+                text=todo_text,
+                task_class=str(candidate.get("task_class") or "advancement_task"),
+                action_kind=str(candidate.get("action_kind") or "analyze"),
+            )
+
+    acceptance_required = not accept_onboarding_agent_todos
+    autonomous_choice_required = not begin_autonomous_advance
+    user_todo = onboarding_user_todo_text(
+        acceptance_required=acceptance_required,
+        autonomous_choice_required=autonomous_choice_required,
+    )
+    if user_todo:
+        add_todo_to_lines(
+            lines,
+            role="user",
+            text=user_todo,
+            task_class="user_gate",
+            action_kind="onboarding_decision",
+        )
+    agent_todo = onboarding_agent_review_todo_text(
+        acceptance_required=acceptance_required,
+        autonomous_choice_required=autonomous_choice_required,
+    )
+    if agent_todo:
+        add_todo_to_lines(
+            lines,
+            role="agent",
+            text=agent_todo,
+            task_class="advancement_task",
+            action_kind="onboarding_todo_review",
+        )
+    return "\n".join(lines) + "\n"
+
+
 def render_state_markdown(
     *,
     project: Path,
@@ -72,10 +273,24 @@ def render_state_markdown(
     updated_at: str,
     goal_doc: Path | None,
     execution_profile: dict[str, Any] | None,
+    onboarding_scan: dict[str, Any] | None = None,
+    accept_onboarding_agent_todos: bool = False,
+    begin_autonomous_advance: bool = False,
 ) -> str:
     safe_objective = objective.replace('"', '\\"')
     profile_summary = execution_profile_summary(execution_profile)
-    return f"""---
+    onboarding_markdown = render_onboarding_state_markdown(
+        onboarding_scan=onboarding_scan,
+        accept_onboarding_agent_todos=accept_onboarding_agent_todos,
+        begin_autonomous_advance=begin_autonomous_advance,
+    )
+    onboarding_block = f"\n{onboarding_markdown}\n" if onboarding_markdown else ""
+    next_action = onboarding_next_action(
+        onboarding_scan=onboarding_scan,
+        accept_onboarding_agent_todos=accept_onboarding_agent_todos,
+        begin_autonomous_advance=begin_autonomous_advance,
+    )
+    state_text = f"""---
 status: active
 owner_mode: goal
 objective: "{safe_objective}"
@@ -112,10 +327,11 @@ adapter_id: {goal_id}
 - Do not perform irreversible production operations without explicit approval.
 - Do not publish private project evidence.
 - Do not optimize for activity if no useful artifact or decision can be produced.
+{onboarding_block}
 
 ## Next Action
 
-- Run `goal-harness check` against the project registry and decide the first project-specific adapter signal.
+- {next_action}
 
 ## Recent User Feedback
 
@@ -125,10 +341,33 @@ adapter_id: {goal_id}
 
 - Created the initial goal state and registry connection.
 """
+    return apply_onboarding_todos_to_state(
+        state_text,
+        onboarding_scan=onboarding_scan,
+        accept_onboarding_agent_todos=accept_onboarding_agent_todos,
+        begin_autonomous_advance=begin_autonomous_advance,
+    )
 
 
 def relative_state_file(project: Path, state_file: Path) -> str:
     return rel_or_abs(state_file, project)
+
+
+def todo_add_command(
+    *,
+    project: Path,
+    registry_path: Path,
+    goal_id: str,
+    candidate: dict[str, Any],
+) -> str:
+    return (
+        f"goal-harness --registry {shlex.quote(relative_state_file(project, registry_path))} todo add "
+        f"--goal-id {shlex.quote(goal_id)} "
+        "--role agent "
+        f"--text {shlex.quote(str(candidate.get('text') or ''))} "
+        f"--task-class {shlex.quote(str(candidate.get('task_class') or 'advancement_task'))} "
+        f"--action-kind {shlex.quote(str(candidate.get('action_kind') or 'analyze'))}"
+    )
 
 
 def build_goal_entry(
@@ -253,6 +492,12 @@ def bootstrap_project(
     execution_surface_only_hints: list[str] | None = None,
     execution_surface_streak_threshold: int | None = None,
     execution_outcome_must_advance: list[str] | None = None,
+    onboarding_scan_enabled: bool = True,
+    accept_onboarding_agent_todos: bool = False,
+    begin_autonomous_advance: bool = False,
+    onboarding_max_commits: int = 5,
+    onboarding_max_status_paths: int = 12,
+    onboarding_max_top_level_files: int = 24,
     force: bool,
     dry_run: bool,
     sync_global: bool,
@@ -277,6 +522,16 @@ def bootstrap_project(
         surface_only_hints=execution_surface_only_hints,
         surface_streak_threshold=execution_surface_streak_threshold,
         outcome_must_advance=execution_outcome_must_advance,
+    )
+    onboarding_scan = (
+        build_onboarding_scan(
+            project,
+            max_commits=onboarding_max_commits,
+            max_status_paths=onboarding_max_status_paths,
+            max_top_level_files=onboarding_max_top_level_files,
+        )
+        if onboarding_scan_enabled
+        else None
     )
 
     registry = read_json_if_exists(registry_path)
@@ -343,6 +598,9 @@ def bootstrap_project(
                     updated_at=updated_at,
                     goal_doc=goal_doc,
                     execution_profile=execution_profile,
+                    onboarding_scan=onboarding_scan,
+                    accept_onboarding_agent_todos=accept_onboarding_agent_todos,
+                    begin_autonomous_advance=begin_autonomous_advance,
                 ),
                 encoding="utf-8",
             )
@@ -354,6 +612,16 @@ def bootstrap_project(
                 dry_run=False,
             )
 
+    candidates = onboarding_candidates(onboarding_scan)
+    accept_candidate_commands = [
+        todo_add_command(
+            project=project,
+            registry_path=registry_path,
+            goal_id=goal_id,
+            candidate=candidate,
+        )
+        for candidate in candidates
+    ]
     return {
         "ok": True,
         "dry_run": dry_run,
@@ -367,6 +635,16 @@ def bootstrap_project(
         "registry_goal_action": registry_goal_action,
         "state_action": state_action,
         "execution_profile": execution_profile,
+        "onboarding_scan": onboarding_scan,
+        "onboarding_agent_todo_candidates": candidates,
+        "accept_onboarding_agent_todos": accept_onboarding_agent_todos,
+        "begin_autonomous_advance": begin_autonomous_advance,
+        "onboarding_acceptance_required": bool(onboarding_scan and not accept_onboarding_agent_todos),
+        "autonomous_advance_choice_required": bool(onboarding_scan and not begin_autonomous_advance),
+        "onboarding_todos_written": bool(
+            onboarding_scan and state_action in {"created", "replaced"} and not dry_run
+        ),
+        "accept_candidate_commands": accept_candidate_commands,
         "global_sync": global_sync
         or {
             "enabled": sync_global,
@@ -378,7 +656,10 @@ def bootstrap_project(
         "actions": actions,
         "next_commands": [
             f"goal-harness --registry {relative_state_file(project, registry_path)} registry",
+            f"goal-harness --registry {relative_state_file(project, registry_path)} status",
             f"goal-harness --registry {relative_state_file(project, registry_path)} check --scan-root {project}",
+            f"goal-harness --format json --registry {runtime_root / 'registry.global.json'} quota should-run --goal-id {goal_id}",
+            f"goal-harness --registry {relative_state_file(project, registry_path)} refresh-state --goal-id {goal_id}",
             f"goal-harness --registry {runtime_root / 'registry.global.json'} status",
             f"goal-harness --registry {relative_state_file(project, registry_path)} history --goal-id {goal_id}",
         ],
@@ -408,12 +689,85 @@ def render_bootstrap_markdown(payload: dict[str, Any]) -> str:
         f"- registry_goal_action: `{payload.get('registry_goal_action')}`",
         f"- state_action: `{payload.get('state_action')}`",
         f"- execution_profile: `{execution_profile_text}`",
+        f"- onboarding_acceptance_required: `{payload.get('onboarding_acceptance_required')}`",
+        f"- autonomous_advance_choice_required: `{payload.get('autonomous_advance_choice_required')}`",
+        f"- onboarding_todos_written: `{payload.get('onboarding_todos_written')}`",
         f"- global_sync: `{(payload.get('global_sync') or {}).get('wrote')}`",
         "",
         "## Actions",
     ]
     for action in payload.get("actions") or []:
         lines.append(f"- `{action.get('path')}`: {action.get('action')} ({action.get('goal', '')})")
+
+    onboarding_scan = payload.get("onboarding_scan")
+    if isinstance(onboarding_scan, dict):
+        recent_commits = onboarding_scan.get("recent_commits")
+        recent_commits = recent_commits if isinstance(recent_commits, list) else []
+        signal_files = onboarding_scan.get("signal_files")
+        signal_files = signal_files if isinstance(signal_files, list) else []
+        status_sample = onboarding_scan.get("status_paths_sample")
+        status_sample = status_sample if isinstance(status_sample, list) else []
+        lines.extend(
+            [
+                "",
+                "## Onboarding Scan",
+                f"- schema: `{onboarding_scan.get('schema_version')}`",
+                f"- git_repo: `{onboarding_scan.get('is_git_repo')}`",
+                f"- status_path_count: `{onboarding_scan.get('status_path_count')}`",
+                f"- recent_commits: `{len(recent_commits)}`",
+                f"- signal_files: `{', '.join(str(item) for item in signal_files) or 'none'}`",
+                "- raw_file_bodies_read: `False`",
+            ]
+        )
+        if status_sample:
+            lines.append("- status_sample:")
+            for item in status_sample[:5]:
+                lines.append(f"  - `{item}`")
+        if recent_commits:
+            lines.append("- recent_commit_sample:")
+            for commit in recent_commits[:5]:
+                if isinstance(commit, dict):
+                    lines.append(f"  - `{commit.get('hash')}` {commit.get('subject')}")
+
+    candidates = payload.get("onboarding_agent_todo_candidates")
+    candidates = candidates if isinstance(candidates, list) else []
+    if candidates:
+        lines.extend(["", "## Proposed Onboarding Candidates"])
+        for index, candidate in enumerate(candidates, start=1):
+            if not isinstance(candidate, dict):
+                continue
+            lines.append(f"{index}. {candidate.get('text')}")
+            if candidate.get("reason"):
+                lines.append(f"   - reason: {candidate.get('reason')}")
+            lines.append(
+                "   - metadata: "
+                f"`{candidate.get('task_class') or 'advancement_task'}:{candidate.get('action_kind') or 'analyze'}`"
+            )
+
+    accept_commands = payload.get("accept_candidate_commands")
+    accept_commands = accept_commands if isinstance(accept_commands, list) else []
+    if accept_commands:
+        lines.extend(
+            [
+                "",
+                "## Accept Candidate Commands",
+                "Run only the commands for candidates the user accepts, then refresh state.",
+            ]
+        )
+        for command in accept_commands:
+            lines.append(f"- `{command}`")
+
+    if onboarding_scan:
+        lines.extend(
+            [
+                "",
+                "## Autonomy Choice",
+                (
+                    "- Ask the user whether Codex may start autonomous advancement. If yes, run the quota guard "
+                    "and execute the first accepted Agent Todo; if no, stop after writing accepted todos and refresh-state."
+                ),
+            ]
+        )
 
     lines.extend(["", "## Next Commands"])
     for command in payload.get("next_commands") or []:

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -1636,6 +1636,39 @@ def main(argv: list[str] | None = None) -> int:
         default=[],
         help="Outcome/evidence floor label that future delivery must advance. Repeatable.",
     )
+    bootstrap_parser.add_argument(
+        "--no-onboarding-scan",
+        action="store_true",
+        help="Skip the fast first-connect repository scan and todo candidate proposal.",
+    )
+    bootstrap_parser.add_argument(
+        "--accept-onboarding-agent-todos",
+        action="store_true",
+        help="Write all proposed onboarding agent todos into the initial active state.",
+    )
+    bootstrap_parser.add_argument(
+        "--begin-autonomous-advance",
+        action="store_true",
+        help="Record that Codex may begin from accepted onboarding agent todos after the quota guard permits work.",
+    )
+    bootstrap_parser.add_argument(
+        "--onboarding-max-commits",
+        type=int,
+        default=5,
+        help="Maximum recent commits sampled by the fast onboarding scan.",
+    )
+    bootstrap_parser.add_argument(
+        "--onboarding-max-status-paths",
+        type=int,
+        default=12,
+        help="Maximum git status lines sampled by the fast onboarding scan.",
+    )
+    bootstrap_parser.add_argument(
+        "--onboarding-max-top-level-files",
+        type=int,
+        default=24,
+        help="Maximum top-level names sampled by the fast onboarding scan.",
+    )
     bootstrap_parser.add_argument("--force", action="store_true", help="Replace existing goal entry or state file.")
     bootstrap_parser.add_argument("--dry-run", action="store_true", help="Show planned writes without changing files.")
     bootstrap_parser.add_argument(
@@ -4953,6 +4986,12 @@ def main(argv: list[str] | None = None) -> int:
                 execution_surface_only_hints=args.execution_surface_only_hint or None,
                 execution_surface_streak_threshold=args.execution_surface_streak_threshold,
                 execution_outcome_must_advance=args.execution_outcome_must_advance or None,
+                onboarding_scan_enabled=not bool(args.no_onboarding_scan),
+                accept_onboarding_agent_todos=bool(args.accept_onboarding_agent_todos),
+                begin_autonomous_advance=bool(args.begin_autonomous_advance),
+                onboarding_max_commits=args.onboarding_max_commits,
+                onboarding_max_status_paths=args.onboarding_max_status_paths,
+                onboarding_max_top_level_files=args.onboarding_max_top_level_files,
                 force=args.force,
                 dry_run=args.dry_run,
                 sync_global=not bool(args.no_global_sync),

--- a/goal_harness/demo.py
+++ b/goal_harness/demo.py
@@ -70,6 +70,7 @@ def run_demo(
         allowed_domains=[],
         write_scope=[],
         claim_ttl_minutes=30,
+        onboarding_scan_enabled=False,
         force=False,
         dry_run=False,
         sync_global=False,

--- a/goal_harness/onboarding.py
+++ b/goal_harness/onboarding.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+
+ONBOARDING_SCAN_SCHEMA_VERSION = "goal_harness_project_onboarding_v0"
+
+PROJECT_SIGNAL_FILES = (
+    "GOAL.md",
+    "README.md",
+    "AGENTS.md",
+    "CONTRIBUTING.md",
+    "pyproject.toml",
+    "package.json",
+    "Cargo.toml",
+    "go.mod",
+    "Makefile",
+    "justfile",
+)
+
+VALIDATION_SIGNAL_FILES = {
+    "pyproject.toml": "python",
+    "package.json": "node",
+    "Cargo.toml": "rust",
+    "go.mod": "go",
+    "Makefile": "make",
+    "justfile": "just",
+}
+
+
+def _git(project: Path, *args: str, timeout_seconds: float = 1.5) -> subprocess.CompletedProcess[str] | None:
+    try:
+        return subprocess.run(
+            ["git", "-C", str(project), *args],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+
+
+def _git_lines(project: Path, *args: str, timeout_seconds: float = 1.5) -> list[str]:
+    result = _git(project, *args, timeout_seconds=timeout_seconds)
+    if result is None or result.returncode != 0:
+        return []
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def _is_git_repo(project: Path) -> bool:
+    result = _git(project, "rev-parse", "--is-inside-work-tree", timeout_seconds=1)
+    return bool(result and result.returncode == 0 and result.stdout.strip() == "true")
+
+
+def _top_level_files(project: Path, *, limit: int) -> list[str]:
+    names: list[str] = []
+    try:
+        for child in sorted(project.iterdir(), key=lambda path: path.name.lower()):
+            if child.name.startswith(".git"):
+                continue
+            suffix = "/" if child.is_dir() else ""
+            names.append(f"{child.name}{suffix}")
+            if len(names) >= limit:
+                break
+    except OSError:
+        return []
+    return names
+
+
+def _detected_signal_files(project: Path) -> list[str]:
+    return [name for name in PROJECT_SIGNAL_FILES if (project / name).exists()]
+
+
+def _recent_commits(project: Path, *, max_commits: int) -> list[dict[str, str]]:
+    lines = _git_lines(project, "log", f"--max-count={max(0, max_commits)}", "--pretty=format:%h%x09%s")
+    commits: list[dict[str, str]] = []
+    for line in lines:
+        if "\t" in line:
+            short_hash, subject = line.split("\t", 1)
+        else:
+            short_hash, subject = line, ""
+        commits.append({"hash": short_hash, "subject": subject})
+    return commits
+
+
+def _candidate(
+    *,
+    text: str,
+    task_class: str = "advancement_task",
+    action_kind: str = "analyze",
+    reason: str,
+) -> dict[str, str]:
+    return {
+        "text": " ".join(text.split()),
+        "task_class": task_class,
+        "action_kind": action_kind,
+        "reason": " ".join(reason.split()),
+    }
+
+
+def build_onboarding_scan(
+    project: Path,
+    *,
+    max_commits: int = 5,
+    max_status_paths: int = 12,
+    max_top_level_files: int = 24,
+) -> dict[str, Any]:
+    """Build a bounded, body-free scan for first-time project onboarding."""
+    project = project.expanduser().resolve()
+    is_git_repo = _is_git_repo(project)
+    status_paths = (
+        _git_lines(project, "status", "--short", "--untracked-files=normal", timeout_seconds=1.5)
+        if is_git_repo
+        else []
+    )
+    status_sample = status_paths[: max(0, max_status_paths)]
+    commits = _recent_commits(project, max_commits=max_commits) if is_git_repo else []
+    signal_files = _detected_signal_files(project)
+    validation_signal_files = [
+        {"path": path, "ecosystem": VALIDATION_SIGNAL_FILES[path]}
+        for path in signal_files
+        if path in VALIDATION_SIGNAL_FILES
+    ]
+    top_level_files = _top_level_files(project, limit=max(0, max_top_level_files))
+
+    candidates: list[dict[str, str]] = []
+    if status_sample:
+        sample = ", ".join(status_sample[:5])
+        candidates.append(
+            _candidate(
+                text=(
+                    f"[P1] Inspect current uncommitted changes ({sample}) and decide what belongs "
+                    "in the first Goal Harness segment before editing."
+                ),
+                action_kind="repo_status_review",
+                reason="The repo already has local changes, so the first safe step is ownership and scope classification.",
+            )
+        )
+    elif is_git_repo:
+        candidates.append(
+            _candidate(
+                text="[P1] Confirm the clean git baseline and record the first safe bounded segment before editing.",
+                action_kind="repo_status_review",
+                reason="The repo appears clean, so the agent can establish a baseline before selecting delivery work.",
+            )
+        )
+
+    if commits:
+        count = len(commits)
+        candidates.append(
+            _candidate(
+                text=f"[P1] Summarize the last {count} commits and extract the safest next bounded project follow-up.",
+                action_kind="commit_summary",
+                reason="Recent commits are a fast signal of current project direction without reading private bodies.",
+            )
+        )
+
+    if validation_signal_files:
+        files = ", ".join(item["path"] for item in validation_signal_files[:4])
+        candidates.append(
+            _candidate(
+                text=f"[P1] Identify the fastest validation command from {files} and record whether it is safe to run now.",
+                action_kind="validation_plan",
+                reason="Validation entrypoints are visible from top-level project metadata.",
+            )
+        )
+
+    if signal_files:
+        files = ", ".join(signal_files[:5])
+        candidates.append(
+            _candidate(
+                text=(
+                    f"[P2] Build a compact read-only project map from {files} and note authority sources, "
+                    "risks, and first useful handoff."
+                ),
+                action_kind="read_only_map",
+                reason="Top-level project files can seed a useful map before any implementation work.",
+            )
+        )
+
+    if not candidates:
+        candidates.append(
+            _candidate(
+                text="[P1] Do a bounded read-only repo intake and ask the user to confirm the first concrete delivery target.",
+                action_kind="repo_intake",
+                reason="No common project signals were found, so the safest first step is a narrow intake.",
+            )
+        )
+
+    return {
+        "schema_version": ONBOARDING_SCAN_SCHEMA_VERSION,
+        "project_label": project.name,
+        "is_git_repo": is_git_repo,
+        "status_path_count": len(status_paths),
+        "status_paths_sample": status_sample,
+        "recent_commits": commits,
+        "signal_files": signal_files,
+        "validation_signal_files": validation_signal_files,
+        "top_level_files_sample": top_level_files,
+        "agent_todo_candidates": candidates[:4],
+        "user_acceptance_required": True,
+        "scan_policy": {
+            "fast": True,
+            "max_commits": max_commits,
+            "max_status_paths": max_status_paths,
+            "max_top_level_files": max_top_level_files,
+            "raw_file_bodies_read": False,
+        },
+    }

--- a/goal_harness/project_prompt.py
+++ b/goal_harness/project_prompt.py
@@ -202,6 +202,10 @@ def render_prompt_text(
 {goal_doc}
 
 请你按下面步骤推进，不要停在方案讨论；如果信息缺失，先从目标文档和项目结构中做保守抽取，并在最后说明假设。
+重要：`goal-harness connect` 默认会做一次快速 onboarding scan，基于 git status、最近 commit、顶层项目信号生成候选 agent todo。
+接入后不要直接开始 delivery；先把候选 todo 展示给我，并问我两件事：
+1. 接受、编辑或拒绝哪些候选 agent todo；
+2. 是否允许你从接受的 todo 开始自主推进。
 
 0. 先确认当前 shell 能调用 Goal Harness CLI；如果提示 `goal-harness` 不在 PATH，运行本机安装脚本再继续：
 
@@ -236,6 +240,15 @@ def render_prompt_text(
 ```
 
 4. 确认 `.goal-harness/registry.json` 和 `.codex/goals/{goal_id}/ACTIVE_GOAL_STATE.md` 已创建或更新。
+   阅读输出里的 `Onboarding Scan`、`Proposed Onboarding Candidates`、`Accept Candidate Commands`
+   和 `Autonomy Choice`。不要让用户手动执行这些命令；你应当用中文简要解释候选 todo，
+   然后询问用户：
+   - 接受哪些编号，是否需要改写；
+   - 是否 `autonomous=yes`，允许你在 quota guard 通过后开始执行第一个接受的 agent todo。
+   如果用户接受候选 todo，用输出里的 `goal-harness todo add ...` 命令写入 agent todo；
+   如果用户允许自主推进，先运行 quota guard，再执行第一个已接受 agent todo。
+   如果用户不允许自主推进，只写入接受的 todo 并运行 `goal-harness refresh-state --goal-id {goal_id}`，
+   然后停下来汇报。
    如果目标状态包含私有证据，把 `.goal-harness/` 和 `.codex/goals/` 加入该项目 `.gitignore`。
    `goal-harness connect` 默认会同步到共享全局 registry；不要手动编辑其他项目的 registry。
    接入后检查 registry 里的 `execution_profile`：它是本项目后续 heartbeat / adapter 的执行画像。

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -5192,6 +5192,20 @@ def attention_item(
     return item
 
 
+def sync_connected_attention_action_from_todos(item: dict[str, Any]) -> None:
+    if item.get("status") != "connected_without_run":
+        return
+    agent_action = first_open_todo_text(
+        item.get("agent_todos") if isinstance(item.get("agent_todos"), dict) else None
+    )
+    if not agent_action:
+        return
+    item["recommended_action"] = agent_action
+    project_asset = item.get("project_asset")
+    if isinstance(project_asset, dict):
+        project_asset["next_action"] = agent_action
+
+
 def compact_global_registry_shadow_finding(finding: dict[str, Any]) -> dict[str, Any]:
     compact: dict[str, Any] = {
         "kind": str(finding.get("kind") or "global_registry_finding"),
@@ -5930,6 +5944,7 @@ def build_attention_queue(
                     item["project_asset"]["stale_latest_run_warning"] = projection_warning
             if goal.get("registry_member"):
                 item.update(active_state_todo_fields(goal))
+                sync_connected_attention_action_from_todos(item)
                 backlog_warning = (
                     item.get("backlog_hygiene_warning")
                     if isinstance(item.get("backlog_hygiene_warning"), dict)


### PR DESCRIPTION
## Summary

- add a fast first-connect onboarding scan that samples git status, recent commits, and top-level project signals without reading file bodies
- project bootstrap/connect now writes proposed onboarding candidates, a user acceptance/autonomy gate, and an agent todo to present the candidates before delivery work
- add preauthorization flags for accepting onboarding agent todos and allowing autonomous advancement after a fresh quota guard
- update status projection so connected goals with open agent todos show that todo as the first-screen recommended action
- update quick start/new-project prompts so Codex/Claude asks which candidate todos to accept and whether to start autonomous advancement

## Root Cause

The rough onboarding came from a state-projection gap: first connect created registry/state plus a generic prose next action, but did not project a concrete user decision or agent todo. New agents then treated Goal Harness as a tool to explain or asked the user to run commands manually, instead of using it as the current task control plane.

## Validation

- `python3 examples/onboarding-connect-candidates-smoke.py`
- `python3 examples/demo-cli-smoke.py`
- `python3 examples/todo-lifecycle-cli-smoke.py`
- `python3 examples/install-local-smoke.py`
- `python3 -m py_compile goal_harness/onboarding.py goal_harness/bootstrap.py goal_harness/cli.py goal_harness/project_prompt.py goal_harness/status.py goal_harness/demo.py examples/onboarding-connect-candidates-smoke.py`
- `python3 -m goal_harness.cli --format markdown new-project-prompt --project /tmp/example-project --goal-doc /tmp/example-project/GOAL.md | rg "onboarding scan|Proposed Onboarding Candidates|autonomous=yes|自主推进"`
- `git diff --check`

## Notes

This touches runtime/API behavior for bootstrap/connect and status projection, so I am opening a PR rather than self-merging.
