### PR TITLE
Refactor starter bootstrap command family

### DIFF
--- a/examples/cli-starter-bootstrap-family-command-modularization-smoke.py
+++ b/examples/cli-starter-bootstrap-family-command-modularization-smoke.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+STARTER = ROOT / "loopx" / "cli_commands" / "starter.py"
+BOOTSTRAP = ROOT / "loopx" / "cli_commands" / "starter_bootstrap.py"
+INIT = ROOT / "loopx" / "cli_commands" / "__init__.py"
+
+
+def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "loopx.cli", *args],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def require_success(result: subprocess.CompletedProcess[str]) -> str:
+    if result.returncode != 0:
+        raise AssertionError(
+            f"expected success, got {result.returncode}\n"
+            f"stdout:\n{result.stdout}\n\nstderr:\n{result.stderr}"
+        )
+    return result.stdout
+
+
+def require_json_success(result: subprocess.CompletedProcess[str]) -> dict[str, object]:
+    payload = json.loads(require_success(result))
+    require(isinstance(payload, dict), "expected JSON object payload")
+    require(payload.get("ok") is True, f"payload was not ok: {payload}")
+    return payload
+
+
+def assert_source_shape() -> None:
+    starter_source = STARTER.read_text(encoding="utf-8")
+    bootstrap_source = BOOTSTRAP.read_text(encoding="utf-8")
+    init_source = INIT.read_text(encoding="utf-8")
+
+    forbidden_starter_markers = [
+        "DEFAULT_HANDOFF_ADAPTER_KIND",
+        "build_new_project_prompt(",
+        "render_new_project_prompt_markdown",
+        "build_codex_cli_bootstrap_message(",
+        "render_codex_cli_bootstrap_message_markdown",
+        "build_codex_cli_tui_bootstrap_smoke_bundle(",
+        "build_codex_cli_exec_handoff(",
+        "def handle_new_project_prompt_command(",
+        "def handle_codex_cli_bootstrap_message_command(",
+        "def handle_codex_cli_tui_bootstrap_smoke_bundle_command(",
+        "def handle_codex_cli_exec_handoff_command(",
+    ]
+    for marker in forbidden_starter_markers:
+        require(marker not in starter_source, f"bootstrap/message marker leaked into starter.py: {marker}")
+
+    for marker in (
+        "register_starter_bootstrap_commands(subparsers)",
+        "handle_starter_bootstrap_command(args, print_payload)",
+    ):
+        require(marker in starter_source, f"starter.py missing bootstrap delegation marker: {marker}")
+
+    for marker in (
+        "def register_starter_bootstrap_commands(",
+        "def handle_starter_bootstrap_command(",
+        "def handle_new_project_prompt_command(",
+        "def handle_codex_cli_bootstrap_message_command(",
+        "def handle_codex_cli_tui_bootstrap_smoke_bundle_command(",
+        "def handle_codex_cli_exec_handoff_command(",
+        "build_new_project_prompt(",
+        "build_codex_cli_exec_handoff(",
+    ):
+        require(marker in bootstrap_source, f"starter_bootstrap.py missing marker: {marker}")
+
+    for marker in (
+        "handle_starter_bootstrap_command",
+        "register_starter_bootstrap_commands",
+        "handle_new_project_prompt_command",
+        "handle_codex_cli_exec_handoff_command",
+    ):
+        require(marker in init_source, f"__init__ omitted bootstrap export: {marker}")
+
+
+def assert_cli_surfaces() -> None:
+    for command, needles in {
+        "new-project-prompt": ["--goal-doc", "--adapter-status", "--write-scope"],
+        "codex-cli-bootstrap-message": ["--agent-id", "--message-only"],
+        "codex-cli-tui-bootstrap-smoke-bundle": ["--agent-id", "--cli-bin"],
+        "codex-cli-exec-handoff": ["--codex-bin", "--cli-bin"],
+    }.items():
+        help_text = require_success(run_cli(command, "--help"))
+        for needle in needles:
+            require(needle in help_text, f"{command} help omitted {needle}")
+
+    prompt_payload = require_json_success(
+        run_cli(
+            "--format",
+            "json",
+            "new-project-prompt",
+            "--project",
+            ".",
+            "--goal-doc",
+            "README.md",
+            "--goal-id",
+            "starter-bootstrap-smoke",
+        )
+    )
+    require(prompt_payload.get("goal_id") == "starter-bootstrap-smoke", prompt_payload)
+
+    bootstrap_text = require_success(
+        run_cli(
+            "codex-cli-bootstrap-message",
+            "--project",
+            ".",
+            "--goal-id",
+            "starter-bootstrap-smoke",
+            "--message-only",
+        )
+    )
+    require("loopx" in bootstrap_text, "bootstrap message lost LoopX text")
+
+    bundle_payload = require_json_success(
+        run_cli(
+            "--format",
+            "json",
+            "codex-cli-tui-bootstrap-smoke-bundle",
+            "--project",
+            ".",
+            "--goal-id",
+            "starter-bootstrap-smoke",
+        )
+    )
+    require(bundle_payload.get("goal_id") == "starter-bootstrap-smoke", bundle_payload)
+
+    handoff_payload = require_json_success(
+        run_cli(
+            "--format",
+            "json",
+            "codex-cli-exec-handoff",
+            "--project",
+            ".",
+            "--goal-id",
+            "starter-bootstrap-smoke",
+        )
+    )
+    require(handoff_payload.get("goal_id") == "starter-bootstrap-smoke", handoff_payload)
+
+
+def main() -> None:
+    assert_source_shape()
+    assert_cli_surfaces()
+    print("cli-starter-bootstrap-family-command-modularization-smoke: ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/cli_commands/__init__.py
+++ b/loopx/cli_commands/__init__.py
@@ -51,8 +51,6 @@ from .registry_admin import (
 )
 from .starter import (
     handle_codex_cli_bounded_visible_pilot_adapter_command,
-    handle_codex_cli_bootstrap_message_command,
-    handle_codex_cli_exec_handoff_command,
     handle_codex_cli_visible_first_response_capture_plan_command,
     handle_codex_cli_local_driver_plan_command,
     handle_codex_cli_local_scheduler_exec_command,
@@ -60,16 +58,22 @@ from .starter import (
     handle_codex_cli_one_message_loop_pilot_command,
     handle_codex_cli_runtime_idle_detector_command,
     handle_codex_cli_session_probe_command,
-    handle_codex_cli_tui_bootstrap_smoke_bundle_command,
     handle_codex_cli_visible_attach_acceptance_command,
     handle_codex_cli_visible_local_driver_pilot_command,
     handle_codex_cli_visible_driver_run_command,
     handle_codex_cli_visible_driver_plan_command,
     handle_codex_cli_visible_session_proof_command,
     handle_demo_command,
-    handle_new_project_prompt_command,
     handle_starter_command,
     register_starter_commands,
+)
+from .starter_bootstrap import (
+    handle_codex_cli_bootstrap_message_command,
+    handle_codex_cli_exec_handoff_command,
+    handle_codex_cli_tui_bootstrap_smoke_bundle_command,
+    handle_new_project_prompt_command,
+    handle_starter_bootstrap_command,
+    register_starter_bootstrap_commands,
 )
 from .status import (
     handle_check_command,
@@ -131,6 +135,7 @@ __all__ = [
     "handle_review_packet_command",
     "handle_status_command",
     "handle_starter_command",
+    "handle_starter_bootstrap_command",
     "handle_support_control_command",
     "handle_terminal_bench_adapter_command",
     "handle_terminal_bench_environment_result_command",
@@ -151,6 +156,7 @@ __all__ = [
     "register_quota_command",
     "register_registry_admin_commands",
     "register_starter_commands",
+    "register_starter_bootstrap_commands",
     "register_status_commands",
     "register_support_control_commands",
     "register_terminal_bench_adapter_commands",

--- a/loopx/cli_commands/starter.py
+++ b/loopx/cli_commands/starter.py
@@ -13,18 +13,6 @@ from ..demo import (
     render_demo_markdown,
     run_demo,
 )
-from ..project_prompt import (
-    DEFAULT_HANDOFF_ADAPTER_KIND,
-    DEFAULT_HANDOFF_ADAPTER_STATUS,
-    build_codex_cli_bootstrap_message,
-    build_codex_cli_exec_handoff,
-    build_codex_cli_tui_bootstrap_smoke_bundle,
-    build_new_project_prompt,
-    render_codex_cli_bootstrap_message_markdown,
-    render_codex_cli_exec_handoff_markdown,
-    render_codex_cli_tui_bootstrap_smoke_bundle_markdown,
-    render_new_project_prompt_markdown,
-)
 from ..codex_cli_probe import (
     DEFAULT_CODEX_BIN,
     DEFAULT_EXECUTOR_TIMEOUT_SECONDS,
@@ -61,6 +49,10 @@ from ..codex_cli_probe import (
     render_codex_cli_runtime_idle_detector_markdown,
     probe_human_input_idle_seconds,
     run_codex_cli_session_probe,
+)
+from .starter_bootstrap import (
+    handle_starter_bootstrap_command,
+    register_starter_bootstrap_commands,
 )
 
 
@@ -167,67 +159,7 @@ def _load_codex_cli_runtime_idle_payload(args: argparse.Namespace) -> dict[str, 
 
 
 def register_starter_commands(subparsers: argparse._SubParsersAction) -> None:
-    prompt_parser = subparsers.add_parser(
-        "new-project-prompt",
-        help="Generate a copy-paste Codex prompt for connecting a project from a goal document.",
-    )
-    prompt_parser.add_argument("--project", required=True, help="Project directory the target Codex session can access.")
-    prompt_parser.add_argument("--goal-doc", required=True, help="Goal document path for the target project.")
-    prompt_parser.add_argument("--goal-id", help="Initial stable goal id. Defaults to <project-name>-goal.")
-    prompt_parser.add_argument("--objective", help="Initial objective. Defaults to an extraction placeholder.")
-    prompt_parser.add_argument("--domain", help="Initial domain label. Defaults to an extraction placeholder.")
-    prompt_parser.add_argument("--adapter-kind", default=DEFAULT_HANDOFF_ADAPTER_KIND)
-    prompt_parser.add_argument("--adapter-status", default=DEFAULT_HANDOFF_ADAPTER_STATUS)
-    prompt_parser.add_argument("--next-probe", help="Optional read-only pre-tick command for the target project.")
-    prompt_parser.add_argument("--spawn-allowed", action="store_true", help="Include controller/sub-agent flags.")
-    prompt_parser.add_argument("--allowed-domain", action="append", default=[], help="Allowed child work domain. Repeatable.")
-    prompt_parser.add_argument("--write-scope", action="append", default=[], help="Allowed write scope such as docs/**. Repeatable.")
-
-    codex_cli_bootstrap_parser = subparsers.add_parser(
-        "codex-cli-bootstrap-message",
-        help="Generate a one-message Codex CLI TUI setup prompt that installs/connects LoopX, then sets the thin /goal loop.",
-    )
-    codex_cli_bootstrap_parser.add_argument("--project", default=".", help="Project directory to start from.")
-    codex_cli_bootstrap_parser.add_argument("--goal-id", help="Goal id. Defaults to <project-name>-goal.")
-    codex_cli_bootstrap_parser.add_argument(
-        "--agent-id",
-        help="Registered LoopX agent id to include in quota/claim instructions.",
-    )
-    codex_cli_bootstrap_parser.add_argument(
-        "--cli-bin",
-        default="loopx",
-        help="LoopX CLI binary name embedded in generated commands.",
-    )
-    codex_cli_bootstrap_parser.add_argument(
-        "--message-only",
-        "--copy-only",
-        dest="message_only",
-        action="store_true",
-        help="Print only the Codex CLI TUI paste message, without the Markdown review packet.",
-    )
-
-    codex_cli_tui_bootstrap_smoke_parser = subparsers.add_parser(
-        "codex-cli-tui-bootstrap-smoke-bundle",
-        help="Generate a transcript-free first-run smoke packet for the Codex CLI TUI bootstrap path.",
-    )
-    codex_cli_tui_bootstrap_smoke_parser.add_argument(
-        "--project",
-        default=".",
-        help="Project directory to model as the fresh repo.",
-    )
-    codex_cli_tui_bootstrap_smoke_parser.add_argument(
-        "--goal-id",
-        help="Goal id. Defaults to <project-name>-goal.",
-    )
-    codex_cli_tui_bootstrap_smoke_parser.add_argument(
-        "--agent-id",
-        help="Registered LoopX agent id to include in quota/claim instructions.",
-    )
-    codex_cli_tui_bootstrap_smoke_parser.add_argument(
-        "--cli-bin",
-        default="loopx",
-        help="LoopX CLI binary name embedded in generated commands.",
-    )
+    register_starter_bootstrap_commands(subparsers)
 
     codex_cli_one_message_loop_parser = subparsers.add_parser(
         "codex-cli-one-message-loop-pilot",
@@ -737,27 +669,6 @@ def register_starter_commands(subparsers: argparse._SubParsersAction) -> None:
         help="Confirm manual takeover remains available.",
     )
 
-    codex_cli_exec_parser = subparsers.add_parser(
-        "codex-cli-exec-handoff",
-        help="Show the disabled headless handoff boundary and the TUI message-only bootstrap command.",
-    )
-    codex_cli_exec_parser.add_argument("--project", default=".", help="Project directory to start from.")
-    codex_cli_exec_parser.add_argument("--goal-id", help="Goal id. Defaults to <project-name>-goal.")
-    codex_cli_exec_parser.add_argument(
-        "--agent-id",
-        help="Registered LoopX agent id to include in quota/claim instructions.",
-    )
-    codex_cli_exec_parser.add_argument(
-        "--cli-bin",
-        default="loopx",
-        help="LoopX CLI binary name embedded in generated commands.",
-    )
-    codex_cli_exec_parser.add_argument(
-        "--codex-bin",
-        default=DEFAULT_CODEX_BIN,
-        help="Codex CLI executable name embedded in the generated handoff command.",
-    )
-
     demo_parser = subparsers.add_parser(
         "demo",
         help="Create a disposable local demo goal and show status/quota output.",
@@ -771,58 +682,6 @@ def register_starter_commands(subparsers: argparse._SubParsersAction) -> None:
     demo_parser.add_argument("--objective", default=DEFAULT_DEMO_OBJECTIVE)
     demo_parser.add_argument("--user-todo", default=DEFAULT_DEMO_USER_TODO)
     demo_parser.add_argument("--agent-todo", default=DEFAULT_DEMO_AGENT_TODO)
-
-
-def handle_new_project_prompt_command(
-    args: argparse.Namespace,
-    print_payload: PrintPayload,
-) -> int:
-    payload = build_new_project_prompt(
-        project=Path(args.project),
-        goal_doc=Path(args.goal_doc),
-        goal_id=args.goal_id,
-        objective=args.objective,
-        domain=args.domain,
-        adapter_kind=args.adapter_kind,
-        adapter_status=args.adapter_status,
-        next_probe=args.next_probe,
-        spawn_allowed=bool(args.spawn_allowed),
-        allowed_domains=args.allowed_domain,
-        write_scope=args.write_scope,
-    )
-    print_payload(payload, args.format, render_new_project_prompt_markdown)
-    return 0
-
-
-def handle_codex_cli_bootstrap_message_command(
-    args: argparse.Namespace,
-    print_payload: PrintPayload,
-) -> int:
-    payload = build_codex_cli_bootstrap_message(
-        project=Path(args.project),
-        goal_id=args.goal_id,
-        agent_id=args.agent_id,
-        cli_bin=args.cli_bin,
-    )
-    if bool(getattr(args, "message_only", False)):
-        print(str(payload.get("message") or ""))
-        return 0
-    print_payload(payload, args.format, render_codex_cli_bootstrap_message_markdown)
-    return 0
-
-
-def handle_codex_cli_tui_bootstrap_smoke_bundle_command(
-    args: argparse.Namespace,
-    print_payload: PrintPayload,
-) -> int:
-    payload = build_codex_cli_tui_bootstrap_smoke_bundle(
-        project=Path(args.project),
-        goal_id=args.goal_id,
-        agent_id=args.agent_id,
-        cli_bin=args.cli_bin,
-    )
-    print_payload(payload, args.format, render_codex_cli_tui_bootstrap_smoke_bundle_markdown)
-    return 0
 
 
 def handle_codex_cli_one_message_loop_pilot_command(
@@ -1136,21 +995,6 @@ def handle_codex_cli_runtime_idle_detector_command(
     return 0 if payload.get("ok") else 1
 
 
-def handle_codex_cli_exec_handoff_command(
-    args: argparse.Namespace,
-    print_payload: PrintPayload,
-) -> int:
-    payload = build_codex_cli_exec_handoff(
-        project=Path(args.project),
-        goal_id=args.goal_id,
-        agent_id=args.agent_id,
-        cli_bin=args.cli_bin,
-        codex_bin=args.codex_bin,
-    )
-    print_payload(payload, args.format, render_codex_cli_exec_handoff_markdown)
-    return 0 if payload.get("ok") else 1
-
-
 def handle_demo_command(args: argparse.Namespace, print_payload: PrintPayload) -> int:
     try:
         payload = run_demo(
@@ -1176,16 +1020,15 @@ def handle_starter_command(
     args: argparse.Namespace,
     print_payload: PrintPayload,
 ) -> int | None:
+    bootstrap_result = handle_starter_bootstrap_command(args, print_payload)
+    if bootstrap_result is not None:
+        return bootstrap_result
     handlers: dict[str, Callable[[argparse.Namespace, PrintPayload], int]] = {
-        "new-project-prompt": handle_new_project_prompt_command,
-        "codex-cli-bootstrap-message": handle_codex_cli_bootstrap_message_command,
-        "codex-cli-tui-bootstrap-smoke-bundle": handle_codex_cli_tui_bootstrap_smoke_bundle_command,
         "codex-cli-one-message-loop-pilot": handle_codex_cli_one_message_loop_pilot_command,
         "codex-cli-visible-local-driver-pilot": handle_codex_cli_visible_local_driver_pilot_command,
         "codex-cli-bounded-visible-pilot-adapter": handle_codex_cli_bounded_visible_pilot_adapter_command,
         "codex-cli-visible-first-response-capture-plan": handle_codex_cli_visible_first_response_capture_plan_command,
         "codex-cli-visible-attach-acceptance": handle_codex_cli_visible_attach_acceptance_command,
-        "codex-cli-exec-handoff": handle_codex_cli_exec_handoff_command,
         "codex-cli-session-probe": handle_codex_cli_session_probe_command,
         "codex-cli-visible-driver-plan": handle_codex_cli_visible_driver_plan_command,
         "codex-cli-local-driver-plan": handle_codex_cli_local_driver_plan_command,

--- a/loopx/cli_commands/starter_bootstrap.py
+++ b/loopx/cli_commands/starter_bootstrap.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+from pathlib import Path
+
+from ..codex_cli_probe import DEFAULT_CODEX_BIN
+from ..project_prompt import (
+    DEFAULT_HANDOFF_ADAPTER_KIND,
+    DEFAULT_HANDOFF_ADAPTER_STATUS,
+    build_codex_cli_bootstrap_message,
+    build_codex_cli_exec_handoff,
+    build_codex_cli_tui_bootstrap_smoke_bundle,
+    build_new_project_prompt,
+    render_codex_cli_bootstrap_message_markdown,
+    render_codex_cli_exec_handoff_markdown,
+    render_codex_cli_tui_bootstrap_smoke_bundle_markdown,
+    render_new_project_prompt_markdown,
+)
+
+
+PrintPayload = Callable[
+    [dict[str, object], str, Callable[[dict[str, object]], str]],
+    None,
+]
+
+
+def register_starter_bootstrap_commands(subparsers: argparse._SubParsersAction) -> None:
+    prompt_parser = subparsers.add_parser(
+        "new-project-prompt",
+        help="Generate a copy-paste Codex prompt for connecting a project from a goal document.",
+    )
+    prompt_parser.add_argument("--project", required=True, help="Project directory the target Codex session can access.")
+    prompt_parser.add_argument("--goal-doc", required=True, help="Goal document path for the target project.")
+    prompt_parser.add_argument("--goal-id", help="Initial stable goal id. Defaults to <project-name>-goal.")
+    prompt_parser.add_argument("--objective", help="Initial objective. Defaults to an extraction placeholder.")
+    prompt_parser.add_argument("--domain", help="Initial domain label. Defaults to an extraction placeholder.")
+    prompt_parser.add_argument("--adapter-kind", default=DEFAULT_HANDOFF_ADAPTER_KIND)
+    prompt_parser.add_argument("--adapter-status", default=DEFAULT_HANDOFF_ADAPTER_STATUS)
+    prompt_parser.add_argument("--next-probe", help="Optional read-only pre-tick command for the target project.")
+    prompt_parser.add_argument("--spawn-allowed", action="store_true", help="Include controller/sub-agent flags.")
+    prompt_parser.add_argument("--allowed-domain", action="append", default=[], help="Allowed child work domain. Repeatable.")
+    prompt_parser.add_argument("--write-scope", action="append", default=[], help="Allowed write scope such as docs/**. Repeatable.")
+
+    codex_cli_bootstrap_parser = subparsers.add_parser(
+        "codex-cli-bootstrap-message",
+        help="Generate a one-message Codex CLI TUI setup prompt that installs/connects LoopX, then sets the thin /goal loop.",
+    )
+    codex_cli_bootstrap_parser.add_argument("--project", default=".", help="Project directory to start from.")
+    codex_cli_bootstrap_parser.add_argument("--goal-id", help="Goal id. Defaults to <project-name>-goal.")
+    codex_cli_bootstrap_parser.add_argument(
+        "--agent-id",
+        help="Registered LoopX agent id to include in quota/claim instructions.",
+    )
+    codex_cli_bootstrap_parser.add_argument(
+        "--cli-bin",
+        default="loopx",
+        help="LoopX CLI binary name embedded in generated commands.",
+    )
+    codex_cli_bootstrap_parser.add_argument(
+        "--message-only",
+        "--copy-only",
+        dest="message_only",
+        action="store_true",
+        help="Print only the Codex CLI TUI paste message, without the Markdown review packet.",
+    )
+
+    codex_cli_tui_bootstrap_smoke_parser = subparsers.add_parser(
+        "codex-cli-tui-bootstrap-smoke-bundle",
+        help="Generate a transcript-free first-run smoke packet for the Codex CLI TUI bootstrap path.",
+    )
+    codex_cli_tui_bootstrap_smoke_parser.add_argument(
+        "--project",
+        default=".",
+        help="Project directory to model as the fresh repo.",
+    )
+    codex_cli_tui_bootstrap_smoke_parser.add_argument(
+        "--goal-id",
+        help="Goal id. Defaults to <project-name>-goal.",
+    )
+    codex_cli_tui_bootstrap_smoke_parser.add_argument(
+        "--agent-id",
+        help="Registered LoopX agent id to include in quota/claim instructions.",
+    )
+    codex_cli_tui_bootstrap_smoke_parser.add_argument(
+        "--cli-bin",
+        default="loopx",
+        help="LoopX CLI binary name embedded in generated commands.",
+    )
+
+    codex_cli_exec_parser = subparsers.add_parser(
+        "codex-cli-exec-handoff",
+        help="Show the disabled headless handoff boundary and the TUI message-only bootstrap command.",
+    )
+    codex_cli_exec_parser.add_argument("--project", default=".", help="Project directory to start from.")
+    codex_cli_exec_parser.add_argument("--goal-id", help="Goal id. Defaults to <project-name>-goal.")
+    codex_cli_exec_parser.add_argument(
+        "--agent-id",
+        help="Registered LoopX agent id to include in quota/claim instructions.",
+    )
+    codex_cli_exec_parser.add_argument(
+        "--cli-bin",
+        default="loopx",
+        help="LoopX CLI binary name embedded in generated commands.",
+    )
+    codex_cli_exec_parser.add_argument(
+        "--codex-bin",
+        default=DEFAULT_CODEX_BIN,
+        help="Codex CLI executable name embedded in the generated handoff command.",
+    )
+
+
+def handle_new_project_prompt_command(
+    args: argparse.Namespace,
+    print_payload: PrintPayload,
+) -> int:
+    payload = build_new_project_prompt(
+        project=Path(args.project),
+        goal_doc=Path(args.goal_doc),
+        goal_id=args.goal_id,
+        objective=args.objective,
+        domain=args.domain,
+        adapter_kind=args.adapter_kind,
+        adapter_status=args.adapter_status,
+        next_probe=args.next_probe,
+        spawn_allowed=bool(args.spawn_allowed),
+        allowed_domains=args.allowed_domain,
+        write_scope=args.write_scope,
+    )
+    print_payload(payload, args.format, render_new_project_prompt_markdown)
+    return 0
+
+
+def handle_codex_cli_bootstrap_message_command(
+    args: argparse.Namespace,
+    print_payload: PrintPayload,
+) -> int:
+    payload = build_codex_cli_bootstrap_message(
+        project=Path(args.project),
+        goal_id=args.goal_id,
+        agent_id=args.agent_id,
+        cli_bin=args.cli_bin,
+    )
+    if bool(getattr(args, "message_only", False)):
+        print(str(payload.get("message") or ""))
+        return 0
+    print_payload(payload, args.format, render_codex_cli_bootstrap_message_markdown)
+    return 0
+
+
+def handle_codex_cli_tui_bootstrap_smoke_bundle_command(
+    args: argparse.Namespace,
+    print_payload: PrintPayload,
+) -> int:
+    payload = build_codex_cli_tui_bootstrap_smoke_bundle(
+        project=Path(args.project),
+        goal_id=args.goal_id,
+        agent_id=args.agent_id,
+        cli_bin=args.cli_bin,
+    )
+    print_payload(payload, args.format, render_codex_cli_tui_bootstrap_smoke_bundle_markdown)
+    return 0
+
+
+def handle_codex_cli_exec_handoff_command(
+    args: argparse.Namespace,
+    print_payload: PrintPayload,
+) -> int:
+    payload = build_codex_cli_exec_handoff(
+        project=Path(args.project),
+        goal_id=args.goal_id,
+        agent_id=args.agent_id,
+        cli_bin=args.cli_bin,
+        codex_bin=args.codex_bin,
+    )
+    print_payload(payload, args.format, render_codex_cli_exec_handoff_markdown)
+    return 0 if payload.get("ok") else 1
+
+
+def handle_starter_bootstrap_command(
+    args: argparse.Namespace,
+    print_payload: PrintPayload,
+) -> int | None:
+    handlers: dict[str, Callable[[argparse.Namespace, PrintPayload], int]] = {
+        "new-project-prompt": handle_new_project_prompt_command,
+        "codex-cli-bootstrap-message": handle_codex_cli_bootstrap_message_command,
+        "codex-cli-tui-bootstrap-smoke-bundle": handle_codex_cli_tui_bootstrap_smoke_bundle_command,
+        "codex-cli-exec-handoff": handle_codex_cli_exec_handoff_command,
+    }
+    handler = handlers.get(str(getattr(args, "command", "")))
+    if handler is None:
+        return None
+    return handler(args, print_payload)


### PR DESCRIPTION
## Summary
- Extract starter bootstrap/message commands into `loopx/cli_commands/starter_bootstrap.py`.
- Keep `starter.py` as the visible-driver/scheduler/proof command module while delegating bootstrap family registration and dispatch.
- Preserve existing `cli_commands` exports and add a focused bootstrap-family modularization smoke.

## Validation
- `python3 -m py_compile loopx/cli_commands/starter.py loopx/cli_commands/starter_bootstrap.py loopx/cli_commands/__init__.py examples/cli-starter-bootstrap-family-command-modularization-smoke.py`
- `python3 examples/cli-starter-bootstrap-family-command-modularization-smoke.py`
- `python3 examples/cli-starter-dispatch-command-modularization-smoke.py`
- `for smoke in examples/cli-*-command-modularization-smoke.py; do python3 "$smoke" || exit 1; done`
- `python3 -m py_compile $(git ls-files 'loopx/*.py' 'loopx/cli_commands/*.py')`
- `git diff --check`
- `python3 -m loopx.cli check --scan-path loopx/cli_commands/__init__.py --scan-path loopx/cli_commands/starter.py --scan-path loopx/cli_commands/starter_bootstrap.py --scan-path examples/cli-starter-bootstrap-family-command-modularization-smoke.py`

LoopX check reported the existing duplicate index rows warning (`loopx-meta: duplicate index rows raw=4710 unique=4706`) and no scan errors.
