### PR TITLE
feat: add loopx update interface

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -227,9 +227,18 @@ under `~/.local/share/loopx/releases/`, installs the CLI wrapper under
 `~/.local/bin`, and installs the reusable LoopX skills under
 `~/.codex/skills`.
 
-`loopx doctor` reports `install_freshness`. When it says
-`requires_upgrade=true`, rerun the no-clone installer printed in
-`upgrade_command`, then run `loopx doctor` again before continuing.
+`loopx doctor` reports `install_freshness`. For a productized upgrade path, use
+the explicit self-update interface:
+
+```bash
+loopx update --check
+loopx update --dry-run
+loopx update --execute
+```
+
+`--check` and `--dry-run` are read-only. `--execute` reruns the no-clone
+installer, reports the source archive, keeps the previous release snapshot as a
+rollback target when possible, and validates the result with `loopx doctor`.
 
 This is the recommended install repair path for Codex CLI users because an
 agent can run it from inside the TUI without asking the user to clone this
@@ -266,12 +275,12 @@ checkout to the default local release.
 - the CLI wrappers under `~/.local/bin`;
 - the LoopX Codex skills under `~/.codex/skills`.
 
-For a no-clone install, rerun the GitHub archive installer to refresh the
-release snapshot and skills:
+For a no-clone install, use `loopx update` to refresh the release snapshot and
+skills:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh | bash
-loopx doctor
+loopx update --check
+loopx update --execute
 ```
 
 For a contributor checkout, re-run the installer to update both surfaces from
@@ -731,6 +740,7 @@ bootstrap / connect     connect a project-local goal
 new-project-prompt      generate a Codex prompt for project connection
 demo                    create a disposable local demo goal
 doctor                  diagnose installation and import health
+update                  check or execute a no-clone LoopX self-update
 registry                inspect registered goals
 registry-boundary       classify registry local/public boundary and push policy
 status                  show first-screen operator status

--- a/examples/loopx-update-smoke.py
+++ b/examples/loopx-update-smoke.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Smoke-test the read-only LoopX update planning interface."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.self_update import build_update_plan
+
+
+def fake_doctor_payload() -> dict[str, object]:
+    return {
+        "path": {
+            "loopx": "/home/user/.local/bin/loopx",
+            "loopx_realpath": "/home/user/.local/share/loopx/releases/20260621T170342Z/scripts/loopx",
+        },
+        "package": {
+            "release_root": "/home/user/.local/share/loopx/releases/20260621T170342Z",
+        },
+        "install_freshness": {
+            "status": "stale",
+            "requires_upgrade": True,
+            "reason": "fixture is intentionally stale",
+            "current_version": "0.1.2",
+            "release_id": "20260621T170342Z",
+        },
+    }
+
+
+def test_module_plan() -> None:
+    payload = build_update_plan(
+        repo="example/loopx",
+        ref="fixture",
+        archive_url="https://example.invalid/loopx.tar.gz",
+        doctor_payload=fake_doctor_payload(),
+    )
+    assert payload["ok"] is True, payload
+    assert payload["mode"] == "update", payload
+    assert payload["dry_run"] is True, payload
+    assert payload["execute_requested"] is False, payload
+    assert payload["current"]["requires_upgrade"] is True, payload
+    assert payload["plan"]["mutates_loopx_runtime_state"] is False, payload
+    assert payload["plan"]["mutates_release_install"] is False, payload
+    assert payload["plan"]["backup"]["available"] is True, payload
+    assert "LOOPX_ARCHIVE_URL=https://example.invalid/loopx.tar.gz" in payload["plan"]["install_command"], payload
+
+
+def test_cli_check() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "update",
+            "--format",
+            "json",
+            "--check",
+            "--repo",
+            "example/loopx",
+            "--ref",
+            "fixture",
+            "--archive-url",
+            "https://example.invalid/loopx.tar.gz",
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+    )
+    assert result.returncode == 0, (result.returncode, result.stdout, result.stderr)
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True, payload
+    assert payload["mode"] == "update", payload
+    assert payload["check_only"] is True, payload
+    assert payload["dry_run"] is True, payload
+    assert payload["source"]["repo"] == "example/loopx", payload
+    assert payload["source"]["ref"] == "fixture", payload
+    assert payload["plan"]["mutates_loopx_runtime_state"] is False, payload
+
+
+def main() -> int:
+    test_module_plan()
+    test_cli_check()
+    print("loopx-update-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/subcommand-format-smoke.py
+++ b/examples/subcommand-format-smoke.py
@@ -143,6 +143,11 @@ def main() -> int:
         assert upgrade["ok"] is True, upgrade
         assert upgrade["mode"] == "upgrade-plan", upgrade
 
+        update = cli_json(registry_path, "update", "--format", "json", "--check")
+        assert update["ok"] is True, update
+        assert update["mode"] == "update", update
+        assert update["check_only"] is True, update
+
         promotion = cli_json(registry_path, "promotion-gate", "--format", "json")
         assert promotion["ok"] is True, promotion
         assert promotion["gate"] == "promotion_readiness", promotion

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -283,6 +283,7 @@ from .todos import (
     supersede_goal_todo,
     update_goal_todo,
 )
+from .self_update import build_update_plan, execute_update_plan, render_update_plan_markdown
 from .upgrade import build_upgrade_plan, render_upgrade_plan_markdown
 from .worker_bridge import (
     DEFAULT_WORKER_BRIDGE_ACTIVE_USER_FEED_JSONL,
@@ -2853,6 +2854,34 @@ def main(argv: list[str] | None = None) -> int:
         choices=["thin", "brief", "compact"],
         default=[],
         help="Prompt mode to compare. Repeatable; defaults to the thin installed heartbeat contract.",
+    )
+
+    update_parser = sub.add_parser(
+        "update",
+        help="Check or execute a no-clone LoopX self-update.",
+    )
+    add_subcommand_format(update_parser)
+    update_mode = update_parser.add_mutually_exclusive_group()
+    update_mode.add_argument("--check", action="store_true", help="Only report install freshness and update source.")
+    update_mode.add_argument("--dry-run", action="store_true", help="Preview the update plan without installing.")
+    update_mode.add_argument("--execute", action="store_true", help="Run the installer and validate with loopx doctor.")
+    update_parser.add_argument(
+        "--repo",
+        help="GitHub repo owner/name used by the installer archive. Defaults to LOOPX_REPO or huangruiteng/loopx.",
+    )
+    update_parser.add_argument(
+        "--ref",
+        help="Git ref used by the installer archive. Defaults to LOOPX_REF or main.",
+    )
+    update_parser.add_argument(
+        "--archive-url",
+        help="Explicit tarball URL passed to the installer as LOOPX_ARCHIVE_URL.",
+    )
+    update_parser.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=600,
+        help="Timeout for --execute installer and post-update doctor commands.",
     )
 
     ml_experiment_parser = sub.add_parser(
@@ -6702,6 +6731,31 @@ def main(argv: list[str] | None = None) -> int:
                 "recommended_action": "fix upgrade-plan collection before default promotion",
             }
         print_payload(payload, output_format(args), render_upgrade_plan_markdown)
+        return 0 if payload.get("ok") else 1
+
+    if args.command == "update":
+        try:
+            payload = build_update_plan(
+                repo=args.repo,
+                ref=args.ref,
+                archive_url=args.archive_url,
+                check_only=args.check,
+                execute=args.execute,
+            )
+            if args.execute:
+                payload = execute_update_plan(payload, timeout_seconds=args.timeout_seconds)
+        except Exception as exc:
+            payload = {
+                "ok": False,
+                "schema_version": "loopx_update_plan_v0",
+                "mode": "update",
+                "check_only": bool(getattr(args, "check", False)),
+                "dry_run": not bool(getattr(args, "execute", False)),
+                "execute_requested": bool(getattr(args, "execute", False)),
+                "error": str(exc),
+                "recommended_action": "fix update planning or installation before retrying",
+            }
+        print_payload(payload, output_format(args), render_update_plan_markdown)
         return 0 if payload.get("ok") else 1
 
     if args.command == "ml-experiment":

--- a/loopx/self_update.py
+++ b/loopx/self_update.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+from pathlib import Path
+import os
+import shlex
+import subprocess
+from typing import Any
+
+from .doctor import NO_CLONE_INSTALL_URL, collect_doctor
+
+
+UPDATE_PLAN_SCHEMA_VERSION = "loopx_update_plan_v0"
+DEFAULT_UPDATE_REPO = "huangruiteng/loopx"
+DEFAULT_UPDATE_REF = "main"
+
+
+def _source_config(
+    *,
+    repo: str | None,
+    ref: str | None,
+    archive_url: str | None,
+) -> dict[str, Any]:
+    selected_repo = repo or os.environ.get("LOOPX_REPO") or DEFAULT_UPDATE_REPO
+    selected_ref = ref or os.environ.get("LOOPX_REF") or DEFAULT_UPDATE_REF
+    selected_archive_url = archive_url or os.environ.get("LOOPX_ARCHIVE_URL")
+    if not selected_archive_url:
+        selected_archive_url = f"https://codeload.github.com/{selected_repo}/tar.gz/{selected_ref}"
+    return {
+        "channel": "github_archive",
+        "repo": selected_repo,
+        "ref": selected_ref,
+        "archive_url": selected_archive_url,
+        "installer_url": NO_CLONE_INSTALL_URL,
+    }
+
+
+def _command_for_source(source: dict[str, Any]) -> str:
+    exports = [
+        f"LOOPX_REPO={shlex.quote(str(source['repo']))}",
+        f"LOOPX_REF={shlex.quote(str(source['ref']))}",
+    ]
+    archive_url = source.get("archive_url")
+    if archive_url:
+        exports.append(f"LOOPX_ARCHIVE_URL={shlex.quote(str(archive_url))}")
+    return (
+        " ".join(exports)
+        + f" curl -fsSL {shlex.quote(str(source['installer_url']))} | bash\n"
+        'export PATH="$HOME/.local/bin:$PATH"\n'
+        "loopx doctor"
+    )
+
+
+def _release_root_from_doctor(doctor_payload: dict[str, Any]) -> str | None:
+    package = doctor_payload.get("package") if isinstance(doctor_payload.get("package"), dict) else {}
+    release_root = package.get("release_root")
+    if isinstance(release_root, str) and release_root:
+        return release_root
+    path = doctor_payload.get("path") if isinstance(doctor_payload.get("path"), dict) else {}
+    realpath = path.get("loopx_realpath")
+    if isinstance(realpath, str) and realpath:
+        realpath_path = Path(realpath)
+        if realpath_path.name == "loopx" and realpath_path.parent.name == "scripts":
+            return str(realpath_path.parent.parent)
+    return None
+
+
+def _rollback_plan(doctor_payload: dict[str, Any]) -> dict[str, Any]:
+    release_root = _release_root_from_doctor(doctor_payload)
+    if not release_root:
+        return {
+            "available": False,
+            "reason": "current loopx command is not a release snapshot",
+            "current_release_root": None,
+            "rollback_command": None,
+        }
+    return {
+        "available": True,
+        "reason": "current release snapshot can be restored by repointing the user-local command",
+        "current_release_root": release_root,
+        "rollback_command": (
+            f'ln -sfn "{release_root}/scripts/loopx" "$HOME/.local/bin/loopx"\n'
+            "loopx doctor"
+        ),
+    }
+
+
+def build_update_plan(
+    *,
+    repo: str | None = None,
+    ref: str | None = None,
+    archive_url: str | None = None,
+    check_only: bool = False,
+    execute: bool = False,
+    doctor_payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    doctor = doctor_payload or collect_doctor()
+    install_freshness = (
+        doctor.get("install_freshness")
+        if isinstance(doctor.get("install_freshness"), dict)
+        else {}
+    )
+    source = _source_config(repo=repo, ref=ref, archive_url=archive_url)
+    install_command = _command_for_source(source)
+    dry_run = not execute
+    path = doctor.get("path") if isinstance(doctor.get("path"), dict) else {}
+    return {
+        "ok": True,
+        "schema_version": UPDATE_PLAN_SCHEMA_VERSION,
+        "mode": "update",
+        "check_only": check_only,
+        "dry_run": dry_run,
+        "execute_requested": execute,
+        "source": source,
+        "current": {
+            "loopx_command": path.get("loopx"),
+            "loopx_realpath": path.get("loopx_realpath"),
+            "current_version": install_freshness.get("current_version"),
+            "release_id": install_freshness.get("release_id"),
+            "install_freshness_status": install_freshness.get("status"),
+            "requires_upgrade": install_freshness.get("requires_upgrade"),
+            "reason": install_freshness.get("reason"),
+        },
+        "plan": {
+            "action": "check_only" if check_only else "execute_installer" if execute else "dry_run",
+            "install_command": install_command,
+            "post_update_validation": "loopx doctor",
+            "mutates_loopx_runtime_state": False,
+            "mutates_release_install": execute,
+            "backup": _rollback_plan(doctor),
+        },
+        "execution": None,
+        "recommended_action": (
+            "run `loopx update --execute` if you accept the source and rollback plan"
+            if not execute
+            else "review execution result and post-update doctor output"
+        ),
+    }
+
+
+def execute_update_plan(payload: dict[str, Any], *, timeout_seconds: int = 600) -> dict[str, Any]:
+    source = payload.get("source") if isinstance(payload.get("source"), dict) else {}
+    installer_url = str(source.get("installer_url") or NO_CLONE_INSTALL_URL)
+    env = os.environ.copy()
+    env["LOOPX_REPO"] = str(source.get("repo") or DEFAULT_UPDATE_REPO)
+    env["LOOPX_REF"] = str(source.get("ref") or DEFAULT_UPDATE_REF)
+    if source.get("archive_url"):
+        env["LOOPX_ARCHIVE_URL"] = str(source["archive_url"])
+    install_result = subprocess.run(
+        ["bash", "-lc", f"curl -fsSL {shlex.quote(installer_url)} | bash"],
+        text=True,
+        capture_output=True,
+        env=env,
+        timeout=timeout_seconds,
+    )
+    loopx_bin = Path.home() / ".local" / "bin" / "loopx"
+    doctor_result = subprocess.run(
+        [str(loopx_bin), "--format", "json", "doctor"],
+        text=True,
+        capture_output=True,
+        env=env,
+        timeout=timeout_seconds,
+    )
+    execution = {
+        "install_returncode": install_result.returncode,
+        "doctor_returncode": doctor_result.returncode,
+        "install_stdout_tail": install_result.stdout[-2000:],
+        "install_stderr_tail": install_result.stderr[-2000:],
+        "doctor_stdout_tail": doctor_result.stdout[-2000:],
+        "doctor_stderr_tail": doctor_result.stderr[-2000:],
+    }
+    updated = dict(payload)
+    updated["execution"] = execution
+    updated["ok"] = install_result.returncode == 0 and doctor_result.returncode == 0
+    if not updated["ok"]:
+        updated["recommended_action"] = "inspect update execution tails and restore from rollback plan if needed"
+    return updated
+
+
+def render_update_plan_markdown(payload: dict[str, Any]) -> str:
+    source = payload.get("source") if isinstance(payload.get("source"), dict) else {}
+    current = payload.get("current") if isinstance(payload.get("current"), dict) else {}
+    plan = payload.get("plan") if isinstance(payload.get("plan"), dict) else {}
+    backup = plan.get("backup") if isinstance(plan.get("backup"), dict) else {}
+    lines = [
+        "# LoopX Update",
+        "",
+        f"- OK: `{payload.get('ok')}`",
+        f"- Mode: `{plan.get('action')}`",
+        f"- Dry run: `{payload.get('dry_run')}`",
+        f"- Source: `{source.get('repo')}` @ `{source.get('ref')}`",
+        f"- Current version: `{current.get('current_version')}`",
+        f"- Freshness: `{current.get('install_freshness_status')}`",
+        f"- Requires upgrade: `{current.get('requires_upgrade')}`",
+        f"- Runtime state mutation: `{plan.get('mutates_loopx_runtime_state')}`",
+        f"- Release install mutation: `{plan.get('mutates_release_install')}`",
+        f"- Rollback available: `{backup.get('available')}`",
+        f"- Recommended action: {payload.get('recommended_action')}",
+        "",
+        "## Install Command",
+        "",
+        "```bash",
+        str(plan.get("install_command") or ""),
+        "```",
+    ]
+    rollback_command = backup.get("rollback_command")
+    if rollback_command:
+        lines.extend(["", "## Rollback Command", "", "```bash", str(rollback_command), "```"])
+    execution = payload.get("execution")
+    if isinstance(execution, dict):
+        lines.extend(
+            [
+                "",
+                "## Execution",
+                "",
+                f"- Install return code: `{execution.get('install_returncode')}`",
+                f"- Doctor return code: `{execution.get('doctor_returncode')}`",
+            ]
+        )
+    return "\n".join(lines) + "\n"


### PR DESCRIPTION
## Summary
- add `loopx update` with `--check`, `--dry-run`, and explicit `--execute` modes
- report update source, release freshness, rollback command, and post-update `loopx doctor` validation
- document the productized no-clone update path and cover JSON subcommand output with smokes

## Validation
- `python3 examples/loopx-update-smoke.py`
- `python3 examples/subcommand-format-smoke.py`
- `python3 -m compileall loopx`
- `loopx check --scan-path loopx/self_update.py --scan-path loopx/cli.py --scan-path docs/guides/getting-started.md --scan-path examples/loopx-update-smoke.py --scan-path examples/subcommand-format-smoke.py`

Note: `loopx check` reports the existing `loopx-meta` duplicate index rows warning; public boundary scan over changed files is clean.