### PR TITLE
benchmarks: classify SkillsBench zero-score closeouts

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
@@ -6040,9 +6040,9 @@
         "travel-planning": {
           "case_id": "travel-planning",
           "latest_decision": {
-            "baseline_run_id": "084e5289e5ea",
-            "decision": "baseline_passed_not_current_treatment_priority",
-            "failure_scope": "passed"
+            "baseline_run_id": "e553cee31756",
+            "decision": "baseline_failed_treatment_candidate",
+            "failure_scope": "case_or_solution"
           },
           "runs": [
             {
@@ -6107,11 +6107,77 @@
                 "staged": true,
                 "task_skills_removed": true
               }
+            },
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "skillsbench_raw_codex_autonomous_max5_baseline",
+              "artifact_refs": {
+                "compact_artifact_ref": "cloud-ecs/skillsbench-real-case/gh-skillsbench-travel-planning-container-acp-configfix-20260620T063851/benchmark_run.compact.json"
+              },
+              "benchmark_id": "skillsbench@1.1",
+              "case_id": "travel-planning",
+              "case_ids": [
+                "travel-planning"
+              ],
+              "codex_acp_runtime_preflight_passed": true,
+              "failure_class": "official_score_zero_case_failure",
+              "failure_labels": [
+                "skillsbench_runner_error",
+                "official_score_zero_case_failure"
+              ],
+              "failure_scope": "case_or_solution",
+              "goal_harness_inside_case": false,
+              "job_name": "skillsbench_1_1_travel_planning_raw_codex_autonomous_max5",
+              "leaderboard_evidence": false,
+              "loop_score_policy": "best_round_for_offline_controller_analysis",
+              "max_rounds_budget": 1,
+              "mode": "skillsbench_raw_codex_autonomous_max5_baseline",
+              "model_control_status": "reported_model_from_result_metadata",
+              "notes": "official SkillsBench v1.1 travel-planning raw Codex autonomous max5; official score completed at 0.0 from reward artifact; runner_failure retained as closeout diagnostic, score failure classified as official_score_zer...",
+              "official_feedback_blinded": true,
+              "official_passed": false,
+              "official_score": 0.0,
+              "official_score_policy": "final_workspace_official_result",
+              "recorded_at": "2026-06-20T07:08:23+08:00",
+              "reward_feedback_forwarded": false,
+              "round_reward_count": 1,
+              "round_rewards": [
+                {
+                  "agent_round": 1,
+                  "passed": false,
+                  "reward_present": false
+                }
+              ],
+              "round_success_observed": false,
+              "run_group_id": "gh-skillsbench-travel-planning-container-acp-configfix-20260620T063851",
+              "run_id": "e553cee31756",
+              "score_status": "failed",
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false,
+              "task_staging": {
+                "app_skills_mount_patch_applied": true,
+                "apt_retry_patch_applied": false,
+                "apt_retry_patch_required": false,
+                "apt_risk_preflight_blocked": false,
+                "apt_setup_risk_detected": false,
+                "codex_acp_runtime_tools_patch_applied": true,
+                "include_task_skills": false,
+                "original_task_mutated": false,
+                "resource_cap_patch": {
+                  "applied": false,
+                  "host_cpus": 32.0
+                },
+                "staged": true,
+                "task_skills_removed": true
+              }
             }
           ]
         }
       },
-      "run_count": 110
+      "run_count": 111
     },
     "terminal-bench-worker-materialization@v0": {
       "benchmark_id": "terminal-bench-worker-materialization@v0",
@@ -9601,5 +9667,5 @@
     "source_of_truth": "benchmark_run_v0 compact run events",
     "update_rule": "upsert one run entry when a benchmark case is ingested or closed"
   },
-  "updated_at": "2026-06-20T04:51:08+08:00"
+  "updated_at": "2026-06-20T07:08:23+08:00"
 }

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
@@ -5,7 +5,7 @@ benchmark case outcomes and artifact references; it must not contain raw
 logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 
 - schema_version: `benchmark_run_ledger_v0`
-- updated_at: `2026-06-20T04:51:08+08:00`
+- updated_at: `2026-06-20T07:08:23+08:00`
 
 ## Case Decisions
 
@@ -32,7 +32,7 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `skillsbench@1.1` | `software-dependency-audit` | `paired_no_score_uplift` | - | `6` |
 | `skillsbench@1.1` | `suricata-custom-exfil` | `paired_treatment_codex_acp_runtime_preflight_required` | - | `5` |
 | `skillsbench@1.1` | `tictoc-unnecessary-abort-detection` | `baseline_runner_or_setup_repair_required` | - | `1` |
-| `skillsbench@1.1` | `travel-planning` | `baseline_passed_not_current_treatment_priority` | - | `1` |
+| `skillsbench@1.1` | `travel-planning` | `baseline_failed_treatment_candidate` | - | `2` |
 | `terminal-bench-worker-materialization@v0` | `nginx-request-logging` | `single_arm_recorded` | - | `2` |
 | `terminal-bench@2.0` | `build-cython-ext` | `baseline_passed_not_current_treatment_priority` | - | `5` |
 | `terminal-bench@2.0` | `cobol-modernization` | `paired_baseline_solved_treatment_preserved` | - | `2` |
@@ -186,6 +186,7 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `skillsbench@1.1` | `suricata-custom-exfil` | `codex_goal_harness_treatment` | `` | `missing` | `` | `` | `skillsbench_codex_acp_jsonrpc_internal_error` | `` |
 | `skillsbench@1.1` | `tictoc-unnecessary-abort-detection` | `skillsbench_raw_codex_autonomous_max5_baseline` | `` | `missing` | `` | `` | `skillsbench_docker_compose_setup_failure` | `.local/private-benchmark-jobs/skillsbench-product-mode-tictoc-unnecessary-abort-detection-raw-baseline-20260616T202521CST/skillsbench-product-mode-tictoc-unnecessary-abort-detection-raw-baseline-20260616T202521CST/tictoc-unnecessary-abort-detection__raw_codex_autonomous_max5/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `travel-planning` | `baseline` | `` | `1.0` | `1` | `1:1*` | `none` | `.local/private-benchmark-jobs/skillsbench-travel-planning-blind-baseline-20260616T1238CST/travel-planning__codex_acp_blind_loop/benchmark_run.compact.json` |
+| `skillsbench@1.1` | `travel-planning` | `skillsbench_raw_codex_autonomous_max5_baseline` | `` | `0.0` | `` | `1:missing` | `official_score_zero_case_failure` | `cloud-ecs/skillsbench-real-case/gh-skillsbench-travel-planning-container-acp-configfix-20260620T063851/benchmark_run.compact.json` |
 | `terminal-bench-worker-materialization@v0` | `nginx-request-logging` | `hardened_codex_worker_materialization_runtime_probe` | `` | `missing` | `` | `` | `not_applicable_worker_materialization_probe` | `.local/private-benchmark-jobs/terminal-bench-nginx-hardened-worker-materialization-runtime-probe-20260616T113050CST/jobs/terminal_bench_nginx_request_logging_hardened_worker_materialization_runtime_probe_20260616T113050CST/result.json` |
 | `terminal-bench-worker-materialization@v0` | `nginx-request-logging` | `hardened_codex_worker_materialization_runtime_probe` | `` | `missing` | `` | `` | `not_applicable_worker_materialization_probe` | `` |
 | `terminal-bench@2.0` | `build-cython-ext` | `codex_goal_mode_baseline` | `` | `0.0` | `` | `` | `codex_model_access_unsupported_for_account` | `.local/private-benchmark-jobs/terminal-bench-build-cython-ext-goal-mode-baseline-20260614T175604CST/jobs/terminal_bench_2_0_build_cython_ext_codex_goal_mode_baseline_real_no_upload_20260614T175604CST/result.json` |

--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -446,33 +446,34 @@ def test_skillsbench_host_local_acp_transport_probe_uses_benchflow_client() -> N
 
 
 def test_skillsbench_worker_handshake_preflight_probe_clears_relay_gap() -> None:
-    proc = subprocess.run(
-        [
-            sys.executable,
-            str(REPO_ROOT / "scripts/skillsbench_automation_loop.py"),
-            "--local-driver-worker-handshake-preflight",
-            "--local-codex-cli-participant-ready",
-            "--local-acp-relay-probe",
-            "--task-id",
-            "ada-bathroom-plan-repair",
-        ],
-        cwd=REPO_ROOT,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        check=False,
-    )
-    assert proc.returncode == 0, proc.stderr
-    payload = json.loads(proc.stdout)
+    with tempfile.TemporaryDirectory(prefix="skillsbench-worker-preflight-") as tmp:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(REPO_ROOT / "scripts/skillsbench_automation_loop.py"),
+                "--local-driver-worker-handshake-preflight",
+                "--skillsbench-root",
+                str(Path(tmp) / "missing-skillsbench"),
+                "--local-codex-cli-participant-ready",
+                "--local-acp-relay-probe",
+                "--task-id",
+                "ada-bathroom-plan-repair",
+            ],
+            cwd=REPO_ROOT,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+        )
+        assert proc.returncode == 0, proc.stderr
+        payload = json.loads(proc.stdout)
     assert payload["local_driver_contract"]["acp_relay_materialized"] is True, payload
     assert (
         payload["local_driver_contract"]["acp_relay_probe"]["ready"] is True
     ), payload
     assert "skillsbench_local_acp_relay_missing" not in payload["blockers"], payload
-    assert payload["first_blocker"] == "skillsbench_host_local_acp_transport_missing"
-    assert (
-        payload["next_action"] == "wire_host_local_acp_transport_before_mini_pair"
-    ), payload
+    assert payload["first_blocker"] == "skillsbench_benchflow_runtime_missing"
+    assert payload["next_action"] == "install_or_select_skillsbench_benchflow_runtime"
     assert payload["boundary"]["credential_values_recorded"] is False, payload
     text = json.dumps(payload, sort_keys=True)
     for forbidden in ("/Users/", "~/.codex", "OPENAI_API_KEY", "HF_TOKEN"):
@@ -931,6 +932,31 @@ def write_official_skillsbench_reward_artifact_recovery_result(root: Path) -> Pa
     return result_path
 
 
+def write_official_skillsbench_runner_error_zero_reward_result(root: Path) -> Path:
+    run_dir = root / "official" / "2026-06-20__06-38-51" / "travel-planning__raw"
+    result_path = run_dir / "result.json"
+    write_json(
+        result_path,
+        {
+            "task_name": "travel-planning",
+            "rollout_name": "travel-planning__raw",
+            "agent": "codex-acp",
+            "agent_name": "codex-acp",
+            "model": "gpt-5.5",
+            "n_tool_calls": 0,
+            "n_prompts": 1,
+            "error": "agent process ended after verifier wrote reward",
+            "verifier_error": "reward missing from compact result",
+            "partial_trajectory": False,
+            "trajectory_source": None,
+        },
+    )
+    reward_path = run_dir / "verifier" / "reward.txt"
+    reward_path.parent.mkdir(parents=True, exist_ok=True)
+    reward_path.write_text("0\n", encoding="utf-8")
+    return result_path
+
+
 def write_official_skillsbench_oracle_reward_artifact_recovery_result(
     root: Path,
 ) -> Path:
@@ -1337,6 +1363,49 @@ def test_skillsbench_result_reward_artifact_recovery() -> None:
         ), compact
         assert compact["progress"]["n_completed_trials"] == 1, compact
         assert compact["progress"]["n_errored_trials"] == 0, compact
+
+
+def test_skillsbench_runner_error_zero_reward_is_case_score_failure() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-zero-reward-") as tmp:
+        result_path = write_official_skillsbench_runner_error_zero_reward_result(
+            Path(tmp)
+        )
+        compact = compact_benchmark_run(
+            build_skillsbench_benchflow_result_benchmark_run(
+                result_path,
+                route="raw-codex-autonomous-max5",
+            )
+        )
+        assert compact is not None
+        assert compact["official_score_status"] == "completed", compact
+        assert compact["official_task_score"] == {
+            "kind": "skillsbench_verifier_reward_recovered_from_reward_txt",
+            "passed": False,
+            "value": 0.0,
+        }, compact
+        assert compact["progress"]["n_errored_trials"] == 1, compact
+        assert compact["runner_failure"]["failure_class"] == (
+            "skillsbench_runner_error"
+        ), compact
+        assert compact["score_failure_attribution"] == (
+            "official_score_zero_case_failure"
+        ), compact
+        assert "skillsbench_runner_error" in compact["failure_attribution_labels"]
+        assert "official_score_zero_case_failure" in compact[
+            "failure_attribution_labels"
+        ]
+        ledger_path = Path(tmp) / "ledger.json"
+        update = update_benchmark_run_ledger(
+            ledger_path=ledger_path,
+            benchmark_run=compact,
+            run_group_id="skillsbench-travel-planning-zero-score",
+            dry_run=False,
+        )
+        assert update["entry"]["score_status"] == "failed", update
+        assert update["entry"]["failure_class"] == (
+            "official_score_zero_case_failure"
+        ), update
+        assert update["entry"]["failure_scope"] == "case_or_solution", update
 
 
 def test_skillsbench_oracle_result_reward_artifact_recovery() -> None:

--- a/examples/skillsbench-host-local-launch-plan-smoke.py
+++ b/examples/skillsbench-host-local-launch-plan-smoke.py
@@ -15,6 +15,11 @@ SCRIPT = REPO_ROOT / "scripts" / "skillsbench_automation_loop.py"
 
 
 def main() -> int:
+    source = SCRIPT.read_text(encoding="utf-8")
+    assert "def _filter_kwargs_for_signature(" in source
+    assert "getattr(\n        benchflow_rollout_module, \"connect_acp\", _MISSING" in source
+    assert "if original_rollout_connect_acp is not _MISSING:" in source
+    assert "_filter_kwargs_for_signature(RolloutConfig, rollout_config_kwargs)" in source
     with tempfile.TemporaryDirectory(prefix="gh-skillsbench-plan-") as tmp:
         root = Path(tmp) / "skillsbench"
         task = root / "tasks" / "demo-task" / "environment"

--- a/goal_harness/benchmark_adapters/skillsbench.py
+++ b/goal_harness/benchmark_adapters/skillsbench.py
@@ -1963,6 +1963,14 @@ def build_skillsbench_benchflow_result_benchmark_run(
     if reward_value == 0 and not failure_labels and not partial_trajectory:
         failure_labels.append("official_verifier_solution_failure")
         score_failure_attribution = "official_verifier_solution_failure"
+    elif (
+        reward_value == 0
+        and reward_artifact_source
+        and score_failure_attribution == "skillsbench_runner_error"
+        and failure_labels == ["skillsbench_runner_error"]
+    ):
+        failure_labels.append("official_score_zero_case_failure")
+        score_failure_attribution = "official_score_zero_case_failure"
     elif reward_value == 0 and not failure_labels:
         failure_labels.append("official_score_zero_case_failure")
     real_run_completed = not error_text and (

--- a/goal_harness/benchmark_ledger.py
+++ b/goal_harness/benchmark_ledger.py
@@ -553,6 +553,7 @@ def _failure_scope(failure_class: str, score: float | int | None, passed: bool |
     if failure_class in {
         "none",
         "official_verifier_solution_failure",
+        "official_score_zero_case_failure",
         "model_solution_failure",
         "agent_solution_failure",
         "task_solution_failure",

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -45,6 +45,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import contextlib
+import inspect
 import json
 import logging
 import os
@@ -90,6 +91,7 @@ DEFAULT_GOAL_ID = "goal-harness-meta"
 DEFAULT_MODEL = "gpt-5.5"
 DEFAULT_TIMEOUT_SEC = 7200
 DEFAULT_MAX_ROUNDS = 5
+_MISSING = object()
 SUPPORTED_ROUTES = (
     "codex-acp-blind-loop-baseline",
     "goal-harness-blind-loop-treatment",
@@ -112,6 +114,30 @@ PRODUCT_MODE_CASE_STATE_PATH = benchmark_case_active_state_path(
     PRODUCT_MODE_CASE_GOAL_ID
 )
 PRODUCT_MODE_CASE_STATE_SCHEMA_VERSION = BENCHMARK_CASE_ACTIVE_STATE_SCHEMA_VERSION
+
+
+def _filter_kwargs_for_signature(
+    target: Any,
+    kwargs: dict[str, Any],
+) -> dict[str, Any]:
+    """Drop optional kwargs that an installed upstream callable cannot accept."""
+
+    try:
+        signature = inspect.signature(target)
+    except (TypeError, ValueError):
+        return dict(kwargs)
+    if any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in signature.parameters.values()
+    ):
+        return dict(kwargs)
+    return {
+        key: value
+        for key, value in kwargs.items()
+        if key in signature.parameters
+    }
+
+
 DOCKER_APP_SKILLS_MOUNT_BEGIN = "# BEGIN GOAL_HARNESS_SKILLSBENCH_APP_SKILLS_MOUNT"
 DOCKER_APP_SKILLS_MOUNT_END = "# END GOAL_HARNESS_SKILLSBENCH_APP_SKILLS_MOUNT"
 DOCKER_APT_RETRY_BEGIN = "# BEGIN GOAL_HARNESS_SKILLSBENCH_APT_RETRY"
@@ -2729,7 +2755,9 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
 
     original_install_agent = Rollout.install_agent
     original_runtime_connect_acp = benchflow_acp_runtime.connect_acp
-    original_rollout_connect_acp = benchflow_rollout_module.connect_acp
+    original_rollout_connect_acp = getattr(
+        benchflow_rollout_module, "connect_acp", _MISSING
+    )
 
     async def install_agent_host_local_acp(self: Any) -> None:
         cfg = self._config
@@ -2770,7 +2798,11 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
             cfg.sandbox_user,
             self._agent_cwd,
             self._task,
-            include_task_skills=cfg.include_task_skills,
+            include_task_skills=getattr(
+                cfg,
+                "include_task_skills",
+                bool(args.include_task_skills),
+            ),
         )
         if cfg.export_generated_skills_to:
             await benchflow_rollout_module._ensure_sandbox_dir(
@@ -2835,27 +2867,31 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
     if args.route == "goal-harness-product-mode":
         pre_agent_hooks.append(seed_product_mode_case_state)
 
+    rollout_config_kwargs = {
+        "task_path": effective_task_path,
+        "environment": args.sandbox,
+        "sandbox_user": args.sandbox_user,
+        "sandbox_setup_timeout": args.sandbox_setup_timeout,
+        "job_name": plan["job_name"],
+        "rollout_name": plan["rollout_name"],
+        "jobs_dir": Path(plan["jobs_dir"]),
+        "user": controller_user,
+        "max_user_rounds": args.max_rounds,
+        "agent": "codex-acp",
+        "model": args.model,
+        "agent_idle_timeout": args.agent_idle_timeout,
+        "include_task_skills": bool(args.include_task_skills),
+        "pre_agent_hooks": pre_agent_hooks,
+    }
     config = RolloutConfig(
-        task_path=effective_task_path,
-        environment=args.sandbox,
-        sandbox_user=args.sandbox_user,
-        sandbox_setup_timeout=args.sandbox_setup_timeout,
-        job_name=plan["job_name"],
-        rollout_name=plan["rollout_name"],
-        jobs_dir=Path(plan["jobs_dir"]),
-        user=controller_user,
-        max_user_rounds=args.max_rounds,
-        agent="codex-acp",
-        model=args.model,
-        agent_idle_timeout=args.agent_idle_timeout,
-        include_task_skills=bool(args.include_task_skills),
-        pre_agent_hooks=pre_agent_hooks,
+        **_filter_kwargs_for_signature(RolloutConfig, rollout_config_kwargs)
     )
     result_path: Path | None = None
     Rollout.install_agent = install_agent_with_launch_preflight
     if args.host_local_acp_launch:
         benchflow_acp_runtime.connect_acp = connect_host_local_acp
-        benchflow_rollout_module.connect_acp = connect_host_local_acp
+        if original_rollout_connect_acp is not _MISSING:
+            benchflow_rollout_module.connect_acp = connect_host_local_acp
     try:
         await benchflow_run(config)
         result_path = discover_benchflow_result_path(plan)
@@ -2864,7 +2900,8 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
     finally:
         Rollout.install_agent = original_install_agent
         benchflow_acp_runtime.connect_acp = original_runtime_connect_acp
-        benchflow_rollout_module.connect_acp = original_rollout_connect_acp
+        if original_rollout_connect_acp is not _MISSING:
+            benchflow_rollout_module.connect_acp = original_rollout_connect_acp
         _merge_acp_trajectory_summary(plan, controller_trace)
         _write_controller_trace(plan, controller_trace)
     if result_path is None:


### PR DESCRIPTION
## Summary
- classify SkillsBench runs that have a recovered official 0.0 reward artifact plus a generic runner error as `official_score_zero_case_failure` while preserving the runner diagnostic label
- map that failure class to `case_or_solution` in the public benchmark ledger
- record the cloud ECS `travel-planning` raw Codex baseline closeout and make the SkillsBench smoke hermetic for fresh clones

## Validation
- `python3 -m py_compile goal_harness/benchmark_adapters/skillsbench.py goal_harness/benchmark_ledger.py scripts/skillsbench_automation_loop.py examples/skillsbench-benchmark-run-smoke.py examples/skillsbench-host-local-launch-plan-smoke.py`
- `python3 examples/skillsbench-host-local-launch-plan-smoke.py`
- `python3 examples/skillsbench-benchmark-run-smoke.py`
- `python3 examples/benchmark-run-ledger-smoke.py`
- `git diff --check`
- `goal-harness check --scan-path ...` for the 7 touched public files

## Boundary
- excluded private runner logs, raw task text, raw trajectories, credentials, uploads, and local absolute artifact paths
- public ledger records only compact artifact references and aggregate score/failure fields

## Residual risk
- the original main worktree still has the same uncommitted SkillsBench edits because this PR was intentionally split into a clean worktree to avoid mixing into PR #254; after this PR is reviewed/merged that duplicate local diff should be reconciled.
