### PR TITLE
Add frontstage local status query layer

### DIFF
--- a/apps/dashboard/README.md
+++ b/apps/dashboard/README.md
@@ -81,7 +81,12 @@ then reads `attention_queue.items[].goal_channel_projection` and stays
 read-only; if the feed is missing or has no projection, the bundled demo
 fixture remains visible. Ops-mode status sources are limited to relative or
 loopback URLs so public frontstage links do not silently pull external/private
-feeds. Do not use ops-mode URLs as public links.
+feeds. The ops feed is loaded through a TanStack Query-backed local data layer
+with schema-version freshness checks, stale-daemon repair copy, and a
+`local_dashboard_api` capability projection. It remains read-only by default:
+reward or control-plane write affordances require explicit loopback opt-in,
+advertised capability URLs, and preview-locked local APIs. Do not use ops-mode
+URLs as public links.
 
 To create a public-safe static bundle for demos, Lark shares, or future GitHub
 Pages hosting, export the frontstage with the sanitized fixture:

--- a/apps/dashboard/package-lock.json
+++ b/apps/dashboard/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.0",
+        "@tanstack/react-query": "^5.101.0",
         "@tanstack/react-router": "^1.170.10",
         "@tanstack/react-table": "^8.21.3",
         "@vitejs/plugin-react": "^6.0.2",
@@ -696,6 +697,32 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.101.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.0.tgz",
+      "integrity": "sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.101.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.0.tgz",
+      "integrity": "sha512-rLlJXSpkqfizLWgkR5+eLeIk0MvTx/meEIR7LRjxic+qxiQP8zVjq7BqQkiCMNLQBlLfuOLqqr6KO5GtrDlmSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.101.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tanstack/react-router": {

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -21,9 +21,10 @@
     "smoke:usage-progress": "rm -rf /tmp/goal-harness-usage-progress-smoke && tsc --ignoreConfig --target ES2022 --module NodeNext --moduleResolution NodeNext --skipLibCheck --strict --outDir /tmp/goal-harness-usage-progress-smoke smoke/usage-progress-smoke.ts && node /tmp/goal-harness-usage-progress-smoke/usage-progress-smoke.js"
   },
   "dependencies": {
+    "@tailwindcss/vite": "^4.3.0",
+    "@tanstack/react-query": "^5.101.0",
     "@tanstack/react-router": "^1.170.10",
     "@tanstack/react-table": "^8.21.3",
-    "@tailwindcss/vite": "^4.3.0",
     "@vitejs/plugin-react": "^6.0.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/apps/dashboard/smoke/frontstage-route-smoke.ts
+++ b/apps/dashboard/smoke/frontstage-route-smoke.ts
@@ -23,9 +23,11 @@ function sourceBetween(source: string, start: string, end: string, label: string
 }
 
 const routerSource = readFileSync("src/router.tsx", "utf8");
+const mainSource = readFileSync("src/main.tsx", "utf8");
 const frontstageSource = readFileSync("src/views/frontstage-page.tsx", "utf8");
 const stylesSource = readFileSync("src/styles.css", "utf8");
 const dataSource = readFileSync("src/data/goal-channel-frontstage.ts", "utf8");
+const localStatusQuerySource = readFileSync("src/data/local-status-query.ts", "utf8");
 const statusSource = readFileSync("src/data/status.ts", "utf8");
 const catalogSource = readFileSync("../../docs/showcases/showcase-catalog.json", "utf8");
 const privateTrapFixtureSource = readFileSync("../../examples/fixtures/frontstage-private-status-trap.public.json", "utf8");
@@ -46,6 +48,12 @@ includes(packageSource, '"smoke:frontstage-route"', "frontstage smoke script");
 includes(privateTrapFixtureSource, "GH_FAKE_PRIVATE_PLAN_SUMMARY_ALPHA", "fake-private status trap plan marker");
 includes(privateTrapFixtureSource, "GH_FAKE_LIVE_STATUS_FEED_BETA", "fake-private live status trap marker");
 includes(privateTrapFixtureSource, "GH_FAKE_PRIVATE_TODO_GAMMA", "fake-private todo trap marker");
+includes(packageSource, '"@tanstack/react-query"', "TanStack Query dependency");
+
+includes(mainSource, "QueryClientProvider", "TanStack Query provider");
+includes(mainSource, "new QueryClient", "query client construction");
+includes(mainSource, "refetchOnWindowFocus: false", "query focus refetch policy");
+includes(mainSource, "staleTime: 15_000", "query freshness window");
 
 includes(dataSource, 'schema_version: "goal_channel_projection_v0"', "goal channel schema");
 includes(dataSource, "goalChannelProjectionSchema", "goal channel zod schema");
@@ -53,6 +61,17 @@ includes(dataSource, 'mode: "read_only"', "read-only mode");
 includes(dataSource, 'claimed_by: "codex-side-bypass"', "side-agent claim fixture");
 includes(dataSource, "raw_or_private_material_omitted", "source warning fixture");
 includes(statusSource, "goal_channel_projection: goalChannelProjectionSchema", "status projection parser");
+includes(statusSource, "local_dashboard_api", "local dashboard API status parser");
+
+includes(localStatusQuerySource, "resolveFrontstageOpsStatusUrl", "frontstage status URL resolver");
+includes(localStatusQuerySource, "fetchFrontstageStatusPayload", "frontstage status query fetcher");
+includes(localStatusQuerySource, "parseStatusPayload", "status payload parser in query helper");
+includes(localStatusQuerySource, "statusContractFreshnessIssue", "status contract freshness helper");
+includes(localStatusQuerySource, "localDashboardApiCapabilities", "local dashboard API capability helper");
+includes(localStatusQuerySource, "expectedStatusContractSchemaVersion", "schema freshness gate");
+includes(localStatusQuerySource, "fallbackStatusContractReloadHint", "stale daemon repair hint");
+includes(localStatusQuerySource, "isLoopbackHostname", "loopback source guard");
+includes(localStatusQuerySource, "Ops statusUrl must be relative or loopback", "ops status URL guard copy");
 
 includes(frontstageSource, 'data-testid="goal-channel-frontstage-route"', "route test id");
 includes(frontstageSource, 'data-frontstage-surface={isOpsMode ? "ops-control-plane" : "showcase-homepage"}', "frontstage surface split marker");
@@ -61,12 +80,20 @@ includes(frontstageSource, 'data-testid="frontstage-live-source-panel"', "live s
 includes(frontstageSource, 'data-testid="frontstage-public-boundary-note"', "public boundary note");
 includes(frontstageSource, "Showcase mode ignores statusUrl", "public mode statusUrl guard copy");
 includes(frontstageSource, 'if (!liveMode)', "live status feed requires ops mode");
+includes(frontstageSource, "useQuery", "frontstage uses TanStack Query");
+includes(frontstageSource, 'queryKey: ["frontstage-ops-status"', "frontstage query key");
+includes(frontstageSource, "fetchFrontstageStatusPayload", "frontstage status query function");
+includes(frontstageSource, 'data-testid="frontstage-stale-daemon-repair"', "frontstage stale daemon repair panel");
+includes(frontstageSource, 'data-testid="frontstage-local-api-capabilities"', "frontstage local API capability panel");
+includes(frontstageSource, "local_dashboard_api:", "local dashboard API copy");
+includes(frontstageSource, "read-only default", "read-only default copy");
+includes(frontstageSource, "Write affordances require explicit loopback opt-in", "loopback opt-in copy");
+includes(frontstageSource, "TanStack Query", "TanStack Query copy");
 includes(frontstageSource, 'data-testid="frontstage-operations-strip"', "operations signal strip");
 includes(frontstageSource, 'data-testid="frontstage-goal-select"', "goal selector");
-includes(frontstageSource, "parseStatusPayload", "status payload parser");
-includes(frontstageSource, "resolveOpsStatusUrl", "ops status URL resolver");
-includes(frontstageSource, "isLoopbackHostname", "ops loopback source guard");
-includes(frontstageSource, "Ops statusUrl must be relative or loopback", "ops status URL guard copy");
+includes(frontstageSource, "resolveFrontstageOpsStatusUrl", "ops status URL resolver");
+includes(frontstageSource, "statusContractFreshnessIssue", "schema freshness gate");
+includes(frontstageSource, "localDashboardApiCapabilities", "local capability projection");
 includes(frontstageSource, "Ops statusUrl accepts only relative or loopback sources.", "ops source guard helper copy");
 includes(frontstageSource, 'data-testid="frontstage-user-todos"', "user todo lane");
 includes(frontstageSource, 'data-testid="frontstage-agent-todos"', "agent todo lane");

--- a/apps/dashboard/src/data/local-status-query.ts
+++ b/apps/dashboard/src/data/local-status-query.ts
@@ -1,0 +1,128 @@
+import { StatusPayload, parseStatusPayload } from "./status";
+
+export const expectedStatusContractSchemaVersion = 2;
+export const fallbackStatusContractReloadHint = "scripts/macos-dashboard-launchagent.sh restart";
+
+export type ResolvedFrontstageStatusUrl = {
+  isLoopback: boolean;
+  isRelative: boolean;
+  url: string;
+};
+
+export type StatusContractFreshnessIssue = {
+  reloadHint: string;
+  schemaVersion: number;
+};
+
+export type LocalDashboardApiCapabilities = {
+  controlPlaneApplyUrl: string | null;
+  controlPlaneDryRunUrl: string | null;
+  controlPlaneWriteEnabled: boolean;
+  loopbackOnly: boolean;
+  readOnlyDefault: boolean;
+  rewardAppendUrl: string | null;
+  rewardDryRunUrl: string | null;
+  rewardWriteEnabled: boolean;
+  source: string;
+};
+
+function isExplicitUrl(value: string) {
+  return /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(value) || value.startsWith("//");
+}
+
+export function isLoopbackHostname(hostname: string) {
+  return ["localhost", "127.0.0.1", "::1", "[::1]"].includes(hostname);
+}
+
+export function resolveFrontstageOpsStatusUrl(value: string, baseHref: string) {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return { error: "status URL is empty" };
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed, baseHref);
+  } catch {
+    return { error: "status URL is invalid" };
+  }
+
+  const isRelative = !isExplicitUrl(trimmed);
+  const isLoopback = isLoopbackHostname(parsed.hostname);
+  if (!isRelative && !isLoopback) {
+    return {
+      error: "Ops statusUrl must be relative or loopback; use showcase mode for public links.",
+    };
+  }
+
+  return {
+    source: {
+      isLoopback,
+      isRelative,
+      url: trimmed,
+    } satisfies ResolvedFrontstageStatusUrl,
+  };
+}
+
+export async function fetchFrontstageStatusPayload(statusUrl: string) {
+  const response = await fetch(statusUrl, { cache: "no-store" });
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} while loading ${statusUrl}`);
+  }
+  return parseStatusPayload(await response.json());
+}
+
+export function statusContractFreshnessIssue(
+  payload: StatusPayload,
+  source: ResolvedFrontstageStatusUrl,
+): StatusContractFreshnessIssue | null {
+  if (!source.isLoopback) {
+    return null;
+  }
+  const schemaVersion = payload.status_contract.schema_version ?? 0;
+  if (schemaVersion >= expectedStatusContractSchemaVersion) {
+    return null;
+  }
+  return {
+    reloadHint: payload.status_contract.reload_hint || fallbackStatusContractReloadHint,
+    schemaVersion,
+  };
+}
+
+function localApiUrl(source: ResolvedFrontstageStatusUrl, path: string | null | undefined) {
+  if (!path || !source.isLoopback) {
+    return null;
+  }
+  try {
+    const sourceUrl = new URL(source.url, window.location.href);
+    const targetUrl = new URL(path, sourceUrl.origin);
+    return isLoopbackHostname(targetUrl.hostname) ? targetUrl.toString() : null;
+  } catch {
+    return null;
+  }
+}
+
+export function localDashboardApiCapabilities(
+  payload: StatusPayload,
+  source: ResolvedFrontstageStatusUrl,
+): LocalDashboardApiCapabilities {
+  const localApi = payload.local_dashboard_api;
+  const rewardDryRunUrl = localApiUrl(source, localApi?.reward_dry_run_url);
+  const rewardAppendUrl = localApiUrl(source, localApi?.reward_append_url);
+  const controlPlaneDryRunUrl = localApiUrl(source, localApi?.configure_goal_dry_run_url);
+  const controlPlaneApplyUrl = localApiUrl(source, localApi?.configure_goal_apply_url);
+  const rewardWriteEnabled = Boolean(localApi?.reward_write_enabled && rewardAppendUrl);
+  const controlPlaneWriteEnabled = Boolean(localApi?.control_plane_write_enabled && controlPlaneApplyUrl);
+
+  return {
+    controlPlaneApplyUrl,
+    controlPlaneDryRunUrl,
+    controlPlaneWriteEnabled,
+    loopbackOnly: source.isLoopback,
+    readOnlyDefault: !rewardWriteEnabled && !controlPlaneWriteEnabled,
+    rewardAppendUrl,
+    rewardDryRunUrl,
+    rewardWriteEnabled,
+    source: localApi?.source ?? "not advertised",
+  };
+}

--- a/apps/dashboard/src/main.tsx
+++ b/apps/dashboard/src/main.tsx
@@ -1,4 +1,5 @@
 import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { RouterProvider } from "@tanstack/react-router";
 
 import { router } from "./router";
@@ -10,4 +11,18 @@ if (!root) {
   throw new Error("Root element not found");
 }
 
-createRoot(root).render(<RouterProvider router={router} />);
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      retry: 1,
+      staleTime: 15_000,
+    },
+  },
+});
+
+createRoot(root).render(
+  <QueryClientProvider client={queryClient}>
+    <RouterProvider router={router} />
+  </QueryClientProvider>,
+);

--- a/apps/dashboard/src/views/frontstage-page.tsx
+++ b/apps/dashboard/src/views/frontstage-page.tsx
@@ -13,6 +13,7 @@ import {
   ShieldCheck,
   Users,
 } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
 
 import showcaseCatalog from "../../../../docs/showcases/showcase-catalog.json";
@@ -22,7 +23,15 @@ import {
   GoalChannelTodo,
   sampleGoalChannelProjection,
 } from "../data/goal-channel-frontstage";
-import { QueueItem, StatusPayload, formatStatusError, parseStatusPayload } from "../data/status";
+import { QueueItem, StatusPayload, formatStatusError } from "../data/status";
+import {
+  LocalDashboardApiCapabilities,
+  StatusContractFreshnessIssue,
+  fetchFrontstageStatusPayload,
+  localDashboardApiCapabilities,
+  resolveFrontstageOpsStatusUrl,
+  statusContractFreshnessIssue,
+} from "../data/local-status-query";
 import { Badge } from "../components/ui/badge";
 import { Button } from "../components/ui/button";
 import { Select } from "../components/ui/select";
@@ -129,37 +138,6 @@ function warningMessage(value: string | string[] | undefined) {
     return value.join(", ");
   }
   return value ?? "compact source warning";
-}
-
-function isExplicitUrl(value: string) {
-  return /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(value) || value.startsWith("//");
-}
-
-function isLoopbackHostname(hostname: string) {
-  return ["localhost", "127.0.0.1", "::1", "[::1]"].includes(hostname);
-}
-
-function resolveOpsStatusUrl(value: string) {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return { error: "status URL is empty" };
-  }
-
-  let parsed: URL;
-  try {
-    parsed = new URL(trimmed, window.location.href);
-  } catch {
-    return { error: "status URL is invalid" };
-  }
-
-  const isRelative = !isExplicitUrl(trimmed);
-  if (!isRelative && !isLoopbackHostname(parsed.hostname)) {
-    return {
-      error: "Ops statusUrl must be relative or loopback; use showcase mode for public links.",
-    };
-  }
-
-  return { url: trimmed };
 }
 
 function artifactDisplayValue(value: string | number | boolean | null | undefined) {
@@ -992,6 +970,9 @@ function FrontstageRoute({
   onTodoLaneChange,
   onTodoQueryChange,
   projection,
+  freshnessIssue,
+  localApiCapabilities,
+  queryStateLabel,
   selectedGoalId,
   source,
   statusUrl,
@@ -1010,6 +991,9 @@ function FrontstageRoute({
   onTodoLaneChange: (value: TodoLaneFilter) => void;
   onTodoQueryChange: (value: string) => void;
   projection: GoalChannelProjection;
+  freshnessIssue: StatusContractFreshnessIssue | null;
+  localApiCapabilities: LocalDashboardApiCapabilities | null;
+  queryStateLabel: string;
   selectedGoalId: string;
   source: FrontstageSource;
   statusUrl: string;
@@ -1175,6 +1159,9 @@ function FrontstageRoute({
               <Badge variant={isOpsMode && source.kind === "url" ? "info" : "neutral"}>
                 {isOpsMode && source.kind === "url" ? "live status feed" : "bundled fixture"}
               </Badge>
+              <Badge variant={isOpsMode && source.kind === "url" ? "success" : "neutral"}>
+                {isOpsMode ? queryStateLabel : "static"}
+              </Badge>
               <span className="break-words text-xs font-medium text-slate-500">
                 {isOpsMode ? source.label : publicSourceLabel}
               </span>
@@ -1244,6 +1231,52 @@ function FrontstageRoute({
               <div className="flex gap-2 rounded-md border border-amber-200 bg-amber-50 px-2 py-2 text-xs leading-5 text-amber-950" data-testid="frontstage-load-error">
                 <CircleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0" />
                 <span>{loadError}</span>
+              </div>
+            ) : null}
+            {freshnessIssue ? (
+              <div
+                className="rounded-md border border-amber-200 bg-amber-50 px-2 py-2 text-xs leading-5 text-amber-950"
+                data-testid="frontstage-stale-daemon-repair"
+              >
+                <div className="flex flex-wrap items-center gap-2 font-semibold">
+                  <CircleAlert className="h-3.5 w-3.5" />
+                  status service contract stale
+                  <Badge variant="warning">schema v{freshnessIssue.schemaVersion}</Badge>
+                </div>
+                <p className="mt-1">
+                  Restart the local status daemon with <span className="font-mono">{freshnessIssue.reloadHint}</span>, then reload this ops feed.
+                </p>
+              </div>
+            ) : null}
+            {isOpsMode && localApiCapabilities ? (
+              <div
+                className="grid gap-2 rounded-md border border-slate-200 bg-white px-2 py-2 text-xs leading-5 text-slate-600"
+                data-testid="frontstage-local-api-capabilities"
+              >
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge variant="info">TanStack Query</Badge>
+                  <Badge variant={localApiCapabilities.readOnlyDefault ? "success" : "warning"}>
+                    {localApiCapabilities.readOnlyDefault ? "read-only default" : "write opt-in active"}
+                  </Badge>
+                  <Badge variant={localApiCapabilities.loopbackOnly ? "success" : "neutral"}>
+                    {localApiCapabilities.loopbackOnly ? "loopback source" : "relative source"}
+                  </Badge>
+                </div>
+                <div className="break-words">
+                  <span className="font-semibold text-slate-950">local_dashboard_api:</span>{" "}
+                  {localApiCapabilities.source}
+                </div>
+                <div className="grid gap-1">
+                  <span>
+                    reward dry-run {localApiCapabilities.rewardDryRunUrl ? "advertised" : "not advertised"};
+                    append {localApiCapabilities.rewardWriteEnabled ? "enabled by loopback opt-in" : "disabled"}
+                  </span>
+                  <span>
+                    control-plane dry-run {localApiCapabilities.controlPlaneDryRunUrl ? "advertised" : "not advertised"};
+                    apply {localApiCapabilities.controlPlaneWriteEnabled ? "enabled by loopback opt-in" : "disabled"}
+                  </span>
+                  <span>Write affordances require explicit loopback opt-in and preview-locked APIs.</span>
+                </div>
               </div>
             ) : null}
           </div>
@@ -1538,11 +1571,8 @@ function FrontstageRoute({
 export function FrontstagePage() {
   const search = frontstageRoute.useSearch();
   const navigate = frontstageRoute.useNavigate();
-  const [payload, setPayload] = useState<StatusPayload | null>(null);
-  const [source, setSource] = useState<FrontstageSource>({ kind: "demo", label: "bundled fixture" });
   const [statusUrl, setStatusUrl] = useState(search.statusUrl);
-  const [loadError, setLoadError] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
+  const [manualLoadError, setManualLoadError] = useState<string | null>(null);
   const mode: FrontstageMode = search.mode === "ops"
     ? "ops"
     : search.mode === "developer"
@@ -1554,6 +1584,21 @@ export function FrontstagePage() {
   const todoQuery = search.todoQuery ?? "";
   const liveMode = mode === "ops";
   const hasIgnoredStatusUrl = !liveMode && Boolean(search.statusUrl);
+  const resolvedSearchStatusUrl = useMemo(
+    () => (liveMode && search.statusUrl
+      ? resolveFrontstageOpsStatusUrl(search.statusUrl, window.location.href)
+      : null),
+    [liveMode, search.statusUrl],
+  );
+  const statusQuery = useQuery({
+    enabled: Boolean(liveMode && resolvedSearchStatusUrl?.source),
+    queryFn: () => fetchFrontstageStatusPayload(resolvedSearchStatusUrl?.source?.url ?? ""),
+    queryKey: ["frontstage-ops-status", resolvedSearchStatusUrl?.source?.url ?? ""],
+  });
+  const payload: StatusPayload | null = liveMode ? statusQuery.data ?? null : null;
+  const source: FrontstageSource = liveMode && payload && resolvedSearchStatusUrl?.source
+    ? { kind: "url", label: resolvedSearchStatusUrl.source.url }
+    : { kind: "demo", label: "bundled fixture" };
 
   const rawGoalOptions = useMemo(
     () => (payload ? projectionOptionsFromPayload(payload) : []),
@@ -1565,6 +1610,29 @@ export function FrontstagePage() {
     : goalOptions[0]?.goalId ?? sampleGoalChannelProjection.goal_id;
   const selectedProjection = goalOptions.find((option) => option.goalId === selectedGoalId)?.projection
     ?? sampleGoalChannelProjection;
+  const freshnessIssue = payload && resolvedSearchStatusUrl?.source
+    ? statusContractFreshnessIssue(payload, resolvedSearchStatusUrl.source)
+    : null;
+  const localApiCapabilities = payload && resolvedSearchStatusUrl?.source
+    ? localDashboardApiCapabilities(payload, resolvedSearchStatusUrl.source)
+    : null;
+  const queryError = statusQuery.error ? formatStatusError(statusQuery.error) : null;
+  const projectionError = liveMode && statusQuery.isSuccess && rawGoalOptions.length === 0
+    ? "status feed has no goal_channel_projection items; showing demo fixture"
+    : null;
+  const loadError = manualLoadError
+    ?? resolvedSearchStatusUrl?.error
+    ?? queryError
+    ?? projectionError;
+  const queryStateLabel = !liveMode
+    ? "static"
+    : !resolvedSearchStatusUrl?.source
+      ? "query idle"
+    : statusQuery.isFetching
+      ? "query fetching"
+      : statusQuery.isStale
+        ? "query stale"
+        : "query fresh";
 
   async function updateSearch(next: {
     goalId?: string;
@@ -1581,52 +1649,32 @@ export function FrontstagePage() {
     });
   }
 
-  async function loadFromUrl(url: string, updateUrl = true) {
+  async function loadSelectedStatusUrl() {
     if (!liveMode) {
-      setLoadError("statusUrl is ignored in showcase mode; switch to Ops live for local status feeds");
+      setManualLoadError("statusUrl is ignored in showcase mode; switch to Ops live for local status feeds");
       return;
     }
-    const trimmed = url.trim();
-    const resolvedStatusUrl = resolveOpsStatusUrl(trimmed);
-    if (resolvedStatusUrl.error || !resolvedStatusUrl.url) {
-      setLoadError(resolvedStatusUrl.error ?? "status URL is invalid");
+    const resolvedStatusUrl = resolveFrontstageOpsStatusUrl(statusUrl, window.location.href);
+    if (resolvedStatusUrl.error || !resolvedStatusUrl.source) {
+      setManualLoadError(resolvedStatusUrl.error ?? "status URL is invalid");
       return;
     }
-    const loadUrl = resolvedStatusUrl.url;
-    setIsLoading(true);
-    setLoadError(null);
-    try {
-      const response = await fetch(loadUrl, { cache: "no-store" });
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status} while loading ${loadUrl}`);
-      }
-      const nextPayload = parseStatusPayload(await response.json());
-      const nextOptions = projectionOptionsFromPayload(nextPayload);
-      setPayload(nextPayload);
-      setSource({ kind: "url", label: loadUrl });
-      setStatusUrl(loadUrl);
-      if (nextOptions.length === 0) {
-        setLoadError("status feed has no goal_channel_projection items; showing demo fixture");
-      }
-      if (updateUrl) {
-        await updateSearch({
-          goalId: nextOptions[0]?.goalId ?? "",
-          mode: "ops",
-          statusUrl: loadUrl,
-        });
-      }
-    } catch (error) {
-      setLoadError(formatStatusError(error));
-    } finally {
-      setIsLoading(false);
+    setManualLoadError(null);
+    setStatusUrl(resolvedStatusUrl.source.url);
+    if (search.statusUrl === resolvedStatusUrl.source.url) {
+      await statusQuery.refetch();
+      return;
     }
+    await updateSearch({
+      goalId: "",
+      mode: "ops",
+      statusUrl: resolvedStatusUrl.source.url,
+    });
   }
 
   function resetToDemo() {
-    setPayload(null);
-    setSource({ kind: "demo", label: "bundled fixture" });
     setStatusUrl("");
-    setLoadError(null);
+    setManualLoadError(null);
     void updateSearch({ goalId: "", mode: "showcase", statusUrl: "", todoLane: "all", todoQuery: "" });
   }
 
@@ -1643,10 +1691,8 @@ export function FrontstagePage() {
   }
 
   useEffect(() => {
-    if (liveMode && search.statusUrl) {
-      void loadFromUrl(search.statusUrl, false);
-    }
-  }, [liveMode, search.statusUrl]);
+    setStatusUrl(search.statusUrl);
+  }, [search.statusUrl]);
 
   useEffect(() => {
     if (!goalOptions.length || search.goalId === selectedGoalId) {
@@ -1659,15 +1705,18 @@ export function FrontstagePage() {
     <FrontstageRoute
       goalOptions={goalOptions}
       hasIgnoredStatusUrl={hasIgnoredStatusUrl}
-      isLoading={isLoading}
+      isLoading={statusQuery.isFetching}
       loadError={loadError}
       mode={mode}
       onGoalChange={changeGoal}
-      onLoadStatusUrl={() => void loadFromUrl(statusUrl)}
+      onLoadStatusUrl={() => void loadSelectedStatusUrl()}
       onResetDemo={resetToDemo}
       onTodoLaneChange={changeTodoLane}
       onTodoQueryChange={changeTodoQuery}
       projection={selectedProjection}
+      freshnessIssue={freshnessIssue}
+      localApiCapabilities={localApiCapabilities}
+      queryStateLabel={queryStateLabel}
       selectedGoalId={selectedGoalId}
       setStatusUrl={setStatusUrl}
       source={source}

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -81,6 +81,22 @@ contract for local write affordances:
 }
 ```
 
+The dashboard frontstage ops route uses a TanStack Query-backed local status
+reader for `/frontstage?mode=ops&statusUrl=<relative-or-loopback>`. Showcase
+mode still ignores `statusUrl`; only explicit ops mode may fetch a status feed.
+The query layer validates `status_contract.schema_version` before trusting a
+loopback feed. If the feed is below the dashboard's expected schema version,
+the route shows stale-daemon repair copy using `status_contract.reload_hint`
+instead of silently rendering an old protocol.
+
+The same frontstage query layer projects `local_dashboard_api` as capabilities,
+not browser authority. It may show that reward dry-run or control-plane dry-run
+URLs are advertised, but write affordances stay disabled unless the feed is
+relative or loopback, the matching URL is present, and the corresponding
+`*_write_enabled` flag is true. The frontstage must remain read-only by default;
+any future write UI must still use preview-locked local APIs and keep CLI/event
+ledger state as the source of truth.
+
 The control-plane settings write path follows the same opt-in rule as reward
 append. By default `serve-status` validates dashboard setting drafts through
 `POST /control-plane/configure-goal/dry-run` but does not expose an apply

--- a/examples/dashboard-frontstage-browser-smoke.mjs
+++ b/examples/dashboard-frontstage-browser-smoke.mjs
@@ -151,6 +151,15 @@ const statusFixture = {
     producer: "goal-harness status",
     reload_hint: "scripts/macos-dashboard-launchagent.sh restart",
   },
+  local_dashboard_api: {
+    source: "serve-status",
+    reward_dry_run_url: "/reward/dry-run",
+    reward_append_url: null,
+    reward_write_enabled: false,
+    configure_goal_dry_run_url: "/control-plane/configure-goal/dry-run",
+    configure_goal_apply_url: null,
+    control_plane_write_enabled: false,
+  },
   contract: {
     ok: true,
     summary: { errors: 0, warnings: 0, checks: 1 },
@@ -592,6 +601,12 @@ async function main() {
         [
           "ops live",
           "live status feed",
+          "TanStack Query",
+          "read-only default",
+          "local_dashboard_api: serve-status",
+          "reward dry-run advertised; append disabled",
+          "control-plane dry-run advertised; apply disabled",
+          "Write affordances require explicit loopback opt-in",
           "Ops statusUrl accepts only relative or loopback sources.",
           "Live Goal Channel",
           "goal_channel_projection_v0",


### PR DESCRIPTION
## Summary
- Add `@tanstack/react-query` and wrap the dashboard with a shared `QueryClientProvider`.
- Move `/frontstage?mode=ops&statusUrl=...` live status loading into a frontstage local status query helper with relative/loopback URL guards, schema-version freshness checks, stale-daemon repair copy, and `local_dashboard_api` capability projection.
- Keep frontstage read-only by default: write affordances are only displayed as disabled/enabled capability state and require explicit loopback opt-in plus preview-locked local APIs.
- Update dashboard/status-contract docs and strengthen route/browser smokes for the TanStack Query path and local capability panel.

## Validation
- `npm --prefix apps/dashboard run smoke:frontstage-route`
- `npm --prefix apps/dashboard run smoke:frontstage-browser`
- `npm --prefix apps/dashboard run smoke:frontstage-share-bundle`
- `npm --prefix apps/dashboard run build`
- `python3 examples/docs-governance-smoke.py`
- `python3 examples/frontstage-two-surface-strategy-smoke.py`
- `goal-harness check --scan-path apps/dashboard/README.md --scan-path apps/dashboard/package.json --scan-path apps/dashboard/package-lock.json --scan-path apps/dashboard/smoke/frontstage-route-smoke.ts --scan-path apps/dashboard/src/main.tsx --scan-path apps/dashboard/src/views/frontstage-page.tsx --scan-path apps/dashboard/src/data/local-status-query.ts --scan-path examples/dashboard-frontstage-browser-smoke.mjs --scan-path docs/status-data-contract.md`
- `git diff --check origin/main...HEAD`

## Boundary
- This changes dashboard runtime behavior and adds a frontend dependency, so this PR is left for `codex-main-control` review instead of side-agent self-merge.
- No local Goal Harness state, raw run history, transcripts, credentials, generated dashboard bundles, or `node_modules` are included.
- `goal-harness check` reports the existing duplicate-index warning for `goal-harness-meta`; the public boundary scan for the changed files is clean.
