### PR TITLE
Reject pre-rename Harbor agent kwargs

### DIFF
--- a/examples/harbor-host-codex-goal-agent-smoke.py
+++ b/examples/harbor-host-codex-goal-agent-smoke.py
@@ -470,6 +470,24 @@ def main() -> int:
         assert treatment_agent.loopx_benchmark_id == "swe-marathon"
         assert treatment_agent.loopx_case_id == "current-case"
         assert treatment_agent.loopx_arm_id == "codex_loopx_treatment"
+        legacy_prefix = "goal_" + "harness_"
+        try:
+            module.HarborHostCodexGoalAgent(
+                logs_dir=Path(tmp) / "legacy-treatment-logs",
+                goal_surface="app_server",
+                **{
+                    legacy_prefix + "mode": "codex_" + legacy_prefix.rstrip("_"),
+                    legacy_prefix + "access_packet_mode": "compact",
+                    legacy_prefix + "cli_bridge_enabled": "true",
+                },
+            )
+        except ValueError as exc:
+            message = str(exc)
+            assert "legacy_pre_rename_kwargs_unsupported" in message, message
+            assert "use loopx_* kwargs before worker start" in message, message
+            assert "count=3" in message, message
+        else:
+            raise AssertionError("legacy benchmark kwargs must fail closed")
         polling_agent = module.HarborHostCodexGoalAgent(
             logs_dir=Path(tmp) / "polling-logs",
             goal_surface="app_server",

--- a/scripts/harbor_host_codex_goal_agent.py
+++ b/scripts/harbor_host_codex_goal_agent.py
@@ -162,6 +162,25 @@ def _coerce_bool(value: str | bool) -> bool:
     return value.strip().lower() not in {"0", "false", "no", "off"}
 
 
+LEGACY_PRE_RENAME_KWARG_PREFIX = "goal_" + "harness_"
+
+
+def _reject_pre_rename_kwargs(kwargs: dict[str, Any]) -> None:
+    """Fail closed when a launcher still sends pre-rename benchmark kwargs."""
+
+    legacy_keys = sorted(
+        key for key in kwargs if key.startswith(LEGACY_PRE_RENAME_KWARG_PREFIX)
+    )
+    if not legacy_keys:
+        return
+    first_key = legacy_keys[0]
+    raise ValueError(
+        "legacy_pre_rename_kwargs_unsupported: "
+        f"use loopx_* kwargs before worker start; first_key={first_key}; "
+        f"count={len(legacy_keys)}"
+    )
+
+
 def _compact_todo_summary(value: Any, *, todo_id: str = "") -> dict[str, Any]:
     if not isinstance(value, dict):
         return {}
@@ -815,6 +834,7 @@ class HarborHostCodexGoalAgent(BaseAgent):
         poll_interval_sec: str | int | float = 5,
         **kwargs: Any,
     ) -> None:
+        _reject_pre_rename_kwargs(kwargs)
         super().__init__(logs_dir=logs_dir, model_name=model_name, **kwargs)
         self.goal_timeout_sec = float(goal_timeout_sec)
         self.codex_bin = codex_bin


### PR DESCRIPTION
## Summary
- Make `HarborHostCodexGoalAgent` fail closed when a launcher still sends pre-rename benchmark kwargs.
- Keep the product path fully on `loopx_*` rather than silently migrating or absorbing old names.
- Add a smoke assertion that old kwargs cannot quietly fall back to baseline/no access packet.

## Why
A real SWE-Marathon treatment run passed old benchmark kwargs, which meant the agent defaulted to baseline-like behavior and produced zero worker LoopX CLI calls. Failing closed makes this class of false treatment evidence visible before another long run.

## Validation
- `python3 examples/harbor-host-codex-goal-agent-smoke.py`
- `python3 -m py_compile scripts/harbor_host_codex_goal_agent.py`
- `python3 examples/benchmark-adapter-kwarg-absorption-smoke.py`
- `python3 examples/terminal-bench-harbor-prompt-driven-reducer-smoke.py`
- `loopx check --scan-path scripts/harbor_host_codex_goal_agent.py --scan-path examples/harbor-host-codex-goal-agent-smoke.py`
- `git diff --check`
