### PR TITLE
fix: use LoopX todo in heartbeat prompt

### DIFF
--- a/examples/heartbeat-prompt-smoke.py
+++ b/examples/heartbeat-prompt-smoke.py
@@ -362,7 +362,7 @@ def main() -> int:
         "If false/0: 无用户待办/无需通知 or quiet",
         "具体 user todo 未投影，需修复 LoopX 状态投影",
         "Do bounded validated batch or quiet no-op; spend after writeback",
-        "Plans/done -> GH todo or rationale",
+        "Plans/done -> LoopX todo or rationale",
         "After 2 no-progress, self-repair",
         "If P0 is blocked but CLI contract permits safe work",
         "monitor-only quiet skips stay active/no-spend",

--- a/loopx/heartbeat_prompt.py
+++ b/loopx/heartbeat_prompt.py
@@ -839,7 +839,7 @@ action_required=true/open_count>0, list concrete payload todo(s)/questions;
 never only "owner gate"; missing -> "具体 user todo 未投影，需修复 LoopX 状态投影".
 If false/0: 无用户待办/无需通知 or quiet.
 Do bounded validated batch or quiet no-op; spend after writeback.
-Plans/done -> GH todo or rationale.
+Plans/done -> LoopX todo or rationale.
 After 2 no-progress, self-repair.
 
 If P0 is blocked but CLI contract permits safe work, continue verifiable


### PR DESCRIPTION
## Summary\n- replace stale GH todo wording in generated heartbeat prompts with LoopX todo\n- update heartbeat prompt smoke expectation\n\n## Validation\n- python3 -m py_compile loopx/heartbeat_prompt.py examples/heartbeat-prompt-smoke.py\n- python3 examples/heartbeat-prompt-smoke.py\n- loopx --format json heartbeat-prompt --thin --goal-id loopx-meta --agent-id codex-side-bypass --agent-scope ... (asserted generated task body uses LoopX todo and not GH todo)\n- ./scripts/loopx check --scan-root .\n- git diff --check\n\n## Notes\n- The live loopx heartbeat automation was also simplified to a durable thin contract: no post-rename/PR-specific/no-compat worklist in the prompt.