### PR TITLE
benchmarks: clarify SkillsBench runner failure closeout

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -2256,6 +2256,7 @@ def test_skillsbench_runner_plan_supports_baseline_route() -> None:
         assert plan["sandbox_setup_timeout_sec"] == 7200, plan
         assert plan["runner_prerequisites"] == {
             "schema_version": "skillsbench_runner_prerequisites_v0",
+            "agent_execution_mode": "container_codex_acp",
             "codex_acp_runtime_container_bootstrap": True,
             "codex_acp_runtime_dependency_preflight": True,
             "codex_acp_runtime_launch_preflight": False,
@@ -2264,6 +2265,10 @@ def test_skillsbench_runner_plan_supports_baseline_route() -> None:
             ),
             "codex_acp_runtime_launch_preflight_status": "pending",
             "codex_acp_runtime_launch_preflight_raw_logs_read": False,
+            "container_codex_acp_install_skipped": False,
+            "host_local_acp_launch": False,
+            "host_local_acp_launch_status": "not_requested",
+            "remote_command_file_bridge_materialized": False,
         }, plan
         assert "curl" in CODEX_ACP_RUNTIME_CONTAINER_BOOTSTRAP_CMD
         assert "curl-minimal" in CODEX_ACP_RUNTIME_CONTAINER_BOOTSTRAP_CMD
@@ -3461,6 +3466,16 @@ def test_skillsbench_runner_failure_compact_closeout() -> None:
             "codex_acp_runtime_launch_preflight_status": "pending",
             "codex_acp_runtime_launch_preflight_raw_logs_read": False,
         }, compact
+        assert "do_not_run_benchflow_from_skeleton" not in compact[
+            "stop_conditions"
+        ], compact
+        assert "classify_compact_runner_failure_before_rerun" in compact[
+            "stop_conditions"
+        ], compact
+        assert (
+            "do_not_read_raw_task_prompt_solution_log_or_trajectory"
+            in compact["stop_conditions"]
+        ), compact
         assert "BenchFlow result.json not found" not in json.dumps(compact), compact
 
 
@@ -3476,6 +3491,7 @@ def test_skillsbench_reduce_only_missing_result_records_closeout_exit_zero() -> 
                     "pddl-airport-planning",
                     "--route",
                     "codex-goal-mode-baseline",
+                    "--allow-unverified-goal-prefix-baseline",
                     "--jobs-dir",
                     str(jobs_dir),
                     "--job-name",
@@ -3537,6 +3553,7 @@ def test_skillsbench_reduce_only_discovers_nested_official_result() -> None:
                     "pddl-airport-planning",
                     "--route",
                     "codex-goal-mode-baseline",
+                    "--allow-unverified-goal-prefix-baseline",
                     "--jobs-dir",
                     str(jobs_dir),
                     "--job-name",

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -2974,6 +2974,12 @@ def build_runner_failure_compact(
                 "raw_solutions_recorded": False,
                 "raw_logs_recorded": False,
             },
+            "stop_conditions": [
+                "classify_compact_runner_failure_before_rerun",
+                "do_not_read_raw_task_prompt_solution_log_or_trajectory",
+                "do_not_upload_or_submit_leaderboard",
+                "do_not_record_secrets_or_raw_sessions",
+            ],
         }
     )
     runner_prerequisites = _public_runner_prerequisites(


### PR DESCRIPTION
## Summary
- make real SkillsBench runner-failure compact closeouts replace skeleton stop conditions with runner-failure rerun boundaries
- keep launch-plan prerequisites and compacted prerequisites distinct in smoke coverage
- mark reduce-only Codex goal-mode fixtures as explicit unverified slash-prefix experiments

## Live benchmark context
- A cloud SkillsBench raw Codex max1 no-upload launch for hello-world produced a compact benchmark_run record but no official result/summary.
- The compact record classified the blocker as skillsbench_runner_error / failed_before_official_result, with no raw task/log/trajectory/verifier material read into public state.
- This PR fixes the misleading skeleton stop_conditions observed in that compact closeout path.

## Validation
- python3 examples/skillsbench-benchmark-run-smoke.py
- python3 -m py_compile scripts/skillsbench_automation_loop.py examples/skillsbench-benchmark-run-smoke.py
- git diff --check
- goal-harness check --scan-path scripts/skillsbench_automation_loop.py --scan-path examples/skillsbench-benchmark-run-smoke.py

Known residual warning: existing duplicate index rows in Goal Harness runtime history.