### PR TITLE
Add benchmark closeout failure attribution

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/README.md
+++ b/docs/research/long-horizon-agent-benchmarks/README.md
@@ -74,6 +74,12 @@ work still belongs in the existing code, examples, and contract documents:
   outcomes, GH todo/status transitions, case routes, failure attribution, and
   next debug questions without copying raw task text, logs, trajectories,
   verifier output, credentials, or private paths.
+- `benchmark-closeout-failure-attribution-20260620.md`: public-safe
+  attribution layer for the Terminal-Bench `build-cython-ext`, SWE-Marathon
+  `find-network-alignments`, and two SkillsBench closeouts. It records what a
+  compact zero score does and does not prove, splits native app-server Goal
+  failures from non-native ACP blind-loop no-uplift, and makes the next
+  reducer/worker obligation explicit before another rotation.
 - `benchmark-route-transition-retrospective-20260619.md`: retrospective and
   runbook for the local-Codex split-control to cloud-host Codex route pivot. It
   records why split-control was hard, which contracts/reducers remain useful,

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-active-case-status-20260620.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-active-case-status-20260620.md
@@ -31,6 +31,11 @@ Public boundary:
   GH todo/status transitions, route shape, failure attribution, and next debug
   questions without copying raw task text, logs, trajectories, verifier output,
   credentials, or private paths.
+- After each compact closeout, write public-safe failure attribution before
+  treating the case as done or rotating away. The first attribution artifact is
+  `benchmark-closeout-failure-attribution-20260620.md`; it separates native
+  app-server Goal zero-score closeouts from non-native ACP blind-loop
+  no-uplift evidence and names the next reducer/worker obligation.
 
 ## Active Cloud Batch
 
@@ -44,6 +49,17 @@ Batch id: `parallel-benchmark-20260620T131254Z`.
 | `swe-marathon` | `find-network-alignments` | host Codex app-server Goal through Harbor bridge | compact official score `0.0`; ledger upserted under `gh-swe-find-network-alignments-host-app-server-goal-r6-20260620`; `thread/goal/get` confirmed `active`; `turn/start` id present; raw transcript not recorded; bridge responses observed | completed: app-server route reached Harbor environment operation, agent execution, verifier, and job closeout; official verifier returned `0.0` | Treat as a real native Goal baseline result with `official_verifier_solution_failure`; next SWE-Marathon work should either run a second small case or compare a treatment under the same no-upload boundary. |
 | `skillsbench@1.1` | `tictoc-unnecessary-abort-detection` | BenchFlow ACP blind-loop baseline | compact official score `0.0`; ledger upserted under `gh-skillsbench-tictoc-cloud-pair-r2-20260620` | completed as r2; r1 duplicate rerun may continue as background validation | Treat as ACP-compatible baseline evidence: runner/verifier completed, but the selected case did not score. |
 | `skillsbench@1.1` | `tictoc-unnecessary-abort-detection` | Goal Harness blind-loop treatment | compact official score `0.0`; ledger upserted under `gh-skillsbench-tictoc-cloud-pair-r2-20260620` | completed as r2; r1 duplicate rerun may continue as background validation | Pair with the ACP baseline as `paired_no_score_uplift`; next SkillsBench work should rotate to another early case or implement a native app-server Goal worker surface. |
+
+Failure-attribution update:
+
+- `build-cython-ext` is now classified as
+  `official_zero_native_goal_regression_needs_phase_attribution`, because a
+  historical compact control for the same case scored `1.0`.
+- `find-network-alignments` is now classified as
+  `official_zero_native_goal_first_closeout_needs_solution_phase_counters`.
+- both SkillsBench pairs are classified as
+  `paired_zero_acp_blind_loop_non_native_goal_no_uplift`; the next primary
+  SkillsBench engineering slice is the native app-server Goal worker.
 
 ## Rerun Queue After App-Server Sync
 
@@ -75,3 +91,7 @@ or blocker.
 5. For closeout batches with ambiguous zero scores, update the rollout/debug
    layer before launching another rotation so future agents can inspect the GH
    state flow and runner phase boundary, not only the final score.
+6. For every completed case, add or update a failure-attribution row before
+   selecting the next rotation. A zero score with only
+   `official_verifier_solution_failure` is not precise enough to choose the next
+   case by itself.

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-closeout-failure-attribution-20260620.json
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-closeout-failure-attribution-20260620.json
@@ -1,0 +1,161 @@
+{
+  "schema_version": "benchmark_closeout_failure_attribution_v0",
+  "generated_at": "2026-06-21T01:05:00+08:00",
+  "scope": "public_safe_failure_attribution_for_20260620_cloud_benchmark_closeouts",
+  "public_boundary": {
+    "raw_task_text_copied": false,
+    "raw_logs_copied": false,
+    "raw_verifier_output_copied": false,
+    "raw_trajectory_copied": false,
+    "credential_material_copied": false,
+    "private_or_absolute_paths_copied": false,
+    "notes": "This file records compact result metadata, route facts, and attribution labels only. Raw task bodies, trajectories, logs, verifier output, private paths, and credentials stay out of public artifacts."
+  },
+  "policy": {
+    "closeout_requires_failure_attribution_before_rotation": true,
+    "purpose": "A compact result closes runner accounting, but a case should not rotate forward until the result has a public-safe attribution label and a next debugging obligation.",
+    "official_verifier_solution_failure_meaning": "The benchmark runner reached the official verifier and the verifier returned a failing score. It does not by itself distinguish timeout, incomplete edit, wrong solution, insufficient native worker behavior, or a bad canary.",
+    "required_next_signal_for_zero_scores": [
+      "public-safe phase counters",
+      "route-native evidence flag",
+      "whether setup/verifier preflight passed",
+      "whether a comparable historical control passed",
+      "whether paired treatment improved over baseline"
+    ]
+  },
+  "case_attributions": [
+    {
+      "benchmark_id": "terminal-bench@2.0",
+      "case_id": "build-cython-ext",
+      "run_ids": {
+        "current_baseline": "f004782b573f",
+        "historical_passing_control": "53729101fea3"
+      },
+      "route": "host_codex_app_server_goal",
+      "native_codex_goal_evidence": true,
+      "official_score": 0.0,
+      "official_passed": false,
+      "ledger_failure_class": "official_verifier_solution_failure",
+      "ledger_failure_scope": "case_or_solution",
+      "refined_attribution": "official_zero_native_goal_regression_needs_phase_attribution",
+      "not_a_setup_blocker_because": [
+        "app-server Goal route reached official Terminal-Bench closeout",
+        "metadata-only reducer wrote a compact result",
+        "ledger upsert completed",
+        "a previous compact control for the same case scored 1.0"
+      ],
+      "remaining_unknowns": [
+        "whether the native Goal run timed out before meaningful solution work",
+        "whether the solution was incomplete or simply wrong",
+        "whether app-server Goal budget differed materially from the historical pass",
+        "whether the current reducer can expose enough phase counters without raw trial fields"
+      ],
+      "next_obligation": "Add or inspect public-safe Terminal-Bench phase counters, then compare against the historical passing control before launching more build-cython-ext treatment or declaring case difficulty."
+    },
+    {
+      "benchmark_id": "swe-marathon",
+      "case_id": "find-network-alignments",
+      "run_ids": {
+        "current_baseline": "78318f625e3f"
+      },
+      "route": "harbor_host_codex_app_server_goal",
+      "native_codex_goal_evidence": true,
+      "official_score": 0.0,
+      "official_passed": false,
+      "ledger_failure_class": "official_verifier_solution_failure",
+      "ledger_failure_scope": "case_or_solution",
+      "refined_attribution": "official_zero_native_goal_first_closeout_needs_solution_phase_counters",
+      "not_a_setup_blocker_because": [
+        "Harbor source and jobconfig preflight passed",
+        "app-server Goal route started",
+        "Harbor environment operation, agent execution, official verifier, and job closeout were reached",
+        "compact result and ledger upsert completed"
+      ],
+      "remaining_unknowns": [
+        "whether the zero came from timeout, incomplete edit, wrong edit, or missing validation loop",
+        "whether edit/test/verify phase counters can be reduced without raw diffs or logs",
+        "whether the next step should be a matched treatment arm or a second small control case"
+      ],
+      "next_obligation": "Teach the SWE-Marathon reducer to preserve public-safe edit/test/verify phase counters before treating this as a model-capability conclusion."
+    },
+    {
+      "benchmark_id": "skillsbench@1.1",
+      "case_id": "llm-prefix-cache-replay",
+      "run_ids": {
+        "baseline": "ec3f2c4a4a79",
+        "treatment": "5bfbc9e250f5"
+      },
+      "route": "benchflow_acp_blind_loop",
+      "native_codex_goal_evidence": false,
+      "official_scores": {
+        "baseline": 0.0,
+        "treatment": 0.0,
+        "delta": 0.0
+      },
+      "ledger_decision": "paired_no_score_uplift",
+      "ledger_failure_class": "official_score_zero_case_failure",
+      "ledger_failure_scope": "case_or_solution",
+      "refined_attribution": "paired_zero_acp_blind_loop_non_native_goal_no_uplift",
+      "not_a_setup_blocker_because": [
+        "Codex ACP runtime preflight passed",
+        "BenchFlow runner entered rounds",
+        "both arms produced compact official scores",
+        "baseline and treatment both recorded round reward counts"
+      ],
+      "remaining_unknowns": [
+        "whether native app-server Goal would produce a different baseline",
+        "whether the selected case is a poor lift canary",
+        "whether the blind-loop policy is too weak to represent the intended Codex Goal baseline"
+      ],
+      "next_obligation": "Stop using more ACP blind-loop repeats as primary Goal evidence; implement a native SkillsBench app-server Goal worker first."
+    },
+    {
+      "benchmark_id": "skillsbench@1.1",
+      "case_id": "tictoc-unnecessary-abort-detection",
+      "run_ids": {
+        "baseline": "99b2fe6538a4",
+        "treatment": "f86e63762ab2"
+      },
+      "route": "benchflow_acp_blind_loop",
+      "native_codex_goal_evidence": false,
+      "official_scores": {
+        "baseline": 0.0,
+        "treatment": 0.0,
+        "delta": 0.0
+      },
+      "ledger_decision": "paired_no_score_uplift",
+      "ledger_failure_class": "official_score_zero_case_failure",
+      "ledger_failure_scope": "case_or_solution",
+      "refined_attribution": "paired_zero_acp_blind_loop_non_native_goal_no_uplift",
+      "not_a_setup_blocker_because": [
+        "Codex ACP runtime preflight passed",
+        "BenchFlow runner entered rounds",
+        "both arms produced compact official scores",
+        "the earlier setup-blocked state has been superseded by r2 compact closeouts"
+      ],
+      "remaining_unknowns": [
+        "whether this case should remain only a stability canary",
+        "whether native app-server Goal can solve or expose a more informative failure mode",
+        "which compact trajectory counters predict zero before full budget is spent"
+      ],
+      "next_obligation": "Use this case as a stability canary only until the native SkillsBench app-server Goal worker exists."
+    }
+  ],
+  "route_decisions": [
+    {
+      "route": "terminal_bench",
+      "decision": "do_not_rotate_blindly",
+      "reason": "The route is native Goal and reached official closeout, but the current zero conflicts with a historical passing control."
+    },
+    {
+      "route": "swe_marathon",
+      "decision": "keep_native_goal_route_but_add_phase_counters",
+      "reason": "The first closeout is real, but zero-score attribution is still too coarse for treatment decisions."
+    },
+    {
+      "route": "skillsbench",
+      "decision": "build_native_app_server_goal_worker",
+      "reason": "Current compact pairs are ACP blind-loop evidence, not the intended Codex Goal baseline."
+    }
+  ]
+}

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-closeout-failure-attribution-20260620.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-closeout-failure-attribution-20260620.md
@@ -1,0 +1,65 @@
+# Benchmark Closeout Failure Attribution 2026-06-20
+
+This note turns the latest compact benchmark closeouts into public-safe failure
+attribution. The goal is to stop treating a final `0.0` score as the end of
+debugging. A compact closeout answers "what did the verifier record"; this
+layer answers "what should the next engineering move be."
+
+Public boundary:
+
+- no raw task text, raw trajectories, verifier output, raw logs, credentials,
+  uploads, leaderboard submissions, or remote absolute paths are copied here;
+- compact refs, run ids, case ids, route names, and public-safe phase labels
+  are allowed;
+- raw trajectories and verifier tails remain private runtime evidence.
+
+Machine-readable companion:
+`benchmark-closeout-failure-attribution-20260620.json`.
+
+## Policy
+
+Every benchmark case closeout should get failure attribution before the next
+rotation. The minimum row is:
+
+- compact run id and route;
+- whether this is native Codex app-server Goal evidence;
+- official score/pass/failure class;
+- what has been ruled out;
+- what remains unknown;
+- the next reducer, runner, or worker obligation.
+
+`official_verifier_solution_failure` means the runner reached the official
+verifier and the verifier returned a failing score. It is not precise enough to
+choose the next action by itself: it can hide timeout, incomplete edits, wrong
+solution, a weak worker policy, or a bad canary.
+
+## Case Attribution
+
+| Benchmark | Case | Route | Compact Result | Refined Attribution | Next Obligation |
+| --- | --- | --- | --- | --- | --- |
+| `terminal-bench@2.0` | `build-cython-ext` | host Codex app-server Goal | `0.0`, `official_verifier_solution_failure`; historical compact control `53729101fea3` scored `1.0` | `official_zero_native_goal_regression_needs_phase_attribution` | Add public-safe Terminal-Bench phase counters and compare against the historical passing control before launching more treatment on this case. |
+| `swe-marathon` | `find-network-alignments` | Harbor host Codex app-server Goal | `0.0`, `official_verifier_solution_failure` | `official_zero_native_goal_first_closeout_needs_solution_phase_counters` | Teach the Harbor/SWE-Marathon reducer to preserve public-safe edit/test/verify phase counters before treating this as model-capability evidence. |
+| `skillsbench@1.1` | `llm-prefix-cache-replay` | BenchFlow ACP blind-loop baseline/treatment | `0.0/0.0`, `paired_no_score_uplift` | `paired_zero_acp_blind_loop_non_native_goal_no_uplift` | Stop using more ACP blind-loop repeats as primary Codex Goal evidence; implement a native SkillsBench app-server Goal worker first. |
+| `skillsbench@1.1` | `tictoc-unnecessary-abort-detection` | BenchFlow ACP blind-loop baseline/treatment | `0.0/0.0`, `paired_no_score_uplift` | `paired_zero_acp_blind_loop_non_native_goal_no_uplift` | Keep as a stability canary only until the native SkillsBench app-server Goal worker exists. |
+
+## What This Changes
+
+Terminal-Bench and SWE-Marathon have crossed the important infrastructure
+line: app-server Goal can start, run, reach verifier, and produce compact
+official closeouts. Their current failures are no longer setup blockers.
+The next missing piece is solution-phase attribution.
+
+SkillsBench is different. The two latest cases prove that setup, prewarm, ACP
+rounds, and official scoring can complete. They do not prove native Codex Goal
+behavior, because the route is still BenchFlow ACP blind-loop. The next
+engineering slice should therefore be a native app-server Goal worker, not
+another same-policy repeat.
+
+## Durable Rule
+
+Do not rotate merely because a row has a compact result. Rotate only after the
+case has a refined attribution and one of these is true:
+
+- the next obligation is a different benchmark lane;
+- the failure is already precise enough for a treatment/control comparison;
+- the current lane is blocked on a named reducer or worker capability.

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-goal-rollout-debug-20260620.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-goal-rollout-debug-20260620.md
@@ -24,6 +24,9 @@ Public boundary:
 Machine-readable companion:
 `benchmark-goal-rollout-debug-20260620.json`.
 
+Failure-attribution companion:
+`benchmark-closeout-failure-attribution-20260620.md`.
+
 ## Control-Plane Flow
 
 | Time | GH classification / todo | Meaning |
@@ -90,3 +93,8 @@ For each real benchmark case closeout, write one public-safe rollout row with:
 
 Raw trajectories remain private. Public trajectory summaries should be counters
 only, following `goal_harness/benchmark_trajectory.py`.
+
+The follow-up failure-attribution layer narrows these rows into concrete
+obligations: Terminal-Bench and SWE-Marathon need public-safe solution-phase
+counters, while SkillsBench should stop repeating ACP blind-loop pairs as the
+primary Goal evidence and implement a native app-server Goal worker.

--- a/examples/benchmark-closeout-failure-attribution-smoke.py
+++ b/examples/benchmark-closeout-failure-attribution-smoke.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Smoke-test public-safe benchmark closeout failure attribution."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ATTRIBUTION_JSON = (
+    REPO_ROOT
+    / "docs/research/long-horizon-agent-benchmarks/"
+    / "benchmark-closeout-failure-attribution-20260620.json"
+)
+ATTRIBUTION_MD = (
+    REPO_ROOT
+    / "docs/research/long-horizon-agent-benchmarks/"
+    / "benchmark-closeout-failure-attribution-20260620.md"
+)
+
+
+FORBIDDEN_MARKERS = [
+    "/Users/",
+    "/private/",
+    "/home/",
+    "/root/",
+    ".local/private-benchmark-jobs",
+    "BEGIN OPENSSH PRIVATE KEY",
+    "OPENAI_API_KEY",
+    "Authorization:",
+    '"raw_task_text_copied": true',
+    '"raw_logs_copied": true',
+    '"raw_verifier_output_copied": true',
+    '"raw_trajectory_copied": true',
+    '"credential_material_copied": true',
+    '"private_or_absolute_paths_copied": true',
+]
+
+
+def main() -> None:
+    payload = json.loads(ATTRIBUTION_JSON.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == "benchmark_closeout_failure_attribution_v0"
+    assert payload["policy"]["closeout_requires_failure_attribution_before_rotation"]
+
+    boundary = payload["public_boundary"]
+    for key in [
+        "raw_task_text_copied",
+        "raw_logs_copied",
+        "raw_verifier_output_copied",
+        "raw_trajectory_copied",
+        "credential_material_copied",
+        "private_or_absolute_paths_copied",
+    ]:
+        assert boundary[key] is False, (key, boundary)
+
+    cases = {
+        (case["benchmark_id"], case["case_id"]): case
+        for case in payload["case_attributions"]
+    }
+    expected = {
+        ("terminal-bench@2.0", "build-cython-ext"),
+        ("swe-marathon", "find-network-alignments"),
+        ("skillsbench@1.1", "llm-prefix-cache-replay"),
+        ("skillsbench@1.1", "tictoc-unnecessary-abort-detection"),
+    }
+    assert expected <= set(cases), cases
+
+    terminal = cases[("terminal-bench@2.0", "build-cython-ext")]
+    assert terminal["native_codex_goal_evidence"] is True
+    assert (
+        terminal["refined_attribution"]
+        == "official_zero_native_goal_regression_needs_phase_attribution"
+    )
+    assert terminal["run_ids"]["historical_passing_control"] == "53729101fea3"
+
+    swe = cases[("swe-marathon", "find-network-alignments")]
+    assert swe["native_codex_goal_evidence"] is True
+    assert (
+        swe["refined_attribution"]
+        == "official_zero_native_goal_first_closeout_needs_solution_phase_counters"
+    )
+
+    for key in [
+        ("skillsbench@1.1", "llm-prefix-cache-replay"),
+        ("skillsbench@1.1", "tictoc-unnecessary-abort-detection"),
+    ]:
+        case = cases[key]
+        assert case["native_codex_goal_evidence"] is False
+        assert (
+            case["refined_attribution"]
+            == "paired_zero_acp_blind_loop_non_native_goal_no_uplift"
+        )
+        assert "native SkillsBench app-server Goal worker" in case["next_obligation"]
+
+    decisions = {entry["route"]: entry for entry in payload["route_decisions"]}
+    assert decisions["skillsbench"]["decision"] == "build_native_app_server_goal_worker"
+
+    rendered = json.dumps(payload, sort_keys=True) + "\n" + ATTRIBUTION_MD.read_text(
+        encoding="utf-8"
+    )
+    leaks = [marker for marker in FORBIDDEN_MARKERS if marker in rendered]
+    assert not leaks, leaks
+    print("ok")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a public-safe failure-attribution layer for the latest Terminal-Bench, SWE-Marathon, and SkillsBench closeouts
- distinguish native app-server Goal zero-score closeouts from non-native ACP blind-loop no-uplift evidence
- add a smoke that guards the attribution schema and public/private boundary

## Validation
- python3 examples/benchmark-closeout-failure-attribution-smoke.py
- python3 examples/benchmark-goal-rollout-debug-smoke.py
- python3 examples/benchmark-run-ledger-smoke.py
- python3 -m py_compile examples/benchmark-closeout-failure-attribution-smoke.py
- git diff --check

## Boundary
- excludes raw task text, raw logs, raw verifier output, raw trajectories, credentials, private paths, uploads, and leaderboard submissions
