### PR TITLE
Add public showcase animation storyboard artifact

### DIFF
--- a/docs/outreach/showcase-animation-skill-spike.md
+++ b/docs/outreach/showcase-animation-skill-spike.md
@@ -49,6 +49,23 @@ Success means:
 - the implementation adds a boundary smoke or scripted scan proving the public
   video path does not consume local live status.
 
+## Storyboard Artifact
+
+The first public-safe storyboard artifact is
+[`docs/showcases/showcase-animation-storyboard.json`](../showcases/showcase-animation-storyboard.json).
+It is not the final MP4; it is the compact contract a Remotion or HyperFrames
+experiment can render without reading live registry state.
+
+The storyboard keeps the video deliberately short:
+
+- one opening control-plane frame;
+- one beat for the 0617 user gate and safe side lane;
+- one beat for the sanitized 0619 multi-agent workflow;
+- one beat for the repo-scale self-iteration efficiency case;
+- one beat for the creator-operator synthetic case;
+- one closing frame that says the public demo reads the showcase catalog, not
+  private control-plane state.
+
 ## Validation
 
 Run `python3 examples/showcase-animation-source-boundary-smoke.py` before

--- a/docs/showcases/README.md
+++ b/docs/showcases/README.md
@@ -54,7 +54,9 @@ For a short external walkthrough, use the
 [frontstage demo script](../outreach/frontstage-demo-script.md).
 For animated outreach assets, start from the
 [showcase animation skill spike](../outreach/showcase-animation-skill-spike.md)
-and keep `showcase-catalog.json` as the only case data source.
+and the
+[public storyboard artifact](showcase-animation-storyboard.json). Keep
+`showcase-catalog.json` as the only case data source.
 
 ![Hosted Goal Harness frontstage showing public-safe showcase cases](../assets/frontstage-showcase-first-screen.png)
 

--- a/docs/showcases/showcase-animation-storyboard.json
+++ b/docs/showcases/showcase-animation-storyboard.json
@@ -1,0 +1,80 @@
+{
+  "schema_version": "goal_harness_showcase_animation_storyboard_v0",
+  "source_catalog": "docs/showcases/showcase-catalog.json",
+  "duration_seconds_target": {
+    "min": 20,
+    "max": 30
+  },
+  "public_boundary": {
+    "allowed_sources": [
+      "docs/showcases/showcase-catalog.json",
+      "docs/showcases/cases/*.md",
+      "docs/assets/control-plane-board.svg",
+      "docs/assets/frontstage-showcase-first-screen.png"
+    ],
+    "live_registry_state": false,
+    "local_status_exports": false,
+    "user_specific_active_state": false,
+    "private_docs_or_chats": false,
+    "raw_benchmark_traces": false,
+    "internal_project_names": false
+  },
+  "recommended_motion_stack": {
+    "video_primary": "remotion-agent-skills",
+    "video_fallback": "hyperframes",
+    "page_motion": "motion-for-react",
+    "micro_loops": "lottie"
+  },
+  "hero_line": "From AI assist to async agent work.",
+  "supporting_line": "A human sets gates and evidence; agent lanes keep safe work moving across turns.",
+  "scenes": [
+    {
+      "id": "opening-control-plane",
+      "time_seconds": [0, 4],
+      "source_case_ids": [],
+      "visual": "dark canvas with a single shared goal state node; agent lanes orbit into view",
+      "copy": "One shared control plane for long-running agent work.",
+      "motion_notes": "fade in the goal node, then pulse two safe lanes without implying live ops data"
+    },
+    {
+      "id": "gate-visible-safe-lane-moves",
+      "time_seconds": [4, 9],
+      "source_case_ids": ["2026-06-17-blocked-p0-safe-rotation"],
+      "visual": "a gated P0 lane pauses while a safe side lane advances with a validation marker",
+      "copy": "A user gate stays visible. Safe side work still moves.",
+      "motion_notes": "keep the blocked lane still; animate only the safe lane and evidence writeback"
+    },
+    {
+      "id": "multi-agent-shared-state",
+      "time_seconds": [9, 14],
+      "source_case_ids": ["2026-06-19-dynamic-workflow-hardware-agent"],
+      "visual": "primary and side-agent lanes claim separate todos against one catalog-backed board",
+      "copy": "Multiple agents can share one project memory without guessing each other's state.",
+      "motion_notes": "show claims and handoff lines as lightweight beams into shared state"
+    },
+    {
+      "id": "self-iteration-efficiency-evidence",
+      "time_seconds": [14, 21],
+      "source_case_ids": ["2026-06-19-goal-harness-self-iteration"],
+      "visual": "repo-scale requirement clusters compress into validated commits, docs, smokes, and frontstage surfaces",
+      "copy": "Async side work turns repo history into recoverable product momentum.",
+      "motion_notes": "avoid raw commit firehoses; use compact clusters and conservative evidence labels"
+    },
+    {
+      "id": "creator-operator-safe-production-loop",
+      "time_seconds": [21, 27],
+      "source_case_ids": ["2026-06-20-creator-operator-case-spec"],
+      "visual": "research, preference memory, and draft material move while publishing remains gated",
+      "copy": "The agent can keep researching while human judgment guards what ships.",
+      "motion_notes": "animate safe research cards; leave publish decision locked until the final frame"
+    },
+    {
+      "id": "boundary-close",
+      "time_seconds": [27, 30],
+      "source_case_ids": [],
+      "visual": "public showcase catalog badge replaces the live status feed",
+      "copy": "Public demos read the showcase catalog, not private control-plane state.",
+      "motion_notes": "close on the catalog badge and a clean public/private boundary line"
+    }
+  ]
+}

--- a/examples/showcase-animation-source-boundary-smoke.py
+++ b/examples/showcase-animation-source-boundary-smoke.py
@@ -11,6 +11,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 SPIKE_DOC = REPO_ROOT / "docs" / "outreach" / "showcase-animation-skill-spike.md"
 SHOWCASE_INDEX = REPO_ROOT / "docs" / "showcases" / "README.md"
 CATALOG = REPO_ROOT / "docs" / "showcases" / "showcase-catalog.json"
+STORYBOARD = REPO_ROOT / "docs" / "showcases" / "showcase-animation-storyboard.json"
 
 REQUIRED_SPIKE_PHRASES = (
     "20-30 second animated demo",
@@ -23,6 +24,7 @@ REQUIRED_SPIKE_PHRASES = (
     "Remotion Agent Skills",
     "HyperFrames",
     "Motion for React",
+    "showcase-animation-storyboard.json",
     "Run `python3 examples/showcase-animation-source-boundary-smoke.py`",
 )
 
@@ -47,13 +49,16 @@ def assert_required_content() -> None:
 
     showcase_index = read(SHOWCASE_INDEX)
     assert "showcase-animation-skill-spike.md" in showcase_index, SHOWCASE_INDEX
+    assert "showcase-animation-storyboard.json" in showcase_index, SHOWCASE_INDEX
     assert "showcase-catalog.json` as the only case data source" in showcase_index, SHOWCASE_INDEX
 
 
 def assert_no_live_source_promotion() -> None:
     spike = read(SPIKE_DOC)
+    storyboard = read(STORYBOARD)
     for marker in FORBIDDEN_SOURCE_PROMOTIONS:
         assert marker not in spike, f"{SPIKE_DOC}: live/private source marker {marker!r}"
+        assert marker not in storyboard, f"{STORYBOARD}: live/private source marker {marker!r}"
 
 
 def assert_catalog_is_frontstage_ready() -> None:
@@ -71,10 +76,48 @@ def assert_catalog_is_frontstage_ready() -> None:
         assert isinstance(beats, list) and len(beats) >= 3, case
 
 
+def assert_storyboard_uses_public_catalog() -> None:
+    catalog = json.loads(read(CATALOG))
+    catalog_ids = {case["id"] for case in catalog["cases"]}
+
+    storyboard = json.loads(read(STORYBOARD))
+    assert storyboard.get("schema_version") == "goal_harness_showcase_animation_storyboard_v0", storyboard
+    assert storyboard.get("source_catalog") == "docs/showcases/showcase-catalog.json", storyboard
+    assert storyboard.get("duration_seconds_target") == {"min": 20, "max": 30}, storyboard
+
+    boundary = storyboard.get("public_boundary")
+    assert isinstance(boundary, dict), storyboard
+    for key in (
+        "live_registry_state",
+        "local_status_exports",
+        "user_specific_active_state",
+        "private_docs_or_chats",
+        "raw_benchmark_traces",
+        "internal_project_names",
+    ):
+        assert boundary.get(key) is False, (key, boundary)
+
+    scenes = storyboard.get("scenes")
+    assert isinstance(scenes, list) and len(scenes) >= 5, storyboard
+    referenced_ids: set[str] = set()
+    for scene in scenes:
+        assert scene.get("id"), scene
+        assert scene.get("copy"), scene
+        assert scene.get("visual"), scene
+        source_case_ids = scene.get("source_case_ids")
+        assert isinstance(source_case_ids, list), scene
+        for case_id in source_case_ids:
+            assert case_id in catalog_ids, (case_id, scene)
+            referenced_ids.add(case_id)
+
+    assert referenced_ids == catalog_ids, (referenced_ids, catalog_ids)
+
+
 def main() -> int:
     assert_required_content()
     assert_no_live_source_promotion()
     assert_catalog_is_frontstage_ready()
+    assert_storyboard_uses_public_catalog()
     print("showcase-animation-source-boundary-smoke ok")
     return 0
 


### PR DESCRIPTION
## Summary
- add a public-safe storyboard JSON for the first 20-30s showcase animation path
- link the artifact from the animation spike and showcase catalog docs
- extend the boundary smoke so animation sources stay catalog-only and never read live/private state

## Validation
- python3 examples/showcase-animation-source-boundary-smoke.py
- python3 examples/showcase-catalog-smoke.py
- goal-harness check --scan-path docs/showcases --scan-path docs/outreach/showcase-animation-skill-spike.md --scan-path examples/showcase-animation-source-boundary-smoke.py
- git diff --check
- diff public/private marker scan clean