### PR TITLE
docs: put Quick Start before showcase proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,149 +21,13 @@ surface, and writeback trail.
 LoopX 把一次静态 goal 变成能持续流转的动态 loop：该等人的地方明确等人，
 不该空等的安全侧路继续推进，下一轮 agent 总能读到目标、边界、证据和交接。
 
-[Quick Start](#quick-start) · [Getting Started](docs/guides/getting-started.md) ·
-[Showcases](docs/showcases/README.md) · [Hosted Frontstage](https://huangruiteng.github.io/loopx/frontstage/) ·
+[Quick Start](#quick-start) · [See It In Action](#see-it-in-action) ·
+[Getting Started](docs/guides/getting-started.md) · [Showcases](docs/showcases/README.md) ·
+[Hosted Frontstage](https://huangruiteng.github.io/loopx/frontstage/) ·
 [Community](#community--feedback) · [Product Vision](docs/product/vision.md) · [Architecture](docs/architecture.md) ·
 [Dashboard](apps/dashboard/README.md) · [简体中文](README.zh-CN.md)
 
 > Keep the loop moving. Keep the judgment human.
-
-New here? Start with the
-[Hosted Frontstage](https://huangruiteng.github.io/loopx/frontstage/) for a
-visual tour, or jump straight to [Quick Start](#quick-start). The
-[3-minute demo script](docs/outreach/frontstage-demo-script.md) is for
-presenters who need a timed walkthrough.
-
-## What Is It?
-
-LoopX does not replace Codex, Claude Code, Cursor, or another agent
-runtime. It sits above them as a loop-engineering control plane: the runtime
-executes bounded agent loops, while LoopX preserves the dynamic goal state those
-loops need to keep working without losing the plot.
-
-Short answer: LoopX is not another executor. Codex goal, Codex App
-automation, CLI scripts, cron jobs, or a human-visible TUI can trigger the next
-executor loop; LoopX keeps the goal, gate, evidence, quota, and handoff contract
-stable across those turns.
-
-| Layer | Role |
-| --- | --- |
-| Codex / Claude Code / Cursor | Execute a bounded agent loop: read, write, run commands, and respond. |
-| Goal mode / automation / CLI scripts / TUI | Trigger or schedule the next executor loop. |
-| LoopX | Preserve the dynamic loop state: gates, todos, run history, quota, evidence, boundaries, and handoff state. |
-
-The product promise is not "more todo lists." It is a practical foundation for
-loop engineering: keep human judgment at high-value decision points, keep safe
-fallback work moving when one lane is gated, and stop compute spend when a turn
-cannot produce a verified transition.
-
-Put differently: LoopX lets a user's agent team keep working across tools,
-turns, and off-hours without turning the project into a pile of hidden scripts
-and stale prompts. The technical contract underneath that promise is explicit:
-agent identity, todo ownership, scope, capability gates, quota, evidence
-writeback, and public/private boundaries stay visible to the next turn.
-
-![LoopX control-plane board](docs/assets/control-plane-board.svg)
-
-## See It In Action
-
-| Case | What It Shows | Public Surface |
-| --- | --- | --- |
-| [Blocked P0 with safe P1/P2 rotation](docs/showcases/cases/0617-blocked-p0-safe-rotation.md) | A user-gated high-priority lane stays visible while safe fallback work continues. | Reproducible synthetic demo |
-| [LoopX self-iteration loop](docs/showcases/cases/0619-loopx-self-iteration.md) | A side agent improved LoopX itself while the primary agent stayed focused on benchmark work. | Commit-backed public evidence case |
-| [Dynamic workflow for hardware-agent development](docs/showcases/cases/0619-dynamic-workflow-hardware-agent.md) | A fuzzy multi-agent engineering workflow can converge through one shared control plane. | Redacted public-safe stub |
-
-Start with the [showcase catalog](docs/showcases/README.md): public-safe
-cases that show where LoopX helps, with reproducible demos where the
-evidence allows.
-
-Open the [hosted frontstage](https://huangruiteng.github.io/loopx/frontstage/)
-for the product-facing view: case cards, narrative motion, efficiency evidence,
-and public/private boundary notes rendered from `docs/showcases/`. Live registry
-or local status projections are separate ops-mode surfaces, not public demo
-content.
-
-<table>
-  <tr>
-    <td width="62%">
-      <img src="docs/assets/frontstage-showcase-first-screen.png" alt="Hosted LoopX frontstage showing public-safe showcase cases">
-    </td>
-    <td width="38%">
-      <strong>From AI assist to async agent work.</strong><br><br>
-      Traditional AI-assisted development speeds up the active coding session.
-      LoopX changes the operating model: humans set gates, scope, and
-      evidence, while primary and side agents keep safe lanes moving across
-      turns and off-hours.<br><br>
-      <strong>从“人带着 AI 写代码”，到“agent 团队异步接力”。</strong><br>
-      人在关键判断处掌舵，agent 在可验证边界内持续推进。
-    </td>
-  </tr>
-</table>
-
-## Why Loop Engineering Needs A Control Plane
-
-Short agent tasks usually fail because the model makes a bad local choice.
-Long-running loops fail differently: state drifts.
-
-Loop engineering often begins with a timer, a long prompt, a shell script, or a
-visible TUI session. That can prove the idea, but it is not enough for real
-work. Once the goal changes, the user gives feedback, an owner gate appears, or
-multiple agents touch the same repo, the loop needs shared state instead of
-chat memory.
-
-After several runs, several projects, or several handoffs, the hard questions
-become:
-
-- What is the current objective, and what is explicitly out of scope?
-- Which owner decision, source document, run artifact, or benchmark result is
-  the current authority?
-- What did the last agent run actually do, and how was it validated?
-- Which next action belongs to the human, and which belongs to the agent?
-- Which actions are safe read-only work, and which cross write, production,
-  private-data, or publication boundaries?
-- How does human feedback survive into the next run?
-
-LoopX makes those questions machine-readable enough for agents and legible
-enough for operators, so a loop can run longer without becoming less
-accountable.
-
-## What You Get
-
-- **Lifetime goals**: durable project intentions that outlive one chat thread,
-  run, todo, or implementation plan. A lifetime goal does not grant open-ended
-  autonomy: only the next bounded transition is executable.
-- **User gates**: concrete human decisions that stay visible instead of
-  disappearing into chat.
-- **Safe fallback**: audited side paths that can continue when one lane is
-  gated, without bypassing the gate.
-- **Todo ownership**: user and agent todos with `claimed_by` for multi-agent
-  coordination.
-- **Quota and steering**: a guard that says whether an automatic turn should
-  run, wait, ask the user, self-repair, or stay quiet.
-- **Run history and evidence**: compact append-only events for progress,
-  validation, blockers, reward, benchmark results, and quota spend.
-- **Public/private boundary checks**: local scans and docs rules to keep raw
-  private state, credentials, logs, traces, and benchmark material out of
-  public artifacts.
-
-## Good Fits
-
-Use LoopX when agent work spans time, people, projects, or safety
-boundaries:
-
-- multi-day or multi-week engineering and research goals;
-- recurring heartbeat or monitor-style agent turns;
-- benchmark and experiment loops that must wait for evidence;
-- projects with owner/SOP gates or human reward judgments;
-- controller agents that spawn scoped side agents;
-- creator, research, or operations workflows where non-engineering users need
-  agent progress translated into clear state, blockers, and feedback prompts;
-- public/private boundary checks before publishing artifacts;
-- local dashboards that should foreground user decisions before raw logs.
-
-Do not use LoopX as an autonomous production controller. It is a local
-coordination substrate; project ownership and dangerous permissions stay with
-the human/operator.
 
 ## Quick Start
 
@@ -264,6 +128,121 @@ loopx doctor
 For the full install, diagnose, connect, heartbeat, dashboard, development, and
 command-reference workflow, read
 [docs/guides/getting-started.md](docs/guides/getting-started.md).
+
+## See It In Action
+
+Want proof before reading the control-plane details? Use three short entry
+points:
+
+- [Hosted Frontstage](https://huangruiteng.github.io/loopx/frontstage/):
+  the public showcase homepage with the canonical case cards.
+- [Blocked P0 with safe P1/P2 rotation](docs/showcases/cases/0617-blocked-p0-safe-rotation.md):
+  a reproducible synthetic demo where a human gate stays visible while safe
+  fallback work continues.
+- [LoopX self-iteration](docs/showcases/cases/0619-loopx-self-iteration.md)
+  and the [hardware-agent workflow](docs/showcases/cases/0619-dynamic-workflow-hardware-agent.md):
+  public-safe evidence that one control plane can coordinate primary and side
+  agents without hiding ownership or scope.
+
+For more cases, open the [showcase catalog](docs/showcases/README.md). For a
+timed presenter walkthrough, use the
+[3-minute demo script](docs/outreach/frontstage-demo-script.md).
+
+## What Is It?
+
+LoopX does not replace Codex, Claude Code, Cursor, or another agent
+runtime. It sits above them as a loop-engineering control plane: the runtime
+executes bounded agent loops, while LoopX preserves the dynamic goal state those
+loops need to keep working without losing the plot.
+
+Short answer: LoopX is not another executor. Codex goal, Codex App
+automation, CLI scripts, cron jobs, or a human-visible TUI can trigger the next
+executor loop; LoopX keeps the goal, gate, evidence, quota, and handoff contract
+stable across those turns.
+
+| Layer | Role |
+| --- | --- |
+| Codex / Claude Code / Cursor | Execute a bounded agent loop: read, write, run commands, and respond. |
+| Goal mode / automation / CLI scripts / TUI | Trigger or schedule the next executor loop. |
+| LoopX | Preserve the dynamic loop state: gates, todos, run history, quota, evidence, boundaries, and handoff state. |
+
+The product promise is not "more todo lists." It is a practical foundation for
+loop engineering: keep human judgment at high-value decision points, keep safe
+fallback work moving when one lane is gated, and stop compute spend when a turn
+cannot produce a verified transition.
+
+Put differently: LoopX lets a user's agent team keep working across tools,
+turns, and off-hours without turning the project into a pile of hidden scripts
+and stale prompts. The technical contract underneath that promise is explicit:
+agent identity, todo ownership, scope, capability gates, quota, evidence
+writeback, and public/private boundaries stay visible to the next turn.
+
+![LoopX control-plane board](docs/assets/control-plane-board.svg)
+
+## Why Loop Engineering Needs A Control Plane
+
+Short agent tasks usually fail because the model makes a bad local choice.
+Long-running loops fail differently: state drifts.
+
+Loop engineering often begins with a timer, a long prompt, a shell script, or a
+visible TUI session. That can prove the idea, but it is not enough for real
+work. Once the goal changes, the user gives feedback, an owner gate appears, or
+multiple agents touch the same repo, the loop needs shared state instead of
+chat memory.
+
+After several runs, several projects, or several handoffs, the hard questions
+become:
+
+- What is the current objective, and what is explicitly out of scope?
+- Which owner decision, source document, run artifact, or benchmark result is
+  the current authority?
+- What did the last agent run actually do, and how was it validated?
+- Which next action belongs to the human, and which belongs to the agent?
+- Which actions are safe read-only work, and which cross write, production,
+  private-data, or publication boundaries?
+- How does human feedback survive into the next run?
+
+LoopX makes those questions machine-readable enough for agents and legible
+enough for operators, so a loop can run longer without becoming less
+accountable.
+
+## What You Get
+
+- **Lifetime goals**: durable project intentions that outlive one chat thread,
+  run, todo, or implementation plan. A lifetime goal does not grant open-ended
+  autonomy: only the next bounded transition is executable.
+- **User gates**: concrete human decisions that stay visible instead of
+  disappearing into chat.
+- **Safe fallback**: audited side paths that can continue when one lane is
+  gated, without bypassing the gate.
+- **Todo ownership**: user and agent todos with `claimed_by` for multi-agent
+  coordination.
+- **Quota and steering**: a guard that says whether an automatic turn should
+  run, wait, ask the user, self-repair, or stay quiet.
+- **Run history and evidence**: compact append-only events for progress,
+  validation, blockers, reward, benchmark results, and quota spend.
+- **Public/private boundary checks**: local scans and docs rules to keep raw
+  private state, credentials, logs, traces, and benchmark material out of
+  public artifacts.
+
+## Good Fits
+
+Use LoopX when agent work spans time, people, projects, or safety
+boundaries:
+
+- multi-day or multi-week engineering and research goals;
+- recurring heartbeat or monitor-style agent turns;
+- benchmark and experiment loops that must wait for evidence;
+- projects with owner/SOP gates or human reward judgments;
+- controller agents that spawn scoped side agents;
+- creator, research, or operations workflows where non-engineering users need
+  agent progress translated into clear state, blockers, and feedback prompts;
+- public/private boundary checks before publishing artifacts;
+- local dashboards that should foreground user decisions before raw logs.
+
+Do not use LoopX as an autonomous production controller. It is a local
+coordination substrate; project ownership and dangerous permissions stay with
+the human/operator.
 
 ## Community & Feedback
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -16,102 +16,9 @@ loop 状态：目标、用户决策、agent todo、认领关系、scope、证据
 和 quota 留在同一层状态里。该等人的地方明确等人，不该空等的安全侧路继续推进，
 每一次自动执行都留下边界、验证面和写回轨迹。
 
-[English](README.md) · [快速开始](#快速开始) · [Showcases](docs/showcases/README.md) ·
-[用户群与反馈](#用户群与反馈) · [产品愿景](docs/product/vision.md) · [架构](docs/architecture.md)
-
-第一次看 LoopX？先打开
-[Hosted Frontstage](https://huangruiteng.github.io/loopx/frontstage/) 看公开
-案例，或直接跳到 [快速开始](#快速开始)。[3 分钟 demo script](docs/outreach/frontstage-demo-script.md)
-只给演示者做 timed walkthrough 用。
-
-## 它是什么
-
-LoopX 不是另一个 agent runtime，也不是要替代 Codex、Claude Code、
-Cursor 或其他终端 agent。更准确地说，它是 loop engineering 的控制面：
-runtime 负责执行一次次 bounded agent loop，LoopX 负责保存这些 loop 继续工作所需
-的动态目标状态。
-
-| 层次 | 负责什么 |
-| --- | --- |
-| Codex / Claude Code / Cursor | 执行 bounded agent loop，写代码、读文件、运行命令、回复用户 |
-| goal mode / automation / CLI 脚本 / TUI | 触发或调度下一次 executor loop |
-| LoopX | 维护动态 loop 状态：当前目标、用户决策、agent todo、run history、quota、证据、边界和交接 |
-
-一句话：LoopX 不是执行器，而是让 goal mode、automation、CLI 脚本或可见 TUI
-触发的 agent loop 都能共享同一份动态长期目标状态。
-
-## 为什么 Loop Engineering 需要控制面
-
-短任务失败，常常是因为模型某一步做错了。长期任务失败，更常见的原因是
-state drift。
-
-Loop engineering 常常从一个定时器、一段长 prompt、一个 shell 脚本或一个可见
-TUI session 开始。它们能证明想法，但不足以承载真实工作：一旦目标变化、用户反馈
-出现、owner gate 卡住、多 agent 同时碰同一个 repo，就需要共享状态，而不是继续依赖
-聊天记忆。
-
-- 用户已经做过的决策散落在聊天里，后续 agent 不知道；
-- P0 卡在 user gate 上，agent 只会空等，或者绕过人类决策继续乱跑；
-- 多个 agent 同时工作，却看不到彼此认领了哪些 todo；
-- 上一轮到底做了什么、怎么验证的、为什么没继续，难以复盘；
-- public/private 边界、benchmark no-upload 边界、生产权限边界没有被稳定投影；
-- 人类反馈没有沉淀成下一轮 agent 能读懂的控制面信号。
-
-LoopX 的产品判断是：强能力 agent loop 已经存在，问题在于如何把它变成长期
-可用、可控、可解释的协作系统。
-
-换句话说，LoopX 想让人的多个 agent 可以持续接力，包括夜间和用户离开后的安全工作；
-但接力的前提不是绕过人，而是把人类判断、scope、能力门、quota 和证据写成下一轮
-agent 也能读懂的控制面。
-
-## 它如何工作
-
-```mermaid
-flowchart LR
-  U["用户判断 / gate / feedback"] --> GH["LoopX state"]
-  P["主控 agent"] --> GH
-  S["旁路 agent"] --> GH
-  GH --> T["User todo / Agent todo"]
-  GH --> H["Run history / evidence"]
-  GH --> Q["Quota guard"]
-  T --> A["下一步 bounded action"]
-  Q --> A
-  A --> GH
-```
-
-核心对象：
-
-- **Lifetime goal**：能跨越单个聊天、单个 agent run、单个 todo 的长期目标。
-- **User gate**：需要人类判断的位置，明确停下并把问题投影出来。
-- **Safe fallback**：不依赖该 gate 的安全侧路，允许继续推进并留下证据。
-- **Todo ownership**：agent 通过 `claimed_by` 认领 todo，减少并发冲突。
-- **Quota guard**：每次自动 heartbeat 前判断是否应该运行、等待、通知或自修复。
-- **Run history**：把每轮进展、验证、blocker、reward、quota spend 记录成紧凑历史。
-
-## 看几个例子
-
-| Case | 说明 | 入口 |
-| --- | --- | --- |
-| Blocked P0 with safe P1/P2 rotation | P0 被用户决策卡住，但 P1/P2 安全侧路继续推进，且 gate 不丢失。 | [0617 case](docs/showcases/cases/0617-blocked-p0-safe-rotation.md) |
-| LoopX self-iteration loop | 主控聚焦 benchmark，旁路 agent 在独立 scope 里改进控制面、文档和自合并机制。 | [0619 self-iteration](docs/showcases/cases/0619-loopx-self-iteration.md) |
-| Dynamic workflow for hardware-agent development | 模糊、多 agent、跨阶段工程协作如何收敛到同一控制面。 | [0619 redacted stub](docs/showcases/cases/0619-dynamic-workflow-hardware-agent.md) |
-
-完整案例目录见 [docs/showcases/README.md](docs/showcases/README.md)。案例默认只保留
-public-safe 信息，不提交内部截图、私有链接、raw benchmark 日志或本地状态。
-
-## 适合什么场景
-
-LoopX 适合长期、多人、多 agent 或带边界的工作：
-
-- 多天或多周的工程、研究、benchmark、实验推进；
-- Codex / Claude Code / Cursor 的 recurring heartbeat 或 monitor-style 工作；
-- 需要等待 CI、benchmark、外部 owner、用户判断的项目；
-- 一个主控 agent 加多个旁路 agent 的协作；
-- 需要把“agent 做了什么、卡在哪、下一步是什么”翻译给非技术用户的产品；
-- 发布公开材料前需要持续检查 public/private 边界的项目。
-
-它不适合直接作为生产自动化控制器。危险权限、生产操作、私有材料公开、发布
-动作仍然应该由人类或宿主项目明确授权。
+[English](README.md) · [快速开始](#快速开始) · [看几个例子](#看几个例子) ·
+[Showcases](docs/showcases/README.md) · [用户群与反馈](#用户群与反馈) ·
+[产品愿景](docs/product/vision.md) · [架构](docs/architecture.md)
 
 ## 快速开始
 
@@ -180,6 +87,100 @@ loopx bootstrap \
 成功连接后应该能看到 `.loopx/registry.json`、
 `.codex/goals/<goal-id>/ACTIVE_GOAL_STATE.md`、`loopx status` 的下一步投影；
 这些本地状态必须被 gitignore，不要提交到公开仓库。
+
+## 看几个例子
+
+想先看证明，再读控制面细节，可以从三个短入口开始：
+
+- [Hosted Frontstage](https://huangruiteng.github.io/loopx/frontstage/)：
+  公开 showcase 首页，用 canonical case cards 解释 LoopX 解决什么问题。
+- [Blocked P0 with safe P1/P2 rotation](docs/showcases/cases/0617-blocked-p0-safe-rotation.md)：
+  一个可复现 synthetic demo，展示用户决策保持可见时，安全侧路仍可继续推进。
+- [LoopX self-iteration](docs/showcases/cases/0619-loopx-self-iteration.md)
+  和 [hardware-agent workflow](docs/showcases/cases/0619-dynamic-workflow-hardware-agent.md)：
+  用 public-safe 证据展示同一控制面如何协调主控、旁路、scope 和 ownership。
+
+完整案例目录见 [docs/showcases/README.md](docs/showcases/README.md)。
+演示者需要 timed walkthrough 时，再打开
+[3 分钟 demo script](docs/outreach/frontstage-demo-script.md)。
+
+## 它是什么
+
+LoopX 不是另一个 agent runtime，也不是要替代 Codex、Claude Code、
+Cursor 或其他终端 agent。更准确地说，它是 loop engineering 的控制面：
+runtime 负责执行一次次 bounded agent loop，LoopX 负责保存这些 loop 继续工作所需
+的动态目标状态。
+
+| 层次 | 负责什么 |
+| --- | --- |
+| Codex / Claude Code / Cursor | 执行 bounded agent loop，写代码、读文件、运行命令、回复用户 |
+| goal mode / automation / CLI 脚本 / TUI | 触发或调度下一次 executor loop |
+| LoopX | 维护动态 loop 状态：当前目标、用户决策、agent todo、run history、quota、证据、边界和交接 |
+
+一句话：LoopX 不是执行器，而是让 goal mode、automation、CLI 脚本或可见 TUI
+触发的 agent loop 都能共享同一份动态长期目标状态。
+
+## 为什么 Loop Engineering 需要控制面
+
+短任务失败，常常是因为模型某一步做错了。长期任务失败，更常见的原因是
+state drift。
+
+Loop engineering 常常从一个定时器、一段长 prompt、一个 shell 脚本或一个可见
+TUI session 开始。它们能证明想法，但不足以承载真实工作：一旦目标变化、用户反馈
+出现、owner gate 卡住、多 agent 同时碰同一个 repo，就需要共享状态，而不是继续依赖
+聊天记忆。
+
+- 用户已经做过的决策散落在聊天里，后续 agent 不知道；
+- P0 卡在 user gate 上，agent 只会空等，或者绕过人类决策继续乱跑；
+- 多个 agent 同时工作，却看不到彼此认领了哪些 todo；
+- 上一轮到底做了什么、怎么验证的、为什么没继续，难以复盘；
+- public/private 边界、benchmark no-upload 边界、生产权限边界没有被稳定投影；
+- 人类反馈没有沉淀成下一轮 agent 能读懂的控制面信号。
+
+LoopX 的产品判断是：强能力 agent loop 已经存在，问题在于如何把它变成长期
+可用、可控、可解释的协作系统。
+
+换句话说，LoopX 想让人的多个 agent 可以持续接力，包括夜间和用户离开后的安全工作；
+但接力的前提不是绕过人，而是把人类判断、scope、能力门、quota 和证据写成下一轮
+agent 也能读懂的控制面。
+
+## 它如何工作
+
+```mermaid
+flowchart LR
+  U["用户判断 / gate / feedback"] --> GH["LoopX state"]
+  P["主控 agent"] --> GH
+  S["旁路 agent"] --> GH
+  GH --> T["User todo / Agent todo"]
+  GH --> H["Run history / evidence"]
+  GH --> Q["Quota guard"]
+  T --> A["下一步 bounded action"]
+  Q --> A
+  A --> GH
+```
+
+核心对象：
+
+- **Lifetime goal**：能跨越单个聊天、单个 agent run、单个 todo 的长期目标。
+- **User gate**：需要人类判断的位置，明确停下并把问题投影出来。
+- **Safe fallback**：不依赖该 gate 的安全侧路，允许继续推进并留下证据。
+- **Todo ownership**：agent 通过 `claimed_by` 认领 todo，减少并发冲突。
+- **Quota guard**：每次自动 heartbeat 前判断是否应该运行、等待、通知或自修复。
+- **Run history**：把每轮进展、验证、blocker、reward、quota spend 记录成紧凑历史。
+
+## 适合什么场景
+
+LoopX 适合长期、多人、多 agent 或带边界的工作：
+
+- 多天或多周的工程、研究、benchmark、实验推进；
+- Codex / Claude Code / Cursor 的 recurring heartbeat 或 monitor-style 工作；
+- 需要等待 CI、benchmark、外部 owner、用户判断的项目；
+- 一个主控 agent 加多个旁路 agent 的协作；
+- 需要把“agent 做了什么、卡在哪、下一步是什么”翻译给非技术用户的产品；
+- 发布公开材料前需要持续检查 public/private 边界的项目。
+
+它不适合直接作为生产自动化控制器。危险权限、生产操作、私有材料公开、发布
+动作仍然应该由人类或宿主项目明确授权。
 
 ## 用户群与反馈
 


### PR DESCRIPTION
## Summary
- move README / zh-CN README flow to value statement -> Quick Start -> See It In Action
- slim the showcase proof section to three short entry points
- keep detailed 3-minute demo script and showcase catalog as secondary links

## Validation
- python3 examples/showcase-catalog-smoke.py
- loopx check --scan-path README.md --scan-path README.zh-CN.md