### PR TITLE
Extract ALE local plan CLI command family

### DIFF
--- a/examples/cli-agents-last-exam-command-modularization-smoke.py
+++ b/examples/cli-agents-last-exam-command-modularization-smoke.py
@@ -37,6 +37,9 @@ def main() -> int:
     ale_source = (ROOT / "loopx" / "cli_commands" / "agents_last_exam.py").read_text(
         encoding="utf-8"
     )
+    local_plan_source = (
+        ROOT / "loopx" / "cli_commands" / "agents_last_exam_local_plan.py"
+    ).read_text(encoding="utf-8")
 
     leaked_markers = [
         "ale_local_preflight_parser = benchmark_sub.add_parser",
@@ -55,8 +58,28 @@ def main() -> int:
     assert_contains(dispatch_source, "handle_agents_last_exam_command(")
     assert_contains(init_source, "register_agents_last_exam_commands")
     assert_contains(init_source, "handle_agents_last_exam_command")
+    assert_contains(init_source, "register_agents_last_exam_local_plan_commands")
+    assert_contains(init_source, "handle_agents_last_exam_local_plan_command")
     assert_contains(ale_source, "AGENTS_LAST_EXAM_COMMANDS")
     assert_contains(ale_source, "ale-validation-run-gate")
+    assert_contains(
+        ale_source,
+        "register_agents_last_exam_local_plan_commands(",
+    )
+    assert_contains(
+        ale_source,
+        "handle_agents_last_exam_local_plan_command(",
+    )
+    for marker in (
+        "def render_agents_last_exam_local_preflight_markdown",
+        "def render_agents_last_exam_local_dry_run_plan_markdown",
+        "build_agents_last_exam_local_preflight(",
+        "build_agents_last_exam_local_dry_run_plan(",
+        'if args.benchmark_command == "ale-local-preflight":',
+    ):
+        if marker in ale_source:
+            raise AssertionError(f"{marker} leaked back into agents_last_exam.py")
+        assert_contains(local_plan_source, marker)
 
     help_result = run_cli("benchmark", "ale-validation-run-gate", "--help")
     if help_result.returncode != 0:

--- a/examples/cli-command-module-size-ownership-command-modularization-smoke.py
+++ b/examples/cli-command-module-size-ownership-command-modularization-smoke.py
@@ -10,7 +10,7 @@ CLI_COMMANDS = ROOT / "loopx" / "cli_commands"
 
 DEFAULT_MAX_LINES = 500
 LEGACY_MODULE_LIMITS = {
-    "agents_last_exam.py": 2100,
+    "agents_last_exam.py": 1850,
     "benchmark_review_lifecycle.py": 1300,
     "benchmark_run_ledger.py": 1360,
     "history.py": 720,

--- a/loopx/cli_commands/__init__.py
+++ b/loopx/cli_commands/__init__.py
@@ -12,6 +12,10 @@ from .agents_last_exam import (
     handle_agents_last_exam_command,
     register_agents_last_exam_commands,
 )
+from .agents_last_exam_local_plan import (
+    handle_agents_last_exam_local_plan_command,
+    register_agents_last_exam_local_plan_commands,
+)
 from .agentissue_runner_flow import (
     handle_agentissue_runner_flow_command,
     register_agentissue_runner_flow_commands,
@@ -115,6 +119,7 @@ from .worker_bridge import handle_worker_bridge_command, register_worker_bridge_
 
 __all__ = [
     "handle_agents_last_exam_command",
+    "handle_agents_last_exam_local_plan_command",
     "handle_agentissue_runner_flow_command",
     "handle_benchmark_boundary_command",
     "handle_benchmark_command",
@@ -162,6 +167,7 @@ __all__ = [
     "handle_todo_command",
     "handle_worker_bridge_command",
     "register_agents_last_exam_commands",
+    "register_agents_last_exam_local_plan_commands",
     "register_agentissue_runner_flow_commands",
     "register_benchmark_boundary_commands",
     "register_benchmark_command_group",

--- a/loopx/cli_commands/agents_last_exam.py
+++ b/loopx/cli_commands/agents_last_exam.py
@@ -14,14 +14,17 @@ from ..benchmark_adapters.agents_last_exam import (
     build_agents_last_exam_candidate_task_data_scan,
     build_agents_last_exam_host_codex_cli_route,
     build_agents_last_exam_host_codex_cua_no_task_smoke_from_environment,
-    build_agents_last_exam_local_dry_run_plan,
     build_agents_last_exam_local_exact_dry_run_result,
     build_agents_last_exam_local_launch_packet,
-    build_agents_last_exam_local_preflight,
     build_agents_last_exam_local_runner_readiness,
     build_agents_last_exam_local_source_readiness,
     build_agents_last_exam_task_material_readiness,
     build_agents_last_exam_validation_run_gate,
+)
+from .agents_last_exam_local_plan import (
+    AGENTS_LAST_EXAM_LOCAL_PLAN_COMMANDS,
+    handle_agents_last_exam_local_plan_command,
+    register_agents_last_exam_local_plan_commands,
 )
 
 
@@ -32,8 +35,6 @@ PrintPayload = Callable[
 OutputFormat = Callable[[argparse.Namespace], str]
 
 AGENTS_LAST_EXAM_COMMANDS = {
-    "ale-local-preflight",
-    "ale-local-dry-run-plan",
     "ale-local-runner-readiness",
     "ale-local-source-readiness",
     "ale-task-material-readiness",
@@ -45,83 +46,7 @@ AGENTS_LAST_EXAM_COMMANDS = {
     "ale-host-codex-cli-route",
     "ale-host-codex-cua-no-task-e2e",
     "ale-validation-run-gate",
-}
-
-
-def render_agents_last_exam_local_preflight_markdown(payload: dict[str, object]) -> str:
-    provider = (
-        payload.get("provider") if isinstance(payload.get("provider"), dict) else {}
-    )
-    required_image = (
-        provider.get("required_image")
-        if isinstance(provider.get("required_image"), dict)
-        else {}
-    )
-    boundary = (
-        payload.get("boundary") if isinstance(payload.get("boundary"), dict) else {}
-    )
-    decision = (
-        payload.get("decision") if isinstance(payload.get("decision"), dict) else {}
-    )
-    read_boundary = (
-        payload.get("read_boundary")
-        if isinstance(payload.get("read_boundary"), dict)
-        else {}
-    )
-    lines = [
-        "# Agents Last Exam Local Preflight",
-        "",
-        f"- Schema: `{payload.get('schema_version')}`",
-        f"- Task: `{payload.get('task_id')}`",
-        f"- Snapshot: `{payload.get('snapshot')}`",
-        f"- Ready: `{payload.get('ready')}`",
-        f"- First blocker: `{payload.get('first_blocker')}`",
-        f"- Provider: `{provider.get('kind')}`",
-        f"- No cloud: `{provider.get('no_cloud')}`",
-        f"- Required image present: `{required_image.get('present')}`",
-        f"- Required image arch/os: `{required_image.get('architecture')}`/`{required_image.get('os')}`",
-        f"- Container started: `{boundary.get('container_started')}`",
-        f"- Task body read: `{boundary.get('task_body_read')}`",
-        f"- Upload/submit eligible: `{boundary.get('no_upload')}`/`{boundary.get('submit_eligible')}`",
-        f"- Next action: {decision.get('next_allowed_action')}",
-        f"- Compact only: `{read_boundary.get('compact_only')}`",
-        f"- Raw artifacts read: `{read_boundary.get('raw_artifacts_read')}`",
-    ]
-    return "\n".join(lines) + "\n"
-
-
-def render_agents_last_exam_local_dry_run_plan_markdown(payload: dict[str, object]) -> str:
-    adapter_plan = (
-        payload.get("adapter_plan")
-        if isinstance(payload.get("adapter_plan"), dict)
-        else {}
-    )
-    decision = (
-        payload.get("decision") if isinstance(payload.get("decision"), dict) else {}
-    )
-    read_boundary = (
-        payload.get("read_boundary")
-        if isinstance(payload.get("read_boundary"), dict)
-        else {}
-    )
-    lines = [
-        "# Agents Last Exam Local Dry-Run Plan",
-        "",
-        f"- Schema: `{payload.get('schema_version')}`",
-        f"- Task: `{payload.get('task_id')}`",
-        f"- Snapshot: `{payload.get('snapshot')}`",
-        f"- Ready: `{payload.get('ready')}`",
-        f"- First blocker: `{payload.get('first_blocker')}`",
-        f"- Mode: `{adapter_plan.get('mode')}`",
-        f"- Provider: `{adapter_plan.get('provider')}`",
-        f"- Will start container: `{adapter_plan.get('will_start_container')}`",
-        f"- Will read task body: `{adapter_plan.get('will_read_task_body')}`",
-        f"- Will upload/submit: `{adapter_plan.get('will_upload')}`/`{adapter_plan.get('will_submit')}`",
-        f"- Next action: {decision.get('next_allowed_action')}",
-        f"- Compact only: `{read_boundary.get('compact_only')}`",
-        f"- Raw artifacts read: `{read_boundary.get('raw_artifacts_read')}`",
-    ]
-    return "\n".join(lines) + "\n"
+} | AGENTS_LAST_EXAM_LOCAL_PLAN_COMMANDS
 
 
 def render_agents_last_exam_local_runner_readiness_markdown(
@@ -570,102 +495,9 @@ def register_agents_last_exam_commands(
     benchmark_subparsers: argparse._SubParsersAction,
     add_subcommand_format: Callable[[argparse.ArgumentParser], None],
 ) -> None:
-    ale_local_preflight_parser = benchmark_subparsers.add_parser(
-        "ale-local-preflight",
-        help=(
-            "Check Agents' Last Exam local no-cloud/no-upload adapter readiness. "
-            "This may inspect local Docker image metadata, but it does not start "
-            "containers, read task bodies, call model APIs, upload, or claim "
-            "leaderboard evidence."
-        ),
-    )
-    add_subcommand_format(ale_local_preflight_parser)
-    ale_local_preflight_parser.add_argument(
-        "--selected-task-id",
-        help="Optional public task id label for the metadata-only candidate.",
-    )
-    ale_local_preflight_parser.add_argument(
-        "--snapshot",
-        default=AGENTS_LAST_EXAM_DEFAULT_SNAPSHOT,
-        help="ALE snapshot label to check. Defaults to cpu-free-ubuntu.",
-    )
-    ale_local_preflight_parser.add_argument(
-        "--image",
-        default=AGENTS_LAST_EXAM_DEFAULT_DOCKER_IMAGE,
-        help="Primary local Docker image ref to inspect.",
-    )
-    ale_local_preflight_parser.add_argument(
-        "--alternate-image",
-        default=AGENTS_LAST_EXAM_DEFAULT_ALT_DOCKER_IMAGE,
-        help="Optional alternate local Docker image ref to inspect.",
-    )
-    ale_local_preflight_parser.add_argument(
-        "--provider-kind",
-        choices=["docker"],
-        default="docker",
-        help="Provider kind. Only local docker is preflight-ready.",
-    )
-    ale_local_preflight_parser.add_argument(
-        "--require-ready",
-        action="store_true",
-        help="Return non-zero unless the local no-cloud/no-upload preflight is ready.",
-    )
-    ale_local_preflight_parser.add_argument(
-        "--no-docker-probe",
-        action="store_true",
-        help=(
-            "Do not call Docker; emit a fixture-like blocked preflight. "
-            "Used by dependency-free smokes."
-        ),
-    )
-
-    ale_local_dry_run_plan_parser = benchmark_subparsers.add_parser(
-        "ale-local-dry-run-plan",
-        help=(
-            "Build an Agents' Last Exam local adapter dry-run plan without "
-            "running the adapter. This contract-only gate may inspect local "
-            "Docker image metadata, but it does not start containers, read task "
-            "bodies, invoke model APIs, upload, or claim score evidence."
-        ),
-    )
-    add_subcommand_format(ale_local_dry_run_plan_parser)
-    ale_local_dry_run_plan_parser.add_argument(
-        "--selected-task-id",
-        help="Optional public task id label for the metadata-only candidate.",
-    )
-    ale_local_dry_run_plan_parser.add_argument(
-        "--snapshot",
-        default=AGENTS_LAST_EXAM_DEFAULT_SNAPSHOT,
-        help="ALE snapshot label to check. Defaults to cpu-free-ubuntu.",
-    )
-    ale_local_dry_run_plan_parser.add_argument(
-        "--image",
-        default=AGENTS_LAST_EXAM_DEFAULT_DOCKER_IMAGE,
-        help="Primary local Docker image ref to inspect.",
-    )
-    ale_local_dry_run_plan_parser.add_argument(
-        "--alternate-image",
-        default=AGENTS_LAST_EXAM_DEFAULT_ALT_DOCKER_IMAGE,
-        help="Optional alternate local Docker image ref to inspect.",
-    )
-    ale_local_dry_run_plan_parser.add_argument(
-        "--provider-kind",
-        choices=["docker"],
-        default="docker",
-        help="Provider kind. Only local docker is dry-run-plan-ready.",
-    )
-    ale_local_dry_run_plan_parser.add_argument(
-        "--require-ready",
-        action="store_true",
-        help="Return non-zero unless the contract-only dry-run plan is ready.",
-    )
-    ale_local_dry_run_plan_parser.add_argument(
-        "--no-docker-probe",
-        action="store_true",
-        help=(
-            "Do not call Docker; emit a fixture-like blocked plan. "
-            "Used by dependency-free smokes."
-        ),
+    register_agents_last_exam_local_plan_commands(
+        benchmark_subparsers,
+        add_subcommand_format,
     )
 
     ale_local_runner_readiness_parser = benchmark_subparsers.add_parser(
@@ -1382,111 +1214,14 @@ def handle_agents_last_exam_command(
     if args.benchmark_command not in AGENTS_LAST_EXAM_COMMANDS:
         return None
 
-    if args.benchmark_command == "ale-local-preflight":
-        try:
-            image_metadata = None
-            alternate_image_metadata = None
-            if args.no_docker_probe:
-                image_metadata = {
-                    "image_ref": args.image,
-                    "present": False,
-                    "probe_available": False,
-                    "first_blocker": "docker_probe_disabled",
-                }
-                alternate_image_metadata = {
-                    "image_ref": args.alternate_image,
-                    "present": False,
-                    "probe_available": False,
-                    "first_blocker": "docker_probe_disabled",
-                }
-            payload = build_agents_last_exam_local_preflight(
-                selected_task_id=args.selected_task_id,
-                snapshot=args.snapshot,
-                provider_kind=args.provider_kind,
-                image_ref=args.image,
-                alternate_image_ref=args.alternate_image,
-                image_metadata=image_metadata,
-                alternate_image_metadata=alternate_image_metadata,
-            )
-        except Exception:
-            payload = {
-                "ok": False,
-                "schema_version": "agents_last_exam_local_preflight_v0",
-                "error": "ale_local_preflight_failed",
-                "read_boundary": {
-                    "compact_only": True,
-                    "task_text_read": False,
-                    "raw_artifacts_read": False,
-                    "local_paths_recorded": False,
-                },
-            }
-        else:
-            payload["ok"] = True
-            if args.require_ready and payload.get("ready") is not True:
-                payload["ok"] = False
-                payload["error"] = (
-                    payload.get("first_blocker")
-                    or "ale_local_preflight_not_ready"
-                )
-        print_payload(
-            payload,
-            output_format(args),
-            render_agents_last_exam_local_preflight_markdown,
-        )
-        return 0 if payload.get("ok") else 1
-    if args.benchmark_command == "ale-local-dry-run-plan":
-        try:
-            image_metadata = None
-            alternate_image_metadata = None
-            if args.no_docker_probe:
-                image_metadata = {
-                    "image_ref": args.image,
-                    "present": False,
-                    "probe_available": False,
-                    "first_blocker": "docker_probe_disabled",
-                }
-                alternate_image_metadata = {
-                    "image_ref": args.alternate_image,
-                    "present": False,
-                    "probe_available": False,
-                    "first_blocker": "docker_probe_disabled",
-                }
-            payload = build_agents_last_exam_local_dry_run_plan(
-                selected_task_id=args.selected_task_id,
-                snapshot=args.snapshot,
-                provider_kind=args.provider_kind,
-                image_ref=args.image,
-                alternate_image_ref=args.alternate_image,
-                image_metadata=image_metadata,
-                alternate_image_metadata=alternate_image_metadata,
-            )
-        except Exception:
-            payload = {
-                "ok": False,
-                "schema_version": "agents_last_exam_local_dry_run_plan_v0",
-                "error": "ale_local_dry_run_plan_failed",
-                "read_boundary": {
-                    "compact_only": True,
-                    "task_text_read": False,
-                    "raw_artifacts_read": False,
-                    "local_paths_recorded": False,
-                    "container_started": False,
-                },
-            }
-        else:
-            payload["ok"] = True
-            if args.require_ready and payload.get("ready") is not True:
-                payload["ok"] = False
-                payload["error"] = (
-                    payload.get("first_blocker")
-                    or "ale_local_dry_run_plan_not_ready"
-                )
-        print_payload(
-            payload,
-            output_format(args),
-            render_agents_last_exam_local_dry_run_plan_markdown,
-        )
-        return 0 if payload.get("ok") else 1
+    local_plan_result = handle_agents_last_exam_local_plan_command(
+        args,
+        print_payload=print_payload,
+        output_format=output_format,
+    )
+    if local_plan_result is not None:
+        return local_plan_result
+
     if args.benchmark_command == "ale-local-runner-readiness":
         try:
             image_metadata = None

--- a/loopx/cli_commands/agents_last_exam_local_plan.py
+++ b/loopx/cli_commands/agents_last_exam_local_plan.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+
+from ..benchmark_adapters.agents_last_exam import (
+    AGENTS_LAST_EXAM_DEFAULT_ALT_DOCKER_IMAGE,
+    AGENTS_LAST_EXAM_DEFAULT_DOCKER_IMAGE,
+    AGENTS_LAST_EXAM_DEFAULT_SNAPSHOT,
+    build_agents_last_exam_local_dry_run_plan,
+    build_agents_last_exam_local_preflight,
+)
+
+
+PrintPayload = Callable[
+    [dict[str, object], str, Callable[[dict[str, object]], str]],
+    None,
+]
+OutputFormat = Callable[[argparse.Namespace], str]
+
+AGENTS_LAST_EXAM_LOCAL_PLAN_COMMANDS = {
+    "ale-local-preflight",
+    "ale-local-dry-run-plan",
+}
+
+
+def render_agents_last_exam_local_preflight_markdown(payload: dict[str, object]) -> str:
+    provider = (
+        payload.get("provider") if isinstance(payload.get("provider"), dict) else {}
+    )
+    required_image = (
+        provider.get("required_image")
+        if isinstance(provider.get("required_image"), dict)
+        else {}
+    )
+    boundary = (
+        payload.get("boundary") if isinstance(payload.get("boundary"), dict) else {}
+    )
+    decision = (
+        payload.get("decision") if isinstance(payload.get("decision"), dict) else {}
+    )
+    read_boundary = (
+        payload.get("read_boundary")
+        if isinstance(payload.get("read_boundary"), dict)
+        else {}
+    )
+    lines = [
+        "# Agents Last Exam Local Preflight",
+        "",
+        f"- Schema: `{payload.get('schema_version')}`",
+        f"- Task: `{payload.get('task_id')}`",
+        f"- Snapshot: `{payload.get('snapshot')}`",
+        f"- Ready: `{payload.get('ready')}`",
+        f"- First blocker: `{payload.get('first_blocker')}`",
+        f"- Provider: `{provider.get('kind')}`",
+        f"- No cloud: `{provider.get('no_cloud')}`",
+        f"- Required image present: `{required_image.get('present')}`",
+        f"- Required image arch/os: `{required_image.get('architecture')}`/`{required_image.get('os')}`",
+        f"- Container started: `{boundary.get('container_started')}`",
+        f"- Task body read: `{boundary.get('task_body_read')}`",
+        f"- Upload/submit eligible: `{boundary.get('no_upload')}`/`{boundary.get('submit_eligible')}`",
+        f"- Next action: {decision.get('next_allowed_action')}",
+        f"- Compact only: `{read_boundary.get('compact_only')}`",
+        f"- Raw artifacts read: `{read_boundary.get('raw_artifacts_read')}`",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def render_agents_last_exam_local_dry_run_plan_markdown(payload: dict[str, object]) -> str:
+    adapter_plan = (
+        payload.get("adapter_plan")
+        if isinstance(payload.get("adapter_plan"), dict)
+        else {}
+    )
+    decision = (
+        payload.get("decision") if isinstance(payload.get("decision"), dict) else {}
+    )
+    read_boundary = (
+        payload.get("read_boundary")
+        if isinstance(payload.get("read_boundary"), dict)
+        else {}
+    )
+    lines = [
+        "# Agents Last Exam Local Dry-Run Plan",
+        "",
+        f"- Schema: `{payload.get('schema_version')}`",
+        f"- Task: `{payload.get('task_id')}`",
+        f"- Snapshot: `{payload.get('snapshot')}`",
+        f"- Ready: `{payload.get('ready')}`",
+        f"- First blocker: `{payload.get('first_blocker')}`",
+        f"- Mode: `{adapter_plan.get('mode')}`",
+        f"- Provider: `{adapter_plan.get('provider')}`",
+        f"- Will start container: `{adapter_plan.get('will_start_container')}`",
+        f"- Will read task body: `{adapter_plan.get('will_read_task_body')}`",
+        f"- Will upload/submit: `{adapter_plan.get('will_upload')}`/`{adapter_plan.get('will_submit')}`",
+        f"- Next action: {decision.get('next_allowed_action')}",
+        f"- Compact only: `{read_boundary.get('compact_only')}`",
+        f"- Raw artifacts read: `{read_boundary.get('raw_artifacts_read')}`",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def register_agents_last_exam_local_plan_commands(
+    benchmark_subparsers: argparse._SubParsersAction,
+    add_subcommand_format: Callable[[argparse.ArgumentParser], None],
+) -> None:
+    ale_local_preflight_parser = benchmark_subparsers.add_parser(
+        "ale-local-preflight",
+        help=(
+            "Check Agents' Last Exam local no-cloud/no-upload adapter readiness. "
+            "This may inspect local Docker image metadata, but it does not start "
+            "containers, read task bodies, call model APIs, upload, or claim "
+            "leaderboard evidence."
+        ),
+    )
+    add_subcommand_format(ale_local_preflight_parser)
+    ale_local_preflight_parser.add_argument(
+        "--selected-task-id",
+        help="Optional public task id label for the metadata-only candidate.",
+    )
+    ale_local_preflight_parser.add_argument(
+        "--snapshot",
+        default=AGENTS_LAST_EXAM_DEFAULT_SNAPSHOT,
+        help="ALE snapshot label to check. Defaults to cpu-free-ubuntu.",
+    )
+    ale_local_preflight_parser.add_argument(
+        "--image",
+        default=AGENTS_LAST_EXAM_DEFAULT_DOCKER_IMAGE,
+        help="Primary local Docker image ref to inspect.",
+    )
+    ale_local_preflight_parser.add_argument(
+        "--alternate-image",
+        default=AGENTS_LAST_EXAM_DEFAULT_ALT_DOCKER_IMAGE,
+        help="Optional alternate local Docker image ref to inspect.",
+    )
+    ale_local_preflight_parser.add_argument(
+        "--provider-kind",
+        choices=["docker"],
+        default="docker",
+        help="Provider kind. Only local docker is preflight-ready.",
+    )
+    ale_local_preflight_parser.add_argument(
+        "--require-ready",
+        action="store_true",
+        help="Return non-zero unless the local no-cloud/no-upload preflight is ready.",
+    )
+    ale_local_preflight_parser.add_argument(
+        "--no-docker-probe",
+        action="store_true",
+        help=(
+            "Do not call Docker; emit a fixture-like blocked preflight. "
+            "Used by dependency-free smokes."
+        ),
+    )
+
+    ale_local_dry_run_plan_parser = benchmark_subparsers.add_parser(
+        "ale-local-dry-run-plan",
+        help=(
+            "Build an Agents' Last Exam local adapter dry-run plan without "
+            "running the adapter. This contract-only gate may inspect local "
+            "Docker image metadata, but it does not start containers, read task "
+            "bodies, invoke model APIs, upload, or claim score evidence."
+        ),
+    )
+    add_subcommand_format(ale_local_dry_run_plan_parser)
+    ale_local_dry_run_plan_parser.add_argument(
+        "--selected-task-id",
+        help="Optional public task id label for the metadata-only candidate.",
+    )
+    ale_local_dry_run_plan_parser.add_argument(
+        "--snapshot",
+        default=AGENTS_LAST_EXAM_DEFAULT_SNAPSHOT,
+        help="ALE snapshot label to check. Defaults to cpu-free-ubuntu.",
+    )
+    ale_local_dry_run_plan_parser.add_argument(
+        "--image",
+        default=AGENTS_LAST_EXAM_DEFAULT_DOCKER_IMAGE,
+        help="Primary local Docker image ref to inspect.",
+    )
+    ale_local_dry_run_plan_parser.add_argument(
+        "--alternate-image",
+        default=AGENTS_LAST_EXAM_DEFAULT_ALT_DOCKER_IMAGE,
+        help="Optional alternate local Docker image ref to inspect.",
+    )
+    ale_local_dry_run_plan_parser.add_argument(
+        "--provider-kind",
+        choices=["docker"],
+        default="docker",
+        help="Provider kind. Only local docker is dry-run-plan-ready.",
+    )
+    ale_local_dry_run_plan_parser.add_argument(
+        "--require-ready",
+        action="store_true",
+        help="Return non-zero unless the contract-only dry-run plan is ready.",
+    )
+    ale_local_dry_run_plan_parser.add_argument(
+        "--no-docker-probe",
+        action="store_true",
+        help=(
+            "Do not call Docker; emit a fixture-like blocked plan. "
+            "Used by dependency-free smokes."
+        ),
+    )
+
+
+def handle_agents_last_exam_local_plan_command(
+    args: argparse.Namespace,
+    *,
+    print_payload: PrintPayload,
+    output_format: OutputFormat,
+) -> int | None:
+    if args.benchmark_command not in AGENTS_LAST_EXAM_LOCAL_PLAN_COMMANDS:
+        return None
+
+    if args.benchmark_command == "ale-local-preflight":
+        try:
+            image_metadata = None
+            alternate_image_metadata = None
+            if args.no_docker_probe:
+                image_metadata = {
+                    "image_ref": args.image,
+                    "present": False,
+                    "probe_available": False,
+                    "first_blocker": "docker_probe_disabled",
+                }
+                alternate_image_metadata = {
+                    "image_ref": args.alternate_image,
+                    "present": False,
+                    "probe_available": False,
+                    "first_blocker": "docker_probe_disabled",
+                }
+            payload = build_agents_last_exam_local_preflight(
+                selected_task_id=args.selected_task_id,
+                snapshot=args.snapshot,
+                provider_kind=args.provider_kind,
+                image_ref=args.image,
+                alternate_image_ref=args.alternate_image,
+                image_metadata=image_metadata,
+                alternate_image_metadata=alternate_image_metadata,
+            )
+        except Exception:
+            payload = {
+                "ok": False,
+                "schema_version": "agents_last_exam_local_preflight_v0",
+                "error": "ale_local_preflight_failed",
+                "read_boundary": {
+                    "compact_only": True,
+                    "task_text_read": False,
+                    "raw_artifacts_read": False,
+                    "local_paths_recorded": False,
+                },
+            }
+        else:
+            payload["ok"] = True
+            if args.require_ready and payload.get("ready") is not True:
+                payload["ok"] = False
+                payload["error"] = (
+                    payload.get("first_blocker")
+                    or "ale_local_preflight_not_ready"
+                )
+        print_payload(
+            payload,
+            output_format(args),
+            render_agents_last_exam_local_preflight_markdown,
+        )
+        return 0 if payload.get("ok") else 1
+
+    if args.benchmark_command == "ale-local-dry-run-plan":
+        try:
+            image_metadata = None
+            alternate_image_metadata = None
+            if args.no_docker_probe:
+                image_metadata = {
+                    "image_ref": args.image,
+                    "present": False,
+                    "probe_available": False,
+                    "first_blocker": "docker_probe_disabled",
+                }
+                alternate_image_metadata = {
+                    "image_ref": args.alternate_image,
+                    "present": False,
+                    "probe_available": False,
+                    "first_blocker": "docker_probe_disabled",
+                }
+            payload = build_agents_last_exam_local_dry_run_plan(
+                selected_task_id=args.selected_task_id,
+                snapshot=args.snapshot,
+                provider_kind=args.provider_kind,
+                image_ref=args.image,
+                alternate_image_ref=args.alternate_image,
+                image_metadata=image_metadata,
+                alternate_image_metadata=alternate_image_metadata,
+            )
+        except Exception:
+            payload = {
+                "ok": False,
+                "schema_version": "agents_last_exam_local_dry_run_plan_v0",
+                "error": "ale_local_dry_run_plan_failed",
+                "read_boundary": {
+                    "compact_only": True,
+                    "task_text_read": False,
+                    "raw_artifacts_read": False,
+                    "local_paths_recorded": False,
+                    "container_started": False,
+                },
+            }
+        else:
+            payload["ok"] = True
+            if args.require_ready and payload.get("ready") is not True:
+                payload["ok"] = False
+                payload["error"] = (
+                    payload.get("first_blocker")
+                    or "ale_local_dry_run_plan_not_ready"
+                )
+        print_payload(
+            payload,
+            output_format(args),
+            render_agents_last_exam_local_dry_run_plan_markdown,
+        )
+        return 0 if payload.get("ok") else 1
+
+    return None


### PR DESCRIPTION
## Summary
- extract ALE local preflight and dry-run-plan CLI registration/handler code into agents_last_exam_local_plan.py
- keep agents_last_exam.py as the aggregate ALE command dispatcher while reducing it from 2067 to 1802 lines
- tighten the module-size guard budget for agents_last_exam.py and add smoke assertions preventing local-plan logic from leaking back

## Validation
- python3 examples/cli-agents-last-exam-command-modularization-smoke.py
- python3 examples/cli-command-module-size-ownership-command-modularization-smoke.py
- python3 all examples/cli-*-command-modularization-smoke.py
- python3 -m py_compile loopx/*.py loopx/cli_commands/*.py plus new agents_last_exam_local_plan.py
- python3 -m loopx.cli benchmark ale-local-dry-run-plan --no-docker-probe --format json
- loopx check --scan-path loopx/cli_commands/agents_last_exam.py --scan-path loopx/cli_commands/agents_last_exam_local_plan.py --scan-path examples/cli-agents-last-exam-command-modularization-smoke.py --scan-path examples/cli-command-module-size-ownership-command-modularization-smoke.py