### PR TITLE
Add frontstage showcase spotlight

### DIFF
--- a/apps/dashboard/smoke/frontstage-route-smoke.ts
+++ b/apps/dashboard/smoke/frontstage-route-smoke.ts
@@ -90,10 +90,13 @@ includes(frontstageSource, "No public showcase matched the current filters.", "s
 includes(frontstageSource, "frontstageShowcases", "catalog-driven showcase cases");
 includes(frontstageSource, 'data-testid="frontstage-showcase-motion"', "showcase motion panel");
 includes(frontstageSource, 'data-testid="frontstage-showcase-journey-rail"', "showcase journey rail");
+includes(frontstageSource, 'data-testid="frontstage-showcase-spotlight"', "showcase spotlight panel");
+includes(frontstageSource, 'data-testid="frontstage-showcase-motion-card"', "showcase motion card control");
 includes(frontstageSource, "Showcase Motion", "showcase motion copy");
 includes(frontstageSource, "Case-driven motion board", "case-driven motion board copy");
 includes(frontstageSource, "Asynchronous agent rhythm", "showcase asynchronous rhythm copy");
 includes(frontstageSource, "Always-on agent teams can keep safe work moving", "showcase always-on agent copy");
+includes(frontstageSource, "Evidence boundary:", "showcase spotlight evidence boundary copy");
 includes(frontstageSource, "docs/showcases/showcase-catalog.json", "showcase catalog source copy");
 includes(frontstageSource, "Open case page", "case page outbound link");
 includes(frontstageSource, "github.com/huangruiteng/goal-harness/blob/main", "public GitHub case page links");
@@ -111,8 +114,11 @@ includes(catalogSource, '"2026-06-20-creator-operator-case-spec"', "creator oper
 const motionSource = sourceBetween(frontstageSource, "function ShowcaseMotionBoard", "function ShowcaseCasePackPanel", "showcase motion board");
 includes(motionSource, "frontstageShowcases", "motion board catalog source");
 includes(motionSource, "journeySegments", "motion board journey summary");
+includes(motionSource, "activeCaseId", "motion board active case state");
+includes(motionSource, "setActiveCaseId", "motion board case selection");
 includes(motionSource, "visual_metaphor", "motion board visual metaphor field");
 includes(motionSource, "story_beats", "motion board story beats field");
+includes(motionSource, "evidence_boundary", "motion board evidence boundary field");
 includes(motionSource, "Always-on agent teams", "motion board always-on copy");
 excludes(motionSource, "projection", "motion board live projection dependency");
 excludes(motionSource, "payload", "motion board live payload dependency");

--- a/apps/dashboard/src/views/frontstage-page.tsx
+++ b/apps/dashboard/src/views/frontstage-page.tsx
@@ -365,10 +365,17 @@ const showcaseMotionTones = [
 ];
 
 function ShowcaseMotionBoard() {
+  const [activeCaseId, setActiveCaseId] = useState(frontstageShowcases[0]?.id ?? "");
   if (!frontstageShowcases.length) {
     return null;
   }
 
+  const activeCase = frontstageShowcases.find((item) => item.id === activeCaseId) ?? frontstageShowcases[0];
+  if (!activeCase) {
+    return null;
+  }
+  const activeStoryBeats = activeCase.frontend_card?.story_beats?.slice(0, 5) ?? [];
+  const activeFeaturePoints = activeCase.feature_points?.slice(0, 3) ?? [];
   const journeySegments = [
     {
       label: "human judgment",
@@ -443,14 +450,65 @@ function ShowcaseMotionBoard() {
             ))}
           </div>
         </div>
+        <div
+          className="grid gap-4 rounded-md border border-slate-200 bg-white p-4 lg:grid-cols-[minmax(0,1fr)_minmax(260px,360px)]"
+          data-testid="frontstage-showcase-spotlight"
+        >
+          <div className="min-w-0">
+            <div className="flex flex-wrap gap-2">
+              <Badge variant="info">{activeCase.status ?? "case"}</Badge>
+              {activeCase.domain ? <Badge variant="neutral">{activeCase.domain}</Badge> : null}
+              <Badge variant="success">public-safe</Badge>
+            </div>
+            <h3 className="mt-3 text-lg font-semibold leading-7 text-slate-950">{activeCase.title}</h3>
+            <p className="mt-2 text-sm leading-6 text-slate-600">{activeCase.headline}</p>
+            {activeCase.evidence_boundary ? (
+              <div className="mt-3 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-xs font-medium leading-5 text-slate-600">
+                <span className="font-semibold text-slate-950">Evidence boundary: </span>
+                {activeCase.evidence_boundary}
+              </div>
+            ) : null}
+          </div>
+          <div className="grid gap-3">
+            <div>
+              <div className="text-[11px] font-semibold uppercase tracking-normal text-slate-500">story beats</div>
+              <ol className="mt-2 space-y-2 text-xs font-medium leading-5 text-slate-700">
+                {activeStoryBeats.map((beat, index) => (
+                  <li className="flex gap-2 rounded-md border border-slate-200 bg-slate-50 px-2 py-1.5" key={beat}>
+                    <span className="font-mono text-slate-400">{String(index + 1).padStart(2, "0")}</span>
+                    <span>{beat}</span>
+                  </li>
+                ))}
+              </ol>
+            </div>
+            {activeFeaturePoints.length ? (
+              <div>
+                <div className="text-[11px] font-semibold uppercase tracking-normal text-slate-500">requirement signals</div>
+                <div className="mt-2 flex flex-wrap gap-1.5">
+                  {activeFeaturePoints.map((point) => (
+                    <Badge key={point} variant="neutral">{point}</Badge>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+          </div>
+        </div>
         <div className="grid gap-3 xl:grid-cols-4">
           {frontstageShowcases.map((item, index) => {
             const tone = showcaseMotionTones[index % showcaseMotionTones.length];
             const beats = item.frontend_card?.story_beats?.slice(0, 4) ?? [];
             return (
-              <article
-                className={cn("rounded-md border p-3 shadow-sm transition duration-300 hover:-translate-y-0.5", tone.card)}
+              <button
+                aria-pressed={activeCase.id === item.id}
+                className={cn(
+                  "rounded-md border p-3 text-left shadow-sm transition duration-300 hover:-translate-y-0.5 focus:outline-none focus:ring-2 focus:ring-slate-500",
+                  tone.card,
+                  activeCase.id === item.id ? "ring-2 ring-slate-900" : "",
+                )}
+                data-testid="frontstage-showcase-motion-card"
                 key={item.id}
+                onClick={() => setActiveCaseId(item.id)}
+                type="button"
               >
                 <div className="flex items-start gap-3">
                   <div className={cn("relative mt-1 flex h-9 w-9 shrink-0 items-center justify-center rounded-full border text-xs font-semibold text-white", tone.dot)}>
@@ -478,7 +536,7 @@ function ShowcaseMotionBoard() {
                     ))}
                   </ol>
                 ) : null}
-              </article>
+              </button>
             );
           })}
         </div>

--- a/examples/dashboard-frontstage-browser-smoke.mjs
+++ b/examples/dashboard-frontstage-browser-smoke.mjs
@@ -358,6 +358,24 @@ async function main() {
         "Ops live only",
         "None in browser",
       ]);
+      const spotlight = desktopPage.locator('[data-testid="frontstage-showcase-spotlight"]');
+      const initialSpotlightText = await spotlight.innerText();
+      if (!initialSpotlightText.includes("Blocked P0 with safe P1/P2 rotation")) {
+        throw new Error("Showcase spotlight did not default to the first public case");
+      }
+      await desktopPage
+        .locator('[data-testid="frontstage-showcase-motion-card"]')
+        .filter({ hasText: "Creator-operator long-running agent case" })
+        .click();
+      await desktopPage.waitForFunction(() =>
+        document
+          .querySelector('[data-testid="frontstage-showcase-spotlight"]')
+          ?.textContent?.includes("Creator-operator long-running agent case"),
+      );
+      const creatorSpotlightText = await spotlight.innerText();
+      if (!creatorSpotlightText.includes("Synthetic case spec only")) {
+        throw new Error("Showcase spotlight did not expose the selected case evidence boundary");
+      }
       await desktopPage.locator('[data-testid="frontstage-showcase-search"]').fill("self-iteration");
       await desktopPage.waitForFunction(() => document.body.innerText.includes("Showing 1 of 4 public-safe cases"));
       const filteredCaseText = await desktopPage.locator('[data-testid="frontstage-showcase-cases"]').innerText();


### PR DESCRIPTION
## Summary
- add an interactive public case spotlight to the frontstage showcase motion board
- let users select a showcase card and inspect story beats, requirement signals, and evidence boundary
- extend route and browser smokes to keep spotlight content catalog-driven and independent from live projection payloads

## Validation
- npm run smoke:frontstage-route
- npm run build
- npm run smoke:frontstage-browser
- npm run smoke:frontstage-share-bundle
- git diff --check
- goal-harness check --scan-path apps/dashboard/src/views/frontstage-page.tsx --scan-path apps/dashboard/smoke/frontstage-route-smoke.ts --scan-path examples/dashboard-frontstage-browser-smoke.mjs
