### PR TITLE
Recover SkillsBench results after runner exceptions

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -4011,6 +4011,138 @@ def test_skillsbench_main_recovers_missing_reward_with_structured_prereq_blocker
         ), compact
 
 
+def test_skillsbench_main_marks_empty_acp_trajectory_after_host_install() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-empty-acp-") as tmp:
+        jobs_dir = Path(tmp) / "jobs"
+        job_name = "skillsbench-empty-acp-fixture"
+
+        original_ensure = skillsbench_loop.ensure_benchflow_runtime
+        original_run = skillsbench_loop.run_benchflow_case
+
+        def fake_ensure(_args: Any) -> None:
+            return None
+
+        async def fake_run(_args: Any, plan: dict[str, Any]) -> Path:
+            prerequisites = plan.setdefault("runner_prerequisites", {})
+            prerequisites.update(
+                {
+                    "agent_execution_mode": "host_local_acp",
+                    "host_local_acp_launch": True,
+                    "host_local_acp_launch_status": "sandbox_installed",
+                    "host_local_acp_install_stage": "sandbox_installed",
+                    "container_codex_acp_install_skipped": True,
+                    "codex_acp_runtime_container_bootstrap": False,
+                    "codex_acp_runtime_dependency_preflight": False,
+                    "codex_acp_runtime_launch_preflight": True,
+                    "codex_acp_runtime_launch_preflight_status": "skipped",
+                    "codex_acp_runtime_launch_preflight_raw_logs_read": False,
+                }
+            )
+            write_json(
+                Path(plan["controller_trace_json"]),
+                {
+                    "schema_version": "skillsbench_goal_harness_controller_trace_v0",
+                    "route": "goal-harness-blind-loop-treatment",
+                    "trace_publicness": "public_counts_only_no_task_text_no_verifier_output",
+                    "heartbeat_count": 1,
+                    "controller_action_decisions": 1,
+                    "initial_prompt_count": 1,
+                    "round_rewards": [
+                        {
+                            "agent_round": 1,
+                            "reward_present": False,
+                            "passed": False,
+                        }
+                    ],
+                    "official_success_observed": False,
+                    "raw_task_text_recorded": False,
+                    "raw_verifier_output_recorded": False,
+                    "raw_agent_trajectory_recorded": False,
+                    "acp_trajectory_summary": {
+                        "schema_version": "skillsbench_acp_trajectory_summary_v0",
+                        "private_trajectory_present": True,
+                        "raw_text_copied_to_public": False,
+                        "event_count": 0,
+                        "round_count": 0,
+                        "user_message_count": 0,
+                        "agent_message_count": 0,
+                        "tool_call_count": 0,
+                        "codex_acp_text_present": False,
+                        "codex_acp_text_bytes": 0,
+                    },
+                },
+            )
+            result_path = Path(plan["result_json"])
+            write_json(
+                result_path,
+                {
+                    "task_name": "tictoc-unnecessary-abort-detection",
+                    "rollout_name": "tictoc-unnecessary-abort-detection__goal_harness_blind_loop",
+                    "rewards": None,
+                    "agent": "codex-acp",
+                    "agent_name": "",
+                    "model": "gpt-5.5",
+                    "n_tool_calls": 0,
+                    "n_prompts": 1,
+                    "error": "compact-safe official runner error",
+                    "error_category": "setup",
+                    "verifier_error": None,
+                    "partial_trajectory": False,
+                },
+            )
+            write_json(result_path.with_name("timing.json"), {"total": 2.0})
+            raise RuntimeError("PRIVATE_EXCEPTION_DETAIL_SHOULD_NOT_ESCAPE")
+
+        skillsbench_loop.ensure_benchflow_runtime = fake_ensure
+        skillsbench_loop.run_benchflow_case = fake_run
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        try:
+            with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+                rc = skillsbench_automation_loop_main(
+                    [
+                        "--task-id",
+                        "tictoc-unnecessary-abort-detection",
+                        "--route",
+                        "goal-harness-blind-loop-treatment",
+                        "--jobs-dir",
+                        str(jobs_dir),
+                        "--job-name",
+                        job_name,
+                        "--rollout-name",
+                        "tictoc-unnecessary-abort-detection__goal_harness_blind_loop",
+                        "--run-group-id",
+                        "skillsbench-empty-acp-fixture",
+                    ]
+                )
+        finally:
+            skillsbench_loop.ensure_benchflow_runtime = original_ensure
+            skillsbench_loop.run_benchflow_case = original_run
+
+        assert rc == 0, stderr.getvalue()
+        payload = json.loads(stdout.getvalue())
+        compact = json.loads(
+            Path(payload["compact_benchmark_run_json"]).read_text(encoding="utf-8")
+        )
+        assert compact["official_score_status"] == "missing", compact
+        assert compact["runner_prerequisites"]["host_local_acp_launch_status"] == (
+            "sandbox_installed"
+        ), compact
+        assert compact["interaction_counters"]["private_trajectory_event_count"] == 0
+        assert compact["score_failure_attribution"] == (
+            "skillsbench_host_local_acp_empty_trajectory_after_install"
+        ), compact
+        assert compact["first_blocker"] == (
+            "skillsbench_host_local_acp_empty_trajectory_after_install"
+        ), compact
+        assert "skillsbench_runner_setup_error" in compact[
+            "failure_attribution_labels"
+        ], compact
+        assert "PRIVATE_EXCEPTION_DETAIL_SHOULD_NOT_ESCAPE" not in json.dumps(
+            compact
+        ), compact
+
+
 def test_skillsbench_main_redirects_runner_output_to_private_log() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-private-runner-output-") as tmp:
         jobs_dir = Path(tmp) / "jobs"
@@ -4254,6 +4386,7 @@ if __name__ == "__main__":
     test_skillsbench_main_failure_closeout_preserves_mutated_prerequisites()
     test_skillsbench_main_recovers_official_result_after_runner_exception()
     test_skillsbench_main_recovers_missing_reward_with_structured_prereq_blocker()
+    test_skillsbench_main_marks_empty_acp_trajectory_after_host_install()
     test_skillsbench_main_redirects_runner_output_to_private_log()
     test_skillsbench_reduce_only_discovers_nested_official_result()
     test_skillsbench_reduce_only_preserves_round_reward_trace()

--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -3910,6 +3910,107 @@ def test_skillsbench_main_recovers_official_result_after_runner_exception() -> N
         assert exception_message not in json.dumps(compact), compact
 
 
+def test_skillsbench_main_recovers_missing_reward_with_structured_prereq_blocker() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-missing-reward-prereq-") as tmp:
+        jobs_dir = Path(tmp) / "jobs"
+        job_name = "skillsbench-missing-reward-prereq-fixture"
+
+        original_ensure = skillsbench_loop.ensure_benchflow_runtime
+        original_run = skillsbench_loop.run_benchflow_case
+
+        def fake_ensure(_args: Any) -> None:
+            return None
+
+        async def fake_run(_args: Any, plan: dict[str, Any]) -> Path:
+            prerequisites = plan.setdefault("runner_prerequisites", {})
+            prerequisites.update(
+                {
+                    "agent_execution_mode": "host_local_acp",
+                    "host_local_acp_launch": True,
+                    "host_local_acp_launch_status": "sandbox_install_failed",
+                    "host_local_acp_install_stage": "deploy_skills",
+                    "host_local_acp_install_failed_stage": "deploy_skills",
+                    "container_codex_acp_install_skipped": True,
+                    "codex_acp_runtime_container_bootstrap": False,
+                    "codex_acp_runtime_dependency_preflight": False,
+                    "codex_acp_runtime_launch_preflight": True,
+                    "codex_acp_runtime_launch_preflight_status": "skipped",
+                    "codex_acp_runtime_launch_preflight_raw_logs_read": False,
+                }
+            )
+            result_path = Path(plan["result_json"])
+            write_json(
+                result_path,
+                {
+                    "task_name": "tictoc-unnecessary-abort-detection",
+                    "rollout_name": "tictoc-unnecessary-abort-detection__goal_harness_blind_loop",
+                    "rewards": None,
+                    "agent": "codex-acp",
+                    "agent_name": "",
+                    "model": "gpt-5.5",
+                    "n_tool_calls": 0,
+                    "n_prompts": 1,
+                    "error": "compact-safe official runner error",
+                    "error_category": "setup",
+                    "verifier_error": None,
+                    "partial_trajectory": False,
+                },
+            )
+            write_json(result_path.with_name("timing.json"), {"total": 2.0})
+            raise RuntimeError("PRIVATE_EXCEPTION_DETAIL_SHOULD_NOT_ESCAPE")
+
+        skillsbench_loop.ensure_benchflow_runtime = fake_ensure
+        skillsbench_loop.run_benchflow_case = fake_run
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        try:
+            with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+                rc = skillsbench_automation_loop_main(
+                    [
+                        "--task-id",
+                        "tictoc-unnecessary-abort-detection",
+                        "--route",
+                        "goal-harness-blind-loop-treatment",
+                        "--jobs-dir",
+                        str(jobs_dir),
+                        "--job-name",
+                        job_name,
+                        "--rollout-name",
+                        "tictoc-unnecessary-abort-detection__goal_harness_blind_loop",
+                        "--run-group-id",
+                        "skillsbench-missing-reward-prereq-fixture",
+                    ]
+                )
+        finally:
+            skillsbench_loop.ensure_benchflow_runtime = original_ensure
+            skillsbench_loop.run_benchflow_case = original_run
+
+        assert rc == 0, stderr.getvalue()
+        payload = json.loads(stdout.getvalue())
+        compact = json.loads(
+            Path(payload["compact_benchmark_run_json"]).read_text(encoding="utf-8")
+        )
+        assert compact["official_score_status"] == "missing", compact
+        assert compact["score_failure_attribution"] == (
+            "skillsbench_host_local_acp_sandbox_install_failed"
+        ), compact
+        assert compact["first_blocker"] == (
+            "skillsbench_host_local_acp_sandbox_install_failed"
+        ), compact
+        assert "skillsbench_runner_setup_error" in compact[
+            "failure_attribution_labels"
+        ], compact
+        assert compact["runner_prerequisites"]["host_local_acp_install_stage"] == (
+            "deploy_skills"
+        ), compact
+        assert compact["runner_prerequisites"][
+            "host_local_acp_install_failed_stage"
+        ] == "deploy_skills", compact
+        assert "PRIVATE_EXCEPTION_DETAIL_SHOULD_NOT_ESCAPE" not in json.dumps(
+            compact
+        ), compact
+
+
 def test_skillsbench_main_redirects_runner_output_to_private_log() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-private-runner-output-") as tmp:
         jobs_dir = Path(tmp) / "jobs"
@@ -4151,6 +4252,8 @@ if __name__ == "__main__":
     test_skillsbench_runner_failure_marks_pre_agent_install_stage()
     test_skillsbench_reduce_only_missing_result_records_closeout_exit_zero()
     test_skillsbench_main_failure_closeout_preserves_mutated_prerequisites()
+    test_skillsbench_main_recovers_official_result_after_runner_exception()
+    test_skillsbench_main_recovers_missing_reward_with_structured_prereq_blocker()
     test_skillsbench_main_redirects_runner_output_to_private_log()
     test_skillsbench_reduce_only_discovers_nested_official_result()
     test_skillsbench_reduce_only_preserves_round_reward_trace()

--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -4143,6 +4143,140 @@ def test_skillsbench_main_marks_empty_acp_trajectory_after_host_install() -> Non
         ), compact
 
 
+def test_skillsbench_main_marks_agent_message_only_no_tool_calls() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-agent-message-only-") as tmp:
+        jobs_dir = Path(tmp) / "jobs"
+        job_name = "skillsbench-agent-message-only-fixture"
+
+        original_ensure = skillsbench_loop.ensure_benchflow_runtime
+        original_run = skillsbench_loop.run_benchflow_case
+
+        def fake_ensure(_args: Any) -> None:
+            return None
+
+        async def fake_run(_args: Any, plan: dict[str, Any]) -> Path:
+            prerequisites = plan.setdefault("runner_prerequisites", {})
+            prerequisites.update(
+                {
+                    "agent_execution_mode": "container_local_acp",
+                    "container_codex_acp_install_skipped": False,
+                    "codex_acp_runtime_container_bootstrap": True,
+                    "codex_acp_runtime_dependency_preflight": True,
+                    "codex_acp_runtime_launch_preflight": True,
+                    "codex_acp_runtime_launch_preflight_status": "passed",
+                    "codex_acp_runtime_launch_preflight_raw_logs_read": False,
+                }
+            )
+            write_json(
+                Path(plan["controller_trace_json"]),
+                {
+                    "schema_version": "skillsbench_goal_harness_controller_trace_v0",
+                    "route": "goal-harness-blind-loop-treatment",
+                    "trace_publicness": "public_counts_only_no_task_text_no_verifier_output",
+                    "heartbeat_count": 2,
+                    "controller_action_decisions": 2,
+                    "initial_prompt_count": 1,
+                    "followup_prompt_count": 1,
+                    "round_rewards": [
+                        {
+                            "agent_round": 1,
+                            "reward_present": False,
+                            "passed": False,
+                        },
+                        {
+                            "agent_round": 2,
+                            "reward_present": False,
+                            "passed": False,
+                        },
+                    ],
+                    "official_success_observed": False,
+                    "raw_task_text_recorded": False,
+                    "raw_verifier_output_recorded": False,
+                    "raw_agent_trajectory_recorded": False,
+                    "acp_trajectory_summary": {
+                        "schema_version": "skillsbench_acp_trajectory_summary_v0",
+                        "private_trajectory_present": True,
+                        "raw_text_copied_to_public": False,
+                        "event_count": 4,
+                        "round_count": 2,
+                        "user_message_count": 2,
+                        "agent_message_count": 2,
+                        "tool_call_count": 0,
+                        "codex_acp_text_present": False,
+                        "codex_acp_text_bytes": 0,
+                    },
+                },
+            )
+            result_path = Path(plan["result_json"])
+            write_json(
+                result_path,
+                {
+                    "task_name": "tictoc-unnecessary-abort-detection",
+                    "rollout_name": "tictoc-unnecessary-abort-detection__goal_harness_blind_loop",
+                    "rewards": None,
+                    "agent": "codex-acp",
+                    "agent_name": "codex-acp",
+                    "model": "gpt-5.5",
+                    "n_tool_calls": 0,
+                    "n_prompts": 2,
+                    "error": "compact-safe official runner error",
+                    "error_category": "agent_behavior",
+                    "verifier_error": None,
+                    "partial_trajectory": False,
+                    "trajectory_source": "acp",
+                },
+            )
+            write_json(result_path.with_name("timing.json"), {"total": 2.0})
+            raise RuntimeError("PRIVATE_EXCEPTION_DETAIL_SHOULD_NOT_ESCAPE")
+
+        skillsbench_loop.ensure_benchflow_runtime = fake_ensure
+        skillsbench_loop.run_benchflow_case = fake_run
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        try:
+            with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+                rc = skillsbench_automation_loop_main(
+                    [
+                        "--task-id",
+                        "tictoc-unnecessary-abort-detection",
+                        "--route",
+                        "goal-harness-blind-loop-treatment",
+                        "--jobs-dir",
+                        str(jobs_dir),
+                        "--job-name",
+                        job_name,
+                        "--rollout-name",
+                        "tictoc-unnecessary-abort-detection__goal_harness_blind_loop",
+                        "--run-group-id",
+                        "skillsbench-agent-message-only-fixture",
+                    ]
+                )
+        finally:
+            skillsbench_loop.ensure_benchflow_runtime = original_ensure
+            skillsbench_loop.run_benchflow_case = original_run
+
+        assert rc == 0, stderr.getvalue()
+        payload = json.loads(stdout.getvalue())
+        compact = json.loads(
+            Path(payload["compact_benchmark_run_json"]).read_text(encoding="utf-8")
+        )
+        assert compact["official_score_status"] == "missing", compact
+        assert compact["interaction_counters"]["private_trajectory_event_count"] == 4
+        assert compact["interaction_counters"]["private_trajectory_tool_call_count"] == 0
+        assert compact["score_failure_attribution"] == (
+            "skillsbench_acp_agent_message_only_no_tool_calls"
+        ), compact
+        assert compact["first_blocker"] == (
+            "skillsbench_acp_agent_message_only_no_tool_calls"
+        ), compact
+        assert "skillsbench_agent_behavior_gap" in compact[
+            "failure_attribution_labels"
+        ], compact
+        assert "PRIVATE_EXCEPTION_DETAIL_SHOULD_NOT_ESCAPE" not in json.dumps(
+            compact
+        ), compact
+
+
 def test_skillsbench_main_redirects_runner_output_to_private_log() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-private-runner-output-") as tmp:
         jobs_dir = Path(tmp) / "jobs"
@@ -4387,6 +4521,7 @@ if __name__ == "__main__":
     test_skillsbench_main_recovers_official_result_after_runner_exception()
     test_skillsbench_main_recovers_missing_reward_with_structured_prereq_blocker()
     test_skillsbench_main_marks_empty_acp_trajectory_after_host_install()
+    test_skillsbench_main_marks_agent_message_only_no_tool_calls()
     test_skillsbench_main_redirects_runner_output_to_private_log()
     test_skillsbench_reduce_only_discovers_nested_official_result()
     test_skillsbench_reduce_only_preserves_round_reward_trace()

--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -4162,8 +4162,11 @@ def test_skillsbench_main_marks_agent_message_only_no_tool_calls() -> None:
                     "container_codex_acp_install_skipped": False,
                     "codex_acp_runtime_container_bootstrap": True,
                     "codex_acp_runtime_dependency_preflight": True,
-                    "codex_acp_runtime_launch_preflight": True,
-                    "codex_acp_runtime_launch_preflight_status": "passed",
+                    "codex_acp_runtime_launch_preflight": False,
+                    "codex_acp_runtime_launch_preflight_stage": (
+                        "after_agent_install_before_acp_connect"
+                    ),
+                    "codex_acp_runtime_launch_preflight_status": "pending",
                     "codex_acp_runtime_launch_preflight_raw_logs_read": False,
                 }
             )

--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -3822,6 +3822,94 @@ def test_skillsbench_main_failure_closeout_preserves_mutated_prerequisites() -> 
         }, compact
 
 
+def test_skillsbench_main_recovers_official_result_after_runner_exception() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-result-recovery-") as tmp:
+        jobs_dir = Path(tmp) / "jobs"
+        job_name = "skillsbench-result-recovery-fixture"
+        exception_message = "PRIVATE_EXCEPTION_DETAIL_SHOULD_NOT_ESCAPE"
+
+        original_ensure = skillsbench_loop.ensure_benchflow_runtime
+        original_run = skillsbench_loop.run_benchflow_case
+
+        def fake_ensure(_args: Any) -> None:
+            return None
+
+        async def fake_run(_args: Any, plan: dict[str, Any]) -> Path:
+            result_path = Path(plan["result_json"])
+            write_json(
+                result_path,
+                {
+                    "task_name": "tictoc-unnecessary-abort-detection",
+                    "rollout_name": "tictoc-unnecessary-abort-detection__codex_acp_blind_loop",
+                    "rewards": {"reward": 0.0},
+                    "agent": "codex-acp",
+                    "agent_name": "codex-acp",
+                    "model": "gpt-5.5",
+                    "n_tool_calls": 0,
+                    "n_prompts": 1,
+                    "error": "compact-safe official runner error",
+                    "error_category": "idle_timeout",
+                    "verifier_error": None,
+                    "partial_trajectory": False,
+                    "trajectory_source": "acp",
+                },
+            )
+            write_json(result_path.with_name("timing.json"), {"total": 2.0})
+            raise RuntimeError(exception_message)
+
+        skillsbench_loop.ensure_benchflow_runtime = fake_ensure
+        skillsbench_loop.run_benchflow_case = fake_run
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        try:
+            with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+                rc = skillsbench_automation_loop_main(
+                    [
+                        "--task-id",
+                        "tictoc-unnecessary-abort-detection",
+                        "--route",
+                        "codex-acp-blind-loop-baseline",
+                        "--jobs-dir",
+                        str(jobs_dir),
+                        "--job-name",
+                        job_name,
+                        "--rollout-name",
+                        "tictoc-unnecessary-abort-detection__codex_acp_blind_loop",
+                        "--run-group-id",
+                        "skillsbench-result-recovery-fixture",
+                    ]
+                )
+        finally:
+            skillsbench_loop.ensure_benchflow_runtime = original_ensure
+            skillsbench_loop.run_benchflow_case = original_run
+
+        assert rc == 0, stderr.getvalue()
+        assert stderr.getvalue() == "", stderr.getvalue()
+        payload = json.loads(stdout.getvalue())
+        assert payload["ok"] is True, payload
+        assert payload["recovered_after_runner_exception"] is True, payload
+        assert payload["runner_exception_type"] == "RuntimeError", payload
+        compact_path = Path(payload["compact_benchmark_run_json"])
+        compact = json.loads(compact_path.read_text(encoding="utf-8"))
+        assert compact["official_score_status"] == "completed", compact
+        assert compact["official_task_score"]["value"] == 0.0, compact
+        assert compact["runner_return_status"] == (
+            "official_result_recovered_after_runner_exception"
+        ), compact
+        assert compact["result_recovery"] == {
+            "exception_type": "RuntimeError",
+            "official_result_json_materialized": True,
+            "raw_exception_recorded": False,
+            "raw_logs_read": False,
+            "raw_task_text_read": False,
+            "raw_trajectory_read": False,
+            "schema_version": "skillsbench_result_recovery_v0",
+            "status": "official_result_recovered_after_runner_exception",
+        }, compact
+        assert exception_message not in json.dumps(payload), payload
+        assert exception_message not in json.dumps(compact), compact
+
+
 def test_skillsbench_main_redirects_runner_output_to_private_log() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-private-runner-output-") as tmp:
         jobs_dir = Path(tmp) / "jobs"

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -3026,6 +3026,34 @@ def reduce_result(
                     if item not in existing_labels:
                         existing_labels.append(item)
                 compact["failure_attribution_labels"] = existing_labels
+    elif compact.get("official_score_status") == "missing":
+        counters = compact.get("interaction_counters")
+        if isinstance(counters, dict):
+            event_count = counters.get("private_trajectory_event_count")
+            round_count = counters.get("private_trajectory_round_count")
+            tool_count = counters.get("private_trajectory_tool_call_count")
+            controller_decisions = counters.get("controller_action_decisions")
+            if (
+                isinstance(event_count, int)
+                and event_count > 0
+                and isinstance(round_count, int)
+                and round_count > 0
+                and tool_count == 0
+                and isinstance(controller_decisions, int)
+                and controller_decisions > 0
+            ):
+                label = "skillsbench_acp_agent_message_only_no_tool_calls"
+                compact["score_failure_attribution"] = label
+                compact.setdefault("first_blocker", label)
+                existing_labels = [
+                    item
+                    for item in compact.get("failure_attribution_labels", [])
+                    if isinstance(item, str)
+                ]
+                for item in (label, "skillsbench_agent_behavior_gap"):
+                    if item not in existing_labels:
+                        existing_labels.append(item)
+                compact["failure_attribution_labels"] = existing_labels
     if task_staging:
         compact["task_staging"] = task_staging
     discovery = plan.get("result_discovery")

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -694,6 +694,43 @@ def _runner_prerequisite_failure_attribution(
     return None
 
 
+def _apply_agent_message_only_no_tool_calls_attribution(
+    compact: dict[str, Any],
+) -> bool:
+    counters = compact.get("interaction_counters")
+    if not isinstance(counters, dict):
+        return False
+
+    event_count = counters.get("private_trajectory_event_count")
+    round_count = counters.get("private_trajectory_round_count")
+    tool_count = counters.get("private_trajectory_tool_call_count")
+    controller_decisions = counters.get("controller_action_decisions")
+    if not (
+        isinstance(event_count, int)
+        and event_count > 0
+        and isinstance(round_count, int)
+        and round_count > 0
+        and tool_count == 0
+        and isinstance(controller_decisions, int)
+        and controller_decisions > 0
+    ):
+        return False
+
+    label = "skillsbench_acp_agent_message_only_no_tool_calls"
+    compact["score_failure_attribution"] = label
+    compact.setdefault("first_blocker", label)
+    existing_labels = [
+        item
+        for item in compact.get("failure_attribution_labels", [])
+        if isinstance(item, str)
+    ]
+    for item in (label, "skillsbench_agent_behavior_gap"):
+        if item not in existing_labels:
+            existing_labels.append(item)
+    compact["failure_attribution_labels"] = existing_labels
+    return True
+
+
 def _public_task_staging(value: Any) -> dict[str, Any]:
     if not isinstance(value, dict):
         return {}
@@ -2982,78 +3019,54 @@ def reduce_result(
     prereq_failure = _runner_prerequisite_failure_attribution(
         plan.get("runner_prerequisites")
     )
-    if (
-        prereq_failure is not None
-        and compact.get("official_score_status") == "missing"
-    ):
-        _exception_type, score_failure_attribution, labels = prereq_failure
-        compact["score_failure_attribution"] = score_failure_attribution
-        compact.setdefault("first_blocker", score_failure_attribution)
-        existing_labels = [
-            label
-            for label in compact.get("failure_attribution_labels", [])
-            if isinstance(label, str)
-        ]
-        for label in labels:
-            if label not in existing_labels:
-                existing_labels.append(label)
-        compact["failure_attribution_labels"] = existing_labels
-    elif (
-        compact.get("official_score_status") == "missing"
-        and runner_prerequisites.get("agent_execution_mode") == "host_local_acp"
-        and runner_prerequisites.get("host_local_acp_launch_status")
-        == "sandbox_installed"
-    ):
-        counters = compact.get("interaction_counters")
-        if isinstance(counters, dict):
-            event_count = counters.get("private_trajectory_event_count")
-            tool_count = counters.get("private_trajectory_tool_call_count")
-            summary_present = counters.get("private_trajectory_summary_present")
-            if (
-                summary_present is True
-                and event_count == 0
-                and tool_count == 0
-            ):
-                label = "skillsbench_host_local_acp_empty_trajectory_after_install"
-                compact["score_failure_attribution"] = label
-                compact.setdefault("first_blocker", label)
-                existing_labels = [
-                    item
-                    for item in compact.get("failure_attribution_labels", [])
-                    if isinstance(item, str)
-                ]
-                for item in (label, "skillsbench_runner_setup_error"):
-                    if item not in existing_labels:
-                        existing_labels.append(item)
-                compact["failure_attribution_labels"] = existing_labels
-    elif compact.get("official_score_status") == "missing":
-        counters = compact.get("interaction_counters")
-        if isinstance(counters, dict):
-            event_count = counters.get("private_trajectory_event_count")
-            round_count = counters.get("private_trajectory_round_count")
-            tool_count = counters.get("private_trajectory_tool_call_count")
-            controller_decisions = counters.get("controller_action_decisions")
-            if (
-                isinstance(event_count, int)
-                and event_count > 0
-                and isinstance(round_count, int)
-                and round_count > 0
-                and tool_count == 0
-                and isinstance(controller_decisions, int)
-                and controller_decisions > 0
-            ):
-                label = "skillsbench_acp_agent_message_only_no_tool_calls"
-                compact["score_failure_attribution"] = label
-                compact.setdefault("first_blocker", label)
-                existing_labels = [
-                    item
-                    for item in compact.get("failure_attribution_labels", [])
-                    if isinstance(item, str)
-                ]
-                for item in (label, "skillsbench_agent_behavior_gap"):
-                    if item not in existing_labels:
-                        existing_labels.append(item)
-                compact["failure_attribution_labels"] = existing_labels
+    if compact.get("official_score_status") == "missing":
+        has_agent_message_only_evidence = (
+            _apply_agent_message_only_no_tool_calls_attribution(compact)
+        )
+    else:
+        has_agent_message_only_evidence = False
+    if compact.get("official_score_status") == "missing":
+        if prereq_failure is not None and not has_agent_message_only_evidence:
+            _exception_type, score_failure_attribution, labels = prereq_failure
+            compact["score_failure_attribution"] = score_failure_attribution
+            compact.setdefault("first_blocker", score_failure_attribution)
+            existing_labels = [
+                label
+                for label in compact.get("failure_attribution_labels", [])
+                if isinstance(label, str)
+            ]
+            for label in labels:
+                if label not in existing_labels:
+                    existing_labels.append(label)
+            compact["failure_attribution_labels"] = existing_labels
+        elif (
+            not has_agent_message_only_evidence
+            and runner_prerequisites.get("agent_execution_mode") == "host_local_acp"
+            and runner_prerequisites.get("host_local_acp_launch_status")
+            == "sandbox_installed"
+        ):
+            counters = compact.get("interaction_counters")
+            if isinstance(counters, dict):
+                event_count = counters.get("private_trajectory_event_count")
+                tool_count = counters.get("private_trajectory_tool_call_count")
+                summary_present = counters.get("private_trajectory_summary_present")
+                if (
+                    summary_present is True
+                    and event_count == 0
+                    and tool_count == 0
+                ):
+                    label = "skillsbench_host_local_acp_empty_trajectory_after_install"
+                    compact["score_failure_attribution"] = label
+                    compact.setdefault("first_blocker", label)
+                    existing_labels = [
+                        item
+                        for item in compact.get("failure_attribution_labels", [])
+                        if isinstance(item, str)
+                    ]
+                    for item in (label, "skillsbench_runner_setup_error"):
+                        if item not in existing_labels:
+                            existing_labels.append(item)
+                    compact["failure_attribution_labels"] = existing_labels
     if task_staging:
         compact["task_staging"] = task_staging
     discovery = plan.get("result_discovery")

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -621,6 +621,8 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "schema_version",
         "agent_execution_mode",
         "host_local_acp_launch_status",
+        "host_local_acp_install_stage",
+        "host_local_acp_install_failed_stage",
         "codex_acp_runtime_launch_preflight_stage",
         "codex_acp_runtime_launch_preflight_status",
     ):
@@ -668,6 +670,14 @@ def _runner_prerequisite_failure_attribution(
 
     if value.get("host_local_acp_launch_status") == "failed":
         label = "skillsbench_host_local_acp_launch_failed"
+        return label, label, [label, "skillsbench_runner_setup_error"]
+
+    if value.get("host_local_acp_launch_status") == "sandbox_install_failed":
+        label = "skillsbench_host_local_acp_sandbox_install_failed"
+        return label, label, [label, "skillsbench_runner_setup_error"]
+
+    if value.get("host_local_acp_launch_status") == "installing_sandbox":
+        label = "skillsbench_host_local_acp_sandbox_install_incomplete"
         return label, label, [label, "skillsbench_runner_setup_error"]
 
     if (
@@ -2774,43 +2784,60 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
         )
         prerequisites["codex_acp_runtime_launch_preflight_status"] = "skipped"
         prerequisites["codex_acp_runtime_launch_preflight_raw_logs_read"] = False
-        cwd_result = await self._env.exec("pwd", timeout_sec=10)
-        self._agent_cwd = (cwd_result.stdout or "").strip() or "/app"
-        self._agent_cfg = None
-        if cfg.sandbox_user:
-            self._agent_cwd = await benchflow_rollout_module.setup_sandbox_user(
+        try:
+            prerequisites["host_local_acp_install_stage"] = "pwd_probe"
+            cwd_result = await self._env.exec("pwd", timeout_sec=10)
+            self._agent_cwd = (cwd_result.stdout or "").strip() or "/app"
+            self._agent_cfg = None
+            if cfg.sandbox_user:
+                prerequisites["host_local_acp_install_stage"] = "sandbox_user_setup"
+                self._agent_cwd = await benchflow_rollout_module.setup_sandbox_user(
+                    self._env,
+                    cfg.sandbox_user,
+                    workspace=self._agent_cwd,
+                    timeout_sec=cfg.sandbox_setup_timeout,
+                )
+            prerequisites["host_local_acp_install_stage"] = "snapshot_build_config"
+            await benchflow_rollout_module._snapshot_build_config(
+                self._env, workspace=self._agent_cwd
+            )
+            prerequisites["host_local_acp_install_stage"] = "seed_verifier_workspace"
+            await benchflow_rollout_module._seed_verifier_workspace(
+                self._env, workspace=self._agent_cwd, sandbox_user=cfg.sandbox_user
+            )
+            prerequisites["host_local_acp_install_stage"] = "deploy_skills"
+            await benchflow_rollout_module.deploy_skills(
                 self._env,
+                getattr(self, "_effective_task_path", cfg.task_path),
+                cfg.skills_dir,
+                None,
                 cfg.sandbox_user,
-                workspace=self._agent_cwd,
-                timeout_sec=cfg.sandbox_setup_timeout,
+                self._agent_cwd,
+                self._task,
+                include_task_skills=getattr(
+                    cfg,
+                    "include_task_skills",
+                    bool(args.include_task_skills),
+                ),
             )
-        await benchflow_rollout_module._snapshot_build_config(
-            self._env, workspace=self._agent_cwd
-        )
-        await benchflow_rollout_module._seed_verifier_workspace(
-            self._env, workspace=self._agent_cwd, sandbox_user=cfg.sandbox_user
-        )
-        await benchflow_rollout_module.deploy_skills(
-            self._env,
-            getattr(self, "_effective_task_path", cfg.task_path),
-            cfg.skills_dir,
-            None,
-            cfg.sandbox_user,
-            self._agent_cwd,
-            self._task,
-            include_task_skills=getattr(
-                cfg,
-                "include_task_skills",
-                bool(args.include_task_skills),
-            ),
-        )
-        if cfg.export_generated_skills_to:
-            await benchflow_rollout_module._ensure_sandbox_dir(
-                self._env, cfg.generated_skills_root, cfg.sandbox_user
+            if cfg.export_generated_skills_to:
+                prerequisites["host_local_acp_install_stage"] = (
+                    "ensure_generated_skills_dir"
+                )
+                await benchflow_rollout_module._ensure_sandbox_dir(
+                    self._env, cfg.generated_skills_root, cfg.sandbox_user
+                )
+            prerequisites["host_local_acp_install_stage"] = "lockdown_paths"
+            await benchflow_rollout_module.lockdown_paths(
+                self._env, self._effective_locked
             )
-        await benchflow_rollout_module.lockdown_paths(
-            self._env, self._effective_locked
-        )
+        except Exception:
+            prerequisites["host_local_acp_install_failed_stage"] = str(
+                prerequisites.get("host_local_acp_install_stage") or "unknown"
+            )
+            prerequisites["host_local_acp_launch_status"] = "sandbox_install_failed"
+            raise
+        prerequisites["host_local_acp_install_stage"] = "sandbox_installed"
         prerequisites["host_local_acp_launch_status"] = "sandbox_installed"
         self._phase = "installed"
 
@@ -2949,6 +2976,25 @@ def reduce_result(
         raise RuntimeError("SkillsBench treatment reducer produced non-compact run")
     if runner_prerequisites:
         compact["runner_prerequisites"] = runner_prerequisites
+    prereq_failure = _runner_prerequisite_failure_attribution(
+        plan.get("runner_prerequisites")
+    )
+    if (
+        prereq_failure is not None
+        and compact.get("official_score_status") == "missing"
+    ):
+        _exception_type, score_failure_attribution, labels = prereq_failure
+        compact["score_failure_attribution"] = score_failure_attribution
+        compact.setdefault("first_blocker", score_failure_attribution)
+        existing_labels = [
+            label
+            for label in compact.get("failure_attribution_labels", [])
+            if isinstance(label, str)
+        ]
+        for label in labels:
+            if label not in existing_labels:
+                existing_labels.append(label)
+        compact["failure_attribution_labels"] = existing_labels
     if task_staging:
         compact["task_staging"] = task_staging
     discovery = plan.get("result_discovery")

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -2981,6 +2981,62 @@ def reduce_result(
     return compact
 
 
+def reduce_official_result_after_runner_exception(
+    args: argparse.Namespace,
+    plan: dict[str, Any],
+    exc: BaseException,
+) -> dict[str, Any] | None:
+    """Recover an official result that BenchFlow wrote before raising.
+
+    BenchFlow can raise for the rollout while still leaving a valid
+    ``result.json``/``timing.json`` behind. In that case the public benchmark
+    truth is the official result, not a synthetic "missing result" closeout.
+    This path still reads only the official compact result artifacts.
+    """
+
+    try:
+        result_path = discover_benchflow_result_path(plan)
+    except Exception:
+        return None
+    if not result_path.exists():
+        return None
+
+    compact = reduce_result(args, result_path, plan)
+    compact["runner_return_status"] = (
+        "official_result_recovered_after_runner_exception"
+    )
+    compact["result_recovery"] = {
+        "schema_version": "skillsbench_result_recovery_v0",
+        "status": "official_result_recovered_after_runner_exception",
+        "exception_type": type(exc).__name__,
+        "official_result_json_materialized": True,
+        "raw_exception_recorded": False,
+        "raw_logs_read": False,
+        "raw_task_text_read": False,
+        "raw_trajectory_read": False,
+    }
+    compact_path = Path(plan["compact_benchmark_run_json"])
+    compact_path.parent.mkdir(parents=True, exist_ok=True)
+    compact_path.write_text(
+        json.dumps(compact, indent=2, sort_keys=True, default=_json_default) + "\n",
+        encoding="utf-8",
+    )
+    ledger_update = update_ledger(args, compact, compact_path=compact_path)
+    append_history(args, compact_path)
+    return {
+        "ok": True,
+        "plan_only": False,
+        "recovered_after_runner_exception": True,
+        "runner_exception_type": type(exc).__name__,
+        "result_json": str(result_path),
+        "compact_benchmark_run_json": str(compact_path),
+        "result_discovery": plan.get("result_discovery"),
+        "official_task_score": compact.get("official_task_score"),
+        "score_failure_attribution": compact.get("score_failure_attribution"),
+        "ledger_update": ledger_update,
+    }
+
+
 def build_runner_failure_compact(
     args: argparse.Namespace,
     plan: dict[str, Any],
@@ -3555,6 +3611,12 @@ def main(argv: list[str] | None = None) -> int:
     try:
         payload = asyncio.run(async_main(args, plan=plan))
     except Exception as exc:
+        recovered_payload = reduce_official_result_after_runner_exception(
+            args, plan, exc
+        )
+        if recovered_payload is not None:
+            print(json.dumps(recovered_payload, indent=2, sort_keys=True))
+            return 0
         try:
             compact = build_runner_failure_compact(args, plan, exc)
             compact_path = Path(plan["compact_benchmark_run_json"])

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -2789,48 +2789,51 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
             cwd_result = await self._env.exec("pwd", timeout_sec=10)
             self._agent_cwd = (cwd_result.stdout or "").strip() or "/app"
             self._agent_cfg = None
+            planes = getattr(self, "_planes", None)
+            if planes is None:
+                raise RuntimeError("BenchFlow rollout planes unavailable")
             if cfg.sandbox_user:
                 prerequisites["host_local_acp_install_stage"] = "sandbox_user_setup"
-                self._agent_cwd = await benchflow_rollout_module.setup_sandbox_user(
+                self._agent_cwd = await planes.setup_sandbox_user(
                     self._env,
                     cfg.sandbox_user,
                     workspace=self._agent_cwd,
                     timeout_sec=cfg.sandbox_setup_timeout,
                 )
             prerequisites["host_local_acp_install_stage"] = "snapshot_build_config"
-            await benchflow_rollout_module._snapshot_build_config(
-                self._env, workspace=self._agent_cwd
-            )
+            await planes.snapshot_build_config(self._env, workspace=self._agent_cwd)
             prerequisites["host_local_acp_install_stage"] = "seed_verifier_workspace"
-            await benchflow_rollout_module._seed_verifier_workspace(
+            await planes.seed_verifier_workspace(
                 self._env, workspace=self._agent_cwd, sandbox_user=cfg.sandbox_user
             )
             prerequisites["host_local_acp_install_stage"] = "deploy_skills"
-            await benchflow_rollout_module.deploy_skills(
+            await planes.deploy_skills(
                 self._env,
                 getattr(self, "_effective_task_path", cfg.task_path),
-                cfg.skills_dir,
+                getattr(self, "_effective_skills_dir", cfg.skills_dir),
                 None,
                 cfg.sandbox_user,
                 self._agent_cwd,
-                self._task,
-                include_task_skills=getattr(
-                    cfg,
-                    "include_task_skills",
-                    bool(args.include_task_skills),
+                skills_sandbox_dir=getattr(
+                    self,
+                    "_effective_skills_sandbox_dir",
+                    getattr(cfg, "skills_sandbox_dir", "/app/skills"),
                 ),
             )
             if cfg.export_generated_skills_to:
                 prerequisites["host_local_acp_install_stage"] = (
                     "ensure_generated_skills_dir"
                 )
-                await benchflow_rollout_module._ensure_sandbox_dir(
+                ensure_sandbox_dir = getattr(
+                    benchflow_rollout_module, "_ensure_sandbox_dir", None
+                )
+                if ensure_sandbox_dir is None:
+                    raise RuntimeError("BenchFlow ensure_sandbox_dir unavailable")
+                await ensure_sandbox_dir(
                     self._env, cfg.generated_skills_root, cfg.sandbox_user
                 )
             prerequisites["host_local_acp_install_stage"] = "lockdown_paths"
-            await benchflow_rollout_module.lockdown_paths(
-                self._env, self._effective_locked
-            )
+            await planes.lockdown_paths(self._env, self._effective_locked)
         except Exception:
             prerequisites["host_local_acp_install_failed_stage"] = str(
                 prerequisites.get("host_local_acp_install_stage") or "unknown"
@@ -2995,6 +2998,34 @@ def reduce_result(
             if label not in existing_labels:
                 existing_labels.append(label)
         compact["failure_attribution_labels"] = existing_labels
+    elif (
+        compact.get("official_score_status") == "missing"
+        and runner_prerequisites.get("agent_execution_mode") == "host_local_acp"
+        and runner_prerequisites.get("host_local_acp_launch_status")
+        == "sandbox_installed"
+    ):
+        counters = compact.get("interaction_counters")
+        if isinstance(counters, dict):
+            event_count = counters.get("private_trajectory_event_count")
+            tool_count = counters.get("private_trajectory_tool_call_count")
+            summary_present = counters.get("private_trajectory_summary_present")
+            if (
+                summary_present is True
+                and event_count == 0
+                and tool_count == 0
+            ):
+                label = "skillsbench_host_local_acp_empty_trajectory_after_install"
+                compact["score_failure_attribution"] = label
+                compact.setdefault("first_blocker", label)
+                existing_labels = [
+                    item
+                    for item in compact.get("failure_attribution_labels", [])
+                    if isinstance(item, str)
+                ]
+                for item in (label, "skillsbench_runner_setup_error"):
+                    if item not in existing_labels:
+                        existing_labels.append(item)
+                compact["failure_attribution_labels"] = existing_labels
     if task_staging:
         compact["task_staging"] = task_staging
     discovery = plan.get("result_discovery")


### PR DESCRIPTION
## Summary
- Recover official SkillsBench `result.json`/`timing.json` when BenchFlow raises after writing the official result
- Mark recovered closeouts with a public-safe `result_recovery` record instead of falling back to missing-result compact blockers
- Add a regression for the tictoc-shaped case where a 0.0 official score exists but the runner throws

## Validation
- `python3 -m py_compile scripts/skillsbench_automation_loop.py examples/skillsbench-benchmark-run-smoke.py`
- `python3 examples/skillsbench-benchmark-run-smoke.py`
- `goal-harness check --scan-path scripts/skillsbench_automation_loop.py`
- `goal-harness check --scan-path examples/skillsbench-benchmark-run-smoke.py`
- `git diff --check`

## Boundary
- No raw task text, raw logs, raw trajectories, credentials, or generated benchmark artifacts are included.
- The recovery path reads only official SkillsBench compact result artifacts (`result.json` and sibling `timing.json`).