### PR TITLE
Record native Goal benchmark compact results

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
@@ -2626,9 +2626,10 @@
         "llm-prefix-cache-replay": {
           "case_id": "llm-prefix-cache-replay",
           "latest_decision": {
-            "baseline_failure_scope": "case_or_solution",
-            "baseline_run_id": "ec3f2c4a4a79",
-            "decision": "paired_no_score_uplift",
+            "baseline_failure_scope": "runner_or_setup",
+            "baseline_run_id": "07af93abd7ae",
+            "decision": "paired_baseline_runner_or_setup_repair_required",
+            "failure_class": "skillsbench_runner_error",
             "official_score_delta": 0.0,
             "treatment_failure_scope": "case_or_solution",
             "treatment_run_id": "5bfbc9e250f5"
@@ -3796,6 +3797,43 @@
               "round_success_observed": false,
               "run_group_id": "gh-skillsbench-llm-prefix-cloud-pair-r1-20260620",
               "run_id": "5bfbc9e250f5",
+              "score_status": "failed",
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false
+            },
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "skillsbench_codex_app_server_goal_baseline",
+              "artifact_refs": {
+                "compact_artifact_ref": "cloud-ecs/parallel-benchmark-20260621T194222Z/skillsbench-llm-prefix-native-goal-keepalive-r3/benchmark_run.compact.json"
+              },
+              "benchmark_id": "skillsbench@1.1",
+              "case_id": "llm-prefix-cache-replay",
+              "case_ids": [
+                "llm-prefix-cache-replay"
+              ],
+              "codex_acp_runtime_preflight_passed": true,
+              "failure_class": "skillsbench_runner_error",
+              "failure_labels": [
+                "skillsbench_runner_error"
+              ],
+              "failure_scope": "runner_or_setup",
+              "goal_harness_inside_case": false,
+              "job_name": "skillsbench_1_1_llm_prefix_cache_replay_codex_app_server_goal_baseline",
+              "leaderboard_evidence": false,
+              "mode": "skillsbench_codex_app_server_goal_baseline",
+              "model_control_status": "reported_model_from_result_metadata",
+              "notes": "ECS native app-server Goal keepalive compact official BenchFlow result; score=0.0; attribution=skillsbench_runner_error plus controller-trace validation gap; no raw task/log/trajectory read.",
+              "official_passed": false,
+              "official_score": 0.0,
+              "recorded_at": "2026-06-21T04:38:45+08:00",
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-llm-prefix-native-goal-keepalive-r3-20260621T194222Z",
+              "run_id": "07af93abd7ae",
               "score_status": "failed",
               "source_event_schema": "benchmark_run_v0",
               "status": "completed",
@@ -6145,9 +6183,10 @@
         "tictoc-unnecessary-abort-detection": {
           "case_id": "tictoc-unnecessary-abort-detection",
           "latest_decision": {
-            "baseline_failure_scope": "case_or_solution",
-            "baseline_run_id": "99b2fe6538a4",
-            "decision": "paired_no_score_uplift",
+            "baseline_failure_scope": "runner_or_setup",
+            "baseline_run_id": "617dd17115c6",
+            "decision": "paired_baseline_runner_or_setup_repair_required",
+            "failure_class": "skillsbench_runner_error",
             "official_score_delta": 0.0,
             "treatment_failure_scope": "case_or_solution",
             "treatment_run_id": "f86e63762ab2"
@@ -6375,6 +6414,43 @@
               "source_event_schema": "benchmark_run_v0",
               "status": "completed",
               "submit_eligible": false
+            },
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "skillsbench_codex_app_server_goal_baseline",
+              "artifact_refs": {
+                "compact_artifact_ref": "cloud-ecs/parallel-benchmark-20260621T194222Z/skillsbench-tictoc-native-goal-keepalive-r2/benchmark_run.compact.json"
+              },
+              "benchmark_id": "skillsbench@1.1",
+              "case_id": "tictoc-unnecessary-abort-detection",
+              "case_ids": [
+                "tictoc-unnecessary-abort-detection"
+              ],
+              "codex_acp_runtime_preflight_passed": true,
+              "failure_class": "skillsbench_runner_error",
+              "failure_labels": [
+                "skillsbench_runner_error"
+              ],
+              "failure_scope": "runner_or_setup",
+              "goal_harness_inside_case": false,
+              "job_name": "skillsbench_1_1_tictoc_unnecessary_abort_detection_codex_app_server_goal_baseline",
+              "leaderboard_evidence": false,
+              "mode": "skillsbench_codex_app_server_goal_baseline",
+              "model_control_status": "reported_model_from_result_metadata",
+              "notes": "ECS native app-server Goal keepalive compact official BenchFlow result; score=0.0; attribution=skillsbench_runner_error plus controller-trace validation gap; no raw task/log/trajectory read.",
+              "official_passed": false,
+              "official_score": 0.0,
+              "recorded_at": "2026-06-21T04:38:45+08:00",
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-tictoc-native-goal-keepalive-r2-20260621T194222Z",
+              "run_id": "617dd17115c6",
+              "score_status": "failed",
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false
             }
           ]
         },
@@ -6518,7 +6594,7 @@
           ]
         }
       },
-      "run_count": 115
+      "run_count": 117
     },
     "swe-marathon": {
       "benchmark_id": "swe-marathon",
@@ -7059,6 +7135,37 @@
               "run_group_id": "terminal-bench-build-cython-ext-app-server-pr336-r2",
               "run_id": "36cb8a6eabd8",
               "score_status": "failed",
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false
+            },
+            {
+              "agent_declared_done": false,
+              "arm_id": "terminal_bench_host_codex_app_server_goal_observe_only",
+              "artifact_refs": {
+                "compact_artifact_ref": "cloud-ecs/parallel-benchmark-20260621T203200Z/terminal-bench-build-cython-ext-app-server-observe-pr346-r1/terminal_bench_official_result.compact.json"
+              },
+              "benchmark_id": "terminal-bench@2.0",
+              "case_id": "build-cython-ext",
+              "case_ids": [
+                "build-cython-ext"
+              ],
+              "codex_acp_runtime_preflight_passed": false,
+              "failure_class": "none",
+              "failure_scope": "passed",
+              "goal_harness_inside_case": false,
+              "job_name": "build-cython-ext-host-app-server-goal-observe-20260620t203545z",
+              "leaderboard_evidence": false,
+              "mode": "terminal_bench_host_codex_app_server_goal_observe_only",
+              "notes": "ECS Terminal-Bench build-cython-ext host app-server Goal observe-only compact official result; accuracy=1.0; marker/official-verifier gated; no raw task/log/trajectory read.",
+              "official_passed": true,
+              "official_score": 1.0,
+              "recorded_at": "2026-06-21T04:42:27+08:00",
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "terminal-bench-build-cython-ext-app-server-observe-pr346-r1-20260621T203200Z",
+              "run_id": "80d729022ae6",
+              "score_status": "passed",
               "source_event_schema": "benchmark_run_v0",
               "status": "completed",
               "submit_eligible": false
@@ -10214,7 +10321,7 @@
           ]
         }
       },
-      "run_count": 84
+      "run_count": 85
     }
   },
   "schema_version": "benchmark_run_ledger_v0",
@@ -10225,5 +10332,5 @@
     "source_of_truth": "benchmark_run_v0 compact run events",
     "update_rule": "upsert one run entry when a benchmark case is ingested or closed"
   },
-  "updated_at": "2026-06-21T04:08:18+08:00"
+  "updated_at": "2026-06-21T04:42:27+08:00"
 }

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
@@ -5,7 +5,7 @@ benchmark case outcomes and artifact references; it must not contain raw
 logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 
 - schema_version: `benchmark_run_ledger_v0`
-- updated_at: `2026-06-21T04:08:18+08:00`
+- updated_at: `2026-06-21T04:42:27+08:00`
 
 ## Case Decisions
 
@@ -22,7 +22,7 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `skillsbench@1.1` | `dapt-intrusion-detection` | `paired_baseline_setup_preflight_selection_required` | - | `5` |
 | `skillsbench@1.1` | `debug-trl-grpo` | `paired_baseline_runner_or_setup_repair_required` | - | `9` |
 | `skillsbench@1.1` | `fix-build-agentops` | `baseline_runner_or_setup_repair_required` | - | `2` |
-| `skillsbench@1.1` | `llm-prefix-cache-replay` | `paired_no_score_uplift` | - | `22` |
+| `skillsbench@1.1` | `llm-prefix-cache-replay` | `paired_baseline_runner_or_setup_repair_required` | - | `23` |
 | `skillsbench@1.1` | `manufacturing-codebook-normalization` | `paired_no_score_uplift` | - | `4` |
 | `skillsbench@1.1` | `organize-messy-files` | `paired_baseline_solved_treatment_preserved` | - | `3` |
 | `skillsbench@1.1` | `paratransit-routing` | `paired_treatment_improved` | - | `9` |
@@ -31,11 +31,11 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `skillsbench@1.1` | `setup-fuzzing-py` | `baseline_runner_or_setup_repair_required` | - | `3` |
 | `skillsbench@1.1` | `software-dependency-audit` | `paired_no_score_uplift` | - | `6` |
 | `skillsbench@1.1` | `suricata-custom-exfil` | `paired_treatment_codex_acp_runtime_preflight_required` | - | `5` |
-| `skillsbench@1.1` | `tictoc-unnecessary-abort-detection` | `paired_no_score_uplift` | - | `3` |
+| `skillsbench@1.1` | `tictoc-unnecessary-abort-detection` | `paired_baseline_runner_or_setup_repair_required` | - | `4` |
 | `skillsbench@1.1` | `travel-planning` | `baseline_failed_treatment_candidate` | - | `2` |
 | `swe-marathon` | `find-network-alignments` | `baseline_failed_treatment_candidate` | - | `1` |
 | `terminal-bench-worker-materialization@v0` | `nginx-request-logging` | `single_arm_recorded` | - | `2` |
-| `terminal-bench@2.0` | `build-cython-ext` | `baseline_passed_not_current_treatment_priority` | - | `10` |
+| `terminal-bench@2.0` | `build-cython-ext` | `baseline_passed_not_current_treatment_priority` | - | `11` |
 | `terminal-bench@2.0` | `cobol-modernization` | `paired_baseline_solved_treatment_preserved` | - | `2` |
 | `terminal-bench@2.0` | `compile-compcert` | `baseline_passed_not_current_treatment_priority` | - | `1` |
 | `terminal-bench@2.0` | `financial-document-processor` | `baseline_passed_not_current_treatment_priority` | - | `2` |
@@ -144,6 +144,7 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `skillsbench@1.1` | `llm-prefix-cache-replay` | `skillsbench_raw_codex_autonomous_max5_baseline` | `` | `missing` | `` | `` | `skillsbench_docker_compose_image_build_failure` | `.local/private-benchmark-jobs/skillsbench-product-mode-llm-prefix-raw-baseline-20260616T1954CST/skillsbench_product_mode_llm_prefix_raw_baseline_20260616T1954CST/llm-prefix-cache-replay__raw_codex_autonomous_max5/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `llm-prefix-cache-replay` | `skillsbench_codex_acp_blind_loop_baseline` | `` | `0.0` | `` | `1:0,2:0,3:0,4:0,5:missing` | `official_score_zero_case_failure` | `cloud-ecs/parallel-benchmark-20260620T131254Z/skillsbench-llm-prefix-baseline-r1/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `llm-prefix-cache-replay` | `skillsbench_goal_harness_blind_loop_treatment` | `` | `0.0` | `` | `1:0,2:0,3:0,4:0,5:missing` | `official_score_zero_case_failure` | `cloud-ecs/parallel-benchmark-20260620T131254Z/skillsbench-llm-prefix-treatment-r1/benchmark_run.compact.json` |
+| `skillsbench@1.1` | `llm-prefix-cache-replay` | `skillsbench_codex_app_server_goal_baseline` | `` | `0.0` | `` | `` | `skillsbench_runner_error` | `cloud-ecs/parallel-benchmark-20260621T194222Z/skillsbench-llm-prefix-native-goal-keepalive-r3/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `manufacturing-codebook-normalization` | `codex_goal_mode_baseline` | `` | `0.0` | `` | `` | `official_verifier_solution_failure` | `` |
 | `skillsbench@1.1` | `manufacturing-codebook-normalization` | `goal_harness_automation_loop_treatment` | `` | `0.0` | `` | `` | `official_verifier_solution_failure` | `` |
 | `skillsbench@1.1` | `manufacturing-codebook-normalization` | `baseline` | `` | `0.0` | `` | `1:0,2:0` | `official_verifier_solution_failure` | `.local/private-benchmark-jobs/skillsbench-manufacturing-codebook-normalization-blind-baseline-v0/manufacturing-codebook-normalization__codex_acp_blind_loop_v0/benchmark_run.compact.json` |
@@ -190,6 +191,7 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `skillsbench@1.1` | `tictoc-unnecessary-abort-detection` | `skillsbench_raw_codex_autonomous_max5_baseline` | `` | `missing` | `` | `` | `skillsbench_docker_compose_setup_failure` | `.local/private-benchmark-jobs/skillsbench-product-mode-tictoc-unnecessary-abort-detection-raw-baseline-20260616T202521CST/skillsbench-product-mode-tictoc-unnecessary-abort-detection-raw-baseline-20260616T202521CST/tictoc-unnecessary-abort-detection__raw_codex_autonomous_max5/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `tictoc-unnecessary-abort-detection` | `skillsbench_codex_acp_blind_loop_baseline` | `` | `0.0` | `` | `1:0,2:0,3:0,4:0,5:missing` | `official_score_zero_case_failure` | `cloud-ecs/parallel-benchmark-20260620T131254Z/skillsbench-tictoc-baseline-r2/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `tictoc-unnecessary-abort-detection` | `skillsbench_goal_harness_blind_loop_treatment` | `` | `0.0` | `` | `1:0,2:0,3:0,4:0,5:missing` | `official_score_zero_case_failure` | `cloud-ecs/parallel-benchmark-20260620T131254Z/skillsbench-tictoc-treatment-r2/benchmark_run.compact.json` |
+| `skillsbench@1.1` | `tictoc-unnecessary-abort-detection` | `skillsbench_codex_app_server_goal_baseline` | `` | `0.0` | `` | `` | `skillsbench_runner_error` | `cloud-ecs/parallel-benchmark-20260621T194222Z/skillsbench-tictoc-native-goal-keepalive-r2/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `travel-planning` | `baseline` | `` | `1.0` | `1` | `1:1*` | `none` | `.local/private-benchmark-jobs/skillsbench-travel-planning-blind-baseline-20260616T1238CST/travel-planning__codex_acp_blind_loop/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `travel-planning` | `skillsbench_raw_codex_autonomous_max5_baseline` | `` | `0.0` | `` | `1:missing` | `official_score_zero_case_failure` | `cloud-ecs/skillsbench-real-case/gh-skillsbench-travel-planning-container-acp-configfix-20260620T063851/benchmark_run.compact.json` |
 | `swe-marathon` | `find-network-alignments` | `swe_marathon_host_codex_app_server_goal_baseline` | `` | `0.0` | `` | `` | `official_verifier_solution_failure` | `cloud-ecs/parallel-benchmark-20260620T131254Z/swe-marathon-find-network-alignments-host-app-server-goal-r6/harbor_job_result.compact.json` |
@@ -205,6 +207,7 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `terminal-bench@2.0` | `build-cython-ext` | `terminal_bench_host_codex_app_server_goal_completion_aware` | `` | `0.0` | `` | `` | `official_verifier_solution_failure` | `cloud-ecs/parallel-benchmark-20260621T022100Z/terminal-bench-build-cython-ext-app-server-pr336-r2/terminal_bench_official_result.compact.json` |
 | `terminal-bench@2.0` | `build-cython-ext` | `codex-native-goal` | `` | `1.0` | `` | `` | `none` | `terminal-bench/build-cython-ext/pr335-r1/terminal_bench_official_result.compact.json` |
 | `terminal-bench@2.0` | `build-cython-ext` | `codex-native-goal-completion-aware` | `` | `0.0` | `` | `` | `official_verifier_solution_failure` | `terminal-bench/build-cython-ext/pr336-r2/terminal_bench_official_result.compact.json` |
+| `terminal-bench@2.0` | `build-cython-ext` | `terminal_bench_host_codex_app_server_goal_observe_only` | `` | `1.0` | `` | `` | `none` | `cloud-ecs/parallel-benchmark-20260621T203200Z/terminal-bench-build-cython-ext-app-server-observe-pr346-r1/terminal_bench_official_result.compact.json` |
 | `terminal-bench@2.0` | `cobol-modernization` | `hardened_codex_baseline` | `` | `1.0` | `` | `` | `none` | `.local/private-benchmark-jobs/terminal-bench-cobol-modernization-paired-20260611T0903Z/baseline.compact.json` |
 | `terminal-bench@2.0` | `cobol-modernization` | `codex_goal_harness_treatment` | `` | `1.0` | `` | `` | `none` | `.local/private-benchmark-jobs/terminal-bench-cobol-modernization-paired-20260611T0903Z/treatment.compact.json` |
 | `terminal-bench@2.0` | `compile-compcert` | `codex_goal_mode_baseline` | `` | `1.0` | `` | `` | `none` | `.local/private-benchmark-jobs/terminal-bench-compile-compcert-baseline-2h-20260615T1934CST/baseline/jobs/terminal_bench_compile_compcert_codex_goal_mode_baseline_2h_20260615T1934CST/result.json` |


### PR DESCRIPTION
## Summary
- Record two SkillsBench native app-server Goal keepalive compact results for `llm-prefix-cache-replay` and `tictoc-unnecessary-abort-detection`.
- Record Terminal-Bench `build-cython-ext` host app-server Goal observe-only compact official result with accuracy 1.0.
- Keep only public-safe compact artifact refs and attribution labels; no raw logs, task text, trajectories, verifier output tails, credentials, or absolute local paths were added.

## Validation
- `python3 examples/benchmark-run-ledger-smoke.py`
- `goal-harness benchmark run-ledger-check --goal-id goal-harness-meta --run-ledger-path docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json`
- `goal-harness check --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md`
- `git diff --check HEAD~1..HEAD`

## Notes
- Goal Harness check still reports the existing duplicate history index warning; this PR does not touch runtime history indexes.
