### PR TITLE
Add canonical SkillsBench LoopX lifecycle closeout

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -59,12 +59,16 @@ from scripts.skillsbench_automation_loop import (  # noqa: E402
     _tail,
     _blind_loop_persistent_continuation_clause,
     _build_product_mode_user,
+    _product_mode_depth_gate_satisfied,
     _merge_app_server_goal_worker_trace_summary,
     _merge_acp_trajectory_summary,
     _merge_final_result_round_reward,
     _round_result_declared_done,
     build_compose_setup_diagnostic,
     build_plan,
+    cleanup_benchflow_setup_stall_children,
+    install_benchflow_user_loop_final_verify_recovery,
+    install_benchflow_verifier_prep_timeout_override,
     build_runner_failure_compact,
     main as skillsbench_automation_loop_main,
     materialize_local_codex_participant,
@@ -86,9 +90,9 @@ def assert_prerequisites_include(actual: dict[str, Any], expected: dict[str, Any
         assert actual.get(key) == value, (key, actual)
 
 
-def test_skillsbench_default_blind_loop_budget_is_five() -> None:
+def test_skillsbench_default_blind_loop_budget_is_eight() -> None:
     args = parse_args([])
-    assert args.max_rounds == DEFAULT_MAX_ROUNDS == 5, args
+    assert args.max_rounds == DEFAULT_MAX_ROUNDS == 8, args
     assert "blind-loop" in args.route, args
     assert args.route != "codex-goal-mode-baseline", args
 
@@ -668,14 +672,148 @@ def test_product_mode_declared_done_requires_case_state_depth() -> None:
             )
         )
         assert prompt is not None, trace
-        assert "not evidence that the official verifier passed or failed" in prompt
+        assert "Mandatory LoopX lifecycle checkpoint" in prompt
+        assert "quota should-run --goal-id skillsbench-case" in prompt
+        assert "todo claim --goal-id skillsbench-case" in prompt
+        assert "todo update --goal-id skillsbench-case" in prompt
+        assert "refresh-state --goal-id skillsbench-case" in prompt
+        assert "You declared done" in prompt
         assert PRODUCT_MODE_CASE_STATE_PATH in prompt
         assert trace["product_mode_depth_gate_gap"] is True, trace
         assert trace["product_mode_depth_gate_gap_round"] == 1, trace
-        assert trace["last_decision"] == "send_product_mode_depth_gate_continuation"
+        assert (
+            trace["last_decision"]
+            == "send_product_mode_lifecycle_checkpoint_continuation"
+        )
+        assert trace["product_mode_lifecycle_checkpoint_required"] is True, trace
+        assert trace["product_mode_lifecycle_checkpoint_round"] == 1, trace
+        assert trace["product_mode_lifecycle_checkpoint_count"] == 1, trace
+        assert trace["product_mode_lifecycle_checkpoint_missing_reason"] == (
+            "missing_case_local_loopx_state_read_or_write"
+        )
         assert trace["followup_prompt_count"] == 1, trace
         assert trace["stop_decision_count"] == 0, trace
         assert trace.get("agent_declared_done") is not True, trace
+
+
+def test_product_mode_missing_lifecycle_prompts_exact_checkpoint() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-lifecycle-checkpoint-") as tmp:
+        root = Path(tmp)
+        jobs_dir = root / "jobs"
+        job_name = "skillsbench_lifecycle_checkpoint_fixture"
+        rollout_name = "case__loopx_product_mode"
+        trajectory_path = (
+            jobs_dir / job_name / rollout_name / "agent" / "acp_trajectory.jsonl"
+        )
+        trajectory_path.parent.mkdir(parents=True)
+        trajectory_path.write_text(
+            json.dumps(
+                {
+                    "type": "user_message",
+                    "text": "LoopX product-mode treatment round 1.",
+                },
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        trace = {
+            "schema_version": "skillsbench_loopx_controller_trace_v0",
+            "route": "loopx-product-mode",
+            "loopx_state_reads": 0,
+            "loopx_state_writes": 0,
+            "loopx_case_state_reads": 0,
+            "loopx_case_state_writes": 0,
+            "heartbeat_count": 0,
+            "controller_action_decisions": 0,
+            "initial_prompt_count": 0,
+            "followup_prompt_count": 0,
+            "stop_decision_count": 0,
+            "reward_observation_count": 0,
+            "round_rewards": [],
+        }
+        plan = {
+            "jobs_dir": str(jobs_dir),
+            "job_name": job_name,
+            "rollout_name": rollout_name,
+        }
+        saved_modules = {
+            name: sys.modules.get(name)
+            for name in (
+                "benchflow",
+                "benchflow.sandbox",
+                "benchflow.sandbox.user",
+            )
+        }
+        fake_benchflow = types.ModuleType("benchflow")
+        fake_sandbox = types.ModuleType("benchflow.sandbox")
+        fake_user = types.ModuleType("benchflow.sandbox.user")
+
+        class FakeBaseUser:
+            pass
+
+        class FakeRoundResultBase:
+            pass
+
+        fake_user.BaseUser = FakeBaseUser
+        fake_user.RoundResult = FakeRoundResultBase
+        sys.modules["benchflow"] = fake_benchflow
+        sys.modules["benchflow.sandbox"] = fake_sandbox
+        sys.modules["benchflow.sandbox.user"] = fake_user
+        try:
+            user = _build_product_mode_user(
+                route="loopx-product-mode",
+                max_rounds=5,
+                trace=trace,
+                plan=plan,
+            )
+        finally:
+            for name, module in saved_modules.items():
+                if module is None:
+                    sys.modules.pop(name, None)
+                else:
+                    sys.modules[name] = module
+
+        class FakeRoundResult:
+            rewards = {}
+            trajectory = [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Still working.",
+                        }
+                    ],
+                }
+            ]
+
+        prompt = asyncio.run(
+            user.run(
+                1,
+                "Fix the fixture.",
+                round_result=FakeRoundResult(),
+            )
+        )
+        assert prompt is not None, trace
+        assert "Mandatory LoopX lifecycle checkpoint" in prompt
+        assert "quota should-run --goal-id skillsbench-case" in prompt
+        assert "todo claim --goal-id skillsbench-case" in prompt
+        assert "todo update --goal-id skillsbench-case" in prompt
+        assert "refresh-state --goal-id skillsbench-case" in prompt
+        assert "Do not answer with prose only" in prompt
+        assert (
+            trace["last_decision"]
+            == "send_product_mode_lifecycle_checkpoint_continuation"
+        )
+        assert trace["product_mode_lifecycle_checkpoint_required"] is True
+        assert trace["product_mode_lifecycle_checkpoint_round"] == 1
+        assert trace["product_mode_lifecycle_checkpoint_count"] == 1
+        assert trace["product_mode_lifecycle_checkpoint_missing_reason"] == (
+            "missing_case_local_loopx_state_read_or_write"
+        )
+        assert trace["followup_prompt_count"] == 1
+        assert trace["stop_decision_count"] == 0
 
 
 def write_json(path: Path, payload: dict[str, Any]) -> None:
@@ -2483,6 +2621,24 @@ def test_skillsbench_runner_prerequisites_are_compacted() -> None:
             "benchflow_agent_runtime_mount_read_only": True,
             "benchflow_agent_runtime_mount_source_recorded": False,
             "codex_acp_runtime_dependency_setup_skipped": True,
+            "benchflow_intermediate_soft_verify_policy": "final-only",
+            "benchflow_intermediate_soft_verify_final_only": True,
+            "benchflow_intermediate_soft_verify_call_count": 0,
+            "benchflow_intermediate_soft_verify_skipped_count": 3,
+            "benchflow_intermediate_soft_verify_raw_output_recorded": False,
+            "benchflow_verifier_prep_timeout_override_enabled": True,
+            "benchflow_verifier_prep_timeout_sec": 120,
+            "benchflow_verifier_prep_timeout_override_count": 2,
+            "benchflow_verify_prep_timeout_override_count": 1,
+            "benchflow_soft_verify_prep_timeout_override_count": 1,
+            "benchflow_verifier_prep_timeout_raw_command_recorded": False,
+            "benchflow_setup_stall_cleanup_requested": True,
+            "benchflow_setup_stall_cleanup_raw_logs_read": False,
+            "benchflow_setup_stall_cleanup_status": "terminated",
+            "benchflow_setup_stall_cleanup_match_count": 2,
+            "benchflow_setup_stall_cleanup_term_sent_count": 2,
+            "benchflow_setup_stall_cleanup_kill_sent_count": 0,
+            "benchflow_setup_stall_cleanup_alive_after_count": 0,
             "private_unlisted_detail": "must not compact",
         }
         compact = compact_benchmark_run(benchmark_run)
@@ -2510,6 +2666,24 @@ def test_skillsbench_runner_prerequisites_are_compacted() -> None:
                 "benchflow_agent_runtime_mount_read_only": True,
                 "benchflow_agent_runtime_mount_source_recorded": False,
                 "codex_acp_runtime_dependency_setup_skipped": True,
+                "benchflow_intermediate_soft_verify_policy": "final-only",
+                "benchflow_intermediate_soft_verify_final_only": True,
+                "benchflow_intermediate_soft_verify_call_count": 0,
+                "benchflow_intermediate_soft_verify_skipped_count": 3,
+                "benchflow_intermediate_soft_verify_raw_output_recorded": False,
+                "benchflow_verifier_prep_timeout_override_enabled": True,
+                "benchflow_verifier_prep_timeout_sec": 120,
+                "benchflow_verifier_prep_timeout_override_count": 2,
+                "benchflow_verify_prep_timeout_override_count": 1,
+                "benchflow_soft_verify_prep_timeout_override_count": 1,
+                "benchflow_verifier_prep_timeout_raw_command_recorded": False,
+                "benchflow_setup_stall_cleanup_requested": True,
+                "benchflow_setup_stall_cleanup_raw_logs_read": False,
+                "benchflow_setup_stall_cleanup_status": "terminated",
+                "benchflow_setup_stall_cleanup_match_count": 2,
+                "benchflow_setup_stall_cleanup_term_sent_count": 2,
+                "benchflow_setup_stall_cleanup_kill_sent_count": 0,
+                "benchflow_setup_stall_cleanup_alive_after_count": 0,
             },
         )
         assert "private_unlisted_detail" not in json.dumps(compact), compact
@@ -3230,6 +3404,11 @@ def test_skillsbench_product_mode_declared_done_is_compacted() -> None:
             "case_goal_state_path": PRODUCT_MODE_CASE_STATE_PATH,
             "case_goal_state_schema_version": PRODUCT_MODE_CASE_STATE_SCHEMA_VERSION,
             "declared_done_requires_no_remaining_goals": True,
+            "benchflow_intermediate_soft_verify_policy": "final-only",
+            "benchflow_intermediate_soft_verify_final_only": True,
+            "benchflow_intermediate_soft_verify_call_count": 0,
+            "benchflow_intermediate_soft_verify_skipped_count": 1,
+            "benchflow_intermediate_soft_verify_raw_output_recorded": False,
             "max_rounds_budget": 5,
             "loopx_state_reads": 1,
             "loopx_state_writes": 1,
@@ -3265,6 +3444,14 @@ def test_skillsbench_product_mode_declared_done_is_compacted() -> None:
         assert counters["declared_done_requires_no_remaining_goals"] is True, compact
         assert counters["agent_declared_done"] is True, compact
         assert counters["declared_done_round"] == 1, compact
+        assert counters["benchflow_intermediate_soft_verify_policy"] == "final-only"
+        assert counters["benchflow_intermediate_soft_verify_final_only"] is True
+        assert counters["benchflow_intermediate_soft_verify_call_count"] == 0
+        assert counters["benchflow_intermediate_soft_verify_skipped_count"] == 1
+        assert (
+            counters["benchflow_intermediate_soft_verify_raw_output_recorded"]
+            is False
+        )
         assert counters["loopx_case_state_reads"] == 1, compact
         assert counters["loopx_case_state_writes"] == 1, compact
         round_trace = compact["round_reward_trace"]
@@ -3291,6 +3478,58 @@ def test_skillsbench_product_mode_declared_done_is_compacted() -> None:
         assert run["final_round_reward"] == 0.25, update
         assert run["best_reward_round"] == 1, update
         assert run["best_round_reward"] == 0.25, update
+
+
+def test_skillsbench_product_mode_lifecycle_checkpoint_is_compacted() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-lifecycle-compact-") as tmp:
+        root = Path(tmp)
+        result_path = write_official_skillsbench_result(root, reward=0.0)
+        controller_trace = {
+            "schema_version": "skillsbench_loopx_controller_trace_v0",
+            "route": "loopx-product-mode",
+            "trace_publicness": "public_counts_only_no_task_text_no_verifier_output",
+            "product_mode": True,
+            "heartbeat_count": 2,
+            "controller_action_decisions": 2,
+            "initial_prompt_count": 1,
+            "followup_prompt_count": 1,
+            "stop_decision_count": 0,
+            "product_mode_lifecycle_checkpoint_required": True,
+            "product_mode_lifecycle_checkpoint_count": 1,
+            "product_mode_lifecycle_checkpoint_round": 1,
+            "product_mode_lifecycle_checkpoint_missing_reason": (
+                "missing_case_local_loopx_state_read_or_write"
+            ),
+            "loopx_state_reads": 0,
+            "loopx_state_writes": 0,
+            "loopx_case_state_reads": 0,
+            "loopx_case_state_writes": 0,
+            "last_decision": "send_product_mode_lifecycle_checkpoint_continuation",
+            "raw_task_text_recorded": False,
+            "raw_verifier_output_recorded": False,
+            "raw_agent_trajectory_recorded": False,
+        }
+        compact = compact_benchmark_run(
+            build_skillsbench_benchflow_result_benchmark_run(
+                result_path,
+                route="loopx-product-mode",
+                controller_trace=controller_trace,
+            )
+        )
+        assert compact is not None
+        counters = compact["interaction_counters"]
+        assert counters["product_mode"] is True, compact
+        assert counters["product_mode_lifecycle_checkpoint_required"] is True
+        assert counters["product_mode_lifecycle_checkpoint_count"] == 1
+        assert counters["product_mode_lifecycle_checkpoint_round"] == 1
+        assert counters["product_mode_lifecycle_checkpoint_missing_reason"] == (
+            "missing_case_local_loopx_state_read_or_write"
+        )
+        compact_again = compact_benchmark_run(compact)
+        assert compact_again is not None
+        compact_counters = compact_again["interaction_counters"]
+        assert compact_counters["product_mode_lifecycle_checkpoint_required"] is True
+        assert compact_counters["product_mode_lifecycle_checkpoint_count"] == 1
 
 
 def test_skillsbench_product_mode_case_state_usage_is_compacted() -> None:
@@ -3362,6 +3601,16 @@ def test_skillsbench_product_mode_case_state_usage_is_compacted() -> None:
         assert trace["loopx_case_state_writes"] == 1, trace
         assert trace["loopx_state_reads"] == 1, trace
         assert trace["loopx_state_writes"] == 1, trace
+        assert _product_mode_depth_gate_satisfied(trace) is True, trace
+        cli_only_trace = {
+            "schema_version": "skillsbench_loopx_controller_trace_v0",
+            "route": "loopx-product-mode",
+            "loopx_state_reads": 3,
+            "loopx_state_writes": 2,
+            "loopx_case_state_reads": 0,
+            "loopx_case_state_writes": 0,
+        }
+        assert _product_mode_depth_gate_satisfied(cli_only_trace) is True, cli_only_trace
 
 
 def test_skillsbench_product_mode_legacy_case_state_path_is_not_compacted() -> None:
@@ -3423,6 +3672,26 @@ def test_skillsbench_acp_trajectory_summary_is_compacted() -> None:
             {
                 "type": "tool_call",
                 "title": (
+                    "/app/.local/bin/loopx --registry /app/.loopx/registry.json "
+                    "--runtime-root /app/.loopx/runtime --format json todo update "
+                    "--goal-id demo --todo-id todo_demo --status open"
+                ),
+                "status": "failed",
+                "content": [],
+            },
+            {
+                "type": "tool_call",
+                "title": (
+                    "/app/.local/bin/loopx --registry /app/.loopx/registry.json "
+                    "--runtime-root /app/.loopx/runtime --format json quota spend-slot "
+                    "--goal-id demo --agent-id codex-benchmark-agent --execute"
+                ),
+                "status": "completed",
+                "content": [],
+            },
+            {
+                "type": "tool_call",
+                "title": (
                     "perl -0pi -e 's/config=config,/args=config,/' "
                     "/app/train_grpo.py"
                 ),
@@ -3447,10 +3716,10 @@ def test_skillsbench_acp_trajectory_summary_is_compacted() -> None:
         (run_dir / "agent" / "codex_acp.txt").write_text("", encoding="utf-8")
 
         summary = summarize_acp_trajectory(trajectory_path)
-        assert summary["event_count"] == 5, summary
+        assert summary["event_count"] == 7, summary
         assert summary["round_count"] == 1, summary
-        assert summary["tool_call_count"] == 3, summary
-        assert summary["loopx_cli_call_count"] == 1, summary
+        assert summary["tool_call_count"] == 5, summary
+        assert summary["loopx_cli_call_count"] == 3, summary
         assert summary["loopx_cli_calls"] == [
             {
                 "round": 1,
@@ -3460,18 +3729,37 @@ def test_skillsbench_acp_trajectory_summary_is_compacted() -> None:
                 "state_usage": "state_read",
                 "raw_title_copied": False,
                 "raw_output_copied": False,
-            }
+            },
+            {
+                "round": 1,
+                "command": "loopx todo update",
+                "subcommands": ["todo", "update"],
+                "flags": ["--format", "--registry", "--runtime-root"],
+                "state_usage": "state_write",
+                "raw_title_copied": False,
+                "raw_output_copied": False,
+            },
+            {
+                "round": 1,
+                "command": "loopx quota spend-slot",
+                "subcommands": ["quota", "spend-slot"],
+                "flags": ["--format", "--registry", "--runtime-root"],
+                "state_usage": "state_write",
+                "raw_title_copied": False,
+                "raw_output_copied": False,
+            },
         ], summary
         assert summary["action_category_counts"] == {
             "edit": 1,
-            "loopx_cli": 1,
+            "loopx_cli": 3,
             "validation": 1,
         }, summary
         assert summary["loopx_cli_state_usage_counts"] == {
             "state_read": 1,
+            "state_write": 2,
         }, summary
         assert summary["loopx_cli_state_read_count"] == 1, summary
-        assert summary["loopx_cli_state_write_count"] == 0, summary
+        assert summary["loopx_cli_state_write_count"] == 2, summary
         assert summary["protected_path_mentions"] == [
             "/app/reward_fn.py",
             "/app/train_grpo.py",
@@ -3515,27 +3803,42 @@ def test_skillsbench_acp_trajectory_summary_is_compacted() -> None:
         compact = reduce_result(args, result_path, plan)
         counters = compact["interaction_counters"]
         assert counters["private_trajectory_summary_present"] is True, compact
-        assert counters["private_trajectory_event_count"] == 5, compact
-        assert counters["private_trajectory_tool_call_count"] == 3, compact
-        assert counters["loopx_cli_call_count"] == 1, compact
+        assert counters["private_trajectory_event_count"] == 7, compact
+        assert counters["private_trajectory_tool_call_count"] == 5, compact
+        assert counters["loopx_cli_call_count"] == 3, compact
         assert counters["loopx_cli_calls"] == [
             {
                 "round": 1,
                 "command": "loopx status",
                 "raw_title_copied": False,
                 "raw_output_copied": False,
-            }
+            },
+            {
+                "round": 1,
+                "command": "loopx todo update",
+                "flags": ["--format", "--registry", "--runtime-root"],
+                "raw_title_copied": False,
+                "raw_output_copied": False,
+            },
+            {
+                "round": 1,
+                "command": "loopx quota spend-slot",
+                "flags": ["--format", "--registry", "--runtime-root"],
+                "raw_title_copied": False,
+                "raw_output_copied": False,
+            },
         ], compact
         assert counters["trajectory_action_category_counts"] == {
             "edit": 1,
-            "loopx_cli": 1,
+            "loopx_cli": 3,
             "validation": 1,
         }, compact
         assert counters["loopx_cli_state_usage_counts"] == {
             "state_read": 1,
+            "state_write": 2,
         }, compact
         assert counters["loopx_cli_state_read_count"] == 1, compact
-        assert counters["loopx_cli_state_write_count"] == 0, compact
+        assert counters["loopx_cli_state_write_count"] == 2, compact
         assert counters["protected_path_mention_count"] == 2, compact
         assert counters["protected_path_edit_signal_count"] == 1, compact
         assert "loopx:acp_trajectory_summary" in compact["evidence_files"], compact
@@ -3963,6 +4266,242 @@ def test_skillsbench_runner_failure_marks_pre_agent_install_stage() -> None:
         ), compact
 
 
+def test_skillsbench_runner_failure_marks_build_stall_timeout() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-build-stall-") as tmp:
+        args = parse_args(
+            [
+                "--task-id",
+                "organize-messy-files",
+                "--route",
+                "loopx-product-mode",
+                "--jobs-dir",
+                str(Path(tmp) / "jobs"),
+                "--job-name",
+                "skillsbench-organize-messy-files-build-stall-fixture",
+                "--build-stall-timeout-sec",
+                "60",
+            ]
+        )
+        plan = build_plan(args)
+
+        compact = build_runner_failure_compact(
+            args,
+            plan,
+            asyncio.TimeoutError(
+                "skillsbench docker compose build/setup stall timeout before agent lifecycle"
+            ),
+        )
+
+        assert compact["first_blocker"] == (
+            "skillsbench_docker_compose_build_stall_timeout"
+        ), compact
+        assert compact["score_failure_attribution"] == (
+            "skillsbench_docker_compose_build_stall_timeout"
+        ), compact
+        assert "skillsbench_environment_setup_error" in compact[
+            "failure_attribution_labels"
+        ], compact
+        assert_prerequisites_include(
+            compact["runner_prerequisites"],
+            {
+                "benchflow_run_stage": "build_or_setup_stall_before_agent",
+                "benchflow_setup_stall_timeout_enabled": True,
+                "benchflow_setup_stall_timeout_sec": 60,
+                "benchflow_setup_stall_timeout_triggered": True,
+                "benchflow_setup_stall_before_agent_lifecycle": True,
+                "benchflow_setup_stall_raw_logs_read": False,
+            },
+        )
+        assert compact["compose_setup_diagnostic"]["status"] == (
+            "compose_setup_blocked_before_agent_rounds"
+        ), compact
+        assert compact["compose_setup_diagnostic"][
+            "case_attempt_budget_should_count"
+        ] is False, compact
+        compact_text = json.dumps(compact, sort_keys=True)
+        assert "skillsbench docker compose build/setup stall timeout" not in compact_text
+        assert "/private/" not in compact_text
+
+
+def test_skillsbench_runner_failure_backfills_generic_timeout_stall_cleanup() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-generic-timeout-") as tmp:
+        args = parse_args(
+            [
+                "--task-id",
+                "citation-check",
+                "--route",
+                "loopx-product-mode",
+                "--jobs-dir",
+                str(Path(tmp) / "jobs"),
+                "--job-name",
+                "skillsbench-citation-check-generic-timeout-fixture",
+                "--build-stall-timeout-sec",
+                "180",
+            ]
+        )
+        plan = build_plan(args)
+        plan.setdefault("runner_prerequisites", {})[
+            "codex_acp_runtime_launch_preflight_status"
+        ] = "pending"
+        cleanup_calls: list[str] = []
+        original_cleanup = skillsbench_loop.cleanup_benchflow_setup_stall_children
+
+        def fake_cleanup(plan_arg: dict[str, Any], **_kwargs: Any) -> dict[str, Any]:
+            cleanup_calls.append(str(plan_arg.get("job_name") or ""))
+            prereqs = plan_arg.setdefault("runner_prerequisites", {})
+            prereqs.update(
+                {
+                    "benchflow_setup_stall_cleanup_requested": True,
+                    "benchflow_setup_stall_cleanup_raw_logs_read": False,
+                    "benchflow_setup_stall_cleanup_status": "no_matching_processes",
+                    "benchflow_setup_stall_cleanup_match_count": 0,
+                    "benchflow_setup_stall_cleanup_term_sent_count": 0,
+                    "benchflow_setup_stall_cleanup_kill_sent_count": 0,
+                    "benchflow_setup_stall_cleanup_alive_after_count": 0,
+                }
+            )
+            return {
+                "schema_version": "skillsbench_setup_stall_process_cleanup_v0",
+                "requested": True,
+                "raw_logs_read": False,
+                "status": "no_matching_processes",
+                "match_count": 0,
+                "term_sent_count": 0,
+                "kill_sent_count": 0,
+                "alive_after_count": 0,
+            }
+
+        try:
+            skillsbench_loop.cleanup_benchflow_setup_stall_children = fake_cleanup
+            compact = build_runner_failure_compact(
+                args,
+                plan,
+                asyncio.TimeoutError(),
+            )
+        finally:
+            skillsbench_loop.cleanup_benchflow_setup_stall_children = (
+                original_cleanup
+            )
+
+        assert cleanup_calls == [plan["job_name"]], cleanup_calls
+        assert compact["first_blocker"] == (
+            "skillsbench_docker_compose_build_stall_timeout"
+        ), compact
+        assert compact["score_failure_attribution"] == (
+            "skillsbench_docker_compose_build_stall_timeout"
+        ), compact
+        assert_prerequisites_include(
+            compact["runner_prerequisites"],
+            {
+                "benchflow_run_stage": "build_or_setup_stall_before_agent",
+                "benchflow_setup_stall_timeout_enabled": True,
+                "benchflow_setup_stall_timeout_sec": 180,
+                "benchflow_setup_stall_timeout_triggered": True,
+                "benchflow_setup_stall_before_agent_lifecycle": True,
+                "benchflow_setup_stall_raw_logs_read": False,
+                "benchflow_setup_stall_cleanup_requested": True,
+                "benchflow_setup_stall_cleanup_raw_logs_read": False,
+                "benchflow_setup_stall_cleanup_status": "no_matching_processes",
+                "benchflow_setup_stall_cleanup_match_count": 0,
+                "benchflow_setup_stall_cleanup_term_sent_count": 0,
+                "benchflow_setup_stall_cleanup_kill_sent_count": 0,
+                "benchflow_setup_stall_cleanup_alive_after_count": 0,
+            },
+        )
+        assert compact["compose_setup_diagnostic"]["status"] == (
+            "compose_setup_blocked_before_agent_rounds"
+        ), compact
+        compact_text = json.dumps(compact, sort_keys=True)
+        assert "/private/" not in compact_text
+
+
+def test_skillsbench_setup_stall_cleanup_targets_current_job_only() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-cleanup-") as tmp:
+        args = parse_args(
+            [
+                "--task-id",
+                "organize-messy-files",
+                "--route",
+                "loopx-product-mode",
+                "--jobs-dir",
+                str(Path(tmp) / "jobs"),
+                "--job-name",
+                "skillsbench-organize-messy-files-cleanup-fixture",
+            ]
+        )
+        plan = build_plan(args)
+        job_name = plan["job_name"]
+        rollout_name = plan["rollout_name"]
+        ps_stdout = "\n".join(
+            [
+                (
+                    f"101 1 docker compose --project-name {rollout_name} "
+                    f"--project-directory /tmp/{job_name}/prepared build"
+                ),
+                (
+                    f"102 101 /usr/libexec/docker/cli-plugins/docker-buildx "
+                    f"bake --allow fs.read=/tmp/{job_name}/prepared"
+                ),
+                (
+                    "103 1 docker compose --project-name unrelated "
+                    "--project-directory /tmp/other-job build"
+                ),
+            ]
+        )
+        alive = {101, 102, 103}
+        sent: list[tuple[int, int]] = []
+        original_run = skillsbench_loop.subprocess.run
+        original_kill = skillsbench_loop.os.kill
+        original_sleep = skillsbench_loop.time.sleep
+
+        def fake_run(*_args: Any, **_kwargs: Any) -> Any:
+            return types.SimpleNamespace(returncode=0, stdout=ps_stdout, stderr="")
+
+        def fake_kill(pid: int, sig: int) -> None:
+            if sig == 0:
+                if pid in alive:
+                    return
+                raise ProcessLookupError(pid)
+            sent.append((pid, sig))
+            if sig == skillsbench_loop.signal.SIGTERM:
+                alive.discard(pid)
+
+        try:
+            skillsbench_loop.subprocess.run = fake_run
+            skillsbench_loop.os.kill = fake_kill
+            skillsbench_loop.time.sleep = lambda _seconds: None
+            cleanup = cleanup_benchflow_setup_stall_children(
+                plan,
+                grace_seconds=0,
+            )
+        finally:
+            skillsbench_loop.subprocess.run = original_run
+            skillsbench_loop.os.kill = original_kill
+            skillsbench_loop.time.sleep = original_sleep
+
+        assert cleanup["status"] == "terminated", cleanup
+        assert cleanup["match_count"] == 2, cleanup
+        assert set(sent) == {
+            (101, skillsbench_loop.signal.SIGTERM),
+            (102, skillsbench_loop.signal.SIGTERM),
+        }, sent
+        assert 103 in alive, alive
+        prereqs = plan["runner_prerequisites"]
+        assert_prerequisites_include(
+            prereqs,
+            {
+                "benchflow_setup_stall_cleanup_requested": True,
+                "benchflow_setup_stall_cleanup_raw_logs_read": False,
+                "benchflow_setup_stall_cleanup_status": "terminated",
+                "benchflow_setup_stall_cleanup_match_count": 2,
+                "benchflow_setup_stall_cleanup_term_sent_count": 2,
+                "benchflow_setup_stall_cleanup_kill_sent_count": 0,
+                "benchflow_setup_stall_cleanup_alive_after_count": 0,
+            },
+        )
+        assert job_name not in json.dumps(cleanup, sort_keys=True)
+
+
 def test_skillsbench_reduce_only_missing_result_records_closeout_exit_zero() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-missing-result-main-") as tmp:
         jobs_dir = Path(tmp) / "jobs"
@@ -4327,6 +4866,538 @@ def test_skillsbench_main_recovers_missing_reward_with_structured_prereq_blocker
         assert "PRIVATE_EXCEPTION_DETAIL_SHOULD_NOT_ESCAPE" not in json.dumps(
             compact
         ), compact
+
+
+def test_skillsbench_result_timeout_after_loopx_lifecycle_is_attributed() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-result-timeout-") as tmp:
+        root = Path(tmp)
+        jobs_dir = root / "jobs"
+        args = parse_args(
+            [
+                "--task-id",
+                "powerlifting-coef-calc",
+                "--route",
+                "loopx-product-mode",
+                "--jobs-dir",
+                str(jobs_dir),
+                "--job-name",
+                "skillsbench-result-timeout-fixture",
+                "--rollout-name",
+                "powerlifting-coef-calc__loopx_product_mode",
+            ]
+        )
+        plan = build_plan(args)
+        write_json(
+            Path(plan["controller_trace_json"]),
+            {
+                "schema_version": "skillsbench_loopx_controller_trace_v0",
+                "route": "loopx-product-mode",
+                "trace_publicness": "public_counts_only_no_task_text_no_verifier_output",
+                "product_mode": True,
+                "heartbeat_count": 1,
+                "controller_action_decisions": 1,
+                "initial_prompt_count": 1,
+                "max_rounds_budget": 8,
+                "max_round_observed": 0,
+                "loopx_canonical_product_mode_lifecycle_driver": True,
+                "case_goal_state_init_status": "passed",
+                "case_goal_state_initialized_before_agent": True,
+                "raw_task_text_recorded": False,
+                "raw_verifier_output_recorded": False,
+                "raw_agent_trajectory_recorded": False,
+                "acp_trajectory_summary": {
+                    "schema_version": "skillsbench_acp_trajectory_summary_v0",
+                    "private_trajectory_present": True,
+                    "raw_text_copied_to_public": False,
+                    "event_count": 42,
+                    "round_count": 1,
+                    "user_message_count": 1,
+                    "agent_message_count": 16,
+                    "tool_call_count": 25,
+                    "loopx_cli_call_count": 9,
+                    "loopx_cli_state_read_count": 6,
+                    "loopx_cli_state_write_count": 4,
+                },
+            },
+        )
+        result_path = Path(plan["result_json"])
+        write_json(
+            result_path,
+            {
+                "task_name": "powerlifting-coef-calc",
+                "rollout_name": "powerlifting-coef-calc__loopx_product_mode",
+                "rewards": None,
+                "agent": "codex-acp",
+                "agent_name": "",
+                "model": "gpt-5.5",
+                "n_tool_calls": 25,
+                "n_prompts": 1,
+                "error": "Command timed out after 10 seconds",
+                "verifier_error": None,
+                "partial_trajectory": True,
+            },
+        )
+        write_json(result_path.with_name("timing.json"), {"agent_execution": 240.0})
+
+        compact = reduce_result(args, result_path, plan)
+        assert compact["official_score_status"] == "missing", compact
+        assert compact["score_failure_attribution"] == (
+            "skillsbench_result_timeout_after_agent_round_no_reward_artifact"
+        ), compact
+        assert compact["runner_failure"]["failure_class"] == (
+            "skillsbench_result_timeout_after_agent_round_no_reward_artifact"
+        ), compact
+        assert "skillsbench_result_error_after_agent_round" in compact[
+            "failure_attribution_labels"
+        ], compact
+        assert "skillsbench_reward_artifact_missing" in compact[
+            "failure_attribution_labels"
+        ], compact
+        assert "skillsbench_controller_budget_not_exercised" in compact[
+            "failure_attribution_labels"
+        ], compact
+        assert "skillsbench_result_error_cut_off_followup_loop" in compact[
+            "failure_attribution_labels"
+        ], compact
+        assert "timeout" in compact["runner_failure_fingerprint"][
+            "matched_patterns"
+        ], compact
+        assert "subprocess_command_timeout" in compact["runner_failure_fingerprint"][
+            "matched_patterns"
+        ], compact
+        assert compact["runner_failure"]["controller_cutoff"] == {
+            "schema_version": "skillsbench_controller_cutoff_v0",
+            "cutoff_before_followup": True,
+            "reason": "result_error_after_agent_round_no_reward_artifact",
+            "max_rounds_budget": 8,
+            "initial_prompt_count": 1,
+            "followup_prompt_count": 0,
+            "stop_decision_count": 0,
+        }, compact
+        assert compact["interaction_counters"]["loopx_cli_call_count"] == 9, compact
+        assert compact["interaction_counters"]["loopx_cli_state_write_count"] == 4, compact
+        assert compact["interaction_counters"][
+            "controller_budget_cutoff_before_followup"
+        ] is True, compact
+        assert compact["interaction_counters"]["controller_budget_cutoff_reason"] == (
+            "result_error_after_agent_round_no_reward_artifact"
+        ), compact
+
+
+def test_skillsbench_user_loop_recovery_preserves_final_verify_path() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-user-loop-recovery-") as tmp:
+        rollout_dir = Path(tmp)
+        plan = {"runner_prerequisites": {}}
+        trace: dict[str, Any] = {
+            "schema_version": "skillsbench_loopx_controller_trace_v0",
+        }
+
+        fake_benchflow = types.ModuleType("benchflow")
+        fake_sandbox = types.ModuleType("benchflow.sandbox")
+        fake_user_module = types.ModuleType("benchflow.sandbox.user")
+
+        class FakeRoundResult:
+            def __init__(self, **kwargs: Any) -> None:
+                self.__dict__.update(kwargs)
+
+        fake_user_module.RoundResult = FakeRoundResult
+        old_modules = {
+            name: sys.modules.get(name)
+            for name in (
+                "benchflow",
+                "benchflow.sandbox",
+                "benchflow.sandbox.user",
+            )
+        }
+        sys.modules["benchflow"] = fake_benchflow
+        sys.modules["benchflow.sandbox"] = fake_sandbox
+        sys.modules["benchflow.sandbox.user"] = fake_user_module
+
+        class FakeUser:
+            async def setup(self, instruction: str, solution: str | None) -> None:
+                assert instruction == "fixture instruction"
+                assert solution is None
+
+            async def run(
+                self,
+                round: int,
+                instruction: str,
+                round_result: Any | None = None,
+            ) -> str | None:
+                assert instruction == "fixture instruction"
+                if round == 0:
+                    return "continue without verifier feedback"
+                return None
+
+        class FakeRole:
+            pass
+
+        class FakeScene:
+            roles = [FakeRole()]
+
+        class FakeConfig:
+            user = FakeUser()
+            effective_scenes = [FakeScene()]
+            oracle_access = False
+            max_user_rounds = 3
+
+        class FakeRollout:
+            async def _run_user_loop(self) -> None:
+                raise AssertionError("original user loop should be patched")
+
+            def __init__(self) -> None:
+                self._config = FakeConfig()
+                self._resolved_prompts = ["fixture instruction"]
+                self._trajectory: list[dict[str, Any]] = []
+                self._rollout_dir = rollout_dir
+                self.connected = False
+                self.disconnected = False
+
+            async def connect_as(self, role: Any) -> None:
+                self.connected = True
+
+            async def execute(self, prompts: list[str] | None = None) -> None:
+                assert prompts == ["continue without verifier feedback"]
+                self._trajectory.extend(
+                    [
+                        {"type": "agent_message"},
+                        {"type": "tool_call"},
+                    ]
+                )
+
+            async def disconnect(self) -> None:
+                self.disconnected = True
+
+            async def soft_verify(self) -> tuple[dict | None, str | None, str | None]:
+                raise TimeoutError("PRIVATE_PATH_SHOULD_NOT_ESCAPE")
+
+        try:
+            original = install_benchflow_user_loop_final_verify_recovery(
+                FakeRollout,
+                plan=plan,
+                trace=trace,
+            )
+            fake_rollout = FakeRollout()
+            asyncio.run(FakeRollout._run_user_loop(fake_rollout))
+            FakeRollout._run_user_loop = original
+        finally:
+            for name, module in old_modules.items():
+                if module is None:
+                    sys.modules.pop(name, None)
+                else:
+                    sys.modules[name] = module
+
+        prerequisites = plan["runner_prerequisites"]
+        assert fake_rollout.connected is True
+        assert fake_rollout.disconnected is True
+        assert prerequisites["benchflow_user_loop_final_verify_recovery_enabled"] is True
+        assert (
+            prerequisites["benchflow_user_loop_final_verify_recovery_triggered"]
+            is True
+        )
+        assert prerequisites["benchflow_user_loop_recovery_stage"] == "soft_verify"
+        assert prerequisites["benchflow_user_loop_recovery_exception_type"] == (
+            "TimeoutError"
+        )
+        assert prerequisites["benchflow_user_loop_recovery_delta_events"] == 2
+        assert prerequisites["benchflow_user_loop_recovery_delta_tool_calls"] == 1
+        assert prerequisites["benchflow_user_loop_recovery_raw_error_recorded"] is False
+        assert trace["benchflow_user_loop_recovery_preserved_final_verify"] is True
+        rounds_log = (rollout_dir / "user_rounds.jsonl").read_text(encoding="utf-8")
+        assert "public_safe_soft_verify_exception_after_agent_round" in rounds_log
+        assert "PRIVATE_PATH_SHOULD_NOT_ESCAPE" not in rounds_log
+
+
+def test_skillsbench_product_mode_can_skip_intermediate_soft_verify() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-soft-verify-policy-") as tmp:
+        rollout_dir = Path(tmp)
+        plan = {"runner_prerequisites": {}}
+        trace: dict[str, Any] = {
+            "schema_version": "skillsbench_loopx_controller_trace_v0",
+        }
+
+        fake_benchflow = types.ModuleType("benchflow")
+        fake_sandbox = types.ModuleType("benchflow.sandbox")
+        fake_user_module = types.ModuleType("benchflow.sandbox.user")
+
+        class FakeRoundResult:
+            def __init__(self, **kwargs: Any) -> None:
+                self.__dict__.update(kwargs)
+
+        fake_user_module.RoundResult = FakeRoundResult
+        old_modules = {
+            name: sys.modules.get(name)
+            for name in (
+                "benchflow",
+                "benchflow.sandbox",
+                "benchflow.sandbox.user",
+            )
+        }
+        sys.modules["benchflow"] = fake_benchflow
+        sys.modules["benchflow.sandbox"] = fake_sandbox
+        sys.modules["benchflow.sandbox.user"] = fake_user_module
+
+        class FakeUser:
+            async def setup(self, instruction: str, solution: str | None) -> None:
+                assert instruction == "fixture instruction"
+                assert solution is None
+
+            async def run(
+                self,
+                round: int,
+                instruction: str,
+                round_result: Any | None = None,
+            ) -> str | None:
+                if round == 0:
+                    assert round_result is None
+                    return "continue without verifier feedback"
+                assert round_result is not None
+                assert round_result.rewards is None
+                assert round_result.verifier_output is None
+                assert round_result.verifier_error is None
+                return None
+
+        class FakeRole:
+            pass
+
+        class FakeScene:
+            roles = [FakeRole()]
+
+        class FakeConfig:
+            user = FakeUser()
+            effective_scenes = [FakeScene()]
+            oracle_access = False
+            max_user_rounds = 2
+
+        class FakeRollout:
+            async def _run_user_loop(self) -> None:
+                raise AssertionError("original user loop should be patched")
+
+            def __init__(self) -> None:
+                self._config = FakeConfig()
+                self._resolved_prompts = ["fixture instruction"]
+                self._trajectory: list[dict[str, Any]] = []
+                self._rollout_dir = rollout_dir
+                self.soft_verify_called = 0
+
+            async def connect_as(self, role: Any) -> None:
+                return None
+
+            async def execute(self, prompts: list[str] | None = None) -> None:
+                assert prompts == ["continue without verifier feedback"]
+                self._trajectory.append({"type": "tool_call"})
+
+            async def disconnect(self) -> None:
+                return None
+
+            async def soft_verify(self) -> tuple[dict | None, str | None, str | None]:
+                self.soft_verify_called += 1
+                raise AssertionError("intermediate soft_verify must be skipped")
+
+        try:
+            original = install_benchflow_user_loop_final_verify_recovery(
+                FakeRollout,
+                plan=plan,
+                trace=trace,
+                intermediate_soft_verify_policy="final-only",
+            )
+            fake_rollout = FakeRollout()
+            asyncio.run(FakeRollout._run_user_loop(fake_rollout))
+            FakeRollout._run_user_loop = original
+        finally:
+            for name, module in old_modules.items():
+                if module is None:
+                    sys.modules.pop(name, None)
+                else:
+                    sys.modules[name] = module
+
+        prerequisites = plan["runner_prerequisites"]
+        assert fake_rollout.soft_verify_called == 0
+        assert prerequisites["benchflow_intermediate_soft_verify_policy"] == (
+            "final-only"
+        )
+        assert prerequisites["benchflow_intermediate_soft_verify_final_only"] is True
+        assert prerequisites["benchflow_intermediate_soft_verify_call_count"] == 0
+        assert prerequisites["benchflow_intermediate_soft_verify_skipped_count"] == 1
+        assert (
+            prerequisites["benchflow_intermediate_soft_verify_raw_output_recorded"]
+            is False
+        )
+        assert trace["benchflow_intermediate_soft_verify_skipped_count"] == 1
+        rounds = [
+            json.loads(line)
+            for line in (rollout_dir / "user_rounds.jsonl")
+            .read_text(encoding="utf-8")
+            .splitlines()
+        ]
+        assert rounds[0]["soft_verify_policy"] == "final-only"
+        assert rounds[0]["soft_verify_skipped"] is True
+        assert "intermediate soft_verify must be skipped" not in json.dumps(rounds)
+
+
+def test_skillsbench_final_verify_timeout_after_user_loop_recovery_is_attributed() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-final-verify-timeout-") as tmp:
+        root = Path(tmp)
+        jobs_dir = root / "jobs"
+        args = parse_args(
+            [
+                "--task-id",
+                "citation-check",
+                "--route",
+                "loopx-product-mode",
+                "--jobs-dir",
+                str(jobs_dir),
+                "--job-name",
+                "skillsbench-final-verify-timeout-fixture",
+                "--rollout-name",
+                "citation-check__loopx_product_mode",
+            ]
+        )
+        plan = build_plan(args)
+        write_json(
+            Path(plan["controller_trace_json"]),
+            {
+                "schema_version": "skillsbench_loopx_controller_trace_v0",
+                "route": "loopx-product-mode",
+                "trace_publicness": "public_counts_only_no_task_text_no_verifier_output",
+                "product_mode": True,
+                "heartbeat_count": 1,
+                "controller_action_decisions": 1,
+                "initial_prompt_count": 1,
+                "max_rounds_budget": 8,
+                "max_round_observed": 0,
+                "benchflow_user_loop_final_verify_recovery_triggered": True,
+                "benchflow_user_loop_recovery_after_agent_activity": True,
+                "benchflow_user_loop_recovery_preserved_final_verify": True,
+                "benchflow_user_loop_recovery_raw_error_recorded": False,
+                "benchflow_user_loop_recovery_stage": "soft_verify",
+                "benchflow_user_loop_recovery_exception_type": "RuntimeError",
+                "benchflow_user_loop_recovery_round": 0,
+                "benchflow_user_loop_recovery_delta_events": 40,
+                "benchflow_user_loop_recovery_delta_tool_calls": 27,
+                "raw_task_text_recorded": False,
+                "raw_verifier_output_recorded": False,
+                "raw_agent_trajectory_recorded": False,
+                "acp_trajectory_summary": {
+                    "schema_version": "skillsbench_acp_trajectory_summary_v0",
+                    "private_trajectory_present": True,
+                    "raw_text_copied_to_public": False,
+                    "event_count": 40,
+                    "round_count": 1,
+                    "user_message_count": 1,
+                    "agent_message_count": 12,
+                    "tool_call_count": 27,
+                    "loopx_cli_call_count": 8,
+                    "loopx_cli_state_read_count": 3,
+                    "loopx_cli_state_write_count": 5,
+                },
+            },
+        )
+        result_path = Path(plan["result_json"])
+        write_json(
+            result_path,
+            {
+                "task_name": "citation-check",
+                "rollout_name": "citation-check__loopx_product_mode",
+                "rewards": None,
+                "agent": "codex-acp",
+                "agent_name": "",
+                "model": "gpt-5.5",
+                "n_tool_calls": 27,
+                "n_prompts": 1,
+                "error": "Command timed out after 10 seconds",
+                "verifier_error": None,
+                "partial_trajectory": False,
+            },
+        )
+        write_json(result_path.with_name("timing.json"), {"agent_execution": 240.0})
+
+        compact = reduce_result(args, result_path, plan)
+        expected = (
+            "skillsbench_final_verify_timeout_after_user_loop_recovery_no_reward_artifact"
+        )
+        assert compact["score_failure_attribution"] == expected, compact
+        assert compact["runner_failure"]["failure_class"] == expected, compact
+        assert expected in compact["failure_attribution_labels"], compact
+        assert "skillsbench_controller_budget_not_exercised" not in compact[
+            "failure_attribution_labels"
+        ], compact
+        assert compact["runner_failure"]["user_loop_recovery"] == {
+            "schema_version": "skillsbench_user_loop_recovery_v0",
+            "preserved_final_verify": True,
+            "stage": "soft_verify",
+            "exception_type": "runtimeerror",
+            "round": 0,
+            "delta_events": 40,
+            "delta_tool_calls": 27,
+            "raw_error_recorded": False,
+        }, compact
+        assert compact["interaction_counters"][
+            "benchflow_user_loop_final_verify_recovery_triggered"
+        ] is True
+        assert compact["interaction_counters"][
+            "benchflow_user_loop_recovery_raw_error_recorded"
+        ] is False
+
+
+def test_skillsbench_verifier_prep_timeout_override_is_public_safe() -> None:
+    plan = {"runner_prerequisites": {}}
+    trace: dict[str, Any] = {}
+
+    class ExecResult:
+        stdout = ""
+        stderr = ""
+        return_code = 0
+
+    class FakeEnv:
+        def __init__(self) -> None:
+            self.timeouts: list[int | None] = []
+
+        async def exec(self, _command: str, **kwargs: Any) -> ExecResult:
+            self.timeouts.append(kwargs.get("timeout_sec"))
+            return ExecResult()
+
+    class FakeRollout:
+        def __init__(self) -> None:
+            self._env = FakeEnv()
+
+        async def verify(self) -> dict[str, float]:
+            await self._env.exec("mkdir -p /logs/agent", timeout_sec=10)
+            await self._env.exec("official verifier body", timeout_sec=99)
+            return {"score": 1.0}
+
+        async def soft_verify(self) -> tuple[None, None, None]:
+            await self._env.exec("rm -rf /logs/verifier", timeout_sec=10)
+            return None, None, None
+
+    original_verify, original_soft_verify = install_benchflow_verifier_prep_timeout_override(
+        FakeRollout,
+        timeout_sec=120,
+        plan=plan,
+        trace=trace,
+    )
+    try:
+        fake_rollout = FakeRollout()
+        assert asyncio.run(FakeRollout.verify(fake_rollout)) == {"score": 1.0}
+        assert asyncio.run(FakeRollout.soft_verify(fake_rollout)) == (
+            None,
+            None,
+            None,
+        )
+    finally:
+        FakeRollout.verify = original_verify
+        FakeRollout.soft_verify = original_soft_verify
+
+    assert fake_rollout._env.timeouts == [120, 99, 120]
+    prerequisites = plan["runner_prerequisites"]
+    assert prerequisites["benchflow_verifier_prep_timeout_override_enabled"] is True
+    assert prerequisites["benchflow_verifier_prep_timeout_sec"] == 120
+    assert prerequisites["benchflow_verifier_prep_timeout_override_count"] == 2
+    assert prerequisites["benchflow_verify_prep_timeout_override_count"] == 1
+    assert prerequisites["benchflow_soft_verify_prep_timeout_override_count"] == 1
+    assert prerequisites["benchflow_verifier_prep_timeout_raw_command_recorded"] is False
+    assert "mkdir -p" not in json.dumps(prerequisites)
+    assert trace["benchflow_verifier_prep_timeout_override_count"] == 2
 
 
 def test_skillsbench_main_marks_empty_acp_trajectory_after_host_install() -> None:
@@ -4776,7 +5847,7 @@ def test_skillsbench_reduce_only_preserves_round_reward_trace() -> None:
 
 
 if __name__ == "__main__":
-    test_skillsbench_default_blind_loop_budget_is_five()
+    test_skillsbench_default_blind_loop_budget_is_eight()
     test_skillsbench_local_driver_a2a_contract_keeps_codex_local()
     test_skillsbench_local_driver_a2a_contract_ready_only_after_both_sides()
     test_skillsbench_local_driver_a2a_contract_distinguishes_cli_from_handshake()
@@ -4795,6 +5866,7 @@ if __name__ == "__main__":
     test_product_mode_declared_done_marker_detection()
     test_product_mode_case_state_seed_uses_active_goal_shape()
     test_product_mode_declared_done_requires_case_state_depth()
+    test_product_mode_missing_lifecycle_prompts_exact_checkpoint()
     test_skillsbench_skeleton_builder()
     test_skillsbench_official_result_builder()
     test_skillsbench_result_reward_artifact_recovery()
@@ -4826,6 +5898,7 @@ if __name__ == "__main__":
     test_skillsbench_reduce_only_recovers_prepared_task_staging_metadata()
     test_skillsbench_controller_trace_counts_are_compacted()
     test_skillsbench_product_mode_declared_done_is_compacted()
+    test_skillsbench_product_mode_lifecycle_checkpoint_is_compacted()
     test_skillsbench_product_mode_case_state_usage_is_compacted()
     test_skillsbench_product_mode_legacy_case_state_path_is_not_compacted()
     test_skillsbench_round_trace_records_best_round_score()
@@ -4838,10 +5911,17 @@ if __name__ == "__main__":
     test_skillsbench_runner_failure_compact_closeout()
     test_skillsbench_runner_failure_prefers_structured_preflight_blocker()
     test_skillsbench_runner_failure_marks_pre_agent_install_stage()
+    test_skillsbench_runner_failure_marks_build_stall_timeout()
+    test_skillsbench_runner_failure_backfills_generic_timeout_stall_cleanup()
+    test_skillsbench_setup_stall_cleanup_targets_current_job_only()
     test_skillsbench_reduce_only_missing_result_records_closeout_exit_zero()
     test_skillsbench_main_failure_closeout_preserves_mutated_prerequisites()
     test_skillsbench_main_recovers_official_result_after_runner_exception()
     test_skillsbench_main_recovers_missing_reward_with_structured_prereq_blocker()
+    test_skillsbench_result_timeout_after_loopx_lifecycle_is_attributed()
+    test_skillsbench_user_loop_recovery_preserves_final_verify_path()
+    test_skillsbench_final_verify_timeout_after_user_loop_recovery_is_attributed()
+    test_skillsbench_verifier_prep_timeout_override_is_public_safe()
     test_skillsbench_main_marks_empty_acp_trajectory_after_host_install()
     test_skillsbench_main_marks_agent_message_only_no_tool_calls()
     test_skillsbench_main_redirects_runner_output_to_private_log()

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -214,7 +214,7 @@ def skillsbench_route_contract(route: str) -> dict[str, Any]:
         return {
             "mode": "skillsbench_loopx_product_mode_treatment",
             "arm_id": "loopx_product_mode",
-            "source_runner": "loopx_skillsbench_product_mode_skeleton",
+            "source_runner": "loopx_skillsbench_canonical_product_lifecycle_driver",
             "inner_codex_goal_mode": False,
             "native_goal_mode_requested": False,
             "native_goal_mode_invoked": False,
@@ -231,10 +231,10 @@ def skillsbench_route_contract(route: str) -> dict[str, Any]:
             "case_semantics_changed_by_harness": True,
             "official_score_comparable_to_native_codex": True,
             "official_score_comparable_to_loopx_treatment": True,
-            "first_blocker": "skillsbench_adapter_skeleton_no_real_case",
+            "first_blocker": "none",
             "next_action": (
                 "run LoopX product-mode treatment with goal state, todos, "
-                "replan/status writeback, and GH CLI/ledger surfaces; do not "
+                "replan/status writeback, and LoopX CLI/ledger surfaces; do not "
                 "return official reward or verifier feedback during execution"
             ),
         }
@@ -1449,6 +1449,7 @@ def skillsbench_runner_error_fingerprint(error_text: str) -> dict[str, Any]:
         "image_build": r"failed to solve|failed to build|dockerfile|pull access denied|manifest unknown",
         "port_conflict": r"port is already allocated|address already in use|ports are not available|bind for",
         "apt_failure": r"apt-get|apt update|apt |gpg error|hash sum mismatch|failed to fetch",
+        "subprocess_command_timeout": r"command timed out after \d+ seconds",
         "timeout": r"timeout|timed out|deadline",
     }
     matched = [
@@ -1930,6 +1931,10 @@ def _skillsbench_controller_trace_counters(
             "declared_done_requires_no_remaining_goals"
         )
         is True,
+        "product_mode_lifecycle_checkpoint_required": controller_trace.get(
+            "product_mode_lifecycle_checkpoint_required"
+        )
+        is True,
         "agent_declared_done": controller_trace.get("agent_declared_done") is True,
         "agent_declared_no_remaining_goals": controller_trace.get(
             "agent_declared_no_remaining_goals"
@@ -1988,6 +1993,63 @@ def _skillsbench_controller_trace_counters(
             "raw_agent_trajectory_recorded"
         )
         is True,
+        "loopx_case_source_install_requested": controller_trace.get(
+            "loopx_case_source_install_requested"
+        )
+        is True,
+        "loopx_case_source_path_recorded": controller_trace.get(
+            "loopx_case_source_path_recorded"
+        )
+        is True,
+        "benchflow_user_loop_final_verify_recovery_enabled": controller_trace.get(
+            "benchflow_user_loop_final_verify_recovery_enabled"
+        )
+        is True,
+        "benchflow_user_loop_final_verify_recovery_triggered": controller_trace.get(
+            "benchflow_user_loop_final_verify_recovery_triggered"
+        )
+        is True,
+        "benchflow_user_loop_recovery_after_agent_activity": controller_trace.get(
+            "benchflow_user_loop_recovery_after_agent_activity"
+        )
+        is True,
+        "benchflow_user_loop_recovery_preserved_final_verify": controller_trace.get(
+            "benchflow_user_loop_recovery_preserved_final_verify"
+        )
+        is True,
+        "benchflow_user_loop_recovery_raw_error_recorded": controller_trace.get(
+            "benchflow_user_loop_recovery_raw_error_recorded"
+        )
+        is True,
+        "benchflow_user_loop_recovery_round": count(
+            "benchflow_user_loop_recovery_round"
+        ),
+        "benchflow_user_loop_recovery_delta_events": count(
+            "benchflow_user_loop_recovery_delta_events"
+        ),
+        "benchflow_user_loop_recovery_delta_tool_calls": count(
+            "benchflow_user_loop_recovery_delta_tool_calls"
+        ),
+        "benchflow_intermediate_soft_verify_final_only": controller_trace.get(
+            "benchflow_intermediate_soft_verify_final_only"
+        )
+        is True,
+        "benchflow_intermediate_soft_verify_raw_output_recorded": controller_trace.get(
+            "benchflow_intermediate_soft_verify_raw_output_recorded"
+        )
+        is True,
+        "benchflow_intermediate_soft_verify_call_count": count(
+            "benchflow_intermediate_soft_verify_call_count"
+        ),
+        "benchflow_intermediate_soft_verify_skipped_count": count(
+            "benchflow_intermediate_soft_verify_skipped_count"
+        ),
+        "product_mode_lifecycle_checkpoint_count": count(
+            "product_mode_lifecycle_checkpoint_count"
+        ),
+        "product_mode_lifecycle_checkpoint_round": count(
+            "product_mode_lifecycle_checkpoint_round"
+        ),
     }
     last_decision = _skillsbench_public_safe_label(
         controller_trace.get("last_decision") or ""
@@ -1999,11 +2061,41 @@ def _skillsbench_controller_trace_counters(
     )
     if init_status:
         counters["case_goal_state_init_status"] = init_status
+    init_failed_phase = _skillsbench_public_safe_label(
+        controller_trace.get("case_goal_state_init_failed_phase") or ""
+    )
+    if init_failed_phase:
+        counters["case_goal_state_init_failed_phase"] = init_failed_phase
     case_state_schema = _skillsbench_public_safe_label(
         controller_trace.get("case_goal_state_schema_version") or ""
     )
     if case_state_schema:
         counters["case_goal_state_schema_version"] = case_state_schema
+    recovery_stage = _skillsbench_public_safe_label(
+        controller_trace.get("benchflow_user_loop_recovery_stage") or ""
+    )
+    if recovery_stage:
+        counters["benchflow_user_loop_recovery_stage"] = recovery_stage
+    recovery_exception_type = _skillsbench_public_safe_label(
+        controller_trace.get("benchflow_user_loop_recovery_exception_type") or ""
+    )
+    if recovery_exception_type:
+        counters["benchflow_user_loop_recovery_exception_type"] = (
+            recovery_exception_type
+        )
+    soft_verify_policy = _skillsbench_public_safe_label(
+        controller_trace.get("benchflow_intermediate_soft_verify_policy") or ""
+    )
+    if soft_verify_policy:
+        counters["benchflow_intermediate_soft_verify_policy"] = soft_verify_policy
+    lifecycle_missing_reason = _skillsbench_public_safe_label(
+        controller_trace.get("product_mode_lifecycle_checkpoint_missing_reason")
+        or ""
+    )
+    if lifecycle_missing_reason:
+        counters["product_mode_lifecycle_checkpoint_missing_reason"] = (
+            lifecycle_missing_reason
+        )
     case_state_path = str(controller_trace.get("case_goal_state_path") or "")
     if (
         "/.codex/goals/" in case_state_path
@@ -2430,6 +2522,101 @@ def build_skillsbench_benchflow_result_benchmark_run(
         if isinstance(controller_counters.get("acp_trajectory_summary"), dict)
         else {}
     )
+    controller_initial_prompt_count = controller_counters.get("initial_prompt_count", 0)
+    if not isinstance(controller_initial_prompt_count, int) or isinstance(
+        controller_initial_prompt_count, bool
+    ):
+        controller_initial_prompt_count = 0
+    controller_followup_prompt_count = controller_counters.get("followup_prompt_count", 0)
+    if not isinstance(controller_followup_prompt_count, int) or isinstance(
+        controller_followup_prompt_count, bool
+    ):
+        controller_followup_prompt_count = 0
+    controller_stop_decision_count = controller_counters.get("stop_decision_count", 0)
+    if not isinstance(controller_stop_decision_count, int) or isinstance(
+        controller_stop_decision_count, bool
+    ):
+        controller_stop_decision_count = 0
+    controller_max_rounds_budget = controller_counters.get("max_rounds_budget", 0)
+    if not isinstance(controller_max_rounds_budget, int) or isinstance(
+        controller_max_rounds_budget, bool
+    ):
+        controller_max_rounds_budget = 0
+    user_loop_final_verify_recovery_triggered = bool(
+        controller_counters.get("benchflow_user_loop_final_verify_recovery_triggered")
+    )
+    controller_budget_cutoff_before_followup = (
+        bool(error_text)
+        and reward_value is None
+        and controller_trace_present
+        and not user_loop_final_verify_recovery_triggered
+        and controller_max_rounds_budget > 1
+        and controller_initial_prompt_count > 0
+        and controller_followup_prompt_count == 0
+        and controller_stop_decision_count == 0
+        and (partial_trajectory or tool_calls > 0)
+    )
+    controller_budget_cutoff_reason = (
+        "result_error_after_agent_round_no_reward_artifact"
+        if controller_budget_cutoff_before_followup
+        else "none"
+    )
+    if controller_budget_cutoff_before_followup:
+        for item in (
+            "skillsbench_controller_budget_not_exercised",
+            "skillsbench_result_error_cut_off_followup_loop",
+        ):
+            if item not in failure_labels:
+                failure_labels.append(item)
+    if (
+        error_text
+        and reward_value is None
+        and re.search(r"timeout|timed out|deadline", error_text, re.I)
+        and controller_trace_present
+        and user_loop_final_verify_recovery_triggered
+    ):
+        label = "skillsbench_final_verify_timeout_after_user_loop_recovery_no_reward_artifact"
+        exception_type = label
+        score_failure_attribution = label
+        runner_score_failure_attribution = label
+        failure_labels = [
+            item
+            for item in failure_labels
+            if item
+            not in {
+                "skillsbench_runner_error",
+                "skillsbench_controller_budget_not_exercised",
+                "skillsbench_result_error_cut_off_followup_loop",
+            }
+        ]
+        for item in (
+            label,
+            "skillsbench_final_verify_attempted_after_user_loop_recovery",
+            "skillsbench_reward_artifact_missing",
+        ):
+            if item not in failure_labels:
+                failure_labels.append(item)
+    elif (
+        error_text
+        and reward_value is None
+        and re.search(r"timeout|timed out|deadline", error_text, re.I)
+        and controller_trace_present
+        and (partial_trajectory or tool_calls > 0)
+    ):
+        label = "skillsbench_result_timeout_after_agent_round_no_reward_artifact"
+        exception_type = label
+        score_failure_attribution = label
+        runner_score_failure_attribution = label
+        failure_labels = [
+            item for item in failure_labels if item != "skillsbench_runner_error"
+        ]
+        for item in (
+            label,
+            "skillsbench_result_error_after_agent_round",
+            "skillsbench_reward_artifact_missing",
+        ):
+            if item not in failure_labels:
+                failure_labels.append(item)
     if trajectory_summary:
         evidence_files.append("loopx:acp_trajectory_summary")
     runner_failure: dict[str, Any] | None = None
@@ -2443,6 +2630,50 @@ def build_skillsbench_benchflow_result_benchmark_run(
             "raw_task_text_read": False,
             "raw_trajectory_read": False,
         }
+        if controller_budget_cutoff_before_followup:
+            runner_failure["controller_cutoff"] = {
+                "schema_version": "skillsbench_controller_cutoff_v0",
+                "cutoff_before_followup": True,
+                "reason": controller_budget_cutoff_reason,
+                "max_rounds_budget": controller_max_rounds_budget,
+                "initial_prompt_count": controller_initial_prompt_count,
+                "followup_prompt_count": controller_followup_prompt_count,
+                "stop_decision_count": controller_stop_decision_count,
+            }
+        if user_loop_final_verify_recovery_triggered:
+            runner_failure["user_loop_recovery"] = {
+                "schema_version": "skillsbench_user_loop_recovery_v0",
+                "preserved_final_verify": bool(
+                    controller_counters.get(
+                        "benchflow_user_loop_recovery_preserved_final_verify"
+                    )
+                ),
+                "stage": controller_counters.get(
+                    "benchflow_user_loop_recovery_stage",
+                    "",
+                ),
+                "exception_type": controller_counters.get(
+                    "benchflow_user_loop_recovery_exception_type",
+                    "",
+                ),
+                "round": controller_counters.get(
+                    "benchflow_user_loop_recovery_round",
+                    0,
+                ),
+                "delta_events": controller_counters.get(
+                    "benchflow_user_loop_recovery_delta_events",
+                    0,
+                ),
+                "delta_tool_calls": controller_counters.get(
+                    "benchflow_user_loop_recovery_delta_tool_calls",
+                    0,
+                ),
+                "raw_error_recorded": bool(
+                    controller_counters.get(
+                        "benchflow_user_loop_recovery_raw_error_recorded"
+                    )
+                ),
+            }
         runner_failure_fingerprint = skillsbench_runner_error_fingerprint(
             error_text
         )
@@ -2652,6 +2883,68 @@ def build_skillsbench_benchflow_result_benchmark_run(
             "controller_stop_decision_count": controller_counters.get(
                 "stop_decision_count", 0
             ),
+            "controller_budget_cutoff_before_followup": controller_budget_cutoff_before_followup,
+            "controller_budget_cutoff_reason": controller_budget_cutoff_reason,
+            "benchflow_user_loop_final_verify_recovery_enabled": controller_counters.get(
+                "benchflow_user_loop_final_verify_recovery_enabled",
+                False,
+            ),
+            "benchflow_user_loop_final_verify_recovery_triggered": controller_counters.get(
+                "benchflow_user_loop_final_verify_recovery_triggered",
+                False,
+            ),
+            "benchflow_user_loop_recovery_after_agent_activity": controller_counters.get(
+                "benchflow_user_loop_recovery_after_agent_activity",
+                False,
+            ),
+            "benchflow_user_loop_recovery_preserved_final_verify": controller_counters.get(
+                "benchflow_user_loop_recovery_preserved_final_verify",
+                False,
+            ),
+            "benchflow_user_loop_recovery_raw_error_recorded": controller_counters.get(
+                "benchflow_user_loop_recovery_raw_error_recorded",
+                False,
+            ),
+            "benchflow_user_loop_recovery_stage": controller_counters.get(
+                "benchflow_user_loop_recovery_stage",
+                "",
+            ),
+            "benchflow_user_loop_recovery_exception_type": controller_counters.get(
+                "benchflow_user_loop_recovery_exception_type",
+                "",
+            ),
+            "benchflow_user_loop_recovery_round": controller_counters.get(
+                "benchflow_user_loop_recovery_round",
+                0,
+            ),
+            "benchflow_user_loop_recovery_delta_events": controller_counters.get(
+                "benchflow_user_loop_recovery_delta_events",
+                0,
+            ),
+            "benchflow_user_loop_recovery_delta_tool_calls": controller_counters.get(
+                "benchflow_user_loop_recovery_delta_tool_calls",
+                0,
+            ),
+            "benchflow_intermediate_soft_verify_policy": controller_counters.get(
+                "benchflow_intermediate_soft_verify_policy",
+                "",
+            ),
+            "benchflow_intermediate_soft_verify_final_only": controller_counters.get(
+                "benchflow_intermediate_soft_verify_final_only",
+                False,
+            ),
+            "benchflow_intermediate_soft_verify_call_count": controller_counters.get(
+                "benchflow_intermediate_soft_verify_call_count",
+                0,
+            ),
+            "benchflow_intermediate_soft_verify_skipped_count": controller_counters.get(
+                "benchflow_intermediate_soft_verify_skipped_count",
+                0,
+            ),
+            "benchflow_intermediate_soft_verify_raw_output_recorded": controller_counters.get(
+                "benchflow_intermediate_soft_verify_raw_output_recorded",
+                False,
+            ),
             "controller_reward_observation_count": controller_counters.get(
                 "reward_observation_count", 0
             ),
@@ -2688,6 +2981,9 @@ def build_skillsbench_benchflow_result_benchmark_run(
             "case_goal_state_init_status": controller_counters.get(
                 "case_goal_state_init_status", ""
             ),
+            "case_goal_state_init_failed_phase": controller_counters.get(
+                "case_goal_state_init_failed_phase", ""
+            ),
             "case_goal_state_schema_version": controller_counters.get(
                 "case_goal_state_schema_version", ""
             ),
@@ -2696,6 +2992,18 @@ def build_skillsbench_benchflow_result_benchmark_run(
             ),
             "declared_done_requires_no_remaining_goals": controller_counters.get(
                 "declared_done_requires_no_remaining_goals", False
+            ),
+            "product_mode_lifecycle_checkpoint_required": controller_counters.get(
+                "product_mode_lifecycle_checkpoint_required", False
+            ),
+            "product_mode_lifecycle_checkpoint_count": controller_counters.get(
+                "product_mode_lifecycle_checkpoint_count", 0
+            ),
+            "product_mode_lifecycle_checkpoint_round": controller_counters.get(
+                "product_mode_lifecycle_checkpoint_round", 0
+            ),
+            "product_mode_lifecycle_checkpoint_missing_reason": controller_counters.get(
+                "product_mode_lifecycle_checkpoint_missing_reason", ""
             ),
             "agent_declared_done": controller_counters.get(
                 "agent_declared_done", False

--- a/loopx/benchmark_case_state.py
+++ b/loopx/benchmark_case_state.py
@@ -4,6 +4,8 @@ import posixpath
 import re
 import shlex
 
+from .todo_contract import build_todo_id
+
 BENCHMARK_CASE_ACTIVE_STATE_SCHEMA_VERSION = (
     "loopx_benchmark_case_active_state_v1"
 )
@@ -19,10 +21,42 @@ BENCHMARK_CASE_LIFECYCLE_SOURCE_OF_TRUTH = "case_active_state_and_rollout_event_
 BENCHMARK_CASE_LOOPX_INSTALL_FLOW_SCHEMA_VERSION = (
     "loopx_benchmark_case_install_flow_v0"
 )
+BENCHMARK_CASE_LIFECYCLE_DRIVER_SCHEMA_VERSION = (
+    "loopx_benchmark_case_product_lifecycle_driver_v1"
+)
+BENCHMARK_CASE_LOOPX_PROJECT_ROOT = "/app"
+BENCHMARK_CASE_LOOPX_HOME = "/app"
 BENCHMARK_CASE_LOOPX_CLI_PATH = "/app/.local/bin/loopx"
+BENCHMARK_CASE_LOOPX_REGISTRY_PATH = "/app/.loopx/registry.json"
+BENCHMARK_CASE_LOOPX_RUNTIME_ROOT = "/app/.loopx/runtime"
+BENCHMARK_CASE_LOOPX_GOAL_DOC_PATH = "/app/.loopx/LOOPX_CASE_GOAL.md"
+BENCHMARK_CASE_LOOPX_SOURCE_MOUNT_TARGET = "/app/.loopx-source"
 BENCHMARK_CASE_LOOPX_EVENT_LOG_BASENAME = "rollout-event-log.jsonl"
 BENCHMARK_CASE_LOOPX_AGENT_ID = "codex-benchmark-agent"
-BENCHMARK_CASE_LOOPX_TODO_ID = "todo_benchmark_case_main"
+BENCHMARK_CASE_LOOPX_TODO_TEXT = (
+    "Solve the current benchmark case using the official LoopX product-mode "
+    "lifecycle; inspect the task, implement the fix, validate locally, update "
+    "this todo, refresh state, and spend quota once after validated work."
+)
+BENCHMARK_CASE_LOOPX_TODO_ID = build_todo_id(
+    role="agent",
+    source_section="Agent Todo",
+    index=1,
+    text=BENCHMARK_CASE_LOOPX_TODO_TEXT,
+)
+BENCHMARK_CASE_LOOPX_FORMAL_TREATMENT_SEMANTICS = "loopx-product-mode"
+BENCHMARK_CASE_LOOPX_PROMPT_DRIVEN_EXECUTION_STYLE = "prompt_driven_loopx_cli"
+BENCHMARK_CASE_LOOPX_ORCHESTRATED_EXECUTION_STYLE = (
+    "orchestrated_agentloop_loopx_cli"
+)
+BENCHMARK_CASE_LOOPX_EXECUTION_STYLES = (
+    BENCHMARK_CASE_LOOPX_PROMPT_DRIVEN_EXECUTION_STYLE,
+    BENCHMARK_CASE_LOOPX_ORCHESTRATED_EXECUTION_STYLE,
+)
+BENCHMARK_CASE_LOOPX_OFFICIAL_INSTALLER_URL = (
+    "https://raw.githubusercontent.com/huangruiteng/loopx/main/"
+    "scripts/install-from-github.sh"
+)
 BENCHMARK_CASE_LOOPX_PRODUCT_PATH_PRIMARY_ROUTE = (
     "prompt_driven_case_local_loopx_cli"
 )
@@ -96,10 +130,10 @@ def benchmark_case_loopx_case_dir(
 def benchmark_case_loopx_event_log_path(
     goal_id: str,
     *,
-    root: str = BENCHMARK_CASE_STATE_ROOT,
+    root: str = BENCHMARK_CASE_LOOPX_RUNTIME_ROOT,
 ) -> str:
     return (
-        f"{benchmark_case_loopx_case_dir(goal_id, root=root).rstrip('/')}/"
+        f"{root.rstrip('/')}/goals/{goal_id}/"
         f"{BENCHMARK_CASE_LOOPX_EVENT_LOG_BASENAME}"
     )
 
@@ -161,17 +195,35 @@ def benchmark_case_lifecycle_contract(
     rounds = max_rounds if isinstance(max_rounds, int) and max_rounds > 0 else 5
     return {
         "schema_version": BENCHMARK_CASE_LIFECYCLE_SCHEMA_VERSION,
+        "lifecycle_driver_schema_version": (
+            BENCHMARK_CASE_LIFECYCLE_DRIVER_SCHEMA_VERSION
+        ),
         "benchmark_id": benchmark_id,
         "case_id": case_id,
         "arm_id": arm_id,
         "case_isolation_scope": "per_benchmark_case_arm",
         "benchmark_case_goal_id": resolved_goal_id,
         "case_state_path": resolved_path,
+        "case_registry_path": BENCHMARK_CASE_LOOPX_REGISTRY_PATH,
+        "case_runtime_root": BENCHMARK_CASE_LOOPX_RUNTIME_ROOT,
+        "case_goal_doc_path": BENCHMARK_CASE_LOOPX_GOAL_DOC_PATH,
+        "case_cli_path": BENCHMARK_CASE_LOOPX_CLI_PATH,
+        "case_agent_id": BENCHMARK_CASE_LOOPX_AGENT_ID,
+        "case_todo_id": BENCHMARK_CASE_LOOPX_TODO_ID,
+        "case_todo_text_public_safe": BENCHMARK_CASE_LOOPX_TODO_TEXT,
         "case_state_init_required_before_worker": True,
+        "formal_treatment_semantics": BENCHMARK_CASE_LOOPX_FORMAL_TREATMENT_SEMANTICS,
+        "canonical_product_mode_lifecycle_driver": True,
+        "supported_execution_styles": list(BENCHMARK_CASE_LOOPX_EXECUTION_STYLES),
+        "preferred_execution_style": BENCHMARK_CASE_LOOPX_PROMPT_DRIVEN_EXECUTION_STYLE,
         "source_of_truth": BENCHMARK_CASE_LIFECYCLE_SOURCE_OF_TRUTH,
         "required_lifecycle_steps": list(BENCHMARK_CASE_LIFECYCLE_STEPS),
         "required_rollout_event_kinds": list(BENCHMARK_CASE_LIFECYCLE_ROLLOUT_EVENTS),
         "max_rounds_budget": rounds,
+        "host_may_install_and_seed_case_state": True,
+        "host_may_preflight_quota_before_agent": True,
+        "host_claims_case_todo_before_agent": False,
+        "agent_must_claim_selected_case_todo": True,
         "runner_internal_prompt_polling_only_allowed": False,
         "surrogate_state_files_allowed": False,
         "official_feedback_forwarded": False,
@@ -193,8 +245,19 @@ def render_benchmark_case_lifecycle_contract_lines(
         "case_isolation_scope",
         "benchmark_case_goal_id",
         "case_state_path",
+        "case_registry_path",
+        "case_runtime_root",
+        "case_goal_doc_path",
+        "case_cli_path",
+        "case_agent_id",
+        "case_todo_id",
+        "formal_treatment_semantics",
+        "preferred_execution_style",
         "source_of_truth",
         "max_rounds_budget",
+        "canonical_product_mode_lifecycle_driver",
+        "host_claims_case_todo_before_agent",
+        "agent_must_claim_selected_case_todo",
         "runner_internal_prompt_polling_only_allowed",
         "surrogate_state_files_allowed",
         "official_feedback_forwarded",
@@ -206,7 +269,11 @@ def render_benchmark_case_lifecycle_contract_lines(
             continue
         rendered = str(value).lower() if isinstance(value, bool) else str(value)
         lines.append(f"  {field}: {rendered}")
-    for field in ("required_lifecycle_steps", "required_rollout_event_kinds"):
+    for field in (
+        "supported_execution_styles",
+        "required_lifecycle_steps",
+        "required_rollout_event_kinds",
+    ):
         value = contract.get(field)
         if isinstance(value, list) and value:
             lines.append(f"  {field}: {','.join(str(item) for item in value)}")
@@ -292,152 +359,221 @@ def benchmark_case_active_state_write_command(
     )
 
 
+def benchmark_case_goal_doc_text(
+    *,
+    benchmark_name: str,
+    goal_id: str,
+    task_id: str,
+    route: str,
+    max_rounds: int,
+) -> str:
+    """Return the public-safe goal doc used by official case-local LoopX."""
+
+    return (
+        f"# {benchmark_name} Case Goal\n\n"
+        "Solve the current benchmark task inside the sandbox using official "
+        "LoopX product-mode lifecycle evidence.\n\n"
+        "## Boundary\n\n"
+        "- Do not upload, submit to leaderboards, expose credentials, or record "
+        "raw task text, verifier output, raw logs, screenshots, or agent "
+        "trajectories in LoopX state.\n"
+        "- The benchmark runner/scorer remains authoritative for official "
+        "reward and pass/fail results.\n"
+        "- Case-local LoopX state is only for planning, todo ownership, local "
+        "evidence, validation, refresh, and quota accounting.\n\n"
+        "## Case Metadata\n\n"
+        f"- benchmark: `{benchmark_name}`\n"
+        f"- task_id: `{task_id}`\n"
+        f"- route: `{route}`\n"
+        f"- goal_id: `{goal_id}`\n"
+        f"- max_rounds: `{max_rounds}`\n"
+    )
+
+
+def _benchmark_case_write_text_command(path: str, content: str) -> str:
+    delimiter = "__LOOPX_BENCHMARK_CASE_TEXT_EOF__"
+    while delimiter in content:
+        delimiter += "_"
+    target = shlex.quote(path)
+    tmp_template = shlex.quote(f"{path}.tmp.XXXXXX")
+    parent = shlex.quote(posixpath.dirname(path.rstrip("/")) or "/")
+    return (
+        f"mkdir -p {parent} && "
+        f"tmp=$(mktemp {tmp_template}) && "
+        f"cat > \"$tmp\" <<'{delimiter}'\n"
+        f"{content}"
+        f"{delimiter}\n"
+        f"mv \"$tmp\" {target} && "
+        f"test -s {target}"
+    )
+
+
+def benchmark_case_loopx_command_prefix(
+    *,
+    case_cli_path: str = BENCHMARK_CASE_LOOPX_CLI_PATH,
+    case_registry_path: str = BENCHMARK_CASE_LOOPX_REGISTRY_PATH,
+    case_runtime_root: str = BENCHMARK_CASE_LOOPX_RUNTIME_ROOT,
+    json_output: bool = True,
+) -> str:
+    """Return the canonical case-local LoopX CLI prefix."""
+
+    parts = [
+        shlex.quote(case_cli_path),
+        "--registry",
+        shlex.quote(case_registry_path),
+        "--runtime-root",
+        shlex.quote(case_runtime_root),
+    ]
+    if json_output:
+        parts.extend(["--format", "json"])
+    return " ".join(parts)
+
+
 def benchmark_case_loopx_install_command(
     *,
     goal_id: str,
     case_state_path: str,
     content: str,
+    benchmark_id: str = "benchmark",
+    case_id: str = "current-case",
+    route: str = BENCHMARK_CASE_LOOPX_FORMAL_TREATMENT_SEMANTICS,
+    max_rounds: int = 0,
     case_cli_path: str = BENCHMARK_CASE_LOOPX_CLI_PATH,
-    case_rollout_event_log_path: str | None = None,
+    case_registry_path: str = BENCHMARK_CASE_LOOPX_REGISTRY_PATH,
+    case_runtime_root: str = BENCHMARK_CASE_LOOPX_RUNTIME_ROOT,
+    case_goal_doc_path: str = BENCHMARK_CASE_LOOPX_GOAL_DOC_PATH,
+    case_project_root: str = BENCHMARK_CASE_LOOPX_PROJECT_ROOT,
+    case_home: str = BENCHMARK_CASE_LOOPX_HOME,
+    case_loopx_source_path: str | None = None,
     case_agent_id: str = BENCHMARK_CASE_LOOPX_AGENT_ID,
+    case_todo_text: str = BENCHMARK_CASE_LOOPX_TODO_TEXT,
     case_todo_id: str = BENCHMARK_CASE_LOOPX_TODO_ID,
 ) -> str:
-    """Return a shell command that installs the per-case GH CLI surface.
+    """Return the official case-local LoopX product-mode install command.
 
-    The installed CLI is intentionally tiny and public-safe: it models the
-    quota/todo/status/refresh/spend lifecycle inside the benchmark sandbox, logs
-    only event kinds and ids, and never records raw task text, verifier output,
-    trajectories, credentials, or host-local paths.
+    The command mirrors the README path: install or reuse the real ``loopx``
+    CLI, bootstrap/connect a project-local registry and active state, register
+    the benchmark agent, seed one open agent todo through ``loopx todo add``,
+    and run a quota guard. The host may run this before the agent starts, but
+    it must not claim or complete the case todo on the agent's behalf.
     """
 
-    event_log_path = case_rollout_event_log_path or (
-        benchmark_case_loopx_event_log_path(goal_id)
+    del content  # Official bootstrap owns the initial state body.
+    cli_prefix = benchmark_case_loopx_command_prefix(
+        case_cli_path=case_cli_path,
+        case_registry_path=case_registry_path,
+        case_runtime_root=case_runtime_root,
+    )
+    goal_doc = benchmark_case_goal_doc_text(
+        benchmark_name=benchmark_id,
+        goal_id=goal_id,
+        task_id=case_id,
+        route=route,
+        max_rounds=max_rounds,
+    )
+    goal_doc_write = _benchmark_case_write_text_command(
+        case_goal_doc_path,
+        goal_doc,
     )
     cli_parent = shlex.quote(posixpath.dirname(case_cli_path.rstrip("/")) or "/")
+    project_root = shlex.quote(case_project_root)
+    home = shlex.quote(case_home)
     cli_target = shlex.quote(case_cli_path)
-    event_log_target = shlex.quote(event_log_path)
-    case_dir = shlex.quote(posixpath.dirname(case_state_path.rstrip("/")) or "/")
-    state_write = benchmark_case_active_state_write_command(
-        case_state_path=case_state_path,
-        content=content,
+    source_path_value = case_loopx_source_path.rstrip("/") if case_loopx_source_path else ""
+    source_path = shlex.quote(source_path_value) if source_path_value else ""
+    registry_parent = shlex.quote(
+        posixpath.dirname(case_registry_path.rstrip("/")) or "/"
     )
-    script = f"""#!/usr/bin/env sh
-set -eu
-GOAL_ID={shlex.quote(goal_id)}
-STATE_FILE={shlex.quote(case_state_path)}
-EVENT_LOG={shlex.quote(event_log_path)}
-AGENT_ID={shlex.quote(case_agent_id)}
-TODO_ID={shlex.quote(case_todo_id)}
-
-record_event() {{
-  kind="$1"
-  mkdir -p "$(dirname "$EVENT_LOG")"
-  printf '{{"schema_version":"benchmark_case_loopx_cli_event_v0","event_kind":"%s","goal_id":"%s","todo_id":"%s","agent_id":"%s","raw_logs_recorded":false,"raw_task_text_recorded":false,"raw_verifier_output_recorded":false,"raw_agent_trajectory_recorded":false,"local_paths_recorded":false}}\\n' "$kind" "$GOAL_ID" "$TODO_ID" "$AGENT_ID" >> "$EVENT_LOG"
-}}
-
-if [ "${{1:-}}" = "--format" ]; then
-  shift
-  [ "${{1:-}}" = "json" ] && shift || true
-fi
-
-cmd="${{1:-}}"
-[ "$#" -gt 0 ] && shift || true
-
-case "$cmd" in
-  check)
-    record_event check
-    cat <<JSON
-{{"ok":true,"goal_id":"$GOAL_ID","scan_path_public":true,"raw_logs_recorded":false}}
-JSON
-    ;;
-  status)
-    record_event status
-    cat <<JSON
-{{"ok":true,"goal_id":"$GOAL_ID","status":"active","active_state_path":"$STATE_FILE","agent_todo_summary":{{"open_count":1,"items":[{{"todo_id":"$TODO_ID","priority":"P0","status":"open","task_class":"advancement_task","claimed_by":"$AGENT_ID"}}]}},"raw_logs_recorded":false,"local_paths_recorded":false}}
-JSON
-    ;;
-  history)
-    record_event history
-    cat <<JSON
-{{"ok":true,"goal_id":"$GOAL_ID","events_public_counts_only":true,"raw_logs_recorded":false,"raw_task_text_recorded":false}}
-JSON
-    ;;
-  refresh-state)
-    record_event refresh_state
-    cat <<JSON
-{{"ok":true,"goal_id":"$GOAL_ID","refreshed":true,"raw_logs_recorded":false}}
-JSON
-    ;;
-  quota)
-    sub="${{1:-}}"
-    [ "$#" -gt 0 ] && shift || true
-    case "$sub" in
-      should-run)
-        record_event quota_should_run
-        cat <<JSON
-{{"ok":true,"goal_id":"$GOAL_ID","agent_id":"$AGENT_ID","should_run":true,"decision":"run","interaction_contract":{{"user_channel":{{"action_required":false,"open_count":0}}}},"agent_lane_next_action":{{"todo_id":"$TODO_ID","priority":"P0","status":"open","task_class":"advancement_task","claimed_by":"$AGENT_ID"}},"raw_logs_recorded":false}}
-JSON
-        ;;
-      spend-slot|spend)
-        record_event quota_spend
-        cat <<JSON
-{{"ok":true,"goal_id":"$GOAL_ID","spent":true,"raw_logs_recorded":false}}
-JSON
-        ;;
-      *)
-        echo "unsupported quota subcommand: $sub" >&2
-        exit 2
-        ;;
-    esac
-    ;;
-  todo)
-    sub="${{1:-}}"
-    [ "$#" -gt 0 ] && shift || true
-    case "$sub" in
-      claim)
-        record_event todo_claim
-        cat <<JSON
-{{"ok":true,"goal_id":"$GOAL_ID","todo_id":"$TODO_ID","claimed_by":"$AGENT_ID","status":"claimed","raw_logs_recorded":false}}
-JSON
-        ;;
-      update)
-        record_event todo_update
-        cat <<JSON
-{{"ok":true,"goal_id":"$GOAL_ID","todo_id":"$TODO_ID","status":"updated","raw_logs_recorded":false}}
-JSON
-        ;;
-      *)
-        echo "unsupported todo subcommand: $sub" >&2
-        exit 2
-        ;;
-    esac
-    ;;
-  *)
-    echo "unsupported loopx case CLI command: $cmd" >&2
-    exit 2
-    ;;
-esac
-"""
-    delimiter = "__LOOPX_BENCHMARK_CASE_CLI_EOF__"
-    while delimiter in script:
-        delimiter += "_"
-    install_event = (
-        '{"schema_version":"benchmark_case_loopx_cli_event_v0",'
-        '"event_kind":"install","raw_logs_recorded":false,'
-        '"raw_task_text_recorded":false,"raw_verifier_output_recorded":false,'
-        '"raw_agent_trajectory_recorded":false,"local_paths_recorded":false}'
+    runtime_root = shlex.quote(case_runtime_root)
+    installer_url = shlex.quote(BENCHMARK_CASE_LOOPX_OFFICIAL_INSTALLER_URL)
+    todo_text = shlex.quote(case_todo_text)
+    bootstrap_cmd = (
+        f"{cli_prefix} bootstrap "
+        f"--project {project_root} "
+        f"--goal-id {shlex.quote(goal_id)} "
+        f"--objective {shlex.quote('Solve the current benchmark case using LoopX product-mode lifecycle.')} "
+        "--domain benchmark "
+        f"--state-file {shlex.quote(case_state_path)} "
+        f"--goal-doc {shlex.quote(case_goal_doc_path)} "
+        "--adapter-kind benchmark_case_loopx_product_mode_v0 "
+        "--adapter-status connected "
+        "--no-onboarding-scan "
+        "--force "
+        "--no-global-sync"
+    )
+    configure_cmd = (
+        f"{cli_prefix} configure-goal "
+        f"--goal-id {shlex.quote(goal_id)} "
+        f"--registered-agent {shlex.quote(case_agent_id)} "
+        f"--primary-agent {shlex.quote(case_agent_id)} "
+        "--execute"
+    )
+    todo_add_cmd = (
+        f"{cli_prefix} todo add "
+        f"--goal-id {shlex.quote(goal_id)} "
+        "--role agent "
+        f"--text {todo_text} "
+        "--task-class advancement_task "
+        "--action-kind solve_benchmark_case"
+    )
+    quota_cmd = (
+        f"{cli_prefix} quota should-run "
+        f"--goal-id {shlex.quote(goal_id)} "
+        f"--agent-id {shlex.quote(case_agent_id)}"
+    )
+    refresh_cmd = (
+        f"{cli_prefix} refresh-state "
+        f"--goal-id {shlex.quote(goal_id)} "
+        "--classification benchmark_case_lifecycle_initialized "
+        "--delivery-batch-scale single_surface "
+        "--delivery-outcome surface_only "
+        "--no-global-sync"
+    )
+    expected_todo_comment = (
+        f"# expected stable case todo id: {shlex.quote(case_todo_id)}"
     )
     return (
-        f"{state_write} && "
-        f"mkdir -p {cli_parent} {case_dir} && "
-        f"cat > {cli_target} <<'{delimiter}'\n"
-        f"{script}"
-        f"{delimiter}\n"
-        f"chmod +x {cli_target} && "
-        f": > {event_log_target} && "
-        f"printf '%s\\n' {shlex.quote(install_event)} >> {event_log_target} && "
-        f"test -x {cli_target} && "
-        f"test -s {shlex.quote(case_state_path)}"
+        "set -eu\n"
+        "echo 'loopx_case_init_phase:prepare_paths' >&2\n"
+        f"export HOME={home}\n"
+        f"export PATH={shlex.quote(posixpath.dirname(case_cli_path.rstrip('/')))}:$PATH\n"
+        f"mkdir -p {cli_parent} {registry_parent} {runtime_root} {project_root}\n"
+        "echo 'loopx_case_init_phase:ensure_cli' >&2\n"
+        f"if [ ! -x {cli_target} ]; then\n"
+        f"  if [ -n {shlex.quote(source_path_value)} ]; then\n"
+        f"    if [ ! -x {source_path}/scripts/install-local.sh ]; then\n"
+        "      echo 'LoopX local source install requested but scripts/install-local.sh is missing' >&2\n"
+        "      exit 127\n"
+        "    fi\n"
+        f"    LOOPX_BIN_DIR={cli_parent} LOOPX_INSTALL_CANARY=0 LOOPX_INSTALL_SKILL=0 LOOPX_SHELL_PROFILE={shlex.quote(case_home.rstrip('/') + '/.loopx-install-profile')} HOME={home} {source_path}/scripts/install-local.sh >/dev/null\n"
+        "  elif command -v loopx >/dev/null 2>&1; then\n"
+        f"    ln -sf \"$(command -v loopx)\" {cli_target}\n"
+        "  elif command -v curl >/dev/null 2>&1; then\n"
+        f"    curl -fsSL {installer_url} | HOME={home} bash\n"
+        "  else\n"
+        "    echo 'LoopX CLI unavailable and curl is missing for official install' >&2\n"
+        "    exit 127\n"
+        "  fi\n"
+        "fi\n"
+        f"test -x {cli_target}\n"
+        "echo 'loopx_case_init_phase:write_goal_doc' >&2\n"
+        f"{goal_doc_write}\n"
+        f"{expected_todo_comment}\n"
+        "echo 'loopx_case_init_phase:bootstrap' >&2\n"
+        f"{bootstrap_cmd}\n"
+        "echo 'loopx_case_init_phase:configure_goal' >&2\n"
+        f"{configure_cmd}\n"
+        "echo 'loopx_case_init_phase:todo_add' >&2\n"
+        f"{todo_add_cmd}\n"
+        "echo 'loopx_case_init_phase:quota_should_run' >&2\n"
+        f"{quota_cmd}\n"
+        "echo 'loopx_case_init_phase:refresh_state' >&2\n"
+        f"{refresh_cmd}\n"
+        "echo 'loopx_case_init_phase:verify_state' >&2\n"
+        f"test -s {shlex.quote(case_state_path)}\n"
+        "echo 'loopx_case_init_phase:grant_agent_access' >&2\n"
+        "chmod -R a+rwX /app/.codex /app/.loopx /app/.local 2>/dev/null || true\n"
+        "echo 'loopx_case_init_phase:complete' >&2\n"
     )
 
 
@@ -449,6 +585,7 @@ def benchmark_case_loopx_install_payload(
     route: str,
     max_rounds: int,
     case_cli_path: str = BENCHMARK_CASE_LOOPX_CLI_PATH,
+    case_loopx_source_path: str | None = None,
     case_agent_id: str = BENCHMARK_CASE_LOOPX_AGENT_ID,
     case_todo_id: str = BENCHMARK_CASE_LOOPX_TODO_ID,
 ) -> dict[str, object]:
@@ -476,27 +613,57 @@ def benchmark_case_loopx_install_payload(
         "install_flow_schema_version": (
             BENCHMARK_CASE_LOOPX_INSTALL_FLOW_SCHEMA_VERSION
         ),
+        "lifecycle_driver_schema_version": (
+            BENCHMARK_CASE_LIFECYCLE_DRIVER_SCHEMA_VERSION
+        ),
+        "formal_treatment_semantics": BENCHMARK_CASE_LOOPX_FORMAL_TREATMENT_SEMANTICS,
+        "canonical_product_mode_lifecycle_driver": True,
+        "execution_style": BENCHMARK_CASE_LOOPX_PROMPT_DRIVEN_EXECUTION_STYLE,
+        "supported_execution_styles": list(BENCHMARK_CASE_LOOPX_EXECUTION_STYLES),
         "benchmark_case_goal_id": goal_id,
         "case_state_path": case_state_path,
+        "case_registry_path": BENCHMARK_CASE_LOOPX_REGISTRY_PATH,
+        "case_runtime_root": BENCHMARK_CASE_LOOPX_RUNTIME_ROOT,
+        "case_goal_doc_path": BENCHMARK_CASE_LOOPX_GOAL_DOC_PATH,
         "case_cli_path": case_cli_path,
+        "case_loopx_source_path": case_loopx_source_path or "",
+        "case_loopx_source_path_recorded": False,
+        "case_loopx_source_install_requested": bool(case_loopx_source_path),
         "case_rollout_event_log_path": case_rollout_event_log_path,
         "case_agent_id": case_agent_id,
         "case_todo_id": case_todo_id,
+        "case_todo_text_public_safe": BENCHMARK_CASE_LOOPX_TODO_TEXT,
         "case_todo_seeded": True,
+        "case_todo_preclaimed": False,
+        "case_todo_seeded_by": "loopx todo add",
         "install_flow_required": True,
         "prompt_driven_route_required": True,
         "product_path_primary_route": (
             BENCHMARK_CASE_LOOPX_PRODUCT_PATH_PRIMARY_ROUTE
         ),
+        "host_claims_case_todo_before_agent": False,
+        "agent_must_claim_selected_case_todo": True,
         "scheduler_route_supported": True,
         "scheduler_route": BENCHMARK_CASE_LOOPX_SCHEDULER_ROUTE,
+        "workflow_orchestrated_route_supported": True,
+        "workflow_orchestrated_route": (
+            BENCHMARK_CASE_LOOPX_ORCHESTRATED_EXECUTION_STYLE
+        ),
         "command": benchmark_case_loopx_install_command(
+            benchmark_id=benchmark_id,
+            case_id=case_id,
+            route=route,
+            max_rounds=max_rounds,
             goal_id=goal_id,
             case_state_path=case_state_path,
             content=seed,
             case_cli_path=case_cli_path,
-            case_rollout_event_log_path=case_rollout_event_log_path,
+            case_loopx_source_path=case_loopx_source_path,
+            case_registry_path=BENCHMARK_CASE_LOOPX_REGISTRY_PATH,
+            case_runtime_root=BENCHMARK_CASE_LOOPX_RUNTIME_ROOT,
+            case_goal_doc_path=BENCHMARK_CASE_LOOPX_GOAL_DOC_PATH,
             case_agent_id=case_agent_id,
+            case_todo_text=BENCHMARK_CASE_LOOPX_TODO_TEXT,
             case_todo_id=case_todo_id,
         ),
         "raw_task_text_required_for_init": False,

--- a/loopx/benchmark_trajectory.py
+++ b/loopx/benchmark_trajectory.py
@@ -10,7 +10,7 @@ from typing import Any
 PUBLIC_TRAJECTORY_SUMMARY_SCHEMA_VERSION = "public_trajectory_summary_v0"
 
 SANDBOX_PATH_RE = re.compile(r"/(?:app|root|workspace|tmp)/[A-Za-z0-9_./-]+")
-LOOPX_CLI_RE = re.compile(r"(?:^|\s)loopx(?:\s|$)")
+LOOPX_CLI_RE = re.compile(r"(?:^|\s|/)loopx(?:\s|$)")
 SHELL_EDIT_RE = re.compile(
     r"(?i)(?:apply_patch|perl\b.*\s-[0-9a-z]*p|sed\b.*\s-i|"
     r"python\b[\s\S]*(?:write_text|open\(.+['\"]w|Path\(.+\)\.write)|"
@@ -45,6 +45,9 @@ LOOPX_WRITE_COMMANDS = {
     "reward",
     "sync-global",
 }
+LOOPX_QUOTA_WRITE_ACTIONS = {
+    "spend-slot",
+}
 LOOPX_TODO_WRITE_ACTIONS = {
     "add",
     "archive-completed",
@@ -57,6 +60,11 @@ LOOPX_BENCHMARK_WRITE_ACTIONS = {
 }
 LOOPX_CONTEXT_COMMANDS = {
     ("which", "goal"),
+}
+LOOPX_FLAG_VALUE_OPTIONS = {
+    "--format",
+    "--registry",
+    "--runtime-root",
 }
 
 
@@ -138,9 +146,16 @@ def normalized_loopx_cli_call(
     after = tokens[command_index + 1 :] if command_index >= 0 else []
     subcommands: list[str] = []
     flags: list[str] = []
+    skip_next = False
     for token in after:
+        if skip_next:
+            skip_next = False
+            continue
         if token.startswith("--"):
-            flags.append(token.split("=", 1)[0][:60])
+            flag = token.split("=", 1)[0][:60]
+            flags.append(flag)
+            if "=" not in token and flag in LOOPX_FLAG_VALUE_OPTIONS:
+                skip_next = True
             continue
         if token.startswith("-"):
             flags.append(token[:20])
@@ -173,6 +188,8 @@ def loopx_cli_state_usage(call: dict[str, Any]) -> str:
         return "context_lookup"
     primary = normalized[0] if normalized else ""
     secondary = normalized[1] if len(normalized) > 1 else ""
+    if primary == "quota" and secondary in LOOPX_QUOTA_WRITE_ACTIONS:
+        return "state_write"
     if primary == "todo":
         return "state_write" if secondary in LOOPX_TODO_WRITE_ACTIONS else "state_read"
     if primary == "benchmark" and secondary in LOOPX_BENCHMARK_WRITE_ACTIONS:

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -509,6 +509,7 @@ def _compact_benchmark_interaction_counters(value: Any) -> dict[str, Any]:
         "case_goal_state_init_required",
         "case_goal_state_initialized_before_agent",
         "declared_done_requires_no_remaining_goals",
+        "product_mode_lifecycle_checkpoint_required",
         "agent_declared_done",
         "agent_declared_no_remaining_goals",
         "official_feedback_blinded",
@@ -516,6 +517,14 @@ def _compact_benchmark_interaction_counters(value: Any) -> dict[str, Any]:
         "controller_official_feedback_forwarded",
         "controller_blind_loop",
         "controller_official_success_observed",
+        "controller_budget_cutoff_before_followup",
+        "benchflow_user_loop_final_verify_recovery_enabled",
+        "benchflow_user_loop_final_verify_recovery_triggered",
+        "benchflow_user_loop_recovery_after_agent_activity",
+        "benchflow_user_loop_recovery_preserved_final_verify",
+        "benchflow_user_loop_recovery_raw_error_recorded",
+        "benchflow_intermediate_soft_verify_final_only",
+        "benchflow_intermediate_soft_verify_raw_output_recorded",
         "private_trajectory_summary_present",
         "native_goal_worker_route",
         "native_goal_worker_connected",
@@ -540,9 +549,16 @@ def _compact_benchmark_interaction_counters(value: Any) -> dict[str, Any]:
         "controller_official_success_observation_count",
         "controller_first_success_round",
         "declared_done_round",
+        "product_mode_lifecycle_checkpoint_count",
+        "product_mode_lifecycle_checkpoint_round",
         "controller_verifier_feedback_observation_count",
         "controller_official_feedback_blinded_count",
         "controller_max_rounds_budget",
+        "benchflow_user_loop_recovery_round",
+        "benchflow_user_loop_recovery_delta_events",
+        "benchflow_user_loop_recovery_delta_tool_calls",
+        "benchflow_intermediate_soft_verify_call_count",
+        "benchflow_intermediate_soft_verify_skipped_count",
         "private_trajectory_event_count",
         "private_trajectory_round_count",
         "private_trajectory_tool_call_count",
@@ -589,7 +605,13 @@ def _compact_benchmark_interaction_counters(value: Any) -> dict[str, Any]:
         "controller_trace_schema_version",
         "controller_trace_publicness",
         "case_goal_state_init_status",
+        "case_goal_state_init_failed_phase",
         "case_goal_state_schema_version",
+        "product_mode_lifecycle_checkpoint_missing_reason",
+        "controller_budget_cutoff_reason",
+        "benchflow_user_loop_recovery_stage",
+        "benchflow_user_loop_recovery_exception_type",
+        "benchflow_intermediate_soft_verify_policy",
         "last_decision",
         "worker_submit_eligible_mismatch_reason",
         "worker_bridge_writeback_loss_reason",
@@ -903,9 +925,16 @@ def _compact_benchmark_runner_prerequisites(value: Any) -> dict[str, Any]:
         "codex_acp_runtime_launch_preflight_stage",
         "codex_acp_runtime_launch_preflight_status",
         "agent_execution_mode",
+        "benchflow_run_stage",
         "benchflow_agent_runtime_layer_status",
         "benchflow_agent_runtime_layer_mount_target",
+        "loopx_source_mount_status",
+        "loopx_source_mount_target",
         "codex_app_server_goal_worker_plan_schema",
+        "benchflow_user_loop_recovery_exception_type",
+        "benchflow_user_loop_recovery_stage",
+        "benchflow_intermediate_soft_verify_policy",
+        "benchflow_setup_stall_cleanup_status",
     ):
         text = public_safe_compact_text(value.get(field), limit=180)
         if text:
@@ -929,10 +958,50 @@ def _compact_benchmark_runner_prerequisites(value: Any) -> dict[str, Any]:
         "codex_app_server_goal_worker_turn_start_required",
         "codex_app_server_goal_worker_goal_get_required",
         "codex_app_server_goal_worker_runner_integration_ready",
+        "benchflow_user_loop_final_verify_recovery_enabled",
+        "benchflow_user_loop_final_verify_recovery_triggered",
+        "benchflow_user_loop_recovery_after_agent_activity",
+        "benchflow_user_loop_recovery_raw_error_recorded",
+        "benchflow_user_loop_recovery_preserved_final_verify",
+        "benchflow_intermediate_soft_verify_final_only",
+        "benchflow_intermediate_soft_verify_raw_output_recorded",
+        "benchflow_verifier_prep_timeout_override_enabled",
+        "benchflow_verifier_prep_timeout_raw_command_recorded",
+        "loopx_source_mount_requested",
+        "loopx_source_mount_ready",
+        "loopx_source_mount_injected",
+        "loopx_source_mount_read_only",
+        "loopx_source_mount_source_recorded",
+        "benchflow_setup_stall_timeout_enabled",
+        "benchflow_setup_stall_timeout_triggered",
+        "benchflow_setup_stall_raw_logs_read",
+        "benchflow_setup_stall_before_agent_lifecycle",
+        "benchflow_agent_install_started",
+        "benchflow_setup_stall_task_cancel_requested",
+        "benchflow_setup_stall_task_cancel_acknowledged",
+        "benchflow_setup_stall_task_cancel_timeout",
+        "benchflow_setup_stall_cleanup_requested",
+        "benchflow_setup_stall_cleanup_raw_logs_read",
     ):
         if isinstance(value.get(field), bool):
             compact[field] = value[field]
-    for field in ("codex_acp_runtime_launch_preflight_rc",):
+    for field in (
+        "codex_acp_runtime_launch_preflight_rc",
+        "benchflow_user_loop_recovery_round",
+        "benchflow_user_loop_recovery_delta_events",
+        "benchflow_user_loop_recovery_delta_tool_calls",
+        "benchflow_intermediate_soft_verify_call_count",
+        "benchflow_intermediate_soft_verify_skipped_count",
+        "benchflow_verifier_prep_timeout_sec",
+        "benchflow_verifier_prep_timeout_override_count",
+        "benchflow_verify_prep_timeout_override_count",
+        "benchflow_soft_verify_prep_timeout_override_count",
+        "benchflow_setup_stall_timeout_sec",
+        "benchflow_setup_stall_cleanup_match_count",
+        "benchflow_setup_stall_cleanup_term_sent_count",
+        "benchflow_setup_stall_cleanup_kill_sent_count",
+        "benchflow_setup_stall_cleanup_alive_after_count",
+    ):
         if isinstance(value.get(field), int) and not isinstance(value.get(field), bool):
             compact[field] = value[field]
     return compact
@@ -2284,6 +2353,54 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
         ):
             if isinstance(runner_failure.get(field), bool):
                 compact_runner_failure[field] = runner_failure[field]
+        controller_cutoff = runner_failure.get("controller_cutoff")
+        if isinstance(controller_cutoff, dict):
+            compact_cutoff: dict[str, Any] = {}
+            for field in ("schema_version", "reason"):
+                value = public_safe_compact_text(
+                    controller_cutoff.get(field),
+                    limit=140,
+                )
+                if value:
+                    compact_cutoff[field] = value
+            if isinstance(controller_cutoff.get("cutoff_before_followup"), bool):
+                compact_cutoff["cutoff_before_followup"] = controller_cutoff[
+                    "cutoff_before_followup"
+                ]
+            for field in (
+                "max_rounds_budget",
+                "initial_prompt_count",
+                "followup_prompt_count",
+                "stop_decision_count",
+            ):
+                if isinstance(controller_cutoff.get(field), int) and not isinstance(
+                    controller_cutoff.get(field),
+                    bool,
+                ):
+                    compact_cutoff[field] = controller_cutoff[field]
+            if compact_cutoff:
+                compact_runner_failure["controller_cutoff"] = compact_cutoff
+        user_loop_recovery = runner_failure.get("user_loop_recovery")
+        if isinstance(user_loop_recovery, dict):
+            compact_recovery: dict[str, Any] = {}
+            for field in ("schema_version", "stage", "exception_type"):
+                value = public_safe_compact_text(
+                    user_loop_recovery.get(field),
+                    limit=140,
+                )
+                if value:
+                    compact_recovery[field] = value
+            for field in ("preserved_final_verify", "raw_error_recorded"):
+                if isinstance(user_loop_recovery.get(field), bool):
+                    compact_recovery[field] = user_loop_recovery[field]
+            for field in ("round", "delta_events", "delta_tool_calls"):
+                if isinstance(user_loop_recovery.get(field), int) and not isinstance(
+                    user_loop_recovery.get(field),
+                    bool,
+                ):
+                    compact_recovery[field] = user_loop_recovery[field]
+            if compact_recovery:
+                compact_runner_failure["user_loop_recovery"] = compact_recovery
         if compact_runner_failure:
             compact["runner_failure"] = compact_runner_failure
 

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -54,6 +54,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import contextlib
+import importlib
 import inspect
 import json
 import logging
@@ -61,9 +62,11 @@ import os
 import re
 import shlex
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
+import time
 from contextlib import redirect_stderr, redirect_stdout
 from datetime import datetime
 from pathlib import Path
@@ -74,6 +77,11 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 from loopx.benchmark_case_state import (  # noqa: E402
     BENCHMARK_CASE_ACTIVE_STATE_SCHEMA_VERSION,
+    BENCHMARK_CASE_LOOPX_AGENT_ID,
+    BENCHMARK_CASE_LOOPX_TODO_ID,
+    BENCHMARK_CASE_LOOPX_SOURCE_MOUNT_TARGET,
+    benchmark_case_loopx_command_prefix,
+    benchmark_case_loopx_install_payload,
     benchmark_case_active_state_path,
     benchmark_case_active_state_seed_text,
     benchmark_case_active_state_write_command,
@@ -114,7 +122,9 @@ DEFAULT_LEDGER = (
 DEFAULT_GOAL_ID = "loopx-meta"
 DEFAULT_MODEL = "gpt-5.5"
 DEFAULT_TIMEOUT_SEC = 7200
-DEFAULT_MAX_ROUNDS = BLIND_LOOP_DEFAULT_MAX_ROUNDS
+DEFAULT_VERIFIER_PREP_TIMEOUT_SEC = 120
+DEFAULT_PRODUCT_MODE_SOFT_VERIFY_POLICY = "final-only"
+DEFAULT_MAX_ROUNDS = 8
 _MISSING = object()
 SUPPORTED_ROUTES = (
     CODEX_ACP_BLIND_LOOP_BASELINE_ROUTE,
@@ -140,6 +150,15 @@ PRODUCT_MODE_CASE_STATE_PATH = benchmark_case_active_state_path(
     PRODUCT_MODE_CASE_GOAL_ID
 )
 PRODUCT_MODE_CASE_STATE_SCHEMA_VERSION = BENCHMARK_CASE_ACTIVE_STATE_SCHEMA_VERSION
+
+
+def product_mode_soft_verify_policy_for_route(
+    route: str,
+    requested_policy: str,
+) -> str:
+    if route in {"raw-codex-autonomous-max5", "loopx-product-mode"}:
+        return requested_policy
+    return "every-round"
 
 
 def _filter_kwargs_for_signature(
@@ -176,7 +195,12 @@ DOCKER_CODEX_ACP_RUNTIME_TOOLS_END = (
 )
 DOCKER_HOST_CPU_ENV = "LOOPX_SKILLSBENCH_DOCKER_CPUS"
 SANDBOX_PATH_RE = re.compile(r"/(?:app|root|workspace|tmp)/[A-Za-z0-9_./-]+")
-LOOPX_CLI_RE = re.compile(r"(?:^|\s)loopx(?:\s|$)")
+LOOPX_CLI_RE = re.compile(r"(?:^|\s|/)loopx(?:\s|$)")
+LOOPX_FLAG_VALUE_OPTIONS = {
+    "--format",
+    "--registry",
+    "--runtime-root",
+}
 SHELL_EDIT_RE = re.compile(
     r"(?i)(?:apply_patch|perl\b.*\s-[0-9a-z]*p|sed\b.*\s-i|"
     r"python\b.*(?:write_text|open\(.+['\"]w|Path\(.+\)\.write)|"
@@ -730,6 +754,59 @@ def _benchflow_agent_runtime_mounts(
     ]
 
 
+def _loopx_source_mount_contract(args: argparse.Namespace) -> dict[str, Any]:
+    source_arg = getattr(args, "loopx_source_dir", None)
+    source_dir = Path(str(source_arg)).expanduser() if source_arg else None
+    disabled = bool(getattr(args, "no_loopx_source_mount", False))
+    requested = (
+        args.route == LOOPX_PRODUCT_MODE_ROUTE
+        and args.sandbox == "docker"
+        and not disabled
+        and source_dir is not None
+    )
+    ready = bool(
+        requested
+        and source_dir is not None
+        and (source_dir / "scripts" / "install-local.sh").exists()
+        and (source_dir / "loopx" / "cli.py").exists()
+    )
+    status = "not_requested"
+    if requested:
+        status = "ready" if ready else "missing_local_source_files"
+    return {
+        "schema_version": "skillsbench_loopx_source_mount_contract_v0",
+        "requested": requested,
+        "ready": ready,
+        "status": status,
+        "source_path_recorded": False,
+        "mount_target": BENCHMARK_CASE_LOOPX_SOURCE_MOUNT_TARGET,
+        "read_only": True,
+        "first_blocker": "" if ready or not requested else "missing_loopx_source_mount",
+    }
+
+
+def _loopx_source_mounts(args: argparse.Namespace) -> list[dict[str, Any]]:
+    contract = _loopx_source_mount_contract(args)
+    if not contract.get("requested"):
+        return []
+    source_dir = Path(str(args.loopx_source_dir)).expanduser()
+    return [
+        {
+            "type": "bind",
+            "source": str(source_dir),
+            "target": BENCHMARK_CASE_LOOPX_SOURCE_MOUNT_TARGET,
+            "read_only": True,
+        }
+    ]
+
+
+def _loopx_case_source_path_for_container(args: argparse.Namespace) -> str | None:
+    contract = _loopx_source_mount_contract(args)
+    if contract.get("ready"):
+        return BENCHMARK_CASE_LOOPX_SOURCE_MOUNT_TARGET
+    return None
+
+
 def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
     if not isinstance(value, dict):
         return {}
@@ -738,6 +815,7 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
     for field in (
         "schema_version",
         "agent_execution_mode",
+        "benchflow_run_stage",
         "host_local_acp_launch_status",
         "host_local_acp_install_stage",
         "host_local_acp_install_failed_stage",
@@ -745,7 +823,13 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "codex_acp_runtime_launch_preflight_status",
         "benchflow_agent_runtime_layer_status",
         "benchflow_agent_runtime_layer_mount_target",
+        "loopx_source_mount_status",
+        "loopx_source_mount_target",
         "codex_app_server_goal_worker_plan_schema",
+        "benchflow_user_loop_recovery_exception_type",
+        "benchflow_user_loop_recovery_stage",
+        "benchflow_intermediate_soft_verify_policy",
+        "benchflow_setup_stall_cleanup_status",
     ):
         raw = value.get(field)
         if isinstance(raw, str) and raw:
@@ -765,17 +849,558 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "benchflow_agent_runtime_mount_injected",
         "benchflow_agent_runtime_mount_read_only",
         "benchflow_agent_runtime_mount_source_recorded",
+        "loopx_source_mount_requested",
+        "loopx_source_mount_ready",
+        "loopx_source_mount_injected",
+        "loopx_source_mount_read_only",
+        "loopx_source_mount_source_recorded",
+        "benchflow_agent_timeout_overridden",
         "codex_app_server_goal_worker_adapter_present",
         "codex_app_server_goal_worker_turn_start_required",
         "codex_app_server_goal_worker_goal_get_required",
         "codex_app_server_goal_worker_runner_integration_ready",
+        "benchflow_user_loop_final_verify_recovery_enabled",
+        "benchflow_user_loop_final_verify_recovery_triggered",
+        "benchflow_user_loop_recovery_after_agent_activity",
+        "benchflow_user_loop_recovery_raw_error_recorded",
+        "benchflow_user_loop_recovery_preserved_final_verify",
+        "benchflow_intermediate_soft_verify_final_only",
+        "benchflow_intermediate_soft_verify_raw_output_recorded",
+        "benchflow_verifier_prep_timeout_override_enabled",
+        "benchflow_verifier_prep_timeout_raw_command_recorded",
+        "benchflow_setup_stall_timeout_enabled",
+        "benchflow_setup_stall_timeout_triggered",
+        "benchflow_setup_stall_raw_logs_read",
+        "benchflow_setup_stall_before_agent_lifecycle",
+        "benchflow_agent_install_started",
+        "benchflow_setup_stall_task_cancel_requested",
+        "benchflow_setup_stall_task_cancel_acknowledged",
+        "benchflow_setup_stall_task_cancel_timeout",
+        "benchflow_setup_stall_cleanup_requested",
+        "benchflow_setup_stall_cleanup_raw_logs_read",
     ):
         if isinstance(value.get(field), bool):
             compact[field] = value[field]
-    for field in ("codex_acp_runtime_launch_preflight_rc",):
+    for field in (
+        "codex_acp_runtime_launch_preflight_rc",
+        "benchflow_agent_timeout_original_sec",
+        "benchflow_agent_timeout_effective_sec",
+        "benchflow_user_loop_recovery_round",
+        "benchflow_user_loop_recovery_delta_events",
+        "benchflow_user_loop_recovery_delta_tool_calls",
+        "benchflow_intermediate_soft_verify_call_count",
+        "benchflow_intermediate_soft_verify_skipped_count",
+        "benchflow_verifier_prep_timeout_sec",
+        "benchflow_verifier_prep_timeout_override_count",
+        "benchflow_verify_prep_timeout_override_count",
+        "benchflow_soft_verify_prep_timeout_override_count",
+        "benchflow_setup_stall_timeout_sec",
+        "benchflow_setup_stall_cleanup_match_count",
+        "benchflow_setup_stall_cleanup_term_sent_count",
+        "benchflow_setup_stall_cleanup_kill_sent_count",
+        "benchflow_setup_stall_cleanup_alive_after_count",
+    ):
         if isinstance(value.get(field), int) and not isinstance(value.get(field), bool):
             compact[field] = value[field]
     return compact
+
+
+def cleanup_benchflow_setup_stall_children(
+    plan: dict[str, Any],
+    *,
+    grace_seconds: float = 5.0,
+) -> dict[str, Any]:
+    """Terminate docker compose/buildx processes scoped to this SkillsBench run."""
+
+    prerequisites = plan.setdefault("runner_prerequisites", {})
+    cleanup: dict[str, Any] = {
+        "schema_version": "skillsbench_setup_stall_process_cleanup_v0",
+        "requested": True,
+        "raw_logs_read": False,
+        "status": "not_attempted",
+        "match_count": 0,
+        "term_sent_count": 0,
+        "kill_sent_count": 0,
+        "alive_after_count": 0,
+    }
+
+    def publish() -> dict[str, Any]:
+        prerequisites["benchflow_setup_stall_cleanup_requested"] = True
+        prerequisites["benchflow_setup_stall_cleanup_raw_logs_read"] = False
+        prerequisites["benchflow_setup_stall_cleanup_status"] = str(
+            cleanup.get("status") or "unknown"
+        )
+        for source, target in (
+            ("match_count", "benchflow_setup_stall_cleanup_match_count"),
+            ("term_sent_count", "benchflow_setup_stall_cleanup_term_sent_count"),
+            ("kill_sent_count", "benchflow_setup_stall_cleanup_kill_sent_count"),
+            ("alive_after_count", "benchflow_setup_stall_cleanup_alive_after_count"),
+        ):
+            value = cleanup.get(source)
+            if isinstance(value, int):
+                prerequisites[target] = value
+        return cleanup
+
+    if os.name != "posix":
+        cleanup["status"] = "unsupported_platform"
+        return publish()
+
+    job_name = str(plan.get("job_name") or "").strip()
+    rollout_name = str(plan.get("rollout_name") or "").strip()
+    if not job_name or not rollout_name:
+        cleanup["status"] = "missing_run_identifiers"
+        return publish()
+
+    try:
+        proc = subprocess.run(
+            ["ps", "-eo", "pid=,ppid=,command="],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        cleanup["status"] = "process_table_unavailable"
+        return publish()
+    if proc.returncode != 0:
+        cleanup["status"] = "process_table_unavailable"
+        return publish()
+
+    entries: dict[int, tuple[int, str]] = {}
+    children: dict[int, set[int]] = {}
+    for line in proc.stdout.splitlines():
+        parts = line.strip().split(maxsplit=2)
+        if len(parts) < 3:
+            continue
+        try:
+            pid = int(parts[0])
+            ppid = int(parts[1])
+        except ValueError:
+            continue
+        command = parts[2]
+        entries[pid] = (ppid, command)
+        children.setdefault(ppid, set()).add(pid)
+
+    docker_tokens = (
+        "docker compose",
+        "docker-compose",
+        "docker-buildx",
+        "buildx bake",
+    )
+    root_matches = {
+        pid
+        for pid, (_ppid, command) in entries.items()
+        if pid != os.getpid()
+        and job_name in command
+        and rollout_name in command
+        and any(token in command for token in docker_tokens)
+    }
+    to_terminate = set(root_matches)
+    stack = list(root_matches)
+    while stack:
+        parent = stack.pop()
+        for child in children.get(parent, set()):
+            if child not in to_terminate and child != os.getpid():
+                to_terminate.add(child)
+                stack.append(child)
+
+    cleanup["match_count"] = len(to_terminate)
+    if not to_terminate:
+        cleanup["status"] = "no_matching_processes"
+        return publish()
+
+    def is_alive(pid: int) -> bool:
+        try:
+            os.kill(pid, 0)
+            return True
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return True
+
+    term_sent = 0
+    for pid in sorted(to_terminate, reverse=True):
+        try:
+            os.kill(pid, signal.SIGTERM)
+            term_sent += 1
+        except ProcessLookupError:
+            continue
+        except PermissionError:
+            continue
+    cleanup["term_sent_count"] = term_sent
+
+    deadline = time.monotonic() + max(0.0, grace_seconds)
+    alive = {pid for pid in to_terminate if is_alive(pid)}
+    while alive and time.monotonic() < deadline:
+        time.sleep(0.1)
+        alive = {pid for pid in alive if is_alive(pid)}
+
+    kill_sent = 0
+    if alive:
+        for pid in sorted(alive, reverse=True):
+            try:
+                os.kill(pid, signal.SIGKILL)
+                kill_sent += 1
+            except ProcessLookupError:
+                continue
+            except PermissionError:
+                continue
+        cleanup["kill_sent_count"] = kill_sent
+        time.sleep(0.1)
+        alive = {pid for pid in alive if is_alive(pid)}
+    cleanup["alive_after_count"] = len(alive)
+    if alive:
+        cleanup["status"] = "cleanup_incomplete"
+    elif kill_sent:
+        cleanup["status"] = "killed"
+    else:
+        cleanup["status"] = "terminated"
+    return publish()
+
+
+def install_benchflow_verifier_prep_timeout_override(
+    rollout_cls: Any,
+    *,
+    timeout_sec: int,
+    plan: dict[str, Any],
+    trace: dict[str, Any] | None,
+) -> tuple[Any, Any]:
+    """Raise verifier-phase prep exec timeouts without changing scoring."""
+
+    original_verify = rollout_cls.verify
+    original_soft_verify = rollout_cls.soft_verify
+    prerequisites = plan.setdefault("runner_prerequisites", {})
+    enabled = timeout_sec > 10
+    prerequisites["benchflow_verifier_prep_timeout_override_enabled"] = enabled
+    prerequisites["benchflow_verifier_prep_timeout_raw_command_recorded"] = False
+    if enabled:
+        prerequisites["benchflow_verifier_prep_timeout_sec"] = timeout_sec
+    if isinstance(trace, dict):
+        trace["benchflow_verifier_prep_timeout_override_enabled"] = enabled
+        trace["benchflow_verifier_prep_timeout_raw_command_recorded"] = False
+        if enabled:
+            trace["benchflow_verifier_prep_timeout_sec"] = timeout_sec
+
+    async def _run_with_override(self: Any, phase: str, original: Any) -> Any:
+        if not enabled:
+            return await original(self)
+
+        env = getattr(self, "_env", None)
+        original_exec = getattr(env, "exec", None) if env is not None else None
+        if original_exec is None:
+            return await original(self)
+
+        override_count = 0
+
+        async def exec_with_verifier_prep_timeout(*args: Any, **kwargs: Any) -> Any:
+            nonlocal override_count
+            if kwargs.get("timeout_sec") == 10:
+                kwargs = dict(kwargs)
+                kwargs["timeout_sec"] = timeout_sec
+                override_count += 1
+            return await original_exec(*args, **kwargs)
+
+        try:
+            env.exec = exec_with_verifier_prep_timeout
+            return await original(self)
+        finally:
+            env.exec = original_exec
+            phase_key = f"benchflow_{phase}_prep_timeout_override_count"
+            total_key = "benchflow_verifier_prep_timeout_override_count"
+            prerequisites[phase_key] = (
+                int(prerequisites.get(phase_key) or 0) + override_count
+            )
+            prerequisites[total_key] = (
+                int(prerequisites.get(total_key) or 0) + override_count
+            )
+            if isinstance(trace, dict):
+                trace[phase_key] = int(trace.get(phase_key) or 0) + override_count
+                trace[total_key] = int(trace.get(total_key) or 0) + override_count
+
+    async def verify_with_prep_timeout_override(self: Any) -> Any:
+        return await _run_with_override(self, "verify", original_verify)
+
+    async def soft_verify_with_prep_timeout_override(self: Any) -> Any:
+        return await _run_with_override(self, "soft_verify", original_soft_verify)
+
+    rollout_cls.verify = verify_with_prep_timeout_override
+    rollout_cls.soft_verify = soft_verify_with_prep_timeout_override
+    return original_verify, original_soft_verify
+
+
+def _mark_user_loop_final_verify_recovery(
+    *,
+    plan: dict[str, Any],
+    trace: dict[str, Any] | None,
+    stage: str,
+    round_num: int,
+    exception: Exception,
+    delta_events: int,
+    delta_tool_calls: int,
+) -> None:
+    prerequisites = plan.setdefault("runner_prerequisites", {})
+    prerequisites["benchflow_user_loop_final_verify_recovery_enabled"] = True
+    prerequisites["benchflow_user_loop_final_verify_recovery_triggered"] = True
+    prerequisites["benchflow_user_loop_recovery_after_agent_activity"] = True
+    prerequisites["benchflow_user_loop_recovery_preserved_final_verify"] = True
+    prerequisites["benchflow_user_loop_recovery_raw_error_recorded"] = False
+    prerequisites["benchflow_user_loop_recovery_stage"] = stage
+    prerequisites["benchflow_user_loop_recovery_exception_type"] = type(
+        exception
+    ).__name__
+    prerequisites["benchflow_user_loop_recovery_round"] = round_num
+    prerequisites["benchflow_user_loop_recovery_delta_events"] = max(0, delta_events)
+    prerequisites["benchflow_user_loop_recovery_delta_tool_calls"] = max(
+        0,
+        delta_tool_calls,
+    )
+    if isinstance(trace, dict):
+        trace["benchflow_user_loop_final_verify_recovery_enabled"] = True
+        trace["benchflow_user_loop_final_verify_recovery_triggered"] = True
+        trace["benchflow_user_loop_recovery_after_agent_activity"] = True
+        trace["benchflow_user_loop_recovery_preserved_final_verify"] = True
+        trace["benchflow_user_loop_recovery_raw_error_recorded"] = False
+        trace["benchflow_user_loop_recovery_stage"] = stage
+        trace["benchflow_user_loop_recovery_exception_type"] = type(exception).__name__
+        trace["benchflow_user_loop_recovery_round"] = round_num
+        trace["benchflow_user_loop_recovery_delta_events"] = max(0, delta_events)
+        trace["benchflow_user_loop_recovery_delta_tool_calls"] = max(
+            0,
+            delta_tool_calls,
+        )
+        trace["last_decision"] = "break_after_agent_round_preserve_final_verify"
+
+
+def install_benchflow_user_loop_final_verify_recovery(
+    rollout_cls: Any,
+    *,
+    plan: dict[str, Any],
+    trace: dict[str, Any] | None,
+    intermediate_soft_verify_policy: str = "every-round",
+) -> Any:
+    """Keep final official verify reachable after post-agent loop failures."""
+
+    original_user_loop = rollout_cls._run_user_loop
+    prerequisites = plan.setdefault("runner_prerequisites", {})
+    prerequisites["benchflow_user_loop_final_verify_recovery_enabled"] = True
+    if intermediate_soft_verify_policy not in {"every-round", "final-only"}:
+        raise ValueError(
+            "intermediate_soft_verify_policy must be 'every-round' or 'final-only'"
+        )
+    final_only_soft_verify = intermediate_soft_verify_policy == "final-only"
+    for target in (prerequisites, trace if isinstance(trace, dict) else None):
+        if target is None:
+            continue
+        target["benchflow_intermediate_soft_verify_policy"] = (
+            intermediate_soft_verify_policy
+        )
+        target["benchflow_intermediate_soft_verify_final_only"] = (
+            final_only_soft_verify
+        )
+        target["benchflow_intermediate_soft_verify_raw_output_recorded"] = False
+        target.setdefault("benchflow_intermediate_soft_verify_call_count", 0)
+        target.setdefault("benchflow_intermediate_soft_verify_skipped_count", 0)
+
+    def record_soft_verify_counter(key: str) -> None:
+        _inc_counter(prerequisites, key)
+        if isinstance(trace, dict):
+            _inc_counter(trace, key)
+
+    async def run_user_loop_with_final_verify_recovery(self: Any) -> None:
+        from benchflow.sandbox.user import RoundResult
+
+        cfg = self._config
+        user = cfg.user
+        assert user is not None
+
+        if len(cfg.effective_scenes) > 1:
+            raise ValueError(
+                "User-driven loops operate on a single scene. "
+                f"Got {len(cfg.effective_scenes)} scenes."
+            )
+        scene = cfg.effective_scenes[0]
+        if len(scene.roles) != 1:
+            raise ValueError(
+                "User-driven loops require a single-role scene. "
+                f"Got {len(scene.roles)} roles."
+            )
+        role = scene.roles[0]
+
+        instruction = (
+            self._resolved_prompts[0]
+            if self._resolved_prompts
+            else ("Solve the task described in /app/instruction.md")
+        )
+
+        solution: str | None = None
+        if cfg.oracle_access:
+            cat = await self._env.exec(
+                "cat /solution/solve.sh 2>/dev/null || true",
+                user="root",
+                timeout_sec=10,
+            )
+            solution = (cat.stdout or "").strip() or None
+
+        await user.setup(instruction, solution)
+
+        if cfg.oracle_access:
+            await self._env.exec(
+                "mv /solution /solution_oracle_backup 2>/dev/null || true",
+                user="root",
+                timeout_sec=10,
+            )
+
+        round_result: Any | None = None
+        rounds_log: list[dict[str, Any]] = []
+
+        for round_num in range(cfg.max_user_rounds):
+            try:
+                prompt = await user.run(round_num, instruction, round_result)
+            except Exception as exc:
+                self._error = f"user.run() failed at round {round_num}: {exc}"
+                logging.getLogger(__name__).error(self._error, exc_info=True)
+                break
+
+            if prompt is None:
+                logging.getLogger(__name__).info(
+                    "[User] stopped at round %s",
+                    round_num,
+                )
+                break
+
+            logging.getLogger(__name__).info(
+                "[User] round %s: prompt=%r...",
+                round_num,
+                prompt[:80],
+            )
+
+            traj_before = len(self._trajectory)
+            connected = False
+            try:
+                await self.connect_as(role)
+                connected = True
+                await self.execute(prompts=[prompt])
+            except Exception as exc:
+                delta_events = max(0, len(self._trajectory) - traj_before)
+                round_trajectory = self._trajectory[traj_before:]
+                delta_tool_calls = sum(
+                    1
+                    for event in round_trajectory
+                    if isinstance(event, dict) and event.get("type") == "tool_call"
+                )
+                if (not connected) or delta_events <= 0:
+                    raise
+                _mark_user_loop_final_verify_recovery(
+                    plan=plan,
+                    trace=trace,
+                    stage="agent_execute",
+                    round_num=round_num,
+                    exception=exc,
+                    delta_events=delta_events,
+                    delta_tool_calls=delta_tool_calls,
+                )
+                rounds_log.append(
+                    {
+                        "round": round_num,
+                        "rewards": None,
+                        "verifier_error": "public_safe_agent_execute_exception_after_activity",
+                        "n_tool_calls": delta_tool_calls,
+                        "n_trajectory_events": delta_events,
+                    }
+                )
+                break
+            finally:
+                await self.disconnect()
+
+            round_trajectory = self._trajectory[traj_before:]
+            round_tools = sum(
+                1
+                for event in round_trajectory
+                if isinstance(event, dict) and event.get("type") == "tool_call"
+            )
+
+            if cfg.oracle_access:
+                await self._env.exec(
+                    "mv /solution_oracle_backup /solution 2>/dev/null || true",
+                    user="root",
+                    timeout_sec=10,
+                )
+            soft_verify_skipped = False
+            try:
+                if final_only_soft_verify:
+                    soft_verify_skipped = True
+                    record_soft_verify_counter(
+                        "benchflow_intermediate_soft_verify_skipped_count"
+                    )
+                    rewards = None
+                    verifier_output = None
+                    verifier_error = None
+                else:
+                    record_soft_verify_counter(
+                        "benchflow_intermediate_soft_verify_call_count"
+                    )
+                    rewards, verifier_output, verifier_error = await self.soft_verify()
+            except Exception as exc:
+                _mark_user_loop_final_verify_recovery(
+                    plan=plan,
+                    trace=trace,
+                    stage="soft_verify",
+                    round_num=round_num,
+                    exception=exc,
+                    delta_events=len(round_trajectory),
+                    delta_tool_calls=round_tools,
+                )
+                rounds_log.append(
+                    {
+                        "round": round_num,
+                        "rewards": None,
+                        "verifier_error": "public_safe_soft_verify_exception_after_agent_round",
+                        "soft_verify_policy": intermediate_soft_verify_policy,
+                        "soft_verify_skipped": False,
+                        "n_tool_calls": round_tools,
+                        "n_trajectory_events": len(round_trajectory),
+                    }
+                )
+                break
+            finally:
+                if cfg.oracle_access:
+                    await self._env.exec(
+                        "mv /solution /solution_oracle_backup 2>/dev/null || true",
+                        user="root",
+                        timeout_sec=10,
+                    )
+
+            round_result = RoundResult(
+                round=round_num,
+                trajectory=round_trajectory,
+                rewards=rewards,
+                verifier_output=verifier_output,
+                verifier_error=verifier_error,
+                n_tool_calls=round_tools,
+            )
+
+            rounds_log.append(
+                {
+                    "round": round_num,
+                    "prompt": prompt,
+                    "rewards": rewards,
+                    "verifier_error": verifier_error,
+                    "soft_verify_policy": intermediate_soft_verify_policy,
+                    "soft_verify_skipped": soft_verify_skipped,
+                    "n_tool_calls": round_tools,
+                    "n_trajectory_events": len(round_trajectory),
+                }
+            )
+
+        if rounds_log and self._rollout_dir:
+            log_path = self._rollout_dir / "user_rounds.jsonl"
+            with log_path.open("w") as handle:
+                for entry in rounds_log:
+                    handle.write(json.dumps(entry) + "\n")
+
+    rollout_cls._run_user_loop = run_user_loop_with_final_verify_recovery
+    return original_user_loop
 
 
 def _runner_prerequisite_failure_attribution(
@@ -785,6 +1410,17 @@ def _runner_prerequisite_failure_attribution(
 
     if not isinstance(value, dict):
         return None
+
+    if (
+        value.get("benchflow_setup_stall_timeout_triggered") is True
+        and value.get("benchflow_setup_stall_before_agent_lifecycle") is True
+    ):
+        label = "skillsbench_docker_compose_build_stall_timeout"
+        return label, label, [
+            label,
+            "skillsbench_docker_compose_setup_failure",
+            "skillsbench_environment_setup_error",
+        ]
 
     if (
         value.get("preinstalled_benchflow_agent_runtime_required") is True
@@ -831,6 +1467,77 @@ def _runner_prerequisite_failure_attribution(
         return label, label, [label, "skillsbench_runner_setup_error"]
 
     return None
+
+
+def _agent_lifecycle_observed_for_setup_stall(plan: dict[str, Any]) -> bool:
+    prerequisites = plan.get("runner_prerequisites")
+    if not isinstance(prerequisites, dict):
+        prerequisites = {}
+
+    if prerequisites.get("benchflow_agent_install_started") is True:
+        return True
+    launch_status = str(
+        prerequisites.get("codex_acp_runtime_launch_preflight_status") or ""
+    )
+    if launch_status not in {"", "pending", "not_requested"}:
+        return True
+    host_status = str(prerequisites.get("host_local_acp_launch_status") or "")
+    if host_status not in {"", "pending", "not_requested"}:
+        return True
+
+    controller_trace = plan.get("controller_trace")
+    if not isinstance(controller_trace, dict):
+        return False
+    return bool(
+        controller_trace.get("case_goal_state_initialized_before_agent")
+        or controller_trace.get("case_goal_state_init_rc") is not None
+        or int(controller_trace.get("initial_prompt_count") or 0) > 0
+        or int(controller_trace.get("heartbeat_count") or 0) > 0
+        or int(controller_trace.get("controller_action_decisions") or 0) > 0
+        or int(controller_trace.get("private_trajectory_round_count") or 0) > 0
+        or int(controller_trace.get("loopx_cli_call_count") or 0) > 0
+    )
+
+
+def _runner_exception_indicates_timeout(exc: BaseException) -> bool:
+    text = f"{type(exc).__name__} {exc}".lower()
+    return "timeout" in text or "timed out" in text
+
+
+def _ensure_setup_stall_timeout_prerequisites(
+    args: argparse.Namespace,
+    plan: dict[str, Any],
+    exc: BaseException,
+    *,
+    cleanup_if_missing: bool,
+) -> None:
+    """Backfill public setup-stall evidence when BenchFlow times out pre-agent."""
+
+    build_stall_timeout_sec = int(args.build_stall_timeout_sec or 0)
+    if build_stall_timeout_sec <= 0:
+        return
+    if not _runner_exception_indicates_timeout(exc):
+        return
+    if _agent_lifecycle_observed_for_setup_stall(plan):
+        return
+
+    raw_prerequisites = plan.setdefault("runner_prerequisites", {})
+    raw_prerequisites.setdefault(
+        "benchflow_run_stage", "build_or_setup_stall_before_agent"
+    )
+    raw_prerequisites.setdefault("benchflow_setup_stall_timeout_enabled", True)
+    raw_prerequisites.setdefault(
+        "benchflow_setup_stall_timeout_sec", build_stall_timeout_sec
+    )
+    raw_prerequisites.setdefault("benchflow_setup_stall_timeout_triggered", True)
+    raw_prerequisites.setdefault(
+        "benchflow_setup_stall_before_agent_lifecycle", True
+    )
+    raw_prerequisites.setdefault("benchflow_setup_stall_raw_logs_read", False)
+    if cleanup_if_missing and not raw_prerequisites.get(
+        "benchflow_setup_stall_cleanup_requested"
+    ):
+        cleanup_benchflow_setup_stall_children(plan)
 
 
 def _apply_agent_message_only_no_tool_calls_attribution(
@@ -1605,6 +2312,10 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
     task_id = args.task_id
     route = args.route
     route_slug = route.replace("-", "_")
+    intermediate_soft_verify_policy = product_mode_soft_verify_policy_for_route(
+        route,
+        args.product_mode_soft_verify_policy,
+    )
     job_name = args.job_name or (
         f"skillsbench-{task_id}-{route}-{_now_stamp()}"
     )
@@ -1638,6 +2349,7 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
         sandbox=args.sandbox,
     )
     agent_runtime_layer = _benchflow_agent_runtime_layer_contract(args)
+    loopx_source_mount = _loopx_source_mount_contract(args)
     requires_preinstalled_runtime = bool(agent_runtime_layer.get("required"))
     is_app_server_goal_route = route == "codex-app-server-goal-baseline"
     app_server_goal_bridge_ready = bool(
@@ -1689,6 +2401,7 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
             or args.remote_command_file_bridge_probe
         ),
         "benchflow_agent_runtime_layer": agent_runtime_layer,
+        "loopx_source_mount": loopx_source_mount,
         "skillsbench_root": str(Path(args.skillsbench_root).expanduser()),
         "jobs_dir": str(jobs_dir),
         "job_name": job_name,
@@ -1696,6 +2409,7 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
         "result_json": str(result_path),
         "compact_benchmark_run_json": str(compact_path),
         "controller_trace_json": str(controller_trace_path),
+        "build_stall_timeout_sec": int(args.build_stall_timeout_sec or 0),
         "app_server_goal_worker_trace_dir": (
             str(app_server_goal_worker_trace_dir)
             if is_app_server_goal_route
@@ -1718,6 +2432,13 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
         },
         "runner_prerequisites": {
             "schema_version": "skillsbench_runner_prerequisites_v0",
+            "benchflow_setup_stall_timeout_enabled": (
+                int(args.build_stall_timeout_sec or 0) > 0
+            ),
+            "benchflow_setup_stall_timeout_sec": int(
+                args.build_stall_timeout_sec or 0
+            ),
+            "benchflow_setup_stall_raw_logs_read": False,
             "codex_acp_runtime_container_bootstrap": (
                 False
                 if is_app_server_goal_route
@@ -1787,6 +2508,22 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
                 requires_preinstalled_runtime
             ),
             "benchflow_agent_runtime_mount_source_recorded": False,
+            "loopx_source_mount_requested": bool(
+                loopx_source_mount.get("requested")
+            ),
+            "loopx_source_mount_ready": bool(loopx_source_mount.get("ready")),
+            "loopx_source_mount_status": str(
+                loopx_source_mount.get("status") or ""
+            ),
+            "loopx_source_mount_target": str(
+                loopx_source_mount.get("mount_target") or ""
+            ),
+            "loopx_source_mount_injected": False,
+            "loopx_source_mount_read_only": bool(loopx_source_mount.get("read_only")),
+            "loopx_source_mount_source_recorded": False,
+            "benchflow_agent_timeout_original_sec": 0,
+            "benchflow_agent_timeout_effective_sec": 0,
+            "benchflow_agent_timeout_overridden": False,
             "codex_app_server_goal_worker_plan_schema": (
                 app_server_goal_worker_contract["worker_plan"]["schema_version"]
                 if app_server_goal_worker_contract
@@ -1818,6 +2555,15 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
                 if app_server_goal_worker_contract
                 else False
             ),
+            "benchflow_intermediate_soft_verify_policy": (
+                intermediate_soft_verify_policy
+            ),
+            "benchflow_intermediate_soft_verify_final_only": (
+                intermediate_soft_verify_policy == "final-only"
+            ),
+            "benchflow_intermediate_soft_verify_call_count": 0,
+            "benchflow_intermediate_soft_verify_skipped_count": 0,
+            "benchflow_intermediate_soft_verify_raw_output_recorded": False,
         },
         "public_boundary": {
             "leaderboard_upload": False,
@@ -2030,6 +2776,13 @@ def _tail(text: str | None, *, limit: int) -> str:
     if len(cleaned) <= limit:
         return cleaned
     return cleaned[-limit:]
+
+
+def _last_loopx_case_init_phase(text: str | None) -> str:
+    if not text:
+        return ""
+    phases = re.findall(r"loopx_case_init_phase:([a-z0-9_:-]+)", text)
+    return phases[-1] if phases else ""
 
 
 def _inc_counter(payload: dict[str, Any], key: str, amount: int = 1) -> None:
@@ -2414,9 +3167,16 @@ def _normalized_loopx_cli_call(
     after = tokens[command_index + 1 :] if command_index >= 0 else []
     subcommands: list[str] = []
     flags: list[str] = []
+    skip_next = False
     for token in after:
+        if skip_next:
+            skip_next = False
+            continue
         if token.startswith("--"):
-            flags.append(token.split("=", 1)[0][:60])
+            flag = token.split("=", 1)[0][:60]
+            flags.append(flag)
+            if "=" not in token and flag in LOOPX_FLAG_VALUE_OPTIONS:
+                skip_next = True
             continue
         if token.startswith("-"):
             flags.append(token[:20])
@@ -2507,8 +3267,25 @@ def _record_declared_done(
 
 
 def _product_mode_depth_gate_satisfied(trace: dict[str, Any]) -> bool:
-    reads = trace.get("loopx_case_state_reads")
-    writes = trace.get("loopx_case_state_writes")
+    def count(*fields: str) -> int:
+        values = [
+            trace.get(field)
+            for field in fields
+            if isinstance(trace.get(field), int)
+            and not isinstance(trace.get(field), bool)
+        ]
+        return max(values, default=0)
+
+    reads = count(
+        "loopx_state_reads",
+        "loopx_cli_state_read_count",
+        "loopx_case_state_reads",
+    )
+    writes = count(
+        "loopx_state_writes",
+        "loopx_cli_state_write_count",
+        "loopx_case_state_writes",
+    )
     return (
         isinstance(reads, int)
         and not isinstance(reads, bool)
@@ -2530,6 +3307,22 @@ def _record_product_mode_depth_gate_gap(
     if not isinstance(current, int) or isinstance(current, bool):
         current = 0
     trace["product_mode_depth_gate_gap_count"] = current + 1
+
+
+def _record_product_mode_lifecycle_checkpoint_gap(
+    trace: dict[str, Any],
+    *,
+    agent_round: int,
+) -> None:
+    trace["product_mode_lifecycle_checkpoint_required"] = True
+    trace["product_mode_lifecycle_checkpoint_round"] = agent_round
+    trace["product_mode_lifecycle_checkpoint_missing_reason"] = (
+        "missing_case_local_loopx_state_read_or_write"
+    )
+    current = trace.get("product_mode_lifecycle_checkpoint_count")
+    if not isinstance(current, int) or isinstance(current, bool):
+        current = 0
+    trace["product_mode_lifecycle_checkpoint_count"] = current + 1
 
 
 def _trajectory_candidate_paths(plan: dict[str, Any]) -> list[Path]:
@@ -2799,26 +3592,81 @@ def _build_product_mode_user(
     max_rounds: int,
     trace: dict[str, Any],
     plan: dict[str, Any] | None = None,
+    case_payload: dict[str, Any] | None = None,
 ):
     from benchflow.sandbox.user import BaseUser, RoundResult
 
     treatment = route == "loopx-product-mode"
+    payload = case_payload or {}
+    case_state_path = str(
+        payload.get("case_state_path") or PRODUCT_MODE_CASE_STATE_PATH
+    )
+    case_goal_id = str(payload.get("benchmark_case_goal_id") or PRODUCT_MODE_CASE_GOAL_ID)
+    case_agent_id = str(payload.get("case_agent_id") or BENCHMARK_CASE_LOOPX_AGENT_ID)
+    case_todo_id = str(payload.get("case_todo_id") or BENCHMARK_CASE_LOOPX_TODO_ID)
+    case_cli_prefix = benchmark_case_loopx_command_prefix(
+        case_cli_path=str(payload.get("case_cli_path") or "/app/.local/bin/loopx"),
+        case_registry_path=str(payload.get("case_registry_path") or "/app/.loopx/registry.json"),
+        case_runtime_root=str(payload.get("case_runtime_root") or "/app/.loopx/runtime"),
+    )
 
     def treatment_state_contract() -> str:
         return (
-            "LoopX case-state contract: a canonical active-state "
-            f"skeleton is already initialized at `{PRODUCT_MODE_CASE_STATE_PATH}` "
-            "before the agent starts. This path intentionally mirrors the "
-            "normal LoopX active-state shape inside the benchmark "
-            "sandbox. Before substantive edits, read the file and keep its "
-            f"`schema_version: {PRODUCT_MODE_CASE_STATE_SCHEMA_VERSION}`, "
-            "`## Agent Todo`, `## Done Todo`, `## Local Evidence`, "
-            "`## Replan Log`, and `## Remaining Goals` sections. Re-read it "
-            "before each continuation, update it after local evidence changes, "
-            "and before declaring done rewrite it so there are no open agent "
-            "todos and `## Remaining Goals` says none. If the real "
-            "LoopX CLI is available you may also use it, but this file "
-            "is the required per-case state surface. "
+            "LoopX product-mode lifecycle contract: official case-local "
+            f"LoopX is initialized before the agent starts. Active state: "
+            f"`{case_state_path}`. This is the only formal treatment "
+            "lifecycle; runner polling is only the outer transport. Before "
+            "planning, run "
+            f"`{case_cli_prefix} quota should-run --goal-id {case_goal_id} "
+            f"--agent-id {case_agent_id}` and claim the selected case todo "
+            f"with `{case_cli_prefix} todo claim --goal-id {case_goal_id} "
+            f"--todo-id {case_todo_id} --claimed-by {case_agent_id}`. "
+            "After meaningful local evidence or validation, update the todo "
+            "through LoopX CLI; when complete, use `todo complete`, then "
+            "`refresh-state`, then `quota spend-slot --execute`. Do not rely "
+            "on only reading or editing the Markdown state file, and do not "
+            "write a separate marker as the source of truth. "
+        )
+
+    def lifecycle_checkpoint_commands(round_number: int) -> str:
+        safe_round = max(1, round_number)
+        checkpoint_note = shlex.quote(
+            f"round {safe_round} product-mode lifecycle checkpoint"
+        )
+        checkpoint_evidence = shlex.quote(
+            "public-safe checkpoint: case-local LoopX lifecycle touched"
+        )
+        classification = shlex.quote("benchmark_case_lifecycle_checkpoint")
+        return (
+            "```bash\n"
+            f"{case_cli_prefix} quota should-run --goal-id {case_goal_id} "
+            f"--agent-id {case_agent_id}\n"
+            f"{case_cli_prefix} todo claim --goal-id {case_goal_id} "
+            f"--todo-id {case_todo_id} --claimed-by {case_agent_id}\n"
+            f"{case_cli_prefix} todo update --goal-id {case_goal_id} "
+            f"--todo-id {case_todo_id} --status open "
+            f"--note {checkpoint_note} --evidence {checkpoint_evidence}\n"
+            f"{case_cli_prefix} refresh-state --goal-id {case_goal_id} "
+            f"--classification {classification} "
+            "--delivery-batch-scale single_surface "
+            "--delivery-outcome surface_only --no-global-sync\n"
+            "```\n"
+        )
+
+    def lifecycle_checkpoint_prompt(round_number: int) -> str:
+        return (
+            f"Mandatory LoopX lifecycle checkpoint before round {round_number} "
+            "continues. The previous product-mode round did not produce public "
+            "evidence of case-local LoopX state read/write. This is not "
+            "official verifier feedback and says nothing about task success. "
+            "Before doing any more task work or declaring done, run these "
+            "case-local LoopX CLI commands exactly from the sandbox, then "
+            f"continue solving from the updated case state at `{case_state_path}`. "
+            "Do not answer with prose only.\n\n"
+            f"{lifecycle_checkpoint_commands(round_number)}"
+            "After meaningful local validation or completion, update the same "
+            "case todo again; only spend quota after validated work or final "
+            "closeout."
         )
 
     class ProductModeUser(BaseUser):
@@ -2851,6 +3699,10 @@ def _build_product_mode_user(
                                 trace,
                                 agent_round=round,
                             )
+                            _record_product_mode_lifecycle_checkpoint_gap(
+                                trace,
+                                agent_round=round,
+                            )
                             _inc_counter(trace, "controller_action_decisions")
                             if round >= max_rounds:
                                 _inc_counter(trace, "stop_decision_count")
@@ -2860,20 +3712,13 @@ def _build_product_mode_user(
                                 return None
                             _inc_counter(trace, "followup_prompt_count")
                             trace["last_decision"] = (
-                                "send_product_mode_depth_gate_continuation"
+                                "send_product_mode_lifecycle_checkpoint_continuation"
                             )
                             return (
-                                f"Scheduled product-mode continuation round "
-                                f"{round + 1} of {max_rounds}. This is part of "
-                                "the fixed autonomous budget and is not "
-                                "evidence that the official verifier passed "
-                                "or failed. You are not being shown official "
-                                "reward, pass/fail status, verifier error, or "
-                                "verifier output. You declared done, but the "
-                                "required LoopX case-state interaction "
-                                f"was not observed. Re-read "
-                                f"`{PRODUCT_MODE_CASE_STATE_PATH}`, update it "
-                                "with current todos/evidence/replan state, "
+                                lifecycle_checkpoint_prompt(round + 1)
+                                + "\n\nYou declared done, but the required "
+                                "LoopX case-state interaction was not "
+                                "observed. Re-read the updated case state, "
                                 "validate locally, and only end with "
                                 f"{DECLARED_DONE_MARKER} after it records no "
                                 "open agent todos and no remaining goals."
@@ -2921,12 +3766,20 @@ def _build_product_mode_user(
                         "Use ordinary Codex autonomous behavior. You may keep a "
                         "brief local plan or todo list, but do not use Goal "
                         "Harness state, todo, replan, ledger, CLI surfaces, or "
-                        f"`{PRODUCT_MODE_CASE_STATE_PATH}`. "
+                    f"`{case_state_path}`. "
                     )
                 return (
                     prefix
                     + "You are running inside the official SkillsBench sandbox. "
                     + control_clause
+                    + (
+                        "For this treatment, LoopX lifecycle evidence is a "
+                        "hard product-mode requirement: first run the "
+                        "case-local quota/todo commands above before "
+                        "substantive task work. "
+                        if treatment
+                        else ""
+                    )
                     + "No official reward, pass/fail status, verifier error, "
                     "verifier output, or verifier tail will be shown during this "
                     "run. If you believe the task is complete and there are no "
@@ -2938,11 +3791,22 @@ def _build_product_mode_user(
 
             _inc_counter(trace, "controller_action_decisions")
             _inc_counter(trace, "followup_prompt_count")
+            if treatment:
+                _merge_acp_trajectory_summary(plan or {}, trace)
+                if not _product_mode_depth_gate_satisfied(trace):
+                    _record_product_mode_lifecycle_checkpoint_gap(
+                        trace,
+                        agent_round=round,
+                    )
+                    trace["last_decision"] = (
+                        "send_product_mode_lifecycle_checkpoint_continuation"
+                    )
+                    return lifecycle_checkpoint_prompt(round + 1)
             trace["last_decision"] = "send_product_mode_scheduled_continuation"
             if treatment:
                 mode_clause = (
                     "Continue from your LoopX case state at "
-                    f"`{PRODUCT_MODE_CASE_STATE_PATH}` and todo/replan ledger; "
+                    f"`{case_state_path}` and todo/replan ledger; "
                     "re-read and update them if local evidence changed."
                 )
             else:
@@ -2969,6 +3833,12 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
     task_path = skillsbench_root / "tasks" / args.task_id
     if not task_path.exists():
         raise FileNotFoundError(f"SkillsBench task not found: {task_path}")
+    loopx_source_contract = _loopx_source_mount_contract(args)
+    if loopx_source_contract.get("requested") and not loopx_source_contract.get("ready"):
+        raise FileNotFoundError(
+            "LoopX source mount requested but local source files are missing; "
+            "use --no-loopx-source-mount to test the public GitHub installer instead"
+        )
     effective_task_path, staging_metadata = stage_task_for_sandbox(
         task_path=task_path,
         jobs_dir=Path(plan["jobs_dir"]),
@@ -2984,9 +3854,20 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
 
     import benchflow.acp.runtime as benchflow_acp_runtime
     import benchflow.rollout as benchflow_rollout_module
-    import benchflow.rollout_planes as benchflow_rollout_planes_module
+    import benchflow.sandbox.setup as benchflow_sandbox_setup_module
+    try:
+        benchflow_rollout_planes_module = importlib.import_module(
+            "benchflow.rollout_planes"
+        )
+    except ModuleNotFoundError as exc:
+        if exc.name != "benchflow.rollout_planes":
+            raise
+        benchflow_rollout_planes_module = None
     from benchflow.rollout import Rollout, RolloutConfig
     from benchflow.runtime import run as benchflow_run
+    plan.setdefault("runner_prerequisites", {})[
+        "benchflow_rollout_planes_module_available"
+    ] = benchflow_rollout_planes_module is not None
 
     host_local_acp_command = _host_local_acp_launch_command(args, plan)
     runtime_mounts = (
@@ -2994,6 +3875,8 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
         if args.require_preinstalled_benchflow_agent_runtime
         else []
     )
+    loopx_source_mounts = _loopx_source_mounts(args)
+    container_mounts = [*runtime_mounts, *loopx_source_mounts]
 
     async def connect_host_local_acp(
         env: Any,
@@ -3116,43 +3999,83 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
     async def seed_product_mode_case_state(env: Any) -> None:
         if args.route != "loopx-product-mode":
             return
-        trace = controller_trace if isinstance(controller_trace, dict) else {}
-        trace["case_goal_state_init_required"] = True
-        trace["case_goal_state_path"] = PRODUCT_MODE_CASE_STATE_PATH
-        trace["case_goal_state_schema_version"] = PRODUCT_MODE_CASE_STATE_SCHEMA_VERSION
-        trace["case_goal_state_initialized_before_agent"] = False
-        content = product_mode_case_state_seed_text(
-            task_id=args.task_id,
+        payload = benchmark_case_loopx_install_payload(
+            benchmark_id="skillsbench",
+            case_id=args.task_id,
+            arm_id="loopx_product_mode",
             route=args.route,
             max_rounds=args.max_rounds,
+            case_loopx_source_path=_loopx_case_source_path_for_container(args),
         )
-        cmd = benchmark_case_active_state_write_command(
-            case_state_path=PRODUCT_MODE_CASE_STATE_PATH,
-            content=content,
+        trace = controller_trace if isinstance(controller_trace, dict) else {}
+        trace["case_goal_state_init_required"] = True
+        trace["case_goal_state_path"] = payload.get("case_state_path") or ""
+        trace["case_goal_state_schema_version"] = payload.get("schema_version") or ""
+        trace["loopx_lifecycle_driver_schema_version"] = (
+            payload.get("lifecycle_driver_schema_version") or ""
         )
-        result = await env.exec(cmd, timeout_sec=30)
+        trace["loopx_formal_treatment_semantics"] = (
+            payload.get("formal_treatment_semantics") or ""
+        )
+        trace["loopx_canonical_product_mode_lifecycle_driver"] = bool(
+            payload.get("canonical_product_mode_lifecycle_driver")
+        )
+        trace["loopx_execution_style"] = payload.get("execution_style") or ""
+        trace["loopx_case_cli_path"] = payload.get("case_cli_path") or ""
+        trace["loopx_case_source_install_requested"] = bool(
+            payload.get("case_loopx_source_install_requested")
+        )
+        trace["loopx_case_source_path_recorded"] = bool(
+            payload.get("case_loopx_source_path_recorded")
+        )
+        trace["loopx_case_registry_path"] = payload.get("case_registry_path") or ""
+        trace["loopx_case_runtime_root"] = payload.get("case_runtime_root") or ""
+        trace["loopx_case_agent_id"] = payload.get("case_agent_id") or ""
+        trace["loopx_case_todo_id"] = payload.get("case_todo_id") or ""
+        trace["loopx_case_todo_seeded"] = bool(payload.get("case_todo_seeded"))
+        trace["loopx_case_todo_preclaimed"] = bool(payload.get("case_todo_preclaimed"))
+        trace["case_goal_state_initialized_before_agent"] = False
+        result = await env.exec(str(payload["command"]), timeout_sec=180)
         trace["case_goal_state_init_rc"] = int(result.return_code)
         if result.return_code != 0:
             stderr = (getattr(result, "stderr", "") or "").strip()
             stdout = (getattr(result, "stdout", "") or "").strip()
             detail = stderr or stdout or "no output"
+            failed_phase = _last_loopx_case_init_phase(detail)
+            if failed_phase:
+                trace["case_goal_state_init_failed_phase"] = failed_phase
             trace["case_goal_state_init_status"] = "failed"
             raise RuntimeError(
-                "LoopX case active-state init failed: " + detail[:1000]
+                "LoopX official case lifecycle init failed: " + detail[:1000]
             )
         trace["case_goal_state_initialized_before_agent"] = True
         trace["case_goal_state_init_status"] = "passed"
+        trace["loopx_case_cli_installed_before_agent"] = True
 
     original_install_agent = Rollout.install_agent
     original_runtime_connect_acp = benchflow_acp_runtime.connect_acp
+    original_rollout_create_environment = getattr(
+        benchflow_rollout_module,
+        "_create_environment",
+        _MISSING,
+    )
+    original_setup_create_environment = getattr(
+        benchflow_sandbox_setup_module,
+        "_create_environment",
+        _MISSING,
+    )
     original_rollout_connect_acp = getattr(
         benchflow_rollout_module, "connect_acp", _MISSING
     )
-    original_rollout_planes_connect_acp = getattr(
-        benchflow_rollout_planes_module, "connect_acp", _MISSING
+    original_rollout_planes_connect_acp = (
+        getattr(benchflow_rollout_planes_module, "connect_acp", _MISSING)
+        if benchflow_rollout_planes_module is not None
+        else _MISSING
     )
-    rollout_planes_class = getattr(
-        benchflow_rollout_planes_module, "DefaultRolloutPlanes", None
+    rollout_planes_class = (
+        getattr(benchflow_rollout_planes_module, "DefaultRolloutPlanes", None)
+        if benchflow_rollout_planes_module is not None
+        else None
     )
     original_create_environment = (
         getattr(rollout_planes_class, "create_environment", None)
@@ -3166,21 +4089,65 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
         env = original_create_environment(self, *call_args, **call_kwargs)
         prerequisites = plan.setdefault("runner_prerequisites", {})
         environment = str(call_args[0]) if call_args else ""
-        if (
-            runtime_mounts
-            and environment == "docker"
-            and hasattr(env, "_mounts_json")
-        ):
+        if container_mounts and environment == "docker":
             existing_mounts = getattr(env, "_mounts_json", None) or []
-            setattr(env, "_mounts_json", [*existing_mounts, *runtime_mounts])
-            prerequisites["benchflow_agent_runtime_mount_injected"] = True
-            prerequisites["benchflow_agent_runtime_mount_read_only"] = True
-            prerequisites["benchflow_agent_runtime_mount_source_recorded"] = False
-        elif runtime_mounts:
-            prerequisites["benchflow_agent_runtime_mount_injected"] = False
-            prerequisites["benchflow_agent_runtime_mount_read_only"] = True
-            prerequisites["benchflow_agent_runtime_mount_source_recorded"] = False
+            setattr(env, "_mounts_json", [*existing_mounts, *container_mounts])
+            if runtime_mounts:
+                prerequisites["benchflow_agent_runtime_mount_injected"] = True
+                prerequisites["benchflow_agent_runtime_mount_read_only"] = True
+                prerequisites["benchflow_agent_runtime_mount_source_recorded"] = False
+            if loopx_source_mounts:
+                prerequisites["loopx_source_mount_injected"] = True
+                prerequisites["loopx_source_mount_read_only"] = True
+                prerequisites["loopx_source_mount_source_recorded"] = False
+        elif container_mounts:
+            if runtime_mounts:
+                prerequisites["benchflow_agent_runtime_mount_injected"] = False
+                prerequisites["benchflow_agent_runtime_mount_read_only"] = True
+                prerequisites["benchflow_agent_runtime_mount_source_recorded"] = False
+            if loopx_source_mounts:
+                prerequisites["loopx_source_mount_injected"] = False
+                prerequisites["loopx_source_mount_read_only"] = True
+                prerequisites["loopx_source_mount_source_recorded"] = False
         return env
+
+    def _record_container_mount_injection(env: Any, environment: str) -> Any:
+        prerequisites = plan.setdefault("runner_prerequisites", {})
+        if container_mounts and environment == "docker":
+            existing_mounts = getattr(env, "_mounts_json", None) or []
+            setattr(env, "_mounts_json", [*existing_mounts, *container_mounts])
+            if runtime_mounts:
+                prerequisites["benchflow_agent_runtime_mount_injected"] = True
+                prerequisites["benchflow_agent_runtime_mount_read_only"] = True
+                prerequisites["benchflow_agent_runtime_mount_source_recorded"] = False
+            if loopx_source_mounts:
+                prerequisites["loopx_source_mount_injected"] = True
+                prerequisites["loopx_source_mount_read_only"] = True
+                prerequisites["loopx_source_mount_source_recorded"] = False
+        elif container_mounts:
+            if runtime_mounts:
+                prerequisites["benchflow_agent_runtime_mount_injected"] = False
+                prerequisites["benchflow_agent_runtime_mount_read_only"] = True
+                prerequisites["benchflow_agent_runtime_mount_source_recorded"] = False
+            if loopx_source_mounts:
+                prerequisites["loopx_source_mount_injected"] = False
+                prerequisites["loopx_source_mount_read_only"] = True
+                prerequisites["loopx_source_mount_source_recorded"] = False
+        return env
+
+    def create_environment_function_with_runtime_mount(
+        environment: str,
+        *call_args: Any,
+        **call_kwargs: Any,
+    ) -> Any:
+        if original_rollout_create_environment is _MISSING:
+            raise RuntimeError("BenchFlow rollout _create_environment missing")
+        env = original_rollout_create_environment(
+            environment,
+            *call_args,
+            **call_kwargs,
+        )
+        return _record_container_mount_injection(env, environment)
 
     async def install_agent_host_local_acp(self: Any) -> None:
         cfg = self._config
@@ -3262,10 +4229,26 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
         self._phase = "installed"
 
     async def install_agent_with_launch_preflight(self: Any) -> Any:
+        prerequisites = plan.setdefault("runner_prerequisites", {})
+        prerequisites["benchflow_agent_install_started"] = True
+        prerequisites["benchflow_run_stage"] = "agent_install_started"
+        original_timeout = getattr(self, "_timeout", None)
+        requested_timeout = max(0, int(args.agent_idle_timeout or 0))
+        if (
+            isinstance(original_timeout, int)
+            and not isinstance(original_timeout, bool)
+            and requested_timeout > 0
+        ):
+            prerequisites["benchflow_agent_timeout_original_sec"] = original_timeout
+            effective_timeout = max(original_timeout, requested_timeout)
+            prerequisites["benchflow_agent_timeout_effective_sec"] = effective_timeout
+            prerequisites["benchflow_agent_timeout_overridden"] = (
+                effective_timeout != original_timeout
+            )
+            self._timeout = effective_timeout
         if args.host_local_acp_launch:
             return await install_agent_host_local_acp(self)
         result = await original_install_agent(self)
-        prerequisites = plan.setdefault("runner_prerequisites", {})
         if prerequisites.get("codex_acp_runtime_launch_preflight_status") != "passed":
             env = getattr(self, "_env", None)
             if env is None:
@@ -3279,6 +4262,16 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
 
     controller_user = None
     controller_trace: dict[str, Any] | None = None
+    product_mode_case_payload: dict[str, Any] | None = None
+    if args.route == "loopx-product-mode":
+        product_mode_case_payload = benchmark_case_loopx_install_payload(
+            benchmark_id="skillsbench",
+            case_id=args.task_id,
+            arm_id="loopx_product_mode",
+            route=args.route,
+            max_rounds=args.max_rounds,
+            case_loopx_source_path=_loopx_case_source_path_for_container(args),
+        )
     if args.route == "automation-loop-treatment":
         controller_trace = _new_controller_trace(args.route, max_rounds=args.max_rounds)
         controller_user = _build_controller_user(
@@ -3307,6 +4300,7 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
             max_rounds=args.max_rounds,
             trace=controller_trace,
             plan=plan,
+            case_payload=product_mode_case_payload,
         )
     elif args.route == "codex-goal-mode-baseline":
         controller_user = _build_codex_goal_mode_baseline_user()
@@ -3314,6 +4308,24 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
         controller_trace = _new_controller_trace(args.route, max_rounds=args.max_rounds)
         controller_trace["native_goal_worker_route"] = True
         controller_trace["last_decision"] = "host_app_server_goal_worker_selected"
+
+    original_user_loop = install_benchflow_user_loop_final_verify_recovery(
+        Rollout,
+        plan=plan,
+        trace=controller_trace,
+        intermediate_soft_verify_policy=product_mode_soft_verify_policy_for_route(
+            args.route,
+            args.product_mode_soft_verify_policy,
+        ),
+    )
+    original_verify, original_soft_verify = (
+        install_benchflow_verifier_prep_timeout_override(
+            Rollout,
+            timeout_sec=args.verifier_prep_timeout_sec,
+            plan=plan,
+            trace=controller_trace,
+        )
+    )
 
     pre_agent_hooks = (
         []
@@ -3351,32 +4363,128 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
         **_filter_kwargs_for_signature(RolloutConfig, rollout_config_kwargs)
     )
     result_path: Path | None = None
+    prerequisites = plan.setdefault("runner_prerequisites", {})
+    build_stall_timeout_sec = max(0, int(args.build_stall_timeout_sec or 0))
+    prerequisites["benchflow_setup_stall_timeout_enabled"] = (
+        build_stall_timeout_sec > 0
+    )
+    prerequisites["benchflow_setup_stall_timeout_sec"] = build_stall_timeout_sec
+    prerequisites["benchflow_setup_stall_raw_logs_read"] = False
+    prerequisites["benchflow_run_stage"] = "before_benchflow_run"
+
+    def agent_lifecycle_started() -> bool:
+        if prerequisites.get("benchflow_agent_install_started") is True:
+            return True
+        launch_status = str(
+            prerequisites.get("codex_acp_runtime_launch_preflight_status") or ""
+        )
+        if launch_status not in {"", "pending", "not_requested"}:
+            return True
+        host_status = str(prerequisites.get("host_local_acp_launch_status") or "")
+        if host_status not in {"", "pending", "not_requested"}:
+            return True
+        if isinstance(controller_trace, dict):
+            return bool(
+                controller_trace.get("case_goal_state_initialized_before_agent")
+                or controller_trace.get("case_goal_state_init_rc") is not None
+                or int(controller_trace.get("initial_prompt_count") or 0) > 0
+                or int(controller_trace.get("heartbeat_count") or 0) > 0
+                or int(controller_trace.get("controller_action_decisions") or 0) > 0
+                or int(controller_trace.get("private_trajectory_round_count") or 0) > 0
+                or int(controller_trace.get("loopx_cli_call_count") or 0) > 0
+            )
+        return False
+
+    async def run_benchflow_with_setup_stall_watchdog() -> None:
+        prerequisites["benchflow_run_stage"] = "benchflow_run_started"
+        task = asyncio.create_task(benchflow_run(config))
+        if build_stall_timeout_sec <= 0:
+            await task
+            prerequisites["benchflow_run_stage"] = "benchflow_run_completed"
+            return
+        done, _pending = await asyncio.wait(
+            {task},
+            timeout=build_stall_timeout_sec,
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        if done:
+            await task
+            prerequisites["benchflow_run_stage"] = "benchflow_run_completed"
+            return
+        if agent_lifecycle_started():
+            prerequisites["benchflow_run_stage"] = (
+                "benchflow_run_continues_after_agent_lifecycle_started"
+            )
+            await task
+            prerequisites["benchflow_run_stage"] = "benchflow_run_completed"
+            return
+        prerequisites["benchflow_setup_stall_timeout_triggered"] = True
+        prerequisites["benchflow_setup_stall_before_agent_lifecycle"] = True
+        prerequisites["benchflow_run_stage"] = "build_or_setup_stall_before_agent"
+        prerequisites["benchflow_setup_stall_task_cancel_requested"] = True
+        task.cancel()
+        try:
+            await asyncio.wait_for(task, timeout=5)
+        except asyncio.CancelledError:
+            prerequisites["benchflow_setup_stall_task_cancel_acknowledged"] = True
+        except asyncio.TimeoutError:
+            prerequisites["benchflow_setup_stall_task_cancel_timeout"] = True
+        cleanup_benchflow_setup_stall_children(plan)
+        raise asyncio.TimeoutError(
+            "skillsbench docker compose build/setup stall timeout before agent lifecycle"
+        )
+
     Rollout.install_agent = install_agent_with_launch_preflight
-    if runtime_mounts and rollout_planes_class is not None:
+    if container_mounts and rollout_planes_class is not None:
         rollout_planes_class.create_environment = create_environment_with_runtime_mount
+    if container_mounts and original_rollout_create_environment is not _MISSING:
+        benchflow_rollout_module._create_environment = (
+            create_environment_function_with_runtime_mount
+        )
+    if container_mounts and original_setup_create_environment is not _MISSING:
+        benchflow_sandbox_setup_module._create_environment = (
+            create_environment_function_with_runtime_mount
+        )
     if args.host_local_acp_launch:
         benchflow_acp_runtime.connect_acp = connect_host_local_acp
         if original_rollout_connect_acp is not _MISSING:
             benchflow_rollout_module.connect_acp = connect_host_local_acp
-        if original_rollout_planes_connect_acp is not _MISSING:
+        if (
+            benchflow_rollout_planes_module is not None
+            and original_rollout_planes_connect_acp is not _MISSING
+        ):
             benchflow_rollout_planes_module.connect_acp = connect_host_local_acp
     try:
-        await benchflow_run(config)
+        await run_benchflow_with_setup_stall_watchdog()
         result_path = discover_benchflow_result_path(plan)
         if result_path.exists():
             _merge_final_result_round_reward(controller_trace, result_path)
     finally:
         Rollout.install_agent = original_install_agent
+        Rollout._run_user_loop = original_user_loop
+        Rollout.verify = original_verify
+        Rollout.soft_verify = original_soft_verify
         if (
-            runtime_mounts
+            container_mounts
             and rollout_planes_class is not None
             and original_create_environment is not None
         ):
             rollout_planes_class.create_environment = original_create_environment
+        if original_rollout_create_environment is not _MISSING:
+            benchflow_rollout_module._create_environment = (
+                original_rollout_create_environment
+            )
+        if original_setup_create_environment is not _MISSING:
+            benchflow_sandbox_setup_module._create_environment = (
+                original_setup_create_environment
+            )
         benchflow_acp_runtime.connect_acp = original_runtime_connect_acp
         if original_rollout_connect_acp is not _MISSING:
             benchflow_rollout_module.connect_acp = original_rollout_connect_acp
-        if original_rollout_planes_connect_acp is not _MISSING:
+        if (
+            benchflow_rollout_planes_module is not None
+            and original_rollout_planes_connect_acp is not _MISSING
+        ):
             benchflow_rollout_planes_module.connect_acp = (
                 original_rollout_planes_connect_acp
             )
@@ -3439,7 +4547,12 @@ def reduce_result(
     else:
         has_agent_message_only_evidence = False
     if compact.get("official_score_status") == "missing":
-        if prereq_failure is not None and not has_agent_message_only_evidence:
+        current_attribution = str(compact.get("score_failure_attribution") or "")
+        if (
+            prereq_failure is not None
+            and not has_agent_message_only_evidence
+            and current_attribution in {"", "none", "skillsbench_runner_error"}
+        ):
             _exception_type, score_failure_attribution, labels = prereq_failure
             compact["score_failure_attribution"] = score_failure_attribution
             compact.setdefault("first_blocker", score_failure_attribution)
@@ -3583,6 +4696,14 @@ def build_runner_failure_compact(
         skillsbench_runner_error_fingerprint,
     )
     from loopx.status import compact_benchmark_run
+
+    plan.setdefault("runner_prerequisites", {})
+    _ensure_setup_stall_timeout_prerequisites(
+        args,
+        plan,
+        exc,
+        cleanup_if_missing=True,
+    )
 
     exception_type, attribution, labels = skillsbench_runner_error_attribution(
         str(exc)
@@ -3850,7 +4971,36 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     )
     parser.add_argument("--outer-timeout-sec", type=int, default=DEFAULT_TIMEOUT_SEC)
     parser.add_argument("--sandbox-setup-timeout", type=int, default=DEFAULT_TIMEOUT_SEC)
+    parser.add_argument(
+        "--build-stall-timeout-sec",
+        type=int,
+        default=0,
+        help=(
+            "Optional public-safe watchdog for Docker build/setup before any "
+            "agent lifecycle starts. 0 keeps the historical behavior and relies "
+            "only on --outer-timeout-sec."
+        ),
+    )
     parser.add_argument("--agent-idle-timeout", type=int, default=900)
+    parser.add_argument(
+        "--verifier-prep-timeout-sec",
+        type=int,
+        default=DEFAULT_VERIFIER_PREP_TIMEOUT_SEC,
+        help=(
+            "Timeout for BenchFlow verifier-phase prep/hardening shell calls. "
+            "This does not change the task verifier scoring timeout."
+        ),
+    )
+    parser.add_argument(
+        "--product-mode-soft-verify-policy",
+        choices=("final-only", "every-round"),
+        default=DEFAULT_PRODUCT_MODE_SOFT_VERIFY_POLICY,
+        help=(
+            "Intermediate BenchFlow soft-verify policy for the main-table "
+            "product-mode routes. final-only preserves official final scoring "
+            "without per-round verifier reward/output observations."
+        ),
+    )
     parser.add_argument(
         "--app-server-acp-heartbeat-interval-sec",
         type=float,
@@ -3863,6 +5013,23 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     )
     parser.add_argument("--max-verifier-output-chars", type=int, default=0)
     parser.add_argument("--skillsbench-root", default=str(DEFAULT_SKILLSBENCH_ROOT))
+    parser.add_argument(
+        "--loopx-source-dir",
+        default=str(REPO_ROOT),
+        help=(
+            "Local LoopX checkout mounted read-only into docker product-mode "
+            "runs and installed with scripts/install-local.sh. Public compact "
+            "artifacts record only the mount target, not this host path."
+        ),
+    )
+    parser.add_argument(
+        "--no-loopx-source-mount",
+        action="store_true",
+        help=(
+            "Do not mount the local LoopX checkout for product-mode runs; the "
+            "case init falls back to the README GitHub installer."
+        ),
+    )
     parser.add_argument(
         "--jobs-dir",
         default=str(REPO_ROOT / ".local/private-benchmark-jobs"),


### PR DESCRIPTION
## Summary

This PR is the first reviewable batch extracted from the dirty benchmark checkout. It keeps only the canonical SkillsBench LoopX product-mode lifecycle / closeout work:

- replaces the old surrogate/tiny case-local contract with an official case-local LoopX install/registry/todo lifecycle contract;
- mounts local LoopX source into product-mode runs when requested and records only public-safe mount metadata;
- adds final-only soft-verify and user-loop final-verify recovery bookkeeping;
- adds pre-agent Docker setup/build-stall watchdog closeout with scoped compose/buildx cleanup counters;
- preserves public-safe compact fields for task staging, attempt accounting, controller cutoff, runner prerequisites, and trajectory/LoopX CLI usage;
- extends the SkillsBench smoke to cover the canonical lifecycle, setup-stall projection, cleanup, trajectory counting, and closeout paths.

## Commit grouping

1. `Add canonical SkillsBench LoopX lifecycle closeout`
   - runtime/adapter/status behavior
2. `Cover SkillsBench lifecycle closeout paths`
   - focused public smoke coverage

## Validation

- `python3 -m py_compile loopx/benchmark_adapters/skillsbench.py loopx/benchmark_case_state.py loopx/benchmark_trajectory.py loopx/status.py scripts/skillsbench_automation_loop.py examples/skillsbench-benchmark-run-smoke.py`
- `git diff --check HEAD~2..HEAD`
- `python3 examples/skillsbench-benchmark-run-smoke.py`
- `loopx check --scan-path loopx/benchmark_adapters/skillsbench.py --scan-path loopx/benchmark_case_state.py --scan-path loopx/benchmark_trajectory.py --scan-path loopx/status.py --scan-path scripts/skillsbench_automation_loop.py --scan-path examples/skillsbench-benchmark-run-smoke.py`

## Excluded from this batch

The original dirty checkout still contains unrelated or later batches: dashboard/frontstage work, product/outreach docs, benchmark ledger updates, Harbor/Terminal host scripts, registry changes, and `examples/quota-no-git-status-smoke.py`. Those are intentionally not included here.

## Residual risk

The smoke is large because it already hosts the SkillsBench adapter contract. A future cleanup can split smaller reusable seams once this lifecycle contract lands.
