### PR TITLE
docs: cut over repo links for LoopX rename

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Contributor task board
-    url: https://github.com/huangruiteng/goal-harness/blob/main/CONTRIBUTOR_TASKS.md
+    url: https://github.com/huangruiteng/loopx/blob/main/CONTRIBUTOR_TASKS.md
     about: Start here for public, claimable work.

--- a/.github/workflows/frontstage-pages.yml
+++ b/.github/workflows/frontstage-pages.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Export Pages frontstage artifact
         working-directory: apps/dashboard
-        run: npm run export:frontstage-share -- --base /goal-harness/ --out-dir ../../output/frontstage-pages
+        run: npm run export:frontstage-share -- --base /loopx/ --out-dir ../../output/frontstage-pages
 
       - name: Configure Pages
         if: github.event_name != 'pull_request'

--- a/docs/product/loopx-rename-migration.md
+++ b/docs/product/loopx-rename-migration.md
@@ -34,22 +34,25 @@ missed migration work.
    Pages URLs, external docs, and any release notes that cannot be validated
    until the canonical code rename has landed.
 6. P1 GitHub rename gate: rename `huangruiteng/goal-harness` to
-   `huangruiteng/loopx` only after the canonical rename PR lands and the
-   maintainer accepts the public URL migration plan. The no-clone installer
-   points at the new repo URL, so the GitHub rename is a merge/release gate,
-   not an optional cleanup.
+   `huangruiteng/loopx` after the canonical rename PR lands, the maintainer
+   accepts the public URL migration plan, and the Pages/issue-template cutover
+   PR is merged. The no-clone installer already points at the new repo URL, so
+   the GitHub rename is a controlled release cutover, not a compatibility
+   alias.
 
 ## GitHub Rename Gate
 
 The current authenticated GitHub user has admin permission on the existing
-`huangruiteng/goal-harness` repository. Codex should perform the final rename
-to `huangruiteng/loopx` only after an explicit maintainer gate.
+`huangruiteng/goal-harness` repository. Codex may perform the final rename to
+`huangruiteng/loopx` after the maintainer explicitly approves the repo rename
+gate and the cutover checklist below is complete.
 
 Do not rename the repository as part of an ordinary code PR. Before the rename:
 
 - merge the LoopX canonical rename PR;
 - confirm the no-clone installer works from the new URL;
 - decide the hosted Pages URL strategy;
+- update Pages base paths and public GitHub links to `/loopx/`;
 - update repository description/topics;
 - update local remotes after rename with `git remote set-url origin`;
 - keep the old repository name unused so GitHub redirects are not invalidated.


### PR DESCRIPTION
## Summary\n- point contributor issue-template link at huangruiteng/loopx\n- switch Pages frontstage base path from /goal-harness/ to /loopx/\n- update the rename gate doc now that maintainer approval is in progress\n\n## Validation\n- python3 -m py_compile examples/install-local-smoke.py\n- python3 examples/codex-cli-no-clone-release-verification-smoke.py\n- python3 examples/fresh-clone-quickstart-smoke.py\n- npm run smoke:frontstage-share-bundle --prefix apps/dashboard\n- npm run export:frontstage-share --prefix apps/dashboard -- --base /loopx/ --out-dir /tmp/loopx-pages-cutover-output\n- ./scripts/loopx check --scan-root .\n- git diff --check\n\n## Notes\n- This PR is the small cutover step before renaming the GitHub repository.\n- PR #199 remains blocked until rewritten onto LoopX naming.