### PR TITLE
Degrade registry git probe when git is unavailable

### DIFF
--- a/examples/quota-no-git-status-smoke.py
+++ b/examples/quota-no-git-status-smoke.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Smoke-test quota/status degradation when git is unavailable."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GOAL_ID = "no-git-quota-fixture"
+AGENT_ID = "codex-benchmark-agent"
+
+
+def write_fixture(root: Path) -> Path:
+    project = root / "project"
+    runtime = root / "runtime"
+    state_file = project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+    registry_path = project / ".loopx" / "registry.json"
+    state_file.parent.mkdir(parents=True)
+    state_file.write_text(
+        "---\n"
+        "status: active\n"
+        "---\n\n"
+        "# Active Goal State\n\n"
+        "## Objective\n\n"
+        "Solve this no-git fixture.\n\n"
+        "## Next Action\n\n"
+        "- Pick the seeded todo.\n",
+        encoding="utf-8",
+    )
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "no-git-quota",
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md",
+                        "adapter": {"kind": "generic_project_goal_v0", "status": "connected"},
+                        "coordination": {
+                            "registered_agents": [AGENT_ID],
+                            "primary_agent": AGENT_ID,
+                        },
+                    }
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return registry_path
+
+
+def run_cli(registry_path: Path, *args: str, env: dict[str, str] | None = None) -> dict:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--registry",
+            str(registry_path),
+            "--format",
+            "json",
+            *args,
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return json.loads(result.stdout)
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="loopx-no-git-quota-") as tmp:
+        root = Path(tmp)
+        registry_path = write_fixture(root)
+        todo = run_cli(
+            registry_path,
+            "todo",
+            "add",
+            "--goal-id",
+            GOAL_ID,
+            "--role",
+            "agent",
+            "--text",
+            "Solve the no-git quota fixture.",
+        )
+        assert todo["ok"] is True, todo
+
+        no_git_bin = root / "no-git-bin"
+        no_git_bin.mkdir()
+        env = os.environ.copy()
+        env["PATH"] = str(no_git_bin)
+        env["PYTHONPATH"] = str(REPO_ROOT)
+        quota = run_cli(
+            registry_path,
+            "quota",
+            "should-run",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_ID,
+            env=env,
+        )
+        assert quota.get("status") != "quota_collection_failed", quota
+        assert quota["should_run"] is True, quota
+        assert quota["recommended_action"] == "Solve the no-git quota fixture.", quota
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/registry.py
+++ b/loopx/registry.py
@@ -65,17 +65,33 @@ PRIVATE_REGISTRY_TEXT_RE = re.compile(
 def _registry_git_probe(path: Path) -> dict[str, Any]:
     probe_dir = path if path.is_dir() else path.parent
 
-    def run_git(*args: str) -> subprocess.CompletedProcess[str]:
-        return subprocess.run(
-            ["git", *args],
-            cwd=probe_dir,
-            text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            check=False,
-        )
+    def unavailable() -> dict[str, Any]:
+        return {
+            "available": False,
+            "probe_status": "git_unavailable",
+            "inside_worktree": False,
+            "tracked": False,
+            "ignored": False,
+            "worktree_root_recorded": False,
+        }
+
+    def run_git(*args: str, cwd: Path = probe_dir) -> subprocess.CompletedProcess[str] | None:
+        try:
+            return subprocess.run(
+                ["git", *args],
+                cwd=cwd,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+                timeout=1.5,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return None
 
     root = run_git("rev-parse", "--show-toplevel")
+    if root is None:
+        return unavailable()
     inside = root.returncode == 0
     tracked = False
     ignored = False
@@ -85,29 +101,13 @@ def _registry_git_probe(path: Path) -> dict[str, Any]:
             rel_path = os.path.relpath(path.resolve(), root_path)
         except (OSError, ValueError):
             rel_path = path.name
-        tracked = (
-            subprocess.run(
-                ["git", "ls-files", "--error-unmatch", "--", rel_path],
-                cwd=root_path,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                text=True,
-                check=False,
-            ).returncode
-            == 0
-        )
-        ignored = (
-            subprocess.run(
-                ["git", "check-ignore", "-q", "--", rel_path],
-                cwd=root_path,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                text=True,
-                check=False,
-            ).returncode
-            == 0
-        )
+        tracked_result = run_git("ls-files", "--error-unmatch", "--", rel_path, cwd=root_path)
+        ignored_result = run_git("check-ignore", "-q", "--", rel_path, cwd=root_path)
+        tracked = tracked_result is not None and tracked_result.returncode == 0
+        ignored = ignored_result is not None and ignored_result.returncode == 0
     return {
+        "available": True,
+        "probe_status": "ok",
         "inside_worktree": inside,
         "tracked": tracked,
         "ignored": ignored,


### PR DESCRIPTION
## Summary

This is the second reviewable batch extracted from the dirty checkout. It makes LoopX registry/status collection degrade gracefully when `git` is unavailable, which matches minimal benchmark containers where `git` may not be installed.

- wraps registry git probes so missing/timeout git returns `probe_status=git_unavailable` instead of raising;
- keeps tracked/ignored/worktree-root booleans conservative when git cannot be queried;
- adds a smoke proving `quota should-run` still selects a seeded agent todo under a PATH with no `git` binary.

## Validation

- `python3 -m py_compile loopx/registry.py examples/quota-no-git-status-smoke.py`
- `python3 examples/quota-no-git-status-smoke.py`
- `git diff --check -- loopx/registry.py examples/quota-no-git-status-smoke.py`
- `loopx check --scan-path loopx/registry.py --scan-path examples/quota-no-git-status-smoke.py`

## Excluded from this batch

The broader dirty checkout still contains dashboard/frontstage, docs/outreach/product, benchmark ledger, and cross-benchmark host-script changes. Those are intentionally left for separate review batches.
