### PR TITLE
Refactor starter runtime command families

### DIFF
--- a/examples/cli-starter-dispatch-command-modularization-smoke.py
+++ b/examples/cli-starter-dispatch-command-modularization-smoke.py
@@ -11,6 +11,8 @@ ROOT = Path(__file__).resolve().parents[1]
 CLI = ROOT / "loopx" / "cli.py"
 STARTER_MODULE = ROOT / "loopx" / "cli_commands" / "starter.py"
 VISIBLE_DRIVER_MODULE = ROOT / "loopx" / "cli_commands" / "starter_visible_driver.py"
+SCHEDULER_MODULE = ROOT / "loopx" / "cli_commands" / "starter_scheduler.py"
+SESSION_RUNTIME_MODULE = ROOT / "loopx" / "cli_commands" / "starter_session_runtime.py"
 INIT = ROOT / "loopx" / "cli_commands" / "__init__.py"
 
 
@@ -49,6 +51,8 @@ def assert_source_shape() -> None:
     cli_source = CLI.read_text(encoding="utf-8")
     starter_source = STARTER_MODULE.read_text(encoding="utf-8")
     visible_driver_source = VISIBLE_DRIVER_MODULE.read_text(encoding="utf-8")
+    scheduler_source = SCHEDULER_MODULE.read_text(encoding="utf-8")
+    session_runtime_source = SESSION_RUNTIME_MODULE.read_text(encoding="utf-8")
     init_source = INIT.read_text(encoding="utf-8")
 
     starter_commands = [
@@ -97,10 +101,34 @@ def assert_source_shape() -> None:
         "starter module omitted visible-driver dispatch delegation",
     )
     require(
+        "register_starter_session_runtime_commands(subparsers)" in starter_source,
+        "starter module omitted session-runtime registration delegation",
+    )
+    require(
+        "handle_starter_session_runtime_command(args, print_payload)" in starter_source,
+        "starter module omitted session-runtime dispatch delegation",
+    )
+    require(
+        "register_starter_scheduler_commands(subparsers)" in starter_source,
+        "starter module omitted scheduler registration delegation",
+    )
+    require(
+        "handle_starter_scheduler_command(args, print_payload)" in starter_source,
+        "starter module omitted scheduler dispatch delegation",
+    )
+    require(
         '"codex-cli-visible-driver-run": handle_codex_cli_visible_driver_run_command' in visible_driver_source,
         "visible-driver module omitted visible driver run dispatch",
     )
-    require('"demo": handle_demo_command' in starter_source, "starter dispatcher omitted demo")
+    require(
+        '"codex-cli-local-scheduler-exec": handle_codex_cli_local_scheduler_exec_command' in scheduler_source,
+        "scheduler module omitted local scheduler exec dispatch",
+    )
+    require(
+        '"codex-cli-runtime-idle-detector": handle_codex_cli_runtime_idle_detector_command' in session_runtime_source,
+        "session-runtime module omitted runtime idle dispatch",
+    )
+    require('str(getattr(args, "command", "")) == "demo"' in starter_source, "starter dispatcher omitted demo")
     require("handle_starter_command" in init_source, "__init__ omitted starter dispatcher export")
 
 

--- a/examples/cli-starter-runtime-family-command-modularization-smoke.py
+++ b/examples/cli-starter-runtime-family-command-modularization-smoke.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+STARTER = ROOT / "loopx" / "cli_commands" / "starter.py"
+SCHEDULER = ROOT / "loopx" / "cli_commands" / "starter_scheduler.py"
+SESSION_RUNTIME = ROOT / "loopx" / "cli_commands" / "starter_session_runtime.py"
+RUNTIME_IDLE = ROOT / "loopx" / "cli_commands" / "starter_runtime_idle.py"
+INIT = ROOT / "loopx" / "cli_commands" / "__init__.py"
+VISIBLE_HELP_FIXTURE = (
+    ROOT / "examples" / "fixtures" / "codex-cli-visible-proof" / "codex-visible-resume-help.public.json"
+)
+VISIBLE_PROOF_FIXTURE = (
+    ROOT / "examples" / "fixtures" / "codex-cli-visible-proof" / "visible-resume-proof.public.json"
+)
+RUNTIME_IDLE_FIXTURE = (
+    ROOT / "examples" / "fixtures" / "codex-cli-visible-proof" / "runtime-idle-visible-resume.public.json"
+)
+
+
+SESSION_RUNTIME_COMMANDS = {
+    "codex-cli-session-probe": ["--fixture", "--codex-bin"],
+    "codex-cli-visible-session-proof": ["--proof-fixture", "--cli-bin"],
+    "codex-cli-runtime-idle-detector": ["--idle-fixture", "--observe-local-runtime"],
+}
+SCHEDULER_COMMANDS = {
+    "codex-cli-local-scheduler-tick": ["--proof-fixture", "--idle-fixture", "--allow-headless-fallback"],
+    "codex-cli-local-scheduler-exec": ["--guard-checked", "--candidate-command-prefix", "--executor-timeout-seconds"],
+}
+
+
+def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "loopx.cli", *args],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def require_success(result: subprocess.CompletedProcess[str]) -> str:
+    if result.returncode != 0:
+        raise AssertionError(
+            f"expected success, got {result.returncode}\n"
+            f"stdout:\n{result.stdout}\n\nstderr:\n{result.stderr}"
+        )
+    return result.stdout
+
+
+def require_json_success(result: subprocess.CompletedProcess[str]) -> dict[str, object]:
+    payload = json.loads(require_success(result))
+    require(isinstance(payload, dict), "expected JSON object payload")
+    require(payload.get("ok") is True, f"payload was not ok: {payload}")
+    return payload
+
+
+def assert_source_shape() -> None:
+    starter_source = STARTER.read_text(encoding="utf-8")
+    scheduler_source = SCHEDULER.read_text(encoding="utf-8")
+    session_runtime_source = SESSION_RUNTIME.read_text(encoding="utf-8")
+    runtime_idle_source = RUNTIME_IDLE.read_text(encoding="utf-8")
+    init_source = INIT.read_text(encoding="utf-8")
+
+    forbidden_starter_markers = [
+        "codex-cli-session-probe",
+        "codex-cli-local-scheduler-tick",
+        "codex-cli-local-scheduler-exec",
+        "codex-cli-visible-session-proof",
+        "codex-cli-runtime-idle-detector",
+        "def handle_codex_cli_session_probe_command(",
+        "def handle_codex_cli_local_scheduler_tick_command(",
+        "def handle_codex_cli_local_scheduler_exec_command(",
+        "def handle_codex_cli_visible_session_proof_command(",
+        "def handle_codex_cli_runtime_idle_detector_command(",
+        "build_codex_cli_local_scheduler_tick(",
+        "build_codex_cli_local_scheduler_executor(",
+        "build_codex_cli_visible_session_proof(",
+        "build_codex_cli_runtime_idle_detector(",
+    ]
+    for marker in forbidden_starter_markers:
+        require(marker not in starter_source, f"runtime/scheduler marker leaked into starter.py: {marker}")
+
+    for marker in (
+        "register_starter_session_runtime_commands(subparsers)",
+        "handle_starter_session_runtime_command(args, print_payload)",
+        "register_starter_scheduler_commands(subparsers)",
+        "handle_starter_scheduler_command(args, print_payload)",
+    ):
+        require(marker in starter_source, f"starter.py missing delegation marker: {marker}")
+
+    for command in SESSION_RUNTIME_COMMANDS:
+        require(command in session_runtime_source, f"starter_session_runtime.py missing command: {command}")
+    for marker in (
+        "def register_starter_session_runtime_commands(",
+        "def handle_starter_session_runtime_command(",
+        "_SESSION_RUNTIME_HANDLERS",
+        "build_codex_cli_visible_session_proof(",
+        "build_codex_cli_runtime_idle_detector(",
+    ):
+        require(marker in session_runtime_source, f"starter_session_runtime.py missing marker: {marker}")
+
+    for command in SCHEDULER_COMMANDS:
+        require(command in scheduler_source, f"starter_scheduler.py missing command: {command}")
+    for marker in (
+        "def register_starter_scheduler_commands(",
+        "def handle_starter_scheduler_command(",
+        "_SCHEDULER_HANDLERS",
+        "build_codex_cli_local_scheduler_tick(",
+        "build_codex_cli_local_scheduler_executor(",
+    ):
+        require(marker in scheduler_source, f"starter_scheduler.py missing marker: {marker}")
+
+    for marker in (
+        "def _add_runtime_idle_observation_arguments(",
+        "def _load_codex_cli_runtime_idle_payload(",
+    ):
+        require(marker in runtime_idle_source, f"starter_runtime_idle.py missing marker: {marker}")
+
+    for marker in (
+        "handle_starter_scheduler_command",
+        "register_starter_scheduler_commands",
+        "handle_starter_session_runtime_command",
+        "register_starter_session_runtime_commands",
+        "handle_codex_cli_runtime_idle_detector_command",
+        "handle_codex_cli_local_scheduler_exec_command",
+    ):
+        require(marker in init_source, f"__init__ omitted runtime/scheduler export: {marker}")
+
+
+def assert_cli_surfaces() -> None:
+    for command, needles in {**SESSION_RUNTIME_COMMANDS, **SCHEDULER_COMMANDS}.items():
+        help_text = require_success(run_cli(command, "--help"))
+        for needle in needles:
+            require(needle in help_text, f"{command} help omitted {needle}")
+
+    probe_payload = require_json_success(
+        run_cli(
+            "--format",
+            "json",
+            "codex-cli-session-probe",
+            "--fixture",
+            str(VISIBLE_HELP_FIXTURE),
+        )
+    )
+    require(probe_payload.get("recommended_mode") == "visible_resume_or_remote_control_spike", probe_payload)
+
+    proof_payload = require_json_success(
+        run_cli(
+            "--format",
+            "json",
+            "codex-cli-visible-session-proof",
+            "--project",
+            ".",
+            "--goal-id",
+            "starter-runtime-family-smoke",
+            "--proof-fixture",
+            str(VISIBLE_PROOF_FIXTURE),
+        )
+    )
+    require(proof_payload.get("decision") == "visible_session_proof_passed", proof_payload)
+
+    idle_payload = require_json_success(
+        run_cli(
+            "--format",
+            "json",
+            "codex-cli-runtime-idle-detector",
+            "--project",
+            ".",
+            "--goal-id",
+            "starter-runtime-family-smoke",
+            "--idle-fixture",
+            str(RUNTIME_IDLE_FIXTURE),
+        )
+    )
+    require(idle_payload.get("decision") == "runtime_idle_detector_passed", idle_payload)
+
+    scheduler_payload = require_json_success(
+        run_cli(
+            "--format",
+            "json",
+            "codex-cli-local-scheduler-exec",
+            "--project",
+            ".",
+            "--goal-id",
+            "starter-runtime-family-smoke",
+            "--fixture",
+            str(VISIBLE_HELP_FIXTURE),
+            "--proof-fixture",
+            str(VISIBLE_PROOF_FIXTURE),
+            "--idle-fixture",
+            str(RUNTIME_IDLE_FIXTURE),
+        )
+    )
+    require(scheduler_payload.get("decision") == "visible_session_turn_candidate", scheduler_payload)
+    boundary = scheduler_payload.get("boundary")
+    require(isinstance(boundary, dict), scheduler_payload)
+    require(boundary.get("runs_external_candidate") is False, scheduler_payload)
+    require(boundary.get("runs_codex_candidate_possible") is False, scheduler_payload)
+    require(boundary.get("requires_fresh_quota_guard_confirmation") is True, scheduler_payload)
+
+
+def main() -> None:
+    assert_source_shape()
+    assert_cli_surfaces()
+    print("cli-starter-runtime-family-command-modularization-smoke: ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/cli_commands/__init__.py
+++ b/loopx/cli_commands/__init__.py
@@ -50,11 +50,6 @@ from .registry_admin import (
     register_registry_admin_commands,
 )
 from .starter import (
-    handle_codex_cli_local_scheduler_exec_command,
-    handle_codex_cli_local_scheduler_tick_command,
-    handle_codex_cli_runtime_idle_detector_command,
-    handle_codex_cli_session_probe_command,
-    handle_codex_cli_visible_session_proof_command,
     handle_demo_command,
     handle_starter_command,
     register_starter_commands,
@@ -66,6 +61,19 @@ from .starter_bootstrap import (
     handle_new_project_prompt_command,
     handle_starter_bootstrap_command,
     register_starter_bootstrap_commands,
+)
+from .starter_scheduler import (
+    handle_codex_cli_local_scheduler_exec_command,
+    handle_codex_cli_local_scheduler_tick_command,
+    handle_starter_scheduler_command,
+    register_starter_scheduler_commands,
+)
+from .starter_session_runtime import (
+    handle_codex_cli_runtime_idle_detector_command,
+    handle_codex_cli_session_probe_command,
+    handle_codex_cli_visible_session_proof_command,
+    handle_starter_session_runtime_command,
+    register_starter_session_runtime_commands,
 )
 from .starter_visible_driver import (
     handle_codex_cli_bounded_visible_pilot_adapter_command,
@@ -140,6 +148,8 @@ __all__ = [
     "handle_status_command",
     "handle_starter_command",
     "handle_starter_bootstrap_command",
+    "handle_starter_scheduler_command",
+    "handle_starter_session_runtime_command",
     "handle_starter_visible_driver_command",
     "handle_support_control_command",
     "handle_terminal_bench_adapter_command",
@@ -162,6 +172,8 @@ __all__ = [
     "register_registry_admin_commands",
     "register_starter_commands",
     "register_starter_bootstrap_commands",
+    "register_starter_scheduler_commands",
+    "register_starter_session_runtime_commands",
     "register_starter_visible_driver_commands",
     "register_status_commands",
     "register_support_control_commands",

--- a/loopx/cli_commands/starter.py
+++ b/loopx/cli_commands/starter.py
@@ -13,29 +13,17 @@ from ..demo import (
     render_demo_markdown,
     run_demo,
 )
-from ..codex_cli_probe import (
-    DEFAULT_CODEX_BIN,
-    DEFAULT_EXECUTOR_TIMEOUT_SECONDS,
-    DEFAULT_TIMEOUT_SECONDS,
-    build_codex_cli_local_scheduler_executor,
-    build_codex_cli_local_scheduler_tick,
-    build_codex_cli_runtime_idle_detector,
-    build_codex_cli_visible_session_proof,
-    load_codex_cli_visible_session_proof_fixture,
-    render_codex_cli_local_scheduler_executor_markdown,
-    render_codex_cli_local_scheduler_tick_markdown,
-    render_codex_cli_session_probe_markdown,
-    render_codex_cli_runtime_idle_detector_markdown,
-    render_codex_cli_visible_session_proof_markdown,
-    run_codex_cli_session_probe,
-)
 from .starter_bootstrap import (
     handle_starter_bootstrap_command,
     register_starter_bootstrap_commands,
 )
-from .starter_runtime_idle import (
-    _add_runtime_idle_observation_arguments,
-    _load_codex_cli_runtime_idle_payload,
+from .starter_scheduler import (
+    handle_starter_scheduler_command,
+    register_starter_scheduler_commands,
+)
+from .starter_session_runtime import (
+    handle_starter_session_runtime_command,
+    register_starter_session_runtime_commands,
 )
 from .starter_visible_driver import (
     handle_starter_visible_driver_command,
@@ -52,172 +40,8 @@ PrintPayload = Callable[
 def register_starter_commands(subparsers: argparse._SubParsersAction) -> None:
     register_starter_bootstrap_commands(subparsers)
     register_starter_visible_driver_commands(subparsers)
-
-    codex_cli_probe_parser = subparsers.add_parser(
-        "codex-cli-session-probe",
-        help="Probe Codex CLI help surfaces for same-session LoopX automation support.",
-    )
-    codex_cli_probe_parser.add_argument(
-        "--codex-bin",
-        default=DEFAULT_CODEX_BIN,
-        help="Codex CLI executable to probe with help-only commands.",
-    )
-    codex_cli_probe_parser.add_argument(
-        "--timeout-seconds",
-        type=float,
-        default=DEFAULT_TIMEOUT_SECONDS,
-        help="Per-command timeout for help-only Codex CLI probes.",
-    )
-    codex_cli_probe_parser.add_argument(
-        "--fixture",
-        help="Public-safe JSON fixture with command_outputs, used instead of invoking Codex CLI.",
-    )
-
-    codex_cli_local_scheduler_tick_parser = subparsers.add_parser(
-        "codex-cli-local-scheduler-tick",
-        help="Build a no-execution local scheduler tick around codex-cli-visible-driver-run.",
-    )
-    codex_cli_local_scheduler_tick_parser.add_argument("--project", default=".", help="Project directory to start from.")
-    codex_cli_local_scheduler_tick_parser.add_argument("--goal-id", help="Goal id. Defaults to <project-name>-goal.")
-    codex_cli_local_scheduler_tick_parser.add_argument(
-        "--agent-id",
-        help="Registered LoopX agent id to include in quota/claim instructions.",
-    )
-    codex_cli_local_scheduler_tick_parser.add_argument(
-        "--cli-bin",
-        default="loopx",
-        help="LoopX CLI binary name embedded in generated commands.",
-    )
-    codex_cli_local_scheduler_tick_parser.add_argument(
-        "--codex-bin",
-        default=DEFAULT_CODEX_BIN,
-        help="Codex CLI executable to probe for visible-session capabilities.",
-    )
-    codex_cli_local_scheduler_tick_parser.add_argument(
-        "--timeout-seconds",
-        type=float,
-        default=DEFAULT_TIMEOUT_SECONDS,
-        help="Per-command timeout for help-only Codex CLI probes.",
-    )
-    codex_cli_local_scheduler_tick_parser.add_argument(
-        "--fixture",
-        help="Public-safe JSON fixture with command_outputs, used instead of invoking Codex CLI.",
-    )
-    codex_cli_local_scheduler_tick_parser.add_argument(
-        "--proof-fixture",
-        help="Optional public-safe visible-session proof fixture. Without it, same-session automation remains blocked.",
-    )
-    _add_runtime_idle_observation_arguments(codex_cli_local_scheduler_tick_parser)
-    codex_cli_local_scheduler_tick_parser.add_argument(
-        "--allow-headless-fallback",
-        action="store_true",
-        help="Deprecated and ignored; headless codex exec is disabled for this default /goal path.",
-    )
-
-    codex_cli_local_scheduler_exec_parser = subparsers.add_parser(
-        "codex-cli-local-scheduler-exec",
-        help="Explicit opt-in executor wrapper for codex-cli-local-scheduler-tick results.",
-    )
-    codex_cli_local_scheduler_exec_parser.add_argument("--project", default=".", help="Project directory to start from.")
-    codex_cli_local_scheduler_exec_parser.add_argument("--goal-id", help="Goal id. Defaults to <project-name>-goal.")
-    codex_cli_local_scheduler_exec_parser.add_argument(
-        "--agent-id",
-        help="Registered LoopX agent id to include in quota/claim instructions.",
-    )
-    codex_cli_local_scheduler_exec_parser.add_argument(
-        "--cli-bin",
-        default="loopx",
-        help="LoopX CLI binary name embedded in generated commands.",
-    )
-    codex_cli_local_scheduler_exec_parser.add_argument(
-        "--codex-bin",
-        default=DEFAULT_CODEX_BIN,
-        help="Codex CLI executable to probe for visible-session capabilities.",
-    )
-    codex_cli_local_scheduler_exec_parser.add_argument(
-        "--timeout-seconds",
-        type=float,
-        default=DEFAULT_TIMEOUT_SECONDS,
-        help="Per-command timeout for help-only Codex CLI probes.",
-    )
-    codex_cli_local_scheduler_exec_parser.add_argument(
-        "--executor-timeout-seconds",
-        type=float,
-        default=DEFAULT_EXECUTOR_TIMEOUT_SECONDS,
-        help="Timeout for the explicitly executed scheduler result command.",
-    )
-    codex_cli_local_scheduler_exec_parser.add_argument(
-        "--fixture",
-        help="Public-safe JSON fixture with command_outputs, used instead of invoking Codex CLI.",
-    )
-    codex_cli_local_scheduler_exec_parser.add_argument(
-        "--proof-fixture",
-        help="Optional public-safe visible-session proof fixture. Without it, same-session automation remains blocked.",
-    )
-    _add_runtime_idle_observation_arguments(codex_cli_local_scheduler_exec_parser)
-    codex_cli_local_scheduler_exec_parser.add_argument(
-        "--allow-headless-fallback",
-        action="store_true",
-        help="Deprecated and ignored; headless codex exec is disabled for this default /goal path.",
-    )
-    codex_cli_local_scheduler_exec_parser.add_argument(
-        "--guard-checked",
-        action="store_true",
-        help="Confirm a fresh quota/user-gate guard was checked before executing a candidate or blocker writeback.",
-    )
-    codex_cli_local_scheduler_exec_parser.add_argument(
-        "--execute-candidate",
-        action="store_true",
-        help="Execute the scheduler candidate command after guard and prefix checks.",
-    )
-    codex_cli_local_scheduler_exec_parser.add_argument(
-        "--execute-blocker-writeback",
-        action="store_true",
-        help="Execute the precise LoopX blocker writeback command after a fresh guard check.",
-    )
-    codex_cli_local_scheduler_exec_parser.add_argument(
-        "--candidate-command-prefix",
-        action="append",
-        default=[],
-        help="Allowed command prefix for --execute-candidate. Repeatable; required before candidate execution.",
-    )
-
-    codex_cli_visible_session_proof_parser = subparsers.add_parser(
-        "codex-cli-visible-session-proof",
-        help="Validate a public-safe proof fixture before treating Codex CLI resume or remote-control as same-session automation.",
-    )
-    codex_cli_visible_session_proof_parser.add_argument("--project", default=".", help="Project directory to start from.")
-    codex_cli_visible_session_proof_parser.add_argument("--goal-id", help="Goal id. Defaults to <project-name>-goal.")
-    codex_cli_visible_session_proof_parser.add_argument(
-        "--agent-id",
-        help="Registered LoopX agent id to include in the proof packet.",
-    )
-    codex_cli_visible_session_proof_parser.add_argument(
-        "--cli-bin",
-        default="loopx",
-        help="LoopX CLI binary name embedded in proof metadata.",
-    )
-    codex_cli_visible_session_proof_parser.add_argument(
-        "--proof-fixture",
-        help="Public-safe JSON proof fixture. When omitted, prints the required fixture shape.",
-    )
-
-    codex_cli_runtime_idle_parser = subparsers.add_parser(
-        "codex-cli-runtime-idle-detector",
-        help="Validate public-safe runtime idle evidence before a later visible Codex CLI turn.",
-    )
-    codex_cli_runtime_idle_parser.add_argument("--project", default=".", help="Project directory to start from.")
-    codex_cli_runtime_idle_parser.add_argument("--goal-id", help="Goal id. Defaults to <project-name>-goal.")
-    codex_cli_runtime_idle_parser.add_argument(
-        "--agent-id",
-        help="Registered LoopX agent id to include in the idle packet.",
-    )
-    codex_cli_runtime_idle_parser.add_argument(
-        "--cli-bin",
-        default="loopx",
-        help="LoopX CLI binary name embedded in idle detector metadata.",
-    )
-    _add_runtime_idle_observation_arguments(codex_cli_runtime_idle_parser)
+    register_starter_session_runtime_commands(subparsers)
+    register_starter_scheduler_commands(subparsers)
 
     demo_parser = subparsers.add_parser(
         "demo",
@@ -232,120 +56,6 @@ def register_starter_commands(subparsers: argparse._SubParsersAction) -> None:
     demo_parser.add_argument("--objective", default=DEFAULT_DEMO_OBJECTIVE)
     demo_parser.add_argument("--user-todo", default=DEFAULT_DEMO_USER_TODO)
     demo_parser.add_argument("--agent-todo", default=DEFAULT_DEMO_AGENT_TODO)
-
-
-def handle_codex_cli_session_probe_command(
-    args: argparse.Namespace,
-    print_payload: PrintPayload,
-) -> int:
-    payload = run_codex_cli_session_probe(
-        codex_bin=args.codex_bin,
-        timeout_seconds=args.timeout_seconds,
-        fixture=Path(args.fixture).expanduser() if args.fixture else None,
-    )
-    print_payload(payload, args.format, render_codex_cli_session_probe_markdown)
-    return 0 if payload.get("ok") else 1
-
-
-def handle_codex_cli_local_scheduler_tick_command(
-    args: argparse.Namespace,
-    print_payload: PrintPayload,
-) -> int:
-    probe_payload = run_codex_cli_session_probe(
-        codex_bin=args.codex_bin,
-        timeout_seconds=args.timeout_seconds,
-        fixture=Path(args.fixture).expanduser() if args.fixture else None,
-    )
-    proof_payload = (
-        load_codex_cli_visible_session_proof_fixture(Path(args.proof_fixture).expanduser())
-        if args.proof_fixture
-        else None
-    )
-    idle_payload = _load_codex_cli_runtime_idle_payload(args)
-    payload = build_codex_cli_local_scheduler_tick(
-        project=Path(args.project),
-        goal_id=args.goal_id,
-        agent_id=args.agent_id,
-        cli_bin=args.cli_bin,
-        codex_bin=args.codex_bin,
-        probe_payload=probe_payload,
-        proof_payload=proof_payload,
-        idle_payload=idle_payload,
-        allow_headless_fallback=bool(args.allow_headless_fallback),
-    )
-    print_payload(payload, args.format, render_codex_cli_local_scheduler_tick_markdown)
-    return 0 if payload.get("ok") else 1
-
-
-def handle_codex_cli_local_scheduler_exec_command(
-    args: argparse.Namespace,
-    print_payload: PrintPayload,
-) -> int:
-    probe_payload = run_codex_cli_session_probe(
-        codex_bin=args.codex_bin,
-        timeout_seconds=args.timeout_seconds,
-        fixture=Path(args.fixture).expanduser() if args.fixture else None,
-    )
-    proof_payload = (
-        load_codex_cli_visible_session_proof_fixture(Path(args.proof_fixture).expanduser())
-        if args.proof_fixture
-        else None
-    )
-    idle_payload = _load_codex_cli_runtime_idle_payload(args)
-    payload = build_codex_cli_local_scheduler_executor(
-        project=Path(args.project),
-        goal_id=args.goal_id,
-        agent_id=args.agent_id,
-        cli_bin=args.cli_bin,
-        codex_bin=args.codex_bin,
-        probe_payload=probe_payload,
-        proof_payload=proof_payload,
-        idle_payload=idle_payload,
-        allow_headless_fallback=bool(args.allow_headless_fallback),
-        execute_candidate=bool(args.execute_candidate),
-        execute_blocker_writeback=bool(args.execute_blocker_writeback),
-        guard_checked=bool(args.guard_checked),
-        candidate_command_prefixes=list(args.candidate_command_prefix or []),
-        executor_timeout_seconds=args.executor_timeout_seconds,
-    )
-    print_payload(payload, args.format, render_codex_cli_local_scheduler_executor_markdown)
-    return 0 if payload.get("ok") else 1
-
-
-def handle_codex_cli_visible_session_proof_command(
-    args: argparse.Namespace,
-    print_payload: PrintPayload,
-) -> int:
-    proof_payload = (
-        load_codex_cli_visible_session_proof_fixture(Path(args.proof_fixture).expanduser())
-        if args.proof_fixture
-        else None
-    )
-    payload = build_codex_cli_visible_session_proof(
-        project=Path(args.project),
-        goal_id=args.goal_id,
-        agent_id=args.agent_id,
-        cli_bin=args.cli_bin,
-        proof_payload=proof_payload,
-    )
-    print_payload(payload, args.format, render_codex_cli_visible_session_proof_markdown)
-    return 0 if payload.get("ok") else 1
-
-
-def handle_codex_cli_runtime_idle_detector_command(
-    args: argparse.Namespace,
-    print_payload: PrintPayload,
-) -> int:
-    idle_payload = _load_codex_cli_runtime_idle_payload(args)
-    payload = build_codex_cli_runtime_idle_detector(
-        project=Path(args.project),
-        goal_id=args.goal_id,
-        agent_id=args.agent_id,
-        cli_bin=args.cli_bin,
-        idle_payload=idle_payload,
-    )
-    print_payload(payload, args.format, render_codex_cli_runtime_idle_detector_markdown)
-    return 0 if payload.get("ok") else 1
 
 
 def handle_demo_command(args: argparse.Namespace, print_payload: PrintPayload) -> int:
@@ -379,15 +89,12 @@ def handle_starter_command(
     visible_driver_result = handle_starter_visible_driver_command(args, print_payload)
     if visible_driver_result is not None:
         return visible_driver_result
-    handlers: dict[str, Callable[[argparse.Namespace, PrintPayload], int]] = {
-        "codex-cli-session-probe": handle_codex_cli_session_probe_command,
-        "codex-cli-local-scheduler-tick": handle_codex_cli_local_scheduler_tick_command,
-        "codex-cli-local-scheduler-exec": handle_codex_cli_local_scheduler_exec_command,
-        "codex-cli-visible-session-proof": handle_codex_cli_visible_session_proof_command,
-        "codex-cli-runtime-idle-detector": handle_codex_cli_runtime_idle_detector_command,
-        "demo": handle_demo_command,
-    }
-    handler = handlers.get(str(getattr(args, "command", "")))
-    if handler is None:
-        return None
-    return handler(args, print_payload)
+    session_runtime_result = handle_starter_session_runtime_command(args, print_payload)
+    if session_runtime_result is not None:
+        return session_runtime_result
+    scheduler_result = handle_starter_scheduler_command(args, print_payload)
+    if scheduler_result is not None:
+        return scheduler_result
+    if str(getattr(args, "command", "")) == "demo":
+        return handle_demo_command(args, print_payload)
+    return None

--- a/loopx/cli_commands/starter_scheduler.py
+++ b/loopx/cli_commands/starter_scheduler.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+from pathlib import Path
+
+from ..codex_cli_probe import (
+    DEFAULT_CODEX_BIN,
+    DEFAULT_EXECUTOR_TIMEOUT_SECONDS,
+    DEFAULT_TIMEOUT_SECONDS,
+    build_codex_cli_local_scheduler_executor,
+    build_codex_cli_local_scheduler_tick,
+    load_codex_cli_visible_session_proof_fixture,
+    render_codex_cli_local_scheduler_executor_markdown,
+    render_codex_cli_local_scheduler_tick_markdown,
+    run_codex_cli_session_probe,
+)
+from .starter_runtime_idle import (
+    _add_runtime_idle_observation_arguments,
+    _load_codex_cli_runtime_idle_payload,
+)
+
+
+PrintPayload = Callable[
+    [dict[str, object], str, Callable[[dict[str, object]], str]],
+    None,
+]
+
+
+def _add_scheduler_common_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--project", default=".", help="Project directory to start from.")
+    parser.add_argument("--goal-id", help="Goal id. Defaults to <project-name>-goal.")
+    parser.add_argument(
+        "--agent-id",
+        help="Registered LoopX agent id to include in quota/claim instructions.",
+    )
+    parser.add_argument(
+        "--cli-bin",
+        default="loopx",
+        help="LoopX CLI binary name embedded in generated commands.",
+    )
+    parser.add_argument(
+        "--codex-bin",
+        default=DEFAULT_CODEX_BIN,
+        help="Codex CLI executable to probe for visible-session capabilities.",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=DEFAULT_TIMEOUT_SECONDS,
+        help="Per-command timeout for help-only Codex CLI probes.",
+    )
+    parser.add_argument(
+        "--fixture",
+        help="Public-safe JSON fixture with command_outputs, used instead of invoking Codex CLI.",
+    )
+    parser.add_argument(
+        "--proof-fixture",
+        help="Optional public-safe visible-session proof fixture. Without it, same-session automation remains blocked.",
+    )
+    _add_runtime_idle_observation_arguments(parser)
+    parser.add_argument(
+        "--allow-headless-fallback",
+        action="store_true",
+        help="Deprecated and ignored; headless codex exec is disabled for this default /goal path.",
+    )
+
+
+def register_starter_scheduler_commands(subparsers: argparse._SubParsersAction) -> None:
+    codex_cli_local_scheduler_tick_parser = subparsers.add_parser(
+        "codex-cli-local-scheduler-tick",
+        help="Build a no-execution local scheduler tick around codex-cli-visible-driver-run.",
+    )
+    _add_scheduler_common_arguments(codex_cli_local_scheduler_tick_parser)
+
+    codex_cli_local_scheduler_exec_parser = subparsers.add_parser(
+        "codex-cli-local-scheduler-exec",
+        help="Explicit opt-in executor wrapper for codex-cli-local-scheduler-tick results.",
+    )
+    _add_scheduler_common_arguments(codex_cli_local_scheduler_exec_parser)
+    codex_cli_local_scheduler_exec_parser.add_argument(
+        "--executor-timeout-seconds",
+        type=float,
+        default=DEFAULT_EXECUTOR_TIMEOUT_SECONDS,
+        help="Timeout for the explicitly executed scheduler result command.",
+    )
+    codex_cli_local_scheduler_exec_parser.add_argument(
+        "--guard-checked",
+        action="store_true",
+        help="Confirm a fresh quota/user-gate guard was checked before executing a candidate or blocker writeback.",
+    )
+    codex_cli_local_scheduler_exec_parser.add_argument(
+        "--execute-candidate",
+        action="store_true",
+        help="Execute the scheduler candidate command after guard and prefix checks.",
+    )
+    codex_cli_local_scheduler_exec_parser.add_argument(
+        "--execute-blocker-writeback",
+        action="store_true",
+        help="Execute the precise LoopX blocker writeback command after a fresh guard check.",
+    )
+    codex_cli_local_scheduler_exec_parser.add_argument(
+        "--candidate-command-prefix",
+        action="append",
+        default=[],
+        help="Allowed command prefix for --execute-candidate. Repeatable; required before candidate execution.",
+    )
+
+
+def handle_codex_cli_local_scheduler_tick_command(
+    args: argparse.Namespace,
+    print_payload: PrintPayload,
+) -> int:
+    probe_payload = run_codex_cli_session_probe(
+        codex_bin=args.codex_bin,
+        timeout_seconds=args.timeout_seconds,
+        fixture=Path(args.fixture).expanduser() if args.fixture else None,
+    )
+    proof_payload = (
+        load_codex_cli_visible_session_proof_fixture(Path(args.proof_fixture).expanduser())
+        if args.proof_fixture
+        else None
+    )
+    idle_payload = _load_codex_cli_runtime_idle_payload(args)
+    payload = build_codex_cli_local_scheduler_tick(
+        project=Path(args.project),
+        goal_id=args.goal_id,
+        agent_id=args.agent_id,
+        cli_bin=args.cli_bin,
+        codex_bin=args.codex_bin,
+        probe_payload=probe_payload,
+        proof_payload=proof_payload,
+        idle_payload=idle_payload,
+        allow_headless_fallback=bool(args.allow_headless_fallback),
+    )
+    print_payload(payload, args.format, render_codex_cli_local_scheduler_tick_markdown)
+    return 0 if payload.get("ok") else 1
+
+
+def handle_codex_cli_local_scheduler_exec_command(
+    args: argparse.Namespace,
+    print_payload: PrintPayload,
+) -> int:
+    probe_payload = run_codex_cli_session_probe(
+        codex_bin=args.codex_bin,
+        timeout_seconds=args.timeout_seconds,
+        fixture=Path(args.fixture).expanduser() if args.fixture else None,
+    )
+    proof_payload = (
+        load_codex_cli_visible_session_proof_fixture(Path(args.proof_fixture).expanduser())
+        if args.proof_fixture
+        else None
+    )
+    idle_payload = _load_codex_cli_runtime_idle_payload(args)
+    payload = build_codex_cli_local_scheduler_executor(
+        project=Path(args.project),
+        goal_id=args.goal_id,
+        agent_id=args.agent_id,
+        cli_bin=args.cli_bin,
+        codex_bin=args.codex_bin,
+        probe_payload=probe_payload,
+        proof_payload=proof_payload,
+        idle_payload=idle_payload,
+        allow_headless_fallback=bool(args.allow_headless_fallback),
+        execute_candidate=bool(args.execute_candidate),
+        execute_blocker_writeback=bool(args.execute_blocker_writeback),
+        guard_checked=bool(args.guard_checked),
+        candidate_command_prefixes=list(args.candidate_command_prefix or []),
+        executor_timeout_seconds=args.executor_timeout_seconds,
+    )
+    print_payload(payload, args.format, render_codex_cli_local_scheduler_executor_markdown)
+    return 0 if payload.get("ok") else 1
+
+
+_SCHEDULER_HANDLERS: dict[str, Callable[[argparse.Namespace, PrintPayload], int]] = {
+    "codex-cli-local-scheduler-tick": handle_codex_cli_local_scheduler_tick_command,
+    "codex-cli-local-scheduler-exec": handle_codex_cli_local_scheduler_exec_command,
+}
+
+
+def handle_starter_scheduler_command(
+    args: argparse.Namespace,
+    print_payload: PrintPayload,
+) -> int | None:
+    handler = _SCHEDULER_HANDLERS.get(str(getattr(args, "command", "")))
+    if handler is None:
+        return None
+    return handler(args, print_payload)

--- a/loopx/cli_commands/starter_session_runtime.py
+++ b/loopx/cli_commands/starter_session_runtime.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+from pathlib import Path
+
+from ..codex_cli_probe import (
+    DEFAULT_CODEX_BIN,
+    DEFAULT_TIMEOUT_SECONDS,
+    build_codex_cli_runtime_idle_detector,
+    build_codex_cli_visible_session_proof,
+    load_codex_cli_visible_session_proof_fixture,
+    render_codex_cli_runtime_idle_detector_markdown,
+    render_codex_cli_session_probe_markdown,
+    render_codex_cli_visible_session_proof_markdown,
+    run_codex_cli_session_probe,
+)
+from .starter_runtime_idle import (
+    _add_runtime_idle_observation_arguments,
+    _load_codex_cli_runtime_idle_payload,
+)
+
+
+PrintPayload = Callable[
+    [dict[str, object], str, Callable[[dict[str, object]], str]],
+    None,
+]
+
+
+def register_starter_session_runtime_commands(subparsers: argparse._SubParsersAction) -> None:
+    codex_cli_probe_parser = subparsers.add_parser(
+        "codex-cli-session-probe",
+        help="Probe Codex CLI help surfaces for same-session LoopX automation support.",
+    )
+    codex_cli_probe_parser.add_argument(
+        "--codex-bin",
+        default=DEFAULT_CODEX_BIN,
+        help="Codex CLI executable to probe with help-only commands.",
+    )
+    codex_cli_probe_parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=DEFAULT_TIMEOUT_SECONDS,
+        help="Per-command timeout for help-only Codex CLI probes.",
+    )
+    codex_cli_probe_parser.add_argument(
+        "--fixture",
+        help="Public-safe JSON fixture with command_outputs, used instead of invoking Codex CLI.",
+    )
+
+    codex_cli_visible_session_proof_parser = subparsers.add_parser(
+        "codex-cli-visible-session-proof",
+        help="Validate a public-safe proof fixture before treating Codex CLI resume or remote-control as same-session automation.",
+    )
+    codex_cli_visible_session_proof_parser.add_argument("--project", default=".", help="Project directory to start from.")
+    codex_cli_visible_session_proof_parser.add_argument("--goal-id", help="Goal id. Defaults to <project-name>-goal.")
+    codex_cli_visible_session_proof_parser.add_argument(
+        "--agent-id",
+        help="Registered LoopX agent id to include in the proof packet.",
+    )
+    codex_cli_visible_session_proof_parser.add_argument(
+        "--cli-bin",
+        default="loopx",
+        help="LoopX CLI binary name embedded in proof metadata.",
+    )
+    codex_cli_visible_session_proof_parser.add_argument(
+        "--proof-fixture",
+        help="Public-safe JSON proof fixture. When omitted, prints the required fixture shape.",
+    )
+
+    codex_cli_runtime_idle_parser = subparsers.add_parser(
+        "codex-cli-runtime-idle-detector",
+        help="Validate public-safe runtime idle evidence before a later visible Codex CLI turn.",
+    )
+    codex_cli_runtime_idle_parser.add_argument("--project", default=".", help="Project directory to start from.")
+    codex_cli_runtime_idle_parser.add_argument("--goal-id", help="Goal id. Defaults to <project-name>-goal.")
+    codex_cli_runtime_idle_parser.add_argument(
+        "--agent-id",
+        help="Registered LoopX agent id to include in the idle packet.",
+    )
+    codex_cli_runtime_idle_parser.add_argument(
+        "--cli-bin",
+        default="loopx",
+        help="LoopX CLI binary name embedded in idle detector metadata.",
+    )
+    _add_runtime_idle_observation_arguments(codex_cli_runtime_idle_parser)
+
+
+def handle_codex_cli_session_probe_command(
+    args: argparse.Namespace,
+    print_payload: PrintPayload,
+) -> int:
+    payload = run_codex_cli_session_probe(
+        codex_bin=args.codex_bin,
+        timeout_seconds=args.timeout_seconds,
+        fixture=Path(args.fixture).expanduser() if args.fixture else None,
+    )
+    print_payload(payload, args.format, render_codex_cli_session_probe_markdown)
+    return 0 if payload.get("ok") else 1
+
+
+def handle_codex_cli_visible_session_proof_command(
+    args: argparse.Namespace,
+    print_payload: PrintPayload,
+) -> int:
+    proof_payload = (
+        load_codex_cli_visible_session_proof_fixture(Path(args.proof_fixture).expanduser())
+        if args.proof_fixture
+        else None
+    )
+    payload = build_codex_cli_visible_session_proof(
+        project=Path(args.project),
+        goal_id=args.goal_id,
+        agent_id=args.agent_id,
+        cli_bin=args.cli_bin,
+        proof_payload=proof_payload,
+    )
+    print_payload(payload, args.format, render_codex_cli_visible_session_proof_markdown)
+    return 0 if payload.get("ok") else 1
+
+
+def handle_codex_cli_runtime_idle_detector_command(
+    args: argparse.Namespace,
+    print_payload: PrintPayload,
+) -> int:
+    idle_payload = _load_codex_cli_runtime_idle_payload(args)
+    payload = build_codex_cli_runtime_idle_detector(
+        project=Path(args.project),
+        goal_id=args.goal_id,
+        agent_id=args.agent_id,
+        cli_bin=args.cli_bin,
+        idle_payload=idle_payload,
+    )
+    print_payload(payload, args.format, render_codex_cli_runtime_idle_detector_markdown)
+    return 0 if payload.get("ok") else 1
+
+
+_SESSION_RUNTIME_HANDLERS: dict[str, Callable[[argparse.Namespace, PrintPayload], int]] = {
+    "codex-cli-session-probe": handle_codex_cli_session_probe_command,
+    "codex-cli-visible-session-proof": handle_codex_cli_visible_session_proof_command,
+    "codex-cli-runtime-idle-detector": handle_codex_cli_runtime_idle_detector_command,
+}
+
+
+def handle_starter_session_runtime_command(
+    args: argparse.Namespace,
+    print_payload: PrintPayload,
+) -> int | None:
+    handler = _SESSION_RUNTIME_HANDLERS.get(str(getattr(args, "command", "")))
+    if handler is None:
+        return None
+    return handler(args, print_payload)


### PR DESCRIPTION
## Summary
- extract Codex session/proof/runtime-idle starter commands into loopx/cli_commands/starter_session_runtime.py
- extract local scheduler tick/exec starter commands into loopx/cli_commands/starter_scheduler.py
- leave starter.py as a thin registration/dispatch composition layer plus demo
- add focused runtime-family modularization smoke and update starter dispatch smoke for delegation

## Validation
- python3 -m py_compile loopx/cli_commands/starter.py loopx/cli_commands/starter_scheduler.py loopx/cli_commands/starter_session_runtime.py loopx/cli_commands/starter_runtime_idle.py loopx/cli_commands/starter_visible_driver.py loopx/cli_commands/__init__.py examples/cli-starter-runtime-family-command-modularization-smoke.py examples/cli-starter-dispatch-command-modularization-smoke.py
- python3 examples/cli-starter-runtime-family-command-modularization-smoke.py
- python3 examples/cli-starter-dispatch-command-modularization-smoke.py
- python3 examples/cli-starter-visible-driver-family-command-modularization-smoke.py
- python3 examples/codex-cli-session-probe-smoke.py
- python3 examples/codex-cli-visible-session-proof-smoke.py
- python3 examples/codex-cli-runtime-idle-detector-smoke.py
- python3 examples/codex-cli-local-scheduler-tick-smoke.py
- python3 examples/codex-cli-local-scheduler-exec-smoke.py
- python3 -m py_compile loopx/__init__.py
loopx/agent_registry.py
loopx/authority.py
loopx/benchmark.py
loopx/benchmark_adapters/__init__.py
loopx/benchmark_adapters/agentissue.py
loopx/benchmark_adapters/agents_last_exam.py
loopx/benchmark_adapters/skillsbench.py
loopx/benchmark_adapters/skillsbench_acp_relay.py
loopx/benchmark_adapters/skillsbench_remote_bridge.py
loopx/benchmark_adapters/terminal_bench.py
loopx/benchmark_case_analysis.py
loopx/benchmark_case_state.py
loopx/benchmark_core/__init__.py
loopx/benchmark_core/adapter.py
loopx/benchmark_core/artifacts.py
loopx/benchmark_core/attempts.py
loopx/benchmark_core/io.py
loopx/benchmark_core/lifecycle.py
loopx/benchmark_core/loop_protocol.py
loopx/benchmark_core/observable_handles.py
loopx/benchmark_core/parity.py
loopx/benchmark_core/rounds.py
loopx/benchmark_core/run_permissions.py
loopx/benchmark_core/split_control.py
loopx/benchmark_ledger.py
loopx/benchmark_trajectory.py
loopx/bootstrap.py
loopx/boundary_authority.py
loopx/cli.py
loopx/cli_commands/__init__.py
loopx/cli_commands/agentissue_runner_flow.py
loopx/cli_commands/agents_last_exam.py
loopx/cli_commands/benchmark_boundary.py
loopx/cli_commands/benchmark_dispatch.py
loopx/cli_commands/benchmark_review_lifecycle.py
loopx/cli_commands/benchmark_run_ledger.py
loopx/cli_commands/bootstrap_connect.py
loopx/cli_commands/doctor.py
loopx/cli_commands/dreaming.py
loopx/cli_commands/history.py
loopx/cli_commands/ml_experiment.py
loopx/cli_commands/project_lifecycle.py
loopx/cli_commands/quota.py
loopx/cli_commands/registry_admin.py
loopx/cli_commands/starter.py
loopx/cli_commands/starter_bootstrap.py
loopx/cli_commands/starter_runtime_idle.py
loopx/cli_commands/starter_scheduler.py
loopx/cli_commands/starter_session_runtime.py
loopx/cli_commands/starter_visible_driver.py
loopx/cli_commands/status.py
loopx/cli_commands/support_control.py
loopx/cli_commands/terminal_bench_adapter.py
loopx/cli_commands/terminal_bench_environment_result.py
loopx/cli_commands/todo.py
loopx/cli_commands/worker_bridge.py
loopx/cli_rollout.py
loopx/codex_cli_probe.py
loopx/codex_goal_baseline.py
loopx/configure_goal.py
loopx/content_ops_surface.py
loopx/contract.py
loopx/control_plane.py
loopx/delivery_outcome.py
loopx/demo.py
loopx/diagnose.py
loopx/doctor.py
loopx/dreaming.py
loopx/execution_profile.py
loopx/feedback.py
loopx/file_lock.py
loopx/frontstage.py
loopx/global_registry.py
loopx/handoff_budget.py
loopx/heartbeat_prompt.py
loopx/history.py
loopx/interface_budget.py
loopx/materials.py
loopx/ml_experiment.py
loopx/onboarding.py
loopx/operator_gate.py
loopx/orchestration.py
loopx/paths.py
loopx/project_map.py
loopx/project_prompt.py
loopx/promotion_gate.py
loopx/quota.py
loopx/registry.py
loopx/review_packet.py
loopx/rollout_event_log.py
loopx/runtime.py
loopx/self_update.py
loopx/session_runtime.py
loopx/state_migration.py
loopx/state_projection.py
loopx/state_refresh.py
loopx/status.py
loopx/status_server.py
loopx/terminal_bench_agent.py
loopx/todo_contract.py
loopx/todos.py
loopx/upgrade.py
loopx/worker_bridge.py
- git diff --check
- for smoke in examples/cli-*-command-modularization-smoke.py; do python3 "" || exit 1; done
- loopx check --scan-path loopx/cli_commands/starter.py --scan-path loopx/cli_commands/starter_scheduler.py --scan-path loopx/cli_commands/starter_session_runtime.py --scan-path loopx/cli_commands/starter_runtime_idle.py --scan-path loopx/cli_commands/__init__.py --scan-path examples/cli-starter-runtime-family-command-modularization-smoke.py --scan-path examples/cli-starter-dispatch-command-modularization-smoke.py