### PR TITLE
Document side-agent delivery outcome writeback

### DIFF
--- a/docs/project-agent-todo-contract.md
+++ b/docs/project-agent-todo-contract.md
@@ -250,6 +250,24 @@ goal-harness todo complete \
 `--side-agent-self-merged` requires `--evidence`. Do not use it for runtime,
 benchmark, permission, production, destructive git, publication, public
 evidence-policy, or broad coordination changes that need primary review.
+After a validated self-merge, write back the real delivery outcome at the
+project level when the slice advanced the public product or case path. An
+agent-lane refresh with `--agent-id` is useful for side-lane notes, but it does
+not replace the goal-level latest run used by quota and dashboard routing. Do
+not append a follow-up goal-level `surface_only` sync after a validated
+`outcome_progress` slice; either skip the duplicate sync or mirror the product
+progress with:
+
+```bash
+goal-harness refresh-state \
+  --goal-id <goal-id> \
+  --classification <public-safe-progress-classification> \
+  --delivery-batch-scale multi_surface \
+  --delivery-outcome outcome_progress
+```
+
+This keeps validated side-agent product work from being misread as another
+surface-only heartbeat turn.
 When a self-merged side-agent slice has an obvious same-scope continuation, it
 may also atomically add that successor todo and claim it back to the same side
 agent:

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -890,6 +890,13 @@ note as `agent_lane_recommendation` on the attention item and project asset.
 Use this for side agents that want to record their own lane recommendation
 without replacing the primary controller's next action.
 
+If a side-agent self-merged slice materially advanced the public product or
+case path, the controller or side agent should also write a project-level
+refresh with the matching `delivery_outcome=outcome_progress` (or skip the
+extra project-level sync entirely). A later `surface_only` project-level sync
+will become the latest non-agent-lane run, so quota may correctly ask for
+follow-through even though the side-lane note recorded real progress.
+
 For registered `connected`, `connected-read-only`, and `pre-tick-runnable`
 adapters, custom compact progress classifications that are not blocker, gate,
 or watch classifications also remain Codex-ready. This lets a controller record

--- a/examples/docs-governance-smoke.py
+++ b/examples/docs-governance-smoke.py
@@ -50,8 +50,17 @@ def read(path: str) -> str:
     return (REPO_ROOT / path).read_text(encoding="utf-8")
 
 
+def compact(text: str) -> str:
+    return " ".join(text.split())
+
+
 def main() -> int:
     docs_index = read("docs/README.md")
+    project_agent_contract = read("docs/project-agent-todo-contract.md")
+    status_contract = read("docs/status-data-contract.md")
+    compact_project_agent_contract = compact(project_agent_contract)
+    compact_status_contract = compact(status_contract)
+
     for required in [
         "## Start Here",
         "## Stable Reference",
@@ -107,6 +116,18 @@ def main() -> int:
             or basename in combined_public_indexes
             or new_path.startswith("docs/archive/")
         ), new_path
+
+    for required in [
+        "Do not append a follow-up goal-level `surface_only` sync",
+        "--delivery-outcome outcome_progress",
+    ]:
+        assert required in compact_project_agent_contract, required
+
+    for required in [
+        "A later `surface_only` project-level sync will become the latest non-agent-lane run",
+        "agent_lane_recommendation",
+    ]:
+        assert required in compact_status_contract, required
 
     print("docs-governance-smoke ok")
     return 0


### PR DESCRIPTION
## Summary
- document that validated side-agent self-merge progress must not be shadowed by a later goal-level surface_only sync
- clarify status contract behavior for agent-lane vs project-level latest runs
- extend docs governance smoke to cover the writeback rule

## Validation
- python3 examples/docs-governance-smoke.py
- git diff --check
- goal-harness check --scan-path docs/project-agent-todo-contract.md --scan-path docs/status-data-contract.md --scan-path examples/docs-governance-smoke.py
- public/private diff scan for internal names, local paths, credentials, and tokens