### PR TITLE
Add benchmark round artifact restore plan

### DIFF
--- a/docs/benchmark-developer-workflow.md
+++ b/docs/benchmark-developer-workflow.md
@@ -521,6 +521,14 @@ parallel old/new definitions. The contract requires:
 - if a Harbor/app-server route cannot provide that controller trace, classify it
   as packet-only route-safety evidence and do not compare it as test.
 
+`best_score` is only an executable final-selection policy when the runner also
+captures a compact per-round artifact snapshot. Use
+`loopx.benchmark_core.build_round_artifact_restore_plan` to combine
+`round_rewards` with public-safe snapshot handles. If the best scored round is
+not the final round and has no restore-ready snapshot handle, keep the run as
+offline analysis evidence and record `missing_snapshot_for_best_round` instead
+of claiming the runner can submit or verify the best round.
+
 When launching the actual test arm, the outer controller should set
 `loopx_experiment_protocol=max5_blind_loop_no_feedback`, inject a fresh
 LoopX packet before each scheduled prompt, keep official feedback

--- a/examples/benchmark-core-adapter-contract-smoke.py
+++ b/examples/benchmark-core-adapter-contract-smoke.py
@@ -34,6 +34,8 @@ from loopx.benchmark_core import (  # noqa: E402
     Observation,
     PreflightResult,
     RunHandle,
+    build_round_artifact_restore_plan,
+    compact_round_artifact_snapshots,
     canonical_lifecycle,
     load_json_object,
     optional_float,
@@ -140,6 +142,75 @@ def test_round_reward_summary_prefers_best_score() -> None:
     assert summary["best_round_is_final"] is False, summary
 
 
+def test_best_round_restore_plan_uses_public_snapshot_handle() -> None:
+    plan = build_round_artifact_restore_plan(
+        round_rewards=[
+            {"agent_round": 1, "reward": 0.25},
+            {"agent_round": 2, "reward": 1.0, "passed": True},
+            {"agent_round": 3, "reward": 0.0},
+        ],
+        round_artifact_snapshots=[
+            {"agent_round": 1, "snapshot_ref": "round-1-compact-snapshot"},
+            {"agent_round": 2, "snapshot_ref": "round-2-compact-snapshot"},
+            {"agent_round": 3, "snapshot_ref": "round-3-compact-snapshot"},
+        ],
+    )
+    assert plan["schema_version"] == "benchmark_round_artifact_restore_plan_v0", plan
+    assert plan["selected_round"] == 2, plan
+    assert plan["selected_reward"] == 1.0, plan
+    assert plan["best_round_is_final"] is False, plan
+    assert plan["restore_required"] is True, plan
+    assert plan["executable_final_selection"] is True, plan
+    assert plan["blocked_reason"] == "", plan
+    assert plan["restore_plan"] == {
+        "action": "restore_best_round_snapshot_before_final_scoring",
+        "snapshot_ref": "round-2-compact-snapshot",
+        "agent_round": 2,
+    }, plan
+    assert plan["boundary"]["raw_snapshot_paths_recorded"] is False, plan
+
+
+def test_best_round_restore_plan_blocks_without_snapshot() -> None:
+    plan = build_round_artifact_restore_plan(
+        round_rewards=[
+            {"agent_round": 1, "reward": 0.25},
+            {"agent_round": 2, "reward": 1.0, "passed": True},
+            {"agent_round": 3, "reward": 0.0},
+        ],
+        round_artifact_snapshots=[
+            {"agent_round": 1, "snapshot_ref": "round-1-compact-snapshot"},
+            {"agent_round": 3, "snapshot_ref": "round-3-compact-snapshot"},
+            {"agent_round": 2, "snapshot_ref": "/private/raw/round-2"},
+        ],
+    )
+    assert plan["selected_round"] == 2, plan
+    assert plan["executable_final_selection"] is False, plan
+    assert plan["blocked_reason"] == "missing_snapshot_for_best_round", plan
+    assert plan["restore_plan"] == {
+        "action": "capture_per_round_snapshot_before_using_best_score_policy"
+    }, plan
+    snapshots = compact_round_artifact_snapshots(
+        [{"agent_round": 2, "snapshot_ref": "/private/raw/round-2"}]
+    )
+    assert snapshots == [], snapshots
+
+
+def test_best_round_restore_plan_keeps_final_when_best_is_final() -> None:
+    plan = build_round_artifact_restore_plan(
+        round_rewards=[
+            {"agent_round": 1, "reward": 0.25},
+            {"agent_round": 2, "reward": 1.0, "passed": True},
+        ],
+        round_artifact_snapshots=[],
+    )
+    assert plan["selected_round"] == 2, plan
+    assert plan["final_round"] == 2, plan
+    assert plan["best_round_is_final"] is True, plan
+    assert plan["restore_required"] is False, plan
+    assert plan["executable_final_selection"] is True, plan
+    assert plan["restore_plan"] == {"action": "keep_final_workspace"}, plan
+
+
 def test_benchmark_adapter_modules_own_public_config() -> None:
     assert TERMINAL_BENCH_DEFAULT_DATASET == "terminal-bench@2.0"
     assert TERMINAL_BENCH_DEFAULT_TASK == "build-cython-ext"
@@ -188,6 +259,9 @@ def main() -> int:
     test_process_started_is_not_case_entry()
     test_existing_lifecycle_builder_projects_canonical_state()
     test_round_reward_summary_prefers_best_score()
+    test_best_round_restore_plan_uses_public_snapshot_handle()
+    test_best_round_restore_plan_blocks_without_snapshot()
+    test_best_round_restore_plan_keeps_final_when_best_is_final()
     test_benchmark_adapter_modules_own_public_config()
     test_benchmark_adapter_modules_own_helper_surfaces()
     test_benchmark_facade_has_no_shadowed_top_level_definitions()

--- a/loopx/benchmark_core/__init__.py
+++ b/loopx/benchmark_core/__init__.py
@@ -70,7 +70,14 @@ from .parity import (
     build_codex_app_parity_posthoc_check,
     render_codex_app_parity_posthoc_check_markdown,
 )
-from .rounds import RoundReward, compact_round_rewards, summarize_round_rewards
+from .rounds import (
+    BENCHMARK_ROUND_ARTIFACT_RESTORE_PLAN_SCHEMA_VERSION,
+    RoundReward,
+    build_round_artifact_restore_plan,
+    compact_round_artifact_snapshots,
+    compact_round_rewards,
+    summarize_round_rewards,
+)
 from .run_permissions import (
     DEFAULT_RUN_PERMISSION_ALLOWED_ACTIONS,
     DEFAULT_RUN_PERMISSION_FORBIDDEN_ACTIONS,
@@ -101,6 +108,7 @@ __all__ = [
     "BENCHMARK_LOOP_CONTROLLER_TRACE_SCHEMA_VERSION",
     "BENCHMARK_LOOP_PROTOCOL_SCHEMA_VERSION",
     "BENCHMARK_OBSERVABLE_HANDLE_POLICY_SCHEMA_VERSION",
+    "BENCHMARK_ROUND_ARTIFACT_RESTORE_PLAN_SCHEMA_VERSION",
     "BENCHMARK_SPLIT_CONTROL_REMOTE_EXECUTOR_EXECUTION_SEAM_SCHEMA_VERSION",
     "BENCHMARK_SPLIT_CONTROL_REMOTE_EXECUTOR_LAUNCH_PLAN_SCHEMA_VERSION",
     "BENCHMARK_SPLIT_CONTROL_REMOTE_EXECUTOR_RUNNER_BATCH_SCHEMA_VERSION",
@@ -116,6 +124,7 @@ __all__ = [
     "build_benchmark_loop_contract",
     "build_benchmark_loop_controller_trace",
     "build_benchmark_observable_handle_policy",
+    "build_round_artifact_restore_plan",
     "build_benchmark_candidate_source_boundary",
     "build_blind_loop_continuation_prompt",
     "build_blind_loop_initial_prompt",
@@ -156,6 +165,7 @@ __all__ = [
     "canonical_lifecycle",
     "compact_run_permission_policy_for_quota",
     "compact_round_rewards",
+    "compact_round_artifact_snapshots",
     "load_json_object",
     "load_jsonl_objects",
     "optional_float",

--- a/loopx/benchmark_core/rounds.py
+++ b/loopx/benchmark_core/rounds.py
@@ -4,6 +4,25 @@ from dataclasses import dataclass
 from typing import Any
 
 
+BENCHMARK_ROUND_ARTIFACT_RESTORE_PLAN_SCHEMA_VERSION = (
+    "benchmark_round_artifact_restore_plan_v0"
+)
+_UNSAFE_SNAPSHOT_REF_MARKERS = (
+    "/Users/",
+    "/private/",
+    "/tmp/",
+    "\\",
+    "trajectory",
+    "task.md",
+    "instruction.md",
+    "verifier",
+    "logs/",
+    "raw/",
+    "credential",
+    "secret",
+)
+
+
 @dataclass(frozen=True)
 class RoundReward:
     agent_round: int
@@ -37,6 +56,56 @@ def compact_round_rewards(records: list[Any]) -> list[dict[str, Any]]:
     return sorted(compact, key=lambda item: item["agent_round"])
 
 
+def _public_snapshot_ref(value: Any) -> str:
+    if not isinstance(value, (str, int, float)) or isinstance(value, bool):
+        return ""
+    ref = str(value).strip()
+    if not ref or ref in {".", ".."}:
+        return ""
+    lower_ref = ref.lower()
+    if any(marker.lower() in lower_ref for marker in _UNSAFE_SNAPSHOT_REF_MARKERS):
+        return ""
+    return ref[:200]
+
+
+def compact_round_artifact_snapshots(records: list[Any]) -> list[dict[str, Any]]:
+    """Return public-safe per-round artifact snapshot handles.
+
+    Snapshot handles must be logical compact references, not raw local paths.
+    Host adapters own the actual filesystem copy/restore implementation.
+    """
+
+    compact: list[dict[str, Any]] = []
+    seen_rounds: set[int] = set()
+    for record in records:
+        if not isinstance(record, dict):
+            continue
+        agent_round = record.get("agent_round")
+        if not isinstance(agent_round, int) or isinstance(agent_round, bool):
+            continue
+        if agent_round <= 0 or agent_round in seen_rounds:
+            continue
+        snapshot_ref = (
+            _public_snapshot_ref(record.get("snapshot_ref"))
+            or _public_snapshot_ref(record.get("artifact_ref"))
+            or _public_snapshot_ref(record.get("restore_handle"))
+        )
+        if not snapshot_ref:
+            continue
+        item: dict[str, Any] = {
+            "agent_round": agent_round,
+            "snapshot_ref": snapshot_ref,
+            "restore_kind": "benchmark_host_round_snapshot",
+        }
+        if isinstance(record.get("ready_for_restore"), bool):
+            item["ready_for_restore"] = record["ready_for_restore"]
+        else:
+            item["ready_for_restore"] = True
+        compact.append(item)
+        seen_rounds.add(agent_round)
+    return sorted(compact, key=lambda item: item["agent_round"])
+
+
 def summarize_round_rewards(records: list[Any]) -> dict[str, Any]:
     compact = compact_round_rewards(records)
     numeric = [item for item in compact if isinstance(item.get("reward"), float)]
@@ -64,4 +133,83 @@ def summarize_round_rewards(records: list[Any]) -> dict[str, Any]:
         "best_round_reward": best["reward"],
         "best_round_passed": best.get("passed"),
         "best_round_is_final": best["agent_round"] == final["agent_round"],
+    }
+
+
+def build_round_artifact_restore_plan(
+    *,
+    round_rewards: list[Any],
+    round_artifact_snapshots: list[Any],
+) -> dict[str, Any]:
+    """Build the public control-plane plan for best-round artifact selection.
+
+    This makes best-round scoring executable only when the best scored round is
+    already final or has a compact per-round snapshot handle that a host adapter
+    can restore. It deliberately records no raw paths or commands.
+    """
+
+    reward_summary = summarize_round_rewards(round_rewards)
+    snapshots = compact_round_artifact_snapshots(round_artifact_snapshots)
+    snapshots_by_round = {item["agent_round"]: item for item in snapshots}
+    best_round = reward_summary.get("best_reward_round")
+    final_round = reward_summary.get("final_round")
+    best_round_is_final = reward_summary.get("best_round_is_final") is True
+
+    selected_snapshot = (
+        snapshots_by_round.get(best_round)
+        if isinstance(best_round, int) and not isinstance(best_round, bool)
+        else None
+    )
+    restore_required = bool(best_round is not None and not best_round_is_final)
+    if best_round is None:
+        executable = False
+        blocked_reason = "missing_numeric_round_reward"
+        action = "record_round_rewards_before_final_selection"
+    elif best_round_is_final:
+        executable = True
+        blocked_reason = ""
+        action = "keep_final_workspace"
+    elif selected_snapshot and selected_snapshot.get("ready_for_restore") is not False:
+        executable = True
+        blocked_reason = ""
+        action = "restore_best_round_snapshot_before_final_scoring"
+    elif selected_snapshot:
+        executable = False
+        blocked_reason = "best_round_snapshot_not_ready_for_restore"
+        action = "repair_best_round_snapshot_before_final_selection"
+    else:
+        executable = False
+        blocked_reason = "missing_snapshot_for_best_round"
+        action = "capture_per_round_snapshot_before_using_best_score_policy"
+
+    restore_plan: dict[str, Any] = {"action": action}
+    if selected_snapshot and restore_required:
+        restore_plan["snapshot_ref"] = selected_snapshot["snapshot_ref"]
+        restore_plan["agent_round"] = selected_snapshot["agent_round"]
+
+    return {
+        "schema_version": BENCHMARK_ROUND_ARTIFACT_RESTORE_PLAN_SCHEMA_VERSION,
+        "policy_id": "best_round_artifact_restore_v0",
+        "final_selection_policy": "use_best_scored_round_when_executable_snapshot_available",
+        "selected_round": best_round,
+        "selected_reward": reward_summary.get("best_round_reward"),
+        "selected_passed": reward_summary.get("best_round_passed"),
+        "final_round": final_round,
+        "final_round_reward": reward_summary.get("final_round_reward"),
+        "best_round_is_final": best_round_is_final,
+        "restore_required": restore_required,
+        "executable_final_selection": executable,
+        "blocked_reason": blocked_reason,
+        "round_snapshot_count": len(snapshots),
+        "rounds_with_snapshot": [item["agent_round"] for item in snapshots],
+        "restore_plan": restore_plan,
+        "round_reward_summary": reward_summary,
+        "boundary": {
+            "raw_snapshot_paths_recorded": False,
+            "raw_logs_read": False,
+            "raw_task_text_read": False,
+            "raw_verifier_output_read": False,
+            "trajectory_read": False,
+            "host_restore_command_recorded": False,
+        },
     }


### PR DESCRIPTION
## Summary\n- add public-safe per-round artifact snapshot compaction for benchmark runs\n- add a best-round restore-plan helper so best_score can be treated as executable only when a restore-ready snapshot exists\n- document the contract and cover it in the benchmark core adapter smoke\n\n## Validation\n- python examples/benchmark-core-adapter-contract-smoke.py\n- python examples/benchmark-developer-workflow-doc-smoke.py\n- python -m py_compile loopx/benchmark_core/rounds.py loopx/benchmark_core/__init__.py\n- git diff --check\n- loopx check --scan-path loopx/benchmark_core/rounds.py --scan-path loopx/benchmark_core/__init__.py --scan-path examples/benchmark-core-adapter-contract-smoke.py --scan-path docs/benchmark-developer-workflow.md