### PR TITLE
Preserve SkillsBench native Goal worker traces

### DIFF
--- a/examples/skillsbench-app-server-goal-worker-smoke.py
+++ b/examples/skillsbench-app-server-goal-worker-smoke.py
@@ -168,6 +168,9 @@ def test_launcher_plan_only_uses_native_worker_route() -> None:
     contract = plan["app_server_goal_worker_contract"]
     assert contract["route"] == ROUTE, contract
     assert contract["worker_plan"]["schema_version"] == "codex_app_server_goal_worker_v0", contract
+    assert plan["app_server_goal_worker_trace_dir"].endswith(
+        "app_server_goal_worker_traces"
+    ), plan
 
 
 def test_launcher_plan_only_marks_bridge_ready_when_explicit() -> None:
@@ -351,6 +354,7 @@ Path(args.output_json).write_text(json.dumps({"ok": True}), encoding="utf-8")
         root = Path(tmp)
         worker = root / "fake_worker.py"
         work = root / "work"
+        trace_dir = root / "worker-traces"
         worker.write_text(fake_worker, encoding="utf-8")
         worker.chmod(0o755)
         work.mkdir()
@@ -367,6 +371,8 @@ Path(args.output_json).write_text(json.dumps({"ok": True}), encoding="utf-8")
                 "5",
                 "--stream-heartbeat-interval-sec",
                 "0.05",
+                "--worker-public-trace-dir",
+                str(trace_dir),
             ],
             cwd=REPO_ROOT,
             stdin=subprocess.PIPE,
@@ -437,6 +443,16 @@ Path(args.output_json).write_text(json.dumps({"ok": True}), encoding="utf-8")
         assert keepalive_seen
         assert final_response is not None
         assert final_response["result"]["stopReason"] == "end_turn"
+        trace_files = sorted(trace_dir.glob("*.compact.json"))
+        assert len(trace_files) == 1, trace_files
+        trace = json.loads(trace_files[0].read_text(encoding="utf-8"))
+        assert (
+            trace["schema_version"]
+            == "skillsbench_host_codex_goal_worker_public_trace_v0"
+        ), trace
+        assert trace["ok"] is True, trace
+        assert trace["private_response_text"].get("path_recorded") is not True, trace
+        assert "private delayed answer" not in json.dumps(trace), trace
         proc.terminate()
         proc.wait(timeout=2)
 

--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -59,6 +59,7 @@ from scripts.skillsbench_automation_loop import (  # noqa: E402
     _tail,
     _blind_loop_persistent_continuation_clause,
     _build_product_mode_user,
+    _merge_app_server_goal_worker_trace_summary,
     _merge_acp_trajectory_summary,
     _merge_final_result_round_reward,
     _round_result_declared_done,
@@ -879,14 +880,19 @@ def test_skillsbench_verifier_tail_disabled_at_zero() -> None:
     assert default_args.route == "goal-harness-blind-loop-treatment", default_args
 
 
-def write_official_skillsbench_result(root: Path, *, reward: float = 0.0) -> Path:
-    run_dir = root / "official" / "2026-06-15__00-00-00" / "sample-task__abc123"
+def write_official_skillsbench_result(
+    root: Path,
+    *,
+    reward: float = 0.0,
+    task_id: str = "sample-task",
+) -> Path:
+    run_dir = root / "official" / "2026-06-15__00-00-00" / f"{task_id}__abc123"
     result_path = run_dir / "result.json"
     write_json(
         result_path,
         {
-            "task_name": "sample-task",
-            "rollout_name": "sample-task__abc123",
+            "task_name": task_id,
+            "rollout_name": f"{task_id}__abc123",
             "rewards": {"reward": reward},
             "agent": "codex-acp",
             "agent_name": "codex-acp",
@@ -2882,6 +2888,81 @@ def test_skillsbench_round_trace_records_best_round_score() -> None:
         compact_text = json.dumps(compact, sort_keys=True)
         assert "private_verifier_output" not in compact_text
         assert "TASK INSTRUCTION" not in compact_text
+
+        worker_trace_dir = root / "native-worker-traces"
+        worker_trace_dir.mkdir()
+        write_json(
+            worker_trace_dir / "worker-000001.compact.json",
+            {
+                "schema_version": "skillsbench_host_codex_goal_worker_public_trace_v0",
+                "ok": True,
+                "route": "codex-app-server-goal-baseline",
+                "benchmark_id": "skillsbench@1.1",
+                "task_id": "llm-prefix-cache-replay",
+                "turn": {
+                    "thread_id_present": True,
+                    "goal_get_present": True,
+                    "goal_status": "active",
+                    "turn_id_present": True,
+                    "turn_status": "completed",
+                    "turn_completed_observed": True,
+                    "assistant_message_present": True,
+                    "assistant_message_chars": 42,
+                    "raw_transcript_recorded": False,
+                    "raw_assistant_message_recorded": False,
+                },
+                "boundary": {
+                    "raw_task_text_recorded": False,
+                    "raw_logs_recorded": False,
+                    "raw_trajectory_recorded": False,
+                    "credential_values_recorded": False,
+                    "host_paths_recorded": False,
+                },
+            },
+        )
+        app_server_trace = {
+            "schema_version": "skillsbench_goal_harness_controller_trace_v0",
+            "route": "codex-app-server-goal-baseline",
+            "trace_publicness": "public_counts_only_no_task_text_no_verifier_output",
+            "native_goal_worker_route": True,
+            "native_goal_worker_connected": True,
+            "native_goal_worker_connect_count": 1,
+            "raw_task_text_recorded": False,
+            "raw_verifier_output_recorded": False,
+            "raw_agent_trajectory_recorded": False,
+        }
+        _merge_app_server_goal_worker_trace_summary(
+            {
+                "route": "codex-app-server-goal-baseline",
+                "app_server_goal_worker_trace_dir": str(worker_trace_dir),
+            },
+            app_server_trace,
+        )
+        native_compact = compact_benchmark_run(
+            build_skillsbench_benchflow_result_benchmark_run(
+                write_official_skillsbench_result(
+                    root / "native",
+                    reward=0.0,
+                    task_id="llm-prefix-cache-replay",
+                ),
+                route="codex-app-server-goal-baseline",
+                controller_trace=app_server_trace,
+            )
+        )
+        assert native_compact is not None
+        assert native_compact["case_id"] == "llm-prefix-cache-replay", native_compact
+        assert native_compact["case_ids"] == ["llm-prefix-cache-replay"], native_compact
+        assert native_compact["validation"]["goal_harness_controller_trace_present"] is True
+        assert native_compact["validation"]["failed_checks"] == [], native_compact
+        native_counters = native_compact["interaction_counters"]
+        assert native_counters["controller_trace_present"] is True, native_compact
+        assert native_counters["native_goal_worker_route"] is True, native_compact
+        assert native_counters["native_goal_worker_trace_count"] == 1, native_compact
+        assert native_counters["native_goal_worker_ok_count"] == 1, native_compact
+        assert native_counters["native_goal_worker_goal_get_count"] == 1, native_compact
+        assert native_counters["native_goal_worker_turn_start_count"] == 1, native_compact
+        assert native_counters["native_goal_worker_turn_completed_observed_count"] == 1, native_compact
+        assert native_counters["native_goal_worker_raw_material_recorded"] is False, native_compact
 
         baseline = compact_benchmark_run(
             build_skillsbench_benchflow_result_benchmark_run(

--- a/goal_harness/benchmark_adapters/skillsbench.py
+++ b/goal_harness/benchmark_adapters/skillsbench.py
@@ -1800,6 +1800,37 @@ def _skillsbench_controller_trace_counters(
         "goal_harness_state_writes": count("goal_harness_state_writes"),
         "goal_harness_case_state_reads": count("goal_harness_case_state_reads"),
         "goal_harness_case_state_writes": count("goal_harness_case_state_writes"),
+        "native_goal_worker_route": controller_trace.get("native_goal_worker_route")
+        is True,
+        "native_goal_worker_connected": controller_trace.get(
+            "native_goal_worker_connected"
+        )
+        is True,
+        "native_goal_worker_trace_dir_present": controller_trace.get(
+            "native_goal_worker_trace_dir_present"
+        )
+        is True,
+        "native_goal_worker_public_trace_read": controller_trace.get(
+            "native_goal_worker_public_trace_read"
+        )
+        is True,
+        "native_goal_worker_raw_material_recorded": controller_trace.get(
+            "native_goal_worker_raw_material_recorded"
+        )
+        is True,
+        "native_goal_worker_connect_count": count("native_goal_worker_connect_count"),
+        "native_goal_worker_trace_count": count("native_goal_worker_trace_count"),
+        "native_goal_worker_ok_count": count("native_goal_worker_ok_count"),
+        "native_goal_worker_goal_get_count": count("native_goal_worker_goal_get_count"),
+        "native_goal_worker_turn_start_count": count(
+            "native_goal_worker_turn_start_count"
+        ),
+        "native_goal_worker_turn_completed_observed_count": count(
+            "native_goal_worker_turn_completed_observed_count"
+        ),
+        "native_goal_worker_assistant_message_present_count": count(
+            "native_goal_worker_assistant_message_present_count"
+        ),
         "heartbeat_count": count("heartbeat_count"),
         "raw_task_text_recorded": controller_trace.get("raw_task_text_recorded")
         is True,
@@ -2319,6 +2350,8 @@ def build_skillsbench_benchflow_result_benchmark_run(
         "schema_version": "benchmark_run_v0",
         "source_runner": "official_skillsbench_benchflow_result",
         "benchmark_id": dataset,
+        "case_id": task_id,
+        "case_ids": [task_id],
         "job_name": job_name,
         "mode": contract["mode"],
         "route": route,
@@ -2474,6 +2507,46 @@ def build_skillsbench_benchflow_result_benchmark_run(
             ),
             "goal_harness_cli_state_write_count": trajectory_summary.get(
                 "goal_harness_cli_state_write_count", 0
+            ),
+            "native_goal_worker_route": controller_counters.get(
+                "native_goal_worker_route", False
+            ),
+            "native_goal_worker_connected": controller_counters.get(
+                "native_goal_worker_connected", False
+            ),
+            "native_goal_worker_trace_dir_present": controller_counters.get(
+                "native_goal_worker_trace_dir_present", False
+            ),
+            "native_goal_worker_public_trace_read": controller_counters.get(
+                "native_goal_worker_public_trace_read", False
+            ),
+            "native_goal_worker_raw_material_recorded": controller_counters.get(
+                "native_goal_worker_raw_material_recorded", False
+            ),
+            "native_goal_worker_connect_count": controller_counters.get(
+                "native_goal_worker_connect_count", 0
+            ),
+            "native_goal_worker_trace_count": controller_counters.get(
+                "native_goal_worker_trace_count", 0
+            ),
+            "native_goal_worker_ok_count": controller_counters.get(
+                "native_goal_worker_ok_count", 0
+            ),
+            "native_goal_worker_goal_get_count": controller_counters.get(
+                "native_goal_worker_goal_get_count", 0
+            ),
+            "native_goal_worker_turn_start_count": controller_counters.get(
+                "native_goal_worker_turn_start_count", 0
+            ),
+            "native_goal_worker_turn_completed_observed_count": (
+                controller_counters.get(
+                    "native_goal_worker_turn_completed_observed_count", 0
+                )
+            ),
+            "native_goal_worker_assistant_message_present_count": (
+                controller_counters.get(
+                    "native_goal_worker_assistant_message_present_count", 0
+                )
             ),
             "goal_harness_case_state_path_count": trajectory_summary.get(
                 "goal_harness_case_state_path_count", 0

--- a/goal_harness/benchmark_adapters/skillsbench_acp_relay.py
+++ b/goal_harness/benchmark_adapters/skillsbench_acp_relay.py
@@ -71,6 +71,7 @@ class CodexExecConfig:
     worker_script: str | None = None
     stream_heartbeat_interval_sec: float = 120.0
     reasoning_effort: str | None = "high"
+    worker_public_trace_dir: str | None = None
 
 
 class SkillsBenchLocalAcpRelay:
@@ -335,11 +336,106 @@ class SkillsBenchLocalAcpRelay:
                 raise TimeoutError from exc
             if proc.returncode != 0:
                 raise RuntimeError("host app-server goal worker failed")
+            self._publish_worker_trace(output_json)
             try:
                 response = response_path.read_text(encoding="utf-8").strip()
             except OSError as exc:
                 raise RuntimeError("host app-server goal worker response missing") from exc
             return response or "host app-server goal worker returned an empty final message"
+
+    def _publish_worker_trace(self, output_json: Path) -> None:
+        """Persist a public-safe app-server worker trace for the reducer.
+
+        The worker output is already compact, but this method still rewrites a
+        smaller allowlisted shape so the benchmark run directory never needs the
+        private response text or raw app-server stream.
+        """
+
+        if not self._config.worker_public_trace_dir:
+            return
+        try:
+            payload = json.loads(output_json.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return
+        if not isinstance(payload, dict):
+            return
+
+        def compact_dict(source: Any, allowed: tuple[str, ...]) -> dict[str, Any]:
+            if not isinstance(source, dict):
+                return {}
+            result: dict[str, Any] = {}
+            for key in allowed:
+                value = source.get(key)
+                if isinstance(value, (str, bool, int, float)) and not (
+                    isinstance(value, float) and (value != value)
+                ):
+                    result[key] = value
+            return result
+
+        worker_contract = payload.get("worker_contract")
+        if not isinstance(worker_contract, dict):
+            worker_contract = {}
+        trace = {
+            "schema_version": "skillsbench_host_codex_goal_worker_public_trace_v0",
+            "ok": payload.get("ok") is True,
+            "route": "codex-app-server-goal-baseline",
+            "benchmark_id": str(payload.get("benchmark_id") or ""),
+            "task_id": str(payload.get("task_id") or ""),
+            "worker_contract": compact_dict(
+                worker_contract,
+                (
+                    "schema_version",
+                    "route",
+                    "ready",
+                    "runner_integration_ready",
+                    "first_blocker",
+                ),
+            ),
+            "prompt": compact_dict(
+                payload.get("prompt"),
+                ("sha256", "chars", "raw_recorded"),
+            ),
+            "turn": compact_dict(
+                payload.get("turn"),
+                (
+                    "schema_version",
+                    "thread_id_present",
+                    "goal_get_present",
+                    "goal_status",
+                    "turn_id_present",
+                    "turn_status",
+                    "turn_completed_observed",
+                    "agent_message_delta_count",
+                    "agent_message_item_count",
+                    "item_completed_count",
+                    "assistant_message_present",
+                    "assistant_message_chars",
+                    "raw_transcript_recorded",
+                    "raw_assistant_message_recorded",
+                ),
+            ),
+            "private_response_text": compact_dict(
+                payload.get("private_response_text"),
+                ("written", "path_recorded", "raw_recorded_in_public_json"),
+            ),
+            "boundary": compact_dict(
+                payload.get("boundary"),
+                (
+                    "raw_task_text_recorded",
+                    "raw_logs_recorded",
+                    "raw_trajectory_recorded",
+                    "credential_values_recorded",
+                    "host_paths_recorded",
+                ),
+            ),
+        }
+        trace_dir = Path(self._config.worker_public_trace_dir).expanduser()
+        trace_dir.mkdir(parents=True, exist_ok=True)
+        trace_path = trace_dir / f"worker-{uuid.uuid4().hex[:12]}.compact.json"
+        trace_path.write_text(
+            json.dumps(trace, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
 
     def _write_worker_heartbeat(
         self,

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -497,6 +497,11 @@ def _compact_benchmark_interaction_counters(value: Any) -> dict[str, Any]:
         "controller_blind_loop",
         "controller_official_success_observed",
         "private_trajectory_summary_present",
+        "native_goal_worker_route",
+        "native_goal_worker_connected",
+        "native_goal_worker_trace_dir_present",
+        "native_goal_worker_public_trace_read",
+        "native_goal_worker_raw_material_recorded",
     ):
         if isinstance(value.get(field), bool):
             compact[field] = value[field]
@@ -546,6 +551,13 @@ def _compact_benchmark_interaction_counters(value: Any) -> dict[str, Any]:
         "environment_setup_failure_before_worker_count",
         "pre_worker_agent_setup_failure_count",
         "codex_runtime_goal_tool_trial_count",
+        "native_goal_worker_connect_count",
+        "native_goal_worker_trace_count",
+        "native_goal_worker_ok_count",
+        "native_goal_worker_goal_get_count",
+        "native_goal_worker_turn_start_count",
+        "native_goal_worker_turn_completed_observed_count",
+        "native_goal_worker_assistant_message_present_count",
     ):
         if isinstance(value.get(field), int) and not isinstance(value.get(field), bool):
             compact[field] = value[field]
@@ -1810,6 +1822,25 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
         value = public_safe_compact_text(source.get(field), limit=120)
         if value:
             compact[field] = value
+    trials_source = source.get("trials") if isinstance(source.get("trials"), list) else []
+    first_trial = trials_source[0] if trials_source and isinstance(trials_source[0], dict) else {}
+    case_ids_source = (
+        source.get("case_ids") if isinstance(source.get("case_ids"), list) else []
+    )
+    case_id = (
+        public_safe_compact_text(source.get("case_id"), limit=120)
+        or public_safe_compact_text(source.get("task_id"), limit=120)
+        or public_safe_compact_text(first_trial.get("task_id"), limit=120)
+        or (
+            public_safe_compact_text(case_ids_source[0], limit=120)
+            if case_ids_source
+            else None
+        )
+    )
+    if case_id:
+        compact["case_id"] = case_id
+        case_ids = public_safe_compact_list(case_ids_source, limit=MAX_BENCHMARK_RUN_LIST_ITEMS)
+        compact["case_ids"] = case_ids or [case_id]
     for field in (
         "worker_mode",
         "trace_publicness",
@@ -1878,6 +1909,11 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
         "agent_declared_done",
         "official_feedback_blinded",
         "reward_feedback_forwarded",
+        "native_goal_worker_route",
+        "native_goal_worker_connected",
+        "native_goal_worker_trace_dir_present",
+        "native_goal_worker_public_trace_read",
+        "native_goal_worker_raw_material_recorded",
     ):
         if isinstance(source.get(field), bool):
             compact[field] = source.get(field)
@@ -1903,6 +1939,13 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
         "official_zero_observation_count",
         "planned_worker_goal_harness_cli_call_total",
         "required_worker_goal_harness_cli_call_total_min",
+        "native_goal_worker_connect_count",
+        "native_goal_worker_trace_count",
+        "native_goal_worker_ok_count",
+        "native_goal_worker_goal_get_count",
+        "native_goal_worker_turn_start_count",
+        "native_goal_worker_turn_completed_observed_count",
+        "native_goal_worker_assistant_message_present_count",
     ):
         if isinstance(source.get(field), int) and not isinstance(source.get(field), bool):
             compact[field] = source.get(field)
@@ -2275,13 +2318,15 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
             "worker_bridge_materialized_when_required",
             "worker_bridge_repeat_ready",
             "worker_startup_blocker_recorded",
+            "goal_harness_controller_trace_present",
+            "goal_harness_controller_trace_public_safe",
         ):
             if isinstance(validation.get(field), bool):
                 compact_validation[field] = validation[field]
         compact["validation"] = compact_validation
 
     trials: list[dict[str, Any]] = []
-    for trial in source.get("trials") or []:
+    for trial in trials_source or []:
         if not isinstance(trial, dict):
             continue
         compact_trial: dict[str, Any] = {}

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -609,7 +609,10 @@ def inspect_skillsbench_worker_handshake(
     )
 
 
-def _host_local_acp_launch_command(args: argparse.Namespace) -> list[str]:
+def _host_local_acp_launch_command(
+    args: argparse.Namespace,
+    plan: dict[str, Any],
+) -> list[str]:
     if args.local_acp_relay_command:
         return shlex.split(args.local_acp_relay_command)
     command = list(default_skillsbench_local_acp_relay_command())
@@ -617,6 +620,7 @@ def _host_local_acp_launch_command(args: argparse.Namespace) -> list[str]:
         index = command.index("--dry-run-response")
         del command[index : index + 2]
     if args.route == "codex-app-server-goal-baseline":
+        worker_trace_dir = str(plan.get("app_server_goal_worker_trace_dir") or "")
         command.extend(
             [
                 "--app-server-goal-worker",
@@ -634,6 +638,8 @@ def _host_local_acp_launch_command(args: argparse.Namespace) -> list[str]:
                 str(args.app_server_acp_heartbeat_interval_sec),
             ]
         )
+        if worker_trace_dir:
+            command.extend(["--worker-public-trace-dir", worker_trace_dir])
     command.extend(
         [
             "--codex-bin",
@@ -1603,6 +1609,9 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
     result_path = jobs_dir / job_name / rollout_name / "result.json"
     compact_path = jobs_dir / job_name / rollout_name / "benchmark_run.compact.json"
     controller_trace_path = jobs_dir / job_name / "goal_harness_controller_trace.public.json"
+    app_server_goal_worker_trace_dir = (
+        jobs_dir / job_name / "app_server_goal_worker_traces"
+    )
     task_path = Path(args.skillsbench_root).expanduser() / "tasks" / task_id
     setup_preflight = skillsbench_task_setup_preflight(
         task_path=task_path,
@@ -1663,6 +1672,11 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
         "result_json": str(result_path),
         "compact_benchmark_run_json": str(compact_path),
         "controller_trace_json": str(controller_trace_path),
+        "app_server_goal_worker_trace_dir": (
+            str(app_server_goal_worker_trace_dir)
+            if is_app_server_goal_route
+            else ""
+        ),
         "ledger_path": str(Path(args.ledger_path).expanduser()),
         "task_setup_preflight": setup_preflight,
         "task_staging": {
@@ -2201,6 +2215,18 @@ def _new_controller_trace(route: str, *, max_rounds: int | None = None) -> dict[
         "goal_harness_state_writes": 0,
         "goal_harness_case_state_reads": 0,
         "goal_harness_case_state_writes": 0,
+        "native_goal_worker_route": route == "codex-app-server-goal-baseline",
+        "native_goal_worker_connected": False,
+        "native_goal_worker_connect_count": 0,
+        "native_goal_worker_trace_dir_present": False,
+        "native_goal_worker_trace_count": 0,
+        "native_goal_worker_ok_count": 0,
+        "native_goal_worker_goal_get_count": 0,
+        "native_goal_worker_turn_start_count": 0,
+        "native_goal_worker_turn_completed_observed_count": 0,
+        "native_goal_worker_assistant_message_present_count": 0,
+        "native_goal_worker_public_trace_read": False,
+        "native_goal_worker_raw_material_recorded": False,
         "max_round_observed": -1,
         "last_decision": "not_started",
         "raw_task_text_recorded": False,
@@ -2235,6 +2261,83 @@ def _read_controller_trace(plan: dict[str, Any]) -> dict[str, Any] | None:
     except (OSError, json.JSONDecodeError):
         return None
     return payload if isinstance(payload, dict) else None
+
+
+def _merge_app_server_goal_worker_trace_summary(
+    plan: dict[str, Any],
+    trace: dict[str, Any] | None,
+) -> None:
+    if not isinstance(trace, dict):
+        return
+    raw_trace_dir = plan.get("app_server_goal_worker_trace_dir")
+    if not isinstance(raw_trace_dir, str) or not raw_trace_dir.strip():
+        return
+    trace_dir = Path(raw_trace_dir)
+    files = sorted(trace_dir.glob("*.compact.json")) if trace_dir.exists() else []
+    worker_trace_count = 0
+    ok_count = 0
+    goal_get_count = 0
+    turn_start_count = 0
+    turn_completed_count = 0
+    assistant_message_count = 0
+    raw_material_recorded = False
+    for path in files:
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if (
+            payload.get("schema_version")
+            != "skillsbench_host_codex_goal_worker_public_trace_v0"
+        ):
+            continue
+        worker_trace_count += 1
+        if payload.get("ok") is True:
+            ok_count += 1
+        turn = payload.get("turn") if isinstance(payload.get("turn"), dict) else {}
+        if turn.get("goal_get_present") is True:
+            goal_get_count += 1
+        if turn.get("turn_id_present") is True:
+            turn_start_count += 1
+        if turn.get("turn_completed_observed") is True:
+            turn_completed_count += 1
+        if turn.get("assistant_message_present") is True:
+            assistant_message_count += 1
+        boundary = (
+            payload.get("boundary")
+            if isinstance(payload.get("boundary"), dict)
+            else {}
+        )
+        raw_material_recorded = raw_material_recorded or any(
+            boundary.get(field) is True
+            for field in (
+                "raw_task_text_recorded",
+                "raw_logs_recorded",
+                "raw_trajectory_recorded",
+                "credential_values_recorded",
+                "host_paths_recorded",
+            )
+        )
+        raw_material_recorded = raw_material_recorded or (
+            turn.get("raw_transcript_recorded") is True
+            or turn.get("raw_assistant_message_recorded") is True
+        )
+    trace["native_goal_worker_route"] = plan.get("route") == "codex-app-server-goal-baseline"
+    trace["native_goal_worker_trace_dir_present"] = trace_dir.exists()
+    trace["native_goal_worker_trace_count"] = worker_trace_count
+    trace["native_goal_worker_ok_count"] = ok_count
+    trace["native_goal_worker_goal_get_count"] = goal_get_count
+    trace["native_goal_worker_turn_start_count"] = turn_start_count
+    trace["native_goal_worker_turn_completed_observed_count"] = turn_completed_count
+    trace["native_goal_worker_assistant_message_present_count"] = (
+        assistant_message_count
+    )
+    trace["native_goal_worker_public_trace_read"] = worker_trace_count > 0
+    trace["native_goal_worker_raw_material_recorded"] = raw_material_recorded
+    if worker_trace_count:
+        trace["last_decision"] = "host_app_server_goal_worker_trace_recorded"
 
 
 def _round_count_key(round_index: int) -> str:
@@ -2905,7 +3008,7 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
     from benchflow.rollout import Rollout, RolloutConfig
     from benchflow.runtime import run as benchflow_run
 
-    host_local_acp_command = _host_local_acp_launch_command(args)
+    host_local_acp_command = _host_local_acp_launch_command(args, plan)
     runtime_mounts = (
         _benchflow_agent_runtime_mounts(args)
         if args.require_preinstalled_benchflow_agent_runtime
@@ -2961,6 +3064,17 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
             if model:
                 await asyncio.wait_for(client.set_model(model), timeout=60)
             prerequisites["host_local_acp_launch_status"] = "connected"
+            if isinstance(controller_trace, dict):
+                controller_trace["native_goal_worker_route"] = (
+                    args.route == "codex-app-server-goal-baseline"
+                )
+                controller_trace["native_goal_worker_connect_count"] = int(
+                    controller_trace.get("native_goal_worker_connect_count") or 0
+                ) + 1
+                controller_trace["native_goal_worker_connected"] = True
+                controller_trace["last_decision"] = (
+                    "host_app_server_goal_worker_connected"
+                )
             return client, session, ACPSessionAdapter(client), agent_name
         except Exception:
             prerequisites["host_local_acp_launch_status"] = "failed"
@@ -3215,6 +3329,10 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
         )
     elif args.route == "codex-goal-mode-baseline":
         controller_user = _build_codex_goal_mode_baseline_user()
+    elif args.route == "codex-app-server-goal-baseline":
+        controller_trace = _new_controller_trace(args.route, max_rounds=args.max_rounds)
+        controller_trace["native_goal_worker_route"] = True
+        controller_trace["last_decision"] = "host_app_server_goal_worker_selected"
 
     pre_agent_hooks = (
         []
@@ -3282,6 +3400,7 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
                 original_rollout_planes_connect_acp
             )
         _merge_acp_trajectory_summary(plan, controller_trace)
+        _merge_app_server_goal_worker_trace_summary(plan, controller_trace)
         _write_controller_trace(plan, controller_trace)
     if result_path is None:
         result_path = discover_benchflow_result_path(plan)
@@ -3304,6 +3423,7 @@ def reduce_result(
 
     controller_trace = _read_controller_trace(plan)
     _merge_acp_trajectory_summary(plan, controller_trace)
+    _merge_app_server_goal_worker_trace_summary(plan, controller_trace)
     _write_controller_trace(plan, controller_trace)
 
     benchmark_run = build_skillsbench_benchflow_result_benchmark_run(

--- a/scripts/skillsbench_local_acp_relay.py
+++ b/scripts/skillsbench_local_acp_relay.py
@@ -89,6 +89,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         default=None,
         help="Optional path to skillsbench_host_codex_goal_worker.py.",
     )
+    parser.add_argument(
+        "--worker-public-trace-dir",
+        default=None,
+        help=(
+            "Optional directory for public-safe host app-server Goal worker "
+            "compact traces. Response text and raw app-server streams are not "
+            "written there."
+        ),
+    )
     return parser.parse_args(argv)
 
 
@@ -109,6 +118,7 @@ def main(argv: list[str] | None = None) -> int:
             response_timeout_sec=args.response_timeout_sec,
             worker_script=args.worker_script,
             stream_heartbeat_interval_sec=args.stream_heartbeat_interval_sec,
+            worker_public_trace_dir=args.worker_public_trace_dir,
         )
     )
     return relay.serve()


### PR DESCRIPTION
## Summary
- write public-safe compact traces from the SkillsBench native Codex app-server Goal worker
- propagate worker trace presence, Goal/turn completion counts, and case ids into compact benchmark results
- cover the launcher/reducer path with focused SkillsBench smokes

## Validation
- python3 -m py_compile goal_harness/benchmark_adapters/skillsbench_acp_relay.py scripts/skillsbench_local_acp_relay.py scripts/skillsbench_automation_loop.py goal_harness/benchmark_adapters/skillsbench.py goal_harness/status.py examples/skillsbench-app-server-goal-worker-smoke.py examples/skillsbench-benchmark-run-smoke.py
- python3 examples/skillsbench-app-server-goal-worker-smoke.py
- python3 examples/skillsbench-benchmark-run-smoke.py
- git diff --check
- goal-harness check --scan-path examples/skillsbench-app-server-goal-worker-smoke.py --scan-path examples/skillsbench-benchmark-run-smoke.py --scan-path goal_harness/benchmark_adapters/skillsbench.py --scan-path goal_harness/benchmark_adapters/skillsbench_acp_relay.py --scan-path goal_harness/status.py --scan-path scripts/skillsbench_automation_loop.py --scan-path scripts/skillsbench_local_acp_relay.py

## Boundary
- public-safe compact trace only; no raw task text, raw app-server streams, private response text, raw logs, raw trajectories, credentials, or local paths are written to public artifacts
- does not change benchmark scoring or official runner behavior