### PR TITLE
Align benchmark goal timeout evidence

### DIFF
--- a/docs/benchmark-developer-workflow.md
+++ b/docs/benchmark-developer-workflow.md
@@ -390,11 +390,19 @@ export PYTHONPATH=<goal-harness-checkout>:<goal-harness-checkout>/scripts:${PYTH
 UV_LINK_MODE=copy uv run --no-default-groups harbor run \
   --env docker \
   --agent-import-path harbor_host_codex_goal_agent:HarborHostCodexGoalAgent \
-  --agent-kwarg goal_timeout_sec=1200 \
+  --agent-kwarg goal_timeout_sec=10800 \
   --agent-kwarg task_workdir=/app \
   --jobs-dir <run-dir>/jobs \
   -p <task-dir>
 ```
+
+Use the same long timeout envelope for base and treatment arms while measuring
+capability ceilings. The host Goal agents default to `10800` seconds; pass an
+explicit shorter value only for a timeout-cost experiment and record that tier
+in the compact result. Goal Harness prompt-polling treatments use the same
+envelope for each observed round by default, so the controller does not cut off
+a still-running Codex Goal turn at the older `900s` official timeout before
+continuation evidence exists.
 
 When wrapping that launch in `tmux`, `launchd`, or a generated `run.sh`, put the
 same `PYTHONPATH` export inside the wrapper script, not only in the interactive
@@ -795,7 +803,7 @@ tb run \
   --no-rebuild \
   --agent-import-path terminal_bench_host_codex_goal_agent:HostCodexGoalAgent \
   --agent-kwarg goal_surface=app_server \
-  --agent-kwarg goal_timeout_sec=1200
+  --agent-kwarg goal_timeout_sec=10800
 ```
 
 This uses Codex native Goal mode on the host through the app-server Goal API
@@ -814,7 +822,7 @@ tb run \
   ... \
   --agent-import-path terminal_bench_host_codex_goal_agent:HostCodexGoalAgent \
   --agent-kwarg goal_surface=app_server \
-  --agent-kwarg goal_timeout_sec=1200 \
+  --agent-kwarg goal_timeout_sec=10800 \
   --agent-kwarg goal_harness_mode=codex_goal_harness \
   --agent-kwarg goal_harness_access_packet_mode=compact \
   --agent-kwarg goal_harness_case_id=<task-id> \

--- a/examples/harbor-host-codex-goal-agent-smoke.py
+++ b/examples/harbor-host-codex-goal-agent-smoke.py
@@ -376,6 +376,7 @@ def main() -> int:
             app_server_wait_for_completion="false",
         )
         assert no_wait_agent.app_server_wait_for_completion is False
+        assert no_wait_agent.goal_timeout_sec == 10800.0
 
         treatment_agent = module.HarborHostCodexGoalAgent(
             logs_dir=Path(tmp) / "treatment-logs",
@@ -402,7 +403,7 @@ def main() -> int:
             goal_harness_case_id="find-network-alignments",
         )
         assert polling_agent.goal_harness_prompt_polling_rounds == 5
-        assert polling_agent.goal_harness_prompt_polling_round_timeout_sec == 300.0
+        assert polling_agent.goal_harness_prompt_polling_round_timeout_sec == 10800.0
         assert polling_agent.goal_harness_case_id == "find-network-alignments"
         long_polling_agent = module.HarborHostCodexGoalAgent(
             logs_dir=Path(tmp) / "long-polling-logs",
@@ -413,7 +414,7 @@ def main() -> int:
             goal_harness_experiment_protocol="max5_blind_loop_no_feedback",
             goal_harness_max_rounds=5,
         )
-        assert long_polling_agent.goal_harness_prompt_polling_round_timeout_sec == 900.0
+        assert long_polling_agent.goal_harness_prompt_polling_round_timeout_sec == 18000.0
         explicit_timeout_agent = module.HarborHostCodexGoalAgent(
             logs_dir=Path(tmp) / "explicit-timeout-logs",
             goal_surface="app_server",

--- a/examples/terminal-bench-harbor-prompt-driven-reducer-smoke.py
+++ b/examples/terminal-bench-harbor-prompt-driven-reducer-smoke.py
@@ -110,6 +110,21 @@ def write_prompt_driven_fixture(root: Path) -> Path:
         "refresh_state": 1,
         "quota_spend": 1,
     }
+    controller_trace = {
+        "schema_version": "harbor_host_prompt_polling_controller_trace_v0",
+        "trace_publicness": "public_counts_only_no_task_text_no_verifier_output",
+        "raw_task_text_recorded": False,
+        "raw_verifier_output_recorded": False,
+        "raw_agent_trajectory_recorded": False,
+        "max_rounds_budget": 5,
+        "max_round_observed": 1,
+        "initial_prompt_count": 1,
+        "followup_prompt_count": 0,
+        "controller_action_decisions": 1,
+        "completion_marker_observed_count": 0,
+        "round_timeout_sec": 900.0,
+        "last_decision": "harbor_prompt_polling_round_timeout_before_completion",
+    }
     work_dir = trial_dir / "agent" / "host-codex-goal-fixture"
     write_json(
         work_dir / "goal_harness_prompt_driven_trace.public.json",
@@ -123,10 +138,17 @@ def write_prompt_driven_fixture(root: Path) -> Path:
         },
     )
     write_json(
+        work_dir / "goal_harness_controller_trace.public.json",
+        controller_trace,
+    )
+    write_json(
         work_dir / "app_server_goal_turn.compact.json",
         {
             "schema_version": "codex_app_server_goal_turn_driver_v0",
             "first_blocker": "harbor_prompt_polling_round_timeout_before_completion",
+            "turn_completed_observed": False,
+            "goal_harness_controller_trace_present": True,
+            "goal_harness_controller_trace": controller_trace,
             "goal_harness_prompt_driven_case_cli_call_count": sum(prompt_counts.values()),
             "goal_harness_prompt_driven_event_counts": prompt_counts,
             "goal_harness_prompt_driven_lifecycle_observed": True,
@@ -143,6 +165,17 @@ def assert_prompt_driven_result(payload: dict) -> None:
     assert payload["goal_harness_worker_cli_bridge_trace_observed"] is True, payload
     assert payload["goal_harness_prompt_driven_lifecycle_observed"] is True, payload
     assert payload["goal_harness_prompt_driven_case_cli_call_count"] == 6, payload
+    assert payload["goal_harness_controller_trace_present"] is True, payload
+    assert payload["goal_harness_controller_trace_public_safe"] is True, payload
+    assert payload["controller_max_rounds_budget"] == 5, payload
+    assert payload["controller_max_round_observed"] == 1, payload
+    assert payload["controller_followup_prompt_count"] == 0, payload
+    assert payload["controller_round_timeout_sec"] == 900.0, payload
+    assert payload["controller_turn_completed_observed"] is False, payload
+    assert (
+        payload["controller_last_decision"]
+        == "harbor_prompt_polling_round_timeout_before_completion"
+    ), payload
     assert payload["worker_goal_harness_cli_call_total"] == 6, payload
     assert (
         payload["first_blocker"]
@@ -155,6 +188,8 @@ def assert_prompt_driven_result(payload: dict) -> None:
     assert validation["worker_benchmark_run_file_present"] is True, validation
     assert validation["worker_benchmark_run_schema_ok"] is True, validation
     assert validation["worker_bridge_materialized_when_required"] is True, validation
+    assert validation["goal_harness_controller_trace_present"] is True, validation
+    assert validation["goal_harness_controller_trace_public_safe"] is True, validation
     overhead = payload["overhead_attribution_counters"]
     assert (
         overhead["attribution_granularity"]
@@ -175,6 +210,14 @@ def main() -> int:
         assert compact is not None
         assert compact["worker_bridge_materialization_status"] == "verified", compact
         assert compact["goal_harness_prompt_driven_lifecycle_observed"] is True, compact
+        assert compact["goal_harness_controller_trace_present"] is True, compact
+        assert compact["controller_max_round_observed"] == 1, compact
+        assert compact["controller_followup_prompt_count"] == 0, compact
+        assert compact["controller_round_timeout_sec"] == 900.0, compact
+        assert (
+            compact["controller_last_decision"]
+            == "harbor_prompt_polling_round_timeout_before_completion"
+        ), compact
         output_path = Path(tmp) / "harbor_job_result.compact.json"
         subprocess.run(
             [
@@ -205,6 +248,16 @@ def main() -> int:
         assert (
             reduced_compact["goal_harness_prompt_driven_case_cli_call_count"] == 6
         ), reduced_compact
+        assert reduced_compact["goal_harness_controller_trace_present"] is True, (
+            reduced_compact
+        )
+        assert reduced_compact["controller_max_round_observed"] == 1, reduced_compact
+        assert reduced_compact["controller_followup_prompt_count"] == 0, (
+            reduced_compact
+        )
+        assert reduced_compact["controller_round_timeout_sec"] == 900.0, (
+            reduced_compact
+        )
     print("terminal-bench harbor prompt-driven reducer smoke passed")
     return 0
 

--- a/examples/terminal-bench-host-codex-goal-agent-smoke.py
+++ b/examples/terminal-bench-host-codex-goal-agent-smoke.py
@@ -134,6 +134,7 @@ def main() -> int:
         app_server_wait_for_completion="false",
     )
     assert no_wait_agent.app_server_wait_for_completion is False
+    assert no_wait_agent.goal_timeout_sec == 10800.0
 
     print("terminal-bench host Codex Goal agent smoke passed")
     return 0

--- a/goal_harness/benchmark_adapters/terminal_bench.py
+++ b/goal_harness/benchmark_adapters/terminal_bench.py
@@ -351,6 +351,7 @@ TERMINAL_BENCH_WORKER_BENCHMARK_RUN_FILE = "goal-harness-worker-benchmark-run.js
 TERMINAL_BENCH_PROMPT_DRIVEN_TRACE_FILE = (
     "goal_harness_prompt_driven_trace.public.json"
 )
+TERMINAL_BENCH_CONTROLLER_TRACE_FILE = "goal_harness_controller_trace.public.json"
 TERMINAL_BENCH_APP_SERVER_GOAL_TURN_COMPACT_FILE = (
     "app_server_goal_turn.compact.json"
 )
@@ -4096,6 +4097,7 @@ def _terminal_bench_prompt_driven_goal_harness_observation(
         else job_path.parent
     )
     trace_paths: list[Path] = []
+    controller_paths: list[Path] = []
     compact_paths: list[Path] = []
     seen_paths: set[Path] = set()
     for path in sorted(job_path.rglob(TERMINAL_BENCH_PROMPT_DRIVEN_TRACE_FILE)):
@@ -4106,6 +4108,15 @@ def _terminal_bench_prompt_driven_goal_harness_observation(
     if direct_trace.is_file() and direct_trace not in seen_paths:
         trace_paths.append(direct_trace)
         seen_paths.add(direct_trace)
+    seen_paths.clear()
+    for path in sorted(job_path.rglob(TERMINAL_BENCH_CONTROLLER_TRACE_FILE)):
+        if path.is_file() and path not in seen_paths:
+            controller_paths.append(path)
+            seen_paths.add(path)
+    direct_controller = run_root / TERMINAL_BENCH_CONTROLLER_TRACE_FILE
+    if direct_controller.is_file() and direct_controller not in seen_paths:
+        controller_paths.append(direct_controller)
+        seen_paths.add(direct_controller)
     seen_paths.clear()
     for path in sorted(job_path.rglob(TERMINAL_BENCH_APP_SERVER_GOAL_TURN_COMPACT_FILE)):
         if path.is_file() and path not in seen_paths:
@@ -4124,6 +4135,76 @@ def _terminal_bench_prompt_driven_goal_harness_observation(
     first_blocker = "none"
     treatment_claim_blocker = "none"
     strict_claim_allowed = False
+    controller_trace_observed = False
+    controller_trace_public_safe = False
+    controller_max_round_observed = -1
+    controller_max_rounds_budget = 0
+    controller_initial_prompt_count = 0
+    controller_followup_prompt_count = 0
+    controller_action_decisions = 0
+    controller_completion_marker_observed_count = 0
+    controller_round_timeout_sec: float | None = None
+    controller_last_decision = "none"
+    controller_turn_completed_observed = False
+
+    def observe_controller_trace(payload: Any) -> None:
+        nonlocal controller_trace_observed
+        nonlocal controller_trace_public_safe
+        nonlocal controller_max_round_observed
+        nonlocal controller_max_rounds_budget
+        nonlocal controller_initial_prompt_count
+        nonlocal controller_followup_prompt_count
+        nonlocal controller_action_decisions
+        nonlocal controller_completion_marker_observed_count
+        nonlocal controller_round_timeout_sec
+        nonlocal controller_last_decision
+        if not isinstance(payload, dict):
+            return
+        controller_trace_observed = True
+        publicness = str(payload.get("trace_publicness") or "")
+        controller_trace_public_safe = controller_trace_public_safe or (
+            "public" in publicness
+            and payload.get("raw_task_text_recorded") is not True
+            and payload.get("raw_verifier_output_recorded") is not True
+            and payload.get("raw_agent_trajectory_recorded") is not True
+        )
+        for field, current in (
+            ("max_round_observed", controller_max_round_observed),
+            ("max_rounds_budget", controller_max_rounds_budget),
+            ("initial_prompt_count", controller_initial_prompt_count),
+            ("followup_prompt_count", controller_followup_prompt_count),
+            ("controller_action_decisions", controller_action_decisions),
+            (
+                "completion_marker_observed_count",
+                controller_completion_marker_observed_count,
+            ),
+        ):
+            raw = payload.get(field)
+            if not isinstance(raw, int) or isinstance(raw, bool):
+                continue
+            value = max(current, raw)
+            if field == "max_round_observed":
+                controller_max_round_observed = value
+            elif field == "max_rounds_budget":
+                controller_max_rounds_budget = value
+            elif field == "initial_prompt_count":
+                controller_initial_prompt_count = value
+            elif field == "followup_prompt_count":
+                controller_followup_prompt_count = value
+            elif field == "controller_action_decisions":
+                controller_action_decisions = value
+            elif field == "completion_marker_observed_count":
+                controller_completion_marker_observed_count = value
+        timeout_raw = payload.get("round_timeout_sec")
+        if isinstance(timeout_raw, (int, float)) and not isinstance(timeout_raw, bool):
+            controller_round_timeout_sec = max(
+                float(controller_round_timeout_sec or 0.0),
+                float(timeout_raw),
+            )
+        decision = _public_safe_benchmark_label(payload.get("last_decision"))
+        if decision and decision != "none":
+            controller_last_decision = decision
+
     for path in trace_paths:
         payload = _load_json_object(path)
         counts = _compact_numeric_int_map(payload.get("event_kind_counts"))
@@ -4135,6 +4216,8 @@ def _terminal_bench_prompt_driven_goal_harness_observation(
         lifecycle_observed = lifecycle_observed or payload.get(
             "lifecycle_observed"
         ) is True
+    for path in controller_paths:
+        observe_controller_trace(_load_json_object(path))
     for path in compact_paths:
         payload = _load_json_object(path)
         counts = _compact_numeric_int_map(
@@ -4165,6 +4248,14 @@ def _terminal_bench_prompt_driven_goal_harness_observation(
         strict_claim_allowed = strict_claim_allowed or payload.get(
             "strict_goal_harness_treatment_claim_allowed"
         ) is True
+        observe_controller_trace(payload.get("goal_harness_controller_trace"))
+        controller_trace_observed = controller_trace_observed or payload.get(
+            "goal_harness_controller_trace_present"
+        ) is True
+        controller_turn_completed_observed = (
+            controller_turn_completed_observed
+            or payload.get("turn_completed_observed") is True
+        )
 
     event_counts = trace_event_counts if trace_event_counts else compact_event_counts
     command_count = max(
@@ -4199,6 +4290,19 @@ def _terminal_bench_prompt_driven_goal_harness_observation(
         "first_blocker": first_blocker,
         "strict_goal_harness_treatment_claim_allowed": strict_claim_allowed,
         "goal_harness_treatment_claim_blocker": treatment_claim_blocker,
+        "controller_trace_observed": controller_trace_observed,
+        "controller_trace_public_safe": controller_trace_public_safe,
+        "controller_max_round_observed": controller_max_round_observed,
+        "controller_max_rounds_budget": controller_max_rounds_budget,
+        "controller_initial_prompt_count": controller_initial_prompt_count,
+        "controller_followup_prompt_count": controller_followup_prompt_count,
+        "controller_action_decisions": controller_action_decisions,
+        "controller_completion_marker_observed_count": (
+            controller_completion_marker_observed_count
+        ),
+        "controller_round_timeout_sec": controller_round_timeout_sec,
+        "controller_last_decision": controller_last_decision,
+        "controller_turn_completed_observed": controller_turn_completed_observed,
     }
 
 def _total_from_counter_map(value: Any) -> int:
@@ -4819,6 +4923,12 @@ def build_terminal_bench_harbor_result_benchmark_run(
     prompt_driven_lifecycle_observed = bool(
         prompt_driven_goal_harness.get("lifecycle_observed")
     )
+    prompt_driven_controller_trace_observed = bool(
+        prompt_driven_goal_harness.get("controller_trace_observed")
+    )
+    prompt_driven_controller_trace_public_safe = bool(
+        prompt_driven_goal_harness.get("controller_trace_public_safe")
+    )
     if prompt_driven_cli_total:
         prompt_driven_calls = (
             prompt_driven_goal_harness.get("event_counts")
@@ -4885,6 +4995,24 @@ def build_terminal_bench_harbor_result_benchmark_run(
         interaction_counters["prompt_driven_goal_harness_cli_call_total"] = (
             prompt_driven_cli_total
         )
+        if prompt_driven_controller_trace_observed:
+            interaction_counters["controller_trace_present"] = True
+            interaction_counters["controller_max_rounds_budget"] = _non_negative_int(
+                prompt_driven_goal_harness.get("controller_max_rounds_budget")
+            )
+            interaction_counters["controller_followup_prompt_count"] = (
+                _non_negative_int(
+                    prompt_driven_goal_harness.get("controller_followup_prompt_count")
+                )
+            )
+            interaction_counters["controller_initial_prompt_count"] = (
+                _non_negative_int(
+                    prompt_driven_goal_harness.get("controller_initial_prompt_count")
+                )
+            )
+            interaction_counters["controller_action_decisions"] = _non_negative_int(
+                prompt_driven_goal_harness.get("controller_action_decisions")
+            )
     worker_cli_total = 0
     if interaction_counters:
         interaction_counters["worker_counter_trace_trial_count"] = (
@@ -5238,6 +5366,13 @@ def build_terminal_bench_harbor_result_benchmark_run(
         ),
         "pre_worker_agent_setup_failures_classified": True,
         "environment_setup_failures_before_worker_classified": True,
+        "goal_harness_controller_trace_present": (
+            prompt_driven_controller_trace_observed
+        ),
+        "goal_harness_controller_trace_public_safe": (
+            (not prompt_driven_controller_trace_observed)
+            or prompt_driven_controller_trace_public_safe
+        ),
         "verifier_failure_attribution_public_safe": True,
         "verifier_dependency_failures_classified": True,
         "worker_checkpoint_not_expected_before_agent_setup": True,
@@ -5270,8 +5405,10 @@ def build_terminal_bench_harbor_result_benchmark_run(
         "trial:agent/goal-harness-worker-benchmark-run.json",
         "trial:agent/goal-harness-worker-setup-diagnostic.json",
         "trial:agent/goal_harness_prompt_driven_trace.public.json",
+        "trial:agent/goal_harness_controller_trace.public.json",
         "trial:agent/app_server_goal_turn.compact.json",
         "run:goal_harness_prompt_driven_trace.public.json",
+        "run:goal_harness_controller_trace.public.json",
         "run:app_server_goal_turn.compact.json",
         "trial:verifier/reward.txt",
         "trial:artifacts/manifest.json",
@@ -5446,6 +5583,50 @@ def build_terminal_bench_harbor_result_benchmark_run(
         "goal_harness_prompt_driven_compact_file_count": _non_negative_int(
             prompt_driven_goal_harness.get("compact_file_count")
         ),
+        "goal_harness_controller_trace_present": (
+            prompt_driven_controller_trace_observed
+        ),
+        "goal_harness_controller_trace_public_safe": (
+            prompt_driven_controller_trace_public_safe
+        ),
+        "controller_max_round_observed": _non_negative_int(
+            prompt_driven_goal_harness.get("controller_max_round_observed")
+        ),
+        "controller_max_rounds_budget": _non_negative_int(
+            prompt_driven_goal_harness.get("controller_max_rounds_budget")
+        ),
+        "controller_initial_prompt_count": _non_negative_int(
+            prompt_driven_goal_harness.get("controller_initial_prompt_count")
+        ),
+        "controller_followup_prompt_count": _non_negative_int(
+            prompt_driven_goal_harness.get("controller_followup_prompt_count")
+        ),
+        "controller_action_decisions": _non_negative_int(
+            prompt_driven_goal_harness.get("controller_action_decisions")
+        ),
+        "controller_completion_marker_observed_count": _non_negative_int(
+            prompt_driven_goal_harness.get(
+                "controller_completion_marker_observed_count"
+            )
+        ),
+        "controller_round_timeout_sec": (
+            prompt_driven_goal_harness.get("controller_round_timeout_sec")
+            if isinstance(
+                prompt_driven_goal_harness.get("controller_round_timeout_sec"),
+                (int, float),
+            )
+            and not isinstance(
+                prompt_driven_goal_harness.get("controller_round_timeout_sec"),
+                bool,
+            )
+            else None
+        ),
+        "controller_last_decision": (
+            prompt_driven_goal_harness.get("controller_last_decision") or "none"
+        ),
+        "controller_turn_completed_observed": bool(
+            prompt_driven_goal_harness.get("controller_turn_completed_observed")
+        ),
         "strict_goal_harness_treatment_claim_allowed": (
             strict_goal_harness_treatment_claim_allowed
         ),
@@ -5593,6 +5774,39 @@ def build_terminal_bench_harbor_result_benchmark_run(
             ),
             "goal_harness_prompt_driven_case_cli_call_count": (
                 prompt_driven_cli_total
+            ),
+            "goal_harness_controller_trace_present": (
+                prompt_driven_controller_trace_observed
+            ),
+            "goal_harness_controller_trace_public_safe": (
+                prompt_driven_controller_trace_public_safe
+            ),
+            "controller_max_round_observed": _non_negative_int(
+                prompt_driven_goal_harness.get("controller_max_round_observed")
+            ),
+            "controller_max_rounds_budget": _non_negative_int(
+                prompt_driven_goal_harness.get("controller_max_rounds_budget")
+            ),
+            "controller_followup_prompt_count": _non_negative_int(
+                prompt_driven_goal_harness.get("controller_followup_prompt_count")
+            ),
+            "controller_round_timeout_sec": (
+                prompt_driven_goal_harness.get("controller_round_timeout_sec")
+                if isinstance(
+                    prompt_driven_goal_harness.get("controller_round_timeout_sec"),
+                    (int, float),
+                )
+                and not isinstance(
+                    prompt_driven_goal_harness.get("controller_round_timeout_sec"),
+                    bool,
+                )
+                else None
+            ),
+            "controller_last_decision": (
+                prompt_driven_goal_harness.get("controller_last_decision") or "none"
+            ),
+            "controller_turn_completed_observed": bool(
+                prompt_driven_goal_harness.get("controller_turn_completed_observed")
             ),
             "worker_materialization_probe_only": worker_materialization_probe_only,
             "worker_materialization_probe_contract_present": (

--- a/goal_harness/status.py
+++ b/goal_harness/status.py
@@ -1626,6 +1626,7 @@ def _compact_worker_bridge_outcome(value: Any) -> dict[str, Any]:
         "worker_bridge_materialization_blocker",
         "worker_bridge_failure_attribution",
         "prompt_driven_first_blocker",
+        "controller_last_decision",
         "repeat_blocked_by",
         "pre_worker_startup_blocker",
     ):
@@ -1646,6 +1647,9 @@ def _compact_worker_bridge_outcome(value: Any) -> dict[str, Any]:
         "runner_side_writeback_guaranteed",
         "worker_submit_eligible_mismatch_observed",
         "worker_bridge_writeback_loss_observed",
+        "goal_harness_controller_trace_present",
+        "goal_harness_controller_trace_public_safe",
+        "controller_turn_completed_observed",
     ):
         if isinstance(value.get(field), bool):
             compact[field] = value[field]
@@ -1666,9 +1670,15 @@ def _compact_worker_bridge_outcome(value: Any) -> dict[str, Any]:
         "worker_runtime_exception_before_checkpoint_count",
         "verifier_failure_attribution_count",
         "verifier_dependency_failure_count",
+        "controller_max_round_observed",
+        "controller_max_rounds_budget",
+        "controller_followup_prompt_count",
     ):
         if isinstance(value.get(field), int) and not isinstance(value.get(field), bool):
             compact[field] = value[field]
+    round_timeout = value.get("controller_round_timeout_sec")
+    if isinstance(round_timeout, (int, float)) and not isinstance(round_timeout, bool):
+        compact["controller_round_timeout_sec"] = round_timeout
     score = value.get("official_score_value")
     if isinstance(score, (int, float)) and not isinstance(score, bool):
         compact["official_score_value"] = score
@@ -1911,6 +1921,9 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
         "goal_harness_worker_cli_bridge_trace_observed",
         "goal_harness_prompt_driven_trace_observed",
         "goal_harness_prompt_driven_lifecycle_observed",
+        "goal_harness_controller_trace_present",
+        "goal_harness_controller_trace_public_safe",
+        "controller_turn_completed_observed",
         "assisted_collaboration_claim_allowed",
         "official_score_claim_allowed",
         "bridge_connectivity_claim_allowed",
@@ -1970,11 +1983,26 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
         "native_goal_worker_turn_start_count",
         "native_goal_worker_turn_completed_observed_count",
         "native_goal_worker_assistant_message_present_count",
+        "controller_max_round_observed",
+        "controller_max_rounds_budget",
+        "controller_initial_prompt_count",
+        "controller_followup_prompt_count",
+        "controller_action_decisions",
+        "controller_completion_marker_observed_count",
         "max_rounds_budget",
         "round_reward_count",
     ):
         if isinstance(source.get(field), int) and not isinstance(source.get(field), bool):
             compact[field] = source.get(field)
+    for field in ("controller_round_timeout_sec",):
+        if isinstance(source.get(field), (int, float)) and not isinstance(
+            source.get(field), bool
+        ):
+            compact[field] = source.get(field)
+    for field in ("controller_last_decision",):
+        value = public_safe_compact_text(source.get(field), limit=120)
+        if value:
+            compact[field] = value
     for field in ("goal_harness_prompt_driven_event_counts",):
         calls = _compact_numeric_map(source.get(field))
         if calls:

--- a/scripts/harbor_host_codex_goal_agent.py
+++ b/scripts/harbor_host_codex_goal_agent.py
@@ -59,6 +59,8 @@ from goal_harness.benchmark_core.loop_protocol import (
     render_loop_contract_packet_lines,
 )
 
+LONG_RUN_DEFAULT_GOAL_TIMEOUT_SEC = 10800.0
+
 
 try:  # pragma: no cover - exercised on the benchmark host.
     from harbor.agents.base import BaseAgent
@@ -638,7 +640,7 @@ class HarborHostCodexGoalAgent(BaseAgent):
         self,
         logs_dir: Path,
         model_name: str | None = None,
-        goal_timeout_sec: str | int | float = 300,
+        goal_timeout_sec: str | int | float = LONG_RUN_DEFAULT_GOAL_TIMEOUT_SEC,
         codex_bin: str = "codex",
         task_workdir: str = "/app",
         goal_surface: str = "tui",
@@ -704,13 +706,9 @@ class HarborHostCodexGoalAgent(BaseAgent):
                 int(goal_harness_prompt_polling_rounds),
             )
         if str(goal_harness_prompt_polling_round_timeout_sec).strip().lower() == "auto":
-            self.goal_harness_prompt_polling_round_timeout_sec = min(
+            self.goal_harness_prompt_polling_round_timeout_sec = max(
+                30.0,
                 self.goal_timeout_sec,
-                900.0,
-                max(
-                    300.0,
-                    self.goal_timeout_sec / max(1, self.goal_harness_prompt_polling_rounds),
-                ),
             )
         else:
             self.goal_harness_prompt_polling_round_timeout_sec = max(

--- a/scripts/terminal_bench_host_codex_goal_agent.py
+++ b/scripts/terminal_bench_host_codex_goal_agent.py
@@ -37,6 +37,8 @@ from goal_harness.benchmark_case_state import (
     render_benchmark_case_lifecycle_contract_lines,
 )
 
+LONG_RUN_DEFAULT_GOAL_TIMEOUT_SEC = 10800.0
+
 
 try:  # pragma: no cover - exercised on the benchmark host.
     from terminal_bench.agents.base_agent import AgentResult, BaseAgent
@@ -162,7 +164,7 @@ class HostCodexGoalAgent(BaseAgent):
     def __init__(
         self,
         model_name: str | None = None,
-        goal_timeout_sec: str | int | float = 300,
+        goal_timeout_sec: str | int | float = LONG_RUN_DEFAULT_GOAL_TIMEOUT_SEC,
         work_root: str = "/tmp/goal-harness-terminal-bench",
         network_bootstrap_script: str = "",
         task_workdir: str = "/app",


### PR DESCRIPTION
## Summary
- default Harbor and Terminal-Bench host Codex Goal agents to a 10800s evidence envelope
- remove the Harbor prompt-polling auto clamp that cut rounds back to 900s
- expose public-safe controller phase counters in Harbor reducer compact output
- document the matched long-timeout base/treatment SOP and guard it with focused smokes

## Validation
- python examples/harbor-host-codex-goal-agent-smoke.py
- python examples/terminal-bench-host-codex-goal-agent-smoke.py
- python examples/terminal-bench-harbor-prompt-driven-reducer-smoke.py
- python examples/benchmark-developer-workflow-doc-smoke.py
- python -m py_compile scripts/harbor_host_codex_goal_agent.py scripts/terminal_bench_host_codex_goal_agent.py examples/harbor-host-codex-goal-agent-smoke.py examples/terminal-bench-host-codex-goal-agent-smoke.py examples/terminal-bench-harbor-prompt-driven-reducer-smoke.py goal_harness/benchmark_adapters/terminal_bench.py goal_harness/status.py
- git diff --check
- goal-harness check --scan-path scripts/harbor_host_codex_goal_agent.py --scan-path scripts/terminal_bench_host_codex_goal_agent.py --scan-path goal_harness/benchmark_adapters/terminal_bench.py --scan-path goal_harness/status.py --scan-path examples/harbor-host-codex-goal-agent-smoke.py --scan-path examples/terminal-bench-host-codex-goal-agent-smoke.py --scan-path examples/terminal-bench-harbor-prompt-driven-reducer-smoke.py --scan-path docs/benchmark-developer-workflow.md

## Notes
- Timeout closeout remains observational: the runner does not mutate the case todo into a terminal status. A timeout is represented by controller phase evidence such as last_decision, completion marker count, turn-completed observation, and followup count.
