### PR TITLE
Record build-cython-ext app-server baseline success

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
@@ -6652,9 +6652,9 @@
         "build-cython-ext": {
           "case_id": "build-cython-ext",
           "latest_decision": {
-            "baseline_run_id": "f004782b573f",
-            "decision": "baseline_failed_treatment_candidate",
-            "failure_scope": "case_or_solution"
+            "baseline_run_id": "63b6f4ee387e",
+            "decision": "baseline_passed_not_current_treatment_priority",
+            "failure_scope": "passed"
           },
           "runs": [
             {
@@ -6929,6 +6929,37 @@
               "run_group_id": "gh-terminal-build-cython-ext-host-app-server-goal-r9-20260620",
               "run_id": "f004782b573f",
               "score_status": "failed",
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false
+            },
+            {
+              "agent_declared_done": false,
+              "arm_id": "terminal_bench_host_codex_app_server_goal_baseline",
+              "artifact_refs": {
+                "compact_artifact_ref": "cloud-ecs/parallel-benchmark-20260621T020900Z/terminal-bench-build-cython-ext-app-server-pr335-r1/terminal_bench_official_result.compact.json"
+              },
+              "benchmark_id": "terminal-bench@2.0",
+              "case_id": "build-cython-ext",
+              "case_ids": [
+                "build-cython-ext"
+              ],
+              "codex_acp_runtime_preflight_passed": false,
+              "failure_class": "none",
+              "failure_scope": "passed",
+              "goal_harness_inside_case": false,
+              "job_name": "build-cython-ext-host-app-server-goal-20260620t181051z",
+              "leaderboard_evidence": false,
+              "mode": "terminal_bench_host_codex_app_server_goal",
+              "notes": "ECS app-server Goal r1 completed build-cython-ext no-upload with official metadata-only accuracy 1.0; turn compact was marker-only/inProgress because this was the pre-PR336 agent, so keep PR336 r2 for turn-completed a...",
+              "official_passed": true,
+              "official_score": 1.0,
+              "recorded_at": "2026-06-21T02:25:49+08:00",
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "gh-terminal-build-cython-ext-host-app-server-goal-pr335-r1-20260621",
+              "run_id": "63b6f4ee387e",
+              "score_status": "passed",
               "source_event_schema": "benchmark_run_v0",
               "status": "completed",
               "submit_eligible": false
@@ -10084,7 +10115,7 @@
           ]
         }
       },
-      "run_count": 80
+      "run_count": 81
     }
   },
   "schema_version": "benchmark_run_ledger_v0",
@@ -10095,5 +10126,5 @@
     "source_of_truth": "benchmark_run_v0 compact run events",
     "update_rule": "upsert one run entry when a benchmark case is ingested or closed"
   },
-  "updated_at": "2026-06-20T23:49:38+08:00"
+  "updated_at": "2026-06-21T02:25:49+08:00"
 }

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
@@ -5,7 +5,7 @@ benchmark case outcomes and artifact references; it must not contain raw
 logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 
 - schema_version: `benchmark_run_ledger_v0`
-- updated_at: `2026-06-20T23:49:38+08:00`
+- updated_at: `2026-06-21T02:25:49+08:00`
 
 ## Case Decisions
 
@@ -35,7 +35,7 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `skillsbench@1.1` | `travel-planning` | `baseline_failed_treatment_candidate` | - | `2` |
 | `swe-marathon` | `find-network-alignments` | `baseline_failed_treatment_candidate` | - | `1` |
 | `terminal-bench-worker-materialization@v0` | `nginx-request-logging` | `single_arm_recorded` | - | `2` |
-| `terminal-bench@2.0` | `build-cython-ext` | `baseline_failed_treatment_candidate` | - | `6` |
+| `terminal-bench@2.0` | `build-cython-ext` | `baseline_passed_not_current_treatment_priority` | - | `7` |
 | `terminal-bench@2.0` | `cobol-modernization` | `paired_baseline_solved_treatment_preserved` | - | `2` |
 | `terminal-bench@2.0` | `compile-compcert` | `baseline_passed_not_current_treatment_priority` | - | `1` |
 | `terminal-bench@2.0` | `financial-document-processor` | `baseline_passed_not_current_treatment_priority` | - | `2` |
@@ -201,6 +201,7 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `terminal-bench@2.0` | `build-cython-ext` | `codex_goal_mode_baseline` | `` | `0.0` | `` | `` | `codex_cli_not_on_path` | `` |
 | `terminal-bench@2.0` | `build-cython-ext` | `codex_goal_mode_baseline` | `` | `1.0` | `` | `` | `none` | `.local/private-benchmark-jobs/terminal-bench-build-cython-ext-runtime-extended-20260614T2257CST/terminal_bench_2_0_build_cython_ext_codex_goal_mode_baseline_runtime_extended_no_upload_20260614T2257CST/result.json` |
 | `terminal-bench@2.0` | `build-cython-ext` | `terminal_bench_host_codex_app_server_goal_baseline` | `` | `0.0` | `` | `` | `official_verifier_solution_failure` | `cloud-ecs/parallel-benchmark-20260620T131254Z/terminal-bench-build-cython-ext-host-app-server-goal-r9/terminal_official_metadata.compact.json` |
+| `terminal-bench@2.0` | `build-cython-ext` | `terminal_bench_host_codex_app_server_goal_baseline` | `` | `1.0` | `` | `` | `none` | `cloud-ecs/parallel-benchmark-20260621T020900Z/terminal-bench-build-cython-ext-app-server-pr335-r1/terminal_bench_official_result.compact.json` |
 | `terminal-bench@2.0` | `cobol-modernization` | `hardened_codex_baseline` | `` | `1.0` | `` | `` | `none` | `.local/private-benchmark-jobs/terminal-bench-cobol-modernization-paired-20260611T0903Z/baseline.compact.json` |
 | `terminal-bench@2.0` | `cobol-modernization` | `codex_goal_harness_treatment` | `` | `1.0` | `` | `` | `none` | `.local/private-benchmark-jobs/terminal-bench-cobol-modernization-paired-20260611T0903Z/treatment.compact.json` |
 | `terminal-bench@2.0` | `compile-compcert` | `codex_goal_mode_baseline` | `` | `1.0` | `` | `` | `none` | `.local/private-benchmark-jobs/terminal-bench-compile-compcert-baseline-2h-20260615T1934CST/baseline/jobs/terminal_bench_compile_compcert_codex_goal_mode_baseline_2h_20260615T1934CST/result.json` |


### PR DESCRIPTION
## Summary
- record the ECS Terminal-Bench `build-cython-ext` host app-server Goal baseline r1 as an official metadata-only success
- update the run-ledger case decision from baseline-failed candidate to baseline-passed/not-current-treatment-priority
- keep artifact reference public-safe and compact-only

## Validation
- python3 examples/benchmark-run-ledger-smoke.py
- python3 -m goal_harness.cli benchmark run-ledger-check --goal-id goal-harness-meta --run-ledger-path docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
- python3 -m goal_harness.cli check --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
- git diff --check

## Boundary
The ledger update uses the compact `benchmark_run_v0` projection from the Terminal-Bench metadata-only reducer. No raw logs, task text, trajectories, credentials, uploads, or absolute host paths are included.
