### PR TITLE
Add SWE-Marathon Harbor Goal Harness treatment packet

### DIFF
--- a/docs/benchmark-developer-workflow.md
+++ b/docs/benchmark-developer-workflow.md
@@ -412,6 +412,41 @@ Harbor-family runs: the official environment result and the host completion
 marker are the scoring path, while app-server completion events are diagnostic
 only.
 
+For a matched SWE-Marathon Goal Harness treatment arm, keep the same task,
+model, timeout, environment, jobs directory shape, and no-upload boundary as the
+baseline, but add an explicit Goal Harness access packet to the host agent:
+
+```bash
+export PYTHONPATH=<goal-harness-checkout>/scripts:${PYTHONPATH:-}
+UV_LINK_MODE=copy uv run --no-default-groups harbor run \
+  --env docker \
+  --agent-import-path harbor_host_codex_goal_agent:HarborHostCodexGoalAgent \
+  --agent-kwarg goal_surface=app_server \
+  --agent-kwarg reasoning_effort=high \
+  --agent-kwarg app_server_wait_for_completion=true \
+  --agent-kwarg app_server_response_timeout_sec=90 \
+  --agent-kwarg goal_timeout_sec=<seconds> \
+  --agent-kwarg task_workdir=/app \
+  --agent-kwarg goal_harness_mode=codex_goal_harness \
+  --agent-kwarg goal_harness_access_packet_mode=compact \
+  --agent-kwarg goal_harness_cli_bridge_enabled=true \
+  --agent-kwarg goal_harness_goal_id=<goal-id> \
+  --agent-kwarg goal_harness_registry_arg=<registry.global.json> \
+  --agent-kwarg goal_harness_runtime_root_arg=<runtime-root> \
+  --agent-kwarg goal_harness_scan_path=<public-scan-path> \
+  --agent-kwarg goal_harness_classification=<public-classification> \
+  --jobs-dir <run-dir>/jobs \
+  --job-name <matched-treatment-job-name> \
+  -p <task-dir>
+```
+
+The treatment packet is intentionally lightweight: it gives the host Codex
+worker Goal Harness planning/checkpoint commands and boundary reminders, while
+the task solution still goes through `harbor-env-exec` and the official Harbor
+verifier remains authoritative. This is the right comparison against
+`codex_goal_mode_baseline`; it is not a submit/upload path and should still be
+reduced to compact public evidence before ledger ingestion.
+
 The Harbor bundle requires `codex` and `rg`. `curl` is intentionally optional:
 host-copied dynamic curl binaries can fail inside Ubuntu task images because of
 shared-library differences. Use the task image's curl, a static curl, or

--- a/examples/harbor-host-codex-goal-agent-smoke.py
+++ b/examples/harbor-host-codex-goal-agent-smoke.py
@@ -50,6 +50,41 @@ def main() -> int:
     assert "/data/goal-harness-bench" not in prompt
     assert "/root/goal-harness-bench" not in prompt
 
+    disabled_packet = module.build_goal_harness_access_packet(
+        mode="codex_goal_mode_baseline",
+        packet_mode="none",
+    )
+    assert disabled_packet == ""
+
+    treatment_packet = module.build_goal_harness_access_packet(
+        mode="codex_goal_harness",
+        packet_mode="compact",
+        goal_id="goal-harness-meta",
+        cli_bridge_enabled="true",
+        command_prefix="goal-harness",
+        registry_arg="/tmp/gh/registry.global.json",
+        runtime_root_arg="/tmp/gh/runtime",
+        scan_path="/workspace/goal_harness/benchmark.py",
+        classification="swe_marathon_rust_c_compiler_treatment",
+    )
+    assert "Goal Harness Access Packet V0" in treatment_packet
+    assert "benchmark_family: harbor" in treatment_packet
+    assert "mode: codex_goal_harness" in treatment_packet
+    assert "goal_harness_cli_bridge_available: true" in treatment_packet
+    assert "goal_harness_command_check:" in treatment_packet
+    assert "quota should-run" in treatment_packet
+    assert "do_not_upload_or_submit_to_leaderboard: true" in treatment_packet
+
+    treatment_prompt = module.build_host_goal_prompt(
+        instruction="Synthetic Harbor instruction placeholder.",
+        bridge_command=Path("/tmp/gh-harbor/bin/harbor-env-exec"),
+        marker_path=Path("/tmp/gh-harbor/done.marker"),
+        task_workdir="/workspace",
+        goal_harness_access_packet=treatment_packet,
+    )
+    assert "Goal Harness treatment access packet:" in treatment_prompt
+    assert "mode: codex_goal_harness" in treatment_prompt
+
     with tempfile.TemporaryDirectory(prefix="gh-harbor-host-agent-") as tmp:
         request_dir = Path(tmp) / "requests"
         request_dir.mkdir()
@@ -71,7 +106,7 @@ def main() -> int:
             app_server_response_timeout_sec="4",
         )
         assert agent.name() == "harbor-host-codex-goal"
-        assert agent.version() == "0.3.0"
+        assert agent.version() == "0.4.0"
         assert agent.goal_timeout_sec == 9.0
         assert agent.poll_interval_sec == 0.5
         assert agent.task_workdir == "/workspace"
@@ -79,6 +114,8 @@ def main() -> int:
         assert agent.reasoning_effort == "high"
         assert agent.app_server_wait_for_completion is False
         assert agent.app_server_response_timeout_sec == 4.0
+        assert agent.goal_harness_mode == "codex_goal_mode_baseline"
+        assert agent.goal_harness_access_packet_mode == "none"
 
         no_wait_agent = module.HarborHostCodexGoalAgent(
             logs_dir=Path(tmp) / "no-wait-logs",
@@ -86,6 +123,17 @@ def main() -> int:
             app_server_wait_for_completion="false",
         )
         assert no_wait_agent.app_server_wait_for_completion is False
+
+        treatment_agent = module.HarborHostCodexGoalAgent(
+            logs_dir=Path(tmp) / "treatment-logs",
+            goal_surface="app_server",
+            goal_harness_mode="codex_goal_harness",
+            goal_harness_access_packet_mode="compact",
+            goal_harness_cli_bridge_enabled="true",
+        )
+        assert treatment_agent.goal_harness_mode == "codex_goal_harness"
+        assert treatment_agent.goal_harness_access_packet_mode == "compact"
+        assert treatment_agent.goal_harness_cli_bridge_enabled is True
 
     print("harbor host Codex Goal agent smoke passed")
     return 0

--- a/scripts/harbor_host_codex_goal_agent.py
+++ b/scripts/harbor_host_codex_goal_agent.py
@@ -139,10 +139,17 @@ def build_host_goal_prompt(
     bridge_command: Path,
     marker_path: Path,
     task_workdir: str = "/app",
+    goal_harness_access_packet: str = "",
 ) -> str:
     bridge = shlex.quote(str(bridge_command))
     marker_cmd = f"touch {shlex.quote(str(marker_path))}"
     task_workdir_arg = shlex.quote(task_workdir)
+    access_packet = goal_harness_access_packet.strip()
+    access_packet_section = (
+        f"\n\nGoal Harness treatment access packet:\n{access_packet}"
+        if access_packet
+        else ""
+    )
     return f"""
 You are solving a Harbor benchmark task using native Codex Goal mode on the host.
 
@@ -156,11 +163,76 @@ Do not modify tests. Complete the task inside the Harbor environment only.
 
 Task instruction:
 {instruction}
+{access_packet_section}
 
 When and only when the task is complete, run this exact host command so the
 harness can observe completion:
 {marker_cmd}
 """.strip()
+
+
+def build_goal_harness_access_packet(
+    *,
+    mode: str,
+    packet_mode: str = "compact",
+    goal_id: str = "goal-harness-meta",
+    cli_bridge_enabled: str | bool = False,
+    command_prefix: str = "goal-harness",
+    registry_arg: str = "",
+    runtime_root_arg: str = "",
+    scan_path: str = "",
+    classification: str = "swe_marathon_codex_goal_harness_treatment",
+) -> str:
+    """Build a public-safe Goal Harness access packet for Harbor/SWE tasks."""
+
+    if mode != "codex_goal_harness" or packet_mode == "none":
+        return ""
+
+    cli_enabled = _coerce_bool(cli_bridge_enabled)
+    base = command_prefix
+    if registry_arg:
+        base += f" --registry {shlex.quote(registry_arg)}"
+    if runtime_root_arg:
+        base += f" --runtime-root {shlex.quote(runtime_root_arg)}"
+    base += " --format json"
+    goal_id_arg = shlex.quote(goal_id)
+    scan_path_arg = shlex.quote(scan_path) if scan_path else "<public-scan-path>"
+
+    lines = [
+        "Goal Harness Access Packet V0",
+        "benchmark_family: harbor",
+        f"mode: {mode}",
+        f"packet_mode: {packet_mode}",
+        f"goal_id: {goal_id}",
+        f"classification: {classification}",
+        f"goal_harness_cli_bridge_available: {str(cli_enabled).lower()}",
+        "runner_side_official_verifier_remains_authoritative: true",
+        "do_not_modify_tests: true",
+        "do_not_upload_or_submit_to_leaderboard: true",
+        "do_not_record_raw_task_text_logs_trajectories_or_credentials: true",
+        "use_goal_harness_for_planning_checkpoints_and_boundary_awareness_only: true",
+        "task_environment_commands_still_must_use_harbor_env_exec_bridge: true",
+    ]
+    if cli_enabled:
+        lines.extend(
+            [
+                f"goal_harness_command_check: {base} check --scan-path {scan_path_arg}",
+                f"goal_harness_command_status: {base} status --limit 5",
+                f"goal_harness_command_quota_should_run: {base} quota should-run --goal-id {goal_id_arg}",
+                f"goal_harness_command_history: {base} history --goal-id {goal_id_arg} --limit 5",
+                "before_long_actions_call_goal_harness_check_once: true",
+                "before_final_marker_review_goal_harness_status_or_history_once: true",
+                "goal_harness_cli_calls_are_observational_unless_an_explicit_write_command_is_provided: true",
+            ]
+        )
+    else:
+        lines.extend(
+            [
+                "goal_harness_interface_surface: prompt_packet_only",
+                "worker_receives_no_goal_harness_cli_templates: true",
+            ]
+        )
+    return "\n".join(lines)
 
 
 class HarborHostCodexGoalAgent(BaseAgent):
@@ -179,6 +251,17 @@ class HarborHostCodexGoalAgent(BaseAgent):
         reasoning_effort: str | None = "high",
         app_server_wait_for_completion: str | bool = False,
         app_server_response_timeout_sec: str | int | float = 30,
+        goal_harness_mode: str = "codex_goal_mode_baseline",
+        goal_harness_goal_id: str = "goal-harness-meta",
+        goal_harness_access_packet_mode: str = "none",
+        goal_harness_cli_bridge_enabled: str | bool = False,
+        goal_harness_command_prefix: str = "goal-harness",
+        goal_harness_registry_arg: str = "",
+        goal_harness_runtime_root_arg: str = "",
+        goal_harness_scan_path: str = "",
+        goal_harness_classification: str = (
+            "swe_marathon_codex_goal_harness_treatment"
+        ),
         startup_delay_sec: str | int | float = 5,
         poll_interval_sec: str | int | float = 5,
         **kwargs: Any,
@@ -191,12 +274,23 @@ class HarborHostCodexGoalAgent(BaseAgent):
         self.reasoning_effort = reasoning_effort
         self.app_server_wait_for_completion = _coerce_bool(app_server_wait_for_completion)
         self.app_server_response_timeout_sec = float(app_server_response_timeout_sec)
+        self.goal_harness_mode = goal_harness_mode
+        self.goal_harness_goal_id = goal_harness_goal_id
+        self.goal_harness_access_packet_mode = goal_harness_access_packet_mode
+        self.goal_harness_cli_bridge_enabled = _coerce_bool(
+            goal_harness_cli_bridge_enabled
+        )
+        self.goal_harness_command_prefix = goal_harness_command_prefix
+        self.goal_harness_registry_arg = goal_harness_registry_arg
+        self.goal_harness_runtime_root_arg = goal_harness_runtime_root_arg
+        self.goal_harness_scan_path = goal_harness_scan_path
+        self.goal_harness_classification = goal_harness_classification
         self.startup_delay_sec = float(startup_delay_sec)
         self.poll_interval_sec = float(poll_interval_sec)
         self._served_request_count = 0
 
     def version(self) -> str:
-        return "0.3.0"
+        return "0.4.0"
 
     async def setup(self, environment: BaseEnvironment) -> None:
         del environment
@@ -294,11 +388,23 @@ class HarborHostCodexGoalAgent(BaseAgent):
         tmux_name = f"gh_harbor_goal_{run_id}"
         self._write_bridge_script(bridge, request_dir)
 
+        goal_harness_access_packet = build_goal_harness_access_packet(
+            mode=self.goal_harness_mode,
+            packet_mode=self.goal_harness_access_packet_mode,
+            goal_id=self.goal_harness_goal_id,
+            cli_bridge_enabled=self.goal_harness_cli_bridge_enabled,
+            command_prefix=self.goal_harness_command_prefix,
+            registry_arg=self.goal_harness_registry_arg,
+            runtime_root_arg=self.goal_harness_runtime_root_arg,
+            scan_path=self.goal_harness_scan_path,
+            classification=self.goal_harness_classification,
+        )
         prompt = build_host_goal_prompt(
             instruction=instruction,
             bridge_command=bridge,
             marker_path=marker,
             task_workdir=self.task_workdir,
+            goal_harness_access_packet=goal_harness_access_packet,
         )
         prompt_path.write_text(prompt, encoding="utf-8")
 
@@ -356,6 +462,13 @@ class HarborHostCodexGoalAgent(BaseAgent):
                         "completion_marker_observed": marker.exists(),
                         "bridge_request_count": self._served_request_count,
                         "first_blocker": first_blocker,
+                        "goal_harness_mode": self.goal_harness_mode,
+                        "goal_harness_access_packet_injected": bool(
+                            goal_harness_access_packet
+                        ),
+                        "goal_harness_cli_bridge_enabled": (
+                            self.goal_harness_cli_bridge_enabled
+                        ),
                     }
                 )
                 (work_dir / "app_server_goal_turn.compact.json").write_text(
@@ -381,6 +494,10 @@ class HarborHostCodexGoalAgent(BaseAgent):
                             "bridge_request_count": self._served_request_count,
                             "goal_surface": "app_server",
                             "turn_completed_observed": bool(turn.turn_completed_observed),
+                            "goal_harness_mode": self.goal_harness_mode,
+                            "goal_harness_access_packet_injected": bool(
+                                goal_harness_access_packet
+                            ),
                         }
                         return
                     await asyncio.sleep(self.poll_interval_sec)
@@ -395,6 +512,10 @@ class HarborHostCodexGoalAgent(BaseAgent):
                 "goal_surface": "app_server",
                 "turn_completed_observed": bool(turn.turn_completed_observed),
                 "first_blocker": "harbor_host_codex_app_server_goal_timeout",
+                "goal_harness_mode": self.goal_harness_mode,
+                "goal_harness_access_packet_injected": bool(
+                    goal_harness_access_packet
+                ),
             }
             return
 
@@ -444,6 +565,10 @@ class HarborHostCodexGoalAgent(BaseAgent):
                     "goal_harness_agent": self.name(),
                     "completion_marker_observed": True,
                     "bridge_request_count": self._served_request_count,
+                    "goal_harness_mode": self.goal_harness_mode,
+                    "goal_harness_access_packet_injected": bool(
+                        goal_harness_access_packet
+                    ),
                 }
                 return
             capture_path.write_text(self._capture(tmux_name), encoding="utf-8")
@@ -455,4 +580,6 @@ class HarborHostCodexGoalAgent(BaseAgent):
             "completion_marker_observed": False,
             "bridge_request_count": self._served_request_count,
             "first_blocker": "harbor_host_codex_goal_timeout",
+            "goal_harness_mode": self.goal_harness_mode,
+            "goal_harness_access_packet_injected": bool(goal_harness_access_packet),
         }


### PR DESCRIPTION
## Summary
- add an optional Goal Harness access packet to the Harbor host Codex Goal agent for SWE-Marathon matched treatment runs
- keep baseline behavior unchanged unless goal_harness_mode=codex_goal_harness is passed
- document the reusable no-upload matched treatment command shape

## Validation
- python3 examples/harbor-host-codex-goal-agent-smoke.py
- python3 -m py_compile scripts/harbor_host_codex_goal_agent.py examples/harbor-host-codex-goal-agent-smoke.py
- git diff --check

No raw benchmark logs, trajectories, task text, verifier tails, credentials, or private runner paths are included.