### PR TITLE
Add public-safe rollout event log

### DIFF
--- a/docs/benchmark-developer-workflow.md
+++ b/docs/benchmark-developer-workflow.md
@@ -121,6 +121,62 @@ The snapshot reports `status.env`, pid liveness, compact result summaries,
 standard artifact presence, and optional keyword booleans for tmux captures. It
 does not emit task text, trajectories, raw logs, or capture content.
 
+### Goal Rollout Event Log
+
+Each benchmark case should leave a compact Goal Harness rollout trail, separate
+from raw Codex sessions or benchmark runner logs. Use the rollout event log when
+you need to explain the lifecycle of a case or an agent workflow:
+
+- `quota_should_run`: the controller allowed a bounded slice.
+- `todo_claim`: an agent claimed the work item.
+- `benchmark_launch` / `benchmark_status`: a case was launched or polled.
+- `validation`: a smoke, reducer, or official verifier finished.
+- `compact_case_result` / `compact_blocker`: public-safe case outcome.
+- `refresh_state` / `quota_spend`: Goal Harness writeback and spend.
+- `codex_session_observed`: a private Codex session source exists, but raw
+  session contents and file paths are not recorded.
+
+Append one compact event at important transitions:
+
+```bash
+python3 scripts/goal_rollout_event_log.py append \
+  --goal-id goal-harness-meta \
+  --event-kind compact_case_result \
+  --agent-id codex-main-control \
+  --todo-id todo_406bb256efd8 \
+  --benchmark-id terminal-bench@2.0 \
+  --case-id build-cython-ext \
+  --status precise_blocker \
+  --summary "Official verifier failed before a countable agent result." \
+  --artifact-ref docs/research/long-horizon-agent-benchmarks/benchmark-case-analysis.json
+```
+
+Summarize the current trail without reading private sources:
+
+```bash
+python3 scripts/goal_rollout_event_log.py summarize \
+  --goal-id goal-harness-meta \
+  --limit 12 \
+  --pretty
+```
+
+Codex session JSONL files can help local debugging, but treat them as private
+source material. Record only their existence/count, never transcript bodies,
+paths, prompts, tool output, or token-bearing content:
+
+```bash
+python3 scripts/goal_rollout_event_log.py observe-codex-sessions \
+  --goal-id goal-harness-meta \
+  --agent-id codex-main-control
+```
+
+The canonical log lives under the Goal Harness runtime root for the goal, for
+example `goals/<goal-id>/rollout-event-log.jsonl`. It is a local control-plane
+artifact, not a raw evidence file to commit. Public docs and ledgers may cite
+compact event ids, case ids, run ids, and artifact refs, but must keep raw task
+text, logs, trajectories, Codex session transcripts, credentials, and absolute
+host paths out.
+
 ## Cloud ECS Benchmark Host Route
 
 Use the cloud ECS benchmark host route as the default for Terminal-Bench,

--- a/examples/goal-rollout-event-log-smoke.py
+++ b/examples/goal-rollout-event-log-smoke.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Validate public-safe Goal Harness rollout event logging."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from goal_harness.rollout_event_log import (  # noqa: E402
+    build_rollout_event,
+    append_rollout_event,
+    load_rollout_events,
+    rollout_event_log_path,
+    summarize_rollout_events,
+)
+
+
+def assert_public_safe_text(text: str) -> None:
+    forbidden = (
+        "/" + "Users/",
+        "/" + "root/",
+        "/" + "private/",
+        "trajectory" + ".json",
+        "Auth" + "orization:",
+        "goal-harness-" + "ecs",
+        "115." + "190.",
+    )
+    for marker in forbidden:
+        assert marker not in text, marker
+
+
+def assert_boundary(payload: dict) -> None:
+    boundary = payload["boundary"]
+    assert boundary["raw_task_text_recorded"] is False, payload
+    assert boundary["raw_logs_recorded"] is False, payload
+    assert boundary["raw_trajectory_recorded"] is False, payload
+    assert boundary["raw_session_transcript_recorded"] is False, payload
+    assert boundary["credential_values_recorded"] is False, payload
+    assert boundary["absolute_paths_recorded"] is False, payload
+
+
+def run_script(*args: str) -> dict:
+    result = subprocess.run(
+        [sys.executable, str(REPO_ROOT / "scripts" / "goal_rollout_event_log.py"), *args],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    assert_public_safe_text(result.stdout)
+    return json.loads(result.stdout)
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory(prefix="goal-harness-rollout-event-log-") as tmp:
+        runtime_root = Path(tmp) / "runtime"
+        goal_id = "goal-harness-meta"
+        log_path = rollout_event_log_path(runtime_root, goal_id)
+        event = build_rollout_event(
+            goal_id=goal_id,
+            event_kind="quota_should_run",
+            agent_id="codex-main-control",
+            todo_id="todo_406bb256efd8",
+            status="eligible",
+            summary="Quota allowed one bounded rollout event-log slice.",
+            artifact_refs=["docs/benchmark-developer-workflow.md"],
+            details={"open_agent_todo_count": 2},
+        )
+        append_rollout_event(log_path, event)
+
+        result_event = run_script(
+            "append",
+            "--goal-id",
+            goal_id,
+            "--runtime-root",
+            str(runtime_root),
+            "--event-kind",
+            "compact_case_result",
+            "--agent-id",
+            "codex-main-control",
+            "--todo-id",
+            "todo_406bb256efd8",
+            "--benchmark-id",
+            "terminal-bench@2.0",
+            "--case-id",
+            "build-cython-ext",
+            "--status",
+            "precise_blocker",
+            "--summary",
+            "Compact case result reduced to public-safe failure attribution.",
+            "--artifact-ref",
+            "docs/research/long-horizon-agent-benchmarks/benchmark-case-analysis.json",
+        )
+        assert result_event["event_kind"] == "compact_case_result", result_event
+        assert_boundary(result_event)
+
+        session_root = Path(tmp) / "sessions"
+        session_root.mkdir()
+        (session_root / "rollout.jsonl").write_text(
+            '{"raw":"this transcript body must not be read"}\n',
+            encoding="utf-8",
+        )
+        session_event = run_script(
+            "observe-codex-sessions",
+            "--goal-id",
+            goal_id,
+            "--runtime-root",
+            str(runtime_root),
+            "--session-root",
+            str(session_root),
+            "--agent-id",
+            "codex-main-control",
+        )
+        assert session_event["event_kind"] == "codex_session_observed", session_event
+        assert session_event["private_source"] == {
+            "kind": "codex_sessions_jsonl",
+            "raw_values_recorded": False,
+            "count": 1,
+        }, session_event
+        assert_boundary(session_event)
+
+        events = load_rollout_events(log_path)
+        summary = summarize_rollout_events(events, limit=5)
+        assert summary["event_count"] == 3, summary
+        assert summary["counts_by_kind"]["quota_should_run"] == 1, summary
+        assert summary["counts_by_kind"]["compact_case_result"] == 1, summary
+        assert summary["counts_by_kind"]["codex_session_observed"] == 1, summary
+        assert_boundary(summary)
+        rendered_summary = run_script(
+            "summarize",
+            "--goal-id",
+            goal_id,
+            "--runtime-root",
+            str(runtime_root),
+            "--limit",
+            "3",
+            "--pretty",
+        )
+        assert rendered_summary["event_count"] == 3, rendered_summary
+
+        try:
+            build_rollout_event(
+                goal_id=goal_id,
+                event_kind="validation",
+                artifact_refs=["/" + "Users/bytedance/private-result.json"],
+            )
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("absolute artifact refs must be rejected")
+
+        try:
+            build_rollout_event(
+                goal_id=goal_id,
+                event_kind="validation",
+                details={"raw_" + "trajectory_path": "trajectory" + ".json"},
+            )
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("raw/private detail keys must be rejected")
+
+        assert_public_safe_text(log_path.read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    main()

--- a/goal_harness/rollout_event_log.py
+++ b/goal_harness/rollout_event_log.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+
+ROLLOUT_EVENT_SCHEMA_VERSION = "goal_harness_rollout_event_v0"
+ROLLOUT_EVENT_SUMMARY_SCHEMA_VERSION = "goal_harness_rollout_event_summary_v0"
+DEFAULT_ROLLOUT_EVENT_LOG_NAME = "rollout-event-log.jsonl"
+
+ROLLOUT_EVENT_KINDS = {
+    "benchmark_launch",
+    "benchmark_status",
+    "codex_session_observed",
+    "compact_blocker",
+    "compact_case_result",
+    "failure_attribution",
+    "pr_merge",
+    "quota_should_run",
+    "quota_spend",
+    "refresh_state",
+    "todo_claim",
+    "validation",
+}
+
+PRIVATE_SOURCE_KINDS = {
+    "benchmark_run_dir",
+    "codex_sessions_jsonl",
+    "local_runtime_state",
+    "private_runner_artifact",
+    "unknown_private_source",
+}
+
+FORBIDDEN_TEXT_MARKERS = (
+    "/" + "Users/",
+    "/" + "root/",
+    "/" + "home/",
+    "/" + "private/",
+    ".local/" + "private",
+    "Auth" + "orization:",
+    "api" + "_key",
+    "api" + "key",
+    "pass" + "word",
+    "sec" + "ret=",
+    "tok" + "en=",
+    "goal-harness-" + "ecs",
+    "115." + "190.",
+)
+
+RAW_KEY_HINTS = (
+    "credential",
+    "local_path",
+    "log",
+    "path",
+    "raw",
+    "secret",
+    "stderr",
+    "stdout",
+    "task_text",
+    "token",
+    "trace",
+    "trajectory",
+    "transcript",
+)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace(
+        "+00:00", "Z"
+    )
+
+
+def _compact_text(value: Any, *, limit: int = 500, field: str = "value") -> str | None:
+    if value is None:
+        return None
+    text = " ".join(str(value).split())
+    if not text:
+        return None
+    lowered = text.lower()
+    for marker in FORBIDDEN_TEXT_MARKERS:
+        if marker.lower() in lowered:
+            raise ValueError(f"{field} contains private or credential-like material")
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 1)].rstrip() + "..."
+
+
+def _safe_key(key: str, *, field: str) -> str:
+    text = str(key).strip()
+    if not text:
+        raise ValueError(f"{field} key is empty")
+    lowered = text.lower()
+    if any(hint in lowered for hint in RAW_KEY_HINTS):
+        raise ValueError(f"{field} key {text!r} looks like raw/private material")
+    return text
+
+
+def _safe_scalar(value: Any, *, field: str) -> bool | int | float | str | None:
+    if value is None or isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value
+    return _compact_text(value, limit=240, field=field)
+
+
+def _safe_public_ref(value: Any, *, field: str) -> str | None:
+    text = _compact_text(value, limit=240, field=field)
+    if text is None:
+        return None
+    path = Path(text)
+    if text.startswith(("~", "/", "\\")) or path.is_absolute() or ".." in path.parts:
+        raise ValueError(f"{field} must be a public relative ref or opaque id")
+    return text
+
+
+def _safe_details(details: Mapping[str, Any] | None) -> dict[str, Any]:
+    safe: dict[str, Any] = {}
+    for key, value in (details or {}).items():
+        safe_key = _safe_key(str(key), field="details")
+        safe[safe_key] = _safe_scalar(value, field=f"details.{safe_key}")
+    return safe
+
+
+def _safe_source_refs(
+    source_refs: Sequence[Mapping[str, Any]] | None,
+) -> list[dict[str, Any]]:
+    safe_refs: list[dict[str, Any]] = []
+    for index, ref in enumerate(source_refs or []):
+        item: dict[str, Any] = {}
+        for key, value in ref.items():
+            safe_key = _safe_key(str(key), field=f"source_refs[{index}]")
+            item[safe_key] = _safe_scalar(
+                value, field=f"source_refs[{index}].{safe_key}"
+            )
+        if item:
+            safe_refs.append(item)
+    return safe_refs
+
+
+def _normalized_event_kind(event_kind: str) -> str:
+    text = str(event_kind).strip().lower().replace("-", "_")
+    if text not in ROLLOUT_EVENT_KINDS:
+        choices = ", ".join(sorted(ROLLOUT_EVENT_KINDS))
+        raise ValueError(f"unsupported rollout event kind {event_kind!r}; choose {choices}")
+    return text
+
+
+def _event_id(payload: Mapping[str, Any]) -> str:
+    stable = {
+        key: value
+        for key, value in payload.items()
+        if key not in {"event_id", "recorded_at"}
+    }
+    encoded = json.dumps(stable, sort_keys=True, ensure_ascii=True).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()[:16]
+
+
+def rollout_event_log_path(runtime_root: Path, goal_id: str) -> Path:
+    return (
+        runtime_root.expanduser()
+        / "goals"
+        / str(goal_id)
+        / DEFAULT_ROLLOUT_EVENT_LOG_NAME
+    )
+
+
+def build_rollout_event(
+    *,
+    goal_id: str,
+    event_kind: str,
+    agent_id: str | None = None,
+    todo_id: str | None = None,
+    benchmark_id: str | None = None,
+    case_id: str | None = None,
+    run_id: str | None = None,
+    status: str | None = None,
+    classification: str | None = None,
+    delivery_outcome: str | None = None,
+    labels: Sequence[str] | None = None,
+    summary: str | None = None,
+    artifact_refs: Sequence[str] | None = None,
+    source_refs: Sequence[Mapping[str, Any]] | None = None,
+    details: Mapping[str, Any] | None = None,
+    private_source_kind: str | None = None,
+    private_source_count: int | None = None,
+    recorded_at: str | None = None,
+) -> dict[str, Any]:
+    """Build a public-safe append-only Goal Harness rollout event.
+
+    The event records lifecycle metadata only. It intentionally keeps raw Codex
+    sessions, benchmark logs, task text, trajectories, credentials, and absolute
+    local paths out of the payload.
+    """
+
+    if not str(goal_id).strip():
+        raise ValueError("goal_id is required")
+    private_kind = (
+        str(private_source_kind).strip()
+        if private_source_kind
+        else None
+    )
+    if private_kind and private_kind not in PRIVATE_SOURCE_KINDS:
+        choices = ", ".join(sorted(PRIVATE_SOURCE_KINDS))
+        raise ValueError(f"unsupported private source kind {private_kind!r}; choose {choices}")
+    safe_artifact_refs = [
+        ref
+        for ref in (
+            _safe_public_ref(value, field="artifact_refs") for value in artifact_refs or []
+        )
+        if ref
+    ]
+    safe_labels = [
+        text
+        for text in (_compact_text(value, limit=80, field="labels") for value in labels or [])
+        if text
+    ]
+    payload: dict[str, Any] = {
+        "schema_version": ROLLOUT_EVENT_SCHEMA_VERSION,
+        "goal_id": str(goal_id).strip(),
+        "event_kind": _normalized_event_kind(event_kind),
+        "recorded_at": recorded_at or _now_iso(),
+        "boundary": {
+            "raw_task_text_recorded": False,
+            "raw_logs_recorded": False,
+            "raw_trajectory_recorded": False,
+            "raw_session_transcript_recorded": False,
+            "credential_values_recorded": False,
+            "absolute_paths_recorded": False,
+        },
+    }
+    optional_scalars = {
+        "agent_id": agent_id,
+        "todo_id": todo_id,
+        "benchmark_id": benchmark_id,
+        "case_id": case_id,
+        "run_id": run_id,
+        "status": status,
+        "classification": classification,
+        "delivery_outcome": delivery_outcome,
+        "summary": summary,
+    }
+    for key, value in optional_scalars.items():
+        safe = _compact_text(value, limit=500 if key == "summary" else 180, field=key)
+        if safe:
+            payload[key] = safe
+    if safe_labels:
+        payload["labels"] = safe_labels
+    if safe_artifact_refs:
+        payload["artifact_refs"] = safe_artifact_refs
+    safe_source_refs = _safe_source_refs(source_refs)
+    if safe_source_refs:
+        payload["source_refs"] = safe_source_refs
+    safe_details = _safe_details(details)
+    if safe_details:
+        payload["details"] = safe_details
+    if private_kind:
+        payload["private_source"] = {
+            "kind": private_kind,
+            "raw_values_recorded": False,
+        }
+        if private_source_count is not None:
+            if private_source_count < 0:
+                raise ValueError("private_source_count must be non-negative")
+            payload["private_source"]["count"] = int(private_source_count)
+    payload["event_id"] = _event_id(payload)
+    return payload
+
+
+def append_rollout_event(log_path: Path, event: Mapping[str, Any]) -> dict[str, Any]:
+    payload = dict(event)
+    if payload.get("schema_version") != ROLLOUT_EVENT_SCHEMA_VERSION:
+        raise ValueError("unsupported rollout event schema")
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, sort_keys=True, ensure_ascii=False) + "\n")
+    return payload
+
+
+def load_rollout_events(log_path: Path, *, limit: int | None = None) -> list[dict[str, Any]]:
+    try:
+        lines = log_path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return []
+    if limit is not None:
+        lines = lines[-max(0, limit) :]
+    events: list[dict[str, Any]] = []
+    for line in lines:
+        if not line.strip():
+            continue
+        try:
+            parsed = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict) and parsed.get("schema_version") == ROLLOUT_EVENT_SCHEMA_VERSION:
+            events.append(parsed)
+    return events
+
+
+def _safe_event_view(event: Mapping[str, Any]) -> dict[str, Any]:
+    keys = (
+        "event_id",
+        "recorded_at",
+        "event_kind",
+        "status",
+        "agent_id",
+        "todo_id",
+        "benchmark_id",
+        "case_id",
+        "run_id",
+        "classification",
+        "delivery_outcome",
+        "summary",
+    )
+    return {key: event[key] for key in keys if key in event}
+
+
+def summarize_rollout_events(
+    events: Iterable[Mapping[str, Any]], *, limit: int = 12
+) -> dict[str, Any]:
+    event_list = [dict(event) for event in events]
+    counts_by_kind = Counter(str(event.get("event_kind") or "") for event in event_list)
+    counts_by_status = Counter(str(event.get("status") or "") for event in event_list if event.get("status"))
+    latest = event_list[-1] if event_list else None
+    return {
+        "schema_version": ROLLOUT_EVENT_SUMMARY_SCHEMA_VERSION,
+        "event_count": len(event_list),
+        "counts_by_kind": dict(sorted(counts_by_kind.items())),
+        "counts_by_status": dict(sorted(counts_by_status.items())),
+        "latest_event": _safe_event_view(latest) if latest else None,
+        "recent_events": [_safe_event_view(event) for event in event_list[-max(0, limit) :]],
+        "boundary": {
+            "raw_task_text_recorded": False,
+            "raw_logs_recorded": False,
+            "raw_trajectory_recorded": False,
+            "raw_session_transcript_recorded": False,
+            "credential_values_recorded": False,
+            "absolute_paths_recorded": False,
+        },
+    }

--- a/scripts/goal_rollout_event_log.py
+++ b/scripts/goal_rollout_event_log.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Append or summarize public-safe Goal Harness rollout events."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from goal_harness.paths import DEFAULT_RUNTIME_ROOT  # noqa: E402
+from goal_harness.rollout_event_log import (  # noqa: E402
+    build_rollout_event,
+    append_rollout_event,
+    load_rollout_events,
+    rollout_event_log_path,
+    summarize_rollout_events,
+)
+
+
+def _json_dump(payload: dict[str, Any], *, pretty: bool) -> None:
+    print(json.dumps(payload, ensure_ascii=False, indent=2 if pretty else None))
+
+
+def _details(values: list[str] | None) -> dict[str, str]:
+    details: dict[str, str] = {}
+    for value in values or []:
+        if "=" not in value:
+            raise SystemExit(f"--detail expects KEY=VALUE, got {value!r}")
+        key, raw = value.split("=", 1)
+        details[key] = raw
+    return details
+
+
+def _log_path(args: argparse.Namespace) -> Path:
+    if args.log_path:
+        return Path(args.log_path).expanduser()
+    return rollout_event_log_path(Path(args.runtime_root).expanduser(), args.goal_id)
+
+
+def handle_append(args: argparse.Namespace) -> int:
+    event = build_rollout_event(
+        goal_id=args.goal_id,
+        event_kind=args.event_kind,
+        agent_id=args.agent_id,
+        todo_id=args.todo_id,
+        benchmark_id=args.benchmark_id,
+        case_id=args.case_id,
+        run_id=args.run_id,
+        status=args.status,
+        classification=args.classification,
+        delivery_outcome=args.delivery_outcome,
+        labels=args.label,
+        summary=args.summary,
+        artifact_refs=args.artifact_ref,
+        details=_details(args.detail),
+        private_source_kind=args.private_source_kind,
+        private_source_count=args.private_source_count,
+    )
+    appended = append_rollout_event(_log_path(args), event)
+    _json_dump(appended, pretty=args.pretty)
+    return 0
+
+
+def handle_summarize(args: argparse.Namespace) -> int:
+    events = load_rollout_events(_log_path(args), limit=args.read_limit)
+    payload = summarize_rollout_events(events, limit=args.limit)
+    _json_dump(payload, pretty=args.pretty)
+    return 0
+
+
+def handle_observe_codex_sessions(args: argparse.Namespace) -> int:
+    session_root = Path(args.session_root).expanduser()
+    count = len(list(session_root.glob("**/*.jsonl"))) if session_root.exists() else 0
+    event = build_rollout_event(
+        goal_id=args.goal_id,
+        event_kind="codex_session_observed",
+        agent_id=args.agent_id,
+        todo_id=args.todo_id,
+        status="observed" if count else "missing",
+        summary=(
+            "Codex session directory shape observed as private source metadata; "
+            "raw session transcripts and file paths were not recorded."
+        ),
+        private_source_kind="codex_sessions_jsonl",
+        private_source_count=count,
+    )
+    appended = append_rollout_event(_log_path(args), event)
+    _json_dump(appended, pretty=args.pretty)
+    return 0
+
+
+def _add_common_path_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--goal-id", required=True)
+    parser.add_argument("--runtime-root", default=str(DEFAULT_RUNTIME_ROOT))
+    parser.add_argument("--log-path")
+    parser.add_argument("--pretty", action="store_true")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Record public-safe rollout events without raw sessions or logs."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    append_parser = subparsers.add_parser("append")
+    _add_common_path_args(append_parser)
+    append_parser.add_argument("--event-kind", required=True)
+    append_parser.add_argument("--agent-id")
+    append_parser.add_argument("--todo-id")
+    append_parser.add_argument("--benchmark-id")
+    append_parser.add_argument("--case-id")
+    append_parser.add_argument("--run-id")
+    append_parser.add_argument("--status")
+    append_parser.add_argument("--classification")
+    append_parser.add_argument("--delivery-outcome")
+    append_parser.add_argument("--summary")
+    append_parser.add_argument("--artifact-ref", action="append")
+    append_parser.add_argument("--label", action="append")
+    append_parser.add_argument("--detail", action="append")
+    append_parser.add_argument("--private-source-kind")
+    append_parser.add_argument("--private-source-count", type=int)
+    append_parser.set_defaults(func=handle_append)
+
+    summarize_parser = subparsers.add_parser("summarize")
+    _add_common_path_args(summarize_parser)
+    summarize_parser.add_argument("--limit", type=int, default=12)
+    summarize_parser.add_argument("--read-limit", type=int)
+    summarize_parser.set_defaults(func=handle_summarize)
+
+    sessions_parser = subparsers.add_parser("observe-codex-sessions")
+    _add_common_path_args(sessions_parser)
+    sessions_parser.add_argument("--agent-id")
+    sessions_parser.add_argument("--todo-id")
+    sessions_parser.add_argument("--session-root", default="~/.codex/sessions")
+    sessions_parser.set_defaults(func=handle_observe_codex_sessions)
+
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a public-safe Goal Harness rollout event log module for lifecycle events
- add a developer script to append/summarize events and observe Codex session sources without reading raw transcripts
- document the benchmark workflow and add a smoke covering boundary rejection

## Validation
- python3 examples/goal-rollout-event-log-smoke.py
- python3 -m py_compile goal_harness/rollout_event_log.py scripts/goal_rollout_event_log.py examples/goal-rollout-event-log-smoke.py
- goal-harness check
- git diff --check