### PR TITLE
Add Terminal-Bench remote materializer contract

### DIFF
--- a/docs/benchmark-developer-workflow.md
+++ b/docs/benchmark-developer-workflow.md
@@ -45,10 +45,14 @@ For a real benchmark slice, use this sequence:
 2. Build or inspect the split-control readiness payload.
 3. Produce a launch plan or runner batch only after a fresh readiness re-check.
 4. Build benchmark-specific command-adapter facts, such as
-   `goal-harness benchmark terminal-bench-command-adapter terminal-bench`, then
-   build the execution seam from those facts. Treat missing command adapters,
-   missing remote-executor materializers, or compact reducers as blockers
-   instead of launching a private script.
+   `goal-harness benchmark terminal-bench-command-adapter terminal-bench`.
+   When a benchmark uses private remote-executor handles, reduce them through a
+   materializer such as
+   `goal-harness benchmark terminal-bench-remote-materializer terminal-bench --handle-manifest-json <private-json>`.
+   The materializer emits only handle field presence, never handle values.
+   Then build the execution seam from those facts. Treat missing command
+   adapters, missing remote-executor materializers, or compact reducers as
+   blockers instead of launching a private script.
 5. Run the smallest no-upload dry-run or mini-pair that can answer the current
    product question.
 6. Ingest a compact result or precise blocker.
@@ -101,7 +105,7 @@ for the current machine contract.
 
 | Family | Product-path target | Current maturity |
 | --- | --- | --- |
-| Terminal-Bench | Local Codex/Goal Harness controls the attempt; remote executor provides Docker or runner substrate and compact result ingestion. | Has public adapter facts and compact reducers, but still needs the remote-executor materializer before the local launcher can count as product-path evidence. |
+| Terminal-Bench | Local Codex/Goal Harness controls the attempt; remote executor provides Docker or runner substrate and compact result ingestion. | Has public adapter facts, compact reducers, and a remote-executor materializer contract; still needs a real private handle manifest plus no-upload dry-run before the route counts as run evidence. |
 | SkillsBench | Local Codex/Goal Harness controls state, prompt, and writeback; remote executor stages task files and runs Docker-bound worker surfaces. | Needs remote task staging plus remote Docker execution instead of local-only BenchFlow assumptions. |
 | Agents' Last Exam | Local Codex/Goal Harness controls the agent; remote Docker/CUA provides the sandbox; compact result or blocker is ingested locally. | A demo/tool-smoke style split-control surface is product-path proven; formal task runs still need task-data and public-claim gates. |
 

--- a/examples/benchmark-split-control-remote-executor-smoke.py
+++ b/examples/benchmark-split-control-remote-executor-smoke.py
@@ -24,7 +24,10 @@ from goal_harness.benchmark_core import (  # noqa: E402
 )
 from goal_harness.benchmark_adapters.terminal_bench import (  # noqa: E402
     TERMINAL_BENCH_REMOTE_EXECUTOR_COMMAND_ADAPTER_SCHEMA,
+    TERMINAL_BENCH_REMOTE_EXECUTOR_HANDLE_FIELDS,
+    TERMINAL_BENCH_REMOTE_EXECUTOR_MATERIALIZER_SCHEMA,
     build_terminal_bench_remote_executor_command_adapter,
+    build_terminal_bench_remote_executor_materializer,
 )
 
 
@@ -383,6 +386,31 @@ def test_terminal_bench_command_adapter_facts_feed_execution_seam() -> None:
     assert terminal_adapter["surface_contract"]["remote_executor_owns_docker_runner_data"] is True
     assert_public_safe(adapter_payload)
 
+    incomplete_materializer = build_terminal_bench_remote_executor_materializer(
+        present_handle_fields=("runner_handle",),
+    )
+    assert (
+        incomplete_materializer["schema_version"]
+        == TERMINAL_BENCH_REMOTE_EXECUTOR_MATERIALIZER_SCHEMA
+    ), incomplete_materializer
+    assert incomplete_materializer["ready"] is False, incomplete_materializer
+    assert incomplete_materializer["first_blocker"] == (
+        "terminal_bench_remote_executor_handle_manifest_incomplete"
+    )
+    assert "runner_handle" in incomplete_materializer["materializer"][
+        "present_handle_fields"
+    ]
+    assert "jobs_dir_handle" in incomplete_materializer["materializer"][
+        "missing_handle_fields"
+    ]
+    assert incomplete_materializer["materializer"][
+        "public_handle_values_recorded"
+    ] is False
+    assert incomplete_materializer["boundary"][
+        "codex_credentials_synced_to_remote"
+    ] is False
+    assert_public_safe(incomplete_materializer)
+
     readiness = build_split_control_remote_executor_readiness(
         benchmark_ids=("terminal-bench@2.0", "skillsbench@1.1"),
         local_agent={
@@ -445,9 +473,10 @@ def test_terminal_bench_command_adapter_facts_feed_execution_seam() -> None:
     )
     assert_public_safe(partial_seam)
 
-    materialized_adapter_payload = build_terminal_bench_remote_executor_command_adapter(
-        remote_materializer_ready=True,
+    materialized_adapter_payload = build_terminal_bench_remote_executor_materializer(
+        present_handle_fields=TERMINAL_BENCH_REMOTE_EXECUTOR_HANDLE_FIELDS,
     )
+    assert materialized_adapter_payload["ready"] is True, materialized_adapter_payload
     materialized_seam = build_split_control_remote_executor_execution_seam(
         batch,
         command_adapters=materialized_adapter_payload["command_adapters"],

--- a/goal_harness/benchmark_adapters/terminal_bench.py
+++ b/goal_harness/benchmark_adapters/terminal_bench.py
@@ -9,7 +9,7 @@ import tempfile
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Iterable, Sequence
+from typing import Any, Iterable, Mapping, Sequence
 
 from ..benchmark_core.io import (
     load_json_object as _load_json_object,
@@ -111,6 +111,9 @@ TERMINAL_BENCH_ENVIRONMENT_SETUP_READINESS_SCHEMA = (
 )
 TERMINAL_BENCH_REMOTE_EXECUTOR_COMMAND_ADAPTER_SCHEMA = (
     "terminal_bench_remote_executor_command_adapter_v1"
+)
+TERMINAL_BENCH_REMOTE_EXECUTOR_MATERIALIZER_SCHEMA = (
+    "terminal_bench_remote_executor_materializer_v0"
 )
 TERMINAL_BENCH_ENVIRONMENT_SETUP_PROBE_GATE_SCHEMA = (
     "terminal_bench_environment_setup_probe_gate_v0"
@@ -3231,6 +3234,18 @@ def _public_safe_benchmark_label(value: Any, *, limit: int = 120) -> str | None:
         return None
     return text[:limit]
 
+TERMINAL_BENCH_REMOTE_EXECUTOR_HANDLE_FIELDS = (
+    "benchmark_id",
+    "runner_handle",
+    "readiness_rechecked",
+    "run_root_handle",
+    "jobs_dir_handle",
+    "job_name",
+    "poll_label",
+    "cleanup_label",
+    "compact_artifact_ref",
+)
+
 def build_terminal_bench_remote_executor_command_adapter(
     *,
     benchmark_id: str = TERMINAL_BENCH_DEFAULT_DATASET,
@@ -3296,17 +3311,7 @@ def build_terminal_bench_remote_executor_command_adapter(
         "poll_label": "terminal_bench_compact_materialization_poll_surface",
         "cleanup_label": "terminal_bench_private_runner_cleanup_surface",
         "result_reducer_label": "terminal_bench_compact_harbor_result_reducer",
-        "handle_fields": [
-            "benchmark_id",
-            "runner_handle",
-            "readiness_rechecked",
-            "run_root_handle",
-            "jobs_dir_handle",
-            "job_name",
-            "poll_label",
-            "cleanup_label",
-            "compact_artifact_ref",
-        ],
+        "handle_fields": list(TERMINAL_BENCH_REMOTE_EXECUTOR_HANDLE_FIELDS),
         "known_blockers": blockers,
         "surface_contract": {
             "launch_surface_ready": launch_surface_ready is True,
@@ -3349,6 +3354,133 @@ def build_terminal_bench_remote_executor_command_adapter(
         ),
         "read_boundary": {
             "compact_only": True,
+            "shell_commands_read": False,
+            "argv_read": False,
+            "raw_task_text_read": False,
+            "raw_logs_read": False,
+            "trajectory_read": False,
+            "local_paths_recorded": False,
+            "remote_paths_recorded": False,
+            "docker_invoked": False,
+            "model_api_invoked": False,
+            "upload_invoked": False,
+            "submit_invoked": False,
+        },
+    }
+
+def build_terminal_bench_remote_executor_materializer(
+    *,
+    benchmark_id: str = TERMINAL_BENCH_DEFAULT_DATASET,
+    handle_manifest: Mapping[str, Any] | None = None,
+    present_handle_fields: Sequence[str] = (),
+    no_upload: bool = True,
+    submit_enabled: bool = False,
+    local_codex_credential_sync: bool = False,
+    remote_model_invocation: bool = False,
+    raw_material_allowed: bool = False,
+) -> dict[str, Any]:
+    """Materialize public-safe Terminal-Bench remote-executor handle shape.
+
+    The private manifest may contain real handles, paths, or process ids, but
+    this reducer records only which required fields are present. It does not
+    launch Harbor, Docker, Codex, or a model API.
+    """
+
+    safe_benchmark_id = _public_safe_benchmark_label(benchmark_id, limit=80)
+    blockers: list[str] = []
+    if not safe_benchmark_id:
+        safe_benchmark_id = TERMINAL_BENCH_DEFAULT_DATASET
+        blockers.append("terminal_bench_benchmark_id_not_public_safe")
+    if safe_benchmark_id != TERMINAL_BENCH_DEFAULT_DATASET:
+        blockers.append("terminal_bench_benchmark_id_unsupported")
+
+    manifest = dict(handle_manifest or {})
+    present = {
+        str(field)
+        for field in present_handle_fields
+        if str(field) in TERMINAL_BENCH_REMOTE_EXECUTOR_HANDLE_FIELDS
+    }
+    present.update(
+        key
+        for key, value in manifest.items()
+        if key in TERMINAL_BENCH_REMOTE_EXECUTOR_HANDLE_FIELDS
+        and value not in (None, "", [], {})
+    )
+    present.add("benchmark_id")
+    missing_fields = [
+        field
+        for field in TERMINAL_BENCH_REMOTE_EXECUTOR_HANDLE_FIELDS
+        if field not in present
+    ]
+    if missing_fields:
+        blockers.append("terminal_bench_remote_executor_handle_manifest_incomplete")
+    if not no_upload:
+        blockers.append("terminal_bench_no_upload_boundary_not_enabled")
+    if submit_enabled:
+        blockers.append("terminal_bench_submit_must_remain_disabled")
+    if local_codex_credential_sync:
+        blockers.append("terminal_bench_codex_credential_sync_forbidden")
+    if remote_model_invocation:
+        blockers.append("terminal_bench_remote_model_invocation_forbidden")
+    if raw_material_allowed:
+        blockers.append("terminal_bench_raw_material_boundary_not_enabled")
+
+    ready = not blockers
+    adapter_payload = build_terminal_bench_remote_executor_command_adapter(
+        benchmark_id=safe_benchmark_id,
+        remote_materializer_ready=ready,
+        no_upload=no_upload,
+        submit_enabled=submit_enabled,
+    )
+    return {
+        "schema_version": TERMINAL_BENCH_REMOTE_EXECUTOR_MATERIALIZER_SCHEMA,
+        "benchmark_id": safe_benchmark_id,
+        "ready": ready,
+        "first_blocker": blockers[0]
+        if blockers
+        else "ready_for_terminal_bench_remote_executor_dry_run",
+        "blockers": blockers,
+        "materializer": {
+            "entrypoint_label": "terminal_bench_no_upload_case_run_surface",
+            "ready": ready,
+            "handle_manifest_read": bool(handle_manifest),
+            "required_handle_fields": list(
+                TERMINAL_BENCH_REMOTE_EXECUTOR_HANDLE_FIELDS
+            ),
+            "present_handle_fields": [
+                field
+                for field in TERMINAL_BENCH_REMOTE_EXECUTOR_HANDLE_FIELDS
+                if field in present
+            ],
+            "missing_handle_fields": missing_fields,
+            "private_handle_values_required": True,
+            "public_handle_values_recorded": False,
+        },
+        "boundary": {
+            "compact_only": True,
+            "shell_command_embedded": False,
+            "argv_embedded": False,
+            "host_path_embedded": False,
+            "remote_path_embedded": False,
+            "raw_task_text_public": False,
+            "raw_logs_public": False,
+            "raw_trajectory_public": False,
+            "credential_values_recorded": False,
+            "codex_credentials_synced_to_remote": False,
+            "remote_model_api_invocation_allowed": False,
+            "upload_allowed": False,
+            "submit_allowed": False,
+        },
+        "command_adapters": adapter_payload["command_adapters"],
+        "command_adapter": adapter_payload["command_adapter"],
+        "next_action": (
+            "feed_materialized_terminal_bench_adapter_to_execution_seam"
+            if ready
+            else "provide_private_remote_executor_handle_manifest_before_launch"
+        ),
+        "read_boundary": {
+            "compact_only": True,
+            "handle_manifest_values_recorded": False,
             "shell_commands_read": False,
             "argv_read": False,
             "raw_task_text_read": False,

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -90,11 +90,13 @@ from .benchmark_adapters.terminal_bench import (
     TERMINAL_BENCH_MANAGED_CODEX_GOAL_HARNESS_KWARGS,
     TERMINAL_BENCH_MODES,
     TERMINAL_BENCH_REMOTE_EXECUTOR_COMMAND_ADAPTER_SCHEMA,
+    TERMINAL_BENCH_REMOTE_EXECUTOR_MATERIALIZER_SCHEMA,
     agent_kwargs_from_invocation,
     build_terminal_bench_benchmark_run,
     build_terminal_bench_environment_setup_probe_gate,
     build_terminal_bench_harbor_result_benchmark_run,
     build_terminal_bench_remote_executor_command_adapter,
+    build_terminal_bench_remote_executor_materializer,
     build_terminal_bench_result_finalization_gate,
     collect_terminal_bench_goal_harness_cli_bridge_trace,
     launch_terminal_bench_environment_setup_probe,
@@ -416,6 +418,56 @@ def render_terminal_bench_remote_executor_command_adapter_markdown(
         f"- host path embedded: `{boundary.get('host_path_embedded')}`",
         f"- raw task text public: `{boundary.get('raw_task_text_public')}`",
         f"- raw logs public: `{boundary.get('raw_logs_public')}`",
+        f"- upload allowed: `{boundary.get('upload_allowed')}`",
+        f"- submit allowed: `{boundary.get('submit_allowed')}`",
+    ]
+    blockers = payload.get("blockers")
+    if isinstance(blockers, list) and blockers:
+        lines.append("- Blockers: " + ", ".join(f"`{item}`" for item in blockers))
+    return "\n".join(lines) + "\n"
+
+
+def render_terminal_bench_remote_executor_materializer_markdown(
+    payload: dict[str, object],
+) -> str:
+    materializer = (
+        payload.get("materializer")
+        if isinstance(payload.get("materializer"), dict)
+        else {}
+    )
+    boundary = (
+        payload.get("boundary") if isinstance(payload.get("boundary"), dict) else {}
+    )
+    lines = [
+        "# Terminal-Bench Remote Executor Materializer",
+        "",
+        f"- Schema: `{payload.get('schema_version')}`",
+        f"- Benchmark: `{payload.get('benchmark_id')}`",
+        f"- Ready: `{payload.get('ready')}`",
+        f"- First blocker: `{payload.get('first_blocker')}`",
+        f"- Entrypoint label: `{materializer.get('entrypoint_label')}`",
+        f"- Manifest read: `{materializer.get('handle_manifest_read')}`",
+        "- Public handle values recorded: "
+        f"`{materializer.get('public_handle_values_recorded')}`",
+        "- Present handle fields: "
+        + ", ".join(f"`{item}`" for item in materializer.get("present_handle_fields", [])),
+        "- Missing handle fields: "
+        + ", ".join(f"`{item}`" for item in materializer.get("missing_handle_fields", [])),
+        f"- Next action: {payload.get('next_action')}",
+        "",
+        "## Boundary",
+        "",
+        f"- Compact only: `{boundary.get('compact_only')}`",
+        f"- Shell command embedded: `{boundary.get('shell_command_embedded')}`",
+        f"- argv embedded: `{boundary.get('argv_embedded')}`",
+        f"- host path embedded: `{boundary.get('host_path_embedded')}`",
+        f"- remote path embedded: `{boundary.get('remote_path_embedded')}`",
+        f"- raw task text public: `{boundary.get('raw_task_text_public')}`",
+        f"- raw logs public: `{boundary.get('raw_logs_public')}`",
+        "- Codex credentials synced to remote: "
+        f"`{boundary.get('codex_credentials_synced_to_remote')}`",
+        "- Remote model API invocation allowed: "
+        f"`{boundary.get('remote_model_api_invocation_allowed')}`",
         f"- upload allowed: `{boundary.get('upload_allowed')}`",
         f"- submit allowed: `{boundary.get('submit_allowed')}`",
     ]
@@ -3118,6 +3170,71 @@ def main(argv: list[str] | None = None) -> int:
         "--require-ready",
         action="store_true",
         help="Return non-zero unless the adapter facts are ready.",
+    )
+
+    terminal_bench_remote_materializer_parser = benchmark_sub.add_parser(
+        "terminal-bench-remote-materializer",
+        help=(
+            "Reduce private Terminal-Bench remote-executor handles to a "
+            "public-safe materializer payload. This does not execute benchmarks."
+        ),
+    )
+    add_subcommand_format(terminal_bench_remote_materializer_parser)
+    terminal_bench_remote_materializer_parser.add_argument(
+        "benchmark_name",
+        choices=["terminal-bench"],
+        help="Benchmark family. Only terminal-bench is supported.",
+    )
+    terminal_bench_remote_materializer_parser.add_argument(
+        "--benchmark-id",
+        default=TERMINAL_BENCH_DEFAULT_DATASET,
+        help="Public-safe split-control benchmark id.",
+    )
+    terminal_bench_remote_materializer_parser.add_argument(
+        "--handle-manifest-json",
+        help=(
+            "Path to a private JSON object with remote-executor handle fields. "
+            "Only field presence is emitted; values are never printed."
+        ),
+    )
+    terminal_bench_remote_materializer_parser.add_argument(
+        "--handle-field",
+        action="append",
+        default=[],
+        help=(
+            "Public-safe fixture field name to mark present without reading a "
+            "private manifest. Repeat as needed."
+        ),
+    )
+    terminal_bench_remote_materializer_parser.add_argument(
+        "--no-upload-disabled",
+        action="store_true",
+        help="Fixture flag proving upload-enabled runs are blocked.",
+    )
+    terminal_bench_remote_materializer_parser.add_argument(
+        "--submit-enabled",
+        action="store_true",
+        help="Fixture flag proving submit-enabled runs are blocked.",
+    )
+    terminal_bench_remote_materializer_parser.add_argument(
+        "--local-codex-credential-sync",
+        action="store_true",
+        help="Fixture flag proving Codex credential sync to remote is blocked.",
+    )
+    terminal_bench_remote_materializer_parser.add_argument(
+        "--remote-model-invocation",
+        action="store_true",
+        help="Fixture flag proving remote model invocation is blocked.",
+    )
+    terminal_bench_remote_materializer_parser.add_argument(
+        "--raw-material-allowed",
+        action="store_true",
+        help="Fixture flag proving raw task/log/trajectory exposure is blocked.",
+    )
+    terminal_bench_remote_materializer_parser.add_argument(
+        "--require-ready",
+        action="store_true",
+        help="Return non-zero unless the materializer payload is ready.",
     )
 
     ale_local_preflight_parser = benchmark_sub.add_parser(
@@ -6009,6 +6126,74 @@ def main(argv: list[str] | None = None) -> int:
                 payload,
                 output_format(args),
                 render_terminal_bench_remote_executor_command_adapter_markdown,
+            )
+            return 0 if payload.get("ok") else 1
+        if args.benchmark_command == "terminal-bench-remote-materializer":
+            try:
+                if args.benchmark_name != "terminal-bench":
+                    raise ValueError("only terminal-bench is supported")
+                handle_manifest = None
+                if args.handle_manifest_json:
+                    try:
+                        loaded_manifest = json.loads(
+                            Path(args.handle_manifest_json).read_text(
+                                encoding="utf-8"
+                            )
+                        )
+                    except (OSError, json.JSONDecodeError) as exc:
+                        raise ValueError(
+                            "private handle manifest could not be read as a JSON object"
+                        ) from exc
+                    if not isinstance(loaded_manifest, dict):
+                        raise ValueError("private handle manifest must be a JSON object")
+                    handle_manifest = loaded_manifest
+                payload = build_terminal_bench_remote_executor_materializer(
+                    benchmark_id=args.benchmark_id,
+                    handle_manifest=handle_manifest,
+                    present_handle_fields=args.handle_field,
+                    no_upload=not bool(args.no_upload_disabled),
+                    submit_enabled=bool(args.submit_enabled),
+                    local_codex_credential_sync=bool(
+                        args.local_codex_credential_sync
+                    ),
+                    remote_model_invocation=bool(args.remote_model_invocation),
+                    raw_material_allowed=bool(args.raw_material_allowed),
+                )
+                payload["ok"] = True
+                payload["dry_run"] = True
+                if args.require_ready and payload.get("ready") is not True:
+                    payload["ok"] = False
+                    payload["error"] = (
+                        payload.get("first_blocker")
+                        or "terminal_bench_remote_materializer_not_ready"
+                    )
+                payload["require_ready"] = bool(args.require_ready)
+            except Exception as exc:
+                payload = {
+                    "ok": False,
+                    "dry_run": True,
+                    "schema_version": TERMINAL_BENCH_REMOTE_EXECUTOR_MATERIALIZER_SCHEMA,
+                    "error": str(exc),
+                    "read_boundary": {
+                        "compact_only": True,
+                        "handle_manifest_values_recorded": False,
+                        "shell_commands_read": False,
+                        "argv_read": False,
+                        "raw_task_text_read": False,
+                        "raw_logs_read": False,
+                        "trajectory_read": False,
+                        "local_paths_recorded": False,
+                        "remote_paths_recorded": False,
+                        "docker_invoked": False,
+                        "model_api_invoked": False,
+                        "upload_invoked": False,
+                        "submit_invoked": False,
+                    },
+                }
+            print_payload(
+                payload,
+                output_format(args),
+                render_terminal_bench_remote_executor_materializer_markdown,
             )
             return 0 if payload.get("ok") else 1
         if args.benchmark_command == "ale-local-preflight":


### PR DESCRIPTION
## Summary
- add a Terminal-Bench remote-executor materializer contract that reduces private runner handles to public-safe field presence
- expose the materializer through `goal-harness benchmark terminal-bench-remote-materializer`
- wire the materializer into the split-control smoke and benchmark developer workflow

## Validation
- `python3 -m py_compile goal_harness/benchmark_adapters/terminal_bench.py goal_harness/cli.py examples/benchmark-split-control-remote-executor-smoke.py`
- `python3 examples/benchmark-split-control-remote-executor-smoke.py`
- `goal-harness --format json benchmark terminal-bench-remote-materializer terminal-bench`
- `goal-harness --format json benchmark terminal-bench-remote-materializer terminal-bench --handle-manifest-json <private-json> --require-ready`
- `git diff --check`
- `goal-harness check` (passes with the existing duplicate-index warning)

## Boundary
- no raw task text, logs, trajectories, shell argv, local paths, remote paths, credentials, uploads, or submit evidence are recorded
- no benchmark job is launched by this PR
- remaining Terminal-Bench blocker is a real private handle manifest plus a no-upload dry-run
