### PR TITLE
Document frontstage two-surface strategy

### DIFF
--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -65,6 +65,10 @@ runtime contract, benchmark route, or launch draft.
 - [Non-technical operator status model](nontechnical-operator-status-model.md):
   first-screen card model for people who need to understand agent progress,
   blockers, next moves, and feedback paths without reading logs or CLI output.
+- [Frontstage two-surface strategy](frontstage-two-surface-strategy.md): route,
+  data-source, visual-freedom, validation, and roadmap boundaries between the
+  public showcase/homepage surface and the real local ops control-plane
+  surface.
 - [Reward-style replanning hints](reward-style-replanning.md): public-safe
   design for turning explicit reward, corrections, and steering feedback into
   compact candidate-ranking hints without raw chat, hidden profiling, or hard

--- a/docs/product/frontstage-two-surface-strategy.md
+++ b/docs/product/frontstage-two-surface-strategy.md
@@ -1,0 +1,141 @@
+# Frontstage Two-Surface Strategy
+
+Goal Harness frontstage work has two different products sharing some dashboard
+code. Treating them as one surface makes the next UI pass ambiguous: public
+showcase pages want visual storytelling, while the real operator control plane
+wants dense, local, stateful inspection. This note is the route and validation
+contract to keep those jobs separate before more large UI changes.
+
+## Decision
+
+The frontstage family has two first-class surfaces:
+
+| Surface | Job | Primary routes | Owner |
+| --- | --- | --- | --- |
+| Public showcase and homepage | Explain Goal Harness through public-safe cases, demos, animation, and product narrative. | `/frontstage`, hosted `/frontstage/`, future homepage entry points. | Product, outreach, and frontstage showcase work. |
+| Real ops control plane | Help the operator inspect current goals, gates, todos, claims, quota, run history, and safe local actions. | `/`, `?view=ops`, `/frontstage?mode=ops&statusUrl=<relative-or-loopback>`. | Runtime, status contract, dashboard, and control-plane work. |
+
+The public surface is the default when a URL can be copied or hosted. The ops
+surface is explicit, local, and read-only unless a loopback server advertises a
+separate capability such as reward dry-run or append preview.
+
+## Route Ownership
+
+`/frontstage` without `mode=ops` belongs to the public showcase surface. It
+must ignore `statusUrl`, render bundled demo or showcase material, and remain
+safe for GitHub Pages, Lark shares, screenshots, and public demos.
+
+`/frontstage?mode=ops&statusUrl=...` belongs to local ops inspection. The
+`statusUrl` must be relative or loopback. This route may read
+`goal_channel_projection_v0` from a local `goal-harness serve-status` feed, but
+it is not a public link and must not be used as hosted showcase material.
+
+`/` is the operator home. It should answer the first-screen operational
+questions for the shared Goal Harness registry: current goal, concrete user
+gate, top user todo, top agent todo, quota or guard judgment, and recent
+evidence. `?view=ops` remains the detailed workbench for debugging status
+contracts, reward previews, and individual queue items.
+
+Compatibility aliases such as `view=share` may exist only as routing bridges.
+They do not define a third product surface.
+
+## Data Sources
+
+The public showcase surface may read:
+
+- `docs/showcases/showcase-catalog.json`;
+- public case pages under `docs/showcases/`;
+- public storyboards, animation prototypes, and generated static bundles;
+- public assets that reveal the product model or a sanitized case.
+
+The public showcase surface must not read:
+
+- `.codex/goals`, `.goal-harness`, or `registry.global.json`;
+- live `goal-harness status` exports;
+- loopback `serve-status` feeds;
+- raw run logs, transcripts, benchmark task text, trajectories, verifier tails,
+  credentials, internal links, local paths, or unpublished project evidence.
+
+The ops control-plane surface may read:
+
+- `goal-harness --format json status`;
+- `goal-harness serve-status --global-registry` or project-local
+  `serve-status`;
+- `goal_channel_projection_v0` and other versioned projections;
+- run-bound reward preview data when the local server explicitly exposes it.
+
+The ops surface should still default to read-only. Browser writes require a
+loopback capability flag, dry-run validation first, and a local CLI-equivalent
+contract. Public hosted bundles must not contain those capabilities.
+
+## Visual Freedom
+
+The public showcase surface can be expressive. It may use case-first
+composition, kinetic lanes, motion, public product imagery, generated bitmap
+assets, and strong narrative hierarchy. It should optimize for understanding:
+what Goal Harness is, why long-running agent work needs a control plane, and
+which public cases prove reusable behavior.
+
+The ops surface should be quieter and denser. It should optimize for scanning,
+comparison, repeated action, stale-daemon repair, and clear local boundaries.
+It can still be polished, but decorative motion must not hide gate, quota,
+todo, claim, or evidence state.
+
+Public visual experiments must not depend on live state. Ops widgets must not
+be promoted to public homepage content unless they have a sanitized fixture and
+a public/private boundary check.
+
+## Validation Boundaries
+
+Public showcase changes should validate:
+
+- catalog shape and case claims with `examples/showcase-catalog-smoke.py`;
+- static prototype or animation contracts when changed;
+- share/export privacy with `npm run smoke:frontstage-share-bundle`;
+- Pages workflow safety with `examples/frontstage-pages-workflow-smoke.py`;
+- public boundary scans with `goal-harness check` over changed docs/examples.
+
+Ops control-plane changes should validate:
+
+- status contract parsing and projection semantics;
+- route gating with `npm run smoke:frontstage-route`;
+- local server behavior when `serve-status` or reward preview APIs change;
+- loopback-only status source rules;
+- read-only defaults and explicit capability flags for any browser-triggered
+  dry-run or append path.
+
+Cross-surface changes must prove both sides when they touch shared code. The
+minimum check is that showcase mode ignores `statusUrl`, ops mode accepts only
+relative or loopback feeds, and exported public bundles do not carry live
+registry state.
+
+## Phased Roadmap
+
+Phase 0, current foundation: keep `/frontstage` defaulting to public showcase
+mode, keep ops mode explicit, and keep the operator home separate from hosted
+showcase links.
+
+Phase 1, public showcase polish: improve public case discovery, homepage
+entry, animation/storytelling, share bundles, and visual assets from
+`docs/showcases/showcase-catalog.json`. Do not add live status dependencies.
+
+Phase 2, local ops data layer: graduate ops views toward a TanStack Query layer
+over `serve-status`, with schema-version freshness checks, stale-daemon repair
+copy, local capability projection, and relative or loopback source rules.
+
+Phase 3, controlled local write affordances: add browser-assisted dry-run
+previews only after the local server advertises a capability. Writes stay
+loopback-only, preview-locked, CLI-equivalent, and opt-in.
+
+Phase 4, optional separation: split routing or packages only if shared code
+starts making ownership, bundle privacy, or validation boundaries harder to
+maintain. Until then, one dashboard app can host both surfaces if this contract
+stays enforced.
+
+## Non-Goals
+
+This strategy does not authorize a remote live status service, public ops-mode
+URLs, hidden session reads, browser write authority by default, or marketing
+claims without public evidence. It also does not change the Codex CLI/TUI loop
+priority: the TUI bootstrap and visible continuation rules remain their own
+product contract.

--- a/examples/frontstage-two-surface-strategy-smoke.py
+++ b/examples/frontstage-two-surface-strategy-smoke.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Smoke-test the frontstage public/ops surface strategy contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(path: str) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def compact(text: str) -> str:
+    return " ".join(text.split())
+
+
+def assert_contains(text: str, needle: str) -> None:
+    if needle not in text:
+        raise AssertionError(f"missing strategy contract: {needle}")
+
+
+def main() -> int:
+    strategy = read("docs/product/frontstage-two-surface-strategy.md")
+    product_index = read("docs/product/README.md")
+    dashboard_readme = read("apps/dashboard/README.md")
+    showcase_note = read("docs/showcases/frontend-surface.md")
+    compact_strategy = compact(strategy)
+    compact_dashboard_readme = compact(dashboard_readme)
+    compact_showcase_note = compact(showcase_note)
+
+    for needle in [
+        "Public showcase and homepage",
+        "Real ops control plane",
+        "`/frontstage` without `mode=ops` belongs to the public showcase surface",
+        "`/frontstage?mode=ops&statusUrl=...` belongs to local ops inspection",
+        "`docs/showcases/showcase-catalog.json`",
+        "`goal-harness serve-status --global-registry`",
+        "The public showcase surface must not read",
+        "The ops surface should still default to read-only",
+        "Public visual experiments must not depend on live state",
+        "showcase mode ignores `statusUrl`",
+        "Phase 1, public showcase polish",
+        "Phase 2, local ops data layer",
+        "Phase 3, controlled local write affordances",
+    ]:
+        assert_contains(strategy, needle)
+
+    for forbidden in [
+        "public ops-mode URLs",
+        "remote live status service",
+        "browser write authority by default",
+        "marketing claims without public evidence",
+    ]:
+        assert_contains(compact_strategy, forbidden)
+
+    assert_contains(product_index, "frontstage-two-surface-strategy.md")
+    assert_contains(product_index, "public showcase/homepage surface")
+    assert_contains(product_index, "real local ops control-plane")
+
+    for existing_contract in [
+        "The default frontstage route is public showcase mode",
+        "ignores `statusUrl`",
+        "relative or loopback URLs",
+        "Do not use ops-mode URLs as public links",
+        "Neither surface is browser write authority",
+    ]:
+        assert_contains(compact_dashboard_readme, existing_contract)
+
+    for public_source_contract in [
+        "The frontend should read `showcase-catalog.json`",
+        "Do not render raw run logs",
+        "It is a product explanation surface, not the local operator dashboard",
+    ]:
+        assert_contains(compact_showcase_note, public_source_contract)
+
+    route_row = "| Public showcase and homepage | Explain Goal Harness"
+    ops_row = "| Real ops control plane | Help the operator inspect"
+    assert_contains(compact_strategy, compact(route_row))
+    assert_contains(compact_strategy, compact(ops_row))
+    assert_contains(
+        compact_strategy,
+        "Ops widgets must not be promoted to public homepage content",
+    )
+    assert_contains(
+        compact_strategy,
+        "ops mode accepts only relative or loopback feeds",
+    )
+    assert_contains(
+        compact_strategy,
+        "does not change the Codex CLI/TUI loop priority",
+    )
+
+    print("frontstage-two-surface-strategy-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add a product strategy note that splits the frontstage family into public showcase/homepage and real local ops control-plane surfaces.
- Define route ownership, data sources, visual freedom, validation boundaries, and phased roadmap before further large UI changes.
- Link the note from the product index and add a focused smoke to keep the public/ops boundary explicit.

## Validation
- `python3 examples/frontstage-two-surface-strategy-smoke.py`
- `python3 examples/docs-governance-smoke.py`
- `python3 examples/showcase-catalog-smoke.py`
- `python3 examples/frontstage-pages-workflow-smoke.py`
- `npm --prefix apps/dashboard run smoke:frontstage-route`
- `npm --prefix apps/dashboard run smoke:frontstage-share-bundle`
- `goal-harness check --scan-path docs/product/frontstage-two-surface-strategy.md --scan-path docs/product/README.md --scan-path examples/frontstage-two-surface-strategy-smoke.py`
- `git diff --check origin/main...HEAD`

## Excluded
- No local Goal Harness state, raw run history, transcripts, credentials, private paths, generated dashboard bundles, or `node_modules` are included.

## Note
`goal-harness check` reports the existing duplicate-index warning for `goal-harness-meta`; the public boundary scan for the three changed files is clean.
