### PR TITLE
fix: project capability-runnable candidates

### DIFF
--- a/docs/interaction-pattern-catalog.md
+++ b/docs/interaction-pattern-catalog.md
@@ -118,7 +118,7 @@ Hot-path execution decisions: deliver, fallback, recover, or stay quiet.
 | P0 | IP-001 | Bounded Delivery | Agent | no interruption | implement, validate, write back, spend once |
 | P0 | IP-002 | Blocked Priority With Safe Fallback | Agent plus user-visible notification | notify without requiring an answer | continue safe fallback after exposing blocked higher-priority work |
 | P0 | IP-003 | Scoped Gate With Safe Fallback | User plus agent | notify concrete scoped gate | execute non-dependent fallback; no gated action |
-| P0 | IP-021 | Per-Todo Capability Gate | CLI/controller plus agent | ask only when missing capability is owner-held | select first runnable executable todo; otherwise repair bridge or skip |
+| P0 | IP-021 | Per-Todo Capability Gate | CLI/controller plus agent | ask only when missing capability is owner-held | project runnable executable candidates; agent chooses one, otherwise repair bridge or skip |
 | P0 | IP-007 | Outcome Floor Recovery | Agent | usually no interruption | produce missing outcome-scale evidence or blocker only |
 | P1 | IP-008 | Monitor Quiet Skip | CLI/controller | no notification | append at most one no-spend poll, then stay quiet |
 
@@ -390,11 +390,12 @@ not a permission grant. `status` should project each todo's
 `required_capabilities`; `quota should-run` should derive a read-only
 `capability_gate` over the visible executable queue.
 
-The controller scans executable candidates in projection order. If the first P0
-requires `benchmark_runner` but the second P0 only needs shell/filesystem
-capability, the second P0 is selected before any P1 fallback. If every visible
-P0 is capability-blocked, the first runnable P1/P2 candidate may run, while the
-blocked higher-priority items remain visible in
+The controller scans executable candidates in projection order and classifies
+them, but it does not make the final todo choice. If the first P0 requires
+`benchmark_runner` but the second P0 only needs shell/filesystem capability,
+both the runnable P0 and any later runnable fallback are projected in
+`capability_gate.runnable_candidates`; the agent chooses the actual work item
+after its steering audit. Blocked higher-priority items remain visible in
 `capability_gate.blocked_candidates`.
 
 If no visible executable todo can run, the gate chooses:
@@ -416,14 +417,15 @@ preflight and accounting phases agree.
 flowchart TD
   Q["quota should-run"] --> E["visible executable todo queue"]
   E --> C{"candidate required_capabilities satisfied?"}
-  C -->|"yes"| R["select first runnable todo"]
+  C -->|"yes"| R["add to runnable_candidates"]
   C -->|"no, more candidates"| B["add to blocked_candidates"]
   B --> E
   C -->|"no candidates runnable"| M{"missing capability class"}
   M -->|"bridge"| P["repair_bridge"]
   M -->|"owner-held"| U["ask_owner with concrete capability ask"]
   M -->|"unsupported"| S["skip without spend"]
-  R --> V["validate selected work"]
+  R --> A["agent steering audit chooses one runnable todo"]
+  A --> V["validate chosen work"]
   V --> W["write back and spend-slot with same available capabilities"]
 ```
 

--- a/docs/interaction-pattern-catalog.md
+++ b/docs/interaction-pattern-catalog.md
@@ -118,7 +118,7 @@ Hot-path execution decisions: deliver, fallback, recover, or stay quiet.
 | P0 | IP-001 | Bounded Delivery | Agent | no interruption | implement, validate, write back, spend once |
 | P0 | IP-002 | Blocked Priority With Safe Fallback | Agent plus user-visible notification | notify without requiring an answer | continue safe fallback after exposing blocked higher-priority work |
 | P0 | IP-003 | Scoped Gate With Safe Fallback | User plus agent | notify concrete scoped gate | execute non-dependent fallback; no gated action |
-| P0 | IP-021 | Per-Todo Capability Gate | CLI/controller plus agent | ask only when missing capability is owner-held | project runnable executable candidates; agent chooses one, otherwise repair bridge or skip |
+| P0 | IP-021 | Per-Todo Capability Gate | CLI projects, agent decides | ask only when missing capability is owner-held | expose runnable executable candidates; agent chooses one, otherwise repair bridge or skip |
 | P0 | IP-007 | Outcome Floor Recovery | Agent | usually no interruption | produce missing outcome-scale evidence or blocker only |
 | P1 | IP-008 | Monitor Quiet Skip | CLI/controller | no notification | append at most one no-spend poll, then stay quiet |
 
@@ -394,9 +394,19 @@ The controller scans executable candidates in projection order and classifies
 them, but it does not make the final todo choice. If the first P0 requires
 `benchmark_runner` but the second P0 only needs shell/filesystem capability,
 both the runnable P0 and any later runnable fallback are projected in
-`capability_gate.runnable_candidates`; the agent chooses the actual work item
-after its steering audit. Blocked higher-priority items remain visible in
-`capability_gate.blocked_candidates`.
+`capability_gate.runnable_candidates`; blocked higher-priority items remain
+visible in `capability_gate.blocked_candidates`. `recommended_action` remains
+routing context, not a chosen runnable todo.
+
+When `capability_gate.action=run`, the decision contract is:
+
+- `decision_owner=agent`;
+- `selection_policy=agent_steering_audit_over_runnable_candidates`;
+- `runnable_candidates` is the allowed candidate set for this turn;
+- `blocked_candidates` is the visible set of higher- or same-priority work
+  that cannot currently run;
+- the agent must choose the actual todo from `runnable_candidates`, then
+  validate and write back that chosen work.
 
 If no visible executable todo can run, the gate chooses:
 
@@ -431,11 +441,11 @@ flowchart TD
 
 **Bad smell**
 
-The system treats quota eligibility as proof that the selected todo can run,
+The system treats quota eligibility as proof that the nearest todo can run,
 then repeatedly fails on missing benchmark/network/tooling capability. The
 opposite bad smell is over-blocking: one P0 needs a missing runner, but another
-P0 or P1 is runnable and safe; the controller freezes instead of selecting the
-first capability-runnable candidate.
+P0 or P1 is runnable and safe; the controller freezes instead of projecting the
+runnable set for the agent to choose from.
 
 **Validation**
 

--- a/docs/project-agent-todo-contract.md
+++ b/docs/project-agent-todo-contract.md
@@ -337,13 +337,14 @@ goal-harness todo add \
 `status` projects `required_capabilities` on every visible todo. `quota
 should-run` then derives a read-only `capability_gate` from the visible
 executable queue, not from a single preselected todo. With multiple P0 or P1
-items, it scans the projected queue in order: if the first P0 is capability
-blocked but the second P0 can run, the second P0 is selected; only when the
-visible P0 candidates are blocked does it fall through to the first runnable
-P1/P2 candidate. Blocked higher-priority candidates remain visible in
-`capability_gate.blocked_candidates`. If no visible executable candidate can
-run, the gate returns `repair_bridge`, `ask_owner`, or `skip` according to the
-missing capability class.
+items, it scans the projected queue in order and exposes the candidate set:
+capability-satisfied todos appear in `capability_gate.runnable_candidates`,
+while blocked higher-priority candidates remain visible in
+`capability_gate.blocked_candidates`. The gate does not choose the final todo;
+the agent keeps decision authority and must pick from the runnable set during
+its steering audit. If no visible executable candidate can run, the gate returns
+`repair_bridge`, `ask_owner`, or `skip` according to the missing capability
+class.
 
 ## Execution Order
 

--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -288,7 +288,11 @@ The resulting `capability_gate` is a read-only projection:
   "action": "run",
   "required": ["shell", "filesystem_write"],
   "missing": [],
-  "selected_todo": {"todo_id": "todo_docs"},
+  "decision_owner": "agent",
+  "selection_policy": "agent_steering_audit_over_runnable_candidates",
+  "runnable_candidates": [
+    {"todo_id": "todo_docs"}
+  ],
   "blocked_candidates": [
     {
       "todo_id": "todo_eval",
@@ -300,11 +304,13 @@ The resulting `capability_gate` is a read-only projection:
 ```
 
 Multiple P0/P1 items are handled as an ordered queue, not as a single selected
-todo. The guard scans visible executable candidates in projection order:
-another runnable P0 beats any P1 fallback; if all visible P0 candidates are
-blocked, the first runnable P1/P2 candidate may run while blocked
-higher-priority candidates stay visible in `blocked_candidates`. If every
-visible executable candidate is missing a capability, the gate returns
+todo. The guard scans visible executable candidates in projection order and
+projects which candidates are actually runnable in `runnable_candidates`; the
+agent then chooses which runnable item to advance during its steering audit. A
+runnable P0 remains visible before any P1 fallback, but Goal Harness does not
+turn that ordering into an automatic final choice. Blocked higher-priority
+candidates stay visible in `blocked_candidates`. If every visible executable
+candidate is missing a capability, the gate returns
 `action=repair_bridge` for repairable local bridges such as
 `benchmark_runner`/`external_evidence_poll`, `action=ask_owner` for owner-held
 capabilities such as `network`/`credentials`/`production_access`, or

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -779,6 +779,15 @@ Item fields:
   primary action surface, while monitor items are supplemental context that
   should not consume the selected goal's advancement slot unless they record a
   material transition or blocker.
+- `capability_gate`: optional per-goal quota projection derived from visible
+  executable agent todos that declare `required_capabilities`. When
+  `action=run`, the gate projects `runnable_candidates` and
+  `blocked_candidates`; `decision_owner=agent` means the agent chooses the
+  actual todo from the runnable set during its steering audit. The gate must
+  not rewrite `recommended_action` into a single selected todo. When no visible
+  executable candidate is runnable, the gate owns the decision and returns
+  `repair_bridge`, `ask_owner`, or `skip` with concrete missing capability
+  details.
 - `project_asset.todo_projection_gap`: optional explicit gap object emitted
   when status cannot project `user_todos` and/or `agent_todos` for a connected
   project. This means "the first-screen todo state is unknown", not "there are

--- a/examples/capability-gate-smoke.py
+++ b/examples/capability-gate-smoke.py
@@ -128,9 +128,14 @@ def main() -> int:
     assert p0_fallback["should_run"] is True, p0_fallback
     assert p0_fallback["normal_delivery_allowed"] is True, p0_fallback
     assert p0_fallback["capability_gate"]["action"] == "run", p0_fallback
-    assert p0_fallback["capability_gate"]["selected_todo"]["todo_id"] == "todo_capability_2", p0_fallback
+    assert p0_fallback["capability_gate"]["decision_owner"] == "agent", p0_fallback
+    assert [
+        item["todo_id"]
+        for item in p0_fallback["capability_gate"]["runnable_candidates"]
+    ] == ["todo_capability_2", "todo_capability_5"], p0_fallback
     assert p0_fallback["capability_gate"]["blocked_candidates"][0]["todo_id"] == "todo_capability_1", p0_fallback
-    assert "Validate the public control-plane docs" in p0_fallback["recommended_action"], p0_fallback
+    assert "Run the benchmark runner once" in p0_fallback["recommended_action"], p0_fallback
+    assert "choose one of 2 capability-runnable todo(s)" in p0_fallback["protocol_action_packet"]["summary"], p0_fallback
 
     fallback = build_quota_should_run(
         status_payload([p0_benchmark, p0_network, p1_gpu, p1_docs]),
@@ -140,7 +145,9 @@ def main() -> int:
     assert fallback["should_run"] is True, fallback
     assert fallback["normal_delivery_allowed"] is True, fallback
     assert fallback["capability_gate"]["action"] == "run", fallback
-    assert fallback["capability_gate"]["selected_todo"]["todo_id"] == "todo_capability_5", fallback
+    assert [item["todo_id"] for item in fallback["capability_gate"]["runnable_candidates"]] == [
+        "todo_capability_5",
+    ], fallback
     assert [item["todo_id"] for item in fallback["capability_gate"]["blocked_candidates"]] == [
         "todo_capability_1",
         "todo_capability_3",
@@ -149,8 +156,8 @@ def main() -> int:
     assert fallback["capability_gate"]["blocked_candidates"][0]["missing_capabilities"] == ["benchmark_runner"], fallback
     assert fallback["capability_gate"]["blocked_candidates"][1]["missing_capabilities"] == ["network"], fallback
     assert fallback["capability_gate"]["blocked_candidates"][2]["missing_capabilities"] == ["gpu_runner"], fallback
-    assert "Refresh the public docs fallback" in fallback["recommended_action"], fallback
-    assert "Refresh the public docs fallback" in fallback["protocol_action_packet"]["summary"], fallback
+    assert "Run the benchmark runner once" in fallback["recommended_action"], fallback
+    assert "choose one of 1 capability-runnable todo(s)" in fallback["protocol_action_packet"]["summary"], fallback
 
     benchmark_ready = build_quota_should_run(
         status_payload([p0_benchmark, p0_validate, p1_docs]),
@@ -158,7 +165,10 @@ def main() -> int:
         available_capabilities=["shell", "filesystem_write", "benchmark_runner"],
     )
     assert benchmark_ready["capability_gate"]["action"] == "run", benchmark_ready
-    assert benchmark_ready["capability_gate"]["selected_todo"]["todo_id"] == "todo_capability_1", benchmark_ready
+    assert [
+        item["todo_id"]
+        for item in benchmark_ready["capability_gate"]["runnable_candidates"]
+    ] == ["todo_capability_1", "todo_capability_2", "todo_capability_5"], benchmark_ready
     assert benchmark_ready["capability_gate"]["blocked_candidates"] == [], benchmark_ready
 
     spend_preview = build_quota_slot_preview(
@@ -168,7 +178,7 @@ def main() -> int:
     )
     assert spend_preview["ok"] is True, spend_preview
     assert spend_preview["before"]["normal_delivery_allowed"] is True, spend_preview
-    assert spend_preview["before"]["capability_gate"]["selected_todo"]["todo_id"] == "todo_capability_1", spend_preview
+    assert spend_preview["before"]["capability_gate"]["runnable_candidates"][0]["todo_id"] == "todo_capability_1", spend_preview
 
     bridge_missing = build_quota_should_run(
         status_payload([p0_benchmark]),

--- a/goal_harness/quota.py
+++ b/goal_harness/quota.py
@@ -1029,9 +1029,8 @@ def _capability_gate(
 
     available = _available_capabilities(available_capabilities)
     blocked: list[dict[str, Any]] = []
+    runnable: list[dict[str, Any]] = []
     saw_requirement = False
-    selected_item: dict[str, Any] | None = None
-    selected_required: list[str] = []
     for item in candidates:
         required = normalize_required_capabilities(item.get("required_capabilities"))
         if required:
@@ -1040,30 +1039,35 @@ def _capability_gate(
         if missing:
             blocked.append(_capability_candidate_item(item, missing=missing))
             continue
-        selected_item = item
-        selected_required = required
-        break
+        runnable.append(_capability_candidate_item(item, missing=[]))
 
     if not saw_requirement and not blocked:
         return None
-    if selected_item is not None:
-        selected_text = str(selected_item.get("text") or "").strip()
-        selected = _compact_todo_summary_item(selected_item, text=selected_text)
-        selected["required_capabilities"] = selected_required
+    if runnable:
+        runnable_required: list[str] = []
+        blocked_missing: list[str] = []
+        for item in runnable:
+            for capability in item.get("required_capabilities") or []:
+                if capability not in runnable_required:
+                    runnable_required.append(str(capability))
+        for item in blocked:
+            for capability in item.get("missing_capabilities") or []:
+                if capability not in blocked_missing:
+                    blocked_missing.append(str(capability))
         return {
             "schema_version": CAPABILITY_GATE_SCHEMA_VERSION,
             "source": source,
-            "required": selected_required,
+            "required": runnable_required,
             "available": available,
             "missing": [],
             "action": "run",
-            "selected_todo": selected,
+            "decision_owner": "agent",
+            "selection_policy": "agent_steering_audit_over_runnable_candidates",
+            "runnable_count": len(runnable),
+            "runnable_candidates": runnable,
             "blocked_candidates": blocked,
-            "reason": (
-                "selected executable todo capability requirements are satisfied"
-                if not blocked
-                else "higher-priority executable todo(s) are capability-blocked; selected first runnable fallback"
-            ),
+            "blocked_missing": blocked_missing,
+            "reason": "capability gate projected runnable candidate set; agent chooses the actual todo",
         }
 
     missing_all: list[str] = []
@@ -1083,6 +1087,10 @@ def _capability_gate(
         "available": available,
         "missing": missing_all,
         "action": action,
+        "decision_owner": "capability_gate",
+        "selection_policy": "no_runnable_candidate",
+        "runnable_count": 0,
+        "runnable_candidates": [],
         "blocked_candidates": blocked,
         "blocks_delivery": True,
         "reason": "all visible executable todo candidates require unavailable capabilities",
@@ -1790,14 +1798,16 @@ def _protocol_first_candidate_action(payload: dict[str, Any]) -> str | None:
         else {}
     )
     if capability_gate.get("action") == "run":
-        selected_capability_todo = (
-            capability_gate.get("selected_todo")
-            if isinstance(capability_gate.get("selected_todo"), dict)
-            else {}
+        runnable_candidates = (
+            capability_gate.get("runnable_candidates")
+            if isinstance(capability_gate.get("runnable_candidates"), list)
+            else []
         )
-        text = _protocol_action_label(selected_capability_todo.get("text"))
-        if text:
-            return text
+        if runnable_candidates:
+            return (
+                f"choose one of {len(runnable_candidates)} "
+                "capability-runnable todo(s) after steering audit"
+            )
     scoped_fallback = (
         payload.get("scoped_user_gate_fallback")
         if isinstance(payload.get("scoped_user_gate_fallback"), dict)
@@ -4300,14 +4310,7 @@ def build_quota_should_run(
             work_lane_contract=work_lane_contract,
         )
         if capability_gate:
-            if capability_gate.get("action") == "run":
-                selected_todo = (
-                    capability_gate.get("selected_todo")
-                    if isinstance(capability_gate.get("selected_todo"), dict)
-                    else {}
-                )
-                selected_recommended_action = selected_todo.get("text") or selected_recommended_action
-            elif capability_gate.get("action") in {"repair_bridge", "ask_owner", "skip"}:
+            if capability_gate.get("action") in {"repair_bridge", "ask_owner", "skip"}:
                 selected_recommended_action = (
                     capability_gate.get("owner_action")
                     or capability_gate.get("reason")
@@ -5675,17 +5678,15 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
             f"required={capability_gate.get('required')} "
             f"missing={capability_gate.get('missing')}"
         )
-        selected_todo = (
-            capability_gate.get("selected_todo")
-            if isinstance(capability_gate.get("selected_todo"), dict)
-            else {}
+        if capability_gate.get("decision_owner"):
+            lines.append(f"- capability_gate_decision_owner: {capability_gate.get('decision_owner')}")
+        runnable_candidates = (
+            capability_gate.get("runnable_candidates")
+            if isinstance(capability_gate.get("runnable_candidates"), list)
+            else []
         )
-        if selected_todo.get("todo_id") or selected_todo.get("text"):
-            lines.append(
-                "- capability_gate_selected: "
-                f"todo_id={selected_todo.get('todo_id')} "
-                f"text={selected_todo.get('text')}"
-            )
+        if runnable_candidates:
+            lines.append(f"- capability_gate_runnable_candidates: `{len(runnable_candidates)}`")
         blocked_candidates = (
             capability_gate.get("blocked_candidates")
             if isinstance(capability_gate.get("blocked_candidates"), list)


### PR DESCRIPTION
## Summary
- change capability_gate from selecting one runnable todo to projecting runnable_candidates and blocked_candidates
- keep recommended_action as routing context; agents choose the actual runnable todo during steering audit
- update quota/docs/catalog contracts and capability gate smoke coverage for multiple P0/P1 candidates

## Validation
- python3 -m py_compile goal_harness/quota.py goal_harness/cli.py
- python3 examples/capability-gate-smoke.py
- python3 examples/quota-plan-smoke.py
- python3 examples/status-markdown-smoke.py
- python3 examples/docs-governance-smoke.py
- goal-harness check --scan-path goal_harness/quota.py --scan-path examples/capability-gate-smoke.py --scan-path docs/quota-allocation.md --scan-path docs/interaction-pattern-catalog.md --scan-path docs/project-agent-todo-contract.md --scan-path docs/status-data-contract.md
- git diff --check

## Note
This changes runtime quota semantics, so it is intentionally left for primary review instead of side-agent self-merge.