### PR TITLE
benchmarks: classify SkillsBench runner blockers from prereqs

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -3479,6 +3479,57 @@ def test_skillsbench_runner_failure_compact_closeout() -> None:
         assert "BenchFlow result.json not found" not in json.dumps(compact), compact
 
 
+def test_skillsbench_runner_failure_prefers_structured_preflight_blocker() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-runner-preflight-") as tmp:
+        args = parse_args(
+            [
+                "--task-id",
+                "debug-trl-grpo",
+                "--route",
+                "raw-codex-autonomous-max5",
+                "--jobs-dir",
+                str(Path(tmp) / "jobs"),
+                "--job-name",
+                "skillsbench-debug-trl-grpo-preflight-fixture",
+            ]
+        )
+        plan = build_plan(args)
+        plan["runner_prerequisites"].update(
+            {
+                "codex_acp_runtime_launch_preflight": False,
+                "codex_acp_runtime_launch_preflight_status": "failed",
+                "codex_acp_runtime_launch_preflight_rc": 127,
+                "codex_acp_runtime_launch_preflight_raw_logs_read": False,
+            }
+        )
+        compact = build_runner_failure_compact(
+            args,
+            plan,
+            RuntimeError("BenchFlow runner exited before official result"),
+        )
+        assert compact["first_blocker"] == (
+            "skillsbench_codex_acp_launch_preflight_failed"
+        ), compact
+        assert compact["score_failure_attribution"] == (
+            "skillsbench_codex_acp_launch_preflight_failed"
+        ), compact
+        assert "skillsbench_runner_setup_error" in compact[
+            "failure_attribution_labels"
+        ], compact
+        assert compact["runner_failure"]["failure_class"] == (
+            "skillsbench_codex_acp_launch_preflight_failed"
+        ), compact
+        assert compact["runner_prerequisites"][
+            "codex_acp_runtime_launch_preflight_status"
+        ] == "failed", compact
+        assert compact["runner_prerequisites"][
+            "codex_acp_runtime_launch_preflight_raw_logs_read"
+        ] is False, compact
+        assert "BenchFlow runner exited before official result" not in json.dumps(
+            compact
+        ), compact
+
+
 def test_skillsbench_reduce_only_missing_result_records_closeout_exit_zero() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-missing-result-main-") as tmp:
         jobs_dir = Path(tmp) / "jobs"
@@ -3890,6 +3941,7 @@ if __name__ == "__main__":
     test_skillsbench_compact_runs_update_ledger_pair()
     test_skillsbench_repeat_same_mode_keeps_distinct_ledger_runs()
     test_skillsbench_runner_failure_compact_closeout()
+    test_skillsbench_runner_failure_prefers_structured_preflight_blocker()
     test_skillsbench_reduce_only_missing_result_records_closeout_exit_zero()
     test_skillsbench_main_failure_closeout_preserves_mutated_prerequisites()
     test_skillsbench_main_redirects_runner_output_to_private_log()

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -618,6 +618,35 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
     return compact
 
 
+def _runner_prerequisite_failure_attribution(
+    value: Any,
+) -> tuple[str, str, list[str]] | None:
+    """Classify runner failures from structured prereq state, not raw stderr."""
+
+    if not isinstance(value, dict):
+        return None
+
+    if (
+        value.get("codex_acp_runtime_launch_preflight") is False
+        and value.get("codex_acp_runtime_launch_preflight_status") == "failed"
+    ):
+        label = "skillsbench_codex_acp_launch_preflight_failed"
+        return label, label, [label, "skillsbench_runner_setup_error"]
+
+    if (
+        value.get("codex_acp_runtime_dependency_preflight") is False
+        and value.get("codex_acp_runtime_launch_preflight_status") == "failed"
+    ):
+        label = "skillsbench_codex_acp_runtime_dependency_preflight_failed"
+        return label, label, [label, "skillsbench_runner_setup_error"]
+
+    if value.get("host_local_acp_launch_status") == "failed":
+        label = "skillsbench_host_local_acp_launch_failed"
+        return label, label, [label, "skillsbench_runner_setup_error"]
+
+    return None
+
+
 def _public_task_staging(value: Any) -> dict[str, Any]:
     if not isinstance(value, dict):
         return {}
@@ -2923,6 +2952,14 @@ def build_runner_failure_compact(
     exception_type, attribution, labels = skillsbench_runner_error_attribution(
         str(exc)
     )
+    runner_prerequisites = _public_runner_prerequisites(
+        plan.get("runner_prerequisites")
+    )
+    prerequisite_attribution = _runner_prerequisite_failure_attribution(
+        runner_prerequisites
+    )
+    if prerequisite_attribution and exception_type == "skillsbench_runner_error":
+        exception_type, attribution, labels = prerequisite_attribution
     compact = build_skillsbench_benchmark_run(
         route=args.route,
         dataset=args.dataset,
@@ -2981,9 +3018,6 @@ def build_runner_failure_compact(
                 "do_not_record_secrets_or_raw_sessions",
             ],
         }
-    )
-    runner_prerequisites = _public_runner_prerequisites(
-        plan.get("runner_prerequisites")
     )
     if runner_prerequisites:
         compact["runner_prerequisites"] = runner_prerequisites


### PR DESCRIPTION
## Summary
- classify SkillsBench runner-failure closeouts from structured runner_prerequisites when raw exception attribution is generic
- keep raw stderr/log/task/trajectory material out of the compact artifact
- add a focused smoke for ACP launch preflight failure classification

## Validation
- python3 -m py_compile scripts/skillsbench_automation_loop.py examples/skillsbench-benchmark-run-smoke.py
- python3 examples/skillsbench-benchmark-run-smoke.py
- git diff --check
- goal-harness check --scan-path scripts/skillsbench_automation_loop.py --scan-path examples/skillsbench-benchmark-run-smoke.py

## Excluded
- remote raw benchmark logs, trajectories, verifier output, task text, credentials, and local state

## Residual risk
- this only improves compact classification after runner failure; the next benchmark run still needs the ACP runtime launch/root-cause repair or a host-local/cloud-native route.