### PR TITLE
Wire SkillsBench native Goal ACP relay

### DIFF
--- a/docs/benchmark-developer-workflow.md
+++ b/docs/benchmark-developer-workflow.md
@@ -721,6 +721,30 @@ There are two distinct gates for a real scored launch:
 2. Wire that host worker through BenchFlow's ACP transport so official task
    staging and verification still run through BenchFlow.
 
+The second gate is implemented through the host-local ACP relay. In
+`codex-app-server-goal-baseline`, pass `--host-local-acp-launch` only after the
+bridge probe is green; the launcher then starts
+`scripts/skillsbench_local_acp_relay.py --app-server-goal-worker`, and the
+relay delegates each ACP `session/prompt` to
+`scripts/skillsbench_host_codex_goal_worker.py`. This preserves BenchFlow as
+the official task stager/verifier while Codex runs through native app-server
+Goal methods on the host:
+
+```bash
+python3 scripts/skillsbench_automation_loop.py \
+  --task-id llm-prefix-cache-replay \
+  --route codex-app-server-goal-baseline \
+  --remote-command-file-bridge-ready \
+  --host-local-acp-launch \
+  --plan-only
+```
+
+With both flags, the plan should show
+`codex_app_server_goal_worker_remote_command_file_bridge_ready=true` and
+`codex_app_server_goal_worker_runner_integration_ready=true`. Without
+`--host-local-acp-launch`, a real launch must still fail closed as
+`SkillsBenchNativeGoalWorkerIntegrationPending`.
+
 A full launch of this route must fail closed rather than falling back to
 `codex-acp`, a slash-prefix `/goal` prompt, or a host-only workspace. The
 host-side worker surface is:
@@ -760,7 +784,8 @@ public docs, ledgers, rollout logs, and PRs.
 Use `--remote-command-file-bridge-ready` only after a public-safe bridge probe
 has passed. That flag updates only the plan's bridge readiness fields;
 `codex_app_server_goal_worker_runner_integration_ready` must remain `false`
-until the BenchFlow transport is actually wired. If the full route exits with
+until the BenchFlow transport is requested through `--host-local-acp-launch`.
+If the full route exits with
 `SkillsBenchNativeGoalWorkerIntegrationPending`, the next fix belongs in the
 host-worker-to-ACP transport, not in verifier timeout, Docker setup, or model
 behavior.

--- a/examples/skillsbench-app-server-goal-worker-smoke.py
+++ b/examples/skillsbench-app-server-goal-worker-smoke.py
@@ -21,6 +21,9 @@ from goal_harness.benchmark import (  # noqa: E402
     build_skillsbench_benchmark_run,
     skillsbench_route_contract,
 )
+from goal_harness.benchmark_adapters.skillsbench_acp_relay import (  # noqa: E402
+    run_skillsbench_local_acp_relay_probe,
+)
 
 
 ROUTE = "codex-app-server-goal-baseline"
@@ -192,6 +195,38 @@ def test_launcher_plan_only_marks_bridge_ready_when_explicit() -> None:
     ), prereq
 
 
+def test_launcher_plan_only_marks_runner_ready_with_host_acp_launch() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-app-goal-plan-") as tmp:
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(REPO_ROOT / "scripts" / "skillsbench_automation_loop.py"),
+                "--task-id",
+                "llm-prefix-cache-replay",
+                "--route",
+                ROUTE,
+                "--jobs-dir",
+                str(Path(tmp) / "jobs"),
+                "--remote-command-file-bridge-ready",
+                "--host-local-acp-launch",
+                "--plan-only",
+            ],
+            cwd=REPO_ROOT,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+    payload = json.loads(result.stdout)
+    prereq = payload["launch_plan"]["runner_prerequisites"]
+    assert (
+        prereq["codex_app_server_goal_worker_remote_command_file_bridge_ready"]
+        is True
+    ), prereq
+    assert (
+        prereq["codex_app_server_goal_worker_runner_integration_ready"] is True
+    ), prereq
+
+
 def test_host_worker_contract_only_cli() -> None:
     result = subprocess.run(
         [
@@ -262,6 +297,34 @@ def test_host_worker_waits_for_completion_and_keeps_public_json_compact() -> Non
         assert "Private task instruction placeholder" not in public_json, payload
 
 
+def test_acp_relay_delegates_to_app_server_goal_worker() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-app-goal-acp-") as tmp:
+        root = Path(tmp)
+        fake = root / "codex"
+        work = root / "work"
+        fake.write_text(FAKE_CODEX, encoding="utf-8")
+        fake.chmod(0o755)
+        work.mkdir()
+        command = [
+            sys.executable,
+            str(REPO_ROOT / "scripts" / "skillsbench_local_acp_relay.py"),
+            "--app-server-goal-worker",
+            "--task-id",
+            "llm-prefix-cache-replay",
+            "--codex-bin",
+            str(fake),
+            "--timeout-sec",
+            "5",
+            "--response-timeout-sec",
+            "5",
+        ]
+        probe = run_skillsbench_local_acp_relay_probe(
+            command,
+            timeout_sec=10,
+        )
+    assert probe["ready"] is True, probe
+
+
 def test_full_run_fails_closed_until_bridge_is_materialized() -> None:
     result = subprocess.run(
         [
@@ -283,7 +346,7 @@ def test_full_run_fails_closed_until_bridge_is_materialized() -> None:
     assert "command/file bridge" in payload["reason"], payload
 
 
-def test_full_run_with_bridge_ready_still_fails_closed_until_transport_is_wired() -> None:
+def test_full_run_with_bridge_ready_requires_host_acp_launch() -> None:
     result = subprocess.run(
         [
             sys.executable,
@@ -302,7 +365,7 @@ def test_full_run_with_bridge_ready_still_fails_closed_until_transport_is_wired(
     assert result.returncode == 2, result
     payload = json.loads(result.stderr)
     assert payload["error_type"] == "SkillsBenchNativeGoalWorkerIntegrationPending", payload
-    assert "codex-acp" in payload["reason"], payload
+    assert "--host-local-acp-launch" in payload["reason"], payload
 
 
 if __name__ == "__main__":
@@ -311,8 +374,10 @@ if __name__ == "__main__":
     test_skeleton_marks_app_server_goal_actor()
     test_launcher_plan_only_uses_native_worker_route()
     test_launcher_plan_only_marks_bridge_ready_when_explicit()
+    test_launcher_plan_only_marks_runner_ready_with_host_acp_launch()
     test_host_worker_contract_only_cli()
     test_host_worker_waits_for_completion_and_keeps_public_json_compact()
+    test_acp_relay_delegates_to_app_server_goal_worker()
     test_full_run_fails_closed_until_bridge_is_materialized()
-    test_full_run_with_bridge_ready_still_fails_closed_until_transport_is_wired()
+    test_full_run_with_bridge_ready_requires_host_acp_launch()
     print("skillsbench-app-server-goal-worker smoke ok")

--- a/goal_harness/benchmark_adapters/skillsbench_acp_relay.py
+++ b/goal_harness/benchmark_adapters/skillsbench_acp_relay.py
@@ -63,6 +63,12 @@ class CodexExecConfig:
     model: str | None = None
     timeout_sec: int = 7200
     dry_run_response: str | None = None
+    app_server_goal_worker: bool = False
+    dataset: str = "skillsbench-v1.1"
+    task_id: str = "llm-prefix-cache-replay"
+    approval_policy: str = "never"
+    response_timeout_sec: float = 30.0
+    worker_script: str | None = None
 
 
 class SkillsBenchLocalAcpRelay:
@@ -177,6 +183,8 @@ class SkillsBenchLocalAcpRelay:
     def _run_codex(self, prompt_text: str, *, session: dict[str, Any]) -> str:
         if self._config.dry_run_response is not None:
             return self._config.dry_run_response
+        if self._config.app_server_goal_worker:
+            return self._run_app_server_goal_worker(prompt_text, session=session)
         cwd = _safe_cwd(session.get("cwd"), default=os.getcwd())
         with tempfile.TemporaryDirectory(prefix="gh-skillsbench-acp-") as tmp:
             output_path = Path(tmp) / "last-message.txt"
@@ -215,6 +223,72 @@ class SkillsBenchLocalAcpRelay:
             except OSError as exc:
                 raise RuntimeError("local codex final message missing") from exc
             return response or "local codex returned an empty final message"
+
+    def _run_app_server_goal_worker(
+        self, prompt_text: str, *, session: dict[str, Any]
+    ) -> str:
+        cwd = _safe_cwd(session.get("cwd"), default=os.getcwd())
+        with tempfile.TemporaryDirectory(prefix="gh-skillsbench-goal-worker-") as tmp:
+            tmp_path = Path(tmp)
+            prompt_path = tmp_path / "prompt.txt"
+            output_json = tmp_path / "worker.compact.json"
+            response_path = tmp_path / "response.txt"
+            prompt_path.write_text(prompt_text, encoding="utf-8")
+            worker_script = (
+                Path(self._config.worker_script).expanduser()
+                if self._config.worker_script
+                else Path(__file__).resolve().parents[2]
+                / "scripts"
+                / "skillsbench_host_codex_goal_worker.py"
+            )
+            cmd = [
+                sys.executable,
+                str(worker_script),
+                "--dataset",
+                self._config.dataset,
+                "--task-id",
+                self._config.task_id,
+                "--codex-bin",
+                self._config.codex_bin,
+                "--sandbox",
+                self._config.sandbox,
+                "--approval-policy",
+                self._config.approval_policy,
+                "--work-dir",
+                cwd,
+                "--prompt-file",
+                str(prompt_path),
+                "--output-json",
+                str(output_json),
+                "--response-text-file",
+                str(response_path),
+                "--response-timeout-sec",
+                str(self._config.response_timeout_sec),
+                "--turn-timeout-sec",
+                str(self._config.timeout_sec),
+                "--runner-integration-ready",
+            ]
+            model = self._config.model or session.get("model")
+            if model:
+                cmd.extend(["--model", str(model)])
+            try:
+                proc = subprocess.run(
+                    cmd,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                    timeout=self._config.timeout_sec + 60,
+                    check=False,
+                )
+            except subprocess.TimeoutExpired as exc:
+                raise TimeoutError from exc
+            if proc.returncode != 0:
+                raise RuntimeError("host app-server goal worker failed")
+            try:
+                response = response_path.read_text(encoding="utf-8").strip()
+            except OSError as exc:
+                raise RuntimeError("host app-server goal worker response missing") from exc
+            return response or "host app-server goal worker returned an empty final message"
 
     @staticmethod
     def _write(stdout: TextIO, message: dict[str, Any]) -> None:

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -616,6 +616,20 @@ def _host_local_acp_launch_command(args: argparse.Namespace) -> list[str]:
     if "--dry-run-response" in command:
         index = command.index("--dry-run-response")
         del command[index : index + 2]
+    if args.route == "codex-app-server-goal-baseline":
+        command.extend(
+            [
+                "--app-server-goal-worker",
+                "--dataset",
+                args.dataset,
+                "--task-id",
+                args.task_id,
+                "--approval-policy",
+                "never",
+                "--response-timeout-sec",
+                "30",
+            ]
+        )
     command.extend(
         [
             "--codex-bin",
@@ -1608,7 +1622,7 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
             no_upload=True,
             submit_enabled=False,
             compact_reducer_ready=True,
-            runner_integration_ready=False,
+            runner_integration_ready=bool(args.host_local_acp_launch),
         )
         if is_app_server_goal_route
         else None
@@ -2903,8 +2917,20 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
         rollout_dir: Path,
         environment: str,
         agent_cwd: str,
-    ) -> tuple[Any, Any, str]:
-        del env, agent_launch, agent_env, sandbox_user, rollout_dir, environment
+        reasoning_effort: str | None = None,
+        mcp_servers: list[Any] | None = None,
+        **_ignored: Any,
+    ) -> tuple[Any, Any, Any, str]:
+        del (
+            env,
+            agent_launch,
+            agent_env,
+            sandbox_user,
+            rollout_dir,
+            environment,
+            reasoning_effort,
+        )
+        from benchflow.agents.protocol import ACPSessionAdapter
         from benchflow.acp.client import ACPClient
         from benchflow.acp.transport import StdioTransport
 
@@ -2921,7 +2947,8 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
             await asyncio.wait_for(client.connect(), timeout=60)
             init_result = await asyncio.wait_for(client.initialize(), timeout=60)
             session = await asyncio.wait_for(
-                client.session_new(cwd=agent_cwd), timeout=60
+                client.session_new(cwd=agent_cwd, mcp_servers=mcp_servers),
+                timeout=60,
             )
             agent_name = (
                 init_result.agent_info.name if init_result.agent_info else agent
@@ -2929,7 +2956,7 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
             if model:
                 await asyncio.wait_for(client.set_model(model), timeout=60)
             prerequisites["host_local_acp_launch_status"] = "connected"
-            return client, session, agent_name
+            return client, session, ACPSessionAdapter(client), agent_name
         except Exception:
             prerequisites["host_local_acp_launch_status"] = "failed"
             with contextlib.suppress(Exception):
@@ -3056,7 +3083,11 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
     async def install_agent_host_local_acp(self: Any) -> None:
         cfg = self._config
         prerequisites = plan.setdefault("runner_prerequisites", {})
-        prerequisites["agent_execution_mode"] = "host_local_acp"
+        prerequisites["agent_execution_mode"] = (
+            "host_codex_app_server_goal_worker"
+            if args.route == "codex-app-server-goal-baseline"
+            else "host_local_acp"
+        )
         prerequisites["host_local_acp_launch"] = True
         prerequisites["host_local_acp_launch_status"] = "installing_sandbox"
         prerequisites["container_codex_acp_install_skipped"] = True
@@ -4003,6 +4034,7 @@ def main(argv: list[str] | None = None) -> int:
             args.remote_command_file_bridge_ready
             or args.remote_command_file_bridge_probe
         )
+        runner_integration_ready = bool(args.host_local_acp_launch)
         if not bridge_ready:
             payload = {
                 "ok": False,
@@ -4024,25 +4056,26 @@ def main(argv: list[str] | None = None) -> int:
             }
             print(json.dumps(payload, indent=2, sort_keys=True), file=sys.stderr)
             return 2
-        payload = {
-            "ok": False,
-            "error_type": "SkillsBenchNativeGoalWorkerIntegrationPending",
-            "route": args.route,
-            "reason": (
-                "codex-app-server-goal-baseline requires a BenchFlow worker "
-                "integration that launches host Codex app-server Goal turns via "
-                "thread/start, thread/goal/set/get, and turn/start while the "
-                "worker uses the ready command/file bridge for sandbox edits; "
-                "the current runner must not fall back to codex-acp"
-            ),
-            "next_action": (
-                "wire the SkillsBench host Codex app-server Goal worker into "
-                "BenchFlow, then rerun the selected case with compact no-upload "
-                "proof"
-            ),
-        }
-        print(json.dumps(payload, indent=2, sort_keys=True), file=sys.stderr)
-        return 2
+        if runner_integration_ready:
+            args.host_local_acp_launch = True
+        else:
+            payload = {
+                "ok": False,
+                "error_type": "SkillsBenchNativeGoalWorkerIntegrationPending",
+                "route": args.route,
+                "reason": (
+                    "codex-app-server-goal-baseline requires --host-local-acp-launch "
+                    "so BenchFlow connects to the Goal Harness ACP relay that "
+                    "delegates prompts to the host Codex app-server Goal worker; "
+                    "the current runner must not fall back to codex-acp"
+                ),
+                "next_action": (
+                    "rerun with --remote-command-file-bridge-ready and "
+                    "--host-local-acp-launch after probing the command/file bridge"
+                ),
+            }
+            print(json.dumps(payload, indent=2, sort_keys=True), file=sys.stderr)
+            return 2
     if args.local_codex_participant_ping:
         payload = materialize_local_codex_participant(
             codex_bin=args.local_codex_bin,

--- a/scripts/skillsbench_local_acp_relay.py
+++ b/scripts/skillsbench_local_acp_relay.py
@@ -50,6 +50,28 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
             "Codex. Intended for handshake/preflight smokes."
         ),
     )
+    parser.add_argument(
+        "--app-server-goal-worker",
+        action="store_true",
+        help=(
+            "Delegate each ACP prompt to scripts/skillsbench_host_codex_goal_worker.py "
+            "instead of codex exec. This is the native Codex Goal baseline path."
+        ),
+    )
+    parser.add_argument("--dataset", default="skillsbench-v1.1")
+    parser.add_argument("--task-id", default="llm-prefix-cache-replay")
+    parser.add_argument("--approval-policy", default="never")
+    parser.add_argument(
+        "--response-timeout-sec",
+        type=float,
+        default=30.0,
+        help="Timeout for the worker to observe initial app-server response events.",
+    )
+    parser.add_argument(
+        "--worker-script",
+        default=None,
+        help="Optional path to skillsbench_host_codex_goal_worker.py.",
+    )
     return parser.parse_args(argv)
 
 
@@ -62,6 +84,12 @@ def main(argv: list[str] | None = None) -> int:
             model=args.model,
             timeout_sec=args.timeout_sec,
             dry_run_response=args.dry_run_response,
+            app_server_goal_worker=args.app_server_goal_worker,
+            dataset=args.dataset,
+            task_id=args.task_id,
+            approval_policy=args.approval_policy,
+            response_timeout_sec=args.response_timeout_sec,
+            worker_script=args.worker_script,
         )
     )
     return relay.serve()


### PR DESCRIPTION
## Summary
- add an app-server Goal worker backend to the SkillsBench ACP relay
- let the SkillsBench app-server baseline mark runner integration ready when --host-local-acp-launch is used
- document the bridge + host-local ACP launch flow and extend the worker smoke

## Validation
- python3 examples/skillsbench-app-server-goal-worker-smoke.py
- python3 -m py_compile goal_harness/benchmark_adapters/skillsbench_acp_relay.py scripts/skillsbench_local_acp_relay.py scripts/skillsbench_automation_loop.py scripts/skillsbench_host_codex_goal_worker.py examples/skillsbench-app-server-goal-worker-smoke.py
- git diff --check
- goal-harness check --scan-path goal_harness/benchmark_adapters/skillsbench_acp_relay.py --scan-path scripts/skillsbench_local_acp_relay.py --scan-path scripts/skillsbench_automation_loop.py --scan-path examples/skillsbench-app-server-goal-worker-smoke.py --scan-path docs/benchmark-developer-workflow.md
- remote ECS: python3 examples/skillsbench-app-server-goal-worker-smoke.py
- remote ECS: SkillsBench venv BenchFlow ACPClient probe against the app-server Goal relay
