### PR TITLE
Define lifetime goal concept

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,17 @@ become:
 Goal Harness makes those questions machine-readable enough for agents and
 legible enough for operators.
 
+## Lifetime Goals
+
+Goal Harness uses **lifetime goal** for a durable human or project intention
+that can outlive any single chat thread, agent run, concrete todo, or
+implementation plan. It does not grant open-ended autonomy: only the next
+bounded transition is executable. The lifetime goal is the continuity layer
+that keeps authority, human decisions, safety boundaries, evidence, and course
+corrections legible for future humans and agents. See
+[Architecture](docs/architecture.md#lifetime-goal-invariant) for the design
+invariant.
+
 ## Core Control Loop
 
 Goal Harness sits between the operator, the agent loop, and external evidence.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,6 +62,35 @@ the same state is available through hook/MCP/server adapters:
 This keeps Goal Harness portable across Codex, local CLI loops, dashboards, and
 future agent hosts while avoiding a forked control plane per host.
 
+## Lifetime Goal Invariant
+
+Goal Harness should optimize for **lifetime goals**: durable intentions that
+may outlive a single thread, executor, project phase, or plan. This is a
+product invariant, not an eighth storage layer.
+
+A lifetime goal must be stable enough that a future human or agent can recover
+what the goal is, what currently defines it, who may change it, and what the
+next safe transition is. It must also stay narrow enough that automation can
+make one bounded, verifiable move instead of claiming open-ended authority.
+
+The architecture maps that invariant onto the existing layers:
+
+- the registry gives the lifetime goal a stable identity, repo boundary,
+  adapter status, guards, and authority-source list;
+- active goal state records the current belief, priority stack, non-goals, and
+  next action without becoming a complete diary;
+- authority sources replace implicit model memory with reviewable context and
+  conflict rules;
+- run history preserves the compact evidence trail across sessions and agents;
+- todos turn the lifetime goal into bounded user and agent obligations;
+- gates, reward, and quota keep human judgment, course correction, and compute
+  spend attached to concrete transitions.
+
+The result should preserve continuity without claiming open-ended autonomy: a
+goal can live for years, but every agent turn still has to pass through current
+authority, boundary, quota, validation, and writeback before it can count as
+progress.
+
 For session-runtime platforms that already own agent definitions, session
 events, tool execution, permissions, billing, and product frontstage, Goal
 Harness should integrate as the goal-level control projection rather than as a

--- a/docs/state-interaction-model.md
+++ b/docs/state-interaction-model.md
@@ -25,6 +25,13 @@ handoff condition.
 A goal is not a chat thread. A thread can execute a goal, but the goal must
 survive thread reloads, network interruptions, and multiple project agents.
 
+For high-level product language, this is the **lifetime goal** object: a
+durable intention that may outlive any specific todo, plan, run, or executor.
+The lifetime goal owns continuity, not unlimited autonomy. It should keep the
+current authority, boundary, evidence trail, and human corrections visible so
+future agents can reinterpret the next bounded step instead of relying on
+private model memory.
+
 Goal-owned state:
 
 - project-local registry entry,


### PR DESCRIPTION
## Summary
- clarify that the product term is `lifetime goal`, not `life-time goal`
- keep README concise with a short definition and link to architecture
- add the detailed design invariant to architecture and anchor the term in the state interaction model

## Validation
- `git diff --check`
- `goal-harness check --scan-path README.md --scan-path docs/architecture.md --scan-path docs/state-interaction-model.md`
  - passes with the existing duplicate-index warning for `goal-harness-meta`
- private-boundary scan clean for the three changed docs

## Notes
- public docs only
- no local runtime state, raw logs, credentials, private links, or local paths committed