### PR TITLE
feat: polish Codex CLI first-run install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,9 @@ paste one message:
    goal-harness codex-cli-bootstrap-message --project . --goal-id <goal-id>
    ```
 
+   The generated packet includes the exact TUI paste block, the no-clone
+   install-repair command, and a transcript-free validation checklist.
+
 This is the primary Codex CLI path: the user keeps the visible TUI for steering,
 review, and takeover; Goal Harness supplies goal state, todo ownership, quota,
 gates, writeback, and the next safe action. Headless `codex exec` is an explicit

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -96,7 +96,10 @@ goal-harness codex-cli-bootstrap-message --project . --goal-id <goal-id>
 ```
 
 Keep that as the preferred interactive path: the human watches and steers in
-Codex CLI TUI, while Goal Harness owns quota/status/todos/gates/writeback.
+Codex CLI TUI, while Goal Harness owns quota/status/todos/gates/writeback. The
+generated packet also shows the no-clone install-repair command and a
+transcript-free validation checklist, so a fresh repo path can be reviewed
+without touching raw Codex session data.
 
 To review the whole one-message loop contract without running Codex, generate a
 pilot packet:

--- a/docs/product/codex-cli-packaged-install.md
+++ b/docs/product/codex-cli-packaged-install.md
@@ -48,6 +48,8 @@ This keeps the product hierarchy clear:
 
 - first run: one visible TUI message;
 - install repair: no manual clone required;
+- generated bootstrap packet: exact TUI paste block, no-clone repair command,
+  and transcript-free validation checklist;
 - recurring automation: separate driver work;
 - contributor development: clone plus canary remains available.
 

--- a/examples/codex-cli-bootstrap-message-smoke.py
+++ b/examples/codex-cli-bootstrap-message-smoke.py
@@ -48,6 +48,10 @@ MUST_HAVE = (
     "quota spend-slot",
     "--source controller",
     "not first-run prerequisites",
+    "no-clone GitHub archive",
+    "install-from-github.sh",
+    "transcript-free validation checklist",
+    "no raw Codex transcripts, session files, credentials, private paths, stdout, or stderr persisted",
 )
 
 
@@ -56,6 +60,11 @@ def assert_message_contract(payload: dict[str, object]) -> None:
     assert payload["schema_version"] == "codex_cli_bootstrap_message_v0", payload
     assert payload["goal_id"] == GOAL_ID, payload
     assert payload["agent_id"] == AGENT_ID, payload
+    assert "install-from-github.sh" in str(payload["install_repair_command"]), payload
+    checklist = payload["first_run_validation_checklist"]
+    assert isinstance(checklist, list) and len(checklist) >= 5, payload
+    assert any("quota/status guard checked" in item for item in checklist), payload
+    assert any("no raw Codex transcripts" in item for item in checklist), payload
     message = str(payload["message"])
     normalized = " ".join(message.split())
     for phrase in MUST_HAVE:
@@ -94,9 +103,11 @@ def assert_docs_surface_codex_cli_quickstart() -> None:
     assert "Headless `codex exec` is an explicit fallback" in normalized_readme, readme
     assert "paste one message" in normalized_readme, readme
     assert "begin the Goal Harness loop" in normalized_readme, readme
+    assert "exact TUI paste block" in normalized_readme, readme
     assert "show the current goal, user gate, top todos, and next safe action" in normalized_readme, readme
     assert "first-run path should not require you to understand registry paths" in normalized_getting_started, getting_started
     assert "finish one bounded validated segment" in normalized_getting_started, getting_started
+    assert "transcript-free validation checklist" in normalized_getting_started, getting_started
     assert "optional automation checks after the one-message path works" in normalized_getting_started, getting_started
     assert "first useful TUI response should be a control-plane snapshot" in normalized_product_contract, product_contract
     assert "first TUI turn should perform one bounded, validated segment" in normalized_product_contract, product_contract
@@ -139,6 +150,9 @@ def main() -> int:
     )
     assert "# Codex CLI Goal Harness Bootstrap Message" in cli_markdown, cli_markdown
     assert "Copy the block below into Codex CLI TUI" in cli_markdown, cli_markdown
+    assert "Fresh Repo Install Repair" in cli_markdown, cli_markdown
+    assert "Transcript-Free Validation Checklist" in cli_markdown, cli_markdown
+    assert "install-from-github.sh" in cli_markdown, cli_markdown
     assert "one-message TUI bootstrap" in cli_markdown, cli_markdown
     assert_docs_surface_codex_cli_quickstart()
 

--- a/goal_harness/project_prompt.py
+++ b/goal_harness/project_prompt.py
@@ -13,6 +13,7 @@ DEFAULT_HANDOFF_ADAPTER_KIND = "read_only_project_map_v0"
 DEFAULT_HANDOFF_ADAPTER_STATUS = "connected-read-only"
 DEFAULT_HANDOFF_NEXT_PROBE = "(omit --next-probe until a read-only pre-tick command exists)"
 SHARED_GLOBAL_REGISTRY = '"$HOME/.codex/goal-harness/registry.global.json"'
+NO_CLONE_INSTALL_URL = "https://raw.githubusercontent.com/huangruiteng/goal-harness/main/scripts/install-from-github.sh"
 
 
 def shell_arg(value: str) -> str:
@@ -29,6 +30,21 @@ if ! command -v {cli_bin_arg} >/dev/null 2>&1; then
     export PATH="$HOME/.local/bin:$PATH"
   else
     echo "goal-harness is not on PATH; clone the Goal Harness repo and run scripts/install-local.sh" >&2
+    exit 1
+  fi
+fi
+{cli_bin_arg} doctor >/dev/null"""
+
+
+def render_codex_cli_no_clone_preflight(*, cli_bin: str = "goal-harness") -> str:
+    cli_bin_arg = shell_arg(cli_bin)
+    return f"""export PATH="$HOME/.local/bin:$PATH"
+if ! command -v {cli_bin_arg} >/dev/null 2>&1; then
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL {NO_CLONE_INSTALL_URL} | bash
+    export PATH="$HOME/.local/bin:$PATH"
+  else
+    echo "goal-harness is not on PATH and curl is unavailable; install curl or use a contributor clone with scripts/install-local.sh" >&2
     exit 1
   fi
 fi
@@ -218,16 +234,26 @@ def build_codex_cli_bootstrap_message(
         cli_bin=cli_bin,
         agent_id=agent_id,
     )
+    install_repair_command = render_codex_cli_no_clone_preflight(cli_bin=cli_bin)
     refresh_command = f"{shell_arg(cli_bin)} refresh-state --goal-id {shell_arg(resolved_goal_id)}"
+    first_run_validation_checklist = [
+        "goal-harness doctor passed after no-clone install repair or existing install",
+        "repo connected conservatively or a concrete install/connect blocker was shown",
+        "quota/status guard checked with the registered agent id when available",
+        "current goal, concrete user gate or none, top todos, and next safe action shown in the TUI",
+        "one bounded segment validated before refresh-state and quota spend-slot",
+        "no raw Codex transcripts, session files, credentials, private paths, stdout, or stderr persisted",
+    ]
     message = render_codex_cli_bootstrap_message_text(
         project=resolved_project,
         goal_id=resolved_goal_id,
         agent_id=agent_id,
-        cli_preflight=render_cli_preflight(cli_bin=cli_bin),
+        cli_preflight=install_repair_command,
         connect_command=connect_command,
         quota_guard_command=quota_guard_command,
         refresh_command=refresh_command,
         quota_spend_command=quota_spend_command,
+        first_run_validation_checklist=first_run_validation_checklist,
     )
     return {
         "ok": True,
@@ -236,10 +262,12 @@ def build_codex_cli_bootstrap_message(
         "goal_id": resolved_goal_id,
         "agent_id": agent_id,
         "cli_bin": cli_bin,
+        "install_repair_command": install_repair_command,
         "connect_command": connect_command,
         "quota_guard_command": quota_guard_command,
         "refresh_command": refresh_command,
         "quota_spend_command": quota_spend_command,
+        "first_run_validation_checklist": first_run_validation_checklist,
         "message": message,
     }
 
@@ -317,10 +345,12 @@ def render_codex_cli_bootstrap_message_text(
     quota_guard_command: str,
     refresh_command: str,
     quota_spend_command: str,
+    first_run_validation_checklist: list[str],
 ) -> str:
     agent_line = f"Use registered Goal Harness agent id `{agent_id}` when claiming or spending." if agent_id else (
         "If this project has registered agents, inspect the registry and use the correct registered agent id before claiming todos."
     )
+    checklist = "\n".join(f"- {item}" for item in first_run_validation_checklist)
     return f"""Start the Goal Harness loop for this repo from this same Codex CLI TUI session.
 
 Goal: one-message TUI bootstrap. Keep this TUI as the visible place where I can
@@ -347,7 +377,9 @@ Success criteria for this first TUI turn:
 - If the guard permits work, claim or choose one runnable agent todo and do one
   bounded validated segment in this same visible TUI turn.
 
-1. Ensure the Goal Harness CLI works:
+1. Ensure the Goal Harness CLI works. Prefer the no-clone GitHub archive
+installer; do not ask me to clone the Goal Harness repo just to try the first
+run:
 
 ```bash
 {cli_preflight}
@@ -381,7 +413,11 @@ execute one bounded segment in this TUI-visible session. Validate the result.
 Do not store raw Codex transcripts, credentials, private paths, raw logs, or
 production artifacts in public docs or Goal Harness state.
 
-5. After validated writeback, refresh state and spend quota once:
+5. Before writeback, use this transcript-free validation checklist:
+
+{checklist}
+
+6. After validated writeback, refresh state and spend quota once:
 
 ```bash
 {refresh_command}
@@ -606,6 +642,9 @@ Copy the block below into the Codex session that can access the target project.
 
 
 def render_codex_cli_bootstrap_message_markdown(payload: dict[str, Any]) -> str:
+    checklist = "\n".join(
+        f"- {item}" for item in payload.get("first_run_validation_checklist", [])
+    )
     return f"""# Codex CLI Goal Harness Bootstrap Message
 
 Copy the block below into Codex CLI TUI from the project repo.
@@ -613,6 +652,19 @@ Copy the block below into Codex CLI TUI from the project repo.
 ````text
 {payload.get("message", "")}
 ````
+
+## Fresh Repo Install Repair
+
+The generated message uses the no-clone GitHub archive installer before asking
+for a contributor clone:
+
+```bash
+{payload.get("install_repair_command", "")}
+```
+
+## Transcript-Free Validation Checklist
+
+{checklist}
 
 ## Generator Inputs
 


### PR DESCRIPTION
## Summary
- make Codex CLI bootstrap use a no-clone GitHub archive installer preflight instead of clone-first setup
- expose the install repair command and transcript-free validation checklist in the generated bootstrap payload/markdown
- update README/getting-started/packaged install docs and bootstrap smoke coverage

## Validation
- python -m py_compile goal_harness/project_prompt.py goal_harness/codex_cli_probe.py goal_harness/heartbeat_prompt.py goal_harness/cli.py
- python examples/codex-cli-bootstrap-message-smoke.py
- python examples/project-prompt-smoke.py
- python examples/heartbeat-prompt-smoke.py
- python examples/docs-governance-smoke.py
- python examples/codex-cli-packaged-install-smoke.py
- git diff --check
- goal-harness check --scan-path README.md --scan-path docs/guides/getting-started.md --scan-path docs/product/codex-cli-packaged-install.md --scan-path goal_harness/project_prompt.py --scan-path examples/codex-cli-bootstrap-message-smoke.py

## Boundary
- Codex CLI bootstrap only; generic heartbeat/new-project preflight remains unchanged
- does not touch a real Codex session or read transcripts/session files
- public/private scan clean; no credentials, local state, or internal docs included