### PR TITLE
docs: trim README PoC walkthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,27 +28,11 @@ LoopX 把一次静态 goal 变成能持续流转的动态 loop：该等人的地
 
 > Keep the loop moving. Keep the judgment human.
 
-## 3-Minute PoC Path
-
-Open the [Hosted Frontstage](https://huangruiteng.github.io/loopx/frontstage/)
-first. It is the public showcase surface, not an ops dashboard: three case
-cards explain the loop-engineering pattern before a new user reads any CLI
-output.
-
-| Minute | Show | Why It Matters |
-| --- | --- | --- |
-| 0:00 | The frontstage hero and canonical top-3 cases | LoopX is about governed agent loops, not another executor. |
-| 1:00 | The blocked-P0 demo and safe fallback lane | User judgment can stay explicit while safe work continues. |
-| 2:00 | The self-iteration and hardware-agent cards | The same control plane scales from public Git evidence to redacted contributor workflows. |
-| 2:40 | GitHub Issues / PRs as the primary feedback path | Early PoC users can report onboarding friction and propose public-safe cases immediately. |
-
-For a timed walkthrough, use the
-[3-minute demo script](docs/outreach/frontstage-demo-script.md). To reproduce
-the smallest behavior proof locally:
-
-```bash
-python3 examples/showcase-0617-blocked-p0-safe-rotation-smoke.py
-```
+New here? Start with the
+[Hosted Frontstage](https://huangruiteng.github.io/loopx/frontstage/) for a
+visual tour, or jump straight to [Quick Start](#quick-start). The
+[3-minute demo script](docs/outreach/frontstage-demo-script.md) is for
+presenters who need a timed walkthrough.
 
 ## What Is It?
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -19,25 +19,10 @@ loop 状态：目标、用户决策、agent todo、认领关系、scope、证据
 [English](README.md) · [快速开始](#快速开始) · [Showcases](docs/showcases/README.md) ·
 [用户群与反馈](#用户群与反馈) · [产品愿景](docs/product/vision.md) · [架构](docs/architecture.md)
 
-## 3 分钟 PoC 路径
-
-先打开 [Hosted Frontstage](https://huangruiteng.github.io/loopx/frontstage/)。
-这是公开 showcase 页面，不是控制面后台：它用三张主案例卡先讲清楚 LoopX 的
-loop-engineering 价值，再让用户进入 CLI、文档或反馈。
-
-| 时间 | 展示 | 传达什么 |
-| --- | --- | --- |
-| 0:00 | Frontstage 首屏和 canonical top-3 cases | LoopX 不是另一个 executor，而是治理长期 agent loop 的控制面。 |
-| 1:00 | Blocked P0 demo 和 safe fallback lane | 需要人判断的地方明确停下，安全侧路仍可继续。 |
-| 2:00 | Self-iteration 与 hardware-agent cards | 同一控制面可以覆盖公开 Git 证据和脱敏贡献者工作流。 |
-| 2:40 | GitHub Issue / PR 作为主反馈入口 | PoC 早期最需要 onboarding 摩擦、真实 case 和 public-safe 示例反馈。 |
-
-完整讲解用 [3 分钟 demo script](docs/outreach/frontstage-demo-script.md)。
-最小可复现行为证明：
-
-```bash
-python3 examples/showcase-0617-blocked-p0-safe-rotation-smoke.py
-```
+第一次看 LoopX？先打开
+[Hosted Frontstage](https://huangruiteng.github.io/loopx/frontstage/) 看公开
+案例，或直接跳到 [快速开始](#快速开始)。[3 分钟 demo script](docs/outreach/frontstage-demo-script.md)
+只给演示者做 timed walkthrough 用。
 
 ## 它是什么
 

--- a/examples/showcase-catalog-smoke.py
+++ b/examples/showcase-catalog-smoke.py
@@ -154,8 +154,8 @@ def main() -> int:
     assert "docs/showcases/README.md" in repo_readme, "README must link showcases"
     for phrase in (
         "Loop engineering for long-running AI agents.",
-        "## 3-Minute PoC Path",
         "https://huangruiteng.github.io/loopx/frontstage/",
+        "docs/outreach/frontstage-demo-script.md",
         "## See It In Action",
         "docs/showcases/cases/0617-blocked-p0-safe-rotation.md",
         "docs/showcases/cases/0619-loopx-self-iteration.md",


### PR DESCRIPTION
## Summary
- replace the oversized 3-minute PoC table in both READMEs with a short new-user CTA
- keep the full timed walkthrough in docs/outreach/frontstage-demo-script.md
- update the showcase catalog smoke to assert the lightweight README links instead of the removed section heading

## Validation
- python3 examples/showcase-catalog-smoke.py
- python3 examples/showcase-frontstage-prototype-smoke.py
- loopx check --scan-path README.md --scan-path README.zh-CN.md --scan-path examples/showcase-catalog-smoke.py