### PR TITLE
Link frontstage spotlight to public cases

### DIFF
--- a/apps/dashboard/smoke/frontstage-route-smoke.ts
+++ b/apps/dashboard/smoke/frontstage-route-smoke.ts
@@ -76,6 +76,7 @@ includes(frontstageSource, "evidence loop", "evidence loop signal");
 includes(frontstageSource, 'data-testid="frontstage-efficiency-evidence"', "efficiency evidence panel");
 includes(frontstageSource, "Efficiency Evidence", "efficiency evidence copy");
 includes(frontstageSource, "showcaseCatalog", "showcase catalog import");
+includes(frontstageSource, "showcaseCaseHref", "central showcase case page link helper");
 includes(frontstageSource, "estimated_developer_days", "efficiency baseline range");
 includes(frontstageSource, "single_engineer_calendar_compression", "efficiency compression range");
 includes(frontstageSource, "maturity-adjusted", "maturity adjusted copy");
@@ -102,6 +103,8 @@ includes(frontstageSource, "Case-driven motion board", "case-driven motion board
 includes(frontstageSource, "Asynchronous agent rhythm", "showcase asynchronous rhythm copy");
 includes(frontstageSource, "Always-on agent teams can keep safe work moving", "showcase always-on agent copy");
 includes(frontstageSource, "Evidence boundary:", "showcase spotlight evidence boundary copy");
+includes(frontstageSource, 'data-testid="frontstage-showcase-spotlight-case-page"', "showcase spotlight case page link");
+includes(frontstageSource, "Open selected case page", "showcase spotlight case page copy");
 includes(frontstageSource, "docs/showcases/showcase-catalog.json", "showcase catalog source copy");
 includes(frontstageSource, "Open case page", "case page outbound link");
 includes(frontstageSource, "github.com/huangruiteng/goal-harness/blob/main", "public GitHub case page links");

--- a/apps/dashboard/src/views/frontstage-page.tsx
+++ b/apps/dashboard/src/views/frontstage-page.tsx
@@ -4,6 +4,7 @@ import {
   Bot,
   CircleAlert,
   Clock3,
+  ExternalLink,
   GitBranch,
   LayoutDashboard,
   ListChecks,
@@ -167,6 +168,13 @@ function showcaseSearchText(item: ShowcaseFrontstageCase) {
     .filter(Boolean)
     .join(" ")
     .toLowerCase();
+}
+
+function showcaseCaseHref(casePage?: string) {
+  if (!casePage) {
+    return undefined;
+  }
+  return `https://github.com/huangruiteng/goal-harness/blob/main/${casePage}`;
 }
 
 function uniqueClaimOwners(projection: GoalChannelProjection) {
@@ -376,6 +384,7 @@ function ShowcaseMotionBoard() {
   }
   const activeStoryBeats = activeCase.frontend_card?.story_beats?.slice(0, 5) ?? [];
   const activeFeaturePoints = activeCase.feature_points?.slice(0, 3) ?? [];
+  const activeCaseHref = showcaseCaseHref(activeCase.case_page);
   const journeySegments = [
     {
       label: "human judgment",
@@ -472,6 +481,18 @@ function ShowcaseMotionBoard() {
                 <span className="font-semibold text-slate-950">Evidence boundary: </span>
                 {activeCase.evidence_boundary}
               </div>
+            ) : null}
+            {activeCaseHref ? (
+              <a
+                className="mt-3 inline-flex items-center gap-1.5 rounded-md border border-slate-200 bg-slate-950 px-3 py-2 text-xs font-semibold text-white shadow-sm transition hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-slate-500"
+                data-testid="frontstage-showcase-spotlight-case-page"
+                href={activeCaseHref}
+                rel="noreferrer"
+                target="_blank"
+              >
+                <ExternalLink className="h-3.5 w-3.5" />
+                Open selected case page
+              </a>
             ) : null}
           </div>
           <div className="grid gap-3">
@@ -615,6 +636,7 @@ function ShowcaseCasePackPanel() {
         <div className="grid gap-3 lg:grid-cols-2">
           {filteredCases.map((item) => {
             const badges = item.frontend_card?.badges?.slice(0, 4) ?? item.pattern_tags?.slice(0, 4) ?? [];
+            const caseHref = showcaseCaseHref(item.case_page);
             return (
               <article className="rounded-md border border-slate-200 bg-slate-50 p-3" key={item.id}>
                 <div className="flex flex-wrap items-center gap-2">
@@ -633,10 +655,10 @@ function ShowcaseCasePackPanel() {
                     {item.frontend_card.primary_metric_hint}
                   </div>
                 ) : null}
-                {item.case_page ? (
+                {caseHref ? (
                   <a
                     className="mt-3 inline-flex text-xs font-semibold text-slate-950 underline underline-offset-4"
-                    href={`https://github.com/huangruiteng/goal-harness/blob/main/${item.case_page}`}
+                    href={caseHref}
                     rel="noreferrer"
                     target="_blank"
                   >

--- a/examples/dashboard-frontstage-browser-smoke.mjs
+++ b/examples/dashboard-frontstage-browser-smoke.mjs
@@ -390,6 +390,12 @@ async function main() {
       if (!creatorSpotlightText.includes("Synthetic case spec only")) {
         throw new Error("Showcase spotlight did not expose the selected case evidence boundary");
       }
+      const spotlightCaseHref = await desktopPage
+        .locator('[data-testid="frontstage-showcase-spotlight-case-page"]')
+        .getAttribute("href");
+      if (!spotlightCaseHref?.includes("github.com/huangruiteng/goal-harness/blob/main/docs/showcases/")) {
+        throw new Error(`Showcase spotlight case link points outside public showcases: ${spotlightCaseHref}`);
+      }
       await desktopPage.locator('[data-testid="frontstage-showcase-search"]').fill("self-iteration");
       await desktopPage.waitForFunction(() => document.body.innerText.includes("Showing 1 of 4 public-safe cases"));
       const filteredCaseText = await desktopPage.locator('[data-testid="frontstage-showcase-cases"]').innerText();


### PR DESCRIPTION
## Summary
- add a public case-page link to the selected Showcase Motion spotlight
- centralize GitHub case-page URL construction for spotlight and case cards
- extend source/browser smokes to verify the spotlight link stays inside docs/showcases

## Validation
- npm run smoke:frontstage-route
- npm run smoke:frontstage-share-bundle
- npm run build
- npm run smoke:frontstage-browser
- git diff --check
- goal-harness check --scan-path apps/dashboard/src/views/frontstage-page.tsx --scan-path apps/dashboard/smoke/frontstage-route-smoke.ts --scan-path examples/dashboard-frontstage-browser-smoke.mjs

## Boundary
Public frontstage/showcase files only. Links target public GitHub docs/showcases pages; no live local/global status or private registry state is used for showcase content.