### PR TITLE
docs: record Codex CLI live TUI pilot

### DIFF
--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -22,6 +22,10 @@ runtime contract, benchmark route, or launch draft.
   fresh-user route that connects no-clone install, one-message TUI bootstrap,
   and proof-capture fixtures while keeping later same-TUI automation optional
   until visible proof passes.
+- [Codex CLI live TUI first-message pilot](codex-cli-live-tui-first-message-pilot.md):
+  the first real TUI launch attempt for the generated start message, recording
+  why manual paste remains primary until a bounded visible completion proof
+  exists.
 - [Codex CLI no-clone release verification](codex-cli-no-clone-release-verification.md):
   the compact release note and smoke contract that prove the packaged installer,
   fresh-project bootstrap message, bootstrap bundle, and proof fixtures stay

--- a/docs/product/codex-cli-first-run-rehearsal.md
+++ b/docs/product/codex-cli-first-run-rehearsal.md
@@ -99,6 +99,18 @@ does not prove same-open-TUI automation. Until a same-TUI attach proof is
 accepted, the product path remains one-message TUI bootstrap plus explicit
 fallbacks.
 
+## Live TUI Pilot Note
+
+The first real [live TUI first-message pilot](codex-cli-live-tui-first-message-pilot.md)
+confirmed that the generated message can launch Codex CLI through
+`codex [PROMPT]`, but it did not prove that the Goal Harness loop started
+successfully. The process stayed active, no bounded first-response marker was
+available, and passing the message as argv would leak project-specific prompt
+text through the process command line in real repos.
+
+So the reliable first-run route remains manual paste into the visible Codex CLI
+TUI. Automated live launch needs a bounded visible completion proof first.
+
 ## Boundary
 
 This first-run route must not:

--- a/docs/product/codex-cli-live-tui-first-message-pilot.md
+++ b/docs/product/codex-cli-live-tui-first-message-pilot.md
@@ -1,0 +1,110 @@
+# Codex CLI Live TUI First-Message Pilot
+
+Status: blocker recorded; manual TUI bootstrap remains primary.
+Recorded: 2026-06-21.
+
+This note records a real Codex CLI TUI pilot for the one-message Goal Harness
+bootstrap path. The pilot used only a disposable public-safe repo and kept raw
+TUI output, Codex transcripts, session files, credentials, and private project
+paths out of the repository.
+
+## Question
+
+Can Goal Harness launch a real visible Codex CLI TUI with the generated start
+message and prove that the loop starts, remains observable, and stays steerable
+by the user?
+
+## Method
+
+The pilot used a temporary public repo with a small `README.md`, a small
+`GOAL.md`, and a generated start message:
+
+```bash
+goal-harness codex-cli-bootstrap-message \
+  --project /tmp/goal-harness-live-tui-pilot.<suffix> \
+  --goal-id public-live-tui-pilot-goal \
+  --agent-id codex-side-bypass \
+  --message-only
+```
+
+The local Codex CLI surface was `codex-cli 0.142.0-alpha.7`. Its help exposed:
+
+- `codex [OPTIONS] [PROMPT]`;
+- `--no-alt-screen`;
+- `--cd <DIR>`;
+- `resume`;
+- `remote-control`.
+
+Two bounded probes were attempted:
+
+1. `codex doctor` from the disposable repo. It did not produce bounded output
+   before manual interrupt.
+2. A real TUI launch with a public-safe generated message:
+
+   ```bash
+   codex --no-alt-screen --ask-for-approval never --sandbox workspace-write \
+     -C /tmp/goal-harness-live-tui-pilot.<suffix> \
+     "$(cat goal-harness-start-message.txt)"
+   ```
+
+The second probe launched Codex CLI, but it did not produce a compact,
+machine-checkable first-response result in the bounded capture window. The
+process was still active afterward and was stopped by exact temp-repo process
+match.
+
+## Result
+
+Not proven yet.
+
+The generated message can start a real Codex CLI TUI through `codex [PROMPT]`,
+but the current automation-side proof is insufficient for claiming that the
+Goal Harness loop started successfully.
+
+Observed blockers:
+
+- no bounded first-response or completion marker;
+- capture output exceeded the automation budget before a compact result was
+  available;
+- the TUI process remained active after the capture window;
+- passing the generated message as `[PROMPT]` exposes the prompt in the process
+  command line, which is acceptable only for this public-safe pilot and should
+  not become the default path for real project repos.
+
+Decision:
+
+`live_tui_first_message_blocked_by_bounded_visible_completion_missing`
+
+## Product Implication
+
+The public user path should still be:
+
+1. the user opens Codex CLI TUI in the project repo;
+2. the user pastes one Goal Harness start message;
+3. Codex keeps the visible TUI as the live control surface.
+
+Goal Harness should not advertise automated `codex [PROMPT]` launch as a
+verified first-run path until a bounded visible pilot adapter exists.
+
+That adapter needs to prove all of these without raw transcript or session-file
+reads:
+
+- inject or paste the start message without leaking project-specific prompt
+  text through process arguments;
+- observe a compact public-safe first-response marker;
+- stop or idle-check the TUI without racing the user;
+- show that the user can still steer, review, interrupt, or take over;
+- write compact success evidence or a precise blocker before quota spend.
+
+## Follow-Up
+
+Create a bounded visible pilot adapter before promoting live TUI automation:
+
+```text
+[P0] Codex CLI bounded visible pilot adapter: define and test a minimal
+public-safe first-response capture and stop protocol for Codex CLI TUI bootstrap
+before claiming live TUI first-message success; avoid raw transcripts, session
+files, credentials, private paths, and argv prompt leakage.
+```
+
+Until then, keep the no-clone installer, generated paste message, and
+transcript-free smoke bundle as the reliable first-run route.

--- a/examples/codex-cli-live-tui-first-message-pilot-smoke.py
+++ b/examples/codex-cli-live-tui-first-message-pilot-smoke.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Validate the Codex CLI live TUI first-message pilot record."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DOC = REPO_ROOT / "docs" / "product" / "codex-cli-live-tui-first-message-pilot.md"
+FIRST_RUN = REPO_ROOT / "docs" / "product" / "codex-cli-first-run-rehearsal.md"
+PRODUCT_README = REPO_ROOT / "docs" / "product" / "README.md"
+GOAL_ID = "public-live-tui-pilot-goal"
+AGENT_ID = "codex-side-bypass"
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def run_cli(*args: str) -> str:
+    result = subprocess.run(
+        [sys.executable, "-m", "goal_harness.cli", *args],
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return result.stdout
+
+
+def assert_doc() -> None:
+    text = DOC.read_text(encoding="utf-8")
+    normalized = normalize(text)
+
+    must_have = (
+        "Codex CLI Live TUI First-Message Pilot",
+        "Status: blocker recorded; manual TUI bootstrap remains primary.",
+        "Recorded: 2026-06-21.",
+        "disposable public-safe repo",
+        "codex [OPTIONS] [PROMPT]",
+        "--no-alt-screen",
+        "--cd <DIR>",
+        "resume",
+        "remote-control",
+        "codex doctor",
+        "did not produce bounded output before manual interrupt",
+        "no bounded first-response or completion marker",
+        "capture output exceeded the automation budget",
+        "process remained active",
+        "process command line",
+        "live_tui_first_message_blocked_by_bounded_visible_completion_missing",
+        "manual TUI bootstrap remains primary",
+        "the user pastes one Goal Harness start message",
+        "without leaking project-specific prompt text through process arguments",
+        "raw transcript or session-file reads",
+        "Codex CLI bounded visible pilot adapter",
+    )
+    for phrase in must_have:
+        assert phrase in normalized, phrase
+
+    assert "Goal Harness should not advertise automated `codex [PROMPT]` launch" in text
+    assert "raw TUI output, Codex transcripts, session files" in normalized, text
+    assert "without raw transcript or session-file reads" in normalized, text
+
+
+def assert_indexes() -> None:
+    product = PRODUCT_README.read_text(encoding="utf-8")
+    first_run = FIRST_RUN.read_text(encoding="utf-8")
+    assert "codex-cli-live-tui-first-message-pilot.md" in product, product
+    assert "Codex CLI live TUI first-message pilot" in product, product
+    assert "Live TUI Pilot Note" in first_run, first_run
+    assert (
+        "Automated live launch needs a bounded visible completion proof first." in first_run
+    ), first_run
+
+
+def assert_bootstrap_message_still_copy_first() -> None:
+    message = run_cli(
+        "codex-cli-bootstrap-message",
+        "--project",
+        "/tmp/goal-harness-live-tui-pilot.public",
+        "--goal-id",
+        GOAL_ID,
+        "--agent-id",
+        AGENT_ID,
+        "--message-only",
+    )
+    normalized = normalize(message)
+    assert "Start the Goal Harness loop" in normalized, message
+    assert "same Codex CLI TUI session" in normalized, message
+    assert "begin the Goal Harness loop automatically" in normalized, message
+    assert "Do not store raw Codex transcripts" in normalized, message
+    assert "visible steering turns" in normalized, message
+
+
+def main() -> int:
+    assert_doc()
+    assert_indexes()
+    assert_bootstrap_message_still_copy_first()
+    print("codex-cli-live-tui-first-message-pilot-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- record the real Codex CLI live TUI first-message pilot as a precise blocker, not a success claim
- link the pilot from product docs and first-run rehearsal
- add a smoke that keeps the first-run route copy-first and guards against overclaiming live TUI automation

## Validation
- python3 examples/codex-cli-live-tui-first-message-pilot-smoke.py
- python3 -m py_compile examples/codex-cli-live-tui-first-message-pilot-smoke.py
- python3 examples/codex-cli-first-run-rehearsal-smoke.py
- python3 examples/codex-cli-bootstrap-message-smoke.py
- python3 examples/codex-cli-one-message-loop-pilot-smoke.py
- python3 examples/codex-cli-visible-local-driver-pilot-smoke.py
- python3 examples/codex-cli-no-clone-release-verification-smoke.py
- python3 examples/docs-governance-smoke.py
- goal-harness check --scan-path docs/product/codex-cli-live-tui-first-message-pilot.md --scan-path docs/product/codex-cli-first-run-rehearsal.md --scan-path docs/product/README.md --scan-path examples/codex-cli-live-tui-first-message-pilot-smoke.py
- git diff --check