### PR TITLE
docs: record Terminal-Bench build-cython closeouts

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
@@ -6997,6 +6997,71 @@
               "source_event_schema": "benchmark_run_v0",
               "status": "completed",
               "submit_eligible": false
+            },
+            {
+              "agent_declared_done": false,
+              "arm_id": "codex-native-goal",
+              "artifact_refs": {
+                "compact_artifact_ref": "terminal-bench/build-cython-ext/pr335-r1/terminal_bench_official_result.compact.json"
+              },
+              "benchmark_id": "terminal-bench@2.0",
+              "case_id": "build-cython-ext",
+              "case_ids": [
+                "build-cython-ext"
+              ],
+              "codex_acp_runtime_preflight_passed": false,
+              "failure_class": "none",
+              "failure_scope": "passed",
+              "goal_harness_inside_case": false,
+              "job_name": "build-cython-ext-host-app-server-goal-20260620t181051z",
+              "leaderboard_evidence": false,
+              "mode": "terminal_bench_host_codex_app_server_goal",
+              "notes": "Terminal-Bench build-cython-ext native app-server Goal compact official result: score 1.0; public-safe compact only.",
+              "official_passed": true,
+              "official_score": 1.0,
+              "recorded_at": "2026-06-21T04:08:17+08:00",
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "terminal-bench-build-cython-ext-app-server-pr335-r1",
+              "run_id": "84f5b6b69627",
+              "score_status": "passed",
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false
+            },
+            {
+              "agent_declared_done": false,
+              "arm_id": "codex-native-goal-completion-aware",
+              "artifact_refs": {
+                "compact_artifact_ref": "terminal-bench/build-cython-ext/pr336-r2/terminal_bench_official_result.compact.json"
+              },
+              "benchmark_id": "terminal-bench@2.0",
+              "case_id": "build-cython-ext",
+              "case_ids": [
+                "build-cython-ext"
+              ],
+              "codex_acp_runtime_preflight_passed": false,
+              "failure_class": "official_verifier_solution_failure",
+              "failure_labels": [
+                "official_verifier_solution_failure"
+              ],
+              "failure_scope": "case_or_solution",
+              "goal_harness_inside_case": false,
+              "job_name": "build-cython-ext-host-app-server-goal-20260620t182136z",
+              "leaderboard_evidence": false,
+              "mode": "terminal_bench_host_codex_app_server_goal_completion_aware",
+              "notes": "Terminal-Bench build-cython-ext completion-aware app-server Goal compact official result: score 0.0; verifier-solution failure; public-safe compact only.",
+              "official_passed": false,
+              "official_score": 0.0,
+              "recorded_at": "2026-06-21T04:08:18+08:00",
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "terminal-bench-build-cython-ext-app-server-pr336-r2",
+              "run_id": "36cb8a6eabd8",
+              "score_status": "failed",
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false
             }
           ]
         },
@@ -10149,7 +10214,7 @@
           ]
         }
       },
-      "run_count": 82
+      "run_count": 84
     }
   },
   "schema_version": "benchmark_run_ledger_v0",
@@ -10160,5 +10225,5 @@
     "source_of_truth": "benchmark_run_v0 compact run events",
     "update_rule": "upsert one run entry when a benchmark case is ingested or closed"
   },
-  "updated_at": "2026-06-21T02:50:45+08:00"
+  "updated_at": "2026-06-21T04:08:18+08:00"
 }

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
@@ -5,7 +5,7 @@ benchmark case outcomes and artifact references; it must not contain raw
 logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 
 - schema_version: `benchmark_run_ledger_v0`
-- updated_at: `2026-06-21T02:50:45+08:00`
+- updated_at: `2026-06-21T04:08:18+08:00`
 
 ## Case Decisions
 
@@ -35,7 +35,7 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `skillsbench@1.1` | `travel-planning` | `baseline_failed_treatment_candidate` | - | `2` |
 | `swe-marathon` | `find-network-alignments` | `baseline_failed_treatment_candidate` | - | `1` |
 | `terminal-bench-worker-materialization@v0` | `nginx-request-logging` | `single_arm_recorded` | - | `2` |
-| `terminal-bench@2.0` | `build-cython-ext` | `baseline_passed_not_current_treatment_priority` | - | `8` |
+| `terminal-bench@2.0` | `build-cython-ext` | `baseline_passed_not_current_treatment_priority` | - | `10` |
 | `terminal-bench@2.0` | `cobol-modernization` | `paired_baseline_solved_treatment_preserved` | - | `2` |
 | `terminal-bench@2.0` | `compile-compcert` | `baseline_passed_not_current_treatment_priority` | - | `1` |
 | `terminal-bench@2.0` | `financial-document-processor` | `baseline_passed_not_current_treatment_priority` | - | `2` |
@@ -203,6 +203,8 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `terminal-bench@2.0` | `build-cython-ext` | `terminal_bench_host_codex_app_server_goal_baseline` | `` | `0.0` | `` | `` | `official_verifier_solution_failure` | `cloud-ecs/parallel-benchmark-20260620T131254Z/terminal-bench-build-cython-ext-host-app-server-goal-r9/terminal_official_metadata.compact.json` |
 | `terminal-bench@2.0` | `build-cython-ext` | `terminal_bench_host_codex_app_server_goal_baseline` | `` | `1.0` | `` | `` | `none` | `cloud-ecs/parallel-benchmark-20260621T020900Z/terminal-bench-build-cython-ext-app-server-pr335-r1/terminal_bench_official_result.compact.json` |
 | `terminal-bench@2.0` | `build-cython-ext` | `terminal_bench_host_codex_app_server_goal_completion_aware` | `` | `0.0` | `` | `` | `official_verifier_solution_failure` | `cloud-ecs/parallel-benchmark-20260621T022100Z/terminal-bench-build-cython-ext-app-server-pr336-r2/terminal_bench_official_result.compact.json` |
+| `terminal-bench@2.0` | `build-cython-ext` | `codex-native-goal` | `` | `1.0` | `` | `` | `none` | `terminal-bench/build-cython-ext/pr335-r1/terminal_bench_official_result.compact.json` |
+| `terminal-bench@2.0` | `build-cython-ext` | `codex-native-goal-completion-aware` | `` | `0.0` | `` | `` | `official_verifier_solution_failure` | `terminal-bench/build-cython-ext/pr336-r2/terminal_bench_official_result.compact.json` |
 | `terminal-bench@2.0` | `cobol-modernization` | `hardened_codex_baseline` | `` | `1.0` | `` | `` | `none` | `.local/private-benchmark-jobs/terminal-bench-cobol-modernization-paired-20260611T0903Z/baseline.compact.json` |
 | `terminal-bench@2.0` | `cobol-modernization` | `codex_goal_harness_treatment` | `` | `1.0` | `` | `` | `none` | `.local/private-benchmark-jobs/terminal-bench-cobol-modernization-paired-20260611T0903Z/treatment.compact.json` |
 | `terminal-bench@2.0` | `compile-compcert` | `codex_goal_mode_baseline` | `` | `1.0` | `` | `` | `none` | `.local/private-benchmark-jobs/terminal-bench-compile-compcert-baseline-2h-20260615T1934CST/baseline/jobs/terminal_bench_compile_compcert_codex_goal_mode_baseline_2h_20260615T1934CST/result.json` |


### PR DESCRIPTION
## Summary
- upsert two public-safe Terminal-Bench `build-cython-ext` app-server Goal compact closeouts into the benchmark run ledger
- record one score=1.0 native Goal result and one score=0.0 completion-aware result with `official_verifier_solution_failure`
- regenerate the Markdown ledger view

## Validation
- `goal-harness benchmark run-ledger-check --goal-id goal-harness-meta --run-ledger-path docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json`
- `python3 examples/benchmark-run-ledger-smoke.py`
- `goal-harness check --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md`
- `git diff --check -- docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md`

## Boundary
- compact benchmark result fields only
- no raw task text, raw logs, trajectories, credentials, uploads, or absolute private paths added
- existing historical `.local/private...` references in diff context are not newly introduced by this PR; `goal-harness check` reports public boundary scan clean for the touched files
