### PR TITLE
Make Codex CLI Goal Harness bootstrap visible-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,21 +188,26 @@ goal-harness heartbeat-prompt --thin --goal-id <goal-id> --agent-id <agent-id> -
 ### Codex CLI
 
 Use this when you want the human-visible TUI to stay primary. Open Codex CLI
-from your project repo and paste one message:
+from your project repo and paste one goal-mode message:
 
 ```text
-Start Goal Harness for this repo. If `goal-harness` is missing, install it with
-the official no-clone GitHub installer, then connect this project. Show me the
-current goal, concrete user gate if any, top todos, and next safe action before
-running longer work. Keep me in this Codex CLI TUI unless I explicitly accept a
-headless fallback. After I paste this, begin the Goal Harness loop; do not stop
-after only explaining what Goal Harness is.
+/goal Start Goal Harness for this repo. Use Goal Harness as the control plane
+for this visible Codex CLI TUI goal. If `goal-harness` is missing, install it
+with the official no-clone GitHub installer, then connect this project. Show me
+the current goal, concrete user gate if any, top todos, and next safe action
+before running longer work. Keep me in this Codex CLI TUI and do not use hidden
+headless execution. Begin the Goal Harness loop now; do not stop after only
+explaining what Goal Harness is.
 ```
 
-The first useful response should show the current goal, user gate, top todos,
-and next safe action. If the guard permits work, the same visible TUI turn can
-claim or choose one runnable agent todo and complete one bounded validated
-segment.
+The `/goal` message gives Codex CLI goal mode the durable loop objective and
+completion criteria. The text is a Codex CLI rewrite of the Goal Harness
+heartbeat prompt: it keeps the App automation lifecycle ideas, but speaks in
+the visible TUI's style and uses `heartbeat-prompt --thin` only as a drift
+check. The first useful response should show the current goal, user gate, top
+todos, and next safe action. If the guard permits work, the same visible TUI
+turn can claim or choose one runnable agent todo and complete one bounded
+validated segment.
 
 After Goal Harness is installed, generate a stricter exact TUI paste block:
 
@@ -216,9 +221,9 @@ For only the pasteable text:
 goal-harness codex-cli-bootstrap-message --project . --goal-id <goal-id> --message-only
 ```
 
-Headless `codex exec` is an explicit fallback, not the default experience.
-Pilot packets, local drivers, idle detection, and same-session proof details
-live in [Getting Started](docs/guides/getting-started.md) and the
+Hidden `codex exec` is not part of the default TUI bootstrap. Pilot packets,
+local drivers, idle detection, and same-session proof details live in
+[Getting Started](docs/guides/getting-started.md) and the
 [Codex CLI TUI-first loop](docs/product/codex-cli-tui-loop.md).
 
 ### Other Agents And Manual Shell

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -74,19 +74,24 @@ paths, runtime roots, JSON payloads, or session files.
 First-run path:
 
 ```text
-Start Goal Harness for this repo. If `goal-harness` is missing, install it with
-the official no-clone GitHub installer, then connect this project. Show me the
-current goal, concrete user gate if any, top todos, and next safe action before
-running longer work. Keep me in this Codex CLI TUI unless I explicitly accept a
-headless fallback. After I paste this, begin the Goal Harness loop; do not stop
-after only explaining what Goal Harness is.
+/goal Start Goal Harness for this repo. Use Goal Harness as the control plane
+for this visible Codex CLI TUI goal. If `goal-harness` is missing, install it
+with the official no-clone GitHub installer, then connect this project. Show me
+the current goal, concrete user gate if any, top todos, and next safe action
+before running longer work. Keep me in this Codex CLI TUI and do not use hidden
+headless execution. Begin the Goal Harness loop now; do not stop after only
+explaining what Goal Harness is.
 ```
 
-The first useful response should show the current goal id, concrete user gate
-if one exists, top user todo if any, top agent todo, and next safe action before
-longer delivery work. When the guard permits work, the same TUI turn should
-claim or choose one runnable agent todo and finish one bounded validated
-segment, rather than asking the user to run a separate setup flow.
+The generated paste block is a Codex CLI `/goal` rewrite of the App heartbeat
+prompt, not a copy of that automation body. It keeps the same lifecycle ideas
+while using the TUI as the live control surface; `heartbeat-prompt --thin`
+remains a drift check when the contract changes. The first useful response
+should show the current goal id, concrete user gate if one exists, top user
+todo if any, top agent todo, and next safe action before longer delivery work.
+When the guard permits work, the same TUI turn should claim or choose one
+runnable agent todo and finish one bounded validated segment, rather than
+asking the user to run a separate setup flow.
 
 Once `goal-harness` is installed, generate a stricter repo-specific paste
 message:
@@ -152,8 +157,8 @@ goal-harness codex-cli-visible-driver-plan --project . --goal-id <goal-id>
 ```
 
 To see the full local automation setup plan in one packet, including quota
-guard, visible-driver decision, TUI bootstrap command, explicit headless
-fallback command, and idle-guard requirement, run:
+guard, visible-driver decision, TUI bootstrap command, the headless-disabled
+boundary, and idle-guard requirement, run:
 
 ```bash
 goal-harness codex-cli-local-driver-plan --project . --goal-id <goal-id> --agent-id <agent-id>
@@ -178,16 +183,16 @@ The fixture should contain only booleans and public-safe labels proving user
 opt-in, quota guard, idle guard, visible turn, interruptibility, no transcript
 or session-file reads, and compact writeback planning.
 
-If same-session steering is unavailable and the user explicitly accepts a
-headless fallback, generate the fallback handoff instead of pretending the open
-TUI is preserved:
+The default Codex CLI `/goal` product path does not offer a headless fallback.
+For compatibility, the old handoff command only reports the disabled boundary
+and points back to the message-only TUI bootstrap:
 
 ```bash
 goal-harness codex-cli-exec-handoff --project . --goal-id <goal-id>
 ```
 
 See the [Codex CLI TUI-first loop](../product/codex-cli-tui-loop.md) contract
-for the bootstrap, session-attached automation, and headless fallback split.
+for the bootstrap, session-attached automation, and headless-disabled boundary.
 The [Codex CLI first-run rehearsal](../product/codex-cli-first-run-rehearsal.md)
 keeps the shortest user-facing route in one place: no-clone install,
 one-message TUI bootstrap, and proof-capture fixtures for later automation.

--- a/docs/product/codex-cli-automation-driver.md
+++ b/docs/product/codex-cli-automation-driver.md
@@ -6,7 +6,8 @@ Goal Harness should make Codex CLI feel easy before it feels automated. The
 primary path is still the Codex TUI: the user starts from a project repo, sends
 one Goal-Harness-generated message, and can keep watching, steering, reviewing,
 or taking over. Automation is allowed only when it preserves that visible
-control surface or falls back explicitly.
+control surface. The default `/goal` product path does not offer headless
+fallback.
 
 ## Current Finding
 
@@ -30,7 +31,7 @@ The important product distinction is:
 | --- | --- | --- |
 | `codex [PROMPT]` | one-message TUI bootstrap is viable | scheduled wakeups |
 | `codex resume ... [PROMPT]` | a visible resume proof is plausible | safe injection into an already-open TUI |
-| `codex exec` | headless fallback is viable | preserved TUI experience |
+| `codex exec` | non-interactive execution exists | preserved TUI experience or default Goal Harness fallback |
 | `remote-control` / app-server | a future visible-control bridge may exist | production-safe Goal Harness driver semantics |
 
 ## Driver Shape
@@ -48,9 +49,9 @@ The v0 driver should be explicit and conservative:
 5. The driver runs `goal-harness codex-cli-visible-driver-plan`.
 6. If the plan proves a visible attach path, the driver may attempt a visible
    `resume` / remote-control turn behind an idle guard.
-7. If no visible attach path is proven, the driver keeps TUI bootstrap primary
-   and offers `goal-harness codex-cli-exec-handoff` as an explicit headless
-   fallback.
+7. If no visible attach path is proven, the driver keeps TUI bootstrap primary.
+   `goal-harness codex-cli-exec-handoff` reports the disabled boundary and does
+   not print a runnable `codex exec` script.
 8. The driver spends quota only after validated writeback.
 
 The local driver must never read or publish:
@@ -80,14 +81,15 @@ The local driver must never read or publish:
 - A visible resume / remote-control proof shows the turn is visible,
   interruptible, and idle-guarded before Goal Harness calls it
   session-attached automation.
-- Headless `codex exec` remains a named fallback, not the default user story.
+- Headless `codex exec` is disabled for the default `/goal` product path, not a
+  named fallback.
 - Every automatic turn writes compact evidence or a precise blocker before
   quota spend.
 
 ## Current MVP
 
 The dry-run-first local driver planner composes the existing quota, TUI,
-visible-driver, and explicit fallback pieces into one operator-facing packet:
+visible-driver, and headless-disabled boundary into one operator-facing packet:
 
 ```bash
 goal-harness codex-cli-local-driver-plan --project . --goal-id <goal> --agent-id <agent>
@@ -98,10 +100,10 @@ transcripts, inspect session files, mutate a Codex session, or spend Goal
 Harness quota. It emits:
 
 - the quota guard command that must run before work;
-- the visible-driver decision for TUI bootstrap, visible attach proof,
-  resume/remote-control spike, or explicit headless fallback;
+- the visible-driver decision for TUI bootstrap, visible attach proof, or
+  resume/remote-control spike;
 - the repo-specific TUI bootstrap message command;
-- the explicit `codex exec` fallback generator;
+- the disabled `codex exec` boundary;
 - the idle-guard placeholder that must exist before any same-session attach is
   treated as production automation.
 
@@ -134,8 +136,8 @@ Harness quota. It only chooses the next safe boundary:
 - require a public-safe visible-session proof before any resume or
   remote-control path is treated as same-session automation;
 - keep the TUI bootstrap as the default when no proof exists;
-- require `--allow-headless-fallback` before emitting a headless `codex exec`
-  fallback command;
+- never emit a headless `codex exec` fallback command from the default `/goal`
+  product path;
 - mark a visible session as a candidate only when the proof fixture confirms
   user opt-in, quota guard, idle guard, visibility, interruptibility, boundary,
   and compact writeback planning.
@@ -149,9 +151,8 @@ goal-harness codex-cli-local-scheduler-tick --project . --goal-id <goal> --agent
 This command is still no-execution by design. A launchd/cron/local-daemon
 wrapper can call it and receive one of two safe outputs:
 
-- a candidate external command, when visible-session proof or explicit headless
-  fallback opt-in is present;
-- a precise blocker writeback command, when proof or opt-in is missing.
+- a candidate external command, when visible-session proof is present;
+- a precise blocker writeback command, when proof is missing.
 
 The tick itself does not run Codex, read transcripts, inspect session files,
 mutate sessions, write Goal Harness state, or spend quota. That boundary keeps
@@ -204,4 +205,5 @@ post-turn writeback path.
 Use the executor wrapper as the smallest local-driver bridge, then move toward
 the real product loop: one TUI message starts Goal Harness, recurring wakeups
 run the guard, a visible same-session turn is attempted only after proof and
-idle checks, and headless `codex exec` remains an explicit fallback.
+idle checks, and headless `codex exec` remains disabled for the default
+`/goal` path.

--- a/docs/product/codex-cli-tui-loop.md
+++ b/docs/product/codex-cli-tui-loop.md
@@ -18,18 +18,23 @@ daemon instead of Codex." The target is:
 
 ## Product Goal
 
-The best first-run experience is one TUI message:
+The best first-run experience is one TUI goal-mode message:
 
 ```text
-Start Goal Harness for this repo. If `goal-harness` is missing, install it with
-the official no-clone GitHub installer, then connect this project. Show me the
-current goal, concrete user gate if any, top todos, and next safe action before
-running longer work. Keep me in this Codex CLI TUI unless I explicitly accept a
-headless fallback. After I paste this, begin the Goal Harness loop; do not stop
-after only explaining what Goal Harness is.
+/goal Start Goal Harness for this repo. Use Goal Harness as the control plane
+for this visible Codex CLI TUI goal. If `goal-harness` is missing, install it
+with the official no-clone GitHub installer, then connect this project. Show me
+the current goal, concrete user gate if any, top todos, and next safe action
+before running longer work. Keep me in this Codex CLI TUI and do not use hidden
+headless execution. Begin the Goal Harness loop now; do not stop after only
+explaining what Goal Harness is.
 ```
 
-That message should be enough for a terminal agent to:
+That `/goal` text should be a Codex CLI-native rewrite of the App heartbeat
+automation prompt. It should keep the same loop discipline while using the TUI
+as the user's live control surface, with `heartbeat-prompt --thin` reserved
+as a drift check when the Goal Harness lifecycle contract changes. The message
+should be enough for a terminal agent to:
 
 - run `goal-harness doctor`;
 - install or repair the local CLI if it is missing, using the no-clone archive
@@ -60,7 +65,7 @@ and the user's live console.
 ### 1. TUI Bootstrap
 
 This is the first supported path. The user starts in Codex CLI TUI and pastes a
-single Goal Harness bootstrap request. The agent performs install/connect,
+single `/goal` Goal Harness bootstrap request. The agent performs install/connect,
 surfaces onboarding decisions, and starts a bounded Goal Harness turn in the
 same conversation. It should not stop after describing the product; once the
 quota/status guard permits work, the first TUI turn should perform one bounded,
@@ -75,10 +80,10 @@ Current prototype:
 goal-harness codex-cli-bootstrap-message --project . --goal-id <goal-id>
 ```
 
-Copy the generated message into Codex CLI TUI. The message tells the agent to
-repair/install Goal Harness if needed, connect the repo conservatively, run the
-quota/status guard, obey `interaction_contract`, preserve the visible TUI, and
-spend quota only after validated writeback.
+Copy the generated message into Codex CLI TUI. It starts with `/goal` and tells
+the agent to repair/install Goal Harness if needed, connect the repo
+conservatively, run the quota/status guard, obey `interaction_contract`,
+preserve the visible TUI, and spend quota only after validated writeback.
 
 Transcript-free first-run smoke packet:
 
@@ -174,17 +179,16 @@ goal-harness codex-cli-visible-driver-plan --project . --goal-id <goal-id>
 
 This command turns the probe result into a dry-run driver plan. It does not run
 Codex, read raw transcripts, read session files, mutate a Codex session, or
-spend Goal Harness quota. Its job is to choose one of four next modes:
+spend Goal Harness quota. Its job is to choose one of three next modes:
 
 - `session_attached_visible_turn`: a future local driver may try the detected
   visible attach primitive, but only behind quota guard and idle guard.
 - `visible_resume_or_remote_control_spike`: `resume [PROMPT]` or
   `remote-control` exists, but it must prove that the turn is visible and
   interruptible before Goal Harness treats it as session-attached automation.
-- `explicit_headless_fallback_after_tui_bootstrap`: keep the one-message TUI
-  bootstrap as the main path and use `codex exec` only when the user knowingly
-  accepts a headless fallback.
-- `tui_bootstrap_only`: ask the user to start inside Codex CLI TUI.
+- `tui_bootstrap_only`: ask the user to start inside Codex CLI TUI. If the
+  probe only exposes `codex exec`, Goal Harness still stays in this mode
+  because headless fallback is disabled for the default `/goal` product path.
 
 Current local-driver planner:
 
@@ -193,8 +197,8 @@ goal-harness codex-cli-local-driver-plan --project . --goal-id <goal-id> --agent
 ```
 
 This command is the conservative MVP for automation setup. It composes the
-quota guard, visible-driver plan, TUI bootstrap command, explicit headless
-fallback command, and idle-guard requirement into a single dry-run packet. It
+quota guard, visible-driver plan, TUI bootstrap command, headless-disabled
+boundary, and idle-guard requirement into a single dry-run packet. It
 does not run Codex, read transcripts, read session files, mutate a session, or
 spend quota.
 
@@ -216,10 +220,9 @@ With runtime-idle evidence and `--guard-checked`, a local scheduler may choose
 exactly one opt-in side effect:
 
 - `--execute-candidate --candidate-command-prefix <prefix>`: run a proven
-  visible or explicit fallback candidate whose command starts with an allowed
-  prefix.
+  visible candidate whose command starts with an allowed prefix.
 - `--execute-blocker-writeback`: run the precise Goal Harness blocker writeback
-  command when the tick says proof or opt-in is missing.
+  command when the tick says proof is missing.
 
 The wrapper reports only whether it ran, return code, timeout, and the selected
 kind. It discards stdout/stderr, does not read transcripts, does not inspect
@@ -333,31 +336,25 @@ It treats `resume` / `remote-control` as proof targets, keeps fixtures
 public-safe, and records blocker-first stop conditions before any later visible
 turn is promoted.
 
-### 3. Headless Fallback
+### 3. Headless Disabled Boundary
 
 `codex exec` remains useful for scheduled or CI-like work, but it is not the
-primary product experience for interactive users. A headless driver is allowed
-when:
+primary product experience for interactive users. The default Codex CLI
+Goal Harness `/goal` path does not expose a headless fallback, even as an
+opt-in, so a first-run packet cannot accidentally move work into hidden
+execution.
 
-- the user knowingly opted into background execution;
-- the goal boundary permits it;
-- the work is independent of an active TUI decision;
-- the driver writes compact evidence back into Goal Harness.
-
-Headless fallback should never be the only way to start Goal Harness.
-
-Current explicit fallback generator:
+Compatibility boundary:
 
 ```bash
 goal-harness codex-cli-exec-handoff --project . --goal-id <goal-id>
 ```
 
-This command prints a `codex exec` handoff script that embeds the same
-Goal-Harness-aware bootstrap message. It does not run Codex, read transcripts,
-read credentials, read session files, mutate a session, or spend quota. Use it
-only when the user knowingly chooses a headless fallback or when a future
-driver decides that same-session attachment is unavailable and the goal
-boundary permits background execution.
+This command no longer prints a runnable `codex exec` handoff script. It
+reports the disabled boundary and points back to
+`codex-cli-bootstrap-message --message-only` for use inside the visible TUI.
+It does not run Codex, read transcripts, read credentials, read session files,
+mutate a session, or spend quota.
 
 ## Session-Attached Turn Algorithm
 
@@ -369,8 +366,8 @@ boundary permits background execution.
    worktree before editing.
 5. Choose among current-agent claimed advancement todos and runnable unclaimed
    candidates; monitor todos are context unless they produce a material event.
-6. Inject a visible steering prompt into the idle TUI session, or fall back to
-   an explicit headless run when the user has allowed it.
+6. Inject a visible steering prompt into the idle TUI session when proven, or
+   keep the one-message TUI bootstrap as the user-facing path.
 7. After validation, run `refresh-state` and `quota spend-slot --execute`.
 8. If validation fails, write a compact blocker instead of spending success
    prose.
@@ -389,7 +386,7 @@ projects runnable candidates; it should not over-specify the model's local plan.
 - Do not let a side agent edit from the primary checkout; obey
   `workspace_guard`.
 - Prefer a visible TUI prompt over silent background mutation.
-- Treat session-attachment failure as an explicit fallback decision, not as a
+- Treat session-attachment failure as a disabled-boundary decision, not as a
   reason to lose the Goal Harness loop.
 
 ## Implementation Roadmap
@@ -407,30 +404,30 @@ projects runnable candidates; it should not over-specify the model's local plan.
 5. **Session probe**: document whether current Codex CLI exposes a stable
    session id, resume handle, or safe injection primitive. The current
    implementation is `goal-harness codex-cli-session-probe`; it separates
-   `exec` fallback support, visible resume / remote-control spike surfaces, and
-   true same-open-TUI visible injection.
+   headless-disabled execution support, visible resume / remote-control spike
+   surfaces, and true same-open-TUI visible injection.
 6. **Visible driver plan**: generate a dry-run plan with
    `goal-harness codex-cli-visible-driver-plan` so the next local driver knows
    whether to attempt visible attach, run a resume/remote-control proof, or
-   fall back explicitly.
+   keep the one-message TUI bootstrap as the product path.
 7. **Local driver planner**: ship
    `goal-harness codex-cli-local-driver-plan` as the dry-run command that
-   composes quota, visible-driver, TUI bootstrap, explicit fallback, and
-   idle-guard requirements.
+   composes quota, visible-driver, TUI bootstrap, headless-disabled boundary,
+   and idle-guard requirements.
 8. **Visible-session proof harness**: validate public-safe observations with
    `goal-harness codex-cli-visible-session-proof` before promoting
    resume/remote-control into any same-session automation path.
 9. **Visible driver run packet**: add
    `goal-harness codex-cli-visible-driver-run` as the no-execution packet that
-   decides whether the next turn needs visible proof, TUI bootstrap, explicit
-   headless opt-in, or a proven visible-session candidate.
+   decides whether the next turn needs visible proof, TUI bootstrap, or a
+   proven visible-session candidate.
 10. **Local scheduler tick**: add
    `goal-harness codex-cli-local-scheduler-tick` as the first executor-facing
    one-shot packet. It emits either an external command candidate or a precise
    blocker writeback command, but does not run Codex, read session files, or
    write Goal Harness state itself. Visible candidates require both
    visible-session proof and runtime-idle detector approval; headless fallback
-   remains explicit opt-in.
+   remains disabled for the default `/goal` path.
 11. **Local scheduler executor wrapper**: add
    `goal-harness codex-cli-local-scheduler-exec` as the explicit opt-in bridge
    that can run one tick result only after guard confirmation, runtime-idle

--- a/examples/codex-cli-automation-driver-audit-smoke.py
+++ b/examples/codex-cli-automation-driver-audit-smoke.py
@@ -25,6 +25,7 @@ def main() -> int:
         "goal-harness codex-cli-visible-driver-plan",
         "goal-harness codex-cli-exec-handoff",
         "TUI bootstrap primary",
+        "headless-disabled boundary",
         "idle guard",
         "validated writeback",
     ]

--- a/examples/codex-cli-bootstrap-message-smoke.py
+++ b/examples/codex-cli-bootstrap-message-smoke.py
@@ -21,59 +21,64 @@ GOAL_ID = "public-codex-cli-goal"
 AGENT_ID = "codex-side-bypass"
 
 MUST_HAVE = (
-    "one-message TUI bootstrap",
-    "same Codex CLI TUI session",
-    "begin the Goal Harness loop automatically",
-    "Do not stop after explaining what Goal Harness is",
-    "hidden headless `codex exec`",
-    "explicit fallback",
+    "one-message /goal",
+    "visible Codex CLI TUI",
+    "durable TUI heartbeat prompt",
+    "hidden headless codex exec",
+    "registry-declared active state",
+    "goal-harness-project",
+    "goal-harness-self-repair",
     "current goal id",
     "top user todo",
     "top agent todo",
     "next safe action",
-    "goal-harness doctor",
+    "todo claim",
     "goal-harness bootstrap",
     "quota should-run",
     "--agent-id codex-side-bypass",
     "interaction_contract",
-    "user_channel.action_required=true",
+    "action_required=true",
+    "open_count>0",
     "workspace_guard",
-    "independent worktree",
-    "runnable agent todo",
-    "one bounded validated segment",
-    "Do not store raw Codex transcripts",
-    "visible steering turns",
-    "runtime idle evidence",
+    "independent git worktree",
+    "bounded steering audit",
+    "coherent validated batch",
+    "concrete blocker",
+    "After two no-progress turns",
+    "raw Codex transcripts",
     "refresh-state",
     "quota spend-slot",
-    "--source controller",
-    "not first-run prerequisites",
-    "no-clone GitHub archive",
+    "--source heartbeat",
+    "No project-specific branches",
     "install-from-github.sh",
-    "transcript-free validation checklist",
-    "no raw Codex transcripts, session files, credentials, private paths, stdout, or stderr persisted",
 )
 
 
 def assert_message_contract(payload: dict[str, object]) -> None:
     assert payload["ok"] is True, payload
     assert payload["schema_version"] == "codex_cli_bootstrap_message_v0", payload
+    assert payload["invocation_mode"] == "codex_cli_goal_mode", payload
     assert payload["goal_id"] == GOAL_ID, payload
     assert payload["agent_id"] == AGENT_ID, payload
     assert "install-from-github.sh" in str(payload["install_repair_command"]), payload
+    assert "heartbeat-prompt --thin" in str(payload["heartbeat_prompt_command"]), payload
+    assert "--agent-scope 'Codex CLI /goal visible TUI loop'" in str(payload["heartbeat_prompt_command"]), payload
     checklist = payload["first_run_validation_checklist"]
     assert isinstance(checklist, list) and len(checklist) >= 5, payload
     assert any("quota/status guard checked" in item for item in checklist), payload
     assert any("no raw Codex transcripts" in item for item in checklist), payload
     message = str(payload["message"])
     normalized = " ".join(message.split())
+    assert message.startswith("/goal Advance `public-codex-cli-goal` from the registry-declared active state"), message
+    assert int(payload["goal_objective_characters"]) <= int(payload["goal_objective_max_chars"]), payload
     for phrase in MUST_HAVE:
         assert phrase in normalized, (phrase, message)
     assert normalized.index("quota should-run") < normalized.index("interaction_contract"), message
-    assert normalized.index("workspace_guard") < normalized.index("independent worktree"), message
+    assert normalized.index("workspace_guard") < normalized.index("independent git worktree"), message
     assert normalized.index("refresh-state") < normalized.index("quota spend-slot"), message
     assert "Headless fallback should never be the only way" not in message, message
-    assert "quota spend-slot --goal-id public-codex-cli-goal --slots 1 --source controller --execute --agent-id codex-side-bypass" in message, message
+    assert "quota spend-slot --goal-id public-codex-cli-goal" in message, message
+    assert "--source heartbeat --execute --agent-id codex-side-bypass" in message, message
 
 
 def run_cli(*extra_args: str) -> str:
@@ -100,9 +105,9 @@ def assert_docs_surface_codex_cli_quickstart() -> None:
     normalized_readme = " ".join(readme.split())
     normalized_getting_started = " ".join(getting_started.split())
     normalized_product_contract = " ".join(product_contract.split())
-    assert "Headless `codex exec` is an explicit fallback" in normalized_readme, readme
-    assert "paste one message" in normalized_readme, readme
-    assert "begin the Goal Harness loop" in normalized_readme, readme
+    assert "Hidden `codex exec` is not part of the default TUI bootstrap" in normalized_readme, readme
+    assert "paste one goal-mode message" in normalized_readme, readme
+    assert "Begin the Goal Harness loop" in normalized_readme, readme
     assert "exact TUI paste block" in normalized_readme, readme
     assert "show the current goal, user gate, top todos, and next safe action" in normalized_readme, readme
     assert "first-run path should not require you to understand registry paths" in normalized_getting_started, getting_started
@@ -113,6 +118,8 @@ def assert_docs_surface_codex_cli_quickstart() -> None:
     assert "first TUI turn should perform one bounded, validated segment" in normalized_product_contract, product_contract
     assert "goal-harness codex-cli-session-probe" in getting_started, getting_started
     assert "goal-harness codex-cli-exec-handoff --project . --goal-id <goal-id>" in getting_started, getting_started
+    assert "headless-disabled boundary" in normalized_getting_started, getting_started
+    assert "This command no longer prints a runnable `codex exec` handoff script" in product_contract, product_contract
 
 
 def main() -> int:
@@ -150,10 +157,12 @@ def main() -> int:
     )
     assert "# Codex CLI Goal Harness Bootstrap Message" in cli_markdown, cli_markdown
     assert "Copy the block below into Codex CLI TUI" in cli_markdown, cli_markdown
+    assert "starts with `/goal`" in cli_markdown, cli_markdown
+    assert "heartbeat-prompt --thin" in cli_markdown, cli_markdown
     assert "Fresh Repo Install Repair" in cli_markdown, cli_markdown
     assert "Transcript-Free Validation Checklist" in cli_markdown, cli_markdown
     assert "install-from-github.sh" in cli_markdown, cli_markdown
-    assert "one-message TUI bootstrap" in cli_markdown, cli_markdown
+    assert "one-message /goal" in cli_markdown, cli_markdown
 
     cli_message_only = run_cli(
         "codex-cli-bootstrap-message",
@@ -168,7 +177,7 @@ def main() -> int:
     assert cli_message_only == str(payload["message"]) + "\n", cli_message_only
     assert "# Codex CLI Goal Harness Bootstrap Message" not in cli_message_only, cli_message_only
     assert "Fresh Repo Install Repair" not in cli_message_only, cli_message_only
-    assert "Start the Goal Harness loop" in cli_message_only, cli_message_only
+    assert cli_message_only.startswith("/goal Advance `public-codex-cli-goal` from the registry-declared active state"), cli_message_only
 
     cli_copy_only = run_cli(
         "codex-cli-bootstrap-message",

--- a/examples/codex-cli-exec-handoff-smoke.py
+++ b/examples/codex-cli-exec-handoff-smoke.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Smoke-test explicit Codex CLI exec fallback handoff generation."""
+"""Smoke-test the disabled Codex CLI exec handoff boundary."""
 
 from __future__ import annotations
 
@@ -35,22 +35,17 @@ def run_cli(*extra_args: str) -> str:
 def assert_handoff_contract(payload: dict[str, object]) -> None:
     assert payload["ok"] is True, payload
     assert payload["schema_version"] == "codex_cli_exec_handoff_v0", payload
-    assert payload["mode"] == "explicit_headless_fallback", payload
-    assert payload["primary_experience"] == "codex_cli_tui_bootstrap", payload
+    assert payload["mode"] == "headless_fallback_disabled_for_goal_mode_bootstrap", payload
+    assert payload["primary_experience"] == "codex_cli_tui_goal_bootstrap", payload
     assert payload["goal_id"] == GOAL_ID, payload
     assert payload["agent_id"] == AGENT_ID, payload
     command = str(payload["handoff_command"])
-    normalized = " ".join(command.split())
-    assert "cat <<'GOAL_HARNESS_CODEX_PROMPT' | codex exec" in command, command
-    assert "codex exec -" not in command, command
-    assert "Start the Goal Harness loop for this repo from this same Codex CLI TUI session." in command, command
-    assert "hidden headless `codex exec`" in command, command
-    assert "explicit fallback" in command, command
-    assert "quota should-run --goal-id public-codex-cli-goal --agent-id codex-side-bypass" in normalized, command
-    assert "workspace_guard" in command, command
-    assert "refresh-state" in command, command
-    assert "quota spend-slot --goal-id public-codex-cli-goal" in normalized, command
-    assert "GOAL_HARNESS_CODEX_PROMPT" in command, command
+    message_only = str(payload["message_only_command"])
+    assert command == "", payload
+    assert "codex exec" not in command, payload
+    assert "codex-cli-bootstrap-message" in message_only, payload
+    assert "--message-only" in message_only, payload
+    assert "disabled" in str(payload["disabled_reason"]).lower(), payload
     boundary = payload["boundary"]
     assert boundary["runs_codex"] is False, payload
     assert boundary["reads_raw_transcripts"] is False, payload
@@ -58,6 +53,8 @@ def assert_handoff_contract(payload: dict[str, object]) -> None:
     assert boundary["reads_session_files"] is False, payload
     assert boundary["mutates_codex_session"] is False, payload
     assert boundary["spends_goal_harness_quota"] is False, payload
+    assert boundary["headless_execution_disabled"] is True, payload
+    assert boundary["provides_executable_headless_command"] is False, payload
 
 
 def main() -> int:
@@ -94,10 +91,10 @@ def main() -> int:
         "--agent-id",
         AGENT_ID,
     )
-    assert "# Codex CLI Exec Handoff" in cli_markdown, cli_markdown
-    assert "explicit headless fallback" in cli_markdown, cli_markdown
-    assert "Prefer `goal-harness codex-cli-bootstrap-message`" in cli_markdown, cli_markdown
-    assert "cat <<'GOAL_HARNESS_CODEX_PROMPT' | codex exec" in cli_markdown, cli_markdown
+    assert "# Codex CLI Exec Handoff Disabled" in cli_markdown, cli_markdown
+    assert "Headless `codex exec` handoff is disabled" in cli_markdown, cli_markdown
+    assert "codex-cli-bootstrap-message" in cli_markdown, cli_markdown
+    assert "cat <<'GOAL_HARNESS_CODEX_PROMPT' | codex exec" not in cli_markdown, cli_markdown
 
     print("codex-cli-exec-handoff-smoke ok")
     return 0

--- a/examples/codex-cli-first-run-rehearsal-smoke.py
+++ b/examples/codex-cli-first-run-rehearsal-smoke.py
@@ -88,12 +88,12 @@ def assert_cli_surfaces_align() -> None:
         "--message-only",
     )
     normalized = normalize(message)
-    assert "Start the Goal Harness loop" in normalized, message
+    assert "/goal Advance `public-codex-cli-goal` from the registry-declared active state" in normalized, message
     assert "install-from-github.sh" in normalized, message
-    assert "same Codex CLI TUI session" in normalized, message
+    assert "visible Codex CLI TUI" in normalized, message
     assert "quota should-run" in normalized, message
     assert "quota spend-slot" in normalized, message
-    assert "no raw Codex transcripts" in normalized, message
+    assert "raw Codex transcripts/session files" in normalized, message
 
     bundle = run_cli(
         "codex-cli-tui-bootstrap-smoke-bundle",

--- a/examples/codex-cli-live-tui-first-message-pilot-smoke.py
+++ b/examples/codex-cli-live-tui-first-message-pilot-smoke.py
@@ -89,11 +89,11 @@ def assert_bootstrap_message_still_copy_first() -> None:
         "--message-only",
     )
     normalized = normalize(message)
-    assert "Start the Goal Harness loop" in normalized, message
-    assert "same Codex CLI TUI session" in normalized, message
-    assert "begin the Goal Harness loop automatically" in normalized, message
-    assert "Do not store raw Codex transcripts" in normalized, message
-    assert "visible steering turns" in normalized, message
+    assert "/goal Advance `public-live-tui-pilot-goal` from the registry-declared active state" in normalized, message
+    assert "visible Codex CLI TUI" in normalized, message
+    assert "durable TUI heartbeat prompt" in normalized, message
+    assert "raw Codex transcripts/session files" in normalized, message
+    assert "keep the user able to watch, steer, review, and take over" in normalized, message
 
 
 def main() -> int:

--- a/examples/codex-cli-local-driver-plan-smoke.py
+++ b/examples/codex-cli-local-driver-plan-smoke.py
@@ -94,12 +94,13 @@ def assert_common_contract(payload: dict[str, object]) -> None:
     assert "quota should-run --goal-id public-codex-cli-goal --agent-id codex-side-bypass" in commands["quota_guard"], payload
     assert "codex-cli-visible-driver-plan" in commands["visible_driver_plan"], payload
     assert "codex-cli-bootstrap-message" in commands["tui_bootstrap_message"], payload
-    assert "codex-cli-exec-handoff" in commands["explicit_headless_fallback"], payload
+    assert commands["explicit_headless_fallback"] is None, payload
+    assert "headless codex exec is disabled" in commands["headless_fallback_disabled"], payload
     assert payload["idle_guard"]["required"] is True, payload
     assert payload["idle_guard"]["implemented"] is False, payload
     policy = payload["execution_policy"]
     assert policy["tui_bootstrap_primary"] is True, payload
-    assert policy["headless_fallback_requires_user_opt_in"] is True, payload
+    assert policy["headless_execution_disabled"] is True, payload
     assert policy["same_session_attachment_requires_visible_proof"] is True, payload
     boundary = payload["boundary"]
     assert boundary["dry_run_plan_only"] is True, payload
@@ -125,8 +126,8 @@ def build_plan(command_outputs: dict[str, str]) -> dict[str, object]:
 def main() -> int:
     fallback_plan = build_plan(HELP_FIXTURE)
     assert_common_contract(fallback_plan)
-    assert fallback_plan["driver_mode"] == "explicit_headless_fallback_after_tui_bootstrap", fallback_plan
-    assert fallback_plan["decision"] == "keep_tui_primary_offer_explicit_exec_fallback", fallback_plan
+    assert fallback_plan["driver_mode"] == "tui_bootstrap_only", fallback_plan
+    assert fallback_plan["decision"] == "ask_user_to_start_from_tui", fallback_plan
 
     remote_plan = build_plan(REMOTE_RESUME_HELP_FIXTURE)
     assert_common_contract(remote_plan)
@@ -172,7 +173,7 @@ def main() -> int:
         )
         assert "# Codex CLI Local Driver Plan" in cli_markdown, cli_markdown
         assert "driver_phase: `dry_run_plan`" in cli_markdown, cli_markdown
-        assert "headless_fallback_requires_user_opt_in: `True`" in cli_markdown, cli_markdown
+        assert "headless_execution_disabled: `True`" in cli_markdown, cli_markdown
 
     print("codex-cli-local-driver-plan-smoke ok")
     return 0

--- a/examples/codex-cli-local-scheduler-tick-smoke.py
+++ b/examples/codex-cli-local-scheduler-tick-smoke.py
@@ -124,6 +124,7 @@ def assert_boundary(payload: dict[str, object]) -> None:
     assert boundary["spends_goal_harness_quota"] is False, payload
     assert boundary["writes_goal_harness_state"] is False, payload
     assert boundary["visible_candidate_requires_runtime_idle_detector"] is True, payload
+    assert boundary["headless_execution_disabled"] is True, payload
 
 
 def build_tick(
@@ -165,16 +166,18 @@ def main() -> int:
     assert "refresh-state" in proof_missing["blocker_writeback_command"], proof_missing
     assert proof_missing["candidate_command"] is None, proof_missing
 
-    opt_in_missing = build_tick(FALLBACK_HELP_FIXTURE)
-    assert_boundary(opt_in_missing)
-    assert opt_in_missing["scheduler_action"] == "write_precise_blocker", opt_in_missing
-    assert opt_in_missing["precise_blocker"]["reason"] == "headless_fallback_opt_in_missing", opt_in_missing
+    tui_only = build_tick(FALLBACK_HELP_FIXTURE)
+    assert_boundary(tui_only)
+    assert tui_only["scheduler_action"] == "surface_tui_bootstrap", tui_only
+    assert tui_only["candidate_command"] is None, tui_only
+    assert tui_only["blocker_writeback_command"] is None, tui_only
 
-    fallback_candidate = build_tick(FALLBACK_HELP_FIXTURE, allow_headless_fallback=True)
-    assert_boundary(fallback_candidate)
-    assert fallback_candidate["scheduler_action"] == "external_headless_fallback_candidate", fallback_candidate
-    assert "codex-cli-exec-handoff" in fallback_candidate["candidate_command"], fallback_candidate
-    assert fallback_candidate["blocker_writeback_command"] is None, fallback_candidate
+    fallback_ignored = build_tick(FALLBACK_HELP_FIXTURE, allow_headless_fallback=True)
+    assert_boundary(fallback_ignored)
+    assert fallback_ignored["scheduler_action"] == "surface_tui_bootstrap", fallback_ignored
+    assert fallback_ignored["candidate_command"] is None, fallback_ignored
+    assert fallback_ignored["blocker_writeback_command"] is None, fallback_ignored
+    assert any("allow_headless_fallback was ignored" in warning for warning in fallback_ignored["warnings"]), fallback_ignored
 
     visible_idle_missing = build_tick(REMOTE_RESUME_HELP_FIXTURE, proof_payload=VISIBLE_PROOF_FIXTURE)
     assert_boundary(visible_idle_missing)

--- a/examples/codex-cli-no-clone-release-verification-smoke.py
+++ b/examples/codex-cli-no-clone-release-verification-smoke.py
@@ -119,12 +119,12 @@ def assert_installed_release(
         cwd=fresh_repo,
     ).stdout
     normalized_message = normalize(message)
-    assert "Start the Goal Harness loop" in normalized_message, message
+    assert "/goal Advance `public-no-clone-release-goal` from the registry-declared active state" in normalized_message, message
     assert "install-from-github.sh" in normalized_message, message
-    assert "same Codex CLI TUI session" in normalized_message, message
+    assert "visible Codex CLI TUI" in normalized_message, message
     assert "quota should-run" in normalized_message, message
     assert "quota spend-slot" in normalized_message, message
-    assert "no raw Codex transcripts" in normalized_message, message
+    assert "raw Codex transcripts/session files" in normalized_message, message
 
     bundle = json.loads(
         run(

--- a/examples/codex-cli-one-message-loop-pilot-smoke.py
+++ b/examples/codex-cli-one-message-loop-pilot-smoke.py
@@ -126,7 +126,7 @@ def assert_pilot_boundary(payload: dict[str, object]) -> None:
     assert boundary["mutates_codex_session"] is False, payload
     assert boundary["spends_goal_harness_quota"] is False, payload
     assert boundary["requires_user_visible_start"] is True, payload
-    assert boundary["headless_fallback_explicit_only"] is True, payload
+    assert boundary["headless_execution_disabled"] is True, payload
 
 
 def run_cli(*extra_args: str) -> str:
@@ -148,9 +148,9 @@ def main() -> int:
     assert no_proof["first_turn"]["autostarts_goal_harness_loop"] is True, no_proof
     assert no_proof["first_turn"]["preserve_tui"] is True, no_proof
     assert "workspace_guard" in no_proof["first_turn"]["stop_only_for"], no_proof
-    assert "Start the Goal Harness loop" in no_proof["first_turn"]["message"], no_proof
-    assert "begin the Goal Harness loop automatically" in no_proof["first_turn"]["message"], no_proof
-    assert "same Codex CLI TUI" in no_proof["first_turn"]["message"], no_proof
+    assert no_proof["first_turn"]["message"].startswith("/goal Advance `public-codex-cli-goal`"), no_proof
+    assert "visible Codex CLI TUI" in no_proof["first_turn"]["message"], no_proof
+    assert "do not use hidden headless codex exec" in no_proof["first_turn"]["message"], no_proof
     assert "runtime_idle_evidence" in no_proof["later_turn_contract"]["visible_steering_requires"], no_proof
     assert no_proof["later_turn_contract"]["default_without_proof"] == "write_blocker_or_keep_tui_bootstrap_primary", no_proof
     assert no_proof["automation_bridge"]["command"] == "codex-cli-local-scheduler-exec", no_proof

--- a/examples/codex-cli-session-probe-smoke.py
+++ b/examples/codex-cli-session-probe-smoke.py
@@ -99,8 +99,9 @@ def assert_fallback_contract(payload: dict[str, object]) -> None:
     assert capabilities["remote_control_surface_detected"] is False, payload
     assert capabilities["same_tui_injection_detected"] is False, payload
     assert capabilities["safe_injection_supported"] is False, payload
-    assert payload["recommended_mode"] == "tui_bootstrap_then_explicit_headless_fallback", payload
-    assert payload["automation_action"] == "keep_tui_bootstrap_primary_and_require_explicit_fallback", payload
+    assert payload["recommended_mode"] == "tui_bootstrap_only", payload
+    assert payload["automation_action"] == "ask_user_to_start_inside_codex_cli_tui", payload
+    assert any("headless fallback is disabled" in warning for warning in payload["warnings"]), payload
     boundary = payload["boundary"]
     assert boundary["help_only_probe"] is True, payload
     assert boundary["reads_raw_transcripts"] is False, payload
@@ -136,7 +137,8 @@ def main() -> int:
     assert remote_plan["boundary"]["mutates_codex_session"] is False, remote_plan
     assert remote_plan["boundary"]["spends_goal_harness_quota"] is False, remote_plan
     assert "resume [PROMPT]" in " ".join(remote_plan["driver_steps"]), remote_plan
-    assert "goal-harness codex-cli-exec-handoff" in remote_plan["commands"]["explicit_headless_fallback"], remote_plan
+    assert remote_plan["commands"]["explicit_headless_fallback"] is None, remote_plan
+    assert "headless codex exec is disabled" in remote_plan["commands"]["headless_fallback_disabled"], remote_plan
 
     attach_payload = classify_codex_cli_session_surface(command_outputs=ATTACH_HELP_FIXTURE)
     assert attach_payload["capabilities"]["safe_injection_supported"] is True, attach_payload
@@ -168,7 +170,7 @@ def main() -> int:
 
         cli_markdown = run_cli("codex-cli-session-probe", "--fixture", str(fixture))
         assert "# Codex CLI Session Probe" in cli_markdown, cli_markdown
-        assert "recommended_mode: `tui_bootstrap_then_explicit_headless_fallback`" in cli_markdown, cli_markdown
+        assert "recommended_mode: `tui_bootstrap_only`" in cli_markdown, cli_markdown
         assert "same_tui_injection_detected: `False`" in cli_markdown, cli_markdown
 
         remote_fixture = Path(tmp) / "codex-remote-help.json"

--- a/examples/codex-cli-tui-bootstrap-smoke-bundle-smoke.py
+++ b/examples/codex-cli-tui-bootstrap-smoke-bundle-smoke.py
@@ -124,7 +124,7 @@ def main() -> None:
         assert "--agent-id codex-side-bypass" in bundle["quota_guard_command"], bundle
         assert "refresh-state --goal-id public-fresh-codex-cli-goal" in bundle["refresh_command"], bundle
         assert "quota spend-slot" in bundle["quota_spend_command"], bundle
-        assert "--source controller --execute --agent-id codex-side-bypass" in bundle["quota_spend_command"], bundle
+        assert "--source heartbeat --execute --agent-id codex-side-bypass" in bundle["quota_spend_command"], bundle
         assert any("message-only command" in item for item in bundle["validation_checklist"]), bundle
         assert any("no raw Codex transcripts" in item for item in bundle["validation_checklist"]), bundle
 
@@ -155,14 +155,14 @@ def main() -> None:
             env=env,
             cwd=fresh_repo,
         ).stdout
-        assert message_only.startswith("Start the Goal Harness loop"), message_only
+        assert message_only.startswith("/goal Advance `public-fresh-codex-cli-goal` from the registry-declared active state"), message_only
         assert "# Codex CLI Goal Harness Bootstrap Message" not in message_only, message_only
         assert "Fresh Repo Install Repair" not in message_only, message_only
         assert "install-from-github.sh" in message_only, message_only
         assert "quota should-run" in message_only, message_only
         assert "refresh-state --goal-id public-fresh-codex-cli-goal" in message_only, message_only
         assert "quota spend-slot" in message_only, message_only
-        assert "no raw Codex transcripts" in message_only, message_only
+        assert "raw Codex transcripts/session files" in message_only, message_only
 
         markdown = run(
             [

--- a/examples/codex-cli-visible-attach-acceptance-smoke.py
+++ b/examples/codex-cli-visible-attach-acceptance-smoke.py
@@ -201,9 +201,10 @@ def main() -> int:
     assert_public_safe_boundary(missing_idle)
 
     fallback = build(FALLBACK_HELP_FIXTURE)
-    assert fallback["decision"] == "explicit_headless_fallback_after_tui_bootstrap", fallback
+    assert fallback["decision"] == "tui_bootstrap_only", fallback
     assert fallback["accepted_for_same_tui_automation"] is False, fallback
     assert fallback["accepted_for_visible_later_turn"] is False, fallback
+    assert fallback["requirements"]["headless_execution_disabled"] is True, fallback
     assert_public_safe_boundary(fallback)
 
     with tempfile.TemporaryDirectory(prefix="goal-harness-codex-cli-visible-attach-") as tmp:

--- a/examples/codex-cli-visible-driver-run-smoke.py
+++ b/examples/codex-cli-visible-driver-run-smoke.py
@@ -114,7 +114,7 @@ def assert_boundary(payload: dict[str, object]) -> None:
     policy = payload["execution_policy"]
     assert policy["tui_bootstrap_primary"] is True, payload
     assert policy["same_session_attachment_requires_visible_proof"] is True, payload
-    assert policy["headless_fallback_requires_explicit_opt_in"] is True, payload
+    assert policy["headless_execution_disabled"] is True, payload
     assert policy["quota_guard_required"] is True, payload
     assert policy["idle_guard_required_before_visible_prompt"] is True, payload
     assert policy["spend_after_validated_writeback_only"] is True, payload
@@ -146,17 +146,18 @@ def main() -> int:
     assert proof_required["visible_session_proof"]["supplied"] is False, proof_required
     assert "codex-cli-visible-session-proof" in proof_required["recommended_command"], proof_required
 
-    fallback_blocked = build_packet(FALLBACK_HELP_FIXTURE)
-    assert_boundary(fallback_blocked)
-    assert fallback_blocked["decision"] == "headless_fallback_requires_explicit_opt_in", fallback_blocked
-    assert fallback_blocked["next_driver_action"] == "ask_user_before_headless_codex_exec", fallback_blocked
-    assert "codex-cli-bootstrap-message" in fallback_blocked["recommended_command"], fallback_blocked
+    tui_only = build_packet(FALLBACK_HELP_FIXTURE)
+    assert_boundary(tui_only)
+    assert tui_only["decision"] == "tui_bootstrap_only", tui_only
+    assert tui_only["next_driver_action"] == "ask_user_to_start_inside_codex_cli_tui", tui_only
+    assert "codex-cli-bootstrap-message" in tui_only["recommended_command"], tui_only
 
-    fallback_allowed = build_packet(FALLBACK_HELP_FIXTURE, allow_headless_fallback=True)
-    assert_boundary(fallback_allowed)
-    assert fallback_allowed["decision"] == "headless_fallback_command_ready", fallback_allowed
-    assert fallback_allowed["next_driver_action"] == "run_explicit_headless_fallback_after_quota_guard", fallback_allowed
-    assert "codex-cli-exec-handoff" in fallback_allowed["recommended_command"], fallback_allowed
+    fallback_ignored = build_packet(FALLBACK_HELP_FIXTURE, allow_headless_fallback=True)
+    assert_boundary(fallback_ignored)
+    assert fallback_ignored["decision"] == "tui_bootstrap_only", fallback_ignored
+    assert fallback_ignored["next_driver_action"] == "ask_user_to_start_inside_codex_cli_tui", fallback_ignored
+    assert "codex-cli-bootstrap-message" in fallback_ignored["recommended_command"], fallback_ignored
+    assert any("allow_headless_fallback was ignored" in warning for warning in fallback_ignored["warnings"]), fallback_ignored
 
     visible_candidate = build_packet(REMOTE_RESUME_HELP_FIXTURE, proof_payload=VISIBLE_PROOF_FIXTURE)
     assert_boundary(visible_candidate)

--- a/examples/docs-governance-smoke.py
+++ b/examples/docs-governance-smoke.py
@@ -128,9 +128,9 @@ def main() -> int:
         assert required in compact_project_agent_contract, required
 
     for required in [
-        "The best first-run experience is one TUI message",
+        "The best first-run experience is one TUI goal-mode message",
         "Session-Attached Automation",
-        "Headless fallback should never be the only way to start Goal Harness",
+        "Headless Disabled Boundary",
     ]:
         assert required in compact_codex_cli_tui_loop, required
 

--- a/goal_harness/cli_commands/starter.py
+++ b/goal_harness/cli_commands/starter.py
@@ -267,7 +267,7 @@ def register_starter_commands(subparsers: argparse._SubParsersAction) -> None:
     codex_cli_one_message_loop_parser.add_argument(
         "--allow-headless-fallback",
         action="store_true",
-        help="Explicitly mark user/operator opt-in for a headless codex exec fallback candidate.",
+        help="Deprecated and ignored; headless codex exec is disabled for this default /goal path.",
     )
 
     codex_cli_visible_local_driver_parser = subparsers.add_parser(
@@ -315,7 +315,7 @@ def register_starter_commands(subparsers: argparse._SubParsersAction) -> None:
     codex_cli_visible_local_driver_parser.add_argument(
         "--allow-headless-fallback",
         action="store_true",
-        help="Explicitly mark user/operator opt-in for a headless codex exec fallback candidate.",
+        help="Deprecated and ignored; headless codex exec is disabled for this default /goal path.",
     )
 
     codex_cli_bounded_visible_parser = subparsers.add_parser(
@@ -508,7 +508,7 @@ def register_starter_commands(subparsers: argparse._SubParsersAction) -> None:
     codex_cli_visible_driver_run_parser.add_argument(
         "--codex-bin",
         default=DEFAULT_CODEX_BIN,
-        help="Codex CLI executable to probe and reference in fallback commands.",
+        help="Codex CLI executable to probe for visible-session capabilities.",
     )
     codex_cli_visible_driver_run_parser.add_argument(
         "--timeout-seconds",
@@ -527,7 +527,7 @@ def register_starter_commands(subparsers: argparse._SubParsersAction) -> None:
     codex_cli_visible_driver_run_parser.add_argument(
         "--allow-headless-fallback",
         action="store_true",
-        help="Explicitly mark user/operator opt-in for a headless codex exec fallback packet.",
+        help="Deprecated and ignored; headless codex exec is disabled for this default /goal path.",
     )
 
     codex_cli_local_scheduler_tick_parser = subparsers.add_parser(
@@ -548,7 +548,7 @@ def register_starter_commands(subparsers: argparse._SubParsersAction) -> None:
     codex_cli_local_scheduler_tick_parser.add_argument(
         "--codex-bin",
         default=DEFAULT_CODEX_BIN,
-        help="Codex CLI executable to probe and reference in fallback commands.",
+        help="Codex CLI executable to probe for visible-session capabilities.",
     )
     codex_cli_local_scheduler_tick_parser.add_argument(
         "--timeout-seconds",
@@ -568,7 +568,7 @@ def register_starter_commands(subparsers: argparse._SubParsersAction) -> None:
     codex_cli_local_scheduler_tick_parser.add_argument(
         "--allow-headless-fallback",
         action="store_true",
-        help="Explicitly mark user/operator opt-in for a headless codex exec fallback candidate.",
+        help="Deprecated and ignored; headless codex exec is disabled for this default /goal path.",
     )
 
     codex_cli_local_scheduler_exec_parser = subparsers.add_parser(
@@ -589,7 +589,7 @@ def register_starter_commands(subparsers: argparse._SubParsersAction) -> None:
     codex_cli_local_scheduler_exec_parser.add_argument(
         "--codex-bin",
         default=DEFAULT_CODEX_BIN,
-        help="Codex CLI executable to probe and reference in fallback commands.",
+        help="Codex CLI executable to probe for visible-session capabilities.",
     )
     codex_cli_local_scheduler_exec_parser.add_argument(
         "--timeout-seconds",
@@ -615,7 +615,7 @@ def register_starter_commands(subparsers: argparse._SubParsersAction) -> None:
     codex_cli_local_scheduler_exec_parser.add_argument(
         "--allow-headless-fallback",
         action="store_true",
-        help="Explicitly mark user/operator opt-in for a headless codex exec fallback candidate.",
+        help="Deprecated and ignored; headless codex exec is disabled for this default /goal path.",
     )
     codex_cli_local_scheduler_exec_parser.add_argument(
         "--guard-checked",
@@ -739,7 +739,7 @@ def register_starter_commands(subparsers: argparse._SubParsersAction) -> None:
 
     codex_cli_exec_parser = subparsers.add_parser(
         "codex-cli-exec-handoff",
-        help="Generate an explicit one-shot codex exec fallback for Goal Harness onboarding.",
+        help="Show the disabled headless handoff boundary and the TUI message-only bootstrap command.",
     )
     codex_cli_exec_parser.add_argument("--project", default=".", help="Project directory to start from.")
     codex_cli_exec_parser.add_argument("--goal-id", help="Goal id. Defaults to <project-name>-goal.")

--- a/goal_harness/codex_cli_probe.py
+++ b/goal_harness/codex_cli_probe.py
@@ -117,8 +117,8 @@ def classify_codex_cli_session_surface(
         recommended_mode = "visible_resume_or_remote_control_spike"
         automation_action = "prototype_visible_resume_or_remote_control_with_idle_guard"
     elif exec_supported:
-        recommended_mode = "tui_bootstrap_then_explicit_headless_fallback"
-        automation_action = "keep_tui_bootstrap_primary_and_require_explicit_fallback"
+        recommended_mode = "tui_bootstrap_only"
+        automation_action = "ask_user_to_start_inside_codex_cli_tui"
     else:
         recommended_mode = "tui_bootstrap_only"
         automation_action = "ask_user_to_start_inside_codex_cli_tui"
@@ -131,6 +131,10 @@ def classify_codex_cli_session_surface(
     if (remote_control_surface_detected or visible_resume_supported) and not same_tui_injection_detected:
         warnings.append(
             "A visible resume or remote-control surface exists; prototype it behind an idle guard before calling it session-attached automation."
+        )
+    if exec_supported and not (safe_injection_supported or remote_control_surface_detected or visible_resume_supported):
+        warnings.append(
+            "Codex exec is available, but headless fallback is disabled for the default Goal Harness /goal bootstrap path."
         )
     if not codex_cli_available:
         warnings.append("Codex CLI was not available on PATH; classification used missing-command evidence.")
@@ -701,7 +705,7 @@ def build_codex_cli_visible_session_proof(
     else:
         decision = "visible_session_proof_incomplete"
         recommended_action = (
-            "keep TUI bootstrap primary and headless exec explicit; do not treat this as same-session automation"
+            "keep TUI bootstrap primary; do not treat this as same-session automation"
         )
 
     return {
@@ -828,19 +832,14 @@ def build_codex_cli_visible_attach_acceptance(
             "do not call this accepted automation yet; first prove visibility, "
             "interruptibility, boundaries, and compact writeback planning"
         )
-    elif driver_mode == "explicit_headless_fallback_after_tui_bootstrap":
-        decision = "explicit_headless_fallback_after_tui_bootstrap"
-        acceptance_action = "keep_tui_bootstrap_primary_and_require_explicit_fallback_opt_in"
-        blockers.append("same_tui_or_visible_surface_not_exposed_by_probe")
-        next_safe_step = (
-            "keep one-message TUI bootstrap as the primary path; offer headless "
-            "codex exec only after explicit opt-in"
-        )
     else:
         decision = "tui_bootstrap_only"
         acceptance_action = "ask_user_to_start_inside_codex_cli_tui"
         blockers.append("codex_cli_attach_surface_not_exposed_by_probe")
-        next_safe_step = "ask the user to start in Codex CLI TUI and paste the bootstrap message"
+        next_safe_step = (
+            "ask the user to start in Codex CLI TUI and paste the bootstrap message; "
+            "headless codex exec is disabled for this product path"
+        )
 
     commands = (
         local_plan.get("commands")
@@ -869,7 +868,7 @@ def build_codex_cli_visible_attach_acceptance(
             "runtime_idle_detector_required": True,
             "same_tui_surface_required_for_same_tui_acceptance": True,
             "fresh_quota_guard_required_before_execution": True,
-            "explicit_headless_fallback_opt_in_required": True,
+            "headless_execution_disabled": True,
         },
         "probe": {
             "schema_version": probe_payload.get("schema_version"),
@@ -917,7 +916,8 @@ def build_codex_cli_visible_attach_acceptance(
                 f"{agent_arg} --idle-fixture <public-runtime-idle.json>"
             ),
             "tui_bootstrap_message": commands.get("tui_bootstrap_message"),
-            "explicit_headless_fallback": commands.get("explicit_headless_fallback"),
+            "explicit_headless_fallback": None,
+            "headless_fallback_disabled": commands.get("headless_fallback_disabled"),
         },
         "boundary": {
             "acceptance_packet_only": True,
@@ -930,6 +930,7 @@ def build_codex_cli_visible_attach_acceptance(
             "spends_goal_harness_quota": False,
             "writes_goal_harness_state": False,
             "requires_fresh_quota_guard_before_execution": True,
+            "headless_execution_disabled": True,
         },
         "warnings": list(probe_payload.get("warnings") or []),
     }
@@ -948,7 +949,7 @@ def build_codex_cli_visible_driver_plan(
 
     The plan is intentionally read-only. It decides whether a future local
     driver should attempt a visible session attachment, run a resume/remote
-    control spike, or fall back explicitly to headless `codex exec`.
+    control spike, or keep the one-message TUI bootstrap as the product path.
     """
 
     resolved_project = str(project.expanduser())
@@ -957,7 +958,6 @@ def build_codex_cli_visible_driver_plan(
     safe_injection_supported = bool(capabilities.get("safe_injection_supported"))
     visible_resume_supported = bool(capabilities.get("visible_resume_supported"))
     remote_control_supported = bool(capabilities.get("remote_control_surface_detected"))
-    exec_supported = bool(capabilities.get("exec_supported"))
     agent_arg = f" --agent-id {_shell_arg(agent_id)}" if agent_id else ""
     quota_guard_command = (
         f"{_shell_arg(cli_bin)} --format json quota should-run "
@@ -966,11 +966,6 @@ def build_codex_cli_visible_driver_plan(
     bootstrap_command = (
         f"{_shell_arg(cli_bin)} codex-cli-bootstrap-message "
         f"--project {_shell_arg(resolved_project)} --goal-id {_shell_arg(resolved_goal_id)}{agent_arg}"
-    )
-    exec_fallback_command = (
-        f"{_shell_arg(cli_bin)} codex-cli-exec-handoff "
-        f"--project {_shell_arg(resolved_project)} --goal-id {_shell_arg(resolved_goal_id)}{agent_arg} "
-        f"--codex-bin {_shell_arg(codex_bin)}"
     )
     probe_command = f"{_shell_arg(cli_bin)} codex-cli-session-probe --codex-bin {_shell_arg(codex_bin)}"
 
@@ -982,20 +977,16 @@ def build_codex_cli_visible_driver_plan(
         driver_mode = "visible_resume_or_remote_control_spike"
         automation_action = "prototype_visible_resume_or_remote_control_with_idle_guard"
         next_step = "run an explicit proof that resume or remote-control creates a visible interruptible turn"
-    elif exec_supported:
-        driver_mode = "explicit_headless_fallback_after_tui_bootstrap"
-        automation_action = "keep_tui_bootstrap_primary_and_require_explicit_fallback"
-        next_step = "keep one-message TUI bootstrap primary; use codex exec only as explicit fallback"
     else:
         driver_mode = "tui_bootstrap_only"
         automation_action = "ask_user_to_start_inside_codex_cli_tui"
-        next_step = "ask the user to start in Codex CLI TUI and paste the bootstrap message"
+        next_step = "ask the user to start in Codex CLI TUI and paste the bootstrap message; headless fallback is disabled"
 
     driver_steps = [
         "run the session probe and quota guard before any delivery turn",
         "if user_channel.action_required=true, surface only the concrete user gate",
         "if delivery is allowed, verify idle_guard before any visible prompt",
-        "prefer a visible same-TUI turn; otherwise use the explicit headless fallback command",
+        "prefer a visible same-TUI turn; otherwise keep the one-message TUI bootstrap as the product path",
         "write back compact evidence and spend quota only after validation",
     ]
     if driver_mode == "visible_resume_or_remote_control_spike":
@@ -1024,7 +1015,8 @@ def build_codex_cli_visible_driver_plan(
             "probe": probe_command,
             "quota_guard": quota_guard_command,
             "tui_bootstrap_message": bootstrap_command,
-            "explicit_headless_fallback": exec_fallback_command,
+            "explicit_headless_fallback": None,
+            "headless_fallback_disabled": "headless codex exec is disabled for the default Goal Harness /goal bootstrap path",
         },
         "driver_steps": driver_steps,
         "boundary": {
@@ -1037,6 +1029,7 @@ def build_codex_cli_visible_driver_plan(
             "spends_goal_harness_quota": False,
             "requires_idle_guard_before_visible_prompt": True,
             "requires_user_gate_stop": True,
+            "headless_execution_disabled": True,
         },
         "warnings": list(probe_payload.get("warnings") or []),
     }
@@ -1054,8 +1047,8 @@ def build_codex_cli_local_driver_plan(
     """Build a dry-run-first local driver plan for Codex CLI.
 
     This does not launch Codex or mutate any session. It composes the existing
-    one-message TUI bootstrap, visible-driver plan, quota guard, and explicit
-    headless fallback into one operator-facing decision packet.
+    one-message TUI bootstrap, visible-driver plan, quota guard, and the
+    headless-disabled boundary into one operator-facing decision packet.
     """
 
     visible_plan = build_codex_cli_visible_driver_plan(
@@ -1083,11 +1076,6 @@ def build_codex_cli_local_driver_plan(
         f"{_shell_arg(cli_bin)} codex-cli-bootstrap-message "
         f"--project {_shell_arg(resolved_project)} --goal-id {_shell_arg(resolved_goal_id)}{agent_arg}"
     )
-    exec_fallback_command = (
-        f"{_shell_arg(cli_bin)} codex-cli-exec-handoff "
-        f"--project {_shell_arg(resolved_project)} --goal-id {_shell_arg(resolved_goal_id)}{agent_arg} "
-        f"--codex-bin {_shell_arg(codex_bin)}"
-    )
     driver_mode = str(visible_plan.get("driver_mode") or "tui_bootstrap_only")
 
     if driver_mode == "session_attached_visible_turn":
@@ -1100,14 +1088,12 @@ def build_codex_cli_local_driver_plan(
         operator_instruction = (
             "Treat resume or remote-control as a proof target, not production session attachment, until the turn is visible and interruptible."
         )
-    elif driver_mode == "explicit_headless_fallback_after_tui_bootstrap":
-        decision = "keep_tui_primary_offer_explicit_exec_fallback"
-        operator_instruction = (
-            "Keep one-message Codex CLI TUI bootstrap as the default; use codex exec only after explicit opt-in."
-        )
     else:
         decision = "ask_user_to_start_from_tui"
-        operator_instruction = "Ask the user to start inside Codex CLI TUI and paste the bootstrap message."
+        operator_instruction = (
+            "Ask the user to start inside Codex CLI TUI and paste the bootstrap message; "
+            "headless codex exec is disabled for this product path."
+        )
 
     return {
         "ok": True,
@@ -1136,14 +1122,15 @@ def build_codex_cli_local_driver_plan(
             ),
             "visible_driver_plan": visible_driver_plan_command,
             "tui_bootstrap_message": bootstrap_command,
-            "explicit_headless_fallback": exec_fallback_command,
+            "explicit_headless_fallback": None,
+            "headless_fallback_disabled": "headless codex exec is disabled for the default Goal Harness /goal bootstrap path",
         },
         "driver_steps": [
             "run quota_guard and stop when user_channel.action_required=true",
-            "run visible_driver_plan to classify TUI, resume, remote-control, or exec fallback mode",
+            "run visible_driver_plan to classify TUI, resume, or remote-control mode",
             "verify idle_guard before any visible resume or remote-control prompt",
             "prefer one-message TUI bootstrap until visible attach is proven",
-            "offer explicit_headless_fallback only after opt-in and goal_boundary approval",
+            "do not offer headless codex exec from the default Goal Harness /goal bootstrap path",
             "write back compact evidence or a precise blocker before quota spend",
         ],
         "idle_guard": {
@@ -1153,7 +1140,7 @@ def build_codex_cli_local_driver_plan(
         },
         "execution_policy": {
             "tui_bootstrap_primary": True,
-            "headless_fallback_requires_user_opt_in": True,
+            "headless_execution_disabled": True,
             "same_session_attachment_requires_visible_proof": True,
             "quota_guard_required": True,
             "spend_after_validated_writeback_only": True,
@@ -1168,6 +1155,7 @@ def build_codex_cli_local_driver_plan(
             "spends_goal_harness_quota": False,
             "requires_idle_guard_before_visible_prompt": True,
             "requires_user_gate_stop": True,
+            "headless_execution_disabled": True,
         },
         "warnings": list(visible_plan.get("warnings") or []),
     }
@@ -1187,8 +1175,9 @@ def build_codex_cli_visible_driver_run_packet(
     """Build the v0 runner packet for one visible Codex CLI driver turn.
 
     The packet is deliberately not an executor. It converts the dry-run local
-    driver plan, optional visible-session proof, and explicit headless opt-in
-    into the next safe command boundary for a local scheduler or human operator.
+    driver plan and optional visible-session proof into the next safe command
+    boundary for a local scheduler or human operator. Headless fallback remains
+    disabled for this default Goal Harness /goal bootstrap path.
     """
 
     local_plan = build_codex_cli_local_driver_plan(
@@ -1228,14 +1217,6 @@ def build_codex_cli_visible_driver_run_packet(
         decision = "visible_session_proof_required"
         next_driver_action = "capture_public_safe_visible_session_proof"
         recommended_command = proof_command
-    elif driver_mode == "explicit_headless_fallback_after_tui_bootstrap" and allow_headless_fallback:
-        decision = "headless_fallback_command_ready"
-        next_driver_action = "run_explicit_headless_fallback_after_quota_guard"
-        recommended_command = commands.get("explicit_headless_fallback")
-    elif driver_mode == "explicit_headless_fallback_after_tui_bootstrap":
-        decision = "headless_fallback_requires_explicit_opt_in"
-        next_driver_action = "ask_user_before_headless_codex_exec"
-        recommended_command = commands.get("tui_bootstrap_message")
     else:
         decision = "tui_bootstrap_only"
         next_driver_action = "ask_user_to_start_inside_codex_cli_tui"
@@ -1245,10 +1226,15 @@ def build_codex_cli_visible_driver_run_packet(
         "run quota_guard and stop if user_channel.action_required=true",
         "stop or relocate if workspace_guard blocks the current checkout",
         "use a visible session only when proof_approved=true and an idle guard passes",
-        "use headless codex exec only when allow_headless_fallback=true and the goal boundary permits it",
+        "do not use headless codex exec from the default Goal Harness /goal bootstrap path",
         "after the Codex turn, validate evidence or blocker before refresh-state",
         "spend quota exactly once after validated writeback, never for this packet alone",
     ]
+    warnings = list(local_plan.get("warnings") or [])
+    if allow_headless_fallback:
+        warnings.append(
+            "allow_headless_fallback was ignored because headless fallback is disabled for the default Goal Harness /goal bootstrap path."
+        )
 
     return {
         "ok": True,
@@ -1280,13 +1266,14 @@ def build_codex_cli_visible_driver_run_packet(
             "quota_guard": commands.get("quota_guard"),
             "tui_bootstrap_message": commands.get("tui_bootstrap_message"),
             "visible_session_proof": proof_command,
-            "explicit_headless_fallback": commands.get("explicit_headless_fallback"),
+            "explicit_headless_fallback": None,
+            "headless_fallback_disabled": commands.get("headless_fallback_disabled"),
         },
         "driver_steps": driver_steps,
         "execution_policy": {
             "tui_bootstrap_primary": True,
             "same_session_attachment_requires_visible_proof": True,
-            "headless_fallback_requires_explicit_opt_in": True,
+            "headless_execution_disabled": True,
             "quota_guard_required": True,
             "idle_guard_required_before_visible_prompt": True,
             "spend_after_validated_writeback_only": True,
@@ -1300,9 +1287,9 @@ def build_codex_cli_visible_driver_run_packet(
             "mutates_codex_session": False,
             "spends_goal_harness_quota": False,
             "requires_user_gate_stop": True,
-            "requires_goal_boundary_before_headless": True,
+            "headless_execution_disabled": True,
         },
-        "warnings": list(local_plan.get("warnings") or []),
+        "warnings": warnings,
     }
 
 
@@ -1412,10 +1399,6 @@ def build_codex_cli_local_scheduler_tick(
                 "capture a public-safe runtime idle observation, keep the one-message TUI path visible, "
                 "and do not run Codex from the scheduler"
             )
-    elif decision == "headless_fallback_command_ready":
-        scheduler_action = "external_headless_fallback_candidate"
-        candidate_command = run_packet.get("recommended_command")
-        next_safe_step = "external scheduler may run the headless fallback only after explicit opt-in and a fresh quota guard"
     elif decision == "visible_session_proof_required":
         scheduler_action = "write_precise_blocker"
         precise_blocker = {
@@ -1427,13 +1410,13 @@ def build_codex_cli_local_scheduler_tick(
             ),
         }
         next_safe_step = "write the blocker, keep TUI bootstrap primary, and do not run Codex from the scheduler"
-    elif decision == "headless_fallback_requires_explicit_opt_in":
+    elif decision.startswith("headless_"):
         scheduler_action = "write_precise_blocker"
         precise_blocker = {
-            "reason": "headless_fallback_opt_in_missing",
+            "reason": "headless_fallback_disabled",
             "message": (
-                "Codex CLI automation is blocked from using headless codex exec until the user "
-                "or operator explicitly opts into the fallback for this goal."
+                "Codex CLI headless fallback is disabled for the default Goal Harness "
+                "/goal bootstrap path; keep the visible TUI bootstrap primary."
             ),
         }
         next_safe_step = "write the blocker and keep the one-message TUI bootstrap as the user-facing path"
@@ -1513,7 +1496,7 @@ def build_codex_cli_local_scheduler_tick(
             "writes_goal_harness_state": False,
             "blocker_writeback_requires_external_execution": True,
             "visible_candidate_requires_runtime_idle_detector": True,
-            "headless_fallback_requires_runtime_idle_detector": False,
+            "headless_execution_disabled": True,
         },
         "warnings": list(run_packet.get("warnings") or []),
     }
@@ -1639,10 +1622,7 @@ def execute_codex_cli_local_scheduler_tick_result(
     elif (execute_candidate or execute_blocker_writeback) and not guard_checked:
         execution["reason"] = "fresh_quota_guard_confirmation_required"
     elif execute_candidate:
-        if scheduler_action not in {
-            "external_visible_command_candidate",
-            "external_headless_fallback_candidate",
-        }:
+        if scheduler_action != "external_visible_command_candidate":
             execution["reason"] = "scheduler_action_not_candidate"
         elif scheduler_action == "external_visible_command_candidate" and not runtime_idle_approved:
             execution["reason"] = "runtime_idle_detector_required"
@@ -1837,7 +1817,7 @@ def build_codex_cli_one_message_loop_pilot(
         else {}
     )
     scheduler_blocker_reason = str(scheduler_blocker.get("reason") or "")
-    if scheduler_action in {"external_visible_command_candidate", "external_headless_fallback_candidate"}:
+    if scheduler_action == "external_visible_command_candidate":
         pilot_decision = "first_message_then_candidate_available"
         followup_mode = "local scheduler can show the candidate, but execution still requires guard and prefix opt-in"
     elif scheduler_action == "write_precise_blocker" and scheduler_blocker_reason.startswith("runtime_idle_"):
@@ -1850,7 +1830,7 @@ def build_codex_cli_one_message_loop_pilot(
         followup_mode = "local scheduler can write the precise blocker after explicit guard-checked opt-in"
     else:
         pilot_decision = "first_message_tui_bootstrap_only"
-        followup_mode = "keep the TUI bootstrap as the product path until a proof or opt-in exists"
+        followup_mode = "keep the TUI bootstrap as the product path until a visible proof exists"
 
     bootstrap_command = (
         f"{_shell_arg(cli_bin)} codex-cli-bootstrap-message "
@@ -1861,7 +1841,6 @@ def build_codex_cli_one_message_loop_pilot(
         " --observe-local-runtime --observed-surface visible_resume_prompt "
         "--turn-state idle --probe-human-input-idle --checked-before-prompt "
         "--visible-to-user --user-can-interrupt --manual-takeover-available"
-        f"{' --allow-headless-fallback' if allow_headless_fallback else ''}"
     )
     candidate_execute_template = (
         f"{scheduler_exec_dry_run_command} --guard-checked --execute-candidate "
@@ -1944,7 +1923,7 @@ def build_codex_cli_one_message_loop_pilot(
             "mutates_codex_session": False,
             "spends_goal_harness_quota": False,
             "requires_user_visible_start": True,
-            "headless_fallback_explicit_only": True,
+            "headless_execution_disabled": True,
             "candidate_execution_requires_guard_and_prefix": True,
         },
         "warnings": list(scheduler_executor.get("warnings") or []),
@@ -2142,7 +2121,7 @@ def build_codex_cli_visible_local_driver_pilot(
             "later_turns_visible_to_user": True,
             "user_can_interrupt_or_take_over": True,
             "same_session_attachment_requires_visible_proof": True,
-            "headless_fallback_requires_explicit_opt_in": True,
+            "headless_execution_disabled": True,
             "quota_guard_required_each_tick": True,
             "spend_after_validated_writeback_only": True,
         },
@@ -2160,6 +2139,7 @@ def build_codex_cli_visible_local_driver_pilot(
             "requires_fresh_guard_before_execution": True,
             "candidate_execution_requires_guard_and_prefix": True,
             "blocker_writeback_requires_guard_checked": True,
+            "headless_execution_disabled": True,
         },
         "warnings": [
             *list(one_message.get("warnings") or []),
@@ -2635,6 +2615,9 @@ def render_codex_cli_visible_driver_plan_markdown(payload: dict[str, Any]) -> st
     warnings = payload.get("warnings") if isinstance(payload.get("warnings"), list) else []
     step_lines = "\n".join(f"{index}. {step}" for index, step in enumerate(steps, start=1))
     warning_lines = "\n".join(f"- {warning}" for warning in warnings) if warnings else "- none"
+    headless_line = commands.get("explicit_headless_fallback") or (
+        f"# {commands.get('headless_fallback_disabled') or 'headless fallback disabled'}"
+    )
     return f"""# Codex CLI Visible Driver Plan
 
 - driver_mode: `{payload.get("driver_mode")}`
@@ -2648,7 +2631,7 @@ def render_codex_cli_visible_driver_plan_markdown(payload: dict[str, Any]) -> st
 {commands.get("probe")}
 {commands.get("quota_guard")}
 {commands.get("tui_bootstrap_message")}
-{commands.get("explicit_headless_fallback")}
+{headless_line}
 ```
 
 ## Driver Steps
@@ -2680,6 +2663,9 @@ def render_codex_cli_local_driver_plan_markdown(payload: dict[str, Any]) -> str:
     warnings = payload.get("warnings") if isinstance(payload.get("warnings"), list) else []
     step_lines = "\n".join(f"{index}. {step}" for index, step in enumerate(steps, start=1))
     warning_lines = "\n".join(f"- {warning}" for warning in warnings) if warnings else "- none"
+    headless_line = commands.get("explicit_headless_fallback") or (
+        f"# {commands.get('headless_fallback_disabled') or 'headless fallback disabled'}"
+    )
     return f"""# Codex CLI Local Driver Plan
 
 - driver_phase: `{payload.get("driver_phase")}`
@@ -2693,7 +2679,7 @@ def render_codex_cli_local_driver_plan_markdown(payload: dict[str, Any]) -> str:
 {commands.get("quota_guard")}
 {commands.get("visible_driver_plan")}
 {commands.get("tui_bootstrap_message")}
-{commands.get("explicit_headless_fallback")}
+{headless_line}
 ```
 
 ## Driver Steps
@@ -2709,7 +2695,7 @@ def render_codex_cli_local_driver_plan_markdown(payload: dict[str, Any]) -> str:
 ## Execution Policy
 
 - tui_bootstrap_primary: `{policy.get("tui_bootstrap_primary")}`
-- headless_fallback_requires_user_opt_in: `{policy.get("headless_fallback_requires_user_opt_in")}`
+- headless_execution_disabled: `{policy.get("headless_execution_disabled")}`
 - same_session_attachment_requires_visible_proof: `{policy.get("same_session_attachment_requires_visible_proof")}`
 - quota_guard_required: `{policy.get("quota_guard_required")}`
 - spend_after_validated_writeback_only: `{policy.get("spend_after_validated_writeback_only")}`
@@ -2738,6 +2724,9 @@ def render_codex_cli_visible_driver_run_packet_markdown(payload: dict[str, Any])
     warnings = payload.get("warnings") if isinstance(payload.get("warnings"), list) else []
     step_lines = "\n".join(f"{index}. {step}" for index, step in enumerate(steps, start=1))
     warning_lines = "\n".join(f"- {warning}" for warning in warnings) if warnings else "- none"
+    headless_line = commands.get("explicit_headless_fallback") or (
+        f"# {commands.get('headless_fallback_disabled') or 'headless fallback disabled'}"
+    )
     return f"""# Codex CLI Visible Driver Run Packet
 
 - driver_phase: `{payload.get("driver_phase")}`
@@ -2758,7 +2747,7 @@ def render_codex_cli_visible_driver_run_packet_markdown(payload: dict[str, Any])
 {commands.get("quota_guard")}
 {commands.get("tui_bootstrap_message")}
 {commands.get("visible_session_proof")}
-{commands.get("explicit_headless_fallback")}
+{headless_line}
 ```
 
 ## Visible Session Proof
@@ -2776,7 +2765,7 @@ def render_codex_cli_visible_driver_run_packet_markdown(payload: dict[str, Any])
 
 - tui_bootstrap_primary: `{policy.get("tui_bootstrap_primary")}`
 - same_session_attachment_requires_visible_proof: `{policy.get("same_session_attachment_requires_visible_proof")}`
-- headless_fallback_requires_explicit_opt_in: `{policy.get("headless_fallback_requires_explicit_opt_in")}`
+- headless_execution_disabled: `{policy.get("headless_execution_disabled")}`
 - quota_guard_required: `{policy.get("quota_guard_required")}`
 - idle_guard_required_before_visible_prompt: `{policy.get("idle_guard_required_before_visible_prompt")}`
 - spend_after_validated_writeback_only: `{policy.get("spend_after_validated_writeback_only")}`
@@ -2789,6 +2778,7 @@ def render_codex_cli_visible_driver_run_packet_markdown(payload: dict[str, Any])
 - reads_session_files: `{boundary.get("reads_session_files")}`
 - mutates_codex_session: `{boundary.get("mutates_codex_session")}`
 - spends_goal_harness_quota: `{boundary.get("spends_goal_harness_quota")}`
+- headless_execution_disabled: `{boundary.get("headless_execution_disabled")}`
 
 ## Warnings
 
@@ -2857,6 +2847,7 @@ def render_codex_cli_local_scheduler_tick_markdown(payload: dict[str, Any]) -> s
 - spends_goal_harness_quota: `{boundary.get("spends_goal_harness_quota")}`
 - writes_goal_harness_state: `{boundary.get("writes_goal_harness_state")}`
 - visible_candidate_requires_runtime_idle_detector: `{boundary.get("visible_candidate_requires_runtime_idle_detector")}`
+- headless_execution_disabled: `{boundary.get("headless_execution_disabled")}`
 
 ## Warnings
 
@@ -2996,7 +2987,7 @@ The first response should show:
 - mutates_codex_session: `{boundary.get("mutates_codex_session")}`
 - spends_goal_harness_quota: `{boundary.get("spends_goal_harness_quota")}`
 - requires_user_visible_start: `{boundary.get("requires_user_visible_start")}`
-- headless_fallback_explicit_only: `{boundary.get("headless_fallback_explicit_only")}`
+- headless_execution_disabled: `{boundary.get("headless_execution_disabled")}`
 - candidate_execution_requires_guard_and_prefix: `{boundary.get("candidate_execution_requires_guard_and_prefix")}`
 
 ## Warnings
@@ -3084,7 +3075,7 @@ def render_codex_cli_visible_local_driver_pilot_markdown(payload: dict[str, Any]
 - later_turns_visible_to_user: `{policy.get("later_turns_visible_to_user")}`
 - user_can_interrupt_or_take_over: `{policy.get("user_can_interrupt_or_take_over")}`
 - same_session_attachment_requires_visible_proof: `{policy.get("same_session_attachment_requires_visible_proof")}`
-- headless_fallback_requires_explicit_opt_in: `{policy.get("headless_fallback_requires_explicit_opt_in")}`
+- headless_execution_disabled: `{policy.get("headless_execution_disabled")}`
 - quota_guard_required_each_tick: `{policy.get("quota_guard_required_each_tick")}`
 - spend_after_validated_writeback_only: `{policy.get("spend_after_validated_writeback_only")}`
 
@@ -3101,6 +3092,7 @@ def render_codex_cli_visible_local_driver_pilot_markdown(payload: dict[str, Any]
 - spends_goal_harness_quota: `{boundary.get("spends_goal_harness_quota")}`
 - candidate_execution_requires_guard_and_prefix: `{boundary.get("candidate_execution_requires_guard_and_prefix")}`
 - blocker_writeback_requires_guard_checked: `{boundary.get("blocker_writeback_requires_guard_checked")}`
+- headless_execution_disabled: `{boundary.get("headless_execution_disabled")}`
 
 ## Warnings
 

--- a/goal_harness/project_prompt.py
+++ b/goal_harness/project_prompt.py
@@ -14,6 +14,7 @@ DEFAULT_HANDOFF_ADAPTER_STATUS = "connected-read-only"
 DEFAULT_HANDOFF_NEXT_PROBE = "(omit --next-probe until a read-only pre-tick command exists)"
 SHARED_GLOBAL_REGISTRY = '"$HOME/.codex/goal-harness/registry.global.json"'
 NO_CLONE_INSTALL_URL = "https://raw.githubusercontent.com/huangruiteng/goal-harness/main/scripts/install-from-github.sh"
+CODEX_GOAL_OBJECTIVE_MAX_CHARS = 6000
 
 
 def shell_arg(value: str) -> str:
@@ -74,6 +75,22 @@ def render_quota_spend_command(
         "quota spend-slot "
         f"--goal-id {shell_arg(goal_id)} "
         f"--slots 1 --source {shell_arg(source)} --execute{agent_arg}"
+    )
+
+
+def render_heartbeat_prompt_command(
+    goal_id: str,
+    *,
+    cli_bin: str = "goal-harness",
+    agent_id: str | None = None,
+    agent_scope: str = "Codex CLI /goal visible TUI loop",
+    body: str = "thin",
+) -> str:
+    agent_arg = f" --agent-id {shell_arg(agent_id)}" if agent_id else ""
+    scope_arg = f" --agent-scope {shell_arg(agent_scope)}" if agent_id else ""
+    return (
+        f"{shell_arg(cli_bin)} heartbeat-prompt --{shell_arg(body)} "
+        f"--goal-id {shell_arg(goal_id)}{agent_arg}{scope_arg}"
     )
 
 
@@ -230,7 +247,12 @@ def build_codex_cli_bootstrap_message(
     )
     quota_spend_command = render_quota_spend_command(
         resolved_goal_id,
-        source="controller",
+        source="heartbeat",
+        cli_bin=cli_bin,
+        agent_id=agent_id,
+    )
+    heartbeat_prompt_command = render_heartbeat_prompt_command(
+        resolved_goal_id,
         cli_bin=cli_bin,
         agent_id=agent_id,
     )
@@ -244,7 +266,7 @@ def build_codex_cli_bootstrap_message(
         "one bounded segment validated before refresh-state and quota spend-slot",
         "no raw Codex transcripts, session files, credentials, private paths, stdout, or stderr persisted",
     ]
-    message = render_codex_cli_bootstrap_message_text(
+    message = render_codex_cli_goal_mode_bootstrap_text(
         project=resolved_project,
         goal_id=resolved_goal_id,
         agent_id=agent_id,
@@ -253,21 +275,24 @@ def build_codex_cli_bootstrap_message(
         quota_guard_command=quota_guard_command,
         refresh_command=refresh_command,
         quota_spend_command=quota_spend_command,
-        first_run_validation_checklist=first_run_validation_checklist,
     )
     return {
         "ok": True,
         "schema_version": "codex_cli_bootstrap_message_v0",
+        "invocation_mode": "codex_cli_goal_mode",
         "project": resolved_project,
         "goal_id": resolved_goal_id,
         "agent_id": agent_id,
         "cli_bin": cli_bin,
         "install_repair_command": install_repair_command,
         "connect_command": connect_command,
+        "heartbeat_prompt_command": heartbeat_prompt_command,
         "quota_guard_command": quota_guard_command,
         "refresh_command": refresh_command,
         "quota_spend_command": quota_spend_command,
         "first_run_validation_checklist": first_run_validation_checklist,
+        "goal_objective_max_chars": CODEX_GOAL_OBJECTIVE_MAX_CHARS,
+        "goal_objective_characters": len(message.removeprefix("/goal ").strip()),
         "message": message,
     }
 
@@ -310,7 +335,7 @@ def build_codex_cli_tui_bootstrap_smoke_bundle(
     validation_checklist = [
         "archive installer works from a temporary GitHub-style tarball or existing install",
         "message-only command prints only the TUI paste block, not the Markdown review packet",
-        "paste block includes no-clone install repair, quota guard, and bounded writeback commands",
+        "paste block includes no-clone install repair, heartbeat prompt load, quota guard, and bounded writeback commands",
         "quota spend remains a post-validation command inside the paste block, not a smoke side effect",
         "no raw Codex transcripts, session files, credentials, stdout, stderr, or private paths are read",
     ]
@@ -324,28 +349,13 @@ def build_codex_cli_tui_bootstrap_smoke_bundle(
         "install_repair_command": bootstrap["install_repair_command"],
         "review_packet_command": review_packet_command,
         "message_only_command": message_only_command,
+        "heartbeat_prompt_command": bootstrap["heartbeat_prompt_command"],
         "quota_guard_command": bootstrap["quota_guard_command"],
         "refresh_command": bootstrap["refresh_command"],
         "quota_spend_command": bootstrap["quota_spend_command"],
         "validation_checklist": validation_checklist,
         "boundary": boundary,
     }
-
-
-def render_codex_cli_exec_handoff_command(
-    *,
-    project: str,
-    codex_bin: str,
-    prompt: str,
-) -> str:
-    return "\n".join(
-        [
-            f"cd {shell_arg(project)}",
-            "cat <<'GOAL_HARNESS_CODEX_PROMPT' | " f"{shell_arg(codex_bin)} exec",
-            prompt,
-            "GOAL_HARNESS_CODEX_PROMPT",
-        ]
-    )
 
 
 def build_codex_cli_exec_handoff(
@@ -364,26 +374,31 @@ def build_codex_cli_exec_handoff(
     )
     resolved_project = str(project.expanduser())
     resolved_goal_id = str(bootstrap["goal_id"])
-    prompt = str(bootstrap["message"])
-    handoff_command = render_codex_cli_exec_handoff_command(
-        project=resolved_project,
-        codex_bin=codex_bin,
-        prompt=prompt,
+    agent_arg = f" --agent-id {shell_arg(agent_id)}" if agent_id else ""
+    message_only_command = (
+        f"{shell_arg(cli_bin)} codex-cli-bootstrap-message "
+        f"--project {shell_arg(resolved_project)} "
+        f"--goal-id {shell_arg(resolved_goal_id)}{agent_arg} --message-only"
     )
     return {
         "ok": True,
         "schema_version": "codex_cli_exec_handoff_v0",
-        "mode": "explicit_headless_fallback",
-        "primary_experience": "codex_cli_tui_bootstrap",
+        "mode": "headless_fallback_disabled_for_goal_mode_bootstrap",
+        "primary_experience": "codex_cli_tui_goal_bootstrap",
         "project": resolved_project,
         "goal_id": resolved_goal_id,
         "agent_id": agent_id,
         "cli_bin": cli_bin,
         "codex_bin": codex_bin,
+        "disabled_reason": (
+            "Default Codex CLI Goal Harness bootstrap must stay visible in the TUI; "
+            "headless codex exec handoff is disabled to avoid accidental hidden execution."
+        ),
         "session_probe_command": f"{shell_arg(cli_bin)} codex-cli-session-probe --codex-bin {shell_arg(codex_bin)}",
         "quota_guard_command": bootstrap["quota_guard_command"],
         "quota_spend_command": bootstrap["quota_spend_command"],
-        "handoff_command": handoff_command,
+        "message_only_command": message_only_command,
+        "handoff_command": "",
         "boundary": {
             "runs_codex": False,
             "reads_raw_transcripts": False,
@@ -391,6 +406,8 @@ def build_codex_cli_exec_handoff(
             "reads_session_files": False,
             "mutates_codex_session": False,
             "spends_goal_harness_quota": False,
+            "headless_execution_disabled": True,
+            "provides_executable_headless_command": False,
         },
     }
 
@@ -414,9 +431,8 @@ def render_codex_cli_bootstrap_message_text(
     return f"""Start the Goal Harness loop for this repo from this same Codex CLI TUI session.
 
 Goal: one-message TUI bootstrap. Keep this TUI as the visible place where I can
-watch, steer, review, and take over. Do not switch to hidden headless `codex exec`
-as the primary path; use headless only as an explicit fallback after Goal Harness
-or the user allows it.
+watch, steer, review, and take over. Do not use hidden headless `codex exec`
+for this bootstrap loop.
 
 After I paste this message, begin the Goal Harness loop automatically. Do not
 stop after explaining what Goal Harness is. Stop only for a concrete user gate,
@@ -491,6 +507,53 @@ explicit execution bounds. Keep optional automation checks such as
 local-driver-plan or visible-session-proof as follow-up diagnostics, not
 first-run prerequisites.
 """
+
+
+def render_codex_cli_goal_mode_bootstrap_text(
+    *,
+    project: str,
+    goal_id: str,
+    agent_id: str | None,
+    cli_preflight: str,
+    connect_command: str,
+    quota_guard_command: str,
+    refresh_command: str,
+    quota_spend_command: str,
+) -> str:
+    del cli_preflight
+    resolved_agent = agent_id or "the registry-selected agent"
+    claim_command = (
+        f"goal-harness todo claim --goal-id {goal_id} --todo-id <todo_id> --claimed-by {resolved_agent}"
+    )
+    goal_text = (
+        f"Advance `{goal_id}` from the registry-declared active state in this visible Codex CLI TUI. "
+        "This one-message /goal is the durable TUI heartbeat prompt: keep the user able to watch, steer, review, and take over; "
+        "do not use hidden headless codex exec for this bootstrap loop; do not read or store raw Codex transcripts/session files. "
+        "Use skills: `goal-harness-project`; if behavior is surprising, tiny, or contradictory, use `goal-harness-self-repair`. "
+        "Goal Harness CLI is source of truth. "
+        f"Project: `{project}`. Agent: `{resolved_agent}`; read role, primary agent, scope, write boundary, and workspace rules from registry/quota. "
+        "If this agent is side-agent or workspace_guard requires it, use an independent git worktree/branch before edits. "
+        f"Claim in-scope todo with `{claim_command}`; if claimed/outside scope, choose another or report none. Do not write scope into todo metadata. "
+        "At each continuation, first show: current goal id; concrete user gate or none; top user todo or none; top agent todo; next safe action. "
+        f"Ensure PATH has `$HOME/.local/bin`; if `goal-harness` is missing, install via {NO_CLONE_INSTALL_URL}; if the repo is not connected, bootstrap conservatively with `{connect_command}`. "
+        "Inspect registry/global quota truth, active state, status/run history, repo state. Run `goal-harness doctor >/dev/null`, then "
+        f"`{quota_guard_command}`; follow `interaction_contract`. "
+        "If action_required=true or open_count>0, list concrete payload todo(s)/questions, never only owner gate; if missing, say `具体 user todo 未投影，需修复 Goal Harness 状态投影`; no delivery/spend. "
+        "If false/0, say `无用户待办/无需通知` or continue quietly. "
+        "If should_run=false, do only the permitted monitor/quiet path; monitor-only quiet skips stay active and no-spend. "
+        "If P0 is blocked but CLI contract permits safe work, continue verifiable P1/P2. "
+        "If should_run=true, do a bounded steering audit across P0/P1/P2, choose one in-scope todo, complete one coherent validated batch or a concrete blocker. "
+        "Plans/done must become Goal Harness todos, writeback, or no-follow-up rationale, not chat-only prose. After two no-progress turns, self-repair before another quiet no-op. "
+        f"After validated writeback, run `{refresh_command}` if needed, then spend exactly once with `{quota_spend_command}`. "
+        "Do not spend for quiet skips, preflight failures, blocker-push asks, pure dry-runs, self-cancel turns, or duplicate accounting. "
+        "No project-specific branches here. Do not consume the learning material queue unless explicitly asked. Stop for private material, credentials, destructive git, unauthorized production actions, unsafe ambiguity, or true goal completion."
+    )
+    if len(goal_text) > CODEX_GOAL_OBJECTIVE_MAX_CHARS:
+        raise ValueError(
+            "Codex CLI /goal bootstrap objective exceeds "
+            f"{CODEX_GOAL_OBJECTIVE_MAX_CHARS} characters"
+        )
+    return f"/goal {goal_text}"
 
 
 def render_prompt_text(
@@ -705,9 +768,16 @@ def render_codex_cli_bootstrap_message_markdown(payload: dict[str, Any]) -> str:
     checklist = "\n".join(
         f"- {item}" for item in payload.get("first_run_validation_checklist", [])
     )
+    goal_mode_note = ""
+    if payload.get("invocation_mode") == "codex_cli_goal_mode":
+        goal_mode_note = (
+            "\nThe generated block starts with `/goal`, so Codex CLI goal mode "
+            "owns the visible loop objective and completion criteria.\n"
+        )
     return f"""# Codex CLI Goal Harness Bootstrap Message
 
 Copy the block below into Codex CLI TUI from the project repo.
+{goal_mode_note}
 
 ````text
 {payload.get("message", "")}
@@ -732,6 +802,7 @@ for a contributor clone:
 - goal_id: `{payload.get("goal_id")}`
 - agent_id: `{payload.get("agent_id") or "(not provided)"}`
 - cli_bin: `{payload.get("cli_bin")}`
+- heartbeat_prompt_drift_check: `{payload.get("heartbeat_prompt_command")}`
 """
 
 
@@ -750,6 +821,7 @@ mutating a real Codex session.
 ```
 
 - review_packet: `{payload.get("review_packet_command")}`
+- heartbeat_prompt: `{payload.get("heartbeat_prompt_command")}`
 - quota_guard: `{payload.get("quota_guard_command")}`
 - refresh_state: `{payload.get("refresh_command")}`
 - quota_spend_after_validation: `{payload.get("quota_spend_command")}`
@@ -778,14 +850,14 @@ mutating a real Codex session.
 
 def render_codex_cli_exec_handoff_markdown(payload: dict[str, Any]) -> str:
     boundary = payload.get("boundary") or {}
-    return f"""# Codex CLI Exec Handoff
+    return f"""# Codex CLI Exec Handoff Disabled
 
-This is an explicit headless fallback, not the primary TUI experience.
-Prefer `goal-harness codex-cli-bootstrap-message` when a user can start from
-the Codex CLI TUI.
+The default Codex CLI Goal Harness bootstrap is TUI-visible `/goal` mode.
+Headless `codex exec` handoff is disabled here to avoid accidental hidden
+execution. Use the message-only command below inside the visible Codex CLI TUI.
 
 ````bash
-{payload.get("handoff_command", "")}
+{payload.get("message_only_command", "")}
 ````
 
 ## Guard Commands
@@ -793,6 +865,7 @@ the Codex CLI TUI.
 - session_probe: `{payload.get("session_probe_command")}`
 - quota_guard: `{payload.get("quota_guard_command")}`
 - quota_spend: `{payload.get("quota_spend_command")}`
+- disabled_reason: {payload.get("disabled_reason")}
 
 ## Boundary
 
@@ -802,4 +875,6 @@ the Codex CLI TUI.
 - reads_session_files: `{boundary.get("reads_session_files")}`
 - mutates_codex_session: `{boundary.get("mutates_codex_session")}`
 - spends_goal_harness_quota: `{boundary.get("spends_goal_harness_quota")}`
+- headless_execution_disabled: `{boundary.get("headless_execution_disabled")}`
+- provides_executable_headless_command: `{boundary.get("provides_executable_headless_command")}`
 """


### PR DESCRIPTION
## Summary
- make `codex-cli-bootstrap-message` generate a `/goal`-mode visible TUI heartbeat prompt with Goal Harness quota/writeback discipline
- disable the default `codex-cli-exec-handoff` path so it returns a disabled boundary plus message-only TUI bootstrap command instead of a runnable `codex exec` script
- update visible-driver, scheduler, docs, and smokes so exec-only environments stay `tui_bootstrap_only` and `--allow-headless-fallback` is ignored/deprecated

## Commit grouping
- runtime/API behavior: goal-mode bootstrap, disabled handoff, driver/scheduler policy
- public docs: README, Getting Started, Codex CLI product contracts
- validation: focused Codex CLI smoke updates and docs governance smoke

## Validation
- `python3 -m py_compile goal_harness/project_prompt.py goal_harness/codex_cli_probe.py goal_harness/cli_commands/starter.py`
- `python3 examples/codex-cli-bootstrap-message-smoke.py`
- `python3 examples/codex-cli-exec-handoff-smoke.py`
- `python3 examples/codex-cli-session-probe-smoke.py`
- `python3 examples/codex-cli-local-driver-plan-smoke.py`
- `python3 examples/codex-cli-visible-driver-run-smoke.py`
- `python3 examples/codex-cli-local-scheduler-tick-smoke.py`
- `python3 examples/codex-cli-local-scheduler-exec-smoke.py`
- `python3 examples/codex-cli-one-message-loop-pilot-smoke.py`
- `python3 examples/codex-cli-visible-local-driver-pilot-smoke.py`
- `python3 examples/docs-governance-smoke.py`
- `goal-harness check --scan-path ...` passed with one pre-existing duplicate-index warning for `goal-harness-meta`
- `git diff --check origin/main...HEAD`

## Boundary scan
- no untracked files included
- credential/private marker scan found no secrets or private absolute paths in candidate paths
- old headless fallback decision-name scan found no default-product-path matches

## Residual risk
- `goal-harness check` still reports existing duplicate run-history index rows for `goal-harness-meta`; this PR does not repair run-history indexing.
