### PR TITLE
Tighten scoped user gate matching

### DIFF
--- a/goal_harness/quota.py
+++ b/goal_harness/quota.py
@@ -1200,19 +1200,20 @@ def _todo_action_scope_tokens(item: dict[str, Any]) -> set[str]:
 def _user_gate_blocks_agent_item(gate: dict[str, Any], agent_item: dict[str, Any]) -> bool:
     gate_action_tokens = _todo_action_kind_tokens(gate)
     agent_action_tokens = _todo_action_kind_tokens(agent_item)
+    if gate_action_tokens and agent_action_tokens:
+        return bool(gate_action_tokens & agent_action_tokens)
+    if agent_action_tokens:
+        # A prose-only user gate may still be user-visible, but it is not
+        # precise enough to block an explicitly scoped agent action.
+        return False
+
     gate_tokens = _todo_action_scope_tokens(gate)
     agent_tokens = _todo_action_scope_tokens(agent_item)
     if not gate_tokens or not agent_tokens:
         return False
     if gate_action_tokens:
-        return bool(
-            gate_action_tokens & agent_action_tokens
-            or len(gate_action_tokens & agent_tokens) >= 2
-        )
-    overlap = gate_tokens & agent_tokens
-    if agent_action_tokens:
-        return len(gate_tokens & agent_action_tokens) >= 2
-    return len(overlap) >= 3
+        return len(gate_action_tokens & agent_tokens) >= 2
+    return len(gate_tokens & agent_tokens) >= 3
 
 
 def _scoped_user_gate_fallback(

--- a/regression/README.md
+++ b/regression/README.md
@@ -47,7 +47,9 @@ Runs a contract-only projection regression for a scoped user gate: one user
 decision blocks the matching agent todo, but a non-dependent executable fallback
 remains available. It checks that `quota should-run` keeps the user gate
 `NOTIFY` path visible while still requiring the agent to execute the selected
-fallback and spend only after validated writeback.
+fallback and spend only after validated writeback. It also checks that a
+prose-only user gate does not block an explicitly scoped, unrelated agent
+action just because the two texts share generic benchmark terms.
 
 ```bash
 python3 regression/no-progress-self-repair-contract.py

--- a/regression/scoped-user-gate-fallback-contract.py
+++ b/regression/scoped-user-gate-fallback-contract.py
@@ -156,7 +156,7 @@ def build_nonblocking_user_gate_status_payload() -> dict:
                 "text": INDEPENDENT_AGENT_TODO,
                 "status": "open",
                 "task_class": "advancement_task",
-                "action_kind": "skillsbench_local_acp_stdio_relay",
+                "action_kind": "skillsbench_no_upload_mini_pair",
             },
             {
                 "index": 2,


### PR DESCRIPTION
## Summary
- require structured action_kind overlap before a user gate can block an explicitly scoped agent todo
- keep prose-only user gates visible as notifications without hijacking unrelated structured agent work
- update the scoped-user-gate regression fixture to cover an ALE prose gate plus SkillsBench no-upload action scope

## Validation
- python3 -m py_compile goal_harness/quota.py regression/scoped-user-gate-fallback-contract.py
- python3 regression/scoped-user-gate-fallback-contract.py
- python3 regression/autonomous-replan-vs-dreaming-contract.py
- python3 regression/run-regressions.py
- goal-harness check --scan-path goal_harness/quota.py --scan-path regression/scoped-user-gate-fallback-contract.py --scan-path regression/README.md
- git diff --check
- goal-harness --format json quota should-run --goal-id goal-harness-meta (verified agent primary action remains the SkillsBench P0 while ALE user gate stays user-visible)