### PR TITLE
docs: clarify dynamic goal positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 **Gate-aware human-in-the-loop control plane**
 
+**Dynamic goal control plane for long-running agents**
+
 **让多个 agent 昼夜接力，把人的判断留在控制面。**
 
 Goal Harness 把目标、用户决策、agent todo、认领关系、scope、safe fallback、
@@ -11,9 +13,10 @@ run history 和 quota 放进同一层状态：该等人的地方明确等人，�
 安全侧路继续推进。
 
 Goal Harness is a local control plane for long-running AI agent projects. It
-keeps goals, gates, todos, claims, scopes, run history, quota, evidence, and
-human decisions visible across many turns, so primary and side agents can keep
-working on safe lanes while gated work waits for the person.
+turns a static agent goal into a dynamic, reviewable state layer: goals, gates,
+todos, claims, scopes, run history, quota, evidence, and human decisions stay
+visible across many turns, so primary and side agents can keep working on safe
+lanes while gated work waits for the person.
 
 [Quick Start](#quick-start) · [Getting Started](docs/guides/getting-started.md) ·
 [Showcases](docs/showcases/README.md) · [Hosted Frontstage](https://huangruiteng.github.io/goal-harness/frontstage/) ·
@@ -30,14 +33,14 @@ long-running work.
 
 Short answer: Goal Harness is not replacing Codex goal mode. Codex goal,
 Codex App automation, and CLI scripts can trigger executor loops; Goal Harness
-preserves the lifetime-goal state those loops need to keep working across
+preserves the dynamic goal state those loops need to keep working across
 turns.
 
 | Layer | Role |
 | --- | --- |
 | Codex / Claude Code / Cursor | Execute an agent loop: read, write, run commands, and respond. |
 | Codex goal / automation / CLI scripts | Trigger or schedule the next executor loop. |
-| Goal Harness | Preserve the lifetime goal: gates, todos, run history, quota, evidence, boundaries, and handoff state. |
+| Goal Harness | Preserve the dynamic goal state: gates, todos, run history, quota, evidence, boundaries, and handoff state. |
 
 The product promise is not "more todo lists." It is a better
 human-in-the-loop control surface: keep human judgment at high-value decision
@@ -301,7 +304,7 @@ contracts live in [Status Data](docs/status-data-contract.md),
 
 Goal Harness starts with AI coding, research, and benchmark loops because those
 workflows make state drift easy to see. The broader product direction is a
-lifetime-goal control plane for any long-running agent work where humans need
+dynamic goal control plane for any long-running agent work where humans need
 clear progress, gates, feedback, and recovery without reading raw logs.
 
 One medium-term productization case is a creator-operator workflow: a

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,16 +4,18 @@
 
 **Gate-aware human-in-the-loop control plane**
 
+**Dynamic goal control plane for long-running agents**
+
 **让多个 agent 昼夜接力，把人的判断留在控制面。**
 
 Goal Harness 把目标、用户决策、agent todo、认领关系、scope、safe fallback、
 run history 和 quota 放进同一层状态：该等人的地方明确等人，不该空等的
 安全侧路继续推进。
 
-Goal Harness 是一个面向长期 agent 工作的本地控制面。它让 Codex、Claude Code、
-Cursor、automation 和旁路 agent 共享同一份长期目标状态：目标、gate、todo、
-认领、scope、运行历史、quota、证据和项目边界在多轮工作中保持可见、可恢复、
-可交接。
+Goal Harness 是一个面向长期 agent 工作的本地控制面。它把一次性的静态 goal
+变成可演化、可复盘、可接力的动态目标状态：Codex、Claude Code、Cursor、
+automation 和旁路 agent 共享目标、gate、todo、认领、scope、运行历史、quota、
+证据和项目边界，在多轮工作中保持可见、可恢复、可交接。
 
 [English](README.md) · [快速开始](#快速开始) · [Showcases](docs/showcases/README.md) ·
 [用户群与反馈](#用户群与反馈) · [产品愿景](docs/product/vision.md) · [架构](docs/architecture.md)
@@ -30,7 +32,7 @@ Cursor 或其他终端 agent。更准确地说：
 | Goal Harness | 维护长期目标的控制面：当前目标、用户决策、agent todo、run history、quota、证据、边界和交接 |
 
 一句话：Goal Harness 不是 Codex goal 的替代品，而是让 Codex goal、automation
-和外部脚本触发的 agent loop 都能共享同一份长期状态。
+和外部脚本触发的 agent loop 都能共享同一份动态长期目标状态。
 
 ## 为什么需要
 

--- a/docs/outreach/marketing-copy-bank.md
+++ b/docs/outreach/marketing-copy-bank.md
@@ -39,7 +39,7 @@ Technical angle:
 > The always-on promise is backed by agent identity, `claimed_by`, scope,
 > capability gates, quota, run history, evidence writeback, and public/private
 > boundary checks. Goal Harness is not "run agents forever"; it is governed
-> continuity.
+> continuity: a dynamic goal control plane around executor loops.
 
 Plain Chinese form:
 
@@ -53,7 +53,7 @@ Plain Chinese form:
 When someone asks whether Goal Harness replaces Codex goal mode:
 
 > No. Codex goal, automation, CLI loops, Claude Code, Cursor, and benchmark
-> runners execute bounded work. Goal Harness keeps the lifetime-goal control
+> runners execute bounded work. Goal Harness keeps the dynamic goal control
 > plane visible across those loops.
 
 When someone asks why this matters:
@@ -260,8 +260,17 @@ Then explain the relationship:
 
 ```text
 Codex, Claude Code, Cursor, and scheduled terminal agents execute work.
-Goal Harness keeps the lifetime-goal control plane visible across those loops:
+Goal Harness keeps the dynamic goal control plane visible across those loops:
 goals, gates, todos, claims, scopes, run history, quota, and evidence.
+```
+
+Prefer this wording when the reader is comparing Goal Harness to static goal
+prompts:
+
+```text
+Goal Harness turns a static agent goal into dynamic, reviewable state: gates,
+todos, claims, scopes, evidence, quota, and handoff boundaries survive across
+executor loops.
 ```
 
 ### Lark / Internal Intro
@@ -274,8 +283,8 @@ Gate-aware human-in-the-loop control plane
 让多个 agent 昼夜接力，把人的判断留在控制面。
 
 Goal Harness 不是替代 Codex goal/automation，而是给这些 agent loop
-提供长期控制面：目标、用户决策、agent todo、认领、scope、safe fallback、
-run history 和 quota 能在同一层状态里被看见、继承、验证。
+提供动态长期目标控制面：目标、用户决策、agent todo、认领、scope、
+safe fallback、run history 和 quota 能在同一层状态里被看见、继承、验证。
 ```
 
 ### Social Post
@@ -313,8 +322,8 @@ handoff boundary.
 
 - Prefer concrete cases over abstract hype.
 - Prefer "control plane around agent loops" over "agent teammate" framing.
-- Keep "lifetime-goal" as category/tagline language unless a rename decision
-  packet changes the public brand.
+- Keep `Goal Harness` as the brand. Use "dynamic goal control plane" as the
+  category, and reserve "lifetime-goal" for explaining the time horizon.
 - If a phrase becomes a stable product promise, move it into README/docs and
   add appropriate validation. Do not enforce temporary marketing wording with
   brittle text-only smokes.

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -4,8 +4,8 @@ This folder keeps stable product-direction notes that are broader than one
 runtime contract, benchmark route, or launch draft.
 
 - [Product vision](vision.md): how Goal Harness grows from an engineering
-  control plane into a human-friendly control plane for long-running agent work,
-  including the creator-operator productization case.
+  control plane into a human-friendly dynamic goal control plane for
+  long-running agent work, including the creator-operator productization case.
 - [Server-client product shape](server-client-product-shape.md): the medium-term
   product model where the server owns durable state, delivery/planning queue
   boundaries, and governed proposal promotion, the client acts as the user's
@@ -22,5 +22,5 @@ runtime contract, benchmark route, or launch draft.
   compact candidate-ranking hints without raw chat, hidden profiling, or hard
   gate semantics.
 - [Naming decision packet](naming-decision-packet.md): why the project should
-  keep `Goal Harness` as the brand while testing `lifetime-goal control plane`
+  keep `Goal Harness` as the brand while testing `dynamic goal control plane`
   as category/tagline language.

--- a/docs/product/naming-decision-packet.md
+++ b/docs/product/naming-decision-packet.md
@@ -28,18 +28,19 @@ Gate-aware human-in-the-loop control plane
 Use this supporting category/tagline language when more explanation is needed:
 
 ```text
-lifetime-goal control plane
+dynamic goal control plane
 ```
 
 The public story should be:
 
-> Goal Harness is the lifetime-goal control plane around agent loops. Codex,
+> Goal Harness is the dynamic goal control plane around agent loops. Codex,
 > Claude Code, Cursor, terminal agents, and benchmark runners execute bounded
-> work; Goal Harness keeps the long-running goal, gates, todos, claims, scopes,
-> quota, evidence, and handoffs visible across those loops.
+> work; Goal Harness turns a static goal into long-running state: gates, todos,
+> claims, scopes, quota, evidence, and handoffs stay visible across those loops.
 
-Do not rename the repo to `lifetime-goal-harness` now. Use "lifetime-goal" as
-category language until there is stronger evidence that users remember it
+Do not rename the repo to `lifetime-goal-harness` or
+`dynamic-goal-harness` now. Use "dynamic goal control plane" as category
+language until there is stronger evidence that users remember another name
 better than `Goal Harness`.
 
 ## Why Not Rename Yet
@@ -57,7 +58,7 @@ copy:
 
 ```text
 Not an agent runtime; the control plane around the runtime.
-Not Codex goal mode; the lifetime-goal state that survives across executor
+Not Codex goal mode; the dynamic goal state that survives across executor
 loops.
 ```
 
@@ -71,6 +72,7 @@ comprehension.
 | --- | --- | --- | --- |
 | `Goal Harness` | Short, current, command-friendly, broad enough for engineering and creator/operator cases. | Needs category copy to avoid confusion with Codex goal mode or todo apps. | Keep as brand. |
 | `Lifetime Goal Harness` | Makes the long-horizon ambition explicit. | Long, heavy, awkward as a repo/package name, and can sound abstract before users understand the product. | Use as explanatory language, not brand. |
+| `Dynamic Goal Harness` | Captures the contrast with static goal prompts and one-shot automation. | Still long as a repo/package name, and "dynamic" can sound generic without the control-plane proof. | Use as category signal, not brand. |
 | `Goal Control Plane` | Directly names the category. | Too generic; weak brand; less distinctive in search or conversation. | Use as occasional explanation only. |
 | `Agent Control Plane` | Clear for agent-infrastructure audiences. | Overclaims the scope and implies Goal Harness is a runtime/orchestrator. | Avoid as primary framing. |
 | `Long-Horizon Control Plane` | Emphasizes the real problem. | Broad and technical; less connected to the user's concrete goal. | Use in long-form docs when useful. |
@@ -83,7 +85,7 @@ Use three layers:
 1. **Brand**: `Goal Harness`
 2. **Hero promise**: `Always-on agent teams, governed by human judgment`
 3. **Category**: `Gate-aware human-in-the-loop control plane`
-4. **Support phrase**: `lifetime-goal control plane`
+4. **Support phrase**: `dynamic goal control plane`
 
 This lets the project keep a stable name while still sharpening the product
 category.
@@ -96,6 +98,8 @@ Goal Harness
 Always-on agent teams, governed by human judgment.
 
 Gate-aware human-in-the-loop control plane.
+
+Dynamic goal control plane for long-running agents.
 ```
 
 Chinese-first stack:
@@ -105,10 +109,11 @@ Goal Harness
 
 Always-on agent teams, governed by human judgment
 Gate-aware human-in-the-loop control plane
+Dynamic goal control plane for long-running agents
 让多个 agent 昼夜接力，把人的判断留在控制面。
 
 Goal Harness 不是替代 Codex goal/automation，而是给这些 executor loop
-提供 lifetime-goal 控制面。
+提供动态长期目标控制面。
 ```
 
 ## When To Use Each Phrase
@@ -123,8 +128,10 @@ overclaiming autonomous production control.
 Use `Gate-aware human-in-the-loop control plane` when a first-contact reader
 needs the technical category immediately.
 
-Use `lifetime-goal control plane` when explaining why this is larger than one
-agent session, one terminal command, or one benchmark run.
+Use `dynamic goal control plane` when explaining why this is larger than one
+agent session, one terminal command, or one benchmark run. Use
+`lifetime-goal` only as a secondary explanation for time horizon, not as the
+main category.
 
 Use `Your agents keep the night shift. You keep the judgment.` as a social or
 demo tagline, not as a formal architecture term.
@@ -144,8 +151,8 @@ A good validation cycle:
    - Is Goal Harness replacing Codex/Claude/Cursor, or wrapping them?
    - What problem does it solve in long-running agent work?
    - What phrase do they remember after closing the page?
-3. Compare recall of `Goal Harness`, `lifetime-goal control plane`, and
-   `human-in-the-loop control plane`.
+3. Compare recall of `Goal Harness`, `dynamic goal control plane`,
+   `lifetime-goal control plane`, and `human-in-the-loop control plane`.
 4. Record only public-safe aggregated notes: no raw chat transcripts, personal
    names, screenshots, internal links, or private project context.
 5. Rename only if users consistently remember another name better and also
@@ -160,8 +167,9 @@ changing the brand.
   `Goal Harness, an always-on control plane for agent teams governed by human
   judgment`.
 - When users confuse it with Codex goal mode, answer with the executor-loop
-  split: Codex does bounded work; Goal Harness preserves lifetime-goal state.
-- Use "lifetime-goal" in explanatory paragraphs, not every headline.
+  split: Codex does bounded work; Goal Harness preserves dynamic goal state.
+- Use "dynamic goal" for the category; use "lifetime-goal" in explanatory
+  paragraphs only when the time horizon needs emphasis.
 - Keep bilingual hero copy for Chinese-first surfaces, but keep English README
   body primarily English.
 - Treat naming claims as outreach language. Do not add brittle smoke tests that

--- a/docs/product/server-client-product-shape.md
+++ b/docs/product/server-client-product-shape.md
@@ -226,7 +226,7 @@ public/private boundary check before it becomes part of a richer UI.
 ## Roadmap Implication
 
 This product shape changes the center of gravity from "a CLI around a Markdown
-goal file" to "a lifetime-goal control plane with CLI as the first client."
+goal file" to "a dynamic goal control plane with CLI as the first client."
 
 That does not make the CLI obsolete. The CLI is the compatibility baseline and
 the safety fallback. It also keeps contracts honest: if a future server or

--- a/docs/product/vision.md
+++ b/docs/product/vision.md
@@ -3,9 +3,9 @@
 Goal Harness is not only a developer tool for AI coding loops. It starts there
 because engineering work exposes the hard control-plane problems quickly:
 state drift, human gates, run evidence, handoffs, ownership, quota, and
-public/private boundaries. The larger product category is a control plane for
-lifetime goals: long-running agent work that has to stay understandable and
-recoverable across many turns.
+public/private boundaries. The larger product category is a dynamic goal
+control plane: a way to turn a static agent goal into long-running, reviewable
+state that stays understandable and recoverable across many turns.
 
 The long-term product should help humans who do not want to inspect prompts,
 logs, or traces. A user should be able to run multiple agents across tools and
@@ -24,6 +24,8 @@ off-hours, then open a first screen and understand:
 
 **Gate-aware human-in-the-loop control plane**
 
+**Dynamic goal control plane for long-running agents**
+
 **让多个 agent 昼夜接力，把人的判断留在控制面。**
 
 Goal Harness 把目标、用户决策、agent todo、认领关系、scope、safe fallback、
@@ -32,7 +34,9 @@ run history 和 quota 放进同一层状态：该等人的地方明确等人，�
 
 The product promise is always-on progress without uncontrolled autonomy:
 primary and side agents can continue bounded work, while human gates,
-capability gates, quota, evidence, and project boundaries remain explicit.
+capability gates, quota, evidence, and project boundaries remain explicit. In
+that sense, Goal Harness is not just a longer prompt or a bigger todo list; it
+is the dynamic goal state around executor loops.
 
 ## Creator-Operator Case
 


### PR DESCRIPTION
## Summary\n- keep Goal Harness as the brand while shifting the explanatory category to dynamic goal control plane\n- update README, Chinese README, product vision, naming packet, server/client note, and marketing copy bank\n- clarify the static goal vs dynamic reviewable state distinction for first-contact users\n\n## Validation\n- goal-harness check --scan-path README.md --scan-path README.zh-CN.md --scan-path docs/product --scan-path docs/outreach/marketing-copy-bank.md\n- git diff --check\n- diff-level private marker scan