### PR TITLE
Make app-server completion observation non-blocking

### DIFF
--- a/docs/benchmark-developer-workflow.md
+++ b/docs/benchmark-developer-workflow.md
@@ -376,7 +376,6 @@ UV_LINK_MODE=copy uv run --no-default-groups harbor run \
   --env docker \
   --agent-import-path harbor_host_codex_goal_agent:HarborHostCodexGoalAgent \
   --agent-kwarg goal_timeout_sec=1200 \
-  --agent-kwarg app_server_wait_for_completion=true \
   --agent-kwarg task_workdir=/app \
   --jobs-dir <run-dir>/jobs \
   -p <task-dir>
@@ -389,11 +388,14 @@ benchmark family instead of hardcoding `/app` in runner patches. Commands issued
 through that bridge are forwarded to Harbor's `environment.exec()`, so the
 benchmark environment remains the task/scoring surface while Codex login, model
 access, tmux, and runtime state stay on the stable host layer.
-The Harbor app-server agent waits for `turn/completed` in a background thread
-while the async runner loop continues to serve `harbor-env-exec` bridge
-requests. Its compact turn file records bridge request count, marker
+The Harbor app-server agent drains app-server turn events while the async
+runner loop continues to serve `harbor-env-exec` bridge requests. Its compact
+turn file records bridge request count, marker observation, `turn/completed`
 observation, and assistant-message counters without raw task text, raw logs, or
-raw trajectories.
+raw trajectories. Do not make `turn/completed` the benchmark success gate for
+Harbor-family runs: the official environment result and the host completion
+marker are the scoring path, while app-server completion events are diagnostic
+only.
 
 The Harbor bundle requires `codex` and `rg`. `curl` is intentionally optional:
 host-copied dynamic curl binaries can fail inside Ubuntu task images because of
@@ -616,7 +618,6 @@ tb run \
   --no-rebuild \
   --agent-import-path terminal_bench_host_codex_goal_agent:HostCodexGoalAgent \
   --agent-kwarg goal_surface=app_server \
-  --agent-kwarg app_server_wait_for_completion=true \
   --agent-kwarg goal_timeout_sec=1200
 ```
 
@@ -627,11 +628,14 @@ case container while the container remains responsible for task files and
 official tests. The TUI `/goal` surface is a manual fallback only; do not count
 it as the default baseline when app-server `thread/goal/set`,
 `thread/goal/get`, and `turn/start` are available.
-The app-server host agent waits for `turn/completed` by default and writes a
-compact turn file with `turn_completed_observed`, assistant-message counters,
-and `completion_marker_observed`; pass
-`--agent-kwarg app_server_wait_for_completion=false` only for an explicit
-marker-only fallback probe.
+The app-server host agent treats the benchmark completion marker and official
+verifier as the success path. It drains app-server events opportunistically and
+writes a compact turn file with `turn_completed_observed`,
+assistant-message counters, and `completion_marker_observed`, but missing or
+late `turn/completed` is diagnostic only. Do not use `turn/completed` as a hard
+failure gate for Terminal-Bench: doing so can change execution semantics by
+terminating a still-running Goal turn before the marker or verifier has a chance
+to reflect the case outcome.
 
 When a Terminal-Bench launch produces only startup or materialization state,
 reduce it before writing Goal Harness evidence:

--- a/examples/codex-app-server-goal-driver-smoke.py
+++ b/examples/codex-app-server-goal-driver-smoke.py
@@ -101,6 +101,16 @@ def main() -> int:
             assert compact["turn_completed_observed"] is False
             assert compact["raw_transcript_recorded"] is False
             assert "Synthetic prompt" not in json.dumps(compact)
+            observed = module.observe_codex_app_server_goal_turn(
+                turn,
+                timeout_sec=5,
+                until_completed=True,
+            )
+            assert observed is True
+            compact = module.compact_turn_metadata(turn)
+            assert compact["turn_completed_observed"] is True, compact
+            assert compact["assistant_message_present"] is True, compact
+            assert "Synthetic final answer." not in json.dumps(compact), compact
         finally:
             turn.terminate()
 

--- a/examples/harbor-host-codex-goal-agent-smoke.py
+++ b/examples/harbor-host-codex-goal-agent-smoke.py
@@ -77,7 +77,7 @@ def main() -> int:
         assert agent.task_workdir == "/workspace"
         assert agent.goal_surface == "app_server"
         assert agent.reasoning_effort == "high"
-        assert agent.app_server_wait_for_completion is True
+        assert agent.app_server_wait_for_completion is False
         assert agent.app_server_response_timeout_sec == 4.0
 
         no_wait_agent = module.HarborHostCodexGoalAgent(

--- a/examples/terminal-bench-host-codex-goal-agent-smoke.py
+++ b/examples/terminal-bench-host-codex-goal-agent-smoke.py
@@ -67,7 +67,7 @@ def main() -> int:
     assert agent.poll_interval_sec == 0.5
     assert agent.goal_surface == "app_server"
     assert agent.reasoning_effort == "high"
-    assert agent.app_server_wait_for_completion is True
+    assert agent.app_server_wait_for_completion is False
     assert agent.app_server_response_timeout_sec == 4.0
     assert str(agent.work_root) == "/tmp/goal-harness-terminal-bench"
     assert agent.network_bootstrap_script is None

--- a/scripts/codex_app_server_goal_driver.py
+++ b/scripts/codex_app_server_goal_driver.py
@@ -31,6 +31,11 @@ class CodexAppServerGoalTurn:
     agent_message_item_count: int = 0
     item_completed_count: int = 0
     notifications: list[str] = field(default_factory=list)
+    _responses: "queue.Queue[dict[str, Any] | Exception] | None" = field(
+        default=None,
+        repr=False,
+    )
+    _assistant_message_parts: list[str] = field(default_factory=list, repr=False)
 
     def terminate(self, *, timeout_sec: float = 2.0) -> None:
         self.process.terminate()
@@ -159,61 +164,105 @@ def _item_text(item: Any) -> str:
     return ""
 
 
-def _wait_for_turn_completion(
+def _record_turn_event(
     turn: CodexAppServerGoalTurn,
-    responses: "queue.Queue[dict[str, Any] | Exception]",
+    msg: dict[str, Any] | Exception,
     *,
-    timeout_sec: float,
-) -> None:
-    deadline = time.monotonic() + timeout_sec
-    deltas: list[str] = []
-    while time.monotonic() < deadline:
-        try:
-            msg = responses.get(timeout=max(0.1, min(0.5, deadline - time.monotonic())))
-        except queue.Empty:
-            continue
-        if isinstance(msg, EOFError):
+    raise_on_error: bool,
+) -> bool:
+    if isinstance(msg, EOFError):
+        if raise_on_error:
             raise CodexAppServerGoalDriverError(
                 "codex app-server exited before turn completion"
             )
-        if isinstance(msg, Exception):
+        turn.notifications.append("stream/eof")
+        return False
+    if isinstance(msg, Exception):
+        if raise_on_error:
             raise CodexAppServerGoalDriverError(str(msg))
-        method = str(msg.get("method") or "")
-        if method:
-            turn.notifications.append(method)
-        params = msg.get("params") if isinstance(msg.get("params"), dict) else {}
-        if not method:
-            continue
-        msg_turn_id = _notification_turn_id(params)
-        msg_thread_id = _notification_thread_id(params)
-        if msg_turn_id and msg_turn_id != turn.turn_id:
-            continue
-        if msg_thread_id and msg_thread_id != turn.thread_id:
-            continue
-        if method == "item/agentMessage/delta":
-            delta = params.get("delta")
-            if isinstance(delta, str) and delta:
-                deltas.append(delta)
-                turn.agent_message_delta_count += 1
-            continue
-        if method == "item/completed":
-            turn.item_completed_count += 1
-            item = params.get("item")
-            item_text = _item_text(item)
-            if item_text:
-                turn.agent_message_item_count += 1
-                if not deltas:
-                    deltas.append(item_text)
-            continue
-        if method == "turn/completed":
-            turn.turn_completed_observed = True
-            turn.turn_status = _extract_turn_status(params) or turn.turn_status
-            turn.assistant_message = "".join(deltas)
-            return
-        if method == "error":
-            message = params.get("message") if isinstance(params, dict) else ""
+        turn.notifications.append("stream/error")
+        return False
+    method = str(msg.get("method") or "")
+    if method:
+        turn.notifications.append(method)
+    params = msg.get("params") if isinstance(msg.get("params"), dict) else {}
+    if not method:
+        return False
+    msg_turn_id = _notification_turn_id(params)
+    msg_thread_id = _notification_thread_id(params)
+    if msg_turn_id and msg_turn_id != turn.turn_id:
+        return False
+    if msg_thread_id and msg_thread_id != turn.thread_id:
+        return False
+    if method == "item/agentMessage/delta":
+        delta = params.get("delta")
+        if isinstance(delta, str) and delta:
+            turn._assistant_message_parts.append(delta)
+            turn.agent_message_delta_count += 1
+        return False
+    if method == "item/completed":
+        turn.item_completed_count += 1
+        item = params.get("item")
+        item_text = _item_text(item)
+        if item_text:
+            turn.agent_message_item_count += 1
+            if not turn._assistant_message_parts:
+                turn._assistant_message_parts.append(item_text)
+        return False
+    if method == "turn/completed":
+        turn.turn_completed_observed = True
+        turn.turn_status = _extract_turn_status(params) or turn.turn_status
+        turn.assistant_message = "".join(turn._assistant_message_parts)
+        return True
+    if method == "error":
+        message = params.get("message") if isinstance(params, dict) else ""
+        if raise_on_error:
             raise CodexAppServerGoalDriverError(str(message or "app-server error"))
-    raise CodexAppServerGoalDriverError("timed out waiting for turn completion")
+        turn.notifications.append("turn/error")
+    return False
+
+
+def observe_codex_app_server_goal_turn(
+    turn: CodexAppServerGoalTurn,
+    *,
+    timeout_sec: float = 0.0,
+    until_completed: bool = False,
+    raise_on_error: bool = False,
+) -> bool:
+    """Drain app-server turn events without making completion a success gate."""
+    if turn._responses is None:
+        return bool(turn.turn_completed_observed)
+    deadline = time.monotonic() + max(0.0, timeout_sec)
+    while True:
+        wait = 0.0
+        if timeout_sec > 0:
+            wait = max(0.0, min(0.5, deadline - time.monotonic()))
+        try:
+            msg = turn._responses.get(timeout=wait) if wait else turn._responses.get_nowait()
+        except queue.Empty:
+            if not until_completed or time.monotonic() >= deadline:
+                return bool(turn.turn_completed_observed)
+            continue
+        if _record_turn_event(turn, msg, raise_on_error=raise_on_error):
+            return True
+        if not until_completed and timeout_sec <= 0:
+            continue
+        if time.monotonic() >= deadline and not until_completed:
+            return bool(turn.turn_completed_observed)
+
+
+def _wait_for_turn_completion(
+    turn: CodexAppServerGoalTurn,
+    *,
+    timeout_sec: float,
+) -> None:
+    if not observe_codex_app_server_goal_turn(
+        turn,
+        timeout_sec=timeout_sec,
+        until_completed=True,
+        raise_on_error=True,
+    ):
+        raise CodexAppServerGoalDriverError("timed out waiting for turn completion")
 
 
 def start_codex_app_server_goal_turn(
@@ -363,11 +412,11 @@ def start_codex_app_server_goal_turn(
             goal_status=goal_status,
             turn_status=_extract_turn_status(turn_result),
             notifications=notifications,
+            _responses=responses,
         )
         if wait_for_completion:
             _wait_for_turn_completion(
                 turn,
-                responses,
                 timeout_sec=turn_timeout_sec or response_timeout_sec,
             )
         return turn

--- a/scripts/harbor_host_codex_goal_agent.py
+++ b/scripts/harbor_host_codex_goal_agent.py
@@ -28,6 +28,7 @@ if str(SCRIPT_DIR) not in sys.path:
 from codex_app_server_goal_driver import (
     CodexAppServerGoalDriverError,
     compact_turn_metadata,
+    observe_codex_app_server_goal_turn,
     start_codex_app_server_goal_turn,
 )
 
@@ -176,7 +177,7 @@ class HarborHostCodexGoalAgent(BaseAgent):
         task_workdir: str = "/app",
         goal_surface: str = "tui",
         reasoning_effort: str | None = "high",
-        app_server_wait_for_completion: str | bool = True,
+        app_server_wait_for_completion: str | bool = False,
         app_server_response_timeout_sec: str | int | float = 30,
         startup_delay_sec: str | int | float = 5,
         poll_interval_sec: str | int | float = 5,
@@ -313,8 +314,7 @@ class HarborHostCodexGoalAgent(BaseAgent):
                         model_name=self.model_name,
                         reasoning_effort=self.reasoning_effort,
                         response_timeout_sec=self.app_server_response_timeout_sec,
-                        wait_for_completion=self.app_server_wait_for_completion,
-                        turn_timeout_sec=self.goal_timeout_sec,
+                        wait_for_completion=False,
                     )
                 )
                 while not turn_task.done():
@@ -345,49 +345,47 @@ class HarborHostCodexGoalAgent(BaseAgent):
                 }
                 return
             await self._serve_bridge_requests(environment, request_dir)
-            compact = compact_turn_metadata(turn)
-            compact.update(
-                {
-                    "goal_surface": "app_server",
-                    "app_server_wait_for_completion": self.app_server_wait_for_completion,
-                    "completion_marker_observed": marker.exists(),
-                    "bridge_request_count": self._served_request_count,
-                    "first_blocker": ""
-                    if marker.exists()
-                    else "harbor_completion_marker_missing_after_turn_completed",
-                }
-            )
-            (work_dir / "app_server_goal_turn.compact.json").write_text(
-                json.dumps(compact, sort_keys=True) + "\n",
-                encoding="utf-8",
-            )
-            if self.app_server_wait_for_completion:
-                turn.terminate()
-                context.metadata = {
-                    "goal_harness_agent": self.name(),
-                    "completion_marker_observed": marker.exists(),
-                    "bridge_request_count": self._served_request_count,
-                    "goal_surface": "app_server",
-                    "turn_completed_observed": bool(turn.turn_completed_observed),
-                    "first_blocker": ""
-                    if marker.exists()
-                    else "harbor_completion_marker_missing_after_turn_completed",
-                }
-                return
+
+            def write_compact(first_blocker: str = "") -> None:
+                compact = compact_turn_metadata(turn)
+                compact.update(
+                    {
+                        "goal_surface": "app_server",
+                        "app_server_wait_for_completion_requested": self.app_server_wait_for_completion,
+                        "app_server_completion_hard_gate": False,
+                        "completion_marker_observed": marker.exists(),
+                        "bridge_request_count": self._served_request_count,
+                        "first_blocker": first_blocker,
+                    }
+                )
+                (work_dir / "app_server_goal_turn.compact.json").write_text(
+                    json.dumps(compact, sort_keys=True) + "\n",
+                    encoding="utf-8",
+                )
+
             deadline = time.time() + self.goal_timeout_sec
             try:
                 while time.time() < deadline:
+                    observe_codex_app_server_goal_turn(turn)
                     await self._serve_bridge_requests(environment, request_dir)
                     if marker.exists():
+                        observe_codex_app_server_goal_turn(
+                            turn,
+                            timeout_sec=min(2.0, self.poll_interval_sec),
+                        )
+                        write_compact()
                         turn.terminate()
                         context.metadata = {
                             "goal_harness_agent": self.name(),
                             "completion_marker_observed": True,
                             "bridge_request_count": self._served_request_count,
                             "goal_surface": "app_server",
+                            "turn_completed_observed": bool(turn.turn_completed_observed),
                         }
                         return
                     await asyncio.sleep(self.poll_interval_sec)
+                observe_codex_app_server_goal_turn(turn)
+                write_compact("harbor_completion_marker_missing_before_timeout")
             finally:
                 turn.terminate()
             context.metadata = {
@@ -395,6 +393,7 @@ class HarborHostCodexGoalAgent(BaseAgent):
                 "completion_marker_observed": False,
                 "bridge_request_count": self._served_request_count,
                 "goal_surface": "app_server",
+                "turn_completed_observed": bool(turn.turn_completed_observed),
                 "first_blocker": "harbor_host_codex_app_server_goal_timeout",
             }
             return

--- a/scripts/terminal_bench_host_codex_goal_agent.py
+++ b/scripts/terminal_bench_host_codex_goal_agent.py
@@ -27,6 +27,7 @@ if str(SCRIPT_DIR) not in sys.path:
 from codex_app_server_goal_driver import (
     CodexAppServerGoalDriverError,
     compact_turn_metadata,
+    observe_codex_app_server_goal_turn,
     start_codex_app_server_goal_turn,
 )
 
@@ -124,7 +125,7 @@ class HostCodexGoalAgent(BaseAgent):
         codex_bin: str = "codex",
         goal_surface: str = "tui",
         reasoning_effort: str | None = "high",
-        app_server_wait_for_completion: str | bool = True,
+        app_server_wait_for_completion: str | bool = False,
         app_server_response_timeout_sec: str | int | float = 30,
         startup_delay_sec: str | int | float = 5,
         poll_interval_sec: str | int | float = 5,
@@ -211,8 +212,7 @@ class HostCodexGoalAgent(BaseAgent):
                     model_name=self.model_name,
                     reasoning_effort=self.reasoning_effort,
                     response_timeout_sec=self.app_server_response_timeout_sec,
-                    wait_for_completion=self.app_server_wait_for_completion,
-                    turn_timeout_sec=self.goal_timeout_sec,
+                    wait_for_completion=False,
                 )
             except CodexAppServerGoalDriverError as exc:
                 (work_dir / "app_server_goal_turn.compact.json").write_text(
@@ -235,37 +235,38 @@ class HostCodexGoalAgent(BaseAgent):
                     total_output_tokens=0,
                     failure_mode=FailureMode.AGENT_TIMEOUT,
                 )
-            compact = compact_turn_metadata(turn)
-            compact.update(
-                {
-                    "goal_surface": "app_server",
-                    "app_server_wait_for_completion": self.app_server_wait_for_completion,
-                    "completion_marker_observed": marker.exists(),
-                    "first_blocker": ""
-                    if marker.exists()
-                    else "terminal_bench_completion_marker_missing_after_turn_completed",
-                }
-            )
-            (work_dir / "app_server_goal_turn.compact.json").write_text(
-                json.dumps(compact, sort_keys=True) + "\n",
-                encoding="utf-8",
-            )
-            if self.app_server_wait_for_completion:
-                turn.terminate()
-                if marker.exists():
-                    return AgentResult(total_input_tokens=0, total_output_tokens=0)
-                return AgentResult(
-                    total_input_tokens=0,
-                    total_output_tokens=0,
-                    failure_mode=FailureMode.AGENT_TIMEOUT,
+
+            def write_compact(first_blocker: str = "") -> None:
+                compact = compact_turn_metadata(turn)
+                compact.update(
+                    {
+                        "goal_surface": "app_server",
+                        "app_server_wait_for_completion_requested": self.app_server_wait_for_completion,
+                        "app_server_completion_hard_gate": False,
+                        "completion_marker_observed": marker.exists(),
+                        "first_blocker": first_blocker,
+                    }
                 )
+                (work_dir / "app_server_goal_turn.compact.json").write_text(
+                    json.dumps(compact, sort_keys=True) + "\n",
+                    encoding="utf-8",
+                )
+
             deadline = time.time() + self.goal_timeout_sec
             try:
                 while time.time() < deadline:
+                    observe_codex_app_server_goal_turn(turn)
                     if marker.exists():
+                        observe_codex_app_server_goal_turn(
+                            turn,
+                            timeout_sec=min(2.0, self.poll_interval_sec),
+                        )
+                        write_compact()
                         turn.terminate()
                         return AgentResult(total_input_tokens=0, total_output_tokens=0)
                     time.sleep(self.poll_interval_sec)
+                observe_codex_app_server_goal_turn(turn)
+                write_compact("terminal_bench_completion_marker_missing_before_timeout")
                 return AgentResult(
                     total_input_tokens=0,
                     total_output_tokens=0,


### PR DESCRIPTION
## Summary
- drain Codex app-server Goal turn events without making `turn/completed` a benchmark success gate
- make Terminal-Bench and Harbor host agents use marker/official runner outcome as the hard gate while recording completion metadata compactly
- update focused smokes and benchmark workflow docs to describe completion as diagnostic-only

## Validation
- `python3 -m py_compile scripts/codex_app_server_goal_driver.py scripts/terminal_bench_host_codex_goal_agent.py scripts/harbor_host_codex_goal_agent.py`
- `python3 examples/codex-app-server-goal-driver-smoke.py`
- `python3 examples/terminal-bench-host-codex-goal-agent-smoke.py`
- `python3 examples/harbor-host-codex-goal-agent-smoke.py`
- `goal-harness check --scan-path scripts/codex_app_server_goal_driver.py --scan-path scripts/terminal_bench_host_codex_goal_agent.py --scan-path scripts/harbor_host_codex_goal_agent.py --scan-path examples/codex-app-server-goal-driver-smoke.py --scan-path examples/terminal-bench-host-codex-goal-agent-smoke.py --scan-path examples/harbor-host-codex-goal-agent-smoke.py --scan-path docs/benchmark-developer-workflow.md`
- `git diff --check`

## Notes
- Public/private scan was clean. The only Goal Harness check warning was the pre-existing duplicate history index rows warning.
- This intentionally does not change SkillsBench worker semantics because SkillsBench needs app-server completion to produce its response text.