### PR TITLE
Fix status/quota scan latency for ignored state trees

### DIFF
--- a/examples/check-public-boundary-smoke.py
+++ b/examples/check-public-boundary-smoke.py
@@ -77,6 +77,9 @@ def main() -> int:
             raise AssertionError(local_only_payload)
         if (local_only_payload.get("summary") or {}).get("errors"):
             raise AssertionError(local_only_payload)
+        checks = "\n".join(str(item) for item in local_only_payload.get("checks") or [])
+        if "public boundary scan clean: 1 files" not in checks:
+            raise AssertionError(local_only_payload)
 
         (project / "public.md").write_text(PRIVATE_DOC_MARKER, encoding="utf-8")
         public_leak = run_cli(root, "--format", "json", "check", "--scan-root", str(project))

--- a/goal_harness/contract.py
+++ b/goal_harness/contract.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 from pathlib import Path
 from typing import Any
@@ -114,13 +115,23 @@ def iter_scan_files(scan_root: Path) -> list[Path]:
     if scan_root.is_file():
         return [scan_root]
     files: list[Path] = []
-    for path in scan_root.rglob("*"):
-        if any(part in DEFAULT_SKIP_DIRS or part.endswith(".egg-info") for part in path.parts):
-            continue
-        if path.name.endswith(".local.json"):
-            continue
-        if path.is_file() and path.suffix in DEFAULT_SCAN_SUFFIXES:
-            files.append(path)
+    root_parts = set(scan_root.parts)
+    if any(part in DEFAULT_SKIP_DIRS or part.endswith(".egg-info") for part in root_parts):
+        return files
+
+    for dir_path, dir_names, file_names in os.walk(scan_root):
+        dir_names[:] = [
+            name
+            for name in dir_names
+            if name not in DEFAULT_SKIP_DIRS and not name.endswith(".egg-info")
+        ]
+        current_dir = Path(dir_path)
+        for file_name in file_names:
+            path = current_dir / file_name
+            if path.name.endswith(".local.json"):
+                continue
+            if path.suffix in DEFAULT_SCAN_SUFFIXES:
+                files.append(path)
     return sorted(files)
 
 


### PR DESCRIPTION
## Summary
- prune skipped directories before public-boundary traversal instead of filtering after `Path.rglob` has descended into `.local`, `.git`, and cache trees
- keep explicit file scans intact while avoiding ignored local-state traversal on repo-wide checks
- tighten the public-boundary smoke so skipped private dirs do not count as scanned public files

## Validation
- `python3 -m py_compile goal_harness/contract.py examples/check-public-boundary-smoke.py`
- `python3 examples/check-public-boundary-smoke.py`
- `python3 examples/contract-reward-overlay-smoke.py`
- `python3 -m goal_harness.cli --format json quota should-run --goal-id goal-harness-meta --agent-id codex-main-control` measured about 1.17s after the fix, down from about 14.28s before
- `python3 -m goal_harness.cli status --format json --scan-root . --limit 20` measured about 1.11s after the fix, down from about 14.20s before

## Notes
- Follow-up P1/P2 todos were recorded in Goal Harness for a durable hot-path perf budget and longer-term projection-cache/server-shape work.
- No local/private state, raw benchmark logs, or credentials included.