### PR TITLE
Record Terminal-Bench nginx pass observation

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/benchmark-active-case-status-20260620.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-active-case-status-20260620.md
@@ -44,6 +44,7 @@ Latest batch id: `parallel-benchmark-20260620T235333Z`.
 | Benchmark | Case | Route / Arm | Compact Status | Current Status | Next Action |
 | --- | --- | --- | --- | --- | --- |
 | `terminal-bench@2.0` | `multi-source-data-merger` | host Codex app-server Goal baseline observation | compact official score `0.0`; ledger upserted under `terminal-bench-multi-source-data-merger-app-server-goal-20260620T235333Z` as `codex_app_server_goal_observation`; raw transcript not recorded | completed: the cloud app-server Goal rerun reached official scoring and failed verification | Treat as a current-route baseline observation for this historical pass/control case, not a paired comparison. Do not infer runner breakage from score alone; compare against the previous current-protocol pass rows before selecting a treatment or alternate pass-control case. |
+| `terminal-bench@2.0` | `nginx-request-logging` | host Codex app-server Goal alternate pass/control observation | compact official score `1.0`; ledger upserted under `terminal-bench-nginx-request-logging-app-server-goal-20260621T001123Z` as `codex_app_server_goal_observation`; raw transcript not recorded | completed: the cloud app-server Goal route reached official scoring and passed | Treat as a route sanity pass: current app-server Goal can solve at least one historical pass/control case. Next Terminal-Bench work should avoid another identical observation-only pass and instead choose treatment or a case with unresolved route/debug value. |
 | `skillsbench@1.1` | `react-performance-debugging` | native app-server Goal baseline, high reasoning | compact result pending | running: no public compact closeout yet in the latest snapshot | Poll to compact result or precise blocker; if it closes at zero, inspect public worker-trace materialization before treating it as solver-quality evidence. |
 | `swe-marathon` | `rust-c-compiler` | host Codex app-server Goal completion-aware | compact blocker `swe_marathon_environment_or_image_setup_failure`; no agent execution or verifier result present; compact signals include docker-build, network, and resource labels only | blocked before agent execution | Productize or rerun through a setup/prewarm gate before counting this as an agent-quality result. Keep the exact exception text private and record only compact setup signals. |
 | `terminal-bench@2.0` | `build-cython-ext` | host Codex app-server Goal, marker/official-verifier gated | latest observe-only compact official score `1.0`; ledger upserted under `terminal-bench-build-cython-ext-app-server-observe-pr346-r1-20260621T203200Z`; earlier completion-aware r2 scored `0.0`; raw transcript not recorded | completed: the observe-only native Goal closeout recovered the historical pass-case result while preserving public compact boundaries | Treat as a pass-case route canary. Do not spend another primary slot retrying the same route; next Terminal-Bench work should launch a treatment arm or move to a different historical pass/control case. |
@@ -64,6 +65,11 @@ Failure-attribution update:
   reached official scoring but returned `0.0` with
   `official_verifier_solution_failure`. This is a current-route baseline
   failure for a historical pass/control case, not a setup blocker.
+- `nginx-request-logging` under the same cloud app-server Goal route reached
+  official scoring and passed at `1.0`. This is current route evidence that
+  app-server Goal can complete at least one Terminal-Bench pass/control case;
+  `multi-source-data-merger` should be treated as case-specific or phase-
+  specific until a paired treatment/alternate route explains it.
 - `find-network-alignments` is now classified as
   `official_zero_native_goal_first_closeout_needs_solution_phase_counters`.
 - `rust-c-compiler` is blocked before agent execution by compact
@@ -85,6 +91,7 @@ or blocker.
 | --- | --- | --- | --- | --- |
 | P0 | `terminal-bench@2.0` | `build-cython-ext` | route canary with historical pass and latest observe-only native Goal result `1.0` | route canary complete; next slot should be treatment or a different historical pass/control case, not another route-readiness retry. |
 | P0 | `terminal-bench@2.0` | `multi-source-data-merger` | latest cloud app-server Goal baseline reached official scoring but failed at `0.0` | compare with previous current-protocol pass rows; next slot should be treatment or alternate pass/control rather than another identical baseline retry. |
+| P0 | `terminal-bench@2.0` | `nginx-request-logging` | latest cloud app-server Goal observation reached official score `1.0` | complete for route sanity; do not rerun immediately unless a future regression needs a fast pass/control guard. |
 | P0 | `swe-marathon` | `find-network-alignments` | first active SWE-Marathon cloud case completed at official score `0.0` | completed baseline; next slot should be a second small case or matching treatment arm. |
 | P0 | `swe-marathon` | `rust-c-compiler` | official README example and CPU-oriented case, but latest run blocked before agent execution | repair/prewarm Harbor environment or image setup first; rerun only after setup gate reaches agent execution. |
 | P0 | `skillsbench@1.1` | `llm-prefix-cache-replay` | runtime-refactor pair completed at `0.0/0.0`; native Goal post-PR-353 canary connected but produced no public worker trace | no immediate same-policy rerun; repair native worker trace or choose a new canary through the repaired trace path. |
@@ -93,7 +100,7 @@ or blocker.
 | P1 | `terminal-bench@2.0` | `make-doom-for-mips` | timeout/continuation attribution candidate | timeout phase attribution and app-server route canary complete. |
 | P1 | `terminal-bench@2.0` | `mteb-retrieve` | environment setup blocker candidate | environment setup preflight proves the task reaches agent or writes a compact blocker. |
 | P1 | `skillsbench@1.1` | `travel-planning` | recent cloud case completed at `0.0`; good low-risk sanity/control case | decide whether the next run is ACP control or native Goal route experiment. |
-| P2 | `terminal-bench@2.0` | `multi-source-data-merger`, `nginx-request-logging`, `large-scale-text-editing` | historical pass/non-regression controls | rerun only after the app-server route needs pass-case controls. |
+| P2 | `terminal-bench@2.0` | `large-scale-text-editing` | historical pass/non-regression control | rerun only after the app-server route needs another pass-case control. |
 
 ## Update Rule
 

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
@@ -10116,6 +10116,37 @@
               "status": "completed",
               "submit_eligible": false,
               "worker_bridge_status": "not_required"
+            },
+            {
+              "agent_declared_done": false,
+              "arm_id": "codex_app_server_goal_observation",
+              "artifact_refs": {
+                "compact_artifact_ref": "cloud-ecs/parallel-benchmark-20260620T235333Z/terminal-bench-nginx-request-logging-app-server-r1/terminal_bench_official_result.compact.json"
+              },
+              "benchmark_id": "terminal-bench@2.0",
+              "case_id": "nginx-request-logging",
+              "case_ids": [
+                "nginx-request-logging"
+              ],
+              "codex_acp_runtime_preflight_passed": false,
+              "failure_class": "none",
+              "failure_scope": "passed",
+              "goal_harness_inside_case": false,
+              "job_name": "nginx-request-logging-host-app-server-goal-20260621t001123z",
+              "leaderboard_evidence": false,
+              "mode": "terminal_bench_host_codex_app_server_goal",
+              "notes": "Terminal-Bench nginx-request-logging cloud app-server Goal observation; compact result only; no raw task/log/trajectory read.",
+              "official_passed": true,
+              "official_score": 1.0,
+              "recorded_at": "2026-06-21T08:14:52+08:00",
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "terminal-bench-nginx-request-logging-app-server-goal-20260621T001123Z",
+              "run_id": "249574f7cbde",
+              "score_status": "passed",
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false
             }
           ]
         },
@@ -10491,7 +10522,7 @@
           ]
         }
       },
-      "run_count": 86
+      "run_count": 87
     }
   },
   "schema_version": "benchmark_run_ledger_v0",
@@ -10502,5 +10533,5 @@
     "source_of_truth": "benchmark_run_v0 compact run events",
     "update_rule": "upsert one run entry when a benchmark case is ingested or closed"
   },
-  "updated_at": "2026-06-21T08:03:15+08:00"
+  "updated_at": "2026-06-21T08:14:52+08:00"
 }

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
@@ -5,7 +5,7 @@ benchmark case outcomes and artifact references; it must not contain raw
 logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 
 - schema_version: `benchmark_run_ledger_v0`
-- updated_at: `2026-06-21T08:03:15+08:00`
+- updated_at: `2026-06-21T08:14:52+08:00`
 
 ## Case Decisions
 
@@ -48,7 +48,7 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `terminal-bench@2.0` | `merge-diff-arc-agi-task` | `baseline_passed_not_current_treatment_priority` | - | `1` |
 | `terminal-bench@2.0` | `mteb-retrieve` | `paired_baseline_environment_setup_repair_required` | - | `4` |
 | `terminal-bench@2.0` | `multi-source-data-merger` | `paired_baseline_solved_treatment_preserved` | - | `19` |
-| `terminal-bench@2.0` | `nginx-request-logging` | `paired_baseline_solved_treatment_preserved` | - | `7` |
+| `terminal-bench@2.0` | `nginx-request-logging` | `paired_baseline_solved_treatment_preserved` | - | `8` |
 | `terminal-bench@2.0` | `path-tracing` | `baseline_passed_not_current_treatment_priority` | - | `2` |
 | `terminal-bench@2.0` | `pytorch-model-recovery` | `paired_no_score_uplift_exception_research_required` | `case_exception_research` | `3` |
 | `terminal-bench@2.0` | `regex-log` | `paired_baseline_solved_treatment_preserved` | - | `2` |
@@ -276,6 +276,7 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `terminal-bench@2.0` | `nginx-request-logging` | `hardened_codex_worker_materialization_probe` | `` | `0.0` | `` | `` | `codex_cli_not_on_path` | `.local/private-benchmark-jobs/terminal-bench-nginx-hardened-worker-materialization-probe-20260616T111726CST/jobs/terminal_bench_nginx_request_logging_hardened_worker_materialization_probe_20260616T111726CST/result.json` |
 | `terminal-bench@2.0` | `nginx-request-logging` | `hardened_codex_worker_materialization_runtime_probe` | `` | `0.0` | `` | `` | `pre_worker_startup_blocker_recorded` | `.local/private-benchmark-jobs/terminal-bench-nginx-hardened-worker-materialization-runtime-probe-20260616T113050CST/jobs/terminal_bench_nginx_request_logging_hardened_worker_materialization_runtime_probe_20260616T113050CST/result.json` |
 | `terminal-bench@2.0` | `nginx-request-logging` | `hardened_codex_baseline` | `` | `1.0` | `` | `` | `none` | `.local/private-benchmark-jobs/terminal-bench-nginx-hardened-baseline-rerun-20260616T115916CST/jobs/terminal_bench_nginx_request_logging_hardened_baseline_real_no_upload_20260616T115916CST/result.json` |
+| `terminal-bench@2.0` | `nginx-request-logging` | `codex_app_server_goal_observation` | `` | `1.0` | `` | `` | `none` | `cloud-ecs/parallel-benchmark-20260620T235333Z/terminal-bench-nginx-request-logging-app-server-r1/terminal_bench_official_result.compact.json` |
 | `terminal-bench@2.0` | `path-tracing` | `codex_goal_mode_baseline` | `` | `missing` | `` | `` | `score_missing` | `.local/private-benchmark-jobs/terminal-bench-path-tracing-goal-mode-baseline-20260614T200518CST/baseline/.local/private-benchmark-jobs/terminal-bench-path-tracing-goal-mode-baseline-20260614T200518CST/baseline/jobs/terminal_bench_2_0_path_tracing_codex_goal_mode_baseline_real_no_upload_20260614T200518CST/result.json` |
 | `terminal-bench@2.0` | `path-tracing` | `codex_goal_mode_baseline` | `` | `1.0` | `` | `` | `none` | `.local/private-benchmark-jobs/terminal-bench-path-tracing-goal-mode-baseline-20260614T201017CST/baseline/jobs/terminal_bench_2_0_path_tracing_codex_goal_mode_baseline_real_no_upload_20260614T201017CST/result.json` |
 | `terminal-bench@2.0` | `pytorch-model-recovery` | `codex_goal_mode_baseline` | `` | `0.0` | `` | `` | `agent_exception_before_solution_completion` | `.local/private-benchmark-jobs/terminal-bench-pytorch-model-recovery-paired-repair-20260614T0659Z/baseline.benchmark-run.public.json` |


### PR DESCRIPTION
## Summary
- ledger Terminal-Bench nginx-request-logging cloud app-server Goal observation at official score 1.0
- update active benchmark case status with the pass/control closeout
- keep SkillsBench and SWE-Marathon next actions explicit

## Validation
- python3 examples/benchmark-run-ledger-smoke.py
- goal-harness benchmark run-ledger-check --goal-id goal-harness-meta --run-ledger-path docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json --history-limit 40 --limit 5
- goal-harness check --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-active-case-status-20260620.md --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
- git diff --check

## Boundary
- compact/public docs and ledger only
- no raw task text, raw logs, trajectories, transcript, credentials, or absolute host paths added