### PR TITLE
Exclude represented coverage from case-analysis candidates

### DIFF
--- a/examples/benchmark-case-analysis-candidates-smoke.py
+++ b/examples/benchmark-case-analysis-candidates-smoke.py
@@ -70,7 +70,22 @@ def fixture_ledger() -> dict:
                         "runs": [],
                     },
                 },
-            }
+            },
+            "terminal-bench@2.0": {
+                "benchmark_id": "terminal-bench@2.0",
+                "cases": {
+                    "coverage-row-only": {
+                        "case_id": "coverage-row-only",
+                        "latest_decision": {
+                            "decision": "paired_baseline_solved_treatment_preserved"
+                        },
+                        "runs": [
+                            {"run_id": "baseline", "official_score": 1.0},
+                            {"run_id": "treatment", "official_score": 1.0},
+                        ],
+                    }
+                },
+            },
         },
     }
 
@@ -85,6 +100,16 @@ def fixture_analysis() -> dict:
                 "analysis_id": "bench__existing-case__paired_no_score_uplift",
             }
         ],
+        "terminal_bench_current_protocol_coverage": {
+            "schema_version": "terminal_bench_current_protocol_coverage_v0",
+            "rows": [
+                {
+                    "case_id": "coverage-row-only",
+                    "decision": "paired_baseline_solved_treatment_preserved",
+                    "case_analysis_status": "coverage_row_only_no_deep_case_note_yet",
+                }
+            ],
+        },
     }
 
 

--- a/loopx/benchmark_case_analysis.py
+++ b/loopx/benchmark_case_analysis.py
@@ -42,15 +42,22 @@ def _compact_text(value: object, *, limit: int = 200) -> str:
 def case_analysis_keys(analysis: dict[str, Any]) -> set[tuple[str, str]]:
     keys: set[tuple[str, str]] = set()
     cases = analysis.get("cases")
-    if not isinstance(cases, list):
-        return keys
-    for case in cases:
-        if not isinstance(case, dict):
-            continue
-        benchmark_id = _compact_text(case.get("benchmark_id"), limit=160)
-        case_id = _compact_text(case.get("case_id"), limit=200)
-        if benchmark_id and case_id:
-            keys.add((benchmark_id, case_id))
+    if isinstance(cases, list):
+        for case in cases:
+            if not isinstance(case, dict):
+                continue
+            benchmark_id = _compact_text(case.get("benchmark_id"), limit=160)
+            case_id = _compact_text(case.get("case_id"), limit=200)
+            if benchmark_id and case_id:
+                keys.add((benchmark_id, case_id))
+    coverage = analysis.get("terminal_bench_current_protocol_coverage")
+    if isinstance(coverage, dict) and isinstance(coverage.get("rows"), list):
+        for row in coverage["rows"]:
+            if not isinstance(row, dict):
+                continue
+            case_id = _compact_text(row.get("case_id"), limit=200)
+            if case_id:
+                keys.add(("terminal-bench@2.0", case_id))
     return keys
 
 


### PR DESCRIPTION
## Summary
- treat Terminal-Bench current-protocol coverage rows as represented case-analysis keys
- prevent generated-safe candidate scans from re-promoting coverage-only current-protocol rows into the main case-analysis candidate list
- add fixture coverage so the candidate smoke guards the represented-row boundary

## Validation
- python3 -m py_compile loopx/benchmark_case_analysis.py
- python3 examples/benchmark-case-analysis-candidates-smoke.py
- python3 examples/benchmark-case-analysis-smoke.py
- python3 scripts/benchmark_case_analysis_candidates.py --include-proposed-records --acceptance-policy generated-safe
- loopx check --scan-path loopx/benchmark_case_analysis.py --scan-path examples/benchmark-case-analysis-candidates-smoke.py
- git diff --check

Real asset preview after the fix: candidate_count=15, accepted_record_count=8. The previous four current-protocol coverage rows are no longer candidates. loopx check still reports the existing loopx-meta runtime index duplicate warning; public boundary scan for changed files is clean.