### PR TITLE
docs: guard showcase animation sources

### DIFF
--- a/docs/outreach/showcase-animation-skill-spike.md
+++ b/docs/outreach/showcase-animation-skill-spike.md
@@ -49,6 +49,15 @@ Success means:
 - the implementation adds a boundary smoke or scripted scan proving the public
   video path does not consume local live status.
 
+## Validation
+
+Run `python3 examples/showcase-animation-source-boundary-smoke.py` before
+publishing any animation artifact. The smoke keeps the input contract narrow:
+`docs/showcases/showcase-catalog.json` plus public assets are allowed; live
+registry state, local status exports, user-specific active state, private
+chats, internal project names, and raw benchmark traces are not animation
+sources.
+
 ## Decision Boundary
 
 Do not install animation tooling into the core package or dashboard dependency

--- a/examples/showcase-animation-source-boundary-smoke.py
+++ b/examples/showcase-animation-source-boundary-smoke.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Guard the public showcase animation path against private/live sources."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SPIKE_DOC = REPO_ROOT / "docs" / "outreach" / "showcase-animation-skill-spike.md"
+SHOWCASE_INDEX = REPO_ROOT / "docs" / "showcases" / "README.md"
+CATALOG = REPO_ROOT / "docs" / "showcases" / "showcase-catalog.json"
+
+REQUIRED_SPIKE_PHRASES = (
+    "20-30 second animated demo",
+    "docs/showcases/showcase-catalog.json",
+    "must not read live registry state",
+    "local status exports",
+    "private chats",
+    "raw benchmark traces",
+    "internal project names",
+    "Remotion Agent Skills",
+    "HyperFrames",
+    "Motion for React",
+    "Run `python3 examples/showcase-animation-source-boundary-smoke.py`",
+)
+
+FORBIDDEN_SOURCE_PROMOTIONS = (
+    "status.frontstage-share.json",
+    "status.local.json",
+    "registry.global.json",
+    ".goal-harness/registry.json",
+    ".codex/goals/",
+    "ACTIVE_GOAL_STATE.md",
+)
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def assert_required_content() -> None:
+    spike = read(SPIKE_DOC)
+    for phrase in REQUIRED_SPIKE_PHRASES:
+        assert phrase in spike, f"{SPIKE_DOC}: missing {phrase!r}"
+
+    showcase_index = read(SHOWCASE_INDEX)
+    assert "showcase-animation-skill-spike.md" in showcase_index, SHOWCASE_INDEX
+    assert "showcase-catalog.json` as the only case data source" in showcase_index, SHOWCASE_INDEX
+
+
+def assert_no_live_source_promotion() -> None:
+    spike = read(SPIKE_DOC)
+    for marker in FORBIDDEN_SOURCE_PROMOTIONS:
+        assert marker not in spike, f"{SPIKE_DOC}: live/private source marker {marker!r}"
+
+
+def assert_catalog_is_frontstage_ready() -> None:
+    catalog = json.loads(read(CATALOG))
+    assert catalog.get("schema_version") == "goal_harness_showcase_catalog_v0", catalog
+    cases = catalog.get("cases")
+    assert isinstance(cases, list) and len(cases) >= 4, catalog
+    for case in cases:
+        assert case.get("id"), case
+        assert case.get("headline"), case
+        assert case.get("evidence_boundary"), case
+        frontend = case.get("frontend_card")
+        assert isinstance(frontend, dict), case
+        beats = frontend.get("story_beats")
+        assert isinstance(beats, list) and len(beats) >= 3, case
+
+
+def main() -> int:
+    assert_required_content()
+    assert_no_live_source_promotion()
+    assert_catalog_is_frontstage_ready()
+    print("showcase-animation-source-boundary-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a public showcase animation source-boundary smoke
- document the validation command before publishing animation artifacts
- keep animation inputs constrained to docs/showcases/showcase-catalog.json plus public assets

## Validation
- python3 examples/showcase-animation-source-boundary-smoke.py
- python3 examples/showcase-catalog-smoke.py
- python3 examples/docs-governance-smoke.py
- python3 -m py_compile examples/showcase-animation-source-boundary-smoke.py
- git diff --check
- goal-harness check --scan-path docs/outreach/showcase-animation-skill-spike.md
- goal-harness check --scan-path examples/showcase-animation-source-boundary-smoke.py

## Boundary
Only public docs and a smoke were changed. Sensitive scan found only intentional denylist strings inside the smoke itself; no live registry/status export, private project names, local status files, credentials, or benchmark traces are used as showcase inputs.