### PR TITLE
fix: disable legacy goal-harness install shims

### DIFF
--- a/docs/product/loopx-state-migration-sop.md
+++ b/docs/product/loopx-state-migration-sop.md
@@ -31,6 +31,18 @@ registry. There is no default “migrate everything” behavior.
 loopx doctor
 ```
 
+The installer does not create a `goal-harness` compatibility alias. For
+existing local installs, it disables legacy `goal-harness` and
+`goal-harness-canary` symlinks only when they point at the old local release
+directory. It leaves unrelated user commands untouched.
+
+Verify that the old command is gone before trusting the migration:
+
+```bash
+command -v loopx
+! command -v goal-harness
+```
+
 2. Create a local backup before the first execute.
 
 The migration is copy-first, but existing users should still keep a timestamped

--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -63,6 +63,25 @@ def main() -> int:
         home = root / "home"
         home.mkdir()
         bin_dir = home / ".local" / "bin"
+        bin_dir.mkdir(parents=True)
+        legacy_scripts = (
+            home
+            / ".local"
+            / "share"
+            / "goal-harness"
+            / "releases"
+            / "legacy"
+            / "scripts"
+        )
+        legacy_scripts.mkdir(parents=True)
+        legacy_goal_harness = legacy_scripts / "goal-harness"
+        legacy_goal_harness.write_text("#!/usr/bin/env bash\nexit 99\n", encoding="utf-8")
+        legacy_goal_harness.chmod(0o755)
+        legacy_canary = legacy_scripts / "goal-harness-canary"
+        legacy_canary.write_text("#!/usr/bin/env bash\nexit 99\n", encoding="utf-8")
+        legacy_canary.chmod(0o755)
+        (bin_dir / "goal-harness").symlink_to(legacy_goal_harness)
+        (bin_dir / "goal-harness-canary").symlink_to(legacy_canary)
         codex_home = home / ".codex"
         profile = home / ".zshrc"
         env = {
@@ -84,6 +103,15 @@ def main() -> int:
         assert f"- executable: {bin_dir / 'loopx'}" in install.stdout, install.stdout
         assert "- release: " in install.stdout, install.stdout
         assert f"- canary executable: {bin_dir / 'loopx-canary'}" in install.stdout, install.stdout
+        assert "- executable compatibility: none" in install.stdout, install.stdout
+        assert (
+            f"- legacy command disabled: {bin_dir / 'goal-harness.legacy-disabled'}"
+            in install.stdout
+        ), install.stdout
+        assert (
+            f"- legacy command disabled: {bin_dir / 'goal-harness-canary.legacy-disabled'}"
+            in install.stdout
+        ), install.stdout
         assert f"- skill: {codex_home / 'skills' / 'loopx-doc-registry'}" in install.stdout, install.stdout
         assert f"- skill: {codex_home / 'skills' / 'loopx-project'}" in install.stdout, install.stdout
         assert f"- skill: {codex_home / 'skills' / 'loopx-self-repair'}" in install.stdout, install.stdout
@@ -91,6 +119,7 @@ def main() -> int:
         wrapper = bin_dir / "loopx"
         assert wrapper.is_symlink(), wrapper
         assert not (bin_dir / "goal-harness").exists()
+        assert (bin_dir / "goal-harness.legacy-disabled").is_symlink()
         assert wrapper.resolve() != REPO_ROOT / "scripts" / "loopx", wrapper.resolve()
         assert wrapper.resolve().name == "loopx", wrapper.resolve()
         release_root = wrapper.resolve().parents[1]
@@ -98,6 +127,7 @@ def main() -> int:
         canary_wrapper = bin_dir / "loopx-canary"
         assert canary_wrapper.is_symlink(), canary_wrapper
         assert not (bin_dir / "goal-harness-canary").exists()
+        assert (bin_dir / "goal-harness-canary.legacy-disabled").is_symlink()
         assert canary_wrapper.resolve() == REPO_ROOT / "scripts" / "loopx", canary_wrapper.resolve()
         assert profile.read_text(encoding="utf-8").count("LoopX local CLI") == 1, profile.read_text()
 

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -14,6 +14,7 @@ releases_dir="${LOOPX_RELEASES_DIR:-$HOME/.local/share/loopx/releases}"
 release_id="${LOOPX_RELEASE_ID:-$(date -u +%Y%m%dT%H%M%SZ)}"
 release_dir="$releases_dir/$release_id"
 release_tmp="$release_dir.tmp.$$"
+legacy_line=""
 
 warn_stale_promotion_readiness() {
   local python_bin="${LOOPX_PYTHON:-python3}"
@@ -51,6 +52,37 @@ copy_path() {
   fi
 }
 
+append_legacy_line() {
+  local message="$1"
+  if [[ -z "$legacy_line" ]]; then
+    legacy_line="- $message"
+  else
+    legacy_line="$legacy_line"$'\n'"- $message"
+  fi
+}
+
+disable_legacy_shim() {
+  local name="$1"
+  local legacy="$bin_dir/$name"
+  local disabled="$bin_dir/$name.legacy-disabled"
+  if [[ ! -e "$legacy" && ! -L "$legacy" ]]; then
+    return 0
+  fi
+  if [[ ! -L "$legacy" ]]; then
+    append_legacy_line "legacy command left untouched: $legacy is not a symlink"
+    return 0
+  fi
+  local target
+  target="$(readlink "$legacy" || true)"
+  if [[ "$target" != *"/goal-harness/"* && "$target" != *".local/share/goal-harness/"* ]]; then
+    append_legacy_line "legacy command left untouched: $legacy does not point at a legacy release"
+    return 0
+  fi
+  rm -f "$disabled"
+  mv "$legacy" "$disabled"
+  append_legacy_line "legacy command disabled: $disabled"
+}
+
 if [[ -z "$shell_profile" ]]; then
   case "${SHELL:-}" in
     */zsh) shell_profile="$HOME/.zshrc" ;;
@@ -62,6 +94,11 @@ fi
 warn_stale_promotion_readiness
 
 mkdir -p "$bin_dir"
+disable_legacy_shim "goal-harness"
+disable_legacy_shim "goal-harness-canary"
+if [[ -z "$legacy_line" ]]; then
+  legacy_line="- legacy command disabled: not present"
+fi
 mkdir -p "$releases_dir"
 rm -rf "$release_tmp"
 mkdir -p "$release_tmp"
@@ -131,6 +168,8 @@ loopx installed locally
 - executable: $bin_dir/loopx
 - release: $release_dir
 $canary_line
+- executable compatibility: none
+$legacy_line
 - profile: $shell_profile
 $skill_line
 


### PR DESCRIPTION
## Summary\n- disable stale local goal-harness / goal-harness-canary symlinks during LoopX install when they point at the old local release directory\n- keep unrelated user commands untouched\n- document the no-compat verification step in the migration SOP\n\n## Validation\n- bash -n scripts/install-local.sh\n- python3 -m py_compile examples/install-local-smoke.py\n- python3 examples/install-local-smoke.py\n- python3 examples/fresh-clone-quickstart-smoke.py\n- python3 examples/codex-cli-no-clone-release-verification-smoke.py\n- ./scripts/loopx check --scan-root .\n- git diff --check\n\n## Notes\n- PR #446 is already merged; this is a separate post-merge cleanup for existing local installs.\n- This does not rename the GitHub repository, publish packages, or touch Pages cutover.