### PR TITLE
Fix user todo interaction projection

### DIFF
--- a/examples/protocol-action-packet-smoke.py
+++ b/examples/protocol-action-packet-smoke.py
@@ -227,13 +227,18 @@ def assert_advancement_packet_keeps_user_todo_pending() -> None:
         goal_id=GOAL_ID,
     )
     packet = guard["protocol_action_packet"]
-    assert "actor=agent" in packet["summary"], packet
-    assert "user_action_required=false" in packet["summary"], packet
+    contract = guard["interaction_contract"]
+    assert "actor=agent_with_user_gate" in packet["summary"], packet
+    assert "user_action_required=true" in packet["summary"], packet
     assert "agent_action_required=true" in packet["summary"], packet
     assert "user_action_pending=true" in packet["summary"], packet
     assert f"user_action={USER_TODO}" in packet["summary"], packet
     assert "agent_action=[P1] LLM-assisted protocol simplification research spike" in packet["summary"], packet
     assert f"agent_action={USER_TODO}" not in packet["summary"], packet
+    assert contract["mode"] == "bounded_delivery_with_user_notice", contract
+    assert contract["user_channel"]["action_required"] is True, contract
+    assert contract["user_channel"]["notify"] == "NOTIFY", contract
+    assert contract["agent_channel"]["must_attempt"] is True, contract
 
 
 def assert_explicit_user_gate_still_allows_independent_agent_action() -> None:
@@ -290,13 +295,48 @@ def assert_monitor_only_packet_keeps_user_todo_pending() -> None:
         goal_id=GOAL_ID,
     )
     packet = guard["protocol_action_packet"]
+    contract = guard["interaction_contract"]
+    assert "actor=user" in packet["summary"], packet
+    assert "user_action_required=true" in packet["summary"], packet
+    assert "agent_action_required=false" in packet["summary"], packet
+    assert "quiet_noop_allowed=false" in packet["summary"], packet
+    assert "user_action_pending=true" not in packet["summary"], packet
+    assert f"user_action={USER_TODO}" in packet["summary"], packet
+    assert USER_TODO in packet["summary"], packet
+    assert guard.get("notify_user_on_open_todo") is None, guard
+    assert contract["mode"] == "user_action_required", contract
+    assert contract["user_channel"]["action_required"] is True, contract
+    assert contract["user_channel"]["notify"] == "NOTIFY", contract
+    assert contract["agent_channel"]["quiet_noop_allowed"] is False, contract
+
+
+def assert_explicit_non_gating_user_todo_stays_quiet() -> None:
+    guard = build_quota_should_run(
+        status_payload(
+            status="monitor_fixture",
+            agent_todos=[
+                todo(1, MONITOR_TODO, priority="P2", task_class="continuous_monitor"),
+            ],
+            user_todos=[
+                user_todo(
+                    1,
+                    "[P2] Watch the benchmark dashboard for a material transition.",
+                    task_class="continuous_monitor",
+                    action_kind="monitor",
+                )
+            ],
+        ),
+        goal_id=GOAL_ID,
+    )
+    packet = guard["protocol_action_packet"]
+    contract = guard["interaction_contract"]
     assert "actor=agent" in packet["summary"], packet
     assert "user_action_required=false" in packet["summary"], packet
     assert "agent_action_required=false" in packet["summary"], packet
     assert "quiet_noop_allowed=true" in packet["summary"], packet
     assert "user_action_pending=true" in packet["summary"], packet
-    assert USER_TODO in packet["summary"], packet
-    assert guard.get("notify_user_on_open_todo") is None, guard
+    assert contract["mode"] == "monitor_quiet_skip", contract
+    assert contract["user_channel"]["action_required"] is False, contract
 
 
 def assert_monitor_only_packet_allows_quiet_noop() -> None:
@@ -391,6 +431,7 @@ def main() -> None:
     assert_advancement_packet_keeps_user_todo_pending()
     assert_explicit_user_gate_still_allows_independent_agent_action()
     assert_monitor_only_packet_keeps_user_todo_pending()
+    assert_explicit_non_gating_user_todo_stays_quiet()
     assert_monitor_only_packet_allows_quiet_noop()
     assert_executable_recommended_action_overrides_monitor_todo()
     assert_goal_scoped_primary_action_ignores_foreign_backlog()

--- a/examples/work-lane-contract-smoke.py
+++ b/examples/work-lane-contract-smoke.py
@@ -243,7 +243,7 @@ def assert_monitor_only_todo_waits_quietly() -> None:
     assert "obligation=quiet_until_material_monitor_transition" in markdown, markdown
 
 
-def assert_monitor_only_with_user_todo_stays_quiet_without_transition() -> None:
+def assert_monitor_only_with_user_todo_surfaces_user_action_without_transition() -> None:
     user_todo = (
         "[P1] Decide whether to approve a no-submit Terminal-Bench setup check "
         "or provide public official-runner output."
@@ -295,15 +295,17 @@ def assert_monitor_only_with_user_todo_stays_quiet_without_transition() -> None:
     assert guard["requires_user_action"] is False, guard
     assert guard["execution_obligation"]["must_attempt_work"] is False, guard
     interaction = guard["interaction_contract"]
-    assert interaction["mode"] == "monitor_quiet_skip", interaction
-    assert interaction["user_channel"]["action_required"] is False, interaction
+    assert interaction["mode"] == "user_action_required", interaction
+    assert interaction["user_channel"]["action_required"] is True, interaction
+    assert interaction["user_channel"]["notify"] == "NOTIFY", interaction
     assert interaction["agent_channel"]["must_attempt"] is False, interaction
-    assert interaction["agent_channel"]["quiet_noop_allowed"] is True, interaction
+    assert interaction["agent_channel"]["quiet_noop_allowed"] is False, interaction
     packet = guard["protocol_action_packet"]
-    assert "actor=agent" in packet["summary"], packet
-    assert "user_action_required=false" in packet["summary"], packet
+    assert "actor=user" in packet["summary"], packet
+    assert "user_action_required=true" in packet["summary"], packet
     assert "agent_action_required=false" in packet["summary"], packet
-    assert "quiet_noop_allowed=true" in packet["summary"], packet
+    assert "quiet_noop_allowed=false" in packet["summary"], packet
+    assert "user_action=[P1] Decide whether to approve a no-submit Terminal-Bench" in packet["summary"], packet
     markdown = render_quota_should_run_markdown(guard)
     assert "monitor_quiet_until_material_transition" in markdown, markdown
     assert "heartbeat_repeat_notification_required" not in markdown, markdown
@@ -1006,7 +1008,7 @@ def main() -> int:
     assert_structured_surface_only_run_requires_outcome_followthrough()
     assert_contract_word_alone_does_not_trigger_outcome_followthrough()
     assert_monitor_only_todo_waits_quietly()
-    assert_monitor_only_with_user_todo_stays_quiet_without_transition()
+    assert_monitor_only_with_user_todo_surfaces_user_action_without_transition()
     assert_blocked_agent_todo_with_user_gate_notifies_without_execution()
     assert_monitor_only_with_planning_next_action_materializes_advancement()
     assert_monitor_only_with_adapter_next_action_materializes_advancement()

--- a/goal_harness/quota.py
+++ b/goal_harness/quota.py
@@ -2039,6 +2039,49 @@ def _protocol_todo_actions(summary: Any, *, limit: int = 3) -> list[str]:
     return actions
 
 
+def _user_todo_item_is_explicitly_non_gating(item: dict[str, Any]) -> bool:
+    if item.get("gating") is False or item.get("non_gating") is True:
+        return True
+    if _todo_task_class(item) == TODO_TASK_CLASS_MONITOR:
+        return True
+    action_kind = str(item.get("action_kind") or "").strip().lower()
+    return action_kind in {
+        "monitor",
+        "observe",
+        "watch",
+        "fyi",
+        "informational",
+        "non_gating",
+    }
+
+
+def _user_channel_action_todo_actions(summary: Any, *, limit: int = 3) -> list[str]:
+    if not isinstance(summary, dict):
+        return []
+    first_open_items = summary.get("first_open_items")
+    if not isinstance(first_open_items, list):
+        return []
+    actions: list[str] = []
+    for item in first_open_items:
+        if not isinstance(item, dict):
+            continue
+        if _user_todo_item_is_explicitly_non_gating(item):
+            continue
+        text = _protocol_action_label(item.get("text"))
+        if not text:
+            continue
+        actions.append(text)
+        if len(actions) >= limit:
+            break
+    return actions
+
+
+def _user_channel_action_required(payload: dict[str, Any]) -> bool:
+    return bool(payload.get("requires_user_action")) or bool(
+        _user_channel_action_todo_actions(payload.get("user_todo_summary"))
+    )
+
+
 def _protocol_first_candidate_action(payload: dict[str, Any]) -> str | None:
     goal_id = str(payload.get("goal_id") or "")
     capability_gate = (
@@ -2172,7 +2215,7 @@ def _protocol_action_packet(payload: dict[str, Any]) -> dict[str, Any]:
         if isinstance(payload.get("automation_liveness"), dict)
         else {}
     )
-    requires_user_action = bool(payload.get("requires_user_action"))
+    requires_user_action = _user_channel_action_required(payload)
     must_attempt_work = bool(execution_obligation.get("must_attempt_work"))
     scoped_user_gate_fallback = isinstance(payload.get("scoped_user_gate_fallback"), dict)
     bounded_delivery_with_user_notice = (
@@ -2306,7 +2349,7 @@ def _interaction_mode(payload: dict[str, Any]) -> str:
         return "scoped_user_gate_fallback"
     if effective_action == "automation_prompt_upgrade_required":
         return "automation_prompt_upgrade"
-    if payload.get("requires_user_action"):
+    if _user_channel_action_required(payload):
         if (
             bool(execution_obligation.get("must_attempt_work"))
             and bool(
@@ -2511,7 +2554,7 @@ def _interaction_contract(payload: dict[str, Any]) -> dict[str, Any]:
         else {}
     )
     mode = _interaction_mode(payload)
-    user_required = bool(payload.get("requires_user_action"))
+    user_required = _user_channel_action_required(payload)
     scoped_user_gate_fallback = mode == "scoped_user_gate_fallback"
     bounded_delivery_with_user_notice = mode == "bounded_delivery_with_user_notice"
     must_attempt = bool(execution_obligation.get("must_attempt_work")) if (
@@ -2572,6 +2615,12 @@ def _interaction_contract(payload: dict[str, Any]) -> dict[str, Any]:
         or (
             payload.get("scoped_user_gate_fallback", {}).get("reason")
             if isinstance(payload.get("scoped_user_gate_fallback"), dict)
+            else None
+        )
+        or (
+            "open user todo requires user-visible follow-up while independent "
+            "agent work may continue"
+            if _user_channel_action_todo_actions(payload.get("user_todo_summary"))
             else None
         )
         or (


### PR DESCRIPTION
## Summary
- Surface ordinary open user todos through interaction_contract.user_channel.action_required while preserving independent agent work lanes.
- Keep explicitly non-gating user todos quiet when they are marked as monitor/non-gating.
- Update protocol/work-lane smokes for the ECS kinit-style user todo projection shape.

## Validation
- python3 examples/protocol-action-packet-smoke.py
- python3 examples/work-lane-contract-smoke.py
- python3 examples/quota-plan-smoke.py
- python3 examples/heartbeat-quota-flow-smoke.py
- python3 -m py_compile goal_harness/quota.py examples/protocol-action-packet-smoke.py examples/work-lane-contract-smoke.py
- git diff --check HEAD~1..HEAD
- goal-harness check --scan-path goal_harness/quota.py --scan-path examples/protocol-action-packet-smoke.py --scan-path examples/work-lane-contract-smoke.py

## Boundary
- Only runtime projection logic and durable public smoke tests changed.
- No raw benchmark logs, trajectories, credentials, local state, or private evidence included.