### PR TITLE
Add deferred todo resume projection

### DIFF
--- a/docs/interaction-pattern-catalog.md
+++ b/docs/interaction-pattern-catalog.md
@@ -1299,8 +1299,50 @@ monitor work to crowd out the selected advancement lane.
 
 Agent-scoped quota must distinguish "the goal has runnable work" from "this
 agent has runnable work." When the current agent has no in-scope candidate,
-quota should not force a delivery turn. It should project one of these machine
-states instead:
+quota should not force a delivery turn. It first checks whether the scoped
+frontier is truly empty or whether a deferred successor has become ready.
+
+Deferred work should stay machine-readable without becoming executable backlog
+too early. A deferred todo may carry `resume_when=<token>`, initially
+`resume_when=todo_done:<todo_id>`. Status evaluates the condition, adds
+`resume_condition`, and marks `resume_ready=true` only after the target todo is
+done. Status and quota expose deferred work after sorted open lanes through
+bounded visibility fields:
+
+- `deferred_items`: sorted visibility for deferred todos;
+- `deferred_resume_candidates`: sorted visibility for ready deferred todos;
+- default cap: 8 deferred items per lane.
+
+These fields are visibility and replan input, not normal delivery permission.
+Consumers must not merge them into `first_open_items` or executable backlog
+until a lifecycle command reopens or supersedes the todo.
+
+For agent-scoped quota, ready deferred candidates are split by claim:
+
+- `current_agent_deferred_resume_candidates`;
+- `unclaimed_deferred_resume_candidates`;
+- `other_agent_deferred_resume_candidates`.
+
+Only current-agent and unclaimed ready deferred candidates can wake that side
+agent. Other-agent deferred candidates remain diagnostic visibility. If the
+side agent has no open current-agent or unclaimed advancement todo but does
+have a ready current-agent/unclaimed deferred candidate, quota should return:
+
+```text
+effective_action=successor_replan_required
+should_run=true
+normal_delivery_allowed=false
+execution_obligation.contract=deferred_resume_projection
+interaction_contract.agent_channel.must_attempt=true
+interaction_contract.agent_channel.quiet_noop_allowed=false
+```
+
+The bounded action is to reopen the deferred todo, supersede it with a current
+successor, or record a public-safe no-follow-up rationale. Only after that
+writeback may normal delivery resume.
+
+If no ready current-agent or unclaimed deferred successor exists, quota should
+project one of these machine states instead:
 
 - `scope_exhausted`: no current-agent or unclaimed candidate matches the
   registered agent profile and boundary;
@@ -1322,9 +1364,9 @@ recommended action should name the scoped condition, not borrow the global
 goal-level route. A side agent should be allowed to no-op without spend, or
 claim a newly exposed in-scope todo before delivery becomes allowed again.
 
-This pattern is the runtime counterpart of IP-022. IP-022 makes claimed and
-agent-lane work visible; IP-026 says what to do when that scoped frontier is
-empty.
+This pattern is the runtime counterpart of IP-022. IP-022 makes claimed,
+deferred, and agent-lane work visible; IP-026 says what to do when that scoped
+frontier is empty or when a deferred successor makes it non-empty again.
 
 **Visual Model**
 
@@ -1333,10 +1375,15 @@ flowchart TD
   Q["quota should-run --agent-id side"] --> F{"current-agent frontier?"}
   F -->|"current-agent candidate"| D["bounded delivery allowed"]
   F -->|"unclaimed in-scope candidate"| C["agent may claim before delivery"]
-  F -->|"only other-agent or out-of-scope work"| X["scope_exhausted / primary_review_wait"]
+  F -->|"no open candidate"| R{"ready current/unclaimed deferred successor?"}
+  R -->|"yes"| P["successor_replan_required"]
+  P --> U["reopen, supersede, or no-follow-up rationale"]
+  U --> Q
+  R -->|"no"| X["scope_exhausted / primary_review_wait"]
+  F -->|"only other-agent or out-of-scope work"| X
   X --> N["quiet no-op, no spend"]
-  X --> R["primary may review, merge, or reassign"]
-  R --> Q
+  X --> H["primary may review, merge, or reassign"]
+  H --> Q
 ```
 
 **Bad smell**
@@ -1346,7 +1393,11 @@ A side-agent heartbeat receives `should_run=true`,
 `agent_lane_next_action=None`, `current_agent_claimed_advancement_items=[]`,
 and the only recommendation is a primary-owned benchmark or runtime lane. The
 agent either churns through repeated empty heartbeats or risks working outside
-its registered scope.
+its registered scope. A related failure is a ready deferred successor that
+remains visible only in a quiet no-candidate payload; the side agent reports
+"nothing runnable" until a human notices and asks for the next productization
+layer. The opposite bad smell is also harmful: deferred items are mixed into
+the open todo list, so stale or future work outranks live open tasks.
 
 **Validation**
 
@@ -1354,7 +1405,15 @@ its registered scope.
   work is claimed by the primary and the side-agent `--agent-id` call returns
   `scope_exhausted` or `primary_review_wait`;
 - `examples/work-lane-contract-smoke.py` should cover that an empty
-  current-agent frontier cannot produce `delivery_allowed=true`;
+  current-agent frontier cannot produce `delivery_allowed=true`, and that a
+  ready deferred successor returns `successor_replan_required` instead of a
+  quiet no-op;
+- `examples/todo-durability-fixture-smoke.py` covers parsing
+  `resume_when=todo_done:<todo_id>` and projecting ready deferred candidates
+  after open items;
+- `docs/project-agent-todo-contract.md`
+- `docs/quota-allocation.md`
+- `docs/status-data-contract.md`
 - `skills/loopx-self-repair/references/repair-patterns.md` records
   `agent_scoped_no_candidate_gap` for incident triage.
 

--- a/docs/project-agent-todo-contract.md
+++ b/docs/project-agent-todo-contract.md
@@ -142,6 +142,14 @@ next-action selection should prefer that repair-mode candidate over ordinary
 runnable work in the same claim/priority bucket so capability-building todos do
 not require fragile active-state reordering.
 
+Deferred todos may carry a machine-readable resume condition with
+`resume_when=<token>`. The first supported condition is
+`resume_when=todo_done:<todo_id>`, meaning the deferred todo should become a
+successor replan candidate after the referenced todo reaches `status=done`.
+Status and quota expose deferred todos as a visibility lane after sorted open
+todo lanes; they are not runnable work until an agent reopens, supersedes, or
+records a no-follow-up rationale for the deferred item.
+
 ```bash
 loopx configure-goal \
   --goal-id <goal-id> \
@@ -320,6 +328,18 @@ loopx todo update \
   --task-class blocker
 ```
 
+Use `--resume-when` when deferring a successor that should wake up after a
+machine-readable condition instead of living only in prose:
+
+```bash
+loopx todo update \
+  --goal-id <goal-id> \
+  --todo-id <todo_id> \
+  --status deferred \
+  --resume-when todo_done:<blocking_todo_id> \
+  --reason "<public-safe deferred rationale>"
+```
+
 Use `todo supersede` when the current open todo should be retired and replaced:
 
 ```bash
@@ -352,6 +372,9 @@ carry `schema_version=todo_summary_v0`; individual items carry
 optional `action_kind`, `claimed_by`, `required_capabilities`, and
 `target_capabilities`. Primary review handoffs may also carry
 `blocks_agent` and `unblocks_todo_id` to show which agent/todo they release.
+Deferred successors may carry `resume_when`, `resume_condition`, and
+`resume_ready`; `resume_ready=true` means the deferred item should be considered
+for a successor replan, not that normal delivery may skip the todo lifecycle.
 The `todo_id` is first-class when written by the CLI.
 `claimed_by` values are normalized public-safe agent ids and should correspond to
 `coordination.registered_agents`. Legacy Markdown without metadata still gets a

--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -336,6 +336,18 @@ same-priority backlog, even if the goal-level `Next Action` prose is stale.
 This is only a scheduling hint: capability gates, write-scope checks, user
 gates, and validation still apply.
 
+Deferred todo visibility is a separate quota lane, not executable backlog.
+Status/quota may expose up to eight sorted `deferred_items` and up to eight
+ready `deferred_resume_candidates` after the sorted open todo lanes. In
+agent-scoped `quota should-run --agent-id <side-agent>`, all deferred items may
+remain visible for diagnosis, but only ready candidates claimed by the current
+agent or left unclaimed can wake that side agent. If such a candidate exists
+and no open current-agent/unclaimed advancement todo exists, quota returns
+`effective_action=successor_replan_required`,
+`normal_delivery_allowed=false`, and `execution_obligation.contract =
+deferred_resume_projection`. The worker must reopen, supersede, or record a
+public-safe no-follow-up rationale before ordinary delivery work.
+
 External-evidence waits have an additional CLI-level observation contract. When
 the selected goal is `state=waiting`, `waiting_on=external_evidence`, and its
 current lane is a continuous monitor, or when the active state says a

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -881,6 +881,17 @@ Item fields:
   claimed items. Other-agent claims are visibility context and last-resort
   candidates; they are not a hard lock, but they also should not outrank the
   current agent's own claimed work or unclaimed work.
+  Deferred todos are projected after sorted open todo lanes through
+  `deferred_items` and, when a machine-readable resume condition is satisfied,
+  `deferred_resume_candidates`. The default deferred visibility cap is eight
+  items. Parsed deferred items may include `resume_when`,
+  `resume_condition`, and `resume_ready`; consumers should not merge these into
+  `first_open_items` or executable backlog until a lifecycle command reopens or
+  supersedes the todo. Agent-scoped quota may further split ready candidates
+  into `current_agent_deferred_resume_candidates`,
+  `unclaimed_deferred_resume_candidates`, and
+  `other_agent_deferred_resume_candidates`, where only the first two can wake
+  the current side agent.
   Optional future fields such as `created_at`, lease TTLs, dependencies, or
   evidence links should extend this item shape rather than inventing another
   todo surface.

--- a/examples/todo-durability-fixture-smoke.py
+++ b/examples/todo-durability-fixture-smoke.py
@@ -24,6 +24,7 @@ FIRST_OPEN_TODO = (
 )
 SECOND_OPEN_TODO = "[P2] Keep the todo archive warning visible in quota should-run."
 ACTIVE_DONE_TODO = "[P2] Prior completed implementation remains in active Agent Todo until archived."
+DEFERRED_TODO = "[P1] Resume the issue surface fixture after CLI extraction stabilizes."
 ARCHIVED_DONE_TODOS = 25
 
 
@@ -64,6 +65,9 @@ def state_text() -> str:
         "- [ ] [P1] Add a parseable todo fixture when discovered planning work\n"
         "  cannot be represented by the current Markdown parser.\n"
         f"- [x] {ACTIVE_DONE_TODO}\n"
+        "  <!-- loopx:todo todo_id=todo_done_cli status=done task_class=advancement_task -->\n"
+        f"- [-] {DEFERRED_TODO}\n"
+        "  <!-- loopx:todo todo_id=todo_deferred_surface status=deferred task_class=advancement_task claimed_by=codex-product-capability resume_when=todo_done:todo_done_cli -->\n"
         f"- [ ] {SECOND_OPEN_TODO}\n\n"
         "## Completed Work Archive\n\n"
         f"{archived_lines}"
@@ -117,10 +121,11 @@ def write_fixture(root: Path) -> tuple[Path, Path]:
 
 def assert_parseable_agent_todos(agent_todos: dict) -> None:
     assert agent_todos["schema_version"] == "todo_summary_v0", agent_todos
-    assert agent_todos["total_count"] == 3, agent_todos
+    assert agent_todos["total_count"] == 4, agent_todos
     assert agent_todos["open_count"] == 2, agent_todos
-    assert agent_todos["done_count"] == 1, agent_todos
-    assert [item["index"] for item in agent_todos["first_open_items"]] == [1, 3], agent_todos
+    assert agent_todos["done_count"] == 2, agent_todos
+    assert agent_todos["deferred_count"] == 1, agent_todos
+    assert [item["index"] for item in agent_todos["first_open_items"]] == [1, 4], agent_todos
 
     first_open = agent_todos["first_open_items"][0]
     assert first_open["schema_version"] == "todo_item_v0", first_open
@@ -140,6 +145,17 @@ def assert_parseable_agent_todos(agent_todos: dict) -> None:
     assert second_open["priority"] == "P2", second_open
     assert second_open["status"] == "open", second_open
     assert second_open["text"] == SECOND_OPEN_TODO, second_open
+
+    deferred = agent_todos["deferred_items"][0]
+    assert deferred["todo_id"] == "todo_deferred_surface", deferred
+    assert deferred["status"] == "deferred", deferred
+    assert deferred["resume_when"] == "todo_done:todo_done_cli", deferred
+    assert deferred["resume_ready"] is True, deferred
+    assert deferred["resume_condition"]["target_status"] == "done", deferred
+    assert agent_todos["deferred_resume_candidates"][0]["todo_id"] == "todo_deferred_surface", agent_todos
+    if "items" in agent_todos:
+        statuses = [item["status"] for item in agent_todos["items"][:3]]
+        assert statuses == ["open", "open", "deferred"], agent_todos
 
 
 def attention_item(status_payload: dict) -> dict:
@@ -161,7 +177,12 @@ def main() -> int:
         assert "completed_todo_archive_warning" not in item, item
         assert "completed_todo_archive_warning" not in item["project_asset"], item
         assert item["project_asset"]["agent_todos"]["open"] == 2, item
-        assert item["project_asset"]["agent_todos"]["done"] == 1, item
+        assert item["project_asset"]["agent_todos"]["done"] == 2, item
+        assert item["project_asset"]["agent_todos"]["deferred_count"] == 1, item
+        assert (
+            item["project_asset"]["agent_todos"]["deferred_resume_candidates"][0]["todo_id"]
+            == "todo_deferred_surface"
+        ), item
         assert item["project_asset"]["agent_todos"]["next"] == FIRST_OPEN_TODO, item
         assert item["project_asset"]["agent_todos"]["next_index"] == 1, item
 
@@ -198,7 +219,8 @@ def main() -> int:
         post_lifecycle_item = attention_item(post_lifecycle_status)
         post_agent_todos = post_lifecycle_item["agent_todos"]
         assert post_agent_todos["open_count"] == 2, post_agent_todos
-        assert post_agent_todos["done_count"] == 2, post_agent_todos
+        assert post_agent_todos["done_count"] == 3, post_agent_todos
+        assert post_agent_todos["deferred_count"] == 1, post_agent_todos
         assert post_agent_todos["first_open_items"][0]["priority"] == "P1", post_agent_todos
         assert post_agent_todos["first_open_items"][0]["todo_id"] == next_todo["todo_id"], post_agent_todos
         assert post_agent_todos["first_open_items"][0]["action_kind"] == "fixture_follow_up", post_agent_todos

--- a/examples/work-lane-contract-smoke.py
+++ b/examples/work-lane-contract-smoke.py
@@ -1138,6 +1138,135 @@ def assert_side_agent_waits_when_only_other_agent_has_claimed_work() -> None:
     assert "quiet_noop_allowed=True" in markdown, markdown
 
 
+def assert_side_agent_replans_when_deferred_successor_is_ready() -> None:
+    deferred_action = "[P1] Continue the issue meta surface fixture implementation."
+    payload = status_payload(
+        status="side_agent_ready_deferred_successor",
+        has_agent_todo=False,
+        next_action="Continue the ready deferred issue-surface successor.",
+        coordination={
+            "primary_agent": "codex-main-control",
+            "registered_agents": ["codex-main-control", "codex-side-bypass"],
+        },
+    )
+    agent_todos = {
+        "schema_version": "todo_summary_v0",
+        "source_section": "Agent Todo",
+        "total_count": 2,
+        "open_count": 0,
+        "done_count": 2,
+        "deferred_count": 1,
+        "first_open_items": [],
+        "backlog_items": [],
+        "items": [
+            {
+                "index": 1,
+                "text": "[P1] Finish CLI extraction prerequisite.",
+                "role": "agent",
+                "status": "done",
+                "done": True,
+                "priority": "P1",
+                "task_class": "advancement_task",
+                "todo_id": "todo_cli_done",
+            },
+            {
+                "index": 2,
+                "text": deferred_action,
+                "role": "agent",
+                "status": "deferred",
+                "done": True,
+                "priority": "P1",
+                "task_class": "advancement_task",
+                "claimed_by": "codex-side-bypass",
+                "todo_id": "todo_issue_surface_deferred",
+                "resume_when": "todo_done:todo_cli_done",
+                "resume_ready": True,
+                "resume_condition": {
+                    "schema_version": "todo_resume_condition_v0",
+                    "resume_when": "todo_done:todo_cli_done",
+                    "kind": "todo_done",
+                    "target_todo_id": "todo_cli_done",
+                    "target_status": "done",
+                    "satisfied": True,
+                },
+            },
+        ],
+        "deferred_items": [
+            {
+                "index": 2,
+                "text": deferred_action,
+                "role": "agent",
+                "status": "deferred",
+                "done": True,
+                "priority": "P1",
+                "task_class": "advancement_task",
+                "claimed_by": "codex-side-bypass",
+                "todo_id": "todo_issue_surface_deferred",
+                "resume_when": "todo_done:todo_cli_done",
+                "resume_ready": True,
+                "resume_condition": {
+                    "schema_version": "todo_resume_condition_v0",
+                    "resume_when": "todo_done:todo_cli_done",
+                    "kind": "todo_done",
+                    "target_todo_id": "todo_cli_done",
+                    "target_status": "done",
+                    "satisfied": True,
+                },
+            }
+        ],
+        "deferred_resume_candidates": [
+            {
+                "index": 2,
+                "text": deferred_action,
+                "role": "agent",
+                "status": "deferred",
+                "done": True,
+                "priority": "P1",
+                "task_class": "advancement_task",
+                "claimed_by": "codex-side-bypass",
+                "todo_id": "todo_issue_surface_deferred",
+                "resume_when": "todo_done:todo_cli_done",
+                "resume_ready": True,
+            }
+        ],
+    }
+    item = payload["attention_queue"]["items"][0]
+    item["project_asset"]["agent_todos"] = agent_todos
+    item["agent_todos"] = agent_todos
+
+    guard = build_quota_should_run(
+        payload,
+        goal_id=GOAL_ID,
+        agent_id="codex-side-bypass",
+    )
+    assert guard["decision"] == "successor_replan_required", guard
+    assert guard["should_run"] is True, guard
+    assert guard["normal_delivery_allowed"] is False, guard
+    assert guard["actionable_by_codex"] is True, guard
+    assert guard["effective_action"] == "successor_replan_required", guard
+    frontier = guard["agent_scope_frontier"]
+    assert frontier["action"] == "successor_replan_required", frontier
+    assert frontier["quiet_noop_allowed"] is False, frontier
+    assert frontier["requires_replan"] is True, frontier
+    assert frontier["deferred_resume_candidates"][0]["todo_id"] == "todo_issue_surface_deferred", frontier
+    assert guard["agent_todo_summary"]["current_agent_deferred_resume_count"] == 1, guard
+    obligation = guard["execution_obligation"]
+    assert obligation["kind"] == "successor_replan_required", obligation
+    assert obligation["must_attempt_work"] is True, obligation
+    assert obligation["delivery_allowed"] is False, obligation
+    contract = guard["interaction_contract"]
+    assert contract["mode"] == "successor_replan_required", contract
+    assert contract["agent_channel"]["must_attempt"] is True, contract
+    assert contract["agent_channel"]["delivery_allowed"] is False, contract
+    assert contract["agent_channel"]["quiet_noop_allowed"] is False, contract
+    assert contract["cli_channel"]["spend_after_validation"] is True, contract
+    assert "todo_issue_surface_deferred" in contract["cli_channel"]["next_cli_actions"][0], contract
+    assert guard["automation_liveness"]["automation_action"] == "execute_bounded_work", guard
+    markdown = render_quota_should_run_markdown(guard)
+    assert "agent_scope_frontier: action=successor_replan_required" in markdown, markdown
+    assert "agent_scope_deferred_resume_candidates" in markdown, markdown
+
+
 def assert_side_agent_can_take_unclaimed_work() -> None:
     primary_action = "[P0] Run SWE-Marathon full-suite polling and record compact results."
     unclaimed_action = "[P0] Validate hosted Frontstage screenshot and public CTA copy."
@@ -1380,6 +1509,7 @@ def main() -> int:
     assert_launch_then_poll_todo_without_handle_routes_to_advancement()
     assert_side_agent_next_action_projects_without_stealing_goal_next_action()
     assert_side_agent_waits_when_only_other_agent_has_claimed_work()
+    assert_side_agent_replans_when_deferred_successor_is_ready()
     assert_side_agent_can_take_unclaimed_work()
     assert_agent_lane_next_action_prefers_capability_repair_candidate()
     assert_primary_agent_prioritizes_claimed_review_handoff()

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -119,6 +119,13 @@ def register_todo_command(subparsers: argparse._SubParsersAction) -> None:
         ),
     )
     todo_parser.add_argument(
+        "--resume-when",
+        help=(
+            "For deferred todo add/update, declare a machine-readable resume condition "
+            "such as todo_done:todo_ab12cd34ef56."
+        ),
+    )
+    todo_parser.add_argument(
         "--clear-claim",
         action="store_true",
         help="For todo update, remove the soft claimed_by owner from the todo.",
@@ -194,6 +201,7 @@ def handle_todo_command(
                 claimed_by=args.claimed_by,
                 blocks_agent=args.blocks_agent,
                 unblocks_todo_id=args.unblocks_todo_id,
+                resume_when=args.resume_when,
                 project=Path(args.project).expanduser() if args.project else None,
                 state_file=Path(args.state_file).expanduser() if args.state_file else None,
                 dry_run=bool(args.dry_run),
@@ -220,6 +228,7 @@ def handle_todo_command(
                     ("--target-capability", args.target_capabilities),
                     ("--blocks-agent", args.blocks_agent),
                     ("--unblocks-todo-id", args.unblocks_todo_id),
+                    ("--resume-when", args.resume_when),
                     ("--next-agent-todo", args.next_agent_todo),
                     ("--next-user-todo", args.next_user_todo),
                     ("--next-claimed-by", args.next_claimed_by),
@@ -265,9 +274,10 @@ def handle_todo_command(
                 args.claimed_by,
                 args.blocks_agent,
                 args.unblocks_todo_id,
+                args.resume_when,
                 args.clear_claim,
             ]):
-                raise ValueError("todo update requires at least one of --text, --status, --note, --evidence, --reason, --task-class, --action-kind, --required-write-scope, --required-capability, --target-capability, --claimed-by, --blocks-agent, --unblocks-todo-id, or --clear-claim")
+                raise ValueError("todo update requires at least one of --text, --status, --note, --evidence, --reason, --task-class, --action-kind, --required-write-scope, --required-capability, --target-capability, --claimed-by, --blocks-agent, --unblocks-todo-id, --resume-when, or --clear-claim")
             if args.next_claimed_by:
                 raise ValueError("todo update does not support --next-claimed-by")
             if args.side_agent_self_merged:
@@ -290,6 +300,7 @@ def handle_todo_command(
                 claimed_by=args.claimed_by,
                 blocks_agent=args.blocks_agent,
                 unblocks_todo_id=args.unblocks_todo_id,
+                resume_when=args.resume_when,
                 clear_claim=bool(args.clear_claim),
                 project=Path(args.project).expanduser() if args.project else None,
                 state_file=Path(args.state_file).expanduser() if args.state_file else None,
@@ -300,8 +311,8 @@ def handle_todo_command(
                 raise ValueError("todo complete requires --todo-id")
             if args.claimed_by and args.clear_claim:
                 raise ValueError("todo complete accepts either --claimed-by or --clear-claim, not both")
-            if args.blocks_agent or args.unblocks_todo_id:
-                raise ValueError("todo complete does not support --blocks-agent or --unblocks-todo-id; use todo update before completion or side-agent review successor metadata")
+            if args.blocks_agent or args.unblocks_todo_id or args.resume_when:
+                raise ValueError("todo complete does not support --blocks-agent, --unblocks-todo-id, or --resume-when; use todo update before completion or side-agent review successor metadata")
             payload = complete_goal_todo(
                 registry_path=registry_path,
                 goal_id=args.goal_id,
@@ -328,8 +339,8 @@ def handle_todo_command(
                 raise ValueError("todo supersede does not support --claimed-by or --clear-claim")
             if args.side_agent_self_merged:
                 raise ValueError("todo supersede does not support --side-agent-self-merged")
-            if args.blocks_agent or args.unblocks_todo_id:
-                raise ValueError("todo supersede does not support --blocks-agent or --unblocks-todo-id; update the source todo first so the successor can inherit dependency metadata")
+            if args.blocks_agent or args.unblocks_todo_id or args.resume_when:
+                raise ValueError("todo supersede does not support --blocks-agent, --unblocks-todo-id, or --resume-when; update the source todo first so the successor can inherit dependency metadata")
             payload = supersede_goal_todo(
                 registry_path=registry_path,
                 goal_id=args.goal_id,

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -31,6 +31,7 @@ from .execution_profile import (
 from .orchestration import compact_orchestration_policy, orchestration_policy_summary
 from .state_projection import is_user_wait_text, next_action_projection_warning
 from .todo_contract import (
+    TODO_STATUS_DEFERRED,
     TODO_STATUS_OPEN,
     TODO_TASK_CLASS_ADVANCEMENT,
     TODO_TASK_CLASS_BLOCKER,
@@ -42,6 +43,7 @@ from .todo_contract import (
     normalize_todo_blocks_agent,
     normalize_todo_claimed_by,
     normalize_todo_id,
+    normalize_todo_resume_when,
     normalize_required_write_scopes,
     normalize_todo_status,
     normalize_todo_task_class,
@@ -152,6 +154,7 @@ class AgentScopeFrontierAction(str, Enum):
     AGENT_SCOPE_EXHAUSTED = "agent_scope_exhausted"
     PRIMARY_REVIEW_WAIT = "primary_review_wait"
     REASSIGNMENT_REQUIRED = "reassignment_required"
+    SUCCESSOR_REPLAN_REQUIRED = "successor_replan_required"
 
 
 DEFAULT_AVAILABLE_CAPABILITIES = (
@@ -171,6 +174,7 @@ CAPABILITY_OWNER_GATE_HINTS = {
     "production_access",
 }
 TODO_BACKLOG_ITEM_LIMIT = 8
+TODO_DEFERRED_VISIBILITY_LIMIT = 8
 TODO_VISIBILITY_LANE_LIMIT = 16
 TODO_MISSING_PRIORITY_RANK = 50
 TODO_MISSING_INDEX = 999999
@@ -979,6 +983,9 @@ def _compact_todo_summary_item(item: dict[str, Any], *, text: str | None = None)
         "claimed_by",
         "blocks_agent",
         "unblocks_todo_id",
+        "resume_when",
+        "resume_condition",
+        "resume_ready",
     ):
         if item.get(key) is not None:
             compact[key] = item.get(key)
@@ -1390,6 +1397,118 @@ def _todo_summary_visibility_lanes(
     return lanes
 
 
+def _todo_item_is_deferred(item: dict[str, Any]) -> bool:
+    return (normalize_todo_status(item.get("status")) or "") == TODO_STATUS_DEFERRED
+
+
+def _todo_summary_deferred_items(value: dict[str, Any], key: str) -> list[dict[str, Any]]:
+    if not isinstance(value, dict):
+        return []
+    source_items = value.get(key) if isinstance(value.get(key), list) else []
+    if not source_items and key == "deferred_items":
+        source_items = [
+            item
+            for item in value.get("items", [])
+            if isinstance(item, dict) and _todo_item_is_deferred(item)
+        ]
+    items: list[dict[str, Any]] = []
+    for item in source_items:
+        if not isinstance(item, dict):
+            continue
+        text = str(item.get("text") or "").strip()
+        if not text:
+            continue
+        compact = _compact_todo_summary_item(item, text=text)
+        resume_when = normalize_todo_resume_when(item.get("resume_when"))
+        if resume_when:
+            compact["resume_when"] = resume_when
+        if item.get("resume_condition") is not None:
+            compact["resume_condition"] = item.get("resume_condition")
+        if item.get("resume_ready") is not None:
+            compact["resume_ready"] = bool(item.get("resume_ready"))
+        if _todo_item_is_deferred(compact):
+            items.append(compact)
+    return sorted(items, key=_todo_projection_sort_key)
+
+
+def _agent_claim_filtered_deferred_items(
+    items: list[dict[str, Any]],
+    *,
+    agent_id: str | None,
+    claim: str,
+) -> list[dict[str, Any]]:
+    selected: list[dict[str, Any]] = []
+    for item in items:
+        claimed_by = normalize_todo_claimed_by(item.get("claimed_by"))
+        if claim == "current" and claimed_by != agent_id:
+            continue
+        if claim == "unclaimed" and claimed_by:
+            continue
+        if claim == "other" and (not claimed_by or claimed_by == agent_id):
+            continue
+        selected.append(item)
+    return selected
+
+
+def _deferred_visibility_lanes(
+    value: dict[str, Any],
+    *,
+    agent_identity: dict[str, Any] | None,
+) -> dict[str, Any]:
+    deferred_items = _todo_summary_deferred_items(value, "deferred_items")
+    deferred_resume_candidates = [
+        item
+        for item in _todo_summary_deferred_items(value, "deferred_resume_candidates")
+        if item.get("resume_ready") is True
+    ]
+    if not deferred_items and not deferred_resume_candidates and not value.get("deferred_count"):
+        return {}
+
+    lanes: dict[str, Any] = {
+        "deferred_count": value.get("deferred_count", len(deferred_items)),
+        "deferred_visibility_limit": TODO_DEFERRED_VISIBILITY_LIMIT,
+        "deferred_items": deferred_items[:TODO_DEFERRED_VISIBILITY_LIMIT],
+        "deferred_resume_candidates": deferred_resume_candidates[:TODO_DEFERRED_VISIBILITY_LIMIT],
+    }
+    agent_id = (
+        normalize_todo_claimed_by(agent_identity.get("agent_id"))
+        if isinstance(agent_identity, dict)
+        else None
+    )
+    if agent_id:
+        current_agent_candidates = _agent_claim_filtered_deferred_items(
+            deferred_resume_candidates,
+            agent_id=agent_id,
+            claim="current",
+        )
+        unclaimed_candidates = _agent_claim_filtered_deferred_items(
+            deferred_resume_candidates,
+            agent_id=agent_id,
+            claim="unclaimed",
+        )
+        other_agent_candidates = _agent_claim_filtered_deferred_items(
+            deferred_resume_candidates,
+            agent_id=agent_id,
+            claim="other",
+        )
+        lanes.update(
+            {
+                "current_agent_deferred_resume_candidates": current_agent_candidates[:TODO_DEFERRED_VISIBILITY_LIMIT],
+                "unclaimed_deferred_resume_candidates": unclaimed_candidates[:TODO_DEFERRED_VISIBILITY_LIMIT],
+                "other_agent_deferred_resume_candidates": other_agent_candidates[:TODO_DEFERRED_VISIBILITY_LIMIT],
+                "current_agent_deferred_resume_count": len(current_agent_candidates),
+                "unclaimed_deferred_resume_count": len(unclaimed_candidates),
+                "other_agent_deferred_resume_count": len(other_agent_candidates),
+                "deferred_resume_selection_policy": (
+                    "quota may wake the current side-agent only for ready deferred "
+                    "todos claimed by that agent or unclaimed; other-agent deferred "
+                    "todos remain diagnostic visibility"
+                ),
+            }
+        )
+    return lanes
+
+
 def _todo_summary_source_items(value: dict[str, Any]) -> list[dict[str, Any]]:
     source_keys = (
         "first_open_items",
@@ -1486,6 +1605,12 @@ def _summarize_user_todos(
             agent_identity=agent_identity,
         )
     )
+    summary.update(
+        _deferred_visibility_lanes(
+            value,
+            agent_identity=agent_identity,
+        )
+    )
     if claimed_open_items or value.get("claimed_open_count"):
         summary["claimed_open_count"] = value.get("claimed_open_count", len(claimed_open_items))
         summary["unclaimed_open_count"] = value.get(
@@ -1556,6 +1681,12 @@ def _summarize_project_asset_todos(
     summary.update(
         _todo_summary_visibility_lanes(
             all_open_items,
+            agent_identity=agent_identity,
+        )
+    )
+    summary.update(
+        _deferred_visibility_lanes(
+            value,
             agent_identity=agent_identity,
         )
     )
@@ -2016,6 +2147,45 @@ def _agent_scope_frontier_action(value: Any) -> AgentScopeFrontierAction | None:
         return None
 
 
+def _agent_scope_deferred_resume_candidates(
+    agent_todo_summary: dict[str, Any],
+    *,
+    agent_id: str,
+) -> list[dict[str, Any]]:
+    candidates: list[dict[str, Any]] = []
+    for key in (
+        "current_agent_deferred_resume_candidates",
+        "unclaimed_deferred_resume_candidates",
+    ):
+        value = agent_todo_summary.get(key)
+        if isinstance(value, list):
+            candidates.extend(item for item in value if isinstance(item, dict))
+    if not candidates:
+        value = agent_todo_summary.get("deferred_resume_candidates")
+        if isinstance(value, list):
+            for item in value:
+                if not isinstance(item, dict):
+                    continue
+                claimed_by = normalize_todo_claimed_by(item.get("claimed_by"))
+                if claimed_by and claimed_by != agent_id:
+                    continue
+                candidates.append(item)
+
+    unique: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for item in candidates:
+        if item.get("resume_ready") is not True:
+            continue
+        if not _todo_item_is_deferred(item):
+            continue
+        identity = str(item.get("todo_id") or item.get("index") or item.get("text") or "")
+        if identity in seen:
+            continue
+        seen.add(identity)
+        unique.append(_compact_todo_summary_item(item, text=str(item.get("text") or "").strip()))
+    return sorted(unique, key=_todo_projection_sort_key)
+
+
 def _agent_scope_no_candidate_frontier(
     *,
     agent_identity: dict[str, Any] | None,
@@ -2033,12 +2203,11 @@ def _agent_scope_no_candidate_frontier(
         return None
     if isinstance(agent_lane_next_action, dict):
         return None
-    if not isinstance(work_lane_contract, dict):
-        return None
-    if work_lane_contract.get("lane") != TODO_TASK_CLASS_ADVANCEMENT:
-        return None
-    if work_lane_contract.get("must_attempt_work") is not True:
-        return None
+    has_advancement_contract = (
+        isinstance(work_lane_contract, dict)
+        and work_lane_contract.get("lane") == TODO_TASK_CLASS_ADVANCEMENT
+        and work_lane_contract.get("must_attempt_work") is True
+    )
 
     current_agent_count = int(agent_todo_summary.get("current_agent_claimed_advancement_count") or 0)
     current_agent_count = max(
@@ -2063,6 +2232,44 @@ def _agent_scope_no_candidate_frontier(
             _count_advancement_items(executable_items, claimed_by="__unclaimed__"),
         )
     if current_agent_count > 0 or unclaimed_count > 0:
+        return None
+
+    deferred_resume_candidates = _agent_scope_deferred_resume_candidates(
+        agent_todo_summary,
+        agent_id=agent_id,
+    )
+    if deferred_resume_candidates:
+        first_candidate = deferred_resume_candidates[0]
+        candidate_todo_id = str(first_candidate.get("todo_id") or "").strip() or "<todo_id>"
+        reason = (
+            f"current side-agent {agent_id} has no open current/unclaimed "
+            "advancement candidate, but a deferred successor resume condition is satisfied"
+        )
+        recommended_action = (
+            "Run a bounded successor replan before delivery: reopen, supersede, "
+            f"or record a no-follow-up rationale for {candidate_todo_id}."
+        )
+        return {
+            "schema_version": AGENT_SCOPE_FRONTIER_SCHEMA_VERSION,
+            "agent_id": agent_id,
+            "primary_agent": normalize_todo_claimed_by(agent_identity.get("primary_agent")),
+            "action": AgentScopeFrontierAction.SUCCESSOR_REPLAN_REQUIRED.value,
+            "effective_action": AgentScopeFrontierAction.SUCCESSOR_REPLAN_REQUIRED.value,
+            "blocks_delivery": True,
+            "requires_replan": True,
+            "quiet_noop_allowed": False,
+            "spend_policy": "spend once after validated successor replan/todo writeback",
+            "reason": reason,
+            "recommended_action": recommended_action,
+            "candidate_counts": {
+                "current_agent_claimed_advancement_count": current_agent_count,
+                "unclaimed_advancement_count": unclaimed_count,
+                "deferred_resume_candidate_count": len(deferred_resume_candidates),
+            },
+            "deferred_resume_candidates": deferred_resume_candidates[:3],
+        }
+
+    if not has_advancement_contract:
         return None
 
     claimed_advancement_items = (
@@ -2962,6 +3169,24 @@ def _interaction_next_cli_actions(payload: dict[str, Any], *, mode: str) -> list
             f"loopx quota monitor-poll --goal-id {goal_id} --source heartbeat --execute",
             f"loopx --format json quota should-run --goal-id {goal_id}",
         ]
+    if mode == AgentScopeFrontierAction.SUCCESSOR_REPLAN_REQUIRED.value:
+        agent_scope_frontier = (
+            payload.get("agent_scope_frontier")
+            if isinstance(payload.get("agent_scope_frontier"), dict)
+            else {}
+        )
+        candidates = (
+            agent_scope_frontier.get("deferred_resume_candidates")
+            if isinstance(agent_scope_frontier.get("deferred_resume_candidates"), list)
+            else []
+        )
+        first_candidate = candidates[0] if candidates and isinstance(candidates[0], dict) else {}
+        todo_id = str(first_candidate.get("todo_id") or "<todo_id>")
+        return [
+            f"loopx todo update --goal-id {goal_id} --todo-id {todo_id} --status open --note '<public-safe successor replan reason>'",
+            f"loopx refresh-state --goal-id {goal_id} --classification successor_replan_recorded --delivery-batch-scale single_surface --delivery-outcome outcome_progress",
+            f"loopx quota spend-slot --goal-id {goal_id} --slots 1 --source heartbeat --execute",
+        ]
     if _agent_scope_frontier_action(mode) is not None:
         agent_identity = (
             payload.get("agent_identity")
@@ -3033,6 +3258,8 @@ def _interaction_spend_policy(
         return "no spend for gate or blocker push"
     if mode == "monitor_quiet_skip":
         return "no spend for unchanged monitor poll"
+    if mode == AgentScopeFrontierAction.SUCCESSOR_REPLAN_REQUIRED.value:
+        return "spend once after validated successor replan/todo writeback"
     if _agent_scope_frontier_action(mode) is not None:
         return "no spend while the current agent has no in-scope runnable candidate"
     if mode == "side_agent_workspace_repair":
@@ -3104,6 +3331,7 @@ def _interaction_contract(payload: dict[str, Any]) -> dict[str, Any]:
         "control_plane_self_repair",
         "boundary_projection_repair",
         "external_evidence_observation",
+        AgentScopeFrontierAction.SUCCESSOR_REPLAN_REQUIRED.value,
         "scoped_user_gate_fallback",
         "bounded_delivery_with_user_notice",
     }
@@ -3228,6 +3456,17 @@ def _automation_liveness(payload: dict[str, Any]) -> dict[str, Any]:
                 "active but block delivery until it reruns with a registered agent id"
             ),
             "spend_policy": "no quota spend for identity prompt upgrade preflight",
+        }
+    if effective_action == AgentScopeFrontierAction.SUCCESSOR_REPLAN_REQUIRED.value:
+        return {
+            **base,
+            "automation_action": "execute_bounded_work",
+            "reason": (
+                "a ready deferred successor is visible to this agent; run a bounded "
+                "successor replan or write a no-follow-up rationale before another quiet no-op"
+            ),
+            "next_trigger": "deferred successor replan writeback or fresh quota guard",
+            "spend_policy": "spend once only after validated successor replan/todo writeback",
         }
     if _agent_scope_frontier_action(effective_action) is not None:
         return {
@@ -4528,6 +4767,24 @@ def _execution_obligation(
                 "quiet no-op is not allowed until the replan slice is validated or blocked"
             ),
         }
+    if should_run and recommended_mode == AgentScopeFrontierAction.SUCCESSOR_REPLAN_REQUIRED.value:
+        return {
+            "must_attempt_work": True,
+            "kind": AgentScopeFrontierAction.SUCCESSOR_REPLAN_REQUIRED.value,
+            "minimum": "one_successor_replan_or_no_followup_writeback",
+            "delivery_allowed": False,
+            "notify_is_execution_gate": False,
+            "contract": "deferred_resume_projection",
+            "contract_obligation": (
+                "reopen or supersede the ready deferred successor, or record a "
+                "public-safe no-follow-up rationale before another quiet no-op"
+            ),
+            "spend_policy": heartbeat_recommendation.get("spend_policy"),
+            "reason": (
+                "a deferred successor resume condition is satisfied; the agent must "
+                "repair the todo projection before normal delivery"
+            ),
+        }
     if should_run and recommended_mode == "repair_state_projection_gap":
         return {
             "must_attempt_work": True,
@@ -5270,9 +5527,13 @@ def build_quota_should_run(
             candidate_should_run=bool(should_run and normal_delivery_allowed),
         )
         if agent_scope_frontier:
+            frontier_action = str(agent_scope_frontier.get("effective_action") or "")
+            successor_replan_required = (
+                frontier_action == AgentScopeFrontierAction.SUCCESSOR_REPLAN_REQUIRED.value
+            )
             normal_delivery_allowed = False
-            should_run = False
-            effective_action = str(agent_scope_frontier.get("effective_action") or "")
+            should_run = bool(successor_replan_required)
+            effective_action = frontier_action
             reason = str(agent_scope_frontier.get("reason") or reason)
             selected_recommended_action = (
                 agent_scope_frontier.get("recommended_action")
@@ -6719,6 +6980,22 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
         )
         if agent_scope_frontier.get("reason"):
             lines.append(f"- agent_scope_frontier_reason: {agent_scope_frontier.get('reason')}")
+        deferred_resume_candidates = (
+            agent_scope_frontier.get("deferred_resume_candidates")
+            if isinstance(agent_scope_frontier.get("deferred_resume_candidates"), list)
+            else []
+        )
+        if deferred_resume_candidates:
+            first_candidate = (
+                deferred_resume_candidates[0]
+                if isinstance(deferred_resume_candidates[0], dict)
+                else {}
+            )
+            lines.append(
+                "- agent_scope_deferred_resume_candidates: "
+                f"`{len(deferred_resume_candidates)}` "
+                f"top_todo_id={first_candidate.get('todo_id')}"
+            )
     automation_prompt_upgrade = (
         payload.get("automation_prompt_upgrade")
         if isinstance(payload.get("automation_prompt_upgrade"), dict)

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -58,6 +58,7 @@ from .todo_contract import (
     normalize_todo_blocks_agent,
     normalize_todo_claimed_by,
     normalize_todo_id,
+    normalize_todo_resume_when,
     normalize_todo_status,
     normalize_todo_task_class,
     parse_todo_metadata_line,
@@ -358,6 +359,7 @@ MAX_ACTIVE_DONE_TODOS_BEFORE_ARCHIVE = MAX_STATUS_TODOS_PER_ROLE
 MAX_PROJECT_ASSET_TODO_ITEMS = 3
 MAX_PROJECT_ASSET_TODO_BACKLOG_ITEMS = 8
 MAX_TODO_VISIBILITY_LANE_ITEMS = 16
+MAX_DEFERRED_TODO_VISIBILITY_ITEMS = 8
 MAX_TODO_INDEX_ITEMS = 240
 MAX_TODO_INDEX_ROLLOUT_EVENTS_PER_GOAL = 500
 TODO_PROJECTION_VIEW_SCHEMA_VERSION = "todo_projection_view_v0"
@@ -3948,6 +3950,9 @@ def structured_todo_item(
     unblocks_todo_id = normalize_todo_id(item.get("unblocks_todo_id"))
     if unblocks_todo_id:
         normalized["unblocks_todo_id"] = unblocks_todo_id
+    resume_when = normalize_todo_resume_when(item.get("resume_when"))
+    if resume_when:
+        normalized["resume_when"] = resume_when
     if priority:
         normalized["priority"] = priority
         normalized["title"] = normalize_todo_text(title)
@@ -3977,6 +3982,9 @@ def compact_todo_item(item: dict[str, Any]) -> dict[str, Any]:
         "claimed_by",
         "blocks_agent",
         "unblocks_todo_id",
+        "resume_when",
+        "resume_condition",
+        "resume_ready",
         "note",
         "evidence",
         "reason",
@@ -4068,6 +4076,44 @@ def claimed_visibility_items(items: list[dict[str, Any]], *, limit: int) -> list
     return sorted(selected, key=lambda item: original_index.get(id(item), 999999))[:limit]
 
 
+def todo_item_is_deferred(item: dict[str, Any]) -> bool:
+    return (normalize_todo_status(item.get("status")) or TODO_STATUS_OPEN) == "deferred"
+
+
+def apply_resume_conditions(items: list[dict[str, Any]]) -> None:
+    by_id = {
+        str(item.get("todo_id") or ""): item
+        for item in items
+        if str(item.get("todo_id") or "")
+    }
+    for item in items:
+        resume_when = normalize_todo_resume_when(item.get("resume_when"))
+        if not resume_when:
+            continue
+        condition: dict[str, Any] = {
+            "schema_version": "todo_resume_condition_v0",
+            "resume_when": resume_when,
+            "satisfied": False,
+        }
+        kind, separator, target = resume_when.partition(":")
+        condition["kind"] = kind
+        if separator:
+            condition["target"] = target
+        if kind == "todo_done" and target:
+            target_item = by_id.get(target)
+            condition["target_todo_id"] = target
+            condition["target_status"] = (
+                normalize_todo_status(target_item.get("status"))
+                if isinstance(target_item, dict)
+                else None
+            )
+            condition["satisfied"] = condition["target_status"] == "done"
+        else:
+            condition["unsupported"] = True
+        item["resume_condition"] = condition
+        item["resume_ready"] = bool(condition.get("satisfied"))
+
+
 def compact_todo_group(
     items: list[dict[str, Any]],
     *,
@@ -4082,10 +4128,18 @@ def compact_todo_group(
         else item
         for item in items
     ]
+    apply_resume_conditions(items)
     open_items = [item for item in items if not item.get("done")]
-    done_items = [item for item in items if item.get("done")]
-    budgeted_items = [*open_items, *done_items]
+    terminal_items = [item for item in items if item.get("done")]
+    deferred_items = [item for item in terminal_items if todo_item_is_deferred(item)]
+    done_items = [item for item in terminal_items if not todo_item_is_deferred(item)]
     projected_open_items = sorted(open_items, key=todo_projection_sort_key)
+    projected_deferred_items = sorted(deferred_items, key=todo_projection_sort_key)
+    budgeted_items = [
+        *projected_open_items,
+        *projected_deferred_items,
+        *done_items,
+    ]
     claimed_open_items = [item for item in projected_open_items if item.get("claimed_by")]
     unclaimed_open_items = [item for item in projected_open_items if not item.get("claimed_by")]
     executable_items = [
@@ -4117,7 +4171,8 @@ def compact_todo_group(
         "source_section": source_section,
         "total_count": len(items),
         "open_count": len(open_items),
-        "done_count": len(done_items),
+        "done_count": len(terminal_items),
+        "deferred_count": len(deferred_items),
         "first_open_items": [
             compact_todo_item(item) for item in projected_open_items[:3]
         ],
@@ -4160,6 +4215,15 @@ def compact_todo_group(
             compact_todo_item(item)
             for item in executable_items[:MAX_PROJECT_ASSET_TODO_BACKLOG_ITEMS]
         ],
+        "deferred_items": [
+            compact_todo_item(item)
+            for item in projected_deferred_items[:MAX_DEFERRED_TODO_VISIBILITY_ITEMS]
+        ],
+        "deferred_resume_candidates": [
+            compact_todo_item(item)
+            for item in projected_deferred_items
+            if item.get("resume_ready") is True
+        ][:MAX_DEFERRED_TODO_VISIBILITY_ITEMS],
         "items": budgeted_items[:MAX_STATUS_TODOS_PER_ROLE],
     }
     if claimed_open_items:
@@ -4815,6 +4879,7 @@ def project_asset_todo_summary(
             "truth": "derived",
             "canonical_source": canonical_source,
             "item_limit": MAX_PROJECT_ASSET_TODO_ITEMS,
+            "deferred_item_limit": MAX_DEFERRED_TODO_VISIBILITY_ITEMS,
         },
         "detail_pointer": {
             "schema_version": TODO_PROJECTION_DETAIL_POINTER_SCHEMA_VERSION,
@@ -4838,6 +4903,23 @@ def project_asset_todo_summary(
             summary["next_index"] = open_items[0].get("index")
         if open_items[0].get("claimed_by"):
             summary["next_claimed_by"] = open_items[0].get("claimed_by")
+    deferred_items = [
+        compact_todo_item(item)
+        for item in todos.get("deferred_items", [])
+        if isinstance(item, dict)
+    ][:MAX_DEFERRED_TODO_VISIBILITY_ITEMS]
+    deferred_resume_candidates = [
+        compact_todo_item(item)
+        for item in todos.get("deferred_resume_candidates", [])
+        if isinstance(item, dict)
+    ][:MAX_DEFERRED_TODO_VISIBILITY_ITEMS]
+    if todos.get("deferred_count") is not None:
+        summary["deferred_count"] = todos.get("deferred_count")
+        summary["deferred_visibility_limit"] = MAX_DEFERRED_TODO_VISIBILITY_ITEMS
+    if deferred_items:
+        summary["deferred_items"] = deferred_items
+    if deferred_resume_candidates:
+        summary["deferred_resume_candidates"] = deferred_resume_candidates
     executable_items = [
         item
         for item in open_todo_items(

--- a/loopx/todo_contract.py
+++ b/loopx/todo_contract.py
@@ -13,6 +13,7 @@ TODO_ACTION_KIND_PATTERN = re.compile(r"^[a-z][a-z0-9_-]{0,63}$")
 TODO_ID_PATTERN = re.compile(r"^todo_[a-z0-9_-]{3,64}$")
 TODO_AGENT_CLAIM_PATTERN = re.compile(r"^[a-z][a-z0-9_.:@-]{0,79}$")
 TODO_CAPABILITY_PATTERN = re.compile(r"^[a-z][a-z0-9_:-]{0,63}$")
+TODO_RESUME_WHEN_PATTERN = re.compile(r"^[a-z][a-z0-9_-]{0,31}(?::[a-z0-9_.:@-]{1,96})?$")
 TODO_WRITE_SCOPE_MAX_CHARS = 160
 
 TODO_TASK_CLASS_ADVANCEMENT = "advancement_task"
@@ -153,6 +154,13 @@ def normalize_todo_claimed_by(value: Any) -> str | None:
 
 def normalize_todo_blocks_agent(value: Any) -> str | None:
     return normalize_todo_claimed_by(value)
+
+
+def normalize_todo_resume_when(value: Any) -> str | None:
+    candidate = compact_todo_text(value).lower()
+    if candidate and TODO_RESUME_WHEN_PATTERN.match(candidate):
+        return candidate
+    return None
 
 
 def normalize_todo_id(value: Any) -> str | None:
@@ -318,6 +326,10 @@ def parse_todo_metadata_line(line: str) -> dict[str, Any] | None:
             todo_id = normalize_todo_id(value)
             if todo_id:
                 metadata["unblocks_todo_id"] = todo_id
+        elif key == "resume_when":
+            resume_when = normalize_todo_resume_when(value)
+            if resume_when:
+                metadata["resume_when"] = resume_when
         elif key in {"note", "evidence", "reason", "completed_at", "updated_at"}:
             if value:
                 metadata[key] = value
@@ -340,6 +352,7 @@ def format_todo_metadata_line(
     claimed_by: str | None = None,
     blocks_agent: str | None = None,
     unblocks_todo_id: str | None = None,
+    resume_when: str | None = None,
     note: str | None = None,
     evidence: str | None = None,
     reason: str | None = None,
@@ -407,6 +420,11 @@ def format_todo_metadata_line(
         raise ValueError("unblocks_todo_id must use the public token shape todo_<letters-digits-underscore-hyphen>")
     if normalized_unblocks_todo_id:
         fields.append(f"unblocks_todo_id={encode_metadata_value(normalized_unblocks_todo_id)}")
+    normalized_resume_when = normalize_todo_resume_when(resume_when)
+    if resume_when and not normalized_resume_when:
+        raise ValueError("resume_when must be a public-safe token such as todo_done:todo_ab12cd34ef56")
+    if normalized_resume_when:
+        fields.append(f"resume_when={encode_metadata_value(normalized_resume_when)}")
     for key, value in (
         ("note", note),
         ("evidence", evidence),

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -25,6 +25,7 @@ from .todo_contract import (
     normalize_todo_blocks_agent,
     normalize_todo_claimed_by,
     normalize_todo_id,
+    normalize_todo_resume_when,
     normalize_todo_status,
     parse_todo_metadata_line,
     todo_done_for_status,
@@ -49,6 +50,7 @@ TODO_METADATA_FIELDS = (
     "claimed_by",
     "blocks_agent",
     "unblocks_todo_id",
+    "resume_when",
     "note",
     "evidence",
     "reason",
@@ -454,6 +456,7 @@ def add_todo_to_lines(
     claimed_by: str | None = None,
     blocks_agent: str | None = None,
     unblocks_todo_id: str | None = None,
+    resume_when: str | None = None,
 ) -> dict[str, Any]:
     todo_text = normalize_new_todo(text)
     bounds = section_bounds(lines, role)
@@ -492,6 +495,7 @@ def add_todo_to_lines(
             claimed_by=claimed_by,
             blocks_agent=blocks_agent,
             unblocks_todo_id=unblocks_todo_id,
+            resume_when=resume_when,
         )
         todo_line = "\n".join([f"- [ ] {todo_text}", metadata_line] if metadata_line else [f"- [ ] {todo_text}"])
         if bounds:
@@ -520,6 +524,8 @@ def add_todo_to_lines(
             updates["blocks_agent"] = blocks_agent
         if unblocks_todo_id:
             updates["unblocks_todo_id"] = unblocks_todo_id
+        if resume_when:
+            updates["resume_when"] = resume_when
         metadata_line = metadata_line_for_block(block, updates)
         metadata_updated = upsert_todo_metadata(lines, block, metadata_line)
         todo_id = str(block.get("todo_id") or "")
@@ -547,6 +553,7 @@ def add_todo_to_lines(
         "claimed_by": normalize_todo_claimed_by(effective_metadata.get("claimed_by")),
         "blocks_agent": normalize_todo_blocks_agent(effective_metadata.get("blocks_agent")),
         "unblocks_todo_id": normalize_todo_id(effective_metadata.get("unblocks_todo_id")),
+        "resume_when": normalize_todo_resume_when(effective_metadata.get("resume_when")),
     }
 
 
@@ -564,6 +571,7 @@ def add_goal_todo(
     claimed_by: str | None = None,
     blocks_agent: str | None = None,
     unblocks_todo_id: str | None = None,
+    resume_when: str | None = None,
     project: Path | None = None,
     state_file: Path | None = None,
     dry_run: bool = False,
@@ -604,6 +612,9 @@ def add_goal_todo(
         normalized_unblocks_todo_id = normalize_todo_id(unblocks_todo_id) if unblocks_todo_id else None
         if unblocks_todo_id and not normalized_unblocks_todo_id:
             raise ValueError("unblocks_todo_id must use the public token shape todo_<letters-digits-underscore-hyphen>")
+        normalized_resume_when = normalize_todo_resume_when(resume_when) if resume_when else None
+        if resume_when and not normalized_resume_when:
+            raise ValueError("resume_when must be a public-safe token such as todo_done:todo_ab12cd34ef56")
         add_result = add_todo_to_lines(
             lines,
             role=role,
@@ -616,6 +627,7 @@ def add_goal_todo(
             claimed_by=effective_claimed_by,
             blocks_agent=effective_blocks_agent,
             unblocks_todo_id=normalized_unblocks_todo_id,
+            resume_when=normalized_resume_when,
         )
         added = bool(add_result["added"])
         metadata_updated = bool(add_result["metadata_updated"])
@@ -645,6 +657,7 @@ def add_goal_todo(
         "claimed_by": add_result.get("claimed_by"),
         "blocks_agent": add_result.get("blocks_agent"),
         "unblocks_todo_id": add_result.get("unblocks_todo_id"),
+        "resume_when": add_result.get("resume_when"),
         "state_file": str(resolved_state_file),
         "project": str(resolved_project) if resolved_project else None,
         "updated_at": updated_at if added or metadata_updated else None,
@@ -686,6 +699,7 @@ def apply_todo_update_to_lines(
     claimed_by: str | None = None,
     blocks_agent: str | None = None,
     unblocks_todo_id: str | None = None,
+    resume_when: str | None = None,
     clear_claim: bool = False,
     claim_only: bool = False,
     updated_at: str,
@@ -748,6 +762,8 @@ def apply_todo_update_to_lines(
         updates["blocks_agent"] = blocks_agent
     if unblocks_todo_id:
         updates["unblocks_todo_id"] = unblocks_todo_id
+    if resume_when:
+        updates["resume_when"] = resume_when
     metadata_line = metadata_line_for_block(block, updates)
     semantic_metadata_changed = todo_metadata_would_change(lines, block, metadata_line)
     if status_changed or text_changed or semantic_metadata_changed:
@@ -776,6 +792,7 @@ def apply_todo_update_to_lines(
         ),
         "blocks_agent": normalize_todo_blocks_agent(effective_metadata.get("blocks_agent")),
         "unblocks_todo_id": normalize_todo_id(effective_metadata.get("unblocks_todo_id")),
+        "resume_when": normalize_todo_resume_when(effective_metadata.get("resume_when")),
     }
 
 
@@ -798,6 +815,7 @@ def update_goal_todo(
     claimed_by: str | None = None,
     blocks_agent: str | None = None,
     unblocks_todo_id: str | None = None,
+    resume_when: str | None = None,
     clear_claim: bool = False,
     claim_only: bool = False,
     project: Path | None = None,
@@ -836,6 +854,9 @@ def update_goal_todo(
         normalized_unblocks_todo_id = normalize_todo_id(unblocks_todo_id) if unblocks_todo_id else None
         if unblocks_todo_id and not normalized_unblocks_todo_id:
             raise ValueError("unblocks_todo_id must use the public token shape todo_<letters-digits-underscore-hyphen>")
+        normalized_resume_when = normalize_todo_resume_when(resume_when) if resume_when else None
+        if resume_when and not normalized_resume_when:
+            raise ValueError("resume_when must be a public-safe token such as todo_done:todo_ab12cd34ef56")
         update_result = apply_todo_update_to_lines(
             lines,
             todo_id=todo_id,
@@ -853,6 +874,7 @@ def update_goal_todo(
             claimed_by=effective_claimed_by,
             blocks_agent=effective_blocks_agent,
             unblocks_todo_id=normalized_unblocks_todo_id,
+            resume_when=normalized_resume_when,
             clear_claim=clear_claim,
             claim_only=claim_only,
             updated_at=updated_at,
@@ -1265,6 +1287,7 @@ def render_todo_markdown(payload: dict[str, Any]) -> str:
                 f"- required_capabilities: `{payload.get('required_capabilities')}`",
                 f"- target_capabilities: `{payload.get('target_capabilities')}`",
                 f"- claimed_by: `{payload.get('claimed_by')}`",
+                f"- resume_when: `{payload.get('resume_when')}`",
             ]
         )
     if payload.get("error"):


### PR DESCRIPTION
## Summary
- add todo metadata support for machine-readable resume_when conditions
- project deferred todo visibility after sorted open lanes, including ready resume candidates
- make agent-scoped quota return successor_replan_required for current-agent/unclaimed ready deferred successors
- document deferred visibility/resume semantics, folded into IP-026 in the interaction pattern catalog, and cover status/quota behavior with smokes

## Validation
- python3 -m py_compile loopx/todo_contract.py loopx/todos.py loopx/cli_commands/todo.py loopx/status.py loopx/quota.py examples/todo-durability-fixture-smoke.py examples/work-lane-contract-smoke.py
- python3 examples/todo-durability-fixture-smoke.py
- python3 examples/work-lane-contract-smoke.py
- python3 examples/status-markdown-smoke.py
- python3 examples/quota-plan-smoke.py
- git diff --check origin/main...HEAD
- loopx check --scan-path loopx --scan-path examples --scan-path docs (passes with existing duplicate index warning for loopx-meta)
- loopx check --scan-path docs/interaction-pattern-catalog.md (passes with same existing duplicate index warning)