### PR TITLE
Add benchmark case-analysis candidate detector

### DIFF
--- a/examples/benchmark-case-analysis-candidates-smoke.py
+++ b/examples/benchmark-case-analysis-candidates-smoke.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Smoke-test public-safe benchmark case-analysis candidate detection."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from goal_harness.benchmark_case_analysis import (  # noqa: E402
+    BENCHMARK_CASE_ANALYSIS_CANDIDATE_REPORT_SCHEMA_VERSION,
+    build_case_analysis_candidate_report,
+    render_case_analysis_candidate_report_markdown,
+)
+
+
+FORBIDDEN_PATTERNS = [
+    re.compile(r"/Users/"),
+    re.compile(r"trajectory/", re.IGNORECASE),
+    re.compile(r"\.local/"),
+    re.compile(r"(?<![A-Za-z0-9])sk-[A-Za-z0-9_-]{8,}"),
+]
+
+
+def assert_public_safe(text: str) -> None:
+    for pattern in FORBIDDEN_PATTERNS:
+        assert not pattern.search(text), pattern.pattern
+
+
+def fixture_ledger() -> dict:
+    return {
+        "schema_version": "benchmark_run_ledger_v0",
+        "benchmarks": {
+            "bench@v1": {
+                "benchmark_id": "bench@v1",
+                "cases": {
+                    "existing-case": {
+                        "case_id": "existing-case",
+                        "latest_decision": {"decision": "paired_no_score_uplift"},
+                        "runs": [{"run_id": "old"}],
+                    },
+                    "new-no-uplift": {
+                        "case_id": "new-no-uplift",
+                        "latest_decision": {"decision": "paired_no_score_uplift"},
+                        "runs": [
+                            {"run_id": "baseline", "official_score": 0.0},
+                            {"run_id": "treatment", "official_score": 0.0},
+                        ],
+                    },
+                    "new-baseline-pass": {
+                        "case_id": "new-baseline-pass",
+                        "latest_decision": {
+                            "decision": "baseline_passed_not_current_treatment_priority"
+                        },
+                        "runs": [{"run_id": "pass", "official_score": 1.0}],
+                    },
+                    "empty-case": {
+                        "case_id": "empty-case",
+                        "latest_decision": {"decision": "no_runs_recorded"},
+                        "runs": [],
+                    },
+                },
+            }
+        },
+    }
+
+
+def fixture_analysis() -> dict:
+    return {
+        "schema_version": "benchmark_case_analysis_v0",
+        "cases": [
+            {
+                "benchmark_id": "bench@v1",
+                "case_id": "existing-case",
+                "analysis_id": "bench__existing-case__paired_no_score_uplift",
+            }
+        ],
+    }
+
+
+def test_candidate_report_from_fixture() -> None:
+    report = build_case_analysis_candidate_report(
+        ledger=fixture_ledger(),
+        analysis=fixture_analysis(),
+    )
+    assert report["schema_version"] == (
+        BENCHMARK_CASE_ANALYSIS_CANDIDATE_REPORT_SCHEMA_VERSION
+    ), report
+    candidates = report["candidates"]
+    assert [candidate["case_id"] for candidate in candidates] == [
+        "new-no-uplift",
+        "new-baseline-pass",
+    ], candidates
+    by_case = {candidate["case_id"]: candidate for candidate in candidates}
+    assert by_case["new-no-uplift"]["candidate_class"] == (
+        "paired_no_uplift_candidate"
+    ), by_case
+    assert by_case["new-no-uplift"]["promotion_priority"] == "P1", by_case
+    assert by_case["new-baseline-pass"]["candidate_class"] == (
+        "baseline_solved_control_candidate"
+    ), by_case
+    assert report["source_boundary"]["raw_logs_recorded"] is False, report
+    assert report["source_boundary"]["raw_task_text_recorded"] is False, report
+    assert report["source_boundary"]["trajectory_recorded"] is False, report
+    assert_public_safe(json.dumps(report, ensure_ascii=False))
+    assert_public_safe(render_case_analysis_candidate_report_markdown(report))
+
+
+def test_candidate_cli_on_fixture() -> None:
+    with tempfile.TemporaryDirectory(prefix="case-analysis-candidates-") as tmp:
+        root = Path(tmp)
+        ledger_path = root / "ledger.json"
+        analysis_path = root / "analysis.json"
+        ledger_path.write_text(json.dumps(fixture_ledger()), encoding="utf-8")
+        analysis_path.write_text(json.dumps(fixture_analysis()), encoding="utf-8")
+        output = subprocess.check_output(
+            [
+                sys.executable,
+                str(REPO_ROOT / "scripts" / "benchmark_case_analysis_candidates.py"),
+                "--ledger",
+                str(ledger_path),
+                "--analysis",
+                str(analysis_path),
+            ],
+            text=True,
+        )
+        report = json.loads(output)
+        assert report["candidate_count"] == 2, report
+        markdown = subprocess.check_output(
+            [
+                sys.executable,
+                str(REPO_ROOT / "scripts" / "benchmark_case_analysis_candidates.py"),
+                "--ledger",
+                str(ledger_path),
+                "--analysis",
+                str(analysis_path),
+                "--format",
+                "markdown",
+            ],
+            text=True,
+        )
+        assert "new-no-uplift" in markdown, markdown
+        assert "existing-case" not in markdown, markdown
+        assert_public_safe(markdown)
+
+
+def test_default_assets_have_public_safe_candidates() -> None:
+    output = subprocess.check_output(
+        [
+            sys.executable,
+            str(REPO_ROOT / "scripts" / "benchmark_case_analysis_candidates.py"),
+        ],
+        text=True,
+    )
+    assert_public_safe(output)
+    report = json.loads(output)
+    assert report["candidate_count"] >= 1, report
+    assert all(
+        candidate["raw_logs_recorded"] is False
+        and candidate["raw_task_text_recorded"] is False
+        and candidate["trajectory_recorded"] is False
+        for candidate in report["candidates"]
+    ), report
+
+
+def main() -> None:
+    test_candidate_report_from_fixture()
+    test_candidate_cli_on_fixture()
+    test_default_assets_have_public_safe_candidates()
+    print("benchmark-case-analysis-candidates-smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/goal_harness/benchmark_case_analysis.py
+++ b/goal_harness/benchmark_case_analysis.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+BENCHMARK_CASE_ANALYSIS_CANDIDATE_REPORT_SCHEMA_VERSION = (
+    "benchmark_case_analysis_candidate_report_v0"
+)
+
+NO_RUN_DECISIONS = {"", "no_runs_recorded"}
+
+
+def load_json(path: str | Path) -> dict[str, Any]:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def _compact_text(value: object, *, limit: int = 200) -> str:
+    text = str(value or "").strip()
+    text = " ".join(text.split())
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1].rstrip() + "..."
+
+
+def case_analysis_keys(analysis: dict[str, Any]) -> set[tuple[str, str]]:
+    keys: set[tuple[str, str]] = set()
+    cases = analysis.get("cases")
+    if not isinstance(cases, list):
+        return keys
+    for case in cases:
+        if not isinstance(case, dict):
+            continue
+        benchmark_id = _compact_text(case.get("benchmark_id"), limit=160)
+        case_id = _compact_text(case.get("case_id"), limit=200)
+        if benchmark_id and case_id:
+            keys.add((benchmark_id, case_id))
+    return keys
+
+
+def classify_case_analysis_candidate(
+    *,
+    latest_decision: str,
+    run_count: int,
+) -> dict[str, str]:
+    if latest_decision == "paired_no_score_uplift":
+        return {
+            "candidate_class": "paired_no_uplift_candidate",
+            "promotion_priority": "P1",
+            "recommended_handling": (
+                "promote when the no-uplift result changes routing, prompt, or "
+                "treatment policy"
+            ),
+        }
+    if latest_decision == "paired_baseline_solved_treatment_preserved":
+        return {
+            "candidate_class": "baseline_solved_non_regression_candidate",
+            "promotion_priority": "P2",
+            "recommended_handling": (
+                "promote selectively as a non-regression guard or keep in "
+                "generated coverage"
+            ),
+        }
+    if latest_decision.startswith("paired_treatment_") and (
+        "alignment_required" in latest_decision
+        or "preflight_required" in latest_decision
+    ):
+        return {
+            "candidate_class": "infrastructure_alignment_candidate",
+            "promotion_priority": "P1",
+            "recommended_handling": (
+                "promote only when the alignment or preflight lesson is reusable "
+                "across future runs"
+            ),
+        }
+    if latest_decision == "baseline_failed_treatment_candidate":
+        return {
+            "candidate_class": "baseline_failure_treatment_candidate",
+            "promotion_priority": "P1",
+            "recommended_handling": (
+                "add failure attribution or a matched treatment before making a "
+                "strong case-analysis claim"
+            ),
+        }
+    if "runner_or_setup" in latest_decision or "setup" in latest_decision:
+        return {
+            "candidate_class": "setup_or_runner_gap_defer",
+            "promotion_priority": "P2",
+            "recommended_handling": (
+                "defer until the compact run reaches scoring or the setup blocker "
+                "itself becomes a reusable infrastructure lesson"
+            ),
+        }
+    if latest_decision == "baseline_passed_not_current_treatment_priority":
+        return {
+            "candidate_class": "baseline_solved_control_candidate",
+            "promotion_priority": "P2",
+            "recommended_handling": (
+                "promote selectively as a baseline-solved control when the case "
+                "is needed for routing or coverage"
+            ),
+        }
+    if latest_decision == "single_arm_recorded":
+        priority = "P1" if run_count > 1 else "P2"
+        return {
+            "candidate_class": "single_arm_coverage_or_baseline_candidate",
+            "promotion_priority": priority,
+            "recommended_handling": (
+                "keep as coverage unless the single-arm result teaches a durable "
+                "routing or infrastructure lesson"
+            ),
+        }
+    return {
+        "candidate_class": "needs_manual_classification",
+        "promotion_priority": "P1",
+        "recommended_handling": (
+            "inspect compact ledger fields only and classify before editing "
+            "case-analysis"
+        ),
+    }
+
+
+def find_case_analysis_candidates(
+    *,
+    ledger: dict[str, Any],
+    analysis: dict[str, Any],
+) -> list[dict[str, Any]]:
+    existing = case_analysis_keys(analysis)
+    candidates: list[dict[str, Any]] = []
+    benchmarks = ledger.get("benchmarks")
+    if not isinstance(benchmarks, dict):
+        return candidates
+    for benchmark_id in sorted(benchmarks):
+        benchmark = benchmarks[benchmark_id]
+        if not isinstance(benchmark, dict):
+            continue
+        cases = benchmark.get("cases")
+        if not isinstance(cases, dict):
+            continue
+        for case_id in sorted(cases):
+            if (benchmark_id, case_id) in existing:
+                continue
+            case = cases[case_id]
+            if not isinstance(case, dict):
+                continue
+            latest = case.get("latest_decision")
+            if not isinstance(latest, dict):
+                continue
+            decision = _compact_text(latest.get("decision"), limit=160)
+            if decision in NO_RUN_DECISIONS:
+                continue
+            runs = [run for run in case.get("runs", []) if isinstance(run, dict)]
+            classified = classify_case_analysis_candidate(
+                latest_decision=decision,
+                run_count=len(runs),
+            )
+            run_ids = [
+                _compact_text(run.get("run_id"), limit=120)
+                for run in runs[-3:]
+                if run.get("run_id")
+            ]
+            candidates.append(
+                {
+                    "benchmark_id": benchmark_id,
+                    "case_id": case_id,
+                    "latest_decision": decision,
+                    "run_count": len(runs),
+                    "recent_run_ids": run_ids,
+                    **classified,
+                    "raw_logs_recorded": False,
+                    "raw_task_text_recorded": False,
+                    "trajectory_recorded": False,
+                }
+            )
+    priority_order = {"P0": 0, "P1": 1, "P2": 2}
+    candidates.sort(
+        key=lambda item: (
+            priority_order.get(str(item.get("promotion_priority")), 99),
+            str(item.get("candidate_class")),
+            str(item.get("benchmark_id")),
+            str(item.get("case_id")),
+        )
+    )
+    return candidates
+
+
+def build_case_analysis_candidate_report(
+    *,
+    ledger: dict[str, Any],
+    analysis: dict[str, Any],
+) -> dict[str, Any]:
+    candidates = find_case_analysis_candidates(ledger=ledger, analysis=analysis)
+    return {
+        "schema_version": BENCHMARK_CASE_ANALYSIS_CANDIDATE_REPORT_SCHEMA_VERSION,
+        "candidate_count": len(candidates),
+        "candidates": candidates,
+        "source_boundary": {
+            "inputs": [
+                "compact benchmark-run-ledger",
+                "benchmark-case-analysis case keys",
+            ],
+            "raw_logs_recorded": False,
+            "raw_task_text_recorded": False,
+            "trajectory_recorded": False,
+            "absolute_paths_recorded": False,
+        },
+    }
+
+
+def render_case_analysis_candidate_report_markdown(report: dict[str, Any]) -> str:
+    lines = [
+        "# Benchmark Case-Analysis Candidates",
+        "",
+        "This report is derived only from compact benchmark-run ledger rows and",
+        "existing case-analysis keys. It must not include raw task text, logs,",
+        "trajectories, credentials, uploads, verifier tails, or local paths.",
+        "",
+        f"- schema_version: `{report.get('schema_version')}`",
+        f"- candidate_count: `{report.get('candidate_count', 0)}`",
+        "",
+        "| Priority | Class | Benchmark | Case | Decision | Runs | Recommended Handling |",
+        "| --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for candidate in report.get("candidates", []):
+        if not isinstance(candidate, dict):
+            continue
+        lines.append(
+            "| "
+            f"`{candidate.get('promotion_priority', '')}` | "
+            f"`{candidate.get('candidate_class', '')}` | "
+            f"`{candidate.get('benchmark_id', '')}` | "
+            f"`{candidate.get('case_id', '')}` | "
+            f"`{candidate.get('latest_decision', '')}` | "
+            f"`{candidate.get('run_count', 0)}` | "
+            f"{candidate.get('recommended_handling', '')} |"
+        )
+    return "\n".join(lines) + "\n"

--- a/scripts/benchmark_case_analysis_candidates.py
+++ b/scripts/benchmark_case_analysis_candidates.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Find public-safe benchmark case-analysis promotion candidates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from goal_harness.benchmark_case_analysis import (  # noqa: E402
+    build_case_analysis_candidate_report,
+    load_json,
+    render_case_analysis_candidate_report_markdown,
+)
+
+
+DEFAULT_ROOT = REPO_ROOT / "docs" / "research" / "long-horizon-agent-benchmarks"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--ledger",
+        type=Path,
+        default=DEFAULT_ROOT / "benchmark-run-ledger.json",
+        help="Compact benchmark-run-ledger JSON path.",
+    )
+    parser.add_argument(
+        "--analysis",
+        type=Path,
+        default=DEFAULT_ROOT / "benchmark-case-analysis.json",
+        help="Benchmark case-analysis JSON path.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("json", "markdown"),
+        default="json",
+        help="Output format.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    report = build_case_analysis_candidate_report(
+        ledger=load_json(args.ledger),
+        analysis=load_json(args.analysis),
+    )
+    if args.format == "markdown":
+        sys.stdout.write(render_case_analysis_candidate_report_markdown(report))
+    else:
+        sys.stdout.write(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+        sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a public-safe benchmark case-analysis candidate detector over compact benchmark-run ledger rows and existing case-analysis keys
- add a CLI script that emits JSON or Markdown candidate reports without reading raw logs, task text, trajectories, verifier tails, credentials, uploads, or local paths
- add a focused smoke covering fixture candidates, existing-case exclusion, default public assets, and public/private boundary assertions

## Validation
- python3 examples/benchmark-case-analysis-candidates-smoke.py
- python3 examples/benchmark-case-analysis-smoke.py
- python3 examples/benchmark-run-ledger-smoke.py
- python3 -m py_compile goal_harness/benchmark_case_analysis.py scripts/benchmark_case_analysis_candidates.py examples/benchmark-case-analysis-candidates-smoke.py
- goal-harness check --scan-path goal_harness/benchmark_case_analysis.py --scan-path scripts/benchmark_case_analysis_candidates.py --scan-path examples/benchmark-case-analysis-candidates-smoke.py
- git diff --cached --check

## Boundary
- no raw benchmark logs, task text, trajectories, verifier output, credentials, uploads, local private state, or absolute artifact paths were added
- rg hits for /Users, .local, and trajectory are forbidden-pattern assertions inside the smoke, not private data

## Residual Risk
- this is the candidate/planning layer only; actual case-analysis record upsert remains a follow-up after compact result pairs are selected.