### PR TITLE
Add split-control execution seam

### DIFF
--- a/docs/benchmark-developer-workflow.md
+++ b/docs/benchmark-developer-workflow.md
@@ -44,10 +44,13 @@ For a real benchmark slice, use this sequence:
 1. Run a source and boundary preflight for the target benchmark.
 2. Build or inspect the split-control readiness payload.
 3. Produce a launch plan or runner batch only after a fresh readiness re-check.
-4. Run the smallest no-upload dry-run or mini-pair that can answer the current
+4. Build the execution seam from command-adapter facts, and treat missing
+   command adapters or compact reducers as blockers instead of launching a
+   private script.
+5. Run the smallest no-upload dry-run or mini-pair that can answer the current
    product question.
-5. Ingest a compact result or precise blocker.
-6. Update Goal Harness todo/state so the next developer sees the current route.
+6. Ingest a compact result or precise blocker.
+7. Update Goal Harness todo/state so the next developer sees the current route.
 
 Do not start from a raw shell command hidden in a local note. If a benchmark
 cannot be launched through a documented route, the next product task is to

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-split-control-remote-executor-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-split-control-remote-executor-v0.md
@@ -84,6 +84,28 @@ This keeps the benchmark runner interface close to the real split-control
 route while avoiding a second benchmark harness that hides stale readiness,
 raw logs, task text, uploads, or submit attempts.
 
+## Execution Seam V1
+
+`build_split_control_remote_executor_execution_seam(...)` adds the missing
+product layer between a runner batch and real execution. A runner batch can say
+that a benchmark family is ready in principle; the execution seam says whether
+that family has a command adapter and compact result reducer that can actually
+materialize a bounded no-upload run.
+
+The seam records only labels and handle contracts:
+
+- command adapter readiness and blocker labels;
+- result reducer readiness and accepted compact fields;
+- required public handle shape such as runner handle, poll label, cleanup
+  label, readiness re-check, and compact artifact ref;
+- explicit proof that shell commands, argv, local paths, remote paths, raw task
+  text, logs, trajectories, uploads, and submit paths are not embedded.
+
+This prevents the controller from treating a control-plane launch packet as a
+real runnable benchmark route. Missing command adapters or reducers remain
+first-class blockers until a benchmark family exposes a public-safe execution
+surface.
+
 ## Current Use
 
 The same route applies to the three active benchmark families:

--- a/examples/benchmark-split-control-remote-executor-smoke.py
+++ b/examples/benchmark-split-control-remote-executor-smoke.py
@@ -13,9 +13,11 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from goal_harness.benchmark_core import (  # noqa: E402
+    BENCHMARK_SPLIT_CONTROL_REMOTE_EXECUTOR_EXECUTION_SEAM_SCHEMA_VERSION,
     BENCHMARK_SPLIT_CONTROL_REMOTE_EXECUTOR_LAUNCH_PLAN_SCHEMA_VERSION,
     BENCHMARK_SPLIT_CONTROL_REMOTE_EXECUTOR_RUNNER_BATCH_SCHEMA_VERSION,
     BENCHMARK_SPLIT_CONTROL_REMOTE_EXECUTOR_SCHEMA_VERSION,
+    build_split_control_remote_executor_execution_seam,
     build_split_control_remote_executor_launch_plan,
     build_split_control_remote_executor_readiness,
     build_split_control_remote_executor_runner_batch,
@@ -300,6 +302,59 @@ def test_partial_ready_subset_can_launch_without_remote_codex() -> None:
     assert completed["post_launch_evidence_boundary"]["violations"] == [], completed
     assert completed["next_action"] == "write compact evidence and score summary", completed
     assert_public_safe(completed)
+
+    missing_seam = build_split_control_remote_executor_execution_seam(batch)
+    assert (
+        missing_seam["schema_version"]
+        == BENCHMARK_SPLIT_CONTROL_REMOTE_EXECUTOR_EXECUTION_SEAM_SCHEMA_VERSION
+    ), missing_seam
+    assert missing_seam["ready_to_execute"] is False, missing_seam
+    assert missing_seam["blockers"] == [
+        "command_adapter_missing",
+        "compact_result_reducer_missing",
+    ], missing_seam
+    assert missing_seam["missing_command_adapter_ids"] == [
+        "terminal-bench@2.0",
+        "skillsbench@1.1",
+    ], missing_seam
+    assert missing_seam["missing_result_reducer_ids"] == [
+        "terminal-bench@2.0",
+        "skillsbench@1.1",
+    ], missing_seam
+    assert missing_seam["boundary"]["shell_commands_embedded"] is False, missing_seam
+    assert missing_seam["boundary"]["argv_embedded"] is False, missing_seam
+    assert missing_seam["next_action"] == "implement missing remote-executor command adapter(s)", missing_seam
+    assert_public_safe(missing_seam)
+
+    ready_seam = build_split_control_remote_executor_execution_seam(
+        batch,
+        command_adapters={
+            "terminal-bench@2.0": {
+                "command_adapter_ready": True,
+                "result_reducer_ready": True,
+                "command_adapter_status": "ready",
+                "entrypoint_label": "terminal-bench remote-executor no-upload adapter",
+                "result_reducer_label": "terminal-bench compact result reducer",
+            },
+            "skillsbench@1.1": {
+                "command_adapter_ready": True,
+                "result_reducer_ready": True,
+                "command_adapter_status": "ready",
+                "entrypoint_label": "skillsbench remote-executor no-upload adapter",
+                "result_reducer_label": "skillsbench compact result reducer",
+            },
+        },
+    )
+    assert ready_seam["ready_to_execute"] is True, ready_seam
+    assert ready_seam["blockers"] == [], ready_seam
+    assert ready_seam["next_action"] == "launch execution seam cases and ingest compact evidence", ready_seam
+    assert all(
+        case["command_materialization"]["shell_command_embedded"] is False
+        and case["result_reducer"]["raw_values_copied"] is False
+        and case["ready_to_execute_remote_command"] is True
+        for case in ready_seam["execution_cases"]
+    ), ready_seam
+    assert_public_safe(ready_seam)
 
 
 def test_runner_batch_requires_fresh_readiness_recheck() -> None:

--- a/goal_harness/benchmark_core/__init__.py
+++ b/goal_harness/benchmark_core/__init__.py
@@ -43,10 +43,12 @@ from .parity import (
 )
 from .rounds import RoundReward, compact_round_rewards, summarize_round_rewards
 from .split_control import (
+    BENCHMARK_SPLIT_CONTROL_REMOTE_EXECUTOR_EXECUTION_SEAM_SCHEMA_VERSION,
     BENCHMARK_SPLIT_CONTROL_REMOTE_EXECUTOR_LAUNCH_PLAN_SCHEMA_VERSION,
     BENCHMARK_SPLIT_CONTROL_REMOTE_EXECUTOR_RUNNER_BATCH_SCHEMA_VERSION,
     BENCHMARK_SPLIT_CONTROL_REMOTE_EXECUTOR_SCHEMA_VERSION,
     DEFAULT_SPLIT_CONTROL_BENCHMARK_IDS,
+    build_split_control_remote_executor_execution_seam,
     build_split_control_remote_executor_launch_plan,
     build_split_control_remote_executor_readiness,
     build_split_control_remote_executor_runner_batch,
@@ -56,6 +58,7 @@ __all__ = [
     "AdapterClassification",
     "BENCHMARK_CANONICAL_LIFECYCLE_SCHEMA_VERSION",
     "BENCHMARK_LIFECYCLE_STATE_SCHEMA_VERSION",
+    "BENCHMARK_SPLIT_CONTROL_REMOTE_EXECUTOR_EXECUTION_SEAM_SCHEMA_VERSION",
     "BENCHMARK_SPLIT_CONTROL_REMOTE_EXECUTOR_LAUNCH_PLAN_SCHEMA_VERSION",
     "BENCHMARK_SPLIT_CONTROL_REMOTE_EXECUTOR_RUNNER_BATCH_SCHEMA_VERSION",
     "BENCHMARK_SPLIT_CONTROL_REMOTE_EXECUTOR_SCHEMA_VERSION",
@@ -64,6 +67,7 @@ __all__ = [
     "BenchmarkRequest",
     "build_benchmark_candidate_source_boundary",
     "build_codex_app_parity_posthoc_check",
+    "build_split_control_remote_executor_execution_seam",
     "build_split_control_remote_executor_launch_plan",
     "build_split_control_remote_executor_readiness",
     "build_split_control_remote_executor_runner_batch",

--- a/goal_harness/benchmark_core/split_control.py
+++ b/goal_harness/benchmark_core/split_control.py
@@ -12,6 +12,9 @@ BENCHMARK_SPLIT_CONTROL_REMOTE_EXECUTOR_LAUNCH_PLAN_SCHEMA_VERSION = (
 BENCHMARK_SPLIT_CONTROL_REMOTE_EXECUTOR_RUNNER_BATCH_SCHEMA_VERSION = (
     "benchmark_split_control_remote_executor_runner_batch_v0"
 )
+BENCHMARK_SPLIT_CONTROL_REMOTE_EXECUTOR_EXECUTION_SEAM_SCHEMA_VERSION = (
+    "benchmark_split_control_remote_executor_execution_seam_v1"
+)
 
 DEFAULT_SPLIT_CONTROL_BENCHMARK_IDS = (
     "terminal-bench@2.0",
@@ -468,6 +471,104 @@ def build_split_control_remote_executor_runner_batch(
     }
 
 
+def build_split_control_remote_executor_execution_seam(
+    runner_batch: Mapping[str, Any],
+    *,
+    command_adapters: Mapping[str, Mapping[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build the machine-checkable execution seam for remote runner adapters.
+
+    The runner batch says which benchmark families are eligible to run after a
+    fresh readiness re-check. The execution seam adds the next missing layer:
+    whether each family has a real command adapter and compact result reducer.
+    It deliberately records labels and handle contracts only, never shell
+    argv, host paths, raw logs, task text, trajectories, uploads, or submit
+    paths.
+    """
+
+    batch = _as_dict(runner_batch)
+    adapters = dict(command_adapters or {})
+    runner_cases = _as_sequence_of_mappings(batch.get("runner_cases"))
+    batch_blockers = _string_list(batch.get("blockers"))
+    seam_cases = [
+        _execution_seam_case_from_runner_case(
+            case,
+            adapter=_as_dict(adapters.get(str(case.get("benchmark_id")))),
+        )
+        for case in runner_cases
+    ]
+    missing_adapter_ids = [
+        case["benchmark_id"]
+        for case in seam_cases
+        if not case["command_materialization"]["ready"]
+    ]
+    missing_reducer_ids = [
+        case["benchmark_id"]
+        for case in seam_cases
+        if not case["result_reducer"]["ready"]
+    ]
+    case_blockers = [
+        blocker
+        for case in seam_cases
+        for blocker in _string_list(case.get("blockers"))
+    ]
+    seam_blockers: list[str] = list(batch_blockers)
+    if not runner_cases and not batch_blockers:
+        seam_blockers.append("runner_batch_has_no_cases")
+    if missing_adapter_ids:
+        seam_blockers.append("command_adapter_missing")
+    if missing_reducer_ids:
+        seam_blockers.append("compact_result_reducer_missing")
+    seam_blockers.extend(
+        blocker for blocker in case_blockers if blocker not in seam_blockers
+    )
+
+    ready_to_execute = (
+        _truthy(batch.get("ready_to_execute"))
+        and bool(seam_cases)
+        and not seam_blockers
+    )
+    if batch_blockers or not _truthy(batch.get("ready_to_execute")):
+        next_action = "repair runner_batch readiness before command materialization"
+    elif missing_adapter_ids:
+        next_action = "implement missing remote-executor command adapter(s)"
+    elif missing_reducer_ids:
+        next_action = "implement missing compact result reducer(s)"
+    elif seam_blockers:
+        next_action = "repair execution seam blockers before launch"
+    else:
+        next_action = "launch execution seam cases and ingest compact evidence"
+
+    return {
+        "schema_version": BENCHMARK_SPLIT_CONTROL_REMOTE_EXECUTOR_EXECUTION_SEAM_SCHEMA_VERSION,
+        "source_schema_version": batch.get("schema_version"),
+        "ready_to_execute": ready_to_execute,
+        "ready_to_spend": ready_to_execute and _truthy(batch.get("ready_to_spend")),
+        "blockers": seam_blockers,
+        "missing_command_adapter_ids": missing_adapter_ids,
+        "missing_result_reducer_ids": missing_reducer_ids,
+        "planned_benchmark_ids": _string_list(batch.get("planned_benchmark_ids")),
+        "execution_cases": seam_cases,
+        "post_launch_evidence": batch.get("post_launch_evidence") or [],
+        "post_launch_evidence_boundary": _as_dict(
+            batch.get("post_launch_evidence_boundary")
+        ),
+        "boundary": {
+            **_as_dict(batch.get("boundary")),
+            "shell_commands_embedded": False,
+            "argv_embedded": False,
+            "local_paths_embedded": False,
+            "remote_paths_embedded": False,
+            "raw_task_text_public": False,
+            "raw_logs_public": False,
+            "raw_trajectory_public": False,
+            "upload_allowed": False,
+            "submit_allowed": False,
+        },
+        "next_action": next_action,
+    }
+
+
 def _runner_case_from_launch_case(
     launch_case: Mapping[str, Any],
     *,
@@ -505,6 +606,76 @@ def _runner_case_from_launch_case(
             "upload_attempted",
             "submit_attempted",
         ],
+        "raw_material_allowed": False,
+        "upload_allowed": False,
+        "submit_allowed": False,
+    }
+
+
+def _execution_seam_case_from_runner_case(
+    runner_case: Mapping[str, Any],
+    *,
+    adapter: Mapping[str, Any],
+) -> dict[str, Any]:
+    benchmark_id = str(runner_case.get("benchmark_id"))
+    adapter_ready = _truthy(adapter.get("command_adapter_ready"))
+    reducer_ready = _truthy(adapter.get("result_reducer_ready"))
+    adapter_blockers = _string_list(adapter.get("known_blockers"))
+    blockers: list[str] = []
+    if not adapter_ready:
+        blockers.append("command_adapter_missing")
+    if not reducer_ready:
+        blockers.append("compact_result_reducer_missing")
+    blockers.extend(adapter_blockers)
+    return {
+        "benchmark_id": benchmark_id,
+        "route": "local_agent_remote_executor",
+        "execution_mode": _compact_label(str(runner_case.get("execution_mode") or "")),
+        "command_label": _compact_label(str(runner_case.get("command_label") or "")),
+        "ready_to_execute_remote_command": not blockers,
+        "blockers": blockers,
+        "command_materialization": {
+            "ready": adapter_ready,
+            "status": _compact_label(
+                str(
+                    adapter.get("command_adapter_status")
+                    or ("ready" if adapter_ready else "missing")
+                )
+            ),
+            "entrypoint_label": _compact_label(
+                str(adapter.get("entrypoint_label") or "not_materialized")
+            ),
+            "shell_command_embedded": False,
+            "argv_embedded": False,
+            "host_path_embedded": False,
+        },
+        "execution_handle_contract": {
+            "required_fields": _string_list(adapter.get("handle_fields"))
+            or [
+                "benchmark_id",
+                "runner_handle",
+                "readiness_rechecked",
+                "poll_label",
+                "cleanup_label",
+                "compact_artifact_ref",
+            ],
+            "handle_values_may_be_private": True,
+            "public_handle_shape_only": True,
+        },
+        "result_reducer": {
+            "ready": reducer_ready,
+            "label": _compact_label(
+                str(adapter.get("result_reducer_label") or "not_materialized")
+            ),
+            "accepted_public_fields": list(PUBLIC_RUNNER_RESULT_FIELDS),
+            "raw_values_copied": False,
+        },
+        "remote_executor_allowed_actions": _string_list(
+            runner_case.get("remote_executor_allowed_actions")
+        ),
+        "remote_executor_disallowed_actions": _string_list(
+            runner_case.get("remote_executor_disallowed_actions")
+        ),
         "raw_material_allowed": False,
         "upload_allowed": False,
         "submit_allowed": False,

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -115,6 +115,10 @@ from .benchmark_core import (
     build_benchmark_candidate_source_boundary,
     build_codex_app_parity_posthoc_check,
     filter_public_benchmark_artifact_paths,
+    build_split_control_remote_executor_execution_seam,
+    build_split_control_remote_executor_launch_plan,
+    build_split_control_remote_executor_readiness,
+    build_split_control_remote_executor_runner_batch,
     render_codex_app_parity_posthoc_check_markdown,
 )
 from .configure_goal import configure_goal, render_configure_goal_markdown
@@ -306,6 +310,70 @@ def render_benchmark_candidate_source_boundary_markdown(payload: dict[str, objec
         lines.append("- Blocked reasons: " + reasons)
     if payload.get("next_action"):
         lines.append(f"- Next action: {payload.get('next_action')}")
+    return "\n".join(lines) + "\n"
+
+
+def render_split_control_execution_seam_markdown(payload: dict[str, object]) -> str:
+    cases = payload.get("execution_cases") if isinstance(payload.get("execution_cases"), list) else []
+    lines = [
+        "# Benchmark Split-Control Execution Seam",
+        "",
+        f"- Schema: `{payload.get('schema_version')}`",
+        f"- Ready to execute: `{payload.get('ready_to_execute')}`",
+        f"- Ready to spend: `{payload.get('ready_to_spend')}`",
+        f"- Cases: `{len(cases)}`",
+    ]
+    blockers = payload.get("blockers")
+    if isinstance(blockers, list) and blockers:
+        lines.append("- Blockers: " + ", ".join(f"`{item}`" for item in blockers))
+    missing_adapters = payload.get("missing_command_adapter_ids")
+    if isinstance(missing_adapters, list) and missing_adapters:
+        lines.append(
+            "- Missing command adapters: "
+            + ", ".join(f"`{item}`" for item in missing_adapters)
+        )
+    missing_reducers = payload.get("missing_result_reducer_ids")
+    if isinstance(missing_reducers, list) and missing_reducers:
+        lines.append(
+            "- Missing result reducers: "
+            + ", ".join(f"`{item}`" for item in missing_reducers)
+        )
+    if payload.get("next_action"):
+        lines.append(f"- Next action: {payload.get('next_action')}")
+    boundary = payload.get("boundary") if isinstance(payload.get("boundary"), dict) else {}
+    lines.extend(
+        [
+            "",
+            "## Boundary",
+            "",
+            f"- Shell commands embedded: `{boundary.get('shell_commands_embedded')}`",
+            f"- argv embedded: `{boundary.get('argv_embedded')}`",
+            f"- raw task text public: `{boundary.get('raw_task_text_public')}`",
+            f"- raw logs public: `{boundary.get('raw_logs_public')}`",
+            f"- upload allowed: `{boundary.get('upload_allowed')}`",
+            f"- submit allowed: `{boundary.get('submit_allowed')}`",
+        ]
+    )
+    if cases:
+        lines.extend(["", "## Cases", ""])
+        for case in cases:
+            if not isinstance(case, dict):
+                continue
+            materialization = (
+                case.get("command_materialization")
+                if isinstance(case.get("command_materialization"), dict)
+                else {}
+            )
+            reducer = case.get("result_reducer") if isinstance(case.get("result_reducer"), dict) else {}
+            lines.append(
+                "- "
+                + f"`{case.get('benchmark_id')}`: command_ready="
+                + f"`{materialization.get('ready')}`, reducer_ready="
+                + f"`{reducer.get('ready')}`, blockers="
+                + "`"
+                + ",".join(str(item) for item in case.get("blockers", []))
+                + "`"
+            )
     return "\n".join(lines) + "\n"
 
 
@@ -2903,6 +2971,36 @@ def main(argv: list[str] | None = None) -> int:
         "--require-clean",
         action="store_true",
         help="Return non-zero if any source is blocked.",
+    )
+
+    split_control_execution_parser = benchmark_sub.add_parser(
+        "split-control-execution-seam",
+        help=(
+            "Build the public-safe execution seam from split-control readiness "
+            "and command-adapter facts. This does not execute benchmarks."
+        ),
+    )
+    add_subcommand_format(split_control_execution_parser)
+    split_control_execution_parser.add_argument(
+        "--readiness-json",
+        required=True,
+        help=(
+            "Path to a benchmark_split_control_remote_executor_readiness_v0 "
+            "object. Use '-' to read stdin."
+        ),
+    )
+    split_control_execution_parser.add_argument(
+        "--command-adapter-json",
+        help=(
+            "Optional JSON object keyed by benchmark id with "
+            "command_adapter_ready/result_reducer_ready facts. If omitted, "
+            "all launch cases are treated as missing command adapters."
+        ),
+    )
+    split_control_execution_parser.add_argument(
+        "--execution-mode",
+        default="compact_no_upload_dry_run",
+        help="Public-safe execution mode label for runner cases.",
     )
 
     ale_local_preflight_parser = benchmark_sub.add_parser(
@@ -5664,6 +5762,73 @@ def main(argv: list[str] | None = None) -> int:
             if args.require_clean and not payload.get("clean"):
                 return 1
             return 0
+        if args.benchmark_command == "split-control-execution-seam":
+            def read_json_arg(path_text: str | None, label: str) -> dict[str, object]:
+                if not path_text:
+                    return {}
+                raw = sys.stdin.read() if path_text == "-" else Path(path_text).expanduser().read_text(encoding="utf-8")
+                loaded = json.loads(raw)
+                if not isinstance(loaded, dict):
+                    raise ValueError(f"{label} must contain a JSON object")
+                return loaded
+
+            try:
+                readiness = read_json_arg(args.readiness_json, "--readiness-json")
+                command_adapters = read_json_arg(
+                    args.command_adapter_json,
+                    "--command-adapter-json",
+                )
+                launch_plan = build_split_control_remote_executor_launch_plan(
+                    readiness
+                )
+                runner_batch = build_split_control_remote_executor_runner_batch(
+                    launch_plan,
+                    fresh_readiness=readiness,
+                    execution_mode=args.execution_mode,
+                )
+                payload = build_split_control_remote_executor_execution_seam(
+                    runner_batch,
+                    command_adapters=command_adapters,
+                )
+                payload["ok"] = True
+                payload["dry_run"] = True
+                payload["read_boundary"] = {
+                    "compact_only": True,
+                    "readiness_json_read": True,
+                    "command_adapter_json_read": bool(args.command_adapter_json),
+                    "raw_task_text_read": False,
+                    "raw_logs_read": False,
+                    "trajectory_read": False,
+                    "shell_commands_read": False,
+                    "docker_invoked": False,
+                    "model_api_invoked": False,
+                    "upload_invoked": False,
+                    "submit_invoked": False,
+                }
+            except Exception as exc:
+                payload = {
+                    "ok": False,
+                    "dry_run": True,
+                    "schema_version": "benchmark_split_control_remote_executor_execution_seam_v1",
+                    "error": str(exc),
+                    "read_boundary": {
+                        "compact_only": True,
+                        "raw_task_text_read": False,
+                        "raw_logs_read": False,
+                        "trajectory_read": False,
+                        "shell_commands_read": False,
+                        "docker_invoked": False,
+                        "model_api_invoked": False,
+                        "upload_invoked": False,
+                        "submit_invoked": False,
+                    },
+                }
+            print_payload(
+                payload,
+                output_format(args),
+                render_split_control_execution_seam_markdown,
+            )
+            return 0 if payload.get("ok") else 1
         if args.benchmark_command == "ale-local-preflight":
             try:
                 image_metadata = None


### PR DESCRIPTION
## Summary
- add execution seam v1 for split-control remote-executor benchmark runs
- expose `benchmark split-control-execution-seam` from compact readiness and adapter facts
- document the developer workflow and cover missing/ready adapter cases in a focused smoke

## Validation
- `python3 examples/benchmark-split-control-remote-executor-smoke.py`
- `python3 -m py_compile goal_harness/benchmark_core/split_control.py goal_harness/benchmark_core/__init__.py goal_harness/cli.py`
- `goal-harness benchmark split-control-execution-seam --help`
- `goal-harness --format json benchmark split-control-execution-seam --readiness-json -`
- `git diff --check`
- `goal-harness check` (existing duplicate-index warning only)

## Boundary
- excludes local runtime state, raw benchmark evidence, trajectories, credentials, uploads, and submit paths
- the seam embeds no shell commands, argv, host paths, raw task text, raw logs, or raw trajectories
