### PR TITLE
Fix closeout smoke boundary fixture scan

### DIFF
--- a/examples/benchmark-closeout-failure-attribution-smoke.py
+++ b/examples/benchmark-closeout-failure-attribution-smoke.py
@@ -28,7 +28,10 @@ FORBIDDEN_MARKERS = [
     ".local/private-benchmark-jobs",
     "BEGIN OPENSSH PRIVATE KEY",
     "OPENAI_API_KEY",
-    "Authorization:",
+    # Keep active leak markers split in source so `goal-harness check` can
+    # scan this public smoke while the runtime assertion still tests the full
+    # forbidden marker in rendered artifacts.
+    "Author" + "ization:",
     '"raw_task_text_copied": true',
     '"raw_logs_copied": true',
     '"raw_verifier_output_copied": true',


### PR DESCRIPTION
## Summary
- split the auth-header forbidden marker in the benchmark closeout attribution smoke source
- preserves the runtime public-boundary assertion while keeping goal-harness check source scanning clean

## Validation
- python3 examples/benchmark-closeout-failure-attribution-smoke.py
- python3 -m goal_harness.cli check --scan-path .
- python3 examples/canary-promotion-readiness-smoke.py
- git diff --check