### PR TITLE
Expose LoopX benchmark closeout todo state

### DIFF
--- a/examples/harbor-host-codex-goal-agent-smoke.py
+++ b/examples/harbor-host-codex-goal-agent-smoke.py
@@ -268,6 +268,68 @@ def main() -> int:
             trace=trace,
             cwd="/workspace",
         )
+        status_summary = module._compact_json_keys(
+            json.dumps(
+                {
+                    "ok": True,
+                    "goal_id": init_payload["benchmark_case_goal_id"],
+                    "agent_todo_summary": {
+                        "schema_version": "todo_summary_v0",
+                        "open_count": 1,
+                        "first_open_items": [
+                            {
+                                "todo_id": init_payload["case_todo_id"],
+                                "status": "open",
+                                "claimed_by": init_payload["case_agent_id"],
+                                "priority": "P0",
+                                "task_class": "advancement_task",
+                            }
+                        ],
+                    },
+                    "user_todo_summary": {
+                        "schema_version": "todo_summary_v0",
+                        "open_count": 0,
+                    },
+                    "interaction_contract": {
+                        "schema_version": "loopx_interaction_contract_v0",
+                        "mode": "bounded_delivery",
+                        "user_channel": {"action_required": False},
+                        "agent_channel": {
+                            "must_attempt": True,
+                            "delivery_allowed": True,
+                        },
+                        "cli_channel": {"spend_after_validation": True},
+                    },
+                }
+            ),
+            case_todo_id=init_payload["case_todo_id"],
+        )
+        trace["commands"].extend(
+            [
+                {
+                    "action": "timeout_blocker_status",
+                    "ok": True,
+                    "stdout_summary": status_summary,
+                    "raw_output_recorded": False,
+                },
+                {
+                    "action": "timeout_blocker_refresh_state",
+                    "ok": True,
+                    "stdout_summary": {"json_parse_ok": True, "refreshed": True},
+                    "raw_output_recorded": False,
+                },
+                {
+                    "action": "timeout_blocker_quota_spend",
+                    "ok": True,
+                    "stdout_summary": {"json_parse_ok": True, "spent": True},
+                    "raw_output_recorded": False,
+                },
+            ]
+        )
+        trace["closeout_summary"] = module._case_scheduler_closeout_summary(
+            trace,
+            result_kind="timeout_blocker",
+        )
         return trace
 
     scheduler_trace = asyncio.run(_exercise_case_scheduler())
@@ -277,6 +339,21 @@ def main() -> int:
         "install": 1,
         "quota_should_run": 1,
         "todo_claim": 1,
+    }, scheduler_trace
+    assert scheduler_trace["closeout_summary"] == {
+        "schema_version": "harbor_case_loopx_closeout_summary_v0",
+        "result_kind": "timeout_blocker",
+        "status_observed": True,
+        "refresh_state_observed": True,
+        "quota_spend_observed": True,
+        "agent_open_count": 1,
+        "user_open_count": 0,
+        "case_todo_id": "todo_benchmark_case_main",
+        "case_todo_status": "open",
+        "case_todo_claimed_by": "codex-benchmark-agent",
+        "timeout_preserves_open_todo": True,
+        "raw_logs_recorded": False,
+        "raw_output_recorded": False,
     }, scheduler_trace
     assert scheduler_trace["raw_logs_recorded"] is False, scheduler_trace
 
@@ -331,7 +408,7 @@ def main() -> int:
                 ),
             ]
         ):
-            (request_dir / f"case-gh-{index}.request.json").write_text(
+            (request_dir / f"case-loopx-{index}.request.json").write_text(
                 json.dumps(
                     {
                         "command": command,

--- a/scripts/harbor_host_codex_goal_agent.py
+++ b/scripts/harbor_host_codex_goal_agent.py
@@ -162,7 +162,76 @@ def _coerce_bool(value: str | bool) -> bool:
     return value.strip().lower() not in {"0", "false", "no", "off"}
 
 
-def _compact_json_keys(text: str) -> dict[str, Any]:
+def _compact_todo_summary(value: Any, *, todo_id: str = "") -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    summary: dict[str, Any] = {}
+    for key in ("schema_version", "open_count", "done_count", "completed_count"):
+        if key in value:
+            summary[key] = value[key]
+    items: list[Any] = []
+    for key in ("items", "first_open_items", "first_executable_items"):
+        candidate = value.get(key)
+        if isinstance(candidate, list):
+            items.extend(candidate)
+    if todo_id:
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            if str(item.get("todo_id") or "") != todo_id:
+                continue
+            summary["case_todo"] = {
+                key: item.get(key)
+                for key in (
+                    "todo_id",
+                    "status",
+                    "claimed_by",
+                    "priority",
+                    "task_class",
+                )
+                if item.get(key) not in (None, "")
+            }
+            break
+    return summary
+
+
+def _compact_interaction_contract(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    user_channel = value.get("user_channel")
+    agent_channel = value.get("agent_channel")
+    cli_channel = value.get("cli_channel")
+    return {
+        key: compact
+        for key, compact in {
+            "schema_version": value.get("schema_version"),
+            "mode": value.get("mode"),
+            "user_action_required": (
+                user_channel.get("action_required")
+                if isinstance(user_channel, dict)
+                else None
+            ),
+            "agent_must_attempt": (
+                agent_channel.get("must_attempt")
+                if isinstance(agent_channel, dict)
+                else None
+            ),
+            "delivery_allowed": (
+                agent_channel.get("delivery_allowed")
+                if isinstance(agent_channel, dict)
+                else None
+            ),
+            "spend_after_validation": (
+                cli_channel.get("spend_after_validation")
+                if isinstance(cli_channel, dict)
+                else None
+            ),
+        }.items()
+        if compact not in (None, "")
+    }
+
+
+def _compact_json_keys(text: str, *, case_todo_id: str = "") -> dict[str, Any]:
     try:
         payload = json.loads(text)
     except Exception:
@@ -186,10 +255,83 @@ def _compact_json_keys(text: str) -> dict[str, Any]:
         "raw_agent_trajectory_recorded",
         "local_paths_recorded",
     }
-    return {
+    compact = {
         "json_parse_ok": True,
         **{key: payload[key] for key in sorted(allowed & set(payload))},
     }
+    agent_summary = _compact_todo_summary(
+        payload.get("agent_todo_summary"),
+        todo_id=case_todo_id,
+    )
+    if agent_summary:
+        compact["agent_todo_summary"] = agent_summary
+    user_summary = _compact_todo_summary(payload.get("user_todo_summary"))
+    if user_summary:
+        compact["user_todo_summary"] = user_summary
+    interaction = _compact_interaction_contract(payload.get("interaction_contract"))
+    if interaction:
+        compact["interaction_contract"] = interaction
+    return compact
+
+
+def _case_scheduler_closeout_summary(
+    trace: dict[str, Any],
+    *,
+    result_kind: str,
+) -> dict[str, Any]:
+    commands = trace.get("commands") if isinstance(trace.get("commands"), list) else []
+    status_summary: dict[str, Any] = {}
+    refresh_observed = False
+    spend_observed = False
+    for command in commands:
+        if not isinstance(command, dict):
+            continue
+        action = str(command.get("action") or "")
+        if action.endswith("_status") and isinstance(
+            command.get("stdout_summary"), dict
+        ):
+            status_summary = command["stdout_summary"]
+        if action.endswith("_refresh_state") and command.get("ok"):
+            refresh_observed = True
+        if action.endswith("_quota_spend") and command.get("ok"):
+            spend_observed = True
+    agent_summary = (
+        status_summary.get("agent_todo_summary")
+        if isinstance(status_summary.get("agent_todo_summary"), dict)
+        else {}
+    )
+    user_summary = (
+        status_summary.get("user_todo_summary")
+        if isinstance(status_summary.get("user_todo_summary"), dict)
+        else {}
+    )
+    case_todo = (
+        agent_summary.get("case_todo")
+        if isinstance(agent_summary.get("case_todo"), dict)
+        else {}
+    )
+    closeout = {
+        "schema_version": "harbor_case_loopx_closeout_summary_v0",
+        "result_kind": result_kind,
+        "status_observed": bool(status_summary),
+        "refresh_state_observed": refresh_observed,
+        "quota_spend_observed": spend_observed,
+        "agent_open_count": agent_summary.get("open_count"),
+        "user_open_count": user_summary.get("open_count"),
+        "case_todo_id": case_todo.get("todo_id") or trace.get("case_todo_id") or "",
+        "case_todo_status": case_todo.get("status") or "",
+        "case_todo_claimed_by": case_todo.get("claimed_by") or "",
+        "timeout_preserves_open_todo": False,
+        "raw_logs_recorded": False,
+        "raw_output_recorded": False,
+    }
+    if result_kind == "timeout_blocker":
+        closeout["timeout_preserves_open_todo"] = (
+            not case_todo
+            or str(case_todo.get("status") or "").strip().lower()
+            not in {"done", "completed", "closed"}
+        )
+    return closeout
 
 
 def _case_loopx_action_from_command(
@@ -339,6 +481,7 @@ def _new_case_scheduler_trace(payload: dict[str, Any]) -> dict[str, Any]:
         "local_paths_recorded": False,
         "commands": [],
         "event_kind_counts": {},
+        "closeout_summary": {},
     }
 
 
@@ -365,7 +508,10 @@ async def _run_case_loopx_cli(
             "action": action,
             "return_code": return_code,
             "ok": return_code == 0,
-            "stdout_summary": _compact_json_keys(stdout.strip()),
+            "stdout_summary": _compact_json_keys(
+                stdout.strip(),
+                case_todo_id=str(payload.get("case_todo_id") or ""),
+            ),
             "stderr_present": bool(stderr.strip()),
             "raw_output_recorded": False,
         }
@@ -575,7 +721,7 @@ def build_case_goal_state_init_payload(
     route: str,
     max_rounds: int,
 ) -> dict[str, Any]:
-    """Build the public-safe case-local GH install/state/todo payload."""
+    """Build the public-safe case-local LoopX install/state/todo payload."""
 
     return dict(
         benchmark_case_loopx_install_payload(
@@ -1187,6 +1333,9 @@ class HarborHostCodexGoalAgent(BaseAgent):
                         "loopx_case_rollout_event_counts": (
                             case_scheduler_trace.get("event_kind_counts") or {}
                         ),
+                        "loopx_case_closeout_summary": (
+                            case_scheduler_trace.get("closeout_summary") or {}
+                        ),
                         "loopx_prompt_driven_trace_present": bool(
                             prompt_driven_trace.get("command_count")
                         ),
@@ -1319,6 +1468,12 @@ class HarborHostCodexGoalAgent(BaseAgent):
                         args=args,
                         cwd=self.task_workdir,
                     )
+                case_scheduler_trace["closeout_summary"] = (
+                    _case_scheduler_closeout_summary(
+                        case_scheduler_trace,
+                        result_kind=result_kind,
+                    )
+                )
                 await _collect_case_rollout_event_counts(
                     environment,
                     payload=case_state_init_payload,


### PR DESCRIPTION
## Summary
- add public-safe compact status projection for case-local LoopX todo summaries and interaction contract fields
- emit a Harbor case closeout summary showing status/refresh/spend observation and whether timeout preserved an open case todo
- extend Harbor host Codex Goal smoke coverage for timeout closeout semantics without recording raw commands or output

## Validation
- python3 examples/harbor-host-codex-goal-agent-smoke.py
- python3 -m py_compile scripts/harbor_host_codex_goal_agent.py examples/harbor-host-codex-goal-agent-smoke.py
- loopx check --scan-path scripts/harbor_host_codex_goal_agent.py --scan-path examples/harbor-host-codex-goal-agent-smoke.py