### PR TITLE
docs: focus PoC showcase frontstage surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,28 @@ LoopX 把一次静态 goal 变成能持续流转的动态 loop：该等人的地
 
 > Keep the loop moving. Keep the judgment human.
 
+## 3-Minute PoC Path
+
+Open the [Hosted Frontstage](https://huangruiteng.github.io/loopx/frontstage/)
+first. It is the public showcase surface, not an ops dashboard: three case
+cards explain the loop-engineering pattern before a new user reads any CLI
+output.
+
+| Minute | Show | Why It Matters |
+| --- | --- | --- |
+| 0:00 | The frontstage hero and canonical top-3 cases | LoopX is about governed agent loops, not another executor. |
+| 1:00 | The blocked-P0 demo and safe fallback lane | User judgment can stay explicit while safe work continues. |
+| 2:00 | The self-iteration and hardware-agent cards | The same control plane scales from public Git evidence to redacted contributor workflows. |
+| 2:40 | GitHub Issues / PRs as the primary feedback path | Early PoC users can report onboarding friction and propose public-safe cases immediately. |
+
+For a timed walkthrough, use the
+[3-minute demo script](docs/outreach/frontstage-demo-script.md). To reproduce
+the smallest behavior proof locally:
+
+```bash
+python3 examples/showcase-0617-blocked-p0-safe-rotation-smoke.py
+```
+
 ## What Is It?
 
 LoopX does not replace Codex, Claude Code, Cursor, or another agent

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -19,6 +19,26 @@ loop 状态：目标、用户决策、agent todo、认领关系、scope、证据
 [English](README.md) · [快速开始](#快速开始) · [Showcases](docs/showcases/README.md) ·
 [用户群与反馈](#用户群与反馈) · [产品愿景](docs/product/vision.md) · [架构](docs/architecture.md)
 
+## 3 分钟 PoC 路径
+
+先打开 [Hosted Frontstage](https://huangruiteng.github.io/loopx/frontstage/)。
+这是公开 showcase 页面，不是控制面后台：它用三张主案例卡先讲清楚 LoopX 的
+loop-engineering 价值，再让用户进入 CLI、文档或反馈。
+
+| 时间 | 展示 | 传达什么 |
+| --- | --- | --- |
+| 0:00 | Frontstage 首屏和 canonical top-3 cases | LoopX 不是另一个 executor，而是治理长期 agent loop 的控制面。 |
+| 1:00 | Blocked P0 demo 和 safe fallback lane | 需要人判断的地方明确停下，安全侧路仍可继续。 |
+| 2:00 | Self-iteration 与 hardware-agent cards | 同一控制面可以覆盖公开 Git 证据和脱敏贡献者工作流。 |
+| 2:40 | GitHub Issue / PR 作为主反馈入口 | PoC 早期最需要 onboarding 摩擦、真实 case 和 public-safe 示例反馈。 |
+
+完整讲解用 [3 分钟 demo script](docs/outreach/frontstage-demo-script.md)。
+最小可复现行为证明：
+
+```bash
+python3 examples/showcase-0617-blocked-p0-safe-rotation-smoke.py
+```
+
 ## 它是什么
 
 LoopX 不是另一个 agent runtime，也不是要替代 Codex、Claude Code、

--- a/docs/outreach/frontstage-demo-script.md
+++ b/docs/outreach/frontstage-demo-script.md
@@ -10,6 +10,24 @@ Demo URL:
 
 ![Hosted LoopX frontstage showing public-safe showcase cases](../assets/frontstage-showcase-first-screen.png)
 
+## 3-Minute Timestamped Version
+
+Use this when a PoC user, contributor, or maintainer has not seen LoopX before.
+
+| Time | Screen | Talk Track |
+| --- | --- | --- |
+| 0:00 | Hosted frontstage hero | "LoopX is loop engineering for long-running AI agents. It is not another executor; Codex, Claude Code, Cursor, or a TUI still do the work. LoopX keeps the loop state stable." |
+| 0:25 | Top-3 showcase cards | "The public story starts with cases, not a private ops dashboard. These cards come from `docs/showcases/` and are safe to share." |
+| 0:50 | Blocked P0 card | "A high-priority lane can wait for a human decision without freezing the whole goal. LoopX makes the gate concrete and lets safe fallback work continue." |
+| 1:25 | Self-iteration card | "LoopX used itself while this repo changed quickly: primary and side-agent lanes, todo claims, evidence writeback, validation, and self-merge policy stayed visible." |
+| 1:55 | Hardware-agent card | "This is intentionally modest: a redacted contributor workflow stub. It shows the multi-agent control-plane pattern without exposing private artifacts." |
+| 2:20 | Boundary / evidence panels | "The public value includes saying what is not shown: raw sessions, internal sources, local paths, credentials, and benchmark traces stay out." |
+| 2:40 | CTA / repo links | "For PoC users, the fastest next step is feedback: open a GitHub Issue for onboarding friction, propose a public-safe case, or send a PR. Lark/WeChat are secondary chat surfaces." |
+
+Close with one sentence:
+
+> "Your agents keep the loop moving; you keep the judgment."
+
 ## 30-Second Version
 
 LoopX is a control plane for long-running agent work. It does not

--- a/docs/showcases/README.md
+++ b/docs/showcases/README.md
@@ -65,14 +65,28 @@ the artifact with `python3 examples/showcase-animation-prototype-smoke.py`.
 
 ![Hosted LoopX frontstage showing public-safe showcase cases](../assets/frontstage-showcase-first-screen.png)
 
-## Current Cases
+## Canonical PoC Cards
 
 | Case | Pattern | Status | Public Surface |
 | --- | --- | --- | --- |
 | [0617 blocked P0 with safe P1/P2 rotation](cases/0617-blocked-p0-safe-rotation.md) | Blocked priority fallback, concrete user gate, quota discipline | Reproducible synthetic demo | `python3 examples/showcase-0617-blocked-p0-safe-rotation-smoke.py` |
-| [0619 dynamic workflow for hardware-agent development](cases/0619-dynamic-workflow-hardware-agent.md) | Dynamic workflow, multi-agent convergence, shared control plane | Redacted stub pending contributor detail | Public-safe narrative only |
 | [0619 LoopX self-iteration loop](cases/0619-loopx-self-iteration.md) | Self-iteration, side-agent scope, evidence writeback | Public Git evidence case | Commit-backed narrative and workload signal |
+| [0619 dynamic workflow for hardware-agent development](cases/0619-dynamic-workflow-hardware-agent.md) | Dynamic workflow, multi-agent convergence, shared control plane | Redacted stub pending contributor detail | Public-safe narrative only |
+
+The catalog order above is the canonical frontstage order for the PoC. It keeps
+the public homepage focused on one reproducible control-plane proof, one
+commit-backed self-iteration case, and one contributor-facing redacted workflow
+stub that can expand when approved public details arrive.
+
+## Appendix Cases
+
+| Case | Pattern | Status | Public Surface |
+| --- | --- | --- | --- |
 | [0620 creator-operator long-running agent case](cases/0620-creator-operator-case-spec.md) | Creator-operator workflow, user gate, feedback capture, material library | Synthetic product case spec | [Fake-data storyboard](creator-ops-fake-data-storyboard.md), [feedback contract](creator-ops-feedback-boundary-contract.md) |
+
+Appendix cases are useful product direction, but they should not appear as
+frontstage top cards until there is real public evidence or an approved
+public-safe user story.
 
 ## Case Lifecycle
 

--- a/docs/showcases/cases/0620-creator-operator-case-spec.md
+++ b/docs/showcases/cases/0620-creator-operator-case-spec.md
@@ -6,6 +6,10 @@ This case describes a public-safe creator-operator workflow for a
 non-technical user who wants a long-running agent to help with content research
 and planning.
 
+This is an appendix case for product direction. It should not be treated as a
+frontstage top-card proof until a real user story or approved public evidence
+exists.
+
 The user is not trying to operate an agent framework. They want a controlled
 work loop that can keep a creative goal moving:
 

--- a/docs/showcases/showcase-catalog.json
+++ b/docs/showcases/showcase-catalog.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "loopx_showcase_catalog_v0",
-  "updated_at": "2026-06-20",
+  "updated_at": "2026-06-22",
   "redaction_policy": {
     "public_repo_may_include": [
       "sanitized domain labels",
@@ -63,52 +63,6 @@
           "LoopX projects the decision as a user todo",
           "agent continues safe fallback work",
           "state records blocker, fallback, validation, and spend policy"
-        ]
-      }
-    },
-    {
-      "id": "2026-06-19-dynamic-workflow-hardware-agent",
-      "date": "2026-06-19",
-      "title": "Dynamic workflow for hardware-agent development",
-      "status": "redacted_stub_pending_contributor_details",
-      "case_page": "docs/showcases/cases/0619-dynamic-workflow-hardware-agent.md",
-      "demo_command": null,
-      "domain": "hardware-agent-development",
-      "audience": [
-        "agent-platform-developer",
-        "technical-lead",
-        "open-source-user"
-      ],
-      "pattern_tags": [
-        "dynamic_workflow",
-        "multi_agent_coordination",
-        "shared_control_plane",
-        "long_unattended_goal",
-        "convergence"
-      ],
-      "headline": "A fuzzy long-running engineering goal needs a shared control plane when multiple worker agents participate.",
-      "problem": "Specialized engineering work can require multiple agents to split work and converge without losing ownership or state.",
-      "loopx_behavior": [
-        "keep durable goal state outside any one chat thread",
-        "make ownership and review handoff explicit",
-        "project evidence and convergence state for the operator",
-        "leave domain-specific artifacts private until sanitized"
-      ],
-      "user_value": "The public claim is limited to the observed control-plane pattern: shared state helps long-running multi-agent work converge.",
-      "evidence_boundary": "Redacted stub; no raw chats, screenshots, proprietary design details, internal tool names, repositories, paths, task ids, or unpublished hardware artifacts.",
-      "frontend_card": {
-        "visual_metaphor": "multiple worker lanes converging through one shared control plane",
-        "primary_metric_hint": "convergence under a fuzzy goal",
-        "badges": [
-          "redacted",
-          "multi-agent",
-          "pending-demo"
-        ],
-        "story_beats": [
-          "fuzzy engineering goal needs multiple workers",
-          "LoopX provides shared state and ownership",
-          "work converges through evidence and primary review",
-          "public demo waits for safe abstraction"
         ]
       }
     },
@@ -228,6 +182,52 @@
       }
     },
     {
+      "id": "2026-06-19-dynamic-workflow-hardware-agent",
+      "date": "2026-06-19",
+      "title": "Dynamic workflow for hardware-agent development",
+      "status": "redacted_stub_pending_contributor_details",
+      "case_page": "docs/showcases/cases/0619-dynamic-workflow-hardware-agent.md",
+      "demo_command": null,
+      "domain": "hardware-agent-development",
+      "audience": [
+        "agent-platform-developer",
+        "technical-lead",
+        "open-source-user"
+      ],
+      "pattern_tags": [
+        "dynamic_workflow",
+        "multi_agent_coordination",
+        "shared_control_plane",
+        "long_unattended_goal",
+        "convergence"
+      ],
+      "headline": "A fuzzy long-running engineering goal needs a shared control plane when multiple worker agents participate.",
+      "problem": "Specialized engineering work can require multiple agents to split work and converge without losing ownership or state.",
+      "loopx_behavior": [
+        "keep durable goal state outside any one chat thread",
+        "make ownership and review handoff explicit",
+        "project evidence and convergence state for the operator",
+        "leave domain-specific artifacts private until sanitized"
+      ],
+      "user_value": "The public claim is limited to the observed control-plane pattern: shared state helps long-running multi-agent work converge.",
+      "evidence_boundary": "Redacted stub; no raw chats, screenshots, proprietary design details, internal tool names, repositories, paths, task ids, or unpublished hardware artifacts.",
+      "frontend_card": {
+        "visual_metaphor": "multiple worker lanes converging through one shared control plane",
+        "primary_metric_hint": "convergence under a fuzzy goal",
+        "badges": [
+          "redacted",
+          "multi-agent",
+          "pending-demo"
+        ],
+        "story_beats": [
+          "fuzzy engineering goal needs multiple workers",
+          "LoopX provides shared state and ownership",
+          "work converges through evidence and primary review",
+          "public demo waits for safe abstraction"
+        ]
+      }
+    },
+    {
       "id": "2026-06-20-creator-operator-case-spec",
       "date": "2026-06-20",
       "title": "Creator-operator long-running agent case",
@@ -262,20 +262,12 @@
       ],
       "user_value": "A non-technical operator can see what changed, what is blocked, what can safely continue, and how feedback changes the plan without reading prompts, logs, or raw traces.",
       "evidence_boundary": "Synthetic case spec only; no real platform data, creator notes, screenshots, private drafts, raw browsing traces, local paths, credentials, or performance claims.",
-      "frontend_card": {
-        "visual_metaphor": "creator workspace with trend candidates, preference map, insight board, draft queue, material library, and a visible publishing gate",
-        "primary_metric_hint": "legibility: the user can distinguish safe research progress from publish-gated work",
-        "badges": [
-          "synthetic",
-          "creator-ops",
-          "user-gate"
-        ],
-        "story_beats": [
-          "creator-operator wants recurring trend research and content planning",
-          "agent proposes synthetic trend candidates and maps them to preference hints",
-          "LoopX keeps publishing gated while safe side work continues",
-          "user feedback becomes structured control-plane state",
-          "next run starts from visible goals, todos, boundaries, and feedback"
+      "appendix_surface": {
+        "reason": "Synthetic product-direction spec; keep as appendix until real public evidence or an approved public-safe user story exists.",
+        "public_surface": "appendix_only",
+        "links": [
+          "docs/showcases/creator-ops-fake-data-storyboard.md",
+          "docs/showcases/creator-ops-feedback-boundary-contract.md"
         ]
       }
     }

--- a/examples/showcase-catalog-smoke.py
+++ b/examples/showcase-catalog-smoke.py
@@ -46,6 +46,12 @@ def main() -> int:
     assert "2026-06-17-blocked-p0-safe-rotation" in case_ids, case_ids
     assert "2026-06-19-dynamic-workflow-hardware-agent" in case_ids, case_ids
     assert "2026-06-19-loopx-self-iteration" in case_ids, case_ids
+    frontstage_ids = [case.get("id") for case in cases if isinstance(case.get("frontend_card"), dict)]
+    assert frontstage_ids[:3] == [
+        "2026-06-17-blocked-p0-safe-rotation",
+        "2026-06-19-loopx-self-iteration",
+        "2026-06-19-dynamic-workflow-hardware-agent",
+    ], frontstage_ids
 
     assert_public_safe(CATALOG)
     assert_public_safe(SHOWCASES)
@@ -61,9 +67,14 @@ def main() -> int:
         assert case.get("user_value"), case
         assert isinstance(case.get("pattern_tags"), list) and case["pattern_tags"], case
         frontend = case.get("frontend_card")
-        assert isinstance(frontend, dict), case
-        assert frontend.get("visual_metaphor"), case
-        assert isinstance(frontend.get("story_beats"), list) and len(frontend["story_beats"]) >= 3, case
+        appendix = case.get("appendix_surface")
+        assert isinstance(frontend, dict) or isinstance(appendix, dict), case
+        if isinstance(frontend, dict):
+            assert frontend.get("visual_metaphor"), case
+            assert isinstance(frontend.get("story_beats"), list) and len(frontend["story_beats"]) >= 3, case
+        else:
+            assert appendix.get("reason"), case
+            assert appendix.get("public_surface") == "appendix_only", case
 
         demo_command = case.get("demo_command")
         if case.get("status") == "reproducible_synthetic_demo":
@@ -77,6 +88,7 @@ def main() -> int:
             assert "No reproducible public demo is included yet" in page_text, case_id
         if case.get("status") == "public_safe_case_spec":
             assert demo_command is None, case
+            assert isinstance(appendix, dict), case
             storyboard = case.get("storyboard_path")
             assert isinstance(storyboard, str) and storyboard.startswith("docs/showcases/"), case
             storyboard_path = REPO_ROOT / storyboard
@@ -141,7 +153,9 @@ def main() -> int:
     assert "showcases/README.md" in docs_index, "docs index must link showcases"
     assert "docs/showcases/README.md" in repo_readme, "README must link showcases"
     for phrase in (
-        "Always-on agent teams, governed by human judgment.",
+        "Loop engineering for long-running AI agents.",
+        "## 3-Minute PoC Path",
+        "https://huangruiteng.github.io/loopx/frontstage/",
         "## See It In Action",
         "docs/showcases/cases/0617-blocked-p0-safe-rotation.md",
         "docs/showcases/cases/0619-loopx-self-iteration.md",

--- a/examples/showcase-frontstage-prototype-smoke.py
+++ b/examples/showcase-frontstage-prototype-smoke.py
@@ -32,6 +32,8 @@ PRIVATE_MARKERS = tuple(
 def main() -> int:
     catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
     cases = catalog["cases"]
+    frontstage_cases = [case for case in cases if isinstance(case.get("frontend_card"), dict)]
+    appendix_cases = [case for case in cases if isinstance(case.get("appendix_surface"), dict)]
     with tempfile.TemporaryDirectory(prefix="loopx-showcase-frontstage-") as tmp:
         output = Path(tmp) / "frontstage.html"
         result = subprocess.run(
@@ -65,11 +67,21 @@ def main() -> int:
     ):
         assert required in html, required
 
-    statuses = {str(case["status"]) for case in cases}
+    assert [case["id"] for case in frontstage_cases] == [
+        "2026-06-17-blocked-p0-safe-rotation",
+        "2026-06-19-loopx-self-iteration",
+        "2026-06-19-dynamic-workflow-hardware-agent",
+    ], frontstage_cases
+    assert any(case["id"] == "2026-06-20-creator-operator-case-spec" for case in appendix_cases), appendix_cases
+
+    statuses = {str(case["status"]) for case in frontstage_cases}
     for status in statuses:
         assert f'data-status-filter="{status}"' in html, status
 
-    for case in cases:
+    for case in appendix_cases:
+        assert f'data-case-id="{case["id"]}"' not in html, case["id"]
+
+    for case in frontstage_cases:
         case_id = str(case["id"])
         assert f'data-case-id="{case_id}"' in html, case_id
         assert f'data-status="{case["status"]}"' in html, case_id

--- a/examples/showcase-frontstage-prototype.py
+++ b/examples/showcase-frontstage-prototype.py
@@ -211,16 +211,17 @@ def render(catalog: dict[str, Any], *, output: Path | None) -> str:
     cases = catalog.get("cases")
     if not isinstance(cases, list):
         raise ValueError("showcase catalog must contain a cases list")
+    frontstage_cases = [case for case in cases if isinstance(case.get("frontend_card"), dict)]
     asset_href = repo_link("docs/assets/control-plane-board.svg", output=output)
-    case_cards = "\n".join(render_case(case, output=output) for case in cases)
-    case_count = len(cases)
-    status_filters = render_status_filters(cases)
+    case_cards = "\n".join(render_case(case, output=output) for case in frontstage_cases)
+    case_count = len(frontstage_cases)
+    status_filters = render_status_filters(frontstage_cases)
     schema_version = str(catalog.get("schema_version") or "")
     schema_label = schema_version.removeprefix("loopx_showcase_catalog_") or schema_version
     pattern_count = len(
         {
             tag
-            for case in cases
+            for case in frontstage_cases
             for tag in (case.get("pattern_tags") if isinstance(case.get("pattern_tags"), list) else [])
         }
     )
@@ -338,7 +339,7 @@ def render(catalog: dict[str, Any], *, output: Path | None) -> str:
       <img src="{esc(asset_href)}" alt="LoopX control-plane board">
     </section>
     <section class="metrics" aria-label="Catalog metrics">
-      <div><strong>{case_count}</strong><span>public-safe cases</span></div>
+      <div><strong>{case_count}</strong><span>frontstage cards</span></div>
       <div><strong>{pattern_count}</strong><span>pattern tags</span></div>
       <div title="{esc(schema_version)}"><strong>{esc(schema_label)}</strong><span>catalog schema</span></div>
     </section>


### PR DESCRIPTION
## Summary
- add a concise 3-minute PoC path to both READMEs
- make the showcase catalog's canonical frontstage top-3 explicit
- demote the synthetic creator-operator case to appendix-only surface until public evidence exists
- update catalog/frontstage smokes for appendix cases

## Validation
- python3 -m json.tool docs/showcases/showcase-catalog.json >/tmp/loopx-showcase-catalog.json
- python3 examples/showcase-catalog-smoke.py
- python3 examples/showcase-frontstage-prototype-smoke.py
- loopx check --scan-path README.md --scan-path README.zh-CN.md --scan-path docs/showcases --scan-path docs/outreach/frontstage-demo-script.md --scan-path examples/showcase-catalog-smoke.py --scan-path examples/showcase-frontstage-prototype.py --scan-path examples/showcase-frontstage-prototype-smoke.py
- npm --prefix apps/dashboard run smoke:frontstage-share-bundle
- npm --prefix apps/dashboard run smoke:frontstage-route
- npm --prefix apps/dashboard run build