### PR TITLE
fix: sync todo index status from rollout events

### DIFF
--- a/examples/todo-index-rollout-status-smoke.py
+++ b/examples/todo-index-rollout-status-smoke.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from loopx.status import build_todo_index
+
+
+def write_event(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, sort_keys=True) + "\n")
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory() as raw_tmp:
+        runtime_root = Path(raw_tmp)
+        event_log = runtime_root / "goals" / "loopx-meta" / "rollout-event-log.jsonl"
+        write_event(
+            event_log,
+            {
+                "schema_version": "loopx_rollout_event_v0",
+                "event_kind": "todo_add",
+                "goal_id": "loopx-meta",
+                "todo_id": "todo_done_status",
+                "status": "open",
+                "recorded_at": "2026-06-22T16:00:00Z",
+                "details": {"role": "agent"},
+            },
+        )
+        write_event(
+            event_log,
+            {
+                "schema_version": "loopx_rollout_event_v0",
+                "event_kind": "todo_complete",
+                "goal_id": "loopx-meta",
+                "todo_id": "todo_done_status",
+                "recorded_at": "2026-06-22T16:05:00Z",
+                "details": {"role": "agent"},
+            },
+        )
+
+        index = build_todo_index(
+            queue={"items": []},
+            history={"goals": [{"id": "loopx-meta"}]},
+            runtime_root=runtime_root,
+        )
+
+    items = index["items"]
+    assert len(items) == 1, items
+    item = items[0]
+    assert item["todo_id"] == "todo_done_status", item
+    assert item["latest_event_kind"] == "todo_complete", item
+    assert item["latest_event_status"] == "done", item
+    assert item["status"] == "done", item
+    assert item["done"] is True, item
+    print("todo-index-rollout-status smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -7647,7 +7647,7 @@ def _indexed_rollout_todo_event(event: dict[str, Any]) -> dict[str, Any] | None:
         "event_kinds": [str(event.get("event_kind") or "todo_event")],
         "latest_event_kind": str(event.get("event_kind") or "todo_event"),
         "latest_event_at": public_safe_compact_text(event.get("recorded_at"), limit=80),
-        "latest_event_status": public_safe_compact_text(event.get("status"), limit=80),
+        "latest_event_status": status,
         "agent_id": public_safe_compact_text(event.get("agent_id"), limit=120),
     }
 
@@ -7715,6 +7715,9 @@ def build_todo_index(
                 existing["latest_event_kind"] = latest_kind
                 existing["latest_event_at"] = event_item.get("latest_event_at")
                 existing["latest_event_status"] = event_item.get("latest_event_status")
+                if event_item.get("status"):
+                    existing["status"] = event_item.get("status")
+                    existing["done"] = bool(event_item.get("done"))
                 if event_item.get("agent_id"):
                     existing["agent_id"] = event_item.get("agent_id")
                 continue


### PR DESCRIPTION
## Summary
- Fix todo_index rollout-event aggregation so the top-level status/done fields follow the latest todo event.
- Use the computed event status as latest_event_status, including todo_complete events without an explicit status field.
- Add a focused smoke for todo_add -> todo_complete history projection.

## Validation
- python3 examples/todo-index-rollout-status-smoke.py
- python3 -m compileall -q loopx/status.py examples/todo-index-rollout-status-smoke.py
- git diff --check -- loopx/status.py examples/todo-index-rollout-status-smoke.py
- loopx check --scan-path loopx/status.py --scan-path examples/todo-index-rollout-status-smoke.py
- ./scripts/loopx --format json --registry ~/.codex/loopx/registry.global.json --runtime-root ~/.codex/loopx status verified todo_2c5369dc46ee projects as status=done after latest todo_complete

## Boundary
Read-only status projection repair. No todo write behavior, quota behavior, benchmark runner behavior, raw logs, credentials, local state, or private evidence.