### PR TITLE
Recognize prompt-driven GH proof in Harbor reducer

### DIFF
--- a/examples/terminal-bench-harbor-prompt-driven-reducer-smoke.py
+++ b/examples/terminal-bench-harbor-prompt-driven-reducer-smoke.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Smoke-test Harbor reducer ingestion of prompt-driven GH lifecycle proof."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from goal_harness.benchmark_adapters.terminal_bench import (  # noqa: E402
+    build_terminal_bench_harbor_result_benchmark_run,
+)
+from goal_harness.status import compact_benchmark_run  # noqa: E402
+
+
+def write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_prompt_driven_fixture(root: Path) -> Path:
+    run_root = root / "terminal-bench-prompt-driven-run"
+    job_dir = run_root / "jobs" / "swe-marathon-zstd-decoder-gh-treatment"
+    trial_dir = job_dir / "zstd-decoder__prompt"
+    agent = {
+        "import_path": "goal_harness.terminal_bench_agent:GoalHarnessManagedCodex",
+        "model_name": "gpt-5.5",
+        "kwargs": {
+            "goal_harness_mode": "codex_goal_harness",
+            "goal_harness_access_packet_mode": "full",
+            "goal_harness_cli_bridge_enabled": True,
+            "goal_harness_goal_id": "benchmark-case-terminal-bench-zstd-decoder-test",
+        },
+    }
+    write_json(
+        job_dir / "lock.json",
+        {
+            "schema_version": 1,
+            "invocation": [
+                "harbor",
+                "run",
+                "--dataset",
+                "terminal-bench-sample@2.0",
+                "--include-task-name",
+                "zstd-decoder",
+            ],
+            "trials": [
+                {
+                    "task": {
+                        "name": "zstd-decoder",
+                        "source": "terminal-bench-sample",
+                    },
+                    "agent": agent,
+                }
+            ],
+        },
+    )
+    write_json(
+        job_dir / "config.json",
+        {
+            "job_name": job_dir.name,
+            "timeout_multiplier": 1.0,
+            "agent_timeout_multiplier": None,
+            "verifier_timeout_multiplier": None,
+            "agent_setup_timeout_multiplier": None,
+            "environment_build_timeout_multiplier": None,
+        },
+    )
+    write_json(
+        job_dir / "result.json",
+        {
+            "id": "job-id",
+            "started_at": "2026-06-21T10:00:00Z",
+            "updated_at": "2026-06-21T10:15:30Z",
+            "finished_at": "2026-06-21T10:15:30Z",
+            "n_total_trials": 1,
+            "stats": {
+                "n_completed_trials": 1,
+                "n_errored_trials": 0,
+                "n_running_trials": 0,
+                "n_pending_trials": 0,
+                "n_cancelled_trials": 0,
+                "n_retries": 0,
+            },
+        },
+    )
+    write_json(
+        trial_dir / "result.json",
+        {
+            "task_name": "zstd-decoder",
+            "trial_name": "zstd-decoder__prompt",
+            "source": "terminal-bench-sample",
+            "config": {"agent": agent},
+            "agent_result": {},
+            "verifier_result": {"rewards": {"reward": 0.0}},
+            "exception_info": {},
+        },
+    )
+    prompt_counts = {
+        "quota_should_run": 1,
+        "todo_claim": 1,
+        "status": 1,
+        "todo_update": 1,
+        "refresh_state": 1,
+        "quota_spend": 1,
+    }
+    work_dir = trial_dir / "agent" / "host-codex-goal-fixture"
+    write_json(
+        work_dir / "goal_harness_prompt_driven_trace.public.json",
+        {
+            "schema_version": "goal_harness_prompt_driven_case_trace_v0",
+            "command_count": sum(prompt_counts.values()),
+            "event_kind_counts": prompt_counts,
+            "lifecycle_observed": True,
+            "raw_commands_recorded": False,
+            "raw_output_recorded": False,
+        },
+    )
+    write_json(
+        work_dir / "app_server_goal_turn.compact.json",
+        {
+            "schema_version": "codex_app_server_goal_turn_driver_v0",
+            "first_blocker": "harbor_prompt_polling_round_timeout_before_completion",
+            "goal_harness_prompt_driven_case_cli_call_count": sum(prompt_counts.values()),
+            "goal_harness_prompt_driven_event_counts": prompt_counts,
+            "goal_harness_prompt_driven_lifecycle_observed": True,
+            "strict_goal_harness_treatment_claim_allowed": True,
+            "goal_harness_treatment_claim_blocker": "none",
+        },
+    )
+    return job_dir
+
+
+def assert_prompt_driven_result(payload: dict) -> None:
+    assert payload["worker_bridge_materialization_status"] == "verified", payload
+    assert payload["worker_bridge_materialization_blocker"] == "none", payload
+    assert payload["goal_harness_worker_cli_bridge_trace_observed"] is True, payload
+    assert payload["goal_harness_prompt_driven_lifecycle_observed"] is True, payload
+    assert payload["goal_harness_prompt_driven_case_cli_call_count"] == 6, payload
+    assert payload["worker_goal_harness_cli_call_total"] == 6, payload
+    assert (
+        payload["first_blocker"]
+        == "harbor_prompt_polling_round_timeout_before_completion"
+    ), payload
+    assert payload["strict_goal_harness_treatment_claim_allowed"] is True, payload
+    assert payload["goal_harness_treatment_claim_blocker"] == "none", payload
+    validation = payload["validation"]
+    assert validation["worker_counter_trace_loaded"] is True, validation
+    assert validation["worker_benchmark_run_file_present"] is True, validation
+    assert validation["worker_benchmark_run_schema_ok"] is True, validation
+    assert validation["worker_bridge_materialized_when_required"] is True, validation
+    overhead = payload["overhead_attribution_counters"]
+    assert (
+        overhead["attribution_granularity"]
+        == "prompt_driven_case_local_cli_counts"
+    ), overhead
+    assert overhead["goal_harness_cli_call_total"] == 6, overhead
+    outcome = payload["worker_bridge_outcome"]
+    assert outcome["worker_bridge_verified"] is True, outcome
+    assert outcome["prompt_driven_goal_harness_lifecycle_observed"] is True, outcome
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="goal-harness-prompt-driven-reducer-") as tmp:
+        job_dir = write_prompt_driven_fixture(Path(tmp))
+        payload = build_terminal_bench_harbor_result_benchmark_run(job_dir)
+        assert_prompt_driven_result(payload)
+        compact = compact_benchmark_run(payload)
+        assert compact is not None
+        assert compact["worker_bridge_materialization_status"] == "verified", compact
+        assert compact["goal_harness_prompt_driven_lifecycle_observed"] is True, compact
+        output_path = Path(tmp) / "harbor_job_result.compact.json"
+        subprocess.run(
+            [
+                sys.executable,
+                str(REPO_ROOT / "scripts" / "harbor_job_result_reducer.py"),
+                "--job-dir",
+                str(job_dir),
+                "--benchmark-id",
+                "terminal-bench",
+                "--mode",
+                "codex_goal_harness",
+                "--output-json",
+                str(output_path),
+            ],
+            check=True,
+            stdout=subprocess.DEVNULL,
+        )
+        reduced = json.loads(output_path.read_text(encoding="utf-8"))
+        reduced_compact = reduced["compact_benchmark_run"]
+        assert reduced["ok"] is True, reduced
+        assert (
+            reduced_compact["worker_bridge_materialization_status"] == "verified"
+        ), reduced_compact
+        assert (
+            reduced_compact["first_blocker"]
+            == "harbor_prompt_polling_round_timeout_before_completion"
+        ), reduced_compact
+        assert (
+            reduced_compact["goal_harness_prompt_driven_case_cli_call_count"] == 6
+        ), reduced_compact
+    print("terminal-bench harbor prompt-driven reducer smoke passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/goal_harness/benchmark_adapters/terminal_bench.py
+++ b/goal_harness/benchmark_adapters/terminal_bench.py
@@ -348,6 +348,12 @@ TERMINAL_BENCH_EXTRA_PROBE_PATHS = (
 )
 TERMINAL_BENCH_COUNTER_TRACE_FILE = "goal-harness-counter-trace.jsonl"
 TERMINAL_BENCH_WORKER_BENCHMARK_RUN_FILE = "goal-harness-worker-benchmark-run.json"
+TERMINAL_BENCH_PROMPT_DRIVEN_TRACE_FILE = (
+    "goal_harness_prompt_driven_trace.public.json"
+)
+TERMINAL_BENCH_APP_SERVER_GOAL_TURN_COMPACT_FILE = (
+    "app_server_goal_turn.compact.json"
+)
 TERMINAL_BENCH_DEFAULT_AGENT_TIMEOUT_SECONDS = 900.0
 TERMINAL_BENCH_TRUE_LONG_TASK_BAR_SECONDS = 1800.0
 TERMINAL_BENCH_PREFERRED_HOURS_SCALE_BAR_SECONDS = 3600.0
@@ -4059,6 +4065,142 @@ def _counter_trace_interaction_counters(
     )
     return counters
 
+def _compact_numeric_int_map(value: Any) -> dict[str, int]:
+    if not isinstance(value, dict):
+        return {}
+    compact: dict[str, int] = {}
+    for key, raw in value.items():
+        text = _compact_trace_event_text(key)
+        if (
+            text
+            and isinstance(raw, int)
+            and not isinstance(raw, bool)
+            and raw >= 0
+        ):
+            compact[text] = compact.get(text, 0) + raw
+    return compact
+
+def _non_negative_int(value: Any) -> int:
+    if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+        return value
+    return 0
+
+def _terminal_bench_prompt_driven_goal_harness_observation(
+    job_path: Path,
+) -> dict[str, Any]:
+    """Load public-safe prompt-driven Goal Harness lifecycle evidence."""
+
+    run_root = (
+        job_path.parent.parent
+        if job_path.parent.name == "jobs" and job_path.parent.parent.exists()
+        else job_path.parent
+    )
+    trace_paths: list[Path] = []
+    compact_paths: list[Path] = []
+    seen_paths: set[Path] = set()
+    for path in sorted(job_path.rglob(TERMINAL_BENCH_PROMPT_DRIVEN_TRACE_FILE)):
+        if path.is_file() and path not in seen_paths:
+            trace_paths.append(path)
+            seen_paths.add(path)
+    direct_trace = run_root / TERMINAL_BENCH_PROMPT_DRIVEN_TRACE_FILE
+    if direct_trace.is_file() and direct_trace not in seen_paths:
+        trace_paths.append(direct_trace)
+        seen_paths.add(direct_trace)
+    seen_paths.clear()
+    for path in sorted(job_path.rglob(TERMINAL_BENCH_APP_SERVER_GOAL_TURN_COMPACT_FILE)):
+        if path.is_file() and path not in seen_paths:
+            compact_paths.append(path)
+            seen_paths.add(path)
+    direct_compact = run_root / TERMINAL_BENCH_APP_SERVER_GOAL_TURN_COMPACT_FILE
+    if direct_compact.is_file() and direct_compact not in seen_paths:
+        compact_paths.append(direct_compact)
+        seen_paths.add(direct_compact)
+
+    trace_event_counts: dict[str, int] = {}
+    compact_event_counts: dict[str, int] = {}
+    trace_command_total = 0
+    compact_command_total = 0
+    lifecycle_observed = False
+    first_blocker = "none"
+    treatment_claim_blocker = "none"
+    strict_claim_allowed = False
+    for path in trace_paths:
+        payload = _load_json_object(path)
+        counts = _compact_numeric_int_map(payload.get("event_kind_counts"))
+        _merge_numeric_counts(trace_event_counts, counts)
+        trace_command_total += max(
+            _non_negative_int(payload.get("command_count")),
+            sum(counts.values()),
+        )
+        lifecycle_observed = lifecycle_observed or payload.get(
+            "lifecycle_observed"
+        ) is True
+    for path in compact_paths:
+        payload = _load_json_object(path)
+        counts = _compact_numeric_int_map(
+            payload.get("goal_harness_prompt_driven_event_counts")
+        )
+        _merge_numeric_counts(compact_event_counts, counts)
+        compact_command_total += max(
+            _non_negative_int(
+                payload.get("goal_harness_prompt_driven_case_cli_call_count")
+            ),
+            sum(counts.values()),
+        )
+        lifecycle_observed = lifecycle_observed or payload.get(
+            "goal_harness_prompt_driven_lifecycle_observed"
+        ) is True
+        blocker = _public_safe_benchmark_label(payload.get("first_blocker"))
+        if blocker and blocker != "none" and first_blocker == "none":
+            first_blocker = blocker
+        claim_blocker = _public_safe_benchmark_label(
+            payload.get("goal_harness_treatment_claim_blocker")
+        )
+        if (
+            claim_blocker
+            and claim_blocker != "none"
+            and treatment_claim_blocker == "none"
+        ):
+            treatment_claim_blocker = claim_blocker
+        strict_claim_allowed = strict_claim_allowed or payload.get(
+            "strict_goal_harness_treatment_claim_allowed"
+        ) is True
+
+    event_counts = trace_event_counts if trace_event_counts else compact_event_counts
+    command_count = max(
+        trace_command_total,
+        compact_command_total,
+        sum(event_counts.values()),
+    )
+    if command_count and not event_counts:
+        event_counts = {"prompt_driven_cli_call": command_count}
+    read_commands = {"status", "quota_should_run", "todo_list", "history", "check"}
+    write_commands = {
+        "append_benchmark_run",
+        "todo_claim",
+        "todo_update",
+        "refresh_state",
+        "quota_spend",
+        "spend_slot",
+    }
+    return {
+        "trace_file_count": len(trace_paths),
+        "compact_file_count": len(compact_paths),
+        "trace_observed": bool(command_count),
+        "lifecycle_observed": lifecycle_observed,
+        "command_count": command_count,
+        "event_counts": event_counts,
+        "state_read_count": sum(
+            count for command, count in event_counts.items() if command in read_commands
+        ),
+        "state_write_count": sum(
+            count for command, count in event_counts.items() if command in write_commands
+        ),
+        "first_blocker": first_blocker,
+        "strict_goal_harness_treatment_claim_allowed": strict_claim_allowed,
+        "goal_harness_treatment_claim_blocker": treatment_claim_blocker,
+    }
+
 def _total_from_counter_map(value: Any) -> int:
     if not isinstance(value, dict):
         return 0
@@ -4106,6 +4248,12 @@ def _terminal_bench_overhead_attribution_counters(
     codex_goal_tool_calls = interaction_counters.get("codex_runtime_goal_tool_calls")
     cli_call_total = _total_from_counter_map(cli_calls)
     codex_goal_tool_call_total = _total_from_counter_map(codex_goal_tool_calls)
+    prompt_driven_cli_call_total = _non_negative_int(
+        interaction_counters.get("prompt_driven_goal_harness_cli_call_total")
+    )
+    prompt_driven_trace_observed = (
+        interaction_counters.get("prompt_driven_goal_harness_trace_observed") is True
+    )
     required_cli_call_total = 0
     optional_cli_call_total = 0
     if isinstance(cli_calls, dict):
@@ -4126,6 +4274,11 @@ def _terminal_bench_overhead_attribution_counters(
         attribution_granularity = "coarse_worker_bridge_event_counts"
         worker_step_counter_status = (
             "worker_cli_counter_trace_present_no_phase_breakdown"
+        )
+    elif prompt_driven_trace_observed:
+        attribution_granularity = "prompt_driven_case_local_cli_counts"
+        worker_step_counter_status = (
+            "runner_loaded_prompt_driven_case_local_cli_trace"
         )
     elif codex_goal_tool_call_total:
         attribution_granularity = "codex_runtime_goal_tool_counts_only"
@@ -4166,6 +4319,9 @@ def _terminal_bench_overhead_attribution_counters(
         "trial_count": len(trials),
         "errored_trial_count": errored_trial_count,
         "worker_bridge_event_count": len(trace_rows),
+        "goal_harness_prompt_driven_case_cli_call_count": (
+            prompt_driven_cli_call_total
+        ),
         "worker_counter_trace_trial_count": worker_counter_trace_trial_count,
         "worker_benchmark_run_file_count": worker_benchmark_run_file_count,
         "worker_benchmark_run_schema_ok_count": worker_benchmark_run_schema_ok_count,
@@ -4651,6 +4807,84 @@ def build_terminal_bench_harbor_result_benchmark_run(
         ),
         codex_runtime_goal_tool_calls=codex_runtime_goal_tool_calls,
     )
+    prompt_driven_goal_harness = (
+        _terminal_bench_prompt_driven_goal_harness_observation(job_path)
+    )
+    prompt_driven_cli_total = _non_negative_int(
+        prompt_driven_goal_harness.get("command_count")
+    )
+    prompt_driven_trace_observed = bool(
+        prompt_driven_goal_harness.get("trace_observed")
+    )
+    prompt_driven_lifecycle_observed = bool(
+        prompt_driven_goal_harness.get("lifecycle_observed")
+    )
+    if prompt_driven_cli_total:
+        prompt_driven_calls = (
+            prompt_driven_goal_harness.get("event_counts")
+            if isinstance(prompt_driven_goal_harness.get("event_counts"), dict)
+            else {}
+        )
+        if interaction_counters is None:
+            interaction_counters = build_terminal_bench_goal_harness_interaction_counters(
+                prompt_policy_injected=not baseline_without_goal_harness,
+                harness_skill_or_packet_injected=not baseline_without_goal_harness,
+                goal_harness_cli_calls=prompt_driven_calls,
+                goal_harness_state_reads=_non_negative_int(
+                    prompt_driven_goal_harness.get("state_read_count")
+                ),
+                goal_harness_state_writes=_non_negative_int(
+                    prompt_driven_goal_harness.get("state_write_count")
+                ),
+                case_result_writeback=(
+                    "prompt_driven_goal_harness_lifecycle_observed"
+                    if prompt_driven_lifecycle_observed
+                    else "prompt_driven_goal_harness_cli_calls_only"
+                ),
+                counter_trust_level=(
+                    "runner_loaded_prompt_driven_case_local_cli_trace"
+                ),
+            )
+        else:
+            calls = interaction_counters.get("goal_harness_cli_calls")
+            if not isinstance(calls, dict):
+                calls = {}
+            calls = dict(calls)
+            calls.pop("total", None)
+            _merge_numeric_counts(calls, prompt_driven_calls)
+            calls["total"] = sum(
+                value
+                for value in calls.values()
+                if isinstance(value, int) and not isinstance(value, bool)
+            )
+            interaction_counters["goal_harness_cli_calls"] = calls
+            interaction_counters["goal_harness_state_reads"] = _non_negative_int(
+                interaction_counters.get("goal_harness_state_reads")
+            ) + _non_negative_int(prompt_driven_goal_harness.get("state_read_count"))
+            interaction_counters["goal_harness_state_writes"] = _non_negative_int(
+                interaction_counters.get("goal_harness_state_writes")
+            ) + _non_negative_int(prompt_driven_goal_harness.get("state_write_count"))
+            interaction_counters["case_result_writeback"] = (
+                "prompt_driven_goal_harness_lifecycle_observed"
+                if prompt_driven_lifecycle_observed
+                else interaction_counters.get("case_result_writeback")
+                or "prompt_driven_goal_harness_cli_calls_only"
+            )
+            trust = str(interaction_counters.get("counter_trust_level") or "")
+            interaction_counters["counter_trust_level"] = (
+                f"{trust}+prompt_driven_case_local_cli_trace"
+                if trust
+                else "runner_loaded_prompt_driven_case_local_cli_trace"
+            )
+        interaction_counters["prompt_driven_goal_harness_trace_observed"] = (
+            prompt_driven_trace_observed
+        )
+        interaction_counters["prompt_driven_goal_harness_lifecycle_observed"] = (
+            prompt_driven_lifecycle_observed
+        )
+        interaction_counters["prompt_driven_goal_harness_cli_call_total"] = (
+            prompt_driven_cli_total
+        )
     worker_cli_total = 0
     if interaction_counters:
         interaction_counters["worker_counter_trace_trial_count"] = (
@@ -4763,14 +4997,20 @@ def build_terminal_bench_harbor_result_benchmark_run(
         interaction_counters["worker_submit_eligible_mismatch_reason"] = (
             worker_submit_eligible_mismatch_reason
         )
+    worker_bridge_trace_observed = bool(trace_rows) or prompt_driven_trace_observed
+    prompt_driven_bridge_verified = bool(
+        prompt_driven_lifecycle_observed
+        and prompt_driven_cli_total >= required_worker_cli_call_min
+    )
     worker_bridge_verified = bool(
-        trace_rows and worker_cli_total >= required_worker_cli_call_min
+        (trace_rows and worker_cli_total >= required_worker_cli_call_min)
+        or prompt_driven_bridge_verified
     )
     worker_bridge_failure_attribution = "none"
     if not worker_bridge_required:
         worker_bridge_materialization_status = "not_required"
         worker_bridge_materialization_blocker = "none"
-    elif not trace_rows and worker_benchmark_run_file_count == 0:
+    elif not worker_bridge_trace_observed and worker_benchmark_run_file_count == 0:
         if environment_setup_failure_before_worker_count:
             worker_bridge_materialization_status = (
                 "environment_setup_failed_before_worker"
@@ -4797,6 +5037,15 @@ def build_terminal_bench_harbor_result_benchmark_run(
             worker_bridge_materialization_status = "not_materialized"
             worker_bridge_materialization_blocker = "worker_bridge_not_materialized"
         worker_bridge_failure_attribution = worker_bridge_materialization_blocker
+    elif prompt_driven_trace_observed and not prompt_driven_lifecycle_observed:
+        worker_bridge_materialization_status = "prompt_driven_lifecycle_incomplete"
+        worker_bridge_materialization_blocker = (
+            "prompt_driven_goal_harness_lifecycle_absent"
+        )
+        worker_bridge_failure_attribution = worker_bridge_materialization_blocker
+    elif prompt_driven_bridge_verified:
+        worker_bridge_materialization_status = "verified"
+        worker_bridge_materialization_blocker = "none"
     elif trace_rows and worker_benchmark_run_file_count == 0:
         worker_bridge_materialization_status = "trace_without_writeback"
         worker_bridge_materialization_blocker = "worker_bridge_writeback_missing"
@@ -4959,12 +5208,17 @@ def build_terminal_bench_harbor_result_benchmark_run(
         ),
         "runner_completed_or_exception_recorded": bool(job_result.get("finished_at"))
         or bool(agent_timeout_observed),
-        "worker_counter_trace_loaded": (not worker_bridge_required) or bool(trace_rows),
+        "worker_counter_trace_loaded": (
+            (not worker_bridge_required) or worker_bridge_trace_observed
+        ),
         "worker_benchmark_run_file_present": (
-            (not worker_bridge_required) or worker_benchmark_run_written
+            (not worker_bridge_required)
+            or worker_benchmark_run_written
+            or prompt_driven_lifecycle_observed
         ),
         "worker_benchmark_run_schema_ok": (
             (not worker_bridge_required)
+            or prompt_driven_lifecycle_observed
             or (
                 worker_benchmark_run_file_count > 0
                 and worker_benchmark_run_schema_ok_count == worker_benchmark_run_file_count
@@ -5015,6 +5269,10 @@ def build_terminal_bench_harbor_result_benchmark_run(
         "trial:agent/goal-harness-counter-trace.jsonl",
         "trial:agent/goal-harness-worker-benchmark-run.json",
         "trial:agent/goal-harness-worker-setup-diagnostic.json",
+        "trial:agent/goal_harness_prompt_driven_trace.public.json",
+        "trial:agent/app_server_goal_turn.compact.json",
+        "run:goal_harness_prompt_driven_trace.public.json",
+        "run:app_server_goal_turn.compact.json",
         "trial:verifier/reward.txt",
         "trial:artifacts/manifest.json",
     ]
@@ -5064,6 +5322,42 @@ def build_terminal_bench_harbor_result_benchmark_run(
         if official_score is not None
         else {"kind": "harbor_verifier_reward_missing"}
     )
+    prompt_driven_claim_blocker = "none"
+    if not prompt_driven_lifecycle_observed and worker_bridge_required:
+        raw_claim_blocker = prompt_driven_goal_harness.get(
+            "goal_harness_treatment_claim_blocker"
+        )
+        prompt_driven_claim_blocker = (
+            raw_claim_blocker if isinstance(raw_claim_blocker, str) else ""
+        ) or "prompt_driven_goal_harness_lifecycle_absent"
+        if prompt_driven_claim_blocker in {"", "none"}:
+            prompt_driven_claim_blocker = (
+                "prompt_driven_goal_harness_lifecycle_absent"
+            )
+    prompt_driven_evidence_tier = "not_applicable"
+    if worker_bridge_required:
+        prompt_driven_evidence_tier = (
+            "prompt_driven_case_local_goal_harness_cli_lifecycle"
+            if prompt_driven_lifecycle_observed
+            else "prompt_driven_case_local_goal_harness_cli_not_observed"
+        )
+    strict_goal_harness_treatment_claim_allowed = bool(
+        prompt_driven_lifecycle_observed
+        or prompt_driven_goal_harness.get(
+            "strict_goal_harness_treatment_claim_allowed"
+        )
+        is True
+    )
+    raw_prompt_driven_first_blocker = prompt_driven_goal_harness.get(
+        "first_blocker"
+    )
+    prompt_driven_first_blocker = (
+        raw_prompt_driven_first_blocker
+        if isinstance(raw_prompt_driven_first_blocker, str)
+        else ""
+    )
+    if prompt_driven_first_blocker in {"", "none"}:
+        prompt_driven_first_blocker = ""
     payload = {
         "schema_version": "benchmark_run_v0",
         "source_runner": payload_source_runner,
@@ -5129,7 +5423,34 @@ def build_terminal_bench_harbor_result_benchmark_run(
         "goal_harness_worker_cli_bridge_available": bool(
             worker_bridge_required
         ),
-        "goal_harness_worker_cli_bridge_trace_observed": bool(trace_rows),
+        "goal_harness_worker_cli_bridge_trace_observed": (
+            worker_bridge_trace_observed
+        ),
+        "goal_harness_prompt_driven_trace_observed": (
+            prompt_driven_trace_observed
+        ),
+        "goal_harness_prompt_driven_lifecycle_observed": (
+            prompt_driven_lifecycle_observed
+        ),
+        "goal_harness_prompt_driven_case_cli_call_count": (
+            prompt_driven_cli_total
+        ),
+        "goal_harness_prompt_driven_event_counts": (
+            prompt_driven_goal_harness.get("event_counts")
+            if isinstance(prompt_driven_goal_harness.get("event_counts"), dict)
+            else {}
+        ),
+        "goal_harness_prompt_driven_trace_file_count": _non_negative_int(
+            prompt_driven_goal_harness.get("trace_file_count")
+        ),
+        "goal_harness_prompt_driven_compact_file_count": _non_negative_int(
+            prompt_driven_goal_harness.get("compact_file_count")
+        ),
+        "strict_goal_harness_treatment_claim_allowed": (
+            strict_goal_harness_treatment_claim_allowed
+        ),
+        "goal_harness_treatment_claim_blocker": prompt_driven_claim_blocker,
+        "goal_harness_treatment_evidence_tier": prompt_driven_evidence_tier,
         "worker_goal_harness_cli_call_total": worker_cli_total,
         "worker_counter_trace_trial_count": worker_counter_trace_trial_count,
         "worker_benchmark_run_file_count": worker_benchmark_run_file_count,
@@ -5162,6 +5483,8 @@ def build_terminal_bench_harbor_result_benchmark_run(
         "worker_bridge_failure_attribution": worker_bridge_failure_attribution,
         "first_blocker": worker_bridge_materialization_blocker
         if worker_bridge_materialization_blocker != "none"
+        else prompt_driven_first_blocker
+        if prompt_driven_first_blocker
         else None,
         "repeat_blocked_by": repeat_blocked_by,
         "pre_worker_startup_blocker": (
@@ -5262,6 +5585,15 @@ def build_terminal_bench_harbor_result_benchmark_run(
                 else "compare observed runner result against Goal Harness treatment under the same no-upload boundary"
             ),
             "worker_bridge_verified": worker_bridge_verified,
+            "prompt_driven_goal_harness_trace_observed": (
+                prompt_driven_trace_observed
+            ),
+            "prompt_driven_goal_harness_lifecycle_observed": (
+                prompt_driven_lifecycle_observed
+            ),
+            "goal_harness_prompt_driven_case_cli_call_count": (
+                prompt_driven_cli_total
+            ),
             "worker_materialization_probe_only": worker_materialization_probe_only,
             "worker_materialization_probe_contract_present": (
                 worker_materialization_probe_contract_present
@@ -5278,6 +5610,7 @@ def build_terminal_bench_harbor_result_benchmark_run(
             "worker_bridge_materialization_status": worker_bridge_materialization_status,
             "worker_bridge_materialization_blocker": worker_bridge_materialization_blocker,
             "worker_bridge_failure_attribution": worker_bridge_failure_attribution,
+            "prompt_driven_first_blocker": prompt_driven_first_blocker or "none",
             "repeat_blocked_by": repeat_blocked_by,
             "pre_worker_startup_blocker": (
                 worker_bridge_materialization_blocker

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -768,6 +768,7 @@ def _compact_benchmark_overhead_attribution_counters(value: Any) -> dict[str, An
         "trial_count",
         "errored_trial_count",
         "worker_bridge_event_count",
+        "goal_harness_prompt_driven_case_cli_call_count",
         "worker_counter_trace_trial_count",
         "worker_benchmark_run_file_count",
         "worker_benchmark_run_schema_ok_count",
@@ -1624,6 +1625,7 @@ def _compact_worker_bridge_outcome(value: Any) -> dict[str, Any]:
         "worker_bridge_materialization_status",
         "worker_bridge_materialization_blocker",
         "worker_bridge_failure_attribution",
+        "prompt_driven_first_blocker",
         "repeat_blocked_by",
         "pre_worker_startup_blocker",
     ):
@@ -1632,6 +1634,8 @@ def _compact_worker_bridge_outcome(value: Any) -> dict[str, Any]:
             compact[field] = text
     for field in (
         "worker_bridge_verified",
+        "prompt_driven_goal_harness_trace_observed",
+        "prompt_driven_goal_harness_lifecycle_observed",
         "counter_trace_present",
         "runner_return_completed",
         "official_score_completed",
@@ -1647,6 +1651,7 @@ def _compact_worker_bridge_outcome(value: Any) -> dict[str, Any]:
             compact[field] = value[field]
     for field in (
         "worker_goal_harness_cli_call_total",
+        "goal_harness_prompt_driven_case_cli_call_count",
         "required_worker_goal_harness_cli_call_total_min",
         "worker_self_validation_official_score_mismatch_count",
         "worker_validation_scope_ambiguous_official_score_failure_count",
@@ -1904,6 +1909,8 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
         "goal_harness_cli_bridge_trace_observed",
         "goal_harness_worker_cli_bridge_available",
         "goal_harness_worker_cli_bridge_trace_observed",
+        "goal_harness_prompt_driven_trace_observed",
+        "goal_harness_prompt_driven_lifecycle_observed",
         "assisted_collaboration_claim_allowed",
         "official_score_claim_allowed",
         "bridge_connectivity_claim_allowed",
@@ -1932,6 +1939,9 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
     for field in (
         "runner_goal_harness_cli_call_total",
         "worker_goal_harness_cli_call_total",
+        "goal_harness_prompt_driven_case_cli_call_count",
+        "goal_harness_prompt_driven_trace_file_count",
+        "goal_harness_prompt_driven_compact_file_count",
         "worker_counter_trace_trial_count",
         "worker_benchmark_run_file_count",
         "worker_benchmark_run_schema_ok_count",
@@ -1965,6 +1975,10 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
     ):
         if isinstance(source.get(field), int) and not isinstance(source.get(field), bool):
             compact[field] = source.get(field)
+    for field in ("goal_harness_prompt_driven_event_counts",):
+        calls = _compact_numeric_map(source.get(field))
+        if calls:
+            compact[field] = calls
     loop_contract = source.get("benchmark_loop_contract")
     if isinstance(loop_contract, dict):
         compact_loop_contract: dict[str, Any] = {}


### PR DESCRIPTION
## Summary
- ingest public-safe prompt-driven Goal Harness lifecycle compact files in the Harbor result reducer
- treat prompt-driven case-local GH CLI lifecycle proof as worker bridge materialization evidence
- expose prompt-driven lifecycle counts through compact benchmark status and add a focused reducer smoke

## Validation
- python examples/terminal-bench-harbor-prompt-driven-reducer-smoke.py
- python examples/terminal-bench-harbor-runner-ingest-smoke.py
- python examples/benchmark-case-active-state-contract-smoke.py
- python examples/benchmark-run-ledger-smoke.py
- python examples/benchmark-case-analysis-smoke.py
- python examples/worker-bridge-benchmark-run-ingest-smoke.py
- python -m py_compile goal_harness/benchmark_adapters/terminal_bench.py goal_harness/status.py examples/terminal-bench-harbor-prompt-driven-reducer-smoke.py
- git diff --check
- goal-harness --format json check --scan-path goal_harness/benchmark_adapters/terminal_bench.py --scan-path goal_harness/status.py --scan-path examples/terminal-bench-harbor-prompt-driven-reducer-smoke.py