### PR TITLE
Add Harbor agent tools bundle helper

### DIFF
--- a/docs/benchmark-developer-workflow.md
+++ b/docs/benchmark-developer-workflow.md
@@ -178,6 +178,36 @@ python3 scripts/benchmark_ecs_bootstrap.py \
   --pretty
 ```
 
+For Harbor-based SWE or Terminal-style runners, avoid downloading nvm, npm
+packages, or Codex inside every task container. Materialize a host-side
+preinstalled tools bundle and mount it read-only at Harbor's conventional
+agent-tools path:
+
+```bash
+python3 scripts/harbor_agent_tools_bundle.py \
+  --output ~/goal-harness-bench/harbor-agent-tools \
+  --pretty
+```
+
+Then add the mount to the Harbor job config or CLI launch:
+
+```yaml
+environment:
+  type: docker
+  mounts:
+    - type: bind
+      source: ~/goal-harness-bench/harbor-agent-tools
+      target: /opt/harbor-agent-tools
+      read_only: true
+```
+
+Prefer Harbor's preinstalled Codex agent variant when available, for example
+`codex-api-key-no-search`, because it prefixes `/opt/harbor-agent-tools/bin`
+during both setup and execution. A plain `codex` agent may pass setup if it
+finds the bundle, but still fail execution if the runner shell resets PATH.
+If the task container cannot reach the model endpoint after this, classify that
+as agent egress/proxy readiness, not as nvm/npm dependency materialization.
+
 The probe checks command presence, Docker server reachability, disk budget, and
 the standard workspace shape. It intentionally emits only command names,
 version first lines, booleans, counts, and the workspace basename.

--- a/examples/harbor-agent-tools-bundle-smoke.py
+++ b/examples/harbor-agent-tools-bundle-smoke.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Smoke-test Harbor preinstalled agent-tools bundle materialization."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[1]
+SCRIPT = REPO / "scripts" / "harbor_agent_tools_bundle.py"
+
+
+def _fake_executable(path: Path, output: str) -> None:
+    path.write_text(f"#!/usr/bin/env sh\necho {output!r}\n", encoding="utf-8")
+    path.chmod(0o755)
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory(prefix="gh-harbor-agent-tools-") as tmp:
+        root = Path(tmp)
+        src = root / "src"
+        out = root / "bundle"
+        src.mkdir()
+        codex = src / "codex-native"
+        rg = src / "rg"
+        curl = src / "curl"
+        _fake_executable(codex, "codex-cli 0.test")
+        _fake_executable(rg, "ripgrep 0.test")
+        _fake_executable(curl, "curl 0.test")
+
+        completed = subprocess.run(
+            [
+                "python3",
+                str(SCRIPT),
+                "--output",
+                str(out),
+                "--codex-native-bin",
+                str(codex),
+                "--rg-bin",
+                str(rg),
+                "--curl-bin",
+                str(curl),
+            ],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        payload = json.loads(completed.stdout)
+
+        assert payload["ready"] is True, payload
+        assert payload["first_blocker"] == "", payload
+        assert payload["output"]["mount_target"] == "/opt/harbor-agent-tools", payload
+        assert payload["output"]["path_recorded"] is False, payload
+        assert payload["boundary"]["raw_task_text_read"] is False, payload
+        assert payload["boundary"]["credential_values_read"] is False, payload
+        assert set(payload["files"]) == {"codex", "codex-real", "curl", "rg"}, payload
+        assert all(item["ok"] for item in payload["verification"]), payload
+
+        wrapper = (out / "bin" / "codex").read_text(encoding="utf-8")
+        assert "CODEX_OPENAI_PROXY" in wrapper, wrapper
+        assert "127.0.0.1" not in wrapper, wrapper
+
+    print("harbor-agent-tools-bundle smoke passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/harbor_agent_tools_bundle.py
+++ b/scripts/harbor_agent_tools_bundle.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Build a public-safe Harbor preinstalled agent-tools bundle.
+
+The bundle is intended to be mounted read-only into Harbor task containers at
+``/opt/harbor-agent-tools``. Harbor's preinstalled Codex agent variants then
+find ``codex`` and ``rg`` on PATH without downloading nvm, npm packages, or
+Codex inside each benchmark container.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_OUTPUT = "~/goal-harness-bench/harbor-agent-tools"
+CODEX_VENDOR_CANDIDATES = (
+    "/usr/local/lib/node_modules/@openai/codex/node_modules/"
+    "@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/bin/codex",
+)
+RG_VENDOR_CANDIDATES = (
+    "/usr/local/lib/node_modules/@openai/codex/node_modules/"
+    "@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/codex-path/rg",
+    "/usr/local/lib/node_modules/@openai/codex/node_modules/"
+    "@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/path/rg",
+)
+
+
+def _first_existing(paths: list[str] | tuple[str, ...]) -> Path | None:
+    for path in paths:
+        candidate = Path(path).expanduser()
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _which(command: str) -> Path | None:
+    resolved = shutil.which(command)
+    return Path(resolved) if resolved else None
+
+
+def _discover_codex_native(explicit: str | None) -> Path | None:
+    if explicit:
+        return Path(explicit).expanduser()
+    return _first_existing(CODEX_VENDOR_CANDIDATES)
+
+
+def _discover_rg(explicit: str | None) -> Path | None:
+    if explicit:
+        return Path(explicit).expanduser()
+    return _which("rg") or _first_existing(RG_VENDOR_CANDIDATES)
+
+
+def _copy_executable(source: Path, target: Path) -> None:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, target)
+    target.chmod(target.stat().st_mode | 0o111)
+
+
+def _write_codex_wrapper(path: Path) -> None:
+    path.write_text(
+        """#!/usr/bin/env sh
+set -eu
+DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+if [ -n "${CODEX_OPENAI_PROXY:-}" ] \\
+  && [ -z "${HTTPS_PROXY:-}${https_proxy:-}${ALL_PROXY:-}${all_proxy:-}" ]; then
+  export HTTP_PROXY="${CODEX_OPENAI_PROXY}"
+  export HTTPS_PROXY="${CODEX_OPENAI_PROXY}"
+  export ALL_PROXY="${CODEX_OPENAI_PROXY}"
+  export http_proxy="${CODEX_OPENAI_PROXY}"
+  export https_proxy="${CODEX_OPENAI_PROXY}"
+  export all_proxy="${CODEX_OPENAI_PROXY}"
+fi
+exec "$DIR/codex-real" "$@"
+""",
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+
+
+def _probe_command(bin_dir: Path, command: str) -> dict[str, Any]:
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}:{env.get('PATH', '')}"
+    try:
+        completed = subprocess.run(
+            [command, "--version"],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=8,
+            env=env,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return {"command": command, "ok": False, "version_line": ""}
+    version_line = " ".join((completed.stdout or "").splitlines()[:1]).strip()
+    return {
+        "command": command,
+        "ok": completed.returncode == 0,
+        "version_line": version_line[:160],
+    }
+
+
+def build_bundle(
+    *,
+    output: Path,
+    codex_native: Path | None,
+    rg: Path | None,
+    curl: Path | None,
+    verify: bool,
+) -> dict[str, Any]:
+    output = output.expanduser()
+    bin_dir = output / "bin"
+    missing: list[str] = []
+    for name, path in (
+        ("codex_native", codex_native),
+        ("rg", rg),
+        ("curl", curl),
+    ):
+        if path is None or not path.is_file():
+            missing.append(name)
+
+    payload: dict[str, Any] = {
+        "schema_version": "harbor_agent_tools_bundle_v0",
+        "ready": False,
+        "first_blocker": f"missing_{missing[0]}" if missing else "",
+        "output": {
+            "basename": output.name,
+            "path_recorded": False,
+            "mount_target": "/opt/harbor-agent-tools",
+        },
+        "inputs": {
+            "codex_native_found": codex_native is not None and codex_native.is_file(),
+            "rg_found": rg is not None and rg.is_file(),
+            "curl_found": curl is not None and curl.is_file(),
+        },
+        "files": [],
+        "verification": [],
+        "boundary": {
+            "raw_logs_read": False,
+            "raw_task_text_read": False,
+            "trajectory_read": False,
+            "credential_values_read": False,
+            "private_paths_recorded": False,
+        },
+    }
+    if missing:
+        return payload
+
+    assert codex_native is not None
+    assert rg is not None
+    assert curl is not None
+    _copy_executable(codex_native, bin_dir / "codex-real")
+    _copy_executable(rg, bin_dir / "rg")
+    _copy_executable(curl, bin_dir / "curl")
+    _write_codex_wrapper(bin_dir / "codex")
+
+    payload["files"] = sorted(path.name for path in bin_dir.iterdir() if path.is_file())
+    if verify:
+        payload["verification"] = [
+            _probe_command(bin_dir, "codex"),
+            _probe_command(bin_dir, "rg"),
+            _probe_command(bin_dir, "curl"),
+        ]
+        failed = [
+            probe["command"]
+            for probe in payload["verification"]
+            if not probe.get("ok")
+        ]
+        if failed:
+            payload["first_blocker"] = f"verification_failed:{failed[0]}"
+            return payload
+
+    payload["ready"] = True
+    payload["first_blocker"] = ""
+    return payload
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Create a Harbor /opt/harbor-agent-tools bundle so benchmark "
+            "containers can use preinstalled Codex tools without per-case "
+            "nvm/npm downloads."
+        )
+    )
+    parser.add_argument("--output", default=DEFAULT_OUTPUT)
+    parser.add_argument("--codex-native-bin")
+    parser.add_argument("--rg-bin")
+    parser.add_argument("--curl-bin")
+    parser.add_argument("--no-verify", action="store_true")
+    parser.add_argument("--pretty", action="store_true")
+    args = parser.parse_args()
+
+    payload = build_bundle(
+        output=Path(args.output),
+        codex_native=_discover_codex_native(args.codex_native_bin),
+        rg=_discover_rg(args.rg_bin),
+        curl=Path(args.curl_bin).expanduser()
+        if args.curl_bin
+        else _which("curl"),
+        verify=not args.no_verify,
+    )
+    print(json.dumps(payload, ensure_ascii=False, indent=2 if args.pretty else None))
+    return 0 if payload.get("ready") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a public-safe Harbor `/opt/harbor-agent-tools` bundle builder for preinstalling Codex, ripgrep, and curl into benchmark containers
- document the Harbor preinstalled-tools workflow in the benchmark developer guide
- add a focused smoke covering bundle materialization, proxy wrapper behavior, and public/private boundary metadata

## Validation
- `python3 -m py_compile scripts/harbor_agent_tools_bundle.py examples/harbor-agent-tools-bundle-smoke.py`
- `python3 examples/harbor-agent-tools-bundle-smoke.py`
- `python3 examples/benchmark-developer-workflow-doc-smoke.py`
- `goal-harness check --scan-path scripts/harbor_agent_tools_bundle.py --scan-path examples/harbor-agent-tools-bundle-smoke.py --scan-path docs/benchmark-developer-workflow.md`
- `git diff --check`

## Boundary
- excludes raw benchmark logs, task text, trajectories, verifier output, credentials, private host paths, and remote run directories
- only records bundle basename and the public mount target `/opt/harbor-agent-tools`

## Residual Risk
- `goal-harness check` reports an existing duplicate history-index warning for `goal-harness-meta`; unrelated to this PR.
