### PR TITLE
Streamline onboarding quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,8 +176,8 @@ connect, diagnose, and show the next safe action before doing longer work.
 
 ### Codex App
 
-Use this when you are working in Codex App or a Codex App heartbeat-capable
-thread. Paste from the project repo:
+Best when you want LoopX to keep working through Codex App heartbeats. Paste
+this from the project repo:
 
 ```text
 Install and connect LoopX for this project end to end. Do not stop at a
@@ -189,8 +189,8 @@ connected, set or refresh this thread's heartbeat automation from
 `loopx heartbeat-prompt --thin`.
 ```
 
-For recurring Codex App automation, generate the heartbeat body after the
-project is connected:
+After the project is connected, the agent should install the generated
+heartbeat body:
 
 ```bash
 loopx heartbeat-prompt --thin --goal-id <goal-id> --agent-id <agent-id> --agent-scope "<scope>"
@@ -198,16 +198,15 @@ loopx heartbeat-prompt --thin --goal-id <goal-id> --agent-id <agent-id> --agent-
 
 ### Codex CLI
 
-Use this when you want the human-visible TUI to stay primary.
-
-1. Open Codex CLI from your project repo:
+Best when the visible TUI should stay primary. Open Codex CLI from your project
+repo:
 
 ```bash
 cd /path/to/your-project
 codex
 ```
 
-2. In the TUI, paste one setup message:
+Then paste one setup message:
 
 ```text
 Install and connect LoopX for this repo from this visible Codex CLI TUI.
@@ -219,21 +218,13 @@ if any, top todos, and next safe action before longer work. Keep me in this TUI
 and do not use hidden headless execution.
 ```
 
-3. The first useful TUI response should show the current goal, user gate, top
-todos, and next safe action. The setup turn should install or reuse the CLI,
-bootstrap/connect the project, and configure the thin `/goal` loop. Longer
-delivery belongs to that configured loop unless you explicitly ask for it in
-the setup turn.
-
 That one message is the install, connect, status check, and loop activation.
-You do not need to run a separate setup command first or paste a second prompt.
+The first useful TUI response should show the current goal, any concrete user
+gate, top todos, and next safe action. Hidden `codex exec` is not the default
+bootstrap path. Details for generated messages, later same-TUI automation, and
+proof capture live in [Getting Started](docs/guides/getting-started.md).
 
-Hidden `codex exec` is not part of the default TUI bootstrap. Pilot packets,
-template generators, local drivers, idle detection, and same-session proof
-details live in [Getting Started](docs/guides/getting-started.md) and the
-[Codex CLI TUI-first loop](docs/product/codex-cli-tui-loop.md).
-
-A successful connection looks like this for every surface:
+A successful connection looks like this:
 
 - `loopx doctor` passes;
 - the project has `.loopx/registry.json`;

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -115,42 +115,61 @@ LoopX 适合长期、多人、多 agent 或带边界的工作：
 
 ## 快速开始
 
-如果你已经在用 Codex、Claude Code、Cursor 或其他终端 agent，最快的方式是把
-下面这段交给 agent，让它在当前项目里安装并连接 LoopX：
+最快的方式是让你已经在用的 agent 从当前项目里启动 LoopX：Codex App 用
+heartbeat，Codex CLI 保留可见 TUI，其他 agent 或手动 shell 走同一个 no-clone
+安装路径。
+
+### Codex App
+
+适合希望 LoopX 通过 Codex App heartbeat 持续推进的项目。把这段发给当前项目线程：
 
 ```text
-请为这个项目端到端安装并连接 LoopX，不要只给计划。
-
-如果 `loopx` 不在 PATH：
-- 如果 ~/loopx 不存在，clone https://github.com/huangruiteng/loopx 到 ~/loopx；
-- 运行 ~/loopx/scripts/install-local.sh；
-- export PATH="$HOME/.local/bin:$PATH"。
-
-然后：
-1. 运行 `loopx doctor`。
-2. 根据当前 repo 名选择稳定 goal id，除非我显式给了 goal id。
-3. 读取项目目标文档（如 GOAL.md、README.md，或我指定的文档）；若没有，就问我要一句目标。
-4. 运行 `loopx connect` 或 `loopx bootstrap`。
-5. 读取 connect 输出里的 onboarding candidates，向我解释候选 agent todo，并问我接受、修改还是拒绝。
-6. 把 `.loopx/` 和 `.codex/goals/` 加入当前项目 `.gitignore`。
-7. 运行 `loopx registry`、`loopx status`、`loopx check --scan-root .`。
-8. 汇报 goal id、创建文件、当前 user todo、当前 agent todo 和下一步安全动作。
-
-不要提交 `.loopx/`、`.codex/goals/`、ACTIVE_GOAL_STATE、本地 registry、
-raw logs、credentials 或私有本地路径。
+请为这个项目端到端安装并连接 LoopX，不要只给计划。如果 `loopx` 缺失，
+使用官方 no-clone GitHub installer 安装。然后运行 doctor，connect 或 bootstrap
+当前 repo，确认本地 LoopX 状态被 gitignore，并在更长工作前汇报 goal id、当前
+user gate、首个 agent todo 和下一步安全动作。项目连接后，用
+`loopx heartbeat-prompt --thin` 设置或刷新这个 Codex App heartbeat。
 ```
 
-也可以手动安装：
+项目连接后，heartbeat body 由 CLI 生成：
 
 ```bash
-git clone https://github.com/huangruiteng/loopx ~/loopx
-~/loopx/scripts/install-local.sh
+loopx heartbeat-prompt --thin --goal-id <goal-id> --agent-id <agent-id> --agent-scope "<scope>"
+```
+
+### Codex CLI
+
+适合希望保留可见 TUI、随时观察和接管的用户。从项目 repo 打开 Codex CLI：
+
+```bash
+cd /path/to/your-project
+codex
+```
+
+然后在 TUI 里粘贴一条消息：
+
+```text
+Install and connect LoopX for this repo from this visible Codex CLI TUI.
+If `loopx` is missing, install it with the official no-clone GitHub
+installer; if it is already installed, reuse it. Bootstrap or connect this
+project, then generate the thin heartbeat prompt and set the current Codex CLI
+goal to `/goal <thin task_body>`. Show me the current goal, concrete user gate
+if any, top todos, and next safe action before longer work. Keep me in this TUI
+and do not use hidden headless execution.
+```
+
+这条消息就是安装、连接、状态检查和 loop 激活。更细的生成模板、后续同一 TUI
+自动化、idle/proof 边界见
+[Getting Started](docs/guides/getting-started.md)。
+
+### 其他 Agent / 手动 Shell
+
+Claude Code、Cursor、其他终端 agent 或手动 shell 都走同一个 no-clone installer：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
 loopx doctor
-```
-
-连接一个项目：
-
-```bash
 cd /path/to/your-project
 loopx bootstrap \
   --goal-id your-project-goal \
@@ -158,13 +177,9 @@ loopx bootstrap \
   --goal-doc GOAL.md
 ```
 
-诊断当前状态：
-
-```bash
-loopx diagnose
-loopx status
-loopx quota should-run --goal-id your-project-goal
-```
+成功连接后应该能看到 `.loopx/registry.json`、
+`.codex/goals/<goal-id>/ACTIVE_GOAL_STATE.md`、`loopx status` 的下一步投影；
+这些本地状态必须被 gitignore，不要提交到公开仓库。
 
 ## 用户群与反馈
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -5,7 +5,7 @@ README. The root README is now the short product landing page; this page is the
 hands-on path for installation, project connection, diagnosis, heartbeats,
 dashboard use, development checks, and command discovery.
 
-## Start With An Agent
+## Codex App And Other Agent Setup
 
 If you already use Codex, Claude Code, Cursor, or another terminal agent, paste
 this into the agent from your project repo:
@@ -64,6 +64,8 @@ Success looks like this:
 - the project has `.codex/goals/<goal-id>/ACTIVE_GOAL_STATE.md`;
 - `loopx status` shows the goal and who should act next;
 - local runtime state is ignored, not committed.
+
+## Codex CLI TUI Setup
 
 For Codex CLI users, the product target is: start in the Codex TUI, send one
 LoopX setup message, and let the agent install or reuse LoopX,
@@ -138,8 +140,8 @@ This keeps the first-message TUI start primary, then models later scheduler
 ticks, visible proof, idle guard, guarded execution, blocker writeback, and
 no-transcript boundaries as public-safe metadata.
 
-The later-turn rule is intentionally stricter than the first message: Goal
-Harness may add a visible steering turn only after public-safe visible proof,
+The later-turn rule is intentionally stricter than the first message: LoopX may
+add a visible steering turn only after public-safe visible proof,
 runtime idle evidence, a fresh guard, and explicit execution bounds. Without
 that proof, the driver should write a compact blocker or keep the one-message
 setup bootstrap as the product path.


### PR DESCRIPTION
## Summary
- split the root Quick Start by Codex App, Codex CLI, and other agents/manual shell
- shorten the Codex CLI README path so first-time users see one visible TUI message, not the full driver/proof contract
- move the detailed TUI setup anchor into Getting Started and remove a leftover pre-rename product name

## Validation
- `python3 examples/fresh-clone-quickstart-smoke.py`
- `loopx check --scan-path README.md --scan-path README.zh-CN.md --scan-path docs/guides/getting-started.md`
- `git diff --check`

LoopX check warning is the existing duplicate run-history index rows for `loopx-meta`; public boundary scan is clean for the touched files.