### PR TITLE
Backfill product-mode pair ledger decisions

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
@@ -457,11 +457,27 @@
         "azure-bgp-oscillation-route-leak": {
           "case_id": "azure-bgp-oscillation-route-leak",
           "latest_decision": {
-            "baseline_failure_scope": "case_or_solution",
             "baseline_run_id": "788c64ee1ddd",
-            "decision": "paired_no_score_uplift",
-            "official_score_delta": 0.0,
-            "treatment_failure_scope": "case_or_solution",
+            "decision": "product_mode_pair_incomplete",
+            "product_mode_main_table_pair": {
+              "baseline_route_valid": true,
+              "benchmark_id": "skillsbench@1.1",
+              "case_id": "azure-bgp-oscillation-route-leak",
+              "claim_blocker": "treatment_loopx_lifecycle_not_observed",
+              "comparison_id": "skillsbench_product_mode_main_table_v0",
+              "headline_metrics": [
+                "best_score",
+                "final_score",
+                "first_success_round",
+                "declared_done_score"
+              ],
+              "main_table_claim_allowed": false,
+              "official_feedback_blinded": true,
+              "product_mode_pair_complete": false,
+              "schema_version": "benchmark_product_mode_comparison_v0",
+              "treatment_loopx_lifecycle_observed": false,
+              "treatment_route_valid": true
+            },
             "treatment_run_id": "4002396acce9"
           },
           "runs": [
@@ -4251,11 +4267,27 @@
         "paratransit-routing": {
           "case_id": "paratransit-routing",
           "latest_decision": {
-            "baseline_failure_scope": "case_or_solution",
             "baseline_run_id": "34966c13e416",
-            "decision": "paired_treatment_improved",
-            "official_score_delta": 1.0,
-            "treatment_failure_scope": "passed",
+            "decision": "product_mode_pair_incomplete",
+            "product_mode_main_table_pair": {
+              "baseline_route_valid": true,
+              "benchmark_id": "skillsbench@1.1",
+              "case_id": "paratransit-routing",
+              "claim_blocker": "treatment_loopx_lifecycle_not_observed",
+              "comparison_id": "skillsbench_product_mode_main_table_v0",
+              "headline_metrics": [
+                "best_score",
+                "final_score",
+                "first_success_round",
+                "declared_done_score"
+              ],
+              "main_table_claim_allowed": false,
+              "official_feedback_blinded": true,
+              "product_mode_pair_complete": false,
+              "schema_version": "benchmark_product_mode_comparison_v0",
+              "treatment_loopx_lifecycle_observed": false,
+              "treatment_route_valid": true
+            },
             "treatment_run_id": "c9e2eebe7a8e"
           },
           "runs": [
@@ -5920,15 +5952,27 @@
         "suricata-custom-exfil": {
           "case_id": "suricata-custom-exfil",
           "latest_decision": {
-            "baseline_failure_scope": "passed",
             "baseline_run_id": "793ed0aac6e3",
-            "decision": "paired_treatment_codex_acp_runtime_preflight_required",
-            "failure_class": "skillsbench_codex_acp_jsonrpc_internal_error",
-            "next_action": "prove the Codex ACP runtime can start inside the SkillsBench sandbox before rerunning or launching treatment; require compact dependency and launch preflight evidence instead of a generic ACP launch failure",
-            "official_score_delta": null,
-            "repair_class": "skillsbench_codex_acp_runtime_preflight",
-            "repair_priority": "P0",
-            "treatment_failure_scope": "score_missing",
+            "decision": "product_mode_pair_incomplete",
+            "product_mode_main_table_pair": {
+              "baseline_route_valid": false,
+              "benchmark_id": "skillsbench@1.1",
+              "case_id": "suricata-custom-exfil",
+              "claim_blocker": "baseline_not_raw_codex_autonomous_max5,treatment_official_feedback_not_blinded,treatment_reward_feedback_forwarding_not_disabled,treatment_compact_metrics_missing,treatment_loopx_lifecycle_not_observed",
+              "comparison_id": "skillsbench_product_mode_main_table_v0",
+              "headline_metrics": [
+                "best_score",
+                "final_score",
+                "first_success_round",
+                "declared_done_score"
+              ],
+              "main_table_claim_allowed": false,
+              "official_feedback_blinded": false,
+              "product_mode_pair_complete": false,
+              "schema_version": "benchmark_product_mode_comparison_v0",
+              "treatment_loopx_lifecycle_observed": false,
+              "treatment_route_valid": true
+            },
             "treatment_run_id": "d9949ec296f1"
           },
           "runs": [

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
@@ -9,53 +9,53 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 
 ## Case Decisions
 
-| Benchmark | Case | Decision | Case Routing | Runs |
-| --- | --- | --- | --- | --- |
-| `skillsbench-cloud-oracle-sanity@v0` | `hello-world` | `single_arm_recorded` | - | `1` |
-| `skillsbench@1.1` | `3d-scan-calc` | `paired_baseline_solved_treatment_preserved` | - | `3` |
-| `skillsbench@1.1` | `ada-bathroom-plan-repair` | `paired_baseline_solved_treatment_preserved` | - | `4` |
-| `skillsbench@1.1` | `adaptive-cruise-control` | `baseline_runner_or_setup_repair_required` | - | `1` |
-| `skillsbench@1.1` | `azure-bgp-oscillation-route-leak` | `paired_no_score_uplift` | - | `10` |
-| `skillsbench@1.1` | `bike-rebalance` | `paired_baseline_solved_treatment_preserved` | - | `3` |
-| `skillsbench@1.1` | `citation-check` | `paired_baseline_solved_treatment_preserved` | - | `4` |
-| `skillsbench@1.1` | `civ6-adjacency-optimizer` | `paired_no_score_uplift` | - | `4` |
-| `skillsbench@1.1` | `dapt-intrusion-detection` | `paired_baseline_setup_preflight_selection_required` | - | `5` |
-| `skillsbench@1.1` | `debug-trl-grpo` | `paired_baseline_runner_or_setup_repair_required` | - | `9` |
-| `skillsbench@1.1` | `fix-build-agentops` | `baseline_runner_or_setup_repair_required` | - | `2` |
-| `skillsbench@1.1` | `llm-prefix-cache-replay` | `paired_no_score_uplift` | - | `25` |
-| `skillsbench@1.1` | `manufacturing-codebook-normalization` | `paired_no_score_uplift` | - | `4` |
-| `skillsbench@1.1` | `organize-messy-files` | `paired_baseline_solved_treatment_preserved` | - | `3` |
-| `skillsbench@1.1` | `paratransit-routing` | `paired_treatment_improved` | - | `9` |
-| `skillsbench@1.1` | `pddl-airport-planning` | `paired_no_score_uplift` | - | `9` |
-| `skillsbench@1.1` | `react-performance-debugging` | `paired_baseline_runner_or_setup_repair_required` | - | `5` |
-| `skillsbench@1.1` | `setup-fuzzing-py` | `baseline_runner_or_setup_repair_required` | - | `3` |
-| `skillsbench@1.1` | `software-dependency-audit` | `paired_no_score_uplift` | - | `6` |
-| `skillsbench@1.1` | `suricata-custom-exfil` | `paired_treatment_codex_acp_runtime_preflight_required` | - | `5` |
-| `skillsbench@1.1` | `tictoc-unnecessary-abort-detection` | `paired_baseline_runner_or_setup_repair_required` | - | `6` |
-| `skillsbench@1.1` | `travel-planning` | `baseline_failed_treatment_candidate` | - | `2` |
-| `swe-marathon` | `find-network-alignments` | `baseline_failed_treatment_candidate` | - | `1` |
-| `swe-marathon` | `rust-c-compiler` | `single_arm_recorded` | - | `2` |
-| `swe-marathon` | `zstd-decoder` | `paired_treatment_regressed` | `case_exception_research` | `4` |
-| `terminal-bench-worker-materialization@v0` | `nginx-request-logging` | `single_arm_recorded` | - | `2` |
-| `terminal-bench@2.0` | `build-cython-ext` | `baseline_passed_not_current_treatment_priority` | - | `11` |
-| `terminal-bench@2.0` | `cobol-modernization` | `paired_baseline_solved_treatment_preserved` | - | `2` |
-| `terminal-bench@2.0` | `compile-compcert` | `baseline_passed_not_current_treatment_priority` | - | `1` |
-| `terminal-bench@2.0` | `financial-document-processor` | `baseline_passed_not_current_treatment_priority` | - | `2` |
-| `terminal-bench@2.0` | `fix-code-vulnerability` | `baseline_passed_not_current_treatment_priority` | - | `1` |
-| `terminal-bench@2.0` | `git-multibranch` | `paired_baseline_solved_treatment_preserved` | - | `5` |
-| `terminal-bench@2.0` | `headless-terminal` | `paired_no_score_uplift` | `bridge_connected_no_uplift` | `5` |
-| `terminal-bench@2.0` | `install-windows-3.11` | `paired_treatment_worker_verifier_alignment_required` | - | `4` |
-| `terminal-bench@2.0` | `large-scale-text-editing` | `paired_baseline_solved_treatment_preserved` | - | `5` |
-| `terminal-bench@2.0` | `make-doom-for-mips` | `paired_result_requires_attribution` | `timeout_tier_policy_candidate` | `9` |
-| `terminal-bench@2.0` | `merge-diff-arc-agi-task` | `baseline_passed_not_current_treatment_priority` | - | `1` |
-| `terminal-bench@2.0` | `mteb-retrieve` | `paired_baseline_environment_setup_repair_required` | - | `4` |
-| `terminal-bench@2.0` | `multi-source-data-merger` | `paired_baseline_solved_treatment_preserved` | - | `19` |
-| `terminal-bench@2.0` | `nginx-request-logging` | `paired_baseline_solved_treatment_preserved` | - | `8` |
-| `terminal-bench@2.0` | `path-tracing` | `baseline_passed_not_current_treatment_priority` | - | `2` |
-| `terminal-bench@2.0` | `pytorch-model-recovery` | `paired_no_score_uplift_exception_research_required` | `case_exception_research` | `3` |
-| `terminal-bench@2.0` | `regex-log` | `paired_baseline_solved_treatment_preserved` | - | `2` |
-| `terminal-bench@2.0` | `sqlite-db-truncate` | `baseline_passed_not_current_treatment_priority` | - | `1` |
-| `terminal-bench@2.0` | `train-fasttext` | `single_arm_recorded` | - | `2` |
+| Benchmark | Case | Decision | Product Pair | Case Routing | Runs |
+| --- | --- | --- | --- | --- | --- |
+| `skillsbench-cloud-oracle-sanity@v0` | `hello-world` | `single_arm_recorded` | - | - | `1` |
+| `skillsbench@1.1` | `3d-scan-calc` | `paired_baseline_solved_treatment_preserved` | - | - | `3` |
+| `skillsbench@1.1` | `ada-bathroom-plan-repair` | `paired_baseline_solved_treatment_preserved` | - | - | `4` |
+| `skillsbench@1.1` | `adaptive-cruise-control` | `baseline_runner_or_setup_repair_required` | - | - | `1` |
+| `skillsbench@1.1` | `azure-bgp-oscillation-route-leak` | `product_mode_pair_incomplete` | `treatment_loopx_lifecycle_not_observed` | - | `10` |
+| `skillsbench@1.1` | `bike-rebalance` | `paired_baseline_solved_treatment_preserved` | - | - | `3` |
+| `skillsbench@1.1` | `citation-check` | `paired_baseline_solved_treatment_preserved` | - | - | `4` |
+| `skillsbench@1.1` | `civ6-adjacency-optimizer` | `paired_no_score_uplift` | - | - | `4` |
+| `skillsbench@1.1` | `dapt-intrusion-detection` | `paired_baseline_setup_preflight_selection_required` | - | - | `5` |
+| `skillsbench@1.1` | `debug-trl-grpo` | `paired_baseline_runner_or_setup_repair_required` | - | - | `9` |
+| `skillsbench@1.1` | `fix-build-agentops` | `baseline_runner_or_setup_repair_required` | - | - | `2` |
+| `skillsbench@1.1` | `llm-prefix-cache-replay` | `paired_no_score_uplift` | - | - | `25` |
+| `skillsbench@1.1` | `manufacturing-codebook-normalization` | `paired_no_score_uplift` | - | - | `4` |
+| `skillsbench@1.1` | `organize-messy-files` | `paired_baseline_solved_treatment_preserved` | - | - | `3` |
+| `skillsbench@1.1` | `paratransit-routing` | `product_mode_pair_incomplete` | `treatment_loopx_lifecycle_not_observed` | - | `9` |
+| `skillsbench@1.1` | `pddl-airport-planning` | `paired_no_score_uplift` | - | - | `9` |
+| `skillsbench@1.1` | `react-performance-debugging` | `paired_baseline_runner_or_setup_repair_required` | - | - | `5` |
+| `skillsbench@1.1` | `setup-fuzzing-py` | `baseline_runner_or_setup_repair_required` | - | - | `3` |
+| `skillsbench@1.1` | `software-dependency-audit` | `paired_no_score_uplift` | - | - | `6` |
+| `skillsbench@1.1` | `suricata-custom-exfil` | `product_mode_pair_incomplete` | `baseline_not_raw_codex_autonomous_max5,treatment_official_feedback_not_blinded,treatment_reward_feedback_forwarding_n...` | - | `5` |
+| `skillsbench@1.1` | `tictoc-unnecessary-abort-detection` | `paired_baseline_runner_or_setup_repair_required` | - | - | `6` |
+| `skillsbench@1.1` | `travel-planning` | `baseline_failed_treatment_candidate` | - | - | `2` |
+| `swe-marathon` | `find-network-alignments` | `baseline_failed_treatment_candidate` | - | - | `1` |
+| `swe-marathon` | `rust-c-compiler` | `single_arm_recorded` | - | - | `2` |
+| `swe-marathon` | `zstd-decoder` | `paired_treatment_regressed` | - | `case_exception_research` | `4` |
+| `terminal-bench-worker-materialization@v0` | `nginx-request-logging` | `single_arm_recorded` | - | - | `2` |
+| `terminal-bench@2.0` | `build-cython-ext` | `baseline_passed_not_current_treatment_priority` | - | - | `11` |
+| `terminal-bench@2.0` | `cobol-modernization` | `paired_baseline_solved_treatment_preserved` | - | - | `2` |
+| `terminal-bench@2.0` | `compile-compcert` | `baseline_passed_not_current_treatment_priority` | - | - | `1` |
+| `terminal-bench@2.0` | `financial-document-processor` | `baseline_passed_not_current_treatment_priority` | - | - | `2` |
+| `terminal-bench@2.0` | `fix-code-vulnerability` | `baseline_passed_not_current_treatment_priority` | - | - | `1` |
+| `terminal-bench@2.0` | `git-multibranch` | `paired_baseline_solved_treatment_preserved` | - | - | `5` |
+| `terminal-bench@2.0` | `headless-terminal` | `paired_no_score_uplift` | - | `bridge_connected_no_uplift` | `5` |
+| `terminal-bench@2.0` | `install-windows-3.11` | `paired_treatment_worker_verifier_alignment_required` | - | - | `4` |
+| `terminal-bench@2.0` | `large-scale-text-editing` | `paired_baseline_solved_treatment_preserved` | - | - | `5` |
+| `terminal-bench@2.0` | `make-doom-for-mips` | `paired_result_requires_attribution` | - | `timeout_tier_policy_candidate` | `9` |
+| `terminal-bench@2.0` | `merge-diff-arc-agi-task` | `baseline_passed_not_current_treatment_priority` | - | - | `1` |
+| `terminal-bench@2.0` | `mteb-retrieve` | `paired_baseline_environment_setup_repair_required` | - | - | `4` |
+| `terminal-bench@2.0` | `multi-source-data-merger` | `paired_baseline_solved_treatment_preserved` | - | - | `19` |
+| `terminal-bench@2.0` | `nginx-request-logging` | `paired_baseline_solved_treatment_preserved` | - | - | `8` |
+| `terminal-bench@2.0` | `path-tracing` | `baseline_passed_not_current_treatment_priority` | - | - | `2` |
+| `terminal-bench@2.0` | `pytorch-model-recovery` | `paired_no_score_uplift_exception_research_required` | - | `case_exception_research` | `3` |
+| `terminal-bench@2.0` | `regex-log` | `paired_baseline_solved_treatment_preserved` | - | - | `2` |
+| `terminal-bench@2.0` | `sqlite-db-truncate` | `baseline_passed_not_current_treatment_priority` | - | - | `1` |
+| `terminal-bench@2.0` | `train-fasttext` | `single_arm_recorded` | - | - | `2` |
 
 ## Repair Backlog
 

--- a/examples/benchmark-run-ledger-smoke.py
+++ b/examples/benchmark-run-ledger-smoke.py
@@ -991,6 +991,63 @@ def test_skillsbench_product_mode_pair_blocks_shallow_lifecycle() -> None:
         assert "treatment_loopx_lifecycle_not_observed" in rendered, rendered
 
 
+def test_raw_max5_baseline_does_not_force_product_pair_without_product_treatment() -> None:
+    baseline = {
+        "schema_version": "benchmark_run_v0",
+        "benchmark_id": "skillsbench@1.1",
+        "case_id": "ordinary-treatment-case",
+        "mode": "skillsbench_raw_codex_autonomous_max5_baseline",
+        "route": "raw-codex-autonomous-max5",
+        "official_task_score": {
+            "kind": "skillsbench_reward",
+            "value": 0.0,
+            "passed": False,
+        },
+        "score_failure_attribution": "official_verifier_solution_failure",
+        "round_reward_trace": {
+            "records": [{"agent_round": 1, "reward": 0.0, "passed": False}],
+            "max_rounds_budget": 5,
+            "official_feedback_blinded": True,
+            "reward_feedback_forwarded": False,
+        },
+    }
+    treatment = {
+        **baseline,
+        "mode": "skillsbench_loopx_blind_loop_treatment",
+        "route": "loopx-blind-loop-treatment",
+        "official_task_score": {
+            "kind": "skillsbench_reward",
+            "value": 0.0,
+            "passed": False,
+        },
+    }
+
+    with tempfile.TemporaryDirectory(prefix="benchmark-run-ledger-raw-with-ordinary-treatment-") as tmp:
+        root = Path(tmp)
+        ledger_path = root / "ledger.json"
+        update_benchmark_run_ledger(
+            ledger_path=ledger_path,
+            benchmark_run=baseline,
+            run_group_id="raw-with-ordinary-treatment-ledger-smoke",
+            cwd=root,
+        )
+        update_benchmark_run_ledger(
+            ledger_path=ledger_path,
+            benchmark_run=treatment,
+            run_group_id="raw-with-ordinary-treatment-ledger-smoke",
+            cwd=root,
+        )
+        ledger = load_benchmark_run_ledger(ledger_path)
+        case = ledger["benchmarks"]["skillsbench@1.1"]["cases"][
+            "ordinary-treatment-case"
+        ]
+        decision = case["latest_decision"]
+        assert decision["decision"] == "paired_no_score_uplift", decision
+        assert "product_mode_main_table_pair" not in decision, decision
+        rendered = render_benchmark_run_ledger_markdown(ledger)
+        assert "product_mode_pair_incomplete" not in rendered, rendered
+
+
 def stale_active_post_launch() -> dict[str, Any]:
     return {
         "schema_version": "terminal_bench_post_launch_materialization_v0",
@@ -1527,6 +1584,7 @@ if __name__ == "__main__":
     test_verified_bridge_official_zero_routes_to_no_uplift_not_alignment()
     test_skillsbench_product_mode_pair_review_is_ledgered()
     test_skillsbench_product_mode_pair_blocks_shallow_lifecycle()
+    test_raw_max5_baseline_does_not_force_product_pair_without_product_treatment()
     test_ledger_ingests_post_launch_stale_active_marker()
     test_ledger_ingests_post_launch_ended_active_marker()
     test_cli_harbor_ingest_updates_run_ledger()

--- a/loopx/benchmark_ledger.py
+++ b/loopx/benchmark_ledger.py
@@ -1707,9 +1707,7 @@ def _case_decision(case: dict[str, Any]) -> dict[str, Any]:
 
     if latest_baseline and latest_treatment:
         product_mode_pair_review: dict[str, Any] | None = None
-        if _product_mode_baseline_run(latest_baseline) or _product_mode_treatment_run(
-            latest_treatment
-        ):
+        if _product_mode_treatment_run(latest_treatment):
             product_mode_pair_review = _compact_product_mode_pair_review(
                 classify_product_mode_main_table_pair(
                     baseline_run=latest_baseline,


### PR DESCRIPTION
## Summary
- backfill the public benchmark run ledger with product-mode pair review results from the new classifier
- mark existing SkillsBench product-mode-looking rows as incomplete when prompt-driven LoopX lifecycle evidence is absent
- keep raw max5 baselines from forcing product-pair decisions when the latest treatment is not product-mode

## Notable case effects
- paratransit-routing: paired_treatment_improved -> product_mode_pair_incomplete because treatment_loopx_lifecycle_not_observed
- azure-bgp-oscillation-route-leak: product-mode-looking treatment also blocked by treatment_loopx_lifecycle_not_observed
- debug-trl-grpo remains on its existing runner/setup repair path because it has no latest product-mode treatment

## Validation
- python -m py_compile loopx/benchmark_ledger.py
- python examples/benchmark-run-ledger-smoke.py
- python examples/benchmark-loop-protocol-smoke.py
- python -m json.tool docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json >/dev/null
- git diff --check
- loopx check --scan-path loopx/benchmark_ledger.py --scan-path examples/benchmark-run-ledger-smoke.py --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md