### PR TITLE
Document Codex Goal benchmark baseline seam

### DIFF
--- a/docs/benchmark-developer-workflow.md
+++ b/docs/benchmark-developer-workflow.md
@@ -132,12 +132,21 @@ evidence for all of the following:
 
 - the installed Codex build exposes `features.goals=true` or an equivalent
   enabled Goal feature;
-- the runner starts Goal mode through a supported Codex surface, such as the
-  interactive CLI slash command documented as `/goal`;
+- the runner starts Goal mode through a supported Codex surface. Prefer the
+  Codex app-server goal API for automation: initialize with
+  `capabilities.experimentalApi=true`, `thread/start` the benchmark workspace,
+  then call `thread/goal/set` with `objective`, `status: active`, and an
+  optional `tokenBudget`. The interactive CLI slash command `/goal` remains the
+  manual fallback, not the preferred benchmark automation seam;
 - the run evidence shows a persistent goal attached to the active thread, not
   only a prompt string whose first token is `/goal`;
 - the route does not add Goal Harness state, access packets, reward feedback,
   or polling semantics to the baseline arm.
+
+`codex exec` is still useful as a tiny connectivity smoke on the cloud host,
+but a successful `codex exec` run is not by itself a Codex Goal baseline. Do not
+rename a polling loop, resume loop, or prompt-prefixed `/goal` experiment into a
+Goal baseline without `thread/goal/get` or equivalent persistent-goal evidence.
 
 If these facts are not available, classify the result as a runner/readiness
 probe or unverified slash-goal prompt experiment, not as a Codex Goal baseline.

--- a/docs/research/long-horizon-agent-benchmarks/cloud-codex-benchmark-route-20260619.md
+++ b/docs/research/long-horizon-agent-benchmarks/cloud-codex-benchmark-route-20260619.md
@@ -103,9 +103,9 @@ run:
 
 | Family | Next route | Remaining gate |
 | --- | --- | --- |
-| Terminal-Bench | Run Codex CLI and the runner directly on the cloud host; use real Codex Goal only after goal-state evidence exists. | Pick a bounded no-upload case, verify Docker-compatible runtime, and prove or park the Goal baseline trigger. |
-| SkillsBench | Run BenchFlow and Codex CLI on the cloud host; compare only after the Codex Goal baseline trigger is proven. | Prove native Goal-state entry for the baseline, or classify the route as readiness/unverified slash-goal instead of treatment evidence. |
-| Agents' Last Exam | Run upstream-close ALE local-Docker route on the cloud host; use Codex Goal baseline only after the trigger proof exists. | Resolve task-data access, disk budget, and Goal baseline trigger before formal paired claims. |
+| Terminal-Bench | Run Codex CLI and the runner directly on the cloud host; use the Codex app-server `thread/goal/set` path for real Goal-mode baseline automation once the host reproduces the local proof. | Pick a bounded no-upload case, verify Docker-compatible runtime and registry egress, then capture compact `thread/goal/get` evidence for the baseline arm before any paired claim. |
+| SkillsBench | Run BenchFlow and Codex CLI on the cloud host; compare only after the app-server Goal baseline seam is wired into the runner or a manual `/goal` fallback is explicitly labeled. | Reproduce persistent Goal-state entry on the cloud host and keep slash-prefixed prompts classified as readiness/unverified experiments. |
+| Agents' Last Exam | Run upstream-close ALE local-Docker route on the cloud host; use Codex Goal baseline only after task-data/image gates and the app-server Goal seam are ready. | Resolve task-data access, Docker/registry egress, disk budget, and cloud-host Goal-state evidence before formal paired claims. |
 
 ## Claim Boundary
 


### PR DESCRIPTION
## Summary
- document Codex app-server `thread/goal/set` as the preferred automation seam for Codex Goal benchmark baselines
- keep `/goal` as the manual fallback and `codex exec` as connectivity smoke only
- update the cloud benchmark route table to require compact `thread/goal/get` evidence before paired claims

## Validation
- git diff --check
- goal-harness check (passes; existing duplicate index warning remains)

## Excluded
- no `.local`, active goal state, credentials, host/IP details, raw benchmark logs, or private runbooks
