### PR TITLE
docs: add Codex CLI proof capture demo fixtures

### DIFF
--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -27,6 +27,9 @@ runtime contract, benchmark route, or launch draft.
   the opt-in public-safe procedure for turning `resume` / `remote-control`
   signals into evidence, with stop conditions that keep one-message TUI
   bootstrap primary until same-TUI visibility is proven.
+- [Codex CLI proof-capture demo](codex-cli-proof-capture-demo.md): public-safe
+  sample fixtures and acceptance decisions for rehearsing the visible proof
+  path without running Codex or reading session material.
 - [Agent profile contract](agent-profile-contract.md): the registry-owned
   identity/scope contract for primary and side agents, including worktree and
   review handoff policy, while keeping todo ownership in `claimed_by` and future

--- a/docs/product/codex-cli-proof-capture-demo.md
+++ b/docs/product/codex-cli-proof-capture-demo.md
@@ -1,0 +1,72 @@
+# Codex CLI Proof-Capture Demo
+
+This demo bundle lets a user or contributor rehearse the visible proof protocol
+without running Codex, reading session material, or touching local Goal Harness
+state. It is deliberately fixture-first: the commands validate public-safe
+evidence shape and show the acceptance decision that a real opt-in proof would
+need to produce.
+
+## Files
+
+- `examples/fixtures/codex-cli-visible-proof/codex-visible-resume-help.public.json`
+  models a Codex CLI surface with `resume [PROMPT]` / `remote-control`.
+- `examples/fixtures/codex-cli-visible-proof/visible-resume-proof.public.json`
+  records the visible, interruptible proof for that surface.
+- `examples/fixtures/codex-cli-visible-proof/runtime-idle-visible-resume.public.json`
+  records the fresh idle guard for that surface.
+- `examples/fixtures/codex-cli-visible-proof/codex-same-tui-help.public.json`
+  models a future explicit same-TUI attach primitive.
+- `examples/fixtures/codex-cli-visible-proof/same-tui-proof.public.json`
+  records the proof shape that can promote same-TUI automation.
+- `examples/fixtures/codex-cli-visible-proof/runtime-idle-same-tui.public.json`
+  records the matching idle guard.
+
+## Rehearse The Current Likely Path
+
+```bash
+goal-harness --format json codex-cli-visible-attach-acceptance \
+  --project . \
+  --goal-id public-codex-cli-goal \
+  --agent-id codex-side-bypass \
+  --fixture examples/fixtures/codex-cli-visible-proof/codex-visible-resume-help.public.json \
+  --proof-fixture examples/fixtures/codex-cli-visible-proof/visible-resume-proof.public.json \
+  --idle-fixture examples/fixtures/codex-cli-visible-proof/runtime-idle-visible-resume.public.json
+```
+
+Expected decision:
+
+```text
+decision: visible_surface_spike_passed_not_same_tui
+accepted_for_visible_later_turn: true
+accepted_for_same_tui_automation: false
+blocker: same_tui_visible_attach_not_proven
+```
+
+This is the important product distinction. A visible `resume` or
+`remote-control` path can become a useful proof spike, but it still does not
+prove Goal Harness can safely add a turn to the same open TUI.
+
+## Rehearse The Future Promotion Path
+
+```bash
+goal-harness --format json codex-cli-visible-attach-acceptance \
+  --project . \
+  --goal-id public-codex-cli-goal \
+  --agent-id codex-side-bypass \
+  --fixture examples/fixtures/codex-cli-visible-proof/codex-same-tui-help.public.json \
+  --proof-fixture examples/fixtures/codex-cli-visible-proof/same-tui-proof.public.json \
+  --idle-fixture examples/fixtures/codex-cli-visible-proof/runtime-idle-same-tui.public.json
+```
+
+Expected decision:
+
+```text
+decision: same_tui_visible_attach_accepted
+accepted_for_visible_later_turn: true
+accepted_for_same_tui_automation: true
+blockers: []
+```
+
+That result is still an acceptance packet, not an executor. A later driver must
+rerun quota, rerun a fresh idle guard, obey the command boundary, write compact
+evidence or a blocker, and spend quota only after validation.

--- a/docs/product/codex-cli-visible-proof-capture-protocol.md
+++ b/docs/product/codex-cli-visible-proof-capture-protocol.md
@@ -27,6 +27,9 @@ path and record a blocker instead of attempting a later visible turn.
 ## Capture Packet
 
 The durable packet is two public-safe fixtures plus the acceptance result.
+The public demo bundle in
+[Codex CLI Proof-Capture Demo](codex-cli-proof-capture-demo.md) provides sample
+fixtures for both a visible `resume` spike and a future same-TUI attach proof.
 
 ### Visible-Session Proof Fixture
 

--- a/examples/codex-cli-proof-capture-demo-fixtures-smoke.py
+++ b/examples/codex-cli-proof-capture-demo-fixtures-smoke.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Validate the public Codex CLI proof-capture demo fixtures."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from goal_harness.codex_cli_probe import (  # noqa: E402
+    build_codex_cli_visible_attach_acceptance,
+    classify_codex_cli_session_surface,
+)
+
+
+PROJECT = Path("/tmp/public-codex-cli-project")
+GOAL_ID = "public-codex-cli-goal"
+AGENT_ID = "codex-side-bypass"
+FIXTURE_DIR = REPO_ROOT / "examples" / "fixtures" / "codex-cli-visible-proof"
+
+
+def load_fixture(name: str) -> dict[str, object]:
+    path = FIXTURE_DIR / name
+    return json.loads(path.read_text())
+
+
+def command_outputs(name: str) -> dict[str, str]:
+    payload = load_fixture(name)
+    outputs = payload["command_outputs"]
+    assert isinstance(outputs, dict), payload
+    return {str(key): str(value) for key, value in outputs.items()}
+
+
+def build_acceptance(
+    help_fixture: str,
+    proof_fixture: str,
+    idle_fixture: str,
+) -> dict[str, object]:
+    return build_codex_cli_visible_attach_acceptance(
+        project=PROJECT,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        cli_bin="goal-harness",
+        codex_bin="codex",
+        probe_payload=classify_codex_cli_session_surface(
+            command_outputs=command_outputs(help_fixture)
+        ),
+        proof_payload=load_fixture(proof_fixture),
+        idle_payload=load_fixture(idle_fixture),
+    )
+
+
+def run_cli_acceptance(
+    help_fixture: str,
+    proof_fixture: str,
+    idle_fixture: str,
+) -> dict[str, object]:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "goal_harness.cli",
+            "--format",
+            "json",
+            "codex-cli-visible-attach-acceptance",
+            "--project",
+            str(PROJECT),
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_ID,
+            "--fixture",
+            str(FIXTURE_DIR / help_fixture),
+            "--proof-fixture",
+            str(FIXTURE_DIR / proof_fixture),
+            "--idle-fixture",
+            str(FIXTURE_DIR / idle_fixture),
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def assert_public_safe_boundary(payload: dict[str, object]) -> None:
+    boundary = payload["boundary"]
+    assert boundary["acceptance_packet_only"] is True, payload
+    assert boundary["runs_codex"] is False, payload
+    assert boundary["reads_raw_transcripts"] is False, payload
+    assert boundary["reads_session_files"] is False, payload
+    assert boundary["reads_stdout_stderr"] is False, payload
+    assert boundary["mutates_codex_session"] is False, payload
+    assert boundary["spends_goal_harness_quota"] is False, payload
+    assert boundary["writes_goal_harness_state"] is False, payload
+
+
+def assert_visible_resume_spike(payload: dict[str, object]) -> None:
+    assert payload["decision"] == "visible_surface_spike_passed_not_same_tui", payload
+    assert payload["accepted_for_visible_later_turn"] is True, payload
+    assert payload["accepted_for_same_tui_automation"] is False, payload
+    assert payload["observed_surface"] == "visible_resume_prompt", payload
+    assert "same_tui_visible_attach_not_proven" in payload["blockers"], payload
+    assert_public_safe_boundary(payload)
+
+
+def assert_same_tui_accepted(payload: dict[str, object]) -> None:
+    assert payload["decision"] == "same_tui_visible_attach_accepted", payload
+    assert payload["accepted_for_visible_later_turn"] is True, payload
+    assert payload["accepted_for_same_tui_automation"] is True, payload
+    assert payload["observed_surface"] == "same_tui_visible_attach", payload
+    assert payload["blockers"] == [], payload
+    assert_public_safe_boundary(payload)
+
+
+def main() -> int:
+    visible_resume = build_acceptance(
+        "codex-visible-resume-help.public.json",
+        "visible-resume-proof.public.json",
+        "runtime-idle-visible-resume.public.json",
+    )
+    assert_visible_resume_spike(visible_resume)
+
+    visible_resume_cli = run_cli_acceptance(
+        "codex-visible-resume-help.public.json",
+        "visible-resume-proof.public.json",
+        "runtime-idle-visible-resume.public.json",
+    )
+    assert_visible_resume_spike(visible_resume_cli)
+
+    same_tui = build_acceptance(
+        "codex-same-tui-help.public.json",
+        "same-tui-proof.public.json",
+        "runtime-idle-same-tui.public.json",
+    )
+    assert_same_tui_accepted(same_tui)
+
+    same_tui_cli = run_cli_acceptance(
+        "codex-same-tui-help.public.json",
+        "same-tui-proof.public.json",
+        "runtime-idle-same-tui.public.json",
+    )
+    assert_same_tui_accepted(same_tui_cli)
+
+    print("codex-cli-proof-capture-demo-fixtures-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/fixtures/codex-cli-visible-proof/codex-same-tui-help.public.json
+++ b/examples/fixtures/codex-cli-visible-proof/codex-same-tui-help.public.json
@@ -1,0 +1,7 @@
+{
+  "command_outputs": {
+    "root": "Usage: codex [OPTIONS] [PROMPT]\n\nCommands:\n  exec\n  resume\n  attach-session    Send prompt to session after checking the idle TUI\n",
+    "exec": "Usage: codex exec [OPTIONS] [PROMPT]",
+    "resume": "Usage: codex resume [SESSION_ID]"
+  }
+}

--- a/examples/fixtures/codex-cli-visible-proof/codex-visible-resume-help.public.json
+++ b/examples/fixtures/codex-cli-visible-proof/codex-visible-resume-help.public.json
@@ -1,0 +1,7 @@
+{
+  "command_outputs": {
+    "root": "Usage: codex [OPTIONS] [PROMPT]\n\nCommands:\n  exec\n  remote-control  Manage the app-server daemon with remote control enabled\n  resume          Resume a previous interactive session\n\nOptions:\n  --remote <ADDR>  Connect the TUI to a remote app server endpoint\n",
+    "exec": "Usage: codex exec [OPTIONS] [PROMPT]",
+    "resume": "Usage: codex resume [OPTIONS] [SESSION_ID] [PROMPT]"
+  }
+}

--- a/examples/fixtures/codex-cli-visible-proof/runtime-idle-same-tui.public.json
+++ b/examples/fixtures/codex-cli-visible-proof/runtime-idle-same-tui.public.json
@@ -1,0 +1,23 @@
+{
+  "observed_surface": "same_tui_visible_attach",
+  "idle_guard": {
+    "no_active_human_typing": true,
+    "no_running_turn": true,
+    "checked_before_prompt": true
+  },
+  "turn_visibility": {
+    "visible_to_user": true
+  },
+  "interruptibility": {
+    "user_can_interrupt": true,
+    "manual_takeover_available": true
+  },
+  "boundary": {
+    "reads_raw_transcripts": false,
+    "reads_session_files": false,
+    "reads_stdout_stderr": false,
+    "reads_credentials": false,
+    "mutates_hidden_session_state": false
+  },
+  "proof_result": "fresh idle guard passed for a same-TUI demo fixture"
+}

--- a/examples/fixtures/codex-cli-visible-proof/runtime-idle-visible-resume.public.json
+++ b/examples/fixtures/codex-cli-visible-proof/runtime-idle-visible-resume.public.json
@@ -1,0 +1,23 @@
+{
+  "observed_surface": "visible_resume_prompt",
+  "idle_guard": {
+    "no_active_human_typing": true,
+    "no_running_turn": true,
+    "checked_before_prompt": true
+  },
+  "turn_visibility": {
+    "visible_to_user": true
+  },
+  "interruptibility": {
+    "user_can_interrupt": true,
+    "manual_takeover_available": true
+  },
+  "boundary": {
+    "reads_raw_transcripts": false,
+    "reads_session_files": false,
+    "reads_stdout_stderr": false,
+    "reads_credentials": false,
+    "mutates_hidden_session_state": false
+  },
+  "proof_result": "fresh idle guard passed for a visible resume proof prompt"
+}

--- a/examples/fixtures/codex-cli-visible-proof/same-tui-proof.public.json
+++ b/examples/fixtures/codex-cli-visible-proof/same-tui-proof.public.json
@@ -1,0 +1,31 @@
+{
+  "observed_surface": "same_tui_visible_attach",
+  "user_opt_in": true,
+  "quota_guard": {
+    "passed": true
+  },
+  "idle_guard": {
+    "no_active_human_typing": true,
+    "no_running_turn": true,
+    "checked_before_prompt": true
+  },
+  "turn_visibility": {
+    "visible_to_user": true,
+    "prompt_public_safe": true
+  },
+  "interruptibility": {
+    "user_can_interrupt": true,
+    "manual_takeover_available": true
+  },
+  "boundary": {
+    "reads_raw_transcripts": false,
+    "reads_session_files": false,
+    "reads_credentials": false,
+    "mutates_hidden_session_state": false,
+    "spends_quota_before_writeback": false
+  },
+  "writeback": {
+    "compact_evidence_planned": true
+  },
+  "proof_result": "same-TUI visible attach proof passed for a public demo fixture"
+}

--- a/examples/fixtures/codex-cli-visible-proof/visible-resume-proof.public.json
+++ b/examples/fixtures/codex-cli-visible-proof/visible-resume-proof.public.json
@@ -1,0 +1,31 @@
+{
+  "observed_surface": "visible_resume_prompt",
+  "user_opt_in": true,
+  "quota_guard": {
+    "passed": true
+  },
+  "idle_guard": {
+    "no_active_human_typing": true,
+    "no_running_turn": true,
+    "checked_before_prompt": true
+  },
+  "turn_visibility": {
+    "visible_to_user": true,
+    "prompt_public_safe": true
+  },
+  "interruptibility": {
+    "user_can_interrupt": true,
+    "manual_takeover_available": true
+  },
+  "boundary": {
+    "reads_raw_transcripts": false,
+    "reads_session_files": false,
+    "reads_credentials": false,
+    "mutates_hidden_session_state": false,
+    "spends_quota_before_writeback": false
+  },
+  "writeback": {
+    "compact_evidence_planned": true
+  },
+  "proof_result": "visible spike proof only; same-TUI attach not proven"
+}


### PR DESCRIPTION
## Summary
- add public-safe Codex CLI proof-capture demo fixtures for visible resume and future same-TUI attach paths
- add a walkthrough showing the expected acceptance decisions without running Codex or reading session material
- add a smoke that validates the sample fixtures through the existing visible-session proof, runtime-idle, and visible-attach acceptance contracts

## Validation
- python examples/codex-cli-proof-capture-demo-fixtures-smoke.py
- python examples/codex-cli-visible-session-proof-smoke.py
- python examples/codex-cli-runtime-idle-detector-smoke.py
- python examples/codex-cli-visible-attach-acceptance-smoke.py
- python examples/docs-governance-smoke.py
- python -m py_compile examples/codex-cli-proof-capture-demo-fixtures-smoke.py
- git diff --check
- goal-harness check --scan-path docs/product/codex-cli-proof-capture-demo.md --scan-path docs/product/codex-cli-visible-proof-capture-protocol.md --scan-path docs/product/README.md --scan-path examples/fixtures/codex-cli-visible-proof --scan-path examples/codex-cli-proof-capture-demo-fixtures-smoke.py
- private marker scan over touched docs/fixtures/smoke

## Boundary
No Codex execution, no session mutation, no transcript/session/stdout/stderr reads, no credentials, no local Goal Harness state, and no benchmark material.