### PR TITLE
docs: extend benchmark closeout attribution

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/benchmark-closeout-failure-attribution-20260620.json
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-closeout-failure-attribution-20260620.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "benchmark_closeout_failure_attribution_v0",
-  "generated_at": "2026-06-21T08:54:16+08:00",
+  "generated_at": "2026-06-21T09:18:31+08:00",
   "scope": "public_safe_failure_attribution_for_20260620_cloud_benchmark_closeouts",
   "public_boundary": {
     "raw_task_text_copied": false,
@@ -53,6 +53,57 @@
       "next_obligation": "Add or inspect public-safe Terminal-Bench phase counters, then compare against the historical passing control before launching more build-cython-ext treatment or declaring case difficulty."
     },
     {
+      "benchmark_id": "terminal-bench@2.0",
+      "case_id": "multi-source-data-merger",
+      "run_ids": {
+        "current_baseline": "terminal-bench-multi-source-data-merger-app-server-goal-20260620T235333Z"
+      },
+      "route": "host_codex_app_server_goal_observation",
+      "native_codex_goal_evidence": true,
+      "official_score": 0.0,
+      "official_passed": false,
+      "ledger_failure_class": "official_verifier_solution_failure",
+      "ledger_failure_scope": "case_or_solution",
+      "refined_attribution": "official_zero_current_app_server_goal_baseline_needs_phase_or_treatment_comparison",
+      "not_a_setup_blocker_because": [
+        "app-server Goal route reached official Terminal-Bench closeout",
+        "official result reducer wrote a compact result",
+        "ledger upsert completed",
+        "raw transcript, task text, trajectories, and verifier output were not recorded publicly"
+      ],
+      "remaining_unknowns": [
+        "whether the zero is case-specific, phase-specific, or route-specific",
+        "whether a matched treatment arm would recover the case",
+        "whether another current-route pass/control case should be compared first"
+      ],
+      "next_obligation": "Compare against current-protocol passing rows and launch either a matched treatment arm or an alternate pass/control case before making route-quality claims."
+    },
+    {
+      "benchmark_id": "terminal-bench@2.0",
+      "case_id": "nginx-request-logging",
+      "run_ids": {
+        "current_baseline": "terminal-bench-nginx-request-logging-app-server-goal-20260621T001123Z"
+      },
+      "route": "host_codex_app_server_goal_observation",
+      "native_codex_goal_evidence": true,
+      "official_score": 1.0,
+      "official_passed": true,
+      "ledger_failure_class": "none",
+      "ledger_failure_scope": "none",
+      "refined_attribution": "native_goal_route_sanity_pass_current_protocol_control",
+      "not_a_setup_blocker_because": [
+        "app-server Goal route reached official Terminal-Bench closeout",
+        "official result reducer wrote a compact result",
+        "official score passed",
+        "raw transcript, task text, trajectories, and verifier output were not recorded publicly"
+      ],
+      "remaining_unknowns": [
+        "whether the same route helps harder or treatment-selected cases",
+        "whether this pass should become a recurring regression guard"
+      ],
+      "next_obligation": "Use as route sanity evidence; do not rerun the same observation unless a future regression needs a fast pass/control guard."
+    },
+    {
       "benchmark_id": "swe-marathon",
       "case_id": "find-network-alignments",
       "run_ids": {
@@ -103,6 +154,31 @@
         "whether Harbor can preserve public-safe edit/test/verify phase counters without raw diffs or logs"
       ],
       "next_obligation": "Stop treating rust-c-compiler as an environment blocker; add public-safe SWE-Marathon solution-phase counters or run a matched treatment/alternate small case under the same no-upload boundary."
+    },
+    {
+      "benchmark_id": "skillsbench@1.1",
+      "case_id": "react-performance-debugging",
+      "run_ids": {
+        "current_baseline": "skillsbench-react-performance-native-goal-20260620T235333Z"
+      },
+      "route": "skillsbench_codex_app_server_goal_baseline",
+      "native_codex_goal_evidence": true,
+      "official_score": 0.0,
+      "official_passed": false,
+      "ledger_failure_class": "skillsbench_runner_error",
+      "ledger_failure_scope": "runner_or_route",
+      "refined_attribution": "native_goal_worker_connected_trace_dir_missing_not_solver_quality_evidence",
+      "not_a_setup_blocker_because": [
+        "BenchFlow runner produced a compact official result",
+        "the native app-server Goal route connected the host worker",
+        "public controller trace remained compact and public-safe"
+      ],
+      "remaining_unknowns": [
+        "why the worker connected but did not materialize a public worker trace directory",
+        "why no worker turn-start or turn-complete evidence was observed",
+        "whether the runner error is caused by launcher wiring, trace-path wiring, or worker lifecycle"
+      ],
+      "next_obligation": "Repair the native worker public trace materialization path before using this or any new SkillsBench native Goal row as solver-quality baseline evidence."
     },
     {
       "benchmark_id": "skillsbench@1.1",
@@ -171,7 +247,7 @@
     {
       "route": "terminal_bench",
       "decision": "do_not_rotate_blindly",
-      "reason": "The route is native Goal and reached official closeout, but the current zero conflicts with a historical passing control."
+      "reason": "The route is native Goal and reached official closeout; current rows include both a pass control and a zero-score case that needs phase or treatment comparison."
     },
     {
       "route": "swe_marathon",
@@ -180,8 +256,8 @@
     },
     {
       "route": "skillsbench",
-      "decision": "build_native_app_server_goal_worker",
-      "reason": "Current compact pairs are ACP blind-loop evidence, not the intended Codex Goal baseline."
+      "decision": "repair_native_app_server_goal_worker_trace",
+      "reason": "The native worker now connects, but public worker turn trace is still missing; ACP blind-loop evidence remains separate from solver-quality native Goal evidence."
     }
   ]
 }

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-closeout-failure-attribution-20260620.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-closeout-failure-attribution-20260620.md
@@ -38,8 +38,11 @@ solution, a weak worker policy, or a bad canary.
 | Benchmark | Case | Route | Compact Result | Refined Attribution | Next Obligation |
 | --- | --- | --- | --- | --- | --- |
 | `terminal-bench@2.0` | `build-cython-ext` | host Codex app-server Goal | `0.0`, `official_verifier_solution_failure`; historical compact control `53729101fea3` scored `1.0` | `official_zero_native_goal_regression_needs_phase_attribution` | Add public-safe Terminal-Bench phase counters and compare against the historical passing control before launching more treatment on this case. |
+| `terminal-bench@2.0` | `multi-source-data-merger` | host Codex app-server Goal observation | `0.0`, `official_verifier_solution_failure`; current route reached official scoring and wrote compact result | `official_zero_current_app_server_goal_baseline_needs_phase_or_treatment_comparison` | Do not treat this as a setup blocker. Compare against current-protocol passing rows and launch either a treatment arm or an alternate pass/control case before making route-quality claims. |
+| `terminal-bench@2.0` | `nginx-request-logging` | host Codex app-server Goal observation | `1.0`, official pass; raw transcript not recorded | `native_goal_route_sanity_pass_current_protocol_control` | Use as route sanity evidence that app-server Goal can complete a Terminal-Bench pass/control case; do not spend another primary slot rerunning the same observation unless it is needed as a regression guard. |
 | `swe-marathon` | `find-network-alignments` | Harbor host Codex app-server Goal | `0.0`, `official_verifier_solution_failure` | `official_zero_native_goal_first_closeout_needs_solution_phase_counters` | Teach the Harbor/SWE-Marathon reducer to preserve public-safe edit/test/verify phase counters before treating this as model-capability evidence. |
 | `swe-marathon` | `rust-c-compiler` | Harbor host Codex app-server Goal, prewarmed/larger-budget r2 | `0.0`, `official_verifier_solution_failure`; setup, agent execution, official verifier, and job closeout completed | `official_zero_native_goal_second_closeout_setup_cleared_needs_solution_phase_counters` | Stop treating this case as an environment blocker; add public-safe edit/test/verify counters or run a matched treatment/alternate small SWE case before making model-quality claims. |
+| `skillsbench@1.1` | `react-performance-debugging` | native app-server Goal baseline, high reasoning | `0.0`, `skillsbench_runner_error`; public compact shows worker connection but no worker trace directory or turn-start evidence | `native_goal_worker_connected_trace_dir_missing_not_solver_quality_evidence` | Repair the native worker public trace materialization path before using this or any new SkillsBench native Goal row as solver-quality baseline evidence. |
 | `skillsbench@1.1` | `llm-prefix-cache-replay` | BenchFlow ACP blind-loop baseline/treatment | `0.0/0.0`, `paired_no_score_uplift` | `paired_zero_acp_blind_loop_non_native_goal_no_uplift` | Stop using more ACP blind-loop repeats as primary Codex Goal evidence; implement a native SkillsBench app-server Goal worker first. |
 | `skillsbench@1.1` | `tictoc-unnecessary-abort-detection` | BenchFlow ACP blind-loop baseline/treatment | `0.0/0.0`, `paired_no_score_uplift` | `paired_zero_acp_blind_loop_non_native_goal_no_uplift` | Keep as a stability canary only until the native SkillsBench app-server Goal worker exists. |
 
@@ -47,15 +50,18 @@ solution, a weak worker policy, or a bad canary.
 
 Terminal-Bench and SWE-Marathon have crossed the important infrastructure
 line: app-server Goal can start, run, reach verifier, and produce compact
-official closeouts. `rust-c-compiler` r2 also clears the previous SWE-Marathon
-setup blocker. These current failures are no longer setup blockers; the next
-missing piece is solution-phase attribution.
+official closeouts. `nginx-request-logging` now provides a current-route pass
+control, while `multi-source-data-merger` shows a current-route zero that needs
+phase or treatment comparison before route-quality claims. `rust-c-compiler`
+r2 also clears the previous SWE-Marathon setup blocker. These current failures
+are no longer setup blockers; the next missing piece is solution-phase
+attribution.
 
-SkillsBench is different. The two latest cases prove that setup, prewarm, ACP
-rounds, and official scoring can complete. They do not prove native Codex Goal
-behavior, because the route is still BenchFlow ACP blind-loop. The next
-engineering slice should therefore be a native app-server Goal worker, not
-another same-policy repeat.
+SkillsBench is different. The ACP rows prove that setup, prewarm, rounds, and
+official scoring can complete. The native app-server Goal canary proves host
+worker connection, but it still lacks public worker turn trace materialization.
+The next engineering slice should therefore be the native worker trace path,
+not another same-policy repeat.
 
 ## Durable Rule
 

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-goal-rollout-debug-20260620.json
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-goal-rollout-debug-20260620.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "benchmark_goal_rollout_debug_v0",
-  "generated_at": "2026-06-21T08:54:16+08:00",
+  "generated_at": "2026-06-21T09:18:31+08:00",
   "scope": "public_safe_rollout_metadata_for_20260620_cloud_goal_closeouts",
   "public_boundary": {
     "raw_task_text_copied": false,
@@ -82,6 +82,84 @@
         "Can a public-safe terminal/goal phase summary be derived without copying raw trial fields?",
         "Did app-server Goal get enough task-visible time compared with the historical passing run?",
         "Should the next Terminal-Bench step be a historical pass/control rerun before treatment?"
+      ]
+    },
+    {
+      "benchmark_id": "terminal-bench@2.0",
+      "case_id": "multi-source-data-merger",
+      "current_run_id": "terminal-bench-multi-source-data-merger-app-server-goal-20260620T235333Z",
+      "route": "host_codex_app_server_goal_observation",
+      "arm_id": "terminal_bench_host_codex_app_server_goal_observation",
+      "native_codex_goal_evidence": true,
+      "compact_artifact_ref": "cloud-ecs/parallel-benchmark-20260620T235333Z/terminal-bench-multi-source-data-merger-app-server-r1/terminal_bench_official_result.compact.json",
+      "official_score": 0.0,
+      "official_passed": false,
+      "failure_class": "official_verifier_solution_failure",
+      "failure_scope": "case_or_solution",
+      "rollout_stages": [
+        "remote_cloud_host_selected",
+        "codex_app_server_goal_started",
+        "terminal_bench_runner_reached_official_closeout",
+        "official_result_reducer_wrote_compact_result",
+        "ledger_upserted"
+      ],
+      "debug_read": "Current app-server Goal route reached official scoring and failed. Treat this as a current-route baseline observation, not a setup blocker or paired treatment claim.",
+      "next_debug_questions": [
+        "Is the zero case-specific, phase-specific, or route-specific?",
+        "Should the next Terminal-Bench step be a matched treatment arm or a different historical pass/control case?",
+        "Can public-safe phase counters distinguish incomplete solution from wrong solution?"
+      ]
+    },
+    {
+      "benchmark_id": "terminal-bench@2.0",
+      "case_id": "nginx-request-logging",
+      "current_run_id": "terminal-bench-nginx-request-logging-app-server-goal-20260621T001123Z",
+      "route": "host_codex_app_server_goal_observation",
+      "arm_id": "terminal_bench_host_codex_app_server_goal_observation",
+      "native_codex_goal_evidence": true,
+      "compact_artifact_ref": "cloud-ecs/parallel-benchmark-20260620T235333Z/terminal-bench-nginx-request-logging-app-server-r1/terminal_bench_official_result.compact.json",
+      "official_score": 1.0,
+      "official_passed": true,
+      "failure_class": "none",
+      "failure_scope": "none",
+      "rollout_stages": [
+        "remote_cloud_host_selected",
+        "codex_app_server_goal_started",
+        "terminal_bench_runner_reached_official_closeout",
+        "official_result_reducer_wrote_compact_result",
+        "ledger_upserted"
+      ],
+      "debug_read": "This is the current-route pass control for the batch. It proves the app-server Goal route can complete at least one Terminal-Bench pass/control case without public raw transcript capture.",
+      "next_debug_questions": [
+        "Should this pass become a recurring route regression guard?",
+        "Which treatment or unresolved pass/control case should follow instead of another identical observation?",
+        "Which phase counters are useful for comparing against zero-score Terminal-Bench rows?"
+      ]
+    },
+    {
+      "benchmark_id": "skillsbench@1.1",
+      "case_id": "react-performance-debugging",
+      "current_run_id": "skillsbench-react-performance-native-goal-20260620T235333Z",
+      "route": "skillsbench_codex_app_server_goal_baseline",
+      "arm_id": "skillsbench_codex_app_server_goal_baseline",
+      "native_codex_goal_evidence": true,
+      "compact_artifact_ref": "cloud-ecs/parallel-benchmark-20260620T235333Z/skillsbench-react-performance-native-goal-r1/jobs/gh-skillsbench-react-performance-native-goal-r1/react-performance-debugging__codex_app_server_goal/benchmark_run.compact.json",
+      "official_score": 0.0,
+      "official_passed": false,
+      "failure_class": "skillsbench_runner_error",
+      "failure_scope": "runner_or_route",
+      "rollout_stages": [
+        "native_app_server_goal_route_selected",
+        "host_worker_connection_observed",
+        "public_controller_trace_written",
+        "official_verifier_completed_zero",
+        "worker_public_trace_missing"
+      ],
+      "debug_read": "The native worker connected, but no public worker trace directory, turn-start, or turn-complete evidence materialized. This is route/runner evidence, not solver-quality baseline evidence.",
+      "next_debug_questions": [
+        "Why does worker connection not create the public worker trace directory?",
+        "Is trace-path wiring or worker lifecycle terminating before turn/start?",
+        "Can the launcher fail closed before scoring when native worker trace is missing?"
       ]
     },
     {
@@ -208,10 +286,10 @@
     }
   ],
   "cross_case_findings": [
-    "The cloud host and app-server Goal route are now proven for Terminal-Bench and SWE-Marathon; SWE-Marathon now has two native Goal zero-score closeouts, and rust-c-compiler r2 clears the previous setup blocker.",
-    "SkillsBench closeouts are runner/verifier progress, not native Codex Goal evidence, because the current route is ACP/blind-loop.",
+    "The cloud host and app-server Goal route are now proven for Terminal-Bench and SWE-Marathon; Terminal-Bench has both a current-route pass control and a current-route zero, SWE-Marathon has two native Goal zero-score closeouts, and rust-c-compiler r2 clears the previous setup blocker.",
+    "SkillsBench now has native worker connection evidence, but public worker turn trace is still missing; ACP/blind-loop rows remain separate runner/verifier evidence.",
     "The current failure taxonomy is too coarse: official_verifier_solution_failure should be split from agent timeout, incomplete solution, and verifier dependency failures when compact evidence supports it.",
     "A dedicated rollout layer is needed between raw private trajectories and the public benchmark ledger: ledger says what closed; rollout says how the case moved through control-plane and runner phases."
   ],
-  "recommended_next_step": "Before launching another rotation, add a durable public-safe rollout/traj debug artifact and use it to decide which case needs phase-counter reducers, native SkillsBench Goal support, or treatment comparison."
+  "recommended_next_step": "Before launching another SkillsBench native Goal case, repair public worker trace materialization. Terminal-Bench should rotate to treatment or an unresolved pass/control case, and SWE-Marathon should add solution-phase counters or run a matched treatment/alternate small case."
 }

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-goal-rollout-debug-20260620.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-goal-rollout-debug-20260620.md
@@ -46,6 +46,9 @@ next case" or "which phase failed".
 | Benchmark | Case | Route | Official Result | Rollout Read |
 | --- | --- | --- | --- | --- |
 | `terminal-bench@2.0` | `build-cython-ext` | host Codex app-server Goal | `0.0`, `official_verifier_solution_failure` | Native Goal route reached official Terminal-Bench closeout. Historical compact control `53729101fea3` passed this case with score `1.0`, so the current zero is not enough to call the case impossible. The missing evidence is public-safe solution-phase attribution. |
+| `terminal-bench@2.0` | `multi-source-data-merger` | host Codex app-server Goal observation | `0.0`, `official_verifier_solution_failure` | Current app-server Goal route reached official closeout and wrote compact result. Treat this as a current-route baseline observation for a historical pass/control case, not a setup blocker or paired treatment claim. The next useful signal is phase attribution or a matched treatment/alternate pass-control comparison. |
+| `terminal-bench@2.0` | `nginx-request-logging` | host Codex app-server Goal observation | `1.0`, official pass | Current app-server Goal route reached official closeout and passed without recording raw transcript. This is the route sanity control for the batch: app-server Goal can complete at least one Terminal-Bench pass/control case, so the `multi-source-data-merger` zero should be treated as case- or phase-specific until compared. |
+| `skillsbench@1.1` | `react-performance-debugging` | native app-server Goal baseline | `0.0`, `skillsbench_runner_error` | Native worker connection was observed, but the public trace shows no worker trace directory, no turn-start, and no turn-complete evidence. This is route/runner evidence, not solver-quality baseline evidence; the next engineering question is why the host worker connects but does not materialize public worker turn trace. |
 | `skillsbench@1.1` | `llm-prefix-cache-replay` | BenchFlow ACP blind-loop baseline/treatment | `0.0/0.0`, `paired_no_score_uplift` | Runner and verifier reached official score after runtime-layer refactor, but this is not native app-server Goal evidence. Treat it as setup/verifier progress and weak-policy no-uplift evidence. |
 | `skillsbench@1.1` | `tictoc-unnecessary-abort-detection` | BenchFlow ACP blind-loop baseline/treatment | `0.0/0.0`, `paired_no_score_uplift` | Setup/prewarm no longer blocks the case. It is currently a stability canary, not a proof that Goal Harness improves SkillsBench task outcome. |
 | `swe-marathon` | `find-network-alignments` | Harbor host Codex app-server Goal | `0.0`, `official_verifier_solution_failure` | First native Goal SWE-Marathon cloud closeout. Harbor reached environment operation, agent execution, verifier, and job closeout; the next missing signal is whether the zero came from timeout/incomplete edit or wrong solution. |
@@ -54,12 +57,15 @@ next case" or "which phase failed".
 ## Cross-Case Findings
 
 1. Terminal-Bench and SWE-Marathon are now real app-server Goal baseline
-   closeouts. SWE-Marathon has two zero-score native Goal closeouts, and
-   `rust-c-compiler` r2 proves the earlier setup blocker is no longer the
-   current bottleneck.
-2. SkillsBench still lacks a native app-server Goal worker. Its latest rows
-   prove runner/verifier readiness but should not be over-claimed as Codex
-   Goal baseline evidence.
+   closeouts. Terminal-Bench has a current-route pass control
+   (`nginx-request-logging`) and a current-route zero
+   (`multi-source-data-merger`), while SWE-Marathon has two zero-score native
+   Goal closeouts; `rust-c-compiler` r2 proves the earlier setup blocker is no
+   longer the current bottleneck.
+2. SkillsBench has moved from "native worker missing" to "native worker
+   connects but does not materialize public worker turn trace". Its ACP rows
+   still prove runner/verifier readiness, while the native row remains
+   route/runner evidence rather than solver-quality evidence.
 3. `official_verifier_solution_failure` is too broad for ongoing debugging.
    It should eventually split into public-safe sublabels such as
    `official_verifier_completed_zero_score`,
@@ -74,8 +80,9 @@ next case" or "which phase failed".
 - Terminal-Bench: can the reducer expose public-safe app-server/agent phase
   counters, especially timeout versus complete-but-wrong, without copying raw
   trial fields?
-- SkillsBench: should the next implementation slice be a native app-server
-  Goal worker instead of more ACP blind-loop repeats?
+- SkillsBench: why does the native app-server Goal worker connect but fail to
+  materialize a public worker trace directory and turn-start/turn-complete
+  counters?
 - SWE-Marathon: can Harbor expose compact edit/test/verify phase counters so
   `official_verifier_solution_failure` is not the only post-closeout label?
 - Goal Harness: should active-case status and run ledger both link to this
@@ -99,5 +106,6 @@ only, following `goal_harness/benchmark_trajectory.py`.
 
 The follow-up failure-attribution layer narrows these rows into concrete
 obligations: Terminal-Bench and SWE-Marathon need public-safe solution-phase
-counters, while SkillsBench should stop repeating ACP blind-loop pairs as the
-primary Goal evidence and implement a native app-server Goal worker.
+counters, while SkillsBench should repair native worker public trace
+materialization before using more native app-server Goal rows as quality
+baselines.

--- a/examples/benchmark-closeout-failure-attribution-smoke.py
+++ b/examples/benchmark-closeout-failure-attribution-smoke.py
@@ -63,7 +63,11 @@ def main() -> None:
     }
     expected = {
         ("terminal-bench@2.0", "build-cython-ext"),
+        ("terminal-bench@2.0", "multi-source-data-merger"),
+        ("terminal-bench@2.0", "nginx-request-logging"),
         ("swe-marathon", "find-network-alignments"),
+        ("swe-marathon", "rust-c-compiler"),
+        ("skillsbench@1.1", "react-performance-debugging"),
         ("skillsbench@1.1", "llm-prefix-cache-replay"),
         ("skillsbench@1.1", "tictoc-unnecessary-abort-detection"),
     }
@@ -84,6 +88,30 @@ def main() -> None:
         == "official_zero_native_goal_first_closeout_needs_solution_phase_counters"
     )
 
+    terminal_pass = cases[("terminal-bench@2.0", "nginx-request-logging")]
+    assert terminal_pass["native_codex_goal_evidence"] is True
+    assert terminal_pass["official_passed"] is True
+    assert (
+        terminal_pass["refined_attribution"]
+        == "native_goal_route_sanity_pass_current_protocol_control"
+    )
+
+    terminal_zero = cases[("terminal-bench@2.0", "multi-source-data-merger")]
+    assert terminal_zero["native_codex_goal_evidence"] is True
+    assert terminal_zero["official_passed"] is False
+    assert (
+        terminal_zero["refined_attribution"]
+        == "official_zero_current_app_server_goal_baseline_needs_phase_or_treatment_comparison"
+    )
+
+    skills_native = cases[("skillsbench@1.1", "react-performance-debugging")]
+    assert skills_native["native_codex_goal_evidence"] is True
+    assert skills_native["ledger_failure_class"] == "skillsbench_runner_error"
+    assert (
+        skills_native["refined_attribution"]
+        == "native_goal_worker_connected_trace_dir_missing_not_solver_quality_evidence"
+    )
+
     for key in [
         ("skillsbench@1.1", "llm-prefix-cache-replay"),
         ("skillsbench@1.1", "tictoc-unnecessary-abort-detection"),
@@ -97,7 +125,7 @@ def main() -> None:
         assert "native SkillsBench app-server Goal worker" in case["next_obligation"]
 
     decisions = {entry["route"]: entry for entry in payload["route_decisions"]}
-    assert decisions["skillsbench"]["decision"] == "build_native_app_server_goal_worker"
+    assert decisions["skillsbench"]["decision"] == "repair_native_app_server_goal_worker_trace"
 
     rendered = json.dumps(payload, sort_keys=True) + "\n" + ATTRIBUTION_MD.read_text(
         encoding="utf-8"

--- a/examples/benchmark-goal-rollout-debug-smoke.py
+++ b/examples/benchmark-goal-rollout-debug-smoke.py
@@ -55,6 +55,9 @@ def main() -> None:
         for case in payload["case_rollouts"]
     }
     assert ("terminal-bench@2.0", "build-cython-ext") in cases, cases
+    assert ("terminal-bench@2.0", "multi-source-data-merger") in cases, cases
+    assert ("terminal-bench@2.0", "nginx-request-logging") in cases, cases
+    assert ("skillsbench@1.1", "react-performance-debugging") in cases, cases
     assert ("skillsbench@1.1", "llm-prefix-cache-replay") in cases, cases
     assert ("skillsbench@1.1", "tictoc-unnecessary-abort-detection") in cases, cases
     assert ("swe-marathon", "find-network-alignments") in cases, cases
@@ -65,6 +68,18 @@ def main() -> None:
     assert cases[("swe-marathon", "find-network-alignments")][
         "native_codex_goal_evidence"
     ] is True
+    assert cases[("terminal-bench@2.0", "nginx-request-logging")][
+        "official_passed"
+    ] is True
+    assert cases[("terminal-bench@2.0", "multi-source-data-merger")][
+        "failure_class"
+    ] == "official_verifier_solution_failure"
+    assert cases[("skillsbench@1.1", "react-performance-debugging")][
+        "native_codex_goal_evidence"
+    ] is True
+    assert cases[("skillsbench@1.1", "react-performance-debugging")][
+        "failure_scope"
+    ] == "runner_or_route"
     assert cases[("skillsbench@1.1", "llm-prefix-cache-replay")][
         "native_codex_goal_evidence"
     ] is False


### PR DESCRIPTION
## Summary
- Add public-safe rollout/failure-attribution rows for Terminal-Bench multi-source-data-merger and nginx-request-logging closeouts.
- Add SkillsBench react-performance-debugging native app-server Goal trace blocker attribution.
- Update focused smokes for the new closeout/trace semantics.

## Validation
- python3 examples/benchmark-closeout-failure-attribution-smoke.py
- python3 examples/benchmark-goal-rollout-debug-smoke.py
- python3 -m json.tool docs/research/long-horizon-agent-benchmarks/benchmark-closeout-failure-attribution-20260620.json
- python3 -m json.tool docs/research/long-horizon-agent-benchmarks/benchmark-goal-rollout-debug-20260620.json
- git diff --check
- goal-harness check --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-closeout-failure-attribution-20260620.md --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-closeout-failure-attribution-20260620.json --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-goal-rollout-debug-20260620.md --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-goal-rollout-debug-20260620.json --scan-path examples/benchmark-closeout-failure-attribution-smoke.py --scan-path examples/benchmark-goal-rollout-debug-smoke.py

Note: goal-harness check reports the existing duplicate-index warning for goal-harness-meta; public boundary scan is clean.