### PR TITLE
docs: map frontend kernel state to user mental model

### DIFF
--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -43,6 +43,10 @@ runtime contract, benchmark route, or launch draft.
   the two-surface frontend rule for keeping public showcase/homepage work fancy
   and case-driven while the real ops control-plane route stays dense, calm,
   read-only, and reviewable.
+- [Frontend kernel-to-mental-model map](frontend-kernel-mental-model-map.md):
+  interaction contract for compressing kernel concepts such as goals, gates,
+  todos, claims, scope, evidence, run history, quota, and handoff into five
+  user-facing concepts on the ops surface.
 - [Codex CLI automation driver audit](codex-cli-automation-driver.md): the
   current Codex CLI scheduler/session surface audit, with a conservative local
   driver planner that keeps TUI bootstrap primary, composes quota/idle/fallback

--- a/docs/product/frontend-kernel-mental-model-map.md
+++ b/docs/product/frontend-kernel-mental-model-map.md
@@ -1,0 +1,136 @@
+# Frontend Kernel-to-Mental-Model Map
+
+LoopX needs a rich kernel because long-running agent work has real failure
+modes: drifting goals, hidden gates, duplicated work, stale evidence, lost
+handoffs, and uncontrolled compute. The frontend should not expose that kernel
+as the user's everyday vocabulary.
+
+The product rule is:
+
+> Keep the kernel explicit for correctness, but compress it into a smaller
+> mental model for daily operation.
+
+## Five User Concepts
+
+The default management surface should teach only five concepts.
+
+| User concept | User question | Primary UI job |
+| --- | --- | --- |
+| Goal | What are we trying to achieve now? | Show current objective, boundary, and selected anchor. |
+| Next step | What will the agent do next? | Show one bounded action plus a few nearby candidates when useful. |
+| Blocker / permission | Where is human judgment required or forbidden? | Show concrete decisions, gates, and safety boundaries. |
+| Evidence | Why should I believe progress happened? | Show compact validation, artifacts, and confidence. |
+| Continue state | Can I hand this back to the agent? | Show run/wait/observe/repair/handoff readiness. |
+
+Every top-level card, navigation label, and empty state in the ops surface
+should map to one of these concepts.
+
+## Kernel Concepts
+
+The kernel can keep the concepts it needs for correctness.
+
+| Kernel concept | Why it exists | Default exposure |
+| --- | --- | --- |
+| `goal_state` | Durable truth about objective, boundary, and current belief. | Compressed into **Goal**. |
+| `user_gate` | Human decision boundary that the agent cannot cross. | Visible only when action is needed, under **Blocker / permission**. |
+| `todo` | Executable work units and owner/user tasks. | Visible as **Next step** plus a small queue. |
+| `claim` | Multi-agent collision avoidance. | Hidden by default; show as lane owner or diagnostic detail. |
+| `scope` | What a specific agent can and cannot do. | Summarized under agent lane or blocker detail. |
+| `evidence` | Proof that a state transition is trustworthy. | Visible as compact **Evidence**. |
+| `run_history` | Audit log and replay/debug substrate. | Folded behind evidence or diagnostics. |
+| `quota` | Whether an automatic turn may spend compute now. | Rendered as **Continue state**, not raw counters. |
+| `handoff` | Context package for the next loop or agent. | Rendered only when copying, resuming, or debugging. |
+
+These objects are not redundant. They separate truth, work, authority,
+ownership, proof, compute, and transfer. The UI's job is to prevent users from
+paying that complexity cost unless they are debugging.
+
+## Projection Contract
+
+The read model should provide an explicit compression layer instead of letting
+each component invent labels.
+
+```yaml
+mental_model_projection_v0:
+  goal:
+    title: "Current objective"
+    boundary_summary: "What is in and out of scope"
+    anchor: "Optional selected proof path"
+  next_step:
+    primary_action: "One bounded action"
+    nearby_candidates: ["Optional small queue"]
+    selected_reason: "Why this action is first"
+  blocker_permission:
+    status: clear | needs_user | forbidden | needs_repair
+    concrete_question: "Only when needs_user"
+    boundary_reason: "Only when forbidden or needs_repair"
+  evidence:
+    latest_summary: "Compact validation or artifact pointer"
+    confidence: strong | partial | missing
+    drilldown_ref: "Run or artifact id"
+  continue_state:
+    status: can_run | waiting | observe_only | needs_repair | handoff_ready
+    reason: "Short operator-readable reason"
+    next_safe_transition: "Optional CLI/control-plane transition"
+  diagnostics:
+    goal_state_ref: "debug only"
+    todo_ids: ["debug/search"]
+    claims: ["debug/multi-agent"]
+    quota_ref: "debug only"
+    run_history_refs: ["debug/audit"]
+```
+
+The same kernel source can still power search, debug, and audit views. The
+default surface should read from the compressed fields first.
+
+## Interaction Rules
+
+- Default navigation and first-screen headings should use the five user
+  concepts, not kernel names.
+- Search can still accept todo ids, run ids, agent ids, and kernel terms because
+  debugging needs exact handles.
+- `claim`, `quota`, `scope`, and `handoff` should appear as detail chips,
+  tooltips, or diagnostic rows unless they require user action.
+- A user gate is not a generic "owner gate"; it must show the concrete decision
+  and the consequence of approving, rejecting, or deferring.
+- Evidence should be compact by default and link to audit details. Raw logs,
+  private traces, local paths, and sensitive material must not appear in public
+  fixtures.
+- A continue state should never say "run" only because quota allows compute. It
+  must also respect gates, scope, write boundary, and evidence requirements.
+- Review-feed cards should produce feedback in user language, then map it back
+  to typed events such as `review_event_v0`, `feedback_signal_v0`, or
+  `todo_update`.
+
+## Dashboard Layout Implication
+
+For the ops surface, a simple first screen is:
+
+1. **Goal**: objective, active anchor, and boundary summary.
+2. **Next step**: selected action, a small todo queue, and why it was selected.
+3. **Needs your judgment**: concrete user gates and forbidden actions.
+4. **Evidence**: last validated result, confidence, and artifact pointer.
+5. **Can continue?**: run/wait/observe/repair/handoff state.
+
+Diagnostics can sit behind expandable panels:
+
+- todo explorer;
+- agent lane details;
+- claims and scope;
+- quota and run history;
+- handoff packet.
+
+This keeps LoopX honest for long-running work while making the product feel like
+a management surface, not a schema browser.
+
+## Acceptance Criteria
+
+The frontend mapping is acceptable when:
+
+- a new user can explain the first screen using the five concepts above;
+- every visible kernel label has a reason to be visible, such as search,
+  debugging, or an active user decision;
+- all diagnostic expansion still preserves exact ids for audit and recovery;
+- the same projection can represent one project, all projects, and
+  multi-agent lanes;
+- review-feed actions use user-facing labels but write typed LoopX events.

--- a/docs/product/frontstage-dashboard-interaction-baseline.md
+++ b/docs/product/frontstage-dashboard-interaction-baseline.md
@@ -54,9 +54,15 @@ The showcase surface can be fancy because it is not an operator cockpit.
 
 The ops surface should feel like a working console, not a landing page.
 
+- Map kernel state into the five user concepts from
+  [Frontend kernel-to-mental-model map](frontend-kernel-mental-model-map.md):
+  goal, next step, blocker/permission, evidence, and continue state.
 - Keep the first screen scannable: goal header, decision frame, quota guard,
   user todo lane, agent todo lane, claims, gates, artifacts, source warnings,
   and run timeline.
+- Avoid making `claim`, `scope`, `quota`, `run_history`, or `handoff` top-level
+  user vocabulary unless the user is searching, debugging, or resolving a live
+  decision.
 - Prefer rows, strips, filters, and compact panes over large hero sections.
 - Preserve URL-backed search and lane filters so a review can reproduce the
   exact projected slice.

--- a/docs/product/intelligent-management-surface.md
+++ b/docs/product/intelligent-management-surface.md
@@ -174,6 +174,7 @@ The surface should grow from explicit contracts rather than UI-only state.
 | `feedback_signal_v0` | A normalized effect: gate decision, preference hint, todo mutation, reward, or product note. |
 | `performance_review_v0` | Periodic lane-level review of output, quality, cost, attention, and next expectation. |
 | `management_projection_v0` | Read model joining goals, lanes, anchors, gates, todos, evidence, and review feed. |
+| `mental_model_projection_v0` | User-facing compression of kernel state into goal, next step, blocker/permission, evidence, and continue state. |
 
 The existing LoopX objects remain the source of truth for control: goal,
 gate, todo, quota, evidence, run history, handoff, and boundary. The management


### PR DESCRIPTION
## Summary
- add a frontend kernel-to-mental-model map that compresses LoopX kernel concepts into five user-facing concepts
- link the contract from product direction docs
- update the dashboard interaction baseline and management surface contract to use the projection

## Validation
- loopx check --scan-path docs/product/frontend-kernel-mental-model-map.md --scan-path docs/product/README.md --scan-path docs/product/frontstage-dashboard-interaction-baseline.md --scan-path docs/product/intelligent-management-surface.md
- git diff --check HEAD~1..HEAD
- public/private boundary scan over added lines