### PR TITLE
docs: add self-iteration efficiency model

### DIFF
--- a/docs/showcases/cases/0619-goal-harness-self-iteration.md
+++ b/docs/showcases/cases/0619-goal-harness-self-iteration.md
@@ -21,20 +21,23 @@ in parallel.
 ## Public Repository Signal
 
 The workload signal is the whole public repository through fixed anchor commit
-`0510dda` (`Project outcome-floor blocker noop state`). The fixed anchor avoids
-letting this documentation update change its own evidence window.
+`86d6d9d` (`docs: sharpen always-on agent team hero copy`). The fixed anchor
+avoids letting this documentation update change its own evidence window.
 
 | Signal | Value |
 | --- | --- |
-| All public commits in the repository | 736 |
-| Unique files touched across public history | 547 |
-| Cumulative public insertions / deletions | 254763 / 48601 |
-| Public commits since 2026-06-18 00:00 +08:00 | 179 |
-| Recent unique files touched since 2026-06-18 | 189 |
-| Recent cumulative insertions / deletions | 41958 / 19641 |
-| Public commits on 2026-06-19 | 71 |
-| 2026-06-19 unique files touched | 114 |
-| 2026-06-19 cumulative insertions / deletions | 15181 / 957 |
+| All public commits in the repository | 801 |
+| Unique files touched across public history | 570 |
+| Cumulative public insertions / deletions | 265703 / 49895 |
+| Public commits since 2026-06-18 00:00 +08:00 | 244 |
+| Recent unique files touched since 2026-06-18 | 216 |
+| Recent cumulative insertions / deletions | 52898 / 20935 |
+| Public commits on 2026-06-19 | 74 |
+| 2026-06-19 unique files touched | 118 |
+| 2026-06-19 cumulative insertions / deletions | 16087 / 1082 |
+| Public evidence window | 2026-05-31 22:57 +08:00 to 2026-06-20 12:18 +08:00 |
+| Calendar elapsed in public Git window | 19.6 days |
+| Days with public commits | 16 |
 
 The repo-scale numbers show the environment Goal Harness had to manage:
 benchmark work, control-plane fixes, public docs, smoke coverage,
@@ -49,6 +52,60 @@ git rev-list --count HEAD
 git log --numstat --format=COMMIT:%H
 git log --reverse --oneline --since="2026-06-18T00:00:00+08:00"
 ```
+
+## Efficiency Evidence Model
+
+Commit volume is not itself an efficiency claim. The fair comparison is to
+translate the public repository state into product requirements, estimate what
+an ordinary AI-coding-assisted product process would schedule for each
+requirement, then compare that baseline with the public wall-clock evidence
+window.
+
+The baseline below already assumes competent AI coding help. It is not a
+"manual developer with no model" comparison. The assumed traditional process is:
+scope the requirement, write or review the contract, implement, add focused
+validation, document the behavior, review the diff, and merge or release it.
+Requirement clusters are discounted when the shipped state is only a prototype,
+design note, or partial adapter.
+
+| Product requirement cluster | Public evidence surface | Landing level | Conservative AI-coding-assisted baseline |
+| --- | --- | --- | --- |
+| Local control-plane kernel: bootstrap/connect, registry, status, history, check, review packet, todo CLI, public boundary scan | `goal_harness/`, README, status contracts, docs, smokes | shipped core | 11-16 developer-days |
+| Gate, quota, heartbeat, reward, blocker, and safe-fallback lifecycle | quota/status modules, heartbeat prompt docs, state interaction docs, regression smokes | shipped core with ongoing hardening | 10-15 developer-days |
+| Multi-agent ownership and side-agent delivery discipline | `claimed_by`, registered-agent checks, identity-aware heartbeat prompts, worktree guard, self-merge evidence flag | shipped coordination slice | 5-8 developer-days |
+| Benchmark and evaluation control contracts | Terminal-Bench, SkillsBench, ALE, Codex Goal worker contracts, reducers, readiness docs | partial product surface; not full leaderboard automation | 10-16 developer-days |
+| Dashboard, frontstage, and projection surfaces | dashboard app, status server, frontstage fixtures, showcase prototype, goal-channel projection | prototype to beta | 5-8 developer-days |
+| Public smokes, docs governance, and redaction discipline | `examples/`, showcase catalog checks, boundary checks, docs governance smoke | shipped support system | 8-12 developer-days |
+| Product positioning, onboarding, showcases, launch copy, naming, contributor tasks | README, Chinese README, showcases, product vision, outreach drafts | public docs and case surface | 5-8 developer-days |
+| Planning, dreaming, server/client product shape | planning lane docs, dreaming notes, server/client shape docs | design/prototype, deliberately low estimate | 2-4 developer-days |
+| Packaging, install, skills, contributor workflow | install scripts, global skill docs, contributor contracts | usable but still local-first | 3-5 developer-days |
+| **Total conservative baseline** | Whole public repo through `86d6d9d` | mixed maturity | **59-92 developer-days** |
+
+That baseline should be read as a range, not a precision metric. Several
+capabilities are deliberately not counted as high-cost production systems:
+frontstage is still a prototype, server/client shape is mostly product design,
+and benchmark adapters are public contracts plus partial routes rather than a
+finished hosted evaluation service.
+
+The public Git window is 19.6 calendar days, with 16 days containing public
+commits. Compared with a single AI-coding-assisted product engineer, the
+conservative requirement estimate suggests roughly **3.0x-4.7x calendar
+compression**. Compared with a small two-person AI-coding team, the claim
+should be weaker: roughly **1.8x-3.2x calendar compression**, depending on how
+much of the work could truly run in parallel after product review, validation,
+and merge sequencing.
+
+The stronger product claim is not the exact multiplier. It is that Goal
+Harness made the compression governable: multiple lanes moved in the same
+short window while the project still kept goals, gates, todos, ownership,
+evidence, boundary checks, and merge policy visible. Without that control
+plane, the same velocity would be much harder to review, hand off, or trust.
+
+This efficiency model is intentionally conservative and public-safe. It does
+not use private chat logs, local active-state bodies, raw agent sessions, or
+unpublished benchmark artifacts. Future versions can make it more rigorous by
+keeping the requirement clusters in a machine-readable fixture and asking two
+human reviewers to independently score landing level and baseline effort.
 
 ## Feature Chain
 

--- a/docs/showcases/showcase-catalog.json
+++ b/docs/showcases/showcase-catalog.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "goal_harness_showcase_catalog_v0",
-  "updated_at": "2026-06-19",
+  "updated_at": "2026-06-20",
   "redaction_policy": {
     "public_repo_may_include": [
       "sanitized domain labels",
@@ -131,7 +131,8 @@
         "todo_claim_ownership",
         "identity_aware_prompt",
         "self_merge_policy",
-        "evidence_writeback"
+        "evidence_writeback",
+        "efficiency_evidence_model"
       ],
       "headline": "A high-churn Goal Harness repo stayed legible while benchmark, product, docs, planning, and side-agent lanes moved in parallel.",
       "problem": "A long-running agent engineering repo needed to keep many public commits, benchmark routes, planning lanes, user gates, docs, smokes, and side-agent changes reviewable without relying on private chat memory.",
@@ -143,22 +144,44 @@
         "allow small validated side-agent self-merges while preserving primary review for risky work",
         "keep public showcases and smokes free of private chat, internal docs, raw trajectories, and raw benchmark evidence"
       ],
-      "user_value": "The operator can let a fast-moving multi-lane agent project continue across benchmark, product, docs, and side-agent work while keeping ownership, gates, validation, and follow-up visible in one shared control plane.",
+      "user_value": "The operator can let a fast-moving multi-lane agent project continue across benchmark, product, docs, and side-agent work while keeping ownership, gates, validation, follow-up, and conservative efficiency evidence visible in one shared control plane.",
       "workload_signal": {
-        "anchor_commit": "0510dda",
+        "anchor_commit": "86d6d9d",
         "scope": "whole_public_repository",
         "whole_repository": {
-          "commit_count": 736,
-          "files_touched": 547,
-          "insertions": 254763,
-          "deletions": 48601
+          "commit_count": 801,
+          "files_touched": 570,
+          "insertions": 265703,
+          "deletions": 49895
         },
         "recent_window": {
           "since": "2026-06-18T00:00:00+08:00",
-          "commit_count": 179,
-          "files_touched": 189,
-          "insertions": 41958,
-          "deletions": 19641
+          "commit_count": 244,
+          "files_touched": 216,
+          "insertions": 52898,
+          "deletions": 20935
+        },
+        "public_window": {
+          "from": "2026-05-31T22:57:55+08:00",
+          "to": "2026-06-20T12:18:42+08:00",
+          "calendar_days": 19.6,
+          "active_commit_days": 16
+        },
+        "efficiency_model": {
+          "baseline": "AI-coding-assisted product process",
+          "estimated_developer_days": {
+            "low": 59,
+            "high": 92
+          },
+          "single_engineer_calendar_compression": {
+            "low": 3.0,
+            "high": 4.7
+          },
+          "two_person_team_calendar_compression": {
+            "low": 1.8,
+            "high": 3.2
+          },
+          "claim_boundary": "directional, maturity-adjusted, public Git evidence only"
         },
         "main_surfaces": [
           "CLI",
@@ -167,9 +190,11 @@
           "heartbeat prompt",
           "dashboard/status server",
           "benchmark adapters",
+          "frontstage projection",
           "docs",
           "smokes",
-          "showcases"
+          "showcases",
+          "product positioning"
         ]
       },
       "feature_points": [
@@ -179,22 +204,25 @@
         "user/operator surfaces including diagnostics, dashboard framing, onboarding, quickstart, README, and showcases",
         "registered todo claim ownership and identity-aware scoped heartbeat prompts",
         "side-agent self-merge completion flag with evidence",
-        "public-boundary smokes and showcase catalog checks"
+        "public-boundary smokes and showcase catalog checks",
+        "conservative efficiency evidence model that converts commits into maturity-adjusted product requirement clusters"
       ],
       "evidence_boundary": "Public Git evidence only; no private thread text, local active-state bodies, internal document links, screenshots, raw benchmark material, credentials, or machine-specific paths.",
       "frontend_card": {
         "visual_metaphor": "many repo lanes flowing through one control plane, with a side-agent lane branching safely beside the primary benchmark lane",
-        "primary_metric_hint": "736 public repo commits and 179 recent commits stayed reviewable through one control plane",
+        "primary_metric_hint": "801 public commits mapped to a conservative 59-92 AI-assisted developer-day baseline over a 19.6-day public Git window",
         "badges": [
           "self-iteration",
           "commit-backed",
-          "side-agent"
+          "side-agent",
+          "efficiency-model"
         ],
         "story_beats": [
           "whole repo moves quickly across benchmark, runtime, docs, dashboard, planning, and smoke surfaces",
           "Goal Harness keeps durable goals, todos, gates, quota, evidence, and run history visible",
           "side-agent lane progresses beside the primary benchmark lane",
           "validated side changes can self-merge while risky work stays on primary review",
+          "public Git history is converted into conservative product requirement clusters",
           "public docs and smokes turn the experience into a reusable case"
         ]
       }

--- a/examples/showcase-catalog-smoke.py
+++ b/examples/showcase-catalog-smoke.py
@@ -93,24 +93,40 @@ def main() -> int:
             assert demo_command is None, case
             workload = case.get("workload_signal")
             assert isinstance(workload, dict), case
-            assert workload.get("anchor_commit") == "0510dda", workload
+            assert workload.get("anchor_commit") == "86d6d9d", workload
             assert workload.get("scope") == "whole_public_repository", workload
             whole_repository = workload.get("whole_repository")
             assert isinstance(whole_repository, dict), workload
-            assert whole_repository.get("commit_count", 0) >= 700, whole_repository
-            assert whole_repository.get("files_touched", 0) >= 500, whole_repository
-            assert whole_repository.get("insertions", 0) >= 200000, whole_repository
+            assert whole_repository.get("commit_count", 0) >= 800, whole_repository
+            assert whole_repository.get("files_touched", 0) >= 570, whole_repository
+            assert whole_repository.get("insertions", 0) >= 260000, whole_repository
             assert whole_repository.get("deletions", 0) >= 40000, whole_repository
             recent_window = workload.get("recent_window")
             assert isinstance(recent_window, dict), workload
             assert recent_window.get("since") == "2026-06-18T00:00:00+08:00", recent_window
-            assert recent_window.get("commit_count", 0) >= 170, recent_window
-            assert recent_window.get("files_touched", 0) >= 180, recent_window
+            assert recent_window.get("commit_count", 0) >= 240, recent_window
+            assert recent_window.get("files_touched", 0) >= 210, recent_window
+            public_window = workload.get("public_window")
+            assert isinstance(public_window, dict), workload
+            assert public_window.get("calendar_days", 0) >= 19, public_window
+            assert public_window.get("active_commit_days", 0) >= 16, public_window
+            efficiency = workload.get("efficiency_model")
+            assert isinstance(efficiency, dict), workload
+            assert efficiency.get("baseline") == "AI-coding-assisted product process", efficiency
+            estimated_days = efficiency.get("estimated_developer_days")
+            assert isinstance(estimated_days, dict), efficiency
+            assert estimated_days.get("low", 0) >= 50, estimated_days
+            assert estimated_days.get("high", 0) >= estimated_days.get("low", 0), estimated_days
             assert "side_agent_scope" in case.get("pattern_tags", []), case
+            assert "efficiency_evidence_model" in case.get("pattern_tags", []), case
             page_text = read(page)
             for phrase in (
                 "Goal Harness was used to improve a fast-moving Goal Harness repository",
                 "The public repository history shows a connected long-horizon feature chain",
+                "Efficiency Evidence Model",
+                "The baseline below already assumes competent AI coding help",
+                "59-92 developer-days",
+                "3.0x-4.7x calendar",
                 "Benchmark and adapter maturation",
                 "Control-plane correctness",
                 "Planning and dreaming lanes",
@@ -125,7 +141,7 @@ def main() -> int:
     assert "showcases/README.md" in docs_index, "docs index must link showcases"
     assert "docs/showcases/README.md" in repo_readme, "README must link showcases"
     for phrase in (
-        "Long-running agent work, without losing the plot.",
+        "Always-on agent teams, governed by human judgment.",
         "## See It In Action",
         "docs/showcases/cases/0617-blocked-p0-safe-rotation.md",
         "docs/showcases/cases/0619-goal-harness-self-iteration.md",


### PR DESCRIPTION
## Summary
- update the self-iteration showcase anchor to current main commit 86d6d9d and refreshed public Git workload signals
- add a conservative efficiency evidence model that maps all repo commits to maturity-adjusted product requirement clusters
- expose the efficiency model in the showcase catalog and guard it with the catalog smoke

## Validation
- python3 examples/showcase-catalog-smoke.py
- python3 examples/showcase-frontstage-prototype-smoke.py
- python3 examples/docs-governance-smoke.py
- python3 -m py_compile examples/showcase-catalog-smoke.py
- python3 -m json.tool docs/showcases/showcase-catalog.json
- git diff --check
- goal-harness check --scan-path docs/showcases/cases/0619-goal-harness-self-iteration.md --scan-path docs/showcases/showcase-catalog.json --scan-path examples/showcase-catalog-smoke.py