### PR TITLE
Add structured run policy to Terminal-Bench preflight

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/terminal-bench-managed-real-run-preflight-guard-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/terminal-bench-managed-real-run-preflight-guard-v0.md
@@ -35,6 +35,56 @@ The probe includes the current shell path plus standard user-local/Homebrew
 install locations when checking command presence, but it records only booleans
 and fixed surface names, never local directories.
 
+## Structured Run Permission Policy
+
+This policy describes the future private no-upload managed pilot boundary after
+the preflight guard is ready. The preflight command itself remains a no-run
+surface probe and must still not execute Harbor, Terminal-Bench, Codex workers,
+model APIs, task containers, uploads, or leaderboard paths.
+
+```json
+{
+  "schema_version": "run_permission_policy_v0",
+  "policy_id": "terminal_bench_managed_local_no_upload_preflight_20260622",
+  "allowed_actions": [
+    "codex_model_invocation",
+    "local_docker_runner",
+    "local_harbor_runner",
+    "benchmark_dependency_fetch",
+    "compact_result_reduction"
+  ],
+  "forbidden_actions": [
+    "public_result_upload",
+    "leaderboard_submission",
+    "public_benchmark_claim",
+    "production_cloud_action",
+    "credential_sync",
+    "raw_artifact_publication"
+  ],
+  "max_wall_time_minutes": 360,
+  "no_upload_required": true,
+  "submit_allowed": false,
+  "leaderboard_claim_allowed": false,
+  "public_benchmark_claim_allowed": false,
+  "production_cloud_allowed": false,
+  "observation_boundary": {
+    "compact_only": true,
+    "raw_logs_public": false,
+    "raw_task_text_public": false,
+    "raw_trajectory_public": false,
+    "local_paths_public": false
+  },
+  "operator_gate_required_for": [
+    "public_result_upload",
+    "leaderboard_submission",
+    "public_benchmark_claim",
+    "production_cloud_action",
+    "credential_sync",
+    "raw_artifact_publication"
+  ]
+}
+```
+
 The compact event uses:
 
 | Field | Value |

--- a/examples/terminal-bench-managed-real-run-preflight-guard-smoke.py
+++ b/examples/terminal-bench-managed-real-run-preflight-guard-smoke.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import stat
 import subprocess
 import sys
@@ -17,6 +18,11 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from loopx.benchmark_core import (  # noqa: E402
+    RunPermissionAction,
+    compact_run_permission_policy_for_quota,
+    validate_run_permission_policy,
+)
 from loopx.status import collect_status  # noqa: E402
 
 
@@ -36,6 +42,8 @@ REQUIRED_DOC_SNIPPETS = [
     "--preflight-guard",
     "loopx_managed_codex_real_run_preflight_guard",
     "ready_for_private_managed_no_upload_pilot_review",
+    "run_permission_policy_v0",
+    "terminal_bench_managed_local_no_upload_preflight_20260622",
     "auth-surface variable names are checked",
     "credential values are never read or stored",
     "python3 examples/terminal-bench-managed-real-run-preflight-guard-smoke.py",
@@ -175,6 +183,18 @@ def assert_public_safe(payload: dict[str, Any]) -> None:
     assert len(text) < 18000, len(text)
 
 
+def load_run_permission_policy(text: str) -> dict[str, Any]:
+    match = re.search(
+        r"## Structured Run Permission Policy\s+.*?```json\s+(.*?)\s+```",
+        text,
+        re.DOTALL,
+    )
+    assert match, "missing structured run permission policy block"
+    payload = json.loads(match.group(1))
+    assert isinstance(payload, dict), payload
+    return payload
+
+
 def assert_doc_contract() -> None:
     text = DOC.read_text(encoding="utf-8")
     readme = README.read_text(encoding="utf-8")
@@ -183,6 +203,35 @@ def assert_doc_contract() -> None:
     assert "terminal-bench-managed-real-run-preflight-guard-v0.md" in readme, readme
     leaked = [marker for marker in FORBIDDEN_TEXT if marker in text]
     assert not leaked, leaked
+
+
+def assert_structured_run_permission_policy() -> None:
+    text = DOC.read_text(encoding="utf-8")
+    policy = load_run_permission_policy(text)
+    validation = validate_run_permission_policy(policy)
+    projection = compact_run_permission_policy_for_quota(policy)
+
+    assert validation["ok"] is True, validation
+    assert projection is not None, policy
+    assert (
+        projection["policy_id"]
+        == "terminal_bench_managed_local_no_upload_preflight_20260622"
+    )
+    assert projection["delivery_allowed"] is True, projection
+    assert projection["max_wall_time_minutes"] == 360, projection
+    assert projection["no_upload_required"] is True, projection
+    assert projection["submit_allowed"] is False, projection
+    assert projection["leaderboard_claim_allowed"] is False, projection
+    assert projection["compact_observation_only"] is True, projection
+    assert (
+        RunPermissionAction.LOCAL_HARBOR_RUNNER.value
+        in projection["allowed_actions"]
+    )
+    assert (
+        RunPermissionAction.PUBLIC_RESULT_UPLOAD.value
+        in projection["forbidden_actions"]
+    )
+    assert "The preflight command itself remains a no-run\nsurface probe" in text
 
 
 def assert_payload(payload: dict[str, Any], *, appended: bool) -> None:
@@ -269,6 +318,7 @@ def assert_guard_rejects_fake_worker(registry_path: Path, runtime: Path, env: di
 
 def main() -> None:
     assert_doc_contract()
+    assert_structured_run_permission_policy()
     with tempfile.TemporaryDirectory(prefix="terminal-bench-managed-preflight-") as tmp:
         root = Path(tmp)
         registry_path, runtime = write_fixture(root)


### PR DESCRIPTION
## Summary
- Add a structured run_permission_policy_v0 block to the Terminal-Bench managed real-run preflight guard.
- Extend the preflight guard smoke to parse and validate that policy through the shared benchmark_core projection.

## Validation
- python3 examples/terminal-bench-managed-real-run-preflight-guard-smoke.py
- python3 examples/benchmark-run-permission-policy-smoke.py
- python3 -m py_compile examples/terminal-bench-managed-real-run-preflight-guard-smoke.py
- git diff --check
- loopx check --scan-path docs/research/long-horizon-agent-benchmarks/terminal-bench-managed-real-run-preflight-guard-v0.md --scan-path examples/terminal-bench-managed-real-run-preflight-guard-smoke.py

## Boundary
- Excludes raw benchmark logs, task text, trajectories, verifier output, credentials, local state, and private paths.
- Does not launch Harbor/Terminal-Bench/Codex, change scoring, or change runner behavior.

## Residual Risk
- Existing LoopX check warning remains: duplicate index rows for loopx-meta run history.