### PR TITLE
Handle Harbor prompt-polling follow-up failures

### DIFF
--- a/examples/harbor-host-codex-goal-agent-smoke.py
+++ b/examples/harbor-host-codex-goal-agent-smoke.py
@@ -520,6 +520,98 @@ def main() -> int:
         )
         assert explicit_timeout_agent.loopx_prompt_polling_round_timeout_sec == 120.0
 
+        class _FakeTurn:
+            thread_id = "thread_demo"
+            turn_id = "turn_demo"
+            goal_status = "active"
+            turn_status = "completed"
+            turn_completed_observed = True
+            assistant_message = ""
+            agent_message_delta_count = 0
+            agent_message_item_count = 0
+            item_completed_count = 0
+            notifications: list[str] = []
+            _responses = None
+
+            def terminate(self) -> None:
+                self.terminated = True
+
+        class _FakeContext:
+            metadata: dict = {}
+
+        original_start = module.start_codex_app_server_goal_turn
+        original_followup = module.start_codex_app_server_goal_followup_turn
+
+        def _fake_start(*args, **kwargs):
+            del args, kwargs
+            return _FakeTurn()
+
+        def _fake_followup(*args, **kwargs):
+            del args, kwargs
+            raise module.CodexAppServerGoalDriverError("synthetic follow-up failure")
+
+        module.start_codex_app_server_goal_turn = _fake_start
+        module.start_codex_app_server_goal_followup_turn = _fake_followup
+        try:
+            followup_failure_agent = module.HarborHostCodexGoalAgent(
+                logs_dir=Path(tmp) / "followup-failure-logs",
+                goal_surface="app_server",
+                goal_timeout_sec=60,
+                startup_delay_sec=0,
+                poll_interval_sec=0.01,
+                task_workdir="/workspace",
+                loopx_mode="codex_loopx",
+                loopx_access_packet_mode="compact",
+                loopx_cli_bridge_enabled=True,
+                loopx_experiment_protocol="max5_blind_loop_no_feedback",
+                loopx_max_rounds=2,
+            )
+            context = _FakeContext()
+            asyncio.run(
+                followup_failure_agent.run(
+                    "Synthetic Harbor instruction placeholder.",
+                    _FakeEnvironment(),
+                    context,
+                )
+            )
+        finally:
+            module.start_codex_app_server_goal_turn = original_start
+            module.start_codex_app_server_goal_followup_turn = original_followup
+
+        compact_paths = sorted(
+            (Path(tmp) / "followup-failure-logs").glob(
+                "host-codex-goal-*/app_server_goal_turn.compact.json"
+            )
+        )
+        assert compact_paths, "follow-up failure should still write compact closeout"
+        followup_compact = json.loads(compact_paths[-1].read_text(encoding="utf-8"))
+        assert followup_compact["first_blocker"] == (
+            "codex_app_server_goal_followup_turn_failed"
+        ), followup_compact
+        assert followup_compact["loopx_controller_trace_present"] is True
+        assert followup_compact["loopx_controller_trace"]["last_decision"] == (
+            "codex_app_server_goal_followup_turn_failed"
+        )
+        assert followup_compact["loopx_controller_trace"]["raw_error_recorded"] is False
+        assert followup_compact["loopx_case_closeout_summary"][
+            "result_kind"
+        ] == "runtime_exception_blocker"
+        assert followup_compact["loopx_case_closeout_summary"][
+            "status_observed"
+        ] is True
+        assert followup_compact["loopx_case_closeout_summary"][
+            "refresh_state_observed"
+        ] is True
+        assert followup_compact["loopx_case_closeout_summary"][
+            "quota_spend_observed"
+        ] is True
+        assert followup_compact["loopx_case_closeout_summary"][
+            "timeout_preserves_open_todo"
+        ] is False
+        assert context.metadata["first_blocker"] == (
+            "codex_app_server_goal_followup_turn_failed"
+        )
+
     print("harbor host Codex Goal agent smoke passed")
     return 0
 

--- a/scripts/harbor_host_codex_goal_agent.py
+++ b/scripts/harbor_host_codex_goal_agent.py
@@ -1002,7 +1002,7 @@ class HarborHostCodexGoalAgent(BaseAgent):
         marker = work_dir / "done.marker"
         prompt_path = work_dir / "prompt.txt"
         capture_path = work_dir / "tmux_capture.txt"
-        tmux_name = f"gh_harbor_goal_{run_id}"
+        tmux_name = f"loopx_harbor_goal_{run_id}"
         self._write_bridge_script(bridge, request_dir)
 
         loopx_access_packet = build_loopx_access_packet(
@@ -1506,6 +1506,7 @@ class HarborHostCodexGoalAgent(BaseAgent):
                 current_round = 1
                 completion_marker_count = 0
                 timeout_blocker = ""
+                runtime_blocker = ""
                 try:
                     while current_round <= self.loopx_prompt_polling_rounds:
                         marker_seen_this_round = False
@@ -1581,25 +1582,42 @@ class HarborHostCodexGoalAgent(BaseAgent):
                         controller_trace["last_decision"] = (
                             "send_prompt_polling_continuation"
                         )
-                        turn = await asyncio.to_thread(
-                            start_codex_app_server_goal_followup_turn,
-                            turn,
-                            work_dir=work_dir,
-                            prompt=continuation_prompt,
-                            model_name=self.model_name,
-                            reasoning_effort=self.reasoning_effort,
-                            response_timeout_sec=self.app_server_response_timeout_sec,
-                            wait_for_completion=False,
-                        )
+                        try:
+                            turn = await asyncio.to_thread(
+                                start_codex_app_server_goal_followup_turn,
+                                turn,
+                                work_dir=work_dir,
+                                prompt=continuation_prompt,
+                                model_name=self.model_name,
+                                reasoning_effort=self.reasoning_effort,
+                                response_timeout_sec=(
+                                    self.app_server_response_timeout_sec
+                                ),
+                                wait_for_completion=False,
+                            )
+                        except CodexAppServerGoalDriverError as exc:
+                            runtime_blocker = (
+                                "codex_app_server_goal_followup_turn_failed"
+                            )
+                            controller_trace["last_decision"] = runtime_blocker
+                            controller_trace["runtime_error_type"] = type(exc).__name__
+                            controller_trace["raw_error_recorded"] = False
+                            break
                         current_round = next_round
                     observe_codex_app_server_goal_turn(turn)
                     await self._serve_bridge_requests(environment, request_dir)
                     await run_case_scheduler_closeout(
                         result_kind=(
-                            "timeout_blocker" if timeout_blocker else "case_result"
+                            "runtime_exception_blocker"
+                            if runtime_blocker
+                            else (
+                                "timeout_blocker"
+                                if timeout_blocker
+                                else "case_result"
+                            )
                         )
                     )
-                    first_blocker = timeout_blocker
+                    first_blocker = runtime_blocker or timeout_blocker
                     write_compact(first_blocker)
                 finally:
                     turn.terminate()
@@ -1609,7 +1627,7 @@ class HarborHostCodexGoalAgent(BaseAgent):
                     "bridge_request_count": self._served_request_count,
                     "goal_surface": "app_server",
                     "turn_completed_observed": bool(turn.turn_completed_observed),
-                    "first_blocker": timeout_blocker,
+                    "first_blocker": runtime_blocker or timeout_blocker,
                     "loopx_mode": self.loopx_mode,
                     "loopx_access_packet_injected": bool(
                         loopx_access_packet


### PR DESCRIPTION
## Summary
- keep Harbor prompt-polling follow-up app-server failures inside the public-safe worker closeout path instead of bubbling as an unmaterialized worker runtime exception
- write compact blocker metadata plus case scheduler closeout for status/refresh/quota-spend visibility
- add a focused smoke that simulates a follow-up `CodexAppServerGoalDriverError` and verifies compact closeout is still produced

## Validation
- `python3 examples/harbor-host-codex-goal-agent-smoke.py`
- `python3 -m py_compile scripts/harbor_host_codex_goal_agent.py examples/harbor-host-codex-goal-agent-smoke.py`
- `python3 examples/harbor-job-result-reducer-smoke.py`
- `loopx check --scan-path scripts/harbor_host_codex_goal_agent.py --scan-path examples/harbor-host-codex-goal-agent-smoke.py` (public boundary scan clean; existing duplicate history-index warning remains unrelated)
- `git diff --check`

## Excluded
- no `.local` benchmark run artifacts
- no raw task text, raw logs, trajectories, verifier output, credentials, or private paths