### PR TITLE
Refactor starter CLI dispatch

### DIFF
--- a/examples/cli-starter-dispatch-command-modularization-smoke.py
+++ b/examples/cli-starter-dispatch-command-modularization-smoke.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CLI = ROOT / "loopx" / "cli.py"
+STARTER_MODULE = ROOT / "loopx" / "cli_commands" / "starter.py"
+INIT = ROOT / "loopx" / "cli_commands" / "__init__.py"
+
+
+def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "loopx.cli", *args],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def require_success(result: subprocess.CompletedProcess[str]) -> str:
+    if result.returncode != 0:
+        raise AssertionError(
+            f"expected success, got {result.returncode}\n"
+            f"stdout:\n{result.stdout}\n\nstderr:\n{result.stderr}"
+        )
+    return result.stdout
+
+
+def require_json_success(result: subprocess.CompletedProcess[str]) -> dict[str, object]:
+    payload = json.loads(require_success(result))
+    require(isinstance(payload, dict), "expected JSON object payload")
+    require(payload.get("ok") is True, f"payload was not ok: {payload}")
+    return payload
+
+
+def assert_source_shape() -> None:
+    cli_source = CLI.read_text(encoding="utf-8")
+    starter_source = STARTER_MODULE.read_text(encoding="utf-8")
+    init_source = INIT.read_text(encoding="utf-8")
+
+    starter_commands = [
+        "new-project-prompt",
+        "codex-cli-bootstrap-message",
+        "codex-cli-tui-bootstrap-smoke-bundle",
+        "codex-cli-one-message-loop-pilot",
+        "codex-cli-visible-local-driver-pilot",
+        "codex-cli-bounded-visible-pilot-adapter",
+        "codex-cli-visible-first-response-capture-plan",
+        "codex-cli-visible-attach-acceptance",
+        "codex-cli-exec-handoff",
+        "codex-cli-session-probe",
+        "codex-cli-visible-driver-plan",
+        "codex-cli-local-driver-plan",
+        "codex-cli-visible-driver-run",
+        "codex-cli-local-scheduler-tick",
+        "codex-cli-local-scheduler-exec",
+        "codex-cli-visible-session-proof",
+        "codex-cli-runtime-idle-detector",
+        "demo",
+    ]
+    for command in starter_commands:
+        marker = f'if args.command == "{command}":'
+        require(marker not in cli_source, f"starter dispatch branch leaked into cli.py: {marker}")
+
+    forbidden_handler_markers = [
+        "handle_new_project_prompt_command(",
+        "handle_codex_cli_bootstrap_message_command(",
+        "handle_codex_cli_visible_driver_run_command(",
+        "handle_codex_cli_local_scheduler_exec_command(",
+        "handle_demo_command(",
+    ]
+    for marker in forbidden_handler_markers:
+        require(marker not in cli_source, f"starter handler marker leaked into cli.py: {marker}")
+
+    require("register_starter_commands(sub)" in cli_source, "cli.py did not register starter commands")
+    require("handle_starter_command(args, print_payload)" in cli_source, "cli.py did not call starter dispatcher")
+    require("def handle_starter_command(" in starter_source, "starter module omitted dispatcher")
+    require('"codex-cli-visible-driver-run": handle_codex_cli_visible_driver_run_command' in starter_source, "starter dispatcher omitted visible driver run")
+    require('"demo": handle_demo_command' in starter_source, "starter dispatcher omitted demo")
+    require("handle_starter_command" in init_source, "__init__ omitted starter dispatcher export")
+
+
+def assert_cli_surfaces() -> None:
+    help_expectations = {
+        "new-project-prompt": ["--goal-doc", "--write-scope"],
+        "codex-cli-bootstrap-message": ["--agent-id", "--message-only"],
+        "codex-cli-visible-driver-run": ["--proof-fixture", "--allow-headless-fallback"],
+        "codex-cli-local-scheduler-exec": ["--guard-checked", "--candidate-command-prefix"],
+        "demo": ["--user-todo", "--agent-todo"],
+    }
+    for command, needles in help_expectations.items():
+        help_text = require_success(run_cli(command, "--help"))
+        for needle in needles:
+            require(needle in help_text, f"{command} help omitted {needle}")
+
+    prompt_payload = require_json_success(
+        run_cli(
+            "--format",
+            "json",
+            "new-project-prompt",
+            "--project",
+            ".",
+            "--goal-doc",
+            "README.md",
+            "--goal-id",
+            "starter-dispatch-smoke",
+        )
+    )
+    require(prompt_payload.get("goal_id") == "starter-dispatch-smoke", prompt_payload)
+
+    bootstrap_text = require_success(
+        run_cli(
+            "codex-cli-bootstrap-message",
+            "--project",
+            ".",
+            "--goal-id",
+            "starter-dispatch-smoke",
+            "--message-only",
+        )
+    )
+    require("loopx" in bootstrap_text, "message-only bootstrap output lost LoopX command text")
+
+    capture_payload = require_json_success(
+        run_cli(
+            "--format",
+            "json",
+            "codex-cli-visible-first-response-capture-plan",
+            "--project",
+            ".",
+            "--goal-id",
+            "starter-dispatch-smoke",
+        )
+    )
+    require(capture_payload.get("goal_id") == "starter-dispatch-smoke", capture_payload)
+
+    handoff_payload = require_json_success(
+        run_cli(
+            "--format",
+            "json",
+            "codex-cli-exec-handoff",
+            "--project",
+            ".",
+            "--goal-id",
+            "starter-dispatch-smoke",
+        )
+    )
+    require(handoff_payload.get("goal_id") == "starter-dispatch-smoke", handoff_payload)
+
+
+def main() -> None:
+    assert_source_shape()
+    assert_cli_surfaces()
+    print("cli-starter-dispatch-command-modularization-smoke: ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -10,34 +10,17 @@ from .cli_commands import (
     handle_benchmark_command,
     handle_bootstrap_connect_command,
     handle_check_command,
-    handle_codex_cli_bounded_visible_pilot_adapter_command,
-    handle_codex_cli_bootstrap_message_command,
-    handle_codex_cli_exec_handoff_command,
-    handle_codex_cli_visible_first_response_capture_plan_command,
-    handle_codex_cli_local_driver_plan_command,
-    handle_codex_cli_local_scheduler_exec_command,
-    handle_codex_cli_local_scheduler_tick_command,
-    handle_codex_cli_one_message_loop_pilot_command,
-    handle_codex_cli_runtime_idle_detector_command,
-    handle_codex_cli_session_probe_command,
-    handle_codex_cli_tui_bootstrap_smoke_bundle_command,
-    handle_codex_cli_visible_attach_acceptance_command,
-    handle_codex_cli_visible_local_driver_pilot_command,
-    handle_codex_cli_visible_driver_run_command,
-    handle_codex_cli_visible_driver_plan_command,
-    handle_codex_cli_visible_session_proof_command,
     handle_diagnose_command,
-    handle_demo_command,
     handle_doctor_command,
     handle_dreaming_command,
     handle_history_command,
     handle_ml_experiment_command,
-    handle_new_project_prompt_command,
     handle_project_lifecycle_command,
     handle_quota_command,
     handle_registry_admin_command,
     handle_review_packet_command,
     handle_status_command,
+    handle_starter_command,
     handle_support_control_command,
     handle_todo_command,
     handle_worker_bridge_command,
@@ -190,59 +173,9 @@ def main(argv: list[str] | None = None) -> int:
     if bootstrap_connect_result is not None:
         return bootstrap_connect_result
 
-    if args.command == "new-project-prompt":
-        return handle_new_project_prompt_command(args, print_payload)
-
-    if args.command == "codex-cli-bootstrap-message":
-        return handle_codex_cli_bootstrap_message_command(args, print_payload)
-
-    if args.command == "codex-cli-tui-bootstrap-smoke-bundle":
-        return handle_codex_cli_tui_bootstrap_smoke_bundle_command(args, print_payload)
-
-    if args.command == "codex-cli-one-message-loop-pilot":
-        return handle_codex_cli_one_message_loop_pilot_command(args, print_payload)
-
-    if args.command == "codex-cli-visible-local-driver-pilot":
-        return handle_codex_cli_visible_local_driver_pilot_command(args, print_payload)
-
-    if args.command == "codex-cli-bounded-visible-pilot-adapter":
-        return handle_codex_cli_bounded_visible_pilot_adapter_command(args, print_payload)
-
-    if args.command == "codex-cli-visible-first-response-capture-plan":
-        return handle_codex_cli_visible_first_response_capture_plan_command(args, print_payload)
-
-    if args.command == "codex-cli-visible-attach-acceptance":
-        return handle_codex_cli_visible_attach_acceptance_command(args, print_payload)
-
-    if args.command == "codex-cli-exec-handoff":
-        return handle_codex_cli_exec_handoff_command(args, print_payload)
-
-    if args.command == "codex-cli-session-probe":
-        return handle_codex_cli_session_probe_command(args, print_payload)
-
-    if args.command == "codex-cli-visible-driver-plan":
-        return handle_codex_cli_visible_driver_plan_command(args, print_payload)
-
-    if args.command == "codex-cli-local-driver-plan":
-        return handle_codex_cli_local_driver_plan_command(args, print_payload)
-
-    if args.command == "codex-cli-visible-driver-run":
-        return handle_codex_cli_visible_driver_run_command(args, print_payload)
-
-    if args.command == "codex-cli-local-scheduler-tick":
-        return handle_codex_cli_local_scheduler_tick_command(args, print_payload)
-
-    if args.command == "codex-cli-local-scheduler-exec":
-        return handle_codex_cli_local_scheduler_exec_command(args, print_payload)
-
-    if args.command == "codex-cli-visible-session-proof":
-        return handle_codex_cli_visible_session_proof_command(args, print_payload)
-
-    if args.command == "codex-cli-runtime-idle-detector":
-        return handle_codex_cli_runtime_idle_detector_command(args, print_payload)
-
-    if args.command == "demo":
-        return handle_demo_command(args, print_payload)
+    starter_result = handle_starter_command(args, print_payload)
+    if starter_result is not None:
+        return starter_result
 
     if args.command == "doctor":
         return handle_doctor_command(args, print_payload)

--- a/loopx/cli_commands/__init__.py
+++ b/loopx/cli_commands/__init__.py
@@ -68,6 +68,7 @@ from .starter import (
     handle_codex_cli_visible_session_proof_command,
     handle_demo_command,
     handle_new_project_prompt_command,
+    handle_starter_command,
     register_starter_commands,
 )
 from .status import (
@@ -129,6 +130,7 @@ __all__ = [
     "handle_registry_admin_command",
     "handle_review_packet_command",
     "handle_status_command",
+    "handle_starter_command",
     "handle_support_control_command",
     "handle_terminal_bench_adapter_command",
     "handle_terminal_bench_environment_result_command",

--- a/loopx/cli_commands/starter.py
+++ b/loopx/cli_commands/starter.py
@@ -1170,3 +1170,33 @@ def handle_demo_command(args: argparse.Namespace, print_payload: PrintPayload) -
         }
     print_payload(payload, args.format, render_demo_markdown)
     return 0 if payload.get("ok") else 1
+
+
+def handle_starter_command(
+    args: argparse.Namespace,
+    print_payload: PrintPayload,
+) -> int | None:
+    handlers: dict[str, Callable[[argparse.Namespace, PrintPayload], int]] = {
+        "new-project-prompt": handle_new_project_prompt_command,
+        "codex-cli-bootstrap-message": handle_codex_cli_bootstrap_message_command,
+        "codex-cli-tui-bootstrap-smoke-bundle": handle_codex_cli_tui_bootstrap_smoke_bundle_command,
+        "codex-cli-one-message-loop-pilot": handle_codex_cli_one_message_loop_pilot_command,
+        "codex-cli-visible-local-driver-pilot": handle_codex_cli_visible_local_driver_pilot_command,
+        "codex-cli-bounded-visible-pilot-adapter": handle_codex_cli_bounded_visible_pilot_adapter_command,
+        "codex-cli-visible-first-response-capture-plan": handle_codex_cli_visible_first_response_capture_plan_command,
+        "codex-cli-visible-attach-acceptance": handle_codex_cli_visible_attach_acceptance_command,
+        "codex-cli-exec-handoff": handle_codex_cli_exec_handoff_command,
+        "codex-cli-session-probe": handle_codex_cli_session_probe_command,
+        "codex-cli-visible-driver-plan": handle_codex_cli_visible_driver_plan_command,
+        "codex-cli-local-driver-plan": handle_codex_cli_local_driver_plan_command,
+        "codex-cli-visible-driver-run": handle_codex_cli_visible_driver_run_command,
+        "codex-cli-local-scheduler-tick": handle_codex_cli_local_scheduler_tick_command,
+        "codex-cli-local-scheduler-exec": handle_codex_cli_local_scheduler_exec_command,
+        "codex-cli-visible-session-proof": handle_codex_cli_visible_session_proof_command,
+        "codex-cli-runtime-idle-detector": handle_codex_cli_runtime_idle_detector_command,
+        "demo": handle_demo_command,
+    }
+    handler = handlers.get(str(getattr(args, "command", "")))
+    if handler is None:
+        return None
+    return handler(args, print_payload)


### PR DESCRIPTION
## Summary
- Move starter/Codex command dispatch from `loopx/cli.py` into `loopx/cli_commands/starter.py` via `handle_starter_command`.
- Reduce top-level CLI import fan-in while preserving existing individual starter handlers and command registration.
- Add a focused starter dispatch modularization smoke covering source shape, help surfaces, and no-execution starter command payloads.

## Validation
- `python3 -m py_compile loopx/cli.py loopx/cli_commands/__init__.py loopx/cli_commands/starter.py examples/cli-starter-dispatch-command-modularization-smoke.py`
- `python3 examples/cli-starter-dispatch-command-modularization-smoke.py`
- `for smoke in examples/cli-*-command-modularization-smoke.py; do python3 "$smoke" || exit 1; done`
- `python3 -m py_compile $(git ls-files 'loopx/*.py' 'loopx/cli_commands/*.py')`
- `git diff --check`
- `python3 -m loopx.cli check --scan-path loopx/cli.py --scan-path loopx/cli_commands/__init__.py --scan-path loopx/cli_commands/starter.py --scan-path examples/cli-starter-dispatch-command-modularization-smoke.py`

LoopX check reported the existing duplicate index rows warning (`loopx-meta: duplicate index rows raw=4708 unique=4704`) and no scan errors.
