### PR TITLE
Add frontstage dashboard design baseline

### DIFF
--- a/apps/dashboard/README.md
+++ b/apps/dashboard/README.md
@@ -37,6 +37,10 @@ decision, quota, user todo, agent todo, active-claim, open-gate, artifact,
 timeline, and truth contract lanes. Treat it as the product-path replacement for expanding the
 no-dependency static HTML renderer; the Python renderer remains the fallback
 demo/diagnostic surface.
+The product interaction baseline lives in
+`docs/product/frontstage-dashboard-interaction-baseline.md`: showcase mode is
+the public case-driven homepage surface, while `mode=ops` is the dense,
+read-only control-plane workspace.
 
 The frontstage first screen is meant to teach the control-plane model before a
 developer reads raw status JSON. The top operations strip answers whether the

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -11,6 +11,7 @@
     "smoke:action-packet": "rm -rf /tmp/goal-harness-action-packet-smoke && tsc --ignoreConfig --target ES2022 --module NodeNext --moduleResolution NodeNext --skipLibCheck --strict --outDir /tmp/goal-harness-action-packet-smoke smoke/action-packet-smoke.ts src/data/action-packet.ts && node /tmp/goal-harness-action-packet-smoke/smoke/action-packet-smoke.js",
     "smoke:demo-readiness": "python3 ../../examples/dashboard-demo-readiness-smoke.py",
     "smoke:frontstage-browser": "node ../../examples/dashboard-frontstage-browser-smoke.mjs",
+    "smoke:frontstage-design-baseline": "node ../../examples/dashboard-frontstage-design-baseline-smoke.mjs",
     "smoke:frontstage-route": "rm -rf /tmp/goal-harness-frontstage-route-smoke && tsc --ignoreConfig --target ES2022 --module NodeNext --moduleResolution NodeNext --skipLibCheck --strict --outDir /tmp/goal-harness-frontstage-route-smoke smoke/frontstage-route-smoke.ts && node /tmp/goal-harness-frontstage-route-smoke/frontstage-route-smoke.js",
     "smoke:frontstage-share-bundle": "node ../../examples/frontstage-share-bundle-smoke.mjs",
     "smoke:home-browser": "node ../../examples/dashboard-home-browser-smoke.mjs",

--- a/apps/dashboard/smoke/frontstage-route-smoke.ts
+++ b/apps/dashboard/smoke/frontstage-route-smoke.ts
@@ -51,6 +51,8 @@ includes(dataSource, "raw_or_private_material_omitted", "source warning fixture"
 includes(statusSource, "goal_channel_projection: goalChannelProjectionSchema", "status projection parser");
 
 includes(frontstageSource, 'data-testid="goal-channel-frontstage-route"', "route test id");
+includes(frontstageSource, 'data-frontstage-surface={isOpsMode ? "ops-control-plane" : "showcase-homepage"}', "frontstage surface split marker");
+includes(frontstageSource, 'data-testid={isOpsMode ? "frontstage-ops-workspace-shell" : "frontstage-showcase-workspace-shell"}', "frontstage workspace shell marker");
 includes(frontstageSource, 'data-testid="frontstage-live-source-panel"', "live source panel");
 includes(frontstageSource, 'data-testid="frontstage-public-boundary-note"', "public boundary note");
 includes(frontstageSource, "Showcase mode ignores statusUrl", "public mode statusUrl guard copy");
@@ -65,6 +67,7 @@ includes(frontstageSource, "Ops statusUrl accepts only relative or loopback sour
 includes(frontstageSource, 'data-testid="frontstage-user-todos"', "user todo lane");
 includes(frontstageSource, 'data-testid="frontstage-agent-todos"', "agent todo lane");
 includes(frontstageSource, 'data-testid="frontstage-todo-discovery"', "todo discovery controls");
+includes(frontstageSource, 'data-testid="frontstage-ops-command-strip"', "ops command strip");
 includes(frontstageSource, 'data-testid="frontstage-todo-search"', "todo search control");
 includes(frontstageSource, 'data-testid="frontstage-todo-lane-filter"', "todo lane filter control");
 includes(frontstageSource, 'data-testid="frontstage-todo-result-count"', "todo filter result count");

--- a/apps/dashboard/src/styles.css
+++ b/apps/dashboard/src/styles.css
@@ -24,6 +24,55 @@ select {
   font: inherit;
 }
 
+.frontstage-workspace-shell {
+  align-items: start;
+}
+
+.frontstage-ops-workspace {
+  --frontstage-panel: rgb(255 255 255);
+  --frontstage-panel-muted: rgb(248 250 252);
+  --frontstage-border: rgb(226 232 240);
+  background:
+    linear-gradient(180deg, rgb(248 250 252), rgb(247 247 244) 18rem),
+    rgb(247 247 244);
+}
+
+.frontstage-ops-workspace :where(section, aside, .frontstage-ops-command-strip) {
+  border-radius: 0.5rem;
+}
+
+.frontstage-ops-main-pane {
+  min-width: 0;
+}
+
+.frontstage-ops-command-strip {
+  position: relative;
+  overflow: hidden;
+  background:
+    linear-gradient(180deg, var(--frontstage-panel), var(--frontstage-panel-muted)),
+    var(--frontstage-panel);
+}
+
+.frontstage-ops-command-strip::before {
+  position: absolute;
+  inset-block: 0;
+  left: 0;
+  width: 0.25rem;
+  content: "";
+  background: linear-gradient(180deg, rgb(20 184 166), rgb(99 102 241), rgb(245 158 11));
+}
+
+.frontstage-ops-command-strip input,
+.frontstage-ops-command-strip select {
+  min-width: 0;
+}
+
+.frontstage-showcase-workspace {
+  background:
+    linear-gradient(180deg, rgb(255 255 255), rgb(247 247 244) 20rem),
+    rgb(247 247 244);
+}
+
 .frontstage-state-flow-track {
   position: relative;
   height: 0.25rem;
@@ -198,5 +247,11 @@ select {
     left: 0;
     width: 100%;
     opacity: 0.55;
+  }
+}
+
+@media (max-width: 640px) {
+  .frontstage-ops-command-strip {
+    padding-inline: 0.875rem;
   }
 }

--- a/apps/dashboard/src/views/frontstage-page.tsx
+++ b/apps/dashboard/src/views/frontstage-page.tsx
@@ -1027,12 +1027,19 @@ function FrontstageRoute({
 
   return (
     <main
-      className="min-h-screen bg-[#f7f7f4] px-4 py-4 text-slate-950 sm:px-5"
+      className={cn(
+        "min-h-screen bg-[#f7f7f4] px-4 py-4 text-slate-950 sm:px-5",
+        isOpsMode ? "frontstage-ops-workspace" : "frontstage-showcase-workspace",
+      )}
+      data-frontstage-surface={isOpsMode ? "ops-control-plane" : "showcase-homepage"}
       data-mode={projection.mode}
       data-schema={projection.schema_version}
       data-testid="goal-channel-frontstage-route"
     >
-      <div className="mx-auto grid max-w-[1500px] gap-4 xl:grid-cols-[260px_minmax(0,1fr)_320px]">
+      <div
+        className="frontstage-workspace-shell mx-auto grid max-w-[1500px] gap-4 xl:grid-cols-[260px_minmax(0,1fr)_320px]"
+        data-testid={isOpsMode ? "frontstage-ops-workspace-shell" : "frontstage-showcase-workspace-shell"}
+      >
         <aside className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm xl:sticky xl:top-4 xl:self-start">
           <div className="flex items-center gap-2">
             <div className="flex h-9 w-9 items-center justify-center rounded-md border border-slate-200 bg-slate-950 text-white">
@@ -1137,7 +1144,7 @@ function FrontstageRoute({
           </div>
         </aside>
 
-        <section className="space-y-4">
+        <section className={cn("space-y-4", isOpsMode ? "frontstage-ops-main-pane" : "frontstage-showcase-main-pane")}>
           <div className="rounded-lg border border-slate-200 bg-white px-5 py-5 shadow-sm">
             <div className="flex flex-wrap items-start justify-between gap-4">
               <div className="min-w-0">
@@ -1226,10 +1233,10 @@ function FrontstageRoute({
 
               <div className="grid gap-4 lg:grid-cols-2">
                 <div
-                  className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm lg:col-span-2"
-                  data-testid="frontstage-todo-discovery"
+                  className="frontstage-ops-command-strip rounded-lg border border-slate-200 bg-white p-4 shadow-sm lg:col-span-2"
+                  data-testid="frontstage-ops-command-strip"
                 >
-                  <div className="grid gap-3 lg:grid-cols-[minmax(220px,1fr)_180px_auto]">
+                  <div className="grid gap-3 lg:grid-cols-[minmax(220px,1fr)_180px_auto]" data-testid="frontstage-todo-discovery">
                     <label className="block">
                       <span className="text-[11px] font-semibold uppercase tracking-normal text-slate-500">Search todo projection</span>
                       <span className="relative mt-1 block">

--- a/docs/dashboard-frontend-selection.md
+++ b/docs/dashboard-frontend-selection.md
@@ -187,6 +187,9 @@ agent-board density belongs; the existing Python/HTML renderer should stay a
 no-build diagnostic fallback. The next slices should be quality work: visual
 acceptance, richer public-safe fixtures, and operator onboarding details rather
 than another base renderer.
+The durable interaction baseline is tracked in
+`docs/product/frontstage-dashboard-interaction-baseline.md`, including the
+showcase/homepage versus ops/control-plane split.
 
 ## Sources Checked
 

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -39,6 +39,10 @@ runtime contract, benchmark route, or launch draft.
   the compact release note and smoke contract that prove the packaged installer,
   fresh-project bootstrap message, bootstrap bundle, and proof fixtures stay
   aligned before no-clone install is advertised as the default user path.
+- [Frontstage dashboard interaction baseline](frontstage-dashboard-interaction-baseline.md):
+  the two-surface frontend rule for keeping public showcase/homepage work fancy
+  and case-driven while the real ops control-plane route stays dense, calm,
+  read-only, and reviewable.
 - [Codex CLI automation driver audit](codex-cli-automation-driver.md): the
   current Codex CLI scheduler/session surface audit, with a conservative local
   driver planner that keeps TUI bootstrap primary, composes quota/idle/fallback

--- a/docs/product/frontstage-dashboard-interaction-baseline.md
+++ b/docs/product/frontstage-dashboard-interaction-baseline.md
@@ -1,0 +1,88 @@
+# Frontstage Dashboard Interaction Baseline
+
+Goal Harness has two frontend jobs, and they should not collapse into one
+layout.
+
+The showcase surface sells the product model. The ops surface lets real users
+work. They can share React components, icons, tokens, and public-safe fixtures,
+but they should not share data defaults, information density, or motion rules.
+
+## Surface Split
+
+| Surface | Route posture | Primary job | Data source | Visual rule |
+| --- | --- | --- | --- | --- |
+| Showcase/homepage | Default `/frontstage` | Make the product feel obvious and compelling | `docs/showcases/showcase-catalog.json` plus sanitized share fixtures | Case-first, concise, animated, public-safe |
+| Ops/control-plane | Explicit `mode=ops` | Help an operator scan, decide, and review long-running agent work | Relative or loopback `goal_channel_projection_v0` status feeds | Dense, calm, read-only, repeatable |
+
+The default hosted or copied link must open the showcase surface. Live registry
+state requires an explicit ops route and a loopback or relative status source.
+
+## Product Direction
+
+Use the Multica-style agent workspace direction as a product benchmark for
+density and interaction grammar: visible agents, claimed work, boards, timelines,
+search, filters, compact role state, and reusable workspace primitives. Do not
+clone its product model. Goal Harness still treats quota, status, todos, gates,
+leases, run history, and append-only evidence as the control-plane source of
+truth.
+
+The current stack is the baseline:
+
+- React, Vite, TypeScript, and TanStack Router for a static-build-first app with
+  URL-backed filters.
+- TanStack Table when rows need real sorting, grouping, and column control.
+- Tailwind plus owned shadcn/Base UI-like primitives for compact controls,
+  badges, panels, command surfaces, and accessible interaction states.
+- lucide-react for buttons, lane headers, and unfamiliar controls.
+- Zod at the status boundary so public fixtures and local live feeds fail
+  loudly instead of rendering ambiguous state.
+
+## Showcase Rules
+
+The showcase surface can be fancy because it is not an operator cockpit.
+
+- Lead with public cases and the asynchronous agent operating model.
+- Use motion to explain state flow: safe work moving, gates holding, evidence
+  closing loops, and multiple agent lanes converging through one shared control
+  plane.
+- Render only public-safe showcase catalog fields and sanitized share fixtures.
+- Keep local status exports, internal project labels, raw task ids, private
+  screenshots, benchmark raw logs, and machine paths out of this surface.
+- Link deeper reading to public GitHub showcase pages.
+
+## Ops Rules
+
+The ops surface should feel like a working console, not a landing page.
+
+- Keep the first screen scannable: goal header, decision frame, quota guard,
+  user todo lane, agent todo lane, claims, gates, artifacts, source warnings,
+  and run timeline.
+- Prefer rows, strips, filters, and compact panes over large hero sections.
+- Preserve URL-backed search and lane filters so a review can reproduce the
+  exact projected slice.
+- Keep panels at 8px radius or less and avoid nested cards.
+- Keep writes out of the route. Browser write authority belongs behind a
+  separate local capability gate, not inside the read-only frontstage.
+- Optimize for repeated use: stable dimensions, no horizontal overflow,
+  responsive constraints, and reduced-motion fallbacks.
+
+## Current Acceptance Anchors
+
+The route currently exposes these durable anchors:
+
+- `data-frontstage-surface="showcase-homepage"` for the public showcase mode.
+- `data-frontstage-surface="ops-control-plane"` for the live ops mode.
+- `frontstage-ops-workspace-shell` for the dense app shell.
+- `frontstage-ops-command-strip` for search/filter/result-count controls.
+- `frontstage-todo-search`, `frontstage-todo-lane-filter`, and
+  `frontstage-todo-result-count` for reviewable todo projection slices.
+- `frontstage-role-map`, `frontstage-active-claims`, `frontstage-open-gates`,
+  `frontstage-artifacts`, and `frontstage-timeline` for the operator workspace.
+
+`npm run smoke:frontstage-browser` remains the visual acceptance check for this
+surface. It captures desktop and mobile screenshots, checks animated showcase
+rails, verifies public/private boundary behavior, and exercises ops search,
+lane filtering, goal selection, and loopback-source rejection.
+
+`npm run smoke:frontstage-design-baseline` keeps this document, route anchors,
+CSS shell classes, package scripts, and README entry points aligned.

--- a/examples/dashboard-frontstage-design-baseline-smoke.mjs
+++ b/examples/dashboard-frontstage-design-baseline-smoke.mjs
@@ -1,0 +1,87 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function includes(source, snippet, label) {
+  assert(source.includes(snippet), `missing ${label}: ${snippet}`);
+}
+
+function excludes(source, snippet, label) {
+  assert(!source.includes(snippet), `unexpected ${label}: ${snippet}`);
+}
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+function readRepoFile(path) {
+  return readFileSync(resolve(repoRoot, path), "utf8");
+}
+
+const productDoc = readRepoFile("docs/product/frontstage-dashboard-interaction-baseline.md");
+const productReadme = readRepoFile("docs/product/README.md");
+const dashboardReadme = readRepoFile("apps/dashboard/README.md");
+const frontstageSource = readRepoFile("apps/dashboard/src/views/frontstage-page.tsx");
+const stylesSource = readRepoFile("apps/dashboard/src/styles.css");
+const browserSmoke = readRepoFile("examples/dashboard-frontstage-browser-smoke.mjs");
+const packageSource = readRepoFile("apps/dashboard/package.json");
+
+includes(productDoc, "## Surface Split", "surface split section");
+includes(productDoc, "Showcase/homepage", "showcase surface row");
+includes(productDoc, "Ops/control-plane", "ops surface row");
+includes(productDoc, "Multica-style agent workspace direction", "Multica-style product benchmark");
+includes(productDoc, "React, Vite, TypeScript, and TanStack Router", "frontend stack baseline");
+includes(productDoc, "TanStack Table", "table stack baseline");
+includes(productDoc, "Tailwind plus owned shadcn/Base UI-like primitives", "owned component baseline");
+includes(productDoc, "lucide-react", "icon baseline");
+includes(productDoc, "Zod", "schema boundary baseline");
+includes(productDoc, "showcase surface can be fancy", "showcase motion allowance");
+includes(productDoc, "working console, not a landing page", "ops workspace rule");
+includes(productDoc, "frontstage-ops-workspace-shell", "ops shell anchor");
+includes(productDoc, "frontstage-ops-command-strip", "ops command strip anchor");
+includes(productDoc, "npm run smoke:frontstage-browser", "visual acceptance anchor");
+includes(productDoc, "npm run smoke:frontstage-design-baseline", "design smoke anchor");
+
+includes(productReadme, "frontstage-dashboard-interaction-baseline.md", "product README link");
+includes(dashboardReadme, "frontstage-dashboard-interaction-baseline.md", "dashboard README link");
+includes(dashboardReadme, "showcase mode is", "dashboard README surface split");
+includes(dashboardReadme, "mode=ops", "dashboard README ops route");
+
+includes(frontstageSource, 'data-frontstage-surface={isOpsMode ? "ops-control-plane" : "showcase-homepage"}', "surface data attribute");
+includes(frontstageSource, 'data-testid={isOpsMode ? "frontstage-ops-workspace-shell" : "frontstage-showcase-workspace-shell"}', "workspace shell test id");
+includes(frontstageSource, 'frontstage-ops-main-pane', "ops main pane class");
+includes(frontstageSource, 'data-testid="frontstage-ops-command-strip"', "ops command strip test id");
+includes(frontstageSource, 'data-testid="frontstage-todo-discovery"', "todo discovery anchor");
+includes(frontstageSource, 'data-testid="frontstage-todo-search"', "todo search anchor");
+includes(frontstageSource, 'data-testid="frontstage-todo-lane-filter"', "todo lane filter anchor");
+includes(frontstageSource, 'data-testid="frontstage-todo-result-count"', "todo result count anchor");
+includes(frontstageSource, 'data-testid="frontstage-role-map"', "role map anchor");
+includes(frontstageSource, 'data-testid="frontstage-active-claims"', "active claims anchor");
+includes(frontstageSource, 'data-testid="frontstage-open-gates"', "open gates anchor");
+includes(frontstageSource, 'data-testid="frontstage-artifacts"', "artifacts anchor");
+includes(frontstageSource, 'data-testid="frontstage-timeline"', "timeline anchor");
+excludes(frontstageSource, 'data-testid="frontstage-enable-ops-live"', "public in-page ops switch");
+
+includes(stylesSource, ".frontstage-workspace-shell", "workspace shell CSS");
+includes(stylesSource, ".frontstage-ops-workspace", "ops workspace CSS");
+includes(stylesSource, ".frontstage-ops-main-pane", "ops main pane CSS");
+includes(stylesSource, ".frontstage-ops-command-strip", "ops command strip CSS");
+includes(stylesSource, ".frontstage-showcase-workspace", "showcase workspace CSS");
+includes(stylesSource, "@media (max-width: 640px)", "responsive command strip CSS");
+includes(stylesSource, "@media (prefers-reduced-motion: reduce)", "reduced motion fallback");
+
+includes(browserSmoke, "desktop-frontstage-live", "ops visual screenshot smoke");
+includes(browserSmoke, "mobile-frontstage", "mobile visual screenshot smoke");
+includes(browserSmoke, "assertNoHorizontalOverflow", "overflow visual acceptance");
+includes(browserSmoke, "frontstage-showcase-motion-beam", "showcase motion visual check");
+includes(browserSmoke, "frontstage-todo-search", "ops search interaction check");
+includes(browserSmoke, "frontstage-todo-lane-filter", "ops filter interaction check");
+includes(browserSmoke, "Ops statusUrl must be relative or loopback", "loopback-source guard smoke");
+
+includes(packageSource, '"smoke:frontstage-design-baseline"', "package script");
+
+console.log("dashboard-frontstage-design-baseline smoke ok");


### PR DESCRIPTION
## Summary
- Add a durable frontstage dashboard interaction baseline that separates public showcase/homepage work from the real ops control-plane workspace.
- Mark the React frontstage route with stable showcase/ops surface anchors and an ops command-strip wrapper for search/filter/result-count controls.
- Add a focused design-baseline smoke and wire it into the dashboard package scripts.

## Validation
- `npm --prefix apps/dashboard run smoke:frontstage-design-baseline`
- `npm --prefix apps/dashboard run smoke:frontstage-route`
- `npm --prefix apps/dashboard run build`
- `npm --prefix apps/dashboard run smoke:frontstage-browser`
- `python3 examples/docs-governance-smoke.py`
- `goal-harness check --scan-path apps/dashboard --scan-path docs/product/frontstage-dashboard-interaction-baseline.md --scan-path docs/dashboard-frontend-selection.md --scan-path examples/dashboard-frontstage-design-baseline-smoke.mjs`
- `git diff --cached --check`

## Boundary Notes
- This PR does not include live registry exports, local status files, private project labels, raw benchmark logs, credentials, or generated screenshots/build artifacts.
- `goal-harness check` reports only the existing run-history duplicate-index warning for `goal-harness-meta`; public boundary scan is clean.
