### PR TITLE
feat: add Terminal-Bench app-server Goal worker contract

### DIFF
--- a/docs/benchmark-developer-workflow.md
+++ b/docs/benchmark-developer-workflow.md
@@ -355,13 +355,14 @@ python3 -m goal_harness.cli --format json benchmark launch-terminal-bench-run \
   --materialization-wait-seconds 0
 ```
 
-Until a real Terminal-Bench worker adapter consumes the Codex app-server
-`thread/goal/set` + `thread/goal/get` proof inside the case launch, this mode
-must return `execution_ready=false`,
-`first_blocker=terminal_bench_app_server_goal_worker_seam_not_implemented`,
-and `codex_goal_mode_baseline_claim_allowed=false`. The older
-`codex-goal-mode` launcher remains a slash-command fallback and must not be
-used as a scored Codex Goal baseline.
+The app-server Goal launcher now exposes a public worker contract for
+`thread/goal/set`, `thread/goal/get`, and `turn/start`. Until a real
+Terminal-Bench case launch returns compact `turn/start` proof plus no-upload
+case proof, this mode must still return `execution_ready=false`,
+`first_blocker=terminal_bench_app_server_goal_turn_start_proof_missing`, and
+`codex_goal_mode_baseline_claim_allowed=false`. The older `codex-goal-mode`
+launcher remains a slash-command fallback and must not be used as a scored
+Codex Goal baseline.
 
 Default cloud ECS host readiness:
 

--- a/examples/terminal-bench-private-runner-env-guard-smoke.py
+++ b/examples/terminal-bench-private-runner-env-guard-smoke.py
@@ -1271,7 +1271,7 @@ time.sleep(3)
     assert cli_app_server_payload["dry_run"] is True, cli_app_server_payload
     assert cli_app_server_payload["execution_ready"] is False, cli_app_server_payload
     assert cli_app_server_payload["first_blocker"] == (
-        "terminal_bench_app_server_goal_worker_seam_not_implemented"
+        "terminal_bench_app_server_goal_turn_start_proof_missing"
     ), cli_app_server_payload
     assert cli_app_server_payload["launch_summary"][
         "codex_goal_mode_invocation_surface"
@@ -2505,15 +2505,21 @@ time.sleep(3)
     assert app_server_goal_summary["codex_goal_mode_invocation_surface"] == (
         "codex_app_server_thread_goal_set_get"
     ), app_server_goal_summary
-    assert app_server_goal_summary["codex_app_server_goal_worker_adapter_present"] is False, app_server_goal_summary
+    assert app_server_goal_summary["codex_app_server_goal_worker_adapter_present"] is True, app_server_goal_summary
+    assert app_server_goal_summary["codex_app_server_goal_worker_plan_schema"] == (
+        "codex_app_server_goal_worker_v0"
+    ), app_server_goal_summary
+    assert app_server_goal_summary[
+        "codex_app_server_goal_worker_turn_start_required"
+    ] is True, app_server_goal_summary
     assert app_server_goal_summary["codex_app_server_goal_proof_present"] is False, app_server_goal_summary
     assert app_server_goal_summary["codex_goal_mode_baseline_claim_allowed"] is False, app_server_goal_summary
     assert app_server_goal_summary["codex_goal_mode_baseline_claim_blocker"] == (
-        "terminal_bench_app_server_goal_worker_seam_not_implemented"
+        "terminal_bench_app_server_goal_turn_start_proof_missing"
     ), app_server_goal_summary
     assert app_server_goal_summary["goal_harness_access_packet_absent"] is True, app_server_goal_summary
     assert app_server_goal_summary["first_blocker"] == (
-        "terminal_bench_app_server_goal_worker_seam_not_implemented"
+        "terminal_bench_app_server_goal_turn_start_proof_missing"
     ), app_server_goal_summary
 
     expect_raises(

--- a/goal_harness/benchmark_adapters/terminal_bench.py
+++ b/goal_harness/benchmark_adapters/terminal_bench.py
@@ -24,6 +24,11 @@ from ..benchmark_case_state import (
     benchmark_case_active_state_path,
     benchmark_case_goal_id,
 )
+from ..codex_goal_baseline import (
+    CODEX_APP_SERVER_GOAL_WORKER_SCHEMA_VERSION,
+    CODEX_APP_SERVER_GOAL_WORKER_METHODS,
+    build_codex_app_server_goal_worker_plan,
+)
 from ..worker_bridge import (
     ACTIVE_USER_INTERVENTION_CHANNEL_CONTRACT_VERSION,
     ACTIVE_USER_INTERVENTION_CHANNEL_SURFACE,
@@ -198,6 +203,9 @@ TERMINAL_BENCH_CODEX_APP_SERVER_GOAL_BASELINE_MODE = (
 )
 TERMINAL_BENCH_CODEX_APP_SERVER_GOAL_WORKER_SEAM_BLOCKER = (
     "terminal_bench_app_server_goal_worker_seam_not_implemented"
+)
+TERMINAL_BENCH_CODEX_APP_SERVER_GOAL_TURN_PROOF_BLOCKER = (
+    "terminal_bench_app_server_goal_turn_start_proof_missing"
 )
 TERMINAL_BENCH_HARDENED_CODEX_LEGACY_CALIBRATION_MODE = (
     "hardened_codex_calibration"
@@ -5809,8 +5817,20 @@ def build_terminal_bench_private_runner_launch(**command_kwargs: Any) -> dict[st
         first_blocker = str(
             material_readiness.get("first_blocker") or f"task_material_{status}"
         )
+    codex_app_server_goal_worker_plan: dict[str, Any] = {}
     if codex_app_server_goal_mode:
-        first_blocker = TERMINAL_BENCH_CODEX_APP_SERVER_GOAL_WORKER_SEAM_BLOCKER
+        task_name = str(
+            resolved_command_kwargs.get("task_id")
+            or resolved_command_kwargs.get("include_task_name")
+            or TERMINAL_BENCH_DEFAULT_TASK
+        )
+        codex_app_server_goal_worker_plan = build_codex_app_server_goal_worker_plan(
+            objective=f"Complete Terminal-Bench task {task_name} under no-upload baseline.",
+            task_instruction="<terminal-bench-task-instruction-from-runner>",
+            cwd="<terminal-bench-case-workspace>",
+            model=str(resolved_command_kwargs.get("model") or TERMINAL_BENCH_DEFAULT_MODEL),
+        )
+        first_blocker = TERMINAL_BENCH_CODEX_APP_SERVER_GOAL_TURN_PROOF_BLOCKER
     return {
         "schema_version": "terminal_bench_private_runner_launch_v0",
         "argv": argv,
@@ -5822,7 +5842,25 @@ def build_terminal_bench_private_runner_launch(**command_kwargs: Any) -> dict[st
         "setup_timeout_repair_profile": setup_timeout_repair_profile,
         "repair_profile": repair_profile or {},
         "codex_app_server_goal_baseline_requested": codex_app_server_goal_mode,
-        "codex_app_server_goal_worker_adapter_present": False,
+        "codex_app_server_goal_worker_adapter_present": codex_app_server_goal_mode,
+        "codex_app_server_goal_worker_plan_schema": (
+            str(
+                codex_app_server_goal_worker_plan.get("schema_version")
+                or CODEX_APP_SERVER_GOAL_WORKER_SCHEMA_VERSION
+            )
+            if codex_app_server_goal_mode
+            else ""
+        ),
+        "codex_app_server_goal_worker_required_methods": (
+            list(
+                codex_app_server_goal_worker_plan.get("methods")
+                or CODEX_APP_SERVER_GOAL_WORKER_METHODS
+            )
+            if codex_app_server_goal_mode
+            else []
+        ),
+        "codex_app_server_goal_worker_turn_start_required": codex_app_server_goal_mode,
+        "codex_app_server_goal_proof_present": False,
         "codex_app_server_goal_required_surface": (
             "codex_app_server_thread_goal_set_get"
             if codex_app_server_goal_mode
@@ -6566,9 +6604,13 @@ def summarize_terminal_bench_private_runner_launch(
     )
     if codex_goal_mode_baseline_claim_allowed:
         codex_goal_mode_baseline_claim_blocker = ""
-    elif codex_app_server_goal_requested:
+    elif codex_app_server_goal_requested and not codex_app_server_goal_adapter_present:
         codex_goal_mode_baseline_claim_blocker = (
             TERMINAL_BENCH_CODEX_APP_SERVER_GOAL_WORKER_SEAM_BLOCKER
+        )
+    elif codex_app_server_goal_requested:
+        codex_goal_mode_baseline_claim_blocker = (
+            TERMINAL_BENCH_CODEX_APP_SERVER_GOAL_TURN_PROOF_BLOCKER
         )
     elif codex_goal_mode_requested:
         codex_goal_mode_baseline_claim_blocker = "missing_codex_app_server_goal_proof"
@@ -6595,6 +6637,22 @@ def summarize_terminal_bench_private_runner_launch(
         "codex_app_server_goal_baseline_requested": codex_app_server_goal_requested,
         "codex_app_server_goal_worker_adapter_present": (
             codex_app_server_goal_adapter_present
+        ),
+        "codex_app_server_goal_worker_plan_schema": str(
+            launch.get("codex_app_server_goal_worker_plan_schema") or ""
+        )[:100],
+        "codex_app_server_goal_worker_required_methods": [
+            str(method or "")[:80]
+            for method in (
+                launch.get("codex_app_server_goal_worker_required_methods")
+                if isinstance(
+                    launch.get("codex_app_server_goal_worker_required_methods"), list
+                )
+                else []
+            )
+        ],
+        "codex_app_server_goal_worker_turn_start_required": (
+            launch.get("codex_app_server_goal_worker_turn_start_required") is True
         ),
         "codex_app_server_goal_proof_present": codex_app_server_goal_proof_present,
         "codex_goal_mode_invocation_surface": codex_goal_mode_invocation_surface,
@@ -9176,11 +9234,15 @@ def build_terminal_bench_benchmark_run(
                         "codex_app_server_thread_goal_set_get"
                     ),
                     "codex_app_server_goal_baseline_requested": True,
-                    "codex_app_server_goal_worker_adapter_present": False,
+                    "codex_app_server_goal_worker_adapter_present": True,
+                    "codex_app_server_goal_worker_plan_schema": (
+                        CODEX_APP_SERVER_GOAL_WORKER_SCHEMA_VERSION
+                    ),
+                    "codex_app_server_goal_worker_turn_start_required": True,
                     "codex_app_server_goal_proof_present": False,
                     "codex_goal_mode_baseline_claim_allowed": False,
                     "codex_goal_mode_baseline_claim_blocker": (
-                        TERMINAL_BENCH_CODEX_APP_SERVER_GOAL_WORKER_SEAM_BLOCKER
+                        TERMINAL_BENCH_CODEX_APP_SERVER_GOAL_TURN_PROOF_BLOCKER
                     ),
                     "goal_harness_access_packet_absent": True,
                     "goal_harness_cli_bridge_absent": True,
@@ -9196,7 +9258,7 @@ def build_terminal_bench_benchmark_run(
                 "slash_command_is_unverified_fallback": False,
                 "baseline_claim_allowed": False,
                 "first_blocker": (
-                    TERMINAL_BENCH_CODEX_APP_SERVER_GOAL_WORKER_SEAM_BLOCKER
+                    TERMINAL_BENCH_CODEX_APP_SERVER_GOAL_TURN_PROOF_BLOCKER
                 ),
             }
         if active_cli_bridge_preflight:

--- a/goal_harness/codex_goal_baseline.py
+++ b/goal_harness/codex_goal_baseline.py
@@ -18,6 +18,10 @@ CODEX_APP_SERVER_GOAL_BASELINE_SCHEMA_VERSION = (
 CODEX_APP_SERVER_GOAL_BASELINE_PROOF_SCHEMA_VERSION = (
     "codex_app_server_goal_baseline_proof_v0"
 )
+CODEX_APP_SERVER_GOAL_WORKER_SCHEMA_VERSION = "codex_app_server_goal_worker_v0"
+CODEX_APP_SERVER_GOAL_WORKER_PROOF_SCHEMA_VERSION = (
+    "codex_app_server_goal_worker_proof_v0"
+)
 DEFAULT_CODEX_GOAL_BASELINE_CLIENT_NAME = "goal_harness_benchmark_goal_baseline"
 DEFAULT_CODEX_GOAL_BASELINE_CLIENT_TITLE = "Goal Harness Benchmark Goal Baseline"
 DEFAULT_CODEX_GOAL_BASELINE_CLIENT_VERSION = "0.1.0"
@@ -26,6 +30,10 @@ CODEX_APP_SERVER_GOAL_METHODS = (
     "thread/start",
     "thread/goal/set",
     "thread/goal/get",
+)
+CODEX_APP_SERVER_GOAL_WORKER_METHODS = (
+    *CODEX_APP_SERVER_GOAL_METHODS,
+    "turn/start",
 )
 
 
@@ -133,11 +141,116 @@ def build_codex_app_server_goal_baseline_plan(
     }
 
 
+def build_codex_app_server_goal_worker_plan(
+    *,
+    objective: str,
+    task_instruction: str,
+    cwd: str = "<benchmark-workspace>",
+    sandbox: str = "workspace-write",
+    approval_policy: str = "never",
+    status: str = "active",
+    token_budget: int | None = None,
+    model: str | None = None,
+    effort: str | None = None,
+    client_name: str = DEFAULT_CODEX_GOAL_BASELINE_CLIENT_NAME,
+    client_title: str = DEFAULT_CODEX_GOAL_BASELINE_CLIENT_TITLE,
+    client_version: str = DEFAULT_CODEX_GOAL_BASELINE_CLIENT_VERSION,
+) -> dict[str, Any]:
+    """Describe the app-server Goal worker path used by benchmark launches.
+
+    This is still a compact control contract, not a benchmark result. A scored
+    baseline needs both persistent Goal proof and `turn/start` proof for the
+    benchmark task inside the case launch.
+    """
+
+    task_text = str(task_instruction or "").strip()
+    if not task_text:
+        raise ValueError("task_instruction must be non-empty")
+
+    plan = build_codex_app_server_goal_baseline_plan(
+        objective=objective,
+        cwd=cwd,
+        sandbox=sandbox,
+        approval_policy=approval_policy,
+        status=status,
+        token_budget=token_budget,
+        client_name=client_name,
+        client_title=client_title,
+        client_version=client_version,
+    )
+    turn_start_params: dict[str, Any] = {
+        "threadId": "<thread-id>",
+        "input": [{"type": "text", "text": task_text}],
+        "cwd": cwd,
+        "approvalPolicy": approval_policy,
+    }
+    if model:
+        turn_start_params["model"] = str(model)
+    if effort:
+        turn_start_params["effort"] = str(effort)
+
+    worker_messages = dict(plan["messages"])
+    worker_messages["turn_start"] = {
+        "id": 5,
+        "method": "turn/start",
+        "params": turn_start_params,
+    }
+
+    return {
+        **plan,
+        "schema_version": CODEX_APP_SERVER_GOAL_WORKER_SCHEMA_VERSION,
+        "worker_mode": "codex_app_server_goal_turn",
+        "methods": list(CODEX_APP_SERVER_GOAL_WORKER_METHODS),
+        "task_instruction_sha256": stable_text_digest(task_text),
+        "task_instruction_chars": len(task_text),
+        "messages": worker_messages,
+        "claim_boundary": {
+            **plan["claim_boundary"],
+            "requires_turn_start_evidence": True,
+            "turn_start_input_must_match_task": True,
+        },
+    }
+
+
 def _goal_from_response(response: dict[str, Any] | None) -> dict[str, Any]:
     if not isinstance(response, dict):
         return {}
     goal = response.get("goal")
     return goal if isinstance(goal, dict) else {}
+
+
+def _turn_from_response(response: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(response, dict):
+        return {}
+    turn = response.get("turn")
+    return turn if isinstance(turn, dict) else {}
+
+
+def _turn_start_input_text(request: dict[str, Any] | None) -> str:
+    if not isinstance(request, dict):
+        return ""
+    params = request.get("params")
+    if not isinstance(params, dict):
+        return ""
+    inputs = params.get("input")
+    if not isinstance(inputs, list):
+        return ""
+    texts: list[str] = []
+    for item in inputs:
+        if not isinstance(item, dict):
+            continue
+        if item.get("type") == "text" and isinstance(item.get("text"), str):
+            texts.append(item["text"])
+    return "\n".join(texts).strip()
+
+
+def _turn_start_thread_id(request: dict[str, Any] | None) -> str:
+    if not isinstance(request, dict):
+        return ""
+    params = request.get("params")
+    if not isinstance(params, dict):
+        return ""
+    return str(params.get("threadId") or "")
 
 
 def compact_goal(goal: dict[str, Any]) -> dict[str, Any]:
@@ -151,6 +264,20 @@ def compact_goal(goal: dict[str, Any]) -> dict[str, Any]:
         "token_budget_present": goal.get("tokenBudget") is not None,
         "tokens_used": goal.get("tokensUsed"),
         "time_used_seconds": goal.get("timeUsedSeconds"),
+    }
+
+
+def compact_turn(turn: dict[str, Any]) -> dict[str, Any]:
+    status = str(turn.get("status") or "")
+    return {
+        "turn_id_present": bool(turn.get("id")),
+        "status": status or None,
+        "items_count": len(turn.get("items") or [])
+        if isinstance(turn.get("items"), list)
+        else None,
+        "started_at_present": turn.get("startedAt") is not None,
+        "completed_at_present": turn.get("completedAt") is not None,
+        "error_present": turn.get("error") is not None,
     }
 
 
@@ -230,6 +357,88 @@ def build_codex_app_server_goal_baseline_proof(
             "raw_transcript_recorded": bool(raw_transcript_recorded),
             "credentials_read_or_recorded": bool(credentials_read_or_recorded),
         },
+    }
+
+
+def build_codex_app_server_goal_worker_proof(
+    *,
+    set_response: dict[str, Any] | None,
+    get_response: dict[str, Any] | None,
+    turn_start_request: dict[str, Any] | None,
+    turn_start_response: dict[str, Any] | None,
+    expected_objective: str | None = None,
+    expected_task_instruction: str | None = None,
+    expected_status: str = "active",
+    notifications: list[str] | None = None,
+    used_codex_exec: bool = False,
+    used_slash_prefix_prompt: bool = False,
+    included_goal_harness_state: bool = False,
+    raw_paths_recorded: bool = False,
+    raw_transcript_recorded: bool = False,
+    credentials_read_or_recorded: bool = False,
+) -> dict[str, Any]:
+    """Reduce app-server Goal plus turn-start responses into worker evidence."""
+
+    baseline = build_codex_app_server_goal_baseline_proof(
+        set_response=set_response,
+        get_response=get_response,
+        expected_objective=expected_objective,
+        expected_status=expected_status,
+        notifications=notifications,
+        used_codex_exec=used_codex_exec,
+        used_slash_prefix_prompt=used_slash_prefix_prompt,
+        included_goal_harness_state=included_goal_harness_state,
+        raw_paths_recorded=raw_paths_recorded,
+        raw_transcript_recorded=raw_transcript_recorded,
+        credentials_read_or_recorded=credentials_read_or_recorded,
+    )
+    set_goal = _goal_from_response(set_response)
+    turn = _turn_from_response(turn_start_response)
+    request_thread_id = _turn_start_thread_id(turn_start_request)
+    goal_thread_id = str(set_goal.get("threadId") or "")
+    task_text = _turn_start_input_text(turn_start_request)
+    expected_task = str(expected_task_instruction or "").strip()
+    task_matches = bool(task_text) and (
+        not expected_task or task_text == expected_task
+    )
+    thread_matches = bool(goal_thread_id) and request_thread_id == goal_thread_id
+    turn_started = bool(turn.get("id")) and bool(str(turn.get("status") or ""))
+    worker_claim_allowed = bool(
+        baseline.get("baseline_claim_allowed")
+        and thread_matches
+        and task_matches
+        and turn_started
+    )
+
+    return {
+        "schema_version": CODEX_APP_SERVER_GOAL_WORKER_PROOF_SCHEMA_VERSION,
+        "surface": "codex_app_server",
+        "baseline_mode": "codex_goal_mode",
+        "worker_mode": "codex_app_server_goal_turn",
+        "persistent_goal_evidence": bool(baseline.get("persistent_goal_evidence")),
+        "turn_start_evidence": bool(turn_started),
+        "baseline_claim_allowed": worker_claim_allowed,
+        "required_methods_observed": {
+            **baseline.get("required_methods_observed", {}),
+            "turn_start": bool(turn_started),
+        },
+        "matches": {
+            **baseline.get("matches", {}),
+            "turn_thread": thread_matches,
+            "task_instruction": task_matches,
+        },
+        "set_goal": baseline.get("set_goal", {}),
+        "get_goal": baseline.get("get_goal", {}),
+        "turn": compact_turn(turn),
+        "task_instruction": {
+            "present": bool(task_text),
+            "sha256": stable_text_digest(task_text) if task_text else None,
+            "chars": len(task_text),
+            "raw_recorded": False,
+        },
+        "notifications": baseline.get("notifications", []),
+        "negative_controls": baseline.get("negative_controls", {}),
+        "read_boundary": baseline.get("read_boundary", {}),
     }
 
 

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -788,6 +788,7 @@ def _compact_benchmark_preflight_guard(value: Any) -> dict[str, Any]:
         "codex_goal_mode_invocation_surface",
         "codex_goal_mode_required_invocation_surface",
         "codex_goal_mode_baseline_claim_blocker",
+        "codex_app_server_goal_worker_plan_schema",
         "runner_binary_resolution_policy",
         "simulator_setting",
     ):
@@ -809,6 +810,7 @@ def _compact_benchmark_preflight_guard(value: Any) -> dict[str, Any]:
         "codex_app_server_goal_baseline_requested",
         "codex_app_server_goal_worker_adapter_present",
         "codex_app_server_goal_worker_adapter_absent",
+        "codex_app_server_goal_worker_turn_start_required",
         "codex_app_server_goal_proof_present",
         "codex_goal_mode_baseline_claim_allowed",
         "goal_harness_access_packet_absent",
@@ -1218,6 +1220,7 @@ def _compact_benchmark_private_runner_launch(value: Any) -> dict[str, Any]:
         "codex_goal_mode_invocation_surface",
         "codex_goal_mode_required_invocation_surface",
         "codex_goal_mode_baseline_claim_blocker",
+        "codex_app_server_goal_worker_plan_schema",
         "task_material_readiness_status",
         "task_material_first_blocker",
     ):
@@ -1239,6 +1242,7 @@ def _compact_benchmark_private_runner_launch(value: Any) -> dict[str, Any]:
         "codex_goal_mode_baseline_requested",
         "codex_app_server_goal_baseline_requested",
         "codex_app_server_goal_worker_adapter_present",
+        "codex_app_server_goal_worker_turn_start_required",
         "codex_app_server_goal_proof_present",
         "codex_goal_mode_baseline_claim_allowed",
         "goal_harness_access_packet_absent",

--- a/regression/codex-app-server-goal-baseline-contract.py
+++ b/regression/codex-app-server-goal-baseline-contract.py
@@ -15,12 +15,16 @@ sys.path.insert(0, str(REPO_ROOT))
 from goal_harness.codex_goal_baseline import (  # noqa: E402
     build_codex_app_server_goal_baseline_plan,
     build_codex_app_server_goal_baseline_proof,
+    build_codex_app_server_goal_worker_plan,
+    build_codex_app_server_goal_worker_proof,
     run_isolated_codex_app_server_goal_probe,
 )
 
 
 OBJECTIVE = "Complete the benchmark task and validate the final answer."
+TASK_INSTRUCTION = "Solve the benchmark task, write the answer, and run tests."
 THREAD_ID = "thread-fixture-123"
+TURN_ID = "turn-fixture-456"
 
 
 def assert_plan_contract() -> None:
@@ -108,6 +112,101 @@ def assert_proof_contract() -> None:
     assert leaked_state["baseline_claim_allowed"] is False, leaked_state
 
 
+def assert_worker_plan_and_proof_contract() -> None:
+    plan = build_codex_app_server_goal_worker_plan(
+        objective=OBJECTIVE,
+        task_instruction=TASK_INSTRUCTION,
+        cwd="/workspace/benchmark",
+        model="gpt-5.5",
+        token_budget=200000,
+    )
+    assert plan["schema_version"] == "codex_app_server_goal_worker_v0", plan
+    assert "thread/goal/set" in plan["methods"], plan
+    assert "thread/goal/get" in plan["methods"], plan
+    assert "turn/start" in plan["methods"], plan
+    assert plan["claim_boundary"]["requires_turn_start_evidence"] is True, plan
+    turn_start = plan["messages"]["turn_start"]
+    assert turn_start["method"] == "turn/start", turn_start
+    assert turn_start["params"]["threadId"] == "<thread-id>", turn_start
+    assert turn_start["params"]["input"] == [
+        {"type": "text", "text": TASK_INSTRUCTION}
+    ], turn_start
+    assert turn_start["params"]["model"] == "gpt-5.5", turn_start
+
+    set_response = {
+        "goal": {
+            "threadId": THREAD_ID,
+            "objective": OBJECTIVE,
+            "status": "active",
+            "tokenBudget": 200000,
+            "tokensUsed": 0,
+            "timeUsedSeconds": 0,
+        }
+    }
+    get_response = {
+        "goal": {
+            "threadId": THREAD_ID,
+            "objective": OBJECTIVE,
+            "status": "active",
+            "tokenBudget": 200000,
+            "tokensUsed": 0,
+            "timeUsedSeconds": 0,
+        }
+    }
+    turn_start_request = dict(turn_start)
+    turn_start_request["params"] = dict(turn_start["params"])
+    turn_start_request["params"]["threadId"] = THREAD_ID
+    turn_start_response = {
+        "turn": {
+            "id": TURN_ID,
+            "status": "running",
+            "items": [],
+            "startedAt": 1,
+            "completedAt": None,
+            "error": None,
+        }
+    }
+    proof = build_codex_app_server_goal_worker_proof(
+        set_response=set_response,
+        get_response=get_response,
+        turn_start_request=turn_start_request,
+        turn_start_response=turn_start_response,
+        expected_objective=OBJECTIVE,
+        expected_task_instruction=TASK_INSTRUCTION,
+    )
+    assert proof["persistent_goal_evidence"] is True, proof
+    assert proof["turn_start_evidence"] is True, proof
+    assert proof["baseline_claim_allowed"] is True, proof
+    assert proof["matches"]["turn_thread"] is True, proof
+    assert proof["matches"]["task_instruction"] is True, proof
+    assert proof["task_instruction"]["raw_recorded"] is False, proof
+    assert proof["task_instruction"]["chars"] == len(TASK_INSTRUCTION), proof
+
+    missing_turn = build_codex_app_server_goal_worker_proof(
+        set_response=set_response,
+        get_response=get_response,
+        turn_start_request=turn_start_request,
+        turn_start_response=None,
+        expected_objective=OBJECTIVE,
+        expected_task_instruction=TASK_INSTRUCTION,
+    )
+    assert missing_turn["persistent_goal_evidence"] is True, missing_turn
+    assert missing_turn["turn_start_evidence"] is False, missing_turn
+    assert missing_turn["baseline_claim_allowed"] is False, missing_turn
+
+    wrong_task = build_codex_app_server_goal_worker_proof(
+        set_response=set_response,
+        get_response=get_response,
+        turn_start_request=turn_start_request,
+        turn_start_response=turn_start_response,
+        expected_objective=OBJECTIVE,
+        expected_task_instruction="Different task",
+    )
+    assert wrong_task["turn_start_evidence"] is True, wrong_task
+    assert wrong_task["baseline_claim_allowed"] is False, wrong_task
+    assert wrong_task["matches"]["task_instruction"] is False, wrong_task
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -119,6 +218,7 @@ def main() -> int:
 
     assert_plan_contract()
     assert_proof_contract()
+    assert_worker_plan_and_proof_contract()
 
     if args.real_codex:
         result = run_isolated_codex_app_server_goal_probe(


### PR DESCRIPTION
## Summary
- Add a public Codex app-server Goal worker contract that extends the existing `thread/goal/set` + `thread/goal/get` baseline seam with `turn/start` request/proof reduction.
- Move Terminal-Bench `codex-app-server-goal` dry-run status from `worker_seam_not_implemented` to the narrower fail-closed blocker `terminal_bench_app_server_goal_turn_start_proof_missing`.
- Update docs, status compaction, and focused regression/smoke coverage so adapter-present and proof-present stay separate.

## Validation
- `python3 -m py_compile goal_harness/codex_goal_baseline.py goal_harness/benchmark_adapters/terminal_bench.py goal_harness/status.py examples/terminal-bench-private-runner-env-guard-smoke.py regression/codex-app-server-goal-baseline-contract.py`
- `python3 regression/codex-app-server-goal-baseline-contract.py`
- `python3 examples/benchmark-developer-workflow-doc-smoke.py`
- `python3 examples/terminal-bench-private-runner-env-guard-smoke.py`
- `python3 -m goal_harness.cli --format json benchmark launch-terminal-bench-run terminal-bench --mode codex-app-server-goal --include-task-name hello-world --jobs-dir '<private-jobs-dir>' --run-root terminal-bench-app-server-goal-probe --job-name terminal_bench_app_server_goal_probe --wait-seconds 0 --materialization-wait-seconds 0`
- `goal-harness check --scan-path ...` (public scan clean; existing duplicate-index warning only)
- `git diff --check`

## Boundary
No raw benchmark logs, task text, trajectories, credentials, local run dirs, or private ECS details are included. This PR does not launch benchmark jobs and does not claim a scored Codex Goal baseline; it only narrows the next blocker to missing live `turn/start`/case proof.
