### PR TITLE
Add showcase animation prototype

### DIFF
--- a/docs/showcases/README.md
+++ b/docs/showcases/README.md
@@ -57,6 +57,11 @@ For animated outreach assets, start from the
 and the
 [public storyboard artifact](showcase-animation-storyboard.json). Keep
 `showcase-catalog.json` as the only case data source.
+Generate the first catalog-backed animation prototype with
+`python3 examples/showcase-animation-prototype.py --output /tmp/goal-harness-showcase-animation.html`
+or open the committed
+[showcase-animation-prototype.html](showcase-animation-prototype.html). Validate
+the artifact with `python3 examples/showcase-animation-prototype-smoke.py`.
 
 ![Hosted Goal Harness frontstage showing public-safe showcase cases](../assets/frontstage-showcase-first-screen.png)
 

--- a/docs/showcases/showcase-animation-prototype.html
+++ b/docs/showcases/showcase-animation-prototype.html
@@ -1,0 +1,527 @@
+<!doctype html>
+<html lang="en"
+  data-source-storyboard="docs/showcases/showcase-animation-storyboard.json"
+  data-source-catalog="docs/showcases/showcase-catalog.json"
+  data-duration-seconds="30">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Goal Harness Showcase Animation Prototype</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --ink: #15171c;
+      --muted: #596272;
+      --line: #d8dee8;
+      --paper: #ffffff;
+      --soft: #f4f7fb;
+      --green: #087f5b;
+      --blue: #2454c6;
+      --amber: #a66000;
+      --red: #b42318;
+      --shadow: 0 24px 60px rgba(18, 24, 38, 0.14);
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      color: var(--ink);
+      background: #f7f9fc;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.5;
+    }
+    main {
+      width: min(1180px, calc(100vw - 32px));
+      min-height: 100vh;
+      margin: 0 auto;
+      padding: 32px 0 44px;
+      display: grid;
+      grid-template-columns: minmax(280px, 0.88fr) minmax(480px, 1.12fr);
+      gap: 28px;
+      align-items: center;
+    }
+    .intro h1 {
+      margin: 0 0 16px;
+      font-size: 48px;
+      line-height: 1.04;
+      letter-spacing: 0;
+    }
+    .eyebrow {
+      margin: 0 0 10px;
+      color: var(--green);
+      font-size: 13px;
+      font-weight: 800;
+      letter-spacing: 0;
+      text-transform: uppercase;
+    }
+    .intro p {
+      max-width: 620px;
+      margin: 0 0 18px;
+      color: var(--muted);
+      font-size: 18px;
+    }
+    .source-box {
+      display: grid;
+      gap: 10px;
+      max-width: 560px;
+      padding: 16px;
+      border: 1px solid var(--line);
+      background: var(--paper);
+      border-radius: 8px;
+      box-shadow: 0 10px 28px rgba(18, 24, 38, 0.08);
+    }
+    .source-box span {
+      color: var(--muted);
+      font-size: 13px;
+      font-weight: 700;
+      text-transform: uppercase;
+    }
+    .source-box code {
+      display: block;
+      padding: 10px 12px;
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      background: #f8fafc;
+      color: #253044;
+      white-space: normal;
+      overflow-wrap: anywhere;
+    }
+    .stage {
+      position: relative;
+      min-height: 620px;
+      padding: 22px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background:
+        linear-gradient(135deg, rgba(36, 84, 198, 0.08), transparent 42%),
+        linear-gradient(315deg, rgba(8, 127, 91, 0.08), transparent 44%),
+        var(--paper);
+      box-shadow: var(--shadow);
+      overflow: hidden;
+    }
+    .stage::before {
+      content: "";
+      position: absolute;
+      inset: 24px;
+      border: 1px dashed rgba(89, 98, 114, 0.28);
+      border-radius: 8px;
+      pointer-events: none;
+    }
+    .stage__header {
+      position: relative;
+      z-index: 2;
+      display: flex;
+      justify-content: space-between;
+      gap: 16px;
+      align-items: flex-start;
+      margin-bottom: 18px;
+    }
+    .stage__header span {
+      display: inline-flex;
+      padding: 5px 9px;
+      border-radius: 999px;
+      background: #eaf7f1;
+      color: var(--green);
+      font-size: 12px;
+      font-weight: 800;
+    }
+    .stage__header strong {
+      color: var(--muted);
+      font-size: 13px;
+      font-weight: 700;
+      text-align: right;
+    }
+    .timeline {
+      position: relative;
+      z-index: 3;
+      height: 12px;
+      margin: 0 0 18px;
+      border-radius: 999px;
+      background: #e8edf5;
+      overflow: hidden;
+    }
+    .timeline::after {
+      content: "";
+      position: absolute;
+      inset: 0 auto 0 0;
+      width: 12%;
+      border-radius: 999px;
+      background: var(--blue);
+      animation: progress 30s linear infinite;
+    }
+    .timeline__segment {
+      position: absolute;
+      inset: 0 auto 0 var(--start);
+      width: var(--width);
+      border-left: 1px solid rgba(255, 255, 255, 0.92);
+      border-right: 1px solid rgba(255, 255, 255, 0.92);
+    }
+    .scene-stack {
+      position: relative;
+      z-index: 2;
+      min-height: 490px;
+    }
+    .scene {
+      position: absolute;
+      inset: 0;
+      display: grid;
+      align-content: center;
+      gap: 16px;
+      padding: 28px;
+      border: 1px solid rgba(216, 222, 232, 0.94);
+      border-radius: 8px;
+      background: rgba(255, 255, 255, 0.92);
+      opacity: 0;
+      box-shadow: 0 12px 34px rgba(18, 24, 38, 0.08);
+    }
+    .scene__meta {
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+      color: var(--muted);
+      font-size: 13px;
+      font-weight: 800;
+      text-transform: uppercase;
+    }
+    .scene h2 {
+      max-width: 740px;
+      margin: 0;
+      font-size: 34px;
+      line-height: 1.12;
+      letter-spacing: 0;
+    }
+    .visual {
+      max-width: 720px;
+      margin: 0;
+      color: #303947;
+      font-size: 18px;
+      font-weight: 650;
+    }
+    .motion-note {
+      max-width: 720px;
+      margin: 0;
+      color: var(--muted);
+      font-size: 15px;
+    }
+    .case-strip {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+      gap: 12px;
+      margin-top: 4px;
+    }
+    .case-card {
+      display: grid;
+      gap: 8px;
+      min-height: 142px;
+      padding: 14px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: #fbfcff;
+    }
+    .case-card strong {
+      font-size: 15px;
+      line-height: 1.25;
+    }
+    .case-card span {
+      color: var(--muted);
+      font-size: 13px;
+    }
+    .case-card small {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      align-self: end;
+    }
+    .case-card small span {
+      padding: 3px 7px;
+      border-radius: 999px;
+      background: #edf2ff;
+      color: var(--blue);
+      font-size: 11px;
+      font-weight: 800;
+    }
+    .case-card--system small span {
+      background: #eaf7f1;
+      color: var(--green);
+    }
+    @keyframes progress {
+      0% { width: 0%; }
+      100% { width: 100%; }
+    }
+    
+    .scene--opening-control-plane { animation: scene-opening-control-plane 30s linear infinite; }
+    @keyframes scene-opening-control-plane {
+      0%, 0.0000% { opacity: 0; transform: translateY(18px) scale(0.985); pointer-events: none; }
+      2.3333%, 11.0000% { opacity: 1; transform: translateY(0) scale(1); pointer-events: auto; }
+      13.3333%, 100% { opacity: 0; transform: translateY(-14px) scale(0.99); pointer-events: none; }
+    }
+            
+
+    .scene--gate-visible-safe-lane-moves { animation: scene-gate-visible-safe-lane-moves 30s linear infinite; }
+    @keyframes scene-gate-visible-safe-lane-moves {
+      0%, 13.3000% { opacity: 0; transform: translateY(18px) scale(0.985); pointer-events: none; }
+      15.6667%, 27.6667% { opacity: 1; transform: translateY(0) scale(1); pointer-events: auto; }
+      30.0000%, 100% { opacity: 0; transform: translateY(-14px) scale(0.99); pointer-events: none; }
+    }
+            
+
+    .scene--multi-agent-shared-state { animation: scene-multi-agent-shared-state 30s linear infinite; }
+    @keyframes scene-multi-agent-shared-state {
+      0%, 29.9667% { opacity: 0; transform: translateY(18px) scale(0.985); pointer-events: none; }
+      32.3333%, 44.3333% { opacity: 1; transform: translateY(0) scale(1); pointer-events: auto; }
+      46.6667%, 100% { opacity: 0; transform: translateY(-14px) scale(0.99); pointer-events: none; }
+    }
+            
+
+    .scene--self-iteration-efficiency-evidence { animation: scene-self-iteration-efficiency-evidence 30s linear infinite; }
+    @keyframes scene-self-iteration-efficiency-evidence {
+      0%, 46.6333% { opacity: 0; transform: translateY(18px) scale(0.985); pointer-events: none; }
+      49.0000%, 67.6667% { opacity: 1; transform: translateY(0) scale(1); pointer-events: auto; }
+      70.0000%, 100% { opacity: 0; transform: translateY(-14px) scale(0.99); pointer-events: none; }
+    }
+            
+
+    .scene--creator-operator-safe-production-loop { animation: scene-creator-operator-safe-production-loop 30s linear infinite; }
+    @keyframes scene-creator-operator-safe-production-loop {
+      0%, 69.9667% { opacity: 0; transform: translateY(18px) scale(0.985); pointer-events: none; }
+      72.3333%, 87.6667% { opacity: 1; transform: translateY(0) scale(1); pointer-events: auto; }
+      90.0000%, 100% { opacity: 0; transform: translateY(-14px) scale(0.99); pointer-events: none; }
+    }
+            
+
+    .scene--boundary-close { animation: scene-boundary-close 30s linear infinite; }
+    @keyframes scene-boundary-close {
+      0%, 89.9667% { opacity: 0; transform: translateY(18px) scale(0.985); pointer-events: none; }
+      92.3333%, 97.6667% { opacity: 1; transform: translateY(0) scale(1); pointer-events: auto; }
+      100.0000%, 100% { opacity: 0; transform: translateY(-14px) scale(0.99); pointer-events: none; }
+    }
+            
+    @media (max-width: 900px) {
+      main {
+        grid-template-columns: 1fr;
+        align-items: start;
+      }
+      .intro h1 { font-size: 38px; }
+      .stage { min-height: 680px; }
+      .scene-stack { min-height: 548px; }
+      .scene h2 { font-size: 28px; }
+    }
+    @media (max-width: 560px) {
+      main {
+        width: min(100% - 20px, 1180px);
+        padding-top: 18px;
+      }
+      .stage {
+        min-height: 760px;
+        padding: 14px;
+      }
+      .scene-stack { min-height: 640px; }
+      .scene { padding: 18px; }
+      .stage__header {
+        display: grid;
+      }
+      .stage__header strong {
+        text-align: left;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <section class="intro" aria-label="Prototype overview">
+      <p class="eyebrow">Goal Harness public showcase animation</p>
+      <h1>From AI assist to async agent work.</h1>
+      <p>A human sets gates and evidence; agent lanes keep safe work moving across turns.</p>
+      <div class="source-box">
+        <span>Prototype source boundary</span>
+        <code>docs/showcases/showcase-animation-storyboard.json</code>
+        <code>docs/showcases/showcase-catalog.json</code>
+        <span>Remotion Agent Skills / HyperFrames</span>
+      </div>
+    </section>
+    <section class="stage" aria-label="30 second storyboard prototype">
+      <div class="stage__header">
+        <span>30s loop</span>
+        <strong>Public catalog demo. No live registry, local status export, transcript, or private active state.</strong>
+      </div>
+      <div class="timeline" aria-label="Scene timeline">
+        
+          <span class="timeline__segment"
+            data-scene-id="opening-control-plane"
+            style="--start:0.0000%; --width:13.3333%;"></span>
+            
+
+          <span class="timeline__segment"
+            data-scene-id="gate-visible-safe-lane-moves"
+            style="--start:13.3333%; --width:16.6667%;"></span>
+            
+
+          <span class="timeline__segment"
+            data-scene-id="multi-agent-shared-state"
+            style="--start:30.0000%; --width:16.6667%;"></span>
+            
+
+          <span class="timeline__segment"
+            data-scene-id="self-iteration-efficiency-evidence"
+            style="--start:46.6667%; --width:23.3333%;"></span>
+            
+
+          <span class="timeline__segment"
+            data-scene-id="creator-operator-safe-production-loop"
+            style="--start:70.0000%; --width:20.0000%;"></span>
+            
+
+          <span class="timeline__segment"
+            data-scene-id="boundary-close"
+            style="--start:90.0000%; --width:10.0000%;"></span>
+            
+      </div>
+      <div class="scene-stack">
+        
+      <article class="scene scene--opening-control-plane"
+        data-scene-id="opening-control-plane"
+        data-start-seconds="0"
+        data-end-seconds="4"
+        data-source-case-ids="">
+        <div class="scene__meta">
+          <span>00-04s</span>
+          <span>Scene 1</span>
+        </div>
+        <h2>One shared control plane for long-running agent work.</h2>
+        <p class="visual">dark canvas with a single shared goal state node; agent lanes orbit into view</p>
+        <p class="motion-note">fade in the goal node, then pulse two safe lanes without implying live ops data</p>
+        <div class="case-strip">
+          
+            <div class="case-card case-card--system" data-source-case-id="catalog-boundary">
+              <strong>Catalog-backed control plane</strong>
+              <span>The prototype reads the public storyboard and catalog only.</span>
+              <small><span>public-boundary</span><span>no-live-status</span></small>
+            </div>
+    
+        </div>
+      </article>
+    
+
+      <article class="scene scene--gate-visible-safe-lane-moves"
+        data-scene-id="gate-visible-safe-lane-moves"
+        data-start-seconds="4"
+        data-end-seconds="9"
+        data-source-case-ids="2026-06-17-blocked-p0-safe-rotation">
+        <div class="scene__meta">
+          <span>04-09s</span>
+          <span>Scene 2</span>
+        </div>
+        <h2>A user gate stays visible. Safe side work still moves.</h2>
+        <p class="visual">a gated P0 lane pauses while a safe side lane advances with a validation marker</p>
+        <p class="motion-note">keep the blocked lane still; animate only the safe lane and evidence writeback</p>
+        <div class="case-strip">
+          
+            <div class="case-card" data-source-case-id="2026-06-17-blocked-p0-safe-rotation">
+              <strong>Blocked P0 with safe P1/P2 rotation</strong>
+              <span>A gated P0 lane should not stall a whole long-running goal when safe fallback work exists.</span>
+              <small><span>reproducible</span><span>user-gate</span><span>fallback</span></small>
+            </div>
+            
+        </div>
+      </article>
+    
+
+      <article class="scene scene--multi-agent-shared-state"
+        data-scene-id="multi-agent-shared-state"
+        data-start-seconds="9"
+        data-end-seconds="14"
+        data-source-case-ids="2026-06-19-dynamic-workflow-hardware-agent">
+        <div class="scene__meta">
+          <span>09-14s</span>
+          <span>Scene 3</span>
+        </div>
+        <h2>Multiple agents can share one project memory without guessing each other&#x27;s state.</h2>
+        <p class="visual">primary and side-agent lanes claim separate todos against one catalog-backed board</p>
+        <p class="motion-note">show claims and handoff lines as lightweight beams into shared state</p>
+        <div class="case-strip">
+          
+            <div class="case-card" data-source-case-id="2026-06-19-dynamic-workflow-hardware-agent">
+              <strong>Dynamic workflow for hardware-agent development</strong>
+              <span>A fuzzy long-running engineering goal needs a shared control plane when multiple worker agents participate.</span>
+              <small><span>redacted</span><span>multi-agent</span><span>pending-demo</span></small>
+            </div>
+            
+        </div>
+      </article>
+    
+
+      <article class="scene scene--self-iteration-efficiency-evidence"
+        data-scene-id="self-iteration-efficiency-evidence"
+        data-start-seconds="14"
+        data-end-seconds="21"
+        data-source-case-ids="2026-06-19-goal-harness-self-iteration">
+        <div class="scene__meta">
+          <span>14-21s</span>
+          <span>Scene 4</span>
+        </div>
+        <h2>Async side work turns repo history into recoverable product momentum.</h2>
+        <p class="visual">repo-scale requirement clusters compress into validated commits, docs, smokes, and frontstage surfaces</p>
+        <p class="motion-note">avoid raw commit firehoses; use compact clusters and conservative evidence labels</p>
+        <div class="case-strip">
+          
+            <div class="case-card" data-source-case-id="2026-06-19-goal-harness-self-iteration">
+              <strong>Goal Harness self-iteration loop</strong>
+              <span>A high-churn Goal Harness repo stayed legible while benchmark, product, docs, planning, and side-agent lanes moved in parallel.</span>
+              <small><span>self-iteration</span><span>commit-backed</span><span>side-agent</span></small>
+            </div>
+            
+        </div>
+      </article>
+    
+
+      <article class="scene scene--creator-operator-safe-production-loop"
+        data-scene-id="creator-operator-safe-production-loop"
+        data-start-seconds="21"
+        data-end-seconds="27"
+        data-source-case-ids="2026-06-20-creator-operator-case-spec">
+        <div class="scene__meta">
+          <span>21-27s</span>
+          <span>Scene 5</span>
+        </div>
+        <h2>The agent can keep researching while human judgment guards what ships.</h2>
+        <p class="visual">research, preference memory, and draft material move while publishing remains gated</p>
+        <p class="motion-note">animate safe research cards; leave publish decision locked until the final frame</p>
+        <div class="case-strip">
+          
+            <div class="case-card" data-source-case-id="2026-06-20-creator-operator-case-spec">
+              <strong>Creator-operator long-running agent case</strong>
+              <span>A creator-operator needs a long-running agent loop that keeps research moving while publishing decisions stay gated.</span>
+              <small><span>synthetic</span><span>creator-ops</span><span>user-gate</span></small>
+            </div>
+            
+        </div>
+      </article>
+    
+
+      <article class="scene scene--boundary-close"
+        data-scene-id="boundary-close"
+        data-start-seconds="27"
+        data-end-seconds="30"
+        data-source-case-ids="">
+        <div class="scene__meta">
+          <span>27-30s</span>
+          <span>Scene 6</span>
+        </div>
+        <h2>Public demos read the showcase catalog, not private control-plane state.</h2>
+        <p class="visual">public showcase catalog badge replaces the live status feed</p>
+        <p class="motion-note">close on the catalog badge and a clean public/private boundary line</p>
+        <div class="case-strip">
+          
+            <div class="case-card case-card--system" data-source-case-id="catalog-boundary">
+              <strong>Catalog-backed control plane</strong>
+              <span>The prototype reads the public storyboard and catalog only.</span>
+              <small><span>public-boundary</span><span>no-live-status</span></small>
+            </div>
+    
+        </div>
+      </article>
+    
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/examples/showcase-animation-prototype-smoke.py
+++ b/examples/showcase-animation-prototype-smoke.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Smoke-test the public-safe showcase animation prototype artifact."""
+
+from __future__ import annotations
+
+import html as html_lib
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+STORYBOARD = REPO_ROOT / "docs" / "showcases" / "showcase-animation-storyboard.json"
+CATALOG = REPO_ROOT / "docs" / "showcases" / "showcase-catalog.json"
+PROTOTYPE = REPO_ROOT / "examples" / "showcase-animation-prototype.py"
+SHOWCASE_README = REPO_ROOT / "docs" / "showcases" / "README.md"
+COMMITTED_ARTIFACT = REPO_ROOT / "docs" / "showcases" / "showcase-animation-prototype.html"
+PRIVATE_MARKERS = tuple(
+    "".join(parts)
+    for parts in (
+        ("lark", "office.com"),
+        ("internal", "-api-drive"),
+        ("bytedance.com", "/wiki"),
+        ("/", "Users/"),
+        (".codex", "/goal-harness"),
+        ("BEGIN", " PRIVATE ", "KEY"),
+        ("Author", "ization:"),
+        ("to", "ken="),
+        ("pass", "word="),
+        ("registry", ".global.json"),
+        ("ACTIVE", "_GOAL_STATE.md"),
+    )
+)
+
+
+def escaped(value: object) -> str:
+    return html_lib.escape(str(value), quote=True)
+
+
+def main() -> int:
+    storyboard = json.loads(STORYBOARD.read_text(encoding="utf-8"))
+    catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
+    scenes = storyboard["scenes"]
+    cases = catalog["cases"]
+    duration = scenes[-1]["time_seconds"][1]
+
+    with tempfile.TemporaryDirectory(prefix="goal-harness-showcase-animation-") as tmp:
+        output = Path(tmp) / "showcase-animation.html"
+        result = subprocess.run(
+            [sys.executable, str(PROTOTYPE), "--output", str(output)],
+            cwd=REPO_ROOT,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        assert str(output) in result.stdout, result.stdout
+        rendered = output.read_text(encoding="utf-8")
+
+    committed = COMMITTED_ARTIFACT.read_text(encoding="utf-8")
+    assert committed == rendered, "committed prototype must match generated output"
+
+    for marker in PRIVATE_MARKERS:
+        assert marker not in rendered, marker
+
+    for required in (
+        '<section class="stage" aria-label="30 second storyboard prototype">',
+        'data-source-storyboard="docs/showcases/showcase-animation-storyboard.json"',
+        'data-source-catalog="docs/showcases/showcase-catalog.json"',
+        f'data-duration-seconds="{duration}"',
+        f"{duration}s loop",
+        "No live registry, local status export, transcript, or private active state.",
+        "docs/showcases/showcase-animation-storyboard.json",
+        "docs/showcases/showcase-catalog.json",
+        "Remotion Agent Skills / HyperFrames",
+        "@keyframes progress",
+    ):
+        assert required in rendered, required
+
+    assert storyboard["duration_seconds_target"] == {"min": 20, "max": 30}, storyboard
+    assert 20 <= duration <= 30, duration
+    assert rendered.count('class="scene scene--') == len(scenes), rendered
+    assert rendered.count("@keyframes scene-") == len(scenes), rendered
+    assert rendered.count('class="timeline__segment"') == len(scenes), rendered
+
+    for scene in scenes:
+        scene_id = str(scene["id"])
+        start, end = scene["time_seconds"]
+        assert f'data-scene-id="{escaped(scene_id)}"' in rendered, scene_id
+        assert f'data-start-seconds="{start}"' in rendered, scene_id
+        assert f'data-end-seconds="{end}"' in rendered, scene_id
+        for field in ("copy", "visual", "motion_notes"):
+            assert escaped(scene[field]) in rendered, (scene_id, field)
+        for case_id in scene["source_case_ids"]:
+            assert f'data-source-case-id="{escaped(case_id)}"' in rendered, (scene_id, case_id)
+
+    for case in cases:
+        case_id = str(case["id"])
+        assert case_id in rendered, case_id
+        assert escaped(case["title"]) in rendered, case_id
+        assert escaped(case["headline"]) in rendered, case_id
+        frontend = case["frontend_card"]
+        for badge in frontend.get("badges", [])[:3]:
+            assert escaped(badge) in rendered, (case_id, badge)
+
+    readme = SHOWCASE_README.read_text(encoding="utf-8")
+    assert "showcase-animation-prototype.py" in readme, SHOWCASE_README
+    assert "showcase-animation-prototype.html" in readme, SHOWCASE_README
+    assert "showcase-animation-prototype-smoke.py" in readme, SHOWCASE_README
+
+    print("showcase-animation-prototype-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/showcase-animation-prototype.py
+++ b/examples/showcase-animation-prototype.py
@@ -1,0 +1,575 @@
+#!/usr/bin/env python3
+"""Render a public-safe HTML animation prototype from the showcase storyboard."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_STORYBOARD = REPO_ROOT / "docs" / "showcases" / "showcase-animation-storyboard.json"
+DEFAULT_CATALOG = REPO_ROOT / "docs" / "showcases" / "showcase-catalog.json"
+FORBIDDEN_SOURCE_FLAGS = (
+    "live_registry_state",
+    "local_status_exports",
+    "user_specific_active_state",
+    "private_docs_or_chats",
+    "raw_benchmark_traces",
+    "internal_project_names",
+)
+STACK_LABELS = {
+    "remotion-agent-skills": "Remotion Agent Skills",
+    "hyperframes": "HyperFrames",
+    "motion-for-react": "Motion for React",
+    "lottie": "Lottie",
+}
+
+
+def esc(value: object) -> str:
+    return html.escape(str(value), quote=True)
+
+
+def slug(value: object) -> str:
+    safe = re.sub(r"[^a-zA-Z0-9_-]+", "-", str(value)).strip("-")
+    return safe or "scene"
+
+
+def pct(seconds: float, total: float) -> str:
+    return f"{(seconds / total) * 100:.4f}%"
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{path}: expected JSON object")
+    return data
+
+
+def validate(
+    storyboard: dict[str, Any],
+    catalog: dict[str, Any],
+) -> tuple[list[dict[str, Any]], dict[str, dict[str, Any]], int]:
+    if storyboard.get("schema_version") != "goal_harness_showcase_animation_storyboard_v0":
+        raise ValueError("storyboard schema_version mismatch")
+    if storyboard.get("source_catalog") != "docs/showcases/showcase-catalog.json":
+        raise ValueError("storyboard must point to docs/showcases/showcase-catalog.json")
+    if catalog.get("schema_version") != "goal_harness_showcase_catalog_v0":
+        raise ValueError("catalog schema_version mismatch")
+
+    target = storyboard.get("duration_seconds_target")
+    if not isinstance(target, dict) or target.get("min") != 20 or target.get("max") != 30:
+        raise ValueError("storyboard duration target must be 20-30 seconds")
+
+    boundary = storyboard.get("public_boundary")
+    if not isinstance(boundary, dict):
+        raise ValueError("storyboard public_boundary must be an object")
+    for flag in FORBIDDEN_SOURCE_FLAGS:
+        if boundary.get(flag) is not False:
+            raise ValueError(f"storyboard public boundary must keep {flag}=false")
+
+    cases = catalog.get("cases")
+    scenes = storyboard.get("scenes")
+    if not isinstance(cases, list) or not cases:
+        raise ValueError("catalog must contain cases")
+    if not isinstance(scenes, list) or not scenes:
+        raise ValueError("storyboard must contain scenes")
+
+    case_by_id: dict[str, dict[str, Any]] = {}
+    for case in cases:
+        if not isinstance(case, dict) or not case.get("id"):
+            raise ValueError("each catalog case must have an id")
+        case_by_id[str(case["id"])] = case
+
+    previous_end: int | None = None
+    referenced_case_ids: set[str] = set()
+    for scene in scenes:
+        if not isinstance(scene, dict):
+            raise ValueError("each scene must be an object")
+        for required in ("id", "visual", "copy", "motion_notes"):
+            if not scene.get(required):
+                raise ValueError(f"scene missing {required}: {scene}")
+        time_seconds = scene.get("time_seconds")
+        if (
+            not isinstance(time_seconds, list)
+            or len(time_seconds) != 2
+            or not all(isinstance(value, int) for value in time_seconds)
+        ):
+            raise ValueError(f"scene {scene.get('id')}: time_seconds must be [start, end]")
+        start, end = time_seconds
+        if start < 0 or end <= start:
+            raise ValueError(f"scene {scene.get('id')}: invalid time range")
+        if previous_end is not None and start != previous_end:
+            raise ValueError(f"scene {scene.get('id')}: scenes must be contiguous")
+        previous_end = end
+
+        source_case_ids = scene.get("source_case_ids")
+        if not isinstance(source_case_ids, list):
+            raise ValueError(f"scene {scene.get('id')}: source_case_ids must be a list")
+        for case_id in source_case_ids:
+            case_key = str(case_id)
+            if case_key not in case_by_id:
+                raise ValueError(f"scene {scene.get('id')}: unknown case id {case_id}")
+            referenced_case_ids.add(case_key)
+
+    duration = int(scenes[-1]["time_seconds"][1])
+    if duration < int(target["min"]) or duration > int(target["max"]):
+        raise ValueError("storyboard scene duration must fit the 20-30 second target")
+    if referenced_case_ids != set(case_by_id):
+        raise ValueError("storyboard must reference every catalog case exactly through public ids")
+    return scenes, case_by_id, duration
+
+
+def render_badges(values: list[Any], *, limit: int = 3) -> str:
+    return "".join(f"<span>{esc(value)}</span>" for value in values[:limit])
+
+
+def render_stack_label(value: object) -> str:
+    text = str(value)
+    return STACK_LABELS.get(text, text.replace("-", " ").title())
+
+
+def render_case_cards(scene: dict[str, Any], case_by_id: dict[str, dict[str, Any]]) -> str:
+    cards: list[str] = []
+    for case_id in scene.get("source_case_ids") or []:
+        case = case_by_id[str(case_id)]
+        frontend = case.get("frontend_card") if isinstance(case.get("frontend_card"), dict) else {}
+        badges = frontend.get("badges") if isinstance(frontend.get("badges"), list) else []
+        cards.append(
+            f"""
+            <div class="case-card" data-source-case-id="{esc(case_id)}">
+              <strong>{esc(case.get("title") or case_id)}</strong>
+              <span>{esc(case.get("headline") or "")}</span>
+              <small>{render_badges(badges)}</small>
+            </div>
+            """
+        )
+    if cards:
+        return "\n".join(cards)
+    return """
+            <div class="case-card case-card--system" data-source-case-id="catalog-boundary">
+              <strong>Catalog-backed control plane</strong>
+              <span>The prototype reads the public storyboard and catalog only.</span>
+              <small><span>public-boundary</span><span>no-live-status</span></small>
+            </div>
+    """
+
+
+def render_scene(scene: dict[str, Any], case_by_id: dict[str, dict[str, Any]], index: int) -> str:
+    scene_id = str(scene["id"])
+    start, end = scene["time_seconds"]
+    case_ids = ",".join(str(case_id) for case_id in scene.get("source_case_ids") or [])
+    return f"""
+      <article class="scene scene--{slug(scene_id)}"
+        data-scene-id="{esc(scene_id)}"
+        data-start-seconds="{start}"
+        data-end-seconds="{end}"
+        data-source-case-ids="{esc(case_ids)}">
+        <div class="scene__meta">
+          <span>{start:02d}-{end:02d}s</span>
+          <span>Scene {index + 1}</span>
+        </div>
+        <h2>{esc(scene.get("copy") or "")}</h2>
+        <p class="visual">{esc(scene.get("visual") or "")}</p>
+        <p class="motion-note">{esc(scene.get("motion_notes") or "")}</p>
+        <div class="case-strip">
+          {render_case_cards(scene, case_by_id)}
+        </div>
+      </article>
+    """
+
+
+def render_timeline(scenes: list[dict[str, Any]], duration: int) -> str:
+    parts: list[str] = []
+    for scene in scenes:
+        scene_id = str(scene["id"])
+        start, end = scene["time_seconds"]
+        width = end - start
+        parts.append(
+            f"""
+          <span class="timeline__segment"
+            data-scene-id="{esc(scene_id)}"
+            style="--start:{pct(start, duration)}; --width:{pct(width, duration)};"></span>
+            """
+        )
+    return "\n".join(parts)
+
+
+def render_scene_keyframes(scenes: list[dict[str, Any]], duration: int) -> str:
+    blocks: list[str] = []
+    for scene in scenes:
+        scene_class = slug(scene["id"])
+        start, end = scene["time_seconds"]
+        start_pct = pct(start, duration)
+        fade_pct = pct(min(start + 0.7, end), duration)
+        hold_pct = pct(max(end - 0.7, start + 0.7), duration)
+        end_pct = pct(end, duration)
+        before_pct = pct(max(start - 0.01, 0), duration)
+        blocks.append(
+            f"""
+    .scene--{scene_class} {{ animation: scene-{scene_class} {duration}s linear infinite; }}
+    @keyframes scene-{scene_class} {{
+      0%, {before_pct} {{ opacity: 0; transform: translateY(18px) scale(0.985); pointer-events: none; }}
+      {fade_pct}, {hold_pct} {{ opacity: 1; transform: translateY(0) scale(1); pointer-events: auto; }}
+      {end_pct}, 100% {{ opacity: 0; transform: translateY(-14px) scale(0.99); pointer-events: none; }}
+    }}
+            """
+        )
+    return "\n".join(blocks)
+
+
+def render(storyboard: dict[str, Any], catalog: dict[str, Any]) -> str:
+    scenes, case_by_id, duration = validate(storyboard, catalog)
+    scene_markup = "\n".join(render_scene(scene, case_by_id, index) for index, scene in enumerate(scenes))
+    timeline = render_timeline(scenes, duration)
+    scene_keyframes = render_scene_keyframes(scenes, duration)
+    hero_line = storyboard.get("hero_line") or "From AI assist to async agent work."
+    supporting_line = storyboard.get("supporting_line") or ""
+    stack = storyboard.get("recommended_motion_stack")
+    stack_label = ""
+    if isinstance(stack, dict):
+        stack_label = " / ".join(
+            render_stack_label(stack[key])
+            for key in ("video_primary", "video_fallback")
+            if stack.get(key)
+        )
+
+    return f"""<!doctype html>
+<html lang="en"
+  data-source-storyboard="docs/showcases/showcase-animation-storyboard.json"
+  data-source-catalog="docs/showcases/showcase-catalog.json"
+  data-duration-seconds="{duration}">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Goal Harness Showcase Animation Prototype</title>
+  <style>
+    :root {{
+      color-scheme: light;
+      --ink: #15171c;
+      --muted: #596272;
+      --line: #d8dee8;
+      --paper: #ffffff;
+      --soft: #f4f7fb;
+      --green: #087f5b;
+      --blue: #2454c6;
+      --amber: #a66000;
+      --red: #b42318;
+      --shadow: 0 24px 60px rgba(18, 24, 38, 0.14);
+    }}
+    * {{ box-sizing: border-box; }}
+    body {{
+      margin: 0;
+      color: var(--ink);
+      background: #f7f9fc;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.5;
+    }}
+    main {{
+      width: min(1180px, calc(100vw - 32px));
+      min-height: 100vh;
+      margin: 0 auto;
+      padding: 32px 0 44px;
+      display: grid;
+      grid-template-columns: minmax(280px, 0.88fr) minmax(480px, 1.12fr);
+      gap: 28px;
+      align-items: center;
+    }}
+    .intro h1 {{
+      margin: 0 0 16px;
+      font-size: 48px;
+      line-height: 1.04;
+      letter-spacing: 0;
+    }}
+    .eyebrow {{
+      margin: 0 0 10px;
+      color: var(--green);
+      font-size: 13px;
+      font-weight: 800;
+      letter-spacing: 0;
+      text-transform: uppercase;
+    }}
+    .intro p {{
+      max-width: 620px;
+      margin: 0 0 18px;
+      color: var(--muted);
+      font-size: 18px;
+    }}
+    .source-box {{
+      display: grid;
+      gap: 10px;
+      max-width: 560px;
+      padding: 16px;
+      border: 1px solid var(--line);
+      background: var(--paper);
+      border-radius: 8px;
+      box-shadow: 0 10px 28px rgba(18, 24, 38, 0.08);
+    }}
+    .source-box span {{
+      color: var(--muted);
+      font-size: 13px;
+      font-weight: 700;
+      text-transform: uppercase;
+    }}
+    .source-box code {{
+      display: block;
+      padding: 10px 12px;
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      background: #f8fafc;
+      color: #253044;
+      white-space: normal;
+      overflow-wrap: anywhere;
+    }}
+    .stage {{
+      position: relative;
+      min-height: 620px;
+      padding: 22px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background:
+        linear-gradient(135deg, rgba(36, 84, 198, 0.08), transparent 42%),
+        linear-gradient(315deg, rgba(8, 127, 91, 0.08), transparent 44%),
+        var(--paper);
+      box-shadow: var(--shadow);
+      overflow: hidden;
+    }}
+    .stage::before {{
+      content: "";
+      position: absolute;
+      inset: 24px;
+      border: 1px dashed rgba(89, 98, 114, 0.28);
+      border-radius: 8px;
+      pointer-events: none;
+    }}
+    .stage__header {{
+      position: relative;
+      z-index: 2;
+      display: flex;
+      justify-content: space-between;
+      gap: 16px;
+      align-items: flex-start;
+      margin-bottom: 18px;
+    }}
+    .stage__header span {{
+      display: inline-flex;
+      padding: 5px 9px;
+      border-radius: 999px;
+      background: #eaf7f1;
+      color: var(--green);
+      font-size: 12px;
+      font-weight: 800;
+    }}
+    .stage__header strong {{
+      color: var(--muted);
+      font-size: 13px;
+      font-weight: 700;
+      text-align: right;
+    }}
+    .timeline {{
+      position: relative;
+      z-index: 3;
+      height: 12px;
+      margin: 0 0 18px;
+      border-radius: 999px;
+      background: #e8edf5;
+      overflow: hidden;
+    }}
+    .timeline::after {{
+      content: "";
+      position: absolute;
+      inset: 0 auto 0 0;
+      width: 12%;
+      border-radius: 999px;
+      background: var(--blue);
+      animation: progress {duration}s linear infinite;
+    }}
+    .timeline__segment {{
+      position: absolute;
+      inset: 0 auto 0 var(--start);
+      width: var(--width);
+      border-left: 1px solid rgba(255, 255, 255, 0.92);
+      border-right: 1px solid rgba(255, 255, 255, 0.92);
+    }}
+    .scene-stack {{
+      position: relative;
+      z-index: 2;
+      min-height: 490px;
+    }}
+    .scene {{
+      position: absolute;
+      inset: 0;
+      display: grid;
+      align-content: center;
+      gap: 16px;
+      padding: 28px;
+      border: 1px solid rgba(216, 222, 232, 0.94);
+      border-radius: 8px;
+      background: rgba(255, 255, 255, 0.92);
+      opacity: 0;
+      box-shadow: 0 12px 34px rgba(18, 24, 38, 0.08);
+    }}
+    .scene__meta {{
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+      color: var(--muted);
+      font-size: 13px;
+      font-weight: 800;
+      text-transform: uppercase;
+    }}
+    .scene h2 {{
+      max-width: 740px;
+      margin: 0;
+      font-size: 34px;
+      line-height: 1.12;
+      letter-spacing: 0;
+    }}
+    .visual {{
+      max-width: 720px;
+      margin: 0;
+      color: #303947;
+      font-size: 18px;
+      font-weight: 650;
+    }}
+    .motion-note {{
+      max-width: 720px;
+      margin: 0;
+      color: var(--muted);
+      font-size: 15px;
+    }}
+    .case-strip {{
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+      gap: 12px;
+      margin-top: 4px;
+    }}
+    .case-card {{
+      display: grid;
+      gap: 8px;
+      min-height: 142px;
+      padding: 14px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: #fbfcff;
+    }}
+    .case-card strong {{
+      font-size: 15px;
+      line-height: 1.25;
+    }}
+    .case-card span {{
+      color: var(--muted);
+      font-size: 13px;
+    }}
+    .case-card small {{
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      align-self: end;
+    }}
+    .case-card small span {{
+      padding: 3px 7px;
+      border-radius: 999px;
+      background: #edf2ff;
+      color: var(--blue);
+      font-size: 11px;
+      font-weight: 800;
+    }}
+    .case-card--system small span {{
+      background: #eaf7f1;
+      color: var(--green);
+    }}
+    @keyframes progress {{
+      0% {{ width: 0%; }}
+      100% {{ width: 100%; }}
+    }}
+    {scene_keyframes}
+    @media (max-width: 900px) {{
+      main {{
+        grid-template-columns: 1fr;
+        align-items: start;
+      }}
+      .intro h1 {{ font-size: 38px; }}
+      .stage {{ min-height: 680px; }}
+      .scene-stack {{ min-height: 548px; }}
+      .scene h2 {{ font-size: 28px; }}
+    }}
+    @media (max-width: 560px) {{
+      main {{
+        width: min(100% - 20px, 1180px);
+        padding-top: 18px;
+      }}
+      .stage {{
+        min-height: 760px;
+        padding: 14px;
+      }}
+      .scene-stack {{ min-height: 640px; }}
+      .scene {{ padding: 18px; }}
+      .stage__header {{
+        display: grid;
+      }}
+      .stage__header strong {{
+        text-align: left;
+      }}
+    }}
+  </style>
+</head>
+<body>
+  <main>
+    <section class="intro" aria-label="Prototype overview">
+      <p class="eyebrow">Goal Harness public showcase animation</p>
+      <h1>{esc(hero_line)}</h1>
+      <p>{esc(supporting_line)}</p>
+      <div class="source-box">
+        <span>Prototype source boundary</span>
+        <code>docs/showcases/showcase-animation-storyboard.json</code>
+        <code>docs/showcases/showcase-catalog.json</code>
+        <span>{esc(stack_label or "HTML/CSS prototype")}</span>
+      </div>
+    </section>
+    <section class="stage" aria-label="30 second storyboard prototype">
+      <div class="stage__header">
+        <span>{duration}s loop</span>
+        <strong>Public catalog demo. No live registry, local status export, transcript, or private active state.</strong>
+      </div>
+      <div class="timeline" aria-label="Scene timeline">
+        {timeline}
+      </div>
+      <div class="scene-stack">
+        {scene_markup}
+      </div>
+    </section>
+  </main>
+</body>
+</html>
+"""
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--storyboard", type=Path, default=DEFAULT_STORYBOARD)
+    parser.add_argument("--catalog", type=Path, default=DEFAULT_CATALOG)
+    parser.add_argument("--output", type=Path, help="Write the HTML prototype to this path")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    storyboard = read_json(args.storyboard)
+    catalog = read_json(args.catalog)
+    output = render(storyboard, catalog)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(output, encoding="utf-8")
+        print(f"wrote {args.output}")
+    else:
+        print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a committed public-safe 30s showcase animation HTML prototype generated from the storyboard and showcase catalog
- add `examples/showcase-animation-prototype.py` to regenerate the artifact from `docs/showcases/showcase-animation-storyboard.json` and `docs/showcases/showcase-catalog.json`
- add an artifact smoke that verifies the committed HTML matches generated output, preserves the 20-30s storyboard contract, includes all catalog scenes/cases, and avoids live/private Goal Harness state markers
- link the prototype and validation command from `docs/showcases/README.md`

## Validation
- `python3 examples/showcase-animation-prototype-smoke.py`
- `python3 examples/showcase-animation-source-boundary-smoke.py`
- `python3 examples/showcase-catalog-smoke.py`
- `python3 examples/showcase-frontstage-prototype-smoke.py`
- `python3 -m py_compile examples/showcase-animation-prototype.py examples/showcase-animation-prototype-smoke.py`
- `python3 examples/docs-governance-smoke.py`
- `git diff --check`
- `goal-harness check --scan-path docs/showcases/README.md --scan-path docs/showcases/showcase-animation-prototype.html --scan-path examples/showcase-animation-prototype.py --scan-path examples/showcase-animation-prototype-smoke.py` (passes with existing duplicate-index warning)

## Boundary
- Uses only the public storyboard and showcase catalog as data sources.
- Does not read live registry state, local status exports, active state, transcripts, session files, raw benchmark traces, private docs, credentials, or local machine paths.
- Playwright screenshot validation was not run because the local Node environment does not have `playwright`; the committed artifact is covered by the artifact smoke required for this slice.
