### PR TITLE
Add Dashboard Todo Explorer

### DIFF
--- a/apps/dashboard/smoke/home-route-smoke.ts
+++ b/apps/dashboard/smoke/home-route-smoke.ts
@@ -35,13 +35,16 @@ for (const goalId of shareGoalIds) {
 }
 
 includes(routerSource, 'view: z.enum(["ops", "share"]).optional()', "optional view search param");
+includes(routerSource, 'todoGoalId: z.string().optional().default("all")', "todo project search param");
 includes(routerSource, 'todoQuery: z.string().optional().default("")', "todo query search param");
 includes(routerSource, 'todoRole: z.enum(["all", "user", "agent"]).optional().default("all")', "todo role search param");
+includes(routerSource, 'todoStatus: z.enum(["all", "open", "done", "blocked", "deferred"]).optional().default("all")', "todo status search param");
 excludes(routerSource, 'view: z.enum(["ops", "share"]).optional().default("share")', "share default route mode");
 
 includes(dashboardSource, 'const defaultGlobalStatusUrl = "http://127.0.0.1:8766/status.json";', "global default status URL");
 includes(dashboardSource, 'return view === "ops" ? "ops" : undefined;', "canonical URL omits non-ops view");
-includes(dashboardSource, 'if (search.view !== "ops") {', "non-ops renders control-plane home");
+includes(dashboardSource, 'if (search.view !== "ops" && source.kind === "example") {', "non-ops loads global status source once");
+includes(dashboardSource, '[search.statusUrl, search.view, source.kind, source.label]', "status URL change reload effect");
 includes(dashboardSource, 'void loadFromUrl(defaultGlobalStatusUrl);', "home loads global status source");
 includes(dashboardSource, 'data-testid="share-overview"', "control-plane home test id");
 includes(dashboardSource, 'data-testid={`share-top-todos-${view.spec.id}`}', "share top todo list test id");
@@ -67,6 +70,9 @@ includes(dashboardSource, 'data-testid="project-todo-explorer"', "project todo e
 includes(dashboardSource, 'data-testid="project-todo-search-input"', "project todo search input test id");
 includes(dashboardSource, 'data-testid="project-todo-id"', "project todo id rendering");
 includes(dashboardSource, "Project Todo Explorer", "project todo explorer title");
+includes(dashboardSource, "All projects", "project todo all-project selector");
+includes(dashboardSource, "todoExplorerProjectOptions", "project todo auto project options");
+includes(dashboardSource, "selectedTodoGoalId", "project todo selected project prop");
 includes(dashboardSource, "claimed_by=", "project todo claimed owner metadata");
 includes(dashboardSource, "action=", "project todo action metadata");
 includes(dashboardSource, "source={item.source}", "project todo source metadata");
@@ -74,6 +80,7 @@ includes(dashboardSource, "latest_event_kind", "project todo historical event me
 includes(dashboardSource, "todoIndex={payload.todo_index}", "project todo index wiring");
 excludes(dashboardSource, "raw internal slot constraints", "raw internal constraint copy");
 includes(contractSource, "todo_id", "status contract todo id metadata");
+includes(readFileSync("src/data/goal-channel-frontstage.ts", "utf8"), "generated_at: z.string().optional().nullable()", "goal channel generated_at optional live status compatibility");
 includes(packageSource, '"smoke:home-route"', "home route smoke script");
 includes(packageSource, '"smoke:home-browser"', "home browser smoke script");
 includes(packageSource, '"smoke:demo-readiness"', "demo readiness smoke script");

--- a/apps/dashboard/smoke/home-route-smoke.ts
+++ b/apps/dashboard/smoke/home-route-smoke.ts
@@ -35,6 +35,8 @@ for (const goalId of shareGoalIds) {
 }
 
 includes(routerSource, 'view: z.enum(["ops", "share"]).optional()', "optional view search param");
+includes(routerSource, 'todoQuery: z.string().optional().default("")', "todo query search param");
+includes(routerSource, 'todoRole: z.enum(["all", "user", "agent"]).optional().default("all")', "todo role search param");
 excludes(routerSource, 'view: z.enum(["ops", "share"]).optional().default("share")', "share default route mode");
 
 includes(dashboardSource, 'const defaultGlobalStatusUrl = "http://127.0.0.1:8766/status.json";', "global default status URL");
@@ -61,7 +63,17 @@ includes(dashboardSource, '阻塞说明', "Chinese blocker label");
 includes(dashboardSource, '配额守卫', "Chinese quota guard label");
 includes(dashboardSource, '状态写回', "Chinese state writeback label");
 includes(dashboardSource, '<h1 className="text-2xl font-semibold">Goal Operations</h1>', "ops workbench fallback");
+includes(dashboardSource, 'data-testid="project-todo-explorer"', "project todo explorer test id");
+includes(dashboardSource, 'data-testid="project-todo-search-input"', "project todo search input test id");
+includes(dashboardSource, 'data-testid="project-todo-id"', "project todo id rendering");
+includes(dashboardSource, "Project Todo Explorer", "project todo explorer title");
+includes(dashboardSource, "claimed_by=", "project todo claimed owner metadata");
+includes(dashboardSource, "action=", "project todo action metadata");
+includes(dashboardSource, "source={item.source}", "project todo source metadata");
+includes(dashboardSource, "latest_event_kind", "project todo historical event metadata");
+includes(dashboardSource, "todoIndex={payload.todo_index}", "project todo index wiring");
 excludes(dashboardSource, "raw internal slot constraints", "raw internal constraint copy");
+includes(contractSource, "todo_id", "status contract todo id metadata");
 includes(packageSource, '"smoke:home-route"', "home route smoke script");
 includes(packageSource, '"smoke:home-browser"', "home browser smoke script");
 includes(packageSource, '"smoke:demo-readiness"', "demo readiness smoke script");

--- a/apps/dashboard/src/data/goal-channel-frontstage.ts
+++ b/apps/dashboard/src/data/goal-channel-frontstage.ts
@@ -44,7 +44,7 @@ export const goalChannelProjectionSchema = z.object({
   mode: z.literal("read_only"),
   goal_id: z.string(),
   display_name: z.string(),
-  generated_at: z.string(),
+  generated_at: z.string().optional().nullable(),
   latest_status: z.string(),
   waiting_on: z.string(),
   next_action: z.string(),
@@ -106,7 +106,7 @@ export type GoalChannelProjection = {
   mode: "read_only";
   goal_id: string;
   display_name: string;
-  generated_at: string;
+  generated_at?: string | null;
   latest_status: string;
   waiting_on: string;
   next_action: string;

--- a/apps/dashboard/src/data/status.ts
+++ b/apps/dashboard/src/data/status.ts
@@ -61,8 +61,23 @@ export const todoItemSchema = z.object({
   index: z.number(),
   done: z.boolean(),
   text: z.string(),
+  schema_version: z.string().optional().nullable(),
+  todo_id: z.string().optional().nullable(),
+  role: z.string().optional().nullable(),
+  status: z.string().optional().nullable(),
+  priority: z.string().optional().nullable(),
+  title: z.string().optional().nullable(),
+  archive_state: z.string().optional().nullable(),
+  source_section: z.string().optional().nullable(),
+  task_class: z.string().optional().nullable(),
+  action_kind: z.string().optional().nullable(),
+  claimed_by: z.string().optional().nullable(),
+  required_capabilities: z.array(z.string()).optional(),
+  note: z.string().optional().nullable(),
+  evidence: z.string().optional().nullable(),
+  updated_at: z.string().optional().nullable(),
   review_materials: z.array(reviewMaterialSchema).optional().default([]),
-});
+}).passthrough();
 
 export const todoGroupSchema = z.object({
   source_section: z.string().optional().nullable(),
@@ -70,6 +85,27 @@ export const todoGroupSchema = z.object({
   open_count: z.number().optional().default(0),
   done_count: z.number().optional().default(0),
   items: z.array(todoItemSchema).optional().default([]),
+});
+
+export const todoIndexItemSchema = todoItemSchema.extend({
+  goal_id: z.string(),
+  source: z.string().optional().nullable(),
+  event_count: z.number().optional().default(0),
+  event_kinds: z.array(z.string()).optional().default([]),
+  latest_event_kind: z.string().optional().nullable(),
+  latest_event_at: z.string().optional().nullable(),
+  latest_event_status: z.string().optional().nullable(),
+  agent_id: z.string().optional().nullable(),
+}).passthrough();
+
+export const todoIndexSchema = z.object({
+  schema_version: z.string().optional().nullable(),
+  source: z.string().optional().nullable(),
+  total_count: z.number().optional().default(0),
+  current_projected_count: z.number().optional().default(0),
+  rollout_event_count: z.number().optional().default(0),
+  item_limit: z.number().optional().nullable(),
+  items: z.array(todoIndexItemSchema).optional().default([]),
 });
 
 export const projectAssetTodoSummarySchema = z.object({
@@ -638,6 +674,7 @@ export const statusPayloadSchema = z.object({
   promotion_gate: promotionGateSchema.default(null),
   decision_freshness_summary: decisionFreshnessSummarySchema.default(null),
   usage_summary: usageSummarySchema.default(null),
+  todo_index: todoIndexSchema.optional().nullable().default(null),
 });
 
 export const rewardDryRunResponseSchema = z.object({
@@ -682,6 +719,8 @@ export type ProjectAssetLatestValidation = z.infer<typeof projectAssetLatestVali
 export type ProjectAssetHandoffReadiness = z.infer<typeof projectAssetHandoffReadinessSchema>;
 export type TodoGroup = z.infer<typeof todoGroupSchema>;
 export type TodoItem = z.infer<typeof todoItemSchema>;
+export type TodoIndexItem = z.infer<typeof todoIndexItemSchema>;
+export type TodoIndexSummary = z.infer<typeof todoIndexSchema>;
 export type ReviewMaterial = z.infer<typeof reviewMaterialSchema>;
 export type ProjectMap = z.infer<typeof projectMapSchema>;
 export type GlobalRegistryHealth = z.infer<typeof globalRegistryHealthSchema>;

--- a/apps/dashboard/src/router.tsx
+++ b/apps/dashboard/src/router.tsx
@@ -16,6 +16,7 @@ const searchSchema = z.object({
   lane: z.enum(["all", "user", "codex", "watch"]).optional().default("all"),
   severity: z.enum(["all", "high", "action", "watch"]).optional().default("all"),
   statusUrl: z.string().optional().default(""),
+  todoGoalId: z.string().optional().default("all"),
   todoQuery: z.string().optional().default(""),
   todoRole: z.enum(["all", "user", "agent"]).optional().default("all"),
   todoStatus: z.enum(["all", "open", "done", "blocked", "deferred"]).optional().default("all"),

--- a/apps/dashboard/src/router.tsx
+++ b/apps/dashboard/src/router.tsx
@@ -16,6 +16,9 @@ const searchSchema = z.object({
   lane: z.enum(["all", "user", "codex", "watch"]).optional().default("all"),
   severity: z.enum(["all", "high", "action", "watch"]).optional().default("all"),
   statusUrl: z.string().optional().default(""),
+  todoQuery: z.string().optional().default(""),
+  todoRole: z.enum(["all", "user", "agent"]).optional().default("all"),
+  todoStatus: z.enum(["all", "open", "done", "blocked", "deferred"]).optional().default("all"),
   view: z.enum(["ops", "share"]).optional(),
 });
 

--- a/apps/dashboard/src/views/dashboard-page.tsx
+++ b/apps/dashboard/src/views/dashboard-page.tsx
@@ -18,6 +18,7 @@ import {
   Radar,
   RefreshCw,
   RotateCcw,
+  Search,
   ShieldCheck,
   Sun,
   Terminal,
@@ -53,7 +54,9 @@ import {
   ProjectAssetLatestValidation,
   ProjectAssetHandoffReadiness,
   ProjectAssetTodoSummary,
+  TodoItem,
   TodoGroup,
+  TodoIndexSummary,
   EventLedgerSummary,
   PromotionReadinessSummary,
   PromotionGate,
@@ -275,6 +278,22 @@ type TodoFocusItem = {
   waitingOn: string;
   phase: string;
   priority: number;
+};
+
+type TodoExplorerRole = "user" | "agent";
+
+type TodoExplorerItem = {
+  goalId: string;
+  role: TodoExplorerRole;
+  todo: TodoItem;
+  sourceSection: string;
+  source: string;
+  openCount: number;
+  totalCount: number;
+  severity: string;
+  waitingOn: string;
+  phase: string;
+  sourceOrder: number;
 };
 
 function laneFor(item: QueueItem) {
@@ -1116,6 +1135,292 @@ function buildTodoFocusItems(rows: GoalDirectoryRow[]): TodoFocusItem[] {
   }
 
   return items.sort((a, b) => a.priority - b.priority || a.goalId.localeCompare(b.goalId));
+}
+
+function todoDisplayTitle(todo: TodoItem) {
+  return todo.title?.trim() || todo.text;
+}
+
+function todoDisplayStatus(todo: TodoItem) {
+  return todo.status?.trim() || (todo.done ? "done" : "open");
+}
+
+function todoExplorerStatusVariant(item: TodoExplorerItem): BadgeVariant {
+  const todo = item.todo;
+  const status = todoDisplayStatus(todo);
+  if (status === "done") {
+    return "success";
+  }
+  if (status === "blocked") {
+    return "danger";
+  }
+  if (status === "deferred") {
+    return "neutral";
+  }
+  return item.role === "user" ? "warning" : "info";
+}
+
+function todoRoleLabel(role: TodoExplorerRole) {
+  return role === "user" ? "User" : "Agent";
+}
+
+function collectTodoExplorerItems(rows: GoalDirectoryRow[], todoIndex?: TodoIndexSummary | null): TodoExplorerItem[] {
+  const items: TodoExplorerItem[] = [];
+  const seenKeys = new Set<string>();
+
+  for (const row of rows) {
+    const projectAsset = row.queueItem?.project_asset;
+    const groups: Array<[TodoExplorerRole, TodoGroup | null]> = [
+      ["user", todosFromProjectAssetSummary(projectAsset?.user_todos, row.queueItem?.user_todos, "project_asset.user_todos")],
+      ["agent", todosFromProjectAssetSummary(projectAsset?.agent_todos, row.queueItem?.agent_todos, "project_asset.agent_todos")],
+    ];
+    for (const [role, group] of groups) {
+      for (const [sourceOrder, todo] of (group?.items ?? []).entries()) {
+        items.push({
+          goalId: row.goal.id,
+          role,
+          todo,
+          sourceSection: todo.source_section ?? group?.source_section ?? `${role}_todos`,
+          source: "attention_queue",
+          openCount: group?.open_count ?? 0,
+          totalCount: group?.total_count ?? 0,
+          severity: row.severity,
+          waitingOn: row.waitingOn,
+          phase: row.lifecyclePhase,
+          sourceOrder,
+        });
+        seenKeys.add(`${row.goal.id}:${role}:${todo.todo_id ?? todo.index}:${todo.text}`);
+      }
+    }
+  }
+
+  const rowByGoal = new Map(rows.map((row) => [row.goal.id, row]));
+  for (const [sourceOrder, todo] of (todoIndex?.items ?? []).entries()) {
+    const goalId = todo.goal_id;
+    const rawRole = todo.role === "user" || todo.role === "agent" ? todo.role : "agent";
+    const key = `${goalId}:${rawRole}:${todo.todo_id ?? todo.index}:${todo.text}`;
+    if (seenKeys.has(key)) {
+      continue;
+    }
+    const row = rowByGoal.get(goalId);
+    items.push({
+      goalId,
+      role: rawRole,
+      todo,
+      sourceSection: todo.source_section ?? todo.source ?? "todo_index",
+      source: todo.source ?? "todo_index",
+      openCount: 0,
+      totalCount: 0,
+      severity: row?.severity ?? "watch",
+      waitingOn: row?.waitingOn ?? "codex",
+      phase: row?.lifecyclePhase ?? "indexed",
+      sourceOrder: sourceOrder + 10_000,
+    });
+    seenKeys.add(key);
+  }
+
+  return items.sort((left, right) => {
+    const leftDone = left.todo.done ? 1 : 0;
+    const rightDone = right.todo.done ? 1 : 0;
+    return leftDone - rightDone
+      || left.goalId.localeCompare(right.goalId)
+      || left.role.localeCompare(right.role)
+      || left.todo.index - right.todo.index
+      || left.sourceOrder - right.sourceOrder;
+  });
+}
+
+function todoExplorerHaystack(item: TodoExplorerItem) {
+  const todo = item.todo;
+  return [
+    item.goalId,
+    item.role,
+    item.sourceSection,
+    item.severity,
+    item.waitingOn,
+    item.phase,
+    todo.todo_id,
+    todo.priority,
+    todo.status,
+    todo.title,
+    todo.text,
+    todo.task_class,
+    todo.action_kind,
+    todo.claimed_by,
+    todo.archive_state,
+    todo.note,
+    todo.evidence,
+    item.source,
+    (todo as { latest_event_kind?: string | null }).latest_event_kind,
+    (todo as { latest_event_at?: string | null }).latest_event_at,
+    (todo as { agent_id?: string | null }).agent_id,
+    String(todo.index),
+    ...(todo.required_capabilities ?? []),
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+}
+
+function ProjectTodoExplorer({
+  onQueryChange,
+  onRoleChange,
+  onSelectGoal,
+  onStatusChange,
+  query,
+  role,
+  rows,
+  selectedGoalId,
+  status,
+  todoIndex,
+}: {
+  onQueryChange: (query: string) => void;
+  onRoleChange: (role: "all" | TodoExplorerRole) => void;
+  onSelectGoal: (goalId: string) => void;
+  onStatusChange: (status: "all" | "open" | "done" | "blocked" | "deferred") => void;
+  query: string;
+  role: "all" | TodoExplorerRole;
+  rows: GoalDirectoryRow[];
+  selectedGoalId: string;
+  status: "all" | "open" | "done" | "blocked" | "deferred";
+  todoIndex?: TodoIndexSummary | null;
+}) {
+  const allItems = useMemo(() => collectTodoExplorerItems(rows, todoIndex), [rows, todoIndex]);
+  const normalizedQuery = query.trim().toLowerCase();
+  const filteredItems = allItems.filter((item) => {
+    const roleMatches = role === "all" || item.role === role;
+    const itemStatus = todoDisplayStatus(item.todo);
+    const statusMatches = status === "all" || itemStatus === status;
+    const queryMatches = !normalizedQuery || todoExplorerHaystack(item).includes(normalizedQuery);
+    return roleMatches && statusMatches && queryMatches;
+  });
+  const openCount = allItems.filter((item) => !item.todo.done).length;
+  const agentCount = allItems.filter((item) => item.role === "agent").length;
+  const visibleItems = filteredItems.slice(0, 80);
+
+  return (
+    <Card data-testid="project-todo-explorer">
+      <CardHeader className="flex-wrap">
+        <div>
+          <CardTitle className="flex items-center gap-2">
+            <Search className="h-4 w-4" />
+            Project Todo Explorer
+          </CardTitle>
+          <p className="mt-2 text-sm text-slate-500 dark:text-zinc-400">
+            Search current projected todos by id, text, owner, action kind, or claimed agent.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Badge variant="info">{filteredItems.length}/{allItems.length} shown</Badge>
+          <Badge variant={openCount > 0 ? "warning" : "success"}>{openCount} open</Badge>
+          <Badge variant="neutral">{agentCount} agent</Badge>
+          {todoIndex ? <Badge variant="neutral">{todoIndex.rollout_event_count} events</Badge> : null}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="grid gap-2 lg:grid-cols-[minmax(0,1fr)_148px_148px]">
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-3 top-2.5 h-4 w-4 text-slate-400 dark:text-zinc-500" />
+            <input
+              aria-label="Search project todos"
+              className={cn(inputClassName, "pl-9")}
+              data-testid="project-todo-search-input"
+              onChange={(event) => onQueryChange(event.target.value)}
+              placeholder="todo_f2760d7e328f, benchmark, claimed_by, action_kind..."
+              value={query}
+            />
+          </div>
+          <Select
+            aria-label="Todo role"
+            onChange={(event) => onRoleChange(event.target.value as "all" | TodoExplorerRole)}
+            value={role}
+          >
+            <option value="all">All roles</option>
+            <option value="user">User todos</option>
+            <option value="agent">Agent todos</option>
+          </Select>
+          <Select
+            aria-label="Todo status"
+            onChange={(event) => onStatusChange(event.target.value as "all" | "open" | "done" | "blocked" | "deferred")}
+            value={status}
+          >
+            <option value="all">All status</option>
+            <option value="open">Open</option>
+            <option value="blocked">Blocked</option>
+            <option value="deferred">Deferred</option>
+            <option value="done">Done</option>
+          </Select>
+        </div>
+
+        {visibleItems.length === 0 ? (
+          <div className="rounded-lg border border-dashed border-slate-300 p-4 text-sm text-slate-500 dark:border-zinc-700 dark:text-zinc-400">
+            No projected todo matches {query ? <span className="font-mono">{query}</span> : "the current filters"}.
+          </div>
+        ) : (
+          <div className="divide-y divide-slate-200 overflow-hidden rounded-lg border border-slate-200 dark:divide-zinc-800 dark:border-zinc-800">
+            {visibleItems.map((item) => {
+              const todo = item.todo;
+              const statusLabel = todoDisplayStatus(todo);
+              const todoEventFields = todo as unknown as { latest_event_kind?: unknown };
+              const latestEventKind = typeof todoEventFields.latest_event_kind === "string"
+                ? todoEventFields.latest_event_kind
+                : "";
+              return (
+                <button
+                  className={cn(
+                    "w-full bg-white px-4 py-3 text-left transition hover:bg-slate-50 dark:bg-zinc-950 dark:hover:bg-zinc-900",
+                    item.goalId === selectedGoalId && "bg-slate-50 dark:bg-zinc-900",
+                  )}
+                  data-testid="project-todo-result"
+                  key={`${item.goalId}-${item.role}-${todo.todo_id ?? todo.index}-${item.sourceOrder}`}
+                  onClick={() => onSelectGoal(item.goalId)}
+                  type="button"
+                >
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Badge variant={item.role === "user" ? "warning" : "info"}>{todoRoleLabel(item.role)}</Badge>
+                    <Badge variant={todoExplorerStatusVariant(item)}>{statusLabel}</Badge>
+                    {todo.priority ? <Badge variant={todo.priority === "P0" ? "danger" : "neutral"}>{todo.priority}</Badge> : null}
+                    <span className="break-all text-xs font-medium text-slate-500 dark:text-zinc-400">{item.goalId}</span>
+                    {todo.todo_id ? (
+                      <span
+                        className="break-all rounded bg-slate-100 px-1.5 py-0.5 font-mono text-xs text-slate-700 dark:bg-zinc-900 dark:text-zinc-300"
+                        data-testid="project-todo-id"
+                      >
+                        {todo.todo_id}
+                      </span>
+                    ) : (
+                      <span className="text-xs text-slate-400 dark:text-zinc-500">#{todo.index}</span>
+                    )}
+                  </div>
+                  <p className="mt-2 line-clamp-2 text-sm leading-6 text-slate-800 dark:text-zinc-200">
+                    {todoDisplayTitle(todo)}
+                  </p>
+                  <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-slate-500 dark:text-zinc-400">
+                    <span>{item.sourceSection}</span>
+                    {item.source ? <span>source={item.source}</span> : null}
+                    {todo.action_kind ? <span>action={todo.action_kind}</span> : null}
+                    {todo.task_class ? <span>class={todo.task_class}</span> : null}
+                    {todo.claimed_by ? <span>claimed_by={todo.claimed_by}</span> : null}
+                    {latestEventKind ? <span>event={latestEventKind}</span> : null}
+                    {todo.updated_at ? <span>updated={todo.updated_at}</span> : null}
+                  </div>
+                  {todo.note ? (
+                    <p className="mt-2 line-clamp-2 text-xs leading-5 text-slate-500 dark:text-zinc-400">{todo.note}</p>
+                  ) : null}
+                </button>
+              );
+            })}
+          </div>
+        )}
+
+        {filteredItems.length > visibleItems.length ? (
+          <p className="text-xs text-slate-500 dark:text-zinc-400">
+            Showing first {visibleItems.length} matches. Narrow the search to inspect the rest.
+          </p>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
 }
 
 function TodoFocusColumn({
@@ -5667,6 +5972,42 @@ export function DashboardPage() {
 
               <section>
                 <TodoFocusPanel rows={goalRows} onSelectGoal={selectGoal} selectedGoalId={selectedReviewGoalId} />
+              </section>
+
+              <section>
+                <ProjectTodoExplorer
+                  onQueryChange={(todoQuery) =>
+                    navigate({
+                      search: (current) => ({
+                        ...current,
+                        todoQuery,
+                      }),
+                    })
+                  }
+                  onRoleChange={(todoRole) =>
+                    navigate({
+                      search: (current) => ({
+                        ...current,
+                        todoRole,
+                      }),
+                    })
+                  }
+                  onSelectGoal={selectGoal}
+                  onStatusChange={(todoStatus) =>
+                    navigate({
+                      search: (current) => ({
+                        ...current,
+                        todoStatus,
+                      }),
+                    })
+                  }
+                  query={search.todoQuery}
+                  role={search.todoRole}
+                  rows={goalRows}
+                  selectedGoalId={selectedGoalId}
+                  status={search.todoStatus}
+                  todoIndex={payload.todo_index}
+                />
               </section>
 
               <section>

--- a/apps/dashboard/src/views/dashboard-page.tsx
+++ b/apps/dashboard/src/views/dashboard-page.tsx
@@ -1262,7 +1262,14 @@ function todoExplorerHaystack(item: TodoExplorerItem) {
     .toLowerCase();
 }
 
+function todoExplorerProjectOptions(items: TodoExplorerItem[]) {
+  return Array.from(new Set(items.map((item) => item.goalId)))
+    .filter(Boolean)
+    .sort((left, right) => left.localeCompare(right));
+}
+
 function ProjectTodoExplorer({
+  onProjectChange,
   onQueryChange,
   onRoleChange,
   onSelectGoal,
@@ -1270,10 +1277,12 @@ function ProjectTodoExplorer({
   query,
   role,
   rows,
+  selectedTodoGoalId,
   selectedGoalId,
   status,
   todoIndex,
 }: {
+  onProjectChange: (goalId: string) => void;
   onQueryChange: (query: string) => void;
   onRoleChange: (role: "all" | TodoExplorerRole) => void;
   onSelectGoal: (goalId: string) => void;
@@ -1281,18 +1290,24 @@ function ProjectTodoExplorer({
   query: string;
   role: "all" | TodoExplorerRole;
   rows: GoalDirectoryRow[];
+  selectedTodoGoalId: string;
   selectedGoalId: string;
   status: "all" | "open" | "done" | "blocked" | "deferred";
   todoIndex?: TodoIndexSummary | null;
 }) {
   const allItems = useMemo(() => collectTodoExplorerItems(rows, todoIndex), [rows, todoIndex]);
+  const projectOptions = useMemo(() => todoExplorerProjectOptions(allItems), [allItems]);
+  const selectedProject = selectedTodoGoalId === "all" || projectOptions.includes(selectedTodoGoalId)
+    ? selectedTodoGoalId
+    : "all";
   const normalizedQuery = query.trim().toLowerCase();
   const filteredItems = allItems.filter((item) => {
+    const projectMatches = selectedProject === "all" || item.goalId === selectedProject;
     const roleMatches = role === "all" || item.role === role;
     const itemStatus = todoDisplayStatus(item.todo);
     const statusMatches = status === "all" || itemStatus === status;
     const queryMatches = !normalizedQuery || todoExplorerHaystack(item).includes(normalizedQuery);
-    return roleMatches && statusMatches && queryMatches;
+    return projectMatches && roleMatches && statusMatches && queryMatches;
   });
   const openCount = allItems.filter((item) => !item.todo.done).length;
   const agentCount = allItems.filter((item) => item.role === "agent").length;
@@ -1307,18 +1322,19 @@ function ProjectTodoExplorer({
             Project Todo Explorer
           </CardTitle>
           <p className="mt-2 text-sm text-slate-500 dark:text-zinc-400">
-            Search current projected todos by id, text, owner, action kind, or claimed agent.
+            Search current projected and indexed todos by project, id, text, owner, action kind, or claimed agent.
           </p>
         </div>
         <div className="flex flex-wrap gap-2">
           <Badge variant="info">{filteredItems.length}/{allItems.length} shown</Badge>
+          <Badge variant="neutral">{projectOptions.length} projects</Badge>
           <Badge variant={openCount > 0 ? "warning" : "success"}>{openCount} open</Badge>
           <Badge variant="neutral">{agentCount} agent</Badge>
           {todoIndex ? <Badge variant="neutral">{todoIndex.rollout_event_count} events</Badge> : null}
         </div>
       </CardHeader>
       <CardContent className="space-y-3">
-        <div className="grid gap-2 lg:grid-cols-[minmax(0,1fr)_148px_148px]">
+        <div className="grid gap-2 lg:grid-cols-[minmax(0,1fr)_minmax(180px,260px)_148px_148px]">
           <div className="relative">
             <Search className="pointer-events-none absolute left-3 top-2.5 h-4 w-4 text-slate-400 dark:text-zinc-500" />
             <input
@@ -1330,6 +1346,18 @@ function ProjectTodoExplorer({
               value={query}
             />
           </div>
+          <Select
+            aria-label="Todo project"
+            onChange={(event) => onProjectChange(event.target.value)}
+            value={selectedProject}
+          >
+            <option value="all">All projects</option>
+            {projectOptions.map((goalId) => (
+              <option key={goalId} value={goalId}>
+                {goalId}
+              </option>
+            ))}
+          </Select>
           <Select
             aria-label="Todo role"
             onChange={(event) => onRoleChange(event.target.value as "all" | TodoExplorerRole)}
@@ -5833,14 +5861,17 @@ export function DashboardPage() {
   }
 
   useEffect(() => {
-    if (search.statusUrl) {
-      void loadFromUrl(search.statusUrl);
+    const trimmedStatusUrl = search.statusUrl.trim();
+    if (trimmedStatusUrl) {
+      if (source.kind !== "url" || source.label !== trimmedStatusUrl) {
+        void loadFromUrl(trimmedStatusUrl);
+      }
       return;
     }
-    if (search.view !== "ops") {
+    if (search.view !== "ops" && source.kind === "example") {
       void loadFromUrl(defaultGlobalStatusUrl);
     }
-  }, []);
+  }, [search.statusUrl, search.view, source.kind, source.label]);
 
   useEffect(() => {
     if (search.statusUrl && source.kind === "example") {
@@ -5976,6 +6007,14 @@ export function DashboardPage() {
 
               <section>
                 <ProjectTodoExplorer
+                  onProjectChange={(todoGoalId) =>
+                    navigate({
+                      search: (current) => ({
+                        ...current,
+                        todoGoalId,
+                      }),
+                    })
+                  }
                   onQueryChange={(todoQuery) =>
                     navigate({
                       search: (current) => ({
@@ -6004,6 +6043,7 @@ export function DashboardPage() {
                   query={search.todoQuery}
                   role={search.todoRole}
                   rows={goalRows}
+                  selectedTodoGoalId={search.todoGoalId}
                   selectedGoalId={selectedGoalId}
                   status={search.todoStatus}
                   todoIndex={payload.todo_index}

--- a/examples/dashboard-home-browser-smoke.mjs
+++ b/examples/dashboard-home-browser-smoke.mjs
@@ -155,7 +155,16 @@ const goalSpecs = [
     agentTodos: { open: 3, done: 1, total: 4, next: "拆分 dependency blocker 和 current-goal blocker。" },
     agentTodoItems: [
       { done: false, text: "拆分依赖阻塞和当前目标阻塞，避免 meta 可执行回合空转。" },
-      { done: false, text: "增加自动 backlog 候选面，让 P1/P2 可持续推进。" },
+      {
+        done: false,
+        text: "增加自动 backlog 候选面，让 P1/P2 可持续推进。",
+        todo_id: "todo_dashboard_search_meta_backlog",
+        priority: "P1",
+        status: "open",
+        task_class: "advancement_task",
+        action_kind: "dashboard_todo_search_fixture",
+        claimed_by: "codex-side-bypass",
+      },
       { done: false, text: "统一多项目看板的 serve-status --global-registry 命令说明。" },
       { done: true, text: "已硬化 heartbeat prompt，依赖项目 todo 不再吃掉当前 goal turn。" },
     ],
@@ -215,6 +224,12 @@ function todoGroupFor(spec, role) {
       index: index + 1,
       done: item.done,
       text: item.text,
+      todo_id: item.todo_id,
+      priority: item.priority,
+      status: item.status,
+      task_class: item.task_class,
+      action_kind: item.action_kind,
+      claimed_by: item.claimed_by,
       review_materials: [],
     })),
   };
@@ -370,6 +385,34 @@ const statusFixture = {
       progress_signal_run_count_7d: 1,
       project_share_24h: 0.25,
     })),
+  },
+  todo_index: {
+    schema_version: "todo_index_v0",
+    source: "attention_queue_and_rollout_event_log",
+    total_count: 1,
+    current_projected_count: 0,
+    rollout_event_count: 2,
+    item_limit: 240,
+    items: [
+      {
+        schema_version: "todo_index_item_v0",
+        goal_id: "loopx-meta",
+        index: 0,
+        done: false,
+        text: "todo update recorded for todo_f2760d7e328f",
+        title: "todo update recorded for todo_f2760d7e328f",
+        todo_id: "todo_f2760d7e328f",
+        role: "agent",
+        status: "open",
+        source: "rollout_event_log",
+        event_count: 2,
+        event_kinds: ["todo_add", "todo_update"],
+        latest_event_kind: "todo_update",
+        latest_event_at: "2026-06-22T12:28:47Z",
+        latest_event_status: "open",
+        agent_id: "codex-main-control",
+      },
+    ],
   },
   decision_freshness_summary: {
     available: true,
@@ -661,6 +704,39 @@ async function main() {
     }
 
     await page.goto(`${baseUrl}/?view=ops&goalId=loopx-meta&statusUrl=/${fixtureName}`, { waitUntil: "networkidle" });
+    await page.waitForSelector('[data-testid="project-todo-explorer"]', { timeout: 10_000 });
+    const todoExplorer = page.locator('[data-testid="project-todo-explorer"]');
+    const initialTodoExplorerText = await todoExplorer.innerText();
+    const requiredTodoExplorerText = [
+      "Project Todo Explorer",
+      "todo_dashboard_search_meta_backlog",
+      "dashboard_todo_search_fixture",
+      "claimed_by=codex-side-bypass",
+    ];
+    const missingTodoExplorerText = requiredTodoExplorerText.filter((text) => !initialTodoExplorerText.includes(text));
+    if (missingTodoExplorerText.length) {
+      throw new Error(`Missing project todo explorer text: ${missingTodoExplorerText.join(", ")}`);
+    }
+    await page.locator('[data-testid="project-todo-search-input"]').fill("todo_dashboard_search_meta_backlog");
+    const filteredTodoExplorerText = await todoExplorer.innerText();
+    if (!filteredTodoExplorerText.includes("1/")) {
+      throw new Error(`Project todo explorer did not narrow search results: ${filteredTodoExplorerText}`);
+    }
+    if (!filteredTodoExplorerText.includes("增加自动 backlog 候选面")) {
+      throw new Error("Project todo explorer search lost the matching todo body.");
+    }
+    await page.locator('[data-testid="project-todo-search-input"]').fill("todo_f2760d7e328f");
+    const historicalTodoExplorerText = await todoExplorer.innerText();
+    const requiredHistoricalTodoText = [
+      "todo_f2760d7e328f",
+      "source=rollout_event_log",
+      "event=todo_update",
+      "todo update recorded for todo_f2760d7e328f",
+    ];
+    const missingHistoricalTodoText = requiredHistoricalTodoText.filter((text) => !historicalTodoExplorerText.includes(text));
+    if (missingHistoricalTodoText.length) {
+      throw new Error(`Project todo explorer did not expose historical todo index text: ${missingHistoricalTodoText.join(", ")}`);
+    }
     await page.waitForSelector('[data-testid="control-plane-settings-panel"]', { timeout: 10_000 });
     const settingsText = await page.locator('[data-testid="control-plane-settings-panel"]').innerText();
     const requiredSettings = [

--- a/examples/dashboard-home-browser-smoke.mjs
+++ b/examples/dashboard-home-browser-smoke.mjs
@@ -709,6 +709,7 @@ async function main() {
     const initialTodoExplorerText = await todoExplorer.innerText();
     const requiredTodoExplorerText = [
       "Project Todo Explorer",
+      "All projects",
       "todo_dashboard_search_meta_backlog",
       "dashboard_todo_search_fixture",
       "claimed_by=codex-side-bypass",
@@ -725,6 +726,12 @@ async function main() {
     if (!filteredTodoExplorerText.includes("增加自动 backlog 候选面")) {
       throw new Error("Project todo explorer search lost the matching todo body.");
     }
+    await page.getByLabel("Todo project").selectOption("showcase-creator-operator");
+    const projectFilteredTodoExplorerText = await todoExplorer.innerText();
+    if (!projectFilteredTodoExplorerText.includes("No projected todo matches todo_dashboard_search_meta_backlog")) {
+      throw new Error("Project todo explorer did not apply the selected project filter.");
+    }
+    await page.getByLabel("Todo project").selectOption("all");
     await page.locator('[data-testid="project-todo-search-input"]').fill("todo_f2760d7e328f");
     const historicalTodoExplorerText = await todoExplorer.innerText();
     const requiredHistoricalTodoText = [

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -39,6 +39,7 @@ from .paths import global_registry_path, resolve_runtime_root
 from .promotion_gate import build_promotion_gate
 from .quota import quota_status, quota_with_handoff_outcome_floor
 from .registry import registry_goals
+from .rollout_event_log import load_rollout_events, rollout_event_log_path
 from .state_projection import (
     active_state_next_action_entries,
     next_action_projection_warning,
@@ -173,6 +174,8 @@ STATUS_CONTRACT_SCHEMA_VERSION = 2
 MINIMUM_DASHBOARD_STATUS_CONTRACT_SCHEMA_VERSION = 2
 STATUS_CONTRACT_RELOAD_HINT = "scripts/macos-dashboard-launchagent.sh restart"
 PROJECT_ASSET_TODO_PROJECTION_GAP_SCHEMA_VERSION = "project_asset_todo_projection_gap_v0"
+TODO_INDEX_SCHEMA_VERSION = "todo_index_v0"
+TODO_INDEX_ITEM_SCHEMA_VERSION = "todo_index_item_v0"
 DECISION_FRESHNESS_WINDOW_DAYS = 7
 DECISION_FRESHNESS_ITEM_LIMIT = 12
 DECISION_FRESHNESS_PROXY_NOTE = (
@@ -355,6 +358,8 @@ MAX_ACTIVE_DONE_TODOS_BEFORE_ARCHIVE = MAX_STATUS_TODOS_PER_ROLE
 MAX_PROJECT_ASSET_TODO_ITEMS = 3
 MAX_PROJECT_ASSET_TODO_BACKLOG_ITEMS = 8
 MAX_TODO_VISIBILITY_LANE_ITEMS = 16
+MAX_TODO_INDEX_ITEMS = 240
+MAX_TODO_INDEX_ROLLOUT_EVENTS_PER_GOAL = 500
 TODO_PROJECTION_VIEW_SCHEMA_VERSION = "todo_projection_view_v0"
 TODO_PROJECTION_DETAIL_POINTER_SCHEMA_VERSION = "todo_projection_detail_pointer_v0"
 MAX_DEPENDENCY_BLOCKERS = 4
@@ -7568,6 +7573,173 @@ def build_usage_summary(history: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _todo_index_key(goal_id: str, todo: dict[str, Any]) -> tuple[str, str]:
+    todo_id = normalize_todo_id(todo.get("todo_id")) or ""
+    if todo_id:
+        return goal_id, todo_id
+    return goal_id, f"synthetic:{todo.get('role') or ''}:{todo.get('index') or ''}:{todo.get('text') or ''}"
+
+
+def _indexed_status_todo(
+    *,
+    goal_id: str,
+    role: str,
+    todo: dict[str, Any],
+    source: str,
+) -> dict[str, Any] | None:
+    text = public_safe_compact_text(todo.get("title") or todo.get("text"), limit=320)
+    if not text:
+        return None
+    item = compact_todo_item(todo)
+    item.update(
+        {
+            "schema_version": TODO_INDEX_ITEM_SCHEMA_VERSION,
+            "goal_id": goal_id,
+            "role": role,
+            "source": source,
+            "text": text,
+            "title": public_safe_compact_text(todo.get("title"), limit=320) or text,
+        }
+    )
+    return item
+
+
+def _rollout_event_todo_status(event: dict[str, Any]) -> str:
+    status = normalize_todo_status(event.get("status"))
+    if status:
+        return status
+    kind = str(event.get("event_kind") or "")
+    if kind in {"todo_complete", "todo_archive_completed"}:
+        return "done"
+    if kind == "todo_supersede":
+        return "deferred"
+    return "open"
+
+
+def _indexed_rollout_todo_event(event: dict[str, Any]) -> dict[str, Any] | None:
+    todo_id = normalize_todo_id(event.get("todo_id"))
+    goal_id = str(event.get("goal_id") or "").strip()
+    if not goal_id or not todo_id:
+        return None
+    details = event.get("details") if isinstance(event.get("details"), dict) else {}
+    role = str(details.get("role") or "agent").strip().lower()
+    if role not in {"user", "agent"}:
+        role = "agent"
+    status = _rollout_event_todo_status(event)
+    summary = public_safe_compact_text(
+        event.get("summary") or f"{event.get('event_kind') or 'todo_event'} recorded for {todo_id}",
+        limit=320,
+    )
+    if not summary:
+        summary = f"todo event recorded for {todo_id}"
+    return {
+        "schema_version": TODO_INDEX_ITEM_SCHEMA_VERSION,
+        "goal_id": goal_id,
+        "todo_id": todo_id,
+        "role": role,
+        "status": status,
+        "done": todo_done_for_status(status),
+        "index": 0,
+        "text": summary,
+        "title": summary,
+        "source": "rollout_event_log",
+        "event_count": 1,
+        "event_kinds": [str(event.get("event_kind") or "todo_event")],
+        "latest_event_kind": str(event.get("event_kind") or "todo_event"),
+        "latest_event_at": public_safe_compact_text(event.get("recorded_at"), limit=80),
+        "latest_event_status": public_safe_compact_text(event.get("status"), limit=80),
+        "agent_id": public_safe_compact_text(event.get("agent_id"), limit=120),
+    }
+
+
+def build_todo_index(
+    *,
+    queue: dict[str, Any],
+    history: dict[str, Any],
+    runtime_root: Path,
+    limit: int = MAX_TODO_INDEX_ITEMS,
+) -> dict[str, Any]:
+    indexed: dict[tuple[str, str], dict[str, Any]] = {}
+    current_count = 0
+    for item in queue.get("items") or []:
+        if not isinstance(item, dict):
+            continue
+        goal_id = str(item.get("goal_id") or "")
+        if not goal_id:
+            continue
+        for role in ("user", "agent"):
+            todos = item.get(f"{role}_todos")
+            if not isinstance(todos, dict):
+                continue
+            for todo in todos.get("items") or []:
+                if not isinstance(todo, dict):
+                    continue
+                indexed_item = _indexed_status_todo(
+                    goal_id=goal_id,
+                    role=role,
+                    todo=todo,
+                    source="attention_queue",
+                )
+                if indexed_item is None:
+                    continue
+                indexed[_todo_index_key(goal_id, indexed_item)] = indexed_item
+                current_count += 1
+
+    rollout_event_count = 0
+    goal_ids = [
+        str(goal.get("id") or "")
+        for goal in history.get("goals") or []
+        if isinstance(goal, dict) and str(goal.get("id") or "")
+    ]
+    for goal_id in sorted(set(goal_ids)):
+        events = load_rollout_events(
+            rollout_event_log_path(runtime_root, goal_id),
+            limit=MAX_TODO_INDEX_ROLLOUT_EVENTS_PER_GOAL,
+        )
+        for event in events:
+            if not isinstance(event, dict) or not str(event.get("event_kind") or "").startswith("todo_"):
+                continue
+            rollout_event_count += 1
+            event_item = _indexed_rollout_todo_event(event)
+            if event_item is None:
+                continue
+            key = _todo_index_key(goal_id, event_item)
+            existing = indexed.get(key)
+            if existing:
+                existing["event_count"] = int(existing.get("event_count") or 0) + 1
+                kinds = list(existing.get("event_kinds") or [])
+                latest_kind = event_item.get("latest_event_kind")
+                if latest_kind and latest_kind not in kinds:
+                    kinds.append(latest_kind)
+                existing["event_kinds"] = kinds
+                existing["latest_event_kind"] = latest_kind
+                existing["latest_event_at"] = event_item.get("latest_event_at")
+                existing["latest_event_status"] = event_item.get("latest_event_status")
+                if event_item.get("agent_id"):
+                    existing["agent_id"] = event_item.get("agent_id")
+                continue
+            indexed[key] = event_item
+
+    items = sorted(
+        indexed.values(),
+        key=lambda item: (
+            0 if not item.get("done") else 1,
+            str(item.get("goal_id") or ""),
+            str(item.get("todo_id") or ""),
+            str(item.get("latest_event_at") or ""),
+        ),
+    )
+    return {
+        "schema_version": TODO_INDEX_SCHEMA_VERSION,
+        "source": "attention_queue_and_rollout_event_log",
+        "total_count": len(items),
+        "current_projected_count": current_count,
+        "rollout_event_count": rollout_event_count,
+        "item_limit": limit,
+        "items": items[: max(0, limit)],
+    }
+
+
 def collect_status(
     *,
     registry_path: Path,
@@ -7611,6 +7783,12 @@ def collect_status(
     )
     decision_freshness_summary = build_decision_freshness_summary(history)
     usage_summary = build_usage_summary(history)
+    todo_index = build_todo_index(
+        queue=queue,
+        history=history,
+        runtime_root=runtime_root,
+        limit=max(MAX_TODO_INDEX_ITEMS, display_limit),
+    )
     return {
         "ok": bool(contract.get("ok")) and bool(global_registry.get("ok", True)),
         "registry": str(registry_path),
@@ -7633,6 +7811,7 @@ def collect_status(
         "promotion_gate": promotion_gate,
         "decision_freshness_summary": decision_freshness_summary,
         "usage_summary": usage_summary,
+        "todo_index": todo_index,
     }
 
 


### PR DESCRIPTION
## Summary
- add a read-only status todo_index that merges current projected todos with rollout-history todo events
- add a Dashboard Project Todo Explorer with todo id/text/owner/action/status search and filters
- cover current and historical todo lookup in static and browser smokes, including todo_f2760d7e328f

## Validation
- npm run build
- npm run smoke:home-route
- npm run smoke:home-browser
- python3 -m compileall -q loopx/status.py
- git diff --check -- apps/dashboard/smoke/home-route-smoke.ts apps/dashboard/src/data/status.ts apps/dashboard/src/router.tsx apps/dashboard/src/views/dashboard-page.tsx examples/dashboard-home-browser-smoke.mjs loopx/status.py

## Excluded
- main worktree docs edits were intentionally excluded from this PR
- local node_modules from the validation worktree is untracked/ignored
