### PR TITLE
Add showcase kinetic case strip

### DIFF
--- a/apps/dashboard/smoke/frontstage-route-smoke.ts
+++ b/apps/dashboard/smoke/frontstage-route-smoke.ts
@@ -98,8 +98,11 @@ includes(frontstageSource, 'data-testid="frontstage-showcase-motion"', "showcase
 includes(frontstageSource, 'data-testid="frontstage-showcase-journey-rail"', "showcase journey rail");
 includes(frontstageSource, 'data-testid="frontstage-showcase-spotlight"', "showcase spotlight panel");
 includes(frontstageSource, 'data-testid="frontstage-showcase-motion-card"', "showcase motion card control");
+includes(frontstageSource, 'data-testid="frontstage-showcase-kinetic-strip"', "showcase kinetic case strip");
+includes(frontstageSource, 'data-testid="frontstage-showcase-kinetic-card"', "showcase kinetic case card");
 includes(frontstageSource, "Showcase Motion", "showcase motion copy");
 includes(frontstageSource, "Case-driven motion board", "case-driven motion board copy");
+includes(frontstageSource, "Day-and-night agent lanes, governed by one human control plane.", "showcase kinetic strip copy");
 includes(frontstageSource, "Asynchronous agent rhythm", "showcase asynchronous rhythm copy");
 includes(frontstageSource, "Always-on agent teams can keep safe work moving", "showcase always-on agent copy");
 includes(frontstageSource, "Evidence boundary:", "showcase spotlight evidence boundary copy");
@@ -135,6 +138,20 @@ excludes(motionSource, "payload", "motion board live payload dependency");
 includes(stylesSource, ".frontstage-showcase-motion-rail", "motion board rail CSS");
 includes(stylesSource, ".frontstage-showcase-motion-beam", "motion board beam CSS");
 includes(stylesSource, "@keyframes frontstage-case-traffic", "motion board case traffic keyframes");
+
+const kineticStripSource = sourceBetween(frontstageSource, "function ShowcaseKineticCaseStrip", "function FrontstageRoute", "showcase kinetic strip");
+includes(kineticStripSource, "frontstageShowcases", "kinetic strip catalog source");
+includes(kineticStripSource, "showcaseCaseHref", "kinetic strip case links");
+includes(kineticStripSource, "uniqueShowcaseDomains", "kinetic strip domain count");
+includes(kineticStripSource, "stripCases", "kinetic strip duplicated marquee cases");
+includes(kineticStripSource, "Day-and-night agent lanes", "kinetic strip product copy");
+excludes(kineticStripSource, "projection", "kinetic strip live projection dependency");
+excludes(kineticStripSource, "payload", "kinetic strip live payload dependency");
+excludes(kineticStripSource, "statusUrl", "kinetic strip local status dependency");
+includes(stylesSource, ".frontstage-showcase-kinetic-viewport", "kinetic strip viewport CSS");
+includes(stylesSource, ".frontstage-showcase-kinetic-track", "kinetic strip track CSS");
+includes(stylesSource, ".frontstage-showcase-kinetic-card", "kinetic strip card CSS");
+includes(stylesSource, "@keyframes frontstage-kinetic-strip", "kinetic strip keyframes");
 
 const stateFlowHeroSource = sourceBetween(frontstageSource, "function ShowcaseStateFlowHero", "function PublicShowcaseBoundaryPanel", "showcase state-flow hero");
 includes(stateFlowHeroSource, "showcaseStateFlow", "state-flow hero source");

--- a/apps/dashboard/src/styles.css
+++ b/apps/dashboard/src/styles.css
@@ -104,6 +104,64 @@ select {
   animation: frontstage-case-traffic 3.6s cubic-bezier(0.45, 0, 0.2, 1) infinite;
 }
 
+.frontstage-showcase-kinetic-viewport {
+  position: relative;
+  min-width: 0;
+  min-height: 4.875rem;
+  overflow: hidden;
+  padding: 0.75rem;
+  background:
+    linear-gradient(90deg, rgb(248 250 252), transparent 14%),
+    linear-gradient(270deg, rgb(248 250 252), transparent 14%);
+}
+
+.frontstage-showcase-kinetic-track {
+  position: absolute;
+  inset-block-start: 0.75rem;
+  inset-inline-start: 0.75rem;
+  display: flex;
+  width: max-content;
+  gap: 0.625rem;
+  animation: frontstage-kinetic-strip 18s linear infinite;
+}
+
+.frontstage-showcase-kinetic-card {
+  display: grid;
+  grid-template-columns: auto minmax(0, 12rem);
+  align-items: center;
+  gap: 0.625rem;
+  min-width: 14.5rem;
+  border: 1px solid rgb(226 232 240);
+  border-radius: 0.375rem;
+  padding: 0.625rem 0.75rem;
+  color: inherit;
+  text-decoration: none;
+  background: rgb(255 255 255 / 0.92);
+  box-shadow: 0 1px 2px rgb(15 23 42 / 0.06);
+}
+
+.frontstage-showcase-kinetic-dot {
+  width: 0.625rem;
+  height: 0.625rem;
+  border-radius: 9999px;
+  background: linear-gradient(135deg, rgb(6 182 212), rgb(16 185 129));
+  box-shadow: 0 0 16px rgb(6 182 212 / 0.42);
+}
+
+.frontstage-showcase-kinetic-card:hover {
+  border-color: rgb(14 165 233);
+}
+
+@keyframes frontstage-kinetic-strip {
+  from {
+    transform: translateX(0);
+  }
+
+  to {
+    transform: translateX(-50%);
+  }
+}
+
 @keyframes frontstage-case-traffic {
   from {
     transform: translateX(0);
@@ -120,6 +178,17 @@ select {
     left: 1rem;
     width: calc(100% - 2rem);
     opacity: 0.35;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .frontstage-showcase-kinetic-viewport {
+    overflow-x: auto;
+  }
+
+  .frontstage-showcase-kinetic-track {
+    position: static;
+    animation: none;
   }
 }
 

--- a/apps/dashboard/src/views/frontstage-page.tsx
+++ b/apps/dashboard/src/views/frontstage-page.tsx
@@ -785,6 +785,59 @@ function PublicShowcaseBoundaryPanel() {
   );
 }
 
+function ShowcaseKineticCaseStrip() {
+  if (!frontstageShowcases.length) {
+    return null;
+  }
+
+  const stripCases = [...frontstageShowcases, ...frontstageShowcases];
+  const domains = uniqueShowcaseDomains();
+
+  return (
+    <div
+      className="mt-5 overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm"
+      data-testid="frontstage-showcase-kinetic-strip"
+    >
+      <div className="grid gap-3 border-b border-slate-200 bg-slate-950 px-4 py-3 text-white md:grid-cols-[minmax(0,1fr)_auto]">
+        <div>
+          <div className="text-[11px] font-semibold uppercase tracking-normal text-cyan-200">
+            Multi-agent work rhythm
+          </div>
+          <p className="mt-1 text-sm font-semibold leading-6 text-white">
+            Day-and-night agent lanes, governed by one human control plane.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge variant="neutral">{frontstageShowcases.length} public cases</Badge>
+          <Badge variant="neutral">{domains.length} domains</Badge>
+        </div>
+      </div>
+      <div className="frontstage-showcase-kinetic-viewport" data-testid="frontstage-showcase-kinetic-viewport">
+        <div className="frontstage-showcase-kinetic-track" data-testid="frontstage-showcase-kinetic-track">
+          {stripCases.map((item, index) => (
+            <a
+              className="frontstage-showcase-kinetic-card"
+              data-testid="frontstage-showcase-kinetic-card"
+              href={showcaseCaseHref(item.case_page) ?? "#"}
+              key={`${item.id}-${index}`}
+              rel="noreferrer"
+              target="_blank"
+            >
+              <span className="frontstage-showcase-kinetic-dot" aria-hidden="true" />
+              <span className="min-w-0">
+                <span className="block truncate text-xs font-semibold text-slate-950">{item.title}</span>
+                <span className="mt-0.5 block truncate text-[11px] font-medium text-slate-500">
+                  {item.domain ?? "showcase"} / {item.status ?? "case"}
+                </span>
+              </span>
+            </a>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function FrontstageRoute({
   goalOptions,
   hasIgnoredStatusUrl,
@@ -1031,6 +1084,7 @@ function FrontstageRoute({
               </div>
             </div>
             {!isOpsMode ? <ShowcaseStateFlowHero /> : null}
+            {!isOpsMode ? <ShowcaseKineticCaseStrip /> : null}
             <div className="mt-5 grid gap-2 border-t border-slate-200 pt-4 sm:grid-cols-2 xl:grid-cols-4" data-testid="frontstage-operations-strip">
               {operationSignals.map((signal) => (
                 <div className="rounded-md border border-slate-200 bg-slate-50 px-3 py-3" key={signal.label}>


### PR DESCRIPTION
## Summary
- add a catalog-driven kinetic case strip to the showcase-first frontstage hero
- keep the strip sourced only from docs/showcases/showcase-catalog.json via frontstageShowcases
- add route-smoke coverage for the new strip and its no-live-status dependency boundary

## Validation
- npm run smoke:frontstage-route
- npm run smoke:frontstage-browser
- npm run smoke:frontstage-share-bundle
- npm run build
- python3 examples/showcase-animation-source-boundary-smoke.py
- goal-harness check --scan-path apps/dashboard/src/views/frontstage-page.tsx --scan-path apps/dashboard/src/styles.css --scan-path apps/dashboard/smoke/frontstage-route-smoke.ts
- git diff --check
- sensitive-marker diff scan clean