### PR TITLE
Wait for app-server goal completion in host agents

### DIFF
--- a/docs/benchmark-developer-workflow.md
+++ b/docs/benchmark-developer-workflow.md
@@ -376,6 +376,7 @@ UV_LINK_MODE=copy uv run --no-default-groups harbor run \
   --env docker \
   --agent-import-path harbor_host_codex_goal_agent:HarborHostCodexGoalAgent \
   --agent-kwarg goal_timeout_sec=1200 \
+  --agent-kwarg app_server_wait_for_completion=true \
   --agent-kwarg task_workdir=/app \
   --jobs-dir <run-dir>/jobs \
   -p <task-dir>
@@ -388,6 +389,11 @@ benchmark family instead of hardcoding `/app` in runner patches. Commands issued
 through that bridge are forwarded to Harbor's `environment.exec()`, so the
 benchmark environment remains the task/scoring surface while Codex login, model
 access, tmux, and runtime state stay on the stable host layer.
+The Harbor app-server agent waits for `turn/completed` in a background thread
+while the async runner loop continues to serve `harbor-env-exec` bridge
+requests. Its compact turn file records bridge request count, marker
+observation, and assistant-message counters without raw task text, raw logs, or
+raw trajectories.
 
 The Harbor bundle requires `codex` and `rg`. `curl` is intentionally optional:
 host-copied dynamic curl binaries can fail inside Ubuntu task images because of
@@ -610,6 +616,7 @@ tb run \
   --no-rebuild \
   --agent-import-path terminal_bench_host_codex_goal_agent:HostCodexGoalAgent \
   --agent-kwarg goal_surface=app_server \
+  --agent-kwarg app_server_wait_for_completion=true \
   --agent-kwarg goal_timeout_sec=1200
 ```
 
@@ -620,6 +627,11 @@ case container while the container remains responsible for task files and
 official tests. The TUI `/goal` surface is a manual fallback only; do not count
 it as the default baseline when app-server `thread/goal/set`,
 `thread/goal/get`, and `turn/start` are available.
+The app-server host agent waits for `turn/completed` by default and writes a
+compact turn file with `turn_completed_observed`, assistant-message counters,
+and `completion_marker_observed`; pass
+`--agent-kwarg app_server_wait_for_completion=false` only for an explicit
+marker-only fallback probe.
 
 When a Terminal-Bench launch produces only startup or materialization state,
 reduce it before writing Goal Harness evidence:

--- a/examples/harbor-host-codex-goal-agent-smoke.py
+++ b/examples/harbor-host-codex-goal-agent-smoke.py
@@ -76,7 +76,15 @@ def main() -> int:
         assert agent.poll_interval_sec == 0.5
         assert agent.task_workdir == "/workspace"
         assert agent.goal_surface == "app_server"
+        assert agent.app_server_wait_for_completion is True
         assert agent.app_server_response_timeout_sec == 4.0
+
+        no_wait_agent = module.HarborHostCodexGoalAgent(
+            logs_dir=Path(tmp) / "no-wait-logs",
+            goal_surface="app_server",
+            app_server_wait_for_completion="false",
+        )
+        assert no_wait_agent.app_server_wait_for_completion is False
 
     print("harbor host Codex Goal agent smoke passed")
     return 0

--- a/examples/terminal-bench-host-codex-goal-agent-smoke.py
+++ b/examples/terminal-bench-host-codex-goal-agent-smoke.py
@@ -66,9 +66,16 @@ def main() -> int:
     assert agent.goal_timeout_sec == 7.0
     assert agent.poll_interval_sec == 0.5
     assert agent.goal_surface == "app_server"
+    assert agent.app_server_wait_for_completion is True
     assert agent.app_server_response_timeout_sec == 4.0
     assert str(agent.work_root) == "/tmp/goal-harness-terminal-bench"
     assert agent.network_bootstrap_script is None
+
+    no_wait_agent = module.HostCodexGoalAgent(
+        goal_surface="app_server",
+        app_server_wait_for_completion="false",
+    )
+    assert no_wait_agent.app_server_wait_for_completion is False
 
     print("terminal-bench host Codex Goal agent smoke passed")
     return 0

--- a/scripts/harbor_host_codex_goal_agent.py
+++ b/scripts/harbor_host_codex_goal_agent.py
@@ -126,6 +126,12 @@ def build_codex_tui_command(
     return command
 
 
+def _coerce_bool(value: str | bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    return value.strip().lower() not in {"0", "false", "no", "off"}
+
+
 def build_host_goal_prompt(
     *,
     instruction: str,
@@ -169,6 +175,7 @@ class HarborHostCodexGoalAgent(BaseAgent):
         codex_bin: str = "codex",
         task_workdir: str = "/app",
         goal_surface: str = "tui",
+        app_server_wait_for_completion: str | bool = True,
         app_server_response_timeout_sec: str | int | float = 30,
         startup_delay_sec: str | int | float = 5,
         poll_interval_sec: str | int | float = 5,
@@ -179,6 +186,7 @@ class HarborHostCodexGoalAgent(BaseAgent):
         self.codex_bin = codex_bin
         self.task_workdir = task_workdir
         self.goal_surface = goal_surface
+        self.app_server_wait_for_completion = _coerce_bool(app_server_wait_for_completion)
         self.app_server_response_timeout_sec = float(app_server_response_timeout_sec)
         self.startup_delay_sec = float(startup_delay_sec)
         self.poll_interval_sec = float(poll_interval_sec)
@@ -293,14 +301,23 @@ class HarborHostCodexGoalAgent(BaseAgent):
 
         if self.goal_surface == "app_server":
             try:
-                turn = start_codex_app_server_goal_turn(
-                    codex_bin=self.codex_bin,
-                    work_dir=work_dir,
-                    objective="Complete the Harbor benchmark task using the task environment bridge.",
-                    prompt=prompt,
-                    model_name=self.model_name,
-                    response_timeout_sec=self.app_server_response_timeout_sec,
+                turn_task = asyncio.create_task(
+                    asyncio.to_thread(
+                        start_codex_app_server_goal_turn,
+                        codex_bin=self.codex_bin,
+                        work_dir=work_dir,
+                        objective="Complete the Harbor benchmark task using the task environment bridge.",
+                        prompt=prompt,
+                        model_name=self.model_name,
+                        response_timeout_sec=self.app_server_response_timeout_sec,
+                        wait_for_completion=self.app_server_wait_for_completion,
+                        turn_timeout_sec=self.goal_timeout_sec,
+                    )
                 )
+                while not turn_task.done():
+                    await self._serve_bridge_requests(environment, request_dir)
+                    await asyncio.sleep(self.poll_interval_sec)
+                turn = await turn_task
             except CodexAppServerGoalDriverError as exc:
                 (work_dir / "app_server_goal_turn.compact.json").write_text(
                     json.dumps(
@@ -308,7 +325,7 @@ class HarborHostCodexGoalAgent(BaseAgent):
                             "schema_version": "harbor_host_codex_goal_agent_v0",
                             "goal_surface": "app_server",
                             "ok": False,
-                            "first_blocker": "codex_app_server_goal_turn_start_failed",
+                            "first_blocker": "codex_app_server_goal_turn_failed",
                             "error_type": type(exc).__name__,
                             "raw_transcript_recorded": False,
                         },
@@ -321,13 +338,39 @@ class HarborHostCodexGoalAgent(BaseAgent):
                     "goal_harness_agent": self.name(),
                     "completion_marker_observed": False,
                     "bridge_request_count": self._served_request_count,
-                    "first_blocker": "codex_app_server_goal_turn_start_failed",
+                    "first_blocker": "codex_app_server_goal_turn_failed",
                 }
                 return
+            await self._serve_bridge_requests(environment, request_dir)
+            compact = compact_turn_metadata(turn)
+            compact.update(
+                {
+                    "goal_surface": "app_server",
+                    "app_server_wait_for_completion": self.app_server_wait_for_completion,
+                    "completion_marker_observed": marker.exists(),
+                    "bridge_request_count": self._served_request_count,
+                    "first_blocker": ""
+                    if marker.exists()
+                    else "harbor_completion_marker_missing_after_turn_completed",
+                }
+            )
             (work_dir / "app_server_goal_turn.compact.json").write_text(
-                json.dumps(compact_turn_metadata(turn), sort_keys=True) + "\n",
+                json.dumps(compact, sort_keys=True) + "\n",
                 encoding="utf-8",
             )
+            if self.app_server_wait_for_completion:
+                turn.terminate()
+                context.metadata = {
+                    "goal_harness_agent": self.name(),
+                    "completion_marker_observed": marker.exists(),
+                    "bridge_request_count": self._served_request_count,
+                    "goal_surface": "app_server",
+                    "turn_completed_observed": bool(turn.turn_completed_observed),
+                    "first_blocker": ""
+                    if marker.exists()
+                    else "harbor_completion_marker_missing_after_turn_completed",
+                }
+                return
             deadline = time.time() + self.goal_timeout_sec
             try:
                 while time.time() < deadline:

--- a/scripts/terminal_bench_host_codex_goal_agent.py
+++ b/scripts/terminal_bench_host_codex_goal_agent.py
@@ -70,6 +70,12 @@ def build_codex_tui_command(*, codex_bin: str = "codex", model_name: str | None 
     return command
 
 
+def _coerce_bool(value: str | bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    return value.strip().lower() not in {"0", "false", "no", "off"}
+
+
 def build_host_goal_prompt(
     *,
     container_name: str,
@@ -117,6 +123,7 @@ class HostCodexGoalAgent(BaseAgent):
         task_workdir: str = "/app",
         codex_bin: str = "codex",
         goal_surface: str = "tui",
+        app_server_wait_for_completion: str | bool = True,
         app_server_response_timeout_sec: str | int | float = 30,
         startup_delay_sec: str | int | float = 5,
         poll_interval_sec: str | int | float = 5,
@@ -135,6 +142,7 @@ class HostCodexGoalAgent(BaseAgent):
         self.task_workdir = task_workdir
         self.codex_bin = codex_bin
         self.goal_surface = goal_surface
+        self.app_server_wait_for_completion = _coerce_bool(app_server_wait_for_completion)
         self.app_server_response_timeout_sec = float(app_server_response_timeout_sec)
         self.startup_delay_sec = float(startup_delay_sec)
         self.poll_interval_sec = float(poll_interval_sec)
@@ -200,6 +208,8 @@ class HostCodexGoalAgent(BaseAgent):
                     prompt=prompt,
                     model_name=self.model_name,
                     response_timeout_sec=self.app_server_response_timeout_sec,
+                    wait_for_completion=self.app_server_wait_for_completion,
+                    turn_timeout_sec=self.goal_timeout_sec,
                 )
             except CodexAppServerGoalDriverError as exc:
                 (work_dir / "app_server_goal_turn.compact.json").write_text(
@@ -208,7 +218,7 @@ class HostCodexGoalAgent(BaseAgent):
                             "schema_version": "terminal_bench_host_codex_goal_agent_v0",
                             "goal_surface": "app_server",
                             "ok": False,
-                            "first_blocker": "codex_app_server_goal_turn_start_failed",
+                            "first_blocker": "codex_app_server_goal_turn_failed",
                             "error_type": type(exc).__name__,
                             "raw_transcript_recorded": False,
                         },
@@ -222,10 +232,30 @@ class HostCodexGoalAgent(BaseAgent):
                     total_output_tokens=0,
                     failure_mode=FailureMode.AGENT_TIMEOUT,
                 )
+            compact = compact_turn_metadata(turn)
+            compact.update(
+                {
+                    "goal_surface": "app_server",
+                    "app_server_wait_for_completion": self.app_server_wait_for_completion,
+                    "completion_marker_observed": marker.exists(),
+                    "first_blocker": ""
+                    if marker.exists()
+                    else "terminal_bench_completion_marker_missing_after_turn_completed",
+                }
+            )
             (work_dir / "app_server_goal_turn.compact.json").write_text(
-                json.dumps(compact_turn_metadata(turn), sort_keys=True) + "\n",
+                json.dumps(compact, sort_keys=True) + "\n",
                 encoding="utf-8",
             )
+            if self.app_server_wait_for_completion:
+                turn.terminate()
+                if marker.exists():
+                    return AgentResult(total_input_tokens=0, total_output_tokens=0)
+                return AgentResult(
+                    total_input_tokens=0,
+                    total_output_tokens=0,
+                    failure_mode=FailureMode.AGENT_TIMEOUT,
+                )
             deadline = time.time() + self.goal_timeout_sec
             try:
                 while time.time() < deadline:


### PR DESCRIPTION
## Summary
- make Terminal-Bench and Harbor host app-server Goal agents wait for `turn/completed` by default
- preserve explicit marker-only fallback via `app_server_wait_for_completion=false`
- record public-safe compact completion/marker/bridge metadata and document the workflow

## Validation
- python3 examples/benchmark-developer-workflow-doc-smoke.py
- python3 examples/terminal-bench-host-codex-goal-agent-smoke.py
- python3 examples/harbor-host-codex-goal-agent-smoke.py
- python3 examples/codex-app-server-goal-driver-smoke.py
- python3 -m py_compile scripts/terminal_bench_host_codex_goal_agent.py scripts/harbor_host_codex_goal_agent.py scripts/codex_app_server_goal_driver.py examples/terminal-bench-host-codex-goal-agent-smoke.py examples/harbor-host-codex-goal-agent-smoke.py examples/codex-app-server-goal-driver-smoke.py examples/benchmark-developer-workflow-doc-smoke.py
- python3 -m goal_harness.cli check --scan-path scripts/terminal_bench_host_codex_goal_agent.py --scan-path scripts/harbor_host_codex_goal_agent.py --scan-path examples/terminal-bench-host-codex-goal-agent-smoke.py --scan-path examples/harbor-host-codex-goal-agent-smoke.py --scan-path docs/benchmark-developer-workflow.md
- git diff --check

## Boundary
No benchmark task text, raw logs, trajectories, credentials, or private run artifacts are included.
