### PR TITLE
Patch SkillsBench rollout planes ACP connect

### DIFF
--- a/examples/skillsbench-app-server-goal-worker-smoke.py
+++ b/examples/skillsbench-app-server-goal-worker-smoke.py
@@ -368,6 +368,23 @@ def test_full_run_with_bridge_ready_requires_host_acp_launch() -> None:
     assert "--host-local-acp-launch" in payload["reason"], payload
 
 
+def test_launcher_patches_rollout_planes_connect_acp() -> None:
+    source = (REPO_ROOT / "scripts" / "skillsbench_automation_loop.py").read_text(
+        encoding="utf-8"
+    )
+    assert "original_rollout_planes_connect_acp" in source, source
+    assert (
+        "benchflow_rollout_planes_module.connect_acp = connect_host_local_acp"
+        in source
+    ), source
+    assert (
+        "benchflow_rollout_planes_module.connect_acp = (\n"
+        "                original_rollout_planes_connect_acp\n"
+        "            )"
+        in source
+    ), source
+
+
 if __name__ == "__main__":
     test_route_contract_requires_native_goal_proof()
     test_worker_contract_is_public_safe()
@@ -380,4 +397,5 @@ if __name__ == "__main__":
     test_acp_relay_delegates_to_app_server_goal_worker()
     test_full_run_fails_closed_until_bridge_is_materialized()
     test_full_run_with_bridge_ready_requires_host_acp_launch()
+    test_launcher_patches_rollout_planes_connect_acp()
     print("skillsbench-app-server-goal-worker smoke ok")

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -3049,6 +3049,9 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
     original_rollout_connect_acp = getattr(
         benchflow_rollout_module, "connect_acp", _MISSING
     )
+    original_rollout_planes_connect_acp = getattr(
+        benchflow_rollout_planes_module, "connect_acp", _MISSING
+    )
     rollout_planes_class = getattr(
         benchflow_rollout_planes_module, "DefaultRolloutPlanes", None
     )
@@ -3251,6 +3254,8 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
         benchflow_acp_runtime.connect_acp = connect_host_local_acp
         if original_rollout_connect_acp is not _MISSING:
             benchflow_rollout_module.connect_acp = connect_host_local_acp
+        if original_rollout_planes_connect_acp is not _MISSING:
+            benchflow_rollout_planes_module.connect_acp = connect_host_local_acp
     try:
         await benchflow_run(config)
         result_path = discover_benchflow_result_path(plan)
@@ -3267,6 +3272,10 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
         benchflow_acp_runtime.connect_acp = original_runtime_connect_acp
         if original_rollout_connect_acp is not _MISSING:
             benchflow_rollout_module.connect_acp = original_rollout_connect_acp
+        if original_rollout_planes_connect_acp is not _MISSING:
+            benchflow_rollout_planes_module.connect_acp = (
+                original_rollout_planes_connect_acp
+            )
         _merge_acp_trajectory_summary(plan, controller_trace)
         _write_controller_trace(plan, controller_trace)
     if result_path is None:


### PR DESCRIPTION
## Summary
- patch benchflow.rollout_planes.connect_acp for host-local SkillsBench ACP launches
- restore the patched entrypoint after each run
- add smoke coverage so the native Goal route cannot silently fall back to container codex-acp

## Validation
- python3 examples/skillsbench-app-server-goal-worker-smoke.py
- python3 -m py_compile scripts/skillsbench_automation_loop.py examples/skillsbench-app-server-goal-worker-smoke.py
- git diff --check
- goal-harness check --scan-path scripts/skillsbench_automation_loop.py --scan-path examples/skillsbench-app-server-goal-worker-smoke.py
- remote ECS smoke: python3 examples/skillsbench-app-server-goal-worker-smoke.py
- remote ECS r2 launch is running past the previous /opt/benchflow/bin/codex-acp missing blocker
