### PR TITLE
docs: add Codex CLI no-clone release verification

### DIFF
--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -22,6 +22,10 @@ runtime contract, benchmark route, or launch draft.
   fresh-user route that connects no-clone install, one-message TUI bootstrap,
   and proof-capture fixtures while keeping later same-TUI automation optional
   until visible proof passes.
+- [Codex CLI no-clone release verification](codex-cli-no-clone-release-verification.md):
+  the compact release note and smoke contract that prove the packaged installer,
+  fresh-project bootstrap message, bootstrap bundle, and proof fixtures stay
+  aligned before no-clone install is advertised as the default user path.
 - [Codex CLI automation driver audit](codex-cli-automation-driver.md): the
   current Codex CLI scheduler/session surface audit, with a conservative local
   driver planner that keeps TUI bootstrap primary, composes quota/idle/fallback

--- a/docs/product/codex-cli-first-run-rehearsal.md
+++ b/docs/product/codex-cli-first-run-rehearsal.md
@@ -67,6 +67,9 @@ goal-harness codex-cli-tui-bootstrap-smoke-bundle \
 
 That bundle checks the install-repair command, paste block, quota guard,
 bounded writeback, and spend command shape. It is not a first-time user step.
+Use the [no-clone release verification](codex-cli-no-clone-release-verification.md)
+when validating that the packaged installer and fresh-project command surface
+match this route before promotion.
 
 ## Later Automation Gate
 

--- a/docs/product/codex-cli-no-clone-release-verification.md
+++ b/docs/product/codex-cli-no-clone-release-verification.md
@@ -1,0 +1,88 @@
+# Codex CLI No-Clone Release Verification
+
+Status: release verification note.
+
+The Codex CLI first-run route can be advertised as the preferred interactive
+path only when the shipped command surface matches the docs. The user should
+not have to clone Goal Harness before trying it from a project repo.
+
+## Verification Shape
+
+The release verifier exercises the path as a fresh user would see it:
+
+1. create a temporary HOME and a temporary project repo;
+2. run `scripts/install-from-github.sh` with the same archive-installer
+   mechanism used by the public no-clone command;
+3. confirm the installed `goal-harness` wrapper can run `doctor`;
+4. confirm the installed help surface exposes the first-run commands:
+   `codex-cli-bootstrap-message`, `codex-cli-tui-bootstrap-smoke-bundle`, and
+   `codex-cli-visible-attach-acceptance`;
+5. generate the one-message TUI bootstrap text from the fresh project;
+6. generate the transcript-free bootstrap bundle from the fresh project;
+7. replay the public proof-capture fixture from the installed release snapshot.
+
+The verifier does not launch Codex, read transcripts, read session files, read
+credentials, mutate a Codex session, or spend Goal Harness quota.
+
+Run it with:
+
+```bash
+python3 examples/codex-cli-no-clone-release-verification-smoke.py
+```
+
+## Current Result
+
+Current release route: **ready as the default candidate, with one boundary**.
+
+Ready:
+
+- the archive installer creates a stable release snapshot without requiring a
+  local Goal Harness checkout;
+- the installed wrapper exposes the first-run TUI bootstrap, smoke bundle, and
+  visible-attach acceptance commands;
+- the generated bootstrap text tells the agent to install, connect, run quota,
+  preserve the visible TUI, write back evidence, and avoid raw transcripts;
+- the smoke bundle confirms no Codex launch and no Goal Harness quota spend;
+- proof-capture fixtures are packaged into the release snapshot and can be
+  replayed by the installed wrapper.
+
+Boundary:
+
+- public install still depends on network access to GitHub archive endpoints
+  unless the caller overrides `GOAL_HARNESS_ARCHIVE_URL` with a trusted archive;
+- same-TUI automation is not the default path until visible proof plus runtime
+  idle evidence pass.
+
+That means the product copy can prefer no-clone install for Codex CLI users,
+while contributor clone-plus-canary remains the development path.
+
+## Release Checklist
+
+Before promoting a new release snapshot, run:
+
+```bash
+python3 examples/codex-cli-no-clone-release-verification-smoke.py
+python3 examples/codex-cli-first-run-rehearsal-smoke.py
+python3 examples/codex-cli-tui-bootstrap-smoke-bundle-smoke.py
+python3 examples/codex-cli-proof-capture-demo-fixtures-smoke.py
+```
+
+If the first command fails, do not advertise no-clone as the default until the
+failure is reduced to a compact blocker: missing installer dependency, archive
+layout mismatch, missing installed command, broken bootstrap generation, or
+missing public proof fixture.
+
+## Boundary
+
+Keep this verification public-safe:
+
+- no raw Codex transcript or session material;
+- no credentials, auth material, or private local paths;
+- no benchmark logs, task text, trajectories, or production evidence;
+- no Codex execution as part of the verifier.
+
+See also:
+
+- [Codex CLI packaged install path](codex-cli-packaged-install.md)
+- [Codex CLI first-run rehearsal](codex-cli-first-run-rehearsal.md)
+- [Codex CLI proof-capture demo](codex-cli-proof-capture-demo.md)

--- a/examples/codex-cli-no-clone-release-verification-smoke.py
+++ b/examples/codex-cli-no-clone-release-verification-smoke.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Verify the Codex CLI no-clone first-run release route."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tarfile
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DOC = REPO_ROOT / "docs" / "product" / "codex-cli-no-clone-release-verification.md"
+FIRST_RUN_DOC = REPO_ROOT / "docs" / "product" / "codex-cli-first-run-rehearsal.md"
+PRODUCT_README = REPO_ROOT / "docs" / "product" / "README.md"
+GOAL_ID = "public-no-clone-release-goal"
+AGENT_ID = "codex-side-bypass"
+FIRST_RUN_COMMANDS = (
+    "codex-cli-bootstrap-message",
+    "codex-cli-tui-bootstrap-smoke-bundle",
+    "codex-cli-visible-attach-acceptance",
+)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def run(
+    command: list[str],
+    *,
+    env: dict[str, str],
+    cwd: Path,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        check=True,
+        env=env,
+        cwd=cwd,
+        text=True,
+        capture_output=True,
+    )
+
+
+def add_tree(tar: tarfile.TarFile, root: Path, name: str) -> None:
+    path = root / name
+    if path.is_dir():
+        for child in sorted(path.rglob("*")):
+            if ".git" in child.parts or "__pycache__" in child.parts:
+                continue
+            tar.add(child, arcname=str(Path("goal-harness-main") / child.relative_to(root)))
+    else:
+        tar.add(path, arcname=str(Path("goal-harness-main") / name))
+
+
+def assert_docs() -> None:
+    doc = DOC.read_text(encoding="utf-8")
+    first_run = FIRST_RUN_DOC.read_text(encoding="utf-8")
+    product_readme = PRODUCT_README.read_text(encoding="utf-8")
+    normalized = normalize(doc)
+
+    must_have = (
+        "Codex CLI No-Clone Release Verification",
+        "scripts/install-from-github.sh",
+        "codex-cli-bootstrap-message",
+        "codex-cli-tui-bootstrap-smoke-bundle",
+        "codex-cli-visible-attach-acceptance",
+        "Current release route: **ready as the default candidate, with one boundary**.",
+        "network access to GitHub archive endpoints",
+        "same-TUI automation is not the default path",
+        "python3 examples/codex-cli-no-clone-release-verification-smoke.py",
+        "no raw Codex transcript or session material",
+        "no Codex execution as part of the verifier",
+    )
+    for phrase in must_have:
+        assert phrase in normalized, phrase
+
+    for command in FIRST_RUN_COMMANDS:
+        assert command in doc, command
+    assert "codex-cli-no-clone-release-verification.md" in first_run, first_run
+    assert "codex-cli-no-clone-release-verification.md" in product_readme, product_readme
+
+
+def assert_installed_release(
+    *,
+    installed: Path,
+    release_dir: Path,
+    env: dict[str, str],
+    fresh_repo: Path,
+    codex_called_marker: Path,
+) -> None:
+    doctor = run([str(installed), "doctor"], env=env, cwd=fresh_repo)
+    assert "ok: `True`" in doctor.stdout, doctor.stdout
+
+    help_text = run([str(installed), "--help"], env=env, cwd=fresh_repo).stdout
+    for command in FIRST_RUN_COMMANDS:
+        assert command in help_text, help_text
+
+    assert (release_dir / "docs" / "product" / "codex-cli-first-run-rehearsal.md").exists()
+    assert (release_dir / "docs" / "product" / "codex-cli-no-clone-release-verification.md").exists()
+    fixture_dir = release_dir / "examples" / "fixtures" / "codex-cli-visible-proof"
+    assert fixture_dir.exists(), fixture_dir
+
+    message = run(
+        [
+            str(installed),
+            "codex-cli-bootstrap-message",
+            "--project",
+            str(fresh_repo),
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_ID,
+            "--message-only",
+        ],
+        env=env,
+        cwd=fresh_repo,
+    ).stdout
+    normalized_message = normalize(message)
+    assert "Start the Goal Harness loop" in normalized_message, message
+    assert "install-from-github.sh" in normalized_message, message
+    assert "same Codex CLI TUI session" in normalized_message, message
+    assert "quota should-run" in normalized_message, message
+    assert "quota spend-slot" in normalized_message, message
+    assert "no raw Codex transcripts" in normalized_message, message
+
+    bundle = json.loads(
+        run(
+            [
+                str(installed),
+                "--format",
+                "json",
+                "codex-cli-tui-bootstrap-smoke-bundle",
+                "--project",
+                str(fresh_repo),
+                "--goal-id",
+                GOAL_ID,
+                "--agent-id",
+                AGENT_ID,
+            ],
+            env=env,
+            cwd=fresh_repo,
+        ).stdout
+    )
+    assert bundle["schema_version"] == "codex_cli_tui_bootstrap_smoke_bundle_v0", bundle
+    assert bundle["boundary"]["runs_codex"] is False, bundle
+    assert bundle["boundary"]["requires_goal_harness_repo_clone"] is False, bundle
+    assert bundle["boundary"]["spends_goal_harness_quota"] is False, bundle
+    assert str(fresh_repo) in bundle["message_only_command"], bundle
+
+    acceptance = json.loads(
+        run(
+            [
+                str(installed),
+                "--format",
+                "json",
+                "codex-cli-visible-attach-acceptance",
+                "--project",
+                str(fresh_repo),
+                "--goal-id",
+                GOAL_ID,
+                "--agent-id",
+                AGENT_ID,
+                "--fixture",
+                str(fixture_dir / "codex-visible-resume-help.public.json"),
+                "--proof-fixture",
+                str(fixture_dir / "visible-resume-proof.public.json"),
+                "--idle-fixture",
+                str(fixture_dir / "runtime-idle-visible-resume.public.json"),
+            ],
+            env=env,
+            cwd=fresh_repo,
+        ).stdout
+    )
+    assert acceptance["decision"] == "visible_surface_spike_passed_not_same_tui", acceptance
+    assert acceptance["accepted_for_visible_later_turn"] is True, acceptance
+    assert acceptance["accepted_for_same_tui_automation"] is False, acceptance
+    assert acceptance["boundary"]["runs_codex"] is False, acceptance
+    assert acceptance["boundary"]["reads_raw_transcripts"] is False, acceptance
+    assert acceptance["boundary"]["reads_session_files"] is False, acceptance
+
+    assert not codex_called_marker.exists(), codex_called_marker
+
+
+def main() -> None:
+    assert_docs()
+
+    install_script = REPO_ROOT / "scripts" / "install-from-github.sh"
+    subprocess.run(["bash", "-n", str(install_script)], check=True)
+
+    with tempfile.TemporaryDirectory(prefix="goal-harness-no-clone-release-") as td:
+        tmp = Path(td)
+        archive = tmp / "goal-harness.tar.gz"
+        home = tmp / "home"
+        fake_bin = tmp / "fake-bin"
+        fresh_repo = tmp / "public-fresh-project"
+        releases_dir = home / ".local" / "share" / "goal-harness" / "releases"
+        codex_called_marker = tmp / "codex-called"
+        home.mkdir()
+        fake_bin.mkdir()
+        fresh_repo.mkdir()
+        (fresh_repo / "README.md").write_text("# Public fresh project\n", encoding="utf-8")
+
+        fake_codex = fake_bin / "codex"
+        fake_codex.write_text(
+            "#!/usr/bin/env bash\n"
+            "echo called > \"${CODEX_CALLED_MARKER:?}\"\n"
+            "exit 77\n",
+            encoding="utf-8",
+        )
+        fake_codex.chmod(0o755)
+
+        with tarfile.open(archive, "w:gz") as tar:
+            for name in (
+                "goal_harness",
+                "scripts",
+                "skills",
+                "docs",
+                "examples",
+                "README.md",
+                "pyproject.toml",
+                "LICENSE",
+            ):
+                add_tree(tar, REPO_ROOT, name)
+
+        env = os.environ.copy()
+        env.update(
+            {
+                "HOME": str(home),
+                "CODEX_HOME": str(home / ".codex"),
+                "GOAL_HARNESS_BIN_DIR": str(home / ".local" / "bin"),
+                "GOAL_HARNESS_RELEASES_DIR": str(releases_dir),
+                "GOAL_HARNESS_SHELL_PROFILE": str(home / ".profile"),
+                "GOAL_HARNESS_ARCHIVE_URL": f"file://{archive}",
+                "GOAL_HARNESS_INSTALL_CANARY": "0",
+                "CODEX_CALLED_MARKER": str(codex_called_marker),
+                "PATH": f"{fake_bin}:{env.get('PATH', '')}",
+            }
+        )
+        install = run(["bash", str(install_script)], env=env, cwd=tmp)
+        assert "goal-harness installed locally" in install.stdout, install.stdout
+        assert "canary executable: skipped" in install.stdout, install.stdout
+
+        installed = home / ".local" / "bin" / "goal-harness"
+        assert installed.exists(), installed
+        release_dirs = [path for path in releases_dir.iterdir() if path.is_dir()]
+        assert len(release_dirs) == 1, release_dirs
+
+        assert_installed_release(
+            installed=installed,
+            release_dir=release_dirs[0],
+            env=env,
+            fresh_repo=fresh_repo,
+            codex_called_marker=codex_called_marker,
+        )
+
+    print("codex-cli-no-clone-release-verification-smoke ok")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add a compact Codex CLI no-clone release verification note.
- Add a release-path smoke that installs Goal Harness into a temporary HOME from an archive, runs the installed wrapper from a fresh temp project, checks command availability, generates the bootstrap message and bootstrap bundle, and replays packaged proof fixtures.
- Link the verification note from the product docs and first-run rehearsal route.

## Validation
- python3 examples/codex-cli-no-clone-release-verification-smoke.py
- python3 examples/codex-cli-first-run-rehearsal-smoke.py
- python3 examples/codex-cli-tui-bootstrap-smoke-bundle-smoke.py
- python3 examples/codex-cli-proof-capture-demo-fixtures-smoke.py
- python3 examples/docs-governance-smoke.py
- python3 -m py_compile examples/codex-cli-no-clone-release-verification-smoke.py
- git diff --check
- goal-harness check --scan-path docs/product/codex-cli-no-clone-release-verification.md --scan-path docs/product/codex-cli-first-run-rehearsal.md --scan-path docs/product/README.md --scan-path examples/codex-cli-no-clone-release-verification-smoke.py

## Boundary
- No runtime behavior change.
- Smoke does not launch Codex, read transcripts/session files, use credentials, or spend Goal Harness quota.
- Private marker scan for prior internal project names returned no hits.
- The smoke uses a deterministic archive URL override instead of depending on live GitHub network availability.