### PR TITLE
Add Codex CLI bounded visible pilot adapter

### DIFF
--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -26,6 +26,10 @@ runtime contract, benchmark route, or launch draft.
   the first real TUI launch attempt for the generated start message, recording
   why manual paste remains primary until a bounded visible completion proof
   exists.
+- Codex CLI bounded visible pilot adapter: the public-safe packet command and
+  `examples/codex-cli-bounded-visible-pilot-adapter-smoke.py` that validate
+  first-response and runtime-idle fixtures before a live TUI bootstrap can be
+  counted as successful.
 - [Codex CLI no-clone release verification](codex-cli-no-clone-release-verification.md):
   the compact release note and smoke contract that prove the packaged installer,
   fresh-project bootstrap message, bootstrap bundle, and proof fixtures stay

--- a/docs/product/codex-cli-live-tui-first-message-pilot.md
+++ b/docs/product/codex-cli-live-tui-first-message-pilot.md
@@ -108,3 +108,25 @@ files, credentials, private paths, and argv prompt leakage.
 
 Until then, keep the no-clone installer, generated paste message, and
 transcript-free smoke bundle as the reliable first-run route.
+
+## Bounded Adapter Command
+
+The follow-up adapter is public-safe and packet-only: it validates a compact
+first-response fixture plus runtime-idle evidence, but it does not start Codex,
+read transcripts, read session files, capture stdout/stderr, or mutate the TUI.
+
+```bash
+goal-harness codex-cli-bounded-visible-pilot-adapter \
+  --project /tmp/goal-harness-live-tui-pilot.<suffix> \
+  --goal-id public-live-tui-pilot-goal \
+  --agent-id codex-side-bypass \
+  --first-response-fixture public-first-response.json \
+  --idle-fixture public-runtime-idle.json
+```
+
+The first-response fixture must prove the visible TUI showed the goal id, user
+gate or none, top user todo or none, selected agent todo, and next safe action;
+it must also prove the user can interrupt or take over, compact writeback is
+planned before quota spend, and the bootstrap prompt was not passed as an argv
+prompt. If any piece is missing, the pilot stays a precise blocker instead of a
+success claim.

--- a/examples/codex-cli-bounded-visible-pilot-adapter-smoke.py
+++ b/examples/codex-cli-bounded-visible-pilot-adapter-smoke.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Smoke-test the Codex CLI bounded visible pilot adapter packet."""
+
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from goal_harness.codex_cli_probe import (  # noqa: E402
+    build_codex_cli_bounded_visible_pilot_adapter,
+)
+
+
+PROJECT = Path("/tmp/public-codex-cli-project")
+GOAL_ID = "public-codex-cli-goal"
+AGENT_ID = "codex-side-bypass"
+LIVE_PILOT_DOC = REPO_ROOT / "docs" / "product" / "codex-cli-live-tui-first-message-pilot.md"
+PRODUCT_README = REPO_ROOT / "docs" / "product" / "README.md"
+
+
+PASSING_FIRST_RESPONSE_FIXTURE = {
+    "observed_surface": "codex_cli_tui_visible_window",
+    "prompt_delivery": {
+        "manual_or_visible_delivery": True,
+        "prompt_public_safe": True,
+        "argv_prompt_used": False,
+    },
+    "first_response": {
+        "goal_id_visible": True,
+        "user_gate_or_none_visible": True,
+        "top_user_todo_or_none_visible": True,
+        "top_agent_todo_visible": True,
+        "next_safe_action_visible": True,
+        "bounded_segment_started_or_blocker_written": True,
+    },
+    "interruptibility": {
+        "user_can_interrupt": True,
+        "manual_takeover_available": True,
+    },
+    "writeback": {
+        "compact_evidence_planned": True,
+        "quota_spend_after_writeback_only": True,
+    },
+    "boundary": {
+        "reads_raw_transcripts": False,
+        "reads_session_files": False,
+        "reads_stdout_stderr": False,
+        "reads_credentials": False,
+        "mutates_hidden_session_state": False,
+        "spends_quota_before_writeback": False,
+    },
+}
+
+
+PASSING_IDLE_FIXTURE = {
+    "observed_surface": "codex_cli_tui_visible_window",
+    "idle_guard": {
+        "no_active_human_typing": True,
+        "no_running_turn": True,
+        "checked_before_prompt": True,
+    },
+    "turn_visibility": {"visible_to_user": True},
+    "interruptibility": {
+        "user_can_interrupt": True,
+        "manual_takeover_available": True,
+    },
+    "boundary": {
+        "reads_raw_transcripts": False,
+        "reads_session_files": False,
+        "reads_stdout_stderr": False,
+        "reads_credentials": False,
+        "mutates_hidden_session_state": False,
+    },
+}
+
+
+def build_adapter(
+    *,
+    first_response: dict[str, object] | None = None,
+    idle: dict[str, object] | None = None,
+) -> dict[str, object]:
+    return build_codex_cli_bounded_visible_pilot_adapter(
+        project=PROJECT,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        cli_bin="goal-harness",
+        first_response_payload=first_response,
+        idle_payload=idle,
+    )
+
+
+def assert_boundary(payload: dict[str, object]) -> None:
+    boundary = payload["boundary"]
+    assert boundary["adapter_packet_only"] is True, payload
+    assert boundary["runs_codex"] is False, payload
+    assert boundary["reads_raw_transcripts"] is False, payload
+    assert boundary["reads_session_files"] is False, payload
+    assert boundary["reads_stdout_stderr"] is False, payload
+    assert boundary["reads_credentials"] is False, payload
+    assert boundary["mutates_codex_session"] is False, payload
+    assert boundary["writes_goal_harness_state"] is False, payload
+    assert boundary["spends_goal_harness_quota"] is False, payload
+    assert boundary["requires_visible_delivery"] is True, payload
+    assert boundary["argv_prompt_rejected"] is True, payload
+    assert boundary["success_claim_requires_first_response_and_idle"] is True, payload
+
+
+def run_cli(*extra_args: str) -> str:
+    result = subprocess.run(
+        [sys.executable, "-m", "goal_harness.cli", *extra_args],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def assert_docs() -> None:
+    live_pilot = LIVE_PILOT_DOC.read_text(encoding="utf-8")
+    product_readme = PRODUCT_README.read_text(encoding="utf-8")
+    assert "codex-cli-bounded-visible-pilot-adapter" in live_pilot, live_pilot
+    assert "public-first-response.json" in live_pilot, live_pilot
+    assert "argv prompt" in live_pilot, live_pilot
+    assert "Codex CLI bounded visible pilot adapter" in product_readme, product_readme
+    assert "codex-cli-bounded-visible-pilot-adapter-smoke.py" in product_readme, product_readme
+
+
+def main() -> int:
+    missing = build_adapter()
+    assert missing["ok"] is True, missing
+    assert missing["schema_version"] == "codex_cli_bounded_visible_pilot_adapter_v0", missing
+    assert missing["decision"] == "bounded_visible_completion_evidence_required", missing
+    assert missing["approved_for_live_tui_success_claim"] is False, missing
+    assert "missing_first_response_evidence" in missing["blockers"], missing
+    assert "missing_runtime_idle_evidence" in missing["blockers"], missing
+    assert "codex-cli-bootstrap-message" in missing["commands"]["bootstrap_message"], missing
+    assert "codex-cli-bounded-visible-pilot-adapter" in missing["commands"]["bounded_visible_pilot_adapter"], missing
+    assert_boundary(missing)
+
+    argv_leaking = copy.deepcopy(PASSING_FIRST_RESPONSE_FIXTURE)
+    argv_leaking["prompt_delivery"]["argv_prompt_used"] = True
+    rejected = build_adapter(first_response=argv_leaking, idle=PASSING_IDLE_FIXTURE)
+    assert rejected["decision"] == "bounded_visible_first_response_incomplete", rejected
+    assert rejected["approved_for_live_tui_success_claim"] is False, rejected
+    assert "no_argv_prompt" in rejected["blockers"], rejected
+    assert "argv_prompt_leakage_risk" in rejected["blockers"], rejected
+    assert rejected["runtime_idle_detector"]["approved"] is True, rejected
+    assert_boundary(rejected)
+
+    passing = build_adapter(
+        first_response=PASSING_FIRST_RESPONSE_FIXTURE,
+        idle=PASSING_IDLE_FIXTURE,
+    )
+    assert passing["decision"] == "bounded_visible_pilot_ready_for_success_claim", passing
+    assert passing["approved_for_live_tui_success_claim"] is True, passing
+    assert passing["first_response"]["approved"] is True, passing
+    assert passing["runtime_idle_detector"]["approved"] is True, passing
+    assert passing["blockers"] == [], passing
+    assert "--delivery-outcome outcome_progress" in passing["commands"]["success_writeback"], passing
+    assert_boundary(passing)
+
+    with tempfile.TemporaryDirectory(prefix="goal-harness-codex-cli-bounded-visible-") as tmp:
+        tmp_path = Path(tmp)
+        first_response_fixture = tmp_path / "public-first-response.json"
+        first_response_fixture.write_text(json.dumps(PASSING_FIRST_RESPONSE_FIXTURE))
+        idle_fixture = tmp_path / "public-runtime-idle.json"
+        idle_fixture.write_text(json.dumps(PASSING_IDLE_FIXTURE))
+
+        cli_json = json.loads(
+            run_cli(
+                "--format",
+                "json",
+                "codex-cli-bounded-visible-pilot-adapter",
+                "--project",
+                str(PROJECT),
+                "--goal-id",
+                GOAL_ID,
+                "--agent-id",
+                AGENT_ID,
+                "--first-response-fixture",
+                str(first_response_fixture),
+                "--idle-fixture",
+                str(idle_fixture),
+            )
+        )
+        assert cli_json["decision"] == "bounded_visible_pilot_ready_for_success_claim", cli_json
+        assert cli_json["approved_for_live_tui_success_claim"] is True, cli_json
+        assert_boundary(cli_json)
+
+        markdown = run_cli(
+            "codex-cli-bounded-visible-pilot-adapter",
+            "--project",
+            str(PROJECT),
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_ID,
+            "--first-response-fixture",
+            str(first_response_fixture),
+            "--idle-fixture",
+            str(idle_fixture),
+        )
+        assert "# Codex CLI Bounded Visible Pilot Adapter" in markdown, markdown
+        assert "approved_for_live_tui_success_claim" in markdown, markdown
+        assert "argv_prompt_rejected" in markdown, markdown
+
+    assert_docs()
+    print("codex-cli-bounded-visible-pilot-adapter-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -142,6 +142,7 @@ from .configure_goal import configure_goal, render_configure_goal_markdown
 from .delivery_outcome import DELIVERY_OUTCOME_CHOICES
 from .cli_commands import (
     handle_check_command,
+    handle_codex_cli_bounded_visible_pilot_adapter_command,
     handle_codex_cli_bootstrap_message_command,
     handle_codex_cli_exec_handoff_command,
     handle_codex_cli_local_driver_plan_command,
@@ -6000,6 +6001,7 @@ def main(argv: list[str] | None = None) -> int:
             "bootstrap",
             "connect",
             "codex-cli-bootstrap-message",
+            "codex-cli-bounded-visible-pilot-adapter",
             "codex-cli-exec-handoff",
             "codex-cli-local-driver-plan",
             "codex-cli-local-scheduler-exec",
@@ -6090,6 +6092,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "codex-cli-visible-local-driver-pilot":
         return handle_codex_cli_visible_local_driver_pilot_command(args, print_payload)
+
+    if args.command == "codex-cli-bounded-visible-pilot-adapter":
+        return handle_codex_cli_bounded_visible_pilot_adapter_command(args, print_payload)
 
     if args.command == "codex-cli-visible-attach-acceptance":
         return handle_codex_cli_visible_attach_acceptance_command(args, print_payload)

--- a/goal_harness/cli_commands/__init__.py
+++ b/goal_harness/cli_commands/__init__.py
@@ -11,6 +11,7 @@ The top-level CLI keeps global options, registry fallback, and dispatch order.
 from .doctor import handle_doctor_command, register_doctor_command
 from .dreaming import handle_dreaming_command, register_dreaming_commands
 from .starter import (
+    handle_codex_cli_bounded_visible_pilot_adapter_command,
     handle_codex_cli_bootstrap_message_command,
     handle_codex_cli_exec_handoff_command,
     handle_codex_cli_local_driver_plan_command,
@@ -39,6 +40,7 @@ from .status import (
 
 __all__ = [
     "handle_check_command",
+    "handle_codex_cli_bounded_visible_pilot_adapter_command",
     "handle_codex_cli_bootstrap_message_command",
     "handle_codex_cli_exec_handoff_command",
     "handle_codex_cli_local_driver_plan_command",

--- a/goal_harness/cli_commands/starter.py
+++ b/goal_harness/cli_commands/starter.py
@@ -30,6 +30,7 @@ from ..codex_cli_probe import (
     DEFAULT_EXECUTOR_TIMEOUT_SECONDS,
     DEFAULT_MIN_HUMAN_INPUT_IDLE_SECONDS,
     DEFAULT_TIMEOUT_SECONDS,
+    build_codex_cli_bounded_visible_pilot_adapter,
     build_codex_cli_one_message_loop_pilot,
     build_codex_cli_visible_local_driver_pilot,
     build_codex_cli_visible_attach_acceptance,
@@ -41,8 +42,10 @@ from ..codex_cli_probe import (
     build_codex_cli_visible_session_proof,
     build_codex_cli_runtime_idle_observation_payload,
     build_codex_cli_runtime_idle_detector,
+    load_codex_cli_first_response_fixture,
     load_codex_cli_visible_session_proof_fixture,
     load_codex_cli_runtime_idle_fixture,
+    render_codex_cli_bounded_visible_pilot_adapter_markdown,
     render_codex_cli_one_message_loop_pilot_markdown,
     render_codex_cli_visible_local_driver_pilot_markdown,
     render_codex_cli_visible_attach_acceptance_markdown,
@@ -312,6 +315,27 @@ def register_starter_commands(subparsers: argparse._SubParsersAction) -> None:
         action="store_true",
         help="Explicitly mark user/operator opt-in for a headless codex exec fallback candidate.",
     )
+
+    codex_cli_bounded_visible_parser = subparsers.add_parser(
+        "codex-cli-bounded-visible-pilot-adapter",
+        help="Validate public-safe first-response and idle evidence before claiming Codex CLI live TUI bootstrap success.",
+    )
+    codex_cli_bounded_visible_parser.add_argument("--project", default=".", help="Project directory to start from.")
+    codex_cli_bounded_visible_parser.add_argument("--goal-id", help="Goal id. Defaults to <project-name>-goal.")
+    codex_cli_bounded_visible_parser.add_argument(
+        "--agent-id",
+        help="Registered Goal Harness agent id to include in adapter commands.",
+    )
+    codex_cli_bounded_visible_parser.add_argument(
+        "--cli-bin",
+        default="goal-harness",
+        help="Goal Harness CLI binary name embedded in generated commands.",
+    )
+    codex_cli_bounded_visible_parser.add_argument(
+        "--first-response-fixture",
+        help="Public-safe JSON fixture proving the first visible TUI response shape.",
+    )
+    _add_runtime_idle_observation_arguments(codex_cli_bounded_visible_parser)
 
     codex_cli_visible_attach_acceptance_parser = subparsers.add_parser(
         "codex-cli-visible-attach-acceptance",
@@ -823,6 +847,28 @@ def handle_codex_cli_visible_local_driver_pilot_command(
         allow_headless_fallback=bool(args.allow_headless_fallback),
     )
     print_payload(payload, args.format, render_codex_cli_visible_local_driver_pilot_markdown)
+    return 0 if payload.get("ok") else 1
+
+
+def handle_codex_cli_bounded_visible_pilot_adapter_command(
+    args: argparse.Namespace,
+    print_payload: PrintPayload,
+) -> int:
+    first_response_payload = (
+        load_codex_cli_first_response_fixture(Path(args.first_response_fixture).expanduser())
+        if args.first_response_fixture
+        else None
+    )
+    idle_payload = _load_codex_cli_runtime_idle_payload(args)
+    payload = build_codex_cli_bounded_visible_pilot_adapter(
+        project=Path(args.project),
+        goal_id=args.goal_id,
+        agent_id=args.agent_id,
+        cli_bin=args.cli_bin,
+        first_response_payload=first_response_payload,
+        idle_payload=idle_payload,
+    )
+    print_payload(payload, args.format, render_codex_cli_bounded_visible_pilot_adapter_markdown)
     return 0 if payload.get("ok") else 1
 
 

--- a/goal_harness/codex_cli_probe.py
+++ b/goal_harness/codex_cli_probe.py
@@ -190,6 +190,13 @@ def load_codex_cli_runtime_idle_fixture(path: Path) -> dict[str, Any]:
     return data
 
 
+def load_codex_cli_first_response_fixture(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text())
+    if not isinstance(data, dict):
+        raise ValueError("Codex CLI first-response fixture must be a JSON object")
+    return data
+
+
 def probe_human_input_idle_seconds(*, timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS) -> dict[str, Any]:
     """Read a coarse local human-input idle metric without touching Codex state.
 
@@ -352,6 +359,33 @@ RUNTIME_IDLE_REQUIRED_FALSE_CHECKS: tuple[tuple[str, tuple[str, ...], str], ...]
     ("no_stdout_stderr_read", ("boundary", "reads_stdout_stderr"), "stdout/stderr streams were not read"),
     ("no_credentials_read", ("boundary", "reads_credentials"), "credentials were not read"),
     ("no_hidden_session_mutation", ("boundary", "mutates_hidden_session_state"), "hidden session state was not mutated"),
+)
+
+
+FIRST_RESPONSE_REQUIRED_TRUE_CHECKS: tuple[tuple[str, tuple[str, ...], str], ...] = (
+    ("manual_or_visible_delivery", ("prompt_delivery", "manual_or_visible_delivery"), "the start message was delivered through a visible TUI path"),
+    ("prompt_public_safe", ("prompt_delivery", "prompt_public_safe"), "the delivered prompt was public-safe"),
+    ("goal_id_visible", ("first_response", "goal_id_visible"), "the first response showed the current goal id"),
+    ("user_gate_or_none_visible", ("first_response", "user_gate_or_none_visible"), "the first response showed the concrete user gate or that none blocks the path"),
+    ("top_user_todo_or_none_visible", ("first_response", "top_user_todo_or_none_visible"), "the first response showed the top user todo or that none exists"),
+    ("top_agent_todo_visible", ("first_response", "top_agent_todo_visible"), "the first response showed the selected agent todo"),
+    ("next_safe_action_visible", ("first_response", "next_safe_action_visible"), "the first response showed the next safe action"),
+    ("bounded_segment_started_or_blocker_written", ("first_response", "bounded_segment_started_or_blocker_written"), "the first response either started one bounded segment or wrote a precise blocker"),
+    ("user_can_interrupt", ("interruptibility", "user_can_interrupt"), "the user can interrupt the visible TUI path"),
+    ("manual_takeover_available", ("interruptibility", "manual_takeover_available"), "manual takeover remains available"),
+    ("compact_evidence_planned", ("writeback", "compact_evidence_planned"), "compact evidence writeback is planned before quota spend"),
+    ("quota_spend_after_writeback_only", ("writeback", "quota_spend_after_writeback_only"), "quota spend happens only after validated writeback"),
+)
+
+
+FIRST_RESPONSE_REQUIRED_FALSE_CHECKS: tuple[tuple[str, tuple[str, ...], str], ...] = (
+    ("no_argv_prompt", ("prompt_delivery", "argv_prompt_used"), "the start prompt was not passed as a process argv prompt"),
+    ("no_raw_transcript_read", ("boundary", "reads_raw_transcripts"), "raw transcripts were not read"),
+    ("no_session_files_read", ("boundary", "reads_session_files"), "session files were not read"),
+    ("no_stdout_stderr_read", ("boundary", "reads_stdout_stderr"), "stdout/stderr streams were not read"),
+    ("no_credentials_read", ("boundary", "reads_credentials"), "credentials were not read"),
+    ("no_hidden_session_mutation", ("boundary", "mutates_hidden_session_state"), "hidden session state was not mutated"),
+    ("no_quota_spend_before_writeback", ("boundary", "spends_quota_before_writeback"), "quota was not spent before writeback"),
 )
 
 
@@ -2138,6 +2172,229 @@ def build_codex_cli_visible_local_driver_pilot(
     }
 
 
+def build_codex_cli_bounded_visible_pilot_adapter(
+    *,
+    project: Path,
+    goal_id: str | None,
+    agent_id: str | None,
+    cli_bin: str,
+    first_response_payload: dict[str, Any] | None = None,
+    idle_payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Validate the bounded evidence needed before claiming live TUI success.
+
+    The adapter is intentionally a packet builder and fixture validator. It
+    does not start Codex, inspect transcripts, read session files, or capture
+    stdout/stderr. A separate visible/manual run must supply a public-safe
+    first-response fixture and a runtime-idle fixture before this packet can
+    approve a live-TUI first-message success claim.
+    """
+
+    bootstrap = build_codex_cli_bootstrap_message(
+        project=project,
+        goal_id=goal_id,
+        agent_id=agent_id,
+        cli_bin=cli_bin,
+    )
+    resolved_project = str(bootstrap["project"])
+    resolved_goal_id = str(bootstrap["goal_id"])
+    agent_arg = f" --agent-id {_shell_arg(agent_id)}" if agent_id else ""
+    required_first_response_shape = {
+        "observed_surface": "codex_cli_tui_visible_window | visible_paste_adapter",
+        "prompt_delivery": {
+            "manual_or_visible_delivery": True,
+            "prompt_public_safe": True,
+            "argv_prompt_used": False,
+        },
+        "first_response": {
+            "goal_id_visible": True,
+            "user_gate_or_none_visible": True,
+            "top_user_todo_or_none_visible": True,
+            "top_agent_todo_visible": True,
+            "next_safe_action_visible": True,
+            "bounded_segment_started_or_blocker_written": True,
+        },
+        "interruptibility": {
+            "user_can_interrupt": True,
+            "manual_takeover_available": True,
+        },
+        "writeback": {
+            "compact_evidence_planned": True,
+            "quota_spend_after_writeback_only": True,
+        },
+        "boundary": {
+            "reads_raw_transcripts": False,
+            "reads_session_files": False,
+            "reads_stdout_stderr": False,
+            "reads_credentials": False,
+            "mutates_hidden_session_state": False,
+            "spends_quota_before_writeback": False,
+        },
+    }
+
+    first_response_checks: list[dict[str, Any]] = []
+    first_response_failures: list[str] = []
+    observed_surface = "missing"
+    if first_response_payload is None:
+        first_response_failures.append("missing_first_response_evidence")
+    else:
+        observed_surface = str(first_response_payload.get("observed_surface") or "unknown")
+        for key, path, description in FIRST_RESPONSE_REQUIRED_TRUE_CHECKS:
+            passed = _nested_bool(first_response_payload, path)
+            first_response_checks.append(
+                {"key": key, "required": True, "passed": passed, "description": description}
+            )
+            if not passed:
+                first_response_failures.append(key)
+        for key, path, description in FIRST_RESPONSE_REQUIRED_FALSE_CHECKS:
+            passed = _nested_false(first_response_payload, path)
+            first_response_checks.append(
+                {"key": key, "required": False, "passed": passed, "description": description}
+            )
+            if not passed:
+                first_response_failures.append(key)
+        supported_surface = observed_surface in {
+            "codex_cli_tui_visible_window",
+            "visible_paste_adapter",
+        }
+        first_response_checks.append(
+            {
+                "key": "supported_observed_surface",
+                "required": sorted(["codex_cli_tui_visible_window", "visible_paste_adapter"]),
+                "actual": observed_surface,
+                "passed": supported_surface,
+                "description": "first response was observed on a visible Codex CLI surface",
+            }
+        )
+        if not supported_surface:
+            first_response_failures.append("unsupported_observed_surface")
+        if _nested_bool(first_response_payload, ("prompt_delivery", "argv_prompt_used")):
+            first_response_failures.append("argv_prompt_leakage_risk")
+
+    idle_detector = build_codex_cli_runtime_idle_detector(
+        project=project,
+        goal_id=resolved_goal_id,
+        agent_id=agent_id,
+        cli_bin=cli_bin,
+        idle_payload=idle_payload,
+    )
+    idle_approved = idle_detector.get("approved_for_visible_later_turn") is True
+    first_response_approved = bool(first_response_payload is not None and not first_response_failures)
+    blockers: list[str] = []
+    blockers.extend(first_response_failures)
+    if not idle_approved:
+        blockers.extend(idle_detector.get("failures") or ["runtime_idle_evidence_required"])
+
+    if first_response_approved and idle_approved:
+        decision = "bounded_visible_pilot_ready_for_success_claim"
+        approved = True
+        next_safe_step = (
+            "write compact success evidence, refresh state with outcome_progress, "
+            "then spend exactly one quota slot"
+        )
+    elif first_response_payload is None:
+        decision = "bounded_visible_completion_evidence_required"
+        approved = False
+        next_safe_step = (
+            "capture the first visible TUI response as the public-safe fixture shape "
+            "below, then rerun this adapter before spending quota"
+        )
+    elif not first_response_approved:
+        decision = "bounded_visible_first_response_incomplete"
+        approved = False
+        next_safe_step = (
+            "treat the live TUI pilot as blocked and write the precise blocker; "
+            "do not claim first-message success"
+        )
+    else:
+        decision = "bounded_visible_runtime_idle_required"
+        approved = False
+        next_safe_step = (
+            "capture runtime idle evidence proving no active typing or running turn "
+            "before marking the visible pilot complete"
+        )
+
+    bounded_adapter_command = (
+        f"{_shell_arg(cli_bin)} codex-cli-bounded-visible-pilot-adapter "
+        f"--project {_shell_arg(resolved_project)} --goal-id {_shell_arg(resolved_goal_id)}"
+        f"{agent_arg} --first-response-fixture <public-first-response.json> "
+        "--idle-fixture <public-runtime-idle.json>"
+    )
+    runtime_idle_command = (
+        f"{_shell_arg(cli_bin)} codex-cli-runtime-idle-detector "
+        f"--project {_shell_arg(resolved_project)} --goal-id {_shell_arg(resolved_goal_id)}"
+        f"{agent_arg} --idle-fixture <public-runtime-idle.json>"
+    )
+    blocker_summary = blockers[0] if blockers else "none"
+    blocker_writeback = (
+        f"{_shell_arg(cli_bin)} refresh-state --goal-id {_shell_arg(resolved_goal_id)} "
+        "--classification codex_cli_bounded_visible_pilot_blocker "
+        "--delivery-batch-scale implementation --delivery-outcome outcome_gap "
+        f"--recommended-action {_shell_arg('Codex CLI bounded visible pilot blocked: ' + blocker_summary)}"
+    )
+    success_writeback = (
+        f"{_shell_arg(cli_bin)} refresh-state --goal-id {_shell_arg(resolved_goal_id)} "
+        "--classification codex_cli_bounded_visible_pilot_success "
+        "--delivery-batch-scale implementation --delivery-outcome outcome_progress "
+        "--recommended-action "
+        f"{_shell_arg('Promote Codex CLI one-message TUI bootstrap only after documented release-path validation.')}"
+    )
+
+    return {
+        "ok": True,
+        "schema_version": "codex_cli_bounded_visible_pilot_adapter_v0",
+        "project": resolved_project,
+        "goal_id": resolved_goal_id,
+        "agent_id": agent_id,
+        "cli_bin": cli_bin,
+        "decision": decision,
+        "approved_for_live_tui_success_claim": approved,
+        "observed_surface": observed_surface,
+        "next_safe_step": next_safe_step,
+        "blockers": blockers,
+        "first_response": {
+            "supplied": first_response_payload is not None,
+            "approved": first_response_approved,
+            "checks": first_response_checks,
+            "failures": first_response_failures,
+        },
+        "runtime_idle_detector": {
+            "supplied": idle_payload is not None,
+            "approved": idle_approved,
+            "decision": idle_detector.get("decision"),
+            "failures": idle_detector.get("failures") or [],
+            "source": idle_detector.get("source"),
+        },
+        "commands": {
+            "bootstrap_message": (
+                f"{_shell_arg(cli_bin)} codex-cli-bootstrap-message "
+                f"--project {_shell_arg(resolved_project)} --goal-id {_shell_arg(resolved_goal_id)}"
+                f"{agent_arg} --message-only"
+            ),
+            "bounded_visible_pilot_adapter": bounded_adapter_command,
+            "runtime_idle_detector": runtime_idle_command,
+            "blocker_writeback": blocker_writeback,
+            "success_writeback": success_writeback,
+        },
+        "required_first_response_shape": required_first_response_shape,
+        "required_runtime_idle_shape": idle_detector.get("required_fixture_shape"),
+        "boundary": {
+            "adapter_packet_only": True,
+            "runs_codex": False,
+            "reads_raw_transcripts": False,
+            "reads_credentials": False,
+            "reads_session_files": False,
+            "reads_stdout_stderr": False,
+            "mutates_codex_session": False,
+            "writes_goal_harness_state": False,
+            "spends_goal_harness_quota": False,
+            "requires_visible_delivery": True,
+            "argv_prompt_rejected": True,
+            "success_claim_requires_first_response_and_idle": True,
+        },
+    }
+
+
 def render_codex_cli_session_probe_markdown(payload: dict[str, Any]) -> str:
     capabilities = payload.get("capabilities") or {}
     boundary = payload.get("boundary") or {}
@@ -2651,6 +2908,100 @@ def render_codex_cli_visible_local_driver_pilot_markdown(payload: dict[str, Any]
 ## Warnings
 
 {warning_lines}
+"""
+
+
+def render_codex_cli_bounded_visible_pilot_adapter_markdown(payload: dict[str, Any]) -> str:
+    boundary = payload.get("boundary") if isinstance(payload.get("boundary"), dict) else {}
+    commands = payload.get("commands") if isinstance(payload.get("commands"), dict) else {}
+    first_response = (
+        payload.get("first_response")
+        if isinstance(payload.get("first_response"), dict)
+        else {}
+    )
+    runtime_idle = (
+        payload.get("runtime_idle_detector")
+        if isinstance(payload.get("runtime_idle_detector"), dict)
+        else {}
+    )
+    blockers = payload.get("blockers") if isinstance(payload.get("blockers"), list) else []
+    blocker_lines = "\n".join(f"- {blocker}" for blocker in blockers) if blockers else "- none"
+    checks = first_response.get("checks") if isinstance(first_response.get("checks"), list) else []
+    check_lines = "\n".join(
+        f"- [{'x' if check.get('passed') else ' '}] {check.get('key')}: {check.get('description')}"
+        for check in checks
+        if isinstance(check, dict)
+    )
+    if not check_lines:
+        check_lines = "- no first-response fixture supplied"
+    required_first_response_shape = payload.get("required_first_response_shape")
+    required_runtime_idle_shape = payload.get("required_runtime_idle_shape")
+    required_shapes = ""
+    if isinstance(required_first_response_shape, dict):
+        required_shapes += f"""
+## Required First-Response Fixture
+
+```json
+{json.dumps(required_first_response_shape, indent=2, ensure_ascii=False)}
+```
+"""
+    if isinstance(required_runtime_idle_shape, dict):
+        required_shapes += f"""
+## Required Runtime Idle Fixture
+
+```json
+{json.dumps(required_runtime_idle_shape, indent=2, ensure_ascii=False)}
+```
+"""
+    return f"""# Codex CLI Bounded Visible Pilot Adapter
+
+- decision: `{payload.get("decision")}`
+- approved_for_live_tui_success_claim: `{payload.get("approved_for_live_tui_success_claim")}`
+- observed_surface: `{payload.get("observed_surface")}`
+- next_safe_step: {payload.get("next_safe_step")}
+
+## First Response
+
+- supplied: `{first_response.get("supplied")}`
+- approved: `{first_response.get("approved")}`
+
+{check_lines}
+
+## Runtime Idle Detector
+
+- supplied: `{runtime_idle.get("supplied")}`
+- approved: `{runtime_idle.get("approved")}`
+- decision: `{runtime_idle.get("decision")}`
+- failures: `{runtime_idle.get("failures")}`
+
+## Blockers
+
+{blocker_lines}
+
+## Commands
+
+```bash
+{commands.get("bootstrap_message")}
+{commands.get("bounded_visible_pilot_adapter")}
+{commands.get("runtime_idle_detector")}
+{commands.get("blocker_writeback")}
+{commands.get("success_writeback")}
+```
+
+## Boundary
+
+- adapter_packet_only: `{boundary.get("adapter_packet_only")}`
+- runs_codex: `{boundary.get("runs_codex")}`
+- reads_raw_transcripts: `{boundary.get("reads_raw_transcripts")}`
+- reads_session_files: `{boundary.get("reads_session_files")}`
+- reads_stdout_stderr: `{boundary.get("reads_stdout_stderr")}`
+- mutates_codex_session: `{boundary.get("mutates_codex_session")}`
+- writes_goal_harness_state: `{boundary.get("writes_goal_harness_state")}`
+- spends_goal_harness_quota: `{boundary.get("spends_goal_harness_quota")}`
+- requires_visible_delivery: `{boundary.get("requires_visible_delivery")}`
+- argv_prompt_rejected: `{boundary.get("argv_prompt_rejected")}`
+- success_claim_requires_first_response_and_idle: `{boundary.get("success_claim_requires_first_response_and_idle")}`
+{required_shapes}
 """
 
 


### PR DESCRIPTION
## Summary
- add a packet-only Codex CLI bounded visible pilot adapter command
- validate public-safe first-response and runtime-idle fixtures before claiming live TUI bootstrap success
- document the follow-up command in the live TUI pilot note and index the smoke contract

## Safety boundary
- does not start Codex
- does not read raw transcripts, session files, stdout/stderr, credentials, or hidden session state
- rejects argv-prompt delivery as success evidence

## Validation
- python3 -m py_compile goal_harness/codex_cli_probe.py goal_harness/cli_commands/starter.py goal_harness/cli_commands/__init__.py goal_harness/cli.py examples/codex-cli-bounded-visible-pilot-adapter-smoke.py
- python3 examples/codex-cli-bounded-visible-pilot-adapter-smoke.py
- python3 examples/codex-cli-live-tui-first-message-pilot-smoke.py
- python3 examples/codex-cli-one-message-loop-pilot-smoke.py
- python3 examples/codex-cli-visible-local-driver-pilot-smoke.py
- python3 examples/codex-cli-visible-attach-acceptance-smoke.py
- python3 examples/codex-cli-runtime-idle-detector-smoke.py
- python3 examples/codex-cli-no-clone-release-verification-smoke.py
- python3 examples/docs-governance-smoke.py
- goal-harness check --scan-path goal_harness/codex_cli_probe.py --scan-path goal_harness/cli_commands/starter.py --scan-path goal_harness/cli_commands/__init__.py --scan-path goal_harness/cli.py --scan-path examples/codex-cli-bounded-visible-pilot-adapter-smoke.py --scan-path docs/product/codex-cli-live-tui-first-message-pilot.md --scan-path docs/product/README.md
- git diff --check