### PR TITLE
Adopt ALE attempt accounting

### DIFF
--- a/examples/agents-last-exam-triage-smoke.py
+++ b/examples/agents-last-exam-triage-smoke.py
@@ -260,6 +260,27 @@ def assert_ale_result_ingest_contract() -> None:
             run_dir,
             report_id="agents-last-exam-synthetic-ingest-smoke",
         )
+        missing_eval_dir = Path(tmp) / "missing_eval_run"
+        missing_eval_dir.mkdir()
+        write_json(
+            missing_eval_dir / "run.json",
+            {
+                "schema_version": 2,
+                "run_id": "codex__demo__missing_eval",
+                "agent_id": "codex_loopx",
+                "model": "openai/gpt-5.4",
+                "task_path": "demo/missing-eval",
+                "status": "completed",
+            },
+        )
+        (missing_eval_dir / "events.jsonl").write_text(
+            json.dumps({"type": "agent_finished"}, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        missing_eval_report = build_agents_last_exam_result_benchmark_report(
+            missing_eval_dir,
+            report_id="agents-last-exam-missing-eval-smoke",
+        )
 
     assert report["schema_version"] == "benchmark_experiment_report_v0", report
     identity = report["experiment_identity"]
@@ -278,17 +299,37 @@ def assert_ale_result_ingest_contract() -> None:
     assert artifacts["local_paths_recorded"] is False, artifacts
     assert artifacts["event_type_counts"]["unit_started"] == 1, artifacts
     assert "single_arm_no_delta" in report["negative_results"]["negative_evidence_layers"], report
+    attempt = report["attempt_accounting"]
+    assert attempt["schema_version"] == "benchmark_attempt_accounting_v0", report
+    assert attempt["failure_class"] == "none", report
+    assert attempt["case_attempt_countable"] is True, report
+    assert attempt["solver_attempt_countable"] is True, report
+    assert attempt["verifier_attempt_countable"] is True, report
+    assert attempt["official_score_attempt_countable"] is True, report
 
     compact = compact_benchmark_experiment_report(report)
     assert compact is not None, report
     assert compact["experiment_identity"]["benchmark_id"] == BENCHMARK_ID, compact
     assert compact["official_score"]["kind"] == "ale_eval_result", compact
+    compact_attempt = compact["attempt_accounting"]
+    assert compact_attempt["case_attempt_countable"] is True, compact
+    assert compact_attempt["official_score_attempt_countable"] is True, compact
+    missing_compact = compact_benchmark_experiment_report(missing_eval_report)
+    assert missing_compact is not None, missing_eval_report
+    missing_attempt = missing_compact["attempt_accounting"]
+    assert missing_attempt["failure_class"] == "official_score_failed", missing_compact
+    assert missing_attempt["case_attempt_countable"] is True, missing_compact
+    assert missing_attempt["solver_attempt_countable"] is True, missing_compact
+    assert missing_attempt["verifier_attempt_countable"] is False, missing_compact
+    assert missing_attempt["official_score_attempt_countable"] is False, missing_compact
     note = benchmark_experiment_report_readiness_note(compact)
     assert note is not None, compact
     assert note["next_run_authorization"] == "fixture_only", note
     assert note["leaderboard_evidence"] is False, note
     assert_public_safe(report)
     assert_public_safe(compact)
+    assert_public_safe(missing_eval_report)
+    assert_public_safe(missing_compact)
     assert_public_safe(note)
 
 

--- a/loopx/benchmark_adapters/agents_last_exam.py
+++ b/loopx/benchmark_adapters/agents_last_exam.py
@@ -20,6 +20,11 @@ from ..benchmark_case_state import (
     benchmark_case_active_state_path,
     benchmark_case_goal_id,
 )
+from ..benchmark_core import (
+    BenchmarkFailureClass,
+    build_benchmark_attempt_accounting,
+    canonical_lifecycle,
+)
 from ..benchmark_core.io import (
     load_json_object as _load_json_object,
     load_jsonl_objects as _load_jsonl_objects,
@@ -3814,6 +3819,36 @@ def build_agents_last_exam_result_benchmark_report(
         negative_layers.append("eval_result_missing")
     if error_type:
         negative_layers.append("eval_error_present")
+    attempt_lifecycle = canonical_lifecycle(
+        process_started=run_json_present,
+        runner_accepted_args=run_json_present,
+        job_root_materialized=run_json_present,
+        trial_started=run_json_present,
+        worker_started=bool(events) or completed or score is not None or bool(error_type),
+        result_written=eval_result_present,
+        verifier_scored=score is not None or bool(error_type),
+    )
+    if not run_json_present:
+        attempt_failure_class = BenchmarkFailureClass.RUNNER_STARTUP_FAILED
+        attempt_failure_label = "ale_run_json_missing"
+    elif error_type:
+        attempt_failure_class = BenchmarkFailureClass.VERIFIER_FAILED
+        attempt_failure_label = f"ale_eval_error:{error_type}"
+    elif score is None:
+        attempt_failure_class = BenchmarkFailureClass.OFFICIAL_SCORE_FAILED
+        attempt_failure_label = "ale_eval_score_missing"
+    elif score == 0:
+        attempt_failure_class = BenchmarkFailureClass.SOLVER_FAILED
+        attempt_failure_label = "ale_eval_score_zero"
+    else:
+        attempt_failure_class = BenchmarkFailureClass.NONE
+        attempt_failure_label = "none"
+    attempt_accounting = build_benchmark_attempt_accounting(
+        lifecycle=attempt_lifecycle,
+        failure_label=attempt_failure_label,
+        failure_class=attempt_failure_class,
+        official_score_attempted=score is not None,
+    )
 
     return {
         "schema_version": "benchmark_experiment_report_v0",
@@ -3837,6 +3872,7 @@ def build_agents_last_exam_result_benchmark_report(
             "submit_eligible": False,
             "leaderboard_evidence": False,
         },
+        "attempt_accounting": attempt_accounting,
         "passive_control_plane_score": {
             "restartability": 1.0 if run_json_present and events_jsonl_present else 0.5,
             "stale_state_avoidance": 1.0,

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -3390,6 +3390,11 @@ def compact_benchmark_experiment_report(run: dict[str, Any]) -> dict[str, Any] |
             compact_official[field] = official.get(field)
     if compact_official:
         compact["official_score"] = compact_official
+    attempt_accounting = _compact_benchmark_attempt_accounting(
+        source.get("attempt_accounting")
+    )
+    if attempt_accounting:
+        compact["attempt_accounting"] = attempt_accounting
 
     passive = (
         source.get("passive_control_plane_score")


### PR DESCRIPTION
## Summary
- add benchmark_attempt_accounting_v0 to ALE compact experiment reports
- compact attempt accounting through benchmark_experiment_report status output
- extend the existing ALE triage smoke to cover success and missing-eval attempt semantics

## Validation
- python3 examples/agents-last-exam-triage-smoke.py
- python3 examples/benchmark-attempt-accounting-smoke.py
- python3 examples/benchmark-experiment-report-append-cli-smoke.py
- python3 -m py_compile loopx/benchmark_adapters/agents_last_exam.py loopx/status.py examples/agents-last-exam-triage-smoke.py
- git diff --check
- loopx check --scan-path loopx/benchmark_adapters/agents_last_exam.py --scan-path loopx/status.py --scan-path examples/agents-last-exam-triage-smoke.py