### PR TITLE
Skip legacy local state in boundary scan

### DIFF
--- a/examples/check-public-boundary-smoke.py
+++ b/examples/check-public-boundary-smoke.py
@@ -64,7 +64,7 @@ def main() -> int:
         project = root / "project"
         project.mkdir()
         (project / "README.md").write_text("public docs stay clean\n", encoding="utf-8")
-        for dirname in [".local", ".loopx", ".goal-wrapper.local", "runtime"]:
+        for dirname in [".local", ".loopx", ".goal-harness", ".goal-wrapper.local", "runtime"]:
             local_dir = project / dirname
             local_dir.mkdir(parents=True)
             (local_dir / "private.md").write_text(PRIVATE_DOC_MARKER, encoding="utf-8")

--- a/loopx/contract.py
+++ b/loopx/contract.py
@@ -38,6 +38,7 @@ LEAK_PATTERNS = {
 DEFAULT_SCAN_SUFFIXES = {".md", ".py", ".toml", ".json", ".yaml", ".yml", ".sh"}
 DEFAULT_SKIP_DIRS = {
     ".git",
+    ".goal-harness",
     ".loopx",
     ".goal-wrapper.local",
     ".local",


### PR DESCRIPTION
## Summary
- treat legacy `.goal-harness/` as local-private state in the public boundary scanner
- extend the boundary smoke so private markers under `.goal-harness/` are skipped like `.loopx/` and `.local/`

## Validation
- `python3 examples/check-public-boundary-smoke.py`
- `loopx --format json --registry ~/.codex/loopx/registry.global.json status --limit 5 --agent-id codex-main-control`
