### PR TITLE
Add frontstage gate and artifact lanes

### DIFF
--- a/apps/dashboard/README.md
+++ b/apps/dashboard/README.md
@@ -33,8 +33,8 @@ project summaries.
 
 The first read-only channel frontstage lives at `/frontstage`. It renders a
 public-safe `goal_channel_projection_v0` fixture as a dense channel board with
-decision, quota, user todo, agent todo, active-claim, timeline, and truth
-contract lanes. Treat it as the product-path replacement for expanding the
+decision, quota, user todo, agent todo, active-claim, open-gate, artifact,
+timeline, and truth contract lanes. Treat it as the product-path replacement for expanding the
 no-dependency static HTML renderer; the Python renderer remains the fallback
 demo/diagnostic surface.
 

--- a/apps/dashboard/smoke/frontstage-route-smoke.ts
+++ b/apps/dashboard/smoke/frontstage-route-smoke.ts
@@ -60,6 +60,8 @@ includes(frontstageSource, 'data-testid="frontstage-user-todos"', "user todo lan
 includes(frontstageSource, 'data-testid="frontstage-agent-todos"', "agent todo lane");
 includes(frontstageSource, 'data-testid="frontstage-role-map"', "role map lane");
 includes(frontstageSource, 'data-testid="frontstage-active-claims"', "active claims lane");
+includes(frontstageSource, 'data-testid="frontstage-open-gates"', "open gates lane");
+includes(frontstageSource, 'data-testid="frontstage-artifacts"', "artifacts lane");
 includes(frontstageSource, 'data-testid="frontstage-timeline"', "timeline lane");
 includes(frontstageSource, "Frontstage channel", "frontstage channel copy");
 includes(frontstageSource, "Channel board", "channel board nav");
@@ -76,6 +78,9 @@ includes(frontstageSource, "Role Map", "role map copy");
 includes(frontstageSource, "claim owners", "claim owner role signal");
 includes(frontstageSource, "claimed lanes", "claimed lane signal");
 includes(frontstageSource, "evidence loop", "evidence loop signal");
+includes(frontstageSource, "No open gates in this projection.", "open gates empty state");
+includes(frontstageSource, "No compact artifacts projected.", "artifacts empty state");
+includes(frontstageSource, "artifactDisplayValue", "artifact value truncation helper");
 includes(frontstageSource, 'data-testid="frontstage-efficiency-evidence"', "efficiency evidence panel");
 includes(frontstageSource, "Efficiency Evidence", "efficiency evidence copy");
 includes(frontstageSource, "showcaseCatalog", "showcase catalog import");

--- a/apps/dashboard/src/views/frontstage-page.tsx
+++ b/apps/dashboard/src/views/frontstage-page.tsx
@@ -130,6 +130,11 @@ function warningMessage(value: string | string[] | undefined) {
   return value ?? "compact source warning";
 }
 
+function artifactDisplayValue(value: string | number | boolean | null | undefined) {
+  const text = stringifyScalar(value);
+  return text.length > 96 ? `${text.slice(0, 93)}...` : text;
+}
+
 function countOpenTodos(todos: GoalChannelTodo[]) {
   return todos.filter((todo) => todo.status === "open").length;
 }
@@ -1199,6 +1204,60 @@ function FrontstageRoute({
                     <div className="mt-2 break-all text-xs font-medium text-slate-500">{lease.todo_id}</div>
                   </div>
                 ))}
+              </div>
+            </Panel>
+          ) : null}
+
+          {isOpsMode ? (
+            <Panel icon={CircleAlert} title="Open Gates">
+              <div className="divide-y divide-slate-200" data-testid="frontstage-open-gates">
+                {projection.open_gates.map((gate) => (
+                  <div className="px-4 py-3" key={gate.gate_id}>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Badge variant={statusTone(gate.status)}>{gate.status}</Badge>
+                      <Badge variant="neutral">{gate.kind}</Badge>
+                    </div>
+                    <div className="mt-2 break-all text-xs font-semibold text-slate-600">{gate.gate_id}</div>
+                    {gate.blocks?.length ? (
+                      <div className="mt-2 flex flex-wrap gap-1.5">
+                        {gate.blocks.map((blocker) => (
+                          <Badge key={blocker} variant="warning">{blocker}</Badge>
+                        ))}
+                      </div>
+                    ) : null}
+                  </div>
+                ))}
+                {!projection.open_gates.length ? (
+                  <div className="px-4 py-4 text-sm font-medium leading-6 text-slate-500">No open gates in this projection.</div>
+                ) : null}
+              </div>
+            </Panel>
+          ) : null}
+
+          {isOpsMode ? (
+            <Panel icon={ExternalLink} title="Artifacts">
+              <div className="divide-y divide-slate-200" data-testid="frontstage-artifacts">
+                {projection.artifacts.map((artifact, index) => (
+                  <div className="space-y-2 px-4 py-3" key={`${artifact.kind ?? "artifact"}-${index}`}>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Badge variant="info">{artifactDisplayValue(artifact.kind)}</Badge>
+                      {artifact.label ? <Badge variant="neutral">{artifactDisplayValue(artifact.label)}</Badge> : null}
+                    </div>
+                    {Object.entries(artifact)
+                      .filter(([key]) => !["kind", "label"].includes(key))
+                      .map(([key, value]) => (
+                        <div className="grid gap-1 rounded-md border border-slate-100 bg-slate-50 px-2 py-1.5" key={key}>
+                          <span className="text-[11px] font-semibold uppercase tracking-normal text-slate-500">{key}</span>
+                          <span className="break-words text-xs font-medium leading-5 text-slate-700">
+                            {artifactDisplayValue(value)}
+                          </span>
+                        </div>
+                      ))}
+                  </div>
+                ))}
+                {!projection.artifacts.length ? (
+                  <div className="px-4 py-4 text-sm font-medium leading-6 text-slate-500">No compact artifacts projected.</div>
+                ) : null}
               </div>
             </Panel>
           ) : null}

--- a/examples/dashboard-frontstage-browser-smoke.mjs
+++ b/examples/dashboard-frontstage-browser-smoke.mjs
@@ -54,7 +54,14 @@ function projectionFor(goalId, displayName, claimedBy, todoTitle) {
         title: `${todoTitle} FAKE_PRIVATE_TODO_GAMMA`,
       },
     ],
-    open_gates: [],
+    open_gates: [
+      {
+        gate_id: `${goalId}_gate`,
+        kind: "user_channel",
+        status: "clear",
+        blocks: [],
+      },
+    ],
     active_leases: [
       {
         owner_agent: claimedBy,
@@ -66,6 +73,7 @@ function projectionFor(goalId, displayName, claimedBy, todoTitle) {
       {
         kind: "fixture",
         label: "browser smoke statusUrl",
+        path: "docs/showcases/showcase-catalog.json",
       },
     ],
     recent_events: [
@@ -285,7 +293,7 @@ async function captureFrontstage(page, url, label, requiredText = []) {
     "SINGLE-ENGINEER COMPRESSION",
     "maturity-adjusted",
     "PUBLIC GIT FACTS",
-    "Showcase Motion",
+    "Async Work Loop",
     "Case-driven motion board",
     "Case source",
     "docs/showcases/showcase-catalog.json",
@@ -345,16 +353,16 @@ async function main() {
     try {
       await captureFrontstage(desktopPage, `${baseUrl}/frontstage`, "desktop-frontstage", [
         "Goal Harness Showcase Frontstage",
-        "Always-on agent teams, governed by human judgment",
+        "Async agent teams, governed by human judgment",
         "public cases",
         "story beats",
         "showcase mode",
         "Showcase mode ignores statusUrl",
         "STATE FLOW CONTROL PLANE",
-        "The work moves. Judgment stays visible.",
+        "Work keeps moving. Judgment stays in charge.",
         "safe work moves",
         "ASYNCHRONOUS AGENT RHYTHM",
-        "Always-on agent teams can keep safe work moving",
+        "Agent teams work across turns and off-hours",
         "SEARCH PUBLIC SHOWCASES",
         "Showing 4 of 4 public-safe cases",
         "Public Boundary",
@@ -455,9 +463,13 @@ async function main() {
           "Run Timeline",
           "Role Map",
           "Active Claims",
+          "Open Gates",
+          "Artifacts",
           "Truth Contract",
           "CLAIMED LANES",
           "EVIDENCE LOOP",
+          "live-goal-a_gate",
+          "browser smoke statusUrl",
           "browser_smoke_public_fixture",
         ],
       );
@@ -499,7 +511,7 @@ async function main() {
     try {
       await captureFrontstage(mobilePage, `${baseUrl}/frontstage`, "mobile-frontstage", [
         "Goal Harness Showcase Frontstage",
-        "Always-on agent teams, governed by human judgment",
+        "Async agent teams, governed by human judgment",
         "showcase mode",
         "Showcase mode ignores statusUrl",
         "Public Boundary",


### PR DESCRIPTION
## Summary
- add read-only Open Gates and Artifacts panels to the frontstage ops route
- update frontstage route/browser smokes to cover the new lanes and current showcase copy
- document the added lanes in the dashboard README

## Validation
- npm run smoke:frontstage-route
- npm run smoke:frontstage-browser
- npm run build
- python3 -m goal_harness.cli check --scan-path apps/dashboard --scan-path examples/dashboard-frontstage-browser-smoke.mjs
- git diff --check origin/main...HEAD