### PR TITLE
Refactor starter visible driver command family

### DIFF
--- a/examples/cli-starter-dispatch-command-modularization-smoke.py
+++ b/examples/cli-starter-dispatch-command-modularization-smoke.py
@@ -10,6 +10,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 CLI = ROOT / "loopx" / "cli.py"
 STARTER_MODULE = ROOT / "loopx" / "cli_commands" / "starter.py"
+VISIBLE_DRIVER_MODULE = ROOT / "loopx" / "cli_commands" / "starter_visible_driver.py"
 INIT = ROOT / "loopx" / "cli_commands" / "__init__.py"
 
 
@@ -47,6 +48,7 @@ def require_json_success(result: subprocess.CompletedProcess[str]) -> dict[str, 
 def assert_source_shape() -> None:
     cli_source = CLI.read_text(encoding="utf-8")
     starter_source = STARTER_MODULE.read_text(encoding="utf-8")
+    visible_driver_source = VISIBLE_DRIVER_MODULE.read_text(encoding="utf-8")
     init_source = INIT.read_text(encoding="utf-8")
 
     starter_commands = [
@@ -86,7 +88,18 @@ def assert_source_shape() -> None:
     require("register_starter_commands(sub)" in cli_source, "cli.py did not register starter commands")
     require("handle_starter_command(args, print_payload)" in cli_source, "cli.py did not call starter dispatcher")
     require("def handle_starter_command(" in starter_source, "starter module omitted dispatcher")
-    require('"codex-cli-visible-driver-run": handle_codex_cli_visible_driver_run_command' in starter_source, "starter dispatcher omitted visible driver run")
+    require(
+        "register_starter_visible_driver_commands(subparsers)" in starter_source,
+        "starter module omitted visible-driver registration delegation",
+    )
+    require(
+        "handle_starter_visible_driver_command(args, print_payload)" in starter_source,
+        "starter module omitted visible-driver dispatch delegation",
+    )
+    require(
+        '"codex-cli-visible-driver-run": handle_codex_cli_visible_driver_run_command' in visible_driver_source,
+        "visible-driver module omitted visible driver run dispatch",
+    )
     require('"demo": handle_demo_command' in starter_source, "starter dispatcher omitted demo")
     require("handle_starter_command" in init_source, "__init__ omitted starter dispatcher export")
 

--- a/examples/cli-starter-visible-driver-family-command-modularization-smoke.py
+++ b/examples/cli-starter-visible-driver-family-command-modularization-smoke.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+STARTER = ROOT / "loopx" / "cli_commands" / "starter.py"
+VISIBLE_DRIVER = ROOT / "loopx" / "cli_commands" / "starter_visible_driver.py"
+RUNTIME_IDLE = ROOT / "loopx" / "cli_commands" / "starter_runtime_idle.py"
+INIT = ROOT / "loopx" / "cli_commands" / "__init__.py"
+VISIBLE_HELP_FIXTURE = (
+    ROOT / "examples" / "fixtures" / "codex-cli-visible-proof" / "codex-visible-resume-help.public.json"
+)
+VISIBLE_PROOF_FIXTURE = (
+    ROOT / "examples" / "fixtures" / "codex-cli-visible-proof" / "visible-resume-proof.public.json"
+)
+
+
+VISIBLE_DRIVER_COMMANDS = {
+    "codex-cli-one-message-loop-pilot": ["--proof-fixture", "--allow-headless-fallback"],
+    "codex-cli-visible-local-driver-pilot": ["--idle-fixture", "--allow-headless-fallback"],
+    "codex-cli-bounded-visible-pilot-adapter": ["--first-response-fixture", "--idle-fixture"],
+    "codex-cli-visible-first-response-capture-plan": ["--first-response-path", "--idle-path"],
+    "codex-cli-visible-attach-acceptance": ["--proof-fixture", "--idle-fixture"],
+    "codex-cli-visible-driver-plan": ["--fixture", "--codex-bin"],
+    "codex-cli-local-driver-plan": ["--fixture", "--codex-bin"],
+    "codex-cli-visible-driver-run": ["--proof-fixture", "--allow-headless-fallback"],
+}
+
+
+def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "loopx.cli", *args],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def require_success(result: subprocess.CompletedProcess[str]) -> str:
+    if result.returncode != 0:
+        raise AssertionError(
+            f"expected success, got {result.returncode}\n"
+            f"stdout:\n{result.stdout}\n\nstderr:\n{result.stderr}"
+        )
+    return result.stdout
+
+
+def require_json_success(result: subprocess.CompletedProcess[str]) -> dict[str, object]:
+    payload = json.loads(require_success(result))
+    require(isinstance(payload, dict), "expected JSON object payload")
+    require(payload.get("ok") is True, f"payload was not ok: {payload}")
+    return payload
+
+
+def assert_source_shape() -> None:
+    starter_source = STARTER.read_text(encoding="utf-8")
+    visible_driver_source = VISIBLE_DRIVER.read_text(encoding="utf-8")
+    runtime_idle_source = RUNTIME_IDLE.read_text(encoding="utf-8")
+    init_source = INIT.read_text(encoding="utf-8")
+
+    forbidden_starter_markers = [
+        "build_codex_cli_one_message_loop_pilot(",
+        "build_codex_cli_visible_local_driver_pilot(",
+        "build_codex_cli_bounded_visible_pilot_adapter(",
+        "build_codex_cli_visible_first_response_capture_plan(",
+        "build_codex_cli_visible_attach_acceptance(",
+        "build_codex_cli_visible_driver_plan(",
+        "build_codex_cli_local_driver_plan(",
+        "build_codex_cli_visible_driver_run_packet(",
+        "def handle_codex_cli_one_message_loop_pilot_command(",
+        "def handle_codex_cli_visible_local_driver_pilot_command(",
+        "def handle_codex_cli_bounded_visible_pilot_adapter_command(",
+        "def handle_codex_cli_visible_first_response_capture_plan_command(",
+        "def handle_codex_cli_visible_attach_acceptance_command(",
+        "def handle_codex_cli_visible_driver_plan_command(",
+        "def handle_codex_cli_local_driver_plan_command(",
+        "def handle_codex_cli_visible_driver_run_command(",
+    ]
+    for marker in forbidden_starter_markers:
+        require(marker not in starter_source, f"visible-driver marker leaked into starter.py: {marker}")
+
+    for marker in (
+        "register_starter_visible_driver_commands(subparsers)",
+        "handle_starter_visible_driver_command(args, print_payload)",
+    ):
+        require(marker in starter_source, f"starter.py missing visible-driver delegation marker: {marker}")
+
+    for command in VISIBLE_DRIVER_COMMANDS:
+        require(command in visible_driver_source, f"starter_visible_driver.py missing command: {command}")
+
+    for marker in (
+        "def register_starter_visible_driver_commands(",
+        "def handle_starter_visible_driver_command(",
+        "def handle_codex_cli_visible_driver_run_command(",
+        "_VISIBLE_DRIVER_HANDLERS",
+    ):
+        require(marker in visible_driver_source, f"starter_visible_driver.py missing marker: {marker}")
+
+    for marker in (
+        "def _add_runtime_idle_observation_arguments(",
+        "def _load_codex_cli_runtime_idle_payload(",
+        "build_codex_cli_runtime_idle_observation_payload(",
+    ):
+        require(marker in runtime_idle_source, f"starter_runtime_idle.py missing marker: {marker}")
+
+    for marker in (
+        "handle_starter_visible_driver_command",
+        "register_starter_visible_driver_commands",
+        "handle_codex_cli_visible_driver_run_command",
+    ):
+        require(marker in init_source, f"__init__ omitted visible-driver export: {marker}")
+
+
+def assert_cli_surfaces() -> None:
+    for command, needles in VISIBLE_DRIVER_COMMANDS.items():
+        help_text = require_success(run_cli(command, "--help"))
+        for needle in needles:
+            require(needle in help_text, f"{command} help omitted {needle}")
+
+    capture_payload = require_json_success(
+        run_cli(
+            "--format",
+            "json",
+            "codex-cli-visible-first-response-capture-plan",
+            "--project",
+            ".",
+            "--goal-id",
+            "starter-visible-driver-smoke",
+        )
+    )
+    require(capture_payload.get("goal_id") == "starter-visible-driver-smoke", capture_payload)
+
+    plan_payload = require_json_success(
+        run_cli(
+            "--format",
+            "json",
+            "codex-cli-visible-driver-plan",
+            "--project",
+            ".",
+            "--goal-id",
+            "starter-visible-driver-smoke",
+            "--fixture",
+            str(VISIBLE_HELP_FIXTURE),
+        )
+    )
+    require(plan_payload.get("driver_mode") == "visible_resume_or_remote_control_spike", plan_payload)
+
+    run_payload = require_json_success(
+        run_cli(
+            "--format",
+            "json",
+            "codex-cli-visible-driver-run",
+            "--project",
+            ".",
+            "--goal-id",
+            "starter-visible-driver-smoke",
+            "--fixture",
+            str(VISIBLE_HELP_FIXTURE),
+            "--proof-fixture",
+            str(VISIBLE_PROOF_FIXTURE),
+        )
+    )
+    require(run_payload.get("decision") == "visible_session_turn_candidate", run_payload)
+    boundary = run_payload.get("boundary")
+    require(isinstance(boundary, dict), run_payload)
+    require(boundary.get("runs_codex") is False, run_payload)
+    require(boundary.get("mutates_codex_session") is False, run_payload)
+
+
+def main() -> None:
+    assert_source_shape()
+    assert_cli_surfaces()
+    print("cli-starter-visible-driver-family-command-modularization-smoke: ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/cli_commands/__init__.py
+++ b/loopx/cli_commands/__init__.py
@@ -50,18 +50,10 @@ from .registry_admin import (
     register_registry_admin_commands,
 )
 from .starter import (
-    handle_codex_cli_bounded_visible_pilot_adapter_command,
-    handle_codex_cli_visible_first_response_capture_plan_command,
-    handle_codex_cli_local_driver_plan_command,
     handle_codex_cli_local_scheduler_exec_command,
     handle_codex_cli_local_scheduler_tick_command,
-    handle_codex_cli_one_message_loop_pilot_command,
     handle_codex_cli_runtime_idle_detector_command,
     handle_codex_cli_session_probe_command,
-    handle_codex_cli_visible_attach_acceptance_command,
-    handle_codex_cli_visible_local_driver_pilot_command,
-    handle_codex_cli_visible_driver_run_command,
-    handle_codex_cli_visible_driver_plan_command,
     handle_codex_cli_visible_session_proof_command,
     handle_demo_command,
     handle_starter_command,
@@ -74,6 +66,18 @@ from .starter_bootstrap import (
     handle_new_project_prompt_command,
     handle_starter_bootstrap_command,
     register_starter_bootstrap_commands,
+)
+from .starter_visible_driver import (
+    handle_codex_cli_bounded_visible_pilot_adapter_command,
+    handle_codex_cli_visible_first_response_capture_plan_command,
+    handle_codex_cli_local_driver_plan_command,
+    handle_codex_cli_one_message_loop_pilot_command,
+    handle_codex_cli_visible_attach_acceptance_command,
+    handle_codex_cli_visible_local_driver_pilot_command,
+    handle_codex_cli_visible_driver_plan_command,
+    handle_codex_cli_visible_driver_run_command,
+    handle_starter_visible_driver_command,
+    register_starter_visible_driver_commands,
 )
 from .status import (
     handle_check_command,
@@ -136,6 +140,7 @@ __all__ = [
     "handle_status_command",
     "handle_starter_command",
     "handle_starter_bootstrap_command",
+    "handle_starter_visible_driver_command",
     "handle_support_control_command",
     "handle_terminal_bench_adapter_command",
     "handle_terminal_bench_environment_result_command",
@@ -157,6 +162,7 @@ __all__ = [
     "register_registry_admin_commands",
     "register_starter_commands",
     "register_starter_bootstrap_commands",
+    "register_starter_visible_driver_commands",
     "register_status_commands",
     "register_support_control_commands",
     "register_terminal_bench_adapter_commands",

--- a/loopx/cli_commands/starter.py
+++ b/loopx/cli_commands/starter.py
@@ -16,43 +16,30 @@ from ..demo import (
 from ..codex_cli_probe import (
     DEFAULT_CODEX_BIN,
     DEFAULT_EXECUTOR_TIMEOUT_SECONDS,
-    DEFAULT_MIN_HUMAN_INPUT_IDLE_SECONDS,
     DEFAULT_TIMEOUT_SECONDS,
-    build_codex_cli_bounded_visible_pilot_adapter,
-    build_codex_cli_one_message_loop_pilot,
-    build_codex_cli_visible_first_response_capture_plan,
-    build_codex_cli_visible_local_driver_pilot,
-    build_codex_cli_visible_attach_acceptance,
     build_codex_cli_local_scheduler_executor,
     build_codex_cli_local_scheduler_tick,
-    build_codex_cli_local_driver_plan,
-    build_codex_cli_visible_driver_run_packet,
-    build_codex_cli_visible_driver_plan,
-    build_codex_cli_visible_session_proof,
-    build_codex_cli_runtime_idle_observation_payload,
     build_codex_cli_runtime_idle_detector,
-    load_codex_cli_first_response_fixture,
+    build_codex_cli_visible_session_proof,
     load_codex_cli_visible_session_proof_fixture,
-    load_codex_cli_runtime_idle_fixture,
-    render_codex_cli_bounded_visible_pilot_adapter_markdown,
-    render_codex_cli_one_message_loop_pilot_markdown,
-    render_codex_cli_visible_first_response_capture_plan_markdown,
-    render_codex_cli_visible_local_driver_pilot_markdown,
-    render_codex_cli_visible_attach_acceptance_markdown,
     render_codex_cli_local_scheduler_executor_markdown,
     render_codex_cli_local_scheduler_tick_markdown,
-    render_codex_cli_local_driver_plan_markdown,
     render_codex_cli_session_probe_markdown,
-    render_codex_cli_visible_driver_run_packet_markdown,
-    render_codex_cli_visible_driver_plan_markdown,
-    render_codex_cli_visible_session_proof_markdown,
     render_codex_cli_runtime_idle_detector_markdown,
-    probe_human_input_idle_seconds,
+    render_codex_cli_visible_session_proof_markdown,
     run_codex_cli_session_probe,
 )
 from .starter_bootstrap import (
     handle_starter_bootstrap_command,
     register_starter_bootstrap_commands,
+)
+from .starter_runtime_idle import (
+    _add_runtime_idle_observation_arguments,
+    _load_codex_cli_runtime_idle_payload,
+)
+from .starter_visible_driver import (
+    handle_starter_visible_driver_command,
+    register_starter_visible_driver_commands,
 )
 
 
@@ -62,283 +49,9 @@ PrintPayload = Callable[
 ]
 
 
-def _add_runtime_idle_observation_arguments(
-    parser: argparse.ArgumentParser,
-    *,
-    include_idle_fixture: bool = True,
-) -> None:
-    if include_idle_fixture:
-        parser.add_argument(
-            "--idle-fixture",
-            help="Optional public-safe runtime idle fixture. Without it, later visible turn candidates remain blocked.",
-        )
-    parser.add_argument(
-        "--observe-local-runtime",
-        action="store_true",
-        help="Build the idle packet from public-safe local observation fields instead of a JSON fixture.",
-    )
-    parser.add_argument(
-        "--observed-surface",
-        default="codex_cli_tui_visible_window",
-        choices=[
-            "codex_cli_tui_visible_window",
-            "remote_control_visible_prompt",
-            "same_tui_visible_attach",
-            "visible_resume_prompt",
-        ],
-        help="Visible Codex CLI surface observed by the local runtime check.",
-    )
-    parser.add_argument(
-        "--turn-state",
-        choices=["idle", "running", "unknown"],
-        default="unknown",
-        help="Public-safe visible turn state. Unknown or running fails closed.",
-    )
-    parser.add_argument(
-        "--human-input-idle-seconds",
-        type=float,
-        help="Public-safe observed seconds since last human input. Useful for tests or external sensors.",
-    )
-    parser.add_argument(
-        "--probe-human-input-idle",
-        action="store_true",
-        help="Probe the local platform for coarse human-input idle seconds when supported.",
-    )
-    parser.add_argument(
-        "--min-human-input-idle-seconds",
-        type=float,
-        default=DEFAULT_MIN_HUMAN_INPUT_IDLE_SECONDS,
-        help="Minimum idle seconds required to consider human typing inactive.",
-    )
-    parser.add_argument(
-        "--checked-before-prompt",
-        action="store_true",
-        help="Confirm this idle check ran before any later visible prompt.",
-    )
-    parser.add_argument(
-        "--visible-to-user",
-        action="store_true",
-        help="Confirm the target turn remains visible to the user.",
-    )
-    parser.add_argument(
-        "--user-can-interrupt",
-        action="store_true",
-        help="Confirm the user can interrupt the target turn.",
-    )
-    parser.add_argument(
-        "--manual-takeover-available",
-        action="store_true",
-        help="Confirm manual takeover remains available.",
-    )
-
-
-def _load_codex_cli_runtime_idle_payload(args: argparse.Namespace) -> dict[str, object] | None:
-    if args.idle_fixture and args.observe_local_runtime:
-        raise ValueError("Use either --idle-fixture or --observe-local-runtime, not both.")
-    if args.idle_fixture:
-        return load_codex_cli_runtime_idle_fixture(Path(args.idle_fixture).expanduser())
-    if not args.observe_local_runtime:
-        return None
-    probe_result = None
-    human_input_idle_seconds = args.human_input_idle_seconds
-    if args.probe_human_input_idle:
-        probe_result = probe_human_input_idle_seconds()
-        if probe_result.get("ok") is True:
-            human_input_idle_seconds = float(probe_result["human_input_idle_seconds"])
-    return build_codex_cli_runtime_idle_observation_payload(
-        observed_surface=args.observed_surface,
-        turn_state=args.turn_state,
-        human_input_idle_seconds=human_input_idle_seconds,
-        min_human_input_idle_seconds=args.min_human_input_idle_seconds,
-        checked_before_prompt=bool(args.checked_before_prompt),
-        visible_to_user=bool(args.visible_to_user),
-        user_can_interrupt=bool(args.user_can_interrupt),
-        manual_takeover_available=bool(args.manual_takeover_available),
-        probe_result=probe_result,
-    )
-
-
 def register_starter_commands(subparsers: argparse._SubParsersAction) -> None:
     register_starter_bootstrap_commands(subparsers)
-
-    codex_cli_one_message_loop_parser = subparsers.add_parser(
-        "codex-cli-one-message-loop-pilot",
-        help="Compose the first Codex CLI TUI paste message with the safe scheduler/executor bridge.",
-    )
-    codex_cli_one_message_loop_parser.add_argument("--project", default=".", help="Project directory to start from.")
-    codex_cli_one_message_loop_parser.add_argument("--goal-id", help="Goal id. Defaults to <project-name>-goal.")
-    codex_cli_one_message_loop_parser.add_argument(
-        "--agent-id",
-        help="Registered LoopX agent id to include in quota/claim instructions.",
-    )
-    codex_cli_one_message_loop_parser.add_argument(
-        "--cli-bin",
-        default="loopx",
-        help="LoopX CLI binary name embedded in generated commands.",
-    )
-    codex_cli_one_message_loop_parser.add_argument(
-        "--codex-bin",
-        default=DEFAULT_CODEX_BIN,
-        help="Codex CLI executable to probe and reference in bridge commands.",
-    )
-    codex_cli_one_message_loop_parser.add_argument(
-        "--timeout-seconds",
-        type=float,
-        default=DEFAULT_TIMEOUT_SECONDS,
-        help="Per-command timeout for help-only Codex CLI probes.",
-    )
-    codex_cli_one_message_loop_parser.add_argument(
-        "--fixture",
-        help="Public-safe JSON fixture with command_outputs, used instead of invoking Codex CLI.",
-    )
-    codex_cli_one_message_loop_parser.add_argument(
-        "--proof-fixture",
-        help="Optional public-safe visible-session proof fixture. Without it, same-session automation remains blocked.",
-    )
-    _add_runtime_idle_observation_arguments(codex_cli_one_message_loop_parser)
-    codex_cli_one_message_loop_parser.add_argument(
-        "--allow-headless-fallback",
-        action="store_true",
-        help="Deprecated and ignored; headless codex exec is disabled for this default /goal path.",
-    )
-
-    codex_cli_visible_local_driver_parser = subparsers.add_parser(
-        "codex-cli-visible-local-driver-pilot",
-        help="Compose the one-message TUI start and later scheduler bridge into a visible local driver pilot packet.",
-    )
-    codex_cli_visible_local_driver_parser.add_argument("--project", default=".", help="Project directory to start from.")
-    codex_cli_visible_local_driver_parser.add_argument("--goal-id", help="Goal id. Defaults to <project-name>-goal.")
-    codex_cli_visible_local_driver_parser.add_argument(
-        "--agent-id",
-        help="Registered LoopX agent id to include in quota/claim instructions.",
-    )
-    codex_cli_visible_local_driver_parser.add_argument(
-        "--cli-bin",
-        default="loopx",
-        help="LoopX CLI binary name embedded in generated commands.",
-    )
-    codex_cli_visible_local_driver_parser.add_argument(
-        "--codex-bin",
-        default=DEFAULT_CODEX_BIN,
-        help="Codex CLI executable to probe and reference in bridge commands.",
-    )
-    codex_cli_visible_local_driver_parser.add_argument(
-        "--timeout-seconds",
-        type=float,
-        default=DEFAULT_TIMEOUT_SECONDS,
-        help="Per-command timeout for help-only Codex CLI probes.",
-    )
-    codex_cli_visible_local_driver_parser.add_argument(
-        "--fixture",
-        help="Public-safe JSON fixture with command_outputs, used instead of invoking Codex CLI.",
-    )
-    codex_cli_visible_local_driver_parser.add_argument(
-        "--proof-fixture",
-        help="Optional public-safe visible-session proof fixture. Without it, later visible turns remain blocked.",
-    )
-    codex_cli_visible_local_driver_parser.add_argument(
-        "--idle-fixture",
-        help="Optional public-safe runtime idle fixture. Without it, later visible turn candidates remain blocked.",
-    )
-    _add_runtime_idle_observation_arguments(
-        codex_cli_visible_local_driver_parser,
-        include_idle_fixture=False,
-    )
-    codex_cli_visible_local_driver_parser.add_argument(
-        "--allow-headless-fallback",
-        action="store_true",
-        help="Deprecated and ignored; headless codex exec is disabled for this default /goal path.",
-    )
-
-    codex_cli_bounded_visible_parser = subparsers.add_parser(
-        "codex-cli-bounded-visible-pilot-adapter",
-        help="Validate public-safe first-response and idle evidence before claiming Codex CLI live TUI bootstrap success.",
-    )
-    codex_cli_bounded_visible_parser.add_argument("--project", default=".", help="Project directory to start from.")
-    codex_cli_bounded_visible_parser.add_argument("--goal-id", help="Goal id. Defaults to <project-name>-goal.")
-    codex_cli_bounded_visible_parser.add_argument(
-        "--agent-id",
-        help="Registered LoopX agent id to include in adapter commands.",
-    )
-    codex_cli_bounded_visible_parser.add_argument(
-        "--cli-bin",
-        default="loopx",
-        help="LoopX CLI binary name embedded in generated commands.",
-    )
-    codex_cli_bounded_visible_parser.add_argument(
-        "--first-response-fixture",
-        help="Public-safe JSON fixture proving the first visible TUI response shape.",
-    )
-    _add_runtime_idle_observation_arguments(codex_cli_bounded_visible_parser)
-
-    codex_cli_first_response_capture_parser = subparsers.add_parser(
-        "codex-cli-visible-first-response-capture-plan",
-        help="Plan the public-safe manual visible capture of Codex CLI first-response and idle fixtures.",
-    )
-    codex_cli_first_response_capture_parser.add_argument(
-        "--project",
-        default=".",
-        help="Project directory to start from.",
-    )
-    codex_cli_first_response_capture_parser.add_argument(
-        "--goal-id",
-        help="Goal id. Defaults to <project-name>-goal.",
-    )
-    codex_cli_first_response_capture_parser.add_argument(
-        "--agent-id",
-        help="Registered LoopX agent id to include in generated commands.",
-    )
-    codex_cli_first_response_capture_parser.add_argument(
-        "--cli-bin",
-        default="loopx",
-        help="LoopX CLI binary name embedded in generated commands.",
-    )
-    codex_cli_first_response_capture_parser.add_argument(
-        "--first-response-path",
-        default="public-first-response.json",
-        help="Public-safe first-response fixture path used in generated commands.",
-    )
-    codex_cli_first_response_capture_parser.add_argument(
-        "--idle-path",
-        default="public-runtime-idle.json",
-        help="Public-safe runtime idle fixture path used in generated commands.",
-    )
-
-    codex_cli_visible_attach_acceptance_parser = subparsers.add_parser(
-        "codex-cli-visible-attach-acceptance",
-        help="Accept or block same-TUI Codex CLI visible attach from help-only probe, proof, and idle evidence.",
-    )
-    codex_cli_visible_attach_acceptance_parser.add_argument("--project", default=".", help="Project directory to start from.")
-    codex_cli_visible_attach_acceptance_parser.add_argument("--goal-id", help="Goal id. Defaults to <project-name>-goal.")
-    codex_cli_visible_attach_acceptance_parser.add_argument(
-        "--agent-id",
-        help="Registered LoopX agent id to include in acceptance commands.",
-    )
-    codex_cli_visible_attach_acceptance_parser.add_argument(
-        "--cli-bin",
-        default="loopx",
-        help="LoopX CLI binary name embedded in generated commands.",
-    )
-    codex_cli_visible_attach_acceptance_parser.add_argument(
-        "--codex-bin",
-        default=DEFAULT_CODEX_BIN,
-        help="Codex CLI executable to probe and reference in fallback commands.",
-    )
-    codex_cli_visible_attach_acceptance_parser.add_argument(
-        "--timeout-seconds",
-        type=float,
-        default=DEFAULT_TIMEOUT_SECONDS,
-        help="Per-command timeout for help-only Codex CLI probes.",
-    )
-    codex_cli_visible_attach_acceptance_parser.add_argument(
-        "--fixture",
-        help="Public-safe JSON fixture with command_outputs, used instead of invoking Codex CLI.",
-    )
-    codex_cli_visible_attach_acceptance_parser.add_argument(
-        "--proof-fixture",
-        help="Optional public-safe visible-session proof fixture. Without it, same-TUI attach is not accepted.",
-    )
-    _add_runtime_idle_observation_arguments(codex_cli_visible_attach_acceptance_parser)
+    register_starter_visible_driver_commands(subparsers)
 
     codex_cli_probe_parser = subparsers.add_parser(
         "codex-cli-session-probe",
@@ -358,108 +71,6 @@ def register_starter_commands(subparsers: argparse._SubParsersAction) -> None:
     codex_cli_probe_parser.add_argument(
         "--fixture",
         help="Public-safe JSON fixture with command_outputs, used instead of invoking Codex CLI.",
-    )
-
-    codex_cli_visible_driver_parser = subparsers.add_parser(
-        "codex-cli-visible-driver-plan",
-        help="Plan a public-safe visible Codex CLI driver path from session-probe evidence.",
-    )
-    codex_cli_visible_driver_parser.add_argument("--project", default=".", help="Project directory to start from.")
-    codex_cli_visible_driver_parser.add_argument("--goal-id", help="Goal id. Defaults to <project-name>-goal.")
-    codex_cli_visible_driver_parser.add_argument(
-        "--agent-id",
-        help="Registered LoopX agent id to include in quota/claim instructions.",
-    )
-    codex_cli_visible_driver_parser.add_argument(
-        "--cli-bin",
-        default="loopx",
-        help="LoopX CLI binary name embedded in generated commands.",
-    )
-    codex_cli_visible_driver_parser.add_argument(
-        "--codex-bin",
-        default=DEFAULT_CODEX_BIN,
-        help="Codex CLI executable to probe and reference in fallback commands.",
-    )
-    codex_cli_visible_driver_parser.add_argument(
-        "--timeout-seconds",
-        type=float,
-        default=DEFAULT_TIMEOUT_SECONDS,
-        help="Per-command timeout for help-only Codex CLI probes.",
-    )
-    codex_cli_visible_driver_parser.add_argument(
-        "--fixture",
-        help="Public-safe JSON fixture with command_outputs, used instead of invoking Codex CLI.",
-    )
-
-    codex_cli_local_driver_parser = subparsers.add_parser(
-        "codex-cli-local-driver-plan",
-        help="Compose a dry-run-first local Codex CLI driver plan from quota, TUI bootstrap, visible-driver, and exec fallback commands.",
-    )
-    codex_cli_local_driver_parser.add_argument("--project", default=".", help="Project directory to start from.")
-    codex_cli_local_driver_parser.add_argument("--goal-id", help="Goal id. Defaults to <project-name>-goal.")
-    codex_cli_local_driver_parser.add_argument(
-        "--agent-id",
-        help="Registered LoopX agent id to include in quota/claim instructions.",
-    )
-    codex_cli_local_driver_parser.add_argument(
-        "--cli-bin",
-        default="loopx",
-        help="LoopX CLI binary name embedded in generated commands.",
-    )
-    codex_cli_local_driver_parser.add_argument(
-        "--codex-bin",
-        default=DEFAULT_CODEX_BIN,
-        help="Codex CLI executable to probe and reference in fallback commands.",
-    )
-    codex_cli_local_driver_parser.add_argument(
-        "--timeout-seconds",
-        type=float,
-        default=DEFAULT_TIMEOUT_SECONDS,
-        help="Per-command timeout for help-only Codex CLI probes.",
-    )
-    codex_cli_local_driver_parser.add_argument(
-        "--fixture",
-        help="Public-safe JSON fixture with command_outputs, used instead of invoking Codex CLI.",
-    )
-
-    codex_cli_visible_driver_run_parser = subparsers.add_parser(
-        "codex-cli-visible-driver-run",
-        help="Build a no-execution visible Codex CLI driver run packet from quota-safe driver planning inputs.",
-    )
-    codex_cli_visible_driver_run_parser.add_argument("--project", default=".", help="Project directory to start from.")
-    codex_cli_visible_driver_run_parser.add_argument("--goal-id", help="Goal id. Defaults to <project-name>-goal.")
-    codex_cli_visible_driver_run_parser.add_argument(
-        "--agent-id",
-        help="Registered LoopX agent id to include in quota/claim instructions.",
-    )
-    codex_cli_visible_driver_run_parser.add_argument(
-        "--cli-bin",
-        default="loopx",
-        help="LoopX CLI binary name embedded in generated commands.",
-    )
-    codex_cli_visible_driver_run_parser.add_argument(
-        "--codex-bin",
-        default=DEFAULT_CODEX_BIN,
-        help="Codex CLI executable to probe for visible-session capabilities.",
-    )
-    codex_cli_visible_driver_run_parser.add_argument(
-        "--timeout-seconds",
-        type=float,
-        default=DEFAULT_TIMEOUT_SECONDS,
-        help="Per-command timeout for help-only Codex CLI probes.",
-    )
-    codex_cli_visible_driver_run_parser.add_argument(
-        "--fixture",
-        help="Public-safe JSON fixture with command_outputs, used instead of invoking Codex CLI.",
-    )
-    codex_cli_visible_driver_run_parser.add_argument(
-        "--proof-fixture",
-        help="Optional public-safe visible-session proof fixture. Without it, same-session automation remains blocked.",
-    )
-    codex_cli_visible_driver_run_parser.add_argument(
-        "--allow-headless-fallback",
-        action="store_true",
-        help="Deprecated and ignored; headless codex exec is disabled for this default /goal path.",
     )
 
     codex_cli_local_scheduler_tick_parser = subparsers.add_parser(
@@ -606,68 +217,7 @@ def register_starter_commands(subparsers: argparse._SubParsersAction) -> None:
         default="loopx",
         help="LoopX CLI binary name embedded in idle detector metadata.",
     )
-    codex_cli_runtime_idle_parser.add_argument(
-        "--idle-fixture",
-        help="Public-safe JSON idle fixture. Mutually exclusive with --observe-local-runtime.",
-    )
-    codex_cli_runtime_idle_parser.add_argument(
-        "--observe-local-runtime",
-        action="store_true",
-        help="Build the idle packet from public-safe local observation fields instead of a JSON fixture.",
-    )
-    codex_cli_runtime_idle_parser.add_argument(
-        "--observed-surface",
-        default="codex_cli_tui_visible_window",
-        choices=[
-            "codex_cli_tui_visible_window",
-            "remote_control_visible_prompt",
-            "same_tui_visible_attach",
-            "visible_resume_prompt",
-        ],
-        help="Visible Codex CLI surface observed by the local runtime check.",
-    )
-    codex_cli_runtime_idle_parser.add_argument(
-        "--turn-state",
-        choices=["idle", "running", "unknown"],
-        default="unknown",
-        help="Public-safe visible turn state. Unknown or running fails closed.",
-    )
-    codex_cli_runtime_idle_parser.add_argument(
-        "--human-input-idle-seconds",
-        type=float,
-        help="Public-safe observed seconds since last human input. Useful for tests or external sensors.",
-    )
-    codex_cli_runtime_idle_parser.add_argument(
-        "--probe-human-input-idle",
-        action="store_true",
-        help="Probe the local platform for coarse human-input idle seconds when supported.",
-    )
-    codex_cli_runtime_idle_parser.add_argument(
-        "--min-human-input-idle-seconds",
-        type=float,
-        default=DEFAULT_MIN_HUMAN_INPUT_IDLE_SECONDS,
-        help="Minimum idle seconds required to consider human typing inactive.",
-    )
-    codex_cli_runtime_idle_parser.add_argument(
-        "--checked-before-prompt",
-        action="store_true",
-        help="Confirm this idle check ran before any later visible prompt.",
-    )
-    codex_cli_runtime_idle_parser.add_argument(
-        "--visible-to-user",
-        action="store_true",
-        help="Confirm the target turn remains visible to the user.",
-    )
-    codex_cli_runtime_idle_parser.add_argument(
-        "--user-can-interrupt",
-        action="store_true",
-        help="Confirm the user can interrupt the target turn.",
-    )
-    codex_cli_runtime_idle_parser.add_argument(
-        "--manual-takeover-available",
-        action="store_true",
-        help="Confirm manual takeover remains available.",
-    )
+    _add_runtime_idle_observation_arguments(codex_cli_runtime_idle_parser)
 
     demo_parser = subparsers.add_parser(
         "demo",
@@ -684,133 +234,6 @@ def register_starter_commands(subparsers: argparse._SubParsersAction) -> None:
     demo_parser.add_argument("--agent-todo", default=DEFAULT_DEMO_AGENT_TODO)
 
 
-def handle_codex_cli_one_message_loop_pilot_command(
-    args: argparse.Namespace,
-    print_payload: PrintPayload,
-) -> int:
-    probe_payload = run_codex_cli_session_probe(
-        codex_bin=args.codex_bin,
-        timeout_seconds=args.timeout_seconds,
-        fixture=Path(args.fixture).expanduser() if args.fixture else None,
-    )
-    proof_payload = (
-        load_codex_cli_visible_session_proof_fixture(Path(args.proof_fixture).expanduser())
-        if args.proof_fixture
-        else None
-    )
-    idle_payload = _load_codex_cli_runtime_idle_payload(args)
-    payload = build_codex_cli_one_message_loop_pilot(
-        project=Path(args.project),
-        goal_id=args.goal_id,
-        agent_id=args.agent_id,
-        cli_bin=args.cli_bin,
-        codex_bin=args.codex_bin,
-        probe_payload=probe_payload,
-        proof_payload=proof_payload,
-        idle_payload=idle_payload,
-        allow_headless_fallback=bool(args.allow_headless_fallback),
-    )
-    print_payload(payload, args.format, render_codex_cli_one_message_loop_pilot_markdown)
-    return 0 if payload.get("ok") else 1
-
-
-def handle_codex_cli_visible_local_driver_pilot_command(
-    args: argparse.Namespace,
-    print_payload: PrintPayload,
-) -> int:
-    probe_payload = run_codex_cli_session_probe(
-        codex_bin=args.codex_bin,
-        timeout_seconds=args.timeout_seconds,
-        fixture=Path(args.fixture).expanduser() if args.fixture else None,
-    )
-    proof_payload = (
-        load_codex_cli_visible_session_proof_fixture(Path(args.proof_fixture).expanduser())
-        if args.proof_fixture
-        else None
-    )
-    idle_payload = _load_codex_cli_runtime_idle_payload(args)
-    payload = build_codex_cli_visible_local_driver_pilot(
-        project=Path(args.project),
-        goal_id=args.goal_id,
-        agent_id=args.agent_id,
-        cli_bin=args.cli_bin,
-        codex_bin=args.codex_bin,
-        probe_payload=probe_payload,
-        proof_payload=proof_payload,
-        idle_payload=idle_payload,
-        allow_headless_fallback=bool(args.allow_headless_fallback),
-    )
-    print_payload(payload, args.format, render_codex_cli_visible_local_driver_pilot_markdown)
-    return 0 if payload.get("ok") else 1
-
-
-def handle_codex_cli_bounded_visible_pilot_adapter_command(
-    args: argparse.Namespace,
-    print_payload: PrintPayload,
-) -> int:
-    first_response_payload = (
-        load_codex_cli_first_response_fixture(Path(args.first_response_fixture).expanduser())
-        if args.first_response_fixture
-        else None
-    )
-    idle_payload = _load_codex_cli_runtime_idle_payload(args)
-    payload = build_codex_cli_bounded_visible_pilot_adapter(
-        project=Path(args.project),
-        goal_id=args.goal_id,
-        agent_id=args.agent_id,
-        cli_bin=args.cli_bin,
-        first_response_payload=first_response_payload,
-        idle_payload=idle_payload,
-    )
-    print_payload(payload, args.format, render_codex_cli_bounded_visible_pilot_adapter_markdown)
-    return 0 if payload.get("ok") else 1
-
-
-def handle_codex_cli_visible_first_response_capture_plan_command(
-    args: argparse.Namespace,
-    print_payload: PrintPayload,
-) -> int:
-    payload = build_codex_cli_visible_first_response_capture_plan(
-        project=Path(args.project),
-        goal_id=args.goal_id,
-        agent_id=args.agent_id,
-        cli_bin=args.cli_bin,
-        first_response_path=args.first_response_path,
-        idle_path=args.idle_path,
-    )
-    print_payload(payload, args.format, render_codex_cli_visible_first_response_capture_plan_markdown)
-    return 0 if payload.get("ok") else 1
-
-
-def handle_codex_cli_visible_attach_acceptance_command(
-    args: argparse.Namespace,
-    print_payload: PrintPayload,
-) -> int:
-    probe_payload = run_codex_cli_session_probe(
-        codex_bin=args.codex_bin,
-        timeout_seconds=args.timeout_seconds,
-        fixture=Path(args.fixture).expanduser() if args.fixture else None,
-    )
-    proof_payload = (
-        load_codex_cli_visible_session_proof_fixture(Path(args.proof_fixture).expanduser())
-        if args.proof_fixture
-        else None
-    )
-    idle_payload = _load_codex_cli_runtime_idle_payload(args)
-    payload = build_codex_cli_visible_attach_acceptance(
-        project=Path(args.project),
-        goal_id=args.goal_id,
-        agent_id=args.agent_id,
-        cli_bin=args.cli_bin,
-        codex_bin=args.codex_bin,
-        probe_payload=probe_payload,
-        proof_payload=proof_payload,
-        idle_payload=idle_payload,
-    )
-    print_payload(payload, args.format, render_codex_cli_visible_attach_acceptance_markdown)
-    return 0 if payload.get("ok") else 1
-
-
 def handle_codex_cli_session_probe_command(
     args: argparse.Namespace,
     print_payload: PrintPayload,
@@ -821,76 +244,6 @@ def handle_codex_cli_session_probe_command(
         fixture=Path(args.fixture).expanduser() if args.fixture else None,
     )
     print_payload(payload, args.format, render_codex_cli_session_probe_markdown)
-    return 0 if payload.get("ok") else 1
-
-
-def handle_codex_cli_visible_driver_plan_command(
-    args: argparse.Namespace,
-    print_payload: PrintPayload,
-) -> int:
-    probe_payload = run_codex_cli_session_probe(
-        codex_bin=args.codex_bin,
-        timeout_seconds=args.timeout_seconds,
-        fixture=Path(args.fixture).expanduser() if args.fixture else None,
-    )
-    payload = build_codex_cli_visible_driver_plan(
-        project=Path(args.project),
-        goal_id=args.goal_id,
-        agent_id=args.agent_id,
-        cli_bin=args.cli_bin,
-        codex_bin=args.codex_bin,
-        probe_payload=probe_payload,
-    )
-    print_payload(payload, args.format, render_codex_cli_visible_driver_plan_markdown)
-    return 0 if payload.get("ok") else 1
-
-
-def handle_codex_cli_local_driver_plan_command(
-    args: argparse.Namespace,
-    print_payload: PrintPayload,
-) -> int:
-    probe_payload = run_codex_cli_session_probe(
-        codex_bin=args.codex_bin,
-        timeout_seconds=args.timeout_seconds,
-        fixture=Path(args.fixture).expanduser() if args.fixture else None,
-    )
-    payload = build_codex_cli_local_driver_plan(
-        project=Path(args.project),
-        goal_id=args.goal_id,
-        agent_id=args.agent_id,
-        cli_bin=args.cli_bin,
-        codex_bin=args.codex_bin,
-        probe_payload=probe_payload,
-    )
-    print_payload(payload, args.format, render_codex_cli_local_driver_plan_markdown)
-    return 0 if payload.get("ok") else 1
-
-
-def handle_codex_cli_visible_driver_run_command(
-    args: argparse.Namespace,
-    print_payload: PrintPayload,
-) -> int:
-    probe_payload = run_codex_cli_session_probe(
-        codex_bin=args.codex_bin,
-        timeout_seconds=args.timeout_seconds,
-        fixture=Path(args.fixture).expanduser() if args.fixture else None,
-    )
-    proof_payload = (
-        load_codex_cli_visible_session_proof_fixture(Path(args.proof_fixture).expanduser())
-        if args.proof_fixture
-        else None
-    )
-    payload = build_codex_cli_visible_driver_run_packet(
-        project=Path(args.project),
-        goal_id=args.goal_id,
-        agent_id=args.agent_id,
-        cli_bin=args.cli_bin,
-        codex_bin=args.codex_bin,
-        probe_payload=probe_payload,
-        proof_payload=proof_payload,
-        allow_headless_fallback=bool(args.allow_headless_fallback),
-    )
-    print_payload(payload, args.format, render_codex_cli_visible_driver_run_packet_markdown)
     return 0 if payload.get("ok") else 1
 
 
@@ -1023,16 +376,11 @@ def handle_starter_command(
     bootstrap_result = handle_starter_bootstrap_command(args, print_payload)
     if bootstrap_result is not None:
         return bootstrap_result
+    visible_driver_result = handle_starter_visible_driver_command(args, print_payload)
+    if visible_driver_result is not None:
+        return visible_driver_result
     handlers: dict[str, Callable[[argparse.Namespace, PrintPayload], int]] = {
-        "codex-cli-one-message-loop-pilot": handle_codex_cli_one_message_loop_pilot_command,
-        "codex-cli-visible-local-driver-pilot": handle_codex_cli_visible_local_driver_pilot_command,
-        "codex-cli-bounded-visible-pilot-adapter": handle_codex_cli_bounded_visible_pilot_adapter_command,
-        "codex-cli-visible-first-response-capture-plan": handle_codex_cli_visible_first_response_capture_plan_command,
-        "codex-cli-visible-attach-acceptance": handle_codex_cli_visible_attach_acceptance_command,
         "codex-cli-session-probe": handle_codex_cli_session_probe_command,
-        "codex-cli-visible-driver-plan": handle_codex_cli_visible_driver_plan_command,
-        "codex-cli-local-driver-plan": handle_codex_cli_local_driver_plan_command,
-        "codex-cli-visible-driver-run": handle_codex_cli_visible_driver_run_command,
         "codex-cli-local-scheduler-tick": handle_codex_cli_local_scheduler_tick_command,
         "codex-cli-local-scheduler-exec": handle_codex_cli_local_scheduler_exec_command,
         "codex-cli-visible-session-proof": handle_codex_cli_visible_session_proof_command,

--- a/loopx/cli_commands/starter_runtime_idle.py
+++ b/loopx/cli_commands/starter_runtime_idle.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from ..codex_cli_probe import (
+    DEFAULT_MIN_HUMAN_INPUT_IDLE_SECONDS,
+    build_codex_cli_runtime_idle_observation_payload,
+    load_codex_cli_runtime_idle_fixture,
+    probe_human_input_idle_seconds,
+)
+
+
+def _add_runtime_idle_observation_arguments(
+    parser: argparse.ArgumentParser,
+    *,
+    include_idle_fixture: bool = True,
+) -> None:
+    if include_idle_fixture:
+        parser.add_argument(
+            "--idle-fixture",
+            help="Optional public-safe runtime idle fixture. Without it, later visible turn candidates remain blocked.",
+        )
+    parser.add_argument(
+        "--observe-local-runtime",
+        action="store_true",
+        help="Build the idle packet from public-safe local observation fields instead of a JSON fixture.",
+    )
+    parser.add_argument(
+        "--observed-surface",
+        default="codex_cli_tui_visible_window",
+        choices=[
+            "codex_cli_tui_visible_window",
+            "remote_control_visible_prompt",
+            "same_tui_visible_attach",
+            "visible_resume_prompt",
+        ],
+        help="Visible Codex CLI surface observed by the local runtime check.",
+    )
+    parser.add_argument(
+        "--turn-state",
+        choices=["idle", "running", "unknown"],
+        default="unknown",
+        help="Public-safe visible turn state. Unknown or running fails closed.",
+    )
+    parser.add_argument(
+        "--human-input-idle-seconds",
+        type=float,
+        help="Public-safe observed seconds since last human input. Useful for tests or external sensors.",
+    )
+    parser.add_argument(
+        "--probe-human-input-idle",
+        action="store_true",
+        help="Probe the local platform for coarse human-input idle seconds when supported.",
+    )
+    parser.add_argument(
+        "--min-human-input-idle-seconds",
+        type=float,
+        default=DEFAULT_MIN_HUMAN_INPUT_IDLE_SECONDS,
+        help="Minimum idle seconds required to consider human typing inactive.",
+    )
+    parser.add_argument(
+        "--checked-before-prompt",
+        action="store_true",
+        help="Confirm this idle check ran before any later visible prompt.",
+    )
+    parser.add_argument(
+        "--visible-to-user",
+        action="store_true",
+        help="Confirm the target turn remains visible to the user.",
+    )
+    parser.add_argument(
+        "--user-can-interrupt",
+        action="store_true",
+        help="Confirm the user can interrupt the target turn.",
+    )
+    parser.add_argument(
+        "--manual-takeover-available",
+        action="store_true",
+        help="Confirm manual takeover remains available.",
+    )
+
+
+def _load_codex_cli_runtime_idle_payload(args: argparse.Namespace) -> dict[str, object] | None:
+    if args.idle_fixture and args.observe_local_runtime:
+        raise ValueError("Use either --idle-fixture or --observe-local-runtime, not both.")
+    if args.idle_fixture:
+        return load_codex_cli_runtime_idle_fixture(Path(args.idle_fixture).expanduser())
+    if not args.observe_local_runtime:
+        return None
+    probe_result = None
+    human_input_idle_seconds = args.human_input_idle_seconds
+    if args.probe_human_input_idle:
+        probe_result = probe_human_input_idle_seconds()
+        if probe_result.get("ok") is True:
+            human_input_idle_seconds = float(probe_result["human_input_idle_seconds"])
+    return build_codex_cli_runtime_idle_observation_payload(
+        observed_surface=args.observed_surface,
+        turn_state=args.turn_state,
+        human_input_idle_seconds=human_input_idle_seconds,
+        min_human_input_idle_seconds=args.min_human_input_idle_seconds,
+        checked_before_prompt=bool(args.checked_before_prompt),
+        visible_to_user=bool(args.visible_to_user),
+        user_can_interrupt=bool(args.user_can_interrupt),
+        manual_takeover_available=bool(args.manual_takeover_available),
+        probe_result=probe_result,
+    )

--- a/loopx/cli_commands/starter_visible_driver.py
+++ b/loopx/cli_commands/starter_visible_driver.py
@@ -1,0 +1,437 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+from pathlib import Path
+
+from ..codex_cli_probe import (
+    DEFAULT_CODEX_BIN,
+    DEFAULT_TIMEOUT_SECONDS,
+    build_codex_cli_bounded_visible_pilot_adapter,
+    build_codex_cli_local_driver_plan,
+    build_codex_cli_one_message_loop_pilot,
+    build_codex_cli_visible_attach_acceptance,
+    build_codex_cli_visible_driver_plan,
+    build_codex_cli_visible_driver_run_packet,
+    build_codex_cli_visible_first_response_capture_plan,
+    build_codex_cli_visible_local_driver_pilot,
+    load_codex_cli_first_response_fixture,
+    load_codex_cli_visible_session_proof_fixture,
+    render_codex_cli_bounded_visible_pilot_adapter_markdown,
+    render_codex_cli_local_driver_plan_markdown,
+    render_codex_cli_one_message_loop_pilot_markdown,
+    render_codex_cli_visible_attach_acceptance_markdown,
+    render_codex_cli_visible_driver_plan_markdown,
+    render_codex_cli_visible_driver_run_packet_markdown,
+    render_codex_cli_visible_first_response_capture_plan_markdown,
+    render_codex_cli_visible_local_driver_pilot_markdown,
+    run_codex_cli_session_probe,
+)
+from .starter_runtime_idle import (
+    _add_runtime_idle_observation_arguments,
+    _load_codex_cli_runtime_idle_payload,
+)
+
+
+PrintPayload = Callable[
+    [dict[str, object], str, Callable[[dict[str, object]], str]],
+    None,
+]
+
+
+def _add_project_arguments(
+    parser: argparse.ArgumentParser,
+    *,
+    agent_help: str = "Registered LoopX agent id to include in quota/claim instructions.",
+) -> None:
+    parser.add_argument("--project", default=".", help="Project directory to start from.")
+    parser.add_argument("--goal-id", help="Goal id. Defaults to <project-name>-goal.")
+    parser.add_argument("--agent-id", help=agent_help)
+    parser.add_argument(
+        "--cli-bin",
+        default="loopx",
+        help="LoopX CLI binary name embedded in generated commands.",
+    )
+
+
+def _add_codex_probe_arguments(
+    parser: argparse.ArgumentParser,
+    *,
+    codex_help: str = "Codex CLI executable to probe and reference in fallback commands.",
+) -> None:
+    parser.add_argument(
+        "--codex-bin",
+        default=DEFAULT_CODEX_BIN,
+        help=codex_help,
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=DEFAULT_TIMEOUT_SECONDS,
+        help="Per-command timeout for help-only Codex CLI probes.",
+    )
+    parser.add_argument(
+        "--fixture",
+        help="Public-safe JSON fixture with command_outputs, used instead of invoking Codex CLI.",
+    )
+
+
+def _add_optional_proof_fixture(parser: argparse.ArgumentParser, *, help_text: str) -> None:
+    parser.add_argument("--proof-fixture", help=help_text)
+
+
+def _add_headless_fallback_argument(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--allow-headless-fallback",
+        action="store_true",
+        help="Deprecated and ignored; headless codex exec is disabled for this default /goal path.",
+    )
+
+
+def register_starter_visible_driver_commands(subparsers: argparse._SubParsersAction) -> None:
+    codex_cli_one_message_loop_parser = subparsers.add_parser(
+        "codex-cli-one-message-loop-pilot",
+        help="Compose the first Codex CLI TUI paste message with the safe scheduler/executor bridge.",
+    )
+    _add_project_arguments(codex_cli_one_message_loop_parser)
+    _add_codex_probe_arguments(
+        codex_cli_one_message_loop_parser,
+        codex_help="Codex CLI executable to probe and reference in bridge commands.",
+    )
+    _add_optional_proof_fixture(
+        codex_cli_one_message_loop_parser,
+        help_text=(
+            "Optional public-safe visible-session proof fixture. "
+            "Without it, same-session automation remains blocked."
+        ),
+    )
+    _add_runtime_idle_observation_arguments(codex_cli_one_message_loop_parser)
+    _add_headless_fallback_argument(codex_cli_one_message_loop_parser)
+
+    codex_cli_visible_local_driver_parser = subparsers.add_parser(
+        "codex-cli-visible-local-driver-pilot",
+        help="Compose the one-message TUI start and later scheduler bridge into a visible local driver pilot packet.",
+    )
+    _add_project_arguments(codex_cli_visible_local_driver_parser)
+    _add_codex_probe_arguments(
+        codex_cli_visible_local_driver_parser,
+        codex_help="Codex CLI executable to probe and reference in bridge commands.",
+    )
+    _add_optional_proof_fixture(
+        codex_cli_visible_local_driver_parser,
+        help_text="Optional public-safe visible-session proof fixture. Without it, later visible turns remain blocked.",
+    )
+    codex_cli_visible_local_driver_parser.add_argument(
+        "--idle-fixture",
+        help="Optional public-safe runtime idle fixture. Without it, later visible turn candidates remain blocked.",
+    )
+    _add_runtime_idle_observation_arguments(
+        codex_cli_visible_local_driver_parser,
+        include_idle_fixture=False,
+    )
+    _add_headless_fallback_argument(codex_cli_visible_local_driver_parser)
+
+    codex_cli_bounded_visible_parser = subparsers.add_parser(
+        "codex-cli-bounded-visible-pilot-adapter",
+        help="Validate public-safe first-response and idle evidence before claiming Codex CLI live TUI bootstrap success.",
+    )
+    _add_project_arguments(
+        codex_cli_bounded_visible_parser,
+        agent_help="Registered LoopX agent id to include in adapter commands.",
+    )
+    codex_cli_bounded_visible_parser.add_argument(
+        "--first-response-fixture",
+        help="Public-safe JSON fixture proving the first visible TUI response shape.",
+    )
+    _add_runtime_idle_observation_arguments(codex_cli_bounded_visible_parser)
+
+    codex_cli_first_response_capture_parser = subparsers.add_parser(
+        "codex-cli-visible-first-response-capture-plan",
+        help="Plan the public-safe manual visible capture of Codex CLI first-response and idle fixtures.",
+    )
+    _add_project_arguments(
+        codex_cli_first_response_capture_parser,
+        agent_help="Registered LoopX agent id to include in generated commands.",
+    )
+    codex_cli_first_response_capture_parser.add_argument(
+        "--first-response-path",
+        default="public-first-response.json",
+        help="Public-safe first-response fixture path used in generated commands.",
+    )
+    codex_cli_first_response_capture_parser.add_argument(
+        "--idle-path",
+        default="public-runtime-idle.json",
+        help="Public-safe runtime idle fixture path used in generated commands.",
+    )
+
+    codex_cli_visible_attach_acceptance_parser = subparsers.add_parser(
+        "codex-cli-visible-attach-acceptance",
+        help="Accept or block same-TUI Codex CLI visible attach from help-only probe, proof, and idle evidence.",
+    )
+    _add_project_arguments(
+        codex_cli_visible_attach_acceptance_parser,
+        agent_help="Registered LoopX agent id to include in acceptance commands.",
+    )
+    _add_codex_probe_arguments(
+        codex_cli_visible_attach_acceptance_parser,
+        codex_help="Codex CLI executable to probe and reference in fallback commands.",
+    )
+    _add_optional_proof_fixture(
+        codex_cli_visible_attach_acceptance_parser,
+        help_text="Optional public-safe visible-session proof fixture. Without it, same-TUI attach is not accepted.",
+    )
+    _add_runtime_idle_observation_arguments(codex_cli_visible_attach_acceptance_parser)
+
+    codex_cli_visible_driver_parser = subparsers.add_parser(
+        "codex-cli-visible-driver-plan",
+        help="Plan a public-safe visible Codex CLI driver path from session-probe evidence.",
+    )
+    _add_project_arguments(codex_cli_visible_driver_parser)
+    _add_codex_probe_arguments(codex_cli_visible_driver_parser)
+
+    codex_cli_local_driver_parser = subparsers.add_parser(
+        "codex-cli-local-driver-plan",
+        help=(
+            "Compose a dry-run-first local Codex CLI driver plan from quota, "
+            "TUI bootstrap, visible-driver, and exec fallback commands."
+        ),
+    )
+    _add_project_arguments(codex_cli_local_driver_parser)
+    _add_codex_probe_arguments(codex_cli_local_driver_parser)
+
+    codex_cli_visible_driver_run_parser = subparsers.add_parser(
+        "codex-cli-visible-driver-run",
+        help="Build a no-execution visible Codex CLI driver run packet from quota-safe driver planning inputs.",
+    )
+    _add_project_arguments(codex_cli_visible_driver_run_parser)
+    _add_codex_probe_arguments(
+        codex_cli_visible_driver_run_parser,
+        codex_help="Codex CLI executable to probe for visible-session capabilities.",
+    )
+    _add_optional_proof_fixture(
+        codex_cli_visible_driver_run_parser,
+        help_text=(
+            "Optional public-safe visible-session proof fixture. "
+            "Without it, same-session automation remains blocked."
+        ),
+    )
+    _add_headless_fallback_argument(codex_cli_visible_driver_run_parser)
+
+
+def handle_codex_cli_one_message_loop_pilot_command(
+    args: argparse.Namespace,
+    print_payload: PrintPayload,
+) -> int:
+    probe_payload = run_codex_cli_session_probe(
+        codex_bin=args.codex_bin,
+        timeout_seconds=args.timeout_seconds,
+        fixture=Path(args.fixture).expanduser() if args.fixture else None,
+    )
+    proof_payload = (
+        load_codex_cli_visible_session_proof_fixture(Path(args.proof_fixture).expanduser())
+        if args.proof_fixture
+        else None
+    )
+    idle_payload = _load_codex_cli_runtime_idle_payload(args)
+    payload = build_codex_cli_one_message_loop_pilot(
+        project=Path(args.project),
+        goal_id=args.goal_id,
+        agent_id=args.agent_id,
+        cli_bin=args.cli_bin,
+        codex_bin=args.codex_bin,
+        probe_payload=probe_payload,
+        proof_payload=proof_payload,
+        idle_payload=idle_payload,
+        allow_headless_fallback=bool(args.allow_headless_fallback),
+    )
+    print_payload(payload, args.format, render_codex_cli_one_message_loop_pilot_markdown)
+    return 0 if payload.get("ok") else 1
+
+
+def handle_codex_cli_visible_local_driver_pilot_command(
+    args: argparse.Namespace,
+    print_payload: PrintPayload,
+) -> int:
+    probe_payload = run_codex_cli_session_probe(
+        codex_bin=args.codex_bin,
+        timeout_seconds=args.timeout_seconds,
+        fixture=Path(args.fixture).expanduser() if args.fixture else None,
+    )
+    proof_payload = (
+        load_codex_cli_visible_session_proof_fixture(Path(args.proof_fixture).expanduser())
+        if args.proof_fixture
+        else None
+    )
+    idle_payload = _load_codex_cli_runtime_idle_payload(args)
+    payload = build_codex_cli_visible_local_driver_pilot(
+        project=Path(args.project),
+        goal_id=args.goal_id,
+        agent_id=args.agent_id,
+        cli_bin=args.cli_bin,
+        codex_bin=args.codex_bin,
+        probe_payload=probe_payload,
+        proof_payload=proof_payload,
+        idle_payload=idle_payload,
+        allow_headless_fallback=bool(args.allow_headless_fallback),
+    )
+    print_payload(payload, args.format, render_codex_cli_visible_local_driver_pilot_markdown)
+    return 0 if payload.get("ok") else 1
+
+
+def handle_codex_cli_bounded_visible_pilot_adapter_command(
+    args: argparse.Namespace,
+    print_payload: PrintPayload,
+) -> int:
+    first_response_payload = (
+        load_codex_cli_first_response_fixture(Path(args.first_response_fixture).expanduser())
+        if args.first_response_fixture
+        else None
+    )
+    idle_payload = _load_codex_cli_runtime_idle_payload(args)
+    payload = build_codex_cli_bounded_visible_pilot_adapter(
+        project=Path(args.project),
+        goal_id=args.goal_id,
+        agent_id=args.agent_id,
+        cli_bin=args.cli_bin,
+        first_response_payload=first_response_payload,
+        idle_payload=idle_payload,
+    )
+    print_payload(payload, args.format, render_codex_cli_bounded_visible_pilot_adapter_markdown)
+    return 0 if payload.get("ok") else 1
+
+
+def handle_codex_cli_visible_first_response_capture_plan_command(
+    args: argparse.Namespace,
+    print_payload: PrintPayload,
+) -> int:
+    payload = build_codex_cli_visible_first_response_capture_plan(
+        project=Path(args.project),
+        goal_id=args.goal_id,
+        agent_id=args.agent_id,
+        cli_bin=args.cli_bin,
+        first_response_path=args.first_response_path,
+        idle_path=args.idle_path,
+    )
+    print_payload(payload, args.format, render_codex_cli_visible_first_response_capture_plan_markdown)
+    return 0 if payload.get("ok") else 1
+
+
+def handle_codex_cli_visible_attach_acceptance_command(
+    args: argparse.Namespace,
+    print_payload: PrintPayload,
+) -> int:
+    probe_payload = run_codex_cli_session_probe(
+        codex_bin=args.codex_bin,
+        timeout_seconds=args.timeout_seconds,
+        fixture=Path(args.fixture).expanduser() if args.fixture else None,
+    )
+    proof_payload = (
+        load_codex_cli_visible_session_proof_fixture(Path(args.proof_fixture).expanduser())
+        if args.proof_fixture
+        else None
+    )
+    idle_payload = _load_codex_cli_runtime_idle_payload(args)
+    payload = build_codex_cli_visible_attach_acceptance(
+        project=Path(args.project),
+        goal_id=args.goal_id,
+        agent_id=args.agent_id,
+        cli_bin=args.cli_bin,
+        codex_bin=args.codex_bin,
+        probe_payload=probe_payload,
+        proof_payload=proof_payload,
+        idle_payload=idle_payload,
+    )
+    print_payload(payload, args.format, render_codex_cli_visible_attach_acceptance_markdown)
+    return 0 if payload.get("ok") else 1
+
+
+def handle_codex_cli_visible_driver_plan_command(
+    args: argparse.Namespace,
+    print_payload: PrintPayload,
+) -> int:
+    probe_payload = run_codex_cli_session_probe(
+        codex_bin=args.codex_bin,
+        timeout_seconds=args.timeout_seconds,
+        fixture=Path(args.fixture).expanduser() if args.fixture else None,
+    )
+    payload = build_codex_cli_visible_driver_plan(
+        project=Path(args.project),
+        goal_id=args.goal_id,
+        agent_id=args.agent_id,
+        cli_bin=args.cli_bin,
+        codex_bin=args.codex_bin,
+        probe_payload=probe_payload,
+    )
+    print_payload(payload, args.format, render_codex_cli_visible_driver_plan_markdown)
+    return 0 if payload.get("ok") else 1
+
+
+def handle_codex_cli_local_driver_plan_command(
+    args: argparse.Namespace,
+    print_payload: PrintPayload,
+) -> int:
+    probe_payload = run_codex_cli_session_probe(
+        codex_bin=args.codex_bin,
+        timeout_seconds=args.timeout_seconds,
+        fixture=Path(args.fixture).expanduser() if args.fixture else None,
+    )
+    payload = build_codex_cli_local_driver_plan(
+        project=Path(args.project),
+        goal_id=args.goal_id,
+        agent_id=args.agent_id,
+        cli_bin=args.cli_bin,
+        codex_bin=args.codex_bin,
+        probe_payload=probe_payload,
+    )
+    print_payload(payload, args.format, render_codex_cli_local_driver_plan_markdown)
+    return 0 if payload.get("ok") else 1
+
+
+def handle_codex_cli_visible_driver_run_command(
+    args: argparse.Namespace,
+    print_payload: PrintPayload,
+) -> int:
+    probe_payload = run_codex_cli_session_probe(
+        codex_bin=args.codex_bin,
+        timeout_seconds=args.timeout_seconds,
+        fixture=Path(args.fixture).expanduser() if args.fixture else None,
+    )
+    proof_payload = (
+        load_codex_cli_visible_session_proof_fixture(Path(args.proof_fixture).expanduser())
+        if args.proof_fixture
+        else None
+    )
+    payload = build_codex_cli_visible_driver_run_packet(
+        project=Path(args.project),
+        goal_id=args.goal_id,
+        agent_id=args.agent_id,
+        cli_bin=args.cli_bin,
+        codex_bin=args.codex_bin,
+        probe_payload=probe_payload,
+        proof_payload=proof_payload,
+        allow_headless_fallback=bool(args.allow_headless_fallback),
+    )
+    print_payload(payload, args.format, render_codex_cli_visible_driver_run_packet_markdown)
+    return 0 if payload.get("ok") else 1
+
+
+_VISIBLE_DRIVER_HANDLERS: dict[str, Callable[[argparse.Namespace, PrintPayload], int]] = {
+    "codex-cli-one-message-loop-pilot": handle_codex_cli_one_message_loop_pilot_command,
+    "codex-cli-visible-local-driver-pilot": handle_codex_cli_visible_local_driver_pilot_command,
+    "codex-cli-bounded-visible-pilot-adapter": handle_codex_cli_bounded_visible_pilot_adapter_command,
+    "codex-cli-visible-first-response-capture-plan": handle_codex_cli_visible_first_response_capture_plan_command,
+    "codex-cli-visible-attach-acceptance": handle_codex_cli_visible_attach_acceptance_command,
+    "codex-cli-visible-driver-plan": handle_codex_cli_visible_driver_plan_command,
+    "codex-cli-local-driver-plan": handle_codex_cli_local_driver_plan_command,
+    "codex-cli-visible-driver-run": handle_codex_cli_visible_driver_run_command,
+}
+
+
+def handle_starter_visible_driver_command(
+    args: argparse.Namespace,
+    print_payload: PrintPayload,
+) -> int | None:
+    handler = _VISIBLE_DRIVER_HANDLERS.get(str(getattr(args, "command", "")))
+    if handler is None:
+        return None
+    return handler(args, print_payload)


### PR DESCRIPTION
## Summary
- move the starter visible-driver command family into loopx/cli_commands/starter_visible_driver.py
- move shared runtime-idle argument/payload helpers into loopx/cli_commands/starter_runtime_idle.py
- update starter dispatch/export wiring and add a focused modularization smoke

## Validation
- python3 -m py_compile loopx/cli_commands/starter.py loopx/cli_commands/starter_visible_driver.py loopx/cli_commands/starter_runtime_idle.py loopx/cli_commands/__init__.py examples/cli-starter-visible-driver-family-command-modularization-smoke.py examples/cli-starter-dispatch-command-modularization-smoke.py
- python3 examples/cli-starter-visible-driver-family-command-modularization-smoke.py
- python3 examples/cli-starter-dispatch-command-modularization-smoke.py
- python3 examples/cli-starter-bootstrap-family-command-modularization-smoke.py
- python3 examples/codex-cli-one-message-loop-pilot-smoke.py
- python3 examples/codex-cli-visible-local-driver-pilot-smoke.py
- python3 examples/codex-cli-bounded-visible-pilot-adapter-smoke.py
- python3 examples/codex-cli-visible-first-response-capture-plan-smoke.py
- python3 examples/codex-cli-visible-attach-acceptance-smoke.py
- python3 examples/codex-cli-visible-driver-run-smoke.py
- python3 examples/codex-cli-local-driver-plan-smoke.py
- python3 examples/codex-cli-session-probe-smoke.py
- python3 examples/codex-cli-local-scheduler-tick-smoke.py
- python3 examples/codex-cli-local-scheduler-exec-smoke.py
- python3 examples/codex-cli-runtime-idle-detector-smoke.py
- python3 -m py_compile loopx/__init__.py
loopx/agent_registry.py
loopx/authority.py
loopx/benchmark.py
loopx/benchmark_adapters/__init__.py
loopx/benchmark_adapters/agentissue.py
loopx/benchmark_adapters/agents_last_exam.py
loopx/benchmark_adapters/skillsbench.py
loopx/benchmark_adapters/skillsbench_acp_relay.py
loopx/benchmark_adapters/skillsbench_remote_bridge.py
loopx/benchmark_adapters/terminal_bench.py
loopx/benchmark_case_analysis.py
loopx/benchmark_case_state.py
loopx/benchmark_core/__init__.py
loopx/benchmark_core/adapter.py
loopx/benchmark_core/artifacts.py
loopx/benchmark_core/attempts.py
loopx/benchmark_core/io.py
loopx/benchmark_core/lifecycle.py
loopx/benchmark_core/loop_protocol.py
loopx/benchmark_core/observable_handles.py
loopx/benchmark_core/parity.py
loopx/benchmark_core/rounds.py
loopx/benchmark_core/run_permissions.py
loopx/benchmark_core/split_control.py
loopx/benchmark_ledger.py
loopx/benchmark_trajectory.py
loopx/bootstrap.py
loopx/boundary_authority.py
loopx/cli.py
loopx/cli_commands/__init__.py
loopx/cli_commands/agentissue_runner_flow.py
loopx/cli_commands/agents_last_exam.py
loopx/cli_commands/benchmark_boundary.py
loopx/cli_commands/benchmark_dispatch.py
loopx/cli_commands/benchmark_review_lifecycle.py
loopx/cli_commands/benchmark_run_ledger.py
loopx/cli_commands/bootstrap_connect.py
loopx/cli_commands/doctor.py
loopx/cli_commands/dreaming.py
loopx/cli_commands/history.py
loopx/cli_commands/ml_experiment.py
loopx/cli_commands/project_lifecycle.py
loopx/cli_commands/quota.py
loopx/cli_commands/registry_admin.py
loopx/cli_commands/starter.py
loopx/cli_commands/starter_bootstrap.py
loopx/cli_commands/starter_runtime_idle.py
loopx/cli_commands/starter_visible_driver.py
loopx/cli_commands/status.py
loopx/cli_commands/support_control.py
loopx/cli_commands/terminal_bench_adapter.py
loopx/cli_commands/terminal_bench_environment_result.py
loopx/cli_commands/todo.py
loopx/cli_commands/worker_bridge.py
loopx/cli_rollout.py
loopx/codex_cli_probe.py
loopx/codex_goal_baseline.py
loopx/configure_goal.py
loopx/content_ops_surface.py
loopx/contract.py
loopx/control_plane.py
loopx/delivery_outcome.py
loopx/demo.py
loopx/diagnose.py
loopx/doctor.py
loopx/dreaming.py
loopx/execution_profile.py
loopx/feedback.py
loopx/file_lock.py
loopx/frontstage.py
loopx/global_registry.py
loopx/handoff_budget.py
loopx/heartbeat_prompt.py
loopx/history.py
loopx/interface_budget.py
loopx/materials.py
loopx/ml_experiment.py
loopx/onboarding.py
loopx/operator_gate.py
loopx/orchestration.py
loopx/paths.py
loopx/project_map.py
loopx/project_prompt.py
loopx/promotion_gate.py
loopx/quota.py
loopx/registry.py
loopx/review_packet.py
loopx/rollout_event_log.py
loopx/runtime.py
loopx/self_update.py
loopx/session_runtime.py
loopx/state_migration.py
loopx/state_projection.py
loopx/state_refresh.py
loopx/status.py
loopx/status_server.py
loopx/terminal_bench_agent.py
loopx/todo_contract.py
loopx/todos.py
loopx/upgrade.py
loopx/worker_bridge.py
- git diff --check
- loopx check --scan-path loopx/cli_commands/starter.py --scan-path loopx/cli_commands/starter_visible_driver.py --scan-path loopx/cli_commands/starter_runtime_idle.py --scan-path loopx/cli_commands/__init__.py --scan-path examples/cli-starter-visible-driver-family-command-modularization-smoke.py --scan-path examples/cli-starter-dispatch-command-modularization-smoke.py
- for smoke in examples/cli-*-command-modularization-smoke.py; do python3 "" || exit 1; done