### PR TITLE
feat: add dreaming proposal decisions

### DIFF
--- a/examples/dreaming-dry-run-proposal-smoke.py
+++ b/examples/dreaming-dry-run-proposal-smoke.py
@@ -164,12 +164,14 @@ def main() -> int:
         assert payload["ok"] is True, payload
         assert payload["dry_run"] is True, payload
         assert payload["classification"] == "dreaming_refactor_warning", payload
+        assert payload["proposal_id"].startswith("dreaming_"), payload
         assert payload["proposal_type"] == "refactor_warning", payload
         assert len(payload["recent_evidence"]) == 4, payload
         evidence_text = json.dumps(payload["recent_evidence"], ensure_ascii=False)
         assert "/" + "tmp/loopx-private-evidence" not in evidence_text, payload
         preview = payload["run_record_preview"]
         assert preview["agent_command"] is None, preview
+        assert preview["dreaming"]["proposal_id"] == payload["proposal_id"], preview
         assert preview["dreaming"]["advisory"] is True, preview
         assert preview["dreaming"]["execution_allowed"] is False, preview
         assert preview["dreaming"]["delivery_spend_allowed"] is False, preview

--- a/examples/dreaming-proposal-decision-smoke.py
+++ b/examples/dreaming-proposal-decision-smoke.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Smoke-test explicit dreaming proposal decisions and promotion."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GOAL_ID = "dreaming-decision-fixture"
+
+
+def run_cli(*args: str, registry_path: Path, runtime: Path) -> dict:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--registry",
+            str(registry_path),
+            "--runtime-root",
+            str(runtime),
+            "--format",
+            "json",
+            *args,
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def append_recorded_proposal(
+    runs_dir: Path,
+    *,
+    generated_at: str,
+    proposal_id: str,
+) -> None:
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    json_path = runs_dir / f"{proposal_id}.json"
+    markdown_path = runs_dir / f"{proposal_id}.md"
+    record = {
+        "generated_at": generated_at,
+        "goal_id": GOAL_ID,
+        "classification": "dreaming_refactor_warning",
+        "recommended_action": "Review the advisory dreaming proposal before promotion.",
+        "operator_question": "Should this proposal become a normal delivery todo?",
+        "dreaming": {
+            "schema_version": "dreaming_proposal_v0",
+            "proposal_id": proposal_id,
+            "lane": "exploration",
+            "evidence_window": "last_3_non_neutral_runs",
+            "proposal_type": "refactor_warning",
+            "confidence": "medium",
+            "requires_project_controller": True,
+            "advisory": True,
+            "promoted_to_delivery": False,
+            "execution_allowed": False,
+            "delivery_spend_allowed": False,
+            "server_planning_contract": {
+                "schema_version": "server_managed_planning_contract_v0",
+                "lane": "dreaming_planning",
+                "authority": "proposal_only_until_promoted",
+                "may_rank_candidate_todos": True,
+                "may_suggest_evidence_probes": True,
+                "may_execute_protected_actions": False,
+                "may_read_private_material": False,
+                "may_mutate_active_state": False,
+                "may_append_delivery_history": False,
+                "may_spend_delivery_quota": False,
+                "promotion_required": True,
+            },
+        },
+        "json_path": str(json_path),
+        "markdown_path": str(markdown_path),
+    }
+    json_path.write_text(json.dumps(record, sort_keys=True) + "\n", encoding="utf-8")
+    markdown_path.write_text("# Recorded Dreaming Proposal\n", encoding="utf-8")
+    with (runs_dir / "index.jsonl").open("a", encoding="utf-8") as f:
+        f.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+def write_fixture(root: Path) -> tuple[Path, Path, Path, Path]:
+    project = root / "project"
+    runtime = root / "runtime"
+    state_file = f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    state_path = project / state_file
+    registry_path = project / ".loopx" / "registry.json"
+    runs_dir = runtime / "goals" / GOAL_ID / "runs"
+
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        "---\n"
+        "status: active\n"
+        "updated_at: 2026-01-01T00:00:00+00:00\n"
+        "---\n\n"
+        "# Dreaming Decision Fixture\n\n"
+        "## Next Action\n\n"
+        "- Continue delivery only after explicit proposal decisions.\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] [P1] Keep existing normal delivery separate from advisory dreaming.\n",
+        encoding="utf-8",
+    )
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "dreaming-decision-fixture",
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": state_file,
+                        "adapter": {
+                            "kind": "harness_self_improvement",
+                            "status": "connected-read-only",
+                        },
+                        "quota": {
+                            "compute": 1.0,
+                            "window_hours": 24,
+                            "allowed_slots": 5,
+                        },
+                    }
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    append_recorded_proposal(
+        runs_dir,
+        generated_at="2026-01-01T00:00:00+00:00",
+        proposal_id="dreaming_fixture_approve",
+    )
+    append_recorded_proposal(
+        runs_dir,
+        generated_at="2026-01-01T00:01:00+00:00",
+        proposal_id="dreaming_fixture_defer",
+    )
+    append_recorded_proposal(
+        runs_dir,
+        generated_at="2026-01-01T00:02:00+00:00",
+        proposal_id="dreaming_fixture_reject",
+    )
+    return registry_path, runtime, state_path, runs_dir / "index.jsonl"
+
+
+def assert_no_quota_spend(runtime: Path) -> None:
+    text = "\n".join(path.read_text(encoding="utf-8") for path in runtime.rglob("*.json*"))
+    assert "quota_slot_spent" not in text, text
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="loopx-dreaming-decision-") as tmp:
+        registry_path, runtime, state_path, index_path = write_fixture(Path(tmp))
+
+        approve = run_cli(
+            "dreaming",
+            "decide",
+            "--goal-id",
+            GOAL_ID,
+            "--proposal-id",
+            "dreaming_fixture_approve",
+            "--decision",
+            "approve",
+            "--reason-summary",
+            "The proposal is a bounded follow-up worth normal delivery review.",
+            "--todo-text",
+            "[P1] Implement the approved dreaming follow-up as normal delivery.",
+            "--no-global-sync",
+            registry_path=registry_path,
+            runtime=runtime,
+        )
+        assert approve["ok"] is True, approve
+        assert approve["appended"] is True, approve
+        assert approve["classification"] == "dreaming_proposal_approved", approve
+        assert approve["dreaming_decision"]["promoted_to_delivery"] is True, approve
+        assert approve["dreaming_decision"]["delivery_spend_allowed"] is False, approve
+        assert approve["dreaming_decision"]["quota_spent"] is False, approve
+        todo_id = approve["dreaming_decision"]["promoted_todo_id"]
+        assert todo_id and todo_id.startswith("todo_"), approve
+        assert approve["dreaming_decision"]["created_todo_id"] == todo_id, approve
+        assert approve["dreaming_decision"]["todo_added"] is True, approve
+        state_after_approve = state_path.read_text(encoding="utf-8")
+        assert "[P1] Implement the approved dreaming follow-up" in state_after_approve
+        assert "dreaming_fixture_approve" in state_after_approve
+        assert approve["side_effects"]["active_state_mutated"] is True, approve
+        assert approve["side_effects"]["runtime_history_appended"] is True, approve
+        assert approve["side_effects"]["quota_spent"] is False, approve
+        assert_no_quota_spend(runtime)
+
+        before_defer_state = state_path.read_text(encoding="utf-8")
+        before_defer_index = index_path.read_text(encoding="utf-8")
+        defer = run_cli(
+            "dreaming",
+            "decide",
+            "--goal-id",
+            GOAL_ID,
+            "--proposal-id",
+            "dreaming_fixture_defer",
+            "--decision",
+            "defer",
+            "--reason-summary",
+            "The proposal should wait for a stronger delivery boundary.",
+            "--no-global-sync",
+            registry_path=registry_path,
+            runtime=runtime,
+        )
+        assert defer["ok"] is True, defer
+        assert defer["classification"] == "dreaming_proposal_deferred", defer
+        assert defer["dreaming_decision"]["promoted_to_delivery"] is False, defer
+        assert defer["dreaming_decision"]["promoted_todo_id"] is None, defer
+        assert defer["dreaming_decision"]["created_todo_id"] is None, defer
+        assert defer["dreaming_decision"]["todo_added"] is False, defer
+        assert defer["side_effects"]["active_state_mutated"] is False, defer
+        assert defer["side_effects"]["runtime_history_appended"] is True, defer
+        assert defer["side_effects"]["quota_spent"] is False, defer
+        assert state_path.read_text(encoding="utf-8") == before_defer_state
+        assert index_path.read_text(encoding="utf-8") != before_defer_index
+        assert_no_quota_spend(runtime)
+
+        before_reject_state = state_path.read_text(encoding="utf-8")
+        before_reject_index = index_path.read_text(encoding="utf-8")
+        reject = run_cli(
+            "dreaming",
+            "decide",
+            "--goal-id",
+            GOAL_ID,
+            "--proposal-id",
+            "dreaming_fixture_reject",
+            "--decision",
+            "reject",
+            "--reason-summary",
+            "The proposal is not useful for this goal boundary.",
+            "--dry-run",
+            "--no-global-sync",
+            registry_path=registry_path,
+            runtime=runtime,
+        )
+        assert reject["ok"] is True, reject
+        assert reject["dry_run"] is True, reject
+        assert reject["appended"] is False, reject
+        assert reject["side_effects"]["active_state_mutated"] is False, reject
+        assert reject["side_effects"]["runtime_history_appended"] is False, reject
+        assert reject["side_effects"]["quota_spent"] is False, reject
+        assert state_path.read_text(encoding="utf-8") == before_reject_state
+        assert index_path.read_text(encoding="utf-8") == before_reject_index
+
+    print("dreaming-proposal-decision-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/cli_commands/dreaming.py
+++ b/loopx/cli_commands/dreaming.py
@@ -4,7 +4,12 @@ import argparse
 from collections.abc import Callable
 from pathlib import Path
 
-from ..dreaming import build_dreaming_dry_run_proposal, render_dreaming_dry_run_markdown
+from ..dreaming import (
+    DREAMING_PROPOSAL_DECISIONS,
+    build_dreaming_dry_run_proposal,
+    record_dreaming_proposal_decision,
+    render_dreaming_markdown,
+)
 from ..history import collect_history, load_registry
 from ..paths import resolve_runtime_root
 
@@ -39,6 +44,47 @@ def register_dreaming_commands(
         help="Recent compact non-neutral runs to inspect. Defaults to 20; capped at 50.",
     )
 
+    decide_parser = dreaming_sub.add_parser(
+        "decide",
+        help="Record an explicit operator/controller decision for a recorded dreaming proposal.",
+    )
+    add_subcommand_format(decide_parser)
+    decide_parser.add_argument("--goal-id", required=True, help="Goal id that owns the dreaming proposal.")
+    decide_parser.add_argument(
+        "--proposal-id",
+        required=True,
+        help="Recorded dreaming proposal id to approve, defer, or reject.",
+    )
+    decide_parser.add_argument(
+        "--decision",
+        required=True,
+        choices=sorted(DREAMING_PROPOSAL_DECISIONS),
+        help="Decision to apply to the recorded dreaming proposal.",
+    )
+    decide_parser.add_argument(
+        "--reason-summary",
+        required=True,
+        help="Public-safe compact reason for the decision.",
+    )
+    decide_parser.add_argument(
+        "--todo-text",
+        help="Agent Todo text to create when approving the proposal.",
+    )
+    decide_parser.add_argument(
+        "--claimed-by",
+        help="Optional registered agent id to claim the approved follow-up todo.",
+    )
+    decide_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview the decision without appending runtime history or mutating active state.",
+    )
+    decide_parser.add_argument(
+        "--no-global-sync",
+        action="store_true",
+        help="Do not sync the project registry projection into the global registry after writing.",
+    )
+
 
 def handle_dreaming_command(
     args: argparse.Namespace,
@@ -50,27 +96,41 @@ def handle_dreaming_command(
 ) -> int:
     selected_format = output_format(args)
     try:
-        registry = load_registry(registry_path)
-        runtime_root = resolve_runtime_root(registry, runtime_root_arg)
-        history_payload = collect_history(
-            registry_path=registry_path,
-            runtime_root=runtime_root,
-            goal_id=args.goal_id,
-            limit=max(1, min(int(args.limit), 50)),
-            include_runtime_goals=False,
-        )
-        if args.dreaming_command != "dry-run":
+        if args.dreaming_command == "dry-run":
+            registry = load_registry(registry_path)
+            runtime_root = resolve_runtime_root(registry, runtime_root_arg)
+            history_payload = collect_history(
+                registry_path=registry_path,
+                runtime_root=runtime_root,
+                goal_id=args.goal_id,
+                limit=max(1, min(int(args.limit), 50)),
+                include_runtime_goals=False,
+            )
+            payload = build_dreaming_dry_run_proposal(
+                history_payload,
+                goal_id=args.goal_id,
+                limit=args.limit,
+            )
+        elif args.dreaming_command == "decide":
+            payload = record_dreaming_proposal_decision(
+                registry_path=registry_path,
+                runtime_root_override=runtime_root_arg,
+                goal_id=args.goal_id,
+                proposal_id=args.proposal_id,
+                decision=args.decision,
+                reason_summary=args.reason_summary,
+                todo_text=args.todo_text,
+                claimed_by=args.claimed_by,
+                dry_run=bool(args.dry_run),
+                sync_global=not bool(args.no_global_sync),
+            )
+        else:
             raise ValueError(f"unsupported dreaming command: {args.dreaming_command}")
-        payload = build_dreaming_dry_run_proposal(
-            history_payload,
-            goal_id=args.goal_id,
-            limit=args.limit,
-        )
     except Exception as exc:
         payload = {
             "ok": False,
             "goal_id": getattr(args, "goal_id", None),
-            "dry_run": True,
+            "dry_run": bool(getattr(args, "dry_run", True)),
             "error": str(exc),
             "side_effects": {
                 "project_files_mutated": False,
@@ -79,5 +139,5 @@ def handle_dreaming_command(
                 "quota_spent": False,
             },
         }
-    print_payload(payload, selected_format, render_dreaming_dry_run_markdown)
+    print_payload(payload, selected_format, render_dreaming_markdown)
     return 0 if payload.get("ok") else 1

--- a/loopx/dreaming.py
+++ b/loopx/dreaming.py
@@ -1,19 +1,31 @@
 from __future__ import annotations
 
+import hashlib
 from collections import Counter
+from pathlib import Path
 from typing import Any
 
+from .feedback import validate_public_safe_text
+from .global_registry import sync_project_registry_to_global
+from .history import collect_history, load_registry, write_reserved_run_artifacts
+from .paths import resolve_runtime_root
+from .registry import registry_goals
+from .runtime import validate_goal_id_path_segment
 from .status import (
     DREAMING_ADVISORY_CLASSIFICATIONS,
     STATUS_NEUTRAL_CLASSIFICATIONS,
     public_safe_compact_text,
 )
+from .state_refresh import now_local
+from .todos import add_goal_todo, update_goal_todo
 
 
 DREAMING_DRY_RUN_SCHEMA_VERSION = "dreaming_dry_run_proposal_v0"
 DREAMING_PROPOSAL_SCHEMA_VERSION = "dreaming_proposal_v0"
+DREAMING_PROPOSAL_DECISION_SCHEMA_VERSION = "dreaming_proposal_decision_v0"
 SERVER_PLANNING_CONTRACT_SCHEMA_VERSION = "server_managed_planning_contract_v0"
 MAX_DREAMING_EVIDENCE_ITEMS = 5
+DREAMING_PROPOSAL_DECISIONS = {"approve", "defer", "reject"}
 
 
 def _compact_run(run: dict[str, Any]) -> dict[str, Any]:
@@ -131,6 +143,59 @@ def _proposal_summary(runs: list[dict[str, Any]], proposal_type: str) -> str:
     return f"Recent run history suggests an exploration option for operator review: {top}."
 
 
+def _proposal_id(
+    *,
+    goal_id: str,
+    proposal_type: str,
+    evidence_window: str,
+    runs: list[dict[str, Any]],
+) -> str:
+    seed_parts = [goal_id, proposal_type, evidence_window]
+    for run in runs[:MAX_DREAMING_EVIDENCE_ITEMS]:
+        seed_parts.append(str(run.get("generated_at") or ""))
+        seed_parts.append(str(run.get("classification") or ""))
+    digest = hashlib.sha256("\n".join(seed_parts).encode("utf-8")).hexdigest()[:12]
+    return f"dreaming_{digest}"
+
+
+def _registry_goal(registry: dict[str, Any], goal_id: str) -> dict[str, Any] | None:
+    for goal in registry_goals(registry):
+        if str(goal.get("id") or "") == goal_id:
+            return goal
+    return None
+
+
+def _compact_source_proposal(run: dict[str, Any]) -> dict[str, Any]:
+    dreaming = run.get("dreaming") if isinstance(run.get("dreaming"), dict) else {}
+    return {
+        "generated_at": public_safe_compact_text(run.get("generated_at"), limit=120),
+        "classification": public_safe_compact_text(run.get("classification"), limit=120),
+        "proposal_id": public_safe_compact_text(dreaming.get("proposal_id"), limit=120),
+        "proposal_type": public_safe_compact_text(dreaming.get("proposal_type"), limit=120),
+        "evidence_window": public_safe_compact_text(dreaming.get("evidence_window"), limit=160),
+        "summary": public_safe_compact_text(run.get("summary") or run.get("recommended_action"), limit=260),
+    }
+
+
+def _find_source_proposal(
+    history_payload: dict[str, Any],
+    *,
+    goal_id: str,
+    proposal_id: str,
+) -> dict[str, Any] | None:
+    goal = _goal_record(history_payload, goal_id)
+    if not goal:
+        return None
+    latest_runs = goal.get("latest_runs") if isinstance(goal.get("latest_runs"), list) else []
+    for run in latest_runs:
+        if not isinstance(run, dict):
+            continue
+        dreaming = run.get("dreaming") if isinstance(run.get("dreaming"), dict) else {}
+        if str(dreaming.get("proposal_id") or "") == proposal_id:
+            return run
+    return None
+
+
 def build_server_managed_planning_contract() -> dict[str, Any]:
     """Return the default contract for server-managed planning proposals."""
 
@@ -202,10 +267,17 @@ def build_dreaming_dry_run_proposal(
     proposal_type = _proposal_type(runs)
     classification = _classification_for_proposal_type(proposal_type)
     evidence_window = f"last_{len(runs)}_non_neutral_runs" if runs else "no_recent_non_neutral_runs"
+    proposal_id = _proposal_id(
+        goal_id=goal_id,
+        proposal_type=proposal_type,
+        evidence_window=evidence_window,
+        runs=runs,
+    )
     question = _operator_question(goal_id, proposal_type)
     server_planning_contract = build_server_managed_planning_contract()
     dreaming = {
         "schema_version": DREAMING_PROPOSAL_SCHEMA_VERSION,
+        "proposal_id": proposal_id,
         "lane": "exploration",
         "evidence_window": evidence_window,
         "proposal_type": proposal_type,
@@ -233,6 +305,7 @@ def build_dreaming_dry_run_proposal(
         "schema_version": DREAMING_DRY_RUN_SCHEMA_VERSION,
         "goal_id": goal_id,
         "dry_run": True,
+        "proposal_id": proposal_id,
         "classification": classification,
         "proposal_type": proposal_type,
         "summary": _proposal_summary(runs, proposal_type),
@@ -257,6 +330,249 @@ def build_dreaming_dry_run_proposal(
     }
 
 
+def classification_for_dreaming_decision(decision: str) -> str:
+    if decision == "approve":
+        return "dreaming_proposal_approved"
+    if decision == "defer":
+        return "dreaming_proposal_deferred"
+    if decision == "reject":
+        return "dreaming_proposal_rejected"
+    raise ValueError(f"decision must be one of: {', '.join(sorted(DREAMING_PROPOSAL_DECISIONS))}")
+
+
+def _recommended_action_for_decision(decision: str, promoted_todo_id: str | None) -> str:
+    if decision == "approve":
+        if promoted_todo_id:
+            return (
+                f"Approved dreaming proposal was promoted into Agent Todo {promoted_todo_id}; "
+                "run quota should-run before executing it."
+            )
+        return (
+            "Approved dreaming proposal matched an existing Agent Todo; run quota "
+            "should-run before executing the promoted work."
+        )
+    if decision == "defer":
+        return "Deferred dreaming proposal; no delivery todo was created and no quota was spent."
+    return "Rejected dreaming proposal; no delivery todo was created and no quota was spent."
+
+
+def build_dreaming_decision_record(
+    *,
+    goal_id: str,
+    registry_goal: dict[str, Any] | None,
+    generated_at: str,
+    classification: str,
+    recommended_action: str,
+    source_proposal: dict[str, Any],
+    decision_payload: dict[str, Any],
+) -> dict[str, Any]:
+    adapter = (
+        registry_goal.get("adapter")
+        if isinstance(registry_goal, dict) and isinstance(registry_goal.get("adapter"), dict)
+        else {}
+    )
+    promoted_todo_id = decision_payload.get("promoted_todo_id")
+    health_check = (
+        f"dreaming_decision decision={decision_payload.get('decision')}; "
+        "source_proposal 1/1; "
+        f"promoted_todo {1 if promoted_todo_id else 0}/1; "
+        "quota_spent 0/1"
+    )
+    return {
+        "generated_at": generated_at,
+        "goal_id": goal_id,
+        "classification": classification,
+        "recommended_action": recommended_action,
+        "health_check": health_check,
+        "delivery_batch_scale": "single_surface",
+        "delivery_outcome": "outcome_progress",
+        "dreaming_decision": decision_payload,
+        "source_dreaming_proposal": source_proposal,
+        "registry_goal": {
+            "present": bool(registry_goal),
+            "domain": registry_goal.get("domain") if registry_goal else None,
+            "status": registry_goal.get("status") if registry_goal else None,
+            "adapter": {
+                "kind": adapter.get("kind"),
+                "status": adapter.get("status"),
+            },
+        },
+    }
+
+
+def record_dreaming_proposal_decision(
+    *,
+    registry_path: Path,
+    runtime_root_override: str | None,
+    goal_id: str,
+    proposal_id: str,
+    decision: str,
+    reason_summary: str,
+    todo_text: str | None,
+    claimed_by: str | None,
+    dry_run: bool,
+    sync_global: bool = True,
+) -> dict[str, Any]:
+    safe_goal_id = validate_goal_id_path_segment(goal_id)
+    validate_public_safe_text("proposal_id", proposal_id)
+    validate_public_safe_text("reason_summary", reason_summary)
+    validate_public_safe_text("todo_text", todo_text)
+    if decision not in DREAMING_PROPOSAL_DECISIONS:
+        raise ValueError(f"decision must be one of: {', '.join(sorted(DREAMING_PROPOSAL_DECISIONS))}")
+    if decision == "approve" and not todo_text:
+        raise ValueError("--todo-text is required when --decision approve")
+    if decision != "approve" and todo_text:
+        raise ValueError("--todo-text is only valid when --decision approve")
+
+    registry = load_registry(registry_path)
+    runtime_root = resolve_runtime_root(registry, runtime_root_override)
+    history_payload = collect_history(
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        goal_id=safe_goal_id,
+        limit=50,
+        include_runtime_goals=False,
+    )
+    source_run = _find_source_proposal(history_payload, goal_id=safe_goal_id, proposal_id=proposal_id)
+    if not source_run:
+        raise ValueError(f"dreaming proposal not found for goal_id={safe_goal_id} proposal_id={proposal_id}")
+
+    source_proposal = _compact_source_proposal(source_run)
+    promoted_todo_id: str | None = None
+    todo_result: dict[str, Any] | None = None
+    todo_evidence_result: dict[str, Any] | None = None
+    active_state_mutated = False
+    if decision == "approve":
+        if not dry_run:
+            todo_result = add_goal_todo(
+                registry_path=registry_path,
+                goal_id=safe_goal_id,
+                role="agent",
+                text=str(todo_text or ""),
+                task_class="advancement_task",
+                action_kind="dreaming_proposal_promotion",
+                claimed_by=claimed_by,
+                dry_run=False,
+            )
+            promoted_todo_id = str(todo_result.get("todo_id") or "") or None
+            if promoted_todo_id:
+                todo_evidence_result = update_goal_todo(
+                    registry_path=registry_path,
+                    goal_id=safe_goal_id,
+                    role="agent",
+                    todo_id=promoted_todo_id,
+                    evidence=f"dreaming_proposal:{proposal_id}",
+                    note="Approved dreaming proposal promoted to normal Agent Todo.",
+                    dry_run=False,
+                )
+            active_state_mutated = bool(
+                todo_result
+                and (todo_result.get("added") or todo_result.get("metadata_updated"))
+                or todo_evidence_result
+                and todo_evidence_result.get("changed")
+            )
+
+    classification = classification_for_dreaming_decision(decision)
+    generated_at = now_local()
+    decision_payload = {
+        "schema_version": DREAMING_PROPOSAL_DECISION_SCHEMA_VERSION,
+        "proposal_id": proposal_id,
+        "decision": decision,
+        "reason_summary": public_safe_compact_text(reason_summary, limit=260),
+        "promoted_to_delivery": decision == "approve",
+        "promoted_todo_id": promoted_todo_id,
+        "created_todo_id": promoted_todo_id if todo_result and todo_result.get("added") else None,
+        "todo_added": bool(todo_result and todo_result.get("added")),
+        "delivery_spend_allowed": False,
+        "quota_spent": False,
+    }
+    if claimed_by and decision == "approve":
+        decision_payload["claimed_by"] = claimed_by
+    recommended_action = _recommended_action_for_decision(decision, promoted_todo_id)
+    validate_public_safe_text("recommended_action", recommended_action)
+    registry_goal = _registry_goal(registry, safe_goal_id)
+    record = build_dreaming_decision_record(
+        goal_id=safe_goal_id,
+        registry_goal=registry_goal,
+        generated_at=generated_at,
+        classification=classification,
+        recommended_action=recommended_action,
+        source_proposal=source_proposal,
+        decision_payload=decision_payload,
+    )
+
+    runs_dir = runtime_root / "goals" / safe_goal_id / "runs"
+    index_record = {
+        "generated_at": generated_at,
+        "goal_id": safe_goal_id,
+        "classification": classification,
+        "recommended_action": recommended_action,
+        "health_check": record["health_check"],
+        "dreaming_decision": decision_payload,
+        "source_dreaming_proposal": source_proposal,
+    }
+    runtime_history_appended = not dry_run
+    payload: dict[str, Any] = {
+        "ok": True,
+        "schema_version": DREAMING_PROPOSAL_DECISION_SCHEMA_VERSION,
+        "dry_run": dry_run,
+        "appended": not dry_run,
+        "registry": str(registry_path),
+        "runtime_root": str(runtime_root),
+        "goal_id": safe_goal_id,
+        "proposal_id": proposal_id,
+        "classification": classification,
+        "recommended_action": recommended_action,
+        "generated_at": generated_at,
+        "health_check": record["health_check"],
+        "decision": decision,
+        "dreaming_decision": decision_payload,
+        "source_dreaming_proposal": source_proposal,
+        "todo_result": todo_result,
+        "todo_evidence_result": todo_evidence_result,
+        "side_effects": {
+            "project_files_mutated": bool(runtime_history_appended or active_state_mutated),
+            "active_state_mutated": bool(active_state_mutated),
+            "runtime_history_appended": runtime_history_appended,
+            "todo_added": bool(todo_result and todo_result.get("added")),
+            "quota_spent": False,
+        },
+        "write_policy": {
+            "append_runtime_history": True,
+            "mutate_active_state": decision == "approve",
+            "grant_agent_command": False,
+            "spend_quota": False,
+        },
+    }
+    if dry_run:
+        payload.update(
+            {
+                "json_path": None,
+                "markdown_path": None,
+                "index_path": str(runs_dir / "index.jsonl"),
+            }
+        )
+    else:
+        write_reserved_run_artifacts(
+            runs_dir=runs_dir,
+            generated_at=generated_at,
+            record=record,
+            index_record=index_record,
+            payload=payload,
+            render_markdown=render_dreaming_decision_markdown,
+        )
+    if sync_global:
+        payload["global_sync"] = sync_project_registry_to_global(
+            registry_path=registry_path,
+            runtime_root_override=str(runtime_root),
+            goal_id=safe_goal_id,
+            dry_run=dry_run,
+        )
+    else:
+        payload["global_sync"] = {"enabled": False}
+    return payload
+
+
 def render_dreaming_dry_run_markdown(payload: dict[str, Any]) -> str:
     lines = [
         "# Dreaming Dry-Run Proposal",
@@ -278,6 +594,7 @@ def render_dreaming_dry_run_markdown(payload: dict[str, Any]) -> str:
     lines.extend(
         [
             f"- Classification: `{payload.get('classification')}`",
+            f"- Proposal id: `{payload.get('proposal_id')}`",
             f"- Proposal type: `{payload.get('proposal_type')}`",
             f"- Summary: {payload.get('summary')}",
             f"- Operator question: {payload.get('operator_question')}",
@@ -310,3 +627,51 @@ def render_dreaming_dry_run_markdown(payload: dict[str, Any]) -> str:
             f"{item.get('recommended_action') or item.get('delivery_outcome') or ''}"
         )
     return "\n".join(lines) + "\n"
+
+
+def render_dreaming_decision_markdown(payload: dict[str, Any]) -> str:
+    decision = (
+        payload.get("dreaming_decision")
+        if isinstance(payload.get("dreaming_decision"), dict)
+        else {}
+    )
+    source = (
+        payload.get("source_dreaming_proposal")
+        if isinstance(payload.get("source_dreaming_proposal"), dict)
+        else {}
+    )
+    side_effects = payload.get("side_effects") if isinstance(payload.get("side_effects"), dict) else {}
+    lines = [
+        "# Dreaming Proposal Decision",
+        "",
+        f"- Goal: `{payload.get('goal_id')}`",
+        f"- OK: `{payload.get('ok')}`",
+        f"- Dry run: `{payload.get('dry_run')}`",
+        f"- Appended: `{payload.get('appended')}`",
+        f"- Classification: `{payload.get('classification')}`",
+        f"- Proposal id: `{payload.get('proposal_id')}`",
+        f"- Decision: `{payload.get('decision')}`",
+        f"- Promoted to delivery: `{decision.get('promoted_to_delivery')}`",
+        f"- Promoted todo: `{decision.get('promoted_todo_id')}`",
+        f"- Created todo: `{decision.get('created_todo_id')}`",
+        f"- Runtime history appended: `{side_effects.get('runtime_history_appended')}`",
+        f"- Active state mutated: `{side_effects.get('active_state_mutated')}`",
+        f"- Quota spent: `{side_effects.get('quota_spent')}`",
+        f"- Recommended action: {payload.get('recommended_action')}",
+        "",
+        "## Source Proposal",
+        "",
+        f"- Generated at: `{source.get('generated_at')}`",
+        f"- Classification: `{source.get('classification')}`",
+        f"- Proposal type: `{source.get('proposal_type')}`",
+        f"- Evidence window: `{source.get('evidence_window')}`",
+    ]
+    if source.get("summary"):
+        lines.append(f"- Summary: {source.get('summary')}")
+    return "\n".join(lines) + "\n"
+
+
+def render_dreaming_markdown(payload: dict[str, Any]) -> str:
+    if payload.get("schema_version") == DREAMING_PROPOSAL_DECISION_SCHEMA_VERSION:
+        return render_dreaming_decision_markdown(payload)
+    return render_dreaming_dry_run_markdown(payload)

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -6199,7 +6199,7 @@ def compact_dreaming_proposal(run: dict[str, Any] | None) -> dict[str, Any] | No
         "execution_allowed": False,
         "delivery_spend_allowed": False,
     }
-    for key in ("lane", "evidence_window", "proposal_type", "confidence"):
+    for key in ("proposal_id", "lane", "evidence_window", "proposal_type", "confidence"):
         value = public_safe_compact_text(raw.get(key), limit=80)
         if value:
             proposal[key] = value
@@ -6234,7 +6234,7 @@ def compact_dreaming_lane_badge(proposal: dict[str, Any] | None) -> dict[str, An
     }
     if classification:
         badge["status"] = classification
-    for field in ("proposal_type", "confidence", "evidence_window"):
+    for field in ("proposal_id", "proposal_type", "confidence", "evidence_window"):
         value = public_safe_compact_text(proposal.get(field), limit=80)
         if value:
             badge[field] = value
@@ -7891,6 +7891,7 @@ def render_status_markdown(payload: dict[str, Any]) -> str:
                     "    - dreaming_lane_badge: "
                     f"lane={_markdown_scalar(dreaming_lane_badge.get('lane') or '')} "
                     f"status={_markdown_scalar(dreaming_lane_badge.get('status') or '')} "
+                    f"proposal_id={_markdown_scalar(dreaming_lane_badge.get('proposal_id') or '')} "
                     f"advisory={dreaming_lane_badge.get('advisory')} "
                     f"interrupts_delivery={dreaming_lane_badge.get('interrupts_delivery')} "
                     f"execution_allowed={dreaming_lane_badge.get('execution_allowed')}"

--- a/regression/autonomous-replan-vs-dreaming-contract.py
+++ b/regression/autonomous-replan-vs-dreaming-contract.py
@@ -103,6 +103,7 @@ def write_fixture(root: Path) -> tuple[Path, Path]:
         "operator_question": "Should this project open a delivery todo for duplicate state handling?",
         "agent_command": "python should-not-run.py",
         "dreaming": {
+            "proposal_id": "dreaming_contract_fixture",
             "lane": "exploration",
             "evidence_window": "last_20_runs",
             "proposal_type": "refactor_warning",
@@ -150,6 +151,7 @@ def main() -> int:
         assert "next_safe_command" not in item["project_asset"], item
         proposal = item["project_asset"]["dreaming_proposal"]
         assert proposal["schema_version"] == "dreaming_proposal_v0", proposal
+        assert proposal["proposal_id"] == "dreaming_contract_fixture", proposal
         assert proposal["advisory"] is True, proposal
         assert proposal["promoted_to_delivery"] is False, proposal
         assert proposal["execution_allowed"] is False, proposal
@@ -172,6 +174,7 @@ def main() -> int:
         assert lane_badge["lane"] == "dreaming", lane_badge
         assert lane_badge["label"] == "Dreaming", lane_badge
         assert lane_badge["status"] == "dreaming_exploration_proposal", lane_badge
+        assert lane_badge["proposal_id"] == "dreaming_contract_fixture", lane_badge
         assert lane_badge["proposal_type"] == "refactor_warning", lane_badge
         assert lane_badge["advisory"] is True, lane_badge
         assert lane_badge["review_required"] is True, lane_badge


### PR DESCRIPTION
## Summary
- add `loopx dreaming decide` for explicit approve/defer/reject decisions on recorded `dreaming_proposal_v0` records
- promote approved proposals into normal Agent Todo items with source proposal evidence, while keeping defer/reject as decision-only runtime history
- surface `proposal_id` through dreaming status/badge projection so operators can act on the recorded proposal

## Validation
- `python3 -m py_compile loopx/dreaming.py loopx/cli_commands/dreaming.py loopx/status.py`
- `python3 examples/dreaming-dry-run-proposal-smoke.py`
- `python3 examples/dreaming-proposal-decision-smoke.py`
- `python3 regression/autonomous-replan-vs-dreaming-contract.py`
- `loopx check --scan-path loopx/dreaming.py --scan-path loopx/cli_commands/dreaming.py --scan-path loopx/status.py --scan-path examples/dreaming-dry-run-proposal-smoke.py --scan-path examples/dreaming-proposal-decision-smoke.py --scan-path regression/autonomous-replan-vs-dreaming-contract.py`
- `git diff --check`

Note: `loopx check` passed with the existing duplicate-index warning for `loopx-meta`; scanned public files were clean.

## Merge policy
Runtime/API behavior change. This is intentionally not self-merged; please route through primary review.