### PR TITLE
fix: keep frontstage ops entry explicit

### DIFF
--- a/apps/dashboard/smoke/frontstage-route-smoke.ts
+++ b/apps/dashboard/smoke/frontstage-route-smoke.ts
@@ -67,7 +67,9 @@ includes(frontstageSource, "Always-on agent operations", "always-on operations c
 includes(frontstageSource, "Goal Harness Showcase Frontstage", "showcase-first hero title");
 includes(frontstageSource, "Always-on agent teams, governed by human judgment", "showcase-first hero copy");
 includes(frontstageSource, 'data-testid="frontstage-public-showcase-contract"', "public showcase contract panel");
-includes(frontstageSource, "Local status URLs stay behind the explicit Ops live switch", "ops-only live status copy");
+includes(frontstageSource, "Local status URLs stay behind explicit Ops live URLs", "ops-only live status copy");
+includes(frontstageSource, 'data-testid="frontstage-ops-entry-hint"', "explicit ops entry hint");
+excludes(frontstageSource, 'data-testid="frontstage-enable-ops-live"', "in-page ops live switch");
 includes(frontstageSource, "human judgment kept in the control plane", "human judgment control-plane copy");
 includes(frontstageSource, "Role Map", "role map copy");
 includes(frontstageSource, "claim owners", "claim owner role signal");

--- a/apps/dashboard/src/views/frontstage-page.tsx
+++ b/apps/dashboard/src/views/frontstage-page.tsx
@@ -773,7 +773,7 @@ function PublicShowcaseBoundaryPanel() {
         <div className="rounded-md border border-slate-200 bg-slate-50 px-3 py-3">
           <div className="text-[11px] font-semibold uppercase tracking-normal text-slate-500">live feeds</div>
           <div className="mt-2 text-sm font-semibold leading-6 text-slate-950">Ops live only</div>
-          <p className="mt-1 text-xs leading-5 text-slate-600">Local status URLs stay behind the explicit Ops live switch and are not the public showcase source.</p>
+          <p className="mt-1 text-xs leading-5 text-slate-600">Local status URLs stay behind explicit Ops live URLs and are not the public showcase source.</p>
         </div>
         <div className="rounded-md border border-slate-200 bg-slate-50 px-3 py-3">
           <div className="text-[11px] font-semibold uppercase tracking-normal text-slate-500">write authority</div>
@@ -844,7 +844,6 @@ function FrontstageRoute({
   isLoading,
   loadError,
   mode,
-  onEnableOpsMode,
   onGoalChange,
   onLoadStatusUrl,
   onResetDemo,
@@ -859,7 +858,6 @@ function FrontstageRoute({
   isLoading: boolean;
   loadError: string | null;
   mode: FrontstageMode;
-  onEnableOpsMode: () => void;
   onGoalChange: (goalId: string) => void;
   onLoadStatusUrl: () => void;
   onResetDemo: () => void;
@@ -1034,12 +1032,12 @@ function FrontstageRoute({
                 data-testid="frontstage-public-boundary-note"
               >
                 <p>
-                  Showcase mode ignores statusUrl and renders docs/showcases only. Use Ops live for local control-plane inspection.
+                  Showcase mode ignores statusUrl and renders docs/showcases only. Use an explicit ops URL for local control-plane inspection.
                 </p>
                 {hasIgnoredStatusUrl ? <Badge variant="warning">statusUrl ignored</Badge> : null}
-                <Button data-testid="frontstage-enable-ops-live" onClick={onEnableOpsMode} size="sm">
-                  Ops live
-                </Button>
+                <div className="text-[11px] font-semibold text-emerald-800" data-testid="frontstage-ops-entry-hint">
+                  Ops live requires ?mode=ops&amp;statusUrl=...
+                </div>
               </div>
             )}
             {loadError ? (
@@ -1317,10 +1315,6 @@ export function FrontstagePage() {
     void updateSearch({ goalId });
   }
 
-  function enableOpsMode() {
-    void updateSearch({ mode: "ops" });
-  }
-
   useEffect(() => {
     if (liveMode && search.statusUrl) {
       void loadFromUrl(search.statusUrl, false);
@@ -1341,7 +1335,6 @@ export function FrontstagePage() {
       isLoading={isLoading}
       loadError={loadError}
       mode={mode}
-      onEnableOpsMode={enableOpsMode}
       onGoalChange={changeGoal}
       onLoadStatusUrl={() => void loadFromUrl(statusUrl)}
       onResetDemo={resetToDemo}


### PR DESCRIPTION
## Summary
- remove the in-page Ops live switch from default showcase mode
- keep local status inspection available only through explicit ?mode=ops&statusUrl=... URLs
- add route smoke coverage so the showcase surface cannot reintroduce the switch by accident

## Validation
- npm run smoke:frontstage-route
- npm run smoke:frontstage-browser
- npm run smoke:frontstage-share-bundle
- npm run build
- python3 examples/showcase-catalog-smoke.py
- python3 examples/frontstage-pages-workflow-smoke.py
- goal-harness check --scan-path apps/dashboard/src/views/frontstage-page.tsx --scan-path apps/dashboard/smoke/frontstage-route-smoke.ts
- git diff --check
- private-boundary diff scan over changed files