### PR TITLE
benchmarks: record SkillsBench cloud oracle sanity

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
@@ -1,5 +1,65 @@
 {
   "benchmarks": {
+    "skillsbench-cloud-oracle-sanity@v0": {
+      "benchmark_id": "skillsbench-cloud-oracle-sanity@v0",
+      "case_count": 1,
+      "cases": {
+        "hello-world": {
+          "case_id": "hello-world",
+          "latest_decision": {
+            "decision": "single_arm_recorded",
+            "latest_run_id": "ba6d29ecc60f"
+          },
+          "runs": [
+            {
+              "actual_model_verified": false,
+              "agent_model": "oracle",
+              "arm_id": "oracle_uv_prewarm_no_upload_sanity",
+              "artifact_refs": {
+                "compact_artifact_ref": "docs/research/long-horizon-agent-benchmarks/skillsbench-cloud-oracle-sanity-20260620.md"
+              },
+              "benchmark_id": "skillsbench-cloud-oracle-sanity@v0",
+              "case_id": "hello-world",
+              "case_ids": [
+                "hello-world"
+              ],
+              "failure_class": "none",
+              "failure_scope": "passed",
+              "first_success_round": 1,
+              "goal_harness_inside_case": false,
+              "job_name": "skillsbench_cloud_hello_world_uv_prewarm_oracle_sanity",
+              "leaderboard_evidence": false,
+              "ledger_attempt_kind": "oracle_sanity_attempt",
+              "mode": "oracle_uv_prewarm_no_upload_sanity",
+              "model_control_status": "not_applicable_oracle_sanity",
+              "notes": "cloud host SkillsBench hello-world oracle sanity passed after uv verifier dependency prewarm; compact summary only; no raw task/log/verifier/trajectory material recorded",
+              "official_feedback_blinded": false,
+              "official_passed": true,
+              "official_score": 1.0,
+              "recorded_at": "2026-06-20T04:51:08+08:00",
+              "reward_feedback_forwarded": false,
+              "round_reward_count": 1,
+              "round_rewards": [
+                {
+                  "agent_round": 1,
+                  "passed": true,
+                  "reward": 1.0,
+                  "reward_present": true
+                }
+              ],
+              "round_success_observed": true,
+              "run_group_id": "skillsbench-cloud-hello-world-uv-prewarm-oracle-sanity-20260620",
+              "run_id": "ba6d29ecc60f",
+              "score_status": "passed",
+              "source_event_schema": "cloud_host_summary_json_v0",
+              "status": "completed",
+              "submit_eligible": false
+            }
+          ]
+        }
+      },
+      "run_count": 1
+    },
     "skillsbench@1.1": {
       "benchmark_id": "skillsbench@1.1",
       "case_count": 21,
@@ -9541,5 +9601,5 @@
     "source_of_truth": "benchmark_run_v0 compact run events",
     "update_rule": "upsert one run entry when a benchmark case is ingested or closed"
   },
-  "updated_at": "2026-06-18T22:54:59+08:00"
+  "updated_at": "2026-06-20T04:51:08+08:00"
 }

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
@@ -5,12 +5,13 @@ benchmark case outcomes and artifact references; it must not contain raw
 logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 
 - schema_version: `benchmark_run_ledger_v0`
-- updated_at: `2026-06-18T22:54:59+08:00`
+- updated_at: `2026-06-20T04:51:08+08:00`
 
 ## Case Decisions
 
 | Benchmark | Case | Decision | Case Routing | Runs |
 | --- | --- | --- | --- | --- |
+| `skillsbench-cloud-oracle-sanity@v0` | `hello-world` | `single_arm_recorded` | - | `1` |
 | `skillsbench@1.1` | `3d-scan-calc` | `paired_baseline_solved_treatment_preserved` | - | `3` |
 | `skillsbench@1.1` | `ada-bathroom-plan-repair` | `paired_baseline_solved_treatment_preserved` | - | `4` |
 | `skillsbench@1.1` | `adaptive-cruise-control` | `baseline_runner_or_setup_repair_required` | - | `1` |
@@ -74,6 +75,7 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 
 | Benchmark | Case | Arm | Attempt | Score | First Success Round | Round Rewards | Failure | Artifact |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `skillsbench-cloud-oracle-sanity@v0` | `hello-world` | `oracle_uv_prewarm_no_upload_sanity` | `oracle_sanity_attempt` | `1.0` | `1` | `1:1*` | `none` | `docs/research/long-horizon-agent-benchmarks/skillsbench-cloud-oracle-sanity-20260620.md` |
 | `skillsbench@1.1` | `3d-scan-calc` | `codex_goal_mode_baseline` | `` | `1.0` | `` | `` | `none` | `` |
 | `skillsbench@1.1` | `3d-scan-calc` | `baseline` | `` | `1.0` | `1` | `1:1*` | `none` | `.local/private-benchmark-jobs/skillsbench-3d-scan-calc-blind-baseline-v0/3d-scan-calc__codex_acp_blind_loop_v0/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `3d-scan-calc` | `codex_goal_harness_treatment` | `` | `1.0` | `1` | `1:1*` | `none` | `.local/private-benchmark-jobs/skillsbench-3d-scan-calc-blind-treatment-baseline-safe-v0/3d-scan-calc__goal_harness_blind_loop_baseline_safe_v0/benchmark_run.compact.json` |

--- a/docs/research/long-horizon-agent-benchmarks/skillsbench-cloud-oracle-sanity-20260620.md
+++ b/docs/research/long-horizon-agent-benchmarks/skillsbench-cloud-oracle-sanity-20260620.md
@@ -1,0 +1,41 @@
+# SkillsBench Cloud Oracle Sanity 2026-06-20
+
+This note records compact, public-safe evidence from the dedicated cloud
+benchmark host. It does not include raw task text, verifier output, stdout,
+stderr, trajectories, credentials, remote paths, or hostnames.
+
+## Result
+
+| Field | Value |
+| --- | --- |
+| Benchmark surface | `skillsbench-cloud-oracle-sanity@v0` |
+| Case | `hello-world` |
+| Arm | `oracle_uv_prewarm_no_upload_sanity` |
+| Route | dedicated cloud benchmark host |
+| Boundary | no upload, no submit, compact summary only |
+| Dependency substrate | uv verifier dependency prewarm applied before oracle sanity |
+| Official reward summary | `100.0%` |
+| Passed count | `1` |
+| Failure class | `none` |
+| Run group | `skillsbench-cloud-hello-world-uv-prewarm-oracle-sanity-20260620` |
+| Compact run id | `ba6d29ecc60f` |
+
+## Interpretation
+
+The earlier SkillsBench blocker was not a persistent verifier timeout after the
+prewarm substrate landed. The cloud host reached oracle sanity for `hello-world`
+with one passed task and reward `100.0%`.
+
+This is readiness evidence, not benchmark uplift evidence. It authorizes the
+next SkillsBench product step: run a real no-upload case through the same cloud
+host route with compact result reduction, while keeping raw task/verifier
+artifacts private.
+
+## Public Boundary
+
+- raw logs copied: `false`
+- raw task text copied: `false`
+- verifier output copied: `false`
+- trajectory copied: `false`
+- credential values copied: `false`
+- remote absolute paths recorded: `false`


### PR DESCRIPTION
## Summary
- record a public-safe SkillsBench cloud-host oracle sanity result for hello-world
- add compact evidence that uv verifier prewarm plus no-upload oracle sanity reached reward 100% / passed=1
- upsert the single-arm sanity row into benchmark-run-ledger JSON and Markdown

## Validation
- python3 examples/benchmark-run-ledger-smoke.py
- python3 examples/benchmark-developer-workflow-doc-smoke.py
- git diff --cached --check
- goal-harness check --scan-path docs/research/long-horizon-agent-benchmarks/skillsbench-cloud-oracle-sanity-20260620.md --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md

## Excluded
- no raw task text, verifier output, stdout/stderr, trajectories, credentials, remote absolute paths, hostnames, uploads, or leaderboard claims
- local SSH/GSSAPI/ControlMaster details stay out of public evidence

Residual warning: goal-harness check still reports pre-existing duplicate run-history index rows for goal-harness-meta.