### PR TITLE
Preserve SkillsBench worker startup failures

### DIFF
--- a/examples/skillsbench-app-server-goal-worker-smoke.py
+++ b/examples/skillsbench-app-server-goal-worker-smoke.py
@@ -655,6 +655,102 @@ sys.exit(7)
         proc.wait(timeout=2)
 
 
+def test_acp_relay_materializes_public_failure_trace_without_worker_output() -> None:
+    fake_worker = """#!/usr/bin/env python3
+import sys
+
+sys.stderr.write("private startup failure detail")
+sys.exit(9)
+"""
+    with tempfile.TemporaryDirectory(prefix="skillsbench-app-goal-no-output-") as tmp:
+        root = Path(tmp)
+        worker = root / "fake_worker.py"
+        work = root / "work"
+        trace_dir = root / "worker-traces"
+        worker.write_text(fake_worker, encoding="utf-8")
+        worker.chmod(0o755)
+        work.mkdir()
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                str(REPO_ROOT / "scripts" / "skillsbench_local_acp_relay.py"),
+                "--app-server-goal-worker",
+                "--task-id",
+                "llm-prefix-cache-replay",
+                "--worker-script",
+                str(worker),
+                "--timeout-sec",
+                "5",
+                "--worker-public-trace-dir",
+                str(trace_dir),
+            ],
+            cwd=REPO_ROOT,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        assert proc.stdin is not None
+        assert proc.stdout is not None
+
+        def send(message: dict[str, Any]) -> None:
+            proc.stdin.write(json.dumps(message) + "\n")
+            proc.stdin.flush()
+
+        def read_response(request_id: int) -> dict[str, Any]:
+            while True:
+                line = proc.stdout.readline()
+                assert line, proc.stderr.read()
+                message = json.loads(line)
+                if message.get("id") == request_id and "method" not in message:
+                    return message
+
+        send({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}})
+        read_response(1)
+        send(
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "session/new",
+                "params": {"cwd": str(work), "mcpServers": []},
+            }
+        )
+        session_id = read_response(2)["result"]["sessionId"]
+        send(
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "session/prompt",
+                "params": {
+                    "sessionId": session_id,
+                    "prompt": [{"type": "text", "text": "private task placeholder"}],
+                },
+            }
+        )
+        final_response = read_response(3)
+        assert final_response["error"]["message"] == "host app-server goal worker failed"
+        traces = [
+            json.loads(path.read_text(encoding="utf-8"))
+            for path in sorted(trace_dir.glob("*.compact.json"))
+        ]
+        failure_traces = [
+            item
+            for item in traces
+            if item.get("trace_kind") == "host_worker_process_failure"
+        ]
+        assert len(failure_traces) == 1, traces
+        trace = failure_traces[0]
+        assert trace["ok"] is False, trace
+        assert trace["worker_process"]["returncode"] == 9, trace
+        assert trace["worker_process"]["stderr_bytes"] > 0, trace
+        trace_text = json.dumps(trace, sort_keys=True)
+        assert "private startup failure detail" not in trace_text, trace
+        assert "private task placeholder" not in trace_text, trace
+        assert str(work) not in trace_text, trace
+        proc.terminate()
+        proc.wait(timeout=2)
+
+
 def test_full_run_fails_closed_until_bridge_is_materialized() -> None:
     result = subprocess.run(
         [
@@ -728,6 +824,7 @@ if __name__ == "__main__":
     test_acp_relay_materializes_lifecycle_trace_before_prompt()
     test_acp_relay_streams_public_keepalive_while_worker_runs()
     test_acp_relay_preserves_public_worker_trace_on_worker_failure()
+    test_acp_relay_materializes_public_failure_trace_without_worker_output()
     test_full_run_fails_closed_until_bridge_is_materialized()
     test_full_run_with_bridge_ready_requires_host_acp_launch()
     test_launcher_patches_rollout_planes_connect_acp()

--- a/goal_harness/benchmark_adapters/skillsbench_acp_relay.py
+++ b/goal_harness/benchmark_adapters/skillsbench_acp_relay.py
@@ -323,8 +323,14 @@ class SkillsBenchLocalAcpRelay:
                     now = time.monotonic()
                     if now >= deadline:
                         proc.kill()
-                        proc.communicate(timeout=2)
-                        self._publish_worker_trace(output_json)
+                        stdout_text, stderr_text = proc.communicate(timeout=2)
+                        if not self._publish_worker_trace(output_json):
+                            self._publish_worker_failure_trace(
+                                stage="timeout",
+                                returncode=proc.returncode,
+                                stdout_text=stdout_text,
+                                stderr_text=stderr_text,
+                            )
                         raise TimeoutError
                     if now >= next_heartbeat:
                         self._write_worker_heartbeat(
@@ -336,12 +342,24 @@ class SkillsBenchLocalAcpRelay:
                             now + max(1.0, self._config.stream_heartbeat_interval_sec)
                         )
                     time.sleep(0.2)
-                proc.communicate(timeout=5)
+                stdout_text, stderr_text = proc.communicate(timeout=5)
             except subprocess.TimeoutExpired as exc:
-                self._publish_worker_trace(output_json)
+                if not self._publish_worker_trace(output_json):
+                    self._publish_worker_failure_trace(
+                        stage="communicate_timeout",
+                        returncode=proc.returncode,
+                        stdout_text="",
+                        stderr_text="",
+                    )
                 raise TimeoutError from exc
             if proc.returncode != 0:
-                self._publish_worker_trace(output_json)
+                if not self._publish_worker_trace(output_json):
+                    self._publish_worker_failure_trace(
+                        stage="worker_exit_nonzero_before_public_trace",
+                        returncode=proc.returncode,
+                        stdout_text=stdout_text,
+                        stderr_text=stderr_text,
+                    )
                 raise RuntimeError("host app-server goal worker failed")
             self._publish_worker_trace(output_json)
             try:
@@ -350,7 +368,7 @@ class SkillsBenchLocalAcpRelay:
                 raise RuntimeError("host app-server goal worker response missing") from exc
             return response or "host app-server goal worker returned an empty final message"
 
-    def _publish_worker_trace(self, output_json: Path) -> None:
+    def _publish_worker_trace(self, output_json: Path) -> bool:
         """Persist a public-safe app-server worker trace for the reducer.
 
         The worker output is already compact, but this method still rewrites a
@@ -359,13 +377,13 @@ class SkillsBenchLocalAcpRelay:
         """
 
         if not self._config.worker_public_trace_dir:
-            return
+            return False
         try:
             payload = json.loads(output_json.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
-            return
+            return False
         if not isinstance(payload, dict):
-            return
+            return False
 
         def compact_dict(source: Any, allowed: tuple[str, ...]) -> dict[str, Any]:
             if not isinstance(source, dict):
@@ -435,6 +453,76 @@ class SkillsBenchLocalAcpRelay:
                     "host_paths_recorded",
                 ),
             ),
+        }
+        self._write_worker_public_trace(trace)
+        return True
+
+    def _publish_worker_failure_trace(
+        self,
+        *,
+        stage: str,
+        returncode: int | None,
+        stdout_text: str,
+        stderr_text: str,
+    ) -> None:
+        """Persist compact failure evidence when the host worker writes no trace."""
+
+        if not self._config.worker_public_trace_dir:
+            return
+        safe_stage = "".join(
+            ch if ch.isalnum() or ch == "_" else "_"
+            for ch in str(stage or "").strip().lower()
+        )
+        if not safe_stage:
+            safe_stage = "worker_failed_before_public_trace"
+        trace = {
+            "schema_version": "skillsbench_host_codex_goal_worker_public_trace_v0",
+            "ok": False,
+            "route": "codex-app-server-goal-baseline",
+            "trace_kind": "host_worker_process_failure",
+            "benchmark_id": self._config.dataset,
+            "task_id": self._config.task_id,
+            "worker_process": {
+                "schema_version": "skillsbench_host_worker_process_failure_v0",
+                "stage": safe_stage,
+                "returncode": returncode
+                if isinstance(returncode, int) and not isinstance(returncode, bool)
+                else None,
+                "stdout_bytes": len((stdout_text or "").encode("utf-8")),
+                "stderr_bytes": len((stderr_text or "").encode("utf-8")),
+                "raw_stdout_recorded": False,
+                "raw_stderr_recorded": False,
+                "host_paths_recorded": False,
+            },
+            "worker_contract": {
+                "schema_version": "skillsbench_app_server_goal_worker_contract_v0",
+                "route": "codex-app-server-goal-baseline",
+                "ready": False,
+                "runner_integration_ready": True,
+                "first_blocker": safe_stage,
+            },
+            "prompt": {"raw_recorded": False},
+            "turn": {
+                "thread_id_present": False,
+                "goal_get_present": False,
+                "turn_id_present": False,
+                "turn_completed_observed": False,
+                "assistant_message_present": False,
+                "raw_transcript_recorded": False,
+                "raw_assistant_message_recorded": False,
+            },
+            "private_response_text": {
+                "written": False,
+                "path_recorded": False,
+                "raw_recorded_in_public_json": False,
+            },
+            "boundary": {
+                "raw_task_text_recorded": False,
+                "raw_logs_recorded": False,
+                "raw_trajectory_recorded": False,
+                "credential_values_recorded": False,
+                "host_paths_recorded": False,
+            },
         }
         self._write_worker_public_trace(trace)
 


### PR DESCRIPTION
## Summary
- write a public-safe SkillsBench host worker process failure trace when the app-server worker exits before producing its compact output
- keep raw stdout/stderr, task prompt text, response text, local paths, and trajectories out of public trace material
- add a regression smoke for the no-worker-output failure path

## Validation
- python3 examples/skillsbench-app-server-goal-worker-smoke.py
- python3 -m py_compile goal_harness/benchmark_adapters/skillsbench_acp_relay.py examples/skillsbench-app-server-goal-worker-smoke.py
- git diff --check