### PR TITLE
Inject SkillsBench case lifecycle packet

### DIFF
--- a/docs/benchmark-developer-workflow.md
+++ b/docs/benchmark-developer-workflow.md
@@ -924,6 +924,17 @@ python3 scripts/skillsbench_host_codex_goal_worker.py \
   --contract-only
 ```
 
+When the worker is launched from a benchmark host wrapper rather than from the
+Goal Harness checkout, set the import path explicitly so shared driver modules
+are resolved from the shipped checkout:
+
+```bash
+PYTHONPATH=<goal-harness-checkout>:<goal-harness-checkout>/scripts \
+  python3 <goal-harness-checkout>/scripts/skillsbench_host_codex_goal_worker.py \
+    --task-id <task-id> \
+    --contract-only
+```
+
 When used for a private case, the same worker reads the private prompt file and
 workspace path on the benchmark host, invokes Codex app-server Goal mode, waits
 for `turn/completed`, and writes the assistant response only to a private
@@ -945,6 +956,33 @@ python3 scripts/skillsbench_host_codex_goal_worker.py \
   --response-text-file <private-agent-response-file> \
   --output-json <private-compact-worker-json>
 ```
+
+For the Goal Harness treatment arm, pass the same private files plus the
+per-case/arm lifecycle packet parameters. The packet is public-safe control
+context only: it names the isolated case goal, required lifecycle events, and
+round budget, while the official SkillsBench verifier remains authoritative
+and hidden from the agent loop:
+
+```bash
+python3 scripts/skillsbench_host_codex_goal_worker.py \
+  --task-id <task-id> \
+  --work-dir <private-case-workdir> \
+  --prompt-file <private-prompt-file> \
+  --response-text-file <private-agent-response-file> \
+  --output-json <private-compact-worker-json> \
+  --goal-harness-mode codex_goal_harness \
+  --goal-harness-access-packet-mode compact \
+  --goal-harness-case-id <task-id> \
+  --goal-harness-arm-id goal_harness_prompt_polling_test \
+  --goal-harness-max-rounds 5
+```
+
+The compact worker JSON must then show
+`goal_harness_case_lifecycle_packet_injected=true` and a
+`benchmark_case_lifecycle_contract` with
+`case_isolation_scope=per_benchmark_case_arm`. A baseline run should keep
+`goal_harness_access_packet_mode=none` and should not include Goal Harness
+lifecycle state.
 
 The compact worker JSON is safe to inspect for lifecycle debugging, but the
 response text file is private task execution material and must stay out of

--- a/examples/skillsbench-app-server-goal-worker-smoke.py
+++ b/examples/skillsbench-app-server-goal-worker-smoke.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import importlib.util
 import subprocess
 import sys
 import tempfile
@@ -27,6 +28,7 @@ from goal_harness.benchmark_adapters.skillsbench_acp_relay import (  # noqa: E40
 
 
 ROUTE = "codex-app-server-goal-baseline"
+WORKER_SCRIPT = REPO_ROOT / "scripts" / "skillsbench_host_codex_goal_worker.py"
 
 FAKE_CODEX = """#!/usr/bin/env python3
 import json
@@ -143,6 +145,14 @@ def assert_plan_prerequisites(plan: dict[str, Any]) -> None:
         prereq["codex_app_server_goal_worker_remote_command_file_bridge_ready"]
         is False
     ), prereq
+
+
+def _load_worker_module() -> Any:
+    spec = importlib.util.spec_from_file_location("skillsbench_goal_worker", WORKER_SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def test_route_contract_requires_native_goal_proof() -> None:
@@ -283,7 +293,7 @@ def test_host_worker_contract_only_cli() -> None:
     result = subprocess.run(
         [
             sys.executable,
-            str(REPO_ROOT / "scripts" / "skillsbench_host_codex_goal_worker.py"),
+            str(WORKER_SCRIPT),
             "--task-id",
             "tictoc-unnecessary-abort-detection",
             "--contract-only",
@@ -299,6 +309,56 @@ def test_host_worker_contract_only_cli() -> None:
     assert contract["route"] == ROUTE, contract
     assert contract["worker_adapter"]["script"] == "scripts/skillsbench_host_codex_goal_worker.py", contract
     assert contract["worker_adapter"]["reasoning_effort"] == "high", contract
+    assert payload["goal_harness_mode"] == "codex_goal_mode_baseline", payload
+    assert payload["goal_harness_access_packet_mode"] == "none", payload
+    assert payload["goal_harness_case_lifecycle_packet_injected"] is False, payload
+    assert payload["benchmark_case_lifecycle_contract"] is None, payload
+
+
+def test_host_worker_treatment_lifecycle_packet_is_public_safe() -> None:
+    worker = _load_worker_module()
+    args = worker.parse_args(
+        [
+            "--task-id",
+            "tictoc-unnecessary-abort-detection",
+            "--contract-only",
+            "--goal-harness-mode",
+            "codex_goal_harness",
+            "--goal-harness-access-packet-mode",
+            "compact",
+            "--goal-harness-case-id",
+            "tictoc-unnecessary-abort-detection",
+            "--goal-harness-arm-id",
+            "goal_harness_prompt_polling_test",
+            "--goal-harness-max-rounds",
+            "5",
+        ]
+    )
+    packet, contract = worker.build_goal_harness_case_lifecycle_packet(args)
+    assert contract is not None
+    assert "skillsbench_goal_harness_case_lifecycle_packet_v0:" in packet
+    assert "packet_mode: compact" in packet
+    assert "benchmark_family: benchflow" in packet
+    assert "benchmark_case_lifecycle_contract:" in packet
+    assert "benchmark_id: skillsbench" in packet
+    assert "case_id: tictoc-unnecessary-abort-detection" in packet
+    assert "arm_id: goal_harness_prompt_polling_test" in packet
+    assert (
+        "benchmark_case_goal_id: skillsbench-tictoc-unnecessary-abort-detection-goal-harness-prompt-polling-test-case"
+        in packet
+    )
+    assert "case_state_path: /app/.codex/goals/" in packet
+    assert "required_lifecycle_steps: quota_should_run,todo_claim_or_update,bounded_agent_turn,validation_or_case_result,refresh_state,quota_spend" in packet
+    assert "runner_internal_prompt_polling_only_allowed: false" in packet
+    assert "/Users/" not in packet
+    prompt = worker._prompt_with_goal_harness_case_lifecycle_packet(
+        "Private task instruction placeholder.",
+        packet,
+    )
+    assert "Goal Harness case lifecycle packet:" in prompt
+    assert "official SkillsBench/BenchFlow verifier authoritative" in prompt
+    assert "Private task instruction placeholder." in prompt
+    assert "/Users/" not in prompt
 
 
 def test_host_worker_waits_for_completion_and_keeps_public_json_compact() -> None:
@@ -314,7 +374,7 @@ def test_host_worker_waits_for_completion_and_keeps_public_json_compact() -> Non
         result = subprocess.run(
             [
                 sys.executable,
-                str(REPO_ROOT / "scripts" / "skillsbench_host_codex_goal_worker.py"),
+                str(WORKER_SCRIPT),
                 "--task-id",
                 "llm-prefix-cache-replay",
                 "--codex-bin",
@@ -342,6 +402,8 @@ def test_host_worker_waits_for_completion_and_keeps_public_json_compact() -> Non
         assert payload["ok"] is True, payload
         assert payload["turn"]["turn_completed_observed"] is True, payload
         assert payload["turn"]["assistant_message_present"] is True, payload
+        assert payload["goal_harness_case_lifecycle_packet_injected"] is False, payload
+        assert payload["turn"]["goal_harness_case_lifecycle_packet_injected"] is False, payload
         assert payload["private_response_text"]["written"] is True, payload
         assert payload["private_response_text"]["path_recorded"] is False, payload
         assert private_response.read_text(encoding="utf-8") == "private worker answer"
@@ -364,7 +426,7 @@ def test_host_worker_marker_completion_when_turn_completed_is_missing() -> None:
         result = subprocess.run(
             [
                 sys.executable,
-                str(REPO_ROOT / "scripts" / "skillsbench_host_codex_goal_worker.py"),
+                str(WORKER_SCRIPT),
                 "--task-id",
                 "llm-prefix-cache-replay",
                 "--codex-bin",

--- a/scripts/skillsbench_host_codex_goal_worker.py
+++ b/scripts/skillsbench_host_codex_goal_worker.py
@@ -26,6 +26,10 @@ from goal_harness.benchmark_adapters.skillsbench import (  # noqa: E402
     SKILLSBENCH_DEFAULT_TASK,
     build_skillsbench_app_server_goal_worker_contract,
 )
+from goal_harness.benchmark_case_state import (  # noqa: E402
+    benchmark_case_lifecycle_contract,
+    render_benchmark_case_lifecycle_contract_lines,
+)
 from goal_harness.codex_goal_baseline import stable_text_digest  # noqa: E402
 from scripts.codex_app_server_goal_driver import (  # noqa: E402
     compact_turn_metadata,
@@ -60,6 +64,50 @@ def build_contract_payload(args: argparse.Namespace) -> dict[str, Any]:
 def _completion_marker_path(work_dir: Path, prompt: str) -> Path:
     digest = stable_text_digest(prompt)[:12]
     return work_dir / f".goal_harness_app_server_goal_worker_response_{digest}.txt"
+
+
+def build_goal_harness_case_lifecycle_packet(
+    args: argparse.Namespace,
+) -> tuple[str, dict[str, object] | None]:
+    if args.goal_harness_mode != "codex_goal_harness":
+        return "", None
+    if args.goal_harness_access_packet_mode == "none":
+        return "", None
+    case_id = args.goal_harness_case_id or args.task_id
+    contract = benchmark_case_lifecycle_contract(
+        benchmark_id=args.dataset,
+        case_id=case_id,
+        arm_id=args.goal_harness_arm_id,
+        max_rounds=args.goal_harness_max_rounds,
+    )
+    lines = [
+        "skillsbench_goal_harness_case_lifecycle_packet_v0:",
+        f"  packet_mode: {args.goal_harness_access_packet_mode}",
+        "  benchmark_family: benchflow",
+    ]
+    lines.extend(render_benchmark_case_lifecycle_contract_lines(contract))
+    return "\n".join(lines), contract
+
+
+def _prompt_with_goal_harness_case_lifecycle_packet(
+    prompt: str,
+    packet: str,
+) -> str:
+    packet_text = packet.strip()
+    if not packet_text:
+        return prompt
+    return (
+        prompt.rstrip()
+        + "\n\n"
+        + "Goal Harness case lifecycle packet:\n"
+        + packet_text
+        + "\n\n"
+        + "Use this packet as observational control-plane context. Keep the "
+        + "official SkillsBench/BenchFlow verifier authoritative, do not expose "
+        + "reward or verifier output during the agent loop, and do not rely on "
+        + "runner-internal polling alone when claiming Goal Harness treatment "
+        + "evidence."
+    )
 
 
 def _prompt_with_completion_marker(prompt: str, marker_name: str) -> str:
@@ -116,7 +164,15 @@ def run_worker(args: argparse.Namespace) -> dict[str, Any]:
     work_dir.mkdir(parents=True, exist_ok=True)
     if marker_path.exists():
         marker_path.unlink()
-    with_marker_prompt = _prompt_with_completion_marker(prompt, marker_path.name)
+    lifecycle_packet, lifecycle_contract = build_goal_harness_case_lifecycle_packet(args)
+    effective_prompt = _prompt_with_goal_harness_case_lifecycle_packet(
+        prompt,
+        lifecycle_packet,
+    )
+    with_marker_prompt = _prompt_with_completion_marker(
+        effective_prompt,
+        marker_path.name,
+    )
     marker_observed = False
     marker_deleted = False
     turn = start_codex_app_server_goal_turn(
@@ -151,6 +207,10 @@ def run_worker(args: argparse.Namespace) -> dict[str, Any]:
                 "completion_marker_requested": True,
                 "completion_marker_observed": marker_observed,
                 "completion_marker_deleted": marker_deleted,
+                "goal_harness_mode": args.goal_harness_mode,
+                "goal_harness_access_packet_mode": args.goal_harness_access_packet_mode,
+                "goal_harness_case_lifecycle_packet_injected": bool(lifecycle_packet),
+                "benchmark_case_lifecycle_contract": lifecycle_contract,
             }
         )
         private_response_written = False
@@ -172,10 +232,16 @@ def run_worker(args: argparse.Namespace) -> dict[str, Any]:
         "route": "codex-app-server-goal-baseline",
         "benchmark_id": args.dataset,
         "task_id": args.task_id,
+        "goal_harness_mode": args.goal_harness_mode,
+        "goal_harness_access_packet_mode": args.goal_harness_access_packet_mode,
+        "goal_harness_case_lifecycle_packet_injected": bool(lifecycle_packet),
+        "benchmark_case_lifecycle_contract": lifecycle_contract,
         "worker_contract": build_contract_payload(args),
         "prompt": {
             "sha256": stable_text_digest(prompt),
             "chars": len(prompt),
+            "effective_sha256": stable_text_digest(with_marker_prompt),
+            "effective_chars": len(with_marker_prompt),
             "raw_recorded": False,
         },
         "turn": compact,
@@ -233,6 +299,35 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help="Mark the surrounding BenchFlow worker integration as ready.",
     )
     parser.add_argument(
+        "--goal-harness-mode",
+        default="codex_goal_mode_baseline",
+        help=(
+            "Goal Harness benchmark arm mode. Use codex_goal_harness only for "
+            "treatment runs that intentionally receive a case lifecycle packet."
+        ),
+    )
+    parser.add_argument(
+        "--goal-harness-access-packet-mode",
+        default="none",
+        help="Set to compact to inject the public-safe case lifecycle packet.",
+    )
+    parser.add_argument(
+        "--goal-harness-case-id",
+        default="",
+        help="Public case id for the per-case/arm Goal Harness lifecycle contract.",
+    )
+    parser.add_argument(
+        "--goal-harness-arm-id",
+        default="codex_app_server_goal_baseline",
+        help="Public arm id for the per-case/arm Goal Harness lifecycle contract.",
+    )
+    parser.add_argument(
+        "--goal-harness-max-rounds",
+        type=int,
+        default=5,
+        help="Maximum public prompt-polling round budget for treatment metadata.",
+    )
+    parser.add_argument(
         "--contract-only",
         action="store_true",
         help="Print only the public-safe worker contract without invoking Codex.",
@@ -248,6 +343,17 @@ def main(argv: list[str] | None = None) -> int:
             "contract_only": True,
             "worker_contract": build_contract_payload(args),
         }
+        lifecycle_packet, lifecycle_contract = build_goal_harness_case_lifecycle_packet(
+            args
+        )
+        payload.update(
+            {
+                "goal_harness_mode": args.goal_harness_mode,
+                "goal_harness_access_packet_mode": args.goal_harness_access_packet_mode,
+                "goal_harness_case_lifecycle_packet_injected": bool(lifecycle_packet),
+                "benchmark_case_lifecycle_contract": lifecycle_contract,
+            }
+        )
     else:
         if not args.work_dir or not args.prompt_file:
             raise SystemExit("--work-dir and --prompt-file are required unless --contract-only")


### PR DESCRIPTION
## Summary
- add explicit Goal Harness per-case/arm lifecycle packet support to the SkillsBench app-server Goal worker
- keep baseline runs packet-free while treatment runs can inject compact public-safe lifecycle context
- document PYTHONPATH launcher usage and treatment worker flags

## Validation
- python3 examples/skillsbench-app-server-goal-worker-smoke.py
- python3 -m py_compile scripts/skillsbench_host_codex_goal_worker.py examples/skillsbench-app-server-goal-worker-smoke.py
- python3 examples/benchmark-case-active-state-contract-smoke.py
- python3 examples/benchmark-codex-app-parity-posthoc-smoke.py
- python3 examples/benchmark-developer-workflow-doc-smoke.py
- goal-harness check --scan-path scripts/skillsbench_host_codex_goal_worker.py --scan-path examples/skillsbench-app-server-goal-worker-smoke.py --scan-path docs/benchmark-developer-workflow.md
- git diff --check