### PR TITLE
Keep template generator out of README quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,22 +209,9 @@ That one message is the install, connect, status check, and first loop
 bootstrap. You do not need to run a separate setup command first or paste a
 second prompt.
 
-Optional, after Goal Harness is already installed: generate an exact TUI paste
-block for another repo or teammate:
-
-```bash
-goal-harness codex-cli-bootstrap-message --project . --goal-id <goal-id>
-```
-
-For only the pasteable text, use:
-
-```bash
-goal-harness codex-cli-bootstrap-message --project . --goal-id <goal-id> --message-only
-```
-
 Hidden `codex exec` is not part of the default TUI bootstrap. Pilot packets,
-local drivers, idle detection, and same-session proof details live in
-[Getting Started](docs/guides/getting-started.md) and the
+template generators, local drivers, idle detection, and same-session proof
+details live in [Getting Started](docs/guides/getting-started.md) and the
 [Codex CLI TUI-first loop](docs/product/codex-cli-tui-loop.md).
 
 A successful connection looks like this for every surface:

--- a/examples/codex-cli-bootstrap-message-smoke.py
+++ b/examples/codex-cli-bootstrap-message-smoke.py
@@ -100,6 +100,7 @@ def assert_docs_surface_codex_cli_quickstart() -> None:
     for text in (readme, getting_started, product_contract):
         assert "Codex CLI" in text and "TUI" in text, text[:500]
         assert "Start Goal Harness for this repo" in text, text[:500]
+    for text in (getting_started, product_contract):
         assert "goal-harness codex-cli-bootstrap-message --project . --goal-id <goal-id>" in text, text[:500]
 
     normalized_readme = " ".join(readme.split())
@@ -108,7 +109,9 @@ def assert_docs_surface_codex_cli_quickstart() -> None:
     assert "Hidden `codex exec` is not part of the default TUI bootstrap" in normalized_readme, readme
     assert "paste one goal-mode message" in normalized_readme, readme
     assert "Begin the Goal Harness loop" in normalized_readme, readme
-    assert "exact TUI paste block" in normalized_readme, readme
+    assert "You do not need to run a separate setup command first or paste a second prompt" in normalized_readme, readme
+    assert "template generators" in normalized_readme, readme
+    assert "goal-harness codex-cli-bootstrap-message --project . --goal-id <goal-id>" not in readme, readme
     assert "show the current goal, user gate, top todos, and next safe action" in normalized_readme, readme
     assert "first-run path should not require you to understand registry paths" in normalized_getting_started, getting_started
     assert "finish one bounded validated segment" in normalized_getting_started, getting_started


### PR DESCRIPTION
## Summary
- remove the optional template-generator commands from README Quick Start
- keep README focused on one Codex CLI `/goal` message that installs, connects, checks status, and starts the first loop
- update the focused README smoke so template-generator commands remain in deeper docs, not Quick Start

## Validation
- `python3 examples/codex-cli-bootstrap-message-smoke.py`
- `python3 examples/docs-governance-smoke.py`
- `git diff --check`
- README/smoke credential marker scan had no hits
