### PR TITLE
Add benchmark case lifecycle contract

### DIFF
--- a/docs/benchmark-developer-workflow.md
+++ b/docs/benchmark-developer-workflow.md
@@ -1110,6 +1110,19 @@ is compared: baseline is native Goal mode; test is prompt-driven polling; a
 single access packet without scheduled controller trace is only
 `packet_only_observation`.
 
+For the test arm, also require the shared per-case lifecycle contract from
+`goal_harness.benchmark_case_state`. Each benchmark/case/arm must have an
+isolated `benchmark_case_lifecycle_contract` with
+`case_isolation_scope=per_benchmark_case_arm`, a canonical
+`/app/.codex/goals/<case-arm>/ACTIVE_GOAL_STATE.md` state path, and the public
+lifecycle sequence `quota_should_run -> todo_claim_or_update ->
+bounded_agent_turn -> validation_or_case_result -> refresh_state ->
+quota_spend`. Harbor-family agents inject this contract into the Goal Harness
+access packet and compact metadata; other adapters should reuse the same
+contract rather than inventing benchmark-specific state markers. A runner that
+only performs internal prompt polling without this lifecycle remains
+`packet_only_observation` or incomplete treatment evidence.
+
 `codex exec` is still useful as a tiny connectivity smoke on the cloud host,
 but a successful `codex exec` run is not by itself a Codex Goal baseline. Do not
 rename a polling loop, resume loop, or prompt-prefixed `/goal` experiment into a

--- a/examples/benchmark-case-active-state-contract-smoke.py
+++ b/examples/benchmark-case-active-state-contract-smoke.py
@@ -26,11 +26,15 @@ from goal_harness.benchmark import (  # noqa: E402
 from goal_harness.benchmark_case_state import (  # noqa: E402
     BENCHMARK_CASE_ACTIVE_STATE_PROOF_FIELDS,
     BENCHMARK_CASE_ACTIVE_STATE_SCHEMA_VERSION,
+    BENCHMARK_CASE_LIFECYCLE_SCHEMA_VERSION,
     benchmark_case_active_state_init_contract,
     benchmark_case_active_state_path,
     benchmark_case_active_state_seed_text,
     benchmark_case_active_state_write_command,
+    benchmark_case_arm_goal_id,
     benchmark_case_goal_id,
+    benchmark_case_lifecycle_contract,
+    render_benchmark_case_lifecycle_contract_lines,
 )
 
 
@@ -121,6 +125,38 @@ def test_seed_write_command_uses_canonical_path() -> None:
     assert "/Users/" not in command
 
 
+def test_case_lifecycle_contract_is_per_case_arm() -> None:
+    contract = benchmark_case_lifecycle_contract(
+        benchmark_id="swe-marathon",
+        case_id="find-network-alignments",
+        arm_id="codex_goal_harness_treatment",
+        max_rounds=5,
+    )
+    expected_goal_id = benchmark_case_arm_goal_id(
+        benchmark_id="swe-marathon",
+        case_id="find-network-alignments",
+        arm_id="codex_goal_harness_treatment",
+    )
+    assert contract["schema_version"] == BENCHMARK_CASE_LIFECYCLE_SCHEMA_VERSION
+    assert contract["case_isolation_scope"] == "per_benchmark_case_arm"
+    assert contract["benchmark_case_goal_id"] == expected_goal_id
+    assert contract["case_state_path"] == benchmark_case_active_state_path(expected_goal_id)
+    assert contract["source_of_truth"] == "case_active_state_and_rollout_event_log"
+    assert "quota_should_run" in contract["required_lifecycle_steps"]
+    assert "todo_claim_or_update" in contract["required_lifecycle_steps"]
+    assert "refresh_state" in contract["required_lifecycle_steps"]
+    assert "quota_spend" in contract["required_lifecycle_steps"]
+    assert "compact_case_result" in contract["required_rollout_event_kinds"]
+    assert contract["runner_internal_prompt_polling_only_allowed"] is False
+    assert contract["surrogate_state_files_allowed"] is False
+    lines = render_benchmark_case_lifecycle_contract_lines(contract)
+    rendered = "\n".join(lines)
+    assert "benchmark_case_lifecycle_contract:" in rendered
+    assert "case_isolation_scope: per_benchmark_case_arm" in rendered
+    assert "/app/.codex/goals/" in rendered
+    assert "/Users/" not in rendered
+
+
 def test_ale_launch_packet_reuses_shared_contract() -> None:
     packet = build_agents_last_exam_local_launch_packet(
         source_root=None,
@@ -156,5 +192,6 @@ if __name__ == "__main__":
     test_shared_contract_for_current_benchmark_routes()
     test_seed_text_uses_real_goal_harness_active_state_shape()
     test_seed_write_command_uses_canonical_path()
+    test_case_lifecycle_contract_is_per_case_arm()
     test_ale_launch_packet_reuses_shared_contract()
     test_terminal_bench_access_packet_fixture_reuses_shared_contract()

--- a/examples/harbor-host-codex-goal-agent-smoke.py
+++ b/examples/harbor-host-codex-goal-agent-smoke.py
@@ -76,6 +76,12 @@ def main() -> int:
     assert "do_not_upload_or_submit_to_leaderboard: true" in treatment_packet
     assert "benchmark_loop_contract:" in treatment_packet
     assert "protocol_id: packet_only_observation" in treatment_packet
+    assert "benchmark_case_lifecycle_contract:" in treatment_packet
+    assert "case_isolation_scope: per_benchmark_case_arm" in treatment_packet
+    assert "benchmark_case_goal_id: swe-marathon-current-case-codex-goal-harness-treatment-case" in treatment_packet
+    assert "case_state_path: /app/.codex/goals/swe-marathon-current-case-codex-goal-harness-treatment-case/ACTIVE_GOAL_STATE.md" in treatment_packet
+    assert "required_lifecycle_steps: quota_should_run,todo_claim_or_update,bounded_agent_turn,validation_or_case_result,refresh_state,quota_spend" in treatment_packet
+    assert "required_rollout_event_kinds: quota_should_run,todo_claim,todo_update,validation,refresh_state,quota_spend,compact_case_result,failure_attribution" in treatment_packet
     assert "strict_goal_harness_treatment_claim_allowed: false" in treatment_packet
     assert "goal_harness_treatment_claim_blocker:" in treatment_packet
     polling_packet = module.build_goal_harness_access_packet(
@@ -154,6 +160,9 @@ def main() -> int:
         assert treatment_agent.goal_harness_cli_bridge_enabled is True
         assert treatment_agent.goal_harness_experiment_protocol == "packet_only_observation"
         assert treatment_agent.goal_harness_prompt_polling_rounds == 1
+        assert treatment_agent.goal_harness_benchmark_id == "swe-marathon"
+        assert treatment_agent.goal_harness_case_id == "current-case"
+        assert treatment_agent.goal_harness_arm_id == "codex_goal_harness_treatment"
         polling_agent = module.HarborHostCodexGoalAgent(
             logs_dir=Path(tmp) / "polling-logs",
             goal_surface="app_server",
@@ -161,8 +170,10 @@ def main() -> int:
             goal_harness_access_packet_mode="compact",
             goal_harness_experiment_protocol="max5_blind_loop_no_feedback",
             goal_harness_max_rounds=5,
+            goal_harness_case_id="find-network-alignments",
         )
         assert polling_agent.goal_harness_prompt_polling_rounds == 5
+        assert polling_agent.goal_harness_case_id == "find-network-alignments"
 
     print("harbor host Codex Goal agent smoke passed")
     return 0

--- a/goal_harness/benchmark_case_state.py
+++ b/goal_harness/benchmark_case_state.py
@@ -14,6 +14,8 @@ BENCHMARK_CASE_ACTIVE_STATE_INIT_FLOW = (
 )
 BENCHMARK_CASE_ACTIVE_STATE_INIT_STAGE = "before_codex_worker_start"
 BENCHMARK_CASE_ACTIVE_STATE_STATUS_FIELD = "case_goal_state_init_status"
+BENCHMARK_CASE_LIFECYCLE_SCHEMA_VERSION = "goal_harness_benchmark_case_lifecycle_v0"
+BENCHMARK_CASE_LIFECYCLE_SOURCE_OF_TRUTH = "case_active_state_and_rollout_event_log"
 BENCHMARK_CASE_ACTIVE_STATE_PROOF_FIELDS = (
     "case_goal_state_init_required",
     "case_goal_state_initialized_before_agent",
@@ -21,11 +23,45 @@ BENCHMARK_CASE_ACTIVE_STATE_PROOF_FIELDS = (
     "case_goal_state_schema_version",
     "case_goal_state_path",
 )
+BENCHMARK_CASE_LIFECYCLE_STEPS = (
+    "quota_should_run",
+    "todo_claim_or_update",
+    "bounded_agent_turn",
+    "validation_or_case_result",
+    "refresh_state",
+    "quota_spend",
+)
+BENCHMARK_CASE_LIFECYCLE_ROLLOUT_EVENTS = (
+    "quota_should_run",
+    "todo_claim",
+    "todo_update",
+    "validation",
+    "refresh_state",
+    "quota_spend",
+    "compact_case_result",
+    "failure_attribution",
+)
 
 
 def benchmark_case_goal_id(benchmark_id: str) -> str:
     slug = re.sub(r"[^a-z0-9]+", "-", benchmark_id.lower()).strip("-")
     return f"{slug or 'benchmark'}-case"
+
+
+def benchmark_case_arm_goal_id(
+    *,
+    benchmark_id: str,
+    case_id: str,
+    arm_id: str,
+) -> str:
+    """Return a canonical per-benchmark/case/arm Goal Harness goal id."""
+
+    slug = re.sub(
+        r"[^a-z0-9]+",
+        "-",
+        f"{benchmark_id}-{case_id}-{arm_id}".lower(),
+    ).strip("-")
+    return f"{slug or 'benchmark-case-arm'}-case"
 
 
 def benchmark_case_active_state_path(
@@ -63,6 +99,86 @@ def benchmark_case_active_state_init_contract(
         "raw_task_text_required_for_init": False,
         "local_paths_recorded": False,
     }
+
+
+def benchmark_case_lifecycle_contract(
+    *,
+    benchmark_id: str,
+    case_id: str,
+    arm_id: str,
+    goal_id: str | None = None,
+    case_state_path: str | None = None,
+    max_rounds: int = 5,
+) -> dict[str, object]:
+    """Return the shared product-path lifecycle contract for a benchmark arm.
+
+    This contract is public-safe and deliberately contains only ids, booleans,
+    and lifecycle/event names. It lets benchmark adapters prove that a treatment
+    arm uses an isolated Goal Harness state path and the real quota/todo/
+    validation/refresh/spend lifecycle instead of a runner-internal surrogate.
+    """
+
+    resolved_goal_id = goal_id or benchmark_case_arm_goal_id(
+        benchmark_id=benchmark_id,
+        case_id=case_id,
+        arm_id=arm_id,
+    )
+    resolved_path = case_state_path or benchmark_case_active_state_path(
+        resolved_goal_id
+    )
+    rounds = max_rounds if isinstance(max_rounds, int) and max_rounds > 0 else 5
+    return {
+        "schema_version": BENCHMARK_CASE_LIFECYCLE_SCHEMA_VERSION,
+        "benchmark_id": benchmark_id,
+        "case_id": case_id,
+        "arm_id": arm_id,
+        "case_isolation_scope": "per_benchmark_case_arm",
+        "benchmark_case_goal_id": resolved_goal_id,
+        "case_state_path": resolved_path,
+        "case_state_init_required_before_worker": True,
+        "source_of_truth": BENCHMARK_CASE_LIFECYCLE_SOURCE_OF_TRUTH,
+        "required_lifecycle_steps": list(BENCHMARK_CASE_LIFECYCLE_STEPS),
+        "required_rollout_event_kinds": list(BENCHMARK_CASE_LIFECYCLE_ROLLOUT_EVENTS),
+        "max_rounds_budget": rounds,
+        "runner_internal_prompt_polling_only_allowed": False,
+        "surrogate_state_files_allowed": False,
+        "official_feedback_forwarded": False,
+        "raw_task_text_required_for_lifecycle": False,
+        "local_paths_recorded": False,
+    }
+
+
+def render_benchmark_case_lifecycle_contract_lines(
+    contract: dict[str, object],
+) -> list[str]:
+    """Render a compact text packet for a case lifecycle contract."""
+
+    fields = (
+        "schema_version",
+        "benchmark_id",
+        "case_id",
+        "arm_id",
+        "case_isolation_scope",
+        "benchmark_case_goal_id",
+        "case_state_path",
+        "source_of_truth",
+        "max_rounds_budget",
+        "runner_internal_prompt_polling_only_allowed",
+        "surrogate_state_files_allowed",
+        "official_feedback_forwarded",
+    )
+    lines = ["benchmark_case_lifecycle_contract:"]
+    for field in fields:
+        value = contract.get(field)
+        if value is None or value == "":
+            continue
+        rendered = str(value).lower() if isinstance(value, bool) else str(value)
+        lines.append(f"  {field}: {rendered}")
+    for field in ("required_lifecycle_steps", "required_rollout_event_kinds"):
+        value = contract.get(field)
+        if isinstance(value, list) and value:
+            lines.append(f"  {field}: {','.join(str(item) for item in value)}")
+    return lines
 
 
 def benchmark_case_active_state_seed_text(

--- a/scripts/harbor_host_codex_goal_agent.py
+++ b/scripts/harbor_host_codex_goal_agent.py
@@ -34,6 +34,10 @@ from codex_app_server_goal_driver import (
     start_codex_app_server_goal_followup_turn,
     start_codex_app_server_goal_turn,
 )
+from goal_harness.benchmark_case_state import (
+    benchmark_case_lifecycle_contract,
+    render_benchmark_case_lifecycle_contract_lines,
+)
 from goal_harness.benchmark_core.loop_protocol import (
     BLIND_LOOP_DEFAULT_MAX_ROUNDS,
     GOAL_HARNESS_PACKET_ONLY_OBSERVATION_ROUTE,
@@ -199,6 +203,9 @@ def build_goal_harness_access_packet(
     classification: str = "swe_marathon_codex_goal_harness_treatment",
     experiment_protocol: str = PACKET_ONLY_OBSERVATION_PROTOCOL_ID,
     max_rounds: int = BLIND_LOOP_DEFAULT_MAX_ROUNDS,
+    benchmark_id: str = "swe-marathon",
+    case_id: str = "current-case",
+    arm_id: str = "codex_goal_harness_treatment",
 ) -> str:
     """Build a public-safe Goal Harness access packet for Harbor/SWE tasks."""
 
@@ -227,6 +234,12 @@ def build_goal_harness_access_packet(
     claim = classify_goal_harness_treatment_claim(
         {"benchmark_loop_contract": loop_contract}
     )
+    case_lifecycle = benchmark_case_lifecycle_contract(
+        benchmark_id=benchmark_id,
+        case_id=case_id,
+        arm_id=arm_id,
+        max_rounds=max_rounds,
+    )
 
     lines = [
         "Goal Harness Access Packet V0",
@@ -247,6 +260,7 @@ def build_goal_harness_access_packet(
         f"goal_harness_treatment_claim_blocker: {claim['goal_harness_treatment_claim_blocker']}",
     ]
     lines.extend(render_loop_contract_packet_lines(loop_contract))
+    lines.extend(render_benchmark_case_lifecycle_contract_lines(case_lifecycle))
     if cli_enabled:
         lines.extend(
             [
@@ -299,6 +313,9 @@ class HarborHostCodexGoalAgent(BaseAgent):
         goal_harness_experiment_protocol: str = PACKET_ONLY_OBSERVATION_PROTOCOL_ID,
         goal_harness_max_rounds: str | int = BLIND_LOOP_DEFAULT_MAX_ROUNDS,
         goal_harness_prompt_polling_rounds: str | int = "auto",
+        goal_harness_benchmark_id: str = "swe-marathon",
+        goal_harness_case_id: str = "current-case",
+        goal_harness_arm_id: str = "codex_goal_harness_treatment",
         startup_delay_sec: str | int | float = 5,
         poll_interval_sec: str | int | float = 5,
         **kwargs: Any,
@@ -324,6 +341,9 @@ class HarborHostCodexGoalAgent(BaseAgent):
         self.goal_harness_classification = goal_harness_classification
         self.goal_harness_experiment_protocol = goal_harness_experiment_protocol
         self.goal_harness_max_rounds = int(goal_harness_max_rounds)
+        self.goal_harness_benchmark_id = goal_harness_benchmark_id
+        self.goal_harness_case_id = goal_harness_case_id
+        self.goal_harness_arm_id = goal_harness_arm_id
         if str(goal_harness_prompt_polling_rounds).strip().lower() == "auto":
             self.goal_harness_prompt_polling_rounds = (
                 self.goal_harness_max_rounds
@@ -451,10 +471,19 @@ class HarborHostCodexGoalAgent(BaseAgent):
             classification=self.goal_harness_classification,
             experiment_protocol=self.goal_harness_experiment_protocol,
             max_rounds=self.goal_harness_max_rounds,
+            benchmark_id=self.goal_harness_benchmark_id,
+            case_id=self.goal_harness_case_id,
+            arm_id=self.goal_harness_arm_id,
         )
         loop_contract: dict[str, Any] = {}
         treatment_claim: dict[str, Any] = {}
         if goal_harness_access_packet:
+            case_lifecycle_contract = benchmark_case_lifecycle_contract(
+                benchmark_id=self.goal_harness_benchmark_id,
+                case_id=self.goal_harness_case_id,
+                arm_id=self.goal_harness_arm_id,
+                max_rounds=self.goal_harness_max_rounds,
+            )
             loop_route = (
                 GOAL_HARNESS_PROMPT_POLLING_TEST_ROUTE
                 if self.goal_harness_experiment_protocol
@@ -469,6 +498,8 @@ class HarborHostCodexGoalAgent(BaseAgent):
             treatment_claim = classify_goal_harness_treatment_claim(
                 {"benchmark_loop_contract": loop_contract}
             )
+        else:
+            case_lifecycle_contract = {}
         prompt = build_host_goal_prompt(
             instruction=instruction,
             bridge_command=bridge,
@@ -567,6 +598,7 @@ class HarborHostCodexGoalAgent(BaseAgent):
                             self.goal_harness_prompt_polling_rounds
                         ),
                         "benchmark_loop_contract": loop_contract,
+                        "benchmark_case_lifecycle_contract": case_lifecycle_contract,
                         **treatment_claim,
                     }
                 )
@@ -682,6 +714,7 @@ class HarborHostCodexGoalAgent(BaseAgent):
                     "prompt_polling_enabled": True,
                     "prompt_polling_rounds_completed": current_round,
                     "benchmark_loop_contract": loop_contract,
+                    "benchmark_case_lifecycle_contract": case_lifecycle_contract,
                     **treatment_claim,
                 }
                 return
@@ -709,6 +742,7 @@ class HarborHostCodexGoalAgent(BaseAgent):
                                 goal_harness_access_packet
                             ),
                             "benchmark_loop_contract": loop_contract,
+                            "benchmark_case_lifecycle_contract": case_lifecycle_contract,
                             **treatment_claim,
                         }
                         return
@@ -729,6 +763,7 @@ class HarborHostCodexGoalAgent(BaseAgent):
                     goal_harness_access_packet
                 ),
                 "benchmark_loop_contract": loop_contract,
+                "benchmark_case_lifecycle_contract": case_lifecycle_contract,
                 **treatment_claim,
             }
             return
@@ -784,6 +819,7 @@ class HarborHostCodexGoalAgent(BaseAgent):
                         goal_harness_access_packet
                     ),
                     "benchmark_loop_contract": loop_contract,
+                    "benchmark_case_lifecycle_contract": case_lifecycle_contract,
                     **treatment_claim,
                 }
                 return
@@ -799,5 +835,6 @@ class HarborHostCodexGoalAgent(BaseAgent):
             "goal_harness_mode": self.goal_harness_mode,
             "goal_harness_access_packet_injected": bool(goal_harness_access_packet),
             "benchmark_loop_contract": loop_contract,
+            "benchmark_case_lifecycle_contract": case_lifecycle_contract,
             **treatment_claim,
         }


### PR DESCRIPTION
## Summary
- add a public-safe per benchmark/case/arm Goal Harness lifecycle contract with canonical case goal/state naming
- inject the contract into Harbor/SWE host agent access packets and compact metadata
- document the prompt-polling treatment gate so runner-internal polling alone is incomplete evidence

## Validation
- python3 examples/benchmark-case-active-state-contract-smoke.py
- python3 examples/harbor-host-codex-goal-agent-smoke.py
- python3 examples/benchmark-codex-app-parity-posthoc-smoke.py
- python3 -m py_compile goal_harness/benchmark_case_state.py scripts/harbor_host_codex_goal_agent.py examples/benchmark-case-active-state-contract-smoke.py examples/harbor-host-codex-goal-agent-smoke.py
- goal-harness check --scan-path goal_harness/benchmark_case_state.py --scan-path scripts/harbor_host_codex_goal_agent.py --scan-path examples/benchmark-case-active-state-contract-smoke.py --scan-path examples/harbor-host-codex-goal-agent-smoke.py --scan-path docs/benchmark-developer-workflow.md
- git diff --check origin/main..HEAD

## Boundary
- no benchmark jobs launched
- no raw task text, trajectories, verifier output, credentials, local state, or private paths included
- secret/private scan only found policy text and negative assertions

## Residual risk
- the known goal-harness-meta duplicate index warning remains unrelated to this patch
