### PR TITLE
docs: add benchmark rollout debug artifact

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/README.md
+++ b/docs/research/long-horizon-agent-benchmarks/README.md
@@ -69,6 +69,11 @@ work still belongs in the existing code, examples, and contract documents:
   queue after the agent-runtime refactor and app-server Goal pivot. It tracks
   running, superseded, and next-rerun case state without copying raw task text,
   logs, trajectories, verifier output, credentials, or remote host paths.
+- `benchmark-goal-rollout-debug-20260620.md`: public-safe rollout/debug layer
+  for the first cloud app-server Goal closeouts. It links compact benchmark
+  outcomes, GH todo/status transitions, case routes, failure attribution, and
+  next debug questions without copying raw task text, logs, trajectories,
+  verifier output, credentials, or private paths.
 - `benchmark-route-transition-retrospective-20260619.md`: retrospective and
   runbook for the local-Codex split-control to cloud-host Codex route pivot. It
   records why split-control was hard, which contracts/reducers remain useful,

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-active-case-status-20260620.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-active-case-status-20260620.md
@@ -25,6 +25,12 @@ Public boundary:
   run the task, official tests, and benchmark verifier only.
 - Remote benchmark checkout patches must follow
   `docs/benchmark-developer-workflow.md#remote-checkout-patch-protocol`.
+- After a compact closeout batch, write or update a public-safe rollout/debug
+  layer before rotating new cases. The first such artifact is
+  `benchmark-goal-rollout-debug-20260620.md`: it links compact result rows,
+  GH todo/status transitions, route shape, failure attribution, and next debug
+  questions without copying raw task text, logs, trajectories, verifier output,
+  credentials, or private paths.
 
 ## Active Cloud Batch
 
@@ -66,3 +72,6 @@ or blocker.
 4. Promote a case into `benchmark-case-analysis.json` only after the compact
    result teaches a durable routing, uplift, no-uplift, regression, or
    infrastructure lesson.
+5. For closeout batches with ambiguous zero scores, update the rollout/debug
+   layer before launching another rotation so future agents can inspect the GH
+   state flow and runner phase boundary, not only the final score.

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-goal-rollout-debug-20260620.json
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-goal-rollout-debug-20260620.json
@@ -1,0 +1,190 @@
+{
+  "schema_version": "benchmark_goal_rollout_debug_v0",
+  "generated_at": "2026-06-21T00:18:00+08:00",
+  "scope": "public_safe_rollout_metadata_for_20260620_cloud_goal_closeouts",
+  "public_boundary": {
+    "raw_task_text_copied": false,
+    "raw_logs_copied": false,
+    "raw_verifier_output_copied": false,
+    "raw_trajectory_copied": false,
+    "credential_material_copied": false,
+    "private_or_absolute_paths_copied": false,
+    "notes": "This file records compact rollout/control-plane metadata only. Raw benchmark artifacts stay on the private cloud host or ignored local runtime state."
+  },
+  "goal_harness_control_plane": {
+    "goal_id": "goal-harness-meta",
+    "pre_debug_recommended_action": {
+      "todo_id": "todo_9b33c85f5b7c",
+      "action_kind": "benchmark_case_rotation",
+      "summary": "Rotate next benchmark cases after app-server Goal closeout."
+    },
+    "debug_reprioritization": {
+      "todo_id": "todo_c5ca9f496ed6",
+      "claimed_by": "codex-main-control",
+      "action_kind": "benchmark_rollout_debug",
+      "summary": "Analyze just-closed benchmark rollouts and GH status flow before launching another rotation."
+    },
+    "recent_status_flow": [
+      {
+        "generated_at": "2026-06-20T23:25:02+08:00",
+        "classification": "benchmark_app_server_goal_runtime_lane_progress_20260620",
+        "delivery_outcome": "outcome_progress",
+        "meaning": "Three benchmark lanes were still active; next action was polling until compact result or precise blocker."
+      },
+      {
+        "generated_at": "2026-06-20T23:57:24+08:00",
+        "classification": "benchmark_cloud_goal_closeouts_pr319_merged_20260620",
+        "delivery_outcome": "outcome_progress",
+        "meaning": "Closeout helpers, reducers, SOP updates, and compact case evidence landed through PR #319."
+      },
+      {
+        "generated_at": "2026-06-20T23:57:59+08:00",
+        "classification": "benchmark_next_action_successor_sync_20260620",
+        "delivery_outcome": "surface_only",
+        "meaning": "Control plane successor switched to case rotation after closeout."
+      },
+      {
+        "generated_at": "2026-06-21T00:03:04+08:00",
+        "classification": "benchmark_rollout_debug_reprioritized_20260621",
+        "delivery_outcome": "surface_only",
+        "meaning": "Owner redirected the next step from rotation to rollout/debug analysis; a dedicated GH todo was created and claimed."
+      }
+    ]
+  },
+  "case_rollouts": [
+    {
+      "benchmark_id": "terminal-bench@2.0",
+      "case_id": "build-cython-ext",
+      "current_run_id": "f004782b573f",
+      "route": "host_codex_app_server_goal",
+      "arm_id": "terminal_bench_host_codex_app_server_goal_baseline",
+      "native_codex_goal_evidence": true,
+      "compact_artifact_ref": "cloud-ecs/parallel-benchmark-20260620T131254Z/terminal-bench-build-cython-ext-host-app-server-goal-r9/terminal_official_metadata.compact.json",
+      "official_score": 0.0,
+      "official_passed": false,
+      "failure_class": "official_verifier_solution_failure",
+      "failure_scope": "case_or_solution",
+      "rollout_stages": [
+        "remote_cloud_host_selected",
+        "codex_app_server_goal_started",
+        "terminal_bench_runner_reached_official_closeout",
+        "metadata_only_reducer_wrote_compact_result",
+        "ledger_upserted"
+      ],
+      "historical_control": {
+        "run_id": "53729101fea3",
+        "route": "codex_goal_mode_baseline_runtime_extended",
+        "official_score": 1.0,
+        "meaning": "This case previously passed after worker runtime setup repair, so the current app-server Goal zero is not enough to claim case impossibility."
+      },
+      "debug_read": "The route reached official scoring, but the public reducer does not yet expose enough solution-phase detail to distinguish timeout, incomplete edit, wrong validation target, or actual task reasoning failure.",
+      "next_debug_questions": [
+        "Can a public-safe terminal/goal phase summary be derived without copying raw trial fields?",
+        "Did app-server Goal get enough task-visible time compared with the historical passing run?",
+        "Should the next Terminal-Bench step be a historical pass/control rerun before treatment?"
+      ]
+    },
+    {
+      "benchmark_id": "skillsbench@1.1",
+      "case_id": "llm-prefix-cache-replay",
+      "current_run_ids": {
+        "baseline": "ec3f2c4a4a79",
+        "treatment": "5bfbc9e250f5"
+      },
+      "route": "benchflow_acp_blind_loop",
+      "native_codex_goal_evidence": false,
+      "compact_artifact_refs": {
+        "baseline": "cloud-ecs/parallel-benchmark-20260620T131254Z/skillsbench-llm-prefix-baseline-r1/benchmark_run.compact.json",
+        "treatment": "cloud-ecs/parallel-benchmark-20260620T131254Z/skillsbench-llm-prefix-treatment-r1/benchmark_run.compact.json"
+      },
+      "official_scores": {
+        "baseline": 0.0,
+        "treatment": 0.0,
+        "delta": 0.0
+      },
+      "failure_class": "official_score_zero_case_failure",
+      "failure_scope": "case_or_solution",
+      "rollout_stages": [
+        "runtime_layer_refactor_applied",
+        "codex_acp_runtime_preflight_passed",
+        "benchflow_runner_entered_rounds",
+        "official_score_zero_for_both_arms",
+        "paired_no_score_uplift_ledger_decision"
+      ],
+      "debug_read": "This is useful runner/verifier evidence, but it is not the native app-server Goal baseline the benchmark program now wants as the primary comparison target.",
+      "next_debug_questions": [
+        "Should SkillsBench get a native app-server Goal worker before more score claims?",
+        "Is the case a poor canary for Goal Harness lift, or is the blind-loop policy too weak?",
+        "Can reduce-only preserve persisted runtime prerequisites to avoid stale setup blockers?"
+      ]
+    },
+    {
+      "benchmark_id": "skillsbench@1.1",
+      "case_id": "tictoc-unnecessary-abort-detection",
+      "current_run_ids": {
+        "baseline": "99b2fe6538a4",
+        "treatment": "f86e63762ab2"
+      },
+      "route": "benchflow_acp_blind_loop",
+      "native_codex_goal_evidence": false,
+      "compact_artifact_refs": {
+        "baseline": "cloud-ecs/parallel-benchmark-20260620T131254Z/skillsbench-tictoc-baseline-r2/benchmark_run.compact.json",
+        "treatment": "cloud-ecs/parallel-benchmark-20260620T131254Z/skillsbench-tictoc-treatment-r2/benchmark_run.compact.json"
+      },
+      "official_scores": {
+        "baseline": 0.0,
+        "treatment": 0.0,
+        "delta": 0.0
+      },
+      "failure_class": "official_score_zero_case_failure",
+      "failure_scope": "case_or_solution",
+      "rollout_stages": [
+        "runtime_layer_refactor_applied",
+        "codex_acp_runtime_preflight_passed",
+        "benchflow_runner_entered_rounds",
+        "official_score_zero_for_both_arms",
+        "paired_no_score_uplift_ledger_decision"
+      ],
+      "debug_read": "The run validates that setup/prewarm no longer blocks this case, but not that the current Goal Harness policy improves task outcome.",
+      "next_debug_questions": [
+        "Is this case suitable as a stability canary only?",
+        "Should future SkillsBench treatment wait for native app-server Goal rather than another blind-loop repeat?",
+        "What compact trajectory counters predict zero-score before spending full case budget?"
+      ]
+    },
+    {
+      "benchmark_id": "swe-marathon",
+      "case_id": "find-network-alignments",
+      "current_run_id": "78318f625e3f",
+      "route": "harbor_host_codex_app_server_goal",
+      "arm_id": "swe_marathon_host_codex_app_server_goal_baseline",
+      "native_codex_goal_evidence": true,
+      "compact_artifact_ref": "cloud-ecs/parallel-benchmark-20260620T131254Z/swe-marathon-find-network-alignments-host-app-server-goal-r6/harbor_job_result.compact.json",
+      "official_score": 0.0,
+      "official_passed": false,
+      "failure_class": "official_verifier_solution_failure",
+      "failure_scope": "case_or_solution",
+      "rollout_stages": [
+        "harbor_source_and_jobconfig_preflight_passed",
+        "codex_app_server_goal_started",
+        "harbor_environment_operation_reached",
+        "agent_execution_reached",
+        "official_verifier_completed_zero",
+        "ledger_upserted"
+      ],
+      "debug_read": "This is the first real native Goal SWE-Marathon cloud closeout. It proves runner reachability but not task-solving capability.",
+      "next_debug_questions": [
+        "Was the solution incomplete because of app-server Goal timeout or because the model made a wrong edit?",
+        "Can Harbor expose public-safe phase counters for edit/test/verify without raw diffs?",
+        "Should the next SWE-Marathon step be a second small case or a matched treatment arm?"
+      ]
+    }
+  ],
+  "cross_case_findings": [
+    "The cloud host and app-server Goal route are now proven for Terminal-Bench and SWE-Marathon, but both native Goal baselines currently score zero.",
+    "SkillsBench closeouts are runner/verifier progress, not native Codex Goal evidence, because the current route is ACP/blind-loop.",
+    "The current failure taxonomy is too coarse: official_verifier_solution_failure should be split from agent timeout, incomplete solution, and verifier dependency failures when compact evidence supports it.",
+    "A dedicated rollout layer is needed between raw private trajectories and the public benchmark ledger: ledger says what closed; rollout says how the case moved through control-plane and runner phases."
+  ],
+  "recommended_next_step": "Before launching another rotation, add a durable public-safe rollout/traj debug artifact and use it to decide which case needs phase-counter reducers, native SkillsBench Goal support, or treatment comparison."
+}

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-goal-rollout-debug-20260620.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-goal-rollout-debug-20260620.md
@@ -1,0 +1,92 @@
+# Benchmark Goal Rollout Debug 2026-06-20
+
+This note is a public-safe rollout/debug layer for the benchmark cases that
+closed after the cloud-host app-server Goal pivot. It sits between two existing
+layers:
+
+- `benchmark-run-ledger.json` records compact final outcomes;
+- private cloud-host artifacts and trajectories retain raw task/log/verifier
+  evidence.
+
+The missing layer was the one operators and future agents need for debugging:
+what path the case took, which Goal Harness todo/status transition drove it,
+where official scoring was reached, and which next question should be answered
+before spending another case rotation.
+
+Public boundary:
+
+- no raw task text, raw trajectories, verifier output, raw logs, credentials,
+  uploads, leaderboard submissions, or remote absolute paths are copied here;
+- artifact references are compact logical refs only;
+- this file can name case ids, compact run ids, failure classes, status
+  classifications, and public-safe phase labels.
+
+Machine-readable companion:
+`benchmark-goal-rollout-debug-20260620.json`.
+
+## Control-Plane Flow
+
+| Time | GH classification / todo | Meaning |
+| --- | --- | --- |
+| `2026-06-20T23:25:02+08:00` | `benchmark_app_server_goal_runtime_lane_progress_20260620` | Three benchmark lanes were active; next action was polling Terminal-Bench, SWE-Marathon, and SkillsBench until each yielded compact result or precise blocker. |
+| `2026-06-20T23:57:24+08:00` | `benchmark_cloud_goal_closeouts_pr319_merged_20260620` | PR #319 landed the app-server Goal helpers, reducers, SOP updates, and compact case closeouts. |
+| `2026-06-20T23:57:59+08:00` | `benchmark_next_action_successor_sync_20260620` / `todo_9b33c85f5b7c` | Control plane moved to next case rotation. |
+| `2026-06-21T00:03:04+08:00` | `todo_c5ca9f496ed6` | Owner redirected the next step from rotation to rollout/traj analysis; this todo was created and claimed by `codex-main-control`. |
+
+The important correction is that rotation should not be treated as the next
+automatic step until this rollout has been inspected. The current state tells
+us "what scored"; it does not yet tell us enough about "why this was the right
+next case" or "which phase failed".
+
+## Case Rollouts
+
+| Benchmark | Case | Route | Official Result | Rollout Read |
+| --- | --- | --- | --- | --- |
+| `terminal-bench@2.0` | `build-cython-ext` | host Codex app-server Goal | `0.0`, `official_verifier_solution_failure` | Native Goal route reached official Terminal-Bench closeout. Historical compact control `53729101fea3` passed this case with score `1.0`, so the current zero is not enough to call the case impossible. The missing evidence is public-safe solution-phase attribution. |
+| `skillsbench@1.1` | `llm-prefix-cache-replay` | BenchFlow ACP blind-loop baseline/treatment | `0.0/0.0`, `paired_no_score_uplift` | Runner and verifier reached official score after runtime-layer refactor, but this is not native app-server Goal evidence. Treat it as setup/verifier progress and weak-policy no-uplift evidence. |
+| `skillsbench@1.1` | `tictoc-unnecessary-abort-detection` | BenchFlow ACP blind-loop baseline/treatment | `0.0/0.0`, `paired_no_score_uplift` | Setup/prewarm no longer blocks the case. It is currently a stability canary, not a proof that Goal Harness improves SkillsBench task outcome. |
+| `swe-marathon` | `find-network-alignments` | Harbor host Codex app-server Goal | `0.0`, `official_verifier_solution_failure` | First native Goal SWE-Marathon cloud closeout. Harbor reached environment operation, agent execution, verifier, and job closeout; the next missing signal is whether the zero came from timeout/incomplete edit or wrong solution. |
+
+## Cross-Case Findings
+
+1. Terminal-Bench and SWE-Marathon are now real app-server Goal baseline
+   closeouts. Their failures are case/solution failures, not setup blockers.
+2. SkillsBench still lacks a native app-server Goal worker. Its latest rows
+   prove runner/verifier readiness but should not be over-claimed as Codex
+   Goal baseline evidence.
+3. `official_verifier_solution_failure` is too broad for ongoing debugging.
+   It should eventually split into public-safe sublabels such as
+   `official_verifier_completed_zero_score`,
+   `agent_goal_timeout_then_official_zero`, and
+   `solution_phase_incomplete`.
+4. A rollout file is the right public artifact for this gap: it can show
+   control-plane phase, case route, compact result, and next debug question
+   while keeping raw trajectory and verifier evidence private.
+
+## Immediate Debug Questions
+
+- Terminal-Bench: can the reducer expose public-safe app-server/agent phase
+  counters, especially timeout versus complete-but-wrong, without copying raw
+  trial fields?
+- SkillsBench: should the next implementation slice be a native app-server
+  Goal worker instead of more ACP blind-loop repeats?
+- SWE-Marathon: can Harbor expose compact edit/test/verify phase counters so
+  `official_verifier_solution_failure` is not the only post-closeout label?
+- Goal Harness: should active-case status and run ledger both link to this
+  rollout layer so future agents can debug the path, not only the score?
+
+## Proposed Durable Shape
+
+For each real benchmark case closeout, write one public-safe rollout row with:
+
+- `benchmark_id`, `case_id`, `run_id`, route, arm, compact artifact ref;
+- native Goal evidence flag;
+- official score/pass/failure class/failure scope;
+- phase labels such as runner preflight, app-server Goal start, agent
+  execution, official verifier, ledger writeback;
+- GH todo/status transitions that selected, monitored, closed, and followed up
+  the run;
+- next debug questions.
+
+Raw trajectories remain private. Public trajectory summaries should be counters
+only, following `goal_harness/benchmark_trajectory.py`.

--- a/examples/benchmark-goal-rollout-debug-smoke.py
+++ b/examples/benchmark-goal-rollout-debug-smoke.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Smoke-test the public-safe benchmark rollout debug artifact."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ROLLUP_JSON = (
+    REPO_ROOT
+    / "docs/research/long-horizon-agent-benchmarks/benchmark-goal-rollout-debug-20260620.json"
+)
+ROLLUP_MD = (
+    REPO_ROOT
+    / "docs/research/long-horizon-agent-benchmarks/benchmark-goal-rollout-debug-20260620.md"
+)
+
+
+FORBIDDEN_MARKERS = [
+    "/Users/",
+    "/private/",
+    "/home/",
+    "/root/",
+    ".local/private-benchmark-jobs",
+    "BEGIN OPENSSH PRIVATE KEY",
+    "OPENAI_API_KEY",
+    "Authorization:",
+    '"raw_task_text_copied": true',
+    '"raw_logs_copied": true',
+    '"raw_verifier_output_copied": true',
+    '"raw_trajectory_copied": true',
+    '"credential_material_copied": true',
+    '"private_or_absolute_paths_copied": true',
+]
+
+
+def main() -> None:
+    payload = json.loads(ROLLUP_JSON.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == "benchmark_goal_rollout_debug_v0", payload
+    boundary = payload["public_boundary"]
+    assert boundary["raw_task_text_copied"] is False, boundary
+    assert boundary["raw_logs_copied"] is False, boundary
+    assert boundary["raw_verifier_output_copied"] is False, boundary
+    assert boundary["raw_trajectory_copied"] is False, boundary
+    assert boundary["credential_material_copied"] is False, boundary
+    assert boundary["private_or_absolute_paths_copied"] is False, boundary
+
+    cases = {
+        (case["benchmark_id"], case["case_id"]): case
+        for case in payload["case_rollouts"]
+    }
+    assert ("terminal-bench@2.0", "build-cython-ext") in cases, cases
+    assert ("skillsbench@1.1", "llm-prefix-cache-replay") in cases, cases
+    assert ("skillsbench@1.1", "tictoc-unnecessary-abort-detection") in cases, cases
+    assert ("swe-marathon", "find-network-alignments") in cases, cases
+
+    assert cases[("terminal-bench@2.0", "build-cython-ext")][
+        "native_codex_goal_evidence"
+    ] is True
+    assert cases[("swe-marathon", "find-network-alignments")][
+        "native_codex_goal_evidence"
+    ] is True
+    assert cases[("skillsbench@1.1", "llm-prefix-cache-replay")][
+        "native_codex_goal_evidence"
+    ] is False
+
+    rendered = json.dumps(payload, sort_keys=True) + "\n" + ROLLUP_MD.read_text(
+        encoding="utf-8"
+    )
+    leaks = [marker for marker in FORBIDDEN_MARKERS if marker in rendered]
+    assert not leaks, leaks
+    print("ok")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a public-safe benchmark Goal rollout/debug JSON+Markdown artifact for the 2026-06-20 cloud closeouts
- connect the active case status and research README to this rollout layer
- add a smoke that checks required cases and public-boundary flags

## Validation
- python3 examples/benchmark-goal-rollout-debug-smoke.py
- python3 examples/benchmark-run-ledger-smoke.py
- python3 -m py_compile examples/benchmark-goal-rollout-debug-smoke.py
- git diff --check
- git diff --cached --check

## Boundary
- no raw task text, raw logs, raw verifier output, raw trajectories, credentials, uploads, private paths, or leaderboard submissions
- scan hits were limited to forbidden-marker constants inside the smoke itself