### PR TITLE
fix: record scoped quota accounting identity

### DIFF
--- a/examples/quota-plan-smoke.py
+++ b/examples/quota-plan-smoke.py
@@ -18,6 +18,7 @@ if str(REPO_ROOT) not in sys.path:
 
 from goal_harness.quota import (  # noqa: E402
     build_quota_plan,
+    build_quota_monitor_poll_event,
     build_quota_should_run,
     build_quota_slot_spend_event,
     build_quota_slot_void_event,
@@ -31,6 +32,9 @@ from goal_harness.quota import (  # noqa: E402
     render_quota_should_run_markdown,
     void_quota_slot,
 )
+
+
+SCOPED_AGENT_ID = "codex-side-bypass"
 
 
 def goal(
@@ -263,7 +267,7 @@ def append_quota_slot_spend_fixture(
         )
 
 
-def write_cli_fixture(root: Path) -> tuple[Path, Path, Path]:
+def write_cli_fixture(root: Path, *, scoped_agents: bool = False) -> tuple[Path, Path, Path]:
     project = root / "project"
     runtime = root / "runtime"
     registry_path = project / ".goal-harness" / "registry.json"
@@ -291,29 +295,33 @@ def write_cli_fixture(root: Path) -> tuple[Path, Path, Path]:
             f"- continue {goal_id}\n",
             encoding="utf-8",
         )
-        registry_goals.append(
-            {
-                "id": goal_id,
-                "domain": "quota-fixture",
-                "status": "active",
-                "repo": str(project),
-                "state_file": state_file,
-                "adapter": {
-                    "kind": "read_only_project_map_v0",
-                    "status": "connected-read-only",
-                },
-                "authority_sources": [],
-                "quota": {
-                    key: value
-                    for key, value in {
-                        "compute": compute,
-                        "window_hours": 24,
-                        "allowed_slots": allowed_slots,
-                    }.items()
-                    if value is not None
-                },
+        goal_record = {
+            "id": goal_id,
+            "domain": "quota-fixture",
+            "status": "active",
+            "repo": str(project),
+            "state_file": state_file,
+            "adapter": {
+                "kind": "read_only_project_map_v0",
+                "status": "connected-read-only",
+            },
+            "authority_sources": [],
+            "quota": {
+                key: value
+                for key, value in {
+                    "compute": compute,
+                    "window_hours": 24,
+                    "allowed_slots": allowed_slots,
+                }.items()
+                if value is not None
+            },
+        }
+        if scoped_agents:
+            goal_record["coordination"] = {
+                "registered_agents": ["codex-main-control", SCOPED_AGENT_ID],
+                "primary_agent": SCOPED_AGENT_ID,
             }
-        )
+        registry_goals.append(goal_record)
         runs_dir = runtime / "goals" / goal_id / "runs"
         runs_dir.mkdir(parents=True, exist_ok=True)
         json_path = runs_dir / "20260101T000000-run.json"
@@ -481,7 +489,7 @@ def run_cli_slot_preview(root: Path) -> tuple[dict, dict]:
 
 
 def run_cli_slot_spend_execute(root: Path) -> tuple[dict, dict, str, str]:
-    registry_path, runtime, project = write_cli_fixture(root)
+    registry_path, runtime, project = write_cli_fixture(root, scoped_agents=True)
     registry_before = registry_path.read_text(encoding="utf-8")
     base_args = [
         sys.executable,
@@ -506,6 +514,8 @@ def run_cli_slot_spend_execute(root: Path) -> tuple[dict, dict, str, str]:
             "--source",
             "heartbeat",
             "--execute",
+            "--agent-id",
+            SCOPED_AGENT_ID,
             "--scan-path",
             str(project),
         ],
@@ -520,6 +530,8 @@ def run_cli_slot_spend_execute(root: Path) -> tuple[dict, dict, str, str]:
             "should-run",
             "--goal-id",
             "near-limit-half",
+            "--agent-id",
+            SCOPED_AGENT_ID,
             "--scan-path",
             str(project),
         ],
@@ -537,7 +549,7 @@ def run_cli_slot_spend_execute(root: Path) -> tuple[dict, dict, str, str]:
 
 
 def run_cli_slot_void_execute(root: Path) -> tuple[dict, dict, dict, str, str]:
-    registry_path, runtime, project = write_cli_fixture(root)
+    registry_path, runtime, project = write_cli_fixture(root, scoped_agents=True)
     registry_before = registry_path.read_text(encoding="utf-8")
     base_args = [
         sys.executable,
@@ -562,6 +574,8 @@ def run_cli_slot_void_execute(root: Path) -> tuple[dict, dict, dict, str, str]:
             "--source",
             "heartbeat",
             "--execute",
+            "--agent-id",
+            SCOPED_AGENT_ID,
             "--scan-path",
             str(project),
         ],
@@ -584,6 +598,8 @@ def run_cli_slot_void_execute(root: Path) -> tuple[dict, dict, dict, str, str]:
             "--reason-summary",
             "duplicate heartbeat spend",
             "--execute",
+            "--agent-id",
+            SCOPED_AGENT_ID,
             "--scan-path",
             str(project),
         ],
@@ -598,6 +614,8 @@ def run_cli_slot_void_execute(root: Path) -> tuple[dict, dict, dict, str, str]:
             "should-run",
             "--goal-id",
             "near-limit-half",
+            "--agent-id",
+            SCOPED_AGENT_ID,
             "--scan-path",
             str(project),
         ],
@@ -1762,12 +1780,14 @@ def assert_slot_spend_execute(payload: dict, next_should_run: dict, registry_bef
     assert payload["appended"] is True, payload
     assert payload["registry_mutated"] is False, payload
     assert payload["classification"] == "quota_slot_spent", payload
+    assert payload["agent_id"] == SCOPED_AGENT_ID, payload
     assert payload["source"] == "heartbeat", payload
     assert registry_after == registry_before
     assert '"spent_slots"' not in registry_after
     assert json_path.exists(), payload
     assert index_path.exists(), payload
     assert quota_event["event_type"] == "quota_slot_spent", payload
+    assert quota_event["agent_id"] == SCOPED_AGENT_ID, payload
     assert quota_event["slots"] == 1, payload
     assert before["should_run"] is True, payload
     assert before["state"] == "eligible", payload
@@ -1779,12 +1799,14 @@ def assert_slot_spend_execute(payload: dict, next_should_run: dict, registry_bef
 
     record = json.loads(json_path.read_text(encoding="utf-8"))
     assert record["classification"] == "quota_slot_spent", record
+    assert record["agent_id"] == SCOPED_AGENT_ID, record
     assert record["quota_event"] == quota_event, record
     forbidden = {"human_reward", "operator_gate", "write_control", "private_evidence", "agent_command"}
     assert forbidden.isdisjoint(record), record
     assert forbidden.isdisjoint(record["quota_event"]), record
     index_lines = index_path.read_text(encoding="utf-8").splitlines()
     assert any('"classification": "quota_slot_spent"' in line for line in index_lines), index_lines
+    assert any(f'"agent_id": "{SCOPED_AGENT_ID}"' in line for line in index_lines), index_lines
 
     assert next_should_run["goal_id"] == "near-limit-half", next_should_run
     assert next_should_run["should_run"] is False, next_should_run
@@ -1811,11 +1833,13 @@ def assert_slot_void_execute(
     assert void_payload["appended"] is True, void_payload
     assert void_payload["registry_mutated"] is False, void_payload
     assert void_payload["classification"] == "quota_slot_voided", void_payload
+    assert void_payload["agent_id"] == SCOPED_AGENT_ID, void_payload
     assert void_payload["source"] == "heartbeat", void_payload
     assert registry_after == registry_before
     assert json_path.exists(), void_payload
     assert index_path.exists(), void_payload
     assert quota_event["event_type"] == "quota_slot_voided", void_payload
+    assert quota_event["agent_id"] == SCOPED_AGENT_ID, void_payload
     assert quota_event["slots"] == 1, void_payload
     assert quota_event["voided_run_generated_at"] == spend_payload["generated_at"], void_payload
     assert "duplicate heartbeat spend" in quota_event["reason_summary"], void_payload
@@ -1823,6 +1847,7 @@ def assert_slot_void_execute(
 
     record = json.loads(json_path.read_text(encoding="utf-8"))
     assert record["classification"] == "quota_slot_voided", record
+    assert record["agent_id"] == SCOPED_AGENT_ID, record
     assert record["quota_event"] == quota_event, record
     forbidden = {"human_reward", "operator_gate", "write_control", "private_evidence", "agent_command"}
     assert forbidden.isdisjoint(record), record
@@ -1830,6 +1855,7 @@ def assert_slot_void_execute(
     index_lines = index_path.read_text(encoding="utf-8").splitlines()
     assert any('"classification": "quota_slot_spent"' in line for line in index_lines), index_lines
     assert any('"classification": "quota_slot_voided"' in line for line in index_lines), index_lines
+    assert any(f'"agent_id": "{SCOPED_AGENT_ID}"' in line for line in index_lines), index_lines
 
     assert next_should_run["goal_id"] == "near-limit-half", next_should_run
     assert next_should_run["should_run"] is True, next_should_run
@@ -1888,6 +1914,33 @@ def assert_quota_void_event_net_ledger() -> None:
         assert after["void_event_count"] == 1, after
 
 
+def assert_monitor_poll_event_carries_agent_id() -> None:
+    event = build_quota_monitor_poll_event(
+        {
+            "goal_id": "scoped-monitor-goal",
+            "should_run": True,
+            "effective_action": "monitor_quiet_skip",
+            "recommended_action": "stay quiet until material transition",
+            "reason": "unchanged monitor target",
+            "heartbeat_recommendation": {
+                "recommended_mode": "monitor_quiet_until_material_transition",
+                "reason": "unchanged monitor target",
+            },
+            "agent_identity": {
+                "agent_id": SCOPED_AGENT_ID,
+                "registered": True,
+                "role": "side-agent",
+                "primary_agent": "codex-main-control",
+                "registered_agents": ["codex-main-control", SCOPED_AGENT_ID],
+            },
+        },
+        source="heartbeat",
+    )
+
+    assert event["agent_id"] == SCOPED_AGENT_ID, event
+    assert event["monitor_event"]["agent_id"] == SCOPED_AGENT_ID, event
+
+
 def main() -> int:
     assert_default_quota_is_duty_cycle()
     assert_rolling_window_ledger_expires_old_spends()
@@ -1914,6 +1967,7 @@ def main() -> int:
     assert_decision_freshness_warning_in_should_run()
     assert_safe_bypass_slot_preview(status_payload)
     assert_quota_void_event_net_ledger()
+    assert_monitor_poll_event_carries_agent_id()
     assert_slot_preview(build_quota_slot_preview(status_payload, goal_id="near-limit-half", slots=1))
     with tempfile.TemporaryDirectory(prefix="goal-harness-quota-plan-smoke-") as tmp:
         cli_plan, cli_markdown = run_cli_quota_plan(Path(tmp))

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -5944,7 +5944,11 @@ def main(argv: list[str] | None = None) -> int:
     quota_parser.add_argument("--goal-id", help="Goal id to check. Required for `quota should-run`, `quota monitor-poll`, `quota spend-slot`, and `quota void-slot`.")
     quota_parser.add_argument(
         "--agent-id",
-        help="Registered agent id for `quota should-run`; suppresses identity-upgrade warnings for current prompts.",
+        help=(
+            "Registered agent id for `quota should-run` and scoped quota accounting "
+            "commands; suppresses identity-upgrade warnings and records the identity "
+            "on appended monitor/spend/void events."
+        ),
     )
     quota_parser.add_argument(
         "--available-capability",
@@ -10505,6 +10509,7 @@ def main(argv: list[str] | None = None) -> int:
                     execute=bool(args.execute),
                     source=args.source,
                     reason_summary=args.reason_summary,
+                    agent_id=args.agent_id,
                 )
             elif args.quota_command == "spend-slot":
                 if not args.goal_id:
@@ -10534,6 +10539,7 @@ def main(argv: list[str] | None = None) -> int:
                     execute=bool(args.execute),
                     source=args.source,
                     reason_summary=args.reason_summary,
+                    agent_id=args.agent_id,
                 )
             else:
                 payload = build_quota_plan(status_payload, mode=args.quota_command)

--- a/goal_harness/quota.py
+++ b/goal_harness/quota.py
@@ -5298,6 +5298,15 @@ def _compact_quota_decision(decision: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _quota_decision_agent_id(decision: dict[str, Any]) -> str | None:
+    agent_identity = (
+        decision.get("agent_identity")
+        if isinstance(decision.get("agent_identity"), dict)
+        else {}
+    )
+    return normalize_todo_claimed_by(agent_identity.get("agent_id"))
+
+
 def _work_lane_reason_codes(work_lane_contract: dict[str, Any]) -> set[str]:
     reason_codes = work_lane_contract.get("reason_codes")
     if not isinstance(reason_codes, list):
@@ -5370,8 +5379,9 @@ def build_quota_monitor_poll_event(
             or before.get("reason")
             or "monitor-only poll had no material transition"
         )
+    safe_agent_id = _quota_decision_agent_id(before)
 
-    return {
+    record = {
         "generated_at": generated_at or _now_local(),
         "goal_id": before.get("goal_id"),
         "classification": QUOTA_MONITOR_POLL_CLASSIFICATION,
@@ -5390,6 +5400,10 @@ def build_quota_monitor_poll_event(
             "before": _compact_quota_decision(before),
         },
     }
+    if safe_agent_id:
+        record["agent_id"] = safe_agent_id
+        record["monitor_event"]["agent_id"] = safe_agent_id
+    return record
 
 
 def build_quota_slot_spend_event(
@@ -5405,6 +5419,7 @@ def build_quota_slot_spend_event(
         raise ValueError(f"quota slot spend source must be one of: {', '.join(sorted(VALID_SLOT_SPEND_SOURCES))}")
     before = preview.get("before") if isinstance(preview.get("before"), dict) else {}
     after = preview.get("after") if isinstance(preview.get("after"), dict) else {}
+    safe_agent_id = _quota_decision_agent_id(before)
     slots = max(1, _int_number(preview.get("slots"), default=1))
     before_compact = _compact_quota_decision(before)
     after_compact = _compact_quota_decision(after)
@@ -5451,7 +5466,7 @@ def build_quota_slot_spend_event(
             "capability bridge repair, or latest validated delivery-completion quota should-run decision"
         )
 
-    return {
+    record = {
         "generated_at": generated_at or _now_local(),
         "goal_id": preview.get("goal_id"),
         "classification": QUOTA_SLOT_SPENT_CLASSIFICATION,
@@ -5513,6 +5528,10 @@ def build_quota_slot_spend_event(
             "after": after_compact,
         },
     }
+    if safe_agent_id:
+        record["agent_id"] = safe_agent_id
+        record["quota_event"]["agent_id"] = safe_agent_id
+    return record
 
 
 def _load_goal_run_index_records(runtime_root: Path, goal_id: str) -> list[dict[str, Any]]:
@@ -5561,9 +5580,10 @@ def record_quota_monitor_poll(
     execute: bool = False,
     source: str = DEFAULT_SLOT_SPEND_SOURCE,
     reason_summary: str | None = None,
+    agent_id: str | None = None,
 ) -> dict[str, Any]:
     safe_goal_id = _validate_goal_id_path_segment(str(goal_id or ""))
-    before = build_quota_should_run(status_payload, goal_id=safe_goal_id)
+    before = build_quota_should_run(status_payload, goal_id=safe_goal_id, agent_id=agent_id)
     if before.get("effective_action") != "monitor_quiet_skip" and not _allows_no_spend_external_monitor_poll(before):
         return {
             "ok": False,
@@ -5605,6 +5625,8 @@ def record_quota_monitor_poll(
         "json_path": str(json_path),
         "markdown_path": str(markdown_path),
     }
+    if record.get("agent_id"):
+        index_record["agent_id"] = record["agent_id"]
 
     after_status = deepcopy(status_payload)
     if execute:
@@ -5623,7 +5645,7 @@ def record_quota_monitor_poll(
         recent_runs = run_history.get("recent_runs") if isinstance(run_history.get("recent_runs"), list) else []
         run_history["recent_runs"] = [index_record, *recent_runs]
 
-    after = build_quota_should_run(after_status, goal_id=safe_goal_id)
+    after = build_quota_should_run(after_status, goal_id=safe_goal_id, agent_id=agent_id)
     return {
         "ok": True,
         "mode": "monitor-poll",
@@ -5634,6 +5656,7 @@ def record_quota_monitor_poll(
         "source": record["monitor_event"]["source"],
         "classification": QUOTA_MONITOR_POLL_CLASSIFICATION,
         "generated_at": generated_at,
+        "agent_id": record.get("agent_id"),
         "monitor_event": record["monitor_event"],
         "health_check": record["health_check"],
         "delivery_outcome": record["delivery_outcome"],
@@ -5674,6 +5697,7 @@ def build_quota_slot_void_preview(
     *,
     goal_id: str,
     voided_run_generated_at: str,
+    agent_id: str | None = None,
 ) -> dict[str, Any]:
     safe_goal_id = _validate_goal_id_path_segment(str(goal_id or ""))
     safe_voided_at = str(voided_run_generated_at or "").strip()
@@ -5706,7 +5730,7 @@ def build_quota_slot_void_preview(
         }
     target_run, target_event = target
     slots = max(1, _int_number(target_event.get("slots"), default=1))
-    before = build_quota_should_run(status_payload, goal_id=safe_goal_id)
+    before = build_quota_should_run(status_payload, goal_id=safe_goal_id, agent_id=agent_id)
     before_quota = before.get("quota") if isinstance(before.get("quota"), dict) else {}
     after = deepcopy(before)
     after_quota = deepcopy(before_quota)
@@ -5754,7 +5778,8 @@ def build_quota_slot_void_event(
     safe_reason = str(reason_summary or "").strip() or "void duplicate or invalid quota slot spend event"
     before = preview.get("before") if isinstance(preview.get("before"), dict) else {}
     after = preview.get("after") if isinstance(preview.get("after"), dict) else {}
-    return {
+    safe_agent_id = _quota_decision_agent_id(before)
+    record = {
         "generated_at": generated_at or _now_local(),
         "goal_id": preview.get("goal_id"),
         "classification": QUOTA_SLOT_VOIDED_CLASSIFICATION,
@@ -5771,6 +5796,10 @@ def build_quota_slot_void_event(
             "after": _compact_quota_decision(after) if after else {},
         },
     }
+    if safe_agent_id:
+        record["agent_id"] = safe_agent_id
+        record["quota_event"]["agent_id"] = safe_agent_id
+    return record
 
 
 def void_quota_slot(
@@ -5781,12 +5810,14 @@ def void_quota_slot(
     execute: bool = False,
     source: str = DEFAULT_SLOT_SPEND_SOURCE,
     reason_summary: str | None = None,
+    agent_id: str | None = None,
 ) -> dict[str, Any]:
     safe_goal_id = _validate_goal_id_path_segment(str(goal_id or ""))
     preview = build_quota_slot_void_preview(
         status_payload,
         goal_id=safe_goal_id,
         voided_run_generated_at=voided_run_generated_at,
+        agent_id=agent_id,
     )
     if not preview.get("ok"):
         return preview
@@ -5815,6 +5846,8 @@ def void_quota_slot(
         "json_path": str(json_path),
         "markdown_path": str(markdown_path),
     }
+    if record.get("agent_id"):
+        index_record["agent_id"] = record["agent_id"]
     payload = {
         **preview,
         "dry_run": not execute,
@@ -5823,6 +5856,7 @@ def void_quota_slot(
         "source": record["quota_event"]["source"],
         "classification": QUOTA_SLOT_VOIDED_CLASSIFICATION,
         "generated_at": generated_at,
+        "agent_id": record.get("agent_id"),
         "quota_event": record["quota_event"],
         "json_path": str(json_path),
         "markdown_path": str(markdown_path),
@@ -5882,6 +5916,8 @@ def spend_quota_slot(
         "json_path": str(json_path),
         "markdown_path": str(markdown_path),
     }
+    if record.get("agent_id"):
+        index_record["agent_id"] = record["agent_id"]
 
     payload = {
         **preview,
@@ -5891,6 +5927,7 @@ def spend_quota_slot(
         "source": record["quota_event"]["source"],
         "classification": QUOTA_SLOT_SPENT_CLASSIFICATION,
         "generated_at": generated_at,
+        "agent_id": record.get("agent_id"),
         "quota_event": record["quota_event"],
         "json_path": str(json_path),
         "markdown_path": str(markdown_path),
@@ -6016,6 +6053,7 @@ def render_quota_slot_preview_markdown(payload: dict[str, Any]) -> str:
         f"- dry_run: `{payload.get('dry_run')}`",
         f"- goal_id: `{payload.get('goal_id')}`",
         f"- classification: `{payload.get('classification') or QUOTA_SLOT_SPENT_CLASSIFICATION}`",
+        f"- agent_id: `{payload.get('agent_id') or ''}`",
         f"- slots: `{payload.get('slots')}`",
         f"- appended: `{payload.get('appended')}`",
         f"- registry_mutated: `{payload.get('registry_mutated')}`",
@@ -6057,6 +6095,7 @@ def render_quota_monitor_poll_markdown(payload: dict[str, Any]) -> str:
         "",
         f"- goal_id: `{payload.get('goal_id')}`",
         f"- classification: `{payload.get('classification')}`",
+        f"- agent_id: `{payload.get('agent_id') or event.get('agent_id') or ''}`",
         f"- source: `{event.get('source')}`",
         f"- effective_action: `{before.get('effective_action')}`",
         f"- should_run: `{before.get('should_run')}`",


### PR DESCRIPTION
## Summary
- carry registered agent identity from scoped quota decisions into monitor/spend/void accounting events
- persist agent_id in appended quota run JSON, index records, CLI payloads, and markdown previews
- cover scoped spend/void and monitor-poll identity propagation in quota-plan smoke

## Validation
- python3 -m py_compile goal_harness/quota.py goal_harness/cli.py examples/quota-plan-smoke.py
- python3 examples/quota-plan-smoke.py
- python3 examples/heartbeat-prompt-smoke.py
- python3 examples/project-prompt-smoke.py
- python3 examples/docs-governance-smoke.py
- python3 examples/interaction-pattern-catalog-smoke.py
- goal-harness check --scan-path goal_harness/quota.py --scan-path goal_harness/cli.py --scan-path examples/quota-plan-smoke.py
- git diff --check

Note: python3 examples/quota-contract-smoke.py currently fails on an existing README wording contract unrelated to this change.