### PR TITLE
Fix frontstage Pages router basepath

### DIFF
--- a/apps/dashboard/smoke/frontstage-route-smoke.ts
+++ b/apps/dashboard/smoke/frontstage-route-smoke.ts
@@ -26,6 +26,8 @@ const packageSource = readFileSync("package.json", "utf8");
 includes(routerSource, 'path: "/frontstage"', "frontstage route path");
 includes(routerSource, "component: FrontstagePage", "frontstage route component");
 includes(routerSource, "frontstageSearchSchema", "frontstage search schema");
+includes(routerSource, "basepath:", "router basepath option");
+includes(routerSource, "import.meta.env.BASE_URL", "Vite base URL router source");
 includes(packageSource, '"smoke:frontstage-browser"', "frontstage browser smoke script");
 includes(packageSource, '"smoke:frontstage-route"', "frontstage smoke script");
 

--- a/apps/dashboard/src/router.tsx
+++ b/apps/dashboard/src/router.tsx
@@ -43,7 +43,18 @@ export const frontstageRoute = createRoute({
 
 const routeTree = rootRoute.addChildren([dashboardRoute, frontstageRoute]);
 
-export const router = createRouter({ routeTree });
+function routerBasepathFromViteBase(baseUrl: string) {
+  if (!baseUrl || baseUrl === "/" || baseUrl === "./") {
+    return "/";
+  }
+  const withLeadingSlash = baseUrl.startsWith("/") ? baseUrl : `/${baseUrl}`;
+  return withLeadingSlash.replace(/\/+$/, "") || "/";
+}
+
+export const router = createRouter({
+  routeTree,
+  basepath: routerBasepathFromViteBase(import.meta.env.BASE_URL),
+});
 
 declare module "@tanstack/react-router" {
   interface Register {

--- a/examples/frontstage-share-bundle-smoke.mjs
+++ b/examples/frontstage-share-bundle-smoke.mjs
@@ -65,6 +65,11 @@ assertExists(resolve(siteDir, "status.frontstage-share.json"));
 assertExists(resolve(outDir, "README.md"));
 assertExists(resolve(outDir, "frontstage-share-manifest.json"));
 
+const routerSource = await readFile(resolve(repoRoot, "apps/dashboard/src/router.tsx"), "utf8");
+if (!routerSource.includes("basepath:") || !routerSource.includes("import.meta.env.BASE_URL")) {
+  throw new Error("dashboard router must derive basepath from Vite BASE_URL for GitHub Pages");
+}
+
 const status = JSON.parse(await readFile(resolve(siteDir, "status.frontstage-share.json"), "utf8"));
 if (status.attention_queue?.items?.[0]?.goal_channel_projection?.schema_version !== "goal_channel_projection_v0") {
   throw new Error("share fixture did not include goal_channel_projection_v0");


### PR DESCRIPTION
## Summary
- derive the TanStack Router basepath from Vite BASE_URL so GitHub Pages /goal-harness/frontstage routes match the app routes
- add route smoke coverage for the BASE_URL-backed router basepath
- extend the Pages share-bundle smoke so the CI path checks the router basepath contract

## Validation
- npm run smoke:frontstage-share-bundle
- npm run smoke:frontstage-route
- npm run build
- npm run export:frontstage-share -- --base /goal-harness/ --out-dir /tmp/goal-harness-frontstage-pages-base-test
- local Pages simulation under /goal-harness/ with Chrome: /goal-harness/frontstage/?statusUrl=%2Fgoal-harness%2Fstatus.frontstage-share.json rendered Role Map and operations strip instead of Not Found
- git diff --check
- goal-harness check --scan-path apps/dashboard/src/router.tsx --scan-path apps/dashboard/smoke/frontstage-route-smoke.ts --scan-path examples/frontstage-share-bundle-smoke.mjs

## Self-merge rationale
Small public frontend routing fix plus durable smokes; no benchmark, runtime write authority, permission, private-state, or evidence-policy changes.