### PR TITLE
docs: foreground Codex CLI TUI quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,31 @@ the human/operator.
 Requirements: Python 3.11+, Git, macOS or Linux shell. The Python package has
 no runtime dependencies outside the standard library.
 
-The recommended start is agent-first. Paste this into Codex, Claude Code,
-Cursor, or another terminal agent from the project repo:
+The recommended start is agent-first. For Codex CLI users, stay in the TUI:
+
+1. Open Codex CLI from your project repo.
+2. Ask it to generate or use this Goal Harness bootstrap:
+
+   ```text
+   Start Goal Harness for this repo. Install or repair it if needed, connect this
+   project, show me the first user gate if one exists, then run the first safe
+   agent todo only after quota says it should run.
+   ```
+
+3. After Goal Harness is installed, you can generate a tailored one-message
+   bootstrap and paste it into the same Codex CLI TUI:
+
+   ```bash
+   goal-harness codex-cli-bootstrap-message --project . --goal-id <goal-id>
+   ```
+
+This is the primary Codex CLI path: the user keeps the visible TUI for steering,
+review, and takeover; Goal Harness supplies goal state, todo ownership, quota,
+gates, writeback, and the next safe action. Headless `codex exec` is an explicit
+fallback, not the default experience.
+
+For Codex App, Claude Code, Cursor, or another terminal agent, paste this from
+the project repo:
 
 ```text
 Install and connect Goal Harness for this project end to end. Do not stop at a

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -68,9 +68,41 @@ Success looks like this:
 For Codex CLI users, the product target is even simpler: start in the Codex
 TUI, send one Goal Harness bootstrap message, and keep later automation visible
 and interruptible in that TUI whenever the CLI exposes a safe session-attachment
-primitive. See the
-[Codex CLI TUI-first loop](../product/codex-cli-tui-loop.md) contract for the
-bootstrap, session-attached automation, and headless fallback split.
+primitive.
+
+First-run path:
+
+```text
+Start Goal Harness for this repo. Install or repair it if needed, connect this
+project, show me the first user gate if one exists, then run the first safe
+agent todo only after quota says it should run.
+```
+
+Once `goal-harness` is installed, generate a repo-specific paste message:
+
+```bash
+goal-harness codex-cli-bootstrap-message --project . --goal-id <goal-id>
+```
+
+Keep that as the preferred interactive path: the human watches and steers in
+Codex CLI TUI, while Goal Harness owns quota/status/todos/gates/writeback. To
+evaluate future same-session automation support without touching transcripts or
+session files, run:
+
+```bash
+goal-harness codex-cli-session-probe
+```
+
+If same-session steering is unavailable and the user explicitly accepts a
+headless fallback, generate the fallback handoff instead of pretending the open
+TUI is preserved:
+
+```bash
+goal-harness codex-cli-exec-handoff --project . --goal-id <goal-id>
+```
+
+See the [Codex CLI TUI-first loop](../product/codex-cli-tui-loop.md) contract
+for the bootstrap, session-attached automation, and headless fallback split.
 
 Maintainers can validate the public fresh-clone path with:
 

--- a/examples/codex-cli-bootstrap-message-smoke.py
+++ b/examples/codex-cli-bootstrap-message-smoke.py
@@ -68,6 +68,22 @@ def run_cli(*extra_args: str) -> str:
     return result.stdout
 
 
+def assert_docs_surface_codex_cli_quickstart() -> None:
+    readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    getting_started = (REPO_ROOT / "docs/guides/getting-started.md").read_text(encoding="utf-8")
+    product_contract = (REPO_ROOT / "docs/product/codex-cli-tui-loop.md").read_text(encoding="utf-8")
+
+    for text in (readme, getting_started, product_contract):
+        assert "Codex CLI TUI" in text, text[:500]
+        assert "Start Goal Harness for this repo" in text, text[:500]
+        assert "goal-harness codex-cli-bootstrap-message --project . --goal-id <goal-id>" in text, text[:500]
+
+    normalized_readme = " ".join(readme.split())
+    assert "Headless `codex exec` is an explicit fallback" in normalized_readme, readme
+    assert "goal-harness codex-cli-session-probe" in getting_started, getting_started
+    assert "goal-harness codex-cli-exec-handoff --project . --goal-id <goal-id>" in getting_started, getting_started
+
+
 def main() -> int:
     payload = build_codex_cli_bootstrap_message(
         project=PROJECT,
@@ -104,6 +120,7 @@ def main() -> int:
     assert "# Codex CLI Goal Harness Bootstrap Message" in cli_markdown, cli_markdown
     assert "Copy the block below into Codex CLI TUI" in cli_markdown, cli_markdown
     assert "one-message TUI bootstrap" in cli_markdown, cli_markdown
+    assert_docs_surface_codex_cli_quickstart()
 
     print("codex-cli-bootstrap-message-smoke ok")
     return 0


### PR DESCRIPTION
## Summary
- make the README Quick Start lead with the Codex CLI TUI-first Goal Harness bootstrap path
- expand Getting Started with bootstrap-message, session-probe, and explicit exec fallback
- extend the Codex CLI bootstrap smoke so docs keep the TUI-first promise visible

## Validation
- python3 -m py_compile examples/codex-cli-bootstrap-message-smoke.py goal_harness/cli_commands/starter.py goal_harness/project_prompt.py
- python3 examples/codex-cli-bootstrap-message-smoke.py
- python3 examples/codex-cli-exec-handoff-smoke.py
- PYTHONPATH=. python3 -m goal_harness.cli check --scan-path README.md --scan-path docs/guides/getting-started.md --scan-path docs/product/codex-cli-tui-loop.md --scan-path examples/codex-cli-bootstrap-message-smoke.py
- git diff --check

Goal Harness check only reported the existing runtime duplicate-index warning; public boundary scan passed.