### PR TITLE
Add structured run policy to ALE local route

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/agents-last-exam-local-docker-host-codex-route-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/agents-last-exam-local-docker-host-codex-route-v0.md
@@ -38,6 +38,55 @@ This differs from upstream ALE's in-sandbox `codex` agent path. The upstream
 agent can require provider-key configuration inside the sandbox. Our path keeps
 Codex auth on the host and uses the bridge as the interface boundary.
 
+## Structured Run Permission Policy
+
+This policy records the local Docker plus host Codex validation boundary. It
+does not authorize official GCP execution, leaderboard submission, public result
+claims, credential sync, or launch from an automatic heartbeat.
+
+```json
+{
+  "schema_version": "run_permission_policy_v0",
+  "policy_id": "agents_last_exam_local_docker_host_codex_no_upload_20260622",
+  "allowed_actions": [
+    "codex_model_invocation",
+    "local_docker_runner",
+    "local_harbor_runner",
+    "benchmark_dependency_fetch",
+    "compact_result_reduction"
+  ],
+  "forbidden_actions": [
+    "public_result_upload",
+    "leaderboard_submission",
+    "public_benchmark_claim",
+    "production_cloud_action",
+    "credential_sync",
+    "raw_artifact_publication"
+  ],
+  "max_wall_time_minutes": 480,
+  "no_upload_required": true,
+  "submit_allowed": false,
+  "leaderboard_claim_allowed": false,
+  "public_benchmark_claim_allowed": false,
+  "production_cloud_allowed": false,
+  "observation_boundary": {
+    "compact_only": true,
+    "raw_logs_public": false,
+    "raw_task_text_public": false,
+    "raw_trajectory_public": false,
+    "local_paths_public": false
+  },
+  "operator_gate_required_for": [
+    "public_result_upload",
+    "leaderboard_submission",
+    "public_benchmark_claim",
+    "production_cloud_action",
+    "credential_sync",
+    "raw_artifact_publication"
+  ]
+}
+```
+
 ## Current Evidence
 
 - The local Docker/CUA substrate has been validated on `agentslastexam/ale-kasm`

--- a/examples/agents-last-exam-local-docker-host-codex-route-smoke.py
+++ b/examples/agents-last-exam-local-docker-host-codex-route-smoke.py
@@ -3,9 +3,21 @@
 
 from __future__ import annotations
 
+import json
+import re
+import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.benchmark_core import (  # noqa: E402
+    RunPermissionAction,
+    compact_run_permission_policy_for_quota,
+    validate_run_permission_policy,
+)
+
 DOC = (
     REPO_ROOT
     / "docs"
@@ -18,6 +30,45 @@ README = REPO_ROOT / "docs" / "research" / "long-horizon-agent-benchmarks" / "RE
 
 def normalized(text: str) -> str:
     return " ".join(text.split())
+
+
+def load_run_permission_policy(text: str) -> dict:
+    match = re.search(
+        r"## Structured Run Permission Policy\s+.*?```json\s+(.*?)\s+```",
+        text,
+        re.DOTALL,
+    )
+    assert match, "missing structured run permission policy block"
+    payload = json.loads(match.group(1))
+    assert isinstance(payload, dict), payload
+    return payload
+
+
+def assert_structured_run_permission_policy(doc: str) -> None:
+    policy = load_run_permission_policy(doc)
+    validation = validate_run_permission_policy(policy)
+    projection = compact_run_permission_policy_for_quota(policy)
+
+    assert validation["ok"] is True, validation
+    assert projection is not None, policy
+    assert (
+        projection["policy_id"]
+        == "agents_last_exam_local_docker_host_codex_no_upload_20260622"
+    )
+    assert projection["delivery_allowed"] is True, projection
+    assert projection["max_wall_time_minutes"] == 480, projection
+    assert projection["no_upload_required"] is True, projection
+    assert projection["submit_allowed"] is False, projection
+    assert projection["leaderboard_claim_allowed"] is False, projection
+    assert projection["compact_observation_only"] is True, projection
+    assert (
+        RunPermissionAction.LOCAL_DOCKER_RUNNER.value
+        in projection["allowed_actions"]
+    )
+    assert (
+        RunPermissionAction.PUBLIC_RESULT_UPLOAD.value
+        in projection["forbidden_actions"]
+    )
 
 
 def main() -> None:
@@ -33,6 +84,9 @@ def main() -> None:
         "CUA/MCP bridge",
         "Google Cloud is the supported provider",
         "output_path: local",
+        "run_permission_policy_v0",
+        "agents_last_exam_local_docker_host_codex_no_upload_20260622",
+        "does not authorize official GCP execution",
         "agentslastexam/ale-kasm:latest",
         "demo/tool_smoke",
         "score `1.0`",
@@ -54,6 +108,7 @@ def main() -> None:
     assert "agents-last-exam-local-docker-host-codex-route-v0.md" in compact_readme
     assert "local Docker/Colima plus host Codex CLI" in compact_readme
     assert "score `1.0` canary as route evidence rather than uplift" in compact_readme
+    assert_structured_run_permission_policy(doc)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a structured run_permission_policy_v0 block to the Agents Last Exam local Docker plus host Codex route note
- validate that policy through the existing ALE route smoke and shared run-permission policy helpers

## Validation
- python3 examples/agents-last-exam-local-docker-host-codex-route-smoke.py
- python3 examples/benchmark-run-permission-policy-smoke.py
- python3 -m py_compile examples/agents-last-exam-local-docker-host-codex-route-smoke.py
- git diff --check
- loopx check --scan-path docs/research/long-horizon-agent-benchmarks/agents-last-exam-local-docker-host-codex-route-v0.md --scan-path examples/agents-last-exam-local-docker-host-codex-route-smoke.py

## Boundary
- public docs and durable smoke only
- no benchmark launch, no official GCP execution, no upload, no leaderboard/public result claim
- no raw task text, raw trajectories, raw logs, verifier output, credentials, or local private artifacts