### PR TITLE
fix: render monitor quiet as watch lane

### DIFF
--- a/docs/attention-queue.md
+++ b/docs/attention-queue.md
@@ -61,8 +61,8 @@ Fields:
 - `status`: classification or derived state.
 - `lifecycle_phase`: derived state-interaction phase for dashboard grouping.
 - `lifecycle_flags`: all compact phases that apply to the latest goal state.
-- `waiting_on`: one of `user_or_controller`, `codex`, `external_evidence`, or
-  `controller`.
+- `waiting_on`: one of `user_or_controller`, `codex`, `external_evidence`,
+  `monitor_signal`, or `controller`.
 - `severity`: `high`, `action`, or `watch`.
 - `recommended_action`: exactly one user-facing next action from the adapter or
   status layer.
@@ -93,6 +93,8 @@ The queue summary keeps controller handoff visible:
 - `needs_codex`: counts goals ready for Codex action.
 - `watching_external_evidence`: counts goals waiting on outside evidence or
   metrics.
+- `watching_monitor`: counts monitor-only goals that should stay visible but
+  do not require immediate Codex work.
 
 ## Classification Mapping
 

--- a/docs/interaction-pattern-catalog.md
+++ b/docs/interaction-pattern-catalog.md
@@ -508,6 +508,11 @@ The agent may append at most one no-spend monitor poll, rerun the guard, and
 then stay quiet. The automation remains alive; monitor-only quiet skips are not
 completion or deletion signals.
 
+Status and diagnose should display unchanged monitor-only work as
+`waiting_on=monitor_signal` with `severity=watch`, while retaining the quota
+decision `effective_action=monitor_quiet_skip`. This keeps the monitor visible
+without making it look like immediate Codex work or a user/controller gate.
+
 **Visual Model**
 
 ```mermaid

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -248,6 +248,7 @@ goals must stay out of the eligible lane even when they have a high
     "needs_controller": 0,
     "needs_codex": 1,
     "watching_external_evidence": 0,
+    "watching_monitor": 0,
     "autonomous_backlog_candidates": {
       "source": "attention_queue.agent_todos",
       "open_count": 1,
@@ -584,6 +585,8 @@ Counters:
 - `needs_codex`: items ready for a Codex action.
 - `watching_external_evidence`: items that should be monitored but not acted on
   until outside evidence changes.
+- `watching_monitor`: monitor-only items that remain visible without implying
+  immediate Codex work.
 
 Item shape:
 
@@ -674,8 +677,8 @@ Item fields:
 - `lifecycle_phase`: derived state-interaction phase for first-screen
   visualization.
 - `lifecycle_flags`: all compact phases that apply to the latest state.
-- `waiting_on`: `user_or_controller`, `controller`, `codex`, or
-  `external_evidence`.
+- `waiting_on`: `user_or_controller`, `controller`, `codex`,
+  `external_evidence`, or `monitor_signal`.
 - `severity`: `high`, `action`, or `watch`.
 - `recommended_action`: exactly one next action.
 - `project_asset`: a compact control-plane projection derived from the same
@@ -911,8 +914,9 @@ unfinished `advancement_task` agent todos from current queue items where
 intentionally excluded from this backlog so dependency/readiness observation
 cannot crowd out implementation, planning, or blocker-writeback candidates.
 `attention_queue.autonomous_monitor_candidates` may separately expose compact
-`continuous_monitor` todos so heartbeat dispatchers still see the current
-watch surfaces without treating them as primary advancement work.
+`continuous_monitor` todos from `waiting_on=codex` or
+`waiting_on=monitor_signal` queue items so heartbeat dispatchers still see the
+current watch surfaces without treating them as primary advancement work.
 Both candidate surfaces preserve `action_kind` when the agent registered one
 with the todo CLI.
 
@@ -2017,7 +2021,8 @@ A first useful UI can be built from the export alone:
   watched goal is not ready yet without opening the full run payload.
 - User lane: items with `waiting_on=user_or_controller` or `controller`.
 - Codex lane: items with `waiting_on=codex`.
-- Watch lane: items with `waiting_on=external_evidence`.
+- Watch lane: items with `waiting_on=external_evidence` or
+  `waiting_on=monitor_signal`.
 - Dreaming lane/badge: items with
   `project_asset.dreaming_lane_badge.schema_version=dreaming_lane_badge_v0`.
   These items are advisory review surfaces; delivery lanes continue to follow
@@ -2067,7 +2072,8 @@ Suggested badge mapping:
 
 - `severity=high`: blocking.
 - `severity=action`: needs a decision or bounded work segment.
-- `severity=watch`: no immediate action; wait for evidence.
+- `severity=watch`: no immediate action; wait for evidence or a material
+  monitor transition.
 
 ## Static Dashboard Demo
 

--- a/examples/status-neutral-run-window-smoke.py
+++ b/examples/status-neutral-run-window-smoke.py
@@ -19,8 +19,13 @@ from goal_harness.status import collect_status  # noqa: E402
 
 GOAL_ID = "neutral-window-connected-delivery"
 REAL_CLASSIFICATION = "autonomous_replan_recorded_stable_monitor"
-REAL_ACTION = "continue the stable monitor lane without asking the user"
-AGENT_TODO = "[P1] Continue the stable monitor lane and write back compact evidence."
+REAL_ACTION = "Quiet monitor only until a material stable monitor transition appears."
+DISPLAY_ACTION = (
+    "No immediate agent work; keep the monitor quiet until a material stable monitor transition appears."
+)
+AGENT_TODO = (
+    "[P1] Monitor the stable signal; write back only a material transition, regression, or blocker."
+)
 
 
 def write_registry(root: Path) -> Path:
@@ -37,7 +42,9 @@ def write_registry(root: Path) -> Path:
         "---\n\n"
         "# Neutral Window Fixture\n\n"
         "## Agent Todo\n\n"
-        f"- [ ] {AGENT_TODO}\n",
+        f"- [ ] {AGENT_TODO}\n"
+        "  <!-- goal-harness:todo todo_id=todo_monitor_fixture status=open "
+        "task_class=continuous_monitor action_kind=stable_signal_monitor -->\n",
         encoding="utf-8",
     )
     registry_path.parent.mkdir(parents=True, exist_ok=True)
@@ -139,9 +146,20 @@ def main() -> int:
         item = status["attention_queue"]["items"][0]
         assert item["goal_id"] == GOAL_ID, item
         assert item["status"] == REAL_CLASSIFICATION, item
-        assert item["waiting_on"] == "codex", item
+        assert item["waiting_on"] == "monitor_signal", item
+        assert item["severity"] == "watch", item
+        assert item["execution_waiting_on"] == "codex", item
         assert item["source"] == "latest_run", item
-        assert item["recommended_action"] == REAL_ACTION, item
+        assert item["recommended_action"] == DISPLAY_ACTION, item
+        assert item["monitor_display"]["no_immediate_agent_work"] is True, item
+        project_asset = item["project_asset"]
+        assert project_asset["owner"] == "monitor_signal", project_asset
+        assert project_asset["support_mode"] == "read_only_observer", project_asset
+        assert status["attention_queue"]["needs_codex"] == 0, status["attention_queue"]
+        assert status["attention_queue"]["watching_monitor"] == 1, status["attention_queue"]
+        assert status["attention_queue"]["autonomous_monitor_candidates"]["open_count"] == 1, (
+            status["attention_queue"]
+        )
         assert "connect an adapter" not in item["recommended_action"], item
 
         run_goal = status["run_history"]["goals"][0]
@@ -157,11 +175,15 @@ def main() -> int:
 
         quota = build_quota_should_run(status, goal_id=GOAL_ID)
         assert quota["state"] != "operator_gate", quota
+        assert quota["effective_action"] == "monitor_quiet_skip", quota
+        assert quota["actionable_by_codex"] is False, quota
         assert quota["requires_user_action"] is False, quota
         user_todo_summary = quota.get("user_todo_summary") if isinstance(quota.get("user_todo_summary"), dict) else {}
         assert user_todo_summary.get("open_count", 0) == 0, quota
         assert quota["status"] == REAL_CLASSIFICATION, quota
+        assert quota["waiting_on"] == "monitor_signal", quota
         assert "connect an adapter" not in quota["recommended_action"], quota
+        assert quota["recommended_action"] == DISPLAY_ACTION, quota
         assert (
             quota["handoff_readiness"]["post_handoff_latest_run"]["classification"]
             == REAL_CLASSIFICATION
@@ -176,11 +198,10 @@ def main() -> int:
         )
         selected = diagnosis["selected"]
         assert selected["status"] == REAL_CLASSIFICATION, selected
-        assert selected["waiting_on"] == "codex", selected
-        assert selected["machine_signal"] in {
-            "agent_work_attention",
-            "no_immediate_agent_delivery_signal",
-        }, selected
+        assert selected["waiting_on"] == "monitor_signal", selected
+        assert selected["severity"] == "watch", selected
+        assert selected["machine_signal"] == "no_immediate_agent_delivery_signal", selected
+        assert selected["quota_signals"]["effective_action"] == "monitor_quiet_skip", selected
         assert selected["todo_evidence"]["user_open_count"] == 0, selected
 
     print("status-neutral-run-window-smoke ok")

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -101,6 +101,15 @@ REGISTRY_WAITING_ON_OVERRIDES = {
     "external_evidence",
 }
 WATCH_CLASSIFICATION_PREFIXES = ("await_", "monitor_", "external_evidence_observation_")
+MONITOR_SIGNAL_WAITING_ON = "monitor_signal"
+MONITOR_DISPLAY_SCHEMA_VERSION = "monitor_quiet_display_v0"
+MONITOR_DISPLAY_STOP_CONDITION = (
+    "stop until a material monitor transition, regression, or concrete blocker appears"
+)
+MONITOR_DISPLAY_FALLBACK_ACTION = (
+    "No immediate agent work; keep the monitor quiet until a material monitor "
+    "transition, regression, or concrete blocker appears."
+)
 BLOCKING_CLASSIFICATIONS = {
     "blocked_by_safety",
 }
@@ -4282,6 +4291,8 @@ def project_asset_owner(waiting_on: str) -> str:
         return "codex"
     if waiting_on == "external_evidence":
         return "external_evidence"
+    if waiting_on == MONITOR_SIGNAL_WAITING_ON:
+        return MONITOR_SIGNAL_WAITING_ON
     if waiting_on == "controller":
         return "controller"
     if waiting_on == "user_or_controller":
@@ -4304,6 +4315,8 @@ def project_asset_gate(
         return status or waiting_on
     if waiting_on == "external_evidence":
         return "external_evidence"
+    if waiting_on == MONITOR_SIGNAL_WAITING_ON:
+        return "none"
     return "none"
 
 
@@ -4321,6 +4334,8 @@ def project_asset_stop_condition(
         return "stop until the controller or owner resolves this gate"
     if waiting_on == "external_evidence":
         return "stop until external evidence changes"
+    if waiting_on == MONITOR_SIGNAL_WAITING_ON:
+        return MONITOR_DISPLAY_STOP_CONDITION
     if agent_command:
         return "stop if the command fails or needs write, production, or additional approval"
     return "stop if the next action needs reward, gate approval, write control, or production access"
@@ -4343,7 +4358,7 @@ def project_asset_support_mode(
         return "reward_capture"
     if operator_question or missing_gates or waiting_on in {"user_or_controller", "controller"}:
         return "decision_support"
-    if waiting_on == "external_evidence":
+    if waiting_on in {"external_evidence", MONITOR_SIGNAL_WAITING_ON}:
         return "read_only_observer"
     if agent_command or waiting_on == "codex":
         return "selective_assist"
@@ -4597,11 +4612,13 @@ def autonomous_todo_candidates(
     items: list[dict[str, Any]],
     *,
     task_class: str,
+    allowed_waiting_on: set[str] | None = None,
     limit: int = MAX_AUTONOMOUS_BACKLOG_CANDIDATES,
 ) -> dict[str, Any] | None:
+    allowed_waiting_on = allowed_waiting_on or {"codex"}
     candidates: list[dict[str, Any]] = []
     for item in items:
-        if not isinstance(item, dict) or item.get("waiting_on") != "codex":
+        if not isinstance(item, dict) or item.get("waiting_on") not in allowed_waiting_on:
             continue
         quota = item.get("quota") if isinstance(item.get("quota"), dict) else {}
         if quota.get("state") != "eligible":
@@ -4674,6 +4691,7 @@ def autonomous_monitor_candidates(
     return autonomous_todo_candidates(
         items,
         task_class=TODO_TASK_CLASS_MONITOR,
+        allowed_waiting_on={"codex", MONITOR_SIGNAL_WAITING_ON},
         limit=limit,
     )
 
@@ -5412,6 +5430,106 @@ def sync_connected_attention_action_from_todos(item: dict[str, Any]) -> None:
     project_asset = item.get("project_asset")
     if isinstance(project_asset, dict):
         project_asset["next_action"] = agent_action
+
+
+def todo_summary_open_count(summary: dict[str, Any] | None) -> int:
+    if not isinstance(summary, dict):
+        return 0
+    for key in ("open_count", "open"):
+        value = summary.get(key)
+        if isinstance(value, int):
+            return max(0, value)
+    return len(
+        [
+            item
+            for item in open_todo_items(summary, limit=MAX_STATUS_TODOS_PER_ROLE)
+            if todo_item_is_actionable_open(item)
+        ]
+    )
+
+
+def todo_summary_lane_items(summary: dict[str, Any] | None, lane: str) -> list[dict[str, Any]]:
+    if not isinstance(summary, dict):
+        return []
+    raw_items = summary.get(lane)
+    if not isinstance(raw_items, list):
+        return []
+    return [item for item in raw_items if isinstance(item, dict)]
+
+
+def attention_item_is_monitor_quiet_display_candidate(item: dict[str, Any]) -> bool:
+    if item.get("waiting_on") != "codex" or item.get("severity") != "action":
+        return False
+    agent_todos = item.get("agent_todos") if isinstance(item.get("agent_todos"), dict) else None
+    if not agent_todos:
+        return False
+    user_todos = item.get("user_todos") if isinstance(item.get("user_todos"), dict) else None
+    if todo_summary_open_count(user_todos) > 0:
+        return False
+    open_count = todo_summary_open_count(agent_todos)
+    if open_count <= 0:
+        return False
+    monitor_items = [
+        item
+        for item in todo_summary_lane_items(agent_todos, "monitor_open_items")
+        if todo_item_is_actionable_open(item)
+    ]
+    executable_items = [
+        *todo_summary_lane_items(agent_todos, "first_executable_items"),
+        *todo_summary_lane_items(agent_todos, "executable_backlog_items"),
+        *todo_summary_lane_items(agent_todos, "claimed_advancement_open_items"),
+    ]
+    if any(todo_item_is_actionable_open(todo) for todo in executable_items):
+        return False
+    return len(monitor_items) == open_count
+
+
+def quiet_monitor_display_action(raw_action: str | None) -> str:
+    action = str(raw_action or "").strip()
+    if not action:
+        return MONITOR_DISPLAY_FALLBACK_ACTION
+    lowered = action.lower()
+    if lowered.startswith("no immediate agent work"):
+        return action
+    if lowered.startswith("quiet monitor only until "):
+        suffix = action[len("Quiet monitor only until ") :].strip()
+        if suffix:
+            return f"No immediate agent work; keep the monitor quiet until {suffix}"
+    if lowered.startswith("wait quietly"):
+        return f"No immediate agent work; {action[0].lower()}{action[1:]}"
+    return f"No immediate agent work; monitor quietly. Context: {action}"
+
+
+def normalize_monitor_quiet_attention_display(item: dict[str, Any]) -> None:
+    if not attention_item_is_monitor_quiet_display_candidate(item):
+        return
+    old_waiting_on = str(item.get("waiting_on") or "")
+    old_severity = str(item.get("severity") or "")
+    display_action = quiet_monitor_display_action(str(item.get("recommended_action") or ""))
+    item["execution_waiting_on"] = old_waiting_on
+    item["waiting_on"] = MONITOR_SIGNAL_WAITING_ON
+    item["severity"] = "watch"
+    item["recommended_action"] = display_action
+    item["monitor_display"] = {
+        "schema_version": MONITOR_DISPLAY_SCHEMA_VERSION,
+        "mode": "monitor_quiet",
+        "no_immediate_agent_work": True,
+        "execution_waiting_on": old_waiting_on,
+        "execution_severity": old_severity,
+        "waiting_on": MONITOR_SIGNAL_WAITING_ON,
+        "severity": "watch",
+        "material_transition": (
+            "write back only a material monitor transition, regression, or concrete blocker"
+        ),
+    }
+    project_asset = item.get("project_asset")
+    if isinstance(project_asset, dict):
+        project_asset["owner"] = MONITOR_SIGNAL_WAITING_ON
+        project_asset["gate"] = "none"
+        project_asset["support_mode"] = "read_only_observer"
+        project_asset["next_action"] = display_action
+        project_asset["stop_condition"] = MONITOR_DISPLAY_STOP_CONDITION
+        project_asset["monitor_display"] = dict(item["monitor_display"])
 
 
 def compact_global_registry_shadow_finding(finding: dict[str, Any]) -> dict[str, Any]:
@@ -6299,6 +6417,7 @@ def build_attention_queue(
                         subagent_activity=subagent_activity,
                         interface_budget_cadence=interface_budget_cadence,
                     )
+                normalize_monitor_quiet_attention_display(item)
             attach_goal_channel_projection(
                 item,
                 goal=goal,
@@ -6347,6 +6466,7 @@ def build_attention_queue(
         "needs_controller": sum(1 for item in items if item["waiting_on"] == "controller"),
         "needs_codex": sum(1 for item in items if item["waiting_on"] == "codex"),
         "watching_external_evidence": sum(1 for item in items if item["waiting_on"] == "external_evidence"),
+        "watching_monitor": sum(1 for item in items if item["waiting_on"] == MONITOR_SIGNAL_WAITING_ON),
         "items": items,
     }
     if backlog_candidates:
@@ -7408,7 +7528,8 @@ def render_status_markdown(payload: dict[str, Any]) -> str:
             f"needs_user_or_controller={queue.get('needs_user_or_controller')}, "
             f"needs_controller={queue.get('needs_controller')}, "
             f"needs_codex={queue.get('needs_codex')}, "
-            f"watching_external_evidence={queue.get('watching_external_evidence')}",
+            f"watching_external_evidence={queue.get('watching_external_evidence')}, "
+            f"watching_monitor={queue.get('watching_monitor')}",
         ]
     )
     items = queue.get("items") if isinstance(queue.get("items"), list) else []


### PR DESCRIPTION
## Summary
- Display monitor-only quiet states as `waiting_on=monitor_signal` with `severity=watch` instead of Codex action work.
- Keep quota execution semantics unchanged: monitor-only fixtures still return `effective_action=monitor_quiet_skip` and `actionable_by_codex=false`.
- Document the new watch lane counter and update IP-008/status contracts.

## Validation
- `python3 -m py_compile goal_harness/status.py goal_harness/diagnose.py goal_harness/quota.py`
- `python3 examples/status-neutral-run-window-smoke.py`
- `python3 examples/protocol-action-packet-smoke.py`
- `python3 examples/quota-plan-smoke.py`
- `python3 examples/status-markdown-smoke.py`
- `goal-harness check --scan-path goal_harness/status.py --scan-path examples/status-neutral-run-window-smoke.py --scan-path docs/status-data-contract.md --scan-path docs/attention-queue.md --scan-path docs/interaction-pattern-catalog.md`
- `git diff --check`

Note: `goal-harness check` reported an existing global run-history duplicate-row warning outside the changed public scan paths. The changed paths passed the public/private scan.