### PR TITLE
Define task graph projection contract

### DIFF
--- a/docs/reference/protocols/README.md
+++ b/docs/reference/protocols/README.md
@@ -8,3 +8,4 @@ Current contracts:
 - [Action packet decision v0](protocol-action-packet-decision-v0.md)
 - [Codex CLI wrapper action packet v0](protocol-action-packet-codex-cli-wrapper-v0.md)
 - [Action packet router comparison v0](protocol-action-packet-router-comparison-v0.md)
+- [task_graph_projection_v0](task-graph-projection-v0.md)

--- a/docs/reference/protocols/task-graph-projection-v0.md
+++ b/docs/reference/protocols/task-graph-projection-v0.md
@@ -1,0 +1,127 @@
+# task_graph_projection_v0
+
+`task_graph_projection_v0` is an optional read-only graph view over existing
+Goal Harness state. It helps agents and operators see dependency, gate,
+validation, repair, and handoff relationships without creating a second task
+store.
+
+The source of truth remains:
+
+- the append-only event ledger and compact run indexes;
+- the active goal state and its todos;
+- operator gates and user todos;
+- leases or todo claims;
+- quota and status projections;
+- run-history evidence and blocker writebacks.
+
+The projection may appear under `attention_queue.items[].task_graph_projection`
+in `goal-harness --format json status`. Full
+`goal-harness --format json review-packet --goal-id <goal-id>` output may
+include the same object for operator review. The handoff-only review-packet
+surface should stay compact and omit the graph unless a future interface budget
+explicitly allows it.
+
+## Shape
+
+```json
+{
+  "schema_version": "task_graph_projection_v0",
+  "mode": "read_only",
+  "goal_id": "goal-harness-meta",
+  "generated_at": "2026-06-21T12:00:00Z",
+  "derived_from": {
+    "source_of_truth": [
+      "event_ledger",
+      "active_goal_state",
+      "todos",
+      "gates",
+      "leases",
+      "run_history"
+    ],
+    "status_item_goal_id": "goal-harness-meta",
+    "active_state_updated_at": "2026-06-21T11:55:00Z",
+    "run_history_window": "compact_latest_runs"
+  },
+  "truth_contract": {
+    "event_ledger_is_source_of_truth": true,
+    "projection_is_writable": false,
+    "write_api": false,
+    "recompute_rule": "Recompute from status, active state, gates, leases, and run history after each lifecycle event."
+  },
+  "nodes": [],
+  "edges": []
+}
+```
+
+## Nodes
+
+Each node must be compact and must point back to durable Goal Harness ids.
+Allowed `kind` values are:
+
+- `deliverable`: a todo-backed artifact or implementation step;
+- `gate`: a user, owner, or operator decision point;
+- `lease`: an active claim or worker ownership signal;
+- `validation`: a smoke, check, CI result, or review proof;
+- `repair`: a self-repair or blocker-recovery step;
+- `handoff`: a transition from one agent or surface to another;
+- `evidence`: a compact run-history evidence item.
+
+Required node fields:
+
+- `node_id`: stable inside this projection;
+- `kind`;
+- `title`;
+- `state`: one of `open`, `ready`, `blocked`, `done`, `waiting`, or `unknown`;
+- `refs`: compact references such as `todo_ids`, `gate_ids`, `lease_ids`,
+  `run_ids`, or `review_packet_ids`.
+
+Nodes must not copy raw task text, transcripts, logs, credentials, private file
+paths, or large run artifacts. They should summarize only the relationship
+needed for dispatch or review.
+
+## Edges
+
+Edges describe why one node affects another. Allowed `relation` values are:
+
+- `depends_on`;
+- `blocks`;
+- `validates`;
+- `repairs`;
+- `hands_off_to`;
+- `supersedes`.
+
+Each edge must name `from_node_id`, `to_node_id`, `relation`, and a compact
+public-safe `reason`. Edges may carry the same compact `refs` object as nodes.
+An edge does not grant permission to run a command or mutate state.
+
+## Write Boundary
+
+`task_graph_projection_v0` has no write authority. It must never expose a graph
+write command, browser write affordance, hidden scheduler, or alternate lease
+store. State changes continue through existing Goal Harness lifecycle commands:
+
+- `goal-harness todo ...`;
+- `goal-harness operator-gate ...`;
+- `goal-harness reward ...`;
+- `goal-harness refresh-state ...`;
+- `goal-harness quota spend-slot ...`;
+- future server/MCP write APIs that preserve the same event-ledger semantics.
+
+Consumers should treat the graph as stale after any lifecycle event until it is
+recomputed from the current status and run-history window.
+
+## Acceptance Checks
+
+A valid public fixture or implementation must prove:
+
+- `schema_version` is exactly `task_graph_projection_v0`;
+- `mode` is `read_only`;
+- `truth_contract.projection_is_writable=false`;
+- `truth_contract.write_api=false`;
+- every node id is unique;
+- every edge endpoint references an existing node;
+- every node and edge references existing Goal Harness ids rather than raw
+  private material;
+- no local absolute paths, credentials, raw transcripts, or raw logs are
+  projected;
+- status/review-packet consumers can safely ignore the field when absent.

--- a/docs/state-interaction-model.md
+++ b/docs/state-interaction-model.md
@@ -521,7 +521,9 @@ worker may resume.
 The first implementation should be read-mostly: expose an optional compact
 `task_graph_projection_v0` from status or review packets, backed by existing
 todo ids, gate ids, run ids, and lease ids. Writes should continue through the
-existing lifecycle commands until a server-backed lease/graph API exists.
+existing lifecycle commands until a server-backed lease/graph API exists. The
+initial protocol and public fixture live in
+[`docs/reference/protocols/task-graph-projection-v0.md`](reference/protocols/task-graph-projection-v0.md).
 
 Old user decisions need freshness checks. A reward, steering note, or approval
 from seven days ago can remain valuable, but a worker should apply it only after

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -48,6 +48,16 @@ truth contract. It is not a write API. Dashboards may render it as a channel
 card or timeline, but project truth still comes from the registry, active
 state, quota guard, and append-only run history.
 
+Rows may also include an optional `task_graph_projection` object with
+`schema_version=task_graph_projection_v0`. This is a compact graph-shaped view
+over existing todos, gates, leases, run ids, and event-ledger state. It is
+read-only and exists only to show dependency, validation, repair, and handoff
+relationships that are hard to scan in a flat todo list. It must not introduce a
+second scheduler, graph write API, hidden lease store, or alternate task truth.
+The protocol is defined in
+[`docs/reference/protocols/task-graph-projection-v0.md`](reference/protocols/task-graph-projection-v0.md);
+consumers should ignore the field when absent.
+
 Loopback status exports include `status_contract.schema_version`. The dashboard
 uses that small protocol marker to detect when `127.0.0.1:8766` is still served
 by an older daemon or release snapshot after the checkout has moved forward. If

--- a/examples/fixtures/task-graph-projection-status.public.json
+++ b/examples/fixtures/task-graph-projection-status.public.json
@@ -1,0 +1,142 @@
+{
+  "fixture": "task_graph_projection_status_public_v0",
+  "ok": true,
+  "status_contract": {
+    "schema_version": 2,
+    "minimum_dashboard_schema_version": 2,
+    "producer": "goal-harness status"
+  },
+  "attention_queue": {
+    "available": true,
+    "item_count": 1,
+    "items": [
+      {
+        "goal_id": "goal-harness-meta",
+        "status": "active",
+        "waiting_on": "codex",
+        "severity": "action",
+        "recommended_action": "Review task graph projection shape before implementation.",
+        "task_graph_projection": {
+          "schema_version": "task_graph_projection_v0",
+          "mode": "read_only",
+          "goal_id": "goal-harness-meta",
+          "generated_at": "2026-06-21T12:00:00Z",
+          "derived_from": {
+            "source_of_truth": [
+              "event_ledger",
+              "active_goal_state",
+              "todos",
+              "gates",
+              "leases",
+              "run_history"
+            ],
+            "status_item_goal_id": "goal-harness-meta",
+            "active_state_updated_at": "2026-06-21T11:55:00Z",
+            "run_history_window": "compact_latest_runs"
+          },
+          "truth_contract": {
+            "event_ledger_is_source_of_truth": true,
+            "projection_is_writable": false,
+            "write_api": false,
+            "recompute_rule": "Recompute from status, active state, gates, leases, and run history after each lifecycle event."
+          },
+          "nodes": [
+            {
+              "node_id": "node_operator_gate_clear",
+              "kind": "gate",
+              "title": "Owner gate already clear for public fixture design.",
+              "state": "done",
+              "refs": {
+                "gate_ids": [
+                  "gate_public_fixture_design"
+                ],
+                "run_ids": [
+                  "run_operator_gate_approved"
+                ]
+              }
+            },
+            {
+              "node_id": "node_design_contract",
+              "kind": "deliverable",
+              "title": "Define task_graph_projection_v0 as a read-only derived contract.",
+              "state": "open",
+              "refs": {
+                "todo_ids": [
+                  "todo_8e138e5a1cc1"
+                ]
+              },
+              "owner_agent": "codex-side-bypass"
+            },
+            {
+              "node_id": "node_fixture_validation",
+              "kind": "validation",
+              "title": "Validate one public status fixture before runtime implementation.",
+              "state": "ready",
+              "refs": {
+                "todo_ids": [
+                  "todo_8e138e5a1cc1"
+                ],
+                "run_ids": [
+                  "run_task_graph_fixture_smoke"
+                ]
+              }
+            },
+            {
+              "node_id": "node_primary_review_handoff",
+              "kind": "handoff",
+              "title": "Primary agent reviews runtime implementation only after fixture contract is stable.",
+              "state": "waiting",
+              "refs": {
+                "lease_ids": [
+                  "lease_codex_main_control"
+                ],
+                "review_packet_ids": [
+                  "review_packet_task_graph_projection_v0"
+                ]
+              },
+              "owner_agent": "codex-main-control"
+            }
+          ],
+          "edges": [
+            {
+              "edge_id": "edge_gate_allows_design",
+              "from_node_id": "node_operator_gate_clear",
+              "to_node_id": "node_design_contract",
+              "relation": "blocks",
+              "reason": "If the owner gate were open, the design contract would wait.",
+              "refs": {
+                "gate_ids": [
+                  "gate_public_fixture_design"
+                ]
+              }
+            },
+            {
+              "edge_id": "edge_design_validated_by_fixture",
+              "from_node_id": "node_fixture_validation",
+              "to_node_id": "node_design_contract",
+              "relation": "validates",
+              "reason": "The smoke fixture proves the compact graph shape before implementation.",
+              "refs": {
+                "run_ids": [
+                  "run_task_graph_fixture_smoke"
+                ]
+              }
+            },
+            {
+              "edge_id": "edge_fixture_hands_off_to_primary",
+              "from_node_id": "node_fixture_validation",
+              "to_node_id": "node_primary_review_handoff",
+              "relation": "hands_off_to",
+              "reason": "Runtime implementation should wait until the design fixture is reviewed or merged.",
+              "refs": {
+                "review_packet_ids": [
+                  "review_packet_task_graph_projection_v0"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/examples/task-graph-projection-fixture-smoke.py
+++ b/examples/task-graph-projection-fixture-smoke.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Smoke-test the public task_graph_projection_v0 fixture and contract."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_PATH = REPO_ROOT / "examples/fixtures/task-graph-projection-status.public.json"
+CONTRACT_PATH = REPO_ROOT / "docs/reference/protocols/task-graph-projection-v0.md"
+STATUS_CONTRACT_PATH = REPO_ROOT / "docs/status-data-contract.md"
+PROTOCOL_INDEX_PATH = REPO_ROOT / "docs/reference/protocols/README.md"
+STATE_MODEL_PATH = REPO_ROOT / "docs/state-interaction-model.md"
+
+ALLOWED_NODE_KINDS = {
+    "deliverable",
+    "gate",
+    "lease",
+    "validation",
+    "repair",
+    "handoff",
+    "evidence",
+}
+ALLOWED_NODE_STATES = {"open", "ready", "blocked", "done", "waiting", "unknown"}
+ALLOWED_EDGE_RELATIONS = {
+    "depends_on",
+    "blocks",
+    "validates",
+    "repairs",
+    "hands_off_to",
+    "supersedes",
+}
+ALLOWED_REF_KEYS = {
+    "todo_ids",
+    "gate_ids",
+    "lease_ids",
+    "run_ids",
+    "review_packet_ids",
+}
+SOURCE_OF_TRUTH = {
+    "event_ledger",
+    "active_goal_state",
+    "todos",
+    "gates",
+    "leases",
+    "run_history",
+}
+PRIVATE_PATTERNS = [
+    re.compile(r"/Users/[A-Za-z0-9._-]+/"),
+    re.compile(r"/home/[A-Za-z0-9._-]+/"),
+    re.compile(r"/private/"),
+    re.compile(r"[A-Za-z]:\\\\Users\\\\"),
+    re.compile(r"\bBearer\s+[A-Za-z0-9._-]+"),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+]
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def assert_contains(text: str, needle: str, label: str) -> None:
+    if needle not in text:
+        raise AssertionError(f"{label} missing {needle!r}")
+
+
+def assert_public_safe(text: str, label: str) -> None:
+    for pattern in PRIVATE_PATTERNS:
+        if pattern.search(text):
+            raise AssertionError(f"{label} matched private pattern {pattern.pattern!r}")
+
+
+def assert_refs(refs: object, label: str) -> None:
+    assert isinstance(refs, dict) and refs, (label, refs)
+    unknown = set(refs) - ALLOWED_REF_KEYS
+    assert not unknown, (label, unknown)
+    for key, values in refs.items():
+        assert isinstance(values, list) and values, (label, key, values)
+        for value in values:
+            assert isinstance(value, str) and value, (label, key, value)
+            assert not value.startswith("/"), (label, key, value)
+
+
+def main() -> int:
+    fixture_text = read(FIXTURE_PATH)
+    contract = read(CONTRACT_PATH)
+    status_contract = read(STATUS_CONTRACT_PATH)
+    protocol_index = read(PROTOCOL_INDEX_PATH)
+    state_model = read(STATE_MODEL_PATH)
+
+    for label, text in {
+        "fixture": fixture_text,
+        "contract": contract,
+        "status contract": status_contract,
+    }.items():
+        assert_public_safe(text, label)
+
+    for needle in [
+        "attention_queue.items[].task_graph_projection",
+        "goal-harness --format json review-packet --goal-id <goal-id>",
+        "event ledger",
+        "active goal state",
+        "projection_is_writable=false",
+        "write_api=false",
+        "todo_ids",
+        "gate_ids",
+        "lease_ids",
+        "run_ids",
+    ]:
+        assert_contains(contract, needle, "contract")
+
+    assert_contains(status_contract, "task_graph_projection_v0", "status contract")
+    assert_contains(protocol_index, "task_graph_projection_v0", "protocol index")
+    assert_contains(state_model, "task-graph-projection-v0.md", "state model")
+
+    payload = json.loads(fixture_text)
+    item = payload["attention_queue"]["items"][0]
+    projection = item["task_graph_projection"]
+
+    assert projection["schema_version"] == "task_graph_projection_v0", projection
+    assert projection["mode"] == "read_only", projection
+    assert projection["goal_id"] == item["goal_id"], projection
+    assert set(projection["derived_from"]["source_of_truth"]) == SOURCE_OF_TRUTH, projection
+    truth = projection["truth_contract"]
+    assert truth["event_ledger_is_source_of_truth"] is True, truth
+    assert truth["projection_is_writable"] is False, truth
+    assert truth["write_api"] is False, truth
+
+    nodes = projection["nodes"]
+    edges = projection["edges"]
+    assert isinstance(nodes, list) and len(nodes) >= 4, nodes
+    assert isinstance(edges, list) and len(edges) >= 3, edges
+    node_ids = [node["node_id"] for node in nodes]
+    assert len(node_ids) == len(set(node_ids)), node_ids
+    node_id_set = set(node_ids)
+
+    for node in nodes:
+        assert node["kind"] in ALLOWED_NODE_KINDS, node
+        assert node["state"] in ALLOWED_NODE_STATES, node
+        assert isinstance(node["title"], str) and node["title"], node
+        assert_refs(node.get("refs"), f"node {node['node_id']}")
+
+    for edge in edges:
+        assert edge["relation"] in ALLOWED_EDGE_RELATIONS, edge
+        assert edge["from_node_id"] in node_id_set, edge
+        assert edge["to_node_id"] in node_id_set, edge
+        assert edge["from_node_id"] != edge["to_node_id"], edge
+        assert isinstance(edge["reason"], str) and edge["reason"], edge
+        if "refs" in edge:
+            assert_refs(edge["refs"], f"edge {edge['edge_id']}")
+
+    forbidden_keys = {"write_command", "agent_command", "raw_log", "raw_transcript"}
+    fixture_keys = set(json.dumps(payload, sort_keys=True).split('"'))
+    assert not (fixture_keys & forbidden_keys), fixture_keys & forbidden_keys
+
+    print("task-graph-projection-fixture-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- define task_graph_projection_v0 as a read-only derived status/review-packet graph over existing todos, gates, leases, run ids, and event-ledger state
- add one public-safe status fixture for the projection before runtime implementation
- add a focused fixture smoke and link the protocol from the status/state docs

## Validation
- python3 examples/task-graph-projection-fixture-smoke.py
- python3 examples/docs-governance-smoke.py
- python3 -m py_compile examples/task-graph-projection-fixture-smoke.py
- goal-harness check --scan-path docs/reference/protocols/task-graph-projection-v0.md --scan-path docs/reference/protocols/README.md --scan-path docs/status-data-contract.md --scan-path docs/state-interaction-model.md --scan-path examples/fixtures/task-graph-projection-status.public.json --scan-path examples/task-graph-projection-fixture-smoke.py
- git diff --check origin/main..HEAD

## Boundary
- docs/examples only; no runtime status or review-packet implementation yet
- no local state, raw run history, private paths, credentials, transcripts, or generated logs included
- goal-harness check reports only the existing duplicate-index warning; public boundary scan is clean