### PR TITLE
Clarify SkillsBench app-server bridge gate

### DIFF
--- a/docs/benchmark-developer-workflow.md
+++ b/docs/benchmark-developer-workflow.md
@@ -708,10 +708,22 @@ python3 scripts/skillsbench_automation_loop.py \
 The plan must show
 `agent_execution_mode=host_codex_app_server_goal_worker`,
 `codex_app_server_goal_worker_turn_start_required=true`, and
-`codex_app_server_goal_worker_runner_integration_ready=false` until the
-BenchFlow worker integration is actually wired. A full launch of this route
-must fail closed rather than falling back to `codex-acp`. The host-side worker
-surface is:
+`codex_app_server_goal_worker_remote_command_file_bridge_required=true`.
+By default it should also show
+`codex_app_server_goal_worker_remote_command_file_bridge_ready=false` and
+`codex_app_server_goal_worker_runner_integration_ready=false`.
+
+There are two distinct gates for a real scored launch:
+
+1. Materialize a bounded command/file bridge so the host Codex app-server Goal
+   worker can operate on the BenchFlow sandbox where task files and edits live.
+   A host cwd that cannot see the sandbox is not a valid fallback.
+2. Wire that host worker through BenchFlow's ACP transport so official task
+   staging and verification still run through BenchFlow.
+
+A full launch of this route must fail closed rather than falling back to
+`codex-acp`, a slash-prefix `/goal` prompt, or a host-only workspace. The
+host-side worker surface is:
 
 ```bash
 python3 scripts/skillsbench_host_codex_goal_worker.py \
@@ -744,6 +756,14 @@ python3 scripts/skillsbench_host_codex_goal_worker.py \
 The compact worker JSON is safe to inspect for lifecycle debugging, but the
 response text file is private task execution material and must stay out of
 public docs, ledgers, rollout logs, and PRs.
+
+Use `--remote-command-file-bridge-ready` only after a public-safe bridge probe
+has passed. That flag updates only the plan's bridge readiness fields;
+`codex_app_server_goal_worker_runner_integration_ready` must remain `false`
+until the BenchFlow transport is actually wired. If the full route exits with
+`SkillsBenchNativeGoalWorkerIntegrationPending`, the next fix belongs in the
+host-worker-to-ACP transport, not in verifier timeout, Docker setup, or model
+behavior.
 
 Preview the public-safe prewarm plan:
 

--- a/examples/skillsbench-app-server-goal-worker-smoke.py
+++ b/examples/skillsbench-app-server-goal-worker-smoke.py
@@ -81,7 +81,15 @@ def assert_plan_prerequisites(plan: dict[str, Any]) -> None:
     assert prereq["codex_app_server_goal_worker_turn_start_required"] is True, prereq
     assert prereq["codex_app_server_goal_worker_goal_get_required"] is True, prereq
     assert (
+        prereq["codex_app_server_goal_worker_remote_command_file_bridge_required"]
+        is True
+    ), prereq
+    assert (
         prereq["codex_app_server_goal_worker_runner_integration_ready"] is False
+    ), prereq
+    assert (
+        prereq["codex_app_server_goal_worker_remote_command_file_bridge_ready"]
+        is False
     ), prereq
 
 
@@ -151,6 +159,37 @@ def test_launcher_plan_only_uses_native_worker_route() -> None:
     contract = plan["app_server_goal_worker_contract"]
     assert contract["route"] == ROUTE, contract
     assert contract["worker_plan"]["schema_version"] == "codex_app_server_goal_worker_v0", contract
+
+
+def test_launcher_plan_only_marks_bridge_ready_when_explicit() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-app-goal-plan-") as tmp:
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(REPO_ROOT / "scripts" / "skillsbench_automation_loop.py"),
+                "--task-id",
+                "llm-prefix-cache-replay",
+                "--route",
+                ROUTE,
+                "--jobs-dir",
+                str(Path(tmp) / "jobs"),
+                "--remote-command-file-bridge-ready",
+                "--plan-only",
+            ],
+            cwd=REPO_ROOT,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+    payload = json.loads(result.stdout)
+    prereq = payload["launch_plan"]["runner_prerequisites"]
+    assert (
+        prereq["codex_app_server_goal_worker_remote_command_file_bridge_ready"]
+        is True
+    ), prereq
+    assert (
+        prereq["codex_app_server_goal_worker_runner_integration_ready"] is False
+    ), prereq
 
 
 def test_host_worker_contract_only_cli() -> None:
@@ -223,7 +262,7 @@ def test_host_worker_waits_for_completion_and_keeps_public_json_compact() -> Non
         assert "Private task instruction placeholder" not in public_json, payload
 
 
-def test_full_run_fails_closed_until_worker_is_wired() -> None:
+def test_full_run_fails_closed_until_bridge_is_materialized() -> None:
     result = subprocess.run(
         [
             sys.executable,
@@ -232,6 +271,28 @@ def test_full_run_fails_closed_until_worker_is_wired() -> None:
             "llm-prefix-cache-replay",
             "--route",
             ROUTE,
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    assert result.returncode == 2, result
+    payload = json.loads(result.stderr)
+    assert payload["error_type"] == "SkillsBenchNativeGoalWorkerBridgePending", payload
+    assert "command/file bridge" in payload["reason"], payload
+
+
+def test_full_run_with_bridge_ready_still_fails_closed_until_transport_is_wired() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "scripts" / "skillsbench_automation_loop.py"),
+            "--task-id",
+            "llm-prefix-cache-replay",
+            "--route",
+            ROUTE,
+            "--remote-command-file-bridge-ready",
         ],
         cwd=REPO_ROOT,
         check=False,
@@ -249,7 +310,9 @@ if __name__ == "__main__":
     test_worker_contract_is_public_safe()
     test_skeleton_marks_app_server_goal_actor()
     test_launcher_plan_only_uses_native_worker_route()
+    test_launcher_plan_only_marks_bridge_ready_when_explicit()
     test_host_worker_contract_only_cli()
     test_host_worker_waits_for_completion_and_keeps_public_json_compact()
-    test_full_run_fails_closed_until_worker_is_wired()
+    test_full_run_fails_closed_until_bridge_is_materialized()
+    test_full_run_with_bridge_ready_still_fails_closed_until_transport_is_wired()
     print("skillsbench-app-server-goal-worker smoke ok")

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -1593,6 +1593,10 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
     agent_runtime_layer = _benchflow_agent_runtime_layer_contract(args)
     requires_preinstalled_runtime = bool(agent_runtime_layer.get("required"))
     is_app_server_goal_route = route == "codex-app-server-goal-baseline"
+    app_server_goal_bridge_ready = bool(
+        args.remote_command_file_bridge_ready
+        or args.remote_command_file_bridge_probe
+    )
     app_server_goal_worker_contract = (
         build_skillsbench_app_server_goal_worker_contract(
             dataset=args.dataset,
@@ -1745,6 +1749,14 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
                         "runner_integration_ready"
                     )
                 )
+                if app_server_goal_worker_contract
+                else False
+            ),
+            "codex_app_server_goal_worker_remote_command_file_bridge_required": (
+                bool(app_server_goal_worker_contract)
+            ),
+            "codex_app_server_goal_worker_remote_command_file_bridge_ready": (
+                app_server_goal_bridge_ready
                 if app_server_goal_worker_contract
                 else False
             ),
@@ -3987,6 +3999,31 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps(payload, indent=2, sort_keys=True), file=sys.stderr)
         return 2
     if args.route == "codex-app-server-goal-baseline" and not args.plan_only:
+        bridge_ready = bool(
+            args.remote_command_file_bridge_ready
+            or args.remote_command_file_bridge_probe
+        )
+        if not bridge_ready:
+            payload = {
+                "ok": False,
+                "error_type": "SkillsBenchNativeGoalWorkerBridgePending",
+                "route": args.route,
+                "reason": (
+                    "codex-app-server-goal-baseline runs Codex on the host, but "
+                    "SkillsBench task files and edits live inside the BenchFlow "
+                    "sandbox. A bounded command/file bridge must be materialized "
+                    "before a host app-server Goal turn can operate on the "
+                    "scored workspace."
+                ),
+                "next_action": (
+                    "materialize and probe the SkillsBench remote command/file "
+                    "bridge, then wire the host app-server Goal worker into the "
+                    "BenchFlow ACP transport; do not fall back to codex-acp or "
+                    "a host cwd that cannot see the sandbox"
+                ),
+            }
+            print(json.dumps(payload, indent=2, sort_keys=True), file=sys.stderr)
+            return 2
         payload = {
             "ok": False,
             "error_type": "SkillsBenchNativeGoalWorkerIntegrationPending",
@@ -3994,8 +4031,9 @@ def main(argv: list[str] | None = None) -> int:
             "reason": (
                 "codex-app-server-goal-baseline requires a BenchFlow worker "
                 "integration that launches host Codex app-server Goal turns via "
-                "thread/start, thread/goal/set/get, and turn/start; the current "
-                "runner must not fall back to codex-acp"
+                "thread/start, thread/goal/set/get, and turn/start while the "
+                "worker uses the ready command/file bridge for sandbox edits; "
+                "the current runner must not fall back to codex-acp"
             ),
             "next_action": (
                 "wire the SkillsBench host Codex app-server Goal worker into "


### PR DESCRIPTION
## Summary
- split the SkillsBench app-server Goal route gate into command/file bridge readiness and BenchFlow transport integration
- expose bridge-required/bridge-ready fields in the public-safe launch plan
- update the focused smoke and developer guide so full runs fail closed before falling back to codex-acp or a host-only cwd

## Validation
- python3 examples/skillsbench-app-server-goal-worker-smoke.py
- python3 -m py_compile scripts/skillsbench_automation_loop.py examples/skillsbench-app-server-goal-worker-smoke.py
- git diff --check
- goal-harness check --scan-path scripts/skillsbench_automation_loop.py --scan-path examples/skillsbench-app-server-goal-worker-smoke.py --scan-path docs/benchmark-developer-workflow.md
