### PR TITLE
Clarify agent-scoped status todos

### DIFF
--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -1020,6 +1020,9 @@ field must therefore carry `preserves_goal_next_action=true` and must not be
 treated as a project-level status overwrite. `status --agent-id` may reuse the
 same quota-derived object as item/project-asset observation data; consumers must
 render it as an agent-lane pointer, not as `recommended_action` replacement.
+Human markdown should label this pointer as the current agent's todo and mark
+co-displayed global agent todo rows as goal-wide, so `--agent-id` is not
+mistaken for a filter that replaces the primary/global queue.
 Within a candidate source, selection is ordered by current-agent claim first,
 then `capability_repair_mode=true`, then priority/index. A repair-mode item
 therefore stays visible as the suggested agent-lane slice even when an older

--- a/examples/status-markdown-smoke.py
+++ b/examples/status-markdown-smoke.py
@@ -25,6 +25,7 @@ from goal_harness.status import (  # noqa: E402
     delivery_batch_scale_for_run,
     delivery_outcome_for_run,
     project_asset_summary_is_public_safe,
+    project_asset_todo_summary,
     render_status_markdown,
 )
 from goal_harness.quota import build_quota_should_run, render_quota_should_run_markdown  # noqa: E402
@@ -1335,25 +1336,27 @@ def assert_status_agent_lane_next_action_projection() -> None:
         "required_capabilities": ["shell", "filesystem_write"],
         "text": side_action,
     }
+    primary_todo = {
+        "schema_version": "todo_item_v0",
+        "todo_id": "todo_primary_route",
+        "index": 1,
+        "role": "agent",
+        "status": "open",
+        "priority": "P0",
+        "task_class": "advancement_task",
+        "claimed_by": "codex-main-control",
+        "text": primary_action,
+    }
     agent_todos = {
         "schema_version": "todo_summary_v0",
         "open_count": 2,
         "done_count": 0,
         "total_count": 2,
         "first_open_items": [
-            {
-                "schema_version": "todo_item_v0",
-                "todo_id": "todo_primary_route",
-                "index": 1,
-                "role": "agent",
-                "status": "open",
-                "priority": "P0",
-                "task_class": "advancement_task",
-                "claimed_by": "codex-main-control",
-                "text": primary_action,
-            },
+            primary_todo,
             side_todo,
         ],
+        "items": [primary_todo, side_todo],
         "first_executable_items": [side_todo],
     }
     coordination = {
@@ -1393,7 +1396,7 @@ def assert_status_agent_lane_next_action_projection() -> None:
                         "gate": "none",
                         "stop_condition": "stop on unsafe workspace or user gate",
                         "next_action": primary_action,
-                        "agent_todos": agent_todos,
+                        "agent_todos": project_asset_todo_summary(agent_todos, role="agent"),
                     },
                 }
             ],
@@ -1425,8 +1428,11 @@ def assert_status_agent_lane_next_action_projection() -> None:
     assert item["recommended_action"] == primary_action, item
     assert item["project_asset"]["next_action"] == primary_action, item
     markdown = render_status_markdown(payload)
-    assert "agent_lane_next_action: agent=codex-side-bypass todo_id=todo_side_tui" in markdown, markdown
+    assert "current_agent_todo: agent=codex-side-bypass todo_id=todo_side_tui" in markdown, markdown
+    assert "source=agent_lane_next_action" in markdown, markdown
     assert side_action in markdown, markdown
+    assert f"next_agent_todo: {primary_action} claimed_by=codex-main-control scope=goal_all_agents" in markdown, markdown
+    assert f"asset_agent_todo: {primary_action} claimed_by=codex-main-control scope=goal_all_agents" in markdown, markdown
 
 
 def assert_quota_should_run(payload: dict, *, expected: bool, state: str, waiting_on: str) -> dict:

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -7787,6 +7787,14 @@ def render_status_markdown(payload: dict[str, Any]) -> str:
         if authority_summary:
             lines.append(f"  - authority_material: {authority_summary}")
         project_asset = item.get("project_asset") if isinstance(item.get("project_asset"), dict) else {}
+        agent_lane_next_action = (
+            project_asset.get("agent_lane_next_action")
+            if isinstance(project_asset.get("agent_lane_next_action"), dict)
+            else item.get("agent_lane_next_action")
+            if isinstance(item.get("agent_lane_next_action"), dict)
+            else {}
+        )
+        goal_todo_scope_suffix = " scope=goal_all_agents" if agent_lane_next_action else ""
         lines.append(
             "  - project_asset_source: "
             + (
@@ -7820,22 +7828,16 @@ def render_status_markdown(payload: dict[str, Any]) -> str:
                     "    - agent_lane_recommendation: "
                     f"agent={agent} lane={lane} action={recommendation}"
                 )
-            agent_lane_next_action = (
-                project_asset.get("agent_lane_next_action")
-                if isinstance(project_asset.get("agent_lane_next_action"), dict)
-                else item.get("agent_lane_next_action")
-                if isinstance(item.get("agent_lane_next_action"), dict)
-                else {}
-            )
             if agent_lane_next_action:
                 agent = _markdown_scalar(agent_lane_next_action.get("agent_id") or "")
                 todo_id = _markdown_scalar(agent_lane_next_action.get("todo_id") or "")
                 selected_by = _markdown_scalar(agent_lane_next_action.get("selected_by") or "")
+                confidence = _markdown_scalar(agent_lane_next_action.get("confidence") or "")
                 action = _markdown_scalar(agent_lane_next_action.get("text") or "")
                 lines.append(
-                    "    - agent_lane_next_action: "
+                    "    - current_agent_todo: "
                     f"agent={agent} todo_id={todo_id} selected_by={selected_by} "
-                    f"action={action}"
+                    f"confidence={confidence} source=agent_lane_next_action action={action}"
                 )
             dreaming_lane_badge = (
                 project_asset.get("dreaming_lane_badge")
@@ -7931,14 +7933,22 @@ def render_status_markdown(payload: dict[str, Any]) -> str:
                 if asset_agent_todos.get("next"):
                     claimed = asset_agent_todos.get("next_claimed_by")
                     claim_suffix = f" claimed_by={_markdown_scalar(claimed)}" if claimed else ""
-                    lines.append(f"      - asset_agent_todo: {_markdown_scalar(asset_agent_todos.get('next') or '')}{claim_suffix}")
+                    lines.append(
+                        f"      - asset_agent_todo: "
+                        f"{_markdown_scalar(asset_agent_todos.get('next') or '')}"
+                        f"{claim_suffix}{goal_todo_scope_suffix}"
+                    )
                 for todo in (asset_agent_todos.get("items") or [])[1:3]:
                     if isinstance(todo, dict) and todo.get("text"):
                         index = todo.get("index")
                         suffix = f"[{index}]" if index is not None else ""
                         claimed = todo.get("claimed_by")
                         claim_suffix = f" claimed_by={_markdown_scalar(claimed)}" if claimed else ""
-                        lines.append(f"      - asset_agent_todo{suffix}: {_markdown_scalar(todo.get('text') or '')}{claim_suffix}")
+                        lines.append(
+                            f"      - asset_agent_todo{suffix}: "
+                            f"{_markdown_scalar(todo.get('text') or '')}"
+                            f"{claim_suffix}{goal_todo_scope_suffix}"
+                        )
             asset_quota = (
                 project_asset.get("quota")
                 if isinstance(project_asset.get("quota"), dict)
@@ -8195,7 +8205,11 @@ def render_status_markdown(payload: dict[str, Any]) -> str:
                     continue
                 claimed = todo.get("claimed_by")
                 claim_suffix = f" claimed_by={_markdown_scalar(claimed)}" if claimed else ""
-                lines.append(f"    - next_agent_todo: {_markdown_scalar(todo.get('text') or '')}{claim_suffix}")
+                lines.append(
+                    f"    - next_agent_todo: "
+                    f"{_markdown_scalar(todo.get('text') or '')}"
+                    f"{claim_suffix}{goal_todo_scope_suffix}"
+                )
                 break
         dependency_blockers = (
             item.get("dependency_blockers")


### PR DESCRIPTION
## Summary
- Render `status --agent-id` agent-lane pointers as `current_agent_todo` in markdown.
- Mark co-displayed goal-wide agent todo rows with `scope=goal_all_agents`.
- Add status markdown smoke coverage and document the projection contract.

## Validation
- `python3 examples/status-markdown-smoke.py`
- `python3 examples/docs-governance-smoke.py`
- `python3 -m py_compile goal_harness/status.py examples/status-markdown-smoke.py goal_harness/cli_commands/status.py`
- `goal-harness check --scan-path docs/status-data-contract.md --scan-path goal_harness/status.py --scan-path examples/status-markdown-smoke.py` (passes; existing duplicate-index warning only)
- `git diff --check`

## Notes
This fixes the confusing case where `goal-harness status --agent-id codex-side-bypass` correctly attaches an agent-lane todo, but the human output still made the primary/global queue look like the current side-agent todo.
