### PR TITLE
Add Terminal-Bench command adapter facts

### DIFF
--- a/docs/benchmark-developer-workflow.md
+++ b/docs/benchmark-developer-workflow.md
@@ -44,9 +44,10 @@ For a real benchmark slice, use this sequence:
 1. Run a source and boundary preflight for the target benchmark.
 2. Build or inspect the split-control readiness payload.
 3. Produce a launch plan or runner batch only after a fresh readiness re-check.
-4. Build the execution seam from command-adapter facts, and treat missing
-   command adapters or compact reducers as blockers instead of launching a
-   private script.
+4. Build benchmark-specific command-adapter facts, such as
+   `goal-harness benchmark terminal-bench-command-adapter terminal-bench`, then
+   build the execution seam from those facts. Treat missing command adapters or
+   compact reducers as blockers instead of launching a private script.
 5. Run the smallest no-upload dry-run or mini-pair that can answer the current
    product question.
 6. Ingest a compact result or precise blocker.

--- a/examples/benchmark-split-control-remote-executor-smoke.py
+++ b/examples/benchmark-split-control-remote-executor-smoke.py
@@ -22,6 +22,10 @@ from goal_harness.benchmark_core import (  # noqa: E402
     build_split_control_remote_executor_readiness,
     build_split_control_remote_executor_runner_batch,
 )
+from goal_harness.benchmark_adapters.terminal_bench import (  # noqa: E402
+    TERMINAL_BENCH_REMOTE_EXECUTOR_COMMAND_ADAPTER_SCHEMA,
+    build_terminal_bench_remote_executor_command_adapter,
+)
 
 
 FORBIDDEN_TEXT = (
@@ -357,6 +361,75 @@ def test_partial_ready_subset_can_launch_without_remote_codex() -> None:
     assert_public_safe(ready_seam)
 
 
+def test_terminal_bench_command_adapter_facts_feed_execution_seam() -> None:
+    adapter_payload = build_terminal_bench_remote_executor_command_adapter()
+    assert (
+        adapter_payload["schema_version"]
+        == TERMINAL_BENCH_REMOTE_EXECUTOR_COMMAND_ADAPTER_SCHEMA
+    ), adapter_payload
+    assert adapter_payload["ready"] is True, adapter_payload
+    terminal_adapter = adapter_payload["command_adapters"]["terminal-bench@2.0"]
+    assert terminal_adapter["command_adapter_ready"] is True, terminal_adapter
+    assert terminal_adapter["result_reducer_ready"] is True, terminal_adapter
+    assert terminal_adapter["boundary"]["shell_command_embedded"] is False
+    assert terminal_adapter["boundary"]["argv_embedded"] is False
+    assert terminal_adapter["boundary"]["host_path_embedded"] is False
+    assert terminal_adapter["surface_contract"]["local_codex_owns_auth_model_state"] is True
+    assert terminal_adapter["surface_contract"]["remote_executor_owns_docker_runner_data"] is True
+    assert_public_safe(adapter_payload)
+
+    readiness = build_split_control_remote_executor_readiness(
+        benchmark_ids=("terminal-bench@2.0", "skillsbench@1.1"),
+        local_agent={
+            "codex_cli_available": True,
+            "goal_harness_available": True,
+            "codex_auth_ready": True,
+            "codex_auth_local_only": True,
+            "model_invocation_local": True,
+        },
+        remote_executor={
+            "docker_available": True,
+            "python_available": True,
+            "git_available": True,
+            "rsync_available": True,
+        },
+        adapter_readiness={
+            "terminal-bench@2.0": {
+                "split_control_adapter_ready": True,
+                "runner_tooling_ready": True,
+                "task_data_ready": True,
+            },
+            "skillsbench@1.1": {
+                "split_control_adapter_ready": True,
+                "runner_tooling_ready": True,
+                "task_data_ready": True,
+            },
+        },
+    )
+    plan = build_split_control_remote_executor_launch_plan(readiness)
+    batch = build_split_control_remote_executor_runner_batch(
+        plan,
+        fresh_readiness=readiness,
+    )
+    partial_seam = build_split_control_remote_executor_execution_seam(
+        batch,
+        command_adapters=adapter_payload["command_adapters"],
+    )
+    assert partial_seam["ready_to_execute"] is False, partial_seam
+    assert partial_seam["missing_command_adapter_ids"] == ["skillsbench@1.1"], partial_seam
+    assert partial_seam["missing_result_reducer_ids"] == ["skillsbench@1.1"], partial_seam
+    terminal_case = next(
+        case
+        for case in partial_seam["execution_cases"]
+        if case["benchmark_id"] == "terminal-bench@2.0"
+    )
+    assert terminal_case["ready_to_execute_remote_command"] is True, partial_seam
+    assert terminal_case["command_materialization"]["entrypoint_label"] == (
+        "terminal_bench_no_upload_case_run_surface"
+    )
+    assert_public_safe(partial_seam)
+
+
 def test_runner_batch_requires_fresh_readiness_recheck() -> None:
     payload = build_split_control_remote_executor_readiness(
         benchmark_ids=("terminal-bench@2.0",),
@@ -514,6 +587,7 @@ def main() -> int:
     test_remote_codex_is_not_required_for_split_control()
     test_ready_parallel_batch_size_is_capped()
     test_partial_ready_subset_can_launch_without_remote_codex()
+    test_terminal_bench_command_adapter_facts_feed_execution_seam()
     test_runner_batch_requires_fresh_readiness_recheck()
     test_runner_batch_sanitizes_post_launch_evidence()
     test_launch_plan_blocks_when_no_subset_is_ready()

--- a/goal_harness/benchmark_adapters/terminal_bench.py
+++ b/goal_harness/benchmark_adapters/terminal_bench.py
@@ -9,7 +9,7 @@ import tempfile
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Iterable, Sequence
 
 from ..benchmark_core.io import (
     load_json_object as _load_json_object,
@@ -108,6 +108,9 @@ TERMINAL_BENCH_RUN_LEDGER_CLOSEOUT_SCHEMA = (
 )
 TERMINAL_BENCH_ENVIRONMENT_SETUP_READINESS_SCHEMA = (
     "terminal_bench_environment_setup_readiness_preflight_v0"
+)
+TERMINAL_BENCH_REMOTE_EXECUTOR_COMMAND_ADAPTER_SCHEMA = (
+    "terminal_bench_remote_executor_command_adapter_v1"
 )
 TERMINAL_BENCH_ENVIRONMENT_SETUP_PROBE_GATE_SCHEMA = (
     "terminal_bench_environment_setup_probe_gate_v0"
@@ -3227,6 +3230,132 @@ def _public_safe_benchmark_label(value: Any, *, limit: int = 120) -> str | None:
     if not text or "/" in text or "\\" in text:
         return None
     return text[:limit]
+
+def build_terminal_bench_remote_executor_command_adapter(
+    *,
+    benchmark_id: str = TERMINAL_BENCH_DEFAULT_DATASET,
+    launch_surface_ready: bool = True,
+    poll_surface_ready: bool = True,
+    resume_surface_ready: bool = True,
+    compact_ingest_ready: bool = True,
+    result_reducer_ready: bool = True,
+    no_upload: bool = True,
+    submit_enabled: bool = False,
+    known_blockers: Sequence[str] = (),
+) -> dict[str, Any]:
+    """Return Terminal-Bench adapter facts for the split-control seam.
+
+    This is not a launcher and it deliberately avoids shell commands, argv,
+    host paths, task text, logs, trajectories, uploads, and submit surfaces.
+    Private runners may use the labels to find their own local implementation,
+    but public Goal Harness state stores only the adapter contract.
+    """
+
+    safe_benchmark_id = _public_safe_benchmark_label(benchmark_id, limit=80)
+    blockers = [str(item) for item in known_blockers if str(item)]
+    if not safe_benchmark_id:
+        safe_benchmark_id = TERMINAL_BENCH_DEFAULT_DATASET
+        blockers.append("terminal_bench_benchmark_id_not_public_safe")
+    if safe_benchmark_id != TERMINAL_BENCH_DEFAULT_DATASET:
+        blockers.append("terminal_bench_benchmark_id_unsupported")
+    if not launch_surface_ready:
+        blockers.append("terminal_bench_launch_surface_not_ready")
+    if not poll_surface_ready:
+        blockers.append("terminal_bench_poll_surface_not_ready")
+    if not resume_surface_ready:
+        blockers.append("terminal_bench_resume_surface_not_ready")
+    if not compact_ingest_ready:
+        blockers.append("terminal_bench_compact_ingest_surface_not_ready")
+    if not no_upload:
+        blockers.append("terminal_bench_no_upload_boundary_not_enabled")
+    if submit_enabled:
+        blockers.append("terminal_bench_submit_must_remain_disabled")
+
+    reducer_ready = (
+        result_reducer_ready is True
+        and compact_ingest_ready is True
+        and no_upload is True
+        and submit_enabled is False
+    )
+    if not reducer_ready:
+        blockers.append("terminal_bench_compact_result_reducer_not_ready")
+
+    adapter_ready = not blockers
+    adapter = {
+        "schema_version": TERMINAL_BENCH_REMOTE_EXECUTOR_COMMAND_ADAPTER_SCHEMA,
+        "benchmark_id": safe_benchmark_id,
+        "command_adapter_ready": adapter_ready,
+        "result_reducer_ready": reducer_ready,
+        "command_adapter_status": "ready" if adapter_ready else "blocked",
+        "entrypoint_label": "terminal_bench_no_upload_case_run_surface",
+        "poll_label": "terminal_bench_compact_materialization_poll_surface",
+        "cleanup_label": "terminal_bench_private_runner_cleanup_surface",
+        "result_reducer_label": "terminal_bench_compact_harbor_result_reducer",
+        "handle_fields": [
+            "benchmark_id",
+            "runner_handle",
+            "readiness_rechecked",
+            "run_root_handle",
+            "jobs_dir_handle",
+            "job_name",
+            "poll_label",
+            "cleanup_label",
+            "compact_artifact_ref",
+        ],
+        "known_blockers": blockers,
+        "surface_contract": {
+            "launch_surface_ready": launch_surface_ready is True,
+            "poll_surface_ready": poll_surface_ready is True,
+            "resume_surface_ready": resume_surface_ready is True,
+            "compact_ingest_ready": compact_ingest_ready is True,
+            "private_handle_values_required": True,
+            "public_handle_shape_only": True,
+            "local_codex_owns_auth_model_state": True,
+            "remote_executor_owns_docker_runner_data": True,
+        },
+        "boundary": {
+            "shell_command_embedded": False,
+            "argv_embedded": False,
+            "host_path_embedded": False,
+            "remote_path_embedded": False,
+            "raw_task_text_public": False,
+            "raw_logs_public": False,
+            "raw_trajectory_public": False,
+            "credential_values_recorded": False,
+            "upload_allowed": False,
+            "submit_allowed": False,
+        },
+    }
+    return {
+        "schema_version": TERMINAL_BENCH_REMOTE_EXECUTOR_COMMAND_ADAPTER_SCHEMA,
+        "benchmark_id": safe_benchmark_id,
+        "ready": adapter_ready and reducer_ready,
+        "first_blocker": blockers[0]
+        if blockers
+        else "ready_for_split_control_execution_seam",
+        "blockers": blockers,
+        "command_adapters": {safe_benchmark_id: adapter},
+        "command_adapter": adapter,
+        "next_action": (
+            "feed_terminal_bench_adapter_facts_to_split_control_execution_seam"
+            if adapter_ready and reducer_ready
+            else "repair_terminal_bench_adapter_surface_before_execution_seam"
+        ),
+        "read_boundary": {
+            "compact_only": True,
+            "shell_commands_read": False,
+            "argv_read": False,
+            "raw_task_text_read": False,
+            "raw_logs_read": False,
+            "trajectory_read": False,
+            "local_paths_recorded": False,
+            "remote_paths_recorded": False,
+            "docker_invoked": False,
+            "model_api_invoked": False,
+            "upload_invoked": False,
+            "submit_invoked": False,
+        },
+    }
 
 def build_terminal_bench_single_agent_episode_policy(
     *,

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -89,10 +89,12 @@ from .benchmark_adapters.terminal_bench import (
     TERMINAL_BENCH_HARDENED_CODEX_BASELINE_PREFLIGHT_MODE,
     TERMINAL_BENCH_MANAGED_CODEX_GOAL_HARNESS_KWARGS,
     TERMINAL_BENCH_MODES,
+    TERMINAL_BENCH_REMOTE_EXECUTOR_COMMAND_ADAPTER_SCHEMA,
     agent_kwargs_from_invocation,
     build_terminal_bench_benchmark_run,
     build_terminal_bench_environment_setup_probe_gate,
     build_terminal_bench_harbor_result_benchmark_run,
+    build_terminal_bench_remote_executor_command_adapter,
     build_terminal_bench_result_finalization_gate,
     collect_terminal_bench_goal_harness_cli_bridge_trace,
     launch_terminal_bench_environment_setup_probe,
@@ -374,6 +376,45 @@ def render_split_control_execution_seam_markdown(payload: dict[str, object]) -> 
                 + ",".join(str(item) for item in case.get("blockers", []))
                 + "`"
             )
+    return "\n".join(lines) + "\n"
+
+def render_terminal_bench_remote_executor_command_adapter_markdown(
+    payload: dict[str, object],
+) -> str:
+    adapter = (
+        payload.get("command_adapter")
+        if isinstance(payload.get("command_adapter"), dict)
+        else {}
+    )
+    boundary = (
+        adapter.get("boundary") if isinstance(adapter.get("boundary"), dict) else {}
+    )
+    lines = [
+        "# Terminal-Bench Remote Executor Command Adapter",
+        "",
+        f"- Schema: `{payload.get('schema_version')}`",
+        f"- Benchmark: `{payload.get('benchmark_id')}`",
+        f"- Ready: `{payload.get('ready')}`",
+        f"- First blocker: `{payload.get('first_blocker')}`",
+        f"- Command adapter ready: `{adapter.get('command_adapter_ready')}`",
+        f"- Result reducer ready: `{adapter.get('result_reducer_ready')}`",
+        f"- Entrypoint label: `{adapter.get('entrypoint_label')}`",
+        f"- Result reducer label: `{adapter.get('result_reducer_label')}`",
+        f"- Next action: {payload.get('next_action')}",
+        "",
+        "## Boundary",
+        "",
+        f"- Shell command embedded: `{boundary.get('shell_command_embedded')}`",
+        f"- argv embedded: `{boundary.get('argv_embedded')}`",
+        f"- host path embedded: `{boundary.get('host_path_embedded')}`",
+        f"- raw task text public: `{boundary.get('raw_task_text_public')}`",
+        f"- raw logs public: `{boundary.get('raw_logs_public')}`",
+        f"- upload allowed: `{boundary.get('upload_allowed')}`",
+        f"- submit allowed: `{boundary.get('submit_allowed')}`",
+    ]
+    blockers = payload.get("blockers")
+    if isinstance(blockers, list) and blockers:
+        lines.append("- Blockers: " + ", ".join(f"`{item}`" for item in blockers))
     return "\n".join(lines) + "\n"
 
 
@@ -3001,6 +3042,66 @@ def main(argv: list[str] | None = None) -> int:
         "--execution-mode",
         default="compact_no_upload_dry_run",
         help="Public-safe execution mode label for runner cases.",
+    )
+
+    terminal_bench_command_adapter_parser = benchmark_sub.add_parser(
+        "terminal-bench-command-adapter",
+        help=(
+            "Emit Terminal-Bench command-adapter facts for the split-control "
+            "execution seam. This does not execute benchmarks."
+        ),
+    )
+    add_subcommand_format(terminal_bench_command_adapter_parser)
+    terminal_bench_command_adapter_parser.add_argument(
+        "benchmark_name",
+        choices=["terminal-bench"],
+        help="Benchmark family. Only terminal-bench is supported.",
+    )
+    terminal_bench_command_adapter_parser.add_argument(
+        "--benchmark-id",
+        default=TERMINAL_BENCH_DEFAULT_DATASET,
+        help="Public-safe split-control benchmark id.",
+    )
+    terminal_bench_command_adapter_parser.add_argument(
+        "--launch-surface-not-ready",
+        action="store_true",
+        help="Fixture flag for a missing launch surface.",
+    )
+    terminal_bench_command_adapter_parser.add_argument(
+        "--poll-surface-not-ready",
+        action="store_true",
+        help="Fixture flag for a missing compact poll surface.",
+    )
+    terminal_bench_command_adapter_parser.add_argument(
+        "--resume-surface-not-ready",
+        action="store_true",
+        help="Fixture flag for a missing no-upload resume surface.",
+    )
+    terminal_bench_command_adapter_parser.add_argument(
+        "--compact-ingest-not-ready",
+        action="store_true",
+        help="Fixture flag for a missing compact Harbor result ingest surface.",
+    )
+    terminal_bench_command_adapter_parser.add_argument(
+        "--result-reducer-not-ready",
+        action="store_true",
+        help="Fixture flag for a missing compact result reducer.",
+    )
+    terminal_bench_command_adapter_parser.add_argument(
+        "--submit-enabled",
+        action="store_true",
+        help="Fixture flag proving submit-enabled runs are blocked.",
+    )
+    terminal_bench_command_adapter_parser.add_argument(
+        "--surface-blocker",
+        action="append",
+        default=[],
+        help="Public-safe adapter blocker label. Repeat as needed.",
+    )
+    terminal_bench_command_adapter_parser.add_argument(
+        "--require-ready",
+        action="store_true",
+        help="Return non-zero unless the adapter facts are ready.",
     )
 
     ale_local_preflight_parser = benchmark_sub.add_parser(
@@ -5774,9 +5875,16 @@ def main(argv: list[str] | None = None) -> int:
 
             try:
                 readiness = read_json_arg(args.readiness_json, "--readiness-json")
-                command_adapters = read_json_arg(
+                command_adapter_payload = read_json_arg(
                     args.command_adapter_json,
                     "--command-adapter-json",
+                )
+                command_adapters = (
+                    command_adapter_payload.get("command_adapters")
+                    if isinstance(
+                        command_adapter_payload.get("command_adapters"), dict
+                    )
+                    else command_adapter_payload
                 )
                 launch_plan = build_split_control_remote_executor_launch_plan(
                     readiness
@@ -5796,6 +5904,12 @@ def main(argv: list[str] | None = None) -> int:
                     "compact_only": True,
                     "readiness_json_read": True,
                     "command_adapter_json_read": bool(args.command_adapter_json),
+                    "command_adapter_wrapper_unwrapped": bool(
+                        args.command_adapter_json
+                        and isinstance(
+                            command_adapter_payload.get("command_adapters"), dict
+                        )
+                    ),
                     "raw_task_text_read": False,
                     "raw_logs_read": False,
                     "trajectory_read": False,
@@ -5827,6 +5941,57 @@ def main(argv: list[str] | None = None) -> int:
                 payload,
                 output_format(args),
                 render_split_control_execution_seam_markdown,
+            )
+            return 0 if payload.get("ok") else 1
+        if args.benchmark_command == "terminal-bench-command-adapter":
+            try:
+                if args.benchmark_name != "terminal-bench":
+                    raise ValueError("only terminal-bench is supported")
+                payload = build_terminal_bench_remote_executor_command_adapter(
+                    benchmark_id=args.benchmark_id,
+                    launch_surface_ready=not bool(args.launch_surface_not_ready),
+                    poll_surface_ready=not bool(args.poll_surface_not_ready),
+                    resume_surface_ready=not bool(args.resume_surface_not_ready),
+                    compact_ingest_ready=not bool(args.compact_ingest_not_ready),
+                    result_reducer_ready=not bool(args.result_reducer_not_ready),
+                    no_upload=not bool(args.submit_enabled),
+                    submit_enabled=bool(args.submit_enabled),
+                    known_blockers=args.surface_blocker,
+                )
+                payload["ok"] = True
+                payload["dry_run"] = True
+                if args.require_ready and payload.get("ready") is not True:
+                    payload["ok"] = False
+                    payload["error"] = (
+                        payload.get("first_blocker")
+                        or "terminal_bench_command_adapter_not_ready"
+                    )
+                payload["require_ready"] = bool(args.require_ready)
+            except Exception as exc:
+                payload = {
+                    "ok": False,
+                    "dry_run": True,
+                    "schema_version": TERMINAL_BENCH_REMOTE_EXECUTOR_COMMAND_ADAPTER_SCHEMA,
+                    "error": str(exc),
+                    "read_boundary": {
+                        "compact_only": True,
+                        "shell_commands_read": False,
+                        "argv_read": False,
+                        "raw_task_text_read": False,
+                        "raw_logs_read": False,
+                        "trajectory_read": False,
+                        "local_paths_recorded": False,
+                        "remote_paths_recorded": False,
+                        "docker_invoked": False,
+                        "model_api_invoked": False,
+                        "upload_invoked": False,
+                        "submit_invoked": False,
+                    },
+                }
+            print_payload(
+                payload,
+                output_format(args),
+                render_terminal_bench_remote_executor_command_adapter_markdown,
             )
             return 0 if payload.get("ok") else 1
         if args.benchmark_command == "ale-local-preflight":


### PR DESCRIPTION
## Summary
- add a Terminal-Bench command-adapter fact payload for the split-control remote-executor seam
- let `benchmark split-control-execution-seam` consume wrapped adapter payloads from benchmark-specific commands
- document the command-adapter step and cover the Terminal-Bench adapter facts in the existing split-control smoke

## Boundary
- does not launch Terminal-Bench jobs
- does not embed shell commands, argv, local or remote paths
- does not expose raw task text, raw logs, trajectories, credentials, uploads, or submit surfaces
- preserves the split-control product boundary: local Codex owns auth/model/state; the remote executor owns Docker/runner/data

## Validation
- `python3 examples/benchmark-split-control-remote-executor-smoke.py`
- `python3 -m py_compile goal_harness/benchmark_adapters/terminal_bench.py goal_harness/cli.py goal_harness/benchmark_core/split_control.py`
- `goal-harness benchmark terminal-bench-command-adapter --help`
- `goal-harness --format json benchmark terminal-bench-command-adapter terminal-bench --require-ready`
- Terminal-only split-control execution-seam CLI dry-run returned `ready_to_execute=True`
- `git diff --check`
- `goal-harness check` (passes; existing duplicate-index warning only)
