### PR TITLE
Project outcome-floor blocker noop state

### DIFF
--- a/examples/quota-plan-smoke.py
+++ b/examples/quota-plan-smoke.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 import json
 import subprocess
@@ -948,6 +949,105 @@ def assert_outcome_floor_recovery_should_run() -> None:
     assert "outcome-floor recovery safe-bypass" in spend_event["quota_event"]["reason_summary"], spend_event
 
 
+def assert_outcome_floor_projected_blocker_quiet_noop() -> None:
+    goal_id = "outcome-floor-blocker-projected"
+    recovery_goal = goal(goal_id, compute=1.0)
+    recovery_item = attention(goal_id, compute=1.0)
+    recovery_item["project_asset"] = {
+        "owner": "codex",
+        "next_action": (
+            "Blocked until a fresh public-safe non-replay ranker/cross-domain route appears."
+        ),
+        "stop_condition": "stop if recovery needs owner approval",
+        "quota": recovery_item["quota"],
+        "execution_profile": {
+            "cadence": "macro_evidence_segment",
+            "minimum_scale": "implementation",
+            "must_include": ["experiment_or_evidence_artifact", "targeted_validation", "state_writeback"],
+            "outcome_floor": {
+                "surface_streak_threshold": 1,
+                "must_advance": ["ranker_or_cross_domain_evidence"],
+                "avoid": ["surface_only_summary", "synthetic_only_test_chain"],
+            },
+        },
+        "agent_todos": {
+            "source_section": "Agent Todo",
+            "total_count": 1,
+            "open_count": 1,
+            "done_count": 0,
+            "items": [
+                {
+                    "index": 1,
+                    "done": False,
+                    "text": (
+                        "Blocked until a fresh public-safe non-replay ranker/cross-domain "
+                        "route appears."
+                    ),
+                    "task_class": "blocker",
+                    "action_kind": "outcome_floor_no_nonduplicate_successor_blocker",
+                }
+            ],
+        },
+    }
+    recovery_item["handoff_readiness"] = {
+        "ready": False,
+        "codex_ready": False,
+        "source": "project_asset",
+        "quota_state": "eligible",
+        "post_handoff_run_seen": True,
+        "post_handoff_outcome_gap_streak": 2,
+        "post_handoff_latest_run": {
+            "classification": "outcome_floor_blocker_recorded",
+            "generated_at": "2026-01-01T00:00:00+00:00",
+            "delivery_batch_scale": "single_surface",
+            "delivery_outcome": "outcome_gap",
+        },
+    }
+    payload = {
+        "ok": True,
+        "registry": "./fixtures/registry.json",
+        "runtime_root": "./fixtures/runtime",
+        "goal_count": 1,
+        "run_count": 1,
+        "attention_queue": {"items": [recovery_item]},
+        "run_history": {"goals": [recovery_goal]},
+    }
+    decision = build_quota_should_run(payload, goal_id=goal_id)
+    markdown = render_quota_should_run_markdown(decision)
+    contract = decision["interaction_contract"]
+
+    assert decision["ok"] is True, decision
+    assert decision["decision"] == "skip", decision
+    assert decision["should_run"] is False, decision
+    assert decision["normal_delivery_allowed"] is False, decision
+    assert decision["recovery_delivery_allowed"] is False, decision
+    assert decision["actionable_by_codex"] is False, decision
+    assert decision["effective_action"] == "blocked_wait", decision
+    assert decision["state"] == "focus_wait", decision
+    assert decision["quota"]["outcome_floor_blocker_projected"] is True, decision
+    assert decision["safe_bypass_allowed"] is False, decision
+    assert decision["safe_bypass_kind"] is None, decision
+    assert decision["agent_todo_summary"]["first_executable_items"] == [], decision
+    assert decision["heartbeat_recommendation"]["recommended_mode"] == (
+        "outcome_floor_blocker_projected_noop"
+    ), decision
+    assert decision["heartbeat_recommendation"]["notify"] == "DONT_NOTIFY", decision
+    assert contract["mode"] == "blocked_wait", contract
+    assert contract["agent_channel"]["must_attempt"] is False, contract
+    assert contract["agent_channel"]["quiet_noop_allowed"] is True, contract
+    assert contract["cli_channel"]["spend_after_validation"] is False, contract
+    assert "outcome_floor_blocker_projected_noop" in markdown, markdown
+
+    monitor_payload = deepcopy(payload)
+    monitor_item = monitor_payload["attention_queue"]["items"][0]
+    monitor_item["project_asset"]["agent_todos"]["items"][0]["task_class"] = "continuous_monitor"
+    monitor_item["project_asset"]["agent_todos"]["items"][0]["action_kind"] = "monitor"
+    monitor_decision = build_quota_should_run(monitor_payload, goal_id=goal_id)
+    assert "outcome_floor_blocker_projected" not in monitor_decision["quota"], monitor_decision
+    assert monitor_decision["effective_action"] == "outcome_floor_recovery", monitor_decision
+    assert monitor_decision["should_run"] is True, monitor_decision
+
+
 def assert_control_plane_health_self_repair_should_run() -> None:
     goal_id = "goal-harness-meta"
     meta_goal = goal(goal_id, compute=1.0)
@@ -1794,6 +1894,7 @@ def main() -> int:
     assert_operator_gate_should_run(status_payload)
     assert_focus_wait_should_run()
     assert_outcome_floor_recovery_should_run()
+    assert_outcome_floor_projected_blocker_quiet_noop()
     assert_control_plane_health_self_repair_should_run()
     assert_control_plane_self_repair_default_off()
     assert_control_plane_waiting_projection_self_repair_should_run()

--- a/goal_harness/quota.py
+++ b/goal_harness/quota.py
@@ -30,6 +30,7 @@ from .state_projection import is_user_wait_text
 from .todo_contract import (
     TODO_STATUS_OPEN,
     TODO_TASK_CLASS_ADVANCEMENT,
+    TODO_TASK_CLASS_BLOCKER,
     TODO_TASK_CLASS_MONITOR,
     TODO_TASK_CLASS_USER_GATE,
     next_action_requires_advancement_text,
@@ -2534,6 +2535,44 @@ def _open_todo_task_counts(summary: dict[str, Any] | None) -> dict[str, int]:
     }
 
 
+def _outcome_floor_blocker_already_projected(
+    agent_todo_summary: dict[str, Any] | None,
+) -> bool:
+    if not isinstance(agent_todo_summary, dict):
+        return False
+    if _open_todo_count(agent_todo_summary) <= 0:
+        return False
+
+    executable_items = (
+        agent_todo_summary.get("first_executable_items")
+        if isinstance(agent_todo_summary.get("first_executable_items"), list)
+        else []
+    )
+    if any(
+        isinstance(item, dict) and _todo_item_is_actionable_open(item)
+        for item in executable_items
+    ):
+        return False
+
+    first_open = (
+        agent_todo_summary.get("first_open_items")
+        if isinstance(agent_todo_summary.get("first_open_items"), list)
+        else []
+    )
+    visible_open = [
+        item
+        for item in first_open
+        if isinstance(item, dict) and _todo_item_is_actionable_open(item)
+    ]
+    if not visible_open:
+        return False
+    visible_classes = [_todo_task_class(item) for item in visible_open]
+    return (
+        TODO_TASK_CLASS_BLOCKER in visible_classes
+        and all(task_class != TODO_TASK_CLASS_ADVANCEMENT for task_class in visible_classes)
+    )
+
+
 def _next_action_requires_advancement(item: dict[str, Any]) -> bool:
     project_asset = item.get("project_asset") if isinstance(item.get("project_asset"), dict) else {}
     values = (
@@ -2967,6 +3006,20 @@ def _heartbeat_recommendation(
             "reason": _open_todo_notify_reason(state=state, waiting_on=waiting_on),
         }
     if state == "focus_wait" and quota.get("handoff_outcome_floor_block"):
+        if quota.get("outcome_floor_blocker_projected"):
+            return {
+                **base,
+                "recommended_mode": "outcome_floor_blocker_projected_noop",
+                "notify": "DONT_NOTIFY",
+                "spend_policy": (
+                    "do not append quota spend while the same concrete outcome-floor "
+                    "blocker is already projected and no executable agent todo exists"
+                ),
+                "reason": str(
+                    quota.get("reason")
+                    or "outcome-floor blocker is already projected; wait for fresh outcome evidence"
+                ),
+            }
         if quota.get("safe_bypass_allowed"):
             return {
                 **base,
@@ -3640,6 +3693,24 @@ def build_quota_should_run(status_payload: dict[str, Any], *, goal_id: str, agen
         agent_todo_summary = _summarize_project_asset_todos(
             project_asset.get("agent_todos") if project_asset else None
         ) or _summarize_user_todos(item.get("agent_todos"))
+        outcome_floor_blocker_projected = (
+            recovery_allowed
+            and _outcome_floor_blocker_already_projected(agent_todo_summary)
+        )
+        if outcome_floor_blocker_projected:
+            quota = {
+                **quota,
+                "safe_bypass_allowed": False,
+                "safe_bypass_kind": None,
+                "outcome_floor_blocker_projected": True,
+                "reason": (
+                    "handoff outcome floor blocker already projected: no executable "
+                    "agent todo exists; wait for fresh ranker/cross-domain evidence "
+                    "or a new manifest before spending recovery compute"
+                ),
+            }
+            recovery_allowed = False
+            reason = str(quota["reason"])
         goal_boundary = _goal_boundary(item)
         agent_identity = _quota_agent_identity(item, agent_id=agent_id)
         automation_prompt_upgrade = _automation_prompt_upgrade(
@@ -3696,8 +3767,9 @@ def build_quota_should_run(status_payload: dict[str, Any], *, goal_id: str, agen
             state=state,
             quota=quota,
         )
+        recommendation_item = {**item, "quota": quota}
         heartbeat_recommendation = _heartbeat_recommendation(
-            item,
+            recommendation_item,
             goal_id=safe_goal_id,
             state=state,
             should_run=should_run,


### PR DESCRIPTION
## Summary
- stop outcome-floor recovery from spending another automatic turn when a concrete blocker todo is already projected and no executable agent todo exists
- keep monitor-only todo cases out of the blocker-projected path so observation lanes do not suppress recovery by accident
- add quota-plan coverage for both the projected blocker noop and monitor-only counterexample

## Validation
- python3 -m py_compile goal_harness/quota.py
- python3 examples/quota-plan-smoke.py
- git diff --check
- goal-harness check --scan-path goal_harness/quota.py --scan-path examples/quota-plan-smoke.py
- private/secret scan on candidate paths; only existing test fixture .goal-harness path hit, no private state committed

## Excluded
- local Goal Harness runtime state
- raw benchmark logs, trajectories, verifier output, credentials, local/private artifact paths

## Residual risk
- existing goal-harness check warning about duplicate run-history index rows remains unrelated to this change