### PR TITLE
Define bounded derived state contract

### DIFF
--- a/docs/field-derived-patterns.md
+++ b/docs/field-derived-patterns.md
@@ -73,8 +73,8 @@ with a deprecated or archived source.
 The same pattern applies outside documentation-heavy agent repositories. A
 platform migration or product integration goal often has several material
 classes at once: design docs, owner review notes, target and source
-repositories, migration checklists, dashboards, and validation records. Goal
-Harness should compact those into a public-safe material registry: expose roles,
+repositories, migration checklists, dashboards, and validation records. LoopX
+should compact those into a public-safe material registry: expose roles,
 freshness, missing owner evidence, and next action, while keeping private URLs,
 repository paths, product configs, and raw review text in project-local payloads.
 This lets a new project agent know which sources are current without flooding
@@ -114,7 +114,32 @@ read-only-map summaries:
 This makes state refreshes useful. A state-only update is not a log entry; it is
 a new current-belief surface for the next agent tick and dashboard.
 
-## 3. Managed External-Source Manifest
+## 3. Bounded Derived State Inheritance
+
+LoopX may derive state from structured sources such as active-state Markdown,
+todo metadata comments, authority registries, JSON run records, and AST/source
+inspections. Derived state is useful only when it stays smaller and more
+auditable than the material it summarizes.
+
+A derived-state surface should declare:
+
+- canonical source: the structured field, file, or command that can reconstruct
+  the full view;
+- inheritance rule: which source fields are copied, compacted, or deliberately
+  dropped;
+- item limits: top-N counts for hot paths, plus a cold path for the full list;
+- archive/prune rule: when old completed or superseded state must leave the
+  active projection;
+- projection semantics: whether status, quota, dashboard, or review packets may
+  schedule from the derived view or only display it.
+
+Model-created state must not become a second source of truth. If an agent
+summarizes todos, benchmark cases, experiments, or authority sources, that
+summary should either point back to a parseable source or be written through a
+LoopX command that adds structured metadata. Unbounded lists belong behind
+detail pointers, not in heartbeat payloads or first-screen status.
+
+## 4. Managed External-Source Manifest
 
 Many real projects depend on external documents, review surfaces, or product
 discussion artifacts. They should not be treated as ordinary links.
@@ -140,7 +165,7 @@ This pattern prevents two common failures:
   cleaner;
 - letting a stale local note become the current project authority.
 
-## 4. Validation Surface Map
+## 5. Validation Surface Map
 
 Complex projects rarely have one validation command. Progress may be proven by
 different surfaces:
@@ -158,7 +183,7 @@ LoopX should require each complex-project map to name validation
 surfaces before proposing implementation work. This lets the dashboard show
 "ready for Codex" only when the next action has a credible verification path.
 
-## 5. Experiment Board
+## 6. Experiment Board
 
 Long-window experiment projects need an experiment board, not only a run log.
 The board should separate:
@@ -195,7 +220,7 @@ Adapters should surface `waiting_on=external_evidence` until the decisive
 evidence is comparable. Human reward or decision advice should not be inferred
 from training-only guardrails.
 
-## 6. Gate Order
+## 7. Gate Order
 
 Several field failures become simpler if LoopX applies gates in a stable
 order:
@@ -210,7 +235,7 @@ Compute quota decides how much automatic agent time a goal may consume. It does
 not authorize writes, production actions, or route decisions. Operator gates
 and human reward remain separate durable events.
 
-## 7. Handoff Packet
+## 8. Handoff Packet
 
 A good handoff packet is short enough to forward, but precise enough to avoid
 re-discovery. It should include:
@@ -225,11 +250,11 @@ re-discovery. It should include:
 - the exact condition that would allow the next stage.
 
 It should not include raw private evidence. It should also not pretend to be
-user approval. If a project agent needs permission to cross a gate, Goal
-Harness should record an `operator_gate_*` run before the command becomes
+user approval. If a project agent needs permission to cross a gate, LoopX
+should record an `operator_gate_*` run before the command becomes
 Codex-ready.
 
-## 8. Parallel Work Claims
+## 9. Parallel Work Claims
 
 Large projects often need several agents, but parallelism only works when
 claims are explicit:
@@ -245,7 +270,7 @@ claims are explicit:
 LoopX should record these as proposed sub-agent scopes in read-only
 maps, then let the controller accept, edit, or reject them.
 
-## 9. Anti-Patterns To Block
+## 10. Anti-Patterns To Block
 
 LoopX should actively prevent these patterns:
 

--- a/examples/derived-state-boundary-smoke.py
+++ b/examples/derived-state-boundary-smoke.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Smoke-test that derived state projections stay bounded and reconstructable."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.status import (  # noqa: E402
+    MAX_PROJECT_ASSET_TODO_BACKLOG_ITEMS,
+    MAX_PROJECT_ASSET_TODO_ITEMS,
+    MAX_STATUS_TODOS_PER_ROLE,
+    MAX_TODO_VISIBILITY_LANE_ITEMS,
+    TODO_PROJECTION_DETAIL_POINTER_SCHEMA_VERSION,
+    TODO_PROJECTION_VIEW_SCHEMA_VERSION,
+    completed_todo_archive_warning,
+    parse_active_state_todos,
+    project_asset_todo_summary,
+)
+
+
+def build_active_state() -> str:
+    open_lines: list[str] = []
+    claimants = ("codex-main-control", "codex-side-bypass", "codex-review")
+    for index in range(1, 31):
+        claimant = claimants[index % len(claimants)] if index <= 24 else ""
+        metadata = (
+            f"  <!-- loopx:todo todo_id=todo_derived_{index:02d} "
+            "status=open task_class=advancement_task "
+            f"action_kind=derived_state_fixture_{index:02d}"
+        )
+        if claimant:
+            metadata += f" claimed_by={claimant}"
+        metadata += " -->"
+        open_lines.append(f"- [ ] [P1] Derived projection candidate {index:02d}.")
+        open_lines.append(metadata)
+
+    done_lines = [
+        (
+            f"- [x] [P2] Completed derived projection history {index:02d}.\n"
+            f"  <!-- loopx:todo todo_id=todo_done_{index:02d} "
+            "status=done task_class=advancement_task -->"
+        )
+        for index in range(1, 21)
+    ]
+    return (
+        "## Agent Todo\n\n"
+        + "\n".join(open_lines)
+        + "\n"
+        + "\n".join(done_lines)
+        + "\n"
+    )
+
+
+def main() -> int:
+    agent_todos = parse_active_state_todos(build_active_state())["agent_todos"]
+    assert agent_todos["total_count"] == 50, agent_todos
+    assert agent_todos["open_count"] == 30, agent_todos
+    assert agent_todos["done_count"] == 20, agent_todos
+
+    assert len(agent_todos["items"]) == MAX_STATUS_TODOS_PER_ROLE, agent_todos
+    assert len(agent_todos["backlog_items"]) == MAX_PROJECT_ASSET_TODO_BACKLOG_ITEMS, agent_todos
+    assert len(agent_todos["executable_backlog_items"]) == (
+        MAX_PROJECT_ASSET_TODO_BACKLOG_ITEMS
+    ), agent_todos
+    assert len(agent_todos["claimed_open_items"]) == MAX_TODO_VISIBILITY_LANE_ITEMS, agent_todos
+    assert len(agent_todos["claimed_advancement_open_items"]) == (
+        MAX_TODO_VISIBILITY_LANE_ITEMS
+    ), agent_todos
+    assert agent_todos["claimed_open_count"] == 24, agent_todos
+    assert agent_todos["claimed_advancement_open_count"] == 24, agent_todos
+    assert agent_todos["claimed_open_items"][0]["todo_id"].startswith("todo_derived_"), (
+        agent_todos
+    )
+    assert agent_todos["claimed_open_items"][0]["source_section"] == "Agent Todo", agent_todos
+
+    asset_summary = project_asset_todo_summary(agent_todos, role="agent")
+    assert asset_summary is not None, agent_todos
+    assert asset_summary["projection_view"] == {
+        "schema_version": TODO_PROJECTION_VIEW_SCHEMA_VERSION,
+        "view": "project_asset_overview",
+        "truth": "derived",
+        "canonical_source": "attention_queue.items[].agent_todos",
+        "item_limit": MAX_PROJECT_ASSET_TODO_ITEMS,
+    }, asset_summary
+    assert asset_summary["detail_pointer"] == {
+        "schema_version": TODO_PROJECTION_DETAIL_POINTER_SCHEMA_VERSION,
+        "cold_path": "loopx status --format json",
+        "active_state_source": "registry goal state_file",
+        "full_list_included": False,
+    }, asset_summary
+    assert len(asset_summary["items"]) == MAX_PROJECT_ASSET_TODO_ITEMS, asset_summary
+    assert "backlog_items" not in asset_summary, asset_summary
+    assert "claimed_open_items" not in asset_summary, asset_summary
+
+    archive_warning = completed_todo_archive_warning(agent_todos)
+    assert archive_warning is not None, agent_todos
+    assert archive_warning["kind"] == "completed_agent_todo_archive_required", archive_warning
+    assert archive_warning["active_done_count"] == 20, archive_warning
+    assert archive_warning["max_active_done_count"] == MAX_STATUS_TODOS_PER_ROLE, (
+        archive_warning
+    )
+
+    docs = (REPO_ROOT / "docs" / "field-derived-patterns.md").read_text(encoding="utf-8")
+    for required in (
+        "## 3. Bounded Derived State Inheritance",
+        "canonical source",
+        "inheritance rule",
+        "item limits",
+        "archive/prune rule",
+        "projection semantics",
+        "Model-created state must not become a second source of truth",
+    ):
+        assert required in docs, required
+
+    print("derived-state-boundary-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a bounded derived-state inheritance contract to the field-derived patterns doc
- add a public smoke proving todo-derived projections stay bounded, reconstructable, and archive-warning aware
- replace remaining legacy Goal Harness wording in the touched field pattern doc

## Validation
- python3 examples/derived-state-boundary-smoke.py
- python3 examples/todo-first-open-summary-smoke.py
- python3 examples/docs-governance-smoke.py
- python3 -m py_compile examples/derived-state-boundary-smoke.py
- git diff --check
- loopx check --scan-path docs/field-derived-patterns.md --scan-path examples/derived-state-boundary-smoke.py