### PR TITLE
Record SkillsBench tictoc native Goal closeout

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
@@ -6184,7 +6184,7 @@
           "case_id": "tictoc-unnecessary-abort-detection",
           "latest_decision": {
             "baseline_failure_scope": "runner_or_setup",
-            "baseline_run_id": "617dd17115c6",
+            "baseline_run_id": "97f003b9f1c1",
             "decision": "paired_baseline_runner_or_setup_repair_required",
             "failure_class": "skillsbench_runner_error",
             "official_score_delta": 0.0,
@@ -6451,6 +6451,62 @@
               "source_event_schema": "benchmark_run_v0",
               "status": "completed",
               "submit_eligible": false
+            },
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "baseline",
+              "artifact_refs": {
+                "compact_artifact_ref": "cloud-ecs/parallel-benchmark-20260620T210604Z/skillsbench-tictoc-native-goal-r4/.../benchmark_run.compact.json"
+              },
+              "benchmark_id": "skillsbench@1.1",
+              "case_id": "tictoc-unnecessary-abort-detection",
+              "case_ids": [
+                "tictoc-unnecessary-abort-detection"
+              ],
+              "codex_acp_runtime_preflight_passed": true,
+              "failure_class": "skillsbench_runner_error",
+              "failure_labels": [
+                "skillsbench_runner_error"
+              ],
+              "failure_scope": "runner_or_setup",
+              "goal_harness_inside_case": false,
+              "job_name": "skillsbench_1_1_tictoc_unnecessary_abort_detection_codex_app_server_goal_baseline",
+              "leaderboard_evidence": false,
+              "max_rounds_budget": 5,
+              "mode": "skillsbench_codex_app_server_goal_baseline",
+              "model_control_status": "reported_model_from_result_metadata",
+              "notes": "ECS native app-server Goal r4 compact official BenchFlow result; score=0.0; attribution=skillsbench_runner_error; launched before PR #353 so native worker public trace count remained 0; no raw task/log/trajectory read.",
+              "official_feedback_blinded": true,
+              "official_passed": false,
+              "official_score": 0.0,
+              "recorded_at": "2026-06-21T05:48:23+08:00",
+              "reward_feedback_forwarded": false,
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "parallel-benchmark-20260620T210604Z",
+              "run_id": "97f003b9f1c1",
+              "score_status": "failed",
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false,
+              "task_staging": {
+                "app_skills_mount_patch_applied": true,
+                "apt_retry_patch_applied": false,
+                "apt_retry_patch_required": false,
+                "apt_risk_preflight_blocked": false,
+                "apt_setup_risk_detected": false,
+                "codex_acp_runtime_tools_patch_applied": true,
+                "include_task_skills": false,
+                "original_task_mutated": false,
+                "resource_cap_patch": {
+                  "applied": false,
+                  "host_cpus": 32.0
+                },
+                "staged": true,
+                "task_skills_removed": true
+              }
             }
           ]
         },
@@ -6594,7 +6650,7 @@
           ]
         }
       },
-      "run_count": 117
+      "run_count": 118
     },
     "swe-marathon": {
       "benchmark_id": "swe-marathon",
@@ -10332,5 +10388,5 @@
     "source_of_truth": "benchmark_run_v0 compact run events",
     "update_rule": "upsert one run entry when a benchmark case is ingested or closed"
   },
-  "updated_at": "2026-06-21T04:42:27+08:00"
+  "updated_at": "2026-06-21T05:48:23+08:00"
 }

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
@@ -5,7 +5,7 @@ benchmark case outcomes and artifact references; it must not contain raw
 logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 
 - schema_version: `benchmark_run_ledger_v0`
-- updated_at: `2026-06-21T04:42:27+08:00`
+- updated_at: `2026-06-21T05:48:23+08:00`
 
 ## Case Decisions
 
@@ -31,7 +31,7 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `skillsbench@1.1` | `setup-fuzzing-py` | `baseline_runner_or_setup_repair_required` | - | `3` |
 | `skillsbench@1.1` | `software-dependency-audit` | `paired_no_score_uplift` | - | `6` |
 | `skillsbench@1.1` | `suricata-custom-exfil` | `paired_treatment_codex_acp_runtime_preflight_required` | - | `5` |
-| `skillsbench@1.1` | `tictoc-unnecessary-abort-detection` | `paired_baseline_runner_or_setup_repair_required` | - | `4` |
+| `skillsbench@1.1` | `tictoc-unnecessary-abort-detection` | `paired_baseline_runner_or_setup_repair_required` | - | `5` |
 | `skillsbench@1.1` | `travel-planning` | `baseline_failed_treatment_candidate` | - | `2` |
 | `swe-marathon` | `find-network-alignments` | `baseline_failed_treatment_candidate` | - | `1` |
 | `terminal-bench-worker-materialization@v0` | `nginx-request-logging` | `single_arm_recorded` | - | `2` |
@@ -192,6 +192,7 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `skillsbench@1.1` | `tictoc-unnecessary-abort-detection` | `skillsbench_codex_acp_blind_loop_baseline` | `` | `0.0` | `` | `1:0,2:0,3:0,4:0,5:missing` | `official_score_zero_case_failure` | `cloud-ecs/parallel-benchmark-20260620T131254Z/skillsbench-tictoc-baseline-r2/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `tictoc-unnecessary-abort-detection` | `skillsbench_goal_harness_blind_loop_treatment` | `` | `0.0` | `` | `1:0,2:0,3:0,4:0,5:missing` | `official_score_zero_case_failure` | `cloud-ecs/parallel-benchmark-20260620T131254Z/skillsbench-tictoc-treatment-r2/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `tictoc-unnecessary-abort-detection` | `skillsbench_codex_app_server_goal_baseline` | `` | `0.0` | `` | `` | `skillsbench_runner_error` | `cloud-ecs/parallel-benchmark-20260621T194222Z/skillsbench-tictoc-native-goal-keepalive-r2/benchmark_run.compact.json` |
+| `skillsbench@1.1` | `tictoc-unnecessary-abort-detection` | `baseline` | `` | `0.0` | `` | `` | `skillsbench_runner_error` | `cloud-ecs/parallel-benchmark-20260620T210604Z/skillsbench-tictoc-native-goal-r4/.../benchmark_run.compact.json` |
 | `skillsbench@1.1` | `travel-planning` | `baseline` | `` | `1.0` | `1` | `1:1*` | `none` | `.local/private-benchmark-jobs/skillsbench-travel-planning-blind-baseline-20260616T1238CST/travel-planning__codex_acp_blind_loop/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `travel-planning` | `skillsbench_raw_codex_autonomous_max5_baseline` | `` | `0.0` | `` | `1:missing` | `official_score_zero_case_failure` | `cloud-ecs/skillsbench-real-case/gh-skillsbench-travel-planning-container-acp-configfix-20260620T063851/benchmark_run.compact.json` |
 | `swe-marathon` | `find-network-alignments` | `swe_marathon_host_codex_app_server_goal_baseline` | `` | `0.0` | `` | `` | `official_verifier_solution_failure` | `cloud-ecs/parallel-benchmark-20260620T131254Z/swe-marathon-find-network-alignments-host-app-server-goal-r6/harbor_job_result.compact.json` |


### PR DESCRIPTION
## Summary
- add the SkillsBench `tictoc-unnecessary-abort-detection` native app-server Goal r4 compact closeout to the public benchmark run ledger
- update the derived markdown ledger counts and latest case decision

## Validation
- `python3 examples/benchmark-run-ledger-smoke.py`
- `git diff --check`
- `goal-harness check --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md`
- diff-only sensitive/private path scan on added lines

## Boundary
- source is remote `benchmark_run.compact.json` only
- no raw task text, private runner logs, trajectories, credentials, uploads, or absolute host paths included
- records that this case was launched before PR #353, so worker trace count remained zero