### PR TITLE
Log core CLI rollout events automatically

### DIFF
--- a/docs/benchmark-developer-workflow.md
+++ b/docs/benchmark-developer-workflow.md
@@ -136,7 +136,15 @@ you need to explain the lifecycle of a case or an agent workflow:
 - `codex_session_observed`: a private Codex session source exists, but raw
   session contents and file paths are not recorded.
 
-Append one compact event at important transitions:
+Core Goal Harness CLI lifecycle commands append compact events automatically:
+`todo` transitions, `refresh-state`, and `quota should-run` /
+`quota monitor-poll` / `quota spend-slot` / `quota void-slot` all write to the
+rollout event log when they run through the CLI. This makes the log closer to a
+Codex session ledger for Goal Harness itself: agents do not need to remember to
+record routine GH control-plane transitions by hand.
+
+Use the script for external benchmark transitions, backfills, or operator-side
+facts that happen outside those core CLI paths:
 
 ```bash
 python3 scripts/goal_rollout_event_log.py append \

--- a/examples/goal-rollout-event-log-smoke.py
+++ b/examples/goal-rollout-event-log-smoke.py
@@ -58,9 +58,79 @@ def run_script(*args: str) -> dict:
     return json.loads(result.stdout)
 
 
+def run_goal_harness_cli(*args: str, allow_failure: bool = False) -> dict:
+    result = subprocess.run(
+        [sys.executable, "-m", "goal_harness.cli", *args],
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode != 0 and not allow_failure:
+        raise AssertionError(
+            f"goal_harness.cli failed rc={result.returncode}\n"
+            f"stdout={result.stdout}\nstderr={result.stderr}"
+        )
+    assert_public_safe_text(result.stdout)
+    return json.loads(result.stdout)
+
+
+def write_smoke_project(tmp_root: Path) -> tuple[Path, Path, Path, str]:
+    runtime_root = tmp_root / "runtime"
+    project = tmp_root / "project"
+    project.mkdir(parents=True)
+    goal_id = "rollout-log-smoke"
+    state_file = project / "ACTIVE_GOAL_STATE.md"
+    state_file.write_text(
+        """---
+status: smoke
+updated_at: 2026-06-21T00:00:00+08:00
+---
+
+# Rollout Log Smoke
+
+## Next Action
+
+- [P0] Exercise automatic rollout logging.
+
+## Agent Todo
+
+- [ ] [P0] Claim the smoke todo.
+  <!-- goal-harness:todo todo_id=todo_auto_rollout status=open task_class=advancement_task action_kind=smoke -->
+""",
+        encoding="utf-8",
+    )
+    registry_path = tmp_root / "registry.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "common_runtime_root": str(runtime_root),
+                "goals": [
+                    {
+                        "id": goal_id,
+                        "domain": "smoke",
+                        "status": "active-read-only",
+                        "repo": str(project),
+                        "state_file": "ACTIVE_GOAL_STATE.md",
+                        "coordination": {
+                            "primary_agent": "codex-main-control",
+                            "registered_agents": ["codex-main-control"],
+                        },
+                    }
+                ],
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return registry_path, runtime_root, project, goal_id
+
+
 def main() -> None:
     with tempfile.TemporaryDirectory(prefix="goal-harness-rollout-event-log-") as tmp:
-        runtime_root = Path(tmp) / "runtime"
+        tmp_root = Path(tmp)
+        runtime_root = tmp_root / "runtime"
         goal_id = "goal-harness-meta"
         log_path = rollout_event_log_path(runtime_root, goal_id)
         event = build_rollout_event(
@@ -168,6 +238,79 @@ def main() -> None:
             raise AssertionError("raw/private detail keys must be rejected")
 
         assert_public_safe_text(log_path.read_text(encoding="utf-8"))
+
+        registry_path, cli_runtime_root, project, cli_goal_id = write_smoke_project(tmp_root / "auto")
+        claim_payload = run_goal_harness_cli(
+            "--registry",
+            str(registry_path),
+            "--runtime-root",
+            str(cli_runtime_root),
+            "--format",
+            "json",
+            "todo",
+            "claim",
+            "--goal-id",
+            cli_goal_id,
+            "--todo-id",
+            "todo_auto_rollout",
+            "--claimed-by",
+            "codex-main-control",
+        )
+        assert claim_payload["rollout_event"]["event_kind"] == "todo_claim", claim_payload
+
+        refresh_payload = run_goal_harness_cli(
+            "--registry",
+            str(registry_path),
+            "--runtime-root",
+            str(cli_runtime_root),
+            "--format",
+            "json",
+            "refresh-state",
+            "--goal-id",
+            cli_goal_id,
+            "--classification",
+            "automatic_rollout_logging_smoke",
+            "--delivery-batch-scale",
+            "implementation",
+            "--delivery-outcome",
+            "outcome_progress",
+            "--agent-id",
+            "codex-main-control",
+            "--agent-lane",
+            "smoke",
+            "--no-global-sync",
+        )
+        assert refresh_payload["rollout_event"]["event_kind"] == "refresh_state", refresh_payload
+
+        should_run_payload = run_goal_harness_cli(
+            "--registry",
+            str(registry_path),
+            "--runtime-root",
+            str(cli_runtime_root),
+            "--format",
+            "json",
+            "quota",
+            "should-run",
+            "--goal-id",
+            cli_goal_id,
+            "--agent-id",
+            "codex-main-control",
+            "--scan-root",
+            str(project),
+            "--limit",
+            "1",
+            allow_failure=True,
+        )
+        assert should_run_payload["rollout_event"]["event_kind"] == (
+            "quota_should_run"
+        ), should_run_payload
+        auto_events = load_rollout_events(rollout_event_log_path(cli_runtime_root, cli_goal_id))
+        auto_kinds = [event["event_kind"] for event in auto_events]
+        assert auto_kinds == ["todo_claim", "refresh_state", "quota_should_run"], auto_kinds
+        auto_log_text = rollout_event_log_path(cli_runtime_root, cli_goal_id).read_text(
+            encoding="utf-8"
+        )
+        assert_public_safe_text(auto_log_text)
 
 
 if __name__ == "__main__":

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -206,6 +206,11 @@ from .registry import (
     render_registry_markdown,
     resolve_state_file,
 )
+from .rollout_event_log import (
+    append_rollout_event,
+    build_rollout_event,
+    rollout_event_log_path,
+)
 from .runtime import archive_runtime_goal, render_archive_runtime_markdown
 from .state_refresh import (
     DEFAULT_REFRESH_ACTION,
@@ -1798,6 +1803,66 @@ def fallback_global_registry(registry_path: Path, runtime_root_arg: str | None) 
 def explicit_global_registry(runtime_root_arg: str | None) -> Path:
     runtime_root = Path(runtime_root_arg).expanduser() if runtime_root_arg else DEFAULT_RUNTIME_ROOT
     return global_registry_path(runtime_root)
+
+
+def append_cli_rollout_event(
+    payload: dict[str, object],
+    *,
+    registry_path: Path,
+    runtime_root_arg: str | None,
+    event_kind: str,
+    agent_id: str | None = None,
+    todo_id: str | None = None,
+    status: str | None = None,
+    summary: str | None = None,
+    details: dict[str, object] | None = None,
+    allow_failed: bool = False,
+) -> dict[str, object]:
+    """Append a compact rollout event for core CLI lifecycle commands.
+
+    Rollout logging is intentionally best-effort so the diagnostic log cannot
+    turn a successful state transition into a failed CLI command. Failures are
+    surfaced in the command payload as compact metadata.
+    """
+
+    if not payload.get("ok") and not allow_failed:
+        return payload
+    goal_id = str(payload.get("goal_id") or "").strip()
+    if not goal_id:
+        return payload
+    try:
+        runtime_root_value = payload.get("runtime_root")
+        if runtime_root_value:
+            runtime_root = Path(str(runtime_root_value)).expanduser()
+        else:
+            registry = load_registry(registry_path)
+            runtime_root = resolve_runtime_root(registry, runtime_root_arg)
+        event = build_rollout_event(
+            goal_id=goal_id,
+            event_kind=event_kind,
+            agent_id=agent_id or str(payload.get("agent_id") or "").strip() or None,
+            todo_id=todo_id or str(payload.get("todo_id") or "").strip() or None,
+            status=status,
+            classification=str(payload.get("classification") or "").strip() or None,
+            delivery_outcome=str(payload.get("delivery_outcome") or "").strip() or None,
+            summary=summary,
+            details=details,
+        )
+        appended = append_rollout_event(rollout_event_log_path(runtime_root, goal_id), event)
+        payload["rollout_event"] = {
+            "schema_version": appended["schema_version"],
+            "event_id": appended["event_id"],
+            "event_kind": appended["event_kind"],
+            "recorded_at": appended["recorded_at"],
+            "status": appended.get("status"),
+        }
+    except Exception as exc:
+        payload["rollout_event_log_error"] = {
+            "recorded": False,
+            "error_type": type(exc).__name__,
+            "message": "rollout event append failed; primary command payload remains authoritative",
+        }
+    return payload
 
 
 def resolve_heartbeat_active_state(
@@ -9464,6 +9529,28 @@ def main(argv: list[str] | None = None) -> int:
                 "dry_run": bool(args.dry_run),
                 "error": str(exc),
             }
+        if payload.get("ok") and payload.get("appended") and not payload.get("dry_run"):
+            append_cli_rollout_event(
+                payload,
+                registry_path=registry_path,
+                runtime_root_arg=args.runtime_root,
+                event_kind="refresh_state",
+                agent_id=args.agent_id,
+                status="appended",
+                summary=(
+                    "refresh-state appended compact control-plane state with "
+                    f"classification={payload.get('classification')}"
+                ),
+                details={
+                    "command": "refresh-state",
+                    "progress_scope": payload.get("progress_scope") or "",
+                    "agent_lane": payload.get("agent_lane") or "",
+                    "global_sync_wrote": bool(
+                        isinstance(payload.get("global_sync"), dict)
+                        and payload["global_sync"].get("wrote")
+                    ),
+                },
+            )
         print_payload(payload, args.format, render_state_refresh_markdown)
         return 0 if payload.get("ok") else 1
 
@@ -9884,6 +9971,36 @@ def main(argv: list[str] | None = None) -> int:
                 "todo": args.text or "",
                 "error": str(exc),
             }
+        todo_event_kinds = {
+            "add": "todo_add",
+            "claim": "todo_claim",
+            "update": "todo_update",
+            "complete": "todo_complete",
+            "supersede": "todo_supersede",
+            "archive-completed": "todo_archive_completed",
+        }
+        if payload.get("ok") and not payload.get("dry_run"):
+            append_cli_rollout_event(
+                payload,
+                registry_path=registry_path,
+                runtime_root_arg=args.runtime_root,
+                event_kind=todo_event_kinds.get(args.todo_command, "todo_update"),
+                agent_id=args.claimed_by,
+                todo_id=args.todo_id or str(payload.get("todo_id") or "").strip() or None,
+                status=str(payload.get("status") or args.todo_command or "").strip(),
+                summary=(
+                    f"todo {args.todo_command} recorded for "
+                    f"{payload.get('todo_id') or args.todo_id or 'unstructured todo'}"
+                ),
+                details={
+                    "command": "todo",
+                    "todo_command": args.todo_command,
+                    "role": payload.get("role") or args.role or "",
+                    "changed": bool(payload.get("changed")),
+                    "added": bool(payload.get("added")),
+                    "already_exists": bool(payload.get("already_exists")),
+                },
+            )
         print_payload(payload, args.format, render_todo_markdown)
         return 0 if payload.get("ok") else 1
 
@@ -9993,6 +10110,48 @@ def main(argv: list[str] | None = None) -> int:
                         }
                     ],
                 }
+        quota_event_kinds = {
+            "should-run": "quota_should_run",
+            "monitor-poll": "quota_monitor_poll",
+            "spend-slot": "quota_spend",
+            "void-slot": "quota_void",
+        }
+        should_log_quota = (
+            args.quota_command in quota_event_kinds
+            and (
+                args.quota_command == "should-run"
+                or (payload.get("ok") and bool(payload.get("appended")))
+            )
+        )
+        if should_log_quota:
+            append_cli_rollout_event(
+                payload,
+                registry_path=registry_path,
+                runtime_root_arg=args.runtime_root,
+                event_kind=quota_event_kinds[args.quota_command],
+                agent_id=args.agent_id,
+                status=str(
+                    payload.get("effective_action")
+                    or payload.get("decision")
+                    or payload.get("mode")
+                    or args.quota_command
+                ),
+                summary=(
+                    f"quota {args.quota_command} decision="
+                    f"{payload.get('decision') or payload.get('mode')} "
+                    f"state={payload.get('state') or ''}"
+                ),
+                details={
+                    "command": "quota",
+                    "quota_command": args.quota_command,
+                    "ok": bool(payload.get("ok")),
+                    "should_run": bool(payload.get("should_run")),
+                    "appended": bool(payload.get("appended")),
+                    "slots": payload.get("slots") or "",
+                    "source": payload.get("source") or "",
+                },
+                allow_failed=args.quota_command == "should-run",
+            )
         renderer = (
             render_quota_should_run_markdown
             if args.quota_command == "should-run"

--- a/goal_harness/rollout_event_log.py
+++ b/goal_harness/rollout_event_log.py
@@ -20,10 +20,17 @@ ROLLOUT_EVENT_KINDS = {
     "compact_case_result",
     "failure_attribution",
     "pr_merge",
+    "quota_monitor_poll",
     "quota_should_run",
     "quota_spend",
+    "quota_void",
     "refresh_state",
+    "todo_add",
+    "todo_archive_completed",
     "todo_claim",
+    "todo_complete",
+    "todo_supersede",
+    "todo_update",
     "validation",
 }
 


### PR DESCRIPTION
## Summary
- auto-append public-safe rollout events from core Goal Harness CLI lifecycle paths
- record quota should-run decisions, todo transitions, refresh-state writes, and quota monitor/spend/void transitions
- extend rollout event smoke to run real CLI commands against a temp registry/runtime and verify automatic log entries
- clarify benchmark workflow docs: scripts are for external/backfill events, not the primary GH logging path

## Validation
- python3 examples/goal-rollout-event-log-smoke.py
- python3 -m py_compile goal_harness/cli.py goal_harness/rollout_event_log.py scripts/goal_rollout_event_log.py examples/goal-rollout-event-log-smoke.py
- goal-harness check
- git diff --check