### PR TITLE
Document frontstage role map

### DIFF
--- a/apps/dashboard/README.md
+++ b/apps/dashboard/README.md
@@ -38,6 +38,15 @@ contract lanes. Treat it as the product-path replacement for expanding the
 no-dependency static HTML renderer; the Python renderer remains the fallback
 demo/diagnostic surface.
 
+The frontstage first screen is meant to teach the control-plane model before a
+developer reads raw status JSON. The top operations strip answers whether the
+human gate is explicit, whether agent work is active, how many lanes are
+claimed, and whether recent evidence exists. The `Role Map` then separates the
+owner, agent lane, and claim-owner responsibilities so a new contributor can
+tell which part of the system is waiting, running, or coordinating side work.
+Both panels are derived from the read-only projection; they are not browser
+write authority.
+
 For live local control-plane inspection, open
 `/frontstage?statusUrl=http://127.0.0.1:8766/status.json`. The route reads
 `attention_queue.items[].goal_channel_projection` and stays read-only; if the

--- a/apps/dashboard/smoke/frontstage-route-smoke.ts
+++ b/apps/dashboard/smoke/frontstage-route-smoke.ts
@@ -61,6 +61,10 @@ excludes(frontstageSource, "method=", "form method");
 excludes(frontstageSource, "onclick=", "inline click handler");
 
 includes(readmeSource, "/frontstage", "README frontstage route mention");
+includes(readmeSource, "operations strip", "README operations strip explanation");
+includes(readmeSource, "Role Map", "README role map explanation");
+includes(readmeSource, "read-only projection", "README read-only projection boundary");
+includes(readmeSource, "write authority", "README write authority boundary");
 includes(selectionSource, "Multica", "Multica benchmark note");
 includes(selectionSource, "agent board", "agent board benchmark note");
 


### PR DESCRIPTION
## Summary
- explain the frontstage operations strip and Role Map in the dashboard README
- clarify that these panels are derived from the read-only projection and are not browser write authority
- extend the frontstage route smoke so the developer-facing explanation stays covered

## Validation
- npm run smoke:frontstage-route
- python3 examples/docs-governance-smoke.py
- git diff --check
- goal-harness check --scan-path apps/dashboard/README.md --scan-path apps/dashboard/smoke/frontstage-route-smoke.ts

## Self-merge rationale
Small public dashboard docs plus a durable smoke only; no runtime, benchmark, permission, write-authority, private-state, or evidence-policy changes.