### PR TITLE
Add benchmark case-analysis markdown renderer

### DIFF
--- a/examples/benchmark-case-analysis-candidates-smoke.py
+++ b/examples/benchmark-case-analysis-candidates-smoke.py
@@ -20,6 +20,7 @@ from loopx.benchmark_case_analysis import (  # noqa: E402
     apply_accepted_case_analysis_records,
     build_case_analysis_candidate_report,
     build_case_analysis_upsert_proposals,
+    render_case_analysis_markdown,
     render_case_analysis_candidate_report_markdown,
 )
 
@@ -207,7 +208,17 @@ def test_generated_safe_acceptance_policy_from_fixture() -> None:
         "generated_from_compact_benchmark_run_ledger"
     ), generated
     assert generated["source_boundary"]["raw_logs_recorded"] is False, generated
+    markdown = render_case_analysis_markdown(
+        result["analysis"],
+        existing_markdown="old generated header\n\n## Treatment Policy Control Set\n\nkeep me\n",
+    )
+    assert "new-no-uplift" in markdown, markdown
+    assert "generated no-uplift asset" in markdown, markdown
+    assert "new-baseline-pass" in markdown, markdown
+    assert "generated baseline-solved control asset" in markdown, markdown
+    assert "## Treatment Policy Control Set" in markdown and "keep me" in markdown
     assert_public_safe(json.dumps(result["analysis"], ensure_ascii=False))
+    assert_public_safe(markdown)
 
 
 def test_candidate_cli_on_fixture() -> None:
@@ -268,6 +279,11 @@ def test_candidate_cli_on_fixture() -> None:
         ), proposal_report
         assert_public_safe(proposals_output)
         accepted_output = root / "accepted-analysis.json"
+        accepted_markdown = root / "accepted-analysis.md"
+        (root / "analysis.md").write_text(
+            "old generated header\n\n## Treatment Policy Control Set\n\npreserve-details\n",
+            encoding="utf-8",
+        )
         accepted_report_output = subprocess.check_output(
             [
                 sys.executable,
@@ -281,6 +297,8 @@ def test_candidate_cli_on_fixture() -> None:
                 "--apply-accepted",
                 "--output-analysis",
                 str(accepted_output),
+                "--output-markdown",
+                str(accepted_markdown),
             ],
             text=True,
         )
@@ -289,13 +307,24 @@ def test_candidate_cli_on_fixture() -> None:
         assert accepted_report["accepted_upsert"]["added_count"] == 2, (
             accepted_report
         )
+        assert accepted_report["accepted_upsert"]["markdown_written"] is True, (
+            accepted_report
+        )
         accepted_analysis = json.loads(accepted_output.read_text(encoding="utf-8"))
+        assert accepted_output.read_text(encoding="utf-8").lstrip().startswith(
+            '{\n  "schema_version"'
+        ), accepted_output.read_text(encoding="utf-8")[:120]
         accepted_cases = {
             (case["benchmark_id"], case["case_id"])
             for case in accepted_analysis["cases"]
         }
         assert ("bench@v1", "new-no-uplift") in accepted_cases, accepted_analysis
+        accepted_markdown_text = accepted_markdown.read_text(encoding="utf-8")
+        assert "new-no-uplift" in accepted_markdown_text, accepted_markdown_text
+        assert "new-baseline-pass" in accepted_markdown_text, accepted_markdown_text
+        assert "preserve-details" in accepted_markdown_text, accepted_markdown_text
         assert_public_safe(accepted_report_output)
+        assert_public_safe(accepted_markdown_text)
 
 
 def test_loopx_benchmark_cli_on_fixture() -> None:
@@ -354,6 +383,11 @@ def test_loopx_benchmark_cli_on_fixture() -> None:
         ] == "proposal_only_not_applied", proposals_payload
         assert_public_safe(proposals_output)
         accepted_output = root / "accepted-loopx-analysis.json"
+        accepted_markdown = root / "accepted-loopx-analysis.md"
+        analysis_path.with_suffix(".md").write_text(
+            "old generated header\n\n## Treatment Policy Control Set\n\ncli-preserve-details\n",
+            encoding="utf-8",
+        )
         accepted_payload_output = subprocess.check_output(
             [
                 str(REPO_ROOT / "scripts" / "loopx"),
@@ -370,6 +404,8 @@ def test_loopx_benchmark_cli_on_fixture() -> None:
                 "--apply-accepted",
                 "--output-case-analysis-path",
                 str(accepted_output),
+                "--output-case-analysis-markdown-path",
+                str(accepted_markdown),
             ],
             text=True,
         )
@@ -381,8 +417,16 @@ def test_loopx_benchmark_cli_on_fixture() -> None:
         assert accepted_payload["accepted_upsert"]["added_count"] == 2, (
             accepted_payload
         )
+        assert accepted_payload["accepted_upsert"]["markdown_written"] is True, (
+            accepted_payload
+        )
         assert accepted_output.exists(), accepted_payload
+        assert accepted_markdown.exists(), accepted_payload
+        accepted_markdown_text = accepted_markdown.read_text(encoding="utf-8")
+        assert "new-no-uplift" in accepted_markdown_text, accepted_markdown_text
+        assert "cli-preserve-details" in accepted_markdown_text, accepted_markdown_text
         assert_public_safe(accepted_payload_output)
+        assert_public_safe(accepted_markdown_text)
         markdown = subprocess.check_output(
             [
                 str(REPO_ROOT / "scripts" / "loopx"),

--- a/loopx/benchmark_case_analysis.py
+++ b/loopx/benchmark_case_analysis.py
@@ -25,6 +25,23 @@ GENERATED_SAFE_ACCEPTED_CLASSES = {
     ),
     "baseline_solved_control_candidate": "generated_baseline_solved_control_asset",
 }
+CASE_ANALYSIS_DETAIL_START_HEADING = "## Treatment Policy Control Set"
+CASE_ANALYSIS_CLASS_LABELS = {
+    "baseline_solved_non_regression_asset": (
+        "current-protocol baseline-solved / non-regression asset"
+    ),
+    "generated_baseline_solved_control_asset": (
+        "generated baseline-solved control asset"
+    ),
+    "generated_baseline_solved_non_regression_asset": (
+        "generated baseline-solved non-regression asset"
+    ),
+    "generated_no_uplift_asset": "generated no-uplift asset",
+    "no_uplift_asset": "no-uplift asset",
+    "positive_uplift_asset": "positive uplift asset",
+    "regression_asset": "regression asset",
+    "setup_blocker_asset": "setup blocker asset",
+}
 
 
 def load_json(path: str | Path) -> dict[str, Any]:
@@ -470,6 +487,184 @@ def apply_accepted_case_analysis_records(
         "added_records": added_records,
         "skipped_records": skipped_records,
     }
+
+
+def _case_analysis_class_label(case: dict[str, Any]) -> str:
+    classification = _compact_text(case.get("classification"), limit=180)
+    if not classification:
+        return "case-analysis asset"
+    if classification in CASE_ANALYSIS_CLASS_LABELS:
+        return CASE_ANALYSIS_CLASS_LABELS[classification]
+    return classification.replace("_", " ")
+
+
+def _case_analysis_score_triplet(case: dict[str, Any]) -> tuple[object, object, object]:
+    scores = case.get("scores") if isinstance(case.get("scores"), dict) else {}
+    baseline = scores.get("baseline_official_score")
+    treatment = scores.get("treatment_official_score")
+    delta = scores.get("official_score_delta")
+    decision = _compact_text(case.get("decision"), limit=180)
+    classification = _compact_text(case.get("classification"), limit=180)
+    if baseline is None and treatment is None and delta is None:
+        if decision == "paired_no_score_uplift":
+            return 0.0, 0.0, 0.0
+        if decision == "baseline_passed_not_current_treatment_priority":
+            return 1.0, None, None
+        if "setup" in classification or "runner" in decision:
+            return "missing", None, None
+    return baseline, treatment, delta
+
+
+def _markdown_table_value(value: object) -> str:
+    if value is None or value == "":
+        return "n/a"
+    text = _compact_text(value, limit=120)
+    return f"`{text}`"
+
+
+def _markdown_escape_cell(value: object) -> str:
+    return _compact_text(value, limit=240).replace("|", "\\|")
+
+
+def _render_case_analysis_summary_table(analysis: dict[str, Any]) -> list[str]:
+    lines = [
+        "| Benchmark | Case | Class | Baseline | Treatment | Delta | Decision |",
+        "| --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    cases = analysis.get("cases")
+    if not isinstance(cases, list):
+        return lines
+    for case in cases:
+        if not isinstance(case, dict):
+            continue
+        baseline, treatment, delta = _case_analysis_score_triplet(case)
+        lines.append(
+            "| "
+            f"`{_markdown_escape_cell(case.get('benchmark_id'))}` | "
+            f"`{_markdown_escape_cell(case.get('case_id'))}` | "
+            f"{_markdown_escape_cell(_case_analysis_class_label(case))} | "
+            f"{_markdown_table_value(baseline)} | "
+            f"{_markdown_table_value(treatment)} | "
+            f"{_markdown_table_value(delta)} | "
+            f"`{_markdown_escape_cell(case.get('decision'))}` |"
+        )
+    return lines
+
+
+def _render_terminal_bench_current_protocol_coverage(
+    analysis: dict[str, Any],
+) -> list[str]:
+    coverage = analysis.get("terminal_bench_current_protocol_coverage")
+    if not isinstance(coverage, dict):
+        return []
+    rows = coverage.get("rows")
+    if not isinstance(rows, list):
+        return []
+    lines = [
+        "## Terminal-Bench Current-Protocol Coverage",
+        "",
+        "These rows are generated from the latest compact ledger decisions. They are",
+        "current-protocol success-preservation guards: both baseline and treatment",
+        "score `1.0`, so none of them should be counted as current uplift.",
+        "",
+        "| Case | Baseline | Treatment | Delta | Role | Case Analysis Status |",
+        "| --- | --- | --- | --- | --- | --- |",
+    ]
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        baseline = row.get("baseline_official_score")
+        treatment = row.get("treatment_official_score")
+        delta = row.get("official_score_delta")
+        baseline_run = _compact_text(row.get("baseline_run_id"), limit=40)
+        treatment_run = _compact_text(row.get("treatment_run_id"), limit=40)
+        lines.append(
+            "| "
+            f"`{_markdown_escape_cell(row.get('case_id'))}` | "
+            f"`{baseline}` (`{baseline_run}`) | "
+            f"`{treatment}` (`{treatment_run}`) | "
+            f"`{delta}` | "
+            f"`{_markdown_escape_cell(row.get('main_table_role'))}` | "
+            f"`{_markdown_escape_cell(row.get('case_analysis_status'))}` |"
+        )
+    return lines
+
+
+def _preserved_case_analysis_detail(existing_markdown: str | None) -> str:
+    if not existing_markdown:
+        return (
+            "## Boundary\n\n"
+            "This file records only compact public-safe evidence. It does not copy "
+            "raw logs, task prompts, trajectories, credentials, hidden tests, "
+            "uploads, or absolute local paths.\n"
+        )
+    marker = f"\n{CASE_ANALYSIS_DETAIL_START_HEADING}"
+    start = existing_markdown.find(marker)
+    if start >= 0:
+        return existing_markdown[start + 1 :].strip() + "\n"
+    if existing_markdown.startswith(CASE_ANALYSIS_DETAIL_START_HEADING):
+        return existing_markdown.strip() + "\n"
+    return (
+        "## Boundary\n\n"
+        "This file records only compact public-safe evidence. It does not copy "
+        "raw logs, task prompts, trajectories, credentials, hidden tests, "
+        "uploads, or absolute local paths.\n"
+    )
+
+
+def render_case_analysis_markdown(
+    analysis: dict[str, Any],
+    *,
+    existing_markdown: str | None = None,
+) -> str:
+    """Render the generated case-analysis summary while preserving deep notes."""
+    cases = analysis.get("cases")
+    case_count = len(cases) if isinstance(cases, list) else 0
+    generated_count = (
+        sum(
+            1
+            for case in cases
+            if isinstance(case, dict)
+            and _compact_text(case.get("classification"), limit=180).startswith(
+                "generated_"
+            )
+        )
+        if isinstance(cases, list)
+        else 0
+    )
+    lines = [
+        "# Benchmark Case Analysis",
+        "",
+        "This file is the human view of `benchmark_case_analysis_v0`. It records durable",
+        "case lessons that should guide benchmark routing, treatment design, and claims.",
+        "",
+        "It is intentionally separate from `benchmark-run-ledger.md`. The run ledger",
+        "records compact attempts and scores; this file records why a result matters.",
+        "",
+        f"- schema_version: `{analysis.get('schema_version')}`",
+        f"- updated_at: `{analysis.get('updated_at')}`",
+        "- machine_source: `benchmark-case-analysis.json`",
+        "- ledger-only migration audit:",
+        "  `benchmark-case-analysis-ledger-only-migration-audit-20260618.md`",
+        "",
+        "## Summary",
+        "",
+        "The table below is generated from compact public case-analysis JSON. It uses",
+        "`n/a` when the compact record does not establish a comparable paired arm,",
+        "and it preserves detailed hand-authored case notes below the generated",
+        "summary sections.",
+        "",
+        f"- case_count: `{case_count}`",
+        f"- generated_compact_record_count: `{generated_count}`",
+        "",
+    ]
+    lines.extend(_render_case_analysis_summary_table(analysis))
+    coverage_lines = _render_terminal_bench_current_protocol_coverage(analysis)
+    if coverage_lines:
+        lines.extend(["", *coverage_lines])
+    detail = _preserved_case_analysis_detail(existing_markdown)
+    lines.extend(["", detail.strip()])
+    return "\n".join(lines).rstrip() + "\n"
 
 
 def find_case_analysis_candidates(

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -128,6 +128,7 @@ from .benchmark_case_analysis import (
     apply_accepted_case_analysis_records,
     build_case_analysis_candidate_report,
     load_json as load_benchmark_case_analysis_json,
+    render_case_analysis_markdown,
     render_case_analysis_candidate_report_markdown,
 )
 from .benchmark_core import (
@@ -694,6 +695,15 @@ def render_benchmark_case_analysis_candidates_markdown(
             + f"- raw logs read: `{read_boundary.get('raw_logs_read')}`\n"
             + f"- task text read: `{read_boundary.get('task_text_read')}`\n"
             + f"- trajectory read: `{read_boundary.get('trajectory_read')}`\n"
+            + (
+                "\n## Accepted Upsert\n\n"
+                f"- output_written: `{payload['accepted_upsert'].get('output_written')}`\n"
+                f"- markdown_written: `{payload['accepted_upsert'].get('markdown_written')}`\n"
+                f"- added_count: `{payload['accepted_upsert'].get('added_count')}`\n"
+                f"- skipped_count: `{payload['accepted_upsert'].get('skipped_count')}`\n"
+                if isinstance(payload.get("accepted_upsert"), dict)
+                else ""
+            )
         )
     lines = [
         "# Benchmark Case-Analysis Candidates",
@@ -3521,6 +3531,15 @@ def main(argv: list[str] | None = None) -> int:
         "--output-case-analysis-path",
         default=None,
         help="Output path for --apply-accepted. Required when applying.",
+    )
+    benchmark_case_analysis_candidates_parser.add_argument(
+        "--output-case-analysis-markdown-path",
+        default=None,
+        help=(
+            "Optional Markdown output path for --apply-accepted. The generated "
+            "summary/table is refreshed from compact JSON and existing deep "
+            "case notes are preserved when available."
+        ),
     )
 
     agentissue_runner_flow_parser = benchmark_sub.add_parser(
@@ -9145,13 +9164,37 @@ def main(argv: list[str] | None = None) -> int:
                             result["analysis"],
                             ensure_ascii=False,
                             indent=2,
-                            sort_keys=True,
                         )
                         + "\n",
                         encoding="utf-8",
                     )
+                    markdown_written = False
+                    if args.output_case_analysis_markdown_path:
+                        markdown_path = Path(args.output_case_analysis_markdown_path)
+                        existing_markdown = None
+                        if markdown_path.exists():
+                            existing_markdown = markdown_path.read_text(
+                                encoding="utf-8"
+                            )
+                        else:
+                            default_markdown_path = Path(
+                                args.case_analysis_path
+                            ).with_suffix(".md")
+                            if default_markdown_path.exists():
+                                existing_markdown = default_markdown_path.read_text(
+                                    encoding="utf-8"
+                                )
+                        markdown_path.write_text(
+                            render_case_analysis_markdown(
+                                result["analysis"],
+                                existing_markdown=existing_markdown,
+                            ),
+                            encoding="utf-8",
+                        )
+                        markdown_written = True
                     payload["accepted_upsert"] = {
                         "output_written": True,
+                        "markdown_written": markdown_written,
                         "added_count": result["added_count"],
                         "skipped_count": result["skipped_count"],
                     }

--- a/scripts/benchmark_case_analysis_candidates.py
+++ b/scripts/benchmark_case_analysis_candidates.py
@@ -16,6 +16,7 @@ from loopx.benchmark_case_analysis import (  # noqa: E402
     apply_accepted_case_analysis_records,
     build_case_analysis_candidate_report,
     load_json,
+    render_case_analysis_markdown,
     render_case_analysis_candidate_report_markdown,
 )
 
@@ -80,6 +81,16 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Output path for --apply-accepted. Required when applying.",
     )
+    parser.add_argument(
+        "--output-markdown",
+        type=Path,
+        default=None,
+        help=(
+            "Optional Markdown output path for --apply-accepted. The generated "
+            "summary/table is refreshed from compact JSON and existing deep "
+            "case notes are preserved when available."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -109,13 +120,30 @@ def main() -> int:
                 result["analysis"],
                 ensure_ascii=False,
                 indent=2,
-                sort_keys=True,
             )
             + "\n",
             encoding="utf-8",
         )
+        markdown_written = False
+        if args.output_markdown is not None:
+            existing_markdown = None
+            if args.output_markdown.exists():
+                existing_markdown = args.output_markdown.read_text(encoding="utf-8")
+            elif args.analysis.with_suffix(".md").exists():
+                existing_markdown = args.analysis.with_suffix(".md").read_text(
+                    encoding="utf-8"
+                )
+            args.output_markdown.write_text(
+                render_case_analysis_markdown(
+                    result["analysis"],
+                    existing_markdown=existing_markdown,
+                ),
+                encoding="utf-8",
+            )
+            markdown_written = True
         report["accepted_upsert"] = {
             "output_written": True,
+            "markdown_written": markdown_written,
             "added_count": result["added_count"],
             "skipped_count": result["skipped_count"],
         }


### PR DESCRIPTION
## Summary
- add a public-safe benchmark case-analysis Markdown renderer that regenerates the summary/table from compact JSON while preserving deep case notes
- let script and LoopX CLI apply paths optionally write Markdown alongside JSON
- preserve JSON key order on accepted upsert output to avoid noisy full-file diffs

## Validation
- python3 -m py_compile loopx/benchmark_case_analysis.py loopx/cli.py scripts/benchmark_case_analysis_candidates.py examples/benchmark-case-analysis-candidates-smoke.py
- python3 examples/benchmark-case-analysis-candidates-smoke.py
- python3 examples/benchmark-case-analysis-smoke.py
- real-asset temporary apply with --output-markdown plus loopx check on generated JSON/MD
- scripts/loopx --format json benchmark case-analysis-candidates --acceptance-policy generated-safe --apply-accepted --output-case-analysis-path <tmp> --output-case-analysis-markdown-path <tmp>
- loopx check on changed files
- git diff --check

Boundary: no benchmark launch, no scoring changes, no raw logs/task text/trajectories, no credentials, and no local private paths in committed artifacts.