### PR TITLE
Fix next-action projection drift

### DIFF
--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -511,6 +511,14 @@ For every registered goal, `quota should-run` also includes a `todo_write_hint`
 so agent executors know to write newly discovered user/owner work with
 `loopx todo add --role user` instead of hiding it in `Next Action`,
 review docs, or chat.
+When available, `quota should-run` also keeps next-action signals separate:
+`active_state_next_action` is the durable `## Next Action`,
+`latest_run_recommended_action` is the latest non-agent-lane run's
+recommendation, and `agent_lane_next_action` is the current `--agent-id`
+slice. If the active-state and latest-run actions differ,
+`next_action_projection_warning` asks the executor to explicitly write back the
+intended durable route with `refresh-state --next-action` or keep treating the
+signals as distinct.
 For goals with `coordination.registered_agents`, `quota should-run` accepts an
 optional `--agent-id <registered-agent>`. Identity-aware heartbeat prompts pass
 that flag through their quota guard. If a registered goal is checked without an

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -927,6 +927,12 @@ If the refresh command was run without `--recommended-action`, the compact
 `recommended_action` should be the first public-safe item from the refreshed
 active state's `## Next Action`, including wrapped continuation lines;
 otherwise it falls back to a generic refresh notice.
+`--recommended-action` describes the appended run record; it does not rewrite
+the active state's durable `## Next Action`. To intentionally change that
+durable route, run `refresh-state --next-action <public-safe action>`. Status
+projections may expose both `active_state_next_action` and
+`latest_run_recommended_action`; when they differ, `next_action_projection_warning`
+marks the drift instead of silently choosing one as the only truth.
 
 When a refresh is scoped with `--agent-id`, the run records
 `progress_scope=agent_lane`. This is a side-lane note, not a project-level

--- a/examples/next-action-projection-contract-smoke.py
+++ b/examples/next-action-projection-contract-smoke.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Smoke-test explicit durable Next Action writeback and projection drift."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import loopx.state_refresh as state_refresh
+from loopx.quota import build_quota_should_run, render_quota_should_run_markdown
+from loopx.status import collect_status, render_status_markdown
+
+
+GOAL_ID = "next-action-projection-goal"
+ACTIVE_NEXT_ACTION = "Keep the durable route on the broad public PoC lane."
+RUN_RECOMMENDATION = "Inspect the vliw suite result before changing the durable route."
+UPDATED_NEXT_ACTION = "Promote the vliw repair slice as the durable next action."
+UPDATED_RUN_RECOMMENDATION = "Validate the vliw repair slice and then write compact evidence."
+SIDE_AGENT_ACTION = "Polish the hosted frontstage public case card."
+
+
+def write_fixture(root: Path) -> tuple[Path, Path, Path, Path]:
+    project = root / "project"
+    runtime = root / "runtime"
+    state_file = f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    state_path = project / state_file
+    registry_path = project / ".loopx" / "registry.json"
+
+    state_path.parent.mkdir(parents=True)
+    state_path.write_text(
+        "---\n"
+        "status: active\n"
+        "owner_mode: goal\n"
+        'objective: "Keep next-action projections explicit."\n'
+        "updated_at: 2026-06-22T00:00:00+00:00\n"
+        "---\n\n"
+        "# Next Action Projection Fixture\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] [P0] Validate the primary public PoC control-plane lane.\n"
+        "  <!-- loopx:todo todo_id=todo_primary status=open "
+        "task_class=advancement_task claimed_by=codex-main-control -->\n"
+        f"- [ ] [P1] {SIDE_AGENT_ACTION}\n"
+        "  <!-- loopx:todo todo_id=todo_side status=open "
+        "task_class=advancement_task claimed_by=codex-side-bypass -->\n\n"
+        "## Next Action\n\n"
+        f"- {ACTIVE_NEXT_ACTION}\n\n"
+        "## Progress Ledger\n\n"
+        "- Fixture initialized.\n",
+        encoding="utf-8",
+    )
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "updated_at": "2026-06-22T00:00:00+00:00",
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "next-action-projection-fixture",
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": state_file,
+                        "adapter": {"kind": "fixture", "status": "connected-read-only"},
+                        "coordination": {
+                            "primary_agent": "codex-main-control",
+                            "registered_agents": ["codex-main-control", "codex-side-bypass"],
+                        },
+                        "authority_sources": [],
+                    }
+                ],
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return registry_path, runtime, project, state_path
+
+
+def state_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def assert_state_next_action(path: Path, expected: str) -> None:
+    text = state_text(path)
+    assert f"- {expected}" in text, text
+
+
+def collect_projection(registry_path: Path, runtime: Path, project: Path) -> dict[str, object]:
+    status = collect_status(
+        registry_path=registry_path,
+        runtime_root_override=str(runtime),
+        scan_roots=[project],
+        limit=5,
+    )
+    items = status["attention_queue"]["items"]
+    item = next(item for item in items if item["goal_id"] == GOAL_ID)
+    decision = build_quota_should_run(
+        status,
+        goal_id=GOAL_ID,
+        agent_id="codex-side-bypass",
+    )
+    return {"status": status, "item": item, "decision": decision}
+
+
+def main() -> None:
+    original_now_local = state_refresh.now_local
+    try:
+        with tempfile.TemporaryDirectory(prefix="loopx-next-action-projection-") as raw_tmp:
+            registry_path, runtime, project, state_path = write_fixture(Path(raw_tmp))
+
+            state_refresh.now_local = lambda: "2026-06-22T00:01:00+00:00"
+            default_payload = state_refresh.refresh_state_run(
+                registry_path=registry_path,
+                runtime_root_override=str(runtime),
+                goal_id=GOAL_ID,
+                project=project,
+                state_file=None,
+                classification="state_refreshed",
+                recommended_action=RUN_RECOMMENDATION,
+                dry_run=False,
+                sync_global=False,
+            )
+            assert default_payload["recommended_action"] == RUN_RECOMMENDATION, default_payload
+            assert default_payload.get("active_state_next_action_update") is None, default_payload
+            assert_state_next_action(state_path, ACTIVE_NEXT_ACTION)
+            assert RUN_RECOMMENDATION not in state_text(state_path), state_text(state_path)
+
+            first_projection = collect_projection(registry_path, runtime, project)
+            first_item = first_projection["item"]
+            first_decision = first_projection["decision"]
+            assert first_item["active_state_next_action"] == ACTIVE_NEXT_ACTION, first_item
+            assert first_item["latest_run_recommended_action"] == RUN_RECOMMENDATION, first_item
+            assert first_item["next_action_projection_warning"]["requires_state_writeback"] is True, first_item
+            assert first_decision["active_state_next_action"] == ACTIVE_NEXT_ACTION, first_decision
+            assert first_decision["latest_run_recommended_action"] == RUN_RECOMMENDATION, first_decision
+            assert first_decision["next_action_projection_warning"]["requires_state_writeback"] is True, first_decision
+
+            state_refresh.now_local = lambda: "2026-06-22T00:02:00+00:00"
+            explicit_payload = state_refresh.refresh_state_run(
+                registry_path=registry_path,
+                runtime_root_override=str(runtime),
+                goal_id=GOAL_ID,
+                project=project,
+                state_file=None,
+                classification="state_refreshed",
+                recommended_action=UPDATED_RUN_RECOMMENDATION,
+                next_action=UPDATED_NEXT_ACTION,
+                dry_run=False,
+                sync_global=False,
+            )
+            update = explicit_payload["active_state_next_action_update"]
+            assert update["updated"] is True, explicit_payload
+            assert update["next_action"] == UPDATED_NEXT_ACTION, explicit_payload
+            assert_state_next_action(state_path, UPDATED_NEXT_ACTION)
+            assert ACTIVE_NEXT_ACTION not in state_text(state_path), state_text(state_path)
+
+            second_projection = collect_projection(registry_path, runtime, project)
+            second_status = second_projection["status"]
+            second_item = second_projection["item"]
+            second_decision = second_projection["decision"]
+            status_markdown = render_status_markdown(second_status)
+            quota_markdown = render_quota_should_run_markdown(second_decision)
+
+            assert second_item["active_state_next_action"] == UPDATED_NEXT_ACTION, second_item
+            assert second_item["latest_run_recommended_action"] == UPDATED_RUN_RECOMMENDATION, second_item
+            assert second_decision["active_state_next_action"] == UPDATED_NEXT_ACTION, second_decision
+            assert second_decision["latest_run_recommended_action"] == UPDATED_RUN_RECOMMENDATION, second_decision
+            lane = second_decision["agent_lane_next_action"]
+            assert lane["todo_id"] == "todo_side", second_decision
+            assert lane["title"] == SIDE_AGENT_ACTION, second_decision
+            assert SIDE_AGENT_ACTION in lane["text"], second_decision
+            assert (
+                second_decision["next_action_projection_warning"]["agent_lane_next_action"]
+                == lane["text"]
+            ), second_decision
+            assert "active_state_next_action" in status_markdown, status_markdown
+            assert "latest_run_recommended_action" in status_markdown, status_markdown
+            assert "active_state_next_action" in quota_markdown, quota_markdown
+            assert "latest_run_recommended_action" in quota_markdown, quota_markdown
+    finally:
+        state_refresh.now_local = original_now_local
+
+    print("next-action-projection-contract-smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -5676,6 +5676,14 @@ def main(argv: list[str] | None = None) -> int:
         help=f"Public-safe next action. Defaults to: {DEFAULT_REFRESH_ACTION}",
     )
     refresh_state_parser.add_argument(
+        "--next-action",
+        help=(
+            "Explicitly update the active state's durable ## Next Action before "
+            "appending the refresh run. Without this flag, --recommended-action "
+            "only describes the run record."
+        ),
+    )
+    refresh_state_parser.add_argument(
         "--delivery-batch-scale",
         choices=DELIVERY_BATCH_SCALE_CHOICES,
         help="Optional explicit delivery scale for this refresh run, overriding classification-name inference.",
@@ -10144,6 +10152,7 @@ def main(argv: list[str] | None = None) -> int:
                 state_file=Path(args.state_file).expanduser() if args.state_file else None,
                 classification=args.classification,
                 recommended_action=args.recommended_action,
+                next_action=args.next_action,
                 delivery_batch_scale=args.delivery_batch_scale,
                 delivery_outcome=args.delivery_outcome,
                 agent_id=args.agent_id,

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -29,7 +29,7 @@ from .execution_profile import (
     outcome_floor_threshold,
 )
 from .orchestration import compact_orchestration_policy, orchestration_policy_summary
-from .state_projection import is_user_wait_text
+from .state_projection import is_user_wait_text, next_action_projection_warning
 from .todo_contract import (
     TODO_STATUS_OPEN,
     TODO_TASK_CLASS_ADVANCEMENT,
@@ -5256,6 +5256,26 @@ def build_quota_should_run(
             selected_action=selected_recommended_action,
             work_lane_contract=work_lane_contract,
         )
+        active_state_next_action_text = _protocol_action_text(
+            item.get("active_state_next_action")
+            or project_asset.get("active_state_next_action")
+            or project_asset.get("next_action"),
+            limit=320,
+        )
+        latest_run_recommended_action_text = _protocol_action_text(
+            item.get("latest_run_recommended_action")
+            or project_asset.get("latest_run_recommended_action"),
+            limit=320,
+        )
+        agent_lane_next_action_text = _protocol_action_text(
+            agent_lane_next_action.get("text") if isinstance(agent_lane_next_action, dict) else None,
+            limit=320,
+        )
+        next_action_warning = next_action_projection_warning(
+            active_state_next_action=active_state_next_action_text,
+            latest_run_recommended_action=latest_run_recommended_action_text,
+            agent_lane_next_action=agent_lane_next_action_text,
+        )
         agent_scope_action = _agent_scope_frontier_action(effective_action)
         payload = {
             "ok": bool(plan.get("ok")) or self_repair_allowed or capability_repair_allowed or workspace_repair_allowed,
@@ -5317,6 +5337,8 @@ def build_quota_should_run(
             "source": item.get("source"),
             "project_asset_source": item.get("project_asset_source"),
             "recommended_action": selected_recommended_action,
+            "active_state_next_action": active_state_next_action_text or None,
+            "latest_run_recommended_action": latest_run_recommended_action_text or None,
             "execution_profile": _quota_execution_profile_summary(
                 project_asset.get("execution_profile")
             )
@@ -5467,6 +5489,8 @@ def build_quota_should_run(
             payload["stale_latest_run_warning"] = projection_warning
         if state_action_projection_warning:
             payload["state_action_projection_warning"] = state_action_projection_warning
+        if next_action_warning:
+            payload["next_action_projection_warning"] = next_action_warning
         backlog_warning = (
             item.get("backlog_hygiene_warning")
             if isinstance(item.get("backlog_hygiene_warning"), dict)
@@ -6625,6 +6649,12 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
             f"role={agent_identity.get('role')} "
             f"primary_agent={agent_identity.get('primary_agent')}"
         )
+    if payload.get("active_state_next_action"):
+        lines.append(f"- active_state_next_action: {payload.get('active_state_next_action')}")
+    if payload.get("latest_run_recommended_action"):
+        lines.append(
+            f"- latest_run_recommended_action: {payload.get('latest_run_recommended_action')}"
+        )
     agent_lane_next_action = (
         payload.get("agent_lane_next_action")
         if isinstance(payload.get("agent_lane_next_action"), dict)
@@ -6752,6 +6782,22 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
         if state_action_projection_warning.get("recommended_action"):
             lines.append(
                 f"- state_action_projection_action: {state_action_projection_warning.get('recommended_action')}"
+            )
+    next_action_projection = (
+        payload.get("next_action_projection_warning")
+        if isinstance(payload.get("next_action_projection_warning"), dict)
+        else {}
+    )
+    if next_action_projection:
+        lines.append(
+            "- next_action_projection_warning: "
+            f"requires_state_writeback={next_action_projection.get('requires_state_writeback')} "
+            f"reason={next_action_projection.get('reason')}"
+        )
+        if next_action_projection.get("latest_run_recommended_action"):
+            lines.append(
+                "- latest_run_projection_action: "
+                f"{next_action_projection.get('latest_run_recommended_action')}"
             )
     backlog_hygiene_warning = (
         payload.get("backlog_hygiene_warning")

--- a/loopx/state_projection.py
+++ b/loopx/state_projection.py
@@ -7,6 +7,7 @@ from .todo_contract import TODO_TASK_PATTERN, todo_done_for_status, todo_status_
 
 
 STATE_PROJECTION_GAP_SCHEMA_VERSION = "state_projection_gap_v0"
+NEXT_ACTION_PROJECTION_WARNING_SCHEMA_VERSION = "next_action_projection_warning_v0"
 
 SECTION_HEADING_PATTERN = re.compile(r"^##+\s+(.+?)\s*$")
 BULLET_PATTERN = re.compile(r"^\s*(?:[-*]|\d+[.)])\s+(.+?)\s*$")
@@ -56,6 +57,70 @@ def _compact_text(value: Any, *, limit: int = 220) -> str:
     if len(text) <= limit:
         return text
     return text[: limit - 1].rstrip() + "…"
+
+
+def _action_projection_text(value: Any, *, limit: int = 320) -> str:
+    return _compact_text(value, limit=limit)
+
+
+def _action_projection_compare_text(value: Any) -> str:
+    return re.sub(r"\s+", " ", str(value or "").strip().lower())
+
+
+def _action_projection_prefix(value: Any) -> str:
+    text = _action_projection_compare_text(value)
+    return text[:96]
+
+
+def actions_are_projection_aligned(left: Any, right: Any) -> bool:
+    left_text = _action_projection_compare_text(left)
+    right_text = _action_projection_compare_text(right)
+    if not left_text or not right_text:
+        return False
+    if left_text == right_text:
+        return True
+    left_prefix = _action_projection_prefix(left_text)
+    right_prefix = _action_projection_prefix(right_text)
+    for prefix, text in ((left_prefix, right_text), (right_prefix, left_text)):
+        if prefix and len(prefix) >= 24 and prefix in text:
+            return True
+    shorter, longer = sorted((left_text, right_text), key=len)
+    return len(shorter) >= 32 and shorter in longer
+
+
+def next_action_projection_warning(
+    *,
+    active_state_next_action: Any,
+    latest_run_recommended_action: Any,
+    agent_lane_next_action: Any = None,
+) -> dict[str, Any] | None:
+    active_text = _action_projection_text(active_state_next_action)
+    latest_text = _action_projection_text(latest_run_recommended_action)
+    if not active_text or not latest_text:
+        return None
+    if actions_are_projection_aligned(active_text, latest_text):
+        return None
+    warning: dict[str, Any] = {
+        "schema_version": NEXT_ACTION_PROJECTION_WARNING_SCHEMA_VERSION,
+        "kind": "next_action_projection_mismatch",
+        "severity": "warning",
+        "requires_state_writeback": True,
+        "active_state_next_action": active_text,
+        "latest_run_recommended_action": latest_text,
+        "reason": (
+            "latest run recommended_action differs from the durable active-state "
+            "Next Action"
+        ),
+        "recommended_action": (
+            "if the latest run action is the intended durable route, write it back "
+            "explicitly with refresh-state --next-action; otherwise keep treating "
+            "the run recommendation and active-state Next Action as separate signals"
+        ),
+    }
+    lane_text = _action_projection_text(agent_lane_next_action)
+    if lane_text:
+        warning["agent_lane_next_action"] = lane_text
+    return warning
 
 
 def is_user_wait_text(value: Any) -> bool:

--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from .delivery_outcome import DELIVERY_OUTCOME_CHOICES, require_delivery_outcome
 from .feedback import validate_public_safe_text
+from .file_lock import exclusive_file_lock
 from .global_registry import sync_project_registry_to_global
 from .history import load_registry, reserve_unique_run_paths, unique_run_paths
 from .paths import resolve_runtime_root
@@ -30,6 +31,7 @@ RECOMMENDED_ACTION_SECTION_LINE_LIMIT = 16
 BULLET_PREFIX_RE = re.compile(r"^(?:[-*]\s+|\d+[.)]\s+)")
 CHECKBOX_PREFIX_RE = re.compile(r"^\[(?P<mark>[ xX])\]\s+")
 DELIVERY_BATCH_SCALE_CHOICES = ("test_only", "single_surface", "multi_surface", "implementation")
+ACTIVE_STATE_NEXT_ACTION_UPDATE_SCHEMA_VERSION = "active_state_next_action_update_v0"
 
 
 def now_local() -> str:
@@ -71,6 +73,84 @@ def extract_section_lines(text: str, heading: str, limit: int = 8) -> list[str]:
             if len(collected) >= limit:
                 break
     return collected
+
+
+def replace_updated_at(text: str, updated_at: str) -> str:
+    if not text.startswith("---"):
+        return text
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        return text
+    frontmatter = parts[1]
+    body = parts[2]
+    if re.search(r"(?m)^updated_at:\s*.+$", frontmatter):
+        frontmatter = re.sub(
+            r"(?m)^updated_at:\s*.+$",
+            f"updated_at: {updated_at}",
+            frontmatter,
+            count=1,
+        )
+    else:
+        frontmatter = frontmatter.rstrip("\n") + f"\nupdated_at: {updated_at}\n"
+    return "---" + frontmatter + "---" + body
+
+
+def normalize_next_action_text(value: str) -> str:
+    text = " ".join(str(value or "").strip().split())
+    if not text:
+        raise ValueError("next_action must not be empty")
+    validate_public_safe_text("active_state_next_action", text)
+    return text
+
+
+def next_action_section_bounds(lines: list[str]) -> tuple[int, int] | None:
+    for index, line in enumerate(lines):
+        if line.strip() != "## Next Action":
+            continue
+        end = len(lines)
+        for next_index in range(index + 1, len(lines)):
+            if lines[next_index].startswith("## "):
+                end = next_index
+                break
+        return index, end
+    return None
+
+
+def next_action_insert_anchor(lines: list[str]) -> int:
+    preferred = {
+        "## Recent User Feedback",
+        "## Progress Ledger",
+        "## Operating Lessons",
+        "## Completed Work Archive",
+    }
+    for index, line in enumerate(lines):
+        if line.strip() in preferred:
+            return index
+    return len(lines)
+
+
+def replace_next_action_section(
+    state_text: str,
+    *,
+    next_action: str,
+    updated_at: str,
+) -> tuple[str, bool]:
+    lines = state_text.splitlines()
+    section = ["## Next Action", "", f"- {next_action}", ""]
+    bounds = next_action_section_bounds(lines)
+    if bounds:
+        start, end = bounds
+        updated_lines = [*lines[:start], *section, *lines[end:]]
+    else:
+        anchor = next_action_insert_anchor(lines)
+        insert = list(section)
+        if anchor > 0 and lines[anchor - 1].strip():
+            insert.insert(0, "")
+        updated_lines = [*lines[:anchor], *insert, *lines[anchor:]]
+    section_text = "\n".join(updated_lines).rstrip() + "\n"
+    if section_text.rstrip("\n") == state_text.rstrip("\n"):
+        return state_text, False
+    return replace_updated_at(section_text, updated_at), True
 
 
 def clean_action_line(line: str) -> str:
@@ -330,6 +410,23 @@ def render_state_refresh_markdown(payload: dict[str, Any]) -> str:
         if projection_gap.get("recommended_action"):
             lines.append(f"- state_projection_gap_action: {projection_gap.get('recommended_action')}")
 
+    next_action_update = (
+        payload.get("active_state_next_action_update")
+        if isinstance(payload.get("active_state_next_action_update"), dict)
+        else {}
+    )
+    if next_action_update:
+        lines.append(
+            "- active_state_next_action_update: "
+            f"updated={next_action_update.get('updated')} "
+            f"would_update={next_action_update.get('would_update')} "
+            f"dry_run={next_action_update.get('dry_run')}"
+        )
+        if next_action_update.get("next_action"):
+            lines.append(
+                f"- active_state_next_action: {next_action_update.get('next_action')}"
+            )
+
     global_sync = payload.get("global_sync") if isinstance(payload.get("global_sync"), dict) else {}
     if global_sync:
         lines.extend(
@@ -367,6 +464,7 @@ def refresh_state_run(
     state_file: Path | None,
     classification: str,
     recommended_action: str | None,
+    next_action: str | None = None,
     delivery_batch_scale: str | None = None,
     delivery_outcome: str | None = None,
     agent_id: str | None = None,
@@ -418,9 +516,32 @@ def refresh_state_run(
     if not resolved_state_file.exists():
         raise FileNotFoundError(f"state file does not exist: {resolved_state_file}")
     state_text = resolved_state_file.read_text(encoding="utf-8")
+    normalized_next_action = normalize_next_action_text(next_action) if next_action else None
+    generated_at = now_local()
+    active_state_next_action_update: dict[str, Any] | None = None
+    if normalized_next_action:
+        with exclusive_file_lock(resolved_state_file):
+            locked_state_text = resolved_state_file.read_text(encoding="utf-8")
+            updated_state_text, state_updated = replace_next_action_section(
+                locked_state_text,
+                next_action=normalized_next_action,
+                updated_at=generated_at,
+            )
+            active_state_next_action_update = {
+                "schema_version": ACTIVE_STATE_NEXT_ACTION_UPDATE_SCHEMA_VERSION,
+                "source": "refresh_state",
+                "next_action": normalized_next_action,
+                "updated": bool(state_updated and not dry_run),
+                "would_update": bool(state_updated),
+                "dry_run": bool(dry_run),
+                "updated_at": generated_at if state_updated else None,
+            }
+            if state_updated and not dry_run:
+                resolved_state_file.write_text(updated_state_text, encoding="utf-8")
+            state_text = updated_state_text if state_updated else locked_state_text
+
     action = recommended_action or derive_recommended_action(state_text)
     validate_public_safe_text("recommended_action", action)
-    generated_at = now_local()
     record = build_state_refresh_record(
         goal_id=safe_goal_id,
         state_file=resolved_state_file,
@@ -435,6 +556,8 @@ def refresh_state_run(
         agent_lane=normalized_agent_lane or None,
         autonomous_replan_recorded=autonomous_replan_recorded,
     )
+    if active_state_next_action_update:
+        record["active_state_next_action_update"] = active_state_next_action_update
 
     runs_dir = runtime_root / "goals" / safe_goal_id / "runs"
     json_path, markdown_path = unique_run_paths(runs_dir, generated_at)
@@ -472,6 +595,7 @@ def refresh_state_run(
         "agent_lane": record.get("agent_lane"),
         "autonomous_replan_recorded": autonomous_replan_recorded,
         "recommended_action": action,
+        "active_state_next_action_update": active_state_next_action_update,
         "generated_at": generated_at,
         "health_check": record["health_check"],
         "json_path": str(json_path),

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -39,7 +39,11 @@ from .paths import global_registry_path, resolve_runtime_root
 from .promotion_gate import build_promotion_gate
 from .quota import quota_status, quota_with_handoff_outcome_floor
 from .registry import registry_goals
-from .state_projection import active_state_next_action_entries, state_projection_gap_warning
+from .state_projection import (
+    active_state_next_action_entries,
+    next_action_projection_warning,
+    state_projection_gap_warning,
+)
 from .todo_contract import (
     TODO_STATUS_OPEN,
     TODO_TASK_CLASS_ADVANCEMENT,
@@ -6528,6 +6532,17 @@ def build_attention_queue(
             continue
         item = goal_attention(goal)
         if item:
+            current_status_run = latest_run(goal)
+            latest_run_action = public_safe_compact_text(
+                current_status_run.get("recommended_action")
+                if isinstance(current_status_run, dict)
+                else None,
+                limit=320,
+            )
+            if latest_run_action:
+                item["latest_run_recommended_action"] = latest_run_action
+                if isinstance(item.get("project_asset"), dict):
+                    item["project_asset"]["latest_run_recommended_action"] = latest_run_action
             control_plane = compact_control_plane_policy(goal.get("control_plane"))
             if control_plane:
                 item["control_plane"] = control_plane
@@ -6567,6 +6582,17 @@ def build_attention_queue(
                     item["project_asset"]["stale_latest_run_warning"] = projection_warning
             if goal.get("registry_member"):
                 item.update(active_state_todo_fields(goal))
+                if isinstance(item.get("project_asset"), dict):
+                    active_next_action = item.get("active_state_next_action")
+                    if active_next_action:
+                        item["project_asset"]["active_state_next_action"] = active_next_action
+                    next_action_warning = next_action_projection_warning(
+                        active_state_next_action=active_next_action,
+                        latest_run_recommended_action=item.get("latest_run_recommended_action"),
+                    )
+                    if next_action_warning:
+                        item["next_action_projection_warning"] = next_action_warning
+                        item["project_asset"]["next_action_projection_warning"] = next_action_warning
                 sync_connected_attention_action_from_todos(item)
                 backlog_warning = (
                     item.get("backlog_hygiene_warning")
@@ -7825,6 +7851,12 @@ def render_status_markdown(payload: dict[str, Any]) -> str:
         )
         if action:
             lines.append(f"  - action: {action}")
+        active_state_action = _markdown_scalar(item.get("active_state_next_action") or "")
+        if active_state_action:
+            lines.append(f"  - active_state_next_action: {active_state_action}")
+        latest_run_action = _markdown_scalar(item.get("latest_run_recommended_action") or "")
+        if latest_run_action:
+            lines.append(f"  - latest_run_recommended_action: {latest_run_action}")
         authority_summary = _authority_registry_markdown_summary(goals.get(str(item.get("goal_id") or "")))
         if authority_summary:
             lines.append(f"  - authority_material: {authority_summary}")
@@ -7855,6 +7887,16 @@ def render_status_markdown(payload: dict[str, Any]) -> str:
             asset_next_action = _markdown_scalar(project_asset.get("next_action") or "")
             if asset_next_action:
                 lines.append(f"    - asset_next_action: {asset_next_action}")
+            asset_active_next_action = _markdown_scalar(
+                project_asset.get("active_state_next_action") or ""
+            )
+            if asset_active_next_action:
+                lines.append(f"    - asset_active_state_next_action: {asset_active_next_action}")
+            asset_latest_run_action = _markdown_scalar(
+                project_asset.get("latest_run_recommended_action") or ""
+            )
+            if asset_latest_run_action:
+                lines.append(f"    - asset_latest_run_recommended_action: {asset_latest_run_action}")
             agent_lane_recommendation = (
                 project_asset.get("agent_lane_recommendation")
                 if isinstance(project_asset.get("agent_lane_recommendation"), dict)
@@ -8016,6 +8058,19 @@ def render_status_markdown(payload: dict[str, Any]) -> str:
                     f"active_state_updated_at={_markdown_scalar(projection_warning.get('active_state_updated_at') or '')} "
                     f"latest_run_generated_at={_markdown_scalar(projection_warning.get('latest_run_generated_at') or '')} "
                     f"reason={_markdown_scalar(projection_warning.get('reason') or '')}"
+                )
+            next_action_warning = (
+                project_asset.get("next_action_projection_warning")
+                if isinstance(project_asset.get("next_action_projection_warning"), dict)
+                else item.get("next_action_projection_warning")
+                if isinstance(item.get("next_action_projection_warning"), dict)
+                else {}
+            )
+            if next_action_warning:
+                lines.append(
+                    "    - next_action_projection_warning: "
+                    f"requires_state_writeback={next_action_warning.get('requires_state_writeback')} "
+                    f"reason={_markdown_scalar(next_action_warning.get('reason') or '')}"
                 )
             backlog_warning = (
                 project_asset.get("backlog_hygiene_warning")


### PR DESCRIPTION
## Summary
- add explicit `refresh-state --next-action` writeback for the active state durable `## Next Action` while leaving `--recommended-action` as run-record-only by default
- expose `active_state_next_action`, `latest_run_recommended_action`, and agent-lane next-action context in status/quota projections
- add `next_action_projection_warning` plus docs and a focused smoke for default/no-overwrite and explicit-writeback behavior

## Validation
- `python examples/next-action-projection-contract-smoke.py`
- `python examples/refresh-state-agent-lane-scope-smoke.py`
- `python examples/refresh-state-unique-run-path-smoke.py`
- `python examples/quota-plan-smoke.py`
- `python examples/quota-contract-smoke.py`
- `python examples/status-markdown-smoke.py`
- `python -m py_compile loopx/state_projection.py loopx/state_refresh.py loopx/status.py loopx/quota.py loopx/cli.py examples/next-action-projection-contract-smoke.py`
- `git diff --check`
- `./scripts/loopx check` (passes with existing warning: `loopx-meta` duplicate index rows raw=4479 unique=4475)

## Boundary
- staged with explicit pathspecs only
- narrow sensitive scan found no credentials, private links, or local absolute paths in changed files
