### PR TITLE
Expose LoopX install freshness hints

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -227,6 +227,10 @@ under `~/.local/share/loopx/releases/`, installs the CLI wrapper under
 `~/.local/bin`, and installs the reusable LoopX skills under
 `~/.codex/skills`.
 
+`loopx doctor` reports `install_freshness`. When it says
+`requires_upgrade=true`, rerun the no-clone installer printed in
+`upgrade_command`, then run `loopx doctor` again before continuing.
+
 This is the recommended install repair path for Codex CLI users because an
 agent can run it from inside the TUI without asking the user to clone this
 repository first.

--- a/examples/codex-cli-packaged-install-smoke.py
+++ b/examples/codex-cli-packaged-install-smoke.py
@@ -70,6 +70,8 @@ def main() -> None:
             capture_output=True,
         )
         assert "ok: `True`" in doctor.stdout, doctor.stdout
+        assert "## Install Freshness" in doctor.stdout, doctor.stdout
+        assert "install-from-github.sh" in doctor.stdout, doctor.stdout
 
         for skill in (
             "loopx-project",

--- a/examples/fresh-clone-quickstart-smoke.py
+++ b/examples/fresh-clone-quickstart-smoke.py
@@ -99,6 +99,9 @@ def main() -> int:
         assert doctor["path"]["loopx"] == str(wrapper), doctor
         assert doctor["path"]["loopx_canary"] == str(canary_wrapper), doctor
         assert doctor["package"]["release_root"] == str(release_root), doctor
+        assert doctor["install_freshness"]["schema_version"] == "loopx_install_freshness_v0", doctor
+        assert doctor["install_freshness"]["status"] == "unknown", doctor
+        assert "install-from-github.sh" in doctor["install_freshness"]["upgrade_command"], doctor
         assert doctor["skills"]["loopx-project"]["exists"] is True, doctor
         assert doctor["skills"]["loopx-self-repair"]["exists"] is True, doctor
 
@@ -128,6 +131,8 @@ def main() -> int:
         )
         assert bootstrap["ok"] is True, bootstrap
         assert bootstrap["goal_id"] == GOAL_ID, bootstrap
+        assert "install-from-github.sh" in bootstrap["install_repair_command"], bootstrap
+        assert "loopx doctor" in bootstrap["install_repair_command"], bootstrap
         assert (project / ".loopx" / "registry.json").is_file(), bootstrap
         assert (project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md").is_file(), bootstrap
 

--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -18,7 +18,7 @@ INSTALL_SCRIPT = REPO_ROOT / "scripts" / "install-local.sh"
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from loopx.doctor import add_promotion_readiness_freshness  # noqa: E402
+from loopx.doctor import add_promotion_readiness_freshness, build_install_freshness  # noqa: E402
 
 
 def run_install(env: dict[str, str], release_id: str) -> subprocess.CompletedProcess[str]:
@@ -212,6 +212,14 @@ def main() -> int:
         )
         doctor_payload = json.loads(doctor.stdout)
         assert doctor_payload["ok"] is True, doctor_payload
+        freshness = doctor_payload["install_freshness"]
+        assert freshness["schema_version"] == "loopx_install_freshness_v0", freshness
+        assert freshness["status"] == "unknown", freshness
+        assert freshness["requires_upgrade"] is False, freshness
+        assert freshness["current_version"], freshness
+        assert "install-from-github.sh" in freshness["upgrade_command"], freshness
+        assert "loopx doctor" in freshness["upgrade_command"], freshness
+        assert doctor_payload["upgrade_hint"] == freshness, doctor_payload
         assert doctor_payload["path"]["loopx"] == str(wrapper), doctor_payload
         assert doctor_payload["path"]["loopx_realpath"] == str(wrapper.resolve()), doctor_payload
         assert doctor_payload["path"]["loopx_canary"] == str(canary_wrapper), doctor_payload
@@ -272,6 +280,10 @@ def main() -> int:
         assert "loopx_canary_realpath:" in doctor_markdown, doctor_markdown
         assert "release_root:" in doctor_markdown, doctor_markdown
         assert "## Release Provenance" in doctor_markdown, doctor_markdown
+        assert "## Install Freshness" in doctor_markdown, doctor_markdown
+        assert "schema_version: `loopx_install_freshness_v0`" in doctor_markdown, doctor_markdown
+        assert "status: `unknown`" in doctor_markdown, doctor_markdown
+        assert "install-from-github.sh" in doctor_markdown, doctor_markdown
         assert "latest_promotion_readiness: available=`True`" in doctor_markdown, doctor_markdown
         assert "freshness=`fresh`" in doctor_markdown, doctor_markdown
         assert "requires_readiness_run=`False`" in doctor_markdown, doctor_markdown
@@ -288,6 +300,36 @@ def main() -> int:
         missing = add_promotion_readiness_freshness({"available": False})
         assert missing["freshness_status"] == "missing", missing
         assert missing["requires_readiness_run"] is True, missing
+
+        stale_install = build_install_freshness(
+            command_path=wrapper,
+            release_root=root / "releases" / "20260101T000000Z",
+            repo_root=REPO_ROOT,
+            skills={
+                "loopx-project": {"exists": True, "required_phrases": True},
+                "loopx-doc-registry": {"exists": True, "required_phrases": True},
+                "loopx-self-repair": {"exists": True, "required_phrases": True},
+            },
+            now=datetime(2026, 1, 9, tzinfo=timezone.utc),
+        )
+        assert stale_install["status"] == "stale", stale_install
+        assert stale_install["requires_upgrade"] is True, stale_install
+        assert stale_install["release_age_hours"] == 192.0, stale_install
+        assert "install-from-github.sh" in stale_install["no_clone_upgrade_command"], stale_install
+
+        fresh_install = build_install_freshness(
+            command_path=wrapper,
+            release_root=root / "releases" / "20260108T000000Z",
+            repo_root=REPO_ROOT,
+            skills={
+                "loopx-project": {"exists": True, "required_phrases": True},
+                "loopx-doc-registry": {"exists": True, "required_phrases": True},
+                "loopx-self-repair": {"exists": True, "required_phrases": True},
+            },
+            now=datetime(2026, 1, 9, tzinfo=timezone.utc),
+        )
+        assert fresh_install["status"] == "fresh", fresh_install
+        assert fresh_install["requires_upgrade"] is False, fresh_install
 
         cli = subprocess.run(
             [

--- a/loopx/bootstrap.py
+++ b/loopx/bootstrap.py
@@ -24,6 +24,12 @@ from .todos import add_todo_to_lines
 
 DEFAULT_OBJECTIVE = "Improve this project through bounded, verified goal segments."
 DEFAULT_DOMAIN = "project-goal-control-plane"
+NO_CLONE_INSTALL_URL = "https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh"
+NO_CLONE_INSTALL_REPAIR_COMMAND = (
+    f"curl -fsSL {NO_CLONE_INSTALL_URL} | bash\n"
+    'export PATH="$HOME/.local/bin:$PATH"\n'
+    "loopx doctor"
+)
 
 
 def slugify_goal_id(value: str) -> str:
@@ -663,6 +669,11 @@ def bootstrap_project(
             f"loopx --registry {runtime_root / 'registry.global.json'} status",
             f"loopx --registry {relative_state_file(project, registry_path)} history --goal-id {goal_id}",
         ],
+        "install_repair_command": NO_CLONE_INSTALL_REPAIR_COMMAND,
+        "install_repair_note": (
+            "If this local LoopX install is missing or stale, rerun the no-clone installer, "
+            "refresh PATH, and confirm with loopx doctor before continuing project delivery."
+        ),
         "private_boundary_note": "Add .loopx/ and .codex/goals/ to the project .gitignore if the goal state contains private evidence.",
     }
 
@@ -772,6 +783,18 @@ def render_bootstrap_markdown(payload: dict[str, Any]) -> str:
     lines.extend(["", "## Next Commands"])
     for command in payload.get("next_commands") or []:
         lines.append(f"- `{command}`")
+
+    if payload.get("install_repair_command"):
+        lines.extend(
+            [
+                "",
+                "## Install / Update Hint",
+                str(payload.get("install_repair_note") or ""),
+                "```bash",
+                str(payload.get("install_repair_command")),
+                "```",
+            ]
+        )
 
     if payload.get("private_boundary_note"):
         lines.extend(["", "## Boundary Note", str(payload.get("private_boundary_note"))])

--- a/loopx/doctor.py
+++ b/loopx/doctor.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 from datetime import datetime, timezone
 import json
 import os
+import re
 import shutil
 import sys
 from pathlib import Path
 from typing import Any
 
+from . import __version__
 from .paths import DEFAULT_RUNTIME_ROOT
 
 
@@ -15,6 +17,14 @@ PROMOTION_READINESS_CLASSIFICATIONS = {
     "canary_promotion_readiness_smoke_group",
 }
 PROMOTION_READINESS_FRESHNESS_HOURS = 24
+INSTALL_FRESHNESS_STALE_HOURS = 168
+NO_CLONE_INSTALL_URL = "https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh"
+NO_CLONE_UPGRADE_COMMAND = (
+    f"curl -fsSL {NO_CLONE_INSTALL_URL} | bash\n"
+    'export PATH="$HOME/.local/bin:$PATH"\n'
+    "loopx doctor"
+)
+RELEASE_ID_TIMESTAMP_RE = re.compile(r"^\d{8}T\d{6}Z$")
 REQUIRED_INSTALLED_SKILL_PHRASES = {
     "loopx-project": (
         "--classification <PUBLIC_SAFE_PROGRESS_CLASSIFICATION>",
@@ -69,6 +79,76 @@ def command_root_summary(command_path: Path | None, command_realpath: Path | Non
         "root": str(root) if root else None,
         "release_id": root.name if is_release_snapshot(root) else None,
         "is_release_snapshot": is_release_snapshot(root),
+    }
+
+
+def parse_release_id_time(release_id: str | None) -> datetime | None:
+    if not release_id or not RELEASE_ID_TIMESTAMP_RE.match(release_id):
+        return None
+    try:
+        return datetime.strptime(release_id, "%Y%m%dT%H%M%SZ").replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+def build_install_freshness(
+    *,
+    command_path: Path | None,
+    release_root: Path | None,
+    repo_root: Path,
+    skills: dict[str, dict[str, Any]],
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    reference = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    release_id = release_root.name if is_release_snapshot(release_root) else None
+    release_time = parse_release_id_time(release_id)
+    age_hours: float | None = None
+    if release_time:
+        age_hours = round(max(0, (reference - release_time.astimezone(timezone.utc)).total_seconds()) / 3600, 2)
+
+    skill_problem = any(
+        not skill.get("exists") or not skill.get("required_phrases")
+        for skill in skills.values()
+    )
+    if command_path is None:
+        status = "missing"
+        reason = "loopx is not on PATH"
+        requires_upgrade = True
+    elif skill_problem:
+        status = "repair_recommended"
+        reason = "installed LoopX skills are missing or stale"
+        requires_upgrade = True
+    elif release_id and age_hours is not None and age_hours > INSTALL_FRESHNESS_STALE_HOURS:
+        status = "stale"
+        reason = f"default release snapshot is older than {INSTALL_FRESHNESS_STALE_HOURS} hours"
+        requires_upgrade = True
+    elif release_id and age_hours is not None:
+        status = "fresh"
+        reason = "default release snapshot timestamp is within the freshness window"
+        requires_upgrade = False
+    elif is_release_snapshot(release_root):
+        status = "unknown"
+        reason = "default release snapshot has a non-timestamp release id"
+        requires_upgrade = False
+    else:
+        status = "live_checkout"
+        reason = "current command is not a timestamped release snapshot"
+        requires_upgrade = False
+
+    contributor_upgrade_command = f"{repo_root / 'scripts' / 'install-local.sh'}\nloopx doctor"
+    return {
+        "schema_version": "loopx_install_freshness_v0",
+        "status": status,
+        "requires_upgrade": requires_upgrade,
+        "reason": reason,
+        "current_version": __version__,
+        "stale_after_hours": INSTALL_FRESHNESS_STALE_HOURS,
+        "release_id": release_id,
+        "release_age_hours": age_hours,
+        "upgrade_command": NO_CLONE_UPGRADE_COMMAND,
+        "no_clone_upgrade_command": NO_CLONE_UPGRADE_COMMAND,
+        "contributor_upgrade_command": contributor_upgrade_command,
+        "doctor_after_upgrade": "loopx doctor",
     }
 
 
@@ -258,6 +338,12 @@ def collect_doctor() -> dict[str, Any]:
             latest_promotion_readiness_event(DEFAULT_RUNTIME_ROOT)
         ),
     }
+    install_freshness = build_install_freshness(
+        command_path=command_path,
+        release_root=release_root,
+        repo_root=repo_root,
+        skills=skills,
+    )
     checks = [
         {
             "id": "command_on_path",
@@ -363,6 +449,8 @@ def collect_doctor() -> dict[str, Any]:
             "wrapper_script": str(wrapper_script),
         },
         "release_provenance": release_provenance,
+        "install_freshness": install_freshness,
+        "upgrade_hint": install_freshness,
         "skill": {
             "path": str(skill_path),
             "exists": skill_path.exists(),
@@ -370,7 +458,11 @@ def collect_doctor() -> dict[str, Any]:
         },
         "skills": skills,
         "checks": checks,
-        "fix": f"Run `{repo_root / 'scripts' / 'install-local.sh'}` and start a new shell, or export PATH=\"{local_bin}:$PATH\".",
+        "fix": (
+            f"Run `{repo_root / 'scripts' / 'install-local.sh'}` and start a new shell, "
+            f"or export PATH=\"{local_bin}:$PATH\". For no-clone repair, run "
+            f"`curl -fsSL {NO_CLONE_INSTALL_URL} | bash`."
+        ),
     }
 
 
@@ -437,6 +529,25 @@ def render_doctor_markdown(payload: dict[str, Any]) -> str:
                     f"age_hours=`{readiness.get('age_hours')}`, "
                     f"requires_readiness_run=`{readiness.get('requires_readiness_run')}`"
                 ),
+            ]
+        )
+    freshness = payload.get("install_freshness") if isinstance(payload.get("install_freshness"), dict) else {}
+    if freshness:
+        lines.extend(
+            [
+                "",
+                "## Install Freshness",
+                f"- schema_version: `{freshness.get('schema_version')}`",
+                f"- status: `{freshness.get('status')}`",
+                f"- requires_upgrade: `{freshness.get('requires_upgrade')}`",
+                f"- current_version: `{freshness.get('current_version')}`",
+                f"- release_id: `{freshness.get('release_id')}`",
+                f"- release_age_hours: `{freshness.get('release_age_hours')}`",
+                f"- reason: `{freshness.get('reason')}`",
+                "- upgrade_command:",
+                "```bash",
+                str(freshness.get("upgrade_command") or ""),
+                "```",
             ]
         )
     if not payload.get("ok"):


### PR DESCRIPTION
## Summary
- add structured `install_freshness` / `upgrade_hint` output to `loopx doctor`
- surface the no-clone install repair command from `loopx bootstrap` markdown/json
- document the doctor upgrade hint and extend install/fresh-clone/package smokes

## Validation
- python3 examples/install-local-smoke.py
- python3 examples/codex-cli-packaged-install-smoke.py
- python3 examples/subcommand-format-smoke.py
- python3 examples/fresh-clone-quickstart-smoke.py
- python3 -m py_compile loopx/doctor.py loopx/bootstrap.py examples/install-local-smoke.py examples/fresh-clone-quickstart-smoke.py examples/codex-cli-packaged-install-smoke.py
- git diff --check
- ./scripts/loopx check --scan-path docs/guides/getting-started.md --scan-path examples/codex-cli-packaged-install-smoke.py --scan-path examples/fresh-clone-quickstart-smoke.py --scan-path examples/install-local-smoke.py --scan-path loopx/bootstrap.py --scan-path loopx/doctor.py

Note: `loopx check` still reports the pre-existing duplicate index rows warning for `loopx-meta`; public boundary scan was clean for the six changed files.