### PR TITLE
Guard frontstage showcase from live status feeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ human decisions visible across many turns, so primary and side agents can keep
 working on safe lanes while gated work waits for the person.
 
 [Quick Start](#quick-start) · [Getting Started](docs/guides/getting-started.md) ·
-[Showcases](docs/showcases/README.md) · [Hosted Frontstage](https://huangruiteng.github.io/goal-harness/frontstage/?statusUrl=%2Fgoal-harness%2Fstatus.frontstage-share.json) ·
+[Showcases](docs/showcases/README.md) · [Hosted Frontstage](https://huangruiteng.github.io/goal-harness/frontstage/) ·
 [Product Vision](docs/product/vision.md) · [Architecture](docs/architecture.md) ·
 [Dashboard](apps/dashboard/README.md) · [简体中文](README.zh-CN.md)
 

--- a/apps/dashboard/README.md
+++ b/apps/dashboard/README.md
@@ -53,10 +53,15 @@ public GitHub case pages for deeper reading. Operations lanes are derived from
 the read-only projection; showcase panels are derived only from public-safe
 showcase metadata. Neither surface is browser write authority.
 
-For live local control-plane inspection, open
-`/frontstage?statusUrl=http://127.0.0.1:8766/status.json`. The route reads
-`attention_queue.items[].goal_channel_projection` and stays read-only; if the
-feed is missing or has no projection, the bundled demo fixture remains visible.
+The default frontstage route is public showcase mode. It ignores `statusUrl`
+and renders only bundled showcase/demo material, so a copied or hosted URL does
+not accidentally project local registry state.
+
+For live local control-plane inspection, explicitly enter ops mode:
+`/frontstage?mode=ops&statusUrl=http://127.0.0.1:8766/status.json`. The route
+then reads `attention_queue.items[].goal_channel_projection` and stays
+read-only; if the feed is missing or has no projection, the bundled demo
+fixture remains visible. Do not use ops-mode URLs as public links.
 
 To create a public-safe static bundle for demos, Lark shares, or future GitHub
 Pages hosting, export the frontstage with the sanitized fixture:

--- a/apps/dashboard/smoke/frontstage-route-smoke.ts
+++ b/apps/dashboard/smoke/frontstage-route-smoke.ts
@@ -34,6 +34,7 @@ const packageSource = readFileSync("package.json", "utf8");
 includes(routerSource, 'path: "/frontstage"', "frontstage route path");
 includes(routerSource, "component: FrontstagePage", "frontstage route component");
 includes(routerSource, "frontstageSearchSchema", "frontstage search schema");
+includes(routerSource, 'mode: z.enum(["showcase", "ops"]).optional().default("showcase")', "frontstage mode gate");
 includes(routerSource, "basepath:", "router basepath option");
 includes(routerSource, "import.meta.env.BASE_URL", "Vite base URL router source");
 includes(packageSource, '"smoke:frontstage-browser"', "frontstage browser smoke script");
@@ -48,6 +49,9 @@ includes(statusSource, "goal_channel_projection: goalChannelProjectionSchema", "
 
 includes(frontstageSource, 'data-testid="goal-channel-frontstage-route"', "route test id");
 includes(frontstageSource, 'data-testid="frontstage-live-source-panel"', "live source panel");
+includes(frontstageSource, 'data-testid="frontstage-public-boundary-note"', "public boundary note");
+includes(frontstageSource, "Showcase mode ignores statusUrl", "public mode statusUrl guard copy");
+includes(frontstageSource, 'if (!liveMode)', "live status feed requires ops mode");
 includes(frontstageSource, 'data-testid="frontstage-operations-strip"', "operations signal strip");
 includes(frontstageSource, 'data-testid="frontstage-goal-select"', "goal selector");
 includes(frontstageSource, "parseStatusPayload", "status payload parser");

--- a/apps/dashboard/src/router.tsx
+++ b/apps/dashboard/src/router.tsx
@@ -20,6 +20,7 @@ const searchSchema = z.object({
 
 const frontstageSearchSchema = z.object({
   goalId: z.string().optional().default(""),
+  mode: z.enum(["showcase", "ops"]).optional().default("showcase"),
   statusUrl: z.string().optional().default(""),
 });
 

--- a/apps/dashboard/src/views/frontstage-page.tsx
+++ b/apps/dashboard/src/views/frontstage-page.tsx
@@ -28,6 +28,7 @@ import { cn } from "../lib/utils";
 
 type BadgeTone = "neutral" | "success" | "warning" | "info" | "danger";
 type FrontstageSource = { kind: "demo"; label: string } | { kind: "url"; label: string };
+type FrontstageMode = "showcase" | "ops";
 type NumberRange = { low?: number; high?: number };
 type ShowcaseFrontstageCase = {
   id: string;
@@ -453,8 +454,11 @@ function ShowcaseCasePackPanel() {
 
 function FrontstageRoute({
   goalOptions,
+  hasIgnoredStatusUrl,
   isLoading,
   loadError,
+  mode,
+  onEnableOpsMode,
   onGoalChange,
   onLoadStatusUrl,
   onResetDemo,
@@ -465,8 +469,11 @@ function FrontstageRoute({
   setStatusUrl,
 }: {
   goalOptions: ProjectionOption[];
+  hasIgnoredStatusUrl: boolean;
   isLoading: boolean;
   loadError: string | null;
+  mode: FrontstageMode;
+  onEnableOpsMode: () => void;
   onGoalChange: (goalId: string) => void;
   onLoadStatusUrl: () => void;
   onResetDemo: () => void;
@@ -482,6 +489,7 @@ function FrontstageRoute({
   const claimedAgentTodos = countClaimedTodos(projection.agent_todos);
   const claimOwners = uniqueClaimOwners(projection);
   const claimOwnerPreview = claimOwners.slice(0, 2).join(", ");
+  const isOpsMode = mode === "ops";
   const operationSignals = [
     {
       label: "human gate",
@@ -558,50 +566,72 @@ function FrontstageRoute({
           </div>
           <div className="mt-5 space-y-2 rounded-md border border-slate-200 bg-slate-50 p-3" data-testid="frontstage-live-source-panel">
             <div className="flex flex-wrap items-center gap-2">
-              <Badge variant={source.kind === "url" ? "success" : "neutral"}>
-                {source.kind === "url" ? "live status feed" : "demo fixture"}
+              <Badge variant={isOpsMode ? "warning" : "success"}>
+                {isOpsMode ? "ops live" : "showcase mode"}
               </Badge>
-              <span className="text-xs font-medium text-slate-500">{source.label}</span>
+              <Badge variant={isOpsMode && source.kind === "url" ? "info" : "neutral"}>
+                {isOpsMode && source.kind === "url" ? "live status feed" : "showcase fixture"}
+              </Badge>
+              <span className="break-words text-xs font-medium text-slate-500">
+                {isOpsMode ? source.label : "docs/showcases"}
+              </span>
             </div>
-            <input
-              aria-label="Status URL"
-              className="h-9 w-full rounded-md border border-slate-200 bg-white px-3 text-xs text-slate-900 shadow-sm outline-none focus:ring-2 focus:ring-slate-400"
-              data-testid="frontstage-status-url-input"
-              onChange={(event) => setStatusUrl(event.target.value)}
-              placeholder="/status.local.json"
-              value={statusUrl}
-            />
-            <div className="flex gap-2">
-              <Button
-                className="flex-1"
-                data-testid="frontstage-load-status-url"
-                disabled={isLoading}
-                onClick={onLoadStatusUrl}
-                size="sm"
-                variant="primary"
+            {isOpsMode ? (
+              <>
+                <input
+                  aria-label="Status URL"
+                  className="h-9 w-full rounded-md border border-slate-200 bg-white px-3 text-xs text-slate-900 shadow-sm outline-none focus:ring-2 focus:ring-slate-400"
+                  data-testid="frontstage-status-url-input"
+                  onChange={(event) => setStatusUrl(event.target.value)}
+                  placeholder="/status.local.json"
+                  value={statusUrl}
+                />
+                <div className="flex gap-2">
+                  <Button
+                    className="flex-1"
+                    data-testid="frontstage-load-status-url"
+                    disabled={isLoading}
+                    onClick={onLoadStatusUrl}
+                    size="sm"
+                    variant="primary"
+                  >
+                    <RefreshCw className="h-3.5 w-3.5" />
+                    Load
+                  </Button>
+                  <Button data-testid="frontstage-reset-demo" disabled={isLoading} onClick={onResetDemo} size="sm">
+                    Demo
+                  </Button>
+                </div>
+                {goalOptions.length ? (
+                  <Select
+                    aria-label="Goal channel"
+                    className="w-full text-xs"
+                    data-testid="frontstage-goal-select"
+                    onChange={(event) => onGoalChange(event.target.value)}
+                    value={selectedGoalId}
+                  >
+                    {goalOptions.map((option) => (
+                      <option key={option.goalId} value={option.goalId}>
+                        {option.projection.display_name}
+                      </option>
+                    ))}
+                  </Select>
+                ) : null}
+              </>
+            ) : (
+              <div
+                className="space-y-2 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs leading-5 text-emerald-950"
+                data-testid="frontstage-public-boundary-note"
               >
-                <RefreshCw className="h-3.5 w-3.5" />
-                Load
-              </Button>
-              <Button data-testid="frontstage-reset-demo" disabled={isLoading} onClick={onResetDemo} size="sm">
-                Demo
-              </Button>
-            </div>
-            {goalOptions.length ? (
-              <Select
-                aria-label="Goal channel"
-                className="w-full text-xs"
-                data-testid="frontstage-goal-select"
-                onChange={(event) => onGoalChange(event.target.value)}
-                value={selectedGoalId}
-              >
-                {goalOptions.map((option) => (
-                  <option key={option.goalId} value={option.goalId}>
-                    {option.projection.display_name}
-                  </option>
-                ))}
-              </Select>
-            ) : null}
+                <p>
+                  Showcase mode ignores statusUrl and renders docs/showcases only. Use Ops live for local control-plane inspection.
+                </p>
+                {hasIgnoredStatusUrl ? <Badge variant="warning">statusUrl ignored</Badge> : null}
+                <Button data-testid="frontstage-enable-ops-live" onClick={onEnableOpsMode} size="sm">
+                  Ops live
+                </Button>
+              </div>
+            )}
             {loadError ? (
               <div className="flex gap-2 rounded-md border border-amber-200 bg-amber-50 px-2 py-2 text-xs leading-5 text-amber-950" data-testid="frontstage-load-error">
                 <CircleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0" />
@@ -619,7 +649,10 @@ function FrontstageRoute({
                   <Badge variant="success">goal_channel_projection_v0</Badge>
                   <Badge variant="neutral">{projection.mode}</Badge>
                   <Badge variant="info">{projection.waiting_on}</Badge>
-                  <Badge variant={source.kind === "url" ? "success" : "neutral"}>{source.kind}</Badge>
+                  <Badge variant={isOpsMode ? "warning" : "success"}>{isOpsMode ? "ops live" : "showcase mode"}</Badge>
+                  <Badge variant={isOpsMode && source.kind === "url" ? "success" : "neutral"}>
+                    {isOpsMode && source.kind === "url" ? "url" : "demo"}
+                  </Badge>
                 </div>
                 <h1 className="mt-3 text-3xl font-semibold tracking-normal text-slate-950">
                   {projection.display_name}
@@ -785,18 +818,22 @@ export function FrontstagePage() {
   const [statusUrl, setStatusUrl] = useState(search.statusUrl);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const mode: FrontstageMode = search.mode === "ops" ? "ops" : "showcase";
+  const liveMode = mode === "ops";
+  const hasIgnoredStatusUrl = !liveMode && Boolean(search.statusUrl);
 
-  const goalOptions = useMemo(
+  const rawGoalOptions = useMemo(
     () => (payload ? projectionOptionsFromPayload(payload) : []),
     [payload],
   );
+  const goalOptions = liveMode ? rawGoalOptions : [];
   const selectedGoalId = goalOptions.some((option) => option.goalId === search.goalId)
     ? search.goalId
     : goalOptions[0]?.goalId ?? sampleGoalChannelProjection.goal_id;
   const selectedProjection = goalOptions.find((option) => option.goalId === selectedGoalId)?.projection
     ?? sampleGoalChannelProjection;
 
-  async function updateSearch(next: { goalId?: string; statusUrl?: string }) {
+  async function updateSearch(next: { goalId?: string; mode?: FrontstageMode; statusUrl?: string }) {
     await navigate({
       search: (current) => ({
         ...current,
@@ -806,6 +843,10 @@ export function FrontstagePage() {
   }
 
   async function loadFromUrl(url: string, updateUrl = true) {
+    if (!liveMode) {
+      setLoadError("statusUrl is ignored in showcase mode; switch to Ops live for local status feeds");
+      return;
+    }
     const trimmed = url.trim();
     if (!trimmed) {
       setLoadError("status URL is empty");
@@ -829,6 +870,7 @@ export function FrontstagePage() {
       if (updateUrl) {
         await updateSearch({
           goalId: nextOptions[0]?.goalId ?? "",
+          mode: "ops",
           statusUrl: trimmed,
         });
       }
@@ -844,18 +886,22 @@ export function FrontstagePage() {
     setSource({ kind: "demo", label: "bundled fixture" });
     setStatusUrl("");
     setLoadError(null);
-    void updateSearch({ goalId: "", statusUrl: "" });
+    void updateSearch({ goalId: "", mode: "showcase", statusUrl: "" });
   }
 
   function changeGoal(goalId: string) {
     void updateSearch({ goalId });
   }
 
+  function enableOpsMode() {
+    void updateSearch({ mode: "ops" });
+  }
+
   useEffect(() => {
-    if (search.statusUrl) {
+    if (liveMode && search.statusUrl) {
       void loadFromUrl(search.statusUrl, false);
     }
-  }, []);
+  }, [liveMode, search.statusUrl]);
 
   useEffect(() => {
     if (!goalOptions.length || search.goalId === selectedGoalId) {
@@ -867,8 +913,11 @@ export function FrontstagePage() {
   return (
     <FrontstageRoute
       goalOptions={goalOptions}
+      hasIgnoredStatusUrl={hasIgnoredStatusUrl}
       isLoading={isLoading}
       loadError={loadError}
+      mode={mode}
+      onEnableOpsMode={enableOpsMode}
       onGoalChange={changeGoal}
       onLoadStatusUrl={() => void loadFromUrl(statusUrl)}
       onResetDemo={resetToDemo}

--- a/docs/showcases/README.md
+++ b/docs/showcases/README.md
@@ -45,7 +45,7 @@ future GitHub Pages showcase: Pages should publish this generated artifact, not
 live registry files or local status exports.
 Once repository Pages is enabled for GitHub Actions, the same generated bundle
 is available as the
-[hosted frontstage](https://huangruiteng.github.io/goal-harness/frontstage/?statusUrl=%2Fgoal-harness%2Fstatus.frontstage-share.json).
+[hosted frontstage](https://huangruiteng.github.io/goal-harness/frontstage/).
 
 ## Current Cases
 

--- a/examples/dashboard-frontstage-browser-smoke.mjs
+++ b/examples/dashboard-frontstage-browser-smoke.mjs
@@ -357,6 +357,8 @@ async function main() {
     try {
       await captureFrontstage(desktopPage, `${baseUrl}/frontstage`, "desktop-frontstage", [
         "Demo Goal Channel",
+        "showcase mode",
+        "Showcase mode ignores statusUrl",
         "codex-main-control",
         "codex-side-bypass",
         "Render the productization frontstage fixture",
@@ -364,8 +366,30 @@ async function main() {
       await captureFrontstage(
         desktopPage,
         `${baseUrl}/frontstage?statusUrl=/${fixtureName}&goalId=live-goal-a`,
+        "desktop-frontstage-showcase-ignores-status-url",
+        [
+          "Demo Goal Channel",
+          "showcase mode",
+          "Showcase mode ignores statusUrl",
+          "statusUrl ignored",
+        ],
+      );
+      const publicModeText = await desktopPage.locator("body").innerText();
+      const publicModeForbidden = [
+        "Live Goal Channel",
+        "Second Live Channel",
+        "Render live statusUrl channel projection",
+      ];
+      const publicModePresent = publicModeForbidden.filter((text) => publicModeText.includes(text));
+      if (publicModePresent.length) {
+        throw new Error(`Showcase frontstage loaded live statusUrl text: ${publicModePresent.join(", ")}`);
+      }
+      await captureFrontstage(
+        desktopPage,
+        `${baseUrl}/frontstage?mode=ops&statusUrl=/${fixtureName}&goalId=live-goal-a`,
         "desktop-frontstage-live",
         [
+          "ops live",
           "live status feed",
           "Live Goal Channel",
           "Render live statusUrl channel projection",
@@ -377,6 +401,17 @@ async function main() {
       const selectedUrl = new URL(desktopPage.url());
       if (selectedUrl.searchParams.get("goalId") !== "live-goal-b") {
         throw new Error(`Goal selector did not update URL: ${desktopPage.url()}`);
+      }
+      await captureFrontstage(desktopPage, `${baseUrl}/frontstage`, "desktop-frontstage-after-ops-reset", [
+        "Demo Goal Channel",
+        "showcase mode",
+        "Showcase mode ignores statusUrl",
+      ]);
+      const resetText = await desktopPage.locator("body").innerText();
+      const resetForbidden = ["Live Goal Channel", "Second Live Channel", "Render live statusUrl channel projection"];
+      const resetPresent = resetForbidden.filter((text) => resetText.includes(text));
+      if (resetPresent.length) {
+        throw new Error(`Showcase frontstage retained prior ops live text: ${resetPresent.join(", ")}`);
       }
     } finally {
       await desktopPage.close();
@@ -390,6 +425,8 @@ async function main() {
     try {
       await captureFrontstage(mobilePage, `${baseUrl}/frontstage`, "mobile-frontstage", [
         "Demo Goal Channel",
+        "showcase mode",
+        "Showcase mode ignores statusUrl",
         "codex-main-control",
         "codex-side-bypass",
         "Render the productization frontstage fixture",

--- a/examples/export-frontstage-share-bundle.mjs
+++ b/examples/export-frontstage-share-bundle.mjs
@@ -136,8 +136,7 @@ function buildStatusFixture(projection) {
 
 async function writeShareReadme(outDir, base) {
   const siteDir = resolve(outDir, "site");
-  const statusUrl = `${base}${statusFileName}`;
-  const frontstageUrl = `${base}frontstage/?statusUrl=${encodeURIComponent(statusUrl)}`;
+  const frontstageUrl = `${base}frontstage/`;
   const previewBlock = base === "/"
     ? `## Try It Locally
 
@@ -168,6 +167,8 @@ ${frontstageUrl}
 
 This directory is a generated, public-safe static bundle. It contains the
 dashboard build plus a sanitized \`goal_channel_projection_v0\` status fixture.
+The public entry opens frontstage showcase mode and does not load \`statusUrl\`
+by default.
 
 ${previewBlock}
 
@@ -286,7 +287,7 @@ async function main() {
     ok: true,
     out_dir: outDir,
     site_dir: siteDir,
-    frontstage_url: `${args.base}frontstage/?statusUrl=${encodeURIComponent(`${args.base}${statusFileName}`)}`,
+    frontstage_url: `${args.base}frontstage/`,
     status_fixture: `site/${statusFileName}`,
   }, null, 2));
 }

--- a/examples/frontstage-share-bundle-smoke.mjs
+++ b/examples/frontstage-share-bundle-smoke.mjs
@@ -94,4 +94,12 @@ for (const [label, path] of Object.entries({
   assertNoLeak(await readFile(path, "utf8"), label);
 }
 
+const readmeText = await readFile(resolve(outDir, "README.md"), "utf8");
+if (readmeText.includes("?statusUrl=")) {
+  throw new Error("share bundle README must not publish a statusUrl-loaded frontstage link");
+}
+if (!readmeText.includes("frontstage/")) {
+  throw new Error("share bundle README must publish the frontstage showcase entry");
+}
+
 console.log("frontstage-share-bundle-smoke: ok");


### PR DESCRIPTION
## Summary
- make /frontstage default to showcase mode and ignore statusUrl unless mode=ops
- keep live goal_channel_projection loading available only for explicit local ops mode
- update public frontstage links/exporter output so hosted links use /frontstage/ without statusUrl

## Validation
- npm run smoke:frontstage-route
- npm run smoke:frontstage-browser
- npm run smoke:frontstage-share-bundle
- npm run build
- git diff --check
- goal-harness check --scan-path apps/dashboard/src --scan-path apps/dashboard/smoke/frontstage-route-smoke.ts --scan-path apps/dashboard/README.md --scan-path examples/dashboard-frontstage-browser-smoke.mjs --scan-path examples/export-frontstage-share-bundle.mjs --scan-path examples/frontstage-share-bundle-smoke.mjs --scan-path README.md --scan-path docs/showcases/README.md

## Boundary
Public showcase mode renders docs/showcases/demo material only. Live/local status feeds require explicit ?mode=ops and should not be used as public links.