### PR TITLE
Recover SkillsBench reward artifacts during reduction

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -464,6 +464,31 @@ def write_official_skillsbench_result(root: Path, *, reward: float = 0.0) -> Pat
     return result_path
 
 
+def write_official_skillsbench_reward_artifact_recovery_result(root: Path) -> Path:
+    run_dir = root / "official" / "2026-06-15__00-00-00" / "sample-task__abc123"
+    result_path = run_dir / "result.json"
+    write_json(
+        result_path,
+        {
+            "task_name": "sample-task",
+            "rollout_name": "sample-task__abc123",
+            "agent": "codex-acp",
+            "agent_name": "codex-acp",
+            "model": "gpt-5.5",
+            "n_tool_calls": 7,
+            "n_prompts": 1,
+            "error": None,
+            "verifier_error": "reward missing from compact result",
+            "partial_trajectory": False,
+            "trajectory_source": "acp",
+        },
+    )
+    reward_path = run_dir / "verifier" / "reward.txt"
+    reward_path.parent.mkdir(parents=True, exist_ok=True)
+    reward_path.write_text("1\n", encoding="utf-8")
+    return result_path
+
+
 def write_official_skillsbench_app_mount_failure(root: Path) -> Path:
     run_dir = root / "official" / "2026-06-15__00-00-00" / "citation-check__abc123"
     result_path = run_dir / "result.json"
@@ -811,6 +836,38 @@ def test_skillsbench_official_result_builder() -> None:
         assert compact["trials"][0]["task_id"] == "sample-task"
         assert compact["read_boundary"]["compact_only"] is True
         assert compact["read_boundary"]["trajectory_read"] is False
+
+
+def test_skillsbench_result_reward_artifact_recovery() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-reward-recovery-") as tmp:
+        result_path = write_official_skillsbench_reward_artifact_recovery_result(
+            Path(tmp)
+        )
+        compact = compact_benchmark_run(
+            build_skillsbench_benchflow_result_benchmark_run(
+                result_path,
+                route="codex-goal-mode-baseline",
+            )
+        )
+        assert compact is not None
+        assert compact["official_task_score"]["value"] == 1.0, compact
+        assert compact["official_task_score"]["passed"] is True, compact
+        assert compact["official_score_status"] == "completed", compact
+        assert compact["official_score_source"] == (
+            "official_skillsbench_rollout_verifier_reward_txt"
+        ), compact
+        assert compact["score_failure_attribution"] == "none", compact
+        assert "verifier_infrastructure_failure" not in compact.get(
+            "failure_attribution_labels", []
+        ), compact
+        assert "official_skillsbench:verifier/reward.txt" in compact[
+            "evidence_files"
+        ], compact
+        assert compact["validation"]["validation_scope"] == (
+            "official_benchflow_result_json_plus_rollout_reward_artifact"
+        ), compact
+        assert compact["progress"]["n_completed_trials"] == 1, compact
+        assert compact["progress"]["n_errored_trials"] == 0, compact
 
 
 def test_skillsbench_app_mount_failure_attribution() -> None:
@@ -3257,6 +3314,7 @@ if __name__ == "__main__":
     test_product_mode_declared_done_requires_case_state_depth()
     test_skillsbench_skeleton_builder()
     test_skillsbench_official_result_builder()
+    test_skillsbench_result_reward_artifact_recovery()
     test_skillsbench_app_mount_failure_attribution()
     test_skillsbench_app_skills_failure_attribution()
     test_skillsbench_docker_port_conflict_attribution()

--- a/goal_harness/benchmark_adapters/skillsbench.py
+++ b/goal_harness/benchmark_adapters/skillsbench.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import math
 import re
 from pathlib import Path
 from typing import Any, Iterable
@@ -45,6 +46,25 @@ def _skillsbench_public_safe_label(value: Any, *, limit: int = 120) -> str | Non
     while "--" in label:
         label = label.replace("--", "-")
     return (label or None)[:limit]
+
+
+def _skillsbench_rollout_reward_artifact(
+    result_path: Path,
+) -> tuple[float | None, str | None]:
+    reward_path = result_path.parent / "verifier" / "reward.txt"
+    if not reward_path.exists():
+        return None, None
+    try:
+        raw_reward = reward_path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None, None
+    try:
+        reward = float(raw_reward)
+    except ValueError:
+        return None, None
+    if not math.isfinite(reward):
+        return None, None
+    return reward, "official_skillsbench_rollout_verifier_reward_txt"
 
 
 def skillsbench_route_contract(route: str) -> dict[str, Any]:
@@ -1084,6 +1104,11 @@ def build_skillsbench_benchflow_result_benchmark_run(
     reward_value = rewards.get("reward")
     if not isinstance(reward_value, (int, float)) or isinstance(reward_value, bool):
         reward_value = None
+    reward_artifact_source: str | None = None
+    if reward_value is None:
+        reward_value, reward_artifact_source = _skillsbench_rollout_reward_artifact(
+            result_path
+        )
     official_passed = bool(reward_value is not None and reward_value >= 1)
 
     timing_path = result_path.with_name("timing.json")
@@ -1120,7 +1145,11 @@ def build_skillsbench_benchflow_result_benchmark_run(
             skillsbench_runner_error_attribution(error_text)
         )
         runner_score_failure_attribution = score_failure_attribution
-    if verifier_error_text:
+    if verifier_error_text and reward_artifact_source:
+        warning_labels.append(
+            "skillsbench_result_json_reward_missing_recovered_from_reward_txt"
+        )
+    elif verifier_error_text:
         exception_type = "skillsbench_verifier_error"
         failure_labels.append("verifier_infrastructure_failure")
         score_failure_attribution = "verifier_infrastructure_failure"
@@ -1133,7 +1162,9 @@ def build_skillsbench_benchflow_result_benchmark_run(
         score_failure_attribution = "official_verifier_solution_failure"
     elif reward_value == 0 and not failure_labels:
         failure_labels.append("official_score_zero_case_failure")
-    real_run_completed = not error_text and not verifier_error_text
+    real_run_completed = not error_text and (
+        not verifier_error_text or reward_artifact_source is not None
+    )
     job_name = skillsbench_job_name(dataset, task_id, route)
     controller_counters = _skillsbench_controller_trace_counters(controller_trace)
     controller_trace_present = bool(controller_counters.get("controller_trace_present"))
@@ -1151,6 +1182,8 @@ def build_skillsbench_benchflow_result_benchmark_run(
         "official_skillsbench:result.json",
         "official_skillsbench:timing.json" if timing else "official_skillsbench:timing_missing",
     ]
+    if reward_artifact_source:
+        evidence_files.append("official_skillsbench:verifier/reward.txt")
     if controller_trace_present:
         evidence_files.append("goal_harness:controller_trace.public.json")
     trajectory_summary = (
@@ -1256,6 +1289,12 @@ def build_skillsbench_benchflow_result_benchmark_run(
     official_score_source = "official_skillsbench_benchflow_result_json"
     official_score_status = "completed" if reward_value is not None else "missing"
     validation_scope = "official_benchflow_result_json_only"
+    if reward_artifact_source:
+        official_score_kind = "skillsbench_verifier_reward_recovered_from_reward_txt"
+        official_score_source = reward_artifact_source
+        validation_scope = "official_benchflow_result_json_plus_rollout_reward_artifact"
+        if not controller_trace_present:
+            counter_trust_level = "official_benchflow_result_plus_rollout_reward_artifact"
     if post_success_score:
         official_score_kind = (
             "skillsbench_verifier_reward_recovered_from_controller_trace"


### PR DESCRIPTION
## Summary
- recover SkillsBench compact scores from sibling verifier/reward.txt when result.json omits rewards.reward
- avoid classifying recovered reward artifacts as verifier infrastructure failures
- add a focused SkillsBench smoke for the result/reward mismatch shape

## Validation
- python3 -m compileall goal_harness/benchmark_adapters/skillsbench.py examples/skillsbench-benchmark-run-smoke.py
- python3 examples/skillsbench-benchmark-run-smoke.py
- git diff --check
- goal-harness check

## Excluded
- .local active state, private benchmark mirrors, raw logs, trajectories, verifier tails, credentials, uploads, submissions, and remote paths are not included.

## Residual risk
- This PR validates the reducer recovery seam; the canonical remote no-upload oracle smoke still needs to be rerun with the repaired reducer before wiring AgentBeats to local Codex/A2A.