### PR TITLE
Add Terminal-Bench remote launch adapter

### DIFF
--- a/docs/benchmark-developer-workflow.md
+++ b/docs/benchmark-developer-workflow.md
@@ -46,18 +46,23 @@ For a real benchmark slice, use this sequence:
 3. Produce a launch plan or runner batch only after a fresh readiness re-check.
 4. Build benchmark-specific command-adapter facts, such as
    `goal-harness benchmark terminal-bench-command-adapter terminal-bench`.
-   When a benchmark uses private remote-executor handles, reduce them through a
-   materializer such as
+   When Terminal-Bench uses a remote executor, first reduce the local-driver
+   request plus private remote launch result through the launch adapter:
+   `goal-harness benchmark terminal-bench-remote-launch-adapter terminal-bench --request-json <private-json> --launch-result-json <private-json>`.
+   The launch adapter emits only field presence and compact blocker state; it
+   never executes SSH, Docker, Codex, model calls, uploads, or submits. If a
+   lower-level private runner already produced remote-executor handles, reduce
+   them through a materializer such as
    `goal-harness benchmark terminal-bench-remote-materializer terminal-bench --handle-manifest-json <private-json>`.
    The materializer emits only handle field presence, never handle values. For
-   Terminal-Bench, handle presence is still not enough: the payload must also
-   prove that a local Codex driver owns agent/model/auth and that the remote
-   executor does not require agent or Codex runtime. Then build the execution
-   seam from those facts. The seam should expose both a `local_driver_contract`
-   and a `remote_sandbox_contract`; treat missing command adapters, missing
-   local-driver materializers, missing sandbox contracts, remote-agent-runtime
-   requirements, or compact reducers as blockers instead of launching a
-   private script.
+   Terminal-Bench, handle presence is still not enough: the payload must prove
+   that a local Codex driver owns agent/model/auth and that the remote executor
+   does not require agent or Codex runtime. Then build the execution seam from
+   those facts. The seam should expose both a `local_driver_contract` and a
+   `remote_sandbox_contract`; treat missing command adapters, missing
+   launch-adapter results, missing local-driver materializers, missing sandbox
+   contracts, remote-agent-runtime requirements, or compact reducers as
+   blockers instead of launching a private script.
 5. Run the smallest no-upload dry-run or mini-pair that can answer the current
    product question.
 6. Ingest a compact result or precise blocker.

--- a/examples/benchmark-split-control-remote-executor-smoke.py
+++ b/examples/benchmark-split-control-remote-executor-smoke.py
@@ -25,8 +25,11 @@ from goal_harness.benchmark_core import (  # noqa: E402
 from goal_harness.benchmark_adapters.terminal_bench import (  # noqa: E402
     TERMINAL_BENCH_REMOTE_EXECUTOR_COMMAND_ADAPTER_SCHEMA,
     TERMINAL_BENCH_REMOTE_EXECUTOR_HANDLE_FIELDS,
+    TERMINAL_BENCH_REMOTE_EXECUTOR_LAUNCH_ADAPTER_SCHEMA,
     TERMINAL_BENCH_REMOTE_EXECUTOR_MATERIALIZER_SCHEMA,
+    TERMINAL_BENCH_REMOTE_EXECUTOR_REQUEST_FIELDS,
     build_terminal_bench_remote_executor_command_adapter,
+    build_terminal_bench_remote_executor_launch_adapter,
     build_terminal_bench_remote_executor_materializer,
 )
 
@@ -617,6 +620,83 @@ def test_terminal_bench_command_adapter_facts_feed_execution_seam() -> None:
     assert_public_safe(materialized_seam)
 
 
+def test_terminal_bench_remote_launch_adapter_reduces_private_launch_result() -> None:
+    missing_request = build_terminal_bench_remote_executor_launch_adapter(
+        local_codex_driver_ready=True,
+        remote_sandbox_ready=True,
+    )
+    assert (
+        missing_request["schema_version"]
+        == TERMINAL_BENCH_REMOTE_EXECUTOR_LAUNCH_ADAPTER_SCHEMA
+    ), missing_request
+    assert missing_request["ready"] is False, missing_request
+    assert missing_request["first_blocker"] == (
+        "terminal_bench_local_driver_request_incomplete"
+    )
+    assert missing_request["launch_adapter"]["private_request_values_recorded"] is False
+    assert_public_safe(missing_request)
+
+    sandbox_missing = build_terminal_bench_remote_executor_launch_adapter(
+        present_request_fields=TERMINAL_BENCH_REMOTE_EXECUTOR_REQUEST_FIELDS,
+        local_codex_driver_ready=True,
+        remote_sandbox_ready=False,
+    )
+    assert sandbox_missing["ready"] is False, sandbox_missing
+    assert sandbox_missing["first_blocker"] == (
+        "terminal_bench_remote_sandbox_contract_missing"
+    )
+    assert sandbox_missing["launch_adapter"][
+        "ready_to_request_remote_sandbox"
+    ] is False
+    assert_public_safe(sandbox_missing)
+
+    result_missing = build_terminal_bench_remote_executor_launch_adapter(
+        present_request_fields=TERMINAL_BENCH_REMOTE_EXECUTOR_REQUEST_FIELDS,
+        local_codex_driver_ready=True,
+        remote_sandbox_ready=True,
+    )
+    assert result_missing["ready"] is False, result_missing
+    assert result_missing["first_blocker"] == (
+        "terminal_bench_remote_launch_result_missing"
+    )
+    assert result_missing["launch_adapter"][
+        "ready_to_request_remote_sandbox"
+    ] is True
+    assert result_missing["next_action"] == (
+        "execute_private_remote_sandbox_and_feed_compact_launch_result_manifest"
+    )
+    assert_public_safe(result_missing)
+
+    ready = build_terminal_bench_remote_executor_launch_adapter(
+        present_request_fields=TERMINAL_BENCH_REMOTE_EXECUTOR_REQUEST_FIELDS,
+        present_launch_result_fields=TERMINAL_BENCH_REMOTE_EXECUTOR_HANDLE_FIELDS,
+        local_codex_driver_ready=True,
+        remote_sandbox_ready=True,
+    )
+    assert ready["ready"] is True, ready
+    assert ready["first_blocker"] == "ready_for_terminal_bench_execution_seam"
+    assert ready["launch_adapter"]["private_launch_result_values_recorded"] is False
+    assert ready["materializer"]["public_handle_values_recorded"] is False
+    assert ready["command_adapter"]["command_adapter_ready"] is True
+    assert ready["command_adapter"]["local_driver_contract"]["ready"] is True
+    assert ready["command_adapter"]["remote_sandbox_contract"]["ready"] is True
+    assert_public_safe(ready)
+
+    forbidden = build_terminal_bench_remote_executor_launch_adapter(
+        present_request_fields=TERMINAL_BENCH_REMOTE_EXECUTOR_REQUEST_FIELDS,
+        present_launch_result_fields=TERMINAL_BENCH_REMOTE_EXECUTOR_HANDLE_FIELDS,
+        local_codex_driver_ready=True,
+        remote_sandbox_ready=True,
+        local_codex_credential_sync=True,
+    )
+    assert forbidden["ready"] is False, forbidden
+    assert forbidden["first_blocker"] == (
+        "terminal_bench_codex_credential_sync_forbidden"
+    )
+    assert forbidden["boundary"]["codex_credentials_synced_to_remote"] is False
+    assert_public_safe(forbidden)
+
+
 def test_runner_batch_requires_fresh_readiness_recheck() -> None:
     payload = build_split_control_remote_executor_readiness(
         benchmark_ids=("terminal-bench@2.0",),
@@ -775,6 +855,7 @@ def main() -> int:
     test_ready_parallel_batch_size_is_capped()
     test_partial_ready_subset_can_launch_without_remote_codex()
     test_terminal_bench_command_adapter_facts_feed_execution_seam()
+    test_terminal_bench_remote_launch_adapter_reduces_private_launch_result()
     test_runner_batch_requires_fresh_readiness_recheck()
     test_runner_batch_sanitizes_post_launch_evidence()
     test_launch_plan_blocks_when_no_subset_is_ready()

--- a/goal_harness/benchmark_adapters/terminal_bench.py
+++ b/goal_harness/benchmark_adapters/terminal_bench.py
@@ -115,6 +115,9 @@ TERMINAL_BENCH_REMOTE_EXECUTOR_COMMAND_ADAPTER_SCHEMA = (
 TERMINAL_BENCH_REMOTE_EXECUTOR_MATERIALIZER_SCHEMA = (
     "terminal_bench_remote_executor_materializer_v0"
 )
+TERMINAL_BENCH_REMOTE_EXECUTOR_LAUNCH_ADAPTER_SCHEMA = (
+    "terminal_bench_remote_executor_launch_adapter_v0"
+)
 TERMINAL_BENCH_ENVIRONMENT_SETUP_PROBE_GATE_SCHEMA = (
     "terminal_bench_environment_setup_probe_gate_v0"
 )
@@ -3245,6 +3248,28 @@ TERMINAL_BENCH_REMOTE_EXECUTOR_HANDLE_FIELDS = (
     "cleanup_label",
     "compact_artifact_ref",
 )
+TERMINAL_BENCH_REMOTE_EXECUTOR_REQUEST_FIELDS = (
+    "benchmark_id",
+    "case_handle",
+    "execution_mode",
+    "no_upload",
+    "compact_artifact_ref",
+)
+
+def _present_fields_from_sources(
+    *,
+    manifest: Mapping[str, Any] | None,
+    present_fields: Sequence[str],
+    allowed_fields: Sequence[str],
+) -> set[str]:
+    allowed = set(allowed_fields)
+    present = {str(field) for field in present_fields if str(field) in allowed}
+    present.update(
+        key
+        for key, value in dict(manifest or {}).items()
+        if key in allowed and value not in (None, "", [], {})
+    )
+    return present
 
 def build_terminal_bench_remote_executor_command_adapter(
     *,
@@ -3572,6 +3597,212 @@ def build_terminal_bench_remote_executor_materializer(
         "read_boundary": {
             "compact_only": True,
             "handle_manifest_values_recorded": False,
+            "shell_commands_read": False,
+            "argv_read": False,
+            "raw_task_text_read": False,
+            "raw_logs_read": False,
+            "trajectory_read": False,
+            "local_paths_recorded": False,
+            "remote_paths_recorded": False,
+            "docker_invoked": False,
+            "model_api_invoked": False,
+            "upload_invoked": False,
+            "submit_invoked": False,
+        },
+    }
+
+def build_terminal_bench_remote_executor_launch_adapter(
+    *,
+    benchmark_id: str = TERMINAL_BENCH_DEFAULT_DATASET,
+    request_manifest: Mapping[str, Any] | None = None,
+    present_request_fields: Sequence[str] = (),
+    launch_result_manifest: Mapping[str, Any] | None = None,
+    present_launch_result_fields: Sequence[str] = (),
+    local_codex_driver_ready: bool = False,
+    remote_sandbox_ready: bool = False,
+    no_upload: bool = True,
+    submit_enabled: bool = False,
+    local_codex_credential_sync: bool = False,
+    remote_agent_runtime_required: bool = False,
+    remote_codex_runtime_required: bool = False,
+    remote_model_invocation: bool = False,
+    raw_material_allowed: bool = False,
+) -> dict[str, Any]:
+    """Bridge a local-driver request to private remote-sandbox launch handles.
+
+    This is the public-safe launch adapter surface. It never executes SSH,
+    Docker, Codex, or model calls, and it never records private handle values.
+    A private runner may feed field presence from its local-driver request and
+    remote launch result manifest so Goal Harness can decide whether the
+    command adapter can be materialized for the split-control execution seam.
+    """
+
+    safe_benchmark_id = _public_safe_benchmark_label(benchmark_id, limit=80)
+    blockers: list[str] = []
+    if not safe_benchmark_id:
+        safe_benchmark_id = TERMINAL_BENCH_DEFAULT_DATASET
+        blockers.append("terminal_bench_benchmark_id_not_public_safe")
+    if safe_benchmark_id != TERMINAL_BENCH_DEFAULT_DATASET:
+        blockers.append("terminal_bench_benchmark_id_unsupported")
+
+    request_present = _present_fields_from_sources(
+        manifest=request_manifest,
+        present_fields=present_request_fields,
+        allowed_fields=TERMINAL_BENCH_REMOTE_EXECUTOR_REQUEST_FIELDS,
+    )
+    request_present.add("benchmark_id")
+    request_missing = [
+        field
+        for field in TERMINAL_BENCH_REMOTE_EXECUTOR_REQUEST_FIELDS
+        if field not in request_present
+    ]
+
+    launch_result_present = _present_fields_from_sources(
+        manifest=launch_result_manifest,
+        present_fields=present_launch_result_fields,
+        allowed_fields=TERMINAL_BENCH_REMOTE_EXECUTOR_HANDLE_FIELDS,
+    )
+    launch_result_present.add("benchmark_id")
+    launch_result_missing = [
+        field
+        for field in TERMINAL_BENCH_REMOTE_EXECUTOR_HANDLE_FIELDS
+        if field not in launch_result_present
+    ]
+
+    if not local_codex_driver_ready:
+        blockers.append("terminal_bench_local_codex_driver_missing")
+    if request_missing:
+        blockers.append("terminal_bench_local_driver_request_incomplete")
+    if not remote_sandbox_ready:
+        blockers.append("terminal_bench_remote_sandbox_contract_missing")
+    if not no_upload:
+        blockers.append("terminal_bench_no_upload_boundary_not_enabled")
+    if submit_enabled:
+        blockers.append("terminal_bench_submit_must_remain_disabled")
+    if local_codex_credential_sync:
+        blockers.append("terminal_bench_codex_credential_sync_forbidden")
+    if remote_agent_runtime_required:
+        blockers.append("terminal_bench_remote_agent_runtime_forbidden")
+    if remote_codex_runtime_required:
+        blockers.append("terminal_bench_remote_codex_runtime_forbidden")
+    if remote_model_invocation:
+        blockers.append("terminal_bench_remote_model_invocation_forbidden")
+    if raw_material_allowed:
+        blockers.append("terminal_bench_raw_material_boundary_not_enabled")
+    if not launch_result_manifest and not present_launch_result_fields:
+        blockers.append("terminal_bench_remote_launch_result_missing")
+    elif launch_result_missing:
+        blockers.append("terminal_bench_remote_launch_result_incomplete")
+
+    launch_request_ready = (
+        local_codex_driver_ready is True
+        and not request_missing
+        and remote_sandbox_ready is True
+        and no_upload is True
+        and submit_enabled is False
+        and local_codex_credential_sync is False
+        and remote_agent_runtime_required is False
+        and remote_codex_runtime_required is False
+        and remote_model_invocation is False
+        and raw_material_allowed is False
+    )
+    materializer_payload = build_terminal_bench_remote_executor_materializer(
+        benchmark_id=safe_benchmark_id,
+        handle_manifest=launch_result_manifest,
+        present_handle_fields=tuple(launch_result_present),
+        no_upload=no_upload,
+        submit_enabled=submit_enabled,
+        local_codex_driver_ready=local_codex_driver_ready,
+        remote_agent_runtime_required=remote_agent_runtime_required,
+        remote_codex_runtime_required=remote_codex_runtime_required,
+        local_codex_credential_sync=local_codex_credential_sync,
+        remote_model_invocation=remote_model_invocation,
+        raw_material_allowed=raw_material_allowed,
+    )
+    ready = launch_request_ready and materializer_payload.get("ready") is True
+    materializer_blockers = [
+        str(item)
+        for item in materializer_payload.get("blockers", [])
+        if str(item) and str(item) not in blockers
+    ]
+    all_blockers = blockers + materializer_blockers
+    if not local_codex_driver_ready:
+        next_action = "implement_terminal_bench_local_driver_before_remote_launch"
+    elif request_missing:
+        next_action = "complete_terminal_bench_local_driver_request_before_remote_launch"
+    elif not remote_sandbox_ready:
+        next_action = "implement_terminal_bench_remote_sandbox_launch_adapter"
+    elif "terminal_bench_remote_launch_result_missing" in blockers:
+        next_action = "execute_private_remote_sandbox_and_feed_compact_launch_result_manifest"
+    elif launch_result_missing or materializer_blockers:
+        next_action = "repair_terminal_bench_remote_launch_result_before_materialization"
+    else:
+        next_action = "feed_launch_adapter_materialized_handles_to_execution_seam"
+
+    return {
+        "schema_version": TERMINAL_BENCH_REMOTE_EXECUTOR_LAUNCH_ADAPTER_SCHEMA,
+        "benchmark_id": safe_benchmark_id,
+        "ready": ready,
+        "first_blocker": all_blockers[0]
+        if all_blockers
+        else "ready_for_terminal_bench_execution_seam",
+        "blockers": all_blockers,
+        "launch_adapter": {
+            "request_label": "terminal_bench_local_driver_remote_sandbox_request",
+            "ready_to_request_remote_sandbox": launch_request_ready,
+            "remote_launch_result_read": bool(
+                launch_result_manifest or present_launch_result_fields
+            ),
+            "required_request_fields": list(
+                TERMINAL_BENCH_REMOTE_EXECUTOR_REQUEST_FIELDS
+            ),
+            "present_request_fields": [
+                field
+                for field in TERMINAL_BENCH_REMOTE_EXECUTOR_REQUEST_FIELDS
+                if field in request_present
+            ],
+            "missing_request_fields": request_missing,
+            "required_launch_result_fields": list(
+                TERMINAL_BENCH_REMOTE_EXECUTOR_HANDLE_FIELDS
+            ),
+            "present_launch_result_fields": [
+                field
+                for field in TERMINAL_BENCH_REMOTE_EXECUTOR_HANDLE_FIELDS
+                if field in launch_result_present
+            ],
+            "missing_launch_result_fields": launch_result_missing,
+            "local_codex_driver_ready": local_codex_driver_ready is True,
+            "remote_sandbox_ready": remote_sandbox_ready is True,
+            "private_request_values_recorded": False,
+            "private_launch_result_values_recorded": False,
+        },
+        "materializer": materializer_payload.get("materializer"),
+        "command_adapters": materializer_payload.get("command_adapters"),
+        "command_adapter": materializer_payload.get("command_adapter"),
+        "boundary": {
+            "compact_only": True,
+            "local_codex_driver_required": True,
+            "remote_sandbox_required": True,
+            "remote_agent_runtime_allowed": False,
+            "remote_codex_runtime_allowed": False,
+            "shell_command_embedded": False,
+            "argv_embedded": False,
+            "host_path_embedded": False,
+            "remote_path_embedded": False,
+            "raw_task_text_public": False,
+            "raw_logs_public": False,
+            "raw_trajectory_public": False,
+            "credential_values_recorded": False,
+            "codex_credentials_synced_to_remote": False,
+            "remote_model_api_invocation_allowed": False,
+            "upload_allowed": False,
+            "submit_allowed": False,
+        },
+        "next_action": next_action,
+        "read_boundary": {
+            "compact_only": True,
+            "request_manifest_values_recorded": False,
+            "launch_result_values_recorded": False,
             "shell_commands_read": False,
             "argv_read": False,
             "raw_task_text_read": False,

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -90,12 +90,14 @@ from .benchmark_adapters.terminal_bench import (
     TERMINAL_BENCH_MANAGED_CODEX_GOAL_HARNESS_KWARGS,
     TERMINAL_BENCH_MODES,
     TERMINAL_BENCH_REMOTE_EXECUTOR_COMMAND_ADAPTER_SCHEMA,
+    TERMINAL_BENCH_REMOTE_EXECUTOR_LAUNCH_ADAPTER_SCHEMA,
     TERMINAL_BENCH_REMOTE_EXECUTOR_MATERIALIZER_SCHEMA,
     agent_kwargs_from_invocation,
     build_terminal_bench_benchmark_run,
     build_terminal_bench_environment_setup_probe_gate,
     build_terminal_bench_harbor_result_benchmark_run,
     build_terminal_bench_remote_executor_command_adapter,
+    build_terminal_bench_remote_executor_launch_adapter,
     build_terminal_bench_remote_executor_materializer,
     build_terminal_bench_result_finalization_gate,
     collect_terminal_bench_goal_harness_cli_bridge_trace,
@@ -496,6 +498,65 @@ def render_terminal_bench_remote_executor_materializer_markdown(
         f"- Local Codex driver required: `{boundary.get('local_codex_driver_required')}`",
         f"- Remote agent runtime allowed: `{boundary.get('remote_agent_runtime_allowed')}`",
         f"- Remote Codex runtime allowed: `{boundary.get('remote_codex_runtime_allowed')}`",
+        f"- Shell command embedded: `{boundary.get('shell_command_embedded')}`",
+        f"- argv embedded: `{boundary.get('argv_embedded')}`",
+        f"- host path embedded: `{boundary.get('host_path_embedded')}`",
+        f"- remote path embedded: `{boundary.get('remote_path_embedded')}`",
+        f"- raw task text public: `{boundary.get('raw_task_text_public')}`",
+        f"- raw logs public: `{boundary.get('raw_logs_public')}`",
+        "- Codex credentials synced to remote: "
+        f"`{boundary.get('codex_credentials_synced_to_remote')}`",
+        "- Remote model API invocation allowed: "
+        f"`{boundary.get('remote_model_api_invocation_allowed')}`",
+        f"- upload allowed: `{boundary.get('upload_allowed')}`",
+        f"- submit allowed: `{boundary.get('submit_allowed')}`",
+    ]
+    blockers = payload.get("blockers")
+    if isinstance(blockers, list) and blockers:
+        lines.append("- Blockers: " + ", ".join(f"`{item}`" for item in blockers))
+    return "\n".join(lines) + "\n"
+
+
+def render_terminal_bench_remote_executor_launch_adapter_markdown(
+    payload: dict[str, object],
+) -> str:
+    launch_adapter = (
+        payload.get("launch_adapter")
+        if isinstance(payload.get("launch_adapter"), dict)
+        else {}
+    )
+    boundary = (
+        payload.get("boundary") if isinstance(payload.get("boundary"), dict) else {}
+    )
+    lines = [
+        "# Terminal-Bench Remote Executor Launch Adapter",
+        "",
+        f"- Schema: `{payload.get('schema_version')}`",
+        f"- Benchmark: `{payload.get('benchmark_id')}`",
+        f"- Ready: `{payload.get('ready')}`",
+        f"- First blocker: `{payload.get('first_blocker')}`",
+        "- Ready to request remote sandbox: "
+        f"`{launch_adapter.get('ready_to_request_remote_sandbox')}`",
+        "- Remote launch result read: "
+        f"`{launch_adapter.get('remote_launch_result_read')}`",
+        "- Local Codex driver ready: "
+        f"`{launch_adapter.get('local_codex_driver_ready')}`",
+        "- Remote sandbox ready: "
+        f"`{launch_adapter.get('remote_sandbox_ready')}`",
+        "- Missing request fields: "
+        + ", ".join(
+            f"`{item}`" for item in launch_adapter.get("missing_request_fields", [])
+        ),
+        "- Missing launch result fields: "
+        + ", ".join(
+            f"`{item}`"
+            for item in launch_adapter.get("missing_launch_result_fields", [])
+        ),
+        f"- Next action: {payload.get('next_action')}",
+        "",
+        "## Boundary",
+        "",
+        f"- Compact only: `{boundary.get('compact_only')}`",
         f"- Shell command embedded: `{boundary.get('shell_command_embedded')}`",
         f"- argv embedded: `{boundary.get('argv_embedded')}`",
         f"- host path embedded: `{boundary.get('host_path_embedded')}`",
@@ -3307,6 +3368,111 @@ def main(argv: list[str] | None = None) -> int:
         "--require-ready",
         action="store_true",
         help="Return non-zero unless the materializer payload is ready.",
+    )
+
+    terminal_bench_remote_launch_adapter_parser = benchmark_sub.add_parser(
+        "terminal-bench-remote-launch-adapter",
+        help=(
+            "Reduce a local-driver request plus private remote launch result "
+            "to public-safe Terminal-Bench launch-adapter facts. This does "
+            "not execute benchmarks."
+        ),
+    )
+    add_subcommand_format(terminal_bench_remote_launch_adapter_parser)
+    terminal_bench_remote_launch_adapter_parser.add_argument(
+        "benchmark_name",
+        choices=["terminal-bench"],
+        help="Benchmark family. Only terminal-bench is supported.",
+    )
+    terminal_bench_remote_launch_adapter_parser.add_argument(
+        "--benchmark-id",
+        default=TERMINAL_BENCH_DEFAULT_DATASET,
+        help="Public-safe split-control benchmark id.",
+    )
+    terminal_bench_remote_launch_adapter_parser.add_argument(
+        "--request-json",
+        help=(
+            "Path to a private local-driver request JSON object. Only required "
+            "field presence is emitted; values are never printed."
+        ),
+    )
+    terminal_bench_remote_launch_adapter_parser.add_argument(
+        "--request-field",
+        action="append",
+        default=[],
+        help=(
+            "Public-safe fixture request field name to mark present without "
+            "reading a private request manifest. Repeat as needed."
+        ),
+    )
+    terminal_bench_remote_launch_adapter_parser.add_argument(
+        "--launch-result-json",
+        help=(
+            "Path to a private remote launch result JSON object. Only required "
+            "handle field presence is emitted; values are never printed."
+        ),
+    )
+    terminal_bench_remote_launch_adapter_parser.add_argument(
+        "--launch-result-field",
+        action="append",
+        default=[],
+        help=(
+            "Public-safe fixture launch-result field name to mark present "
+            "without reading a private result manifest. Repeat as needed."
+        ),
+    )
+    terminal_bench_remote_launch_adapter_parser.add_argument(
+        "--local-codex-driver-ready",
+        action="store_true",
+        help="Declare that the local Codex driver owns auth/model/state.",
+    )
+    terminal_bench_remote_launch_adapter_parser.add_argument(
+        "--remote-sandbox-ready",
+        action="store_true",
+        help=(
+            "Declare that the remote executor is only a Docker/runner/data "
+            "sandbox and can return compact launch results."
+        ),
+    )
+    terminal_bench_remote_launch_adapter_parser.add_argument(
+        "--no-upload-disabled",
+        action="store_true",
+        help="Fixture flag proving upload-enabled runs are blocked.",
+    )
+    terminal_bench_remote_launch_adapter_parser.add_argument(
+        "--submit-enabled",
+        action="store_true",
+        help="Fixture flag proving submit-enabled runs are blocked.",
+    )
+    terminal_bench_remote_launch_adapter_parser.add_argument(
+        "--local-codex-credential-sync",
+        action="store_true",
+        help="Fixture flag proving Codex credential sync to remote is blocked.",
+    )
+    terminal_bench_remote_launch_adapter_parser.add_argument(
+        "--remote-agent-runtime-required",
+        action="store_true",
+        help="Fixture flag proving remote agent-runtime execution is blocked.",
+    )
+    terminal_bench_remote_launch_adapter_parser.add_argument(
+        "--remote-codex-runtime-required",
+        action="store_true",
+        help="Fixture flag proving remote Codex-runtime execution is blocked.",
+    )
+    terminal_bench_remote_launch_adapter_parser.add_argument(
+        "--remote-model-invocation",
+        action="store_true",
+        help="Fixture flag proving remote model invocation is blocked.",
+    )
+    terminal_bench_remote_launch_adapter_parser.add_argument(
+        "--raw-material-allowed",
+        action="store_true",
+        help="Fixture flag proving raw task/log/trajectory exposure is blocked.",
+    )
+    terminal_bench_remote_launch_adapter_parser.add_argument(
+        "--require-ready",
+        action="store_true",
+        help="Return non-zero unless the launch adapter is ready.",
     )
 
     ale_local_preflight_parser = benchmark_sub.add_parser(
@@ -6275,6 +6441,93 @@ def main(argv: list[str] | None = None) -> int:
                 payload,
                 output_format(args),
                 render_terminal_bench_remote_executor_materializer_markdown,
+            )
+            return 0 if payload.get("ok") else 1
+        if args.benchmark_command == "terminal-bench-remote-launch-adapter":
+            def read_private_manifest(path_text: str | None, label: str) -> dict[str, object] | None:
+                if not path_text:
+                    return None
+                try:
+                    loaded = json.loads(
+                        Path(path_text).expanduser().read_text(encoding="utf-8")
+                    )
+                except (OSError, json.JSONDecodeError) as exc:
+                    raise ValueError(
+                        f"{label} could not be read as a JSON object"
+                    ) from exc
+                if not isinstance(loaded, dict):
+                    raise ValueError(f"{label} must be a JSON object")
+                return loaded
+
+            try:
+                if args.benchmark_name != "terminal-bench":
+                    raise ValueError("only terminal-bench is supported")
+                request_manifest = read_private_manifest(
+                    args.request_json,
+                    "--request-json",
+                )
+                launch_result_manifest = read_private_manifest(
+                    args.launch_result_json,
+                    "--launch-result-json",
+                )
+                payload = build_terminal_bench_remote_executor_launch_adapter(
+                    benchmark_id=args.benchmark_id,
+                    request_manifest=request_manifest,
+                    present_request_fields=args.request_field,
+                    launch_result_manifest=launch_result_manifest,
+                    present_launch_result_fields=args.launch_result_field,
+                    local_codex_driver_ready=bool(args.local_codex_driver_ready),
+                    remote_sandbox_ready=bool(args.remote_sandbox_ready),
+                    no_upload=not bool(args.no_upload_disabled),
+                    submit_enabled=bool(args.submit_enabled),
+                    local_codex_credential_sync=bool(
+                        args.local_codex_credential_sync
+                    ),
+                    remote_agent_runtime_required=bool(
+                        args.remote_agent_runtime_required
+                    ),
+                    remote_codex_runtime_required=bool(
+                        args.remote_codex_runtime_required
+                    ),
+                    remote_model_invocation=bool(args.remote_model_invocation),
+                    raw_material_allowed=bool(args.raw_material_allowed),
+                )
+                payload["ok"] = True
+                payload["dry_run"] = True
+                if args.require_ready and payload.get("ready") is not True:
+                    payload["ok"] = False
+                    payload["error"] = (
+                        payload.get("first_blocker")
+                        or "terminal_bench_remote_launch_adapter_not_ready"
+                    )
+                payload["require_ready"] = bool(args.require_ready)
+            except Exception as exc:
+                payload = {
+                    "ok": False,
+                    "dry_run": True,
+                    "schema_version": TERMINAL_BENCH_REMOTE_EXECUTOR_LAUNCH_ADAPTER_SCHEMA,
+                    "error": str(exc),
+                    "read_boundary": {
+                        "compact_only": True,
+                        "request_manifest_values_recorded": False,
+                        "launch_result_values_recorded": False,
+                        "shell_commands_read": False,
+                        "argv_read": False,
+                        "raw_task_text_read": False,
+                        "raw_logs_read": False,
+                        "trajectory_read": False,
+                        "local_paths_recorded": False,
+                        "remote_paths_recorded": False,
+                        "docker_invoked": False,
+                        "model_api_invoked": False,
+                        "upload_invoked": False,
+                        "submit_invoked": False,
+                    },
+                }
+            print_payload(
+                payload,
+                output_format(args),
+                render_terminal_bench_remote_executor_launch_adapter_markdown,
             )
             return 0 if payload.get("ok") else 1
         if args.benchmark_command == "ale-local-preflight":


### PR DESCRIPTION
## Summary
- add a public-safe Terminal-Bench remote launch adapter that bridges local-driver request fields and private remote launch-result field presence
- expose the adapter through `goal-harness benchmark terminal-bench-remote-launch-adapter`
- extend the split-control smoke and developer workflow docs for the launch-adapter step

## Validation
- `python3 -m py_compile goal_harness/benchmark_adapters/terminal_bench.py goal_harness/cli.py examples/benchmark-split-control-remote-executor-smoke.py`
- `python3 examples/benchmark-split-control-remote-executor-smoke.py`
- `goal-harness --format json benchmark terminal-bench-remote-launch-adapter terminal-bench --local-codex-driver-ready --remote-sandbox-ready ... --require-ready`
- `python3 examples/benchmark-baseline-failure-gate-smoke.py`
- `git diff --check`
- `goal-harness check` (passes with existing duplicate-index warning)

## Boundary
- no raw benchmark task text, logs, trajectories, verifier tails, credentials, local paths, remote paths, uploads, submits, or private launch values are emitted
- the adapter does not execute SSH, Docker, Codex, or model calls; private runners feed only field-presence manifests

## Excluded
- `.local/` active state and evidence files
- raw benchmark logs, trajectories, verifier output, credentials, and private remote details
- full `examples/run-smokes.py` was started but interrupted after unrelated slow smokes; targeted smoke plus the interrupted smoke's current script passed separately
