### PR TITLE
Extract ML experiment CLI command module

### DIFF
--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -166,11 +166,13 @@ from .cli_commands import (
     handle_demo_command,
     handle_doctor_command,
     handle_dreaming_command,
+    handle_ml_experiment_command,
     handle_new_project_prompt_command,
     handle_review_packet_command,
     handle_status_command,
     register_doctor_command,
     register_dreaming_commands,
+    register_ml_experiment_commands,
     register_starter_commands,
     register_status_commands,
 )
@@ -198,12 +200,6 @@ from .history import (
     render_history_markdown,
     render_index_duplicate_inspection_markdown,
     render_index_duplicate_repair_markdown,
-)
-from .ml_experiment import (
-    GUARDRAIL_STATUSES,
-    HYPOTHESIS_STATUSES,
-    build_ml_experiment_advisory_packet,
-    render_ml_experiment_advisory_markdown,
 )
 from .operator_gate import (
     DEFAULT_OPERATOR_GATE,
@@ -2988,69 +2984,7 @@ def main(argv: list[str] | None = None) -> int:
         help="Timeout for --execute installer and post-update doctor commands.",
     )
 
-    ml_experiment_parser = sub.add_parser(
-        "ml-experiment",
-        help="Render default-off ML experiment advisory packets.",
-    )
-    ml_experiment_sub = ml_experiment_parser.add_subparsers(dest="ml_experiment_command", required=True)
-    ml_experiment_preview_parser = ml_experiment_sub.add_parser(
-        "preview",
-        help="Preview a public-safe ML experiment result, hypothesis ledger, and replan packet.",
-    )
-    add_subcommand_format(ml_experiment_preview_parser)
-    ml_experiment_preview_parser.add_argument("--experiment-id", required=True, help="Public experiment id.")
-    ml_experiment_preview_parser.add_argument("--primary-metric", required=True, help="Primary metric label.")
-    ml_experiment_preview_parser.add_argument("--baseline-value", type=float, required=True)
-    ml_experiment_preview_parser.add_argument("--candidate-value", type=float, required=True)
-    metric_direction = ml_experiment_preview_parser.add_mutually_exclusive_group()
-    metric_direction.add_argument(
-        "--higher-is-better",
-        dest="higher_is_better",
-        action="store_true",
-        default=True,
-        help="Classify positive metric deltas as improvements. This is the default.",
-    )
-    metric_direction.add_argument(
-        "--lower-is-better",
-        dest="higher_is_better",
-        action="store_false",
-        help="Classify negative metric deltas as improvements.",
-    )
-    ml_experiment_preview_parser.add_argument(
-        "--guardrail-status",
-        choices=GUARDRAIL_STATUSES,
-        default="unknown",
-        help="Compact guardrail classification.",
-    )
-    ml_experiment_preview_parser.add_argument("--train-window", required=True)
-    ml_experiment_preview_parser.add_argument("--eval-window", required=True)
-    ml_experiment_preview_parser.add_argument("--granularity", default="daily")
-    ml_experiment_preview_parser.add_argument("--hypothesis-id", required=True)
-    ml_experiment_preview_parser.add_argument("--mechanism-family", required=True)
-    ml_experiment_preview_parser.add_argument("--route", required=True)
-    ml_experiment_preview_parser.add_argument(
-        "--hypothesis-status",
-        choices=HYPOTHESIS_STATUSES,
-        default="active",
-    )
-    ml_experiment_preview_parser.add_argument(
-        "--positive-evidence",
-        action="append",
-        default=[],
-        help="Compact public-safe evidence label. Repeatable.",
-    )
-    ml_experiment_preview_parser.add_argument(
-        "--negative-evidence",
-        action="append",
-        default=[],
-        help="Compact public-safe evidence label. Repeatable.",
-    )
-    ml_experiment_preview_parser.add_argument(
-        "--next-candidate",
-        action="append",
-        default=[],
-        help="Compact public-safe follow-up candidate label. Repeatable.",
-    )
+    register_ml_experiment_commands(sub, add_subcommand_format)
 
     sub.add_parser("registry", help="Inspect registry goals and adapter declarations.")
     registry_boundary_parser = sub.add_parser(
@@ -6893,35 +6827,7 @@ def main(argv: list[str] | None = None) -> int:
         return 0 if payload.get("ok") else 1
 
     if args.command == "ml-experiment":
-        try:
-            if args.ml_experiment_command != "preview":
-                raise ValueError("ml-experiment requires the `preview` subcommand")
-            payload = build_ml_experiment_advisory_packet(
-                experiment_id=args.experiment_id,
-                primary_metric=args.primary_metric,
-                baseline_value=args.baseline_value,
-                candidate_value=args.candidate_value,
-                higher_is_better=bool(args.higher_is_better),
-                guardrail_status=args.guardrail_status,
-                train_window=args.train_window,
-                eval_window=args.eval_window,
-                granularity=args.granularity,
-                hypothesis_id=args.hypothesis_id,
-                mechanism_family=args.mechanism_family,
-                route=args.route,
-                hypothesis_status=args.hypothesis_status,
-                positive_evidence=args.positive_evidence,
-                negative_evidence=args.negative_evidence,
-                next_candidates=args.next_candidate,
-            )
-        except Exception as exc:
-            payload = {
-                "ok": False,
-                "mode": "ml-experiment",
-                "error": str(exc),
-            }
-        print_payload(payload, output_format(args), render_ml_experiment_advisory_markdown)
-        return 0 if payload.get("ok") else 1
+        return handle_ml_experiment_command(args, output_format=output_format, print_payload=print_payload)
 
     if args.command == "registry":
         payload = inspect_registry(registry_path)

--- a/loopx/cli_commands/__init__.py
+++ b/loopx/cli_commands/__init__.py
@@ -10,6 +10,7 @@ The top-level CLI keeps global options, registry fallback, and dispatch order.
 
 from .doctor import handle_doctor_command, register_doctor_command
 from .dreaming import handle_dreaming_command, register_dreaming_commands
+from .ml_experiment import handle_ml_experiment_command, register_ml_experiment_commands
 from .starter import (
     handle_codex_cli_bounded_visible_pilot_adapter_command,
     handle_codex_cli_bootstrap_message_command,
@@ -61,11 +62,13 @@ __all__ = [
     "handle_demo_command",
     "handle_doctor_command",
     "handle_dreaming_command",
+    "handle_ml_experiment_command",
     "handle_new_project_prompt_command",
     "handle_review_packet_command",
     "handle_status_command",
     "register_doctor_command",
     "register_dreaming_commands",
+    "register_ml_experiment_commands",
     "register_starter_commands",
     "register_status_commands",
 ]

--- a/loopx/cli_commands/ml_experiment.py
+++ b/loopx/cli_commands/ml_experiment.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+
+from ..ml_experiment import (
+    GUARDRAIL_STATUSES,
+    HYPOTHESIS_STATUSES,
+    build_ml_experiment_advisory_packet,
+    render_ml_experiment_advisory_markdown,
+)
+
+
+PrintPayload = Callable[
+    [dict[str, object], str, Callable[[dict[str, object]], str]],
+    None,
+]
+FormatSelector = Callable[..., str]
+AddFormat = Callable[[argparse.ArgumentParser], None]
+
+
+def register_ml_experiment_commands(
+    subparsers: argparse._SubParsersAction,
+    add_subcommand_format: AddFormat,
+) -> None:
+    ml_experiment_parser = subparsers.add_parser(
+        "ml-experiment",
+        help="Render default-off ML experiment advisory packets.",
+    )
+    ml_experiment_sub = ml_experiment_parser.add_subparsers(dest="ml_experiment_command", required=True)
+    preview_parser = ml_experiment_sub.add_parser(
+        "preview",
+        help="Preview a public-safe ML experiment result, hypothesis ledger, and replan packet.",
+    )
+    add_subcommand_format(preview_parser)
+    preview_parser.add_argument("--experiment-id", required=True, help="Public experiment id.")
+    preview_parser.add_argument("--primary-metric", required=True, help="Primary metric label.")
+    preview_parser.add_argument("--baseline-value", type=float, required=True)
+    preview_parser.add_argument("--candidate-value", type=float, required=True)
+    metric_direction = preview_parser.add_mutually_exclusive_group()
+    metric_direction.add_argument(
+        "--higher-is-better",
+        dest="higher_is_better",
+        action="store_true",
+        default=True,
+        help="Classify positive metric deltas as improvements. This is the default.",
+    )
+    metric_direction.add_argument(
+        "--lower-is-better",
+        dest="higher_is_better",
+        action="store_false",
+        help="Classify negative metric deltas as improvements.",
+    )
+    preview_parser.add_argument(
+        "--guardrail-status",
+        choices=GUARDRAIL_STATUSES,
+        default="unknown",
+        help="Compact guardrail classification.",
+    )
+    preview_parser.add_argument("--train-window", required=True)
+    preview_parser.add_argument("--eval-window", required=True)
+    preview_parser.add_argument("--granularity", default="daily")
+    preview_parser.add_argument("--hypothesis-id", required=True)
+    preview_parser.add_argument("--mechanism-family", required=True)
+    preview_parser.add_argument("--route", required=True)
+    preview_parser.add_argument(
+        "--hypothesis-status",
+        choices=HYPOTHESIS_STATUSES,
+        default="active",
+    )
+    preview_parser.add_argument(
+        "--positive-evidence",
+        action="append",
+        default=[],
+        help="Compact public-safe evidence label. Repeatable.",
+    )
+    preview_parser.add_argument(
+        "--negative-evidence",
+        action="append",
+        default=[],
+        help="Compact public-safe evidence label. Repeatable.",
+    )
+    preview_parser.add_argument(
+        "--next-candidate",
+        action="append",
+        default=[],
+        help="Compact public-safe follow-up candidate label. Repeatable.",
+    )
+
+
+def handle_ml_experiment_command(
+    args: argparse.Namespace,
+    *,
+    output_format: FormatSelector,
+    print_payload: PrintPayload,
+) -> int:
+    try:
+        if args.ml_experiment_command != "preview":
+            raise ValueError("ml-experiment requires the `preview` subcommand")
+        payload = build_ml_experiment_advisory_packet(
+            experiment_id=args.experiment_id,
+            primary_metric=args.primary_metric,
+            baseline_value=args.baseline_value,
+            candidate_value=args.candidate_value,
+            higher_is_better=bool(args.higher_is_better),
+            guardrail_status=args.guardrail_status,
+            train_window=args.train_window,
+            eval_window=args.eval_window,
+            granularity=args.granularity,
+            hypothesis_id=args.hypothesis_id,
+            mechanism_family=args.mechanism_family,
+            route=args.route,
+            hypothesis_status=args.hypothesis_status,
+            positive_evidence=args.positive_evidence,
+            negative_evidence=args.negative_evidence,
+            next_candidates=args.next_candidate,
+        )
+    except Exception as exc:
+        payload = {
+            "ok": False,
+            "mode": "ml-experiment",
+            "error": str(exc),
+        }
+    print_payload(payload, output_format(args), render_ml_experiment_advisory_markdown)
+    return 0 if payload.get("ok") else 1

--- a/regression/cli-command-module-contract.py
+++ b/regression/cli-command-module-contract.py
@@ -43,10 +43,12 @@ def main() -> int:
         handle_demo_command,
         handle_check_command,
         handle_doctor_command,
+        handle_ml_experiment_command,
         handle_new_project_prompt_command,
         handle_review_packet_command,
         handle_status_command,
         register_doctor_command,
+        register_ml_experiment_commands,
         register_starter_commands,
         register_status_commands,
     )
@@ -54,9 +56,11 @@ def main() -> int:
     assert callable(handle_demo_command)
     assert callable(handle_check_command)
     assert callable(register_doctor_command)
+    assert callable(register_ml_experiment_commands)
     assert callable(register_starter_commands)
     assert callable(register_status_commands)
     assert callable(handle_doctor_command)
+    assert callable(handle_ml_experiment_command)
     assert callable(handle_new_project_prompt_command)
     assert callable(handle_review_packet_command)
     assert callable(handle_status_command)
@@ -104,6 +108,37 @@ def main() -> int:
     review = run_cli("review-packet", "--goal-id", "loopx-meta", "--limit", "1")
     assert review.get("ok") is True, review
     assert review.get("goal_id") == "loopx-meta", review
+
+    ml_preview = run_cli(
+        "ml-experiment",
+        "preview",
+        "--experiment-id",
+        "command-module-exp",
+        "--primary-metric",
+        "offline_auc",
+        "--baseline-value",
+        "0.42",
+        "--candidate-value",
+        "0.43",
+        "--train-window",
+        "train_2026w24",
+        "--eval-window",
+        "eval_2026w25",
+        "--hypothesis-id",
+        "h_command_module",
+        "--mechanism-family",
+        "routing",
+        "--route",
+        "route_a",
+        "--positive-evidence",
+        "compact_eval_delta",
+        "--next-candidate",
+        "holdout_eval",
+    )
+    assert ml_preview.get("ok") is True, ml_preview
+    assert ml_preview.get("mode") == "default_off_advisory_preview", ml_preview
+    assert ml_preview.get("result", {}).get("experiment_id") == "command-module-exp", ml_preview
+    assert ml_preview.get("pack", {}).get("pack") == "ml_experiment", ml_preview
 
     print("cli-command-module-contract-regression ok")
     return 0


### PR DESCRIPTION
## Summary
- Move `ml-experiment preview` argparse wiring and dispatch into `loopx/cli_commands/ml_experiment.py`.
- Export the new command module through the existing CLI command-module contract.
- Extend the modular CLI regression to cover the ML experiment preview invocation.

## Validation
- `git diff --check origin/main...HEAD`
- `python3 -m py_compile loopx/cli.py loopx/cli_commands/*.py`
- `python3 regression/cli-command-module-contract.py`
- `python3 regression/run-regressions.py`
- `loopx --format json check --scan-path loopx/cli.py --scan-path loopx/cli_commands --scan-path regression/cli-command-module-contract.py` (passed with the existing duplicate-index warning only)

This is a narrow no-behavior-change CLI cleanup slice; `loopx/cli.py` drops from 11291 to 11197 lines while preserving the public invocation.