### PR TITLE
Fix SkillsBench worker missing-trace closeout

### DIFF
--- a/examples/skillsbench-app-server-goal-worker-smoke.py
+++ b/examples/skillsbench-app-server-goal-worker-smoke.py
@@ -751,6 +751,113 @@ sys.exit(9)
         proc.wait(timeout=2)
 
 
+def test_acp_relay_fails_closed_when_zero_exit_worker_writes_no_public_output() -> None:
+    fake_worker = """#!/usr/bin/env python3
+import argparse
+import sys
+from pathlib import Path
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--response-text-file")
+args, _ = parser.parse_known_args()
+Path(args.response_text_file).write_text("private response text", encoding="utf-8")
+sys.stderr.write("private normal-exit output omission")
+sys.exit(0)
+"""
+    with tempfile.TemporaryDirectory(prefix="skillsbench-app-goal-zero-no-output-") as tmp:
+        root = Path(tmp)
+        worker = root / "fake_worker.py"
+        work = root / "work"
+        trace_dir = root / "worker-traces"
+        worker.write_text(fake_worker, encoding="utf-8")
+        worker.chmod(0o755)
+        work.mkdir()
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                str(REPO_ROOT / "scripts" / "skillsbench_local_acp_relay.py"),
+                "--app-server-goal-worker",
+                "--task-id",
+                "llm-prefix-cache-replay",
+                "--worker-script",
+                str(worker),
+                "--timeout-sec",
+                "5",
+                "--worker-public-trace-dir",
+                str(trace_dir),
+            ],
+            cwd=REPO_ROOT,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        assert proc.stdin is not None
+        assert proc.stdout is not None
+
+        def send(message: dict[str, Any]) -> None:
+            proc.stdin.write(json.dumps(message) + "\n")
+            proc.stdin.flush()
+
+        def read_response(request_id: int) -> dict[str, Any]:
+            while True:
+                line = proc.stdout.readline()
+                assert line, proc.stderr.read()
+                message = json.loads(line)
+                if message.get("id") == request_id and "method" not in message:
+                    return message
+
+        send({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}})
+        read_response(1)
+        send(
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "session/new",
+                "params": {"cwd": str(work), "mcpServers": []},
+            }
+        )
+        session_id = read_response(2)["result"]["sessionId"]
+        send(
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "session/prompt",
+                "params": {
+                    "sessionId": session_id,
+                    "prompt": [{"type": "text", "text": "private task placeholder"}],
+                },
+            }
+        )
+        final_response = read_response(3)
+        assert (
+            final_response["error"]["message"]
+            == "host app-server goal worker public trace missing"
+        )
+        traces = [
+            json.loads(path.read_text(encoding="utf-8"))
+            for path in sorted(trace_dir.glob("*.compact.json"))
+        ]
+        failure_traces = [
+            item
+            for item in traces
+            if item.get("trace_kind") == "host_worker_process_failure"
+        ]
+        assert len(failure_traces) == 1, traces
+        trace = failure_traces[0]
+        assert trace["ok"] is False, trace
+        assert trace["worker_process"]["stage"] == "worker_exit_zero_before_public_trace"
+        assert trace["worker_process"]["returncode"] == 0, trace
+        assert trace["worker_process"]["stderr_bytes"] > 0, trace
+        trace_text = json.dumps(trace, sort_keys=True)
+        assert "private normal-exit output omission" not in trace_text, trace
+        assert "private response text" not in trace_text, trace
+        assert "private task placeholder" not in trace_text, trace
+        assert str(work) not in trace_text, trace
+        proc.terminate()
+        proc.wait(timeout=2)
+
+
 def test_full_run_fails_closed_until_bridge_is_materialized() -> None:
     result = subprocess.run(
         [
@@ -825,6 +932,7 @@ if __name__ == "__main__":
     test_acp_relay_streams_public_keepalive_while_worker_runs()
     test_acp_relay_preserves_public_worker_trace_on_worker_failure()
     test_acp_relay_materializes_public_failure_trace_without_worker_output()
+    test_acp_relay_fails_closed_when_zero_exit_worker_writes_no_public_output()
     test_full_run_fails_closed_until_bridge_is_materialized()
     test_full_run_with_bridge_ready_requires_host_acp_launch()
     test_launcher_patches_rollout_planes_connect_acp()

--- a/goal_harness/benchmark_adapters/skillsbench_acp_relay.py
+++ b/goal_harness/benchmark_adapters/skillsbench_acp_relay.py
@@ -361,7 +361,16 @@ class SkillsBenchLocalAcpRelay:
                         stderr_text=stderr_text,
                     )
                 raise RuntimeError("host app-server goal worker failed")
-            self._publish_worker_trace(output_json)
+            trace_required = bool(self._config.worker_public_trace_dir)
+            trace_published = self._publish_worker_trace(output_json)
+            if trace_required and not trace_published:
+                self._publish_worker_failure_trace(
+                    stage="worker_exit_zero_before_public_trace",
+                    returncode=proc.returncode,
+                    stdout_text=stdout_text,
+                    stderr_text=stderr_text,
+                )
+                raise RuntimeError("host app-server goal worker public trace missing")
             try:
                 response = response_path.read_text(encoding="utf-8").strip()
             except OSError as exc:


### PR DESCRIPTION
## Summary
- Fail closed when the SkillsBench app-server Goal worker exits successfully but no public compact worker trace can be published.
- Materialize a public-safe host worker process failure trace for the zero-exit/no-output case so future compact results distinguish runner/output failure from relay lifecycle-only evidence.
- Add a focused smoke that reproduces the r3-style normal-exit/no-public-output path and verifies private task/response/stderr text is not recorded.

## Validation
- python3 examples/skillsbench-app-server-goal-worker-smoke.py
- python3 -m py_compile goal_harness/benchmark_adapters/skillsbench_acp_relay.py examples/skillsbench-app-server-goal-worker-smoke.py
- git diff --check
- goal-harness check --scan-path goal_harness/benchmark_adapters/skillsbench_acp_relay.py --scan-path examples/skillsbench-app-server-goal-worker-smoke.py

## Boundary
- No raw benchmark logs, task text, trajectories, credentials, local run dirs, or private session material included.
- Private-looking strings in the smoke are synthetic negative assertions only.
