### PR TITLE
Add default-off ML experiment domain pack

### DIFF
--- a/docs/product/domain-capability-packs.md
+++ b/docs/product/domain-capability-packs.md
@@ -108,6 +108,34 @@ The pack should never infer that a metric board, dataset path, training system,
 or launch command is authorized merely because text in a todo looks familiar.
 Authority comes from the registry, goal boundary, and compact owner decision.
 
+### Quick Trial
+
+Algorithm experiment users can trial the advisory shape without enabling
+delivery authority:
+
+```bash
+loopx ml-experiment preview --format json \
+  --experiment-id exp_preview_v1 \
+  --primary-metric offline_auc \
+  --baseline-value 0.421 \
+  --candidate-value 0.437 \
+  --guardrail-status clean \
+  --train-window train_2026w24 \
+  --eval-window eval_2026w25 \
+  --hypothesis-id h_route_mix_v1 \
+  --mechanism-family "candidate retrieval mix" \
+  --route route_mix \
+  --positive-evidence offline_eval_delta_positive \
+  --next-candidate holdout_eval
+```
+
+The preview writes no state and launches nothing. It returns compact public-safe
+`ml_experiment_result_v0`, `dataset_window_contract_v0`,
+`hypothesis_ledger_v0`, and `experiment_replan_v0` sections with
+`launch_actions_enabled=false` and `production_actions_enabled=false`.
+Use artifact aliases instead of raw logs, private paths, internal links, or
+credential-bearing metric dumps.
+
 ## Detection
 
 `domain_pack_detection_v0` is a suggest-only detector. It may inspect public-safe

--- a/examples/ml-experiment-domain-pack-smoke.py
+++ b/examples/ml-experiment-domain-pack-smoke.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Smoke-test the default-off ML experiment domain capability pack."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.ml_experiment import (  # noqa: E402
+    DATASET_WINDOW_CONTRACT_SCHEMA_VERSION,
+    EXPERIMENT_REPLAN_SCHEMA_VERSION,
+    HYPOTHESIS_LEDGER_SCHEMA_VERSION,
+    ML_EXPERIMENT_ADVISORY_PACKET_SCHEMA_VERSION,
+    ML_EXPERIMENT_RESULT_SCHEMA_VERSION,
+    build_ml_experiment_advisory_packet,
+)
+
+
+def assert_no_private_surface(payload: dict[str, Any]) -> None:
+    text = json.dumps(payload, sort_keys=True)
+    forbidden = [
+        "/" + "Users/",
+        "/" + "private/",
+        "/" + "tmp/",
+        "lark" + "office",
+        "byte" + "dance",
+        "http://",
+        "https://",
+        "s3://",
+        "tos://",
+        "hdfs://",
+        "api" + "_key",
+        "pass" + "word",
+        "sec" + "ret",
+    ]
+    leaked = [needle for needle in forbidden if needle.lower() in text.lower()]
+    assert not leaked, leaked
+
+
+def run_cli(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "loopx.cli", *args],
+        cwd=REPO_ROOT,
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def main() -> None:
+    packet = build_ml_experiment_advisory_packet(
+        experiment_id="exp_preview_v1",
+        primary_metric="offline_auc",
+        baseline_value=0.421,
+        candidate_value=0.437,
+        guardrail_status="clean",
+        train_window="train_2026w24",
+        eval_window="eval_2026w25",
+        hypothesis_id="h_route_mix_v1",
+        mechanism_family="candidate retrieval mix",
+        route="route_mix",
+        positive_evidence=["offline_eval_delta_positive"],
+        negative_evidence=["serving_latency_unknown"],
+        next_candidates=["holdout_eval", "latency_guardrail_probe"],
+    )
+    assert packet["schema_version"] == ML_EXPERIMENT_ADVISORY_PACKET_SCHEMA_VERSION, packet
+    assert packet["pack"]["enabled"] is False, packet
+    assert packet["pack"]["autonomy"] == "suggest_only", packet
+    assert packet["launch_actions_enabled"] is False, packet
+    assert packet["production_actions_enabled"] is False, packet
+    assert packet["result"]["schema_version"] == ML_EXPERIMENT_RESULT_SCHEMA_VERSION, packet
+    assert packet["result"]["primary_metric_status"] == "improved", packet
+    assert packet["result"]["decision_status"] == "candidate_not_winner_yet", packet
+    assert packet["result"]["dataset_window"]["schema_version"] == DATASET_WINDOW_CONTRACT_SCHEMA_VERSION, packet
+    assert packet["result"]["hypothesis"]["schema_version"] == HYPOTHESIS_LEDGER_SCHEMA_VERSION, packet
+    assert packet["replan_preview"]["schema_version"] == EXPERIMENT_REPLAN_SCHEMA_VERSION, packet
+    assert packet["replan_preview"]["launch_actions_enabled"] is False, packet
+    assert_no_private_surface(packet)
+
+    result = run_cli(
+        [
+            "--format",
+            "json",
+            "ml-experiment",
+            "preview",
+            "--experiment-id",
+            "exp_preview_v1",
+            "--primary-metric",
+            "offline_auc",
+            "--baseline-value",
+            "0.421",
+            "--candidate-value",
+            "0.437",
+            "--guardrail-status",
+            "clean",
+            "--train-window",
+            "train_2026w24",
+            "--eval-window",
+            "eval_2026w25",
+            "--hypothesis-id",
+            "h_route_mix_v1",
+            "--mechanism-family",
+            "candidate retrieval mix",
+            "--route",
+            "route_mix",
+            "--positive-evidence",
+            "offline_eval_delta_positive",
+            "--negative-evidence",
+            "serving_latency_unknown",
+            "--next-candidate",
+            "holdout_eval",
+        ]
+    )
+    payload = json.loads(result.stdout)
+    assert payload["ok"], payload
+    assert payload["schema_version"] == ML_EXPERIMENT_ADVISORY_PACKET_SCHEMA_VERSION, payload
+    assert payload["pack"]["enabled"] is False, payload
+    assert payload["result"]["primary_metric_status"] == "improved", payload
+    assert_no_private_surface(payload)
+
+    blocked = run_cli(
+        [
+            "--format",
+            "json",
+            "ml-experiment",
+            "preview",
+            "--experiment-id",
+            "exp_preview_v1",
+            "--primary-metric",
+            "offline_auc",
+            "--baseline-value",
+            "0.421",
+            "--candidate-value",
+            "0.437",
+            "--train-window",
+            "/" + "Users/example/private/train.log",
+            "--eval-window",
+            "eval_2026w25",
+            "--hypothesis-id",
+            "h_route_mix_v1",
+            "--mechanism-family",
+            "candidate retrieval mix",
+            "--route",
+            "route_mix",
+        ],
+        check=False,
+    )
+    assert blocked.returncode == 1, blocked.stdout
+    blocked_payload = json.loads(blocked.stdout)
+    assert blocked_payload["ok"] is False, blocked_payload
+    assert "public alias" in blocked_payload["error"], blocked_payload
+
+    docs = (REPO_ROOT / "docs" / "product" / "domain-capability-packs.md").read_text(encoding="utf-8")
+    assert "loopx ml-experiment preview" in docs, docs
+    assert "launch_actions_enabled=false" in docs, docs
+    assert "production_actions_enabled=false" in docs, docs
+
+    print("ml-experiment-domain-pack-smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -196,6 +196,12 @@ from .history import (
     render_index_duplicate_inspection_markdown,
     render_index_duplicate_repair_markdown,
 )
+from .ml_experiment import (
+    GUARDRAIL_STATUSES,
+    HYPOTHESIS_STATUSES,
+    build_ml_experiment_advisory_packet,
+    render_ml_experiment_advisory_markdown,
+)
 from .operator_gate import (
     DEFAULT_OPERATOR_GATE,
     OPERATOR_GATE_DECISIONS,
@@ -2836,6 +2842,70 @@ def main(argv: list[str] | None = None) -> int:
         choices=["thin", "brief", "compact"],
         default=[],
         help="Prompt mode to compare. Repeatable; defaults to the thin installed heartbeat contract.",
+    )
+
+    ml_experiment_parser = sub.add_parser(
+        "ml-experiment",
+        help="Render default-off ML experiment advisory packets.",
+    )
+    ml_experiment_sub = ml_experiment_parser.add_subparsers(dest="ml_experiment_command", required=True)
+    ml_experiment_preview_parser = ml_experiment_sub.add_parser(
+        "preview",
+        help="Preview a public-safe ML experiment result, hypothesis ledger, and replan packet.",
+    )
+    add_subcommand_format(ml_experiment_preview_parser)
+    ml_experiment_preview_parser.add_argument("--experiment-id", required=True, help="Public experiment id.")
+    ml_experiment_preview_parser.add_argument("--primary-metric", required=True, help="Primary metric label.")
+    ml_experiment_preview_parser.add_argument("--baseline-value", type=float, required=True)
+    ml_experiment_preview_parser.add_argument("--candidate-value", type=float, required=True)
+    metric_direction = ml_experiment_preview_parser.add_mutually_exclusive_group()
+    metric_direction.add_argument(
+        "--higher-is-better",
+        dest="higher_is_better",
+        action="store_true",
+        default=True,
+        help="Classify positive metric deltas as improvements. This is the default.",
+    )
+    metric_direction.add_argument(
+        "--lower-is-better",
+        dest="higher_is_better",
+        action="store_false",
+        help="Classify negative metric deltas as improvements.",
+    )
+    ml_experiment_preview_parser.add_argument(
+        "--guardrail-status",
+        choices=GUARDRAIL_STATUSES,
+        default="unknown",
+        help="Compact guardrail classification.",
+    )
+    ml_experiment_preview_parser.add_argument("--train-window", required=True)
+    ml_experiment_preview_parser.add_argument("--eval-window", required=True)
+    ml_experiment_preview_parser.add_argument("--granularity", default="daily")
+    ml_experiment_preview_parser.add_argument("--hypothesis-id", required=True)
+    ml_experiment_preview_parser.add_argument("--mechanism-family", required=True)
+    ml_experiment_preview_parser.add_argument("--route", required=True)
+    ml_experiment_preview_parser.add_argument(
+        "--hypothesis-status",
+        choices=HYPOTHESIS_STATUSES,
+        default="active",
+    )
+    ml_experiment_preview_parser.add_argument(
+        "--positive-evidence",
+        action="append",
+        default=[],
+        help="Compact public-safe evidence label. Repeatable.",
+    )
+    ml_experiment_preview_parser.add_argument(
+        "--negative-evidence",
+        action="append",
+        default=[],
+        help="Compact public-safe evidence label. Repeatable.",
+    )
+    ml_experiment_preview_parser.add_argument(
+        "--next-candidate",
+        action="append",
+        default=[],
+        help="Compact public-safe follow-up candidate label. Repeatable.",
     )
 
     sub.add_parser("registry", help="Inspect registry goals and adapter declarations.")
@@ -6590,6 +6660,37 @@ def main(argv: list[str] | None = None) -> int:
                 "recommended_action": "fix upgrade-plan collection before default promotion",
             }
         print_payload(payload, output_format(args), render_upgrade_plan_markdown)
+        return 0 if payload.get("ok") else 1
+
+    if args.command == "ml-experiment":
+        try:
+            if args.ml_experiment_command != "preview":
+                raise ValueError("ml-experiment requires the `preview` subcommand")
+            payload = build_ml_experiment_advisory_packet(
+                experiment_id=args.experiment_id,
+                primary_metric=args.primary_metric,
+                baseline_value=args.baseline_value,
+                candidate_value=args.candidate_value,
+                higher_is_better=bool(args.higher_is_better),
+                guardrail_status=args.guardrail_status,
+                train_window=args.train_window,
+                eval_window=args.eval_window,
+                granularity=args.granularity,
+                hypothesis_id=args.hypothesis_id,
+                mechanism_family=args.mechanism_family,
+                route=args.route,
+                hypothesis_status=args.hypothesis_status,
+                positive_evidence=args.positive_evidence,
+                negative_evidence=args.negative_evidence,
+                next_candidates=args.next_candidate,
+            )
+        except Exception as exc:
+            payload = {
+                "ok": False,
+                "mode": "ml-experiment",
+                "error": str(exc),
+            }
+        print_payload(payload, output_format(args), render_ml_experiment_advisory_markdown)
         return 0 if payload.get("ok") else 1
 
     if args.command == "registry":

--- a/loopx/ml_experiment.py
+++ b/loopx/ml_experiment.py
@@ -1,0 +1,336 @@
+from __future__ import annotations
+
+import math
+import re
+from typing import Any, Iterable
+
+
+DOMAIN_PACK_CONTRACT_SCHEMA_VERSION = "domain_pack_contract_v0"
+ML_EXPERIMENT_ADVISORY_PACKET_SCHEMA_VERSION = "ml_experiment_advisory_packet_v0"
+ML_EXPERIMENT_RESULT_SCHEMA_VERSION = "ml_experiment_result_v0"
+DATASET_WINDOW_CONTRACT_SCHEMA_VERSION = "dataset_window_contract_v0"
+HYPOTHESIS_LEDGER_SCHEMA_VERSION = "hypothesis_ledger_v0"
+EXPERIMENT_REPLAN_SCHEMA_VERSION = "experiment_replan_v0"
+
+GUARDRAIL_STATUSES = ("clean", "warning", "failed", "unknown")
+HYPOTHESIS_STATUSES = ("active", "supported", "weakened", "retired", "unknown")
+
+_TOKEN_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_.:-]{0,79}$")
+_ABSOLUTE_PATH_RE = re.compile(
+    r"(^|[\s:=])(?:"
+    + "/" + "Users/"
+    + "|/private/|/tmp/|~[/\\s]|[A-Za-z]:\\\\)"
+)
+_URL_OR_REMOTE_PATH_RE = re.compile(r"(?i)\b(?:https?|file|s3|gs|tos|hdfs)://")
+_PRIVATE_MARKER_TERMS = [
+    "author" + "ization:",
+    r"bearer\s+[A-Za-z0-9._-]+",
+    r"api[_-]?" + "key",
+    "pass" + "word",
+    "sec" + "ret",
+    r"begin (?:rsa |open)?private " + "key",
+    "lark" + "office",
+    r"fei" + r"shu\.cn",
+    "byte" + "dance",
+]
+_PRIVATE_MARKER_RE = re.compile(r"(?i)(" + "|".join(_PRIVATE_MARKER_TERMS) + ")")
+
+
+def _compact_public_text(value: str, *, field: str, max_len: int = 160) -> str:
+    text = " ".join(str(value or "").strip().split())
+    if not text:
+        raise ValueError(f"{field} must be non-empty")
+    if len(text) > max_len:
+        raise ValueError(f"{field} is too long for a compact public-safe field")
+    if ".." in text:
+        raise ValueError(f"{field} must not contain parent-directory markers")
+    if _ABSOLUTE_PATH_RE.search(text) or text.startswith(("/", "~")):
+        raise ValueError(f"{field} must use a public alias, not a local/private path")
+    if _URL_OR_REMOTE_PATH_RE.search(text):
+        raise ValueError(f"{field} must use a public alias, not a raw URL or remote path")
+    if _PRIVATE_MARKER_RE.search(text):
+        raise ValueError(f"{field} contains a private or credential-like marker")
+    return text
+
+
+def _compact_public_token(value: str, *, field: str) -> str:
+    token = _compact_public_text(value, field=field, max_len=80)
+    if not _TOKEN_RE.match(token):
+        raise ValueError(
+            f"{field} must be a compact public token using letters, digits, dot, colon, dash, or underscore"
+        )
+    return token
+
+
+def _compact_public_text_list(values: Iterable[str] | None, *, field: str) -> list[str]:
+    return [_compact_public_text(value, field=f"{field}[]") for value in values or []]
+
+
+def _finite_float(value: float | int | str, *, field: str) -> float:
+    number = float(value)
+    if not math.isfinite(number):
+        raise ValueError(f"{field} must be finite")
+    return number
+
+
+def build_ml_experiment_domain_pack_contract(*, enabled: bool = False) -> dict[str, Any]:
+    """Return the default-off ML experiment domain-pack boundary."""
+
+    return {
+        "schema_version": DOMAIN_PACK_CONTRACT_SCHEMA_VERSION,
+        "pack": "ml_experiment",
+        "enabled": bool(enabled),
+        "autonomy": "suggest_only" if not enabled else "advisory",
+        "allowed_actions": [
+            "ingest_metrics",
+            "classify_results",
+            "write_hypothesis_ledger",
+            "propose_replan",
+        ],
+        "disabled_actions": [
+            "launch_training_job",
+            "stop_training_job",
+            "restart_training_job",
+            "sync_to_production",
+            "select_primary_metric_without_authority",
+        ],
+        "capability_requirements": [
+            "compact_public_metric_artifact",
+            "dataset_window_contract",
+            "hypothesis_ledger",
+        ],
+        "authority_boundary": {
+            "primary_metric_authority": "explicit_board_or_owner_decision_only",
+            "launch_authority": "disabled_until_explicit_registry_delivery_mode",
+            "production_authority": "disabled_until_explicit_registry_delivery_mode",
+        },
+    }
+
+
+def build_dataset_window_contract(
+    *,
+    train_window: str,
+    eval_window: str,
+    granularity: str = "daily",
+    intersection_policy: str = "matched_window_only",
+    missing_window_policy: str = "mark_inconclusive",
+) -> dict[str, Any]:
+    return {
+        "schema_version": DATASET_WINDOW_CONTRACT_SCHEMA_VERSION,
+        "train_window": _compact_public_text(train_window, field="train_window"),
+        "eval_window": _compact_public_text(eval_window, field="eval_window"),
+        "granularity": _compact_public_token(granularity, field="granularity"),
+        "intersection_policy": _compact_public_token(intersection_policy, field="intersection_policy"),
+        "missing_window_policy": _compact_public_token(missing_window_policy, field="missing_window_policy"),
+        "conclusion_eligibility": "eligible_if_windows_match_and_guardrails_clear",
+    }
+
+
+def build_hypothesis_ledger_entry(
+    *,
+    hypothesis_id: str,
+    mechanism_family: str,
+    route: str,
+    status: str = "active",
+    positive_evidence: Iterable[str] | None = None,
+    negative_evidence: Iterable[str] | None = None,
+) -> dict[str, Any]:
+    compact_status = _compact_public_token(status, field="hypothesis_status")
+    if compact_status not in HYPOTHESIS_STATUSES:
+        raise ValueError(f"hypothesis_status must be one of {', '.join(HYPOTHESIS_STATUSES)}")
+    return {
+        "schema_version": HYPOTHESIS_LEDGER_SCHEMA_VERSION,
+        "hypothesis_id": _compact_public_token(hypothesis_id, field="hypothesis_id"),
+        "mechanism_family": _compact_public_text(mechanism_family, field="mechanism_family"),
+        "route": _compact_public_token(route, field="route"),
+        "status": compact_status,
+        "positive_evidence": _compact_public_text_list(positive_evidence, field="positive_evidence"),
+        "negative_evidence": _compact_public_text_list(negative_evidence, field="negative_evidence"),
+        "raw_metrics_recorded": False,
+        "private_artifacts_recorded": False,
+    }
+
+
+def classify_primary_metric_delta(
+    *,
+    baseline_value: float,
+    candidate_value: float,
+    higher_is_better: bool,
+) -> dict[str, Any]:
+    baseline = _finite_float(baseline_value, field="baseline_value")
+    candidate = _finite_float(candidate_value, field="candidate_value")
+    delta = candidate - baseline
+    signed_improvement = delta if higher_is_better else -delta
+    if abs(delta) < 1e-12:
+        status = "flat"
+    elif signed_improvement > 0:
+        status = "improved"
+    else:
+        status = "regressed"
+    relative_delta = None if abs(baseline) < 1e-12 else delta / abs(baseline)
+    return {
+        "baseline_value": baseline,
+        "candidate_value": candidate,
+        "delta": delta,
+        "relative_delta": relative_delta,
+        "higher_is_better": bool(higher_is_better),
+        "primary_metric_status": status,
+    }
+
+
+def build_ml_experiment_result(
+    *,
+    experiment_id: str,
+    primary_metric: str,
+    baseline_value: float,
+    candidate_value: float,
+    higher_is_better: bool = True,
+    guardrail_status: str = "unknown",
+    dataset_window: dict[str, Any],
+    hypothesis: dict[str, Any],
+) -> dict[str, Any]:
+    compact_guardrail_status = _compact_public_token(guardrail_status, field="guardrail_status")
+    if compact_guardrail_status not in GUARDRAIL_STATUSES:
+        raise ValueError(f"guardrail_status must be one of {', '.join(GUARDRAIL_STATUSES)}")
+    metric = classify_primary_metric_delta(
+        baseline_value=baseline_value,
+        candidate_value=candidate_value,
+        higher_is_better=higher_is_better,
+    )
+    if compact_guardrail_status == "failed":
+        decision_status = "blocked_by_guardrail"
+    elif metric["primary_metric_status"] == "improved" and compact_guardrail_status == "clean":
+        decision_status = "candidate_not_winner_yet"
+    elif metric["primary_metric_status"] == "regressed":
+        decision_status = "needs_replan"
+    else:
+        decision_status = "inconclusive"
+    return {
+        "schema_version": ML_EXPERIMENT_RESULT_SCHEMA_VERSION,
+        "experiment_id": _compact_public_token(experiment_id, field="experiment_id"),
+        "primary_metric": _compact_public_text(primary_metric, field="primary_metric"),
+        **metric,
+        "guardrail_status": compact_guardrail_status,
+        "decision_status": decision_status,
+        "dataset_window": dataset_window,
+        "hypothesis": hypothesis,
+        "raw_metrics_recorded": False,
+        "private_artifacts_recorded": False,
+    }
+
+
+def build_experiment_replan_preview(
+    *,
+    result: dict[str, Any],
+    next_candidates: Iterable[str] | None = None,
+    allocation: str = "one_followup",
+) -> dict[str, Any]:
+    candidate_labels = _compact_public_text_list(next_candidates, field="next_candidate")
+    if not candidate_labels:
+        candidate_labels = ["near_neighbor_ablation", "guardrail_holdout_check"]
+    decision_status = str(result.get("decision_status") or "inconclusive")
+    if decision_status == "candidate_not_winner_yet":
+        recommendation = "validate_on_holdout_before_promotion"
+    elif decision_status == "blocked_by_guardrail":
+        recommendation = "repair_guardrail_before_more_exploration"
+    else:
+        recommendation = "run_one_followup_or_retire_hypothesis"
+    return {
+        "schema_version": EXPERIMENT_REPLAN_SCHEMA_VERSION,
+        "recommendation": recommendation,
+        "allocation": _compact_public_token(allocation, field="allocation"),
+        "next_candidates": candidate_labels,
+        "launch_actions_enabled": False,
+        "production_actions_enabled": False,
+        "requires_explicit_authorization": True,
+    }
+
+
+def build_ml_experiment_advisory_packet(
+    *,
+    experiment_id: str,
+    primary_metric: str,
+    baseline_value: float,
+    candidate_value: float,
+    higher_is_better: bool = True,
+    guardrail_status: str = "unknown",
+    train_window: str,
+    eval_window: str,
+    granularity: str = "daily",
+    hypothesis_id: str,
+    mechanism_family: str,
+    route: str,
+    hypothesis_status: str = "active",
+    positive_evidence: Iterable[str] | None = None,
+    negative_evidence: Iterable[str] | None = None,
+    next_candidates: Iterable[str] | None = None,
+) -> dict[str, Any]:
+    dataset_window = build_dataset_window_contract(
+        train_window=train_window,
+        eval_window=eval_window,
+        granularity=granularity,
+    )
+    hypothesis = build_hypothesis_ledger_entry(
+        hypothesis_id=hypothesis_id,
+        mechanism_family=mechanism_family,
+        route=route,
+        status=hypothesis_status,
+        positive_evidence=positive_evidence,
+        negative_evidence=negative_evidence,
+    )
+    result = build_ml_experiment_result(
+        experiment_id=experiment_id,
+        primary_metric=primary_metric,
+        baseline_value=baseline_value,
+        candidate_value=candidate_value,
+        higher_is_better=higher_is_better,
+        guardrail_status=guardrail_status,
+        dataset_window=dataset_window,
+        hypothesis=hypothesis,
+    )
+    replan = build_experiment_replan_preview(
+        result=result,
+        next_candidates=next_candidates,
+    )
+    return {
+        "ok": True,
+        "schema_version": ML_EXPERIMENT_ADVISORY_PACKET_SCHEMA_VERSION,
+        "pack": build_ml_experiment_domain_pack_contract(enabled=False),
+        "mode": "default_off_advisory_preview",
+        "result": result,
+        "replan_preview": replan,
+        "raw_metrics_recorded": False,
+        "private_artifacts_recorded": False,
+        "launch_actions_enabled": False,
+        "production_actions_enabled": False,
+        "recommended_next_action": "owner_or_registry_can_enable_advisory_mode_for_this_goal",
+    }
+
+
+def render_ml_experiment_advisory_markdown(payload: dict[str, Any]) -> str:
+    if not payload.get("ok"):
+        return f"ML experiment advisory preview failed: {payload.get('error')}\n"
+    result = payload.get("result") if isinstance(payload.get("result"), dict) else {}
+    replan = payload.get("replan_preview") if isinstance(payload.get("replan_preview"), dict) else {}
+    pack = payload.get("pack") if isinstance(payload.get("pack"), dict) else {}
+    lines = [
+        "# ML Experiment Advisory Preview",
+        "",
+        f"- experiment: `{result.get('experiment_id')}`",
+        f"- primary metric: `{result.get('primary_metric')}`",
+        f"- status: `{result.get('primary_metric_status')}`",
+        f"- delta: `{result.get('delta')}`",
+        f"- guardrail: `{result.get('guardrail_status')}`",
+        f"- decision: `{result.get('decision_status')}`",
+        f"- pack enabled: `{pack.get('enabled')}`",
+        f"- launch actions enabled: `{payload.get('launch_actions_enabled')}`",
+        f"- production actions enabled: `{payload.get('production_actions_enabled')}`",
+        "",
+        "## Replan Preview",
+        "",
+        f"- recommendation: `{replan.get('recommendation')}`",
+        f"- allocation: `{replan.get('allocation')}`",
+        "- next candidates: "
+        + ", ".join(f"`{candidate}`" for candidate in replan.get("next_candidates", []) or []),
+    ]
+    return "\n".join(lines) + "\n"


### PR DESCRIPTION
## Summary
- add a default-off ML experiment advisory packet builder for compact result, dataset-window, hypothesis ledger, and replan preview contracts
- expose `loopx ml-experiment preview` for public-safe trial use without state writes or launch/production authority
- document the quick trial path and add a focused smoke covering CLI output and private-path rejection

## Validation
- `python3 -m py_compile loopx/ml_experiment.py loopx/cli.py`
- `python3 examples/ml-experiment-domain-pack-smoke.py`
- `python3 examples/docs-governance-smoke.py`
- `loopx check --scan-path loopx/ml_experiment.py --scan-path loopx/cli.py --scan-path examples/ml-experiment-domain-pack-smoke.py --scan-path docs/product/domain-capability-packs.md` (passes; existing loopx-meta duplicate index warning only)
- `git diff --cached --check`

## Excluded local changes
- left existing unstaged changes in docs/interaction-pattern-catalog.md, examples/interaction-pattern-catalog-smoke.py, and skills/loopx-self-repair/references/repair-patterns.md untouched