### PR TITLE
Record benchmark status snapshots in rollout log

### DIFF
--- a/docs/benchmark-developer-workflow.md
+++ b/docs/benchmark-developer-workflow.md
@@ -112,6 +112,9 @@ python3 scripts/benchmark_run_status_snapshot.py \
   --label <terminal-bench-run-label> \
   --label <skillsbench-run-label> \
   --label <swe-marathon-run-label> \
+  --record-rollout-event \
+  --goal-id goal-harness-meta \
+  --agent-id codex-main-control \
   --pattern Working \
   --pattern timed\ out \
   --pretty
@@ -119,7 +122,10 @@ python3 scripts/benchmark_run_status_snapshot.py \
 
 The snapshot reports `status.env`, pid liveness, compact result summaries,
 standard artifact presence, and optional keyword booleans for tmux captures. It
-does not emit task text, trajectories, raw logs, or capture content.
+does not emit task text, trajectories, raw logs, or capture content. With
+`--record-rollout-event`, it also appends one aggregate `benchmark_status`
+event to the rollout log so the control plane can see that a poll happened
+without seeing host paths or capture text.
 
 ### Goal Rollout Event Log
 

--- a/examples/benchmark-run-status-snapshot-smoke.py
+++ b/examples/benchmark-run-status-snapshot-smoke.py
@@ -6,11 +6,21 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import sys
 import tempfile
 from pathlib import Path
 
 
 REPO = Path(__file__).resolve().parents[1]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+from goal_harness.rollout_event_log import (  # noqa: E402
+    load_rollout_events,
+    rollout_event_log_path,
+)
+
+
 SCRIPT = REPO / "scripts" / "benchmark_run_status_snapshot.py"
 
 
@@ -101,6 +111,49 @@ def main() -> int:
         assert item["capture_files"][0]["patterns"]["Working"] is True
         assert "secret raw transcript" not in proc.stdout
         assert str(root) not in proc.stdout
+
+        runtime_root = root / "runtime"
+        rollout_proc = subprocess.run(
+            [
+                "python3",
+                str(SCRIPT),
+                "--run-root",
+                str(root),
+                "--label",
+                "terminal-case-r1",
+                "--pattern",
+                "Working",
+                "--record-rollout-event",
+                "--goal-id",
+                "rollout-status-smoke",
+                "--runtime-root",
+                str(runtime_root),
+                "--agent-id",
+                "codex-main-control",
+                "--todo-id",
+                "todo_status_smoke",
+                "--pretty",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        rollout_payload = json.loads(rollout_proc.stdout)
+        assert rollout_payload["rollout_event"]["event_kind"] == "benchmark_status"
+        assert rollout_payload["rollout_event"]["status"] == "running"
+        assert str(root) not in rollout_proc.stdout
+        events = load_rollout_events(
+            rollout_event_log_path(runtime_root, "rollout-status-smoke")
+        )
+        assert len(events) == 1, events
+        event = events[0]
+        assert event["event_kind"] == "benchmark_status", event
+        assert event["status"] == "running", event
+        assert event["details"]["run_count"] == 1, event
+        assert event["details"]["pid_alive_count"] == 1, event
+        assert event["details"]["compact_result_count"] == 2, event
+        assert event["boundary"]["raw_logs_recorded"] is False, event
+        assert event["boundary"]["absolute_paths_recorded"] is False, event
 
     print("benchmark run status snapshot smoke passed")
     return 0

--- a/scripts/benchmark_run_status_snapshot.py
+++ b/scripts/benchmark_run_status_snapshot.py
@@ -6,9 +6,21 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import sys
 import time
 from pathlib import Path
 from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from goal_harness.rollout_event_log import (  # noqa: E402
+    append_rollout_event,
+    build_rollout_event,
+    rollout_event_log_path,
+)
 
 
 DEFAULT_COMPACT_KEYS = (
@@ -178,6 +190,95 @@ def build_snapshot(
     }
 
 
+def _snapshot_rollout_status(payload: dict[str, Any]) -> str:
+    runs = payload.get("runs") if isinstance(payload.get("runs"), list) else []
+    if not runs:
+        return "empty_snapshot"
+    existing = [run for run in runs if isinstance(run, dict) and run.get("exists")]
+    alive = [run for run in existing if run.get("pid_alive") is True]
+    compact_results = sum(
+        len(run.get("compact_results") or [])
+        for run in existing
+        if isinstance(run, dict)
+    )
+    if alive:
+        return "running"
+    if compact_results:
+        return "compact_artifact_seen"
+    if len(existing) < len(runs):
+        return "missing_run_dir"
+    return "polled"
+
+
+def _snapshot_rollout_details(payload: dict[str, Any]) -> dict[str, Any]:
+    runs = payload.get("runs") if isinstance(payload.get("runs"), list) else []
+    run_items = [run for run in runs if isinstance(run, dict)]
+    existing = [run for run in run_items if run.get("exists")]
+    return {
+        "command": "benchmark_run_status_snapshot",
+        "run_count": len(run_items),
+        "exists_count": len(existing),
+        "missing_count": len(run_items) - len(existing),
+        "pid_alive_count": sum(1 for run in existing if run.get("pid_alive") is True),
+        "compact_result_count": sum(
+            len(run.get("compact_results") or []) for run in existing
+        ),
+        "bridge_request_dir_count": sum(
+            len(run.get("bridge_request_dirs") or []) for run in existing
+        ),
+        "capture_file_count": sum(
+            len(run.get("capture_files") or []) for run in existing
+        ),
+    }
+
+
+def _snapshot_rollout_labels(payload: dict[str, Any]) -> list[str]:
+    runs = payload.get("runs") if isinstance(payload.get("runs"), list) else []
+    labels: list[str] = []
+    for run in runs:
+        if not isinstance(run, dict):
+            continue
+        label = str(run.get("label") or "").strip()
+        if label:
+            labels.append(f"run:{label}")
+    return labels[:20]
+
+
+def append_status_rollout_event(
+    payload: dict[str, Any],
+    *,
+    goal_id: str,
+    runtime_root: Path,
+    agent_id: str | None = None,
+    todo_id: str | None = None,
+) -> dict[str, Any]:
+    status = _snapshot_rollout_status(payload)
+    details = _snapshot_rollout_details(payload)
+    event = build_rollout_event(
+        goal_id=goal_id,
+        event_kind="benchmark_status",
+        agent_id=agent_id,
+        todo_id=todo_id,
+        status=status,
+        labels=_snapshot_rollout_labels(payload),
+        summary=(
+            "benchmark status snapshot recorded: "
+            f"runs={details['run_count']} existing={details['exists_count']} "
+            f"alive={details['pid_alive_count']} compacts={details['compact_result_count']}"
+        ),
+        details=details,
+    )
+    appended = append_rollout_event(rollout_event_log_path(runtime_root, goal_id), event)
+    payload["rollout_event"] = {
+        "schema_version": appended["schema_version"],
+        "event_id": appended["event_id"],
+        "event_kind": appended["event_kind"],
+        "recorded_at": appended["recorded_at"],
+        "status": appended.get("status"),
+    }
+    return payload
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Summarize benchmark run dirs without emitting raw logs."
@@ -197,8 +298,23 @@ def main() -> int:
     )
     parser.add_argument("--max-compacts", type=int, default=12)
     parser.add_argument("--max-captures", type=int, default=3)
+    parser.add_argument(
+        "--record-rollout-event",
+        action="store_true",
+        help="Append a public-safe benchmark_status event to the Goal Harness rollout log.",
+    )
+    parser.add_argument("--goal-id", help="Goal id for --record-rollout-event.")
+    parser.add_argument(
+        "--runtime-root",
+        default=str(Path.home() / ".codex" / "goal-harness"),
+        help="Goal Harness runtime root for --record-rollout-event.",
+    )
+    parser.add_argument("--agent-id", help="Optional public-safe agent id.")
+    parser.add_argument("--todo-id", help="Optional structured todo id.")
     parser.add_argument("--pretty", action="store_true")
     args = parser.parse_args()
+    if args.record_rollout_event and not args.goal_id:
+        parser.error("--record-rollout-event requires --goal-id")
 
     payload = build_snapshot(
         run_root=Path(args.run_root),
@@ -207,6 +323,14 @@ def main() -> int:
         max_compacts=args.max_compacts,
         max_captures=args.max_captures,
     )
+    if args.record_rollout_event:
+        payload = append_status_rollout_event(
+            payload,
+            goal_id=args.goal_id,
+            runtime_root=Path(args.runtime_root),
+            agent_id=args.agent_id,
+            todo_id=args.todo_id,
+        )
     print(json.dumps(payload, ensure_ascii=False, indent=2 if args.pretty else None))
     return 0
 


### PR DESCRIPTION
## Summary
- Add an explicit --record-rollout-event mode to scripts/benchmark_run_status_snapshot.py.
- Record one aggregate public-safe benchmark_status rollout event for routine benchmark polling.
- Extend the status snapshot smoke and developer workflow docs.

## Validation
- python3 examples/benchmark-run-status-snapshot-smoke.py
- python3 -m py_compile scripts/benchmark_run_status_snapshot.py examples/benchmark-run-status-snapshot-smoke.py goal_harness/rollout_event_log.py
- git diff --check
- goal-harness check --scan-path scripts/benchmark_run_status_snapshot.py --scan-path examples/benchmark-run-status-snapshot-smoke.py --scan-path docs/benchmark-developer-workflow.md

## Boundary
- Does not emit run-root, host paths, raw task text, raw logs, trajectories, capture text, transcripts, or credentials.
- Rollout event details are aggregate counts only: run count, existing count, pid-alive count, compact result count, bridge request dir count, and capture file count.