### PR TITLE
docs: add PoC feedback case-report loop

### DIFF
--- a/docs/showcases/README.md
+++ b/docs/showcases/README.md
@@ -18,6 +18,9 @@ The machine-readable catalog lives in
 surfaces should consume that file instead of scraping prose.
 The first frontend surface contract lives in
 [frontend-surface.md](frontend-surface.md).
+Seed-user feedback and case candidates should follow the
+[PoC feedback and case report loop](poc-feedback-case-report-loop.md) before
+they become catalog entries or Frontstage cards.
 
 The first static visual asset is the public-safe
 [control-plane board](../assets/control-plane-board.svg), which shows a user
@@ -92,11 +95,15 @@ public-safe user story.
 
 1. **Captured**: a real project shows a durable behavior pattern. Keep raw
    screenshots, private chats, and internal links outside this repo.
-2. **Sanitized**: write a public-safe case card with the domain generalized,
+2. **Reported**: reduce the feedback into the
+   [case report shape](poc-feedback-case-report-loop.md#case-report-shape):
+   domain, loop length, hard part, LoopX behavior, human decision, evidence,
+   and private boundary.
+3. **Sanitized**: write a public-safe case card with the domain generalized,
    the evidence boundary explicit, and no private source material.
-3. **Reproducible**: add a small synthetic demo or smoke that proves the
+4. **Reproducible**: add a small synthetic demo or smoke that proves the
    reusable LoopX behavior without depending on private artifacts.
-4. **Frontend-ready**: add or update the catalog fields needed for a visual
+5. **Frontend-ready**: add or update the catalog fields needed for a visual
    website card, such as story beats, pattern tags, and suggested visual
    layout.
 

--- a/docs/showcases/poc-feedback-case-report-loop.md
+++ b/docs/showcases/poc-feedback-case-report-loop.md
@@ -1,0 +1,89 @@
+# PoC Feedback And Case Report Loop
+
+LoopX is still early. The fastest useful feedback is not a long review; it is a
+small, public-safe case report that shows where a long-running agent loop became
+hard to govern.
+
+This note defines the default PoC feedback loop for seed users and contributors.
+It turns onboarding friction, real usage stories, and showcase ideas into
+repeatable evidence without publishing private work.
+
+## Intake
+
+Use GitHub Issues or Discussions as the primary public entry. Chat groups are
+useful for quick questions, but public proof should eventually reduce to an
+issue, PR, or showcase patch that future users can inspect.
+
+Good seed-user feedback usually fits one of these shapes:
+
+| Feedback shape | Best public entry | What to include |
+| --- | --- | --- |
+| Onboarding friction | Issue | Install path, agent surface, confusing step, expected next action. |
+| Real case candidate | Issue or Discussion | Domain label, loop length, where the agent got stuck, what stayed private. |
+| Showcase improvement | PR or Issue | Case card, better wording, missing evidence, or public-safe screenshot. |
+| Product gap | Issue | The decision, gate, todo, or evidence signal that was hard to see. |
+
+Do not paste private chats, credentials, internal URLs, raw traces, customer
+names, local paths, or unpublished artifacts. Describe the pattern instead.
+
+## Case Report Shape
+
+A useful case report is short:
+
+```text
+Title:
+Domain:
+Agent surface:
+Loop length:
+What became hard:
+What LoopX made visible:
+Human decision:
+Safe side work:
+Evidence pointer:
+Private boundary:
+Suggested public claim:
+```
+
+The report should be understandable without reading logs. If a field cannot be
+shared publicly, write the boundary instead of the raw detail.
+
+## Evidence Checklist
+
+A case is ready to influence the PoC when it has:
+
+- a reusable control-plane pattern, not just "an agent did work";
+- a public-safe evidence pointer such as a PR, issue, commit, smoke, synthetic
+  fixture, or approved screenshot;
+- an explicit private boundary;
+- a plain-language user value statement;
+- one next action that would make the case more reproducible or clearer.
+
+For the first 3-5 PoC users, prefer modest evidence over broad claims. A case
+can be valuable even when it ends in a blocker, as long as the blocker is
+visible and the next safe action is concrete.
+
+## Promotion Path
+
+1. **Feedback**: a user files an issue, discussion, or small PR.
+2. **Triage**: a maintainer labels the pattern and public/private boundary.
+3. **Report**: the case is reduced into the report shape above.
+4. **Catalog**: mature reports become `docs/showcases` case cards or appendix
+   entries.
+5. **Frontstage**: only catalog-backed, public-safe cases become public cards.
+
+This keeps the hosted Frontstage honest: it shows public product proof, not
+private local status or unreviewed anecdotes.
+
+## Maintainer Triage Notes
+
+When converting feedback into a contributor task, preserve these fields:
+
+- source entry: issue, discussion, PR, or approved public artifact;
+- pattern tags: gate, fallback, ownership, evidence, replan, feedback, or
+  onboarding;
+- claim level: synthetic demo, public evidence, redacted stub, or appendix;
+- boundary: what must not appear in public docs or UI;
+- next proof: smoke, screenshot, case page, frontend card, or user question.
+
+If the report depends on private material, keep it out of the public catalog
+until a sanitized summary or synthetic reproduction exists.

--- a/examples/showcase-catalog-smoke.py
+++ b/examples/showcase-catalog-smoke.py
@@ -10,6 +10,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 CATALOG = REPO_ROOT / "docs" / "showcases" / "showcase-catalog.json"
 SHOWCASES = REPO_ROOT / "docs" / "showcases" / "README.md"
+POC_FEEDBACK_LOOP = REPO_ROOT / "docs" / "showcases" / "poc-feedback-case-report-loop.md"
 PRIVATE_MARKERS = tuple(
     "".join(parts)
     for parts in (
@@ -55,6 +56,7 @@ def main() -> int:
 
     assert_public_safe(CATALOG)
     assert_public_safe(SHOWCASES)
+    assert_public_safe(POC_FEEDBACK_LOOP)
 
     for case in cases:
         case_id = str(case.get("id") or "")
@@ -150,8 +152,19 @@ def main() -> int:
 
     docs_index = read(REPO_ROOT / "docs" / "README.md")
     repo_readme = read(REPO_ROOT / "README.md")
+    showcase_index = read(SHOWCASES)
+    feedback_loop = read(POC_FEEDBACK_LOOP)
     assert "showcases/README.md" in docs_index, "docs index must link showcases"
     assert "docs/showcases/README.md" in repo_readme, "README must link showcases"
+    assert "poc-feedback-case-report-loop.md" in showcase_index, "showcase index must link PoC feedback loop"
+    for phrase in (
+        "GitHub Issues or Discussions as the primary public entry",
+        "Case Report Shape",
+        "Evidence Checklist",
+        "only catalog-backed, public-safe cases become public cards",
+        "private local status or unreviewed anecdotes",
+    ):
+        assert phrase in feedback_loop, phrase
     for phrase in (
         "Loop engineering for long-running AI agents.",
         "https://huangruiteng.github.io/loopx/frontstage/",


### PR DESCRIPTION
## Summary
- add a public-safe PoC feedback and case-report loop for seed-user intake
- link the loop from the showcase index and case lifecycle
- extend showcase catalog smoke so the feedback loop remains linked and public-safe

## Validation
- python3 examples/showcase-catalog-smoke.py
- loopx check --scan-path docs/showcases --scan-path examples/showcase-catalog-smoke.py
- git diff --check
- sensitive marker scan over changed docs

## Boundary
Docs-only plus focused smoke assertion. No private links, credentials, raw traces, internal project names, or local runtime state.