### PR TITLE
feat: project claimed todo visibility lanes

### DIFF
--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -818,9 +818,28 @@ Item fields:
   their automation/handoff scope. `todo_id` is first-class when written by the
   todo CLI; legacy Markdown without metadata still gets a parser-derived
   compatibility id from the current item text and section, and the first
-  lifecycle command materializes that id back into metadata. Optional future
-  fields such as `created_at`, lease TTLs, dependencies, or evidence links
-  should extend this item shape rather than inventing another todo surface.
+  lifecycle command materializes that id back into metadata.
+  The first open item is still available through `first_open_items` for older
+  heartbeats. Frontstage consumers should not treat that top-N scheduler view
+  as the whole backlog. Todo summaries may also project visibility lanes:
+  `unclaimed_priority_open_items` for priority-ranked unclaimed candidates,
+  `claimed_open_items` for claimed work that may be outside the top-N,
+  `claimed_advancement_open_items` for claimed executable delivery work, and
+  `claimed_monitor_open_items` for claimed continuous-monitor work. Agent-aware
+  quota/status projections may further include
+  `current_agent_claimed_open_items`,
+  `current_agent_claimed_advancement_items`,
+  `current_agent_claimed_monitor_items`, and `claimed_by_others_items`.
+  The scheduler can still select from a narrower executable candidate set; the
+  dashboard/frontstage uses these lanes to keep ownership visible. Visibility
+  lanes may be wider than scheduler lanes, but remain bounded; the default
+  agent-facing cap is 16 items per lane. Consumers should use the corresponding
+  counts to indicate when more claimed work exists than is expanded in the
+  current payload, and richer frontstage views should use a future
+  paged/filtered projection instead of forcing larger heartbeat payloads.
+  Optional future fields such as `created_at`, lease TTLs, dependencies, or
+  evidence links should extend this item shape rather than inventing another
+  todo surface.
 - Agent-scoped quota payloads may include
   `agent_todo_summary.claim_scope` with
   `schema_version=side_agent_claim_scope_v0`. For a side agent, the quota guard

--- a/examples/todo-first-open-summary-smoke.py
+++ b/examples/todo-first-open-summary-smoke.py
@@ -36,6 +36,12 @@ BLOCKED_CORE_TODO = (
 FALLBACK_TODO = (
     "[P1] Continue one safe benchmark attribution cleanup while the primary mode is blocked."
 )
+FRONTSTAGE_CLAIMED_TODO = (
+    "[P1] Frontstage dashboard route MVP: render goal_channel_projection_v0 in apps/dashboard."
+)
+FRONTSTAGE_MONITOR_TODO = (
+    "[P2] Repository quality monitor: watch README and dashboard demo freshness."
+)
 
 
 def build_truncated_todo_group() -> dict:
@@ -165,6 +171,10 @@ def build_blocked_priority_fallback_status_payload() -> dict:
                     "id": GOAL_ID,
                     "registry_member": True,
                     "status": "active",
+                    "coordination": {
+                        "primary_agent": "codex-main-control",
+                        "registered_agents": ["codex-main-control", "codex-side-bypass"],
+                    },
                     "quota": {"compute": 1.0, "window_hours": 24},
                     "latest_runs": [],
                 }
@@ -192,6 +202,123 @@ def assert_blocked_priority_fallback_visible() -> None:
     assert "blocked_priority_fallback: notify_user=True" in markdown, markdown
     assert f"blocked_priority_item[1]: {BLOCKED_CORE_TODO}" in markdown, markdown
     assert f"blocked_priority_selected: {FALLBACK_TODO}" in markdown, markdown
+
+
+def assert_claimed_frontstage_lanes_visible() -> None:
+    many_unclaimed = [
+        {
+            "index": index,
+            "done": False,
+            "text": f"[P1] Unclaimed priority backlog item {index}.",
+            "task_class": "advancement_task",
+        }
+        for index in range(1, 14)
+    ]
+    agent_todos = compact_todo_group(
+        [
+            *many_unclaimed,
+            {
+                "index": 40,
+                "done": False,
+                "text": FRONTSTAGE_CLAIMED_TODO,
+                "task_class": "advancement_task",
+                "action_kind": "frontstage_dashboard_route_mvp",
+                "claimed_by": "codex-side-bypass",
+            },
+            {
+                "index": 41,
+                "done": False,
+                "text": FRONTSTAGE_MONITOR_TODO,
+                "task_class": "continuous_monitor",
+                "action_kind": "repository_quality_monitor",
+                "claimed_by": "codex-side-bypass",
+            },
+        ],
+        source_section="Agent Todo",
+        role="agent",
+    )
+    assert agent_todos is not None, agent_todos
+    assert all(item["index"] != 40 for item in agent_todos["first_open_items"]), agent_todos
+    assert all(item["index"] != 40 for item in agent_todos["backlog_items"]), agent_todos
+    assert [item["index"] for item in agent_todos["unclaimed_priority_open_items"]] == list(range(1, 9)), agent_todos
+    assert [item["index"] for item in agent_todos["claimed_open_items"]] == [40, 41], agent_todos
+    assert [item["index"] for item in agent_todos["claimed_advancement_open_items"]] == [40], agent_todos
+    assert [item["index"] for item in agent_todos["claimed_monitor_open_items"]] == [41], agent_todos
+    assert agent_todos["claimed_advancement_open_count"] == 1, agent_todos
+    assert agent_todos["claimed_monitor_open_count"] == 1, agent_todos
+
+    asset_summary = project_asset_todo_summary(agent_todos)
+    assert asset_summary is not None, agent_todos
+    assert [item["index"] for item in asset_summary["unclaimed_priority_open_items"]] == list(range(1, 9)), asset_summary
+    assert [item["index"] for item in asset_summary["claimed_open_items"]] == [40, 41], asset_summary
+    assert [item["index"] for item in asset_summary["claimed_advancement_open_items"]] == [40], asset_summary
+    assert [item["index"] for item in asset_summary["claimed_monitor_open_items"]] == [41], asset_summary
+
+    attention_item = {
+        "goal_id": GOAL_ID,
+        "status": "eligible_with_claimed_frontstage_backlog",
+        "waiting_on": "codex",
+        "severity": "action",
+        "source": "latest_run",
+        "recommended_action": "Use priority candidates for scheduling but keep claimed frontstage work visible.",
+        "coordination": {
+            "primary_agent": "codex-main-control",
+            "registered_agents": ["codex-main-control", "codex-side-bypass"],
+        },
+        "quota": {
+            "compute": 1.0,
+            "slot_minutes": 1,
+            "allowed_slots": 1440,
+            "spent_slots": 0,
+            "state": "eligible",
+            "reason": "eligible fixture",
+        },
+        "project_asset": {
+            "owner": "codex",
+            "next_action": "Use priority candidates for scheduling but keep claimed frontstage work visible.",
+            "stop_condition": "stop on fixture boundary",
+            "agent_todos": asset_summary,
+            "quota": {
+                "compute": 1.0,
+                "slot_minutes": 1,
+                "allowed_slots": 1440,
+                "spent_slots": 0,
+                "state": "eligible",
+                "reason": "eligible fixture",
+            },
+        },
+        "agent_todos": agent_todos,
+    }
+    status_payload = {
+        "ok": True,
+        "attention_queue": {"items": [attention_item]},
+        "run_history": {
+            "goals": [
+                {
+                    "id": GOAL_ID,
+                    "registry_member": True,
+                    "status": "active",
+                    "coordination": {
+                        "primary_agent": "codex-main-control",
+                        "registered_agents": ["codex-main-control", "codex-side-bypass"],
+                    },
+                    "quota": {"compute": 1.0, "window_hours": 24},
+                    "latest_runs": [],
+                }
+            ]
+        },
+    }
+    decision = build_quota_should_run(status_payload, goal_id=GOAL_ID, agent_id="codex-side-bypass")
+    summary = decision["agent_todo_summary"]
+    assert [item["index"] for item in summary["unclaimed_priority_open_items"]] == list(range(1, 9)), summary
+    assert [item["index"] for item in summary["claimed_open_items"]] == [40, 41], summary
+    assert [item["index"] for item in summary["current_agent_claimed_open_items"]] == [40, 41], summary
+    assert [item["index"] for item in summary["current_agent_claimed_advancement_items"]] == [40], summary
+    assert [item["index"] for item in summary["current_agent_claimed_monitor_items"]] == [41], summary
+    assert summary["current_agent_claimed_advancement_count"] == 1, summary
+    assert summary["current_agent_claimed_monitor_count"] == 1, summary
+    assert summary["claim_scope"]["current_agent_claimed_open_count"] == 2, summary
+    assert decision["agent_identity"]["agent_id"] == "codex-side-bypass", decision
 
 
 def main() -> int:
@@ -282,6 +409,7 @@ def main() -> int:
     assert f"Agent 待办：{APPENDED_P0_TODO}" in packet["project_agent_handoff"], packet
     assert f"Agent 待办候选 2：{OPEN_TODO}" in packet["project_agent_handoff"], packet
     assert_blocked_priority_fallback_visible()
+    assert_claimed_frontstage_lanes_visible()
     print("todo-first-open-summary-smoke ok")
     return 0
 

--- a/goal_harness/quota.py
+++ b/goal_harness/quota.py
@@ -155,6 +155,7 @@ CAPABILITY_OWNER_GATE_HINTS = {
     "production_access",
 }
 TODO_BACKLOG_ITEM_LIMIT = 8
+TODO_VISIBILITY_LANE_LIMIT = 16
 TODO_MISSING_PRIORITY_RANK = 50
 TODO_MISSING_INDEX = 999999
 EXTERNAL_EVIDENCE_OBSERVE_PATTERNS = (
@@ -1183,10 +1184,111 @@ def _side_agent_claim_scoped_open_items(
     return selectable_items, claim_scope
 
 
+def _todo_summary_visibility_lanes(
+    open_items: list[dict[str, Any]],
+    *,
+    agent_identity: dict[str, Any] | None,
+) -> dict[str, Any]:
+    claimed_items = [item for item in open_items if normalize_todo_claimed_by(item.get("claimed_by"))]
+    unclaimed_items = [item for item in open_items if not normalize_todo_claimed_by(item.get("claimed_by"))]
+    claimed_advancement_items = [
+        item
+        for item in claimed_items
+        if _todo_item_is_actionable_open(item)
+        if _todo_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
+    ]
+    claimed_monitor_items = [
+        item
+        for item in claimed_items
+        if _todo_item_is_actionable_open(item)
+        if _todo_task_class(item) == TODO_TASK_CLASS_MONITOR
+    ]
+
+    def compact_items(items: list[dict[str, Any]], *, limit: int = TODO_BACKLOG_ITEM_LIMIT) -> list[dict[str, Any]]:
+        return [
+            _compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
+            for item in items[:limit]
+        ]
+
+    lanes: dict[str, Any] = {
+        "unclaimed_priority_open_items": compact_items(unclaimed_items),
+        "claimed_open_items": compact_items(claimed_items, limit=TODO_VISIBILITY_LANE_LIMIT),
+        "claimed_advancement_open_items": compact_items(
+            claimed_advancement_items,
+            limit=TODO_VISIBILITY_LANE_LIMIT,
+        ),
+        "claimed_monitor_open_items": compact_items(
+            claimed_monitor_items,
+            limit=TODO_VISIBILITY_LANE_LIMIT,
+        ),
+    }
+    if claimed_items:
+        lanes["claimed_advancement_open_count"] = len(claimed_advancement_items)
+        lanes["claimed_monitor_open_count"] = len(claimed_monitor_items)
+
+    agent_id = (
+        normalize_todo_claimed_by(agent_identity.get("agent_id"))
+        if isinstance(agent_identity, dict)
+        else None
+    )
+    if agent_id:
+        current_agent_items = [
+            item
+            for item in claimed_items
+            if normalize_todo_claimed_by(item.get("claimed_by")) == agent_id
+        ]
+        claimed_by_others_items = [
+            item
+            for item in claimed_items
+            if normalize_todo_claimed_by(item.get("claimed_by")) != agent_id
+        ]
+        current_agent_advancement_items = [
+            item
+            for item in current_agent_items
+            if _todo_item_is_actionable_open(item)
+            if _todo_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
+        ]
+        current_agent_monitor_items = [
+            item
+            for item in current_agent_items
+            if _todo_item_is_actionable_open(item)
+            if _todo_task_class(item) == TODO_TASK_CLASS_MONITOR
+        ]
+        lanes.update(
+            {
+                "current_agent_claimed_open_items": compact_items(
+                    current_agent_items,
+                    limit=TODO_VISIBILITY_LANE_LIMIT,
+                ),
+                "current_agent_claimed_advancement_items": compact_items(
+                    current_agent_advancement_items,
+                    limit=TODO_VISIBILITY_LANE_LIMIT,
+                ),
+                "current_agent_claimed_monitor_items": compact_items(
+                    current_agent_monitor_items,
+                    limit=TODO_VISIBILITY_LANE_LIMIT,
+                ),
+                "claimed_by_others_items": compact_items(claimed_by_others_items),
+                "current_agent_claimed_open_count": len(current_agent_items),
+                "current_agent_claimed_advancement_count": len(current_agent_advancement_items),
+                "current_agent_claimed_monitor_count": len(current_agent_monitor_items),
+                "claimed_by_others_count": len(claimed_by_others_items),
+            }
+        )
+    return lanes
+
+
 def _todo_summary_source_items(value: dict[str, Any]) -> list[dict[str, Any]]:
     source_keys = (
         "first_open_items",
         "backlog_items",
+        "unclaimed_priority_open_items",
+        "claimed_open_items",
+        "claimed_advancement_open_items",
+        "claimed_monitor_open_items",
+        "current_agent_claimed_open_items",
+        "current_agent_claimed_advancement_items",
+        "current_agent_claimed_monitor_items",
         "items",
     )
     open_items: list[dict[str, Any]] = []
@@ -1266,6 +1368,12 @@ def _summarize_user_todos(
         "backlog_items": open_items[:TODO_BACKLOG_ITEM_LIMIT],
         "executable_backlog_items": executable_items[:TODO_BACKLOG_ITEM_LIMIT],
     }
+    summary.update(
+        _todo_summary_visibility_lanes(
+            all_open_items,
+            agent_identity=agent_identity,
+        )
+    )
     if claimed_open_items or value.get("claimed_open_count"):
         summary["claimed_open_count"] = value.get("claimed_open_count", len(claimed_open_items))
         summary["unclaimed_open_count"] = value.get(
@@ -1333,6 +1441,12 @@ def _summarize_project_asset_todos(
         "backlog_items": open_items[:TODO_BACKLOG_ITEM_LIMIT],
         "executable_backlog_items": executable_items[:TODO_BACKLOG_ITEM_LIMIT],
     }
+    summary.update(
+        _todo_summary_visibility_lanes(
+            all_open_items,
+            agent_identity=agent_identity,
+        )
+    )
     if claimed_open_items or value.get("claimed_open_count"):
         summary["claimed_open_count"] = value.get("claimed_open_count", len(claimed_open_items))
         summary["unclaimed_open_count"] = value.get(

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -333,6 +333,7 @@ MAX_STATUS_TODOS_PER_ROLE = 12
 MAX_ACTIVE_DONE_TODOS_BEFORE_ARCHIVE = MAX_STATUS_TODOS_PER_ROLE
 MAX_PROJECT_ASSET_TODO_ITEMS = 3
 MAX_PROJECT_ASSET_TODO_BACKLOG_ITEMS = 8
+MAX_TODO_VISIBILITY_LANE_ITEMS = 16
 MAX_DEPENDENCY_BLOCKERS = 4
 MAX_AUTONOMOUS_BACKLOG_CANDIDATES = 6
 MAX_SUBAGENT_ACTIVITY_ITEMS = 5
@@ -3655,6 +3656,14 @@ def compact_todo_item(item: dict[str, Any]) -> dict[str, Any]:
     return compact
 
 
+def todo_item_task_class(item: dict[str, Any]) -> str:
+    return normalize_todo_task_class(
+        item.get("task_class"),
+        text=str(item.get("text") or ""),
+        action_kind=item.get("action_kind"),
+    )
+
+
 def todo_item_is_actionable_open(item: dict[str, Any]) -> bool:
     if item.get("done") is True:
         return False
@@ -3700,27 +3709,30 @@ def compact_todo_group(
     budgeted_items = [*open_items, *done_items]
     projected_open_items = sorted(open_items, key=todo_projection_sort_key)
     claimed_open_items = [item for item in projected_open_items if item.get("claimed_by")]
+    unclaimed_open_items = [item for item in projected_open_items if not item.get("claimed_by")]
     executable_items = [
         item
         for item in projected_open_items
         if todo_item_is_actionable_open(item)
-        if normalize_todo_task_class(
-            item.get("task_class"),
-            text=str(item.get("text") or ""),
-            action_kind=item.get("action_kind"),
-        )
-        == TODO_TASK_CLASS_ADVANCEMENT
+        if todo_item_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
     ]
     monitor_items = [
         item
         for item in projected_open_items
         if todo_item_is_actionable_open(item)
-        if normalize_todo_task_class(
-            item.get("task_class"),
-            text=str(item.get("text") or ""),
-            action_kind=item.get("action_kind"),
-        )
-        == TODO_TASK_CLASS_MONITOR
+        if todo_item_task_class(item) == TODO_TASK_CLASS_MONITOR
+    ]
+    claimed_advancement_items = [
+        item
+        for item in claimed_open_items
+        if todo_item_is_actionable_open(item)
+        if todo_item_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
+    ]
+    claimed_monitor_items = [
+        item
+        for item in claimed_open_items
+        if todo_item_is_actionable_open(item)
+        if todo_item_task_class(item) == TODO_TASK_CLASS_MONITOR
     ]
     summary = {
         "schema_version": "todo_summary_v0",
@@ -3737,6 +3749,22 @@ def compact_todo_group(
         "monitor_open_items": [
             compact_todo_item(item) for item in monitor_items
         ],
+        "unclaimed_priority_open_items": [
+            compact_todo_item(item)
+            for item in unclaimed_open_items[:MAX_PROJECT_ASSET_TODO_BACKLOG_ITEMS]
+        ],
+        "claimed_open_items": [
+            compact_todo_item(item)
+            for item in claimed_open_items[:MAX_TODO_VISIBILITY_LANE_ITEMS]
+        ],
+        "claimed_advancement_open_items": [
+            compact_todo_item(item)
+            for item in claimed_advancement_items[:MAX_TODO_VISIBILITY_LANE_ITEMS]
+        ],
+        "claimed_monitor_open_items": [
+            compact_todo_item(item)
+            for item in claimed_monitor_items[:MAX_TODO_VISIBILITY_LANE_ITEMS]
+        ],
         "backlog_items": [
             compact_todo_item(item)
             for item in projected_open_items[:MAX_PROJECT_ASSET_TODO_BACKLOG_ITEMS]
@@ -3750,6 +3778,8 @@ def compact_todo_group(
     if claimed_open_items:
         summary["claimed_open_count"] = len(claimed_open_items)
         summary["unclaimed_open_count"] = len(open_items) - len(claimed_open_items)
+        summary["claimed_advancement_open_count"] = len(claimed_advancement_items)
+        summary["claimed_monitor_open_count"] = len(claimed_monitor_items)
     return summary
 
 
@@ -4302,12 +4332,14 @@ def open_todo_items(
     *,
     limit: int = MAX_PROJECT_ASSET_TODO_ITEMS,
     text_limit: int = 220,
+    source_keys: tuple[str, ...] = ("first_open_items", "items"),
 ) -> list[dict[str, Any]]:
     if not isinstance(todos, dict):
         return []
     result: list[dict[str, Any]] = []
     seen: set[tuple[Any, str]] = set()
-    for source_items in (todos.get("first_open_items"), todos.get("items")):
+    for source_key in source_keys:
+        source_items = todos.get(source_key)
         if not isinstance(source_items, list):
             continue
         for item in source_items:
@@ -4327,6 +4359,21 @@ def open_todo_items(
             if len(result) >= limit:
                 return sorted(result, key=todo_projection_sort_key)
     return sorted(result, key=todo_projection_sort_key)
+
+
+def todo_lane_items(
+    todos: dict[str, Any] | None,
+    lane: str,
+    *,
+    limit: int = MAX_STATUS_TODOS_PER_ROLE,
+    text_limit: int = 220,
+) -> list[dict[str, Any]]:
+    return open_todo_items(
+        todos,
+        limit=limit,
+        text_limit=text_limit,
+        source_keys=(lane,),
+    )
 
 
 def first_open_todo_text(todos: dict[str, Any] | None) -> str | None:
@@ -4368,15 +4415,29 @@ def project_asset_todo_summary(todos: dict[str, Any] | None) -> dict[str, Any] |
             item
             for item in backlog_items
             if todo_item_is_actionable_open(item)
-            if normalize_todo_task_class(
-                item.get("task_class"),
-                text=str(item.get("text") or ""),
-                action_kind=item.get("action_kind"),
-            )
-            == TODO_TASK_CLASS_ADVANCEMENT
+            if todo_item_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
         ]
         if executable_backlog_items:
             summary["executable_backlog_items"] = executable_backlog_items
+    for lane in (
+        "unclaimed_priority_open_items",
+        "claimed_open_items",
+        "claimed_advancement_open_items",
+        "claimed_monitor_open_items",
+    ):
+        lane_items = todo_lane_items(
+            todos,
+            lane,
+            limit=MAX_TODO_VISIBILITY_LANE_ITEMS,
+        )
+        if lane_items:
+            summary[lane] = lane_items
+    for count_key in (
+        "claimed_advancement_open_count",
+        "claimed_monitor_open_count",
+    ):
+        if todos.get(count_key) is not None:
+            summary[count_key] = todos.get(count_key)
     return summary
 
 


### PR DESCRIPTION
## Summary
- Add todo visibility lanes so status/quota can expose priority-ranked unclaimed work separately from claimed work.
- Add agent-aware quota lanes for current-agent claimed advancement and monitor todos, plus claimed-by-others context.
- Document the 16-item agent-facing lane cap and cover deep claimed frontstage todos in the existing todo summary smoke.

## Validation
- python3 examples/todo-first-open-summary-smoke.py
- python3 examples/side-agent-workspace-guard-smoke.py
- python3 examples/work-lane-contract-smoke.py
- python3 examples/docs-governance-smoke.py
- python3 -m py_compile goal_harness/status.py goal_harness/quota.py examples/todo-first-open-summary-smoke.py
- git diff --check
- goal-harness check --scan-path goal_harness/status.py --scan-path goal_harness/quota.py --scan-path examples/todo-first-open-summary-smoke.py --scan-path docs/status-data-contract.md