### PR TITLE
Preserve todo claim in update payload

### DIFF
--- a/examples/todo-cli-smoke.py
+++ b/examples/todo-cli-smoke.py
@@ -276,6 +276,29 @@ def main() -> int:
         assert claimed_fields["agent_todos"]["claimed_open_count"] == 1, claimed_fields
         assert claimed_fields["agent_todos"]["unclaimed_open_count"] == 0, claimed_fields
 
+        preserve_claim_payload = run_cli(
+            registry_path,
+            "todo",
+            "update",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            metadata_payload["todo_id"],
+            "--note",
+            "Claim-preserving progress note.",
+        )
+        assert preserve_claim_payload["changed"] is True, preserve_claim_payload
+        assert preserve_claim_payload["claimed_by"] == "codex-main-control", preserve_claim_payload
+        preserved_claim_fields = parse_active_state_todos(state_file.read_text(encoding="utf-8"))
+        preserved_claim_item = preserved_claim_fields["agent_todos"]["items"][0]
+        assert preserved_claim_item["claimed_by"] == "codex-main-control", preserved_claim_item
+        assert preserved_claim_item["task_class"] == "advancement_task", preserved_claim_item
+        assert preserved_claim_item["action_kind"] == "run_eval", preserved_claim_item
+        assert preserved_claim_item["required_capabilities"] == [
+            "shell",
+            "benchmark_runner",
+        ], preserved_claim_item
+
         conflicting_claim = run_cli_error(
             registry_path,
             "todo",

--- a/goal_harness/todos.py
+++ b/goal_harness/todos.py
@@ -684,6 +684,7 @@ def apply_todo_update_to_lines(
         updates["updated_at"] = updated_at
         metadata_line = metadata_line_for_block(block, updates)
     metadata_updated = upsert_todo_metadata(lines, block, metadata_line)
+    effective_metadata = parse_todo_metadata_line(metadata_line or "") or {}
     return {
         "role": resolved_role,
         "section": section,
@@ -694,7 +695,7 @@ def apply_todo_update_to_lines(
         "text_changed": text_changed,
         "metadata_updated": metadata_updated,
         "changed": status_changed or text_changed or metadata_updated,
-        "claimed_by": normalize_todo_claimed_by(updates.get("claimed_by")),
+        "claimed_by": normalize_todo_claimed_by(effective_metadata.get("claimed_by")),
     }
 
 


### PR DESCRIPTION
## Summary
- make `goal-harness todo update` report the effective `claimed_by` from merged todo metadata instead of only the explicit update argument
- add a focused CLI smoke proving ordinary note updates preserve todo claims and metadata

## Validation
- `python3 examples/todo-cli-smoke.py`
- `python3 -m py_compile goal_harness/todos.py examples/todo-cli-smoke.py`
- `git diff --check`
- `goal-harness check --scan-path goal_harness/todos.py --scan-path examples/todo-cli-smoke.py`

This fixes a misleading CLI payload; the active-state claim was already preserved, but the command output made it look empty.
