### PR TITLE
Extract ALE host Codex CLI command family

### DIFF
--- a/examples/cli-agents-last-exam-command-modularization-smoke.py
+++ b/examples/cli-agents-last-exam-command-modularization-smoke.py
@@ -49,6 +49,9 @@ def main() -> int:
     baked_input_source = (
         ROOT / "loopx" / "cli_commands" / "agents_last_exam_baked_input.py"
     ).read_text(encoding="utf-8")
+    host_codex_source = (
+        ROOT / "loopx" / "cli_commands" / "agents_last_exam_host_codex.py"
+    ).read_text(encoding="utf-8")
     task_material_source = (
         ROOT / "loopx" / "cli_commands" / "agents_last_exam_task_material.py"
     ).read_text(encoding="utf-8")
@@ -78,6 +81,8 @@ def main() -> int:
     assert_contains(init_source, "handle_agents_last_exam_runner_source_command")
     assert_contains(init_source, "register_agents_last_exam_baked_input_commands")
     assert_contains(init_source, "handle_agents_last_exam_baked_input_command")
+    assert_contains(init_source, "register_agents_last_exam_host_codex_commands")
+    assert_contains(init_source, "handle_agents_last_exam_host_codex_command")
     assert_contains(init_source, "register_agents_last_exam_task_material_commands")
     assert_contains(init_source, "handle_agents_last_exam_task_material_command")
     assert_contains(ale_source, "AGENTS_LAST_EXAM_COMMANDS")
@@ -121,6 +126,14 @@ def main() -> int:
     assert_contains(
         ale_source,
         "handle_agents_last_exam_task_material_command(",
+    )
+    assert_contains(
+        ale_source,
+        "register_agents_last_exam_host_codex_commands(",
+    )
+    assert_contains(
+        ale_source,
+        "handle_agents_last_exam_host_codex_command(",
     )
     for marker in (
         "def render_agents_last_exam_local_preflight_markdown",
@@ -176,6 +189,17 @@ def main() -> int:
         if marker in ale_source:
             raise AssertionError(f"{marker} leaked back into agents_last_exam.py")
         assert_contains(task_material_source, marker)
+    for marker in (
+        "def render_agents_last_exam_host_codex_cli_route_markdown",
+        "def render_agents_last_exam_host_codex_cua_no_task_smoke_markdown",
+        "build_agents_last_exam_host_codex_cli_route(",
+        "build_agents_last_exam_host_codex_cua_no_task_smoke_from_environment(",
+        'if args.benchmark_command == "ale-host-codex-cli-route":',
+        'if args.benchmark_command == "ale-host-codex-cua-no-task-e2e":',
+    ):
+        if marker in ale_source:
+            raise AssertionError(f"{marker} leaked back into agents_last_exam.py")
+        assert_contains(host_codex_source, marker)
 
     help_result = run_cli("benchmark", "ale-validation-run-gate", "--help")
     if help_result.returncode != 0:
@@ -220,6 +244,30 @@ def main() -> int:
         raise AssertionError(host_route_payload)
     if host_route_payload["boundary"].get("local_paths_recorded") is not False:
         raise AssertionError(host_route_payload)
+
+    host_no_task_result = run_cli(
+        "benchmark",
+        "ale-host-codex-cua-no-task-e2e",
+        "--assume-codex-binary-available",
+        "--codex-version-text",
+        "codex-smoke",
+        "--cua-mcp-assets-root",
+        ".",
+        "--operator-authorized-host-codex-auth",
+        "--format",
+        "json",
+    )
+    if host_no_task_result.returncode != 0:
+        raise AssertionError(host_no_task_result.stderr or host_no_task_result.stdout)
+    host_no_task_payload = json.loads(host_no_task_result.stdout)
+    if host_no_task_payload.get("ok") is not True:
+        raise AssertionError(host_no_task_payload)
+    if host_no_task_payload["boundary"].get("codex_prompt_sent") is not False:
+        raise AssertionError(host_no_task_payload)
+    if host_no_task_payload["boundary"].get("task_body_read") is not False:
+        raise AssertionError(host_no_task_payload)
+    if host_no_task_payload["boundary"].get("local_paths_recorded") is not False:
+        raise AssertionError(host_no_task_payload)
 
     baked_input_result = run_cli(
         "benchmark",

--- a/examples/cli-command-module-size-ownership-command-modularization-smoke.py
+++ b/examples/cli-command-module-size-ownership-command-modularization-smoke.py
@@ -10,7 +10,6 @@ CLI_COMMANDS = ROOT / "loopx" / "cli_commands"
 
 DEFAULT_MAX_LINES = 500
 LEGACY_MODULE_LIMITS = {
-    "agents_last_exam.py": 700,
     "benchmark_review_lifecycle.py": 1300,
     "benchmark_run_ledger.py": 1360,
     "history.py": 720,

--- a/loopx/cli_commands/__init__.py
+++ b/loopx/cli_commands/__init__.py
@@ -16,6 +16,10 @@ from .agents_last_exam_baked_input import (
     handle_agents_last_exam_baked_input_command,
     register_agents_last_exam_baked_input_commands,
 )
+from .agents_last_exam_host_codex import (
+    handle_agents_last_exam_host_codex_command,
+    register_agents_last_exam_host_codex_commands,
+)
 from .agents_last_exam_local_plan import (
     handle_agents_last_exam_local_plan_command,
     register_agents_last_exam_local_plan_commands,
@@ -136,6 +140,7 @@ from .worker_bridge import handle_worker_bridge_command, register_worker_bridge_
 __all__ = [
     "handle_agents_last_exam_command",
     "handle_agents_last_exam_baked_input_command",
+    "handle_agents_last_exam_host_codex_command",
     "handle_agents_last_exam_launch_dry_run_command",
     "handle_agents_last_exam_local_plan_command",
     "handle_agents_last_exam_runner_source_command",
@@ -188,6 +193,7 @@ __all__ = [
     "handle_worker_bridge_command",
     "register_agents_last_exam_commands",
     "register_agents_last_exam_baked_input_commands",
+    "register_agents_last_exam_host_codex_commands",
     "register_agents_last_exam_launch_dry_run_commands",
     "register_agents_last_exam_local_plan_commands",
     "register_agents_last_exam_runner_source_commands",

--- a/loopx/cli_commands/agents_last_exam.py
+++ b/loopx/cli_commands/agents_last_exam.py
@@ -6,14 +6,17 @@ from collections.abc import Callable
 from pathlib import Path
 
 from ..benchmark_adapters.agents_last_exam import (
-    build_agents_last_exam_host_codex_cli_route,
-    build_agents_last_exam_host_codex_cua_no_task_smoke_from_environment,
     build_agents_last_exam_validation_run_gate,
 )
 from .agents_last_exam_baked_input import (
     AGENTS_LAST_EXAM_BAKED_INPUT_COMMANDS,
     handle_agents_last_exam_baked_input_command,
     register_agents_last_exam_baked_input_commands,
+)
+from .agents_last_exam_host_codex import (
+    AGENTS_LAST_EXAM_HOST_CODEX_COMMANDS,
+    handle_agents_last_exam_host_codex_command,
+    register_agents_last_exam_host_codex_commands,
 )
 from .agents_last_exam_local_plan import (
     AGENTS_LAST_EXAM_LOCAL_PLAN_COMMANDS,
@@ -44,8 +47,6 @@ PrintPayload = Callable[
 OutputFormat = Callable[[argparse.Namespace], str]
 
 AGENTS_LAST_EXAM_COMMANDS = {
-    "ale-host-codex-cli-route",
-    "ale-host-codex-cua-no-task-e2e",
     "ale-validation-run-gate",
 } | (
     AGENTS_LAST_EXAM_LOCAL_PLAN_COMMANDS
@@ -53,97 +54,8 @@ AGENTS_LAST_EXAM_COMMANDS = {
     | AGENTS_LAST_EXAM_TASK_MATERIAL_COMMANDS
     | AGENTS_LAST_EXAM_BAKED_INPUT_COMMANDS
     | AGENTS_LAST_EXAM_LAUNCH_DRY_RUN_COMMANDS
+    | AGENTS_LAST_EXAM_HOST_CODEX_COMMANDS
 )
-
-
-def render_agents_last_exam_host_codex_cli_route_markdown(
-    payload: dict[str, object],
-) -> str:
-    route = payload.get("route") if isinstance(payload.get("route"), dict) else {}
-    codex_cli = (
-        payload.get("host_codex_cli")
-        if isinstance(payload.get("host_codex_cli"), dict)
-        else {}
-    )
-    host_auth = (
-        payload.get("host_auth") if isinstance(payload.get("host_auth"), dict) else {}
-    )
-    cua_assets = (
-        payload.get("cua_mcp_assets")
-        if isinstance(payload.get("cua_mcp_assets"), dict)
-        else {}
-    )
-    ale_sandbox = (
-        payload.get("ale_sandbox")
-        if isinstance(payload.get("ale_sandbox"), dict)
-        else {}
-    )
-    boundary = payload.get("boundary") if isinstance(payload.get("boundary"), dict) else {}
-    decision = (
-        payload.get("decision") if isinstance(payload.get("decision"), dict) else {}
-    )
-    lines = [
-        "# Agents Last Exam Host Codex CLI Route",
-        "",
-        f"- Schema: `{payload.get('schema_version')}`",
-        f"- Ready: `{payload.get('ready')}`",
-        f"- First blocker: `{payload.get('first_blocker')}`",
-        f"- Route mode: `{route.get('mode')}`",
-        f"- Host Codex binary/version: `{codex_cli.get('binary')}` / `{codex_cli.get('version')}`",
-        f"- Host Codex available: `{codex_cli.get('binary_available')}`",
-        f"- Host auth/config present: `{host_auth.get('auth_cache_present')}`/`{host_auth.get('config_present')}`",
-        f"- Credential values recorded: `{host_auth.get('credential_values_recorded')}`",
-        f"- Auth copied to sandbox: `{host_auth.get('auth_material_copied_to_sandbox')}`",
-        f"- CUA MCP assets ready: `{cua_assets.get('available')}`",
-        f"- ALE CUA smoke ready: `{ale_sandbox.get('cua_smoke_ready')}`",
-        f"- Runs Codex in sandbox: `{route.get('runs_codex_inside_ale_sandbox')}`",
-        f"- Container started/task read: `{boundary.get('container_started')}`/`{boundary.get('task_body_read')}`",
-        f"- Upload/submit eligible: `{boundary.get('no_upload')}`/`{boundary.get('submit_eligible')}`",
-        f"- Next action: {decision.get('next_allowed_action')}",
-    ]
-    return "\n".join(lines) + "\n"
-
-
-def render_agents_last_exam_host_codex_cua_no_task_smoke_markdown(
-    payload: dict[str, object],
-) -> str:
-    codex_exec = (
-        payload.get("codex_exec_surface")
-        if isinstance(payload.get("codex_exec_surface"), dict)
-        else {}
-    )
-    mcp_config = (
-        payload.get("codex_mcp_config")
-        if isinstance(payload.get("codex_mcp_config"), dict)
-        else {}
-    )
-    cua_bridge = (
-        payload.get("cua_mcp_bridge")
-        if isinstance(payload.get("cua_mcp_bridge"), dict)
-        else {}
-    )
-    boundary = payload.get("boundary") if isinstance(payload.get("boundary"), dict) else {}
-    decision = (
-        payload.get("decision") if isinstance(payload.get("decision"), dict) else {}
-    )
-    lines = [
-        "# Agents Last Exam Host Codex CUA No-Task E2E",
-        "",
-        f"- Schema: `{payload.get('schema_version')}`",
-        f"- Ready: `{payload.get('ready')}`",
-        f"- First blocker: `{payload.get('first_blocker')}`",
-        f"- Route gate ready: `{payload.get('route_gate_ready')}`",
-        f"- Codex exec surface ready: `{codex_exec.get('available')}`",
-        f"- Codex MCP config ready: `{mcp_config.get('available')}`",
-        f"- CUA MCP bridge ready: `{cua_bridge.get('available')}`",
-        f"- Codex prompt sent: `{boundary.get('codex_prompt_sent')}`",
-        f"- Model API invoked: `{boundary.get('model_api_invoked')}`",
-        f"- Raw output recorded: `{boundary.get('raw_output_recorded')}`",
-        f"- Container started/task read: `{boundary.get('container_started')}`/`{boundary.get('task_body_read')}`",
-        f"- Upload/submit eligible: `{boundary.get('no_upload')}`/`{boundary.get('submit_eligible')}`",
-        f"- Next action: {decision.get('next_allowed_action')}",
-    ]
-    return "\n".join(lines) + "\n"
 
 
 def render_agents_last_exam_validation_run_gate_markdown(
@@ -220,147 +132,9 @@ def register_agents_last_exam_commands(
         benchmark_subparsers,
         add_subcommand_format,
     )
-
-    ale_host_codex_cli_route_parser = benchmark_subparsers.add_parser(
-        "ale-host-codex-cli-route",
-        help=(
-            "Check the host Codex CLI auth route for a future Agents' Last Exam "
-            "run. This verifies only compact host-side readiness signals and "
-            "does not read credential values, copy auth into the sandbox, start "
-            "containers, read task bodies, upload, or submit."
-        ),
-    )
-    add_subcommand_format(ale_host_codex_cli_route_parser)
-    ale_host_codex_cli_route_parser.add_argument(
-        "--codex-binary",
-        default="codex",
-        help="PATH-visible host Codex CLI binary name to probe. Paths are not recorded.",
-    )
-    ale_host_codex_cli_route_parser.add_argument(
-        "--assume-codex-binary-available",
-        action="store_true",
-        help="Fixture flag for dependency-free smokes; records no binary path.",
-    )
-    ale_host_codex_cli_route_parser.add_argument(
-        "--codex-version-text",
-        help=(
-            "Optional pre-probed Codex version text. If omitted, the command "
-            "runs `<codex-binary> --version` without recording argv or paths."
-        ),
-    )
-    ale_host_codex_cli_route_parser.add_argument(
-        "--host-auth-cache-present",
-        action="store_true",
-        help=(
-            "Mark that host Codex auth cache existence was verified. The value "
-            "is not read or recorded."
-        ),
-    )
-    ale_host_codex_cli_route_parser.add_argument(
-        "--host-config-present",
-        action="store_true",
-        help=(
-            "Mark that host Codex config existence was verified. The content is "
-            "not read or recorded."
-        ),
-    )
-    ale_host_codex_cli_route_parser.add_argument(
-        "--require-host-config",
-        action="store_true",
-        help="Require host config existence in addition to host auth cache.",
-    )
-    ale_host_codex_cli_route_parser.add_argument(
-        "--cua-mcp-assets-root",
-        help="Local CUA MCP server asset root to probe. The path is never recorded.",
-    )
-    ale_host_codex_cli_route_parser.add_argument(
-        "--ale-sandbox-cua-smoke-ready",
-        action="store_true",
-        help="Mark that the ALE DockerProvider CUA smoke is already ready.",
-    )
-    ale_host_codex_cli_route_parser.add_argument(
-        "--operator-authorized-host-codex-auth",
-        action="store_true",
-        help="Mark that the owner authorized using host Codex auth for this route.",
-    )
-    ale_host_codex_cli_route_parser.add_argument(
-        "--require-ready",
-        action="store_true",
-        help="Return non-zero unless the host Codex CLI route gate is ready.",
-    )
-
-    ale_host_codex_cua_no_task_e2e_parser = benchmark_subparsers.add_parser(
-        "ale-host-codex-cua-no-task-e2e",
-        help=(
-            "Build compact no-task evidence that host Codex CLI help, Codex MCP "
-            "config loading, and the CUA MCP bridge are ready. This does not "
-            "send a Codex prompt, invoke a model API, read task bodies, record "
-            "raw output, upload, or submit."
-        ),
-    )
-    add_subcommand_format(ale_host_codex_cua_no_task_e2e_parser)
-    ale_host_codex_cua_no_task_e2e_parser.add_argument(
-        "--codex-binary",
-        default="codex",
-        help="PATH-visible host Codex CLI binary name to probe. Paths are not recorded.",
-    )
-    ale_host_codex_cua_no_task_e2e_parser.add_argument(
-        "--assume-codex-binary-available",
-        action="store_true",
-        help="Fixture flag for dependency-free route-gate smokes; records no binary path.",
-    )
-    ale_host_codex_cua_no_task_e2e_parser.add_argument(
-        "--codex-version-text",
-        help=(
-            "Optional pre-probed Codex version text for the route gate. If "
-            "omitted, the command runs `<codex-binary> --version` without "
-            "recording argv or paths."
-        ),
-    )
-    ale_host_codex_cua_no_task_e2e_parser.add_argument(
-        "--host-auth-cache-present",
-        action="store_true",
-        help="Mark that host Codex auth cache existence was verified without reading it.",
-    )
-    ale_host_codex_cua_no_task_e2e_parser.add_argument(
-        "--host-config-present",
-        action="store_true",
-        help="Mark that host Codex config existence was verified without reading it.",
-    )
-    ale_host_codex_cua_no_task_e2e_parser.add_argument(
-        "--require-host-config",
-        action="store_true",
-        help="Require host config existence in addition to host auth cache.",
-    )
-    ale_host_codex_cua_no_task_e2e_parser.add_argument(
-        "--cua-mcp-assets-root",
-        required=True,
-        help="Local CUA MCP server asset root to probe. The path is never recorded.",
-    )
-    ale_host_codex_cua_no_task_e2e_parser.add_argument(
-        "--cua-server-url",
-        default="http://127.0.0.1:8000",
-        help="Local CUA server URL used only inside a temporary Codex MCP config.",
-    )
-    ale_host_codex_cua_no_task_e2e_parser.add_argument(
-        "--install-node-deps",
-        action="store_true",
-        help="Allow npm install in a temporary copy of the CUA MCP assets if node_modules is absent.",
-    )
-    ale_host_codex_cua_no_task_e2e_parser.add_argument(
-        "--ale-sandbox-cua-smoke-ready",
-        action="store_true",
-        help="Mark that the ALE DockerProvider CUA smoke/e2e prerequisite is already ready.",
-    )
-    ale_host_codex_cua_no_task_e2e_parser.add_argument(
-        "--operator-authorized-host-codex-auth",
-        action="store_true",
-        help="Mark that the owner authorized using host Codex auth for this route.",
-    )
-    ale_host_codex_cua_no_task_e2e_parser.add_argument(
-        "--require-ready",
-        action="store_true",
-        help="Return non-zero unless the no-task host Codex CUA E2E gate is ready.",
+    register_agents_last_exam_host_codex_commands(
+        benchmark_subparsers,
+        add_subcommand_format,
     )
 
     ale_validation_run_gate_parser = benchmark_subparsers.add_parser(
@@ -492,108 +266,14 @@ def handle_agents_last_exam_command(
     if launch_dry_run_result is not None:
         return launch_dry_run_result
 
-    if args.benchmark_command == "ale-host-codex-cli-route":
-        try:
-            payload = build_agents_last_exam_host_codex_cli_route(
-                codex_binary=args.codex_binary,
-                codex_binary_available=True
-                if args.assume_codex_binary_available
-                else None,
-                codex_version_text=args.codex_version_text,
-                host_auth_cache_present=True
-                if args.host_auth_cache_present
-                else None,
-                host_config_present=True if args.host_config_present else None,
-                require_host_config=bool(args.require_host_config),
-                cua_mcp_assets_root=args.cua_mcp_assets_root,
-                ale_sandbox_cua_smoke_ready=bool(
-                    args.ale_sandbox_cua_smoke_ready
-                ),
-                operator_authorized_host_codex_auth=bool(
-                    args.operator_authorized_host_codex_auth
-                ),
-            )
-        except Exception:
-            payload = {
-                "ok": False,
-                "schema_version": "agents_last_exam_host_codex_cli_route_v0",
-                "error": "ale_host_codex_cli_route_failed",
-                "read_boundary": {
-                    "compact_only": True,
-                    "auth_values_read": False,
-                    "config_content_read": False,
-                    "task_text_read": False,
-                    "raw_artifacts_read": False,
-                    "local_paths_recorded": False,
-                    "container_started": False,
-                },
-            }
-        else:
-            payload["ok"] = True
-            if args.require_ready and payload.get("ready") is not True:
-                payload["ok"] = False
-                payload["error"] = (
-                    payload.get("first_blocker")
-                    or "ale_host_codex_cli_route_not_ready"
-                )
-        print_payload(
-            payload,
-            output_format(args),
-            render_agents_last_exam_host_codex_cli_route_markdown,
-        )
-        return 0 if payload.get("ok") else 1
-    if args.benchmark_command == "ale-host-codex-cua-no-task-e2e":
-        try:
-            payload = build_agents_last_exam_host_codex_cua_no_task_smoke_from_environment(
-                codex_binary=args.codex_binary,
-                codex_binary_available=True
-                if args.assume_codex_binary_available
-                else None,
-                codex_version_text=args.codex_version_text,
-                host_auth_cache_present=True
-                if args.host_auth_cache_present
-                else None,
-                host_config_present=True if args.host_config_present else None,
-                require_host_config=bool(args.require_host_config),
-                cua_mcp_assets_root=args.cua_mcp_assets_root,
-                cua_server_url=args.cua_server_url,
-                install_node_deps=bool(args.install_node_deps),
-                ale_sandbox_cua_smoke_ready=bool(
-                    args.ale_sandbox_cua_smoke_ready
-                ),
-                operator_authorized_host_codex_auth=bool(
-                    args.operator_authorized_host_codex_auth
-                ),
-            )
-        except Exception:
-            payload = {
-                "ok": False,
-                "schema_version": "agents_last_exam_host_codex_cua_no_task_smoke_v0",
-                "error": "ale_host_codex_cua_no_task_e2e_failed",
-                "read_boundary": {
-                    "compact_only": True,
-                    "auth_values_read": False,
-                    "config_content_read": False,
-                    "task_text_read": False,
-                    "raw_artifacts_read": False,
-                    "local_paths_recorded": False,
-                    "container_started": False,
-                },
-            }
-        else:
-            payload["ok"] = True
-            if args.require_ready and payload.get("ready") is not True:
-                payload["ok"] = False
-                payload["error"] = (
-                    payload.get("first_blocker")
-                    or "ale_host_codex_cua_no_task_e2e_not_ready"
-                )
-        print_payload(
-            payload,
-            output_format(args),
-            render_agents_last_exam_host_codex_cua_no_task_smoke_markdown,
-        )
-        return 0 if payload.get("ok") else 1
+    host_codex_result = handle_agents_last_exam_host_codex_command(
+        args,
+        print_payload=print_payload,
+        output_format=output_format,
+    )
+    if host_codex_result is not None:
+        return host_codex_result
+
     if args.benchmark_command == "ale-validation-run-gate":
         try:
             task_material_readiness = json.loads(

--- a/loopx/cli_commands/agents_last_exam_host_codex.py
+++ b/loopx/cli_commands/agents_last_exam_host_codex.py
@@ -1,0 +1,374 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+
+from ..benchmark_adapters.agents_last_exam import (
+    build_agents_last_exam_host_codex_cli_route,
+    build_agents_last_exam_host_codex_cua_no_task_smoke_from_environment,
+)
+
+
+PrintPayload = Callable[
+    [dict[str, object], str, Callable[[dict[str, object]], str]],
+    None,
+]
+OutputFormat = Callable[[argparse.Namespace], str]
+
+AGENTS_LAST_EXAM_HOST_CODEX_COMMANDS = {
+    "ale-host-codex-cli-route",
+    "ale-host-codex-cua-no-task-e2e",
+}
+
+
+def render_agents_last_exam_host_codex_cli_route_markdown(
+    payload: dict[str, object],
+) -> str:
+    route = payload.get("route") if isinstance(payload.get("route"), dict) else {}
+    codex_cli = (
+        payload.get("host_codex_cli")
+        if isinstance(payload.get("host_codex_cli"), dict)
+        else {}
+    )
+    host_auth = (
+        payload.get("host_auth") if isinstance(payload.get("host_auth"), dict) else {}
+    )
+    cua_assets = (
+        payload.get("cua_mcp_assets")
+        if isinstance(payload.get("cua_mcp_assets"), dict)
+        else {}
+    )
+    ale_sandbox = (
+        payload.get("ale_sandbox")
+        if isinstance(payload.get("ale_sandbox"), dict)
+        else {}
+    )
+    boundary = payload.get("boundary") if isinstance(payload.get("boundary"), dict) else {}
+    decision = (
+        payload.get("decision") if isinstance(payload.get("decision"), dict) else {}
+    )
+    lines = [
+        "# Agents Last Exam Host Codex CLI Route",
+        "",
+        f"- Schema: `{payload.get('schema_version')}`",
+        f"- Ready: `{payload.get('ready')}`",
+        f"- First blocker: `{payload.get('first_blocker')}`",
+        f"- Route mode: `{route.get('mode')}`",
+        f"- Host Codex binary/version: `{codex_cli.get('binary')}` / `{codex_cli.get('version')}`",
+        f"- Host Codex available: `{codex_cli.get('binary_available')}`",
+        f"- Host auth/config present: `{host_auth.get('auth_cache_present')}`/`{host_auth.get('config_present')}`",
+        f"- Credential values recorded: `{host_auth.get('credential_values_recorded')}`",
+        f"- Auth copied to sandbox: `{host_auth.get('auth_material_copied_to_sandbox')}`",
+        f"- CUA MCP assets ready: `{cua_assets.get('available')}`",
+        f"- ALE CUA smoke ready: `{ale_sandbox.get('cua_smoke_ready')}`",
+        f"- Runs Codex in sandbox: `{route.get('runs_codex_inside_ale_sandbox')}`",
+        f"- Container started/task read: `{boundary.get('container_started')}`/`{boundary.get('task_body_read')}`",
+        f"- Upload/submit eligible: `{boundary.get('no_upload')}`/`{boundary.get('submit_eligible')}`",
+        f"- Next action: {decision.get('next_allowed_action')}",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def render_agents_last_exam_host_codex_cua_no_task_smoke_markdown(
+    payload: dict[str, object],
+) -> str:
+    codex_exec = (
+        payload.get("codex_exec_surface")
+        if isinstance(payload.get("codex_exec_surface"), dict)
+        else {}
+    )
+    mcp_config = (
+        payload.get("codex_mcp_config")
+        if isinstance(payload.get("codex_mcp_config"), dict)
+        else {}
+    )
+    cua_bridge = (
+        payload.get("cua_mcp_bridge")
+        if isinstance(payload.get("cua_mcp_bridge"), dict)
+        else {}
+    )
+    boundary = payload.get("boundary") if isinstance(payload.get("boundary"), dict) else {}
+    decision = (
+        payload.get("decision") if isinstance(payload.get("decision"), dict) else {}
+    )
+    lines = [
+        "# Agents Last Exam Host Codex CUA No-Task E2E",
+        "",
+        f"- Schema: `{payload.get('schema_version')}`",
+        f"- Ready: `{payload.get('ready')}`",
+        f"- First blocker: `{payload.get('first_blocker')}`",
+        f"- Route gate ready: `{payload.get('route_gate_ready')}`",
+        f"- Codex exec surface ready: `{codex_exec.get('available')}`",
+        f"- Codex MCP config ready: `{mcp_config.get('available')}`",
+        f"- CUA MCP bridge ready: `{cua_bridge.get('available')}`",
+        f"- Codex prompt sent: `{boundary.get('codex_prompt_sent')}`",
+        f"- Model API invoked: `{boundary.get('model_api_invoked')}`",
+        f"- Raw output recorded: `{boundary.get('raw_output_recorded')}`",
+        f"- Container started/task read: `{boundary.get('container_started')}`/`{boundary.get('task_body_read')}`",
+        f"- Upload/submit eligible: `{boundary.get('no_upload')}`/`{boundary.get('submit_eligible')}`",
+        f"- Next action: {decision.get('next_allowed_action')}",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def register_agents_last_exam_host_codex_commands(
+    benchmark_subparsers: argparse._SubParsersAction,
+    add_subcommand_format: Callable[[argparse.ArgumentParser], None],
+) -> None:
+    ale_host_codex_cli_route_parser = benchmark_subparsers.add_parser(
+        "ale-host-codex-cli-route",
+        help=(
+            "Check the host Codex CLI auth route for a future Agents' Last Exam "
+            "run. This verifies only compact host-side readiness signals and "
+            "does not read credential values, copy auth into the sandbox, start "
+            "containers, read task bodies, upload, or submit."
+        ),
+    )
+    add_subcommand_format(ale_host_codex_cli_route_parser)
+    ale_host_codex_cli_route_parser.add_argument(
+        "--codex-binary",
+        default="codex",
+        help="PATH-visible host Codex CLI binary name to probe. Paths are not recorded.",
+    )
+    ale_host_codex_cli_route_parser.add_argument(
+        "--assume-codex-binary-available",
+        action="store_true",
+        help="Fixture flag for dependency-free smokes; records no binary path.",
+    )
+    ale_host_codex_cli_route_parser.add_argument(
+        "--codex-version-text",
+        help=(
+            "Optional pre-probed Codex version text. If omitted, the command "
+            "runs `<codex-binary> --version` without recording argv or paths."
+        ),
+    )
+    ale_host_codex_cli_route_parser.add_argument(
+        "--host-auth-cache-present",
+        action="store_true",
+        help=(
+            "Mark that host Codex auth cache existence was verified. The value "
+            "is not read or recorded."
+        ),
+    )
+    ale_host_codex_cli_route_parser.add_argument(
+        "--host-config-present",
+        action="store_true",
+        help=(
+            "Mark that host Codex config existence was verified. The content is "
+            "not read or recorded."
+        ),
+    )
+    ale_host_codex_cli_route_parser.add_argument(
+        "--require-host-config",
+        action="store_true",
+        help="Require host config existence in addition to host auth cache.",
+    )
+    ale_host_codex_cli_route_parser.add_argument(
+        "--cua-mcp-assets-root",
+        help="Local CUA MCP server asset root to probe. The path is never recorded.",
+    )
+    ale_host_codex_cli_route_parser.add_argument(
+        "--ale-sandbox-cua-smoke-ready",
+        action="store_true",
+        help="Mark that the ALE DockerProvider CUA smoke is already ready.",
+    )
+    ale_host_codex_cli_route_parser.add_argument(
+        "--operator-authorized-host-codex-auth",
+        action="store_true",
+        help="Mark that the owner authorized using host Codex auth for this route.",
+    )
+    ale_host_codex_cli_route_parser.add_argument(
+        "--require-ready",
+        action="store_true",
+        help="Return non-zero unless the host Codex CLI route gate is ready.",
+    )
+
+    ale_host_codex_cua_no_task_e2e_parser = benchmark_subparsers.add_parser(
+        "ale-host-codex-cua-no-task-e2e",
+        help=(
+            "Build compact no-task evidence that host Codex CLI help, Codex MCP "
+            "config loading, and the CUA MCP bridge are ready. This does not "
+            "send a Codex prompt, invoke a model API, read task bodies, record "
+            "raw output, upload, or submit."
+        ),
+    )
+    add_subcommand_format(ale_host_codex_cua_no_task_e2e_parser)
+    ale_host_codex_cua_no_task_e2e_parser.add_argument(
+        "--codex-binary",
+        default="codex",
+        help="PATH-visible host Codex CLI binary name to probe. Paths are not recorded.",
+    )
+    ale_host_codex_cua_no_task_e2e_parser.add_argument(
+        "--assume-codex-binary-available",
+        action="store_true",
+        help="Fixture flag for dependency-free route-gate smokes; records no binary path.",
+    )
+    ale_host_codex_cua_no_task_e2e_parser.add_argument(
+        "--codex-version-text",
+        help=(
+            "Optional pre-probed Codex version text for the route gate. If "
+            "omitted, the command runs `<codex-binary> --version` without "
+            "recording argv or paths."
+        ),
+    )
+    ale_host_codex_cua_no_task_e2e_parser.add_argument(
+        "--host-auth-cache-present",
+        action="store_true",
+        help="Mark that host Codex auth cache existence was verified without reading it.",
+    )
+    ale_host_codex_cua_no_task_e2e_parser.add_argument(
+        "--host-config-present",
+        action="store_true",
+        help="Mark that host Codex config existence was verified without reading it.",
+    )
+    ale_host_codex_cua_no_task_e2e_parser.add_argument(
+        "--require-host-config",
+        action="store_true",
+        help="Require host config existence in addition to host auth cache.",
+    )
+    ale_host_codex_cua_no_task_e2e_parser.add_argument(
+        "--cua-mcp-assets-root",
+        required=True,
+        help="Local CUA MCP server asset root to probe. The path is never recorded.",
+    )
+    ale_host_codex_cua_no_task_e2e_parser.add_argument(
+        "--cua-server-url",
+        default="http://127.0.0.1:8000",
+        help="Local CUA server URL used only inside a temporary Codex MCP config.",
+    )
+    ale_host_codex_cua_no_task_e2e_parser.add_argument(
+        "--install-node-deps",
+        action="store_true",
+        help="Allow npm install in a temporary copy of the CUA MCP assets if node_modules is absent.",
+    )
+    ale_host_codex_cua_no_task_e2e_parser.add_argument(
+        "--ale-sandbox-cua-smoke-ready",
+        action="store_true",
+        help="Mark that the ALE DockerProvider CUA smoke/e2e prerequisite is already ready.",
+    )
+    ale_host_codex_cua_no_task_e2e_parser.add_argument(
+        "--operator-authorized-host-codex-auth",
+        action="store_true",
+        help="Mark that the owner authorized using host Codex auth for this route.",
+    )
+    ale_host_codex_cua_no_task_e2e_parser.add_argument(
+        "--require-ready",
+        action="store_true",
+        help="Return non-zero unless the no-task host Codex CUA E2E gate is ready.",
+    )
+
+
+def handle_agents_last_exam_host_codex_command(
+    args: argparse.Namespace,
+    *,
+    print_payload: PrintPayload,
+    output_format: OutputFormat,
+) -> int | None:
+    if args.benchmark_command not in AGENTS_LAST_EXAM_HOST_CODEX_COMMANDS:
+        return None
+
+    if args.benchmark_command == "ale-host-codex-cli-route":
+        try:
+            payload = build_agents_last_exam_host_codex_cli_route(
+                codex_binary=args.codex_binary,
+                codex_binary_available=True
+                if args.assume_codex_binary_available
+                else None,
+                codex_version_text=args.codex_version_text,
+                host_auth_cache_present=True
+                if args.host_auth_cache_present
+                else None,
+                host_config_present=True if args.host_config_present else None,
+                require_host_config=bool(args.require_host_config),
+                cua_mcp_assets_root=args.cua_mcp_assets_root,
+                ale_sandbox_cua_smoke_ready=bool(
+                    args.ale_sandbox_cua_smoke_ready
+                ),
+                operator_authorized_host_codex_auth=bool(
+                    args.operator_authorized_host_codex_auth
+                ),
+            )
+        except Exception:
+            payload = {
+                "ok": False,
+                "schema_version": "agents_last_exam_host_codex_cli_route_v0",
+                "error": "ale_host_codex_cli_route_failed",
+                "read_boundary": {
+                    "compact_only": True,
+                    "auth_values_read": False,
+                    "config_content_read": False,
+                    "task_text_read": False,
+                    "raw_artifacts_read": False,
+                    "local_paths_recorded": False,
+                    "container_started": False,
+                },
+            }
+        else:
+            payload["ok"] = True
+            if args.require_ready and payload.get("ready") is not True:
+                payload["ok"] = False
+                payload["error"] = (
+                    payload.get("first_blocker")
+                    or "ale_host_codex_cli_route_not_ready"
+                )
+        print_payload(
+            payload,
+            output_format(args),
+            render_agents_last_exam_host_codex_cli_route_markdown,
+        )
+        return 0 if payload.get("ok") else 1
+
+    if args.benchmark_command == "ale-host-codex-cua-no-task-e2e":
+        try:
+            payload = build_agents_last_exam_host_codex_cua_no_task_smoke_from_environment(
+                codex_binary=args.codex_binary,
+                codex_binary_available=True
+                if args.assume_codex_binary_available
+                else None,
+                codex_version_text=args.codex_version_text,
+                host_auth_cache_present=True
+                if args.host_auth_cache_present
+                else None,
+                host_config_present=True if args.host_config_present else None,
+                require_host_config=bool(args.require_host_config),
+                cua_mcp_assets_root=args.cua_mcp_assets_root,
+                cua_server_url=args.cua_server_url,
+                install_node_deps=bool(args.install_node_deps),
+                ale_sandbox_cua_smoke_ready=bool(
+                    args.ale_sandbox_cua_smoke_ready
+                ),
+                operator_authorized_host_codex_auth=bool(
+                    args.operator_authorized_host_codex_auth
+                ),
+            )
+        except Exception:
+            payload = {
+                "ok": False,
+                "schema_version": "agents_last_exam_host_codex_cua_no_task_smoke_v0",
+                "error": "ale_host_codex_cua_no_task_e2e_failed",
+                "read_boundary": {
+                    "compact_only": True,
+                    "auth_values_read": False,
+                    "config_content_read": False,
+                    "task_text_read": False,
+                    "raw_artifacts_read": False,
+                    "local_paths_recorded": False,
+                    "container_started": False,
+                },
+            }
+        else:
+            payload["ok"] = True
+            if args.require_ready and payload.get("ready") is not True:
+                payload["ok"] = False
+                payload["error"] = (
+                    payload.get("first_blocker")
+                    or "ale_host_codex_cua_no_task_e2e_not_ready"
+                )
+        print_payload(
+            payload,
+            output_format(args),
+            render_agents_last_exam_host_codex_cua_no_task_smoke_markdown,
+        )
+        return 0 if payload.get("ok") else 1
+
+    return None


### PR DESCRIPTION
## Summary
- Extract ALE host Codex route and no-task E2E benchmark commands into `loopx/cli_commands/agents_last_exam_host_codex.py`
- Keep `agents_last_exam.py` as the validation-gate coordinator and remove its legacy size-budget exemption after it drops below the default threshold
- Extend modularization smoke coverage to prevent host Codex render/build/handler code from leaking back into the parent module

## Validation
- `python3 -m py_compile loopx/cli_commands/agents_last_exam.py loopx/cli_commands/agents_last_exam_host_codex.py loopx/cli_commands/__init__.py examples/cli-agents-last-exam-command-modularization-smoke.py examples/cli-command-module-size-ownership-command-modularization-smoke.py`
- `python3 examples/cli-agents-last-exam-command-modularization-smoke.py`
- `python3 examples/cli-command-module-size-ownership-command-modularization-smoke.py`
- all `examples/cli-*-command-modularization-smoke.py`
- `python3 -m loopx.cli benchmark ale-host-codex-cli-route --assume-codex-binary-available --codex-version-text codex-smoke --operator-authorized-host-codex-auth --format json`
- `python3 -m loopx.cli benchmark ale-host-codex-cua-no-task-e2e --assume-codex-binary-available --codex-version-text codex-smoke --cua-mcp-assets-root . --operator-authorized-host-codex-auth --format json`
- `loopx check --scan-path loopx/cli_commands/agents_last_exam.py --scan-path loopx/cli_commands/agents_last_exam_host_codex.py --scan-path loopx/cli_commands/__init__.py --scan-path examples/cli-agents-last-exam-command-modularization-smoke.py --scan-path examples/cli-command-module-size-ownership-command-modularization-smoke.py`