### PR TITLE
Add SkillsBench run permission policy

### DIFF
--- a/examples/skillsbench-app-server-goal-worker-smoke.py
+++ b/examples/skillsbench-app-server-goal-worker-smoke.py
@@ -22,6 +22,11 @@ from loopx.benchmark import (  # noqa: E402
     build_skillsbench_benchmark_run,
     skillsbench_route_contract,
 )
+from loopx.benchmark_core import (  # noqa: E402
+    RunPermissionAction,
+    compact_run_permission_policy_for_quota,
+    validate_run_permission_policy,
+)
 from loopx.benchmark_adapters.skillsbench_acp_relay import (  # noqa: E402
     run_skillsbench_local_acp_relay_probe,
 )
@@ -131,6 +136,40 @@ def assert_plan_prerequisites(plan: dict[str, Any]) -> None:
     ), prereq
 
 
+def assert_skillsbench_run_permission_policy(
+    policy: dict[str, Any],
+    *,
+    expected_route: str,
+) -> None:
+    validation = validate_run_permission_policy(policy)
+    projection = compact_run_permission_policy_for_quota(policy)
+
+    assert validation["ok"] is True, validation
+    assert projection is not None, policy
+    assert (
+        projection["policy_id"]
+        == f"skillsbench_{expected_route.replace('-', '_')}_no_upload_20260622"
+    ), projection
+    assert projection["delivery_allowed"] is True, projection
+    assert projection["max_wall_time_minutes"] >= 480, projection
+    assert projection["no_upload_required"] is True, projection
+    assert projection["submit_allowed"] is False, projection
+    assert projection["leaderboard_claim_allowed"] is False, projection
+    assert projection["compact_observation_only"] is True, projection
+    assert (
+        RunPermissionAction.CODEX_MODEL_INVOCATION.value
+        in projection["allowed_actions"]
+    )
+    assert (
+        RunPermissionAction.LOCAL_DOCKER_RUNNER.value
+        in projection["allowed_actions"]
+    )
+    assert (
+        RunPermissionAction.PUBLIC_RESULT_UPLOAD.value
+        in projection["forbidden_actions"]
+    )
+
+
 def _load_worker_module() -> Any:
     spec = importlib.util.spec_from_file_location("skillsbench_goal_worker", WORKER_SCRIPT)
     assert spec and spec.loader
@@ -165,6 +204,10 @@ def test_worker_contract_is_public_safe() -> None:
     assert payload["proof_required"]["turn_start"] is True, payload
     assert payload["boundary"]["raw_task_text_read_into_public_state"] is False, payload
     assert payload["worker_plan"]["claim_boundary"]["requires_turn_start_evidence"] is True, payload
+    assert_skillsbench_run_permission_policy(
+        payload["run_permission_policy"],
+        expected_route=ROUTE,
+    )
 
 
 def test_skeleton_marks_app_server_goal_actor() -> None:
@@ -177,6 +220,10 @@ def test_skeleton_marks_app_server_goal_actor() -> None:
     assert counters["codex_acp_protocol_used"] is False, counters
     assert policy["outer_controller"] == "codex_app_server_goal_worker", policy
     assert policy["inner_case_actor"] == "host_codex_app_server_goal_worker", policy
+    assert_skillsbench_run_permission_policy(
+        run["run_permission_policy"],
+        expected_route=ROUTE,
+    )
 
 
 def test_launcher_plan_only_uses_native_worker_route() -> None:
@@ -208,6 +255,10 @@ def test_launcher_plan_only_uses_native_worker_route() -> None:
     assert plan["app_server_goal_worker_trace_dir"].endswith(
         "app_server_goal_worker_traces"
     ), plan
+    assert_skillsbench_run_permission_policy(
+        plan["run_permission_policy"],
+        expected_route=ROUTE,
+    )
 
 
 def test_launcher_plan_only_marks_bridge_ready_when_explicit() -> None:

--- a/loopx/benchmark.py
+++ b/loopx/benchmark.py
@@ -88,6 +88,7 @@ from .benchmark_adapters.skillsbench import (
     build_skillsbench_app_server_goal_worker_contract,
     build_skillsbench_benchflow_result_benchmark_run,
     build_skillsbench_local_driver_a2a_contract,
+    build_skillsbench_run_permission_policy,
     build_skillsbench_worker_handshake_preflight,
     skillsbench_recommended_action,
     skillsbench_job_name,

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -10,6 +10,7 @@ from ..benchmark_case_state import (
     BENCHMARK_CASE_ACTIVE_STATE_SCHEMA_VERSION,
     benchmark_case_active_state_path,
 )
+from ..benchmark_core import RunPermissionAction, build_run_permission_policy
 from ..codex_goal_baseline import build_codex_app_server_goal_worker_plan
 
 
@@ -353,6 +354,32 @@ def skillsbench_job_name(dataset: str, task_id: str, route: str) -> str:
     return re.sub(r"[^A-Za-z0-9]+", "_", raw).strip("_").lower()
 
 
+def build_skillsbench_run_permission_policy(
+    *,
+    route: str = SKILLSBENCH_DEFAULT_ROUTE,
+    max_wall_time_minutes: int = 480,
+) -> dict[str, Any]:
+    """Build the public no-upload execution boundary for SkillsBench routes."""
+
+    safe_route = (
+        _skillsbench_public_safe_label(route, limit=80)
+        or SKILLSBENCH_DEFAULT_ROUTE
+    )
+    policy_route = re.sub(r"[^A-Za-z0-9]+", "_", safe_route).strip("_").lower()
+    return build_run_permission_policy(
+        policy_id=f"skillsbench_{policy_route}_no_upload_20260622",
+        allowed_actions=(
+            RunPermissionAction.CODEX_MODEL_INVOCATION.value,
+            RunPermissionAction.LOCAL_DOCKER_RUNNER.value,
+            RunPermissionAction.BENCHMARK_DEPENDENCY_FETCH.value,
+            RunPermissionAction.COMPACT_RESULT_REDUCTION.value,
+        ),
+        max_wall_time_minutes=max_wall_time_minutes,
+        no_upload_required=True,
+        compact_observation_only=True,
+    )
+
+
 def build_skillsbench_app_server_goal_worker_contract(
     *,
     dataset: str = SKILLSBENCH_DEFAULT_DATASET,
@@ -440,6 +467,9 @@ def build_skillsbench_app_server_goal_worker_contract(
         "first_blocker": first_blocker,
         "blockers": blockers,
         "next_action": next_action,
+        "run_permission_policy": build_skillsbench_run_permission_policy(
+            route="codex-app-server-goal-baseline"
+        ),
         "worker_adapter": {
             "label": "skillsbench_host_codex_app_server_goal_worker",
             "script": "scripts/skillsbench_host_codex_goal_worker.py",
@@ -1405,6 +1435,9 @@ def build_skillsbench_benchmark_run(
         "job_name": job_name,
         "mode": contract["mode"],
         "route": route,
+        "run_permission_policy": build_skillsbench_run_permission_policy(
+            route=route
+        ),
         "agent": {
             "name": agent,
             "model": model,

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -80,6 +80,7 @@ from loopx.benchmark_case_state import (  # noqa: E402
 )
 from loopx.benchmark_adapters.skillsbench import (  # noqa: E402
     build_skillsbench_app_server_goal_worker_contract,
+    build_skillsbench_run_permission_policy,
     build_skillsbench_worker_handshake_preflight,
 )
 from loopx.benchmark_adapters.skillsbench_acp_relay import (  # noqa: E402
@@ -1660,6 +1661,10 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
         if is_app_server_goal_route
         else None
     )
+    run_permission_policy = build_skillsbench_run_permission_policy(
+        route=route,
+        max_wall_time_minutes=max(480, (int(args.outer_timeout_sec) + 59) // 60),
+    )
     launch_plan = {
         "schema_version": "skillsbench_runner_launch_plan_v0",
         "benchmark_id": args.dataset,
@@ -1697,6 +1702,7 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
             else ""
         ),
         "ledger_path": str(Path(args.ledger_path).expanduser()),
+        "run_permission_policy": run_permission_policy,
         "task_setup_preflight": setup_preflight,
         "task_staging": {
             "schema_version": "skillsbench_task_staging_v0",


### PR DESCRIPTION
## Summary
- add a SkillsBench run_permission_policy_v0 builder for no-upload benchmark routes
- surface the policy in app-server Goal worker contracts, benchmark_run skeletons, and plan-only launch plans
- extend the SkillsBench app-server Goal worker smoke to validate quota projection of the policy

## Validation
- python3 examples/skillsbench-app-server-goal-worker-smoke.py
- python3 examples/benchmark-run-permission-policy-smoke.py
- python3 -m py_compile loopx/benchmark_adapters/skillsbench.py loopx/benchmark.py scripts/skillsbench_automation_loop.py examples/skillsbench-app-server-goal-worker-smoke.py
- git diff --check
- loopx check --scan-path examples/skillsbench-app-server-goal-worker-smoke.py --scan-path loopx/benchmark.py --scan-path loopx/benchmark_adapters/skillsbench.py --scan-path scripts/skillsbench_automation_loop.py

## Boundary
- contract/smoke adoption only
- no SkillsBench job launch, no scoring behavior change, no upload, no leaderboard/public result claim
- no raw task text, raw trajectories, raw logs, verifier output, credentials, or local private artifacts