### PR TITLE
Add public harness interaction coverage

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/benchmark-case-analysis.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-case-analysis.md
@@ -14,35 +14,43 @@ records compact attempts and scores; this file records why a result matters.
 
 ## Summary
 
-The table now prefers the current benchmark protocol when it exists:
-SkillsBench main rows use raw Codex autonomous max5 versus LoopX
-product-mode, and Terminal-Bench rows must distinguish legacy
-`codex_loopx` evidence from the current LoopX managed route.
-Legacy positives stay in the case notes as assets, but should not be counted as
-current main-table uplift until a current-protocol rerun closes.
+The table below is generated from compact public case-analysis JSON. It uses
+`n/a` when the compact record does not establish a comparable paired arm,
+and it preserves detailed hand-authored case notes below the generated
+summary sections.
 
-The latest ledger-only migration audit explicitly classified 17 compact
-ledger-only cases. Seven are promotion-ready when they teach a reusable routing
-or non-regression lesson; four are already represented by Terminal-Bench
-current-protocol coverage rows; the remainder are setup/probe/defer rows that
-should not be promoted into main case analysis until compact score or blocker
-evidence becomes useful.
-
-The 2026-06-22 generated-safe upsert promoted eight compact-ledger records into
-the machine JSON and human table: one Terminal-Bench no-uplift row and seven
-baseline-solved control rows. It still leaves infrastructure-alignment,
-baseline-failure, setup, and single-arm candidates outside automatic promotion
-until matched treatment or manual attribution exists.
+- case_count: `34`
+- generated_compact_record_count: `8`
 
 | Benchmark | Case | Class | Baseline | Treatment | Delta | Decision |
 | --- | --- | --- | --- | --- | --- | --- |
-| `terminal-bench@2.0` | `multi-source-data-merger` | current-protocol baseline-solved / legacy positive asset | `1.0` | `1.0` | `0.0` | `paired_baseline_solved_treatment_preserved` |
-| `terminal-bench@2.0` | `nginx-request-logging` | current-protocol baseline-solved / legacy runner asset | `1.0` | `1.0` | `0.0` | `paired_baseline_solved_treatment_preserved` |
-| `terminal-bench@2.0` | `make-doom-for-mips` | timeout attribution asset | `0.0` | `0.0` | `0.0` | `paired_result_requires_attribution` |
-| `terminal-bench@2.0` | `mteb-retrieve` | setup probe asset | `0.0` | `0.0` | `0.0` | `environment_setup_probe_materialized_with_exception_repeat_blocked` |
-| `terminal-bench@2.0` | `pytorch-model-recovery` | exception attribution asset | `0.0` | `0.0` | `0.0` | `paired_no_score_uplift_exception_research_required` |
-| `terminal-bench@2.0` | `train-fasttext` | single-arm managed-Codex failure asset | n/a | `0.0` | n/a | `single_arm_recorded` |
-| `terminal-bench@2.0` | `headless-terminal` | generated no-uplift asset | `0.0` | `0.0` | `0.0` | `paired_no_score_uplift` |
+| `terminal-bench@2.0` | `multi-source-data-merger` | current-protocol baseline-solved / non-regression asset | `1` | `1` | `` | `paired_baseline_solved_treatment_preserved` |
+| `terminal-bench@2.0` | `nginx-request-logging` | current-protocol baseline-solved / non-regression asset | `1` | `1` | `` | `paired_baseline_solved_treatment_preserved` |
+| `terminal-bench@2.0` | `make-doom-for-mips` | timeout attribution asset | `` | `` | `` | `paired_result_requires_attribution` |
+| `terminal-bench@2.0` | `mteb-retrieve` | setup probe asset | `` | `` | `` | `environment_setup_probe_materialized_with_exception_repeat_blocked` |
+| `terminal-bench@2.0` | `pytorch-model-recovery` | exception attribution asset | `` | `` | `` | `paired_no_score_uplift_exception_research_required` |
+| `skillsbench@1.1` | `llm-prefix-cache-replay` | reward feedback positive blind loop neutral asset | `` | `` | `` | `reward_feedback_positive_primary_blind_loop_no_uplift` |
+| `skillsbench@1.1` | `tictoc-unnecessary-abort-detection` | native goal connected no trace runner error asset | `` | n/a | n/a | `baseline_runner_or_setup_repair_required` |
+| `skillsbench@1.1` | `dapt-intrusion-detection` | reward feedback positive blind loop neutral asset | `` | `` | `` | `reward_feedback_positive_primary_blind_loop_no_uplift` |
+| `skillsbench@1.1` | `debug-trl-grpo` | regression asset | `0.25` | `` | `-0.25` | `paired_treatment_regressed` |
+| `skillsbench@1.1` | `civ6-adjacency-optimizer` | no-uplift asset | `` | `` | `` | `paired_no_score_uplift` |
+| `skillsbench@1.1` | `manufacturing-codebook-normalization` | no-uplift asset | `` | `` | `` | `paired_no_score_uplift` |
+| `skillsbench@1.1` | `software-dependency-audit` | no-uplift asset | `` | `` | `` | `paired_no_score_uplift` |
+| `skillsbench@1.1` | `react-performance-debugging` | no-uplift asset | `` | `` | `` | `paired_no_score_uplift` |
+| `skillsbench@1.1` | `pddl-airport-planning` | no-uplift asset | `` | `` | `` | `paired_no_score_uplift` |
+| `skillsbench@1.1` | `ada-bathroom-plan-repair` | current-protocol baseline-solved / non-regression asset | `1` | `1` | `` | `paired_baseline_solved_treatment_preserved` |
+| `skillsbench@1.1` | `organize-messy-files` | current-protocol baseline-solved / non-regression asset | `1` | `1` | `` | `paired_baseline_solved_treatment_preserved` |
+| `skillsbench@1.1` | `citation-check` | current-protocol baseline-solved / non-regression asset | `1` | `1` | `` | `paired_baseline_solved_treatment_preserved` |
+| `skillsbench@1.1` | `3d-scan-calc` | current-protocol baseline-solved / non-regression asset | `1` | `1` | `` | `paired_baseline_solved_treatment_preserved` |
+| `skillsbench@1.1` | `bike-rebalance` | current-protocol baseline-solved / non-regression asset | `1` | `1` | `` | `paired_baseline_solved_treatment_preserved` |
+| `skillsbench@1.1` | `azure-bgp-oscillation-route-leak` | no-uplift asset | `` | `` | `` | `paired_no_score_uplift` |
+| `terminal-bench@2.0` | `train-fasttext` | single arm failure asset | n/a | `` | n/a | `single_arm_recorded` |
+| `skillsbench@1.1` | `setup-fuzzing-py` | setup blocker asset | `missing` | n/a | n/a | `baseline_runner_or_setup_repair_required` |
+| `skillsbench@1.1` | `adaptive-cruise-control` | setup blocker asset | `missing` | n/a | n/a | `baseline_runner_or_setup_repair_required` |
+| `skillsbench@1.1` | `travel-planning` | baseline solved control asset | `1.0` | n/a | n/a | `baseline_passed_not_current_treatment_priority` |
+| `skillsbench@1.1` | `paratransit-routing` | product mode invalid shallow loopx asset | `` | `` | `` | `product_mode_treatment_invalid_shallow_loopx_lifecycle` |
+| `swe-marathon` | `zstd-decoder` | extended round product path negative asset | `1.0` | `` | `-1.0` | `paired_treatment_regressed` |
+| `terminal-bench@2.0` | `headless-terminal` | generated no-uplift asset | `` | `` | `` | `paired_no_score_uplift` |
 | `terminal-bench@2.0` | `build-cython-ext` | generated baseline-solved control asset | `1.0` | n/a | n/a | `baseline_passed_not_current_treatment_priority` |
 | `terminal-bench@2.0` | `compile-compcert` | generated baseline-solved control asset | `1.0` | n/a | n/a | `baseline_passed_not_current_treatment_priority` |
 | `terminal-bench@2.0` | `financial-document-processor` | generated baseline-solved control asset | `1.0` | n/a | n/a | `baseline_passed_not_current_treatment_priority` |
@@ -50,26 +58,6 @@ until matched treatment or manual attribution exists.
 | `terminal-bench@2.0` | `merge-diff-arc-agi-task` | generated baseline-solved control asset | `1.0` | n/a | n/a | `baseline_passed_not_current_treatment_priority` |
 | `terminal-bench@2.0` | `path-tracing` | generated baseline-solved control asset | `1.0` | n/a | n/a | `baseline_passed_not_current_treatment_priority` |
 | `terminal-bench@2.0` | `sqlite-db-truncate` | generated baseline-solved control asset | `1.0` | n/a | n/a | `baseline_passed_not_current_treatment_priority` |
-| `swe-marathon` | `zstd-decoder` | extended-round product-path negative asset | `1.0` | `0.0` | `-1.0` | `paired_treatment_regressed` |
-| `skillsbench@1.1` | `llm-prefix-cache-replay` | reward-feedback positive / blind-loop neutral asset | `0.0` | `0.0` | `0.0` | `reward_feedback_positive_primary_blind_loop_no_uplift` |
-| `skillsbench@1.1` | `tictoc-unnecessary-abort-detection` | native Goal connected-no-trace runner-error asset | `0.0` | n/a | n/a | `baseline_runner_or_setup_repair_required` |
-| `skillsbench@1.1` | `dapt-intrusion-detection` | reward-feedback positive / blind-loop neutral asset | `0.0` | `0.0` | `0.0` | `reward_feedback_positive_primary_blind_loop_no_uplift` |
-| `skillsbench@1.1` | `paratransit-routing` | product-mode invalid shallow LoopX / blind-loop+depth-gate positive asset | `0.0` | `0.0` | `0.0` | `product_mode_treatment_invalid_shallow_loopx_lifecycle` |
-| `skillsbench@1.1` | `debug-trl-grpo` | regression asset | `0.25` | `0.0` | `-0.25` | `paired_treatment_regressed` |
-| `skillsbench@1.1` | `civ6-adjacency-optimizer` | no-uplift asset | `0.0` | `0.0` | `0.0` | `paired_no_score_uplift` |
-| `skillsbench@1.1` | `manufacturing-codebook-normalization` | no-uplift asset | `0.0` | `0.0` | `0.0` | `paired_no_score_uplift` |
-| `skillsbench@1.1` | `software-dependency-audit` | no-uplift asset | `0.0` | `0.0` | `0.0` | `paired_no_score_uplift` |
-| `skillsbench@1.1` | `react-performance-debugging` | no-uplift asset | `0.0` | `0.0` | `0.0` | `paired_no_score_uplift` |
-| `skillsbench@1.1` | `pddl-airport-planning` | no-uplift asset | `0.0` | `0.0` | `0.0` | `paired_no_score_uplift` |
-| `skillsbench@1.1` | `azure-bgp-oscillation-route-leak` | no-uplift asset | `0.0` | `0.0` | `0.0` | `paired_no_score_uplift` |
-| `skillsbench@1.1` | `ada-bathroom-plan-repair` | baseline-solved non-regression asset | `1.0` | `1.0` | `0.0` | `paired_baseline_solved_treatment_preserved` |
-| `skillsbench@1.1` | `organize-messy-files` | baseline-solved non-regression asset | `1.0` | `1.0` | `0.0` | `paired_baseline_solved_treatment_preserved` |
-| `skillsbench@1.1` | `citation-check` | baseline-solved non-regression asset | `1.0` | `1.0` | `0.0` | `paired_baseline_solved_treatment_preserved` |
-| `skillsbench@1.1` | `3d-scan-calc` | baseline-solved non-regression asset | `1.0` | `1.0` | `0.0` | `paired_baseline_solved_treatment_preserved` |
-| `skillsbench@1.1` | `bike-rebalance` | baseline-solved non-regression asset | `1.0` | `1.0` | `0.0` | `paired_baseline_solved_treatment_preserved` |
-| `skillsbench@1.1` | `travel-planning` | baseline-solved control asset | `1.0` | n/a | n/a | `baseline_passed_not_current_treatment_priority` |
-| `skillsbench@1.1` | `setup-fuzzing-py` | setup blocker asset | missing | n/a | n/a | `baseline_runner_or_setup_repair_required` |
-| `skillsbench@1.1` | `adaptive-cruise-control` | setup blocker asset | missing | n/a | n/a | `baseline_runner_or_setup_repair_required` |
 
 ## Public Trajectory Summary Coverage
 
@@ -86,6 +74,32 @@ not yet contain a public trajectory summary.
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | `skillsbench@1.1` | `debug-trl-grpo` | `trajectory_public_summary` (public-safe) | `5` | `112` | `0` | `2` | `yes` |
 | `skillsbench@1.1` | `paratransit-routing` | `legacy_blind_loop_positive_result.trajectory_public_summary` (public-safe) | `1` | `16` | `0` | `0` | `yes` |
+
+## Public Harness Interaction Coverage
+
+These rows are generated from compact case-analysis counters across
+benchmarks. They combine SkillsBench trajectory summaries, Terminal-Bench
+worker/LoopX counters, SWE-Marathon product-path counters, and any future
+benchmark case records that expose the same public fields. They do not read
+or copy raw trajectories, task text, verifier output, logs, or local paths.
+
+- schema_version: `harness_interaction_public_summary_coverage_v0`
+- summary_count: `11`
+- benchmark_ids: `skillsbench@1.1, swe-marathon, terminal-bench@2.0`
+
+| Benchmark | Case | Source | Kind | LoopX CLI | Rounds | Tools | Events | Controller Trace | Lifecycle |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `skillsbench@1.1` | `debug-trl-grpo` | `trajectory_public_summary` (public-safe) | `trajectory_public_summary` | `0` | `5` | `112` | `0` | `no` | `no` |
+| `skillsbench@1.1` | `llm-prefix-cache-replay` | `native_goal_route_observations` (public-safe) | `native_goal_route_observation` | `0` | `0` | `0` | `0` | `yes` | `no` |
+| `skillsbench@1.1` | `paratransit-routing` | `arms.treatment` (public-safe) | `case_arm` | `1` | `0` | `0` | `0` | `no` | `no` |
+| `skillsbench@1.1` | `paratransit-routing` | `legacy_blind_loop_positive_result.trajectory_public_summary` (public-safe) | `trajectory_public_summary` | `0` | `1` | `16` | `0` | `no` | `no` |
+| `skillsbench@1.1` | `paratransit-routing` | `product_mode_attribution.blind_loop_positive_treatment` (public-safe) | `product_mode_attribution` | `0` | `0` | `16` | `0` | `no` | `no` |
+| `skillsbench@1.1` | `paratransit-routing` | `product_mode_attribution.product_mode_neutral_treatment` (public-safe) | `product_mode_attribution` | `1` | `0` | `13` | `0` | `no` | `no` |
+| `skillsbench@1.1` | `tictoc-unnecessary-abort-detection` | `native_goal_route_observations` (public-safe) | `native_goal_route_observation` | `0` | `0` | `0` | `0` | `yes` | `no` |
+| `swe-marathon` | `zstd-decoder` | `arms.baseline` (public-safe) | `case_arm` | `0` | `0` | `0` | `0` | `no` | `no` |
+| `swe-marathon` | `zstd-decoder` | `arms.treatment` (public-safe) | `case_arm` | `31` | `0` | `0` | `0` | `no` | `yes` |
+| `terminal-bench@2.0` | `nginx-request-logging` | `arms.treatment` (public-safe) | `case_arm` | `0` | `0` | `0` | `0` | `no` | `no` |
+| `terminal-bench@2.0` | `nginx-request-logging` | `legacy_runner_materialization_asset.arms.treatment` (public-safe) | `case_arm` | `0` | `0` | `0` | `0` | `no` | `no` |
 
 ## Terminal-Bench Current-Protocol Coverage
 

--- a/examples/benchmark-case-analysis-smoke.py
+++ b/examples/benchmark-case-analysis-smoke.py
@@ -13,7 +13,10 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from loopx.benchmark_case_analysis import trajectory_public_summary_coverage  # noqa: E402
+from loopx.benchmark_case_analysis import (  # noqa: E402
+    harness_interaction_public_summary_coverage,
+    trajectory_public_summary_coverage,
+)
 ANALYSIS_JSON = (
     REPO_ROOT
     / "docs"
@@ -88,6 +91,58 @@ def test_case_analysis_json() -> None:
     for row in trajectory_coverage["rows"]:
         assert row["public_safe"] is True, row
         assert row["private_trajectory_present"] is True, row
+    harness_coverage = harness_interaction_public_summary_coverage(payload)
+    assert harness_coverage["schema_version"] == (
+        "harness_interaction_public_summary_coverage_v0"
+    ), harness_coverage
+    assert harness_coverage["raw_trajectory_recorded"] is False, harness_coverage
+    assert harness_coverage["raw_task_text_recorded"] is False, harness_coverage
+    assert harness_coverage["raw_verifier_output_recorded"] is False, harness_coverage
+    assert harness_coverage["raw_logs_recorded"] is False, harness_coverage
+    assert harness_coverage["summary_count"] >= 8, harness_coverage
+    assert harness_coverage["public_safe_count"] == harness_coverage[
+        "summary_count"
+    ], harness_coverage
+    assert {"skillsbench@1.1", "terminal-bench@2.0", "swe-marathon"}.issubset(
+        set(harness_coverage["benchmark_ids"])
+    ), harness_coverage
+    harness_rows = {
+        (row["benchmark_id"], row["case_id"], row["summary_path"]): row
+        for row in harness_coverage["rows"]
+    }
+    swe_zstd_harness = harness_rows[
+        ("swe-marathon", "zstd-decoder", "arms.treatment")
+    ]
+    assert swe_zstd_harness["loopx_cli_call_count"] == 31, swe_zstd_harness
+    assert swe_zstd_harness["lifecycle_observed"] is True, swe_zstd_harness
+    terminal_nginx_harness = harness_rows[
+        ("terminal-bench@2.0", "nginx-request-logging", "arms.treatment")
+    ]
+    assert terminal_nginx_harness["source_kind"] == "case_arm", (
+        terminal_nginx_harness
+    )
+    assert terminal_nginx_harness["loopx_cli_call_count"] == 0, (
+        terminal_nginx_harness
+    )
+    skillsbench_native_harness = harness_rows[
+        (
+            "skillsbench@1.1",
+            "llm-prefix-cache-replay",
+            "native_goal_route_observations",
+        )
+    ]
+    assert skillsbench_native_harness["controller_trace_present"] is True, (
+        skillsbench_native_harness
+    )
+    debug_trajectory_harness = harness_rows[
+        ("skillsbench@1.1", "debug-trl-grpo", "trajectory_public_summary")
+    ]
+    assert debug_trajectory_harness["tool_call_count"] == 112, (
+        debug_trajectory_harness
+    )
+    assert debug_trajectory_harness["private_trajectory_present"] is True, (
+        debug_trajectory_harness
+    )
     by_case = {(case["benchmark_id"], case["case_id"]): case for case in cases}
     terminal_coverage = payload["terminal_bench_current_protocol_coverage"]
     assert terminal_coverage["schema_version"] == (
@@ -1150,7 +1205,7 @@ def test_case_analysis_markdown() -> None:
     assert "dapt-intrusion-detection" in text, text
     assert "debug-trl-grpo" in text, text
     assert "zstd-decoder" in text, text
-    assert "extended-round product-path negative asset" in text, text
+    assert "extended round product path negative asset" in text, text
     assert "Product-path verification does not prove causal regression" in text, text
     assert "31 LoopX CLI calls" in text, text
     assert "make-doom-for-mips" in text, text
@@ -1177,6 +1232,11 @@ def test_case_analysis_markdown() -> None:
     assert "Terminal-Bench Current-Protocol Coverage" in text, text
     assert "Public Trajectory Summary Coverage" in text, text
     assert "trajectory_public_summary_coverage_v0" in text, text
+    assert "Public Harness Interaction Coverage" in text, text
+    assert "harness_interaction_public_summary_coverage_v0" in text, text
+    assert "`swe-marathon` | `zstd-decoder` | `arms.treatment`" in text, text
+    assert "`terminal-bench@2.0` | `nginx-request-logging` | `arms.treatment`" in text, text
+    assert "native_goal_route_observations" in text, text
     assert "legacy_blind_loop_positive_result.trajectory_public_summary" in text, text
     assert "`debug-trl-grpo` | `trajectory_public_summary`" in text, text
     assert "current-protocol success-preservation guards" in text, text
@@ -1202,7 +1262,7 @@ def test_case_analysis_markdown() -> None:
     assert "not explained by interaction count alone" in text, text
     assert "protocol v10" in text and "paired_no_score_uplift" in text, text
     assert "max-5 rerun" in text and "1:0,2:0,3:0,4:0,5:0" in text, text
-    assert "reward-feedback positive / blind-loop neutral asset" in text, text
+    assert "reward feedback positive blind loop neutral asset" in text, text
     assert "protocol v0" in text and "first_success_round=null" in text, text
     assert "blind-loop regression" in text, text
     assert "1:0.25,2:0.25" in text and "1:0.25,2:0" in text, text

--- a/loopx/benchmark_case_analysis.py
+++ b/loopx/benchmark_case_analysis.py
@@ -42,6 +42,55 @@ CASE_ANALYSIS_CLASS_LABELS = {
     "regression_asset": "regression asset",
     "setup_blocker_asset": "setup blocker asset",
 }
+HARNESS_INTERACTION_COUNTER_FIELDS = (
+    "loopx_cli_call_count",
+    "worker_loopx_cli_call_total",
+    "loopx_prompt_driven_case_cli_call_count",
+    "loopx_case_scheduler_command_count",
+    "controller_action_decisions",
+    "followup_prompt_count",
+    "private_trajectory_tool_call_count",
+    "tool_call_count",
+)
+HARNESS_INTERACTION_BOOL_FIELDS = (
+    "loopx_inside_case",
+    "loopx_lifecycle_observed",
+    "loopx_trace_observed",
+    "loopx_prompt_driven_trace_present",
+    "loopx_prompt_driven_lifecycle_observed",
+    "loopx_controller_trace_present",
+    "loopx_controller_trace_public_safe",
+    "native_goal_mode_invoked",
+    "native_goal_worker_connected",
+    "private_trajectory_present",
+)
+HARNESS_INTERACTION_MAP_FIELDS = (
+    "loopx_case_rollout_event_counts",
+    "loopx_prompt_driven_event_counts",
+    "loopx_solution_phase_counters",
+    "trajectory_action_category_counts",
+    "loopx_cli_state_usage_counts",
+)
+HARNESS_PUBLIC_UNSAFE_FIELDS = (
+    "raw_text_copied_to_public",
+    "raw_task_text_copied_to_public",
+    "raw_verifier_output_copied_to_public",
+    "raw_logs_copied",
+    "raw_logs_read",
+    "raw_task_text_copied",
+    "raw_task_text_read",
+    "raw_verifier_output_copied",
+    "raw_verifier_output_read",
+    "raw_trajectory_copied",
+    "raw_trajectory_read",
+    "raw_agent_trajectory_recorded",
+    "raw_commands_recorded",
+    "raw_output_recorded",
+    "trajectory_copied",
+    "trajectory_read",
+    "host_path_recorded",
+    "local_paths_recorded",
+)
 
 
 def load_json(path: str | Path) -> dict[str, Any]:
@@ -620,6 +669,80 @@ def _iter_public_trajectory_summaries(
     return summaries
 
 
+def _first_int_field(value: dict[str, Any], *keys: str) -> int:
+    for key in keys:
+        candidate = value.get(key)
+        if isinstance(candidate, int) and not isinstance(candidate, bool):
+            return candidate
+    return 0
+
+
+def _sum_public_count_map(value: Any) -> int:
+    if isinstance(value, dict):
+        total = 0
+        for child in value.values():
+            if isinstance(child, int) and not isinstance(child, bool):
+                total += child
+            elif isinstance(child, dict):
+                total += _sum_public_count_map(child)
+        return total
+    return 0
+
+
+def _harness_summary_is_public_safe(summary: dict[str, Any]) -> bool:
+    return not any(bool(summary.get(field)) for field in HARNESS_PUBLIC_UNSAFE_FIELDS)
+
+
+def _harness_summary_kind(path: str, summary: dict[str, Any]) -> str:
+    if path.endswith("trajectory_public_summary"):
+        return "trajectory_public_summary"
+    if "native_goal_route_observations" in path:
+        return "native_goal_route_observation"
+    if ".arms." in f".{path}.":
+        return "case_arm"
+    if "product_mode" in path:
+        return "product_mode_attribution"
+    if summary.get("loopx_case_rollout_event_counts"):
+        return "case_rollout_trace"
+    if summary.get("loopx_prompt_driven_event_counts"):
+        return "prompt_driven_trace"
+    return "compact_harness_interaction"
+
+
+def _contains_harness_interaction_summary(summary: dict[str, Any]) -> bool:
+    return any(
+        key in summary
+        for key in (
+            *HARNESS_INTERACTION_COUNTER_FIELDS,
+            *HARNESS_INTERACTION_BOOL_FIELDS,
+            *HARNESS_INTERACTION_MAP_FIELDS,
+        )
+    )
+
+
+def _iter_harness_interaction_summaries(
+    value: object,
+    *,
+    path: str = "",
+) -> list[tuple[str, dict[str, Any]]]:
+    summaries: list[tuple[str, dict[str, Any]]] = []
+    if isinstance(value, dict):
+        if _contains_harness_interaction_summary(value):
+            summaries.append((path or "$", value))
+        for key, child in value.items():
+            child_path = f"{path}.{key}" if path else str(key)
+            summaries.extend(
+                _iter_harness_interaction_summaries(child, path=child_path)
+            )
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            child_path = f"{path}[{index}]" if path else f"[{index}]"
+            summaries.extend(
+                _iter_harness_interaction_summaries(child, path=child_path)
+            )
+    return summaries
+
+
 def _trajectory_summary_is_public_safe(summary: dict[str, Any]) -> bool:
     return not any(
         bool(summary.get(field))
@@ -697,6 +820,97 @@ def trajectory_public_summary_coverage(analysis: dict[str, Any]) -> dict[str, An
     }
 
 
+def harness_interaction_public_summary_coverage(
+    analysis: dict[str, Any],
+) -> dict[str, Any]:
+    """Return generic public-safe harness interaction coverage rows.
+
+    This intentionally consumes only compact case-analysis fields. It does not
+    read raw trajectories, verifier output, task text, logs, or local paths.
+    """
+
+    rows: list[dict[str, Any]] = []
+    cases = analysis.get("cases")
+    if not isinstance(cases, list):
+        cases = []
+    for case in cases:
+        if not isinstance(case, dict):
+            continue
+        benchmark_id = _compact_text(case.get("benchmark_id"), limit=160)
+        case_id = _compact_text(case.get("case_id"), limit=200)
+        classification = _compact_text(case.get("classification"), limit=180)
+        for summary_path, summary in _iter_harness_interaction_summaries(case):
+            event_count = sum(
+                _sum_public_count_map(summary.get(field))
+                for field in HARNESS_INTERACTION_MAP_FIELDS
+            )
+            rows.append(
+                {
+                    "benchmark_id": benchmark_id,
+                    "case_id": case_id,
+                    "classification": classification,
+                    "summary_path": _compact_text(summary_path, limit=220),
+                    "source_kind": _harness_summary_kind(summary_path, summary),
+                    "arm_id": _compact_text(summary.get("arm_id"), limit=160),
+                    "loopx_cli_call_count": _first_int_field(
+                        summary,
+                        "loopx_cli_call_count",
+                        "worker_loopx_cli_call_total",
+                        "loopx_prompt_driven_case_cli_call_count",
+                    ),
+                    "round_count": _first_int_field(
+                        summary,
+                        "round_count",
+                        "private_trajectory_round_count",
+                        "max_round_observed",
+                    ),
+                    "tool_call_count": _first_int_field(
+                        summary,
+                        "tool_call_count",
+                        "private_trajectory_tool_call_count",
+                    ),
+                    "event_count": event_count,
+                    "controller_trace_present": bool(
+                        summary.get("loopx_controller_trace_present")
+                    ),
+                    "lifecycle_observed": bool(
+                        summary.get("loopx_lifecycle_observed")
+                        or summary.get("loopx_prompt_driven_lifecycle_observed")
+                    ),
+                    "private_trajectory_present": bool(
+                        summary.get("private_trajectory_present")
+                    ),
+                    "public_safe": _harness_summary_is_public_safe(summary),
+                }
+            )
+    rows.sort(
+        key=lambda row: (
+            str(row.get("benchmark_id")),
+            str(row.get("case_id")),
+            str(row.get("summary_path")),
+        )
+    )
+    benchmark_ids = sorted(
+        {
+            str(row.get("benchmark_id"))
+            for row in rows
+            if row.get("benchmark_id")
+        }
+    )
+    public_safe_count = sum(1 for row in rows if row.get("public_safe"))
+    return {
+        "schema_version": "harness_interaction_public_summary_coverage_v0",
+        "summary_count": len(rows),
+        "public_safe_count": public_safe_count,
+        "benchmark_ids": benchmark_ids,
+        "raw_trajectory_recorded": False,
+        "raw_task_text_recorded": False,
+        "raw_verifier_output_recorded": False,
+        "raw_logs_recorded": False,
+        "rows": rows,
+    }
+
+
 def _render_public_trajectory_summary_coverage(
     analysis: dict[str, Any],
 ) -> list[str]:
@@ -738,6 +952,55 @@ def _render_public_trajectory_summary_coverage(
             f"`{_markdown_escape_scalar(row.get('loopx_cli_call_count'))}` | "
             f"`{_markdown_escape_scalar(row.get('protected_path_edit_signal_count'))}` | "
             f"`{attribution}` |"
+        )
+    return lines
+
+
+def _render_harness_interaction_public_summary_coverage(
+    analysis: dict[str, Any],
+) -> list[str]:
+    coverage = harness_interaction_public_summary_coverage(analysis)
+    rows = coverage.get("rows")
+    if not isinstance(rows, list) or not rows:
+        return []
+    lines = [
+        "## Public Harness Interaction Coverage",
+        "",
+        "These rows are generated from compact case-analysis counters across",
+        "benchmarks. They combine SkillsBench trajectory summaries, Terminal-Bench",
+        "worker/LoopX counters, SWE-Marathon product-path counters, and any future",
+        "benchmark case records that expose the same public fields. They do not read",
+        "or copy raw trajectories, task text, verifier output, logs, or local paths.",
+        "",
+        "- schema_version: "
+        f"`{coverage.get('schema_version')}`",
+        "- summary_count: "
+        f"`{coverage.get('summary_count', 0)}`",
+        "- benchmark_ids: "
+        f"`{', '.join(coverage.get('benchmark_ids') or [])}`",
+        "",
+        "| Benchmark | Case | Source | Kind | LoopX CLI | Rounds | Tools | Events | Controller Trace | Lifecycle |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        public_safe = "public-safe" if row.get("public_safe") else "unsafe"
+        controller_trace = "yes" if row.get("controller_trace_present") else "no"
+        lifecycle = "yes" if row.get("lifecycle_observed") else "no"
+        lines.append(
+            "| "
+            f"`{_markdown_escape_cell(row.get('benchmark_id'))}` | "
+            f"`{_markdown_escape_cell(row.get('case_id'))}` | "
+            f"`{_markdown_escape_cell(row.get('summary_path'))}` "
+            f"({public_safe}) | "
+            f"`{_markdown_escape_cell(row.get('source_kind'))}` | "
+            f"`{_markdown_escape_scalar(row.get('loopx_cli_call_count'))}` | "
+            f"`{_markdown_escape_scalar(row.get('round_count'))}` | "
+            f"`{_markdown_escape_scalar(row.get('tool_call_count'))}` | "
+            f"`{_markdown_escape_scalar(row.get('event_count'))}` | "
+            f"`{controller_trace}` | "
+            f"`{lifecycle}` |"
         )
     return lines
 
@@ -814,6 +1077,11 @@ def render_case_analysis_markdown(
     trajectory_coverage_lines = _render_public_trajectory_summary_coverage(analysis)
     if trajectory_coverage_lines:
         lines.extend(["", *trajectory_coverage_lines])
+    harness_coverage_lines = _render_harness_interaction_public_summary_coverage(
+        analysis
+    )
+    if harness_coverage_lines:
+        lines.extend(["", *harness_coverage_lines])
     coverage_lines = _render_terminal_bench_current_protocol_coverage(analysis)
     if coverage_lines:
         lines.extend(["", *coverage_lines])


### PR DESCRIPTION
## Summary
- add generic public-safe harness interaction coverage extraction for benchmark case analysis
- render a cross-benchmark Public Harness Interaction Coverage table in the case-analysis markdown
- extend the case-analysis smoke to cover SkillsBench, Terminal-Bench, and SWE compact counters without raw logs, task text, verifier output, or trajectories

## Validation
- python examples/benchmark-case-analysis-smoke.py
- python -m py_compile loopx/benchmark_case_analysis.py
- git diff --check
- loopx check --scan-path loopx/benchmark_case_analysis.py --scan-path examples/benchmark-case-analysis-smoke.py --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-case-analysis.md