### PR TITLE
feat: add Codex CLI no-clone install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,8 +150,9 @@ the human/operator.
 
 ## Quick Start
 
-Requirements: Python 3.11+, Git, macOS or Linux shell. The Python package has
-no runtime dependencies outside the standard library.
+Requirements: Python 3.11+, `curl`, `tar`, macOS or Linux shell. Git is only
+needed for contributor clone/canary workflows. The Python package has no
+runtime dependencies outside the standard library.
 
 The recommended start is agent-first. For Codex CLI users, stay in the TUI and
 paste one message:
@@ -160,9 +161,11 @@ paste one message:
 2. Paste this message:
 
    ```text
-   Start Goal Harness for this repo. Install or repair it if needed, connect this
-   project, show me the first user gate if one exists, then run the first safe
-   agent todo only after quota says it should run.
+   Start Goal Harness for this repo. If `goal-harness` is missing, install it
+   with the official no-clone GitHub installer, then connect this project. Show
+   me the current goal, concrete user gate if any, top todos, and next safe
+   action before running longer work. Keep me in this Codex CLI TUI unless I
+   explicitly accept a headless fallback.
    ```
 
    The agent should install or repair Goal Harness, connect the repo, run the
@@ -189,11 +192,10 @@ the project repo:
 Install and connect Goal Harness for this project end to end. Do not stop at a
 plan.
 
-If `goal-harness` is not on PATH:
-- clone https://github.com/huangruiteng/goal-harness to ~/goal-harness if it is
-  not already present;
-- run ~/goal-harness/scripts/install-local.sh;
-- export PATH="$HOME/.local/bin:$PATH".
+If `goal-harness` is not on PATH, install it without making me clone the repo:
+
+curl -fsSL https://raw.githubusercontent.com/huangruiteng/goal-harness/main/scripts/install-from-github.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
 
 Then:
 1. Run `goal-harness doctor`.
@@ -222,7 +224,16 @@ Success looks like this:
 - `goal-harness status` shows who should act next;
 - local runtime state is ignored, not committed.
 
-Manual install is still available when you want to drive the setup yourself:
+Manual no-clone install is still available when you want to drive the setup
+yourself:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/huangruiteng/goal-harness/main/scripts/install-from-github.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
+goal-harness doctor
+```
+
+Clone-based install is for contributors who want the live canary wrapper:
 
 ```bash
 git clone https://github.com/huangruiteng/goal-harness ~/goal-harness
@@ -356,6 +367,8 @@ contract.
 - [Documentation index](docs/README.md): stable docs grouped by audience.
 - [Architecture](docs/architecture.md): lifetime-goal invariant and core
   control-plane shape.
+- [Codex CLI packaged install](docs/product/codex-cli-packaged-install.md):
+  no-clone install/update/start path for Codex CLI users.
 - [Integration guide](docs/integration.md): how to connect a project to Goal
   Harness.
 - [Showcase catalog](docs/showcases/README.md): public-safe cases and future

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -15,10 +15,10 @@ Install and connect Goal Harness for this project end to end. Do not stop at a
 plan.
 
 If `goal-harness` is not on PATH:
-- clone https://github.com/huangruiteng/goal-harness to ~/goal-harness if it is
-  not already present;
-- run ~/goal-harness/scripts/install-local.sh;
-- export PATH="$HOME/.local/bin:$PATH".
+- install it without making me clone the repo:
+
+curl -fsSL https://raw.githubusercontent.com/huangruiteng/goal-harness/main/scripts/install-from-github.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
 
 Then:
 1. Run `goal-harness doctor`.
@@ -74,9 +74,11 @@ paths, runtime roots, JSON payloads, or session files.
 First-run path:
 
 ```text
-Start Goal Harness for this repo. Install or repair it if needed, connect this
-project, show me the first user gate if one exists, then run the first safe
-agent todo only after quota says it should run.
+Start Goal Harness for this repo. If `goal-harness` is missing, install it with
+the official no-clone GitHub installer, then connect this project. Show me the
+current goal, concrete user gate if any, top todos, and next safe action before
+running longer work. Keep me in this Codex CLI TUI unless I explicitly accept a
+headless fallback.
 ```
 
 The first useful response should show the current goal id, concrete user gate
@@ -152,10 +154,29 @@ Maintainers can validate the public fresh-clone path with:
 python3 examples/fresh-clone-quickstart-smoke.py
 ```
 
-## Manual Install
+## No-Clone Install
 
-Install one shared local checkout manually when you want to drive setup without
-an agent:
+Install or update Goal Harness without cloning the repository:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/huangruiteng/goal-harness/main/scripts/install-from-github.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
+goal-harness doctor
+```
+
+The installer downloads a GitHub archive, writes a stable local release snapshot
+under `~/.local/share/goal-harness/releases/`, installs the CLI wrapper under
+`~/.local/bin`, and installs the reusable Goal Harness skills under
+`~/.codex/skills`.
+
+This is the recommended install repair path for Codex CLI users because an
+agent can run it from inside the TUI without asking the user to clone this
+repository first.
+
+## Contributor Install
+
+Install one shared local checkout when you want to develop Goal Harness itself
+or test a live canary wrapper:
 
 ```bash
 git clone https://github.com/huangruiteng/goal-harness ~/goal-harness
@@ -163,7 +184,7 @@ git clone https://github.com/huangruiteng/goal-harness ~/goal-harness
 goal-harness doctor
 ```
 
-The installer creates:
+The checkout installer creates:
 
 - `~/.local/bin/goal-harness`, pointing at a stable local release snapshot;
 - `~/.local/bin/goal-harness-canary`, pointing at the live checkout;
@@ -183,7 +204,16 @@ checkout to the default local release.
 - the CLI wrappers under `~/.local/bin`;
 - the Goal Harness Codex skills under `~/.codex/skills`.
 
-Re-run the installer to update both surfaces from the current checkout:
+For a no-clone install, rerun the GitHub archive installer to refresh the
+release snapshot and skills:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/huangruiteng/goal-harness/main/scripts/install-from-github.sh | bash
+goal-harness doctor
+```
+
+For a contributor checkout, re-run the installer to update both surfaces from
+the current checkout:
 
 ```bash
 cd ~/goal-harness

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -15,6 +15,9 @@ runtime contract, benchmark route, or launch draft.
   Harness loop, later automation tries to steer the same visible session, and
   headless `codex exec` remains an explicit fallback rather than the default
   user experience.
+- [Codex CLI packaged install path](codex-cli-packaged-install.md): the
+  no-clone install/update/start route for Codex CLI users, with clone-plus-canary
+  reserved for contributors.
 - [Codex CLI automation driver audit](codex-cli-automation-driver.md): the
   current Codex CLI scheduler/session surface audit, with a conservative local
   driver planner that keeps TUI bootstrap primary, composes quota/idle/fallback

--- a/docs/product/codex-cli-packaged-install.md
+++ b/docs/product/codex-cli-packaged-install.md
@@ -1,0 +1,97 @@
+# Codex CLI Packaged Install Path
+
+Status: early product path.
+
+Goal Harness should be easy to adopt from the tool the user already has open.
+For Codex CLI users, the first successful path is:
+
+1. Open Codex CLI TUI in a project repo.
+2. Paste one Goal Harness start message.
+3. If `goal-harness` is missing, let the agent run the no-clone installer.
+4. Return to the same TUI with current goal, gate, todo, and next safe action.
+
+The user should not have to clone this repository before learning whether Goal
+Harness helps their project.
+
+## Current User Path
+
+For a fresh machine, the installer can be run without a manual clone:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/huangruiteng/goal-harness/main/scripts/install-from-github.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
+goal-harness doctor
+```
+
+The installer downloads a GitHub archive, creates a stable local release
+snapshot under `~/.local/share/goal-harness/releases/`, installs the
+`goal-harness` wrapper under `~/.local/bin`, and installs the reusable Codex
+skills under `~/.codex/skills`.
+
+It intentionally skips `goal-harness-canary` by default because there is no
+durable live checkout in this mode. Contributors who want a canary should clone
+the repository and run `scripts/install-local.sh`.
+
+## Codex CLI TUI Message
+
+The agent-first start message can now be stricter about install repair:
+
+```text
+Start Goal Harness for this repo. If `goal-harness` is missing, install it with
+the official no-clone GitHub installer, then connect this project. Show me the
+current goal, concrete user gate if any, top todos, and next safe action before
+running longer work. Keep me in this Codex CLI TUI unless I explicitly accept a
+headless fallback.
+```
+
+This keeps the product hierarchy clear:
+
+- first run: one visible TUI message;
+- install repair: no manual clone required;
+- recurring automation: separate driver work;
+- contributor development: clone plus canary remains available.
+
+## Update Path
+
+For users installed through the archive script, update is the same command:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/huangruiteng/goal-harness/main/scripts/install-from-github.sh | bash
+goal-harness doctor
+```
+
+Each run creates a new timestamped release snapshot and repoints
+`~/.local/bin/goal-harness` to it. This is intentionally conservative: existing
+runtime state stays under `~/.codex/goal-harness`, while the executable and
+skills are refreshed together.
+
+## Contributor Path
+
+For contributors and side agents working on Goal Harness itself, keep using a
+real checkout:
+
+```bash
+git clone https://github.com/huangruiteng/goal-harness ~/goal-harness
+~/goal-harness/scripts/install-local.sh
+goal-harness doctor
+goal-harness-canary doctor
+```
+
+That path installs both the stable release wrapper and a live canary wrapper,
+which is useful for validating local changes before promotion.
+
+## Future Packaging
+
+The no-clone archive installer is the first bridge. A mature release channel
+should later add:
+
+- a signed or checksum-pinned release archive;
+- `pipx install goal-harness` or `uv tool install goal-harness` after package
+  publishing is ready;
+- a Homebrew formula for macOS users;
+- a small update command that reports current release id, latest available
+  release, and installed skill freshness.
+
+Do not make these future channels block the current Codex CLI TUI path. The
+first product win is that a user can paste one message and get a working local
+control plane without leaving the repo.

--- a/docs/product/codex-cli-tui-loop.md
+++ b/docs/product/codex-cli-tui-loop.md
@@ -8,8 +8,9 @@ daemon instead of Codex." The target is:
 
 1. A user opens Codex CLI TUI inside a project repo.
 2. The user sends one short message.
-3. Codex discovers or installs Goal Harness, connects the repo, reads quota and
-   todo state, and enters the Goal Harness loop.
+3. Codex discovers or installs Goal Harness without requiring a manual repo
+   clone, connects the repo, reads quota and todo state, and enters the Goal
+   Harness loop.
 4. Later automation can steer the same visible session when safe, while the
    user can still watch, interrupt, review, or take over.
 
@@ -18,15 +19,18 @@ daemon instead of Codex." The target is:
 The best first-run experience is one TUI message:
 
 ```text
-Start Goal Harness for this repo. Install or repair it if needed, connect this
-project, show me the first user gate if one exists, then run the first safe
-agent todo only after quota says it should run.
+Start Goal Harness for this repo. If `goal-harness` is missing, install it with
+the official no-clone GitHub installer, then connect this project. Show me the
+current goal, concrete user gate if any, top todos, and next safe action before
+running longer work. Keep me in this Codex CLI TUI unless I explicitly accept a
+headless fallback.
 ```
 
 That message should be enough for a terminal agent to:
 
 - run `goal-harness doctor`;
-- install or repair the local CLI if it is missing;
+- install or repair the local CLI if it is missing, using the no-clone archive
+  installer before asking the user to clone the Goal Harness repo;
 - connect or bootstrap the repo;
 - read onboarding candidates and ask the user what to accept when required;
 - run `quota should-run`;
@@ -80,9 +84,10 @@ about internals:
 - top agent todo;
 - next safe action.
 
-Registry paths, runtime roots, JSON payloads, local-driver plans, and
-visible-session proof fixtures are follow-up diagnostics. They should not be
-required before a first-time user sees the current goal/gate/todo state.
+Registry paths, runtime roots, JSON payloads, local-driver plans,
+clone/canary setup, and visible-session proof fixtures are follow-up
+diagnostics. They should not be required before a first-time user sees the
+current goal/gate/todo state.
 
 ### 2. Session-Attached Automation
 
@@ -232,29 +237,32 @@ projects runnable candidates; it should not over-specify the model's local plan.
 
 1. **Bootstrap prompt**: ship a concise Codex CLI TUI paste message in README
    and getting-started docs.
-2. **Bootstrap command**: add a Goal Harness command that prints a tailored
+2. **No-clone install repair**: make the first-run agent path able to install
+   the CLI and reusable skills from a GitHub archive, while reserving
+   clone-plus-canary setup for contributors.
+3. **Bootstrap command**: add a Goal Harness command that prints a tailored
    Codex CLI bootstrap message for the current repo.
-3. **Session probe**: document whether current Codex CLI exposes a stable
+4. **Session probe**: document whether current Codex CLI exposes a stable
    session id, resume handle, or safe injection primitive. The current
    implementation is `goal-harness codex-cli-session-probe`; it separates
    `exec` fallback support, visible resume / remote-control spike surfaces, and
    true same-open-TUI visible injection.
-4. **Visible driver plan**: generate a dry-run plan with
+5. **Visible driver plan**: generate a dry-run plan with
    `goal-harness codex-cli-visible-driver-plan` so the next local driver knows
    whether to attempt visible attach, run a resume/remote-control proof, or
    fall back explicitly.
-5. **Local driver planner**: ship
+6. **Local driver planner**: ship
    `goal-harness codex-cli-local-driver-plan` as the dry-run command that
    composes quota, visible-driver, TUI bootstrap, explicit fallback, and
    idle-guard requirements.
-6. **Visible-session proof harness**: validate public-safe observations with
+7. **Visible-session proof harness**: validate public-safe observations with
    `goal-harness codex-cli-visible-session-proof` before promoting
    resume/remote-control into any same-session automation path.
-7. **Local driver executor**: prototype a scheduler that runs quota, checks
+8. **Local driver executor**: prototype a scheduler that runs quota, checks
    session idle state, and either attaches visibly or falls back explicitly.
-8. **Validation harness**: add a public-safe fixture that proves the driver
+9. **Validation harness**: add a public-safe fixture that proves the driver
    never stores raw transcript text and never spends quota before writeback.
-9. **Claude Code follow-up**: port the same product contract only after the
+10. **Claude Code follow-up**: port the same product contract only after the
    Codex CLI path is credible.
 
 ## Success Criteria

--- a/examples/codex-cli-packaged-install-smoke.py
+++ b/examples/codex-cli-packaged-install-smoke.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+import subprocess
+import tarfile
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def add_tree(tar: tarfile.TarFile, root: Path, name: str) -> None:
+    path = root / name
+    if path.is_dir():
+        for child in sorted(path.rglob("*")):
+            if ".git" in child.parts or "__pycache__" in child.parts:
+                continue
+            tar.add(child, arcname=str(Path("goal-harness-main") / child.relative_to(root)))
+    else:
+        tar.add(path, arcname=str(Path("goal-harness-main") / name))
+
+
+def main() -> None:
+    script = REPO_ROOT / "scripts" / "install-from-github.sh"
+    subprocess.run(["bash", "-n", str(script)], check=True)
+
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        archive = tmp / "goal-harness.tar.gz"
+        home = tmp / "home"
+        home.mkdir()
+
+        with tarfile.open(archive, "w:gz") as tar:
+            for name in (
+                "goal_harness",
+                "scripts",
+                "skills",
+                "docs",
+                "examples",
+                "README.md",
+                "pyproject.toml",
+                "LICENSE",
+            ):
+                add_tree(tar, REPO_ROOT, name)
+
+        env = os.environ.copy()
+        env.update(
+            {
+                "HOME": str(home),
+                "CODEX_HOME": str(home / ".codex"),
+                "GOAL_HARNESS_BIN_DIR": str(home / ".local" / "bin"),
+                "GOAL_HARNESS_RELEASES_DIR": str(home / ".local" / "share" / "goal-harness" / "releases"),
+                "GOAL_HARNESS_SHELL_PROFILE": str(home / ".profile"),
+                "GOAL_HARNESS_ARCHIVE_URL": f"file://{archive}",
+                "GOAL_HARNESS_INSTALL_CANARY": "0",
+            }
+        )
+        subprocess.run(["bash", str(script)], check=True, env=env, cwd=tmp)
+
+        installed = home / ".local" / "bin" / "goal-harness"
+        assert installed.exists(), installed
+        doctor = subprocess.run(
+            [str(installed), "doctor"],
+            check=True,
+            env={**env, "PATH": f"{home / '.local' / 'bin'}:{env.get('PATH', '')}"},
+            text=True,
+            capture_output=True,
+        )
+        assert "ok: `True`" in doctor.stdout, doctor.stdout
+
+        for skill in (
+            "goal-harness-project",
+            "goal-harness-doc-registry",
+            "goal-harness-self-repair",
+        ):
+            assert (home / ".codex" / "skills" / skill / "SKILL.md").exists(), skill
+
+        assert not (home / ".local" / "bin" / "goal-harness-canary").exists()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/install-from-github.sh
+++ b/scripts/install-from-github.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="${GOAL_HARNESS_REPO:-huangruiteng/goal-harness}"
+ref="${GOAL_HARNESS_REF:-main}"
+archive_url="${GOAL_HARNESS_ARCHIVE_URL:-https://codeload.github.com/$repo/tar.gz/$ref}"
+
+need() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "goal-harness installer error: missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+need curl
+need tar
+need python3
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/goal-harness-install.XXXXXX")"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+archive_path="$tmp_dir/goal-harness.tar.gz"
+extract_dir="$tmp_dir/extract"
+mkdir -p "$extract_dir"
+
+echo "goal-harness installer: downloading $archive_url" >&2
+curl -fsSL "$archive_url" -o "$archive_path"
+tar -xzf "$archive_path" -C "$extract_dir"
+
+repo_root="$(find "$extract_dir" -mindepth 1 -maxdepth 1 -type d -print -quit)"
+if [[ -z "$repo_root" || ! -x "$repo_root/scripts/install-local.sh" ]]; then
+  echo "goal-harness installer error: downloaded archive does not contain scripts/install-local.sh" >&2
+  exit 1
+fi
+
+# The downloaded checkout is temporary. Install a stable release snapshot and
+# skip the live canary symlink unless the caller explicitly overrides it.
+export GOAL_HARNESS_INSTALL_CANARY="${GOAL_HARNESS_INSTALL_CANARY:-0}"
+
+"$repo_root/scripts/install-local.sh"


### PR DESCRIPTION
## Summary
- add scripts/install-from-github.sh so Codex CLI users can install Goal Harness from a GitHub archive without manually cloning the repo
- document the no-clone install/update/start path in README, Getting Started, and Codex CLI product notes
- add a smoke that builds a local archive, installs into a temporary HOME, verifies goal-harness doctor, verifies installed skills, and confirms no canary symlink is created for temporary archive installs

## Validation
- python3 -m py_compile examples/codex-cli-packaged-install-smoke.py
- python3 examples/codex-cli-packaged-install-smoke.py
- bash -n scripts/install-from-github.sh
- python3 examples/codex-cli-bootstrap-message-smoke.py
- goal-harness check --scan-path README.md --scan-path docs/guides/getting-started.md --scan-path docs/product/README.md --scan-path docs/product/codex-cli-tui-loop.md --scan-path docs/product/codex-cli-packaged-install.md --scan-path scripts/install-from-github.sh --scan-path examples/codex-cli-packaged-install-smoke.py
- git diff --cached --check

## Boundary
Public docs/script/smoke only. No private registry state, raw logs, credentials, internal links, or local project data.