### PR TITLE
Scrub dashboard demo to showcase data

### DIFF
--- a/apps/dashboard/README.md
+++ b/apps/dashboard/README.md
@@ -273,10 +273,10 @@ node examples/dashboard-operator-gate-browser-smoke.mjs
 
 The home browser smoke protects the canonical control-plane home. It uses a
 public-safe four-project fixture, opens the root route without `view=share`,
-checks the Chinese operator copy for user todos, agent priorities, p4/p3
-concurrency, quota guard state, per-project top-4 todo status, and state
+checks the Chinese operator copy for user todos, agent priorities, showcase
+activity, quota guard state, per-project top-4 todo status, and state
 writeback, and rejects raw machine tokens such as `single_surface`,
-`focus_wait`, or `active p4 <= 2` on the first screen. It also captures desktop
+`focus_wait`, or raw internal slot constraints on the first screen. It also captures desktop
 and mobile first-screen / decision-frame screenshots under
 `output/playwright/dashboard-home-visual-acceptance/` and fails on horizontal
 overflow so density regressions are visible before calling the frontend broadly

--- a/apps/dashboard/smoke/action-packet-smoke.ts
+++ b/apps/dashboard/smoke/action-packet-smoke.ts
@@ -9,19 +9,19 @@ function assert(condition: boolean, message: string) {
 }
 
 const packet = buildActionPacket({
-  goalId: "premium-ui-ai-search-rec-migration",
+  goalId: "showcase-safe-route",
   title: "Review or authorize",
   summary: "production still blocked; owner/SOP snapshot has 9 blockers, but only two user todos are open",
-  userTodoText: "Read the core Lark document section 8 first. Focus on 当前结论 and the Nacos diff 快速锚点 / Diff Anchors table.",
+  userTodoText: "Read the public decision memo section 8 first. Focus on 当前结论 and the config diff 快速锚点 / Diff Anchors table.",
   agentTodoText: "Run the read-only map dry-run after the owner todo is resolved; stop before writes.",
   todoBlocksGate: true,
-  operatorQuestion: "是否同意 premium-ui 迁移在 owner/SOP review 后继续推进？",
+  operatorQuestion: "是否同意 showcase safe route 在 owner/SOP review 后继续推进？",
   suggestedReply: "同意继续 safe-local/offline 路径 / 暂不同意 + 一句话原因。",
   gateFallbackDecision: "同意继续 safe-local/offline 路径；不授权写入或生产动作。",
-  boundary: "不要执行 Nacos 写入、Prem metadata upsert、workflow creation 或生产状态变化。",
+  boundary: "不要执行配置写入、metadata upsert、workflow creation 或生产状态变化。",
   durableRecordRule: "记录规则：先用 operator-gate dry-run 预览；确认写入时去掉 --dry-run。",
   safePathLabel: "Read-only map dry-run",
-  command: "goal-harness read-only-map --goal-id premium-ui-ai-search-rec-migration --dry-run",
+  command: "goal-harness read-only-map --goal-id showcase-safe-route --dry-run",
   quotaShortLine: "Operator gate; 0/1440 slots",
   authorityShortLine: "default entries 10/10; topic 10; materials 6; owner review 1; stale 1; risk medium",
   projectOwner: "user_or_controller",
@@ -40,14 +40,14 @@ assert(packet.includes("Project Asset：Owner=user_or_controller；Gate=owner_so
 assert(packet.includes("Next：Project asset says the owner/SOP review is the current authority."), "missing project-asset next action");
 assert(packet.includes("Stop：Stop before write-control or production mutation."), "missing project-asset stop condition");
 assert(packet.includes("Handoff：ready; codex_ready=true; source=project_asset; quota=eligible; failed=none"), "missing handoff readiness");
-assert(packet.includes("待办：Read the core Lark document section 8 first."), "missing first user todo");
+assert(packet.includes("待办：Read the public decision memo section 8 first."), "missing first user todo");
 assert(packet.includes("先处理/暂缓再判 gate"), "missing todo-before-gate cue");
-assert(packet.includes("Gate：是否同意 premium-ui 迁移"), "missing gate question");
+assert(packet.includes("Gate：是否同意 showcase safe route"), "missing gate question");
 assert(packet.includes("【给项目 Agent】"), "missing project-agent handoff section");
 assert(packet.includes("待办：Run the read-only map dry-run after the owner todo is resolved; stop before writes."), "missing first agent todo");
 assert(packet.includes("路径：Read-only map dry-run"), "missing safe path");
 assert(packet.includes("上下文：只信当前 state/status/history 与命令输出"), "missing agent context rule");
-assert(packet.includes("不授权写入或生产动作") || packet.includes("不要执行 Nacos 写入"), "missing safety boundary");
+assert(packet.includes("不授权写入或生产动作") || packet.includes("不要执行配置写入"), "missing safety boundary");
 assert(packet.length > 600 && packet.length < 1200, `unexpected packet length: ${packet.length}`);
 assert(
   packet.indexOf("【用户/Gate】") < packet.indexOf("【给项目 Agent】"),

--- a/apps/dashboard/smoke/home-route-smoke.ts
+++ b/apps/dashboard/smoke/home-route-smoke.ts
@@ -21,6 +21,19 @@ const readmeSource = readFileSync("README.md", "utf8");
 const contractSource = readFileSync("../../docs/status-data-contract.md", "utf8");
 const packageSource = readFileSync("package.json", "utf8");
 
+const shareGoalSpecStart = dashboardSource.indexOf("const shareGoalSpecs");
+const shareGoalSpecEnd = dashboardSource.indexOf("const shareStatusLabel", shareGoalSpecStart);
+assert(shareGoalSpecStart >= 0 && shareGoalSpecEnd > shareGoalSpecStart, "missing share goal spec block");
+const shareGoalSpecBlock = dashboardSource.slice(shareGoalSpecStart, shareGoalSpecEnd);
+const shareGoalIds = [...shareGoalSpecBlock.matchAll(/id: "([^"]+)"/g)].map((match) => match[1]);
+assert(shareGoalIds.length >= 4, "expected public showcase goal specs");
+for (const goalId of shareGoalIds) {
+  assert(
+    goalId.startsWith("showcase-") || goalId === "goal-harness-meta",
+    `public dashboard goal spec must use showcase/meta id: ${goalId}`,
+  );
+}
+
 includes(routerSource, 'view: z.enum(["ops", "share"]).optional()', "optional view search param");
 excludes(routerSource, 'view: z.enum(["ops", "share"]).optional().default("share")', "share default route mode");
 
@@ -42,13 +55,13 @@ includes(dashboardSource, "Top-4 Todo", "share top-four todo label");
 includes(dashboardSource, "已完成", "share todo done status");
 includes(dashboardSource, "决策需 rebase", "share decision freshness warning");
 includes(dashboardSource, "这不是仓库回滚", "share decision non-rollback copy");
-includes(dashboardSource, '最多 2 个 p4 运行中', "Chinese p4 concurrency constraint");
+includes(dashboardSource, "synthetic-only", "showcase synthetic-only boundary");
 includes(dashboardSource, '单面改动', "Chinese delivery scale label");
 includes(dashboardSource, '阻塞说明', "Chinese blocker label");
 includes(dashboardSource, '配额守卫', "Chinese quota guard label");
 includes(dashboardSource, '状态写回', "Chinese state writeback label");
 includes(dashboardSource, '<h1 className="text-2xl font-semibold">Goal Operations</h1>', "ops workbench fallback");
-excludes(dashboardSource, '{"active p4 <= 2"}', "raw p4 constraint badge");
+excludes(dashboardSource, "raw internal slot constraints", "raw internal constraint copy");
 includes(packageSource, '"smoke:home-route"', "home route smoke script");
 includes(packageSource, '"smoke:home-browser"', "home browser smoke script");
 includes(packageSource, '"smoke:demo-readiness"', "demo readiness smoke script");

--- a/apps/dashboard/src/views/dashboard-page.tsx
+++ b/apps/dashboard/src/views/dashboard-page.tsx
@@ -2363,26 +2363,26 @@ type ShareGoalView = {
 
 const shareGoalSpecs: ShareGoalSpec[] = [
   {
-    id: "premium-ui-ai-search-rec-migration",
-    label: "平台迁移",
-    subtitle: "AI Search / ZJXMT 迁移控制",
-    emphasis: "把用户确认项、Agent 本地研究、Nacos 前置风险拆开管理。",
+    id: "showcase-user-gate-safe-side-path",
+    label: "0617 User Gate",
+    subtitle: "公开 showcase / safe side path",
+    emphasis: "把用户决策、Agent 待办和安全侧路拆开管理：该等人的地方明确等人。",
     accent: "border-t-emerald-500",
     icon: GitBranch,
   },
   {
-    id: "tiger-team-maiduidui-regauc",
-    label: "埋堆堆打平",
-    subtitle: "RegAUC 实验推进",
-    emphasis: "已授权主动推进，但必须遵守最多 2 个 p4、最多 2 个 p3 运行中的并发约束。",
+    id: "showcase-creator-operator",
+    label: "Creator Operator",
+    subtitle: "合成案例 / 长程内容运营",
+    emphasis: "让多个 Agent 围绕热点、素材、洞察和创作 backlog 持续推进，但只展示脱敏 showcase 数据。",
     accent: "border-t-amber-500",
     icon: Gauge,
   },
   {
-    id: "agent-harness-side-bypass",
-    label: "Agent Harness 旁路",
-    subtitle: "TAU2 排序器 / 跨域证据",
-    emphasis: "停止重复小步，要求排序器或跨域证据；做不到就不花配额、直接报告阻塞。",
+    id: "showcase-side-agent-self-iteration",
+    label: "Side Agent 自迭代",
+    subtitle: "公开 repo 事实 / 旁路产品化",
+    emphasis: "主控聚焦高风险主线，旁路 Agent 在独立 worktree 中推进产品化、文档和展示。",
     accent: "border-t-rose-500",
     icon: ShieldCheck,
   },
@@ -2776,17 +2776,17 @@ function shareStatusForGoal(view: ShareGoalView): { label: string; summary: stri
       variant: "warning",
     };
   }
-  if (view.spec.id === "premium-ui-ai-search-rec-migration" && (view.userTodos?.open_count ?? 0) > 0) {
+  if (view.spec.id === "showcase-user-gate-safe-side-path" && (view.userTodos?.open_count ?? 0) > 0) {
     return {
       label: "用户待办已捕获",
-      summary: "源 topic/table 权威确认被单独留给用户，Agent 不会越权重启或上传。",
+      summary: "用户决策被单独留给 owner；Agent 只推进与该决策独立的安全侧路。",
       variant: "warning",
     };
   }
-  if (view.spec.id === "tiger-team-maiduidui-regauc") {
+  if (view.spec.id === "showcase-creator-operator") {
     return {
-      label: "已授权主动推进",
-      summary: "可用 open p4/p3 槽位推进，但必须写回 board 与 project ledger。",
+      label: "合成场景主动推进",
+      summary: "创作运营 backlog 可持续推进，但前台只呈现公开 showcase 和合成数据。",
       variant: "info",
     };
   }
@@ -3139,14 +3139,14 @@ function ShareGuardEvidence({
   payload: StatusPayload;
   views: ShareGoalView[];
 }) {
-  const side = views.find((view) => view.spec.id === "agent-harness-side-bypass");
-  const tiger = views.find((view) => view.spec.id === "tiger-team-maiduidui-regauc");
+  const side = views.find((view) => view.spec.id === "showcase-side-agent-self-iteration");
+  const creator = views.find((view) => view.spec.id === "showcase-creator-operator");
   const meta = views.find((view) => view.spec.id === "goal-harness-meta");
-  const premium = views.find((view) => view.spec.id === "premium-ui-ai-search-rec-migration");
+  const gate = views.find((view) => view.spec.id === "showcase-user-gate-safe-side-path");
   const sideGap = side?.row?.queueItem?.handoff_readiness?.post_handoff_outcome_gap_streak
     ?? side?.row?.queueItem?.quota?.post_handoff_outcome_gap_streak
     ?? 0;
-  const tigerUsage = tiger?.usage;
+  const creatorUsage = creator?.usage;
   const metaUsage = meta?.usage;
 
   return (
@@ -3188,28 +3188,28 @@ function ShareGuardEvidence({
         />
 
         <ShareSignalCard
-          body={`24h 已花 ${tigerUsage?.quota_spend_slots_24h ?? 0} 个配额槽，进展信号 ${tigerUsage?.progress_signal_run_count_24h ?? 0}；推进必须落到任务、失败标记、评估或账本。`}
+          body={`24h 已花 ${creatorUsage?.quota_spend_slots_24h ?? 0} 个配额槽，进展信号 ${creatorUsage?.progress_signal_run_count_24h ?? 0}；创作运营推进必须落到任务、证据、回顾或可展示产物。`}
           icon={Gauge}
           metrics={[
-            { label: "24h quota", value: `${tigerUsage?.quota_spend_slots_24h ?? 0} slots` },
-            { label: "并发边界", value: "最多 2 个 p4 运行中" },
-            { label: "补充边界", value: "最多 2 个 p3 运行中" },
+            { label: "24h quota", value: `${creatorUsage?.quota_spend_slots_24h ?? 0} slots` },
+            { label: "素材 backlog", value: "热点 / 洞察 / 语料" },
+            { label: "展示边界", value: "synthetic-only" },
           ]}
           status={{ label: "主动推进", variant: "info" }}
           steps={[
-            { label: "触发", value: "已授权推进" },
-            { label: "控制", value: "配额 + 并发约束" },
-            { label: "写回", value: "board + ledger" },
+            { label: "触发", value: "长期创作目标" },
+            { label: "控制", value: "配额 + 证据边界" },
+            { label: "写回", value: "showcase + backlog" },
           ]}
-          title="埋堆堆：授权推进但要留痕"
+          title="Creator Operator：昼夜不断的合成运营队列"
           tone="amber"
         />
 
         <ShareSignalCard
-          body={`平台迁移保留 ${premium?.userTodos?.open_count ?? 0} 个真实用户待办；Meta 24h 进展信号 ${metaUsage?.progress_signal_run_count_24h ?? 0}，当前合约错误 ${payload.contract.summary.errors}。`}
+          body={`User-gate showcase 保留 ${gate?.userTodos?.open_count ?? 0} 个 owner 决策；Meta 24h 进展信号 ${metaUsage?.progress_signal_run_count_24h ?? 0}，当前合约错误 ${payload.contract.summary.errors}。`}
           icon={FileCheck2}
           metrics={[
-            { label: "真实用户 gate", value: `${premium?.userTodos?.open_count ?? 0} open` },
+            { label: "公开 user gate", value: `${gate?.userTodos?.open_count ?? 0} open` },
             { label: "Meta 进展", value: `${metaUsage?.progress_signal_run_count_24h ?? 0} signals` },
             { label: "全局发现", value: `${payload.global_registry.summary.findings} findings` },
           ]}
@@ -3219,7 +3219,7 @@ function ShareGuardEvidence({
             { label: "控制", value: "registry 真相源" },
             { label: "写回", value: "active-state 写回" },
           ]}
-          title="平台迁移 + Meta：状态真相"
+          title="Showcase + Meta：状态真相"
           tone="emerald"
         />
       </div>
@@ -3370,14 +3370,14 @@ function ShareEvidenceView({
               <div className="max-w-3xl">
                 <div className="flex flex-wrap items-center gap-2">
                   <Badge variant="success">Goal Harness 控制面</Badge>
-                  <Badge variant="neutral">四项目实证</Badge>
+                  <Badge variant="neutral">公开 showcase</Badge>
                   <Badge variant={payload.ok ? "success" : "danger"}>{payload.ok ? "状态健康" : "健康阻塞"}</Badge>
                 </div>
                 <h1 className="mt-3 text-3xl font-semibold leading-tight tracking-normal text-slate-950 sm:text-4xl sm:leading-tight">
                   把多项目 Agent 工作变成可管理的 Todo、证据和配额
                 </h1>
                 <p className="mt-3 max-w-3xl text-base leading-7 text-slate-600">
-                  这个看板把平台迁移、埋堆堆打平、Agent Harness 旁路和 Goal Harness Meta 统一到同一套控制面：
+                  这个看板只展示公开 showcases：user gate、side-agent 自迭代、creator operator 和 Goal Harness Meta 统一到同一套控制面。
                   用户待办单独挂起，Agent 高优任务继续推进，配额守卫和交接合约负责防止重复空转。
                 </p>
               </div>

--- a/examples/codex-cli-long-run-benchmark-design-smoke.py
+++ b/examples/codex-cli-long-run-benchmark-design-smoke.py
@@ -77,11 +77,11 @@ REQUIRED_PHRASES = (
 )
 
 FORBIDDEN_PHRASES = (
-    "/Users/bytedance/",
-    "agent-harness-side-bypass",
-    "tiger-team",
-    "premium-ui",
-    "OpenViking",
+    "PRIVATE_HOME/",
+    "internal-project-alpha",
+    "internal-team-beta",
+    "internal-product-gamma",
+    "private-runtime-delta",
 )
 
 

--- a/examples/codex-cli-long-run-regression-spec-smoke.py
+++ b/examples/codex-cli-long-run-regression-spec-smoke.py
@@ -68,11 +68,11 @@ REQUIRED_PHRASES = (
 )
 
 FORBIDDEN_PHRASES = (
-    "agent-harness-side-bypass",
-    "tiger-team",
-    "premium-ui",
-    "OpenViking",
-    "/Users/bytedance/",
+    "internal-project-alpha",
+    "internal-team-beta",
+    "internal-product-gamma",
+    "private-runtime-delta",
+    "PRIVATE_HOME/",
     "~/.codex/sessions",
 )
 

--- a/examples/codex-subagent-orchestration-contract-smoke.py
+++ b/examples/codex-subagent-orchestration-contract-smoke.py
@@ -33,7 +33,7 @@ REQUIRED_PHRASES = (
 )
 
 FORBIDDEN_PHRASES = (
-    "/Users/bytedance/",
+    "PRIVATE_HOME/",
     "lark" + "office.com",
     "~/.codex/sessions",
     "raw_thread",

--- a/examples/dashboard-home-browser-smoke.mjs
+++ b/examples/dashboard-home-browser-smoke.mjs
@@ -43,22 +43,22 @@ const quotaFocusWait = {
 
 const goalSpecs = [
   {
-    id: "premium-ui-ai-search-rec-migration",
-    domain: "platform-migration-fixture",
+    id: "showcase-user-gate-safe-side-path",
+    domain: "showcase-user-gate-fixture",
     status: "state_refreshed",
     waiting_on: "user_or_controller",
     quota: { ...quotaEligible, state: "operator_gate" },
-    userTodos: { open: 1, done: 3, total: 4, next: "请确认 ZJXMT 源 topic/table 权威来源。" },
+    userTodos: { open: 1, done: 3, total: 4, next: "请确认 owner 选项 A/B 的取舍。" },
     userTodoItems: [
-      { done: false, text: "请确认 ZJXMT 源 topic/table 权威来源；未确认前不做 Nacos 上传或任务重启。" },
+      { done: false, text: "请确认 owner 选项 A/B 的取舍；未确认前不推进 gated route。" },
       { done: true, text: "已读完核心迁移文档第 8 节，并确认当前结论。" },
       { done: true, text: "已确认 item embedding 不阻塞当前 P0 i2i 路径。" },
       { done: true, text: "已确认 P0 degrade 走统一标准品策略。" },
     ],
-    agentTodos: { open: 4, done: 0, total: 4, next: "验证四个 P0 本地迁移场景。" },
+    agentTodos: { open: 4, done: 0, total: 4, next: "推进与 owner 决策独立的 safe side path。" },
     agentTodoItems: [
-      { done: false, text: "验证四个 P0 本地迁移场景，输出 scene_1/4/6/7 的本地证据。" },
-      { done: false, text: "复查 Nacos 前置条件，确认 upload 前没有 source topic/table 漂移。" },
+      { done: false, text: "推进与 owner 决策独立的 safe side path，输出公开可复现证据。" },
+      { done: false, text: "复查公开边界，确认 showcase 数据不包含内部项目名或生产细节。" },
       { done: false, text: "按安全再生成计划只写私有 tmp_data，不触碰生产配置。" },
       { done: false, text: "把关闭的 P0 阻塞和剩余 gate 写回迁移目标状态。" },
     ],
@@ -72,33 +72,33 @@ const goalSpecs = [
     },
   },
   {
-    id: "tiger-team-maiduidui-regauc",
-    domain: "maiduidui-fixture",
+    id: "showcase-creator-operator",
+    domain: "creator-operator-fixture",
     status: "state_refreshed",
     waiting_on: "codex",
     quota: quotaEligible,
     userTodos: { open: 0, done: 1, total: 1, next: null },
     userTodoItems: [
-      { done: true, text: "用户已授权埋堆堆控制器主动推进。" },
+      { done: true, text: "用户已授权 creator operator 使用合成素材主动推进。" },
     ],
-    agentTodos: { open: 4, done: 0, total: 4, next: "巡检 active p4/p3 占用并写回 board 与 ledger。" },
+    agentTodos: { open: 4, done: 0, total: 4, next: "整理热点、洞察、语料和创作 backlog。" },
     agentTodoItems: [
-      { done: false, text: "巡检 active p4/p3 占用，确认最多 2 个 p4、最多 2 个 p3 运行中。" },
-      { done: false, text: "检查半年度 0.75 eval availability 和 monometrics_eval.txt 是否出现。" },
-      { done: false, text: "如有可启动候选，先验证 prod-compile-clean 再 launch。" },
-      { done: false, text: "每次 launch / fail / eval / retire 都写回 board 和 project ledger。" },
+      { done: false, text: "整理各平台热点，形成按偏好排序的创作候选。" },
+      { done: false, text: "提炼热点洞察，补充素材库和语料库。" },
+      { done: false, text: "把可用素材转成文章或视频脚本草稿。" },
+      { done: false, text: "每次产出都写回 showcase backlog 和证据 ledger。" },
     ],
     latest: {
       generated_at: "2026-01-01T00:01:00+00:00",
       classification: "state_refreshed",
       delivery_batch_scale: "implementation",
-      health_check: "fixture MDD active-delivery authorization",
+      health_check: "fixture creator-operator active-delivery authorization",
       json_exists: true,
       markdown_exists: true,
     },
   },
   {
-    id: "agent-harness-side-bypass",
+    id: "showcase-side-agent-self-iteration",
     domain: "side-bypass-fixture",
     status: "state_refreshed",
     waiting_on: "codex",
@@ -274,19 +274,19 @@ const statusFixture = {
           source: "agent_todos",
         },
         {
-          goal_id: "tiger-team-maiduidui-regauc",
+          goal_id: "showcase-creator-operator",
           status: "state_refreshed",
           waiting_on: "codex",
           quota_state: "eligible",
           priority: "P2",
           todo_index: 1,
-          text: "巡检 active p4/p3 占用，确认最多 2 个 p4、最多 2 个 p3 运行中。",
+          text: "整理热点、洞察、语料和创作 backlog。",
           source: "agent_todos",
         },
       ],
     },
     items: goalSpecs.map((spec) => {
-      const sideBypass = goalSpecs.find((goal) => goal.id === "agent-harness-side-bypass");
+      const sideBypass = goalSpecs.find((goal) => goal.id === "showcase-side-agent-self-iteration");
       const sideBypassUserTodo = sideBypass?.userTodoItems?.find((todo) => !todo.done);
       return {
         goal_id: spec.id,
@@ -305,7 +305,7 @@ const statusFixture = {
               source: "attention_queue.user_todos",
               open_count: 1,
               items: [{
-                goal_id: "agent-harness-side-bypass",
+                goal_id: "showcase-side-agent-self-iteration",
                 status: "state_refreshed",
                 waiting_on: "codex",
                 severity: "action",
@@ -593,12 +593,12 @@ async function main() {
     const body = await page.locator("body").innerText();
     const required = [
       "把多项目 Agent 工作变成可管理的 Todo、证据和配额",
-      "平台迁移",
-      "请确认 ZJXMT 源 topic/table 权威来源",
-      "埋堆堆打平",
-      "最多 2 个 p4 运行中",
-      "最多 2 个 p3 运行中",
-      "Agent Harness 旁路",
+      "0617 User Gate",
+      "请确认 owner 选项 A/B 的取舍",
+      "Creator Operator",
+      "热点",
+      "合成案例",
+      "Side Agent 自迭代",
       "需要 Codex recovery",
       "排序器 / 跨域证据",
       "具体 blocker",
@@ -621,7 +621,7 @@ async function main() {
       "决策需 rebase",
       "审批或转交前先重读",
       "这不是仓库回滚",
-      "验证四个 P0 本地迁移场景",
+      "推进与 owner 决策独立的 safe side path",
       "拆分依赖阻塞和当前目标阻塞",
     ];
     const missing = required.filter((text) => !body.includes(text));
@@ -632,7 +632,7 @@ async function main() {
     const forbidden = [
       "[plugin:vite:oxc]",
       "Transform failed",
-      "active p4 <= 2",
+      "active internal-slot <= 2",
       "single_surface",
       "quota_slot_spent",
       "focus_wait",

--- a/examples/heartbeat-prompt-smoke.py
+++ b/examples/heartbeat-prompt-smoke.py
@@ -25,13 +25,13 @@ PROJECT_SKILL = REPO_ROOT / "skills" / "goal-harness-project" / "SKILL.md"
 GOAL_ID = "public-heartbeat-goal"
 ACTIVE_STATE = Path("/tmp/public-heartbeat-goal/ACTIVE_GOAL_STATE.md")
 PROJECT_SPECIFIC_PROMPT_LEAKS = (
-    "agent-harness-side-bypass",
-    "agent-harness-main-control",
-    "OpenViking",
-    "managed Lark mirrors",
+    "internal-side-agent",
+    "internal-main-control",
+    "private-runtime-delta",
+    "managed private mirrors",
     "docs/TODO.md",
-    "premium-ui",
-    "tiger-team",
+    "internal-product-gamma",
+    "internal-team-beta",
 )
 
 

--- a/examples/quota-plan-smoke.py
+++ b/examples/quota-plan-smoke.py
@@ -643,11 +643,11 @@ def assert_plan_shape(plan: dict, markdown: str | None = None) -> None:
 
 def assert_scheduler_advisory_does_not_override_goal_should_run() -> None:
     meta_id = "goal-harness-meta"
-    tiger_id = "tiger-team-maiduidui-regauc"
-    side_bypass_id = "agent-harness-side-bypass"
+    creator_id = "showcase-creator-operator"
+    side_bypass_id = "showcase-side-agent-self-iteration"
     gated_id = "owner-gated"
     meta_goal = goal(meta_id, compute=0.5)
-    tiger_goal = goal(tiger_id, compute=1.0)
+    creator_goal = goal(creator_id, compute=1.0)
     side_bypass_goal = goal(side_bypass_id, compute=0.8)
     gated_goal = goal(gated_id, compute=1.0)
 
@@ -671,8 +671,8 @@ def assert_scheduler_advisory_does_not_override_goal_should_run() -> None:
             },
         ],
     }
-    tiger_item = attention(tiger_id, compute=1.0)
-    tiger_item["recommended_action"] = "continue authorized evaluation monitoring"
+    creator_item = attention(creator_id, compute=1.0)
+    creator_item["recommended_action"] = "continue creator-operator showcase monitoring"
     side_bypass_item = attention(side_bypass_id, compute=0.8, state="focus_wait")
     side_bypass_item["lifecycle_phase"] = "focus_wait"
     side_bypass_item["lifecycle_flags"] = ["continuation_boundary"]
@@ -688,8 +688,8 @@ def assert_scheduler_advisory_does_not_override_goal_should_run() -> None:
         "runtime_root": "./fixtures/runtime",
         "goal_count": 4,
         "run_count": 4,
-        "attention_queue": {"items": [meta_item, tiger_item, side_bypass_item, gated_item]},
-        "run_history": {"goals": [meta_goal, tiger_goal, side_bypass_goal, gated_goal]},
+        "attention_queue": {"items": [meta_item, creator_item, side_bypass_item, gated_item]},
+        "run_history": {"goals": [meta_goal, creator_goal, side_bypass_goal, gated_goal]},
     }
 
     plan = build_quota_plan(payload, mode="plan")
@@ -700,15 +700,15 @@ def assert_scheduler_advisory_does_not_override_goal_should_run() -> None:
 
     assert [item["goal_id"] for item in plan["groups"]["operator_gate"]] == [gated_id], plan
     assert [item["goal_id"] for item in plan["groups"]["focus_wait"]] == [side_bypass_id], plan
-    assert [item["goal_id"] for item in plan["groups"]["eligible"]] == [tiger_id, meta_id], plan
-    assert plan["summary"]["next_automatic_turn"] == tiger_id, plan
-    assert plan["next_automatic_turn"]["goal_id"] == tiger_id, plan
+    assert [item["goal_id"] for item in plan["groups"]["eligible"]] == [creator_id, meta_id], plan
+    assert plan["summary"]["next_automatic_turn"] == creator_id, plan
+    assert plan["next_automatic_turn"]["goal_id"] == creator_id, plan
 
     assert meta_decision["decision"] == "run", meta_decision
     assert meta_decision["should_run"] is True, meta_decision
     assert meta_decision["normal_delivery_allowed"] is True, meta_decision
     assert meta_decision["state"] == "eligible", meta_decision
-    assert meta_decision["plan_summary"]["next_automatic_turn"] == tiger_id, meta_decision
+    assert meta_decision["plan_summary"]["next_automatic_turn"] == creator_id, meta_decision
     assert meta_decision["execution_obligation"]["must_attempt_work"] is True, meta_decision
     assert meta_decision["execution_obligation"]["notify_is_execution_gate"] is False, meta_decision
     assert meta_decision["agent_todo_summary"]["open_count"] == 2, meta_decision


### PR DESCRIPTION
## Summary
- close the public dashboard/home demo over showcase-only goal specs and synthetic case copy
- remove internal-project-shaped strings from dashboard fixtures, action-packet smoke, and public forbidden-list examples
- add a generic home-route guard that public share goal specs must use showcase/meta ids

## Boundary cleanup
- PR #280 was closed before merge and its branch was deleted
- this PR removes the already-public dashboard demo surface back to showcase-only data

## Validation
- npm run smoke:home-route
- npm run smoke:action-packet
- npm run smoke:home-browser
- npm run build
- python3 examples/quota-plan-smoke.py
- python3 examples/codex-cli-long-run-regression-spec-smoke.py
- python3 examples/codex-cli-long-run-benchmark-design-smoke.py
- python3 examples/heartbeat-prompt-smoke.py
- python3 examples/codex-subagent-orchestration-contract-smoke.py
- goal-harness check --scan-path apps/dashboard --scan-path examples/dashboard-home-browser-smoke.mjs --scan-path examples/quota-plan-smoke.py --scan-path examples/codex-cli-long-run-regression-spec-smoke.py --scan-path examples/codex-cli-long-run-benchmark-design-smoke.py --scan-path examples/heartbeat-prompt-smoke.py --scan-path examples/codex-subagent-orchestration-contract-smoke.py
- git diff --check
- rg sensitive-term scan over the repo returned no matches