### PR TITLE
Expose project asset todo projection gaps

### DIFF
--- a/apps/dashboard/smoke/home-route-smoke.ts
+++ b/apps/dashboard/smoke/home-route-smoke.ts
@@ -37,6 +37,7 @@ includes(dashboardSource, "推荐动作", "first-screen recommended action label
 includes(dashboardSource, "安全边界", "first-screen safety boundary label");
 includes(dashboardSource, "首个用户 Todo", "first-screen first user todo label");
 includes(dashboardSource, "最高优 Agent Todo", "first-screen top agent todo label");
+includes(dashboardSource, "Todo 投影缺口", "first-screen todo projection gap label");
 includes(dashboardSource, "Top-4 Todo", "share top-four todo label");
 includes(dashboardSource, "已完成", "share todo done status");
 includes(dashboardSource, "决策需 rebase", "share decision freshness warning");

--- a/apps/dashboard/src/data/status.ts
+++ b/apps/dashboard/src/data/status.ts
@@ -168,6 +168,14 @@ export const projectAssetHandoffReadinessSchema = z.object({
   next_probe: z.string().optional().nullable(),
 });
 
+export const projectAssetTodoProjectionGapSchema = z.object({
+  schema_version: z.string().optional().nullable(),
+  kind: z.string().optional().nullable(),
+  missing_roles: z.array(z.string()).optional().default([]),
+  source: z.string().optional().nullable(),
+  recommended_action: z.string().optional().nullable(),
+});
+
 export const projectAssetSchema = z.object({
   owner: z.string(),
   gate: z.string(),
@@ -180,6 +188,7 @@ export const projectAssetSchema = z.object({
   orchestration: orchestrationPolicySchema.optional().nullable(),
   latest_validation: projectAssetLatestValidationSchema.optional().nullable(),
   stale_latest_run_warning: staleLatestRunWarningSchema.optional().nullable(),
+  todo_projection_gap: projectAssetTodoProjectionGapSchema.optional().nullable(),
 });
 
 export const queueItemSchema = z.object({

--- a/apps/dashboard/src/views/dashboard-page.tsx
+++ b/apps/dashboard/src/views/dashboard-page.tsx
@@ -2827,14 +2827,20 @@ function ShareDecisionFrame({
     ?? "未显式授权写入或生产动作；只按当前 quota / handoff 边界推进。";
   const firstUserTodo = firstOpenTodo(view.userTodos);
   const firstAgentTodo = firstOpenTodo(view.agentTodos);
+  const missingTodoRoles = projectAsset?.todo_projection_gap?.missing_roles?.length
+    ? projectAsset.todo_projection_gap.missing_roles.join(", ")
+    : null;
 
-  const rows = [
+  const rows: Array<readonly [string, string]> = [
     ["等待方", waitingOwner],
     ["推荐动作", compactShareText(recommendedAction, 108)],
     ["安全边界", compactShareText(safetyBoundary, 108)],
     ["首个用户 Todo", compactShareText(firstUserTodo?.text, 108)],
     ["最高优 Agent Todo", compactShareText(firstAgentTodo?.text, 108)],
-  ] as const;
+  ];
+  if (missingTodoRoles) {
+    rows.push(["Todo 投影缺口", `missing roles: ${missingTodoRoles}`]);
+  }
 
   return (
     <div

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -779,6 +779,12 @@ Item fields:
   primary action surface, while monitor items are supplemental context that
   should not consume the selected goal's advancement slot unless they record a
   material transition or blocker.
+- `project_asset.todo_projection_gap`: optional explicit gap object emitted
+  when status cannot project `user_todos` and/or `agent_todos` for a connected
+  project. This means "the first-screen todo state is unknown", not "there are
+  zero todos". Consumers should surface the missing roles and ask for a
+  parseable active-state todo section or state-file repair before treating the
+  project asset as first-screen complete.
 - Todo summaries use `schema_version=todo_summary_v0`; parsed todo items use
   `schema_version=todo_item_v0`. The source active state can remain ordinary
   Markdown checkboxes, but status/quota/dashboard consumers should prefer the

--- a/examples/project-asset-todo-projection-gap-smoke.py
+++ b/examples/project-asset-todo-projection-gap-smoke.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Smoke-test explicit project_asset todo projection gaps."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from goal_harness.status import (  # noqa: E402
+    project_asset_todo_projection_gap,
+    project_asset_todo_summary,
+)
+
+
+GOAL_ID = "project-asset-todo-gap-goal"
+
+
+def write_fixture(root: Path) -> tuple[Path, Path]:
+    project = root / "project"
+    runtime = root / "runtime"
+    state_file = f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    state_path = project / state_file
+    registry_path = project / ".goal-harness" / "registry.json"
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        "---\n"
+        "status: active-read-only\n"
+        "updated_at: 2026-01-01T00:00:00+00:00\n"
+        "---\n\n"
+        "# Project Asset Todo Gap Goal\n\n"
+        "## Next Action\n\n"
+        "- Run the first read-only adapter tick.\n",
+        encoding="utf-8",
+    )
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "project-asset-gap-fixture",
+                        "status": "active-read-only",
+                        "repo": str(project),
+                        "state_file": state_file,
+                        "adapter": {
+                            "kind": "read_only_project_map_v0",
+                            "status": "connected-read-only",
+                        },
+                        "authority_sources": [],
+                    }
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return registry_path, runtime
+
+
+def run_cli(
+    registry_path: Path,
+    runtime: Path,
+    *args: str,
+    output_format: str = "json",
+) -> dict | str:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "goal_harness.cli",
+            "--registry",
+            str(registry_path),
+            "--runtime-root",
+            str(runtime),
+            "--format",
+            output_format,
+            *args,
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    if output_format == "json":
+        return json.loads(result.stdout)
+    return result.stdout
+
+
+def attention_item(payload: dict) -> dict:
+    items = payload["attention_queue"]["items"]
+    assert len(items) == 1, payload
+    return items[0]
+
+
+def main() -> int:
+    empty_summary = project_asset_todo_summary(
+        {
+            "schema_version": "todo_summary_v0",
+            "open_count": 0,
+            "done_count": 0,
+            "total_count": 0,
+        }
+    )
+    assert empty_summary == {
+        "schema_version": "todo_summary_v0",
+        "source_section": "project_asset",
+        "open": 0,
+        "done": 0,
+        "total": 0,
+    }, empty_summary
+    assert project_asset_todo_projection_gap(user_todos=empty_summary, agent_todos=empty_summary) is None
+    gap = project_asset_todo_projection_gap(user_todos=None, agent_todos=empty_summary)
+    assert gap and gap["missing_roles"] == ["user"], gap
+
+    with tempfile.TemporaryDirectory(prefix="goal-harness-project-asset-todo-gap-") as raw_tmp:
+        registry_path, runtime = write_fixture(Path(raw_tmp))
+        payload = run_cli(registry_path, runtime, "status")
+        item = attention_item(payload)  # type: ignore[arg-type]
+        project_asset = item["project_asset"]
+        projected_gap = project_asset["todo_projection_gap"]
+        assert projected_gap["kind"] == "project_asset_todo_projection_gap", projected_gap
+        assert projected_gap["missing_roles"] == ["user", "agent"], projected_gap
+        assert "user_todos" not in project_asset, project_asset
+        assert "agent_todos" not in project_asset, project_asset
+        assert item["todo_projection_gap"]["missing_roles"] == ["user", "agent"], item
+
+        markdown = run_cli(registry_path, runtime, "status", output_format="markdown")
+        assert "todo_projection_gap" in markdown, markdown
+        assert "missing_roles=user,agent" in markdown, markdown
+
+    print("project-asset-todo-projection-gap-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -148,6 +148,7 @@ MAX_BENCHMARK_RUN_LIST_ITEMS = 5
 STATUS_CONTRACT_SCHEMA_VERSION = 2
 MINIMUM_DASHBOARD_STATUS_CONTRACT_SCHEMA_VERSION = 2
 STATUS_CONTRACT_RELOAD_HINT = "scripts/macos-dashboard-launchagent.sh restart"
+PROJECT_ASSET_TODO_PROJECTION_GAP_SCHEMA_VERSION = "project_asset_todo_projection_gap_v0"
 DECISION_FRESHNESS_WINDOW_DAYS = 7
 DECISION_FRESHNESS_ITEM_LIMIT = 12
 DECISION_FRESHNESS_PROXY_NOTE = (
@@ -4337,6 +4338,30 @@ def project_asset_todo_summary(todos: dict[str, Any] | None) -> dict[str, Any] |
     return summary
 
 
+def project_asset_todo_projection_gap(
+    *,
+    user_todos: dict[str, Any] | None,
+    agent_todos: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    missing_roles: list[str] = []
+    if not isinstance(user_todos, dict):
+        missing_roles.append("user")
+    if not isinstance(agent_todos, dict):
+        missing_roles.append("agent")
+    if not missing_roles:
+        return None
+    return {
+        "schema_version": PROJECT_ASSET_TODO_PROJECTION_GAP_SCHEMA_VERSION,
+        "kind": "project_asset_todo_projection_gap",
+        "missing_roles": missing_roles,
+        "source": "active_state_todo_projection",
+        "recommended_action": (
+            "add parseable User Todo / Agent Todo sections or repair the active state_file "
+            "before treating this project_asset as first-screen complete"
+        ),
+    }
+
+
 def dependency_blocker_summary(
     items: list[dict[str, Any]],
     *,
@@ -5043,6 +5068,16 @@ def enrich_project_asset(
     agent_summary = project_asset_todo_summary(agent_todos)
     if agent_summary:
         project_asset["agent_todos"] = agent_summary
+    todo_projection_gap = project_asset_todo_projection_gap(
+        user_todos=user_todos,
+        agent_todos=agent_todos,
+    )
+    if todo_projection_gap:
+        project_asset["todo_projection_gap"] = todo_projection_gap
+        item["todo_projection_gap"] = todo_projection_gap
+    else:
+        project_asset.pop("todo_projection_gap", None)
+        item.pop("todo_projection_gap", None)
     quota_summary = project_asset_quota_summary(quota)
     if quota_summary:
         project_asset["quota"] = quota_summary
@@ -7361,6 +7396,17 @@ def render_status_markdown(payload: dict[str, Any]) -> str:
                     f"user_open={projection_gap.get('user_open_count')} "
                     f"agent_open={projection_gap.get('agent_open_count')} "
                     f"target_roles={_markdown_scalar(','.join(projection_gap.get('target_roles') or []))}"
+                )
+            todo_projection_gap = (
+                project_asset.get("todo_projection_gap")
+                if isinstance(project_asset.get("todo_projection_gap"), dict)
+                else {}
+            )
+            if todo_projection_gap:
+                lines.append(
+                    "    - todo_projection_gap: "
+                    f"missing_roles={_markdown_scalar(','.join(todo_projection_gap.get('missing_roles') or []))} "
+                    f"source={_markdown_scalar(todo_projection_gap.get('source') or '')}"
                 )
             archive_warning = (
                 project_asset.get("completed_todo_archive_warning")


### PR DESCRIPTION
## Summary
- add explicit project_asset.todo_projection_gap when connected project todo summaries cannot be projected
- preserve the gap through dashboard status schema and first-screen decision frame
- document the distinction between unknown todo projection and zero todos
- add a focused smoke for JSON and markdown projection

## Validation
- python3 examples/project-asset-todo-projection-gap-smoke.py
- python3 examples/status-markdown-smoke.py
- npm --prefix apps/dashboard run smoke:home-route
- npm --prefix apps/dashboard run build
- python3 -m py_compile goal_harness/status.py
- goal-harness check
- git diff --check

## Excluded
- no private state, raw logs, benchmark output, credentials, or local runtime files