### PR TITLE
Refine long-task cadence policy

### DIFF
--- a/docs/long-task-cadence-policy.md
+++ b/docs/long-task-cadence-policy.md
@@ -38,10 +38,19 @@ should usually deliver code/docs plus validation/writeback, not a small status
 mutation. Interactive UI sessions can present `medium` as a friendlier default
 while still letting advanced users opt into `long` or `ultra-long`.
 
+Preset selection should be explicit in product surfaces:
+
+- connected autonomous goals default to `long`;
+- visible TUI sessions default to `medium` unless the user installs a recurring
+  goal loop;
+- diagnosis, PR review, and gate-heavy work should use `short`;
+- `ultra-long` requires an explicit user/controller opt-in and a current
+  boundary contract that allows the larger segment.
+
 ## Signals
 
 The policy should be based on public-safe control-plane signals, not raw
-conversation transcripts:
+conversation transcripts or raw local logs:
 
 - `delivery_batch_scale`: whether recent turns were `single_surface`,
   `multi_surface`, or `implementation`;
@@ -49,12 +58,48 @@ conversation transcripts:
   `outcome_progress`, a blocker, or monitor-only status;
 - small-step streak: consecutive eligible turns that did not produce an
   implementation, durable design, validated evidence, or blocker;
+- compact turn duration: scheduler-visible elapsed minutes for a completed
+  turn, rounded or bucketed so it does not expose transcripts or local logs;
+- progress granularity: a compact enum such as `status_only`,
+  `single_surface`, `multi_surface`, `implementation_plus_validation`, or
+  `milestone`;
 - validation/writeback ratio: whether artifacts are routinely validated and
   reflected into active state/history;
 - user-gate projection: whether a higher-priority blocked item is surfaced
   while lower-priority safe work continues;
 - interface-budget cadence: whether status surfaces remain fresh without
   turning freshness checks into the main work.
+
+## Too-Small Batch Detection
+
+Each completed eligible heartbeat can contribute one compact sample:
+
+```json
+{
+  "turn_duration_minutes": 11,
+  "progress_granularity": "single_surface",
+  "delivery_batch_scale": "single_surface",
+  "delivery_outcome": "surface_only",
+  "validated_artifact": false,
+  "state_writeback": true
+}
+```
+
+The controller should mark `too_small_heartbeat_batch=true` only when all of
+these are true:
+
+- the goal was eligible and no user/controller gate blocked the selected path;
+- the same preset and boundary contract still apply;
+- the recent streak is below the preset's minimum segment;
+- the turn did not write a hard blocker explaining why widening was unsafe.
+
+For the default `long` preset, the minimum useful batch is
+`implementation_plus_validation_writeback`: one coherent artifact, targeted
+validation, and Goal Harness writeback. A docs-only batch can still satisfy
+`long` when the selected todo is a durable design contract and the matching
+smoke or public boundary check passes. Status-only refreshes, repeated brief
+checks, and unvalidated single-surface edits should increment the too-small
+streak.
 
 ## Controller Behavior
 
@@ -76,17 +121,29 @@ If the selected action requires a write scope that is missing from
 repair or a concrete user/controller gate. Cadence widening must not paper over
 a stale checkpointed decision.
 
+When `too_small_heartbeat_batch=true`, the next eligible turn should widen or
+write a blocker. It should not spend another quota slot on a pure status
+mutation unless the quota guard says monitor-only quiet skip or a user gate is
+the actual state.
+
 ## Public Fields
 
 A future status/quota projection can carry these compact fields:
 
 ```json
 {
-  "cadence_preset": "long",
-  "small_step_streak": 2,
-  "recommended_batch_granularity": "implementation_plus_validation_writeback",
-  "widen_next_turn": true,
-  "blocked_priority_fallback_visible": true
+  "long_task_cadence": {
+    "schema_version": "long_task_cadence_policy_v0",
+    "cadence_preset": "long",
+    "preset_source": "connected_autonomous_default",
+    "turn_duration_minutes": 11,
+    "progress_granularity": "single_surface",
+    "small_step_streak": 2,
+    "too_small_heartbeat_batch": true,
+    "recommended_batch_granularity": "implementation_plus_validation_writeback",
+    "widen_next_turn": true,
+    "blocked_priority_fallback_visible": true
+  }
 }
 ```
 
@@ -103,3 +160,6 @@ the existing quota, interaction contract, goal boundary, or public/private scan.
 4. Move rolling metrics into the future server runner so the product can offer
    stable "ultra-long / long / medium / short" controls without each agent
    inventing its own heuristic.
+
+The current smoke for this design is
+`python3 examples/long-task-cadence-policy-smoke.py`.

--- a/examples/long-task-cadence-policy-smoke.py
+++ b/examples/long-task-cadence-policy-smoke.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Smoke-test the long-task cadence policy contract."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+POLICY_PATH = REPO_ROOT / "docs/long-task-cadence-policy.md"
+DOCS_INDEX = REPO_ROOT / "docs/README.md"
+GETTING_STARTED = REPO_ROOT / "docs/guides/getting-started.md"
+INTERACTION_PATTERN = REPO_ROOT / "docs/interaction-pattern-catalog.md"
+
+PRESETS = ["ultra-long", "long", "medium", "short"]
+GRANULARITIES = [
+    "status_only",
+    "single_surface",
+    "multi_surface",
+    "implementation_plus_validation",
+    "milestone",
+]
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def compact(text: str) -> str:
+    return " ".join(text.split())
+
+
+def assert_contains(text: str, needle: str, label: str) -> None:
+    if needle not in text:
+        raise AssertionError(f"{label} missing {needle!r}")
+
+
+def extract_json_block(text: str) -> dict:
+    start = text.index("```json", text.index("## Public Fields"))
+    body_start = text.index("\n", start) + 1
+    end = text.index("```", body_start)
+    return json.loads(text[body_start:end])
+
+
+def main() -> int:
+    policy = read(POLICY_PATH)
+    policy_compact = compact(policy)
+    docs_index = read(DOCS_INDEX)
+    getting_started = read(GETTING_STARTED)
+    interaction = read(INTERACTION_PATTERN)
+
+    for preset in PRESETS:
+        assert_contains(policy, f"`{preset}`", "policy preset table")
+
+    for required in [
+        "connected autonomous goals default to `long`",
+        "visible TUI sessions default to `medium`",
+        "`ultra-long` requires an explicit user/controller opt-in",
+        "compact turn duration",
+        "progress granularity",
+        "Too-Small Batch Detection",
+        "too_small_heartbeat_batch=true",
+        "implementation_plus_validation_writeback",
+        "validated_artifact",
+        "state_writeback",
+        "blocked_priority_fallback_visible",
+        "They do not grant permissions",
+    ]:
+        assert_contains(policy, required, "policy")
+
+    for granularity in GRANULARITIES:
+        assert_contains(policy, granularity, "progress granularity")
+
+    projection = extract_json_block(policy)
+    cadence = projection["long_task_cadence"]
+    assert cadence["schema_version"] == "long_task_cadence_policy_v0", cadence
+    assert cadence["cadence_preset"] == "long", cadence
+    assert cadence["preset_source"] == "connected_autonomous_default", cadence
+    assert isinstance(cadence["turn_duration_minutes"], int), cadence
+    assert cadence["progress_granularity"] in GRANULARITIES, cadence
+    assert cadence["small_step_streak"] >= 2, cadence
+    assert cadence["too_small_heartbeat_batch"] is True, cadence
+    assert cadence["widen_next_turn"] is True, cadence
+
+    for forbidden in [
+        "conversation transcript",
+        "raw local logs",
+        "credentials",
+        "production actions",
+        "still stop or ask",
+    ]:
+        assert_contains(policy_compact, forbidden, "safety boundary")
+
+    assert_contains(docs_index, "Long-task cadence policy", "docs index")
+    assert_contains(getting_started, "Long-task cadence policy", "getting started")
+    assert_contains(interaction, "IP-010 Cadence Widening", "interaction pattern")
+    assert_contains(interaction, "small-step streak", "interaction pattern")
+
+    print("long-task-cadence-policy-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- refine the long-task cadence policy with explicit product preset defaults for autonomous goals, visible TUI sessions, diagnosis/review, and ultra-long opt-in
- define compact turn-duration and progress-granularity signals plus too-small heartbeat batch detection
- add a focused policy smoke that locks preset, safety-boundary, and public field expectations

## Validation
- python3 examples/long-task-cadence-policy-smoke.py
- python3 examples/docs-governance-smoke.py
- python3 -m py_compile examples/long-task-cadence-policy-smoke.py
- goal-harness check --scan-path docs/long-task-cadence-policy.md --scan-path docs/README.md --scan-path docs/guides/getting-started.md --scan-path docs/interaction-pattern-catalog.md --scan-path examples/long-task-cadence-policy-smoke.py
- git diff --check origin/main..HEAD

## Boundary
- docs/examples only; no runtime cadence projection implementation yet
- no local state, raw run history, private paths, credentials, transcripts, or generated logs included
- goal-harness check reports only the existing duplicate-index warning; public boundary scan is clean