### PR TITLE
Adopt SkillsBench attempt accounting

### DIFF
--- a/examples/benchmark-attempt-accounting-smoke.py
+++ b/examples/benchmark-attempt-accounting-smoke.py
@@ -78,6 +78,14 @@ def main() -> None:
     assert verifier["verifier_attempt_countable"] is True
     assert verifier["official_score_attempt_countable"] is True
 
+    explicit_enum = build_benchmark_attempt_accounting(
+        lifecycle=canonical_lifecycle(),
+        failure_label="fixture_no_run",
+        failure_class=BenchmarkFailureClass.NONE,
+    )
+    assert explicit_enum["failure_class"] == BenchmarkFailureClass.NONE
+    assert explicit_enum["case_attempt_countable"] is False
+
     assert (
         classify_benchmark_failure("official-score-missing")
         == BenchmarkFailureClass.OFFICIAL_SCORE_FAILED

--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -781,6 +781,12 @@ def test_skillsbench_skeleton_builder() -> None:
     assert compact["submit_eligible"] is False, compact
     assert compact["leaderboard_evidence"] is False, compact
     assert compact["validation"]["all_passed"] is True, compact
+    attempt_accounting = compact["attempt_accounting"]
+    assert attempt_accounting["schema_version"] == "benchmark_attempt_accounting_v0"
+    assert attempt_accounting["case_attempt_countable"] is False, compact
+    assert attempt_accounting["solver_attempt_countable"] is False, compact
+    assert attempt_accounting["verifier_attempt_countable"] is False, compact
+    assert attempt_accounting["official_score_attempt_countable"] is False, compact
     assert "do_not_read_raw_task_prompt_solution_or_trajectory" in compact[
         "stop_conditions"
     ], compact
@@ -1327,6 +1333,13 @@ def test_skillsbench_official_result_builder() -> None:
         assert compact["leaderboard_evidence"] is False
         assert compact["official_task_score"]["value"] == 0.0
         assert compact["official_task_score"]["passed"] is False
+        attempt_accounting = compact["attempt_accounting"]
+        assert attempt_accounting["failure_class"] == "solver_failed", compact
+        assert attempt_accounting["lifecycle_phase"] == "verifier_scored", compact
+        assert attempt_accounting["case_attempt_countable"] is True, compact
+        assert attempt_accounting["solver_attempt_countable"] is True, compact
+        assert attempt_accounting["verifier_attempt_countable"] is True, compact
+        assert attempt_accounting["official_score_attempt_countable"] is True, compact
         assert compact["score_failure_attribution"] == (
             "official_verifier_solution_failure"
         )
@@ -1708,6 +1721,14 @@ def test_skillsbench_volume_mount_failure_attribution() -> None:
         assert compact["score_failure_attribution"] == (
             "skillsbench_docker_compose_volume_mount_failure"
         ), compact
+        attempt_accounting = compact["attempt_accounting"]
+        assert attempt_accounting["failure_class"] == (
+            "job_materialization_failed"
+        ), compact
+        assert attempt_accounting["case_attempt_countable"] is False, compact
+        assert attempt_accounting["solver_attempt_countable"] is False, compact
+        assert attempt_accounting["verifier_attempt_countable"] is False, compact
+        assert attempt_accounting["official_score_attempt_countable"] is False, compact
         assert "skillsbench_docker_compose_setup_failure" in compact[
             "failure_attribution_labels"
         ], compact

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -10,7 +10,13 @@ from ..benchmark_case_state import (
     BENCHMARK_CASE_ACTIVE_STATE_SCHEMA_VERSION,
     benchmark_case_active_state_path,
 )
-from ..benchmark_core import RunPermissionAction, build_run_permission_policy
+from ..benchmark_core import (
+    BenchmarkFailureClass,
+    RunPermissionAction,
+    build_benchmark_attempt_accounting,
+    build_run_permission_policy,
+    canonical_lifecycle,
+)
 from ..codex_goal_baseline import build_codex_app_server_goal_worker_plan
 
 
@@ -377,6 +383,73 @@ def build_skillsbench_run_permission_policy(
         max_wall_time_minutes=max_wall_time_minutes,
         no_upload_required=True,
         compact_observation_only=True,
+    )
+
+
+_SKILLSBENCH_SETUP_FAILURE_LABELS = {
+    "skillsbench_result_json_missing_after_runner_exit",
+    "skillsbench_runner_setup_error",
+    "skillsbench_environment_setup_error",
+    "skillsbench_docker_setup_preflight_blocked",
+    "skillsbench_docker_compose_setup_failure",
+    "skillsbench_docker_compose_unclassified_setup_failure",
+}
+
+
+def _skillsbench_attempt_setup_blocked(failure_labels: Iterable[str]) -> bool:
+    return any(
+        str(label) in _SKILLSBENCH_SETUP_FAILURE_LABELS for label in failure_labels
+    )
+
+
+def _skillsbench_attempt_failure_class(
+    *,
+    failure_labels: Iterable[str],
+    reward_value: float | int | None,
+    verifier_error_text: str,
+    score_failure_attribution: str,
+) -> BenchmarkFailureClass:
+    if _skillsbench_attempt_setup_blocked(failure_labels):
+        return BenchmarkFailureClass.JOB_MATERIALIZATION_FAILED
+    if verifier_error_text and reward_value is None:
+        return BenchmarkFailureClass.VERIFIER_FAILED
+    if reward_value is None and score_failure_attribution != "none":
+        return BenchmarkFailureClass.OFFICIAL_SCORE_FAILED
+    if reward_value == 0:
+        return BenchmarkFailureClass.SOLVER_FAILED
+    return BenchmarkFailureClass.NONE
+
+
+def _skillsbench_attempt_lifecycle(
+    *,
+    setup_blocked: bool,
+    reward_value: float | int | None,
+    verifier_error_text: str,
+    tool_calls: int,
+    native_goal_worker_trace_observed: bool,
+    controller_trace_present: bool,
+) -> dict[str, Any]:
+    if setup_blocked:
+        return canonical_lifecycle(
+            process_started=True,
+            runner_accepted_args=True,
+        )
+
+    verifier_or_score_seen = reward_value is not None or bool(verifier_error_text)
+    worker_seen = (
+        tool_calls > 0
+        or native_goal_worker_trace_observed
+        or controller_trace_present
+        or verifier_or_score_seen
+    )
+    return canonical_lifecycle(
+        process_started=True,
+        runner_accepted_args=True,
+        job_root_materialized=True,
+        trial_started=True,
+        worker_started=worker_seen,
+        result_written=True,
+        verifier_scored=verifier_or_score_seen,
     )
 
 
@@ -1438,6 +1511,11 @@ def build_skillsbench_benchmark_run(
         "run_permission_policy": build_skillsbench_run_permission_policy(
             route=route
         ),
+        "attempt_accounting": build_benchmark_attempt_accounting(
+            lifecycle=canonical_lifecycle(),
+            failure_label="not_run_adapter_skeleton",
+            failure_class=BenchmarkFailureClass.NONE,
+        ),
         "agent": {
             "name": agent,
             "model": model,
@@ -2476,6 +2554,25 @@ def build_skillsbench_benchflow_result_benchmark_run(
     native_goal_worker_trace_status = _skillsbench_native_goal_worker_trace_status(
         controller_counters
     )
+    setup_blocked = _skillsbench_attempt_setup_blocked(failure_labels)
+    attempt_accounting = build_benchmark_attempt_accounting(
+        lifecycle=_skillsbench_attempt_lifecycle(
+            setup_blocked=setup_blocked,
+            reward_value=reward_value,
+            verifier_error_text=verifier_error_text,
+            tool_calls=tool_calls,
+            native_goal_worker_trace_observed=native_goal_worker_trace_observed,
+            controller_trace_present=controller_trace_present,
+        ),
+        failure_label=score_failure_attribution,
+        failure_class=_skillsbench_attempt_failure_class(
+            failure_labels=failure_labels,
+            reward_value=reward_value,
+            verifier_error_text=verifier_error_text,
+            score_failure_attribution=score_failure_attribution,
+        ),
+        official_score_attempted=reward_value is not None and not setup_blocked,
+    )
 
     benchmark_run: dict[str, Any] = {
         "schema_version": "benchmark_run_v0",
@@ -2486,6 +2583,7 @@ def build_skillsbench_benchflow_result_benchmark_run(
         "job_name": job_name,
         "mode": contract["mode"],
         "route": route,
+        "attempt_accounting": attempt_accounting,
         "agent": {
             "name": observed_agent,
             "model": observed_model,

--- a/loopx/benchmark_core/attempts.py
+++ b/loopx/benchmark_core/attempts.py
@@ -150,6 +150,8 @@ def build_benchmark_attempt_accounting(
         normalized_failure_class = classify_benchmark_failure(
             failure_label, lifecycle=lifecycle_projection
         )
+    elif isinstance(failure_class, BenchmarkFailureClass):
+        normalized_failure_class = failure_class
     else:
         normalized_failure_class = BenchmarkFailureClass(_normalize(failure_class))
 

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -1656,6 +1656,53 @@ def compact_benchmark_post_launch_materialization(value: Any) -> dict[str, Any] 
     return compact or None
 
 
+def _compact_benchmark_attempt_accounting(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+
+    compact: dict[str, Any] = {}
+    for field in (
+        "schema_version",
+        "lifecycle_phase",
+        "failure_label",
+        "failure_class",
+    ):
+        text = public_safe_compact_text(value.get(field), limit=140)
+        if text:
+            compact[field] = text
+    for field in (
+        "launcher_attempt_countable",
+        "case_attempt_countable",
+        "solver_attempt_countable",
+        "verifier_attempt_countable",
+        "official_score_attempt_countable",
+    ):
+        if isinstance(value.get(field), bool):
+            compact[field] = value[field]
+    attempts = value.get("attempts")
+    if isinstance(attempts, dict):
+        compact_attempts: dict[str, Any] = {}
+        for phase in (
+            "launcher",
+            "case",
+            "solver",
+            "verifier",
+            "official_score",
+        ):
+            phase_value = attempts.get(phase)
+            if not isinstance(phase_value, dict):
+                continue
+            compact_phase: dict[str, bool] = {}
+            for field in ("attempted", "countable"):
+                if isinstance(phase_value.get(field), bool):
+                    compact_phase[field] = phase_value[field]
+            if compact_phase:
+                compact_attempts[phase] = compact_phase
+        if compact_attempts:
+            compact["attempts"] = compact_attempts
+    return compact
+
+
 def _compact_worker_bridge_outcome(value: Any) -> dict[str, Any]:
     if not isinstance(value, dict):
         return {}
@@ -2126,6 +2173,11 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
     task_staging = _compact_benchmark_task_staging(source.get("task_staging"))
     if task_staging:
         compact["task_staging"] = task_staging
+    attempt_accounting = _compact_benchmark_attempt_accounting(
+        source.get("attempt_accounting")
+    )
+    if attempt_accounting:
+        compact["attempt_accounting"] = attempt_accounting
 
     official = source.get("official_task_score") if isinstance(source.get("official_task_score"), dict) else {}
     if official:


### PR DESCRIPTION
## Summary
- add benchmark_attempt_accounting_v0 to SkillsBench skeleton and official result reducer
- compact attempt accounting into benchmark_run status output
- fix BenchmarkFailureClass enum handling and cover it with smoke assertions

## Validation
- python3 examples/skillsbench-benchmark-run-smoke.py
- python3 examples/benchmark-attempt-accounting-smoke.py
- python3 examples/benchmark-run-ledger-smoke.py
- python3 -m py_compile loopx/benchmark_core/attempts.py loopx/benchmark_adapters/skillsbench.py loopx/status.py examples/skillsbench-benchmark-run-smoke.py examples/benchmark-attempt-accounting-smoke.py
- git diff --check
- loopx check --scan-path loopx/benchmark_core/attempts.py --scan-path loopx/benchmark_adapters/skillsbench.py --scan-path loopx/status.py --scan-path examples/skillsbench-benchmark-run-smoke.py --scan-path examples/benchmark-attempt-accounting-smoke.py