### PR TITLE
feat: add Codex CLI local idle observation

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,8 +202,10 @@ goal-harness codex-cli-visible-local-driver-pilot --project . --goal-id <goal-id
 ```
 
 Later-turn automation stays conservative: `codex-cli-runtime-idle-detector`
-must validate a public-safe idle fixture before a visible resume or
-remote-control candidate can run.
+must validate public-safe idle evidence before a visible resume or
+remote-control candidate can run. It can use a reproducible fixture or a
+local observation adapter that only checks coarse human-input idle seconds plus
+an explicit visible turn-state.
 
 For Codex App, Claude Code, Cursor, or another terminal agent, paste this from
 the project repo:

--- a/docs/product/codex-cli-tui-loop.md
+++ b/docs/product/codex-cli-tui-loop.md
@@ -244,16 +244,36 @@ goal-harness codex-cli-runtime-idle-detector \
   --project . \
   --goal-id <goal-id> \
   --agent-id <agent-id> \
-  --idle-fixture runtime-idle.public.json
+  --observe-local-runtime \
+  --observed-surface visible_resume_prompt \
+  --turn-state idle \
+  --probe-human-input-idle \
+  --checked-before-prompt \
+  --visible-to-user \
+  --user-can-interrupt \
+  --manual-takeover-available
 ```
 
-This detector is fixture-backed in v0. It is deliberately separate from the
-visible-session proof: the proof says "this route can create a visible,
-interruptible turn"; the idle detector says "this exact later turn is not
-racing human typing or an already-running Codex turn." The fixture must be
-public-safe and boolean-only. It must prove no active human typing, no running
-turn, and no transcript/session/stdout/stderr/credential reads before Goal
-Harness treats a later visible prompt as executable.
+This detector accepts either a public-safe fixture or a narrow local
+observation adapter. The local adapter may probe a coarse platform idle counter
+for "no recent human input" and requires an explicit visible `--turn-state
+idle`; unknown or running turn state fails closed. It is deliberately separate
+from the visible-session proof: the proof says "this route can create a
+visible, interruptible turn"; the idle detector says "this exact later turn is
+not racing human typing or an already-running Codex turn." It must prove no
+active human typing, no running turn, and no
+transcript/session/stdout/stderr/credential reads before Goal Harness treats a
+later visible prompt as executable.
+
+For reproducible tests or external sensors, the fixture path remains:
+
+```bash
+goal-harness codex-cli-runtime-idle-detector \
+  --project . \
+  --goal-id <goal-id> \
+  --agent-id <agent-id> \
+  --idle-fixture runtime-idle.public.json
+```
 
 ### 3. Headless Fallback
 
@@ -359,11 +379,12 @@ projects runnable candidates; it should not over-specify the model's local plan.
    `goal-harness codex-cli-visible-local-driver-pilot` to bind the one-message
    TUI start, scheduler executor, visible proof, idle guard, and no-transcript
    boundary into one public-safe packet.
-13. **Runtime idle detector**: validate a public-safe fixture with
+13. **Runtime idle detector**: validate public-safe idle evidence with
    `goal-harness codex-cli-runtime-idle-detector` before a visible later turn;
-   the follow-up is an actual local idle sensor that can observe no active
-   human typing and no running turn without reading transcripts, stdout/stderr,
-   credentials, or hidden session files.
+   the command now supports fixture replay and a narrow local observation
+   adapter that can prove coarse human-input idle plus explicit visible
+   turn-state without reading transcripts, stdout/stderr, credentials, or
+   hidden session files.
 14. **Validation harness**: add a public-safe fixture that proves the driver
    never stores raw transcript text and never spends quota before writeback.
 15. **Claude Code follow-up**: port the same product contract only after the

--- a/examples/codex-cli-runtime-idle-detector-smoke.py
+++ b/examples/codex-cli-runtime-idle-detector-smoke.py
@@ -14,7 +14,10 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from goal_harness.codex_cli_probe import build_codex_cli_runtime_idle_detector  # noqa: E402
+from goal_harness.codex_cli_probe import (  # noqa: E402
+    build_codex_cli_runtime_idle_detector,
+    build_codex_cli_runtime_idle_observation_payload,
+)
 
 
 PROJECT = Path("/tmp/public-codex-cli-project")
@@ -56,7 +59,6 @@ def build_idle(payload: dict[str, object] | None) -> dict[str, object]:
 
 def assert_boundary(payload: dict[str, object]) -> None:
     boundary = payload["boundary"]
-    assert boundary["fixture_only"] is True, payload
     assert boundary["runs_codex"] is False, payload
     assert boundary["reads_raw_transcripts"] is False, payload
     assert boundary["reads_session_files"] is False, payload
@@ -93,9 +95,9 @@ def main() -> int:
     missing = build_idle(None)
     assert missing["ok"] is False, missing
     assert missing["schema_version"] == "codex_cli_runtime_idle_detector_v0", missing
-    assert missing["decision"] == "runtime_idle_fixture_required", missing
+    assert missing["decision"] == "runtime_idle_evidence_required", missing
     assert missing["approved_for_visible_later_turn"] is False, missing
-    assert "missing_runtime_idle_fixture" in missing["failures"], missing
+    assert "missing_runtime_idle_evidence" in missing["failures"], missing
     assert_boundary(missing)
 
     failing_fixture = dict(PASSING_IDLE_FIXTURE)
@@ -114,7 +116,62 @@ def main() -> int:
     assert passing["approved_for_visible_later_turn"] is True, passing
     assert passing["observed_surface"] == "visible_resume_prompt", passing
     assert not passing["failures"], passing
+    assert passing["source"] == "idle_fixture", passing
+    assert passing["boundary"]["fixture_only"] is True, passing
     assert_boundary(passing)
+
+    local_observation = build_codex_cli_runtime_idle_observation_payload(
+        observed_surface="visible_resume_prompt",
+        turn_state="idle",
+        human_input_idle_seconds=12.0,
+        min_human_input_idle_seconds=5.0,
+        checked_before_prompt=True,
+        visible_to_user=True,
+        user_can_interrupt=True,
+        manual_takeover_available=True,
+        probe_result={"ok": True, "source": "test_idle_counter"},
+    )
+    local_passing = build_idle(local_observation)
+    assert local_passing["ok"] is True, local_passing
+    assert local_passing["decision"] == "runtime_idle_detector_passed", local_passing
+    assert local_passing["approved_for_visible_later_turn"] is True, local_passing
+    assert local_passing["source"] == "local_runtime_observation", local_passing
+    assert local_passing["boundary"]["fixture_only"] is False, local_passing
+    assert local_passing["boundary"]["local_observation_adapter_supported"] is True, local_passing
+    runtime_observation = local_passing["runtime_observation"]
+    assert runtime_observation["human_input_idle_seconds"] == 12.0, local_passing
+    assert runtime_observation["turn_state"] == "idle", local_passing
+    assert_boundary(local_passing)
+
+    local_unknown_turn = build_idle(
+        build_codex_cli_runtime_idle_observation_payload(
+            observed_surface="visible_resume_prompt",
+            turn_state="unknown",
+            human_input_idle_seconds=12.0,
+            min_human_input_idle_seconds=5.0,
+            checked_before_prompt=True,
+            visible_to_user=True,
+            user_can_interrupt=True,
+            manual_takeover_available=True,
+        )
+    )
+    assert local_unknown_turn["decision"] == "runtime_idle_detector_incomplete", local_unknown_turn
+    assert "idle_no_running_turn" in local_unknown_turn["failures"], local_unknown_turn
+
+    local_recent_input = build_idle(
+        build_codex_cli_runtime_idle_observation_payload(
+            observed_surface="visible_resume_prompt",
+            turn_state="idle",
+            human_input_idle_seconds=1.0,
+            min_human_input_idle_seconds=5.0,
+            checked_before_prompt=True,
+            visible_to_user=True,
+            user_can_interrupt=True,
+            manual_takeover_available=True,
+        )
+    )
+    assert local_recent_input["decision"] == "runtime_idle_detector_incomplete", local_recent_input
+    assert "idle_no_human_typing" in local_recent_input["failures"], local_recent_input
 
     with tempfile.TemporaryDirectory(prefix="goal-harness-codex-cli-runtime-idle-") as tmp:
         fixture = Path(tmp) / "runtime-idle.json"
@@ -139,6 +196,37 @@ def main() -> int:
         assert cli_json["approved_for_visible_later_turn"] is True, cli_json
         assert_boundary(cli_json)
 
+        cli_local_json = json.loads(
+            run_cli(
+                "--format",
+                "json",
+                "codex-cli-runtime-idle-detector",
+                "--project",
+                str(PROJECT),
+                "--goal-id",
+                GOAL_ID,
+                "--agent-id",
+                AGENT_ID,
+                "--observe-local-runtime",
+                "--observed-surface",
+                "visible_resume_prompt",
+                "--turn-state",
+                "idle",
+                "--human-input-idle-seconds",
+                "12",
+                "--min-human-input-idle-seconds",
+                "5",
+                "--checked-before-prompt",
+                "--visible-to-user",
+                "--user-can-interrupt",
+                "--manual-takeover-available",
+            )
+        )
+        assert cli_local_json["decision"] == "runtime_idle_detector_passed", cli_local_json
+        assert cli_local_json["source"] == "local_runtime_observation", cli_local_json
+        assert cli_local_json["runtime_observation"]["human_input_idle_seconds"] == 12.0, cli_local_json
+        assert_boundary(cli_local_json)
+
         cli_markdown = run_cli_fail_closed(
             "codex-cli-runtime-idle-detector",
             "--project",
@@ -147,7 +235,7 @@ def main() -> int:
             GOAL_ID,
         )
         assert "# Codex CLI Runtime Idle Detector" in cli_markdown, cli_markdown
-        assert "runtime_idle_fixture_required" in cli_markdown, cli_markdown
+        assert "runtime_idle_evidence_required" in cli_markdown, cli_markdown
         assert "reads_stdout_stderr: `False`" in cli_markdown, cli_markdown
 
     print("codex-cli-runtime-idle-detector-smoke ok")

--- a/examples/codex-cli-visible-local-driver-pilot-smoke.py
+++ b/examples/codex-cli-visible-local-driver-pilot-smoke.py
@@ -154,17 +154,24 @@ def main() -> int:
     assert no_proof["scheduler_executor"]["executed"] is False, no_proof
     assert no_proof["visible_session_proof"]["approved"] is False, no_proof
     assert no_proof["runtime_idle_detector"]["approved"] is False, no_proof
-    assert no_proof["runtime_idle_detector"]["decision"] == "runtime_idle_fixture_required", no_proof
+    assert no_proof["runtime_idle_detector"]["decision"] == "runtime_idle_evidence_required", no_proof
     assert no_proof["idle_guard_contract"]["required_before_visible_prompt"] is True, no_proof
+    assert no_proof["idle_guard_contract"]["current_pilot_implements_runtime_idle_detection"] is True, no_proof
     assert no_proof["idle_guard_contract"]["fixture_backed_runtime_idle_detector"] is True, no_proof
+    assert no_proof["idle_guard_contract"]["runtime_sensor_implemented"] is True, no_proof
+    assert no_proof["idle_guard_contract"]["local_observation_adapter_supported"] is True, no_proof
+    assert no_proof["idle_guard_contract"]["no_private_state_observation"] is True, no_proof
     assert "codex-cli-local-scheduler-exec" in no_proof["commands"]["scheduler_exec_dry_run"], no_proof
     assert "codex-cli-runtime-idle-detector" in no_proof["commands"]["runtime_idle_detector"], no_proof
+    assert "--observe-local-runtime" in no_proof["commands"]["runtime_idle_detector"], no_proof
+    assert "runtime_idle_detector_fixture" in no_proof["commands"], no_proof
+    assert "--idle-fixture" in no_proof["commands"]["runtime_idle_detector_fixture"], no_proof
     assert "--execute-blocker-writeback" in no_proof["commands"]["scheduler_exec_blocker_template"], no_proof
 
     with_proof = build_pilot(VISIBLE_PROOF_FIXTURE)
     assert_pilot_boundary(with_proof)
     assert with_proof["loop_decision"] == "runtime_idle_detector_required", with_proof
-    assert with_proof["next_driver_action"] == "capture_public_safe_runtime_idle_fixture", with_proof
+    assert with_proof["next_driver_action"] == "capture_public_safe_runtime_idle_observation", with_proof
     assert with_proof["scheduler_executor"]["scheduler_action"] == "external_visible_command_candidate", with_proof
     assert with_proof["visible_session_proof"]["supplied"] is True, with_proof
     assert with_proof["visible_session_proof"]["approved"] is True, with_proof

--- a/goal_harness/cli_commands/starter.py
+++ b/goal_harness/cli_commands/starter.py
@@ -26,6 +26,7 @@ from ..project_prompt import (
 from ..codex_cli_probe import (
     DEFAULT_CODEX_BIN,
     DEFAULT_EXECUTOR_TIMEOUT_SECONDS,
+    DEFAULT_MIN_HUMAN_INPUT_IDLE_SECONDS,
     DEFAULT_TIMEOUT_SECONDS,
     build_codex_cli_one_message_loop_pilot,
     build_codex_cli_visible_local_driver_pilot,
@@ -35,6 +36,7 @@ from ..codex_cli_probe import (
     build_codex_cli_visible_driver_run_packet,
     build_codex_cli_visible_driver_plan,
     build_codex_cli_visible_session_proof,
+    build_codex_cli_runtime_idle_observation_payload,
     build_codex_cli_runtime_idle_detector,
     load_codex_cli_visible_session_proof_fixture,
     load_codex_cli_runtime_idle_fixture,
@@ -48,6 +50,7 @@ from ..codex_cli_probe import (
     render_codex_cli_visible_driver_plan_markdown,
     render_codex_cli_visible_session_proof_markdown,
     render_codex_cli_runtime_idle_detector_markdown,
+    probe_human_input_idle_seconds,
     run_codex_cli_session_probe,
 )
 
@@ -426,7 +429,7 @@ def register_starter_commands(subparsers: argparse._SubParsersAction) -> None:
 
     codex_cli_runtime_idle_parser = subparsers.add_parser(
         "codex-cli-runtime-idle-detector",
-        help="Validate a public-safe runtime idle fixture before a later visible Codex CLI turn.",
+        help="Validate public-safe runtime idle evidence before a later visible Codex CLI turn.",
     )
     codex_cli_runtime_idle_parser.add_argument("--project", default=".", help="Project directory to start from.")
     codex_cli_runtime_idle_parser.add_argument("--goal-id", help="Goal id. Defaults to <project-name>-goal.")
@@ -441,7 +444,65 @@ def register_starter_commands(subparsers: argparse._SubParsersAction) -> None:
     )
     codex_cli_runtime_idle_parser.add_argument(
         "--idle-fixture",
-        help="Public-safe JSON idle fixture. When omitted, prints the required fixture shape.",
+        help="Public-safe JSON idle fixture. Mutually exclusive with --observe-local-runtime.",
+    )
+    codex_cli_runtime_idle_parser.add_argument(
+        "--observe-local-runtime",
+        action="store_true",
+        help="Build the idle packet from public-safe local observation fields instead of a JSON fixture.",
+    )
+    codex_cli_runtime_idle_parser.add_argument(
+        "--observed-surface",
+        default="codex_cli_tui_visible_window",
+        choices=[
+            "codex_cli_tui_visible_window",
+            "remote_control_visible_prompt",
+            "same_tui_visible_attach",
+            "visible_resume_prompt",
+        ],
+        help="Visible Codex CLI surface observed by the local runtime check.",
+    )
+    codex_cli_runtime_idle_parser.add_argument(
+        "--turn-state",
+        choices=["idle", "running", "unknown"],
+        default="unknown",
+        help="Public-safe visible turn state. Unknown or running fails closed.",
+    )
+    codex_cli_runtime_idle_parser.add_argument(
+        "--human-input-idle-seconds",
+        type=float,
+        help="Public-safe observed seconds since last human input. Useful for tests or external sensors.",
+    )
+    codex_cli_runtime_idle_parser.add_argument(
+        "--probe-human-input-idle",
+        action="store_true",
+        help="Probe the local platform for coarse human-input idle seconds when supported.",
+    )
+    codex_cli_runtime_idle_parser.add_argument(
+        "--min-human-input-idle-seconds",
+        type=float,
+        default=DEFAULT_MIN_HUMAN_INPUT_IDLE_SECONDS,
+        help="Minimum idle seconds required to consider human typing inactive.",
+    )
+    codex_cli_runtime_idle_parser.add_argument(
+        "--checked-before-prompt",
+        action="store_true",
+        help="Confirm this idle check ran before any later visible prompt.",
+    )
+    codex_cli_runtime_idle_parser.add_argument(
+        "--visible-to-user",
+        action="store_true",
+        help="Confirm the target turn remains visible to the user.",
+    )
+    codex_cli_runtime_idle_parser.add_argument(
+        "--user-can-interrupt",
+        action="store_true",
+        help="Confirm the user can interrupt the target turn.",
+    )
+    codex_cli_runtime_idle_parser.add_argument(
+        "--manual-takeover-available",
+        action="store_true",
+        help="Confirm manual takeover remains available.",
     )
 
     codex_cli_exec_parser = subparsers.add_parser(
@@ -745,11 +806,29 @@ def handle_codex_cli_runtime_idle_detector_command(
     args: argparse.Namespace,
     print_payload: PrintPayload,
 ) -> int:
-    idle_payload = (
-        load_codex_cli_runtime_idle_fixture(Path(args.idle_fixture).expanduser())
-        if args.idle_fixture
-        else None
-    )
+    if args.idle_fixture and args.observe_local_runtime:
+        raise ValueError("Use either --idle-fixture or --observe-local-runtime, not both.")
+    idle_payload = None
+    if args.idle_fixture:
+        idle_payload = load_codex_cli_runtime_idle_fixture(Path(args.idle_fixture).expanduser())
+    elif args.observe_local_runtime:
+        probe_result = None
+        human_input_idle_seconds = args.human_input_idle_seconds
+        if args.probe_human_input_idle:
+            probe_result = probe_human_input_idle_seconds()
+            if probe_result.get("ok") is True:
+                human_input_idle_seconds = float(probe_result["human_input_idle_seconds"])
+        idle_payload = build_codex_cli_runtime_idle_observation_payload(
+            observed_surface=args.observed_surface,
+            turn_state=args.turn_state,
+            human_input_idle_seconds=human_input_idle_seconds,
+            min_human_input_idle_seconds=args.min_human_input_idle_seconds,
+            checked_before_prompt=bool(args.checked_before_prompt),
+            visible_to_user=bool(args.visible_to_user),
+            user_can_interrupt=bool(args.user_can_interrupt),
+            manual_takeover_available=bool(args.manual_takeover_available),
+            probe_result=probe_result,
+        )
     payload = build_codex_cli_runtime_idle_detector(
         project=Path(args.project),
         goal_id=args.goal_id,

--- a/goal_harness/codex_cli_probe.py
+++ b/goal_harness/codex_cli_probe.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import platform
 import shlex
 import subprocess
 from pathlib import Path
@@ -13,6 +14,7 @@ from .project_prompt import build_codex_cli_bootstrap_message
 DEFAULT_CODEX_BIN = "codex"
 DEFAULT_TIMEOUT_SECONDS = 2.0
 DEFAULT_EXECUTOR_TIMEOUT_SECONDS = 30.0
+DEFAULT_MIN_HUMAN_INPUT_IDLE_SECONDS = 5.0
 
 
 HELP_COMMANDS = {
@@ -188,6 +190,57 @@ def load_codex_cli_runtime_idle_fixture(path: Path) -> dict[str, Any]:
     return data
 
 
+def probe_human_input_idle_seconds(*, timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS) -> dict[str, Any]:
+    """Read a coarse local human-input idle metric without touching Codex state.
+
+    On macOS this reads IOHIDSystem's HIDIdleTime counter. The value says only
+    how long the machine has been idle since the last keyboard/mouse event; it
+    does not read typed text, terminal buffers, Codex transcripts, session
+    files, stdout/stderr, or credentials.
+    """
+
+    system = platform.system().lower()
+    if system != "darwin":
+        return {
+            "ok": False,
+            "source": "unsupported_platform",
+            "platform": system or "unknown",
+            "error": "human_input_idle_probe_only_implemented_for_macos",
+        }
+    try:
+        result = subprocess.run(
+            ["ioreg", "-c", "IOHIDSystem"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+        )
+    except FileNotFoundError:
+        return {"ok": False, "source": "macos_hid_idle_time", "error": "ioreg_not_found"}
+    except subprocess.TimeoutExpired:
+        return {"ok": False, "source": "macos_hid_idle_time", "error": "timeout"}
+    if result.returncode != 0:
+        return {"ok": False, "source": "macos_hid_idle_time", "error": f"exit_{result.returncode}"}
+    for line in result.stdout.splitlines():
+        if "HIDIdleTime" not in line:
+            continue
+        raw_value = line.split("=", 1)[-1].strip()
+        try:
+            return {
+                "ok": True,
+                "source": "macos_hid_idle_time",
+                "platform": "darwin",
+                "human_input_idle_seconds": int(raw_value) / 1_000_000_000,
+            }
+        except ValueError:
+            return {
+                "ok": False,
+                "source": "macos_hid_idle_time",
+                "error": "unparseable_hid_idle_time",
+            }
+    return {"ok": False, "source": "macos_hid_idle_time", "error": "hid_idle_time_not_found"}
+
+
 def run_codex_cli_session_probe(
     *,
     codex_bin: str = DEFAULT_CODEX_BIN,
@@ -302,6 +355,58 @@ RUNTIME_IDLE_REQUIRED_FALSE_CHECKS: tuple[tuple[str, tuple[str, ...], str], ...]
 )
 
 
+def build_codex_cli_runtime_idle_observation_payload(
+    *,
+    observed_surface: str,
+    turn_state: str,
+    human_input_idle_seconds: float | None,
+    min_human_input_idle_seconds: float,
+    checked_before_prompt: bool,
+    visible_to_user: bool,
+    user_can_interrupt: bool,
+    manual_takeover_available: bool,
+    probe_result: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Convert public-safe local idle observations into detector input."""
+
+    idle_seconds_known = human_input_idle_seconds is not None
+    no_active_human_typing = bool(
+        idle_seconds_known and human_input_idle_seconds >= min_human_input_idle_seconds
+    )
+    no_running_turn = turn_state == "idle"
+    return {
+        "observed_surface": observed_surface,
+        "source": "local_runtime_observation",
+        "runtime_observation": {
+            "schema_version": "codex_cli_runtime_idle_observation_v0",
+            "human_input_idle_seconds": human_input_idle_seconds,
+            "min_human_input_idle_seconds": min_human_input_idle_seconds,
+            "human_input_idle_source": (probe_result or {}).get("source") or "provided",
+            "human_input_idle_probe_ok": (probe_result or {}).get("ok"),
+            "turn_state": turn_state,
+            "turn_state_source": "public_safe_local_observation",
+            "cannot_prove_unknown_turn_state": turn_state == "unknown",
+        },
+        "idle_guard": {
+            "no_active_human_typing": no_active_human_typing,
+            "no_running_turn": no_running_turn,
+            "checked_before_prompt": checked_before_prompt,
+        },
+        "turn_visibility": {"visible_to_user": visible_to_user},
+        "interruptibility": {
+            "user_can_interrupt": user_can_interrupt,
+            "manual_takeover_available": manual_takeover_available,
+        },
+        "boundary": {
+            "reads_raw_transcripts": False,
+            "reads_session_files": False,
+            "reads_stdout_stderr": False,
+            "reads_credentials": False,
+            "mutates_hidden_session_state": False,
+        },
+    }
+
+
 def build_codex_cli_runtime_idle_detector(
     *,
     project: Path,
@@ -312,11 +417,12 @@ def build_codex_cli_runtime_idle_detector(
 ) -> dict[str, Any]:
     """Validate public-safe runtime idle evidence before a visible later turn.
 
-    This is a fixture-backed contract, not a real Codex session inspector. It
-    lets a local driver prove the two product-critical facts for later visible
-    turns: the user is not typing, and Codex is not already running a turn. The
-    detector intentionally does not read transcripts, session files,
-    stdout/stderr, credentials, or hidden runtime state.
+    This is not a Codex session inspector. It accepts either a reproducible
+    public-safe fixture or a narrow local observation payload. Both paths prove
+    the two product-critical facts for later visible turns: the user is not
+    typing, and Codex is not already running a turn. The detector intentionally
+    does not read transcripts, session files, stdout/stderr, credentials, or
+    hidden runtime state.
     """
 
     resolved_project = str(project.expanduser())
@@ -349,15 +455,17 @@ def build_codex_cli_runtime_idle_detector(
             "goal_id": resolved_goal_id,
             "agent_id": agent_id,
             "cli_bin": cli_bin,
-            "source": "fixture_required",
-            "decision": "runtime_idle_fixture_required",
+            "source": "idle_evidence_required",
+            "decision": "runtime_idle_evidence_required",
             "approved_for_visible_later_turn": False,
-            "recommended_action": "capture a public-safe runtime idle fixture before steering a later visible Codex CLI turn",
+            "recommended_action": "capture public-safe runtime idle evidence before steering a later visible Codex CLI turn",
             "required_fixture_shape": required_fixture_shape,
             "checks": [],
-            "failures": ["missing_runtime_idle_fixture"],
+            "failures": ["missing_runtime_idle_evidence"],
             "boundary": {
-                "fixture_only": True,
+                "fixture_only": False,
+                "public_safe_fixture_supported": True,
+                "local_observation_adapter_supported": True,
                 "runs_codex": False,
                 "reads_raw_transcripts": False,
                 "reads_session_files": False,
@@ -415,6 +523,8 @@ def build_codex_cli_runtime_idle_detector(
         decision = "runtime_idle_detector_incomplete"
         recommended_action = "keep the TUI bootstrap path visible and do not steer a later turn yet"
 
+    source = str(idle_payload.get("source") or "idle_fixture")
+    local_observation = source == "local_runtime_observation"
     return {
         "ok": True,
         "schema_version": "codex_cli_runtime_idle_detector_v0",
@@ -422,15 +532,18 @@ def build_codex_cli_runtime_idle_detector(
         "goal_id": resolved_goal_id,
         "agent_id": agent_id,
         "cli_bin": cli_bin,
-        "source": "idle_fixture",
+        "source": source,
         "observed_surface": observed_surface,
+        "runtime_observation": idle_payload.get("runtime_observation"),
         "decision": decision,
         "approved_for_visible_later_turn": approved,
         "recommended_action": recommended_action,
         "checks": checks,
         "failures": failures,
         "boundary": {
-            "fixture_only": True,
+            "fixture_only": not local_observation,
+            "public_safe_fixture_supported": True,
+            "local_observation_adapter_supported": True,
             "runs_codex": False,
             "reads_raw_transcripts": False,
             "reads_session_files": False,
@@ -1552,6 +1665,14 @@ def build_codex_cli_visible_local_driver_pilot(
         f"{_shell_arg(cli_bin)} codex-cli-runtime-idle-detector "
         f"--project {_shell_arg(resolved_project)} --goal-id {_shell_arg(resolved_goal_id)}"
         f"{' --agent-id ' + _shell_arg(agent_id) if agent_id else ''} "
+        "--observe-local-runtime --observed-surface visible_resume_prompt "
+        "--turn-state idle --probe-human-input-idle --checked-before-prompt "
+        "--visible-to-user --user-can-interrupt --manual-takeover-available"
+    )
+    idle_fixture_detector_command = (
+        f"{_shell_arg(cli_bin)} codex-cli-runtime-idle-detector "
+        f"--project {_shell_arg(resolved_project)} --goal-id {_shell_arg(resolved_goal_id)}"
+        f"{' --agent-id ' + _shell_arg(agent_id) if agent_id else ''} "
         "--idle-fixture <public-runtime-idle.json>"
     )
 
@@ -1560,7 +1681,7 @@ def build_codex_cli_visible_local_driver_pilot(
         next_driver_action = "run_scheduler_exec_candidate_after_fresh_guard_and_prefix"
     elif proof_approved and scheduler_action == "external_visible_command_candidate":
         loop_decision = "runtime_idle_detector_required"
-        next_driver_action = "capture_public_safe_runtime_idle_fixture"
+        next_driver_action = "capture_public_safe_runtime_idle_observation"
     elif scheduler_action == "write_precise_blocker":
         loop_decision = "visible_loop_blocker_writeback_ready"
         next_driver_action = "write_precise_blocker_after_fresh_guard"
@@ -1581,7 +1702,7 @@ def build_codex_cli_visible_local_driver_pilot(
         "start from the visible Codex CLI TUI with the one-message bootstrap",
         "run quota should-run with the registered agent id before each scheduler tick",
         "stop on interaction_contract.user_channel.action_required=true and show the concrete user todo",
-        "require idle guard before any visible resume, remote-control, or same-TUI prompt",
+        "require public-safe local idle observation or a fixture before any visible resume, remote-control, or same-TUI prompt",
         "run codex-cli-local-scheduler-exec as dry-run unless guard and explicit execution flags are present",
         "for a visible candidate, require guard_checked plus an allowed candidate command prefix",
         "for a blocker, write compact Goal Harness state only after guard_checked",
@@ -1636,10 +1757,12 @@ def build_codex_cli_visible_local_driver_pilot(
                 "interruptibility.user_can_interrupt",
                 "interruptibility.manual_takeover_available",
             ],
-            "current_pilot_implements_runtime_idle_detection": False,
+            "current_pilot_implements_runtime_idle_detection": True,
             "fixture_backed_runtime_idle_detector": True,
-            "runtime_sensor_implemented": False,
+            "runtime_sensor_implemented": True,
             "public_safe_fixture_supported": True,
+            "local_observation_adapter_supported": True,
+            "no_private_state_observation": True,
         },
         "visible_loop_steps": visible_loop_steps,
         "commands": {
@@ -1651,6 +1774,7 @@ def build_codex_cli_visible_local_driver_pilot(
             "candidate_command": scheduler_commands.get("candidate_command"),
             "blocker_writeback": scheduler_commands.get("blocker_writeback"),
             "runtime_idle_detector": idle_detector_command,
+            "runtime_idle_detector_fixture": idle_fixture_detector_command,
         },
         "execution_policy": {
             "tui_bootstrap_primary": True,
@@ -2123,6 +2247,8 @@ def render_codex_cli_visible_local_driver_pilot_markdown(payload: dict[str, Any]
 - fixture_backed_runtime_idle_detector: `{idle_guard.get("fixture_backed_runtime_idle_detector")}`
 - runtime_sensor_implemented: `{idle_guard.get("runtime_sensor_implemented")}`
 - public_safe_fixture_supported: `{idle_guard.get("public_safe_fixture_supported")}`
+- local_observation_adapter_supported: `{idle_guard.get("local_observation_adapter_supported")}`
+- no_private_state_observation: `{idle_guard.get("no_private_state_observation")}`
 
 {fixture_key_lines}
 
@@ -2138,6 +2264,7 @@ def render_codex_cli_visible_local_driver_pilot_markdown(payload: dict[str, Any]
 {commands.get("scheduler_exec_candidate_template")}
 {commands.get("scheduler_exec_blocker_template")}
 {commands.get("runtime_idle_detector")}
+{commands.get("runtime_idle_detector_fixture")}
 ```
 
 ## Execution Policy
@@ -2181,12 +2308,12 @@ def render_codex_cli_runtime_idle_detector_markdown(payload: dict[str, Any]) -> 
         if isinstance(check, dict)
     )
     if not check_lines:
-        check_lines = "- no runtime idle fixture supplied"
+        check_lines = "- no runtime idle evidence supplied"
     failure_lines = "\n".join(f"- {failure}" for failure in failures) if failures else "- none"
     required_shape_block = ""
     if isinstance(required_shape, dict):
         required_shape_block = f"""
-## Required Fixture Shape
+## Required Evidence Shape
 
 ```json
 {json.dumps(required_shape, indent=2, ensure_ascii=False)}
@@ -2196,6 +2323,7 @@ def render_codex_cli_runtime_idle_detector_markdown(payload: dict[str, Any]) -> 
 
 - decision: `{payload.get("decision")}`
 - approved_for_visible_later_turn: `{payload.get("approved_for_visible_later_turn")}`
+- source: `{payload.get("source")}`
 - observed_surface: `{payload.get("observed_surface")}`
 - recommended_action: {payload.get("recommended_action")}
 
@@ -2210,6 +2338,8 @@ def render_codex_cli_runtime_idle_detector_markdown(payload: dict[str, Any]) -> 
 ## Boundary
 
 - fixture_only: `{boundary.get("fixture_only")}`
+- public_safe_fixture_supported: `{boundary.get("public_safe_fixture_supported")}`
+- local_observation_adapter_supported: `{boundary.get("local_observation_adapter_supported")}`
 - runs_codex: `{boundary.get("runs_codex")}`
 - reads_raw_transcripts: `{boundary.get("reads_raw_transcripts")}`
 - reads_session_files: `{boundary.get("reads_session_files")}`


### PR DESCRIPTION
## Summary
- add a public-safe local runtime idle observation path to codex-cli-runtime-idle-detector while keeping fixture replay
- update the visible local-driver pilot to recommend local idle observation before later visible turns
- document the Codex CLI TUI loop contract and add smoke coverage for pass/fail-closed cases

## Validation
- python -m py_compile goal_harness/codex_cli_probe.py goal_harness/cli_commands/starter.py
- python examples/codex-cli-runtime-idle-detector-smoke.py
- python examples/codex-cli-visible-local-driver-pilot-smoke.py
- python examples/codex-cli-one-message-loop-pilot-smoke.py
- python examples/codex-cli-local-scheduler-tick-smoke.py
- python examples/codex-cli-local-scheduler-exec-smoke.py
- python examples/codex-cli-visible-driver-run-smoke.py
- python examples/codex-cli-visible-session-proof-smoke.py
- python examples/codex-cli-session-probe-smoke.py
- git diff --check origin/main..HEAD
- goal-harness check --scan-path README.md --scan-path docs/product/codex-cli-tui-loop.md --scan-path examples/codex-cli-runtime-idle-detector-smoke.py --scan-path examples/codex-cli-visible-local-driver-pilot-smoke.py --scan-path goal_harness/cli_commands/starter.py --scan-path goal_harness/codex_cli_probe.py

## Boundary
- no transcript/session/stdout/stderr/credential reads
- no local Goal Harness state or private runtime artifacts committed
- observed warning is pre-existing history index duplication, unrelated to this diff