### PR TITLE
docs: move early surfaces to experimental README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,27 +149,7 @@ points:
   agents without hiding ownership or scope.
 
 For more cases, open the [showcase catalog](docs/showcases/README.md). For a
-timed presenter walkthrough, use the
-[3-minute demo script](docs/outreach/frontstage-demo-script.md).
-
-## Review Agent Work
-
-After a project is connected, LoopX can be used as a read-first management
-surface before it is trusted with more control. The local dashboard helps you
-inspect all connected projects, search todos, review user gates, compare agent
-lanes, and follow evidence without reading raw logs.
-
-```bash
-loopx serve-status --global-registry --port 8766 --limit 80
-cd ~/loopx/apps/dashboard && npm install && npm run dev
-```
-
-This surface is intentionally conservative: CLI state remains the source of
-truth, browser writes require explicit local opt-in, and review signals are
-kept separate from execution permission. See the
-[intelligent management surface](docs/product/intelligent-management-surface.md)
-and [project-level reward model](docs/product/project-level-reward-model.md)
-for the longer product direction.
+full presenter material, see the experimental notes below.
 
 ## What Is It?
 
@@ -462,6 +442,33 @@ The next milestones are stronger project adapters, safer controller/sub-agent
 coordination, better benchmark-runner ergonomics, a more polished operator
 view, and creator/operator showcases that make the same control-plane value
 legible beyond software engineering.
+
+## Experimental
+
+These surfaces are useful for demos and product iteration, but they are not the
+main getting-started path yet.
+
+### Review Agent Work
+
+After a project is connected, LoopX can be used as a read-first management
+surface before it is trusted with more control. The local dashboard helps you
+inspect all connected projects, search todos, review user gates, compare agent
+lanes, and follow evidence without reading raw logs.
+
+```bash
+loopx serve-status --global-registry --port 8766 --limit 80
+cd ~/loopx/apps/dashboard && npm install && npm run dev
+```
+
+This surface is intentionally conservative: CLI state remains the source of
+truth, browser writes require explicit local opt-in, and review signals are
+kept separate from execution permission. See the
+[intelligent management surface](docs/product/intelligent-management-surface.md)
+and [project-level reward model](docs/product/project-level-reward-model.md)
+for the longer product direction.
+
+For a timed presenter walkthrough, use the
+[3-minute demo script](docs/outreach/frontstage-demo-script.md).
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -104,24 +104,7 @@ loopx bootstrap \
   用 public-safe 证据展示同一控制面如何协调主控、旁路、scope 和 ownership。
 
 完整案例目录见 [docs/showcases/README.md](docs/showcases/README.md)。
-演示者需要 timed walkthrough 时，再打开
-[3 分钟 demo script](docs/outreach/frontstage-demo-script.md)。
-
-## 审阅和管理 Agent 工作
-
-项目接入后，LoopX 可以先作为 read-first 管理面使用，而不是一上来就接管更多控制权。
-本地 dashboard 支持查看所有已连接项目、搜索 todo、检查 user gate、对比 agent lane、
-跟踪证据，避免用户从 raw log 里理解 agent 到底做了什么。
-
-```bash
-loopx serve-status --global-registry --port 8766 --limit 80
-cd ~/loopx/apps/dashboard && npm install && npm run dev
-```
-
-这个管理面保持保守：CLI 状态仍然是事实源，浏览器写入需要显式本地 opt-in，
-review 信号不会自动变成执行权限。更完整的设计见
-[intelligent management surface](docs/product/intelligent-management-surface.md)
-和 [project-level reward model](docs/product/project-level-reward-model.md)。
+更完整的演示材料放在文末实验性能力里。
 
 ## 它是什么
 
@@ -263,3 +246,26 @@ benchmark 证据边界。
 - 稳定 CLI/runtime 行为的 focused smoke；
 - 控制面协议、架构说明、贡献者任务；
 - 明确标注 evidence boundary 的展示材料。
+
+## Experimental / 实验性能力
+
+下面这些能力适合 demo 和产品迭代，但还不是主线 getting-started 路径。
+
+### 审阅和管理 Agent 工作
+
+项目接入后，LoopX 可以先作为 read-first 管理面使用，而不是一上来就接管更多控制权。
+本地 dashboard 支持查看所有已连接项目、搜索 todo、检查 user gate、对比 agent lane、
+跟踪证据，避免用户从 raw log 里理解 agent 到底做了什么。
+
+```bash
+loopx serve-status --global-registry --port 8766 --limit 80
+cd ~/loopx/apps/dashboard && npm install && npm run dev
+```
+
+这个管理面保持保守：CLI 状态仍然是事实源，浏览器写入需要显式本地 opt-in，
+review 信号不会自动变成执行权限。更完整的设计见
+[intelligent management surface](docs/product/intelligent-management-surface.md)
+和 [project-level reward model](docs/product/project-level-reward-model.md)。
+
+演示者需要 timed walkthrough 时，可以使用
+[3 分钟 demo script](docs/outreach/frontstage-demo-script.md)。


### PR DESCRIPTION
## Summary\n- move the Review Agent Work dashboard path out of the main README flow into Experimental\n- move the 3-minute presenter script link into Experimental\n- keep the Chinese README aligned with the same maturity signal\n\n## Validation\n- loopx check --scan-path README.md --scan-path README.zh-CN.md\n- git diff --check -- README.md README.zh-CN.md