### PR TITLE
feat: wire frontstage to live status projection

### DIFF
--- a/apps/dashboard/README.md
+++ b/apps/dashboard/README.md
@@ -38,6 +38,11 @@ contract lanes. Treat it as the product-path replacement for expanding the
 no-dependency static HTML renderer; the Python renderer remains the fallback
 demo/diagnostic surface.
 
+For live local control-plane inspection, open
+`/frontstage?statusUrl=http://127.0.0.1:8766/status.json`. The route reads
+`attention_queue.items[].goal_channel_projection` and stays read-only; if the
+feed is missing or has no projection, the bundled demo fixture remains visible.
+
 ## Run
 
 ```bash

--- a/apps/dashboard/smoke/frontstage-route-smoke.ts
+++ b/apps/dashboard/smoke/frontstage-route-smoke.ts
@@ -18,21 +18,28 @@ function excludes(source: string, snippet: string, label: string) {
 const routerSource = readFileSync("src/router.tsx", "utf8");
 const frontstageSource = readFileSync("src/views/frontstage-page.tsx", "utf8");
 const dataSource = readFileSync("src/data/goal-channel-frontstage.ts", "utf8");
+const statusSource = readFileSync("src/data/status.ts", "utf8");
 const readmeSource = readFileSync("README.md", "utf8");
 const selectionSource = readFileSync("../../docs/dashboard-frontend-selection.md", "utf8");
 const packageSource = readFileSync("package.json", "utf8");
 
 includes(routerSource, 'path: "/frontstage"', "frontstage route path");
 includes(routerSource, "component: FrontstagePage", "frontstage route component");
+includes(routerSource, "frontstageSearchSchema", "frontstage search schema");
 includes(packageSource, '"smoke:frontstage-browser"', "frontstage browser smoke script");
 includes(packageSource, '"smoke:frontstage-route"', "frontstage smoke script");
 
 includes(dataSource, 'schema_version: "goal_channel_projection_v0"', "goal channel schema");
+includes(dataSource, "goalChannelProjectionSchema", "goal channel zod schema");
 includes(dataSource, 'mode: "read_only"', "read-only mode");
 includes(dataSource, 'claimed_by: "codex-side-bypass"', "side-agent claim fixture");
 includes(dataSource, "raw_or_private_material_omitted", "source warning fixture");
+includes(statusSource, "goal_channel_projection: goalChannelProjectionSchema", "status projection parser");
 
 includes(frontstageSource, 'data-testid="goal-channel-frontstage-route"', "route test id");
+includes(frontstageSource, 'data-testid="frontstage-live-source-panel"', "live source panel");
+includes(frontstageSource, 'data-testid="frontstage-goal-select"', "goal selector");
+includes(frontstageSource, "parseStatusPayload", "status payload parser");
 includes(frontstageSource, 'data-testid="frontstage-user-todos"', "user todo lane");
 includes(frontstageSource, 'data-testid="frontstage-agent-todos"', "agent todo lane");
 includes(frontstageSource, 'data-testid="frontstage-active-claims"', "active claims lane");

--- a/apps/dashboard/src/data/goal-channel-frontstage.ts
+++ b/apps/dashboard/src/data/goal-channel-frontstage.ts
@@ -1,3 +1,75 @@
+import { z } from "zod";
+
+const scalarSchema = z.union([z.string(), z.number(), z.boolean(), z.null()]);
+const scalarRecordSchema = z.record(z.string(), scalarSchema);
+
+export const goalChannelTodoSchema = z.object({
+  todo_id: z.string().optional(),
+  priority: z.string().optional(),
+  status: z.string(),
+  title: z.string(),
+  claimed_by: z.string().optional(),
+  task_class: z.string().optional(),
+  action_kind: z.string().optional(),
+});
+
+export const goalChannelGateSchema = z.object({
+  gate_id: z.string(),
+  kind: z.string(),
+  status: z.string(),
+  blocks: z.array(z.string()).optional(),
+});
+
+export const goalChannelLeaseSchema = z.object({
+  todo_id: z.string().optional(),
+  owner_agent: z.string().optional(),
+  status: z.string().optional(),
+  lease_until: z.string().optional(),
+  write_scope: z.array(z.string()).optional(),
+});
+
+export const goalChannelEventSchema = z.object({
+  generated_at: z.string().optional(),
+  classification: z.string().optional(),
+  summary: z.string().optional(),
+});
+
+export const goalChannelSourceWarningSchema = z.object({
+  kind: z.string().optional().default("warning"),
+  message: z.union([z.string(), z.array(z.string())]).optional().default("compact source warning"),
+}).passthrough();
+
+export const goalChannelProjectionSchema = z.object({
+  schema_version: z.literal("goal_channel_projection_v0"),
+  mode: z.literal("read_only"),
+  goal_id: z.string(),
+  display_name: z.string(),
+  generated_at: z.string(),
+  latest_status: z.string(),
+  waiting_on: z.string(),
+  next_action: z.string(),
+  source_refs: z.record(z.string(), scalarSchema),
+  decision_frame: z.object({
+    user_action_required: z.boolean(),
+    agent_action_required: z.boolean(),
+    quiet_noop_allowed: z.boolean(),
+  }),
+  quota: scalarRecordSchema,
+  user_todos: z.array(goalChannelTodoSchema).default([]),
+  agent_todos: z.array(goalChannelTodoSchema).default([]),
+  open_gates: z.array(goalChannelGateSchema).default([]),
+  active_leases: z.array(goalChannelLeaseSchema).default([]),
+  artifacts: z.array(scalarRecordSchema).default([]),
+  recent_events: z.array(goalChannelEventSchema).default([]),
+  source_warnings: z.array(goalChannelSourceWarningSchema).default([]),
+  truth_contract: z.object({
+    event_ledger_is_source_of_truth: z.boolean(),
+    projection_is_writable: z.boolean(),
+    recompute_rule: z.string(),
+    write_authority: z.string(),
+  }),
+});
+
 export type GoalChannelTodo = {
   todo_id?: string;
   priority?: string;
@@ -38,20 +110,20 @@ export type GoalChannelProjection = {
   latest_status: string;
   waiting_on: string;
   next_action: string;
-  source_refs: Record<string, string | null>;
+  source_refs: Record<string, string | number | boolean | null>;
   decision_frame: {
     user_action_required: boolean;
     agent_action_required: boolean;
     quiet_noop_allowed: boolean;
   };
-  quota: Record<string, string>;
+  quota: Record<string, string | number | boolean | null>;
   user_todos: GoalChannelTodo[];
   agent_todos: GoalChannelTodo[];
   open_gates: GoalChannelGate[];
   active_leases: GoalChannelLease[];
-  artifacts: Array<Record<string, string>>;
+  artifacts: Array<Record<string, string | number | boolean | null>>;
   recent_events: GoalChannelEvent[];
-  source_warnings: Array<Record<string, string | string[]>>;
+  source_warnings: Array<Record<string, unknown> & { kind?: string; message?: string | string[] }>;
   truth_contract: {
     event_ledger_is_source_of_truth: boolean;
     projection_is_writable: boolean;

--- a/apps/dashboard/src/data/status.ts
+++ b/apps/dashboard/src/data/status.ts
@@ -1,6 +1,8 @@
 import rawStatus from "../../../../examples/status.example.json";
 import { z } from "zod";
 
+import { goalChannelProjectionSchema } from "./goal-channel-frontstage";
+
 export const quotaSchema = z.object({
   compute: z.number().optional().default(1),
   window_hours: z.number().optional().default(24),
@@ -214,6 +216,7 @@ export const queueItemSchema = z.object({
   stale_latest_run_warning: staleLatestRunWarningSchema.optional().nullable(),
   dependency_blockers: dependencyBlockerSummarySchema.optional().nullable(),
   todo_state_file: z.string().optional().nullable(),
+  goal_channel_projection: goalChannelProjectionSchema.optional().nullable(),
 });
 
 export const humanRewardSchema = z.object({

--- a/apps/dashboard/src/router.tsx
+++ b/apps/dashboard/src/router.tsx
@@ -18,6 +18,11 @@ const searchSchema = z.object({
   view: z.enum(["ops", "share"]).optional(),
 });
 
+const frontstageSearchSchema = z.object({
+  goalId: z.string().optional().default(""),
+  statusUrl: z.string().optional().default(""),
+});
+
 export const rootRoute = createRootRoute({
   component: () => <Outlet />,
 });
@@ -32,6 +37,7 @@ export const dashboardRoute = createRoute({
 export const frontstageRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/frontstage",
+  validateSearch: (search) => frontstageSearchSchema.parse(search),
   component: FrontstagePage,
 });
 

--- a/apps/dashboard/src/views/frontstage-page.tsx
+++ b/apps/dashboard/src/views/frontstage-page.tsx
@@ -1,23 +1,37 @@
 import {
   Activity,
   Bot,
+  CircleAlert,
   Clock3,
   GitBranch,
   LayoutDashboard,
   ListChecks,
+  RefreshCw,
   ShieldCheck,
   Users,
 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
 
+import { frontstageRoute } from "../router";
 import {
   GoalChannelProjection,
   GoalChannelTodo,
   sampleGoalChannelProjection,
 } from "../data/goal-channel-frontstage";
+import { QueueItem, StatusPayload, formatStatusError, parseStatusPayload } from "../data/status";
 import { Badge } from "../components/ui/badge";
+import { Button } from "../components/ui/button";
+import { Select } from "../components/ui/select";
 import { cn } from "../lib/utils";
 
 type BadgeTone = "neutral" | "success" | "warning" | "info" | "danger";
+type FrontstageSource = { kind: "demo"; label: string } | { kind: "url"; label: string };
+
+type ProjectionOption = {
+  goalId: string;
+  projection: GoalChannelProjection;
+  queueItem: QueueItem;
+};
 
 function boolBadge(value: boolean, trueLabel: string, falseLabel: string) {
   return (
@@ -56,6 +70,20 @@ function priorityTone(priority?: string): BadgeTone {
   return "neutral";
 }
 
+function stringifyScalar(value: string | number | boolean | null | undefined) {
+  if (value === null || value === undefined) {
+    return "n/a";
+  }
+  return String(value);
+}
+
+function warningMessage(value: string | string[] | undefined) {
+  if (Array.isArray(value)) {
+    return value.join(", ");
+  }
+  return value ?? "compact source warning";
+}
+
 function TodoRow({ todo }: { todo: GoalChannelTodo }) {
   return (
     <div className="grid gap-3 border-b border-slate-200 px-3 py-3 last:border-b-0 md:grid-cols-[96px_minmax(0,1fr)_156px]">
@@ -85,6 +113,19 @@ function TodoRow({ todo }: { todo: GoalChannelTodo }) {
   );
 }
 
+function projectionOptionsFromPayload(payload: StatusPayload): ProjectionOption[] {
+  return payload.attention_queue.items.flatMap((item) => {
+    if (!item.goal_channel_projection) {
+      return [];
+    }
+    return [{
+      goalId: item.goal_id,
+      projection: item.goal_channel_projection,
+      queueItem: item,
+    }];
+  });
+}
+
 function Panel({
   children,
   className,
@@ -109,8 +150,32 @@ function Panel({
   );
 }
 
-function FrontstageRoute({ projection }: { projection: GoalChannelProjection }) {
-  const quotaUsed = `${projection.quota.spent_slots ?? "0"} / ${projection.quota.allowed_slots ?? "?"}`;
+function FrontstageRoute({
+  goalOptions,
+  isLoading,
+  loadError,
+  onGoalChange,
+  onLoadStatusUrl,
+  onResetDemo,
+  projection,
+  selectedGoalId,
+  source,
+  statusUrl,
+  setStatusUrl,
+}: {
+  goalOptions: ProjectionOption[];
+  isLoading: boolean;
+  loadError: string | null;
+  onGoalChange: (goalId: string) => void;
+  onLoadStatusUrl: () => void;
+  onResetDemo: () => void;
+  projection: GoalChannelProjection;
+  selectedGoalId: string;
+  source: FrontstageSource;
+  statusUrl: string;
+  setStatusUrl: (value: string) => void;
+}) {
+  const quotaUsed = `${stringifyScalar(projection.quota.spent_slots)} / ${stringifyScalar(projection.quota.allowed_slots ?? "?")}`;
   return (
     <main
       className="min-h-screen bg-[#f7f7f4] px-4 py-4 text-slate-950 sm:px-5"
@@ -143,6 +208,59 @@ function FrontstageRoute({ projection }: { projection: GoalChannelProjection }) 
             <p>Projection is read-only. The append-only Goal Harness ledger remains the source of truth.</p>
             <p>Inspired by modern agent boards, but scoped to gates, todos, claims, quota, and evidence.</p>
           </div>
+          <div className="mt-5 space-y-2 rounded-md border border-slate-200 bg-slate-50 p-3" data-testid="frontstage-live-source-panel">
+            <div className="flex flex-wrap items-center gap-2">
+              <Badge variant={source.kind === "url" ? "success" : "neutral"}>
+                {source.kind === "url" ? "live status feed" : "demo fixture"}
+              </Badge>
+              <span className="text-xs font-medium text-slate-500">{source.label}</span>
+            </div>
+            <input
+              aria-label="Status URL"
+              className="h-9 w-full rounded-md border border-slate-200 bg-white px-3 text-xs text-slate-900 shadow-sm outline-none focus:ring-2 focus:ring-slate-400"
+              data-testid="frontstage-status-url-input"
+              onChange={(event) => setStatusUrl(event.target.value)}
+              placeholder="/status.local.json"
+              value={statusUrl}
+            />
+            <div className="flex gap-2">
+              <Button
+                className="flex-1"
+                data-testid="frontstage-load-status-url"
+                disabled={isLoading}
+                onClick={onLoadStatusUrl}
+                size="sm"
+                variant="primary"
+              >
+                <RefreshCw className="h-3.5 w-3.5" />
+                Load
+              </Button>
+              <Button data-testid="frontstage-reset-demo" disabled={isLoading} onClick={onResetDemo} size="sm">
+                Demo
+              </Button>
+            </div>
+            {goalOptions.length ? (
+              <Select
+                aria-label="Goal channel"
+                className="w-full text-xs"
+                data-testid="frontstage-goal-select"
+                onChange={(event) => onGoalChange(event.target.value)}
+                value={selectedGoalId}
+              >
+                {goalOptions.map((option) => (
+                  <option key={option.goalId} value={option.goalId}>
+                    {option.projection.display_name}
+                  </option>
+                ))}
+              </Select>
+            ) : null}
+            {loadError ? (
+              <div className="flex gap-2 rounded-md border border-amber-200 bg-amber-50 px-2 py-2 text-xs leading-5 text-amber-950" data-testid="frontstage-load-error">
+                <CircleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                <span>{loadError}</span>
+              </div>
+            ) : null}
+          </div>
         </aside>
 
         <section className="space-y-4">
@@ -153,6 +271,7 @@ function FrontstageRoute({ projection }: { projection: GoalChannelProjection }) 
                   <Badge variant="success">goal_channel_projection_v0</Badge>
                   <Badge variant="neutral">{projection.mode}</Badge>
                   <Badge variant="info">{projection.waiting_on}</Badge>
+                  <Badge variant={source.kind === "url" ? "success" : "neutral"}>{source.kind}</Badge>
                 </div>
                 <h1 className="mt-3 text-3xl font-semibold tracking-normal text-slate-950">
                   {projection.display_name}
@@ -184,13 +303,13 @@ function FrontstageRoute({ projection }: { projection: GoalChannelProjection }) 
               <div className="space-y-2 p-4 text-sm leading-6">
                 <div className="flex items-center justify-between gap-3">
                   <span className="text-slate-500">state</span>
-                  <Badge variant={statusTone(projection.quota.state)}>{projection.quota.state}</Badge>
+                  <Badge variant={statusTone(stringifyScalar(projection.quota.state))}>{stringifyScalar(projection.quota.state)}</Badge>
                 </div>
                 <div className="flex items-center justify-between gap-3">
                   <span className="text-slate-500">slots</span>
                   <span className="font-semibold">{quotaUsed}</span>
                 </div>
-                <p className="text-xs text-slate-500">{projection.quota.spend_policy}</p>
+                <p className="text-xs text-slate-500">{stringifyScalar(projection.quota.spend_policy)}</p>
               </div>
             </Panel>
             <Panel icon={Clock3} title="Source Freshness">
@@ -198,7 +317,7 @@ function FrontstageRoute({ projection }: { projection: GoalChannelProjection }) 
                 {Object.entries(projection.source_refs).map(([key, value]) => (
                   <div className="grid grid-cols-[118px_minmax(0,1fr)] gap-2" key={key}>
                     <span className="font-semibold text-slate-500">{key}</span>
-                    <span className="break-words">{value ?? "n/a"}</span>
+                    <span className="break-words">{stringifyScalar(value)}</span>
                   </div>
                 ))}
               </div>
@@ -266,7 +385,7 @@ function FrontstageRoute({ projection }: { projection: GoalChannelProjection }) 
               {projection.source_warnings.map((warning, index) => (
                 <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm leading-6 text-amber-950" key={`${warning.kind}-${index}`}>
                   <div className="font-semibold">{warning.kind}</div>
-                  <p className="mt-1">{warning.message}</p>
+                  <p className="mt-1">{warningMessage(warning.message)}</p>
                 </div>
               ))}
             </div>
@@ -278,5 +397,105 @@ function FrontstageRoute({ projection }: { projection: GoalChannelProjection }) 
 }
 
 export function FrontstagePage() {
-  return <FrontstageRoute projection={sampleGoalChannelProjection} />;
+  const search = frontstageRoute.useSearch();
+  const navigate = frontstageRoute.useNavigate();
+  const [payload, setPayload] = useState<StatusPayload | null>(null);
+  const [source, setSource] = useState<FrontstageSource>({ kind: "demo", label: "bundled fixture" });
+  const [statusUrl, setStatusUrl] = useState(search.statusUrl);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const goalOptions = useMemo(
+    () => (payload ? projectionOptionsFromPayload(payload) : []),
+    [payload],
+  );
+  const selectedGoalId = goalOptions.some((option) => option.goalId === search.goalId)
+    ? search.goalId
+    : goalOptions[0]?.goalId ?? sampleGoalChannelProjection.goal_id;
+  const selectedProjection = goalOptions.find((option) => option.goalId === selectedGoalId)?.projection
+    ?? sampleGoalChannelProjection;
+
+  async function updateSearch(next: { goalId?: string; statusUrl?: string }) {
+    await navigate({
+      search: (current) => ({
+        ...current,
+        ...next,
+      }),
+    });
+  }
+
+  async function loadFromUrl(url: string, updateUrl = true) {
+    const trimmed = url.trim();
+    if (!trimmed) {
+      setLoadError("status URL is empty");
+      return;
+    }
+    setIsLoading(true);
+    setLoadError(null);
+    try {
+      const response = await fetch(trimmed, { cache: "no-store" });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status} while loading ${trimmed}`);
+      }
+      const nextPayload = parseStatusPayload(await response.json());
+      const nextOptions = projectionOptionsFromPayload(nextPayload);
+      setPayload(nextPayload);
+      setSource({ kind: "url", label: trimmed });
+      setStatusUrl(trimmed);
+      if (nextOptions.length === 0) {
+        setLoadError("status feed has no goal_channel_projection items; showing demo fixture");
+      }
+      if (updateUrl) {
+        await updateSearch({
+          goalId: nextOptions[0]?.goalId ?? "",
+          statusUrl: trimmed,
+        });
+      }
+    } catch (error) {
+      setLoadError(formatStatusError(error));
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  function resetToDemo() {
+    setPayload(null);
+    setSource({ kind: "demo", label: "bundled fixture" });
+    setStatusUrl("");
+    setLoadError(null);
+    void updateSearch({ goalId: "", statusUrl: "" });
+  }
+
+  function changeGoal(goalId: string) {
+    void updateSearch({ goalId });
+  }
+
+  useEffect(() => {
+    if (search.statusUrl) {
+      void loadFromUrl(search.statusUrl, false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!goalOptions.length || search.goalId === selectedGoalId) {
+      return;
+    }
+    void updateSearch({ goalId: selectedGoalId });
+  }, [goalOptions, search.goalId, selectedGoalId]);
+
+  return (
+    <FrontstageRoute
+      goalOptions={goalOptions}
+      isLoading={isLoading}
+      loadError={loadError}
+      onGoalChange={changeGoal}
+      onLoadStatusUrl={() => void loadFromUrl(statusUrl)}
+      onResetDemo={resetToDemo}
+      projection={selectedProjection}
+      selectedGoalId={selectedGoalId}
+      setStatusUrl={setStatusUrl}
+      source={source}
+      statusUrl={statusUrl}
+    />
+  );
 }

--- a/examples/dashboard-frontstage-browser-smoke.mjs
+++ b/examples/dashboard-frontstage-browser-smoke.mjs
@@ -4,7 +4,7 @@
 import { spawn } from "node:child_process";
 import { createRequire } from "node:module";
 import { existsSync } from "node:fs";
-import { mkdir } from "node:fs/promises";
+import { mkdir, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -12,8 +12,142 @@ import { fileURLToPath } from "node:url";
 const require = createRequire(import.meta.url);
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const dashboardDir = resolve(repoRoot, "apps/dashboard");
+const fixtureName = "status.frontstage.browser-smoke.json";
+const fixturePath = resolve(dashboardDir, "public", fixtureName);
 const visualOutputDir = resolve(repoRoot, "output/playwright/dashboard-frontstage-visual-acceptance");
 const port = Number(process.env.GOAL_HARNESS_DASHBOARD_FRONTSTAGE_SMOKE_PORT ?? "5197");
+
+function projectionFor(goalId, displayName, claimedBy, todoTitle) {
+  return {
+    schema_version: "goal_channel_projection_v0",
+    mode: "read_only",
+    goal_id: goalId,
+    display_name: displayName,
+    generated_at: "2026-06-20T09:00:00Z",
+    latest_status: "live_fixture_loaded",
+    waiting_on: "codex",
+    next_action: `${displayName} live next action`,
+    source_refs: {
+      status_generated_at: "2026-06-20T09:00:00Z",
+      event_ledger_source: "browser-smoke-fixture",
+    },
+    decision_frame: {
+      user_action_required: false,
+      agent_action_required: true,
+      quiet_noop_allowed: false,
+    },
+    quota: {
+      allowed_slots: 10,
+      spend_policy: "spend after validated live writeback",
+      spent_slots: 3,
+      state: "eligible",
+    },
+    user_todos: [],
+    agent_todos: [
+      {
+        todo_id: `${goalId}_todo`,
+        priority: "P1",
+        status: "open",
+        claimed_by: claimedBy,
+        task_class: "advancement_task",
+        title: todoTitle,
+      },
+    ],
+    open_gates: [],
+    active_leases: [
+      {
+        owner_agent: claimedBy,
+        status: "soft_claim",
+        todo_id: `${goalId}_todo`,
+      },
+    ],
+    artifacts: [
+      {
+        kind: "fixture",
+        label: "browser smoke statusUrl",
+      },
+    ],
+    recent_events: [
+      {
+        generated_at: "2026-06-20T09:00:00Z",
+        classification: "live_fixture_event",
+        summary: `${displayName} rendered from statusUrl`,
+      },
+    ],
+    source_warnings: [
+      {
+        kind: "browser_smoke_public_fixture",
+        message: "fixture contains compact public-safe fields only",
+      },
+    ],
+    truth_contract: {
+      event_ledger_is_source_of_truth: true,
+      projection_is_writable: false,
+      recompute_rule: "reload statusUrl and parse attention_queue.items[].goal_channel_projection",
+      write_authority: "none",
+    },
+  };
+}
+
+const statusFixture = {
+  ok: true,
+  registry: "./fixtures/registry.global.json",
+  runtime_root: "./fixtures/runtime",
+  goal_count: 2,
+  run_count: 2,
+  status_contract: {
+    schema_version: 2,
+    minimum_dashboard_schema_version: 2,
+    producer: "goal-harness status",
+    reload_hint: "scripts/macos-dashboard-launchagent.sh restart",
+  },
+  contract: {
+    ok: true,
+    summary: { errors: 0, warnings: 0, checks: 1 },
+    errors: [],
+    warnings: [],
+    checks: ["public-safe frontstage browser fixture"],
+  },
+  attention_queue: {
+    available: true,
+    item_count: 2,
+    needs_user_or_controller: 0,
+    needs_controller: 0,
+    needs_codex: 2,
+    watching_external_evidence: 0,
+    autonomous_backlog_candidates: null,
+    items: [
+      {
+        goal_id: "live-goal-a",
+        status: "frontstage_live_fixture",
+        waiting_on: "codex",
+        severity: "action",
+        recommended_action: "render live goal A",
+        source: "fixture",
+        goal_channel_projection: projectionFor(
+          "live-goal-a",
+          "Live Goal Channel",
+          "codex-side-bypass",
+          "Render live statusUrl channel projection.",
+        ),
+      },
+      {
+        goal_id: "live-goal-b",
+        status: "frontstage_live_fixture",
+        waiting_on: "codex",
+        severity: "watch",
+        recommended_action: "render live goal B",
+        source: "fixture",
+        goal_channel_projection: projectionFor(
+          "live-goal-b",
+          "Second Live Channel",
+          "codex-main-control",
+          "Keep second live channel selectable.",
+        ),
+      },
+    ],
+  },
+};
 
 function loadPlaywright() {
   const candidates = [
@@ -136,7 +270,7 @@ async function assertNoHorizontalOverflow(page, label) {
   }
 }
 
-async function captureFrontstage(page, url, label) {
+async function captureFrontstage(page, url, label, requiredText = []) {
   await page.goto(url, { waitUntil: "networkidle" });
   await page.waitForSelector('[data-testid="goal-channel-frontstage-route"]', { timeout: 10_000 });
 
@@ -144,7 +278,6 @@ async function captureFrontstage(page, url, label) {
   const required = [
     "Goal Harness",
     "Frontstage channel",
-    "Demo Goal Channel",
     "goal_channel_projection_v0",
     "Projection is read-only",
     "Decision Frame",
@@ -156,9 +289,7 @@ async function captureFrontstage(page, url, label) {
     "Active Claims",
     "Truth Contract",
     "Boundary Warnings",
-    "codex-main-control",
-    "codex-side-bypass",
-    "Render the productization frontstage fixture",
+    ...requiredText,
   ];
   const missing = required.filter((text) => !body.includes(text));
   if (missing.length) {
@@ -191,6 +322,7 @@ async function captureFrontstage(page, url, label) {
 
 async function main() {
   const { chromium } = loadPlaywright();
+  await writeFile(fixturePath, JSON.stringify(statusFixture, null, 2) + "\n", "utf-8");
   await mkdir(visualOutputDir, { recursive: true });
 
   const server = startDashboardServer();
@@ -204,7 +336,29 @@ async function main() {
     const desktopPage = await browser.newPage({ viewport: { width: 1440, height: 1100 } });
     desktopPage.on("pageerror", (error) => pageErrors.push(error.message));
     try {
-      await captureFrontstage(desktopPage, `${baseUrl}/frontstage`, "desktop-frontstage");
+      await captureFrontstage(desktopPage, `${baseUrl}/frontstage`, "desktop-frontstage", [
+        "Demo Goal Channel",
+        "codex-main-control",
+        "codex-side-bypass",
+        "Render the productization frontstage fixture",
+      ]);
+      await captureFrontstage(
+        desktopPage,
+        `${baseUrl}/frontstage?statusUrl=/${fixtureName}&goalId=live-goal-a`,
+        "desktop-frontstage-live",
+        [
+          "live status feed",
+          "Live Goal Channel",
+          "Render live statusUrl channel projection",
+          "browser_smoke_public_fixture",
+        ],
+      );
+      await desktopPage.locator('[data-testid="frontstage-goal-select"]').selectOption("live-goal-b");
+      await desktopPage.waitForFunction(() => document.body.innerText.includes("Second Live Channel"));
+      const selectedUrl = new URL(desktopPage.url());
+      if (selectedUrl.searchParams.get("goalId") !== "live-goal-b") {
+        throw new Error(`Goal selector did not update URL: ${desktopPage.url()}`);
+      }
     } finally {
       await desktopPage.close();
     }
@@ -215,7 +369,12 @@ async function main() {
     });
     mobilePage.on("pageerror", (error) => pageErrors.push(`mobile: ${error.message}`));
     try {
-      await captureFrontstage(mobilePage, `${baseUrl}/frontstage`, "mobile-frontstage");
+      await captureFrontstage(mobilePage, `${baseUrl}/frontstage`, "mobile-frontstage", [
+        "Demo Goal Channel",
+        "codex-main-control",
+        "codex-side-bypass",
+        "Render the productization frontstage fixture",
+      ]);
     } finally {
       await mobilePage.close();
     }
@@ -230,6 +389,7 @@ async function main() {
       await browser.close();
     }
     server.kill("SIGTERM");
+    await rm(fixturePath, { force: true });
   }
 }
 


### PR DESCRIPTION
## Summary
- parse attention_queue.items[].goal_channel_projection into the dashboard status schema
- make /frontstage accept statusUrl and goalId search params while keeping the bundled demo fallback
- add a read-only live source panel, goal selector, and browser smoke coverage for demo + live fixture flows

## Validation
- npm run smoke:frontstage-route
- npm run smoke:frontstage-browser
- npm run build
- python3 examples/goal-channel-status-export-smoke.py
- python3 examples/goal-channel-frontstage-fixture-smoke.py
- python3 examples/goal-channel-projection-smoke.py
- goal-harness check --scan-path apps/dashboard/src/data/goal-channel-frontstage.ts --scan-path apps/dashboard/src/data/status.ts --scan-path apps/dashboard/src/router.tsx --scan-path apps/dashboard/src/views/frontstage-page.tsx --scan-path apps/dashboard/smoke/frontstage-route-smoke.ts --scan-path examples/dashboard-frontstage-browser-smoke.mjs --scan-path apps/dashboard/README.md
- git diff --check