### PR TITLE
Record SkillsBench native worker lifecycle traces

### DIFF
--- a/docs/benchmark-developer-workflow.md
+++ b/docs/benchmark-developer-workflow.md
@@ -785,6 +785,18 @@ The compact worker JSON is safe to inspect for lifecycle debugging, but the
 response text file is private task execution material and must stay out of
 public docs, ledgers, rollout logs, and PRs.
 
+For the host-local ACP relay, materialize public trace as early as the relay
+lifecycle, not only after a completed worker turn. The relay should write
+compact `relay_lifecycle` traces for `initialize`, `session_new`, and
+`prompt_received` when `--worker-public-trace-dir` is configured. These traces
+are pure observation: they record stage names and boundary booleans only, never
+task text, ACP payloads, stdout/stderr, session ids, response text, or host
+paths. Reducers must not treat lifecycle-only traces as solver evidence. A
+status such as `worker_connected_no_prompt_trace` or
+`worker_prompt_received_no_turn_trace` remains a failed native-worker evidence
+check; it only narrows attribution from "trace directory missing" to "BenchFlow
+connected but did not reach a countable Goal worker turn."
+
 Use `--remote-command-file-bridge-ready` only after a public-safe bridge probe
 has passed. That flag updates only the plan's bridge readiness fields;
 `codex_app_server_goal_worker_runner_integration_ready` must remain `false`

--- a/examples/skillsbench-app-server-goal-worker-smoke.py
+++ b/examples/skillsbench-app-server-goal-worker-smoke.py
@@ -335,6 +335,75 @@ def test_acp_relay_delegates_to_app_server_goal_worker() -> None:
     assert probe["ready"] is True, probe
 
 
+def test_acp_relay_materializes_lifecycle_trace_before_prompt() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-app-goal-lifecycle-") as tmp:
+        root = Path(tmp)
+        work = root / "work"
+        trace_dir = root / "worker-traces"
+        work.mkdir()
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                str(REPO_ROOT / "scripts" / "skillsbench_local_acp_relay.py"),
+                "--app-server-goal-worker",
+                "--task-id",
+                "llm-prefix-cache-replay",
+                "--timeout-sec",
+                "5",
+                "--worker-public-trace-dir",
+                str(trace_dir),
+            ],
+            cwd=REPO_ROOT,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        assert proc.stdin is not None
+        assert proc.stdout is not None
+
+        def send(message: dict[str, Any]) -> None:
+            proc.stdin.write(json.dumps(message) + "\n")
+            proc.stdin.flush()
+
+        def read_response(request_id: int) -> dict[str, Any]:
+            while True:
+                line = proc.stdout.readline()
+                assert line, proc.stderr.read()
+                message = json.loads(line)
+                if message.get("id") == request_id and "method" not in message:
+                    return message
+
+        send({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}})
+        read_response(1)
+        send(
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "session/new",
+                "params": {"cwd": str(work), "mcpServers": []},
+            }
+        )
+        read_response(2)
+        trace_files = sorted(trace_dir.glob("*.compact.json"))
+        assert len(trace_files) >= 1, trace_files
+        lifecycle = [
+            json.loads(path.read_text(encoding="utf-8"))
+            for path in trace_files
+        ]
+        stages = {
+            item.get("relay", {}).get("stage")
+            for item in lifecycle
+            if item.get("trace_kind") == "relay_lifecycle"
+        }
+        assert {"initialize", "session_new"} <= stages, lifecycle
+        trace_text = json.dumps(lifecycle, sort_keys=True)
+        assert str(work) not in trace_text, lifecycle
+        assert "raw_prompt_recorded\": true" not in trace_text, lifecycle
+        proc.terminate()
+        proc.wait(timeout=2)
+
+
 def test_acp_relay_streams_public_keepalive_while_worker_runs() -> None:
     fake_worker = """#!/usr/bin/env python3
 import argparse
@@ -444,8 +513,16 @@ Path(args.output_json).write_text(json.dumps({"ok": True}), encoding="utf-8")
         assert final_response is not None
         assert final_response["result"]["stopReason"] == "end_turn"
         trace_files = sorted(trace_dir.glob("*.compact.json"))
-        assert len(trace_files) == 1, trace_files
-        trace = json.loads(trace_files[0].read_text(encoding="utf-8"))
+        assert len(trace_files) >= 1, trace_files
+        traces = [
+            json.loads(path.read_text(encoding="utf-8"))
+            for path in trace_files
+        ]
+        turn_traces = [
+            item for item in traces if item.get("trace_kind") != "relay_lifecycle"
+        ]
+        assert len(turn_traces) == 1, traces
+        trace = turn_traces[0]
         assert (
             trace["schema_version"]
             == "skillsbench_host_codex_goal_worker_public_trace_v0"
@@ -558,8 +635,16 @@ sys.exit(7)
         final_response = read_response(3)
         assert final_response["error"]["message"] == "host app-server goal worker failed"
         trace_files = sorted(trace_dir.glob("*.compact.json"))
-        assert len(trace_files) == 1, trace_files
-        trace = json.loads(trace_files[0].read_text(encoding="utf-8"))
+        assert len(trace_files) >= 1, trace_files
+        traces = [
+            json.loads(path.read_text(encoding="utf-8"))
+            for path in trace_files
+        ]
+        turn_traces = [
+            item for item in traces if item.get("trace_kind") != "relay_lifecycle"
+        ]
+        assert len(turn_traces) == 1, traces
+        trace = turn_traces[0]
         assert trace["ok"] is False, trace
         assert trace["turn"]["goal_get_present"] is True, trace
         assert trace["turn"]["turn_completed_observed"] is False, trace
@@ -640,6 +725,9 @@ if __name__ == "__main__":
     test_host_worker_contract_only_cli()
     test_host_worker_waits_for_completion_and_keeps_public_json_compact()
     test_acp_relay_delegates_to_app_server_goal_worker()
+    test_acp_relay_materializes_lifecycle_trace_before_prompt()
+    test_acp_relay_streams_public_keepalive_while_worker_runs()
+    test_acp_relay_preserves_public_worker_trace_on_worker_failure()
     test_full_run_fails_closed_until_bridge_is_materialized()
     test_full_run_with_bridge_ready_requires_host_acp_launch()
     test_launcher_patches_rollout_planes_connect_acp()

--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -3003,6 +3003,90 @@ def test_skillsbench_round_trace_records_best_round_score() -> None:
             == "worker_connected_trace_dir_missing"
         ), connected_no_trace_compact
 
+        lifecycle_trace_dir = root / "native-worker-lifecycle-traces"
+        lifecycle_trace_dir.mkdir()
+        write_json(
+            lifecycle_trace_dir / "worker-lifecycle.compact.json",
+            {
+                "schema_version": "skillsbench_host_codex_goal_worker_public_trace_v0",
+                "ok": False,
+                "route": "codex-app-server-goal-baseline",
+                "trace_kind": "relay_lifecycle",
+                "benchmark_id": "skillsbench@1.1",
+                "task_id": "llm-prefix-cache-replay",
+                "relay": {
+                    "schema_version": "skillsbench_app_server_goal_worker_lifecycle_trace_v0",
+                    "stage": "session_new",
+                    "app_server_goal_worker": True,
+                    "worker_public_trace_configured": True,
+                    "raw_prompt_recorded": False,
+                    "raw_stdout_recorded": False,
+                    "raw_stderr_recorded": False,
+                    "host_paths_recorded": False,
+                },
+                "turn": {
+                    "thread_id_present": False,
+                    "goal_get_present": False,
+                    "turn_id_present": False,
+                    "turn_completed_observed": False,
+                    "assistant_message_present": False,
+                    "raw_transcript_recorded": False,
+                    "raw_assistant_message_recorded": False,
+                },
+                "boundary": {
+                    "raw_task_text_recorded": False,
+                    "raw_logs_recorded": False,
+                    "raw_trajectory_recorded": False,
+                    "credential_values_recorded": False,
+                    "host_paths_recorded": False,
+                },
+            },
+        )
+        connected_lifecycle_trace = {
+            "schema_version": "skillsbench_goal_harness_controller_trace_v0",
+            "route": "codex-app-server-goal-baseline",
+            "trace_publicness": "public_counts_only_no_task_text_no_verifier_output",
+            "native_goal_worker_route": True,
+            "native_goal_worker_connected": True,
+            "native_goal_worker_connect_count": 1,
+            "raw_task_text_recorded": False,
+            "raw_verifier_output_recorded": False,
+            "raw_agent_trajectory_recorded": False,
+        }
+        _merge_app_server_goal_worker_trace_summary(
+            {
+                "route": "codex-app-server-goal-baseline",
+                "app_server_goal_worker_trace_dir": str(lifecycle_trace_dir),
+            },
+            connected_lifecycle_trace,
+        )
+        lifecycle_trace_compact = compact_benchmark_run(
+            build_skillsbench_benchflow_result_benchmark_run(
+                write_official_skillsbench_result(
+                    root / "native-connected-lifecycle-trace",
+                    reward=0.0,
+                    task_id="llm-prefix-cache-replay",
+                ),
+                route="codex-app-server-goal-baseline",
+                controller_trace=connected_lifecycle_trace,
+            )
+        )
+        assert lifecycle_trace_compact is not None
+        lifecycle_validation = lifecycle_trace_compact["validation"]
+        assert lifecycle_validation["failed_checks"] == [
+            "native_goal_worker_public_trace_missing"
+        ], lifecycle_trace_compact
+        assert lifecycle_validation["native_goal_worker_trace_observed"] is True, lifecycle_trace_compact
+        assert lifecycle_validation["native_goal_worker_trace_count"] == 1, lifecycle_trace_compact
+        assert lifecycle_validation["native_goal_worker_lifecycle_trace_count"] == 1, lifecycle_trace_compact
+        assert (
+            lifecycle_validation["native_goal_worker_trace_status"]
+            == "worker_connected_no_prompt_trace"
+        ), lifecycle_trace_compact
+        lifecycle_counters = lifecycle_trace_compact["interaction_counters"]
+        assert lifecycle_counters["native_goal_worker_lifecycle_trace_count"] == 1, lifecycle_trace_compact
+        assert lifecycle_counters["native_goal_worker_turn_start_count"] == 0, lifecycle_trace_compact
+
         empty_worker_trace_dir = root / "native-worker-empty-traces"
         empty_worker_trace_dir.mkdir()
         connected_empty_trace_dir = {

--- a/goal_harness/benchmark_adapters/skillsbench.py
+++ b/goal_harness/benchmark_adapters/skillsbench.py
@@ -1820,6 +1820,12 @@ def _skillsbench_controller_trace_counters(
         is True,
         "native_goal_worker_connect_count": count("native_goal_worker_connect_count"),
         "native_goal_worker_trace_count": count("native_goal_worker_trace_count"),
+        "native_goal_worker_lifecycle_trace_count": count(
+            "native_goal_worker_lifecycle_trace_count"
+        ),
+        "native_goal_worker_prompt_received_count": count(
+            "native_goal_worker_prompt_received_count"
+        ),
         "native_goal_worker_ok_count": count("native_goal_worker_ok_count"),
         "native_goal_worker_goal_get_count": count("native_goal_worker_goal_get_count"),
         "native_goal_worker_turn_start_count": count(
@@ -1925,7 +1931,35 @@ def _skillsbench_native_goal_worker_trace_status(
         and trace_count > 0
         and counters.get("native_goal_worker_public_trace_read") is True
     ):
-        return "public_trace_observed"
+        turn_start_count = counters.get("native_goal_worker_turn_start_count")
+        goal_get_count = counters.get("native_goal_worker_goal_get_count")
+        assistant_message_count = counters.get(
+            "native_goal_worker_assistant_message_present_count"
+        )
+        if any(
+            isinstance(value, int) and not isinstance(value, bool) and value > 0
+            for value in (turn_start_count, goal_get_count, assistant_message_count)
+        ):
+            return "public_trace_observed"
+        prompt_received_count = counters.get(
+            "native_goal_worker_prompt_received_count"
+        )
+        if (
+            isinstance(prompt_received_count, int)
+            and not isinstance(prompt_received_count, bool)
+            and prompt_received_count > 0
+        ):
+            return "worker_prompt_received_no_turn_trace"
+        lifecycle_trace_count = counters.get(
+            "native_goal_worker_lifecycle_trace_count"
+        )
+        if (
+            isinstance(lifecycle_trace_count, int)
+            and not isinstance(lifecycle_trace_count, bool)
+            and lifecycle_trace_count > 0
+        ):
+            return "worker_connected_no_prompt_trace"
+        return "worker_connected_no_turn_trace"
     if counters.get("native_goal_worker_connected") is True:
         if counters.get("native_goal_worker_trace_dir_present") is not True:
             return "worker_connected_trace_dir_missing"
@@ -2561,6 +2595,12 @@ def build_skillsbench_benchflow_result_benchmark_run(
             "native_goal_worker_trace_count": controller_counters.get(
                 "native_goal_worker_trace_count", 0
             ),
+            "native_goal_worker_lifecycle_trace_count": controller_counters.get(
+                "native_goal_worker_lifecycle_trace_count", 0
+            ),
+            "native_goal_worker_prompt_received_count": controller_counters.get(
+                "native_goal_worker_prompt_received_count", 0
+            ),
             "native_goal_worker_ok_count": controller_counters.get(
                 "native_goal_worker_ok_count", 0
             ),
@@ -2659,6 +2699,12 @@ def build_skillsbench_benchflow_result_benchmark_run(
             ),
             "native_goal_worker_trace_observed": native_goal_worker_trace_observed,
             "native_goal_worker_trace_count": native_goal_worker_trace_count,
+            "native_goal_worker_lifecycle_trace_count": controller_counters.get(
+                "native_goal_worker_lifecycle_trace_count", 0
+            ),
+            "native_goal_worker_prompt_received_count": controller_counters.get(
+                "native_goal_worker_prompt_received_count", 0
+            ),
             "native_goal_worker_trace_status": native_goal_worker_trace_status,
         },
         "authorization": {

--- a/goal_harness/benchmark_adapters/skillsbench_acp_relay.py
+++ b/goal_harness/benchmark_adapters/skillsbench_acp_relay.py
@@ -86,6 +86,7 @@ class SkillsBenchLocalAcpRelay:
     def __init__(self, config: CodexExecConfig):
         self._config = config
         self._sessions: dict[str, dict[str, Any]] = {}
+        self._published_lifecycle_stages: set[str] = set()
 
     def serve(self, stdin: TextIO = sys.stdin, stdout: TextIO = sys.stdout) -> int:
         for line in stdin:
@@ -114,6 +115,7 @@ class SkillsBenchLocalAcpRelay:
                 return None
             return None
         if method == "initialize":
+            self._publish_worker_lifecycle_trace("initialize")
             return _json_rpc_result(
                 message_id,
                 {
@@ -140,6 +142,7 @@ class SkillsBenchLocalAcpRelay:
                 "model": None,
                 "cancelled": False,
             }
+            self._publish_worker_lifecycle_trace("session_new")
             return _json_rpc_result(message_id, {"sessionId": session_id})
         if method == "session/set_model":
             session = self._sessions.get(str(params.get("sessionId") or ""))
@@ -253,6 +256,7 @@ class SkillsBenchLocalAcpRelay:
         stdout: TextIO,
     ) -> str:
         cwd = _safe_cwd(session.get("cwd"), default=os.getcwd())
+        self._publish_worker_lifecycle_trace("prompt_received")
         with tempfile.TemporaryDirectory(prefix="gh-skillsbench-goal-worker-") as tmp:
             tmp_path = Path(tmp)
             prompt_path = tmp_path / "prompt.txt"
@@ -432,13 +436,87 @@ class SkillsBenchLocalAcpRelay:
                 ),
             ),
         }
-        trace_dir = Path(self._config.worker_public_trace_dir).expanduser()
-        trace_dir.mkdir(parents=True, exist_ok=True)
-        trace_path = trace_dir / f"worker-{uuid.uuid4().hex[:12]}.compact.json"
-        trace_path.write_text(
-            json.dumps(trace, indent=2, sort_keys=True) + "\n",
-            encoding="utf-8",
+        self._write_worker_public_trace(trace)
+
+    def _publish_worker_lifecycle_trace(self, stage: str) -> None:
+        """Record public-safe relay lifecycle evidence before any prompt runs."""
+
+        if (
+            not self._config.app_server_goal_worker
+            or not self._config.worker_public_trace_dir
+        ):
+            return
+        safe_stage = "".join(
+            ch if ch.isalnum() or ch == "_" else "_"
+            for ch in str(stage or "").strip().lower()
         )
+        if not safe_stage:
+            safe_stage = "unknown"
+        if safe_stage in self._published_lifecycle_stages:
+            return
+        self._published_lifecycle_stages.add(safe_stage)
+        trace = {
+            "schema_version": "skillsbench_host_codex_goal_worker_public_trace_v0",
+            "ok": False,
+            "route": "codex-app-server-goal-baseline",
+            "trace_kind": "relay_lifecycle",
+            "benchmark_id": self._config.dataset,
+            "task_id": self._config.task_id,
+            "relay": {
+                "schema_version": "skillsbench_app_server_goal_worker_lifecycle_trace_v0",
+                "stage": safe_stage,
+                "app_server_goal_worker": True,
+                "worker_public_trace_configured": True,
+                "raw_prompt_recorded": False,
+                "raw_stdout_recorded": False,
+                "raw_stderr_recorded": False,
+                "host_paths_recorded": False,
+            },
+            "worker_contract": {
+                "schema_version": "skillsbench_app_server_goal_worker_contract_v0",
+                "route": "codex-app-server-goal-baseline",
+                "ready": False,
+                "runner_integration_ready": True,
+                "first_blocker": "relay_lifecycle_only_no_worker_turn_yet",
+            },
+            "prompt": {"raw_recorded": False},
+            "turn": {
+                "thread_id_present": False,
+                "goal_get_present": False,
+                "turn_id_present": False,
+                "turn_completed_observed": False,
+                "assistant_message_present": False,
+                "raw_transcript_recorded": False,
+                "raw_assistant_message_recorded": False,
+            },
+            "private_response_text": {
+                "written": False,
+                "path_recorded": False,
+                "raw_recorded_in_public_json": False,
+            },
+            "boundary": {
+                "raw_task_text_recorded": False,
+                "raw_logs_recorded": False,
+                "raw_trajectory_recorded": False,
+                "credential_values_recorded": False,
+                "host_paths_recorded": False,
+            },
+        }
+        self._write_worker_public_trace(trace)
+
+    def _write_worker_public_trace(self, trace: dict[str, Any]) -> None:
+        if not self._config.worker_public_trace_dir:
+            return
+        try:
+            trace_dir = Path(self._config.worker_public_trace_dir).expanduser()
+            trace_dir.mkdir(parents=True, exist_ok=True)
+            trace_path = trace_dir / f"worker-{uuid.uuid4().hex[:12]}.compact.json"
+            trace_path.write_text(
+                json.dumps(trace, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+        except OSError:
+            return
 
     def _write_worker_heartbeat(
         self,

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -558,6 +558,8 @@ def _compact_benchmark_interaction_counters(value: Any) -> dict[str, Any]:
         "codex_runtime_goal_tool_trial_count",
         "native_goal_worker_connect_count",
         "native_goal_worker_trace_count",
+        "native_goal_worker_lifecycle_trace_count",
+        "native_goal_worker_prompt_received_count",
         "native_goal_worker_ok_count",
         "native_goal_worker_goal_get_count",
         "native_goal_worker_turn_start_count",
@@ -1946,6 +1948,8 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
         "required_worker_goal_harness_cli_call_total_min",
         "native_goal_worker_connect_count",
         "native_goal_worker_trace_count",
+        "native_goal_worker_lifecycle_trace_count",
+        "native_goal_worker_prompt_received_count",
         "native_goal_worker_ok_count",
         "native_goal_worker_goal_get_count",
         "native_goal_worker_turn_start_count",
@@ -2235,7 +2239,6 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
         ][:MAX_BENCHMARK_RUN_LIST_ITEMS]
         native_goal_worker_trace_missing = (
             validation.get("native_goal_worker_route") is True
-            and validation.get("native_goal_worker_trace_observed") is not True
             and public_safe_compact_text(
                 validation.get("native_goal_worker_trace_status"),
                 limit=140,
@@ -2243,6 +2246,9 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
             in {
                 "worker_connected_trace_dir_missing",
                 "worker_connected_no_public_trace",
+                "worker_connected_no_prompt_trace",
+                "worker_prompt_received_no_turn_trace",
+                "worker_connected_no_turn_trace",
                 "worker_route_selected_not_connected",
             }
         )
@@ -2272,7 +2278,11 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
             text = public_safe_compact_text(validation.get(field), limit=140)
             if text:
                 compact_validation[field] = text
-        for field in ("native_goal_worker_trace_count",):
+        for field in (
+            "native_goal_worker_trace_count",
+            "native_goal_worker_lifecycle_trace_count",
+            "native_goal_worker_prompt_received_count",
+        ):
             value = validation.get(field)
             if isinstance(value, int) and not isinstance(value, bool):
                 compact_validation[field] = value

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -2275,6 +2275,8 @@ def _merge_app_server_goal_worker_trace_summary(
     trace_dir = Path(raw_trace_dir)
     files = sorted(trace_dir.glob("*.compact.json")) if trace_dir.exists() else []
     worker_trace_count = 0
+    lifecycle_trace_count = 0
+    prompt_received_count = 0
     ok_count = 0
     goal_get_count = 0
     turn_start_count = 0
@@ -2294,6 +2296,11 @@ def _merge_app_server_goal_worker_trace_summary(
         ):
             continue
         worker_trace_count += 1
+        relay = payload.get("relay") if isinstance(payload.get("relay"), dict) else {}
+        if payload.get("trace_kind") == "relay_lifecycle":
+            lifecycle_trace_count += 1
+            if relay.get("stage") == "prompt_received":
+                prompt_received_count += 1
         if payload.get("ok") is True:
             ok_count += 1
         turn = payload.get("turn") if isinstance(payload.get("turn"), dict) else {}
@@ -2327,6 +2334,8 @@ def _merge_app_server_goal_worker_trace_summary(
     trace["native_goal_worker_route"] = plan.get("route") == "codex-app-server-goal-baseline"
     trace["native_goal_worker_trace_dir_present"] = trace_dir.exists()
     trace["native_goal_worker_trace_count"] = worker_trace_count
+    trace["native_goal_worker_lifecycle_trace_count"] = lifecycle_trace_count
+    trace["native_goal_worker_prompt_received_count"] = prompt_received_count
     trace["native_goal_worker_ok_count"] = ok_count
     trace["native_goal_worker_goal_get_count"] = goal_get_count
     trace["native_goal_worker_turn_start_count"] = turn_start_count


### PR DESCRIPTION
## Summary
- write public-safe SkillsBench app-server Goal relay lifecycle traces before worker turns
- distinguish lifecycle-only, prompt-received, and turn-level native worker trace states in compact validation
- document the native SkillsBench trace semantics and add focused smokes

## Validation
- python3 examples/skillsbench-app-server-goal-worker-smoke.py
- python3 examples/skillsbench-benchmark-run-smoke.py
- python3 -m py_compile goal_harness/benchmark_adapters/skillsbench.py goal_harness/benchmark_adapters/skillsbench_acp_relay.py goal_harness/status.py scripts/skillsbench_automation_loop.py scripts/skillsbench_local_acp_relay.py scripts/skillsbench_host_codex_goal_worker.py
- git diff --check
- goal-harness check --scan-path goal_harness/benchmark_adapters/skillsbench_acp_relay.py --scan-path scripts/skillsbench_automation_loop.py --scan-path goal_harness/benchmark_adapters/skillsbench.py --scan-path goal_harness/status.py --scan-path examples/skillsbench-app-server-goal-worker-smoke.py --scan-path examples/skillsbench-benchmark-run-smoke.py --scan-path docs/benchmark-developer-workflow.md

Note: goal-harness check reported only the pre-existing duplicate index rows warning for goal-harness-meta.