### PR TITLE
Refactor project lifecycle CLI commands

### DIFF
--- a/examples/cli-project-lifecycle-command-modularization-smoke.py
+++ b/examples/cli-project-lifecycle-command-modularization-smoke.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CLI = ROOT / "loopx" / "cli.py"
+MODULE = ROOT / "loopx" / "cli_commands" / "project_lifecycle.py"
+INIT = ROOT / "loopx" / "cli_commands" / "__init__.py"
+GOAL_ID = "project-lifecycle-smoke"
+
+
+def run_cli(*args: str, cwd: Path = ROOT) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ, "PYTHONPATH": str(ROOT)}
+    return subprocess.run(
+        [sys.executable, "-m", "loopx.cli", *args],
+        cwd=cwd,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def require_success(result: subprocess.CompletedProcess[str]) -> str:
+    if result.returncode != 0:
+        raise AssertionError(
+            f"expected success, got {result.returncode}\n"
+            f"stdout:\n{result.stdout}\n\nstderr:\n{result.stderr}"
+        )
+    return result.stdout
+
+
+def require_json_success(result: subprocess.CompletedProcess[str]) -> dict[str, object]:
+    stdout = require_success(result)
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise AssertionError(f"expected JSON output, got:\n{stdout}") from exc
+    require(payload.get("ok") is True, f"payload was not ok: {payload}")
+    return payload
+
+
+def write_fixture(project: Path) -> tuple[Path, Path, Path]:
+    runtime_root = project / "runtime"
+    registry_path = project / ".loopx" / "registry.json"
+    state_file = project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+    runs_dir = runtime_root / "goals" / GOAL_ID / "runs"
+    run_json = runs_dir / "2026-06-22T00-00-00-smoke.json"
+    run_md = runs_dir / "2026-06-22T00-00-00-smoke.md"
+    index_path = runs_dir / "index.jsonl"
+
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    state_file.parent.mkdir(parents=True, exist_ok=True)
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    (project / "README.md").write_text("# Project Lifecycle Smoke\n", encoding="utf-8")
+    state_file.write_text(
+        "\n".join(
+            [
+                "---",
+                f"goal_id: {GOAL_ID}",
+                "updated_at: 2026-06-22T00:00:00+00:00",
+                "---",
+                "",
+                "## Authority Sources",
+                "",
+                "- public fixture registry",
+                "",
+                "## Operating Contract",
+                "",
+                "- keep lifecycle command previews dry-run only",
+                "",
+                "## Work Clusters",
+                "",
+                "- CLI modularization smoke",
+                "",
+                "## Validation Surfaces",
+                "",
+                "- project lifecycle command smoke",
+                "",
+                "## Private/Public Boundary",
+                "",
+                "- fixture contains only public-safe synthetic values",
+                "",
+                "## Next Action",
+                "",
+                "- Continue project lifecycle command modularization smoke.",
+                "",
+                "## Agent Todo",
+                "",
+                "- [ ] [P1] Continue project lifecycle command modularization smoke.",
+                "  <!-- loopx:todo todo_id=todo_project_lifecycle_smoke role=agent status=open priority=P1 task_class=advancement_task -->",
+                "",
+                "## Progress Ledger",
+                "",
+                "- 2026-06-22T00:00:00+00:00: Fixture initialized.",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "registry_role": "project-local",
+                "common_runtime_root": str(runtime_root),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "objective": "Validate project lifecycle CLI command modularization.",
+                        "domain": "smoke",
+                        "repo": str(project),
+                        "state_file": ".codex/goals/project-lifecycle-smoke/ACTIVE_GOAL_STATE.md",
+                        "status": "connected-read-only",
+                        "adapter": {
+                            "kind": "read_only_project_map_v0",
+                            "status": "connected-read-only",
+                        },
+                        "coordination": {
+                            "registered_agents": [
+                                {"id": "codex-product-capability", "role": "side-agent"}
+                            ]
+                        },
+                        "guards": ["dry-run smoke fixture only"],
+                    }
+                ],
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    run_record = {
+        "generated_at": "2026-06-22T00:00:00+00:00",
+        "goal_id": GOAL_ID,
+        "classification": "state_refreshed",
+        "recommended_action": "Continue project lifecycle command modularization smoke.",
+        "health_check": "fixture run",
+        "json_path": str(run_json),
+        "markdown_path": str(run_md),
+    }
+    run_json.write_text(json.dumps(run_record, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    run_md.write_text("# Fixture Run\n", encoding="utf-8")
+    index_path.write_text(json.dumps(run_record, ensure_ascii=False) + "\n", encoding="utf-8")
+    return registry_path, runtime_root, index_path
+
+
+def main() -> None:
+    cli_source = CLI.read_text(encoding="utf-8")
+    module_source = MODULE.read_text(encoding="utf-8")
+    init_source = INIT.read_text(encoding="utf-8")
+
+    forbidden_cli_markers = [
+        "refresh_state_parser = sub.add_parser",
+        "read_only_map_parser = sub.add_parser",
+        "reward_parser = sub.add_parser",
+        'gate_parser = sub.add_parser(\n        "operator-gate"',
+        "refresh_state_run(",
+        "read_only_project_map_run(",
+        "append_human_reward(",
+        "record_operator_gate(",
+        'if args.command == "refresh-state":',
+        'if args.command == "read-only-map":',
+        'if args.command == "reward":',
+        'if args.command == "operator-gate":',
+    ]
+    for marker in forbidden_cli_markers:
+        require(marker not in cli_source, f"project lifecycle marker leaked into cli.py: {marker}")
+
+    for marker in (
+        "PROJECT_LIFECYCLE_COMMANDS",
+        "register_project_lifecycle_commands",
+        "handle_project_lifecycle_command",
+        "refresh-state",
+        "read-only-map",
+        "reward",
+        "operator-gate",
+    ):
+        require(marker in module_source, f"project lifecycle module missing {marker}")
+    require("register_project_lifecycle_commands" in cli_source, "cli.py did not register project lifecycle commands")
+    require("handle_project_lifecycle_command" in cli_source, "cli.py did not dispatch project lifecycle commands")
+    require("register_project_lifecycle_commands" in init_source, "__init__ did not export project lifecycle registration")
+    require("handle_project_lifecycle_command" in init_source, "__init__ did not export project lifecycle handler")
+
+    for command, options in {
+        "refresh-state": ("--delivery-outcome", "--agent-id", "--dry-run"),
+        "read-only-map": ("--recommended-action", "--dry-run"),
+        "reward": ("--write-active-state-summary", "--dry-run"),
+        "operator-gate": ("--agent-command", "--no-global-sync"),
+    }.items():
+        help_text = require_success(run_cli(command, "--help"))
+        for option in options:
+            require(option in help_text, f"{command} help omitted {option}")
+
+    with tempfile.TemporaryDirectory(prefix="loopx-project-lifecycle-cli-") as tmp:
+        project = Path(tmp)
+        registry_path, runtime_root, index_path = write_fixture(project)
+        before_index = index_path.read_text(encoding="utf-8")
+        command_prefix = (
+            "--registry",
+            str(registry_path),
+            "--runtime-root",
+            str(runtime_root),
+        )
+
+        refresh_payload = require_json_success(
+            run_cli(
+                *command_prefix,
+                "refresh-state",
+                "--goal-id",
+                GOAL_ID,
+                "--dry-run",
+                "--no-global-sync",
+                "--delivery-batch-scale",
+                "implementation",
+                "--delivery-outcome",
+                "outcome_progress",
+                "--format",
+                "json",
+            )
+        )
+        require(refresh_payload.get("dry_run") is True, "refresh-state should stay dry-run")
+        require(refresh_payload.get("appended") is False, "refresh-state dry-run should not append")
+        require(refresh_payload.get("delivery_outcome") == "outcome_progress", "refresh-state outcome changed")
+
+        map_payload = require_json_success(
+            run_cli(
+                *command_prefix,
+                "read-only-map",
+                "--goal-id",
+                GOAL_ID,
+                "--dry-run",
+                "--no-global-sync",
+                "--format",
+                "json",
+            )
+        )
+        require(map_payload.get("dry_run") is True, "read-only-map should stay dry-run")
+        require(map_payload.get("appended") is False, "read-only-map dry-run should not append")
+        require(
+            (map_payload.get("project_map") or {}).get("adapter_kind") == "read_only_project_map_v0",
+            "read-only-map compact payload changed",
+        )
+
+        reward_payload = require_json_success(
+            run_cli(
+                *command_prefix,
+                "reward",
+                "--goal-id",
+                GOAL_ID,
+                "--decision",
+                "continue_route",
+                "--reward",
+                "positive",
+                "--reason-summary",
+                "synthetic dry-run reward",
+                "--follow-up",
+                "continue modularization smoke",
+                "--dry-run",
+                "--format",
+                "json",
+            )
+        )
+        require(reward_payload.get("dry_run") is True, "reward should stay dry-run")
+        require(reward_payload.get("appended") is False, "reward dry-run should not append")
+        require(
+            (reward_payload.get("human_reward") or {}).get("reward") == "positive",
+            "reward payload polarity changed",
+        )
+
+        gate_payload = require_json_success(
+            run_cli(
+                *command_prefix,
+                "operator-gate",
+                "--goal-id",
+                GOAL_ID,
+                "--decision",
+                "defer",
+                "--reason-summary",
+                "synthetic dry-run gate",
+                "--follow-up",
+                "collect more smoke evidence",
+                "--dry-run",
+                "--no-global-sync",
+                "--format",
+                "json",
+            )
+        )
+        require(gate_payload.get("dry_run") is True, "operator-gate should stay dry-run")
+        require(gate_payload.get("appended") is False, "operator-gate dry-run should not append")
+        require(
+            (gate_payload.get("operator_gate") or {}).get("decision") == "defer",
+            "operator-gate decision changed",
+        )
+        require(index_path.read_text(encoding="utf-8") == before_index, "dry-run commands mutated run index")
+
+    print("cli-project-lifecycle-command-modularization-smoke: ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -30,7 +30,6 @@ from .benchmark_core import (
     build_split_control_remote_executor_readiness,
 )
 from .configure_goal import configure_goal, render_configure_goal_markdown
-from .delivery_outcome import DELIVERY_OUTCOME_CHOICES
 from .cli_commands import (
     handle_agents_last_exam_command,
     handle_agentissue_runner_flow_command,
@@ -61,6 +60,7 @@ from .cli_commands import (
     handle_history_command,
     handle_ml_experiment_command,
     handle_new_project_prompt_command,
+    handle_project_lifecycle_command,
     handle_quota_command,
     handle_review_packet_command,
     handle_status_command,
@@ -77,6 +77,7 @@ from .cli_commands import (
     register_dreaming_commands,
     register_history_command,
     register_ml_experiment_commands,
+    register_project_lifecycle_commands,
     register_quota_command,
     register_starter_commands,
     register_status_commands,
@@ -86,7 +87,6 @@ from .cli_commands import (
     register_worker_bridge_commands,
 )
 from .execution_profile import DEFAULT_EXECUTION_PROFILE
-from .feedback import append_human_reward, compact_reward, render_reward_markdown
 from .global_registry import render_global_sync_markdown, sync_project_registry_to_global
 from .heartbeat_prompt import build_heartbeat_prompt, render_heartbeat_prompt_markdown
 from .history import (
@@ -95,18 +95,7 @@ from .history import (
     load_registry,
     render_benchmark_run_append_markdown,
 )
-from .operator_gate import (
-    DEFAULT_OPERATOR_GATE,
-    OPERATOR_GATE_DECISIONS,
-    record_operator_gate,
-    render_operator_gate_markdown,
-)
 from .paths import DEFAULT_RUNTIME_ROOT, default_registry_path, global_registry_path, resolve_runtime_root
-from .project_map import (
-    DEFAULT_PROJECT_MAP_CLASSIFICATION,
-    read_only_project_map_run,
-    render_read_only_project_map_markdown,
-)
 from .promotion_gate import build_promotion_gate, render_promotion_gate_markdown
 from .registry import (
     inspect_registry,
@@ -122,13 +111,6 @@ from .rollout_event_log import (
     rollout_event_log_path,
 )
 from .runtime import archive_runtime_goal, render_archive_runtime_markdown
-from .state_refresh import (
-    DEFAULT_REFRESH_ACTION,
-    DEFAULT_REFRESH_CLASSIFICATION,
-    DELIVERY_BATCH_SCALE_CHOICES,
-    refresh_state_run,
-    render_state_refresh_markdown,
-)
 from .state_migration import (
     LEGACY_GLOBAL_REGISTRY,
     LEGACY_RUNTIME_ROOT,
@@ -1147,179 +1129,7 @@ def main(argv: list[str] | None = None) -> int:
         help="Write migrated state. Without this flag the command is a dry-run preview.",
     )
 
-    refresh_state_parser = sub.add_parser(
-        "refresh-state",
-        help="Append a read-only run from active goal state after state-only updates.",
-    )
-    refresh_state_parser.add_argument(
-        "--goal-id",
-        required=True,
-        help="Goal id whose active state should be refreshed.",
-    )
-    refresh_state_parser.add_argument("--project", help="Project root. Defaults to the registry goal repo.")
-    refresh_state_parser.add_argument(
-        "--state-file",
-        help="Active goal state path. Defaults to the registry goal state_file.",
-    )
-    refresh_state_parser.add_argument(
-        "--classification",
-        default=DEFAULT_REFRESH_CLASSIFICATION,
-        help=f"Refresh run classification. Defaults to {DEFAULT_REFRESH_CLASSIFICATION}.",
-    )
-    refresh_state_parser.add_argument(
-        "--recommended-action",
-        help=f"Public-safe next action. Defaults to: {DEFAULT_REFRESH_ACTION}",
-    )
-    refresh_state_parser.add_argument(
-        "--next-action",
-        help=(
-            "Explicitly update the active state's durable ## Next Action before "
-            "appending the refresh run. Without this flag, --recommended-action "
-            "only describes the run record."
-        ),
-    )
-    refresh_state_parser.add_argument(
-        "--delivery-batch-scale",
-        choices=DELIVERY_BATCH_SCALE_CHOICES,
-        help="Optional explicit delivery scale for this refresh run, overriding classification-name inference.",
-    )
-    refresh_state_parser.add_argument(
-        "--delivery-outcome",
-        choices=DELIVERY_OUTCOME_CHOICES,
-        help="Optional explicit outcome-floor signal for this refresh run.",
-    )
-    refresh_state_parser.add_argument(
-        "--autonomous-replan-recorded",
-        action="store_true",
-        help=(
-            "Mark this refresh as the explicit autonomous replan ACK. "
-            "Use only after the agent has performed and written back the bounded replan slice."
-        ),
-    )
-    refresh_state_parser.add_argument(
-        "--agent-id",
-        help=(
-            "Registered agent id for agent-lane state refreshes. When set, the "
-            "refresh is visible in run history but does not replace goal-level status."
-        ),
-    )
-    refresh_state_parser.add_argument(
-        "--agent-lane",
-        help="Public-safe lane label for --agent-id scoped refreshes, such as productization_frontstage.",
-    )
-    refresh_state_parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Print the refresh payload without appending.",
-    )
-    refresh_state_parser.add_argument(
-        "--no-global-sync",
-        action="store_true",
-        help="Do not refresh the shared global registry after writing the state run.",
-    )
-
-    read_only_map_parser = sub.add_parser(
-        "read-only-map",
-        help="Append a generic read-only project-map run for a connected project.",
-    )
-    read_only_map_parser.add_argument(
-        "--goal-id",
-        required=True,
-        help="Goal id whose project should be mapped.",
-    )
-    read_only_map_parser.add_argument("--project", help="Project root. Defaults to the registry goal repo.")
-    read_only_map_parser.add_argument(
-        "--state-file",
-        help="Active goal state path. Defaults to the registry goal state_file.",
-    )
-    read_only_map_parser.add_argument(
-        "--classification",
-        default=DEFAULT_PROJECT_MAP_CLASSIFICATION,
-        help=f"Project-map run classification. Defaults to {DEFAULT_PROJECT_MAP_CLASSIFICATION}.",
-    )
-    read_only_map_parser.add_argument(
-        "--recommended-action",
-        help="Public-safe next action. Defaults to the first public-safe item from the active state's Next Action.",
-    )
-    read_only_map_parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Print the project-map payload without appending.",
-    )
-    read_only_map_parser.add_argument(
-        "--no-global-sync",
-        action="store_true",
-        help="Do not refresh the shared global registry after writing the project-map run.",
-    )
-
-    reward_parser = sub.add_parser(
-        "reward",
-        help="Append a compact human reward overlay to a goal run index.",
-    )
-    reward_parser.add_argument("--goal-id", required=True, help="Goal id whose latest run should receive feedback.")
-    reward_parser.add_argument(
-        "--run-generated-at",
-        help="Exact run generated_at timestamp. Defaults to the latest compact run for the goal.",
-    )
-    reward_parser.add_argument("--recorded-at", help="Reward timestamp. Defaults to current UTC time.")
-    reward_parser.add_argument("--decision", required=True, help="Operator decision label, such as continue_route.")
-    reward_parser.add_argument(
-        "--reward",
-        required=True,
-        choices=["positive", "negative", "mixed", "neutral"],
-        help="Compact reward polarity.",
-    )
-    reward_parser.add_argument(
-        "--reason-summary",
-        required=True,
-        help="Short public-safe reason. Do not include raw private evidence.",
-    )
-    reward_parser.add_argument("--follow-up", help="Optional next handoff or experiment condition.")
-    reward_parser.add_argument(
-        "--state-file",
-        help="Active goal state path for optional summary writeback. Defaults to the registry goal state_file.",
-    )
-    reward_parser.add_argument(
-        "--write-active-state-summary",
-        action="store_true",
-        help="After a real append, also add the returned active_state_summary to the active state's Progress Ledger. With --dry-run, preview only.",
-    )
-    reward_parser.add_argument("--dry-run", action="store_true", help="Print the overlay without appending it.")
-
-    gate_parser = sub.add_parser(
-        "operator-gate",
-        help="Record an operator gate decision such as read-only map opt-in.",
-    )
-    gate_parser.add_argument("--goal-id", required=True, help="Goal id whose operator gate is being judged.")
-    gate_parser.add_argument("--gate", default=DEFAULT_OPERATOR_GATE, help=f"Gate id. Defaults to {DEFAULT_OPERATOR_GATE}.")
-    gate_parser.add_argument(
-        "--decision",
-        required=True,
-        choices=sorted(OPERATOR_GATE_DECISIONS),
-        help="Operator decision for this gate.",
-    )
-    gate_parser.add_argument("--recorded-at", help="Decision timestamp. Defaults to current local time.")
-    gate_parser.add_argument(
-        "--operator-question",
-        help="Human-facing question being answered. Defaults from --gate and --goal-id.",
-    )
-    gate_parser.add_argument(
-        "--reason-summary",
-        required=True,
-        help="Short public-safe reason. Do not include raw private evidence.",
-    )
-    gate_parser.add_argument("--follow-up", help="Optional next handoff or evidence condition.")
-    gate_parser.add_argument(
-        "--agent-command",
-        help="Target-agent command that becomes valid after approval. Defaults for read_only_map_opt_in approvals.",
-    )
-    gate_parser.add_argument("--recommended-action", help="Public-safe next action for status/dashboard.")
-    gate_parser.add_argument("--dry-run", action="store_true", help="Print the decision run without appending it.")
-    gate_parser.add_argument(
-        "--no-global-sync",
-        action="store_true",
-        help="Do not refresh the shared global registry after writing the gate decision.",
-    )
+    register_project_lifecycle_commands(sub, add_subcommand_format)
 
     authority_parser = sub.add_parser(
         "register-authority-source",
@@ -2006,152 +1816,15 @@ def main(argv: list[str] | None = None) -> int:
         print_payload(payload, args.format, render_state_migration_markdown)
         return 0 if payload.get("ok") else 1
 
-    if args.command == "refresh-state":
-        try:
-            payload = refresh_state_run(
-                registry_path=registry_path,
-                runtime_root_override=args.runtime_root,
-                goal_id=args.goal_id,
-                project=Path(args.project).expanduser() if args.project else None,
-                state_file=Path(args.state_file).expanduser() if args.state_file else None,
-                classification=args.classification,
-                recommended_action=args.recommended_action,
-                next_action=args.next_action,
-                delivery_batch_scale=args.delivery_batch_scale,
-                delivery_outcome=args.delivery_outcome,
-                agent_id=args.agent_id,
-                agent_lane=args.agent_lane,
-                autonomous_replan_recorded=bool(args.autonomous_replan_recorded),
-                dry_run=bool(args.dry_run),
-                sync_global=not bool(args.no_global_sync),
-            )
-        except Exception as exc:
-            payload = {
-                "ok": False,
-                "registry": str(registry_path),
-                "runtime_root": args.runtime_root,
-                "goal_id": args.goal_id,
-                "classification": args.classification,
-                "appended": False,
-                "dry_run": bool(args.dry_run),
-                "error": str(exc),
-            }
-        if payload.get("ok") and payload.get("appended") and not payload.get("dry_run"):
-            append_cli_rollout_event(
-                payload,
-                registry_path=registry_path,
-                runtime_root_arg=args.runtime_root,
-                event_kind="refresh_state",
-                agent_id=args.agent_id,
-                status="appended",
-                summary=(
-                    "refresh-state appended compact control-plane state with "
-                    f"classification={payload.get('classification')}"
-                ),
-                details={
-                    "command": "refresh-state",
-                    "progress_scope": payload.get("progress_scope") or "",
-                    "agent_lane": payload.get("agent_lane") or "",
-                    "autonomous_replan_recorded": bool(
-                        payload.get("autonomous_replan_recorded")
-                    ),
-                    "global_sync_wrote": bool(
-                        isinstance(payload.get("global_sync"), dict)
-                        and payload["global_sync"].get("wrote")
-                    ),
-                },
-            )
-        print_payload(payload, args.format, render_state_refresh_markdown)
-        return 0 if payload.get("ok") else 1
-
-    if args.command == "read-only-map":
-        try:
-            payload = read_only_project_map_run(
-                registry_path=registry_path,
-                runtime_root_override=args.runtime_root,
-                goal_id=args.goal_id,
-                project=Path(args.project).expanduser() if args.project else None,
-                state_file=Path(args.state_file).expanduser() if args.state_file else None,
-                classification=args.classification,
-                recommended_action=args.recommended_action,
-                dry_run=bool(args.dry_run),
-                sync_global=not bool(args.no_global_sync),
-            )
-        except Exception as exc:
-            payload = {
-                "ok": False,
-                "registry": str(registry_path),
-                "runtime_root": args.runtime_root,
-                "goal_id": args.goal_id,
-                "classification": args.classification,
-                "appended": False,
-                "dry_run": bool(args.dry_run),
-                "error": str(exc),
-            }
-        print_payload(payload, args.format, render_read_only_project_map_markdown)
-        return 0 if payload.get("ok") else 1
-
-    if args.command == "reward":
-        try:
-            reward = compact_reward(
-                recorded_at=args.recorded_at,
-                decision=args.decision,
-                reward=args.reward,
-                reason_summary=args.reason_summary,
-                follow_up=args.follow_up,
-            )
-            payload = append_human_reward(
-                registry_path=registry_path,
-                runtime_root_override=args.runtime_root,
-                goal_id=args.goal_id,
-                run_generated_at=args.run_generated_at,
-                reward=reward,
-                dry_run=bool(args.dry_run),
-                state_file_override=Path(args.state_file).expanduser() if args.state_file else None,
-                write_active_state_summary=bool(args.write_active_state_summary),
-            )
-        except Exception as exc:
-            payload = {
-                "ok": False,
-                "registry": str(registry_path),
-                "runtime_root": args.runtime_root,
-                "goal_id": args.goal_id,
-                "appended": False,
-                "dry_run": bool(args.dry_run),
-                "error": str(exc),
-            }
-        print_payload(payload, args.format, render_reward_markdown)
-        return 0 if payload.get("ok") else 1
-
-    if args.command == "operator-gate":
-        try:
-            payload = record_operator_gate(
-                registry_path=registry_path,
-                runtime_root_override=args.runtime_root,
-                goal_id=args.goal_id,
-                gate=args.gate,
-                decision=args.decision,
-                operator_question=args.operator_question,
-                reason_summary=args.reason_summary,
-                follow_up=args.follow_up,
-                agent_command=args.agent_command,
-                recommended_action=args.recommended_action,
-                recorded_at=args.recorded_at,
-                dry_run=bool(args.dry_run),
-                sync_global=not bool(args.no_global_sync),
-            )
-        except Exception as exc:
-            payload = {
-                "ok": False,
-                "registry": str(registry_path),
-                "runtime_root": args.runtime_root,
-                "goal_id": args.goal_id,
-                "appended": False,
-                "dry_run": bool(args.dry_run),
-                "error": str(exc),
-            }
-        print_payload(payload, args.format, render_operator_gate_markdown)
-        return 0 if payload.get("ok") else 1
+    project_lifecycle_result = handle_project_lifecycle_command(
+        args,
+        registry_path=registry_path,
+        print_payload=print_payload,
+        output_format=output_format,
+        append_cli_rollout_event=append_cli_rollout_event,
+    )
+    if project_lifecycle_result is not None:
+        return project_lifecycle_result
 
     if args.command == "register-authority-source":
         try:

--- a/loopx/cli_commands/__init__.py
+++ b/loopx/cli_commands/__init__.py
@@ -32,6 +32,10 @@ from .doctor import handle_doctor_command, register_doctor_command
 from .dreaming import handle_dreaming_command, register_dreaming_commands
 from .history import handle_history_command, register_history_command
 from .ml_experiment import handle_ml_experiment_command, register_ml_experiment_commands
+from .project_lifecycle import (
+    handle_project_lifecycle_command,
+    register_project_lifecycle_commands,
+)
 from .quota import handle_quota_command, register_quota_command
 from .starter import (
     handle_codex_cli_bounded_visible_pilot_adapter_command,
@@ -102,6 +106,7 @@ __all__ = [
     "handle_history_command",
     "handle_ml_experiment_command",
     "handle_new_project_prompt_command",
+    "handle_project_lifecycle_command",
     "handle_quota_command",
     "handle_review_packet_command",
     "handle_status_command",
@@ -118,6 +123,7 @@ __all__ = [
     "register_dreaming_commands",
     "register_history_command",
     "register_ml_experiment_commands",
+    "register_project_lifecycle_commands",
     "register_quota_command",
     "register_starter_commands",
     "register_status_commands",

--- a/loopx/cli_commands/project_lifecycle.py
+++ b/loopx/cli_commands/project_lifecycle.py
@@ -1,0 +1,383 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+from pathlib import Path
+
+from ..delivery_outcome import DELIVERY_OUTCOME_CHOICES
+from ..feedback import append_human_reward, compact_reward, render_reward_markdown
+from ..operator_gate import (
+    DEFAULT_OPERATOR_GATE,
+    OPERATOR_GATE_DECISIONS,
+    record_operator_gate,
+    render_operator_gate_markdown,
+)
+from ..project_map import (
+    DEFAULT_PROJECT_MAP_CLASSIFICATION,
+    read_only_project_map_run,
+    render_read_only_project_map_markdown,
+)
+from ..state_refresh import (
+    DEFAULT_REFRESH_ACTION,
+    DEFAULT_REFRESH_CLASSIFICATION,
+    DELIVERY_BATCH_SCALE_CHOICES,
+    refresh_state_run,
+    render_state_refresh_markdown,
+)
+
+
+PrintPayload = Callable[
+    [dict[str, object], str, Callable[[dict[str, object]], str]],
+    None,
+]
+OutputFormat = Callable[[argparse.Namespace], str]
+AppendCliRolloutEvent = Callable[..., dict[str, object]]
+
+PROJECT_LIFECYCLE_COMMANDS = {
+    "refresh-state",
+    "read-only-map",
+    "reward",
+    "operator-gate",
+}
+
+
+def register_project_lifecycle_commands(
+    subparsers: argparse._SubParsersAction,
+    add_subcommand_format: Callable[[argparse.ArgumentParser], None],
+) -> None:
+    refresh_state_parser = subparsers.add_parser(
+        "refresh-state",
+        help="Append a read-only run from active goal state after state-only updates.",
+    )
+    add_subcommand_format(refresh_state_parser)
+    refresh_state_parser.add_argument(
+        "--goal-id",
+        required=True,
+        help="Goal id whose active state should be refreshed.",
+    )
+    refresh_state_parser.add_argument("--project", help="Project root. Defaults to the registry goal repo.")
+    refresh_state_parser.add_argument(
+        "--state-file",
+        help="Active goal state path. Defaults to the registry goal state_file.",
+    )
+    refresh_state_parser.add_argument(
+        "--classification",
+        default=DEFAULT_REFRESH_CLASSIFICATION,
+        help=f"Refresh run classification. Defaults to {DEFAULT_REFRESH_CLASSIFICATION}.",
+    )
+    refresh_state_parser.add_argument(
+        "--recommended-action",
+        help=f"Public-safe next action. Defaults to: {DEFAULT_REFRESH_ACTION}",
+    )
+    refresh_state_parser.add_argument(
+        "--next-action",
+        help=(
+            "Explicitly update the active state's durable ## Next Action before "
+            "appending the refresh run. Without this flag, --recommended-action "
+            "only describes the run record."
+        ),
+    )
+    refresh_state_parser.add_argument(
+        "--delivery-batch-scale",
+        choices=DELIVERY_BATCH_SCALE_CHOICES,
+        help="Optional explicit delivery scale for this refresh run, overriding classification-name inference.",
+    )
+    refresh_state_parser.add_argument(
+        "--delivery-outcome",
+        choices=DELIVERY_OUTCOME_CHOICES,
+        help="Optional explicit outcome-floor signal for this refresh run.",
+    )
+    refresh_state_parser.add_argument(
+        "--autonomous-replan-recorded",
+        action="store_true",
+        help=(
+            "Mark this refresh as the explicit autonomous replan ACK. "
+            "Use only after the agent has performed and written back the bounded replan slice."
+        ),
+    )
+    refresh_state_parser.add_argument(
+        "--agent-id",
+        help=(
+            "Registered agent id for agent-lane state refreshes. When set, the "
+            "refresh is visible in run history but does not replace goal-level status."
+        ),
+    )
+    refresh_state_parser.add_argument(
+        "--agent-lane",
+        help="Public-safe lane label for --agent-id scoped refreshes, such as productization_frontstage.",
+    )
+    refresh_state_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the refresh payload without appending.",
+    )
+    refresh_state_parser.add_argument(
+        "--no-global-sync",
+        action="store_true",
+        help="Do not refresh the shared global registry after writing the state run.",
+    )
+
+    read_only_map_parser = subparsers.add_parser(
+        "read-only-map",
+        help="Append a generic read-only project-map run for a connected project.",
+    )
+    add_subcommand_format(read_only_map_parser)
+    read_only_map_parser.add_argument(
+        "--goal-id",
+        required=True,
+        help="Goal id whose project should be mapped.",
+    )
+    read_only_map_parser.add_argument("--project", help="Project root. Defaults to the registry goal repo.")
+    read_only_map_parser.add_argument(
+        "--state-file",
+        help="Active goal state path. Defaults to the registry goal state_file.",
+    )
+    read_only_map_parser.add_argument(
+        "--classification",
+        default=DEFAULT_PROJECT_MAP_CLASSIFICATION,
+        help=f"Project-map run classification. Defaults to {DEFAULT_PROJECT_MAP_CLASSIFICATION}.",
+    )
+    read_only_map_parser.add_argument(
+        "--recommended-action",
+        help="Public-safe next action. Defaults to the first public-safe item from the active state's Next Action.",
+    )
+    read_only_map_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the project-map payload without appending.",
+    )
+    read_only_map_parser.add_argument(
+        "--no-global-sync",
+        action="store_true",
+        help="Do not refresh the shared global registry after writing the project-map run.",
+    )
+
+    reward_parser = subparsers.add_parser(
+        "reward",
+        help="Append a compact human reward overlay to a goal run index.",
+    )
+    add_subcommand_format(reward_parser)
+    reward_parser.add_argument("--goal-id", required=True, help="Goal id whose latest run should receive feedback.")
+    reward_parser.add_argument(
+        "--run-generated-at",
+        help="Exact run generated_at timestamp. Defaults to the latest compact run for the goal.",
+    )
+    reward_parser.add_argument("--recorded-at", help="Reward timestamp. Defaults to current UTC time.")
+    reward_parser.add_argument("--decision", required=True, help="Operator decision label, such as continue_route.")
+    reward_parser.add_argument(
+        "--reward",
+        required=True,
+        choices=["positive", "negative", "mixed", "neutral"],
+        help="Compact reward polarity.",
+    )
+    reward_parser.add_argument(
+        "--reason-summary",
+        required=True,
+        help="Short public-safe reason. Do not include raw private evidence.",
+    )
+    reward_parser.add_argument("--follow-up", help="Optional next handoff or experiment condition.")
+    reward_parser.add_argument(
+        "--state-file",
+        help="Active goal state path for optional summary writeback. Defaults to the registry goal state_file.",
+    )
+    reward_parser.add_argument(
+        "--write-active-state-summary",
+        action="store_true",
+        help="After a real append, also add the returned active_state_summary to the active state's Progress Ledger. With --dry-run, preview only.",
+    )
+    reward_parser.add_argument("--dry-run", action="store_true", help="Print the overlay without appending it.")
+
+    gate_parser = subparsers.add_parser(
+        "operator-gate",
+        help="Record an operator gate decision such as read-only map opt-in.",
+    )
+    add_subcommand_format(gate_parser)
+    gate_parser.add_argument("--goal-id", required=True, help="Goal id whose operator gate is being judged.")
+    gate_parser.add_argument("--gate", default=DEFAULT_OPERATOR_GATE, help=f"Gate id. Defaults to {DEFAULT_OPERATOR_GATE}.")
+    gate_parser.add_argument(
+        "--decision",
+        required=True,
+        choices=sorted(OPERATOR_GATE_DECISIONS),
+        help="Operator decision for this gate.",
+    )
+    gate_parser.add_argument("--recorded-at", help="Decision timestamp. Defaults to current local time.")
+    gate_parser.add_argument(
+        "--operator-question",
+        help="Human-facing question being answered. Defaults from --gate and --goal-id.",
+    )
+    gate_parser.add_argument(
+        "--reason-summary",
+        required=True,
+        help="Short public-safe reason. Do not include raw private evidence.",
+    )
+    gate_parser.add_argument("--follow-up", help="Optional next handoff or evidence condition.")
+    gate_parser.add_argument(
+        "--agent-command",
+        help="Target-agent command that becomes valid after approval. Defaults for read_only_map_opt_in approvals.",
+    )
+    gate_parser.add_argument("--recommended-action", help="Public-safe next action for status/dashboard.")
+    gate_parser.add_argument("--dry-run", action="store_true", help="Print the decision run without appending it.")
+    gate_parser.add_argument(
+        "--no-global-sync",
+        action="store_true",
+        help="Do not refresh the shared global registry after writing the gate decision.",
+    )
+
+
+def handle_project_lifecycle_command(
+    args: argparse.Namespace,
+    *,
+    registry_path: Path,
+    print_payload: PrintPayload,
+    output_format: OutputFormat,
+    append_cli_rollout_event: AppendCliRolloutEvent,
+) -> int | None:
+    if args.command not in PROJECT_LIFECYCLE_COMMANDS:
+        return None
+
+    fmt = output_format(args)
+    if args.command == "refresh-state":
+        try:
+            payload = refresh_state_run(
+                registry_path=registry_path,
+                runtime_root_override=args.runtime_root,
+                goal_id=args.goal_id,
+                project=Path(args.project).expanduser() if args.project else None,
+                state_file=Path(args.state_file).expanduser() if args.state_file else None,
+                classification=args.classification,
+                recommended_action=args.recommended_action,
+                next_action=args.next_action,
+                delivery_batch_scale=args.delivery_batch_scale,
+                delivery_outcome=args.delivery_outcome,
+                agent_id=args.agent_id,
+                agent_lane=args.agent_lane,
+                autonomous_replan_recorded=bool(args.autonomous_replan_recorded),
+                dry_run=bool(args.dry_run),
+                sync_global=not bool(args.no_global_sync),
+            )
+        except Exception as exc:
+            payload = {
+                "ok": False,
+                "registry": str(registry_path),
+                "runtime_root": args.runtime_root,
+                "goal_id": args.goal_id,
+                "classification": args.classification,
+                "appended": False,
+                "dry_run": bool(args.dry_run),
+                "error": str(exc),
+            }
+        if payload.get("ok") and payload.get("appended") and not payload.get("dry_run"):
+            append_cli_rollout_event(
+                payload,
+                registry_path=registry_path,
+                runtime_root_arg=args.runtime_root,
+                event_kind="refresh_state",
+                agent_id=args.agent_id,
+                status="appended",
+                summary=(
+                    "refresh-state appended compact control-plane state with "
+                    f"classification={payload.get('classification')}"
+                ),
+                details={
+                    "command": "refresh-state",
+                    "progress_scope": payload.get("progress_scope") or "",
+                    "agent_lane": payload.get("agent_lane") or "",
+                    "autonomous_replan_recorded": bool(
+                        payload.get("autonomous_replan_recorded")
+                    ),
+                    "global_sync_wrote": bool(
+                        isinstance(payload.get("global_sync"), dict)
+                        and payload["global_sync"].get("wrote")
+                    ),
+                },
+            )
+        print_payload(payload, fmt, render_state_refresh_markdown)
+        return 0 if payload.get("ok") else 1
+
+    if args.command == "read-only-map":
+        try:
+            payload = read_only_project_map_run(
+                registry_path=registry_path,
+                runtime_root_override=args.runtime_root,
+                goal_id=args.goal_id,
+                project=Path(args.project).expanduser() if args.project else None,
+                state_file=Path(args.state_file).expanduser() if args.state_file else None,
+                classification=args.classification,
+                recommended_action=args.recommended_action,
+                dry_run=bool(args.dry_run),
+                sync_global=not bool(args.no_global_sync),
+            )
+        except Exception as exc:
+            payload = {
+                "ok": False,
+                "registry": str(registry_path),
+                "runtime_root": args.runtime_root,
+                "goal_id": args.goal_id,
+                "classification": args.classification,
+                "appended": False,
+                "dry_run": bool(args.dry_run),
+                "error": str(exc),
+            }
+        print_payload(payload, fmt, render_read_only_project_map_markdown)
+        return 0 if payload.get("ok") else 1
+
+    if args.command == "reward":
+        try:
+            reward = compact_reward(
+                recorded_at=args.recorded_at,
+                decision=args.decision,
+                reward=args.reward,
+                reason_summary=args.reason_summary,
+                follow_up=args.follow_up,
+            )
+            payload = append_human_reward(
+                registry_path=registry_path,
+                runtime_root_override=args.runtime_root,
+                goal_id=args.goal_id,
+                run_generated_at=args.run_generated_at,
+                reward=reward,
+                dry_run=bool(args.dry_run),
+                state_file_override=Path(args.state_file).expanduser() if args.state_file else None,
+                write_active_state_summary=bool(args.write_active_state_summary),
+            )
+        except Exception as exc:
+            payload = {
+                "ok": False,
+                "registry": str(registry_path),
+                "runtime_root": args.runtime_root,
+                "goal_id": args.goal_id,
+                "appended": False,
+                "dry_run": bool(args.dry_run),
+                "error": str(exc),
+            }
+        print_payload(payload, fmt, render_reward_markdown)
+        return 0 if payload.get("ok") else 1
+
+    try:
+        payload = record_operator_gate(
+            registry_path=registry_path,
+            runtime_root_override=args.runtime_root,
+            goal_id=args.goal_id,
+            gate=args.gate,
+            decision=args.decision,
+            operator_question=args.operator_question,
+            reason_summary=args.reason_summary,
+            follow_up=args.follow_up,
+            agent_command=args.agent_command,
+            recommended_action=args.recommended_action,
+            recorded_at=args.recorded_at,
+            dry_run=bool(args.dry_run),
+            sync_global=not bool(args.no_global_sync),
+        )
+    except Exception as exc:
+        payload = {
+            "ok": False,
+            "registry": str(registry_path),
+            "runtime_root": args.runtime_root,
+            "goal_id": args.goal_id,
+            "appended": False,
+            "dry_run": bool(args.dry_run),
+            "error": str(exc),
+        }
+    print_payload(payload, fmt, render_operator_gate_markdown)
+    return 0 if payload.get("ok") else 1


### PR DESCRIPTION
## Summary
- Extract refresh-state, read-only-map, reward, and operator-gate parser/handler logic into loopx/cli_commands/project_lifecycle.py
- Export/register the new command module from loopx/cli_commands and keep top-level cli.py as dispatcher glue
- Add a focused smoke covering source boundaries, subcommand --format json, dry-run behavior, and no run-index mutation

## Validation
- python3 -m py_compile loopx/cli.py loopx/cli_commands/__init__.py loopx/cli_commands/project_lifecycle.py examples/cli-project-lifecycle-command-modularization-smoke.py
- python3 examples/cli-project-lifecycle-command-modularization-smoke.py
- python3 examples/cli-worker-bridge-command-modularization-smoke.py
- python3 examples/cli-benchmark-review-lifecycle-command-modularization-smoke.py
- python3 examples/cli-agentissue-runner-flow-command-modularization-smoke.py
- python3 examples/cli-benchmark-boundary-command-modularization-smoke.py
- python3 examples/demo-cli-smoke.py
- python3 examples/project-agent-adoption-smoke.py
- python3 -m py_compile loopx/__init__.py
loopx/agent_registry.py
loopx/authority.py
loopx/benchmark.py
loopx/benchmark_adapters/__init__.py
loopx/benchmark_adapters/agentissue.py
loopx/benchmark_adapters/agents_last_exam.py
loopx/benchmark_adapters/skillsbench.py
loopx/benchmark_adapters/skillsbench_acp_relay.py
loopx/benchmark_adapters/skillsbench_remote_bridge.py
loopx/benchmark_adapters/terminal_bench.py
loopx/benchmark_case_analysis.py
loopx/benchmark_case_state.py
loopx/benchmark_core/__init__.py
loopx/benchmark_core/adapter.py
loopx/benchmark_core/artifacts.py
loopx/benchmark_core/attempts.py
loopx/benchmark_core/io.py
loopx/benchmark_core/lifecycle.py
loopx/benchmark_core/loop_protocol.py
loopx/benchmark_core/observable_handles.py
loopx/benchmark_core/parity.py
loopx/benchmark_core/rounds.py
loopx/benchmark_core/run_permissions.py
loopx/benchmark_core/split_control.py
loopx/benchmark_ledger.py
loopx/benchmark_trajectory.py
loopx/bootstrap.py
loopx/boundary_authority.py
loopx/cli.py
loopx/cli_commands/__init__.py
loopx/cli_commands/agentissue_runner_flow.py
loopx/cli_commands/agents_last_exam.py
loopx/cli_commands/benchmark_boundary.py
loopx/cli_commands/benchmark_review_lifecycle.py
loopx/cli_commands/benchmark_run_ledger.py
loopx/cli_commands/doctor.py
loopx/cli_commands/dreaming.py
loopx/cli_commands/history.py
loopx/cli_commands/ml_experiment.py
loopx/cli_commands/project_lifecycle.py
loopx/cli_commands/quota.py
loopx/cli_commands/starter.py
loopx/cli_commands/status.py
loopx/cli_commands/terminal_bench_adapter.py
loopx/cli_commands/terminal_bench_environment_result.py
loopx/cli_commands/todo.py
loopx/cli_commands/worker_bridge.py
loopx/codex_cli_probe.py
loopx/codex_goal_baseline.py
loopx/configure_goal.py
loopx/content_ops_surface.py
loopx/contract.py
loopx/control_plane.py
loopx/delivery_outcome.py
loopx/demo.py
loopx/diagnose.py
loopx/doctor.py
loopx/dreaming.py
loopx/execution_profile.py
loopx/feedback.py
loopx/file_lock.py
loopx/frontstage.py
loopx/global_registry.py
loopx/handoff_budget.py
loopx/heartbeat_prompt.py
loopx/history.py
loopx/interface_budget.py
loopx/materials.py
loopx/ml_experiment.py
loopx/onboarding.py
loopx/operator_gate.py
loopx/orchestration.py
loopx/paths.py
loopx/project_map.py
loopx/project_prompt.py
loopx/promotion_gate.py
loopx/quota.py
loopx/registry.py
loopx/review_packet.py
loopx/rollout_event_log.py
loopx/runtime.py
loopx/self_update.py
loopx/session_runtime.py
loopx/state_migration.py
loopx/state_projection.py
loopx/state_refresh.py
loopx/status.py
loopx/status_server.py
loopx/terminal_bench_agent.py
loopx/todo_contract.py
loopx/todos.py
loopx/upgrade.py
loopx/worker_bridge.py
- git diff --check
- python3 -m loopx.cli check --scan-path loopx/cli.py --scan-path loopx/cli_commands/__init__.py --scan-path loopx/cli_commands/project_lifecycle.py --scan-path examples/cli-project-lifecycle-command-modularization-smoke.py