### PR TITLE
Teach app-server Goal driver turn completion

### DIFF
--- a/docs/benchmark-developer-workflow.md
+++ b/docs/benchmark-developer-workflow.md
@@ -708,11 +708,30 @@ python3 scripts/skillsbench_host_codex_goal_worker.py \
 ```
 
 When used for a private case, the same worker reads the private prompt file and
-workspace path on the benchmark host, invokes Codex app-server Goal mode, and
-writes only compact turn metadata plus prompt hash/size. Do not copy raw task
-text, raw trajectory, raw logs, Goal Harness state, credentials, or host paths
-into the compact result. Keep `codex-goal-mode-baseline` for historical
-slash-prefix probes only; it is not a scored Codex Goal baseline.
+workspace path on the benchmark host, invokes Codex app-server Goal mode, waits
+for `turn/completed`, and writes the assistant response only to a private
+response file for the surrounding runner. The public JSON records compact turn
+proof, assistant-message hash/size, and method counters only. Do not copy raw
+task text, raw assistant response, raw trajectory, raw logs, Goal Harness state,
+credentials, or host paths into the compact result. Keep
+`codex-goal-mode-baseline` for historical slash-prefix probes only; it is not a
+scored Codex Goal baseline.
+
+For a scored SkillsBench route, the worker should be called with an explicit
+private output target:
+
+```bash
+python3 scripts/skillsbench_host_codex_goal_worker.py \
+  --task-id <task-id> \
+  --work-dir <private-case-workdir> \
+  --prompt-file <private-prompt-file> \
+  --response-text-file <private-agent-response-file> \
+  --output-json <private-compact-worker-json>
+```
+
+The compact worker JSON is safe to inspect for lifecycle debugging, but the
+response text file is private task execution material and must stay out of
+public docs, ledgers, rollout logs, and PRs.
 
 Preview the public-safe prewarm plan:
 

--- a/examples/codex-app-server-goal-driver-smoke.py
+++ b/examples/codex-app-server-goal-driver-smoke.py
@@ -34,6 +34,24 @@ for line in sys.stdin:
         result = {"goal": {"threadId": "thread-smoke", "status": "active"}}
     elif method == "turn/start":
         result = {"turn": {"id": "turn-smoke", "status": "running"}}
+        print(json.dumps({"id": mid, "result": result}), flush=True)
+        print(json.dumps({
+            "method": "item/agentMessage/delta",
+            "params": {
+                "threadId": "thread-smoke",
+                "turnId": "turn-smoke",
+                "itemId": "item-smoke",
+                "delta": "Synthetic final answer.",
+            },
+        }), flush=True)
+        print(json.dumps({
+            "method": "turn/completed",
+            "params": {
+                "threadId": "thread-smoke",
+                "turn": {"id": "turn-smoke", "status": "completed"},
+            },
+        }), flush=True)
+        continue
     else:
         result = {}
     print(json.dumps({"id": mid, "result": result}), flush=True)
@@ -73,10 +91,34 @@ def main() -> int:
             assert compact["goal_get_present"] is True
             assert compact["goal_status"] == "active"
             assert compact["turn_id_present"] is True
+            assert compact["turn_completed_observed"] is False
             assert compact["raw_transcript_recorded"] is False
             assert "Synthetic prompt" not in json.dumps(compact)
         finally:
             turn.terminate()
+
+        completed_turn = module.start_codex_app_server_goal_turn(
+            codex_bin=str(fake),
+            work_dir=root / "work-completed",
+            objective="Synthetic objective.",
+            prompt="Synthetic prompt.",
+            model_name="gpt-5.5",
+            response_timeout_sec=5,
+            wait_for_completion=True,
+            turn_timeout_sec=5,
+        )
+        try:
+            assert completed_turn.assistant_message == "Synthetic final answer."
+            compact = module.compact_turn_metadata(completed_turn)
+            assert compact["turn_completed_observed"] is True, compact
+            assert compact["turn_status"] == "completed", compact
+            assert compact["assistant_message_present"] is True, compact
+            assert compact["assistant_message_chars"] == len("Synthetic final answer.")
+            assert compact["assistant_message_sha256"], compact
+            assert compact["raw_assistant_message_recorded"] is False, compact
+            assert "Synthetic final answer." not in json.dumps(compact), compact
+        finally:
+            completed_turn.terminate()
 
     print("codex app-server goal driver smoke passed")
     return 0

--- a/examples/skillsbench-app-server-goal-worker-smoke.py
+++ b/examples/skillsbench-app-server-goal-worker-smoke.py
@@ -25,6 +25,49 @@ from goal_harness.benchmark import (  # noqa: E402
 
 ROUTE = "codex-app-server-goal-baseline"
 
+FAKE_CODEX = """#!/usr/bin/env python3
+import json
+import sys
+
+for line in sys.stdin:
+    msg = json.loads(line)
+    mid = msg.get("id")
+    method = msg.get("method")
+    if method == "initialized":
+        continue
+    if method == "initialize":
+        result = {"serverInfo": {"name": "fake-codex"}}
+    elif method == "thread/start":
+        result = {"thread": {"id": "thread-skillsbench"}}
+    elif method == "thread/goal/set":
+        result = {"goal": {"threadId": "thread-skillsbench", "status": "active"}}
+    elif method == "thread/goal/get":
+        result = {"goal": {"threadId": "thread-skillsbench", "status": "active"}}
+    elif method == "turn/start":
+        result = {"turn": {"id": "turn-skillsbench", "status": "running"}}
+        print(json.dumps({"id": mid, "result": result}), flush=True)
+        print(json.dumps({
+            "method": "item/agentMessage/delta",
+            "params": {
+                "threadId": "thread-skillsbench",
+                "turnId": "turn-skillsbench",
+                "itemId": "item-skillsbench",
+                "delta": "private worker answer",
+            },
+        }), flush=True)
+        print(json.dumps({
+            "method": "turn/completed",
+            "params": {
+                "threadId": "thread-skillsbench",
+                "turn": {"id": "turn-skillsbench", "status": "completed"},
+            },
+        }), flush=True)
+        continue
+    else:
+        result = {}
+    print(json.dumps({"id": mid, "result": result}), flush=True)
+"""
+
 
 def assert_plan_prerequisites(plan: dict[str, Any]) -> None:
     prereq = plan["runner_prerequisites"]
@@ -131,6 +174,55 @@ def test_host_worker_contract_only_cli() -> None:
     assert contract["worker_adapter"]["script"] == "scripts/skillsbench_host_codex_goal_worker.py", contract
 
 
+def test_host_worker_waits_for_completion_and_keeps_public_json_compact() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-app-goal-worker-") as tmp:
+        root = Path(tmp)
+        fake = root / "codex"
+        prompt = root / "prompt.txt"
+        output = root / "worker.compact.json"
+        private_response = root / "private-response.txt"
+        fake.write_text(FAKE_CODEX, encoding="utf-8")
+        fake.chmod(0o755)
+        prompt.write_text("Private task instruction placeholder.", encoding="utf-8")
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(REPO_ROOT / "scripts" / "skillsbench_host_codex_goal_worker.py"),
+                "--task-id",
+                "llm-prefix-cache-replay",
+                "--codex-bin",
+                str(fake),
+                "--work-dir",
+                str(root / "work"),
+                "--prompt-file",
+                str(prompt),
+                "--output-json",
+                str(output),
+                "--response-text-file",
+                str(private_response),
+                "--response-timeout-sec",
+                "5",
+                "--turn-timeout-sec",
+                "5",
+            ],
+            cwd=REPO_ROOT,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        assert result.stdout == "", result
+        payload = json.loads(output.read_text(encoding="utf-8"))
+        assert payload["ok"] is True, payload
+        assert payload["turn"]["turn_completed_observed"] is True, payload
+        assert payload["turn"]["assistant_message_present"] is True, payload
+        assert payload["private_response_text"]["written"] is True, payload
+        assert payload["private_response_text"]["path_recorded"] is False, payload
+        assert private_response.read_text(encoding="utf-8") == "private worker answer"
+        public_json = json.dumps(payload)
+        assert "private worker answer" not in public_json, payload
+        assert "Private task instruction placeholder" not in public_json, payload
+
+
 def test_full_run_fails_closed_until_worker_is_wired() -> None:
     result = subprocess.run(
         [
@@ -158,5 +250,6 @@ if __name__ == "__main__":
     test_skeleton_marks_app_server_goal_actor()
     test_launcher_plan_only_uses_native_worker_route()
     test_host_worker_contract_only_cli()
+    test_host_worker_waits_for_completion_and_keeps_public_json_compact()
     test_full_run_fails_closed_until_worker_is_wired()
     print("skillsbench-app-server-goal-worker smoke ok")

--- a/scripts/codex_app_server_goal_driver.py
+++ b/scripts/codex_app_server_goal_driver.py
@@ -9,6 +9,7 @@ import subprocess
 import threading
 import time
 from dataclasses import dataclass, field
+from hashlib import sha256
 from pathlib import Path
 from typing import Any
 
@@ -23,6 +24,12 @@ class CodexAppServerGoalTurn:
     thread_id: str
     turn_id: str
     goal_status: str = ""
+    turn_status: str = ""
+    turn_completed_observed: bool = False
+    assistant_message: str = ""
+    agent_message_delta_count: int = 0
+    agent_message_item_count: int = 0
+    item_completed_count: int = 0
     notifications: list[str] = field(default_factory=list)
 
     def terminate(self, *, timeout_sec: float = 2.0) -> None:
@@ -104,11 +111,109 @@ def _extract_turn_id(result: dict[str, Any]) -> str:
     return str(result.get("turnId") or "")
 
 
+def _extract_turn_status(result: dict[str, Any]) -> str:
+    turn = result.get("turn")
+    if isinstance(turn, dict):
+        return str(turn.get("status") or "")
+    return str(result.get("status") or "")
+
+
 def _extract_goal_status(result: dict[str, Any]) -> str:
     goal = result.get("goal")
     if isinstance(goal, dict):
         return str(goal.get("status") or "")
     return str(result.get("status") or "")
+
+
+def _notification_turn_id(params: dict[str, Any]) -> str:
+    turn = params.get("turn")
+    if isinstance(turn, dict):
+        return str(turn.get("id") or turn.get("turnId") or "")
+    return str(params.get("turnId") or "")
+
+
+def _notification_thread_id(params: dict[str, Any]) -> str:
+    return str(params.get("threadId") or "")
+
+
+def _item_text(item: Any) -> str:
+    if not isinstance(item, dict):
+        return ""
+    for key in ("text", "content", "message"):
+        value = item.get(key)
+        if isinstance(value, str) and value:
+            return value
+        if isinstance(value, dict):
+            nested = _item_text(value)
+            if nested:
+                return nested
+    value = item.get("content")
+    if isinstance(value, list):
+        parts = []
+        for block in value:
+            if isinstance(block, dict):
+                text = block.get("text")
+                if isinstance(text, str) and text:
+                    parts.append(text)
+        return "".join(parts)
+    return ""
+
+
+def _wait_for_turn_completion(
+    turn: CodexAppServerGoalTurn,
+    responses: "queue.Queue[dict[str, Any] | Exception]",
+    *,
+    timeout_sec: float,
+) -> None:
+    deadline = time.monotonic() + timeout_sec
+    deltas: list[str] = []
+    while time.monotonic() < deadline:
+        try:
+            msg = responses.get(timeout=max(0.1, min(0.5, deadline - time.monotonic())))
+        except queue.Empty:
+            continue
+        if isinstance(msg, EOFError):
+            raise CodexAppServerGoalDriverError(
+                "codex app-server exited before turn completion"
+            )
+        if isinstance(msg, Exception):
+            raise CodexAppServerGoalDriverError(str(msg))
+        method = str(msg.get("method") or "")
+        if method:
+            turn.notifications.append(method)
+        params = msg.get("params") if isinstance(msg.get("params"), dict) else {}
+        if not method:
+            continue
+        msg_turn_id = _notification_turn_id(params)
+        msg_thread_id = _notification_thread_id(params)
+        if msg_turn_id and msg_turn_id != turn.turn_id:
+            continue
+        if msg_thread_id and msg_thread_id != turn.thread_id:
+            continue
+        if method == "item/agentMessage/delta":
+            delta = params.get("delta")
+            if isinstance(delta, str) and delta:
+                deltas.append(delta)
+                turn.agent_message_delta_count += 1
+            continue
+        if method == "item/completed":
+            turn.item_completed_count += 1
+            item = params.get("item")
+            item_text = _item_text(item)
+            if item_text:
+                turn.agent_message_item_count += 1
+                if not deltas:
+                    deltas.append(item_text)
+            continue
+        if method == "turn/completed":
+            turn.turn_completed_observed = True
+            turn.turn_status = _extract_turn_status(params) or turn.turn_status
+            turn.assistant_message = "".join(deltas)
+            return
+        if method == "error":
+            message = params.get("message") if isinstance(params, dict) else ""
+            raise CodexAppServerGoalDriverError(str(message or "app-server error"))
+    raise CodexAppServerGoalDriverError("timed out waiting for turn completion")
 
 
 def start_codex_app_server_goal_turn(
@@ -121,6 +226,8 @@ def start_codex_app_server_goal_turn(
     approval_policy: str = "never",
     sandbox: str = "danger-full-access",
     response_timeout_sec: float = 30.0,
+    wait_for_completion: bool = False,
+    turn_timeout_sec: float | None = None,
 ) -> CodexAppServerGoalTurn:
     work_dir.mkdir(parents=True, exist_ok=True)
     proc = subprocess.Popen(
@@ -246,13 +353,21 @@ def start_codex_app_server_goal_turn(
         if not turn_id:
             raise CodexAppServerGoalDriverError("turn/start did not return turn id")
 
-        return CodexAppServerGoalTurn(
+        turn = CodexAppServerGoalTurn(
             process=proc,
             thread_id=thread_id,
             turn_id=turn_id,
             goal_status=goal_status,
+            turn_status=_extract_turn_status(turn_result),
             notifications=notifications,
         )
+        if wait_for_completion:
+            _wait_for_turn_completion(
+                turn,
+                responses,
+                timeout_sec=turn_timeout_sec or response_timeout_sec,
+            )
+        return turn
     except Exception:
         proc.terminate()
         try:
@@ -263,12 +378,24 @@ def start_codex_app_server_goal_turn(
 
 
 def compact_turn_metadata(turn: CodexAppServerGoalTurn) -> dict[str, Any]:
+    assistant_message = turn.assistant_message or ""
     return {
         "schema_version": "codex_app_server_goal_turn_driver_v0",
         "thread_id_present": bool(turn.thread_id),
         "goal_get_present": bool(turn.goal_status),
         "goal_status": turn.goal_status,
         "turn_id_present": bool(turn.turn_id),
+        "turn_status": turn.turn_status,
+        "turn_completed_observed": bool(turn.turn_completed_observed),
+        "agent_message_delta_count": int(turn.agent_message_delta_count),
+        "agent_message_item_count": int(turn.agent_message_item_count),
+        "item_completed_count": int(turn.item_completed_count),
+        "assistant_message_present": bool(assistant_message),
+        "assistant_message_chars": len(assistant_message),
+        "assistant_message_sha256": sha256(assistant_message.encode()).hexdigest()
+        if assistant_message
+        else "",
         "notifications": sorted(set(turn.notifications)),
         "raw_transcript_recorded": False,
+        "raw_assistant_message_recorded": False,
     }

--- a/scripts/skillsbench_host_codex_goal_worker.py
+++ b/scripts/skillsbench_host_codex_goal_worker.py
@@ -71,11 +71,25 @@ def run_worker(args: argparse.Namespace) -> dict[str, Any]:
         approval_policy=args.approval_policy,
         sandbox=args.sandbox,
         response_timeout_sec=args.response_timeout_sec,
+        wait_for_completion=not args.no_wait_for_completion,
+        turn_timeout_sec=args.turn_timeout_sec,
     )
-    compact = compact_turn_metadata(turn)
+    try:
+        compact = compact_turn_metadata(turn)
+        private_response_written = False
+        if args.response_text_file and turn.assistant_message:
+            response_path = Path(args.response_text_file).expanduser()
+            response_path.parent.mkdir(parents=True, exist_ok=True)
+            response_path.write_text(turn.assistant_message, encoding="utf-8")
+            private_response_written = True
+    finally:
+        turn.terminate()
+    ok = bool(compact.get("turn_id_present")) and (
+        args.no_wait_for_completion or compact.get("turn_completed_observed") is True
+    )
     return {
         "schema_version": "skillsbench_host_codex_goal_worker_result_v0",
-        "ok": bool(compact.get("turn_start_observed")),
+        "ok": ok,
         "route": "codex-app-server-goal-baseline",
         "benchmark_id": args.dataset,
         "task_id": args.task_id,
@@ -86,6 +100,11 @@ def run_worker(args: argparse.Namespace) -> dict[str, Any]:
             "raw_recorded": False,
         },
         "turn": compact,
+        "private_response_text": {
+            "written": private_response_written,
+            "path_recorded": False,
+            "raw_recorded_in_public_json": False,
+        },
         "boundary": {
             "raw_task_text_recorded": False,
             "raw_logs_recorded": False,
@@ -108,7 +127,18 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--work-dir")
     parser.add_argument("--prompt-file")
     parser.add_argument("--output-json")
+    parser.add_argument("--response-text-file")
     parser.add_argument("--response-timeout-sec", type=float, default=30.0)
+    parser.add_argument("--turn-timeout-sec", type=float, default=7200.0)
+    parser.add_argument(
+        "--no-wait-for-completion",
+        action="store_true",
+        help=(
+            "Return after turn/start instead of waiting for turn/completed. "
+            "Use only for external pollers; SkillsBench scored workers should "
+            "wait and write a private response text file."
+        ),
+    )
     parser.add_argument(
         "--runner-integration-ready",
         action="store_true",


### PR DESCRIPTION
## Summary
- extend the host Codex app-server Goal driver to optionally wait for turn/completed and collect assistant-message hash/size/count metadata without recording raw text
- update the SkillsBench native Goal worker to wait for completion by default and write the raw assistant response only to an explicit private response file
- expand focused smokes and developer workflow docs for the public/private boundary

## Validation
- python3 examples/codex-app-server-goal-driver-smoke.py
- python3 examples/skillsbench-app-server-goal-worker-smoke.py
- python3 -m py_compile scripts/codex_app_server_goal_driver.py scripts/skillsbench_host_codex_goal_worker.py examples/codex-app-server-goal-driver-smoke.py examples/skillsbench-app-server-goal-worker-smoke.py
- git diff --check --cached
- goal-harness check --scan-path scripts/codex_app_server_goal_driver.py --scan-path scripts/skillsbench_host_codex_goal_worker.py --scan-path examples/codex-app-server-goal-driver-smoke.py --scan-path examples/skillsbench-app-server-goal-worker-smoke.py --scan-path docs/benchmark-developer-workflow.md

## Boundary
- no raw benchmark task text, raw assistant response, raw logs, trajectories, credentials, local paths, or generated benchmark artifacts included
- the new raw response file path is intentionally private and not recorded in public JSON

## Residual Risk
- this lands the turn-completion seam; the next slice still needs to wire the private response file into the surrounding SkillsBench/BenchFlow scored runner path.
