### PR TITLE
Refactor benchmark CLI dispatch

### DIFF
--- a/examples/cli-agents-last-exam-command-modularization-smoke.py
+++ b/examples/cli-agents-last-exam-command-modularization-smoke.py
@@ -31,6 +31,9 @@ def main() -> int:
     init_source = (ROOT / "loopx" / "cli_commands" / "__init__.py").read_text(
         encoding="utf-8"
     )
+    dispatch_source = (
+        ROOT / "loopx" / "cli_commands" / "benchmark_dispatch.py"
+    ).read_text(encoding="utf-8")
     ale_source = (ROOT / "loopx" / "cli_commands" / "agents_last_exam.py").read_text(
         encoding="utf-8"
     )
@@ -46,10 +49,10 @@ def main() -> int:
         if marker in cli_source:
             raise AssertionError(f"{marker} leaked back into loopx/cli.py")
     assert_contains(
-        cli_source,
+        dispatch_source,
         "register_agents_last_exam_commands(benchmark_sub, add_subcommand_format)",
     )
-    assert_contains(cli_source, "handle_agents_last_exam_command(")
+    assert_contains(dispatch_source, "handle_agents_last_exam_command(")
     assert_contains(init_source, "register_agents_last_exam_commands")
     assert_contains(init_source, "handle_agents_last_exam_command")
     assert_contains(ale_source, "AGENTS_LAST_EXAM_COMMANDS")

--- a/examples/cli-benchmark-boundary-command-modularization-smoke.py
+++ b/examples/cli-benchmark-boundary-command-modularization-smoke.py
@@ -31,6 +31,9 @@ def main() -> int:
     init_source = (ROOT / "loopx" / "cli_commands" / "__init__.py").read_text(
         encoding="utf-8"
     )
+    dispatch_source = (
+        ROOT / "loopx" / "cli_commands" / "benchmark_dispatch.py"
+    ).read_text(encoding="utf-8")
     boundary_source = (
         ROOT / "loopx" / "cli_commands" / "benchmark_boundary.py"
     ).read_text(encoding="utf-8")
@@ -44,8 +47,8 @@ def main() -> int:
     for marker in leaked_markers:
         if marker in cli_source:
             raise AssertionError(f"{marker} leaked back into loopx/cli.py")
-    assert_contains(cli_source, "register_benchmark_boundary_commands(benchmark_sub, add_subcommand_format)")
-    assert_contains(cli_source, "handle_benchmark_boundary_command(")
+    assert_contains(dispatch_source, "register_benchmark_boundary_commands(benchmark_sub, add_subcommand_format)")
+    assert_contains(dispatch_source, "handle_benchmark_boundary_command(")
     assert_contains(init_source, "register_benchmark_boundary_commands")
     assert_contains(init_source, "handle_benchmark_boundary_command")
     assert_contains(boundary_source, "BENCHMARK_BOUNDARY_COMMANDS")

--- a/examples/cli-benchmark-dispatch-command-modularization-smoke.py
+++ b/examples/cli-benchmark-dispatch-command-modularization-smoke.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CLI = ROOT / "loopx" / "cli.py"
+DISPATCH_MODULE = ROOT / "loopx" / "cli_commands" / "benchmark_dispatch.py"
+INIT = ROOT / "loopx" / "cli_commands" / "__init__.py"
+
+
+def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "loopx.cli", *args],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def require_success(result: subprocess.CompletedProcess[str]) -> str:
+    if result.returncode != 0:
+        raise AssertionError(
+            f"expected success, got {result.returncode}\n"
+            f"stdout:\n{result.stdout}\n\nstderr:\n{result.stderr}"
+        )
+    return result.stdout
+
+
+def require_json_success(result: subprocess.CompletedProcess[str]) -> dict[str, object]:
+    payload = json.loads(require_success(result))
+    require(isinstance(payload, dict), "expected JSON object payload")
+    require(payload.get("ok") is True, f"payload was not ok: {payload}")
+    return payload
+
+
+def assert_source_shape() -> None:
+    cli_source = CLI.read_text(encoding="utf-8")
+    dispatch_source = DISPATCH_MODULE.read_text(encoding="utf-8")
+    init_source = INIT.read_text(encoding="utf-8")
+
+    forbidden_cli_markers = [
+        "benchmark_parser = sub.add_parser",
+        "benchmark_sub = benchmark_parser.add_subparsers",
+        "register_benchmark_run_ledger_commands(",
+        "register_agentissue_runner_flow_commands(",
+        "register_benchmark_boundary_commands(",
+        "register_terminal_bench_adapter_commands(",
+        "register_agents_last_exam_commands(",
+        "register_benchmark_review_lifecycle_commands(",
+        "register_terminal_bench_environment_result_commands(",
+        "handle_agentissue_runner_flow_command(",
+        "handle_benchmark_boundary_command(",
+        "handle_terminal_bench_adapter_command(",
+        "handle_agents_last_exam_command(",
+        "handle_benchmark_review_lifecycle_command(",
+        "handle_terminal_bench_environment_result_command(",
+        "handle_benchmark_run_ledger_command(",
+    ]
+    for marker in forbidden_cli_markers:
+        require(marker not in cli_source, f"benchmark dispatch marker leaked into cli.py: {marker}")
+
+    for marker in (
+        "register_benchmark_command_group(sub, add_subcommand_format)",
+        "handle_benchmark_command(",
+    ):
+        require(marker in cli_source, f"cli.py missing benchmark dispatch marker: {marker}")
+
+    for marker in (
+        "def register_benchmark_command_group(",
+        "def handle_benchmark_command(",
+        "benchmark_parser = subparsers.add_parser",
+        "register_benchmark_run_ledger_commands(benchmark_sub, add_subcommand_format)",
+        "register_agentissue_runner_flow_commands(benchmark_sub, add_subcommand_format)",
+        "register_benchmark_boundary_commands(benchmark_sub, add_subcommand_format)",
+        "register_terminal_bench_adapter_commands(benchmark_sub, add_subcommand_format)",
+        "register_agents_last_exam_commands(benchmark_sub, add_subcommand_format)",
+        "register_benchmark_review_lifecycle_commands(benchmark_sub, add_subcommand_format)",
+        "register_terminal_bench_environment_result_commands(benchmark_sub, add_subcommand_format)",
+        "handle_benchmark_run_ledger_command(",
+    ):
+        require(marker in dispatch_source, f"benchmark dispatch module missing marker: {marker}")
+
+    require("register_benchmark_command_group" in init_source, "__init__ omitted benchmark group registrar")
+    require("handle_benchmark_command" in init_source, "__init__ omitted benchmark group handler")
+
+
+def assert_cli_surfaces() -> None:
+    help_text = require_success(run_cli("benchmark", "--help"))
+    for subcommand in (
+        "run",
+        "agentissue-codex-runner-flow",
+        "classify-artifacts",
+        "terminal-bench-command-adapter",
+        "ale-local-preflight",
+        "review-claim",
+        "summarize-post-launch",
+    ):
+        require(subcommand in help_text, f"benchmark help omitted {subcommand}")
+
+    run_payload = require_json_success(
+        run_cli(
+            "--format",
+            "json",
+            "benchmark",
+            "run",
+            "terminal-bench",
+            "--goal-id",
+            "loopx-meta",
+            "--mode",
+            "codex-goal-mode",
+        )
+    )
+    require(run_payload.get("dry_run") is True, "benchmark run default should dry-run")
+    require(run_payload["benchmark_cli"].get("real_runner_invoked") is False, run_payload)
+
+    adapter_payload = require_json_success(
+        run_cli(
+            "benchmark",
+            "terminal-bench-command-adapter",
+            "terminal-bench",
+            "--format",
+            "json",
+        )
+    )
+    require(adapter_payload.get("dry_run") is True, "adapter default should dry-run")
+    require(adapter_payload["command_adapter"]["boundary"].get("submit_allowed") is False, adapter_payload)
+
+
+def main() -> None:
+    assert_source_shape()
+    assert_cli_surfaces()
+    print("cli-benchmark-dispatch-command-modularization-smoke: ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/cli-benchmark-review-lifecycle-command-modularization-smoke.py
+++ b/examples/cli-benchmark-review-lifecycle-command-modularization-smoke.py
@@ -31,6 +31,9 @@ def main() -> int:
     init_source = (ROOT / "loopx" / "cli_commands" / "__init__.py").read_text(
         encoding="utf-8"
     )
+    dispatch_source = (
+        ROOT / "loopx" / "cli_commands" / "benchmark_dispatch.py"
+    ).read_text(encoding="utf-8")
     module_source = (
         ROOT / "loopx" / "cli_commands" / "benchmark_review_lifecycle.py"
     ).read_text(encoding="utf-8")
@@ -56,10 +59,10 @@ def main() -> int:
         if marker in cli_source:
             raise AssertionError(f"{marker} leaked back into loopx/cli.py")
     assert_contains(
-        cli_source,
+        dispatch_source,
         "register_benchmark_review_lifecycle_commands(benchmark_sub, add_subcommand_format)",
     )
-    assert_contains(cli_source, "handle_benchmark_review_lifecycle_command(")
+    assert_contains(dispatch_source, "handle_benchmark_review_lifecycle_command(")
     assert_contains(init_source, "register_benchmark_review_lifecycle_commands")
     assert_contains(init_source, "handle_benchmark_review_lifecycle_command")
     assert_contains(module_source, "BENCHMARK_REVIEW_LIFECYCLE_COMMANDS")

--- a/examples/cli-benchmark-run-ledger-command-modularization-smoke.py
+++ b/examples/cli-benchmark-run-ledger-command-modularization-smoke.py
@@ -44,6 +44,9 @@ def main() -> int:
     init_source = (ROOT / "loopx" / "cli_commands" / "__init__.py").read_text(
         encoding="utf-8"
     )
+    dispatch_source = (
+        ROOT / "loopx" / "cli_commands" / "benchmark_dispatch.py"
+    ).read_text(encoding="utf-8")
     module_source = (
         ROOT / "loopx" / "cli_commands" / "benchmark_run_ledger.py"
     ).read_text(encoding="utf-8")
@@ -61,10 +64,10 @@ def main() -> int:
         if marker in cli_source:
             raise AssertionError(f"{marker} leaked back into loopx/cli.py")
     assert_contains(
-        cli_source,
+        dispatch_source,
         "register_benchmark_run_ledger_commands(benchmark_sub, add_subcommand_format)",
     )
-    assert_contains(cli_source, "handle_benchmark_run_ledger_command(")
+    assert_contains(dispatch_source, "handle_benchmark_run_ledger_command(")
     assert_contains(init_source, "register_benchmark_run_ledger_commands")
     assert_contains(init_source, "handle_benchmark_run_ledger_command")
     assert_contains(module_source, "BENCHMARK_RUN_LEDGER_COMMANDS")

--- a/examples/cli-terminal-bench-adapter-command-modularization-smoke.py
+++ b/examples/cli-terminal-bench-adapter-command-modularization-smoke.py
@@ -31,6 +31,9 @@ def main() -> int:
     init_source = (ROOT / "loopx" / "cli_commands" / "__init__.py").read_text(
         encoding="utf-8"
     )
+    dispatch_source = (
+        ROOT / "loopx" / "cli_commands" / "benchmark_dispatch.py"
+    ).read_text(encoding="utf-8")
     adapter_source = (
         ROOT / "loopx" / "cli_commands" / "terminal_bench_adapter.py"
     ).read_text(encoding="utf-8")
@@ -46,10 +49,10 @@ def main() -> int:
         if marker in cli_source:
             raise AssertionError(f"{marker} leaked back into loopx/cli.py")
     assert_contains(
-        cli_source,
+        dispatch_source,
         "register_terminal_bench_adapter_commands(benchmark_sub, add_subcommand_format)",
     )
-    assert_contains(cli_source, "handle_terminal_bench_adapter_command(")
+    assert_contains(dispatch_source, "handle_terminal_bench_adapter_command(")
     assert_contains(init_source, "register_terminal_bench_adapter_commands")
     assert_contains(init_source, "handle_terminal_bench_adapter_command")
     assert_contains(adapter_source, "TERMINAL_BENCH_ADAPTER_COMMANDS")

--- a/examples/cli-terminal-bench-environment-result-command-modularization-smoke.py
+++ b/examples/cli-terminal-bench-environment-result-command-modularization-smoke.py
@@ -44,6 +44,9 @@ def main() -> int:
     init_source = (ROOT / "loopx" / "cli_commands" / "__init__.py").read_text(
         encoding="utf-8"
     )
+    dispatch_source = (
+        ROOT / "loopx" / "cli_commands" / "benchmark_dispatch.py"
+    ).read_text(encoding="utf-8")
     review_source = (
         ROOT / "loopx" / "cli_commands" / "benchmark_review_lifecycle.py"
     ).read_text(encoding="utf-8")
@@ -66,10 +69,10 @@ def main() -> int:
     if "render_terminal_bench_environment_setup_gate_markdown" in review_source:
         raise AssertionError("Terminal-Bench environment renderers leaked into review lifecycle module")
     assert_contains(
-        cli_source,
+        dispatch_source,
         "register_terminal_bench_environment_result_commands(benchmark_sub, add_subcommand_format)",
     )
-    assert_contains(cli_source, "handle_terminal_bench_environment_result_command(")
+    assert_contains(dispatch_source, "handle_terminal_bench_environment_result_command(")
     assert_contains(init_source, "register_terminal_bench_environment_result_commands")
     assert_contains(init_source, "handle_terminal_bench_environment_result_command")
     assert_contains(module_source, "TERMINAL_BENCH_ENVIRONMENT_RESULT_COMMANDS")

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -7,11 +7,7 @@ from pathlib import Path
 
 from . import __version__
 from .cli_commands import (
-    handle_agents_last_exam_command,
-    handle_agentissue_runner_flow_command,
-    handle_benchmark_review_lifecycle_command,
-    handle_benchmark_run_ledger_command,
-    handle_benchmark_boundary_command,
+    handle_benchmark_command,
     handle_bootstrap_connect_command,
     handle_check_command,
     handle_codex_cli_bounded_visible_pilot_adapter_command,
@@ -44,14 +40,8 @@ from .cli_commands import (
     handle_status_command,
     handle_support_control_command,
     handle_todo_command,
-    handle_terminal_bench_adapter_command,
-    handle_terminal_bench_environment_result_command,
     handle_worker_bridge_command,
-    register_agents_last_exam_commands,
-    register_agentissue_runner_flow_commands,
-    register_benchmark_review_lifecycle_commands,
-    register_benchmark_run_ledger_commands,
-    register_benchmark_boundary_commands,
+    register_benchmark_command_group,
     register_bootstrap_connect_command,
     register_doctor_command,
     register_dreaming_commands,
@@ -64,8 +54,6 @@ from .cli_commands import (
     register_status_commands,
     register_support_control_commands,
     register_todo_command,
-    register_terminal_bench_adapter_commands,
-    register_terminal_bench_environment_result_commands,
     register_worker_bridge_commands,
 )
 from .cli_rollout import (
@@ -144,22 +132,7 @@ def main(argv: list[str] | None = None) -> int:
 
     register_history_command(sub)
 
-    benchmark_parser = sub.add_parser(
-        "benchmark",
-        help="Benchmark runner skeletons. Current public surface is fixture-only and no-run by default.",
-    )
-    benchmark_sub = benchmark_parser.add_subparsers(dest="benchmark_command", required=True)
-
-    register_benchmark_run_ledger_commands(benchmark_sub, add_subcommand_format)
-
-    register_agentissue_runner_flow_commands(benchmark_sub, add_subcommand_format)
-    register_benchmark_boundary_commands(benchmark_sub, add_subcommand_format)
-    register_terminal_bench_adapter_commands(benchmark_sub, add_subcommand_format)
-
-    register_agents_last_exam_commands(benchmark_sub, add_subcommand_format)
-
-    register_benchmark_review_lifecycle_commands(benchmark_sub, add_subcommand_format)
-    register_terminal_bench_environment_result_commands(benchmark_sub, add_subcommand_format)
+    register_benchmark_command_group(sub, add_subcommand_format)
 
     register_project_lifecycle_commands(sub, add_subcommand_format)
 
@@ -303,59 +276,15 @@ def main(argv: list[str] | None = None) -> int:
     if registry_admin_result is not None:
         return registry_admin_result
 
-    if args.command == "benchmark":
-        agentissue_runner_flow_result = handle_agentissue_runner_flow_command(
-            args,
-            registry_path=registry_path,
-            print_payload=print_payload,
-        )
-        if agentissue_runner_flow_result is not None:
-            return agentissue_runner_flow_result
-        benchmark_boundary_result = handle_benchmark_boundary_command(
-            args,
-            print_payload=print_payload,
-            output_format=output_format,
-        )
-        if benchmark_boundary_result is not None:
-            return benchmark_boundary_result
-        terminal_bench_adapter_result = handle_terminal_bench_adapter_command(
-            args,
-            print_payload=print_payload,
-            output_format=output_format,
-        )
-        if terminal_bench_adapter_result is not None:
-            return terminal_bench_adapter_result
-        agents_last_exam_result = handle_agents_last_exam_command(
-            args,
-            print_payload=print_payload,
-            output_format=output_format,
-        )
-        if agents_last_exam_result is not None:
-            return agents_last_exam_result
-        benchmark_review_lifecycle_result = handle_benchmark_review_lifecycle_command(
-            args,
-            registry_path=registry_path,
-            print_payload=print_payload,
-            output_format=output_format,
-        )
-        if benchmark_review_lifecycle_result is not None:
-            return benchmark_review_lifecycle_result
-        terminal_bench_environment_result = handle_terminal_bench_environment_result_command(
-            args,
-            print_payload=print_payload,
-            output_format=output_format,
-        )
-        if terminal_bench_environment_result is not None:
-            return terminal_bench_environment_result
-        benchmark_run_ledger_result = handle_benchmark_run_ledger_command(
-            args,
-            registry_path=registry_path,
-            print_payload=print_payload,
-            output_format=output_format,
-            append_benchmark_run_rollout_event=append_benchmark_run_rollout_event,
-        )
-        if benchmark_run_ledger_result is not None:
-            return benchmark_run_ledger_result
+    benchmark_result = handle_benchmark_command(
+        args,
+        registry_path=registry_path,
+        print_payload=print_payload,
+        output_format=output_format,
+        append_benchmark_run_rollout_event=append_benchmark_run_rollout_event,
+    )
+    if benchmark_result is not None:
+        return benchmark_result
     if args.command == "history":
         return handle_history_command(
             args,

--- a/loopx/cli_commands/__init__.py
+++ b/loopx/cli_commands/__init__.py
@@ -20,6 +20,10 @@ from .benchmark_boundary import (
     handle_benchmark_boundary_command,
     register_benchmark_boundary_commands,
 )
+from .benchmark_dispatch import (
+    handle_benchmark_command,
+    register_benchmark_command_group,
+)
 from .benchmark_review_lifecycle import (
     handle_benchmark_review_lifecycle_command,
     register_benchmark_review_lifecycle_commands,
@@ -92,6 +96,7 @@ __all__ = [
     "handle_agents_last_exam_command",
     "handle_agentissue_runner_flow_command",
     "handle_benchmark_boundary_command",
+    "handle_benchmark_command",
     "handle_benchmark_review_lifecycle_command",
     "handle_benchmark_run_ledger_command",
     "handle_bootstrap_connect_command",
@@ -132,6 +137,7 @@ __all__ = [
     "register_agents_last_exam_commands",
     "register_agentissue_runner_flow_commands",
     "register_benchmark_boundary_commands",
+    "register_benchmark_command_group",
     "register_benchmark_review_lifecycle_commands",
     "register_benchmark_run_ledger_commands",
     "register_bootstrap_connect_command",

--- a/loopx/cli_commands/benchmark_dispatch.py
+++ b/loopx/cli_commands/benchmark_dispatch.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+from pathlib import Path
+
+from .agents_last_exam import (
+    handle_agents_last_exam_command,
+    register_agents_last_exam_commands,
+)
+from .agentissue_runner_flow import (
+    handle_agentissue_runner_flow_command,
+    register_agentissue_runner_flow_commands,
+)
+from .benchmark_boundary import (
+    handle_benchmark_boundary_command,
+    register_benchmark_boundary_commands,
+)
+from .benchmark_review_lifecycle import (
+    handle_benchmark_review_lifecycle_command,
+    register_benchmark_review_lifecycle_commands,
+)
+from .benchmark_run_ledger import (
+    handle_benchmark_run_ledger_command,
+    register_benchmark_run_ledger_commands,
+)
+from .terminal_bench_adapter import (
+    handle_terminal_bench_adapter_command,
+    register_terminal_bench_adapter_commands,
+)
+from .terminal_bench_environment_result import (
+    handle_terminal_bench_environment_result_command,
+    register_terminal_bench_environment_result_commands,
+)
+
+
+AddSubcommandFormat = Callable[[argparse.ArgumentParser], None]
+OutputFormat = Callable[..., str]
+PrintPayload = Callable[..., None]
+BenchmarkRunRolloutEventAppender = Callable[..., dict[str, object]]
+
+
+def register_benchmark_command_group(
+    subparsers: argparse._SubParsersAction,
+    add_subcommand_format: AddSubcommandFormat,
+) -> None:
+    benchmark_parser = subparsers.add_parser(
+        "benchmark",
+        help="Benchmark runner skeletons. Current public surface is fixture-only and no-run by default.",
+    )
+    benchmark_sub = benchmark_parser.add_subparsers(dest="benchmark_command", required=True)
+
+    register_benchmark_run_ledger_commands(benchmark_sub, add_subcommand_format)
+
+    register_agentissue_runner_flow_commands(benchmark_sub, add_subcommand_format)
+    register_benchmark_boundary_commands(benchmark_sub, add_subcommand_format)
+    register_terminal_bench_adapter_commands(benchmark_sub, add_subcommand_format)
+
+    register_agents_last_exam_commands(benchmark_sub, add_subcommand_format)
+
+    register_benchmark_review_lifecycle_commands(benchmark_sub, add_subcommand_format)
+    register_terminal_bench_environment_result_commands(benchmark_sub, add_subcommand_format)
+
+
+def handle_benchmark_command(
+    args: argparse.Namespace,
+    *,
+    registry_path: Path,
+    print_payload: PrintPayload,
+    output_format: OutputFormat,
+    append_benchmark_run_rollout_event: BenchmarkRunRolloutEventAppender,
+) -> int | None:
+    if args.command != "benchmark":
+        return None
+
+    agentissue_runner_flow_result = handle_agentissue_runner_flow_command(
+        args,
+        registry_path=registry_path,
+        print_payload=print_payload,
+    )
+    if agentissue_runner_flow_result is not None:
+        return agentissue_runner_flow_result
+
+    benchmark_boundary_result = handle_benchmark_boundary_command(
+        args,
+        print_payload=print_payload,
+        output_format=output_format,
+    )
+    if benchmark_boundary_result is not None:
+        return benchmark_boundary_result
+
+    terminal_bench_adapter_result = handle_terminal_bench_adapter_command(
+        args,
+        print_payload=print_payload,
+        output_format=output_format,
+    )
+    if terminal_bench_adapter_result is not None:
+        return terminal_bench_adapter_result
+
+    agents_last_exam_result = handle_agents_last_exam_command(
+        args,
+        print_payload=print_payload,
+        output_format=output_format,
+    )
+    if agents_last_exam_result is not None:
+        return agents_last_exam_result
+
+    benchmark_review_lifecycle_result = handle_benchmark_review_lifecycle_command(
+        args,
+        registry_path=registry_path,
+        print_payload=print_payload,
+        output_format=output_format,
+    )
+    if benchmark_review_lifecycle_result is not None:
+        return benchmark_review_lifecycle_result
+
+    terminal_bench_environment_result = handle_terminal_bench_environment_result_command(
+        args,
+        print_payload=print_payload,
+        output_format=output_format,
+    )
+    if terminal_bench_environment_result is not None:
+        return terminal_bench_environment_result
+
+    benchmark_run_ledger_result = handle_benchmark_run_ledger_command(
+        args,
+        registry_path=registry_path,
+        print_payload=print_payload,
+        output_format=output_format,
+        append_benchmark_run_rollout_event=append_benchmark_run_rollout_event,
+    )
+    if benchmark_run_ledger_result is not None:
+        return benchmark_run_ledger_result
+
+    return None


### PR DESCRIPTION
## Summary
- Extract the `benchmark` command group registration and dispatch chain from `loopx/cli.py` into `loopx/cli_commands/benchmark_dispatch.py`.
- Reduce top-level CLI import fan-in for benchmark subcommands while preserving shared rollout-event injection for benchmark run ledger writes.
- Update benchmark command modularization smokes so each subcommand now checks the dispatch module boundary, and add a focused benchmark-dispatch smoke.

## Validation
- `python3 -m py_compile loopx/cli.py loopx/cli_commands/__init__.py loopx/cli_commands/benchmark_dispatch.py examples/cli-benchmark-dispatch-command-modularization-smoke.py examples/cli-agents-last-exam-command-modularization-smoke.py examples/cli-benchmark-boundary-command-modularization-smoke.py examples/cli-benchmark-review-lifecycle-command-modularization-smoke.py examples/cli-benchmark-run-ledger-command-modularization-smoke.py examples/cli-terminal-bench-adapter-command-modularization-smoke.py examples/cli-terminal-bench-environment-result-command-modularization-smoke.py`
- `python3 examples/cli-benchmark-dispatch-command-modularization-smoke.py`
- `for smoke in examples/cli-*-command-modularization-smoke.py; do python3 "$smoke" || exit 1; done`
- `python3 -m py_compile $(git ls-files 'loopx/*.py' 'loopx/cli_commands/*.py')`
- `git diff --check`
- `python3 -m loopx.cli check --scan-path loopx/cli.py --scan-path loopx/cli_commands/__init__.py --scan-path loopx/cli_commands/benchmark_dispatch.py --scan-path examples/cli-benchmark-dispatch-command-modularization-smoke.py --scan-path examples/cli-agents-last-exam-command-modularization-smoke.py --scan-path examples/cli-benchmark-boundary-command-modularization-smoke.py --scan-path examples/cli-benchmark-review-lifecycle-command-modularization-smoke.py --scan-path examples/cli-benchmark-run-ledger-command-modularization-smoke.py --scan-path examples/cli-terminal-bench-adapter-command-modularization-smoke.py --scan-path examples/cli-terminal-bench-environment-result-command-modularization-smoke.py`

LoopX check reported the existing duplicate index rows warning (`loopx-meta: duplicate index rows raw=4706 unique=4702`) and no scan errors.
