### PR TITLE
Compare quota action with active Next Action

### DIFF
--- a/goal_harness/quota.py
+++ b/goal_harness/quota.py
@@ -1543,6 +1543,15 @@ def _action_label_for_compare(value: Any) -> str:
     return text[:120].strip()
 
 
+def _action_prefix_for_compare(value: Any) -> str:
+    text = _normalize_action_for_compare(value)
+    text = re.split(r"[,.;:，。；：]", text, maxsplit=1)[0].strip()
+    words = text.split()
+    if len(words) >= 4:
+        return " ".join(words[:6])
+    return text
+
+
 def _actions_are_projection_aligned(left: Any, right: Any) -> bool:
     left_text = _normalize_action_for_compare(left)
     right_text = _normalize_action_for_compare(right)
@@ -1554,6 +1563,11 @@ def _actions_are_projection_aligned(left: Any, right: Any) -> bool:
     right_label = _action_label_for_compare(right_text)
     for label, text in ((left_label, right_text), (right_label, left_text)):
         if label and len(label) >= 8 and label in text:
+            return True
+    left_prefix = _action_prefix_for_compare(left_text)
+    right_prefix = _action_prefix_for_compare(right_text)
+    for prefix, text in ((left_prefix, right_text), (right_prefix, left_text)):
+        if prefix and len(prefix) >= 24 and prefix in text:
             return True
     shorter, longer = sorted((left_text, right_text), key=len)
     return len(shorter) >= 32 and shorter in longer
@@ -1577,7 +1591,11 @@ def _state_action_projection_warning(
     ):
         return None
     project_asset = item.get("project_asset") if isinstance(item.get("project_asset"), dict) else {}
-    active_next_action = str(project_asset.get("next_action") or "").strip()
+    active_next_action = str(
+        item.get("active_state_next_action")
+        or project_asset.get("next_action")
+        or ""
+    ).strip()
     selected_text = str(selected_action or "").strip()
     if not active_next_action or not selected_text:
         return None
@@ -3861,6 +3879,8 @@ def build_quota_plan(status_payload: dict[str, Any], *, mode: str = "status") ->
             "handoff_readiness",
             "user_todos",
             "agent_todos",
+            "active_state_next_action",
+            "active_state_next_action_entries",
         ):
             if optional_field in attention:
                 if optional_field == "handoff_readiness":

--- a/goal_harness/state_projection.py
+++ b/goal_harness/state_projection.py
@@ -124,6 +124,17 @@ def _section_entries(lines: list[str]) -> list[str]:
     return [entry for entry in entries if entry]
 
 
+def active_state_next_action_entries(
+    state_text: str,
+    *,
+    limit: int | None = 3,
+) -> list[str]:
+    entries = _section_entries(_section_lines(state_text, "Next Action"))
+    if limit is None:
+        return entries
+    return entries[: max(0, limit)]
+
+
 def summarize_state_todo_open_counts(state_text: str) -> dict[str, int]:
     role: str | None = None
     counts = {"user": 0, "agent": 0}

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -37,7 +37,7 @@ from .paths import global_registry_path, resolve_runtime_root
 from .promotion_gate import build_promotion_gate
 from .quota import QUOTA_MONITOR_POLL_CLASSIFICATION, quota_status, quota_with_handoff_outcome_floor
 from .registry import registry_goals
-from .state_projection import state_projection_gap_warning
+from .state_projection import active_state_next_action_entries, state_projection_gap_warning
 from .todo_contract import (
     TODO_STATUS_OPEN,
     TODO_TASK_CLASS_ADVANCEMENT,
@@ -5168,6 +5168,10 @@ def active_state_todo_fields(goal: dict[str, Any]) -> dict[str, Any]:
     except OSError:
         return {}
     fields = parse_active_state_todos(state_text, goal=goal, state_path=state_path)
+    next_action_entries = active_state_next_action_entries(state_text, limit=3)
+    if next_action_entries:
+        fields["active_state_next_action"] = next_action_entries[0]
+        fields["active_state_next_action_entries"] = next_action_entries
     warning = backlog_hygiene_warning(
         state_text,
         agent_todos=fields.get("agent_todos") if isinstance(fields.get("agent_todos"), dict) else None,

--- a/regression/quota-executable-backlog-projection.py
+++ b/regression/quota-executable-backlog-projection.py
@@ -55,7 +55,11 @@ def run_goal_harness(*args: str, registry: Path, runtime: Path) -> dict[str, Any
     return payload
 
 
-def write_fixture(root: Path) -> tuple[Path, Path]:
+def write_fixture(
+    root: Path,
+    *,
+    state_next_action: str = POLL_ACTION,
+) -> tuple[Path, Path]:
     project = root / "project"
     runtime = root / "runtime"
     state_file = f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
@@ -72,7 +76,7 @@ def write_fixture(root: Path) -> tuple[Path, Path]:
         "---\n\n"
         "# Quota Executable Backlog Projection Fixture\n\n"
         "## Next Action\n\n"
-        f"- {POLL_ACTION}\n\n"
+        f"- {state_next_action}\n\n"
         "## Agent Todo\n\n"
         "- [ ] [P0] [P0 monitor] Observe no-upload Terminal-Bench train-fasttext "
         "using compact process/result markers only.\n"
@@ -183,6 +187,28 @@ def assert_refresh_state_prefers_open_agent_todo(
     assert refresh["recommended_action"] != POLL_ACTION, refresh
 
 
+def assert_latest_run_action_does_not_create_false_projection_gap() -> None:
+    with tempfile.TemporaryDirectory(
+        prefix="goal-harness-quota-executable-backlog-synced-"
+    ) as tmp:
+        runtime, registry = write_fixture(
+            Path(tmp),
+            state_next_action=EXECUTABLE_TODO,
+        )
+        guard = run_goal_harness(
+            "quota",
+            "should-run",
+            "--goal-id",
+            GOAL_ID,
+            registry=registry,
+            runtime=runtime,
+        )
+        assert guard["should_run"] is True, guard
+        assert guard["recommended_action"] == EXECUTABLE_TODO, guard
+        assert guard["recommended_action"] != POLL_ACTION, guard
+        assert "state_action_projection_warning" not in guard, guard
+
+
 def main() -> int:
     with tempfile.TemporaryDirectory(prefix="goal-harness-quota-executable-backlog-") as tmp:
         runtime, registry = write_fixture(Path(tmp))
@@ -199,6 +225,7 @@ def main() -> int:
             registry=registry,
             runtime=runtime,
         )
+    assert_latest_run_action_does_not_create_false_projection_gap()
     print("quota-executable-backlog-projection-regression ok")
     return 0
 


### PR DESCRIPTION
## Summary
- parse active-state `Next Action` entries into status/quota payloads
- make `state_action_projection_warning` compare selected executable work against the active state, not a latest-run recommended_action that may come from a side agent
- keep the stale active-state warning path covered while adding a regression for synced active state plus stale latest-run text

## Validation
- `python3 -m py_compile goal_harness/state_projection.py goal_harness/status.py goal_harness/quota.py regression/quota-executable-backlog-projection.py`
- `python3 regression/quota-executable-backlog-projection.py`
- `python3 examples/quota-plan-smoke.py`
- `python3 examples/status-markdown-smoke.py`
- `python3 examples/heartbeat-quota-flow-smoke.py`
- `git diff --check`
- `goal-harness check --scan-path goal_harness/quota.py --scan-path goal_harness/status.py --scan-path goal_harness/state_projection.py --scan-path regression/quota-executable-backlog-projection.py`
- `python3 regression/run-regressions.py`
- `goal-harness --format json --registry /Users/bytedance/.codex/goal-harness/registry.global.json quota should-run --goal-id goal-harness-meta --agent-id codex-main-control`

## Notes
- No raw benchmark logs, local goal state, credentials, or private artifacts included.
- `goal-harness check` still reports the pre-existing duplicate run-history index warning for `goal-harness-meta`; this PR does not touch run-history compaction.
