### PR TITLE
fix: project agent-lane next action

### DIFF
--- a/docs/interaction-pattern-catalog.md
+++ b/docs/interaction-pattern-catalog.md
@@ -145,7 +145,7 @@ Projection, authority, write scope, and lease integrity.
 | P1 | IP-016 | Task Lease Claim | Controller/agent | no interruption unless conflict requires decision | claim bounded work with TTL, write scope, and conflict policy |
 | P1 | IP-019 | Side-Agent Scoped Continuation | Primary plus side agent | no interruption unless scope/review is ambiguous | side agent claims scoped todo, uses independent worktree, then self-merges small validated work or hands review to primary |
 | P1 | IP-020 | Todo Claim / Supersede / Successor Lifecycle | Agent plus controller | no interruption unless successor is a user todo or conflict needs decision | claim before delivery; supersede stale work; complete slices with successor or no-follow-up rationale |
-| P1 | IP-022 | Claimed Todo Visibility Lanes | Status/quota/frontstage | no interruption | keep scheduler candidates separate from claimed-work visibility lanes |
+| P1 | IP-022 | Claimed Todo Visibility And Agent-Lane Next Action | Status/quota/frontstage | no interruption | keep scheduler candidates separate from claimed-work visibility lanes and expose the current agent's slice |
 | P1 | IP-023 | Status Neutral Run Window | Status/quota/history | no interruption | ignore neutral run noise for state authority while retaining it as stall evidence |
 
 ### Evidence Lifecycle
@@ -1157,7 +1157,7 @@ permission to ignore gates and boundaries.
 - future status/quota smoke that verifies first executable successor projection
   after `todo supersede` and `todo complete --next-agent-todo`.
 
-#### IP-022 Claimed Todo Visibility Lanes
+#### IP-022 Claimed Todo Visibility And Agent-Lane Next Action
 
 **Trigger**
 
@@ -1214,6 +1214,18 @@ the current agent's own claimed advancement or genuinely unclaimed work.
 `claimed_by` remains a soft ownership signal, not a lock, lease, capability
 grant, or gate bypass.
 
+For agent-scoped execution payloads, quota may also expose a narrow
+`agent_lane_next_action` object with
+`schema_version=agent_lane_next_action_v0`. It is derived from the same scoped
+runnable queue: prefer `capability_gate.runnable_candidates`, then
+`agent_todo_summary.first_executable_items`, then
+`agent_todo_summary.executable_backlog_items`; filter out other-agent claimed
+todos; select the first current-agent claimed todo before any unclaimed
+fallback. This object is an agent-lane pointer, not a goal-level route rewrite,
+so it must include `preserves_goal_next_action=true`. Status may attach the same
+object for `--agent-id` observation, but it must not replace the item
+`recommended_action`, `project_asset.next_action`, owner, or waiting lane.
+
 **Visual Model**
 
 ```mermaid
@@ -1223,6 +1235,7 @@ flowchart TD
   B --> V["visibility lanes: claimed, unclaimed, monitor"]
   S --> Q["quota/capability guard chooses runnable candidate set"]
   Q --> A["agent steering audit chooses actual todo"]
+  Q --> N["agent_lane_next_action for --agent-id scoped turns"]
   V --> F["dashboard/frontstage/review packet shows ownership"]
   V --> C{"agent identity present?"}
   C -->|"yes"| M["current-agent claimed > unclaimed > other-agent claimed"]
@@ -1243,6 +1256,11 @@ monitor work to crowd out the selected advancement lane.
 
 - `docs/status-data-contract.md`
 - `examples/todo-first-open-summary-smoke.py`
+- `examples/work-lane-contract-smoke.py` for `agent_lane_next_action_v0`
+  preserving the primary/global `Next Action` while surfacing the side-agent
+  TUI slice.
+- `examples/status-markdown-smoke.py` for `status --agent-id` rendering the same
+  agent-lane pointer without replacing the project route.
 - PR #262 / commit `292a2c8`: additive status/quota visibility lanes with a
   16-item agent-facing cap.
 

--- a/docs/project-agent-todo-contract.md
+++ b/docs/project-agent-todo-contract.md
@@ -129,7 +129,13 @@ todo summary is claim-aware: current-agent claimed todos are preferred, unclaime
 todos remain selectable, and primary/other-agent claimed todos are projected as
 blocked-claim context rather than as the side agent's next action. This reduces
 accidental collisions without writing scope into todo metadata or turning
-`claimed_by` into a lease.
+`claimed_by` into a lease. When a runnable current-agent or unclaimed
+advancement todo exists, quota may also expose
+`agent_lane_next_action.schema_version=agent_lane_next_action_v0`. That field is
+the side agent's current slice for this turn; it does not overwrite the
+goal-level `Next Action` owned by the primary/global route. `goal-harness status
+--agent-id <side-agent-id>` may attach the same derived field to matching status
+queue items for observation, while leaving the project-level route unchanged.
 
 ```bash
 goal-harness configure-goal \

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -1003,6 +1003,16 @@ when the subcommand supports it. A spend preview that drops the identity may
 correctly show `automation_prompt_upgrade_required` for an unscoped automation,
 but that is an accounting/projection mismatch for the scoped turn, not evidence
 that the earlier side-agent guard was invalid.
+For registered agent-scoped turns, `quota should-run --agent-id` may include
+`agent_lane_next_action.schema_version=agent_lane_next_action_v0`. This is a
+read-only derived pointer to the current agent's selected advancement slice,
+chosen from runnable capability candidates first and then the agent-scoped
+executable todo summary. It may point to a current-agent claimed todo even when
+the active state's global `Next Action` is still owned by the primary route; the
+field must therefore carry `preserves_goal_next_action=true` and must not be
+treated as a project-level status overwrite. `status --agent-id` may reuse the
+same quota-derived object as item/project-asset observation data; consumers must
+render it as an agent-lane pointer, not as `recommended_action` replacement.
 When the resolved `agent_identity.role` is `side-agent`, `quota should-run`
 also enforces the workspace boundary. If the guard is being run from the
 registered primary checkout, from a non-git directory, or from an unrelated git

--- a/examples/status-markdown-smoke.py
+++ b/examples/status-markdown-smoke.py
@@ -28,6 +28,7 @@ from goal_harness.status import (  # noqa: E402
     render_status_markdown,
 )
 from goal_harness.quota import build_quota_should_run, render_quota_should_run_markdown  # noqa: E402
+from goal_harness.cli_commands.status import attach_agent_lane_next_actions  # noqa: E402
 from goal_harness.review_packet import build_review_packet  # noqa: E402
 from goal_harness.handoff_budget import PROJECT_AGENT_HANDOFF_BUDGET  # noqa: E402
 
@@ -1314,6 +1315,120 @@ def assert_decision_freshness_summary_markdown() -> None:
     assert "`operator-gate`: kind=operator_gate state=rebase_required" in markdown, markdown
 
 
+def assert_status_agent_lane_next_action_projection() -> None:
+    goal_id = "agent-lane-status-fixture"
+    primary_action = "[P0] Continue the primary controller benchmark route."
+    side_action = (
+        "[P0] Codex CLI TUI continuation: prove the visible steering turn "
+        "without losing user takeover."
+    )
+    side_todo = {
+        "schema_version": "todo_item_v0",
+        "todo_id": "todo_side_tui",
+        "index": 2,
+        "role": "agent",
+        "status": "open",
+        "priority": "P0",
+        "task_class": "advancement_task",
+        "action_kind": "codex_cli_tui_continuation",
+        "claimed_by": "codex-side-bypass",
+        "required_capabilities": ["shell", "filesystem_write"],
+        "text": side_action,
+    }
+    agent_todos = {
+        "schema_version": "todo_summary_v0",
+        "open_count": 2,
+        "done_count": 0,
+        "total_count": 2,
+        "first_open_items": [
+            {
+                "schema_version": "todo_item_v0",
+                "todo_id": "todo_primary_route",
+                "index": 1,
+                "role": "agent",
+                "status": "open",
+                "priority": "P0",
+                "task_class": "advancement_task",
+                "claimed_by": "codex-main-control",
+                "text": primary_action,
+            },
+            side_todo,
+        ],
+        "first_executable_items": [side_todo],
+    }
+    coordination = {
+        "primary_agent": "codex-main-control",
+        "registered_agents": ["codex-main-control", "codex-side-bypass"],
+    }
+    payload = {
+        "ok": True,
+        "registry": "./fixtures/registry.json",
+        "runtime_root": "./fixtures/runtime",
+        "goal_count": 1,
+        "run_count": 1,
+        "contract": {"ok": True, "summary": {"errors": 0, "warnings": 0, "checks": 0}},
+        "global_registry": {"available": False, "summary": {}},
+        "attention_queue": {
+            "available": True,
+            "item_count": 1,
+            "items": [
+                {
+                    "goal_id": goal_id,
+                    "status": "primary_route_active",
+                    "waiting_on": "codex",
+                    "severity": "action",
+                    "recommended_action": primary_action,
+                    "source": "registry",
+                    "coordination": coordination,
+                    "quota": {
+                        "state": "eligible",
+                        "compute": 1.0,
+                        "window_hours": 24,
+                        "slot_minutes": 1,
+                        "allowed_slots": 10,
+                    },
+                    "agent_todos": agent_todos,
+                    "project_asset": {
+                        "owner": "codex-main-control",
+                        "gate": "none",
+                        "stop_condition": "stop on unsafe workspace or user gate",
+                        "next_action": primary_action,
+                        "agent_todos": agent_todos,
+                    },
+                }
+            ],
+        },
+        "run_history": {
+            "goals": [
+                {
+                    "id": goal_id,
+                    "registry_member": True,
+                    "status": "primary_route_active",
+                    "coordination": coordination,
+                    "quota": {
+                        "compute": 1.0,
+                        "window_hours": 24,
+                        "slot_minutes": 1,
+                        "allowed_slots": 10,
+                    },
+                }
+            ]
+        },
+    }
+    attach_agent_lane_next_actions(payload, agent_id="codex-side-bypass")
+    item = payload["attention_queue"]["items"][0]
+    next_action = item["agent_lane_next_action"]
+    assert next_action["schema_version"] == "agent_lane_next_action_v0", next_action
+    assert next_action["todo_id"] == "todo_side_tui", next_action
+    assert next_action["agent_id"] == "codex-side-bypass", next_action
+    assert next_action["preserves_goal_next_action"] is True, next_action
+    assert item["recommended_action"] == primary_action, item
+    assert item["project_asset"]["next_action"] == primary_action, item
+    markdown = render_status_markdown(payload)
+    assert "agent_lane_next_action: agent=codex-side-bypass todo_id=todo_side_tui" in markdown, markdown
+    assert side_action in markdown, markdown
+
+
 def assert_quota_should_run(payload: dict, *, expected: bool, state: str, waiting_on: str) -> dict:
     quota_payload = build_quota_should_run(payload, goal_id="planned-main-control")
     quota_markdown = render_quota_should_run_markdown(quota_payload)
@@ -2115,6 +2230,7 @@ def main() -> int:
     assert_project_asset_secret_scanner_boundaries()
     assert_promotion_readiness_full_scan_fallback()
     assert_promotion_readiness_warning_in_quota_guard()
+    assert_status_agent_lane_next_action_projection()
     print("status-markdown-smoke ok")
     return 0
 

--- a/examples/work-lane-contract-smoke.py
+++ b/examples/work-lane-contract-smoke.py
@@ -28,6 +28,7 @@ def status_payload(
     user_todo_items: list[dict] | None = None,
     next_action: str = "Observe dependency state and then advance backlog if unchanged.",
     post_handoff_latest_run: dict | None = None,
+    coordination: dict | None = None,
 ) -> dict:
     if agent_todo_items is None:
         agent_todo_items = [
@@ -76,6 +77,8 @@ def status_payload(
             "handoff_status": "post_handoff_run_seen",
             "post_handoff_latest_run": post_handoff_latest_run,
         }
+    if coordination:
+        item["coordination"] = coordination
     if user_todo_items:
         item["user_todos"] = {
             "schema_version": "todo_summary_v0",
@@ -86,27 +89,28 @@ def status_payload(
             "first_open_items": user_todo_items,
             "items": user_todo_items,
         }
+    goal_history_item = {
+        "id": GOAL_ID,
+        "registry_member": True,
+        "status": status,
+        "adapter_kind": "harness_self_improvement",
+        "adapter_status": "connected-read-only",
+        "quota": {
+            "compute": 1.0,
+            "window_hours": 24,
+            "slot_minutes": 1,
+            "allowed_slots": 10,
+        },
+    }
+    if coordination:
+        goal_history_item["coordination"] = coordination
     return {
         "ok": True,
         "attention_queue": {
             "items": [item]
         },
         "run_history": {
-            "goals": [
-                {
-                    "id": GOAL_ID,
-                    "registry_member": True,
-                    "status": status,
-                    "adapter_kind": "harness_self_improvement",
-                    "adapter_status": "connected-read-only",
-                    "quota": {
-                        "compute": 1.0,
-                        "window_hours": 24,
-                        "slot_minutes": 1,
-                        "allowed_slots": 10,
-                    },
-                }
-            ]
+            "goals": [goal_history_item]
         },
     }
 
@@ -1002,6 +1006,76 @@ def assert_launch_then_poll_todo_without_handle_routes_to_advancement() -> None:
     assert first_items[0]["action_kind"] == "run_eval", guard
 
 
+def assert_side_agent_next_action_projects_without_stealing_goal_next_action() -> None:
+    primary_action = "[P0] Run the primary benchmark monitor owned by main control."
+    side_action = (
+        "[P0] Codex CLI TUI continuation: prove the same-open-TUI steering "
+        "slice without adding temporary runtime packet fields."
+    )
+    guard = build_quota_should_run(
+        status_payload(
+            status="primary_goal_route_active",
+            next_action=primary_action,
+            coordination={
+                "primary_agent": "codex-main-control",
+                "registered_agents": ["codex-main-control", "codex-side-bypass"],
+            },
+            agent_todo_items=[
+                {
+                    "index": 1,
+                    "text": primary_action,
+                    "role": "agent",
+                    "status": "open",
+                    "priority": "P0",
+                    "task_class": "advancement_task",
+                    "claimed_by": "codex-main-control",
+                    "todo_id": "todo_primary",
+                },
+                {
+                    "index": 2,
+                    "text": side_action,
+                    "role": "agent",
+                    "status": "open",
+                    "priority": "P0",
+                    "task_class": "advancement_task",
+                    "action_kind": "codex_cli_tui_continuation",
+                    "claimed_by": "codex-side-bypass",
+                    "todo_id": "todo_side_tui",
+                    "required_capabilities": ["shell", "filesystem_write"],
+                },
+                {
+                    "index": 3,
+                    "text": "[P1] Render the public showcase animation prototype.",
+                    "role": "agent",
+                    "status": "open",
+                    "priority": "P1",
+                    "task_class": "advancement_task",
+                    "claimed_by": "codex-side-bypass",
+                    "todo_id": "todo_side_showcase",
+                },
+            ],
+        ),
+        goal_id=GOAL_ID,
+        agent_id="codex-side-bypass",
+    )
+    assert guard["recommended_action"] == side_action, guard
+    assert guard["agent_identity"]["agent_id"] == "codex-side-bypass", guard
+    next_action = guard["agent_lane_next_action"]
+    assert next_action["schema_version"] == "agent_lane_next_action_v0", next_action
+    assert next_action["agent_id"] == "codex-side-bypass", next_action
+    assert next_action["primary_agent"] == "codex-main-control", next_action
+    assert next_action["todo_id"] == "todo_side_tui", next_action
+    assert next_action["selected_by"] == "current_agent_claimed_todo", next_action
+    assert next_action["confidence"] == "selected", next_action
+    assert next_action["source"] == "capability_gate.runnable_candidates", next_action
+    assert next_action["preserves_goal_next_action"] is True, next_action
+    assert guard["capability_gate"]["runnable_candidates"][0]["todo_id"] == "todo_side_tui", guard
+    markdown = render_quota_should_run_markdown(guard)
+    assert "agent_lane_next_action: todo_id=todo_side_tui" in markdown, markdown
+    assert side_action in markdown, markdown
+    assert primary_action not in guard["agent_lane_next_action"]["text"], guard
+
+
 def main() -> int:
     assert_dependency_monitor_requires_advancement()
     assert_primary_status_stays_advancement_lane()
@@ -1024,6 +1098,7 @@ def main() -> int:
     assert_behavior_regression_suite_routes_to_advancement()
     assert_launched_external_observation_does_not_preempt_advancement_backlog()
     assert_launch_then_poll_todo_without_handle_routes_to_advancement()
+    assert_side_agent_next_action_projects_without_stealing_goal_next_action()
     print("work-lane-contract-smoke ok")
     return 0
 

--- a/goal_harness/cli_commands/status.py
+++ b/goal_harness/cli_commands/status.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from ..contract import check_contract, render_contract_markdown
 from ..diagnose import collect_diagnosis, render_diagnosis_markdown
 from ..handoff_budget import build_handoff_interface_budget
+from ..quota import build_quota_should_run
 from ..review_packet import build_review_packet, render_review_packet_markdown
 from ..status import collect_status, render_status_markdown
 
@@ -55,6 +56,13 @@ def register_status_commands(
         help="Specific public file or directory to scan. Repeatable. Overrides --scan-root when set.",
     )
     status_parser.add_argument("--limit", type=int, default=5)
+    status_parser.add_argument(
+        "--agent-id",
+        help=(
+            "Registered agent id for adding agent-lane next-action projection "
+            "to matching status queue items."
+        ),
+    )
 
     diagnose_parser = subparsers.add_parser(
         "diagnose",
@@ -201,6 +209,8 @@ def handle_status_command(
             scan_roots=_scan_roots(args),
             limit=max(0, args.limit),
         )
+        if args.agent_id:
+            attach_agent_lane_next_actions(payload, agent_id=args.agent_id)
     except Exception as exc:
         payload = {
             "ok": False,
@@ -227,6 +237,45 @@ def handle_status_command(
         }
     print_payload(payload, output_format(args), render_status_markdown)
     return 0 if payload.get("ok") else 1
+
+
+def attach_agent_lane_next_actions(payload: dict[str, object], *, agent_id: str) -> dict[str, object]:
+    safe_agent_id = str(agent_id or "").strip()
+    if not safe_agent_id:
+        return payload
+    queue = payload.get("attention_queue")
+    if not isinstance(queue, dict):
+        return payload
+    items = queue.get("items")
+    if not isinstance(items, list):
+        return payload
+    attached = 0
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        goal_id = str(item.get("goal_id") or "").strip()
+        if not goal_id:
+            continue
+        try:
+            guard = build_quota_should_run(payload, goal_id=goal_id, agent_id=safe_agent_id)
+        except Exception:
+            continue
+        next_action = guard.get("agent_lane_next_action")
+        if not isinstance(next_action, dict):
+            continue
+        item["agent_lane_next_action"] = next_action
+        project_asset = item.get("project_asset")
+        if isinstance(project_asset, dict):
+            project_asset["agent_lane_next_action"] = next_action
+        attached += 1
+    if attached:
+        payload["agent_lane_next_action_projection"] = {
+            "schema_version": "agent_lane_next_action_projection_v0",
+            "agent_id": safe_agent_id,
+            "attached_count": attached,
+            "preserves_goal_next_action": True,
+        }
+    return payload
 
 
 def handle_diagnose_command(

--- a/goal_harness/quota.py
+++ b/goal_harness/quota.py
@@ -140,6 +140,7 @@ CAPABILITY_GATE_SCHEMA_VERSION = "capability_gate_v0"
 SIDE_AGENT_WORKSPACE_GUARD_SCHEMA_VERSION = "side_agent_workspace_guard_v0"
 AGENT_CLAIM_SCOPE_SCHEMA_VERSION = "agent_claim_scope_v0"
 SIDE_AGENT_CLAIM_SCOPE_SCHEMA_VERSION = AGENT_CLAIM_SCOPE_SCHEMA_VERSION
+AGENT_LANE_NEXT_ACTION_SCHEMA_VERSION = "agent_lane_next_action_v0"
 DEFAULT_AVAILABLE_CAPABILITIES = (
     "shell",
     "filesystem_read",
@@ -1784,6 +1785,91 @@ def _first_executable_todo_text(agent_todo_summary: dict[str, Any] | None) -> st
         text = _protocol_action_text(item.get("text"), limit=320)
         if text:
             return text
+    return None
+
+
+def _agent_lane_next_action(
+    *,
+    agent_identity: dict[str, Any] | None,
+    agent_todo_summary: dict[str, Any] | None,
+    capability_gate: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    if not isinstance(agent_identity, dict):
+        return None
+    agent_id = normalize_todo_claimed_by(agent_identity.get("agent_id"))
+    if not agent_id or not isinstance(agent_todo_summary, dict):
+        return None
+
+    candidate_sources: list[tuple[str, list[Any]]] = []
+    if isinstance(capability_gate, dict) and capability_gate.get("action") == "run":
+        candidate_sources.append(
+            (
+                "capability_gate.runnable_candidates",
+                capability_gate.get("runnable_candidates")
+                if isinstance(capability_gate.get("runnable_candidates"), list)
+                else [],
+            )
+        )
+    candidate_sources.append(
+        (
+            "agent_todo_summary.first_executable_items",
+            agent_todo_summary.get("first_executable_items")
+            if isinstance(agent_todo_summary.get("first_executable_items"), list)
+            else [],
+        )
+    )
+    candidate_sources.append(
+        (
+            "agent_todo_summary.executable_backlog_items",
+            agent_todo_summary.get("executable_backlog_items")
+            if isinstance(agent_todo_summary.get("executable_backlog_items"), list)
+            else [],
+        )
+    )
+
+    seen: set[tuple[str, str]] = set()
+    for source, raw_items in candidate_sources:
+        for raw_item in raw_items:
+            if not isinstance(raw_item, dict):
+                continue
+            if not _todo_item_is_actionable_open(raw_item):
+                continue
+            if _todo_task_class(raw_item) != TODO_TASK_CLASS_ADVANCEMENT:
+                continue
+            text = _protocol_action_text(raw_item.get("text"), limit=500)
+            if not text:
+                continue
+            identity = (str(raw_item.get("todo_id") or ""), text)
+            if identity in seen:
+                continue
+            seen.add(identity)
+            claimed_by = normalize_todo_claimed_by(raw_item.get("claimed_by"))
+            if claimed_by and claimed_by != agent_id:
+                continue
+            selected_by = (
+                "current_agent_claimed_todo"
+                if claimed_by == agent_id
+                else "unclaimed_todo"
+            )
+            payload = _compact_todo_summary_item(raw_item, text=text)
+            payload.update(
+                {
+                    "schema_version": AGENT_LANE_NEXT_ACTION_SCHEMA_VERSION,
+                    "agent_id": agent_id,
+                    "primary_agent": normalize_todo_claimed_by(
+                        agent_identity.get("primary_agent")
+                    ),
+                    "source": source,
+                    "selected_by": selected_by,
+                    "confidence": (
+                        "selected"
+                        if selected_by == "current_agent_claimed_todo"
+                        else "candidate"
+                    ),
+                    "preserves_goal_next_action": True,
+                }
+            )
+            return payload
     return None
 
 
@@ -4773,6 +4859,11 @@ def build_quota_should_run(
                 or automation_prompt_upgrade.get("reason")
                 or selected_recommended_action
             )
+        agent_lane_next_action = _agent_lane_next_action(
+            agent_identity=agent_identity,
+            agent_todo_summary=agent_todo_summary,
+            capability_gate=capability_gate,
+        )
         state_action_projection_warning = _state_action_projection_warning(
             item,
             agent_todo_summary=agent_todo_summary,
@@ -4857,6 +4948,8 @@ def build_quota_should_run(
         }
         if agent_identity:
             payload["agent_identity"] = agent_identity
+        if agent_lane_next_action:
+            payload["agent_lane_next_action"] = agent_lane_next_action
         if workspace_guard:
             payload["workspace_guard"] = workspace_guard
         if automation_prompt_upgrade:
@@ -6141,6 +6234,20 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
             f"role={agent_identity.get('role')} "
             f"primary_agent={agent_identity.get('primary_agent')}"
         )
+    agent_lane_next_action = (
+        payload.get("agent_lane_next_action")
+        if isinstance(payload.get("agent_lane_next_action"), dict)
+        else {}
+    )
+    if agent_lane_next_action:
+        lines.append(
+            "- agent_lane_next_action: "
+            f"todo_id={agent_lane_next_action.get('todo_id')} "
+            f"selected_by={agent_lane_next_action.get('selected_by')} "
+            f"confidence={agent_lane_next_action.get('confidence')}"
+        )
+        if agent_lane_next_action.get("text"):
+            lines.append(f"- agent_lane_next_action_text: {agent_lane_next_action.get('text')}")
     automation_prompt_upgrade = (
         payload.get("automation_prompt_upgrade")
         if isinstance(payload.get("automation_prompt_upgrade"), dict)

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -7815,6 +7815,23 @@ def render_status_markdown(payload: dict[str, Any]) -> str:
                     "    - agent_lane_recommendation: "
                     f"agent={agent} lane={lane} action={recommendation}"
                 )
+            agent_lane_next_action = (
+                project_asset.get("agent_lane_next_action")
+                if isinstance(project_asset.get("agent_lane_next_action"), dict)
+                else item.get("agent_lane_next_action")
+                if isinstance(item.get("agent_lane_next_action"), dict)
+                else {}
+            )
+            if agent_lane_next_action:
+                agent = _markdown_scalar(agent_lane_next_action.get("agent_id") or "")
+                todo_id = _markdown_scalar(agent_lane_next_action.get("todo_id") or "")
+                selected_by = _markdown_scalar(agent_lane_next_action.get("selected_by") or "")
+                action = _markdown_scalar(agent_lane_next_action.get("text") or "")
+                lines.append(
+                    "    - agent_lane_next_action: "
+                    f"agent={agent} todo_id={todo_id} selected_by={selected_by} "
+                    f"action={action}"
+                )
             dreaming_lane_badge = (
                 project_asset.get("dreaming_lane_badge")
                 if isinstance(project_asset.get("dreaming_lane_badge"), dict)


### PR DESCRIPTION
## Summary
- add agent_lane_next_action_v0 to quota should-run so --agent-id scoped turns expose the current agent's selected advancement slice without overwriting the primary/global Next Action
- add status --agent-id observation projection for matching queue items and render it in status markdown
- document the interaction pattern/catalog contract and cover quota/status behavior with durable smokes

## Validation
- python3 -m py_compile goal_harness/quota.py goal_harness/status.py goal_harness/cli_commands/status.py examples/work-lane-contract-smoke.py examples/status-markdown-smoke.py
- python3 examples/work-lane-contract-smoke.py
- python3 examples/status-markdown-smoke.py
- python3 examples/docs-governance-smoke.py
- python3 examples/refresh-state-agent-lane-scope-smoke.py
- goal-harness --format json --registry "/Users/bytedance/.codex/goal-harness/registry.global.json" quota should-run --goal-id goal-harness-meta --agent-id codex-side-bypass
- goal-harness --format json --registry "/Users/bytedance/.codex/goal-harness/registry.global.json" status --agent-id codex-side-bypass --limit 5
- goal-harness check --scan-path goal_harness/quota.py --scan-path goal_harness/status.py --scan-path goal_harness/cli_commands/status.py --scan-path examples/work-lane-contract-smoke.py --scan-path examples/status-markdown-smoke.py --scan-path docs/project-agent-todo-contract.md --scan-path docs/status-data-contract.md --scan-path docs/interaction-pattern-catalog.md
- git diff --check
- sensitive marker scan on changed public files