### PR TITLE
Expose SkillsBench native Goal trace status

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -2963,6 +2963,43 @@ def test_skillsbench_round_trace_records_best_round_score() -> None:
         assert native_counters["native_goal_worker_turn_start_count"] == 1, native_compact
         assert native_counters["native_goal_worker_turn_completed_observed_count"] == 1, native_compact
         assert native_counters["native_goal_worker_raw_material_recorded"] is False, native_compact
+        native_validation = native_compact["validation"]
+        assert native_validation["native_goal_worker_trace_observed"] is True, native_compact
+        assert native_validation["native_goal_worker_trace_count"] == 1, native_compact
+        assert native_validation["native_goal_worker_trace_status"] == "public_trace_observed", native_compact
+
+        connected_no_trace = {
+            "schema_version": "skillsbench_goal_harness_controller_trace_v0",
+            "route": "codex-app-server-goal-baseline",
+            "trace_publicness": "public_counts_only_no_task_text_no_verifier_output",
+            "native_goal_worker_route": True,
+            "native_goal_worker_connected": True,
+            "native_goal_worker_connect_count": 1,
+            "raw_task_text_recorded": False,
+            "raw_verifier_output_recorded": False,
+            "raw_agent_trajectory_recorded": False,
+        }
+        connected_no_trace_compact = compact_benchmark_run(
+            build_skillsbench_benchflow_result_benchmark_run(
+                write_official_skillsbench_result(
+                    root / "native-connected-no-trace",
+                    reward=0.0,
+                    task_id="tictoc-unnecessary-abort-detection",
+                ),
+                route="codex-app-server-goal-baseline",
+                controller_trace=connected_no_trace,
+            )
+        )
+        assert connected_no_trace_compact is not None
+        no_trace_validation = connected_no_trace_compact["validation"]
+        assert no_trace_validation["failed_checks"] == [], connected_no_trace_compact
+        assert no_trace_validation["native_goal_worker_connected"] is True, connected_no_trace_compact
+        assert no_trace_validation["native_goal_worker_trace_observed"] is False, connected_no_trace_compact
+        assert no_trace_validation["native_goal_worker_trace_count"] == 0, connected_no_trace_compact
+        assert (
+            no_trace_validation["native_goal_worker_trace_status"]
+            == "worker_connected_trace_dir_missing"
+        ), connected_no_trace_compact
 
         baseline = compact_benchmark_run(
             build_skillsbench_benchflow_result_benchmark_run(

--- a/goal_harness/benchmark_adapters/skillsbench.py
+++ b/goal_harness/benchmark_adapters/skillsbench.py
@@ -1913,6 +1913,26 @@ def _skillsbench_controller_trace_counters(
     return counters
 
 
+def _skillsbench_native_goal_worker_trace_status(
+    counters: dict[str, Any],
+) -> str:
+    if counters.get("native_goal_worker_route") is not True:
+        return "not_native_goal_worker_route"
+    trace_count = counters.get("native_goal_worker_trace_count")
+    if (
+        isinstance(trace_count, int)
+        and not isinstance(trace_count, bool)
+        and trace_count > 0
+        and counters.get("native_goal_worker_public_trace_read") is True
+    ):
+        return "public_trace_observed"
+    if counters.get("native_goal_worker_connected") is True:
+        if counters.get("native_goal_worker_trace_dir_present") is not True:
+            return "worker_connected_trace_dir_missing"
+        return "worker_connected_no_public_trace"
+    return "worker_route_selected_not_connected"
+
+
 def _round_reward_trace_stats(records: list[dict[str, Any]]) -> dict[str, Any]:
     numeric_records: list[dict[str, Any]] = []
     for item in records:
@@ -2346,6 +2366,18 @@ def build_skillsbench_benchflow_result_benchmark_run(
             "official_benchflow_result_json_plus_goal_harness_controller_trace"
         )
 
+    native_goal_worker_trace_count = controller_counters.get(
+        "native_goal_worker_trace_count", 0
+    )
+    if not isinstance(native_goal_worker_trace_count, int) or isinstance(
+        native_goal_worker_trace_count, bool
+    ):
+        native_goal_worker_trace_count = 0
+    native_goal_worker_trace_observed = native_goal_worker_trace_count > 0
+    native_goal_worker_trace_status = _skillsbench_native_goal_worker_trace_status(
+        controller_counters
+    )
+
     benchmark_run: dict[str, Any] = {
         "schema_version": "benchmark_run_v0",
         "source_runner": "official_skillsbench_benchflow_result",
@@ -2613,6 +2645,21 @@ def build_skillsbench_benchflow_result_benchmark_run(
             "official_verifier_status": official_score_status,
             "goal_harness_controller_trace_present": controller_trace_present,
             "goal_harness_controller_trace_public_safe": not controller_raw_material_recorded,
+            "native_goal_worker_route": controller_counters.get(
+                "native_goal_worker_route", False
+            ),
+            "native_goal_worker_connected": controller_counters.get(
+                "native_goal_worker_connected", False
+            ),
+            "native_goal_worker_trace_dir_present": controller_counters.get(
+                "native_goal_worker_trace_dir_present", False
+            ),
+            "native_goal_worker_public_trace_read": controller_counters.get(
+                "native_goal_worker_public_trace_read", False
+            ),
+            "native_goal_worker_trace_observed": native_goal_worker_trace_observed,
+            "native_goal_worker_trace_count": native_goal_worker_trace_count,
+            "native_goal_worker_trace_status": native_goal_worker_trace_status,
         },
         "authorization": {
             "real_case_execution_authorized": True,

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -118,6 +118,11 @@ BENCHMARK_VALIDATION_NEUTRAL_FALSE_FIELDS = {
     "case_solution_not_required_for_probe",
     "official_case_success",
     "official_verifier_validation_present",
+    "native_goal_worker_route",
+    "native_goal_worker_connected",
+    "native_goal_worker_trace_dir_present",
+    "native_goal_worker_public_trace_read",
+    "native_goal_worker_trace_observed",
     "leaderboard_claim_allowed",
     "official_score_claim_allowed",
     "probe_contract_result_present",
@@ -2243,10 +2248,15 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
             "validation_scope",
             "case_success_claim_kind",
             "official_verifier_status",
+            "native_goal_worker_trace_status",
         ):
             text = public_safe_compact_text(validation.get(field), limit=140)
             if text:
                 compact_validation[field] = text
+        for field in ("native_goal_worker_trace_count",):
+            value = validation.get(field)
+            if isinstance(value, int) and not isinstance(value, bool):
+                compact_validation[field] = value
         for field in (
             "active_user_assisted_treatment_preflight",
             "bridge_connected",
@@ -2320,6 +2330,11 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
             "worker_startup_blocker_recorded",
             "goal_harness_controller_trace_present",
             "goal_harness_controller_trace_public_safe",
+            "native_goal_worker_route",
+            "native_goal_worker_connected",
+            "native_goal_worker_trace_dir_present",
+            "native_goal_worker_public_trace_read",
+            "native_goal_worker_trace_observed",
         ):
             if isinstance(validation.get(field), bool):
                 compact_validation[field] = validation[field]


### PR DESCRIPTION
## Summary
- expose native app-server Goal worker trace phase status in SkillsBench compact validation
- keep trace-observed false states neutral so runner-error compacts do not become validation failures
- extend the SkillsBench smoke for both public trace observed and worker-connected/no-trace cases

## Validation
- python3 examples/skillsbench-benchmark-run-smoke.py
- python3 -m py_compile goal_harness/benchmark_adapters/skillsbench.py goal_harness/status.py examples/skillsbench-benchmark-run-smoke.py
- git diff --check

## Boundary
- no raw benchmark logs, task text, trajectories, credentials, or local run artifacts included