### PR TITLE
docs: polish Codex CLI one-message start

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,10 +153,11 @@ the human/operator.
 Requirements: Python 3.11+, Git, macOS or Linux shell. The Python package has
 no runtime dependencies outside the standard library.
 
-The recommended start is agent-first. For Codex CLI users, stay in the TUI:
+The recommended start is agent-first. For Codex CLI users, stay in the TUI and
+paste one message:
 
 1. Open Codex CLI from your project repo.
-2. Ask it to generate or use this Goal Harness bootstrap:
+2. Paste this message:
 
    ```text
    Start Goal Harness for this repo. Install or repair it if needed, connect this
@@ -164,8 +165,12 @@ The recommended start is agent-first. For Codex CLI users, stay in the TUI:
    agent todo only after quota says it should run.
    ```
 
-3. After Goal Harness is installed, you can generate a tailored one-message
-   bootstrap and paste it into the same Codex CLI TUI:
+   The agent should install or repair Goal Harness, connect the repo, run the
+   quota/status guard, then show the current goal, user gate, top todos, and
+   next safe action before longer work.
+
+3. After Goal Harness is installed, generate a tailored one-message bootstrap
+   when you want the stricter reusable prompt:
 
    ```bash
    goal-harness codex-cli-bootstrap-message --project . --goal-id <goal-id>
@@ -174,7 +179,8 @@ The recommended start is agent-first. For Codex CLI users, stay in the TUI:
 This is the primary Codex CLI path: the user keeps the visible TUI for steering,
 review, and takeover; Goal Harness supplies goal state, todo ownership, quota,
 gates, writeback, and the next safe action. Headless `codex exec` is an explicit
-fallback, not the default experience.
+fallback, not the default experience. Local driver and visible-session proof
+commands are follow-up automation checks, not first-run requirements.
 
 For Codex App, Claude Code, Cursor, or another terminal agent, paste this from
 the project repo:

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -68,7 +68,8 @@ Success looks like this:
 For Codex CLI users, the product target is even simpler: start in the Codex
 TUI, send one Goal Harness bootstrap message, and keep later automation visible
 and interruptible in that TUI whenever the CLI exposes a safe session-attachment
-primitive.
+primitive. The first-run path should not require you to understand registry
+paths, runtime roots, JSON payloads, or session files.
 
 First-run path:
 
@@ -78,16 +79,23 @@ project, show me the first user gate if one exists, then run the first safe
 agent todo only after quota says it should run.
 ```
 
-Once `goal-harness` is installed, generate a repo-specific paste message:
+The first useful response should show the current goal id, concrete user gate
+if one exists, top user todo if any, top agent todo, and next safe action before
+longer delivery work.
+
+Once `goal-harness` is installed, generate a stricter repo-specific paste
+message:
 
 ```bash
 goal-harness codex-cli-bootstrap-message --project . --goal-id <goal-id>
 ```
 
 Keep that as the preferred interactive path: the human watches and steers in
-Codex CLI TUI, while Goal Harness owns quota/status/todos/gates/writeback. To
-evaluate future same-session automation support without touching transcripts or
-session files, run:
+Codex CLI TUI, while Goal Harness owns quota/status/todos/gates/writeback.
+
+The commands below are optional automation checks after the one-message path
+works. To evaluate future same-session automation support without touching
+transcripts or session files, run:
 
 ```bash
 goal-harness codex-cli-session-probe

--- a/docs/product/codex-cli-tui-loop.md
+++ b/docs/product/codex-cli-tui-loop.md
@@ -71,6 +71,19 @@ repair/install Goal Harness if needed, connect the repo conservatively, run the
 quota/status guard, obey `interaction_contract`, preserve the visible TUI, and
 spend quota only after validated writeback.
 
+The first useful TUI response should be a control-plane snapshot, not a lecture
+about internals:
+
+- current goal id;
+- concrete user gate, or "none";
+- top user todo, or "none";
+- top agent todo;
+- next safe action.
+
+Registry paths, runtime roots, JSON payloads, local-driver plans, and
+visible-session proof fixtures are follow-up diagnostics. They should not be
+required before a first-time user sees the current goal/gate/todo state.
+
 ### 2. Session-Attached Automation
 
 This is the preferred automation target. A scheduler wakes up, runs

--- a/examples/codex-cli-bootstrap-message-smoke.py
+++ b/examples/codex-cli-bootstrap-message-smoke.py
@@ -25,6 +25,10 @@ MUST_HAVE = (
     "same Codex CLI TUI session",
     "hidden headless `codex exec`",
     "explicit fallback",
+    "current goal id",
+    "top user todo",
+    "top agent todo",
+    "next safe action",
     "goal-harness doctor",
     "goal-harness bootstrap",
     "quota should-run",
@@ -38,6 +42,7 @@ MUST_HAVE = (
     "refresh-state",
     "quota spend-slot",
     "--source controller",
+    "not first-run prerequisites",
 )
 
 
@@ -74,12 +79,19 @@ def assert_docs_surface_codex_cli_quickstart() -> None:
     product_contract = (REPO_ROOT / "docs/product/codex-cli-tui-loop.md").read_text(encoding="utf-8")
 
     for text in (readme, getting_started, product_contract):
-        assert "Codex CLI TUI" in text, text[:500]
+        assert "Codex CLI" in text and "TUI" in text, text[:500]
         assert "Start Goal Harness for this repo" in text, text[:500]
         assert "goal-harness codex-cli-bootstrap-message --project . --goal-id <goal-id>" in text, text[:500]
 
     normalized_readme = " ".join(readme.split())
+    normalized_getting_started = " ".join(getting_started.split())
+    normalized_product_contract = " ".join(product_contract.split())
     assert "Headless `codex exec` is an explicit fallback" in normalized_readme, readme
+    assert "paste one message" in normalized_readme, readme
+    assert "show the current goal, user gate, top todos, and next safe action" in normalized_readme, readme
+    assert "first-run path should not require you to understand registry paths" in normalized_getting_started, getting_started
+    assert "optional automation checks after the one-message path works" in normalized_getting_started, getting_started
+    assert "first useful TUI response should be a control-plane snapshot" in normalized_product_contract, product_contract
     assert "goal-harness codex-cli-session-probe" in getting_started, getting_started
     assert "goal-harness codex-cli-exec-handoff --project . --goal-id <goal-id>" in getting_started, getting_started
 

--- a/goal_harness/project_prompt.py
+++ b/goal_harness/project_prompt.py
@@ -332,6 +332,14 @@ Project: `{project}`
 Goal id: `{goal_id}`
 {agent_line}
 
+Success criteria for this first TUI turn:
+- I should not need to inspect registry paths, runtime roots, JSON payloads, or
+  hidden session files.
+- Before longer delivery work, show me the current goal id, concrete user gate
+  if any, top user todo if any, top agent todo, and next safe action.
+- If no user gate or user todo exists, say that explicitly and continue only
+  after the quota/status guard permits work.
+
 1. Ensure the Goal Harness CLI works:
 
 ```bash
@@ -361,7 +369,8 @@ Follow `interaction_contract` exactly:
 - If delivery is allowed, choose one runnable agent todo after a short steering
   audit, preferably a current-agent claimed advancement todo.
 
-4. Execute one bounded segment in this TUI-visible session. Validate the result.
+4. Report the current goal/gate/todo/next-action snapshot in this TUI, then
+execute one bounded segment in this TUI-visible session. Validate the result.
 Do not store raw Codex transcripts, credentials, private paths, raw logs, or
 production artifacts in public docs or Goal Harness state.
 
@@ -372,8 +381,9 @@ production artifacts in public docs or Goal Harness state.
 {quota_spend_command}
 ```
 
-End with the changed files, validation result, current gate/todo state, and the
-next safe action.
+End with changed files, validation result, current gate/todo state, and next
+safe action. Keep optional automation checks such as local-driver-plan or
+visible-session-proof as follow-up diagnostics, not first-run prerequisites.
 """
 
 


### PR DESCRIPTION
## Summary
- make the Codex CLI quickstart start with one TUI message before optional automation checks
- sharpen the generated bootstrap message success criteria: current goal, user gate, top todos, and next safe action before longer work
- update the bootstrap smoke to guard the one-message TUI path and optional local-driver/proof layering

## Validation
- `python3 -m py_compile goal_harness/project_prompt.py examples/codex-cli-bootstrap-message-smoke.py`
- `python3 examples/codex-cli-bootstrap-message-smoke.py`
- `python3 examples/codex-cli-session-probe-smoke.py && python3 examples/codex-cli-local-driver-plan-smoke.py && python3 examples/codex-cli-visible-session-proof-smoke.py && python3 examples/codex-cli-exec-handoff-smoke.py`
- `goal-harness check` targeted scan passed: errors=0, public boundary clean; one pre-existing duplicate-index warning remains unrelated
- `git diff --check`