### PR TITLE
Add SkillsBench remote command/file bridge probe

### DIFF
--- a/docs/benchmark-developer-workflow.md
+++ b/docs/benchmark-developer-workflow.md
@@ -161,6 +161,28 @@ is product-path evidence only after the remote bridge is also materialized, so
 the preflight may legitimately return `skillsbench_remote_command_file_bridge_missing`
 after both local probes pass.
 
+For the remote bridge, prefer a machine-verifiable probe over a manual
+readiness flag:
+
+```bash
+python3 scripts/skillsbench_automation_loop.py \
+  --local-driver-worker-handshake-preflight \
+  --local-codex-cli-participant-ready \
+  --local-acp-relay-probe \
+  --host-local-acp-transport-probe \
+  --remote-command-file-bridge-probe \
+  --remote-command-file-bridge-probe-command '<private-remote-bridge-command>'
+```
+
+The bridge command reads a fixed JSON request from stdin and writes compact JSON
+to stdout. It must prove four bounded operations: `exec`, `write_file`,
+`read_file`, and `cleanup`. Its public result records only operation kinds,
+statuses, and boundary flags; it must not return raw commands, stdout, stderr,
+task text, paths, credentials, logs, trajectories, uploads, or submissions.
+`scripts/skillsbench_remote_command_file_bridge.py --serve-probe` is only a
+local fake bridge for smoke tests and adapter development. It is not evidence
+that a real remote executor is ready.
+
 ## Evidence Contract
 
 Benchmark evidence may include:

--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -38,6 +38,10 @@ from goal_harness.benchmark_adapters.skillsbench_acp_relay import (  # noqa: E40
     SKILLSBENCH_LOCAL_ACP_RELAY_PROBE_SCHEMA_VERSION,
     run_skillsbench_local_acp_relay_probe,
 )
+from goal_harness.benchmark_adapters.skillsbench_remote_bridge import (  # noqa: E402
+    SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_PROBE_SCHEMA_VERSION,
+    run_skillsbench_remote_command_file_bridge_probe,
+)
 from goal_harness.status import compact_benchmark_run  # noqa: E402
 from scripts.skillsbench_automation_loop import (  # noqa: E402
     CODEX_ACP_RUNTIME_CONTAINER_BOOTSTRAP_CMD,
@@ -278,6 +282,102 @@ def test_skillsbench_worker_handshake_preflight_distinguishes_remote_bridge() ->
         payload["local_driver_contract"]["remote_command_file_bridge_materialized"]
         is False
     ), payload
+
+
+def test_skillsbench_remote_command_file_bridge_probe_requires_command() -> None:
+    payload = run_skillsbench_remote_command_file_bridge_probe(None)
+    assert (
+        payload["schema_version"]
+        == SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_PROBE_SCHEMA_VERSION
+    ), payload
+    assert payload["ready"] is False, payload
+    assert (
+        payload["first_blocker"]
+        == "skillsbench_remote_command_file_bridge_probe_command_missing"
+    ), payload
+    assert payload["bridge_command_invoked"] is False, payload
+    assert payload["raw_command_recorded"] is False, payload
+    assert payload["credential_values_recorded"] is False, payload
+    assert payload["host_paths_recorded"] is False, payload
+
+
+def test_skillsbench_remote_command_file_bridge_probe_fake_bridge_ready() -> None:
+    command = [
+        sys.executable,
+        str(REPO_ROOT / "scripts/skillsbench_remote_command_file_bridge.py"),
+        "--serve-probe",
+    ]
+    payload = run_skillsbench_remote_command_file_bridge_probe(command)
+    assert payload["ready"] is True, payload
+    assert (
+        payload["first_blocker"] == "skillsbench_remote_command_file_bridge_ready"
+    ), payload
+    assert payload["bridge_command_invoked"] is True, payload
+    assert payload["operation_count"] == 4, payload
+    assert payload["missing_operations"] == [], payload
+    assert payload["failed_operations"] == [], payload
+    assert payload["boundary_violations"] == [], payload
+    assert {item["kind"] for item in payload["operations"]} == {
+        "exec",
+        "write_file",
+        "read_file",
+        "cleanup",
+    }, payload
+    assert payload["raw_command_recorded"] is False, payload
+    assert payload["raw_stdout_recorded"] is False, payload
+    assert payload["raw_stderr_recorded"] is False, payload
+    assert payload["raw_task_text_recorded"] is False, payload
+    assert payload["credential_values_recorded"] is False, payload
+    assert payload["host_paths_recorded"] is False, payload
+    assert payload["remote_paths_recorded"] is False, payload
+    text = json.dumps(payload, sort_keys=True)
+    for forbidden in ("/Users/", "~/.codex", "OPENAI_API_KEY", "HF_TOKEN"):
+        assert forbidden not in text, forbidden
+
+
+def test_skillsbench_worker_handshake_preflight_accepts_bridge_probe() -> None:
+    command = [
+        sys.executable,
+        str(REPO_ROOT / "scripts/skillsbench_remote_command_file_bridge.py"),
+        "--serve-probe",
+    ]
+    bridge_probe = run_skillsbench_remote_command_file_bridge_probe(command)
+    payload = build_skillsbench_worker_handshake_preflight(
+        task_id="ada-bathroom-plan-repair",
+        benchflow_available=True,
+        benchflow_agent_registry_available=True,
+        benchflow_acp_runtime_available=True,
+        default_codex_agent="codex-acp",
+        codex_agent_protocol="acp",
+        codex_agent_launch_registered=True,
+        local_codex_cli_participant_ready=True,
+        local_acp_relay_ready=True,
+        host_local_acp_transport_ready=True,
+        remote_command_file_bridge_probe=bridge_probe,
+        remote_executor_ready=True,
+        remote_task_data_ready=True,
+    )
+    assert payload["ready"] is True, payload
+    assert (
+        payload["first_blocker"]
+        == "ready_for_skillsbench_local_driver_worker_handshake"
+    ), payload
+    assert (
+        payload["local_driver_contract"]["remote_command_file_bridge_materialized"]
+        is True
+    ), payload
+    assert (
+        payload["local_driver_contract"][
+            "remote_command_file_bridge_readiness_source"
+        ]
+        == "probe"
+    ), payload
+    assert (
+        payload["local_driver_contract"]["remote_command_file_bridge_probe"]["ready"]
+        is True
+    ), payload
+    assert payload["remote_executor_contract"]["command_file_bridge_ready"] is True
+    assert "skillsbench_remote_command_file_bridge_missing" not in payload["blockers"]
 
 
 def test_skillsbench_local_acp_relay_probe_completes_stdio_handshake() -> None:
@@ -3721,6 +3821,9 @@ if __name__ == "__main__":
     test_skillsbench_worker_handshake_preflight_exposes_acp_relay_gap()
     test_skillsbench_worker_handshake_preflight_distinguishes_host_transport()
     test_skillsbench_worker_handshake_preflight_distinguishes_remote_bridge()
+    test_skillsbench_remote_command_file_bridge_probe_requires_command()
+    test_skillsbench_remote_command_file_bridge_probe_fake_bridge_ready()
+    test_skillsbench_worker_handshake_preflight_accepts_bridge_probe()
     test_skillsbench_local_acp_relay_probe_completes_stdio_handshake()
     test_skillsbench_host_local_acp_transport_probe_uses_benchflow_client()
     test_skillsbench_worker_handshake_preflight_probe_clears_relay_gap()

--- a/goal_harness/benchmark_adapters/skillsbench.py
+++ b/goal_harness/benchmark_adapters/skillsbench.py
@@ -532,6 +532,7 @@ def build_skillsbench_worker_handshake_preflight(
     host_local_acp_transport_ready: bool = False,
     host_local_acp_transport_probe: dict[str, Any] | None = None,
     remote_command_file_bridge_ready: bool = False,
+    remote_command_file_bridge_probe: dict[str, Any] | None = None,
     remote_executor_ready: bool = True,
     remote_task_data_ready: bool = True,
     compact_artifact_reducer_ready: bool = True,
@@ -558,6 +559,21 @@ def build_skillsbench_worker_handshake_preflight(
         safe_task_id = SKILLSBENCH_DEFAULT_TASK
         blockers.append("skillsbench_task_id_not_public_safe")
 
+    remote_command_file_bridge_probe_ready = (
+        isinstance(remote_command_file_bridge_probe, dict)
+        and remote_command_file_bridge_probe.get("ready") is True
+    )
+    remote_command_file_bridge_materialized = (
+        remote_command_file_bridge_ready is True
+        or remote_command_file_bridge_probe_ready is True
+    )
+    if remote_command_file_bridge_probe_ready:
+        remote_command_file_bridge_readiness_source = "probe"
+    elif remote_command_file_bridge_ready:
+        remote_command_file_bridge_readiness_source = "manual_declaration"
+    else:
+        remote_command_file_bridge_readiness_source = "missing"
+
     protocol = str(codex_agent_protocol or "").strip().lower()
     worker_protocol = "acp_stdio" if protocol == "acp" else protocol or "unknown"
     if not benchflow_available:
@@ -576,7 +592,7 @@ def build_skillsbench_worker_handshake_preflight(
         blockers.append("skillsbench_local_acp_relay_missing")
     if local_acp_relay_ready and not host_local_acp_transport_ready:
         blockers.append("skillsbench_host_local_acp_transport_missing")
-    if host_local_acp_transport_ready and not remote_command_file_bridge_ready:
+    if host_local_acp_transport_ready and not remote_command_file_bridge_materialized:
         blockers.append("skillsbench_remote_command_file_bridge_missing")
     if not remote_executor_ready:
         blockers.append("skillsbench_remote_executor_contract_missing")
@@ -644,7 +660,17 @@ def build_skillsbench_worker_handshake_preflight(
                     host_local_acp_transport_probe
                 )
             ),
-            "remote_command_file_bridge_materialized": remote_command_file_bridge_ready,
+            "remote_command_file_bridge_materialized": (
+                remote_command_file_bridge_materialized
+            ),
+            "remote_command_file_bridge_readiness_source": (
+                remote_command_file_bridge_readiness_source
+            ),
+            "remote_command_file_bridge_probe": (
+                _skillsbench_public_remote_command_file_bridge_probe(
+                    remote_command_file_bridge_probe
+                )
+            ),
             "credential_sync_allowed": False,
             "remote_codex_runtime_allowed": False,
             "remote_model_api_invocation_allowed": False,
@@ -653,7 +679,7 @@ def build_skillsbench_worker_handshake_preflight(
             "ready": remote_executor_ready,
             "task_data_ready": remote_task_data_ready,
             "compact_artifact_reducer_ready": compact_artifact_reducer_ready,
-            "command_file_bridge_ready": remote_command_file_bridge_ready,
+            "command_file_bridge_ready": remote_command_file_bridge_materialized,
             "owns": [
                 "docker",
                 "benchflow_runner",
@@ -729,6 +755,77 @@ def _skillsbench_public_host_local_acp_transport_probe(
     value = probe.get("request_count")
     if isinstance(value, int) and not isinstance(value, bool):
         compact["request_count"] = max(0, min(value, 20))
+    return compact or None
+
+
+def _skillsbench_public_remote_command_file_bridge_probe(
+    probe: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    if not isinstance(probe, dict):
+        return None
+    compact: dict[str, Any] = {}
+    for field in (
+        "schema_version",
+        "first_blocker",
+        "stage",
+        "request_schema_version",
+        "response_schema_version",
+    ):
+        value = probe.get(field)
+        if isinstance(value, str) and value:
+            compact[field] = _skillsbench_public_safe_label(value, limit=120)
+    for field in (
+        "ready",
+        "bridge_command_invoked",
+        "raw_command_recorded",
+        "raw_stdout_recorded",
+        "raw_stderr_recorded",
+        "raw_task_text_recorded",
+        "raw_logs_recorded",
+        "raw_trajectory_recorded",
+        "credential_values_recorded",
+        "host_paths_recorded",
+        "remote_paths_recorded",
+        "upload_performed",
+        "submit_performed",
+    ):
+        value = probe.get(field)
+        if isinstance(value, bool):
+            compact[field] = value
+    for field in ("elapsed_ms", "operation_count"):
+        value = probe.get(field)
+        if isinstance(value, int) and not isinstance(value, bool):
+            compact[field] = max(0, min(value, 600_000))
+    for field in (
+        "required_operations",
+        "missing_operations",
+        "failed_operations",
+        "boundary_violations",
+    ):
+        values = probe.get(field)
+        if isinstance(values, list):
+            compact[field] = [
+                label
+                for item in values[:12]
+                if (label := _skillsbench_public_safe_label(item, limit=80))
+            ]
+    operations = probe.get("operations")
+    if isinstance(operations, list):
+        compact["operations"] = []
+        for item in operations[:8]:
+            if not isinstance(item, dict):
+                continue
+            op: dict[str, Any] = {}
+            for field in ("kind", "label", "status"):
+                value = item.get(field)
+                if isinstance(value, str) and value:
+                    op[field] = _skillsbench_public_safe_label(value, limit=80)
+            for field in ("exit_code_zero", "content_match"):
+                value = item.get(field)
+                if isinstance(value, bool):
+                    op[field] = value
+            if op:
+                compact["operations"].append(op)
     return compact or None
 
 

--- a/goal_harness/benchmark_adapters/skillsbench_remote_bridge.py
+++ b/goal_harness/benchmark_adapters/skillsbench_remote_bridge.py
@@ -1,0 +1,373 @@
+from __future__ import annotations
+
+import json
+import shlex
+import subprocess
+import time
+from typing import Any
+
+
+SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_PROBE_REQUEST_SCHEMA_VERSION = (
+    "skillsbench_remote_command_file_bridge_probe_request_v0"
+)
+SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_PROBE_RESPONSE_SCHEMA_VERSION = (
+    "skillsbench_remote_command_file_bridge_probe_response_v0"
+)
+SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_PROBE_SCHEMA_VERSION = (
+    "skillsbench_remote_command_file_bridge_probe_v0"
+)
+
+REQUIRED_REMOTE_COMMAND_FILE_BRIDGE_OPERATIONS = (
+    "exec",
+    "write_file",
+    "read_file",
+    "cleanup",
+)
+
+REMOTE_COMMAND_FILE_BRIDGE_FORBIDDEN_RESPONSE_FLAGS = (
+    "raw_command_recorded",
+    "raw_stdout_recorded",
+    "raw_stderr_recorded",
+    "raw_task_text_recorded",
+    "raw_logs_recorded",
+    "raw_trajectory_recorded",
+    "credential_values_recorded",
+    "host_paths_recorded",
+    "remote_paths_recorded",
+)
+
+
+def _public_safe_label(value: Any, *, limit: int = 120) -> str | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    cleaned = []
+    for char in text:
+        cleaned.append(char.lower() if char.isalnum() or char in {"-", "_", "."} else "-")
+    label = "".join(cleaned).strip("-_.")
+    while "--" in label:
+        label = label.replace("--", "-")
+    return (label or None)[:limit]
+
+
+def build_skillsbench_remote_command_file_bridge_probe_request() -> dict[str, Any]:
+    """Build the non-sensitive operation probe sent to a remote bridge.
+
+    The request intentionally contains only a fixed probe payload. It is not a
+    benchmark task request and does not include task text, credentials, paths,
+    uploads, submissions, or runner logs.
+    """
+
+    return {
+        "schema_version": (
+            SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_PROBE_REQUEST_SCHEMA_VERSION
+        ),
+        "benchmark_id": "skillsbench@1.1",
+        "probe_id": "skillsbench_remote_command_file_bridge_probe",
+        "no_upload": True,
+        "submit_enabled": False,
+        "operations": [
+            {
+                "kind": "exec",
+                "label": "bounded_noop_command",
+                "timeout_sec": 5,
+                "expect_exit_code_zero": True,
+            },
+            {
+                "kind": "write_file",
+                "label": "probe_marker_write",
+                "path_label": "bridge_probe_marker",
+                "max_bytes": 64,
+                "content": "goal-harness-skillsbench-bridge-probe\n",
+            },
+            {
+                "kind": "read_file",
+                "label": "probe_marker_read",
+                "path_label": "bridge_probe_marker",
+                "max_bytes": 64,
+                "expect_content_match": True,
+            },
+            {
+                "kind": "cleanup",
+                "label": "probe_marker_cleanup",
+                "path_label": "bridge_probe_marker",
+            },
+        ],
+        "boundary": {
+            "record_raw_command": False,
+            "record_raw_stdout": False,
+            "record_raw_stderr": False,
+            "record_raw_task_text": False,
+            "record_paths": False,
+            "sync_credentials": False,
+            "allow_upload": False,
+            "allow_submit": False,
+        },
+    }
+
+
+def build_skillsbench_remote_command_file_bridge_probe_response(
+    *,
+    ready: bool,
+    operations: list[dict[str, Any]] | None = None,
+    first_blocker: str | None = None,
+    stage: str = "complete",
+) -> dict[str, Any]:
+    """Build a bridge-side response for tests or simple local probe servers."""
+
+    op_list = list(operations or [])
+    blocker = first_blocker
+    if blocker is None:
+        blocker = (
+            "skillsbench_remote_command_file_bridge_ready"
+            if ready
+            else "skillsbench_remote_command_file_bridge_probe_failed"
+        )
+    return {
+        "schema_version": (
+            SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_PROBE_RESPONSE_SCHEMA_VERSION
+        ),
+        "ready": ready,
+        "first_blocker": blocker,
+        "stage": _public_safe_label(stage, limit=80) or "unknown",
+        "operations": op_list,
+        "raw_command_recorded": False,
+        "raw_stdout_recorded": False,
+        "raw_stderr_recorded": False,
+        "raw_task_text_recorded": False,
+        "raw_logs_recorded": False,
+        "raw_trajectory_recorded": False,
+        "credential_values_recorded": False,
+        "host_paths_recorded": False,
+        "remote_paths_recorded": False,
+        "upload_performed": False,
+        "submit_performed": False,
+    }
+
+
+def run_skillsbench_remote_command_file_bridge_probe(
+    command: str | list[str] | tuple[str, ...] | None,
+    *,
+    timeout_sec: float = 10.0,
+) -> dict[str, Any]:
+    """Run a public-safe command/file probe against a remote bridge command."""
+
+    if not command:
+        return _bridge_probe_payload(
+            ready=False,
+            first_blocker="skillsbench_remote_command_file_bridge_probe_command_missing",
+            stage="command_missing",
+            bridge_command_invoked=False,
+            response=None,
+            elapsed_ms=0,
+        )
+
+    argv = _command_to_argv(command)
+    request = build_skillsbench_remote_command_file_bridge_probe_request()
+    started = time.monotonic()
+    stage = "spawn"
+    try:
+        stage = "communicate"
+        proc = subprocess.run(
+            argv,
+            input=json.dumps(request, separators=(",", ":")),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=timeout_sec,
+            check=False,
+        )
+        elapsed_ms = int((time.monotonic() - started) * 1000)
+        if proc.returncode != 0:
+            return _bridge_probe_payload(
+                ready=False,
+                first_blocker="skillsbench_remote_command_file_bridge_probe_command_failed",
+                stage="command_exit",
+                bridge_command_invoked=True,
+                response=None,
+                elapsed_ms=elapsed_ms,
+            )
+        stage = "parse_response"
+        response = json.loads(proc.stdout)
+        return _payload_from_bridge_response(response, elapsed_ms=elapsed_ms)
+    except subprocess.TimeoutExpired:
+        return _bridge_probe_payload(
+            ready=False,
+            first_blocker="skillsbench_remote_command_file_bridge_probe_timeout",
+            stage=stage,
+            bridge_command_invoked=True,
+            response=None,
+            elapsed_ms=int(timeout_sec * 1000),
+        )
+    except (OSError, json.JSONDecodeError, TypeError, ValueError):
+        return _bridge_probe_payload(
+            ready=False,
+            first_blocker=f"skillsbench_remote_command_file_bridge_{stage}_failed",
+            stage=stage,
+            bridge_command_invoked=True,
+            response=None,
+            elapsed_ms=int((time.monotonic() - started) * 1000),
+        )
+
+
+def _payload_from_bridge_response(
+    response: dict[str, Any],
+    *,
+    elapsed_ms: int,
+) -> dict[str, Any]:
+    if not isinstance(response, dict):
+        return _bridge_probe_payload(
+            ready=False,
+            first_blocker="skillsbench_remote_command_file_bridge_response_invalid",
+            stage="validate_response",
+            bridge_command_invoked=True,
+            response=None,
+            elapsed_ms=elapsed_ms,
+        )
+
+    schema_ok = (
+        response.get("schema_version")
+        == SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_PROBE_RESPONSE_SCHEMA_VERSION
+    )
+    operations = response.get("operations")
+    op_list = operations if isinstance(operations, list) else []
+    op_kinds = [
+        str(op.get("kind") or "")
+        for op in op_list
+        if isinstance(op, dict) and str(op.get("kind") or "")
+    ]
+    missing_ops = [
+        kind
+        for kind in REQUIRED_REMOTE_COMMAND_FILE_BRIDGE_OPERATIONS
+        if kind not in op_kinds
+    ]
+    failed_ops = [
+        str(op.get("kind") or "unknown")
+        for op in op_list
+        if isinstance(op, dict) and op.get("status") != "ok"
+    ]
+    boundary_violations = [
+        flag
+        for flag in REMOTE_COMMAND_FILE_BRIDGE_FORBIDDEN_RESPONSE_FLAGS
+        if response.get(flag) is True
+    ]
+    if response.get("upload_performed") is True:
+        boundary_violations.append("upload_performed")
+    if response.get("submit_performed") is True:
+        boundary_violations.append("submit_performed")
+
+    ready = (
+        schema_ok
+        and response.get("ready") is True
+        and not missing_ops
+        and not failed_ops
+        and not boundary_violations
+    )
+    if ready:
+        first_blocker = "skillsbench_remote_command_file_bridge_ready"
+    elif not schema_ok:
+        first_blocker = "skillsbench_remote_command_file_bridge_response_schema_invalid"
+    elif boundary_violations:
+        first_blocker = "skillsbench_remote_command_file_bridge_boundary_violation"
+    elif missing_ops:
+        first_blocker = "skillsbench_remote_command_file_bridge_operations_incomplete"
+    elif failed_ops:
+        first_blocker = "skillsbench_remote_command_file_bridge_operation_failed"
+    else:
+        first_blocker = (
+            _public_safe_label(response.get("first_blocker"), limit=120)
+            or "skillsbench_remote_command_file_bridge_probe_failed"
+        )
+    return _bridge_probe_payload(
+        ready=ready,
+        first_blocker=first_blocker,
+        stage=_public_safe_label(response.get("stage"), limit=80) or "complete",
+        bridge_command_invoked=True,
+        response=response,
+        elapsed_ms=elapsed_ms,
+        missing_operations=missing_ops,
+        failed_operations=failed_ops,
+        boundary_violations=boundary_violations,
+    )
+
+
+def _bridge_probe_payload(
+    *,
+    ready: bool,
+    first_blocker: str,
+    stage: str,
+    bridge_command_invoked: bool,
+    response: dict[str, Any] | None,
+    elapsed_ms: int,
+    missing_operations: list[str] | None = None,
+    failed_operations: list[str] | None = None,
+    boundary_violations: list[str] | None = None,
+) -> dict[str, Any]:
+    operations = response.get("operations") if isinstance(response, dict) else []
+    op_summaries: list[dict[str, Any]] = []
+    if isinstance(operations, list):
+        for op in operations[:8]:
+            if not isinstance(op, dict):
+                continue
+            summary: dict[str, Any] = {}
+            for field in ("kind", "label", "status"):
+                value = _public_safe_label(op.get(field), limit=80)
+                if value:
+                    summary[field] = value
+            if isinstance(op.get("exit_code_zero"), bool):
+                summary["exit_code_zero"] = op["exit_code_zero"]
+            if isinstance(op.get("content_match"), bool):
+                summary["content_match"] = op["content_match"]
+            if summary:
+                op_summaries.append(summary)
+
+    response_schema = None
+    if isinstance(response, dict):
+        response_schema = _public_safe_label(response.get("schema_version"), limit=120)
+
+    elapsed = max(0, min(int(elapsed_ms), 600_000))
+    return {
+        "schema_version": SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_PROBE_SCHEMA_VERSION,
+        "ready": ready,
+        "first_blocker": _public_safe_label(first_blocker, limit=120)
+        or "skillsbench_remote_command_file_bridge_probe_failed",
+        "stage": _public_safe_label(stage, limit=80) or "unknown",
+        "elapsed_ms": elapsed,
+        "bridge_command_invoked": bridge_command_invoked,
+        "request_schema_version": (
+            SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_PROBE_REQUEST_SCHEMA_VERSION
+        ),
+        "response_schema_version": response_schema,
+        "required_operations": list(REQUIRED_REMOTE_COMMAND_FILE_BRIDGE_OPERATIONS),
+        "operation_count": len(op_summaries),
+        "operations": op_summaries,
+        "missing_operations": [
+            _public_safe_label(item, limit=80) or "unknown"
+            for item in (missing_operations or [])
+        ],
+        "failed_operations": [
+            _public_safe_label(item, limit=80) or "unknown"
+            for item in (failed_operations or [])
+        ],
+        "boundary_violations": [
+            _public_safe_label(item, limit=80) or "unknown"
+            for item in (boundary_violations or [])
+        ],
+        "raw_command_recorded": False,
+        "raw_stdout_recorded": False,
+        "raw_stderr_recorded": False,
+        "raw_task_text_recorded": False,
+        "raw_logs_recorded": False,
+        "raw_trajectory_recorded": False,
+        "credential_values_recorded": False,
+        "host_paths_recorded": False,
+        "remote_paths_recorded": False,
+        "upload_performed": False,
+        "submit_performed": False,
+    }
+
+
+def _command_to_argv(command: str | list[str] | tuple[str, ...]) -> list[str]:
+    if isinstance(command, str):
+        return shlex.split(command)
+    return [str(part) for part in command]

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -72,6 +72,9 @@ from goal_harness.benchmark_adapters.skillsbench_acp_relay import (  # noqa: E40
     run_skillsbench_host_local_acp_transport_probe,
     run_skillsbench_local_acp_relay_probe,
 )
+from goal_harness.benchmark_adapters.skillsbench_remote_bridge import (  # noqa: E402
+    run_skillsbench_remote_command_file_bridge_probe,
+)
 from goal_harness.benchmark_trajectory import summarize_public_acp_trajectory
 
 DEFAULT_SKILLSBENCH_ROOT = REPO_ROOT / ".local/benchmark/externals/skillsbench"
@@ -462,6 +465,9 @@ def inspect_skillsbench_worker_handshake(
     local_acp_relay_probe_timeout_sec: float = 10.0,
     probe_host_local_acp_transport: bool = False,
     host_local_acp_transport_probe_timeout_sec: float = 10.0,
+    probe_remote_command_file_bridge: bool = False,
+    remote_command_file_bridge_probe_command: str | None = None,
+    remote_command_file_bridge_probe_timeout_sec: float = 10.0,
     remote_executor_ready: bool = True,
     remote_task_data_ready: bool = True,
     remote_command_file_bridge_ready: bool = False,
@@ -481,6 +487,7 @@ def inspect_skillsbench_worker_handshake(
     local_acp_relay_ready = False
     host_local_acp_transport_probe = None
     host_local_acp_transport_ready = False
+    remote_command_file_bridge_probe = None
     if probe_local_acp_relay:
         local_acp_relay_probe = run_skillsbench_local_acp_relay_probe(
             local_acp_relay_command,
@@ -495,6 +502,16 @@ def inspect_skillsbench_worker_handshake(
         )
         host_local_acp_transport_ready = (
             host_local_acp_transport_probe.get("ready") is True
+        )
+    if probe_remote_command_file_bridge:
+        remote_command_file_bridge_probe = (
+            run_skillsbench_remote_command_file_bridge_probe(
+                remote_command_file_bridge_probe_command,
+                timeout_sec=remote_command_file_bridge_probe_timeout_sec,
+            )
+        )
+        remote_command_file_bridge_ready = (
+            remote_command_file_bridge_probe.get("ready") is True
         )
     try:
         __import__("benchflow")
@@ -537,6 +554,7 @@ def inspect_skillsbench_worker_handshake(
         host_local_acp_transport_ready=host_local_acp_transport_ready,
         host_local_acp_transport_probe=host_local_acp_transport_probe,
         remote_command_file_bridge_ready=remote_command_file_bridge_ready,
+        remote_command_file_bridge_probe=remote_command_file_bridge_probe,
         remote_executor_ready=remote_executor_ready,
         remote_task_data_ready=remote_task_data_ready,
     )
@@ -3084,6 +3102,29 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--remote-command-file-bridge-probe",
+        action="store_true",
+        help=(
+            "During --local-driver-worker-handshake-preflight, call a bounded "
+            "remote command/file bridge probe command and derive readiness from "
+            "its compact response."
+        ),
+    )
+    parser.add_argument(
+        "--remote-command-file-bridge-probe-command",
+        default=None,
+        help=(
+            "Command used by --remote-command-file-bridge-probe. It must read "
+            "the probe JSON from stdin and write compact probe JSON to stdout."
+        ),
+    )
+    parser.add_argument(
+        "--remote-command-file-bridge-probe-timeout-sec",
+        type=float,
+        default=10.0,
+        help="Timeout for --remote-command-file-bridge-probe.",
+    )
+    parser.add_argument(
         "--fail-fast-on-apt-risk",
         action="store_true",
         help=(
@@ -3188,6 +3229,13 @@ def main(argv: list[str] | None = None) -> int:
             probe_host_local_acp_transport=args.host_local_acp_transport_probe,
             host_local_acp_transport_probe_timeout_sec=(
                 args.host_local_acp_transport_probe_timeout_sec
+            ),
+            probe_remote_command_file_bridge=args.remote_command_file_bridge_probe,
+            remote_command_file_bridge_probe_command=(
+                args.remote_command_file_bridge_probe_command
+            ),
+            remote_command_file_bridge_probe_timeout_sec=(
+                args.remote_command_file_bridge_probe_timeout_sec
             ),
             remote_command_file_bridge_ready=args.remote_command_file_bridge_ready,
             remote_executor_ready=True,

--- a/scripts/skillsbench_remote_command_file_bridge.py
+++ b/scripts/skillsbench_remote_command_file_bridge.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Serve a public-safe SkillsBench remote command/file bridge probe.
+
+This helper is a local fake bridge for validation and developer wiring. Real
+remote executors can implement the same stdin/stdout JSON contract behind SSH
+or another private transport. The response intentionally records only compact
+operation facts, never raw command text, stdout, stderr, paths, credentials,
+logs, trajectories, uploads, or submissions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from goal_harness.benchmark_adapters.skillsbench_remote_bridge import (  # noqa: E402
+    SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_PROBE_REQUEST_SCHEMA_VERSION,
+    build_skillsbench_remote_command_file_bridge_probe_response,
+)
+
+
+def _operation(
+    *,
+    kind: str,
+    label: str,
+    status: str = "ok",
+    exit_code_zero: bool | None = None,
+    content_match: bool | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {"kind": kind, "label": label, "status": status}
+    if exit_code_zero is not None:
+        payload["exit_code_zero"] = exit_code_zero
+    if content_match is not None:
+        payload["content_match"] = content_match
+    return payload
+
+
+def serve_probe(*, fail_operation: str | None = None) -> int:
+    try:
+        request = json.loads(sys.stdin.read() or "{}")
+    except json.JSONDecodeError:
+        response = build_skillsbench_remote_command_file_bridge_probe_response(
+            ready=False,
+            first_blocker="skillsbench_remote_command_file_bridge_request_invalid",
+            stage="parse_request",
+        )
+        print(json.dumps(response, sort_keys=True))
+        return 0
+
+    if (
+        request.get("schema_version")
+        != SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_PROBE_REQUEST_SCHEMA_VERSION
+    ):
+        response = build_skillsbench_remote_command_file_bridge_probe_response(
+            ready=False,
+            first_blocker="skillsbench_remote_command_file_bridge_request_schema_invalid",
+            stage="validate_request",
+        )
+        print(json.dumps(response, sort_keys=True))
+        return 0
+
+    content = "goal-harness-skillsbench-bridge-probe\n"
+    operations: list[dict[str, Any]] = []
+    with tempfile.TemporaryDirectory(prefix="gh-skillsbench-bridge-") as tmp:
+        marker = Path(tmp) / "marker.txt"
+
+        exec_status = "failed" if fail_operation == "exec" else "ok"
+        operations.append(
+            _operation(
+                kind="exec",
+                label="bounded_noop_command",
+                status=exec_status,
+                exit_code_zero=exec_status == "ok",
+            )
+        )
+
+        write_status = "failed" if fail_operation == "write_file" else "ok"
+        if write_status == "ok":
+            marker.write_text(content, encoding="utf-8")
+        operations.append(
+            _operation(
+                kind="write_file",
+                label="probe_marker_write",
+                status=write_status,
+            )
+        )
+
+        read_status = "failed" if fail_operation == "read_file" else "ok"
+        read_match = False
+        if read_status == "ok":
+            try:
+                read_match = marker.read_text(encoding="utf-8") == content
+            except OSError:
+                read_status = "failed"
+        operations.append(
+            _operation(
+                kind="read_file",
+                label="probe_marker_read",
+                status=read_status,
+                content_match=read_match,
+            )
+        )
+
+        cleanup_status = "failed" if fail_operation == "cleanup" else "ok"
+        if cleanup_status == "ok":
+            try:
+                marker.unlink()
+            except FileNotFoundError:
+                pass
+        operations.append(
+            _operation(
+                kind="cleanup",
+                label="probe_marker_cleanup",
+                status=cleanup_status,
+            )
+        )
+
+    ready = all(item["status"] == "ok" for item in operations)
+    response = build_skillsbench_remote_command_file_bridge_probe_response(
+        ready=ready,
+        operations=operations,
+        first_blocker=(
+            None
+            if ready
+            else "skillsbench_remote_command_file_bridge_operation_failed"
+        ),
+    )
+    print(json.dumps(response, sort_keys=True))
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--serve-probe", action="store_true")
+    parser.add_argument(
+        "--fail-operation",
+        choices=["exec", "write_file", "read_file", "cleanup"],
+        default=None,
+    )
+    args = parser.parse_args(argv)
+    if args.serve_probe:
+        return serve_probe(fail_operation=args.fail_operation)
+    parser.error("--serve-probe is required")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a public-safe SkillsBench remote command/file bridge probe contract
- wire SkillsBench worker preflight to derive bridge readiness from compact probe results
- document the developer workflow and keep the local fake bridge clearly separate from real remote-executor evidence

## Validation
- python3 -m py_compile goal_harness/benchmark_adapters/skillsbench.py goal_harness/benchmark_adapters/skillsbench_remote_bridge.py scripts/skillsbench_automation_loop.py scripts/skillsbench_remote_command_file_bridge.py examples/skillsbench-benchmark-run-smoke.py
- python3 examples/skillsbench-benchmark-run-smoke.py
- python3 examples/benchmark-split-control-remote-executor-smoke.py
- python3 examples/benchmark-developer-workflow-doc-smoke.py
- git diff --cached --check
- goal-harness check --scan-path docs/benchmark-developer-workflow.md --scan-path examples/skillsbench-benchmark-run-smoke.py --scan-path goal_harness/benchmark_adapters/skillsbench.py --scan-path goal_harness/benchmark_adapters/skillsbench_remote_bridge.py --scan-path scripts/skillsbench_automation_loop.py --scan-path scripts/skillsbench_remote_command_file_bridge.py

## Excluded
- no remote hostnames, private bridge commands, raw task text, raw logs, raw trajectories, credentials, local paths, uploads, or submissions

## Residual risk
- this proves the reusable bridge contract and fake bridge path; a real remote executor still needs to implement the same stdin/stdout probe before a SkillsBench mini-pair should run.