### PR TITLE
feat: export frontstage share bundle

### DIFF
--- a/apps/dashboard/README.md
+++ b/apps/dashboard/README.md
@@ -43,6 +43,23 @@ For live local control-plane inspection, open
 `attention_queue.items[].goal_channel_projection` and stays read-only; if the
 feed is missing or has no projection, the bundled demo fixture remains visible.
 
+To create a public-safe static bundle for demos, Lark shares, or future GitHub
+Pages hosting, export the frontstage with the sanitized fixture:
+
+```bash
+cd apps/dashboard
+npm run export:frontstage-share
+```
+
+The default output is `/tmp/goal-harness-frontstage-share-bundle`. It includes a
+compiled dashboard, `status.frontstage-share.json`, a direct `/frontstage/`
+static route, a manifest, and a README with the local serve URL. The exporter
+rejects local paths, private registry state, internal document hosts, raw-key
+leaks, token assignments, and private key material before reporting success.
+For repository Pages hosting later, rerun the same exporter with
+`-- --base /goal-harness/ --out-dir <artifact-dir>` and publish only that
+generated site artifact.
+
 ## Run
 
 ```bash
@@ -233,6 +250,7 @@ surface:
 
 ```bash
 npm run smoke:home-browser
+npm run smoke:frontstage-share-bundle
 npm run smoke:ops-decision-freshness
 npm run smoke:promotion-readiness
 node examples/dashboard-throttled-browser-smoke.mjs

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -6,11 +6,13 @@
   "scripts": {
     "build": "tsc --noEmit && vite build",
     "dev": "vite --host 127.0.0.1",
+    "export:frontstage-share": "node ../../examples/export-frontstage-share-bundle.mjs",
     "preview": "vite preview --host 127.0.0.1",
     "smoke:action-packet": "rm -rf /tmp/goal-harness-action-packet-smoke && tsc --ignoreConfig --target ES2022 --module NodeNext --moduleResolution NodeNext --skipLibCheck --strict --outDir /tmp/goal-harness-action-packet-smoke smoke/action-packet-smoke.ts src/data/action-packet.ts && node /tmp/goal-harness-action-packet-smoke/smoke/action-packet-smoke.js",
     "smoke:demo-readiness": "python3 ../../examples/dashboard-demo-readiness-smoke.py",
     "smoke:frontstage-browser": "node ../../examples/dashboard-frontstage-browser-smoke.mjs",
     "smoke:frontstage-route": "rm -rf /tmp/goal-harness-frontstage-route-smoke && tsc --ignoreConfig --target ES2022 --module NodeNext --moduleResolution NodeNext --skipLibCheck --strict --outDir /tmp/goal-harness-frontstage-route-smoke smoke/frontstage-route-smoke.ts && node /tmp/goal-harness-frontstage-route-smoke/frontstage-route-smoke.js",
+    "smoke:frontstage-share-bundle": "node ../../examples/frontstage-share-bundle-smoke.mjs",
     "smoke:home-browser": "node ../../examples/dashboard-home-browser-smoke.mjs",
     "smoke:home-route": "rm -rf /tmp/goal-harness-home-route-smoke && tsc --ignoreConfig --target ES2022 --module NodeNext --moduleResolution NodeNext --skipLibCheck --strict --outDir /tmp/goal-harness-home-route-smoke smoke/home-route-smoke.ts && node /tmp/goal-harness-home-route-smoke/home-route-smoke.js",
     "smoke:ops-decision-freshness": "node ../../examples/dashboard-ops-decision-freshness-smoke.mjs",

--- a/apps/dashboard/src/data/goal-channel-frontstage.ts
+++ b/apps/dashboard/src/data/goal-channel-frontstage.ts
@@ -231,7 +231,6 @@ export const sampleGoalChannelProjection: GoalChannelProjection = {
   ],
   source_warnings: [
     {
-      key_names: ["path", "raw_internal_note"],
       kind: "raw_or_private_material_omitted",
       message:
         "raw/private-looking fields were omitted; inspect compact source references instead of copying raw material into the frontstage channel projection",

--- a/docs/showcases/README.md
+++ b/docs/showcases/README.md
@@ -30,6 +30,20 @@ Its feedback and source-status contract is
 The first static frontstage prototype is generated from the catalog with
 `python3 examples/showcase-frontstage-prototype.py --output /tmp/goal-harness-showcases.html`.
 
+The dashboard frontstage now has a separate public-safe share-bundle path for
+showing a live-looking control-plane board without exposing local state:
+
+```bash
+cd apps/dashboard
+npm run export:frontstage-share
+```
+
+This writes `/tmp/goal-harness-frontstage-share-bundle` with the compiled
+dashboard, a sanitized `goal_channel_projection_v0` status fixture, direct
+`/frontstage/` static-route support, and a manifest. It is the foundation for a
+future GitHub Pages showcase: Pages should publish this generated artifact, not
+live registry files or local status exports.
+
 ## Current Cases
 
 | Case | Pattern | Status | Public Surface |

--- a/examples/export-frontstage-share-bundle.mjs
+++ b/examples/export-frontstage-share-bundle.mjs
@@ -1,0 +1,297 @@
+#!/usr/bin/env node
+// Build a public-safe static frontstage bundle for demos and future Pages hosting.
+
+import { spawnSync } from "node:child_process";
+import { mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const dashboardDir = resolve(repoRoot, "apps/dashboard");
+const defaultOutDir = resolve("/tmp", "goal-harness-frontstage-share-bundle");
+const statusFileName = "status.frontstage-share.json";
+const manifestFileName = "frontstage-share-manifest.json";
+
+function parseArgs(argv) {
+  const args = {
+    base: "/",
+    outDir: defaultOutDir,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === "--base") {
+      args.base = argv[++index];
+    } else if (token === "--out-dir") {
+      args.outDir = resolve(argv[++index]);
+    } else if (token === "--help" || token === "-h") {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${token}`);
+    }
+  }
+  if (!args.base.startsWith("/")) {
+    throw new Error("--base must be an absolute browser path such as / or /goal-harness/");
+  }
+  if (!args.base.endsWith("/")) {
+    args.base = `${args.base}/`;
+  }
+  return args;
+}
+
+function printHelp() {
+  console.log(`Usage: node examples/export-frontstage-share-bundle.mjs [--out-dir DIR] [--base /path/]
+
+Builds apps/dashboard into a public-safe static bundle, writes a sanitized
+goal_channel_projection_v0 status fixture, and creates /frontstage/index.html
+for direct static hosting.
+
+Defaults:
+  --out-dir ${defaultOutDir}
+  --base /
+`);
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd ?? repoRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: ["/opt/homebrew/bin", "/usr/local/bin", process.env.PATH].filter(Boolean).join(":"),
+    },
+    stdio: options.capture ? ["ignore", "pipe", "pipe"] : "inherit",
+  });
+  if (result.status !== 0) {
+    const detail = options.capture ? `${result.stderr}\n${result.stdout}`.trim() : "";
+    throw new Error(`Command failed: ${command} ${args.join(" ")}${detail ? `\n${detail}` : ""}`);
+  }
+  return result.stdout ?? "";
+}
+
+async function copyIndexForFrontstage(siteDir) {
+  const indexPath = resolve(siteDir, "index.html");
+  const frontstageDir = resolve(siteDir, "frontstage");
+  await mkdir(frontstageDir, { recursive: true });
+  const html = await readFile(indexPath, "utf8");
+  await writeFile(resolve(frontstageDir, "index.html"), html);
+}
+
+function sanitizeProjectionForShare(projection) {
+  return {
+    ...projection,
+    source_warnings: (projection.source_warnings ?? []).map((warning) => ({
+      kind: warning.kind ?? "raw_or_private_material_omitted",
+      message: warning.message ?? "raw/private-looking fields were omitted from this public demo projection",
+    })),
+  };
+}
+
+function buildStatusFixture(projection) {
+  return {
+    ok: true,
+    registry: "public-safe fixture",
+    runtime_root: "omitted",
+    goal_count: 1,
+    run_count: projection.recent_events.length,
+    generated_at: "2026-06-20T13:30:00Z",
+    status_contract: {
+      schema_version: 2,
+      minimum_dashboard_schema_version: 2,
+      producer: "examples/export-frontstage-share-bundle.mjs",
+      reload_hint: "rebuild this bundle from the public fixture",
+    },
+    contract: {
+      ok: true,
+      summary: { checks: 2, errors: 0, warnings: 0 },
+      checks: [
+        "public-safe goal_channel_projection_v0 fixture",
+        "static frontstage route exported for direct hosting",
+      ],
+      errors: [],
+      warnings: [],
+    },
+    attention_queue: {
+      available: true,
+      item_count: 1,
+      needs_user_or_controller: projection.decision_frame.user_action_required ? 1 : 0,
+      needs_controller: 0,
+      needs_codex: projection.decision_frame.agent_action_required ? 1 : 0,
+      watching_external_evidence: 0,
+      items: [
+        {
+          goal_id: projection.goal_id,
+          status: projection.latest_status,
+          waiting_on: projection.waiting_on,
+          severity: projection.decision_frame.user_action_required ? "action" : "watch",
+          recommended_action: projection.next_action,
+          source: "frontstage-share-bundle-fixture",
+          goal_channel_projection: projection,
+        },
+      ],
+    },
+  };
+}
+
+async function writeShareReadme(outDir, base) {
+  const siteDir = resolve(outDir, "site");
+  const statusUrl = `${base}${statusFileName}`;
+  const frontstageUrl = `${base}frontstage/?statusUrl=${encodeURIComponent(statusUrl)}`;
+  const previewBlock = base === "/"
+    ? `## Try It Locally
+
+\`\`\`bash
+cd ${relative(process.cwd(), siteDir) || "."}
+python3 -m http.server 8080
+\`\`\`
+
+Then open:
+
+\`\`\`text
+http://127.0.0.1:8080${frontstageUrl}
+\`\`\`
+`
+    : `## Try It Locally
+
+This bundle was built for the non-root browser base \`${base}\`. Upload
+\`site/\` to a host that serves it at that base path. For a quick local preview,
+rerun the exporter without \`--base\` and open the generated root-base URL.
+
+Hosted entry:
+
+\`\`\`text
+${frontstageUrl}
+\`\`\`
+`;
+  const readme = `# Goal Harness Frontstage Share Bundle
+
+This directory is a generated, public-safe static bundle. It contains the
+dashboard build plus a sanitized \`goal_channel_projection_v0\` status fixture.
+
+${previewBlock}
+
+## Publication Boundary
+
+- Includes: compiled dashboard assets, \`${statusFileName}\`, and direct
+  \`/frontstage/\` static route support.
+- Excludes: live registry state, local paths, credentials, raw logs, raw
+  benchmark evidence, and write APIs.
+- Source fixture: \`examples/goal-channel-frontstage-fixture.py --format json\`.
+`;
+  await writeFile(resolve(outDir, "README.md"), readme);
+}
+
+async function writeManifest(outDir, base) {
+  const manifest = {
+    schema_version: "goal_harness_frontstage_share_bundle_v0",
+    base,
+    site_dir: "site",
+    status_fixture: `site/${statusFileName}`,
+    frontstage_entry: "site/frontstage/index.html",
+    public_boundary: {
+      live_registry_state: false,
+      write_api: false,
+      raw_logs: false,
+      local_paths: false,
+      credentials: false,
+    },
+  };
+  const text = `${JSON.stringify(manifest, null, 2)}\n`;
+  await writeFile(resolve(outDir, manifestFileName), text);
+  await writeFile(resolve(outDir, "site", manifestFileName), text);
+}
+
+async function collectTextFiles(rootDir) {
+  const files = [];
+  async function visit(dir) {
+    for (const entry of await readdir(dir, { withFileTypes: true })) {
+      const path = resolve(dir, entry.name);
+      if (entry.isDirectory()) {
+        await visit(path);
+      } else if (entry.isFile()) {
+        const info = await stat(path);
+        if (info.size <= 2_000_000 && /\.(css|html|js|json|md|txt)$/i.test(path)) {
+          files.push(path);
+        }
+      }
+    }
+  }
+  await visit(rootDir);
+  return files;
+}
+
+async function scanPublicBoundary(outDir) {
+  const patterns = [
+    { label: "macOS user path", pattern: /\/Users\// },
+    { label: "private temp path", pattern: /\/private\// },
+    { label: "workspace owner name", pattern: /bytedance/i },
+    { label: "internal doc host", pattern: new RegExp("lark" + "office", "i") },
+    { label: "private goal state", pattern: new RegExp("\\.codex/goals|\\.goal-" + "harness") },
+    { label: "raw internal key", pattern: new RegExp("raw_" + "internal_note") },
+    { label: "private key material", pattern: /BEGIN (?:RSA |OPENSSH |EC |)PRIVATE KEY/ },
+    { label: "token assignment", pattern: /\b(?:api[_-]?key|auth[_-]?token|access[_-]?token)\s*[:=]/i },
+  ];
+  const leaks = [];
+  for (const path of await collectTextFiles(outDir)) {
+    const text = await readFile(path, "utf8");
+    for (const { label, pattern } of patterns) {
+      if (pattern.test(text)) {
+        leaks.push(`${relative(outDir, path)}: ${label}`);
+      }
+    }
+  }
+  if (leaks.length) {
+    throw new Error(`Public boundary scan failed:\n${leaks.join("\n")}`);
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const outDir = args.outDir;
+  const siteDir = resolve(outDir, "site");
+
+  if (!existsSync(resolve(dashboardDir, "node_modules"))) {
+    throw new Error("apps/dashboard/node_modules is missing; run `npm ci` in apps/dashboard first");
+  }
+
+  await rm(outDir, { force: true, recursive: true });
+  await mkdir(siteDir, { recursive: true });
+
+  run(process.execPath, [resolve(dashboardDir, "node_modules/typescript/bin/tsc"), "--noEmit"], { cwd: dashboardDir });
+  run(process.execPath, [
+    resolve(dashboardDir, "node_modules/vite/bin/vite.js"),
+    "build",
+    "--base",
+    args.base,
+    "--outDir",
+    siteDir,
+    "--emptyOutDir",
+  ], { cwd: dashboardDir });
+
+  await copyIndexForFrontstage(siteDir);
+
+  const projectionOutput = run("python3", [resolve(repoRoot, "examples/goal-channel-frontstage-fixture.py"), "--format", "json"], {
+    capture: true,
+    cwd: repoRoot,
+  });
+  const projection = sanitizeProjectionForShare(JSON.parse(projectionOutput));
+  const statusFixture = buildStatusFixture(projection);
+  await writeFile(resolve(siteDir, statusFileName), `${JSON.stringify(statusFixture, null, 2)}\n`);
+  await writeShareReadme(outDir, args.base);
+  await writeManifest(outDir, args.base);
+  await scanPublicBoundary(outDir);
+
+  console.log(JSON.stringify({
+    ok: true,
+    out_dir: outDir,
+    site_dir: siteDir,
+    frontstage_url: `${args.base}frontstage/?statusUrl=${encodeURIComponent(`${args.base}${statusFileName}`)}`,
+    status_fixture: `site/${statusFileName}`,
+  }, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/examples/frontstage-share-bundle-smoke.mjs
+++ b/examples/frontstage-share-bundle-smoke.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+// Smoke-test the public-safe frontstage static export bundle.
+
+import { spawnSync } from "node:child_process";
+import { readFile, rm } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const outDir = resolve("/tmp", "goal-harness-frontstage-share-bundle-smoke");
+
+function run(command, args, cwd = repoRoot) {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: ["/opt/homebrew/bin", "/usr/local/bin", process.env.PATH].filter(Boolean).join(":"),
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.status !== 0) {
+    throw new Error(`Command failed: ${command} ${args.join(" ")}\n${result.stderr}\n${result.stdout}`);
+  }
+  return result.stdout;
+}
+
+function assertExists(path) {
+  if (!existsSync(path)) {
+    throw new Error(`Missing expected file: ${path}`);
+  }
+}
+
+function assertNoLeak(text, label) {
+  const forbidden = [
+    /\/Users\//,
+    /\/private\//,
+    /bytedance/i,
+    new RegExp("lark" + "office", "i"),
+    new RegExp("\\.codex/goals|\\.goal-" + "harness"),
+    new RegExp("raw_" + "internal_note"),
+    /BEGIN (?:RSA |OPENSSH |EC |)PRIVATE KEY/,
+    /\b(?:api[_-]?key|auth[_-]?token|access[_-]?token)\s*[:=]/i,
+  ];
+  const hit = forbidden.find((pattern) => pattern.test(text));
+  if (hit) {
+    throw new Error(`${label} leaked forbidden pattern: ${hit}`);
+  }
+}
+
+await rm(outDir, { force: true, recursive: true });
+run(process.execPath, [
+  resolve(repoRoot, "examples/export-frontstage-share-bundle.mjs"),
+  "--out-dir",
+  outDir,
+  "--base",
+  "/goal-harness/",
+]);
+
+const siteDir = resolve(outDir, "site");
+assertExists(resolve(siteDir, "index.html"));
+assertExists(resolve(siteDir, "frontstage/index.html"));
+assertExists(resolve(siteDir, "status.frontstage-share.json"));
+assertExists(resolve(outDir, "README.md"));
+assertExists(resolve(outDir, "frontstage-share-manifest.json"));
+
+const status = JSON.parse(await readFile(resolve(siteDir, "status.frontstage-share.json"), "utf8"));
+if (status.attention_queue?.items?.[0]?.goal_channel_projection?.schema_version !== "goal_channel_projection_v0") {
+  throw new Error("share fixture did not include goal_channel_projection_v0");
+}
+if (status.attention_queue.items[0].goal_channel_projection.truth_contract.projection_is_writable !== false) {
+  throw new Error("share fixture must stay read-only");
+}
+
+const manifest = JSON.parse(await readFile(resolve(outDir, "frontstage-share-manifest.json"), "utf8"));
+if (manifest.base !== "/goal-harness/") {
+  throw new Error(`manifest base mismatch: ${manifest.base}`);
+}
+if (manifest.public_boundary.write_api !== false || manifest.public_boundary.live_registry_state !== false) {
+  throw new Error(`manifest public boundary is too permissive: ${JSON.stringify(manifest.public_boundary)}`);
+}
+
+for (const [label, path] of Object.entries({
+  readme: resolve(outDir, "README.md"),
+  status: resolve(siteDir, "status.frontstage-share.json"),
+  manifest: resolve(outDir, "frontstage-share-manifest.json"),
+})) {
+  assertNoLeak(await readFile(path, "utf8"), label);
+}
+
+console.log("frontstage-share-bundle-smoke: ok");

--- a/examples/status.example.json
+++ b/examples/status.example.json
@@ -1,6 +1,6 @@
 {
   "ok": true,
-  "registry": ".goal-harness/registry.json",
+  "registry": "./fixtures/project-registry.json",
   "runtime_root": "./runtime",
   "goal_count": 4,
   "run_count": 3,
@@ -152,7 +152,7 @@
   },
   "promotion_gate": {
     "ok": true,
-    "registry": ".goal-harness/registry.json",
+    "registry": "./fixtures/project-registry.json",
     "runtime_root": "./runtime",
     "gate": "promotion_readiness",
     "gate_state": "ready",
@@ -236,8 +236,8 @@
   "global_registry": {
     "available": true,
     "ok": true,
-    "registry": "~/.codex/goal-harness/registry.global.json",
-    "current_registry": ".goal-harness/registry.json",
+    "registry": "./fixtures/registry.global.json",
+    "current_registry": "./fixtures/project-registry.json",
     "current_registry_is_global": false,
     "global_goal_count": 5,
     "current_goal_count": 4,


### PR DESCRIPTION
## Summary
- add a public-safe frontstage share-bundle exporter for the dashboard
- add a smoke that builds the bundle, checks the static route artifact, fixture, manifest, and boundary scan
- clean dashboard public fixture registry paths and document the share-bundle path as the foundation for future Pages hosting

## Validation
- npm run build
- npm run smoke:frontstage-route
- npm run smoke:frontstage-browser
- npm run smoke:frontstage-share-bundle
- python3 examples/goal-channel-frontstage-fixture-smoke.py
- python3 examples/dashboard-tracked-fixtures-smoke.py
- goal-harness check --scan-path apps/dashboard --scan-path examples/export-frontstage-share-bundle.mjs --scan-path examples/frontstage-share-bundle-smoke.mjs --scan-path examples/status.example.json --scan-path docs/showcases/README.md
- git diff --check

Note: goal-harness check reports the pre-existing duplicate run-history index warning for goal-harness-meta, with no boundary errors.