### PR TITLE
fix: route side agents by todo claim

### DIFF
--- a/docs/project-agent-todo-contract.md
+++ b/docs/project-agent-todo-contract.md
@@ -124,6 +124,12 @@ Only after that rerun returns normal delivery should the side agent claim an
 in-scope todo and edit repository files. A primary-owned todo remains
 primary-owned even when the side-agent workspace guard passes; the side agent
 must pick a todo inside its scope or create a primary review successor.
+For agent-specific `quota should-run --agent-id <side-agent-id>` payloads, the
+todo summary is claim-aware: current-agent claimed todos are preferred, unclaimed
+todos remain selectable, and primary/other-agent claimed todos are projected as
+blocked-claim context rather than as the side agent's next action. This reduces
+accidental collisions without writing scope into todo metadata or turning
+`claimed_by` into a lease.
 
 ```bash
 goal-harness configure-goal \

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -803,6 +803,14 @@ Item fields:
   lifecycle command materializes that id back into metadata. Optional future
   fields such as `created_at`, lease TTLs, dependencies, or evidence links
   should extend this item shape rather than inventing another todo surface.
+- Agent-scoped quota payloads may include
+  `agent_todo_summary.claim_scope` with
+  `schema_version=side_agent_claim_scope_v0`. For a side agent, the quota guard
+  should select current-agent claimed todos before unclaimed todos and keep
+  primary/other-agent claimed todos as `blocked_claimed_items` context. This is
+  claim-aware routing, not a hard lease: the primary agent still sees the whole
+  backlog, and a side agent still uses its automation/handoff scope to decide
+  whether an unclaimed todo is appropriate.
 - `dependency_blockers`: optional compact summary of unfinished user todos from
   other current attention-queue goals. This lets dashboards and heartbeat
   dispatchers show sibling/project dependency gates separately from the current

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -810,7 +810,9 @@ Item fields:
   primary/other-agent claimed todos as `blocked_claimed_items` context. This is
   claim-aware routing, not a hard lease: the primary agent still sees the whole
   backlog, and a side agent still uses its automation/handoff scope to decide
-  whether an unclaimed todo is appropriate.
+  whether an unclaimed todo is appropriate. A current-agent claimed todo may be
+  selected even when the active state's global `Next Action` names the primary
+  lane; that is not a state projection mismatch.
 - `dependency_blockers`: optional compact summary of unfinished user todos from
   other current attention-queue goals. This lets dashboards and heartbeat
   dispatchers show sibling/project dependency gates separately from the current

--- a/examples/side-agent-workspace-guard-smoke.py
+++ b/examples/side-agent-workspace-guard-smoke.py
@@ -25,6 +25,9 @@ from goal_harness.quota import (  # noqa: E402
 
 
 GOAL_ID = "side-agent-workspace-goal"
+PRIMARY_TODO = "Run the primary benchmark rotation."
+UNCLAIMED_TODO = "Triage an unclaimed coordination task."
+SIDE_TODO = "Continue the side-agent productization docs lane."
 
 
 @contextmanager
@@ -96,6 +99,51 @@ def status_payload(repo: Path, registry: Path) -> dict:
         "source": "fixture",
         "recommended_action": "Advance one public-safe side-agent slice.",
         "quota": quota,
+        "project_asset": {
+            "agent_todos": {
+                "schema_version": "todo_summary_v0",
+                "total_count": 3,
+                "open_count": 3,
+                "done_count": 0,
+                "items": [
+                    {
+                        "index": 1,
+                        "text": PRIMARY_TODO,
+                        "schema_version": "todo_item_v0",
+                        "todo_id": "todo_primary",
+                        "role": "agent",
+                        "status": "open",
+                        "priority": "P0",
+                        "task_class": "advancement_task",
+                        "action_kind": "benchmark_rotation",
+                        "claimed_by": "codex-main-control",
+                    },
+                    {
+                        "index": 2,
+                        "text": UNCLAIMED_TODO,
+                        "schema_version": "todo_item_v0",
+                        "todo_id": "todo_unclaimed",
+                        "role": "agent",
+                        "status": "open",
+                        "priority": "P1",
+                        "task_class": "advancement_task",
+                        "action_kind": "coordination_task",
+                    },
+                    {
+                        "index": 3,
+                        "text": SIDE_TODO,
+                        "schema_version": "todo_item_v0",
+                        "todo_id": "todo_side",
+                        "role": "agent",
+                        "status": "open",
+                        "priority": "P2",
+                        "task_class": "advancement_task",
+                        "action_kind": "productization_docs",
+                        "claimed_by": "codex-side-bypass",
+                    },
+                ],
+            },
+        },
     }
     return {
         "ok": True,
@@ -165,6 +213,7 @@ def main() -> int:
         assert "independent worktree" in preview["reason"], preview
         assert primary_agent["normal_delivery_allowed"] is True, primary_agent
         assert "workspace_guard" not in primary_agent, primary_agent
+        assert primary_agent["recommended_action"] == PRIMARY_TODO, primary_agent
 
         with pushd(side):
             side_ok = build_quota_should_run(
@@ -174,6 +223,11 @@ def main() -> int:
             )
         assert side_ok["normal_delivery_allowed"] is True, side_ok
         assert "workspace_guard" not in side_ok, side_ok
+        assert side_ok["recommended_action"] == SIDE_TODO, side_ok
+        side_summary = side_ok["agent_todo_summary"]
+        assert side_summary["first_executable_items"][0]["todo_id"] == "todo_side", side_summary
+        assert side_summary["claim_scope"]["current_agent_claimed_open_count"] == 1, side_summary
+        assert side_summary["claim_scope"]["blocked_claimed_items"][0]["todo_id"] == "todo_primary", side_summary
 
         with pushd(foreign):
             foreign_guarded = build_quota_should_run(

--- a/examples/side-agent-workspace-guard-smoke.py
+++ b/examples/side-agent-workspace-guard-smoke.py
@@ -100,6 +100,7 @@ def status_payload(repo: Path, registry: Path) -> dict:
         "recommended_action": "Advance one public-safe side-agent slice.",
         "quota": quota,
         "project_asset": {
+            "next_action": PRIMARY_TODO,
             "agent_todos": {
                 "schema_version": "todo_summary_v0",
                 "total_count": 3,
@@ -224,6 +225,7 @@ def main() -> int:
         assert side_ok["normal_delivery_allowed"] is True, side_ok
         assert "workspace_guard" not in side_ok, side_ok
         assert side_ok["recommended_action"] == SIDE_TODO, side_ok
+        assert "state_action_projection_warning" not in side_ok, side_ok
         side_summary = side_ok["agent_todo_summary"]
         assert side_summary["first_executable_items"][0]["todo_id"] == "todo_side", side_summary
         assert side_summary["claim_scope"]["current_agent_claimed_open_count"] == 1, side_summary

--- a/goal_harness/quota.py
+++ b/goal_harness/quota.py
@@ -137,6 +137,7 @@ PROTOCOL_ACTION_PACKET_SCHEMA_VERSION = "protocol_action_packet_v0"
 AUTOMATION_LIVENESS_SCHEMA_VERSION = "automation_liveness_v0"
 CAPABILITY_GATE_SCHEMA_VERSION = "capability_gate_v0"
 SIDE_AGENT_WORKSPACE_GUARD_SCHEMA_VERSION = "side_agent_workspace_guard_v0"
+SIDE_AGENT_CLAIM_SCOPE_SCHEMA_VERSION = "side_agent_claim_scope_v0"
 DEFAULT_AVAILABLE_CAPABILITIES = (
     "shell",
     "filesystem_read",
@@ -1131,6 +1132,49 @@ def _todo_projection_sort_key(item: dict[str, Any]) -> tuple[int, int]:
     return (_todo_priority_rank(item), _todo_index_rank(item))
 
 
+def _side_agent_claim_scoped_open_items(
+    open_items: list[dict[str, Any]],
+    *,
+    agent_identity: dict[str, Any] | None,
+) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
+    if not isinstance(agent_identity, dict) or agent_identity.get("role") != "side-agent":
+        return open_items, None
+    agent_id = normalize_todo_claimed_by(agent_identity.get("agent_id"))
+    if not agent_id:
+        return open_items, None
+
+    def claim_bucket(item: dict[str, Any]) -> int:
+        claimed_by = normalize_todo_claimed_by(item.get("claimed_by"))
+        if claimed_by == agent_id:
+            return 0
+        if not claimed_by:
+            return 1
+        return 2
+
+    current_agent_items = [item for item in open_items if claim_bucket(item) == 0]
+    unclaimed_items = [item for item in open_items if claim_bucket(item) == 1]
+    blocked_claimed_items = [item for item in open_items if claim_bucket(item) == 2]
+    selectable_items = sorted(
+        [*current_agent_items, *unclaimed_items],
+        key=lambda item: (claim_bucket(item), *_todo_projection_sort_key(item)),
+    )
+    claim_scope = {
+        "schema_version": SIDE_AGENT_CLAIM_SCOPE_SCHEMA_VERSION,
+        "agent_id": agent_id,
+        "primary_agent": normalize_todo_claimed_by(agent_identity.get("primary_agent")),
+        "selection_order": "current_agent_claimed_then_unclaimed",
+        "selectable_open_count": len(selectable_items),
+        "current_agent_claimed_open_count": len(current_agent_items),
+        "unclaimed_open_count": len(unclaimed_items),
+        "blocked_claimed_open_count": len(blocked_claimed_items),
+        "blocked_claimed_items": [
+            _compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
+            for item in blocked_claimed_items[:3]
+        ],
+    }
+    return selectable_items, claim_scope
+
+
 def _todo_summary_source_items(value: dict[str, Any]) -> list[dict[str, Any]]:
     source_keys = (
         "first_open_items",
@@ -1168,12 +1212,20 @@ def _is_user_gate_todo_item(item: dict[str, Any]) -> bool:
     return any(hint in action_kind for hint in USER_GATE_ACTION_KIND_HINTS)
 
 
-def _summarize_user_todos(value: Any) -> dict[str, Any] | None:
+def _summarize_user_todos(
+    value: Any,
+    *,
+    agent_identity: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
     if not isinstance(value, dict):
         return None
-    open_items = sorted(
+    all_open_items = sorted(
         _todo_summary_source_items(value),
         key=_todo_projection_sort_key,
+    )
+    open_items, claim_scope = _side_agent_claim_scoped_open_items(
+        all_open_items,
+        agent_identity=agent_identity,
     )
     executable_items = [
         item
@@ -1187,7 +1239,7 @@ def _summarize_user_todos(value: Any) -> dict[str, Any] | None:
         if _todo_item_is_actionable_open(item)
         if _todo_task_class(item) == TODO_TASK_CLASS_MONITOR
     ]
-    claimed_open_items = [item for item in open_items if item.get("claimed_by")]
+    claimed_open_items = [item for item in all_open_items if item.get("claimed_by")]
     gate_items = [
         item
         for item in open_items
@@ -1197,7 +1249,7 @@ def _summarize_user_todos(value: Any) -> dict[str, Any] | None:
         "schema_version": value.get("schema_version"),
         "source_section": value.get("source_section"),
         "total_count": value.get("total_count"),
-        "open_count": value.get("open_count", len(open_items)),
+        "open_count": value.get("open_count", len(all_open_items)),
         "done_count": value.get("done_count"),
         "first_open_items": open_items[:3],
         "first_executable_items": executable_items[:3],
@@ -1210,12 +1262,18 @@ def _summarize_user_todos(value: Any) -> dict[str, Any] | None:
         summary["claimed_open_count"] = value.get("claimed_open_count", len(claimed_open_items))
         summary["unclaimed_open_count"] = value.get(
             "unclaimed_open_count",
-            max(0, int(value.get("open_count", len(open_items)) or 0) - len(claimed_open_items)),
+            max(0, int(value.get("open_count", len(all_open_items)) or 0) - len(claimed_open_items)),
         )
+    if claim_scope:
+        summary["claim_scope"] = claim_scope
     return summary
 
 
-def _summarize_project_asset_todos(value: Any) -> dict[str, Any] | None:
+def _summarize_project_asset_todos(
+    value: Any,
+    *,
+    agent_identity: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
     if not isinstance(value, dict):
         return None
     if (
@@ -1224,19 +1282,23 @@ def _summarize_project_asset_todos(value: Any) -> dict[str, Any] | None:
     ) and (
         "total_count" in value or "open_count" in value or "done_count" in value
     ):
-        return _summarize_user_todos(value)
+        return _summarize_user_todos(value, agent_identity=agent_identity)
 
-    open_items = sorted(
+    all_open_items = sorted(
         _todo_summary_source_items(value),
         key=_todo_projection_sort_key,
     )
-    if not open_items:
+    if not all_open_items:
         next_text = str(value.get("next") or "").strip()
         next_index = value.get("next_index", 1)
-        open_items = [{"index": next_index, "text": next_text}] if next_text else []
+        all_open_items = [{"index": next_index, "text": next_text}] if next_text else []
         next_claimed_by = str(value.get("next_claimed_by") or "").strip()
-        if open_items and next_claimed_by:
-            open_items[0]["claimed_by"] = next_claimed_by
+        if all_open_items and next_claimed_by:
+            all_open_items[0]["claimed_by"] = next_claimed_by
+    open_items, claim_scope = _side_agent_claim_scoped_open_items(
+        all_open_items,
+        agent_identity=agent_identity,
+    )
     executable_items = [
         item
         for item in open_items
@@ -1249,8 +1311,8 @@ def _summarize_project_asset_todos(value: Any) -> dict[str, Any] | None:
         if _todo_item_is_actionable_open(item)
         if _todo_task_class(item) == TODO_TASK_CLASS_MONITOR
     ]
-    claimed_open_items = [item for item in open_items if item.get("claimed_by")]
-    open_count = value.get("open", value.get("open_count", len(open_items)))
+    claimed_open_items = [item for item in all_open_items if item.get("claimed_by")]
+    open_count = value.get("open", value.get("open_count", len(all_open_items)))
     summary = {
         "schema_version": value.get("schema_version"),
         "source_section": value.get("source_section") or "project_asset",
@@ -1269,6 +1331,8 @@ def _summarize_project_asset_todos(value: Any) -> dict[str, Any] | None:
             "unclaimed_open_count",
             max(0, int(open_count or 0) - len(claimed_open_items)),
         )
+    if claim_scope:
+        summary["claim_scope"] = claim_scope
     return summary
 
 
@@ -4087,12 +4151,14 @@ def build_quota_should_run(
         if not plan.get("ok"):
             reason = "status or contract health is not ok; skip automatic compute"
         project_asset = item.get("project_asset") if isinstance(item.get("project_asset"), dict) else {}
+        agent_identity = _quota_agent_identity(item, agent_id=agent_id)
         user_todo_summary = _summarize_project_asset_todos(
             project_asset.get("user_todos") if project_asset else None
         ) or _summarize_user_todos(item.get("user_todos"))
         agent_todo_summary = _summarize_project_asset_todos(
-            project_asset.get("agent_todos") if project_asset else None
-        ) or _summarize_user_todos(item.get("agent_todos"))
+            project_asset.get("agent_todos") if project_asset else None,
+            agent_identity=agent_identity,
+        ) or _summarize_user_todos(item.get("agent_todos"), agent_identity=agent_identity)
         outcome_floor_blocker_projected = (
             recovery_allowed
             and _outcome_floor_blocker_already_projected(agent_todo_summary)
@@ -4112,7 +4178,6 @@ def build_quota_should_run(
             recovery_allowed = False
             reason = str(quota["reason"])
         goal_boundary = _goal_boundary(item)
-        agent_identity = _quota_agent_identity(item, agent_id=agent_id)
         workspace_guard = _side_agent_workspace_guard(item, agent_identity)
         automation_prompt_upgrade = _automation_prompt_upgrade(
             item,

--- a/goal_harness/quota.py
+++ b/goal_harness/quota.py
@@ -1626,6 +1626,7 @@ def _actions_are_projection_aligned(left: Any, right: Any) -> bool:
 def _state_action_projection_warning(
     item: dict[str, Any],
     *,
+    agent_todo_summary: dict[str, Any] | None,
     selected_action: Any,
     work_lane_contract: dict[str, Any] | None,
 ) -> dict[str, Any] | None:
@@ -1645,6 +1646,27 @@ def _state_action_projection_warning(
     selected_text = str(selected_action or "").strip()
     if not active_next_action or not selected_text:
         return None
+    if isinstance(agent_todo_summary, dict):
+        claim_scope = agent_todo_summary.get("claim_scope")
+        first_executable = (
+            agent_todo_summary.get("first_executable_items")
+            if isinstance(agent_todo_summary.get("first_executable_items"), list)
+            else []
+        )
+        selected_item = next((item for item in first_executable if isinstance(item, dict)), None)
+        selected_claimed_by = normalize_todo_claimed_by(
+            selected_item.get("claimed_by") if selected_item else None
+        )
+        claim_agent_id = normalize_todo_claimed_by(
+            claim_scope.get("agent_id") if isinstance(claim_scope, dict) else None
+        )
+        if (
+            selected_item
+            and selected_claimed_by
+            and claim_agent_id
+            and selected_claimed_by == claim_agent_id
+        ):
+            return None
     if _actions_are_projection_aligned(active_next_action, selected_text):
         return None
     return {
@@ -4386,6 +4408,7 @@ def build_quota_should_run(
             )
         state_action_projection_warning = _state_action_projection_warning(
             item,
+            agent_todo_summary=agent_todo_summary,
             selected_action=selected_recommended_action,
             work_lane_contract=work_lane_contract,
         )


### PR DESCRIPTION
## Summary\n- make side-agent quota todo summaries prefer current-agent claimed work, then unclaimed work\n- keep primary/other-agent claimed todos as claim-scope context instead of side-agent next action\n- extend the side-agent workspace guard smoke and public docs for claim-aware routing\n\n## Validation\n- python3 examples/side-agent-workspace-guard-smoke.py\n- python3 examples/quota-plan-smoke.py\n- python3 -m py_compile goal_harness/*.py\n- goal-harness check --scan-path docs/status-data-contract.md --scan-path docs/project-agent-todo-contract.md --scan-path examples/side-agent-workspace-guard-smoke.py\n\nNote: goal-harness check reports the existing duplicate index rows warning for goal-harness-meta.