### PR TITLE
docs: add Codex CLI first-run rehearsal

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,9 @@ incident report, or launch draft.
 - [Codex CLI TUI-first loop](product/codex-cli-tui-loop.md): first-class
   Codex CLI onboarding target where one visible TUI message starts Goal
   Harness, with session-attached automation as the preferred follow-up.
+- [Codex CLI first-run rehearsal](product/codex-cli-first-run-rehearsal.md):
+  shortest public route from no-clone install to one-message TUI bootstrap and
+  proof-capture fixtures.
 - [Architecture](architecture.md): core concepts and control-plane shape.
 - [Integration guide](integration.md): how to connect a project to Goal
   Harness.

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -188,6 +188,9 @@ goal-harness codex-cli-exec-handoff --project . --goal-id <goal-id>
 
 See the [Codex CLI TUI-first loop](../product/codex-cli-tui-loop.md) contract
 for the bootstrap, session-attached automation, and headless fallback split.
+The [Codex CLI first-run rehearsal](../product/codex-cli-first-run-rehearsal.md)
+keeps the shortest user-facing route in one place: no-clone install,
+one-message TUI bootstrap, and proof-capture fixtures for later automation.
 
 Maintainers can validate the public fresh-clone path with:
 

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -18,6 +18,10 @@ runtime contract, benchmark route, or launch draft.
 - [Codex CLI packaged install path](codex-cli-packaged-install.md): the
   no-clone install/update/start route for Codex CLI users, with clone-plus-canary
   reserved for contributors.
+- [Codex CLI first-run rehearsal](codex-cli-first-run-rehearsal.md): the concise
+  fresh-user route that connects no-clone install, one-message TUI bootstrap,
+  and proof-capture fixtures while keeping later same-TUI automation optional
+  until visible proof passes.
 - [Codex CLI automation driver audit](codex-cli-automation-driver.md): the
   current Codex CLI scheduler/session surface audit, with a conservative local
   driver planner that keeps TUI bootstrap primary, composes quota/idle/fallback

--- a/docs/product/codex-cli-first-run-rehearsal.md
+++ b/docs/product/codex-cli-first-run-rehearsal.md
@@ -1,0 +1,115 @@
+# Codex CLI First-Run Rehearsal
+
+Status: product route and release rehearsal.
+
+Goal Harness should feel easy before it feels powerful. A fresh Codex CLI user
+should be able to stay in the TUI, paste one message, and see current goal
+state, gates, todos, and the next safe action without cloning this repository
+or reading Goal Harness internals first.
+
+This route connects three shipped surfaces:
+
+1. no-clone install/update through the GitHub archive installer;
+2. one-message Codex CLI TUI bootstrap;
+3. proof-capture fixtures for later visible automation.
+
+## Fresh User Path
+
+From the user's project repo:
+
+1. Open Codex CLI TUI.
+2. Paste one start message:
+
+   ```text
+   Start Goal Harness for this repo. If `goal-harness` is missing, install it
+   with the official no-clone GitHub installer, then connect this project. Show
+   me the current goal, concrete user gate if any, top todos, and next safe
+   action before running longer work. Keep me in this Codex CLI TUI unless I
+   explicitly accept a headless fallback. After I paste this, begin the Goal
+   Harness loop; do not stop after only explaining what Goal Harness is.
+   ```
+
+3. The agent installs or repairs Goal Harness when needed, using:
+
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/huangruiteng/goal-harness/main/scripts/install-from-github.sh | bash
+   export PATH="$HOME/.local/bin:$PATH"
+   goal-harness doctor
+   ```
+
+4. The agent connects the repo, runs quota/status, surfaces any concrete user
+   gate, and then starts one bounded validated segment if the guard permits.
+
+The user's first useful response should fit on one screen:
+
+- current goal id;
+- user gate, or none;
+- top user todo, or none;
+- top agent todo;
+- next safe action.
+
+## After Install
+
+Once `goal-harness` is on PATH, generate a stricter project-specific TUI message:
+
+```bash
+goal-harness codex-cli-bootstrap-message --project . --goal-id <goal-id> --message-only
+```
+
+For release rehearsal without running Codex or reading session material:
+
+```bash
+goal-harness codex-cli-tui-bootstrap-smoke-bundle \
+  --project . \
+  --goal-id <goal-id> \
+  --agent-id <agent-id>
+```
+
+That bundle checks the install-repair command, paste block, quota guard,
+bounded writeback, and spend command shape. It is not a first-time user step.
+
+## Later Automation Gate
+
+Same-TUI automation stays optional until the proof path passes. A scheduler may
+return to Codex CLI only after all of these are true:
+
+- visible-session proof is public-safe and accepted;
+- runtime idle evidence is fresh;
+- quota/status guard still permits the selected work;
+- the command boundary is explicit;
+- validation writes compact evidence or a blocker before spend.
+
+Rehearse the proof path with public fixtures:
+
+```bash
+goal-harness --format json codex-cli-visible-attach-acceptance \
+  --project . \
+  --goal-id public-codex-cli-goal \
+  --agent-id codex-side-bypass \
+  --fixture examples/fixtures/codex-cli-visible-proof/codex-visible-resume-help.public.json \
+  --proof-fixture examples/fixtures/codex-cli-visible-proof/visible-resume-proof.public.json \
+  --idle-fixture examples/fixtures/codex-cli-visible-proof/runtime-idle-visible-resume.public.json
+```
+
+This current likely path can pass as a visible later-turn spike, but it still
+does not prove same-open-TUI automation. Until a same-TUI attach proof is
+accepted, the product path remains one-message TUI bootstrap plus explicit
+fallbacks.
+
+## Boundary
+
+This first-run route must not:
+
+- require cloning the Goal Harness repo;
+- launch Codex as part of the rehearsal bundle;
+- read raw Codex transcripts, session files, stdout, stderr, credentials, or
+  private paths;
+- spend Goal Harness quota before validated writeback;
+- treat headless `codex exec` as the default user experience;
+- promote same-TUI automation without visible proof and idle evidence.
+
+See also:
+
+- [Codex CLI packaged install path](codex-cli-packaged-install.md)
+- [Codex CLI TUI-first loop](codex-cli-tui-loop.md)
+- [Codex CLI proof-capture demo](codex-cli-proof-capture-demo.md)

--- a/examples/codex-cli-first-run-rehearsal-smoke.py
+++ b/examples/codex-cli-first-run-rehearsal-smoke.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Validate the public Codex CLI first-run rehearsal route."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DOC = REPO_ROOT / "docs" / "product" / "codex-cli-first-run-rehearsal.md"
+PRODUCT_README = REPO_ROOT / "docs" / "product" / "README.md"
+DOCS_README = REPO_ROOT / "docs" / "README.md"
+GETTING_STARTED = REPO_ROOT / "docs" / "guides" / "getting-started.md"
+GOAL_ID = "public-codex-cli-goal"
+AGENT_ID = "codex-side-bypass"
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def run_cli(*args: str) -> str:
+    result = subprocess.run(
+        [sys.executable, "-m", "goal_harness.cli", *args],
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return result.stdout
+
+
+def assert_doc() -> None:
+    text = DOC.read_text(encoding="utf-8")
+    normalized = normalize(text)
+
+    must_have = (
+        "Codex CLI First-Run Rehearsal",
+        "no-clone install/update through the GitHub archive installer",
+        "one-message Codex CLI TUI bootstrap",
+        "proof-capture fixtures for later visible automation",
+        "Start Goal Harness for this repo",
+        "install-from-github.sh",
+        "goal-harness codex-cli-bootstrap-message --project . --goal-id <goal-id> --message-only",
+        "goal-harness codex-cli-tui-bootstrap-smoke-bundle",
+        "goal-harness --format json codex-cli-visible-attach-acceptance",
+        "does not prove same-open-TUI automation",
+        "Same-TUI automation stays optional until the proof path passes",
+        "must not:",
+        "require cloning the Goal Harness repo",
+        "read raw Codex transcripts, session files, stdout, stderr, credentials, or private paths",
+        "spend Goal Harness quota before validated writeback",
+        "treat headless `codex exec` as the default user experience",
+    )
+    for phrase in must_have:
+        assert phrase in normalized, phrase
+
+    first_response_index = normalized.index("current goal id")
+    later_automation_index = normalized.index("Same-TUI automation stays optional")
+    assert first_response_index < later_automation_index, text
+
+
+def assert_indexes() -> None:
+    product = PRODUCT_README.read_text(encoding="utf-8")
+    docs = DOCS_README.read_text(encoding="utf-8")
+    getting_started = GETTING_STARTED.read_text(encoding="utf-8")
+
+    link = "codex-cli-first-run-rehearsal.md"
+    assert link in product, product
+    assert f"product/{link}" in docs, docs
+    assert f"../product/{link}" in getting_started, getting_started
+    assert "no-clone install" in product, product
+    assert "one-message TUI bootstrap" in product, product
+    assert "proof-capture fixtures" in getting_started, getting_started
+
+
+def assert_cli_surfaces_align() -> None:
+    message = run_cli(
+        "codex-cli-bootstrap-message",
+        "--project",
+        "/tmp/public-codex-cli-project",
+        "--goal-id",
+        GOAL_ID,
+        "--agent-id",
+        AGENT_ID,
+        "--message-only",
+    )
+    normalized = normalize(message)
+    assert "Start the Goal Harness loop" in normalized, message
+    assert "install-from-github.sh" in normalized, message
+    assert "same Codex CLI TUI session" in normalized, message
+    assert "quota should-run" in normalized, message
+    assert "quota spend-slot" in normalized, message
+    assert "no raw Codex transcripts" in normalized, message
+
+    bundle = run_cli(
+        "codex-cli-tui-bootstrap-smoke-bundle",
+        "--project",
+        "/tmp/public-codex-cli-project",
+        "--goal-id",
+        GOAL_ID,
+        "--agent-id",
+        AGENT_ID,
+    )
+    normalized_bundle = normalize(bundle)
+    assert "Codex CLI TUI Bootstrap Smoke Bundle" in normalized_bundle, bundle
+    assert "runs_codex: `False`" in normalized_bundle, bundle
+    assert "requires_goal_harness_repo_clone: `False`" in normalized_bundle, bundle
+
+
+def main() -> int:
+    assert_doc()
+    assert_indexes()
+    assert_cli_surfaces_align()
+    print("codex-cli-first-run-rehearsal-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add a concise Codex CLI first-run rehearsal route that connects no-clone install, one-message TUI bootstrap, and proof-capture fixtures.
- Link the route from product docs, docs index, and getting-started.
- Add a focused smoke that checks the doc/index invariants and live CLI surfaces without running Codex.

## Validation
- python3 examples/codex-cli-first-run-rehearsal-smoke.py
- python3 examples/codex-cli-bootstrap-message-smoke.py
- python3 examples/codex-cli-tui-bootstrap-smoke-bundle-smoke.py
- python3 examples/codex-cli-proof-capture-demo-fixtures-smoke.py
- python3 examples/docs-governance-smoke.py
- python3 -m py_compile examples/codex-cli-first-run-rehearsal-smoke.py
- git diff --check origin/main..HEAD
- goal-harness check --scan-path docs/product/codex-cli-first-run-rehearsal.md --scan-path docs/product/README.md --scan-path docs/guides/getting-started.md --scan-path docs/README.md --scan-path examples/codex-cli-first-run-rehearsal-smoke.py

## Boundary
- No runtime behavior change.
- No Codex launch, transcript read, session-file read, credentials, private paths, benchmark logs, or local Goal Harness state.
- Private marker scan for previously leaked internal project names returned no hits.