### PR TITLE
Animate frontstage showcase motion rail

### DIFF
--- a/apps/dashboard/smoke/frontstage-route-smoke.ts
+++ b/apps/dashboard/smoke/frontstage-route-smoke.ts
@@ -125,8 +125,13 @@ includes(motionSource, "visual_metaphor", "motion board visual metaphor field");
 includes(motionSource, "story_beats", "motion board story beats field");
 includes(motionSource, "evidence_boundary", "motion board evidence boundary field");
 includes(motionSource, "Always-on agent teams", "motion board always-on copy");
+includes(motionSource, 'data-testid="frontstage-showcase-motion-beam"', "motion board animated beam");
+includes(motionSource, 'aria-hidden="true"', "motion board decorative motion hidden from assistive tech");
 excludes(motionSource, "projection", "motion board live projection dependency");
 excludes(motionSource, "payload", "motion board live payload dependency");
+includes(stylesSource, ".frontstage-showcase-motion-rail", "motion board rail CSS");
+includes(stylesSource, ".frontstage-showcase-motion-beam", "motion board beam CSS");
+includes(stylesSource, "@keyframes frontstage-case-traffic", "motion board case traffic keyframes");
 
 const stateFlowHeroSource = sourceBetween(frontstageSource, "function ShowcaseStateFlowHero", "function PublicShowcaseBoundaryPanel", "showcase state-flow hero");
 includes(stateFlowHeroSource, "showcaseStateFlow", "state-flow hero source");

--- a/apps/dashboard/src/styles.css
+++ b/apps/dashboard/src/styles.css
@@ -74,6 +74,55 @@ select {
   }
 }
 
+.frontstage-showcase-motion-rail {
+  isolation: isolate;
+}
+
+.frontstage-showcase-motion-rail::before {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  content: "";
+  background:
+    linear-gradient(120deg, rgb(255 255 255 / 0.06), transparent 36%),
+    radial-gradient(circle at 18% 24%, rgb(103 232 249 / 0.14), transparent 28%),
+    radial-gradient(circle at 76% 18%, rgb(52 211 153 / 0.12), transparent 30%);
+}
+
+.frontstage-showcase-motion-beam {
+  position: absolute;
+  z-index: 0;
+  top: 0.75rem;
+  left: -22%;
+  width: 22%;
+  height: 0.125rem;
+  border-radius: 9999px;
+  background: linear-gradient(90deg, transparent, rgb(103 232 249), rgb(52 211 153), transparent);
+  box-shadow:
+    0 0 16px rgb(103 232 249 / 0.5),
+    0 0 24px rgb(52 211 153 / 0.24);
+  animation: frontstage-case-traffic 3.6s cubic-bezier(0.45, 0, 0.2, 1) infinite;
+}
+
+@keyframes frontstage-case-traffic {
+  from {
+    transform: translateX(0);
+  }
+
+  to {
+    transform: translateX(560%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .frontstage-showcase-motion-beam {
+    animation: none;
+    left: 1rem;
+    width: calc(100% - 2rem);
+    opacity: 0.35;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .frontstage-state-flow-beam {
     animation: none;

--- a/apps/dashboard/src/views/frontstage-page.tsx
+++ b/apps/dashboard/src/views/frontstage-page.tsx
@@ -415,10 +415,15 @@ function ShowcaseMotionBoard() {
           </div>
         </div>
         <div
-          className="overflow-hidden rounded-md border border-slate-800 bg-slate-950 p-3 text-white shadow-sm"
+          className="frontstage-showcase-motion-rail relative overflow-hidden rounded-md border border-slate-800 bg-slate-950 p-3 text-white shadow-sm"
           data-testid="frontstage-showcase-journey-rail"
         >
-          <div className="flex flex-wrap items-start justify-between gap-3">
+          <span
+            aria-hidden="true"
+            className="frontstage-showcase-motion-beam"
+            data-testid="frontstage-showcase-motion-beam"
+          />
+          <div className="relative z-10 flex flex-wrap items-start justify-between gap-3">
             <div>
               <div className="text-[11px] font-semibold uppercase tracking-normal text-slate-300">
                 Asynchronous agent rhythm
@@ -429,7 +434,7 @@ function ShowcaseMotionBoard() {
             </div>
             <Badge variant="neutral">case-first</Badge>
           </div>
-          <div className="mt-4 grid gap-2 lg:grid-cols-4">
+          <div className="relative z-10 mt-4 grid gap-2 lg:grid-cols-4">
             {journeySegments.map((segment, index) => (
               <div className="relative rounded-md border border-white/10 bg-white/5 px-3 py-3" key={segment.label}>
                 {index < journeySegments.length - 1 ? (

--- a/examples/dashboard-frontstage-browser-smoke.mjs
+++ b/examples/dashboard-frontstage-browser-smoke.mjs
@@ -366,6 +366,12 @@ async function main() {
       if (stateFlowTrackCount !== 1 || !stateFlowBeamBox || stateFlowBeamBox.width < 20) {
         throw new Error("Showcase state-flow animation rail did not render");
       }
+      const showcaseMotionBeamBox = await desktopPage
+        .locator('[data-testid="frontstage-showcase-motion-beam"]')
+        .boundingBox();
+      if (!showcaseMotionBeamBox || showcaseMotionBeamBox.width < 20) {
+        throw new Error("Showcase motion traffic beam did not render");
+      }
       const spotlight = desktopPage.locator('[data-testid="frontstage-showcase-spotlight"]');
       const initialSpotlightText = await spotlight.innerText();
       if (!initialSpotlightText.includes("Blocked P0 with safe P1/P2 rotation")) {


### PR DESCRIPTION
## Summary
- add a subtle traffic beam to the showcase motion rail so the case board feels like moving agent lanes
- keep the motion decorative and hidden from assistive tech, with reduced-motion fallback
- extend route/browser smokes to cover the motion rail without hardcoding new product copy

## Validation
- npm run smoke:frontstage-route
- npm run smoke:frontstage-share-bundle
- npm run build
- npm run smoke:frontstage-browser
- git diff --check
- goal-harness check --scan-path apps/dashboard/src/views/frontstage-page.tsx --scan-path apps/dashboard/src/styles.css --scan-path apps/dashboard/smoke/frontstage-route-smoke.ts --scan-path examples/dashboard-frontstage-browser-smoke.mjs

## Boundary
Public frontstage/showcase files only. The showcase route remains catalog-first and does not read live local/global status for public case content.