### PR TITLE
docs: record Codex CLI visible attach proof pilot

### DIFF
--- a/docs/product/codex-cli-tui-loop.md
+++ b/docs/product/codex-cli-tui-loop.md
@@ -322,6 +322,11 @@ the idle detector passes. If either proof or idle evidence is missing, the
 packet returns a precise blocker and keeps the one-message TUI bootstrap as the
 primary path.
 
+The first public-safe proof pilot is recorded in
+[Codex CLI Visible Attach Proof Pilot](codex-cli-visible-attach-proof-pilot.md):
+current `resume` / `remote-control` evidence is promising, but still blocked
+until a visible same-TUI proof and runtime-idle evidence exist.
+
 ### 3. Headless Fallback
 
 `codex exec` remains useful for scheduled or CI-like work, but it is not the

--- a/docs/product/codex-cli-visible-attach-proof-pilot.md
+++ b/docs/product/codex-cli-visible-attach-proof-pilot.md
@@ -1,0 +1,65 @@
+# Codex CLI Visible Attach Proof Pilot
+
+Status: blocker recorded, TUI bootstrap remains primary.
+Recorded: 2026-06-21.
+
+This note records the first public-safe proof pilot for Goal Harness steering a
+later Codex CLI turn without taking the user out of the visible TUI. It uses the
+`codex-cli-visible-attach-acceptance` packet added in PR #383.
+
+## Question
+
+Can Goal Harness safely add a later steering turn to the same open Codex CLI TUI
+session today?
+
+## Result
+
+Not yet.
+
+The current Codex CLI help surface exposes promising `resume` /
+`remote-control` style capabilities, so this remains worth exploring. But the
+available help-only evidence does not prove a safe same-TUI attach primitive.
+The acceptance packet returns:
+
+- `decision`: `visible_session_proof_required`
+- `accepted_for_same_tui_automation`: `False`
+- `accepted_for_visible_later_turn`: `False`
+- `driver_mode`: `visible_resume_or_remote_control_spike`
+- blocker: `visible_session_proof_missing`
+
+## Boundary
+
+This pilot did not:
+
+- run Codex CLI delivery;
+- read raw transcripts;
+- read session files;
+- read stdout/stderr streams;
+- read credentials;
+- mutate a Codex session;
+- spend Goal Harness quota by itself.
+
+## Interpretation
+
+`resume [PROMPT]` and `remote-control` are not enough on their own. They may be
+usable as a visible spike, but Goal Harness should not call them
+same-TUI automation until a public-safe proof shows:
+
+- the resulting turn is visible to the user;
+- the user can interrupt or take over;
+- a runtime idle detector passed immediately before the turn;
+- the route does not require transcript/session-file reads;
+- compact evidence or a blocker will be written before quota spend.
+
+Until that proof exists, the product-safe path stays:
+
+1. Start from one Codex CLI TUI bootstrap message.
+2. Keep later automation in no-execution packet mode.
+3. Use `codex exec` only as an explicit opt-in headless fallback.
+
+## Next Step
+
+Run a visible `resume` / `remote-control` proof only when it can be captured as
+a public-safe fixture with user opt-in and runtime-idle evidence. If that proof
+cannot be captured without reading private session material or racing the TUI,
+keep this blocker and continue improving the one-message TUI bootstrap path.


### PR DESCRIPTION
## Summary
- record the first public-safe Codex CLI visible attach proof pilot
- keep one-message TUI bootstrap as the primary product path until same-TUI visibility and idle evidence are proven
- link the pilot from the Codex CLI TUI loop design doc

## Validation
- python examples/docs-governance-smoke.py
- git diff --check
- goal-harness check --scan-path docs/product/codex-cli-visible-attach-proof-pilot.md --scan-path docs/product/codex-cli-tui-loop.md
- private marker scan over touched docs

## Boundary
Docs-only. No local registry/state, credentials, private paths, raw session material, benchmark evidence, or runtime behavior changes.