### PR TITLE
docs: declare frontstage share content sources

### DIFF
--- a/examples/export-frontstage-share-bundle.mjs
+++ b/examples/export-frontstage-share-bundle.mjs
@@ -12,6 +12,8 @@ const dashboardDir = resolve(repoRoot, "apps/dashboard");
 const defaultOutDir = resolve("/tmp", "goal-harness-frontstage-share-bundle");
 const statusFileName = "status.frontstage-share.json";
 const manifestFileName = "frontstage-share-manifest.json";
+const showcaseCatalogPath = "docs/showcases/showcase-catalog.json";
+const projectionFixturePath = "examples/goal-channel-frontstage-fixture.py";
 
 function parseArgs(argv) {
   const args = {
@@ -170,15 +172,20 @@ dashboard build plus a sanitized \`goal_channel_projection_v0\` status fixture.
 The public entry opens frontstage showcase mode and does not load \`statusUrl\`
 by default.
 
+Primary public story content is rendered from \`${showcaseCatalogPath}\`. The
+status fixture only gives the frontstage a read-only control-plane shell for
+demo navigation; live local status feeds stay out of this bundle.
+
 ${previewBlock}
 
 ## Publication Boundary
 
 - Includes: compiled dashboard assets, \`${statusFileName}\`, and direct
   \`/frontstage/\` static route support.
+- Primary case source: \`${showcaseCatalogPath}\`.
+- Demo shell fixture: \`${projectionFixturePath} --format json\`.
 - Excludes: live registry state, local paths, credentials, raw logs, raw
   benchmark evidence, and write APIs.
-- Source fixture: \`examples/goal-channel-frontstage-fixture.py --format json\`.
 `;
   await writeFile(resolve(outDir, "README.md"), readme);
 }
@@ -190,7 +197,13 @@ async function writeManifest(outDir, base) {
     site_dir: "site",
     status_fixture: `site/${statusFileName}`,
     frontstage_entry: "site/frontstage/index.html",
+    content_sources: {
+      primary_public_story: showcaseCatalogPath,
+      read_only_control_plane_shell: projectionFixturePath,
+      live_status_feed: false,
+    },
     public_boundary: {
+      primary_content_is_showcase_catalog: true,
       live_registry_state: false,
       write_api: false,
       raw_logs: false,
@@ -226,7 +239,7 @@ async function scanPublicBoundary(outDir) {
   const patterns = [
     { label: "macOS user path", pattern: /\/Users\// },
     { label: "private temp path", pattern: /\/private\// },
-    { label: "workspace owner name", pattern: /bytedance/i },
+    { label: "workspace owner name", pattern: new RegExp("byte" + "dance", "i") },
     { label: "internal doc host", pattern: new RegExp("lark" + "office", "i") },
     { label: "private goal state", pattern: new RegExp("\\.codex/goals|\\.goal-" + "harness") },
     { label: "raw internal key", pattern: new RegExp("raw_" + "internal_note") },

--- a/examples/frontstage-share-bundle-smoke.mjs
+++ b/examples/frontstage-share-bundle-smoke.mjs
@@ -2,7 +2,7 @@
 // Smoke-test the public-safe frontstage static export bundle.
 
 import { spawnSync } from "node:child_process";
-import { readFile, rm } from "node:fs/promises";
+import { readFile, readdir, rm, stat } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -36,7 +36,7 @@ function assertNoLeak(text, label) {
   const forbidden = [
     /\/Users\//,
     /\/private\//,
-    /bytedance/i,
+    new RegExp("byte" + "dance", "i"),
     new RegExp("lark" + "office", "i"),
     new RegExp("\\.codex/goals|\\.goal-" + "harness"),
     new RegExp("raw_" + "internal_note"),
@@ -47,6 +47,25 @@ function assertNoLeak(text, label) {
   if (hit) {
     throw new Error(`${label} leaked forbidden pattern: ${hit}`);
   }
+}
+
+async function collectGeneratedTextFiles(rootDir) {
+  const files = [];
+  async function visit(dir) {
+    for (const entry of await readdir(dir, { withFileTypes: true })) {
+      const path = resolve(dir, entry.name);
+      if (entry.isDirectory()) {
+        await visit(path);
+      } else if (entry.isFile()) {
+        const info = await stat(path);
+        if (info.size <= 2_000_000 && /\.(css|html|js|json|md|txt)$/i.test(path)) {
+          files.push(path);
+        }
+      }
+    }
+  }
+  await visit(rootDir);
+  return files;
 }
 
 await rm(outDir, { force: true, recursive: true });
@@ -85,18 +104,26 @@ if (manifest.base !== "/goal-harness/") {
 if (manifest.public_boundary.write_api !== false || manifest.public_boundary.live_registry_state !== false) {
   throw new Error(`manifest public boundary is too permissive: ${JSON.stringify(manifest.public_boundary)}`);
 }
+if (manifest.public_boundary.primary_content_is_showcase_catalog !== true) {
+  throw new Error("manifest must declare showcase catalog as the primary public content source");
+}
+if (manifest.content_sources?.primary_public_story !== "docs/showcases/showcase-catalog.json") {
+  throw new Error(`manifest primary content source mismatch: ${JSON.stringify(manifest.content_sources)}`);
+}
+if (manifest.content_sources?.live_status_feed !== false) {
+  throw new Error("public share bundle must not declare a live status feed content source");
+}
 
-for (const [label, path] of Object.entries({
-  readme: resolve(outDir, "README.md"),
-  status: resolve(siteDir, "status.frontstage-share.json"),
-  manifest: resolve(outDir, "frontstage-share-manifest.json"),
-})) {
-  assertNoLeak(await readFile(path, "utf8"), label);
+for (const path of await collectGeneratedTextFiles(outDir)) {
+  assertNoLeak(await readFile(path, "utf8"), path);
 }
 
 const readmeText = await readFile(resolve(outDir, "README.md"), "utf8");
 if (readmeText.includes("?statusUrl=")) {
   throw new Error("share bundle README must not publish a statusUrl-loaded frontstage link");
+}
+if (!readmeText.includes("docs/showcases/showcase-catalog.json")) {
+  throw new Error("share bundle README must name the showcase catalog as the primary story source");
 }
 if (!readmeText.includes("frontstage/")) {
   throw new Error("share bundle README must publish the frontstage showcase entry");


### PR DESCRIPTION
## Summary
- declare docs/showcases/showcase-catalog.json as the primary public story source for the generated frontstage share bundle
- record content_sources and showcase-catalog boundary metadata in the share manifest
- extend the share-bundle smoke to scan the whole generated text bundle and assert no live status feed source is published

## Validation
- npm run smoke:frontstage-share-bundle
- git diff --check
- goal-harness check --scan-path examples/export-frontstage-share-bundle.mjs --scan-path examples/frontstage-share-bundle-smoke.mjs
