### PR TITLE
docs: refresh benchmark rotation workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,8 @@ contract.
   Harness.
 - [Showcase catalog](docs/showcases/README.md): public-safe cases and future
   frontend data.
+- [Benchmark developer workflow](docs/benchmark-developer-workflow.md):
+  public-safe benchmark setup, cloud-host execution, and evidence rules.
 - [Status data contract](docs/status-data-contract.md): dashboard/status JSON
   contract.
 - [Quota allocation](docs/quota-allocation.md): `should-run` and spend

--- a/docs/benchmark-developer-workflow.md
+++ b/docs/benchmark-developer-workflow.md
@@ -177,6 +177,33 @@ Benchmark source materialization should stay close to upstream:
 - never mix temporary runner probes, raw evidence, local auth setup, or private
   benchmark artifacts into upstream benchmark source trees.
 
+For cloud hosts that cannot reliably fetch public Git sources, stage sources as
+archives from the operator machine. Prefer one compressed archive over many
+small-file transfers, and on macOS disable copyfile metadata and xattrs:
+
+```bash
+COPYFILE_DISABLE=1 tar --no-xattrs -C /tmp -czf benchmark-source.tgz upstream-checkout
+scp benchmark-source.tgz "$BENCHMARK_HOST_ALIAS":~/goal-harness-bench/cache/
+```
+
+After extraction, verify the upstream commit and clean status. If the staged
+archive includes `.git` and Git reports a dubious ownership boundary, add a
+bounded remote `safe.directory` entry for that checkout or restage it as a
+source-only archive with a `.goal-harness-upstream` marker. Do not commit the
+host-specific path or exception.
+
+When a benchmark pins a runner dependency to a public Git repository and the
+cloud host cannot fetch that dependency, stage the dependency source separately
+and patch only a temporary run-work copy to use a local `path` source. Keep the
+upstream-clean checkout unchanged, record the dependency commit, and classify
+the result as dependency readiness or a precise dependency-fetch blocker. Do
+not patch official scorer, task, prompt, or runner behavior merely to work
+around network fetch.
+
+Remote bootstrap snippets should assume a small base image: use `grep`, `find`,
+`git`, `python`, and the benchmark runner itself unless the bootstrap probe has
+confirmed extra tools such as `rg`.
+
 For Terminal-Bench, the first product-path launcher should be no-upload and
 probe-only:
 

--- a/docs/research/long-horizon-agent-benchmarks/README.md
+++ b/docs/research/long-horizon-agent-benchmarks/README.md
@@ -103,6 +103,11 @@ work still belongs in the existing code, examples, and contract documents:
   reachable but under-provisioned at 4 CPUs / 8 GiB memory, below the task's
   16 GiB memory requirement, with host disk headroom also tight before any
   task image build/start.
+- `frontier-swe-setup-readiness-v0.md`: setup-readiness scan that adds
+  FrontierSWE to the candidate set as a P1 frontier-stress lane. It records the
+  official repo, public Codex leaderboard surface, 20-hour task framing,
+  current runner/no-upload unknowns, and the required no-execution launch
+  packet before any task container, model call, upload, or leaderboard path.
 - `remote-gpu-benchmark-route-v0.md`: credential-isolated route packet for
   evaluating the user's `to` SSH path to a shared remote GPU development host.
   It keeps Codex auth/session material local by default, uses an isolated

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-priority-review-20260614.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-priority-review-20260614.md
@@ -1,5 +1,8 @@
 # Benchmark Priority Review 2026-06-14
 
+Refreshed: 2026-06-20 to add FrontierSWE and re-rank heavy SWE candidates
+after the cloud-host Codex benchmark route became the default execution path.
+
 This review re-ranks benchmark lanes by the corrected baseline definition:
 Codex CLI goal mode versus a Goal Harness assisted Codex worker. It uses only
 public-safe compact run ledger entries and public leaderboard/source evidence;
@@ -8,13 +11,16 @@ logs, credentials, uploads, or public leaderboard submissions.
 
 ## Baseline Evidence Classes
 
-Use three separate evidence classes when ranking benchmark lanes:
+Use four separate evidence classes when ranking benchmark lanes:
 
 1. `direct_codex_goal_mode_low`: a direct Codex CLI or Codex goal-mode baseline
    is already low enough to leave room for Goal Harness.
-2. `selected_hard_subset_low`: the public aggregate may be high, but local
+2. `direct_codex_frontier_stress`: the benchmark has direct Codex leaderboard
+   rows and strong long-horizon fit, but this repo has not yet mined a local
+   Codex goal-mode baseline failure.
+3. `selected_hard_subset_low`: the public aggregate may be high, but local
    selected cases show Codex goal-mode failures that can be mined safely.
-3. `adjacent_agent_low_no_clean_codex`: the benchmark is promising because
+4. `adjacent_agent_low_no_clean_codex`: the benchmark is promising because
    other agents fail often, but a clean Codex goal-mode baseline must be mined
    before treatment.
 
@@ -26,13 +32,14 @@ Codex weakness until the worker reaches the task.
 
 | Rank | Benchmark lane | Evidence class | Codex baseline signal | Current interpretation | Next move |
 | --- | --- | --- | --- | --- | --- |
-| 1 | SWE-Marathon | `direct_codex_goal_mode_low` | Prior scan records Codex CLI + GPT-5.5 at 12.0% pass@1, and the paper reports no evaluated configuration above 30% pass@1. | Best strategic target for long-horizon state, restartability, self-verification, and premature-stop failures. | Keep as top new-family lane, but require a capacity route before any real run. Local provider preflight found the first candidate under-provisioned. |
-| 2 | SkillsBench / skill-runtime lane | `direct_codex_goal_mode_low` | Public SkillsBench reports GPT-5.5 Codex at 46.8% without skills and 66.5% with skills. | Strong direct evidence that skill/context routing can move outcomes. More relevant to Goal Harness skill provenance, safe reuse, negative transfer, and exposure/writeback than Terminal-Bench style terminal work. | Promote to a near-term P1 adapter dossier and baseline-failure mining lane after the current Terminal-Bench runner setup blocker is repaired. |
-| 3 | Terminal-Bench selected hard subset | `selected_hard_subset_low` | Official full leaderboard is high for Codex CLI, but the local selected ledger has only 3 passing Codex goal-mode baseline cases among 11 unique selected cases; many failures are setup/model-route blockers rather than task failures. | Keep as the immediate engineering lane because runner, ledger, compact attribution, and worker-bridge surfaces are already wired. Do not treat full Terminal-Bench as low-baseline. | P0 is to repair worker startup/setup timeout first, then mine one attributable baseline failure before treatment. |
-| 4 | AgentIssue-Bench | `adjacent_agent_low_no_clean_codex` | Prior scan found no clean official Codex CLI score; published/leaderboard evidence for other agents is only 0.67% to 4.67% correct resolution. | Very high product fit for agent-runtime bugs, provider/tool failures, and workflow repair. Current local pilot showed a source-alignment blocker, not a benchmark-level conclusion. | Keep focused on one selected tag and align patch generation to the buggy source snapshot before any broader run. |
-| 5 | PerfBench | `adjacent_agent_low_no_clean_codex` | Prior scan found no direct Codex CLI score; OpenHands-style baseline is about 3%, specialized performance agent about 20%. | Strong validation/profiling loop and likely control-plane leverage, but setup/toolchain cost is less known. | Add setup-readiness and one cheap sample route after Terminal-Bench startup repair and AgentIssue source alignment. |
-| 6 | SWE-Bench Pro public | `adjacent_agent_low_no_clean_codex` | Public source is valuable and contamination-resistant, but a clean Codex CLI goal-mode baseline row is not yet established in this repo. | Important later SWE lane, but not the fastest way to prove Goal Harness uplift unless we first find baseline-failing cases under our exact Codex goal-mode surface. | Keep behind a wrapper/descriptor gate and a baseline failure-mining pass. |
-| 7 | WildClawBench / APEX / TheAgentCompany / ALE | `adjacent_agent_low_no_clean_codex` | These are promising professional-agent lanes, but the local repo does not yet have direct Codex goal-mode baseline evidence. | Good watchlist and adapter-dossier candidates, not immediate scoring lanes. | Build dossiers only after the current engineering/skill lanes produce stable runner and ledger patterns. |
+| 1 | Terminal-Bench selected hard subset | `selected_hard_subset_low` | Official full leaderboard is high for Codex CLI, but the local selected ledger has only 3 passing Codex goal-mode baseline cases among 11 unique selected cases; many failures are setup/model-route blockers rather than task failures. | Keep as the immediate engineering lane because the dedicated cloud host, runner, ledger, compact attribution, and no-upload smoke path are closest to producing comparable evidence. Do not treat full Terminal-Bench as low-baseline. | Finish the cloud-host no-upload smoke and compact reducer path, then mine one attributable baseline failure before treatment. |
+| 2 | SkillsBench / skill-runtime lane | `direct_codex_goal_mode_low` | Public SkillsBench reports GPT-5.5 Codex at 46.8% without skills and 66.5% with skills. | Strong direct evidence that skill/context routing can move outcomes. More relevant to Goal Harness skill provenance, safe reuse, negative transfer, and exposure/writeback than Terminal-Bench style terminal work. | Keep as the second near-term execution lane; repair verifier dependency/prewarm issues on the cloud host before broad runs. |
+| 3 | SWE-Marathon | `direct_codex_goal_mode_low` | Prior scan records Codex CLI + GPT-5.5 at 12.0% pass@1, and the paper reports no evaluated configuration above 30% pass@1. | Best strategic heavy-SWE target for long-horizon state, restartability, self-verification, and premature-stop failures. The new cloud route removes the old local Colima capacity blocker from the primary path, but the Harbor fork and multi-hour task cost still require a launch packet. | Refresh the existing setup-readiness note against the dedicated ECS route and produce a no-execution launch packet before any scored run. |
+| 4 | FrontierSWE | `direct_codex_frontier_stress` | Public FrontierSWE leaderboard includes GPT-5.5 via Codex and GPT-5.4 via Codex rows. Public framing gives agents up to roughly 20 hours per task. | Excellent high-end stress test for Goal Harness's long-horizon control-plane thesis, especially performance engineering, computational science, and ML-research tasks. It is not yet the fastest execution lane because this repo has no local checkout, task inventory, no-upload command boundary, or compact reducer. | Add as a P1 readiness lane: inspect the official repo/Harbor extension/task inventory and write a no-execution launch packet after the shared cloud benchmark substrate is proven. |
+| 5 | AgentIssue-Bench | `adjacent_agent_low_no_clean_codex` | Prior scan found no clean official Codex CLI score; published/leaderboard evidence for other agents is only 0.67% to 4.67% correct resolution. | Very high product fit for agent-runtime bugs, provider/tool failures, and workflow repair. Current local pilot showed a source-alignment blocker, not a benchmark-level conclusion. | Keep focused on one selected tag and align patch generation to the buggy source snapshot before any broader run. |
+| 6 | PerfBench | `adjacent_agent_low_no_clean_codex` | Prior scan found no direct Codex CLI score; OpenHands-style baseline is about 3%, specialized performance agent about 20%. | Strong validation/profiling loop and likely control-plane leverage, but setup/toolchain cost is less known. | Add setup-readiness and one cheap sample route after Terminal-Bench/SkillsBench cloud smokes are stable. |
+| 7 | ALE | `adjacent_agent_low_no_clean_codex` | ALE is promising for objective-driven long-horizon algorithm work, but the local repo does not yet have direct Codex goal-mode baseline evidence, and the current route is blocked on large Docker image acquisition. | Keep in rotation because it tests different failure modes from SWE tasks, but do not let image-pull substrate issues starve closer benchmark lanes. | Let the large image pull continue in the background; resume only after image availability and a no-upload smoke are proven. |
+| 8 | SWE-Bench Pro public / WildClawBench / APEX / TheAgentCompany | `adjacent_agent_low_no_clean_codex` | Public sources are valuable, but clean Codex goal-mode baseline rows or local baseline-failure mining plans are not yet established in this repo. | Useful later SWE/professional-agent lanes, but less urgent than the cloud execution substrate and the two direct Codex long-horizon SWE candidates. | Keep as dossier/watchlist lanes until each has a clean Codex goal-mode baseline failure-mining plan. |
 
 ## Terminal-Bench Local Ledger Recheck
 
@@ -53,21 +60,25 @@ while exception/timeout cases remain the next Goal Harness uplift candidates.
 
 ## Updated Priority Order
 
-1. `P0` Repair the Terminal-Bench Codex worker startup/setup path. This unlocks
-   every other Terminal-Bench baseline and treatment run and prevents setup
-   failures from being mistaken for benchmark difficulty.
-2. `P0/P1` After startup repair, rerun exactly one Terminal-Bench P0 case and
-   only launch treatment if the baseline failure is compact-attributed and
-   control-plane-addressable.
-3. `P1` Start the SkillsBench adapter dossier and baseline-failure mining lane.
-   It has a direct low Codex CLI baseline and a visible skill-lift axis.
-4. `P1` Resume the one-tag AgentIssue-Bench lane only after aligning patch
+1. `P0` Finish the cloud-host Terminal-Bench no-upload smoke and compact
+   reducer path. This proves the shared ECS + Codex CLI + Docker + ledger
+   substrate before heavier benchmark families consume time.
+2. `P0/P1` Repair the SkillsBench verifier dependency/prewarm path on the
+   cloud host and mine one baseline failure with compact attribution.
+3. `P1` Refresh SWE-Marathon against the dedicated ECS route and keep it as the
+   highest strategic low-baseline heavy-SWE candidate.
+4. `P1` Add FrontierSWE setup-readiness and a no-execution launch packet. It is
+   a high-end long-horizon stress lane with direct Codex leaderboard evidence,
+   but it must not start real tasks until runner/no-upload boundaries are
+   mapped.
+5. `P1` Resume the one-tag AgentIssue-Bench lane only after aligning patch
    generation to the benchmark buggy source snapshot.
-5. `P1` Keep SWE-Marathon as the highest strategic low-baseline benchmark, but
-   defer real execution until local or remote capacity is proven.
-6. `P1/P2` Add PerfBench setup-readiness after the current runner/setup blocker
-   is resolved.
-7. `P2` Keep SWE-Bench Pro, WildClawBench, APEX, TheAgentCompany, and ALE as
+6. `P1/P2` Keep ALE in background rotation while the large image pull and local
+   Docker route are resolved; do not count image-pull failure as agent
+   capability evidence.
+7. `P1/P2` Add PerfBench setup-readiness after Terminal-Bench and SkillsBench
+   smokes stabilize.
+8. `P2` Keep SWE-Bench Pro, WildClawBench, APEX, and TheAgentCompany as
    dossier/watchlist lanes until each has a clean Codex goal-mode baseline
    failure-mining plan.
 

--- a/docs/research/long-horizon-agent-benchmarks/cloud-codex-benchmark-route-20260619.md
+++ b/docs/research/long-horizon-agent-benchmarks/cloud-codex-benchmark-route-20260619.md
@@ -40,6 +40,48 @@ Public evidence should record only that the SSH alias was reachable and the
 slice used a short-lived multiplexed SSH session; private host names, keys,
 jump-host details, control paths, and shell history stay out of commits.
 
+In practice, treat the SSH path as serial by default. Avoid parallel `ssh` or
+`rsync` probes through the same jump-host path unless the connection has been
+explicitly stress-tested; GSSAPI-backed paths can fail transiently under rapid
+or concurrent handshakes even when the ticket is still valid. On failure,
+prefer a short backoff plus a single retry before projecting a user gate.
+
+When the cloud host cannot fetch a public benchmark source directly, stage the
+source from the operator machine as a single archive rather than thousands of
+small files through `rsync`. From macOS, build that archive with
+`COPYFILE_DISABLE=1` and xattrs disabled so AppleDouble `._*` files and
+extended attributes do not pollute the remote checkout or produce noisy remote
+tar output:
+
+```bash
+COPYFILE_DISABLE=1 tar --no-xattrs -C /tmp -czf benchmark-source.tgz upstream-checkout
+scp benchmark-source.tgz benchmark-host:/path/to/upstream-clean/
+```
+
+After extraction, verify `git status --short --branch` is clean before treating
+the checkout as upstream-close. If a previous archive already produced `._*`
+files, delete them on the remote checkout and re-run the clean-status check
+before any runner preflight.
+
+If the archive includes `.git` metadata and is extracted under a different user
+or privilege boundary, Git may reject the checkout as a dubious repository.
+Either prefer a source-only archive with an explicit upstream marker, or add a
+bounded `safe.directory` entry for the staged checkout before running
+`git status`. Keep that exception local to the benchmark host setup; do not
+commit host-specific paths.
+
+The same staging rule applies to runner dependencies pinned to public Git
+repositories. If the host cannot fetch a Git dependency directly, stage the
+dependency source as its own upstream-close checkout, then patch only a
+temporary run-work copy to use a local `path` source. Keep the upstream-clean
+benchmark checkout unmodified, record the dependency commit, and reduce the
+result to a compact readiness or blocker. This avoids turning network fetch
+failures into benchmark runner failures.
+
+Assume the cloud host starts from a small tool surface. Use POSIX-ish `grep`,
+`find`, `git`, `python`, and runner commands in remote bootstrap snippets unless
+the bootstrap probe has already confirmed tools such as `rg`.
+
 ## Why This Replaces The Default Split-Control Route
 
 The earlier split-control route was the right safety choice for shared hosts:

--- a/docs/research/long-horizon-agent-benchmarks/frontier-swe-setup-readiness-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/frontier-swe-setup-readiness-v0.md
@@ -1,0 +1,106 @@
+# FrontierSWE Setup Readiness v0
+
+Date: 2026-06-20
+
+Purpose: add FrontierSWE to the Goal Harness benchmark candidate set and decide
+whether it should become an execution lane, a readiness lane, or a watchlist
+lane.
+
+This note is a setup-readiness scan only. It does not execute a benchmark task,
+model agent, verifier, Docker environment, upload, leaderboard path, raw
+trajectory, credential read, or paid cloud run.
+
+## Source Pins
+
+- Official benchmark repo:
+  [Proximal-Labs/frontier-swe](https://github.com/Proximal-Labs/frontier-swe).
+- Public leaderboard:
+  [frontierswe.com](https://www.frontierswe.com/).
+- Public announcement and framing:
+  [Proximal FrontierSWE blog](https://www.proximal.ai/blog/frontierswe).
+
+The public repo exposes an execution-oriented benchmark shape with `tasks/`,
+`docker/`, `harbor_ext/`, `pyproject.toml`, and `uv.lock`. The README frames
+the benchmark around the hardest ultra-long-horizon technical challenges in
+performance engineering, computational science, and machine-learning research.
+
+## Codex Surface Evidence
+
+FrontierSWE has direct Codex leaderboard evidence. The public leaderboard
+observed on 2026-06-20 includes GPT-5.5 via Codex and GPT-5.4 via Codex rows.
+That means FrontierSWE is not merely an adjacent-agent benchmark; it already
+has a public Codex surface that can be compared against a Goal Harness assisted
+Codex route once our execution route is stable.
+
+The evidence class is not the same as SWE-Marathon:
+
+- SWE-Marathon is a low-baseline candidate, with prior setup notes recording
+  `Codex CLI + GPT-5.5` at `12.0%` pass@1.
+- FrontierSWE is a frontier-stress candidate, with direct Codex leaderboard
+  rows but no local Goal Harness baseline-failure mining pass yet.
+
+## Readiness Verdict
+
+Add FrontierSWE as a `P1` readiness lane, not as the next immediate execution
+lane.
+
+Reasons it fits Goal Harness:
+
+- Horizon is real. Public framing gives agents up to roughly 20 hours per task,
+  which is closer to Goal Harness's long-running state, gate, restart, and
+  validation thesis than short issue-fix suites.
+- Task domains are control-plane relevant: performance engineering,
+  computational science, and machine-learning research tend to expose long
+  compile/test loops, resource management, partial progress tracking, and
+  self-verification failures.
+- The repo includes a Harbor extension surface, which makes it conceptually
+  close to the benchmark execution work already done for Terminal-Bench and
+  SWE-Marathon.
+- Public Codex rows make it a plausible public comparison target once a clean
+  Codex goal-mode route is confirmed.
+
+Current blockers before a useful run:
+
+- No local or cloud checkout has been inspected under the Goal Harness runbook.
+- The runner boundary, no-upload flags, artifact paths, and failure-reduction
+  schema are not yet documented.
+- Task wall-clock budget is high; a first run should not start before the
+  dedicated ECS benchmark substrate has produced at least one stable
+  Terminal-Bench or SkillsBench no-upload result.
+- The benchmark may expect Prime Intellect or Harbor-specific environment
+  setup. That route should be mapped before any Docker image build, task start,
+  model call, or upload-capable command.
+
+## Proposed First Bounded Step
+
+Produce a no-execution launch packet before any real FrontierSWE run:
+
+1. Clone or inspect the public repo on the benchmark host.
+2. Pin the repo commit, runner entrypoints, task inventory, and environment
+   assumptions.
+3. Identify one CPU-only or otherwise cheap smoke candidate without reading
+   hidden references or task solutions.
+4. Document the exact no-upload/no-submit command boundary.
+5. Define the compact `benchmark_run_v0` reduction fields needed for FrontierSWE
+   evidence.
+6. Stop before any task container, model call, paid run, upload, or leaderboard
+   path.
+
+## Priority Decision
+
+FrontierSWE should sit behind the immediate cloud benchmark substrate work, but
+near the front of the strategic long-horizon queue:
+
+1. Finish at least one cloud-host Terminal-Bench or SkillsBench no-upload smoke
+   that proves the shared ECS + Codex CLI + Docker + compact reducer route.
+2. Refresh SWE-Marathon on the same cloud route because it already has a
+   source-pinned readiness note and a low Codex baseline.
+3. Add FrontierSWE readiness immediately after or in parallel with the
+   SWE-Marathon refresh, but do not start a real FrontierSWE task until the
+   no-execution launch packet exists.
+
+## Sources
+
+- https://github.com/Proximal-Labs/frontier-swe
+- https://www.frontierswe.com/
+- https://www.proximal.ai/blog/frontierswe

--- a/docs/research/long-horizon-agent-benchmarks/paper-runner-dossier.md
+++ b/docs/research/long-horizon-agent-benchmarks/paper-runner-dossier.md
@@ -10,11 +10,11 @@ examples, or contract docs outside this topic folder.
 ## Current Recommendation
 
 Use Terminal-Bench 2.0 as the first official-runner probe, then SWE-Marathon as
-the first heavy long-horizon software-engineering probe. The next milestone is
-not another broad survey; it is a first official-pilot decision packet that
-freezes what a compliant Terminal-Bench pilot must collect before any real
-Terminal-Bench, Docker, model API, cloud sandbox, or leaderboard path is
-invoked.
+the first heavy long-horizon software-engineering probe, with FrontierSWE added
+as the next frontier-stress readiness lane. The next milestone is not another
+broad survey; it is a cloud-host no-upload pilot path that proves what a
+compliant run must collect before any real Docker-heavy benchmark, model API,
+cloud sandbox, or leaderboard path is invoked.
 
 The reason is pragmatic. Terminal-Bench has an open runner, Docker-style
 terminal tasks, verified leaderboard entries, and visible Codex/Codex-adjacent
@@ -22,26 +22,29 @@ agent rows. It is the fastest way to test whether a passive Goal Harness wrapper
 can add restartability, state truth, event ledgers, and failure attribution
 without changing the official scoring protocol.
 
-SWE-Marathon is closer to the user's paper-level ambition because the tasks are
-explicitly ultra-long software-engineering work, but it is heavier: the public
-repo uses a Harbor fork, task execution is likely expensive, and some log
-access is gated by external credentials. It should be the second lane after the
-Terminal-Bench wrapper boundary is understood.
+SWE-Marathon and FrontierSWE are closer to the user's paper-level ambition
+because both are explicitly long-horizon software-engineering work. SWE-Marathon
+remains the first heavy SWE probe because this repo already has a
+source-pinned readiness scan and a low direct Codex baseline. FrontierSWE is
+now the next readiness lane because it has direct Codex leaderboard rows and
+20-hour task framing, but the runner boundary, no-upload surface, and task
+inventory still need a no-execution launch packet.
 
 ## Ranking
 
 | Rank | Candidate | Use | Why |
 | --- | --- | --- | --- |
 | 1 | Terminal-Bench 2.0 | First official-runner probe | Open benchmark repo, terminal task model, verified leaderboard, visible Codex entries, and a protocol that already treats agent tools as part of the scored system. |
-| 2 | SWE-Marathon | First heavy SWE probe | Strongest fit for hours-to-days software-engineering work; public repo and 20 ultra-long tasks, but setup and cost are heavier. |
-| 3 | LongCLI-Bench | Paper hypothesis and failure-analysis source | Directly studies long-horizon CLI programming, step-level failures, and human-agent collaboration gains; runner openness still needs verification before it becomes an execution lane. |
-| 4 | WildClawBench | Native-runtime comparison lane | Promising because it evaluates real CLI harnesses including Codex-style harnesses in reproducible containers, but it is very new and needs protocol/code review. |
-| 5 | HORIZON / METR-style signals | Diagnostic and positioning signal | Useful to explain long-horizon degradation and compare across domains, but currently better as a leaderboard/diagnostic reference than as the first runnable Goal Harness integration. |
-| 6 | RoadmapBench / SWE-EVO | Software-evolution watchlist | Strong long-horizon SWE framing around version upgrades and multi-step codebase evolution, but runner maturity and Codex CLI compatibility need review before they displace Terminal-Bench. |
-| 7 | ALE-Bench | Objective-driven algorithm lane | Good future lane for scored iterative search and restart discipline, but requires heavier compute and stricter benchmark-surface controls. |
-| 8 | OSWorld / WebArena / TheAgentCompany | Cross-surface and simulator design references | Useful for GUI/web/workplace environment design and user-simulator thinking, but not the first Goal Harness engineering runner. |
-| 9 | RALPHBench | Extremely long-horizon watchlist | Potentially close to the paper ambition and advertises Codex rows, but it is pre-launch enough to treat as monitoring input, not a first execution lane. |
-| 10 | Tau-style suites | Simulator research only | Valuable for user-simulator design, but not the headline long-horizon engineering benchmark. |
+| 2 | SWE-Marathon | First heavy SWE probe | Strongest fit for hours-to-days software-engineering work with a low direct Codex baseline; public repo and 20 ultra-long tasks, but Harbor setup and cost are heavier. |
+| 3 | FrontierSWE | Frontier-stress SWE readiness lane | Direct Codex leaderboard rows and 20-hour task framing across performance engineering, computational science, and ML research; needs runner/no-upload mapping before execution. |
+| 4 | LongCLI-Bench | Paper hypothesis and failure-analysis source | Directly studies long-horizon CLI programming, step-level failures, and human-agent collaboration gains; runner openness still needs verification before it becomes an execution lane. |
+| 5 | WildClawBench | Native-runtime comparison lane | Promising because it evaluates real CLI harnesses including Codex-style harnesses in reproducible containers, but it is very new and needs protocol/code review. |
+| 6 | HORIZON / METR-style signals | Diagnostic and positioning signal | Useful to explain long-horizon degradation and compare across domains, but currently better as a leaderboard/diagnostic reference than as the first runnable Goal Harness integration. |
+| 7 | RoadmapBench / SWE-EVO | Software-evolution watchlist | Strong long-horizon SWE framing around version upgrades and multi-step codebase evolution, but runner maturity and Codex CLI compatibility need review before they displace Terminal-Bench. |
+| 8 | ALE-Bench | Objective-driven algorithm lane | Good future lane for scored iterative search and restart discipline, but requires heavier compute and stricter benchmark-surface controls. |
+| 9 | OSWorld / WebArena / TheAgentCompany | Cross-surface and simulator design references | Useful for GUI/web/workplace environment design and user-simulator thinking, but not the first Goal Harness engineering runner. |
+| 10 | RALPHBench | Extremely long-horizon watchlist | Potentially close to the paper ambition and advertises Codex rows, but it is pre-launch enough to treat as monitoring input, not a first execution lane. |
+| 11 | Tau-style suites | Simulator research only | Valuable for user-simulator design, but not the headline long-horizon engineering benchmark. |
 
 ## Source Notes
 
@@ -120,6 +123,43 @@ Sources:
 - https://github.com/abundant-ai/swe-marathon
 - https://www.swe-marathon.org/
 - https://huggingface.co/datasets/rdesai2/swe-marathon
+
+### FrontierSWE
+
+Evidence:
+
+- Public repo frames FrontierSWE as a benchmark for the hardest
+  ultra-long-horizon technical challenges across performance engineering,
+  computational science, and machine-learning research.
+- Repo structure includes `tasks/`, `docker/`, and `harbor_ext/`, suggesting an
+  execution surface close to the Harbor-oriented work already done for
+  Terminal-Bench and SWE-Marathon.
+- Public leaderboard includes direct GPT-5.5 via Codex and GPT-5.4 via Codex
+  rows.
+- Public launch framing gives agents up to roughly 20 hours per task, making it
+  a stronger long-horizon stress test than short issue-fix suites.
+
+Fit for Goal Harness:
+
+- High-value strategic lane for long-horizon checkpointing, validation,
+  partial-progress capture, restart discipline, and compute stewardship.
+- Good public comparison candidate because direct Codex rows exist.
+- Strong paper-positioning candidate once Goal Harness has a stable cloud-host
+  execution substrate and compact reducer.
+
+Risks:
+
+- No Goal Harness source-pinned checkout or runner map exists yet.
+- The no-upload/no-submit boundary, artifact schema, and task inventory need a
+  setup-readiness scan before any real run.
+- The wall-clock budget is high enough that FrontierSWE should not preempt the
+  nearer Terminal-Bench and SkillsBench cloud-smoke lanes.
+
+Sources:
+
+- https://github.com/Proximal-Labs/frontier-swe
+- https://www.frontierswe.com/
+- https://www.proximal.ai/blog/frontierswe
 
 ### LongCLI-Bench
 


### PR DESCRIPTION
## Summary
- refresh the benchmark developer workflow around the dedicated cloud-host route, source/dependency staging, SSH session hygiene, and no-upload runner boundaries
- add FrontierSWE setup-readiness notes and index links
- update long-horizon benchmark priority docs around Terminal-Bench, SkillsBench, SWE-Marathon, and FrontierSWE under the current cloud route

## Validation
- python3 examples/benchmark-developer-workflow-doc-smoke.py
- python3 examples/docs-governance-smoke.py
- git diff --check
- COPYFILE_DISABLE=1 tar --no-xattrs smoke
- goal-harness check over touched public docs (clean except pre-existing duplicate-index warning)

## Boundary
Docs-only batch. Excludes .local active state, raw benchmark logs, trajectories, private host details, credentials, local absolute paths, and verifier/task output.