### PR TITLE
docs: surface LoopX management path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ human decisions stay in one compact layer. User gates stay explicit; safe
 fallback lanes keep moving; every automatic turn has a boundary, validation
 surface, and writeback trail.
 
+The same state also feeds a local management surface: operators can inspect
+projects, agent lanes, user gates, todos, evidence, and review signals before
+granting more autonomy.
+
 LoopX 把一次静态 goal 变成能持续流转的动态 loop：该等人的地方明确等人，
 不该空等的安全侧路继续推进，下一轮 agent 总能读到目标、边界、证据和交接。
 
@@ -148,6 +152,25 @@ For more cases, open the [showcase catalog](docs/showcases/README.md). For a
 timed presenter walkthrough, use the
 [3-minute demo script](docs/outreach/frontstage-demo-script.md).
 
+## Review Agent Work
+
+After a project is connected, LoopX can be used as a read-first management
+surface before it is trusted with more control. The local dashboard helps you
+inspect all connected projects, search todos, review user gates, compare agent
+lanes, and follow evidence without reading raw logs.
+
+```bash
+loopx serve-status --global-registry --port 8766 --limit 80
+cd ~/loopx/apps/dashboard && npm install && npm run dev
+```
+
+This surface is intentionally conservative: CLI state remains the source of
+truth, browser writes require explicit local opt-in, and review signals are
+kept separate from execution permission. See the
+[intelligent management surface](docs/product/intelligent-management-surface.md)
+and [project-level reward model](docs/product/project-level-reward-model.md)
+for the longer product direction.
+
 ## What Is It?
 
 LoopX does not replace Codex, Claude Code, Cursor, or another agent
@@ -232,6 +255,10 @@ or the
   run, wait, ask the user, self-repair, or stay quiet.
 - **Run history and evidence**: compact append-only events for progress,
   validation, blockers, reward, benchmark results, and quota spend.
+- **Read-first management surface**: a local dashboard for project selection,
+  todo search, agent lanes, user gates, evidence, and review signals.
+- **Performance review**: project-level value signals across output quantity,
+  output quality, token cost, and user attention cost.
 - **Public/private boundary checks**: local scans and docs rules to keep raw
   private state, credentials, logs, traces, and benchmark material out of
   public artifacts.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -16,6 +16,9 @@ loop 状态：目标、用户决策、agent todo、认领关系、scope、证据
 和 quota 留在同一层状态里。该等人的地方明确等人，不该空等的安全侧路继续推进，
 每一次自动执行都留下边界、验证面和写回轨迹。
 
+同一份状态也会投影到本地管理面：用户可以先看项目、agent lane、user gate、
+todo、证据和 review 信号，再决定是否给 agent 更多自主权。
+
 [English](README.md) · [快速开始](#快速开始) · [看几个例子](#看几个例子) ·
 [Showcases](docs/showcases/README.md) · [用户群与反馈](#用户群与反馈) ·
 [产品愿景](docs/product/vision.md) · [架构](docs/architecture.md)
@@ -104,6 +107,22 @@ loopx bootstrap \
 演示者需要 timed walkthrough 时，再打开
 [3 分钟 demo script](docs/outreach/frontstage-demo-script.md)。
 
+## 审阅和管理 Agent 工作
+
+项目接入后，LoopX 可以先作为 read-first 管理面使用，而不是一上来就接管更多控制权。
+本地 dashboard 支持查看所有已连接项目、搜索 todo、检查 user gate、对比 agent lane、
+跟踪证据，避免用户从 raw log 里理解 agent 到底做了什么。
+
+```bash
+loopx serve-status --global-registry --port 8766 --limit 80
+cd ~/loopx/apps/dashboard && npm install && npm run dev
+```
+
+这个管理面保持保守：CLI 状态仍然是事实源，浏览器写入需要显式本地 opt-in，
+review 信号不会自动变成执行权限。更完整的设计见
+[intelligent management surface](docs/product/intelligent-management-surface.md)
+和 [project-level reward model](docs/product/project-level-reward-model.md)。
+
 ## 它是什么
 
 LoopX 不是另一个 agent runtime，也不是要替代 Codex、Claude Code、
@@ -167,6 +186,10 @@ flowchart LR
 - **Todo ownership**：agent 通过 `claimed_by` 认领 todo，减少并发冲突。
 - **Quota guard**：每次自动 heartbeat 前判断是否应该运行、等待、通知或自修复。
 - **Run history**：把每轮进展、验证、blocker、reward、quota spend 记录成紧凑历史。
+- **Read-first management surface**：本地 dashboard 用于项目选择、todo 搜索、
+  agent lane、user gate、证据和 review 信号。
+- **Performance review**：用产出数量、产出质量、token cost 和 user attention cost
+  评价长期 Loop Agent 的项目级价值。
 
 ## 适合什么场景
 


### PR DESCRIPTION
## Summary\n- add a concise read-first management-surface path to the English and Chinese READMEs\n- explain project/todo/gate/evidence review before granting more agent autonomy\n- link the management surface and project-level reward model from the README path\n\n## Validation\n- loopx check --scan-path README.md --scan-path README.zh-CN.md\n- git diff --check -- README.md README.zh-CN.md