### PR TITLE
Extract ALE task material CLI command families

### DIFF
--- a/examples/cli-agents-last-exam-command-modularization-smoke.py
+++ b/examples/cli-agents-last-exam-command-modularization-smoke.py
@@ -43,6 +43,12 @@ def main() -> int:
     runner_source_source = (
         ROOT / "loopx" / "cli_commands" / "agents_last_exam_runner_source.py"
     ).read_text(encoding="utf-8")
+    baked_input_source = (
+        ROOT / "loopx" / "cli_commands" / "agents_last_exam_baked_input.py"
+    ).read_text(encoding="utf-8")
+    task_material_source = (
+        ROOT / "loopx" / "cli_commands" / "agents_last_exam_task_material.py"
+    ).read_text(encoding="utf-8")
 
     leaked_markers = [
         "ale_local_preflight_parser = benchmark_sub.add_parser",
@@ -65,6 +71,10 @@ def main() -> int:
     assert_contains(init_source, "handle_agents_last_exam_local_plan_command")
     assert_contains(init_source, "register_agents_last_exam_runner_source_commands")
     assert_contains(init_source, "handle_agents_last_exam_runner_source_command")
+    assert_contains(init_source, "register_agents_last_exam_baked_input_commands")
+    assert_contains(init_source, "handle_agents_last_exam_baked_input_command")
+    assert_contains(init_source, "register_agents_last_exam_task_material_commands")
+    assert_contains(init_source, "handle_agents_last_exam_task_material_command")
     assert_contains(ale_source, "AGENTS_LAST_EXAM_COMMANDS")
     assert_contains(ale_source, "ale-validation-run-gate")
     assert_contains(
@@ -82,6 +92,22 @@ def main() -> int:
     assert_contains(
         ale_source,
         "handle_agents_last_exam_runner_source_command(",
+    )
+    assert_contains(
+        ale_source,
+        "register_agents_last_exam_baked_input_commands(",
+    )
+    assert_contains(
+        ale_source,
+        "handle_agents_last_exam_baked_input_command(",
+    )
+    assert_contains(
+        ale_source,
+        "register_agents_last_exam_task_material_commands(",
+    )
+    assert_contains(
+        ale_source,
+        "handle_agents_last_exam_task_material_command(",
     )
     for marker in (
         "def render_agents_last_exam_local_preflight_markdown",
@@ -104,6 +130,28 @@ def main() -> int:
         if marker in ale_source:
             raise AssertionError(f"{marker} leaked back into agents_last_exam.py")
         assert_contains(runner_source_source, marker)
+    for marker in (
+        "def render_agents_last_exam_baked_task_input_readiness_markdown",
+        "def render_agents_last_exam_baked_task_input_scan_markdown",
+        "build_agents_last_exam_baked_task_input_readiness(",
+        "build_agents_last_exam_baked_task_input_scan(",
+        'if args.benchmark_command == "ale-baked-task-input-readiness":',
+        'if args.benchmark_command == "ale-baked-task-input-scan":',
+    ):
+        if marker in ale_source:
+            raise AssertionError(f"{marker} leaked back into agents_last_exam.py")
+        assert_contains(baked_input_source, marker)
+    for marker in (
+        "def render_agents_last_exam_task_material_readiness_markdown",
+        "def render_agents_last_exam_candidate_task_data_scan_markdown",
+        "build_agents_last_exam_task_material_readiness(",
+        "build_agents_last_exam_candidate_task_data_scan(",
+        'if args.benchmark_command == "ale-task-material-readiness":',
+        'if args.benchmark_command == "ale-candidate-task-data-scan":',
+    ):
+        if marker in ale_source:
+            raise AssertionError(f"{marker} leaked back into agents_last_exam.py")
+        assert_contains(task_material_source, marker)
 
     help_result = run_cli("benchmark", "ale-validation-run-gate", "--help")
     if help_result.returncode != 0:
@@ -148,6 +196,59 @@ def main() -> int:
         raise AssertionError(host_route_payload)
     if host_route_payload["boundary"].get("local_paths_recorded") is not False:
         raise AssertionError(host_route_payload)
+
+    baked_input_result = run_cli(
+        "benchmark",
+        "ale-baked-task-input-readiness",
+        "--selected-task-id",
+        "demo/task",
+        "--no-docker-run",
+        "--format",
+        "json",
+    )
+    if baked_input_result.returncode != 0:
+        raise AssertionError(baked_input_result.stderr or baked_input_result.stdout)
+    baked_input_payload = json.loads(baked_input_result.stdout)
+    if baked_input_payload.get("ok") is not True:
+        raise AssertionError(baked_input_payload)
+    if baked_input_payload["boundary"].get("task_data_content_read") is not False:
+        raise AssertionError(baked_input_payload)
+
+    task_material_result = run_cli(
+        "benchmark",
+        "ale-task-material-readiness",
+        "--source-root",
+        ".",
+        "--selected-task-id",
+        "demo/task",
+        "--format",
+        "json",
+    )
+    if task_material_result.returncode != 0:
+        raise AssertionError(
+            task_material_result.stderr or task_material_result.stdout
+        )
+    task_material_payload = json.loads(task_material_result.stdout)
+    if task_material_payload.get("ok") is not True:
+        raise AssertionError(task_material_payload)
+    if task_material_payload["boundary"].get("task_body_read") is not False:
+        raise AssertionError(task_material_payload)
+
+    candidate_scan_result = run_cli(
+        "benchmark",
+        "ale-candidate-task-data-scan",
+        "--source-root",
+        ".",
+        "--format",
+        "json",
+    )
+    if candidate_scan_result.returncode != 0:
+        raise AssertionError(candidate_scan_result.stderr or candidate_scan_result.stdout)
+    candidate_scan_payload = json.loads(candidate_scan_result.stdout)
+    if candidate_scan_payload.get("ok") is not True:
+        raise AssertionError(candidate_scan_payload)
+    if candidate_scan_payload["boundary"].get("task_config_line_scan") is not True:
+        raise AssertionError(candidate_scan_payload)
 
     with tempfile.TemporaryDirectory() as temp_dir:
         missing_gate = Path(temp_dir) / "missing-gate.json"

--- a/examples/cli-command-module-size-ownership-command-modularization-smoke.py
+++ b/examples/cli-command-module-size-ownership-command-modularization-smoke.py
@@ -10,7 +10,7 @@ CLI_COMMANDS = ROOT / "loopx" / "cli_commands"
 
 DEFAULT_MAX_LINES = 500
 LEGACY_MODULE_LIMITS = {
-    "agents_last_exam.py": 1560,
+    "agents_last_exam.py": 1020,
     "benchmark_review_lifecycle.py": 1300,
     "benchmark_run_ledger.py": 1360,
     "history.py": 720,

--- a/loopx/cli_commands/__init__.py
+++ b/loopx/cli_commands/__init__.py
@@ -12,6 +12,10 @@ from .agents_last_exam import (
     handle_agents_last_exam_command,
     register_agents_last_exam_commands,
 )
+from .agents_last_exam_baked_input import (
+    handle_agents_last_exam_baked_input_command,
+    register_agents_last_exam_baked_input_commands,
+)
 from .agents_last_exam_local_plan import (
     handle_agents_last_exam_local_plan_command,
     register_agents_last_exam_local_plan_commands,
@@ -19,6 +23,10 @@ from .agents_last_exam_local_plan import (
 from .agents_last_exam_runner_source import (
     handle_agents_last_exam_runner_source_command,
     register_agents_last_exam_runner_source_commands,
+)
+from .agents_last_exam_task_material import (
+    handle_agents_last_exam_task_material_command,
+    register_agents_last_exam_task_material_commands,
 )
 from .agentissue_runner_flow import (
     handle_agentissue_runner_flow_command,
@@ -123,8 +131,10 @@ from .worker_bridge import handle_worker_bridge_command, register_worker_bridge_
 
 __all__ = [
     "handle_agents_last_exam_command",
+    "handle_agents_last_exam_baked_input_command",
     "handle_agents_last_exam_local_plan_command",
     "handle_agents_last_exam_runner_source_command",
+    "handle_agents_last_exam_task_material_command",
     "handle_agentissue_runner_flow_command",
     "handle_benchmark_boundary_command",
     "handle_benchmark_command",
@@ -172,8 +182,10 @@ __all__ = [
     "handle_todo_command",
     "handle_worker_bridge_command",
     "register_agents_last_exam_commands",
+    "register_agents_last_exam_baked_input_commands",
     "register_agents_last_exam_local_plan_commands",
     "register_agents_last_exam_runner_source_commands",
+    "register_agents_last_exam_task_material_commands",
     "register_agentissue_runner_flow_commands",
     "register_benchmark_boundary_commands",
     "register_benchmark_command_group",

--- a/loopx/cli_commands/agents_last_exam.py
+++ b/loopx/cli_commands/agents_last_exam.py
@@ -9,15 +9,16 @@ from ..benchmark_adapters.agents_last_exam import (
     AGENTS_LAST_EXAM_DEFAULT_ALT_DOCKER_IMAGE,
     AGENTS_LAST_EXAM_DEFAULT_DOCKER_IMAGE,
     AGENTS_LAST_EXAM_DEFAULT_SNAPSHOT,
-    build_agents_last_exam_baked_task_input_readiness,
-    build_agents_last_exam_baked_task_input_scan,
-    build_agents_last_exam_candidate_task_data_scan,
     build_agents_last_exam_host_codex_cli_route,
     build_agents_last_exam_host_codex_cua_no_task_smoke_from_environment,
     build_agents_last_exam_local_exact_dry_run_result,
     build_agents_last_exam_local_launch_packet,
-    build_agents_last_exam_task_material_readiness,
     build_agents_last_exam_validation_run_gate,
+)
+from .agents_last_exam_baked_input import (
+    AGENTS_LAST_EXAM_BAKED_INPUT_COMMANDS,
+    handle_agents_last_exam_baked_input_command,
+    register_agents_last_exam_baked_input_commands,
 )
 from .agents_last_exam_local_plan import (
     AGENTS_LAST_EXAM_LOCAL_PLAN_COMMANDS,
@@ -29,6 +30,11 @@ from .agents_last_exam_runner_source import (
     handle_agents_last_exam_runner_source_command,
     register_agents_last_exam_runner_source_commands,
 )
+from .agents_last_exam_task_material import (
+    AGENTS_LAST_EXAM_TASK_MATERIAL_COMMANDS,
+    handle_agents_last_exam_task_material_command,
+    register_agents_last_exam_task_material_commands,
+)
 
 
 PrintPayload = Callable[
@@ -38,155 +44,17 @@ PrintPayload = Callable[
 OutputFormat = Callable[[argparse.Namespace], str]
 
 AGENTS_LAST_EXAM_COMMANDS = {
-    "ale-task-material-readiness",
-    "ale-baked-task-input-readiness",
-    "ale-baked-task-input-scan",
-    "ale-candidate-task-data-scan",
     "ale-local-launch-packet",
     "ale-local-exact-dry-run-result",
     "ale-host-codex-cli-route",
     "ale-host-codex-cua-no-task-e2e",
     "ale-validation-run-gate",
-} | AGENTS_LAST_EXAM_LOCAL_PLAN_COMMANDS | AGENTS_LAST_EXAM_RUNNER_SOURCE_COMMANDS
-
-
-def render_agents_last_exam_task_material_readiness_markdown(
-    payload: dict[str, object],
-) -> str:
-    task = payload.get("task") if isinstance(payload.get("task"), dict) else {}
-    public_lists = (
-        payload.get("public_task_lists")
-        if isinstance(payload.get("public_task_lists"), dict)
-        else {}
-    )
-    boundary = payload.get("boundary") if isinstance(payload.get("boundary"), dict) else {}
-    decision = (
-        payload.get("decision") if isinstance(payload.get("decision"), dict) else {}
-    )
-    task_data = payload.get("task_data") if isinstance(payload.get("task_data"), dict) else {}
-    local_staging = (
-        task_data.get("local_task_data_staging")
-        if isinstance(task_data.get("local_task_data_staging"), dict)
-        else {}
-    )
-    lines = [
-        "# Agents Last Exam Task Material Readiness",
-        "",
-        f"- Schema: `{payload.get('schema_version')}`",
-        f"- Ready: `{payload.get('ready')}`",
-        f"- First blocker: `{payload.get('first_blocker')}`",
-        f"- Task: `{task.get('task_id')}`",
-        f"- Task dir/card/scripts: `{task.get('task_dir_available')}`/`{task.get('task_card_json_present')}`/`{task.get('scripts_dir_present')}`",
-        f"- Scorer script count: `{task.get('scorer_script_count')}`",
-        f"- Task data checked/ready/source: `{task_data.get('checked')}`/`{task_data.get('ready')}`/`{task_data.get('task_data_source')}`",
-        f"- Local task-data staging route/tool/auth checked: `{local_staging.get('route')}`/`{local_staging.get('fetch_tool_present')}`/`{local_staging.get('auth_status_checked')}`",
-        f"- Public list membership checked/present: `{public_lists.get('checked')}`/`{public_lists.get('present_count')}`",
-        f"- Task body/card/script content read: `{boundary.get('task_body_read')}`/`{boundary.get('task_card_content_read')}`/`{boundary.get('script_content_read')}`",
-        f"- Local paths/raw output recorded: `{boundary.get('local_paths_recorded')}`/`{boundary.get('raw_output_recorded')}`",
-        f"- Container/model/upload/submit: `{boundary.get('container_started')}`/`{boundary.get('model_api_invoked')}`/`{boundary.get('no_upload')}`/`{boundary.get('submit_eligible')}`",
-        f"- Next action: {decision.get('next_allowed_action')}",
-    ]
-    return "\n".join(lines) + "\n"
-
-
-def render_agents_last_exam_baked_task_input_readiness_markdown(
-    payload: dict[str, object],
-) -> str:
-    task = payload.get("task") if isinstance(payload.get("task"), dict) else {}
-    image = payload.get("image") if isinstance(payload.get("image"), dict) else {}
-    probe = payload.get("probe") if isinstance(payload.get("probe"), dict) else {}
-    boundary = (
-        payload.get("boundary") if isinstance(payload.get("boundary"), dict) else {}
-    )
-    lines = [
-        "# Agents Last Exam Baked Task Input Readiness",
-        "",
-        f"- Schema: `{payload.get('schema_version')}`",
-        f"- Ready: `{payload.get('ready')}`",
-        f"- First blocker: `{payload.get('first_blocker')}`",
-        f"- Selected task: `{task.get('task_id')}`",
-        f"- Image present: `{image.get('present')}`",
-        f"- Probe attempted/container started: `{probe.get('attempted')}`/`{probe.get('container_started')}`",
-        f"- Baked input present/readable: `{probe.get('baked_input_present')}`/`{probe.get('baked_input_readable')}`",
-        f"- Expected path recorded: `{probe.get('expected_path_recorded')}`",
-        f"- Task run/model/upload/submit: `{boundary.get('task_run_started')}`/`{boundary.get('model_api_invoked')}`/`{boundary.get('no_upload')}`/`{boundary.get('submit_eligible')}`",
-        f"- Task data content read: `{boundary.get('task_data_content_read')}`",
-    ]
-    return "\n".join(lines) + "\n"
-
-
-def render_agents_last_exam_baked_task_input_scan_markdown(
-    payload: dict[str, object],
-) -> str:
-    selected = (
-        payload.get("selected_tasks")
-        if isinstance(payload.get("selected_tasks"), dict)
-        else {}
-    )
-    probe = payload.get("probe") if isinstance(payload.get("probe"), dict) else {}
-    candidates = (
-        payload.get("candidates")
-        if isinstance(payload.get("candidates"), dict)
-        else {}
-    )
-    boundary = (
-        payload.get("boundary") if isinstance(payload.get("boundary"), dict) else {}
-    )
-    lines = [
-        "# Agents Last Exam Baked Task Input Scan",
-        "",
-        f"- Schema: `{payload.get('schema_version')}`",
-        f"- Ready: `{payload.get('ready')}`",
-        f"- First blocker: `{payload.get('first_blocker')}`",
-        f"- Selected/probed tasks: `{selected.get('selected_task_count')}`/`{selected.get('probed_task_count')}`",
-        f"- Probe attempted/container started: `{probe.get('attempted')}`/`{probe.get('container_started')}`",
-        f"- Baked input candidate count: `{probe.get('baked_input_candidate_count')}`",
-        f"- Candidate ids: `{candidates.get('eligible_baked_input_candidates')}`",
-        f"- Expected paths/argv/stdout recorded: `{probe.get('expected_path_recorded')}`/`{probe.get('command_argv_recorded')}`/`{probe.get('stdout_recorded')}`",
-        f"- Task run/model/upload/submit: `{boundary.get('task_run_started')}`/`{boundary.get('model_api_invoked')}`/`{boundary.get('no_upload')}`/`{boundary.get('submit_eligible')}`",
-        f"- Task data content read/listed: `{boundary.get('task_data_content_read')}`/`{boundary.get('directory_listed')}`",
-    ]
-    return "\n".join(lines) + "\n"
-
-
-def render_agents_last_exam_candidate_task_data_scan_markdown(
-    payload: dict[str, object],
-) -> str:
-    selected = (
-        payload.get("selected_task_lists")
-        if isinstance(payload.get("selected_task_lists"), dict)
-        else {}
-    )
-    summary = (
-        payload.get("scan_summary")
-        if isinstance(payload.get("scan_summary"), dict)
-        else {}
-    )
-    candidates = (
-        payload.get("candidate_tasks")
-        if isinstance(payload.get("candidate_tasks"), dict)
-        else {}
-    )
-    boundary = payload.get("boundary") if isinstance(payload.get("boundary"), dict) else {}
-    decision = (
-        payload.get("decision") if isinstance(payload.get("decision"), dict) else {}
-    )
-    lines = [
-        "# Agents Last Exam Candidate Task-Data Scan",
-        "",
-        f"- Schema: `{payload.get('schema_version')}`",
-        f"- Ready: `{payload.get('ready')}`",
-        f"- First blocker: `{payload.get('first_blocker')}`",
-        f"- Selected tasks/lists: `{selected.get('selected_task_count')}`/`{selected.get('checked_list_count')}`",
-        f"- Configs checked/missing: `{summary.get('task_config_checked_count')}`/`{summary.get('task_config_missing_or_unreadable_count')}`",
-        f"- No-task-data formal/demo candidates: `{summary.get('formal_no_task_data_candidate_count')}`/`{summary.get('demo_no_task_data_candidate_count')}`",
-        f"- Eligible candidates: `{candidates.get('eligible_no_task_data_candidates')}`",
-        f"- Config line scan/source recorded: `{boundary.get('task_config_line_scan')}`/`{boundary.get('task_config_source_content_recorded')}`",
-        f"- Task card/script/instruction read: `{boundary.get('task_card_content_read')}`/`{boundary.get('script_content_read')}`/`{boundary.get('task_instruction_file_read')}`",
-        f"- Local paths/raw output recorded: `{boundary.get('local_paths_recorded')}`/`{boundary.get('raw_output_recorded')}`",
-        f"- Next action: {decision.get('next_allowed_action')}",
-    ]
-    return "\n".join(lines) + "\n"
+} | (
+    AGENTS_LAST_EXAM_LOCAL_PLAN_COMMANDS
+    | AGENTS_LAST_EXAM_RUNNER_SOURCE_COMMANDS
+    | AGENTS_LAST_EXAM_TASK_MATERIAL_COMMANDS
+    | AGENTS_LAST_EXAM_BAKED_INPUT_COMMANDS
+)
 
 
 def render_agents_last_exam_local_launch_packet_markdown(
@@ -425,217 +293,13 @@ def register_agents_last_exam_commands(
         benchmark_subparsers,
         add_subcommand_format,
     )
-
-    ale_task_material_readiness_parser = benchmark_subparsers.add_parser(
-        "ale-task-material-readiness",
-        help=(
-            "Check whether a selected public ALE task has local material signals "
-            "needed for a future local/no-upload run. This checks directory, "
-            "task_card.json, scripts, scorer scripts, and public selected-task "
-            "list membership only; it does not read task card content, task "
-            "bodies, scripts, trajectories, screenshots, credentials, upload, or submit."
-        ),
+    register_agents_last_exam_baked_input_commands(
+        benchmark_subparsers,
+        add_subcommand_format,
     )
-    add_subcommand_format(ale_task_material_readiness_parser)
-    ale_task_material_readiness_parser.add_argument(
-        "--source-root",
-        required=True,
-        help="Local ALE source checkout root to probe. The path is never recorded.",
-    )
-    ale_task_material_readiness_parser.add_argument(
-        "--selected-task-id",
-        required=True,
-        help="Public ALE task id in category/name form.",
-    )
-    ale_task_material_readiness_parser.add_argument(
-        "--selected-task-list",
-        action="append",
-        default=[],
-        help=(
-            "Public selected_tasks list to check, relative to selected_tasks/. "
-            "May be repeated. Defaults to linux_only.txt and unlicensed/near-term.txt."
-        ),
-    )
-    ale_task_material_readiness_parser.add_argument(
-        "--requires-task-data",
-        choices=("true", "false", "unknown"),
-        help=(
-            "Optional compact task-data requirement signal. Use unknown with "
-            "--enforce-task-data-source to fail closed before a formal task run."
-        ),
-    )
-    ale_task_material_readiness_parser.add_argument(
-        "--task-data-source",
-        help=(
-            "Compact task_data_source label such as baked_in_sandbox or "
-            "gs://ale-data-public. Credential values and paths are never recorded."
-        ),
-    )
-    ale_task_material_readiness_parser.add_argument(
-        "--baked-task-input-present",
-        action="store_true",
-        help="Mark that the selected task's baked sandbox input directory was verified present.",
-    )
-    ale_task_material_readiness_parser.add_argument(
-        "--baked-task-input-readiness-json",
-        help=(
-            "Compact ale-baked-task-input-readiness JSON artifact to consume "
-            "instead of relying on a manual baked-input boolean."
-        ),
-    )
-    ale_task_material_readiness_parser.add_argument(
-        "--gcs-sa-key",
-        help="Service-account key path to check for existence only; the path/value is never recorded.",
-    )
-    ale_task_material_readiness_parser.add_argument(
-        "--gcs-sa-key-present",
-        action="store_true",
-        help="Fixture/operator assertion that the service-account key file presence was verified.",
-    )
-    ale_task_material_readiness_parser.add_argument(
-        "--enforce-task-data-source",
-        action="store_true",
-        help="Require task-data source readiness before returning ready.",
-    )
-    ale_task_material_readiness_parser.add_argument(
-        "--require-ready",
-        action="store_true",
-        help="Return non-zero unless the task material readiness gate is ready.",
-    )
-
-    ale_baked_task_input_readiness_parser = benchmark_subparsers.add_parser(
-        "ale-baked-task-input-readiness",
-        help=(
-            "Probe whether a local ALE Docker image contains a selected task's "
-            "baked input directory. This may start a tiny shell in Docker, but "
-            "it does not run the task, list files, read task data, invoke models, "
-            "upload, submit, or record local/container paths."
-        ),
-    )
-    add_subcommand_format(ale_baked_task_input_readiness_parser)
-    ale_baked_task_input_readiness_parser.add_argument(
-        "--selected-task-id",
-        required=True,
-        help="Public ALE task id in category/name form.",
-    )
-    ale_baked_task_input_readiness_parser.add_argument(
-        "--image",
-        default=AGENTS_LAST_EXAM_DEFAULT_DOCKER_IMAGE,
-        help="Local ALE Docker image ref to probe.",
-    )
-    ale_baked_task_input_readiness_parser.add_argument(
-        "--docker-binary",
-        default="docker",
-        help="PATH-visible Docker binary name to use.",
-    )
-    ale_baked_task_input_readiness_parser.add_argument(
-        "--timeout-seconds",
-        type=int,
-        default=60,
-        help="Timeout for the tiny Docker path-existence probe.",
-    )
-    ale_baked_task_input_readiness_parser.add_argument(
-        "--no-docker-run",
-        action="store_true",
-        help="Do not start Docker; emit a fixture-like blocked readiness payload.",
-    )
-    ale_baked_task_input_readiness_parser.add_argument(
-        "--require-ready",
-        action="store_true",
-        help="Return non-zero unless the baked task input readiness gate is ready.",
-    )
-
-    ale_baked_task_input_scan_parser = benchmark_subparsers.add_parser(
-        "ale-baked-task-input-scan",
-        help=(
-            "Batch-scan public ALE selected tasks for baked input directories in "
-            "a local Docker image. This may start one tiny shell in Docker, but "
-            "does not run tasks, list files, read task data, invoke models, "
-            "upload, submit, or record local/container paths."
-        ),
-    )
-    add_subcommand_format(ale_baked_task_input_scan_parser)
-    ale_baked_task_input_scan_parser.add_argument(
-        "--source-root",
-        required=True,
-        help="Local ALE source checkout root to read selected-task lists from. The path is never recorded.",
-    )
-    ale_baked_task_input_scan_parser.add_argument(
-        "--selected-task-list",
-        action="append",
-        default=[],
-        help=(
-            "Public selected_tasks list to scan, relative to selected_tasks/. "
-            "May be repeated. Defaults to linux_only.txt and unlicensed/near-term.txt."
-        ),
-    )
-    ale_baked_task_input_scan_parser.add_argument(
-        "--image",
-        default=AGENTS_LAST_EXAM_DEFAULT_DOCKER_IMAGE,
-        help="Local ALE Docker image ref to probe.",
-    )
-    ale_baked_task_input_scan_parser.add_argument(
-        "--docker-binary",
-        default="docker",
-        help="PATH-visible Docker binary name to use.",
-    )
-    ale_baked_task_input_scan_parser.add_argument(
-        "--max-tasks",
-        type=int,
-        default=120,
-        help="Maximum selected public task ids to probe.",
-    )
-    ale_baked_task_input_scan_parser.add_argument(
-        "--timeout-seconds",
-        type=int,
-        default=180,
-        help="Timeout for the batch Docker path-existence probe.",
-    )
-    ale_baked_task_input_scan_parser.add_argument(
-        "--no-docker-run",
-        action="store_true",
-        help="Do not start Docker; emit a fixture-like blocked scan payload.",
-    )
-    ale_baked_task_input_scan_parser.add_argument(
-        "--require-ready",
-        action="store_true",
-        help="Return non-zero unless at least one baked-input candidate is found.",
-    )
-
-    ale_candidate_task_data_scan_parser = benchmark_subparsers.add_parser(
-        "ale-candidate-task-data-scan",
-        help=(
-            "Scan public ALE selected-task lists for tasks with an explicit "
-            "REQUIRES_TASK_DATA=False config signal. The scan records only "
-            "counts and public task ids; it does not record task source text, "
-            "task cards, instructions, scripts, trajectories, screenshots, "
-            "credentials, uploads, or submits."
-        ),
-    )
-    add_subcommand_format(ale_candidate_task_data_scan_parser)
-    ale_candidate_task_data_scan_parser.add_argument(
-        "--source-root",
-        required=True,
-        help="Local ALE source checkout root to probe. The path is never recorded.",
-    )
-    ale_candidate_task_data_scan_parser.add_argument(
-        "--selected-task-list",
-        action="append",
-        default=[],
-        help=(
-            "Public selected_tasks list to scan, relative to selected_tasks/. "
-            "May be repeated. Defaults to linux_only.txt and unlicensed/near-term.txt."
-        ),
-    )
-    ale_candidate_task_data_scan_parser.add_argument(
-        "--allow-demo-candidate",
-        action="store_true",
-        help="Allow demo/* no-task-data tasks to satisfy readiness.",
-    )
-    ale_candidate_task_data_scan_parser.add_argument(
-        "--require-ready",
-        action="store_true",
-        help="Return non-zero unless at least one eligible no-task-data candidate is found.",
+    register_agents_last_exam_task_material_commands(
+        benchmark_subparsers,
+        add_subcommand_format,
     )
 
     ale_local_launch_packet_parser = benchmark_subparsers.add_parser(
@@ -1025,209 +689,22 @@ def handle_agents_last_exam_command(
     if runner_source_result is not None:
         return runner_source_result
 
-    if args.benchmark_command == "ale-task-material-readiness":
-        try:
-            selected_task_lists = (
-                args.selected_task_list
-                if args.selected_task_list
-                else ["linux_only.txt", "unlicensed/near-term.txt"]
-            )
-            baked_task_input_readiness = None
-            if args.baked_task_input_readiness_json:
-                baked_task_input_readiness = json.loads(
-                    Path(args.baked_task_input_readiness_json)
-                    .expanduser()
-                    .read_text(encoding="utf-8")
-                )
-            payload = build_agents_last_exam_task_material_readiness(
-                source_root=args.source_root,
-                selected_task_id=args.selected_task_id,
-                selected_task_lists=selected_task_lists,
-                requires_task_data=None
-                if args.requires_task_data in {None, "unknown"}
-                else args.requires_task_data,
-                task_data_source=args.task_data_source,
-                baked_task_input_present=True
-                if args.baked_task_input_present
-                else None,
-                baked_task_input_readiness=baked_task_input_readiness,
-                gcs_sa_key=args.gcs_sa_key,
-                gcs_sa_key_present=True if args.gcs_sa_key_present else None,
-                enforce_task_data_source=bool(args.enforce_task_data_source),
-            )
-        except Exception:
-            payload = {
-                "ok": False,
-                "schema_version": "agents_last_exam_task_material_readiness_v0",
-                "error": "ale_task_material_readiness_failed",
-                "read_boundary": {
-                    "compact_only": True,
-                    "task_text_read": False,
-                    "task_card_content_read": False,
-                    "script_content_read": False,
-                    "raw_artifacts_read": False,
-                    "local_paths_recorded": False,
-                    "container_started": False,
-                },
-            }
-        else:
-            payload["ok"] = True
-            if args.require_ready and payload.get("ready") is not True:
-                payload["ok"] = False
-                payload["error"] = (
-                    payload.get("first_blocker")
-                    or "ale_task_material_readiness_not_ready"
-                )
-        print_payload(
-            payload,
-            output_format(args),
-            render_agents_last_exam_task_material_readiness_markdown,
-        )
-        return 0 if payload.get("ok") else 1
-    if args.benchmark_command == "ale-baked-task-input-readiness":
-        try:
-            image_metadata = None
-            if args.no_docker_run:
-                image_metadata = {
-                    "image_ref": args.image,
-                    "present": False,
-                    "probe_available": False,
-                    "first_blocker": "docker_run_probe_disabled",
-                }
-            payload = build_agents_last_exam_baked_task_input_readiness(
-                selected_task_id=args.selected_task_id,
-                image_ref=args.image,
-                image_metadata=image_metadata,
-                docker_binary=args.docker_binary,
-                timeout_seconds=args.timeout_seconds,
-            )
-        except Exception:
-            payload = {
-                "ok": False,
-                "schema_version": "agents_last_exam_baked_task_input_readiness_v0",
-                "error": "ale_baked_task_input_readiness_failed",
-                "read_boundary": {
-                    "compact_only": True,
-                    "path_existence_only": True,
-                    "task_text_read": False,
-                    "task_card_content_read": False,
-                    "script_content_read": False,
-                    "task_data_content_read": False,
-                    "raw_artifacts_read": False,
-                    "local_paths_recorded": False,
-                },
-            }
-        else:
-            payload["ok"] = True
-            if args.require_ready and payload.get("ready") is not True:
-                payload["ok"] = False
-                payload["error"] = (
-                    payload.get("first_blocker")
-                    or "ale_baked_task_input_readiness_not_ready"
-                )
-        print_payload(
-            payload,
-            output_format(args),
-            render_agents_last_exam_baked_task_input_readiness_markdown,
-        )
-        return 0 if payload.get("ok") else 1
-    if args.benchmark_command == "ale-baked-task-input-scan":
-        try:
-            selected_task_lists = (
-                args.selected_task_list
-                if args.selected_task_list
-                else ["linux_only.txt", "unlicensed/near-term.txt"]
-            )
-            image_metadata = None
-            if args.no_docker_run:
-                image_metadata = {
-                    "image_ref": args.image,
-                    "present": False,
-                    "probe_available": False,
-                    "first_blocker": "docker_run_probe_disabled",
-                }
-            payload = build_agents_last_exam_baked_task_input_scan(
-                source_root=args.source_root,
-                selected_task_lists=selected_task_lists,
-                image_ref=args.image,
-                image_metadata=image_metadata,
-                docker_binary=args.docker_binary,
-                max_tasks=args.max_tasks,
-                timeout_seconds=args.timeout_seconds,
-            )
-        except Exception:
-            payload = {
-                "ok": False,
-                "schema_version": "agents_last_exam_baked_task_input_scan_v0",
-                "error": "ale_baked_task_input_scan_failed",
-                "read_boundary": {
-                    "compact_only": True,
-                    "path_existence_only": True,
-                    "selected_task_lists_read": True,
-                    "task_text_read": False,
-                    "task_card_content_read": False,
-                    "script_content_read": False,
-                    "task_data_content_read": False,
-                    "raw_artifacts_read": False,
-                    "local_paths_recorded": False,
-                },
-            }
-        else:
-            payload["ok"] = True
-            if args.require_ready and payload.get("ready") is not True:
-                payload["ok"] = False
-                payload["error"] = (
-                    payload.get("first_blocker")
-                    or "ale_baked_task_input_scan_not_ready"
-                )
-        print_payload(
-            payload,
-            output_format(args),
-            render_agents_last_exam_baked_task_input_scan_markdown,
-        )
-        return 0 if payload.get("ok") else 1
-    if args.benchmark_command == "ale-candidate-task-data-scan":
-        try:
-            selected_task_lists = (
-                args.selected_task_list
-                if args.selected_task_list
-                else ["linux_only.txt", "unlicensed/near-term.txt"]
-            )
-            payload = build_agents_last_exam_candidate_task_data_scan(
-                source_root=args.source_root,
-                selected_task_lists=selected_task_lists,
-                allow_demo_candidate=bool(args.allow_demo_candidate),
-            )
-        except Exception:
-            payload = {
-                "ok": False,
-                "schema_version": "agents_last_exam_candidate_task_data_scan_v0",
-                "error": "ale_candidate_task_data_scan_failed",
-                "read_boundary": {
-                    "compact_only": True,
-                    "task_config_source_content_recorded": False,
-                    "task_card_content_read": False,
-                    "script_content_read": False,
-                    "task_instruction_file_read": False,
-                    "raw_artifacts_read": False,
-                    "local_paths_recorded": False,
-                    "container_started": False,
-                },
-            }
-        else:
-            payload["ok"] = True
-            if args.require_ready and payload.get("ready") is not True:
-                payload["ok"] = False
-                payload["error"] = (
-                    payload.get("first_blocker")
-                    or "ale_candidate_task_data_scan_not_ready"
-                )
-        print_payload(
-            payload,
-            output_format(args),
-            render_agents_last_exam_candidate_task_data_scan_markdown,
-        )
-        return 0 if payload.get("ok") else 1
+    baked_input_result = handle_agents_last_exam_baked_input_command(
+        args,
+        print_payload=print_payload,
+        output_format=output_format,
+    )
+    if baked_input_result is not None:
+        return baked_input_result
+
+    task_material_result = handle_agents_last_exam_task_material_command(
+        args,
+        print_payload=print_payload,
+        output_format=output_format,
+    )
+    if task_material_result is not None:
+        return task_material_result
+
     if args.benchmark_command == "ale-local-launch-packet":
         try:
             image_metadata = None

--- a/loopx/cli_commands/agents_last_exam_baked_input.py
+++ b/loopx/cli_commands/agents_last_exam_baked_input.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+
+from ..benchmark_adapters.agents_last_exam import (
+    AGENTS_LAST_EXAM_DEFAULT_DOCKER_IMAGE,
+    build_agents_last_exam_baked_task_input_readiness,
+    build_agents_last_exam_baked_task_input_scan,
+)
+
+
+PrintPayload = Callable[
+    [dict[str, object], str, Callable[[dict[str, object]], str]],
+    None,
+]
+OutputFormat = Callable[[argparse.Namespace], str]
+
+AGENTS_LAST_EXAM_BAKED_INPUT_COMMANDS = {
+    "ale-baked-task-input-readiness",
+    "ale-baked-task-input-scan",
+}
+
+
+def render_agents_last_exam_baked_task_input_readiness_markdown(
+    payload: dict[str, object],
+) -> str:
+    task = payload.get("task") if isinstance(payload.get("task"), dict) else {}
+    image = payload.get("image") if isinstance(payload.get("image"), dict) else {}
+    probe = payload.get("probe") if isinstance(payload.get("probe"), dict) else {}
+    boundary = (
+        payload.get("boundary") if isinstance(payload.get("boundary"), dict) else {}
+    )
+    lines = [
+        "# Agents Last Exam Baked Task Input Readiness",
+        "",
+        f"- Schema: `{payload.get('schema_version')}`",
+        f"- Ready: `{payload.get('ready')}`",
+        f"- First blocker: `{payload.get('first_blocker')}`",
+        f"- Selected task: `{task.get('task_id')}`",
+        f"- Image present: `{image.get('present')}`",
+        f"- Probe attempted/container started: `{probe.get('attempted')}`/`{probe.get('container_started')}`",
+        f"- Baked input present/readable: `{probe.get('baked_input_present')}`/`{probe.get('baked_input_readable')}`",
+        f"- Expected path recorded: `{probe.get('expected_path_recorded')}`",
+        f"- Task run/model/upload/submit: `{boundary.get('task_run_started')}`/`{boundary.get('model_api_invoked')}`/`{boundary.get('no_upload')}`/`{boundary.get('submit_eligible')}`",
+        f"- Task data content read: `{boundary.get('task_data_content_read')}`",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def render_agents_last_exam_baked_task_input_scan_markdown(
+    payload: dict[str, object],
+) -> str:
+    selected = (
+        payload.get("selected_tasks")
+        if isinstance(payload.get("selected_tasks"), dict)
+        else {}
+    )
+    probe = payload.get("probe") if isinstance(payload.get("probe"), dict) else {}
+    candidates = (
+        payload.get("candidates")
+        if isinstance(payload.get("candidates"), dict)
+        else {}
+    )
+    boundary = (
+        payload.get("boundary") if isinstance(payload.get("boundary"), dict) else {}
+    )
+    lines = [
+        "# Agents Last Exam Baked Task Input Scan",
+        "",
+        f"- Schema: `{payload.get('schema_version')}`",
+        f"- Ready: `{payload.get('ready')}`",
+        f"- First blocker: `{payload.get('first_blocker')}`",
+        f"- Selected/probed tasks: `{selected.get('selected_task_count')}`/`{selected.get('probed_task_count')}`",
+        f"- Probe attempted/container started: `{probe.get('attempted')}`/`{probe.get('container_started')}`",
+        f"- Baked input candidate count: `{probe.get('baked_input_candidate_count')}`",
+        f"- Candidate ids: `{candidates.get('eligible_baked_input_candidates')}`",
+        f"- Expected paths/argv/stdout recorded: `{probe.get('expected_path_recorded')}`/`{probe.get('command_argv_recorded')}`/`{probe.get('stdout_recorded')}`",
+        f"- Task run/model/upload/submit: `{boundary.get('task_run_started')}`/`{boundary.get('model_api_invoked')}`/`{boundary.get('no_upload')}`/`{boundary.get('submit_eligible')}`",
+        f"- Task data content read/listed: `{boundary.get('task_data_content_read')}`/`{boundary.get('directory_listed')}`",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def register_agents_last_exam_baked_input_commands(
+    benchmark_subparsers: argparse._SubParsersAction,
+    add_subcommand_format: Callable[[argparse.ArgumentParser], None],
+) -> None:
+    ale_baked_task_input_readiness_parser = benchmark_subparsers.add_parser(
+        "ale-baked-task-input-readiness",
+        help=(
+            "Probe whether a local ALE Docker image contains a selected task's "
+            "baked input directory. This may start a tiny shell in Docker, but "
+            "it does not run the task, list files, read task data, invoke models, "
+            "upload, submit, or record local/container paths."
+        ),
+    )
+    add_subcommand_format(ale_baked_task_input_readiness_parser)
+    ale_baked_task_input_readiness_parser.add_argument(
+        "--selected-task-id",
+        required=True,
+        help="Public ALE task id in category/name form.",
+    )
+    ale_baked_task_input_readiness_parser.add_argument(
+        "--image",
+        default=AGENTS_LAST_EXAM_DEFAULT_DOCKER_IMAGE,
+        help="Local ALE Docker image ref to probe.",
+    )
+    ale_baked_task_input_readiness_parser.add_argument(
+        "--docker-binary",
+        default="docker",
+        help="PATH-visible Docker binary name to use.",
+    )
+    ale_baked_task_input_readiness_parser.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=60,
+        help="Timeout for the tiny Docker path-existence probe.",
+    )
+    ale_baked_task_input_readiness_parser.add_argument(
+        "--no-docker-run",
+        action="store_true",
+        help="Do not start Docker; emit a fixture-like blocked readiness payload.",
+    )
+    ale_baked_task_input_readiness_parser.add_argument(
+        "--require-ready",
+        action="store_true",
+        help="Return non-zero unless the baked task input readiness gate is ready.",
+    )
+
+    ale_baked_task_input_scan_parser = benchmark_subparsers.add_parser(
+        "ale-baked-task-input-scan",
+        help=(
+            "Batch-scan public ALE selected tasks for baked input directories in "
+            "a local Docker image. This may start one tiny shell in Docker, but "
+            "does not run tasks, list files, read task data, invoke models, "
+            "upload, submit, or record local/container paths."
+        ),
+    )
+    add_subcommand_format(ale_baked_task_input_scan_parser)
+    ale_baked_task_input_scan_parser.add_argument(
+        "--source-root",
+        required=True,
+        help="Local ALE source checkout root to read selected-task lists from. The path is never recorded.",
+    )
+    ale_baked_task_input_scan_parser.add_argument(
+        "--selected-task-list",
+        action="append",
+        default=[],
+        help=(
+            "Public selected_tasks list to scan, relative to selected_tasks/. "
+            "May be repeated. Defaults to linux_only.txt and unlicensed/near-term.txt."
+        ),
+    )
+    ale_baked_task_input_scan_parser.add_argument(
+        "--image",
+        default=AGENTS_LAST_EXAM_DEFAULT_DOCKER_IMAGE,
+        help="Local ALE Docker image ref to probe.",
+    )
+    ale_baked_task_input_scan_parser.add_argument(
+        "--docker-binary",
+        default="docker",
+        help="PATH-visible Docker binary name to use.",
+    )
+    ale_baked_task_input_scan_parser.add_argument(
+        "--max-tasks",
+        type=int,
+        default=120,
+        help="Maximum selected public task ids to probe.",
+    )
+    ale_baked_task_input_scan_parser.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=180,
+        help="Timeout for the batch Docker path-existence probe.",
+    )
+    ale_baked_task_input_scan_parser.add_argument(
+        "--no-docker-run",
+        action="store_true",
+        help="Do not start Docker; emit a fixture-like blocked scan payload.",
+    )
+    ale_baked_task_input_scan_parser.add_argument(
+        "--require-ready",
+        action="store_true",
+        help="Return non-zero unless at least one baked-input candidate is found.",
+    )
+
+
+def handle_agents_last_exam_baked_input_command(
+    args: argparse.Namespace,
+    *,
+    print_payload: PrintPayload,
+    output_format: OutputFormat,
+) -> int | None:
+    if args.benchmark_command not in AGENTS_LAST_EXAM_BAKED_INPUT_COMMANDS:
+        return None
+
+    if args.benchmark_command == "ale-baked-task-input-readiness":
+        try:
+            image_metadata = None
+            if args.no_docker_run:
+                image_metadata = {
+                    "image_ref": args.image,
+                    "present": False,
+                    "probe_available": False,
+                    "first_blocker": "docker_run_probe_disabled",
+                }
+            payload = build_agents_last_exam_baked_task_input_readiness(
+                selected_task_id=args.selected_task_id,
+                image_ref=args.image,
+                image_metadata=image_metadata,
+                docker_binary=args.docker_binary,
+                timeout_seconds=args.timeout_seconds,
+            )
+        except Exception:
+            payload = {
+                "ok": False,
+                "schema_version": "agents_last_exam_baked_task_input_readiness_v0",
+                "error": "ale_baked_task_input_readiness_failed",
+                "read_boundary": {
+                    "compact_only": True,
+                    "path_existence_only": True,
+                    "task_text_read": False,
+                    "task_card_content_read": False,
+                    "script_content_read": False,
+                    "task_data_content_read": False,
+                    "raw_artifacts_read": False,
+                    "local_paths_recorded": False,
+                },
+            }
+        else:
+            payload["ok"] = True
+            if args.require_ready and payload.get("ready") is not True:
+                payload["ok"] = False
+                payload["error"] = (
+                    payload.get("first_blocker")
+                    or "ale_baked_task_input_readiness_not_ready"
+                )
+        print_payload(
+            payload,
+            output_format(args),
+            render_agents_last_exam_baked_task_input_readiness_markdown,
+        )
+        return 0 if payload.get("ok") else 1
+
+    if args.benchmark_command == "ale-baked-task-input-scan":
+        try:
+            selected_task_lists = (
+                args.selected_task_list
+                if args.selected_task_list
+                else ["linux_only.txt", "unlicensed/near-term.txt"]
+            )
+            image_metadata = None
+            if args.no_docker_run:
+                image_metadata = {
+                    "image_ref": args.image,
+                    "present": False,
+                    "probe_available": False,
+                    "first_blocker": "docker_run_probe_disabled",
+                }
+            payload = build_agents_last_exam_baked_task_input_scan(
+                source_root=args.source_root,
+                selected_task_lists=selected_task_lists,
+                image_ref=args.image,
+                image_metadata=image_metadata,
+                docker_binary=args.docker_binary,
+                max_tasks=args.max_tasks,
+                timeout_seconds=args.timeout_seconds,
+            )
+        except Exception:
+            payload = {
+                "ok": False,
+                "schema_version": "agents_last_exam_baked_task_input_scan_v0",
+                "error": "ale_baked_task_input_scan_failed",
+                "read_boundary": {
+                    "compact_only": True,
+                    "path_existence_only": True,
+                    "selected_task_lists_read": True,
+                    "task_text_read": False,
+                    "task_card_content_read": False,
+                    "script_content_read": False,
+                    "task_data_content_read": False,
+                    "raw_artifacts_read": False,
+                    "local_paths_recorded": False,
+                },
+            }
+        else:
+            payload["ok"] = True
+            if args.require_ready and payload.get("ready") is not True:
+                payload["ok"] = False
+                payload["error"] = (
+                    payload.get("first_blocker")
+                    or "ale_baked_task_input_scan_not_ready"
+                )
+        print_payload(
+            payload,
+            output_format(args),
+            render_agents_last_exam_baked_task_input_scan_markdown,
+        )
+        return 0 if payload.get("ok") else 1
+
+    return None

--- a/loopx/cli_commands/agents_last_exam_task_material.py
+++ b/loopx/cli_commands/agents_last_exam_task_material.py
@@ -1,0 +1,335 @@
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Callable
+from pathlib import Path
+
+from ..benchmark_adapters.agents_last_exam import (
+    build_agents_last_exam_candidate_task_data_scan,
+    build_agents_last_exam_task_material_readiness,
+)
+
+
+PrintPayload = Callable[
+    [dict[str, object], str, Callable[[dict[str, object]], str]],
+    None,
+]
+OutputFormat = Callable[[argparse.Namespace], str]
+
+AGENTS_LAST_EXAM_TASK_MATERIAL_COMMANDS = {
+    "ale-task-material-readiness",
+    "ale-candidate-task-data-scan",
+}
+
+
+def render_agents_last_exam_task_material_readiness_markdown(
+    payload: dict[str, object],
+) -> str:
+    task = payload.get("task") if isinstance(payload.get("task"), dict) else {}
+    public_lists = (
+        payload.get("public_task_lists")
+        if isinstance(payload.get("public_task_lists"), dict)
+        else {}
+    )
+    boundary = payload.get("boundary") if isinstance(payload.get("boundary"), dict) else {}
+    decision = (
+        payload.get("decision") if isinstance(payload.get("decision"), dict) else {}
+    )
+    task_data = payload.get("task_data") if isinstance(payload.get("task_data"), dict) else {}
+    local_staging = (
+        task_data.get("local_task_data_staging")
+        if isinstance(task_data.get("local_task_data_staging"), dict)
+        else {}
+    )
+    lines = [
+        "# Agents Last Exam Task Material Readiness",
+        "",
+        f"- Schema: `{payload.get('schema_version')}`",
+        f"- Ready: `{payload.get('ready')}`",
+        f"- First blocker: `{payload.get('first_blocker')}`",
+        f"- Task: `{task.get('task_id')}`",
+        f"- Task dir/card/scripts: `{task.get('task_dir_available')}`/`{task.get('task_card_json_present')}`/`{task.get('scripts_dir_present')}`",
+        f"- Scorer script count: `{task.get('scorer_script_count')}`",
+        f"- Task data checked/ready/source: `{task_data.get('checked')}`/`{task_data.get('ready')}`/`{task_data.get('task_data_source')}`",
+        f"- Local task-data staging route/tool/auth checked: `{local_staging.get('route')}`/`{local_staging.get('fetch_tool_present')}`/`{local_staging.get('auth_status_checked')}`",
+        f"- Public list membership checked/present: `{public_lists.get('checked')}`/`{public_lists.get('present_count')}`",
+        f"- Task body/card/script content read: `{boundary.get('task_body_read')}`/`{boundary.get('task_card_content_read')}`/`{boundary.get('script_content_read')}`",
+        f"- Local paths/raw output recorded: `{boundary.get('local_paths_recorded')}`/`{boundary.get('raw_output_recorded')}`",
+        f"- Container/model/upload/submit: `{boundary.get('container_started')}`/`{boundary.get('model_api_invoked')}`/`{boundary.get('no_upload')}`/`{boundary.get('submit_eligible')}`",
+        f"- Next action: {decision.get('next_allowed_action')}",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def render_agents_last_exam_candidate_task_data_scan_markdown(
+    payload: dict[str, object],
+) -> str:
+    selected = (
+        payload.get("selected_task_lists")
+        if isinstance(payload.get("selected_task_lists"), dict)
+        else {}
+    )
+    summary = (
+        payload.get("scan_summary")
+        if isinstance(payload.get("scan_summary"), dict)
+        else {}
+    )
+    candidates = (
+        payload.get("candidate_tasks")
+        if isinstance(payload.get("candidate_tasks"), dict)
+        else {}
+    )
+    boundary = payload.get("boundary") if isinstance(payload.get("boundary"), dict) else {}
+    decision = (
+        payload.get("decision") if isinstance(payload.get("decision"), dict) else {}
+    )
+    lines = [
+        "# Agents Last Exam Candidate Task-Data Scan",
+        "",
+        f"- Schema: `{payload.get('schema_version')}`",
+        f"- Ready: `{payload.get('ready')}`",
+        f"- First blocker: `{payload.get('first_blocker')}`",
+        f"- Selected tasks/lists: `{selected.get('selected_task_count')}`/`{selected.get('checked_list_count')}`",
+        f"- Configs checked/missing: `{summary.get('task_config_checked_count')}`/`{summary.get('task_config_missing_or_unreadable_count')}`",
+        f"- No-task-data formal/demo candidates: `{summary.get('formal_no_task_data_candidate_count')}`/`{summary.get('demo_no_task_data_candidate_count')}`",
+        f"- Eligible candidates: `{candidates.get('eligible_no_task_data_candidates')}`",
+        f"- Config line scan/source recorded: `{boundary.get('task_config_line_scan')}`/`{boundary.get('task_config_source_content_recorded')}`",
+        f"- Task card/script/instruction read: `{boundary.get('task_card_content_read')}`/`{boundary.get('script_content_read')}`/`{boundary.get('task_instruction_file_read')}`",
+        f"- Local paths/raw output recorded: `{boundary.get('local_paths_recorded')}`/`{boundary.get('raw_output_recorded')}`",
+        f"- Next action: {decision.get('next_allowed_action')}",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def register_agents_last_exam_task_material_commands(
+    benchmark_subparsers: argparse._SubParsersAction,
+    add_subcommand_format: Callable[[argparse.ArgumentParser], None],
+) -> None:
+    ale_task_material_readiness_parser = benchmark_subparsers.add_parser(
+        "ale-task-material-readiness",
+        help=(
+            "Check whether a selected public ALE task has local material signals "
+            "needed for a future local/no-upload run. This checks directory, "
+            "task_card.json, scripts, scorer scripts, and public selected-task "
+            "list membership only; it does not read task card content, task "
+            "bodies, scripts, trajectories, screenshots, credentials, upload, or submit."
+        ),
+    )
+    add_subcommand_format(ale_task_material_readiness_parser)
+    ale_task_material_readiness_parser.add_argument(
+        "--source-root",
+        required=True,
+        help="Local ALE source checkout root to probe. The path is never recorded.",
+    )
+    ale_task_material_readiness_parser.add_argument(
+        "--selected-task-id",
+        required=True,
+        help="Public ALE task id in category/name form.",
+    )
+    ale_task_material_readiness_parser.add_argument(
+        "--selected-task-list",
+        action="append",
+        default=[],
+        help=(
+            "Public selected_tasks list to check, relative to selected_tasks/. "
+            "May be repeated. Defaults to linux_only.txt and unlicensed/near-term.txt."
+        ),
+    )
+    ale_task_material_readiness_parser.add_argument(
+        "--requires-task-data",
+        choices=("true", "false", "unknown"),
+        help=(
+            "Optional compact task-data requirement signal. Use unknown with "
+            "--enforce-task-data-source to fail closed before a formal task run."
+        ),
+    )
+    ale_task_material_readiness_parser.add_argument(
+        "--task-data-source",
+        help=(
+            "Compact task_data_source label such as baked_in_sandbox or "
+            "gs://ale-data-public. Credential values and paths are never recorded."
+        ),
+    )
+    ale_task_material_readiness_parser.add_argument(
+        "--baked-task-input-present",
+        action="store_true",
+        help="Mark that the selected task's baked sandbox input directory was verified present.",
+    )
+    ale_task_material_readiness_parser.add_argument(
+        "--baked-task-input-readiness-json",
+        help=(
+            "Compact ale-baked-task-input-readiness JSON artifact to consume "
+            "instead of relying on a manual baked-input boolean."
+        ),
+    )
+    ale_task_material_readiness_parser.add_argument(
+        "--gcs-sa-key",
+        help="Service-account key path to check for existence only; the path/value is never recorded.",
+    )
+    ale_task_material_readiness_parser.add_argument(
+        "--gcs-sa-key-present",
+        action="store_true",
+        help="Fixture/operator assertion that the service-account key file presence was verified.",
+    )
+    ale_task_material_readiness_parser.add_argument(
+        "--enforce-task-data-source",
+        action="store_true",
+        help="Require task-data source readiness before returning ready.",
+    )
+    ale_task_material_readiness_parser.add_argument(
+        "--require-ready",
+        action="store_true",
+        help="Return non-zero unless the task material readiness gate is ready.",
+    )
+
+    ale_candidate_task_data_scan_parser = benchmark_subparsers.add_parser(
+        "ale-candidate-task-data-scan",
+        help=(
+            "Scan public ALE selected-task lists for tasks with an explicit "
+            "REQUIRES_TASK_DATA=False config signal. The scan records only "
+            "counts and public task ids; it does not record task source text, "
+            "task cards, instructions, scripts, trajectories, screenshots, "
+            "credentials, uploads, or submits."
+        ),
+    )
+    add_subcommand_format(ale_candidate_task_data_scan_parser)
+    ale_candidate_task_data_scan_parser.add_argument(
+        "--source-root",
+        required=True,
+        help="Local ALE source checkout root to probe. The path is never recorded.",
+    )
+    ale_candidate_task_data_scan_parser.add_argument(
+        "--selected-task-list",
+        action="append",
+        default=[],
+        help=(
+            "Public selected_tasks list to scan, relative to selected_tasks/. "
+            "May be repeated. Defaults to linux_only.txt and unlicensed/near-term.txt."
+        ),
+    )
+    ale_candidate_task_data_scan_parser.add_argument(
+        "--allow-demo-candidate",
+        action="store_true",
+        help="Allow demo/* no-task-data tasks to satisfy readiness.",
+    )
+    ale_candidate_task_data_scan_parser.add_argument(
+        "--require-ready",
+        action="store_true",
+        help="Return non-zero unless at least one eligible no-task-data candidate is found.",
+    )
+
+
+def handle_agents_last_exam_task_material_command(
+    args: argparse.Namespace,
+    *,
+    print_payload: PrintPayload,
+    output_format: OutputFormat,
+) -> int | None:
+    if args.benchmark_command not in AGENTS_LAST_EXAM_TASK_MATERIAL_COMMANDS:
+        return None
+
+    if args.benchmark_command == "ale-task-material-readiness":
+        try:
+            selected_task_lists = (
+                args.selected_task_list
+                if args.selected_task_list
+                else ["linux_only.txt", "unlicensed/near-term.txt"]
+            )
+            baked_task_input_readiness = None
+            if args.baked_task_input_readiness_json:
+                baked_task_input_readiness = json.loads(
+                    Path(args.baked_task_input_readiness_json)
+                    .expanduser()
+                    .read_text(encoding="utf-8")
+                )
+            payload = build_agents_last_exam_task_material_readiness(
+                source_root=args.source_root,
+                selected_task_id=args.selected_task_id,
+                selected_task_lists=selected_task_lists,
+                requires_task_data=None
+                if args.requires_task_data in {None, "unknown"}
+                else args.requires_task_data,
+                task_data_source=args.task_data_source,
+                baked_task_input_present=True
+                if args.baked_task_input_present
+                else None,
+                baked_task_input_readiness=baked_task_input_readiness,
+                gcs_sa_key=args.gcs_sa_key,
+                gcs_sa_key_present=True if args.gcs_sa_key_present else None,
+                enforce_task_data_source=bool(args.enforce_task_data_source),
+            )
+        except Exception:
+            payload = {
+                "ok": False,
+                "schema_version": "agents_last_exam_task_material_readiness_v0",
+                "error": "ale_task_material_readiness_failed",
+                "read_boundary": {
+                    "compact_only": True,
+                    "task_text_read": False,
+                    "task_card_content_read": False,
+                    "script_content_read": False,
+                    "raw_artifacts_read": False,
+                    "local_paths_recorded": False,
+                    "container_started": False,
+                },
+            }
+        else:
+            payload["ok"] = True
+            if args.require_ready and payload.get("ready") is not True:
+                payload["ok"] = False
+                payload["error"] = (
+                    payload.get("first_blocker")
+                    or "ale_task_material_readiness_not_ready"
+                )
+        print_payload(
+            payload,
+            output_format(args),
+            render_agents_last_exam_task_material_readiness_markdown,
+        )
+        return 0 if payload.get("ok") else 1
+
+    if args.benchmark_command == "ale-candidate-task-data-scan":
+        try:
+            selected_task_lists = (
+                args.selected_task_list
+                if args.selected_task_list
+                else ["linux_only.txt", "unlicensed/near-term.txt"]
+            )
+            payload = build_agents_last_exam_candidate_task_data_scan(
+                source_root=args.source_root,
+                selected_task_lists=selected_task_lists,
+                allow_demo_candidate=bool(args.allow_demo_candidate),
+            )
+        except Exception:
+            payload = {
+                "ok": False,
+                "schema_version": "agents_last_exam_candidate_task_data_scan_v0",
+                "error": "ale_candidate_task_data_scan_failed",
+                "read_boundary": {
+                    "compact_only": True,
+                    "task_config_source_content_recorded": False,
+                    "task_card_content_read": False,
+                    "script_content_read": False,
+                    "task_instruction_file_read": False,
+                    "raw_artifacts_read": False,
+                    "local_paths_recorded": False,
+                    "container_started": False,
+                },
+            }
+        else:
+            payload["ok"] = True
+            if args.require_ready and payload.get("ready") is not True:
+                payload["ok"] = False
+                payload["error"] = (
+                    payload.get("first_blocker")
+                    or "ale_candidate_task_data_scan_not_ready"
+                )
+        print_payload(
+            payload,
+            output_format(args),
+            render_agents_last_exam_candidate_task_data_scan_markdown,
+        )
+        return 0 if payload.get("ok") else 1
+
+    return None


### PR DESCRIPTION
## Summary
- extract ALE task-material readiness and candidate task-data scan commands into agents_last_exam_task_material.py
- extract baked task-input readiness and scan commands into agents_last_exam_baked_input.py
- keep agents_last_exam.py as the aggregate ALE dispatcher while reducing it to 983 lines, and tighten its legacy size guard from 1560 to 1020

## Validation
- python3 examples/cli-agents-last-exam-command-modularization-smoke.py
- python3 examples/cli-command-module-size-ownership-command-modularization-smoke.py
- python3 all examples/cli-*-command-modularization-smoke.py
- python3 -m py_compile loopx/*.py loopx/cli_commands/*.py plus the touched modularization smokes
- python3 -m loopx.cli benchmark ale-baked-task-input-readiness --selected-task-id demo/task --no-docker-run --format json
- python3 -m loopx.cli benchmark ale-baked-task-input-scan --source-root . --no-docker-run --format json
- python3 -m loopx.cli benchmark ale-task-material-readiness --source-root . --selected-task-id demo/task --format json
- python3 -m loopx.cli benchmark ale-candidate-task-data-scan --source-root . --format json
- loopx check --scan-path loopx/cli_commands/agents_last_exam.py --scan-path loopx/cli_commands/agents_last_exam_baked_input.py --scan-path loopx/cli_commands/agents_last_exam_task_material.py --scan-path examples/cli-agents-last-exam-command-modularization-smoke.py --scan-path examples/cli-command-module-size-ownership-command-modularization-smoke.py
