### PR TITLE
Add benchmark observable handle policy

### DIFF
--- a/docs/benchmark-developer-workflow.md
+++ b/docs/benchmark-developer-workflow.md
@@ -127,6 +127,21 @@ does not emit task text, trajectories, raw logs, or capture content. With
 event to the rollout log so the control plane can see that a poll happened
 without seeing host paths or capture text.
 
+For local `launchd` or similar scheduler jobs, treat benchmark case launches as
+one-shot observable runs. Do not use `KeepAlive` to rerun a case label
+automatically: a successful compact closeout or a terminal compact failure must
+unload/disable the scheduler label before any rerun is considered. The snapshot
+adds an `observable_handle_policy` per run with these public-safe decisions:
+
+- `monitor_poll_allowed=true`: keep observing the pid/job handle.
+- `cleanup_required=true`: unload/disable the one-shot label, then ingest the
+  compact closeout or write the precise blocker named by `next_action`.
+- `blocker_required_before_rerun=true`: the observable handle ended or vanished
+  without a compact closeout; write that blocker before any rerun.
+
+This keeps reruns explicit and countable while preserving enough handle state
+for another developer or heartbeat to resume polling without chat memory.
+
 ### Goal Rollout Event Log
 
 Each benchmark case should leave a compact Goal Harness rollout trail, separate

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -2114,6 +2114,16 @@ Project adapters may add compact public-safe fields such as `health_check`,
 Raw logs, prompts, private metrics, workspace paths, and internal document
 links belong in private run payloads, not in compact index records.
 
+Benchmark status snapshots may include
+`runs[].observable_handle_policy` with
+`schema_version=benchmark_observable_handle_policy_v0`. This is an additive,
+public-safe lifecycle projection for one-shot benchmark schedulers. Consumers
+may use it to decide whether a run should continue polling, unload/disable a
+local `launchd` label, or write a precise missing-handle blocker before any
+rerun. It must be derived from compact artifacts, pid liveness, and run labels
+only; it must not expose raw logs, task text, trajectories, scheduler payloads,
+or local paths.
+
 ## Boundary
 
 The JSON export is safe to feed to a local dashboard only if the registry ids,

--- a/examples/benchmark-run-status-snapshot-smoke.py
+++ b/examples/benchmark-run-status-snapshot-smoke.py
@@ -30,6 +30,13 @@ def main() -> int:
         run = root / "terminal-case-r1"
         work = run / "host-agent-work" / "host-codex-goal-abc"
         work.mkdir(parents=True)
+        running_run = root / "skills-case-running-r1"
+        running_run.mkdir()
+        (running_run / "status.env").write_text("running\n", encoding="utf-8")
+        (running_run / "pid.private").write_text(str(os.getpid()), encoding="utf-8")
+        failure_run = root / "swe-case-terminal-failure-r1"
+        failure_run.mkdir()
+        (failure_run / "status.env").write_text("rc=1\n", encoding="utf-8")
         requests = work / "requests"
         requests.mkdir()
         (requests / "abc.request.json").write_text("{}", encoding="utf-8")
@@ -67,6 +74,22 @@ def main() -> int:
             ),
             encoding="utf-8",
         )
+        (failure_run / "materialization.compact.json").write_text(
+            json.dumps(
+                {
+                    "compact_benchmark_run": {
+                        "benchmark_id": "swe-marathon",
+                        "case_id": "swe-case",
+                        "ready_for_compact_failure_marker": True,
+                        "compact_failure_class": (
+                            "detached_worker_ended_without_trial_result"
+                        ),
+                        "external_handle_terminal": True,
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
 
         proc = subprocess.run(
             [
@@ -76,6 +99,10 @@ def main() -> int:
                 str(root),
                 "--label",
                 "terminal-case-r1",
+                "--label",
+                "skills-case-running-r1",
+                "--label",
+                "swe-case-terminal-failure-r1",
                 "--pattern",
                 "Working",
                 "--pretty",
@@ -90,6 +117,8 @@ def main() -> int:
         assert payload["boundary"]["local_paths_recorded"] is False
         assert payload["run_root_recorded"] is False
         item = payload["runs"][0]
+        running_item = payload["runs"][1]
+        failure_item = payload["runs"][2]
         assert item["status"] == "rc=0"
         assert item["run_dir_recorded"] is False
         assert item["pid_alive"] is True
@@ -109,6 +138,30 @@ def main() -> int:
         assert item["bridge_request_dirs"][0]["request_count"] == 1
         assert item["bridge_request_dirs"][0]["response_count"] == 1
         assert item["capture_files"][0]["patterns"]["Working"] is True
+        closeout_policy = item["observable_handle_policy"]
+        assert closeout_policy["schema_version"] == (
+            "benchmark_observable_handle_policy_v0"
+        )
+        assert closeout_policy["one_shot_expected"] is True
+        assert closeout_policy["keep_alive_allowed"] is False
+        assert closeout_policy["duplicate_rerun_allowed"] is False
+        assert closeout_policy["terminal_closeout"] is True
+        assert closeout_policy["compact_result_closeout"] is True
+        assert closeout_policy["cleanup_required"] is True
+        assert closeout_policy["disable_scheduler_label_required"] is True
+        assert closeout_policy["unload_launchd_label_required"] is True
+        assert closeout_policy["monitor_poll_allowed"] is False
+        assert closeout_policy["boundary"]["local_paths_recorded"] is False
+        running_policy = running_item["observable_handle_policy"]
+        assert running_policy["terminal_closeout"] is False
+        assert running_policy["cleanup_required"] is False
+        assert running_policy["monitor_poll_allowed"] is True
+        assert running_policy["next_action"] == "poll_observable_handle"
+        failure_policy = failure_item["observable_handle_policy"]
+        assert failure_policy["terminal_closeout"] is True
+        assert failure_policy["compact_failure_closeout"] is True
+        assert failure_policy["cleanup_required"] is True
+        assert failure_policy["blocker_required_before_rerun"] is False
         assert "secret raw transcript" not in proc.stdout
         assert str(root) not in proc.stdout
 
@@ -121,6 +174,10 @@ def main() -> int:
                 str(root),
                 "--label",
                 "terminal-case-r1",
+                "--label",
+                "skills-case-running-r1",
+                "--label",
+                "swe-case-terminal-failure-r1",
                 "--pattern",
                 "Working",
                 "--record-rollout-event",
@@ -149,9 +206,13 @@ def main() -> int:
         event = events[0]
         assert event["event_kind"] == "benchmark_status", event
         assert event["status"] == "running", event
-        assert event["details"]["run_count"] == 1, event
-        assert event["details"]["pid_alive_count"] == 1, event
-        assert event["details"]["compact_result_count"] == 2, event
+        assert event["details"]["run_count"] == 3, event
+        assert event["details"]["pid_alive_count"] == 2, event
+        assert event["details"]["compact_result_count"] == 3, event
+        assert event["details"]["terminal_closeout_count"] == 2, event
+        assert event["details"]["cleanup_required_count"] == 2, event
+        assert event["details"]["monitor_poll_allowed_count"] == 1, event
+        assert event["details"]["blocker_required_count"] == 0, event
         assert event["boundary"]["raw_logs_recorded"] is False, event
         assert event["boundary"]["absolute_paths_recorded"] is False, event
 

--- a/goal_harness/benchmark_core/__init__.py
+++ b/goal_harness/benchmark_core/__init__.py
@@ -41,6 +41,10 @@ from .io import (
     optional_float,
     optional_positive_int,
 )
+from .observable_handles import (
+    BENCHMARK_OBSERVABLE_HANDLE_POLICY_SCHEMA_VERSION,
+    build_benchmark_observable_handle_policy,
+)
 from .parity import (
     CODEX_APP_PARITY_REQUIRED_CLI_CALLS,
     CODEX_APP_PARITY_POSTHOC_CHECK_SCHEMA_VERSION,
@@ -76,6 +80,7 @@ __all__ = [
     "BENCHMARK_ATTEMPT_ACCOUNTING_SCHEMA_VERSION",
     "BENCHMARK_CANONICAL_LIFECYCLE_SCHEMA_VERSION",
     "BENCHMARK_LIFECYCLE_STATE_SCHEMA_VERSION",
+    "BENCHMARK_OBSERVABLE_HANDLE_POLICY_SCHEMA_VERSION",
     "BENCHMARK_SPLIT_CONTROL_REMOTE_EXECUTOR_EXECUTION_SEAM_SCHEMA_VERSION",
     "BENCHMARK_SPLIT_CONTROL_REMOTE_EXECUTOR_LAUNCH_PLAN_SCHEMA_VERSION",
     "BENCHMARK_SPLIT_CONTROL_REMOTE_EXECUTOR_RUNNER_BATCH_SCHEMA_VERSION",
@@ -86,6 +91,7 @@ __all__ = [
     "BenchmarkLifecyclePhase",
     "BenchmarkRequest",
     "build_benchmark_attempt_accounting",
+    "build_benchmark_observable_handle_policy",
     "build_run_permission_policy",
     "build_benchmark_candidate_source_boundary",
     "build_codex_app_parity_posthoc_check",

--- a/goal_harness/benchmark_core/observable_handles.py
+++ b/goal_harness/benchmark_core/observable_handles.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+
+BENCHMARK_OBSERVABLE_HANDLE_POLICY_SCHEMA_VERSION = (
+    "benchmark_observable_handle_policy_v0"
+)
+
+
+_RESULT_CLOSEOUT_STATUS_VALUES = {
+    "completed",
+    "complete",
+    "passed",
+    "failed",
+    "scored",
+    "score_ready",
+}
+
+
+def _summary_items(run_snapshot: Mapping[str, Any]) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    compact_results = run_snapshot.get("compact_results")
+    if not isinstance(compact_results, list):
+        return items
+    for result in compact_results:
+        if not isinstance(result, Mapping):
+            continue
+        summary = result.get("summary")
+        if isinstance(summary, Mapping):
+            items.append(dict(summary))
+    return items
+
+
+def _has_compact_result_closeout(summary: Mapping[str, Any]) -> bool:
+    status = str(summary.get("official_score_status") or "").strip().lower()
+    if status in _RESULT_CLOSEOUT_STATUS_VALUES:
+        return True
+    for field in (
+        "official_score",
+        "official_task_score",
+        "accuracy",
+        "n_resolved",
+        "n_unresolved",
+    ):
+        if summary.get(field) is not None:
+            return True
+    return False
+
+
+def _has_compact_failure_closeout(summary: Mapping[str, Any]) -> bool:
+    if summary.get("ready_for_compact_failure_marker") is True:
+        return True
+    if summary.get("terminal_closeout") is True:
+        return True
+    for field in (
+        "compact_failure_class",
+        "failure_class",
+        "score_failure_attribution",
+    ):
+        value = str(summary.get(field) or "").strip()
+        if value and value.lower() not in {"none", "null", "no_failure"}:
+            return True
+    return False
+
+
+def build_benchmark_observable_handle_policy(
+    run_snapshot: Mapping[str, Any],
+    *,
+    scheduler_kind: str = "launchd",
+) -> dict[str, Any]:
+    """Return a public-safe polling/cleanup policy for a benchmark run handle.
+
+    The policy consumes the compact status snapshot shape produced by
+    `scripts/benchmark_run_status_snapshot.py`. It does not inspect raw logs,
+    trajectories, local paths, Docker state, or scheduler payloads.
+    """
+
+    compact_summaries = _summary_items(run_snapshot)
+    compact_result_closeout = any(
+        _has_compact_result_closeout(summary) for summary in compact_summaries
+    )
+    compact_failure_closeout = any(
+        _has_compact_failure_closeout(summary) for summary in compact_summaries
+    )
+    terminal_closeout = compact_result_closeout or compact_failure_closeout
+    exists = run_snapshot.get("exists") is True
+    pid_present = bool(str(run_snapshot.get("pid") or "").strip())
+    pid_alive = run_snapshot.get("pid_alive") is True
+
+    if pid_alive:
+        handle_state = "running"
+    elif pid_present:
+        handle_state = "ended"
+    elif exists:
+        handle_state = "missing"
+    else:
+        handle_state = "not_found"
+
+    missing_terminal_evidence = exists and not terminal_closeout and not pid_alive
+    cleanup_required = terminal_closeout or missing_terminal_evidence
+    monitor_poll_allowed = exists and not cleanup_required and pid_alive
+    blocker_required = missing_terminal_evidence
+
+    if terminal_closeout:
+        next_action = "disable_one_shot_scheduler_label_and_ingest_compact_closeout"
+    elif blocker_required:
+        next_action = "write_precise_missing_or_ended_handle_blocker_before_rerun"
+    elif monitor_poll_allowed:
+        next_action = "poll_observable_handle"
+    elif not exists:
+        next_action = "write_missing_run_directory_blocker"
+    else:
+        next_action = "continue_compact_observation"
+
+    return {
+        "schema_version": BENCHMARK_OBSERVABLE_HANDLE_POLICY_SCHEMA_VERSION,
+        "scheduler_kind": str(scheduler_kind or "unknown"),
+        "one_shot_expected": True,
+        "keep_alive_allowed": False,
+        "duplicate_rerun_allowed": False,
+        "run_label_present": bool(str(run_snapshot.get("label") or "").strip()),
+        "observable_handle": {
+            "kind": "pid_file" if pid_present else "run_label",
+            "state": handle_state,
+            "pid_recorded": pid_present,
+            "pid_alive": pid_alive,
+            "raw_handle_payload_recorded": False,
+        },
+        "terminal_closeout": terminal_closeout,
+        "compact_result_closeout": compact_result_closeout,
+        "compact_failure_closeout": compact_failure_closeout,
+        "cleanup_required": cleanup_required,
+        "disable_scheduler_label_required": cleanup_required,
+        "unload_launchd_label_required": cleanup_required
+        and str(scheduler_kind or "").lower() == "launchd",
+        "monitor_poll_allowed": monitor_poll_allowed,
+        "blocker_required_before_rerun": blocker_required,
+        "next_action": next_action,
+        "boundary": {
+            "compact_only": True,
+            "raw_logs_read": False,
+            "raw_task_text_read": False,
+            "trajectory_read": False,
+            "local_paths_recorded": False,
+            "scheduler_payload_recorded": False,
+        },
+    }

--- a/scripts/benchmark_run_status_snapshot.py
+++ b/scripts/benchmark_run_status_snapshot.py
@@ -21,6 +21,9 @@ from goal_harness.rollout_event_log import (  # noqa: E402
     build_rollout_event,
     rollout_event_log_path,
 )
+from goal_harness.benchmark_core import (  # noqa: E402
+    build_benchmark_observable_handle_policy,
+)
 
 
 DEFAULT_COMPACT_KEYS = (
@@ -38,6 +41,12 @@ DEFAULT_COMPACT_KEYS = (
     "official_task_score",
     "score_failure_attribution",
     "first_blocker",
+    "ready_for_compact_result_ingest",
+    "ready_for_compact_failure_marker",
+    "compact_failure_class",
+    "failure_class",
+    "terminal_closeout",
+    "external_handle_terminal",
     "runner_return_status",
     "accuracy",
     "n_resolved",
@@ -155,6 +164,7 @@ def snapshot_run(
             _capture_summary(path, run_dir, patterns, now)
             for path in sorted(run_dir.glob("**/tmux_capture.txt"))[:max_captures]
         ]
+    item["observable_handle_policy"] = build_benchmark_observable_handle_policy(item)
     return item
 
 
@@ -229,6 +239,31 @@ def _snapshot_rollout_details(payload: dict[str, Any]) -> dict[str, Any]:
         "capture_file_count": sum(
             len(run.get("capture_files") or []) for run in existing
         ),
+        "terminal_closeout_count": sum(
+            1
+            for run in existing
+            if isinstance(run.get("observable_handle_policy"), dict)
+            and run["observable_handle_policy"].get("terminal_closeout") is True
+        ),
+        "cleanup_required_count": sum(
+            1
+            for run in existing
+            if isinstance(run.get("observable_handle_policy"), dict)
+            and run["observable_handle_policy"].get("cleanup_required") is True
+        ),
+        "monitor_poll_allowed_count": sum(
+            1
+            for run in existing
+            if isinstance(run.get("observable_handle_policy"), dict)
+            and run["observable_handle_policy"].get("monitor_poll_allowed") is True
+        ),
+        "blocker_required_count": sum(
+            1
+            for run in existing
+            if isinstance(run.get("observable_handle_policy"), dict)
+            and run["observable_handle_policy"].get("blocker_required_before_rerun")
+            is True
+        ),
     }
 
 
@@ -264,7 +299,8 @@ def append_status_rollout_event(
         summary=(
             "benchmark status snapshot recorded: "
             f"runs={details['run_count']} existing={details['exists_count']} "
-            f"alive={details['pid_alive_count']} compacts={details['compact_result_count']}"
+            f"alive={details['pid_alive_count']} compacts={details['compact_result_count']} "
+            f"cleanup={details['cleanup_required_count']}"
         ),
         details=details,
     )


### PR DESCRIPTION
## Summary
- Add a reusable benchmark observable-handle policy for one-shot scheduler cleanup decisions.
- Attach the policy to benchmark_run_status_snapshot output and rollout event detail counters.
- Extend the status snapshot smoke and public docs for launchd one-shot polling, cleanup, and blocker rules.

## Validation
- python3 -m py_compile goal_harness/benchmark_core/observable_handles.py goal_harness/benchmark_core/__init__.py scripts/benchmark_run_status_snapshot.py examples/benchmark-run-status-snapshot-smoke.py
- python3 examples/benchmark-run-status-snapshot-smoke.py
- scripts/goal-harness check --scan-path goal_harness/benchmark_core/observable_handles.py --scan-path goal_harness/benchmark_core/__init__.py --scan-path scripts/benchmark_run_status_snapshot.py --scan-path examples/benchmark-run-status-snapshot-smoke.py --scan-path docs/benchmark-developer-workflow.md --scan-path docs/status-data-contract.md
- git diff --check

## Boundary
- No benchmark jobs launched.
- No scoring or runner behavior changed.
- No raw logs, task text, trajectories, local paths, credentials, or scheduler payloads recorded.