### PR TITLE
Add Terminal-Bench local driver seam contract

### DIFF
--- a/docs/benchmark-developer-workflow.md
+++ b/docs/benchmark-developer-workflow.md
@@ -53,9 +53,11 @@ For a real benchmark slice, use this sequence:
    Terminal-Bench, handle presence is still not enough: the payload must also
    prove that a local Codex driver owns agent/model/auth and that the remote
    executor does not require agent or Codex runtime. Then build the execution
-   seam from those facts. Treat missing command adapters, missing local-driver
-   materializers, remote-agent-runtime requirements, or compact reducers as
-   blockers instead of launching a private script.
+   seam from those facts. The seam should expose both a `local_driver_contract`
+   and a `remote_sandbox_contract`; treat missing command adapters, missing
+   local-driver materializers, missing sandbox contracts, remote-agent-runtime
+   requirements, or compact reducers as blockers instead of launching a
+   private script.
 5. Run the smallest no-upload dry-run or mini-pair that can answer the current
    product question.
 6. Ingest a compact result or precise blocker.
@@ -108,7 +110,7 @@ for the current machine contract.
 
 | Family | Product-path target | Current maturity |
 | --- | --- | --- |
-| Terminal-Bench | Local Codex/Goal Harness controls the attempt; remote executor provides Docker or runner substrate and compact result ingestion. | Has public adapter facts, compact reducers, and a remote-executor materializer contract; current blocker is a local-Codex driver / remote-sandbox seam. A direct Harbor/remote-Docker path that requires agent or Codex runtime inside the remote worker is not product-path evidence. |
+| Terminal-Bench | Local Codex/Goal Harness controls the attempt; remote executor provides Docker or runner substrate and compact result ingestion. | Has public adapter facts, compact reducers, a remote-executor materializer contract, and an explicit local-driver / remote-sandbox seam contract. Current blocker is wiring that seam to one real no-upload dry-run or exact compact blocker. A direct Harbor/remote-Docker path that requires agent or Codex runtime inside the remote worker is not product-path evidence. |
 | SkillsBench | Local Codex/Goal Harness controls state, prompt, and writeback; remote executor stages task files and runs Docker-bound worker surfaces. | Needs remote task staging plus remote Docker execution instead of local-only BenchFlow assumptions. |
 | Agents' Last Exam | Local Codex/Goal Harness controls the agent; remote Docker/CUA provides the sandbox; compact result or blocker is ingested locally. | A demo/tool-smoke style split-control surface is product-path proven; formal task runs still need task-data and public-claim gates. |
 

--- a/examples/benchmark-split-control-remote-executor-smoke.py
+++ b/examples/benchmark-split-control-remote-executor-smoke.py
@@ -45,6 +45,69 @@ FORBIDDEN_TEXT = (
 )
 
 
+def ready_local_driver_contract(label: str = "local_codex_driver") -> dict[str, object]:
+    return {
+        "ready": True,
+        "driver_label": label,
+        "owns": [
+            "codex_cli",
+            "codex_auth",
+            "goal_harness_state",
+            "model_invocation",
+            "planning_and_patch_generation",
+        ],
+        "remote_request_fields": [
+            "benchmark_id",
+            "case_handle",
+            "execution_mode",
+            "no_upload",
+            "compact_artifact_ref",
+        ],
+        "keeps_local": [
+            "codex_auth",
+            "model_invocation",
+            "goal_harness_state",
+            "raw_reasoning_trace",
+        ],
+    }
+
+
+def ready_remote_sandbox_contract(label: str = "remote_executor_sandbox") -> dict[str, object]:
+    return {
+        "ready": True,
+        "sandbox_label": label,
+        "owns": [
+            "docker",
+            "runner_dependencies",
+            "task_data_staging",
+            "bounded_command_execution",
+            "compact_result_reduction",
+        ],
+        "allowed_actions": [
+            "runner_dependency_check",
+            "bounded_command_execution",
+            "compact_result_reduction",
+        ],
+        "disallowed_actions": [
+            "codex_auth_sync",
+            "credential_sync",
+            "remote_agent_runtime",
+            "remote_codex_runtime",
+            "remote_model_api_invocation",
+            "raw_task_text_publication",
+            "raw_log_publication",
+            "upload",
+            "submit",
+        ],
+        "returns": [
+            "readiness_state",
+            "job_handle",
+            "compact_result_or_blocker",
+            "cleanup_state",
+        ],
+    }
+
+
 def assert_public_safe(payload: dict[str, object]) -> None:
     text = json.dumps(payload, sort_keys=True)
     leaked = [item for item in FORBIDDEN_TEXT if item in text]
@@ -342,6 +405,12 @@ def test_partial_ready_subset_can_launch_without_remote_codex() -> None:
                 "command_adapter_status": "ready",
                 "entrypoint_label": "terminal-bench remote-executor no-upload adapter",
                 "result_reducer_label": "terminal-bench compact result reducer",
+                "local_driver_contract": ready_local_driver_contract(
+                    "terminal_bench_local_codex_driver"
+                ),
+                "remote_sandbox_contract": ready_remote_sandbox_contract(
+                    "terminal_bench_remote_sandbox"
+                ),
             },
             "skillsbench@1.1": {
                 "command_adapter_ready": True,
@@ -349,6 +418,12 @@ def test_partial_ready_subset_can_launch_without_remote_codex() -> None:
                 "command_adapter_status": "ready",
                 "entrypoint_label": "skillsbench remote-executor no-upload adapter",
                 "result_reducer_label": "skillsbench compact result reducer",
+                "local_driver_contract": ready_local_driver_contract(
+                    "skillsbench_local_codex_driver"
+                ),
+                "remote_sandbox_contract": ready_remote_sandbox_contract(
+                    "skillsbench_remote_sandbox"
+                ),
             },
         },
     )
@@ -358,6 +433,10 @@ def test_partial_ready_subset_can_launch_without_remote_codex() -> None:
     assert all(
         case["command_materialization"]["shell_command_embedded"] is False
         and case["result_reducer"]["raw_values_copied"] is False
+        and case["local_driver_contract"]["ready"] is True
+        and case["remote_sandbox_contract"]["ready"] is True
+        and case["local_driver_contract"]["credential_sync_allowed"] is False
+        and case["remote_sandbox_contract"]["remote_codex_runtime_allowed"] is False
         and case["ready_to_execute_remote_command"] is True
         for case in ready_seam["execution_cases"]
     ), ready_seam
@@ -379,12 +458,23 @@ def test_terminal_bench_command_adapter_facts_feed_execution_seam() -> None:
     assert terminal_adapter["command_adapter_ready"] is True, terminal_adapter
     assert terminal_adapter["result_reducer_ready"] is True, terminal_adapter
     assert terminal_adapter["surface_contract"]["remote_materializer_ready"] is False
+    assert terminal_adapter["local_driver_contract"]["ready"] is False
+    assert terminal_adapter["remote_sandbox_contract"]["ready"] is False
     assert terminal_adapter["boundary"]["shell_command_embedded"] is False
     assert terminal_adapter["boundary"]["argv_embedded"] is False
     assert terminal_adapter["boundary"]["host_path_embedded"] is False
     assert terminal_adapter["surface_contract"]["local_codex_owns_auth_model_state"] is True
     assert terminal_adapter["surface_contract"]["remote_executor_owns_docker_runner_data"] is True
     assert_public_safe(adapter_payload)
+
+    materializer_without_driver = build_terminal_bench_remote_executor_command_adapter(
+        remote_materializer_ready=True,
+    )
+    assert materializer_without_driver["ready"] is False, materializer_without_driver
+    assert materializer_without_driver["first_blocker"] == (
+        "terminal_bench_local_codex_driver_missing"
+    )
+    assert_public_safe(materializer_without_driver)
 
     incomplete_materializer = build_terminal_bench_remote_executor_materializer(
         present_handle_fields=("runner_handle",),
@@ -515,6 +605,14 @@ def test_terminal_bench_command_adapter_facts_feed_execution_seam() -> None:
     )
     assert materialized_terminal_case["ready_to_execute_remote_command"] is True
     assert materialized_terminal_case["command_materialization"]["ready"] is True
+    assert materialized_terminal_case["local_driver_contract"]["ready"] is True
+    assert materialized_terminal_case["remote_sandbox_contract"]["ready"] is True
+    assert materialized_terminal_case["local_driver_contract"][
+        "raw_task_text_sent_to_remote"
+    ] is False
+    assert materialized_terminal_case["remote_sandbox_contract"][
+        "remote_agent_runtime_allowed"
+    ] is False
     assert materialized_seam["missing_command_adapter_ids"] == ["skillsbench@1.1"]
     assert_public_safe(materialized_seam)
 

--- a/goal_harness/benchmark_adapters/terminal_bench.py
+++ b/goal_harness/benchmark_adapters/terminal_bench.py
@@ -3255,6 +3255,8 @@ def build_terminal_bench_remote_executor_command_adapter(
     compact_ingest_ready: bool = True,
     result_reducer_ready: bool = True,
     remote_materializer_ready: bool = False,
+    local_codex_driver_ready: bool = False,
+    remote_sandbox_ready: bool = False,
     no_upload: bool = True,
     submit_enabled: bool = False,
     known_blockers: Sequence[str] = (),
@@ -3290,6 +3292,10 @@ def build_terminal_bench_remote_executor_command_adapter(
     blockers.extend(surface_blockers)
     if not remote_materializer_ready:
         blockers.append("terminal_bench_remote_executor_materializer_missing")
+    elif not local_codex_driver_ready:
+        blockers.append("terminal_bench_local_codex_driver_missing")
+    elif not remote_sandbox_ready:
+        blockers.append("terminal_bench_remote_sandbox_contract_missing")
 
     reducer_ready = (
         result_reducer_ready is True
@@ -3324,6 +3330,64 @@ def build_terminal_bench_remote_executor_command_adapter(
             "local_codex_owns_auth_model_state": True,
             "remote_executor_owns_docker_runner_data": True,
         },
+        "local_driver_contract": {
+            "ready": remote_materializer_ready is True
+            and local_codex_driver_ready is True,
+            "driver_label": "terminal_bench_local_codex_driver",
+            "owns": [
+                "codex_cli",
+                "codex_auth",
+                "goal_harness_state",
+                "model_invocation",
+                "planning_and_patch_generation",
+            ],
+            "remote_request_fields": [
+                "benchmark_id",
+                "case_handle",
+                "execution_mode",
+                "no_upload",
+                "compact_artifact_ref",
+            ],
+            "keeps_local": [
+                "codex_auth",
+                "model_invocation",
+                "goal_harness_state",
+                "raw_reasoning_trace",
+            ],
+        },
+        "remote_sandbox_contract": {
+            "ready": remote_materializer_ready is True and remote_sandbox_ready is True,
+            "sandbox_label": "terminal_bench_remote_sandbox",
+            "owns": [
+                "docker",
+                "runner_dependencies",
+                "task_data_staging",
+                "bounded_command_execution",
+                "compact_result_reduction",
+            ],
+            "allowed_actions": [
+                "runner_dependency_check",
+                "bounded_command_execution",
+                "compact_result_reduction",
+            ],
+            "disallowed_actions": [
+                "codex_auth_sync",
+                "credential_sync",
+                "remote_agent_runtime",
+                "remote_codex_runtime",
+                "remote_model_api_invocation",
+                "raw_task_text_publication",
+                "raw_log_publication",
+                "upload",
+                "submit",
+            ],
+            "returns": [
+                "readiness_state",
+                "job_handle",
+                "compact_result_or_blocker",
+                "cleanup_state",
+            ],
+        },
         "boundary": {
             "shell_command_embedded": False,
             "argv_embedded": False,
@@ -3340,7 +3404,11 @@ def build_terminal_bench_remote_executor_command_adapter(
     return {
         "schema_version": TERMINAL_BENCH_REMOTE_EXECUTOR_COMMAND_ADAPTER_SCHEMA,
         "benchmark_id": safe_benchmark_id,
-        "ready": adapter_ready and reducer_ready and remote_materializer_ready,
+        "ready": adapter_ready
+        and reducer_ready
+        and remote_materializer_ready
+        and local_codex_driver_ready
+        and remote_sandbox_ready,
         "first_blocker": blockers[0]
         if blockers
         else "ready_for_split_control_execution_seam",
@@ -3438,6 +3506,8 @@ def build_terminal_bench_remote_executor_materializer(
     adapter_payload = build_terminal_bench_remote_executor_command_adapter(
         benchmark_id=safe_benchmark_id,
         remote_materializer_ready=ready,
+        local_codex_driver_ready=local_codex_driver_ready,
+        remote_sandbox_ready=ready,
         no_upload=no_upload,
         submit_enabled=submit_enabled,
     )

--- a/goal_harness/benchmark_core/split_control.py
+++ b/goal_harness/benchmark_core/split_control.py
@@ -638,16 +638,40 @@ def _execution_seam_case_from_runner_case(
         remote_materializer_ready = _truthy(adapter.get("remote_materializer_ready"))
     else:
         remote_materializer_ready = True
+    local_driver = _as_dict(adapter.get("local_driver_contract"))
+    remote_sandbox = _as_dict(adapter.get("remote_sandbox_contract"))
     adapter_blockers = _string_list(adapter.get("known_blockers"))
     blockers: list[str] = []
     if not adapter_ready:
         blockers.append("command_adapter_missing")
     if adapter_ready and not remote_materializer_ready:
         blockers.append("remote_executor_materializer_missing")
+    if adapter_ready and remote_materializer_ready and not _truthy(
+        local_driver.get("ready")
+    ):
+        blockers.append("local_driver_contract_missing")
+    if adapter_ready and remote_materializer_ready and not _truthy(
+        remote_sandbox.get("ready")
+    ):
+        blockers.append("remote_sandbox_contract_missing")
     if not reducer_ready:
         blockers.append("compact_result_reducer_missing")
     blockers.extend(adapter_blockers)
     materialization_ready = adapter_ready and remote_materializer_ready
+    local_agent_owns = _string_list(runner_case.get("local_agent_owns")) or [
+        "codex_cli",
+        "codex_auth",
+        "goal_harness_state",
+        "model_invocation",
+        "planning_and_patch_generation",
+    ]
+    remote_executor_owns = _string_list(runner_case.get("remote_executor_owns")) or [
+        "docker",
+        "runner_dependencies",
+        "task_data_staging",
+        "bounded_command_execution",
+        "compact_result_reduction",
+    ]
     return {
         "benchmark_id": benchmark_id,
         "route": "local_agent_remote_executor",
@@ -671,6 +695,60 @@ def _execution_seam_case_from_runner_case(
             "shell_command_embedded": False,
             "argv_embedded": False,
             "host_path_embedded": False,
+        },
+        "local_driver_contract": {
+            "ready": _truthy(local_driver.get("ready")),
+            "driver_label": _compact_label(
+                str(local_driver.get("driver_label") or "local_codex_driver")
+            ),
+            "owns": _string_list(local_driver.get("owns")) or local_agent_owns,
+            "remote_request_fields": _string_list(
+                local_driver.get("remote_request_fields")
+            )
+            or [
+                "benchmark_id",
+                "case_handle",
+                "execution_mode",
+                "no_upload",
+                "compact_artifact_ref",
+            ],
+            "keeps_local": _string_list(local_driver.get("keeps_local"))
+            or [
+                "codex_auth",
+                "model_invocation",
+                "goal_harness_state",
+                "raw_reasoning_trace",
+            ],
+            "credential_sync_allowed": False,
+            "remote_model_invocation_allowed": False,
+            "raw_task_text_sent_to_remote": False,
+            "shell_command_embedded": False,
+            "argv_embedded": False,
+        },
+        "remote_sandbox_contract": {
+            "ready": _truthy(remote_sandbox.get("ready")),
+            "sandbox_label": _compact_label(
+                str(remote_sandbox.get("sandbox_label") or "remote_executor_sandbox")
+            ),
+            "owns": _string_list(remote_sandbox.get("owns")) or remote_executor_owns,
+            "allowed_actions": _string_list(remote_sandbox.get("allowed_actions"))
+            or _string_list(runner_case.get("remote_executor_allowed_actions")),
+            "disallowed_actions": _string_list(
+                remote_sandbox.get("disallowed_actions")
+            )
+            or _string_list(runner_case.get("remote_executor_disallowed_actions")),
+            "returns": _string_list(remote_sandbox.get("returns"))
+            or [
+                "readiness_state",
+                "job_handle",
+                "compact_result_or_blocker",
+                "cleanup_state",
+            ],
+            "remote_agent_runtime_allowed": False,
+            "remote_codex_runtime_allowed": False,
+            "remote_model_api_invocation_allowed": False,
+            "raw_logs_public": False,
+            "raw_trajectory_public": False,
         },
         "execution_handle_contract": {
             "required_fields": _string_list(adapter.get("handle_fields"))

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -368,12 +368,24 @@ def render_split_control_execution_seam_markdown(payload: dict[str, object]) -> 
                 if isinstance(case.get("command_materialization"), dict)
                 else {}
             )
+            local_driver = (
+                case.get("local_driver_contract")
+                if isinstance(case.get("local_driver_contract"), dict)
+                else {}
+            )
+            remote_sandbox = (
+                case.get("remote_sandbox_contract")
+                if isinstance(case.get("remote_sandbox_contract"), dict)
+                else {}
+            )
             reducer = case.get("result_reducer") if isinstance(case.get("result_reducer"), dict) else {}
             lines.append(
                 "- "
                 + f"`{case.get('benchmark_id')}`: command_ready="
                 + f"`{materialization.get('ready')}`, reducer_ready="
-                + f"`{reducer.get('ready')}`, blockers="
+                + f"`{reducer.get('ready')}`, local_driver="
+                + f"`{local_driver.get('ready')}`, remote_sandbox="
+                + f"`{remote_sandbox.get('ready')}`, blockers="
                 + "`"
                 + ",".join(str(item) for item in case.get("blockers", []))
                 + "`"
@@ -396,6 +408,16 @@ def render_terminal_bench_remote_executor_command_adapter_markdown(
         if isinstance(adapter.get("surface_contract"), dict)
         else {}
     )
+    local_driver_contract = (
+        adapter.get("local_driver_contract")
+        if isinstance(adapter.get("local_driver_contract"), dict)
+        else {}
+    )
+    remote_sandbox_contract = (
+        adapter.get("remote_sandbox_contract")
+        if isinstance(adapter.get("remote_sandbox_contract"), dict)
+        else {}
+    )
     lines = [
         "# Terminal-Bench Remote Executor Command Adapter",
         "",
@@ -410,6 +432,13 @@ def render_terminal_bench_remote_executor_command_adapter_markdown(
         f"- Entrypoint label: `{adapter.get('entrypoint_label')}`",
         f"- Result reducer label: `{adapter.get('result_reducer_label')}`",
         f"- Next action: {payload.get('next_action')}",
+        "",
+        "## Local Driver And Remote Sandbox",
+        "",
+        f"- Local driver ready: `{local_driver_contract.get('ready')}`",
+        f"- Local driver label: `{local_driver_contract.get('driver_label')}`",
+        f"- Remote sandbox ready: `{remote_sandbox_contract.get('ready')}`",
+        f"- Remote sandbox label: `{remote_sandbox_contract.get('sandbox_label')}`",
         "",
         "## Boundary",
         "",
@@ -3162,6 +3191,22 @@ def main(argv: list[str] | None = None) -> int:
             "Declare that a real remote-executor materializer exists for the "
             "adapter labels. Omit until the runner can actually stage and poll "
             "remote Docker/runner/data handles."
+        ),
+    )
+    terminal_bench_command_adapter_parser.add_argument(
+        "--local-codex-driver-ready",
+        action="store_true",
+        help=(
+            "Declare that the local Codex driver owns agent/model/auth/state "
+            "for the Terminal-Bench case."
+        ),
+    )
+    terminal_bench_command_adapter_parser.add_argument(
+        "--remote-sandbox-ready",
+        action="store_true",
+        help=(
+            "Declare that the remote executor is only a sandbox for "
+            "Docker/runner/data execution and compact artifact return."
         ),
     )
     terminal_bench_command_adapter_parser.add_argument(
@@ -6115,6 +6160,8 @@ def main(argv: list[str] | None = None) -> int:
                     compact_ingest_ready=not bool(args.compact_ingest_not_ready),
                     result_reducer_ready=not bool(args.result_reducer_not_ready),
                     remote_materializer_ready=bool(args.remote_materializer_ready),
+                    local_codex_driver_ready=bool(args.local_codex_driver_ready),
+                    remote_sandbox_ready=bool(args.remote_sandbox_ready),
                     no_upload=not bool(args.submit_enabled),
                     submit_enabled=bool(args.submit_enabled),
                     known_blockers=args.surface_blocker,


### PR DESCRIPTION
## Summary
- add explicit local_driver_contract and remote_sandbox_contract to split-control execution seam cases
- make Terminal-Bench adapter/materializer require both local Codex driver readiness and remote sandbox readiness before product-path execution
- expose the new readiness flags in CLI output and update the benchmark developer workflow plus smoke coverage

## Validation
- python3 -m py_compile goal_harness/benchmark_core/split_control.py goal_harness/benchmark_adapters/terminal_bench.py goal_harness/cli.py examples/benchmark-split-control-remote-executor-smoke.py
- python3 examples/benchmark-split-control-remote-executor-smoke.py
- python3 examples/benchmark-developer-workflow-doc-smoke.py
- CLI positive/negative checks for terminal-bench-command-adapter local-driver readiness
- CLI materializer to split-control execution-seam check with compact fixture handles only
- git diff --check
- goal-harness check on changed public files, with existing duplicate-index warning only

## Boundary
- no benchmark job launched
- no raw task text, logs, trajectories, verifier output, uploads, submissions, local private paths, or credentials included
- preserves the local Codex CLI/auth/model/state boundary; remote executor remains Docker/runner/data sandbox only
