### PR TITLE
Add case-local Goal Harness benchmark install flow

### DIFF
--- a/docs/benchmark-developer-workflow.md
+++ b/docs/benchmark-developer-workflow.md
@@ -537,6 +537,18 @@ does not expose official reward, pass/fail status, verifier errors, or verifier
 output to the worker. If these controller fields are missing from compact
 evidence, classify the run as packet-only observation.
 
+The treatment path must also install a case-local Goal Harness surface before
+the worker starts. Harbor's host agent seeds
+`/app/.codex/goals/<benchmark-case-goal-id>/ACTIVE_GOAL_STATE.md`, installs a
+task-environment CLI at `/app/.local/bin/goal-harness`, seeds
+`todo_benchmark_case_main`, and writes public-safe lifecycle events to the
+case-local `rollout-event-log.jsonl`. The generated prompt tells the worker to
+call the case-local CLI through `harbor-env-exec` for `quota should-run` and
+`todo claim` before substantive work. Global Goal Harness commands are optional
+context only; they must not select todos for the benchmark case. This keeps
+parallel cases isolated and prevents the main project goal or side-agent lane
+from leaking into benchmark treatment control.
+
 This is not a submit/upload path and should still be reduced to compact public
 evidence before ledger ingestion.
 

--- a/examples/benchmark-case-active-state-contract-smoke.py
+++ b/examples/benchmark-case-active-state-contract-smoke.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -33,6 +35,9 @@ from goal_harness.benchmark_case_state import (  # noqa: E402
     benchmark_case_active_state_write_command,
     benchmark_case_arm_goal_id,
     benchmark_case_goal_id,
+    benchmark_case_goal_harness_event_log_path,
+    benchmark_case_goal_harness_install_command,
+    benchmark_case_goal_harness_install_payload,
     benchmark_case_lifecycle_contract,
     render_benchmark_case_lifecycle_contract_lines,
 )
@@ -125,6 +130,91 @@ def test_seed_write_command_uses_canonical_path() -> None:
     assert "/Users/" not in command
 
 
+def test_case_goal_harness_install_payload_adds_case_local_cli_surface() -> None:
+    payload = benchmark_case_goal_harness_install_payload(
+        benchmark_id="swe-marathon",
+        case_id="zstd-decoder",
+        arm_id="goal_harness_prompt_polling_test",
+        route="goal-harness-prompt-polling-test",
+        max_rounds=5,
+    )
+    goal_id = "swe-marathon-zstd-decoder-goal-harness-prompt-polling-test-case"
+    assert payload["benchmark_case_goal_id"] == goal_id
+    assert payload["case_state_path"] == benchmark_case_active_state_path(goal_id)
+    assert payload["case_cli_path"] == "/app/.local/bin/goal-harness"
+    assert payload["case_rollout_event_log_path"] == benchmark_case_goal_harness_event_log_path(goal_id)
+    assert payload["case_todo_id"] == "todo_benchmark_case_main"
+    assert payload["case_agent_id"] == "codex-benchmark-agent"
+    assert payload["case_todo_seeded"] is True
+    assert payload["install_flow_required"] is True
+    assert payload["prompt_driven_route_required"] is True
+    assert payload["product_path_primary_route"] == "prompt_driven_case_local_goal_harness_cli"
+    command = str(payload["command"])
+    assert "/app/.local/bin/goal-harness" in command
+    assert "quota_should_run" in command
+    assert "todo_claim" in command
+    assert "rollout-event-log.jsonl" in command
+    assert "raw_task_text_recorded\":false" in command
+    assert "/Users/" not in command
+
+
+def test_case_goal_harness_install_command_installs_callable_cli() -> None:
+    with tempfile.TemporaryDirectory(prefix="gh-case-install-") as tmp:
+        root = Path(tmp)
+        state_path = root / "goals" / "demo-case" / "ACTIVE_GOAL_STATE.md"
+        cli_path = root / "bin" / "goal-harness"
+        event_log_path = root / "goals" / "demo-case" / "rollout-event-log.jsonl"
+        command = benchmark_case_goal_harness_install_command(
+            goal_id="demo-case",
+            case_state_path=str(state_path),
+            content="---\nstatus: active\n---\n\n## Agent Todo\n\n- [ ] demo\n",
+            case_cli_path=str(cli_path),
+            case_rollout_event_log_path=str(event_log_path),
+        )
+        subprocess.run(["sh", "-c", command], check=True)
+        assert state_path.exists()
+        assert cli_path.exists()
+        quota = subprocess.run(
+            [
+                str(cli_path),
+                "--format",
+                "json",
+                "quota",
+                "should-run",
+                "--goal-id",
+                "demo-case",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        quota_payload = json.loads(quota.stdout)
+        assert quota_payload["should_run"] is True
+        assert quota_payload["agent_lane_next_action"]["todo_id"] == "todo_benchmark_case_main"
+        claim = subprocess.run(
+            [
+                str(cli_path),
+                "--format",
+                "json",
+                "todo",
+                "claim",
+                "--goal-id",
+                "demo-case",
+                "--todo-id",
+                "todo_benchmark_case_main",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        assert json.loads(claim.stdout)["status"] == "claimed"
+        event_lines = event_log_path.read_text(encoding="utf-8").strip().splitlines()
+        assert any('"event_kind":"install"' in line for line in event_lines)
+        assert any('"event_kind":"quota_should_run"' in line for line in event_lines)
+        assert any('"event_kind":"todo_claim"' in line for line in event_lines)
+        assert all("raw_task_text_recorded\":false" in line for line in event_lines)
+
+
 def test_case_lifecycle_contract_is_per_case_arm() -> None:
     contract = benchmark_case_lifecycle_contract(
         benchmark_id="swe-marathon",
@@ -192,6 +282,8 @@ if __name__ == "__main__":
     test_shared_contract_for_current_benchmark_routes()
     test_seed_text_uses_real_goal_harness_active_state_shape()
     test_seed_write_command_uses_canonical_path()
+    test_case_goal_harness_install_payload_adds_case_local_cli_surface()
+    test_case_goal_harness_install_command_installs_callable_cli()
     test_case_lifecycle_contract_is_per_case_arm()
     test_ale_launch_packet_reuses_shared_contract()
     test_terminal_bench_access_packet_fixture_reuses_shared_contract()

--- a/examples/harbor-host-codex-goal-agent-smoke.py
+++ b/examples/harbor-host-codex-goal-agent-smoke.py
@@ -71,8 +71,14 @@ def main() -> int:
     assert "benchmark_family: harbor" in treatment_packet
     assert "mode: codex_goal_harness" in treatment_packet
     assert "goal_harness_cli_bridge_available: true" in treatment_packet
-    assert "goal_harness_command_check:" in treatment_packet
-    assert "quota should-run" in treatment_packet
+    assert "goal_harness_product_path_primary_route: prompt_driven_case_local_goal_harness_cli" in treatment_packet
+    assert "goal_harness_case_local_cli_installed_before_agent: true" in treatment_packet
+    assert "goal_harness_case_cli_path: /app/.local/bin/goal-harness" in treatment_packet
+    assert "goal_harness_case_todo_id: todo_benchmark_case_main" in treatment_packet
+    assert "goal_harness_case_command_quota_should_run:" in treatment_packet
+    assert "/app/.local/bin/goal-harness --format json quota should-run" in treatment_packet
+    assert "goal_harness_case_command_claim_todo:" in treatment_packet
+    assert "goal_harness_global_command_check_optional_context:" in treatment_packet
     assert "do_not_upload_or_submit_to_leaderboard: true" in treatment_packet
     assert "benchmark_loop_contract:" in treatment_packet
     assert "protocol_id: packet_only_observation" in treatment_packet
@@ -110,12 +116,22 @@ def main() -> int:
     ), init_payload
     assert init_payload["case_state_path"].startswith("/app/.codex/goals/"), init_payload
     assert init_payload["case_state_path"].endswith("/ACTIVE_GOAL_STATE.md"), init_payload
+    assert init_payload["install_flow_schema_version"] == "goal_harness_benchmark_case_install_flow_v0", init_payload
+    assert init_payload["case_cli_path"] == "/app/.local/bin/goal-harness", init_payload
+    assert init_payload["case_todo_id"] == "todo_benchmark_case_main", init_payload
+    assert init_payload["case_agent_id"] == "codex-benchmark-agent", init_payload
+    assert init_payload["product_path_primary_route"] == "prompt_driven_case_local_goal_harness_cli", init_payload
+    assert init_payload["prompt_driven_route_required"] is True, init_payload
     init_command = init_payload["command"]
     assert "mkdir -p" in init_command, init_command
     assert "mv \"$tmp\"" in init_command, init_command
     assert "## Agent Todo" in init_command, init_command
     assert "goal-harness-prompt-polling-test" in init_command, init_command
     assert "find-network-alignments" in init_command, init_command
+    assert "/app/.local/bin/goal-harness" in init_command, init_command
+    assert "quota_should_run" in init_command, init_command
+    assert "todo_claim" in init_command, init_command
+    assert "rollout-event-log.jsonl" in init_command, init_command
     assert "/Users/" not in init_command, init_command
     init_compact = module._case_goal_state_init_compact(
         init_payload,
@@ -126,6 +142,13 @@ def main() -> int:
     assert init_compact["case_goal_state_initialized_before_agent"] is True, init_compact
     assert init_compact["case_goal_state_init_status"] == "initialized", init_compact
     assert init_compact["case_goal_state_path"] == init_payload["case_state_path"], init_compact
+    assert init_compact["goal_harness_install_flow_required"] is True, init_compact
+    assert init_compact["goal_harness_install_flow_status"] == "initialized", init_compact
+    assert init_compact["goal_harness_case_cli_installed_before_agent"] is True, init_compact
+    assert init_compact["goal_harness_case_cli_path"] == "/app/.local/bin/goal-harness", init_compact
+    assert init_compact["goal_harness_case_todo_id"] == "todo_benchmark_case_main", init_compact
+    assert init_compact["goal_harness_product_path_primary_route"] == "prompt_driven_case_local_goal_harness_cli", init_compact
+    assert init_compact["goal_harness_prompt_driven_route_required"] is True, init_compact
     assert init_compact["case_goal_state_raw_output_recorded"] is False, init_compact
 
     treatment_prompt = module.build_host_goal_prompt(
@@ -136,6 +159,7 @@ def main() -> int:
         goal_harness_access_packet=treatment_packet,
     )
     assert "Goal Harness treatment access packet:" in treatment_prompt
+    assert "case-local Goal Harness CLI" in treatment_prompt
     assert "mode: codex_goal_harness" in treatment_prompt
 
     with tempfile.TemporaryDirectory(prefix="gh-harbor-host-agent-") as tmp:

--- a/goal_harness/benchmark_case_state.py
+++ b/goal_harness/benchmark_case_state.py
@@ -16,6 +16,19 @@ BENCHMARK_CASE_ACTIVE_STATE_INIT_STAGE = "before_codex_worker_start"
 BENCHMARK_CASE_ACTIVE_STATE_STATUS_FIELD = "case_goal_state_init_status"
 BENCHMARK_CASE_LIFECYCLE_SCHEMA_VERSION = "goal_harness_benchmark_case_lifecycle_v0"
 BENCHMARK_CASE_LIFECYCLE_SOURCE_OF_TRUTH = "case_active_state_and_rollout_event_log"
+BENCHMARK_CASE_GOAL_HARNESS_INSTALL_FLOW_SCHEMA_VERSION = (
+    "goal_harness_benchmark_case_install_flow_v0"
+)
+BENCHMARK_CASE_GOAL_HARNESS_CLI_PATH = "/app/.local/bin/goal-harness"
+BENCHMARK_CASE_GOAL_HARNESS_EVENT_LOG_BASENAME = "rollout-event-log.jsonl"
+BENCHMARK_CASE_GOAL_HARNESS_AGENT_ID = "codex-benchmark-agent"
+BENCHMARK_CASE_GOAL_HARNESS_TODO_ID = "todo_benchmark_case_main"
+BENCHMARK_CASE_GOAL_HARNESS_PRODUCT_PATH_PRIMARY_ROUTE = (
+    "prompt_driven_case_local_goal_harness_cli"
+)
+BENCHMARK_CASE_GOAL_HARNESS_SCHEDULER_ROUTE = (
+    "cli_scheduler_case_local_goal_harness_cli"
+)
 BENCHMARK_CASE_ACTIVE_STATE_PROOF_FIELDS = (
     "case_goal_state_init_required",
     "case_goal_state_initialized_before_agent",
@@ -70,6 +83,25 @@ def benchmark_case_active_state_path(
     root: str = BENCHMARK_CASE_STATE_ROOT,
 ) -> str:
     return f"{root.rstrip('/')}/{goal_id}/{BENCHMARK_CASE_ACTIVE_STATE_BASENAME}"
+
+
+def benchmark_case_goal_harness_case_dir(
+    goal_id: str,
+    *,
+    root: str = BENCHMARK_CASE_STATE_ROOT,
+) -> str:
+    return f"{root.rstrip('/')}/{goal_id}"
+
+
+def benchmark_case_goal_harness_event_log_path(
+    goal_id: str,
+    *,
+    root: str = BENCHMARK_CASE_STATE_ROOT,
+) -> str:
+    return (
+        f"{benchmark_case_goal_harness_case_dir(goal_id, root=root).rstrip('/')}/"
+        f"{BENCHMARK_CASE_GOAL_HARNESS_EVENT_LOG_BASENAME}"
+    )
 
 
 def benchmark_case_active_state_init_contract(
@@ -258,3 +290,218 @@ def benchmark_case_active_state_write_command(
         f"mv \"$tmp\" {target} && "
         f"test -s {target}"
     )
+
+
+def benchmark_case_goal_harness_install_command(
+    *,
+    goal_id: str,
+    case_state_path: str,
+    content: str,
+    case_cli_path: str = BENCHMARK_CASE_GOAL_HARNESS_CLI_PATH,
+    case_rollout_event_log_path: str | None = None,
+    case_agent_id: str = BENCHMARK_CASE_GOAL_HARNESS_AGENT_ID,
+    case_todo_id: str = BENCHMARK_CASE_GOAL_HARNESS_TODO_ID,
+) -> str:
+    """Return a shell command that installs the per-case GH CLI surface.
+
+    The installed CLI is intentionally tiny and public-safe: it models the
+    quota/todo/status/refresh/spend lifecycle inside the benchmark sandbox, logs
+    only event kinds and ids, and never records raw task text, verifier output,
+    trajectories, credentials, or host-local paths.
+    """
+
+    event_log_path = case_rollout_event_log_path or (
+        benchmark_case_goal_harness_event_log_path(goal_id)
+    )
+    cli_parent = shlex.quote(posixpath.dirname(case_cli_path.rstrip("/")) or "/")
+    cli_target = shlex.quote(case_cli_path)
+    event_log_target = shlex.quote(event_log_path)
+    case_dir = shlex.quote(posixpath.dirname(case_state_path.rstrip("/")) or "/")
+    state_write = benchmark_case_active_state_write_command(
+        case_state_path=case_state_path,
+        content=content,
+    )
+    script = f"""#!/usr/bin/env sh
+set -eu
+GOAL_ID={shlex.quote(goal_id)}
+STATE_FILE={shlex.quote(case_state_path)}
+EVENT_LOG={shlex.quote(event_log_path)}
+AGENT_ID={shlex.quote(case_agent_id)}
+TODO_ID={shlex.quote(case_todo_id)}
+
+record_event() {{
+  kind="$1"
+  mkdir -p "$(dirname "$EVENT_LOG")"
+  printf '{{"schema_version":"benchmark_case_goal_harness_cli_event_v0","event_kind":"%s","goal_id":"%s","todo_id":"%s","agent_id":"%s","raw_logs_recorded":false,"raw_task_text_recorded":false,"raw_verifier_output_recorded":false,"raw_agent_trajectory_recorded":false,"local_paths_recorded":false}}\\n' "$kind" "$GOAL_ID" "$TODO_ID" "$AGENT_ID" >> "$EVENT_LOG"
+}}
+
+if [ "${{1:-}}" = "--format" ]; then
+  shift
+  [ "${{1:-}}" = "json" ] && shift || true
+fi
+
+cmd="${{1:-}}"
+[ "$#" -gt 0 ] && shift || true
+
+case "$cmd" in
+  check)
+    record_event check
+    cat <<JSON
+{{"ok":true,"goal_id":"$GOAL_ID","scan_path_public":true,"raw_logs_recorded":false}}
+JSON
+    ;;
+  status)
+    record_event status
+    cat <<JSON
+{{"ok":true,"goal_id":"$GOAL_ID","status":"active","active_state_path":"$STATE_FILE","agent_todo_summary":{{"open_count":1,"items":[{{"todo_id":"$TODO_ID","priority":"P0","status":"open","task_class":"advancement_task","claimed_by":"$AGENT_ID"}}]}},"raw_logs_recorded":false,"local_paths_recorded":false}}
+JSON
+    ;;
+  history)
+    record_event history
+    cat <<JSON
+{{"ok":true,"goal_id":"$GOAL_ID","events_public_counts_only":true,"raw_logs_recorded":false,"raw_task_text_recorded":false}}
+JSON
+    ;;
+  refresh-state)
+    record_event refresh_state
+    cat <<JSON
+{{"ok":true,"goal_id":"$GOAL_ID","refreshed":true,"raw_logs_recorded":false}}
+JSON
+    ;;
+  quota)
+    sub="${{1:-}}"
+    [ "$#" -gt 0 ] && shift || true
+    case "$sub" in
+      should-run)
+        record_event quota_should_run
+        cat <<JSON
+{{"ok":true,"goal_id":"$GOAL_ID","agent_id":"$AGENT_ID","should_run":true,"decision":"run","interaction_contract":{{"user_channel":{{"action_required":false,"open_count":0}}}},"agent_lane_next_action":{{"todo_id":"$TODO_ID","priority":"P0","status":"open","task_class":"advancement_task","claimed_by":"$AGENT_ID"}},"raw_logs_recorded":false}}
+JSON
+        ;;
+      spend-slot|spend)
+        record_event quota_spend
+        cat <<JSON
+{{"ok":true,"goal_id":"$GOAL_ID","spent":true,"raw_logs_recorded":false}}
+JSON
+        ;;
+      *)
+        echo "unsupported quota subcommand: $sub" >&2
+        exit 2
+        ;;
+    esac
+    ;;
+  todo)
+    sub="${{1:-}}"
+    [ "$#" -gt 0 ] && shift || true
+    case "$sub" in
+      claim)
+        record_event todo_claim
+        cat <<JSON
+{{"ok":true,"goal_id":"$GOAL_ID","todo_id":"$TODO_ID","claimed_by":"$AGENT_ID","status":"claimed","raw_logs_recorded":false}}
+JSON
+        ;;
+      update)
+        record_event todo_update
+        cat <<JSON
+{{"ok":true,"goal_id":"$GOAL_ID","todo_id":"$TODO_ID","status":"updated","raw_logs_recorded":false}}
+JSON
+        ;;
+      *)
+        echo "unsupported todo subcommand: $sub" >&2
+        exit 2
+        ;;
+    esac
+    ;;
+  *)
+    echo "unsupported goal-harness case CLI command: $cmd" >&2
+    exit 2
+    ;;
+esac
+"""
+    delimiter = "__GOAL_HARNESS_BENCHMARK_CASE_CLI_EOF__"
+    while delimiter in script:
+        delimiter += "_"
+    install_event = (
+        '{"schema_version":"benchmark_case_goal_harness_cli_event_v0",'
+        '"event_kind":"install","raw_logs_recorded":false,'
+        '"raw_task_text_recorded":false,"raw_verifier_output_recorded":false,'
+        '"raw_agent_trajectory_recorded":false,"local_paths_recorded":false}'
+    )
+    return (
+        f"{state_write} && "
+        f"mkdir -p {cli_parent} {case_dir} && "
+        f"cat > {cli_target} <<'{delimiter}'\n"
+        f"{script}"
+        f"{delimiter}\n"
+        f"chmod +x {cli_target} && "
+        f": > {event_log_target} && "
+        f"printf '%s\\n' {shlex.quote(install_event)} >> {event_log_target} && "
+        f"test -x {cli_target} && "
+        f"test -s {shlex.quote(case_state_path)}"
+    )
+
+
+def benchmark_case_goal_harness_install_payload(
+    *,
+    benchmark_id: str,
+    case_id: str,
+    arm_id: str,
+    route: str,
+    max_rounds: int,
+    case_cli_path: str = BENCHMARK_CASE_GOAL_HARNESS_CLI_PATH,
+    case_agent_id: str = BENCHMARK_CASE_GOAL_HARNESS_AGENT_ID,
+    case_todo_id: str = BENCHMARK_CASE_GOAL_HARNESS_TODO_ID,
+) -> dict[str, object]:
+    """Return the case-local GH install/state/todo launch payload."""
+
+    contract = benchmark_case_lifecycle_contract(
+        benchmark_id=benchmark_id,
+        case_id=case_id,
+        arm_id=arm_id,
+        max_rounds=max_rounds,
+    )
+    goal_id = str(contract["benchmark_case_goal_id"])
+    case_state_path = str(contract["case_state_path"])
+    seed = benchmark_case_active_state_seed_text(
+        benchmark_name=benchmark_id,
+        goal_id=goal_id,
+        task_id=case_id,
+        route=route,
+        max_rounds=max_rounds,
+        case_state_path=case_state_path,
+    )
+    case_rollout_event_log_path = benchmark_case_goal_harness_event_log_path(goal_id)
+    return {
+        "schema_version": BENCHMARK_CASE_ACTIVE_STATE_SCHEMA_VERSION,
+        "install_flow_schema_version": (
+            BENCHMARK_CASE_GOAL_HARNESS_INSTALL_FLOW_SCHEMA_VERSION
+        ),
+        "benchmark_case_goal_id": goal_id,
+        "case_state_path": case_state_path,
+        "case_cli_path": case_cli_path,
+        "case_rollout_event_log_path": case_rollout_event_log_path,
+        "case_agent_id": case_agent_id,
+        "case_todo_id": case_todo_id,
+        "case_todo_seeded": True,
+        "install_flow_required": True,
+        "prompt_driven_route_required": True,
+        "product_path_primary_route": (
+            BENCHMARK_CASE_GOAL_HARNESS_PRODUCT_PATH_PRIMARY_ROUTE
+        ),
+        "scheduler_route_supported": True,
+        "scheduler_route": BENCHMARK_CASE_GOAL_HARNESS_SCHEDULER_ROUTE,
+        "command": benchmark_case_goal_harness_install_command(
+            goal_id=goal_id,
+            case_state_path=case_state_path,
+            content=seed,
+            case_cli_path=case_cli_path,
+            case_rollout_event_log_path=case_rollout_event_log_path,
+            case_agent_id=case_agent_id,
+            case_todo_id=case_todo_id,
+        ),
+        "raw_task_text_required_for_init": False,
+        "raw_logs_recorded": False,
+        "raw_verifier_output_recorded": False,
+        "raw_agent_trajectory_recorded": False,
+        "local_paths_recorded": False,
+    }

--- a/scripts/harbor_host_codex_goal_agent.py
+++ b/scripts/harbor_host_codex_goal_agent.py
@@ -36,8 +36,12 @@ from codex_app_server_goal_driver import (
 )
 from goal_harness.benchmark_case_state import (
     BENCHMARK_CASE_ACTIVE_STATE_SCHEMA_VERSION,
-    benchmark_case_active_state_seed_text,
-    benchmark_case_active_state_write_command,
+    BENCHMARK_CASE_GOAL_HARNESS_AGENT_ID,
+    BENCHMARK_CASE_GOAL_HARNESS_CLI_PATH,
+    BENCHMARK_CASE_GOAL_HARNESS_PRODUCT_PATH_PRIMARY_ROUTE,
+    BENCHMARK_CASE_GOAL_HARNESS_TODO_ID,
+    benchmark_case_goal_harness_event_log_path,
+    benchmark_case_goal_harness_install_payload,
     benchmark_case_lifecycle_contract,
     render_benchmark_case_lifecycle_contract_lines,
 )
@@ -168,7 +172,12 @@ def build_host_goal_prompt(
     task_workdir_arg = shlex.quote(task_workdir)
     access_packet = goal_harness_access_packet.strip()
     access_packet_section = (
-        f"\n\nGoal Harness treatment access packet:\n{access_packet}"
+        "\n\nGoal Harness treatment access packet:\n"
+        "After the bridge check and before substantive work, use the "
+        "case-local Goal Harness CLI listed below to run quota should-run and "
+        "claim the case todo through the same task-environment bridge. Keep "
+        "case-local state isolated to the listed benchmark_case_goal_id.\n"
+        f"{access_packet}"
         if access_packet
         else ""
     )
@@ -243,6 +252,8 @@ def build_goal_harness_access_packet(
         arm_id=arm_id,
         max_rounds=max_rounds,
     )
+    case_goal_id = str(case_lifecycle["benchmark_case_goal_id"])
+    case_event_log_path = benchmark_case_goal_harness_event_log_path(case_goal_id)
 
     lines = [
         "Goal Harness Access Packet V0",
@@ -256,8 +267,16 @@ def build_goal_harness_access_packet(
         "do_not_modify_tests: true",
         "do_not_upload_or_submit_to_leaderboard: true",
         "do_not_record_raw_task_text_logs_trajectories_or_credentials: true",
-        "use_goal_harness_for_planning_checkpoints_and_boundary_awareness_only: true",
+        "use_goal_harness_for_planning_checkpoints_and_boundary_awareness_only: false",
         "task_environment_commands_still_must_use_harbor_env_exec_bridge: true",
+        f"goal_harness_product_path_primary_route: {BENCHMARK_CASE_GOAL_HARNESS_PRODUCT_PATH_PRIMARY_ROUTE}",
+        "goal_harness_prompt_driven_loop_required: true",
+        "goal_harness_scheduler_route_supported_for_smoke_or_fallback: true",
+        "goal_harness_case_local_cli_installed_before_agent: true",
+        f"goal_harness_case_cli_path: {BENCHMARK_CASE_GOAL_HARNESS_CLI_PATH}",
+        f"goal_harness_case_rollout_event_log_path: {case_event_log_path}",
+        f"goal_harness_case_agent_id: {BENCHMARK_CASE_GOAL_HARNESS_AGENT_ID}",
+        f"goal_harness_case_todo_id: {BENCHMARK_CASE_GOAL_HARNESS_TODO_ID}",
         f"goal_harness_treatment_evidence_tier: {claim['goal_harness_treatment_evidence_tier']}",
         f"strict_goal_harness_treatment_claim_allowed: {str(claim['strict_goal_harness_treatment_claim_allowed']).lower()}",
         f"goal_harness_treatment_claim_blocker: {claim['goal_harness_treatment_claim_blocker']}",
@@ -267,13 +286,19 @@ def build_goal_harness_access_packet(
     if cli_enabled:
         lines.extend(
             [
-                f"goal_harness_command_check: {base} check --scan-path {scan_path_arg}",
-                f"goal_harness_command_status: {base} status --limit 5",
-                f"goal_harness_command_quota_should_run: {base} quota should-run --goal-id {goal_id_arg}",
-                f"goal_harness_command_history: {base} history --goal-id {goal_id_arg} --limit 5",
-                "before_long_actions_call_goal_harness_check_once: true",
-                "before_final_marker_review_goal_harness_status_or_history_once: true",
-                "goal_harness_cli_calls_are_observational_unless_an_explicit_write_command_is_provided: true",
+                "primary_goal_harness_cli_surface: task_environment_case_local_cli",
+                f"goal_harness_case_command_quota_should_run: {BENCHMARK_CASE_GOAL_HARNESS_CLI_PATH} --format json quota should-run --goal-id {shlex.quote(case_goal_id)} --agent-id {BENCHMARK_CASE_GOAL_HARNESS_AGENT_ID}",
+                f"goal_harness_case_command_claim_todo: {BENCHMARK_CASE_GOAL_HARNESS_CLI_PATH} --format json todo claim --goal-id {shlex.quote(case_goal_id)} --todo-id {BENCHMARK_CASE_GOAL_HARNESS_TODO_ID} --claimed-by {BENCHMARK_CASE_GOAL_HARNESS_AGENT_ID}",
+                f"goal_harness_case_command_status: {BENCHMARK_CASE_GOAL_HARNESS_CLI_PATH} --format json status --goal-id {shlex.quote(case_goal_id)} --limit 5",
+                f"goal_harness_case_command_refresh_state: {BENCHMARK_CASE_GOAL_HARNESS_CLI_PATH} --format json refresh-state --goal-id {shlex.quote(case_goal_id)}",
+                f"goal_harness_case_command_spend_quota: {BENCHMARK_CASE_GOAL_HARNESS_CLI_PATH} --format json quota spend-slot --goal-id {shlex.quote(case_goal_id)}",
+                "before_planning_call_goal_harness_case_quota_should_run_once: true",
+                "before_planning_claim_goal_harness_case_todo_once: true",
+                "before_final_marker_review_goal_harness_case_status_or_history_once: true",
+                f"goal_harness_global_command_check_optional_context: {base} check --scan-path {scan_path_arg}",
+                f"goal_harness_global_command_status_optional_context: {base} status --limit 5",
+                f"goal_harness_global_command_history_optional_context: {base} history --goal-id {goal_id_arg} --limit 5",
+                "goal_harness_case_cli_calls_are_part_of_the_treatment_flow: true",
             ]
         )
     else:
@@ -294,35 +319,17 @@ def build_case_goal_state_init_payload(
     route: str,
     max_rounds: int,
 ) -> dict[str, Any]:
-    """Build the public-safe case active-state init payload for Harbor/SWE."""
+    """Build the public-safe case-local GH install/state/todo payload."""
 
-    contract = benchmark_case_lifecycle_contract(
-        benchmark_id=benchmark_id,
-        case_id=case_id,
-        arm_id=arm_id,
-        max_rounds=max_rounds,
+    return dict(
+        benchmark_case_goal_harness_install_payload(
+            benchmark_id=benchmark_id,
+            case_id=case_id,
+            arm_id=arm_id,
+            route=route,
+            max_rounds=max_rounds,
+        )
     )
-    goal_id = str(contract["benchmark_case_goal_id"])
-    case_state_path = str(contract["case_state_path"])
-    seed = benchmark_case_active_state_seed_text(
-        benchmark_name=benchmark_id,
-        goal_id=goal_id,
-        task_id=case_id,
-        route=route,
-        max_rounds=max_rounds,
-        case_state_path=case_state_path,
-    )
-    return {
-        "schema_version": BENCHMARK_CASE_ACTIVE_STATE_SCHEMA_VERSION,
-        "benchmark_case_goal_id": goal_id,
-        "case_state_path": case_state_path,
-        "command": benchmark_case_active_state_write_command(
-            case_state_path=case_state_path,
-            content=seed,
-        ),
-        "raw_task_text_required_for_init": False,
-        "local_paths_recorded": False,
-    }
 
 
 def _case_goal_state_init_compact(
@@ -341,6 +348,29 @@ def _case_goal_state_init_compact(
             payload.get("schema_version") or BENCHMARK_CASE_ACTIVE_STATE_SCHEMA_VERSION
         ),
         "case_goal_state_path": payload.get("case_state_path") or "",
+        "goal_harness_install_flow_required": bool(
+            payload.get("install_flow_required") if required else False
+        ),
+        "goal_harness_install_flow_status": status if required else "not_required",
+        "goal_harness_case_cli_installed_before_agent": bool(
+            payload.get("case_cli_path") and initialized_before_agent
+        ),
+        "goal_harness_case_cli_path": payload.get("case_cli_path") or "",
+        "goal_harness_case_rollout_event_log_path": (
+            payload.get("case_rollout_event_log_path") or ""
+        ),
+        "goal_harness_case_agent_id": payload.get("case_agent_id") or "",
+        "goal_harness_case_todo_id": payload.get("case_todo_id") or "",
+        "goal_harness_case_todo_seeded": bool(payload.get("case_todo_seeded")),
+        "goal_harness_product_path_primary_route": (
+            payload.get("product_path_primary_route") or ""
+        ),
+        "goal_harness_prompt_driven_route_required": bool(
+            payload.get("prompt_driven_route_required")
+        ),
+        "goal_harness_scheduler_route_supported": bool(
+            payload.get("scheduler_route_supported")
+        ),
         "case_goal_state_raw_output_recorded": False,
     }
 


### PR DESCRIPTION
## Summary
- add a shared benchmark case install payload that creates per-case ACTIVE_GOAL_STATE, a case-local goal-harness CLI, seeded todo, and public-safe rollout event log
- switch Harbor Goal Harness treatment packets to make the case-local CLI the primary quota/todo surface while keeping global GH commands optional context
- document the Harbor treatment install flow and cover it with callable CLI and Harbor agent smokes

## Validation
- python examples/benchmark-developer-workflow-doc-smoke.py
- python examples/benchmark-case-active-state-contract-smoke.py
- python examples/harbor-host-codex-goal-agent-smoke.py
- python -m py_compile goal_harness/benchmark_case_state.py scripts/harbor_host_codex_goal_agent.py examples/benchmark-case-active-state-contract-smoke.py
- git diff --check

## Exclusions
- no raw benchmark logs, task text, trajectories, verifier output, credentials, or local/private Goal Harness state committed