### PR TITLE
Fix status projection after neutral monitor polls

### DIFF
--- a/examples/status-neutral-run-window-smoke.py
+++ b/examples/status-neutral-run-window-smoke.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Regression for status/diagnose after consecutive status-neutral runs."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from goal_harness.diagnose import collect_diagnosis  # noqa: E402
+from goal_harness.quota import QUOTA_MONITOR_POLL_CLASSIFICATION, build_quota_should_run  # noqa: E402
+from goal_harness.status import collect_status  # noqa: E402
+
+
+GOAL_ID = "neutral-window-connected-delivery"
+REAL_CLASSIFICATION = "autonomous_replan_recorded_stable_monitor"
+REAL_ACTION = "continue the stable monitor lane without asking the user"
+AGENT_TODO = "[P1] Continue the stable monitor lane and write back compact evidence."
+
+
+def write_registry(root: Path) -> Path:
+    project = root / "project"
+    runtime = root / "runtime"
+    state_file = f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    registry_path = project / ".goal-harness" / "registry.json"
+
+    (project / Path(state_file).parent).mkdir(parents=True, exist_ok=True)
+    (project / state_file).write_text(
+        "---\n"
+        "status: active\n"
+        "updated_at: 2026-01-01T00:00:00+00:00\n"
+        "---\n\n"
+        "# Neutral Window Fixture\n\n"
+        "## Agent Todo\n\n"
+        f"- [ ] {AGENT_TODO}\n",
+        encoding="utf-8",
+    )
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "status-neutral-window-fixture",
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": state_file,
+                        "adapter": {
+                            "kind": "fixture_connected_delivery_v0",
+                            "status": "connected-delivery",
+                        },
+                        "quota": {
+                            "compute": 1.0,
+                            "window_hours": 24,
+                        },
+                        "coordination": {
+                            "write_scope": ["docs/**"],
+                        },
+                    }
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return registry_path
+
+
+def append_run(root: Path, *, generated_at: str, classification: str, action: str) -> None:
+    run_dir = root / "runtime" / "goals" / GOAL_ID / "runs"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    compact_time = generated_at.replace("-", "").replace(":", "")
+    json_path = run_dir / f"{compact_time}-{classification}.json"
+    markdown_path = run_dir / f"{compact_time}-{classification}.md"
+    record = {
+        "generated_at": generated_at,
+        "goal_id": GOAL_ID,
+        "classification": classification,
+        "recommended_action": action,
+        "health_check": "status-neutral-window fixture run",
+        "delivery_batch_scale": "single_surface",
+        "delivery_outcome": "outcome_progress",
+    }
+    json_path.write_text(json.dumps(record, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    markdown_path.write_text(f"# {classification}\n", encoding="utf-8")
+    with (run_dir / "index.jsonl").open("a", encoding="utf-8") as f:
+        f.write(
+            json.dumps(
+                {
+                    **record,
+                    "json_path": str(json_path),
+                    "markdown_path": str(markdown_path),
+                },
+                ensure_ascii=False,
+            )
+            + "\n"
+        )
+
+
+def write_runs(root: Path) -> None:
+    append_run(
+        root,
+        generated_at="2026-01-01T00:00:00+00:00",
+        classification=REAL_CLASSIFICATION,
+        action=REAL_ACTION,
+    )
+    for index in range(1, 7):
+        append_run(
+            root,
+            generated_at=f"2026-01-01T00:0{index}:00+00:00",
+            classification=QUOTA_MONITOR_POLL_CLASSIFICATION,
+            action="monitor poll only; no status transition",
+        )
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="goal-harness-status-neutral-window-") as tmp:
+        root = Path(tmp)
+        registry_path = write_registry(root)
+        write_runs(root)
+
+        status = collect_status(
+            registry_path=registry_path,
+            runtime_root_override=str(root / "runtime"),
+            scan_roots=[root / "project"],
+            limit=5,
+        )
+        item = status["attention_queue"]["items"][0]
+        assert item["goal_id"] == GOAL_ID, item
+        assert item["status"] == REAL_CLASSIFICATION, item
+        assert item["waiting_on"] == "codex", item
+        assert item["source"] == "latest_run", item
+        assert item["recommended_action"] == REAL_ACTION, item
+        assert "connect an adapter" not in item["recommended_action"], item
+
+        run_goal = status["run_history"]["goals"][0]
+        assert run_goal["latest_status_run"]["classification"] == REAL_CLASSIFICATION, run_goal
+        assert len(run_goal["latest_runs"]) == 5, run_goal
+        assert {
+            run["classification"]
+            for run in run_goal["latest_runs"]
+        } == {QUOTA_MONITOR_POLL_CLASSIFICATION}, run_goal
+
+        readiness = item["handoff_readiness"]
+        assert readiness["post_handoff_latest_run"]["classification"] == REAL_CLASSIFICATION, readiness
+
+        quota = build_quota_should_run(status, goal_id=GOAL_ID)
+        assert quota["state"] != "operator_gate", quota
+        assert quota["requires_user_action"] is False, quota
+        user_todo_summary = quota.get("user_todo_summary") if isinstance(quota.get("user_todo_summary"), dict) else {}
+        assert user_todo_summary.get("open_count", 0) == 0, quota
+        assert quota["status"] == REAL_CLASSIFICATION, quota
+        assert "connect an adapter" not in quota["recommended_action"], quota
+        assert (
+            quota["handoff_readiness"]["post_handoff_latest_run"]["classification"]
+            == REAL_CLASSIFICATION
+        ), quota
+
+        diagnosis = collect_diagnosis(
+            registry_path=registry_path,
+            runtime_root_override=str(root / "runtime"),
+            scan_roots=[root / "project"],
+            limit=5,
+            goal_id=GOAL_ID,
+        )
+        selected = diagnosis["selected"]
+        assert selected["status"] == REAL_CLASSIFICATION, selected
+        assert selected["waiting_on"] == "codex", selected
+        assert selected["machine_signal"] in {
+            "agent_work_attention",
+            "no_immediate_agent_delivery_signal",
+        }, selected
+        assert selected["todo_evidence"]["user_open_count"] == 0, selected
+
+    print("status-neutral-run-window-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/goal_harness/history.py
+++ b/goal_harness/history.py
@@ -10,14 +10,21 @@ from typing import Any, Callable
 from .authority import goal_authority_registry_summary
 from .control_plane import compact_control_plane_policy
 from .delivery_outcome import require_delivery_outcome
+from .doctor import PROMOTION_READINESS_CLASSIFICATIONS
 from .execution_profile import compact_execution_profile
 from .paths import resolve_runtime_root
-from .quota import goal_quota_with_spend_ledger
+from .quota import (
+    QUOTA_MONITOR_POLL_CLASSIFICATION,
+    QUOTA_SLOT_SPENT_CLASSIFICATION,
+    goal_quota_with_spend_ledger,
+)
 from .registry import read_json, registry_goals
 
 
 STATUS_NEUTRAL_CLASSIFICATIONS = {
-    "quota_slot_spent",
+    QUOTA_SLOT_SPENT_CLASSIFICATION,
+    QUOTA_MONITOR_POLL_CLASSIFICATION,
+    *PROMOTION_READINESS_CLASSIFICATIONS,
 }
 AGENT_LANE_PROGRESS_SCOPE = "agent_lane"
 REGISTRY_ATTENTION_FIELDS = (

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -30,13 +30,14 @@ from .execution_profile import (
 from .frontstage import build_goal_channel_projection
 from .handoff_budget import handoff_budget_contract
 from .history import collect_history, load_registry
+from .history import STATUS_NEUTRAL_CLASSIFICATIONS as HISTORY_STATUS_NEUTRAL_CLASSIFICATIONS
 from .interface_budget import interface_budget_cadence_for_runs
 from .materials import extract_review_materials
 from .operator_gate import DEFAULT_OPERATOR_GATE, default_operator_question, normalize_operator_question
 from .orchestration import compact_orchestration_policy, orchestration_policy_summary
 from .paths import global_registry_path, resolve_runtime_root
 from .promotion_gate import build_promotion_gate
-from .quota import QUOTA_MONITOR_POLL_CLASSIFICATION, quota_status, quota_with_handoff_outcome_floor
+from .quota import quota_status, quota_with_handoff_outcome_floor
 from .registry import registry_goals
 from .state_projection import active_state_next_action_entries, state_projection_gap_warning
 from .todo_contract import (
@@ -71,11 +72,7 @@ CODEX_READY_CLASSIFICATIONS = {
     "operator_gate_approved",
     "monitor_todo_repeat_dedupe_deployed",
 }
-STATUS_NEUTRAL_CLASSIFICATIONS = {
-    "quota_slot_spent",
-    QUOTA_MONITOR_POLL_CLASSIFICATION,
-    *PROMOTION_READINESS_CLASSIFICATIONS,
-}
+STATUS_NEUTRAL_CLASSIFICATIONS = HISTORY_STATUS_NEUTRAL_CLASSIFICATIONS
 STATUS_CONTROL_PLANE_CONTEXT_LIMIT = 20
 AGENT_LANE_PROGRESS_SCOPE = "agent_lane"
 HANDOFF_READY_CLASSIFICATIONS = {

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -76,6 +76,7 @@ STATUS_NEUTRAL_CLASSIFICATIONS = {
     QUOTA_MONITOR_POLL_CLASSIFICATION,
     *PROMOTION_READINESS_CLASSIFICATIONS,
 }
+STATUS_CONTROL_PLANE_CONTEXT_LIMIT = 20
 AGENT_LANE_PROGRESS_SCOPE = "agent_lane"
 HANDOFF_READY_CLASSIFICATIONS = {
     "operator_gate_approved",
@@ -6530,7 +6531,8 @@ def compact_run(run: dict[str, Any]) -> dict[str, Any]:
     return compact
 
 
-def build_run_history(history: dict[str, Any]) -> dict[str, Any]:
+def build_run_history(history: dict[str, Any], *, display_limit: int | None = None) -> dict[str, Any]:
+    display_limit = None if display_limit is None else max(0, display_limit)
     goals: list[dict[str, Any]] = []
     for goal in history.get("goals") or []:
         if not isinstance(goal, dict):
@@ -6538,6 +6540,13 @@ def build_run_history(history: dict[str, Any]) -> dict[str, Any]:
         current_run = latest_run(goal)
         lifecycle_fields = goal_lifecycle_fields(goal, current_run)
         subagent_activity = subagent_activity_for_goal(goal)
+        latest_runs = [
+            compact_run(run)
+            for run in goal.get("latest_runs") or []
+            if isinstance(run, dict)
+        ]
+        if display_limit is not None:
+            latest_runs = latest_runs[:display_limit]
         goals.append(
             {
                 "id": goal.get("id"),
@@ -6559,11 +6568,7 @@ def build_run_history(history: dict[str, Any]) -> dict[str, Any]:
                 "unique_runs": goal.get("unique_runs"),
                 "subagent_activity": subagent_activity,
                 "latest_status_run": compact_run(current_run) if current_run else None,
-                "latest_runs": [
-                    compact_run(run)
-                    for run in goal.get("latest_runs") or []
-                    if isinstance(run, dict)
-                ],
+                "latest_runs": latest_runs,
             }
         )
 
@@ -6572,6 +6577,8 @@ def build_run_history(history: dict[str, Any]) -> dict[str, Any]:
         for run in history.get("runs") or []
         if isinstance(run, dict)
     ]
+    if display_limit is not None:
+        recent_runs = recent_runs[:display_limit]
     return {
         "available": True,
         "goal_count": history.get("goal_count"),
@@ -7047,6 +7054,8 @@ def collect_status(
     scan_roots: list[Path],
     limit: int,
 ) -> dict[str, Any]:
+    display_limit = max(0, limit)
+    control_plane_limit = max(display_limit, STATUS_CONTROL_PLANE_CONTEXT_LIMIT)
     registry = load_registry(registry_path)
     runtime_root = resolve_runtime_root(registry, runtime_root_override)
     global_registry = collect_global_registry_health(
@@ -7059,7 +7068,7 @@ def collect_status(
         registry_path=registry_path,
         runtime_root=runtime_root,
         goal_id=None,
-        limit=limit,
+        limit=control_plane_limit,
         include_runtime_goals=include_runtime_goals,
     )
     contract = check_contract(
@@ -7069,7 +7078,7 @@ def collect_status(
         limit=limit,
     )
     queue = build_attention_queue(contract=contract, history=history, global_registry=global_registry)
-    run_history = build_run_history(history)
+    run_history = build_run_history(history, display_limit=display_limit)
     event_ledger_summary = build_event_ledger_summary(history)
     promotion_readiness_summary = build_promotion_readiness_summary(
         history,


### PR DESCRIPTION
## Summary
- make history.py treat quota monitor/spend and promotion-readiness events as status-neutral
- let collect_status use a wider internal control-plane history window while still trimming displayed run history to the requested --limit
- make status.py reuse the history.py status-neutral classification set so history/status cannot drift again
- add a regression where six recent quota_monitor_poll events precede the real connected-delivery status run; status/diagnose --limit 5 must still project the real state and avoid controller/user-gate fallback

## Validation
- python3 examples/status-neutral-run-window-smoke.py
- python3 examples/agent-diagnose-packet-smoke.py
- python3 examples/status-markdown-smoke.py
- python3 -m goal_harness.cli check --scan-path goal_harness/history.py --scan-path goal_harness/status.py --scan-path examples/status-neutral-run-window-smoke.py
- python3 -m py_compile goal_harness/history.py goal_harness/status.py goal_harness/diagnose.py goal_harness/quota.py examples/status-neutral-run-window-smoke.py
- git diff --check

Note: this is core runtime/status behavior, so it was reviewed for the shared Goal Harness status-projection contract before merge.