### PR TITLE
Apply accepted benchmark case-analysis records

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/benchmark-case-analysis.json
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-case-analysis.json
@@ -2751,6 +2751,324 @@
         "product_path_claim": "verified",
         "solver_uplift_claim": "not_claimable_extended_round_negative"
       }
+    },
+    {
+      "analysis_id": "terminal-bench-2-0__headless-terminal__paired-no-uplift-candidate",
+      "benchmark_id": "terminal-bench@2.0",
+      "case_id": "headless-terminal",
+      "classification": "generated_no_uplift_asset",
+      "decision": "paired_no_score_uplift",
+      "evidence_status": "generated_from_compact_benchmark_run_ledger",
+      "source_run_ids": [
+        "82872b12d3ba",
+        "c87b8f22c0b0",
+        "d8853f13e62c"
+      ],
+      "source_run_count": 5,
+      "capability_signal": "terminal-bench@2.0/headless-terminal has compact paired no-uplift evidence (paired_no_score_uplift); use it to adjust routing or treatment policy, not as a positive uplift claim.",
+      "control_plane_signal": "Generated as a P1 proposal from compact ledger metadata only. Recommended handling: promote when the no-uplift result changes routing, prompt, or treatment policy.",
+      "routing_guidance": {
+        "repeat_policy": "promote when the no-uplift result changes routing, prompt, or treatment policy"
+      },
+      "acceptance_policy": {
+        "schema_version": "benchmark_case_analysis_acceptance_policy_v0",
+        "policy": "generated-safe",
+        "accepted": true,
+        "status": "accepted_generated_not_applied",
+        "accepted_classification": "generated_no_uplift_asset",
+        "requires_manual_review": false,
+        "reason_codes": [
+          "generated_safe_policy_matched"
+        ]
+      },
+      "source_boundary": {
+        "inputs": [
+          "compact benchmark-run-ledger candidate",
+          "benchmark-case-analysis existing keys"
+        ],
+        "raw_logs_recorded": false,
+        "raw_task_text_recorded": false,
+        "trajectory_recorded": false,
+        "absolute_paths_recorded": false,
+        "generated_case_analysis": true
+      }
+    },
+    {
+      "analysis_id": "terminal-bench-2-0__build-cython-ext__baseline-solved-control-candidate",
+      "benchmark_id": "terminal-bench@2.0",
+      "case_id": "build-cython-ext",
+      "classification": "generated_baseline_solved_control_asset",
+      "decision": "baseline_passed_not_current_treatment_priority",
+      "evidence_status": "generated_from_compact_benchmark_run_ledger",
+      "source_run_ids": [
+        "84f5b6b69627",
+        "36cb8a6eabd8",
+        "80d729022ae6"
+      ],
+      "source_run_count": 11,
+      "capability_signal": "terminal-bench@2.0/build-cython-ext is a compact baseline-solved control (baseline_passed_not_current_treatment_priority); promote selectively for coverage or routing balance.",
+      "control_plane_signal": "Generated as a P2 proposal from compact ledger metadata only. Recommended handling: promote selectively as a baseline-solved control when the case is needed for routing or coverage.",
+      "routing_guidance": {
+        "repeat_policy": "promote selectively as a baseline-solved control when the case is needed for routing or coverage"
+      },
+      "acceptance_policy": {
+        "schema_version": "benchmark_case_analysis_acceptance_policy_v0",
+        "policy": "generated-safe",
+        "accepted": true,
+        "status": "accepted_generated_not_applied",
+        "accepted_classification": "generated_baseline_solved_control_asset",
+        "requires_manual_review": false,
+        "reason_codes": [
+          "generated_safe_policy_matched"
+        ]
+      },
+      "source_boundary": {
+        "inputs": [
+          "compact benchmark-run-ledger candidate",
+          "benchmark-case-analysis existing keys"
+        ],
+        "raw_logs_recorded": false,
+        "raw_task_text_recorded": false,
+        "trajectory_recorded": false,
+        "absolute_paths_recorded": false,
+        "generated_case_analysis": true
+      }
+    },
+    {
+      "analysis_id": "terminal-bench-2-0__compile-compcert__baseline-solved-control-candidate",
+      "benchmark_id": "terminal-bench@2.0",
+      "case_id": "compile-compcert",
+      "classification": "generated_baseline_solved_control_asset",
+      "decision": "baseline_passed_not_current_treatment_priority",
+      "evidence_status": "generated_from_compact_benchmark_run_ledger",
+      "source_run_ids": [
+        "1bbca3393341"
+      ],
+      "source_run_count": 1,
+      "capability_signal": "terminal-bench@2.0/compile-compcert is a compact baseline-solved control (baseline_passed_not_current_treatment_priority); promote selectively for coverage or routing balance.",
+      "control_plane_signal": "Generated as a P2 proposal from compact ledger metadata only. Recommended handling: promote selectively as a baseline-solved control when the case is needed for routing or coverage.",
+      "routing_guidance": {
+        "repeat_policy": "promote selectively as a baseline-solved control when the case is needed for routing or coverage"
+      },
+      "acceptance_policy": {
+        "schema_version": "benchmark_case_analysis_acceptance_policy_v0",
+        "policy": "generated-safe",
+        "accepted": true,
+        "status": "accepted_generated_not_applied",
+        "accepted_classification": "generated_baseline_solved_control_asset",
+        "requires_manual_review": false,
+        "reason_codes": [
+          "generated_safe_policy_matched"
+        ]
+      },
+      "source_boundary": {
+        "inputs": [
+          "compact benchmark-run-ledger candidate",
+          "benchmark-case-analysis existing keys"
+        ],
+        "raw_logs_recorded": false,
+        "raw_task_text_recorded": false,
+        "trajectory_recorded": false,
+        "absolute_paths_recorded": false,
+        "generated_case_analysis": true
+      }
+    },
+    {
+      "analysis_id": "terminal-bench-2-0__financial-document-processor__baseline-solved-control-candidate",
+      "benchmark_id": "terminal-bench@2.0",
+      "case_id": "financial-document-processor",
+      "classification": "generated_baseline_solved_control_asset",
+      "decision": "baseline_passed_not_current_treatment_priority",
+      "evidence_status": "generated_from_compact_benchmark_run_ledger",
+      "source_run_ids": [
+        "0e83bb674871",
+        "927c069179fe"
+      ],
+      "source_run_count": 2,
+      "capability_signal": "terminal-bench@2.0/financial-document-processor is a compact baseline-solved control (baseline_passed_not_current_treatment_priority); promote selectively for coverage or routing balance.",
+      "control_plane_signal": "Generated as a P2 proposal from compact ledger metadata only. Recommended handling: promote selectively as a baseline-solved control when the case is needed for routing or coverage.",
+      "routing_guidance": {
+        "repeat_policy": "promote selectively as a baseline-solved control when the case is needed for routing or coverage"
+      },
+      "acceptance_policy": {
+        "schema_version": "benchmark_case_analysis_acceptance_policy_v0",
+        "policy": "generated-safe",
+        "accepted": true,
+        "status": "accepted_generated_not_applied",
+        "accepted_classification": "generated_baseline_solved_control_asset",
+        "requires_manual_review": false,
+        "reason_codes": [
+          "generated_safe_policy_matched"
+        ]
+      },
+      "source_boundary": {
+        "inputs": [
+          "compact benchmark-run-ledger candidate",
+          "benchmark-case-analysis existing keys"
+        ],
+        "raw_logs_recorded": false,
+        "raw_task_text_recorded": false,
+        "trajectory_recorded": false,
+        "absolute_paths_recorded": false,
+        "generated_case_analysis": true
+      }
+    },
+    {
+      "analysis_id": "terminal-bench-2-0__fix-code-vulnerability__baseline-solved-control-candidate",
+      "benchmark_id": "terminal-bench@2.0",
+      "case_id": "fix-code-vulnerability",
+      "classification": "generated_baseline_solved_control_asset",
+      "decision": "baseline_passed_not_current_treatment_priority",
+      "evidence_status": "generated_from_compact_benchmark_run_ledger",
+      "source_run_ids": [
+        "f42efa143d52"
+      ],
+      "source_run_count": 1,
+      "capability_signal": "terminal-bench@2.0/fix-code-vulnerability is a compact baseline-solved control (baseline_passed_not_current_treatment_priority); promote selectively for coverage or routing balance.",
+      "control_plane_signal": "Generated as a P2 proposal from compact ledger metadata only. Recommended handling: promote selectively as a baseline-solved control when the case is needed for routing or coverage.",
+      "routing_guidance": {
+        "repeat_policy": "promote selectively as a baseline-solved control when the case is needed for routing or coverage"
+      },
+      "acceptance_policy": {
+        "schema_version": "benchmark_case_analysis_acceptance_policy_v0",
+        "policy": "generated-safe",
+        "accepted": true,
+        "status": "accepted_generated_not_applied",
+        "accepted_classification": "generated_baseline_solved_control_asset",
+        "requires_manual_review": false,
+        "reason_codes": [
+          "generated_safe_policy_matched"
+        ]
+      },
+      "source_boundary": {
+        "inputs": [
+          "compact benchmark-run-ledger candidate",
+          "benchmark-case-analysis existing keys"
+        ],
+        "raw_logs_recorded": false,
+        "raw_task_text_recorded": false,
+        "trajectory_recorded": false,
+        "absolute_paths_recorded": false,
+        "generated_case_analysis": true
+      }
+    },
+    {
+      "analysis_id": "terminal-bench-2-0__merge-diff-arc-agi-task__baseline-solved-control-candidate",
+      "benchmark_id": "terminal-bench@2.0",
+      "case_id": "merge-diff-arc-agi-task",
+      "classification": "generated_baseline_solved_control_asset",
+      "decision": "baseline_passed_not_current_treatment_priority",
+      "evidence_status": "generated_from_compact_benchmark_run_ledger",
+      "source_run_ids": [
+        "9ca514c170e6"
+      ],
+      "source_run_count": 1,
+      "capability_signal": "terminal-bench@2.0/merge-diff-arc-agi-task is a compact baseline-solved control (baseline_passed_not_current_treatment_priority); promote selectively for coverage or routing balance.",
+      "control_plane_signal": "Generated as a P2 proposal from compact ledger metadata only. Recommended handling: promote selectively as a baseline-solved control when the case is needed for routing or coverage.",
+      "routing_guidance": {
+        "repeat_policy": "promote selectively as a baseline-solved control when the case is needed for routing or coverage"
+      },
+      "acceptance_policy": {
+        "schema_version": "benchmark_case_analysis_acceptance_policy_v0",
+        "policy": "generated-safe",
+        "accepted": true,
+        "status": "accepted_generated_not_applied",
+        "accepted_classification": "generated_baseline_solved_control_asset",
+        "requires_manual_review": false,
+        "reason_codes": [
+          "generated_safe_policy_matched"
+        ]
+      },
+      "source_boundary": {
+        "inputs": [
+          "compact benchmark-run-ledger candidate",
+          "benchmark-case-analysis existing keys"
+        ],
+        "raw_logs_recorded": false,
+        "raw_task_text_recorded": false,
+        "trajectory_recorded": false,
+        "absolute_paths_recorded": false,
+        "generated_case_analysis": true
+      }
+    },
+    {
+      "analysis_id": "terminal-bench-2-0__path-tracing__baseline-solved-control-candidate",
+      "benchmark_id": "terminal-bench@2.0",
+      "case_id": "path-tracing",
+      "classification": "generated_baseline_solved_control_asset",
+      "decision": "baseline_passed_not_current_treatment_priority",
+      "evidence_status": "generated_from_compact_benchmark_run_ledger",
+      "source_run_ids": [
+        "7e22b45c6fac",
+        "e5f6ebd42244"
+      ],
+      "source_run_count": 2,
+      "capability_signal": "terminal-bench@2.0/path-tracing is a compact baseline-solved control (baseline_passed_not_current_treatment_priority); promote selectively for coverage or routing balance.",
+      "control_plane_signal": "Generated as a P2 proposal from compact ledger metadata only. Recommended handling: promote selectively as a baseline-solved control when the case is needed for routing or coverage.",
+      "routing_guidance": {
+        "repeat_policy": "promote selectively as a baseline-solved control when the case is needed for routing or coverage"
+      },
+      "acceptance_policy": {
+        "schema_version": "benchmark_case_analysis_acceptance_policy_v0",
+        "policy": "generated-safe",
+        "accepted": true,
+        "status": "accepted_generated_not_applied",
+        "accepted_classification": "generated_baseline_solved_control_asset",
+        "requires_manual_review": false,
+        "reason_codes": [
+          "generated_safe_policy_matched"
+        ]
+      },
+      "source_boundary": {
+        "inputs": [
+          "compact benchmark-run-ledger candidate",
+          "benchmark-case-analysis existing keys"
+        ],
+        "raw_logs_recorded": false,
+        "raw_task_text_recorded": false,
+        "trajectory_recorded": false,
+        "absolute_paths_recorded": false,
+        "generated_case_analysis": true
+      }
+    },
+    {
+      "analysis_id": "terminal-bench-2-0__sqlite-db-truncate__baseline-solved-control-candidate",
+      "benchmark_id": "terminal-bench@2.0",
+      "case_id": "sqlite-db-truncate",
+      "classification": "generated_baseline_solved_control_asset",
+      "decision": "baseline_passed_not_current_treatment_priority",
+      "evidence_status": "generated_from_compact_benchmark_run_ledger",
+      "source_run_ids": [
+        "acee75707a05"
+      ],
+      "source_run_count": 1,
+      "capability_signal": "terminal-bench@2.0/sqlite-db-truncate is a compact baseline-solved control (baseline_passed_not_current_treatment_priority); promote selectively for coverage or routing balance.",
+      "control_plane_signal": "Generated as a P2 proposal from compact ledger metadata only. Recommended handling: promote selectively as a baseline-solved control when the case is needed for routing or coverage.",
+      "routing_guidance": {
+        "repeat_policy": "promote selectively as a baseline-solved control when the case is needed for routing or coverage"
+      },
+      "acceptance_policy": {
+        "schema_version": "benchmark_case_analysis_acceptance_policy_v0",
+        "policy": "generated-safe",
+        "accepted": true,
+        "status": "accepted_generated_not_applied",
+        "accepted_classification": "generated_baseline_solved_control_asset",
+        "requires_manual_review": false,
+        "reason_codes": [
+          "generated_safe_policy_matched"
+        ]
+      },
+      "source_boundary": {
+        "inputs": [
+          "compact benchmark-run-ledger candidate",
+          "benchmark-case-analysis existing keys"
+        ],
+        "raw_logs_recorded": false,
+        "raw_task_text_recorded": false,
+        "trajectory_recorded": false,
+        "absolute_paths_recorded": false,
+        "generated_case_analysis": true
+      }
     }
   ],
   "schema_version": "benchmark_case_analysis_v0",
@@ -3456,7 +3774,7 @@
     "trajectory_recorded": false,
     "update_rule": "add one case analysis record after compact result ingest and benchmark-run-ledger update"
   },
-  "updated_at": "2026-06-22T06:08:33+08:00",
+  "updated_at": "2026-06-22T15:01:06+08:00",
   "terminal_bench_current_protocol_coverage": {
     "schema_version": "terminal_bench_current_protocol_coverage_v0",
     "source_ledger": "benchmark-run-ledger.json",

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-case-analysis.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-case-analysis.md
@@ -7,7 +7,7 @@ It is intentionally separate from `benchmark-run-ledger.md`. The run ledger
 records compact attempts and scores; this file records why a result matters.
 
 - schema_version: `benchmark_case_analysis_v0`
-- updated_at: `2026-06-22T06:08:33+08:00`
+- updated_at: `2026-06-22T15:01:06+08:00`
 - machine_source: `benchmark-case-analysis.json`
 - ledger-only migration audit:
   `benchmark-case-analysis-ledger-only-migration-audit-20260618.md`
@@ -28,6 +28,12 @@ current-protocol coverage rows; the remainder are setup/probe/defer rows that
 should not be promoted into main case analysis until compact score or blocker
 evidence becomes useful.
 
+The 2026-06-22 generated-safe upsert promoted eight compact-ledger records into
+the machine JSON and human table: one Terminal-Bench no-uplift row and seven
+baseline-solved control rows. It still leaves infrastructure-alignment,
+baseline-failure, setup, and single-arm candidates outside automatic promotion
+until matched treatment or manual attribution exists.
+
 | Benchmark | Case | Class | Baseline | Treatment | Delta | Decision |
 | --- | --- | --- | --- | --- | --- | --- |
 | `terminal-bench@2.0` | `multi-source-data-merger` | current-protocol baseline-solved / legacy positive asset | `1.0` | `1.0` | `0.0` | `paired_baseline_solved_treatment_preserved` |
@@ -36,6 +42,14 @@ evidence becomes useful.
 | `terminal-bench@2.0` | `mteb-retrieve` | setup probe asset | `0.0` | `0.0` | `0.0` | `environment_setup_probe_materialized_with_exception_repeat_blocked` |
 | `terminal-bench@2.0` | `pytorch-model-recovery` | exception attribution asset | `0.0` | `0.0` | `0.0` | `paired_no_score_uplift_exception_research_required` |
 | `terminal-bench@2.0` | `train-fasttext` | single-arm managed-Codex failure asset | n/a | `0.0` | n/a | `single_arm_recorded` |
+| `terminal-bench@2.0` | `headless-terminal` | generated no-uplift asset | `0.0` | `0.0` | `0.0` | `paired_no_score_uplift` |
+| `terminal-bench@2.0` | `build-cython-ext` | generated baseline-solved control asset | `1.0` | n/a | n/a | `baseline_passed_not_current_treatment_priority` |
+| `terminal-bench@2.0` | `compile-compcert` | generated baseline-solved control asset | `1.0` | n/a | n/a | `baseline_passed_not_current_treatment_priority` |
+| `terminal-bench@2.0` | `financial-document-processor` | generated baseline-solved control asset | `1.0` | n/a | n/a | `baseline_passed_not_current_treatment_priority` |
+| `terminal-bench@2.0` | `fix-code-vulnerability` | generated baseline-solved control asset | `1.0` | n/a | n/a | `baseline_passed_not_current_treatment_priority` |
+| `terminal-bench@2.0` | `merge-diff-arc-agi-task` | generated baseline-solved control asset | `1.0` | n/a | n/a | `baseline_passed_not_current_treatment_priority` |
+| `terminal-bench@2.0` | `path-tracing` | generated baseline-solved control asset | `1.0` | n/a | n/a | `baseline_passed_not_current_treatment_priority` |
+| `terminal-bench@2.0` | `sqlite-db-truncate` | generated baseline-solved control asset | `1.0` | n/a | n/a | `baseline_passed_not_current_treatment_priority` |
 | `swe-marathon` | `zstd-decoder` | extended-round product-path negative asset | `1.0` | `0.0` | `-1.0` | `paired_treatment_regressed` |
 | `skillsbench@1.1` | `llm-prefix-cache-replay` | reward-feedback positive / blind-loop neutral asset | `0.0` | `0.0` | `0.0` | `reward_feedback_positive_primary_blind_loop_no_uplift` |
 | `skillsbench@1.1` | `tictoc-unnecessary-abort-detection` | native Goal connected-no-trace runner-error asset | `0.0` | n/a | n/a | `baseline_runner_or_setup_repair_required` |


### PR DESCRIPTION
## Summary
- apply 8 generated-safe compact-ledger records into benchmark-case-analysis JSON
- mirror those records in the human Markdown summary table
- leave remaining non-generated-safe candidates as proposals only

## Validation
- python3 examples/benchmark-case-analysis-smoke.py
- python3 examples/benchmark-case-analysis-candidates-smoke.py
- python3 scripts/benchmark_case_analysis_candidates.py --include-proposed-records --acceptance-policy generated-safe
- loopx check --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-case-analysis.json --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-case-analysis.md
- git diff --check

Boundary: public docs/data only; no raw logs, task text, trajectories, credentials, local absolute paths, or runner/scoring changes.