### PR TITLE
docs: add frontstage demo script

### DIFF
--- a/docs/outreach/README.md
+++ b/docs/outreach/README.md
@@ -6,6 +6,7 @@ without mixing them into stable product contracts.
 
 Current drafts:
 
+- [Frontstage demo script](frontstage-demo-script.md)
 - [Marketing copy bank](marketing-copy-bank.md)
 - [Public launch narrative draft](public-launch-narrative-draft.md)
 - [Xiaohongshu launch draft](xiaohongshu-launch-draft.md)

--- a/docs/outreach/frontstage-demo-script.md
+++ b/docs/outreach/frontstage-demo-script.md
@@ -1,0 +1,89 @@
+# Frontstage Demo Script
+
+This is a public-safe script for showing Goal Harness to a new user or
+developer in one screen. It uses the hosted frontstage and the showcase catalog,
+not local Goal Harness status exports.
+
+Demo URL:
+
+<https://huangruiteng.github.io/goal-harness/frontstage/>
+
+![Hosted Goal Harness frontstage showing public-safe showcase cases](../assets/frontstage-showcase-first-screen.png)
+
+## 30-Second Version
+
+Goal Harness is a control plane for long-running agent work. It does not
+replace Codex, Claude Code, Cursor, or another executor loop. It keeps the
+long-running goal visible: human gates, agent todos, claims, scope, quota,
+evidence, run history, and public/private boundaries.
+
+The frontstage shows the public version of that idea: case cards, narrative
+motion, efficiency evidence, and boundary warnings rendered from
+`docs/showcases/`.
+
+## 60-Second Walkthrough
+
+1. Open the hosted frontstage.
+2. Point at the headline: "Always-on agent teams, governed by human judgment."
+3. Point at the case counters: Goal Harness is explained through public cases,
+   not raw private runs.
+4. Point at Efficiency Evidence: the self-iteration case maps public Git
+   history into a conservative, maturity-adjusted workload story.
+5. Point at Public Boundary: the public view is useful because it says what was
+   omitted, not because it hides the fact that a boundary exists.
+6. Close with the product distinction: executor loops do the work; Goal Harness
+   preserves the control-plane state that lets the next loop continue safely.
+
+## Two-Minute Version
+
+Use this when the audience already uses terminal agents or scheduled agent
+loops.
+
+1. Start with the problem:
+   "Long-running agent work usually fails when state drifts. A single blocked
+   user decision can freeze the whole loop, while safe side work that could
+   continue is no longer clearly labeled."
+2. Show the frontstage hero:
+   "This public view is case-first. It is intentionally not a live registry
+   dump."
+3. Show the efficiency panel:
+   "The self-iteration case is not a vague productivity claim. It maps public
+   commits into product-requirement clusters and uses a conservative,
+   AI-assisted baseline range."
+4. Show the boundary panel:
+   "The product value includes knowing what must stay private: raw sessions,
+   internal sources, local paths, credentials, and benchmark traces are not
+   part of the public showcase."
+5. Show the navigation:
+   "The hosted frontstage is for public storytelling. Local ops mode exists for
+   private control-plane inspection, but it is not a public link."
+
+## What To Say
+
+- "Your agents keep the night shift. You keep the judgment."
+- "Goal Harness is not another model runtime. It is the state layer around
+  agent runtimes."
+- "The gated route waits clearly; independent safe work can continue with
+  evidence."
+- "The public demo is showcase-first. It uses public-safe cases rather than
+  live local status."
+
+## What Not To Show Publicly
+
+- local `statusUrl` links;
+- `mode=ops` URLs;
+- local registry or run-history paths;
+- raw benchmark logs, trajectories, task text, verifier output, or task ids;
+- internal documents, internal screenshots, private project names, or
+  credentials.
+
+## Operator Checklist
+
+Before sharing a link or screenshot:
+
+- Use the hosted frontstage URL above or a freshly exported share bundle.
+- Confirm the first screen says `showcase mode`.
+- Confirm visible case content comes from `docs/showcases/`.
+- Confirm no private project names, local paths, internal links, raw logs, or
+  live status feeds are visible.
+- Keep any ops-mode inspection local to a trusted operator session.

--- a/docs/showcases/README.md
+++ b/docs/showcases/README.md
@@ -50,6 +50,8 @@ That hosted route is intentionally case-first. It should help a new user or
 developer understand the showcased patterns before reading CLI output: public
 cases, efficiency evidence, and the public boundary come from this directory;
 live local `statusUrl` feeds belong only to explicit ops-mode inspection.
+For a short external walkthrough, use the
+[frontstage demo script](../outreach/frontstage-demo-script.md).
 
 ![Hosted Goal Harness frontstage showing public-safe showcase cases](../assets/frontstage-showcase-first-screen.png)
 


### PR DESCRIPTION
## Summary
- add a public-safe frontstage demo script for 30-second, 60-second, and two-minute walkthroughs
- link it from outreach and showcases docs
- spell out public demo boundaries: hosted showcase mode only, no ops/live status links in public sharing

## Validation
- git diff --check
- goal-harness check --scan-path docs/outreach/frontstage-demo-script.md --scan-path docs/outreach/README.md --scan-path docs/showcases/README.md
- python3 examples/docs-governance-smoke.py
- python3 examples/showcase-catalog-smoke.py
- sensitive/private-term scan over changed docs