### PR TITLE
feat: clarify Codex CLI TUI bootstrap autostart

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,12 +165,15 @@ paste one message:
    with the official no-clone GitHub installer, then connect this project. Show
    me the current goal, concrete user gate if any, top todos, and next safe
    action before running longer work. Keep me in this Codex CLI TUI unless I
-   explicitly accept a headless fallback.
+   explicitly accept a headless fallback. After I paste this, begin the Goal
+   Harness loop; do not stop after only explaining what Goal Harness is.
    ```
 
    The agent should install or repair Goal Harness, connect the repo, run the
    quota/status guard, then show the current goal, user gate, top todos, and
-   next safe action before longer work.
+   next safe action before longer work. If the guard permits work, it should
+   claim or choose one runnable agent todo and complete one bounded validated
+   segment in the same visible TUI turn.
 
 3. After Goal Harness is installed, generate a tailored one-message bootstrap
    when you want the stricter reusable prompt:
@@ -184,6 +187,9 @@ review, and takeover; Goal Harness supplies goal state, todo ownership, quota,
 gates, writeback, and the next safe action. Headless `codex exec` is an explicit
 fallback, not the default experience. Local driver and visible-session proof
 commands are follow-up automation checks, not first-run requirements.
+Later automation must preserve that visible-control promise: a scheduler can
+return to the TUI only with public-safe visible proof, runtime idle evidence, a
+fresh guard, and explicit execution bounds.
 
 For contributors validating the full Codex CLI path without running Codex, use:
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -78,12 +78,15 @@ Start Goal Harness for this repo. If `goal-harness` is missing, install it with
 the official no-clone GitHub installer, then connect this project. Show me the
 current goal, concrete user gate if any, top todos, and next safe action before
 running longer work. Keep me in this Codex CLI TUI unless I explicitly accept a
-headless fallback.
+headless fallback. After I paste this, begin the Goal Harness loop; do not stop
+after only explaining what Goal Harness is.
 ```
 
 The first useful response should show the current goal id, concrete user gate
 if one exists, top user todo if any, top agent todo, and next safe action before
-longer delivery work.
+longer delivery work. When the guard permits work, the same TUI turn should
+claim or choose one runnable agent todo and finish one bounded validated
+segment, rather than asking the user to run a separate setup flow.
 
 Once `goal-harness` is installed, generate a stricter repo-specific paste
 message:
@@ -117,6 +120,12 @@ goal-harness codex-cli-visible-local-driver-pilot --project . --goal-id <goal-id
 This keeps the first-message TUI start primary, then models later scheduler
 ticks, visible proof, idle guard, guarded execution, blocker writeback, and
 no-transcript boundaries as public-safe metadata.
+
+The later-turn rule is intentionally stricter than the first message: Goal
+Harness may add a visible steering turn only after public-safe visible proof,
+runtime idle evidence, a fresh guard, and explicit execution bounds. Without
+that proof, the driver should write a compact blocker or keep the one-message
+TUI bootstrap as the product path.
 
 The commands below are optional automation checks after the one-message path
 works. To evaluate future same-session automation support without touching

--- a/docs/product/codex-cli-tui-loop.md
+++ b/docs/product/codex-cli-tui-loop.md
@@ -11,7 +11,9 @@ daemon instead of Codex." The target is:
 3. Codex discovers or installs Goal Harness without requiring a manual repo
    clone, connects the repo, reads quota and todo state, and enters the Goal
    Harness loop.
-4. Later automation can steer the same visible session when safe, while the
+4. If the guard permits work, that first TUI turn claims or chooses one runnable
+   agent todo and completes one bounded validated segment.
+5. Later automation can steer the same visible session when safe, while the
    user can still watch, interrupt, review, or take over.
 
 ## Product Goal
@@ -23,7 +25,8 @@ Start Goal Harness for this repo. If `goal-harness` is missing, install it with
 the official no-clone GitHub installer, then connect this project. Show me the
 current goal, concrete user gate if any, top todos, and next safe action before
 running longer work. Keep me in this Codex CLI TUI unless I explicitly accept a
-headless fallback.
+headless fallback. After I paste this, begin the Goal Harness loop; do not stop
+after only explaining what Goal Harness is.
 ```
 
 That message should be enough for a terminal agent to:
@@ -59,7 +62,9 @@ and the user's live console.
 This is the first supported path. The user starts in Codex CLI TUI and pastes a
 single Goal Harness bootstrap request. The agent performs install/connect,
 surfaces onboarding decisions, and starts a bounded Goal Harness turn in the
-same conversation.
+same conversation. It should not stop after describing the product; once the
+quota/status guard permits work, the first TUI turn should perform one bounded,
+validated segment.
 
 This mode preserves the TUI completely because the human explicitly starts the
 loop there.
@@ -101,6 +106,9 @@ the safe scheduler/executor bridge into one reviewable packet:
 - first turn: paste one Goal Harness message into the visible Codex CLI TUI;
 - first response: show goal id, concrete user gate or none, top user todo or
   none, top agent todo, and next safe action;
+- first work segment: if the guard permits work, claim or choose one runnable
+  agent todo and complete one bounded validated segment in that same visible
+  TUI turn;
 - later scheduler: use `codex-cli-local-scheduler-exec` in dry-run mode by
   default;
 - bridge side effects: require a fresh guard plus explicit candidate prefix or

--- a/examples/codex-cli-bootstrap-message-smoke.py
+++ b/examples/codex-cli-bootstrap-message-smoke.py
@@ -23,6 +23,8 @@ AGENT_ID = "codex-side-bypass"
 MUST_HAVE = (
     "one-message TUI bootstrap",
     "same Codex CLI TUI session",
+    "begin the Goal Harness loop automatically",
+    "Do not stop after explaining what Goal Harness is",
     "hidden headless `codex exec`",
     "explicit fallback",
     "current goal id",
@@ -38,7 +40,10 @@ MUST_HAVE = (
     "workspace_guard",
     "independent worktree",
     "runnable agent todo",
+    "one bounded validated segment",
     "Do not store raw Codex transcripts",
+    "visible steering turns",
+    "runtime idle evidence",
     "refresh-state",
     "quota spend-slot",
     "--source controller",
@@ -88,10 +93,13 @@ def assert_docs_surface_codex_cli_quickstart() -> None:
     normalized_product_contract = " ".join(product_contract.split())
     assert "Headless `codex exec` is an explicit fallback" in normalized_readme, readme
     assert "paste one message" in normalized_readme, readme
+    assert "begin the Goal Harness loop" in normalized_readme, readme
     assert "show the current goal, user gate, top todos, and next safe action" in normalized_readme, readme
     assert "first-run path should not require you to understand registry paths" in normalized_getting_started, getting_started
+    assert "finish one bounded validated segment" in normalized_getting_started, getting_started
     assert "optional automation checks after the one-message path works" in normalized_getting_started, getting_started
     assert "first useful TUI response should be a control-plane snapshot" in normalized_product_contract, product_contract
+    assert "first TUI turn should perform one bounded, validated segment" in normalized_product_contract, product_contract
     assert "goal-harness codex-cli-session-probe" in getting_started, getting_started
     assert "goal-harness codex-cli-exec-handoff --project . --goal-id <goal-id>" in getting_started, getting_started
 

--- a/examples/codex-cli-one-message-loop-pilot-smoke.py
+++ b/examples/codex-cli-one-message-loop-pilot-smoke.py
@@ -145,8 +145,14 @@ def main() -> int:
     assert_pilot_boundary(no_proof)
     assert no_proof["start_surface"] == "codex_cli_tui_one_message", no_proof
     assert no_proof["pilot_decision"] == "first_message_then_visible_blocker_writeback", no_proof
+    assert no_proof["first_turn"]["autostarts_goal_harness_loop"] is True, no_proof
+    assert no_proof["first_turn"]["preserve_tui"] is True, no_proof
+    assert "workspace_guard" in no_proof["first_turn"]["stop_only_for"], no_proof
     assert "Start the Goal Harness loop" in no_proof["first_turn"]["message"], no_proof
+    assert "begin the Goal Harness loop automatically" in no_proof["first_turn"]["message"], no_proof
     assert "same Codex CLI TUI" in no_proof["first_turn"]["message"], no_proof
+    assert "runtime_idle_evidence" in no_proof["later_turn_contract"]["visible_steering_requires"], no_proof
+    assert no_proof["later_turn_contract"]["default_without_proof"] == "write_blocker_or_keep_tui_bootstrap_primary", no_proof
     assert no_proof["automation_bridge"]["command"] == "codex-cli-local-scheduler-exec", no_proof
     assert no_proof["automation_bridge"]["default_executes"] is False, no_proof
     assert no_proof["automation_bridge"]["scheduler_action"] == "write_precise_blocker", no_proof

--- a/goal_harness/codex_cli_probe.py
+++ b/goal_harness/codex_cli_probe.py
@@ -1644,7 +1644,15 @@ def build_codex_cli_one_message_loop_pilot(
         "start_surface": "codex_cli_tui_one_message",
         "first_turn": {
             "user_action": "paste_bootstrap_message_into_codex_cli_tui",
+            "autostarts_goal_harness_loop": True,
             "preserve_tui": True,
+            "stop_only_for": [
+                "concrete_user_gate",
+                "workspace_guard",
+                "missing_capability",
+                "missing_installation_primitive",
+                "unsafe_boundary",
+            ],
             "message": bootstrap.get("message"),
             "snapshot_required": [
                 "current goal id",
@@ -1653,6 +1661,17 @@ def build_codex_cli_one_message_loop_pilot(
                 "top agent todo",
                 "next safe action",
             ],
+        },
+        "later_turn_contract": {
+            "preserve_visible_tui": True,
+            "visible_steering_requires": [
+                "public_safe_visible_session_proof",
+                "runtime_idle_evidence",
+                "fresh_quota_guard",
+                "guard_checked",
+                "explicit_execution_bounds",
+            ],
+            "default_without_proof": "write_blocker_or_keep_tui_bootstrap_primary",
         },
         "automation_bridge": {
             "command": "codex-cli-local-scheduler-exec",

--- a/goal_harness/project_prompt.py
+++ b/goal_harness/project_prompt.py
@@ -328,6 +328,11 @@ watch, steer, review, and take over. Do not switch to hidden headless `codex exe
 as the primary path; use headless only as an explicit fallback after Goal Harness
 or the user allows it.
 
+After I paste this message, begin the Goal Harness loop automatically. Do not
+stop after explaining what Goal Harness is. Stop only for a concrete user gate,
+workspace guard, missing capability, missing installation primitive, or unsafe
+boundary.
+
 Project: `{project}`
 Goal id: `{goal_id}`
 {agent_line}
@@ -339,6 +344,8 @@ Success criteria for this first TUI turn:
   if any, top user todo if any, top agent todo, and next safe action.
 - If no user gate or user todo exists, say that explicitly and continue only
   after the quota/status guard permits work.
+- If the guard permits work, claim or choose one runnable agent todo and do one
+  bounded validated segment in this same visible TUI turn.
 
 1. Ensure the Goal Harness CLI works:
 
@@ -382,8 +389,11 @@ production artifacts in public docs or Goal Harness state.
 ```
 
 End with changed files, validation result, current gate/todo state, and next
-safe action. Keep optional automation checks such as local-driver-plan or
-visible-session-proof as follow-up diagnostics, not first-run prerequisites.
+safe action. Later automation may add visible steering turns to this session
+only after public-safe visible proof, runtime idle evidence, a fresh guard, and
+explicit execution bounds. Keep optional automation checks such as
+local-driver-plan or visible-session-proof as follow-up diagnostics, not
+first-run prerequisites.
 """
 
 


### PR DESCRIPTION
## Summary
- make the generated Codex CLI bootstrap message explicit that one pasted TUI message should start the Goal Harness loop, not just explain it
- expose the autostart and later-turn visible-steering contract in the one-message pilot JSON
- update README/getting-started/product docs plus focused smokes for the Codex CLI TUI-first path

## Validation
- python -m py_compile goal_harness/project_prompt.py goal_harness/codex_cli_probe.py goal_harness/cli_commands/starter.py goal_harness/cli.py
- python examples/codex-cli-bootstrap-message-smoke.py
- python examples/codex-cli-one-message-loop-pilot-smoke.py
- python examples/docs-governance-smoke.py
- git diff --check
- goal-harness check --scan-path README.md --scan-path docs/guides/getting-started.md --scan-path docs/product/codex-cli-tui-loop.md --scan-path goal_harness/project_prompt.py --scan-path goal_harness/codex_cli_probe.py --scan-path examples/codex-cli-bootstrap-message-smoke.py --scan-path examples/codex-cli-one-message-loop-pilot-smoke.py

## Boundary
- no raw Codex transcripts, credentials, private paths, local registry state, or internal docs included
- later visible automation is still proof/idle/guard gated; this PR does not claim same-TUI injection is available without those gates