### PR TITLE
Align refresh actions with executable todos

### DIFF
--- a/examples/heartbeat-quota-flow-smoke.py
+++ b/examples/heartbeat-quota-flow-smoke.py
@@ -545,7 +545,9 @@ def main() -> int:
         )
         assert refresh["ok"] is True, refresh
         assert refresh["appended"] is True, refresh
-        assert LONG_NEXT_ACTION_TAIL in refresh["recommended_action"], refresh
+        expected_action = "[P1] Run one bounded heartbeat marker and validate the compact result."
+        assert refresh["recommended_action"] == expected_action, refresh
+        assert LONG_NEXT_ACTION_TAIL in " ".join(refresh["state"]["next_action"]), refresh
         assert count_spend_events(runtime) == 0
 
         spend = run_cli(
@@ -592,10 +594,7 @@ def main() -> int:
         assert follow_up["recommended_action"] == expected_action, follow_up
         interaction = follow_up["interaction_contract"]
         assert interaction["agent_channel"]["primary_action"] == expected_action, interaction
-        warning = follow_up["state_action_projection_warning"]
-        assert warning["requires_state_writeback"] is True, warning
-        assert warning["selected_recommended_action"] == expected_action, warning
-        assert "executable backlog item" in warning["reason"], warning
+        assert "state_action_projection_warning" not in follow_up, follow_up
         assert "agent_action=" + expected_action in follow_up["protocol_action_packet"]["summary"], follow_up
         assert registry_path.read_text(encoding="utf-8") == registry_before
 

--- a/goal_harness/state_refresh.py
+++ b/goal_harness/state_refresh.py
@@ -15,12 +15,19 @@ from .paths import resolve_runtime_root
 from .registry import registry_goals, resolve_state_file
 from .runtime import validate_goal_id_path_segment
 from .state_projection import state_projection_gap_warning
+from .todo_contract import (
+    TODO_TASK_CLASS_ADVANCEMENT,
+    TODO_TASK_CLASS_BLOCKER,
+    TODO_TASK_CLASS_MONITOR,
+    TODO_TASK_CLASS_USER_GATE,
+)
 
 
 DEFAULT_REFRESH_CLASSIFICATION = "state_refreshed"
 DEFAULT_REFRESH_ACTION = "inspect refreshed active goal state and continue the next bounded progress segment"
 RECOMMENDED_ACTION_SECTION_LINE_LIMIT = 16
 BULLET_PREFIX_RE = re.compile(r"^(?:[-*]\s+|\d+[.)]\s+)")
+CHECKBOX_PREFIX_RE = re.compile(r"^\[(?P<mark>[ xX])\]\s+")
 DELIVERY_BATCH_SCALE_CHOICES = ("test_only", "single_surface", "multi_surface", "implementation")
 
 
@@ -66,7 +73,8 @@ def extract_section_lines(text: str, heading: str, limit: int = 8) -> list[str]:
 
 
 def clean_action_line(line: str) -> str:
-    return BULLET_PREFIX_RE.sub("", line.strip()).strip()
+    text = BULLET_PREFIX_RE.sub("", line.strip()).strip()
+    return CHECKBOX_PREFIX_RE.sub("", text).strip()
 
 
 def is_bullet_line(line: str) -> bool:
@@ -80,10 +88,74 @@ def first_action_item(lines: list[str], start: int) -> str:
         for line in lines[start + 1 :]:
             if is_bullet_line(line):
                 break
+            if line.strip().startswith("<!--"):
+                continue
             cleaned = clean_action_line(line)
             if cleaned:
                 parts.append(cleaned)
     return " ".join(part for part in parts if part).strip()
+
+
+def checkbox_mark(line: str) -> str | None:
+    text = BULLET_PREFIX_RE.sub("", line.strip()).strip()
+    match = CHECKBOX_PREFIX_RE.match(text)
+    if not match:
+        return None
+    return match.group("mark")
+
+
+def todo_metadata(lines: list[str], start: int) -> dict[str, str]:
+    metadata: dict[str, str] = {}
+    for line in lines[start + 1 :]:
+        if is_bullet_line(line):
+            break
+        text = line.strip()
+        if not text.startswith("<!-- goal-harness:todo"):
+            continue
+        for key, value in re.findall(r"([A-Za-z_][A-Za-z0-9_]*)=([^ >]+)", text):
+            metadata[key] = value
+        break
+    return metadata
+
+
+def todo_priority_rank(action: str) -> int:
+    match = re.match(r"^\[P(?P<rank>\d+)\]\s+", action.strip(), flags=re.IGNORECASE)
+    if not match:
+        return 99
+    return int(match.group("rank"))
+
+
+def first_open_agent_todo_action(state_text: str) -> str | None:
+    lines = extract_section_lines(state_text, "Agent Todo", limit=512)
+    advancement_candidates: list[tuple[int, int, str]] = []
+    fallback_candidates: list[tuple[int, int, str]] = []
+    for index, line in enumerate(lines):
+        mark = checkbox_mark(line)
+        if mark is None or mark.lower() == "x":
+            continue
+        action = first_action_item(lines, index)
+        if not action:
+            continue
+        try:
+            validate_public_safe_text("derived agent_todo recommended_action", action)
+        except ValueError:
+            continue
+        metadata = todo_metadata(lines, index)
+        if metadata.get("task_class") == TODO_TASK_CLASS_ADVANCEMENT:
+            advancement_candidates.append((todo_priority_rank(action), index, action))
+            continue
+        if metadata.get("task_class") in {
+            TODO_TASK_CLASS_MONITOR,
+            TODO_TASK_CLASS_USER_GATE,
+            TODO_TASK_CLASS_BLOCKER,
+        }:
+            continue
+        fallback_candidates.append((todo_priority_rank(action), index, action))
+    if advancement_candidates:
+        return sorted(advancement_candidates)[0][2]
+    if fallback_candidates:
+        return sorted(fallback_candidates)[0][2]
+    return None
 
 
 def section_list_items(lines: list[str]) -> list[str]:
@@ -107,6 +179,9 @@ def section_list_items(lines: list[str]) -> list[str]:
 
 
 def derive_recommended_action(state_text: str) -> str:
+    agent_todo_action = first_open_agent_todo_action(state_text)
+    if agent_todo_action:
+        return agent_todo_action
     lines = extract_section_lines(state_text, "Next Action", limit=RECOMMENDED_ACTION_SECTION_LINE_LIMIT)
     for index, line in enumerate(lines):
         action = first_action_item(lines, index)

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -4004,6 +4004,8 @@ def _run_history_stall_signal(run: dict[str, Any]) -> dict[str, Any] | None:
     classification = str(run.get("classification") or "").strip()
     if not classification or classification in AUTONOMOUS_RUN_HISTORY_NEUTRAL_CLASSIFICATIONS:
         return None
+    if AUTONOMOUS_RUN_HISTORY_REPLAN_ACK_CLASSIFICATION.search(classification):
+        return None
     delivery_outcome = normalize_delivery_outcome(run.get("delivery_outcome"))
     if delivery_outcome in AUTONOMOUS_RUN_HISTORY_PROGRESS_OUTCOMES:
         return None

--- a/regression/README.md
+++ b/regression/README.md
@@ -101,7 +101,9 @@ and a P1 advancement todo is executable, `quota should-run` selects the P1
 backlog item as `recommended_action`, interaction primary action, and protocol
 packet action while keeping the monitor as context. It also checks that the
 payload exposes a state-action projection warning when the visible
-`Next Action` still points at the stale monitor action.
+`Next Action` still points at the stale monitor action, and that
+`refresh-state` derives its default recommended action from the first open
+Agent Todo rather than the stale `Next Action`.
 
 ```bash
 python3 regression/automation-loop-heartbeat-poll-contract.py

--- a/regression/quota-executable-backlog-projection.py
+++ b/regression/quota-executable-backlog-projection.py
@@ -164,6 +164,25 @@ def assert_executable_backlog_projection(guard: dict[str, Any]) -> None:
     assert first_open[1]["task_class"] == "advancement_task", guard
 
 
+def assert_refresh_state_prefers_open_agent_todo(
+    *,
+    registry: Path,
+    runtime: Path,
+) -> None:
+    refresh = run_goal_harness(
+        "refresh-state",
+        "--goal-id",
+        GOAL_ID,
+        "--classification",
+        "refresh_agent_todo_projection_fixture_v0",
+        "--dry-run",
+        registry=registry,
+        runtime=runtime,
+    )
+    assert refresh["recommended_action"] == EXECUTABLE_TODO, refresh
+    assert refresh["recommended_action"] != POLL_ACTION, refresh
+
+
 def main() -> int:
     with tempfile.TemporaryDirectory(prefix="goal-harness-quota-executable-backlog-") as tmp:
         runtime, registry = write_fixture(Path(tmp))
@@ -176,6 +195,10 @@ def main() -> int:
             runtime=runtime,
         )
         assert_executable_backlog_projection(guard)
+        assert_refresh_state_prefers_open_agent_todo(
+            registry=registry,
+            runtime=runtime,
+        )
     print("quota-executable-backlog-projection-regression ok")
     return 0
 


### PR DESCRIPTION
## Summary
- Derive refresh-state default recommended_action from the prioritized open Agent Todo before falling back to stale Next Action text.
- Treat autonomous replan/spend ack records as non-stall run-history boundaries so monitor polls do not immediately re-trigger on ack wording.
- Update heartbeat and executable-backlog regressions to cover the projection contract.

## Validation
- python3 -m py_compile goal_harness/state_refresh.py goal_harness/status.py regression/quota-executable-backlog-projection.py
- python3 regression/quota-executable-backlog-projection.py
- python3 examples/heartbeat-quota-flow-smoke.py
- python3 regression/automation-loop-heartbeat-poll-contract.py
- python3 regression/run-regressions.py
- goal-harness check --scan-path goal_harness/state_refresh.py --scan-path goal_harness/status.py --scan-path examples/heartbeat-quota-flow-smoke.py --scan-path regression/quota-executable-backlog-projection.py --scan-path regression/README.md
- git diff --check

## Excluded
- No local/private state, raw benchmark logs, credentials, or generated artifacts.