### PR TITLE
docs: record SkillsBench native Goal compact results

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/benchmark-case-analysis.json
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-case-analysis.json
@@ -607,7 +607,8 @@
         "Keep the compact controller counters in the ledger because they show the treatment actually exercised the outer loop.",
         "Do not use this single case to claim route-wide superiority; pair it with debug-trl-grpo and civ6 controls.",
         "Preserve the Docker-space preflight because runner setup was a live bottleneck immediately before this run.",
-        "Do not use this case as a positive blind-loop uplift asset: protocol v10 and the later max-5 rerun both completed both blind arms at official 0.0 with no reward feedback forwarded."
+        "Do not use this case as a positive blind-loop uplift asset: protocol v10 and the later max-5 rerun both completed both blind arms at official 0.0 with no reward feedback forwarded.",
+        "Treat the post-PR-353 native app-server Goal run as a route/runner observation: worker connection and public-safe controller trace are confirmed, but the missing public worker trace keeps it out of model-quality and uplift claims."
       ],
       "public_boundary": {
         "artifact_reference_policy": "refer to compact ledger ids, run groups, and public-safe controller counters only",
@@ -618,7 +619,8 @@
       "routing_guidance": {
         "blind_loop_repeat_policy": "treat protocol v10 and the max-5 rerun as no-uplift guards; repeat only after a concrete blind prompt/round-policy hypothesis",
         "next_action": "continue alternating Terminal-Bench and SkillsBench, using this as a reward-feedback positive control while mining or validating primary blind-loop positives elsewhere",
-        "repeat_policy": "repeat_only_after_stability_or_policy_hypothesis"
+        "repeat_policy": "repeat_only_after_stability_or_policy_hypothesis",
+        "native_goal_route_next_action": "repair or expose public worker trace collection, then rerun the native Goal baseline before using this route for quality comparisons"
       },
       "scores": {
         "baseline_official_score": 0,
@@ -673,7 +675,122 @@
         },
         "claim_boundary": "Legacy reward-feedback result is an ablation/positive-control asset only; primary no-reward recheck is 0.0->0.0."
       },
-      "current_protocol_claim_status": "legacy_reward_feedback_positive_primary_no_reward_no_uplift"
+      "current_protocol_claim_status": "legacy_reward_feedback_positive_primary_no_reward_no_uplift",
+      "native_goal_route_observations": {
+        "schema_version": "skillsbench_native_goal_route_observation_v0",
+        "run_group_id": "skillsbench-native-goal-post353-20260620T220003Z",
+        "arm_id": "skillsbench_codex_app_server_goal_baseline",
+        "mode": "skillsbench_codex_app_server_goal_baseline",
+        "native_goal_mode_invoked": true,
+        "goal_harness_controller_trace_present": true,
+        "goal_harness_controller_trace_public_safe": true,
+        "native_goal_worker_connected": true,
+        "native_goal_worker_trace_dir_present": false,
+        "native_goal_worker_public_trace_read": false,
+        "native_goal_worker_trace_count": 0,
+        "failure_class": "skillsbench_runner_error",
+        "failure_scope": "runner_or_setup",
+        "phase": "connected_no_trace_runner_error",
+        "claim_scope": "route_and_runner_observation_not_model_quality_evidence",
+        "boundary": {
+          "raw_logs_read": false,
+          "raw_task_text_read": false,
+          "trajectory_read": false,
+          "leaderboard_submission": false,
+          "compact_only": true
+        },
+        "run_id": "b7fdd71e481b",
+        "official_score": 0,
+        "official_passed": false,
+        "interpretation": "Native app-server Goal reached the host worker connection and produced a public-safe controller trace, but no public worker trace directory was observed. Treat this as a runner/observation repair blocker before drawing model-quality or treatment-uplift conclusions."
+      }
+    },
+    {
+      "analysis_id": "skillsbench-1.1__tictoc-unnecessary-abort-detection__native-goal-connected-no-trace-runner-error",
+      "arms": {
+        "baseline": {
+          "arm_id": "skillsbench_codex_app_server_goal_baseline",
+          "failure_class": "skillsbench_runner_error",
+          "failure_scope": "runner_or_setup",
+          "run_group_id": "skillsbench-native-goal-post353-20260620T220003Z",
+          "run_id": "a054a9322569"
+        },
+        "treatment": null
+      },
+      "benchmark_id": "skillsbench@1.1",
+      "case_id": "tictoc-unnecessary-abort-detection",
+      "classification": "native_goal_connected_no_trace_runner_error_asset",
+      "decision": "baseline_runner_or_setup_repair_required",
+      "evidence_status": "compact_native_goal_baseline_runner_error",
+      "capability_signal": "No model-quality signal yet: the native app-server Goal route connected, but the run is classified as runner_or_setup because public worker trace collection did not materialize.",
+      "control_plane_signal": "The useful signal is route observability. Compact evidence confirms native_goal_mode_invoked=true, host app-server worker connection, public-safe Goal Harness controller trace, and no raw task/log/trajectory read. The missing public worker trace keeps this as a runner/observation repair item.",
+      "native_goal_route_observations": {
+        "schema_version": "skillsbench_native_goal_route_observation_v0",
+        "run_group_id": "skillsbench-native-goal-post353-20260620T220003Z",
+        "arm_id": "skillsbench_codex_app_server_goal_baseline",
+        "mode": "skillsbench_codex_app_server_goal_baseline",
+        "native_goal_mode_invoked": true,
+        "goal_harness_controller_trace_present": true,
+        "goal_harness_controller_trace_public_safe": true,
+        "native_goal_worker_connected": true,
+        "native_goal_worker_trace_dir_present": false,
+        "native_goal_worker_public_trace_read": false,
+        "native_goal_worker_trace_count": 0,
+        "failure_class": "skillsbench_runner_error",
+        "failure_scope": "runner_or_setup",
+        "phase": "connected_no_trace_runner_error",
+        "claim_scope": "route_and_runner_observation_not_model_quality_evidence",
+        "boundary": {
+          "raw_logs_read": false,
+          "raw_task_text_read": false,
+          "trajectory_read": false,
+          "leaderboard_submission": false,
+          "compact_only": true
+        },
+        "run_id": "a054a9322569",
+        "official_score": 0,
+        "official_passed": false,
+        "interpretation": "Native app-server Goal reached the host worker connection and produced a public-safe controller trace, but no public worker trace directory was observed. Treat this as a runner/observation repair blocker before drawing model-quality or treatment-uplift conclusions."
+      },
+      "optimization_guidance": [
+        "Do not count this as uplift, no-uplift, regression, or model-quality evidence yet.",
+        "Use it to validate the native app-server Goal execution surface and to drive public worker trace collection repair.",
+        "After trace collection is repaired, rerun the same case or another selected SkillsBench case before comparing base/test behavior."
+      ],
+      "public_boundary": {
+        "artifact_reference_policy": "refer to compact ledger ids, run groups, and public-safe controller/worker counters only",
+        "raw_logs_copied": false,
+        "task_text_copied": false,
+        "trajectory_copied": false
+      },
+      "routing_guidance": {
+        "next_action": "repair native app-server Goal worker trace collection or classify why the worker produces no public trace directory, then rerun before using the route for quality comparisons",
+        "repeat_policy": "repeat_only_after_trace_collection_or_runner_error_attribution_changes"
+      },
+      "scores": {
+        "baseline_official_score": 0,
+        "treatment_official_score": null,
+        "official_score_delta": null,
+        "claimable_uplift": false
+      },
+      "stability_assessment": {
+        "main_confounds": [
+          "missing public worker trace means the run cannot yet distinguish solver behavior from runner/observation failure"
+        ],
+        "reason": "The compact result reached official BenchFlow result JSON and public-safe controller trace, but failure attribution remains skillsbench_runner_error with native worker connected and worker trace count 0.",
+        "stabilization_needed": [
+          "public worker trace directory materialization or explicit compact explanation for why it is absent",
+          "one rerun after trace/runner attribution repair"
+        ]
+      },
+      "trajectory_analysis": {
+        "baseline_observed_behavior": [
+          "Native app-server Goal mode was invoked and the host worker connection was observed through compact counters.",
+          "No public worker trace directory was observed, so behavior beyond connection is intentionally not inferred."
+        ],
+        "mechanism_hypothesis": "The bottleneck is native Goal runner/observation plumbing, not benchmark task solving.",
+        "treatment_observed_behavior": []
+      }
     },
     {
       "analysis_id": "skillsbench-1.1__dapt-intrusion-detection__reward-feedback-positive-current-protocol-no-uplift",
@@ -3213,7 +3330,7 @@
     "trajectory_recorded": false,
     "update_rule": "add one case analysis record after compact result ingest and benchmark-run-ledger update"
   },
-  "updated_at": "2026-06-18T12:27:07+08:00",
+  "updated_at": "2026-06-21T07:18:00+08:00",
   "terminal_bench_current_protocol_coverage": {
     "schema_version": "terminal_bench_current_protocol_coverage_v0",
     "source_ledger": "benchmark-run-ledger.json",

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-case-analysis.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-case-analysis.md
@@ -7,7 +7,7 @@ It is intentionally separate from `benchmark-run-ledger.md`. The run ledger
 records compact attempts and scores; this file records why a result matters.
 
 - schema_version: `benchmark_case_analysis_v0`
-- updated_at: `2026-06-18T12:49:19+08:00`
+- updated_at: `2026-06-21T07:18:00+08:00`
 - machine_source: `benchmark-case-analysis.json`
 - ledger-only migration audit:
   `benchmark-case-analysis-ledger-only-migration-audit-20260618.md`
@@ -37,6 +37,7 @@ evidence becomes useful.
 | `terminal-bench@2.0` | `pytorch-model-recovery` | exception attribution asset | `0.0` | `0.0` | `0.0` | `paired_no_score_uplift_exception_research_required` |
 | `terminal-bench@2.0` | `train-fasttext` | single-arm managed-Codex failure asset | n/a | `0.0` | n/a | `single_arm_recorded` |
 | `skillsbench@1.1` | `llm-prefix-cache-replay` | reward-feedback positive / blind-loop neutral asset | `0.0` | `0.0` | `0.0` | `reward_feedback_positive_primary_blind_loop_no_uplift` |
+| `skillsbench@1.1` | `tictoc-unnecessary-abort-detection` | native Goal connected-no-trace runner-error asset | `0.0` | n/a | n/a | `baseline_runner_or_setup_repair_required` |
 | `skillsbench@1.1` | `dapt-intrusion-detection` | reward-feedback positive / blind-loop neutral asset | `0.0` | `0.0` | `0.0` | `reward_feedback_positive_primary_blind_loop_no_uplift` |
 | `skillsbench@1.1` | `paratransit-routing` | product-mode no-uplift / blind-loop positive asset | `0.0` | `0.0` | `0.0` | `paired_no_score_uplift` |
 | `skillsbench@1.1` | `debug-trl-grpo` | regression asset | `0.25` | `0.0` | `-0.25` | `paired_treatment_regressed` |
@@ -133,6 +134,12 @@ Interaction-count assessment:
   `/goal`, but `native_goal_mode_invoked` must stay false unless the run has
   interactive Codex CLI slash-command or goal-state evidence. ACP prompt text
   alone is not sufficient confirmation.
+- The post-PR-353 native app-server Goal canary pair now confirms a narrower
+  route fact: `native_goal_mode_invoked=true`, a host app-server worker
+  connection, and a public-safe controller trace can be observed through compact
+  counters. Both observed cases still classify as `skillsbench_runner_error`
+  with no public worker trace directory, so they are runner/observation repair
+  assets rather than model-quality or uplift evidence.
 - The treatment route is `goal_harness_automation_loop_treatment`, still with
   `goal_harness_inside_case=false`; Goal Harness is the outer automation loop,
   not an in-case solver skill. Current positive, neutral, and regression
@@ -759,6 +766,13 @@ Compact evidence:
   rounds `1:0,2:0,3:0,4:0,5:0`, `first_success_round=null`
 - max-5 blind-loop treatment: `goal-harness-blind-loop-treatment`, score `0.0`,
   rounds `1:0,2:0,3:0,4:0,5:0`, `first_success_round=null`
+- native app-server Goal canary run group:
+  `skillsbench-native-goal-post353-20260620T220003Z`
+- native Goal baseline run id: `b7fdd71e481b`
+- native Goal baseline score: `0.0`
+- native Goal baseline failure: `skillsbench_runner_error`
+- native Goal route counters: `native_goal_mode_invoked=true`,
+  worker connected, public worker trace count `0`
 
 Interpretation:
 
@@ -771,6 +785,13 @@ After that follow-up, the official verifier scored the case `1.0`.
 The same case does not improve when reward/pass/fail/verifier feedback is
 blinded: both the two-round blind recheck and the stricter max-5 rerun finished
 at `0.0` for both arms.
+
+The post-PR-353 native app-server Goal canary is a separate route observation:
+it confirms native Goal invocation, host-worker connection, and public-safe
+controller trace, but it still fails as `skillsbench_runner_error` and exposes
+no public worker trace directory. It should not be folded into the reward
+feedback or blind-loop claim table until worker trace collection or runner
+attribution is repaired.
 
 Why it matters:
 
@@ -785,6 +806,9 @@ Why it matters:
 - It shows that compact controller counters are enough to confirm the treatment
   surface actually ran, even without copying raw task text, logs, or
   trajectory.
+- It also gives the native Goal route a concrete repair target: public worker
+  trace collection must materialize before this route can support model-quality
+  comparisons.
 
 Follow-up guidance:
 
@@ -796,6 +820,49 @@ Follow-up guidance:
   protocol v10 and the max-5 rerun are no-uplift guards.
 - Do not generalize from one uplift case; compare future changes against the
   regression and no-uplift assets before making route-wide claims.
+- For native app-server Goal, repair or explain the missing public worker trace
+  directory before using the route as the default SkillsBench quality baseline.
+
+## Case: SkillsBench tictoc-unnecessary-abort-detection
+
+This is a native app-server Goal route/runner observation, not a model-quality
+case result yet.
+
+Compact evidence:
+
+- benchmark: `skillsbench@1.1`
+- baseline arm: `skillsbench_codex_app_server_goal_baseline`
+- run group: `skillsbench-native-goal-post353-20260620T220003Z`
+- baseline run id: `a054a9322569`
+- baseline score: `0.0`
+- baseline failure: `skillsbench_runner_error`
+- native Goal route counters: `native_goal_mode_invoked=true`,
+  worker connected, public-safe controller trace present, public worker trace
+  count `0`
+
+Interpretation:
+
+The compact result proves the host app-server Goal route can connect to the
+worker and record public-safe controller evidence without reading raw task text,
+raw logs, verifier output, or trajectory. The useful finding is still negative:
+the public worker trace directory was not observed, so the failure remains
+`runner_or_setup` and cannot be used to judge whether the agent solved the task.
+
+Why it matters:
+
+- It gives the native Goal SkillsBench route a second concrete canary beyond
+  `llm-prefix-cache-replay`.
+- It confirms route connection and controller trace observability, while
+  keeping the public/private boundary compact-only.
+- It blocks quality comparison until the missing worker trace or runner error is
+  repaired.
+
+Follow-up guidance:
+
+- Do not launch treatment or claim uplift/no-uplift from this row.
+- Repair public worker trace collection, or record a compact explanation for
+  why no worker trace is expected, then rerun a selected SkillsBench case.
+- Keep this as a runner/observation repair asset in the rotation ledger.
 
 ## Case: SkillsBench dapt-intrusion-detection
 

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
@@ -2627,7 +2627,7 @@
           "case_id": "llm-prefix-cache-replay",
           "latest_decision": {
             "baseline_failure_scope": "runner_or_setup",
-            "baseline_run_id": "07af93abd7ae",
+            "baseline_run_id": "b7fdd71e481b",
             "decision": "paired_baseline_runner_or_setup_repair_required",
             "failure_class": "skillsbench_runner_error",
             "official_score_delta": 0.0,
@@ -3834,6 +3834,46 @@
               "round_success_observed": false,
               "run_group_id": "skillsbench-llm-prefix-native-goal-keepalive-r3-20260621T194222Z",
               "run_id": "07af93abd7ae",
+              "score_status": "failed",
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false
+            },
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "skillsbench_codex_app_server_goal_baseline",
+              "artifact_refs": {
+                "compact_artifact_ref": "cloud-ecs/parallel-benchmark-20260620T220003Z/skillsbench-llm-prefix-cache-replay-native-goal-post353-r1/jobs/gh-skillsbench-llm-prefix-cache-replay-native-goal-post353-r1/llm-prefix-cache-replay__codex_app_server_goal/benchmark_run.compact.json"
+              },
+              "benchmark_id": "skillsbench@1.1",
+              "case_id": "llm-prefix-cache-replay",
+              "case_ids": [
+                "llm-prefix-cache-replay"
+              ],
+              "codex_acp_runtime_preflight_passed": true,
+              "failure_class": "skillsbench_runner_error",
+              "failure_labels": [
+                "skillsbench_runner_error"
+              ],
+              "failure_scope": "runner_or_setup",
+              "goal_harness_inside_case": false,
+              "job_name": "skillsbench_1_1_llm_prefix_cache_replay_codex_app_server_goal_baseline",
+              "leaderboard_evidence": false,
+              "max_rounds_budget": 5,
+              "mode": "skillsbench_codex_app_server_goal_baseline",
+              "model_control_status": "reported_model_from_result_metadata",
+              "notes": "Native app-server Goal route connected; controller trace public-safe; native worker connected but no public worker trace directory was observed, so classify as connected-no-trace runner-error phase rather than model-q...",
+              "official_feedback_blinded": true,
+              "official_passed": false,
+              "official_score": 0.0,
+              "recorded_at": "2026-06-21T07:11:23+08:00",
+              "reward_feedback_forwarded": false,
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-native-goal-post353-20260620T220003Z",
+              "run_id": "b7fdd71e481b",
               "score_status": "failed",
               "source_event_schema": "benchmark_run_v0",
               "status": "completed",
@@ -6184,7 +6224,7 @@
           "case_id": "tictoc-unnecessary-abort-detection",
           "latest_decision": {
             "baseline_failure_scope": "runner_or_setup",
-            "baseline_run_id": "97f003b9f1c1",
+            "baseline_run_id": "a054a9322569",
             "decision": "paired_baseline_runner_or_setup_repair_required",
             "failure_class": "skillsbench_runner_error",
             "official_score_delta": 0.0,
@@ -6507,6 +6547,46 @@
                 "staged": true,
                 "task_skills_removed": true
               }
+            },
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "skillsbench_codex_app_server_goal_baseline",
+              "artifact_refs": {
+                "compact_artifact_ref": "cloud-ecs/parallel-benchmark-20260620T220003Z/skillsbench-tictoc-unnecessary-abort-detection-native-goal-post353-r1/jobs/gh-skillsbench-tictoc-unnecessary-abort-detection-native-goal-post353-r1/tictoc-unnecessary-abort-detection__codex_app_server_goal/benchmark_run.compact.json"
+              },
+              "benchmark_id": "skillsbench@1.1",
+              "case_id": "tictoc-unnecessary-abort-detection",
+              "case_ids": [
+                "tictoc-unnecessary-abort-detection"
+              ],
+              "codex_acp_runtime_preflight_passed": true,
+              "failure_class": "skillsbench_runner_error",
+              "failure_labels": [
+                "skillsbench_runner_error"
+              ],
+              "failure_scope": "runner_or_setup",
+              "goal_harness_inside_case": false,
+              "job_name": "skillsbench_1_1_tictoc_unnecessary_abort_detection_codex_app_server_goal_baseline",
+              "leaderboard_evidence": false,
+              "max_rounds_budget": 5,
+              "mode": "skillsbench_codex_app_server_goal_baseline",
+              "model_control_status": "reported_model_from_result_metadata",
+              "notes": "Native app-server Goal route connected; controller trace public-safe; native worker connected but no public worker trace directory was observed, so classify as connected-no-trace runner-error phase rather than model-q...",
+              "official_feedback_blinded": true,
+              "official_passed": false,
+              "official_score": 0.0,
+              "recorded_at": "2026-06-21T07:11:23+08:00",
+              "reward_feedback_forwarded": false,
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-native-goal-post353-20260620T220003Z",
+              "run_id": "a054a9322569",
+              "score_status": "failed",
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false
             }
           ]
         },
@@ -6650,7 +6730,7 @@
           ]
         }
       },
-      "run_count": 118
+      "run_count": 120
     },
     "swe-marathon": {
       "benchmark_id": "swe-marathon",
@@ -10388,5 +10468,5 @@
     "source_of_truth": "benchmark_run_v0 compact run events",
     "update_rule": "upsert one run entry when a benchmark case is ingested or closed"
   },
-  "updated_at": "2026-06-21T05:48:23+08:00"
+  "updated_at": "2026-06-21T07:11:23+08:00"
 }

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
@@ -5,7 +5,7 @@ benchmark case outcomes and artifact references; it must not contain raw
 logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 
 - schema_version: `benchmark_run_ledger_v0`
-- updated_at: `2026-06-21T05:48:23+08:00`
+- updated_at: `2026-06-21T07:11:23+08:00`
 
 ## Case Decisions
 
@@ -22,7 +22,7 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `skillsbench@1.1` | `dapt-intrusion-detection` | `paired_baseline_setup_preflight_selection_required` | - | `5` |
 | `skillsbench@1.1` | `debug-trl-grpo` | `paired_baseline_runner_or_setup_repair_required` | - | `9` |
 | `skillsbench@1.1` | `fix-build-agentops` | `baseline_runner_or_setup_repair_required` | - | `2` |
-| `skillsbench@1.1` | `llm-prefix-cache-replay` | `paired_baseline_runner_or_setup_repair_required` | - | `23` |
+| `skillsbench@1.1` | `llm-prefix-cache-replay` | `paired_baseline_runner_or_setup_repair_required` | - | `24` |
 | `skillsbench@1.1` | `manufacturing-codebook-normalization` | `paired_no_score_uplift` | - | `4` |
 | `skillsbench@1.1` | `organize-messy-files` | `paired_baseline_solved_treatment_preserved` | - | `3` |
 | `skillsbench@1.1` | `paratransit-routing` | `paired_treatment_improved` | - | `9` |
@@ -31,7 +31,7 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `skillsbench@1.1` | `setup-fuzzing-py` | `baseline_runner_or_setup_repair_required` | - | `3` |
 | `skillsbench@1.1` | `software-dependency-audit` | `paired_no_score_uplift` | - | `6` |
 | `skillsbench@1.1` | `suricata-custom-exfil` | `paired_treatment_codex_acp_runtime_preflight_required` | - | `5` |
-| `skillsbench@1.1` | `tictoc-unnecessary-abort-detection` | `paired_baseline_runner_or_setup_repair_required` | - | `5` |
+| `skillsbench@1.1` | `tictoc-unnecessary-abort-detection` | `paired_baseline_runner_or_setup_repair_required` | - | `6` |
 | `skillsbench@1.1` | `travel-planning` | `baseline_failed_treatment_candidate` | - | `2` |
 | `swe-marathon` | `find-network-alignments` | `baseline_failed_treatment_candidate` | - | `1` |
 | `terminal-bench-worker-materialization@v0` | `nginx-request-logging` | `single_arm_recorded` | - | `2` |
@@ -145,6 +145,7 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `skillsbench@1.1` | `llm-prefix-cache-replay` | `skillsbench_codex_acp_blind_loop_baseline` | `` | `0.0` | `` | `1:0,2:0,3:0,4:0,5:missing` | `official_score_zero_case_failure` | `cloud-ecs/parallel-benchmark-20260620T131254Z/skillsbench-llm-prefix-baseline-r1/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `llm-prefix-cache-replay` | `skillsbench_goal_harness_blind_loop_treatment` | `` | `0.0` | `` | `1:0,2:0,3:0,4:0,5:missing` | `official_score_zero_case_failure` | `cloud-ecs/parallel-benchmark-20260620T131254Z/skillsbench-llm-prefix-treatment-r1/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `llm-prefix-cache-replay` | `skillsbench_codex_app_server_goal_baseline` | `` | `0.0` | `` | `` | `skillsbench_runner_error` | `cloud-ecs/parallel-benchmark-20260621T194222Z/skillsbench-llm-prefix-native-goal-keepalive-r3/benchmark_run.compact.json` |
+| `skillsbench@1.1` | `llm-prefix-cache-replay` | `skillsbench_codex_app_server_goal_baseline` | `` | `0.0` | `` | `` | `skillsbench_runner_error` | `cloud-ecs/parallel-benchmark-20260620T220003Z/skillsbench-llm-prefix-cache-replay-native-goal-post353-r1/jobs/gh-skillsbench-llm-prefix-cache-replay-native-goal-post353-r1/llm-prefix-cache-replay__codex_app_server_goal/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `manufacturing-codebook-normalization` | `codex_goal_mode_baseline` | `` | `0.0` | `` | `` | `official_verifier_solution_failure` | `` |
 | `skillsbench@1.1` | `manufacturing-codebook-normalization` | `goal_harness_automation_loop_treatment` | `` | `0.0` | `` | `` | `official_verifier_solution_failure` | `` |
 | `skillsbench@1.1` | `manufacturing-codebook-normalization` | `baseline` | `` | `0.0` | `` | `1:0,2:0` | `official_verifier_solution_failure` | `.local/private-benchmark-jobs/skillsbench-manufacturing-codebook-normalization-blind-baseline-v0/manufacturing-codebook-normalization__codex_acp_blind_loop_v0/benchmark_run.compact.json` |
@@ -193,6 +194,7 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `skillsbench@1.1` | `tictoc-unnecessary-abort-detection` | `skillsbench_goal_harness_blind_loop_treatment` | `` | `0.0` | `` | `1:0,2:0,3:0,4:0,5:missing` | `official_score_zero_case_failure` | `cloud-ecs/parallel-benchmark-20260620T131254Z/skillsbench-tictoc-treatment-r2/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `tictoc-unnecessary-abort-detection` | `skillsbench_codex_app_server_goal_baseline` | `` | `0.0` | `` | `` | `skillsbench_runner_error` | `cloud-ecs/parallel-benchmark-20260621T194222Z/skillsbench-tictoc-native-goal-keepalive-r2/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `tictoc-unnecessary-abort-detection` | `baseline` | `` | `0.0` | `` | `` | `skillsbench_runner_error` | `cloud-ecs/parallel-benchmark-20260620T210604Z/skillsbench-tictoc-native-goal-r4/.../benchmark_run.compact.json` |
+| `skillsbench@1.1` | `tictoc-unnecessary-abort-detection` | `skillsbench_codex_app_server_goal_baseline` | `` | `0.0` | `` | `` | `skillsbench_runner_error` | `cloud-ecs/parallel-benchmark-20260620T220003Z/skillsbench-tictoc-unnecessary-abort-detection-native-goal-post353-r1/jobs/gh-skillsbench-tictoc-unnecessary-abort-detection-native-goal-post353-r1/tictoc-unnecessary-abort-detection__codex_app_server_goal/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `travel-planning` | `baseline` | `` | `1.0` | `1` | `1:1*` | `none` | `.local/private-benchmark-jobs/skillsbench-travel-planning-blind-baseline-20260616T1238CST/travel-planning__codex_acp_blind_loop/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `travel-planning` | `skillsbench_raw_codex_autonomous_max5_baseline` | `` | `0.0` | `` | `1:missing` | `official_score_zero_case_failure` | `cloud-ecs/skillsbench-real-case/gh-skillsbench-travel-planning-container-acp-configfix-20260620T063851/benchmark_run.compact.json` |
 | `swe-marathon` | `find-network-alignments` | `swe_marathon_host_codex_app_server_goal_baseline` | `` | `0.0` | `` | `` | `official_verifier_solution_failure` | `cloud-ecs/parallel-benchmark-20260620T131254Z/swe-marathon-find-network-alignments-host-app-server-goal-r6/harbor_job_result.compact.json` |


### PR DESCRIPTION
## Summary
- add the post-PR-353 SkillsBench native app-server Goal compact pair to the public benchmark run ledger
- classify both llm-prefix-cache-replay and tictoc-unnecessary-abort-detection as connected-no-trace runner/observation repair assets
- update case analysis so these results are not treated as model-quality or uplift evidence

## Validation
- python3 examples/benchmark-run-ledger-smoke.py
- python3 examples/benchmark-case-analysis-smoke.py
- git diff --check
- goal-harness check --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-case-analysis.json --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-case-analysis.md
- goal-harness --format json benchmark run-ledger-check --goal-id goal-harness-meta --run-ledger-path docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json

## Boundary
- public compact artifacts only
- no raw task text, raw logs, verifier output, trajectories, credentials, uploads, Docker invocation, or model API invocation
- diff-addition boundary scan clean

## Residual risk
- existing ledger history still contains older local-style artifact refs; this PR does not add new private/local artifact refs and does not try to rewrite historical ledger rows.