### PR TITLE
Record latest benchmark rotation observations

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/benchmark-active-case-status-20260620.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-active-case-status-20260620.md
@@ -39,10 +39,13 @@ Public boundary:
 
 ## Active Cloud Batch
 
-Batch id: `parallel-benchmark-20260620T131254Z`.
+Latest batch id: `parallel-benchmark-20260620T235333Z`.
 
 | Benchmark | Case | Route / Arm | Compact Status | Current Status | Next Action |
 | --- | --- | --- | --- | --- | --- |
+| `terminal-bench@2.0` | `multi-source-data-merger` | host Codex app-server Goal baseline observation | compact official score `0.0`; ledger upserted under `terminal-bench-multi-source-data-merger-app-server-goal-20260620T235333Z` as `codex_app_server_goal_observation`; raw transcript not recorded | completed: the cloud app-server Goal rerun reached official scoring and failed verification | Treat as a current-route baseline observation for this historical pass/control case, not a paired comparison. Do not infer runner breakage from score alone; compare against the previous current-protocol pass rows before selecting a treatment or alternate pass-control case. |
+| `skillsbench@1.1` | `react-performance-debugging` | native app-server Goal baseline, high reasoning | compact result pending | running: no public compact closeout yet in the latest snapshot | Poll to compact result or precise blocker; if it closes at zero, inspect public worker-trace materialization before treating it as solver-quality evidence. |
+| `swe-marathon` | `rust-c-compiler` | host Codex app-server Goal completion-aware | compact blocker `swe_marathon_environment_or_image_setup_failure`; no agent execution or verifier result present; compact signals include docker-build, network, and resource labels only | blocked before agent execution | Productize or rerun through a setup/prewarm gate before counting this as an agent-quality result. Keep the exact exception text private and record only compact setup signals. |
 | `terminal-bench@2.0` | `build-cython-ext` | host Codex app-server Goal, marker/official-verifier gated | latest observe-only compact official score `1.0`; ledger upserted under `terminal-bench-build-cython-ext-app-server-observe-pr346-r1-20260621T203200Z`; earlier completion-aware r2 scored `0.0`; raw transcript not recorded | completed: the observe-only native Goal closeout recovered the historical pass-case result while preserving public compact boundaries | Treat as a pass-case route canary. Do not spend another primary slot retrying the same route; next Terminal-Bench work should launch a treatment arm or move to a different historical pass/control case. |
 | `skillsbench@1.1` | `llm-prefix-cache-replay` | BenchFlow ACP blind-loop baseline | compact official score `0.0`; ledger upserted under `gh-skillsbench-llm-prefix-cloud-pair-r1-20260620` | completed | Treat as no-uplift runtime-refactor sanity, not as native Codex Goal baseline evidence. |
 | `skillsbench@1.1` | `llm-prefix-cache-replay` | Goal Harness blind-loop treatment | compact official score `0.0`; ledger upserted under `gh-skillsbench-llm-prefix-cloud-pair-r1-20260620` | completed | Pair with the baseline row as `paired_no_score_uplift`; next SkillsBench work should either implement the app-server Goal surface or pick the next ACP-compatible canary explicitly as non-native-Goal evidence. |
@@ -57,8 +60,15 @@ Failure-attribution update:
   observe-only app-server route: the latest compact closeout scored `1.0`,
   while the earlier completion-aware rerun scored `0.0`. Treat the difference
   as runner/route phase evidence, not as a task-difficulty blocker.
+- `multi-source-data-merger` rerun under the cloud app-server Goal baseline
+  reached official scoring but returned `0.0` with
+  `official_verifier_solution_failure`. This is a current-route baseline
+  failure for a historical pass/control case, not a setup blocker.
 - `find-network-alignments` is now classified as
   `official_zero_native_goal_first_closeout_needs_solution_phase_counters`.
+- `rust-c-compiler` is blocked before agent execution by compact
+  environment/image setup signals. It should drive setup-gate or image-cache
+  repair, not capability comparison.
 - both SkillsBench pairs are classified as
   `paired_zero_acp_blind_loop_non_native_goal_no_uplift`; the next primary
   SkillsBench engineering slice is no longer "build the worker" but
@@ -74,8 +84,11 @@ or blocker.
 | Priority | Benchmark | Case | Reason To Rerun | Required Before Launch |
 | --- | --- | --- | --- | --- |
 | P0 | `terminal-bench@2.0` | `build-cython-ext` | route canary with historical pass and latest observe-only native Goal result `1.0` | route canary complete; next slot should be treatment or a different historical pass/control case, not another route-readiness retry. |
+| P0 | `terminal-bench@2.0` | `multi-source-data-merger` | latest cloud app-server Goal baseline reached official scoring but failed at `0.0` | compare with previous current-protocol pass rows; next slot should be treatment or alternate pass/control rather than another identical baseline retry. |
 | P0 | `swe-marathon` | `find-network-alignments` | first active SWE-Marathon cloud case completed at official score `0.0` | completed baseline; next slot should be a second small case or matching treatment arm. |
+| P0 | `swe-marathon` | `rust-c-compiler` | official README example and CPU-oriented case, but latest run blocked before agent execution | repair/prewarm Harbor environment or image setup first; rerun only after setup gate reaches agent execution. |
 | P0 | `skillsbench@1.1` | `llm-prefix-cache-replay` | runtime-refactor pair completed at `0.0/0.0`; native Goal post-PR-353 canary connected but produced no public worker trace | no immediate same-policy rerun; repair native worker trace or choose a new canary through the repaired trace path. |
+| P0 | `skillsbench@1.1` | `react-performance-debugging` | native app-server Goal canary is currently running in the latest batch | close to compact result or precise blocker, then classify worker trace before launching more SkillsBench cases. |
 | P1 | `skillsbench@1.1` | `tictoc-unnecessary-abort-detection` | previously setup-blocked; useful verifier/runtime canary | compact closeout produced `0.0/0.0`; do not spend another primary slot here unless using it as a duplicate stability check. |
 | P1 | `terminal-bench@2.0` | `make-doom-for-mips` | timeout/continuation attribution candidate | timeout phase attribution and app-server route canary complete. |
 | P1 | `terminal-bench@2.0` | `mteb-retrieve` | environment setup blocker candidate | environment setup preflight proves the task reaches agent or writes a compact blocker. |

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
@@ -9757,6 +9757,40 @@
               "status": "completed",
               "submit_eligible": false,
               "worker_bridge_status": "not_required"
+            },
+            {
+              "agent_declared_done": false,
+              "arm_id": "codex_app_server_goal_observation",
+              "artifact_refs": {
+                "compact_artifact_ref": "cloud-ecs/parallel-benchmark-20260620T235333Z/terminal-bench-multi-source-data-merger-app-server-r1/terminal_bench_official_result.compact.json"
+              },
+              "benchmark_id": "terminal-bench@2.0",
+              "case_id": "multi-source-data-merger",
+              "case_ids": [
+                "multi-source-data-merger"
+              ],
+              "codex_acp_runtime_preflight_passed": false,
+              "failure_class": "official_verifier_solution_failure",
+              "failure_labels": [
+                "official_verifier_solution_failure"
+              ],
+              "failure_scope": "case_or_solution",
+              "goal_harness_inside_case": false,
+              "job_name": "multi-source-data-merger-host-app-server-goal-20260620t235333z",
+              "leaderboard_evidence": false,
+              "mode": "terminal_bench_host_codex_app_server_goal",
+              "notes": "Terminal-Bench multi-source-data-merger cloud app-server Goal observation; compact result only; no raw task/log/trajectory read; not paired with historical treatment rows.",
+              "official_passed": false,
+              "official_score": 0.0,
+              "recorded_at": "2026-06-21T08:02:43+08:00",
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "terminal-bench-multi-source-data-merger-app-server-goal-20260620T235333Z",
+              "run_id": "d6510aa6b125",
+              "score_status": "failed",
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false
             }
           ]
         },
@@ -10457,7 +10491,7 @@
           ]
         }
       },
-      "run_count": 85
+      "run_count": 86
     }
   },
   "schema_version": "benchmark_run_ledger_v0",
@@ -10468,5 +10502,5 @@
     "source_of_truth": "benchmark_run_v0 compact run events",
     "update_rule": "upsert one run entry when a benchmark case is ingested or closed"
   },
-  "updated_at": "2026-06-21T07:11:23+08:00"
+  "updated_at": "2026-06-21T08:03:15+08:00"
 }

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
@@ -5,7 +5,7 @@ benchmark case outcomes and artifact references; it must not contain raw
 logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 
 - schema_version: `benchmark_run_ledger_v0`
-- updated_at: `2026-06-21T07:11:23+08:00`
+- updated_at: `2026-06-21T08:03:15+08:00`
 
 ## Case Decisions
 
@@ -47,7 +47,7 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `terminal-bench@2.0` | `make-doom-for-mips` | `paired_result_requires_attribution` | `timeout_tier_policy_candidate` | `9` |
 | `terminal-bench@2.0` | `merge-diff-arc-agi-task` | `baseline_passed_not_current_treatment_priority` | - | `1` |
 | `terminal-bench@2.0` | `mteb-retrieve` | `paired_baseline_environment_setup_repair_required` | - | `4` |
-| `terminal-bench@2.0` | `multi-source-data-merger` | `paired_baseline_solved_treatment_preserved` | - | `18` |
+| `terminal-bench@2.0` | `multi-source-data-merger` | `paired_baseline_solved_treatment_preserved` | - | `19` |
 | `terminal-bench@2.0` | `nginx-request-logging` | `paired_baseline_solved_treatment_preserved` | - | `7` |
 | `terminal-bench@2.0` | `path-tracing` | `baseline_passed_not_current_treatment_priority` | - | `2` |
 | `terminal-bench@2.0` | `pytorch-model-recovery` | `paired_no_score_uplift_exception_research_required` | `case_exception_research` | `3` |
@@ -268,6 +268,7 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `terminal-bench@2.0` | `multi-source-data-merger` | `codex_goal_mode_baseline` | `` | `0.0` | `` | `` | `official_verifier_solution_failure` | `.local/private-benchmark-jobs/terminal-bench-msdm-runtime-materialization-baseline-20260615T170847CST/jobs/terminal_bench_multi_source_data_merger_codex_goal_mode_runtime_materialization_baseline_20260615T170847CST/result.json` |
 | `terminal-bench@2.0` | `multi-source-data-merger` | `codex_goal_harness_treatment` | `` | `1.0` | `` | `` | `none` | `.local/private-benchmark-jobs/terminal-bench-multi-source-data-merger-current-protocol-20260617T201625CST/jobs/terminal_bench_multi_source_data_merger_goal_harness_managed_codex_current_protocol_20260617T201625CST/result.json` |
 | `terminal-bench@2.0` | `multi-source-data-merger` | `hardened_codex_baseline` | `` | `1.0` | `` | `` | `none` | `.local/private-benchmark-jobs/terminal-bench-multi-source-data-merger-current-protocol-20260617T201625CST/jobs/terminal_bench_multi_source_data_merger_hardened_codex_current_protocol_20260617T202500CST/result.json` |
+| `terminal-bench@2.0` | `multi-source-data-merger` | `codex_app_server_goal_observation` | `` | `0.0` | `` | `` | `official_verifier_solution_failure` | `cloud-ecs/parallel-benchmark-20260620T235333Z/terminal-bench-multi-source-data-merger-app-server-r1/terminal_bench_official_result.compact.json` |
 | `terminal-bench@2.0` | `nginx-request-logging` | `codex_goal_mode_baseline` | `` | `1.0` | `` | `` | `none` | `.local/private-benchmark-jobs/terminal-bench-nginx-request-logging-paired-20260614T184054CST/baseline/terminal-bench-nginx-request-logging-paired-20260614T184054CST-baseline/result.json` |
 | `terminal-bench@2.0` | `nginx-request-logging` | `codex_goal_harness_treatment` | `` | `0.0` | `` | `` | `agent_setup_timeout_before_worker_start` | `.local/private-benchmark-jobs/terminal-bench-nginx-request-logging-paired-20260614T184054CST/treatment/terminal-bench-nginx-request-logging-paired-20260614T184054CST-treatment/result.json` |
 | `terminal-bench@2.0` | `nginx-request-logging` | `hardened_codex_baseline` | `` | `0.0` | `` | `` | `worker_install_failed_agent_codex_install_nvm_node` | `.local/private-benchmark-jobs/terminal-bench-nginx-request-logging-hardened-blind-pair-20260616T110017CST/baseline/terminal-bench-nginx-request-logging-hardened-blind-pair-20260616T110017CST-baseline/result.json` |


### PR DESCRIPTION
## Summary
- add the latest cloud rotation batch to the active benchmark case status
- ledger Terminal-Bench multi-source-data-merger as an app-server Goal observation row
- record SWE-Marathon rust-c-compiler as a compact setup blocker while SkillsBench remains running

## Validation
- python3 examples/benchmark-run-ledger-smoke.py
- goal-harness benchmark run-ledger-check --goal-id goal-harness-meta --run-ledger-path docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json --history-limit 40 --limit 5
- goal-harness check --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-active-case-status-20260620.md --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
- git diff --check

## Boundary
- compact/public docs and ledger only
- no raw task text, raw logs, trajectories, transcript, credentials, or absolute host paths added