### PR TITLE
Resolve heartbeat scopes from agent profiles

### DIFF
--- a/examples/heartbeat-prompt-smoke.py
+++ b/examples/heartbeat-prompt-smoke.py
@@ -19,6 +19,7 @@ from goal_harness.heartbeat_prompt import INTERFACE_BUDGET_CHARS, build_heartbea
 
 DOC = REPO_ROOT / "docs" / "heartbeat-automation-prompt.md"
 README = REPO_ROOT / "README.md"
+GETTING_STARTED = REPO_ROOT / "docs" / "guides" / "getting-started.md"
 INTEGRATION_DOC = REPO_ROOT / "docs" / "integration.md"
 PROJECT_SKILL = REPO_ROOT / "skills" / "goal-harness-project" / "SKILL.md"
 GOAL_ID = "public-heartbeat-goal"
@@ -113,6 +114,20 @@ def main() -> int:
         registered_agents=["codex-main-control", "codex-side-bypass"],
         primary_agent="codex-main-control",
     )
+    profile_scoped_payload = build_heartbeat_prompt(
+        goal_id=GOAL_ID,
+        active_state=ACTIVE_STATE,
+        thin=True,
+        agent_id="codex-side-bypass",
+        agent_profile={
+            "schema_version": "agent_profile_v0",
+            "agent_id": "codex-side-bypass",
+            "scope_summary": "productization showcase docs lane",
+            "private_note": "must stay out of heartbeat payload",
+        },
+        registered_agents=["codex-main-control", "codex-side-bypass"],
+        primary_agent="codex-main-control",
+    )
     missing_agent_id = None
     try:
         build_heartbeat_prompt(
@@ -161,6 +176,7 @@ def main() -> int:
     assert_interface_budget_payload("compact", scoped_payload)
     assert_interface_budget_payload("compact", primary_scoped_payload)
     assert_interface_budget_payload("thin", thin_scoped_payload)
+    assert_interface_budget_payload("thin", profile_scoped_payload)
     assert_no_project_specific_prompt_leaks("full", str(payload["task_body"]))
     assert_no_project_specific_prompt_leaks("compact", str(compact_payload["task_body"]))
     assert_no_project_specific_prompt_leaks("brief", str(brief_payload["task_body"]))
@@ -250,6 +266,17 @@ def main() -> int:
     assert primary_scoped_payload["quota_spend_command"].endswith(
         "quota spend-slot --goal-id public-heartbeat-goal --slots 1 --source heartbeat --execute --agent-id codex-main-control"
     ), primary_scoped_payload
+    assert profile_scoped_payload["agent_scopes"] == ["productization showcase docs lane"], profile_scoped_payload
+    assert profile_scoped_payload["agent_scope_source"] == "agent_profile_v0", profile_scoped_payload
+    assert "private_note" not in profile_scoped_payload["agent_profile"], profile_scoped_payload
+    assert profile_scoped_payload["thin_prompt_command"] == (
+        "goal-harness heartbeat-prompt --thin --goal-id public-heartbeat-goal "
+        "--active-state /tmp/public-heartbeat-goal/ACTIVE_GOAL_STATE.md --agent-id codex-side-bypass"
+    ), profile_scoped_payload
+    assert "--agent-scope" not in profile_scoped_payload["thin_prompt_command"], profile_scoped_payload
+    assert "productization showcase docs lane" in normalized(str(profile_scoped_payload["task_body"])), (
+        profile_scoped_payload
+    )
     for phrase in (
         "Agent identity and scope",
         "role: side-agent",
@@ -616,17 +643,21 @@ def main() -> int:
         ),
     )
 
-    assert "docs/heartbeat-automation-prompt.md" in readme, readme
-    assert "goal-harness heartbeat-prompt" in readme, readme
+    getting_started = GETTING_STARTED.read_text(encoding="utf-8")
+    assert "docs/guides/getting-started.md" in readme, readme
     assert "goal-harness heartbeat-prompt --thin" in readme, readme
-    assert "goal-harness-canary" in readme, readme
-    assert "release snapshot" in readme, readme
-    assert "execution_obligation" in readme, readme
-    assert "safe-bypass or self-repair hints" in readme, readme
+    assert "goal-harness quota spend-slot" in readme, readme
+    assert "Generate a guarded Codex App heartbeat body" in getting_started, getting_started
+    assert "goal-harness heartbeat-prompt --thin" in getting_started, getting_started
+    assert "goal-harness heartbeat-prompt --compact" in getting_started, getting_started
+    assert "goal-harness-canary" in getting_started, getting_started
+    assert "release snapshot" in getting_started, getting_started
+    assert "execution_obligation" in getting_started, getting_started
+    assert "safe-bypass or self-repair hints" in getting_started, getting_started
+    assert "../heartbeat-automation-prompt.md" in getting_started, getting_started
     assert "execution_obligation" in doc, doc
     assert "must_attempt_work=true" in doc, doc
     assert "not an execution gate" in normalized(doc), doc
-    assert "Generate a guarded Codex App heartbeat body" in readme, readme
     assert "goal-harness heartbeat-prompt" in doc, doc
     assert "--compact" in doc, doc
     assert "--brief" in doc, doc
@@ -828,6 +859,12 @@ def main() -> int:
                             "coordination": {
                                 "registered_agents": ["codex-main-control", "codex-side-bypass"],
                                 "primary_agent": "codex-main-control",
+                                "agent_profiles": {
+                                    "codex-side-bypass": {
+                                        "schema_version": "agent_profile_v0",
+                                        "scope_summary": "productization showcase docs lane",
+                                    }
+                                },
                             },
                         }
                     ]
@@ -999,6 +1036,43 @@ def main() -> int:
             "codex-side-bypass",
         ], cli_scoped_payload
         assert "todo claim --goal-id public-heartbeat-goal" in cli_scoped_payload["task_body"], cli_scoped_payload
+
+        cli_profile_scoped_json = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "goal_harness.cli",
+                "--format",
+                "json",
+                "--registry",
+                str(registry_path),
+                "heartbeat-prompt",
+                "--goal-id",
+                GOAL_ID,
+                "--thin",
+                "--agent-id",
+                "codex-side-bypass",
+            ],
+            cwd=REPO_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+        cli_profile_scoped_payload = json.loads(cli_profile_scoped_json)
+        assert cli_profile_scoped_payload["agent_id"] == "codex-side-bypass", cli_profile_scoped_payload
+        assert cli_profile_scoped_payload["agent_scopes"] == ["productization showcase docs lane"], (
+            cli_profile_scoped_payload
+        )
+        assert cli_profile_scoped_payload["agent_scope_source"] == "agent_profile_v0", cli_profile_scoped_payload
+        assert cli_profile_scoped_payload["thin_prompt_command"] == (
+            "goal-harness heartbeat-prompt --thin --goal-id public-heartbeat-goal --agent-id codex-side-bypass"
+        ), cli_profile_scoped_payload
+        assert "--agent-scope" not in cli_profile_scoped_payload["thin_prompt_command"], (
+            cli_profile_scoped_payload
+        )
+        assert "productization showcase docs lane" in normalized(cli_profile_scoped_payload["task_body"]), (
+            cli_profile_scoped_payload
+        )
 
         cli_unknown_scoped = subprocess.run(
             [

--- a/goal_harness/agent_registry.py
+++ b/goal_harness/agent_registry.py
@@ -59,6 +59,32 @@ def primary_agent_id_for_goal(goal: dict[str, Any] | None) -> str | None:
     return None
 
 
+def agent_profile_for_goal(goal: dict[str, Any] | None, agent_id: str | None) -> dict[str, Any] | None:
+    normalized_agent_id = normalize_todo_claimed_by(agent_id)
+    if not isinstance(goal, dict) or not normalized_agent_id:
+        return None
+    coordination = goal.get("coordination")
+    if not isinstance(coordination, dict):
+        return None
+    profiles = coordination.get("agent_profiles")
+    raw_profile: Any = None
+    if isinstance(profiles, dict):
+        raw_profile = profiles.get(normalized_agent_id)
+    elif isinstance(profiles, list):
+        for item in profiles:
+            if not isinstance(item, dict):
+                continue
+            item_id = normalize_todo_claimed_by(item.get("agent_id") or item.get("id") or item.get("name"))
+            if item_id == normalized_agent_id:
+                raw_profile = item
+                break
+    if not isinstance(raw_profile, dict):
+        return None
+    profile = dict(raw_profile)
+    profile["agent_id"] = normalized_agent_id
+    return profile
+
+
 def load_goal_from_registry(registry_path: Path, goal_id: str) -> dict[str, Any] | None:
     if not registry_path.exists():
         return None
@@ -75,6 +101,10 @@ def registered_agent_ids_from_registry(registry_path: Path, goal_id: str) -> lis
 
 def primary_agent_id_from_registry(registry_path: Path, goal_id: str) -> str | None:
     return primary_agent_id_for_goal(load_goal_from_registry(registry_path, goal_id))
+
+
+def agent_profile_from_registry(registry_path: Path, goal_id: str, agent_id: str | None) -> dict[str, Any] | None:
+    return agent_profile_for_goal(load_goal_from_registry(registry_path, goal_id), agent_id)
 
 
 def require_registered_agent_id(

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -13,6 +13,7 @@ from .authority import (
     render_authority_source_markdown,
 )
 from .agent_registry import (
+    agent_profile_from_registry,
     primary_agent_id_from_registry,
     registered_agent_ids_from_registry,
     require_registered_agent_id,
@@ -5689,6 +5690,7 @@ def main(argv: list[str] | None = None) -> int:
             registered_agents = registered_agent_ids_from_registry(agent_registry_path, args.goal_id)
             primary_agent = primary_agent_id_from_registry(agent_registry_path, args.goal_id)
             effective_agent_id = None
+            agent_profile = None
             if args.agent_id:
                 effective_agent_id = require_registered_agent_id(
                     registry_path=agent_registry_path,
@@ -5696,6 +5698,7 @@ def main(argv: list[str] | None = None) -> int:
                     agent_id=args.agent_id,
                     field="agent_id",
                 )
+                agent_profile = agent_profile_from_registry(agent_registry_path, args.goal_id, effective_agent_id)
             payload = build_heartbeat_prompt(
                 goal_id=args.goal_id,
                 active_state=active_state,
@@ -5709,6 +5712,7 @@ def main(argv: list[str] | None = None) -> int:
                 cli_bin=args.cli_bin,
                 agent_id=effective_agent_id,
                 agent_scopes=args.agent_scopes,
+                agent_profile=agent_profile,
                 registered_agents=registered_agents,
                 primary_agent=primary_agent,
             )

--- a/goal_harness/heartbeat_prompt.py
+++ b/goal_harness/heartbeat_prompt.py
@@ -57,6 +57,47 @@ def normalize_agent_scopes(values: list[str] | tuple[str, ...] | None) -> list[s
     return scopes
 
 
+def agent_profile_scopes(profile: dict[str, Any] | None) -> list[str]:
+    if not isinstance(profile, dict):
+        return []
+    raw_scopes: list[Any] = []
+    for key in ("scope_summary", "default_scope", "scope"):
+        value = profile.get(key)
+        if isinstance(value, list):
+            raw_scopes.extend(value)
+        elif value:
+            raw_scopes.append(value)
+    for key in ("scope_summaries", "default_scopes", "scopes"):
+        value = profile.get(key)
+        if isinstance(value, list):
+            raw_scopes.extend(value)
+    return normalize_agent_scopes(raw_scopes)
+
+
+def agent_profile_prompt_projection(profile: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(profile, dict):
+        return None
+    public_keys = {
+        "schema_version",
+        "agent_id",
+        "role",
+        "primary_agent",
+        "scope_summary",
+        "default_scope",
+        "scope",
+        "scope_summaries",
+        "default_scopes",
+        "scopes",
+        "default_task_classes",
+        "preferred_action_kinds",
+        "avoid_action_kinds",
+        "worktree_policy",
+        "review_policy",
+    }
+    projection = {key: value for key, value in profile.items() if key in public_keys}
+    return projection or None
+
+
 def agent_prompt_command_args(*, agent_id: str | None, agent_scopes: list[str]) -> str:
     parts: list[str] = []
     if agent_id:
@@ -241,6 +282,7 @@ def build_heartbeat_prompt(
     cli_bin: str = "goal-harness",
     agent_id: str | None = None,
     agent_scopes: list[str] | tuple[str, ...] | None = None,
+    agent_profile: dict[str, Any] | None = None,
     registered_agents: list[str] | tuple[str, ...] | None = None,
     primary_agent: str | None = None,
 ) -> dict[str, Any]:
@@ -256,7 +298,10 @@ def build_heartbeat_prompt(
     normalized_agent_id = normalize_todo_claimed_by(agent_id) if agent_id else None
     if agent_id and not normalized_agent_id:
         raise ValueError("agent_id must be a public-safe token such as codex-main-control")
-    normalized_agent_scopes = normalize_agent_scopes(agent_scopes)
+    explicit_agent_scopes = normalize_agent_scopes(agent_scopes)
+    profile_agent_scopes = agent_profile_scopes(agent_profile)
+    normalized_agent_scopes = explicit_agent_scopes or profile_agent_scopes
+    agent_scope_source = "argument" if explicit_agent_scopes else "agent_profile_v0" if profile_agent_scopes else None
     if normalized_agent_scopes and not normalized_agent_id:
         raise ValueError("--agent-scope requires --agent-id so claimed_by uses a registered agent")
     normalized_registered_agents = normalize_registered_agents(registered_agents)
@@ -304,9 +349,10 @@ def build_heartbeat_prompt(
         if normalized_agent_id
         else None
     )
+    command_agent_scopes = explicit_agent_scopes
     agent_args = agent_prompt_command_args(
         agent_id=normalized_agent_id,
-        agent_scopes=normalized_agent_scopes,
+        agent_scopes=command_agent_scopes,
     )
     agent_scope_instruction = render_agent_scope_instruction(
         goal_id=goal_id,
@@ -367,6 +413,8 @@ def build_heartbeat_prompt(
         "agent_id": normalized_agent_id,
         "agent_role": agent_role,
         "agent_scopes": normalized_agent_scopes,
+        "agent_scope_source": agent_scope_source,
+        "agent_profile": agent_profile_prompt_projection(agent_profile),
         "registered_agents": normalized_registered_agents,
         "primary_agent": normalized_primary_agent,
         "expanded_prompt_command": expanded_prompt_command,


### PR DESCRIPTION
## Summary
- add registry helpers for `coordination.agent_profiles` lookup by registered agent id
- let `heartbeat-prompt --agent-id` derive scope from `agent_profile_v0` when `--agent-scope` is omitted
- keep generated prompt commands slim by omitting repeated profile-backed `--agent-scope` args
- update heartbeat smoke coverage for profile-backed scope resolution and the slim README / getting-started split

## Validation
- `python3 -m py_compile goal_harness/agent_registry.py goal_harness/heartbeat_prompt.py goal_harness/cli.py examples/heartbeat-prompt-smoke.py`
- `python3 examples/heartbeat-prompt-smoke.py`
- `python3 examples/todo-cli-smoke.py`
- `python3 examples/docs-governance-smoke.py`
- `goal-harness check --scan-path goal_harness/agent_registry.py --scan-path goal_harness/heartbeat_prompt.py --scan-path goal_harness/cli.py --scan-path examples/heartbeat-prompt-smoke.py --scan-path docs/product/agent-profile-contract.md --scan-path docs/guides/getting-started.md`

## Notes
- This does not yet implement the `agent_member_v0` status/review projection.
- Contract check still reports the pre-existing duplicate run-history index warning for `goal-harness-meta`.