### PR TITLE
Document Terminal-Bench cloud smoke guardrails

### DIFF
--- a/docs/benchmark-developer-workflow.md
+++ b/docs/benchmark-developer-workflow.md
@@ -192,6 +192,19 @@ That command is a dry-run by default. Add `--execute` only after Codex auth,
 network, Docker, source, and task-data readiness are known. It emits command
 shape and boundary facts, not argv values or raw runner output.
 
+For direct `tb run` smoke runs on the cloud host, keep the runner invocation
+boring and Docker-compose-safe:
+
+- use an all-lowercase run id with only letters, digits, hyphens, or
+  underscores; Docker Compose rejects project names with uppercase timestamp
+  separators such as `T`;
+- pass `--output-path` as the parent runs directory and let Terminal-Bench
+  create the run-id subdirectory itself; pre-creating that directory can make
+  the runner think it is resuming a run and fail before execution;
+- keep `--no-upload-results` explicit for every developer smoke;
+- start with `--no-rebuild` only after the task image already exists, otherwise
+  record the image/build blocker instead of hiding it behind a score result.
+
 When a Terminal-Bench launch produces only startup or materialization state,
 reduce it before writing Goal Harness evidence:
 


### PR DESCRIPTION
## Summary
- document Terminal-Bench cloud-host smoke guardrails learned from the ECS run
- require docker-compose-safe lowercase run ids
- clarify that Terminal-Bench should create the run-id directory itself and that no-upload remains explicit

## Validation
- python3 examples/benchmark-developer-workflow-doc-smoke.py
- goal-harness check --scan-path docs/benchmark-developer-workflow.md
- git diff --check

## Excluded
- no remote hostnames, IPs, credentials, raw logs, trajectories, or private run paths
