### PR TITLE
fix: scope refresh-state recommendations by agent lane

### DIFF
--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -881,6 +881,15 @@ If the refresh command was run without `--recommended-action`, the compact
 `recommended_action` should be the first public-safe item from the refreshed
 active state's `## Next Action`, including wrapped continuation lines;
 otherwise it falls back to a generic refresh notice.
+
+When a refresh is scoped with `--agent-id`, the run records
+`progress_scope=agent_lane`. This is a side-lane note, not a project-level
+status transition: status/quota keep selecting the latest non-agent-lane run for
+the goal-level `status` and `recommended_action`, while exposing the side-lane
+note as `agent_lane_recommendation` on the attention item and project asset.
+Use this for side agents that want to record their own lane recommendation
+without replacing the primary controller's next action.
+
 For registered `connected`, `connected-read-only`, and `pre-tick-runnable`
 adapters, custom compact progress classifications that are not blocker, gate,
 or watch classifications also remain Codex-ready. This lets a controller record

--- a/examples/refresh-state-agent-lane-scope-smoke.py
+++ b/examples/refresh-state-agent-lane-scope-smoke.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Smoke-test agent-lane refreshes without stealing goal-level next action."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import goal_harness.state_refresh as state_refresh
+from goal_harness.history import collect_history
+from goal_harness.status import collect_status
+
+
+GOAL_ID = "refresh-state-agent-lane-goal"
+PRIMARY_ACTION = "Run the primary benchmark bootstrap hardening slice."
+SIDE_ACTION = "Polish the hosted frontstage showcase for external developers."
+
+
+def write_fixture(root: Path) -> tuple[Path, Path, Path]:
+    project = root / "project"
+    runtime = root / "runtime"
+    state_file = f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    state_path = project / state_file
+    registry_path = project / ".goal-harness" / "registry.json"
+
+    state_path.parent.mkdir(parents=True)
+    state_path.write_text(
+        "---\n"
+        "status: primary_bootstrap_ready\n"
+        "owner_mode: goal\n"
+        'objective: "Keep primary and side-agent lanes distinct."\n'
+        "updated_at: 2026-06-20T00:00:00+00:00\n"
+        "---\n\n"
+        "# Agent Lane Refresh Fixture\n\n"
+        "## Agent Todo\n\n"
+        f"- [ ] [P0] {PRIMARY_ACTION}\n"
+        "  <!-- goal-harness:todo todo_id=todo_primary status=open "
+        "task_class=advancement_task claimed_by=codex-main-control -->\n"
+        f"- [ ] [P1] {SIDE_ACTION}\n"
+        "  <!-- goal-harness:todo todo_id=todo_side status=open "
+        "task_class=advancement_task claimed_by=codex-side-bypass -->\n\n"
+        "## Next Action\n\n"
+        f"- {PRIMARY_ACTION}\n",
+        encoding="utf-8",
+    )
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "updated_at": "2026-06-20T00:00:00+00:00",
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "refresh-state-agent-lane-fixture",
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": state_file,
+                        "adapter": {"kind": "fixture", "status": "connected-read-only"},
+                        "coordination": {
+                            "primary_agent": "codex-main-control",
+                            "registered_agents": ["codex-main-control", "codex-side-bypass"],
+                        },
+                        "authority_sources": [],
+                    }
+                ],
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return registry_path, runtime, project
+
+
+def main() -> None:
+    original_now_local = state_refresh.now_local
+    try:
+        with tempfile.TemporaryDirectory(prefix="goal-harness-agent-lane-refresh-") as raw_tmp:
+            registry_path, runtime, project = write_fixture(Path(raw_tmp))
+
+            state_refresh.now_local = lambda: "2026-06-20T00:00:00+00:00"
+            state_refresh.refresh_state_run(
+                registry_path=registry_path,
+                runtime_root_override=str(runtime),
+                goal_id=GOAL_ID,
+                project=project,
+                state_file=None,
+                classification="terminal_bench_primary_ready",
+                recommended_action=PRIMARY_ACTION,
+                delivery_batch_scale="multi_surface",
+                delivery_outcome="outcome_progress",
+                dry_run=False,
+                sync_global=False,
+            )
+
+            state_refresh.now_local = lambda: "2026-06-20T00:01:00+00:00"
+            side_payload = state_refresh.refresh_state_run(
+                registry_path=registry_path,
+                runtime_root_override=str(runtime),
+                goal_id=GOAL_ID,
+                project=project,
+                state_file=None,
+                classification="frontstage_side_lane_next",
+                recommended_action=SIDE_ACTION,
+                delivery_batch_scale="single_surface",
+                delivery_outcome="outcome_progress",
+                agent_id="codex-side-bypass",
+                agent_lane="productization_frontstage",
+                dry_run=False,
+                sync_global=False,
+            )
+            assert side_payload["progress_scope"] == "agent_lane", side_payload
+            assert side_payload["agent_id"] == "codex-side-bypass", side_payload
+
+            history = collect_history(
+                registry_path=registry_path,
+                runtime_root=runtime,
+                goal_id=GOAL_ID,
+                limit=5,
+            )
+            goal = history["goals"][0]
+            assert goal["latest_runs"][0]["classification"] == "frontstage_side_lane_next", goal
+            assert goal["latest_status_run"]["classification"] == "terminal_bench_primary_ready", goal
+
+            status = collect_status(
+                registry_path=registry_path,
+                runtime_root_override=str(runtime),
+                scan_roots=[project],
+                limit=5,
+            )
+            items = status["attention_queue"]["items"]
+            item = next(item for item in items if item["goal_id"] == GOAL_ID)
+            assert item["status"] == "terminal_bench_primary_ready", item
+            assert item["recommended_action"] == PRIMARY_ACTION, item
+            lane = item["agent_lane_recommendation"]
+            assert lane["progress_scope"] == "agent_lane", lane
+            assert lane["agent_id"] == "codex-side-bypass", lane
+            assert lane["agent_lane"] == "productization_frontstage", lane
+            assert lane["recommended_action"] == SIDE_ACTION, lane
+            assert item["project_asset"]["agent_lane_recommendation"] == lane, item
+    finally:
+        state_refresh.now_local = original_now_local
+
+    print("refresh-state-agent-lane-scope-smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -5218,6 +5218,17 @@ def main(argv: list[str] | None = None) -> int:
         help="Optional explicit outcome-floor signal for this refresh run.",
     )
     refresh_state_parser.add_argument(
+        "--agent-id",
+        help=(
+            "Registered agent id for agent-lane state refreshes. When set, the "
+            "refresh is visible in run history but does not replace goal-level status."
+        ),
+    )
+    refresh_state_parser.add_argument(
+        "--agent-lane",
+        help="Public-safe lane label for --agent-id scoped refreshes, such as productization_frontstage.",
+    )
+    refresh_state_parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Print the refresh payload without appending.",
@@ -9437,6 +9448,8 @@ def main(argv: list[str] | None = None) -> int:
                 recommended_action=args.recommended_action,
                 delivery_batch_scale=args.delivery_batch_scale,
                 delivery_outcome=args.delivery_outcome,
+                agent_id=args.agent_id,
+                agent_lane=args.agent_lane,
                 dry_run=bool(args.dry_run),
                 sync_global=not bool(args.no_global_sync),
             )

--- a/goal_harness/history.py
+++ b/goal_harness/history.py
@@ -19,6 +19,7 @@ from .registry import read_json, registry_goals
 STATUS_NEUTRAL_CLASSIFICATIONS = {
     "quota_slot_spent",
 }
+AGENT_LANE_PROGRESS_SCOPE = "agent_lane"
 REGISTRY_ATTENTION_FIELDS = (
     "waiting_on",
     "attention_status",
@@ -637,6 +638,8 @@ def append_active_user_assisted_pilot(
 def latest_status_run(runs: list[dict[str, Any]]) -> dict[str, Any] | None:
     for run in runs:
         if str(run.get("classification") or "") in STATUS_NEUTRAL_CLASSIFICATIONS:
+            continue
+        if str(run.get("progress_scope") or "") == AGENT_LANE_PROGRESS_SCOPE:
             continue
         return run
     return None

--- a/goal_harness/state_refresh.py
+++ b/goal_harness/state_refresh.py
@@ -25,6 +25,7 @@ from .todo_contract import (
 
 DEFAULT_REFRESH_CLASSIFICATION = "state_refreshed"
 DEFAULT_REFRESH_ACTION = "inspect refreshed active goal state and continue the next bounded progress segment"
+AGENT_LANE_PROGRESS_SCOPE = "agent_lane"
 RECOMMENDED_ACTION_SECTION_LINE_LIMIT = 16
 BULLET_PREFIX_RE = re.compile(r"^(?:[-*]\s+|\d+[.)]\s+)")
 CHECKBOX_PREFIX_RE = re.compile(r"^\[(?P<mark>[ xX])\]\s+")
@@ -230,6 +231,8 @@ def build_state_refresh_record(
     registry_goal: dict[str, Any] | None,
     delivery_batch_scale: str | None = None,
     delivery_outcome: str | None = None,
+    agent_id: str | None = None,
+    agent_lane: str | None = None,
 ) -> dict[str, Any]:
     frontmatter = parse_frontmatter(state_text)
     next_action = extract_section_lines(state_text, "Next Action")
@@ -271,6 +274,10 @@ def build_state_refresh_record(
         record["delivery_batch_scale"] = delivery_batch_scale
     if delivery_outcome:
         record["delivery_outcome"] = delivery_outcome
+    if agent_id:
+        record["progress_scope"] = AGENT_LANE_PROGRESS_SCOPE
+        record["agent_id"] = agent_id
+        record["agent_lane"] = agent_lane or agent_id
     return record
 
 
@@ -285,6 +292,9 @@ def render_state_refresh_markdown(payload: dict[str, Any]) -> str:
         f"- appended: `{payload.get('appended')}`",
         f"- goal_id: `{payload.get('goal_id')}`",
         f"- classification: `{payload.get('classification')}`",
+        f"- progress_scope: `{payload.get('progress_scope')}`",
+        f"- agent_id: `{payload.get('agent_id')}`",
+        f"- agent_lane: `{payload.get('agent_lane')}`",
         f"- delivery_batch_scale: `{payload.get('delivery_batch_scale')}`",
         f"- delivery_outcome: `{payload.get('delivery_outcome')}`",
         f"- generated_at: `{payload.get('generated_at')}`",
@@ -351,11 +361,21 @@ def refresh_state_run(
     recommended_action: str | None,
     delivery_batch_scale: str | None = None,
     delivery_outcome: str | None = None,
+    agent_id: str | None = None,
+    agent_lane: str | None = None,
     dry_run: bool,
     sync_global: bool = True,
 ) -> dict[str, Any]:
     safe_goal_id = validate_goal_id_path_segment(goal_id)
     validate_public_safe_text("classification", classification)
+    normalized_agent_id = (agent_id or "").strip()
+    normalized_agent_lane = (agent_lane or "").strip()
+    if normalized_agent_id:
+        validate_public_safe_text("agent_id", normalized_agent_id)
+    if normalized_agent_lane:
+        validate_public_safe_text("agent_lane", normalized_agent_lane)
+    if normalized_agent_lane and not normalized_agent_id:
+        raise ValueError("--agent-lane requires --agent-id so the lane has an owner")
     if delivery_batch_scale and delivery_batch_scale not in DELIVERY_BATCH_SCALE_CHOICES:
         raise ValueError(
             "delivery_batch_scale must be one of: " + ", ".join(DELIVERY_BATCH_SCALE_CHOICES)
@@ -371,6 +391,21 @@ def refresh_state_run(
         project_override=project,
         state_file_override=state_file,
     )
+    if normalized_agent_id and registry_goal:
+        coordination = registry_goal.get("coordination") if isinstance(registry_goal.get("coordination"), dict) else {}
+        registered_raw = coordination.get("registered_agents") if isinstance(coordination, dict) else []
+        registered_agents = []
+        registered_values = registered_raw if isinstance(registered_raw, list) else []
+        for value in registered_values:
+            if isinstance(value, dict):
+                registered_agents.append(str(value.get("id") or ""))
+            else:
+                registered_agents.append(str(value or ""))
+        registered_agents = [value for value in registered_agents if value]
+        if registered_agents and normalized_agent_id not in registered_agents:
+            raise ValueError(
+                f"agent_id {normalized_agent_id!r} is not registered for goal {safe_goal_id!r}"
+            )
     if not resolved_state_file.exists():
         raise FileNotFoundError(f"state file does not exist: {resolved_state_file}")
     state_text = resolved_state_file.read_text(encoding="utf-8")
@@ -387,6 +422,8 @@ def refresh_state_run(
         registry_goal=registry_goal,
         delivery_batch_scale=delivery_batch_scale,
         delivery_outcome=normalized_delivery_outcome,
+        agent_id=normalized_agent_id or None,
+        agent_lane=normalized_agent_lane or None,
     )
 
     runs_dir = runtime_root / "goals" / safe_goal_id / "runs"
@@ -405,6 +442,10 @@ def refresh_state_run(
         index_record["delivery_batch_scale"] = delivery_batch_scale
     if normalized_delivery_outcome:
         index_record["delivery_outcome"] = normalized_delivery_outcome
+    if normalized_agent_id:
+        index_record["progress_scope"] = AGENT_LANE_PROGRESS_SCOPE
+        index_record["agent_id"] = normalized_agent_id
+        index_record["agent_lane"] = normalized_agent_lane or normalized_agent_id
     payload = {
         "ok": True,
         "dry_run": dry_run,
@@ -414,6 +455,9 @@ def refresh_state_run(
         "project": str(resolved_project) if resolved_project else None,
         "goal_id": safe_goal_id,
         "classification": classification,
+        "progress_scope": record.get("progress_scope"),
+        "agent_id": record.get("agent_id"),
+        "agent_lane": record.get("agent_lane"),
         "recommended_action": action,
         "generated_at": generated_at,
         "health_check": record["health_check"],

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -76,6 +76,7 @@ STATUS_NEUTRAL_CLASSIFICATIONS = {
     QUOTA_MONITOR_POLL_CLASSIFICATION,
     *PROMOTION_READINESS_CLASSIFICATIONS,
 }
+AGENT_LANE_PROGRESS_SCOPE = "agent_lane"
 HANDOFF_READY_CLASSIFICATIONS = {
     "operator_gate_approved",
     "controller_opted_in_waiting_for_run",
@@ -5587,7 +5588,46 @@ def collect_global_registry_health(
 
 
 def is_status_neutral_run(run: dict[str, Any]) -> bool:
-    return str(run.get("classification") or "") in STATUS_NEUTRAL_CLASSIFICATIONS
+    return (
+        str(run.get("classification") or "") in STATUS_NEUTRAL_CLASSIFICATIONS
+        or str(run.get("progress_scope") or "") == AGENT_LANE_PROGRESS_SCOPE
+    )
+
+
+def latest_agent_lane_run(goal: dict[str, Any]) -> dict[str, Any] | None:
+    runs = goal.get("latest_runs")
+    if not isinstance(runs, list):
+        return None
+    for run in runs:
+        if not isinstance(run, dict):
+            continue
+        if str(run.get("progress_scope") or "") == AGENT_LANE_PROGRESS_SCOPE:
+            return run
+    return None
+
+
+def compact_agent_lane_recommendation(run: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(run, dict):
+        return None
+    action = public_safe_compact_text(run.get("recommended_action"), limit=220)
+    if not action:
+        return None
+    compact: dict[str, Any] = {
+        "schema_version": "agent_lane_recommendation_v0",
+        "progress_scope": AGENT_LANE_PROGRESS_SCOPE,
+        "recommended_action": action,
+    }
+    for field in (
+        "agent_id",
+        "agent_lane",
+        "classification",
+        "generated_at",
+        "delivery_batch_scale",
+        "delivery_outcome",
+    ):
+        if run.get(field) is not None:
+            compact[field] = run.get(field)
+    return compact
 
 
 def latest_run(goal: dict[str, Any]) -> dict[str, Any] | None:
@@ -6097,6 +6137,11 @@ def build_attention_queue(
             if control_plane:
                 item["control_plane"] = control_plane
             goal_latest_runs = goal.get("latest_runs") if isinstance(goal.get("latest_runs"), list) else []
+            agent_lane_recommendation = compact_agent_lane_recommendation(
+                latest_agent_lane_run(goal)
+            )
+            if agent_lane_recommendation:
+                item["agent_lane_recommendation"] = agent_lane_recommendation
             subagent_activity = subagent_activity_for_goal(goal)
             interface_budget_cadence = interface_budget_cadence_for_runs(goal_latest_runs)
             projection_warning = active_state_projection_warning(goal, latest_run(goal))
@@ -6119,6 +6164,8 @@ def build_attention_queue(
             )
             if control_plane and isinstance(item.get("project_asset"), dict):
                 item["project_asset"]["control_plane"] = control_plane
+            if agent_lane_recommendation and isinstance(item.get("project_asset"), dict):
+                item["project_asset"]["agent_lane_recommendation"] = agent_lane_recommendation
             if projection_warning:
                 item["stale_latest_run_warning"] = projection_warning
                 if isinstance(item.get("project_asset"), dict):
@@ -7394,6 +7441,21 @@ def render_status_markdown(payload: dict[str, Any]) -> str:
             asset_next_action = _markdown_scalar(project_asset.get("next_action") or "")
             if asset_next_action:
                 lines.append(f"    - asset_next_action: {asset_next_action}")
+            agent_lane_recommendation = (
+                project_asset.get("agent_lane_recommendation")
+                if isinstance(project_asset.get("agent_lane_recommendation"), dict)
+                else {}
+            )
+            if agent_lane_recommendation:
+                lane = _markdown_scalar(agent_lane_recommendation.get("agent_lane") or "")
+                agent = _markdown_scalar(agent_lane_recommendation.get("agent_id") or "")
+                recommendation = _markdown_scalar(
+                    agent_lane_recommendation.get("recommended_action") or ""
+                )
+                lines.append(
+                    "    - agent_lane_recommendation: "
+                    f"agent={agent} lane={lane} action={recommendation}"
+                )
             dreaming_lane_badge = (
                 project_asset.get("dreaming_lane_badge")
                 if isinstance(project_asset.get("dreaming_lane_badge"), dict)


### PR DESCRIPTION
## Summary
- add optional refresh-state --agent-id/--agent-lane metadata for side-agent lane notes
- keep agent-lane refreshes in run history while skipping them for goal-level latest status selection
- expose agent_lane_recommendation on status/project_asset so side-lane guidance remains visible without replacing primary next action

## Validation
- python3 -m py_compile goal_harness/state_refresh.py goal_harness/status.py goal_harness/history.py goal_harness/cli.py examples/refresh-state-agent-lane-scope-smoke.py
- python3 examples/refresh-state-agent-lane-scope-smoke.py
- python3 examples/refresh-state-unique-run-path-smoke.py
- python3 examples/work-lane-contract-smoke.py
- python3 examples/docs-governance-smoke.py
- python3 examples/status-markdown-smoke.py
- git diff --check
- goal-harness check --scan-path goal_harness/state_refresh.py --scan-path goal_harness/status.py --scan-path goal_harness/history.py --scan-path goal_harness/cli.py --scan-path examples/refresh-state-agent-lane-scope-smoke.py --scan-path docs/status-data-contract.md

Note: python3 examples/quota-contract-smoke.py currently fails on origin/main because README is missing an older quota-plan advisory sentence; this PR does not touch that surface.