### PR TITLE
Add SWE-Marathon vliw launch packet

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/README.md
+++ b/docs/research/long-horizon-agent-benchmarks/README.md
@@ -116,6 +116,11 @@ work still belongs in the existing code, examples, and contract documents:
   artifact-reduction rules, and Docker/capacity stop gates without reading
   task bodies, tests, solution files, trajectories, screenshots, credentials,
   hidden refs, or starting a benchmark run.
+- `swe-marathon-vliw-kernel-optimization-launch-packet-v0.md`: no-execution
+  launch packet for the next fresh SWE-Marathon CPU/no-CUA case. It records
+  the matched baseline/treatment launch shape, case-local LoopX active-todo
+  completion rule, long-timeout envelope, no-upload boundary, and phase-counter
+  evidence requirements before any scored run.
 - `swe-marathon-rust-c-compiler-provider-capacity-preflight-v0.md`:
   no-execution Docker/Colima provider-capacity preflight for the
   `rust-c-compiler` packet. It finds the local benchmark Colima profile

--- a/docs/research/long-horizon-agent-benchmarks/swe-marathon-vliw-kernel-optimization-launch-packet-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/swe-marathon-vliw-kernel-optimization-launch-packet-v0.md
@@ -1,0 +1,130 @@
+# SWE-Marathon vliw-kernel-optimization Launch Packet v0
+
+Date: 2026-06-22
+
+Purpose: define the public-safe, no-execution launch packet for the next
+SWE-Marathon CPU/no-CUA case. This packet is not a scored run and must not be
+used as benchmark uplift evidence.
+
+## Boundary
+
+This packet does not execute a benchmark task, Docker task build, Docker task
+start, Codex worker, model/API call, upload, leaderboard action, submission,
+credential read, raw trajectory read, screenshot, hidden reference, task
+solution, or task test body.
+
+Allowed inputs for this packet:
+
+- public SWE-Marathon suite metadata already reduced into the full-suite status
+  catalog;
+- compact public benchmark ledger summaries;
+- Harbor/Codex runner contract surfaces already represented in this repo;
+- directory and command-shape requirements, without reading task bodies.
+
+Forbidden inputs for this packet:
+
+- `instruction.md` task body text;
+- files under `solution/`;
+- contents of files under `tests/` or `environment/`;
+- raw verifier logs, trajectories, screenshots, credentials, hidden refs, or
+  local private paths.
+
+## Source Pins
+
+- SWE-Marathon source:
+  `abundant-ai/swe-marathon@0128be1c2f05fe0255dc2ffb083d503c6913486e`.
+- Case catalog:
+  `swe-marathon-full-suite-status-20260622.json`.
+
+## Candidate Metadata
+
+| Field | Value |
+| --- | --- |
+| Task id | `vliw-kernel-optimization` |
+| Category | `optimization` |
+| Difficulty | `hard` |
+| Tags | `python`, `performance`, `simd` |
+| Expert estimate | `8` hours |
+| Agent timeout | `28800` seconds / `8h` |
+| Verifier timeout | `600` seconds / `10m` |
+| Build timeout | `300` seconds / `5m` |
+| CPUs | `4` |
+| Memory | `16384` MB |
+| Storage | `20480` MB |
+| GPUs | `0` |
+| Internet | `allow_internet = true` |
+| CUA required | no CUA lane marker in the public catalog |
+
+Routing verdict: suitable as the next fresh SWE-Marathon CPU/no-CUA case
+because it has no prior public compact run, no GPU requirement, a short expert
+estimate, and fewer attribution layers than browser/full-stack, ML-training, or
+large-rewrite cases.
+
+## Command Preview
+
+Do not execute this command from an automatic heartbeat. It is a future launch
+shape only:
+
+```bash
+harbor run -p tasks/vliw-kernel-optimization -a codex -m <approved-codex-profile> --env docker
+```
+
+The comparable LoopX treatment should use the Harbor host Codex Goal route with
+the custom host agent, not a prompt-only packet. Required treatment properties:
+
+- `reasoning_effort=high`;
+- timeout envelope at least `21600` seconds and preferably matching the case
+  catalog's `28800` second agent timeout;
+- `loopx_*` treatment arguments only;
+- isolated case-local LoopX state and todo;
+- completion source of truth is no active case-local LoopX todo;
+- no separate completion marker file;
+- compact controller trace and rollout events for quota, todo claim/update,
+  state read/write, validation, refresh, spend, and case result.
+
+## No-Upload Guard
+
+A scored local or remote pilot must:
+
+- omit `--upload`;
+- omit leaderboard/publish/submission commands;
+- avoid `harbor upload`, `harbor publish`, `harbor leaderboard`, and any
+  external artifact sync;
+- keep artifacts local to the runner and reduce them to compact metadata before
+  LoopX ingestion.
+
+## Evidence Path
+
+A future run should reduce output to these public-safe fields only:
+
+- source pin, case id, resource class, route, and command shape;
+- official reward or explicit verifier failure state;
+- elapsed wall time and timeout class;
+- setup/build/agent/verifier/result lifecycle stage;
+- public-safe phase counters: edit/build/test/verify/self-declared-done and
+  final active-todo count;
+- LoopX control-plane counters: quota reads, todo claim/update, state reads,
+  state writes, refreshes, validation checks, and boundary stops.
+
+Do not ingest raw terminal logs, task text, diffs, trajectories, screenshots,
+hidden refs, task solutions, or task test bodies.
+
+## Stop Rules
+
+Stop and write a precise blocker instead of launching if any of these are true:
+
+- the run would upload, publish, submit, or touch leaderboard paths;
+- the execution host cannot satisfy 4 CPUs, 16 GB memory, and 20 GB storage;
+- the selected model/profile cannot be mapped to the owner-approved formal run
+  setting;
+- the runner would need raw credentials, task text, trajectories, hidden refs,
+  solution files, or test body content;
+- the treatment route cannot pass case-local `loopx_*` state/todo arguments;
+- an automatic heartbeat is the only launch authority.
+
+## Next Action
+
+Use this packet as the handoff for the first real `vliw-kernel-optimization`
+baseline/treatment run. If launch authority or host capacity is absent, record
+that precise blocker and continue with public-safe SWE-Marathon phase-counter
+instrumentation instead of repeating older cases.

--- a/examples/swe-marathon-vliw-launch-packet-smoke.py
+++ b/examples/swe-marathon-vliw-launch-packet-smoke.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Smoke-test the public SWE-Marathon vliw launch packet."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DOC_DIR = REPO_ROOT / "docs" / "research" / "long-horizon-agent-benchmarks"
+PACKET_PATH = DOC_DIR / "swe-marathon-vliw-kernel-optimization-launch-packet-v0.md"
+CATALOG_PATH = DOC_DIR / "swe-marathon-full-suite-status-20260622.json"
+README_PATH = DOC_DIR / "README.md"
+
+FORBIDDEN_PATTERNS = [
+    re.compile("/" + "Users/"),
+    re.compile("/" + "private/"),
+    re.compile(r"\." + "local/"),
+    re.compile("trajectory_copied" + r"\"\\s*:\\s*" + "tr" + "ue"),
+    re.compile("raw_logs_copied" + r"\"\\s*:\\s*" + "tr" + "ue"),
+    re.compile("raw_task_text_copied" + r"\"\\s*:\\s*" + "tr" + "ue"),
+    re.compile("verifier_output_copied" + r"\"\\s*:\\s*" + "tr" + "ue"),
+    re.compile(r"(?<![A-Za-z0-9])sk-[A-Za-z0-9_-]{8,}"),
+]
+
+
+def assert_public_safe(text: str) -> None:
+    for pattern in FORBIDDEN_PATTERNS:
+        assert not pattern.search(text), pattern.pattern
+
+
+def load_case() -> dict:
+    catalog = json.loads(CATALOG_PATH.read_text(encoding="utf-8"))
+    return next(
+        case
+        for case in catalog["cases"]
+        if case["case_id"] == "vliw-kernel-optimization"
+    )
+
+
+def test_packet_matches_catalog() -> None:
+    case = load_case()
+    packet = PACKET_PATH.read_text(encoding="utf-8")
+    assert case["experiment_tier"] == "p0_next_fresh_cpu_no_cua_candidate"
+    assert case["public_ledger_status"] == "not_started"
+    assert case["gpus"] == 0
+    assert str(case["agent_timeout_sec"]) in packet
+    assert str(case["verifier_timeout_sec"]) in packet
+    assert str(case["build_timeout_sec"]) in packet
+    assert "`vliw-kernel-optimization`" in packet
+    assert "completion source of truth is no active case-local LoopX todo" in packet
+
+
+def test_no_execution_boundary() -> None:
+    packet = PACKET_PATH.read_text(encoding="utf-8")
+    assert "Do not execute this command from an automatic heartbeat" in packet
+    assert "omit `--upload`" in packet
+    assert "automatic heartbeat is the only launch authority" in packet
+    assert "loopx_*" in packet
+    assert "goal_harness" not in packet
+    assert_public_safe(packet)
+
+
+def test_readme_indexes_packet() -> None:
+    readme = README_PATH.read_text(encoding="utf-8")
+    assert "swe-marathon-vliw-kernel-optimization-launch-packet-v0.md" in readme
+
+
+if __name__ == "__main__":
+    test_packet_matches_catalog()
+    test_no_execution_boundary()
+    test_readme_indexes_packet()
+    print("swe-marathon-vliw-launch-packet-smoke ok")


### PR DESCRIPTION
## Summary
- add a public-safe no-execution launch packet for SWE-Marathon vliw-kernel-optimization
- document the matched baseline/treatment shape, no-upload boundary, active-todo completion rule, and phase-counter evidence requirements
- add a focused smoke and index the packet from the benchmark research README

## Validation
- python3 examples/swe-marathon-vliw-launch-packet-smoke.py
- python3 examples/swe-marathon-full-suite-status-smoke.py
- python3 -m py_compile examples/swe-marathon-vliw-launch-packet-smoke.py
- loopx check --scan-path docs/research/long-horizon-agent-benchmarks/swe-marathon-vliw-kernel-optimization-launch-packet-v0.md --scan-path docs/research/long-horizon-agent-benchmarks/README.md --scan-path examples/swe-marathon-vliw-launch-packet-smoke.py
