### PR TITLE
fix: weight claimed advancement lanes

### DIFF
--- a/docs/interaction-pattern-catalog.md
+++ b/docs/interaction-pattern-catalog.md
@@ -1184,17 +1184,33 @@ inflating every heartbeat/quota payload. Monitor lanes remain visibility
 context unless they record a material transition or blocker; they should not
 steal the advancement slot simply because they are claimed.
 
+When a claimed visibility lane has more items than the lane cap, truncation
+should be claimant-balanced rather than raw top-N. First sort claimed items by
+priority and source position, then group them by `claimed_by`, take a fair
+per-claimant slice within the cap, and fill any remaining slots from the
+priority-ordered remainder. The goal is not strict round-robin display order;
+it is to keep one agent's long queue from hiding another agent's claimed work.
+
+Agent-scoped quota then applies focus ordering after visibility balancing:
+current-agent claimed items first, unclaimed items second, and other-agent
+claimed items last with lower weight. Other-agent claims remain visible and may
+be inspected when nothing better is available, but they should not crowd out
+the current agent's own claimed advancement or genuinely unclaimed work.
+`claimed_by` remains a soft ownership signal, not a lock, lease, capability
+grant, or gate bypass.
+
 **Visual Model**
 
 ```mermaid
 flowchart TD
   T["parsed todo set"] --> S["scheduler lanes: first/open/executable candidates"]
-  T --> V["visibility lanes: claimed, unclaimed, monitor"]
+  T --> B["claimed lane claimant-balanced truncation"]
+  B --> V["visibility lanes: claimed, unclaimed, monitor"]
   S --> Q["quota/capability guard chooses runnable candidate set"]
   Q --> A["agent steering audit chooses actual todo"]
   V --> F["dashboard/frontstage/review packet shows ownership"]
   V --> C{"agent identity present?"}
-  C -->|"yes"| M["current-agent claimed advancement + monitor lanes"]
+  C -->|"yes"| M["current-agent claimed > unclaimed > other-agent claimed"]
   C -->|"no"| G["global claimed/unclaimed ownership view"]
   F --> H["human sees who owns what without changing scheduler result"]
 ```

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -840,19 +840,29 @@ Item fields:
   counts to indicate when more claimed work exists than is expanded in the
   current payload, and richer frontstage views should use a future
   paged/filtered projection instead of forcing larger heartbeat payloads.
+  When claimed lanes exceed the cap, producers should avoid raw top-N
+  truncation. Sort by priority and source position, group by `claimed_by`, take
+  a fair per-claimant slice, then fill remaining slots from the sorted
+  remainder. Agent-scoped projections should then order focus as
+  current-agent claimed items, unclaimed items, and lower-weight other-agent
+  claimed items. Other-agent claims are visibility context and last-resort
+  candidates; they are not a hard lock, but they also should not outrank the
+  current agent's own claimed work or unclaimed work.
   Optional future fields such as `created_at`, lease TTLs, dependencies, or
   evidence links should extend this item shape rather than inventing another
   todo surface.
 - Agent-scoped quota payloads may include
   `agent_todo_summary.claim_scope` with
   `schema_version=side_agent_claim_scope_v0`. For a side agent, the quota guard
-  should select current-agent claimed todos before unclaimed todos and keep
-  primary/other-agent claimed todos as `blocked_claimed_items` context. This is
-  claim-aware routing, not a hard lease: the primary agent still sees the whole
-  backlog, and a side agent still uses its automation/handoff scope to decide
-  whether an unclaimed todo is appropriate. A current-agent claimed todo may be
-  selected even when the active state's global `Next Action` names the primary
-  lane; that is not a state projection mismatch.
+  should select current-agent claimed todos before unclaimed todos, then expose
+  primary/other-agent claimed todos as lower-weight candidates. Compatibility
+  payloads may still include `blocked_claimed_items`, but new consumers should
+  prefer `other_agent_claimed_items` and `other_agent_claimed_open_count`. This
+  is claim-aware routing, not a hard lease: the primary agent still sees the
+  whole backlog, and a side agent still uses its automation/handoff scope to
+  decide whether an unclaimed or other-agent claimed todo is appropriate. A
+  current-agent claimed todo may be selected even when the active state's global
+  `Next Action` names the primary lane; that is not a state projection mismatch.
 - `dependency_blockers`: optional compact summary of unfinished user todos from
   other current attention-queue goals. This lets dashboards and heartbeat
   dispatchers show sibling/project dependency gates separately from the current

--- a/examples/todo-first-open-summary-smoke.py
+++ b/examples/todo-first-open-summary-smoke.py
@@ -467,9 +467,12 @@ def assert_claimed_advancement_lanes_preserve_claimants() -> None:
     agent_todos = parse_active_state_todos(state_text)["agent_todos"]
     assert agent_todos["claimed_advancement_open_count"] == 26, agent_todos
     assert agent_todos["first_open_items"][0]["todo_id"] == "todo_side_tui", agent_todos
-    assert "todo_side_tui" in {
+    claimed_advancement_ids = [
         item["todo_id"] for item in agent_todos["claimed_advancement_open_items"]
-    }, agent_todos
+    ]
+    assert "todo_side_tui" in claimed_advancement_ids, agent_todos
+    assert "todo_side_stale_5" in claimed_advancement_ids, agent_todos
+    assert "todo_primary_20" not in claimed_advancement_ids, agent_todos
 
     asset_summary = project_asset_todo_summary(agent_todos, role="agent")
     assert asset_summary is not None, agent_todos
@@ -534,6 +537,12 @@ def assert_claimed_advancement_lanes_preserve_claimants() -> None:
     assert current_agent_advancement_ids[0] == "todo_side_tui", summary
     assert "todo_side_tui" in current_agent_advancement_ids, summary
     assert summary["first_executable_items"][0]["todo_id"] == "todo_side_tui", summary
+    assert summary["claim_scope"]["selection_order"] == (
+        "current_agent_claimed_then_unclaimed_then_other_agent_claimed_low_weight"
+    ), summary
+    assert summary["claim_scope"]["other_agent_claimed_open_count"] == 12, summary
+    assert summary["claim_scope"]["other_agent_claimed_items"][0]["todo_id"] == "todo_primary_1", summary
+    assert summary["claim_scope"]["blocked_claimed_items"][0]["todo_id"] == "todo_primary_1", summary
     assert summary["current_agent_claimed_advancement_count"] == 6, summary
 
 

--- a/goal_harness/quota.py
+++ b/goal_harness/quota.py
@@ -1158,22 +1158,33 @@ def _claimed_visibility_items(items: list[dict[str, Any]], *, limit: int) -> lis
     if not buckets:
         return items[:limit]
 
+    original_index = {id(item): index for index, item in enumerate(items)}
+    per_claimant_cap = max(1, limit // len(buckets))
     selected: list[dict[str, Any]] = []
-    round_index = 0
-    while len(selected) < limit:
-        added = False
-        for claimed_by in claim_order:
-            bucket = buckets[claimed_by]
-            if round_index >= len(bucket):
-                continue
-            selected.append(bucket[round_index])
-            added = True
+    selected_ids: set[int] = set()
+    for claimed_by in claim_order:
+        taken = 0
+        for item in buckets[claimed_by]:
+            if taken >= per_claimant_cap:
+                break
             if len(selected) >= limit:
                 break
-        if not added:
+            selected.append(item)
+            selected_ids.add(id(item))
+            taken += 1
+        if len(selected) >= limit:
             break
-        round_index += 1
-    return selected
+
+    if len(selected) < limit:
+        for item in items:
+            if id(item) in selected_ids:
+                continue
+            selected.append(item)
+            selected_ids.add(id(item))
+            if len(selected) >= limit:
+                break
+
+    return sorted(selected, key=lambda item: original_index.get(id(item), 999999))[:limit]
 
 
 def _side_agent_claim_scoped_open_items(
@@ -1197,23 +1208,29 @@ def _side_agent_claim_scoped_open_items(
 
     current_agent_items = [item for item in open_items if claim_bucket(item) == 0]
     unclaimed_items = [item for item in open_items if claim_bucket(item) == 1]
-    blocked_claimed_items = [item for item in open_items if claim_bucket(item) == 2]
+    other_agent_claimed_items = [item for item in open_items if claim_bucket(item) == 2]
     selectable_items = sorted(
-        [*current_agent_items, *unclaimed_items],
+        [*current_agent_items, *unclaimed_items, *other_agent_claimed_items],
         key=lambda item: (claim_bucket(item), *_todo_projection_sort_key(item)),
     )
     claim_scope = {
         "schema_version": SIDE_AGENT_CLAIM_SCOPE_SCHEMA_VERSION,
         "agent_id": agent_id,
         "primary_agent": normalize_todo_claimed_by(agent_identity.get("primary_agent")),
-        "selection_order": "current_agent_claimed_then_unclaimed",
+        "selection_order": "current_agent_claimed_then_unclaimed_then_other_agent_claimed_low_weight",
         "selectable_open_count": len(selectable_items),
         "current_agent_claimed_open_count": len(current_agent_items),
         "unclaimed_open_count": len(unclaimed_items),
-        "blocked_claimed_open_count": len(blocked_claimed_items),
+        "other_agent_claimed_open_count": len(other_agent_claimed_items),
+        "other_agent_claimed_weight": "lower_than_current_claimed_and_unclaimed",
+        "other_agent_claimed_items": [
+            _compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
+            for item in _claimed_visibility_items(other_agent_claimed_items, limit=3)
+        ],
+        "blocked_claimed_open_count": len(other_agent_claimed_items),
         "blocked_claimed_items": [
             _compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
-            for item in blocked_claimed_items[:3]
+            for item in _claimed_visibility_items(other_agent_claimed_items, limit=3)
         ],
     }
     return selectable_items, claim_scope

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -3823,22 +3823,33 @@ def claimed_visibility_items(items: list[dict[str, Any]], *, limit: int) -> list
     if not buckets:
         return items[:limit]
 
+    original_index = {id(item): index for index, item in enumerate(items)}
+    per_claimant_cap = max(1, limit // len(buckets))
     selected: list[dict[str, Any]] = []
-    round_index = 0
-    while len(selected) < limit:
-        added = False
-        for claimed_by in claim_order:
-            bucket = buckets[claimed_by]
-            if round_index >= len(bucket):
-                continue
-            selected.append(bucket[round_index])
-            added = True
+    selected_ids: set[int] = set()
+    for claimed_by in claim_order:
+        taken = 0
+        for item in buckets[claimed_by]:
+            if taken >= per_claimant_cap:
+                break
             if len(selected) >= limit:
                 break
-        if not added:
+            selected.append(item)
+            selected_ids.add(id(item))
+            taken += 1
+        if len(selected) >= limit:
             break
-        round_index += 1
-    return selected
+
+    if len(selected) < limit:
+        for item in items:
+            if id(item) in selected_ids:
+                continue
+            selected.append(item)
+            selected_ids.add(id(item))
+            if len(selected) >= limit:
+                break
+
+    return sorted(selected, key=lambda item: original_index.get(id(item), 999999))[:limit]
 
 
 def compact_todo_group(


### PR DESCRIPTION
## Summary\n- replace pure claimed-lane round-robin behavior with claimant-balanced truncation\n- expose lower-weight other-agent claimed items after current-agent claimed and unclaimed work\n- document the claimed visibility weighting pattern in the status contract and IP catalog\n\n## Validation\n- python3 examples/todo-first-open-summary-smoke.py\n- python3 examples/side-agent-workspace-guard-smoke.py\n- python3 examples/docs-governance-smoke.py\n- python3 examples/interaction-pattern-catalog-smoke.py\n- python3 -m py_compile goal_harness/status.py goal_harness/quota.py examples/todo-first-open-summary-smoke.py examples/side-agent-workspace-guard-smoke.py\n- goal-harness check\n- git diff --check