### PR TITLE
Allow independent work with user-gate notices

### DIFF
--- a/goal_harness/quota.py
+++ b/goal_harness/quota.py
@@ -1210,12 +1210,9 @@ def _user_gate_blocks_agent_item(gate: dict[str, Any], agent_item: dict[str, Any
             or len(gate_action_tokens & agent_tokens) >= 2
         )
     overlap = gate_tokens & agent_tokens
-    if len(overlap) >= 2:
-        return True
-
-    if agent_action_tokens and overlap:
-        return True
-    return False
+    if agent_action_tokens:
+        return len(gate_tokens & agent_action_tokens) >= 2
+    return len(overlap) >= 3
 
 
 def _scoped_user_gate_fallback(
@@ -1692,6 +1689,20 @@ def _protocol_action_packet(payload: dict[str, Any]) -> dict[str, Any]:
     requires_user_action = bool(payload.get("requires_user_action"))
     must_attempt_work = bool(execution_obligation.get("must_attempt_work"))
     scoped_user_gate_fallback = isinstance(payload.get("scoped_user_gate_fallback"), dict)
+    bounded_delivery_with_user_notice = (
+        requires_user_action
+        and not scoped_user_gate_fallback
+        and must_attempt_work
+        and bool(
+            execution_obligation.get(
+                "delivery_allowed",
+                payload.get("normal_delivery_allowed")
+                or payload.get("recovery_delivery_allowed")
+                or payload.get("self_repair_allowed")
+                or payload.get("should_run"),
+            )
+        )
+    )
     quiet_noop_allowed = (
         not requires_user_action
         and not must_attempt_work
@@ -1712,6 +1723,10 @@ def _protocol_action_packet(payload: dict[str, Any]) -> dict[str, Any]:
         agent_action = _protocol_first_candidate_action(payload) or (
             "surface the scoped user gate, then advance one non-gated fallback"
         )
+    elif bounded_delivery_with_user_notice:
+        primary_actor = "agent_with_user_gate"
+        agent_action_required = True
+        agent_action = _protocol_first_candidate_action(payload) or "advance one bounded segment"
     elif requires_user_action:
         primary_actor = "user"
         agent_action_required = False
@@ -1783,6 +1798,19 @@ def _interaction_mode(payload: dict[str, Any]) -> str:
     if payload.get("scoped_user_gate_fallback"):
         return "scoped_user_gate_fallback"
     if payload.get("requires_user_action"):
+        if (
+            bool(execution_obligation.get("must_attempt_work"))
+            and bool(
+                execution_obligation.get(
+                    "delivery_allowed",
+                    payload.get("normal_delivery_allowed")
+                    or payload.get("recovery_delivery_allowed")
+                    or payload.get("self_repair_allowed")
+                    or payload.get("should_run"),
+                )
+            )
+        ):
+            return "bounded_delivery_with_user_notice"
         if payload.get("notify_user_on_gate") or state == "operator_gate":
             return "user_gate"
         if payload.get("notify_user_on_open_todo"):
@@ -1843,6 +1871,8 @@ def _interaction_primary_agent_action(payload: dict[str, Any], *, mode: str) -> 
         return _protocol_first_candidate_action(payload) or (
             "surface the scoped user gate, then advance one non-gated fallback"
         )
+    if mode == "bounded_delivery_with_user_notice":
+        return _protocol_first_candidate_action(payload) or "advance one bounded validated segment"
     if mode in {"user_gate", "user_todo_blocker_push", "user_action_required"}:
         return "wait for user/owner action after surfacing the blocker or gate"
     if mode == "outcome_floor_recovery":
@@ -1880,6 +1910,7 @@ def _interaction_next_cli_actions(payload: dict[str, Any], *, mode: str) -> list
         "control_plane_self_repair",
         "boundary_projection_repair",
         "scoped_user_gate_fallback",
+        "bounded_delivery_with_user_notice",
     }:
         return [
             f"goal-harness refresh-state --goal-id {goal_id} --classification <validated_progress>",
@@ -1925,10 +1956,15 @@ def _interaction_contract(payload: dict[str, Any]) -> dict[str, Any]:
     mode = _interaction_mode(payload)
     user_required = bool(payload.get("requires_user_action"))
     scoped_user_gate_fallback = mode == "scoped_user_gate_fallback"
+    bounded_delivery_with_user_notice = mode == "bounded_delivery_with_user_notice"
     must_attempt = bool(execution_obligation.get("must_attempt_work")) if (
-        not user_required or scoped_user_gate_fallback
+        not user_required or scoped_user_gate_fallback or bounded_delivery_with_user_notice
     ) else False
-    delivery_allowed = (not user_required or scoped_user_gate_fallback) and bool(
+    delivery_allowed = (
+        not user_required
+        or scoped_user_gate_fallback
+        or bounded_delivery_with_user_notice
+    ) and bool(
         execution_obligation.get(
             "delivery_allowed",
             payload.get("normal_delivery_allowed")
@@ -1958,6 +1994,7 @@ def _interaction_contract(payload: dict[str, Any]) -> dict[str, Any]:
         "boundary_projection_repair",
         "external_evidence_observation",
         "scoped_user_gate_fallback",
+        "bounded_delivery_with_user_notice",
     }
     user_channel: dict[str, Any] = {
         "action_required": user_required,

--- a/regression/scoped-user-gate-fallback-contract.py
+++ b/regression/scoped-user-gate-fallback-contract.py
@@ -29,6 +29,15 @@ FALLBACK_TODO = (
     "[P2] Fold dreaming and periodic replan into the public Goal Harness server "
     "roadmap without reading internal material."
 )
+INDEPENDENT_USER_GATE = (
+    "[P0] Decide or provision the ALE task-data gate: remote executor needs "
+    "approved gated dataset access plus enough disk budget for archive download "
+    "and extraction before formal no-upload ALE task execution."
+)
+INDEPENDENT_AGENT_TODO = (
+    "[P0] Implement the SkillsBench-local ACP stdio relay/shim so BenchFlow can "
+    "drive no-upload mini-pairs while Codex auth/model/state stay local."
+)
 
 
 def build_status_payload() -> dict:
@@ -125,6 +134,99 @@ def build_status_payload() -> dict:
     }
 
 
+def build_nonblocking_user_gate_status_payload() -> dict:
+    user_todos = compact_todo_group(
+        [
+            {
+                "index": 1,
+                "done": False,
+                "text": INDEPENDENT_USER_GATE,
+                "status": "open",
+                "task_class": "user_gate",
+            }
+        ],
+        source_section="User Todo",
+        role="user",
+    )
+    agent_todos = compact_todo_group(
+        [
+            {
+                "index": 1,
+                "done": False,
+                "text": INDEPENDENT_AGENT_TODO,
+                "status": "open",
+                "task_class": "advancement_task",
+                "action_kind": "skillsbench_local_acp_stdio_relay",
+            },
+            {
+                "index": 2,
+                "done": False,
+                "text": FALLBACK_TODO,
+                "status": "open",
+                "task_class": "advancement_task",
+                "action_kind": "server_scheduled_planning_queue",
+            },
+        ],
+        source_section="Agent Todo",
+        role="agent",
+    )
+    assert user_todos is not None, user_todos
+    assert agent_todos is not None, agent_todos
+    user_asset_summary = project_asset_todo_summary(user_todos)
+    agent_asset_summary = project_asset_todo_summary(agent_todos)
+    assert user_asset_summary is not None, user_todos
+    assert agent_asset_summary is not None, agent_todos
+
+    attention_item = {
+        "goal_id": GOAL_ID,
+        "status": "eligible_with_nonblocking_user_gate",
+        "waiting_on": "codex",
+        "severity": "action",
+        "source": "latest_run",
+        "recommended_action": INDEPENDENT_AGENT_TODO,
+        "quota": {
+            "compute": 1.0,
+            "slot_minutes": 1,
+            "allowed_slots": 1440,
+            "spent_slots": 0,
+            "state": "eligible",
+            "reason": "eligible fixture",
+        },
+        "project_asset": {
+            "owner": "codex",
+            "next_action": INDEPENDENT_AGENT_TODO,
+            "stop_condition": "stop on fixture boundary",
+            "user_todos": user_asset_summary,
+            "agent_todos": agent_asset_summary,
+            "quota": {
+                "compute": 1.0,
+                "slot_minutes": 1,
+                "allowed_slots": 1440,
+                "spent_slots": 0,
+                "state": "eligible",
+                "reason": "eligible fixture",
+            },
+        },
+        "user_todos": user_todos,
+        "agent_todos": agent_todos,
+    }
+    return {
+        "ok": True,
+        "attention_queue": {"items": [attention_item]},
+        "run_history": {
+            "goals": [
+                {
+                    "id": GOAL_ID,
+                    "registry_member": True,
+                    "status": "active",
+                    "quota": {"compute": 1.0, "window_hours": 24},
+                    "latest_runs": [],
+                }
+            ]
+        },
+    }
+
+
 def main() -> int:
     guard = build_quota_should_run(build_status_payload(), goal_id=GOAL_ID)
     assert guard["should_run"] is True, guard
@@ -168,6 +270,27 @@ def main() -> int:
     assert f"scoped_user_gate: {USER_GATE}" in markdown, markdown
     assert f"scoped_user_gate_blocked_item[1]: {GATED_AGENT_TODO}" in markdown, markdown
     assert f"scoped_user_gate_selected: {FALLBACK_TODO}" in markdown, markdown
+    nonblocking = build_quota_should_run(
+        build_nonblocking_user_gate_status_payload(),
+        goal_id=GOAL_ID,
+    )
+    assert nonblocking["should_run"] is True, nonblocking
+    assert nonblocking["normal_delivery_allowed"] is True, nonblocking
+    assert "scoped_user_gate_fallback" not in nonblocking, nonblocking
+    interaction = nonblocking["interaction_contract"]
+    assert interaction["mode"] == "bounded_delivery_with_user_notice", interaction
+    assert interaction["user_channel"]["action_required"] is True, interaction
+    assert interaction["agent_channel"]["must_attempt"] is True, interaction
+    assert interaction["agent_channel"]["delivery_allowed"] is True, interaction
+    assert interaction["agent_channel"]["primary_action"].startswith(
+        "[P0] Implement the SkillsBench-local ACP stdio relay"
+    ), interaction
+    packet_summary = nonblocking["protocol_action_packet"]["summary"]
+    assert "actor=agent_with_user_gate" in packet_summary, packet_summary
+    assert "user_action_required=true" in packet_summary, packet_summary
+    assert "agent_action_required=true" in packet_summary, packet_summary
+    assert "agent_action=[P0] Implement the SkillsBench-local ACP stdio relay" in packet_summary, packet_summary
+    assert "Fold dreaming and periodic replan" not in packet_summary, packet_summary
     print("scoped-user-gate-fallback-contract-regression ok")
     return 0
 


### PR DESCRIPTION
## Summary
- tighten scoped user-gate matching so text-only gates do not block unrelated structured agent action kinds through generic token overlap
- add a bounded_delivery_with_user_notice mode so Goal Harness can notify about an open user gate while still requiring independent agent delivery
- extend the scoped-user-gate regression with the ALE gate + SkillsBench ACP relay false-positive case

## Validation
- python3 regression/scoped-user-gate-fallback-contract.py
- python3 -m py_compile goal_harness/quota.py regression/scoped-user-gate-fallback-contract.py
- goal-harness check
- git diff --check
- actual goal-harness-meta quota should-run now projects actor=agent_with_user_gate with agent_action=[P0] SkillsBench-local ACP relay while still surfacing the ALE user gate

## Note
- python3 regression/run-regressions.py was started but interrupted after 90s with no progress while inside an unrelated autonomous-replan smoke subprocess; targeted regression and goal-harness check passed for this change.

## Excluded
- no private state, raw benchmark logs, trajectories, credentials, or local runtime files