### PR TITLE
Extract benchmark ledger maintenance CLI commands

### DIFF
--- a/examples/cli-benchmark-run-ledger-command-modularization-smoke.py
+++ b/examples/cli-benchmark-run-ledger-command-modularization-smoke.py
@@ -50,6 +50,9 @@ def main() -> int:
     module_source = (
         ROOT / "loopx" / "cli_commands" / "benchmark_run_ledger.py"
     ).read_text(encoding="utf-8")
+    maintenance_source = (
+        ROOT / "loopx" / "cli_commands" / "benchmark_run_ledger_maintenance.py"
+    ).read_text(encoding="utf-8")
 
     leaked_markers = [
         "benchmark_run_parser = benchmark_sub.add_parser",
@@ -63,15 +66,33 @@ def main() -> int:
     for marker in leaked_markers:
         if marker in cli_source:
             raise AssertionError(f"{marker} leaked back into loopx/cli.py")
-    assert_contains(
-        dispatch_source,
-        "register_benchmark_run_ledger_commands(benchmark_sub, add_subcommand_format)",
-    )
+    assert_contains(dispatch_source, "register_benchmark_run_ledger_commands(")
     assert_contains(dispatch_source, "handle_benchmark_run_ledger_command(")
     assert_contains(init_source, "register_benchmark_run_ledger_commands")
     assert_contains(init_source, "handle_benchmark_run_ledger_command")
+    assert_contains(init_source, "register_benchmark_run_ledger_maintenance_commands")
+    assert_contains(init_source, "handle_benchmark_run_ledger_maintenance_command")
     assert_contains(module_source, "BENCHMARK_RUN_LEDGER_COMMANDS")
-    assert_contains(module_source, "compact_benchmark_post_launch_materialization")
+    assert_contains(
+        module_source,
+        "register_benchmark_run_ledger_maintenance_commands(benchmark_subparsers)",
+    )
+    assert_contains(module_source, "handle_benchmark_run_ledger_maintenance_command(")
+
+    ownership_markers = [
+        "benchmark_run_ledger_upsert_parser = benchmark_subparsers.add_parser",
+        "benchmark_run_ledger_check_parser = benchmark_subparsers.add_parser",
+        "def render_benchmark_run_ledger_upsert_markdown",
+        "def render_benchmark_run_ledger_check_markdown",
+        'if args.benchmark_command == "run-ledger-upsert":',
+        'if args.benchmark_command == "run-ledger-check":',
+        "compact_benchmark_post_launch_materialization",
+        "check_benchmark_run_ledger_drift(",
+    ]
+    for marker in ownership_markers:
+        if marker in module_source:
+            raise AssertionError(f"{marker} leaked back into benchmark_run_ledger.py")
+        assert_contains(maintenance_source, marker)
 
     help_result = run_cli("benchmark", "run", "--help")
     if help_result.returncode != 0:

--- a/loopx/cli_commands/__init__.py
+++ b/loopx/cli_commands/__init__.py
@@ -60,6 +60,10 @@ from .benchmark_run_ledger import (
     handle_benchmark_run_ledger_command,
     register_benchmark_run_ledger_commands,
 )
+from .benchmark_run_ledger_maintenance import (
+    handle_benchmark_run_ledger_maintenance_command,
+    register_benchmark_run_ledger_maintenance_commands,
+)
 from .bootstrap_connect import (
     handle_bootstrap_connect_command,
     register_bootstrap_connect_command,
@@ -155,6 +159,7 @@ __all__ = [
     "handle_benchmark_command",
     "handle_benchmark_review_lifecycle_command",
     "handle_benchmark_run_ledger_command",
+    "handle_benchmark_run_ledger_maintenance_command",
     "handle_bootstrap_connect_command",
     "handle_check_command",
     "handle_codex_cli_bounded_visible_pilot_adapter_command",
@@ -209,6 +214,7 @@ __all__ = [
     "register_benchmark_command_group",
     "register_benchmark_review_lifecycle_commands",
     "register_benchmark_run_ledger_commands",
+    "register_benchmark_run_ledger_maintenance_commands",
     "register_bootstrap_connect_command",
     "register_doctor_command",
     "register_dreaming_commands",

--- a/loopx/cli_commands/benchmark_run_ledger.py
+++ b/loopx/cli_commands/benchmark_run_ledger.py
@@ -43,23 +43,24 @@ from ..benchmark_core import (
 )
 from ..benchmark_ledger import (
     BENCHMARK_RUN_LEDGER_DEFAULT_PATH,
-    check_benchmark_run_ledger_drift,
-    load_benchmark_run_ledger,
     update_benchmark_run_ledger,
 )
 from ..delivery_outcome import DELIVERY_OUTCOME_CHOICES
 from ..global_registry import sync_project_registry_to_global
 from ..history import (
     append_benchmark_run,
-    collect_history,
     load_registry,
     render_benchmark_run_append_markdown,
 )
 from ..paths import resolve_runtime_root
 from ..state_refresh import DELIVERY_BATCH_SCALE_CHOICES
 from ..status import (
-    compact_benchmark_post_launch_materialization,
     compact_benchmark_run,
+)
+from .benchmark_run_ledger_maintenance import (
+    BENCHMARK_RUN_LEDGER_MAINTENANCE_COMMANDS,
+    handle_benchmark_run_ledger_maintenance_command,
+    register_benchmark_run_ledger_maintenance_commands,
 )
 
 
@@ -74,48 +75,7 @@ BENCHMARK_RUN_LEDGER_COMMANDS = {
     "case-analysis-candidates",
     "parity-check",
     "run",
-    "run-ledger-check",
-    "run-ledger-upsert",
-}
-
-
-def render_benchmark_run_ledger_upsert_markdown(payload: dict[str, object]) -> str:
-    ledger = (
-        payload.get("benchmark_run_ledger")
-        if isinstance(payload.get("benchmark_run_ledger"), dict)
-        else {}
-    )
-    entry = ledger.get("entry") if isinstance(ledger.get("entry"), dict) else {}
-    decision = (
-        ledger.get("case_decision")
-        if isinstance(ledger.get("case_decision"), dict)
-        else {}
-    )
-    read_boundary = (
-        payload.get("read_boundary")
-        if isinstance(payload.get("read_boundary"), dict)
-        else {}
-    )
-    lines = [
-        "# Benchmark Run Ledger Upsert",
-        "",
-        f"- ok: `{payload.get('ok')}`",
-        f"- dry_run: `{payload.get('dry_run')}`",
-        f"- updated: `{ledger.get('updated')}`",
-        f"- benchmark: `{entry.get('benchmark_id')}`",
-        f"- case: `{entry.get('case_id')}`",
-        f"- arm: `{entry.get('arm_id')}`",
-        f"- score: `{entry.get('official_score')}`",
-        f"- failure: `{entry.get('failure_class')}`",
-        f"- decision: `{decision.get('decision')}`",
-        f"- ledger: `{ledger.get('ledger_path')}`",
-        f"- compact only: `{read_boundary.get('compact_only')}`",
-        f"- raw logs read: `{read_boundary.get('raw_logs_read')}`",
-        f"- task text read: `{read_boundary.get('task_text_read')}`",
-    ]
-    if payload.get("error"):
-        lines.append(f"- error: {payload.get('error')}")
-    return "\n".join(lines) + "\n"
+} | BENCHMARK_RUN_LEDGER_MAINTENANCE_COMMANDS
 
 
 def render_benchmark_case_analysis_candidates_markdown(
@@ -154,54 +114,6 @@ def render_benchmark_case_analysis_candidates_markdown(
     if payload.get("error"):
         lines.append(f"- error: {payload.get('error')}")
     return "\n".join(lines) + "\n"
-
-
-def render_benchmark_run_ledger_check_markdown(payload: dict[str, object]) -> str:
-    drift = (
-        payload.get("benchmark_run_ledger_drift")
-        if isinstance(payload.get("benchmark_run_ledger_drift"), dict)
-        else {}
-    )
-    lines = [
-        "# Benchmark Run Ledger Drift Check",
-        "",
-        f"- ok: `{payload.get('ok')}`",
-        f"- drift_detected: `{drift.get('drift_detected')}`",
-        f"- checked_history_run_count: `{drift.get('checked_history_run_count')}`",
-        f"- terminal_history_run_count: `{drift.get('terminal_history_run_count')}`",
-        f"- matched_history_run_count: `{drift.get('matched_history_run_count')}`",
-        f"- missing_ledger_run_count: `{drift.get('missing_ledger_run_count')}`",
-        f"- non_terminal_skipped_count: `{drift.get('non_terminal_skipped_count')}`",
-        f"- ledger_run_count: `{drift.get('ledger_run_count')}`",
-    ]
-    missing_runs = drift.get("missing_runs") if isinstance(drift.get("missing_runs"), list) else []
-    if missing_runs:
-        lines.extend(
-            [
-                "",
-                "## Missing Compact Runs",
-                "",
-                "| Benchmark | Case | Arm | Score | Failure | Catch-up |",
-                "| --- | --- | --- | --- | --- | --- |",
-            ]
-        )
-        for run in missing_runs:
-            if not isinstance(run, dict):
-                continue
-            lines.append(
-                "| "
-                f"`{run.get('benchmark_id')}` | "
-                f"`{run.get('case_id')}` | "
-                f"`{run.get('arm_id')}` | "
-                f"`{run.get('official_score')}` | "
-                f"`{run.get('failure_class')}` | "
-                f"`{run.get('catch_up_command_template')}` |"
-            )
-    if payload.get("error"):
-        lines.append(f"- error: {payload.get('error')}")
-    return "\n".join(lines) + "\n"
-
-
 
 
 def register_benchmark_run_ledger_commands(
@@ -458,85 +370,8 @@ def register_benchmark_run_ledger_commands(
     benchmark_run_parser.add_argument("--execute", action="store_true", help="Append the compact fixture event.")
     benchmark_run_parser.add_argument("--no-global-sync", action="store_true", help="Skip global registry sync after append.")
 
-    benchmark_run_ledger_upsert_parser = benchmark_subparsers.add_parser(
-        "run-ledger-upsert",
-        help=(
-            "Upsert benchmark_run_ledger_v0 from an existing compact "
-            "benchmark_run_v0 JSON file. This does not read raw runner artifacts."
-        ),
-    )
-    benchmark_run_ledger_upsert_parser.add_argument(
-        "--benchmark-run-json",
-        help="Path to a compact benchmark_run_v0 JSON object. Use '-' to read stdin.",
-    )
-    benchmark_run_ledger_upsert_parser.add_argument(
-        "--post-launch-json",
-        help=(
-            "Path to a compact terminal_bench_post_launch_materialization_v0 "
-            "object. Use '-' to read stdin. This records result-finalization "
-            "or post-launch failure markers without reading raw runner artifacts."
-        ),
-    )
-    benchmark_run_ledger_upsert_parser.add_argument(
-        "--run-ledger-path",
-        default=str(BENCHMARK_RUN_LEDGER_DEFAULT_PATH),
-        help="Path to benchmark_run_ledger_v0 JSON. Markdown is rendered next to it.",
-    )
-    benchmark_run_ledger_upsert_parser.add_argument(
-        "--run-group-id",
-        help="Optional stable run group id for the ledger row.",
-    )
-    benchmark_run_ledger_upsert_parser.add_argument(
-        "--arm-id",
-        help="Optional arm id override for the ledger row.",
-    )
-    benchmark_run_ledger_upsert_parser.add_argument(
-        "--compact-artifact-ref",
-        help="Optional public-safe relative reference to the compact run artifact.",
-    )
-    benchmark_run_ledger_upsert_parser.add_argument(
-        "--run-ledger-note",
-        help="Optional compact note for the ledger row.",
-    )
-    benchmark_run_ledger_upsert_parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Preview ledger update without writing. This is the default.",
-    )
-    benchmark_run_ledger_upsert_parser.add_argument(
-        "--execute",
-        action="store_true",
-        help="Write the benchmark run ledger update.",
-    )
-    benchmark_run_ledger_check_parser = benchmark_subparsers.add_parser(
-        "run-ledger-check",
-        help=(
-            "Compare compact benchmark_run_v0 run history with the public "
-            "benchmark_run_ledger_v0. This reads compact history only."
-        ),
-    )
-    benchmark_run_ledger_check_parser.add_argument(
-        "--goal-id",
-        required=True,
-        help="Goal id whose compact benchmark run history should be checked.",
-    )
-    benchmark_run_ledger_check_parser.add_argument(
-        "--run-ledger-path",
-        default=str(BENCHMARK_RUN_LEDGER_DEFAULT_PATH),
-        help="Path to benchmark_run_ledger_v0 JSON.",
-    )
-    benchmark_run_ledger_check_parser.add_argument(
-        "--history-limit",
-        type=int,
-        default=500,
-        help="Maximum recent compact run-history rows to compare.",
-    )
-    benchmark_run_ledger_check_parser.add_argument(
-        "--limit",
-        type=int,
-        default=20,
-        help="Maximum missing rows to include in output.",
-    )
+    register_benchmark_run_ledger_maintenance_commands(benchmark_subparsers)
+
     benchmark_case_analysis_candidates_parser = benchmark_subparsers.add_parser(
         "case-analysis-candidates",
         help=(
@@ -605,7 +440,6 @@ def register_benchmark_run_ledger_commands(
     )
 
 
-
 def handle_benchmark_run_ledger_command(
     args: argparse.Namespace,
     *,
@@ -655,62 +489,16 @@ def handle_benchmark_run_ledger_command(
             ),
         )
         return 0 if payload.get("ok") else 1
-    if args.benchmark_command == "run-ledger-check":
-        try:
-            history_payload = collect_history(
-                registry_path=registry_path,
-                runtime_root=resolve_runtime_root(
-                    load_registry(registry_path),
-                    args.runtime_root,
-                ),
-                goal_id=args.goal_id,
-                limit=max(0, int(args.history_limit)),
-            )
-            ledger = load_benchmark_run_ledger(args.run_ledger_path)
-            drift = check_benchmark_run_ledger_drift(
-                history_records=[
-                    run
-                    for run in history_payload.get("runs", [])
-                    if isinstance(run, dict)
-                ],
-                ledger=ledger,
-                ledger_path=args.run_ledger_path,
-                limit=max(0, int(args.limit)),
-                cwd=Path.cwd(),
-            )
-            payload = {
-                "ok": True,
-                "goal_id": args.goal_id,
-                "history_limit": args.history_limit,
-                "benchmark_run_ledger_drift": drift,
-                "read_boundary": drift.get("read_boundary"),
-            }
-        except Exception as exc:
-            payload = {
-                "ok": False,
-                "goal_id": args.goal_id,
-                "benchmark_run_ledger_drift": {
-                    "schema_version": "benchmark_run_ledger_drift_v0",
-                    "ok": False,
-                    "drift_detected": False,
-                },
-                "read_boundary": {
-                    "compact_only": True,
-                    "raw_logs_read": False,
-                    "task_text_read": False,
-                    "trajectory_read": False,
-                    "docker_invoked": False,
-                    "model_api_invoked": False,
-                    "upload_invoked": False,
-                },
-                "error": str(exc),
-            }
-        print_payload(
-            payload,
-            args.format,
-            render_benchmark_run_ledger_check_markdown,
-        )
-        return 0 if payload.get("ok") else 1
+
+    ledger_maintenance_result = handle_benchmark_run_ledger_maintenance_command(
+        args,
+        registry_path=registry_path,
+        print_payload=print_payload,
+        output_format=output_format,
+    )
+    if ledger_maintenance_result is not None:
+        return ledger_maintenance_result
+
     if args.benchmark_command == "case-analysis-candidates":
         try:
             if (
@@ -819,94 +607,7 @@ def handle_benchmark_run_ledger_command(
             render_benchmark_case_analysis_candidates_markdown,
         )
         return 0 if payload.get("ok") else 1
-    if args.benchmark_command == "run-ledger-upsert":
-        try:
-            if args.dry_run and args.execute:
-                raise ValueError(
-                    "benchmark run-ledger-upsert accepts either --dry-run or --execute, not both"
-                )
-            if bool(args.benchmark_run_json) == bool(args.post_launch_json):
-                raise ValueError(
-                    "provide exactly one of --benchmark-run-json or --post-launch-json"
-                )
 
-            input_path_text = args.benchmark_run_json or args.post_launch_json
-            if input_path_text == "-":
-                run_input = json.loads(sys.stdin.read())
-                compact_artifact_ref = args.compact_artifact_ref
-            else:
-                input_path = Path(input_path_text).expanduser()
-                run_input = json.loads(input_path.read_text(encoding="utf-8"))
-                compact_artifact_ref = args.compact_artifact_ref or str(input_path)
-            if not isinstance(run_input, dict):
-                raise ValueError("ledger input JSON must contain an object")
-
-            if args.benchmark_run_json:
-                benchmark_run = compact_benchmark_run(run_input)
-                if not benchmark_run:
-                    raise ValueError(
-                        "--benchmark-run-json did not contain a compactable benchmark_run_v0 object"
-                    )
-                input_kind = "benchmark_run_v0"
-            else:
-                benchmark_run = compact_benchmark_post_launch_materialization(
-                    run_input
-                )
-                if not benchmark_run:
-                    raise ValueError(
-                        "--post-launch-json did not contain a compactable terminal_bench_post_launch_materialization_v0 object"
-                    )
-                input_kind = "terminal_bench_post_launch_materialization_v0"
-            dry_run = not bool(args.execute)
-            ledger_update = update_benchmark_run_ledger(
-                ledger_path=args.run_ledger_path,
-                benchmark_run=benchmark_run,
-                compact_artifact_ref=compact_artifact_ref,
-                run_group_id=args.run_group_id,
-                arm_id=args.arm_id,
-                notes=args.run_ledger_note,
-                dry_run=dry_run,
-            )
-            payload = {
-                "ok": True,
-                "dry_run": dry_run,
-                "input_kind": input_kind,
-                "benchmark_run_ledger": ledger_update,
-                "read_boundary": {
-                    "compact_only": True,
-                    "raw_logs_read": False,
-                    "task_text_read": False,
-                    "trajectory_read": False,
-                    "docker_invoked": False,
-                    "model_api_invoked": False,
-                    "upload_invoked": False,
-                },
-            }
-        except Exception as exc:
-            payload = {
-                "ok": False,
-                "dry_run": not bool(args.execute),
-                "benchmark_run_ledger": {
-                    "updated": False,
-                    "ledger_path": args.run_ledger_path,
-                },
-                "read_boundary": {
-                    "compact_only": True,
-                    "raw_logs_read": False,
-                    "task_text_read": False,
-                    "trajectory_read": False,
-                    "docker_invoked": False,
-                    "model_api_invoked": False,
-                    "upload_invoked": False,
-                },
-                "error": str(exc),
-            }
-        print_payload(
-            payload,
-            args.format,
-            render_benchmark_run_ledger_upsert_markdown,
-        )
-        return 0 if payload.get("ok") else 1
     if args.benchmark_command == "run":
         try:
             if args.dry_run and args.execute:

--- a/loopx/cli_commands/benchmark_run_ledger_maintenance.py
+++ b/loopx/cli_commands/benchmark_run_ledger_maintenance.py
@@ -1,0 +1,363 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+from ..benchmark_ledger import (
+    BENCHMARK_RUN_LEDGER_DEFAULT_PATH,
+    check_benchmark_run_ledger_drift,
+    load_benchmark_run_ledger,
+    update_benchmark_run_ledger,
+)
+from ..history import collect_history, load_registry
+from ..paths import resolve_runtime_root
+from ..status import (
+    compact_benchmark_post_launch_materialization,
+    compact_benchmark_run,
+)
+
+
+PrintPayload = Callable[
+    [dict[str, object], str, Callable[[dict[str, object]], str]],
+    None,
+]
+OutputFormat = Callable[[argparse.Namespace], str]
+
+BENCHMARK_RUN_LEDGER_MAINTENANCE_COMMANDS = {
+    "run-ledger-check",
+    "run-ledger-upsert",
+}
+
+
+def render_benchmark_run_ledger_upsert_markdown(payload: dict[str, object]) -> str:
+    ledger = (
+        payload.get("benchmark_run_ledger")
+        if isinstance(payload.get("benchmark_run_ledger"), dict)
+        else {}
+    )
+    entry = ledger.get("entry") if isinstance(ledger.get("entry"), dict) else {}
+    decision = (
+        ledger.get("case_decision")
+        if isinstance(ledger.get("case_decision"), dict)
+        else {}
+    )
+    read_boundary = (
+        payload.get("read_boundary")
+        if isinstance(payload.get("read_boundary"), dict)
+        else {}
+    )
+    lines = [
+        "# Benchmark Run Ledger Upsert",
+        "",
+        f"- ok: `{payload.get('ok')}`",
+        f"- dry_run: `{payload.get('dry_run')}`",
+        f"- updated: `{ledger.get('updated')}`",
+        f"- benchmark: `{entry.get('benchmark_id')}`",
+        f"- case: `{entry.get('case_id')}`",
+        f"- arm: `{entry.get('arm_id')}`",
+        f"- score: `{entry.get('official_score')}`",
+        f"- failure: `{entry.get('failure_class')}`",
+        f"- decision: `{decision.get('decision')}`",
+        f"- ledger: `{ledger.get('ledger_path')}`",
+        f"- compact only: `{read_boundary.get('compact_only')}`",
+        f"- raw logs read: `{read_boundary.get('raw_logs_read')}`",
+        f"- task text read: `{read_boundary.get('task_text_read')}`",
+    ]
+    if payload.get("error"):
+        lines.append(f"- error: {payload.get('error')}")
+    return "\n".join(lines) + "\n"
+
+
+def render_benchmark_run_ledger_check_markdown(payload: dict[str, object]) -> str:
+    drift = (
+        payload.get("benchmark_run_ledger_drift")
+        if isinstance(payload.get("benchmark_run_ledger_drift"), dict)
+        else {}
+    )
+    lines = [
+        "# Benchmark Run Ledger Drift Check",
+        "",
+        f"- ok: `{payload.get('ok')}`",
+        f"- drift_detected: `{drift.get('drift_detected')}`",
+        f"- checked_history_run_count: `{drift.get('checked_history_run_count')}`",
+        f"- terminal_history_run_count: `{drift.get('terminal_history_run_count')}`",
+        f"- matched_history_run_count: `{drift.get('matched_history_run_count')}`",
+        f"- missing_ledger_run_count: `{drift.get('missing_ledger_run_count')}`",
+        f"- non_terminal_skipped_count: `{drift.get('non_terminal_skipped_count')}`",
+        f"- ledger_run_count: `{drift.get('ledger_run_count')}`",
+    ]
+    missing_runs = (
+        drift.get("missing_runs") if isinstance(drift.get("missing_runs"), list) else []
+    )
+    if missing_runs:
+        lines.extend(
+            [
+                "",
+                "## Missing Compact Runs",
+                "",
+                "| Benchmark | Case | Arm | Score | Failure | Catch-up |",
+                "| --- | --- | --- | --- | --- | --- |",
+            ]
+        )
+        for run in missing_runs:
+            if not isinstance(run, dict):
+                continue
+            lines.append(
+                "| "
+                f"`{run.get('benchmark_id')}` | "
+                f"`{run.get('case_id')}` | "
+                f"`{run.get('arm_id')}` | "
+                f"`{run.get('official_score')}` | "
+                f"`{run.get('failure_class')}` | "
+                f"`{run.get('catch_up_command_template')}` |"
+            )
+    if payload.get("error"):
+        lines.append(f"- error: {payload.get('error')}")
+    return "\n".join(lines) + "\n"
+
+
+def register_benchmark_run_ledger_maintenance_commands(
+    benchmark_subparsers: argparse._SubParsersAction,
+) -> None:
+    benchmark_run_ledger_upsert_parser = benchmark_subparsers.add_parser(
+        "run-ledger-upsert",
+        help=(
+            "Upsert benchmark_run_ledger_v0 from an existing compact "
+            "benchmark_run_v0 JSON file. This does not read raw runner artifacts."
+        ),
+    )
+    benchmark_run_ledger_upsert_parser.add_argument(
+        "--benchmark-run-json",
+        help="Path to a compact benchmark_run_v0 JSON object. Use '-' to read stdin.",
+    )
+    benchmark_run_ledger_upsert_parser.add_argument(
+        "--post-launch-json",
+        help=(
+            "Path to a compact terminal_bench_post_launch_materialization_v0 "
+            "object. Use '-' to read stdin. This records result-finalization "
+            "or post-launch failure markers without reading raw runner artifacts."
+        ),
+    )
+    benchmark_run_ledger_upsert_parser.add_argument(
+        "--run-ledger-path",
+        default=str(BENCHMARK_RUN_LEDGER_DEFAULT_PATH),
+        help="Path to benchmark_run_ledger_v0 JSON. Markdown is rendered next to it.",
+    )
+    benchmark_run_ledger_upsert_parser.add_argument(
+        "--run-group-id",
+        help="Optional stable run group id for the ledger row.",
+    )
+    benchmark_run_ledger_upsert_parser.add_argument(
+        "--arm-id",
+        help="Optional arm id override for the ledger row.",
+    )
+    benchmark_run_ledger_upsert_parser.add_argument(
+        "--compact-artifact-ref",
+        help="Optional public-safe relative reference to the compact run artifact.",
+    )
+    benchmark_run_ledger_upsert_parser.add_argument(
+        "--run-ledger-note",
+        help="Optional compact note for the ledger row.",
+    )
+    benchmark_run_ledger_upsert_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview ledger update without writing. This is the default.",
+    )
+    benchmark_run_ledger_upsert_parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Write the benchmark run ledger update.",
+    )
+
+    benchmark_run_ledger_check_parser = benchmark_subparsers.add_parser(
+        "run-ledger-check",
+        help=(
+            "Compare compact benchmark_run_v0 run history with the public "
+            "benchmark_run_ledger_v0. This reads compact history only."
+        ),
+    )
+    benchmark_run_ledger_check_parser.add_argument(
+        "--goal-id",
+        required=True,
+        help="Goal id whose compact benchmark run history should be checked.",
+    )
+    benchmark_run_ledger_check_parser.add_argument(
+        "--run-ledger-path",
+        default=str(BENCHMARK_RUN_LEDGER_DEFAULT_PATH),
+        help="Path to benchmark_run_ledger_v0 JSON.",
+    )
+    benchmark_run_ledger_check_parser.add_argument(
+        "--history-limit",
+        type=int,
+        default=500,
+        help="Maximum recent compact run-history rows to compare.",
+    )
+    benchmark_run_ledger_check_parser.add_argument(
+        "--limit",
+        type=int,
+        default=20,
+        help="Maximum missing rows to include in output.",
+    )
+
+
+def handle_benchmark_run_ledger_maintenance_command(
+    args: argparse.Namespace,
+    *,
+    registry_path: Path,
+    print_payload: PrintPayload,
+    output_format: OutputFormat,
+) -> int | None:
+    if args.benchmark_command not in BENCHMARK_RUN_LEDGER_MAINTENANCE_COMMANDS:
+        return None
+
+    if args.benchmark_command == "run-ledger-check":
+        try:
+            history_payload = collect_history(
+                registry_path=registry_path,
+                runtime_root=resolve_runtime_root(
+                    load_registry(registry_path),
+                    args.runtime_root,
+                ),
+                goal_id=args.goal_id,
+                limit=max(0, int(args.history_limit)),
+            )
+            ledger = load_benchmark_run_ledger(args.run_ledger_path)
+            drift = check_benchmark_run_ledger_drift(
+                history_records=[
+                    run
+                    for run in history_payload.get("runs", [])
+                    if isinstance(run, dict)
+                ],
+                ledger=ledger,
+                ledger_path=args.run_ledger_path,
+                limit=max(0, int(args.limit)),
+                cwd=Path.cwd(),
+            )
+            payload = {
+                "ok": True,
+                "goal_id": args.goal_id,
+                "history_limit": args.history_limit,
+                "benchmark_run_ledger_drift": drift,
+                "read_boundary": drift.get("read_boundary"),
+            }
+        except Exception as exc:
+            payload = {
+                "ok": False,
+                "goal_id": args.goal_id,
+                "benchmark_run_ledger_drift": {
+                    "schema_version": "benchmark_run_ledger_drift_v0",
+                    "ok": False,
+                    "drift_detected": False,
+                },
+                "read_boundary": {
+                    "compact_only": True,
+                    "raw_logs_read": False,
+                    "task_text_read": False,
+                    "trajectory_read": False,
+                    "docker_invoked": False,
+                    "model_api_invoked": False,
+                    "upload_invoked": False,
+                },
+                "error": str(exc),
+            }
+        print_payload(
+            payload,
+            output_format(args),
+            render_benchmark_run_ledger_check_markdown,
+        )
+        return 0 if payload.get("ok") else 1
+
+    if args.benchmark_command == "run-ledger-upsert":
+        try:
+            if args.dry_run and args.execute:
+                raise ValueError(
+                    "benchmark run-ledger-upsert accepts either --dry-run or --execute, not both"
+                )
+            if bool(args.benchmark_run_json) == bool(args.post_launch_json):
+                raise ValueError(
+                    "provide exactly one of --benchmark-run-json or --post-launch-json"
+                )
+
+            input_path_text = args.benchmark_run_json or args.post_launch_json
+            if input_path_text == "-":
+                run_input = json.loads(sys.stdin.read())
+                compact_artifact_ref = args.compact_artifact_ref
+            else:
+                input_path = Path(input_path_text).expanduser()
+                run_input = json.loads(input_path.read_text(encoding="utf-8"))
+                compact_artifact_ref = args.compact_artifact_ref or str(input_path)
+            if not isinstance(run_input, dict):
+                raise ValueError("ledger input JSON must contain an object")
+
+            if args.benchmark_run_json:
+                benchmark_run = compact_benchmark_run(run_input)
+                if not benchmark_run:
+                    raise ValueError(
+                        "--benchmark-run-json did not contain a compactable benchmark_run_v0 object"
+                    )
+                input_kind = "benchmark_run_v0"
+            else:
+                benchmark_run = compact_benchmark_post_launch_materialization(
+                    run_input
+                )
+                if not benchmark_run:
+                    raise ValueError(
+                        "--post-launch-json did not contain a compactable terminal_bench_post_launch_materialization_v0 object"
+                    )
+                input_kind = "terminal_bench_post_launch_materialization_v0"
+            dry_run = not bool(args.execute)
+            ledger_update = update_benchmark_run_ledger(
+                ledger_path=args.run_ledger_path,
+                benchmark_run=benchmark_run,
+                compact_artifact_ref=compact_artifact_ref,
+                run_group_id=args.run_group_id,
+                arm_id=args.arm_id,
+                notes=args.run_ledger_note,
+                dry_run=dry_run,
+            )
+            payload = {
+                "ok": True,
+                "dry_run": dry_run,
+                "input_kind": input_kind,
+                "benchmark_run_ledger": ledger_update,
+                "read_boundary": {
+                    "compact_only": True,
+                    "raw_logs_read": False,
+                    "task_text_read": False,
+                    "trajectory_read": False,
+                    "docker_invoked": False,
+                    "model_api_invoked": False,
+                    "upload_invoked": False,
+                },
+            }
+        except Exception as exc:
+            payload = {
+                "ok": False,
+                "dry_run": not bool(args.execute),
+                "benchmark_run_ledger": {
+                    "updated": False,
+                    "ledger_path": args.run_ledger_path,
+                },
+                "read_boundary": {
+                    "compact_only": True,
+                    "raw_logs_read": False,
+                    "task_text_read": False,
+                    "trajectory_read": False,
+                    "docker_invoked": False,
+                    "model_api_invoked": False,
+                    "upload_invoked": False,
+                },
+                "error": str(exc),
+            }
+        print_payload(
+            payload,
+            output_format(args),
+            render_benchmark_run_ledger_upsert_markdown,
+        )
+        return 0 if payload.get("ok") else 1
+
+    return None


### PR DESCRIPTION
## Summary
- Extract benchmark run-ledger-upsert/check parser, renderers, and handlers into benchmark_run_ledger_maintenance.py.
- Keep benchmark_run_ledger.py as the owner for run/parity-check/case-analysis-candidates plus a maintenance delegate.
- Extend the benchmark run-ledger modularization smoke to assert ownership does not leak back into the parent module.

## Validation
- python3 examples/cli-benchmark-run-ledger-command-modularization-smoke.py
- python3 examples/cli-command-module-size-ownership-command-modularization-smoke.py
- for smoke in examples/cli-*-command-modularization-smoke.py; do python3 "" || exit 1; done
- python3 -m py_compile 
- loopx check --scan-path loopx/cli_commands/benchmark_run_ledger.py --scan-path loopx/cli_commands/benchmark_run_ledger_maintenance.py --scan-path loopx/cli_commands/__init__.py --scan-path examples/cli-benchmark-run-ledger-command-modularization-smoke.py
- git diff --check / git diff --cached --check

LoopX check warning observed: existing loopx-meta duplicate index rows raw=4751 unique=4747.