### PR TITLE
Refactor benchmark review gate CLI commands

### DIFF
--- a/examples/cli-benchmark-review-lifecycle-command-modularization-smoke.py
+++ b/examples/cli-benchmark-review-lifecycle-command-modularization-smoke.py
@@ -36,11 +36,21 @@ def main() -> int:
     ).read_text(encoding="utf-8")
 
     leaked_markers = [
+        "benchmark_baseline_gate_parser = benchmark_sub.add_parser",
         "benchmark_claim_review_parser = benchmark_sub.add_parser",
         "benchmark_lifecycle_state_parser = benchmark_sub.add_parser",
+        "benchmark_runner_invariant_parser = benchmark_sub.add_parser",
+        "benchmark_verifier_attribution_parser = benchmark_sub.add_parser",
         "def render_benchmark_claim_review_markdown",
+        "def render_benchmark_baseline_failure_gate_markdown",
+        "build_benchmark_baseline_failure_gate_comparison(",
         "build_benchmark_claim_review(",
+        "build_benchmark_runner_invariant_review(",
+        "build_benchmark_verifier_attribution_review(",
+        'if args.benchmark_command == "baseline-failure-gate":',
         'if args.benchmark_command == "review-claim":',
+        'if args.benchmark_command == "review-runner-invariants":',
+        'if args.benchmark_command == "review-verifier-attribution":',
     ]
     for marker in leaked_markers:
         if marker in cli_source:
@@ -53,13 +63,32 @@ def main() -> int:
     assert_contains(init_source, "register_benchmark_review_lifecycle_commands")
     assert_contains(init_source, "handle_benchmark_review_lifecycle_command")
     assert_contains(module_source, "BENCHMARK_REVIEW_LIFECYCLE_COMMANDS")
+    assert_contains(module_source, "baseline-failure-gate")
     assert_contains(module_source, "lifecycle-state")
+    assert_contains(module_source, "review-runner-invariants")
+    assert_contains(module_source, "review-verifier-attribution")
 
     help_result = run_cli("benchmark", "review-claim", "--help")
     if help_result.returncode != 0:
         raise AssertionError(help_result.stderr or help_result.stdout)
     assert_contains(help_result.stdout, "--benchmark-comparison-json")
     assert_contains(help_result.stdout, "--benchmark-run-json")
+
+    baseline_help = run_cli("benchmark", "baseline-failure-gate", "--help")
+    if baseline_help.returncode != 0:
+        raise AssertionError(baseline_help.stderr or baseline_help.stdout)
+    assert_contains(baseline_help.stdout, "--baseline-result-json")
+    assert_contains(baseline_help.stdout, "--trace-publicness-verified")
+
+    verifier_help = run_cli("benchmark", "review-verifier-attribution", "--help")
+    if verifier_help.returncode != 0:
+        raise AssertionError(verifier_help.stderr or verifier_help.stdout)
+    assert_contains(verifier_help.stdout, "--benchmark-run-json")
+
+    runner_help = run_cli("benchmark", "review-runner-invariants", "--help")
+    if runner_help.returncode != 0:
+        raise AssertionError(runner_help.stderr or runner_help.stdout)
+    assert_contains(runner_help.stdout, "--expect-compact-only")
 
     kwarg_result = run_cli(
         "benchmark",
@@ -109,6 +138,84 @@ def main() -> int:
     if gate_payload.get("ok") is not False:
         raise AssertionError(gate_payload)
     assert_contains(str(gate_payload.get("error")), "No such file")
+
+    generated_run_result = run_cli(
+        "--format",
+        "json",
+        "benchmark",
+        "run",
+        "terminal-bench",
+        "--goal-id",
+        "loopx-meta",
+        "--no-global-sync",
+    )
+    if generated_run_result.returncode != 0:
+        raise AssertionError(generated_run_result.stderr or generated_run_result.stdout)
+    benchmark_run = json.loads(generated_run_result.stdout)["benchmark_run"]
+    with tempfile.TemporaryDirectory() as temp_dir:
+        run_json = Path(temp_dir) / "benchmark-run.json"
+        run_json.write_text(json.dumps(benchmark_run), encoding="utf-8")
+
+        runner_result = run_cli(
+            "--format",
+            "json",
+            "benchmark",
+            "review-runner-invariants",
+            "--benchmark-run-json",
+            str(run_json),
+        )
+        if runner_result.returncode != 0:
+            raise AssertionError(runner_result.stderr or runner_result.stdout)
+        runner_payload = json.loads(runner_result.stdout)
+        if runner_payload.get("ok") is not True:
+            raise AssertionError(runner_payload)
+        if runner_payload.get("schema_version") != "benchmark_runner_invariant_review_v0":
+            raise AssertionError(runner_payload)
+        if runner_payload["read_boundary"].get("raw_artifacts_read") is not False:
+            raise AssertionError(runner_payload)
+
+        verifier_result = run_cli(
+            "--format",
+            "json",
+            "benchmark",
+            "review-verifier-attribution",
+            "--benchmark-run-json",
+            str(run_json),
+        )
+        if verifier_result.returncode != 0:
+            raise AssertionError(verifier_result.stderr or verifier_result.stdout)
+        verifier_payload = json.loads(verifier_result.stdout)
+        if verifier_payload.get("ok") is not True:
+            raise AssertionError(verifier_payload)
+        if verifier_payload.get("reviewed_run_count") != 1:
+            raise AssertionError(verifier_payload)
+
+        baseline_result = run_cli(
+            "--format",
+            "json",
+            "benchmark",
+            "baseline-failure-gate",
+            "--benchmark-id",
+            "terminal-bench@2.0",
+            "--baseline-result-json",
+            str(run_json),
+            "--control-plane-addressable",
+            "--same-task-semantics",
+            "--same-runner-protocol",
+            "--trace-publicness-verified",
+            "--no-global-sync",
+        )
+        if baseline_result.returncode != 0:
+            raise AssertionError(baseline_result.stderr or baseline_result.stdout)
+        baseline_payload = json.loads(baseline_result.stdout)
+        if baseline_payload.get("ok") is not True:
+            raise AssertionError(baseline_payload)
+        if baseline_payload.get("appended") is not False:
+            raise AssertionError(baseline_payload)
+        if baseline_payload["baseline_gate_cli"].get("source") != "compact_benchmark_run_v0":
+            raise AssertionError(baseline_payload)
+        if str(run_json) in json.dumps(baseline_payload):
+            raise AssertionError("baseline gate payload leaked the local fixture path")
 
     print("cli-benchmark-review-lifecycle-command-modularization-smoke: ok")
     return 0

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -26,12 +26,6 @@ from .bootstrap import (
     bootstrap_project,
     render_bootstrap_markdown,
 )
-from .benchmark import (
-    benchmark_result_from_benchmark_run_for_baseline_gate,
-    build_benchmark_baseline_failure_gate_comparison,
-    build_benchmark_runner_invariant_review,
-    build_benchmark_verifier_attribution_review,
-)
 from .benchmark_core import (
     build_split_control_remote_executor_readiness,
 )
@@ -94,11 +88,9 @@ from .feedback import append_human_reward, compact_reward, render_reward_markdow
 from .global_registry import render_global_sync_markdown, sync_project_registry_to_global
 from .heartbeat_prompt import build_heartbeat_prompt, render_heartbeat_prompt_markdown
 from .history import (
-    append_benchmark_comparison,
     append_benchmark_run,
     collect_history,
     load_registry,
-    render_benchmark_comparison_append_markdown,
     render_benchmark_run_append_markdown,
 )
 from .operator_gate import (
@@ -144,8 +136,6 @@ from .state_migration import (
     render_state_migration_markdown,
 )
 from .status import (
-    compact_benchmark_comparison,
-    compact_benchmark_result,
     compact_benchmark_run,
     render_status_markdown,
 )
@@ -208,40 +198,6 @@ def build_version_payload() -> dict[str, object]:
 
 def render_version_markdown(payload: dict[str, object]) -> str:
     return f"{payload.get('name')} {payload.get('version')}\n"
-
-
-def render_benchmark_baseline_failure_gate_markdown(payload: dict[str, object]) -> str:
-    comparison = (
-        payload.get("benchmark_comparison")
-        if isinstance(payload.get("benchmark_comparison"), dict)
-        else {}
-    )
-    gate = (
-        comparison.get("baseline_failure_gate")
-        if isinstance(comparison.get("baseline_failure_gate"), dict)
-        else {}
-    )
-    lines = [
-        "# Benchmark Baseline Failure Gate",
-        "",
-        f"- ok: `{payload.get('ok')}`",
-        f"- dry_run: `{payload.get('dry_run')}`",
-        f"- appended: `{payload.get('appended')}`",
-        f"- goal_id: `{payload.get('goal_id')}`",
-        f"- benchmark_id: `{comparison.get('benchmark_id')}`",
-        f"- task_id: `{comparison.get('task_id')}`",
-        f"- baseline_failed: `{gate.get('baseline_failed')}`",
-        f"- control_plane_addressable: `{gate.get('control_plane_addressable')}`",
-        f"- treatment_eligible: `{gate.get('treatment_eligible')}`",
-        f"- failure_class: `{gate.get('failure_class')}`",
-    ]
-    if gate.get("minimum_next_evidence"):
-        lines.append(f"- minimum_next_evidence: {gate.get('minimum_next_evidence')}")
-    if gate.get("negative_selection_reason"):
-        lines.append(f"- negative_selection_reason: {gate.get('negative_selection_reason')}")
-    if payload.get("error"):
-        lines.append(f"- error: {payload.get('error')}")
-    return "\n".join(lines) + "\n"
 
 
 def add_subcommand_format(arg_parser: argparse.ArgumentParser) -> None:
@@ -1551,185 +1507,8 @@ def main(argv: list[str] | None = None) -> int:
 
     register_agents_last_exam_commands(benchmark_sub, add_subcommand_format)
 
-    benchmark_baseline_gate_parser = benchmark_sub.add_parser(
-        "baseline-failure-gate",
-        help=(
-            "Reduce a compact goal-mode baseline benchmark_result_v0 or benchmark_run_v0 into a "
-            "benchmark_comparison_v0 baseline-failure gate. This reads only "
-            "compact JSON, not raw task text, logs, traces, Harbor job "
-            "directories, Docker, model APIs, uploads, screenshots, or credentials."
-        ),
-    )
-    add_subcommand_format(benchmark_baseline_gate_parser)
-    benchmark_baseline_gate_parser.add_argument(
-        "--goal-id",
-        help="Goal id for optional append context. Required with --execute.",
-    )
-    benchmark_baseline_gate_parser.add_argument(
-        "--benchmark-id",
-        required=True,
-        help="Public-safe benchmark id for the comparison row.",
-    )
-    benchmark_baseline_gate_parser.add_argument(
-        "--baseline-result-json",
-        required=True,
-        help=(
-            "Path to a compact benchmark_result_v0 or benchmark_run_v0 JSON object. "
-            "Use '-' to read stdin."
-        ),
-    )
-    benchmark_baseline_gate_parser.add_argument(
-        "--baseline-mode",
-        default="codex_cli_goal_mode",
-        help="Public-safe baseline mode label.",
-    )
-    benchmark_baseline_gate_parser.add_argument(
-        "--treatment-scenario-id",
-        default="codex_loopx",
-        help="Public-safe treatment scenario id planned after the gate.",
-    )
-    benchmark_baseline_gate_parser.add_argument("--comparison-id")
-    benchmark_baseline_gate_parser.add_argument("--failure-phase")
-    benchmark_baseline_gate_parser.add_argument("--failure-class")
-    benchmark_baseline_gate_parser.add_argument(
-        "--failure-attribution-label",
-        action="append",
-        default=[],
-        help="Public-safe failure attribution label. Repeat as needed.",
-    )
-    benchmark_baseline_gate_parser.add_argument(
-        "--control-plane-addressable",
-        action="store_true",
-        help="Mark the baseline failure as plausibly fixable by LoopX control-plane intervention.",
-    )
-    benchmark_baseline_gate_parser.add_argument(
-        "--same-task-semantics",
-        action="store_true",
-        help="Confirm treatment will use the same benchmark task semantics.",
-    )
-    benchmark_baseline_gate_parser.add_argument(
-        "--same-runner-protocol",
-        action="store_true",
-        help="Confirm treatment will use the same runner protocol.",
-    )
-    benchmark_baseline_gate_parser.add_argument(
-        "--trace-publicness-verified",
-        action="store_true",
-        help="Confirm the compact result excludes private raw trace material.",
-    )
-    benchmark_baseline_gate_parser.add_argument(
-        "--baseline-attempt-count",
-        type=int,
-        default=1,
-        help="Number of baseline attempts represented by this gate.",
-    )
-    benchmark_baseline_gate_parser.add_argument("--minimum-next-evidence")
-    benchmark_baseline_gate_parser.add_argument("--negative-selection-reason")
-    benchmark_baseline_gate_parser.add_argument("--next-action")
-    benchmark_baseline_gate_parser.add_argument(
-        "--evidence-ref",
-        action="append",
-        default=[],
-        help="Public-safe compact evidence reference. Repeat as needed.",
-    )
-    benchmark_baseline_gate_parser.add_argument("--classification")
-    benchmark_baseline_gate_parser.add_argument("--recommended-action")
-    benchmark_baseline_gate_parser.add_argument(
-        "--delivery-batch-scale",
-        choices=DELIVERY_BATCH_SCALE_CHOICES,
-        help="Optional delivery scale label for the run index.",
-    )
-    benchmark_baseline_gate_parser.add_argument(
-        "--delivery-outcome",
-        choices=DELIVERY_OUTCOME_CHOICES,
-        help="Optional delivery outcome label for the run index.",
-    )
-    benchmark_baseline_gate_parser.add_argument("--dry-run", action="store_true", help="Preview without writing. This is the default.")
-    benchmark_baseline_gate_parser.add_argument("--execute", action="store_true", help="Append the compact baseline gate comparison.")
-    benchmark_baseline_gate_parser.add_argument("--no-global-sync", action="store_true", help="Skip global registry sync after append.")
-
     register_benchmark_review_lifecycle_commands(benchmark_sub, add_subcommand_format)
     register_terminal_bench_environment_result_commands(benchmark_sub, add_subcommand_format)
-
-    benchmark_verifier_attribution_parser = benchmark_sub.add_parser(
-        "review-verifier-attribution",
-        help=(
-            "Review compact benchmark_run_v0 verifier attribution and decide "
-            "whether a score-failure caveat is resolved without opening raw logs, "
-            "task text, traces, Harbor job directories, Docker, model APIs, or uploads."
-        ),
-    )
-    add_subcommand_format(benchmark_verifier_attribution_parser)
-    benchmark_verifier_attribution_parser.add_argument(
-        "--benchmark-run-json",
-        action="append",
-        required=True,
-        help=(
-            "Path to a compact benchmark_run_v0 JSON object. Repeat for baseline "
-            "and treatment compact run files."
-        ),
-    )
-
-    benchmark_runner_invariant_parser = benchmark_sub.add_parser(
-        "review-runner-invariants",
-        help=(
-            "Review compact benchmark_run_v0 runner-owned boundary invariants "
-            "before trusting worker writeback. This reads only compact JSON, not "
-            "raw task text, logs, traces, Harbor job directories, Docker, model "
-            "APIs, uploads, or screenshots."
-        ),
-    )
-    add_subcommand_format(benchmark_runner_invariant_parser)
-    benchmark_runner_invariant_parser.add_argument(
-        "--benchmark-run-json",
-        required=True,
-        help="Path to a compact benchmark_run_v0 JSON object.",
-    )
-    benchmark_runner_invariant_parser.add_argument(
-        "--runner-label",
-        help="Public-safe runner label to include in the review payload.",
-    )
-    benchmark_runner_invariant_parser.add_argument(
-        "--expect-submit-eligible",
-        choices=["true", "false"],
-        default="false",
-        help="Expected runner-owned submit_eligible value. Defaults to false.",
-    )
-    benchmark_runner_invariant_parser.add_argument(
-        "--expect-leaderboard-evidence",
-        choices=["true", "false"],
-        default="false",
-        help="Expected runner-owned leaderboard_evidence value. Defaults to false.",
-    )
-    benchmark_runner_invariant_parser.add_argument(
-        "--expect-compact-only",
-        choices=["true", "false"],
-        default="true",
-        help="Expected compact read boundary. Defaults to true.",
-    )
-    benchmark_runner_invariant_parser.add_argument(
-        "--expect-raw-artifacts-read",
-        choices=["true", "false"],
-        default="false",
-        help="Expected raw artifact read boundary. Defaults to false.",
-    )
-    benchmark_runner_invariant_parser.add_argument(
-        "--expect-task-text-read",
-        choices=["true", "false"],
-        default="false",
-        help="Expected task text read boundary. Defaults to false.",
-    )
-    benchmark_runner_invariant_parser.add_argument(
-        "--expect-local-paths-recorded",
-        choices=["true", "false"],
-        default="false",
-        help="Expected local path recording boundary. Defaults to false.",
-    )
-    benchmark_runner_invariant_parser.add_argument(
-        "--require-clean",
-        action="store_true",
-        help="Return non-zero unless all runner-owned invariant fields match.",
-    )
 
     archive_runtime_parser = sub.add_parser(
         "archive-runtime",
@@ -2740,6 +2519,7 @@ def main(argv: list[str] | None = None) -> int:
             return agents_last_exam_result
         benchmark_review_lifecycle_result = handle_benchmark_review_lifecycle_command(
             args,
+            registry_path=registry_path,
             print_payload=print_payload,
             output_format=output_format,
         )
@@ -2761,241 +2541,6 @@ def main(argv: list[str] | None = None) -> int:
         )
         if benchmark_run_ledger_result is not None:
             return benchmark_run_ledger_result
-        if args.benchmark_command == "review-verifier-attribution":
-            try:
-                runs = []
-                for run_json in args.benchmark_run_json:
-                    run_input = json.loads(Path(run_json).expanduser().read_text(encoding="utf-8"))
-                    if not isinstance(run_input, dict):
-                        raise ValueError("--benchmark-run-json must contain JSON objects")
-                    run = compact_benchmark_run(run_input)
-                    if not run:
-                        raise ValueError(
-                            "--benchmark-run-json did not contain a compactable benchmark_run_v0 object"
-                        )
-                    runs.append(run)
-                payload = build_benchmark_verifier_attribution_review(
-                    benchmark_runs=runs,
-                )
-            except Exception as exc:
-                payload = {
-                    "ok": False,
-                    "schema_version": "benchmark_verifier_attribution_review_v0",
-                    "error": str(exc),
-                    "read_boundary": {
-                        "compact_only": True,
-                        "raw_artifacts_read": False,
-                        "task_text_read": False,
-                        "local_paths_recorded": False,
-                    },
-                }
-            else:
-                payload["ok"] = True
-            print_payload(
-                payload,
-                output_format(args),
-                render_benchmark_verifier_attribution_review_markdown,
-            )
-            return 0 if payload.get("ok") else 1
-        if args.benchmark_command == "review-runner-invariants":
-            try:
-                run_input = json.loads(
-                    Path(args.benchmark_run_json).expanduser().read_text(encoding="utf-8")
-                )
-                if not isinstance(run_input, dict):
-                    raise ValueError("--benchmark-run-json must contain a JSON object")
-                run = compact_benchmark_run(run_input)
-                if not run:
-                    raise ValueError(
-                        "--benchmark-run-json did not contain a compactable benchmark_run_v0 object"
-                    )
-                payload = build_benchmark_runner_invariant_review(
-                    run,
-                    expected_flags={
-                        "submit_eligible": args.expect_submit_eligible == "true",
-                        "leaderboard_evidence": args.expect_leaderboard_evidence
-                        == "true",
-                    },
-                    expected_read_boundary={
-                        "compact_only": args.expect_compact_only == "true",
-                        "raw_artifacts_read": args.expect_raw_artifacts_read
-                        == "true",
-                        "task_text_read": args.expect_task_text_read == "true",
-                        "local_paths_recorded": args.expect_local_paths_recorded
-                        == "true",
-                    },
-                    runner_label=args.runner_label,
-                )
-                payload["ok"] = True
-                if args.require_clean and payload.get("clean") is not True:
-                    payload["ok"] = False
-                    payload["error"] = payload.get("classification") or (
-                        "benchmark_runner_invariant_review_not_clean"
-                    )
-                payload["require_clean"] = bool(args.require_clean)
-            except Exception as exc:
-                payload = {
-                    "ok": False,
-                    "schema_version": "benchmark_runner_invariant_review_v0",
-                    "error": str(exc),
-                    "read_boundary": {
-                        "compact_only": True,
-                        "raw_artifacts_read": False,
-                        "task_text_read": False,
-                        "local_paths_recorded": False,
-                    },
-                }
-            print_payload(
-                payload,
-                output_format(args),
-                render_benchmark_runner_invariant_review_markdown,
-            )
-            return 0 if payload.get("ok") else 1
-        if args.benchmark_command == "baseline-failure-gate":
-            try:
-                if args.dry_run and args.execute:
-                    raise ValueError(
-                        "benchmark baseline-failure-gate accepts either --dry-run or --execute, not both"
-                    )
-                if args.execute and not args.goal_id:
-                    raise ValueError(
-                        "benchmark baseline-failure-gate requires --goal-id with --execute"
-                    )
-                if args.baseline_result_json == "-":
-                    baseline_result_input = json.loads(sys.stdin.read())
-                else:
-                    baseline_result_input = json.loads(
-                        Path(args.baseline_result_json)
-                        .expanduser()
-                        .read_text(encoding="utf-8")
-                    )
-                if not isinstance(baseline_result_input, dict):
-                    raise ValueError("--baseline-result-json must contain a JSON object")
-                baseline_result = compact_benchmark_result(baseline_result_input)
-                baseline_gate_source = "compact_benchmark_result_v0"
-                if not baseline_result:
-                    benchmark_run = compact_benchmark_run(baseline_result_input)
-                    if benchmark_run:
-                        baseline_result = (
-                            benchmark_result_from_benchmark_run_for_baseline_gate(
-                                benchmark_run
-                            )
-                        )
-                        baseline_gate_source = "compact_benchmark_run_v0"
-                    else:
-                        raise ValueError(
-                            "--baseline-result-json did not contain a compactable benchmark_result_v0 or benchmark_run_v0 object"
-                        )
-                comparison_input = build_benchmark_baseline_failure_gate_comparison(
-                    baseline_result=baseline_result,
-                    benchmark_id=args.benchmark_id,
-                    baseline_mode=args.baseline_mode,
-                    treatment_scenario_id=args.treatment_scenario_id,
-                    comparison_id=args.comparison_id,
-                    failure_phase=args.failure_phase,
-                    failure_class=args.failure_class,
-                    failure_attribution_labels=args.failure_attribution_label,
-                    control_plane_addressable=bool(args.control_plane_addressable),
-                    same_task_semantics=bool(args.same_task_semantics),
-                    same_runner_protocol=bool(args.same_runner_protocol),
-                    trace_publicness_verified=bool(args.trace_publicness_verified),
-                    baseline_attempt_count=args.baseline_attempt_count,
-                    minimum_next_evidence=args.minimum_next_evidence,
-                    negative_selection_reason=args.negative_selection_reason,
-                    next_action=args.next_action,
-                    evidence_refs=args.evidence_ref,
-                )
-                comparison = compact_benchmark_comparison(comparison_input)
-                if not comparison:
-                    raise ValueError(
-                        "baseline gate reducer did not produce a compactable benchmark_comparison_v0 object"
-                    )
-                dry_run = not bool(args.execute)
-                if args.execute:
-                    payload = append_benchmark_comparison(
-                        registry_path=registry_path,
-                        runtime_root_override=args.runtime_root,
-                        goal_id=args.goal_id,
-                        benchmark_comparison=comparison,
-                        classification=args.classification
-                        or "benchmark_comparison_v0",
-                        recommended_action=args.recommended_action
-                        or (
-                            comparison.get("next_action")
-                            if isinstance(comparison.get("next_action"), str)
-                            else None
-                        )
-                        or "route the baseline failure gate before any treatment run",
-                        delivery_batch_scale=args.delivery_batch_scale,
-                        delivery_outcome=args.delivery_outcome,
-                        dry_run=False,
-                    )
-                    if args.no_global_sync:
-                        payload["global_sync"] = {
-                            "ok": True,
-                            "dry_run": False,
-                            "skipped": True,
-                            "reason": "disabled by --no-global-sync",
-                        }
-                    else:
-                        payload["global_sync"] = sync_project_registry_to_global(
-                            registry_path=registry_path,
-                            runtime_root_override=args.runtime_root,
-                            goal_id=args.goal_id,
-                            dry_run=False,
-                        )
-                else:
-                    payload = {
-                        "ok": True,
-                        "dry_run": dry_run,
-                        "appended": False,
-                        "goal_id": args.goal_id,
-                        "classification": args.classification
-                        or "benchmark_comparison_v0",
-                        "benchmark_comparison": comparison,
-                    }
-                payload["baseline_gate_cli"] = {
-                    "source": baseline_gate_source,
-                    "accepted_schemas": [
-                        "benchmark_result_v0",
-                        "benchmark_run_v0",
-                    ],
-                    "raw_artifacts_read": False,
-                    "task_text_read": False,
-                    "local_paths_recorded": False,
-                    "docker_invoked": False,
-                    "model_api_invoked": False,
-                    "upload_invoked": False,
-                }
-            except Exception as exc:
-                payload = {
-                    "ok": False,
-                    "dry_run": not bool(getattr(args, "execute", False)),
-                    "appended": False,
-                    "goal_id": getattr(args, "goal_id", None),
-                    "classification": getattr(args, "classification", None)
-                    or "benchmark_comparison_v0",
-                    "error": str(exc),
-                    "baseline_gate_cli": {
-                        "source": "compact_benchmark_result_v0_or_benchmark_run_v0",
-                        "accepted_schemas": [
-                            "benchmark_result_v0",
-                            "benchmark_run_v0",
-                        ],
-                        "raw_artifacts_read": False,
-                        "task_text_read": False,
-                        "local_paths_recorded": False,
-                        "docker_invoked": False,
-                        "model_api_invoked": False,
-                        "upload_invoked": False,
-                    },
-                }
-            print_payload(
-                payload,
-                output_format(args),
-                render_benchmark_baseline_failure_gate_markdown,
-            )
-            return 0 if payload.get("ok") else 1
     if args.command == "history":
         return handle_history_command(
             args,

--- a/loopx/cli_commands/benchmark_review_lifecycle.py
+++ b/loopx/cli_commands/benchmark_review_lifecycle.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -9,17 +10,26 @@ from typing import Any
 from ..benchmark import (
     build_benchmark_adapter_kwarg_absorption_review,
     build_benchmark_attempt_learning_gate,
+    build_benchmark_baseline_failure_gate_comparison,
     build_benchmark_claim_review,
     build_benchmark_learning_ledger,
     build_benchmark_lifecycle_state,
+    build_benchmark_runner_invariant_review,
+    build_benchmark_verifier_attribution_review,
+    benchmark_result_from_benchmark_run_for_baseline_gate,
 )
 from ..benchmark_adapters.terminal_bench import (
     TERMINAL_BENCH_MANAGED_CODEX_LOOPX_KWARGS,
     agent_kwargs_from_invocation,
 )
+from ..delivery_outcome import DELIVERY_OUTCOME_CHOICES
+from ..global_registry import sync_project_registry_to_global
+from ..history import append_benchmark_comparison
+from ..state_refresh import DELIVERY_BATCH_SCALE_CHOICES
 from ..status import (
     compact_benchmark_comparison,
     compact_benchmark_learning_ledger,
+    compact_benchmark_result,
     compact_benchmark_post_launch_materialization,
     compact_benchmark_run,
 )
@@ -35,8 +45,11 @@ BENCHMARK_REVIEW_LIFECYCLE_COMMANDS = {
     "review-claim",
     "learning-ledger",
     "attempt-learning-gate",
+    "baseline-failure-gate",
     "review-adapter-kwargs",
     "lifecycle-state",
+    "review-runner-invariants",
+    "review-verifier-attribution",
 }
 
 
@@ -268,6 +281,42 @@ def render_benchmark_runner_invariant_review_markdown(
     return "\n".join(lines) + "\n"
 
 
+def render_benchmark_baseline_failure_gate_markdown(payload: dict[str, object]) -> str:
+    comparison = (
+        payload.get("benchmark_comparison")
+        if isinstance(payload.get("benchmark_comparison"), dict)
+        else {}
+    )
+    gate = (
+        comparison.get("baseline_failure_gate")
+        if isinstance(comparison.get("baseline_failure_gate"), dict)
+        else {}
+    )
+    lines = [
+        "# Benchmark Baseline Failure Gate",
+        "",
+        f"- ok: `{payload.get('ok')}`",
+        f"- dry_run: `{payload.get('dry_run')}`",
+        f"- appended: `{payload.get('appended')}`",
+        f"- goal_id: `{payload.get('goal_id')}`",
+        f"- benchmark_id: `{comparison.get('benchmark_id')}`",
+        f"- task_id: `{comparison.get('task_id')}`",
+        f"- baseline_failed: `{gate.get('baseline_failed')}`",
+        f"- control_plane_addressable: `{gate.get('control_plane_addressable')}`",
+        f"- treatment_eligible: `{gate.get('treatment_eligible')}`",
+        f"- failure_class: `{gate.get('failure_class')}`",
+    ]
+    if gate.get("minimum_next_evidence"):
+        lines.append(f"- minimum_next_evidence: {gate.get('minimum_next_evidence')}")
+    if gate.get("negative_selection_reason"):
+        lines.append(
+            f"- negative_selection_reason: {gate.get('negative_selection_reason')}"
+        )
+    if payload.get("error"):
+        lines.append(f"- error: {payload.get('error')}")
+    return "\n".join(lines) + "\n"
+
+
 
 def register_benchmark_review_lifecycle_commands(
     benchmark_subparsers: argparse._SubParsersAction,
@@ -457,11 +506,205 @@ def register_benchmark_review_lifecycle_commands(
         help="Return non-zero unless the lifecycle state allows budget counting.",
     )
 
+    benchmark_baseline_gate_parser = benchmark_subparsers.add_parser(
+        "baseline-failure-gate",
+        help=(
+            "Reduce a compact goal-mode baseline benchmark_result_v0 or "
+            "benchmark_run_v0 into a benchmark_comparison_v0 baseline-failure "
+            "gate. This reads only compact JSON, not raw task text, logs, "
+            "traces, Harbor job directories, Docker, model APIs, uploads, "
+            "screenshots, or credentials."
+        ),
+    )
+    add_subcommand_format(benchmark_baseline_gate_parser)
+    benchmark_baseline_gate_parser.add_argument(
+        "--goal-id",
+        help="Goal id for optional append context. Required with --execute.",
+    )
+    benchmark_baseline_gate_parser.add_argument(
+        "--benchmark-id",
+        required=True,
+        help="Public-safe benchmark id for the comparison row.",
+    )
+    benchmark_baseline_gate_parser.add_argument(
+        "--baseline-result-json",
+        required=True,
+        help=(
+            "Path to a compact benchmark_result_v0 or benchmark_run_v0 JSON object. "
+            "Use '-' to read stdin."
+        ),
+    )
+    benchmark_baseline_gate_parser.add_argument(
+        "--baseline-mode",
+        default="codex_cli_goal_mode",
+        help="Public-safe baseline mode label.",
+    )
+    benchmark_baseline_gate_parser.add_argument(
+        "--treatment-scenario-id",
+        default="codex_loopx",
+        help="Public-safe treatment scenario id planned after the gate.",
+    )
+    benchmark_baseline_gate_parser.add_argument("--comparison-id")
+    benchmark_baseline_gate_parser.add_argument("--failure-phase")
+    benchmark_baseline_gate_parser.add_argument("--failure-class")
+    benchmark_baseline_gate_parser.add_argument(
+        "--failure-attribution-label",
+        action="append",
+        default=[],
+        help="Public-safe failure attribution label. Repeat as needed.",
+    )
+    benchmark_baseline_gate_parser.add_argument(
+        "--control-plane-addressable",
+        action="store_true",
+        help=(
+            "Mark the baseline failure as plausibly fixable by LoopX "
+            "control-plane intervention."
+        ),
+    )
+    benchmark_baseline_gate_parser.add_argument(
+        "--same-task-semantics",
+        action="store_true",
+        help="Confirm treatment will use the same benchmark task semantics.",
+    )
+    benchmark_baseline_gate_parser.add_argument(
+        "--same-runner-protocol",
+        action="store_true",
+        help="Confirm treatment will use the same runner protocol.",
+    )
+    benchmark_baseline_gate_parser.add_argument(
+        "--trace-publicness-verified",
+        action="store_true",
+        help="Confirm the compact result excludes private raw trace material.",
+    )
+    benchmark_baseline_gate_parser.add_argument(
+        "--baseline-attempt-count",
+        type=int,
+        default=1,
+        help="Number of baseline attempts represented by this gate.",
+    )
+    benchmark_baseline_gate_parser.add_argument("--minimum-next-evidence")
+    benchmark_baseline_gate_parser.add_argument("--negative-selection-reason")
+    benchmark_baseline_gate_parser.add_argument("--next-action")
+    benchmark_baseline_gate_parser.add_argument(
+        "--evidence-ref",
+        action="append",
+        default=[],
+        help="Public-safe compact evidence reference. Repeat as needed.",
+    )
+    benchmark_baseline_gate_parser.add_argument("--classification")
+    benchmark_baseline_gate_parser.add_argument("--recommended-action")
+    benchmark_baseline_gate_parser.add_argument(
+        "--delivery-batch-scale",
+        choices=DELIVERY_BATCH_SCALE_CHOICES,
+        help="Optional delivery scale label for the run index.",
+    )
+    benchmark_baseline_gate_parser.add_argument(
+        "--delivery-outcome",
+        choices=DELIVERY_OUTCOME_CHOICES,
+        help="Optional delivery outcome label for the run index.",
+    )
+    benchmark_baseline_gate_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview without writing. This is the default.",
+    )
+    benchmark_baseline_gate_parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Append the compact baseline gate comparison.",
+    )
+    benchmark_baseline_gate_parser.add_argument(
+        "--no-global-sync",
+        action="store_true",
+        help="Skip global registry sync after append.",
+    )
+
+    benchmark_verifier_attribution_parser = benchmark_subparsers.add_parser(
+        "review-verifier-attribution",
+        help=(
+            "Review compact benchmark_run_v0 verifier attribution and decide "
+            "whether a score-failure caveat is resolved without opening raw logs, "
+            "task text, traces, Harbor job directories, Docker, model APIs, or uploads."
+        ),
+    )
+    add_subcommand_format(benchmark_verifier_attribution_parser)
+    benchmark_verifier_attribution_parser.add_argument(
+        "--benchmark-run-json",
+        action="append",
+        required=True,
+        help=(
+            "Path to a compact benchmark_run_v0 JSON object. Repeat for baseline "
+            "and treatment compact run files."
+        ),
+    )
+
+    benchmark_runner_invariant_parser = benchmark_subparsers.add_parser(
+        "review-runner-invariants",
+        help=(
+            "Review compact benchmark_run_v0 runner-owned boundary invariants "
+            "before trusting worker writeback. This reads only compact JSON, not "
+            "raw task text, logs, traces, Harbor job directories, Docker, model "
+            "APIs, uploads, or screenshots."
+        ),
+    )
+    add_subcommand_format(benchmark_runner_invariant_parser)
+    benchmark_runner_invariant_parser.add_argument(
+        "--benchmark-run-json",
+        required=True,
+        help="Path to a compact benchmark_run_v0 JSON object.",
+    )
+    benchmark_runner_invariant_parser.add_argument(
+        "--runner-label",
+        help="Public-safe runner label to include in the review payload.",
+    )
+    benchmark_runner_invariant_parser.add_argument(
+        "--expect-submit-eligible",
+        choices=["true", "false"],
+        default="false",
+        help="Expected runner-owned submit_eligible value. Defaults to false.",
+    )
+    benchmark_runner_invariant_parser.add_argument(
+        "--expect-leaderboard-evidence",
+        choices=["true", "false"],
+        default="false",
+        help="Expected runner-owned leaderboard_evidence value. Defaults to false.",
+    )
+    benchmark_runner_invariant_parser.add_argument(
+        "--expect-compact-only",
+        choices=["true", "false"],
+        default="true",
+        help="Expected compact read boundary. Defaults to true.",
+    )
+    benchmark_runner_invariant_parser.add_argument(
+        "--expect-raw-artifacts-read",
+        choices=["true", "false"],
+        default="false",
+        help="Expected raw artifact read boundary. Defaults to false.",
+    )
+    benchmark_runner_invariant_parser.add_argument(
+        "--expect-task-text-read",
+        choices=["true", "false"],
+        default="false",
+        help="Expected task text read boundary. Defaults to false.",
+    )
+    benchmark_runner_invariant_parser.add_argument(
+        "--expect-local-paths-recorded",
+        choices=["true", "false"],
+        default="false",
+        help="Expected local path recording boundary. Defaults to false.",
+    )
+    benchmark_runner_invariant_parser.add_argument(
+        "--require-clean",
+        action="store_true",
+        help="Return non-zero unless all runner-owned invariant fields match.",
+    )
+
 
 
 def handle_benchmark_review_lifecycle_command(
     args: argparse.Namespace,
     *,
+    registry_path: Path | None = None,
     print_payload: PrintPayload,
     output_format: OutputFormat,
 ) -> int | None:
@@ -790,5 +1033,242 @@ def handle_benchmark_review_lifecycle_command(
             payload,
             output_format(args),
             render_benchmark_lifecycle_state_markdown,
+        )
+        return 0 if payload.get("ok") else 1
+    if args.benchmark_command == "review-verifier-attribution":
+        try:
+            runs = []
+            for run_json in args.benchmark_run_json:
+                run_input = json.loads(
+                    Path(run_json).expanduser().read_text(encoding="utf-8")
+                )
+                if not isinstance(run_input, dict):
+                    raise ValueError("--benchmark-run-json must contain JSON objects")
+                run = compact_benchmark_run(run_input)
+                if not run:
+                    raise ValueError(
+                        "--benchmark-run-json did not contain a compactable benchmark_run_v0 object"
+                    )
+                runs.append(run)
+            payload = build_benchmark_verifier_attribution_review(
+                benchmark_runs=runs,
+            )
+        except Exception as exc:
+            payload = {
+                "ok": False,
+                "schema_version": "benchmark_verifier_attribution_review_v0",
+                "error": str(exc),
+                "read_boundary": {
+                    "compact_only": True,
+                    "raw_artifacts_read": False,
+                    "task_text_read": False,
+                    "local_paths_recorded": False,
+                },
+            }
+        else:
+            payload["ok"] = True
+        print_payload(
+            payload,
+            output_format(args),
+            render_benchmark_verifier_attribution_review_markdown,
+        )
+        return 0 if payload.get("ok") else 1
+    if args.benchmark_command == "review-runner-invariants":
+        try:
+            run_input = json.loads(
+                Path(args.benchmark_run_json).expanduser().read_text(encoding="utf-8")
+            )
+            if not isinstance(run_input, dict):
+                raise ValueError("--benchmark-run-json must contain a JSON object")
+            run = compact_benchmark_run(run_input)
+            if not run:
+                raise ValueError(
+                    "--benchmark-run-json did not contain a compactable benchmark_run_v0 object"
+                )
+            payload = build_benchmark_runner_invariant_review(
+                run,
+                expected_flags={
+                    "submit_eligible": args.expect_submit_eligible == "true",
+                    "leaderboard_evidence": args.expect_leaderboard_evidence
+                    == "true",
+                },
+                expected_read_boundary={
+                    "compact_only": args.expect_compact_only == "true",
+                    "raw_artifacts_read": args.expect_raw_artifacts_read == "true",
+                    "task_text_read": args.expect_task_text_read == "true",
+                    "local_paths_recorded": args.expect_local_paths_recorded
+                    == "true",
+                },
+                runner_label=args.runner_label,
+            )
+            payload["ok"] = True
+            if args.require_clean and payload.get("clean") is not True:
+                payload["ok"] = False
+                payload["error"] = payload.get("classification") or (
+                    "benchmark_runner_invariant_review_not_clean"
+                )
+            payload["require_clean"] = bool(args.require_clean)
+        except Exception as exc:
+            payload = {
+                "ok": False,
+                "schema_version": "benchmark_runner_invariant_review_v0",
+                "error": str(exc),
+                "read_boundary": {
+                    "compact_only": True,
+                    "raw_artifacts_read": False,
+                    "task_text_read": False,
+                    "local_paths_recorded": False,
+                },
+            }
+        print_payload(
+            payload,
+            output_format(args),
+            render_benchmark_runner_invariant_review_markdown,
+        )
+        return 0 if payload.get("ok") else 1
+    if args.benchmark_command == "baseline-failure-gate":
+        try:
+            if args.dry_run and args.execute:
+                raise ValueError(
+                    "benchmark baseline-failure-gate accepts either --dry-run or --execute, not both"
+                )
+            if args.execute and not args.goal_id:
+                raise ValueError(
+                    "benchmark baseline-failure-gate requires --goal-id with --execute"
+                )
+            if args.execute and registry_path is None:
+                raise ValueError(
+                    "benchmark baseline-failure-gate requires registry_path with --execute"
+                )
+            if args.baseline_result_json == "-":
+                baseline_result_input = json.loads(sys.stdin.read())
+            else:
+                baseline_result_input = json.loads(
+                    Path(args.baseline_result_json)
+                    .expanduser()
+                    .read_text(encoding="utf-8")
+                )
+            if not isinstance(baseline_result_input, dict):
+                raise ValueError("--baseline-result-json must contain a JSON object")
+            baseline_result = compact_benchmark_result(baseline_result_input)
+            baseline_gate_source = "compact_benchmark_result_v0"
+            if not baseline_result:
+                benchmark_run = compact_benchmark_run(baseline_result_input)
+                if benchmark_run:
+                    baseline_result = benchmark_result_from_benchmark_run_for_baseline_gate(
+                        benchmark_run
+                    )
+                    baseline_gate_source = "compact_benchmark_run_v0"
+                else:
+                    raise ValueError(
+                        "--baseline-result-json did not contain a compactable benchmark_result_v0 or benchmark_run_v0 object"
+                    )
+            comparison_input = build_benchmark_baseline_failure_gate_comparison(
+                baseline_result=baseline_result,
+                benchmark_id=args.benchmark_id,
+                baseline_mode=args.baseline_mode,
+                treatment_scenario_id=args.treatment_scenario_id,
+                comparison_id=args.comparison_id,
+                failure_phase=args.failure_phase,
+                failure_class=args.failure_class,
+                failure_attribution_labels=args.failure_attribution_label,
+                control_plane_addressable=bool(args.control_plane_addressable),
+                same_task_semantics=bool(args.same_task_semantics),
+                same_runner_protocol=bool(args.same_runner_protocol),
+                trace_publicness_verified=bool(args.trace_publicness_verified),
+                baseline_attempt_count=args.baseline_attempt_count,
+                minimum_next_evidence=args.minimum_next_evidence,
+                negative_selection_reason=args.negative_selection_reason,
+                next_action=args.next_action,
+                evidence_refs=args.evidence_ref,
+            )
+            comparison = compact_benchmark_comparison(comparison_input)
+            if not comparison:
+                raise ValueError(
+                    "baseline gate reducer did not produce a compactable benchmark_comparison_v0 object"
+                )
+            dry_run = not bool(args.execute)
+            if args.execute:
+                payload = append_benchmark_comparison(
+                    registry_path=registry_path,
+                    runtime_root_override=args.runtime_root,
+                    goal_id=args.goal_id,
+                    benchmark_comparison=comparison,
+                    classification=args.classification or "benchmark_comparison_v0",
+                    recommended_action=args.recommended_action
+                    or (
+                        comparison.get("next_action")
+                        if isinstance(comparison.get("next_action"), str)
+                        else None
+                    )
+                    or "route the baseline failure gate before any treatment run",
+                    delivery_batch_scale=args.delivery_batch_scale,
+                    delivery_outcome=args.delivery_outcome,
+                    dry_run=False,
+                )
+                if args.no_global_sync:
+                    payload["global_sync"] = {
+                        "ok": True,
+                        "dry_run": False,
+                        "skipped": True,
+                        "reason": "disabled by --no-global-sync",
+                    }
+                else:
+                    payload["global_sync"] = sync_project_registry_to_global(
+                        registry_path=registry_path,
+                        runtime_root_override=args.runtime_root,
+                        goal_id=args.goal_id,
+                        dry_run=False,
+                    )
+            else:
+                payload = {
+                    "ok": True,
+                    "dry_run": dry_run,
+                    "appended": False,
+                    "goal_id": args.goal_id,
+                    "classification": args.classification
+                    or "benchmark_comparison_v0",
+                    "benchmark_comparison": comparison,
+                }
+            payload["baseline_gate_cli"] = {
+                "source": baseline_gate_source,
+                "accepted_schemas": [
+                    "benchmark_result_v0",
+                    "benchmark_run_v0",
+                ],
+                "raw_artifacts_read": False,
+                "task_text_read": False,
+                "local_paths_recorded": False,
+                "docker_invoked": False,
+                "model_api_invoked": False,
+                "upload_invoked": False,
+            }
+        except Exception as exc:
+            payload = {
+                "ok": False,
+                "dry_run": not bool(getattr(args, "execute", False)),
+                "appended": False,
+                "goal_id": getattr(args, "goal_id", None),
+                "classification": getattr(args, "classification", None)
+                or "benchmark_comparison_v0",
+                "error": str(exc),
+                "baseline_gate_cli": {
+                    "source": "compact_benchmark_result_v0_or_benchmark_run_v0",
+                    "accepted_schemas": [
+                        "benchmark_result_v0",
+                        "benchmark_run_v0",
+                    ],
+                    "raw_artifacts_read": False,
+                    "task_text_read": False,
+                    "local_paths_recorded": False,
+                    "docker_invoked": False,
+                    "model_api_invoked": False,
+                    "upload_invoked": False,
+                },
+            }
+        print_payload(
+            payload,
+            output_format(args),
+            render_benchmark_baseline_failure_gate_markdown,
         )
         return 0 if payload.get("ok") else 1


### PR DESCRIPTION
## Summary
- Move baseline-failure-gate, review-verifier-attribution, and review-runner-invariants out of loopx/cli.py and into loopx/cli_commands/benchmark_review_lifecycle.py.
- Keep top-level CLI focused on registration/dispatch, including registry_path handoff for baseline-gate append behavior.
- Expand the benchmark review lifecycle modularization smoke to cover help output, compact-only review execution, baseline gate dry-run from a compact benchmark_run, and no local fixture path leakage.

## Validation
- python3 -m py_compile loopx/cli.py loopx/cli_commands/__init__.py loopx/cli_commands/benchmark_review_lifecycle.py examples/cli-benchmark-review-lifecycle-command-modularization-smoke.py
- python3 examples/cli-benchmark-review-lifecycle-command-modularization-smoke.py
- python3 examples/cli-benchmark-run-ledger-command-modularization-smoke.py
- python3 examples/cli-agentissue-runner-flow-command-modularization-smoke.py
- python3 examples/cli-terminal-bench-environment-result-command-modularization-smoke.py
- python3 examples/cli-terminal-bench-adapter-command-modularization-smoke.py
- python3 examples/cli-benchmark-boundary-command-modularization-smoke.py
- python3 examples/cli-history-command-modularization-smoke.py
- python3 examples/cli-control-plane-command-modularization-smoke.py
- python3 examples/project-agent-adoption-smoke.py
- python3 examples/demo-cli-smoke.py
- python3 -m py_compile loopx/__init__.py
loopx/agent_registry.py
loopx/authority.py
loopx/benchmark.py
loopx/benchmark_adapters/__init__.py
loopx/benchmark_adapters/agentissue.py
loopx/benchmark_adapters/agents_last_exam.py
loopx/benchmark_adapters/skillsbench.py
loopx/benchmark_adapters/skillsbench_acp_relay.py
loopx/benchmark_adapters/skillsbench_remote_bridge.py
loopx/benchmark_adapters/terminal_bench.py
loopx/benchmark_case_analysis.py
loopx/benchmark_case_state.py
loopx/benchmark_core/__init__.py
loopx/benchmark_core/adapter.py
loopx/benchmark_core/artifacts.py
loopx/benchmark_core/attempts.py
loopx/benchmark_core/io.py
loopx/benchmark_core/lifecycle.py
loopx/benchmark_core/loop_protocol.py
loopx/benchmark_core/observable_handles.py
loopx/benchmark_core/parity.py
loopx/benchmark_core/rounds.py
loopx/benchmark_core/run_permissions.py
loopx/benchmark_core/split_control.py
loopx/benchmark_ledger.py
loopx/benchmark_trajectory.py
loopx/bootstrap.py
loopx/boundary_authority.py
loopx/cli.py
loopx/cli_commands/__init__.py
loopx/cli_commands/agentissue_runner_flow.py
loopx/cli_commands/agents_last_exam.py
loopx/cli_commands/benchmark_boundary.py
loopx/cli_commands/benchmark_review_lifecycle.py
loopx/cli_commands/benchmark_run_ledger.py
loopx/cli_commands/doctor.py
loopx/cli_commands/dreaming.py
loopx/cli_commands/history.py
loopx/cli_commands/ml_experiment.py
loopx/cli_commands/quota.py
loopx/cli_commands/starter.py
loopx/cli_commands/status.py
loopx/cli_commands/terminal_bench_adapter.py
loopx/cli_commands/terminal_bench_environment_result.py
loopx/cli_commands/todo.py
loopx/codex_cli_probe.py
loopx/codex_goal_baseline.py
loopx/configure_goal.py
loopx/content_ops_surface.py
loopx/contract.py
loopx/control_plane.py
loopx/delivery_outcome.py
loopx/demo.py
loopx/diagnose.py
loopx/doctor.py
loopx/dreaming.py
loopx/execution_profile.py
loopx/feedback.py
loopx/file_lock.py
loopx/frontstage.py
loopx/global_registry.py
loopx/handoff_budget.py
loopx/heartbeat_prompt.py
loopx/history.py
loopx/interface_budget.py
loopx/materials.py
loopx/ml_experiment.py
loopx/onboarding.py
loopx/operator_gate.py
loopx/orchestration.py
loopx/paths.py
loopx/project_map.py
loopx/project_prompt.py
loopx/promotion_gate.py
loopx/quota.py
loopx/registry.py
loopx/review_packet.py
loopx/rollout_event_log.py
loopx/runtime.py
loopx/self_update.py
loopx/session_runtime.py
loopx/state_migration.py
loopx/state_projection.py
loopx/state_refresh.py
loopx/status.py
loopx/status_server.py
loopx/terminal_bench_agent.py
loopx/todo_contract.py
loopx/todos.py
loopx/upgrade.py
loopx/worker_bridge.py
- git diff --check
- loopx check --scan-path loopx/cli.py --scan-path loopx/cli_commands/benchmark_review_lifecycle.py --scan-path examples/cli-benchmark-review-lifecycle-command-modularization-smoke.py

LoopX check reports the existing duplicate index warning for loopx-meta only; public boundary scan is clean.