### PR TITLE
Refactor benchmark boundary CLI helpers

### DIFF
--- a/examples/cli-benchmark-boundary-command-modularization-smoke.py
+++ b/examples/cli-benchmark-boundary-command-modularization-smoke.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "loopx.cli", *args],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def assert_contains(text: str, needle: str) -> None:
+    if needle not in text:
+        raise AssertionError(f"expected to find {needle!r} in output:\n{text}")
+
+
+def main() -> int:
+    cli_source = (ROOT / "loopx" / "cli.py").read_text(encoding="utf-8")
+    init_source = (ROOT / "loopx" / "cli_commands" / "__init__.py").read_text(
+        encoding="utf-8"
+    )
+    boundary_source = (
+        ROOT / "loopx" / "cli_commands" / "benchmark_boundary.py"
+    ).read_text(encoding="utf-8")
+
+    leaked_markers = [
+        "benchmark_artifact_filter_parser = benchmark_sub.add_parser",
+        "benchmark_candidate_source_parser = benchmark_sub.add_parser",
+        "split_control_execution_parser = benchmark_sub.add_parser",
+        "def render_benchmark_artifact_path_filter_markdown",
+    ]
+    for marker in leaked_markers:
+        if marker in cli_source:
+            raise AssertionError(f"{marker} leaked back into loopx/cli.py")
+    assert_contains(cli_source, "register_benchmark_boundary_commands(benchmark_sub, add_subcommand_format)")
+    assert_contains(cli_source, "handle_benchmark_boundary_command(")
+    assert_contains(init_source, "register_benchmark_boundary_commands")
+    assert_contains(init_source, "handle_benchmark_boundary_command")
+    assert_contains(boundary_source, "BENCHMARK_BOUNDARY_COMMANDS")
+    assert_contains(boundary_source, "split-control-execution-seam")
+
+    help_result = run_cli("benchmark", "classify-artifacts", "--help")
+    if help_result.returncode != 0:
+        raise AssertionError(help_result.stderr or help_result.stdout)
+    assert_contains(help_result.stdout, "--adapter-kind")
+    assert_contains(help_result.stdout, "--allow-public-filename")
+
+    classify_result = run_cli(
+        "benchmark",
+        "classify-artifacts",
+        "benchmark_run.compact.json",
+        "--format",
+        "json",
+    )
+    if classify_result.returncode != 0:
+        raise AssertionError(classify_result.stderr or classify_result.stdout)
+    classify_payload = json.loads(classify_result.stdout)
+    if classify_payload.get("path_recorded") is not False:
+        raise AssertionError(classify_payload)
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        missing_readiness = Path(temp_dir) / "missing-readiness.json"
+        seam_result = run_cli(
+            "benchmark",
+            "split-control-execution-seam",
+            "--readiness-json",
+            str(missing_readiness),
+            "--format",
+            "json",
+        )
+    if seam_result.returncode != 1:
+        raise AssertionError(
+            f"expected split-control validation failure, got {seam_result.returncode}:\n"
+            f"stdout={seam_result.stdout}\nstderr={seam_result.stderr}"
+        )
+    seam_payload = json.loads(seam_result.stdout)
+    if seam_payload.get("ok") is not False:
+        raise AssertionError(seam_payload)
+    assert_contains(str(seam_payload.get("error")), "No such file")
+
+    print("cli-benchmark-boundary-command-modularization-smoke: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -132,18 +132,14 @@ from .benchmark_case_analysis import (
     render_case_analysis_candidate_report_markdown,
 )
 from .benchmark_core import (
-    build_benchmark_candidate_source_boundary,
     build_codex_app_parity_posthoc_check,
-    filter_public_benchmark_artifact_paths,
-    build_split_control_remote_executor_execution_seam,
-    build_split_control_remote_executor_launch_plan,
     build_split_control_remote_executor_readiness,
-    build_split_control_remote_executor_runner_batch,
     render_codex_app_parity_posthoc_check_markdown,
 )
 from .configure_goal import configure_goal, render_configure_goal_markdown
 from .delivery_outcome import DELIVERY_OUTCOME_CHOICES
 from .cli_commands import (
+    handle_benchmark_boundary_command,
     handle_check_command,
     handle_codex_cli_bounded_visible_pilot_adapter_command,
     handle_codex_cli_bootstrap_message_command,
@@ -172,6 +168,7 @@ from .cli_commands import (
     handle_review_packet_command,
     handle_status_command,
     handle_todo_command,
+    register_benchmark_boundary_commands,
     register_doctor_command,
     register_dreaming_commands,
     register_history_command,
@@ -303,125 +300,6 @@ def build_version_payload() -> dict[str, object]:
 def render_version_markdown(payload: dict[str, object]) -> str:
     return f"{payload.get('name')} {payload.get('version')}\n"
 
-
-def render_benchmark_artifact_path_filter_markdown(payload: dict[str, object]) -> str:
-    artifact_policy = (
-        payload.get("artifact_policy")
-        if isinstance(payload.get("artifact_policy"), dict)
-        else {}
-    )
-    lines = [
-        "# Benchmark Artifact Path Filter",
-        "",
-        f"- Schema: `{payload.get('schema_version')}`",
-        f"- Adapter policy: `{artifact_policy.get('adapter_kind')}`",
-        f"- Allowed to read: `{payload.get('allowed_to_read_count')}`",
-        f"- Blocked: `{payload.get('blocked_count')}`",
-        f"- Full paths recorded: `{payload.get('path_recorded')}`",
-    ]
-    allowed = payload.get("allowed_artifact_basenames")
-    if isinstance(allowed, list) and allowed:
-        lines.append("- Allowed basenames: " + ", ".join(f"`{item}`" for item in allowed))
-    blocked = payload.get("blocked_reasons")
-    if isinstance(blocked, dict) and blocked:
-        reasons = ", ".join(f"`{key}`={value}" for key, value in blocked.items())
-        lines.append("- Blocked reasons: " + reasons)
-    return "\n".join(lines) + "\n"
-
-
-def render_benchmark_candidate_source_boundary_markdown(payload: dict[str, object]) -> str:
-    lines = [
-        "# Benchmark Candidate Source Boundary",
-        "",
-        f"- Schema: `{payload.get('schema_version')}`",
-        f"- Clean: `{payload.get('clean')}`",
-        f"- Allowed: `{payload.get('allowed_source_count')}`",
-        f"- Blocked: `{payload.get('blocked_source_count')}`",
-        f"- Paths recorded: `{payload.get('path_recorded')}`",
-    ]
-    blocked = payload.get("blocked_reasons")
-    if isinstance(blocked, dict) and blocked:
-        reasons = ", ".join(f"`{key}`={value}" for key, value in blocked.items())
-        lines.append("- Blocked reasons: " + reasons)
-    if payload.get("next_action"):
-        lines.append(f"- Next action: {payload.get('next_action')}")
-    return "\n".join(lines) + "\n"
-
-
-def render_split_control_execution_seam_markdown(payload: dict[str, object]) -> str:
-    cases = payload.get("execution_cases") if isinstance(payload.get("execution_cases"), list) else []
-    lines = [
-        "# Benchmark Split-Control Execution Seam",
-        "",
-        f"- Schema: `{payload.get('schema_version')}`",
-        f"- Ready to execute: `{payload.get('ready_to_execute')}`",
-        f"- Ready to spend: `{payload.get('ready_to_spend')}`",
-        f"- Cases: `{len(cases)}`",
-    ]
-    blockers = payload.get("blockers")
-    if isinstance(blockers, list) and blockers:
-        lines.append("- Blockers: " + ", ".join(f"`{item}`" for item in blockers))
-    missing_adapters = payload.get("missing_command_adapter_ids")
-    if isinstance(missing_adapters, list) and missing_adapters:
-        lines.append(
-            "- Missing command adapters: "
-            + ", ".join(f"`{item}`" for item in missing_adapters)
-        )
-    missing_reducers = payload.get("missing_result_reducer_ids")
-    if isinstance(missing_reducers, list) and missing_reducers:
-        lines.append(
-            "- Missing result reducers: "
-            + ", ".join(f"`{item}`" for item in missing_reducers)
-        )
-    if payload.get("next_action"):
-        lines.append(f"- Next action: {payload.get('next_action')}")
-    boundary = payload.get("boundary") if isinstance(payload.get("boundary"), dict) else {}
-    lines.extend(
-        [
-            "",
-            "## Boundary",
-            "",
-            f"- Shell commands embedded: `{boundary.get('shell_commands_embedded')}`",
-            f"- argv embedded: `{boundary.get('argv_embedded')}`",
-            f"- raw task text public: `{boundary.get('raw_task_text_public')}`",
-            f"- raw logs public: `{boundary.get('raw_logs_public')}`",
-            f"- upload allowed: `{boundary.get('upload_allowed')}`",
-            f"- submit allowed: `{boundary.get('submit_allowed')}`",
-        ]
-    )
-    if cases:
-        lines.extend(["", "## Cases", ""])
-        for case in cases:
-            if not isinstance(case, dict):
-                continue
-            materialization = (
-                case.get("command_materialization")
-                if isinstance(case.get("command_materialization"), dict)
-                else {}
-            )
-            local_driver = (
-                case.get("local_driver_contract")
-                if isinstance(case.get("local_driver_contract"), dict)
-                else {}
-            )
-            remote_sandbox = (
-                case.get("remote_sandbox_contract")
-                if isinstance(case.get("remote_sandbox_contract"), dict)
-                else {}
-            )
-            reducer = case.get("result_reducer") if isinstance(case.get("result_reducer"), dict) else {}
-            lines.append(
-                "- "
-                + f"`{case.get('benchmark_id')}`: command_ready="
-                + f"`{materialization.get('ready')}`, reducer_ready="
-                + f"`{reducer.get('ready')}`, local_driver="
-                + f"`{local_driver.get('ready')}`, remote_sandbox="
-                + f"`{remote_sandbox.get('ready')}`, blockers="
-                + "`"
-                + ",".join(str(item) for item in case.get("blockers", []))
-                + "`"
-            )
-    return "\n".join(lines) + "\n"
 
 def render_terminal_bench_remote_executor_command_adapter_markdown(
     payload: dict[str, object],
@@ -3644,101 +3522,7 @@ def main(argv: list[str] | None = None) -> int:
         help="Skip global registry sync after append.",
     )
 
-    benchmark_artifact_filter_parser = benchmark_sub.add_parser(
-        "classify-artifacts",
-        help=(
-            "Classify benchmark artifact paths before reading them. The classifier "
-            "returns basenames and blocker reasons only; it does not read files or "
-            "echo host directories."
-        ),
-    )
-    add_subcommand_format(benchmark_artifact_filter_parser)
-    benchmark_artifact_filter_parser.add_argument(
-        "artifact_paths",
-        nargs="+",
-        help="Candidate benchmark artifact paths to classify without reading.",
-    )
-    benchmark_artifact_filter_parser.add_argument(
-        "--adapter-kind",
-        default="default",
-        help=(
-            "Benchmark adapter artifact policy key. Unknown values fall back to "
-            "default without recording paths."
-        ),
-    )
-    benchmark_artifact_filter_parser.add_argument(
-        "--allow-public-filename",
-        action="append",
-        default=[],
-        help=(
-            "Additional public compact basename to allow for this classification "
-            "run. Only the basename is used and values are filtered."
-        ),
-    )
-
-    benchmark_candidate_source_parser = benchmark_sub.add_parser(
-        "candidate-source-boundary",
-        help=(
-            "Classify candidate-selection source paths before using them. This "
-            "does not read files or echo host paths; it blocks raw runner roots, "
-            "trial directories, task bodies, trajectories, and Codex transcripts."
-        ),
-    )
-    add_subcommand_format(benchmark_candidate_source_parser)
-    benchmark_candidate_source_parser.add_argument(
-        "source_paths",
-        nargs="+",
-        help="Candidate-selection source paths to classify without reading.",
-    )
-    benchmark_candidate_source_parser.add_argument(
-        "--adapter-kind",
-        default="default",
-        help="Benchmark adapter artifact policy key for compact artifact allowlists.",
-    )
-    benchmark_candidate_source_parser.add_argument(
-        "--allow-public-filename",
-        action="append",
-        default=[],
-        help=(
-            "Additional compact/public basename to allow for this classification "
-            "run. Only the basename is used and values are filtered."
-        ),
-    )
-    benchmark_candidate_source_parser.add_argument(
-        "--require-clean",
-        action="store_true",
-        help="Return non-zero if any source is blocked.",
-    )
-
-    split_control_execution_parser = benchmark_sub.add_parser(
-        "split-control-execution-seam",
-        help=(
-            "Build the public-safe execution seam from split-control readiness "
-            "and command-adapter facts. This does not execute benchmarks."
-        ),
-    )
-    add_subcommand_format(split_control_execution_parser)
-    split_control_execution_parser.add_argument(
-        "--readiness-json",
-        required=True,
-        help=(
-            "Path to a benchmark_split_control_remote_executor_readiness_v0 "
-            "object. Use '-' to read stdin."
-        ),
-    )
-    split_control_execution_parser.add_argument(
-        "--command-adapter-json",
-        help=(
-            "Optional JSON object keyed by benchmark id with "
-            "command_adapter_ready/result_reducer_ready facts. If omitted, "
-            "all launch cases are treated as missing command adapters."
-        ),
-    )
-    split_control_execution_parser.add_argument(
-        "--execution-mode",
-        default="compact_no_upload_dry_run",
-        help="Public-safe execution mode label for runner cases.",
-    )
+    register_benchmark_boundary_commands(benchmark_sub, add_subcommand_format)
 
     terminal_bench_command_adapter_parser = benchmark_sub.add_parser(
         "terminal-bench-command-adapter",
@@ -6901,112 +6685,13 @@ def main(argv: list[str] | None = None) -> int:
                 }
             print_payload(payload, args.format, render_benchmark_run_append_markdown)
             return 0 if payload.get("ok") else 1
-        if args.benchmark_command == "classify-artifacts":
-            payload = filter_public_benchmark_artifact_paths(
-                args.artifact_paths,
-                adapter_kind=args.adapter_kind,
-                extra_public_filenames=args.allow_public_filename,
-            )
-            print_payload(
-                payload,
-                output_format(args),
-                render_benchmark_artifact_path_filter_markdown,
-            )
-            return 0
-        if args.benchmark_command == "candidate-source-boundary":
-            payload = build_benchmark_candidate_source_boundary(
-                args.source_paths,
-                adapter_kind=args.adapter_kind,
-                extra_public_filenames=args.allow_public_filename,
-            )
-            print_payload(
-                payload,
-                output_format(args),
-                render_benchmark_candidate_source_boundary_markdown,
-            )
-            if args.require_clean and not payload.get("clean"):
-                return 1
-            return 0
-        if args.benchmark_command == "split-control-execution-seam":
-            def read_json_arg(path_text: str | None, label: str) -> dict[str, object]:
-                if not path_text:
-                    return {}
-                raw = sys.stdin.read() if path_text == "-" else Path(path_text).expanduser().read_text(encoding="utf-8")
-                loaded = json.loads(raw)
-                if not isinstance(loaded, dict):
-                    raise ValueError(f"{label} must contain a JSON object")
-                return loaded
-
-            try:
-                readiness = read_json_arg(args.readiness_json, "--readiness-json")
-                command_adapter_payload = read_json_arg(
-                    args.command_adapter_json,
-                    "--command-adapter-json",
-                )
-                command_adapters = (
-                    command_adapter_payload.get("command_adapters")
-                    if isinstance(
-                        command_adapter_payload.get("command_adapters"), dict
-                    )
-                    else command_adapter_payload
-                )
-                launch_plan = build_split_control_remote_executor_launch_plan(
-                    readiness
-                )
-                runner_batch = build_split_control_remote_executor_runner_batch(
-                    launch_plan,
-                    fresh_readiness=readiness,
-                    execution_mode=args.execution_mode,
-                )
-                payload = build_split_control_remote_executor_execution_seam(
-                    runner_batch,
-                    command_adapters=command_adapters,
-                )
-                payload["ok"] = True
-                payload["dry_run"] = True
-                payload["read_boundary"] = {
-                    "compact_only": True,
-                    "readiness_json_read": True,
-                    "command_adapter_json_read": bool(args.command_adapter_json),
-                    "command_adapter_wrapper_unwrapped": bool(
-                        args.command_adapter_json
-                        and isinstance(
-                            command_adapter_payload.get("command_adapters"), dict
-                        )
-                    ),
-                    "raw_task_text_read": False,
-                    "raw_logs_read": False,
-                    "trajectory_read": False,
-                    "shell_commands_read": False,
-                    "docker_invoked": False,
-                    "model_api_invoked": False,
-                    "upload_invoked": False,
-                    "submit_invoked": False,
-                }
-            except Exception as exc:
-                payload = {
-                    "ok": False,
-                    "dry_run": True,
-                    "schema_version": "benchmark_split_control_remote_executor_execution_seam_v1",
-                    "error": str(exc),
-                    "read_boundary": {
-                        "compact_only": True,
-                        "raw_task_text_read": False,
-                        "raw_logs_read": False,
-                        "trajectory_read": False,
-                        "shell_commands_read": False,
-                        "docker_invoked": False,
-                        "model_api_invoked": False,
-                        "upload_invoked": False,
-                        "submit_invoked": False,
-                    },
-                }
-            print_payload(
-                payload,
-                output_format(args),
-                render_split_control_execution_seam_markdown,
-            )
-            return 0 if payload.get("ok") else 1
+        benchmark_boundary_result = handle_benchmark_boundary_command(
+            args,
+            print_payload=print_payload,
+            output_format=output_format,
+        )
+        if benchmark_boundary_result is not None:
+            return benchmark_boundary_result
         if args.benchmark_command == "terminal-bench-command-adapter":
             try:
                 if args.benchmark_name != "terminal-bench":

--- a/loopx/cli_commands/__init__.py
+++ b/loopx/cli_commands/__init__.py
@@ -8,6 +8,10 @@ Command modules expose two small functions:
 The top-level CLI keeps global options, registry fallback, and dispatch order.
 """
 
+from .benchmark_boundary import (
+    handle_benchmark_boundary_command,
+    register_benchmark_boundary_commands,
+)
 from .doctor import handle_doctor_command, register_doctor_command
 from .dreaming import handle_dreaming_command, register_dreaming_commands
 from .history import handle_history_command, register_history_command
@@ -44,6 +48,7 @@ from .status import (
 from .todo import handle_todo_command, register_todo_command
 
 __all__ = [
+    "handle_benchmark_boundary_command",
     "handle_check_command",
     "handle_codex_cli_bounded_visible_pilot_adapter_command",
     "handle_codex_cli_bootstrap_message_command",
@@ -72,6 +77,7 @@ __all__ = [
     "handle_review_packet_command",
     "handle_status_command",
     "handle_todo_command",
+    "register_benchmark_boundary_commands",
     "register_doctor_command",
     "register_dreaming_commands",
     "register_history_command",

--- a/loopx/cli_commands/benchmark_boundary.py
+++ b/loopx/cli_commands/benchmark_boundary.py
@@ -1,0 +1,367 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+from ..benchmark_core import (
+    build_benchmark_candidate_source_boundary,
+    build_split_control_remote_executor_execution_seam,
+    build_split_control_remote_executor_launch_plan,
+    build_split_control_remote_executor_runner_batch,
+    filter_public_benchmark_artifact_paths,
+)
+
+
+PrintPayload = Callable[
+    [dict[str, object], str, Callable[[dict[str, object]], str]],
+    None,
+]
+OutputFormat = Callable[[argparse.Namespace], str]
+
+BENCHMARK_BOUNDARY_COMMANDS = {
+    "classify-artifacts",
+    "candidate-source-boundary",
+    "split-control-execution-seam",
+}
+
+
+def render_benchmark_artifact_path_filter_markdown(payload: dict[str, object]) -> str:
+    artifact_policy = (
+        payload.get("artifact_policy")
+        if isinstance(payload.get("artifact_policy"), dict)
+        else {}
+    )
+    lines = [
+        "# Benchmark Artifact Path Filter",
+        "",
+        f"- Schema: `{payload.get('schema_version')}`",
+        f"- Adapter policy: `{artifact_policy.get('adapter_kind')}`",
+        f"- Allowed to read: `{payload.get('allowed_to_read_count')}`",
+        f"- Blocked: `{payload.get('blocked_count')}`",
+        f"- Full paths recorded: `{payload.get('path_recorded')}`",
+    ]
+    allowed = payload.get("allowed_artifact_basenames")
+    if isinstance(allowed, list) and allowed:
+        lines.append("- Allowed basenames: " + ", ".join(f"`{item}`" for item in allowed))
+    blocked = payload.get("blocked_reasons")
+    if isinstance(blocked, dict) and blocked:
+        reasons = ", ".join(f"`{key}`={value}" for key, value in blocked.items())
+        lines.append("- Blocked reasons: " + reasons)
+    return "\n".join(lines) + "\n"
+
+
+def render_benchmark_candidate_source_boundary_markdown(payload: dict[str, object]) -> str:
+    lines = [
+        "# Benchmark Candidate Source Boundary",
+        "",
+        f"- Schema: `{payload.get('schema_version')}`",
+        f"- Clean: `{payload.get('clean')}`",
+        f"- Allowed: `{payload.get('allowed_source_count')}`",
+        f"- Blocked: `{payload.get('blocked_source_count')}`",
+        f"- Paths recorded: `{payload.get('path_recorded')}`",
+    ]
+    blocked = payload.get("blocked_reasons")
+    if isinstance(blocked, dict) and blocked:
+        reasons = ", ".join(f"`{key}`={value}" for key, value in blocked.items())
+        lines.append("- Blocked reasons: " + reasons)
+    if payload.get("next_action"):
+        lines.append(f"- Next action: {payload.get('next_action')}")
+    return "\n".join(lines) + "\n"
+
+
+def render_split_control_execution_seam_markdown(payload: dict[str, object]) -> str:
+    cases = payload.get("execution_cases") if isinstance(payload.get("execution_cases"), list) else []
+    lines = [
+        "# Benchmark Split-Control Execution Seam",
+        "",
+        f"- Schema: `{payload.get('schema_version')}`",
+        f"- Ready to execute: `{payload.get('ready_to_execute')}`",
+        f"- Ready to spend: `{payload.get('ready_to_spend')}`",
+        f"- Cases: `{len(cases)}`",
+    ]
+    blockers = payload.get("blockers")
+    if isinstance(blockers, list) and blockers:
+        lines.append("- Blockers: " + ", ".join(f"`{item}`" for item in blockers))
+    missing_adapters = payload.get("missing_command_adapter_ids")
+    if isinstance(missing_adapters, list) and missing_adapters:
+        lines.append(
+            "- Missing command adapters: "
+            + ", ".join(f"`{item}`" for item in missing_adapters)
+        )
+    missing_reducers = payload.get("missing_result_reducer_ids")
+    if isinstance(missing_reducers, list) and missing_reducers:
+        lines.append(
+            "- Missing result reducers: "
+            + ", ".join(f"`{item}`" for item in missing_reducers)
+        )
+    if payload.get("next_action"):
+        lines.append(f"- Next action: {payload.get('next_action')}")
+    boundary = payload.get("boundary") if isinstance(payload.get("boundary"), dict) else {}
+    lines.extend(
+        [
+            "",
+            "## Boundary",
+            "",
+            f"- Shell commands embedded: `{boundary.get('shell_commands_embedded')}`",
+            f"- argv embedded: `{boundary.get('argv_embedded')}`",
+            f"- raw task text public: `{boundary.get('raw_task_text_public')}`",
+            f"- raw logs public: `{boundary.get('raw_logs_public')}`",
+            f"- upload allowed: `{boundary.get('upload_allowed')}`",
+            f"- submit allowed: `{boundary.get('submit_allowed')}`",
+        ]
+    )
+    if cases:
+        lines.extend(["", "## Cases", ""])
+        for case in cases:
+            if not isinstance(case, dict):
+                continue
+            materialization = (
+                case.get("command_materialization")
+                if isinstance(case.get("command_materialization"), dict)
+                else {}
+            )
+            local_driver = (
+                case.get("local_driver_contract")
+                if isinstance(case.get("local_driver_contract"), dict)
+                else {}
+            )
+            remote_sandbox = (
+                case.get("remote_sandbox_contract")
+                if isinstance(case.get("remote_sandbox_contract"), dict)
+                else {}
+            )
+            reducer = case.get("result_reducer") if isinstance(case.get("result_reducer"), dict) else {}
+            lines.append(
+                "- "
+                + f"`{case.get('benchmark_id')}`: command_ready="
+                + f"`{materialization.get('ready')}`, reducer_ready="
+                + f"`{reducer.get('ready')}`, local_driver="
+                + f"`{local_driver.get('ready')}`, remote_sandbox="
+                + f"`{remote_sandbox.get('ready')}`, blockers="
+                + "`"
+                + ",".join(str(item) for item in case.get("blockers", []))
+                + "`"
+            )
+    return "\n".join(lines) + "\n"
+
+
+def register_benchmark_boundary_commands(
+    benchmark_subparsers: argparse._SubParsersAction,
+    add_subcommand_format: Callable[[argparse.ArgumentParser], None],
+) -> None:
+    benchmark_artifact_filter_parser = benchmark_subparsers.add_parser(
+        "classify-artifacts",
+        help=(
+            "Classify benchmark artifact paths before reading them. The classifier "
+            "returns basenames and blocker reasons only; it does not read files or "
+            "echo host directories."
+        ),
+    )
+    add_subcommand_format(benchmark_artifact_filter_parser)
+    benchmark_artifact_filter_parser.add_argument(
+        "artifact_paths",
+        nargs="+",
+        help="Candidate benchmark artifact paths to classify without reading.",
+    )
+    benchmark_artifact_filter_parser.add_argument(
+        "--adapter-kind",
+        default="default",
+        help=(
+            "Benchmark adapter artifact policy key. Unknown values fall back to "
+            "default without recording paths."
+        ),
+    )
+    benchmark_artifact_filter_parser.add_argument(
+        "--allow-public-filename",
+        action="append",
+        default=[],
+        help=(
+            "Additional public compact basename to allow for this classification "
+            "run. Only the basename is used and values are filtered."
+        ),
+    )
+
+    benchmark_candidate_source_parser = benchmark_subparsers.add_parser(
+        "candidate-source-boundary",
+        help=(
+            "Classify candidate-selection source paths before using them. This "
+            "does not read files or echo host paths; it blocks raw runner roots, "
+            "trial directories, task bodies, trajectories, and Codex transcripts."
+        ),
+    )
+    add_subcommand_format(benchmark_candidate_source_parser)
+    benchmark_candidate_source_parser.add_argument(
+        "source_paths",
+        nargs="+",
+        help="Candidate-selection source paths to classify without reading.",
+    )
+    benchmark_candidate_source_parser.add_argument(
+        "--adapter-kind",
+        default="default",
+        help="Benchmark adapter artifact policy key for compact artifact allowlists.",
+    )
+    benchmark_candidate_source_parser.add_argument(
+        "--allow-public-filename",
+        action="append",
+        default=[],
+        help=(
+            "Additional compact/public basename to allow for this classification "
+            "run. Only the basename is used and values are filtered."
+        ),
+    )
+    benchmark_candidate_source_parser.add_argument(
+        "--require-clean",
+        action="store_true",
+        help="Return non-zero if any source is blocked.",
+    )
+
+    split_control_execution_parser = benchmark_subparsers.add_parser(
+        "split-control-execution-seam",
+        help=(
+            "Build the public-safe execution seam from split-control readiness "
+            "and command-adapter facts. This does not execute benchmarks."
+        ),
+    )
+    add_subcommand_format(split_control_execution_parser)
+    split_control_execution_parser.add_argument(
+        "--readiness-json",
+        required=True,
+        help=(
+            "Path to a benchmark_split_control_remote_executor_readiness_v0 "
+            "object. Use '-' to read stdin."
+        ),
+    )
+    split_control_execution_parser.add_argument(
+        "--command-adapter-json",
+        help=(
+            "Optional JSON object keyed by benchmark id with "
+            "command_adapter_ready/result_reducer_ready facts. If omitted, "
+            "all launch cases are treated as missing command adapters."
+        ),
+    )
+    split_control_execution_parser.add_argument(
+        "--execution-mode",
+        default="compact_no_upload_dry_run",
+        help="Public-safe execution mode label for runner cases.",
+    )
+
+
+def handle_benchmark_boundary_command(
+    args: argparse.Namespace,
+    *,
+    print_payload: PrintPayload,
+    output_format: OutputFormat,
+) -> int | None:
+    if args.benchmark_command not in BENCHMARK_BOUNDARY_COMMANDS:
+        return None
+
+    if args.benchmark_command == "classify-artifacts":
+        payload = filter_public_benchmark_artifact_paths(
+            args.artifact_paths,
+            adapter_kind=args.adapter_kind,
+            extra_public_filenames=args.allow_public_filename,
+        )
+        print_payload(
+            payload,
+            output_format(args),
+            render_benchmark_artifact_path_filter_markdown,
+        )
+        return 0
+
+    if args.benchmark_command == "candidate-source-boundary":
+        payload = build_benchmark_candidate_source_boundary(
+            args.source_paths,
+            adapter_kind=args.adapter_kind,
+            extra_public_filenames=args.allow_public_filename,
+        )
+        print_payload(
+            payload,
+            output_format(args),
+            render_benchmark_candidate_source_boundary_markdown,
+        )
+        if args.require_clean and not payload.get("clean"):
+            return 1
+        return 0
+
+    def read_json_arg(path_text: str | None, label: str) -> dict[str, object]:
+        if not path_text:
+            return {}
+        raw = sys.stdin.read() if path_text == "-" else Path(path_text).expanduser().read_text(encoding="utf-8")
+        loaded = json.loads(raw)
+        if not isinstance(loaded, dict):
+            raise ValueError(f"{label} must contain a JSON object")
+        return loaded
+
+    try:
+        readiness = read_json_arg(args.readiness_json, "--readiness-json")
+        command_adapter_payload = read_json_arg(
+            args.command_adapter_json,
+            "--command-adapter-json",
+        )
+        command_adapters = (
+            command_adapter_payload.get("command_adapters")
+            if isinstance(
+                command_adapter_payload.get("command_adapters"), dict
+            )
+            else command_adapter_payload
+        )
+        launch_plan = build_split_control_remote_executor_launch_plan(
+            readiness
+        )
+        runner_batch = build_split_control_remote_executor_runner_batch(
+            launch_plan,
+            fresh_readiness=readiness,
+            execution_mode=args.execution_mode,
+        )
+        payload = build_split_control_remote_executor_execution_seam(
+            runner_batch,
+            command_adapters=command_adapters,
+        )
+        payload["ok"] = True
+        payload["dry_run"] = True
+        payload["read_boundary"] = {
+            "compact_only": True,
+            "readiness_json_read": True,
+            "command_adapter_json_read": bool(args.command_adapter_json),
+            "command_adapter_wrapper_unwrapped": bool(
+                args.command_adapter_json
+                and isinstance(
+                    command_adapter_payload.get("command_adapters"), dict
+                )
+            ),
+            "raw_task_text_read": False,
+            "raw_logs_read": False,
+            "trajectory_read": False,
+            "shell_commands_read": False,
+            "docker_invoked": False,
+            "model_api_invoked": False,
+            "upload_invoked": False,
+            "submit_invoked": False,
+        }
+    except Exception as exc:
+        payload = {
+            "ok": False,
+            "dry_run": True,
+            "schema_version": "benchmark_split_control_remote_executor_execution_seam_v1",
+            "error": str(exc),
+            "read_boundary": {
+                "compact_only": True,
+                "raw_task_text_read": False,
+                "raw_logs_read": False,
+                "trajectory_read": False,
+                "shell_commands_read": False,
+                "docker_invoked": False,
+                "model_api_invoked": False,
+                "upload_invoked": False,
+                "submit_invoked": False,
+            },
+        }
+    print_payload(
+        payload,
+        output_format(args),
+        render_split_control_execution_seam_markdown,
+    )
+    return 0 if payload.get("ok") else 1


### PR DESCRIPTION
## Summary
- extract benchmark boundary helper subcommands into `loopx.cli_commands.benchmark_boundary`
- move parser, handler, and markdown renderers for `classify-artifacts`, `candidate-source-boundary`, and `split-control-execution-seam`
- keep full benchmark runner/scoring logic in `loopx/cli.py` untouched
- add focused smoke coverage for source shape, help surface, classify JSON output, and split-control error path

## Validation
- `python3 -m py_compile loopx/cli.py loopx/cli_commands/benchmark_boundary.py loopx/cli_commands/__init__.py`
- `python3 examples/cli-benchmark-boundary-command-modularization-smoke.py`
- `python3 examples/cli-history-command-modularization-smoke.py`
- `python3 examples/cli-control-plane-command-modularization-smoke.py`
- `python3 examples/project-agent-adoption-smoke.py`
- `python3 examples/demo-cli-smoke.py`
- `git diff --check`
- `loopx check --scan-path loopx/cli.py --scan-path loopx/cli_commands/__init__.py --scan-path loopx/cli_commands/benchmark_boundary.py --scan-path examples/cli-benchmark-boundary-command-modularization-smoke.py`

`loopx check` reported only the pre-existing duplicate index rows warning for `loopx-meta`.