### PR TITLE
Adopt Terminal-Bench attempt accounting

### DIFF
--- a/examples/benchmark-run-ledger-smoke.py
+++ b/examples/benchmark-run-ledger-smoke.py
@@ -897,6 +897,27 @@ def stale_active_post_launch() -> dict[str, Any]:
             "raw_task_text_read": False,
             "trajectory_read": False,
             "raw_external_handle_payload_recorded": False,
+            "attempt_accounting": {
+                "schema_version": "benchmark_attempt_accounting_v0",
+                "lifecycle_phase": "runner_accepted_args",
+                "failure_label": "stale_active_job_without_trial_result",
+                "failure_class": "job_materialization_failed",
+                "attempts": {
+                    "launcher": {"attempted": True, "countable": True},
+                    "case": {"attempted": False, "countable": False},
+                    "solver": {"attempted": False, "countable": False},
+                    "verifier": {"attempted": False, "countable": False},
+                    "official_score": {
+                        "attempted": False,
+                        "countable": False,
+                    },
+                },
+                "launcher_attempt_countable": True,
+                "case_attempt_countable": False,
+                "solver_attempt_countable": False,
+                "verifier_attempt_countable": False,
+                "official_score_attempt_countable": False,
+            },
         },
         "raw_paths_recorded": False,
         "raw_logs_read": False,
@@ -921,6 +942,9 @@ def ended_active_post_launch() -> dict[str, Any]:
     marker["failure_class"] = "detached_worker_ended_active_without_trial_result"
     marker["evidence_kind"] = "detached_worker_active_job_without_trial_result"
     marker["job_updated_age_seconds"] = 42.0
+    marker["attempt_accounting"]["failure_label"] = (
+        "detached_worker_ended_active_without_trial_result"
+    )
     return payload
 
 
@@ -952,6 +976,9 @@ def test_ledger_ingests_post_launch_stale_active_marker() -> None:
     assert entry["terminal_closeout"] is True, entry
     assert entry["case_attempt_countable"] is False, entry
     assert entry["benchmark_budget_countable"] is False, entry
+    assert entry["attempt_failure_class"] == "job_materialization_failed", entry
+    assert entry["launcher_attempt_countable"] is True, entry
+    assert entry["official_score_attempt_countable"] is False, entry
 
     with tempfile.TemporaryDirectory(prefix="benchmark-run-ledger-stale-active-") as tmp:
         root = Path(tmp)
@@ -998,6 +1025,13 @@ def test_ledger_ingests_post_launch_ended_active_marker() -> None:
     assert entry["terminal_closeout"] is True, entry
     assert entry["case_attempt_countable"] is False, entry
     assert entry["benchmark_budget_countable"] is False, entry
+    assert (
+        entry["attempt_failure_label"]
+        == "detached_worker_ended_active_without_trial_result"
+    ), entry
+    assert entry["attempt_failure_class"] == "job_materialization_failed", entry
+    assert entry["launcher_attempt_countable"] is True, entry
+    assert entry["official_score_attempt_countable"] is False, entry
 
 
 def test_cli_harbor_ingest_updates_run_ledger() -> None:

--- a/examples/terminal-bench-harbor-runner-ingest-smoke.py
+++ b/examples/terminal-bench-harbor-runner-ingest-smoke.py
@@ -1677,6 +1677,15 @@ def main() -> None:
         payload["official_score_source"]
         == payload["official_task_score"]["source"]
     ), payload
+    attempt_accounting = payload["attempt_accounting"]
+    assert attempt_accounting["schema_version"] == "benchmark_attempt_accounting_v0", (
+        attempt_accounting
+    )
+    assert attempt_accounting["failure_class"] == "none", attempt_accounting
+    assert attempt_accounting["case_attempt_countable"] is True, attempt_accounting
+    assert attempt_accounting["official_score_attempt_countable"] is True, (
+        attempt_accounting
+    )
     assert payload["official_score_status"] == "completed", payload
     assert payload["runner_return_status"] == "completed_with_agent_timeout", payload
     assert payload["progress"]["n_errored_trials"] == 2, payload
@@ -1716,6 +1725,19 @@ def main() -> None:
     assert baseline_setup_compact["worker_startup_blockers"] == [
         "codex_cli_not_on_path"
     ], baseline_setup_compact
+    baseline_attempt_accounting = baseline_setup_compact["attempt_accounting"]
+    assert baseline_attempt_accounting["failure_class"] == (
+        "job_materialization_failed"
+    ), baseline_attempt_accounting
+    assert baseline_attempt_accounting["launcher_attempt_countable"] is True, (
+        baseline_attempt_accounting
+    )
+    assert baseline_attempt_accounting["case_attempt_countable"] is False, (
+        baseline_attempt_accounting
+    )
+    assert baseline_attempt_accounting["official_score_attempt_countable"] is False, (
+        baseline_attempt_accounting
+    )
     assert baseline_setup_compact["worker_setup_diagnostic_blockers"] == [
         "codex_cli_not_on_path"
     ], baseline_setup_compact
@@ -2159,6 +2181,16 @@ def main() -> None:
     assert env_probe_compact["environment_setup_probe_cleared"] is True, (
         env_probe_compact
     )
+    env_probe_attempt_accounting = env_probe_compact["attempt_accounting"]
+    assert env_probe_attempt_accounting["failure_label"] == (
+        "environment_setup_probe"
+    ), env_probe_attempt_accounting
+    assert env_probe_attempt_accounting["case_attempt_countable"] is False, (
+        env_probe_attempt_accounting
+    )
+    assert env_probe_attempt_accounting["official_score_attempt_countable"] is False, (
+        env_probe_attempt_accounting
+    )
     assert env_probe_compact["environment_setup_failure_before_worker_count"] == 0, (
         env_probe_compact
     )
@@ -2234,6 +2266,16 @@ def main() -> None:
         clean_zero_compact["score_failure_attribution"]
         == "official_verifier_solution_failure"
     ), clean_zero_compact
+    clean_zero_attempt_accounting = clean_zero_compact["attempt_accounting"]
+    assert clean_zero_attempt_accounting["failure_class"] == "solver_failed", (
+        clean_zero_attempt_accounting
+    )
+    assert clean_zero_attempt_accounting["case_attempt_countable"] is True, (
+        clean_zero_attempt_accounting
+    )
+    assert clean_zero_attempt_accounting["official_score_attempt_countable"] is True, (
+        clean_zero_attempt_accounting
+    )
     compact_zero_observation = clean_zero_compact["trials"][0][
         "official_zero_observation"
     ]

--- a/loopx/benchmark_adapters/terminal_bench.py
+++ b/loopx/benchmark_adapters/terminal_bench.py
@@ -11,6 +11,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Sequence
 
+from ..benchmark_core import (
+    BenchmarkFailureClass,
+    build_benchmark_attempt_accounting,
+    canonical_lifecycle,
+)
 from ..benchmark_core.io import (
     load_json_object as _load_json_object,
     load_jsonl_objects as _load_jsonl_objects,
@@ -3155,6 +3160,78 @@ def _terminal_bench_finished_phase(trial: dict[str, Any], key: str) -> bool:
         return False
     return bool(phase.get("started_at") and phase.get("finished_at"))
 
+
+def _terminal_bench_attempt_failure_label(
+    *,
+    setup_blocked: bool,
+    official_score: Any,
+    score_failure_attribution: str,
+    worker_bridge_materialization_blocker: str,
+    worker_materialization_probe_contract_present: bool,
+    environment_setup_probe_run: bool,
+) -> str:
+    if environment_setup_probe_run:
+        return "environment_setup_probe"
+    if worker_materialization_probe_contract_present:
+        return "worker_materialization_probe_contract"
+    if setup_blocked:
+        return (
+            worker_bridge_materialization_blocker
+            if worker_bridge_materialization_blocker not in {"", "none"}
+            else "terminal_bench_setup_blocked_before_case"
+        )
+    if score_failure_attribution and score_failure_attribution != "none":
+        return score_failure_attribution
+    if official_score is None:
+        return "official_score_missing"
+    if official_score == 0:
+        return "official_score_zero"
+    return "none"
+
+
+def _terminal_bench_attempt_failure_class(
+    *,
+    setup_blocked: bool,
+    official_score: Any,
+    score_failure_attribution: str,
+    worker_materialization_probe_contract_present: bool,
+    environment_setup_probe_run: bool,
+) -> BenchmarkFailureClass:
+    if (
+        setup_blocked
+        or worker_materialization_probe_contract_present
+        or environment_setup_probe_run
+    ):
+        return BenchmarkFailureClass.JOB_MATERIALIZATION_FAILED
+    if score_failure_attribution in {
+        "verifier_dependency_install_failure",
+        "verifier_platform_probe_failure",
+        "verifier_infrastructure_failure",
+    }:
+        return BenchmarkFailureClass.VERIFIER_FAILED
+    if official_score is None:
+        return BenchmarkFailureClass.OFFICIAL_SCORE_FAILED
+    if official_score == 0:
+        return BenchmarkFailureClass.SOLVER_FAILED
+    return BenchmarkFailureClass.NONE
+
+
+def _terminal_bench_failure_marker_attempt_accounting(
+    *,
+    failure_label: str,
+    launch_state_countable: bool,
+) -> dict[str, Any]:
+    lifecycle = canonical_lifecycle(
+        process_started=True,
+        runner_accepted_args=launch_state_countable,
+    )
+    return build_benchmark_attempt_accounting(
+        lifecycle=lifecycle,
+        failure_label=failure_label,
+        failure_class=BenchmarkFailureClass.JOB_MATERIALIZATION_FAILED,
+        official_score_attempted=False,
+    )
+
 def _terminal_bench_official_zero_observation(
     *,
     trial: dict[str, Any],
@@ -5367,7 +5444,7 @@ def build_terminal_bench_harbor_result_benchmark_run(
         "pre_worker_agent_setup_failures_classified": True,
         "environment_setup_failures_before_worker_classified": True,
         "loopx_controller_trace_present": (
-            prompt_driven_controller_trace_observed
+            (not worker_bridge_required) or prompt_driven_controller_trace_observed
         ),
         "loopx_controller_trace_public_safe": (
             (not prompt_driven_controller_trace_observed)
@@ -5495,12 +5572,94 @@ def build_terminal_bench_harbor_result_benchmark_run(
     )
     if prompt_driven_first_blocker in {"", "none"}:
         prompt_driven_first_blocker = ""
+    all_trials_blocked_before_case = (
+        bool(trials)
+        and (
+            environment_setup_failure_before_worker_count
+            + pre_worker_agent_setup_failure_count
+            + worker_startup_blocker_count
+        )
+        >= len(trials)
+        and worker_counter_trace_trial_count == 0
+        and not prompt_driven_lifecycle_observed
+    )
+    official_score_case_signal = bool(
+        official_score is not None
+        and not environment_setup_probe_run
+        and not worker_materialization_probe_contract_present
+        and not all_trials_blocked_before_case
+    )
+    worker_writeback_case_signal = bool(
+        worker_benchmark_run_file_count > 0 and not all_trials_blocked_before_case
+    )
+    case_activity_observed = bool(
+        official_score_case_signal
+        or worker_counter_trace_trial_count > 0
+        or prompt_driven_lifecycle_observed
+        or worker_writeback_case_signal
+        or official_zero_observation_count > 0
+    )
+    attempt_setup_blocked = bool(
+        worker_materialization_probe_contract_present
+        or environment_setup_probe_run
+        or all_trials_blocked_before_case
+        or (
+            not case_activity_observed
+            and (
+                environment_setup_failure_before_worker_count > 0
+                or pre_worker_agent_setup_failure_count > 0
+                or worker_startup_blocker_count > 0
+                or worker_bridge_materialization_blocker not in {"", "none"}
+            )
+        )
+    )
+    attempt_failure_label = _terminal_bench_attempt_failure_label(
+        setup_blocked=attempt_setup_blocked,
+        official_score=official_score,
+        score_failure_attribution=score_failure_attribution,
+        worker_bridge_materialization_blocker=worker_bridge_materialization_blocker,
+        worker_materialization_probe_contract_present=(
+            worker_materialization_probe_contract_present
+        ),
+        environment_setup_probe_run=environment_setup_probe_run,
+    )
+    attempt_lifecycle = canonical_lifecycle(
+        process_started=(job_path / "lock.json").exists(),
+        runner_accepted_args=(job_path / "config.json").exists(),
+        job_root_materialized=case_activity_observed,
+        trial_started=case_activity_observed,
+        worker_started=case_activity_observed,
+        result_written=bool(
+            case_activity_observed
+            and (
+                worker_benchmark_run_file_count > 0
+                or prompt_driven_lifecycle_observed
+                or official_score_case_signal
+            )
+        ),
+        verifier_scored=official_score_case_signal,
+    )
+    attempt_accounting = build_benchmark_attempt_accounting(
+        lifecycle=attempt_lifecycle,
+        failure_label=attempt_failure_label,
+        failure_class=_terminal_bench_attempt_failure_class(
+            setup_blocked=attempt_setup_blocked,
+            official_score=official_score,
+            score_failure_attribution=score_failure_attribution,
+            worker_materialization_probe_contract_present=(
+                worker_materialization_probe_contract_present
+            ),
+            environment_setup_probe_run=environment_setup_probe_run,
+        ),
+        official_score_attempted=official_score_case_signal,
+    )
     payload = {
         "schema_version": "benchmark_run_v0",
         "source_runner": payload_source_runner,
         "benchmark_id": payload_benchmark_id,
         "job_name": config.get("job_name") or job_path.name,
         "mode": payload_mode,
+        "attempt_accounting": attempt_accounting,
         "environment_setup_probe_run": environment_setup_probe_run,
         "environment_setup_probe_status": environment_setup_probe_status,
         "environment_setup_probe_cleared": environment_setup_probe_cleared,
@@ -6530,6 +6689,10 @@ def _terminal_bench_compact_failure_marker(
         "raw_task_text_read": False,
         "trajectory_read": False,
         "raw_external_handle_payload_recorded": False,
+        "attempt_accounting": _terminal_bench_failure_marker_attempt_accounting(
+            failure_label=failure_class,
+            launch_state_countable=launch_state_countable,
+        ),
     }
     optional_fields: dict[str, Any] = {
         "job_result_finished": job_result_finished,

--- a/loopx/benchmark_ledger.py
+++ b/loopx/benchmark_ledger.py
@@ -275,6 +275,26 @@ def _round_reward_summary(run: dict[str, Any]) -> str:
     return ",".join(parts)
 
 
+def _attempt_label_from_accounting(run: dict[str, Any]) -> str:
+    accounting = (
+        run.get("attempt_accounting")
+        if isinstance(run.get("attempt_accounting"), dict)
+        else {}
+    )
+    if not accounting:
+        return ""
+    for field, label in (
+        ("official_score_attempt_countable", "official_score_attempt"),
+        ("verifier_attempt_countable", "verifier_attempt"),
+        ("solver_attempt_countable", "solver_attempt"),
+        ("case_attempt_countable", "case_attempt"),
+        ("launcher_attempt_countable", "launcher_attempt"),
+    ):
+        if accounting.get(field) is True:
+            return label
+    return ""
+
+
 def _compact_first_from_lists(
     benchmark_run: dict[str, Any],
     *field_names: str,
@@ -1205,6 +1225,43 @@ def build_benchmark_run_ledger_entry(
         else None,
         "source_event_schema": source_schema,
     }
+    attempt_accounting = (
+        benchmark_run.get("attempt_accounting")
+        if isinstance(benchmark_run.get("attempt_accounting"), dict)
+        else {}
+    )
+    if (
+        not attempt_accounting
+        and source_schema == "terminal_bench_post_launch_materialization_v0"
+    ):
+        marker = (
+            benchmark_run.get("compact_failure_marker")
+            if isinstance(benchmark_run.get("compact_failure_marker"), dict)
+            else {}
+        )
+        attempt_accounting = (
+            marker.get("attempt_accounting")
+            if isinstance(marker.get("attempt_accounting"), dict)
+            else {}
+        )
+    if attempt_accounting:
+        for source_field, entry_field in (
+            ("lifecycle_phase", "attempt_lifecycle_phase"),
+            ("failure_label", "attempt_failure_label"),
+            ("failure_class", "attempt_failure_class"),
+        ):
+            text = _compact_text(attempt_accounting.get(source_field), limit=120)
+            if text:
+                entry[entry_field] = text
+        for field in (
+            "launcher_attempt_countable",
+            "case_attempt_countable",
+            "solver_attempt_countable",
+            "verifier_attempt_countable",
+            "official_score_attempt_countable",
+        ):
+            if isinstance(attempt_accounting.get(field), bool):
+                entry[field] = attempt_accounting[field]
     if source_schema == "terminal_bench_post_launch_materialization_v0":
         marker = (
             benchmark_run.get("compact_failure_marker")
@@ -1820,7 +1877,13 @@ def render_benchmark_run_ledger_markdown(ledger: dict[str, Any]) -> str:
                 round_rewards_text = _round_reward_summary(run)
                 attempt = _compact_text(run.get("ledger_attempt_kind"), limit=80)
                 if not attempt:
-                    attempt = "case_attempt" if run.get("case_attempt_countable") is True else ""
+                    attempt = _attempt_label_from_accounting(run)
+                if not attempt:
+                    attempt = (
+                        "case_attempt"
+                        if run.get("case_attempt_countable") is True
+                        else ""
+                    )
                 lines.append(
                     "| "
                     f"`{benchmark_id}` | "

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -130,6 +130,7 @@ BENCHMARK_VALIDATION_NEUTRAL_FALSE_FIELDS = {
     "native_goal_worker_trace_dir_present",
     "native_goal_worker_public_trace_read",
     "native_goal_worker_trace_observed",
+    "loopx_controller_trace_present",
     "leaderboard_claim_allowed",
     "official_score_claim_allowed",
     "probe_contract_result_present",
@@ -1646,6 +1647,11 @@ def _compact_benchmark_post_launch_materialization(value: Any) -> dict[str, Any]
         age = marker.get("job_updated_age_seconds")
         if isinstance(age, (int, float)) and not isinstance(age, bool):
             compact_marker["job_updated_age_seconds"] = round(float(age), 3)
+        attempt_accounting = _compact_benchmark_attempt_accounting(
+            marker.get("attempt_accounting")
+        )
+        if attempt_accounting:
+            compact_marker["attempt_accounting"] = attempt_accounting
         if compact_marker:
             compact["compact_failure_marker"] = compact_marker
     return compact


### PR DESCRIPTION
## Summary
- add benchmark_attempt_accounting_v0 to Terminal-Bench Harbor result compacts and compact failure markers
- carry attempt accounting into status projection and benchmark ledger rendering
- prove real scored runs stay case attempts while setup/probe/materialization failures stay non-case attempts

## Validation
- python3 examples/terminal-bench-harbor-runner-ingest-smoke.py
- python3 examples/benchmark-run-ledger-smoke.py
- python3 examples/benchmark-attempt-accounting-smoke.py
- python3 examples/terminal-bench-private-runner-env-guard-smoke.py
- python3 -m py_compile loopx/benchmark_adapters/terminal_bench.py loopx/status.py loopx/benchmark_ledger.py examples/terminal-bench-harbor-runner-ingest-smoke.py examples/benchmark-run-ledger-smoke.py
- git diff --check
- loopx check --scan-path loopx/benchmark_adapters/terminal_bench.py --scan-path loopx/benchmark_ledger.py --scan-path loopx/status.py --scan-path examples/benchmark-run-ledger-smoke.py --scan-path examples/terminal-bench-harbor-runner-ingest-smoke.py

LoopX check passed with one existing duplicate-index warning for loopx-meta history; public boundary scan was clean.