### PR TITLE
Expose benchmark case-analysis candidates in CLI

### DIFF
--- a/examples/benchmark-case-analysis-candidates-smoke.py
+++ b/examples/benchmark-case-analysis-candidates-smoke.py
@@ -151,6 +151,54 @@ def test_candidate_cli_on_fixture() -> None:
         assert_public_safe(markdown)
 
 
+def test_goal_harness_benchmark_cli_on_fixture() -> None:
+    with tempfile.TemporaryDirectory(prefix="case-analysis-candidates-gh-cli-") as tmp:
+        root = Path(tmp)
+        ledger_path = root / "ledger.json"
+        analysis_path = root / "analysis.json"
+        ledger_path.write_text(json.dumps(fixture_ledger()), encoding="utf-8")
+        analysis_path.write_text(json.dumps(fixture_analysis()), encoding="utf-8")
+        output = subprocess.check_output(
+            [
+                str(REPO_ROOT / "scripts" / "goal-harness"),
+                "--format",
+                "json",
+                "benchmark",
+                "case-analysis-candidates",
+                "--run-ledger-path",
+                str(ledger_path),
+                "--case-analysis-path",
+                str(analysis_path),
+            ],
+            text=True,
+        )
+        payload = json.loads(output)
+        assert payload["ok"] is True, payload
+        assert payload["report"]["candidate_count"] == 2, payload
+        assert payload["read_boundary"]["compact_only"] is True, payload
+        assert payload["read_boundary"]["raw_logs_read"] is False, payload
+        assert payload["read_boundary"]["task_text_read"] is False, payload
+        assert payload["read_boundary"]["trajectory_read"] is False, payload
+        assert_public_safe(output)
+        markdown = subprocess.check_output(
+            [
+                str(REPO_ROOT / "scripts" / "goal-harness"),
+                "benchmark",
+                "case-analysis-candidates",
+                "--run-ledger-path",
+                str(ledger_path),
+                "--case-analysis-path",
+                str(analysis_path),
+            ],
+            text=True,
+        )
+        assert "# Benchmark Case-Analysis Candidates" in markdown, markdown
+        assert "Read Boundary" in markdown, markdown
+        assert "new-no-uplift" in markdown, markdown
+        assert "existing-case" not in markdown, markdown
+        assert_public_safe(markdown)
+
+
 def test_default_assets_have_public_safe_candidates() -> None:
     output = subprocess.check_output(
         [
@@ -173,6 +221,7 @@ def test_default_assets_have_public_safe_candidates() -> None:
 def main() -> None:
     test_candidate_report_from_fixture()
     test_candidate_cli_on_fixture()
+    test_goal_harness_benchmark_cli_on_fixture()
     test_default_assets_have_public_safe_candidates()
     print("benchmark-case-analysis-candidates-smoke ok")
 

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -123,6 +123,11 @@ from .benchmark_ledger import (
     load_benchmark_run_ledger,
     update_benchmark_run_ledger,
 )
+from .benchmark_case_analysis import (
+    build_case_analysis_candidate_report,
+    load_json as load_benchmark_case_analysis_json,
+    render_case_analysis_candidate_report_markdown,
+)
 from .benchmark_core import (
     build_benchmark_candidate_source_boundary,
     build_codex_app_parity_posthoc_check,
@@ -634,6 +639,35 @@ def render_benchmark_run_ledger_upsert_markdown(payload: dict[str, object]) -> s
         f"- compact only: `{read_boundary.get('compact_only')}`",
         f"- raw logs read: `{read_boundary.get('raw_logs_read')}`",
         f"- task text read: `{read_boundary.get('task_text_read')}`",
+    ]
+    if payload.get("error"):
+        lines.append(f"- error: {payload.get('error')}")
+    return "\n".join(lines) + "\n"
+
+
+def render_benchmark_case_analysis_candidates_markdown(
+    payload: dict[str, object],
+) -> str:
+    if payload.get("ok") and isinstance(payload.get("report"), dict):
+        report = payload["report"]
+        text = render_case_analysis_candidate_report_markdown(report)
+        read_boundary = (
+            payload.get("read_boundary")
+            if isinstance(payload.get("read_boundary"), dict)
+            else {}
+        )
+        return (
+            text
+            + "\n## Read Boundary\n\n"
+            + f"- compact only: `{read_boundary.get('compact_only')}`\n"
+            + f"- raw logs read: `{read_boundary.get('raw_logs_read')}`\n"
+            + f"- task text read: `{read_boundary.get('task_text_read')}`\n"
+            + f"- trajectory read: `{read_boundary.get('trajectory_read')}`\n"
+        )
+    lines = [
+        "# Benchmark Case-Analysis Candidates",
+        "",
+        f"- ok: `{payload.get('ok')}`",
     ]
     if payload.get("error"):
         lines.append(f"- error: {payload.get('error')}")
@@ -3332,6 +3366,27 @@ def main(argv: list[str] | None = None) -> int:
         type=int,
         default=20,
         help="Maximum missing rows to include in output.",
+    )
+    benchmark_case_analysis_candidates_parser = benchmark_sub.add_parser(
+        "case-analysis-candidates",
+        help=(
+            "Find public-safe benchmark case-analysis candidates from the compact "
+            "benchmark run ledger and existing case-analysis keys."
+        ),
+    )
+    benchmark_case_analysis_candidates_parser.add_argument(
+        "--run-ledger-path",
+        default=str(BENCHMARK_RUN_LEDGER_DEFAULT_PATH),
+        help="Path to benchmark_run_ledger_v0 JSON.",
+    )
+    benchmark_case_analysis_candidates_parser.add_argument(
+        "--case-analysis-path",
+        default=str(
+            BENCHMARK_RUN_LEDGER_DEFAULT_PATH.with_name(
+                "benchmark-case-analysis.json"
+            )
+        ),
+        help="Path to benchmark_case_analysis_v0 JSON.",
     )
 
     agentissue_runner_flow_parser = benchmark_sub.add_parser(
@@ -8757,6 +8812,53 @@ def main(argv: list[str] | None = None) -> int:
                 payload,
                 args.format,
                 render_benchmark_run_ledger_check_markdown,
+            )
+            return 0 if payload.get("ok") else 1
+        if args.benchmark_command == "case-analysis-candidates":
+            try:
+                ledger = load_benchmark_case_analysis_json(args.run_ledger_path)
+                analysis = load_benchmark_case_analysis_json(
+                    args.case_analysis_path
+                )
+                report = build_case_analysis_candidate_report(
+                    ledger=ledger,
+                    analysis=analysis,
+                )
+                payload = {
+                    "ok": True,
+                    "report": report,
+                    "run_ledger_path": str(args.run_ledger_path),
+                    "case_analysis_path": str(args.case_analysis_path),
+                    "read_boundary": {
+                        "compact_only": True,
+                        "raw_logs_read": False,
+                        "task_text_read": False,
+                        "trajectory_read": False,
+                        "docker_invoked": False,
+                        "model_api_invoked": False,
+                        "upload_invoked": False,
+                    },
+                }
+            except Exception as exc:
+                payload = {
+                    "ok": False,
+                    "run_ledger_path": str(args.run_ledger_path),
+                    "case_analysis_path": str(args.case_analysis_path),
+                    "read_boundary": {
+                        "compact_only": True,
+                        "raw_logs_read": False,
+                        "task_text_read": False,
+                        "trajectory_read": False,
+                        "docker_invoked": False,
+                        "model_api_invoked": False,
+                        "upload_invoked": False,
+                    },
+                    "error": str(exc),
+                }
+            print_payload(
+                payload,
+                args.format,
+                render_benchmark_case_analysis_candidates_markdown,
             )
             return 0 if payload.get("ok") else 1
         if args.benchmark_command == "run-ledger-upsert":


### PR DESCRIPTION
## Summary
- expose the benchmark case-analysis candidate detector through # Benchmark Case-Analysis Candidates

This report is derived only from compact benchmark-run ledger rows and
existing case-analysis keys. It must not include raw task text, logs,
trajectories, credentials, uploads, verifier tails, or local paths.

- schema_version: `benchmark_case_analysis_candidate_report_v0`
- candidate_count: `19`

| Priority | Class | Benchmark | Case | Decision | Runs | Recommended Handling |
| --- | --- | --- | --- | --- | --- | --- |
| `P1` | `baseline_failure_treatment_candidate` | `swe-marathon` | `find-network-alignments` | `baseline_failed_treatment_candidate` | `1` | add failure attribution or a matched treatment before making a strong case-analysis claim |
| `P1` | `infrastructure_alignment_candidate` | `skillsbench@1.1` | `suricata-custom-exfil` | `paired_treatment_codex_acp_runtime_preflight_required` | `5` | promote only when the alignment or preflight lesson is reusable across future runs |
| `P1` | `infrastructure_alignment_candidate` | `terminal-bench@2.0` | `install-windows-3.11` | `paired_treatment_worker_verifier_alignment_required` | `4` | promote only when the alignment or preflight lesson is reusable across future runs |
| `P1` | `paired_no_uplift_candidate` | `terminal-bench@2.0` | `headless-terminal` | `paired_no_score_uplift` | `5` | promote when the no-uplift result changes routing, prompt, or treatment policy |
| `P1` | `single_arm_coverage_or_baseline_candidate` | `terminal-bench-worker-materialization@v0` | `nginx-request-logging` | `single_arm_recorded` | `2` | keep as coverage unless the single-arm result teaches a durable routing or infrastructure lesson |
| `P2` | `baseline_solved_control_candidate` | `terminal-bench@2.0` | `build-cython-ext` | `baseline_passed_not_current_treatment_priority` | `11` | promote selectively as a baseline-solved control when the case is needed for routing or coverage |
| `P2` | `baseline_solved_control_candidate` | `terminal-bench@2.0` | `compile-compcert` | `baseline_passed_not_current_treatment_priority` | `1` | promote selectively as a baseline-solved control when the case is needed for routing or coverage |
| `P2` | `baseline_solved_control_candidate` | `terminal-bench@2.0` | `financial-document-processor` | `baseline_passed_not_current_treatment_priority` | `2` | promote selectively as a baseline-solved control when the case is needed for routing or coverage |
| `P2` | `baseline_solved_control_candidate` | `terminal-bench@2.0` | `fix-code-vulnerability` | `baseline_passed_not_current_treatment_priority` | `1` | promote selectively as a baseline-solved control when the case is needed for routing or coverage |
| `P2` | `baseline_solved_control_candidate` | `terminal-bench@2.0` | `merge-diff-arc-agi-task` | `baseline_passed_not_current_treatment_priority` | `1` | promote selectively as a baseline-solved control when the case is needed for routing or coverage |
| `P2` | `baseline_solved_control_candidate` | `terminal-bench@2.0` | `path-tracing` | `baseline_passed_not_current_treatment_priority` | `2` | promote selectively as a baseline-solved control when the case is needed for routing or coverage |
| `P2` | `baseline_solved_control_candidate` | `terminal-bench@2.0` | `sqlite-db-truncate` | `baseline_passed_not_current_treatment_priority` | `1` | promote selectively as a baseline-solved control when the case is needed for routing or coverage |
| `P2` | `baseline_solved_non_regression_candidate` | `terminal-bench@2.0` | `cobol-modernization` | `paired_baseline_solved_treatment_preserved` | `2` | promote selectively as a non-regression guard or keep in generated coverage |
| `P2` | `baseline_solved_non_regression_candidate` | `terminal-bench@2.0` | `git-multibranch` | `paired_baseline_solved_treatment_preserved` | `5` | promote selectively as a non-regression guard or keep in generated coverage |
| `P2` | `baseline_solved_non_regression_candidate` | `terminal-bench@2.0` | `large-scale-text-editing` | `paired_baseline_solved_treatment_preserved` | `5` | promote selectively as a non-regression guard or keep in generated coverage |
| `P2` | `baseline_solved_non_regression_candidate` | `terminal-bench@2.0` | `regex-log` | `paired_baseline_solved_treatment_preserved` | `2` | promote selectively as a non-regression guard or keep in generated coverage |
| `P2` | `setup_or_runner_gap_defer` | `skillsbench@1.1` | `fix-build-agentops` | `baseline_runner_or_setup_repair_required` | `2` | defer until the compact run reaches scoring or the setup blocker itself becomes a reusable infrastructure lesson |
| `P2` | `single_arm_coverage_or_baseline_candidate` | `skillsbench-cloud-oracle-sanity@v0` | `hello-world` | `single_arm_recorded` | `1` | keep as coverage unless the single-arm result teaches a durable routing or infrastructure lesson |
| `P2` | `single_arm_coverage_or_baseline_candidate` | `swe-marathon` | `rust-c-compiler` | `single_arm_recorded` | `1` | keep as coverage unless the single-arm result teaches a durable routing or infrastructure lesson |

## Read Boundary

- compact only: `True`
- raw logs read: `False`
- task text read: `False`
- trajectory read: `False`
- keep JSON/Markdown output public-safe and include an explicit read boundary
- extend the candidate smoke to cover the Goal Harness CLI entrypoint as well as the helper script

## Validation
- python3 examples/benchmark-case-analysis-candidates-smoke.py
- python3 examples/benchmark-case-analysis-smoke.py
- python3 examples/benchmark-run-ledger-smoke.py
- python3 -m py_compile goal_harness/cli.py goal_harness/benchmark_case_analysis.py examples/benchmark-case-analysis-candidates-smoke.py scripts/benchmark_case_analysis_candidates.py
- goal-harness check --scan-path goal_harness/cli.py --scan-path examples/benchmark-case-analysis-candidates-smoke.py
- git diff --cached --check

## Boundary
- reads only compact benchmark-run-ledger and benchmark-case-analysis keys
- no raw logs, task text, trajectories, verifier tails, credentials, uploads, or local private state added
- scan hits for /Users/.local/trajectory are forbidden-pattern assertions or pre-existing boundary text, not private data

## Residual Risk
- this still identifies candidates only; actual case-analysis record generation/upsert is the next slice.