### PR TITLE
Classify SkillsBench pre-agent runner failures

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -3530,6 +3530,55 @@ def test_skillsbench_runner_failure_prefers_structured_preflight_blocker() -> No
         ), compact
 
 
+def test_skillsbench_runner_failure_marks_pre_agent_install_stage() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-runner-pre-agent-") as tmp:
+        args = parse_args(
+            [
+                "--task-id",
+                "hello-world",
+                "--route",
+                "raw-codex-autonomous-max5",
+                "--jobs-dir",
+                str(Path(tmp) / "jobs"),
+                "--job-name",
+                "skillsbench-hello-world-pre-agent-fixture",
+            ]
+        )
+        plan = build_plan(args)
+        compact = build_runner_failure_compact(
+            args,
+            plan,
+            RuntimeError("BenchFlow runner exited before official result"),
+        )
+        assert compact["first_blocker"] == (
+            "skillsbench_runner_failed_before_agent_install"
+        ), compact
+        assert compact["score_failure_attribution"] == (
+            "skillsbench_runner_failed_before_agent_install"
+        ), compact
+        assert "skillsbench_runner_setup_error" in compact[
+            "failure_attribution_labels"
+        ], compact
+        assert compact["runner_failure"]["failure_class"] == (
+            "skillsbench_runner_failed_before_agent_install"
+        ), compact
+        assert compact["runner_prerequisites"][
+            "codex_acp_runtime_container_bootstrap"
+        ] is True, compact
+        assert compact["runner_prerequisites"][
+            "codex_acp_runtime_dependency_preflight"
+        ] is True, compact
+        assert compact["runner_prerequisites"][
+            "codex_acp_runtime_launch_preflight_status"
+        ] == "pending", compact
+        assert compact["runner_prerequisites"][
+            "codex_acp_runtime_launch_preflight_stage"
+        ] == "after_agent_install_before_acp_connect", compact
+        assert "BenchFlow runner exited before official result" not in json.dumps(
+            compact
+        ), compact
+
+
 def test_skillsbench_reduce_only_missing_result_records_closeout_exit_zero() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-missing-result-main-") as tmp:
         jobs_dir = Path(tmp) / "jobs"
@@ -3942,6 +3991,7 @@ if __name__ == "__main__":
     test_skillsbench_repeat_same_mode_keeps_distinct_ledger_runs()
     test_skillsbench_runner_failure_compact_closeout()
     test_skillsbench_runner_failure_prefers_structured_preflight_blocker()
+    test_skillsbench_runner_failure_marks_pre_agent_install_stage()
     test_skillsbench_reduce_only_missing_result_records_closeout_exit_zero()
     test_skillsbench_main_failure_closeout_preserves_mutated_prerequisites()
     test_skillsbench_main_redirects_runner_output_to_private_log()

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -644,6 +644,17 @@ def _runner_prerequisite_failure_attribution(
         label = "skillsbench_host_local_acp_launch_failed"
         return label, label, [label, "skillsbench_runner_setup_error"]
 
+    if (
+        value.get("codex_acp_runtime_container_bootstrap") is True
+        and value.get("codex_acp_runtime_dependency_preflight") is True
+        and value.get("codex_acp_runtime_launch_preflight") is False
+        and value.get("codex_acp_runtime_launch_preflight_stage")
+        == "after_agent_install_before_acp_connect"
+        and value.get("codex_acp_runtime_launch_preflight_status") == "pending"
+    ):
+        label = "skillsbench_runner_failed_before_agent_install"
+        return label, label, [label, "skillsbench_runner_setup_error"]
+
     return None
 
 


### PR DESCRIPTION
## Summary
- classify SkillsBench runner failures that stop before the agent-install/ACP launch preflight stage
- keep the compact failure record public-safe and avoid raw runner stderr/log/task/trajectory content
- add focused smoke coverage for the new pre-agent-install blocker label

## Validation
- python3 -m py_compile scripts/skillsbench_automation_loop.py examples/skillsbench-benchmark-run-smoke.py
- python3 examples/skillsbench-benchmark-run-smoke.py
- git diff --check
- goal-harness check --scan-path scripts/skillsbench_automation_loop.py --scan-path examples/skillsbench-benchmark-run-smoke.py

## Excluded
- no raw benchmark logs, task text, trajectories, verifier output, credentials, or local runtime state
- no runner/scorer/task behavior changes