### PR TITLE
Make Codex CLI bootstrap setup-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,9 @@ Install and connect Goal Harness for this project end to end. Do not stop at a
 plan. If `goal-harness` is missing, install it with the official no-clone
 GitHub installer. Then run doctor, connect or bootstrap this repo, ensure local
 Goal Harness state is ignored, and report the goal id, current user gate, top
-agent todo, and next safe action before longer work.
+agent todo, and next safe action before longer work. After the project is
+connected, set or refresh this thread's heartbeat automation from
+`goal-harness heartbeat-prompt --thin`.
 ```
 
 For recurring Codex App automation, generate the heartbeat body after the
@@ -188,28 +190,26 @@ cd /path/to/your-project
 codex
 ```
 
-2. In the TUI, paste one goal-mode message:
+2. In the TUI, paste one setup message:
 
 ```text
-/goal Start Goal Harness for this repo. Use Goal Harness as the control plane
-for this visible Codex CLI TUI goal. This `/goal` message is the Codex
-goal-setting envelope for this TUI session; do not continue under any previous
-goal. After that, install or repair `goal-harness` if needed, connect or
-bootstrap this project, run the Goal Harness checks, and show me the current
-goal, concrete user gate if any, top todos, and next safe action before running
-longer work. Keep me in this Codex CLI TUI and do not use hidden headless
-execution. Begin the Goal Harness loop now; do not stop after only explaining
-what Goal Harness is.
+Install and connect Goal Harness for this repo from this visible Codex CLI TUI.
+If `goal-harness` is missing, install it with the official no-clone GitHub
+installer; if it is already installed, reuse it. Bootstrap or connect this
+project, then generate the thin heartbeat prompt and set the current Codex CLI
+goal to `/goal <thin task_body>`. Show me the current goal, concrete user gate
+if any, top todos, and next safe action before longer work. Keep me in this TUI
+and do not use hidden headless execution.
 ```
 
 3. The first useful TUI response should show the current goal, user gate, top
-todos, and next safe action. If work is allowed, the same visible TUI turn can
-claim or choose one runnable agent todo and complete one bounded validated
-segment.
+todos, and next safe action. The setup turn should install or reuse the CLI,
+bootstrap/connect the project, and configure the thin `/goal` loop. Longer
+delivery belongs to that configured loop unless you explicitly ask for it in
+the setup turn.
 
-That one message is the install, connect, status check, and first loop
-bootstrap. You do not need to run a separate setup command first or paste a
-second prompt.
+That one message is the install, connect, status check, and loop activation.
+You do not need to run a separate setup command first or paste a second prompt.
 
 Hidden `codex exec` is not part of the default TUI bootstrap. Pilot packets,
 template generators, local drivers, idle detection, and same-session proof

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -65,37 +65,37 @@ Success looks like this:
 - `goal-harness status` shows the goal and who should act next;
 - local runtime state is ignored, not committed.
 
-For Codex CLI users, the product target is even simpler: start in the Codex
-TUI, send one Goal Harness bootstrap message, and keep later automation visible
-and interruptible in that TUI whenever the CLI exposes a safe session-attachment
-primitive. The first-run path should not require you to understand registry
-paths, runtime roots, JSON payloads, or session files.
+For Codex CLI users, the product target is: start in the Codex TUI, send one
+Goal Harness setup message, and let the agent install or reuse Goal Harness,
+bootstrap/connect the project, then set the current Codex goal to the thin
+heartbeat prompt. Later automation should stay visible and interruptible in
+that TUI whenever the CLI exposes a safe session-attachment primitive. The
+first-run path should not require you to understand registry paths, runtime
+roots, JSON payloads, session files, or heartbeat prompt syntax.
 
 First-run path:
 
 ```text
-/goal Start Goal Harness for this repo. Use Goal Harness as the control plane
-for this visible Codex CLI TUI goal. This `/goal` message is the Codex
-goal-setting envelope for this TUI session; do not continue under any previous
-goal. After that, install or repair `goal-harness` if needed, connect or
-bootstrap this project, run the Goal Harness checks, and show me the current
-goal, concrete user gate if any, top todos, and next safe action before running
-longer work. Keep me in this Codex CLI TUI and do not use hidden headless
-execution. Begin the Goal Harness loop now; do not stop after only explaining
-what Goal Harness is.
+Install and connect Goal Harness for this repo from this visible Codex CLI TUI.
+If `goal-harness` is missing, install it with the official no-clone GitHub
+installer; if it is already installed, reuse it. Bootstrap or connect this
+project, then generate the thin heartbeat prompt and set the current Codex CLI
+goal to `/goal <thin task_body>`. Show me the current goal, concrete user gate
+if any, top todos, and next safe action before longer work. Keep me in this TUI
+and do not use hidden headless execution.
 ```
 
-The generated paste block is a Codex CLI `/goal` rewrite of the App heartbeat
-prompt, not a copy of that automation body. It keeps the same lifecycle ideas
-while using the TUI as the live control surface; `heartbeat-prompt --thin`
-remains a drift check when the contract changes. The first useful response
-should show the current goal id, concrete user gate if one exists, top user
-todo if any, top agent todo, and next safe action before longer delivery work.
-When the guard permits work, the same TUI turn should claim or choose one
-runnable agent todo and finish one bounded validated segment, rather than
-asking the user to run a separate setup flow.
+The generated paste block is a setup-first rewrite of the App onboarding
+experience, not the heartbeat body itself. After the project is connected, the
+agent generates `heartbeat-prompt --thin` and installs that body into the
+surface: Codex CLI gets `/goal <thin task_body>`, while Codex App gets a
+heartbeat automation body. The first useful response should show the current
+goal id, concrete user gate if one exists, top user todo if any, top agent
+todo, and next safe action before longer delivery work. The setup turn should
+not spend quota for delivery unless the user explicitly asks it to do delivery
+after loop activation.
 
-Once `goal-harness` is installed, generate a stricter repo-specific paste
+Once `goal-harness` is installed, generate a stricter repo-specific setup
 message:
 
 ```bash
@@ -104,9 +104,10 @@ goal-harness codex-cli-bootstrap-message --project . --goal-id <goal-id>
 
 Keep that as the preferred interactive path: the human watches and steers in
 Codex CLI TUI, while Goal Harness owns quota/status/todos/gates/writeback. The
-generated packet also shows the no-clone install-repair command and a
-transcript-free validation checklist, so a fresh repo path can be reviewed
-without touching raw Codex session data.
+generated packet also shows the no-clone install-repair command, the
+post-bootstrap thin prompt generation command, and a transcript-free validation
+checklist, so a fresh repo path can be reviewed without touching raw Codex
+session data.
 
 If the user only wants the pasteable TUI text, omit the wrapper:
 
@@ -141,9 +142,9 @@ The later-turn rule is intentionally stricter than the first message: Goal
 Harness may add a visible steering turn only after public-safe visible proof,
 runtime idle evidence, a fresh guard, and explicit execution bounds. Without
 that proof, the driver should write a compact blocker or keep the one-message
-TUI bootstrap as the product path.
+setup bootstrap as the product path.
 
-The commands below are optional automation checks after the one-message path
+The commands below are optional automation checks after the setup path
 works. To evaluate future same-session automation support without touching
 transcripts or session files, run:
 
@@ -185,7 +186,7 @@ The fixture should contain only booleans and public-safe labels proving user
 opt-in, quota guard, idle guard, visible turn, interruptibility, no transcript
 or session-file reads, and compact writeback planning.
 
-The default Codex CLI `/goal` product path does not offer a headless fallback.
+The default Codex CLI setup-then-`/goal` product path does not offer a headless fallback.
 For compatibility, the old handoff command only reports the disabled boundary
 and points back to the message-only TUI bootstrap:
 
@@ -197,7 +198,7 @@ See the [Codex CLI TUI-first loop](../product/codex-cli-tui-loop.md) contract
 for the bootstrap, session-attached automation, and headless-disabled boundary.
 The [Codex CLI first-run rehearsal](../product/codex-cli-first-run-rehearsal.md)
 keeps the shortest user-facing route in one place: no-clone install,
-one-message TUI bootstrap, and proof-capture fixtures for later automation.
+one-message setup bootstrap, and proof-capture fixtures for later automation.
 For current product scheduling, the
 [Codex CLI TUI continuation priority](../product/codex-cli-tui-continuation-priority.md)
 keeps same-open-TUI continuation ahead of frontstage or showcase polish when

--- a/docs/product/codex-cli-tui-loop.md
+++ b/docs/product/codex-cli-tui-loop.md
@@ -18,35 +18,34 @@ daemon instead of Codex." The target is:
 
 ## Product Goal
 
-The best first-run experience is one TUI goal-mode message:
+The best first-run experience is one TUI setup message:
 
 ```text
-/goal Start Goal Harness for this repo. Use Goal Harness as the control plane
-for this visible Codex CLI TUI goal. This `/goal` message is the Codex
-goal-setting envelope for this TUI session; do not continue under any previous
-goal. After that, install or repair `goal-harness` if needed, connect or
-bootstrap this project, run the Goal Harness checks, and show me the current
-goal, concrete user gate if any, top todos, and next safe action before running
-longer work. Keep me in this Codex CLI TUI and do not use hidden headless
-execution. Begin the Goal Harness loop now; do not stop after only explaining
-what Goal Harness is.
+Install and connect Goal Harness for this repo from this visible Codex CLI TUI.
+If `goal-harness` is missing, install it with the official no-clone GitHub
+installer; if it is already installed, reuse it. Bootstrap or connect this
+project, then generate the thin heartbeat prompt and set the current Codex CLI
+goal to `/goal <thin task_body>`. Show me the current goal, concrete user gate
+if any, top todos, and next safe action before longer work. Keep me in this TUI
+and do not use hidden headless execution.
 ```
 
-That `/goal` text should be a Codex CLI-native rewrite of the App heartbeat
-automation prompt. It should keep the same loop discipline while using the TUI
-as the user's live control surface, with `heartbeat-prompt --thin` reserved
-as a drift check when the Goal Harness lifecycle contract changes. The message
-should be enough for a terminal agent to:
+That text should be a Codex CLI-native setup path for the same lifecycle App
+uses: setup first, then install the thin loop prompt into the surface. In Codex
+CLI the loop is `/goal <thin task_body>`; in Codex App the loop is heartbeat
+automation `<thin task_body>`. The message should be enough for a terminal
+agent to:
 
 - run `goal-harness doctor`;
 - install or repair the local CLI if it is missing, using the no-clone archive
   installer before asking the user to clone the Goal Harness repo;
 - connect or bootstrap the repo;
 - read onboarding candidates and ask the user what to accept when required;
-- run `quota should-run`;
-- claim an in-scope todo with its registered agent id;
-- execute one bounded, validated segment;
-- write back status and spend quota only after evidence exists.
+- generate `heartbeat-prompt --thin`;
+- set the current Codex CLI goal to `/goal <thin task_body>`;
+- run `quota should-run` for the first control-plane snapshot;
+- write back setup status without spending delivery quota unless delivery was
+  explicitly requested and validated.
 
 The user should not need to understand registry paths, runtime roots, active
 state files, quota JSON, or heartbeat prompts before seeing value.
@@ -67,11 +66,11 @@ and the user's live console.
 ### 1. TUI Bootstrap
 
 This is the first supported path. The user starts in Codex CLI TUI and pastes a
-single `/goal` Goal Harness bootstrap request. The agent performs install/connect,
-surfaces onboarding decisions, and starts a bounded Goal Harness turn in the
-same conversation. It should not stop after describing the product; once the
-quota/status guard permits work, the first TUI turn should perform one bounded,
-validated segment.
+single Goal Harness setup request. The agent performs install/connect,
+surfaces onboarding decisions, generates the thin heartbeat prompt, and sets the
+current Codex CLI goal to `/goal <thin task_body>`. It should not stop after
+describing the product, and it should not spend delivery quota for setup-only
+work.
 
 This mode preserves the TUI completely because the human explicitly starts the
 loop there.
@@ -82,10 +81,11 @@ Current prototype:
 goal-harness codex-cli-bootstrap-message --project . --goal-id <goal-id>
 ```
 
-Copy the generated message into Codex CLI TUI. It starts with `/goal` and tells
-the agent to repair/install Goal Harness if needed, connect the repo
-conservatively, run the quota/status guard, obey `interaction_contract`,
-preserve the visible TUI, and spend quota only after validated writeback.
+Copy the generated setup message into Codex CLI TUI. It tells the agent to
+repair/install Goal Harness if needed, connect the repo conservatively,
+generate the thin heartbeat body, set Codex CLI goal mode to `/goal <thin
+task_body>`, run the quota/status guard for the first snapshot, obey
+`interaction_contract`, and preserve the visible TUI.
 
 Transcript-free first-run smoke packet:
 
@@ -324,7 +324,7 @@ visible-session proof, and runtime-idle detector. `remote-control` or `resume
 [PROMPT]` can pass as a visible spike candidate, but they are not accepted as
 same-TUI automation unless the proof surface is `same_tui_visible_attach` and
 the idle detector passes. If either proof or idle evidence is missing, the
-packet returns a precise blocker and keeps the one-message TUI bootstrap as the
+packet returns a precise blocker and keeps the one-message setup bootstrap as the
 primary path.
 
 The first public-safe proof pilot is recorded in
@@ -342,8 +342,8 @@ turn is promoted.
 
 `codex exec` remains useful for scheduled or CI-like work, but it is not the
 primary product experience for interactive users. The default Codex CLI
-Goal Harness `/goal` path does not expose a headless fallback, even as an
-opt-in, so a first-run packet cannot accidentally move work into hidden
+Goal Harness setup-then-`/goal` path does not expose a headless fallback, even
+as an opt-in, so a first-run packet cannot accidentally move work into hidden
 execution.
 
 Compatibility boundary:
@@ -369,7 +369,7 @@ mutate a session, or spend quota.
 5. Choose among current-agent claimed advancement todos and runnable unclaimed
    candidates; monitor todos are context unless they produce a material event.
 6. Inject a visible steering prompt into the idle TUI session when proven, or
-   keep the one-message TUI bootstrap as the user-facing path.
+   keep the one-message setup bootstrap as the user-facing path.
 7. After validation, run `refresh-state` and `quota spend-slot --execute`.
 8. If validation fails, write a compact blocker instead of spending success
    prose.
@@ -411,7 +411,7 @@ projects runnable candidates; it should not over-specify the model's local plan.
 6. **Visible driver plan**: generate a dry-run plan with
    `goal-harness codex-cli-visible-driver-plan` so the next local driver knows
    whether to attempt visible attach, run a resume/remote-control proof, or
-   keep the one-message TUI bootstrap as the product path.
+   keep the one-message setup bootstrap as the product path.
 7. **Local driver planner**: ship
    `goal-harness codex-cli-local-driver-plan` as the dry-run command that
    composes quota, visible-driver, TUI bootstrap, headless-disabled boundary,

--- a/examples/codex-cli-bootstrap-message-smoke.py
+++ b/examples/codex-cli-bootstrap-message-smoke.py
@@ -21,61 +21,60 @@ GOAL_ID = "public-codex-cli-goal"
 AGENT_ID = "codex-side-bypass"
 
 MUST_HAVE = (
-    "one-message /goal",
-    "visible Codex CLI TUI",
-    "durable TUI heartbeat prompt",
-    "hidden headless codex exec",
-    "registry-declared active state",
-    "Codex goal-setting envelope",
-    "goal-harness-project",
-    "goal-harness-self-repair",
+    "one-message setup",
+    "Codex CLI TUI",
+    "setup/bootstrap instruction",
+    "thin task_body",
+    "/goal <thin task_body>",
+    "heartbeat automation",
+    "hidden headless `codex exec`",
     "current goal id",
     "top user todo",
     "top agent todo",
     "next safe action",
-    "todo claim",
     "goal-harness bootstrap",
+    "heartbeat-prompt --thin",
     "quota should-run",
     "--agent-id codex-side-bypass",
     "interaction_contract",
-    "action_required=true",
-    "open_count>0",
     "workspace_guard",
-    "independent git worktree",
-    "bounded steering audit",
-    "coherent validated batch",
-    "concrete blocker",
-    "After two no-progress turns",
+    "independent worktree",
     "raw Codex transcripts",
     "refresh-state",
     "quota spend-slot",
-    "--source heartbeat",
-    "No project-specific branches",
+    "Do not spend quota for a setup-only turn",
     "install-from-github.sh",
 )
 
 
 def assert_message_contract(payload: dict[str, object]) -> None:
     assert payload["ok"] is True, payload
-    assert payload["schema_version"] == "codex_cli_bootstrap_message_v0", payload
-    assert payload["invocation_mode"] == "codex_cli_goal_mode", payload
+    assert payload["schema_version"] == "codex_cli_bootstrap_message_v1", payload
+    assert payload["invocation_mode"] == "codex_cli_setup_then_goal_mode", payload
     assert payload["goal_id"] == GOAL_ID, payload
     assert payload["agent_id"] == AGENT_ID, payload
     assert "install-from-github.sh" in str(payload["install_repair_command"]), payload
     assert "heartbeat-prompt --thin" in str(payload["heartbeat_prompt_command"]), payload
+    assert "heartbeat-prompt --thin" in str(payload["heartbeat_prompt_json_command"]), payload
+    assert "--format json heartbeat-prompt" in str(payload["heartbeat_prompt_json_command"]), payload
+    assert payload["codex_cli_goal_prefix"] == "/goal ", payload
+    assert payload["codex_app_loop_surface"] == "heartbeat automation task_body", payload
     assert "--agent-scope 'Codex CLI /goal visible TUI loop'" in str(payload["heartbeat_prompt_command"]), payload
     checklist = payload["first_run_validation_checklist"]
     assert isinstance(checklist, list) and len(checklist) >= 5, payload
-    assert any("quota/status guard checked" in item for item in checklist), payload
+    assert any("bootstrap/connect completed" in item for item in checklist), payload
+    assert any("thin heartbeat task_body generated" in item for item in checklist), payload
+    assert any("loop surface configured" in item for item in checklist), payload
     assert any("no raw Codex transcripts" in item for item in checklist), payload
     message = str(payload["message"])
     normalized = " ".join(message.split())
-    assert message.startswith("/goal Advance `public-codex-cli-goal` from the registry-declared active state"), message
-    assert int(payload["goal_objective_characters"]) <= int(payload["goal_objective_max_chars"]), payload
+    assert message.startswith("Install and connect Goal Harness for this repo"), message
+    assert not message.startswith("/goal "), message
     for phrase in MUST_HAVE:
         assert phrase in normalized, (phrase, message)
+    assert normalized.index("install or repair Goal Harness") < normalized.index("bootstrap/connect this project"), message
+    assert normalized.index("bootstrap/connect this project") < normalized.index("heartbeat-prompt --thin"), message
     assert normalized.index("quota should-run") < normalized.index("interaction_contract"), message
-    assert normalized.index("workspace_guard") < normalized.index("independent git worktree"), message
     assert normalized.index("refresh-state") < normalized.index("quota spend-slot"), message
     assert "Headless fallback should never be the only way" not in message, message
     assert "quota spend-slot --goal-id public-codex-cli-goal" in message, message
@@ -100,7 +99,7 @@ def assert_docs_surface_codex_cli_quickstart() -> None:
 
     for text in (readme, getting_started, product_contract):
         assert "Codex CLI" in text and "TUI" in text, text[:500]
-        assert "Start Goal Harness for this repo" in text, text[:500]
+        assert "Install and connect Goal Harness" in text, text[:500]
     for text in (getting_started, product_contract):
         assert "goal-harness codex-cli-bootstrap-message --project . --goal-id <goal-id>" in text, text[:500]
 
@@ -108,21 +107,20 @@ def assert_docs_surface_codex_cli_quickstart() -> None:
     normalized_getting_started = " ".join(getting_started.split())
     normalized_product_contract = " ".join(product_contract.split())
     assert "Hidden `codex exec` is not part of the default TUI bootstrap" in normalized_readme, readme
-    assert "paste one goal-mode message" in normalized_readme, readme
-    assert "This `/goal` message is the Codex goal-setting envelope" in normalized_readme, readme
-    assert "do not continue under any previous goal" in normalized_readme, readme
-    assert "Begin the Goal Harness loop" in normalized_readme, readme
+    assert "paste one setup message" in normalized_readme, readme
+    assert "set the current Codex CLI goal to `/goal <thin task_body>`" in normalized_readme, readme
+    assert "reuse it" in normalized_readme, readme
     assert "You do not need to run a separate setup command first or paste a second prompt" in normalized_readme, readme
     assert "template generators" in normalized_readme, readme
     assert "goal-harness codex-cli-bootstrap-message --project . --goal-id <goal-id>" not in readme, readme
     assert "show the current goal, user gate, top todos, and next safe action" in normalized_readme, readme
     assert "first-run path should not require you to understand registry paths" in normalized_getting_started, getting_started
-    assert "connect or bootstrap this project, run the Goal Harness checks" in normalized_getting_started, getting_started
-    assert "finish one bounded validated segment" in normalized_getting_started, getting_started
+    assert "setup-first rewrite of the App onboarding experience" in normalized_getting_started, getting_started
+    assert "Codex App gets a heartbeat automation body" in normalized_getting_started, getting_started
     assert "transcript-free validation checklist" in normalized_getting_started, getting_started
-    assert "optional automation checks after the one-message path works" in normalized_getting_started, getting_started
+    assert "optional automation checks after the setup path works" in normalized_getting_started, getting_started
     assert "first useful TUI response should be a control-plane snapshot" in normalized_product_contract, product_contract
-    assert "first TUI turn should perform one bounded, validated segment" in normalized_product_contract, product_contract
+    assert "setup-only work" in normalized_product_contract, product_contract
     assert "goal-harness codex-cli-session-probe" in getting_started, getting_started
     assert "goal-harness codex-cli-exec-handoff --project . --goal-id <goal-id>" in getting_started, getting_started
     assert "headless-disabled boundary" in normalized_getting_started, getting_started
@@ -164,12 +162,13 @@ def main() -> int:
     )
     assert "# Codex CLI Goal Harness Bootstrap Message" in cli_markdown, cli_markdown
     assert "Copy the block below into Codex CLI TUI" in cli_markdown, cli_markdown
-    assert "starts with `/goal`" in cli_markdown, cli_markdown
+    assert "setup message, not the reusable heartbeat body" in cli_markdown, cli_markdown
+    assert "`/goal <thin task_body>`" in cli_markdown, cli_markdown
     assert "heartbeat-prompt --thin" in cli_markdown, cli_markdown
     assert "Fresh Repo Install Repair" in cli_markdown, cli_markdown
+    assert "Post-Bootstrap Thin Loop Prompt" in cli_markdown, cli_markdown
     assert "Transcript-Free Validation Checklist" in cli_markdown, cli_markdown
     assert "install-from-github.sh" in cli_markdown, cli_markdown
-    assert "one-message /goal" in cli_markdown, cli_markdown
 
     cli_message_only = run_cli(
         "codex-cli-bootstrap-message",
@@ -184,7 +183,8 @@ def main() -> int:
     assert cli_message_only == str(payload["message"]) + "\n", cli_message_only
     assert "# Codex CLI Goal Harness Bootstrap Message" not in cli_message_only, cli_message_only
     assert "Fresh Repo Install Repair" not in cli_message_only, cli_message_only
-    assert cli_message_only.startswith("/goal Advance `public-codex-cli-goal` from the registry-declared active state"), cli_message_only
+    assert cli_message_only.startswith("Install and connect Goal Harness for this repo"), cli_message_only
+    assert not cli_message_only.startswith("/goal "), cli_message_only
 
     cli_copy_only = run_cli(
         "codex-cli-bootstrap-message",

--- a/examples/codex-cli-first-run-rehearsal-smoke.py
+++ b/examples/codex-cli-first-run-rehearsal-smoke.py
@@ -88,12 +88,15 @@ def assert_cli_surfaces_align() -> None:
         "--message-only",
     )
     normalized = normalize(message)
-    assert "/goal Advance `public-codex-cli-goal` from the registry-declared active state" in normalized, message
+    assert message.startswith("Install and connect Goal Harness for this repo"), message
+    assert not message.startswith("/goal "), message
+    assert "setup/bootstrap instruction" in normalized, message
+    assert "/goal <thin task_body>" in normalized, message
     assert "install-from-github.sh" in normalized, message
-    assert "visible Codex CLI TUI" in normalized, message
+    assert "Codex CLI TUI" in normalized, message
     assert "quota should-run" in normalized, message
     assert "quota spend-slot" in normalized, message
-    assert "raw Codex transcripts/session files" in normalized, message
+    assert "raw Codex transcripts" in normalized, message
 
     bundle = run_cli(
         "codex-cli-tui-bootstrap-smoke-bundle",

--- a/examples/codex-cli-live-tui-first-message-pilot-smoke.py
+++ b/examples/codex-cli-live-tui-first-message-pilot-smoke.py
@@ -89,11 +89,13 @@ def assert_bootstrap_message_still_copy_first() -> None:
         "--message-only",
     )
     normalized = normalize(message)
-    assert "/goal Advance `public-live-tui-pilot-goal` from the registry-declared active state" in normalized, message
-    assert "visible Codex CLI TUI" in normalized, message
-    assert "durable TUI heartbeat prompt" in normalized, message
-    assert "raw Codex transcripts/session files" in normalized, message
-    assert "keep the user able to watch, steer, review, and take over" in normalized, message
+    assert message.startswith("Install and connect Goal Harness for this repo"), message
+    assert not message.startswith("/goal "), message
+    assert "Codex CLI TUI" in normalized, message
+    assert "setup/bootstrap instruction" in normalized, message
+    assert "/goal <thin task_body>" in normalized, message
+    assert "raw Codex transcripts" in normalized, message
+    assert "watch, steer, review, and take over" in normalized, message
 
 
 def main() -> int:

--- a/examples/codex-cli-no-clone-release-verification-smoke.py
+++ b/examples/codex-cli-no-clone-release-verification-smoke.py
@@ -119,12 +119,15 @@ def assert_installed_release(
         cwd=fresh_repo,
     ).stdout
     normalized_message = normalize(message)
-    assert "/goal Advance `public-no-clone-release-goal` from the registry-declared active state" in normalized_message, message
+    assert message.startswith("Install and connect Goal Harness for this repo"), message
+    assert not message.startswith("/goal "), message
+    assert "setup/bootstrap instruction" in normalized_message, message
+    assert "/goal <thin task_body>" in normalized_message, message
     assert "install-from-github.sh" in normalized_message, message
-    assert "visible Codex CLI TUI" in normalized_message, message
+    assert "Codex CLI TUI" in normalized_message, message
     assert "quota should-run" in normalized_message, message
     assert "quota spend-slot" in normalized_message, message
-    assert "raw Codex transcripts/session files" in normalized_message, message
+    assert "raw Codex transcripts" in normalized_message, message
 
     bundle = json.loads(
         run(

--- a/examples/codex-cli-one-message-loop-pilot-smoke.py
+++ b/examples/codex-cli-one-message-loop-pilot-smoke.py
@@ -146,12 +146,18 @@ def main() -> int:
     assert no_proof["start_surface"] == "codex_cli_tui_one_message", no_proof
     assert no_proof["pilot_decision"] == "first_message_then_visible_blocker_writeback", no_proof
     assert no_proof["first_turn"]["autostarts_goal_harness_loop"] is True, no_proof
+    assert no_proof["first_turn"]["setup_then_loop_activation"] is True, no_proof
+    assert no_proof["first_turn"]["loop_activation"]["codex_cli"] == "/goal <thin task_body>", no_proof
+    assert no_proof["first_turn"]["loop_activation"]["codex_app"] == "<thin task_body> heartbeat automation", no_proof
     assert no_proof["first_turn"]["preserve_tui"] is True, no_proof
     assert "workspace_guard" in no_proof["first_turn"]["stop_only_for"], no_proof
-    assert no_proof["first_turn"]["message"].startswith("/goal Advance `public-codex-cli-goal`"), no_proof
-    assert "visible Codex CLI TUI" in no_proof["first_turn"]["message"], no_proof
-    assert "do not use hidden headless codex exec" in no_proof["first_turn"]["message"], no_proof
+    assert no_proof["first_turn"]["message"].startswith("Install and connect Goal Harness for this repo"), no_proof
+    assert not no_proof["first_turn"]["message"].startswith("/goal "), no_proof
+    assert "Codex CLI TUI" in no_proof["first_turn"]["message"], no_proof
+    assert "headless `codex exec`" in no_proof["first_turn"]["message"], no_proof
     assert "runtime_idle_evidence" in no_proof["later_turn_contract"]["visible_steering_requires"], no_proof
+    assert no_proof["bootstrap_message"]["invocation_mode"] == "codex_cli_setup_then_goal_mode", no_proof
+    assert "heartbeat-prompt --thin" in no_proof["bootstrap_message"]["heartbeat_prompt_json_command"], no_proof
     assert no_proof["later_turn_contract"]["default_without_proof"] == "write_blocker_or_keep_tui_bootstrap_primary", no_proof
     assert no_proof["automation_bridge"]["command"] == "codex-cli-local-scheduler-exec", no_proof
     assert no_proof["automation_bridge"]["default_executes"] is False, no_proof

--- a/examples/codex-cli-tui-bootstrap-smoke-bundle-smoke.py
+++ b/examples/codex-cli-tui-bootstrap-smoke-bundle-smoke.py
@@ -155,14 +155,16 @@ def main() -> None:
             env=env,
             cwd=fresh_repo,
         ).stdout
-        assert message_only.startswith("/goal Advance `public-fresh-codex-cli-goal` from the registry-declared active state"), message_only
+        assert message_only.startswith("Install and connect Goal Harness for this repo"), message_only
+        assert not message_only.startswith("/goal "), message_only
         assert "# Codex CLI Goal Harness Bootstrap Message" not in message_only, message_only
         assert "Fresh Repo Install Repair" not in message_only, message_only
         assert "install-from-github.sh" in message_only, message_only
+        assert "/goal <thin task_body>" in message_only, message_only
         assert "quota should-run" in message_only, message_only
         assert "refresh-state --goal-id public-fresh-codex-cli-goal" in message_only, message_only
         assert "quota spend-slot" in message_only, message_only
-        assert "raw Codex transcripts/session files" in message_only, message_only
+        assert "raw Codex transcripts" in message_only, message_only
 
         markdown = run(
             [

--- a/examples/docs-governance-smoke.py
+++ b/examples/docs-governance-smoke.py
@@ -128,7 +128,7 @@ def main() -> int:
         assert required in compact_project_agent_contract, required
 
     for required in [
-        "The best first-run experience is one TUI goal-mode message",
+        "The best first-run experience is one TUI setup message",
         "Session-Attached Automation",
         "Headless Disabled Boundary",
     ]:

--- a/goal_harness/cli_commands/starter.py
+++ b/goal_harness/cli_commands/starter.py
@@ -185,7 +185,7 @@ def register_starter_commands(subparsers: argparse._SubParsersAction) -> None:
 
     codex_cli_bootstrap_parser = subparsers.add_parser(
         "codex-cli-bootstrap-message",
-        help="Generate a one-message Codex CLI TUI bootstrap prompt for a Goal Harness loop.",
+        help="Generate a one-message Codex CLI TUI setup prompt that installs/connects Goal Harness, then sets the thin /goal loop.",
     )
     codex_cli_bootstrap_parser.add_argument("--project", default=".", help="Project directory to start from.")
     codex_cli_bootstrap_parser.add_argument("--goal-id", help="Goal id. Defaults to <project-name>-goal.")

--- a/goal_harness/codex_cli_probe.py
+++ b/goal_harness/codex_cli_probe.py
@@ -134,7 +134,7 @@ def classify_codex_cli_session_surface(
         )
     if exec_supported and not (safe_injection_supported or remote_control_surface_detected or visible_resume_supported):
         warnings.append(
-            "Codex exec is available, but headless fallback is disabled for the default Goal Harness /goal bootstrap path."
+            "Codex exec is available, but headless fallback is disabled for the default Goal Harness setup-then-goal bootstrap path."
         )
     if not codex_cli_available:
         warnings.append("Codex CLI was not available on PATH; classification used missing-command evidence.")
@@ -1016,7 +1016,7 @@ def build_codex_cli_visible_driver_plan(
             "quota_guard": quota_guard_command,
             "tui_bootstrap_message": bootstrap_command,
             "explicit_headless_fallback": None,
-            "headless_fallback_disabled": "headless codex exec is disabled for the default Goal Harness /goal bootstrap path",
+            "headless_fallback_disabled": "headless codex exec is disabled for the default Goal Harness setup-then-goal bootstrap path",
         },
         "driver_steps": driver_steps,
         "boundary": {
@@ -1123,14 +1123,14 @@ def build_codex_cli_local_driver_plan(
             "visible_driver_plan": visible_driver_plan_command,
             "tui_bootstrap_message": bootstrap_command,
             "explicit_headless_fallback": None,
-            "headless_fallback_disabled": "headless codex exec is disabled for the default Goal Harness /goal bootstrap path",
+            "headless_fallback_disabled": "headless codex exec is disabled for the default Goal Harness setup-then-goal bootstrap path",
         },
         "driver_steps": [
             "run quota_guard and stop when user_channel.action_required=true",
             "run visible_driver_plan to classify TUI, resume, or remote-control mode",
             "verify idle_guard before any visible resume or remote-control prompt",
             "prefer one-message TUI bootstrap until visible attach is proven",
-            "do not offer headless codex exec from the default Goal Harness /goal bootstrap path",
+            "do not offer headless codex exec from the default Goal Harness setup-then-goal bootstrap path",
             "write back compact evidence or a precise blocker before quota spend",
         ],
         "idle_guard": {
@@ -1177,7 +1177,7 @@ def build_codex_cli_visible_driver_run_packet(
     The packet is deliberately not an executor. It converts the dry-run local
     driver plan and optional visible-session proof into the next safe command
     boundary for a local scheduler or human operator. Headless fallback remains
-    disabled for this default Goal Harness /goal bootstrap path.
+    disabled for this default Goal Harness setup-then-goal bootstrap path.
     """
 
     local_plan = build_codex_cli_local_driver_plan(
@@ -1226,14 +1226,14 @@ def build_codex_cli_visible_driver_run_packet(
         "run quota_guard and stop if user_channel.action_required=true",
         "stop or relocate if workspace_guard blocks the current checkout",
         "use a visible session only when proof_approved=true and an idle guard passes",
-        "do not use headless codex exec from the default Goal Harness /goal bootstrap path",
+        "do not use headless codex exec from the default Goal Harness setup-then-goal bootstrap path",
         "after the Codex turn, validate evidence or blocker before refresh-state",
         "spend quota exactly once after validated writeback, never for this packet alone",
     ]
     warnings = list(local_plan.get("warnings") or [])
     if allow_headless_fallback:
         warnings.append(
-            "allow_headless_fallback was ignored because headless fallback is disabled for the default Goal Harness /goal bootstrap path."
+            "allow_headless_fallback was ignored because headless fallback is disabled for the default Goal Harness setup-then-goal bootstrap path."
         )
 
     return {
@@ -1863,7 +1863,13 @@ def build_codex_cli_one_message_loop_pilot(
         "first_turn": {
             "user_action": "paste_bootstrap_message_into_codex_cli_tui",
             "autostarts_goal_harness_loop": True,
+            "setup_then_loop_activation": True,
             "preserve_tui": True,
+            "loop_activation": {
+                "source_command": bootstrap.get("heartbeat_prompt_json_command"),
+                "codex_cli": "/goal <thin task_body>",
+                "codex_app": "<thin task_body> heartbeat automation",
+            },
             "stop_only_for": [
                 "concrete_user_gate",
                 "workspace_guard",
@@ -1908,6 +1914,8 @@ def build_codex_cli_one_message_loop_pilot(
         },
         "bootstrap_message": {
             "schema_version": bootstrap.get("schema_version"),
+            "invocation_mode": bootstrap.get("invocation_mode"),
+            "heartbeat_prompt_json_command": bootstrap.get("heartbeat_prompt_json_command"),
             "quota_guard_command": bootstrap.get("quota_guard_command"),
             "refresh_command": bootstrap.get("refresh_command"),
             "quota_spend_command": bootstrap.get("quota_spend_command"),

--- a/goal_harness/project_prompt.py
+++ b/goal_harness/project_prompt.py
@@ -14,7 +14,6 @@ DEFAULT_HANDOFF_ADAPTER_STATUS = "connected-read-only"
 DEFAULT_HANDOFF_NEXT_PROBE = "(omit --next-probe until a read-only pre-tick command exists)"
 SHARED_GLOBAL_REGISTRY = '"$HOME/.codex/goal-harness/registry.global.json"'
 NO_CLONE_INSTALL_URL = "https://raw.githubusercontent.com/huangruiteng/goal-harness/main/scripts/install-from-github.sh"
-CODEX_GOAL_OBJECTIVE_MAX_CHARS = 6000
 
 
 def shell_arg(value: str) -> str:
@@ -90,6 +89,22 @@ def render_heartbeat_prompt_command(
     scope_arg = f" --agent-scope {shell_arg(agent_scope)}" if agent_id else ""
     return (
         f"{shell_arg(cli_bin)} heartbeat-prompt --{shell_arg(body)} "
+        f"--goal-id {shell_arg(goal_id)}{agent_arg}{scope_arg}"
+    )
+
+
+def render_heartbeat_prompt_json_command(
+    goal_id: str,
+    *,
+    cli_bin: str = "goal-harness",
+    agent_id: str | None = None,
+    agent_scope: str = "Codex CLI /goal visible TUI loop",
+    body: str = "thin",
+) -> str:
+    agent_arg = f" --agent-id {shell_arg(agent_id)}" if agent_id else ""
+    scope_arg = f" --agent-scope {shell_arg(agent_scope)}" if agent_id else ""
+    return (
+        f"{shell_arg(cli_bin)} --format json heartbeat-prompt --{shell_arg(body)} "
         f"--goal-id {shell_arg(goal_id)}{agent_arg}{scope_arg}"
     )
 
@@ -256,30 +271,39 @@ def build_codex_cli_bootstrap_message(
         cli_bin=cli_bin,
         agent_id=agent_id,
     )
+    heartbeat_prompt_json_command = render_heartbeat_prompt_json_command(
+        resolved_goal_id,
+        cli_bin=cli_bin,
+        agent_id=agent_id,
+    )
     install_repair_command = render_codex_cli_no_clone_preflight(cli_bin=cli_bin)
     refresh_command = f"{shell_arg(cli_bin)} refresh-state --goal-id {shell_arg(resolved_goal_id)}"
     first_run_validation_checklist = [
         "goal-harness doctor passed after no-clone install repair or existing install",
-        "repo connected conservatively or a concrete install/connect blocker was shown",
-        "quota/status guard checked with the registered agent id when available",
+        "repo bootstrap/connect completed conservatively or a concrete install/connect blocker was shown",
+        "thin heartbeat task_body generated from goal-harness heartbeat-prompt --thin, not hand-written",
+        "current loop surface configured from the thin task_body: Codex CLI /goal or Codex App automation",
+        "quota/status guard checked with the registered agent id when available after bootstrap/connect",
         "current goal, concrete user gate or none, top todos, and next safe action shown in the TUI",
-        "one bounded segment validated before refresh-state and quota spend-slot",
         "no raw Codex transcripts, session files, credentials, private paths, stdout, or stderr persisted",
     ]
-    message = render_codex_cli_goal_mode_bootstrap_text(
+    message = render_codex_cli_bootstrap_message_text(
         project=resolved_project,
         goal_id=resolved_goal_id,
         agent_id=agent_id,
         cli_preflight=install_repair_command,
         connect_command=connect_command,
+        heartbeat_prompt_json_command=heartbeat_prompt_json_command,
+        heartbeat_prompt_command=heartbeat_prompt_command,
         quota_guard_command=quota_guard_command,
         refresh_command=refresh_command,
         quota_spend_command=quota_spend_command,
+        first_run_validation_checklist=first_run_validation_checklist,
     )
     return {
         "ok": True,
-        "schema_version": "codex_cli_bootstrap_message_v0",
-        "invocation_mode": "codex_cli_goal_mode",
+        "schema_version": "codex_cli_bootstrap_message_v1",
+        "invocation_mode": "codex_cli_setup_then_goal_mode",
         "project": resolved_project,
         "goal_id": resolved_goal_id,
         "agent_id": agent_id,
@@ -287,12 +311,13 @@ def build_codex_cli_bootstrap_message(
         "install_repair_command": install_repair_command,
         "connect_command": connect_command,
         "heartbeat_prompt_command": heartbeat_prompt_command,
+        "heartbeat_prompt_json_command": heartbeat_prompt_json_command,
+        "codex_cli_goal_prefix": "/goal ",
+        "codex_app_loop_surface": "heartbeat automation task_body",
         "quota_guard_command": quota_guard_command,
         "refresh_command": refresh_command,
         "quota_spend_command": quota_spend_command,
         "first_run_validation_checklist": first_run_validation_checklist,
-        "goal_objective_max_chars": CODEX_GOAL_OBJECTIVE_MAX_CHARS,
-        "goal_objective_characters": len(message.removeprefix("/goal ").strip()),
         "message": message,
     }
 
@@ -334,9 +359,9 @@ def build_codex_cli_tui_bootstrap_smoke_bundle(
     }
     validation_checklist = [
         "archive installer works from a temporary GitHub-style tarball or existing install",
-        "message-only command prints only the TUI paste block, not the Markdown review packet",
-        "paste block includes no-clone install repair, heartbeat prompt load, quota guard, and bounded writeback commands",
-        "quota spend remains a post-validation command inside the paste block, not a smoke side effect",
+        "message-only command prints only the setup paste block, not the Markdown review packet",
+        "paste block includes no-clone install repair, project bootstrap/connect, thin heartbeat generation, loop activation, and quota guard",
+        "quota spend remains a later post-delivery command inside the paste block, not a setup or smoke side effect",
         "no raw Codex transcripts, session files, credentials, stdout, stderr, or private paths are read",
     ]
     return {
@@ -350,6 +375,7 @@ def build_codex_cli_tui_bootstrap_smoke_bundle(
         "review_packet_command": review_packet_command,
         "message_only_command": message_only_command,
         "heartbeat_prompt_command": bootstrap["heartbeat_prompt_command"],
+        "heartbeat_prompt_json_command": bootstrap["heartbeat_prompt_json_command"],
         "quota_guard_command": bootstrap["quota_guard_command"],
         "refresh_command": bootstrap["refresh_command"],
         "quota_spend_command": bootstrap["quota_spend_command"],
@@ -397,6 +423,7 @@ def build_codex_cli_exec_handoff(
         "session_probe_command": f"{shell_arg(cli_bin)} codex-cli-session-probe --codex-bin {shell_arg(codex_bin)}",
         "quota_guard_command": bootstrap["quota_guard_command"],
         "quota_spend_command": bootstrap["quota_spend_command"],
+        "heartbeat_prompt_json_command": bootstrap["heartbeat_prompt_json_command"],
         "message_only_command": message_only_command,
         "handoff_command": "",
         "boundary": {
@@ -419,6 +446,8 @@ def render_codex_cli_bootstrap_message_text(
     agent_id: str | None,
     cli_preflight: str,
     connect_command: str,
+    heartbeat_prompt_json_command: str,
+    heartbeat_prompt_command: str,
     quota_guard_command: str,
     refresh_command: str,
     quota_spend_command: str,
@@ -428,30 +457,37 @@ def render_codex_cli_bootstrap_message_text(
         "If this project has registered agents, inspect the registry and use the correct registered agent id before claiming todos."
     )
     checklist = "\n".join(f"- {item}" for item in first_run_validation_checklist)
-    return f"""Start the Goal Harness loop for this repo from this same Codex CLI TUI session.
+    return f"""Install and connect Goal Harness for this repo from this same Codex CLI TUI session.
 
-Goal: one-message TUI bootstrap. Keep this TUI as the visible place where I can
-watch, steer, review, and take over. Do not use hidden headless `codex exec`
-for this bootstrap loop.
+Goal: one-message setup, then loop activation. Keep this TUI as the visible
+place where I can watch, steer, review, and take over. Do not use hidden
+headless `codex exec` for this bootstrap path.
 
-After I paste this message, begin the Goal Harness loop automatically. Do not
-stop after explaining what Goal Harness is. Stop only for a concrete user gate,
-workspace guard, missing capability, missing installation primitive, or unsafe
-boundary.
+This first message is the setup/bootstrap instruction, not the reusable
+heartbeat prompt. Complete the setup in order: install or repair Goal Harness
+if needed; bootstrap/connect this project; then configure the current loop
+surface from the generated thin heartbeat prompt. For Codex CLI, set the
+current TUI goal to `/goal ` plus the thin `task_body`. For Codex App, set or
+refresh the heartbeat automation to that same thin `task_body`. If the current
+surface cannot be mutated from this session, show the exact pasteable `/goal`
+or automation body and report that as a concrete user gate; do not claim setup
+success.
 
 Project: `{project}`
 Goal id: `{goal_id}`
 {agent_line}
 
-Success criteria for this first TUI turn:
+Success criteria for this first setup turn:
 - I should not need to inspect registry paths, runtime roots, JSON payloads, or
   hidden session files.
-- Before longer delivery work, show me the current goal id, concrete user gate
-  if any, top user todo if any, top agent todo, and next safe action.
-- If no user gate or user todo exists, say that explicitly and continue only
-  after the quota/status guard permits work.
-- If the guard permits work, claim or choose one runnable agent todo and do one
-  bounded validated segment in this same visible TUI turn.
+- If Goal Harness is already installed and this repo is already connected,
+  reuse the existing install/state and do not reinstall or duplicate bootstrap.
+- Configure the loop target after bootstrap: Codex CLI `/goal <thin task_body>`
+  or Codex App heartbeat automation `<thin task_body>`.
+- Show me the current goal id, concrete user gate if any, top user todo if any,
+  top agent todo, and next safe action.
+- Do not do longer delivery work in the setup turn unless I explicitly ask; the
+  configured thin loop owns later quota/spend delivery turns.
 
 1. Ensure the Goal Harness CLI works. Prefer the no-clone GitHub archive
 installer; do not ask me to clone the Goal Harness repo just to try the first
@@ -470,7 +506,25 @@ run:
 If the connect output includes onboarding candidate todos, summarize them in
 this TUI and ask me which ones to accept before starting autonomous delivery.
 
-3. Before any delivery work, run the quota/status guard:
+3. Generate the thin loop prompt after bootstrap/connect, not before. Do not
+hand-write or copy an old heartbeat body:
+
+```bash
+{heartbeat_prompt_json_command}
+```
+
+Read `task_body` from the JSON result. Then configure the current surface:
+- Codex CLI TUI: set the current goal to `/goal ` followed by that `task_body`.
+- Codex App: set or update the heartbeat automation body to that `task_body`.
+
+For review, the Markdown form is:
+
+```bash
+{heartbeat_prompt_command}
+```
+
+4. After install/connect and loop activation, run the quota/status guard for
+the first control-plane snapshot:
 
 ```bash
 {quota_guard_command}
@@ -484,16 +538,19 @@ Follow `interaction_contract` exactly:
 - If delivery is allowed, choose one runnable agent todo after a short steering
   audit, preferably a current-agent claimed advancement todo.
 
-4. Report the current goal/gate/todo/next-action snapshot in this TUI, then
-execute one bounded segment in this TUI-visible session. Validate the result.
-Do not store raw Codex transcripts, credentials, private paths, raw logs, or
+5. Report the current goal/gate/todo/next-action snapshot in this TUI. Stop
+after setup unless I explicitly asked for delivery in this same turn. Do not
+store raw Codex transcripts, credentials, private paths, raw logs, or
 production artifacts in public docs or Goal Harness state.
 
-5. Before writeback, use this transcript-free validation checklist:
+6. Before writeback, use this transcript-free validation checklist:
 
 {checklist}
 
-6. After validated writeback, refresh state and spend quota once:
+7. After setup writeback, refresh state if needed. Do not spend quota for a
+setup-only turn. The configured thin loop spends only after a later validated
+delivery writeback. If I explicitly asked you to do delivery in this same turn
+and you completed a validated delivery segment, spend exactly once:
 
 ```bash
 {refresh_command}
@@ -507,55 +564,6 @@ explicit execution bounds. Keep optional automation checks such as
 local-driver-plan or visible-session-proof as follow-up diagnostics, not
 first-run prerequisites.
 """
-
-
-def render_codex_cli_goal_mode_bootstrap_text(
-    *,
-    project: str,
-    goal_id: str,
-    agent_id: str | None,
-    cli_preflight: str,
-    connect_command: str,
-    quota_guard_command: str,
-    refresh_command: str,
-    quota_spend_command: str,
-) -> str:
-    del cli_preflight
-    resolved_agent = agent_id or "the registry-selected agent"
-    claim_command = (
-        f"goal-harness todo claim --goal-id {goal_id} --todo-id <todo_id> --claimed-by {resolved_agent}"
-    )
-    goal_text = (
-        f"Advance `{goal_id}` from the registry-declared active state in this visible Codex CLI TUI. "
-        "This one-message /goal is the durable TUI heartbeat prompt: keep the user able to watch, steer, review, and take over; "
-        "do not use hidden headless codex exec for this bootstrap loop; do not read or store raw Codex transcripts/session files. "
-        "This `/goal` invocation is the Codex goal-setting envelope for the TUI session; do not continue under any previous Codex goal. "
-        "Use skills: `goal-harness-project`; if behavior is surprising, tiny, or contradictory, use `goal-harness-self-repair`. "
-        "Goal Harness CLI is source of truth. "
-        f"Project: `{project}`. Agent: `{resolved_agent}`; read role, primary agent, scope, write boundary, and workspace rules from registry/quota. "
-        "If this agent is side-agent or workspace_guard requires it, use an independent git worktree/branch before edits. "
-        f"Claim in-scope todo with `{claim_command}`; if claimed/outside scope, choose another or report none. Do not write scope into todo metadata. "
-        "At each continuation, first show: current goal id; concrete user gate or none; top user todo or none; top agent todo; next safe action. "
-        f"Ensure PATH has `$HOME/.local/bin`; if `goal-harness` is missing, install via {NO_CLONE_INSTALL_URL}; if the repo is not connected, bootstrap conservatively with `{connect_command}`. "
-        "Step order after the `/goal` envelope is active: install/repair CLI if needed; bootstrap/connect the project if needed; run `goal-harness doctor >/dev/null`; inspect registry/global quota truth, active state, status/run history, and repo state; then run "
-        f"`{quota_guard_command}`; follow `interaction_contract`. "
-        "If action_required=true or open_count>0, list concrete payload todo(s)/questions, never only owner gate; if missing, say `具体 user todo 未投影，需修复 Goal Harness 状态投影`; no delivery/spend. "
-        "If false/0, say `无用户待办/无需通知` or continue quietly. "
-        "If should_run=false, do only the permitted monitor/quiet path; monitor-only quiet skips stay active and no-spend. "
-        "If P0 is blocked but CLI contract permits safe work, continue verifiable P1/P2. "
-        "If should_run=true, do a bounded steering audit across P0/P1/P2, choose one in-scope todo, complete one coherent validated batch or a concrete blocker. "
-        "Plans/done must become Goal Harness todos, writeback, or no-follow-up rationale, not chat-only prose. After two no-progress turns, self-repair before another quiet no-op. "
-        f"After validated writeback, run `{refresh_command}` if needed, then spend exactly once with `{quota_spend_command}`. "
-        "Do not spend for quiet skips, preflight failures, blocker-push asks, pure dry-runs, self-cancel turns, or duplicate accounting. "
-        "No project-specific branches here. Do not consume the learning material queue unless explicitly asked. Stop for private material, credentials, destructive git, unauthorized production actions, unsafe ambiguity, or true goal completion."
-    )
-    if len(goal_text) > CODEX_GOAL_OBJECTIVE_MAX_CHARS:
-        raise ValueError(
-            "Codex CLI /goal bootstrap objective exceeds "
-            f"{CODEX_GOAL_OBJECTIVE_MAX_CHARS} characters"
-        )
-    return f"/goal {goal_text}"
-
 
 def render_prompt_text(
     *,
@@ -770,10 +778,11 @@ def render_codex_cli_bootstrap_message_markdown(payload: dict[str, Any]) -> str:
         f"- {item}" for item in payload.get("first_run_validation_checklist", [])
     )
     goal_mode_note = ""
-    if payload.get("invocation_mode") == "codex_cli_goal_mode":
+    if payload.get("invocation_mode") == "codex_cli_setup_then_goal_mode":
         goal_mode_note = (
-            "\nThe generated block starts with `/goal`, so Codex CLI goal mode "
-            "owns the visible loop objective and completion criteria.\n"
+            "\nThe generated block is a setup message, not the reusable heartbeat body. "
+            "After install/bootstrap, it tells the agent to set Codex CLI goal mode "
+            "to `/goal <thin task_body>` or Codex App automation to `<thin task_body>`.\n"
         )
     return f"""# Codex CLI Goal Harness Bootstrap Message
 
@@ -792,6 +801,17 @@ for a contributor clone:
 ```bash
 {payload.get("install_repair_command", "")}
 ```
+
+## Post-Bootstrap Thin Loop Prompt
+
+Generate the thin task body after the project is connected:
+
+```bash
+{payload.get("heartbeat_prompt_json_command", "")}
+```
+
+- Codex CLI TUI loop: set `/goal <task_body>`.
+- Codex App loop: set heartbeat automation body to `<task_body>`.
 
 ## Transcript-Free Validation Checklist
 
@@ -823,6 +843,7 @@ mutating a real Codex session.
 
 - review_packet: `{payload.get("review_packet_command")}`
 - heartbeat_prompt: `{payload.get("heartbeat_prompt_command")}`
+- heartbeat_prompt_json: `{payload.get("heartbeat_prompt_json_command")}`
 - quota_guard: `{payload.get("quota_guard_command")}`
 - refresh_state: `{payload.get("refresh_command")}`
 - quota_spend_after_validation: `{payload.get("quota_spend_command")}`
@@ -853,9 +874,10 @@ def render_codex_cli_exec_handoff_markdown(payload: dict[str, Any]) -> str:
     boundary = payload.get("boundary") or {}
     return f"""# Codex CLI Exec Handoff Disabled
 
-The default Codex CLI Goal Harness bootstrap is TUI-visible `/goal` mode.
-Headless `codex exec` handoff is disabled here to avoid accidental hidden
-execution. Use the message-only command below inside the visible Codex CLI TUI.
+The default Codex CLI Goal Harness bootstrap is visible setup, then thin
+`/goal <task_body>` activation. Headless `codex exec` handoff is disabled here
+to avoid accidental hidden execution. Use the message-only command below inside
+the visible Codex CLI TUI.
 
 ````bash
 {payload.get("message_only_command", "")}


### PR DESCRIPTION
## Summary
- change `codex-cli-bootstrap-message` from a first-message `/goal` heartbeat into a setup-first prompt
- make the setup prompt install/reuse Goal Harness, bootstrap/connect the repo, then configure the loop from `heartbeat-prompt --thin`
- document the cross-surface mapping: Codex CLI uses `/goal <thin task_body>`, Codex App uses heartbeat automation `<thin task_body>`
- update README, Getting Started, product contract, driver packets, and focused smokes

## Validation
- python3 examples/codex-cli-bootstrap-message-smoke.py
- python3 examples/codex-cli-tui-bootstrap-smoke-bundle-smoke.py
- python3 examples/codex-cli-one-message-loop-pilot-smoke.py
- python3 examples/codex-cli-live-tui-first-message-pilot-smoke.py
- python3 examples/codex-cli-first-run-rehearsal-smoke.py
- python3 examples/codex-cli-no-clone-release-verification-smoke.py
- python3 examples/codex-cli-exec-handoff-smoke.py
- python3 examples/codex-cli-local-driver-plan-smoke.py
- python3 examples/docs-governance-smoke.py
- python3 -m py_compile goal_harness/project_prompt.py goal_harness/codex_cli_probe.py goal_harness/cli_commands/starter.py
- git diff --check
- goal-harness check --scan-path README.md --scan-path docs/guides/getting-started.md --scan-path docs/product/codex-cli-tui-loop.md --scan-path examples/codex-cli-bootstrap-message-smoke.py

## Boundary scan
- touched runtime bootstrap prompt/probe text, public docs, and focused smokes only
- no private state, local paths, credentials, raw logs, transcripts, or generated runtime files added
- `goal-harness check` passed with only the existing duplicate index warning for goal-harness-meta
