### PR TITLE
Gate unverified Codex goal benchmark baselines

### DIFF
--- a/docs/benchmark-developer-workflow.md
+++ b/docs/benchmark-developer-workflow.md
@@ -49,8 +49,13 @@ For a real benchmark slice, use this sequence:
      enough CPU/memory/disk, and can run Codex CLI plus containers directly;
    - use a split-control route only when host credentials, local policy, or
      runner constraints make a single cloud host unsuitable.
-3. Produce a launch plan or runner batch only after a fresh readiness re-check.
-4. Build benchmark-specific command-adapter facts when the route still needs a
+3. Prove the comparison baseline before any treatment claim. The preferred
+   baseline is real Codex Goal mode, not a hand-rolled polling loop and not a
+   prompt that merely starts with `/goal`. If the runner cannot prove that Codex
+   entered a persistent goal state through a supported Codex surface, park the
+   A/B baseline and continue only readiness, runner, or blocker work.
+4. Produce a launch plan or runner batch only after a fresh readiness re-check.
+5. Build benchmark-specific command-adapter facts when the route still needs a
    Goal Harness adapter, such as
    `goal-harness benchmark terminal-bench-command-adapter terminal-bench`.
    When Terminal-Bench uses a remote executor, first reduce the local-driver
@@ -70,10 +75,10 @@ For a real benchmark slice, use this sequence:
    launch-adapter results, missing local-driver materializers, missing sandbox
    contracts, remote-agent-runtime requirements, or compact reducers as
    blockers instead of launching a private script.
-5. Run the smallest no-upload dry-run or mini-pair that can answer the current
+6. Run the smallest no-upload dry-run or mini-pair that can answer the current
    product question.
-6. Ingest a compact result or precise blocker.
-7. Update Goal Harness todo/state so the next developer sees the current route.
+7. Ingest a compact result or precise blocker.
+8. Update Goal Harness todo/state so the next developer sees the current route.
 
 Do not start from a raw shell command hidden in a local note. If a benchmark
 cannot be launched through a documented route, the next product task is to
@@ -118,6 +123,27 @@ host, then Codex CLI runs there like a normal developer would. Goal Harness
 should not need to understand SSH internals, jump hosts, or remote file bridges
 in the hot path. It should only record compact route readiness, result handles,
 blockers, and no-upload boundaries.
+
+### Codex Goal Baseline Gate
+
+The primary comparison target is **Codex Goal mode** running on the benchmark
+host. A benchmark route may call itself a Codex Goal baseline only when it has
+evidence for all of the following:
+
+- the installed Codex build exposes `features.goals=true` or an equivalent
+  enabled Goal feature;
+- the runner starts Goal mode through a supported Codex surface, such as the
+  interactive CLI slash command documented as `/goal`;
+- the run evidence shows a persistent goal attached to the active thread, not
+  only a prompt string whose first token is `/goal`;
+- the route does not add Goal Harness state, access packets, reward feedback,
+  or polling semantics to the baseline arm.
+
+If these facts are not available, classify the result as a runner/readiness
+probe or unverified slash-goal prompt experiment, not as a Codex Goal baseline.
+In that state, do not launch matched Goal Harness treatment for uplift claims;
+instead record the exact trigger gap and keep working on cloud host, runner,
+task-data, or compact-result readiness.
 
 Default cloud ECS host readiness:
 

--- a/docs/research/long-horizon-agent-benchmarks/cloud-codex-benchmark-route-20260619.md
+++ b/docs/research/long-horizon-agent-benchmarks/cloud-codex-benchmark-route-20260619.md
@@ -18,6 +18,13 @@ The route is:
    raw artifacts, and compact reducers on that host.
 4. Write only compact public-safe evidence back to Goal Harness.
 
+The comparison baseline for product claims is real Codex Goal mode, not a
+Codex CLI polling loop. If the cloud host can run `codex exec` but the benchmark
+runner cannot prove a stable `/goal` invocation and persistent goal state, the
+run remains a readiness or unverified slash-goal experiment. It should not be
+paired with a Goal Harness treatment for uplift claims until that baseline
+trigger is proven or an equivalent supported Codex Goal surface is documented.
+
 Goal Harness should not need to understand the SSH jump path, remote file
 bridge, or command relay in the hot path. Once the host is reachable and Codex
 is authenticated there by the operator, benchmark execution should look like a
@@ -96,9 +103,9 @@ run:
 
 | Family | Next route | Remaining gate |
 | --- | --- | --- |
-| Terminal-Bench | Run Codex CLI and the runner directly on the cloud host. | Pick a bounded no-upload case and verify the Docker-compatible runtime is sufficient for the runner. |
-| SkillsBench | Run BenchFlow and Codex CLI on the cloud host; compare base/test mini-pair through compact evidence. | Run the first no-upload mini-pair and record any BenchFlow/container blocker compactly. |
-| Agents' Last Exam | Run upstream-close ALE local-Docker route on the cloud host. | Resolve task-data access and disk budget before formal task execution. |
+| Terminal-Bench | Run Codex CLI and the runner directly on the cloud host; use real Codex Goal only after goal-state evidence exists. | Pick a bounded no-upload case, verify Docker-compatible runtime, and prove or park the Goal baseline trigger. |
+| SkillsBench | Run BenchFlow and Codex CLI on the cloud host; compare only after the Codex Goal baseline trigger is proven. | Prove native Goal-state entry for the baseline, or classify the route as readiness/unverified slash-goal instead of treatment evidence. |
+| Agents' Last Exam | Run upstream-close ALE local-Docker route on the cloud host; use Codex Goal baseline only after the trigger proof exists. | Resolve task-data access, disk budget, and Goal baseline trigger before formal paired claims. |
 
 ## Claim Boundary
 

--- a/docs/research/long-horizon-agent-benchmarks/roadmap.md
+++ b/docs/research/long-horizon-agent-benchmarks/roadmap.md
@@ -445,11 +445,16 @@ Run the same task slice under at least two user-simulator settings. Record
 whether failures are caused by the agent, the simulator, policy ambiguity,
 tool-state mismatch, or orchestration overhead.
 
-### P1: Codex CLI Engineering Baseline
+### P1: Codex Goal Engineering Baseline
 
-Run the selected engineering pilot with Codex CLI goal mode and a Goal Harness
-wrapped goal-mode Codex worker. Measure completion, validation, restartability,
-stale-state errors, overhead, and evidence quality.
+Run the selected engineering pilot against real Codex Goal mode and a Goal
+Harness wrapped Codex worker. The baseline is not a Codex CLI polling loop and
+not a prompt that merely begins with `/goal`; it must show that Codex entered a
+persistent goal state through a supported surface. If no stable benchmark-runner
+trigger exists yet, park the A/B comparison and keep only runner readiness,
+task-data, or trigger-validation work active. Measure completion, validation,
+restartability, stale-state errors, overhead, and evidence quality only after
+that baseline is proven.
 
 ### P1/P2: Cross-Benchmark Failure-Case Gate
 
@@ -485,12 +490,13 @@ separate from external benchmark execution.
 
 ## Active Agent Todo Seed
 
-- [ ] [P0] Run the Terminal-Bench 2.0 private/no-upload baseline failure gate
-  with Codex CLI goal mode for the selected first case
-  (`fix-code-vulnerability` unless the runner blocker forces a backup). Record
-  a compact baseline event with goal-mode invocation surface, official outcome,
-  terminal phase, failure class, trace boundary, and Goal Harness leverage
-  decision.
+- [ ] [P0] Prove the Terminal-Bench 2.0 private/no-upload baseline trigger for
+  real Codex Goal mode before any paired treatment: identify the supported
+  runner invocation surface, show persistent goal-state evidence, and only then
+  run the selected first case (`fix-code-vulnerability` unless the runner
+  blocker forces a backup). If the trigger is not stable, record the precise
+  trigger gap and do not treat a slash-prefix prompt or polling loop as the
+  baseline.
 - [ ] [P0] If the Terminal-Bench goal-mode baseline failure is
   control-plane-addressable, run the matched `codex-goal-harness` treatment on
   the same case with task, prompt, tests, scorer, image, timeout, model, runner

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -24,7 +24,9 @@ For the ``codex-goal-mode-baseline`` route it uses BenchFlow's user hook only
 to request a slash-goal-style initial prompt, with no reward follow-up, no Goal
 Harness controller state, and no verifier feedback. This is not sufficient by
 itself to prove native Codex CLI goal mode; that requires separate CLI
-slash-command/goal-state evidence.
+slash-command/goal-state evidence. Full execution of this route is blocked by
+default until that evidence exists; use it only for explicit slash-prefix
+experiments.
 
 Run from the SkillsBench checkout so BenchFlow's dependency environment is
 available, for example:
@@ -3106,7 +3108,8 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
             "main-table product-mode comparison routes; "
             "codex-goal-mode-baseline sends one /goal-prefixed prompt request "
             "with no reward follow-up, but native goal-mode invocation remains "
-            "unconfirmed without interactive CLI goal-state evidence; "
+            "unconfirmed without CLI slash-command/goal-state evidence and is "
+            "blocked by default except for --plan-only or explicit experiments; "
             "automation-loop-treatment is a reward-feedback ablation."
         ),
     )
@@ -3140,6 +3143,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
             "Diagnostic prompt wrapper for goal-harness-blind-loop-treatment. "
             "baseline-safe keeps treatment routing/ledger metadata while using "
             "the baseline-style first prompt to isolate ACP prompt-wrapper issues."
+        ),
+    )
+    parser.add_argument(
+        "--allow-unverified-goal-prefix-baseline",
+        action="store_true",
+        help=(
+            "Allow the codex-goal-mode-baseline route to run as an explicit "
+            "slash-prefix experiment. This does not prove native Codex Goal "
+            "mode and must not be used for A/B uplift claims."
         ),
     )
     parser.add_argument("--outer-timeout-sec", type=int, default=DEFAULT_TIMEOUT_SEC)
@@ -3390,6 +3402,28 @@ async def async_main(
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv or sys.argv[1:])
     logging.getLogger().setLevel(logging.WARNING)
+    if (
+        args.route == "codex-goal-mode-baseline"
+        and not args.plan_only
+        and not args.allow_unverified_goal_prefix_baseline
+    ):
+        payload = {
+            "ok": False,
+            "error_type": "CodexGoalModeBaselineUnverified",
+            "route": args.route,
+            "reason": (
+                "codex-goal-mode-baseline currently sends a slash-goal-style "
+                "prompt through BenchFlow; it is not proven to enter native "
+                "Codex Goal mode or attach persistent goal state"
+            ),
+            "next_action": (
+                "prove a stable Codex CLI /goal trigger with goal-state evidence, "
+                "or rerun with --allow-unverified-goal-prefix-baseline only as a "
+                "non-claiming slash-prefix experiment"
+            ),
+        }
+        print(json.dumps(payload, indent=2, sort_keys=True), file=sys.stderr)
+        return 2
     if args.local_codex_participant_ping:
         payload = materialize_local_codex_participant(
             codex_bin=args.local_codex_bin,


### PR DESCRIPTION
## Summary
- document that benchmark product claims must compare against real Codex Goal mode, not CLI polling or slash-prefix prompts
- update the cloud benchmark route and roadmap to park paired A/B claims until persistent goal-state evidence exists
- block SkillsBench codex-goal-mode-baseline execution by default unless explicitly run as an unverified slash-prefix experiment

## Validation
- git diff --check
- python3 -m py_compile scripts/skillsbench_automation_loop.py
- python3 scripts/skillsbench_automation_loop.py --route codex-goal-mode-baseline --task-id react-performance-debugging  # exits 2 with CodexGoalModeBaselineUnverified
- python3 scripts/skillsbench_automation_loop.py --route codex-goal-mode-baseline --task-id react-performance-debugging --plan-only
- goal-harness check --scan-path docs/benchmark-developer-workflow.md --scan-path docs/research/long-horizon-agent-benchmarks/cloud-codex-benchmark-route-20260619.md --scan-path docs/research/long-horizon-agent-benchmarks/roadmap.md --scan-path scripts/skillsbench_automation_loop.py

## Excluded
- local Goal Harness active state and .local evidence notes
- raw benchmark logs, trajectories, credentials, host details, and private paths

## Residual Risk
- The real Codex Goal trigger proof remains a follow-up; this PR prevents claiming baseline evidence before that proof exists.