### PR TITLE
docs: add Codex CLI automation driver audit

### DIFF
--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -15,6 +15,10 @@ runtime contract, benchmark route, or launch draft.
   Harness loop, later automation tries to steer the same visible session, and
   headless `codex exec` remains an explicit fallback rather than the default
   user experience.
+- [Codex CLI automation driver audit](codex-cli-automation-driver.md): the
+  current Codex CLI scheduler/session surface audit, with a conservative local
+  driver shape that keeps TUI bootstrap primary and treats `codex exec` as an
+  explicit fallback.
 - [Agent profile contract](agent-profile-contract.md): the registry-owned
   identity/scope contract for primary and side agents, including worktree and
   review handoff policy, while keeping todo ownership in `claimed_by` and future

--- a/docs/product/codex-cli-automation-driver.md
+++ b/docs/product/codex-cli-automation-driver.md
@@ -1,0 +1,101 @@
+# Codex CLI Automation Driver Audit
+
+Status: product contract and implementation target.
+
+Goal Harness should make Codex CLI feel easy before it feels automated. The
+primary path is still the Codex TUI: the user starts from a project repo, sends
+one Goal-Harness-generated message, and can keep watching, steering, reviewing,
+or taking over. Automation is allowed only when it preserves that visible
+control surface or falls back explicitly.
+
+## Current Finding
+
+The current local Codex CLI help surface exposes useful execution and session
+primitives:
+
+- `codex [PROMPT]` starts the interactive TUI with an initial prompt.
+- `codex resume [SESSION_ID] [PROMPT]` can resume an interactive session and
+  start it with a prompt.
+- `codex exec [PROMPT]` runs a non-interactive executor loop.
+- `codex --remote <ADDR>`, `codex app-server`, and `codex remote-control` expose
+  experimental app-server / remote-control surfaces worth probing.
+
+It does not expose a mature native recurring scheduler for Goal Harness. Treat
+recurrence as a Goal Harness local-driver concern until Codex provides a
+first-class automation primitive.
+
+The important product distinction is:
+
+| Surface | What It Proves | What It Does Not Prove |
+| --- | --- | --- |
+| `codex [PROMPT]` | one-message TUI bootstrap is viable | scheduled wakeups |
+| `codex resume ... [PROMPT]` | a visible resume proof is plausible | safe injection into an already-open TUI |
+| `codex exec` | headless fallback is viable | preserved TUI experience |
+| `remote-control` / app-server | a future visible-control bridge may exist | production-safe Goal Harness driver semantics |
+
+## Driver Shape
+
+The v0 driver should be explicit and conservative:
+
+1. A scheduler wakes up: manual command, `launchd`, cron, or a future local
+   daemon.
+2. The driver runs `goal-harness quota should-run --goal-id <goal> --agent-id
+   <agent>`.
+3. If user action is required, the driver surfaces only the concrete user gate
+   and stops.
+4. If the side-agent workspace guard fires, the driver relocates to an
+   independent worktree before any file edit.
+5. The driver runs `goal-harness codex-cli-visible-driver-plan`.
+6. If the plan proves a visible attach path, the driver may attempt a visible
+   `resume` / remote-control turn behind an idle guard.
+7. If no visible attach path is proven, the driver keeps TUI bootstrap primary
+   and offers `goal-harness codex-cli-exec-handoff` as an explicit headless
+   fallback.
+8. The driver spends quota only after validated writeback.
+
+The local driver must never read or publish:
+
+- raw Codex transcripts;
+- credentials;
+- hidden session files;
+- private logs;
+- local Goal Harness runtime state that would leak into public docs or
+  fixtures.
+
+## Scheduler Options
+
+| Option | Good For | Not Good For | v0 Use |
+| --- | --- | --- | --- |
+| Manual command | transparent user testing | unattended work | default proof path |
+| `launchd` | local recurring wakeups on macOS | cross-platform install, visible TUI attach by itself | first packaged scheduler |
+| cron | simple Unix recurrence | user-friendly install, logs, env repair | documented fallback |
+| GitHub Actions | public docs/build/status checks | local TUI, local credentials, workstation state | Pages and public bundle only |
+| Local daemon | best long-term UX | install/update/auth complexity | later product milestone |
+
+## Success Criteria
+
+- One pasted TUI message can start the Goal Harness loop in a repo.
+- A scheduled driver can decide whether work is allowed without reading private
+  Codex session data.
+- A visible resume / remote-control proof shows the turn is visible,
+  interruptible, and idle-guarded before Goal Harness calls it
+  session-attached automation.
+- Headless `codex exec` remains a named fallback, not the default user story.
+- Every automatic turn writes compact evidence or a precise blocker before
+  quota spend.
+
+## Next Build Slice
+
+Implement a dry-run-first local driver command that composes the existing
+pieces:
+
+```bash
+goal-harness codex-cli-visible-driver-plan --project . --goal-id <goal> --agent-id <agent>
+goal-harness codex-cli-bootstrap-message --project . --goal-id <goal> --agent-id <agent>
+goal-harness codex-cli-exec-handoff --project . --goal-id <goal> --agent-id <agent>
+```
+
+The first runnable milestone should not try to be clever. It should emit the
+exact driver decision, explain whether the user keeps the TUI path or has opted
+into headless fallback, and include an idle-guard placeholder before any
+visible resume / remote-control experiment.

--- a/examples/codex-cli-automation-driver-audit-smoke.py
+++ b/examples/codex-cli-automation-driver-audit-smoke.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Smoke-test the public Codex CLI automation driver audit contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DOC = REPO_ROOT / "docs/product/codex-cli-automation-driver.md"
+PRODUCT_INDEX = REPO_ROOT / "docs/product/README.md"
+
+
+def main() -> int:
+    doc = DOC.read_text()
+    index = PRODUCT_INDEX.read_text()
+
+    required_contracts = [
+        "one Goal-Harness-generated message",
+        "does not expose a mature native recurring scheduler",
+        "recurrence as a Goal Harness local-driver concern",
+        "codex resume [SESSION_ID] [PROMPT]",
+        "codex exec",
+        "remote-control",
+        "goal-harness codex-cli-visible-driver-plan",
+        "goal-harness codex-cli-exec-handoff",
+        "TUI bootstrap primary",
+        "idle guard",
+        "validated writeback",
+    ]
+    for phrase in required_contracts:
+        assert phrase in doc, phrase
+
+    boundary_terms = [
+        "raw Codex transcripts",
+        "credentials",
+        "hidden session files",
+    ]
+    for phrase in boundary_terms:
+        assert phrase in doc, phrase
+
+    assert "codex-cli-automation-driver.md" in index, "product index link"
+
+    print("codex-cli-automation-driver-audit-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a product contract for Codex CLI automation driver choices
- document the current scheduler/session surface: TUI bootstrap first, visible resume/remote-control proof before session-attached automation, explicit codex exec fallback
- add a small smoke for the public driver audit contract

## Validation
- python3 -m py_compile examples/codex-cli-automation-driver-audit-smoke.py
- python3 examples/codex-cli-automation-driver-audit-smoke.py
- python3 examples/codex-cli-session-probe-smoke.py
- goal-harness check --scan-path docs/product/codex-cli-automation-driver.md --scan-path docs/product/README.md --scan-path examples/codex-cli-automation-driver-audit-smoke.py
- git diff --check