### PR TITLE
Extract ALE runner source CLI command family

### DIFF
--- a/examples/cli-agents-last-exam-command-modularization-smoke.py
+++ b/examples/cli-agents-last-exam-command-modularization-smoke.py
@@ -40,6 +40,9 @@ def main() -> int:
     local_plan_source = (
         ROOT / "loopx" / "cli_commands" / "agents_last_exam_local_plan.py"
     ).read_text(encoding="utf-8")
+    runner_source_source = (
+        ROOT / "loopx" / "cli_commands" / "agents_last_exam_runner_source.py"
+    ).read_text(encoding="utf-8")
 
     leaked_markers = [
         "ale_local_preflight_parser = benchmark_sub.add_parser",
@@ -60,6 +63,8 @@ def main() -> int:
     assert_contains(init_source, "handle_agents_last_exam_command")
     assert_contains(init_source, "register_agents_last_exam_local_plan_commands")
     assert_contains(init_source, "handle_agents_last_exam_local_plan_command")
+    assert_contains(init_source, "register_agents_last_exam_runner_source_commands")
+    assert_contains(init_source, "handle_agents_last_exam_runner_source_command")
     assert_contains(ale_source, "AGENTS_LAST_EXAM_COMMANDS")
     assert_contains(ale_source, "ale-validation-run-gate")
     assert_contains(
@@ -69,6 +74,14 @@ def main() -> int:
     assert_contains(
         ale_source,
         "handle_agents_last_exam_local_plan_command(",
+    )
+    assert_contains(
+        ale_source,
+        "register_agents_last_exam_runner_source_commands(",
+    )
+    assert_contains(
+        ale_source,
+        "handle_agents_last_exam_runner_source_command(",
     )
     for marker in (
         "def render_agents_last_exam_local_preflight_markdown",
@@ -80,6 +93,17 @@ def main() -> int:
         if marker in ale_source:
             raise AssertionError(f"{marker} leaked back into agents_last_exam.py")
         assert_contains(local_plan_source, marker)
+    for marker in (
+        "def render_agents_last_exam_local_runner_readiness_markdown",
+        "def render_agents_last_exam_local_source_readiness_markdown",
+        "build_agents_last_exam_local_runner_readiness(",
+        "build_agents_last_exam_local_source_readiness(",
+        'if args.benchmark_command == "ale-local-runner-readiness":',
+        'if args.benchmark_command == "ale-local-source-readiness":',
+    ):
+        if marker in ale_source:
+            raise AssertionError(f"{marker} leaked back into agents_last_exam.py")
+        assert_contains(runner_source_source, marker)
 
     help_result = run_cli("benchmark", "ale-validation-run-gate", "--help")
     if help_result.returncode != 0:

--- a/examples/cli-command-module-size-ownership-command-modularization-smoke.py
+++ b/examples/cli-command-module-size-ownership-command-modularization-smoke.py
@@ -10,7 +10,7 @@ CLI_COMMANDS = ROOT / "loopx" / "cli_commands"
 
 DEFAULT_MAX_LINES = 500
 LEGACY_MODULE_LIMITS = {
-    "agents_last_exam.py": 1850,
+    "agents_last_exam.py": 1560,
     "benchmark_review_lifecycle.py": 1300,
     "benchmark_run_ledger.py": 1360,
     "history.py": 720,

--- a/loopx/cli_commands/__init__.py
+++ b/loopx/cli_commands/__init__.py
@@ -16,6 +16,10 @@ from .agents_last_exam_local_plan import (
     handle_agents_last_exam_local_plan_command,
     register_agents_last_exam_local_plan_commands,
 )
+from .agents_last_exam_runner_source import (
+    handle_agents_last_exam_runner_source_command,
+    register_agents_last_exam_runner_source_commands,
+)
 from .agentissue_runner_flow import (
     handle_agentissue_runner_flow_command,
     register_agentissue_runner_flow_commands,
@@ -120,6 +124,7 @@ from .worker_bridge import handle_worker_bridge_command, register_worker_bridge_
 __all__ = [
     "handle_agents_last_exam_command",
     "handle_agents_last_exam_local_plan_command",
+    "handle_agents_last_exam_runner_source_command",
     "handle_agentissue_runner_flow_command",
     "handle_benchmark_boundary_command",
     "handle_benchmark_command",
@@ -168,6 +173,7 @@ __all__ = [
     "handle_worker_bridge_command",
     "register_agents_last_exam_commands",
     "register_agents_last_exam_local_plan_commands",
+    "register_agents_last_exam_runner_source_commands",
     "register_agentissue_runner_flow_commands",
     "register_benchmark_boundary_commands",
     "register_benchmark_command_group",

--- a/loopx/cli_commands/agents_last_exam.py
+++ b/loopx/cli_commands/agents_last_exam.py
@@ -16,8 +16,6 @@ from ..benchmark_adapters.agents_last_exam import (
     build_agents_last_exam_host_codex_cua_no_task_smoke_from_environment,
     build_agents_last_exam_local_exact_dry_run_result,
     build_agents_last_exam_local_launch_packet,
-    build_agents_last_exam_local_runner_readiness,
-    build_agents_last_exam_local_source_readiness,
     build_agents_last_exam_task_material_readiness,
     build_agents_last_exam_validation_run_gate,
 )
@@ -25,6 +23,11 @@ from .agents_last_exam_local_plan import (
     AGENTS_LAST_EXAM_LOCAL_PLAN_COMMANDS,
     handle_agents_last_exam_local_plan_command,
     register_agents_last_exam_local_plan_commands,
+)
+from .agents_last_exam_runner_source import (
+    AGENTS_LAST_EXAM_RUNNER_SOURCE_COMMANDS,
+    handle_agents_last_exam_runner_source_command,
+    register_agents_last_exam_runner_source_commands,
 )
 
 
@@ -35,8 +38,6 @@ PrintPayload = Callable[
 OutputFormat = Callable[[argparse.Namespace], str]
 
 AGENTS_LAST_EXAM_COMMANDS = {
-    "ale-local-runner-readiness",
-    "ale-local-source-readiness",
     "ale-task-material-readiness",
     "ale-baked-task-input-readiness",
     "ale-baked-task-input-scan",
@@ -46,86 +47,7 @@ AGENTS_LAST_EXAM_COMMANDS = {
     "ale-host-codex-cli-route",
     "ale-host-codex-cua-no-task-e2e",
     "ale-validation-run-gate",
-} | AGENTS_LAST_EXAM_LOCAL_PLAN_COMMANDS
-
-
-def render_agents_last_exam_local_runner_readiness_markdown(
-    payload: dict[str, object],
-) -> str:
-    runner_probe = (
-        payload.get("runner_probe")
-        if isinstance(payload.get("runner_probe"), dict)
-        else {}
-    )
-    boundary = payload.get("boundary") if isinstance(payload.get("boundary"), dict) else {}
-    decision = (
-        payload.get("decision") if isinstance(payload.get("decision"), dict) else {}
-    )
-    read_boundary = (
-        payload.get("read_boundary")
-        if isinstance(payload.get("read_boundary"), dict)
-        else {}
-    )
-    lines = [
-        "# Agents Last Exam Local Runner Readiness",
-        "",
-        f"- Schema: `{payload.get('schema_version')}`",
-        f"- Task: `{payload.get('task_id')}`",
-        f"- Snapshot: `{payload.get('snapshot')}`",
-        f"- Ready: `{payload.get('ready')}`",
-        f"- First blocker: `{payload.get('first_blocker')}`",
-        f"- Preflight ready: `{payload.get('preflight_ready')}`",
-        f"- Dry-run plan ready: `{payload.get('dry_run_plan_ready')}`",
-        f"- Runner binary: `{runner_probe.get('binary')}`",
-        f"- Runner binary available: `{runner_probe.get('binary_available')}`",
-        f"- Runner Python module: `{runner_probe.get('python_module')}`",
-        f"- Runner Python module available: `{runner_probe.get('python_module_available')}`",
-        f"- Runner source root declared/available: `{runner_probe.get('source_root_declared')}`/`{runner_probe.get('source_root_available')}`",
-        f"- Container started: `{boundary.get('container_started')}`",
-        f"- Public task material authorized: `{boundary.get('operator_authorized_public_task_material')}`",
-        f"- Upload/submit allowed: `{boundary.get('upload_allowed')}`/`{boundary.get('submit_allowed')}`",
-        f"- Model API allowed/invoked: `{boundary.get('model_api_allowed')}`/`{boundary.get('model_api_invoked')}`",
-        f"- Next action: {decision.get('next_allowed_action')}",
-        f"- Compact only: `{read_boundary.get('compact_only')}`",
-        f"- Raw artifacts read: `{read_boundary.get('raw_artifacts_read')}`",
-    ]
-    return "\n".join(lines) + "\n"
-
-
-def render_agents_last_exam_local_source_readiness_markdown(
-    payload: dict[str, object],
-) -> str:
-    source = payload.get("source") if isinstance(payload.get("source"), dict) else {}
-    runner_probe = (
-        payload.get("runner_probe")
-        if isinstance(payload.get("runner_probe"), dict)
-        else {}
-    )
-    boundary = payload.get("boundary") if isinstance(payload.get("boundary"), dict) else {}
-    decision = (
-        payload.get("decision") if isinstance(payload.get("decision"), dict) else {}
-    )
-    lines = [
-        "# Agents Last Exam Local Source Readiness",
-        "",
-        f"- Schema: `{payload.get('schema_version')}`",
-        f"- Ready: `{payload.get('ready')}`",
-        f"- First blocker: `{payload.get('first_blocker')}`",
-        f"- Expected repo: `{source.get('expected_repo')}`",
-        f"- Remote matches expected: `{source.get('remote_matches_expected')}`",
-        f"- Source head: `{source.get('head')}`",
-        f"- Upstream current: `{source.get('head_matches_upstream')}`",
-        f"- Upstream ahead/behind: `{source.get('upstream_ahead_count')}`/`{source.get('upstream_behind_count')}`",
-        f"- Fetch origin attempted/ok: `{source.get('fetch_origin_attempted')}`/`{source.get('fetch_origin_ok')}`",
-        f"- Source root path recorded: `{source.get('source_root_path_recorded')}`",
-        f"- Runner Python module: `{runner_probe.get('python_module')}`",
-        f"- Runner Python module available: `{runner_probe.get('python_module_available')}`",
-        f"- Container started: `{boundary.get('container_started')}`",
-        f"- Task body read: `{boundary.get('task_body_read')}`",
-        f"- Upload/submit eligible: `{boundary.get('no_upload')}`/`{boundary.get('submit_eligible')}`",
-        f"- Next action: {decision.get('next_allowed_action')}",
-    ]
-    return "\n".join(lines) + "\n"
+} | AGENTS_LAST_EXAM_LOCAL_PLAN_COMMANDS | AGENTS_LAST_EXAM_RUNNER_SOURCE_COMMANDS
 
 
 def render_agents_last_exam_task_material_readiness_markdown(
@@ -499,136 +421,9 @@ def register_agents_last_exam_commands(
         benchmark_subparsers,
         add_subcommand_format,
     )
-
-    ale_local_runner_readiness_parser = benchmark_subparsers.add_parser(
-        "ale-local-runner-readiness",
-        help=(
-            "Check whether a real Agents' Last Exam local dry-run runner is "
-            "explicitly configured. This may inspect local Docker image metadata "
-            "and PATH availability for a runner binary, but it does not start "
-            "containers, read task bodies, invoke model APIs, upload, or submit."
-        ),
-    )
-    add_subcommand_format(ale_local_runner_readiness_parser)
-    ale_local_runner_readiness_parser.add_argument(
-        "--selected-task-id",
-        help="Optional public task id label for the metadata-only candidate.",
-    )
-    ale_local_runner_readiness_parser.add_argument(
-        "--snapshot",
-        default=AGENTS_LAST_EXAM_DEFAULT_SNAPSHOT,
-        help="ALE snapshot label to check. Defaults to cpu-free-ubuntu.",
-    )
-    ale_local_runner_readiness_parser.add_argument(
-        "--image",
-        default=AGENTS_LAST_EXAM_DEFAULT_DOCKER_IMAGE,
-        help="Primary local Docker image ref to inspect.",
-    )
-    ale_local_runner_readiness_parser.add_argument(
-        "--alternate-image",
-        default=AGENTS_LAST_EXAM_DEFAULT_ALT_DOCKER_IMAGE,
-        help="Optional alternate local Docker image ref to inspect.",
-    )
-    ale_local_runner_readiness_parser.add_argument(
-        "--provider-kind",
-        choices=["docker"],
-        default="docker",
-        help="Provider kind. Only local docker is runner-ready.",
-    )
-    ale_local_runner_readiness_parser.add_argument(
-        "--runner-binary",
-        help=(
-            "PATH-visible runner binary name to probe. Absolute or relative paths "
-            "are rejected so local paths are not recorded."
-        ),
-    )
-    ale_local_runner_readiness_parser.add_argument(
-        "--runner-python-module",
-        help=(
-            "Optional Python module to probe when the runner command is "
-            "`python -m <module>`. The module path is never recorded."
-        ),
-    )
-    ale_local_runner_readiness_parser.add_argument(
-        "--runner-source-root",
-        help=(
-            "Optional local source checkout root to add only for module probing. "
-            "The local path is never recorded in output."
-        ),
-    )
-    ale_local_runner_readiness_parser.add_argument(
-        "--runner-command-label",
-        help=(
-            "Public-safe label for the configured runner command. The command "
-            "argv itself is never recorded."
-        ),
-    )
-    ale_local_runner_readiness_parser.add_argument(
-        "--operator-authorized",
-        action="store_true",
-        help="Mark that the operator authorized local container start for dry-run.",
-    )
-    ale_local_runner_readiness_parser.add_argument(
-        "--allow-public-task-material",
-        action="store_true",
-        help="Mark that public ALE task material may be touched by a later dry-run.",
-    )
-    ale_local_runner_readiness_parser.add_argument(
-        "--require-ready",
-        action="store_true",
-        help="Return non-zero unless the local runner readiness gate is ready.",
-    )
-    ale_local_runner_readiness_parser.add_argument(
-        "--no-docker-probe",
-        action="store_true",
-        help=(
-            "Do not call Docker; emit a fixture-like blocked readiness payload. "
-            "Used by dependency-free smokes."
-        ),
-    )
-
-    ale_local_source_readiness_parser = benchmark_subparsers.add_parser(
-        "ale-local-source-readiness",
-        help=(
-            "Check whether a local Agents' Last Exam source checkout can be used "
-            "as a redacted public runner source lock. This reads git metadata and "
-            "module availability only; it does not start containers, read task "
-            "bodies, invoke model APIs, upload, or submit."
-        ),
-    )
-    add_subcommand_format(ale_local_source_readiness_parser)
-    ale_local_source_readiness_parser.add_argument(
-        "--source-root",
-        required=True,
-        help="Local ALE source checkout root to probe. The path is never recorded.",
-    )
-    ale_local_source_readiness_parser.add_argument(
-        "--expected-repo-url",
-        default="https://github.com/rdi-berkeley/agents-last-exam.git",
-        help="Expected public ALE repository URL.",
-    )
-    ale_local_source_readiness_parser.add_argument(
-        "--runner-python-module",
-        default="ale_run",
-        help="Python module expected to provide the ALE runner CLI.",
-    )
-    ale_local_source_readiness_parser.add_argument(
-        "--fetch-origin",
-        action="store_true",
-        help=(
-            "Run git fetch --prune origin before checking freshness. The command "
-            "argv, local path, and raw git output are never recorded."
-        ),
-    )
-    ale_local_source_readiness_parser.add_argument(
-        "--require-upstream-current",
-        action="store_true",
-        help="Require HEAD to match the configured upstream ref before returning ready.",
-    )
-    ale_local_source_readiness_parser.add_argument(
-        "--require-ready",
-        action="store_true",
-        help="Return non-zero unless the source readiness gate is ready.",
+    register_agents_last_exam_runner_source_commands(
+        benchmark_subparsers,
+        add_subcommand_format,
     )
 
     ale_task_material_readiness_parser = benchmark_subparsers.add_parser(
@@ -1222,105 +1017,14 @@ def handle_agents_last_exam_command(
     if local_plan_result is not None:
         return local_plan_result
 
-    if args.benchmark_command == "ale-local-runner-readiness":
-        try:
-            image_metadata = None
-            alternate_image_metadata = None
-            if args.no_docker_probe:
-                image_metadata = {
-                    "image_ref": args.image,
-                    "present": False,
-                    "probe_available": False,
-                    "first_blocker": "docker_probe_disabled",
-                }
-                alternate_image_metadata = {
-                    "image_ref": args.alternate_image,
-                    "present": False,
-                    "probe_available": False,
-                    "first_blocker": "docker_probe_disabled",
-                }
-            payload = build_agents_last_exam_local_runner_readiness(
-                selected_task_id=args.selected_task_id,
-                snapshot=args.snapshot,
-                provider_kind=args.provider_kind,
-                image_ref=args.image,
-                alternate_image_ref=args.alternate_image,
-                runner_binary=args.runner_binary,
-                runner_python_module=args.runner_python_module,
-                runner_source_root=args.runner_source_root,
-                runner_command_label=args.runner_command_label,
-                operator_authorized=bool(args.operator_authorized),
-                allow_public_task_material=bool(args.allow_public_task_material),
-                fetch_origin=bool(getattr(args, "fetch_origin", False)),
-                require_upstream_current=bool(
-                    getattr(args, "require_upstream_current", False)
-                ),
-                image_metadata=image_metadata,
-                alternate_image_metadata=alternate_image_metadata,
-            )
-        except Exception:
-            payload = {
-                "ok": False,
-                "schema_version": "agents_last_exam_local_runner_readiness_v0",
-                "error": "ale_local_runner_readiness_failed",
-                "read_boundary": {
-                    "compact_only": True,
-                    "task_text_read": False,
-                    "raw_artifacts_read": False,
-                    "local_paths_recorded": False,
-                    "container_started": False,
-                },
-            }
-        else:
-            payload["ok"] = True
-            if args.require_ready and payload.get("ready") is not True:
-                payload["ok"] = False
-                payload["error"] = (
-                    payload.get("first_blocker")
-                    or "ale_local_runner_readiness_not_ready"
-                )
-        print_payload(
-            payload,
-            output_format(args),
-            render_agents_last_exam_local_runner_readiness_markdown,
-        )
-        return 0 if payload.get("ok") else 1
-    if args.benchmark_command == "ale-local-source-readiness":
-        try:
-            payload = build_agents_last_exam_local_source_readiness(
-                source_root=args.source_root,
-                expected_repo_url=args.expected_repo_url,
-                runner_python_module=args.runner_python_module,
-                fetch_origin=bool(args.fetch_origin),
-                require_upstream_current=bool(args.require_upstream_current),
-            )
-        except Exception:
-            payload = {
-                "ok": False,
-                "schema_version": "agents_last_exam_local_source_readiness_v0",
-                "error": "ale_local_source_readiness_failed",
-                "read_boundary": {
-                    "compact_only": True,
-                    "task_text_read": False,
-                    "raw_artifacts_read": False,
-                    "local_paths_recorded": False,
-                    "container_started": False,
-                },
-            }
-        else:
-            payload["ok"] = True
-            if args.require_ready and payload.get("ready") is not True:
-                payload["ok"] = False
-                payload["error"] = (
-                    payload.get("first_blocker")
-                    or "ale_local_source_readiness_not_ready"
-                )
-        print_payload(
-            payload,
-            output_format(args),
-            render_agents_last_exam_local_source_readiness_markdown,
-        )
-        return 0 if payload.get("ok") else 1
+    runner_source_result = handle_agents_last_exam_runner_source_command(
+        args,
+        print_payload=print_payload,
+        output_format=output_format,
+    )
+    if runner_source_result is not None:
+        return runner_source_result
+
     if args.benchmark_command == "ale-task-material-readiness":
         try:
             selected_task_lists = (

--- a/loopx/cli_commands/agents_last_exam_runner_source.py
+++ b/loopx/cli_commands/agents_last_exam_runner_source.py
@@ -1,0 +1,352 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+
+from ..benchmark_adapters.agents_last_exam import (
+    AGENTS_LAST_EXAM_DEFAULT_ALT_DOCKER_IMAGE,
+    AGENTS_LAST_EXAM_DEFAULT_DOCKER_IMAGE,
+    AGENTS_LAST_EXAM_DEFAULT_SNAPSHOT,
+    build_agents_last_exam_local_runner_readiness,
+    build_agents_last_exam_local_source_readiness,
+)
+
+
+PrintPayload = Callable[
+    [dict[str, object], str, Callable[[dict[str, object]], str]],
+    None,
+]
+OutputFormat = Callable[[argparse.Namespace], str]
+
+AGENTS_LAST_EXAM_RUNNER_SOURCE_COMMANDS = {
+    "ale-local-runner-readiness",
+    "ale-local-source-readiness",
+}
+
+
+def render_agents_last_exam_local_runner_readiness_markdown(
+    payload: dict[str, object],
+) -> str:
+    runner_probe = (
+        payload.get("runner_probe")
+        if isinstance(payload.get("runner_probe"), dict)
+        else {}
+    )
+    boundary = payload.get("boundary") if isinstance(payload.get("boundary"), dict) else {}
+    decision = (
+        payload.get("decision") if isinstance(payload.get("decision"), dict) else {}
+    )
+    read_boundary = (
+        payload.get("read_boundary")
+        if isinstance(payload.get("read_boundary"), dict)
+        else {}
+    )
+    lines = [
+        "# Agents Last Exam Local Runner Readiness",
+        "",
+        f"- Schema: `{payload.get('schema_version')}`",
+        f"- Task: `{payload.get('task_id')}`",
+        f"- Snapshot: `{payload.get('snapshot')}`",
+        f"- Ready: `{payload.get('ready')}`",
+        f"- First blocker: `{payload.get('first_blocker')}`",
+        f"- Preflight ready: `{payload.get('preflight_ready')}`",
+        f"- Dry-run plan ready: `{payload.get('dry_run_plan_ready')}`",
+        f"- Runner binary: `{runner_probe.get('binary')}`",
+        f"- Runner binary available: `{runner_probe.get('binary_available')}`",
+        f"- Runner Python module: `{runner_probe.get('python_module')}`",
+        f"- Runner Python module available: `{runner_probe.get('python_module_available')}`",
+        f"- Runner source root declared/available: `{runner_probe.get('source_root_declared')}`/`{runner_probe.get('source_root_available')}`",
+        f"- Container started: `{boundary.get('container_started')}`",
+        f"- Public task material authorized: `{boundary.get('operator_authorized_public_task_material')}`",
+        f"- Upload/submit allowed: `{boundary.get('upload_allowed')}`/`{boundary.get('submit_allowed')}`",
+        f"- Model API allowed/invoked: `{boundary.get('model_api_allowed')}`/`{boundary.get('model_api_invoked')}`",
+        f"- Next action: {decision.get('next_allowed_action')}",
+        f"- Compact only: `{read_boundary.get('compact_only')}`",
+        f"- Raw artifacts read: `{read_boundary.get('raw_artifacts_read')}`",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def render_agents_last_exam_local_source_readiness_markdown(
+    payload: dict[str, object],
+) -> str:
+    source = payload.get("source") if isinstance(payload.get("source"), dict) else {}
+    runner_probe = (
+        payload.get("runner_probe")
+        if isinstance(payload.get("runner_probe"), dict)
+        else {}
+    )
+    boundary = payload.get("boundary") if isinstance(payload.get("boundary"), dict) else {}
+    decision = (
+        payload.get("decision") if isinstance(payload.get("decision"), dict) else {}
+    )
+    lines = [
+        "# Agents Last Exam Local Source Readiness",
+        "",
+        f"- Schema: `{payload.get('schema_version')}`",
+        f"- Ready: `{payload.get('ready')}`",
+        f"- First blocker: `{payload.get('first_blocker')}`",
+        f"- Expected repo: `{source.get('expected_repo')}`",
+        f"- Remote matches expected: `{source.get('remote_matches_expected')}`",
+        f"- Source head: `{source.get('head')}`",
+        f"- Upstream current: `{source.get('head_matches_upstream')}`",
+        f"- Upstream ahead/behind: `{source.get('upstream_ahead_count')}`/`{source.get('upstream_behind_count')}`",
+        f"- Fetch origin attempted/ok: `{source.get('fetch_origin_attempted')}`/`{source.get('fetch_origin_ok')}`",
+        f"- Source root path recorded: `{source.get('source_root_path_recorded')}`",
+        f"- Runner Python module: `{runner_probe.get('python_module')}`",
+        f"- Runner Python module available: `{runner_probe.get('python_module_available')}`",
+        f"- Container started: `{boundary.get('container_started')}`",
+        f"- Task body read: `{boundary.get('task_body_read')}`",
+        f"- Upload/submit eligible: `{boundary.get('no_upload')}`/`{boundary.get('submit_eligible')}`",
+        f"- Next action: {decision.get('next_allowed_action')}",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def register_agents_last_exam_runner_source_commands(
+    benchmark_subparsers: argparse._SubParsersAction,
+    add_subcommand_format: Callable[[argparse.ArgumentParser], None],
+) -> None:
+    ale_local_runner_readiness_parser = benchmark_subparsers.add_parser(
+        "ale-local-runner-readiness",
+        help=(
+            "Check whether a real Agents' Last Exam local dry-run runner is "
+            "explicitly configured. This may inspect local Docker image metadata "
+            "and PATH availability for a runner binary, but it does not start "
+            "containers, read task bodies, invoke model APIs, upload, or submit."
+        ),
+    )
+    add_subcommand_format(ale_local_runner_readiness_parser)
+    ale_local_runner_readiness_parser.add_argument(
+        "--selected-task-id",
+        help="Optional public task id label for the metadata-only candidate.",
+    )
+    ale_local_runner_readiness_parser.add_argument(
+        "--snapshot",
+        default=AGENTS_LAST_EXAM_DEFAULT_SNAPSHOT,
+        help="ALE snapshot label to check. Defaults to cpu-free-ubuntu.",
+    )
+    ale_local_runner_readiness_parser.add_argument(
+        "--image",
+        default=AGENTS_LAST_EXAM_DEFAULT_DOCKER_IMAGE,
+        help="Primary local Docker image ref to inspect.",
+    )
+    ale_local_runner_readiness_parser.add_argument(
+        "--alternate-image",
+        default=AGENTS_LAST_EXAM_DEFAULT_ALT_DOCKER_IMAGE,
+        help="Optional alternate local Docker image ref to inspect.",
+    )
+    ale_local_runner_readiness_parser.add_argument(
+        "--provider-kind",
+        choices=["docker"],
+        default="docker",
+        help="Provider kind. Only local docker is runner-ready.",
+    )
+    ale_local_runner_readiness_parser.add_argument(
+        "--runner-binary",
+        help=(
+            "PATH-visible runner binary name to probe. Absolute or relative paths "
+            "are rejected so local paths are not recorded."
+        ),
+    )
+    ale_local_runner_readiness_parser.add_argument(
+        "--runner-python-module",
+        help=(
+            "Optional Python module to probe when the runner command is "
+            "`python -m <module>`. The module path is never recorded."
+        ),
+    )
+    ale_local_runner_readiness_parser.add_argument(
+        "--runner-source-root",
+        help=(
+            "Optional local source checkout root to add only for module probing. "
+            "The local path is never recorded in output."
+        ),
+    )
+    ale_local_runner_readiness_parser.add_argument(
+        "--runner-command-label",
+        help=(
+            "Public-safe label for the configured runner command. The command "
+            "argv itself is never recorded."
+        ),
+    )
+    ale_local_runner_readiness_parser.add_argument(
+        "--operator-authorized",
+        action="store_true",
+        help="Mark that the operator authorized local container start for dry-run.",
+    )
+    ale_local_runner_readiness_parser.add_argument(
+        "--allow-public-task-material",
+        action="store_true",
+        help="Mark that public ALE task material may be touched by a later dry-run.",
+    )
+    ale_local_runner_readiness_parser.add_argument(
+        "--require-ready",
+        action="store_true",
+        help="Return non-zero unless the local runner readiness gate is ready.",
+    )
+    ale_local_runner_readiness_parser.add_argument(
+        "--no-docker-probe",
+        action="store_true",
+        help=(
+            "Do not call Docker; emit a fixture-like blocked readiness payload. "
+            "Used by dependency-free smokes."
+        ),
+    )
+
+    ale_local_source_readiness_parser = benchmark_subparsers.add_parser(
+        "ale-local-source-readiness",
+        help=(
+            "Check whether a local Agents' Last Exam source checkout can be used "
+            "as a redacted public runner source lock. This reads git metadata and "
+            "module availability only; it does not start containers, read task "
+            "bodies, invoke model APIs, upload, or submit."
+        ),
+    )
+    add_subcommand_format(ale_local_source_readiness_parser)
+    ale_local_source_readiness_parser.add_argument(
+        "--source-root",
+        required=True,
+        help="Local ALE source checkout root to probe. The path is never recorded.",
+    )
+    ale_local_source_readiness_parser.add_argument(
+        "--expected-repo-url",
+        default="https://github.com/rdi-berkeley/agents-last-exam.git",
+        help="Expected public ALE repository URL.",
+    )
+    ale_local_source_readiness_parser.add_argument(
+        "--runner-python-module",
+        default="ale_run",
+        help="Python module expected to provide the ALE runner CLI.",
+    )
+    ale_local_source_readiness_parser.add_argument(
+        "--fetch-origin",
+        action="store_true",
+        help=(
+            "Run git fetch --prune origin before checking freshness. The command "
+            "argv, local path, and raw git output are never recorded."
+        ),
+    )
+    ale_local_source_readiness_parser.add_argument(
+        "--require-upstream-current",
+        action="store_true",
+        help="Require HEAD to match the configured upstream ref before returning ready.",
+    )
+    ale_local_source_readiness_parser.add_argument(
+        "--require-ready",
+        action="store_true",
+        help="Return non-zero unless the source readiness gate is ready.",
+    )
+
+
+def handle_agents_last_exam_runner_source_command(
+    args: argparse.Namespace,
+    *,
+    print_payload: PrintPayload,
+    output_format: OutputFormat,
+) -> int | None:
+    if args.benchmark_command not in AGENTS_LAST_EXAM_RUNNER_SOURCE_COMMANDS:
+        return None
+
+    if args.benchmark_command == "ale-local-runner-readiness":
+        try:
+            image_metadata = None
+            alternate_image_metadata = None
+            if args.no_docker_probe:
+                image_metadata = {
+                    "image_ref": args.image,
+                    "present": False,
+                    "probe_available": False,
+                    "first_blocker": "docker_probe_disabled",
+                }
+                alternate_image_metadata = {
+                    "image_ref": args.alternate_image,
+                    "present": False,
+                    "probe_available": False,
+                    "first_blocker": "docker_probe_disabled",
+                }
+            payload = build_agents_last_exam_local_runner_readiness(
+                selected_task_id=args.selected_task_id,
+                snapshot=args.snapshot,
+                provider_kind=args.provider_kind,
+                image_ref=args.image,
+                alternate_image_ref=args.alternate_image,
+                runner_binary=args.runner_binary,
+                runner_python_module=args.runner_python_module,
+                runner_source_root=args.runner_source_root,
+                runner_command_label=args.runner_command_label,
+                operator_authorized=bool(args.operator_authorized),
+                allow_public_task_material=bool(args.allow_public_task_material),
+                fetch_origin=bool(getattr(args, "fetch_origin", False)),
+                require_upstream_current=bool(
+                    getattr(args, "require_upstream_current", False)
+                ),
+                image_metadata=image_metadata,
+                alternate_image_metadata=alternate_image_metadata,
+            )
+        except Exception:
+            payload = {
+                "ok": False,
+                "schema_version": "agents_last_exam_local_runner_readiness_v0",
+                "error": "ale_local_runner_readiness_failed",
+                "read_boundary": {
+                    "compact_only": True,
+                    "task_text_read": False,
+                    "raw_artifacts_read": False,
+                    "local_paths_recorded": False,
+                    "container_started": False,
+                },
+            }
+        else:
+            payload["ok"] = True
+            if args.require_ready and payload.get("ready") is not True:
+                payload["ok"] = False
+                payload["error"] = (
+                    payload.get("first_blocker")
+                    or "ale_local_runner_readiness_not_ready"
+                )
+        print_payload(
+            payload,
+            output_format(args),
+            render_agents_last_exam_local_runner_readiness_markdown,
+        )
+        return 0 if payload.get("ok") else 1
+
+    if args.benchmark_command == "ale-local-source-readiness":
+        try:
+            payload = build_agents_last_exam_local_source_readiness(
+                source_root=args.source_root,
+                expected_repo_url=args.expected_repo_url,
+                runner_python_module=args.runner_python_module,
+                fetch_origin=bool(args.fetch_origin),
+                require_upstream_current=bool(args.require_upstream_current),
+            )
+        except Exception:
+            payload = {
+                "ok": False,
+                "schema_version": "agents_last_exam_local_source_readiness_v0",
+                "error": "ale_local_source_readiness_failed",
+                "read_boundary": {
+                    "compact_only": True,
+                    "task_text_read": False,
+                    "raw_artifacts_read": False,
+                    "local_paths_recorded": False,
+                    "container_started": False,
+                },
+            }
+        else:
+            payload["ok"] = True
+            if args.require_ready and payload.get("ready") is not True:
+                payload["ok"] = False
+                payload["error"] = (
+                    payload.get("first_blocker")
+                    or "ale_local_source_readiness_not_ready"
+                )
+        print_payload(
+            payload,
+            output_format(args),
+            render_agents_last_exam_local_source_readiness_markdown,
+        )
+        return 0 if payload.get("ok") else 1
+
+    return None


### PR DESCRIPTION
## Summary
- extract ALE local runner/source readiness CLI registration and handler code into agents_last_exam_runner_source.py
- keep agents_last_exam.py as the aggregate ALE dispatcher while reducing it from 1802 to 1506 lines
- tighten the module-size guard budget for agents_last_exam.py and add smoke assertions preventing runner/source logic from leaking back

## Validation
- python3 examples/cli-agents-last-exam-command-modularization-smoke.py
- python3 examples/cli-command-module-size-ownership-command-modularization-smoke.py
- python3 all examples/cli-*-command-modularization-smoke.py
- python3 -m py_compile loopx/*.py loopx/cli_commands/*.py plus new agents_last_exam_runner_source.py
- python3 -m loopx.cli benchmark ale-local-runner-readiness --no-docker-probe --format json
- python3 -m loopx.cli benchmark ale-local-source-readiness --source-root . --format json
- loopx check --scan-path loopx/cli_commands/agents_last_exam.py --scan-path loopx/cli_commands/agents_last_exam_runner_source.py --scan-path examples/cli-agents-last-exam-command-modularization-smoke.py --scan-path examples/cli-command-module-size-ownership-command-modularization-smoke.py
