### PR TITLE
Keep native Goal benchmark ACP runs active

### DIFF
--- a/examples/codex-app-server-goal-driver-smoke.py
+++ b/examples/codex-app-server-goal-driver-smoke.py
@@ -33,6 +33,12 @@ for line in sys.stdin:
     elif method == "thread/goal/get":
         result = {"goal": {"threadId": "thread-smoke", "status": "active"}}
     elif method == "turn/start":
+        if msg.get("params", {}).get("effort") != "high":
+            print(json.dumps({
+                "id": mid,
+                "error": {"code": -32602, "message": "missing high effort"},
+            }), flush=True)
+            continue
         result = {"turn": {"id": "turn-smoke", "status": "running"}}
         print(json.dumps({"id": mid, "result": result}), flush=True)
         print(json.dumps({
@@ -80,6 +86,7 @@ def main() -> int:
             objective="Synthetic objective.",
             prompt="Synthetic prompt.",
             model_name="gpt-5.5",
+            reasoning_effort="high",
             response_timeout_sec=5,
         )
         try:
@@ -103,6 +110,7 @@ def main() -> int:
             objective="Synthetic objective.",
             prompt="Synthetic prompt.",
             model_name="gpt-5.5",
+            reasoning_effort="high",
             response_timeout_sec=5,
             wait_for_completion=True,
             turn_timeout_sec=5,

--- a/examples/harbor-host-codex-goal-agent-smoke.py
+++ b/examples/harbor-host-codex-goal-agent-smoke.py
@@ -76,6 +76,7 @@ def main() -> int:
         assert agent.poll_interval_sec == 0.5
         assert agent.task_workdir == "/workspace"
         assert agent.goal_surface == "app_server"
+        assert agent.reasoning_effort == "high"
         assert agent.app_server_wait_for_completion is True
         assert agent.app_server_response_timeout_sec == 4.0
 

--- a/examples/skillsbench-app-server-goal-worker-smoke.py
+++ b/examples/skillsbench-app-server-goal-worker-smoke.py
@@ -47,6 +47,12 @@ for line in sys.stdin:
     elif method == "thread/goal/get":
         result = {"goal": {"threadId": "thread-skillsbench", "status": "active"}}
     elif method == "turn/start":
+        if msg.get("params", {}).get("effort") != "high":
+            print(json.dumps({
+                "id": mid,
+                "error": {"code": -32602, "message": "missing high effort"},
+            }), flush=True)
+            continue
         result = {"turn": {"id": "turn-skillsbench", "status": "running"}}
         print(json.dumps({"id": mid, "result": result}), flush=True)
         print(json.dumps({
@@ -246,6 +252,7 @@ def test_host_worker_contract_only_cli() -> None:
     contract = payload["worker_contract"]
     assert contract["route"] == ROUTE, contract
     assert contract["worker_adapter"]["script"] == "scripts/skillsbench_host_codex_goal_worker.py", contract
+    assert contract["worker_adapter"]["reasoning_effort"] == "high", contract
 
 
 def test_host_worker_waits_for_completion_and_keeps_public_json_compact() -> None:
@@ -323,6 +330,115 @@ def test_acp_relay_delegates_to_app_server_goal_worker() -> None:
             timeout_sec=10,
         )
     assert probe["ready"] is True, probe
+
+
+def test_acp_relay_streams_public_keepalive_while_worker_runs() -> None:
+    fake_worker = """#!/usr/bin/env python3
+import argparse
+import json
+import time
+from pathlib import Path
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--response-text-file")
+parser.add_argument("--output-json")
+args, _ = parser.parse_known_args()
+time.sleep(0.25)
+Path(args.response_text_file).write_text("private delayed answer", encoding="utf-8")
+Path(args.output_json).write_text(json.dumps({"ok": True}), encoding="utf-8")
+"""
+    with tempfile.TemporaryDirectory(prefix="skillsbench-app-goal-keepalive-") as tmp:
+        root = Path(tmp)
+        worker = root / "fake_worker.py"
+        work = root / "work"
+        worker.write_text(fake_worker, encoding="utf-8")
+        worker.chmod(0o755)
+        work.mkdir()
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                str(REPO_ROOT / "scripts" / "skillsbench_local_acp_relay.py"),
+                "--app-server-goal-worker",
+                "--task-id",
+                "llm-prefix-cache-replay",
+                "--worker-script",
+                str(worker),
+                "--timeout-sec",
+                "5",
+                "--stream-heartbeat-interval-sec",
+                "0.05",
+            ],
+            cwd=REPO_ROOT,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        assert proc.stdin is not None
+        assert proc.stdout is not None
+
+        def send(message: dict[str, Any]) -> None:
+            proc.stdin.write(json.dumps(message) + "\n")
+            proc.stdin.flush()
+
+        def read_response(request_id: int) -> dict[str, Any]:
+            while True:
+                line = proc.stdout.readline()
+                assert line, proc.stderr.read()
+                message = json.loads(line)
+                if message.get("id") == request_id and "method" not in message:
+                    return message
+
+        send({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}})
+        read_response(1)
+        send(
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "session/new",
+                "params": {"cwd": str(work), "mcpServers": []},
+            }
+        )
+        session_id = read_response(2)["result"]["sessionId"]
+        send(
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "session/set_model",
+                "params": {"sessionId": session_id, "modelId": "probe-model"},
+            }
+        )
+        read_response(3)
+        send(
+            {
+                "jsonrpc": "2.0",
+                "id": 4,
+                "method": "session/prompt",
+                "params": {
+                    "sessionId": session_id,
+                    "prompt": [{"type": "text", "text": "private task placeholder"}],
+                },
+            }
+        )
+        keepalive_seen = False
+        final_response = None
+        for _ in range(20):
+            line = proc.stdout.readline()
+            assert line, proc.stderr.read()
+            message = json.loads(line)
+            if message.get("method") == "session/update":
+                update = message["params"]["update"]
+                if update.get("sessionUpdate") == "agent_thought_chunk":
+                    keepalive_seen = True
+                    assert "task placeholder" not in json.dumps(update), update
+            if message.get("id") == 4 and "method" not in message:
+                final_response = message
+                break
+        assert keepalive_seen
+        assert final_response is not None
+        assert final_response["result"]["stopReason"] == "end_turn"
+        proc.terminate()
+        proc.wait(timeout=2)
 
 
 def test_full_run_fails_closed_until_bridge_is_materialized() -> None:

--- a/examples/terminal-bench-host-codex-goal-agent-smoke.py
+++ b/examples/terminal-bench-host-codex-goal-agent-smoke.py
@@ -66,6 +66,7 @@ def main() -> int:
     assert agent.goal_timeout_sec == 7.0
     assert agent.poll_interval_sec == 0.5
     assert agent.goal_surface == "app_server"
+    assert agent.reasoning_effort == "high"
     assert agent.app_server_wait_for_completion is True
     assert agent.app_server_response_timeout_sec == 4.0
     assert str(agent.work_root) == "/tmp/goal-harness-terminal-bench"

--- a/goal_harness/benchmark_adapters/skillsbench.py
+++ b/goal_harness/benchmark_adapters/skillsbench.py
@@ -342,6 +342,7 @@ def build_skillsbench_app_server_goal_worker_contract(
     task_id: str = SKILLSBENCH_DEFAULT_TASK,
     cwd: str = "<skillsbench-task-workspace>",
     model: str = SKILLSBENCH_DEFAULT_MODEL,
+    reasoning_effort: str = "high",
     codex_bin: str = "codex",
     sandbox: str = "workspace-write",
     approval_policy: str = "never",
@@ -402,6 +403,7 @@ def build_skillsbench_app_server_goal_worker_contract(
         sandbox=sandbox,
         approval_policy=approval_policy,
         model=model,
+        effort=reasoning_effort,
     )
     ready = not blockers and compact_reducer_ready and no_upload and not submit_enabled
     if ready:
@@ -425,6 +427,10 @@ def build_skillsbench_app_server_goal_worker_contract(
             "label": "skillsbench_host_codex_app_server_goal_worker",
             "script": "scripts/skillsbench_host_codex_goal_worker.py",
             "codex_bin": _skillsbench_public_safe_label(codex_bin, limit=80) or "codex",
+            "reasoning_effort": _skillsbench_public_safe_label(
+                reasoning_effort, limit=40
+            )
+            or "high",
             "agent_execution_mode": "host_codex_app_server_goal_worker",
             "worker_surface": "codex_app_server",
             "native_goal_methods_required": list(worker_plan["methods"]),

--- a/goal_harness/benchmark_adapters/skillsbench_acp_relay.py
+++ b/goal_harness/benchmark_adapters/skillsbench_acp_relay.py
@@ -69,6 +69,8 @@ class CodexExecConfig:
     approval_policy: str = "never"
     response_timeout_sec: float = 30.0
     worker_script: str | None = None
+    stream_heartbeat_interval_sec: float = 120.0
+    reasoning_effort: str | None = "high"
 
 
 class SkillsBenchLocalAcpRelay:
@@ -159,7 +161,12 @@ class SkillsBenchLocalAcpRelay:
         if not prompt_text:
             return _json_rpc_error(message_id, -32602, "prompt text missing")
         try:
-            response_text = self._run_codex(prompt_text, session=session)
+            response_text = self._run_codex(
+                prompt_text,
+                session=session,
+                session_id=session_id,
+                stdout=stdout,
+            )
         except TimeoutError:
             return _json_rpc_error(message_id, -32002, "local codex execution timeout")
         except RuntimeError as exc:
@@ -180,11 +187,23 @@ class SkillsBenchLocalAcpRelay:
         )
         return _json_rpc_result(message_id, {"stopReason": "end_turn"})
 
-    def _run_codex(self, prompt_text: str, *, session: dict[str, Any]) -> str:
+    def _run_codex(
+        self,
+        prompt_text: str,
+        *,
+        session: dict[str, Any],
+        session_id: str,
+        stdout: TextIO,
+    ) -> str:
         if self._config.dry_run_response is not None:
             return self._config.dry_run_response
         if self._config.app_server_goal_worker:
-            return self._run_app_server_goal_worker(prompt_text, session=session)
+            return self._run_app_server_goal_worker(
+                prompt_text,
+                session=session,
+                session_id=session_id,
+                stdout=stdout,
+            )
         cwd = _safe_cwd(session.get("cwd"), default=os.getcwd())
         with tempfile.TemporaryDirectory(prefix="gh-skillsbench-acp-") as tmp:
             output_path = Path(tmp) / "last-message.txt"
@@ -225,7 +244,12 @@ class SkillsBenchLocalAcpRelay:
             return response or "local codex returned an empty final message"
 
     def _run_app_server_goal_worker(
-        self, prompt_text: str, *, session: dict[str, Any]
+        self,
+        prompt_text: str,
+        *,
+        session: dict[str, Any],
+        session_id: str,
+        stdout: TextIO,
     ) -> str:
         cwd = _safe_cwd(session.get("cwd"), default=os.getcwd())
         with tempfile.TemporaryDirectory(prefix="gh-skillsbench-goal-worker-") as tmp:
@@ -266,20 +290,47 @@ class SkillsBenchLocalAcpRelay:
                 str(self._config.response_timeout_sec),
                 "--turn-timeout-sec",
                 str(self._config.timeout_sec),
+                "--reasoning-effort",
+                str(self._config.reasoning_effort or "high"),
                 "--runner-integration-ready",
             ]
             model = self._config.model or session.get("model")
             if model:
                 cmd.extend(["--model", str(model)])
             try:
-                proc = subprocess.run(
+                proc = subprocess.Popen(
                     cmd,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
                     text=True,
-                    timeout=self._config.timeout_sec + 60,
-                    check=False,
                 )
+                self._write_worker_heartbeat(
+                    stdout,
+                    session_id=session_id,
+                    text="host app-server goal worker started",
+                )
+                deadline = time.monotonic() + self._config.timeout_sec + 60
+                next_heartbeat = (
+                    time.monotonic()
+                    + max(1.0, self._config.stream_heartbeat_interval_sec)
+                )
+                while proc.poll() is None:
+                    now = time.monotonic()
+                    if now >= deadline:
+                        proc.kill()
+                        proc.communicate(timeout=2)
+                        raise TimeoutError
+                    if now >= next_heartbeat:
+                        self._write_worker_heartbeat(
+                            stdout,
+                            session_id=session_id,
+                            text="host app-server goal worker still running",
+                        )
+                        next_heartbeat = (
+                            now + max(1.0, self._config.stream_heartbeat_interval_sec)
+                        )
+                    time.sleep(0.2)
+                proc.communicate(timeout=5)
             except subprocess.TimeoutExpired as exc:
                 raise TimeoutError from exc
             if proc.returncode != 0:
@@ -289,6 +340,30 @@ class SkillsBenchLocalAcpRelay:
             except OSError as exc:
                 raise RuntimeError("host app-server goal worker response missing") from exc
             return response or "host app-server goal worker returned an empty final message"
+
+    def _write_worker_heartbeat(
+        self,
+        stdout: TextIO,
+        *,
+        session_id: str,
+        text: str,
+    ) -> None:
+        """Emit a public-safe ACP activity heartbeat while the host worker runs."""
+
+        self._write(
+            stdout,
+            {
+                "jsonrpc": "2.0",
+                "method": "session/update",
+                "params": {
+                    "sessionId": session_id,
+                    "update": {
+                        "sessionUpdate": "agent_thought_chunk",
+                        "content": {"type": "text", "text": text},
+                    },
+                },
+            },
+        )
 
     @staticmethod
     def _write(stdout: TextIO, message: dict[str, Any]) -> None:

--- a/scripts/codex_app_server_goal_driver.py
+++ b/scripts/codex_app_server_goal_driver.py
@@ -223,6 +223,7 @@ def start_codex_app_server_goal_turn(
     objective: str,
     prompt: str,
     model_name: str | None = None,
+    reasoning_effort: str | None = None,
     approval_policy: str = "never",
     sandbox: str = "danger-full-access",
     response_timeout_sec: float = 30.0,
@@ -336,6 +337,8 @@ def start_codex_app_server_goal_turn(
         }
         if model_name:
             turn_params["model"] = model_name
+        if reasoning_effort:
+            turn_params["effort"] = reasoning_effort
         turn_start = {
             "id": 5,
             "method": "turn/start",

--- a/scripts/harbor_host_codex_goal_agent.py
+++ b/scripts/harbor_host_codex_goal_agent.py
@@ -175,6 +175,7 @@ class HarborHostCodexGoalAgent(BaseAgent):
         codex_bin: str = "codex",
         task_workdir: str = "/app",
         goal_surface: str = "tui",
+        reasoning_effort: str | None = "high",
         app_server_wait_for_completion: str | bool = True,
         app_server_response_timeout_sec: str | int | float = 30,
         startup_delay_sec: str | int | float = 5,
@@ -186,6 +187,7 @@ class HarborHostCodexGoalAgent(BaseAgent):
         self.codex_bin = codex_bin
         self.task_workdir = task_workdir
         self.goal_surface = goal_surface
+        self.reasoning_effort = reasoning_effort
         self.app_server_wait_for_completion = _coerce_bool(app_server_wait_for_completion)
         self.app_server_response_timeout_sec = float(app_server_response_timeout_sec)
         self.startup_delay_sec = float(startup_delay_sec)
@@ -309,6 +311,7 @@ class HarborHostCodexGoalAgent(BaseAgent):
                         objective="Complete the Harbor benchmark task using the task environment bridge.",
                         prompt=prompt,
                         model_name=self.model_name,
+                        reasoning_effort=self.reasoning_effort,
                         response_timeout_sec=self.app_server_response_timeout_sec,
                         wait_for_completion=self.app_server_wait_for_completion,
                         turn_timeout_sec=self.goal_timeout_sec,

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -626,8 +626,12 @@ def _host_local_acp_launch_command(args: argparse.Namespace) -> list[str]:
                 args.task_id,
                 "--approval-policy",
                 "never",
+                "--reasoning-effort",
+                args.app_server_reasoning_effort,
                 "--response-timeout-sec",
                 "30",
+                "--stream-heartbeat-interval-sec",
+                str(args.app_server_acp_heartbeat_interval_sec),
             ]
         )
     command.extend(
@@ -1617,6 +1621,7 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
             task_id=task_id,
             cwd="<skillsbench-task-workspace>",
             model=args.model,
+            reasoning_effort=args.app_server_reasoning_effort,
             sandbox="workspace-write",
             approval_policy="never",
             no_upload=True,
@@ -3686,6 +3691,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         ),
     )
     parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument(
+        "--app-server-reasoning-effort",
+        default="high",
+        help=(
+            "Reasoning effort passed as turn/start effort for native "
+            "codex-app-server-goal-baseline runs. Formal benchmark runs "
+            "default to high."
+        ),
+    )
     parser.add_argument("--sandbox", default="docker")
     parser.add_argument("--sandbox-user", default="agent")
     parser.add_argument(
@@ -3729,6 +3743,16 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--outer-timeout-sec", type=int, default=DEFAULT_TIMEOUT_SEC)
     parser.add_argument("--sandbox-setup-timeout", type=int, default=DEFAULT_TIMEOUT_SEC)
     parser.add_argument("--agent-idle-timeout", type=int, default=900)
+    parser.add_argument(
+        "--app-server-acp-heartbeat-interval-sec",
+        type=float,
+        default=120.0,
+        help=(
+            "Public-safe ACP thought keepalive interval while a host "
+            "app-server Goal worker is active. Must stay below "
+            "--agent-idle-timeout for long-running native Goal cases."
+        ),
+    )
     parser.add_argument("--max-verifier-output-chars", type=int, default=0)
     parser.add_argument("--skillsbench-root", default=str(DEFAULT_SKILLSBENCH_ROOT))
     parser.add_argument(

--- a/scripts/skillsbench_host_codex_goal_worker.py
+++ b/scripts/skillsbench_host_codex_goal_worker.py
@@ -44,6 +44,7 @@ def build_contract_payload(args: argparse.Namespace) -> dict[str, Any]:
         task_id=args.task_id,
         cwd="<skillsbench-task-workspace>",
         model=args.model,
+        reasoning_effort=args.reasoning_effort,
         codex_bin=args.codex_bin,
         sandbox=args.sandbox,
         approval_policy=args.approval_policy,
@@ -68,6 +69,7 @@ def run_worker(args: argparse.Namespace) -> dict[str, Any]:
         objective=objective,
         prompt=prompt,
         model_name=args.model,
+        reasoning_effort=args.reasoning_effort,
         approval_policy=args.approval_policy,
         sandbox=args.sandbox,
         response_timeout_sec=args.response_timeout_sec,
@@ -120,6 +122,14 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--dataset", default=SKILLSBENCH_DEFAULT_DATASET)
     parser.add_argument("--task-id", default=SKILLSBENCH_DEFAULT_TASK)
     parser.add_argument("--model", default=SKILLSBENCH_DEFAULT_MODEL)
+    parser.add_argument(
+        "--reasoning-effort",
+        default="high",
+        help=(
+            "Codex app-server turn/start effort. Formal benchmark runs default "
+            "to high; smoke/debug runs may override this explicitly."
+        ),
+    )
     parser.add_argument("--codex-bin", default="codex")
     parser.add_argument("--sandbox", default="workspace-write")
     parser.add_argument("--approval-policy", default="never")

--- a/scripts/skillsbench_local_acp_relay.py
+++ b/scripts/skillsbench_local_acp_relay.py
@@ -62,10 +62,27 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--task-id", default="llm-prefix-cache-replay")
     parser.add_argument("--approval-policy", default="never")
     parser.add_argument(
+        "--reasoning-effort",
+        default="high",
+        help=(
+            "Codex app-server turn/start effort for --app-server-goal-worker. "
+            "Formal benchmark runs default to high."
+        ),
+    )
+    parser.add_argument(
         "--response-timeout-sec",
         type=float,
         default=30.0,
         help="Timeout for the worker to observe initial app-server response events.",
+    )
+    parser.add_argument(
+        "--stream-heartbeat-interval-sec",
+        type=float,
+        default=120.0,
+        help=(
+            "Interval for public-safe ACP thought keepalives while the host "
+            "app-server Goal worker is still executing."
+        ),
     )
     parser.add_argument(
         "--worker-script",
@@ -88,8 +105,10 @@ def main(argv: list[str] | None = None) -> int:
             dataset=args.dataset,
             task_id=args.task_id,
             approval_policy=args.approval_policy,
+            reasoning_effort=args.reasoning_effort,
             response_timeout_sec=args.response_timeout_sec,
             worker_script=args.worker_script,
+            stream_heartbeat_interval_sec=args.stream_heartbeat_interval_sec,
         )
     )
     return relay.serve()

--- a/scripts/terminal_bench_host_codex_goal_agent.py
+++ b/scripts/terminal_bench_host_codex_goal_agent.py
@@ -123,6 +123,7 @@ class HostCodexGoalAgent(BaseAgent):
         task_workdir: str = "/app",
         codex_bin: str = "codex",
         goal_surface: str = "tui",
+        reasoning_effort: str | None = "high",
         app_server_wait_for_completion: str | bool = True,
         app_server_response_timeout_sec: str | int | float = 30,
         startup_delay_sec: str | int | float = 5,
@@ -142,6 +143,7 @@ class HostCodexGoalAgent(BaseAgent):
         self.task_workdir = task_workdir
         self.codex_bin = codex_bin
         self.goal_surface = goal_surface
+        self.reasoning_effort = reasoning_effort
         self.app_server_wait_for_completion = _coerce_bool(app_server_wait_for_completion)
         self.app_server_response_timeout_sec = float(app_server_response_timeout_sec)
         self.startup_delay_sec = float(startup_delay_sec)
@@ -207,6 +209,7 @@ class HostCodexGoalAgent(BaseAgent):
                     objective="Complete the Terminal-Bench task using the task container.",
                     prompt=prompt,
                     model_name=self.model_name,
+                    reasoning_effort=self.reasoning_effort,
                     response_timeout_sec=self.app_server_response_timeout_sec,
                     wait_for_completion=self.app_server_wait_for_completion,
                     turn_timeout_sec=self.goal_timeout_sec,


### PR DESCRIPTION
## Summary
- stream public-safe ACP thought keepalives while SkillsBench host app-server Goal workers are still executing, so BenchFlow does not misclassify active long-running Goal turns as idle
- pass explicit `effort=high` through app-server Goal benchmark launches for SkillsBench, Terminal-Bench, and SWE-Marathon/Harbor host agents
- add focused smokes for app-server effort propagation and SkillsBench ACP keepalive behavior

## Validation
- `python3 examples/codex-app-server-goal-driver-smoke.py`
- `python3 examples/skillsbench-app-server-goal-worker-smoke.py`
- `python3 examples/terminal-bench-host-codex-goal-agent-smoke.py`
- `python3 examples/harbor-host-codex-goal-agent-smoke.py`
- `python3 -m py_compile scripts/codex_app_server_goal_driver.py scripts/skillsbench_host_codex_goal_worker.py scripts/skillsbench_local_acp_relay.py scripts/skillsbench_automation_loop.py scripts/terminal_bench_host_codex_goal_agent.py scripts/harbor_host_codex_goal_agent.py goal_harness/benchmark_adapters/skillsbench.py goal_harness/benchmark_adapters/skillsbench_acp_relay.py examples/skillsbench-app-server-goal-worker-smoke.py examples/codex-app-server-goal-driver-smoke.py examples/terminal-bench-host-codex-goal-agent-smoke.py examples/harbor-host-codex-goal-agent-smoke.py`
- `git diff --check`
- `goal-harness check --scan-path ...`

## Remote follow-up
- synced to `/data/goal-harness-bench/tools/goal-harness-main-20260621-acp-keepalive`
- relaunched SkillsBench `llm-prefix-cache-replay` and `tictoc-unnecessary-abort-detection` with keepalive + `effort=high`
