### PR TITLE
Add benchmark case-analysis proposal drafts

### DIFF
--- a/examples/benchmark-case-analysis-candidates-smoke.py
+++ b/examples/benchmark-case-analysis-candidates-smoke.py
@@ -16,7 +16,9 @@ if str(REPO_ROOT) not in sys.path:
 
 from goal_harness.benchmark_case_analysis import (  # noqa: E402
     BENCHMARK_CASE_ANALYSIS_CANDIDATE_REPORT_SCHEMA_VERSION,
+    BENCHMARK_CASE_ANALYSIS_UPSERT_PROPOSAL_SCHEMA_VERSION,
     build_case_analysis_candidate_report,
+    build_case_analysis_upsert_proposals,
     render_case_analysis_candidate_report_markdown,
 )
 
@@ -113,6 +115,40 @@ def test_candidate_report_from_fixture() -> None:
     assert_public_safe(render_case_analysis_candidate_report_markdown(report))
 
 
+def test_proposed_records_from_fixture() -> None:
+    proposals = build_case_analysis_upsert_proposals(
+        ledger=fixture_ledger(),
+        analysis=fixture_analysis(),
+    )
+    assert len(proposals) == 2, proposals
+    first = proposals[0]
+    assert first["schema_version"] == (
+        BENCHMARK_CASE_ANALYSIS_UPSERT_PROPOSAL_SCHEMA_VERSION
+    ), first
+    assert first["proposal_status"] == "proposal_only_not_applied", first
+    assert first["case_id"] == "new-no-uplift", first
+    assert first["classification"] == "no_uplift_candidate_proposal", first
+    assert first["source_boundary"]["proposal_only"] is True, first
+    assert first["source_boundary"]["raw_logs_recorded"] is False, first
+    assert first["source_boundary"]["raw_task_text_recorded"] is False, first
+    assert first["source_boundary"]["trajectory_recorded"] is False, first
+    assert_public_safe(json.dumps(proposals, ensure_ascii=False))
+
+    report = build_case_analysis_candidate_report(
+        ledger=fixture_ledger(),
+        analysis=fixture_analysis(),
+        include_proposed_records=True,
+        proposal_limit=1,
+    )
+    assert report["candidate_count"] == 2, report
+    assert report["proposed_record_count"] == 1, report
+    assert len(report["proposed_records"]) == 1, report
+    assert "Proposed Case-Analysis Records" in (
+        render_case_analysis_candidate_report_markdown(report)
+    )
+    assert_public_safe(render_case_analysis_candidate_report_markdown(report))
+
+
 def test_candidate_cli_on_fixture() -> None:
     with tempfile.TemporaryDirectory(prefix="case-analysis-candidates-") as tmp:
         root = Path(tmp)
@@ -149,6 +185,27 @@ def test_candidate_cli_on_fixture() -> None:
         assert "new-no-uplift" in markdown, markdown
         assert "existing-case" not in markdown, markdown
         assert_public_safe(markdown)
+        proposals_output = subprocess.check_output(
+            [
+                sys.executable,
+                str(REPO_ROOT / "scripts" / "benchmark_case_analysis_candidates.py"),
+                "--ledger",
+                str(ledger_path),
+                "--analysis",
+                str(analysis_path),
+                "--include-proposed-records",
+                "--proposal-limit",
+                "1",
+            ],
+            text=True,
+        )
+        proposal_report = json.loads(proposals_output)
+        assert proposal_report["candidate_count"] == 2, proposal_report
+        assert proposal_report["proposed_record_count"] == 1, proposal_report
+        assert proposal_report["proposed_records"][0]["proposal_status"] == (
+            "proposal_only_not_applied"
+        ), proposal_report
+        assert_public_safe(proposals_output)
 
 
 def test_goal_harness_benchmark_cli_on_fixture() -> None:
@@ -180,6 +237,32 @@ def test_goal_harness_benchmark_cli_on_fixture() -> None:
         assert payload["read_boundary"]["task_text_read"] is False, payload
         assert payload["read_boundary"]["trajectory_read"] is False, payload
         assert_public_safe(output)
+        proposals_output = subprocess.check_output(
+            [
+                str(REPO_ROOT / "scripts" / "goal-harness"),
+                "--format",
+                "json",
+                "benchmark",
+                "case-analysis-candidates",
+                "--run-ledger-path",
+                str(ledger_path),
+                "--case-analysis-path",
+                str(analysis_path),
+                "--include-proposed-records",
+                "--proposal-limit",
+                "1",
+            ],
+            text=True,
+        )
+        proposals_payload = json.loads(proposals_output)
+        assert proposals_payload["ok"] is True, proposals_payload
+        assert proposals_payload["report"]["proposed_record_count"] == 1, (
+            proposals_payload
+        )
+        assert proposals_payload["report"]["proposed_records"][0][
+            "proposal_status"
+        ] == "proposal_only_not_applied", proposals_payload
+        assert_public_safe(proposals_output)
         markdown = subprocess.check_output(
             [
                 str(REPO_ROOT / "scripts" / "goal-harness"),
@@ -216,10 +299,31 @@ def test_default_assets_have_public_safe_candidates() -> None:
         and candidate["trajectory_recorded"] is False
         for candidate in report["candidates"]
     ), report
+    proposal_output = subprocess.check_output(
+        [
+            sys.executable,
+            str(REPO_ROOT / "scripts" / "benchmark_case_analysis_candidates.py"),
+            "--include-proposed-records",
+            "--proposal-limit",
+            "3",
+        ],
+        text=True,
+    )
+    assert_public_safe(proposal_output)
+    proposal_report = json.loads(proposal_output)
+    assert proposal_report["proposed_record_count"] == 3, proposal_report
+    assert all(
+        record["source_boundary"]["raw_logs_recorded"] is False
+        and record["source_boundary"]["raw_task_text_recorded"] is False
+        and record["source_boundary"]["trajectory_recorded"] is False
+        and record["source_boundary"]["proposal_only"] is True
+        for record in proposal_report["proposed_records"]
+    ), proposal_report
 
 
 def main() -> None:
     test_candidate_report_from_fixture()
+    test_proposed_records_from_fixture()
     test_candidate_cli_on_fixture()
     test_goal_harness_benchmark_cli_on_fixture()
     test_default_assets_have_public_safe_candidates()

--- a/goal_harness/benchmark_case_analysis.py
+++ b/goal_harness/benchmark_case_analysis.py
@@ -8,6 +8,9 @@ from typing import Any
 BENCHMARK_CASE_ANALYSIS_CANDIDATE_REPORT_SCHEMA_VERSION = (
     "benchmark_case_analysis_candidate_report_v0"
 )
+BENCHMARK_CASE_ANALYSIS_UPSERT_PROPOSAL_SCHEMA_VERSION = (
+    "benchmark_case_analysis_upsert_proposal_v0"
+)
 
 NO_RUN_DECISIONS = {"", "no_runs_recorded"}
 
@@ -121,6 +124,145 @@ def classify_case_analysis_candidate(
     }
 
 
+def _case_analysis_id(benchmark_id: str, case_id: str, candidate_class: str) -> str:
+    def slug(value: str) -> str:
+        text = "".join(ch if ch.isalnum() else "-" for ch in value.lower())
+        text = "-".join(part for part in text.split("-") if part)
+        return text or "unknown"
+
+    return f"{slug(benchmark_id)}__{slug(case_id)}__{slug(candidate_class)}"
+
+
+def _proposal_classification(candidate_class: str) -> str:
+    mapping = {
+        "paired_no_uplift_candidate": "no_uplift_candidate_proposal",
+        "baseline_solved_non_regression_candidate": (
+            "baseline_solved_non_regression_candidate_proposal"
+        ),
+        "infrastructure_alignment_candidate": (
+            "infrastructure_alignment_candidate_proposal"
+        ),
+        "baseline_failure_treatment_candidate": (
+            "baseline_failure_treatment_candidate_proposal"
+        ),
+        "setup_or_runner_gap_defer": "setup_or_runner_gap_defer_proposal",
+        "baseline_solved_control_candidate": (
+            "baseline_solved_control_candidate_proposal"
+        ),
+        "single_arm_coverage_or_baseline_candidate": (
+            "single_arm_coverage_or_baseline_candidate_proposal"
+        ),
+    }
+    return mapping.get(candidate_class, "manual_classification_required_proposal")
+
+
+def _proposal_capability_signal(candidate: dict[str, Any]) -> str:
+    candidate_class = _compact_text(candidate.get("candidate_class"), limit=120)
+    decision = _compact_text(candidate.get("latest_decision"), limit=120)
+    benchmark_id = _compact_text(candidate.get("benchmark_id"), limit=120)
+    case_id = _compact_text(candidate.get("case_id"), limit=160)
+    run_count = candidate.get("run_count", 0)
+    if candidate_class == "baseline_failure_treatment_candidate":
+        return (
+            f"{benchmark_id}/{case_id} has a compact baseline failure candidate "
+            f"({decision}) across {run_count} recorded run(s); promote only after "
+            "matched treatment or stronger compact attribution."
+        )
+    if candidate_class == "infrastructure_alignment_candidate":
+        return (
+            f"{benchmark_id}/{case_id} carries a compact infrastructure/alignment "
+            f"lesson ({decision}); promote if the setup or verifier-alignment "
+            "lesson applies beyond this single run."
+        )
+    if candidate_class == "paired_no_uplift_candidate":
+        return (
+            f"{benchmark_id}/{case_id} has compact paired no-uplift evidence "
+            f"({decision}); use it to adjust routing or treatment policy, not as "
+            "a positive uplift claim."
+        )
+    if candidate_class == "baseline_solved_control_candidate":
+        return (
+            f"{benchmark_id}/{case_id} is a compact baseline-solved control "
+            f"({decision}); promote selectively for coverage or routing balance."
+        )
+    return (
+        f"{benchmark_id}/{case_id} is a compact ledger-only candidate "
+        f"({decision}); review proposed classification before editing the case "
+        "analysis table."
+    )
+
+
+def _proposal_control_plane_signal(candidate: dict[str, Any]) -> str:
+    handling = _compact_text(candidate.get("recommended_handling"), limit=220)
+    priority = _compact_text(candidate.get("promotion_priority"), limit=20)
+    return (
+        f"Generated as a {priority} proposal from compact ledger metadata only. "
+        f"Recommended handling: {handling}."
+    )
+
+
+def proposed_case_analysis_record_from_candidate(
+    candidate: dict[str, Any],
+) -> dict[str, Any]:
+    benchmark_id = _compact_text(candidate.get("benchmark_id"), limit=160)
+    case_id = _compact_text(candidate.get("case_id"), limit=200)
+    candidate_class = _compact_text(candidate.get("candidate_class"), limit=160)
+    recent_run_ids = [
+        _compact_text(run_id, limit=120)
+        for run_id in candidate.get("recent_run_ids", [])
+        if run_id
+    ]
+    return {
+        "schema_version": BENCHMARK_CASE_ANALYSIS_UPSERT_PROPOSAL_SCHEMA_VERSION,
+        "proposal_status": "proposal_only_not_applied",
+        "analysis_id": _case_analysis_id(benchmark_id, case_id, candidate_class),
+        "benchmark_id": benchmark_id,
+        "case_id": case_id,
+        "classification": _proposal_classification(candidate_class),
+        "latest_ledger_decision": _compact_text(
+            candidate.get("latest_decision"), limit=160
+        ),
+        "candidate_class": candidate_class,
+        "promotion_priority": _compact_text(
+            candidate.get("promotion_priority"), limit=20
+        ),
+        "source_run_ids": recent_run_ids,
+        "source_run_count": int(candidate.get("run_count") or 0),
+        "capability_signal": _proposal_capability_signal(candidate),
+        "control_plane_signal": _proposal_control_plane_signal(candidate),
+        "recommended_next_action": _compact_text(
+            candidate.get("recommended_handling"), limit=260
+        ),
+        "source_boundary": {
+            "inputs": [
+                "compact benchmark-run-ledger candidate",
+                "benchmark-case-analysis existing keys",
+            ],
+            "raw_logs_recorded": False,
+            "raw_task_text_recorded": False,
+            "trajectory_recorded": False,
+            "absolute_paths_recorded": False,
+            "proposal_only": True,
+        },
+    }
+
+
+def build_case_analysis_upsert_proposals(
+    *,
+    ledger: dict[str, Any],
+    analysis: dict[str, Any],
+    limit: int | None = None,
+) -> list[dict[str, Any]]:
+    candidates = find_case_analysis_candidates(ledger=ledger, analysis=analysis)
+    proposals = [
+        proposed_case_analysis_record_from_candidate(candidate)
+        for candidate in candidates
+    ]
+    if limit is not None:
+        return proposals[: max(0, limit)]
+    return proposals
+
+
 def find_case_analysis_candidates(
     *,
     ledger: dict[str, Any],
@@ -189,9 +331,11 @@ def build_case_analysis_candidate_report(
     *,
     ledger: dict[str, Any],
     analysis: dict[str, Any],
+    include_proposed_records: bool = False,
+    proposal_limit: int | None = None,
 ) -> dict[str, Any]:
     candidates = find_case_analysis_candidates(ledger=ledger, analysis=analysis)
-    return {
+    report: dict[str, Any] = {
         "schema_version": BENCHMARK_CASE_ANALYSIS_CANDIDATE_REPORT_SCHEMA_VERSION,
         "candidate_count": len(candidates),
         "candidates": candidates,
@@ -206,6 +350,16 @@ def build_case_analysis_candidate_report(
             "absolute_paths_recorded": False,
         },
     }
+    if include_proposed_records:
+        proposed_records = [
+            proposed_case_analysis_record_from_candidate(candidate)
+            for candidate in candidates
+        ]
+        if proposal_limit is not None:
+            proposed_records = proposed_records[: max(0, proposal_limit)]
+        report["proposed_record_count"] = len(proposed_records)
+        report["proposed_records"] = proposed_records
+    return report
 
 
 def render_case_analysis_candidate_report_markdown(report: dict[str, Any]) -> str:
@@ -235,4 +389,30 @@ def render_case_analysis_candidate_report_markdown(report: dict[str, Any]) -> st
             f"`{candidate.get('run_count', 0)}` | "
             f"{candidate.get('recommended_handling', '')} |"
         )
+    proposed_records = report.get("proposed_records")
+    if isinstance(proposed_records, list):
+        lines.extend(
+            [
+                "",
+                "## Proposed Case-Analysis Records",
+                "",
+                "These records are proposal-only. They are safe to review, but the",
+                "case-analysis file should not be edited until the proposed",
+                "classification and handling are accepted.",
+                "",
+                "| Priority | Benchmark | Case | Classification | Source Runs |",
+                "| --- | --- | --- | --- | --- |",
+            ]
+        )
+        for record in proposed_records:
+            if not isinstance(record, dict):
+                continue
+            lines.append(
+                "| "
+                f"`{record.get('promotion_priority', '')}` | "
+                f"`{record.get('benchmark_id', '')}` | "
+                f"`{record.get('case_id', '')}` | "
+                f"`{record.get('classification', '')}` | "
+                f"`{record.get('source_run_count', 0)}` |"
+            )
     return "\n".join(lines) + "\n"

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -3389,6 +3389,20 @@ def main(argv: list[str] | None = None) -> int:
         ),
         help="Path to benchmark_case_analysis_v0 JSON.",
     )
+    benchmark_case_analysis_candidates_parser.add_argument(
+        "--include-proposed-records",
+        action="store_true",
+        help=(
+            "Include proposal-only benchmark_case_analysis_v0 record drafts. "
+            "This does not edit the case-analysis file."
+        ),
+    )
+    benchmark_case_analysis_candidates_parser.add_argument(
+        "--proposal-limit",
+        type=int,
+        default=None,
+        help="Maximum proposal records to include when --include-proposed-records is set.",
+    )
 
     agentissue_runner_flow_parser = benchmark_sub.add_parser(
         "agentissue-codex-runner-flow",
@@ -8828,6 +8842,8 @@ def main(argv: list[str] | None = None) -> int:
                 report = build_case_analysis_candidate_report(
                     ledger=ledger,
                     analysis=analysis,
+                    include_proposed_records=args.include_proposed_records,
+                    proposal_limit=args.proposal_limit,
                 )
                 payload = {
                     "ok": True,

--- a/scripts/benchmark_case_analysis_candidates.py
+++ b/scripts/benchmark_case_analysis_candidates.py
@@ -42,6 +42,20 @@ def parse_args() -> argparse.Namespace:
         default="json",
         help="Output format.",
     )
+    parser.add_argument(
+        "--include-proposed-records",
+        action="store_true",
+        help=(
+            "Include proposal-only benchmark_case_analysis_v0 record drafts. "
+            "This does not edit the case-analysis file."
+        ),
+    )
+    parser.add_argument(
+        "--proposal-limit",
+        type=int,
+        default=None,
+        help="Maximum proposal records to include when --include-proposed-records is set.",
+    )
     return parser.parse_args()
 
 
@@ -50,6 +64,8 @@ def main() -> int:
     report = build_case_analysis_candidate_report(
         ledger=load_json(args.ledger),
         analysis=load_json(args.analysis),
+        include_proposed_records=args.include_proposed_records,
+        proposal_limit=args.proposal_limit,
     )
     if args.format == "markdown":
         sys.stdout.write(render_case_analysis_candidate_report_markdown(report))


### PR DESCRIPTION
## Summary
- add proposal-only benchmark case-analysis record drafts derived from compact ledger candidates
- expose the proposal draft output through the standalone script and the `goal-harness benchmark case-analysis-candidates` CLI with `--include-proposed-records`
- extend the candidate smoke to verify proposal-only status, public-safe boundaries, and CLI output

## Validation
- `python3 -m py_compile goal_harness/benchmark_case_analysis.py goal_harness/cli.py examples/benchmark-case-analysis-candidates-smoke.py scripts/benchmark_case_analysis_candidates.py`
- `python3 examples/benchmark-case-analysis-candidates-smoke.py`
- `python3 examples/benchmark-case-analysis-smoke.py`
- `python3 examples/benchmark-run-ledger-smoke.py`
- `scripts/goal-harness --format json benchmark case-analysis-candidates --include-proposed-records --proposal-limit 3`
- `goal-harness check --scan-path goal_harness/benchmark_case_analysis.py --scan-path goal_harness/cli.py --scan-path scripts/benchmark_case_analysis_candidates.py --scan-path examples/benchmark-case-analysis-candidates-smoke.py`
- `git diff --check`

## Boundary
- no raw benchmark logs, task text, trajectories, verifier tails, credentials, uploads, or local/private artifacts are read or written
- proposal output is explicitly `proposal_only_not_applied` and does not edit `benchmark-case-analysis.json`
