### PR TITLE
Add SkillsBench local ACP relay preflight

### DIFF
--- a/docs/benchmark-developer-workflow.md
+++ b/docs/benchmark-developer-workflow.md
@@ -116,11 +116,33 @@ for the current machine contract.
 | Family | Product-path target | Current maturity |
 | --- | --- | --- |
 | Terminal-Bench | Local Codex/Goal Harness controls the attempt; remote executor provides Docker or runner substrate and compact result ingestion. | Has public adapter facts, compact reducers, a remote-executor materializer contract, and an explicit local-driver / remote-sandbox seam contract. Current blocker is wiring that seam to one real no-upload dry-run or exact compact blocker. A direct Harbor/remote-Docker path that requires agent or Codex runtime inside the remote worker is not product-path evidence. |
-| SkillsBench | Local Codex/Goal Harness controls state, prompt, and writeback; remote executor stages task files and runs Docker-bound worker surfaces. | Needs remote task staging plus remote Docker execution instead of local-only BenchFlow assumptions. |
+| SkillsBench | Local Codex/Goal Harness controls state, prompt, and writeback; remote executor stages task files and runs Docker-bound worker surfaces. | Has a local ACP stdio relay handshake preflight that proves BenchFlow can speak to a local Codex-owned participant without copying auth or invoking a remote model runtime. Next product-path blocker is launching a no-upload mini-pair through the split-control route. |
 | Agents' Last Exam | Local Codex/Goal Harness controls the agent; remote Docker/CUA provides the sandbox; compact result or blocker is ingested locally. | A demo/tool-smoke style split-control surface is product-path proven; formal task runs still need task-data and public-claim gates. |
 
 This table is intentionally about runner maturity, not leaderboard score.
 Score claims require separate public-safe result ingestion and review.
+
+### SkillsBench Local ACP Preflight
+
+SkillsBench currently uses BenchFlow's ACP stdio worker protocol for Codex-like
+agents. For Goal Harness product-mode runs, Codex auth, model invocation, and
+goal state must stay local. Before launching a mini-pair, run:
+
+```bash
+python3 scripts/skillsbench_automation_loop.py \
+  --local-driver-worker-handshake-preflight \
+  --local-codex-cli-participant-ready \
+  --local-acp-relay-probe
+```
+
+The preflight is successful only when BenchFlow is importable, the default
+Codex agent is registered as ACP, the local Codex CLI participant was already
+materialized, and the local ACP relay completes `initialize`, `session/new`,
+`session/set_model`, and `session/prompt`. The default relay probe is dry-run:
+it does not invoke Codex, read task text, copy credentials, record raw logs, or
+launch a benchmark task. Once the payload reports
+`ready_for_skillsbench_local_driver_worker_handshake`, the next slice should be
+a no-upload mini-pair or a precise split-control launch blocker.
 
 ## Evidence Contract
 

--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -34,6 +34,10 @@ from goal_harness.benchmark_ledger import (  # noqa: E402
     load_benchmark_run_ledger,
     update_benchmark_run_ledger,
 )
+from goal_harness.benchmark_adapters.skillsbench_acp_relay import (  # noqa: E402
+    SKILLSBENCH_LOCAL_ACP_RELAY_PROBE_SCHEMA_VERSION,
+    run_skillsbench_local_acp_relay_probe,
+)
 from goal_harness.status import compact_benchmark_run  # noqa: E402
 from scripts.skillsbench_automation_loop import (  # noqa: E402
     CODEX_ACP_RUNTIME_CONTAINER_BOOTSTRAP_CMD,
@@ -207,6 +211,56 @@ def test_skillsbench_worker_handshake_preflight_exposes_acp_relay_gap() -> None:
     assert payload["benchflow_contract"]["stdio_transport_required"] is True, payload
     assert payload["local_driver_contract"]["remote_codex_runtime_allowed"] is False, payload
     assert payload["boundary"]["raw_task_text_read"] is False, payload
+    assert payload["boundary"]["credential_values_recorded"] is False, payload
+    text = json.dumps(payload, sort_keys=True)
+    for forbidden in ("/Users/", "~/.codex", "OPENAI_API_KEY", "HF_TOKEN"):
+        assert forbidden not in text, forbidden
+
+
+def test_skillsbench_local_acp_relay_probe_completes_stdio_handshake() -> None:
+    payload = run_skillsbench_local_acp_relay_probe(timeout_sec=10)
+    assert (
+        payload["schema_version"]
+        == SKILLSBENCH_LOCAL_ACP_RELAY_PROBE_SCHEMA_VERSION
+    ), payload
+    assert payload["ready"] is True, payload
+    assert payload["first_blocker"] == "skillsbench_local_acp_relay_ready", payload
+    assert payload["worker_protocol"] == "acp_stdio", payload
+    assert payload["request_count"] == 4, payload
+    assert payload["codex_cli_invoked"] is False, payload
+    assert payload["raw_output_recorded"] is False, payload
+    assert payload["raw_event_jsonl_recorded"] is False, payload
+    assert payload["credential_values_recorded"] is False, payload
+    assert payload["host_paths_recorded"] is False, payload
+    text = json.dumps(payload, sort_keys=True)
+    for forbidden in ("/Users/", "~/.codex", "OPENAI_API_KEY", "HF_TOKEN"):
+        assert forbidden not in text, forbidden
+
+
+def test_skillsbench_worker_handshake_preflight_probe_clears_relay_gap() -> None:
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "scripts/skillsbench_automation_loop.py"),
+            "--local-driver-worker-handshake-preflight",
+            "--local-codex-cli-participant-ready",
+            "--local-acp-relay-probe",
+            "--task-id",
+            "ada-bathroom-plan-repair",
+        ],
+        cwd=REPO_ROOT,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["local_driver_contract"]["acp_relay_materialized"] is True, payload
+    assert (
+        payload["local_driver_contract"]["acp_relay_probe"]["ready"] is True
+    ), payload
+    assert "skillsbench_local_acp_relay_missing" not in payload["blockers"], payload
     assert payload["boundary"]["credential_values_recorded"] is False, payload
     text = json.dumps(payload, sort_keys=True)
     for forbidden in ("/Users/", "~/.codex", "OPENAI_API_KEY", "HF_TOKEN"):
@@ -3552,6 +3606,10 @@ if __name__ == "__main__":
     test_skillsbench_local_driver_a2a_contract_keeps_codex_local()
     test_skillsbench_local_driver_a2a_contract_ready_only_after_both_sides()
     test_skillsbench_local_driver_a2a_contract_distinguishes_cli_from_handshake()
+    test_skillsbench_worker_handshake_preflight_exposes_acp_relay_gap()
+    test_skillsbench_local_acp_relay_probe_completes_stdio_handshake()
+    test_skillsbench_worker_handshake_preflight_probe_clears_relay_gap()
+    test_skillsbench_worker_handshake_preflight_missing_runtime_is_compact()
     test_local_codex_participant_ping_missing_binary_is_compact()
     test_blind_loop_continuation_reprojects_round_one_constraints()
     test_product_mode_declared_done_marker_detection()

--- a/goal_harness/benchmark_adapters/skillsbench.py
+++ b/goal_harness/benchmark_adapters/skillsbench.py
@@ -528,6 +528,7 @@ def build_skillsbench_worker_handshake_preflight(
     codex_agent_launch_registered: bool = False,
     local_codex_cli_participant_ready: bool = False,
     local_acp_relay_ready: bool = False,
+    local_acp_relay_probe: dict[str, Any] | None = None,
     remote_executor_ready: bool = True,
     remote_task_data_ready: bool = True,
     compact_artifact_reducer_ready: bool = True,
@@ -621,6 +622,9 @@ def build_skillsbench_worker_handshake_preflight(
         "local_driver_contract": {
             "codex_cli_participant_materialized": local_codex_cli_participant_ready,
             "acp_relay_materialized": local_acp_relay_ready,
+            "acp_relay_probe": _skillsbench_public_acp_relay_probe(
+                local_acp_relay_probe
+            ),
             "credential_sync_allowed": False,
             "remote_codex_runtime_allowed": False,
             "remote_model_api_invocation_allowed": False,
@@ -649,6 +653,33 @@ def build_skillsbench_worker_handshake_preflight(
             "submit_allowed": False,
         },
     }
+
+
+def _skillsbench_public_acp_relay_probe(
+    probe: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    if not isinstance(probe, dict):
+        return None
+    compact: dict[str, Any] = {}
+    for field in ("schema_version", "first_blocker", "stage", "worker_protocol"):
+        value = probe.get(field)
+        if isinstance(value, str) and value:
+            compact[field] = _skillsbench_public_safe_label(value, limit=120)
+    for field in (
+        "ready",
+        "codex_cli_invoked",
+        "raw_output_recorded",
+        "raw_event_jsonl_recorded",
+        "credential_values_recorded",
+        "host_paths_recorded",
+    ):
+        value = probe.get(field)
+        if isinstance(value, bool):
+            compact[field] = value
+    value = probe.get("request_count")
+    if isinstance(value, int) and not isinstance(value, bool):
+        compact["request_count"] = max(0, min(value, 20))
+    return compact or None
 
 
 def skillsbench_runner_error_attribution(error_text: str) -> tuple[str, str, list[str]]:

--- a/goal_harness/benchmark_adapters/skillsbench_acp_relay.py
+++ b/goal_harness/benchmark_adapters/skillsbench_acp_relay.py
@@ -1,0 +1,412 @@
+from __future__ import annotations
+
+import json
+import os
+import selectors
+import shlex
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, TextIO
+
+
+SKILLSBENCH_LOCAL_ACP_RELAY_SCHEMA_VERSION = "skillsbench_local_acp_relay_v0"
+SKILLSBENCH_LOCAL_ACP_RELAY_PROBE_SCHEMA_VERSION = (
+    "skillsbench_local_acp_relay_probe_v0"
+)
+SKILLSBENCH_LOCAL_ACP_RELAY_READY_MARKER = (
+    "GOAL_HARNESS_SKILLSBENCH_LOCAL_ACP_RELAY_READY"
+)
+
+
+def _json_rpc_result(message_id: Any, result: dict[str, Any]) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": message_id, "result": result}
+
+
+def _json_rpc_error(message_id: Any, code: int, message: str) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": message_id,
+        "error": {"code": code, "message": message},
+    }
+
+
+def _text_blocks_to_prompt(prompt: Any) -> str:
+    if not isinstance(prompt, list):
+        return ""
+    parts: list[str] = []
+    for block in prompt:
+        if isinstance(block, dict) and block.get("type") == "text":
+            text = str(block.get("text") or "").strip()
+            if text:
+                parts.append(text)
+    return "\n\n".join(parts)
+
+
+def _safe_cwd(value: Any, *, default: str) -> str:
+    text = str(value or "").strip()
+    return text or default
+
+
+@dataclass(frozen=True)
+class CodexExecConfig:
+    codex_bin: str = "codex"
+    sandbox: str = "workspace-write"
+    model: str | None = None
+    timeout_sec: int = 7200
+    dry_run_response: str | None = None
+
+
+class SkillsBenchLocalAcpRelay:
+    """Minimal ACP stdio server for the SkillsBench local-driver route.
+
+    The relay is intentionally a local ACP adapter, not a remote Codex runtime.
+    In dry-run mode it proves the BenchFlow JSON-RPC handshake without invoking
+    Codex. In normal mode it delegates each prompt to the local Codex CLI and
+    sends only the final assistant message back over ACP stdout.
+    """
+
+    def __init__(self, config: CodexExecConfig):
+        self._config = config
+        self._sessions: dict[str, dict[str, Any]] = {}
+
+    def serve(self, stdin: TextIO = sys.stdin, stdout: TextIO = sys.stdout) -> int:
+        for line in stdin:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                message = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(message, dict) or message.get("jsonrpc") != "2.0":
+                continue
+            response = self.handle_message(message, stdout=stdout)
+            if response is not None:
+                self._write(stdout, response)
+        return 0
+
+    def handle_message(
+        self, message: dict[str, Any], *, stdout: TextIO
+    ) -> dict[str, Any] | None:
+        method = str(message.get("method") or "")
+        message_id = message.get("id")
+        params = message.get("params") if isinstance(message.get("params"), dict) else {}
+        if "id" not in message:
+            if method == "session/cancel":
+                return None
+            return None
+        if method == "initialize":
+            return _json_rpc_result(
+                message_id,
+                {
+                    "protocolVersion": int(params.get("protocolVersion") or 0),
+                    "agentCapabilities": {
+                        "promptCapabilities": {
+                            "image": False,
+                            "audio": False,
+                            "embeddedContext": False,
+                        },
+                        "mcpCapabilities": {"sse": False, "http": False},
+                        "loadSession": True,
+                    },
+                    "agentInfo": {
+                        "name": "goal-harness-skillsbench-local-acp-relay",
+                        "version": SKILLSBENCH_LOCAL_ACP_RELAY_SCHEMA_VERSION,
+                    },
+                },
+            )
+        if method in {"session/new", "session/load"}:
+            session_id = str(params.get("sessionId") or f"gh-sb-{uuid.uuid4().hex[:12]}")
+            self._sessions[session_id] = {
+                "cwd": _safe_cwd(params.get("cwd"), default=os.getcwd()),
+                "model": None,
+                "cancelled": False,
+            }
+            return _json_rpc_result(message_id, {"sessionId": session_id})
+        if method == "session/set_model":
+            session = self._sessions.get(str(params.get("sessionId") or ""))
+            if session is None:
+                return _json_rpc_error(message_id, -32001, "unknown session")
+            session["model"] = str(params.get("modelId") or "")
+            return _json_rpc_result(message_id, {})
+        if method == "session/prompt":
+            return self._handle_prompt(message_id, params, stdout=stdout)
+        return _json_rpc_error(message_id, -32601, f"method not found: {method}")
+
+    def _handle_prompt(
+        self, message_id: Any, params: dict[str, Any], *, stdout: TextIO
+    ) -> dict[str, Any]:
+        session_id = str(params.get("sessionId") or "")
+        session = self._sessions.get(session_id)
+        if session is None:
+            return _json_rpc_error(message_id, -32001, "unknown session")
+        prompt_text = _text_blocks_to_prompt(params.get("prompt"))
+        if not prompt_text:
+            return _json_rpc_error(message_id, -32602, "prompt text missing")
+        try:
+            response_text = self._run_codex(prompt_text, session=session)
+        except TimeoutError:
+            return _json_rpc_error(message_id, -32002, "local codex execution timeout")
+        except RuntimeError as exc:
+            return _json_rpc_error(message_id, -32003, str(exc))
+        self._write(
+            stdout,
+            {
+                "jsonrpc": "2.0",
+                "method": "session/update",
+                "params": {
+                    "sessionId": session_id,
+                    "update": {
+                        "sessionUpdate": "agent_message_chunk",
+                        "content": {"type": "text", "text": response_text},
+                    },
+                },
+            },
+        )
+        return _json_rpc_result(message_id, {"stopReason": "end_turn"})
+
+    def _run_codex(self, prompt_text: str, *, session: dict[str, Any]) -> str:
+        if self._config.dry_run_response is not None:
+            return self._config.dry_run_response
+        cwd = _safe_cwd(session.get("cwd"), default=os.getcwd())
+        with tempfile.TemporaryDirectory(prefix="gh-skillsbench-acp-") as tmp:
+            output_path = Path(tmp) / "last-message.txt"
+            cmd = [
+                self._config.codex_bin,
+                "exec",
+                "--ephemeral",
+                "--skip-git-repo-check",
+                "--sandbox",
+                self._config.sandbox,
+                "-C",
+                cwd,
+                "--output-last-message",
+                str(output_path),
+                "--json",
+            ]
+            model = self._config.model or session.get("model")
+            if model:
+                cmd.extend(["--model", str(model)])
+            cmd.append(prompt_text)
+            try:
+                proc = subprocess.run(
+                    cmd,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                    timeout=self._config.timeout_sec,
+                    check=False,
+                )
+            except subprocess.TimeoutExpired as exc:
+                raise TimeoutError from exc
+            if proc.returncode != 0:
+                raise RuntimeError("local codex execution failed")
+            try:
+                response = output_path.read_text(encoding="utf-8").strip()
+            except OSError as exc:
+                raise RuntimeError("local codex final message missing") from exc
+            return response or "local codex returned an empty final message"
+
+    @staticmethod
+    def _write(stdout: TextIO, message: dict[str, Any]) -> None:
+        stdout.write(json.dumps(message, separators=(",", ":")) + "\n")
+        stdout.flush()
+
+
+def default_skillsbench_local_acp_relay_command() -> list[str]:
+    script = (
+        Path(__file__).resolve().parents[2]
+        / "scripts"
+        / "skillsbench_local_acp_relay.py"
+    )
+    return [
+        sys.executable,
+        str(script),
+        "--dry-run-response",
+        SKILLSBENCH_LOCAL_ACP_RELAY_READY_MARKER,
+    ]
+
+
+def run_skillsbench_local_acp_relay_probe(
+    command: str | list[str] | tuple[str, ...] | None = None,
+    *,
+    timeout_sec: float = 10.0,
+) -> dict[str, Any]:
+    argv = (
+        _command_to_argv(command)
+        if command
+        else default_skillsbench_local_acp_relay_command()
+    )
+    started = time.monotonic()
+    proc: subprocess.Popen[bytes] | None = None
+    stage = "spawn"
+    try:
+        proc = subprocess.Popen(
+            argv,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        stage = "initialize"
+        initialize = _probe_request(
+            proc,
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+            timeout_at=started + timeout_sec,
+        )
+        stage = "session_new"
+        session = _probe_request(
+            proc,
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "session/new",
+                "params": {"cwd": os.getcwd(), "mcpServers": []},
+            },
+            timeout_at=started + timeout_sec,
+        )
+        session_id = str(session.get("result", {}).get("sessionId") or "")
+        stage = "set_model"
+        _probe_request(
+            proc,
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "session/set_model",
+                "params": {"sessionId": session_id, "modelId": "probe-model"},
+            },
+            timeout_at=started + timeout_sec,
+        )
+        stage = "prompt"
+        prompt = _probe_request(
+            proc,
+            {
+                "jsonrpc": "2.0",
+                "id": 4,
+                "method": "session/prompt",
+                "params": {
+                    "sessionId": session_id,
+                    "prompt": [{"type": "text", "text": "relay handshake probe"}],
+                },
+            },
+            timeout_at=started + timeout_sec,
+        )
+        ready = (
+            initialize.get("result", {}).get("agentInfo", {}).get("name")
+            == "goal-harness-skillsbench-local-acp-relay"
+            and bool(session_id)
+            and prompt.get("result", {}).get("stopReason") == "end_turn"
+        )
+        return _relay_probe_payload(
+            ready=ready,
+            first_blocker=(
+                "skillsbench_local_acp_relay_ready"
+                if ready
+                else "skillsbench_local_acp_relay_probe_failed"
+            ),
+            stage="complete",
+            request_count=4,
+        )
+    except (OSError, RuntimeError, TimeoutError, json.JSONDecodeError):
+        return _relay_probe_payload(
+            ready=False,
+            first_blocker=f"skillsbench_local_acp_relay_{stage}_failed",
+            stage=stage,
+            request_count=0,
+        )
+    finally:
+        if proc is not None:
+            _terminate_probe_process(proc)
+
+
+def _command_to_argv(command: str | list[str] | tuple[str, ...]) -> list[str]:
+    if isinstance(command, str):
+        return shlex.split(command)
+    return [str(part) for part in command]
+
+
+def _probe_request(
+    proc: subprocess.Popen[bytes],
+    message: dict[str, Any],
+    *,
+    timeout_at: float,
+) -> dict[str, Any]:
+    if proc.stdin is None or proc.stdout is None:
+        raise RuntimeError("probe process pipes missing")
+    proc.stdin.write((json.dumps(message) + "\n").encode())
+    proc.stdin.flush()
+    selector = selectors.DefaultSelector()
+    selector.register(proc.stdout, selectors.EVENT_READ)
+    pending = b""
+    try:
+        while True:
+            remaining = timeout_at - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError("ACP relay probe timed out")
+            events = selector.select(timeout=remaining)
+            if not events:
+                raise TimeoutError("ACP relay probe timed out")
+            chunk = os.read(proc.stdout.fileno(), 65536)
+            if not chunk:
+                raise RuntimeError("ACP relay closed stdout")
+            pending += chunk
+            while b"\n" in pending:
+                raw_line, pending = pending.split(b"\n", 1)
+                if not raw_line.strip():
+                    continue
+                decoded = json.loads(raw_line.decode())
+                if (
+                    isinstance(decoded, dict)
+                    and decoded.get("jsonrpc") == "2.0"
+                    and decoded.get("id") == message.get("id")
+                ):
+                    if decoded.get("error"):
+                        raise RuntimeError(
+                            str(decoded["error"].get("message") or "error")
+                        )
+                    return decoded
+    finally:
+        selector.close()
+
+
+def _terminate_probe_process(proc: subprocess.Popen[bytes]) -> None:
+    if proc.stdin:
+        try:
+            proc.stdin.close()
+        except OSError:
+            pass
+    try:
+        proc.terminate()
+        proc.wait(timeout=2)
+    except (OSError, subprocess.TimeoutExpired):
+        try:
+            proc.kill()
+            proc.wait(timeout=2)
+        except OSError:
+            pass
+
+
+def _relay_probe_payload(
+    *,
+    ready: bool,
+    first_blocker: str,
+    stage: str,
+    request_count: int,
+) -> dict[str, Any]:
+    return {
+        "schema_version": SKILLSBENCH_LOCAL_ACP_RELAY_PROBE_SCHEMA_VERSION,
+        "ready": ready,
+        "first_blocker": first_blocker,
+        "stage": stage,
+        "request_count": request_count,
+        "worker_protocol": "acp_stdio",
+        "codex_cli_invoked": False,
+        "raw_output_recorded": False,
+        "raw_event_jsonl_recorded": False,
+        "credential_values_recorded": False,
+        "host_paths_recorded": False,
+    }

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -68,6 +68,9 @@ from goal_harness.benchmark_case_state import (  # noqa: E402
 from goal_harness.benchmark_adapters.skillsbench import (  # noqa: E402
     build_skillsbench_worker_handshake_preflight,
 )
+from goal_harness.benchmark_adapters.skillsbench_acp_relay import (  # noqa: E402
+    run_skillsbench_local_acp_relay_probe,
+)
 from goal_harness.benchmark_trajectory import summarize_public_acp_trajectory
 
 DEFAULT_SKILLSBENCH_ROOT = REPO_ROOT / ".local/benchmark/externals/skillsbench"
@@ -453,6 +456,9 @@ def inspect_skillsbench_worker_handshake(
     dataset: str,
     task_id: str,
     local_codex_cli_participant_ready: bool = False,
+    local_acp_relay_command: str | None = None,
+    probe_local_acp_relay: bool = False,
+    local_acp_relay_probe_timeout_sec: float = 10.0,
     remote_executor_ready: bool = True,
     remote_task_data_ready: bool = True,
 ) -> dict[str, Any]:
@@ -467,6 +473,14 @@ def inspect_skillsbench_worker_handshake(
     default_codex_agent = "codex-acp"
     codex_agent_protocol = None
     codex_agent_launch_registered = False
+    local_acp_relay_probe = None
+    local_acp_relay_ready = False
+    if probe_local_acp_relay:
+        local_acp_relay_probe = run_skillsbench_local_acp_relay_probe(
+            local_acp_relay_command,
+            timeout_sec=local_acp_relay_probe_timeout_sec,
+        )
+        local_acp_relay_ready = local_acp_relay_probe.get("ready") is True
     try:
         __import__("benchflow")
         benchflow_available = True
@@ -503,7 +517,8 @@ def inspect_skillsbench_worker_handshake(
         codex_agent_protocol=codex_agent_protocol,
         codex_agent_launch_registered=codex_agent_launch_registered,
         local_codex_cli_participant_ready=local_codex_cli_participant_ready,
-        local_acp_relay_ready=False,
+        local_acp_relay_ready=local_acp_relay_ready,
+        local_acp_relay_probe=local_acp_relay_probe,
         remote_executor_ready=remote_executor_ready,
         remote_task_data_ready=remote_task_data_ready,
     )
@@ -3005,6 +3020,29 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--local-acp-relay-probe",
+        action="store_true",
+        help=(
+            "During --local-driver-worker-handshake-preflight, launch a local "
+            "ACP stdio relay handshake probe. The default probe uses the "
+            "Goal Harness dry-run relay and does not invoke Codex."
+        ),
+    )
+    parser.add_argument(
+        "--local-acp-relay-command",
+        default=None,
+        help=(
+            "Optional command for --local-acp-relay-probe. Omit to use the "
+            "Goal Harness dry-run relay."
+        ),
+    )
+    parser.add_argument(
+        "--local-acp-relay-probe-timeout-sec",
+        type=float,
+        default=10.0,
+        help="Timeout for --local-acp-relay-probe.",
+    )
+    parser.add_argument(
         "--fail-fast-on-apt-risk",
         action="store_true",
         help=(
@@ -3103,6 +3141,9 @@ def main(argv: list[str] | None = None) -> int:
             dataset=args.dataset,
             task_id=args.task_id,
             local_codex_cli_participant_ready=args.local_codex_cli_participant_ready,
+            local_acp_relay_command=args.local_acp_relay_command,
+            probe_local_acp_relay=args.local_acp_relay_probe,
+            local_acp_relay_probe_timeout_sec=args.local_acp_relay_probe_timeout_sec,
             remote_executor_ready=True,
             remote_task_data_ready=True,
         )

--- a/scripts/skillsbench_local_acp_relay.py
+++ b/scripts/skillsbench_local_acp_relay.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Serve the Goal Harness SkillsBench local ACP relay over stdio."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from goal_harness.benchmark_adapters.skillsbench_acp_relay import (  # noqa: E402
+    CodexExecConfig,
+    SkillsBenchLocalAcpRelay,
+)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--codex-bin",
+        default="codex",
+        help="Local Codex CLI binary used outside dry-run mode.",
+    )
+    parser.add_argument(
+        "--sandbox",
+        choices=("read-only", "workspace-write", "danger-full-access"),
+        default="workspace-write",
+        help="Sandbox mode passed to local codex exec outside dry-run mode.",
+    )
+    parser.add_argument(
+        "--model",
+        default=None,
+        help="Optional model passed to local codex exec.",
+    )
+    parser.add_argument(
+        "--timeout-sec",
+        type=int,
+        default=7200,
+        help="Per-prompt local codex exec timeout outside dry-run mode.",
+    )
+    parser.add_argument(
+        "--dry-run-response",
+        default=None,
+        help=(
+            "Return this fixed response for session/prompt instead of invoking "
+            "Codex. Intended for handshake/preflight smokes."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    relay = SkillsBenchLocalAcpRelay(
+        CodexExecConfig(
+            codex_bin=args.codex_bin,
+            sandbox=args.sandbox,
+            model=args.model,
+            timeout_sec=args.timeout_sec,
+            dry_run_response=args.dry_run_response,
+        )
+    )
+    return relay.serve()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a public SkillsBench local ACP stdio relay that can either dry-run the ACP handshake or delegate prompts to local codex exec
- wire the SkillsBench worker-handshake preflight to probe the local relay and clear the acp relay blocker when ready
- document the developer workflow and add focused smoke coverage

## Validation
- python3 -m py_compile goal_harness/benchmark_adapters/skillsbench.py goal_harness/benchmark_adapters/skillsbench_acp_relay.py scripts/skillsbench_automation_loop.py scripts/skillsbench_local_acp_relay.py examples/skillsbench-benchmark-run-smoke.py
- python3 examples/skillsbench-benchmark-run-smoke.py
- python3 examples/benchmark-developer-workflow-doc-smoke.py
- python3 scripts/skillsbench_automation_loop.py --local-driver-worker-handshake-preflight --local-codex-cli-participant-ready --local-acp-relay-probe
- git diff --check
- goal-harness check --scan-path goal_harness/benchmark_adapters/skillsbench.py --scan-path goal_harness/benchmark_adapters/skillsbench_acp_relay.py --scan-path scripts/skillsbench_automation_loop.py --scan-path scripts/skillsbench_local_acp_relay.py --scan-path examples/skillsbench-benchmark-run-smoke.py --scan-path docs/benchmark-developer-workflow.md

## Excluded
- no .local state, raw benchmark logs, task text, trajectories, credentials, or private handles