### PR TITLE
Add unblock metadata for primary review handoffs

### DIFF
--- a/docs/project-agent-todo-contract.md
+++ b/docs/project-agent-todo-contract.md
@@ -245,6 +245,18 @@ requiring a successor primary review todo and defaults that successor todo's
 allowed only when it matches the primary agent. This keeps broad side-agent
 handoff visible to the shared control plane.
 
+That generated primary review successor also records `action_kind=primary_review`,
+`blocks_agent=<side-agent-id>`, and `unblocks_todo_id=<completed-todo-id>`.
+These fields are a small unblock hint, not a general dependency graph: they let
+quota and dashboards recognize that reviewing this todo releases another agent's
+lane without parsing prose or PR numbers.
+
+For primary-agent completions and self-merged same-lane continuations, a
+successor created with `--next-agent-todo` inherits the completed todo's
+effective `claimed_by` unless `--next-claimed-by` explicitly names another
+registered agent. This prevents follow-up work from accidentally falling into
+the unclaimed pool.
+
 For small changes that satisfy the repository's self-merge rules, the side
 agent may self-merge and complete without a successor review todo by making the
 exception explicit:
@@ -318,6 +330,11 @@ loopx todo supersede \
   --next-agent-todo "<replacement executable action>"
 ```
 
+If the superseded todo was claimed, the replacement inherits that `claimed_by`.
+If it carried `blocks_agent` / `unblocks_todo_id`, the replacement inherits
+those unblock fields too. Use `--next-claimed-by <agent-id>` to make a handoff
+explicit.
+
 `todo complete` and `todo supersede` are intentionally idempotent for repeated
 heartbeats: if the old todo is already complete and the next todo already
 exists with the same metadata, the command returns `changed=false` and does not
@@ -333,7 +350,9 @@ carry `schema_version=todo_summary_v0`; individual items carry
 `schema_version=todo_item_v0`, `todo_id`, `role`, `status`, `priority`,
 `title`, `archive_state`, `source_section`, `index`, `text`, `task_class`, and
 optional `action_kind`, `claimed_by`, `required_capabilities`, and
-`target_capabilities`. The `todo_id` is first-class when written by the CLI.
+`target_capabilities`. Primary review handoffs may also carry
+`blocks_agent` and `unblocks_todo_id` to show which agent/todo they release.
+The `todo_id` is first-class when written by the CLI.
 `claimed_by` values are normalized public-safe agent ids and should correspond to
 `coordination.registered_agents`. Legacy Markdown without metadata still gets a
 parser-derived compatibility id from local section/index/text, and the first

--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -328,6 +328,14 @@ candidate remains in `runnable_candidates` with `capability_repair_mode=true`,
 `missing_target_capabilities`. This avoids a circular gate where a todo cannot
 develop `benchmark_runner` because it does not already have `benchmark_runner`.
 
+For multi-agent goals, executable primary-review handoffs can carry
+`blocks_agent=<side-agent>` and `unblocks_todo_id=<todo_id>`. When the current
+agent is the primary agent and the handoff is already claimed by that primary
+agent, `agent_lane_next_action` ranks that explicit unblock ahead of ordinary
+same-priority backlog, even if the goal-level `Next Action` prose is stale.
+This is only a scheduling hint: capability gates, write-scope checks, user
+gates, and validation still apply.
+
 External-evidence waits have an additional CLI-level observation contract. When
 the selected goal is `state=waiting`, `waiting_on=external_evidence`, and its
 current lane is a continuous monitor, or when the active state says a
@@ -519,6 +527,9 @@ slice. If the active-state and latest-run actions differ,
 `next_action_projection_warning` asks the executor to explicitly write back the
 intended durable route with `refresh-state --next-action` or keep treating the
 signals as distinct.
+When `agent_lane_next_action.selected_by=unclaimed_todo`, the payload marks
+`claim_required_before_work=true`; executors must claim the todo before editing
+or launching delivery work.
 For goals with `coordination.registered_agents`, `quota should-run` accepts an
 optional `--agent-id <registered-agent>`. Identity-aware heartbeat prompts pass
 that flag through their quota guard. If a registered goal is checked without an

--- a/examples/todo-lifecycle-cli-smoke.py
+++ b/examples/todo-lifecycle-cli-smoke.py
@@ -191,6 +191,7 @@ def main() -> int:
         assert completed_item["claimed_by"] == "codex-main-control", completed_item
         assert rebuild_item["done"] is False and rebuild_item["task_class"] == "advancement_task", rebuild_item
         assert rebuild_item["action_kind"] == "rebuild_score", rebuild_item
+        assert rebuild_item["claimed_by"] == "codex-main-control", rebuild_item
 
         side_added = run_cli(
             registry_path,
@@ -369,6 +370,8 @@ def main() -> int:
         assert side_completed["changed"] is True, side_completed
         review_todo_id = side_completed["next_todos"][0]["todo_id"]
         assert side_completed["next_todos"][0]["claimed_by"] == "codex-main-control", side_completed
+        assert side_completed["next_todos"][0]["blocks_agent"] == "codex-side-bypass", side_completed
+        assert side_completed["next_todos"][0]["unblocks_todo_id"] == side_review_todo_id, side_completed
         items = parsed_items(state_file)
         side_item = next(item for item in items if item["todo_id"] == side_todo_id)
         side_review_item = next(item for item in items if item["todo_id"] == side_review_todo_id)
@@ -378,6 +381,9 @@ def main() -> int:
             side_review_item
         )
         assert review_item["done"] is False and review_item["claimed_by"] == "codex-main-control", review_item
+        assert review_item["action_kind"] == "primary_review", review_item
+        assert review_item["blocks_agent"] == "codex-side-bypass", review_item
+        assert review_item["unblocks_todo_id"] == side_review_todo_id, review_item
 
         repeated = run_cli(
             registry_path,
@@ -419,6 +425,7 @@ def main() -> int:
         validate_item = next(item for item in items if item["todo_id"] == validate_todo_id)
         assert rebuild_item["done"] is True and rebuild_item["superseded_by"] == validate_todo_id, rebuild_item
         assert validate_item["done"] is False and validate_item["task_class"] == "advancement_task", validate_item
+        assert validate_item["claimed_by"] == "codex-main-control", validate_item
 
         blocked = run_cli(
             registry_path,

--- a/examples/work-lane-contract-smoke.py
+++ b/examples/work-lane-contract-smoke.py
@@ -1182,6 +1182,7 @@ def assert_side_agent_can_take_unclaimed_work() -> None:
     next_action = guard["agent_lane_next_action"]
     assert next_action["todo_id"] == "todo_unclaimed_frontstage", guard
     assert next_action["selected_by"] == "unclaimed_todo", guard
+    assert next_action["claim_required_before_work"] is True, guard
 
 
 def assert_agent_lane_next_action_prefers_capability_repair_candidate() -> None:
@@ -1244,6 +1245,60 @@ def assert_agent_lane_next_action_prefers_capability_repair_candidate() -> None:
     assert next_action["missing_target_capabilities"] == ["benchmark_runner"], next_action
     markdown = render_quota_should_run_markdown(guard)
     assert "agent_lane_next_action: todo_id=todo_bridge_repair" in markdown, markdown
+
+
+def assert_primary_agent_prioritizes_claimed_review_handoff() -> None:
+    primary_action = "[P0] Run SWE-Marathon full-suite polling and record compact results."
+    review_action = "[P0] Review PR #464 for the side-agent Frontstage handoff."
+    guard = build_quota_should_run(
+        status_payload(
+            status="primary_review_handoff_frontier",
+            next_action=primary_action,
+            coordination={
+                "primary_agent": "codex-main-control",
+                "registered_agents": ["codex-main-control", "codex-side-bypass"],
+            },
+            agent_todo_items=[
+                {
+                    "index": 1,
+                    "text": primary_action,
+                    "role": "agent",
+                    "status": "open",
+                    "priority": "P0",
+                    "task_class": "advancement_task",
+                    "claimed_by": "codex-main-control",
+                    "todo_id": "todo_primary_suite",
+                    "required_capabilities": ["shell"],
+                },
+                {
+                    "index": 2,
+                    "text": review_action,
+                    "role": "agent",
+                    "status": "open",
+                    "priority": "P0",
+                    "task_class": "advancement_task",
+                    "action_kind": "primary_review",
+                    "claimed_by": "codex-main-control",
+                    "todo_id": "todo_primary_review",
+                    "required_capabilities": ["shell"],
+                    "blocks_agent": "codex-side-bypass",
+                    "unblocks_todo_id": "todo_frontstage_showcase",
+                },
+            ],
+        ),
+        goal_id=GOAL_ID,
+        agent_id="codex-main-control",
+    )
+    next_action = guard["agent_lane_next_action"]
+    assert next_action["todo_id"] == "todo_primary_review", guard
+    assert next_action["selected_by"] == "current_agent_claimed_todo", next_action
+    assert next_action["unblock_handoff"] == {
+        "blocks_agent": "codex-side-bypass",
+        "unblocks_todo_id": "todo_frontstage_showcase",
+    }, next_action
+    assert guard["recommended_action"] == review_action, guard
+    markdown = render_quota_should_run_markdown(guard)
+    assert "agent_lane_next_action: todo_id=todo_primary_review" in markdown, markdown
 
 
 def assert_agent_lane_next_action_prefers_explicit_next_action_todo_id() -> None:
@@ -1327,6 +1382,7 @@ def main() -> int:
     assert_side_agent_waits_when_only_other_agent_has_claimed_work()
     assert_side_agent_can_take_unclaimed_work()
     assert_agent_lane_next_action_prefers_capability_repair_candidate()
+    assert_primary_agent_prioritizes_claimed_review_handoff()
     assert_agent_lane_next_action_prefers_explicit_next_action_todo_id()
     print("work-lane-contract-smoke ok")
     return 0

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -5997,6 +5997,20 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     todo_parser.add_argument(
+        "--blocks-agent",
+        help=(
+            "For todo add/update, mark that this todo unblocks a registered agent, "
+            "for example codex-side-bypass."
+        ),
+    )
+    todo_parser.add_argument(
+        "--unblocks-todo-id",
+        help=(
+            "For todo add/update, link this todo to the blocked todo it unblocks, "
+            "for example todo_ab12cd34ef56."
+        ),
+    )
+    todo_parser.add_argument(
         "--clear-claim",
         action="store_true",
         help="For todo update, remove the soft claimed_by owner from the todo.",
@@ -6006,9 +6020,10 @@ def main(argv: list[str] | None = None) -> int:
     todo_parser.add_argument(
         "--next-claimed-by",
         help=(
-            "For complete with --next-agent-todo, soft-claim the successor todo for "
-            "a registered agent. Side-agent review handoffs default this to primary_agent; "
-            "self-merged side-agent continuations may claim their own successor."
+            "For complete/supersede with --next-agent-todo, soft-claim the successor "
+            "todo for a registered agent. If omitted, claimed successors inherit the "
+            "completed/superseded todo owner when available; side-agent review handoffs "
+            "default to primary_agent."
         ),
     )
     todo_parser.add_argument(
@@ -10448,6 +10463,8 @@ def main(argv: list[str] | None = None) -> int:
                     required_capabilities=args.required_capabilities,
                     target_capabilities=args.target_capabilities,
                     claimed_by=args.claimed_by,
+                    blocks_agent=args.blocks_agent,
+                    unblocks_todo_id=args.unblocks_todo_id,
                     project=Path(args.project).expanduser() if args.project else None,
                     state_file=Path(args.state_file).expanduser() if args.state_file else None,
                     dry_run=bool(args.dry_run),
@@ -10472,6 +10489,8 @@ def main(argv: list[str] | None = None) -> int:
                         ("--required-write-scope", args.required_write_scopes),
                         ("--required-capability", args.required_capabilities),
                         ("--target-capability", args.target_capabilities),
+                        ("--blocks-agent", args.blocks_agent),
+                        ("--unblocks-todo-id", args.unblocks_todo_id),
                         ("--next-agent-todo", args.next_agent_todo),
                         ("--next-user-todo", args.next_user_todo),
                         ("--next-claimed-by", args.next_claimed_by),
@@ -10515,9 +10534,11 @@ def main(argv: list[str] | None = None) -> int:
                     args.required_capabilities,
                     args.target_capabilities,
                     args.claimed_by,
+                    args.blocks_agent,
+                    args.unblocks_todo_id,
                     args.clear_claim,
                 ]):
-                    raise ValueError("todo update requires at least one of --text, --status, --note, --evidence, --reason, --task-class, --action-kind, --required-write-scope, --required-capability, --target-capability, --claimed-by, or --clear-claim")
+                    raise ValueError("todo update requires at least one of --text, --status, --note, --evidence, --reason, --task-class, --action-kind, --required-write-scope, --required-capability, --target-capability, --claimed-by, --blocks-agent, --unblocks-todo-id, or --clear-claim")
                 if args.next_claimed_by:
                     raise ValueError("todo update does not support --next-claimed-by")
                 if args.side_agent_self_merged:
@@ -10538,6 +10559,8 @@ def main(argv: list[str] | None = None) -> int:
                     required_capabilities=args.required_capabilities,
                     target_capabilities=args.target_capabilities,
                     claimed_by=args.claimed_by,
+                    blocks_agent=args.blocks_agent,
+                    unblocks_todo_id=args.unblocks_todo_id,
                     clear_claim=bool(args.clear_claim),
                     project=Path(args.project).expanduser() if args.project else None,
                     state_file=Path(args.state_file).expanduser() if args.state_file else None,
@@ -10548,6 +10571,8 @@ def main(argv: list[str] | None = None) -> int:
                     raise ValueError("todo complete requires --todo-id")
                 if args.claimed_by and args.clear_claim:
                     raise ValueError("todo complete accepts either --claimed-by or --clear-claim, not both")
+                if args.blocks_agent or args.unblocks_todo_id:
+                    raise ValueError("todo complete does not support --blocks-agent or --unblocks-todo-id; use todo update before completion or side-agent review successor metadata")
                 payload = complete_goal_todo(
                     registry_path=registry_path,
                     goal_id=args.goal_id,
@@ -10572,10 +10597,10 @@ def main(argv: list[str] | None = None) -> int:
                     raise ValueError("todo supersede requires --todo-id")
                 if args.claimed_by or args.clear_claim:
                     raise ValueError("todo supersede does not support --claimed-by or --clear-claim")
-                if args.next_claimed_by:
-                    raise ValueError("todo supersede does not support --next-claimed-by")
                 if args.side_agent_self_merged:
                     raise ValueError("todo supersede does not support --side-agent-self-merged")
+                if args.blocks_agent or args.unblocks_todo_id:
+                    raise ValueError("todo supersede does not support --blocks-agent or --unblocks-todo-id; update the source todo first so the successor can inherit dependency metadata")
                 payload = supersede_goal_todo(
                     registry_path=registry_path,
                     goal_id=args.goal_id,
@@ -10584,6 +10609,7 @@ def main(argv: list[str] | None = None) -> int:
                     reason=args.reason,
                     next_agent_todo=args.next_agent_todo,
                     next_user_todo=args.next_user_todo,
+                    next_claimed_by=args.next_claimed_by,
                     next_task_class=args.next_task_class,
                     next_action_kind=args.next_action_kind,
                     project=Path(args.project).expanduser() if args.project else None,

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -39,7 +39,9 @@ from .todo_contract import (
     next_action_requires_advancement_text,
     normalize_required_capabilities,
     normalize_target_capabilities,
+    normalize_todo_blocks_agent,
     normalize_todo_claimed_by,
+    normalize_todo_id,
     normalize_required_write_scopes,
     normalize_todo_status,
     normalize_todo_task_class,
@@ -975,6 +977,8 @@ def _compact_todo_summary_item(item: dict[str, Any], *, text: str | None = None)
         "required_capabilities",
         "target_capabilities",
         "claimed_by",
+        "blocks_agent",
+        "unblocks_todo_id",
     ):
         if item.get(key) is not None:
             compact[key] = item.get(key)
@@ -1874,15 +1878,38 @@ def _agent_lane_next_action(
 
     preferred_todo_ids = _todo_ids_from_action(active_next_action)
 
-    def lane_candidate_sort_key(raw_item: dict[str, Any]) -> tuple[int, int, int, int, int]:
+    primary_agent = normalize_todo_claimed_by(agent_identity.get("primary_agent"))
+
+    def lane_candidate_sort_key(raw_item: dict[str, Any]) -> tuple[int, int, int, int, int, int, int]:
         todo_id = str(raw_item.get("todo_id") or "").strip()
         active_next_rank = 0 if todo_id and todo_id in preferred_todo_ids else 1
         claimed_by = normalize_todo_claimed_by(raw_item.get("claimed_by"))
         claim_rank = 0 if claimed_by == agent_id else 1
+        action_kind = str(raw_item.get("action_kind") or "").strip()
+        blocks_agent = normalize_todo_blocks_agent(raw_item.get("blocks_agent"))
+        unblocks_todo_id = normalize_todo_id(raw_item.get("unblocks_todo_id"))
+        explicit_unblock_rank = (
+            0
+            if agent_id == primary_agent
+            and claimed_by == agent_id
+            and blocks_agent
+            and blocks_agent != agent_id
+            and unblocks_todo_id
+            else 1
+        )
+        primary_review_rank = (
+            0
+            if agent_id == primary_agent
+            and claimed_by == agent_id
+            and (action_kind == "primary_review" or action_kind.startswith("primary_review_"))
+            else 1
+        )
         repair_rank = 0 if raw_item.get("capability_repair_mode") is True else 1
         return (
+            explicit_unblock_rank,
             active_next_rank,
             claim_rank,
+            primary_review_rank,
             repair_rank,
             _todo_priority_rank(raw_item),
             _todo_index_rank(raw_item),
@@ -1922,6 +1949,15 @@ def _agent_lane_next_action(
                 else "unclaimed_todo"
             )
             payload = _compact_todo_summary_item(raw_item, text=text)
+            if selected_by == "unclaimed_todo":
+                payload["claim_required_before_work"] = True
+            blocks_agent = normalize_todo_blocks_agent(raw_item.get("blocks_agent"))
+            unblocks_todo_id = normalize_todo_id(raw_item.get("unblocks_todo_id"))
+            if blocks_agent and unblocks_todo_id:
+                payload["unblock_handoff"] = {
+                    "blocks_agent": blocks_agent,
+                    "unblocks_todo_id": unblocks_todo_id,
+                }
             for key in (
                 "missing_capabilities",
                 "missing_target_capabilities",

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -54,7 +54,9 @@ from .todo_contract import (
     normalize_required_capabilities,
     normalize_target_capabilities,
     normalize_required_write_scopes,
+    normalize_todo_blocks_agent,
     normalize_todo_claimed_by,
+    normalize_todo_id,
     normalize_todo_status,
     normalize_todo_task_class,
     parse_todo_metadata_line,
@@ -3821,6 +3823,12 @@ def structured_todo_item(
     claimed_by = normalize_todo_claimed_by(item.get("claimed_by"))
     if claimed_by:
         normalized["claimed_by"] = claimed_by
+    blocks_agent = normalize_todo_blocks_agent(item.get("blocks_agent"))
+    if blocks_agent:
+        normalized["blocks_agent"] = blocks_agent
+    unblocks_todo_id = normalize_todo_id(item.get("unblocks_todo_id"))
+    if unblocks_todo_id:
+        normalized["unblocks_todo_id"] = unblocks_todo_id
     if priority:
         normalized["priority"] = priority
         normalized["title"] = normalize_todo_text(title)
@@ -3848,6 +3856,8 @@ def compact_todo_item(item: dict[str, Any]) -> dict[str, Any]:
         "required_capabilities",
         "target_capabilities",
         "claimed_by",
+        "blocks_agent",
+        "unblocks_todo_id",
         "note",
         "evidence",
         "reason",

--- a/loopx/todo_contract.py
+++ b/loopx/todo_contract.py
@@ -151,6 +151,10 @@ def normalize_todo_claimed_by(value: Any) -> str | None:
     return None
 
 
+def normalize_todo_blocks_agent(value: Any) -> str | None:
+    return normalize_todo_claimed_by(value)
+
+
 def normalize_todo_id(value: Any) -> str | None:
     candidate = str(value or "").strip().lower()
     if candidate and TODO_ID_PATTERN.match(candidate):
@@ -306,6 +310,14 @@ def parse_todo_metadata_line(line: str) -> dict[str, Any] | None:
             claimed_by = normalize_todo_claimed_by(value)
             if claimed_by:
                 metadata["claimed_by"] = claimed_by
+        elif key == "blocks_agent":
+            blocks_agent = normalize_todo_blocks_agent(value)
+            if blocks_agent:
+                metadata["blocks_agent"] = blocks_agent
+        elif key == "unblocks_todo_id":
+            todo_id = normalize_todo_id(value)
+            if todo_id:
+                metadata["unblocks_todo_id"] = todo_id
         elif key in {"note", "evidence", "reason", "completed_at", "updated_at"}:
             if value:
                 metadata[key] = value
@@ -326,6 +338,8 @@ def format_todo_metadata_line(
     required_capabilities: Any = None,
     target_capabilities: Any = None,
     claimed_by: str | None = None,
+    blocks_agent: str | None = None,
+    unblocks_todo_id: str | None = None,
     note: str | None = None,
     evidence: str | None = None,
     reason: str | None = None,
@@ -383,6 +397,16 @@ def format_todo_metadata_line(
         raise ValueError("claimed_by must be a public-safe agent token such as codex-main-control")
     if normalized_claimed_by:
         fields.append(f"claimed_by={encode_metadata_value(normalized_claimed_by)}")
+    normalized_blocks_agent = normalize_todo_blocks_agent(blocks_agent)
+    if blocks_agent and not normalized_blocks_agent:
+        raise ValueError("blocks_agent must be a public-safe agent token such as codex-side-bypass")
+    if normalized_blocks_agent:
+        fields.append(f"blocks_agent={encode_metadata_value(normalized_blocks_agent)}")
+    normalized_unblocks_todo_id = normalize_todo_id(unblocks_todo_id)
+    if unblocks_todo_id and not normalized_unblocks_todo_id:
+        raise ValueError("unblocks_todo_id must use the public token shape todo_<letters-digits-underscore-hyphen>")
+    if normalized_unblocks_todo_id:
+        fields.append(f"unblocks_todo_id={encode_metadata_value(normalized_unblocks_todo_id)}")
     for key, value in (
         ("note", note),
         ("evidence", evidence),

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -22,6 +22,7 @@ from .todo_contract import (
     normalize_required_capabilities,
     normalize_required_write_scopes,
     normalize_target_capabilities,
+    normalize_todo_blocks_agent,
     normalize_todo_claimed_by,
     normalize_todo_id,
     normalize_todo_status,
@@ -46,6 +47,8 @@ TODO_METADATA_FIELDS = (
     "required_capabilities",
     "target_capabilities",
     "claimed_by",
+    "blocks_agent",
+    "unblocks_todo_id",
     "note",
     "evidence",
     "reason",
@@ -449,6 +452,8 @@ def add_todo_to_lines(
     required_capabilities: list[str] | None = None,
     target_capabilities: list[str] | None = None,
     claimed_by: str | None = None,
+    blocks_agent: str | None = None,
+    unblocks_todo_id: str | None = None,
 ) -> dict[str, Any]:
     todo_text = normalize_new_todo(text)
     bounds = section_bounds(lines, role)
@@ -485,12 +490,15 @@ def add_todo_to_lines(
             required_capabilities=required_capabilities,
             target_capabilities=target_capabilities,
             claimed_by=claimed_by,
+            blocks_agent=blocks_agent,
+            unblocks_todo_id=unblocks_todo_id,
         )
         todo_line = "\n".join([f"- [ ] {todo_text}", metadata_line] if metadata_line else [f"- [ ] {todo_text}"])
         if bounds:
             insert_into_existing_section(lines, bounds[0], bounds[1], todo_line)
         else:
             insert_new_section(lines, role, todo_line)
+        effective_metadata = parse_todo_metadata_line(metadata_line or "") or {}
     else:
         updates: dict[str, Any] = {
             "todo_id": block.get("todo_id"),
@@ -508,9 +516,14 @@ def add_todo_to_lines(
             updates["target_capabilities"] = target_capabilities
         if claimed_by:
             updates["claimed_by"] = claimed_by
+        if blocks_agent:
+            updates["blocks_agent"] = blocks_agent
+        if unblocks_todo_id:
+            updates["unblocks_todo_id"] = unblocks_todo_id
         metadata_line = metadata_line_for_block(block, updates)
         metadata_updated = upsert_todo_metadata(lines, block, metadata_line)
         todo_id = str(block.get("todo_id") or "")
+        effective_metadata = parse_todo_metadata_line(metadata_line or "") or {}
 
     return {
         "added": added,
@@ -520,12 +533,20 @@ def add_todo_to_lines(
         "section": section,
         "todo": todo_text,
         "todo_id": todo_id,
-        "task_class": task_class,
-        "action_kind": action_kind,
-        "required_write_scopes": normalize_required_write_scopes(required_write_scopes),
-        "required_capabilities": normalize_required_capabilities(required_capabilities),
-        "target_capabilities": normalize_target_capabilities(target_capabilities),
-        "claimed_by": normalize_todo_claimed_by(claimed_by),
+        "task_class": effective_metadata.get("task_class") or task_class,
+        "action_kind": effective_metadata.get("action_kind") or action_kind,
+        "required_write_scopes": normalize_required_write_scopes(
+            effective_metadata.get("required_write_scopes") or required_write_scopes
+        ),
+        "required_capabilities": normalize_required_capabilities(
+            effective_metadata.get("required_capabilities") or required_capabilities
+        ),
+        "target_capabilities": normalize_target_capabilities(
+            effective_metadata.get("target_capabilities") or target_capabilities
+        ),
+        "claimed_by": normalize_todo_claimed_by(effective_metadata.get("claimed_by")),
+        "blocks_agent": normalize_todo_blocks_agent(effective_metadata.get("blocks_agent")),
+        "unblocks_todo_id": normalize_todo_id(effective_metadata.get("unblocks_todo_id")),
     }
 
 
@@ -541,6 +562,8 @@ def add_goal_todo(
     required_capabilities: list[str] | None = None,
     target_capabilities: list[str] | None = None,
     claimed_by: str | None = None,
+    blocks_agent: str | None = None,
+    unblocks_todo_id: str | None = None,
     project: Path | None = None,
     state_file: Path | None = None,
     dry_run: bool = False,
@@ -568,6 +591,19 @@ def add_goal_todo(
             if claimed_by
             else None
         )
+        effective_blocks_agent = (
+            require_registered_agent_id(
+                registry_path=registry_path,
+                goal_id=goal_id,
+                agent_id=blocks_agent,
+                field="blocks_agent",
+            )
+            if blocks_agent
+            else None
+        )
+        normalized_unblocks_todo_id = normalize_todo_id(unblocks_todo_id) if unblocks_todo_id else None
+        if unblocks_todo_id and not normalized_unblocks_todo_id:
+            raise ValueError("unblocks_todo_id must use the public token shape todo_<letters-digits-underscore-hyphen>")
         add_result = add_todo_to_lines(
             lines,
             role=role,
@@ -578,6 +614,8 @@ def add_goal_todo(
             required_capabilities=required_capabilities,
             target_capabilities=target_capabilities,
             claimed_by=effective_claimed_by,
+            blocks_agent=effective_blocks_agent,
+            unblocks_todo_id=normalized_unblocks_todo_id,
         )
         added = bool(add_result["added"])
         metadata_updated = bool(add_result["metadata_updated"])
@@ -605,6 +643,8 @@ def add_goal_todo(
         "required_capabilities": add_result.get("required_capabilities"),
         "target_capabilities": add_result.get("target_capabilities"),
         "claimed_by": add_result.get("claimed_by"),
+        "blocks_agent": add_result.get("blocks_agent"),
+        "unblocks_todo_id": add_result.get("unblocks_todo_id"),
         "state_file": str(resolved_state_file),
         "project": str(resolved_project) if resolved_project else None,
         "updated_at": updated_at if added or metadata_updated else None,
@@ -644,6 +684,8 @@ def apply_todo_update_to_lines(
     required_capabilities: list[str] | None = None,
     target_capabilities: list[str] | None = None,
     claimed_by: str | None = None,
+    blocks_agent: str | None = None,
+    unblocks_todo_id: str | None = None,
     clear_claim: bool = False,
     claim_only: bool = False,
     updated_at: str,
@@ -702,6 +744,10 @@ def apply_todo_update_to_lines(
                 "clear or transfer the claim explicitly before claiming it"
             )
         updates["claimed_by"] = claimed_by
+    if blocks_agent:
+        updates["blocks_agent"] = blocks_agent
+    if unblocks_todo_id:
+        updates["unblocks_todo_id"] = unblocks_todo_id
     metadata_line = metadata_line_for_block(block, updates)
     semantic_metadata_changed = todo_metadata_would_change(lines, block, metadata_line)
     if status_changed or text_changed or semantic_metadata_changed:
@@ -728,6 +774,8 @@ def apply_todo_update_to_lines(
         "target_capabilities": normalize_target_capabilities(
             effective_metadata.get("target_capabilities")
         ),
+        "blocks_agent": normalize_todo_blocks_agent(effective_metadata.get("blocks_agent")),
+        "unblocks_todo_id": normalize_todo_id(effective_metadata.get("unblocks_todo_id")),
     }
 
 
@@ -748,6 +796,8 @@ def update_goal_todo(
     required_capabilities: list[str] | None = None,
     target_capabilities: list[str] | None = None,
     claimed_by: str | None = None,
+    blocks_agent: str | None = None,
+    unblocks_todo_id: str | None = None,
     clear_claim: bool = False,
     claim_only: bool = False,
     project: Path | None = None,
@@ -773,6 +823,19 @@ def update_goal_todo(
             if claimed_by
             else None
         )
+        effective_blocks_agent = (
+            require_registered_agent_id(
+                registry_path=registry_path,
+                goal_id=goal_id,
+                agent_id=blocks_agent,
+                field="blocks_agent",
+            )
+            if blocks_agent
+            else None
+        )
+        normalized_unblocks_todo_id = normalize_todo_id(unblocks_todo_id) if unblocks_todo_id else None
+        if unblocks_todo_id and not normalized_unblocks_todo_id:
+            raise ValueError("unblocks_todo_id must use the public token shape todo_<letters-digits-underscore-hyphen>")
         update_result = apply_todo_update_to_lines(
             lines,
             todo_id=todo_id,
@@ -788,6 +851,8 @@ def update_goal_todo(
             required_capabilities=required_capabilities,
             target_capabilities=target_capabilities,
             claimed_by=effective_claimed_by,
+            blocks_agent=effective_blocks_agent,
+            unblocks_todo_id=normalized_unblocks_todo_id,
             clear_claim=clear_claim,
             claim_only=claim_only,
             updated_at=updated_at,
@@ -890,6 +955,8 @@ def complete_goal_todo(
                 )
             if next_agent_todo and not side_agent_self_merged:
                 effective_next_claimed_by = primary_agent
+                if not next_action_kind:
+                    next_action_kind = "primary_review"
         if effective_next_claimed_by and not next_agent_todo:
             raise ValueError("--next-claimed-by requires --next-agent-todo")
         update_result = apply_todo_update_to_lines(
@@ -903,6 +970,13 @@ def complete_goal_todo(
             clear_claim=clear_claim,
             updated_at=updated_at,
         )
+        if next_agent_todo and not effective_next_claimed_by:
+            effective_next_claimed_by = normalize_todo_claimed_by(update_result.get("claimed_by"))
+        next_blocks_agent = None
+        next_unblocks_todo_id = None
+        if side_agent_completion and next_agent_todo and not side_agent_self_merged:
+            next_blocks_agent = effective_claimed_by
+            next_unblocks_todo_id = normalize_todo_id(str(update_result.get("todo_id") or todo_id))
         next_results: list[dict[str, Any]] = []
         if next_agent_todo:
             next_results.append(
@@ -916,6 +990,8 @@ def complete_goal_todo(
                     task_class=next_task_class or "advancement_task",
                     action_kind=next_action_kind,
                     claimed_by=effective_next_claimed_by,
+                    blocks_agent=next_blocks_agent,
+                    unblocks_todo_id=next_unblocks_todo_id,
                 )
             )
         if next_user_todo:
@@ -961,6 +1037,7 @@ def supersede_goal_todo(
     reason: str | None = None,
     next_agent_todo: str | None = None,
     next_user_todo: str | None = None,
+    next_claimed_by: str | None = None,
     next_task_class: str | None = None,
     next_action_kind: str | None = None,
     project: Path | None = None,
@@ -977,6 +1054,18 @@ def supersede_goal_todo(
         original = resolved_state_file.read_text(encoding="utf-8")
         lines = original.splitlines()
         updated_at = now_local()
+        effective_next_claimed_by = (
+            require_registered_agent_id(
+                registry_path=registry_path,
+                goal_id=goal_id,
+                agent_id=next_claimed_by,
+                field="next_claimed_by",
+            )
+            if next_claimed_by
+            else None
+        )
+        if effective_next_claimed_by and not next_agent_todo:
+            raise ValueError("--next-claimed-by requires --next-agent-todo")
         update_result = apply_todo_update_to_lines(
             lines,
             todo_id=todo_id,
@@ -986,6 +1075,10 @@ def supersede_goal_todo(
             note="superseded",
             updated_at=updated_at,
         )
+        if next_agent_todo and not effective_next_claimed_by:
+            effective_next_claimed_by = normalize_todo_claimed_by(update_result.get("claimed_by"))
+        next_blocks_agent = normalize_todo_blocks_agent(update_result.get("blocks_agent"))
+        next_unblocks_todo_id = normalize_todo_id(update_result.get("unblocks_todo_id"))
         next_results: list[dict[str, Any]] = []
         if next_agent_todo:
             next_results.append(
@@ -998,6 +1091,9 @@ def supersede_goal_todo(
                     ),
                     task_class=next_task_class or "advancement_task",
                     action_kind=next_action_kind,
+                    claimed_by=effective_next_claimed_by,
+                    blocks_agent=next_blocks_agent,
+                    unblocks_todo_id=next_unblocks_todo_id,
                 )
             )
         if next_user_todo:


### PR DESCRIPTION
## Summary
- add public-safe todo metadata for `blocks_agent` and `unblocks_todo_id`
- auto-tag side-agent primary-review successors with unblock metadata and preserve it through supersede
- rank explicit primary review unblock handoffs ahead of ordinary same-priority backlog in `agent_lane_next_action`
- document the contract and cover lifecycle/quota behavior with focused smokes

## Validation
- `python3 examples/todo-lifecycle-cli-smoke.py`
- `python3 examples/work-lane-contract-smoke.py`
- `python3 examples/docs-governance-smoke.py`
- `python3 -m py_compile loopx/todo_contract.py loopx/todos.py loopx/cli.py loopx/status.py loopx/quota.py`
- `loopx check --scan-path loopx/todo_contract.py --scan-path loopx/todos.py --scan-path loopx/cli.py --scan-path loopx/status.py --scan-path loopx/quota.py --scan-path examples/todo-lifecycle-cli-smoke.py --scan-path examples/work-lane-contract-smoke.py --scan-path docs/project-agent-todo-contract.md --scan-path docs/quota-allocation.md`

## Excluded from this PR
- existing unstaged `docs/interaction-pattern-catalog.md`
- existing unstaged `examples/interaction-pattern-catalog-smoke.py`
- existing unstaged `skills/loopx-self-repair/references/repair-patterns.md`

`loopx check` still reports the pre-existing duplicate history index warning for `loopx-meta`; no public/private boundary errors.