### PR TITLE
Add LoopX version command

### DIFF
--- a/docs/product/codex-cli-automation-driver.md
+++ b/docs/product/codex-cli-automation-driver.md
@@ -4,7 +4,7 @@ Status: product contract and implementation target.
 
 LoopX should make Codex CLI feel easy before it feels automated. The
 primary path is still the Codex TUI: the user starts from a project repo, sends
-one Goal-Harness-generated message, and can keep watching, steering, reviewing,
+one LoopX-generated message, and can keep watching, steering, reviewing,
 or taking over. Automation is allowed only when it preserves that visible
 control surface. The default `/goal` product path does not offer headless
 fallback.

--- a/docs/research/long-horizon-agent-benchmarks/terminal-bench-codex-loopx-custom-agent-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/terminal-bench-codex-loopx-custom-agent-v0.md
@@ -29,7 +29,7 @@ leaderboard paths.
 When `loopx_mode=codex_loopx`, the custom agent injects:
 
 ```text
------ GOAL-HARNESS ACCESS PACKET -----
+----- LOOPX ACCESS PACKET -----
 LoopX Access Packet V0
 mode: codex_loopx
 loopx_interface_surface: prompt_packet_only_no_cli_bridge
@@ -39,7 +39,7 @@ declared_loopx_interface_commands: status, quota_should_run, todo_list, history,
 count_codex_runtime_goal_tools_separately_from_loopx_calls: true
 do_not_claim_loopx_cli_calls_without_bridge_or_trace: true
 report_interaction_counters_after_the_case: true
------ END GOAL-HARNESS ACCESS PACKET -----
+----- END LOOPX ACCESS PACKET -----
 ```
 
 The raw prompt is not recorded in public artifacts. The adapter records only

--- a/examples/codex-cli-automation-driver-audit-smoke.py
+++ b/examples/codex-cli-automation-driver-audit-smoke.py
@@ -16,7 +16,7 @@ def main() -> int:
     index = PRODUCT_INDEX.read_text()
 
     required_contracts = [
-        "one Goal-Harness-generated message",
+        "one LoopX-generated message",
         "does not expose a mature native recurring scheduler",
         "recurrence as a LoopX local-driver concern",
         "codex resume [SESSION_ID] [PROMPT]",

--- a/examples/subcommand-format-smoke.py
+++ b/examples/subcommand-format-smoke.py
@@ -14,6 +14,14 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 GOAL_ID = "subcommand-format-goal"
 
 
+def package_version() -> str:
+    namespace: dict[str, object] = {}
+    exec((REPO_ROOT / "loopx" / "__init__.py").read_text(encoding="utf-8"), namespace)
+    version = namespace.get("__version__")
+    assert isinstance(version, str), version
+    return version
+
+
 def write_fixture(root: Path) -> Path:
     project = root / "project"
     runtime = root / "runtime"
@@ -86,6 +94,35 @@ def cli_json(registry_path: Path, *args: str) -> dict:
 
 
 def main() -> int:
+    expected_version = package_version()
+    version_text = subprocess.run(
+        [sys.executable, "-m", "loopx.cli", "--version"],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+    )
+    assert version_text.returncode == 0, (
+        version_text.returncode,
+        version_text.stdout,
+        version_text.stderr,
+    )
+    assert version_text.stdout.strip() == f"loopx {expected_version}", version_text.stdout
+
+    version_json = subprocess.run(
+        [sys.executable, "-m", "loopx.cli", "--format", "json", "version"],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+    )
+    assert version_json.returncode == 0, (
+        version_json.returncode,
+        version_json.stdout,
+        version_json.stderr,
+    )
+    version_payload = json.loads(version_json.stdout)
+    assert version_payload["ok"] is True, version_payload
+    assert version_payload["version"] == expected_version, version_payload
+
     with tempfile.TemporaryDirectory(prefix="loopx-subcommand-format-smoke-") as raw_tmp:
         registry_path = write_fixture(Path(raw_tmp))
 
@@ -110,7 +147,16 @@ def main() -> int:
         assert promotion["ok"] is True, promotion
         assert promotion["gate"] == "promotion_readiness", promotion
 
-        status = cli_json(registry_path, "status", "--format", "json", "--limit", "1")
+        status = cli_json(
+            registry_path,
+            "status",
+            "--format",
+            "json",
+            "--limit",
+            "1",
+            "--scan-root",
+            str(registry_path.parent.parent),
+        )
         assert status["ok"] is True, status
         assert "attention_queue" in status, status
 

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -5,6 +5,7 @@ import json
 import sys
 from pathlib import Path
 
+from . import __version__
 from .authority import (
     AUTHORITY_SOURCE_BOUNDARIES,
     import_doc_registry_authority,
@@ -313,6 +314,19 @@ def print_payload(payload: dict[str, object], fmt: str, markdown_renderer) -> No
         print(json.dumps(payload, ensure_ascii=False, indent=2))
     else:
         print(markdown_renderer(payload))
+
+
+def build_version_payload() -> dict[str, object]:
+    return {
+        "ok": True,
+        "schema_version": "loopx_version_v0",
+        "name": "loopx",
+        "version": __version__,
+    }
+
+
+def render_version_markdown(payload: dict[str, object]) -> str:
+    return f"{payload.get('name')} {payload.get('version')}\n"
 
 
 def render_benchmark_artifact_path_filter_markdown(payload: dict[str, object]) -> str:
@@ -2195,10 +2209,13 @@ def default_public_scan_root() -> str:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="LoopX control-plane helper.")
+    parser.add_argument("--version", action="version", version=f"loopx {__version__}")
     parser.add_argument("--registry", default=str(default_registry_path()), help="Path to a project-local registry.")
     parser.add_argument("--runtime-root", help="Override registry common_runtime_root.")
     parser.add_argument("--format", choices=["markdown", "json"], default="markdown")
     sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("version", help="Print the installed LoopX version.")
 
     bootstrap_parser = sub.add_parser(
         "bootstrap",
@@ -6121,6 +6138,7 @@ def main(argv: list[str] | None = None) -> int:
             "new-project-prompt",
             "heartbeat-prompt",
             "sync-global",
+            "version",
         }
         and not user_supplied_registry(argv)
         and not registry_path.exists()
@@ -6129,6 +6147,10 @@ def main(argv: list[str] | None = None) -> int:
         fallback_registry = global_registry_path(runtime_root)
         if fallback_registry.exists():
             registry_path = fallback_registry
+
+    if args.command == "version":
+        print_payload(build_version_payload(), args.format, render_version_markdown)
+        return 0
 
     if args.command in {"bootstrap", "connect"}:
         try:

--- a/loopx/terminal_bench_agent.py
+++ b/loopx/terminal_bench_agent.py
@@ -254,9 +254,9 @@ def build_managed_terminal_bench_instruction(
         )
         access_packet = (
             "\nLoopX access packet for this case:\n\n"
-            "----- GOAL-HARNESS ACCESS PACKET -----\n"
+            "----- LOOPX ACCESS PACKET -----\n"
             f"{access_packet_body}\n"
-            "----- END GOAL-HARNESS ACCESS PACKET -----\n\n"
+            "----- END LOOPX ACCESS PACKET -----\n\n"
         )
     active_user_observe_instruction = build_private_active_user_observe_instruction(
         enabled=(


### PR DESCRIPTION
## Summary\n- add loopx 0.1.2 and loopx 0.1.2 with JSON output support\n- cover version probing in the subcommand format smoke\n- clean up remaining public Goal Harness wording in LoopX-facing docs/packet labels\n\n## Validation\n- subcommand-format-smoke ok\n- codex-cli-automation-driver-audit-smoke ok\n- loopx 0.1.2\n- {
  "ok": true,
  "schema_version": "loopx_version_v0",
  "name": "loopx",
  "version": "0.1.2"
}