### PR TITLE
feat: add dashboard frontstage channel route

### DIFF
--- a/apps/dashboard/README.md
+++ b/apps/dashboard/README.md
@@ -31,6 +31,13 @@ demo, or switch to a loopback status URL only after you have started
 status exports; they can contain local registry/runtime paths and private
 project summaries.
 
+The first read-only channel frontstage lives at `/frontstage`. It renders a
+public-safe `goal_channel_projection_v0` fixture as a dense channel board with
+decision, quota, user todo, agent todo, active-claim, timeline, and truth
+contract lanes. Treat it as the product-path replacement for expanding the
+no-dependency static HTML renderer; the Python renderer remains the fallback
+demo/diagnostic surface.
+
 ## Run
 
 ```bash

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -9,6 +9,8 @@
     "preview": "vite preview --host 127.0.0.1",
     "smoke:action-packet": "rm -rf /tmp/goal-harness-action-packet-smoke && tsc --ignoreConfig --target ES2022 --module NodeNext --moduleResolution NodeNext --skipLibCheck --strict --outDir /tmp/goal-harness-action-packet-smoke smoke/action-packet-smoke.ts src/data/action-packet.ts && node /tmp/goal-harness-action-packet-smoke/smoke/action-packet-smoke.js",
     "smoke:demo-readiness": "python3 ../../examples/dashboard-demo-readiness-smoke.py",
+    "smoke:frontstage-browser": "node ../../examples/dashboard-frontstage-browser-smoke.mjs",
+    "smoke:frontstage-route": "rm -rf /tmp/goal-harness-frontstage-route-smoke && tsc --ignoreConfig --target ES2022 --module NodeNext --moduleResolution NodeNext --skipLibCheck --strict --outDir /tmp/goal-harness-frontstage-route-smoke smoke/frontstage-route-smoke.ts && node /tmp/goal-harness-frontstage-route-smoke/frontstage-route-smoke.js",
     "smoke:home-browser": "node ../../examples/dashboard-home-browser-smoke.mjs",
     "smoke:home-route": "rm -rf /tmp/goal-harness-home-route-smoke && tsc --ignoreConfig --target ES2022 --module NodeNext --moduleResolution NodeNext --skipLibCheck --strict --outDir /tmp/goal-harness-home-route-smoke smoke/home-route-smoke.ts && node /tmp/goal-harness-home-route-smoke/home-route-smoke.js",
     "smoke:ops-decision-freshness": "node ../../examples/dashboard-ops-decision-freshness-smoke.mjs",

--- a/apps/dashboard/smoke/frontstage-route-smoke.ts
+++ b/apps/dashboard/smoke/frontstage-route-smoke.ts
@@ -1,0 +1,52 @@
+// @ts-expect-error The smoke compiler intentionally runs without @types/node.
+import { readFileSync } from "node:fs";
+
+function assert(condition: boolean, message: string) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function includes(source: string, snippet: string, label: string) {
+  assert(source.includes(snippet), `missing ${label}: ${snippet}`);
+}
+
+function excludes(source: string, snippet: string, label: string) {
+  assert(!source.includes(snippet), `unexpected ${label}: ${snippet}`);
+}
+
+const routerSource = readFileSync("src/router.tsx", "utf8");
+const frontstageSource = readFileSync("src/views/frontstage-page.tsx", "utf8");
+const dataSource = readFileSync("src/data/goal-channel-frontstage.ts", "utf8");
+const readmeSource = readFileSync("README.md", "utf8");
+const selectionSource = readFileSync("../../docs/dashboard-frontend-selection.md", "utf8");
+const packageSource = readFileSync("package.json", "utf8");
+
+includes(routerSource, 'path: "/frontstage"', "frontstage route path");
+includes(routerSource, "component: FrontstagePage", "frontstage route component");
+includes(packageSource, '"smoke:frontstage-browser"', "frontstage browser smoke script");
+includes(packageSource, '"smoke:frontstage-route"', "frontstage smoke script");
+
+includes(dataSource, 'schema_version: "goal_channel_projection_v0"', "goal channel schema");
+includes(dataSource, 'mode: "read_only"', "read-only mode");
+includes(dataSource, 'claimed_by: "codex-side-bypass"', "side-agent claim fixture");
+includes(dataSource, "raw_or_private_material_omitted", "source warning fixture");
+
+includes(frontstageSource, 'data-testid="goal-channel-frontstage-route"', "route test id");
+includes(frontstageSource, 'data-testid="frontstage-user-todos"', "user todo lane");
+includes(frontstageSource, 'data-testid="frontstage-agent-todos"', "agent todo lane");
+includes(frontstageSource, 'data-testid="frontstage-active-claims"', "active claims lane");
+includes(frontstageSource, 'data-testid="frontstage-timeline"', "timeline lane");
+includes(frontstageSource, "Frontstage channel", "frontstage channel copy");
+includes(frontstageSource, "Channel board", "channel board nav");
+includes(frontstageSource, "Projection is read-only", "read-only truth copy");
+includes(frontstageSource, "Inspired by modern agent boards", "product benchmark copy");
+excludes(frontstageSource, "<form", "write form");
+excludes(frontstageSource, "method=", "form method");
+excludes(frontstageSource, "onclick=", "inline click handler");
+
+includes(readmeSource, "/frontstage", "README frontstage route mention");
+includes(selectionSource, "Multica", "Multica benchmark note");
+includes(selectionSource, "agent board", "agent board benchmark note");
+
+console.log("frontstage-route smoke ok");

--- a/apps/dashboard/src/data/goal-channel-frontstage.ts
+++ b/apps/dashboard/src/data/goal-channel-frontstage.ts
@@ -1,0 +1,175 @@
+export type GoalChannelTodo = {
+  todo_id?: string;
+  priority?: string;
+  status: string;
+  title: string;
+  claimed_by?: string;
+  task_class?: string;
+  action_kind?: string;
+};
+
+export type GoalChannelGate = {
+  gate_id: string;
+  kind: string;
+  status: string;
+  blocks?: string[];
+};
+
+export type GoalChannelLease = {
+  todo_id?: string;
+  owner_agent?: string;
+  status?: string;
+  lease_until?: string;
+  write_scope?: string[];
+};
+
+export type GoalChannelEvent = {
+  generated_at?: string;
+  classification?: string;
+  summary?: string;
+};
+
+export type GoalChannelProjection = {
+  schema_version: "goal_channel_projection_v0";
+  mode: "read_only";
+  goal_id: string;
+  display_name: string;
+  generated_at: string;
+  latest_status: string;
+  waiting_on: string;
+  next_action: string;
+  source_refs: Record<string, string | null>;
+  decision_frame: {
+    user_action_required: boolean;
+    agent_action_required: boolean;
+    quiet_noop_allowed: boolean;
+  };
+  quota: Record<string, string>;
+  user_todos: GoalChannelTodo[];
+  agent_todos: GoalChannelTodo[];
+  open_gates: GoalChannelGate[];
+  active_leases: GoalChannelLease[];
+  artifacts: Array<Record<string, string>>;
+  recent_events: GoalChannelEvent[];
+  source_warnings: Array<Record<string, string | string[]>>;
+  truth_contract: {
+    event_ledger_is_source_of_truth: boolean;
+    projection_is_writable: boolean;
+    recompute_rule: string;
+    write_authority: string;
+  };
+};
+
+export const sampleGoalChannelProjection: GoalChannelProjection = {
+  schema_version: "goal_channel_projection_v0",
+  mode: "read_only",
+  goal_id: "demo-goal-channel",
+  display_name: "Demo Goal Channel",
+  generated_at: "2026-06-20T08:04:00Z",
+  latest_status: "safe_side_path_running",
+  waiting_on: "codex",
+  next_action: "Render the read-only channel projection and keep the event ledger as truth.",
+  source_refs: {
+    status_generated_at: "2026-06-20T08:01:00Z",
+    active_state_updated_at: "2026-06-20T08:00:00Z",
+    latest_run_generated_at: "2026-06-20T08:02:00Z",
+    review_packet_generated_at: "2026-06-20T08:03:00Z",
+    event_ledger_source: "run_history",
+  },
+  decision_frame: {
+    user_action_required: true,
+    agent_action_required: true,
+    quiet_noop_allowed: false,
+  },
+  quota: {
+    allowed_slots: "10",
+    reason: "synthetic fixture has quota",
+    spend_policy: "spend after validated writeback",
+    spent_slots: "2",
+    state: "eligible",
+  },
+  user_todos: [
+    {
+      todo_id: "todo_user_decision",
+      priority: "P0",
+      status: "open",
+      title: "Decide whether the gated delivery route may continue.",
+    },
+  ],
+  agent_todos: [
+    {
+      todo_id: "todo_primary_route",
+      priority: "P0",
+      status: "open",
+      claimed_by: "codex-main-control",
+      task_class: "advancement_task",
+      title: "Keep the primary delivery route visible while it waits.",
+    },
+    {
+      todo_id: "todo_side_fixture",
+      priority: "P2",
+      status: "open",
+      claimed_by: "codex-side-bypass",
+      task_class: "advancement_task",
+      title: "Render the productization frontstage fixture.",
+    },
+  ],
+  open_gates: [
+    {
+      gate_id: "interaction_contract_user_channel",
+      kind: "user_channel",
+      status: "action_required",
+      blocks: ["todo_user_decision"],
+    },
+  ],
+  active_leases: [
+    {
+      owner_agent: "codex-main-control",
+      status: "soft_claim",
+      todo_id: "todo_primary_route",
+    },
+    {
+      owner_agent: "codex-side-bypass",
+      status: "soft_claim",
+      todo_id: "todo_side_fixture",
+    },
+  ],
+  artifacts: [
+    {
+      kind: "doc",
+      label: "frontstage roadmap",
+      path: "docs/frontstage-channel-lease-roadmap.md",
+    },
+    {
+      kind: "local_state",
+      label: "omitted private control-plane source",
+    },
+  ],
+  recent_events: [
+    {
+      generated_at: "2026-06-20T08:02:00Z",
+      classification: "validated_progress",
+      summary: "frontstage fixture rendered from compact projection",
+    },
+    {
+      generated_at: "2026-06-20T07:50:00Z",
+      classification: "operator_gate_recorded",
+      summary: "human decision stayed explicit",
+    },
+  ],
+  source_warnings: [
+    {
+      key_names: ["path", "raw_internal_note"],
+      kind: "raw_or_private_material_omitted",
+      message:
+        "raw/private-looking fields were omitted; inspect compact source references instead of copying raw material into the frontstage channel projection",
+    },
+  ],
+  truth_contract: {
+    event_ledger_is_source_of_truth: true,
+    projection_is_writable: false,
+    recompute_rule:
+      "refresh from Goal Harness status/quota/run history; do not edit the channel projection as project truth",
+    write_authority: "none",
+  },
+};

--- a/apps/dashboard/src/router.tsx
+++ b/apps/dashboard/src/router.tsx
@@ -7,6 +7,7 @@ import {
 import { z } from "zod";
 
 import { DashboardPage } from "./views/dashboard-page";
+import { FrontstagePage } from "./views/frontstage-page";
 
 const searchSchema = z.object({
   actionKind: z.enum(["all", "reward", "controller", "codex", "evidence", "health"]).optional().default("all"),
@@ -28,7 +29,13 @@ export const dashboardRoute = createRoute({
   component: DashboardPage,
 });
 
-const routeTree = rootRoute.addChildren([dashboardRoute]);
+export const frontstageRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/frontstage",
+  component: FrontstagePage,
+});
+
+const routeTree = rootRoute.addChildren([dashboardRoute, frontstageRoute]);
 
 export const router = createRouter({ routeTree });
 

--- a/apps/dashboard/src/views/frontstage-page.tsx
+++ b/apps/dashboard/src/views/frontstage-page.tsx
@@ -1,0 +1,282 @@
+import {
+  Activity,
+  Bot,
+  Clock3,
+  GitBranch,
+  LayoutDashboard,
+  ListChecks,
+  ShieldCheck,
+  Users,
+} from "lucide-react";
+
+import {
+  GoalChannelProjection,
+  GoalChannelTodo,
+  sampleGoalChannelProjection,
+} from "../data/goal-channel-frontstage";
+import { Badge } from "../components/ui/badge";
+import { cn } from "../lib/utils";
+
+type BadgeTone = "neutral" | "success" | "warning" | "info" | "danger";
+
+function boolBadge(value: boolean, trueLabel: string, falseLabel: string) {
+  return (
+    <Badge variant={value ? "success" : "neutral"}>
+      {value ? trueLabel : falseLabel}
+    </Badge>
+  );
+}
+
+function statusTone(value?: string): BadgeTone {
+  if (!value) {
+    return "neutral";
+  }
+  if (["done", "closed", "resolved"].includes(value)) {
+    return "success";
+  }
+  if (["blocked", "action_required", "waiting"].includes(value)) {
+    return "warning";
+  }
+  if (["failed", "error"].includes(value)) {
+    return "danger";
+  }
+  return "info";
+}
+
+function priorityTone(priority?: string): BadgeTone {
+  if (priority === "P0") {
+    return "danger";
+  }
+  if (priority === "P1") {
+    return "warning";
+  }
+  if (priority === "P2") {
+    return "info";
+  }
+  return "neutral";
+}
+
+function TodoRow({ todo }: { todo: GoalChannelTodo }) {
+  return (
+    <div className="grid gap-3 border-b border-slate-200 px-3 py-3 last:border-b-0 md:grid-cols-[96px_minmax(0,1fr)_156px]">
+      <div className="flex flex-wrap gap-1">
+        {todo.priority ? <Badge variant={priorityTone(todo.priority)}>{todo.priority}</Badge> : null}
+        <Badge variant={statusTone(todo.status)}>{todo.status}</Badge>
+      </div>
+      <div className="min-w-0">
+        <p className="break-words text-sm font-medium leading-6 text-slate-950">{todo.title}</p>
+        <div className="mt-1 flex flex-wrap gap-2 text-[11px] font-medium text-slate-500">
+          {todo.todo_id ? <span>{todo.todo_id}</span> : null}
+          {todo.action_kind ? <span>{todo.action_kind}</span> : null}
+          {todo.task_class ? <span>{todo.task_class}</span> : null}
+        </div>
+      </div>
+      <div className="flex items-start justify-start md:justify-end">
+        {todo.claimed_by ? (
+          <Badge variant="info">
+            <Bot className="h-3 w-3" />
+            {todo.claimed_by}
+          </Badge>
+        ) : (
+          <Badge variant="neutral">unclaimed</Badge>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Panel({
+  children,
+  className,
+  title,
+  icon: Icon,
+}: {
+  children: React.ReactNode;
+  className?: string;
+  icon: React.ComponentType<{ className?: string }>;
+  title: string;
+}) {
+  return (
+    <section className={cn("rounded-lg border border-slate-200 bg-white shadow-sm", className)}>
+      <div className="flex items-center justify-between gap-3 border-b border-slate-200 px-4 py-3">
+        <h2 className="flex items-center gap-2 text-sm font-semibold text-slate-950">
+          <Icon className="h-4 w-4 text-slate-500" />
+          {title}
+        </h2>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function FrontstageRoute({ projection }: { projection: GoalChannelProjection }) {
+  const quotaUsed = `${projection.quota.spent_slots ?? "0"} / ${projection.quota.allowed_slots ?? "?"}`;
+  return (
+    <main
+      className="min-h-screen bg-[#f7f7f4] px-4 py-4 text-slate-950 sm:px-5"
+      data-mode={projection.mode}
+      data-schema={projection.schema_version}
+      data-testid="goal-channel-frontstage-route"
+    >
+      <div className="mx-auto grid max-w-[1500px] gap-4 xl:grid-cols-[260px_minmax(0,1fr)_320px]">
+        <aside className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm xl:sticky xl:top-4 xl:self-start">
+          <div className="flex items-center gap-2">
+            <div className="flex h-9 w-9 items-center justify-center rounded-md border border-slate-200 bg-slate-950 text-white">
+              <GitBranch className="h-4 w-4" />
+            </div>
+            <div>
+              <div className="text-sm font-semibold">Goal Harness</div>
+              <div className="text-xs text-slate-500">Frontstage channel</div>
+            </div>
+          </div>
+          <div className="mt-4 grid gap-2">
+            <a className="flex items-center gap-2 rounded-md border border-slate-200 px-3 py-2 text-sm font-medium" href="/">
+              <LayoutDashboard className="h-4 w-4" />
+              Control home
+            </a>
+            <a className="flex items-center gap-2 rounded-md bg-slate-950 px-3 py-2 text-sm font-medium text-white" href="/frontstage">
+              <Activity className="h-4 w-4" />
+              Channel board
+            </a>
+          </div>
+          <div className="mt-5 space-y-2 text-xs leading-5 text-slate-500">
+            <p>Projection is read-only. The append-only Goal Harness ledger remains the source of truth.</p>
+            <p>Inspired by modern agent boards, but scoped to gates, todos, claims, quota, and evidence.</p>
+          </div>
+        </aside>
+
+        <section className="space-y-4">
+          <div className="rounded-lg border border-slate-200 bg-white px-5 py-5 shadow-sm">
+            <div className="flex flex-wrap items-start justify-between gap-4">
+              <div className="min-w-0">
+                <div className="flex flex-wrap gap-2">
+                  <Badge variant="success">goal_channel_projection_v0</Badge>
+                  <Badge variant="neutral">{projection.mode}</Badge>
+                  <Badge variant="info">{projection.waiting_on}</Badge>
+                </div>
+                <h1 className="mt-3 text-3xl font-semibold tracking-normal text-slate-950">
+                  {projection.display_name}
+                </h1>
+                <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">{projection.next_action}</p>
+              </div>
+              <div className="grid min-w-[220px] grid-cols-2 gap-2 text-center">
+                <div className="rounded-md border border-slate-200 bg-slate-50 px-3 py-2">
+                  <div className="text-lg font-semibold">{projection.user_todos.length}</div>
+                  <div className="text-[11px] font-medium text-slate-500">user todos</div>
+                </div>
+                <div className="rounded-md border border-slate-200 bg-slate-50 px-3 py-2">
+                  <div className="text-lg font-semibold">{projection.agent_todos.length}</div>
+                  <div className="text-[11px] font-medium text-slate-500">agent todos</div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="grid gap-4 lg:grid-cols-3">
+            <Panel icon={Users} title="Decision Frame">
+              <div className="grid gap-2 p-4">
+                {boolBadge(projection.decision_frame.user_action_required, "user action", "no user action")}
+                {boolBadge(projection.decision_frame.agent_action_required, "agent action", "no agent action")}
+                {boolBadge(!projection.decision_frame.quiet_noop_allowed, "no quiet noop", "quiet noop ok")}
+              </div>
+            </Panel>
+            <Panel icon={ShieldCheck} title="Quota Guard">
+              <div className="space-y-2 p-4 text-sm leading-6">
+                <div className="flex items-center justify-between gap-3">
+                  <span className="text-slate-500">state</span>
+                  <Badge variant={statusTone(projection.quota.state)}>{projection.quota.state}</Badge>
+                </div>
+                <div className="flex items-center justify-between gap-3">
+                  <span className="text-slate-500">slots</span>
+                  <span className="font-semibold">{quotaUsed}</span>
+                </div>
+                <p className="text-xs text-slate-500">{projection.quota.spend_policy}</p>
+              </div>
+            </Panel>
+            <Panel icon={Clock3} title="Source Freshness">
+              <div className="space-y-2 p-4 text-xs leading-5 text-slate-600">
+                {Object.entries(projection.source_refs).map(([key, value]) => (
+                  <div className="grid grid-cols-[118px_minmax(0,1fr)] gap-2" key={key}>
+                    <span className="font-semibold text-slate-500">{key}</span>
+                    <span className="break-words">{value ?? "n/a"}</span>
+                  </div>
+                ))}
+              </div>
+            </Panel>
+          </div>
+
+          <div className="grid gap-4 lg:grid-cols-2">
+            <Panel icon={Users} title="User Todo Lane">
+              <div data-testid="frontstage-user-todos">
+                {projection.user_todos.map((todo) => (
+                  <TodoRow key={todo.todo_id ?? todo.title} todo={todo} />
+                ))}
+              </div>
+            </Panel>
+            <Panel icon={Bot} title="Agent Todo Lane">
+              <div data-testid="frontstage-agent-todos">
+                {projection.agent_todos.map((todo) => (
+                  <TodoRow key={todo.todo_id ?? todo.title} todo={todo} />
+                ))}
+              </div>
+            </Panel>
+          </div>
+
+          <Panel icon={Activity} title="Run Timeline">
+            <div className="divide-y divide-slate-200" data-testid="frontstage-timeline">
+              {projection.recent_events.map((event, index) => (
+                <div className="grid gap-3 px-4 py-3 md:grid-cols-[190px_180px_minmax(0,1fr)]" key={`${event.generated_at ?? "event"}-${index}`}>
+                  <div className="font-mono text-xs text-slate-500">{event.generated_at ?? "n/a"}</div>
+                  <Badge variant="neutral">{event.classification ?? "event"}</Badge>
+                  <div className="text-sm leading-6 text-slate-700">{event.summary ?? "compact event"}</div>
+                </div>
+              ))}
+            </div>
+          </Panel>
+        </section>
+
+        <aside className="space-y-4">
+          <Panel icon={ListChecks} title="Active Claims">
+            <div className="divide-y divide-slate-200" data-testid="frontstage-active-claims">
+              {projection.active_leases.map((lease, index) => (
+                <div className="px-4 py-3" key={`${lease.todo_id ?? "claim"}-${index}`}>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Badge variant="info">{lease.owner_agent ?? "unknown"}</Badge>
+                    <Badge variant="neutral">{lease.status ?? "claim"}</Badge>
+                  </div>
+                  <div className="mt-2 break-all text-xs font-medium text-slate-500">{lease.todo_id}</div>
+                </div>
+              ))}
+            </div>
+          </Panel>
+
+          <Panel icon={ShieldCheck} title="Truth Contract">
+            <div className="space-y-3 p-4 text-sm leading-6">
+              <div className="flex flex-wrap gap-2">
+                {boolBadge(projection.truth_contract.event_ledger_is_source_of_truth, "ledger truth", "ledger missing")}
+                {boolBadge(!projection.truth_contract.projection_is_writable, "read-only", "writeable")}
+              </div>
+              <p className="text-slate-600">{projection.truth_contract.recompute_rule}</p>
+              <p className="text-xs font-semibold text-slate-500">write authority: {projection.truth_contract.write_authority}</p>
+            </div>
+          </Panel>
+
+          <Panel icon={ShieldCheck} title="Boundary Warnings">
+            <div className="space-y-3 p-4" data-testid="frontstage-source-warnings">
+              {projection.source_warnings.map((warning, index) => (
+                <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm leading-6 text-amber-950" key={`${warning.kind}-${index}`}>
+                  <div className="font-semibold">{warning.kind}</div>
+                  <p className="mt-1">{warning.message}</p>
+                </div>
+              ))}
+            </div>
+          </Panel>
+        </aside>
+      </div>
+    </main>
+  );
+}
+
+export function FrontstagePage() {
+  return <FrontstageRoute projection={sampleGoalChannelProjection} />;
+}

--- a/docs/dashboard-frontend-selection.md
+++ b/docs/dashboard-frontend-selection.md
@@ -28,6 +28,14 @@ The useful reference products cluster around three product surfaces:
 - Observability products such as Datadog and Grafana set the density bar:
   reusable widgets, health panels, filters, dashboard links, and drill-downs
   that turn a first screen into an operator cockpit.
+- Multica is a useful near-neighbor for product shape, not for direct cloning:
+  its public repo uses a Next.js web app, Go backend, PostgreSQL/pgvector,
+  local agent daemon, shared UI package, Base UI/shadcn-style components,
+  TanStack Query/Table, resizable panels, command menus, agent boards, agent
+  profiles, runtimes, squads, task timelines, and reusable skill surfaces.
+  Goal Harness should borrow the dense agent-board and workspace-member
+  grammar while keeping the control-plane source of truth in Goal Harness
+  status/quota/run history rather than in a chat or issue board.
 
 For Goal Harness, the common lesson is not "more charts." The first screen
 needs an action-oriented queue and trustworthy drill-downs:
@@ -144,6 +152,13 @@ stack and renders a real screen from `examples/status.example.json`:
 Keep `examples/render-status-dashboard.py` as a low-friction fallback until the
 React dashboard can be built and opened in one command.
 
+The next product-path slice is `/frontstage`: a read-only
+`goal_channel_projection_v0` channel board that makes a single goal feel like a
+managed workspace lane. It should show the decision frame, quota guard, user
+todo lane, agent todo lane, active claims, timeline, source warnings, and truth
+contract. This route is where Multica-style agent board density belongs; the
+existing Python/HTML renderer should stay a no-build diagnostic fallback.
+
 ## Sources Checked
 
 - Langfuse observability docs: <https://langfuse.com/docs/observability/overview>
@@ -164,3 +179,4 @@ React dashboard can be built and opened in one command.
 - Vercel Geist design system: <https://vercel.com/geist/introduction>
 - Linear changelog and interface direction: <https://linear.app/changelog>
 - Datadog dashboard widgets docs: <https://docs.datadoghq.com/dashboards/widgets/>
+- Multica public repo and README architecture section: <https://github.com/multica-ai/multica>

--- a/examples/dashboard-frontstage-browser-smoke.mjs
+++ b/examples/dashboard-frontstage-browser-smoke.mjs
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+// Browser-level smoke for the read-only goal channel frontstage route.
+
+import { spawn } from "node:child_process";
+import { createRequire } from "node:module";
+import { existsSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const require = createRequire(import.meta.url);
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const dashboardDir = resolve(repoRoot, "apps/dashboard");
+const visualOutputDir = resolve(repoRoot, "output/playwright/dashboard-frontstage-visual-acceptance");
+const port = Number(process.env.GOAL_HARNESS_DASHBOARD_FRONTSTAGE_SMOKE_PORT ?? "5197");
+
+function loadPlaywright() {
+  const candidates = [
+    process.env.GOAL_HARNESS_PLAYWRIGHT_PACKAGE,
+    resolve(homedir(), ".cache/codex-runtimes/codex-primary-runtime/dependencies/node/node_modules/playwright"),
+  ].filter(Boolean);
+
+  try {
+    return require("playwright");
+  } catch {
+    // Try explicit or bundled local packages below.
+  }
+
+  for (const candidate of candidates) {
+    if (!candidate || !existsSync(candidate)) {
+      continue;
+    }
+    try {
+      return require(candidate);
+    } catch {
+      // Keep looking.
+    }
+  }
+
+  throw new Error("Playwright package not found; install playwright or set GOAL_HARNESS_PLAYWRIGHT_PACKAGE");
+}
+
+async function launchBrowser(chromium) {
+  try {
+    return await chromium.launch({ channel: "chrome", headless: true });
+  } catch {
+    return chromium.launch({ headless: true });
+  }
+}
+
+async function waitForDashboard(url) {
+  const deadline = Date.now() + 20_000;
+  let lastError;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) {
+        return;
+      }
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolveTimeout) => setTimeout(resolveTimeout, 250));
+  }
+  throw lastError ?? new Error(`Timed out waiting for ${url}`);
+}
+
+function startDashboardServer() {
+  const viteBin = resolve(dashboardDir, "node_modules/vite/bin/vite.js");
+  if (!existsSync(viteBin)) {
+    throw new Error(`Vite package not installed: ${viteBin}`);
+  }
+  const nodeBin = [
+    process.env.GOAL_HARNESS_NODE_BIN,
+    "/opt/homebrew/bin/node",
+    "/usr/local/bin/node",
+    process.execPath,
+  ].find((candidate) => candidate && existsSync(candidate));
+  return spawn(nodeBin, [viteBin, "--host", "127.0.0.1", "--port", String(port), "--strictPort"], {
+    cwd: dashboardDir,
+    env: {
+      ...process.env,
+      PATH: ["/opt/homebrew/bin", "/usr/local/bin", process.env.PATH].filter(Boolean).join(":"),
+    },
+    stdio: "ignore",
+  });
+}
+
+function formatOverflowOffender(offender) {
+  const id = offender.testid ? `[data-testid="${offender.testid}"]` : offender.tag;
+  return `${id} left=${offender.left} right=${offender.right} width=${offender.width} "${offender.text}"`;
+}
+
+async function assertNoHorizontalOverflow(page, label) {
+  const report = await page.evaluate(() => {
+    const viewportWidth = window.innerWidth;
+    const root = document.documentElement;
+    const body = document.body;
+    const scrollWidth = Math.max(root.scrollWidth, body?.scrollWidth ?? 0);
+    const offenders = [];
+    for (const element of Array.from(document.body.querySelectorAll("*"))) {
+      const style = window.getComputedStyle(element);
+      if (style.display === "none" || style.visibility === "hidden" || Number(style.opacity) === 0) {
+        continue;
+      }
+      const rect = element.getBoundingClientRect();
+      if (rect.width < 1 || rect.height < 1) {
+        continue;
+      }
+      if (rect.left < -2 || rect.right > viewportWidth + 2) {
+        offenders.push({
+          tag: element.tagName.toLowerCase(),
+          testid: element.getAttribute("data-testid"),
+          left: Math.round(rect.left),
+          right: Math.round(rect.right),
+          width: Math.round(rect.width),
+          text: (element.textContent ?? "").replace(/\s+/g, " ").trim().slice(0, 90),
+        });
+      }
+      if (offenders.length >= 8) {
+        break;
+      }
+    }
+    return {
+      viewportWidth,
+      scrollWidth,
+      overflowPx: Math.max(0, scrollWidth - viewportWidth),
+      offenders,
+    };
+  });
+  if (report.overflowPx > 2) {
+    const offenders = report.offenders.map(formatOverflowOffender).join(" | ");
+    throw new Error(`${label} horizontal overflow: viewport=${report.viewportWidth} scroll=${report.scrollWidth} offenders=${offenders || "none"}`);
+  }
+}
+
+async function captureFrontstage(page, url, label) {
+  await page.goto(url, { waitUntil: "networkidle" });
+  await page.waitForSelector('[data-testid="goal-channel-frontstage-route"]', { timeout: 10_000 });
+
+  const body = await page.locator("body").innerText();
+  const required = [
+    "Goal Harness",
+    "Frontstage channel",
+    "Demo Goal Channel",
+    "goal_channel_projection_v0",
+    "Projection is read-only",
+    "Decision Frame",
+    "Quota Guard",
+    "Source Freshness",
+    "User Todo Lane",
+    "Agent Todo Lane",
+    "Run Timeline",
+    "Active Claims",
+    "Truth Contract",
+    "Boundary Warnings",
+    "codex-main-control",
+    "codex-side-bypass",
+    "Render the productization frontstage fixture",
+  ];
+  const missing = required.filter((text) => !body.includes(text));
+  if (missing.length) {
+    throw new Error(`Missing frontstage text: ${missing.join(", ")}`);
+  }
+
+  const forbidden = [
+    "[plugin:vite:oxc]",
+    "Transform failed",
+    "onclick=",
+    "method=",
+  ];
+  const present = forbidden.filter((text) => body.includes(text));
+  if (present.length) {
+    throw new Error(`Frontstage leaked debug/write text: ${present.join(", ")}`);
+  }
+
+  const forms = await page.locator("form").count();
+  if (forms !== 0) {
+    throw new Error(`Read-only frontstage should not render forms; found ${forms}`);
+  }
+
+  await assertNoHorizontalOverflow(page, label);
+  await page.screenshot({
+    path: resolve(visualOutputDir, `${label}.png`),
+    fullPage: true,
+    animations: "disabled",
+  });
+}
+
+async function main() {
+  const { chromium } = loadPlaywright();
+  await mkdir(visualOutputDir, { recursive: true });
+
+  const server = startDashboardServer();
+  let browser;
+  const pageErrors = [];
+  try {
+    const baseUrl = `http://127.0.0.1:${port}`;
+    await waitForDashboard(baseUrl);
+    browser = await launchBrowser(chromium);
+
+    const desktopPage = await browser.newPage({ viewport: { width: 1440, height: 1100 } });
+    desktopPage.on("pageerror", (error) => pageErrors.push(error.message));
+    try {
+      await captureFrontstage(desktopPage, `${baseUrl}/frontstage`, "desktop-frontstage");
+    } finally {
+      await desktopPage.close();
+    }
+
+    const mobilePage = await browser.newPage({
+      isMobile: true,
+      viewport: { width: 390, height: 900 },
+    });
+    mobilePage.on("pageerror", (error) => pageErrors.push(`mobile: ${error.message}`));
+    try {
+      await captureFrontstage(mobilePage, `${baseUrl}/frontstage`, "mobile-frontstage");
+    } finally {
+      await mobilePage.close();
+    }
+
+    if (pageErrors.length) {
+      throw new Error(`Frontstage page errors: ${pageErrors.join(" | ")}`);
+    }
+
+    console.log("dashboard-frontstage-browser-smoke ok");
+  } finally {
+    if (browser) {
+      await browser.close();
+    }
+    server.kill("SIGTERM");
+  }
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a read-only /frontstage route for a public-safe goal_channel_projection_v0 channel board
- port the frontstage fixture into the dashboard app with decision, quota, todo, claim, timeline, warning, and truth-contract lanes
- record the Multica-inspired frontend/product benchmark direction and add route/browser smokes

## Validation
- npm run smoke:frontstage-route
- npm run smoke:frontstage-browser
- npm run build
- python3 examples/goal-channel-frontstage-fixture-smoke.py
- python3 examples/goal-channel-projection-smoke.py
- goal-harness check --scan-path apps/dashboard/src/data/goal-channel-frontstage.ts --scan-path apps/dashboard/src/views/frontstage-page.tsx --scan-path apps/dashboard/src/router.tsx --scan-path apps/dashboard/smoke/frontstage-route-smoke.ts --scan-path examples/dashboard-frontstage-browser-smoke.mjs --scan-path apps/dashboard/README.md --scan-path docs/dashboard-frontend-selection.md
- git diff --check