### PR TITLE
feat: add Codex CLI bootstrap copy-only output

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,11 @@ paste one message:
 
    The generated packet includes the exact TUI paste block, the no-clone
    install-repair command, and a transcript-free validation checklist.
+   When you only need the text to paste into Codex CLI TUI, use:
+
+   ```bash
+   goal-harness codex-cli-bootstrap-message --project . --goal-id <goal-id> --message-only
+   ```
 
 This is the primary Codex CLI path: the user keeps the visible TUI for steering,
 review, and takeover; Goal Harness supplies goal state, todo ownership, quota,

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -101,6 +101,12 @@ generated packet also shows the no-clone install-repair command and a
 transcript-free validation checklist, so a fresh repo path can be reviewed
 without touching raw Codex session data.
 
+If the user only wants the pasteable TUI text, omit the wrapper:
+
+```bash
+goal-harness codex-cli-bootstrap-message --project . --goal-id <goal-id> --message-only
+```
+
 To review the whole one-message loop contract without running Codex, generate a
 pilot packet:
 

--- a/docs/product/codex-cli-packaged-install.md
+++ b/docs/product/codex-cli-packaged-install.md
@@ -50,6 +50,8 @@ This keeps the product hierarchy clear:
 - install repair: no manual clone required;
 - generated bootstrap packet: exact TUI paste block, no-clone repair command,
   and transcript-free validation checklist;
+- copy-only mode: `codex-cli-bootstrap-message --message-only` prints just the
+  pasteable TUI block, while the default output remains the review packet;
 - recurring automation: separate driver work;
 - contributor development: clone plus canary remains available.
 

--- a/examples/codex-cli-bootstrap-message-smoke.py
+++ b/examples/codex-cli-bootstrap-message-smoke.py
@@ -154,6 +154,33 @@ def main() -> int:
     assert "Transcript-Free Validation Checklist" in cli_markdown, cli_markdown
     assert "install-from-github.sh" in cli_markdown, cli_markdown
     assert "one-message TUI bootstrap" in cli_markdown, cli_markdown
+
+    cli_message_only = run_cli(
+        "codex-cli-bootstrap-message",
+        "--project",
+        str(PROJECT),
+        "--goal-id",
+        GOAL_ID,
+        "--agent-id",
+        AGENT_ID,
+        "--message-only",
+    )
+    assert cli_message_only == str(payload["message"]) + "\n", cli_message_only
+    assert "# Codex CLI Goal Harness Bootstrap Message" not in cli_message_only, cli_message_only
+    assert "Fresh Repo Install Repair" not in cli_message_only, cli_message_only
+    assert "Start the Goal Harness loop" in cli_message_only, cli_message_only
+
+    cli_copy_only = run_cli(
+        "codex-cli-bootstrap-message",
+        "--project",
+        str(PROJECT),
+        "--goal-id",
+        GOAL_ID,
+        "--agent-id",
+        AGENT_ID,
+        "--copy-only",
+    )
+    assert cli_copy_only == cli_message_only, cli_copy_only
     assert_docs_surface_codex_cli_quickstart()
 
     print("codex-cli-bootstrap-message-smoke ok")

--- a/goal_harness/cli_commands/starter.py
+++ b/goal_harness/cli_commands/starter.py
@@ -189,6 +189,13 @@ def register_starter_commands(subparsers: argparse._SubParsersAction) -> None:
         default="goal-harness",
         help="Goal Harness CLI binary name embedded in generated commands.",
     )
+    codex_cli_bootstrap_parser.add_argument(
+        "--message-only",
+        "--copy-only",
+        dest="message_only",
+        action="store_true",
+        help="Print only the Codex CLI TUI paste message, without the Markdown review packet.",
+    )
 
     codex_cli_one_message_loop_parser = subparsers.add_parser(
         "codex-cli-one-message-loop-pilot",
@@ -675,6 +682,9 @@ def handle_codex_cli_bootstrap_message_command(
         agent_id=args.agent_id,
         cli_bin=args.cli_bin,
     )
+    if bool(getattr(args, "message_only", False)):
+        print(str(payload.get("message") or ""))
+        return 0
     print_payload(payload, args.format, render_codex_cli_bootstrap_message_markdown)
     return 0
 


### PR DESCRIPTION
## Summary
- add `--message-only` / `--copy-only` to `goal-harness codex-cli-bootstrap-message` for pure Codex CLI TUI paste text
- keep the default Markdown review packet and existing JSON payload path intact
- document the copy-only path in README/getting-started/product notes

## Validation
- `python -m py_compile goal_harness/cli_commands/starter.py goal_harness/project_prompt.py goal_harness/cli.py`
- `python examples/codex-cli-bootstrap-message-smoke.py`
- `python examples/docs-governance-smoke.py`
- `git diff --check`
- `goal-harness check --scan-path README.md --scan-path docs/guides/getting-started.md --scan-path docs/product/codex-cli-packaged-install.md --scan-path goal_harness/cli_commands/starter.py --scan-path examples/codex-cli-bootstrap-message-smoke.py`

## Boundary
- no real Codex TUI session is launched or mutated
- no transcripts, session files, credentials, private paths, or local registry exports are included
- public/private boundary scan is clean; existing duplicate-index warning is unrelated
