### PR TITLE
feat: gate Codex CLI scheduler on runtime idle

### DIFF
--- a/docs/product/codex-cli-tui-loop.md
+++ b/docs/product/codex-cli-tui-loop.md
@@ -185,8 +185,15 @@ goal-harness codex-cli-local-scheduler-exec --project . --goal-id <goal-id> --ag
 ```
 
 Without explicit execution flags, this command is still a no-execution packet.
-With `--guard-checked`, a local scheduler may choose exactly one opt-in side
-effect:
+For a later visible Codex CLI turn, it must also receive public-safe runtime
+idle evidence through `--observe-local-runtime ...` or `--idle-fixture
+<public-runtime-idle.json>`. A visible-session proof says the route is visible
+and interruptible; the runtime-idle detector says this exact later turn is not
+racing human typing or an already-running Codex turn. Missing runtime-idle
+evidence produces a precise blocker instead of a candidate command.
+
+With runtime-idle evidence and `--guard-checked`, a local scheduler may choose
+exactly one opt-in side effect:
 
 - `--execute-candidate --candidate-command-prefix <prefix>`: run a proven
   visible or explicit fallback candidate whose command starts with an allowed
@@ -370,11 +377,13 @@ projects runnable candidates; it should not over-specify the model's local plan.
    `goal-harness codex-cli-local-scheduler-tick` as the first executor-facing
    one-shot packet. It emits either an external command candidate or a precise
    blocker writeback command, but does not run Codex, read session files, or
-   write Goal Harness state itself.
+   write Goal Harness state itself. Visible candidates require both
+   visible-session proof and runtime-idle detector approval; headless fallback
+   remains explicit opt-in.
 11. **Local scheduler executor wrapper**: add
    `goal-harness codex-cli-local-scheduler-exec` as the explicit opt-in bridge
-   that can run one tick result only after guard confirmation and, for
-   candidates, an allowed command prefix.
+   that can run one tick result only after guard confirmation, runtime-idle
+   approval for visible candidates, and an allowed command prefix.
 12. **Visible local driver pilot**: ship
    `goal-harness codex-cli-visible-local-driver-pilot` to bind the one-message
    TUI start, scheduler executor, visible proof, idle guard, and no-transcript

--- a/examples/codex-cli-local-scheduler-exec-smoke.py
+++ b/examples/codex-cli-local-scheduler-exec-smoke.py
@@ -18,6 +18,7 @@ if str(REPO_ROOT) not in sys.path:
 from goal_harness.codex_cli_probe import (  # noqa: E402
     build_codex_cli_local_scheduler_executor,
     classify_codex_cli_session_surface,
+    execute_codex_cli_local_scheduler_tick_result,
 )
 
 
@@ -76,6 +77,28 @@ VISIBLE_PROOF_FIXTURE = {
 }
 
 
+RUNTIME_IDLE_FIXTURE = {
+    "observed_surface": "visible_resume_prompt",
+    "idle_guard": {
+        "no_active_human_typing": True,
+        "no_running_turn": True,
+        "checked_before_prompt": True,
+    },
+    "turn_visibility": {"visible_to_user": True},
+    "interruptibility": {
+        "user_can_interrupt": True,
+        "manual_takeover_available": True,
+    },
+    "boundary": {
+        "reads_raw_transcripts": False,
+        "reads_session_files": False,
+        "reads_stdout_stderr": False,
+        "reads_credentials": False,
+        "mutates_hidden_session_state": False,
+    },
+}
+
+
 def fake_runner_calls() -> tuple[list[dict[str, object]], object]:
     calls: list[dict[str, object]] = []
 
@@ -100,6 +123,7 @@ def fake_runner_calls() -> tuple[list[dict[str, object]], object]:
 def build_exec(
     *,
     proof_payload: dict[str, object] | None = VISIBLE_PROOF_FIXTURE,
+    idle_payload: dict[str, object] | None = RUNTIME_IDLE_FIXTURE,
     execute_candidate: bool = False,
     execute_blocker_writeback: bool = False,
     guard_checked: bool = False,
@@ -114,6 +138,7 @@ def build_exec(
         codex_bin="codex",
         probe_payload=classify_codex_cli_session_surface(command_outputs=REMOTE_RESUME_HELP_FIXTURE),
         proof_payload=proof_payload,
+        idle_payload=idle_payload,
         execute_candidate=execute_candidate,
         execute_blocker_writeback=execute_blocker_writeback,
         guard_checked=guard_checked,
@@ -129,6 +154,7 @@ def assert_executor_boundary(payload: dict[str, object]) -> None:
     assert boundary["requires_explicit_execute_flag"] is True, payload
     assert boundary["requires_fresh_quota_guard_confirmation"] is True, payload
     assert boundary["candidate_prefix_required"] is True, payload
+    assert boundary["runtime_idle_detector_required_for_visible_candidate"] is True, payload
     assert boundary["reads_raw_transcripts"] is False, payload
     assert boundary["reads_credentials"] is False, payload
     assert boundary["reads_session_files"] is False, payload
@@ -165,6 +191,46 @@ def main() -> int:
         runner=runner,
     )
     assert guard_missing["execution"]["reason"] == "fresh_quota_guard_confirmation_required", guard_missing
+    assert calls == [], calls
+
+    idle_missing = build_exec(
+        idle_payload=None,
+        execute_candidate=True,
+        guard_checked=True,
+        prefixes=[sys.executable],
+        runner=runner,
+    )
+    assert idle_missing["scheduler_action"] == "write_precise_blocker", idle_missing
+    assert idle_missing["scheduler_tick"]["precise_blocker"]["reason"] == "runtime_idle_evidence_missing", idle_missing
+    assert idle_missing["execution"]["reason"] == "scheduler_action_not_candidate", idle_missing
+    assert calls == [], calls
+
+    tampered_tick = {
+        "schema_version": "codex_cli_local_scheduler_tick_v0",
+        "project": str(PROJECT),
+        "goal_id": GOAL_ID,
+        "agent_id": AGENT_ID,
+        "cli_bin": "goal-harness",
+        "codex_bin": "codex",
+        "scheduler_phase": "tick_packet_no_execution",
+        "scheduler_action": "external_visible_command_candidate",
+        "decision": "visible_session_turn_candidate",
+        "next_safe_step": "tampered visible candidate",
+        "candidate_command": f"{shlex.quote(sys.executable)} -c 'pass'",
+        "commands": {"scheduler_tick": "goal-harness codex-cli-local-scheduler-tick"},
+        "visible_driver_run_packet": {
+            "visible_session_proof": {"supplied": True, "approved": True}
+        },
+        "runtime_idle_detector": {"supplied": False, "approved": False},
+    }
+    tampered_reject = execute_codex_cli_local_scheduler_tick_result(
+        tampered_tick,
+        execute_candidate=True,
+        guard_checked=True,
+        candidate_command_prefixes=[sys.executable],
+        runner=runner,
+    )
+    assert tampered_reject["execution"]["reason"] == "runtime_idle_detector_required", tampered_reject
     assert calls == [], calls
 
     prefix_missing = build_exec(
@@ -216,6 +282,8 @@ def main() -> int:
         help_fixture.write_text(json.dumps({"command_outputs": REMOTE_RESUME_HELP_FIXTURE}))
         proof_fixture = tmp_path / "visible-proof.json"
         proof_fixture.write_text(json.dumps(VISIBLE_PROOF_FIXTURE))
+        idle_fixture = tmp_path / "runtime-idle.json"
+        idle_fixture.write_text(json.dumps(RUNTIME_IDLE_FIXTURE))
         missing_registry = tmp_path / "missing-registry.json"
         runtime_root = tmp_path / "runtime"
 
@@ -256,6 +324,8 @@ def main() -> int:
                 str(help_fixture),
                 "--proof-fixture",
                 str(proof_fixture),
+                "--idle-fixture",
+                str(idle_fixture),
                 "--execute-candidate",
                 "--guard-checked",
                 "--candidate-command-prefix",

--- a/examples/codex-cli-local-scheduler-tick-smoke.py
+++ b/examples/codex-cli-local-scheduler-tick-smoke.py
@@ -88,6 +88,28 @@ VISIBLE_PROOF_FIXTURE = {
 }
 
 
+RUNTIME_IDLE_FIXTURE = {
+    "observed_surface": "visible_resume_prompt",
+    "idle_guard": {
+        "no_active_human_typing": True,
+        "no_running_turn": True,
+        "checked_before_prompt": True,
+    },
+    "turn_visibility": {"visible_to_user": True},
+    "interruptibility": {
+        "user_can_interrupt": True,
+        "manual_takeover_available": True,
+    },
+    "boundary": {
+        "reads_raw_transcripts": False,
+        "reads_session_files": False,
+        "reads_stdout_stderr": False,
+        "reads_credentials": False,
+        "mutates_hidden_session_state": False,
+    },
+}
+
+
 def assert_boundary(payload: dict[str, object]) -> None:
     assert payload["ok"] is True, payload
     assert payload["schema_version"] == "codex_cli_local_scheduler_tick_v0", payload
@@ -101,12 +123,14 @@ def assert_boundary(payload: dict[str, object]) -> None:
     assert boundary["mutates_codex_session"] is False, payload
     assert boundary["spends_goal_harness_quota"] is False, payload
     assert boundary["writes_goal_harness_state"] is False, payload
+    assert boundary["visible_candidate_requires_runtime_idle_detector"] is True, payload
 
 
 def build_tick(
     command_outputs: dict[str, str],
     *,
     proof_payload: dict[str, object] | None = None,
+    idle_payload: dict[str, object] | None = None,
     allow_headless_fallback: bool = False,
 ) -> dict[str, object]:
     return build_codex_cli_local_scheduler_tick(
@@ -117,6 +141,7 @@ def build_tick(
         codex_bin="codex",
         probe_payload=classify_codex_cli_session_surface(command_outputs=command_outputs),
         proof_payload=proof_payload,
+        idle_payload=idle_payload,
         allow_headless_fallback=allow_headless_fallback,
     )
 
@@ -151,10 +176,22 @@ def main() -> int:
     assert "codex-cli-exec-handoff" in fallback_candidate["candidate_command"], fallback_candidate
     assert fallback_candidate["blocker_writeback_command"] is None, fallback_candidate
 
-    visible_candidate = build_tick(REMOTE_RESUME_HELP_FIXTURE, proof_payload=VISIBLE_PROOF_FIXTURE)
+    visible_idle_missing = build_tick(REMOTE_RESUME_HELP_FIXTURE, proof_payload=VISIBLE_PROOF_FIXTURE)
+    assert_boundary(visible_idle_missing)
+    assert visible_idle_missing["scheduler_action"] == "write_precise_blocker", visible_idle_missing
+    assert visible_idle_missing["precise_blocker"]["reason"] == "runtime_idle_evidence_missing", visible_idle_missing
+    assert visible_idle_missing["runtime_idle_detector"]["approved"] is False, visible_idle_missing
+    assert visible_idle_missing["candidate_command"] is None, visible_idle_missing
+
+    visible_candidate = build_tick(
+        REMOTE_RESUME_HELP_FIXTURE,
+        proof_payload=VISIBLE_PROOF_FIXTURE,
+        idle_payload=RUNTIME_IDLE_FIXTURE,
+    )
     assert_boundary(visible_candidate)
     assert visible_candidate["scheduler_action"] == "external_visible_command_candidate", visible_candidate
     assert "codex resume public-session-id" in visible_candidate["candidate_command"], visible_candidate
+    assert visible_candidate["runtime_idle_detector"]["approved"] is True, visible_candidate
 
     with tempfile.TemporaryDirectory(prefix="goal-harness-codex-cli-scheduler-tick-") as tmp:
         tmp_path = Path(tmp)
@@ -162,6 +199,8 @@ def main() -> int:
         help_fixture.write_text(json.dumps({"command_outputs": REMOTE_RESUME_HELP_FIXTURE}))
         proof_fixture = tmp_path / "visible-proof.json"
         proof_fixture.write_text(json.dumps(VISIBLE_PROOF_FIXTURE))
+        idle_fixture = tmp_path / "runtime-idle.json"
+        idle_fixture.write_text(json.dumps(RUNTIME_IDLE_FIXTURE))
         missing_registry = tmp_path / "missing-registry.json"
         runtime_root = tmp_path / "runtime"
 
@@ -205,7 +244,31 @@ def main() -> int:
             )
         )
         assert_boundary(cli_proof_json)
-        assert cli_proof_json["scheduler_action"] == "external_visible_command_candidate", cli_proof_json
+        assert cli_proof_json["scheduler_action"] == "write_precise_blocker", cli_proof_json
+        assert cli_proof_json["precise_blocker"]["reason"] == "runtime_idle_evidence_missing", cli_proof_json
+
+        cli_proof_idle_json = json.loads(
+            run_cli(
+                "--format",
+                "json",
+                "codex-cli-local-scheduler-tick",
+                "--project",
+                str(PROJECT),
+                "--goal-id",
+                GOAL_ID,
+                "--agent-id",
+                AGENT_ID,
+                "--fixture",
+                str(help_fixture),
+                "--proof-fixture",
+                str(proof_fixture),
+                "--idle-fixture",
+                str(idle_fixture),
+            )
+        )
+        assert_boundary(cli_proof_idle_json)
+        assert cli_proof_idle_json["scheduler_action"] == "external_visible_command_candidate", cli_proof_idle_json
+        assert cli_proof_idle_json["runtime_idle_detector"]["approved"] is True, cli_proof_idle_json
 
         cli_markdown = run_cli(
             "codex-cli-local-scheduler-tick",

--- a/examples/codex-cli-one-message-loop-pilot-smoke.py
+++ b/examples/codex-cli-one-message-loop-pilot-smoke.py
@@ -75,7 +75,32 @@ VISIBLE_PROOF_FIXTURE = {
 }
 
 
-def build_pilot(proof_payload: dict[str, object] | None = None) -> dict[str, object]:
+RUNTIME_IDLE_FIXTURE = {
+    "observed_surface": "visible_resume_prompt",
+    "idle_guard": {
+        "no_active_human_typing": True,
+        "no_running_turn": True,
+        "checked_before_prompt": True,
+    },
+    "turn_visibility": {"visible_to_user": True},
+    "interruptibility": {
+        "user_can_interrupt": True,
+        "manual_takeover_available": True,
+    },
+    "boundary": {
+        "reads_raw_transcripts": False,
+        "reads_session_files": False,
+        "reads_stdout_stderr": False,
+        "reads_credentials": False,
+        "mutates_hidden_session_state": False,
+    },
+}
+
+
+def build_pilot(
+    proof_payload: dict[str, object] | None = None,
+    idle_payload: dict[str, object] | None = None,
+) -> dict[str, object]:
     return build_codex_cli_one_message_loop_pilot(
         project=PROJECT,
         goal_id=GOAL_ID,
@@ -84,6 +109,7 @@ def build_pilot(proof_payload: dict[str, object] | None = None) -> dict[str, obj
         codex_bin="codex",
         probe_payload=classify_codex_cli_session_surface(command_outputs=REMOTE_RESUME_HELP_FIXTURE),
         proof_payload=proof_payload,
+        idle_payload=idle_payload,
     )
 
 
@@ -131,9 +157,15 @@ def main() -> int:
 
     with_proof = build_pilot(VISIBLE_PROOF_FIXTURE)
     assert_pilot_boundary(with_proof)
-    assert with_proof["pilot_decision"] == "first_message_then_candidate_available", with_proof
-    assert with_proof["automation_bridge"]["scheduler_action"] == "external_visible_command_candidate", with_proof
+    assert with_proof["pilot_decision"] == "first_message_then_runtime_idle_required", with_proof
+    assert with_proof["automation_bridge"]["scheduler_action"] == "write_precise_blocker", with_proof
     assert with_proof["scheduler_executor"]["execution"]["executed"] is False, with_proof
+
+    with_proof_and_idle = build_pilot(VISIBLE_PROOF_FIXTURE, RUNTIME_IDLE_FIXTURE)
+    assert_pilot_boundary(with_proof_and_idle)
+    assert with_proof_and_idle["pilot_decision"] == "first_message_then_candidate_available", with_proof_and_idle
+    assert with_proof_and_idle["automation_bridge"]["scheduler_action"] == "external_visible_command_candidate", with_proof_and_idle
+    assert with_proof_and_idle["scheduler_executor"]["scheduler_tick"]["runtime_idle_detector"]["approved"] is True, with_proof_and_idle
 
     with tempfile.TemporaryDirectory(prefix="goal-harness-codex-cli-one-message-") as tmp:
         tmp_path = Path(tmp)
@@ -141,6 +173,8 @@ def main() -> int:
         help_fixture.write_text(json.dumps({"command_outputs": REMOTE_RESUME_HELP_FIXTURE}))
         proof_fixture = tmp_path / "visible-proof.json"
         proof_fixture.write_text(json.dumps(VISIBLE_PROOF_FIXTURE))
+        idle_fixture = tmp_path / "runtime-idle.json"
+        idle_fixture.write_text(json.dumps(RUNTIME_IDLE_FIXTURE))
         missing_registry = tmp_path / "missing-registry.json"
         runtime_root = tmp_path / "runtime"
 
@@ -184,7 +218,29 @@ def main() -> int:
             )
         )
         assert_pilot_boundary(cli_proof_json)
-        assert cli_proof_json["pilot_decision"] == "first_message_then_candidate_available", cli_proof_json
+        assert cli_proof_json["pilot_decision"] == "first_message_then_runtime_idle_required", cli_proof_json
+
+        cli_proof_idle_json = json.loads(
+            run_cli(
+                "--format",
+                "json",
+                "codex-cli-one-message-loop-pilot",
+                "--project",
+                str(PROJECT),
+                "--goal-id",
+                GOAL_ID,
+                "--agent-id",
+                AGENT_ID,
+                "--fixture",
+                str(help_fixture),
+                "--proof-fixture",
+                str(proof_fixture),
+                "--idle-fixture",
+                str(idle_fixture),
+            )
+        )
+        assert_pilot_boundary(cli_proof_idle_json)
+        assert cli_proof_idle_json["pilot_decision"] == "first_message_then_candidate_available", cli_proof_idle_json
 
         cli_markdown = run_cli(
             "codex-cli-one-message-loop-pilot",

--- a/examples/codex-cli-visible-local-driver-pilot-smoke.py
+++ b/examples/codex-cli-visible-local-driver-pilot-smoke.py
@@ -172,7 +172,7 @@ def main() -> int:
     assert_pilot_boundary(with_proof)
     assert with_proof["loop_decision"] == "runtime_idle_detector_required", with_proof
     assert with_proof["next_driver_action"] == "capture_public_safe_runtime_idle_observation", with_proof
-    assert with_proof["scheduler_executor"]["scheduler_action"] == "external_visible_command_candidate", with_proof
+    assert with_proof["scheduler_executor"]["scheduler_action"] == "write_precise_blocker", with_proof
     assert with_proof["visible_session_proof"]["supplied"] is True, with_proof
     assert with_proof["visible_session_proof"]["approved"] is True, with_proof
     assert with_proof["runtime_idle_detector"]["supplied"] is False, with_proof

--- a/goal_harness/cli_commands/starter.py
+++ b/goal_harness/cli_commands/starter.py
@@ -61,6 +61,102 @@ PrintPayload = Callable[
 ]
 
 
+def _add_runtime_idle_observation_arguments(
+    parser: argparse.ArgumentParser,
+    *,
+    include_idle_fixture: bool = True,
+) -> None:
+    if include_idle_fixture:
+        parser.add_argument(
+            "--idle-fixture",
+            help="Optional public-safe runtime idle fixture. Without it, later visible turn candidates remain blocked.",
+        )
+    parser.add_argument(
+        "--observe-local-runtime",
+        action="store_true",
+        help="Build the idle packet from public-safe local observation fields instead of a JSON fixture.",
+    )
+    parser.add_argument(
+        "--observed-surface",
+        default="codex_cli_tui_visible_window",
+        choices=[
+            "codex_cli_tui_visible_window",
+            "remote_control_visible_prompt",
+            "same_tui_visible_attach",
+            "visible_resume_prompt",
+        ],
+        help="Visible Codex CLI surface observed by the local runtime check.",
+    )
+    parser.add_argument(
+        "--turn-state",
+        choices=["idle", "running", "unknown"],
+        default="unknown",
+        help="Public-safe visible turn state. Unknown or running fails closed.",
+    )
+    parser.add_argument(
+        "--human-input-idle-seconds",
+        type=float,
+        help="Public-safe observed seconds since last human input. Useful for tests or external sensors.",
+    )
+    parser.add_argument(
+        "--probe-human-input-idle",
+        action="store_true",
+        help="Probe the local platform for coarse human-input idle seconds when supported.",
+    )
+    parser.add_argument(
+        "--min-human-input-idle-seconds",
+        type=float,
+        default=DEFAULT_MIN_HUMAN_INPUT_IDLE_SECONDS,
+        help="Minimum idle seconds required to consider human typing inactive.",
+    )
+    parser.add_argument(
+        "--checked-before-prompt",
+        action="store_true",
+        help="Confirm this idle check ran before any later visible prompt.",
+    )
+    parser.add_argument(
+        "--visible-to-user",
+        action="store_true",
+        help="Confirm the target turn remains visible to the user.",
+    )
+    parser.add_argument(
+        "--user-can-interrupt",
+        action="store_true",
+        help="Confirm the user can interrupt the target turn.",
+    )
+    parser.add_argument(
+        "--manual-takeover-available",
+        action="store_true",
+        help="Confirm manual takeover remains available.",
+    )
+
+
+def _load_codex_cli_runtime_idle_payload(args: argparse.Namespace) -> dict[str, object] | None:
+    if args.idle_fixture and args.observe_local_runtime:
+        raise ValueError("Use either --idle-fixture or --observe-local-runtime, not both.")
+    if args.idle_fixture:
+        return load_codex_cli_runtime_idle_fixture(Path(args.idle_fixture).expanduser())
+    if not args.observe_local_runtime:
+        return None
+    probe_result = None
+    human_input_idle_seconds = args.human_input_idle_seconds
+    if args.probe_human_input_idle:
+        probe_result = probe_human_input_idle_seconds()
+        if probe_result.get("ok") is True:
+            human_input_idle_seconds = float(probe_result["human_input_idle_seconds"])
+    return build_codex_cli_runtime_idle_observation_payload(
+        observed_surface=args.observed_surface,
+        turn_state=args.turn_state,
+        human_input_idle_seconds=human_input_idle_seconds,
+        min_human_input_idle_seconds=args.min_human_input_idle_seconds,
+        checked_before_prompt=bool(args.checked_before_prompt),
+        visible_to_user=bool(args.visible_to_user),
+        user_can_interrupt=bool(args.user_can_interrupt),
+        manual_takeover_available=bool(args.manual_takeover_available),
+        probe_result=probe_result,
+    )
+
+
 def register_starter_commands(subparsers: argparse._SubParsersAction) -> None:
     prompt_parser = subparsers.add_parser(
         "new-project-prompt",
@@ -128,6 +224,7 @@ def register_starter_commands(subparsers: argparse._SubParsersAction) -> None:
         "--proof-fixture",
         help="Optional public-safe visible-session proof fixture. Without it, same-session automation remains blocked.",
     )
+    _add_runtime_idle_observation_arguments(codex_cli_one_message_loop_parser)
     codex_cli_one_message_loop_parser.add_argument(
         "--allow-headless-fallback",
         action="store_true",
@@ -171,6 +268,10 @@ def register_starter_commands(subparsers: argparse._SubParsersAction) -> None:
     codex_cli_visible_local_driver_parser.add_argument(
         "--idle-fixture",
         help="Optional public-safe runtime idle fixture. Without it, later visible turn candidates remain blocked.",
+    )
+    _add_runtime_idle_observation_arguments(
+        codex_cli_visible_local_driver_parser,
+        include_idle_fixture=False,
     )
     codex_cli_visible_local_driver_parser.add_argument(
         "--allow-headless-fallback",
@@ -334,6 +435,7 @@ def register_starter_commands(subparsers: argparse._SubParsersAction) -> None:
         "--proof-fixture",
         help="Optional public-safe visible-session proof fixture. Without it, same-session automation remains blocked.",
     )
+    _add_runtime_idle_observation_arguments(codex_cli_local_scheduler_tick_parser)
     codex_cli_local_scheduler_tick_parser.add_argument(
         "--allow-headless-fallback",
         action="store_true",
@@ -380,6 +482,7 @@ def register_starter_commands(subparsers: argparse._SubParsersAction) -> None:
         "--proof-fixture",
         help="Optional public-safe visible-session proof fixture. Without it, same-session automation remains blocked.",
     )
+    _add_runtime_idle_observation_arguments(codex_cli_local_scheduler_exec_parser)
     codex_cli_local_scheduler_exec_parser.add_argument(
         "--allow-headless-fallback",
         action="store_true",
@@ -590,6 +693,7 @@ def handle_codex_cli_one_message_loop_pilot_command(
         if args.proof_fixture
         else None
     )
+    idle_payload = _load_codex_cli_runtime_idle_payload(args)
     payload = build_codex_cli_one_message_loop_pilot(
         project=Path(args.project),
         goal_id=args.goal_id,
@@ -598,6 +702,7 @@ def handle_codex_cli_one_message_loop_pilot_command(
         codex_bin=args.codex_bin,
         probe_payload=probe_payload,
         proof_payload=proof_payload,
+        idle_payload=idle_payload,
         allow_headless_fallback=bool(args.allow_headless_fallback),
     )
     print_payload(payload, args.format, render_codex_cli_one_message_loop_pilot_markdown)
@@ -618,11 +723,7 @@ def handle_codex_cli_visible_local_driver_pilot_command(
         if args.proof_fixture
         else None
     )
-    idle_payload = (
-        load_codex_cli_runtime_idle_fixture(Path(args.idle_fixture).expanduser())
-        if args.idle_fixture
-        else None
-    )
+    idle_payload = _load_codex_cli_runtime_idle_payload(args)
     payload = build_codex_cli_visible_local_driver_pilot(
         project=Path(args.project),
         goal_id=args.goal_id,
@@ -735,6 +836,7 @@ def handle_codex_cli_local_scheduler_tick_command(
         if args.proof_fixture
         else None
     )
+    idle_payload = _load_codex_cli_runtime_idle_payload(args)
     payload = build_codex_cli_local_scheduler_tick(
         project=Path(args.project),
         goal_id=args.goal_id,
@@ -743,6 +845,7 @@ def handle_codex_cli_local_scheduler_tick_command(
         codex_bin=args.codex_bin,
         probe_payload=probe_payload,
         proof_payload=proof_payload,
+        idle_payload=idle_payload,
         allow_headless_fallback=bool(args.allow_headless_fallback),
     )
     print_payload(payload, args.format, render_codex_cli_local_scheduler_tick_markdown)
@@ -763,6 +866,7 @@ def handle_codex_cli_local_scheduler_exec_command(
         if args.proof_fixture
         else None
     )
+    idle_payload = _load_codex_cli_runtime_idle_payload(args)
     payload = build_codex_cli_local_scheduler_executor(
         project=Path(args.project),
         goal_id=args.goal_id,
@@ -771,6 +875,7 @@ def handle_codex_cli_local_scheduler_exec_command(
         codex_bin=args.codex_bin,
         probe_payload=probe_payload,
         proof_payload=proof_payload,
+        idle_payload=idle_payload,
         allow_headless_fallback=bool(args.allow_headless_fallback),
         execute_candidate=bool(args.execute_candidate),
         execute_blocker_writeback=bool(args.execute_blocker_writeback),
@@ -806,29 +911,7 @@ def handle_codex_cli_runtime_idle_detector_command(
     args: argparse.Namespace,
     print_payload: PrintPayload,
 ) -> int:
-    if args.idle_fixture and args.observe_local_runtime:
-        raise ValueError("Use either --idle-fixture or --observe-local-runtime, not both.")
-    idle_payload = None
-    if args.idle_fixture:
-        idle_payload = load_codex_cli_runtime_idle_fixture(Path(args.idle_fixture).expanduser())
-    elif args.observe_local_runtime:
-        probe_result = None
-        human_input_idle_seconds = args.human_input_idle_seconds
-        if args.probe_human_input_idle:
-            probe_result = probe_human_input_idle_seconds()
-            if probe_result.get("ok") is True:
-                human_input_idle_seconds = float(probe_result["human_input_idle_seconds"])
-        idle_payload = build_codex_cli_runtime_idle_observation_payload(
-            observed_surface=args.observed_surface,
-            turn_state=args.turn_state,
-            human_input_idle_seconds=human_input_idle_seconds,
-            min_human_input_idle_seconds=args.min_human_input_idle_seconds,
-            checked_before_prompt=bool(args.checked_before_prompt),
-            visible_to_user=bool(args.visible_to_user),
-            user_can_interrupt=bool(args.user_can_interrupt),
-            manual_takeover_available=bool(args.manual_takeover_available),
-            probe_result=probe_result,
-        )
+    idle_payload = _load_codex_cli_runtime_idle_payload(args)
     payload = build_codex_cli_runtime_idle_detector(
         project=Path(args.project),
         goal_id=args.goal_id,

--- a/goal_harness/codex_cli_probe.py
+++ b/goal_harness/codex_cli_probe.py
@@ -1083,6 +1083,7 @@ def build_codex_cli_local_scheduler_tick(
     codex_bin: str,
     probe_payload: dict[str, Any],
     proof_payload: dict[str, Any] | None = None,
+    idle_payload: dict[str, Any] | None = None,
     allow_headless_fallback: bool = False,
 ) -> dict[str, Any]:
     """Build a local scheduler tick packet without executing Codex.
@@ -1103,6 +1104,14 @@ def build_codex_cli_local_scheduler_tick(
         proof_payload=proof_payload,
         allow_headless_fallback=allow_headless_fallback,
     )
+    idle_detector = build_codex_cli_runtime_idle_detector(
+        project=project,
+        goal_id=goal_id,
+        agent_id=agent_id,
+        cli_bin=cli_bin,
+        idle_payload=idle_payload,
+    )
+    idle_approved = bool(idle_detector.get("approved_for_visible_later_turn") is True)
     resolved_project = str(run_packet["project"])
     resolved_goal_id = str(run_packet["goal_id"])
     decision = str(run_packet.get("decision") or "tui_bootstrap_only")
@@ -1115,16 +1124,55 @@ def build_codex_cli_local_scheduler_tick(
     visible_driver_run_command = (
         f"{_shell_arg(cli_bin)} codex-cli-visible-driver-run {common_args}"
     )
+    runtime_idle_detector_command = (
+        f"{_shell_arg(cli_bin)} codex-cli-runtime-idle-detector "
+        f"--project {_shell_arg(resolved_project)} --goal-id {_shell_arg(resolved_goal_id)}"
+        f"{agent_arg} --observe-local-runtime --observed-surface visible_resume_prompt "
+        "--turn-state idle --probe-human-input-idle --checked-before-prompt "
+        "--visible-to-user --user-can-interrupt --manual-takeover-available"
+    )
+    runtime_idle_fixture_command = (
+        f"{_shell_arg(cli_bin)} codex-cli-runtime-idle-detector "
+        f"--project {_shell_arg(resolved_project)} --goal-id {_shell_arg(resolved_goal_id)}"
+        f"{agent_arg} --idle-fixture <public-runtime-idle.json>"
+    )
     scheduler_tick_command = (
-        f"{_shell_arg(cli_bin)} codex-cli-local-scheduler-tick {common_args}"
+        f"{_shell_arg(cli_bin)} codex-cli-local-scheduler-tick {common_args} "
+        "--observe-local-runtime --observed-surface visible_resume_prompt "
+        "--turn-state idle --probe-human-input-idle --checked-before-prompt "
+        "--visible-to-user --user-can-interrupt --manual-takeover-available"
     )
 
     candidate_command = None
     precise_blocker: dict[str, str] | None = None
     if decision == "visible_session_turn_candidate":
-        scheduler_action = "external_visible_command_candidate"
-        candidate_command = run_packet.get("recommended_command")
-        next_safe_step = "external scheduler may run the visible command only after a fresh quota guard and idle guard"
+        if idle_approved:
+            scheduler_action = "external_visible_command_candidate"
+            candidate_command = run_packet.get("recommended_command")
+            next_safe_step = (
+                "external scheduler may run the visible command only after a fresh quota guard, "
+                "runtime idle observation, guard_checked, and an allowed command prefix"
+            )
+        else:
+            scheduler_action = "write_precise_blocker"
+            reason = (
+                "runtime_idle_evidence_missing"
+                if idle_payload is None
+                else "runtime_idle_detector_incomplete"
+            )
+            failures = idle_detector.get("failures") if isinstance(idle_detector.get("failures"), list) else []
+            precise_blocker = {
+                "reason": reason,
+                "message": (
+                    "Codex CLI visible automation is blocked until a public-safe runtime idle "
+                    "observation proves no active human typing, no running visible turn, user "
+                    f"visibility, and interruptibility. failures={failures}"
+                ),
+            }
+            next_safe_step = (
+                "capture a public-safe runtime idle observation, keep the one-message TUI path visible, "
+                "and do not run Codex from the scheduler"
+            )
     elif decision == "headless_fallback_command_ready":
         scheduler_action = "external_headless_fallback_candidate"
         candidate_command = run_packet.get("recommended_command")
@@ -1194,6 +1242,8 @@ def build_codex_cli_local_scheduler_tick(
         },
         "commands": {
             "visible_driver_run": visible_driver_run_command,
+            "runtime_idle_detector": runtime_idle_detector_command,
+            "runtime_idle_detector_fixture": runtime_idle_fixture_command,
             "scheduler_tick": scheduler_tick_command,
             "candidate_codex_command": candidate_command,
             "blocker_writeback": blocker_writeback_command,
@@ -1206,6 +1256,13 @@ def build_codex_cli_local_scheduler_tick(
             "allow_headless_fallback": run_packet.get("allow_headless_fallback"),
             "visible_session_proof": run_packet.get("visible_session_proof"),
         },
+        "runtime_idle_detector": {
+            "supplied": idle_payload is not None,
+            "approved": idle_approved,
+            "decision": idle_detector.get("decision"),
+            "failures": idle_detector.get("failures") or [],
+            "source": idle_detector.get("source"),
+        },
         "boundary": {
             "tick_packet_only": True,
             "runs_codex": False,
@@ -1216,6 +1273,8 @@ def build_codex_cli_local_scheduler_tick(
             "spends_goal_harness_quota": False,
             "writes_goal_harness_state": False,
             "blocker_writeback_requires_external_execution": True,
+            "visible_candidate_requires_runtime_idle_detector": True,
+            "headless_fallback_requires_runtime_idle_detector": False,
         },
         "warnings": list(run_packet.get("warnings") or []),
     }
@@ -1318,6 +1377,12 @@ def execute_codex_cli_local_scheduler_tick_result(
         blocker_writeback_command if isinstance(blocker_writeback_command, str) else None
     )
     commands = tick_payload.get("commands") if isinstance(tick_payload.get("commands"), dict) else {}
+    runtime_idle = (
+        tick_payload.get("runtime_idle_detector")
+        if isinstance(tick_payload.get("runtime_idle_detector"), dict)
+        else {}
+    )
+    runtime_idle_approved = bool(runtime_idle.get("approved") is True)
 
     execution: dict[str, Any] = {
         "attempted": False,
@@ -1340,6 +1405,8 @@ def execute_codex_cli_local_scheduler_tick_result(
             "external_headless_fallback_candidate",
         }:
             execution["reason"] = "scheduler_action_not_candidate"
+        elif scheduler_action == "external_visible_command_candidate" and not runtime_idle_approved:
+            execution["reason"] = "runtime_idle_detector_required"
         elif not candidate_command:
             execution["reason"] = "candidate_command_missing"
         elif not candidate_command_prefixes:
@@ -1396,6 +1463,7 @@ def execute_codex_cli_local_scheduler_tick_result(
             "guard_checked": guard_checked,
             "candidate_command_prefixes": candidate_command_prefixes,
             "executor_timeout_seconds": executor_timeout_seconds,
+            "runtime_idle_detector_required_for_visible_candidate": True,
         },
         "execution": execution,
         "commands": {
@@ -1414,12 +1482,14 @@ def execute_codex_cli_local_scheduler_tick_result(
                 if isinstance(tick_payload.get("visible_driver_run_packet"), dict)
                 else None
             ),
+            "runtime_idle_detector": runtime_idle,
         },
         "boundary": {
             "executor_wrapper": True,
             "requires_explicit_execute_flag": True,
             "requires_fresh_quota_guard_confirmation": True,
             "candidate_prefix_required": True,
+            "runtime_idle_detector_required_for_visible_candidate": True,
             "runs_external_candidate": executed and execution.get("kind") == "candidate_command",
             "runs_codex_candidate_possible": executed and execution.get("kind") == "candidate_command",
             "reads_raw_transcripts": False,
@@ -1444,6 +1514,7 @@ def build_codex_cli_local_scheduler_executor(
     codex_bin: str,
     probe_payload: dict[str, Any],
     proof_payload: dict[str, Any] | None = None,
+    idle_payload: dict[str, Any] | None = None,
     allow_headless_fallback: bool = False,
     execute_candidate: bool = False,
     execute_blocker_writeback: bool = False,
@@ -1460,6 +1531,7 @@ def build_codex_cli_local_scheduler_executor(
         codex_bin=codex_bin,
         probe_payload=probe_payload,
         proof_payload=proof_payload,
+        idle_payload=idle_payload,
         allow_headless_fallback=allow_headless_fallback,
     )
     return execute_codex_cli_local_scheduler_tick_result(
@@ -1482,6 +1554,7 @@ def build_codex_cli_one_message_loop_pilot(
     codex_bin: str,
     probe_payload: dict[str, Any],
     proof_payload: dict[str, Any] | None = None,
+    idle_payload: dict[str, Any] | None = None,
     allow_headless_fallback: bool = False,
 ) -> dict[str, Any]:
     """Compose the first-message TUI path with the safe scheduler bridge."""
@@ -1508,14 +1581,31 @@ def build_codex_cli_one_message_loop_pilot(
         codex_bin=codex_bin,
         probe_payload=probe_payload,
         proof_payload=proof_payload,
+        idle_payload=idle_payload,
         allow_headless_fallback=allow_headless_fallback,
         execute_candidate=False,
         execute_blocker_writeback=False,
     )
     scheduler_action = str(scheduler_executor.get("scheduler_action") or "")
+    scheduler_tick = (
+        scheduler_executor.get("scheduler_tick")
+        if isinstance(scheduler_executor.get("scheduler_tick"), dict)
+        else {}
+    )
+    scheduler_blocker = (
+        scheduler_tick.get("precise_blocker")
+        if isinstance(scheduler_tick.get("precise_blocker"), dict)
+        else {}
+    )
+    scheduler_blocker_reason = str(scheduler_blocker.get("reason") or "")
     if scheduler_action in {"external_visible_command_candidate", "external_headless_fallback_candidate"}:
         pilot_decision = "first_message_then_candidate_available"
         followup_mode = "local scheduler can show the candidate, but execution still requires guard and prefix opt-in"
+    elif scheduler_action == "write_precise_blocker" and scheduler_blocker_reason.startswith("runtime_idle_"):
+        pilot_decision = "first_message_then_runtime_idle_required"
+        followup_mode = (
+            "local scheduler must capture public-safe runtime idle observation before later visible automation"
+        )
     elif scheduler_action == "write_precise_blocker":
         pilot_decision = "first_message_then_visible_blocker_writeback"
         followup_mode = "local scheduler can write the precise blocker after explicit guard-checked opt-in"
@@ -1529,6 +1619,9 @@ def build_codex_cli_one_message_loop_pilot(
     )
     scheduler_exec_dry_run_command = (
         f"{_shell_arg(cli_bin)} codex-cli-local-scheduler-exec {common_args}"
+        " --observe-local-runtime --observed-surface visible_resume_prompt "
+        "--turn-state idle --probe-human-input-idle --checked-before-prompt "
+        "--visible-to-user --user-can-interrupt --manual-takeover-available"
         f"{' --allow-headless-fallback' if allow_headless_fallback else ''}"
     )
     candidate_execute_template = (
@@ -1627,6 +1720,7 @@ def build_codex_cli_visible_local_driver_pilot(
         codex_bin=codex_bin,
         probe_payload=probe_payload,
         proof_payload=proof_payload,
+        idle_payload=idle_payload,
         allow_headless_fallback=allow_headless_fallback,
     )
     scheduler_executor = (
@@ -1647,6 +1741,12 @@ def build_codex_cli_visible_local_driver_pilot(
     resolved_project = str(one_message["project"])
     resolved_goal_id = str(one_message["goal_id"])
     scheduler_action = str(scheduler_executor.get("scheduler_action") or "")
+    scheduler_blocker = (
+        scheduler_tick.get("precise_blocker")
+        if isinstance(scheduler_tick.get("precise_blocker"), dict)
+        else {}
+    )
+    scheduler_blocker_reason = str(scheduler_blocker.get("reason") or "")
     proof = (
         scheduler_tick.get("visible_session_proof")
         if isinstance(scheduler_tick.get("visible_session_proof"), dict)
@@ -1679,7 +1779,10 @@ def build_codex_cli_visible_local_driver_pilot(
     if proof_approved and scheduler_action == "external_visible_command_candidate" and idle_approved:
         loop_decision = "visible_candidate_ready_for_guarded_execution"
         next_driver_action = "run_scheduler_exec_candidate_after_fresh_guard_and_prefix"
-    elif proof_approved and scheduler_action == "external_visible_command_candidate":
+    elif proof_approved and (
+        scheduler_action == "external_visible_command_candidate"
+        or scheduler_blocker_reason.startswith("runtime_idle_")
+    ):
         loop_decision = "runtime_idle_detector_required"
         next_driver_action = "capture_public_safe_runtime_idle_observation"
     elif scheduler_action == "write_precise_blocker":
@@ -2020,6 +2123,11 @@ def render_codex_cli_local_scheduler_tick_markdown(payload: dict[str, Any]) -> s
     commands = payload.get("commands") if isinstance(payload.get("commands"), dict) else {}
     launchd = payload.get("launchd") if isinstance(payload.get("launchd"), dict) else {}
     blocker = payload.get("precise_blocker") if isinstance(payload.get("precise_blocker"), dict) else None
+    runtime_idle = (
+        payload.get("runtime_idle_detector")
+        if isinstance(payload.get("runtime_idle_detector"), dict)
+        else {}
+    )
     warnings = payload.get("warnings") if isinstance(payload.get("warnings"), list) else []
     warning_lines = "\n".join(f"- {warning}" for warning in warnings) if warnings else "- none"
     blocker_lines = "- none"
@@ -2036,6 +2144,8 @@ def render_codex_cli_local_scheduler_tick_markdown(payload: dict[str, Any]) -> s
 
 ```bash
 {commands.get("visible_driver_run")}
+{commands.get("runtime_idle_detector")}
+{commands.get("runtime_idle_detector_fixture")}
 {commands.get("scheduler_tick")}
 {commands.get("candidate_codex_command") or "# no Codex command candidate"}
 {commands.get("blocker_writeback") or "# no blocker writeback command"}
@@ -2044,6 +2154,13 @@ def render_codex_cli_local_scheduler_tick_markdown(payload: dict[str, Any]) -> s
 ## Precise Blocker
 
 {blocker_lines}
+
+## Runtime Idle Detector
+
+- supplied: `{runtime_idle.get("supplied")}`
+- approved: `{runtime_idle.get("approved")}`
+- decision: `{runtime_idle.get("decision")}`
+- failures: `{runtime_idle.get("failures")}`
 
 ## Launchd Shape
 
@@ -2061,6 +2178,7 @@ def render_codex_cli_local_scheduler_tick_markdown(payload: dict[str, Any]) -> s
 - mutates_codex_session: `{boundary.get("mutates_codex_session")}`
 - spends_goal_harness_quota: `{boundary.get("spends_goal_harness_quota")}`
 - writes_goal_harness_state: `{boundary.get("writes_goal_harness_state")}`
+- visible_candidate_requires_runtime_idle_detector: `{boundary.get("visible_candidate_requires_runtime_idle_detector")}`
 
 ## Warnings
 
@@ -2073,6 +2191,12 @@ def render_codex_cli_local_scheduler_executor_markdown(payload: dict[str, Any]) 
     commands = payload.get("commands") if isinstance(payload.get("commands"), dict) else {}
     execution = payload.get("execution") if isinstance(payload.get("execution"), dict) else {}
     request = payload.get("execution_request") if isinstance(payload.get("execution_request"), dict) else {}
+    scheduler_tick = payload.get("scheduler_tick") if isinstance(payload.get("scheduler_tick"), dict) else {}
+    runtime_idle = (
+        scheduler_tick.get("runtime_idle_detector")
+        if isinstance(scheduler_tick.get("runtime_idle_detector"), dict)
+        else {}
+    )
     warnings = payload.get("warnings") if isinstance(payload.get("warnings"), list) else []
     warning_lines = "\n".join(f"- {warning}" for warning in warnings) if warnings else "- none"
     return f"""# Codex CLI Local Scheduler Executor
@@ -2089,6 +2213,7 @@ def render_codex_cli_local_scheduler_executor_markdown(payload: dict[str, Any]) 
 - guard_checked: `{request.get("guard_checked")}`
 - candidate_command_prefixes: `{request.get("candidate_command_prefixes")}`
 - executor_timeout_seconds: `{request.get("executor_timeout_seconds")}`
+- runtime_idle_detector_required_for_visible_candidate: `{request.get("runtime_idle_detector_required_for_visible_candidate")}`
 
 ## Execution Result
 
@@ -2100,6 +2225,13 @@ def render_codex_cli_local_scheduler_executor_markdown(payload: dict[str, Any]) 
 - timed_out: `{execution.get("timed_out")}`
 - output_captured: `{execution.get("output_captured")}`
 - candidate_prefix_matched: `{execution.get("candidate_prefix_matched")}`
+
+## Runtime Idle Detector
+
+- supplied: `{runtime_idle.get("supplied")}`
+- approved: `{runtime_idle.get("approved")}`
+- decision: `{runtime_idle.get("decision")}`
+- failures: `{runtime_idle.get("failures")}`
 
 ## Commands
 
@@ -2115,6 +2247,7 @@ def render_codex_cli_local_scheduler_executor_markdown(payload: dict[str, Any]) 
 - requires_explicit_execute_flag: `{boundary.get("requires_explicit_execute_flag")}`
 - requires_fresh_quota_guard_confirmation: `{boundary.get("requires_fresh_quota_guard_confirmation")}`
 - candidate_prefix_required: `{boundary.get("candidate_prefix_required")}`
+- runtime_idle_detector_required_for_visible_candidate: `{boundary.get("runtime_idle_detector_required_for_visible_candidate")}`
 - runs_external_candidate: `{boundary.get("runs_external_candidate")}`
 - reads_raw_transcripts: `{boundary.get("reads_raw_transcripts")}`
 - reads_session_files: `{boundary.get("reads_session_files")}`


### PR DESCRIPTION
## Summary
- require runtime-idle detector approval before local scheduler tick emits visible Codex CLI candidates
- add executor-side fail-closed check for visible candidates even if a tick payload is malformed
- pass runtime-idle evidence through one-message and visible local-driver pilots, with CLI flags for fixture or local observation
- update Codex CLI TUI loop docs and durable smokes

## Validation
- python examples/codex-cli-local-scheduler-tick-smoke.py
- python examples/codex-cli-local-scheduler-exec-smoke.py
- python examples/codex-cli-one-message-loop-pilot-smoke.py
- python examples/codex-cli-visible-local-driver-pilot-smoke.py
- python examples/codex-cli-runtime-idle-detector-smoke.py
- python examples/codex-cli-visible-driver-run-smoke.py
- python examples/codex-cli-visible-session-proof-smoke.py
- python examples/codex-cli-session-probe-smoke.py
- python examples/codex-cli-local-driver-plan-smoke.py
- python examples/codex-cli-automation-driver-audit-smoke.py
- python examples/codex-cli-bootstrap-message-smoke.py
- python -m py_compile goal_harness/codex_cli_probe.py goal_harness/cli_commands/starter.py
- git diff --check HEAD~1..HEAD

## Boundary
- Public docs/code/smokes only
- No private state, credentials, raw transcripts, session files, or benchmark artifacts
- No Codex session mutation or Goal Harness quota spend from the scheduler packet