### PR TITLE
feat: add Codex CLI local driver plan

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -100,6 +100,17 @@ session, run:
 goal-harness codex-cli-visible-driver-plan --project . --goal-id <goal-id>
 ```
 
+To see the full local automation setup plan in one packet, including quota
+guard, visible-driver decision, TUI bootstrap command, explicit headless
+fallback command, and idle-guard requirement, run:
+
+```bash
+goal-harness codex-cli-local-driver-plan --project . --goal-id <goal-id> --agent-id <agent-id>
+```
+
+This is still dry-run-only. It does not run Codex, read transcripts, read
+session files, mutate a session, or spend quota.
+
 If same-session steering is unavailable and the user explicitly accepts a
 headless fallback, generate the fallback handoff instead of pretending the open
 TUI is preserved:

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -17,8 +17,8 @@ runtime contract, benchmark route, or launch draft.
   user experience.
 - [Codex CLI automation driver audit](codex-cli-automation-driver.md): the
   current Codex CLI scheduler/session surface audit, with a conservative local
-  driver shape that keeps TUI bootstrap primary and treats `codex exec` as an
-  explicit fallback.
+  driver planner that keeps TUI bootstrap primary, composes quota/idle/fallback
+  checks, and treats `codex exec` as an explicit fallback.
 - [Agent profile contract](agent-profile-contract.md): the registry-owned
   identity/scope contract for primary and side agents, including worktree and
   review handoff policy, while keeping todo ownership in `claimed_by` and future

--- a/docs/product/codex-cli-automation-driver.md
+++ b/docs/product/codex-cli-automation-driver.md
@@ -84,18 +84,30 @@ The local driver must never read or publish:
 - Every automatic turn writes compact evidence or a precise blocker before
   quota spend.
 
-## Next Build Slice
+## Current MVP
 
-Implement a dry-run-first local driver command that composes the existing
-pieces:
+The dry-run-first local driver planner composes the existing quota, TUI,
+visible-driver, and explicit fallback pieces into one operator-facing packet:
 
 ```bash
-goal-harness codex-cli-visible-driver-plan --project . --goal-id <goal> --agent-id <agent>
-goal-harness codex-cli-bootstrap-message --project . --goal-id <goal> --agent-id <agent>
-goal-harness codex-cli-exec-handoff --project . --goal-id <goal> --agent-id <agent>
+goal-harness codex-cli-local-driver-plan --project . --goal-id <goal> --agent-id <agent>
 ```
 
-The first runnable milestone should not try to be clever. It should emit the
-exact driver decision, explain whether the user keeps the TUI path or has opted
-into headless fallback, and include an idle-guard placeholder before any
-visible resume / remote-control experiment.
+It is intentionally not a scheduler yet. It does not run Codex, read raw
+transcripts, inspect session files, mutate a Codex session, or spend Goal
+Harness quota. It emits:
+
+- the quota guard command that must run before work;
+- the visible-driver decision for TUI bootstrap, visible attach proof,
+  resume/remote-control spike, or explicit headless fallback;
+- the repo-specific TUI bootstrap message command;
+- the explicit `codex exec` fallback generator;
+- the idle-guard placeholder that must exist before any same-session attach is
+  treated as production automation.
+
+## Next Build Slice
+
+Turn the dry-run planner into a real local driver only after the same-session
+path has a visible, idle-guarded proof. Until then, the user-facing happy path
+stays simple: start in Codex CLI TUI with one Goal Harness message, and use
+headless `codex exec` only as an explicit opt-in fallback.

--- a/docs/product/codex-cli-tui-loop.md
+++ b/docs/product/codex-cli-tui-loop.md
@@ -127,6 +127,18 @@ spend Goal Harness quota. Its job is to choose one of four next modes:
   accepts a headless fallback.
 - `tui_bootstrap_only`: ask the user to start inside Codex CLI TUI.
 
+Current local-driver planner:
+
+```bash
+goal-harness codex-cli-local-driver-plan --project . --goal-id <goal-id> --agent-id <agent-id>
+```
+
+This command is the conservative MVP for automation setup. It composes the
+quota guard, visible-driver plan, TUI bootstrap command, explicit headless
+fallback command, and idle-guard requirement into a single dry-run packet. It
+does not run Codex, read transcripts, read session files, mutate a session, or
+spend quota.
+
 ### 3. Headless Fallback
 
 `codex exec` remains useful for scheduled or CI-like work, but it is not the
@@ -201,11 +213,15 @@ projects runnable candidates; it should not over-specify the model's local plan.
    `goal-harness codex-cli-visible-driver-plan` so the next local driver knows
    whether to attempt visible attach, run a resume/remote-control proof, or
    fall back explicitly.
-5. **Local driver**: prototype a scheduler that runs quota, checks session
-   idle state, and either attaches visibly or falls back explicitly.
-6. **Validation harness**: add a public-safe fixture that proves the driver
+5. **Local driver planner**: ship
+   `goal-harness codex-cli-local-driver-plan` as the dry-run command that
+   composes quota, visible-driver, TUI bootstrap, explicit fallback, and
+   idle-guard requirements.
+6. **Local driver executor**: prototype a scheduler that runs quota, checks
+   session idle state, and either attaches visibly or falls back explicitly.
+7. **Validation harness**: add a public-safe fixture that proves the driver
    never stores raw transcript text and never spends quota before writeback.
-7. **Claude Code follow-up**: port the same product contract only after the
+8. **Claude Code follow-up**: port the same product contract only after the
    Codex CLI path is credible.
 
 ## Success Criteria

--- a/examples/codex-cli-local-driver-plan-smoke.py
+++ b/examples/codex-cli-local-driver-plan-smoke.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Smoke-test the dry-run-first Codex CLI local driver plan."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from goal_harness.codex_cli_probe import (  # noqa: E402
+    build_codex_cli_local_driver_plan,
+    classify_codex_cli_session_surface,
+)
+
+
+PROJECT = Path("/tmp/public-codex-cli-project")
+GOAL_ID = "public-codex-cli-goal"
+AGENT_ID = "codex-side-bypass"
+
+
+HELP_FIXTURE = {
+    "root": """
+Usage: codex [OPTIONS] [PROMPT]
+
+Commands:
+  exec      Run Codex non-interactively
+  resume    Resume a previous conversation
+""",
+    "exec": "Usage: codex exec [OPTIONS] [PROMPT]",
+    "resume": "Usage: codex resume [SESSION_ID]",
+}
+
+
+REMOTE_RESUME_HELP_FIXTURE = {
+    "root": """
+Usage: codex [OPTIONS] [PROMPT]
+
+Commands:
+  exec
+  remote-control  Manage the app-server daemon with remote control enabled
+  resume          Resume a previous interactive session
+
+Options:
+  --remote <ADDR>  Connect the TUI to a remote app server endpoint
+""",
+    "exec": "Usage: codex exec [OPTIONS] [PROMPT]",
+    "resume": """
+Usage: codex resume [OPTIONS] [SESSION_ID] [PROMPT]
+
+Resume a previous interactive session.
+""",
+}
+
+
+ATTACH_HELP_FIXTURE = {
+    "root": """
+Usage: codex [OPTIONS] [PROMPT]
+
+Commands:
+  exec
+  resume
+  attach-session    Send prompt to session after checking the idle TUI
+""",
+    "exec": "Usage: codex exec [OPTIONS] [PROMPT]",
+    "resume": "Usage: codex resume [SESSION_ID]",
+}
+
+
+def run_cli(*extra_args: str) -> str:
+    result = subprocess.run(
+        [sys.executable, "-m", "goal_harness.cli", *extra_args],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def assert_common_contract(payload: dict[str, object]) -> None:
+    assert payload["ok"] is True, payload
+    assert payload["schema_version"] == "codex_cli_local_driver_plan_v0", payload
+    assert payload["driver_phase"] == "dry_run_plan", payload
+    assert payload["goal_id"] == GOAL_ID, payload
+    assert payload["agent_id"] == AGENT_ID, payload
+    commands = payload["commands"]
+    assert "quota should-run --goal-id public-codex-cli-goal --agent-id codex-side-bypass" in commands["quota_guard"], payload
+    assert "codex-cli-visible-driver-plan" in commands["visible_driver_plan"], payload
+    assert "codex-cli-bootstrap-message" in commands["tui_bootstrap_message"], payload
+    assert "codex-cli-exec-handoff" in commands["explicit_headless_fallback"], payload
+    assert payload["idle_guard"]["required"] is True, payload
+    assert payload["idle_guard"]["implemented"] is False, payload
+    policy = payload["execution_policy"]
+    assert policy["tui_bootstrap_primary"] is True, payload
+    assert policy["headless_fallback_requires_user_opt_in"] is True, payload
+    assert policy["same_session_attachment_requires_visible_proof"] is True, payload
+    boundary = payload["boundary"]
+    assert boundary["dry_run_plan_only"] is True, payload
+    assert boundary["runs_codex"] is False, payload
+    assert boundary["reads_raw_transcripts"] is False, payload
+    assert boundary["reads_credentials"] is False, payload
+    assert boundary["reads_session_files"] is False, payload
+    assert boundary["mutates_codex_session"] is False, payload
+    assert boundary["spends_goal_harness_quota"] is False, payload
+
+
+def build_plan(command_outputs: dict[str, str]) -> dict[str, object]:
+    return build_codex_cli_local_driver_plan(
+        project=PROJECT,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        cli_bin="goal-harness",
+        codex_bin="codex",
+        probe_payload=classify_codex_cli_session_surface(command_outputs=command_outputs),
+    )
+
+
+def main() -> int:
+    fallback_plan = build_plan(HELP_FIXTURE)
+    assert_common_contract(fallback_plan)
+    assert fallback_plan["driver_mode"] == "explicit_headless_fallback_after_tui_bootstrap", fallback_plan
+    assert fallback_plan["decision"] == "keep_tui_primary_offer_explicit_exec_fallback", fallback_plan
+
+    remote_plan = build_plan(REMOTE_RESUME_HELP_FIXTURE)
+    assert_common_contract(remote_plan)
+    assert remote_plan["driver_mode"] == "visible_resume_or_remote_control_spike", remote_plan
+    assert remote_plan["decision"] == "run_visible_resume_or_remote_control_proof", remote_plan
+
+    attach_plan = build_plan(ATTACH_HELP_FIXTURE)
+    assert_common_contract(attach_plan)
+    assert attach_plan["driver_mode"] == "session_attached_visible_turn", attach_plan
+    assert attach_plan["decision"] == "attempt_visible_session_attach_after_idle_guard", attach_plan
+
+    with tempfile.TemporaryDirectory(prefix="goal-harness-codex-cli-local-driver-") as tmp:
+        fixture = Path(tmp) / "codex-remote-help.json"
+        fixture.write_text(json.dumps({"command_outputs": REMOTE_RESUME_HELP_FIXTURE}))
+        cli_json = json.loads(
+            run_cli(
+                "--format",
+                "json",
+                "codex-cli-local-driver-plan",
+                "--project",
+                str(PROJECT),
+                "--goal-id",
+                GOAL_ID,
+                "--agent-id",
+                AGENT_ID,
+                "--fixture",
+                str(fixture),
+            )
+        )
+        assert_common_contract(cli_json)
+        assert cli_json["driver_mode"] == "visible_resume_or_remote_control_spike", cli_json
+
+        cli_markdown = run_cli(
+            "codex-cli-local-driver-plan",
+            "--project",
+            str(PROJECT),
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_ID,
+            "--fixture",
+            str(fixture),
+        )
+        assert "# Codex CLI Local Driver Plan" in cli_markdown, cli_markdown
+        assert "driver_phase: `dry_run_plan`" in cli_markdown, cli_markdown
+        assert "headless_fallback_requires_user_opt_in: `True`" in cli_markdown, cli_markdown
+
+    print("codex-cli-local-driver-plan-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -139,6 +139,7 @@ from .cli_commands import (
     handle_check_command,
     handle_codex_cli_bootstrap_message_command,
     handle_codex_cli_exec_handoff_command,
+    handle_codex_cli_local_driver_plan_command,
     handle_codex_cli_session_probe_command,
     handle_codex_cli_visible_driver_plan_command,
     handle_diagnose_command,
@@ -5936,6 +5937,7 @@ def main(argv: list[str] | None = None) -> int:
             "connect",
             "codex-cli-bootstrap-message",
             "codex-cli-exec-handoff",
+            "codex-cli-local-driver-plan",
             "codex-cli-session-probe",
             "codex-cli-visible-driver-plan",
             "demo",
@@ -6016,6 +6018,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "codex-cli-visible-driver-plan":
         return handle_codex_cli_visible_driver_plan_command(args, print_payload)
+
+    if args.command == "codex-cli-local-driver-plan":
+        return handle_codex_cli_local_driver_plan_command(args, print_payload)
 
     if args.command == "heartbeat-prompt":
         try:

--- a/goal_harness/cli_commands/__init__.py
+++ b/goal_harness/cli_commands/__init__.py
@@ -13,6 +13,7 @@ from .dreaming import handle_dreaming_command, register_dreaming_commands
 from .starter import (
     handle_codex_cli_bootstrap_message_command,
     handle_codex_cli_exec_handoff_command,
+    handle_codex_cli_local_driver_plan_command,
     handle_codex_cli_session_probe_command,
     handle_codex_cli_visible_driver_plan_command,
     handle_demo_command,
@@ -31,6 +32,7 @@ __all__ = [
     "handle_check_command",
     "handle_codex_cli_bootstrap_message_command",
     "handle_codex_cli_exec_handoff_command",
+    "handle_codex_cli_local_driver_plan_command",
     "handle_codex_cli_session_probe_command",
     "handle_codex_cli_visible_driver_plan_command",
     "handle_diagnose_command",

--- a/goal_harness/cli_commands/starter.py
+++ b/goal_harness/cli_commands/starter.py
@@ -26,7 +26,9 @@ from ..project_prompt import (
 from ..codex_cli_probe import (
     DEFAULT_CODEX_BIN,
     DEFAULT_TIMEOUT_SECONDS,
+    build_codex_cli_local_driver_plan,
     build_codex_cli_visible_driver_plan,
+    render_codex_cli_local_driver_plan_markdown,
     render_codex_cli_session_probe_markdown,
     render_codex_cli_visible_driver_plan_markdown,
     run_codex_cli_session_probe,
@@ -119,6 +121,37 @@ def register_starter_commands(subparsers: argparse._SubParsersAction) -> None:
         help="Per-command timeout for help-only Codex CLI probes.",
     )
     codex_cli_visible_driver_parser.add_argument(
+        "--fixture",
+        help="Public-safe JSON fixture with command_outputs, used instead of invoking Codex CLI.",
+    )
+
+    codex_cli_local_driver_parser = subparsers.add_parser(
+        "codex-cli-local-driver-plan",
+        help="Compose a dry-run-first local Codex CLI driver plan from quota, TUI bootstrap, visible-driver, and exec fallback commands.",
+    )
+    codex_cli_local_driver_parser.add_argument("--project", default=".", help="Project directory to start from.")
+    codex_cli_local_driver_parser.add_argument("--goal-id", help="Goal id. Defaults to <project-name>-goal.")
+    codex_cli_local_driver_parser.add_argument(
+        "--agent-id",
+        help="Registered Goal Harness agent id to include in quota/claim instructions.",
+    )
+    codex_cli_local_driver_parser.add_argument(
+        "--cli-bin",
+        default="goal-harness",
+        help="Goal Harness CLI binary name embedded in generated commands.",
+    )
+    codex_cli_local_driver_parser.add_argument(
+        "--codex-bin",
+        default=DEFAULT_CODEX_BIN,
+        help="Codex CLI executable to probe and reference in fallback commands.",
+    )
+    codex_cli_local_driver_parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=DEFAULT_TIMEOUT_SECONDS,
+        help="Per-command timeout for help-only Codex CLI probes.",
+    )
+    codex_cli_local_driver_parser.add_argument(
         "--fixture",
         help="Public-safe JSON fixture with command_outputs, used instead of invoking Codex CLI.",
     )
@@ -225,6 +258,27 @@ def handle_codex_cli_visible_driver_plan_command(
         probe_payload=probe_payload,
     )
     print_payload(payload, args.format, render_codex_cli_visible_driver_plan_markdown)
+    return 0 if payload.get("ok") else 1
+
+
+def handle_codex_cli_local_driver_plan_command(
+    args: argparse.Namespace,
+    print_payload: PrintPayload,
+) -> int:
+    probe_payload = run_codex_cli_session_probe(
+        codex_bin=args.codex_bin,
+        timeout_seconds=args.timeout_seconds,
+        fixture=Path(args.fixture).expanduser() if args.fixture else None,
+    )
+    payload = build_codex_cli_local_driver_plan(
+        project=Path(args.project),
+        goal_id=args.goal_id,
+        agent_id=args.agent_id,
+        cli_bin=args.cli_bin,
+        codex_bin=args.codex_bin,
+        probe_payload=probe_payload,
+    )
+    print_payload(payload, args.format, render_codex_cli_local_driver_plan_markdown)
     return 0 if payload.get("ok") else 1
 
 

--- a/goal_harness/codex_cli_probe.py
+++ b/goal_harness/codex_cli_probe.py
@@ -333,6 +333,137 @@ def build_codex_cli_visible_driver_plan(
     }
 
 
+def build_codex_cli_local_driver_plan(
+    *,
+    project: Path,
+    goal_id: str | None,
+    agent_id: str | None,
+    cli_bin: str,
+    codex_bin: str,
+    probe_payload: dict[str, Any],
+) -> dict[str, Any]:
+    """Build a dry-run-first local driver plan for Codex CLI.
+
+    This does not launch Codex or mutate any session. It composes the existing
+    one-message TUI bootstrap, visible-driver plan, quota guard, and explicit
+    headless fallback into one operator-facing decision packet.
+    """
+
+    visible_plan = build_codex_cli_visible_driver_plan(
+        project=project,
+        goal_id=goal_id,
+        agent_id=agent_id,
+        cli_bin=cli_bin,
+        codex_bin=codex_bin,
+        probe_payload=probe_payload,
+    )
+    resolved_project = visible_plan["project"]
+    resolved_goal_id = visible_plan["goal_id"]
+    agent_arg = f" --agent-id {_shell_arg(agent_id)}" if agent_id else ""
+    visible_driver_plan_command = (
+        f"{_shell_arg(cli_bin)} codex-cli-visible-driver-plan "
+        f"--project {_shell_arg(resolved_project)} --goal-id {_shell_arg(resolved_goal_id)}{agent_arg} "
+        f"--codex-bin {_shell_arg(codex_bin)}"
+    )
+    quota_guard_command = (
+        f"{_shell_arg(cli_bin)} --format json "
+        "--registry \"$HOME/.codex/goal-harness/registry.global.json\" "
+        f"quota should-run --goal-id {_shell_arg(resolved_goal_id)}{agent_arg}"
+    )
+    bootstrap_command = (
+        f"{_shell_arg(cli_bin)} codex-cli-bootstrap-message "
+        f"--project {_shell_arg(resolved_project)} --goal-id {_shell_arg(resolved_goal_id)}{agent_arg}"
+    )
+    exec_fallback_command = (
+        f"{_shell_arg(cli_bin)} codex-cli-exec-handoff "
+        f"--project {_shell_arg(resolved_project)} --goal-id {_shell_arg(resolved_goal_id)}{agent_arg} "
+        f"--codex-bin {_shell_arg(codex_bin)}"
+    )
+    driver_mode = str(visible_plan.get("driver_mode") or "tui_bootstrap_only")
+
+    if driver_mode == "session_attached_visible_turn":
+        decision = "attempt_visible_session_attach_after_idle_guard"
+        operator_instruction = (
+            "Run quota guard, verify idle guard, then attempt only the detected visible attach primitive."
+        )
+    elif driver_mode == "visible_resume_or_remote_control_spike":
+        decision = "run_visible_resume_or_remote_control_proof"
+        operator_instruction = (
+            "Treat resume or remote-control as a proof target, not production session attachment, until the turn is visible and interruptible."
+        )
+    elif driver_mode == "explicit_headless_fallback_after_tui_bootstrap":
+        decision = "keep_tui_primary_offer_explicit_exec_fallback"
+        operator_instruction = (
+            "Keep one-message Codex CLI TUI bootstrap as the default; use codex exec only after explicit opt-in."
+        )
+    else:
+        decision = "ask_user_to_start_from_tui"
+        operator_instruction = "Ask the user to start inside Codex CLI TUI and paste the bootstrap message."
+
+    return {
+        "ok": True,
+        "schema_version": "codex_cli_local_driver_plan_v0",
+        "project": resolved_project,
+        "goal_id": resolved_goal_id,
+        "agent_id": agent_id,
+        "cli_bin": cli_bin,
+        "codex_bin": codex_bin,
+        "driver_phase": "dry_run_plan",
+        "driver_mode": driver_mode,
+        "decision": decision,
+        "operator_instruction": operator_instruction,
+        "visible_driver_plan": {
+            "schema_version": visible_plan.get("schema_version"),
+            "driver_mode": visible_plan.get("driver_mode"),
+            "automation_action": visible_plan.get("automation_action"),
+            "next_step": visible_plan.get("next_step"),
+        },
+        "commands": {
+            "quota_guard": quota_guard_command,
+            "local_driver_plan": (
+                f"{_shell_arg(cli_bin)} codex-cli-local-driver-plan "
+                f"--project {_shell_arg(resolved_project)} --goal-id {_shell_arg(resolved_goal_id)}{agent_arg} "
+                f"--codex-bin {_shell_arg(codex_bin)}"
+            ),
+            "visible_driver_plan": visible_driver_plan_command,
+            "tui_bootstrap_message": bootstrap_command,
+            "explicit_headless_fallback": exec_fallback_command,
+        },
+        "driver_steps": [
+            "run quota_guard and stop when user_channel.action_required=true",
+            "run visible_driver_plan to classify TUI, resume, remote-control, or exec fallback mode",
+            "verify idle_guard before any visible resume or remote-control prompt",
+            "prefer one-message TUI bootstrap until visible attach is proven",
+            "offer explicit_headless_fallback only after opt-in and goal_boundary approval",
+            "write back compact evidence or a precise blocker before quota spend",
+        ],
+        "idle_guard": {
+            "required": True,
+            "implemented": False,
+            "placeholder": "future driver must prove no active human typing and no running turn before visible resume or remote-control prompt",
+        },
+        "execution_policy": {
+            "tui_bootstrap_primary": True,
+            "headless_fallback_requires_user_opt_in": True,
+            "same_session_attachment_requires_visible_proof": True,
+            "quota_guard_required": True,
+            "spend_after_validated_writeback_only": True,
+        },
+        "boundary": {
+            "dry_run_plan_only": True,
+            "runs_codex": False,
+            "reads_raw_transcripts": False,
+            "reads_credentials": False,
+            "reads_session_files": False,
+            "mutates_codex_session": False,
+            "spends_goal_harness_quota": False,
+            "requires_idle_guard_before_visible_prompt": True,
+            "requires_user_gate_stop": True,
+        },
+        "warnings": list(visible_plan.get("warnings") or []),
+    }
+
+
 def render_codex_cli_session_probe_markdown(payload: dict[str, Any]) -> str:
     capabilities = payload.get("capabilities") or {}
     boundary = payload.get("boundary") or {}
@@ -405,6 +536,64 @@ def render_codex_cli_visible_driver_plan_markdown(payload: dict[str, Any]) -> st
 - spends_goal_harness_quota: `{boundary.get("spends_goal_harness_quota")}`
 - requires_idle_guard_before_visible_prompt: `{boundary.get("requires_idle_guard_before_visible_prompt")}`
 - requires_user_gate_stop: `{boundary.get("requires_user_gate_stop")}`
+
+## Warnings
+
+{warning_lines}
+"""
+
+
+def render_codex_cli_local_driver_plan_markdown(payload: dict[str, Any]) -> str:
+    boundary = payload.get("boundary") if isinstance(payload.get("boundary"), dict) else {}
+    commands = payload.get("commands") if isinstance(payload.get("commands"), dict) else {}
+    steps = payload.get("driver_steps") if isinstance(payload.get("driver_steps"), list) else []
+    idle_guard = payload.get("idle_guard") if isinstance(payload.get("idle_guard"), dict) else {}
+    policy = payload.get("execution_policy") if isinstance(payload.get("execution_policy"), dict) else {}
+    warnings = payload.get("warnings") if isinstance(payload.get("warnings"), list) else []
+    step_lines = "\n".join(f"{index}. {step}" for index, step in enumerate(steps, start=1))
+    warning_lines = "\n".join(f"- {warning}" for warning in warnings) if warnings else "- none"
+    return f"""# Codex CLI Local Driver Plan
+
+- driver_phase: `{payload.get("driver_phase")}`
+- driver_mode: `{payload.get("driver_mode")}`
+- decision: `{payload.get("decision")}`
+- operator_instruction: {payload.get("operator_instruction")}
+
+## Commands
+
+```bash
+{commands.get("quota_guard")}
+{commands.get("visible_driver_plan")}
+{commands.get("tui_bootstrap_message")}
+{commands.get("explicit_headless_fallback")}
+```
+
+## Driver Steps
+
+{step_lines}
+
+## Idle Guard
+
+- required: `{idle_guard.get("required")}`
+- implemented: `{idle_guard.get("implemented")}`
+- placeholder: {idle_guard.get("placeholder")}
+
+## Execution Policy
+
+- tui_bootstrap_primary: `{policy.get("tui_bootstrap_primary")}`
+- headless_fallback_requires_user_opt_in: `{policy.get("headless_fallback_requires_user_opt_in")}`
+- same_session_attachment_requires_visible_proof: `{policy.get("same_session_attachment_requires_visible_proof")}`
+- quota_guard_required: `{policy.get("quota_guard_required")}`
+- spend_after_validated_writeback_only: `{policy.get("spend_after_validated_writeback_only")}`
+
+## Boundary
+
+- dry_run_plan_only: `{boundary.get("dry_run_plan_only")}`
+- runs_codex: `{boundary.get("runs_codex")}`
+- reads_raw_transcripts: `{boundary.get("reads_raw_transcripts")}`
+- reads_session_files: `{boundary.get("reads_session_files")}`
+- mutates_codex_session: `{boundary.get("mutates_codex_session")}`
+- spends_goal_harness_quota: `{boundary.get("spends_goal_harness_quota")}`
 
 ## Warnings
 


### PR DESCRIPTION
## Summary
- add a dry-run-first `codex-cli-local-driver-plan` command that composes quota guard, visible-driver plan, TUI bootstrap, explicit headless fallback, and idle-guard requirements
- document the current MVP in the Codex CLI product and getting-started docs
- add a public-safe smoke for fallback, resume/remote-control, and visible attach classifications

## Validation
- `python3 -m py_compile goal_harness/codex_cli_probe.py goal_harness/cli_commands/starter.py goal_harness/cli.py examples/codex-cli-local-driver-plan-smoke.py`
- `python3 examples/codex-cli-local-driver-plan-smoke.py`
- `python3 examples/codex-cli-session-probe-smoke.py && python3 examples/codex-cli-bootstrap-message-smoke.py && python3 examples/codex-cli-exec-handoff-smoke.py`
- `goal-harness check` targeted scan passed: errors=0, public boundary clean; one pre-existing duplicate-index warning remains unrelated
- `git diff --check`