### PR TITLE
Guard frontstage public projection boundaries

### DIFF
--- a/apps/dashboard/README.md
+++ b/apps/dashboard/README.md
@@ -59,6 +59,10 @@ showcase metadata. Neither surface is browser write authority.
 The default frontstage route is public showcase mode. It ignores `statusUrl`
 and renders only bundled showcase/demo material, so a copied or hosted URL does
 not accidentally project local registry state.
+`examples/fixtures/frontstage-private-status-trap.public.json` is the synthetic
+negative fixture for that boundary: browser smokes prove its `GH_FAKE_*` live
+status markers stay out of showcase URLs and appear only after an explicit
+`mode=ops` load.
 
 For live local control-plane inspection, explicitly enter ops mode:
 `/frontstage?mode=ops&statusUrl=http://127.0.0.1:8766/status.json`. The route
@@ -81,6 +85,8 @@ compiled dashboard, `status.frontstage-share.json`, a direct `/frontstage/`
 static route, a manifest, and a README with the local serve URL. The exporter
 rejects local paths, private registry state, internal document hosts, raw-key
 leaks, token assignments, and private key material before reporting success.
+The share-bundle smoke also scans generated files for the synthetic `GH_FAKE_*`
+trap markers so public exports cannot accidentally carry a live-status payload.
 For repository Pages hosting later, rerun the same exporter with
 `-- --base /goal-harness/ --out-dir <artifact-dir>` and publish only that
 generated site artifact.

--- a/apps/dashboard/smoke/frontstage-route-smoke.ts
+++ b/apps/dashboard/smoke/frontstage-route-smoke.ts
@@ -28,6 +28,7 @@ const stylesSource = readFileSync("src/styles.css", "utf8");
 const dataSource = readFileSync("src/data/goal-channel-frontstage.ts", "utf8");
 const statusSource = readFileSync("src/data/status.ts", "utf8");
 const catalogSource = readFileSync("../../docs/showcases/showcase-catalog.json", "utf8");
+const privateTrapFixtureSource = readFileSync("../../examples/fixtures/frontstage-private-status-trap.public.json", "utf8");
 const readmeSource = readFileSync("README.md", "utf8");
 const selectionSource = readFileSync("../../docs/dashboard-frontend-selection.md", "utf8");
 const packageSource = readFileSync("package.json", "utf8");
@@ -42,6 +43,9 @@ includes(routerSource, "basepath:", "router basepath option");
 includes(routerSource, "import.meta.env.BASE_URL", "Vite base URL router source");
 includes(packageSource, '"smoke:frontstage-browser"', "frontstage browser smoke script");
 includes(packageSource, '"smoke:frontstage-route"', "frontstage smoke script");
+includes(privateTrapFixtureSource, "GH_FAKE_PRIVATE_PLAN_SUMMARY_ALPHA", "fake-private status trap plan marker");
+includes(privateTrapFixtureSource, "GH_FAKE_LIVE_STATUS_FEED_BETA", "fake-private live status trap marker");
+includes(privateTrapFixtureSource, "GH_FAKE_PRIVATE_TODO_GAMMA", "fake-private todo trap marker");
 
 includes(dataSource, 'schema_version: "goal_channel_projection_v0"', "goal channel schema");
 includes(dataSource, "goalChannelProjectionSchema", "goal channel zod schema");

--- a/docs/product/frontstage-two-surface-strategy.md
+++ b/docs/product/frontstage-two-surface-strategy.md
@@ -107,7 +107,11 @@ Ops control-plane changes should validate:
 Cross-surface changes must prove both sides when they touch shared code. The
 minimum check is that showcase mode ignores `statusUrl`, ops mode accepts only
 relative or loopback feeds, and exported public bundles do not carry live
-registry state.
+registry state. Use
+`examples/fixtures/frontstage-private-status-trap.public.json` as the
+synthetic negative fixture: public showcase URLs and share bundles must not
+render its `GH_FAKE_*` markers, while explicit ops-mode statusUrl loading may
+render them during local inspection.
 
 ## Phased Roadmap
 

--- a/examples/dashboard-frontstage-browser-smoke.mjs
+++ b/examples/dashboard-frontstage-browser-smoke.mjs
@@ -4,7 +4,7 @@
 import { spawn } from "node:child_process";
 import { createRequire } from "node:module";
 import { existsSync } from "node:fs";
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -14,8 +14,24 @@ const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const dashboardDir = resolve(repoRoot, "apps/dashboard");
 const fixtureName = "status.frontstage.browser-smoke.json";
 const fixturePath = resolve(dashboardDir, "public", fixtureName);
+const privateTrapFixtureName = "status.frontstage.private-trap.json";
+const privateTrapFixturePath = resolve(dashboardDir, "public", privateTrapFixtureName);
+const privateTrapSourcePath = resolve(repoRoot, "examples/fixtures/frontstage-private-status-trap.public.json");
 const visualOutputDir = resolve(repoRoot, "output/playwright/dashboard-frontstage-visual-acceptance");
 const port = Number(process.env.GOAL_HARNESS_DASHBOARD_FRONTSTAGE_SMOKE_PORT ?? "5197");
+const fakePrivateTrapMarkers = [
+  "GH_FAKE_PRIVATE_STATUS_ALPHA",
+  "GH_FAKE_PRIVATE_PLAN_SUMMARY_ALPHA",
+  "GH_FAKE_LIVE_STATUS_FEED_BETA",
+  "GH_FAKE_PRIVATE_REGISTRY_SUMMARY_GAMMA",
+  "GH_FAKE_PRIVATE_TODO_GAMMA",
+  "GH_FAKE_PRIVATE_EVENT_DELTA",
+  "GH_FAKE_PRIVATE_LEDGER_SOURCE_EPSILON",
+  "GH_FAKE_PRIVATE_SPEND_POLICY_ZETA",
+  "GH_FAKE_PRIVATE_ARTIFACT_ETA",
+  "GH_FAKE_PRIVATE_RUNTIME_ROOT_THETA",
+  "GH_FAKE_PRIVATE_ARTIFACT_PATH_IOTA",
+];
 
 function projectionFor(goalId, displayName, claimedBy, todoTitle) {
   return {
@@ -363,6 +379,7 @@ async function captureFrontstage(page, url, label, requiredText = []) {
 async function main() {
   const { chromium } = loadPlaywright();
   await writeFile(fixturePath, JSON.stringify(statusFixture, null, 2) + "\n", "utf-8");
+  await writeFile(privateTrapFixturePath, await readFile(privateTrapSourcePath, "utf8"), "utf-8");
   await mkdir(visualOutputDir, { recursive: true });
 
   const server = startDashboardServer();
@@ -468,6 +485,47 @@ async function main() {
       const publicModePresent = publicModeForbidden.filter((text) => publicModeText.includes(text));
       if (publicModePresent.length) {
         throw new Error(`Showcase frontstage loaded live statusUrl text: ${publicModePresent.join(", ")}`);
+      }
+      await captureFrontstage(
+        desktopPage,
+        `${baseUrl}/frontstage?statusUrl=/${privateTrapFixtureName}&goalId=fake-private-trap-goal`,
+        "desktop-frontstage-showcase-private-trap-ignored",
+        [
+          "Goal Harness Showcase Frontstage",
+          "showcase mode",
+          "Showcase mode ignores statusUrl",
+          "statusUrl ignored",
+          "Public Boundary",
+          "docs/showcases",
+        ],
+      );
+      const privateTrapPublicText = await desktopPage.locator("body").innerText();
+      const leakedTrapMarkers = fakePrivateTrapMarkers.filter((text) => privateTrapPublicText.includes(text));
+      if (leakedTrapMarkers.length) {
+        throw new Error(`Showcase mode rendered fake-private status trap markers: ${leakedTrapMarkers.join(", ")}`);
+      }
+      await captureFrontstage(
+        desktopPage,
+        `${baseUrl}/frontstage?mode=ops&statusUrl=/${privateTrapFixtureName}&goalId=fake-private-trap-goal`,
+        "desktop-frontstage-ops-private-trap-explicit",
+        [
+          "ops live",
+          "live status feed",
+          "Fake Private Trap Goal",
+          "GH_FAKE_PRIVATE_PLAN_SUMMARY_ALPHA",
+          "GH_FAKE_PRIVATE_TODO_GAMMA",
+          "GH_FAKE_PRIVATE_EVENT_DELTA",
+        ],
+      );
+      const privateTrapOpsText = await desktopPage.locator("body").innerText();
+      for (const marker of [
+        "GH_FAKE_PRIVATE_PLAN_SUMMARY_ALPHA",
+        "GH_FAKE_PRIVATE_TODO_GAMMA",
+        "GH_FAKE_PRIVATE_EVENT_DELTA",
+      ]) {
+        if (!privateTrapOpsText.includes(marker)) {
+          throw new Error(`Explicit ops mode did not render fake-private status trap marker: ${marker}`);
+        }
       }
       await captureFrontstage(
         desktopPage,
@@ -598,6 +656,7 @@ async function main() {
     }
     server.kill("SIGTERM");
     await rm(fixturePath, { force: true });
+    await rm(privateTrapFixturePath, { force: true });
   }
 }
 

--- a/examples/export-frontstage-share-bundle.mjs
+++ b/examples/export-frontstage-share-bundle.mjs
@@ -80,6 +80,17 @@ async function copyIndexForFrontstage(siteDir) {
   await writeFile(resolve(frontstageDir, "index.html"), html);
 }
 
+async function removeCopiedLiveStatusFiles(siteDir) {
+  for (const entry of await readdir(siteDir, { withFileTypes: true })) {
+    if (!entry.isFile()) {
+      continue;
+    }
+    if (/^status\..*\.json$/i.test(entry.name) && entry.name !== statusFileName) {
+      await rm(resolve(siteDir, entry.name), { force: true });
+    }
+  }
+}
+
 function sanitizeProjectionForShare(projection) {
   return {
     ...projection,
@@ -283,6 +294,7 @@ async function main() {
     "--emptyOutDir",
   ], { cwd: dashboardDir });
 
+  await removeCopiedLiveStatusFiles(siteDir);
   await copyIndexForFrontstage(siteDir);
 
   const projectionOutput = run("python3", [resolve(repoRoot, "examples/goal-channel-frontstage-fixture.py"), "--format", "json"], {

--- a/examples/fixtures/frontstage-private-status-trap.public.json
+++ b/examples/fixtures/frontstage-private-status-trap.public.json
@@ -1,0 +1,116 @@
+{
+  "ok": true,
+  "registry": "GH_FAKE_PRIVATE_REGISTRY_SUMMARY_GAMMA",
+  "runtime_root": "GH_FAKE_PRIVATE_RUNTIME_ROOT_THETA",
+  "goal_count": 1,
+  "run_count": 1,
+  "status_contract": {
+    "schema_version": 2,
+    "minimum_dashboard_schema_version": 2,
+    "producer": "frontstage-private-status-trap.public.json",
+    "reload_hint": "GH_FAKE_LIVE_STATUS_FEED_BETA"
+  },
+  "contract": {
+    "ok": true,
+    "summary": {
+      "errors": 0,
+      "warnings": 0,
+      "checks": 1
+    },
+    "errors": [],
+    "warnings": [],
+    "checks": [
+      "synthetic fake-private status trap for frontstage boundary smokes"
+    ]
+  },
+  "attention_queue": {
+    "available": true,
+    "item_count": 1,
+    "needs_user_or_controller": 0,
+    "needs_controller": 0,
+    "needs_codex": 1,
+    "watching_external_evidence": 0,
+    "items": [
+      {
+        "goal_id": "fake-private-trap-goal",
+        "status": "GH_FAKE_PRIVATE_STATUS_ALPHA",
+        "waiting_on": "codex",
+        "severity": "action",
+        "recommended_action": "GH_FAKE_PRIVATE_PLAN_SUMMARY_ALPHA should appear only in explicit ops mode.",
+        "source": "synthetic-public-boundary-trap",
+        "goal_channel_projection": {
+          "schema_version": "goal_channel_projection_v0",
+          "mode": "read_only",
+          "goal_id": "fake-private-trap-goal",
+          "display_name": "Fake Private Trap Goal",
+          "generated_at": "2026-06-21T10:00:00Z",
+          "latest_status": "GH_FAKE_PRIVATE_STATUS_ALPHA",
+          "waiting_on": "codex",
+          "next_action": "GH_FAKE_PRIVATE_PLAN_SUMMARY_ALPHA visible only after mode=ops statusUrl load.",
+          "source_refs": {
+            "status_generated_at": "2026-06-21T10:00:00Z",
+            "event_ledger_source": "GH_FAKE_PRIVATE_LEDGER_SOURCE_EPSILON",
+            "live_status_feed": "GH_FAKE_LIVE_STATUS_FEED_BETA"
+          },
+          "decision_frame": {
+            "user_action_required": false,
+            "agent_action_required": true,
+            "quiet_noop_allowed": false
+          },
+          "quota": {
+            "allowed_slots": 10,
+            "spent_slots": 1,
+            "state": "eligible",
+            "spend_policy": "GH_FAKE_PRIVATE_SPEND_POLICY_ZETA"
+          },
+          "user_todos": [],
+          "agent_todos": [
+            {
+              "todo_id": "fake_private_trap_todo",
+              "priority": "P2",
+              "status": "open",
+              "claimed_by": "codex-side-bypass",
+              "task_class": "advancement_task",
+              "action_kind": "frontstage_public_boundary_trap",
+              "title": "GH_FAKE_PRIVATE_TODO_GAMMA should not render on public showcase URLs."
+            }
+          ],
+          "open_gates": [],
+          "active_leases": [
+            {
+              "todo_id": "fake_private_trap_todo",
+              "owner_agent": "codex-side-bypass",
+              "status": "soft_claim"
+            }
+          ],
+          "artifacts": [
+            {
+              "kind": "trap",
+              "label": "GH_FAKE_PRIVATE_ARTIFACT_ETA",
+              "path": "GH_FAKE_PRIVATE_ARTIFACT_PATH_IOTA"
+            }
+          ],
+          "recent_events": [
+            {
+              "generated_at": "2026-06-21T10:01:00Z",
+              "classification": "frontstage_public_boundary_trap",
+              "summary": "GH_FAKE_PRIVATE_EVENT_DELTA should require explicit ops mode."
+            }
+          ],
+          "source_warnings": [
+            {
+              "kind": "fake_private_status_trap",
+              "message": "Synthetic fake-private fixture: public showcase and exported bundles must not render GH_FAKE_* markers."
+            }
+          ],
+          "truth_contract": {
+            "event_ledger_is_source_of_truth": true,
+            "projection_is_writable": false,
+            "recompute_rule": "reload explicit ops statusUrl only",
+            "write_authority": "none"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/examples/frontstage-share-bundle-smoke.mjs
+++ b/examples/frontstage-share-bundle-smoke.mjs
@@ -9,6 +9,7 @@ import { fileURLToPath } from "node:url";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const outDir = resolve("/tmp", "goal-harness-frontstage-share-bundle-smoke");
+const privateTrapFixturePath = resolve(repoRoot, "examples/fixtures/frontstage-private-status-trap.public.json");
 
 function run(command, args, cwd = repoRoot) {
   const result = spawnSync(command, args, {
@@ -47,6 +48,10 @@ function assertNoLeak(text, label) {
   if (hit) {
     throw new Error(`${label} leaked forbidden pattern: ${hit}`);
   }
+}
+
+function collectFakePrivateMarkers(text) {
+  return Array.from(new Set(text.match(/GH_FAKE_[A-Z0-9_]+/g) ?? [])).sort();
 }
 
 async function collectGeneratedTextFiles(rootDir) {
@@ -114,8 +119,18 @@ if (manifest.content_sources?.live_status_feed !== false) {
   throw new Error("public share bundle must not declare a live status feed content source");
 }
 
+const fakePrivateTrapFixture = await readFile(privateTrapFixturePath, "utf8");
+const fakePrivateTrapMarkers = collectFakePrivateMarkers(fakePrivateTrapFixture);
+if (fakePrivateTrapMarkers.length < 6) {
+  throw new Error("fake-private frontstage trap fixture is too weak");
+}
 for (const path of await collectGeneratedTextFiles(outDir)) {
-  assertNoLeak(await readFile(path, "utf8"), path);
+  const text = await readFile(path, "utf8");
+  assertNoLeak(text, path);
+  const leakedTrapMarkers = fakePrivateTrapMarkers.filter((marker) => text.includes(marker));
+  if (leakedTrapMarkers.length) {
+    throw new Error(`${path} leaked fake-private frontstage trap markers: ${leakedTrapMarkers.join(", ")}`);
+  }
 }
 
 const readmeText = await readFile(resolve(outDir, "README.md"), "utf8");

--- a/examples/frontstage-two-surface-strategy-smoke.py
+++ b/examples/frontstage-two-surface-strategy-smoke.py
@@ -42,6 +42,8 @@ def main() -> int:
         "The ops surface should still default to read-only",
         "Public visual experiments must not depend on live state",
         "showcase mode ignores `statusUrl`",
+        "frontstage-private-status-trap.public.json",
+        "`GH_FAKE_*` markers",
         "Phase 1, public showcase polish",
         "Phase 2, local ops data layer",
         "Phase 3, controlled local write affordances",
@@ -66,6 +68,8 @@ def main() -> int:
         "relative or loopback URLs",
         "Do not use ops-mode URLs as public links",
         "Neither surface is browser write authority",
+        "frontstage-private-status-trap.public.json",
+        "synthetic `GH_FAKE_*` trap markers",
     ]:
         assert_contains(compact_dashboard_readme, existing_contract)
 


### PR DESCRIPTION
## Summary
- add a synthetic fake-private frontstage status trap fixture with `GH_FAKE_*` markers
- extend the frontstage browser smoke to prove showcase/public URLs ignore trap `statusUrl` payloads while explicit ops mode can load them
- scrub copied `status.*.json` files from the share bundle export before writing the sanitized `status.frontstage-share.json`
- extend the share-bundle smoke to scan generated files for trap markers and update the two-surface/dashboard docs

## Validation
- `npm --prefix apps/dashboard run smoke:frontstage-browser`
- `npm --prefix apps/dashboard run smoke:frontstage-share-bundle`
- `npm --prefix apps/dashboard run smoke:frontstage-route`
- `npm --prefix apps/dashboard run build`
- `python3 examples/frontstage-two-surface-strategy-smoke.py`
- `python3 examples/docs-governance-smoke.py`
- `goal-harness check --scan-path apps/dashboard/README.md --scan-path apps/dashboard/smoke/frontstage-route-smoke.ts --scan-path docs/product/frontstage-two-surface-strategy.md --scan-path examples/dashboard-frontstage-browser-smoke.mjs --scan-path examples/export-frontstage-share-bundle.mjs --scan-path examples/frontstage-share-bundle-smoke.mjs --scan-path examples/frontstage-two-surface-strategy-smoke.py --scan-path examples/fixtures/frontstage-private-status-trap.public.json`
- `git diff --check`

## Boundary
- `GH_FAKE_*` markers are synthetic public test sentinels, not real private material
- excludes local active state, `.goal-harness`, live status exports, credentials, raw logs, transcripts, and trajectories
- not self-merged: this changes dashboard export behavior and browser/share validation, so primary review should approve it
