### PR TITLE
fix: preserve claimed advancement lanes

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -191,6 +191,10 @@ for the bootstrap, session-attached automation, and headless fallback split.
 The [Codex CLI first-run rehearsal](../product/codex-cli-first-run-rehearsal.md)
 keeps the shortest user-facing route in one place: no-clone install,
 one-message TUI bootstrap, and proof-capture fixtures for later automation.
+For current product scheduling, the
+[Codex CLI TUI continuation priority](../product/codex-cli-tui-continuation-priority.md)
+keeps same-open-TUI continuation ahead of frontstage or showcase polish when
+both are runnable.
 
 Maintainers can validate the public fresh-clone path with:
 

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -51,6 +51,9 @@ runtime contract, benchmark route, or launch draft.
 - [Codex CLI proof-capture demo](codex-cli-proof-capture-demo.md): public-safe
   sample fixtures and acceptance decisions for rehearsing the visible proof
   path without running Codex or reading session material.
+- [Codex CLI TUI continuation priority](codex-cli-tui-continuation-priority.md):
+  the current scheduling guard that keeps same-open-TUI continuation ahead of
+  frontstage/showcase polish when both are runnable.
 - [Agent profile contract](agent-profile-contract.md): the registry-owned
   identity/scope contract for primary and side agents, including worktree and
   review handoff policy, while keeping todo ownership in `claimed_by` and future

--- a/docs/product/codex-cli-tui-continuation-priority.md
+++ b/docs/product/codex-cli-tui-continuation-priority.md
@@ -1,0 +1,74 @@
+# Codex CLI TUI Continuation Priority
+
+Status: scheduling contract for the next Codex CLI product slice.
+
+This note exists because a side-agent can drift toward visible, easy-to-ship
+frontstage work even when the user has just steered the product priority back
+to Codex CLI TUI adoption. Frontstage and showcase work are important support
+surfaces, but they must not outrank a runnable Codex CLI TUI continuation task.
+
+## Product Priority
+
+The near-term product promise is:
+
+1. a user opens Codex CLI TUI in a project repo;
+2. one pasted Goal Harness message starts the loop;
+3. Goal Harness can later steer or resume work through the same visible TUI
+   whenever Codex exposes a safe attach primitive;
+4. the user can keep watching, interrupt, steer, review, or take over.
+
+The first message is already documented. The next priority is the second half:
+prove a later visible steering turn after the first TUI bootstrap, or record the
+exact blocker that prevents it.
+
+## Scheduling Rule
+
+When Goal Harness chooses between runnable productization tasks:
+
+- Codex CLI TUI continuation wins over frontstage polish, showcase copy, or
+  dashboard route work when the continuation task is runnable and in scope.
+- Frontstage and showcase work can run first only when the TUI continuation is
+  concretely gated by missing proof, missing CLI capability, user decision, or
+  a higher-risk runtime boundary.
+- If Goal Harness selects frontstage work while a Codex CLI TUI continuation
+  task is runnable, the agent should treat that as a planning drift and run
+  self-repair before writing code.
+
+This is not a permanent global priority. It is a current product-stage rule:
+the most valuable external-developer path is fast Codex CLI adoption without
+losing the trusted TUI.
+
+## Acceptance Target
+
+The next useful Codex CLI TUI continuation slice should produce public-safe
+evidence for one of these outcomes:
+
+- `same_tui_continuation_proven`: a later Goal Harness steering prompt is added
+  to the same open Codex CLI TUI session, with visible proof and runtime idle
+  evidence.
+- `same_tui_continuation_blocked`: the current Codex CLI surface cannot safely
+  accept a later visible turn; the blocker names the missing primitive and the
+  fallback remains manual paste or explicit `codex exec`.
+- `same_tui_continuation_gated`: the task cannot run because it would require
+  raw transcripts, session files, private material, credentials, or production
+  actions.
+
+The evidence must stay transcript-free. It may use public-safe fixtures,
+boolean capability probes, visible-window metadata, and compact writeback
+records, but must not read raw Codex transcripts, session files, hidden TUI
+buffers, credentials, or private project state.
+
+## Agent Reminder
+
+If a heartbeat, quota summary, or claimed advancement lane recommends
+frontstage while recent user steering says Codex CLI TUI continuation should
+come first, the agent should:
+
+1. inspect the current runnable todo list;
+2. prefer the Codex CLI TUI continuation todo if it is runnable;
+3. write back the reason if it is not runnable;
+4. only then advance frontstage or showcase support work.
+
+This keeps fancy demo surfaces aligned with the more important adoption path:
+Goal Harness should be easy to start from inside the TUI that developers
+already trust.

--- a/examples/codex-cli-tui-continuation-priority-smoke.py
+++ b/examples/codex-cli-tui-continuation-priority-smoke.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Validate the Codex CLI TUI continuation scheduling contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DOC = REPO_ROOT / "docs" / "product" / "codex-cli-tui-continuation-priority.md"
+PRODUCT_README = REPO_ROOT / "docs" / "product" / "README.md"
+GETTING_STARTED = REPO_ROOT / "docs" / "guides" / "getting-started.md"
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def assert_contract_doc() -> None:
+    text = DOC.read_text(encoding="utf-8")
+    normalized = normalize(text)
+
+    must_have = (
+        "Codex CLI TUI Continuation Priority",
+        "Frontstage and showcase work are important support surfaces",
+        "must not outrank a runnable Codex CLI TUI continuation task",
+        "one pasted Goal Harness message starts the loop",
+        "later steer or resume work through the same visible TUI",
+        "Codex CLI TUI continuation wins over frontstage polish",
+        "planning drift and run self-repair",
+        "same_tui_continuation_proven",
+        "same_tui_continuation_blocked",
+        "same_tui_continuation_gated",
+        "visible proof and runtime idle evidence",
+        "must not read raw Codex transcripts, session files",
+    )
+    for phrase in must_have:
+        assert phrase in normalized, phrase
+
+    priority_index = normalized.index("Scheduling Rule")
+    frontstage_index = normalized.index("frontstage or showcase support work")
+    assert priority_index < frontstage_index, text
+
+
+def assert_indexes() -> None:
+    product = PRODUCT_README.read_text(encoding="utf-8")
+    getting_started = GETTING_STARTED.read_text(encoding="utf-8")
+
+    link = "codex-cli-tui-continuation-priority.md"
+    assert link in product, product
+    assert f"../product/{link}" in getting_started, getting_started
+    assert "same-open-TUI continuation ahead of" in product, product
+    assert "frontstage or showcase polish" in getting_started, getting_started
+
+
+def main() -> int:
+    assert_contract_doc()
+    assert_indexes()
+    print("codex-cli-tui-continuation-priority-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/todo-first-open-summary-smoke.py
+++ b/examples/todo-first-open-summary-smoke.py
@@ -190,6 +190,7 @@ def assert_blocked_priority_fallback_visible() -> None:
     decision = build_quota_should_run(
         build_blocked_priority_fallback_status_payload(),
         goal_id=GOAL_ID,
+        agent_id="codex-main-control",
     )
     assert decision["should_run"] is True, decision
     fallback = decision["blocked_priority_fallback"]
@@ -435,6 +436,107 @@ def assert_claimed_markdown_todos_survive_visibility_lanes() -> None:
     assert summary["current_agent_claimed_monitor_count"] == 1, summary
 
 
+def assert_claimed_advancement_lanes_preserve_claimants() -> None:
+    primary_claimed_lines = "\n".join(
+        (
+            f"- [ ] [P1] Primary claimed advancement item {index}.\n"
+            f"  <!-- goal-harness:todo todo_id=todo_primary_{index} status=open "
+            "task_class=advancement_task action_kind=primary_backlog "
+            "claimed_by=codex-main-control -->"
+        )
+        for index in range(1, 21)
+    )
+    stale_side_lines = "\n".join(
+        (
+            f"- [ ] [P1] Stale side claimed advancement item {index}.\n"
+            f"  <!-- goal-harness:todo todo_id=todo_side_stale_{index} status=open "
+            "task_class=advancement_task action_kind=frontstage_stale_backlog "
+            "claimed_by=codex-side-bypass -->"
+        )
+        for index in range(1, 6)
+    )
+    state_text = (
+        "## Agent Todo\n\n"
+        f"{primary_claimed_lines}\n"
+        f"{stale_side_lines}\n"
+        "- [ ] [P0] Side claimed TUI continuation item.\n"
+        "  <!-- goal-harness:todo todo_id=todo_side_tui status=open "
+        "task_class=advancement_task action_kind=codex_cli_tui_continuation "
+        "claimed_by=codex-side-bypass -->\n"
+    )
+    agent_todos = parse_active_state_todos(state_text)["agent_todos"]
+    assert agent_todos["claimed_advancement_open_count"] == 26, agent_todos
+    assert agent_todos["first_open_items"][0]["todo_id"] == "todo_side_tui", agent_todos
+    assert "todo_side_tui" in {
+        item["todo_id"] for item in agent_todos["claimed_advancement_open_items"]
+    }, agent_todos
+
+    asset_summary = project_asset_todo_summary(agent_todos, role="agent")
+    assert asset_summary is not None, agent_todos
+    status_payload = {
+        "ok": True,
+        "attention_queue": {
+            "items": [
+                {
+                    "goal_id": GOAL_ID,
+                    "status": "eligible_with_many_claimed_advancement_items",
+                    "waiting_on": "codex",
+                    "severity": "action",
+                    "source": "latest_run",
+                    "recommended_action": "Use claimed advancement lanes without losing side agents.",
+                    "coordination": {
+                        "primary_agent": "codex-main-control",
+                        "registered_agents": ["codex-main-control", "codex-side-bypass"],
+                    },
+                    "quota": {
+                        "compute": 1.0,
+                        "slot_minutes": 1,
+                        "allowed_slots": 1440,
+                        "spent_slots": 0,
+                        "state": "eligible",
+                        "reason": "eligible fixture",
+                    },
+                    "project_asset": {
+                        "owner": "codex",
+                        "next_action": "Use claimed advancement lanes without losing side agents.",
+                        "stop_condition": "stop on fixture boundary",
+                        "agent_todos": asset_summary,
+                    },
+                    "agent_todos": agent_todos,
+                }
+            ]
+        },
+        "run_history": {
+            "goals": [
+                {
+                    "id": GOAL_ID,
+                    "registry_member": True,
+                    "status": "active",
+                    "coordination": {
+                        "primary_agent": "codex-main-control",
+                        "registered_agents": ["codex-main-control", "codex-side-bypass"],
+                    },
+                    "quota": {"compute": 1.0, "window_hours": 24},
+                    "latest_runs": [],
+                }
+            ]
+        },
+    }
+    decision = build_quota_should_run(
+        status_payload,
+        goal_id=GOAL_ID,
+        agent_id="codex-side-bypass",
+    )
+    summary = decision["agent_todo_summary"]
+    current_agent_advancement_ids = [
+        item["todo_id"] for item in summary["current_agent_claimed_advancement_items"]
+    ]
+    assert current_agent_advancement_ids[0] == "todo_side_tui", summary
+    assert "todo_side_tui" in current_agent_advancement_ids, summary
+    assert summary["first_executable_items"][0]["todo_id"] == "todo_side_tui", summary
+    assert summary["current_agent_claimed_advancement_count"] == 6, summary
+
+
 def main() -> int:
     agent_todos = build_truncated_todo_group()
     parsed_agent_todos = parse_multiline_deep_open_todo()
@@ -539,6 +641,7 @@ def main() -> int:
     assert_blocked_priority_fallback_visible()
     assert_claimed_frontstage_lanes_visible()
     assert_claimed_markdown_todos_survive_visibility_lanes()
+    assert_claimed_advancement_lanes_preserve_claimants()
     print("todo-first-open-summary-smoke ok")
     return 0
 

--- a/goal_harness/quota.py
+++ b/goal_harness/quota.py
@@ -1142,6 +1142,40 @@ def _todo_projection_sort_key(item: dict[str, Any]) -> tuple[int, int]:
     return (_todo_priority_rank(item), _todo_index_rank(item))
 
 
+def _claimed_visibility_items(items: list[dict[str, Any]], *, limit: int) -> list[dict[str, Any]]:
+    if limit <= 0 or len(items) <= limit:
+        return items[:limit]
+    claim_order: list[str] = []
+    buckets: dict[str, list[dict[str, Any]]] = {}
+    for item in items:
+        claimed_by = normalize_todo_claimed_by(item.get("claimed_by"))
+        if not claimed_by:
+            continue
+        if claimed_by not in buckets:
+            buckets[claimed_by] = []
+            claim_order.append(claimed_by)
+        buckets[claimed_by].append(item)
+    if not buckets:
+        return items[:limit]
+
+    selected: list[dict[str, Any]] = []
+    round_index = 0
+    while len(selected) < limit:
+        added = False
+        for claimed_by in claim_order:
+            bucket = buckets[claimed_by]
+            if round_index >= len(bucket):
+                continue
+            selected.append(bucket[round_index])
+            added = True
+            if len(selected) >= limit:
+                break
+        if not added:
+            break
+        round_index += 1
+    return selected
+
+
 def _side_agent_claim_scoped_open_items(
     open_items: list[dict[str, Any]],
     *,
@@ -1213,13 +1247,22 @@ def _todo_summary_visibility_lanes(
 
     lanes: dict[str, Any] = {
         "unclaimed_priority_open_items": compact_items(unclaimed_items),
-        "claimed_open_items": compact_items(claimed_items, limit=TODO_VISIBILITY_LANE_LIMIT),
+        "claimed_open_items": compact_items(
+            _claimed_visibility_items(claimed_items, limit=TODO_VISIBILITY_LANE_LIMIT),
+            limit=TODO_VISIBILITY_LANE_LIMIT,
+        ),
         "claimed_advancement_open_items": compact_items(
-            claimed_advancement_items,
+            _claimed_visibility_items(
+                claimed_advancement_items,
+                limit=TODO_VISIBILITY_LANE_LIMIT,
+            ),
             limit=TODO_VISIBILITY_LANE_LIMIT,
         ),
         "claimed_monitor_open_items": compact_items(
-            claimed_monitor_items,
+            _claimed_visibility_items(
+                claimed_monitor_items,
+                limit=TODO_VISIBILITY_LANE_LIMIT,
+            ),
             limit=TODO_VISIBILITY_LANE_LIMIT,
         ),
     }

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -3807,6 +3807,40 @@ def todo_projection_sort_key(item: dict[str, Any]) -> tuple[int, int]:
     )
 
 
+def claimed_visibility_items(items: list[dict[str, Any]], *, limit: int) -> list[dict[str, Any]]:
+    if limit <= 0 or len(items) <= limit:
+        return items[:limit]
+    claim_order: list[str] = []
+    buckets: dict[str, list[dict[str, Any]]] = {}
+    for item in items:
+        claimed_by = normalize_todo_claimed_by(item.get("claimed_by"))
+        if not claimed_by:
+            continue
+        if claimed_by not in buckets:
+            buckets[claimed_by] = []
+            claim_order.append(claimed_by)
+        buckets[claimed_by].append(item)
+    if not buckets:
+        return items[:limit]
+
+    selected: list[dict[str, Any]] = []
+    round_index = 0
+    while len(selected) < limit:
+        added = False
+        for claimed_by in claim_order:
+            bucket = buckets[claimed_by]
+            if round_index >= len(bucket):
+                continue
+            selected.append(bucket[round_index])
+            added = True
+            if len(selected) >= limit:
+                break
+        if not added:
+            break
+        round_index += 1
+    return selected
+
+
 def compact_todo_group(
     items: list[dict[str, Any]],
     *,
@@ -3872,15 +3906,24 @@ def compact_todo_group(
         ],
         "claimed_open_items": [
             compact_todo_item(item)
-            for item in claimed_open_items[:MAX_TODO_VISIBILITY_LANE_ITEMS]
+            for item in claimed_visibility_items(
+                claimed_open_items,
+                limit=MAX_TODO_VISIBILITY_LANE_ITEMS,
+            )
         ],
         "claimed_advancement_open_items": [
             compact_todo_item(item)
-            for item in claimed_advancement_items[:MAX_TODO_VISIBILITY_LANE_ITEMS]
+            for item in claimed_visibility_items(
+                claimed_advancement_items,
+                limit=MAX_TODO_VISIBILITY_LANE_ITEMS,
+            )
         ],
         "claimed_monitor_open_items": [
             compact_todo_item(item)
-            for item in claimed_monitor_items[:MAX_TODO_VISIBILITY_LANE_ITEMS]
+            for item in claimed_visibility_items(
+                claimed_monitor_items,
+                limit=MAX_TODO_VISIBILITY_LANE_ITEMS,
+            )
         ],
         "backlog_items": [
             compact_todo_item(item)


### PR DESCRIPTION
## Summary
- preserve claimed todo visibility with claimant-balanced lanes so side-agent advancement items are not hidden behind another claimant's long queue
- add a Codex CLI TUI continuation priority note and smoke
- add regression coverage for many claimed advancement items plus side-agent routing

## Validation
- python3 examples/todo-first-open-summary-smoke.py
- python3 examples/codex-cli-tui-continuation-priority-smoke.py
- python3 examples/codex-cli-first-run-rehearsal-smoke.py
- python3 examples/docs-governance-smoke.py
- python3 -m py_compile goal_harness/status.py goal_harness/quota.py examples/todo-first-open-summary-smoke.py examples/codex-cli-tui-continuation-priority-smoke.py
- git diff --check
- goal-harness check