### PR TITLE
Add frontstage developer cockpit

### DIFF
--- a/apps/dashboard/README.md
+++ b/apps/dashboard/README.md
@@ -75,6 +75,13 @@ and writeback boundary without loading live registry data. It is meant to help
 new developers understand how to enter Goal Harness from Codex CLI or another
 agent TUI before they open the denser ops board.
 
+The developer extension cockpit lives at `/frontstage/developer`. It is a
+read-only contributor workbench for status-contract exploration, projection
+diffing, fixture generation rules, smoke-run checklists, and component examples
+so new projection work does not require reverse-engineering the large
+dashboard page. It uses static public contracts and fixtures only; live status
+feeds, registry files, and browser write APIs stay out of this route.
+
 For live local control-plane inspection, explicitly enter ops mode:
 `/frontstage?mode=ops&statusUrl=http://127.0.0.1:8766/status.json`. The route
 then reads `attention_queue.items[].goal_channel_projection` and stays

--- a/apps/dashboard/smoke/frontstage-route-smoke.ts
+++ b/apps/dashboard/smoke/frontstage-route-smoke.ts
@@ -24,6 +24,7 @@ function sourceBetween(source: string, start: string, end: string, label: string
 
 const routerSource = readFileSync("src/router.tsx", "utf8");
 const mainSource = readFileSync("src/main.tsx", "utf8");
+const frontstageDeveloperSource = readFileSync("src/views/frontstage-developer-page.tsx", "utf8");
 const frontstageSource = readFileSync("src/views/frontstage-page.tsx", "utf8");
 const stylesSource = readFileSync("src/styles.css", "utf8");
 const dataSource = readFileSync("src/data/goal-channel-frontstage.ts", "utf8");
@@ -37,6 +38,9 @@ const packageSource = readFileSync("package.json", "utf8");
 
 includes(routerSource, 'path: "/frontstage"', "frontstage route path");
 includes(routerSource, "component: FrontstagePage", "frontstage route component");
+includes(routerSource, 'path: "/frontstage/developer"', "frontstage developer route path");
+includes(routerSource, "component: FrontstageDeveloperPage", "frontstage developer route component");
+includes(routerSource, "frontstageDeveloperRoute", "frontstage developer route export");
 includes(routerSource, "frontstageSearchSchema", "frontstage search schema");
 includes(routerSource, 'mode: z.enum(["showcase", "developer", "ops"]).optional().default("showcase")', "frontstage mode gate");
 includes(routerSource, 'todoLane: z.enum(["all", "user", "agent"]).optional().default("all")', "frontstage todo lane filter search param");
@@ -112,6 +116,7 @@ includes(frontstageSource, 'data-testid="frontstage-artifacts"', "artifacts lane
 includes(frontstageSource, 'data-testid="frontstage-timeline"', "timeline lane");
 includes(frontstageSource, "Frontstage channel", "frontstage channel copy");
 includes(frontstageSource, "Channel board", "channel board nav");
+includes(frontstageSource, "Developer cockpit", "developer cockpit nav");
 includes(frontstageSource, "Always-on agent operations", "always-on operations copy");
 includes(frontstageSource, "Goal Harness Showcase Frontstage", "showcase-first hero title");
 includes(frontstageSource, "Async agent teams, governed by human judgment", "showcase-first hero copy");
@@ -243,5 +248,28 @@ includes(readmeSource, "read-only projection", "README read-only projection boun
 includes(readmeSource, "write authority", "README write authority boundary");
 includes(selectionSource, "Multica", "Multica benchmark note");
 includes(selectionSource, "agent board", "agent board benchmark note");
+
+includes(frontstageDeveloperSource, 'data-testid="frontstage-developer-cockpit"', "developer cockpit route test id");
+includes(frontstageDeveloperSource, "Goal Harness Projection Developer Cockpit", "developer cockpit title");
+includes(frontstageDeveloperSource, "Status Contract Explorer", "status contract explorer panel");
+includes(frontstageDeveloperSource, 'data-testid="developer-contract-explorer"', "developer contract explorer test id");
+includes(frontstageDeveloperSource, "Projection Diffing", "projection diffing panel");
+includes(frontstageDeveloperSource, 'data-testid="developer-projection-diffing"', "projection diffing test id");
+includes(frontstageDeveloperSource, "Fixture Generation", "fixture generation panel");
+includes(frontstageDeveloperSource, 'data-testid="developer-fixture-generation"', "fixture generation test id");
+includes(frontstageDeveloperSource, "Smoke Checklist", "smoke checklist panel");
+includes(frontstageDeveloperSource, 'data-testid="developer-smoke-checklist"', "smoke checklist test id");
+includes(frontstageDeveloperSource, "Component Examples", "component examples panel");
+includes(frontstageDeveloperSource, 'data-testid="developer-component-examples"', "component examples test id");
+includes(frontstageDeveloperSource, "Extension Boundary", "extension boundary panel");
+includes(frontstageDeveloperSource, 'data-testid="developer-extension-boundary"', "extension boundary test id");
+includes(frontstageDeveloperSource, "apps/dashboard/src/data/status.ts", "status parser source pointer");
+includes(frontstageDeveloperSource, "apps/dashboard/src/data/goal-channel-frontstage.ts", "projection source pointer");
+includes(frontstageDeveloperSource, "examples/status.example.json", "fixture source pointer");
+includes(frontstageDeveloperSource, "goal-harness check --scan-path apps/dashboard", "boundary check command");
+includes(frontstageDeveloperSource, "reverse-engineering the large operator page", "developer cockpit purpose");
+includes(frontstageDeveloperSource, "live status feeds, registry files, and browser write APIs stay outside", "developer cockpit boundary");
+excludes(frontstageDeveloperSource, "<form", "developer cockpit write form");
+excludes(frontstageDeveloperSource, "method=", "developer cockpit form method");
 
 console.log("frontstage-route smoke ok");

--- a/apps/dashboard/src/router.tsx
+++ b/apps/dashboard/src/router.tsx
@@ -7,6 +7,7 @@ import {
 import { z } from "zod";
 
 import { DashboardPage } from "./views/dashboard-page";
+import { FrontstageDeveloperPage } from "./views/frontstage-developer-page";
 import { FrontstagePage } from "./views/frontstage-page";
 
 const searchSchema = z.object({
@@ -44,7 +45,13 @@ export const frontstageRoute = createRoute({
   component: FrontstagePage,
 });
 
-const routeTree = rootRoute.addChildren([dashboardRoute, frontstageRoute]);
+export const frontstageDeveloperRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/frontstage/developer",
+  component: FrontstageDeveloperPage,
+});
+
+const routeTree = rootRoute.addChildren([dashboardRoute, frontstageRoute, frontstageDeveloperRoute]);
 
 function routerBasepathFromViteBase(baseUrl: string) {
   if (!baseUrl || baseUrl === "/" || baseUrl === "./") {

--- a/apps/dashboard/src/views/frontstage-developer-page.tsx
+++ b/apps/dashboard/src/views/frontstage-developer-page.tsx
@@ -1,0 +1,326 @@
+import {
+  BadgeCheck,
+  Braces,
+  ClipboardCheck,
+  Code2,
+  ExternalLink,
+  FileJson,
+  GitCompareArrows,
+  LayoutDashboard,
+  ListChecks,
+  ShieldCheck,
+  TestTube2,
+} from "lucide-react";
+
+import { Badge } from "../components/ui/badge";
+
+type CockpitPanelProps = {
+  children: React.ReactNode;
+  icon: React.ComponentType<{ className?: string }>;
+  title: string;
+};
+
+const contractFields = [
+  {
+    label: "status payload",
+    source: "apps/dashboard/src/data/status.ts",
+    detail: "status_contract, attention_queue, local_dashboard_api, run_history",
+  },
+  {
+    label: "channel projection",
+    source: "apps/dashboard/src/data/goal-channel-frontstage.ts",
+    detail: "decision_frame, todos, gates, leases, artifacts, truth_contract",
+  },
+  {
+    label: "public showcase catalog",
+    source: "docs/showcases/showcase-catalog.json",
+    detail: "case metadata, visual hints, evidence boundaries, story beats",
+  },
+  {
+    label: "route smoke",
+    source: "apps/dashboard/smoke/frontstage-route-smoke.ts",
+    detail: "static route contract, source guards, component expectations",
+  },
+];
+
+const projectionDiffRows = [
+  {
+    axis: "schema",
+    current: "goal_channel_projection_v0",
+    proposed: "new optional projection field",
+    gate: "parser default plus route smoke assertion",
+  },
+  {
+    axis: "truth",
+    current: "event ledger and active state remain source of truth",
+    proposed: "derived UI state only",
+    gate: "truth_contract must stay read-only",
+  },
+  {
+    axis: "privacy",
+    current: "compact source refs and warnings",
+    proposed: "public-safe fixture field",
+    gate: "goal-harness check and browser fake-private fixture",
+  },
+  {
+    axis: "interaction",
+    current: "render, filter, select, inspect",
+    proposed: "no browser write by default",
+    gate: "write affordance requires explicit loopback capability",
+  },
+];
+
+const fixtureRules = [
+  {
+    title: "Fixture sources",
+    body: "Use examples/status.example.json, browser-smoke fixtures, and docs/showcases/showcase-catalog.json.",
+  },
+  {
+    title: "Required proof",
+    body: "Every projection addition needs parser coverage, route smoke assertions, and one browser or bundle check when UI output changes.",
+  },
+  {
+    title: "Never include",
+    body: "Raw task text, trajectories, transcripts, local paths, private registry state, credentials, or internal document links.",
+  },
+];
+
+const smokeChecklist = [
+  "npm --prefix apps/dashboard run smoke:frontstage-route",
+  "npm --prefix apps/dashboard run smoke:frontstage-browser",
+  "npm --prefix apps/dashboard run smoke:frontstage-share-bundle",
+  "npm --prefix apps/dashboard run build",
+  "goal-harness check --scan-path apps/dashboard --scan-path docs/status-data-contract.md",
+];
+
+const componentExamples = [
+  {
+    name: "Projection lane",
+    badges: ["read-only", "schema v0"],
+    body: "Summarizes one compact projection lane without mutating the underlying Goal Harness state.",
+  },
+  {
+    name: "Capability badge",
+    badges: ["loopback", "dry-run"],
+    body: "Shows an advertised local capability only after the status feed declares it.",
+  },
+  {
+    name: "Boundary warning",
+    badges: ["public-safe", "omitted"],
+    body: "Names omitted private material and points contributors back to compact source references.",
+  },
+];
+
+function CockpitPanel({ children, icon: Icon, title }: CockpitPanelProps) {
+  return (
+    <section className="rounded-lg border border-slate-200 bg-white shadow-sm">
+      <div className="flex items-center justify-between gap-3 border-b border-slate-200 px-4 py-3">
+        <h2 className="flex items-center gap-2 text-sm font-semibold text-slate-950">
+          <Icon className="h-4 w-4 text-slate-500" />
+          {title}
+        </h2>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function ContractExplorer() {
+  return (
+    <CockpitPanel icon={Braces} title="Status Contract Explorer">
+      <div className="grid gap-3 p-4 lg:grid-cols-2" data-testid="developer-contract-explorer">
+        {contractFields.map((item) => (
+          <div className="rounded-md border border-slate-200 bg-slate-50 px-3 py-3" key={item.label}>
+            <div className="flex flex-wrap items-center gap-2">
+              <Badge variant="info">{item.label}</Badge>
+              <Badge variant="neutral">public contract</Badge>
+            </div>
+            <div className="mt-2 break-words font-mono text-xs text-slate-700">{item.source}</div>
+            <p className="mt-2 text-sm leading-6 text-slate-600">{item.detail}</p>
+          </div>
+        ))}
+      </div>
+    </CockpitPanel>
+  );
+}
+
+function ProjectionDiffing() {
+  return (
+    <CockpitPanel icon={GitCompareArrows} title="Projection Diffing">
+      <div className="overflow-x-auto" data-testid="developer-projection-diffing">
+        <table className="min-w-full border-separate border-spacing-0 text-left text-sm">
+          <thead>
+            <tr className="bg-slate-50 text-xs uppercase tracking-normal text-slate-500">
+              <th className="border-b border-slate-200 px-4 py-3 font-semibold">Axis</th>
+              <th className="border-b border-slate-200 px-4 py-3 font-semibold">Current</th>
+              <th className="border-b border-slate-200 px-4 py-3 font-semibold">Proposed</th>
+              <th className="border-b border-slate-200 px-4 py-3 font-semibold">Gate</th>
+            </tr>
+          </thead>
+          <tbody>
+            {projectionDiffRows.map((row) => (
+              <tr className="align-top" key={row.axis}>
+                <td className="border-b border-slate-100 px-4 py-3 font-semibold text-slate-950">{row.axis}</td>
+                <td className="border-b border-slate-100 px-4 py-3 text-slate-600">{row.current}</td>
+                <td className="border-b border-slate-100 px-4 py-3 text-slate-600">{row.proposed}</td>
+                <td className="border-b border-slate-100 px-4 py-3 text-slate-600">{row.gate}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </CockpitPanel>
+  );
+}
+
+function FixtureGeneration() {
+  return (
+    <CockpitPanel icon={FileJson} title="Fixture Generation">
+      <div className="grid gap-3 p-4 md:grid-cols-3" data-testid="developer-fixture-generation">
+        {fixtureRules.map((rule) => (
+          <div className="rounded-md border border-slate-200 bg-slate-50 px-3 py-3" key={rule.title}>
+            <div className="text-sm font-semibold text-slate-950">{rule.title}</div>
+            <p className="mt-2 text-sm leading-6 text-slate-600">{rule.body}</p>
+          </div>
+        ))}
+      </div>
+    </CockpitPanel>
+  );
+}
+
+function SmokeChecklist() {
+  return (
+    <CockpitPanel icon={ClipboardCheck} title="Smoke Checklist">
+      <div className="space-y-2 p-4" data-testid="developer-smoke-checklist">
+        {smokeChecklist.map((command) => (
+          <div className="flex items-start gap-3 rounded-md border border-slate-200 bg-slate-50 px-3 py-2" key={command}>
+            <BadgeCheck className="mt-0.5 h-4 w-4 shrink-0 text-emerald-600" />
+            <code className="break-all text-xs font-semibold leading-5 text-slate-700">{command}</code>
+          </div>
+        ))}
+      </div>
+    </CockpitPanel>
+  );
+}
+
+function ComponentExamples() {
+  return (
+    <CockpitPanel icon={Code2} title="Component Examples">
+      <div className="grid gap-3 p-4 lg:grid-cols-3" data-testid="developer-component-examples">
+        {componentExamples.map((example) => (
+          <article className="rounded-md border border-slate-200 bg-slate-50 p-3" key={example.name}>
+            <div className="flex flex-wrap gap-2">
+              {example.badges.map((badge) => (
+                <Badge key={badge} variant={badge === "read-only" || badge === "public-safe" ? "success" : "neutral"}>
+                  {badge}
+                </Badge>
+              ))}
+            </div>
+            <h3 className="mt-3 text-sm font-semibold leading-6 text-slate-950">{example.name}</h3>
+            <p className="mt-2 text-sm leading-6 text-slate-600">{example.body}</p>
+          </article>
+        ))}
+      </div>
+    </CockpitPanel>
+  );
+}
+
+export function FrontstageDeveloperPage() {
+  return (
+    <main className="min-h-screen bg-[#f7f7f4] px-4 py-4 text-slate-950 sm:px-5" data-testid="frontstage-developer-cockpit">
+      <div className="mx-auto grid max-w-[1500px] gap-4 xl:grid-cols-[260px_minmax(0,1fr)]">
+        <aside className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm xl:sticky xl:top-4 xl:self-start">
+          <div className="flex items-center gap-2">
+            <div className="flex h-9 w-9 items-center justify-center rounded-md border border-slate-200 bg-slate-950 text-white">
+              <TestTube2 className="h-4 w-4" />
+            </div>
+            <div>
+              <div className="text-sm font-semibold">Developer Cockpit</div>
+              <div className="text-xs text-slate-500">Projection extension</div>
+            </div>
+          </div>
+          <div className="mt-4 grid gap-2">
+            <a className="flex items-center gap-2 rounded-md border border-slate-200 px-3 py-2 text-sm font-medium" href="/">
+              <LayoutDashboard className="h-4 w-4" />
+              Control home
+            </a>
+            <a className="flex items-center gap-2 rounded-md border border-slate-200 px-3 py-2 text-sm font-medium" href="/frontstage">
+              <ExternalLink className="h-4 w-4" />
+              Public frontstage
+            </a>
+            <a className="flex items-center gap-2 rounded-md bg-slate-950 px-3 py-2 text-sm font-medium text-white" href="/frontstage/developer">
+              <Code2 className="h-4 w-4" />
+              Developer cockpit
+            </a>
+          </div>
+          <div className="mt-5 space-y-2 rounded-md border border-emerald-200 bg-emerald-50 p-3 text-xs leading-5 text-emerald-950">
+            <div className="flex flex-wrap gap-2">
+              <Badge variant="success">read-only</Badge>
+              <Badge variant="neutral">public fixtures</Badge>
+            </div>
+            <p>
+              This route uses static public contracts only; live status feeds, registry files, and browser write APIs stay outside the cockpit.
+            </p>
+          </div>
+        </aside>
+
+        <section className="space-y-4">
+          <div className="rounded-lg border border-slate-200 bg-white px-5 py-5 shadow-sm">
+            <div className="flex flex-wrap items-start justify-between gap-4">
+              <div>
+                <div className="flex flex-wrap gap-2">
+                  <Badge variant="info">frontstage/developer</Badge>
+                  <Badge variant="success">public-safe</Badge>
+                  <Badge variant="neutral">no browser writes</Badge>
+                </div>
+                <h1 className="mt-3 text-3xl font-semibold tracking-normal text-slate-950">
+                  Goal Harness Projection Developer Cockpit
+                </h1>
+                <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">
+                  A read-only contributor workbench for adding dashboard/frontstage projections without reverse-engineering the large operator page.
+                </p>
+              </div>
+              <div className="grid min-w-[260px] gap-2 text-sm">
+                <div className="rounded-md border border-slate-200 bg-slate-50 px-3 py-2">
+                  <div className="text-[11px] font-semibold uppercase tracking-normal text-slate-500">Source of truth</div>
+                  <div className="mt-1 font-semibold text-slate-950">status contract + compact fixtures</div>
+                </div>
+                <div className="rounded-md border border-slate-200 bg-slate-50 px-3 py-2">
+                  <div className="text-[11px] font-semibold uppercase tracking-normal text-slate-500">Boundary</div>
+                  <div className="mt-1 font-semibold text-slate-950">read-only extension surface</div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="grid gap-4 xl:grid-cols-2">
+            <ContractExplorer />
+            <ProjectionDiffing />
+          </div>
+          <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_420px]">
+            <FixtureGeneration />
+            <SmokeChecklist />
+          </div>
+          <ComponentExamples />
+
+          <CockpitPanel icon={ShieldCheck} title="Extension Boundary">
+            <div className="grid gap-3 p-4 md:grid-cols-3" data-testid="developer-extension-boundary">
+              <div className="rounded-md border border-emerald-200 bg-emerald-50 px-3 py-3">
+                <div className="text-sm font-semibold text-slate-950">Allowed</div>
+                <p className="mt-2 text-sm leading-6 text-slate-600">Versioned parser defaults, public fixtures, read-only route panels, and focused smoke assertions.</p>
+              </div>
+              <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-3">
+                <div className="text-sm font-semibold text-slate-950">Review</div>
+                <p className="mt-2 text-sm leading-6 text-slate-600">New dashboard dependencies, status contract fields, loopback capability display, and browser-visible workflows.</p>
+              </div>
+              <div className="rounded-md border border-rose-200 bg-rose-50 px-3 py-3">
+                <div className="text-sm font-semibold text-slate-950">Stop</div>
+                <p className="mt-2 text-sm leading-6 text-slate-600">Credentials, private registry material, raw logs, transcripts, production actions, or default browser write authority.</p>
+              </div>
+            </div>
+          </CockpitPanel>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/apps/dashboard/src/views/frontstage-page.tsx
+++ b/apps/dashboard/src/views/frontstage-page.tsx
@@ -1142,9 +1142,9 @@ function FrontstageRoute({
               <Activity className="h-4 w-4" />
               Channel board
             </a>
-            <a className="flex items-center gap-2 rounded-md border border-slate-200 px-3 py-2 text-sm font-medium" href="/frontstage?mode=developer">
-              <Bot className="h-4 w-4" />
-              Developer path
+            <a className="flex items-center gap-2 rounded-md border border-slate-200 px-3 py-2 text-sm font-medium" href="/frontstage/developer">
+              <ExternalLink className="h-4 w-4" />
+              Developer cockpit
             </a>
           </div>
           <div className="mt-5 space-y-2 text-xs leading-5 text-slate-500">

--- a/docs/product/frontstage-two-surface-strategy.md
+++ b/docs/product/frontstage-two-surface-strategy.md
@@ -36,6 +36,12 @@ gate, top user todo, top agent todo, quota or guard judgment, and recent
 evidence. `?view=ops` remains the detailed workbench for debugging status
 contracts, reward previews, and individual queue items.
 
+`/frontstage/developer` is a read-only contributor cockpit. It belongs to the
+frontstage developer-extension lane rather than the public homepage or live ops
+surface: it renders static public contracts, projection diffing, fixture rules,
+smoke checklists, and component examples so contributors can add projections
+without mining the large dashboard page.
+
 Compatibility aliases such as `view=share` may exist only as routing bridges.
 They do not define a third product surface.
 

--- a/examples/dashboard-frontstage-browser-smoke.mjs
+++ b/examples/dashboard-frontstage-browser-smoke.mjs
@@ -329,12 +329,12 @@ async function assertNoHorizontalOverflow(page, label) {
   }
 }
 
-async function captureFrontstage(page, url, label, requiredText = []) {
+async function captureFrontstage(page, url, label, requiredText = [], options = {}) {
   await page.goto(url, { waitUntil: "networkidle" });
-  await page.waitForSelector('[data-testid="goal-channel-frontstage-route"]', { timeout: 10_000 });
+  await page.waitForSelector(options.rootSelector ?? '[data-testid="goal-channel-frontstage-route"]', { timeout: 10_000 });
 
   const body = await page.locator("body").innerText();
-  const required = [
+  const frontstageRequired = [
     "Goal Harness",
     "Frontstage channel",
     "Projection is read-only",
@@ -354,8 +354,10 @@ async function captureFrontstage(page, url, label, requiredText = []) {
     "Goal Harness self-iteration loop",
     "Creator-operator long-running agent case",
     "Boundary Warnings",
-    ...requiredText,
   ];
+  const required = options.includeFrontstageRequired === false
+    ? requiredText
+    : [...frontstageRequired, ...requiredText];
   const missing = required.filter((text) => !body.includes(text));
   if (missing.length) {
     throw new Error(`Missing frontstage text: ${missing.join(", ")}`);
@@ -594,6 +596,30 @@ async function main() {
           throw new Error(`Explicit ops mode did not render fake-private status trap marker: ${marker}`);
         }
       }
+      await captureFrontstage(
+        desktopPage,
+        `${baseUrl}/frontstage/developer`,
+        "desktop-frontstage-developer-cockpit",
+        [
+          "Goal Harness Projection Developer Cockpit",
+          "Status Contract Explorer",
+          "Projection Diffing",
+          "Fixture Generation",
+          "Smoke Checklist",
+          "Component Examples",
+          "Extension Boundary",
+          "apps/dashboard/src/data/status.ts",
+          "apps/dashboard/src/data/goal-channel-frontstage.ts",
+          "examples/status.example.json",
+          "goal-harness check --scan-path apps/dashboard",
+          "read-only contributor workbench",
+          "live status feeds, registry files, and browser write APIs stay outside",
+        ],
+        {
+          includeFrontstageRequired: false,
+          rootSelector: '[data-testid="frontstage-developer-cockpit"]',
+        },
+      );
       await captureFrontstage(
         desktopPage,
         `${baseUrl}/frontstage?mode=ops&statusUrl=/${fixtureName}&goalId=live-goal-a`,

--- a/examples/frontstage-two-surface-strategy-smoke.py
+++ b/examples/frontstage-two-surface-strategy-smoke.py
@@ -44,6 +44,7 @@ def main() -> int:
         "showcase mode ignores `statusUrl`",
         "frontstage-private-status-trap.public.json",
         "`GH_FAKE_*` markers",
+        "`/frontstage/developer` is a read-only contributor cockpit",
         "Phase 1, public showcase polish",
         "Phase 2, local ops data layer",
         "Phase 3, controlled local write affordances",
@@ -70,6 +71,7 @@ def main() -> int:
         "Neither surface is browser write authority",
         "frontstage-private-status-trap.public.json",
         "synthetic `GH_FAKE_*` trap markers",
+        "developer extension cockpit lives at `/frontstage/developer`",
     ]:
         assert_contains(compact_dashboard_readme, existing_contract)
 


### PR DESCRIPTION
## Summary
- add a read-only `/frontstage/developer` route for status-contract exploration, projection diffing, fixture rules, smoke checklists, component examples, and extension boundaries
- link the cockpit from the frontstage sidebar and document its ownership in the dashboard README and two-surface strategy
- extend route/browser/two-surface smokes so the public-safe developer route stays static and does not depend on live status feeds, registry files, or browser write APIs

## Validation
- `npm --prefix apps/dashboard run smoke:frontstage-route`
- `npm --prefix apps/dashboard run smoke:frontstage-browser`
- `npm --prefix apps/dashboard run smoke:frontstage-share-bundle`
- `npm --prefix apps/dashboard run build`
- `python3 examples/docs-governance-smoke.py`
- `python3 examples/frontstage-two-surface-strategy-smoke.py`
- `goal-harness check --scan-path apps/dashboard/README.md --scan-path apps/dashboard/src/router.tsx --scan-path apps/dashboard/src/views/frontstage-page.tsx --scan-path apps/dashboard/src/views/frontstage-developer-page.tsx --scan-path apps/dashboard/smoke/frontstage-route-smoke.ts --scan-path examples/dashboard-frontstage-browser-smoke.mjs --scan-path examples/frontstage-two-surface-strategy-smoke.py --scan-path docs/product/frontstage-two-surface-strategy.md`
- `git diff --check`

## Boundary
- excludes `.local`, `.goal-harness`, runtime history, live status exports, credentials, private docs, raw benchmark logs, transcripts, and trajectories
- not self-merged: this adds a dashboard runtime route/UI surface and should get primary review
