### PR TITLE
Inject Terminal-Bench case lifecycle packet

### DIFF
--- a/docs/benchmark-developer-workflow.md
+++ b/docs/benchmark-developer-workflow.md
@@ -771,6 +771,28 @@ case container while the container remains responsible for task files and
 official tests. The TUI `/goal` surface is a manual fallback only; do not count
 it as the default baseline when app-server `thread/goal/set`,
 `thread/goal/get`, and `turn/start` are available.
+
+For a Goal Harness prompt-polling treatment arm, keep the same host agent and
+explicitly request the case lifecycle packet:
+
+```bash
+tb run \
+  ... \
+  --agent-import-path terminal_bench_host_codex_goal_agent:HostCodexGoalAgent \
+  --agent-kwarg goal_surface=app_server \
+  --agent-kwarg goal_timeout_sec=1200 \
+  --agent-kwarg goal_harness_mode=codex_goal_harness \
+  --agent-kwarg goal_harness_access_packet_mode=compact \
+  --agent-kwarg goal_harness_case_id=<task-id> \
+  --agent-kwarg goal_harness_arm_id=goal_harness_prompt_polling_test \
+  --agent-kwarg goal_harness_max_rounds=5
+```
+
+This injects the shared `benchmark_case_lifecycle_contract` into the worker
+prompt and compact app-server metadata. A Terminal-Bench treatment run remains
+incomplete evidence until the per-case Goal Harness lifecycle can be observed:
+`quota_should_run`, `todo_claim_or_update`, bounded work/continuation, official
+case result or validation, `refresh_state`, and `quota_spend`.
 The app-server host agent treats the benchmark completion marker and official
 verifier as the success path. It drains app-server events opportunistically and
 writes a compact turn file with `turn_completed_observed`,

--- a/examples/terminal-bench-host-codex-goal-agent-smoke.py
+++ b/examples/terminal-bench-host-codex-goal-agent-smoke.py
@@ -54,6 +54,44 @@ def main() -> int:
     assert "/Users/" not in prompt
     assert "/data/goal-harness-bench" not in prompt
     assert "/root/goal-harness-bench" not in prompt
+    assert "benchmark_case_lifecycle_contract:" not in prompt
+
+    lifecycle_packet, lifecycle_contract = module.build_goal_harness_case_lifecycle_packet(
+        mode="codex_goal_harness",
+        packet_mode="compact",
+        benchmark_id="terminal-bench",
+        case_id="build-cython-ext",
+        arm_id="goal_harness_prompt_polling_test",
+        max_rounds=5,
+    )
+    assert lifecycle_contract is not None
+    assert "terminal_bench_goal_harness_case_lifecycle_packet_v0:" in lifecycle_packet
+    assert "packet_mode: compact" in lifecycle_packet
+    assert "benchmark_family: harbor" in lifecycle_packet
+    assert "benchmark_case_lifecycle_contract:" in lifecycle_packet
+    assert "benchmark_id: terminal-bench" in lifecycle_packet
+    assert "case_id: build-cython-ext" in lifecycle_packet
+    assert "arm_id: goal_harness_prompt_polling_test" in lifecycle_packet
+    assert (
+        "benchmark_case_goal_id: terminal-bench-build-cython-ext-goal-harness-prompt-polling-test-case"
+        in lifecycle_packet
+    )
+    assert "case_state_path: /app/.codex/goals/" in lifecycle_packet
+    assert "required_lifecycle_steps: quota_should_run,todo_claim_or_update,bounded_agent_turn,validation_or_case_result,refresh_state,quota_spend" in lifecycle_packet
+    assert "runner_internal_prompt_polling_only_allowed: false" in lifecycle_packet
+    assert "/Users/" not in lifecycle_packet
+
+    treatment_prompt = module.build_host_goal_prompt(
+        container_name="example-container",
+        instruction="Synthetic instruction placeholder.",
+        marker_path=marker,
+        task_workdir="/app",
+        goal_harness_case_lifecycle_packet=lifecycle_packet,
+    )
+    assert "Goal Harness case lifecycle packet:" in treatment_prompt
+    assert "benchmark_case_lifecycle_contract:" in treatment_prompt
+    assert "official Terminal-Bench scorer authoritative" in treatment_prompt
+    assert "/Users/" not in treatment_prompt
 
     agent = module.HostCodexGoalAgent(
         goal_timeout_sec="7",
@@ -71,6 +109,25 @@ def main() -> int:
     assert agent.app_server_response_timeout_sec == 4.0
     assert str(agent.work_root) == "/tmp/goal-harness-terminal-bench"
     assert agent.network_bootstrap_script is None
+    assert agent.goal_harness_mode == "codex_goal_mode_baseline"
+    assert agent.goal_harness_access_packet_mode == "none"
+    assert agent.goal_harness_benchmark_id == "terminal-bench"
+    assert agent.goal_harness_case_id == "current-case"
+    assert agent.goal_harness_arm_id == "codex_goal_harness_treatment"
+    assert agent.goal_harness_max_rounds == 5
+
+    treatment_agent = module.HostCodexGoalAgent(
+        goal_surface="app_server",
+        goal_harness_mode="codex_goal_harness",
+        goal_harness_access_packet_mode="compact",
+        goal_harness_case_id="build-cython-ext",
+        goal_harness_arm_id="goal_harness_prompt_polling_test",
+        goal_harness_max_rounds="5",
+    )
+    assert treatment_agent.goal_harness_mode == "codex_goal_harness"
+    assert treatment_agent.goal_harness_access_packet_mode == "compact"
+    assert treatment_agent.goal_harness_case_id == "build-cython-ext"
+    assert treatment_agent.goal_harness_arm_id == "goal_harness_prompt_polling_test"
 
     no_wait_agent = module.HostCodexGoalAgent(
         goal_surface="app_server",

--- a/scripts/terminal_bench_host_codex_goal_agent.py
+++ b/scripts/terminal_bench_host_codex_goal_agent.py
@@ -21,14 +21,20 @@ from pathlib import Path
 from typing import Any
 
 SCRIPT_DIR = Path(__file__).resolve().parent
-if str(SCRIPT_DIR) not in sys.path:
-    sys.path.insert(0, str(SCRIPT_DIR))
+REPO_ROOT = SCRIPT_DIR.parent
+for _path in (SCRIPT_DIR, REPO_ROOT):
+    if str(_path) not in sys.path:
+        sys.path.insert(0, str(_path))
 
 from codex_app_server_goal_driver import (
     CodexAppServerGoalDriverError,
     compact_turn_metadata,
     observe_codex_app_server_goal_turn,
     start_codex_app_server_goal_turn,
+)
+from goal_harness.benchmark_case_state import (
+    benchmark_case_lifecycle_contract,
+    render_benchmark_case_lifecycle_contract_lines,
 )
 
 
@@ -83,13 +89,14 @@ def build_host_goal_prompt(
     instruction: str,
     marker_path: Path,
     task_workdir: str = "/app",
+    goal_harness_case_lifecycle_packet: str = "",
 ) -> str:
     marker_cmd = f"touch {shlex.quote(str(marker_path))}"
     docker_exec = (
         f"docker exec {shlex.quote(container_name)} "
         f"bash -lc 'cd {shlex.quote(task_workdir)} && <command>'"
     )
-    return f"""
+    prompt = f"""
 You are solving a Terminal-Bench task on this host using native Codex Goal mode.
 
 Task container name: {container_name}
@@ -108,6 +115,43 @@ Task instruction:
 When and only when the task is complete, run this exact host command so the harness can observe completion:
 {marker_cmd}
 """.strip()
+    packet = goal_harness_case_lifecycle_packet.strip()
+    if packet:
+        prompt += (
+            "\n\nGoal Harness case lifecycle packet:\n"
+            f"{packet}\n\n"
+            "Use this packet as observational control-plane context. Keep the official "
+            "Terminal-Bench scorer authoritative, do not expose reward or verifier output "
+            "during the agent loop, and do not rely on runner-internal polling alone when "
+            "claiming Goal Harness treatment evidence."
+        )
+    return prompt
+
+
+def build_goal_harness_case_lifecycle_packet(
+    *,
+    mode: str = "codex_goal_mode_baseline",
+    packet_mode: str = "none",
+    benchmark_id: str = "terminal-bench",
+    case_id: str = "current-case",
+    arm_id: str = "codex_goal_harness_treatment",
+    max_rounds: int = 5,
+) -> tuple[str, dict[str, object] | None]:
+    if mode != "codex_goal_harness" or packet_mode == "none":
+        return "", None
+    contract = benchmark_case_lifecycle_contract(
+        benchmark_id=benchmark_id,
+        case_id=case_id,
+        arm_id=arm_id,
+        max_rounds=max_rounds,
+    )
+    lines = [
+        "terminal_bench_goal_harness_case_lifecycle_packet_v0:",
+        f"  packet_mode: {packet_mode}",
+        "  benchmark_family: harbor",
+    ]
+    lines.extend(render_benchmark_case_lifecycle_contract_lines(contract))
+    return "\n".join(lines), contract
 
 
 class HostCodexGoalAgent(BaseAgent):
@@ -129,6 +173,12 @@ class HostCodexGoalAgent(BaseAgent):
         app_server_response_timeout_sec: str | int | float = 30,
         startup_delay_sec: str | int | float = 5,
         poll_interval_sec: str | int | float = 5,
+        goal_harness_mode: str = "codex_goal_mode_baseline",
+        goal_harness_access_packet_mode: str = "none",
+        goal_harness_benchmark_id: str = "terminal-bench",
+        goal_harness_case_id: str = "current-case",
+        goal_harness_arm_id: str = "codex_goal_harness_treatment",
+        goal_harness_max_rounds: str | int = 5,
         *args: Any,
         **kwargs: Any,
     ):
@@ -149,6 +199,12 @@ class HostCodexGoalAgent(BaseAgent):
         self.app_server_response_timeout_sec = float(app_server_response_timeout_sec)
         self.startup_delay_sec = float(startup_delay_sec)
         self.poll_interval_sec = float(poll_interval_sec)
+        self.goal_harness_mode = goal_harness_mode
+        self.goal_harness_access_packet_mode = goal_harness_access_packet_mode
+        self.goal_harness_benchmark_id = goal_harness_benchmark_id
+        self.goal_harness_case_id = goal_harness_case_id
+        self.goal_harness_arm_id = goal_harness_arm_id
+        self.goal_harness_max_rounds = int(goal_harness_max_rounds)
 
     def _tmux(self, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
         return subprocess.run(
@@ -193,12 +249,21 @@ class HostCodexGoalAgent(BaseAgent):
         capture_path = work_dir / "tmux_capture.txt"
         prompt_path = work_dir / "prompt.txt"
         tmux_name = f"gh_tb_goal_{run_id}"
+        goal_harness_packet, case_lifecycle_contract = build_goal_harness_case_lifecycle_packet(
+            mode=self.goal_harness_mode,
+            packet_mode=self.goal_harness_access_packet_mode,
+            benchmark_id=self.goal_harness_benchmark_id,
+            case_id=self.goal_harness_case_id,
+            arm_id=self.goal_harness_arm_id,
+            max_rounds=self.goal_harness_max_rounds,
+        )
 
         prompt = build_host_goal_prompt(
             container_name=container_name,
             instruction=instruction,
             marker_path=marker,
             task_workdir=self.task_workdir,
+            goal_harness_case_lifecycle_packet=goal_harness_packet,
         )
         prompt_path.write_text(prompt, encoding="utf-8")
 
@@ -245,6 +310,12 @@ class HostCodexGoalAgent(BaseAgent):
                         "app_server_completion_hard_gate": False,
                         "completion_marker_observed": marker.exists(),
                         "first_blocker": first_blocker,
+                        "goal_harness_mode": self.goal_harness_mode,
+                        "goal_harness_access_packet_mode": self.goal_harness_access_packet_mode,
+                        "goal_harness_case_lifecycle_packet_injected": bool(
+                            goal_harness_packet
+                        ),
+                        "benchmark_case_lifecycle_contract": case_lifecycle_contract,
                     }
                 )
                 (work_dir / "app_server_goal_turn.compact.json").write_text(


### PR DESCRIPTION
## Summary
- add Terminal-Bench host-agent support for a Goal Harness per-case lifecycle packet
- keep baseline behavior unchanged unless goal_harness_mode=codex_goal_harness and packet mode is enabled
- write the lifecycle contract into app-server compact metadata for treatment attribution
- document the treatment launch kwargs in the benchmark developer workflow

## Validation
- python3 examples/terminal-bench-host-codex-goal-agent-smoke.py
- python3 examples/benchmark-case-active-state-contract-smoke.py
- python3 examples/benchmark-codex-app-parity-posthoc-smoke.py
- python3 examples/benchmark-developer-workflow-doc-smoke.py
- python3 -m py_compile scripts/terminal_bench_host_codex_goal_agent.py examples/terminal-bench-host-codex-goal-agent-smoke.py
- goal-harness check --scan-path scripts/terminal_bench_host_codex_goal_agent.py --scan-path examples/terminal-bench-host-codex-goal-agent-smoke.py --scan-path docs/benchmark-developer-workflow.md
- git diff --check

## Boundary
- no benchmark jobs launched
- no raw task text, trajectories, verifier output, credentials, local state, or private paths included
- scan hits are policy text or negative assertions only

## Residual risk
- existing duplicate-index warning remains unrelated
