### PR TITLE
docs: sharpen always-on agent team hero copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,26 @@
 # Goal Harness
 
-**Long-running agent work, without losing the plot.**
+**Always-on agent teams, governed by human judgment.**
 
 **Gate-aware human-in-the-loop control plane**
 
-**让人的判断成为控制面，而不是让 agent 在等待里空转。**
+**让多个 agent 昼夜接力，把人的判断留在控制面。**
 
-Goal Harness 把用户决策、agent todo、safe fallback、run history 和 quota
-放进同一层状态：该停的地方明确停，该继续的安全侧路继续走。
+Goal Harness 把目标、用户决策、agent todo、认领关系、scope、safe fallback、
+run history 和 quota 放进同一层状态：该等人的地方明确等人，不该空等的
+安全侧路继续推进。
 
-Goal Harness is a local control plane for AI agent projects. It keeps goals,
-gates, todos, run history, quota, side-agent ownership, and human decisions
-visible across many turns.
+Goal Harness is a local control plane for long-running AI agent projects. It
+keeps goals, gates, todos, claims, scopes, run history, quota, evidence, and
+human decisions visible across many turns, so primary and side agents can keep
+working on safe lanes while gated work waits for the person.
 
 [Quick Start](#quick-start) · [Getting Started](docs/guides/getting-started.md) ·
 [Showcases](docs/showcases/README.md) · [Product Vision](docs/product/vision.md) ·
 [Architecture](docs/architecture.md) · [Dashboard](apps/dashboard/README.md) ·
 [简体中文](README.zh-CN.md)
 
-> Long-running agent work should be recoverable, reviewable, handoffable, and
-> safe by default.
+> Your agents keep the night shift. You keep the judgment.
 
 ## What Is It?
 
@@ -42,6 +43,12 @@ The product promise is not "more todo lists." It is a better
 human-in-the-loop control surface: keep human judgment at high-value decision
 points, keep safe fallback work moving when one lane is gated, and stop compute
 spend when a turn cannot produce a verified transition.
+
+Put differently: Goal Harness lets a user's agent team keep working across
+tools, turns, and off-hours without losing the goal boundary. The technical
+contract underneath that promise is explicit: agent identity, todo ownership,
+scope, capability gates, quota, evidence writeback, and public/private
+boundaries stay visible to the next turn.
 
 ![Goal Harness control-plane board](docs/assets/control-plane-board.svg)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,15 +1,19 @@
 # Goal Harness
 
+**Always-on agent teams, governed by human judgment**
+
 **Gate-aware human-in-the-loop control plane**
 
-**让人的判断成为控制面，而不是让 agent 在等待里空转。**
+**让多个 agent 昼夜接力，把人的判断留在控制面。**
 
-Goal Harness 把用户决策、agent todo、safe fallback、run history 和 quota
-放进同一层状态：该停的地方明确停，该继续的安全侧路继续走。
+Goal Harness 把目标、用户决策、agent todo、认领关系、scope、safe fallback、
+run history 和 quota 放进同一层状态：该等人的地方明确等人，不该空等的
+安全侧路继续推进。
 
-Goal Harness 是一个面向长期 agent 工作的本地控制面。它让目标、用户
-gate、todo、运行历史、quota、旁路 agent 归属、人类反馈和项目边界在多轮
-工作中保持可见、可恢复、可交接。
+Goal Harness 是一个面向长期 agent 工作的本地控制面。它让 Codex、Claude Code、
+Cursor、automation 和旁路 agent 共享同一份长期目标状态：目标、gate、todo、
+认领、scope、运行历史、quota、证据和项目边界在多轮工作中保持可见、可恢复、
+可交接。
 
 [English](README.md) · [快速开始](#快速开始) · [Showcases](docs/showcases/README.md) ·
 [产品愿景](docs/product/vision.md) · [架构](docs/architecture.md)
@@ -42,6 +46,10 @@ state drift：
 
 Goal Harness 的产品判断是：强能力 agent-loop 已经存在，问题在于如何把它变成
 长期可用、可控、可解释的协作系统。
+
+换句话说，Goal Harness 想让人的多个 agent 可以持续接力，包括夜间和用户离开
+后的安全工作；但接力的前提不是绕过人，而是把人类判断、scope、能力门、quota
+和证据写成下一轮 agent 也能读懂的控制面。
 
 ## 它如何工作
 
@@ -179,4 +187,3 @@ benchmark 证据边界。
 - 稳定 CLI/runtime 行为的 focused smoke；
 - 控制面协议、架构说明、贡献者任务；
 - 明确标注 evidence boundary 的展示材料。
-

--- a/docs/outreach/marketing-copy-bank.md
+++ b/docs/outreach/marketing-copy-bank.md
@@ -13,23 +13,40 @@ showcase catalog.
 
 ## Core Positioning
 
+**Always-on agent teams, governed by human judgment**
+
 **Gate-aware human-in-the-loop control plane**
 
-**让人的判断成为控制面，而不是让 agent 在等待里空转。**
+**让多个 agent 昼夜接力，把人的判断留在控制面。**
 
-Goal Harness keeps user decisions, agent todos, safe fallback, run history,
-quota, and public/private boundaries in one shared state layer. The gated
-route waits clearly; independent safe side work can continue with evidence.
+Goal Harness keeps goals, user decisions, agent todos, claims, scopes, safe
+fallback, run history, quota, evidence, and public/private boundaries in one
+shared state layer. The gated route waits clearly; independent safe side work
+can continue with evidence.
 
 Short form:
 
-> Long-running agent work, without losing the plot.
+> Your agents keep the night shift. You keep the judgment.
+
+Product angle:
+
+> Let a user's primary and side agents keep a long-running goal moving across
+> tools, turns, and off-hours, while the user sees what happened, what is
+> blocked, who owns which todo, and where judgment is needed.
+
+Technical angle:
+
+> The always-on promise is backed by agent identity, `claimed_by`, scope,
+> capability gates, quota, run history, evidence writeback, and public/private
+> boundary checks. Goal Harness is not "run agents forever"; it is governed
+> continuity.
 
 Plain Chinese form:
 
 > Goal Harness 不是新的 agent runtime。它是给 Codex、Claude Code、Cursor 这类
-> agent loop 加的一层长程控制面：目标、用户决策、agent todo、fallback、证据和
-> quota 不再散落在聊天里。
+> agent loop 加的一层长程控制面：目标、用户决策、agent todo、认领、scope、
+> fallback、证据和 quota 不再散落在聊天里。人的多个 agent 可以持续接力，但
+> 每一次接力都要受 gate、scope、quota 和证据约束。
 
 ## What To Say First
 
@@ -102,6 +119,9 @@ without turning into uncontrolled autonomy.
 
 Good copy:
 
+- "Your agents keep the night shift. You keep the judgment."
+- "Always-on agent work only makes sense when gates, scope, quota, and evidence
+  are explicit."
 - "Off-hours progress is valuable only when the agent knows what counts as a
   safe side path."
 - "Quota spend should follow validated writeback, not a vague feeling that the
@@ -231,9 +251,9 @@ Keep the first screen direct:
 ```text
 # Goal Harness
 
-Gate-aware human-in-the-loop control plane.
+Always-on agent teams, governed by human judgment.
 
-Long-running agent work, without losing the plot.
+Gate-aware human-in-the-loop control plane.
 ```
 
 Then explain the relationship:
@@ -241,7 +261,7 @@ Then explain the relationship:
 ```text
 Codex, Claude Code, Cursor, and scheduled terminal agents execute work.
 Goal Harness keeps the lifetime-goal control plane visible across those loops:
-goals, gates, todos, ownership, run history, quota, and evidence.
+goals, gates, todos, claims, scopes, run history, quota, and evidence.
 ```
 
 ### Lark / Internal Intro
@@ -249,12 +269,13 @@ goals, gates, todos, ownership, run history, quota, and evidence.
 Lead with the bilingual punchline, then use Chinese for the explanation:
 
 ```text
+Always-on agent teams, governed by human judgment
 Gate-aware human-in-the-loop control plane
-让人的判断成为控制面，而不是让 agent 在等待里空转。
+让多个 agent 昼夜接力，把人的判断留在控制面。
 
 Goal Harness 不是替代 Codex goal/automation，而是给这些 agent loop
-提供长期控制面：用户决策、agent todo、safe fallback、run history 和 quota
-能在同一层状态里被看见、继承、验证。
+提供长期控制面：目标、用户决策、agent todo、认领、scope、safe fallback、
+run history 和 quota 能在同一层状态里被看见、继承、验证。
 ```
 
 ### Social Post

--- a/docs/outreach/public-launch-narrative-draft.md
+++ b/docs/outreach/public-launch-narrative-draft.md
@@ -13,13 +13,15 @@ agent framework.
 
 Its strongest public position is:
 
-> Long-running agents need a human-in-the-loop control plane that can keep
-> working safely when one high-priority lane is gated by a human decision.
+> Always-on agent teams need a human-in-the-loop control plane: human-gated
+> work waits explicitly, while independent safe lanes keep moving with
+> evidence.
 
 The important product detail is not that the harness stores more state. It is
 that the state becomes actionable:
 
 - the blocked human decision remains visible as a concrete user todo;
+- primary and side agents can see who owns which todo and scope;
 - safe fallback work can continue without pretending the fallback is now the
   main lane;
 - quota, validation, public/private boundaries, and run evidence remain tied to

--- a/docs/outreach/xiaohongshu-launch-draft.md
+++ b/docs/outreach/xiaohongshu-launch-draft.md
@@ -2,17 +2,19 @@
 
 ## 首屏核心
 
+**Always-on agent teams, governed by human judgment**
+
 **Gate-aware human-in-the-loop control plane**
 
-**让人的判断成为控制面，而不是让 agent 在等待里空转。**
+**让多个 agent 昼夜接力，把人的判断留在控制面。**
 
-Goal Harness 把用户决策、agent todo、safe fallback、run history 和 quota 放进同一层状态：该停的地方明确停，该继续的安全侧路继续走。
+Goal Harness 把目标、用户决策、agent todo、认领关系、scope、safe fallback、run history 和 quota 放进同一层状态：该等人的地方明确等人，不该空等的安全侧路继续推进。
 
 ## Current Positioning
 
 Goal Harness 的发布重点不是“又做了一个 agent 框架”，而是一个更小、更真实的产品问题：
 
-> 当 Codex / Claude Code / Cursor 这类 agent runtime 已经足够强，下一步缺的是一层 human-in-the-loop 控制面，让 agent 在等待人类判断时不空等、不越界，并且把每一次 fallback、验证和边界都留下证据。
+> 当 Codex / Claude Code / Cursor 这类 agent runtime 已经足够强，下一步缺的是一层 human-in-the-loop 控制面：让人的多个 agent 可以昼夜接力，同时在等待人类判断时不空等、不越界，并且把每一次 fallback、验证和边界都留下证据。
 
 这不是把 todo 写得更细。
 

--- a/docs/product/naming-decision-packet.md
+++ b/docs/product/naming-decision-packet.md
@@ -13,7 +13,13 @@ Keep the repository and product name:
 Goal Harness
 ```
 
-Use this category line near the first screen:
+Use this hero promise near the first screen:
+
+```text
+Always-on agent teams, governed by human judgment
+```
+
+Use this control-plane category line next to it:
 
 ```text
 Gate-aware human-in-the-loop control plane
@@ -29,7 +35,7 @@ The public story should be:
 
 > Goal Harness is the lifetime-goal control plane around agent loops. Codex,
 > Claude Code, Cursor, terminal agents, and benchmark runners execute bounded
-> work; Goal Harness keeps the long-running goal, gates, todos, ownership,
+> work; Goal Harness keeps the long-running goal, gates, todos, claims, scopes,
 > quota, evidence, and handoffs visible across those loops.
 
 Do not rename the repo to `lifetime-goal-harness` now. Use "lifetime-goal" as
@@ -75,8 +81,9 @@ comprehension.
 Use three layers:
 
 1. **Brand**: `Goal Harness`
-2. **Category**: `Gate-aware human-in-the-loop control plane`
-3. **Support phrase**: `lifetime-goal control plane`
+2. **Hero promise**: `Always-on agent teams, governed by human judgment`
+3. **Category**: `Gate-aware human-in-the-loop control plane`
+4. **Support phrase**: `lifetime-goal control plane`
 
 This lets the project keep a stable name while still sharpening the product
 category.
@@ -86,9 +93,9 @@ Example first-screen stack:
 ```text
 Goal Harness
 
-Gate-aware human-in-the-loop control plane.
+Always-on agent teams, governed by human judgment.
 
-Long-running agent work, without losing the plot.
+Gate-aware human-in-the-loop control plane.
 ```
 
 Chinese-first stack:
@@ -96,8 +103,9 @@ Chinese-first stack:
 ```text
 Goal Harness
 
+Always-on agent teams, governed by human judgment
 Gate-aware human-in-the-loop control plane
-让人的判断成为控制面，而不是让 agent 在等待里空转。
+让多个 agent 昼夜接力，把人的判断留在控制面。
 
 Goal Harness 不是替代 Codex goal/automation，而是给这些 executor loop
 提供 lifetime-goal 控制面。
@@ -108,14 +116,18 @@ Goal Harness 不是替代 Codex goal/automation，而是给这些 executor loop
 Use `Goal Harness` when naming the product, repository, CLI, examples, and
 showcase cases.
 
+Use `Always-on agent teams, governed by human judgment` when the first-contact
+surface needs a stronger product promise than "state management" without
+overclaiming autonomous production control.
+
 Use `Gate-aware human-in-the-loop control plane` when a first-contact reader
-needs the product category immediately.
+needs the technical category immediately.
 
 Use `lifetime-goal control plane` when explaining why this is larger than one
 agent session, one terminal command, or one benchmark run.
 
-Use `long-running agent work, without losing the plot` as a human tagline, not
-as a formal architecture term.
+Use `Your agents keep the night shift. You keep the judgment.` as a social or
+demo tagline, not as a formal architecture term.
 
 Avoid `agent teammate`, `agent framework`, `autonomous platform`, or `agent OS`
 unless a future product surface actually owns those capabilities.
@@ -145,7 +157,8 @@ changing the brand.
 ## Practical Copy Rules
 
 - Pair the brand with the category on first mention:
-  `Goal Harness, a gate-aware human-in-the-loop control plane`.
+  `Goal Harness, an always-on control plane for agent teams governed by human
+  judgment`.
 - When users confuse it with Codex goal mode, answer with the executor-loop
   split: Codex does bounded work; Goal Harness preserves lifetime-goal state.
 - Use "lifetime-goal" in explanatory paragraphs, not every headline.

--- a/docs/product/vision.md
+++ b/docs/product/vision.md
@@ -8,7 +8,8 @@ lifetime goals: long-running agent work that has to stay understandable and
 recoverable across many turns.
 
 The long-term product should help humans who do not want to inspect prompts,
-logs, or traces. They should be able to open a first screen and understand:
+logs, or traces. A user should be able to run multiple agents across tools and
+off-hours, then open a first screen and understand:
 
 - what the agent has done;
 - what the agent is doing now;
@@ -19,12 +20,19 @@ logs, or traces. They should be able to open a first screen and understand:
 
 ## First-Screen Copy
 
+**Always-on agent teams, governed by human judgment**
+
 **Gate-aware human-in-the-loop control plane**
 
-**让人的判断成为控制面，而不是让 agent 在等待里空转。**
+**让多个 agent 昼夜接力，把人的判断留在控制面。**
 
-Goal Harness 把用户决策、agent todo、safe fallback、run history 和 quota
-放进同一层状态：该停的地方明确停，该继续的安全侧路继续走。
+Goal Harness 把目标、用户决策、agent todo、认领关系、scope、safe fallback、
+run history 和 quota 放进同一层状态：该等人的地方明确等人，不该空等的
+安全侧路继续推进。
+
+The product promise is always-on progress without uncontrolled autonomy:
+primary and side agents can continue bounded work, while human gates,
+capability gates, quota, evidence, and project boundaries remain explicit.
 
 ## Creator-Operator Case
 

--- a/docs/showcases/frontend-surface.md
+++ b/docs/showcases/frontend-surface.md
@@ -54,16 +54,17 @@ Use a compact comparison block:
 Recommended headline stack for Chinese-first material:
 
 ```text
+Always-on agent teams, governed by human judgment
 Gate-aware human-in-the-loop control plane
-让人的判断成为控制面，而不是让 agent 在等待里空转。
+让多个 agent 昼夜接力，把人的判断留在控制面。
 ```
 
 Recommended English explanation:
 
 ```text
-Goal Harness keeps user decisions, agent todos, safe fallback, run history,
-and quota in one shared state layer: the gated route waits clearly, while
-independent safe side work can keep moving with evidence.
+Goal Harness keeps goals, gates, todos, claims, scopes, safe fallback, run
+history, quota, and evidence in one shared state layer: the gated route waits
+clearly, while independent safe side work can keep moving with evidence.
 ```
 
 ## Case Card Model


### PR DESCRIPTION
## Summary
- update the README and Chinese README hero copy around always-on agent teams governed by human judgment
- align product vision, naming packet, marketing copy bank, launch drafts, and frontend surface guidance with the new positioning
- keep the technical contract explicit: claims, scopes, quota, evidence, gates, and boundaries

## Validation
- python3 examples/docs-governance-smoke.py
- git diff --check
- goal-harness check --scan-path README.md --scan-path README.zh-CN.md --scan-path docs/product/vision.md --scan-path docs/product/naming-decision-packet.md --scan-path docs/outreach/marketing-copy-bank.md --scan-path docs/outreach/public-launch-narrative-draft.md --scan-path docs/outreach/xiaohongshu-launch-draft.md --scan-path docs/showcases/frontend-surface.md