### PR TITLE
Gate Terminal-Bench materializer on local driver readiness

### DIFF
--- a/docs/benchmark-developer-workflow.md
+++ b/docs/benchmark-developer-workflow.md
@@ -49,9 +49,12 @@ For a real benchmark slice, use this sequence:
    When a benchmark uses private remote-executor handles, reduce them through a
    materializer such as
    `goal-harness benchmark terminal-bench-remote-materializer terminal-bench --handle-manifest-json <private-json>`.
-   The materializer emits only handle field presence, never handle values.
-   Then build the execution seam from those facts. Treat missing command
-   adapters, missing remote-executor materializers, or compact reducers as
+   The materializer emits only handle field presence, never handle values. For
+   Terminal-Bench, handle presence is still not enough: the payload must also
+   prove that a local Codex driver owns agent/model/auth and that the remote
+   executor does not require agent or Codex runtime. Then build the execution
+   seam from those facts. Treat missing command adapters, missing local-driver
+   materializers, remote-agent-runtime requirements, or compact reducers as
    blockers instead of launching a private script.
 5. Run the smallest no-upload dry-run or mini-pair that can answer the current
    product question.
@@ -105,7 +108,7 @@ for the current machine contract.
 
 | Family | Product-path target | Current maturity |
 | --- | --- | --- |
-| Terminal-Bench | Local Codex/Goal Harness controls the attempt; remote executor provides Docker or runner substrate and compact result ingestion. | Has public adapter facts, compact reducers, and a remote-executor materializer contract; still needs a real private handle manifest plus no-upload dry-run before the route counts as run evidence. |
+| Terminal-Bench | Local Codex/Goal Harness controls the attempt; remote executor provides Docker or runner substrate and compact result ingestion. | Has public adapter facts, compact reducers, and a remote-executor materializer contract; current blocker is a local-Codex driver / remote-sandbox seam. A direct Harbor/remote-Docker path that requires agent or Codex runtime inside the remote worker is not product-path evidence. |
 | SkillsBench | Local Codex/Goal Harness controls state, prompt, and writeback; remote executor stages task files and runs Docker-bound worker surfaces. | Needs remote task staging plus remote Docker execution instead of local-only BenchFlow assumptions. |
 | Agents' Last Exam | Local Codex/Goal Harness controls the agent; remote Docker/CUA provides the sandbox; compact result or blocker is ingested locally. | A demo/tool-smoke style split-control surface is product-path proven; formal task runs still need task-data and public-claim gates. |
 

--- a/examples/benchmark-split-control-remote-executor-smoke.py
+++ b/examples/benchmark-split-control-remote-executor-smoke.py
@@ -411,6 +411,32 @@ def test_terminal_bench_command_adapter_facts_feed_execution_seam() -> None:
     ] is False
     assert_public_safe(incomplete_materializer)
 
+    handle_only_materializer = build_terminal_bench_remote_executor_materializer(
+        present_handle_fields=TERMINAL_BENCH_REMOTE_EXECUTOR_HANDLE_FIELDS,
+    )
+    assert handle_only_materializer["ready"] is False, handle_only_materializer
+    assert handle_only_materializer["first_blocker"] == (
+        "terminal_bench_local_codex_driver_missing"
+    )
+    assert handle_only_materializer["materializer"][
+        "local_codex_driver_ready"
+    ] is False
+    assert handle_only_materializer["boundary"][
+        "remote_agent_runtime_allowed"
+    ] is False
+    assert_public_safe(handle_only_materializer)
+
+    remote_agent_runtime_materializer = build_terminal_bench_remote_executor_materializer(
+        present_handle_fields=TERMINAL_BENCH_REMOTE_EXECUTOR_HANDLE_FIELDS,
+        local_codex_driver_ready=True,
+        remote_agent_runtime_required=True,
+    )
+    assert remote_agent_runtime_materializer["ready"] is False
+    assert remote_agent_runtime_materializer["first_blocker"] == (
+        "terminal_bench_remote_agent_runtime_forbidden"
+    )
+    assert_public_safe(remote_agent_runtime_materializer)
+
     readiness = build_split_control_remote_executor_readiness(
         benchmark_ids=("terminal-bench@2.0", "skillsbench@1.1"),
         local_agent={
@@ -475,6 +501,7 @@ def test_terminal_bench_command_adapter_facts_feed_execution_seam() -> None:
 
     materialized_adapter_payload = build_terminal_bench_remote_executor_materializer(
         present_handle_fields=TERMINAL_BENCH_REMOTE_EXECUTOR_HANDLE_FIELDS,
+        local_codex_driver_ready=True,
     )
     assert materialized_adapter_payload["ready"] is True, materialized_adapter_payload
     materialized_seam = build_split_control_remote_executor_execution_seam(

--- a/goal_harness/benchmark_adapters/terminal_bench.py
+++ b/goal_harness/benchmark_adapters/terminal_bench.py
@@ -3375,6 +3375,9 @@ def build_terminal_bench_remote_executor_materializer(
     present_handle_fields: Sequence[str] = (),
     no_upload: bool = True,
     submit_enabled: bool = False,
+    local_codex_driver_ready: bool = False,
+    remote_agent_runtime_required: bool = False,
+    remote_codex_runtime_required: bool = False,
     local_codex_credential_sync: bool = False,
     remote_model_invocation: bool = False,
     raw_material_allowed: bool = False,
@@ -3414,6 +3417,12 @@ def build_terminal_bench_remote_executor_materializer(
     ]
     if missing_fields:
         blockers.append("terminal_bench_remote_executor_handle_manifest_incomplete")
+    if not local_codex_driver_ready:
+        blockers.append("terminal_bench_local_codex_driver_missing")
+    if remote_agent_runtime_required:
+        blockers.append("terminal_bench_remote_agent_runtime_forbidden")
+    if remote_codex_runtime_required:
+        blockers.append("terminal_bench_remote_codex_runtime_forbidden")
     if not no_upload:
         blockers.append("terminal_bench_no_upload_boundary_not_enabled")
     if submit_enabled:
@@ -3453,11 +3462,17 @@ def build_terminal_bench_remote_executor_materializer(
                 if field in present
             ],
             "missing_handle_fields": missing_fields,
+            "local_codex_driver_ready": local_codex_driver_ready is True,
+            "remote_agent_runtime_required": remote_agent_runtime_required is True,
+            "remote_codex_runtime_required": remote_codex_runtime_required is True,
             "private_handle_values_required": True,
             "public_handle_values_recorded": False,
         },
         "boundary": {
             "compact_only": True,
+            "local_codex_driver_required": True,
+            "remote_agent_runtime_allowed": False,
+            "remote_codex_runtime_allowed": False,
             "shell_command_embedded": False,
             "argv_embedded": False,
             "host_path_embedded": False,
@@ -3477,6 +3492,12 @@ def build_terminal_bench_remote_executor_materializer(
             "feed_materialized_terminal_bench_adapter_to_execution_seam"
             if ready
             else "provide_private_remote_executor_handle_manifest_before_launch"
+            if missing_fields
+            else "implement_terminal_bench_local_codex_driver_before_launch"
+            if not local_codex_driver_ready
+            else "remove_remote_agent_runtime_from_terminal_bench_execution_path"
+            if remote_agent_runtime_required or remote_codex_runtime_required
+            else "repair_terminal_bench_materializer_boundary_before_launch"
         ),
         "read_boundary": {
             "compact_only": True,

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -449,6 +449,12 @@ def render_terminal_bench_remote_executor_materializer_markdown(
         f"- Manifest read: `{materializer.get('handle_manifest_read')}`",
         "- Public handle values recorded: "
         f"`{materializer.get('public_handle_values_recorded')}`",
+        "- Local Codex driver ready: "
+        f"`{materializer.get('local_codex_driver_ready')}`",
+        "- Remote agent runtime required: "
+        f"`{materializer.get('remote_agent_runtime_required')}`",
+        "- Remote Codex runtime required: "
+        f"`{materializer.get('remote_codex_runtime_required')}`",
         "- Present handle fields: "
         + ", ".join(f"`{item}`" for item in materializer.get("present_handle_fields", [])),
         "- Missing handle fields: "
@@ -458,6 +464,9 @@ def render_terminal_bench_remote_executor_materializer_markdown(
         "## Boundary",
         "",
         f"- Compact only: `{boundary.get('compact_only')}`",
+        f"- Local Codex driver required: `{boundary.get('local_codex_driver_required')}`",
+        f"- Remote agent runtime allowed: `{boundary.get('remote_agent_runtime_allowed')}`",
+        f"- Remote Codex runtime allowed: `{boundary.get('remote_codex_runtime_allowed')}`",
         f"- Shell command embedded: `{boundary.get('shell_command_embedded')}`",
         f"- argv embedded: `{boundary.get('argv_embedded')}`",
         f"- host path embedded: `{boundary.get('host_path_embedded')}`",
@@ -3215,6 +3224,24 @@ def main(argv: list[str] | None = None) -> int:
         "--submit-enabled",
         action="store_true",
         help="Fixture flag proving submit-enabled runs are blocked.",
+    )
+    terminal_bench_remote_materializer_parser.add_argument(
+        "--local-codex-driver-ready",
+        action="store_true",
+        help=(
+            "Declare that a local Codex driver can control the case while the "
+            "remote executor owns only Docker/runner/data work."
+        ),
+    )
+    terminal_bench_remote_materializer_parser.add_argument(
+        "--remote-agent-runtime-required",
+        action="store_true",
+        help="Fixture flag proving remote agent-runtime execution is blocked.",
+    )
+    terminal_bench_remote_materializer_parser.add_argument(
+        "--remote-codex-runtime-required",
+        action="store_true",
+        help="Fixture flag proving remote Codex-runtime execution is blocked.",
     )
     terminal_bench_remote_materializer_parser.add_argument(
         "--local-codex-credential-sync",
@@ -6153,6 +6180,13 @@ def main(argv: list[str] | None = None) -> int:
                     present_handle_fields=args.handle_field,
                     no_upload=not bool(args.no_upload_disabled),
                     submit_enabled=bool(args.submit_enabled),
+                    local_codex_driver_ready=bool(args.local_codex_driver_ready),
+                    remote_agent_runtime_required=bool(
+                        args.remote_agent_runtime_required
+                    ),
+                    remote_codex_runtime_required=bool(
+                        args.remote_codex_runtime_required
+                    ),
                     local_codex_credential_sync=bool(
                         args.local_codex_credential_sync
                     ),


### PR DESCRIPTION
## Summary
- require Terminal-Bench remote materializers to prove the local Codex driver is ready before the adapter can feed execution
- forbid remote agent or Codex runtime requirements in the remote executor path
- update the split-control smoke and developer workflow doc so handle-shape presence alone is not treated as product-path readiness

## Validation
- python3 -m py_compile goal_harness/benchmark_adapters/terminal_bench.py goal_harness/cli.py examples/benchmark-split-control-remote-executor-smoke.py
- python3 examples/benchmark-split-control-remote-executor-smoke.py
- CLI materializer boundary checks for handle-only, remote-agent-forbidden, and local-driver-ready paths
- git diff --check
- goal-harness check, with existing duplicate-index warning only

## Boundary
- no benchmark job launched
- no raw task text, logs, trajectories, verifier output, uploads, submissions, local private paths, or credentials included
- keeps Codex auth/model/state local while remote handles remain execution substrate only