### PR TITLE
Record paratransit product-mode runner blocker

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
@@ -4273,7 +4273,7 @@
               "baseline_route_valid": true,
               "benchmark_id": "skillsbench@1.1",
               "case_id": "paratransit-routing",
-              "claim_blocker": "treatment_loopx_lifecycle_not_observed",
+              "claim_blocker": "treatment_official_feedback_not_blinded,treatment_reward_feedback_forwarding_not_disabled,treatment_compact_metrics_missing,treatment_loopx_lifecycle_not_observed",
               "comparison_id": "skillsbench_product_mode_main_table_v0",
               "headline_metrics": [
                 "best_score",
@@ -4282,13 +4282,13 @@
                 "declared_done_score"
               ],
               "main_table_claim_allowed": false,
-              "official_feedback_blinded": true,
+              "official_feedback_blinded": false,
               "product_mode_pair_complete": false,
               "schema_version": "benchmark_product_mode_comparison_v0",
               "treatment_loopx_lifecycle_observed": false,
               "treatment_route_valid": true
             },
-            "treatment_run_id": "c9e2eebe7a8e"
+            "treatment_run_id": "885394be2262"
           },
           "runs": [
             {
@@ -5004,6 +5004,54 @@
                 "staged": true,
                 "task_skills_removed": true
               }
+            },
+            {
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "codex_loopx_treatment",
+              "artifact_refs": {
+                "compact_artifact_ref": ".local/private-benchmark-jobs/paratransit-loopx-product-mode-20260622T102509Z/loopx-product-mode-20260622T102509Z/benchmark_run.compact.json"
+              },
+              "attempt_failure_class": "none",
+              "attempt_failure_label": "not_run_adapter_skeleton",
+              "attempt_lifecycle_phase": "not_started",
+              "benchmark_id": "skillsbench@1.1",
+              "case_attempt_countable": false,
+              "case_id": "paratransit-routing",
+              "case_ids": [
+                "paratransit-routing"
+              ],
+              "codex_acp_runtime_preflight_passed": false,
+              "failure_class": "skillsbench_runner_failed_before_agent_install",
+              "failure_labels": [
+                "skillsbench_runner_failed_before_agent_install",
+                "skillsbench_runner_setup_error"
+              ],
+              "failure_scope": "score_missing",
+              "job_name": "paratransit-loopx-product-mode-20260622T102509Z",
+              "launcher_attempt_countable": false,
+              "leaderboard_evidence": false,
+              "loopx_inside_case": true,
+              "mode": "skillsbench_loopx_product_mode_treatment",
+              "notes": "official SkillsBench BenchFlow LoopX product-mode treatment; compact result only; no raw task/log/trajectory read into public state",
+              "official_score_attempt_countable": false,
+              "recorded_at": "2026-06-22T18:25:10+08:00",
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-product-mode-paratransit-20260622T102509Z",
+              "run_id": "885394be2262",
+              "score_status": "missing",
+              "solver_attempt_countable": false,
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false,
+              "task_staging": {
+                "apt_retry_patch_required": false,
+                "apt_risk_preflight_blocked": false,
+                "apt_setup_risk_detected": false,
+                "staged": false
+              },
+              "verifier_attempt_countable": false
             }
           ]
         },
@@ -6871,7 +6919,7 @@
           ]
         }
       },
-      "run_count": 122
+      "run_count": 124
     },
     "swe-marathon": {
       "benchmark_id": "swe-marathon",
@@ -10923,5 +10971,5 @@
     "source_of_truth": "benchmark_run_v0 compact run events",
     "update_rule": "upsert one run entry when a benchmark case is ingested or closed"
   },
-  "updated_at": "2026-06-22T06:08:33+08:00"
+  "updated_at": "2026-06-22T18:25:10+08:00"
 }

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
@@ -5,7 +5,7 @@ benchmark case outcomes and artifact references; it must not contain raw
 logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 
 - schema_version: `benchmark_run_ledger_v0`
-- updated_at: `2026-06-22T06:08:33+08:00`
+- updated_at: `2026-06-22T18:25:10+08:00`
 
 ## Case Decisions
 
@@ -25,7 +25,7 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `skillsbench@1.1` | `llm-prefix-cache-replay` | `paired_no_score_uplift` | - | - | `25` |
 | `skillsbench@1.1` | `manufacturing-codebook-normalization` | `paired_no_score_uplift` | - | - | `4` |
 | `skillsbench@1.1` | `organize-messy-files` | `paired_baseline_solved_treatment_preserved` | - | - | `3` |
-| `skillsbench@1.1` | `paratransit-routing` | `product_mode_pair_incomplete` | `treatment_loopx_lifecycle_not_observed` | - | `9` |
+| `skillsbench@1.1` | `paratransit-routing` | `product_mode_pair_incomplete` | `treatment_official_feedback_not_blinded,treatment_reward_feedback_forwarding_not_disabled,treatment_compact_metrics_m...` | - | `10` |
 | `skillsbench@1.1` | `pddl-airport-planning` | `paired_no_score_uplift` | - | - | `9` |
 | `skillsbench@1.1` | `react-performance-debugging` | `paired_baseline_runner_or_setup_repair_required` | - | - | `5` |
 | `skillsbench@1.1` | `setup-fuzzing-py` | `baseline_runner_or_setup_repair_required` | - | - | `3` |
@@ -166,6 +166,7 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `skillsbench@1.1` | `paratransit-routing` | `codex_loopx_treatment` | `` | `missing` | `` | `` | `skillsbench_docker_daemon_unavailable` | `.local/private-benchmark-jobs/skillsbench-paratransit-routing-loopx-product-mode-depth-rerun-20260617T113221CST/paratransit-routing__loopx_product_mode_depth_rerun/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `paratransit-routing` | `codex_loopx_treatment` | `` | `0.0` | `` | `1:0` | `official_verifier_solution_failure` | `.local/private-benchmark-jobs/skillsbench-paratransit-routing-loopx-product-mode-depth-rerun-20260617T113439CST/paratransit-routing__loopx_product_mode_depth_rerun/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `paratransit-routing` | `codex_loopx_treatment` | `` | `1.0` | `5` | `1:0,2:0,3:0,4:0,5:1*` | `none` | `.local/private-benchmark-jobs/skillsbench-paratransit-routing-loopx-product-mode-depth-gate-20260617T1229CST/paratransit-routing__loopx_product_mode_depth_gate/benchmark_run.compact.json` |
+| `skillsbench@1.1` | `paratransit-routing` | `codex_loopx_treatment` | `` | `missing` | `` | `` | `skillsbench_runner_failed_before_agent_install` | `.local/private-benchmark-jobs/paratransit-loopx-product-mode-20260622T102509Z/loopx-product-mode-20260622T102509Z/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `pddl-airport-planning` | `codex_goal_mode_baseline` | `` | `0.0` | `` | `` | `official_verifier_solution_failure` | `result.json` |
 | `skillsbench@1.1` | `pddl-airport-planning` | `codex_goal_mode_baseline` | `` | `0.0` | `` | `` | `official_verifier_solution_failure` | `result.json` |
 | `skillsbench@1.1` | `pddl-airport-planning` | `codex_goal_mode_baseline` | `` | `0.0` | `` | `` | `official_verifier_solution_failure` | `result.json` |


### PR DESCRIPTION
## Summary
- record the latest paratransit-routing LoopX product-mode launch as a compact runner/setup blocker
- keep only the meaningful global-registry launch record and drop the duplicate local-registry mislaunch row
- preserve public boundary: no raw task text, trajectories, verifier logs, credentials, submissions, or leaderboard claims

## Validation
- python -m json.tool docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json >/dev/null
- python examples/benchmark-run-ledger-smoke.py
- python examples/benchmark-case-analysis-smoke.py
- git diff --check
- loopx check --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md