### PR TITLE
fix: harden frontstage ops status sources

### DIFF
--- a/apps/dashboard/README.md
+++ b/apps/dashboard/README.md
@@ -64,7 +64,9 @@ For live local control-plane inspection, explicitly enter ops mode:
 `/frontstage?mode=ops&statusUrl=http://127.0.0.1:8766/status.json`. The route
 then reads `attention_queue.items[].goal_channel_projection` and stays
 read-only; if the feed is missing or has no projection, the bundled demo
-fixture remains visible. Do not use ops-mode URLs as public links.
+fixture remains visible. Ops-mode status sources are limited to relative or
+loopback URLs so public frontstage links do not silently pull external/private
+feeds. Do not use ops-mode URLs as public links.
 
 To create a public-safe static bundle for demos, Lark shares, or future GitHub
 Pages hosting, export the frontstage with the sanitized fixture:

--- a/apps/dashboard/smoke/frontstage-route-smoke.ts
+++ b/apps/dashboard/smoke/frontstage-route-smoke.ts
@@ -58,6 +58,10 @@ includes(frontstageSource, 'if (!liveMode)', "live status feed requires ops mode
 includes(frontstageSource, 'data-testid="frontstage-operations-strip"', "operations signal strip");
 includes(frontstageSource, 'data-testid="frontstage-goal-select"', "goal selector");
 includes(frontstageSource, "parseStatusPayload", "status payload parser");
+includes(frontstageSource, "resolveOpsStatusUrl", "ops status URL resolver");
+includes(frontstageSource, "isLoopbackHostname", "ops loopback source guard");
+includes(frontstageSource, "Ops statusUrl must be relative or loopback", "ops status URL guard copy");
+includes(frontstageSource, "Ops statusUrl accepts only relative or loopback sources.", "ops source guard helper copy");
 includes(frontstageSource, 'data-testid="frontstage-user-todos"', "user todo lane");
 includes(frontstageSource, 'data-testid="frontstage-agent-todos"', "agent todo lane");
 includes(frontstageSource, 'data-testid="frontstage-todo-discovery"', "todo discovery controls");

--- a/apps/dashboard/src/views/frontstage-page.tsx
+++ b/apps/dashboard/src/views/frontstage-page.tsx
@@ -131,6 +131,37 @@ function warningMessage(value: string | string[] | undefined) {
   return value ?? "compact source warning";
 }
 
+function isExplicitUrl(value: string) {
+  return /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(value) || value.startsWith("//");
+}
+
+function isLoopbackHostname(hostname: string) {
+  return ["localhost", "127.0.0.1", "::1", "[::1]"].includes(hostname);
+}
+
+function resolveOpsStatusUrl(value: string) {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return { error: "status URL is empty" };
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed, window.location.href);
+  } catch {
+    return { error: "status URL is invalid" };
+  }
+
+  const isRelative = !isExplicitUrl(trimmed);
+  if (!isRelative && !isLoopbackHostname(parsed.hostname)) {
+    return {
+      error: "Ops statusUrl must be relative or loopback; use showcase mode for public links.",
+    };
+  }
+
+  return { url: trimmed };
+}
+
 function artifactDisplayValue(value: string | number | boolean | null | undefined) {
   const text = stringifyScalar(value);
   return text.length > 96 ? `${text.slice(0, 93)}...` : text;
@@ -1045,9 +1076,12 @@ function FrontstageRoute({
                   className="h-9 w-full rounded-md border border-slate-200 bg-white px-3 text-xs text-slate-900 shadow-sm outline-none focus:ring-2 focus:ring-slate-400"
                   data-testid="frontstage-status-url-input"
                   onChange={(event) => setStatusUrl(event.target.value)}
-                  placeholder="/status.local.json"
+                  placeholder="/status.local.json or http://127.0.0.1:8766/status.json"
                   value={statusUrl}
                 />
+                <div className="text-[11px] font-medium leading-5 text-slate-500">
+                  Ops statusUrl accepts only relative or loopback sources.
+                </div>
                 <div className="flex gap-2">
                   <Button
                     className="flex-1"
@@ -1435,22 +1469,24 @@ export function FrontstagePage() {
       return;
     }
     const trimmed = url.trim();
-    if (!trimmed) {
-      setLoadError("status URL is empty");
+    const resolvedStatusUrl = resolveOpsStatusUrl(trimmed);
+    if (resolvedStatusUrl.error || !resolvedStatusUrl.url) {
+      setLoadError(resolvedStatusUrl.error ?? "status URL is invalid");
       return;
     }
+    const loadUrl = resolvedStatusUrl.url;
     setIsLoading(true);
     setLoadError(null);
     try {
-      const response = await fetch(trimmed, { cache: "no-store" });
+      const response = await fetch(loadUrl, { cache: "no-store" });
       if (!response.ok) {
-        throw new Error(`HTTP ${response.status} while loading ${trimmed}`);
+        throw new Error(`HTTP ${response.status} while loading ${loadUrl}`);
       }
       const nextPayload = parseStatusPayload(await response.json());
       const nextOptions = projectionOptionsFromPayload(nextPayload);
       setPayload(nextPayload);
-      setSource({ kind: "url", label: trimmed });
-      setStatusUrl(trimmed);
+      setSource({ kind: "url", label: loadUrl });
+      setStatusUrl(loadUrl);
       if (nextOptions.length === 0) {
         setLoadError("status feed has no goal_channel_projection items; showing demo fixture");
       }
@@ -1458,7 +1494,7 @@ export function FrontstagePage() {
         await updateSearch({
           goalId: nextOptions[0]?.goalId ?? "",
           mode: "ops",
-          statusUrl: trimmed,
+          statusUrl: loadUrl,
         });
       }
     } catch (error) {

--- a/examples/dashboard-frontstage-browser-smoke.mjs
+++ b/examples/dashboard-frontstage-browser-smoke.mjs
@@ -476,6 +476,7 @@ async function main() {
         [
           "ops live",
           "live status feed",
+          "Ops statusUrl accepts only relative or loopback sources.",
           "Live Goal Channel",
           "goal_channel_projection_v0",
           "Always-on agent operations",
@@ -537,6 +538,13 @@ async function main() {
       if (selectedUrl.searchParams.get("goalId") !== "live-goal-b") {
         throw new Error(`Goal selector did not update URL: ${desktopPage.url()}`);
       }
+      await desktopPage.locator('[data-testid="frontstage-status-url-input"]').fill("https://example.com/status.json");
+      await desktopPage.locator('[data-testid="frontstage-load-status-url"]').click();
+      const loadErrorText = await desktopPage.locator('[data-testid="frontstage-load-error"]').innerText();
+      if (!loadErrorText.includes("Ops statusUrl must be relative or loopback")) {
+        throw new Error(`External ops statusUrl was not rejected locally: ${loadErrorText}`);
+      }
+      await desktopPage.locator('[data-testid="frontstage-reset-demo"]').click();
       await captureFrontstage(desktopPage, `${baseUrl}/frontstage`, "desktop-frontstage-after-ops-reset", [
         "Goal Harness Showcase Frontstage",
         "showcase mode",


### PR DESCRIPTION
## Summary
- restrict frontstage ops statusUrl loading to relative or loopback sources
- add user-facing helper copy for the source boundary
- extend route/browser smokes to cover external URL rejection without affecting showcase mode

## Validation
- npm run smoke:frontstage-route
- npm run smoke:frontstage-browser
- npm run build
- python3 -m goal_harness.cli check --scan-path apps/dashboard --scan-path examples/dashboard-frontstage-browser-smoke.mjs
- git diff --check origin/main...HEAD

## Boundary
- public dashboard code/docs/smokes only
- no live registry exports, local status JSON, credentials, or private/internal project data committed