### PR TITLE
Add content ops surface contract

### DIFF
--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -96,5 +96,9 @@ runtime contract, benchmark route, or launch draft.
   bottom-layer LoopX capability increments needed by repo issue-fix loops,
   creator/self-media operations, and other repository scenario signals before
   domain-specific adapters are built.
+- [content_ops_surface_v0](../reference/protocols/content-ops-surface-v0.md):
+  compact creator/self-media operations state surface with source items,
+  angle candidates, draft items, feedback signals, publish gates, material
+  memory, and a public-safe projection/smoke contract.
 - [Naming decision packet](naming-decision-packet.md): historical naming
   context before the LoopX rename.

--- a/docs/product/scenario-capability-gap-map.md
+++ b/docs/product/scenario-capability-gap-map.md
@@ -193,6 +193,13 @@ boundaries visible.
 | `publish_gate_v0` | Human approval record for external posting; no autopublish from draft existence. |
 | `material_memory_v0` | Durable source-safe library entry with attribution, rejected angles, and reuse boundary. |
 
+The first public-safe implementation is now anchored by
+`loopx/content_ops_surface.py`, `docs/reference/protocols/content-ops-surface-v0.md`,
+and `examples/content-ops-surface-fixture-smoke.py`. This keeps the MVP as a
+state-surface contract: source/draft/feedback/gate facts can promote into
+normal LoopX todos, but the projection itself is read-only and has no publish
+authority.
+
 The state flow should stay deliberately boring:
 
 ```text
@@ -226,6 +233,8 @@ P0 content-ops acceptance:
   available";
 - no connector, browser, or chat adapter writes raw private material into
   public LoopX state.
+- the public fixture and projection smoke pass before a connector or frontend
+  treats the surface as stable.
 
 ### Creator-Ops Gaps
 
@@ -318,8 +327,9 @@ P0: make issue-fix loops product-native.
 
 P0: make creator-ops feedback durable.
 
-5. Define `content_ops_surface_v0` over source items, angle candidates, drafts,
-   feedback signals, publish gates, and material memory.
+5. Defined `content_ops_surface_v0` over source items, angle candidates,
+   drafts, feedback signals, publish gates, and material memory, with a
+   public-safe fixture/projection helper and smoke.
 6. Promote `source_status_v0` and `feedback_writeback_v0` into reusable
    product contracts.
 7. Keep no-autopublish gates visible in status and frontend demo data.

--- a/docs/reference/protocols/README.md
+++ b/docs/reference/protocols/README.md
@@ -13,3 +13,4 @@ Current contracts:
 - [Codex CLI wrapper action packet v0](protocol-action-packet-codex-cli-wrapper-v0.md)
 - [Action packet router comparison v0](protocol-action-packet-router-comparison-v0.md)
 - [task_graph_projection_v0](task-graph-projection-v0.md)
+- [content_ops_surface_v0](content-ops-surface-v0.md)

--- a/docs/reference/protocols/content-ops-surface-v0.md
+++ b/docs/reference/protocols/content-ops-surface-v0.md
@@ -1,0 +1,104 @@
+# content_ops_surface_v0
+
+Status: public-safe state-surface contract v0.
+
+`content_ops_surface_v0` is a compact creator/self-media operations state
+surface. It lets LoopX remember source status, angle selection, draft state,
+feedback effects, publish gates, and reusable material memory without turning
+LoopX into a publisher or storing raw platform/chat material.
+
+The surface is intentionally a meta layer over the generic LoopX model:
+
+- source records may promote into normal LoopX agent or user todos;
+- feedback records may become preference hints, boundary corrections, rewrite
+  todos, or publish decisions;
+- publish records are gates, never implicit permission to post;
+- projections are read-only views and must be recomputed from compact source
+  records.
+
+## Records
+
+| Record | Required Purpose |
+| --- | --- |
+| `source_item_v0` | Compact observation with `source_status`, `freshness`, terms note, attribution, and allowed quote/use policy. |
+| `angle_candidate_v0` | Candidate content angle linked to source items, with audience, topic, preference fit, evidence quality, decision, and rejection reason when skipped. |
+| `draft_item_v0` | Outline/draft/rewrite state with source map, preference hints, validation surface, and `publish_gate_id`. |
+| `feedback_signal_v0` | User or operator feedback with a typed effect: preference hint, source boundary correction, rewrite todo, or publish decision. |
+| `publish_gate_v0` | Human approval state for external posting. Draft existence never allows autopublish. |
+| `material_memory_v0` | Durable source-safe library entry with attribution, reuse boundary, rejected angles, and preference hints. |
+
+## Source Status
+
+`source_item_v0.source_status` should use one of:
+
+- `public`;
+- `private_needs_review`;
+- `synthetic_public_safe`;
+- `unpublished`;
+- `forbidden_for_public_surface`.
+
+Every source item must also include `freshness` and `allowed_use`. The v0
+allowed-use set is:
+
+- `summarize_and_transform`;
+- `metadata_only`;
+- `do_not_quote`;
+- `forbidden`.
+
+This keeps connector output from becoming raw evidence by accident. Browser,
+chat, platform, and document connectors own raw retrieval; LoopX stores only the
+compact source contract.
+
+## Projection
+
+`content_ops_surface_projection_v0` is the first-screen status view derived from
+the compact surface. It should include:
+
+- `first_screen.waiting_on`: `user`, `operator`, or `agent`;
+- counts for source review, ready-to-draft angles, feedback waits, and publish
+  decisions;
+- `todo_candidates` that can promote into normal LoopX todos;
+- source-status, draft-state, feedback-effect, and publish-gate counts;
+- validation result and public/private boundary result;
+- a `truth_contract` that says `projection_is_writable=false`.
+
+The projection is useful when an operator can answer:
+
+- what can be drafted safely now;
+- what source still needs review;
+- what feedback changed durable preferences or boundaries;
+- what publish decision is waiting;
+- which side work can continue while publishing is gated.
+
+## Boundary Rules
+
+The surface is valid only when:
+
+- every draft has a source map and publish gate;
+- every publish gate has `approval_required=true` and
+  `autopublish_allowed=false`;
+- raw private material, raw platform bodies, credentials, local paths, and raw
+  logs are absent from compact records;
+- private or metadata-only sources remain blocked from quoting until a user or
+  owner review changes the source status;
+- external posting, platform publish, and production actions remain outside
+  this contract.
+
+## Fixture And Smoke
+
+The public-safe fixture helper is implemented in
+`loopx/content_ops_surface.py`. It provides:
+
+- `build_content_ops_surface_fixture()`;
+- `validate_content_ops_surface(surface)`;
+- `project_content_ops_surface(surface)`.
+
+The durable smoke is:
+
+```bash
+python3 examples/content-ops-surface-fixture-smoke.py
+```
+
+The smoke checks record coverage, source/draft/gate references, first-screen
+projection fields, todo candidates, no-autopublish policy, and public/private
+boundary hygiene.

--- a/examples/content-ops-surface-fixture-smoke.py
+++ b/examples/content-ops-surface-fixture-smoke.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Smoke-test content_ops_surface_v0 fixture, validation, and projection."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.content_ops_surface import (  # noqa: E402
+    CONTENT_OPS_SURFACE_PROJECTION_SCHEMA_VERSION,
+    CONTENT_OPS_SURFACE_SCHEMA_VERSION,
+    build_content_ops_surface_fixture,
+    project_content_ops_surface,
+    validate_content_ops_surface,
+)
+
+
+PRIVATE_PATTERNS = [
+    re.compile(r"/Users/[A-Za-z0-9._-]+/"),
+    re.compile(r"/home/[A-Za-z0-9._-]+/"),
+    re.compile(r"/private/"),
+    re.compile(r"[A-Za-z]:\\\\Users\\\\"),
+    re.compile(r"\bBearer\s+[A-Za-z0-9._-]+"),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+]
+
+REQUIRED_RECORD_GROUPS = {
+    "source_items",
+    "angle_candidates",
+    "draft_items",
+    "feedback_signals",
+    "publish_gates",
+    "material_memory",
+}
+
+REQUIRED_OPERATOR_STATES = {
+    "waiting_for_source_review",
+    "ready_to_draft",
+    "waiting_for_feedback",
+    "ready_for_publish_decision",
+    "safe_side_work_available",
+}
+
+
+def assert_public_safe(payload: dict[str, object], label: str) -> None:
+    text = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    for pattern in PRIVATE_PATTERNS:
+        if pattern.search(text):
+            raise AssertionError(f"{label} matched private pattern {pattern.pattern!r}")
+    forbidden_values = [
+        "full chat transcript",
+        "raw platform post body",
+        "secret-value",
+        "credential-value",
+    ]
+    leaked = [value for value in forbidden_values if value in text]
+    assert not leaked, (label, leaked)
+
+
+def assert_fixture_contract(surface: dict[str, object]) -> None:
+    assert surface["schema_version"] == CONTENT_OPS_SURFACE_SCHEMA_VERSION, surface
+    assert surface["mode"] == "compact_state_surface", surface
+    for group in REQUIRED_RECORD_GROUPS:
+        records = surface[group]
+        assert isinstance(records, list) and records, (group, records)
+    assert REQUIRED_OPERATOR_STATES.issubset(set(surface["operator_states"])), surface
+
+    boundary = surface["boundary"]
+    assert isinstance(boundary, dict), boundary
+    assert boundary["public_safe"] is True, boundary
+    assert boundary["raw_private_material_recorded"] is False, boundary
+    assert boundary["raw_platform_data_recorded"] is False, boundary
+    assert boundary["credentials_recorded"] is False, boundary
+    assert boundary["autopublish_allowed"] is False, boundary
+    assert boundary["publish_requires_user_gate"] is True, boundary
+
+    sources = surface["source_items"]
+    assert isinstance(sources, list), sources
+    statuses = {item["source_status"] for item in sources}
+    assert {"synthetic_public_safe", "private_needs_review"}.issubset(statuses), statuses
+    assert all(item["freshness"] for item in sources), sources
+    assert all(item["allowed_use"] for item in sources), sources
+
+    drafts = surface["draft_items"]
+    assert isinstance(drafts, list), drafts
+    for draft in drafts:
+        assert draft["source_map"], draft
+        assert draft["publish_gate_id"], draft
+        assert draft["validation_surface"], draft
+
+    gates = surface["publish_gates"]
+    assert isinstance(gates, list), gates
+    for gate in gates:
+        assert gate["approval_required"] is True, gate
+        assert gate["autopublish_allowed"] is False, gate
+        assert gate["status"] == "blocked_until_user_approval", gate
+
+
+def assert_projection_contract(projection: dict[str, object]) -> None:
+    assert (
+        projection["schema_version"]
+        == CONTENT_OPS_SURFACE_PROJECTION_SCHEMA_VERSION
+    ), projection
+    assert projection["mode"] == "read_only", projection
+    first_screen = projection["first_screen"]
+    assert isinstance(first_screen, dict), first_screen
+    assert first_screen["waiting_on"] == "user", first_screen
+    assert first_screen["user_action_required"] is True, first_screen
+    assert first_screen["agent_can_continue"] is True, first_screen
+    assert first_screen["safe_side_work_available"] is True, first_screen
+    assert first_screen["source_review_required_count"] == 1, first_screen
+    assert first_screen["ready_to_draft_count"] == 1, first_screen
+    assert first_screen["publish_decision_count"] == 1, first_screen
+
+    truth = projection["truth_contract"]
+    assert isinstance(truth, dict), truth
+    assert truth["projection_is_writable"] is False, truth
+    assert truth["write_authority"] == "none", truth
+    assert truth["publish_gate_required"] is True, truth
+    assert truth["autopublish_allowed"] is False, truth
+    assert truth["raw_private_material_copied"] is False, truth
+
+    validation = projection["validation"]
+    assert isinstance(validation, dict), validation
+    assert validation["ok"] is True, validation
+    assert validation["raw_material_key_names"] == [], validation
+    assert set(validation["record_counts"]) == REQUIRED_RECORD_GROUPS, validation
+
+    todo_candidates = projection["todo_candidates"]
+    assert isinstance(todo_candidates, list) and len(todo_candidates) >= 3, (
+        todo_candidates
+    )
+    roles = {candidate["role"] for candidate in todo_candidates}
+    assert {"agent", "user"}.issubset(roles), todo_candidates
+    action_kinds = {candidate["action_kind"] for candidate in todo_candidates}
+    assert "content_ops_draft_from_angle" in action_kinds, todo_candidates
+    assert "content_ops_source_review" in action_kinds, todo_candidates
+    assert "content_ops_publish_gate" in action_kinds, todo_candidates
+
+
+def main() -> int:
+    surface = build_content_ops_surface_fixture()
+    validation = validate_content_ops_surface(surface)
+    projection = project_content_ops_surface(surface)
+
+    assert validation["ok"] is True, validation
+    assert validation["errors"] == [], validation
+    assert_fixture_contract(surface)
+    assert_projection_contract(projection)
+    assert_public_safe(surface, "surface")
+    assert_public_safe(projection, "projection")
+    print("content-ops-surface-fixture-smoke: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/content_ops_surface.py
+++ b/loopx/content_ops_surface.py
@@ -1,0 +1,546 @@
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+
+CONTENT_OPS_SURFACE_SCHEMA_VERSION = "content_ops_surface_v0"
+CONTENT_OPS_SURFACE_PROJECTION_SCHEMA_VERSION = "content_ops_surface_projection_v0"
+
+SOURCE_ITEM_SCHEMA_VERSION = "source_item_v0"
+ANGLE_CANDIDATE_SCHEMA_VERSION = "angle_candidate_v0"
+DRAFT_ITEM_SCHEMA_VERSION = "draft_item_v0"
+FEEDBACK_SIGNAL_SCHEMA_VERSION = "feedback_signal_v0"
+PUBLISH_GATE_SCHEMA_VERSION = "publish_gate_v0"
+MATERIAL_MEMORY_SCHEMA_VERSION = "material_memory_v0"
+CONTENT_OPS_VALIDATION_SCHEMA_VERSION = "content_ops_surface_validation_v0"
+
+RAW_MATERIAL_KEY_HINTS = (
+    "body",
+    "chat",
+    "credential",
+    "dm",
+    "local_path",
+    "log",
+    "message",
+    "raw",
+    "secret",
+    "token",
+    "transcript",
+)
+
+ALLOWED_SOURCE_STATUSES = {
+    "public",
+    "private_needs_review",
+    "synthetic_public_safe",
+    "unpublished",
+    "forbidden_for_public_surface",
+}
+ALLOWED_FRESHNESS = {"fresh", "stale", "unknown"}
+ALLOWED_USE_POLICIES = {
+    "summarize_and_transform",
+    "metadata_only",
+    "do_not_quote",
+    "forbidden",
+}
+ALLOWED_ANGLE_DECISIONS = {"draft", "reject", "hold", "needs_review"}
+ALLOWED_DRAFT_STATES = {"outline", "draft", "rewrite", "blocked", "ready_for_review"}
+ALLOWED_FEEDBACK_EFFECTS = {
+    "preference_hint",
+    "source_boundary_correction",
+    "rewrite_todo",
+    "publish_decision",
+}
+ALLOWED_PUBLISH_GATE_STATUSES = {
+    "blocked_until_user_approval",
+    "approved",
+    "denied",
+    "needs_revision",
+}
+
+
+def _as_mappings(values: Sequence[Mapping[str, Any]] | None) -> list[dict[str, Any]]:
+    if not values:
+        return []
+    return [dict(item) for item in values if isinstance(item, Mapping)]
+
+
+def _text(value: Any, *, limit: int = 160) -> str | None:
+    if value is None:
+        return None
+    text = " ".join(str(value).split())
+    if not text:
+        return None
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 1)].rstrip() + "..."
+
+
+def _ids(items: Sequence[Mapping[str, Any]], key: str) -> set[str]:
+    return {
+        str(item.get(key))
+        for item in items
+        if item.get(key) is not None and str(item.get(key)).strip()
+    }
+
+
+def _counter(values: Sequence[Any]) -> dict[str, int]:
+    return dict(sorted(Counter(str(value) for value in values if value).items()))
+
+
+def _raw_material_key_names(*groups: Sequence[Mapping[str, Any]]) -> list[str]:
+    names: set[str] = set()
+    for group in groups:
+        for item in group:
+            for key in item:
+                lowered = str(key).lower()
+                if any(hint in lowered for hint in RAW_MATERIAL_KEY_HINTS):
+                    names.add(str(key))
+    return sorted(names)
+
+
+def build_content_ops_surface_fixture(
+    *, generated_at: str | None = "2026-06-23T00:00:00Z"
+) -> dict[str, Any]:
+    """Build a synthetic public-safe content-ops state surface fixture.
+
+    This fixture demonstrates the shape of a creator/self-media loop without
+    copying raw platform posts, chat messages, draft bodies, credentials, or
+    local paths into LoopX state.
+    """
+
+    source_items = [
+        {
+            "schema_version": SOURCE_ITEM_SCHEMA_VERSION,
+            "source_item_id": "source_demo_public_feed_001",
+            "source_kind": "synthetic_demo_feed",
+            "source_status": "synthetic_public_safe",
+            "freshness": "fresh",
+            "terms_note": "synthetic demo only; no platform scraping claim",
+            "allowed_use": "summarize_and_transform",
+            "attribution": "LoopX synthetic creator-ops demo",
+            "summary": (
+                "A public-safe trend summary suggests creator operators need "
+                "source-aware drafting queues."
+            ),
+        },
+        {
+            "schema_version": SOURCE_ITEM_SCHEMA_VERSION,
+            "source_item_id": "source_demo_private_note_001",
+            "source_kind": "synthetic_private_note",
+            "source_status": "private_needs_review",
+            "freshness": "fresh",
+            "terms_note": "metadata-only placeholder for private material",
+            "allowed_use": "metadata_only",
+            "attribution": "operator-owned private source placeholder",
+            "summary": "Private source is represented only as a compact review-needed signal.",
+        },
+    ]
+    angle_candidates = [
+        {
+            "schema_version": ANGLE_CANDIDATE_SCHEMA_VERSION,
+            "angle_id": "angle_source_aware_loop",
+            "source_item_ids": ["source_demo_public_feed_001"],
+            "audience": "maintainers evaluating creator-ops automation",
+            "topic": "source-aware drafting loop",
+            "novelty": "connects connector observations to explicit publish gates",
+            "preference_fit": "high",
+            "evidence_quality": "synthetic_demo",
+            "decision": "draft",
+        },
+        {
+            "schema_version": ANGLE_CANDIDATE_SCHEMA_VERSION,
+            "angle_id": "angle_private_material_quote",
+            "source_item_ids": ["source_demo_private_note_001"],
+            "audience": "same",
+            "topic": "private source quote",
+            "novelty": "blocked by source boundary",
+            "preference_fit": "unknown",
+            "evidence_quality": "needs_owner_review",
+            "decision": "reject",
+            "rejection_reason": "private material cannot be quoted or promoted without review",
+        },
+    ]
+    draft_items = [
+        {
+            "schema_version": DRAFT_ITEM_SCHEMA_VERSION,
+            "draft_id": "draft_source_aware_loop_outline",
+            "angle_id": "angle_source_aware_loop",
+            "state": "outline",
+            "source_map": [
+                {
+                    "source_item_id": "source_demo_public_feed_001",
+                    "use": "summarized premise",
+                }
+            ],
+            "preference_hints": [
+                "explain value as quality and feedback, not raw publish count",
+                "keep publish decision human-gated",
+            ],
+            "publish_gate_id": "publish_gate_source_aware_loop",
+            "validation_surface": (
+                "source map present; no raw private material; publish gate visible"
+            ),
+        }
+    ]
+    feedback_signals = [
+        {
+            "schema_version": FEEDBACK_SIGNAL_SCHEMA_VERSION,
+            "feedback_id": "feedback_demo_style_001",
+            "target_id": "draft_source_aware_loop_outline",
+            "signal": "useful_but_less_salesy",
+            "effect": "preference_hint",
+            "writes_todo": False,
+            "summary": "Favor operator-quality framing over content volume claims.",
+        },
+        {
+            "schema_version": FEEDBACK_SIGNAL_SCHEMA_VERSION,
+            "feedback_id": "feedback_private_source_boundary_001",
+            "target_id": "source_demo_private_note_001",
+            "signal": "do_not_use_source_body",
+            "effect": "source_boundary_correction",
+            "writes_todo": False,
+            "summary": "Private source stays metadata-only until an explicit review approves use.",
+        },
+    ]
+    publish_gates = [
+        {
+            "schema_version": PUBLISH_GATE_SCHEMA_VERSION,
+            "gate_id": "publish_gate_source_aware_loop",
+            "draft_id": "draft_source_aware_loop_outline",
+            "status": "blocked_until_user_approval",
+            "approval_required": True,
+            "autopublish_allowed": False,
+            "required_review": [
+                "source attribution",
+                "tone/style",
+                "platform policy",
+                "final publish destination",
+            ],
+        }
+    ]
+    material_memory = [
+        {
+            "schema_version": MATERIAL_MEMORY_SCHEMA_VERSION,
+            "memory_id": "memory_source_aware_loop",
+            "source_item_id": "source_demo_public_feed_001",
+            "attribution": "LoopX synthetic creator-ops demo",
+            "reuse_boundary": "demo_only",
+            "rejected_angles": ["angle_private_material_quote"],
+            "preference_hints": ["quality and feedback beat raw article count"],
+        }
+    ]
+    return {
+        "schema_version": CONTENT_OPS_SURFACE_SCHEMA_VERSION,
+        "surface_id": "creator_ops_public_safe_demo",
+        "generated_at": generated_at,
+        "mode": "compact_state_surface",
+        "source_items": source_items,
+        "angle_candidates": angle_candidates,
+        "draft_items": draft_items,
+        "feedback_signals": feedback_signals,
+        "publish_gates": publish_gates,
+        "material_memory": material_memory,
+        "operator_states": [
+            "waiting_for_source_review",
+            "ready_to_draft",
+            "waiting_for_feedback",
+            "ready_for_publish_decision",
+            "safe_side_work_available",
+        ],
+        "boundary": {
+            "public_safe": True,
+            "raw_private_material_recorded": False,
+            "raw_platform_data_recorded": False,
+            "credentials_recorded": False,
+            "autopublish_allowed": False,
+            "publish_requires_user_gate": True,
+            "connector_bodies_are_source_of_truth": False,
+        },
+    }
+
+
+def validate_content_ops_surface(surface: Mapping[str, Any]) -> dict[str, Any]:
+    source_items = _as_mappings(surface.get("source_items"))  # type: ignore[arg-type]
+    angle_candidates = _as_mappings(surface.get("angle_candidates"))  # type: ignore[arg-type]
+    draft_items = _as_mappings(surface.get("draft_items"))  # type: ignore[arg-type]
+    feedback_signals = _as_mappings(surface.get("feedback_signals"))  # type: ignore[arg-type]
+    publish_gates = _as_mappings(surface.get("publish_gates"))  # type: ignore[arg-type]
+    material_memory = _as_mappings(surface.get("material_memory"))  # type: ignore[arg-type]
+
+    errors: list[str] = []
+    source_ids = _ids(source_items, "source_item_id")
+    angle_ids = _ids(angle_candidates, "angle_id")
+    draft_ids = _ids(draft_items, "draft_id")
+    gate_ids = _ids(publish_gates, "gate_id")
+
+    if surface.get("schema_version") != CONTENT_OPS_SURFACE_SCHEMA_VERSION:
+        errors.append("surface schema_version must be content_ops_surface_v0")
+    if not source_items:
+        errors.append("at least one source_item_v0 record is required")
+    if not angle_candidates:
+        errors.append("at least one angle_candidate_v0 record is required")
+    if not draft_items:
+        errors.append("at least one draft_item_v0 record is required")
+    if not feedback_signals:
+        errors.append("at least one feedback_signal_v0 record is required")
+    if not publish_gates:
+        errors.append("at least one publish_gate_v0 record is required")
+    if not material_memory:
+        errors.append("at least one material_memory_v0 record is required")
+
+    for item in source_items:
+        if item.get("schema_version") != SOURCE_ITEM_SCHEMA_VERSION:
+            errors.append(f"source item {item.get('source_item_id')} has wrong schema")
+        if item.get("source_status") not in ALLOWED_SOURCE_STATUSES:
+            errors.append(
+                f"source item {item.get('source_item_id')} has invalid source_status"
+            )
+        if item.get("freshness") not in ALLOWED_FRESHNESS:
+            errors.append(f"source item {item.get('source_item_id')} has invalid freshness")
+        if item.get("allowed_use") not in ALLOWED_USE_POLICIES:
+            errors.append(f"source item {item.get('source_item_id')} has invalid allowed_use")
+
+    for item in angle_candidates:
+        if item.get("schema_version") != ANGLE_CANDIDATE_SCHEMA_VERSION:
+            errors.append(f"angle {item.get('angle_id')} has wrong schema")
+        if item.get("decision") not in ALLOWED_ANGLE_DECISIONS:
+            errors.append(f"angle {item.get('angle_id')} has invalid decision")
+        for source_id in item.get("source_item_ids") or []:
+            if str(source_id) not in source_ids:
+                errors.append(
+                    f"angle {item.get('angle_id')} references unknown source {source_id}"
+                )
+
+    for item in draft_items:
+        if item.get("schema_version") != DRAFT_ITEM_SCHEMA_VERSION:
+            errors.append(f"draft {item.get('draft_id')} has wrong schema")
+        if item.get("state") not in ALLOWED_DRAFT_STATES:
+            errors.append(f"draft {item.get('draft_id')} has invalid state")
+        if str(item.get("angle_id")) not in angle_ids:
+            errors.append(f"draft {item.get('draft_id')} references unknown angle")
+        if str(item.get("publish_gate_id")) not in gate_ids:
+            errors.append(f"draft {item.get('draft_id')} references unknown publish gate")
+        source_map = item.get("source_map")
+        if not isinstance(source_map, Sequence) or isinstance(source_map, (str, bytes)):
+            errors.append(f"draft {item.get('draft_id')} must carry a source_map")
+        else:
+            for source_ref in source_map:
+                if not isinstance(source_ref, Mapping):
+                    errors.append(f"draft {item.get('draft_id')} has invalid source_map item")
+                    continue
+                source_id = str(source_ref.get("source_item_id") or "")
+                if source_id not in source_ids:
+                    errors.append(
+                        f"draft {item.get('draft_id')} source_map references unknown source"
+                    )
+
+    for item in feedback_signals:
+        if item.get("schema_version") != FEEDBACK_SIGNAL_SCHEMA_VERSION:
+            errors.append(f"feedback {item.get('feedback_id')} has wrong schema")
+        if item.get("effect") not in ALLOWED_FEEDBACK_EFFECTS:
+            errors.append(f"feedback {item.get('feedback_id')} has invalid effect")
+        target_id = str(item.get("target_id") or "")
+        if (
+            target_id not in draft_ids
+            and target_id not in source_ids
+            and target_id not in angle_ids
+        ):
+            errors.append(f"feedback {item.get('feedback_id')} references unknown target")
+
+    for item in publish_gates:
+        if item.get("schema_version") != PUBLISH_GATE_SCHEMA_VERSION:
+            errors.append(f"publish gate {item.get('gate_id')} has wrong schema")
+        if item.get("status") not in ALLOWED_PUBLISH_GATE_STATUSES:
+            errors.append(f"publish gate {item.get('gate_id')} has invalid status")
+        if item.get("autopublish_allowed") is not False:
+            errors.append(
+                f"publish gate {item.get('gate_id')} must set autopublish_allowed=false"
+            )
+        if item.get("approval_required") is not True:
+            errors.append(f"publish gate {item.get('gate_id')} must require approval")
+
+    for item in material_memory:
+        if item.get("schema_version") != MATERIAL_MEMORY_SCHEMA_VERSION:
+            errors.append(f"memory {item.get('memory_id')} has wrong schema")
+        source_id = str(item.get("source_item_id") or "")
+        if source_id not in source_ids:
+            errors.append(f"memory {item.get('memory_id')} references unknown source")
+
+    boundary = surface.get("boundary") if isinstance(surface.get("boundary"), Mapping) else {}
+    if boundary.get("public_safe") is not True:
+        errors.append("boundary.public_safe must be true")
+    for key in (
+        "raw_private_material_recorded",
+        "raw_platform_data_recorded",
+        "credentials_recorded",
+        "autopublish_allowed",
+        "connector_bodies_are_source_of_truth",
+    ):
+        if boundary.get(key) is not False:
+            errors.append(f"boundary.{key} must be false")
+    if boundary.get("publish_requires_user_gate") is not True:
+        errors.append("boundary.publish_requires_user_gate must be true")
+
+    raw_key_names = _raw_material_key_names(
+        source_items,
+        angle_candidates,
+        draft_items,
+        feedback_signals,
+        publish_gates,
+        material_memory,
+    )
+    if raw_key_names:
+        errors.append(
+            "raw/private-looking key names must not appear in content-ops records"
+        )
+
+    return {
+        "schema_version": CONTENT_OPS_VALIDATION_SCHEMA_VERSION,
+        "ok": not errors,
+        "errors": errors,
+        "record_counts": {
+            "source_items": len(source_items),
+            "angle_candidates": len(angle_candidates),
+            "draft_items": len(draft_items),
+            "feedback_signals": len(feedback_signals),
+            "publish_gates": len(publish_gates),
+            "material_memory": len(material_memory),
+        },
+        "raw_material_key_names": raw_key_names,
+    }
+
+
+def project_content_ops_surface(surface: Mapping[str, Any]) -> dict[str, Any]:
+    """Project a content-ops surface into first-screen status fields."""
+
+    source_items = _as_mappings(surface.get("source_items"))  # type: ignore[arg-type]
+    angle_candidates = _as_mappings(surface.get("angle_candidates"))  # type: ignore[arg-type]
+    draft_items = _as_mappings(surface.get("draft_items"))  # type: ignore[arg-type]
+    feedback_signals = _as_mappings(surface.get("feedback_signals"))  # type: ignore[arg-type]
+    publish_gates = _as_mappings(surface.get("publish_gates"))  # type: ignore[arg-type]
+    material_memory = _as_mappings(surface.get("material_memory"))  # type: ignore[arg-type]
+    validation = validate_content_ops_surface(surface)
+
+    source_review_required = [
+        item
+        for item in source_items
+        if item.get("source_status") in {"private_needs_review", "unpublished"}
+        or item.get("allowed_use") == "metadata_only"
+    ]
+    ready_angles = [
+        item for item in angle_candidates if item.get("decision") == "draft"
+    ]
+    drafts_waiting_feedback = [
+        item
+        for item in draft_items
+        if item.get("state") in {"outline", "draft", "ready_for_review"}
+    ]
+    publish_decision_gates = [
+        item
+        for item in publish_gates
+        if item.get("status") == "blocked_until_user_approval"
+    ]
+    feedback_effects = _counter(item.get("effect") for item in feedback_signals)
+    operator_states = [
+        str(item)
+        for item in surface.get("operator_states", []) or []
+        if isinstance(item, str) and item.strip()
+    ]
+    user_action_required = bool(publish_decision_gates)
+    safe_side_work_available = "safe_side_work_available" in operator_states
+    ready_to_draft = bool(ready_angles)
+
+    if user_action_required:
+        waiting_on = "user"
+        next_safe_action = "review source map and publish gate before external posting"
+    elif ready_to_draft:
+        waiting_on = "agent"
+        next_safe_action = "draft or rewrite from approved source-mapped angle"
+    elif source_review_required:
+        waiting_on = "operator"
+        next_safe_action = "review source status before drafting"
+    else:
+        waiting_on = "agent"
+        next_safe_action = "collect more compact source signals"
+
+    todo_candidates = []
+    if ready_angles:
+        todo_candidates.append(
+            {
+                "role": "agent",
+                "action_kind": "content_ops_draft_from_angle",
+                "title": "Draft or rewrite the selected source-mapped angle",
+                "angle_ids": [str(item.get("angle_id")) for item in ready_angles],
+                "validation_surface": "source_map plus publish_gate must remain present",
+                "stop_condition": "stop before external posting",
+            }
+        )
+    if source_review_required:
+        todo_candidates.append(
+            {
+                "role": "user",
+                "action_kind": "content_ops_source_review",
+                "title": "Review private or metadata-only source before use",
+                "source_item_ids": [
+                    str(item.get("source_item_id")) for item in source_review_required
+                ],
+                "validation_surface": "source_status and allowed_use updated",
+            }
+        )
+    if publish_decision_gates:
+        todo_candidates.append(
+            {
+                "role": "user",
+                "action_kind": "content_ops_publish_gate",
+                "title": "Approve, deny, or request revision before publication",
+                "publish_gate_ids": [
+                    str(item.get("gate_id")) for item in publish_decision_gates
+                ],
+                "validation_surface": "publish gate decision recorded",
+            }
+        )
+
+    return {
+        "schema_version": CONTENT_OPS_SURFACE_PROJECTION_SCHEMA_VERSION,
+        "surface_schema_version": surface.get("schema_version"),
+        "surface_id": _text(surface.get("surface_id"), limit=120),
+        "mode": "read_only",
+        "first_screen": {
+            "waiting_on": waiting_on,
+            "user_action_required": user_action_required,
+            "agent_can_continue": bool(ready_to_draft or safe_side_work_available),
+            "safe_side_work_available": safe_side_work_available,
+            "source_review_required_count": len(source_review_required),
+            "ready_to_draft_count": len(ready_angles),
+            "waiting_for_feedback_count": len(drafts_waiting_feedback),
+            "publish_decision_count": len(publish_decision_gates),
+            "next_safe_action": next_safe_action,
+        },
+        "record_counts": validation["record_counts"],
+        "source_statuses": _counter(item.get("source_status") for item in source_items),
+        "draft_states": _counter(item.get("state") for item in draft_items),
+        "feedback_effects": feedback_effects,
+        "publish_gate_statuses": _counter(item.get("status") for item in publish_gates),
+        "material_memory": {
+            "count": len(material_memory),
+            "reuse_boundaries": _counter(
+                item.get("reuse_boundary") for item in material_memory
+            ),
+        },
+        "todo_candidates": todo_candidates,
+        "validation": validation,
+        "truth_contract": {
+            "projection_is_writable": False,
+            "write_authority": "none",
+            "source_surface_is_source_of_truth": True,
+            "publish_gate_required": True,
+            "autopublish_allowed": False,
+            "raw_private_material_copied": False,
+            "recompute_rule": (
+                "recompute from compact content_ops_surface_v0 records; "
+                "do not edit this projection as source state"
+            ),
+        },
+    }


### PR DESCRIPTION
## Summary
- add content_ops_surface_v0 fixture, validation, and read-only projection helpers
- add durable smoke coverage for source/draft/feedback/publish-gate/material-memory records
- document the public-safe contract and link it from product/protocol indexes

## Validation
- python3 -m py_compile loopx/content_ops_surface.py
- python3 examples/content-ops-surface-fixture-smoke.py
- git diff --check
- loopx check --scan-path loopx/content_ops_surface.py --scan-path examples/content-ops-surface-fixture-smoke.py --scan-path docs/reference/protocols/content-ops-surface-v0.md --scan-path docs/reference/protocols/README.md --scan-path docs/product/README.md --scan-path docs/product/scenario-capability-gap-map.md

## Boundary
- public-safe synthetic fixture only
- no raw private material, credentials, local paths, platform bodies, or publish authority
- publish stays gated by publish_gate_v0