### PR TITLE
Log benchmark compact writebacks in rollout events

### DIFF
--- a/docs/benchmark-developer-workflow.md
+++ b/docs/benchmark-developer-workflow.md
@@ -143,6 +143,15 @@ rollout event log when they run through the CLI. This makes the log closer to a
 Codex session ledger for Goal Harness itself: agents do not need to remember to
 record routine GH control-plane transitions by hand.
 
+Compact benchmark history writes also append automatically when they are
+executed through the CLI. `goal-harness history append-benchmark-run
+--execute`, `goal-harness history append-benchmark-result --execute`, and the
+`goal-harness benchmark ... --execute` fixture/ingest path write
+`compact_case_result` or `compact_blocker` events derived only from the compact
+`benchmark_run_v0` / `benchmark_result_v0` payload. This is the default path for
+case-level observation: launch/poll scripts may keep their own private raw
+artifacts, but Goal Harness should observe the public-safe compact writeback.
+
 Use the script for external benchmark transitions, backfills, or operator-side
 facts that happen outside those core CLI paths:
 

--- a/examples/goal-rollout-event-log-smoke.py
+++ b/examples/goal-rollout-event-log-smoke.py
@@ -304,9 +304,82 @@ def main() -> None:
         assert should_run_payload["rollout_event"]["event_kind"] == (
             "quota_should_run"
         ), should_run_payload
+
+        benchmark_run_path = tmp_root / "auto" / "benchmark-run.json"
+        benchmark_run_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": "benchmark_run_v0",
+                    "benchmark_id": "terminal-bench@2.0",
+                    "case_id": "build-cython-ext",
+                    "source_runner": "harbor",
+                    "mode": "codex-goal-mode",
+                    "progress": {
+                        "n_completed_trials": 1,
+                        "n_total_trials": 1,
+                    },
+                    "official_task_score": {
+                        "kind": "official_score",
+                        "value": 0.0,
+                        "passed": False,
+                    },
+                    "score_failure_attribution": (
+                        "official_verifier_solution_failure"
+                    ),
+                    "trials": [
+                        {
+                            "task_id": "build-cython-ext",
+                            "trial_name": "build-cython-ext-baseline",
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        benchmark_payload = run_goal_harness_cli(
+            "--registry",
+            str(registry_path),
+            "--runtime-root",
+            str(cli_runtime_root),
+            "--format",
+            "json",
+            "history",
+            "append-benchmark-run",
+            "--goal-id",
+            cli_goal_id,
+            "--benchmark-run-json",
+            str(benchmark_run_path),
+            "--classification",
+            "benchmark_run_v0",
+            "--delivery-batch-scale",
+            "implementation",
+            "--delivery-outcome",
+            "outcome_progress",
+            "--execute",
+            "--no-global-sync",
+        )
+        assert benchmark_payload["rollout_event"]["event_kind"] == (
+            "compact_blocker"
+        ), benchmark_payload
+        assert benchmark_payload["rollout_event"]["status"] == (
+            "precise_blocker"
+        ), benchmark_payload
+
         auto_events = load_rollout_events(rollout_event_log_path(cli_runtime_root, cli_goal_id))
         auto_kinds = [event["event_kind"] for event in auto_events]
-        assert auto_kinds == ["todo_claim", "refresh_state", "quota_should_run"], auto_kinds
+        assert auto_kinds == [
+            "todo_claim",
+            "refresh_state",
+            "quota_should_run",
+            "compact_blocker",
+        ], auto_kinds
+        latest_event = auto_events[-1]
+        assert latest_event["benchmark_id"] == "terminal-bench@2.0", latest_event
+        assert latest_event["case_id"] == "build-cython-ext", latest_event
+        assert_boundary(latest_event)
         auto_log_text = rollout_event_log_path(cli_runtime_root, cli_goal_id).read_text(
             encoding="utf-8"
         )

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -1813,8 +1813,13 @@ def append_cli_rollout_event(
     event_kind: str,
     agent_id: str | None = None,
     todo_id: str | None = None,
+    benchmark_id: str | None = None,
+    case_id: str | None = None,
+    run_id: str | None = None,
     status: str | None = None,
     summary: str | None = None,
+    labels: list[str] | None = None,
+    artifact_refs: list[str] | None = None,
     details: dict[str, object] | None = None,
     allow_failed: bool = False,
 ) -> dict[str, object]:
@@ -1842,10 +1847,15 @@ def append_cli_rollout_event(
             event_kind=event_kind,
             agent_id=agent_id or str(payload.get("agent_id") or "").strip() or None,
             todo_id=todo_id or str(payload.get("todo_id") or "").strip() or None,
+            benchmark_id=benchmark_id,
+            case_id=case_id,
+            run_id=run_id,
             status=status,
             classification=str(payload.get("classification") or "").strip() or None,
             delivery_outcome=str(payload.get("delivery_outcome") or "").strip() or None,
+            labels=labels,
             summary=summary,
+            artifact_refs=artifact_refs,
             details=details,
         )
         appended = append_rollout_event(rollout_event_log_path(runtime_root, goal_id), event)
@@ -1863,6 +1873,225 @@ def append_cli_rollout_event(
             "message": "rollout event append failed; primary command payload remains authoritative",
         }
     return payload
+
+
+def _compact_benchmark_rollout_label(value: object, *, limit: int = 180) -> str | None:
+    if value is None:
+        return None
+    text = " ".join(str(value).split())
+    if not text:
+        return None
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 1)].rstrip() + "..."
+
+
+def _first_benchmark_trial_value(
+    benchmark_record: dict[str, object],
+    key: str,
+) -> object | None:
+    trials = benchmark_record.get("trials")
+    if not isinstance(trials, list):
+        return None
+    for trial in trials:
+        if isinstance(trial, dict) and trial.get(key) is not None:
+            return trial.get(key)
+    return None
+
+
+def _benchmark_rollout_case_id(benchmark_record: dict[str, object]) -> str | None:
+    return _compact_benchmark_rollout_label(
+        benchmark_record.get("case_id")
+        or benchmark_record.get("task_id")
+        or _first_benchmark_trial_value(benchmark_record, "task_id")
+        or benchmark_record.get("scenario_id")
+    )
+
+
+def _benchmark_official_score_summary(
+    benchmark_record: dict[str, object],
+) -> tuple[object | None, object | None, str | None]:
+    official = benchmark_record.get("official_task_score")
+    if isinstance(official, dict):
+        return (
+            official.get("value"),
+            official.get("passed"),
+            _compact_benchmark_rollout_label(
+                official.get("status") or official.get("kind")
+            ),
+        )
+    return (
+        benchmark_record.get("official_score"),
+        benchmark_record.get("official_score_passed"),
+        _compact_benchmark_rollout_label(benchmark_record.get("official_score_status")),
+    )
+
+
+def _benchmark_rollout_status(benchmark_record: dict[str, object]) -> str:
+    failure_attribution = _compact_benchmark_rollout_label(
+        benchmark_record.get("score_failure_attribution")
+        or benchmark_record.get("failure_attribution")
+    )
+    score, passed, score_status = _benchmark_official_score_summary(benchmark_record)
+    if failure_attribution and failure_attribution not in {
+        "none",
+        "no_score_failure",
+    }:
+        return "precise_blocker"
+    if passed is True:
+        return "passed"
+    if passed is False:
+        return "failed"
+    if score_status == "not_run":
+        return "not_run"
+    runner_status = _compact_benchmark_rollout_label(
+        benchmark_record.get("runner_return_status")
+        or benchmark_record.get("terminal_state")
+    )
+    if runner_status:
+        return runner_status
+    if score is not None:
+        return "scored"
+    return "appended"
+
+
+def _benchmark_rollout_event_kind(benchmark_record: dict[str, object]) -> str:
+    return (
+        "compact_blocker"
+        if _benchmark_rollout_status(benchmark_record) == "precise_blocker"
+        else "compact_case_result"
+    )
+
+
+def _benchmark_rollout_labels(benchmark_record: dict[str, object]) -> list[str]:
+    labels: list[str] = []
+    for value in (
+        benchmark_record.get("mode"),
+        benchmark_record.get("source_runner"),
+        benchmark_record.get("runner_return_status"),
+        benchmark_record.get("official_score_status"),
+        benchmark_record.get("score_failure_attribution"),
+        benchmark_record.get("failure_attribution"),
+    ):
+        label = _compact_benchmark_rollout_label(value, limit=80)
+        if label and label not in labels:
+            labels.append(label)
+    return labels
+
+
+def _benchmark_rollout_details(
+    benchmark_record: dict[str, object],
+    *,
+    command: str,
+    action: str | None = None,
+) -> dict[str, object]:
+    score, passed, score_status = _benchmark_official_score_summary(benchmark_record)
+    progress = (
+        benchmark_record.get("progress")
+        if isinstance(benchmark_record.get("progress"), dict)
+        else {}
+    )
+    trials = benchmark_record.get("trials")
+    return {
+        "command": command,
+        "action": action or "",
+        "mode": benchmark_record.get("mode") or "",
+        "source_runner": benchmark_record.get("source_runner") or "",
+        "runner_status": benchmark_record.get("runner_return_status") or "",
+        "score_status": score_status or "",
+        "official_score": score if isinstance(score, (int, float)) else "",
+        "official_passed": passed if isinstance(passed, bool) else "",
+        "failure_attribution": benchmark_record.get("score_failure_attribution")
+        or benchmark_record.get("failure_attribution")
+        or "",
+        "trial_count": len(trials) if isinstance(trials, list) else "",
+        "progress_completed": progress.get("n_completed_trials") or "",
+        "progress_total": progress.get("n_total_trials") or "",
+    }
+
+
+def append_benchmark_run_rollout_event(
+    payload: dict[str, object],
+    *,
+    registry_path: Path,
+    runtime_root_arg: str | None,
+    command: str,
+    action: str | None = None,
+) -> dict[str, object]:
+    benchmark_run = (
+        payload.get("benchmark_run")
+        if isinstance(payload.get("benchmark_run"), dict)
+        else {}
+    )
+    if not benchmark_run or payload.get("dry_run") or not payload.get("appended"):
+        return payload
+    benchmark_id = _compact_benchmark_rollout_label(benchmark_run.get("benchmark_id"))
+    case_id = _benchmark_rollout_case_id(benchmark_run)
+    status = _benchmark_rollout_status(benchmark_run)
+    return append_cli_rollout_event(
+        payload,
+        registry_path=registry_path,
+        runtime_root_arg=runtime_root_arg,
+        event_kind=_benchmark_rollout_event_kind(benchmark_run),
+        benchmark_id=benchmark_id,
+        case_id=case_id,
+        run_id=_compact_benchmark_rollout_label(payload.get("generated_at")),
+        status=status,
+        summary=(
+            "benchmark_run compact lifecycle event recorded: "
+            f"benchmark={benchmark_id or 'unknown'} "
+            f"case={case_id or 'unknown'} status={status}"
+        ),
+        labels=_benchmark_rollout_labels(benchmark_run),
+        details=_benchmark_rollout_details(
+            benchmark_run,
+            command=command,
+            action=action,
+        ),
+    )
+
+
+def append_benchmark_result_rollout_event(
+    payload: dict[str, object],
+    *,
+    registry_path: Path,
+    runtime_root_arg: str | None,
+    command: str,
+    action: str | None = None,
+) -> dict[str, object]:
+    benchmark_result = (
+        payload.get("benchmark_result")
+        if isinstance(payload.get("benchmark_result"), dict)
+        else {}
+    )
+    if not benchmark_result or payload.get("dry_run") or not payload.get("appended"):
+        return payload
+    benchmark_id = _compact_benchmark_rollout_label(
+        benchmark_result.get("benchmark_id") or "benchmark_result"
+    )
+    case_id = _benchmark_rollout_case_id(benchmark_result)
+    status = _benchmark_rollout_status(benchmark_result)
+    return append_cli_rollout_event(
+        payload,
+        registry_path=registry_path,
+        runtime_root_arg=runtime_root_arg,
+        event_kind=_benchmark_rollout_event_kind(benchmark_result),
+        benchmark_id=benchmark_id,
+        case_id=case_id,
+        run_id=_compact_benchmark_rollout_label(payload.get("generated_at")),
+        status=status,
+        summary=(
+            "benchmark_result compact lifecycle event recorded: "
+            f"benchmark={benchmark_id or 'unknown'} "
+            f"case={case_id or 'unknown'} status={status}"
+        ),
+        labels=_benchmark_rollout_labels(benchmark_result),
+        details=_benchmark_rollout_details(
+            benchmark_result,
+            command=command,
+            action=action,
+        ),
+    )
 
 
 def resolve_heartbeat_active_state(
@@ -8902,6 +9131,13 @@ def main(argv: list[str] | None = None) -> int:
                         goal_id=args.goal_id,
                         dry_run=dry_run,
                     )
+                append_benchmark_run_rollout_event(
+                    payload,
+                    registry_path=registry_path,
+                    runtime_root_arg=args.runtime_root,
+                    command="benchmark",
+                    action=args.benchmark_name,
+                )
             except Exception as exc:
                 payload = {
                     "ok": False,
@@ -9035,6 +9271,13 @@ def main(argv: list[str] | None = None) -> int:
                         goal_id=args.goal_id,
                         dry_run=dry_run,
                     )
+                append_benchmark_run_rollout_event(
+                    payload,
+                    registry_path=registry_path,
+                    runtime_root_arg=args.runtime_root,
+                    command="history",
+                    action="append-benchmark-run",
+                )
             except Exception as exc:
                 payload = {
                     "ok": False,
@@ -9094,6 +9337,13 @@ def main(argv: list[str] | None = None) -> int:
                         goal_id=args.goal_id,
                         dry_run=dry_run,
                     )
+                append_benchmark_result_rollout_event(
+                    payload,
+                    registry_path=registry_path,
+                    runtime_root_arg=args.runtime_root,
+                    command="history",
+                    action="append-benchmark-result",
+                )
             except Exception as exc:
                 payload = {
                     "ok": False,


### PR DESCRIPTION
## Summary
- Append rollout events automatically when compact benchmark_run_v0 / benchmark_result_v0 writebacks are executed through Goal Harness CLI.
- Derive case-level compact_case_result / compact_blocker metadata from public-safe benchmark payloads only.
- Extend the rollout event log smoke and developer workflow docs for the benchmark writeback path.

## Validation
- python3 examples/goal-rollout-event-log-smoke.py
- python3 -m py_compile goal_harness/cli.py goal_harness/rollout_event_log.py examples/goal-rollout-event-log-smoke.py scripts/goal_rollout_event_log.py
- python3 examples/autonomous-replan-obligation-smoke.py
- goal-harness check --scan-path goal_harness/cli.py --scan-path examples/goal-rollout-event-log-smoke.py --scan-path docs/benchmark-developer-workflow.md
- git diff --check

## Boundary
- No raw task text, raw logs, trajectories, Codex session transcripts, credentials, benchmark run dirs, or local absolute evidence paths are added.
- Rollout events are derived from compact public-safe benchmark_run_v0 / benchmark_result_v0 payloads.