### PR TITLE
Add SkillsBench local Codex participant ping

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -43,6 +43,7 @@ from scripts.skillsbench_automation_loop import (  # noqa: E402
     DOCKER_APT_RETRY_BEGIN,
     DOCKER_APP_SKILLS_MOUNT_BEGIN,
     DOCKER_HOST_CPU_ENV,
+    LOCAL_CODEX_PARTICIPANT_MATERIALIZATION_SCHEMA_VERSION,
     PRODUCT_MODE_CASE_STATE_PATH,
     PRODUCT_MODE_CASE_STATE_SCHEMA_VERSION,
     _tail,
@@ -55,6 +56,7 @@ from scripts.skillsbench_automation_loop import (  # noqa: E402
     build_plan,
     build_runner_failure_compact,
     main as skillsbench_automation_loop_main,
+    materialize_local_codex_participant,
     parse_args,
     product_mode_case_state_seed_text,
     reduce_result,
@@ -89,9 +91,17 @@ def test_skillsbench_local_driver_a2a_contract_keeps_codex_local() -> None:
     assert payload["ready"] is False, payload
     assert (
         payload["first_blocker"]
-        == "skillsbench_local_codex_a2a_participant_not_materialized"
+        == "skillsbench_local_codex_cli_participant_not_materialized"
     ), payload
     assert payload["local_driver_contract"]["ready"] is False, payload
+    assert (
+        payload["local_driver_contract"]["codex_cli_participant_materialized"]
+        is False
+    ), payload
+    assert (
+        payload["local_driver_contract"]["a2a_worker_handshake_materialized"]
+        is False
+    ), payload
     assert payload["local_driver_contract"]["credential_sync_allowed"] is False, payload
     assert payload["remote_executor_contract"]["ready"] is True, payload
     assert (
@@ -138,6 +148,52 @@ def test_skillsbench_local_driver_a2a_contract_ready_only_after_both_sides() -> 
     assert payload["remote_executor_contract"]["ready"] is True, payload
     assert payload["boundary"]["raw_logs_public"] is False, payload
     assert payload["read_boundary"]["compact_only"] is True, payload
+
+
+def test_skillsbench_local_driver_a2a_contract_distinguishes_cli_from_handshake() -> None:
+    payload = build_skillsbench_local_driver_a2a_contract(
+        task_id="ada-bathroom-plan-repair",
+        local_codex_driver_ready=True,
+        local_codex_cli_participant_ready=True,
+        local_a2a_worker_handshake_ready=False,
+        remote_executor_ready=True,
+        remote_task_data_ready=True,
+    )
+    assert payload["ready"] is False, payload
+    assert (
+        payload["first_blocker"]
+        == "skillsbench_local_a2a_worker_handshake_not_materialized"
+    ), payload
+    assert (
+        payload["next_action"]
+        == "wire_local_codex_participant_to_a2a_worker_before_mini_pair"
+    ), payload
+    assert (
+        payload["local_driver_contract"]["codex_cli_participant_materialized"]
+        is True
+    ), payload
+    assert (
+        payload["local_driver_contract"]["a2a_worker_handshake_materialized"]
+        is False
+    ), payload
+
+
+def test_local_codex_participant_ping_missing_binary_is_compact() -> None:
+    payload = materialize_local_codex_participant(
+        codex_bin="/definitely/missing/goal-harness-codex",
+        timeout_sec=1,
+    )
+    assert (
+        payload["schema_version"]
+        == LOCAL_CODEX_PARTICIPANT_MATERIALIZATION_SCHEMA_VERSION
+    ), payload
+    assert payload["ready"] is False, payload
+    assert payload["first_blocker"] == "local_codex_cli_not_on_path", payload
+    assert payload["codex_cli_invoked"] is False, payload
+    assert payload["raw_output_recorded"] is False, payload
+    assert payload["raw_event_jsonl_recorded"] is False, payload
+    assert payload["credential_values_recorded"] is False, payload
+    assert payload["host_paths_recorded"] is False, payload
 
 
 def test_blind_loop_continuation_reprojects_round_one_constraints() -> None:
@@ -3443,6 +3499,8 @@ if __name__ == "__main__":
     test_skillsbench_default_blind_loop_budget_is_five()
     test_skillsbench_local_driver_a2a_contract_keeps_codex_local()
     test_skillsbench_local_driver_a2a_contract_ready_only_after_both_sides()
+    test_skillsbench_local_driver_a2a_contract_distinguishes_cli_from_handshake()
+    test_local_codex_participant_ping_missing_binary_is_compact()
     test_blind_loop_continuation_reprojects_round_one_constraints()
     test_product_mode_declared_done_marker_detection()
     test_product_mode_case_state_seed_uses_active_goal_shape()

--- a/goal_harness/benchmark_adapters/skillsbench.py
+++ b/goal_harness/benchmark_adapters/skillsbench.py
@@ -281,6 +281,8 @@ def build_skillsbench_local_driver_a2a_contract(
     task_id: str = SKILLSBENCH_DEFAULT_TASK,
     pair_routes: Iterable[str] = SKILLSBENCH_LOCAL_DRIVER_A2A_PAIR_ROUTES,
     local_codex_driver_ready: bool = False,
+    local_codex_cli_participant_ready: bool | None = None,
+    local_a2a_worker_handshake_ready: bool | None = None,
     local_a2a_participant_ready: bool = False,
     remote_executor_ready: bool = False,
     remote_task_data_ready: bool = False,
@@ -336,10 +338,30 @@ def build_skillsbench_local_driver_a2a_contract(
         blockers.append("skillsbench_remote_executor_contract_missing")
     if not local_codex_driver_ready:
         blockers.append("skillsbench_local_codex_driver_not_ready")
-    if local_codex_driver_ready and not local_a2a_participant_ready:
-        blockers.append("skillsbench_local_codex_a2a_participant_not_materialized")
+    codex_cli_participant_ready = (
+        local_a2a_participant_ready
+        if local_codex_cli_participant_ready is None
+        else local_codex_cli_participant_ready
+    )
+    a2a_worker_handshake_ready = (
+        local_a2a_participant_ready
+        if local_a2a_worker_handshake_ready is None
+        else local_a2a_worker_handshake_ready
+    )
+    if local_codex_driver_ready and not codex_cli_participant_ready:
+        blockers.append("skillsbench_local_codex_cli_participant_not_materialized")
+    if (
+        local_codex_driver_ready
+        and codex_cli_participant_ready
+        and not a2a_worker_handshake_ready
+    ):
+        blockers.append("skillsbench_local_a2a_worker_handshake_not_materialized")
 
-    local_ready = local_codex_driver_ready is True and local_a2a_participant_ready is True
+    local_ready = (
+        local_codex_driver_ready is True
+        and codex_cli_participant_ready is True
+        and a2a_worker_handshake_ready is True
+    )
     remote_ready = (
         remote_executor_ready is True
         and remote_task_data_ready is True
@@ -370,9 +392,12 @@ def build_skillsbench_local_driver_a2a_contract(
     if ready:
         first_blocker = "ready_for_skillsbench_local_driver_a2a_mini_pair"
         next_action = "launch_no_upload_skillsbench_local_driver_a2a_mini_pair"
-    elif "skillsbench_local_codex_a2a_participant_not_materialized" in blockers:
-        first_blocker = "skillsbench_local_codex_a2a_participant_not_materialized"
-        next_action = "materialize_local_codex_a2a_participant_before_mini_pair"
+    elif "skillsbench_local_codex_cli_participant_not_materialized" in blockers:
+        first_blocker = "skillsbench_local_codex_cli_participant_not_materialized"
+        next_action = "materialize_local_codex_cli_participant_before_mini_pair"
+    elif "skillsbench_local_a2a_worker_handshake_not_materialized" in blockers:
+        first_blocker = "skillsbench_local_a2a_worker_handshake_not_materialized"
+        next_action = "wire_local_codex_participant_to_a2a_worker_before_mini_pair"
     elif "skillsbench_remote_executor_contract_missing" in blockers:
         first_blocker = "skillsbench_remote_executor_contract_missing"
         next_action = "materialize_remote_executor_contract_before_mini_pair"
@@ -421,7 +446,9 @@ def build_skillsbench_local_driver_a2a_contract(
                 "no_upload",
                 "compact_artifact_ref",
             ],
-            "participant_materialized": local_a2a_participant_ready is True,
+            "participant_materialized": local_ready,
+            "codex_cli_participant_materialized": codex_cli_participant_ready is True,
+            "a2a_worker_handshake_materialized": a2a_worker_handshake_ready is True,
             "credential_sync_allowed": False,
         },
         "remote_executor_contract": {

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -50,6 +50,7 @@ import shlex
 import shutil
 import subprocess
 import sys
+import tempfile
 from contextlib import redirect_stderr, redirect_stdout
 from datetime import datetime
 from pathlib import Path
@@ -86,6 +87,12 @@ SUPPORTED_ROUTES = (
 DEFAULT_ROUTE = "goal-harness-blind-loop-treatment"
 CODEX_ACP_SET_MODEL_UNSUPPORTED_LABEL = "codex_acp_set_model_unsupported"
 ACP_TRAJECTORY_SUMMARY_SCHEMA_VERSION = "skillsbench_acp_trajectory_summary_v0"
+LOCAL_CODEX_PARTICIPANT_MATERIALIZATION_SCHEMA_VERSION = (
+    "skillsbench_local_codex_participant_materialization_v0"
+)
+LOCAL_CODEX_PARTICIPANT_READY_MARKER = (
+    "GOAL_HARNESS_LOCAL_CODEX_PARTICIPANT_READY"
+)
 PRODUCT_MODE_CASE_GOAL_ID = "skillsbench-case"
 PRODUCT_MODE_CASE_STATE_PATH = benchmark_case_active_state_path(
     PRODUCT_MODE_CASE_GOAL_ID
@@ -276,6 +283,142 @@ def _json_default(value: Any) -> str:
     if isinstance(value, Path):
         return str(value)
     return str(value)
+
+
+def _compact_size_bucket(size: int) -> str:
+    if size <= 0:
+        return "empty"
+    if size < 200:
+        return "1_199"
+    if size < 1000:
+        return "200_999"
+    if size < 5000:
+        return "1000_4999"
+    return "5000_plus"
+
+
+def materialize_local_codex_participant(
+    *,
+    codex_bin: str = "codex",
+    timeout_sec: int = 120,
+) -> dict[str, Any]:
+    """Run a fixed local Codex CLI ping and return a compact materialization proof.
+
+    This proves only the local CLI participant. It does not claim that the
+    SkillsBench A2A/worker handshake is wired, and it deliberately drops raw
+    JSONL events, stderr, prompts, paths, and credentials.
+    """
+
+    resolved = shutil.which(codex_bin) if os.sep not in codex_bin else codex_bin
+    if not resolved or (os.sep in str(resolved) and not Path(resolved).exists()):
+        return {
+            "schema_version": LOCAL_CODEX_PARTICIPANT_MATERIALIZATION_SCHEMA_VERSION,
+            "ready": False,
+            "first_blocker": "local_codex_cli_not_on_path",
+            "codex_cli_available": False,
+            "codex_cli_invoked": False,
+            "raw_output_recorded": False,
+            "raw_event_jsonl_recorded": False,
+            "credential_values_recorded": False,
+            "host_paths_recorded": False,
+            "a2a_worker_handshake_ready": False,
+        }
+
+    with tempfile.TemporaryDirectory(prefix="gh-skillsbench-codex-") as tmp:
+        tmpdir = Path(tmp)
+        output_path = tmpdir / "last-message.txt"
+        prompt = (
+            "Respond with exactly this single line and nothing else: "
+            f"{LOCAL_CODEX_PARTICIPANT_READY_MARKER}"
+        )
+        cmd = [
+            resolved,
+            "exec",
+            "--ephemeral",
+            "--skip-git-repo-check",
+            "--sandbox",
+            "read-only",
+            "-C",
+            str(tmpdir),
+            "--output-last-message",
+            str(output_path),
+            "--json",
+            prompt,
+        ]
+        try:
+            proc = subprocess.run(
+                cmd,
+                cwd=tmpdir,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=timeout_sec,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            return {
+                "schema_version": LOCAL_CODEX_PARTICIPANT_MATERIALIZATION_SCHEMA_VERSION,
+                "ready": False,
+                "first_blocker": "local_codex_cli_participant_timeout",
+                "codex_cli_available": True,
+                "codex_cli_invoked": True,
+                "exit_code": None,
+                "timeout_sec": timeout_sec,
+                "stdout_len_bucket": _compact_size_bucket(
+                    len(exc.stdout or "")
+                    if isinstance(exc.stdout, str)
+                    else len(exc.stdout or b"")
+                ),
+                "stderr_len_bucket": _compact_size_bucket(
+                    len(exc.stderr or "")
+                    if isinstance(exc.stderr, str)
+                    else len(exc.stderr or b"")
+                ),
+                "raw_output_recorded": False,
+                "raw_event_jsonl_recorded": False,
+                "credential_values_recorded": False,
+                "host_paths_recorded": False,
+                "a2a_worker_handshake_ready": False,
+            }
+
+        marker = ""
+        if output_path.exists():
+            try:
+                marker = output_path.read_text(encoding="utf-8").strip()
+            except OSError:
+                marker = ""
+        stdout = proc.stdout or ""
+        stderr = proc.stderr or ""
+        event_count = len([line for line in stdout.splitlines() if line.strip()])
+        ready = proc.returncode == 0 and marker == LOCAL_CODEX_PARTICIPANT_READY_MARKER
+        if ready:
+            first_blocker = "local_codex_cli_participant_ready"
+        elif proc.returncode != 0:
+            first_blocker = "local_codex_cli_participant_exit_nonzero"
+        else:
+            first_blocker = "local_codex_cli_participant_marker_missing"
+        return {
+            "schema_version": LOCAL_CODEX_PARTICIPANT_MATERIALIZATION_SCHEMA_VERSION,
+            "ready": ready,
+            "first_blocker": first_blocker,
+            "codex_cli_available": True,
+            "codex_cli_invoked": True,
+            "exit_code": proc.returncode,
+            "marker_matched": marker == LOCAL_CODEX_PARTICIPANT_READY_MARKER,
+            "json_event_count": event_count,
+            "stdout_len_bucket": _compact_size_bucket(len(stdout)),
+            "stderr_len_bucket": _compact_size_bucket(len(stderr)),
+            "raw_output_recorded": False,
+            "raw_event_jsonl_recorded": False,
+            "credential_values_recorded": False,
+            "host_paths_recorded": False,
+            "a2a_worker_handshake_ready": False,
+            "next_blocker_after_ready": (
+                "skillsbench_local_a2a_worker_handshake_not_materialized"
+                if ready
+                else first_blocker
+            ),
+        }
 
 
 def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
@@ -2737,6 +2880,26 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help="Reduce an existing result.json for the selected job without rerunning the task.",
     )
     parser.add_argument(
+        "--local-codex-participant-ping",
+        action="store_true",
+        help=(
+            "Run a fixed local Codex CLI participant materialization ping and "
+            "print compact public-safe readiness JSON. This does not launch "
+            "BenchFlow or claim the A2A worker handshake is wired."
+        ),
+    )
+    parser.add_argument(
+        "--local-codex-bin",
+        default="codex",
+        help="Codex CLI binary for --local-codex-participant-ping.",
+    )
+    parser.add_argument(
+        "--local-codex-ping-timeout-sec",
+        type=int,
+        default=120,
+        help="Timeout for --local-codex-participant-ping.",
+    )
+    parser.add_argument(
         "--fail-fast-on-apt-risk",
         action="store_true",
         help=(
@@ -2821,6 +2984,13 @@ async def async_main(
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv or sys.argv[1:])
     logging.getLogger().setLevel(logging.WARNING)
+    if args.local_codex_participant_ping:
+        payload = materialize_local_codex_participant(
+            codex_bin=args.local_codex_bin,
+            timeout_sec=args.local_codex_ping_timeout_sec,
+        )
+        print(json.dumps(payload, indent=2, sort_keys=True, default=_json_default))
+        return 0 if payload.get("codex_cli_invoked") is True else 1
     closeout_recorded = False
     if args.run_group_id is None:
         args.run_group_id = (


### PR DESCRIPTION
## Summary
- add a compact SkillsBench local Codex CLI participant ping to the automation loop script
- split the SkillsBench local-driver contract into Codex CLI participant readiness and A2A worker handshake readiness
- keep default smoke model-free by testing missing-binary compact failure and contract state transitions

## Validation
- python3 -m compileall goal_harness/benchmark_adapters/skillsbench.py scripts/skillsbench_automation_loop.py examples/skillsbench-benchmark-run-smoke.py
- python3 examples/skillsbench-benchmark-run-smoke.py
- python3 scripts/skillsbench_automation_loop.py --local-codex-participant-ping --local-codex-ping-timeout-sec 90
- python3 examples/benchmark-split-control-remote-executor-smoke.py
- git diff --check
- goal-harness check (passes with existing duplicate-index warning)

## Excluded
- no raw event JSONL, raw model output, task text, trajectories, credentials, private paths, uploads, or submissions
- no SkillsBench task launch; this only materializes the local Codex CLI participant and narrows the next blocker to the A2A worker handshake