### PR TITLE
Record app-server benchmark r2 ledger result

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
@@ -6963,6 +6963,40 @@
               "source_event_schema": "benchmark_run_v0",
               "status": "completed",
               "submit_eligible": false
+            },
+            {
+              "agent_declared_done": false,
+              "arm_id": "terminal_bench_host_codex_app_server_goal_completion_aware",
+              "artifact_refs": {
+                "compact_artifact_ref": "cloud-ecs/parallel-benchmark-20260621T022100Z/terminal-bench-build-cython-ext-app-server-pr336-r2/terminal_bench_official_result.compact.json"
+              },
+              "benchmark_id": "terminal-bench@2.0",
+              "case_id": "build-cython-ext",
+              "case_ids": [
+                "build-cython-ext"
+              ],
+              "codex_acp_runtime_preflight_passed": false,
+              "failure_class": "official_verifier_solution_failure",
+              "failure_labels": [
+                "official_verifier_solution_failure"
+              ],
+              "failure_scope": "case_or_solution",
+              "goal_harness_inside_case": false,
+              "job_name": "build-cython-ext-host-app-server-goal-20260620t182136z",
+              "leaderboard_evidence": false,
+              "mode": "terminal_bench_host_codex_app_server_goal_completion_aware",
+              "notes": "ECS host app-server Goal completion-aware rerun; official Terminal-Bench metadata-only reducer; compact public-safe result only; no raw task/log/trajectory material recorded",
+              "official_passed": false,
+              "official_score": 0.0,
+              "recorded_at": "2026-06-21T02:50:45+08:00",
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "parallel-benchmark-20260621T022100Z",
+              "run_id": "b674c8b7b3a3",
+              "score_status": "failed",
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false
             }
           ]
         },
@@ -10115,7 +10149,7 @@
           ]
         }
       },
-      "run_count": 81
+      "run_count": 82
     }
   },
   "schema_version": "benchmark_run_ledger_v0",
@@ -10126,5 +10160,5 @@
     "source_of_truth": "benchmark_run_v0 compact run events",
     "update_rule": "upsert one run entry when a benchmark case is ingested or closed"
   },
-  "updated_at": "2026-06-21T02:25:49+08:00"
+  "updated_at": "2026-06-21T02:50:45+08:00"
 }

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
@@ -5,7 +5,7 @@ benchmark case outcomes and artifact references; it must not contain raw
 logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 
 - schema_version: `benchmark_run_ledger_v0`
-- updated_at: `2026-06-21T02:25:49+08:00`
+- updated_at: `2026-06-21T02:50:45+08:00`
 
 ## Case Decisions
 
@@ -35,7 +35,7 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `skillsbench@1.1` | `travel-planning` | `baseline_failed_treatment_candidate` | - | `2` |
 | `swe-marathon` | `find-network-alignments` | `baseline_failed_treatment_candidate` | - | `1` |
 | `terminal-bench-worker-materialization@v0` | `nginx-request-logging` | `single_arm_recorded` | - | `2` |
-| `terminal-bench@2.0` | `build-cython-ext` | `baseline_passed_not_current_treatment_priority` | - | `7` |
+| `terminal-bench@2.0` | `build-cython-ext` | `baseline_passed_not_current_treatment_priority` | - | `8` |
 | `terminal-bench@2.0` | `cobol-modernization` | `paired_baseline_solved_treatment_preserved` | - | `2` |
 | `terminal-bench@2.0` | `compile-compcert` | `baseline_passed_not_current_treatment_priority` | - | `1` |
 | `terminal-bench@2.0` | `financial-document-processor` | `baseline_passed_not_current_treatment_priority` | - | `2` |
@@ -202,6 +202,7 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `terminal-bench@2.0` | `build-cython-ext` | `codex_goal_mode_baseline` | `` | `1.0` | `` | `` | `none` | `.local/private-benchmark-jobs/terminal-bench-build-cython-ext-runtime-extended-20260614T2257CST/terminal_bench_2_0_build_cython_ext_codex_goal_mode_baseline_runtime_extended_no_upload_20260614T2257CST/result.json` |
 | `terminal-bench@2.0` | `build-cython-ext` | `terminal_bench_host_codex_app_server_goal_baseline` | `` | `0.0` | `` | `` | `official_verifier_solution_failure` | `cloud-ecs/parallel-benchmark-20260620T131254Z/terminal-bench-build-cython-ext-host-app-server-goal-r9/terminal_official_metadata.compact.json` |
 | `terminal-bench@2.0` | `build-cython-ext` | `terminal_bench_host_codex_app_server_goal_baseline` | `` | `1.0` | `` | `` | `none` | `cloud-ecs/parallel-benchmark-20260621T020900Z/terminal-bench-build-cython-ext-app-server-pr335-r1/terminal_bench_official_result.compact.json` |
+| `terminal-bench@2.0` | `build-cython-ext` | `terminal_bench_host_codex_app_server_goal_completion_aware` | `` | `0.0` | `` | `` | `official_verifier_solution_failure` | `cloud-ecs/parallel-benchmark-20260621T022100Z/terminal-bench-build-cython-ext-app-server-pr336-r2/terminal_bench_official_result.compact.json` |
 | `terminal-bench@2.0` | `cobol-modernization` | `hardened_codex_baseline` | `` | `1.0` | `` | `` | `none` | `.local/private-benchmark-jobs/terminal-bench-cobol-modernization-paired-20260611T0903Z/baseline.compact.json` |
 | `terminal-bench@2.0` | `cobol-modernization` | `codex_goal_harness_treatment` | `` | `1.0` | `` | `` | `none` | `.local/private-benchmark-jobs/terminal-bench-cobol-modernization-paired-20260611T0903Z/treatment.compact.json` |
 | `terminal-bench@2.0` | `compile-compcert` | `codex_goal_mode_baseline` | `` | `1.0` | `` | `` | `none` | `.local/private-benchmark-jobs/terminal-bench-compile-compcert-baseline-2h-20260615T1934CST/baseline/jobs/terminal_bench_compile_compcert_codex_goal_mode_baseline_2h_20260615T1934CST/result.json` |


### PR DESCRIPTION
## Summary
- record the Terminal-Bench build-cython-ext app-server completion-aware r2 compact result in the public benchmark run ledger
- regenerate the markdown ledger from benchmark_run_ledger_v0

## Validation
- python3 examples/benchmark-run-ledger-smoke.py
- git diff --check
- goal-harness check --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md

Boundary: compact metadata-only result, no raw task text/logs/trajectories/uploads or absolute private paths.