### PR TITLE
Fix repair-mode agent next-action selection

### DIFF
--- a/docs/interaction-pattern-catalog.md
+++ b/docs/interaction-pattern-catalog.md
@@ -1234,8 +1234,9 @@ For agent-scoped execution payloads, quota may also expose a narrow
 runnable queue: prefer `capability_gate.runnable_candidates`, then
 `agent_todo_summary.first_executable_items`, then
 `agent_todo_summary.executable_backlog_items`; filter out other-agent claimed
-todos; select the first current-agent claimed todo before any unclaimed
-fallback. This object is an agent-lane pointer, not a goal-level route rewrite,
+todos; select current-agent claimed todos before unclaimed fallback, and within
+that claim bucket prefer `capability_repair_mode=true` before ordinary runnable
+work of the same priority. This object is an agent-lane pointer, not a goal-level route rewrite,
 so it must include `preserves_goal_next_action=true`. Status may attach the same
 object for `--agent-id` observation, but it must not replace the item
 `recommended_action`, `project_asset.next_action`, owner, or waiting lane.

--- a/docs/project-agent-todo-contract.md
+++ b/docs/project-agent-todo-contract.md
@@ -136,6 +136,11 @@ the side agent's current slice for this turn; it does not overwrite the
 goal-level `Next Action` owned by the primary/global route. `goal-harness status
 --agent-id <side-agent-id>` may attach the same derived field to matching status
 queue items for observation, while leaving the project-level route unchanged.
+When a candidate has `target_capabilities` and missing target bridge
+capabilities, quota may mark it `capability_repair_mode=true`; scoped
+next-action selection should prefer that repair-mode candidate over ordinary
+runnable work in the same claim/priority bucket so capability-building todos do
+not require fragile active-state reordering.
 
 ```bash
 goal-harness configure-goal \

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -1020,6 +1020,12 @@ field must therefore carry `preserves_goal_next_action=true` and must not be
 treated as a project-level status overwrite. `status --agent-id` may reuse the
 same quota-derived object as item/project-asset observation data; consumers must
 render it as an agent-lane pointer, not as `recommended_action` replacement.
+Within a candidate source, selection is ordered by current-agent claim first,
+then `capability_repair_mode=true`, then priority/index. A repair-mode item
+therefore stays visible as the suggested agent-lane slice even when an older
+ordinary runnable P0 todo appears earlier in the active state; otherwise a todo
+that exists to build the missing capability can be starved by work that depends
+on that capability becoming reliable.
 When the resolved `agent_identity.role` is `side-agent`, `quota should-run`
 also enforces the workspace boundary. If the guard is being run from the
 registered primary checkout, from a non-git directory, or from an unrelated git

--- a/examples/work-lane-contract-smoke.py
+++ b/examples/work-lane-contract-smoke.py
@@ -1076,6 +1076,67 @@ def assert_side_agent_next_action_projects_without_stealing_goal_next_action() -
     assert primary_action not in guard["agent_lane_next_action"]["text"], guard
 
 
+def assert_agent_lane_next_action_prefers_capability_repair_candidate() -> None:
+    ordinary_action = (
+        "[P0] Run the already-launched full-suite polling lane and record compact results."
+    )
+    repair_action = (
+        "[P0] Repair benchmark treatment product-path parity by building the "
+        "benchmark_runner bridge itself before claiming uplift."
+    )
+    guard = build_quota_should_run(
+        status_payload(
+            status="target_capabilities_gate_merged",
+            next_action=ordinary_action,
+            coordination={
+                "primary_agent": "codex-main-control",
+                "registered_agents": ["codex-main-control"],
+            },
+            agent_todo_items=[
+                {
+                    "index": 1,
+                    "text": ordinary_action,
+                    "role": "agent",
+                    "status": "open",
+                    "priority": "P0",
+                    "task_class": "advancement_task",
+                    "claimed_by": "codex-main-control",
+                    "todo_id": "todo_full_suite",
+                },
+                {
+                    "index": 2,
+                    "text": repair_action,
+                    "role": "agent",
+                    "status": "open",
+                    "priority": "P0",
+                    "task_class": "advancement_task",
+                    "claimed_by": "codex-main-control",
+                    "todo_id": "todo_bridge_repair",
+                    "required_capabilities": ["shell"],
+                    "target_capabilities": ["benchmark_runner"],
+                },
+            ],
+        ),
+        goal_id=GOAL_ID,
+        agent_id="codex-main-control",
+    )
+    capability_gate = guard["capability_gate"]
+    repair_candidates = [
+        item
+        for item in capability_gate["runnable_candidates"]
+        if item.get("capability_repair_mode") is True
+    ]
+    assert [item["todo_id"] for item in repair_candidates] == ["todo_bridge_repair"], guard
+    next_action = guard["agent_lane_next_action"]
+    assert next_action["todo_id"] == "todo_bridge_repair", guard
+    assert next_action["source"] == "capability_gate.runnable_candidates", next_action
+    assert next_action["selected_by"] == "current_agent_claimed_todo", next_action
+    assert next_action["capability_repair_mode"] is True, next_action
+    assert next_action["missing_target_capabilities"] == ["benchmark_runner"], next_action
+    markdown = render_quota_should_run_markdown(guard)
+    assert "agent_lane_next_action: todo_id=todo_bridge_repair" in markdown, markdown
+
+
 def main() -> int:
     assert_dependency_monitor_requires_advancement()
     assert_primary_status_stays_advancement_lane()
@@ -1099,6 +1160,7 @@ def main() -> int:
     assert_launched_external_observation_does_not_preempt_advancement_backlog()
     assert_launch_then_poll_todo_without_handle_routes_to_advancement()
     assert_side_agent_next_action_projects_without_stealing_goal_next_action()
+    assert_agent_lane_next_action_prefers_capability_repair_candidate()
     print("work-lane-contract-smoke ok")
     return 0
 

--- a/goal_harness/quota.py
+++ b/goal_harness/quota.py
@@ -1861,8 +1861,15 @@ def _agent_lane_next_action(
         )
     )
 
+    def lane_candidate_sort_key(raw_item: dict[str, Any]) -> tuple[int, int, int, int]:
+        claimed_by = normalize_todo_claimed_by(raw_item.get("claimed_by"))
+        claim_rank = 0 if claimed_by == agent_id else 1
+        repair_rank = 0 if raw_item.get("capability_repair_mode") is True else 1
+        return (claim_rank, repair_rank, _todo_priority_rank(raw_item), _todo_index_rank(raw_item))
+
     seen: set[tuple[str, str]] = set()
     for source, raw_items in candidate_sources:
+        source_candidates: list[dict[str, Any]] = []
         for raw_item in raw_items:
             if not isinstance(raw_item, dict):
                 continue
@@ -1876,16 +1883,28 @@ def _agent_lane_next_action(
             identity = (str(raw_item.get("todo_id") or ""), text)
             if identity in seen:
                 continue
-            seen.add(identity)
             claimed_by = normalize_todo_claimed_by(raw_item.get("claimed_by"))
             if claimed_by and claimed_by != agent_id:
                 continue
+            seen.add(identity)
+            source_candidates.append(raw_item)
+        for raw_item in sorted(source_candidates, key=lane_candidate_sort_key):
+            text = _protocol_action_text(raw_item.get("text"), limit=500)
+            claimed_by = normalize_todo_claimed_by(raw_item.get("claimed_by"))
             selected_by = (
                 "current_agent_claimed_todo"
                 if claimed_by == agent_id
                 else "unclaimed_todo"
             )
             payload = _compact_todo_summary_item(raw_item, text=text)
+            for key in (
+                "missing_capabilities",
+                "missing_target_capabilities",
+                "capability_action",
+                "capability_repair_mode",
+            ):
+                if raw_item.get(key) is not None:
+                    payload[key] = raw_item.get(key)
             payload.update(
                 {
                     "schema_version": AGENT_LANE_NEXT_ACTION_SCHEMA_VERSION,


### PR DESCRIPTION
## Summary
- prefer current-agent capability repair candidates when deriving `agent_lane_next_action`
- carry repair-mode capability fields into the derived next-action payload
- document the repair-mode ordering contract for status/quota consumers

## Validation
- `python3 examples/work-lane-contract-smoke.py`
- `python3 examples/capability-gate-smoke.py`
- `python3 -m py_compile goal_harness/quota.py examples/work-lane-contract-smoke.py`
- `python3 -m goal_harness.cli check --scan-path goal_harness/quota.py --scan-path examples/work-lane-contract-smoke.py --scan-path docs/status-data-contract.md --scan-path docs/interaction-pattern-catalog.md --scan-path docs/project-agent-todo-contract.md`
- `git diff --check`

## Boundary
No raw benchmark logs, trajectories, verifier output, credentials, local state, or private artifacts are included.