### PR TITLE
docs: clarify hosted frontstage showcase mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ public-safe, reproducible where possible, and ready for future frontend
 surfaces.
 The hosted frontstage path publishes only the generated public-safe share bundle,
 not live registry state or local status exports.
+It opens in showcase-first mode: public case cards, narrative motion, and the
+public/private boundary render from `docs/showcases/` before any ops-style live
+projection is available.
 
 ## Why It Matters
 

--- a/docs/showcases/README.md
+++ b/docs/showcases/README.md
@@ -46,6 +46,10 @@ live registry files or local status exports.
 Once repository Pages is enabled for GitHub Actions, the same generated bundle
 is available as the
 [hosted frontstage](https://huangruiteng.github.io/goal-harness/frontstage/).
+That hosted route is intentionally case-first. It should help a new user or
+developer understand the showcased patterns before reading CLI output: public
+cases, efficiency evidence, and the public boundary come from this directory;
+live local `statusUrl` feeds belong only to explicit ops-mode inspection.
 
 ## Current Cases
 


### PR DESCRIPTION
## Summary
- clarify that the hosted frontstage opens in showcase-first mode
- point external users at public case cards, narrative motion, and public/private boundary content from docs/showcases
- restate that live local status feeds are ops-mode only

## Validation
- git diff --check
- goal-harness check --scan-path README.md --scan-path docs/showcases/README.md
- python3 examples/docs-governance-smoke.py
- npm run smoke:frontstage-share-bundle