### PR TITLE
Gate Terminal-Bench on remote materializer readiness

### DIFF
--- a/docs/benchmark-developer-workflow.md
+++ b/docs/benchmark-developer-workflow.md
@@ -46,8 +46,9 @@ For a real benchmark slice, use this sequence:
 3. Produce a launch plan or runner batch only after a fresh readiness re-check.
 4. Build benchmark-specific command-adapter facts, such as
    `goal-harness benchmark terminal-bench-command-adapter terminal-bench`, then
-   build the execution seam from those facts. Treat missing command adapters or
-   compact reducers as blockers instead of launching a private script.
+   build the execution seam from those facts. Treat missing command adapters,
+   missing remote-executor materializers, or compact reducers as blockers
+   instead of launching a private script.
 5. Run the smallest no-upload dry-run or mini-pair that can answer the current
    product question.
 6. Ingest a compact result or precise blocker.
@@ -100,7 +101,7 @@ for the current machine contract.
 
 | Family | Product-path target | Current maturity |
 | --- | --- | --- |
-| Terminal-Bench | Local Codex/Goal Harness controls the attempt; remote executor provides Docker or runner substrate and compact result ingestion. | Needs a real remote-executor launch seam before the local launcher can count as product-path evidence. |
+| Terminal-Bench | Local Codex/Goal Harness controls the attempt; remote executor provides Docker or runner substrate and compact result ingestion. | Has public adapter facts and compact reducers, but still needs the remote-executor materializer before the local launcher can count as product-path evidence. |
 | SkillsBench | Local Codex/Goal Harness controls state, prompt, and writeback; remote executor stages task files and runs Docker-bound worker surfaces. | Needs remote task staging plus remote Docker execution instead of local-only BenchFlow assumptions. |
 | Agents' Last Exam | Local Codex/Goal Harness controls the agent; remote Docker/CUA provides the sandbox; compact result or blocker is ingested locally. | A demo/tool-smoke style split-control surface is product-path proven; formal task runs still need task-data and public-claim gates. |
 

--- a/examples/benchmark-split-control-remote-executor-smoke.py
+++ b/examples/benchmark-split-control-remote-executor-smoke.py
@@ -367,10 +367,15 @@ def test_terminal_bench_command_adapter_facts_feed_execution_seam() -> None:
         adapter_payload["schema_version"]
         == TERMINAL_BENCH_REMOTE_EXECUTOR_COMMAND_ADAPTER_SCHEMA
     ), adapter_payload
-    assert adapter_payload["ready"] is True, adapter_payload
+    assert adapter_payload["ready"] is False, adapter_payload
+    assert (
+        adapter_payload["first_blocker"]
+        == "terminal_bench_remote_executor_materializer_missing"
+    ), adapter_payload
     terminal_adapter = adapter_payload["command_adapters"]["terminal-bench@2.0"]
     assert terminal_adapter["command_adapter_ready"] is True, terminal_adapter
     assert terminal_adapter["result_reducer_ready"] is True, terminal_adapter
+    assert terminal_adapter["surface_contract"]["remote_materializer_ready"] is False
     assert terminal_adapter["boundary"]["shell_command_embedded"] is False
     assert terminal_adapter["boundary"]["argv_embedded"] is False
     assert terminal_adapter["boundary"]["host_path_embedded"] is False
@@ -417,17 +422,45 @@ def test_terminal_bench_command_adapter_facts_feed_execution_seam() -> None:
     )
     assert partial_seam["ready_to_execute"] is False, partial_seam
     assert partial_seam["missing_command_adapter_ids"] == ["skillsbench@1.1"], partial_seam
+    assert partial_seam["missing_remote_materializer_ids"] == [
+        "terminal-bench@2.0"
+    ], partial_seam
     assert partial_seam["missing_result_reducer_ids"] == ["skillsbench@1.1"], partial_seam
     terminal_case = next(
         case
         for case in partial_seam["execution_cases"]
         if case["benchmark_id"] == "terminal-bench@2.0"
     )
-    assert terminal_case["ready_to_execute_remote_command"] is True, partial_seam
+    assert terminal_case["ready_to_execute_remote_command"] is False, partial_seam
+    assert "remote_executor_materializer_missing" in terminal_case["blockers"]
+    assert (
+        "terminal_bench_remote_executor_materializer_missing"
+        in terminal_case["blockers"]
+    )
+    assert (
+        terminal_case["command_materialization"]["remote_materializer_ready"] is False
+    )
     assert terminal_case["command_materialization"]["entrypoint_label"] == (
         "terminal_bench_no_upload_case_run_surface"
     )
     assert_public_safe(partial_seam)
+
+    materialized_adapter_payload = build_terminal_bench_remote_executor_command_adapter(
+        remote_materializer_ready=True,
+    )
+    materialized_seam = build_split_control_remote_executor_execution_seam(
+        batch,
+        command_adapters=materialized_adapter_payload["command_adapters"],
+    )
+    materialized_terminal_case = next(
+        case
+        for case in materialized_seam["execution_cases"]
+        if case["benchmark_id"] == "terminal-bench@2.0"
+    )
+    assert materialized_terminal_case["ready_to_execute_remote_command"] is True
+    assert materialized_terminal_case["command_materialization"]["ready"] is True
+    assert materialized_seam["missing_command_adapter_ids"] == ["skillsbench@1.1"]
+    assert_public_safe(materialized_seam)
 
 
 def test_runner_batch_requires_fresh_readiness_recheck() -> None:

--- a/goal_harness/benchmark_adapters/terminal_bench.py
+++ b/goal_harness/benchmark_adapters/terminal_bench.py
@@ -3239,6 +3239,7 @@ def build_terminal_bench_remote_executor_command_adapter(
     resume_surface_ready: bool = True,
     compact_ingest_ready: bool = True,
     result_reducer_ready: bool = True,
+    remote_materializer_ready: bool = False,
     no_upload: bool = True,
     submit_enabled: bool = False,
     known_blockers: Sequence[str] = (),
@@ -3252,24 +3253,28 @@ def build_terminal_bench_remote_executor_command_adapter(
     """
 
     safe_benchmark_id = _public_safe_benchmark_label(benchmark_id, limit=80)
-    blockers = [str(item) for item in known_blockers if str(item)]
+    surface_blockers = [str(item) for item in known_blockers if str(item)]
+    blockers: list[str] = []
     if not safe_benchmark_id:
         safe_benchmark_id = TERMINAL_BENCH_DEFAULT_DATASET
-        blockers.append("terminal_bench_benchmark_id_not_public_safe")
+        surface_blockers.append("terminal_bench_benchmark_id_not_public_safe")
     if safe_benchmark_id != TERMINAL_BENCH_DEFAULT_DATASET:
-        blockers.append("terminal_bench_benchmark_id_unsupported")
+        surface_blockers.append("terminal_bench_benchmark_id_unsupported")
     if not launch_surface_ready:
-        blockers.append("terminal_bench_launch_surface_not_ready")
+        surface_blockers.append("terminal_bench_launch_surface_not_ready")
     if not poll_surface_ready:
-        blockers.append("terminal_bench_poll_surface_not_ready")
+        surface_blockers.append("terminal_bench_poll_surface_not_ready")
     if not resume_surface_ready:
-        blockers.append("terminal_bench_resume_surface_not_ready")
+        surface_blockers.append("terminal_bench_resume_surface_not_ready")
     if not compact_ingest_ready:
-        blockers.append("terminal_bench_compact_ingest_surface_not_ready")
+        surface_blockers.append("terminal_bench_compact_ingest_surface_not_ready")
     if not no_upload:
-        blockers.append("terminal_bench_no_upload_boundary_not_enabled")
+        surface_blockers.append("terminal_bench_no_upload_boundary_not_enabled")
     if submit_enabled:
-        blockers.append("terminal_bench_submit_must_remain_disabled")
+        surface_blockers.append("terminal_bench_submit_must_remain_disabled")
+    blockers.extend(surface_blockers)
+    if not remote_materializer_ready:
+        blockers.append("terminal_bench_remote_executor_materializer_missing")
 
     reducer_ready = (
         result_reducer_ready is True
@@ -3280,7 +3285,7 @@ def build_terminal_bench_remote_executor_command_adapter(
     if not reducer_ready:
         blockers.append("terminal_bench_compact_result_reducer_not_ready")
 
-    adapter_ready = not blockers
+    adapter_ready = not surface_blockers
     adapter = {
         "schema_version": TERMINAL_BENCH_REMOTE_EXECUTOR_COMMAND_ADAPTER_SCHEMA,
         "benchmark_id": safe_benchmark_id,
@@ -3308,6 +3313,7 @@ def build_terminal_bench_remote_executor_command_adapter(
             "poll_surface_ready": poll_surface_ready is True,
             "resume_surface_ready": resume_surface_ready is True,
             "compact_ingest_ready": compact_ingest_ready is True,
+            "remote_materializer_ready": remote_materializer_ready is True,
             "private_handle_values_required": True,
             "public_handle_shape_only": True,
             "local_codex_owns_auth_model_state": True,
@@ -3329,7 +3335,7 @@ def build_terminal_bench_remote_executor_command_adapter(
     return {
         "schema_version": TERMINAL_BENCH_REMOTE_EXECUTOR_COMMAND_ADAPTER_SCHEMA,
         "benchmark_id": safe_benchmark_id,
-        "ready": adapter_ready and reducer_ready,
+        "ready": adapter_ready and reducer_ready and remote_materializer_ready,
         "first_blocker": blockers[0]
         if blockers
         else "ready_for_split_control_execution_seam",
@@ -3338,7 +3344,7 @@ def build_terminal_bench_remote_executor_command_adapter(
         "command_adapter": adapter,
         "next_action": (
             "feed_terminal_bench_adapter_facts_to_split_control_execution_seam"
-            if adapter_ready and reducer_ready
+            if adapter_ready and reducer_ready and remote_materializer_ready
             else "repair_terminal_bench_adapter_surface_before_execution_seam"
         ),
         "read_boundary": {

--- a/goal_harness/benchmark_core/split_control.py
+++ b/goal_harness/benchmark_core/split_control.py
@@ -500,7 +500,13 @@ def build_split_control_remote_executor_execution_seam(
     missing_adapter_ids = [
         case["benchmark_id"]
         for case in seam_cases
-        if not case["command_materialization"]["ready"]
+        if not case["command_materialization"]["adapter_facts_ready"]
+    ]
+    missing_materializer_ids = [
+        case["benchmark_id"]
+        for case in seam_cases
+        if case["command_materialization"]["adapter_facts_ready"]
+        and not case["command_materialization"]["ready"]
     ]
     missing_reducer_ids = [
         case["benchmark_id"]
@@ -517,6 +523,8 @@ def build_split_control_remote_executor_execution_seam(
         seam_blockers.append("runner_batch_has_no_cases")
     if missing_adapter_ids:
         seam_blockers.append("command_adapter_missing")
+    if missing_materializer_ids:
+        seam_blockers.append("remote_executor_materializer_missing")
     if missing_reducer_ids:
         seam_blockers.append("compact_result_reducer_missing")
     seam_blockers.extend(
@@ -546,6 +554,7 @@ def build_split_control_remote_executor_execution_seam(
         "ready_to_spend": ready_to_execute and _truthy(batch.get("ready_to_spend")),
         "blockers": seam_blockers,
         "missing_command_adapter_ids": missing_adapter_ids,
+        "missing_remote_materializer_ids": missing_materializer_ids,
         "missing_result_reducer_ids": missing_reducer_ids,
         "planned_benchmark_ids": _string_list(batch.get("planned_benchmark_ids")),
         "execution_cases": seam_cases,
@@ -620,13 +629,25 @@ def _execution_seam_case_from_runner_case(
     benchmark_id = str(runner_case.get("benchmark_id"))
     adapter_ready = _truthy(adapter.get("command_adapter_ready"))
     reducer_ready = _truthy(adapter.get("result_reducer_ready"))
+    surface_contract = _as_dict(adapter.get("surface_contract"))
+    if "remote_materializer_ready" in surface_contract:
+        remote_materializer_ready = _truthy(
+            surface_contract.get("remote_materializer_ready")
+        )
+    elif "remote_materializer_ready" in adapter:
+        remote_materializer_ready = _truthy(adapter.get("remote_materializer_ready"))
+    else:
+        remote_materializer_ready = True
     adapter_blockers = _string_list(adapter.get("known_blockers"))
     blockers: list[str] = []
     if not adapter_ready:
         blockers.append("command_adapter_missing")
+    if adapter_ready and not remote_materializer_ready:
+        blockers.append("remote_executor_materializer_missing")
     if not reducer_ready:
         blockers.append("compact_result_reducer_missing")
     blockers.extend(adapter_blockers)
+    materialization_ready = adapter_ready and remote_materializer_ready
     return {
         "benchmark_id": benchmark_id,
         "route": "local_agent_remote_executor",
@@ -635,16 +656,18 @@ def _execution_seam_case_from_runner_case(
         "ready_to_execute_remote_command": not blockers,
         "blockers": blockers,
         "command_materialization": {
-            "ready": adapter_ready,
+            "ready": materialization_ready,
+            "adapter_facts_ready": adapter_ready,
             "status": _compact_label(
                 str(
                     adapter.get("command_adapter_status")
-                    or ("ready" if adapter_ready else "missing")
+                    or ("ready" if materialization_ready else "missing")
                 )
             ),
             "entrypoint_label": _compact_label(
                 str(adapter.get("entrypoint_label") or "not_materialized")
             ),
+            "remote_materializer_ready": remote_materializer_ready,
             "shell_command_embedded": False,
             "argv_embedded": False,
             "host_path_embedded": False,

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -389,6 +389,11 @@ def render_terminal_bench_remote_executor_command_adapter_markdown(
     boundary = (
         adapter.get("boundary") if isinstance(adapter.get("boundary"), dict) else {}
     )
+    surface_contract = (
+        adapter.get("surface_contract")
+        if isinstance(adapter.get("surface_contract"), dict)
+        else {}
+    )
     lines = [
         "# Terminal-Bench Remote Executor Command Adapter",
         "",
@@ -398,6 +403,8 @@ def render_terminal_bench_remote_executor_command_adapter_markdown(
         f"- First blocker: `{payload.get('first_blocker')}`",
         f"- Command adapter ready: `{adapter.get('command_adapter_ready')}`",
         f"- Result reducer ready: `{adapter.get('result_reducer_ready')}`",
+        "- Remote materializer ready: "
+        f"`{surface_contract.get('remote_materializer_ready')}`",
         f"- Entrypoint label: `{adapter.get('entrypoint_label')}`",
         f"- Result reducer label: `{adapter.get('result_reducer_label')}`",
         f"- Next action: {payload.get('next_action')}",
@@ -3086,6 +3093,15 @@ def main(argv: list[str] | None = None) -> int:
         "--result-reducer-not-ready",
         action="store_true",
         help="Fixture flag for a missing compact result reducer.",
+    )
+    terminal_bench_command_adapter_parser.add_argument(
+        "--remote-materializer-ready",
+        action="store_true",
+        help=(
+            "Declare that a real remote-executor materializer exists for the "
+            "adapter labels. Omit until the runner can actually stage and poll "
+            "remote Docker/runner/data handles."
+        ),
     )
     terminal_bench_command_adapter_parser.add_argument(
         "--submit-enabled",
@@ -5954,6 +5970,7 @@ def main(argv: list[str] | None = None) -> int:
                     resume_surface_ready=not bool(args.resume_surface_not_ready),
                     compact_ingest_ready=not bool(args.compact_ingest_not_ready),
                     result_reducer_ready=not bool(args.result_reducer_not_ready),
+                    remote_materializer_ready=bool(args.remote_materializer_ready),
                     no_upload=not bool(args.submit_enabled),
                     submit_enabled=bool(args.submit_enabled),
                     known_blockers=args.surface_blocker,


### PR DESCRIPTION
## Summary
- split Terminal-Bench command-adapter facts from the real remote-executor materializer gate
- expose `remote_materializer_ready` in the adapter payload and execution seam
- report `missing_remote_materializer_ids` instead of treating a materializer gap as a missing command adapter
- update the developer workflow and focused split-control smoke

## Why
PR #207 made Terminal-Bench adapter facts consumable by the split-control execution seam, but the default payload could still be interpreted as executable even though no remote Docker/runner/data materializer exists yet. This PR makes that blocker explicit so automation writes the compact blocker instead of trying to launch the local Harbor path.

## Validation
- `python3 examples/benchmark-split-control-remote-executor-smoke.py`
- `python3 -m py_compile goal_harness/benchmark_adapters/terminal_bench.py goal_harness/benchmark_core/split_control.py goal_harness/cli.py`
- default Terminal-Bench command-adapter CLI now returns `ready=false` with `terminal_bench_remote_executor_materializer_missing`
- split-control execution-seam CLI now returns `ready_to_execute=false`, `missing_command_adapter_ids=[]`, and `missing_remote_materializer_ids=["terminal-bench@2.0"]`
- `git diff --check`
- `goal-harness check` (passes; existing duplicate-index warning only)

## Boundary
No benchmark job was launched by this PR. No raw task text, logs, trajectories, verifier output, credentials, local paths, remote paths, uploads, submit surfaces, or private state are included.
