### PR TITLE
Fix todo target capability gating

### DIFF
--- a/docs/interaction-pattern-catalog.md
+++ b/docs/interaction-pattern-catalog.md
@@ -392,6 +392,12 @@ Capability is a per-todo execution preflight, not a global agent profile and
 not a permission grant. `status` should project each todo's
 `required_capabilities`; `quota should-run` should derive a read-only
 `capability_gate` over the visible executable queue.
+Do not declare a capability as required merely because the todo is meant to
+develop, repair, or parity-check that capability. Use `target_capabilities` for
+that output side of the work. For example, a product-path parity todo can
+declare `required_capabilities=shell` and `target_capabilities=benchmark_runner`:
+the gate may project it as runnable repair work even while the target bridge
+capability is absent.
 
 The controller scans executable candidates in projection order and classifies
 them, but it does not make the final todo choice. If the first P0 requires
@@ -400,12 +406,20 @@ both the runnable P0 and any later runnable fallback are projected in
 `capability_gate.runnable_candidates`; blocked higher-priority items remain
 visible in `capability_gate.blocked_candidates`. `recommended_action` remains
 routing context, not a chosen runnable todo.
+If the first P0 is not trying to run the benchmark but to repair or materialize
+the benchmark bridge itself, it should appear in `runnable_candidates` with
+`target_capabilities`, `capability_repair_mode=true`, and
+`capability_action=repair_bridge` instead of being hidden behind a lower-value
+fallback.
 
 When `capability_gate.action=run`, the decision contract is:
 
 - `decision_owner=agent`;
 - `selection_policy=agent_steering_audit_over_runnable_candidates`;
 - `runnable_candidates` is the allowed candidate set for this turn;
+- candidates with `capability_repair_mode=true` are allowed repair/development
+  work for a missing `target_capabilities` bridge, not direct execution through
+  that missing bridge;
 - `blocked_candidates` is the visible set of higher- or same-priority work
   that cannot currently run;
 - the agent must choose the actual todo from `runnable_candidates`, then

--- a/docs/project-agent-todo-contract.md
+++ b/docs/project-agent-todo-contract.md
@@ -321,9 +321,9 @@ the structured projection emitted by status/quota when available. Todo summaries
 carry `schema_version=todo_summary_v0`; individual items carry
 `schema_version=todo_item_v0`, `todo_id`, `role`, `status`, `priority`,
 `title`, `archive_state`, `source_section`, `index`, `text`, `task_class`, and
-optional `action_kind`, `claimed_by`, and `required_capabilities`. The `todo_id`
-is first-class when written by the CLI. `claimed_by` values are normalized
-public-safe agent ids and should correspond to
+optional `action_kind`, `claimed_by`, `required_capabilities`, and
+`target_capabilities`. The `todo_id` is first-class when written by the CLI.
+`claimed_by` values are normalized public-safe agent ids and should correspond to
 `coordination.registered_agents`. Legacy Markdown without metadata still gets a
 parser-derived compatibility id from local section/index/text, and the first
 lifecycle command will materialize that id back into metadata. Future lease
@@ -358,6 +358,22 @@ goal-harness todo add \
   --required-capability benchmark_runner
 ```
 
+Use `--target-capability` when the todo is meant to build, repair,
+materialize, or parity-check a capability rather than use that capability as a
+prerequisite. For example, a benchmark product-path parity todo can hard-require
+only shell while targeting the benchmark runner bridge:
+
+```bash
+goal-harness todo add \
+  --goal-id <goal-id> \
+  --role agent \
+  --text "<public-safe benchmark parity repair action>" \
+  --task-class advancement_task \
+  --action-kind benchmark_treatment_product_path_parity \
+  --required-capability shell \
+  --target-capability benchmark_runner
+```
+
 `status` projects `required_capabilities` on every visible todo. `quota
 should-run` then derives a read-only `capability_gate` from the visible
 executable queue, not from a single preselected todo. With multiple P0 or P1
@@ -369,6 +385,10 @@ the agent keeps decision authority and must pick from the runnable set during
 its steering audit. If no visible executable candidate can run, the gate returns
 `repair_bridge`, `ask_owner`, or `skip` according to the missing capability
 class.
+`target_capabilities` stay visible in runnable candidate payloads. If a target
+bridge is absent, the candidate is annotated with `capability_repair_mode=true`
+and `missing_target_capabilities`, but that target is not treated as a hard
+execution blocker.
 
 ## Execution Order
 

--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -264,6 +264,11 @@ the CLI flag `goal-harness todo add --required-capability benchmark_runner`.
 This is not a global agent profile and not a permission system. It is a
 per-todo execution preflight so the guard can distinguish "quota is available"
 from "this step can actually run in the current environment."
+Use `required_capabilities` for prerequisites, not for the capability the todo
+is intended to create. A todo that repairs, develops, materializes, or
+parity-checks a bridge capability should declare that output side with
+`target_capabilities`. Target capabilities are projected for visibility and
+repair-mode routing, but they are not hard execution gates.
 
 `quota should-run` compares the visible executable advancement queue with the
 current launcher capabilities. Basic local capabilities such as `shell`,
@@ -315,6 +320,13 @@ candidate is missing a capability, the gate returns
 `benchmark_runner`/`external_evidence_poll`, `action=ask_owner` for owner-held
 capabilities such as `network`/`credentials`/`production_access`, or
 `action=skip` for unsupported capability classes.
+
+When a missing repairable bridge is itself the target of the todo, for example
+`required_capabilities=shell` plus `target_capabilities=benchmark_runner`, the
+candidate remains in `runnable_candidates` with `capability_repair_mode=true`,
+`capability_action=repair_bridge`, and candidate-local
+`missing_target_capabilities`. This avoids a circular gate where a todo cannot
+develop `benchmark_runner` because it does not already have `benchmark_runner`.
 
 External-evidence waits have an additional CLI-level observation contract. When
 the selected goal is `state=waiting`, `waiting_on=external_evidence`, and its

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -796,10 +796,17 @@ Item fields:
   `action=run`, the gate projects `runnable_candidates` and
   `blocked_candidates`; `decision_owner=agent` means the agent chooses the
   actual todo from the runnable set during its steering audit. The gate must
-  not rewrite `recommended_action` into a single selected todo. When no visible
-  executable candidate is runnable, the gate owns the decision and returns
-  `repair_bridge`, `ask_owner`, or `skip` with concrete missing capability
-  details.
+  not rewrite `recommended_action` into a single selected todo.
+  `required_capabilities` means a prerequisite for directly executing that
+  todo, not the capability the todo is trying to build. A todo may separately
+  declare `target_capabilities` for capabilities it is developing, repairing,
+  materializing, or parity-checking. Target capabilities are not hard gates. If
+  a target bridge such as `benchmark_runner` is absent, the candidate may still
+  appear in `runnable_candidates` with `capability_repair_mode=true`,
+  `capability_action=repair_bridge`, and `missing_target_capabilities` on the
+  candidate. When no visible executable candidate is runnable, the gate owns
+  the decision and returns `repair_bridge`, `ask_owner`, or `skip` with
+  concrete missing capability details.
 - `project_asset.todo_projection_gap`: optional explicit gap object emitted
   when status cannot project `user_todos` and/or `agent_todos` for a connected
   project. This means "the first-screen todo state is unknown", not "there are

--- a/examples/capability-gate-smoke.py
+++ b/examples/capability-gate-smoke.py
@@ -18,8 +18,16 @@ from goal_harness.quota import build_quota_should_run, build_quota_slot_preview 
 GOAL_ID = "capability-gate-goal"
 
 
-def todo(index: int, priority: str, text: str, capabilities: list[str]) -> dict[str, Any]:
-    return {
+def todo(
+    index: int,
+    priority: str,
+    text: str,
+    capabilities: list[str],
+    *,
+    action_kind: str | None = None,
+    target_capabilities: list[str] | None = None,
+) -> dict[str, Any]:
+    item = {
         "schema_version": "todo_item_v0",
         "todo_id": f"todo_capability_{index}",
         "role": "agent",
@@ -30,9 +38,12 @@ def todo(index: int, priority: str, text: str, capabilities: list[str]) -> dict[
         "text": text,
         "title": text.removeprefix(f"[{priority}] "),
         "task_class": "advancement_task",
-        "action_kind": "run_eval" if "benchmark" in text.lower() else "validate",
+        "action_kind": action_kind or ("run_eval" if "benchmark" in text.lower() else "validate"),
         "required_capabilities": capabilities,
     }
+    if target_capabilities:
+        item["target_capabilities"] = target_capabilities
+    return item
 
 
 def status_payload(items: list[dict[str, Any]]) -> dict[str, Any]:
@@ -119,6 +130,14 @@ def main() -> int:
         "[P1] Refresh the public docs fallback and validate it.",
         ["shell", "filesystem_write"],
     )
+    p0_repair_benchmark_bridge = todo(
+        7,
+        "P0",
+        "[P0] Repair benchmark treatment product-path parity before claiming uplift.",
+        ["shell"],
+        action_kind="benchmark_treatment_product_path_parity",
+        target_capabilities=["benchmark_runner"],
+    )
 
     p0_fallback = build_quota_should_run(
         status_payload([p0_benchmark, p0_validate, p1_docs]),
@@ -158,6 +177,31 @@ def main() -> int:
     assert fallback["capability_gate"]["blocked_candidates"][2]["missing_capabilities"] == ["gpu_runner"], fallback
     assert "Run the benchmark runner once" in fallback["recommended_action"], fallback
     assert "choose one of 1 capability-runnable todo(s)" in fallback["protocol_action_packet"]["summary"], fallback
+
+    repair_candidate = build_quota_should_run(
+        status_payload([p0_repair_benchmark_bridge, p0_benchmark, p1_docs]),
+        goal_id=GOAL_ID,
+        available_capabilities=["shell", "filesystem_write"],
+    )
+    assert repair_candidate["should_run"] is True, repair_candidate
+    assert repair_candidate["normal_delivery_allowed"] is True, repair_candidate
+    assert repair_candidate["capability_gate"]["action"] == "run", repair_candidate
+    assert [
+        item["todo_id"]
+        for item in repair_candidate["capability_gate"]["runnable_candidates"]
+    ] == ["todo_capability_7", "todo_capability_5"], repair_candidate
+    bridge_candidate = repair_candidate["capability_gate"]["runnable_candidates"][0]
+    assert bridge_candidate["missing_capabilities"] == [], repair_candidate
+    assert bridge_candidate["target_capabilities"] == ["benchmark_runner"], repair_candidate
+    assert bridge_candidate["missing_target_capabilities"] == ["benchmark_runner"], repair_candidate
+    assert bridge_candidate["capability_action"] == "repair_bridge", repair_candidate
+    assert bridge_candidate["capability_repair_mode"] is True, repair_candidate
+    assert repair_candidate["capability_gate"]["repair_missing"] == ["benchmark_runner"], repair_candidate
+    assert repair_candidate["capability_gate"]["repair_candidate_count"] == 1, repair_candidate
+    assert [
+        item["todo_id"]
+        for item in repair_candidate["capability_gate"]["blocked_candidates"]
+    ] == ["todo_capability_1"], repair_candidate
 
     benchmark_ready = build_quota_should_run(
         status_payload([p0_benchmark, p0_validate, p1_docs]),

--- a/examples/todo-cli-smoke.py
+++ b/examples/todo-cli-smoke.py
@@ -189,6 +189,8 @@ def main() -> int:
             "shell",
             "--required-capability",
             "benchmark_runner",
+            "--target-capability",
+            "benchmark_runner",
         )
         assert metadata_payload["added"] is False, metadata_payload
         assert metadata_payload["already_exists"] is True, metadata_payload
@@ -196,6 +198,7 @@ def main() -> int:
         assert metadata_payload["task_class"] == "advancement_task", metadata_payload
         assert metadata_payload["action_kind"] == "run_eval", metadata_payload
         assert metadata_payload["required_capabilities"] == ["shell", "benchmark_runner"], metadata_payload
+        assert metadata_payload["target_capabilities"] == ["benchmark_runner"], metadata_payload
         after_metadata = state_file.read_text(encoding="utf-8")
         assert after_metadata.count("- [ ] Summarize the read-only evidence after the user") == 1, after_metadata
         agent_block_start = after_metadata.index("- [ ] Summarize the read-only evidence after the user")
@@ -203,6 +206,7 @@ def main() -> int:
         assert after_metadata.index("checklist is done.", agent_block_start) < agent_metadata_start, after_metadata
         assert "status=open task_class=advancement_task action_kind=run_eval" in after_metadata
         assert "required_capabilities=shell%2Cbenchmark_runner" in after_metadata
+        assert "target_capabilities=benchmark_runner" in after_metadata
         fields = parse_active_state_todos(state_file.read_text(encoding="utf-8"))
         assert fields["user_todos"]["items"][0]["text"] == USER_TODO, fields
         assert fields["user_todos"]["items"][0]["todo_id"].startswith("todo_"), fields
@@ -212,6 +216,9 @@ def main() -> int:
         assert fields["agent_todos"]["items"][0]["action_kind"] == "run_eval", fields
         assert fields["agent_todos"]["items"][0]["required_capabilities"] == [
             "shell",
+            "benchmark_runner",
+        ], fields
+        assert fields["agent_todos"]["items"][0]["target_capabilities"] == [
             "benchmark_runner",
         ], fields
         assert fields["user_todos"]["source_section"] == "User Todo / Owner Review Reading Queue", fields
@@ -296,6 +303,9 @@ def main() -> int:
         assert preserved_claim_item["action_kind"] == "run_eval", preserved_claim_item
         assert preserved_claim_item["required_capabilities"] == [
             "shell",
+            "benchmark_runner",
+        ], preserved_claim_item
+        assert preserved_claim_item["target_capabilities"] == [
             "benchmark_runner",
         ], preserved_claim_item
 

--- a/goal_harness/cli.py
+++ b/goal_harness/cli.py
@@ -5883,6 +5883,16 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     todo_parser.add_argument(
+        "--target-capability",
+        dest="target_capabilities",
+        action="append",
+        help=(
+            "For todo add/update, declare a capability this todo is building, "
+            "repairing, materializing, or parity-checking. This is not a hard "
+            "execution prerequisite."
+        ),
+    )
+    todo_parser.add_argument(
         "--claimed-by",
         help=(
             "For todo add/claim/update/complete, soft-claim the todo for a registered "
@@ -10271,6 +10281,7 @@ def main(argv: list[str] | None = None) -> int:
                     action_kind=args.action_kind,
                     required_write_scopes=args.required_write_scopes,
                     required_capabilities=args.required_capabilities,
+                    target_capabilities=args.target_capabilities,
                     claimed_by=args.claimed_by,
                     project=Path(args.project).expanduser() if args.project else None,
                     state_file=Path(args.state_file).expanduser() if args.state_file else None,
@@ -10295,6 +10306,7 @@ def main(argv: list[str] | None = None) -> int:
                         ("--action-kind", args.action_kind),
                         ("--required-write-scope", args.required_write_scopes),
                         ("--required-capability", args.required_capabilities),
+                        ("--target-capability", args.target_capabilities),
                         ("--next-agent-todo", args.next_agent_todo),
                         ("--next-user-todo", args.next_user_todo),
                         ("--next-claimed-by", args.next_claimed_by),
@@ -10336,10 +10348,11 @@ def main(argv: list[str] | None = None) -> int:
                     args.action_kind,
                     args.required_write_scopes,
                     args.required_capabilities,
+                    args.target_capabilities,
                     args.claimed_by,
                     args.clear_claim,
                 ]):
-                    raise ValueError("todo update requires at least one of --text, --status, --note, --evidence, --reason, --task-class, --action-kind, --required-write-scope, --required-capability, --claimed-by, or --clear-claim")
+                    raise ValueError("todo update requires at least one of --text, --status, --note, --evidence, --reason, --task-class, --action-kind, --required-write-scope, --required-capability, --target-capability, --claimed-by, or --clear-claim")
                 if args.next_claimed_by:
                     raise ValueError("todo update does not support --next-claimed-by")
                 if args.side_agent_self_merged:
@@ -10358,6 +10371,7 @@ def main(argv: list[str] | None = None) -> int:
                     action_kind=args.action_kind,
                     required_write_scopes=args.required_write_scopes,
                     required_capabilities=args.required_capabilities,
+                    target_capabilities=args.target_capabilities,
                     claimed_by=args.claimed_by,
                     clear_claim=bool(args.clear_claim),
                     project=Path(args.project).expanduser() if args.project else None,

--- a/goal_harness/quota.py
+++ b/goal_harness/quota.py
@@ -37,6 +37,7 @@ from .todo_contract import (
     TODO_TASK_CLASS_USER_GATE,
     next_action_requires_advancement_text,
     normalize_required_capabilities,
+    normalize_target_capabilities,
     normalize_todo_claimed_by,
     normalize_required_write_scopes,
     normalize_todo_status,
@@ -961,6 +962,7 @@ def _compact_todo_summary_item(item: dict[str, Any], *, text: str | None = None)
         "action_kind",
         "required_write_scopes",
         "required_capabilities",
+        "target_capabilities",
         "claimed_by",
     ):
         if item.get(key) is not None:
@@ -993,13 +995,27 @@ def _capability_missing_action(missing: list[str]) -> str:
     return "skip"
 
 
-def _capability_candidate_item(item: dict[str, Any], *, missing: list[str]) -> dict[str, Any]:
+def _capability_candidate_item(
+    item: dict[str, Any],
+    *,
+    missing: list[str],
+    missing_target_capabilities: list[str] | None = None,
+) -> dict[str, Any]:
     text = str(item.get("text") or "").strip()
     payload = _compact_todo_summary_item(item, text=text)
     required = normalize_required_capabilities(item.get("required_capabilities"))
+    targets = normalize_target_capabilities(item.get("target_capabilities"))
     payload["required_capabilities"] = required
+    if targets:
+        payload["target_capabilities"] = targets
     payload["missing_capabilities"] = missing
     payload["capability_action"] = _capability_missing_action(missing)
+    missing_targets = normalize_target_capabilities(missing_target_capabilities)
+    if missing_targets:
+        payload["missing_target_capabilities"] = missing_targets
+    if missing_targets and set(missing_targets) & CAPABILITY_REPAIR_BRIDGE_HINTS:
+        payload["capability_repair_mode"] = True
+        payload["capability_action"] = "repair_bridge"
     return payload
 
 
@@ -1037,23 +1053,37 @@ def _capability_gate(
     saw_requirement = False
     for item in candidates:
         required = normalize_required_capabilities(item.get("required_capabilities"))
-        if required:
+        targets = normalize_target_capabilities(item.get("target_capabilities"))
+        if required or targets:
             saw_requirement = True
-        missing = [capability for capability in required if capability not in available]
+        hard_required = [capability for capability in required if capability not in targets]
+        missing = [capability for capability in hard_required if capability not in available]
+        missing_targets = [capability for capability in targets if capability not in available]
         if missing:
             blocked.append(_capability_candidate_item(item, missing=missing))
             continue
-        runnable.append(_capability_candidate_item(item, missing=[]))
+        runnable.append(
+            _capability_candidate_item(
+                item,
+                missing=[],
+                missing_target_capabilities=missing_targets,
+            )
+        )
 
     if not saw_requirement and not blocked:
         return None
     if runnable:
         runnable_required: list[str] = []
         blocked_missing: list[str] = []
+        repair_missing: list[str] = []
         for item in runnable:
             for capability in item.get("required_capabilities") or []:
                 if capability not in runnable_required:
                     runnable_required.append(str(capability))
+            if item.get("capability_repair_mode") is True:
+                for capability in item.get("missing_target_capabilities") or []:
+                    if capability not in repair_missing:
+                        repair_missing.append(str(capability))
         for item in blocked:
             for capability in item.get("missing_capabilities") or []:
                 if capability not in blocked_missing:
@@ -1071,6 +1101,10 @@ def _capability_gate(
             "runnable_candidates": runnable,
             "blocked_candidates": blocked,
             "blocked_missing": blocked_missing,
+            "repair_missing": repair_missing,
+            "repair_candidate_count": sum(
+                1 for item in runnable if item.get("capability_repair_mode") is True
+            ),
             "reason": "capability gate projected runnable candidate set; agent chooses the actual todo",
         }
 

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -48,6 +48,7 @@ from .todo_contract import (
     build_todo_id,
     normalize_todo_action_kind,
     normalize_required_capabilities,
+    normalize_target_capabilities,
     normalize_required_write_scopes,
     normalize_todo_claimed_by,
     normalize_todo_status,
@@ -3768,6 +3769,9 @@ def structured_todo_item(
     required_capabilities = normalize_required_capabilities(item.get("required_capabilities"))
     if required_capabilities:
         normalized["required_capabilities"] = required_capabilities
+    target_capabilities = normalize_target_capabilities(item.get("target_capabilities"))
+    if target_capabilities:
+        normalized["target_capabilities"] = target_capabilities
     claimed_by = normalize_todo_claimed_by(item.get("claimed_by"))
     if claimed_by:
         normalized["claimed_by"] = claimed_by
@@ -3796,6 +3800,7 @@ def compact_todo_item(item: dict[str, Any]) -> dict[str, Any]:
         "action_kind",
         "required_write_scopes",
         "required_capabilities",
+        "target_capabilities",
         "claimed_by",
         "note",
         "evidence",

--- a/goal_harness/todo_contract.py
+++ b/goal_harness/todo_contract.py
@@ -206,6 +206,10 @@ def normalize_required_capabilities(value: Any) -> list[str]:
     return capabilities
 
 
+def normalize_target_capabilities(value: Any) -> list[str]:
+    return normalize_required_capabilities(value)
+
+
 def build_todo_id(
     *,
     role: Any,
@@ -294,6 +298,10 @@ def parse_todo_metadata_line(line: str) -> dict[str, Any] | None:
             capabilities = normalize_required_capabilities(value)
             if capabilities:
                 metadata["required_capabilities"] = capabilities
+        elif key in {"target_capability", "target_capabilities"}:
+            capabilities = normalize_target_capabilities(value)
+            if capabilities:
+                metadata["target_capabilities"] = capabilities
         elif key == "claimed_by":
             claimed_by = normalize_todo_claimed_by(value)
             if claimed_by:
@@ -316,6 +324,7 @@ def format_todo_metadata_line(
     action_kind: str | None = None,
     required_write_scopes: Any = None,
     required_capabilities: Any = None,
+    target_capabilities: Any = None,
     claimed_by: str | None = None,
     note: str | None = None,
     evidence: str | None = None,
@@ -360,6 +369,14 @@ def format_todo_metadata_line(
         fields.append(
             "required_capabilities="
             f"{encode_metadata_value(','.join(normalized_capabilities))}"
+        )
+    normalized_target_capabilities = normalize_target_capabilities(target_capabilities)
+    if target_capabilities and not normalized_target_capabilities:
+        raise ValueError("target_capabilities must contain public-safe capability tokens")
+    if normalized_target_capabilities:
+        fields.append(
+            "target_capabilities="
+            f"{encode_metadata_value(','.join(normalized_target_capabilities))}"
         )
     normalized_claimed_by = normalize_todo_claimed_by(claimed_by)
     if claimed_by and not normalized_claimed_by:

--- a/goal_harness/todos.py
+++ b/goal_harness/todos.py
@@ -21,6 +21,7 @@ from .todo_contract import (
     format_todo_metadata_line,
     normalize_required_capabilities,
     normalize_required_write_scopes,
+    normalize_target_capabilities,
     normalize_todo_claimed_by,
     normalize_todo_id,
     normalize_todo_status,
@@ -43,6 +44,7 @@ TODO_METADATA_FIELDS = (
     "action_kind",
     "required_write_scopes",
     "required_capabilities",
+    "target_capabilities",
     "claimed_by",
     "note",
     "evidence",
@@ -306,6 +308,11 @@ def block_metadata(block: dict[str, Any]) -> dict[str, Any]:
             if capabilities:
                 metadata[key] = capabilities
             continue
+        if key == "target_capabilities":
+            capabilities = normalize_target_capabilities(value)
+            if capabilities:
+                metadata[key] = capabilities
+            continue
         if str(value or "").strip():
             metadata[key] = str(value).strip()
     return metadata
@@ -326,6 +333,12 @@ def metadata_line_for_block(block: dict[str, Any], updates: dict[str, Any]) -> s
                 metadata.pop(key, None)
         elif key == "required_capabilities":
             capabilities = normalize_required_capabilities(value)
+            if capabilities:
+                metadata[key] = capabilities
+            else:
+                metadata.pop(key, None)
+        elif key == "target_capabilities":
+            capabilities = normalize_target_capabilities(value)
             if capabilities:
                 metadata[key] = capabilities
             else:
@@ -434,6 +447,7 @@ def add_todo_to_lines(
     action_kind: str | None = None,
     required_write_scopes: list[str] | None = None,
     required_capabilities: list[str] | None = None,
+    target_capabilities: list[str] | None = None,
     claimed_by: str | None = None,
 ) -> dict[str, Any]:
     todo_text = normalize_new_todo(text)
@@ -469,6 +483,7 @@ def add_todo_to_lines(
             action_kind=action_kind,
             required_write_scopes=required_write_scopes,
             required_capabilities=required_capabilities,
+            target_capabilities=target_capabilities,
             claimed_by=claimed_by,
         )
         todo_line = "\n".join([f"- [ ] {todo_text}", metadata_line] if metadata_line else [f"- [ ] {todo_text}"])
@@ -489,6 +504,8 @@ def add_todo_to_lines(
             updates["required_write_scopes"] = required_write_scopes
         if required_capabilities is not None:
             updates["required_capabilities"] = required_capabilities
+        if target_capabilities is not None:
+            updates["target_capabilities"] = target_capabilities
         if claimed_by:
             updates["claimed_by"] = claimed_by
         metadata_line = metadata_line_for_block(block, updates)
@@ -507,6 +524,7 @@ def add_todo_to_lines(
         "action_kind": action_kind,
         "required_write_scopes": normalize_required_write_scopes(required_write_scopes),
         "required_capabilities": normalize_required_capabilities(required_capabilities),
+        "target_capabilities": normalize_target_capabilities(target_capabilities),
         "claimed_by": normalize_todo_claimed_by(claimed_by),
     }
 
@@ -521,6 +539,7 @@ def add_goal_todo(
     action_kind: str | None = None,
     required_write_scopes: list[str] | None = None,
     required_capabilities: list[str] | None = None,
+    target_capabilities: list[str] | None = None,
     claimed_by: str | None = None,
     project: Path | None = None,
     state_file: Path | None = None,
@@ -557,6 +576,7 @@ def add_goal_todo(
             action_kind=action_kind,
             required_write_scopes=required_write_scopes,
             required_capabilities=required_capabilities,
+            target_capabilities=target_capabilities,
             claimed_by=effective_claimed_by,
         )
         added = bool(add_result["added"])
@@ -583,6 +603,7 @@ def add_goal_todo(
         "action_kind": add_result.get("action_kind"),
         "required_write_scopes": add_result.get("required_write_scopes"),
         "required_capabilities": add_result.get("required_capabilities"),
+        "target_capabilities": add_result.get("target_capabilities"),
         "claimed_by": add_result.get("claimed_by"),
         "state_file": str(resolved_state_file),
         "project": str(resolved_project) if resolved_project else None,
@@ -621,6 +642,7 @@ def apply_todo_update_to_lines(
     action_kind: str | None = None,
     required_write_scopes: list[str] | None = None,
     required_capabilities: list[str] | None = None,
+    target_capabilities: list[str] | None = None,
     claimed_by: str | None = None,
     clear_claim: bool = False,
     claim_only: bool = False,
@@ -668,6 +690,8 @@ def apply_todo_update_to_lines(
         updates["required_write_scopes"] = required_write_scopes
     if required_capabilities is not None:
         updates["required_capabilities"] = required_capabilities
+    if target_capabilities is not None:
+        updates["target_capabilities"] = target_capabilities
     if clear_claim:
         updates["claimed_by"] = None
     elif claimed_by:
@@ -696,6 +720,14 @@ def apply_todo_update_to_lines(
         "metadata_updated": metadata_updated,
         "changed": status_changed or text_changed or metadata_updated,
         "claimed_by": normalize_todo_claimed_by(effective_metadata.get("claimed_by")),
+        "task_class": effective_metadata.get("task_class"),
+        "action_kind": effective_metadata.get("action_kind"),
+        "required_capabilities": normalize_required_capabilities(
+            effective_metadata.get("required_capabilities")
+        ),
+        "target_capabilities": normalize_target_capabilities(
+            effective_metadata.get("target_capabilities")
+        ),
     }
 
 
@@ -714,6 +746,7 @@ def update_goal_todo(
     action_kind: str | None = None,
     required_write_scopes: list[str] | None = None,
     required_capabilities: list[str] | None = None,
+    target_capabilities: list[str] | None = None,
     claimed_by: str | None = None,
     clear_claim: bool = False,
     claim_only: bool = False,
@@ -753,6 +786,7 @@ def update_goal_todo(
             action_kind=action_kind,
             required_write_scopes=required_write_scopes,
             required_capabilities=required_capabilities,
+            target_capabilities=target_capabilities,
             claimed_by=effective_claimed_by,
             clear_claim=clear_claim,
             claim_only=claim_only,
@@ -1133,6 +1167,7 @@ def render_todo_markdown(payload: dict[str, Any]) -> str:
                 f"- todo_id: `{payload.get('todo_id')}`",
                 f"- status: `{payload.get('status')}`",
                 f"- required_capabilities: `{payload.get('required_capabilities')}`",
+                f"- target_capabilities: `{payload.get('target_capabilities')}`",
                 f"- claimed_by: `{payload.get('claimed_by')}`",
             ]
         )


### PR DESCRIPTION
## Summary
- Add explicit todo target_capabilities metadata and --target-capability CLI support.
- Keep required_capabilities as hard execution prerequisites, while target capabilities are projected as repair-mode outputs.
- Update capability gate so bridge-development todos remain runnable with capability_repair_mode=true instead of being blocked by the capability they are meant to build.
- Document the required/target split and extend focused smokes.

## Validation
- python3 -m py_compile goal_harness/todo_contract.py goal_harness/todos.py goal_harness/status.py goal_harness/quota.py goal_harness/cli.py examples/capability-gate-smoke.py examples/todo-cli-smoke.py
- python3 examples/capability-gate-smoke.py
- python3 examples/todo-cli-smoke.py
- git diff --check
- python3 -m goal_harness.cli check --scan-path goal_harness/todo_contract.py --scan-path goal_harness/todos.py --scan-path goal_harness/status.py --scan-path goal_harness/quota.py --scan-path goal_harness/cli.py --scan-path examples/capability-gate-smoke.py --scan-path examples/todo-cli-smoke.py --scan-path docs/status-data-contract.md --scan-path docs/interaction-pattern-catalog.md --scan-path docs/quota-allocation.md --scan-path docs/project-agent-todo-contract.md

Note: check reported only the existing duplicate run-index warning.