### PR TITLE
Refactor starter visible pilot commands

### DIFF
--- a/examples/cli-starter-visible-driver-family-command-modularization-smoke.py
+++ b/examples/cli-starter-visible-driver-family-command-modularization-smoke.py
@@ -9,7 +9,9 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 STARTER = ROOT / "loopx" / "cli_commands" / "starter.py"
+VISIBLE_COMMON = ROOT / "loopx" / "cli_commands" / "starter_visible_common.py"
 VISIBLE_DRIVER = ROOT / "loopx" / "cli_commands" / "starter_visible_driver.py"
+VISIBLE_PILOT = ROOT / "loopx" / "cli_commands" / "starter_visible_pilot.py"
 RUNTIME_IDLE = ROOT / "loopx" / "cli_commands" / "starter_runtime_idle.py"
 INIT = ROOT / "loopx" / "cli_commands" / "__init__.py"
 VISIBLE_HELP_FIXTURE = (
@@ -20,12 +22,14 @@ VISIBLE_PROOF_FIXTURE = (
 )
 
 
-VISIBLE_DRIVER_COMMANDS = {
+VISIBLE_PILOT_COMMANDS = {
     "codex-cli-one-message-loop-pilot": ["--proof-fixture", "--allow-headless-fallback"],
     "codex-cli-visible-local-driver-pilot": ["--idle-fixture", "--allow-headless-fallback"],
     "codex-cli-bounded-visible-pilot-adapter": ["--first-response-fixture", "--idle-fixture"],
     "codex-cli-visible-first-response-capture-plan": ["--first-response-path", "--idle-path"],
     "codex-cli-visible-attach-acceptance": ["--proof-fixture", "--idle-fixture"],
+}
+VISIBLE_DRIVER_COMMANDS = {
     "codex-cli-visible-driver-plan": ["--fixture", "--codex-bin"],
     "codex-cli-local-driver-plan": ["--fixture", "--codex-bin"],
     "codex-cli-visible-driver-run": ["--proof-fixture", "--allow-headless-fallback"],
@@ -65,7 +69,9 @@ def require_json_success(result: subprocess.CompletedProcess[str]) -> dict[str, 
 
 def assert_source_shape() -> None:
     starter_source = STARTER.read_text(encoding="utf-8")
+    visible_common_source = VISIBLE_COMMON.read_text(encoding="utf-8")
     visible_driver_source = VISIBLE_DRIVER.read_text(encoding="utf-8")
+    visible_pilot_source = VISIBLE_PILOT.read_text(encoding="utf-8")
     runtime_idle_source = RUNTIME_IDLE.read_text(encoding="utf-8")
     init_source = INIT.read_text(encoding="utf-8")
 
@@ -96,6 +102,9 @@ def assert_source_shape() -> None:
     ):
         require(marker in starter_source, f"starter.py missing visible-driver delegation marker: {marker}")
 
+    for command in VISIBLE_PILOT_COMMANDS:
+        require(command in visible_pilot_source, f"starter_visible_pilot.py missing command: {command}")
+        require(command not in visible_driver_source, f"pilot command leaked into starter_visible_driver.py: {command}")
     for command in VISIBLE_DRIVER_COMMANDS:
         require(command in visible_driver_source, f"starter_visible_driver.py missing command: {command}")
 
@@ -106,6 +115,27 @@ def assert_source_shape() -> None:
         "_VISIBLE_DRIVER_HANDLERS",
     ):
         require(marker in visible_driver_source, f"starter_visible_driver.py missing marker: {marker}")
+    for marker in (
+        "register_starter_visible_pilot_commands(subparsers)",
+        "handle_starter_visible_pilot_command(args, print_payload)",
+    ):
+        require(marker in visible_driver_source, f"starter_visible_driver.py missing pilot delegation marker: {marker}")
+    for marker in (
+        "def register_starter_visible_pilot_commands(",
+        "def handle_starter_visible_pilot_command(",
+        "def handle_codex_cli_one_message_loop_pilot_command(",
+        "def handle_codex_cli_visible_attach_acceptance_command(",
+        "_VISIBLE_PILOT_HANDLERS",
+    ):
+        require(marker in visible_pilot_source, f"starter_visible_pilot.py missing marker: {marker}")
+
+    for marker in (
+        "def _add_project_arguments(",
+        "def _add_codex_probe_arguments(",
+        "def _add_optional_proof_fixture(",
+        "def _add_headless_fallback_argument(",
+    ):
+        require(marker in visible_common_source, f"starter_visible_common.py missing marker: {marker}")
 
     for marker in (
         "def _add_runtime_idle_observation_arguments(",
@@ -116,14 +146,19 @@ def assert_source_shape() -> None:
 
     for marker in (
         "handle_starter_visible_driver_command",
+        "handle_starter_visible_pilot_command",
         "register_starter_visible_driver_commands",
+        "register_starter_visible_pilot_commands",
         "handle_codex_cli_visible_driver_run_command",
     ):
         require(marker in init_source, f"__init__ omitted visible-driver export: {marker}")
 
+    require(len(visible_driver_source.splitlines()) <= 220, "starter_visible_driver.py exceeded size guard")
+    require(len(visible_pilot_source.splitlines()) <= 340, "starter_visible_pilot.py exceeded size guard")
+
 
 def assert_cli_surfaces() -> None:
-    for command, needles in VISIBLE_DRIVER_COMMANDS.items():
+    for command, needles in {**VISIBLE_PILOT_COMMANDS, **VISIBLE_DRIVER_COMMANDS}.items():
         help_text = require_success(run_cli(command, "--help"))
         for needle in needles:
             require(needle in help_text, f"{command} help omitted {needle}")

--- a/loopx/cli_commands/__init__.py
+++ b/loopx/cli_commands/__init__.py
@@ -76,16 +76,20 @@ from .starter_session_runtime import (
     register_starter_session_runtime_commands,
 )
 from .starter_visible_driver import (
-    handle_codex_cli_bounded_visible_pilot_adapter_command,
-    handle_codex_cli_visible_first_response_capture_plan_command,
     handle_codex_cli_local_driver_plan_command,
-    handle_codex_cli_one_message_loop_pilot_command,
-    handle_codex_cli_visible_attach_acceptance_command,
-    handle_codex_cli_visible_local_driver_pilot_command,
     handle_codex_cli_visible_driver_plan_command,
     handle_codex_cli_visible_driver_run_command,
     handle_starter_visible_driver_command,
     register_starter_visible_driver_commands,
+)
+from .starter_visible_pilot import (
+    handle_codex_cli_bounded_visible_pilot_adapter_command,
+    handle_codex_cli_one_message_loop_pilot_command,
+    handle_codex_cli_visible_attach_acceptance_command,
+    handle_codex_cli_visible_first_response_capture_plan_command,
+    handle_codex_cli_visible_local_driver_pilot_command,
+    handle_starter_visible_pilot_command,
+    register_starter_visible_pilot_commands,
 )
 from .status import (
     handle_check_command,
@@ -151,6 +155,7 @@ __all__ = [
     "handle_starter_scheduler_command",
     "handle_starter_session_runtime_command",
     "handle_starter_visible_driver_command",
+    "handle_starter_visible_pilot_command",
     "handle_support_control_command",
     "handle_terminal_bench_adapter_command",
     "handle_terminal_bench_environment_result_command",
@@ -175,6 +180,7 @@ __all__ = [
     "register_starter_scheduler_commands",
     "register_starter_session_runtime_commands",
     "register_starter_visible_driver_commands",
+    "register_starter_visible_pilot_commands",
     "register_status_commands",
     "register_support_control_commands",
     "register_terminal_bench_adapter_commands",

--- a/loopx/cli_commands/starter_visible_common.py
+++ b/loopx/cli_commands/starter_visible_common.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import argparse
+
+from ..codex_cli_probe import DEFAULT_CODEX_BIN, DEFAULT_TIMEOUT_SECONDS
+
+
+def _add_project_arguments(
+    parser: argparse.ArgumentParser,
+    *,
+    agent_help: str = "Registered LoopX agent id to include in quota/claim instructions.",
+) -> None:
+    parser.add_argument("--project", default=".", help="Project directory to start from.")
+    parser.add_argument("--goal-id", help="Goal id. Defaults to <project-name>-goal.")
+    parser.add_argument("--agent-id", help=agent_help)
+    parser.add_argument(
+        "--cli-bin",
+        default="loopx",
+        help="LoopX CLI binary name embedded in generated commands.",
+    )
+
+
+def _add_codex_probe_arguments(
+    parser: argparse.ArgumentParser,
+    *,
+    codex_help: str = "Codex CLI executable to probe and reference in fallback commands.",
+) -> None:
+    parser.add_argument(
+        "--codex-bin",
+        default=DEFAULT_CODEX_BIN,
+        help=codex_help,
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=DEFAULT_TIMEOUT_SECONDS,
+        help="Per-command timeout for help-only Codex CLI probes.",
+    )
+    parser.add_argument(
+        "--fixture",
+        help="Public-safe JSON fixture with command_outputs, used instead of invoking Codex CLI.",
+    )
+
+
+def _add_optional_proof_fixture(parser: argparse.ArgumentParser, *, help_text: str) -> None:
+    parser.add_argument("--proof-fixture", help=help_text)
+
+
+def _add_headless_fallback_argument(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--allow-headless-fallback",
+        action="store_true",
+        help="Deprecated and ignored; headless codex exec is disabled for this default /goal path.",
+    )

--- a/loopx/cli_commands/starter_visible_driver.py
+++ b/loopx/cli_commands/starter_visible_driver.py
@@ -5,31 +5,24 @@ from collections.abc import Callable
 from pathlib import Path
 
 from ..codex_cli_probe import (
-    DEFAULT_CODEX_BIN,
-    DEFAULT_TIMEOUT_SECONDS,
-    build_codex_cli_bounded_visible_pilot_adapter,
     build_codex_cli_local_driver_plan,
-    build_codex_cli_one_message_loop_pilot,
-    build_codex_cli_visible_attach_acceptance,
     build_codex_cli_visible_driver_plan,
     build_codex_cli_visible_driver_run_packet,
-    build_codex_cli_visible_first_response_capture_plan,
-    build_codex_cli_visible_local_driver_pilot,
-    load_codex_cli_first_response_fixture,
     load_codex_cli_visible_session_proof_fixture,
-    render_codex_cli_bounded_visible_pilot_adapter_markdown,
     render_codex_cli_local_driver_plan_markdown,
-    render_codex_cli_one_message_loop_pilot_markdown,
-    render_codex_cli_visible_attach_acceptance_markdown,
     render_codex_cli_visible_driver_plan_markdown,
     render_codex_cli_visible_driver_run_packet_markdown,
-    render_codex_cli_visible_first_response_capture_plan_markdown,
-    render_codex_cli_visible_local_driver_pilot_markdown,
     run_codex_cli_session_probe,
 )
-from .starter_runtime_idle import (
-    _add_runtime_idle_observation_arguments,
-    _load_codex_cli_runtime_idle_payload,
+from .starter_visible_common import (
+    _add_codex_probe_arguments,
+    _add_headless_fallback_argument,
+    _add_optional_proof_fixture,
+    _add_project_arguments,
+)
+from .starter_visible_pilot import (
+    handle_starter_visible_pilot_command,
+    register_starter_visible_pilot_commands,
 )
 
 
@@ -39,148 +32,8 @@ PrintPayload = Callable[
 ]
 
 
-def _add_project_arguments(
-    parser: argparse.ArgumentParser,
-    *,
-    agent_help: str = "Registered LoopX agent id to include in quota/claim instructions.",
-) -> None:
-    parser.add_argument("--project", default=".", help="Project directory to start from.")
-    parser.add_argument("--goal-id", help="Goal id. Defaults to <project-name>-goal.")
-    parser.add_argument("--agent-id", help=agent_help)
-    parser.add_argument(
-        "--cli-bin",
-        default="loopx",
-        help="LoopX CLI binary name embedded in generated commands.",
-    )
-
-
-def _add_codex_probe_arguments(
-    parser: argparse.ArgumentParser,
-    *,
-    codex_help: str = "Codex CLI executable to probe and reference in fallback commands.",
-) -> None:
-    parser.add_argument(
-        "--codex-bin",
-        default=DEFAULT_CODEX_BIN,
-        help=codex_help,
-    )
-    parser.add_argument(
-        "--timeout-seconds",
-        type=float,
-        default=DEFAULT_TIMEOUT_SECONDS,
-        help="Per-command timeout for help-only Codex CLI probes.",
-    )
-    parser.add_argument(
-        "--fixture",
-        help="Public-safe JSON fixture with command_outputs, used instead of invoking Codex CLI.",
-    )
-
-
-def _add_optional_proof_fixture(parser: argparse.ArgumentParser, *, help_text: str) -> None:
-    parser.add_argument("--proof-fixture", help=help_text)
-
-
-def _add_headless_fallback_argument(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument(
-        "--allow-headless-fallback",
-        action="store_true",
-        help="Deprecated and ignored; headless codex exec is disabled for this default /goal path.",
-    )
-
-
 def register_starter_visible_driver_commands(subparsers: argparse._SubParsersAction) -> None:
-    codex_cli_one_message_loop_parser = subparsers.add_parser(
-        "codex-cli-one-message-loop-pilot",
-        help="Compose the first Codex CLI TUI paste message with the safe scheduler/executor bridge.",
-    )
-    _add_project_arguments(codex_cli_one_message_loop_parser)
-    _add_codex_probe_arguments(
-        codex_cli_one_message_loop_parser,
-        codex_help="Codex CLI executable to probe and reference in bridge commands.",
-    )
-    _add_optional_proof_fixture(
-        codex_cli_one_message_loop_parser,
-        help_text=(
-            "Optional public-safe visible-session proof fixture. "
-            "Without it, same-session automation remains blocked."
-        ),
-    )
-    _add_runtime_idle_observation_arguments(codex_cli_one_message_loop_parser)
-    _add_headless_fallback_argument(codex_cli_one_message_loop_parser)
-
-    codex_cli_visible_local_driver_parser = subparsers.add_parser(
-        "codex-cli-visible-local-driver-pilot",
-        help="Compose the one-message TUI start and later scheduler bridge into a visible local driver pilot packet.",
-    )
-    _add_project_arguments(codex_cli_visible_local_driver_parser)
-    _add_codex_probe_arguments(
-        codex_cli_visible_local_driver_parser,
-        codex_help="Codex CLI executable to probe and reference in bridge commands.",
-    )
-    _add_optional_proof_fixture(
-        codex_cli_visible_local_driver_parser,
-        help_text="Optional public-safe visible-session proof fixture. Without it, later visible turns remain blocked.",
-    )
-    codex_cli_visible_local_driver_parser.add_argument(
-        "--idle-fixture",
-        help="Optional public-safe runtime idle fixture. Without it, later visible turn candidates remain blocked.",
-    )
-    _add_runtime_idle_observation_arguments(
-        codex_cli_visible_local_driver_parser,
-        include_idle_fixture=False,
-    )
-    _add_headless_fallback_argument(codex_cli_visible_local_driver_parser)
-
-    codex_cli_bounded_visible_parser = subparsers.add_parser(
-        "codex-cli-bounded-visible-pilot-adapter",
-        help="Validate public-safe first-response and idle evidence before claiming Codex CLI live TUI bootstrap success.",
-    )
-    _add_project_arguments(
-        codex_cli_bounded_visible_parser,
-        agent_help="Registered LoopX agent id to include in adapter commands.",
-    )
-    codex_cli_bounded_visible_parser.add_argument(
-        "--first-response-fixture",
-        help="Public-safe JSON fixture proving the first visible TUI response shape.",
-    )
-    _add_runtime_idle_observation_arguments(codex_cli_bounded_visible_parser)
-
-    codex_cli_first_response_capture_parser = subparsers.add_parser(
-        "codex-cli-visible-first-response-capture-plan",
-        help="Plan the public-safe manual visible capture of Codex CLI first-response and idle fixtures.",
-    )
-    _add_project_arguments(
-        codex_cli_first_response_capture_parser,
-        agent_help="Registered LoopX agent id to include in generated commands.",
-    )
-    codex_cli_first_response_capture_parser.add_argument(
-        "--first-response-path",
-        default="public-first-response.json",
-        help="Public-safe first-response fixture path used in generated commands.",
-    )
-    codex_cli_first_response_capture_parser.add_argument(
-        "--idle-path",
-        default="public-runtime-idle.json",
-        help="Public-safe runtime idle fixture path used in generated commands.",
-    )
-
-    codex_cli_visible_attach_acceptance_parser = subparsers.add_parser(
-        "codex-cli-visible-attach-acceptance",
-        help="Accept or block same-TUI Codex CLI visible attach from help-only probe, proof, and idle evidence.",
-    )
-    _add_project_arguments(
-        codex_cli_visible_attach_acceptance_parser,
-        agent_help="Registered LoopX agent id to include in acceptance commands.",
-    )
-    _add_codex_probe_arguments(
-        codex_cli_visible_attach_acceptance_parser,
-        codex_help="Codex CLI executable to probe and reference in fallback commands.",
-    )
-    _add_optional_proof_fixture(
-        codex_cli_visible_attach_acceptance_parser,
-        help_text="Optional public-safe visible-session proof fixture. Without it, same-TUI attach is not accepted.",
-    )
-    _add_runtime_idle_observation_arguments(codex_cli_visible_attach_acceptance_parser)
+    register_starter_visible_pilot_commands(subparsers)
 
     codex_cli_visible_driver_parser = subparsers.add_parser(
         "codex-cli-visible-driver-plan",
@@ -216,133 +69,6 @@ def register_starter_visible_driver_commands(subparsers: argparse._SubParsersAct
         ),
     )
     _add_headless_fallback_argument(codex_cli_visible_driver_run_parser)
-
-
-def handle_codex_cli_one_message_loop_pilot_command(
-    args: argparse.Namespace,
-    print_payload: PrintPayload,
-) -> int:
-    probe_payload = run_codex_cli_session_probe(
-        codex_bin=args.codex_bin,
-        timeout_seconds=args.timeout_seconds,
-        fixture=Path(args.fixture).expanduser() if args.fixture else None,
-    )
-    proof_payload = (
-        load_codex_cli_visible_session_proof_fixture(Path(args.proof_fixture).expanduser())
-        if args.proof_fixture
-        else None
-    )
-    idle_payload = _load_codex_cli_runtime_idle_payload(args)
-    payload = build_codex_cli_one_message_loop_pilot(
-        project=Path(args.project),
-        goal_id=args.goal_id,
-        agent_id=args.agent_id,
-        cli_bin=args.cli_bin,
-        codex_bin=args.codex_bin,
-        probe_payload=probe_payload,
-        proof_payload=proof_payload,
-        idle_payload=idle_payload,
-        allow_headless_fallback=bool(args.allow_headless_fallback),
-    )
-    print_payload(payload, args.format, render_codex_cli_one_message_loop_pilot_markdown)
-    return 0 if payload.get("ok") else 1
-
-
-def handle_codex_cli_visible_local_driver_pilot_command(
-    args: argparse.Namespace,
-    print_payload: PrintPayload,
-) -> int:
-    probe_payload = run_codex_cli_session_probe(
-        codex_bin=args.codex_bin,
-        timeout_seconds=args.timeout_seconds,
-        fixture=Path(args.fixture).expanduser() if args.fixture else None,
-    )
-    proof_payload = (
-        load_codex_cli_visible_session_proof_fixture(Path(args.proof_fixture).expanduser())
-        if args.proof_fixture
-        else None
-    )
-    idle_payload = _load_codex_cli_runtime_idle_payload(args)
-    payload = build_codex_cli_visible_local_driver_pilot(
-        project=Path(args.project),
-        goal_id=args.goal_id,
-        agent_id=args.agent_id,
-        cli_bin=args.cli_bin,
-        codex_bin=args.codex_bin,
-        probe_payload=probe_payload,
-        proof_payload=proof_payload,
-        idle_payload=idle_payload,
-        allow_headless_fallback=bool(args.allow_headless_fallback),
-    )
-    print_payload(payload, args.format, render_codex_cli_visible_local_driver_pilot_markdown)
-    return 0 if payload.get("ok") else 1
-
-
-def handle_codex_cli_bounded_visible_pilot_adapter_command(
-    args: argparse.Namespace,
-    print_payload: PrintPayload,
-) -> int:
-    first_response_payload = (
-        load_codex_cli_first_response_fixture(Path(args.first_response_fixture).expanduser())
-        if args.first_response_fixture
-        else None
-    )
-    idle_payload = _load_codex_cli_runtime_idle_payload(args)
-    payload = build_codex_cli_bounded_visible_pilot_adapter(
-        project=Path(args.project),
-        goal_id=args.goal_id,
-        agent_id=args.agent_id,
-        cli_bin=args.cli_bin,
-        first_response_payload=first_response_payload,
-        idle_payload=idle_payload,
-    )
-    print_payload(payload, args.format, render_codex_cli_bounded_visible_pilot_adapter_markdown)
-    return 0 if payload.get("ok") else 1
-
-
-def handle_codex_cli_visible_first_response_capture_plan_command(
-    args: argparse.Namespace,
-    print_payload: PrintPayload,
-) -> int:
-    payload = build_codex_cli_visible_first_response_capture_plan(
-        project=Path(args.project),
-        goal_id=args.goal_id,
-        agent_id=args.agent_id,
-        cli_bin=args.cli_bin,
-        first_response_path=args.first_response_path,
-        idle_path=args.idle_path,
-    )
-    print_payload(payload, args.format, render_codex_cli_visible_first_response_capture_plan_markdown)
-    return 0 if payload.get("ok") else 1
-
-
-def handle_codex_cli_visible_attach_acceptance_command(
-    args: argparse.Namespace,
-    print_payload: PrintPayload,
-) -> int:
-    probe_payload = run_codex_cli_session_probe(
-        codex_bin=args.codex_bin,
-        timeout_seconds=args.timeout_seconds,
-        fixture=Path(args.fixture).expanduser() if args.fixture else None,
-    )
-    proof_payload = (
-        load_codex_cli_visible_session_proof_fixture(Path(args.proof_fixture).expanduser())
-        if args.proof_fixture
-        else None
-    )
-    idle_payload = _load_codex_cli_runtime_idle_payload(args)
-    payload = build_codex_cli_visible_attach_acceptance(
-        project=Path(args.project),
-        goal_id=args.goal_id,
-        agent_id=args.agent_id,
-        cli_bin=args.cli_bin,
-        codex_bin=args.codex_bin,
-        probe_payload=probe_payload,
-        proof_payload=proof_payload,
-        idle_payload=idle_payload,
-    )
-    print_payload(payload, args.format, render_codex_cli_visible_attach_acceptance_markdown)
-    return 0 if payload.get("ok") else 1
 
 
 def handle_codex_cli_visible_driver_plan_command(
@@ -416,11 +142,6 @@ def handle_codex_cli_visible_driver_run_command(
 
 
 _VISIBLE_DRIVER_HANDLERS: dict[str, Callable[[argparse.Namespace, PrintPayload], int]] = {
-    "codex-cli-one-message-loop-pilot": handle_codex_cli_one_message_loop_pilot_command,
-    "codex-cli-visible-local-driver-pilot": handle_codex_cli_visible_local_driver_pilot_command,
-    "codex-cli-bounded-visible-pilot-adapter": handle_codex_cli_bounded_visible_pilot_adapter_command,
-    "codex-cli-visible-first-response-capture-plan": handle_codex_cli_visible_first_response_capture_plan_command,
-    "codex-cli-visible-attach-acceptance": handle_codex_cli_visible_attach_acceptance_command,
     "codex-cli-visible-driver-plan": handle_codex_cli_visible_driver_plan_command,
     "codex-cli-local-driver-plan": handle_codex_cli_local_driver_plan_command,
     "codex-cli-visible-driver-run": handle_codex_cli_visible_driver_run_command,
@@ -431,6 +152,9 @@ def handle_starter_visible_driver_command(
     args: argparse.Namespace,
     print_payload: PrintPayload,
 ) -> int | None:
+    pilot_result = handle_starter_visible_pilot_command(args, print_payload)
+    if pilot_result is not None:
+        return pilot_result
     handler = _VISIBLE_DRIVER_HANDLERS.get(str(getattr(args, "command", "")))
     if handler is None:
         return None

--- a/loopx/cli_commands/starter_visible_pilot.py
+++ b/loopx/cli_commands/starter_visible_pilot.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+from pathlib import Path
+
+from ..codex_cli_probe import (
+    build_codex_cli_bounded_visible_pilot_adapter,
+    build_codex_cli_one_message_loop_pilot,
+    build_codex_cli_visible_attach_acceptance,
+    build_codex_cli_visible_first_response_capture_plan,
+    build_codex_cli_visible_local_driver_pilot,
+    load_codex_cli_first_response_fixture,
+    load_codex_cli_visible_session_proof_fixture,
+    render_codex_cli_bounded_visible_pilot_adapter_markdown,
+    render_codex_cli_one_message_loop_pilot_markdown,
+    render_codex_cli_visible_attach_acceptance_markdown,
+    render_codex_cli_visible_first_response_capture_plan_markdown,
+    render_codex_cli_visible_local_driver_pilot_markdown,
+    run_codex_cli_session_probe,
+)
+from .starter_runtime_idle import (
+    _add_runtime_idle_observation_arguments,
+    _load_codex_cli_runtime_idle_payload,
+)
+from .starter_visible_common import (
+    _add_codex_probe_arguments,
+    _add_headless_fallback_argument,
+    _add_optional_proof_fixture,
+    _add_project_arguments,
+)
+
+
+PrintPayload = Callable[
+    [dict[str, object], str, Callable[[dict[str, object]], str]],
+    None,
+]
+
+
+def register_starter_visible_pilot_commands(subparsers: argparse._SubParsersAction) -> None:
+    codex_cli_one_message_loop_parser = subparsers.add_parser(
+        "codex-cli-one-message-loop-pilot",
+        help="Compose the first Codex CLI TUI paste message with the safe scheduler/executor bridge.",
+    )
+    _add_project_arguments(codex_cli_one_message_loop_parser)
+    _add_codex_probe_arguments(
+        codex_cli_one_message_loop_parser,
+        codex_help="Codex CLI executable to probe and reference in bridge commands.",
+    )
+    _add_optional_proof_fixture(
+        codex_cli_one_message_loop_parser,
+        help_text=(
+            "Optional public-safe visible-session proof fixture. "
+            "Without it, same-session automation remains blocked."
+        ),
+    )
+    _add_runtime_idle_observation_arguments(codex_cli_one_message_loop_parser)
+    _add_headless_fallback_argument(codex_cli_one_message_loop_parser)
+
+    codex_cli_visible_local_driver_parser = subparsers.add_parser(
+        "codex-cli-visible-local-driver-pilot",
+        help="Compose the one-message TUI start and later scheduler bridge into a visible local driver pilot packet.",
+    )
+    _add_project_arguments(codex_cli_visible_local_driver_parser)
+    _add_codex_probe_arguments(
+        codex_cli_visible_local_driver_parser,
+        codex_help="Codex CLI executable to probe and reference in bridge commands.",
+    )
+    _add_optional_proof_fixture(
+        codex_cli_visible_local_driver_parser,
+        help_text="Optional public-safe visible-session proof fixture. Without it, later visible turns remain blocked.",
+    )
+    codex_cli_visible_local_driver_parser.add_argument(
+        "--idle-fixture",
+        help="Optional public-safe runtime idle fixture. Without it, later visible turn candidates remain blocked.",
+    )
+    _add_runtime_idle_observation_arguments(
+        codex_cli_visible_local_driver_parser,
+        include_idle_fixture=False,
+    )
+    _add_headless_fallback_argument(codex_cli_visible_local_driver_parser)
+
+    codex_cli_bounded_visible_parser = subparsers.add_parser(
+        "codex-cli-bounded-visible-pilot-adapter",
+        help="Validate public-safe first-response and idle evidence before claiming Codex CLI live TUI bootstrap success.",
+    )
+    _add_project_arguments(
+        codex_cli_bounded_visible_parser,
+        agent_help="Registered LoopX agent id to include in adapter commands.",
+    )
+    codex_cli_bounded_visible_parser.add_argument(
+        "--first-response-fixture",
+        help="Public-safe JSON fixture proving the first visible TUI response shape.",
+    )
+    _add_runtime_idle_observation_arguments(codex_cli_bounded_visible_parser)
+
+    codex_cli_first_response_capture_parser = subparsers.add_parser(
+        "codex-cli-visible-first-response-capture-plan",
+        help="Plan the public-safe manual visible capture of Codex CLI first-response and idle fixtures.",
+    )
+    _add_project_arguments(
+        codex_cli_first_response_capture_parser,
+        agent_help="Registered LoopX agent id to include in generated commands.",
+    )
+    codex_cli_first_response_capture_parser.add_argument(
+        "--first-response-path",
+        default="public-first-response.json",
+        help="Public-safe first-response fixture path used in generated commands.",
+    )
+    codex_cli_first_response_capture_parser.add_argument(
+        "--idle-path",
+        default="public-runtime-idle.json",
+        help="Public-safe runtime idle fixture path used in generated commands.",
+    )
+
+    codex_cli_visible_attach_acceptance_parser = subparsers.add_parser(
+        "codex-cli-visible-attach-acceptance",
+        help="Accept or block same-TUI Codex CLI visible attach from help-only probe, proof, and idle evidence.",
+    )
+    _add_project_arguments(
+        codex_cli_visible_attach_acceptance_parser,
+        agent_help="Registered LoopX agent id to include in acceptance commands.",
+    )
+    _add_codex_probe_arguments(
+        codex_cli_visible_attach_acceptance_parser,
+        codex_help="Codex CLI executable to probe and reference in fallback commands.",
+    )
+    _add_optional_proof_fixture(
+        codex_cli_visible_attach_acceptance_parser,
+        help_text="Optional public-safe visible-session proof fixture. Without it, same-TUI attach is not accepted.",
+    )
+    _add_runtime_idle_observation_arguments(codex_cli_visible_attach_acceptance_parser)
+
+
+def handle_codex_cli_one_message_loop_pilot_command(
+    args: argparse.Namespace,
+    print_payload: PrintPayload,
+) -> int:
+    probe_payload = run_codex_cli_session_probe(
+        codex_bin=args.codex_bin,
+        timeout_seconds=args.timeout_seconds,
+        fixture=Path(args.fixture).expanduser() if args.fixture else None,
+    )
+    proof_payload = (
+        load_codex_cli_visible_session_proof_fixture(Path(args.proof_fixture).expanduser())
+        if args.proof_fixture
+        else None
+    )
+    idle_payload = _load_codex_cli_runtime_idle_payload(args)
+    payload = build_codex_cli_one_message_loop_pilot(
+        project=Path(args.project),
+        goal_id=args.goal_id,
+        agent_id=args.agent_id,
+        cli_bin=args.cli_bin,
+        codex_bin=args.codex_bin,
+        probe_payload=probe_payload,
+        proof_payload=proof_payload,
+        idle_payload=idle_payload,
+        allow_headless_fallback=bool(args.allow_headless_fallback),
+    )
+    print_payload(payload, args.format, render_codex_cli_one_message_loop_pilot_markdown)
+    return 0 if payload.get("ok") else 1
+
+
+def handle_codex_cli_visible_local_driver_pilot_command(
+    args: argparse.Namespace,
+    print_payload: PrintPayload,
+) -> int:
+    probe_payload = run_codex_cli_session_probe(
+        codex_bin=args.codex_bin,
+        timeout_seconds=args.timeout_seconds,
+        fixture=Path(args.fixture).expanduser() if args.fixture else None,
+    )
+    proof_payload = (
+        load_codex_cli_visible_session_proof_fixture(Path(args.proof_fixture).expanduser())
+        if args.proof_fixture
+        else None
+    )
+    idle_payload = _load_codex_cli_runtime_idle_payload(args)
+    payload = build_codex_cli_visible_local_driver_pilot(
+        project=Path(args.project),
+        goal_id=args.goal_id,
+        agent_id=args.agent_id,
+        cli_bin=args.cli_bin,
+        codex_bin=args.codex_bin,
+        probe_payload=probe_payload,
+        proof_payload=proof_payload,
+        idle_payload=idle_payload,
+        allow_headless_fallback=bool(args.allow_headless_fallback),
+    )
+    print_payload(payload, args.format, render_codex_cli_visible_local_driver_pilot_markdown)
+    return 0 if payload.get("ok") else 1
+
+
+def handle_codex_cli_bounded_visible_pilot_adapter_command(
+    args: argparse.Namespace,
+    print_payload: PrintPayload,
+) -> int:
+    first_response_payload = (
+        load_codex_cli_first_response_fixture(Path(args.first_response_fixture).expanduser())
+        if args.first_response_fixture
+        else None
+    )
+    idle_payload = _load_codex_cli_runtime_idle_payload(args)
+    payload = build_codex_cli_bounded_visible_pilot_adapter(
+        project=Path(args.project),
+        goal_id=args.goal_id,
+        agent_id=args.agent_id,
+        cli_bin=args.cli_bin,
+        first_response_payload=first_response_payload,
+        idle_payload=idle_payload,
+    )
+    print_payload(payload, args.format, render_codex_cli_bounded_visible_pilot_adapter_markdown)
+    return 0 if payload.get("ok") else 1
+
+
+def handle_codex_cli_visible_first_response_capture_plan_command(
+    args: argparse.Namespace,
+    print_payload: PrintPayload,
+) -> int:
+    payload = build_codex_cli_visible_first_response_capture_plan(
+        project=Path(args.project),
+        goal_id=args.goal_id,
+        agent_id=args.agent_id,
+        cli_bin=args.cli_bin,
+        first_response_path=args.first_response_path,
+        idle_path=args.idle_path,
+    )
+    print_payload(payload, args.format, render_codex_cli_visible_first_response_capture_plan_markdown)
+    return 0 if payload.get("ok") else 1
+
+
+def handle_codex_cli_visible_attach_acceptance_command(
+    args: argparse.Namespace,
+    print_payload: PrintPayload,
+) -> int:
+    probe_payload = run_codex_cli_session_probe(
+        codex_bin=args.codex_bin,
+        timeout_seconds=args.timeout_seconds,
+        fixture=Path(args.fixture).expanduser() if args.fixture else None,
+    )
+    proof_payload = (
+        load_codex_cli_visible_session_proof_fixture(Path(args.proof_fixture).expanduser())
+        if args.proof_fixture
+        else None
+    )
+    idle_payload = _load_codex_cli_runtime_idle_payload(args)
+    payload = build_codex_cli_visible_attach_acceptance(
+        project=Path(args.project),
+        goal_id=args.goal_id,
+        agent_id=args.agent_id,
+        cli_bin=args.cli_bin,
+        codex_bin=args.codex_bin,
+        probe_payload=probe_payload,
+        proof_payload=proof_payload,
+        idle_payload=idle_payload,
+    )
+    print_payload(payload, args.format, render_codex_cli_visible_attach_acceptance_markdown)
+    return 0 if payload.get("ok") else 1
+
+
+_VISIBLE_PILOT_HANDLERS: dict[str, Callable[[argparse.Namespace, PrintPayload], int]] = {
+    "codex-cli-one-message-loop-pilot": handle_codex_cli_one_message_loop_pilot_command,
+    "codex-cli-visible-local-driver-pilot": handle_codex_cli_visible_local_driver_pilot_command,
+    "codex-cli-bounded-visible-pilot-adapter": handle_codex_cli_bounded_visible_pilot_adapter_command,
+    "codex-cli-visible-first-response-capture-plan": handle_codex_cli_visible_first_response_capture_plan_command,
+    "codex-cli-visible-attach-acceptance": handle_codex_cli_visible_attach_acceptance_command,
+}
+
+
+def handle_starter_visible_pilot_command(
+    args: argparse.Namespace,
+    print_payload: PrintPayload,
+) -> int | None:
+    handler = _VISIBLE_PILOT_HANDLERS.get(str(getattr(args, "command", "")))
+    if handler is None:
+        return None
+    return handler(args, print_payload)


### PR DESCRIPTION
## Summary
- extract visible pilot/adapter/capture/attach commands from starter_visible_driver.py into starter_visible_pilot.py
- move shared visible starter argparse helpers into starter_visible_common.py
- keep starter_visible_driver.py focused on visible-driver plan/local-driver/run and delegate pilot commands
- extend visible-driver modularization smoke with module ownership and size guards

## Validation
- python3 -m py_compile loopx/cli_commands/starter_visible_common.py loopx/cli_commands/starter_visible_pilot.py loopx/cli_commands/starter_visible_driver.py loopx/cli_commands/__init__.py examples/cli-starter-visible-driver-family-command-modularization-smoke.py
- python3 examples/cli-starter-visible-driver-family-command-modularization-smoke.py
- python3 examples/codex-cli-one-message-loop-pilot-smoke.py
- python3 examples/codex-cli-visible-local-driver-pilot-smoke.py
- python3 examples/codex-cli-bounded-visible-pilot-adapter-smoke.py
- python3 examples/codex-cli-visible-first-response-capture-plan-smoke.py
- python3 examples/codex-cli-visible-attach-acceptance-smoke.py
- python3 examples/codex-cli-visible-driver-run-smoke.py
- python3 examples/codex-cli-local-driver-plan-smoke.py
- python3 examples/codex-cli-session-probe-smoke.py
- python3 -m py_compile loopx/__init__.py
loopx/agent_registry.py
loopx/authority.py
loopx/benchmark.py
loopx/benchmark_adapters/__init__.py
loopx/benchmark_adapters/agentissue.py
loopx/benchmark_adapters/agents_last_exam.py
loopx/benchmark_adapters/skillsbench.py
loopx/benchmark_adapters/skillsbench_acp_relay.py
loopx/benchmark_adapters/skillsbench_remote_bridge.py
loopx/benchmark_adapters/terminal_bench.py
loopx/benchmark_case_analysis.py
loopx/benchmark_case_state.py
loopx/benchmark_core/__init__.py
loopx/benchmark_core/adapter.py
loopx/benchmark_core/artifacts.py
loopx/benchmark_core/attempts.py
loopx/benchmark_core/io.py
loopx/benchmark_core/lifecycle.py
loopx/benchmark_core/loop_protocol.py
loopx/benchmark_core/observable_handles.py
loopx/benchmark_core/parity.py
loopx/benchmark_core/rounds.py
loopx/benchmark_core/run_permissions.py
loopx/benchmark_core/split_control.py
loopx/benchmark_ledger.py
loopx/benchmark_trajectory.py
loopx/bootstrap.py
loopx/boundary_authority.py
loopx/cli.py
loopx/cli_commands/__init__.py
loopx/cli_commands/agentissue_runner_flow.py
loopx/cli_commands/agents_last_exam.py
loopx/cli_commands/benchmark_boundary.py
loopx/cli_commands/benchmark_dispatch.py
loopx/cli_commands/benchmark_review_lifecycle.py
loopx/cli_commands/benchmark_run_ledger.py
loopx/cli_commands/bootstrap_connect.py
loopx/cli_commands/doctor.py
loopx/cli_commands/dreaming.py
loopx/cli_commands/history.py
loopx/cli_commands/ml_experiment.py
loopx/cli_commands/project_lifecycle.py
loopx/cli_commands/quota.py
loopx/cli_commands/registry_admin.py
loopx/cli_commands/starter.py
loopx/cli_commands/starter_bootstrap.py
loopx/cli_commands/starter_runtime_idle.py
loopx/cli_commands/starter_scheduler.py
loopx/cli_commands/starter_session_runtime.py
loopx/cli_commands/starter_visible_common.py
loopx/cli_commands/starter_visible_driver.py
loopx/cli_commands/starter_visible_pilot.py
loopx/cli_commands/status.py
loopx/cli_commands/support_control.py
loopx/cli_commands/terminal_bench_adapter.py
loopx/cli_commands/terminal_bench_environment_result.py
loopx/cli_commands/todo.py
loopx/cli_commands/worker_bridge.py
loopx/cli_rollout.py
loopx/codex_cli_probe.py
loopx/codex_goal_baseline.py
loopx/configure_goal.py
loopx/content_ops_surface.py
loopx/contract.py
loopx/control_plane.py
loopx/delivery_outcome.py
loopx/demo.py
loopx/diagnose.py
loopx/doctor.py
loopx/dreaming.py
loopx/execution_profile.py
loopx/feedback.py
loopx/file_lock.py
loopx/frontstage.py
loopx/global_registry.py
loopx/handoff_budget.py
loopx/heartbeat_prompt.py
loopx/history.py
loopx/interface_budget.py
loopx/materials.py
loopx/ml_experiment.py
loopx/onboarding.py
loopx/operator_gate.py
loopx/orchestration.py
loopx/paths.py
loopx/project_map.py
loopx/project_prompt.py
loopx/promotion_gate.py
loopx/quota.py
loopx/registry.py
loopx/review_packet.py
loopx/rollout_event_log.py
loopx/runtime.py
loopx/self_update.py
loopx/session_runtime.py
loopx/state_migration.py
loopx/state_projection.py
loopx/state_refresh.py
loopx/status.py
loopx/status_server.py
loopx/terminal_bench_agent.py
loopx/todo_contract.py
loopx/todos.py
loopx/upgrade.py
loopx/worker_bridge.py
- git diff --check
- for smoke in examples/cli-*-command-modularization-smoke.py; do python3 "" || exit 1; done
- loopx check --scan-path loopx/cli_commands/starter_visible_driver.py --scan-path loopx/cli_commands/starter_visible_pilot.py --scan-path loopx/cli_commands/starter_visible_common.py --scan-path loopx/cli_commands/__init__.py --scan-path examples/cli-starter-visible-driver-family-command-modularization-smoke.py