### PR TITLE
Align quota action with selected agent lane

### DIFF
--- a/examples/work-lane-contract-smoke.py
+++ b/examples/work-lane-contract-smoke.py
@@ -1127,6 +1127,7 @@ def assert_agent_lane_next_action_prefers_capability_repair_candidate() -> None:
         if item.get("capability_repair_mode") is True
     ]
     assert [item["todo_id"] for item in repair_candidates] == ["todo_bridge_repair"], guard
+    assert guard["recommended_action"] == repair_action, guard
     next_action = guard["agent_lane_next_action"]
     assert next_action["todo_id"] == "todo_bridge_repair", guard
     assert next_action["source"] == "capability_gate.runnable_candidates", next_action

--- a/goal_harness/quota.py
+++ b/goal_harness/quota.py
@@ -1946,6 +1946,23 @@ def _selected_recommended_action(
     return raw_action
 
 
+def _selected_action_with_agent_lane(
+    selected_action: Any,
+    *,
+    agent_lane_next_action: dict[str, Any] | None,
+) -> Any:
+    if not isinstance(agent_lane_next_action, dict):
+        return selected_action
+    if (
+        agent_lane_next_action.get("source") != "capability_gate.runnable_candidates"
+        or agent_lane_next_action.get("confidence") != "selected"
+        or agent_lane_next_action.get("selected_by") != "current_agent_claimed_todo"
+    ):
+        return selected_action
+    lane_text = str(agent_lane_next_action.get("text") or "").strip()
+    return lane_text or selected_action
+
+
 def _normalize_action_for_compare(value: Any) -> str:
     text = re.sub(r"\s+", " ", str(value or "")).strip().lower()
     text = re.sub(r"^(?:agent|user|owner|codex)\s*:\s*", "", text)
@@ -4916,6 +4933,10 @@ def build_quota_should_run(
             agent_identity=agent_identity,
             agent_todo_summary=agent_todo_summary,
             capability_gate=capability_gate,
+        )
+        selected_recommended_action = _selected_action_with_agent_lane(
+            selected_recommended_action,
+            agent_lane_next_action=agent_lane_next_action,
         )
         state_action_projection_warning = _state_action_projection_warning(
             item,


### PR DESCRIPTION
## Summary
- when capability-gate runnable candidates select the current agent's claimed todo, mirror that selected agent-lane text into quota recommended_action
- keep candidate-only agent-lane projections separate so status can still preserve the global next action
- add a focused work-lane smoke assertion for repair-mode candidate selection

## Validation
- python3 examples/work-lane-contract-smoke.py
- python3 examples/quota-plan-smoke.py
- python3 examples/status-markdown-smoke.py
- python3 -m py_compile goal_harness/quota.py examples/work-lane-contract-smoke.py
- goal-harness check --scan-path goal_harness/quota.py --scan-path examples/work-lane-contract-smoke.py
- git diff --check
- goal-harness-canary quota should-run live probe for goal-harness-meta shows recommended_action aligned with todo_4deab280e20e

## Boundary
- no benchmark jobs launched
- no private state, raw logs, trajectories, verifier output, credentials, or local paths included

## Residual risk
- existing duplicate-index warning remains unrelated
