### PR TITLE
Refine todo projection ownership

### DIFF
--- a/examples/project-asset-todo-projection-gap-smoke.py
+++ b/examples/project-asset-todo-projection-gap-smoke.py
@@ -15,6 +15,8 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from goal_harness.status import (  # noqa: E402
+    TODO_PROJECTION_DETAIL_POINTER_SCHEMA_VERSION,
+    TODO_PROJECTION_VIEW_SCHEMA_VERSION,
     project_asset_todo_projection_gap,
     project_asset_todo_summary,
 )
@@ -115,13 +117,16 @@ def main() -> int:
             "total_count": 0,
         }
     )
-    assert empty_summary == {
-        "schema_version": "todo_summary_v0",
-        "source_section": "project_asset",
-        "open": 0,
-        "done": 0,
-        "total": 0,
-    }, empty_summary
+    assert empty_summary["schema_version"] == "todo_summary_v0", empty_summary
+    assert empty_summary["source_section"] == "project_asset", empty_summary
+    assert empty_summary["open"] == 0, empty_summary
+    assert empty_summary["done"] == 0, empty_summary
+    assert empty_summary["total"] == 0, empty_summary
+    assert empty_summary["projection_view"]["schema_version"] == TODO_PROJECTION_VIEW_SCHEMA_VERSION, empty_summary
+    assert empty_summary["projection_view"]["view"] == "project_asset_overview", empty_summary
+    assert empty_summary["projection_view"]["truth"] == "derived", empty_summary
+    assert empty_summary["detail_pointer"]["schema_version"] == TODO_PROJECTION_DETAIL_POINTER_SCHEMA_VERSION, empty_summary
+    assert empty_summary["detail_pointer"]["full_list_included"] is False, empty_summary
     assert project_asset_todo_projection_gap(user_todos=empty_summary, agent_todos=empty_summary) is None
     gap = project_asset_todo_projection_gap(user_todos=None, agent_todos=empty_summary)
     assert gap and gap["missing_roles"] == ["user"], gap

--- a/examples/project-asset-todo-projection-gap-smoke.py
+++ b/examples/project-asset-todo-projection-gap-smoke.py
@@ -125,8 +125,16 @@ def main() -> int:
     assert empty_summary["projection_view"]["schema_version"] == TODO_PROJECTION_VIEW_SCHEMA_VERSION, empty_summary
     assert empty_summary["projection_view"]["view"] == "project_asset_overview", empty_summary
     assert empty_summary["projection_view"]["truth"] == "derived", empty_summary
+    assert (
+        empty_summary["projection_view"]["canonical_source"]
+        == "attention_queue.items[].{user_todos,agent_todos}"
+    ), empty_summary
     assert empty_summary["detail_pointer"]["schema_version"] == TODO_PROJECTION_DETAIL_POINTER_SCHEMA_VERSION, empty_summary
     assert empty_summary["detail_pointer"]["full_list_included"] is False, empty_summary
+    user_empty_summary = project_asset_todo_summary(empty_summary, role="user")
+    assert user_empty_summary["projection_view"]["canonical_source"] == "attention_queue.items[].user_todos"
+    agent_empty_summary = project_asset_todo_summary(empty_summary, role="agent")
+    assert agent_empty_summary["projection_view"]["canonical_source"] == "attention_queue.items[].agent_todos"
     assert project_asset_todo_projection_gap(user_todos=empty_summary, agent_todos=empty_summary) is None
     gap = project_asset_todo_projection_gap(user_todos=None, agent_todos=empty_summary)
     assert gap and gap["missing_roles"] == ["user"], gap

--- a/examples/todo-first-open-summary-smoke.py
+++ b/examples/todo-first-open-summary-smoke.py
@@ -132,7 +132,7 @@ def build_blocked_priority_fallback_status_payload() -> dict:
     assert agent_todos is not None, agent_todos
     assert agent_todos["first_open_items"][0]["status"] == "blocked", agent_todos
     assert agent_todos["first_executable_items"][0]["text"] == FALLBACK_TODO, agent_todos
-    asset_summary = project_asset_todo_summary(agent_todos)
+    asset_summary = project_asset_todo_summary(agent_todos, role="agent")
     assert asset_summary is not None, agent_todos
     attention_item = {
         "goal_id": GOAL_ID,
@@ -250,7 +250,7 @@ def assert_claimed_frontstage_lanes_visible() -> None:
     assert agent_todos["claimed_advancement_open_count"] == 1, agent_todos
     assert agent_todos["claimed_monitor_open_count"] == 1, agent_todos
 
-    asset_summary = project_asset_todo_summary(agent_todos)
+    asset_summary = project_asset_todo_summary(agent_todos, role="agent")
     assert asset_summary is not None, agent_todos
     assert asset_summary["projection_view"]["view"] == "project_asset_overview", asset_summary
     assert asset_summary["projection_view"]["truth"] == "derived", asset_summary
@@ -331,7 +331,7 @@ def main() -> int:
     agent_todos = build_truncated_todo_group()
     parsed_agent_todos = parse_multiline_deep_open_todo()
     assert parsed_agent_todos["first_open_items"] == agent_todos["first_open_items"], parsed_agent_todos
-    asset_summary = project_asset_todo_summary(agent_todos)
+    asset_summary = project_asset_todo_summary(agent_todos, role="agent")
     assert asset_summary is not None, agent_todos
     assert asset_summary["open"] == 4, asset_summary
     assert asset_summary["next"] == APPENDED_P0_TODO, asset_summary

--- a/examples/todo-first-open-summary-smoke.py
+++ b/examples/todo-first-open-summary-smoke.py
@@ -14,6 +14,9 @@ if str(REPO_ROOT) not in sys.path:
 from goal_harness.quota import build_quota_should_run, render_quota_should_run_markdown  # noqa: E402
 from goal_harness.review_packet import build_review_packet  # noqa: E402
 from goal_harness.status import (  # noqa: E402
+    MAX_PROJECT_ASSET_TODO_ITEMS,
+    TODO_PROJECTION_DETAIL_POINTER_SCHEMA_VERSION,
+    TODO_PROJECTION_VIEW_SCHEMA_VERSION,
     compact_todo_group,
     parse_active_state_todos,
     project_asset_todo_summary,
@@ -249,10 +252,13 @@ def assert_claimed_frontstage_lanes_visible() -> None:
 
     asset_summary = project_asset_todo_summary(agent_todos)
     assert asset_summary is not None, agent_todos
-    assert [item["index"] for item in asset_summary["unclaimed_priority_open_items"]] == list(range(1, 9)), asset_summary
-    assert [item["index"] for item in asset_summary["claimed_open_items"]] == [40, 41], asset_summary
-    assert [item["index"] for item in asset_summary["claimed_advancement_open_items"]] == [40], asset_summary
-    assert [item["index"] for item in asset_summary["claimed_monitor_open_items"]] == [41], asset_summary
+    assert asset_summary["projection_view"]["view"] == "project_asset_overview", asset_summary
+    assert asset_summary["projection_view"]["truth"] == "derived", asset_summary
+    assert asset_summary["detail_pointer"]["full_list_included"] is False, asset_summary
+    assert "unclaimed_priority_open_items" not in asset_summary, asset_summary
+    assert "claimed_open_items" not in asset_summary, asset_summary
+    assert "claimed_advancement_open_items" not in asset_summary, asset_summary
+    assert "claimed_monitor_open_items" not in asset_summary, asset_summary
 
     attention_item = {
         "goal_id": GOAL_ID,
@@ -330,9 +336,23 @@ def main() -> int:
     assert asset_summary["open"] == 4, asset_summary
     assert asset_summary["next"] == APPENDED_P0_TODO, asset_summary
     assert asset_summary["next_index"] == 17, asset_summary
-    assert [item["index"] for item in asset_summary["items"]] == [17, 14, 15, 16], asset_summary
-    assert [item["index"] for item in asset_summary["backlog_items"]] == [17, 14, 15, 16], asset_summary
-    assert [item["index"] for item in asset_summary["executable_backlog_items"]] == [17, 14, 15, 16], asset_summary
+    assert asset_summary["projection_view"] == {
+        "schema_version": TODO_PROJECTION_VIEW_SCHEMA_VERSION,
+        "view": "project_asset_overview",
+        "truth": "derived",
+        "canonical_source": "attention_queue.items[].agent_todos",
+        "item_limit": MAX_PROJECT_ASSET_TODO_ITEMS,
+    }, asset_summary
+    assert asset_summary["detail_pointer"] == {
+        "schema_version": TODO_PROJECTION_DETAIL_POINTER_SCHEMA_VERSION,
+        "cold_path": "goal-harness status --format json",
+        "active_state_source": "registry goal state_file",
+        "full_list_included": False,
+    }, asset_summary
+    assert [item["index"] for item in asset_summary["items"]] == [17, 14, 15], asset_summary
+    assert [item["index"] for item in asset_summary["first_executable_items"]] == [17, 14, 15], asset_summary
+    assert "backlog_items" not in asset_summary, asset_summary
+    assert "executable_backlog_items" not in asset_summary, asset_summary
     assert asset_summary["items"][0]["priority"] == "P0", asset_summary
     assert asset_summary["items"][0]["status"] == "open", asset_summary
     assert asset_summary["items"][0]["todo_id"] == agent_todos["first_open_items"][0]["todo_id"], asset_summary

--- a/goal_harness/quota.py
+++ b/goal_harness/quota.py
@@ -1459,6 +1459,36 @@ def _summarize_project_asset_todos(
     return summary
 
 
+def _is_canonical_attention_todo_summary(value: Any) -> bool:
+    if not isinstance(value, dict):
+        return False
+    if value.get("schema_version") == "todo_summary_v0":
+        return True
+    source_section = str(value.get("source_section") or "").strip().lower()
+    if source_section.startswith("raw "):
+        return False
+    return source_section in {"agent todo", "user todo"}
+
+
+def _select_todo_summary(
+    canonical_value: Any,
+    project_asset_value: Any,
+    *,
+    agent_identity: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    canonical_summary = _summarize_user_todos(
+        canonical_value,
+        agent_identity=agent_identity,
+    )
+    project_asset_summary = _summarize_project_asset_todos(
+        project_asset_value,
+        agent_identity=agent_identity,
+    )
+    if _is_canonical_attention_todo_summary(canonical_value):
+        return canonical_summary or project_asset_summary
+    return project_asset_summary or canonical_summary
+
+
 def _same_todo_identity(left: dict[str, Any], right: dict[str, Any]) -> bool:
     left_id = str(left.get("todo_id") or "").strip()
     right_id = str(right.get("todo_id") or "").strip()
@@ -4335,13 +4365,15 @@ def build_quota_should_run(
             reason = "status or contract health is not ok; skip automatic compute"
         project_asset = item.get("project_asset") if isinstance(item.get("project_asset"), dict) else {}
         agent_identity = _quota_agent_identity(item, agent_id=agent_id)
-        user_todo_summary = _summarize_project_asset_todos(
-            project_asset.get("user_todos") if project_asset else None
-        ) or _summarize_user_todos(item.get("user_todos"))
-        agent_todo_summary = _summarize_project_asset_todos(
+        user_todo_summary = _select_todo_summary(
+            item.get("user_todos"),
+            project_asset.get("user_todos") if project_asset else None,
+        )
+        agent_todo_summary = _select_todo_summary(
+            item.get("agent_todos"),
             project_asset.get("agent_todos") if project_asset else None,
             agent_identity=agent_identity,
-        ) or _summarize_user_todos(item.get("agent_todos"), agent_identity=agent_identity)
+        )
         outcome_floor_blocker_projected = (
             recovery_allowed
             and _outcome_floor_blocker_already_projected(agent_todo_summary)

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -335,6 +335,8 @@ MAX_ACTIVE_DONE_TODOS_BEFORE_ARCHIVE = MAX_STATUS_TODOS_PER_ROLE
 MAX_PROJECT_ASSET_TODO_ITEMS = 3
 MAX_PROJECT_ASSET_TODO_BACKLOG_ITEMS = 8
 MAX_TODO_VISIBILITY_LANE_ITEMS = 16
+TODO_PROJECTION_VIEW_SCHEMA_VERSION = "todo_projection_view_v0"
+TODO_PROJECTION_DETAIL_POINTER_SCHEMA_VERSION = "todo_projection_detail_pointer_v0"
 MAX_DEPENDENCY_BLOCKERS = 4
 MAX_AUTONOMOUS_BACKLOG_CANDIDATES = 6
 MAX_SUBAGENT_ACTIVITY_ITEMS = 5
@@ -4387,14 +4389,30 @@ def first_open_todo_text(todos: dict[str, Any] | None) -> str | None:
 def project_asset_todo_summary(todos: dict[str, Any] | None) -> dict[str, Any] | None:
     if not isinstance(todos, dict):
         return None
+    open_count = todos.get("open_count", 0)
+    done_count = todos.get("done_count", 0)
+    total_count = todos.get("total_count", 0)
     summary: dict[str, Any] = {
         "schema_version": todos.get("schema_version") or "todo_summary_v0",
         "source_section": "project_asset",
-        "open": todos.get("open_count", 0),
-        "done": todos.get("done_count", 0),
-        "total": todos.get("total_count", 0),
+        "open": open_count,
+        "done": done_count,
+        "total": total_count,
+        "projection_view": {
+            "schema_version": TODO_PROJECTION_VIEW_SCHEMA_VERSION,
+            "view": "project_asset_overview",
+            "truth": "derived",
+            "canonical_source": "attention_queue.items[].agent_todos",
+            "item_limit": MAX_PROJECT_ASSET_TODO_ITEMS,
+        },
+        "detail_pointer": {
+            "schema_version": TODO_PROJECTION_DETAIL_POINTER_SCHEMA_VERSION,
+            "cold_path": "goal-harness status --format json",
+            "active_state_source": "registry goal state_file",
+            "full_list_included": False,
+        },
     }
-    open_items = open_todo_items(todos, limit=MAX_STATUS_TODOS_PER_ROLE)
+    open_items = open_todo_items(todos, limit=MAX_PROJECT_ASSET_TODO_ITEMS)
     claimed_open_count = sum(1 for item in open_items if item.get("claimed_by"))
     if claimed_open_count or todos.get("claimed_open_count"):
         summary["claimed_open_count"] = todos.get("claimed_open_count", claimed_open_count)
@@ -4409,27 +4427,23 @@ def project_asset_todo_summary(todos: dict[str, Any] | None) -> dict[str, Any] |
             summary["next_index"] = open_items[0].get("index")
         if open_items[0].get("claimed_by"):
             summary["next_claimed_by"] = open_items[0].get("claimed_by")
-    backlog_items = open_todo_items(todos, limit=MAX_PROJECT_ASSET_TODO_BACKLOG_ITEMS)
-    if backlog_items:
-        summary["backlog_items"] = backlog_items
-        executable_backlog_items = [
-            item
-            for item in backlog_items
-            if todo_item_is_actionable_open(item)
-            if todo_item_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
-        ]
-        if executable_backlog_items:
-            summary["executable_backlog_items"] = executable_backlog_items
-    for lane in (
-        "unclaimed_priority_open_items",
-        "claimed_open_items",
-        "claimed_advancement_open_items",
-        "claimed_monitor_open_items",
-    ):
+    executable_items = [
+        item
+        for item in open_todo_items(
+            todos,
+            limit=MAX_PROJECT_ASSET_TODO_ITEMS,
+            source_keys=("first_executable_items", "executable_backlog_items", "items"),
+        )
+        if todo_item_is_actionable_open(item)
+        if todo_item_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
+    ]
+    if executable_items:
+        summary["first_executable_items"] = executable_items[:MAX_PROJECT_ASSET_TODO_ITEMS]
+    for lane in ("gate_open_items", "current_agent_claimed_open_items"):
         lane_items = todo_lane_items(
             todos,
             lane,
-            limit=MAX_TODO_VISIBILITY_LANE_ITEMS,
+            limit=MAX_PROJECT_ASSET_TODO_ITEMS,
         )
         if lane_items:
             summary[lane] = lane_items

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -4386,12 +4386,23 @@ def first_open_todo_text(todos: dict[str, Any] | None) -> str | None:
     return str(items[0].get("text") or "") or None
 
 
-def project_asset_todo_summary(todos: dict[str, Any] | None) -> dict[str, Any] | None:
+def project_asset_todo_summary(
+    todos: dict[str, Any] | None,
+    *,
+    role: str | None = None,
+) -> dict[str, Any] | None:
     if not isinstance(todos, dict):
         return None
     open_count = todos.get("open_count", 0)
     done_count = todos.get("done_count", 0)
     total_count = todos.get("total_count", 0)
+    todo_role = str(role or todos.get("role") or "").strip().lower()
+    if todo_role == "user":
+        canonical_source = "attention_queue.items[].user_todos"
+    elif todo_role == "agent":
+        canonical_source = "attention_queue.items[].agent_todos"
+    else:
+        canonical_source = "attention_queue.items[].{user_todos,agent_todos}"
     summary: dict[str, Any] = {
         "schema_version": todos.get("schema_version") or "todo_summary_v0",
         "source_section": "project_asset",
@@ -4402,7 +4413,7 @@ def project_asset_todo_summary(todos: dict[str, Any] | None) -> dict[str, Any] |
             "schema_version": TODO_PROJECTION_VIEW_SCHEMA_VERSION,
             "view": "project_asset_overview",
             "truth": "derived",
-            "canonical_source": "attention_queue.items[].agent_todos",
+            "canonical_source": canonical_source,
             "item_limit": MAX_PROJECT_ASSET_TODO_ITEMS,
         },
         "detail_pointer": {
@@ -5180,10 +5191,10 @@ def enrich_project_asset(
     project_asset = item.get("project_asset")
     if not isinstance(project_asset, dict):
         return
-    user_summary = project_asset_todo_summary(user_todos)
+    user_summary = project_asset_todo_summary(user_todos, role="user")
     if user_summary:
         project_asset["user_todos"] = user_summary
-    agent_summary = project_asset_todo_summary(agent_todos)
+    agent_summary = project_asset_todo_summary(agent_todos, role="agent")
     if agent_summary:
         project_asset["agent_todos"] = agent_summary
     todo_projection_gap = project_asset_todo_projection_gap(


### PR DESCRIPTION
## Summary
- make project_asset todo summaries an explicit bounded overview with projection metadata and cold-path detail pointers
- keep quota routing on canonical attention item todos when structured, while preserving legacy project_asset-backed routing for raw fallback states
- update focused smokes for projection ownership and project_asset gap behavior

## Validation
- python3 -m py_compile goal_harness/status.py goal_harness/quota.py
- python3 examples/todo-first-open-summary-smoke.py
- python3 examples/project-asset-todo-projection-gap-smoke.py
- python3 examples/quota-action-scope-guard-smoke.py
- python3 examples/quota-plan-smoke.py
- python3 examples/status-markdown-smoke.py
- goal-harness check --scan-path goal_harness/status.py --scan-path goal_harness/quota.py --scan-path examples/todo-first-open-summary-smoke.py --scan-path examples/project-asset-todo-projection-gap-smoke.py

## Notes
- examples/hot-path-interface-budget-smoke.py currently reports heartbeat_prompt_json at 27 top-level keys vs budget 25; that appears to be a separate heartbeat prompt budget drift, not caused by this todo projection patch.
- Remote benchmark status while this PR was opened: Terminal-Bench is blocked in Harbor GitHub fetch; SkillsBench produced compact public blocker gh-skillsbench-tictoc-baseline-20260620T163748 with skillsbench_runner_error before official result; SWE Harbor uv startup/prewarm still times out on heavy dependency download.
