### PR TITLE
Order quota todo projections by priority

### DIFF
--- a/examples/protocol-action-packet-smoke.py
+++ b/examples/protocol-action-packet-smoke.py
@@ -236,7 +236,7 @@ def assert_advancement_packet_keeps_user_todo_pending() -> None:
     assert f"agent_action={USER_TODO}" not in packet["summary"], packet
 
 
-def assert_explicit_user_gate_preempts_agent_action() -> None:
+def assert_explicit_user_gate_still_allows_independent_agent_action() -> None:
     gate_todo = (
         "[P0] Approve one no-upload Terminal-Bench rerun before crossing the "
         "resource boundary."
@@ -264,17 +264,17 @@ def assert_explicit_user_gate_preempts_agent_action() -> None:
     assert guard["notify_user_on_gate"] is True, guard
     assert guard["open_todo_notification_policy"] == "repeat_until_resolved", guard
     assert user_summary["gate_open_items"][0]["text"] == gate_todo, user_summary
-    assert "actor=user" in packet["summary"], packet
+    assert "actor=agent_with_user_gate" in packet["summary"], packet
     assert "user_action_required=true" in packet["summary"], packet
-    assert "agent_action_required=false" in packet["summary"], packet
+    assert "agent_action_required=true" in packet["summary"], packet
     assert "user_action=[P0] Approve one no-upload Terminal-Bench rerun" in packet["summary"], packet
-    assert "agent_action=[P1] LLM-assisted protocol simplification" not in packet["summary"], packet
-    assert contract["mode"] == "user_gate", contract
+    assert "agent_action=[P1] LLM-assisted protocol simplification" in packet["summary"], packet
+    assert contract["mode"] == "bounded_delivery_with_user_notice", contract
     assert contract["user_channel"]["action_required"] is True, contract
     assert contract["user_channel"]["notify"] == "NOTIFY", contract
-    assert contract["agent_channel"]["must_attempt"] is False, contract
+    assert contract["agent_channel"]["must_attempt"] is True, contract
     assert contract["agent_channel"]["primary_action"] == (
-        "wait for user/owner action after surfacing the blocker or gate"
+        "[P1] LLM-assisted protocol simplification research spike"
     ), contract
 
 
@@ -389,7 +389,7 @@ def assert_goal_scoped_primary_action_ignores_foreign_backlog() -> None:
 def main() -> None:
     assert_advancement_packet_prefers_backlog_candidate()
     assert_advancement_packet_keeps_user_todo_pending()
-    assert_explicit_user_gate_preempts_agent_action()
+    assert_explicit_user_gate_still_allows_independent_agent_action()
     assert_monitor_only_packet_keeps_user_todo_pending()
     assert_monitor_only_packet_allows_quiet_noop()
     assert_executable_recommended_action_overrides_monitor_todo()

--- a/examples/work-lane-contract-smoke.py
+++ b/examples/work-lane-contract-smoke.py
@@ -663,7 +663,41 @@ def assert_mixed_monitor_and_advancement_routes_to_advancement() -> None:
     assert guard["interaction_contract"]["agent_channel"]["primary_action"] == executable_todo, guard
     assert f"agent_action={executable_todo}" in guard["protocol_action_packet"]["summary"], guard
     first_items = guard["agent_todo_summary"]["first_open_items"]
-    assert [item["task_class"] for item in first_items] == ["continuous_monitor", "advancement_task"], guard
+    assert [item["task_class"] for item in first_items] == ["advancement_task", "continuous_monitor"], guard
+
+
+def assert_lower_priority_executable_before_higher_priority_is_reordered() -> None:
+    p2_todo = "[P2] Fold server scheduling into the longer-term roadmap."
+    p1_todo = "[P1] Fix first-screen dashboard acceptance before roadmap cleanup."
+    guard = build_quota_should_run(
+        status_payload(
+            status="todo_priority_projection_fixture",
+            agent_todo_items=[
+                {
+                    "index": 1,
+                    "text": p2_todo,
+                    "role": "agent",
+                    "status": "open",
+                    "priority": "P2",
+                    "task_class": "advancement_task",
+                },
+                {
+                    "index": 2,
+                    "text": p1_todo,
+                    "role": "agent",
+                    "status": "open",
+                    "priority": "P1",
+                    "task_class": "advancement_task",
+                },
+            ],
+        ),
+        goal_id=GOAL_ID,
+    )
+    assert guard["decision"] == "run", guard
+    assert guard["recommended_action"] == p1_todo, guard
+    assert guard["interaction_contract"]["agent_channel"]["primary_action"] == p1_todo, guard
+    executable_items = guard["agent_todo_summary"]["first_executable_items"]
+    assert [item["priority"] for item in executable_items[:2]] == ["P1", "P2"], guard
 
 
 def assert_external_monitor_context_recommends_executable_backlog() -> None:
@@ -981,6 +1015,7 @@ def main() -> int:
     assert_structured_todo_lane_registration_beats_text_fallback()
     assert_structured_monitor_registration_beats_action_text()
     assert_mixed_monitor_and_advancement_routes_to_advancement()
+    assert_lower_priority_executable_before_higher_priority_is_reordered()
     assert_external_monitor_context_recommends_executable_backlog()
     assert_benchmark_readiness_scan_routes_to_advancement()
     assert_benchmark_source_preflight_routes_to_advancement()

--- a/goal_harness/quota.py
+++ b/goal_harness/quota.py
@@ -132,6 +132,8 @@ INTERACTION_CONTRACT_SCHEMA_VERSION = "goal_harness_interaction_contract_v0"
 PROTOCOL_ACTION_PACKET_SCHEMA_VERSION = "protocol_action_packet_v0"
 AUTOMATION_LIVENESS_SCHEMA_VERSION = "automation_liveness_v0"
 TODO_BACKLOG_ITEM_LIMIT = 8
+TODO_MISSING_PRIORITY_RANK = 50
+TODO_MISSING_INDEX = 999999
 EXTERNAL_EVIDENCE_OBSERVE_PATTERNS = (
     re.compile(
         r"(?i)\b(?:poll(?:ing)?|observ(?:e|ing)|watch(?:ing)?|await(?:ing)?|wait\s+for|monitor(?:ing)?)\b.*\b"
@@ -944,6 +946,42 @@ def _compact_todo_summary_item(item: dict[str, Any], *, text: str | None = None)
     return compact
 
 
+def _todo_priority_label(item: dict[str, Any]) -> str | None:
+    priority = item.get("priority")
+    if isinstance(priority, str) and priority.strip():
+        return priority.strip().upper()
+    text = " ".join(
+        str(value or "")
+        for value in (item.get("title"), item.get("text"))
+        if str(value or "").strip()
+    )
+    match = re.search(r"\bP([0-4])\b", text.upper())
+    if not match:
+        return None
+    return f"P{match.group(1)}"
+
+
+def _todo_priority_rank(item: dict[str, Any]) -> int:
+    priority = _todo_priority_label(item)
+    if not priority:
+        return TODO_MISSING_PRIORITY_RANK
+    match = re.match(r"P([0-4])", priority)
+    if not match:
+        return TODO_MISSING_PRIORITY_RANK
+    return int(match.group(1))
+
+
+def _todo_index_rank(item: dict[str, Any]) -> int:
+    try:
+        return int(item.get("index"))
+    except (TypeError, ValueError):
+        return TODO_MISSING_INDEX
+
+
+def _todo_projection_sort_key(item: dict[str, Any]) -> tuple[int, int]:
+    return (_todo_priority_rank(item), _todo_index_rank(item))
+
+
 def _todo_summary_source_items(value: dict[str, Any]) -> list[dict[str, Any]]:
     source_keys = (
         "first_open_items",
@@ -984,7 +1022,10 @@ def _is_user_gate_todo_item(item: dict[str, Any]) -> bool:
 def _summarize_user_todos(value: Any) -> dict[str, Any] | None:
     if not isinstance(value, dict):
         return None
-    open_items = _todo_summary_source_items(value)
+    open_items = sorted(
+        _todo_summary_source_items(value),
+        key=_todo_projection_sort_key,
+    )
     executable_items = [
         item
         for item in open_items
@@ -1028,7 +1069,10 @@ def _summarize_project_asset_todos(value: Any) -> dict[str, Any] | None:
     ):
         return _summarize_user_todos(value)
 
-    open_items = _todo_summary_source_items(value)
+    open_items = sorted(
+        _todo_summary_source_items(value),
+        key=_todo_projection_sort_key,
+    )
     if not open_items:
         next_text = str(value.get("next") or "").strip()
         next_index = value.get("next_index", 1)


### PR DESCRIPTION
## Summary
- order quota todo summaries by P0/P1/P2 priority before selecting executable backlog items
- add a work-lane smoke for a P2 item appearing before a P1 item in source order
- refresh protocol action packet smoke for scoped user-gate fallback semantics

## Validation
- python3 examples/work-lane-contract-smoke.py
- python3 examples/quota-plan-smoke.py
- python3 examples/todo-first-open-summary-smoke.py
- python3 examples/todo-durability-fixture-smoke.py
- python3 examples/protocol-action-packet-smoke.py
- python3 regression/quota-executable-backlog-projection.py
- python3 -m py_compile goal_harness/quota.py examples/work-lane-contract-smoke.py examples/protocol-action-packet-smoke.py
- goal-harness check

## Excluded
- ignored .local active-state and evidence files
- raw benchmark logs, credentials, remote host details, and private material

## Notes
- goal-harness check still reports the pre-existing duplicate index warning for goal-harness-meta; this PR does not change history indexing.