### PR TITLE
fix: surface Codex CLI continuation outcome

### DIFF
--- a/docs/product/codex-cli-tui-loop.md
+++ b/docs/product/codex-cli-tui-loop.md
@@ -322,6 +322,17 @@ the idle detector passes. If either proof or idle evidence is missing, the
 packet returns a precise blocker and keeps the one-message TUI bootstrap as the
 primary path.
 
+The packet also emits a product-level `continuation_outcome` so schedulers and
+agents do not have to infer intent from low-level probe details:
+
+- `same_tui_continuation_proven`: same-TUI visible attach proof and runtime
+  idle evidence both passed.
+- `same_tui_continuation_blocked`: the current Codex CLI probe does not expose
+  a safe same-open-TUI attach/inject primitive. Manual TUI paste remains
+  primary; `codex exec` remains explicit opt-in fallback.
+- `same_tui_continuation_gated`: a same-TUI primitive is visible in help, but
+  public-safe proof or runtime-idle evidence is still missing.
+
 The first public-safe proof pilot is recorded in
 [Codex CLI Visible Attach Proof Pilot](codex-cli-visible-attach-proof-pilot.md):
 current `resume` / `remote-control` evidence is promising, but still blocked

--- a/docs/product/codex-cli-visible-attach-proof-pilot.md
+++ b/docs/product/codex-cli-visible-attach-proof-pilot.md
@@ -22,10 +22,16 @@ available help-only evidence does not prove a safe same-TUI attach primitive.
 The acceptance packet returns:
 
 - `decision`: `visible_session_proof_required`
+- `continuation_outcome`: `same_tui_continuation_blocked`
 - `accepted_for_same_tui_automation`: `False`
 - `accepted_for_visible_later_turn`: `False`
 - `driver_mode`: `visible_resume_or_remote_control_spike`
 - blocker: `visible_session_proof_missing`
+
+The important product distinction is that `resume` / `remote-control` may
+still become a visible continuation route, but they do not prove same-open-TUI
+injection. Until a safe same-TUI attach/inject primitive is proven, the machine
+outcome is blocked, not merely "unknown".
 
 ## Boundary
 

--- a/examples/codex-cli-visible-attach-acceptance-smoke.py
+++ b/examples/codex-cli-visible-attach-acceptance-smoke.py
@@ -165,7 +165,9 @@ def main() -> int:
     remote_without_proof = build(REMOTE_RESUME_HELP_FIXTURE)
     assert remote_without_proof["ok"] is True, remote_without_proof
     assert remote_without_proof["decision"] == "visible_session_proof_required", remote_without_proof
+    assert remote_without_proof["continuation_outcome"] == "same_tui_continuation_blocked", remote_without_proof
     assert remote_without_proof["accepted_for_same_tui_automation"] is False, remote_without_proof
+    assert remote_without_proof["fallback_contract"]["manual_tui_paste_remains_primary"] is True, remote_without_proof
     assert "visible_session_proof_missing" in remote_without_proof["blockers"], remote_without_proof
     assert_public_safe_boundary(remote_without_proof)
 
@@ -175,6 +177,7 @@ def main() -> int:
         idle={**PASSING_IDLE_FIXTURE, "observed_surface": "remote_control_visible_prompt"},
     )
     assert remote_spike["decision"] == "visible_surface_spike_passed_not_same_tui", remote_spike
+    assert remote_spike["continuation_outcome"] == "same_tui_continuation_blocked", remote_spike
     assert remote_spike["accepted_for_visible_later_turn"] is True, remote_spike
     assert remote_spike["accepted_for_same_tui_automation"] is False, remote_spike
     assert "same_tui_visible_attach_not_proven" in remote_spike["blockers"], remote_spike
@@ -186,7 +189,9 @@ def main() -> int:
         idle=PASSING_IDLE_FIXTURE,
     )
     assert same_tui_accepted["decision"] == "same_tui_visible_attach_accepted", same_tui_accepted
+    assert same_tui_accepted["continuation_outcome"] == "same_tui_continuation_proven", same_tui_accepted
     assert same_tui_accepted["accepted_for_same_tui_automation"] is True, same_tui_accepted
+    assert same_tui_accepted["fallback_contract"]["manual_tui_paste_remains_primary"] is False, same_tui_accepted
     assert same_tui_accepted["accepted_for_visible_later_turn"] is True, same_tui_accepted
     assert same_tui_accepted["blockers"] == [], same_tui_accepted
     assert_public_safe_boundary(same_tui_accepted)
@@ -196,12 +201,14 @@ def main() -> int:
         proof=proof_fixture("same_tui_visible_attach"),
     )
     assert missing_idle["decision"] == "runtime_idle_evidence_required", missing_idle
+    assert missing_idle["continuation_outcome"] == "same_tui_continuation_gated", missing_idle
     assert missing_idle["accepted_for_same_tui_automation"] is False, missing_idle
     assert "missing_runtime_idle_evidence" in missing_idle["blockers"], missing_idle
     assert_public_safe_boundary(missing_idle)
 
     fallback = build(FALLBACK_HELP_FIXTURE)
     assert fallback["decision"] == "explicit_headless_fallback_after_tui_bootstrap", fallback
+    assert fallback["continuation_outcome"] == "same_tui_continuation_blocked", fallback
     assert fallback["accepted_for_same_tui_automation"] is False, fallback
     assert fallback["accepted_for_visible_later_turn"] is False, fallback
     assert_public_safe_boundary(fallback)
@@ -235,6 +242,7 @@ def main() -> int:
             )
         )
         assert cli_json["decision"] == "same_tui_visible_attach_accepted", cli_json
+        assert cli_json["continuation_outcome"] == "same_tui_continuation_proven", cli_json
         assert cli_json["accepted_for_same_tui_automation"] is True, cli_json
 
         cli_markdown = run_cli(
@@ -254,6 +262,8 @@ def main() -> int:
         )
         assert "# Codex CLI Visible Attach Acceptance" in cli_markdown, cli_markdown
         assert "accepted_for_same_tui_automation: `True`" in cli_markdown, cli_markdown
+        assert "continuation_outcome: `same_tui_continuation_proven`" in cli_markdown, cli_markdown
+        assert "manual_tui_paste_remains_primary: `False`" in cli_markdown, cli_markdown
         assert "same_tui_visible_attach_accepted" in cli_markdown, cli_markdown
 
     print("codex-cli-visible-attach-acceptance-smoke ok")

--- a/goal_harness/codex_cli_probe.py
+++ b/goal_harness/codex_cli_probe.py
@@ -788,6 +788,13 @@ def build_codex_cli_visible_attach_acceptance(
     idle_approved = idle_detector.get("approved_for_visible_later_turn") is True
     observed_surface = str(proof.get("observed_surface") or "unknown")
     driver_mode = str(local_plan.get("driver_mode") or "tui_bootstrap_only")
+    capabilities = (
+        probe_payload.get("capabilities")
+        if isinstance(probe_payload.get("capabilities"), dict)
+        else {}
+    )
+    same_tui_injection_detected = bool(capabilities.get("same_tui_injection_detected"))
+    safe_injection_supported = bool(capabilities.get("safe_injection_supported"))
     same_tui_proof = proof_approved and observed_surface == "same_tui_visible_attach"
     accepted_same_tui = same_tui_proof and idle_approved
     visible_later_turn_candidate = proof_approved and idle_approved
@@ -842,6 +849,22 @@ def build_codex_cli_visible_attach_acceptance(
         blockers.append("codex_cli_attach_surface_not_exposed_by_probe")
         next_safe_step = "ask the user to start in Codex CLI TUI and paste the bootstrap message"
 
+    if accepted_same_tui:
+        continuation_outcome = "same_tui_continuation_proven"
+        continuation_reason = "same-TUI visible attach proof and runtime idle evidence passed"
+    elif not same_tui_injection_detected or not safe_injection_supported:
+        continuation_outcome = "same_tui_continuation_blocked"
+        continuation_reason = (
+            "current Codex CLI probe did not expose a safe same-open-TUI "
+            "attach/inject primitive"
+        )
+    else:
+        continuation_outcome = "same_tui_continuation_gated"
+        continuation_reason = (
+            "same-TUI primitive is visible in help, but public-safe proof and "
+            "runtime idle evidence are not both accepted"
+        )
+
     commands = (
         local_plan.get("commands")
         if isinstance(local_plan.get("commands"), dict)
@@ -856,6 +879,8 @@ def build_codex_cli_visible_attach_acceptance(
         "cli_bin": cli_bin,
         "codex_bin": codex_bin,
         "decision": decision,
+        "continuation_outcome": continuation_outcome,
+        "continuation_reason": continuation_reason,
         "acceptance_action": acceptance_action,
         "accepted_for_same_tui_automation": accepted_same_tui,
         "accepted_for_visible_later_turn": visible_later_turn_candidate,
@@ -870,6 +895,14 @@ def build_codex_cli_visible_attach_acceptance(
             "same_tui_surface_required_for_same_tui_acceptance": True,
             "fresh_quota_guard_required_before_execution": True,
             "explicit_headless_fallback_opt_in_required": True,
+        },
+        "fallback_contract": {
+            "manual_tui_paste_remains_primary": (
+                continuation_outcome != "same_tui_continuation_proven"
+            ),
+            "visible_resume_or_remote_control_requires_proof": True,
+            "headless_codex_exec_requires_explicit_opt_in": True,
+            "never_read_raw_transcripts_or_session_files": True,
         },
         "probe": {
             "schema_version": probe_payload.get("schema_version"),
@@ -3386,6 +3419,11 @@ def render_codex_cli_visible_attach_acceptance_markdown(payload: dict[str, Any])
         if isinstance(payload.get("runtime_idle_detector"), dict)
         else {}
     )
+    fallback = (
+        payload.get("fallback_contract")
+        if isinstance(payload.get("fallback_contract"), dict)
+        else {}
+    )
     blockers = payload.get("blockers") if isinstance(payload.get("blockers"), list) else []
     blocker_lines = "\n".join(f"- {blocker}" for blocker in blockers) if blockers else "- none"
     warnings = payload.get("warnings") if isinstance(payload.get("warnings"), list) else []
@@ -3393,6 +3431,8 @@ def render_codex_cli_visible_attach_acceptance_markdown(payload: dict[str, Any])
     return f"""# Codex CLI Visible Attach Acceptance
 
 - decision: `{payload.get("decision")}`
+- continuation_outcome: `{payload.get("continuation_outcome")}`
+- continuation_reason: {payload.get("continuation_reason")}
 - accepted_for_same_tui_automation: `{payload.get("accepted_for_same_tui_automation")}`
 - accepted_for_visible_later_turn: `{payload.get("accepted_for_visible_later_turn")}`
 - observed_surface: `{payload.get("observed_surface")}`
@@ -3411,6 +3451,13 @@ def render_codex_cli_visible_attach_acceptance_markdown(payload: dict[str, Any])
 ## Blockers
 
 {blocker_lines}
+
+## Fallback Contract
+
+- manual_tui_paste_remains_primary: `{fallback.get("manual_tui_paste_remains_primary")}`
+- visible_resume_or_remote_control_requires_proof: `{fallback.get("visible_resume_or_remote_control_requires_proof")}`
+- headless_codex_exec_requires_explicit_opt_in: `{fallback.get("headless_codex_exec_requires_explicit_opt_in")}`
+- never_read_raw_transcripts_or_session_files: `{fallback.get("never_read_raw_transcripts_or_session_files")}`
 
 ## Commands
 


### PR DESCRIPTION
## Summary
- add product-level continuation_outcome to the Codex CLI visible attach acceptance packet
- distinguish proven, gated, and blocked same-TUI continuation states
- document the fallback contract: manual TUI paste stays primary unless same-TUI attach is proven, visible resume/remote-control needs proof, headless codex exec requires explicit opt-in

## Validation
- python3 -m py_compile goal_harness/codex_cli_probe.py examples/codex-cli-visible-attach-acceptance-smoke.py
- python3 examples/codex-cli-visible-attach-acceptance-smoke.py
- python3 examples/codex-cli-visible-driver-run-smoke.py
- python3 examples/codex-cli-local-scheduler-exec-smoke.py
- python3 examples/docs-governance-smoke.py
- python3 -m goal_harness.cli --format json codex-cli-visible-attach-acceptance --project /private/tmp/goal-harness-dashboard-visual-acceptance --goal-id goal-harness-meta --agent-id codex-side-bypass --timeout-seconds 10
- python3 -m goal_harness.cli check --scan-path goal_harness/codex_cli_probe.py --scan-path examples/codex-cli-visible-attach-acceptance-smoke.py --scan-path docs/product/codex-cli-visible-attach-proof-pilot.md --scan-path docs/product/codex-cli-tui-loop.md
- git diff --check

## Notes
- goal-harness check only reported existing duplicate-index warnings; public boundary scan was clean.
- The real help-only packet currently reports same_tui_continuation_blocked because Codex CLI exposes resume/remote-control hints but no safe same-open-TUI attach/inject primitive.