### PR TITLE
Add SkillsBench agent runtime layer materializer

### DIFF
--- a/docs/benchmark-developer-workflow.md
+++ b/docs/benchmark-developer-workflow.md
@@ -248,6 +248,21 @@ run the `codex-acp` launch preflight before a real case. Until that preflight is
 green, classify SkillsBench as agent-runtime readiness blocked rather than
 spending more official attempts.
 
+Use the SkillsBench materializer with host-side cached sources:
+
+```bash
+python3 scripts/skillsbench_agent_runtime_layer.py \
+  --output ~/goal-harness-bench/benchflow-agent-runtime \
+  --node-root ~/goal-harness-bench/cache/node-v22.20.0-linux-x64 \
+  --codex-acp-bin ~/goal-harness-bench/cache/codex-acp \
+  --pretty
+```
+
+If the host has no cached `codex-acp` binary but may use network outside the
+case container, use `--use-default-codex-acp-package` once during host
+bootstrap. Record that as host dependency materialization, not as a benchmark
+case step.
+
 The probe checks command presence, Docker server reachability, disk budget, and
 the standard workspace shape. It intentionally emits only command names,
 version first lines, booleans, counts, and the workspace basename.

--- a/examples/benchmark-agent-runtime-layer-smoke.py
+++ b/examples/benchmark-agent-runtime-layer-smoke.py
@@ -84,7 +84,11 @@ def main() -> None:
         skillsbench = profiles["skillsbench"]
         assert (
             skillsbench["host_materialization"]["materializer_status"]
-            == "planned"
+            == "implemented"
+        )
+        assert (
+            skillsbench["host_materialization"]["script"]
+            == "scripts/skillsbench_agent_runtime_layer.py"
         )
         assert "codex-acp" in skillsbench["container_contract"]["required_commands"]
         assert "/opt/benchflow" in skillsbench["container_contract"]["environment"][

--- a/examples/benchmark-developer-workflow-doc-smoke.py
+++ b/examples/benchmark-developer-workflow-doc-smoke.py
@@ -51,6 +51,7 @@ def main() -> int:
             "preinstalled as a stable layer",
             "harbor_codex_cli_tools",
             "benchflow_js_agent_runtime",
+            "scripts/skillsbench_agent_runtime_layer.py",
             "scripts/terminal_bench_no_upload_smoke.py",
             "scripts/terminal_bench_compose_startup_reducer.py",
             "scripts/skillsbench_verifier_prewarm_plan.py",

--- a/examples/benchmark-ecs-developer-tooling-smoke.py
+++ b/examples/benchmark-ecs-developer-tooling-smoke.py
@@ -82,6 +82,46 @@ def main() -> int:
             == "benchflow_js_agent_runtime"
         )
 
+        node_root = tmp_path / "node-v22.test-linux-x64"
+        (node_root / "bin").mkdir(parents=True)
+        for name, output in (
+            ("node", "v22.20.0"),
+            ("npm", "10.9.0"),
+        ):
+            executable = node_root / "bin" / name
+            executable.write_text(
+                f"#!/usr/bin/env sh\necho {output!r}\n",
+                encoding="utf-8",
+            )
+            executable.chmod(0o755)
+        codex_acp = tmp_path / "codex-acp"
+        codex_acp.write_text(
+            "#!/usr/bin/env sh\necho 'codex-acp 0.test'\n",
+            encoding="utf-8",
+        )
+        codex_acp.chmod(0o755)
+        skillsbench_agent_layer = run_json(
+            [
+                "scripts/skillsbench_agent_runtime_layer.py",
+                "--output",
+                str(tmp_path / "benchflow-agent-runtime"),
+                "--node-root",
+                str(node_root),
+                "--codex-acp-bin",
+                str(codex_acp),
+            ]
+        )
+        assert (
+            skillsbench_agent_layer["schema_version"]
+            == "skillsbench_agent_runtime_layer_v0"
+        )
+        assert skillsbench_agent_layer["ready"] is True
+        assert (
+            skillsbench_agent_layer["output"]["mount_target"]
+            == "/opt/benchflow"
+        )
+        assert skillsbench_agent_layer["boundary"]["raw_logs_read"] is False
+
         launch = run_json(
             [
                 "scripts/terminal_bench_no_upload_smoke.py",

--- a/examples/skillsbench-agent-runtime-layer-smoke.py
+++ b/examples/skillsbench-agent-runtime-layer-smoke.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Smoke-test SkillsBench BenchFlow agent runtime layer materialization."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[1]
+SCRIPT = REPO / "scripts" / "skillsbench_agent_runtime_layer.py"
+
+
+def _fake_executable(path: Path, output: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"#!/usr/bin/env sh\necho {output!r}\n", encoding="utf-8")
+    path.chmod(0o755)
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory(prefix="gh-skillsbench-runtime-") as tmp:
+        root = Path(tmp)
+        node_root = root / "node-v22.test-linux-x64"
+        _fake_executable(node_root / "bin" / "node", "v22.20.0")
+        _fake_executable(node_root / "bin" / "npm", "10.9.0")
+        codex_acp = root / "src" / "codex-acp"
+        _fake_executable(codex_acp, "codex-acp 0.test")
+
+        output = root / "benchflow-agent-runtime"
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--output",
+                str(output),
+                "--node-root",
+                str(node_root),
+                "--codex-acp-bin",
+                str(codex_acp),
+                "--pretty",
+            ],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        payload = json.loads(completed.stdout)
+
+        assert payload["schema_version"] == "skillsbench_agent_runtime_layer_v0"
+        assert payload["ready"] is True, payload
+        assert payload["first_blocker"] == "", payload
+        assert payload["output"]["mount_target"] == "/opt/benchflow", payload
+        assert payload["output"]["path_recorded"] is False, payload
+        assert payload["required_tools"] == ["node", "npm", "codex-acp"], payload
+        assert set(payload["files"]) == {"codex-acp", "node", "npm"}, payload
+        assert all(item["ok"] for item in payload["verification"]), payload
+        assert payload["install"]["npm_install_attempted"] is False, payload
+        assert payload["boundary"]["raw_logs_read"] is False, payload
+        assert payload["boundary"]["credential_values_read"] is False, payload
+        node_wrapper = (output / "bin" / "node").read_text(encoding="utf-8")
+        assert str(root) not in node_wrapper, node_wrapper
+        assert "/opt/benchflow/node/bin/node" in node_wrapper, node_wrapper
+
+        missing = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--output",
+                str(root / "missing"),
+                "--codex-acp-bin",
+                str(codex_acp),
+            ],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        assert missing.returncode == 1, missing.stdout
+        missing_payload = json.loads(missing.stdout)
+        assert (
+            missing_payload["first_blocker"] == "missing_node_runtime_source"
+        ), missing_payload
+
+    print("skillsbench-agent-runtime-layer smoke passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark_agent_runtime_layer.py
+++ b/scripts/benchmark_agent_runtime_layer.py
@@ -146,11 +146,13 @@ def _benchflow_profile(
         "layer_id": "benchflow_js_agent_runtime",
         "layer_target": BENCHFLOW_TARGET,
         "host_materialization": {
-            "materializer_status": "planned",
+            "materializer_status": "implemented",
             "script": "scripts/skillsbench_agent_runtime_layer.py",
             "command": (
-                "materialize Node.js and codex-acp into "
-                "<workspace>/benchflow-agent-runtime before case launch"
+                "python3 scripts/skillsbench_agent_runtime_layer.py "
+                "--output <workspace>/benchflow-agent-runtime "
+                "--node-root <cached-node-root> "
+                "--codex-acp-bin <cached-codex-acp-bin> --pretty"
             ),
             "source": source,
             "source_basename": benchflow_tools_dir.expanduser().name,

--- a/scripts/skillsbench_agent_runtime_layer.py
+++ b/scripts/skillsbench_agent_runtime_layer.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""Materialize a SkillsBench BenchFlow agent runtime layer.
+
+SkillsBench cases should not download Node.js or install the ACP agent inside
+every task container.  This helper builds a host-side runtime directory that can
+be mounted read-only at ``/opt/benchflow`` before a case starts.
+
+The helper is intentionally offline by default.  Feed it cached sources from
+the host, a local artifact cache, or an operator-provided archive.  Network
+fetching belongs outside the case container and should be recorded separately as
+host bootstrap evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import tarfile
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = "skillsbench_agent_runtime_layer_v0"
+DEFAULT_OUTPUT = "~/goal-harness-bench/benchflow-agent-runtime"
+MOUNT_TARGET = "/opt/benchflow"
+DEFAULT_CODEX_ACP_PACKAGE = "@agentclientprotocol/codex-acp"
+DEFAULT_CODEX_ACP_VERSION = "0.0.45"
+
+
+def _copytree(source: Path, target: Path) -> None:
+    if target.exists():
+        shutil.rmtree(target)
+    shutil.copytree(source, target, symlinks=True)
+
+
+def _safe_extract_tarball(tarball: Path, target: Path) -> Path:
+    if target.exists():
+        shutil.rmtree(target)
+    target.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(tarball) as archive:
+        members = archive.getmembers()
+        for member in members:
+            destination = (target / member.name).resolve()
+            if not str(destination).startswith(str(target.resolve())):
+                raise ValueError(f"unsafe tar member: {member.name}")
+        archive.extractall(target, members=members)
+    dirs = [path for path in target.iterdir() if path.is_dir()]
+    if len(dirs) == 1 and (dirs[0] / "bin" / "node").exists():
+        return dirs[0]
+    return target
+
+
+def _write_layer_wrapper(path: Path, relative_executable: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "#!/usr/bin/env sh\n"
+        "set -eu\n"
+        "DIR=$(CDPATH= cd -- \"$(dirname -- \"$0\")/..\" && pwd)\n"
+        f"if [ -x \"$DIR/{relative_executable}\" ]; then\n"
+        f"  exec \"$DIR/{relative_executable}\" \"$@\"\n"
+        "fi\n"
+        f"exec \"{MOUNT_TARGET}/{relative_executable}\" \"$@\"\n",
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+
+
+def _copy_executable(source: Path, target: Path) -> None:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, target)
+    target.chmod(target.stat().st_mode | 0o111)
+
+
+def _probe(bin_dir: Path, command: str, *args: str) -> dict[str, Any]:
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}:{env.get('PATH', '')}"
+    try:
+        completed = subprocess.run(
+            [command, *args],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=20,
+            env=env,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return {"command": command, "ok": False, "version_line": ""}
+    version_line = " ".join((completed.stdout or "").splitlines()[:1]).strip()
+    return {
+        "command": command,
+        "ok": completed.returncode == 0,
+        "version_line": version_line[:160],
+    }
+
+
+def _install_codex_acp_package(
+    *,
+    npm_bin: Path,
+    package: str,
+    target_prefix: Path,
+) -> dict[str, Any]:
+    target_prefix.mkdir(parents=True, exist_ok=True)
+    completed = subprocess.run(
+        [
+            str(npm_bin),
+            "install",
+            "--prefix",
+            str(target_prefix),
+            "--no-audit",
+            "--no-fund",
+            package,
+        ],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        timeout=300,
+    )
+    return {
+        "ok": completed.returncode == 0,
+        "returncode": completed.returncode,
+        "output_first_line": " ".join((completed.stdout or "").splitlines()[:1])[:160],
+    }
+
+
+def build_layer(
+    *,
+    output: Path,
+    node_root: Path | None,
+    node_tarball: Path | None,
+    codex_acp_bin: Path | None,
+    codex_acp_package: Path | str | None,
+    verify: bool,
+) -> dict[str, Any]:
+    output = output.expanduser()
+    bin_dir = output / "bin"
+    node_target = output / "node"
+    js_agents_target = output / "js-agents"
+
+    payload: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "ready": False,
+        "first_blocker": "",
+        "output": {
+            "basename": output.name,
+            "path_recorded": False,
+            "mount_target": MOUNT_TARGET,
+        },
+        "inputs": {
+            "node_root_found": node_root is not None and node_root.exists(),
+            "node_tarball_found": node_tarball is not None and node_tarball.is_file(),
+            "codex_acp_bin_found": (
+                codex_acp_bin is not None and codex_acp_bin.is_file()
+            ),
+            "codex_acp_package": str(codex_acp_package)
+            if codex_acp_package
+            else "",
+        },
+        "required_tools": ["node", "npm", "codex-acp"],
+        "files": [],
+        "verification": [],
+        "install": {
+            "npm_install_attempted": False,
+            "npm_install_ok": None,
+            "npm_install_output_first_line": "",
+        },
+        "boundary": {
+            "raw_logs_read": False,
+            "raw_task_text_read": False,
+            "trajectory_read": False,
+            "credential_values_read": False,
+            "private_paths_recorded": False,
+        },
+    }
+
+    if node_root and node_root.exists():
+        _copytree(node_root.expanduser(), node_target)
+    elif node_tarball and node_tarball.is_file():
+        extracted = _safe_extract_tarball(node_tarball.expanduser(), output / ".node-extract")
+        _copytree(extracted, node_target)
+        shutil.rmtree(output / ".node-extract", ignore_errors=True)
+    else:
+        payload["first_blocker"] = "missing_node_runtime_source"
+        return payload
+
+    node_bin = node_target / "bin" / "node"
+    npm_bin = node_target / "bin" / "npm"
+    if not node_bin.exists():
+        payload["first_blocker"] = "missing_node_bin"
+        return payload
+    if not npm_bin.exists():
+        payload["first_blocker"] = "missing_npm_bin"
+        return payload
+
+    _write_layer_wrapper(bin_dir / "node", "node/bin/node")
+    _write_layer_wrapper(bin_dir / "npm", "node/bin/npm")
+
+    if codex_acp_bin and codex_acp_bin.is_file():
+        _copy_executable(codex_acp_bin.expanduser(), bin_dir / "codex-acp")
+    else:
+        package_spec = codex_acp_package
+        if package_spec is None:
+            payload["first_blocker"] = "missing_codex_acp_runtime_source"
+            return payload
+        if isinstance(package_spec, Path):
+            package_spec = str(package_spec.expanduser())
+        payload["install"]["npm_install_attempted"] = True
+        install = _install_codex_acp_package(
+            npm_bin=bin_dir / "npm",
+            package=str(package_spec),
+            target_prefix=js_agents_target,
+        )
+        payload["install"]["npm_install_ok"] = install["ok"]
+        payload["install"]["npm_install_output_first_line"] = install[
+            "output_first_line"
+        ]
+        if not install["ok"]:
+            payload["first_blocker"] = "codex_acp_package_install_failed"
+            return payload
+        acp_bin = js_agents_target / "node_modules" / ".bin" / "codex-acp"
+        if not acp_bin.exists():
+            payload["first_blocker"] = "missing_codex_acp_bin_after_install"
+            return payload
+        _write_layer_wrapper(
+            bin_dir / "codex-acp",
+            "js-agents/node_modules/.bin/codex-acp",
+        )
+
+    payload["files"] = sorted(path.name for path in bin_dir.iterdir() if path.is_file())
+    if verify:
+        payload["verification"] = [
+            _probe(bin_dir, "node", "--version"),
+            _probe(bin_dir, "npm", "--version"),
+            _probe(bin_dir, "codex-acp", "--version"),
+        ]
+        if not payload["verification"][-1]["ok"]:
+            payload["verification"][-1] = _probe(bin_dir, "codex-acp", "--help")
+        failed = [
+            probe["command"]
+            for probe in payload["verification"]
+            if not probe.get("ok")
+        ]
+        if failed:
+            payload["first_blocker"] = f"verification_failed:{failed[0]}"
+            return payload
+
+    payload["ready"] = True
+    payload["first_blocker"] = ""
+    return payload
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Create a BenchFlow /opt/benchflow agent runtime layer for "
+            "SkillsBench cases from cached host-side runtime sources."
+        )
+    )
+    parser.add_argument("--output", default=DEFAULT_OUTPUT)
+    parser.add_argument("--node-root")
+    parser.add_argument("--node-tarball")
+    parser.add_argument("--codex-acp-bin")
+    parser.add_argument("--codex-acp-package")
+    parser.add_argument(
+        "--use-default-codex-acp-package",
+        action="store_true",
+        help=(
+            "Install @agentclientprotocol/codex-acp from the host npm registry "
+            "once into the layer. This may use network on the host, never "
+            "inside the case container."
+        ),
+    )
+    parser.add_argument("--no-verify", action="store_true")
+    parser.add_argument("--pretty", action="store_true")
+    args = parser.parse_args()
+
+    codex_acp_package: Path | str | None = None
+    if args.codex_acp_package:
+        codex_acp_package = Path(args.codex_acp_package)
+    elif args.use_default_codex_acp_package:
+        codex_acp_package = (
+            f"{DEFAULT_CODEX_ACP_PACKAGE}@{DEFAULT_CODEX_ACP_VERSION}"
+        )
+
+    payload = build_layer(
+        output=Path(args.output),
+        node_root=Path(args.node_root).expanduser() if args.node_root else None,
+        node_tarball=Path(args.node_tarball).expanduser()
+        if args.node_tarball
+        else None,
+        codex_acp_bin=Path(args.codex_acp_bin).expanduser()
+        if args.codex_acp_bin
+        else None,
+        codex_acp_package=codex_acp_package,
+        verify=not args.no_verify,
+    )
+    print(json.dumps(payload, ensure_ascii=False, indent=2 if args.pretty else None))
+    return 0 if payload.get("ready") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add scripts/skillsbench_agent_runtime_layer.py to materialize a BenchFlow /opt/benchflow agent runtime layer from cached host-side Node and codex-acp sources
- update benchmark_agent_runtime_layer.py so the SkillsBench profile points to the implemented materializer
- document the SkillsBench host-side runtime layer workflow and add focused smoke coverage

## Validation
- python3 -m py_compile scripts/skillsbench_agent_runtime_layer.py scripts/benchmark_agent_runtime_layer.py examples/skillsbench-agent-runtime-layer-smoke.py examples/benchmark-agent-runtime-layer-smoke.py examples/benchmark-ecs-developer-tooling-smoke.py examples/benchmark-developer-workflow-doc-smoke.py
- python3 examples/skillsbench-agent-runtime-layer-smoke.py
- python3 examples/benchmark-agent-runtime-layer-smoke.py
- python3 examples/benchmark-ecs-developer-tooling-smoke.py
- python3 examples/benchmark-developer-workflow-doc-smoke.py
- goal-harness check --scan-path scripts/skillsbench_agent_runtime_layer.py --scan-path scripts/benchmark_agent_runtime_layer.py --scan-path examples/skillsbench-agent-runtime-layer-smoke.py --scan-path examples/benchmark-agent-runtime-layer-smoke.py --scan-path examples/benchmark-ecs-developer-tooling-smoke.py --scan-path examples/benchmark-developer-workflow-doc-smoke.py --scan-path docs/benchmark-developer-workflow.md

## Boundary
- no raw benchmark logs, raw task text, trajectories, verifier output, credentials, local active state, or private run directories
- materializer is offline by default and emits public-safe compact blockers when runtime sources are absent

## Residual risk
- The next step is to wire this layer into the remote SkillsBench case launcher and rerun the tictoc base/treatment pair after container-local preflight passes.