### PR TITLE
Refactor registry admin CLI commands

### DIFF
--- a/examples/cli-registry-admin-command-modularization-smoke.py
+++ b/examples/cli-registry-admin-command-modularization-smoke.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CLI = ROOT / "loopx" / "cli.py"
+MODULE = ROOT / "loopx" / "cli_commands" / "registry_admin.py"
+INIT = ROOT / "loopx" / "cli_commands" / "__init__.py"
+GOAL_ID = "registry-admin-smoke"
+
+def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ, "PYTHONPATH": str(ROOT)}
+    return subprocess.run(
+        [sys.executable, "-m", "loopx.cli", *args],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def require_success(result: subprocess.CompletedProcess[str]) -> str:
+    if result.returncode != 0:
+        raise AssertionError(
+            f"expected success, got {result.returncode}\n"
+            f"stdout:\n{result.stdout}\n\nstderr:\n{result.stderr}"
+        )
+    return result.stdout
+
+
+def require_json_success(result: subprocess.CompletedProcess[str]) -> dict[str, object]:
+    stdout = require_success(result)
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise AssertionError(f"expected JSON output, got:\n{stdout}") from exc
+    require(payload.get("ok") is True, f"payload was not ok: {payload}")
+    return payload
+
+
+def run_json(command_prefix: tuple[str, ...], command: str, *args: str) -> dict[str, object]:
+    return require_json_success(run_cli(*command_prefix, command, *args))
+
+def write_json(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def write_fixture(project: Path) -> tuple[Path, Path, Path, Path]:
+    runtime_root = project / "runtime"
+    registry_path = project / ".loopx" / "registry.json"
+    legacy_registry_path = project / "legacy" / "registry.global.json"
+    doc_registry_path = project / "DOC_REGISTRY.yaml"
+    obsolete_runtime = runtime_root / "goals" / "obsolete-runtime-goal" / "runs"
+    obsolete_runtime.mkdir(parents=True, exist_ok=True)
+    (project / "README.md").write_text("# Registry Admin Smoke\n", encoding="utf-8")
+
+    goal = {
+        "id": GOAL_ID,
+        "objective": "Validate registry admin command modularization.",
+        "domain": "smoke",
+        "repo": str(project),
+        "state_file": ".codex/goals/registry-admin-smoke/ACTIVE_GOAL_STATE.md",
+        "status": "connected-read-only",
+        "adapter": {"kind": "read_only_project_map_v0", "status": "connected-read-only"},
+        "coordination": {
+            "registered_agents": [{"id": "codex-main-control", "role": "primary"}],
+            "primary_agent": "codex-main-control",
+        },
+        "guards": ["dry-run registry admin smoke fixture only"],
+    }
+    registry_payload = {
+        "schema_version": "0.1",
+        "registry_role": "project-local",
+        "common_runtime_root": str(runtime_root),
+        "goals": [goal],
+    }
+    write_json(registry_path, registry_payload)
+    write_json(
+        runtime_root / "registry.global.json",
+        {
+            "schema_version": "0.1",
+            "registry_role": "global-local",
+            "common_runtime_root": str(runtime_root),
+            "goals": [{**goal, "source_registry": str(registry_path)}],
+        },
+    )
+    write_json(
+        legacy_registry_path,
+        {
+            "schema_version": "0.1",
+            "common_runtime_root": str(project / "legacy-runtime"),
+            "goals": [
+                {
+                    "id": "legacy-smoke-goal",
+                    "objective": "Legacy smoke goal.",
+                    "repo": str(project / "legacy-repo"),
+                    "state_file": ".codex/goals/legacy-smoke-goal/ACTIVE_GOAL_STATE.md",
+                    "status": "legacy",
+                }
+            ],
+        },
+    )
+    doc_registry_path.write_text(
+        "version: doc_registry_v0\n"
+        "updated_at: 2026-06-22T00:00:00+00:00\n"
+        "default_entry_docs:\n"
+        "  - README.md\n"
+        "topic_authority:\n"
+        "  issue_fix: README.md\n"
+        "status_definitions:\n"
+        "  current: usable\n",
+        encoding="utf-8",
+    )
+    return registry_path, runtime_root, legacy_registry_path, doc_registry_path
+
+
+def main() -> None:
+    cli_source = CLI.read_text(encoding="utf-8")
+    module_source = MODULE.read_text(encoding="utf-8")
+    init_source = INIT.read_text(encoding="utf-8")
+
+    forbidden_cli_markers = [
+        "configure_goal_parser = sub.add_parser",
+        "register_agent_parser = sub.add_parser",
+        "archive_runtime_parser = sub.add_parser",
+        "sync_global_parser = sub.add_parser",
+        "migrate_state_parser = sub.add_parser",
+        "authority_parser = sub.add_parser",
+        "doc_registry_authority_parser = sub.add_parser",
+        "register_agent_via_source_registry(",
+        "configure_goal(",
+        "archive_runtime_goal(",
+        "migrate_legacy_state(",
+        "register_authority_source(",
+        "import_doc_registry_authority(",
+        'if args.command == "configure-goal":',
+        'if args.command == "register-agent":',
+        'if args.command == "archive-runtime":',
+        'if args.command == "sync-global":',
+        'if args.command == "migrate-state":',
+        'if args.command == "register-authority-source":',
+        'if args.command == "import-doc-registry-authority":',
+    ]
+    for marker in forbidden_cli_markers:
+        require(marker not in cli_source, f"registry admin marker leaked into cli.py: {marker}")
+
+    for marker in (
+        "REGISTRY_ADMIN_COMMANDS",
+        "register_registry_admin_commands",
+        "handle_registry_admin_command",
+        "configure-goal",
+        "register-agent",
+        "archive-runtime",
+        "sync-global",
+        "migrate-state",
+        "register-authority-source",
+        "import-doc-registry-authority",
+    ):
+        require(marker in module_source, f"registry admin module missing {marker}")
+    require("register_registry_admin_commands" in cli_source, "cli.py did not register registry admin commands")
+    require("handle_registry_admin_command" in cli_source, "cli.py did not dispatch registry admin commands")
+    require("register_registry_admin_commands" in init_source, "__init__ did not export registry admin registration")
+    require("handle_registry_admin_command" in init_source, "__init__ did not export registry admin handler")
+
+    for command, options in {
+        "configure-goal": ("--quota-compute", "--registered-agent", "--execute"),
+        "register-agent": ("--agent-id", "--primary-agent", "--execute"),
+        "archive-runtime": ("--archive-root", "--allow-registered", "--execute"),
+        "sync-global": ("--replace-state", "--dry-run"),
+        "migrate-state": ("--legacy-registry", "--goal-id-map", "--copy-runtime"),
+        "register-authority-source": ("--source-ref", "--boundary", "--no-global-sync"),
+        "import-doc-registry-authority": ("--doc-registry-path", "--import-topic-prefix", "--max-imported-topics"),
+    }.items():
+        help_text = require_success(run_cli(command, "--help"))
+        for option in options:
+            require(option in help_text, f"{command} help omitted {option}")
+
+    with tempfile.TemporaryDirectory(prefix="loopx-registry-admin-cli-") as tmp:
+        project = Path(tmp)
+        registry_path, runtime_root, legacy_registry_path, doc_registry_path = write_fixture(project)
+        command_prefix = ("--format", "json", "--registry", str(registry_path), "--runtime-root", str(runtime_root))
+        registry_before = registry_path.read_text(encoding="utf-8")
+
+        configure_payload = run_json(
+            command_prefix,
+            "configure-goal",
+            "--goal-id",
+            GOAL_ID,
+            "--quota-compute",
+            "2",
+            "--registered-agent",
+            "codex-product-capability",
+        )
+        require(configure_payload.get("dry_run") is True, "configure-goal should preview by default")
+        require(configure_payload.get("written") is False, "configure-goal preview should not write")
+
+        register_payload = run_json(
+            command_prefix,
+            "register-agent",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            "codex-product-capability",
+        )
+        require(register_payload.get("dry_run") is True, "register-agent should preview by default")
+        require("codex-product-capability" in (register_payload.get("registered_agents") or []), register_payload)
+
+        archive_payload = run_json(command_prefix, "archive-runtime", "--goal-id", "obsolete-runtime-goal")
+        require(archive_payload.get("dry_run") is True, "archive-runtime should dry-run by default")
+        require(archive_payload.get("archived") is False, "archive-runtime preview should not move")
+        require((runtime_root / "goals" / "obsolete-runtime-goal").exists(), "archive-runtime preview moved source")
+
+        sync_payload = run_json(command_prefix, "sync-global", "--goal-id", GOAL_ID, "--dry-run")
+        require(sync_payload.get("dry_run") is True, "sync-global should honor --dry-run")
+        require(sync_payload.get("wrote") is False, "sync-global dry-run should not write")
+
+        migrate_payload = run_json(
+            command_prefix,
+            "migrate-state",
+            "--legacy-registry",
+            str(legacy_registry_path),
+            "--legacy-runtime-root",
+            str(project / "legacy-runtime"),
+            "--target-runtime-root",
+            str(runtime_root),
+            "--goal-id",
+            "legacy-smoke-goal",
+            "--goal-id-map",
+            "legacy-smoke-goal=migrated-smoke-goal",
+            "--no-global-sync",
+        )
+        require(migrate_payload.get("dry_run") is True, "migrate-state should dry-run by default")
+        require(migrate_payload.get("wrote_project_registry") is False, "migrate-state preview should not write")
+        require("migrated-smoke-goal" in (migrate_payload.get("migrated_goal_ids") or []), migrate_payload)
+
+        authority_payload = run_json(
+            command_prefix,
+            "register-authority-source",
+            "--goal-id",
+            GOAL_ID,
+            "--source-id",
+            "source-smoke",
+            "--source-ref",
+            "https://example.com/public-smoke",
+            "--source-kind",
+            "doc",
+            "--role",
+            "smoke_authority",
+            "--freshness",
+            "current",
+            "--topic",
+            "issue_fix",
+            "--dry-run",
+            "--no-global-sync",
+        )
+        require(authority_payload.get("dry_run") is True, "authority registration should honor --dry-run")
+        require(authority_payload.get("written") is False, "authority dry-run should not write")
+        require(authority_payload.get("raw_source_ref_stored") is False, "authority source ref must stay redacted")
+
+        doc_payload = run_json(
+            command_prefix,
+            "import-doc-registry-authority",
+            "--goal-id",
+            GOAL_ID,
+            "--source-id",
+            "doc-registry-smoke",
+            "--doc-registry-path",
+            str(doc_registry_path),
+            "--topic",
+            "content_ops",
+            "--import-topic-prefix",
+            "smoke:",
+            "--dry-run",
+            "--no-global-sync",
+        )
+        require(doc_payload.get("dry_run") is True, "doc registry import should honor --dry-run")
+        require(doc_payload.get("written") is False, "doc registry import dry-run should not write")
+        require(doc_payload.get("raw_doc_registry_path_stored") is False, "doc registry path must stay redacted")
+        require(registry_path.read_text(encoding="utf-8") == registry_before, "dry-run commands mutated registry")
+
+    print("cli-registry-admin-command-modularization-smoke: ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -6,16 +6,8 @@ import sys
 from pathlib import Path
 
 from . import __version__
-from .authority import (
-    AUTHORITY_SOURCE_BOUNDARIES,
-    import_doc_registry_authority,
-    register_authority_source,
-    render_doc_registry_authority_import_markdown,
-    render_authority_source_markdown,
-)
 from .agent_registry import (
     agent_profile_from_registry,
-    normalize_registered_agents,
     primary_agent_id_from_registry,
     registered_agent_ids_from_registry,
     require_registered_agent_id,
@@ -29,7 +21,6 @@ from .bootstrap import (
 from .benchmark_core import (
     build_split_control_remote_executor_readiness,
 )
-from .configure_goal import configure_goal, render_configure_goal_markdown
 from .cli_commands import (
     handle_agents_last_exam_command,
     handle_agentissue_runner_flow_command,
@@ -62,6 +53,7 @@ from .cli_commands import (
     handle_new_project_prompt_command,
     handle_project_lifecycle_command,
     handle_quota_command,
+    handle_registry_admin_command,
     handle_review_packet_command,
     handle_status_command,
     handle_todo_command,
@@ -79,6 +71,7 @@ from .cli_commands import (
     register_ml_experiment_commands,
     register_project_lifecycle_commands,
     register_quota_command,
+    register_registry_admin_commands,
     register_starter_commands,
     register_status_commands,
     register_todo_command,
@@ -87,7 +80,6 @@ from .cli_commands import (
     register_worker_bridge_commands,
 )
 from .execution_profile import DEFAULT_EXECUTION_PROFILE
-from .global_registry import render_global_sync_markdown, sync_project_registry_to_global
 from .heartbeat_prompt import build_heartbeat_prompt, render_heartbeat_prompt_markdown
 from .history import (
     append_benchmark_run,
@@ -109,15 +101,6 @@ from .rollout_event_log import (
     append_rollout_event,
     build_rollout_event,
     rollout_event_log_path,
-)
-from .runtime import archive_runtime_goal, render_archive_runtime_markdown
-from .state_migration import (
-    LEGACY_GLOBAL_REGISTRY,
-    LEGACY_RUNTIME_ROOT,
-    legacy_registry_goal_ids,
-    migrate_legacy_state,
-    parse_key_value_map,
-    render_state_migration_markdown,
 )
 from .status import (
     compact_benchmark_run,
@@ -517,97 +500,6 @@ def default_public_scan_root() -> str:
     return str(Path(__file__).resolve().parents[1])
 
 
-def register_agent_via_source_registry(
-    *,
-    runtime_root_arg: str | None,
-    goal_id: str,
-    agent_ids: list[str],
-    primary_agent: str | None,
-    execute: bool,
-) -> dict[str, object]:
-    global_path = explicit_global_registry(runtime_root_arg)
-    if not global_path.exists():
-        raise FileNotFoundError(f"global registry does not exist: {global_path}")
-    global_registry = load_registry(global_path)
-    goal = next((item for item in registry_goals(global_registry) if item.get("id") == goal_id), None)
-    if goal is None:
-        raise ValueError(f"goal_id not found in global registry: {goal_id}")
-    source_registry = goal.get("source_registry")
-    if not source_registry:
-        raise ValueError(
-            f"{goal_id}: global registry entry has no source_registry; "
-            "use configure-goal with an explicit --registry instead of connect"
-        )
-    source_registry_path = Path(str(source_registry)).expanduser()
-    source_payload = load_registry(source_registry_path)
-    source_goal = next((item for item in registry_goals(source_payload) if item.get("id") == goal_id), None)
-    if source_goal is None:
-        raise ValueError(f"{goal_id}: source_registry does not contain the goal: {source_registry_path}")
-    coordination = source_goal.get("coordination") if isinstance(source_goal.get("coordination"), dict) else {}
-    existing_agents = normalize_registered_agents(coordination.get("registered_agents"))
-    requested_agents = normalize_registered_agents(agent_ids)
-    merged_agents = list(existing_agents)
-    for agent_id in requested_agents:
-        if agent_id not in merged_agents:
-            merged_agents.append(agent_id)
-    effective_primary = primary_agent or primary_agent_id_from_registry(source_registry_path, goal_id)
-    configure_payload = configure_goal(
-        registry_path=source_registry_path,
-        goal_id=goal_id,
-        registered_agents=merged_agents,
-        primary_agent=effective_primary,
-        execute=execute,
-    )
-    sync_payload: dict[str, object] | None = None
-    if execute and configure_payload.get("written"):
-        sync_payload = sync_project_registry_to_global(
-            registry_path=source_registry_path,
-            runtime_root_override=runtime_root_arg,
-            goal_id=goal_id,
-            dry_run=False,
-        )
-    return {
-        "ok": True,
-        "dry_run": not execute,
-        "execute": execute,
-        "goal_id": goal_id,
-        "global_registry": str(global_path),
-        "source_registry": str(source_registry_path),
-        "existing_agents": existing_agents,
-        "requested_agents": requested_agents,
-        "registered_agents": merged_agents,
-        "primary_agent": effective_primary,
-        "changed": configure_payload.get("changed"),
-        "written": configure_payload.get("written"),
-        "configure_goal": configure_payload,
-        "global_sync": sync_payload or {"enabled": bool(execute), "wrote": False},
-    }
-
-
-def render_register_agent_markdown(payload: dict[str, object]) -> str:
-    lines = [
-        "# LoopX Agent Registration",
-        "",
-        f"- ok: `{payload.get('ok')}`",
-        f"- dry_run: `{payload.get('dry_run')}`",
-        f"- goal_id: `{payload.get('goal_id')}`",
-        f"- global_registry: `{payload.get('global_registry')}`",
-        f"- source_registry: `{payload.get('source_registry')}`",
-        f"- primary_agent: `{payload.get('primary_agent')}`",
-        f"- changed: `{payload.get('changed')}`",
-        f"- written: `{payload.get('written')}`",
-    ]
-    if payload.get("error"):
-        lines.append(f"- error: {payload.get('error')}")
-        return "\n".join(lines)
-    lines.append(f"- existing_agents: `{', '.join(payload.get('existing_agents') or [])}`")
-    lines.append(f"- registered_agents: `{', '.join(payload.get('registered_agents') or [])}`")
-    sync_payload = payload.get("global_sync")
-    if isinstance(sync_payload, dict):
-        lines.append(f"- global_sync_wrote: `{sync_payload.get('wrote')}`")
-    return "\n".join(lines)
-
-
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="LoopX control-plane helper.")
     parser.add_argument("--version", action="version", version=f"loopx {__version__}")
@@ -872,147 +764,7 @@ def main(argv: list[str] | None = None) -> int:
         help="Return non-zero if the registry should be ignored but is neither ignored nor tracked.",
     )
 
-    configure_goal_parser = sub.add_parser(
-        "configure-goal",
-        help="Preview or apply per-goal registry settings for quota, self-repair, and orchestration.",
-    )
-    configure_goal_parser.add_argument("--goal-id", required=True, help="Goal id to configure.")
-    configure_goal_parser.add_argument("--quota-compute", type=float, help="Per-goal quota compute multiplier.")
-    configure_goal_parser.add_argument("--quota-window-hours", type=float, help="Quota rolling window in hours.")
-    configure_goal_parser.add_argument(
-        "--self-repair-enabled",
-        action=argparse.BooleanOptionalAction,
-        default=None,
-        help="Enable or disable control_plane.self_repair for this goal.",
-    )
-    configure_goal_parser.add_argument(
-        "--self-repair-health",
-        action=argparse.BooleanOptionalAction,
-        default=None,
-        help="Enable or disable control-plane health blocker repair for this goal.",
-    )
-    configure_goal_parser.add_argument(
-        "--self-repair-waiting-projection",
-        action=argparse.BooleanOptionalAction,
-        default=None,
-        help="Enable or disable waiting-projection repair for this goal.",
-    )
-    configure_goal_parser.add_argument(
-        "--orchestration-mode",
-        choices=["default", "multi_subagent"],
-        help="Per-goal orchestration mode.",
-    )
-    configure_goal_parser.add_argument(
-        "--spawn-allowed",
-        action=argparse.BooleanOptionalAction,
-        default=None,
-        help="Allow or block sub-agent spawning for this goal.",
-    )
-    configure_goal_parser.add_argument("--max-children", type=int, help="Maximum child agents for orchestration.")
-    configure_goal_parser.add_argument(
-        "--allowed-domain",
-        action="append",
-        default=None,
-        help="Allowed child-agent domain. Repeatable; comma-separated values are also accepted.",
-    )
-    configure_goal_parser.add_argument(
-        "--clear-allowed-domains",
-        action="store_true",
-        help="Clear allowed child-agent domains.",
-    )
-    configure_goal_parser.add_argument(
-        "--registered-agent",
-        dest="registered_agents",
-        action="append",
-        default=None,
-        help=(
-            "Registered public-safe agent id allowed to claim todos and receive scoped "
-            "heartbeat prompts. Repeatable; comma-separated values are also accepted."
-        ),
-    )
-    configure_goal_parser.add_argument(
-        "--clear-registered-agents",
-        action="store_true",
-        help="Clear coordination.registered_agents.",
-    )
-    configure_goal_parser.add_argument(
-        "--primary-agent",
-        help=(
-            "The single registered agent id that owns main-control review, "
-            "verification, merge, and final project coordination."
-        ),
-    )
-    configure_goal_parser.add_argument(
-        "--clear-primary-agent",
-        action="store_true",
-        help="Clear coordination.primary_agent.",
-    )
-    configure_goal_parser.add_argument(
-        "--waiting-on",
-        choices=["codex", "user_or_controller", "controller", "external_evidence"],
-        help="Override registry waiting owner for status/quota routing.",
-    )
-    configure_goal_parser.add_argument(
-        "--clear-waiting-on",
-        action="store_true",
-        help="Remove the registry waiting_on override.",
-    )
-    configure_goal_parser.add_argument(
-        "--boundary-authority-scope",
-        action="append",
-        default=None,
-        help=(
-            "Checkpointed write scope approved by an operator/controller decision. "
-            "Repeatable; comma-separated values are also accepted."
-        ),
-    )
-    configure_goal_parser.add_argument(
-        "--boundary-authority-source",
-        help="Public-safe provenance for the checkpointed boundary authority.",
-    )
-    configure_goal_parser.add_argument(
-        "--boundary-authority-decision-id",
-        help="Public-safe decision/run/gate id for the checkpointed boundary authority.",
-    )
-    configure_goal_parser.add_argument(
-        "--boundary-authority-recorded-at",
-        help="ISO timestamp for the checkpointed decision. Defaults to now.",
-    )
-    configure_goal_parser.add_argument(
-        "--boundary-authority-expires-at",
-        help="Optional ISO timestamp after which the checkpointed authority is no longer fresh.",
-    )
-    configure_goal_parser.add_argument(
-        "--clear-boundary-authority",
-        action="store_true",
-        help="Clear coordination.checkpointed_boundary_authority.",
-    )
-    configure_goal_parser.add_argument(
-        "--execute",
-        action="store_true",
-        help="Write the registry. Without this flag, configure-goal is a dry-run preview.",
-    )
-
-    register_agent_parser = sub.add_parser(
-        "register-agent",
-        help="Register an automation agent through the existing global source_registry without reconnecting the goal.",
-    )
-    register_agent_parser.add_argument("--goal-id", required=True, help="Goal id already present in the global registry.")
-    register_agent_parser.add_argument(
-        "--agent-id",
-        action="append",
-        required=True,
-        help="Public-safe agent id to add. Repeatable; comma-separated values are also accepted.",
-    )
-    register_agent_parser.add_argument(
-        "--primary-agent",
-        help="Optional primary agent id to set; defaults to the existing primary agent.",
-    )
-    register_agent_parser.add_argument(
-        "--execute",
-        action="store_true",
-        help="Write the source registry and sync it globally. Without this flag, preview only.",
-    )
+    register_registry_admin_commands(sub)
 
     register_history_command(sub)
 
@@ -1033,195 +785,7 @@ def main(argv: list[str] | None = None) -> int:
     register_benchmark_review_lifecycle_commands(benchmark_sub, add_subcommand_format)
     register_terminal_bench_environment_result_commands(benchmark_sub, add_subcommand_format)
 
-    archive_runtime_parser = sub.add_parser(
-        "archive-runtime",
-        help="Move an obsolete runtime goal directory into the archive area. Defaults to dry-run.",
-    )
-    archive_runtime_parser.add_argument("--goal-id", required=True, help="Runtime goal id to archive.")
-    archive_runtime_parser.add_argument(
-        "--archive-root",
-        help="Archive directory. Defaults to <runtime-root>/archived-goals.",
-    )
-    archive_runtime_parser.add_argument(
-        "--allow-registered",
-        action="store_true",
-        help="Allow archiving a goal that is still present in the registry.",
-    )
-    archive_runtime_parser.add_argument(
-        "--execute",
-        action="store_true",
-        help="Actually move the runtime directory. Without this flag the command is a dry-run.",
-    )
-
-    sync_global_parser = sub.add_parser(
-        "sync-global",
-        help="Merge this project-local registry into the shared global registry.",
-    )
-    sync_global_parser.add_argument("--goal-id", help="Only sync one goal id from the source registry.")
-    sync_global_parser.add_argument(
-        "--replace-state",
-        action="store_true",
-        help="Allow replacing an existing global route and write a backup before doing so.",
-    )
-    sync_global_parser.add_argument("--dry-run", action="store_true", help="Preview the global registry merge.")
-
-    migrate_state_parser = sub.add_parser(
-        "migrate-state",
-        help="One-shot migration from a legacy Goal Harness registry/runtime into LoopX state.",
-    )
-    migrate_state_parser.add_argument(
-        "--legacy-registry",
-        default=str(LEGACY_GLOBAL_REGISTRY),
-        help="Legacy registry JSON to import from. Defaults to ~/.codex/goal-harness/registry.global.json.",
-    )
-    migrate_state_parser.add_argument(
-        "--legacy-runtime-root",
-        default=str(LEGACY_RUNTIME_ROOT),
-        help="Legacy runtime root. Defaults to ~/.codex/goal-harness.",
-    )
-    migrate_state_parser.add_argument(
-        "--target-runtime-root",
-        help="LoopX runtime root. Defaults to --runtime-root or ~/.codex/loopx.",
-    )
-    migrate_goal_selector = migrate_state_parser.add_mutually_exclusive_group(required=True)
-    migrate_goal_selector.add_argument(
-        "--goal-id",
-        action="append",
-        help="Legacy goal id to migrate. Repeat for multiple explicit goals.",
-    )
-    migrate_goal_selector.add_argument(
-        "--all-goals",
-        action="store_true",
-        help="Migrate every goal listed in the explicit legacy registry. Still dry-run by default.",
-    )
-    migrate_state_parser.add_argument(
-        "--goal-id-map",
-        action="append",
-        default=[],
-        metavar="OLD=NEW",
-        help="Rename a goal id during migration, for example goal-harness-meta=loopx-meta.",
-    )
-    migrate_state_parser.add_argument(
-        "--path-map",
-        action="append",
-        default=[],
-        metavar="OLD=NEW",
-        help="Rewrite local path prefixes during migration.",
-    )
-    migrate_state_parser.add_argument(
-        "--copy-active-state",
-        action="store_true",
-        help="Copy and rewrite selected goals' active-state files into their migrated target paths.",
-    )
-    migrate_state_parser.add_argument(
-        "--copy-runtime",
-        action="store_true",
-        help="Copy and rewrite selected runtime goal directories from the legacy runtime root.",
-    )
-    migrate_state_parser.add_argument(
-        "--no-global-sync",
-        action="store_true",
-        help="Do not sync the migrated project registry into the LoopX global registry after --execute.",
-    )
-    migrate_state_parser.add_argument(
-        "--execute",
-        action="store_true",
-        help="Write migrated state. Without this flag the command is a dry-run preview.",
-    )
-
     register_project_lifecycle_commands(sub, add_subcommand_format)
-
-    authority_parser = sub.add_parser(
-        "register-authority-source",
-        help="Register a redacted local authority/material source for a goal.",
-    )
-    authority_parser.add_argument("--goal-id", required=True, help="Goal id whose local registry should be updated.")
-    authority_parser.add_argument("--source-id", required=True, help="Stable local source id.")
-    authority_parser.add_argument(
-        "--source-ref",
-        help="Raw local source reference to hash and redact. The raw value is never stored.",
-    )
-    authority_parser.add_argument("--source-kind", required=True, help="Public-safe source kind, such as doc or repository.")
-    authority_parser.add_argument("--role", required=True, help="Public-safe material role.")
-    authority_parser.add_argument("--freshness", required=True, help="Public-safe freshness state.")
-    authority_parser.add_argument("--owner-status", help="Optional public-safe owner/review status.")
-    authority_parser.add_argument("--gate-status", help="Optional public-safe gate status.")
-    authority_parser.add_argument(
-        "--boundary",
-        choices=sorted(AUTHORITY_SOURCE_BOUNDARIES),
-        default="private_redacted",
-        help="Public/private boundary for this source. Defaults to private_redacted.",
-    )
-    authority_parser.add_argument("--revision", help="Optional public-safe revision label.")
-    authority_parser.add_argument("--conflict-rule", help="Optional public-safe conflict rule.")
-    authority_parser.add_argument("--topic", help="Optional topic_authority key to map to this source id.")
-    authority_parser.add_argument("--dry-run", action="store_true", help="Preview the registry update without writing.")
-    authority_parser.add_argument(
-        "--no-global-sync",
-        action="store_true",
-        help="Do not refresh the shared global registry after writing the local source registry.",
-    )
-
-    doc_registry_authority_parser = sub.add_parser(
-        "import-doc-registry-authority",
-        help="Import a redacted DOC_REGISTRY summary as a local authority/material source.",
-    )
-    doc_registry_authority_parser.add_argument(
-        "--goal-id", required=True, help="Goal id whose local registry should be updated."
-    )
-    doc_registry_authority_parser.add_argument("--source-id", required=True, help="Stable local source id.")
-    doc_registry_authority_parser.add_argument(
-        "--doc-registry-path",
-        required=True,
-        help="Local DOC_REGISTRY.yaml path to read. The raw path is hashed and not stored.",
-    )
-    doc_registry_authority_parser.add_argument(
-        "--source-kind",
-        default="doc_registry",
-        help="Public-safe source kind. Defaults to doc_registry.",
-    )
-    doc_registry_authority_parser.add_argument(
-        "--role",
-        default="external_doc_authority_registry",
-        help="Public-safe material role. Defaults to external_doc_authority_registry.",
-    )
-    doc_registry_authority_parser.add_argument(
-        "--freshness",
-        default="current",
-        help="Public-safe freshness state. Defaults to current.",
-    )
-    doc_registry_authority_parser.add_argument("--owner-status", help="Optional public-safe owner/review status.")
-    doc_registry_authority_parser.add_argument("--gate-status", help="Optional public-safe gate status.")
-    doc_registry_authority_parser.add_argument(
-        "--boundary",
-        choices=sorted(AUTHORITY_SOURCE_BOUNDARIES),
-        default="private_redacted",
-        help="Public/private boundary for this source. Defaults to private_redacted.",
-    )
-    doc_registry_authority_parser.add_argument("--revision", help="Optional public-safe revision label.")
-    doc_registry_authority_parser.add_argument("--conflict-rule", help="Optional public-safe conflict rule.")
-    doc_registry_authority_parser.add_argument(
-        "--topic",
-        action="append",
-        default=[],
-        help="Additional local topic_authority key to map to this source id. Repeatable.",
-    )
-    doc_registry_authority_parser.add_argument(
-        "--import-topic-prefix",
-        help="Prefix imported DOC_REGISTRY topic keys with this value before mapping them to the source id.",
-    )
-    doc_registry_authority_parser.add_argument(
-        "--max-imported-topics",
-        type=int,
-        default=50,
-        help="Maximum DOC_REGISTRY topics to map when --import-topic-prefix is set. Defaults to 50.",
-    )
-    doc_registry_authority_parser.add_argument("--dry-run", action="store_true", help="Preview without writing.")
-    doc_registry_authority_parser.add_argument(
-        "--no-global-sync",
-        action="store_true",
-        help="Do not refresh the shared global registry after writing the local source registry.",
-    )
 
     register_status_commands(sub, add_subcommand_format)
     register_dreaming_commands(sub, add_subcommand_format)
@@ -1580,70 +1144,13 @@ def main(argv: list[str] | None = None) -> int:
         print_payload(payload, args.format, render_registry_boundary_markdown)
         return 0 if payload.get("ok") else 1
 
-    if args.command == "configure-goal":
-        try:
-            payload = configure_goal(
-                registry_path=registry_path,
-                goal_id=args.goal_id,
-                quota_compute=args.quota_compute,
-                quota_window_hours=args.quota_window_hours,
-                self_repair_enabled=args.self_repair_enabled,
-                self_repair_health=args.self_repair_health,
-                self_repair_waiting_projection=args.self_repair_waiting_projection,
-                orchestration_mode=args.orchestration_mode,
-                spawn_allowed=args.spawn_allowed,
-                max_children=args.max_children,
-                allowed_domains=args.allowed_domain,
-                clear_allowed_domains=bool(args.clear_allowed_domains),
-                registered_agents=args.registered_agents,
-                clear_registered_agents=bool(args.clear_registered_agents),
-                primary_agent=args.primary_agent,
-                clear_primary_agent=bool(args.clear_primary_agent),
-                waiting_on=args.waiting_on,
-                clear_waiting_on=bool(args.clear_waiting_on),
-                boundary_authority_scopes=args.boundary_authority_scope,
-                boundary_authority_source=args.boundary_authority_source,
-                boundary_authority_decision_id=args.boundary_authority_decision_id,
-                boundary_authority_recorded_at=args.boundary_authority_recorded_at,
-                boundary_authority_expires_at=args.boundary_authority_expires_at,
-                clear_boundary_authority=bool(args.clear_boundary_authority),
-                execute=bool(args.execute),
-            )
-        except Exception as exc:
-            payload = {
-                "ok": False,
-                "dry_run": not bool(args.execute),
-                "execute": bool(args.execute),
-                "registry": str(registry_path),
-                "goal_id": args.goal_id,
-                "changed": False,
-                "written": False,
-                "error": str(exc),
-            }
-        print_payload(payload, args.format, render_configure_goal_markdown)
-        return 0 if payload.get("ok") else 1
-
-    if args.command == "register-agent":
-        try:
-            payload = register_agent_via_source_registry(
-                runtime_root_arg=args.runtime_root,
-                goal_id=args.goal_id,
-                agent_ids=args.agent_id,
-                primary_agent=args.primary_agent,
-                execute=bool(args.execute),
-            )
-        except Exception as exc:
-            payload = {
-                "ok": False,
-                "dry_run": not bool(args.execute),
-                "execute": bool(args.execute),
-                "goal_id": args.goal_id,
-                "changed": False,
-                "written": False,
-                "error": str(exc),
-            }
-        print_payload(payload, args.format, render_register_agent_markdown)
-        return 0 if payload.get("ok") else 1
+    registry_admin_result = handle_registry_admin_command(
+        args,
+        registry_path=registry_path,
+        print_payload=print_payload,
+    )
+    if registry_admin_result is not None:
+        return registry_admin_result
 
     if args.command == "benchmark":
         agentissue_runner_flow_result = handle_agentissue_runner_flow_command(
@@ -1708,114 +1215,6 @@ def main(argv: list[str] | None = None) -> int:
             append_benchmark_result_rollout_event=append_benchmark_result_rollout_event,
         )
 
-    if args.command == "archive-runtime":
-        try:
-            payload = archive_runtime_goal(
-                registry_path=registry_path,
-                runtime_root_override=args.runtime_root,
-                goal_id=args.goal_id,
-                archive_root=Path(args.archive_root).expanduser() if args.archive_root else None,
-                allow_registered=bool(args.allow_registered),
-                execute=bool(args.execute),
-            )
-        except Exception as exc:
-            payload = {
-                "ok": False,
-                "registry": str(registry_path),
-                "runtime_root": args.runtime_root,
-                "goal_id": args.goal_id,
-                "dry_run": not bool(args.execute),
-                "archived": False,
-                "error": str(exc),
-            }
-        print_payload(payload, args.format, render_archive_runtime_markdown)
-        return 0 if payload.get("ok") else 1
-
-    if args.command == "sync-global":
-        try:
-            payload = sync_project_registry_to_global(
-                registry_path=registry_path,
-                runtime_root_override=args.runtime_root,
-                goal_id=args.goal_id,
-                dry_run=bool(args.dry_run),
-                allow_route_replacement=bool(args.replace_state),
-            )
-        except Exception as exc:
-            registry = load_registry(registry_path)
-            runtime_root = resolve_runtime_root(registry, args.runtime_root)
-            payload = {
-                "ok": False,
-                "registry": str(registry_path),
-                "runtime_root": str(runtime_root),
-                "global_registry": str(global_registry_path(runtime_root)),
-                "dry_run": bool(args.dry_run),
-                "error": str(exc),
-            }
-        print_payload(payload, args.format, render_global_sync_markdown)
-        return 0 if payload.get("ok") else 1
-
-    if args.command == "migrate-state":
-        try:
-            target_runtime_root = (
-                Path(args.target_runtime_root).expanduser()
-                if args.target_runtime_root
-                else (Path(args.runtime_root).expanduser() if args.runtime_root else DEFAULT_RUNTIME_ROOT)
-            )
-            selected_goal_ids = (
-                legacy_registry_goal_ids(Path(args.legacy_registry))
-                if args.all_goals
-                else (args.goal_id or [])
-            )
-            payload = migrate_legacy_state(
-                legacy_registry_path=Path(args.legacy_registry),
-                target_registry_path=registry_path,
-                legacy_runtime_root=Path(args.legacy_runtime_root),
-                target_runtime_root=target_runtime_root,
-                goal_ids=selected_goal_ids,
-                goal_id_map=parse_key_value_map(args.goal_id_map, flag_name="--goal-id-map"),
-                path_map=parse_key_value_map(args.path_map, flag_name="--path-map"),
-                copy_active_state=bool(args.copy_active_state),
-                copy_runtime=bool(args.copy_runtime),
-                execute=bool(args.execute),
-            )
-            if payload.get("ok") and args.execute and not args.no_global_sync:
-                sync_results = []
-                for migrated_goal_id in payload.get("migrated_goal_ids") or []:
-                    sync_results.append(
-                        sync_project_registry_to_global(
-                            registry_path=registry_path,
-                            runtime_root_override=str(target_runtime_root),
-                            goal_id=str(migrated_goal_id),
-                            dry_run=False,
-                        )
-                    )
-                payload["global_sync"] = {
-                    "ok": all(result.get("ok") for result in sync_results),
-                    "dry_run": False,
-                    "wrote": bool(sync_results),
-                    "results": sync_results,
-                    "synced_goal_ids": [
-                        goal_id
-                        for result in sync_results
-                        for goal_id in (result.get("synced_goal_ids") or [])
-                    ],
-                }
-        except Exception as exc:
-            payload = {
-                "ok": False,
-                "schema_version": "loopx_state_migration_v0",
-                "dry_run": not bool(args.execute),
-                "execute": bool(args.execute),
-                "legacy_registry": args.legacy_registry,
-                "target_registry": str(registry_path),
-                "legacy_runtime_root": args.legacy_runtime_root,
-                "target_runtime_root": args.target_runtime_root or args.runtime_root or str(DEFAULT_RUNTIME_ROOT),
-                "selected_goal_ids": args.goal_id or ([] if not getattr(args, "all_goals", False) else ["<all-goals>"]),
-                "error": str(exc),
-            }
-        print_payload(payload, args.format, render_state_migration_markdown)
-        return 0 if payload.get("ok") else 1
-
     project_lifecycle_result = handle_project_lifecycle_command(
         args,
         registry_path=registry_path,
@@ -1825,96 +1224,6 @@ def main(argv: list[str] | None = None) -> int:
     )
     if project_lifecycle_result is not None:
         return project_lifecycle_result
-
-    if args.command == "register-authority-source":
-        try:
-            payload = register_authority_source(
-                registry_path=registry_path,
-                goal_id=args.goal_id,
-                source_id=args.source_id,
-                source_ref=args.source_ref,
-                source_kind=args.source_kind,
-                role=args.role,
-                freshness=args.freshness,
-                owner_status=args.owner_status,
-                gate_status=args.gate_status,
-                boundary=args.boundary,
-                revision=args.revision,
-                conflict_rule=args.conflict_rule,
-                topic=args.topic,
-                dry_run=bool(args.dry_run),
-            )
-            if not bool(args.no_global_sync):
-                if args.dry_run:
-                    payload["global_sync"] = {"enabled": True, "dry_run": True, "wrote": False}
-                else:
-                    payload["global_sync"] = sync_project_registry_to_global(
-                        registry_path=registry_path,
-                        runtime_root_override=args.runtime_root,
-                        goal_id=args.goal_id,
-                        dry_run=False,
-                    )
-            else:
-                payload["global_sync"] = {"enabled": False}
-        except Exception as exc:
-            payload = {
-                "ok": False,
-                "registry": str(registry_path),
-                "runtime_root": args.runtime_root,
-                "goal_id": args.goal_id,
-                "source_id": getattr(args, "source_id", None),
-                "written": False,
-                "dry_run": bool(getattr(args, "dry_run", False)),
-                "error": str(exc),
-            }
-        print_payload(payload, args.format, render_authority_source_markdown)
-        return 0 if payload.get("ok") else 1
-
-    if args.command == "import-doc-registry-authority":
-        try:
-            payload = import_doc_registry_authority(
-                registry_path=registry_path,
-                goal_id=args.goal_id,
-                source_id=args.source_id,
-                doc_registry_path=Path(args.doc_registry_path),
-                source_kind=args.source_kind,
-                role=args.role,
-                freshness=args.freshness,
-                owner_status=args.owner_status,
-                gate_status=args.gate_status,
-                boundary=args.boundary,
-                revision=args.revision,
-                conflict_rule=args.conflict_rule,
-                topics=list(args.topic or []),
-                import_topic_prefix=args.import_topic_prefix,
-                max_imported_topics=int(args.max_imported_topics),
-                dry_run=bool(args.dry_run),
-            )
-            if not bool(args.no_global_sync):
-                if args.dry_run:
-                    payload["global_sync"] = {"enabled": True, "dry_run": True, "wrote": False}
-                else:
-                    payload["global_sync"] = sync_project_registry_to_global(
-                        registry_path=registry_path,
-                        runtime_root_override=args.runtime_root,
-                        goal_id=args.goal_id,
-                        dry_run=False,
-                    )
-            else:
-                payload["global_sync"] = {"enabled": False}
-        except Exception as exc:
-            payload = {
-                "ok": False,
-                "registry": str(registry_path),
-                "runtime_root": args.runtime_root,
-                "goal_id": args.goal_id,
-                "source_id": getattr(args, "source_id", None),
-                "written": False,
-                "dry_run": bool(getattr(args, "dry_run", False)),
-                "error": str(exc),
-            }
-        print_payload(payload, args.format, render_doc_registry_authority_import_markdown)
-        return 0 if payload.get("ok") else 1
 
     if args.command == "check":
         return handle_check_command(

--- a/loopx/cli_commands/__init__.py
+++ b/loopx/cli_commands/__init__.py
@@ -37,6 +37,10 @@ from .project_lifecycle import (
     register_project_lifecycle_commands,
 )
 from .quota import handle_quota_command, register_quota_command
+from .registry_admin import (
+    handle_registry_admin_command,
+    register_registry_admin_commands,
+)
 from .starter import (
     handle_codex_cli_bounded_visible_pilot_adapter_command,
     handle_codex_cli_bootstrap_message_command,
@@ -108,6 +112,7 @@ __all__ = [
     "handle_new_project_prompt_command",
     "handle_project_lifecycle_command",
     "handle_quota_command",
+    "handle_registry_admin_command",
     "handle_review_packet_command",
     "handle_status_command",
     "handle_terminal_bench_adapter_command",
@@ -125,6 +130,7 @@ __all__ = [
     "register_ml_experiment_commands",
     "register_project_lifecycle_commands",
     "register_quota_command",
+    "register_registry_admin_commands",
     "register_starter_commands",
     "register_status_commands",
     "register_terminal_bench_adapter_commands",

--- a/loopx/cli_commands/registry_admin.py
+++ b/loopx/cli_commands/registry_admin.py
@@ -1,0 +1,747 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+from pathlib import Path
+
+from ..agent_registry import (
+    normalize_registered_agents,
+    primary_agent_id_from_registry,
+)
+from ..authority import (
+    AUTHORITY_SOURCE_BOUNDARIES,
+    import_doc_registry_authority,
+    register_authority_source,
+    render_doc_registry_authority_import_markdown,
+    render_authority_source_markdown,
+)
+from ..configure_goal import configure_goal, render_configure_goal_markdown
+from ..global_registry import render_global_sync_markdown, sync_project_registry_to_global
+from ..history import load_registry
+from ..paths import DEFAULT_RUNTIME_ROOT, global_registry_path, resolve_runtime_root
+from ..registry import registry_goals
+from ..runtime import archive_runtime_goal, render_archive_runtime_markdown
+from ..state_migration import (
+    LEGACY_GLOBAL_REGISTRY,
+    LEGACY_RUNTIME_ROOT,
+    legacy_registry_goal_ids,
+    migrate_legacy_state,
+    parse_key_value_map,
+    render_state_migration_markdown,
+)
+
+
+PrintPayload = Callable[
+    [dict[str, object], str, Callable[[dict[str, object]], str]],
+    None,
+]
+
+REGISTRY_ADMIN_COMMANDS = {
+    "configure-goal",
+    "register-agent",
+    "archive-runtime",
+    "sync-global",
+    "migrate-state",
+    "register-authority-source",
+    "import-doc-registry-authority",
+}
+
+
+def explicit_global_registry(runtime_root_arg: str | None) -> Path:
+    runtime_root = Path(runtime_root_arg).expanduser() if runtime_root_arg else DEFAULT_RUNTIME_ROOT
+    return global_registry_path(runtime_root)
+
+
+def register_agent_via_source_registry(
+    *,
+    runtime_root_arg: str | None,
+    goal_id: str,
+    agent_ids: list[str],
+    primary_agent: str | None,
+    execute: bool,
+) -> dict[str, object]:
+    global_path = explicit_global_registry(runtime_root_arg)
+    if not global_path.exists():
+        raise FileNotFoundError(f"global registry does not exist: {global_path}")
+    global_registry = load_registry(global_path)
+    goal = next((item for item in registry_goals(global_registry) if item.get("id") == goal_id), None)
+    if goal is None:
+        raise ValueError(f"goal_id not found in global registry: {goal_id}")
+    source_registry = goal.get("source_registry")
+    if not source_registry:
+        raise ValueError(
+            f"{goal_id}: global registry entry has no source_registry; "
+            "use configure-goal with an explicit --registry instead of connect"
+        )
+    source_registry_path = Path(str(source_registry)).expanduser()
+    source_payload = load_registry(source_registry_path)
+    source_goal = next((item for item in registry_goals(source_payload) if item.get("id") == goal_id), None)
+    if source_goal is None:
+        raise ValueError(f"{goal_id}: source_registry does not contain the goal: {source_registry_path}")
+    coordination = source_goal.get("coordination") if isinstance(source_goal.get("coordination"), dict) else {}
+    existing_agents = normalize_registered_agents(coordination.get("registered_agents"))
+    requested_agents = normalize_registered_agents(agent_ids)
+    merged_agents = list(existing_agents)
+    for agent_id in requested_agents:
+        if agent_id not in merged_agents:
+            merged_agents.append(agent_id)
+    effective_primary = primary_agent or primary_agent_id_from_registry(source_registry_path, goal_id)
+    configure_payload = configure_goal(
+        registry_path=source_registry_path,
+        goal_id=goal_id,
+        registered_agents=merged_agents,
+        primary_agent=effective_primary,
+        execute=execute,
+    )
+    sync_payload: dict[str, object] | None = None
+    if execute and configure_payload.get("written"):
+        sync_payload = sync_project_registry_to_global(
+            registry_path=source_registry_path,
+            runtime_root_override=runtime_root_arg,
+            goal_id=goal_id,
+            dry_run=False,
+        )
+    return {
+        "ok": True,
+        "dry_run": not execute,
+        "execute": execute,
+        "goal_id": goal_id,
+        "global_registry": str(global_path),
+        "source_registry": str(source_registry_path),
+        "existing_agents": existing_agents,
+        "requested_agents": requested_agents,
+        "registered_agents": merged_agents,
+        "primary_agent": effective_primary,
+        "changed": configure_payload.get("changed"),
+        "written": configure_payload.get("written"),
+        "configure_goal": configure_payload,
+        "global_sync": sync_payload or {"enabled": bool(execute), "wrote": False},
+    }
+
+
+def render_register_agent_markdown(payload: dict[str, object]) -> str:
+    lines = [
+        "# LoopX Agent Registration",
+        "",
+        f"- ok: `{payload.get('ok')}`",
+        f"- dry_run: `{payload.get('dry_run')}`",
+        f"- goal_id: `{payload.get('goal_id')}`",
+        f"- global_registry: `{payload.get('global_registry')}`",
+        f"- source_registry: `{payload.get('source_registry')}`",
+        f"- primary_agent: `{payload.get('primary_agent')}`",
+        f"- changed: `{payload.get('changed')}`",
+        f"- written: `{payload.get('written')}`",
+    ]
+    if payload.get("error"):
+        lines.append(f"- error: {payload.get('error')}")
+        return "\n".join(lines)
+    lines.append(f"- existing_agents: `{', '.join(payload.get('existing_agents') or [])}`")
+    lines.append(f"- registered_agents: `{', '.join(payload.get('registered_agents') or [])}`")
+    sync_payload = payload.get("global_sync")
+    if isinstance(sync_payload, dict):
+        lines.append(f"- global_sync_wrote: `{sync_payload.get('wrote')}`")
+    return "\n".join(lines)
+
+
+def register_registry_admin_commands(subparsers: argparse._SubParsersAction) -> None:
+    configure_goal_parser = subparsers.add_parser(
+        "configure-goal",
+        help="Preview or apply per-goal registry settings for quota, self-repair, and orchestration.",
+    )
+    configure_goal_parser.add_argument("--goal-id", required=True, help="Goal id to configure.")
+    configure_goal_parser.add_argument("--quota-compute", type=float, help="Per-goal quota compute multiplier.")
+    configure_goal_parser.add_argument("--quota-window-hours", type=float, help="Quota rolling window in hours.")
+    configure_goal_parser.add_argument(
+        "--self-repair-enabled",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Enable or disable control_plane.self_repair for this goal.",
+    )
+    configure_goal_parser.add_argument(
+        "--self-repair-health",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Enable or disable control-plane health blocker repair for this goal.",
+    )
+    configure_goal_parser.add_argument(
+        "--self-repair-waiting-projection",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Enable or disable waiting-projection repair for this goal.",
+    )
+    configure_goal_parser.add_argument(
+        "--orchestration-mode",
+        choices=["default", "multi_subagent"],
+        help="Per-goal orchestration mode.",
+    )
+    configure_goal_parser.add_argument(
+        "--spawn-allowed",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Allow or block sub-agent spawning for this goal.",
+    )
+    configure_goal_parser.add_argument("--max-children", type=int, help="Maximum child agents for orchestration.")
+    configure_goal_parser.add_argument(
+        "--allowed-domain",
+        action="append",
+        default=None,
+        help="Allowed child-agent domain. Repeatable; comma-separated values are also accepted.",
+    )
+    configure_goal_parser.add_argument(
+        "--clear-allowed-domains",
+        action="store_true",
+        help="Clear allowed child-agent domains.",
+    )
+    configure_goal_parser.add_argument(
+        "--registered-agent",
+        dest="registered_agents",
+        action="append",
+        default=None,
+        help=(
+            "Registered public-safe agent id allowed to claim todos and receive scoped "
+            "heartbeat prompts. Repeatable; comma-separated values are also accepted."
+        ),
+    )
+    configure_goal_parser.add_argument(
+        "--clear-registered-agents",
+        action="store_true",
+        help="Clear coordination.registered_agents.",
+    )
+    configure_goal_parser.add_argument(
+        "--primary-agent",
+        help=(
+            "The single registered agent id that owns main-control review, "
+            "verification, merge, and final project coordination."
+        ),
+    )
+    configure_goal_parser.add_argument(
+        "--clear-primary-agent",
+        action="store_true",
+        help="Clear coordination.primary_agent.",
+    )
+    configure_goal_parser.add_argument(
+        "--waiting-on",
+        choices=["codex", "user_or_controller", "controller", "external_evidence"],
+        help="Override registry waiting owner for status/quota routing.",
+    )
+    configure_goal_parser.add_argument(
+        "--clear-waiting-on",
+        action="store_true",
+        help="Remove the registry waiting_on override.",
+    )
+    configure_goal_parser.add_argument(
+        "--boundary-authority-scope",
+        action="append",
+        default=None,
+        help=(
+            "Checkpointed write scope approved by an operator/controller decision. "
+            "Repeatable; comma-separated values are also accepted."
+        ),
+    )
+    configure_goal_parser.add_argument(
+        "--boundary-authority-source",
+        help="Public-safe provenance for the checkpointed boundary authority.",
+    )
+    configure_goal_parser.add_argument(
+        "--boundary-authority-decision-id",
+        help="Public-safe decision/run/gate id for the checkpointed boundary authority.",
+    )
+    configure_goal_parser.add_argument(
+        "--boundary-authority-recorded-at",
+        help="ISO timestamp for the checkpointed decision. Defaults to now.",
+    )
+    configure_goal_parser.add_argument(
+        "--boundary-authority-expires-at",
+        help="Optional ISO timestamp after which the checkpointed authority is no longer fresh.",
+    )
+    configure_goal_parser.add_argument(
+        "--clear-boundary-authority",
+        action="store_true",
+        help="Clear coordination.checkpointed_boundary_authority.",
+    )
+    configure_goal_parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Write the registry. Without this flag, configure-goal is a dry-run preview.",
+    )
+
+    register_agent_parser = subparsers.add_parser(
+        "register-agent",
+        help="Register an automation agent through the existing global source_registry without reconnecting the goal.",
+    )
+    register_agent_parser.add_argument("--goal-id", required=True, help="Goal id already present in the global registry.")
+    register_agent_parser.add_argument(
+        "--agent-id",
+        action="append",
+        required=True,
+        help="Public-safe agent id to add. Repeatable; comma-separated values are also accepted.",
+    )
+    register_agent_parser.add_argument(
+        "--primary-agent",
+        help="Optional primary agent id to set; defaults to the existing primary agent.",
+    )
+    register_agent_parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Write the source registry and sync it globally. Without this flag, preview only.",
+    )
+
+    archive_runtime_parser = subparsers.add_parser(
+        "archive-runtime",
+        help="Move an obsolete runtime goal directory into the archive area. Defaults to dry-run.",
+    )
+    archive_runtime_parser.add_argument("--goal-id", required=True, help="Runtime goal id to archive.")
+    archive_runtime_parser.add_argument(
+        "--archive-root",
+        help="Archive directory. Defaults to <runtime-root>/archived-goals.",
+    )
+    archive_runtime_parser.add_argument(
+        "--allow-registered",
+        action="store_true",
+        help="Allow archiving a goal that is still present in the registry.",
+    )
+    archive_runtime_parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Actually move the runtime directory. Without this flag the command is a dry-run.",
+    )
+
+    sync_global_parser = subparsers.add_parser(
+        "sync-global",
+        help="Merge this project-local registry into the shared global registry.",
+    )
+    sync_global_parser.add_argument("--goal-id", help="Only sync one goal id from the source registry.")
+    sync_global_parser.add_argument(
+        "--replace-state",
+        action="store_true",
+        help="Allow replacing an existing global route and write a backup before doing so.",
+    )
+    sync_global_parser.add_argument("--dry-run", action="store_true", help="Preview the global registry merge.")
+
+    migrate_state_parser = subparsers.add_parser(
+        "migrate-state",
+        help="One-shot migration from a legacy Goal Harness registry/runtime into LoopX state.",
+    )
+    migrate_state_parser.add_argument(
+        "--legacy-registry",
+        default=str(LEGACY_GLOBAL_REGISTRY),
+        help="Legacy registry JSON to import from. Defaults to ~/.codex/goal-harness/registry.global.json.",
+    )
+    migrate_state_parser.add_argument(
+        "--legacy-runtime-root",
+        default=str(LEGACY_RUNTIME_ROOT),
+        help="Legacy runtime root. Defaults to ~/.codex/goal-harness.",
+    )
+    migrate_state_parser.add_argument(
+        "--target-runtime-root",
+        help="LoopX runtime root. Defaults to --runtime-root or ~/.codex/loopx.",
+    )
+    migrate_goal_selector = migrate_state_parser.add_mutually_exclusive_group(required=True)
+    migrate_goal_selector.add_argument(
+        "--goal-id",
+        action="append",
+        help="Legacy goal id to migrate. Repeat for multiple explicit goals.",
+    )
+    migrate_goal_selector.add_argument(
+        "--all-goals",
+        action="store_true",
+        help="Migrate every goal listed in the explicit legacy registry. Still dry-run by default.",
+    )
+    migrate_state_parser.add_argument(
+        "--goal-id-map",
+        action="append",
+        default=[],
+        metavar="OLD=NEW",
+        help="Rename a goal id during migration, for example goal-harness-meta=loopx-meta.",
+    )
+    migrate_state_parser.add_argument(
+        "--path-map",
+        action="append",
+        default=[],
+        metavar="OLD=NEW",
+        help="Rewrite local path prefixes during migration.",
+    )
+    migrate_state_parser.add_argument(
+        "--copy-active-state",
+        action="store_true",
+        help="Copy and rewrite selected goals' active-state files into their migrated target paths.",
+    )
+    migrate_state_parser.add_argument(
+        "--copy-runtime",
+        action="store_true",
+        help="Copy and rewrite selected runtime goal directories from the legacy runtime root.",
+    )
+    migrate_state_parser.add_argument(
+        "--no-global-sync",
+        action="store_true",
+        help="Do not sync the migrated project registry into the LoopX global registry after --execute.",
+    )
+    migrate_state_parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Write migrated state. Without this flag the command is a dry-run preview.",
+    )
+
+    authority_parser = subparsers.add_parser(
+        "register-authority-source",
+        help="Register a redacted local authority/material source for a goal.",
+    )
+    authority_parser.add_argument("--goal-id", required=True, help="Goal id whose local registry should be updated.")
+    authority_parser.add_argument("--source-id", required=True, help="Stable local source id.")
+    authority_parser.add_argument(
+        "--source-ref",
+        help="Raw local source reference to hash and redact. The raw value is never stored.",
+    )
+    authority_parser.add_argument("--source-kind", required=True, help="Public-safe source kind, such as doc or repository.")
+    authority_parser.add_argument("--role", required=True, help="Public-safe material role.")
+    authority_parser.add_argument("--freshness", required=True, help="Public-safe freshness state.")
+    authority_parser.add_argument("--owner-status", help="Optional public-safe owner/review status.")
+    authority_parser.add_argument("--gate-status", help="Optional public-safe gate status.")
+    authority_parser.add_argument(
+        "--boundary",
+        choices=sorted(AUTHORITY_SOURCE_BOUNDARIES),
+        default="private_redacted",
+        help="Public/private boundary for this source. Defaults to private_redacted.",
+    )
+    authority_parser.add_argument("--revision", help="Optional public-safe revision label.")
+    authority_parser.add_argument("--conflict-rule", help="Optional public-safe conflict rule.")
+    authority_parser.add_argument("--topic", help="Optional topic_authority key to map to this source id.")
+    authority_parser.add_argument("--dry-run", action="store_true", help="Preview the registry update without writing.")
+    authority_parser.add_argument(
+        "--no-global-sync",
+        action="store_true",
+        help="Do not refresh the shared global registry after writing the local source registry.",
+    )
+
+    doc_registry_authority_parser = subparsers.add_parser(
+        "import-doc-registry-authority",
+        help="Import a redacted DOC_REGISTRY summary as a local authority/material source.",
+    )
+    doc_registry_authority_parser.add_argument(
+        "--goal-id", required=True, help="Goal id whose local registry should be updated."
+    )
+    doc_registry_authority_parser.add_argument("--source-id", required=True, help="Stable local source id.")
+    doc_registry_authority_parser.add_argument(
+        "--doc-registry-path",
+        required=True,
+        help="Local DOC_REGISTRY.yaml path to read. The raw path is hashed and not stored.",
+    )
+    doc_registry_authority_parser.add_argument(
+        "--source-kind",
+        default="doc_registry",
+        help="Public-safe source kind. Defaults to doc_registry.",
+    )
+    doc_registry_authority_parser.add_argument(
+        "--role",
+        default="external_doc_authority_registry",
+        help="Public-safe material role. Defaults to external_doc_authority_registry.",
+    )
+    doc_registry_authority_parser.add_argument(
+        "--freshness",
+        default="current",
+        help="Public-safe freshness state. Defaults to current.",
+    )
+    doc_registry_authority_parser.add_argument("--owner-status", help="Optional public-safe owner/review status.")
+    doc_registry_authority_parser.add_argument("--gate-status", help="Optional public-safe gate status.")
+    doc_registry_authority_parser.add_argument(
+        "--boundary",
+        choices=sorted(AUTHORITY_SOURCE_BOUNDARIES),
+        default="private_redacted",
+        help="Public/private boundary for this source. Defaults to private_redacted.",
+    )
+    doc_registry_authority_parser.add_argument("--revision", help="Optional public-safe revision label.")
+    doc_registry_authority_parser.add_argument("--conflict-rule", help="Optional public-safe conflict rule.")
+    doc_registry_authority_parser.add_argument(
+        "--topic",
+        action="append",
+        default=[],
+        help="Additional local topic_authority key to map to this source id. Repeatable.",
+    )
+    doc_registry_authority_parser.add_argument(
+        "--import-topic-prefix",
+        help="Prefix imported DOC_REGISTRY topic keys with this value before mapping them to the source id.",
+    )
+    doc_registry_authority_parser.add_argument(
+        "--max-imported-topics",
+        type=int,
+        default=50,
+        help="Maximum DOC_REGISTRY topics to map when --import-topic-prefix is set. Defaults to 50.",
+    )
+    doc_registry_authority_parser.add_argument("--dry-run", action="store_true", help="Preview without writing.")
+    doc_registry_authority_parser.add_argument(
+        "--no-global-sync",
+        action="store_true",
+        help="Do not refresh the shared global registry after writing the local source registry.",
+    )
+
+
+def handle_registry_admin_command(
+    args: argparse.Namespace,
+    *,
+    registry_path: Path,
+    print_payload: PrintPayload,
+) -> int | None:
+    if args.command not in REGISTRY_ADMIN_COMMANDS:
+        return None
+
+    if args.command == "configure-goal":
+        try:
+            payload = configure_goal(
+                registry_path=registry_path,
+                goal_id=args.goal_id,
+                quota_compute=args.quota_compute,
+                quota_window_hours=args.quota_window_hours,
+                self_repair_enabled=args.self_repair_enabled,
+                self_repair_health=args.self_repair_health,
+                self_repair_waiting_projection=args.self_repair_waiting_projection,
+                orchestration_mode=args.orchestration_mode,
+                spawn_allowed=args.spawn_allowed,
+                max_children=args.max_children,
+                allowed_domains=args.allowed_domain,
+                clear_allowed_domains=bool(args.clear_allowed_domains),
+                registered_agents=args.registered_agents,
+                clear_registered_agents=bool(args.clear_registered_agents),
+                primary_agent=args.primary_agent,
+                clear_primary_agent=bool(args.clear_primary_agent),
+                waiting_on=args.waiting_on,
+                clear_waiting_on=bool(args.clear_waiting_on),
+                boundary_authority_scopes=args.boundary_authority_scope,
+                boundary_authority_source=args.boundary_authority_source,
+                boundary_authority_decision_id=args.boundary_authority_decision_id,
+                boundary_authority_recorded_at=args.boundary_authority_recorded_at,
+                boundary_authority_expires_at=args.boundary_authority_expires_at,
+                clear_boundary_authority=bool(args.clear_boundary_authority),
+                execute=bool(args.execute),
+            )
+        except Exception as exc:
+            payload = {
+                "ok": False,
+                "dry_run": not bool(args.execute),
+                "execute": bool(args.execute),
+                "registry": str(registry_path),
+                "goal_id": args.goal_id,
+                "changed": False,
+                "written": False,
+                "error": str(exc),
+            }
+        print_payload(payload, args.format, render_configure_goal_markdown)
+        return 0 if payload.get("ok") else 1
+
+    if args.command == "register-agent":
+        try:
+            payload = register_agent_via_source_registry(
+                runtime_root_arg=args.runtime_root,
+                goal_id=args.goal_id,
+                agent_ids=args.agent_id,
+                primary_agent=args.primary_agent,
+                execute=bool(args.execute),
+            )
+        except Exception as exc:
+            payload = {
+                "ok": False,
+                "dry_run": not bool(args.execute),
+                "execute": bool(args.execute),
+                "goal_id": args.goal_id,
+                "changed": False,
+                "written": False,
+                "error": str(exc),
+            }
+        print_payload(payload, args.format, render_register_agent_markdown)
+        return 0 if payload.get("ok") else 1
+
+    if args.command == "archive-runtime":
+        try:
+            payload = archive_runtime_goal(
+                registry_path=registry_path,
+                runtime_root_override=args.runtime_root,
+                goal_id=args.goal_id,
+                archive_root=Path(args.archive_root).expanduser() if args.archive_root else None,
+                allow_registered=bool(args.allow_registered),
+                execute=bool(args.execute),
+            )
+        except Exception as exc:
+            payload = {
+                "ok": False,
+                "registry": str(registry_path),
+                "runtime_root": args.runtime_root,
+                "goal_id": args.goal_id,
+                "dry_run": not bool(args.execute),
+                "archived": False,
+                "error": str(exc),
+            }
+        print_payload(payload, args.format, render_archive_runtime_markdown)
+        return 0 if payload.get("ok") else 1
+
+    if args.command == "sync-global":
+        try:
+            payload = sync_project_registry_to_global(
+                registry_path=registry_path,
+                runtime_root_override=args.runtime_root,
+                goal_id=args.goal_id,
+                dry_run=bool(args.dry_run),
+                allow_route_replacement=bool(args.replace_state),
+            )
+        except Exception as exc:
+            registry = load_registry(registry_path)
+            runtime_root = resolve_runtime_root(registry, args.runtime_root)
+            payload = {
+                "ok": False,
+                "registry": str(registry_path),
+                "runtime_root": str(runtime_root),
+                "global_registry": str(global_registry_path(runtime_root)),
+                "dry_run": bool(args.dry_run),
+                "error": str(exc),
+            }
+        print_payload(payload, args.format, render_global_sync_markdown)
+        return 0 if payload.get("ok") else 1
+
+    if args.command == "migrate-state":
+        try:
+            target_runtime_root = (
+                Path(args.target_runtime_root).expanduser()
+                if args.target_runtime_root
+                else (Path(args.runtime_root).expanduser() if args.runtime_root else DEFAULT_RUNTIME_ROOT)
+            )
+            selected_goal_ids = (
+                legacy_registry_goal_ids(Path(args.legacy_registry))
+                if args.all_goals
+                else (args.goal_id or [])
+            )
+            payload = migrate_legacy_state(
+                legacy_registry_path=Path(args.legacy_registry),
+                target_registry_path=registry_path,
+                legacy_runtime_root=Path(args.legacy_runtime_root),
+                target_runtime_root=target_runtime_root,
+                goal_ids=selected_goal_ids,
+                goal_id_map=parse_key_value_map(args.goal_id_map, flag_name="--goal-id-map"),
+                path_map=parse_key_value_map(args.path_map, flag_name="--path-map"),
+                copy_active_state=bool(args.copy_active_state),
+                copy_runtime=bool(args.copy_runtime),
+                execute=bool(args.execute),
+            )
+            if payload.get("ok") and args.execute and not args.no_global_sync:
+                sync_results = []
+                for migrated_goal_id in payload.get("migrated_goal_ids") or []:
+                    sync_results.append(
+                        sync_project_registry_to_global(
+                            registry_path=registry_path,
+                            runtime_root_override=str(target_runtime_root),
+                            goal_id=str(migrated_goal_id),
+                            dry_run=False,
+                        )
+                    )
+                payload["global_sync"] = {
+                    "ok": all(result.get("ok") for result in sync_results),
+                    "dry_run": False,
+                    "wrote": bool(sync_results),
+                    "results": sync_results,
+                    "synced_goal_ids": [
+                        goal_id
+                        for result in sync_results
+                        for goal_id in (result.get("synced_goal_ids") or [])
+                    ],
+                }
+        except Exception as exc:
+            payload = {
+                "ok": False,
+                "schema_version": "loopx_state_migration_v0",
+                "dry_run": not bool(args.execute),
+                "execute": bool(args.execute),
+                "legacy_registry": args.legacy_registry,
+                "target_registry": str(registry_path),
+                "legacy_runtime_root": args.legacy_runtime_root,
+                "target_runtime_root": args.target_runtime_root or args.runtime_root or str(DEFAULT_RUNTIME_ROOT),
+                "selected_goal_ids": args.goal_id or ([] if not getattr(args, "all_goals", False) else ["<all-goals>"]),
+                "error": str(exc),
+            }
+        print_payload(payload, args.format, render_state_migration_markdown)
+        return 0 if payload.get("ok") else 1
+
+    if args.command == "register-authority-source":
+        try:
+            payload = register_authority_source(
+                registry_path=registry_path,
+                goal_id=args.goal_id,
+                source_id=args.source_id,
+                source_ref=args.source_ref,
+                source_kind=args.source_kind,
+                role=args.role,
+                freshness=args.freshness,
+                owner_status=args.owner_status,
+                gate_status=args.gate_status,
+                boundary=args.boundary,
+                revision=args.revision,
+                conflict_rule=args.conflict_rule,
+                topic=args.topic,
+                dry_run=bool(args.dry_run),
+            )
+            if not bool(args.no_global_sync):
+                if args.dry_run:
+                    payload["global_sync"] = {"enabled": True, "dry_run": True, "wrote": False}
+                else:
+                    payload["global_sync"] = sync_project_registry_to_global(
+                        registry_path=registry_path,
+                        runtime_root_override=args.runtime_root,
+                        goal_id=args.goal_id,
+                        dry_run=False,
+                    )
+            else:
+                payload["global_sync"] = {"enabled": False}
+        except Exception as exc:
+            payload = {
+                "ok": False,
+                "registry": str(registry_path),
+                "runtime_root": args.runtime_root,
+                "goal_id": args.goal_id,
+                "source_id": getattr(args, "source_id", None),
+                "written": False,
+                "dry_run": bool(getattr(args, "dry_run", False)),
+                "error": str(exc),
+            }
+        print_payload(payload, args.format, render_authority_source_markdown)
+        return 0 if payload.get("ok") else 1
+
+    try:
+        payload = import_doc_registry_authority(
+            registry_path=registry_path,
+            goal_id=args.goal_id,
+            source_id=args.source_id,
+            doc_registry_path=Path(args.doc_registry_path),
+            source_kind=args.source_kind,
+            role=args.role,
+            freshness=args.freshness,
+            owner_status=args.owner_status,
+            gate_status=args.gate_status,
+            boundary=args.boundary,
+            revision=args.revision,
+            conflict_rule=args.conflict_rule,
+            topics=list(args.topic or []),
+            import_topic_prefix=args.import_topic_prefix,
+            max_imported_topics=int(args.max_imported_topics),
+            dry_run=bool(args.dry_run),
+        )
+        if not bool(args.no_global_sync):
+            if args.dry_run:
+                payload["global_sync"] = {"enabled": True, "dry_run": True, "wrote": False}
+            else:
+                payload["global_sync"] = sync_project_registry_to_global(
+                    registry_path=registry_path,
+                    runtime_root_override=args.runtime_root,
+                    goal_id=args.goal_id,
+                    dry_run=False,
+                )
+        else:
+            payload["global_sync"] = {"enabled": False}
+    except Exception as exc:
+        payload = {
+            "ok": False,
+            "registry": str(registry_path),
+            "runtime_root": args.runtime_root,
+            "goal_id": args.goal_id,
+            "source_id": getattr(args, "source_id", None),
+            "written": False,
+            "dry_run": bool(getattr(args, "dry_run", False)),
+            "error": str(exc),
+        }
+    print_payload(payload, args.format, render_doc_registry_authority_import_markdown)
+    return 0 if payload.get("ok") else 1


### PR DESCRIPTION
## Summary\n- extract configure-goal/register-agent/archive-runtime/sync-global/migrate-state/authority import commands from loopx/cli.py into loopx/cli_commands/registry_admin.py\n- export the new registry admin command registration/handler through loopx.cli_commands\n- add a focused registry admin modularization smoke that checks help coverage, dry-run semantics, redaction flags, and source-boundary placement\n\n## Validation\n- python3 -m py_compile loopx/cli.py loopx/cli_commands/__init__.py loopx/cli_commands/registry_admin.py examples/cli-registry-admin-command-modularization-smoke.py\n- python3 -m py_compile $(git ls-files 'loopx/*.py' 'loopx/cli_commands/*.py')\n- python3 examples/cli-registry-admin-command-modularization-smoke.py\n- python3 examples/cli-project-lifecycle-command-modularization-smoke.py\n- python3 examples/cli-worker-bridge-command-modularization-smoke.py\n- python3 examples/cli-benchmark-review-lifecycle-command-modularization-smoke.py\n- python3 examples/cli-agentissue-runner-flow-command-modularization-smoke.py\n- python3 examples/demo-cli-smoke.py\n- python3 examples/project-agent-adoption-smoke.py\n- git diff --check\n- python3 -m loopx.cli check --scan-path loopx/cli.py --scan-path loopx/cli_commands/__init__.py --scan-path loopx/cli_commands/registry_admin.py --scan-path examples/cli-registry-admin-command-modularization-smoke.py