### PR TITLE
Animate frontstage state flow rail

### DIFF
--- a/apps/dashboard/smoke/frontstage-route-smoke.ts
+++ b/apps/dashboard/smoke/frontstage-route-smoke.ts
@@ -24,6 +24,7 @@ function sourceBetween(source: string, start: string, end: string, label: string
 
 const routerSource = readFileSync("src/router.tsx", "utf8");
 const frontstageSource = readFileSync("src/views/frontstage-page.tsx", "utf8");
+const stylesSource = readFileSync("src/styles.css", "utf8");
 const dataSource = readFileSync("src/data/goal-channel-frontstage.ts", "utf8");
 const statusSource = readFileSync("src/data/status.ts", "utf8");
 const catalogSource = readFileSync("../../docs/showcases/showcase-catalog.json", "utf8");
@@ -130,9 +131,15 @@ excludes(motionSource, "payload", "motion board live payload dependency");
 const stateFlowHeroSource = sourceBetween(frontstageSource, "function ShowcaseStateFlowHero", "function PublicShowcaseBoundaryPanel", "showcase state-flow hero");
 includes(stateFlowHeroSource, "showcaseStateFlow", "state-flow hero source");
 includes(stateFlowHeroSource, "animate-ping", "state-flow hero pulse");
-includes(stateFlowHeroSource, "animate-pulse", "state-flow hero rail pulse");
+includes(stateFlowHeroSource, 'data-testid="frontstage-state-flow-track"', "state-flow animated track");
+includes(stateFlowHeroSource, 'data-testid="frontstage-state-flow-beam"', "state-flow animated beam");
+includes(stateFlowHeroSource, 'aria-hidden="true"', "state-flow decorative motion hidden from assistive tech");
 excludes(stateFlowHeroSource, "projection", "state-flow hero live projection dependency");
 excludes(stateFlowHeroSource, "payload", "state-flow hero live payload dependency");
+includes(stylesSource, ".frontstage-state-flow-track", "state-flow track CSS");
+includes(stylesSource, ".frontstage-state-flow-beam", "state-flow beam CSS");
+includes(stylesSource, "@keyframes frontstage-flow-scan", "state-flow scan keyframes");
+includes(stylesSource, "@media (prefers-reduced-motion: reduce)", "state-flow reduced-motion fallback");
 
 const casePackSource = sourceBetween(frontstageSource, "function ShowcaseCasePackPanel", "function PublicShowcaseBoundaryPanel", "showcase case pack");
 includes(casePackSource, "showcaseSearchText", "case pack catalog search index");

--- a/apps/dashboard/src/styles.css
+++ b/apps/dashboard/src/styles.css
@@ -23,3 +23,62 @@ button,
 select {
   font: inherit;
 }
+
+.frontstage-state-flow-track {
+  position: relative;
+  height: 0.25rem;
+  overflow: hidden;
+  border-radius: 9999px;
+  background: rgb(255 255 255 / 0.1);
+}
+
+.frontstage-state-flow-track::before {
+  position: absolute;
+  inset: 0;
+  content: "";
+  background: linear-gradient(
+    90deg,
+    rgb(103 232 249 / 0.12),
+    rgb(52 211 153 / 0.34),
+    rgb(251 146 60 / 0.2),
+    rgb(103 232 249 / 0.12)
+  );
+  opacity: 0.72;
+}
+
+.frontstage-state-flow-beam {
+  position: absolute;
+  inset-block: 0;
+  left: -36%;
+  width: 36%;
+  border-radius: inherit;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgb(103 232 249 / 0.15),
+    rgb(103 232 249),
+    rgb(52 211 153),
+    transparent
+  );
+  box-shadow: 0 0 18px rgb(103 232 249 / 0.45);
+  animation: frontstage-flow-scan 2.8s cubic-bezier(0.55, 0, 0.2, 1) infinite;
+}
+
+@keyframes frontstage-flow-scan {
+  from {
+    transform: translateX(0);
+  }
+
+  to {
+    transform: translateX(380%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .frontstage-state-flow-beam {
+    animation: none;
+    left: 0;
+    width: 100%;
+    opacity: 0.55;
+  }
+}

--- a/apps/dashboard/src/views/frontstage-page.tsx
+++ b/apps/dashboard/src/views/frontstage-page.tsx
@@ -722,8 +722,12 @@ function ShowcaseStateFlowHero() {
             );
           })}
         </div>
-        <div className="mt-3 h-1 overflow-hidden rounded-full bg-white/10">
-          <div className="h-full w-1/3 animate-pulse rounded-full bg-cyan-300" />
+        <div
+          aria-hidden="true"
+          className="frontstage-state-flow-track mt-3"
+          data-testid="frontstage-state-flow-track"
+        >
+          <span className="frontstage-state-flow-beam" data-testid="frontstage-state-flow-beam" />
         </div>
       </div>
     </div>

--- a/examples/dashboard-frontstage-browser-smoke.mjs
+++ b/examples/dashboard-frontstage-browser-smoke.mjs
@@ -361,6 +361,11 @@ async function main() {
         "Ops live only",
         "None in browser",
       ]);
+      const stateFlowTrackCount = await desktopPage.locator('[data-testid="frontstage-state-flow-track"]').count();
+      const stateFlowBeamBox = await desktopPage.locator('[data-testid="frontstage-state-flow-beam"]').boundingBox();
+      if (stateFlowTrackCount !== 1 || !stateFlowBeamBox || stateFlowBeamBox.width < 20) {
+        throw new Error("Showcase state-flow animation rail did not render");
+      }
       const spotlight = desktopPage.locator('[data-testid="frontstage-showcase-spotlight"]');
       const initialSpotlightText = await spotlight.innerText();
       if (!initialSpotlightText.includes("Blocked P0 with safe P1/P2 rotation")) {


### PR DESCRIPTION
## Summary
- replace the static pulse bar in the showcase state-flow hero with a flowing CSS rail
- add reduced-motion fallback for the decorative motion
- extend route/browser smokes to cover the motion rail structure

## Validation
- npm run smoke:frontstage-route
- npm run smoke:frontstage-share-bundle
- npm run build
- npm run smoke:frontstage-browser
- git diff --check
- goal-harness check --scan-path apps/dashboard/src/views/frontstage-page.tsx --scan-path apps/dashboard/src/styles.css --scan-path apps/dashboard/smoke/frontstage-route-smoke.ts --scan-path examples/dashboard-frontstage-browser-smoke.mjs

## Boundary
Public showcase/frontstage files only. No live local status, private registry state, internal project data, credentials, raw logs, or benchmark evidence.