### PR TITLE
Add issue meta surface projection

### DIFF
--- a/docs/product/issue-pr-solver-anchor-coordination.md
+++ b/docs/product/issue-pr-solver-anchor-coordination.md
@@ -194,6 +194,22 @@ The coordination lane should write normal LoopX objects:
 - a compact metric-board update;
 - a case-catalog or showcase todo only after consent.
 
+For the first repo-local projection, an active state may also include a compact
+`## Issue Meta Surface` section. `loopx status` lifts each public-safe
+key-value bullet into `issue_meta_surface_v0` and mirrors it under
+`project_asset.issue_meta_surface`:
+
+```md
+## Issue Meta Surface
+
+- anchor_id=issue_anchor_parser_bug repo=sample-org/sample-repo issue=#128 labels=bug,good-first-issue owner_route=repo_maintainer_review related_code=src/parser.py validation=unit_smoke promotion_target=agent_todo:todo_issue_fix status=selected_anchor freshness=fresh
+```
+
+This is the small state face for issue/PR anchor selection. It keeps labels,
+owner route, related-code hint, validation surface, and promotion target visible
+to agents and dashboards without storing issue bodies, private source context,
+raw solver traces, or publication authority.
+
 This keeps open-source PR-led growth connected to LoopX's core promise:
 long-running agent work should be selectable, bounded, reviewable, and improved
 through human feedback.

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -817,6 +817,14 @@ Item fields:
   primary action surface, while monitor items are supplemental context that
   should not consume the selected goal's advancement slot unless they record a
   material transition or blocker.
+- `issue_meta_surface`: optional public-safe issue/PR anchor projection parsed
+  from an active-state `## Issue Meta Surface` section and mirrored under
+  `project_asset.issue_meta_surface`. Schema `issue_meta_surface_v0` carries a
+  bounded list of compact `issue_meta_surface_item_v0` rows with
+  `repo_handle`, `issue_handle`, GitHub-style `labels`, `owner_route`,
+  `related_code_hint`, `validation_surface`, `promotion_target`, `status`, and
+  `freshness`. It is a scenario state surface for issue/PR solver anchors, not
+  a command to read private source, publish comments, or open PRs.
 - `capability_gate`: optional per-goal quota projection derived from visible
   executable agent todos that declare `required_capabilities`. When
   `action=run`, the gate projects `runnable_candidates` and

--- a/examples/issue-meta-surface-smoke.py
+++ b/examples/issue-meta-surface-smoke.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Smoke-test public-safe issue meta surface projection."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.status import parse_issue_meta_surface, project_asset_summary_is_public_safe  # noqa: E402
+
+
+GOAL_ID = "issue-meta-surface-fixture"
+ISSUE_META_LINE = (
+    "- anchor_id=issue_anchor_parser_bug repo=sample-org/sample-repo "
+    "issue=#128 labels=bug,good-first-issue owner_route=repo_maintainer_review "
+    "related_code=src/parser.py validation=unit_smoke "
+    "promotion_target=agent_todo:todo_issue_fix status=selected_anchor freshness=fresh"
+)
+
+
+def state_text() -> str:
+    return (
+        "---\n"
+        "status: active\n"
+        "updated_at: 2026-01-01T00:00:00+00:00\n"
+        "---\n\n"
+        "# Issue Meta Surface Fixture\n\n"
+        "## Next Action\n\n"
+        "- Promote the public issue anchor into a bounded solver todo.\n\n"
+        "## Issue Meta Surface\n\n"
+        f"{ISSUE_META_LINE}\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] [P1] Promote issue_anchor_parser_bug into an approved solver handoff.\n"
+    )
+
+
+def run_cli(*args: str, registry_path: Path, runtime: Path) -> dict:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--registry",
+            str(registry_path),
+            "--runtime-root",
+            str(runtime),
+            "--format",
+            "json",
+            *args,
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def write_fixture(root: Path) -> tuple[Path, Path]:
+    project = root / "project"
+    runtime = root / "runtime"
+    state_file = f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    state_path = project / state_file
+    registry_path = project / ".loopx" / "registry.json"
+
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(state_text(), encoding="utf-8")
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "issue-meta-surface-fixture",
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": state_file,
+                        "adapter": {
+                            "kind": "harness_self_improvement",
+                            "status": "connected-read-only",
+                        },
+                        "authority_sources": [],
+                        "quota": {
+                            "compute": 1.0,
+                            "window_hours": 24,
+                            "allowed_slots": 5,
+                        },
+                    }
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return registry_path, runtime
+
+
+def assert_issue_meta_surface(surface: dict) -> None:
+    assert surface["schema_version"] == "issue_meta_surface_v0", surface
+    assert surface["source_section"] == "Issue Meta Surface", surface
+    assert surface["item_count"] == 1, surface
+    item = surface["items"][0]
+    assert item["schema_version"] == "issue_meta_surface_item_v0", item
+    assert item["anchor_id"] == "issue_anchor_parser_bug", item
+    assert item["repo_handle"] == "sample-org/sample-repo", item
+    assert item["issue_handle"] == "#128", item
+    assert item["labels"] == ["bug", "good-first-issue"], item
+    assert item["owner_route"] == "repo_maintainer_review", item
+    assert item["related_code_hint"] == "src/parser.py", item
+    assert item["validation_surface"] == "unit_smoke", item
+    assert item["promotion_target"] == "agent_todo:todo_issue_fix", item
+    assert item["status"] == "selected_anchor", item
+    assert item["freshness"] == "fresh", item
+    assert project_asset_summary_is_public_safe({"issue_meta_surface": surface}), surface
+
+
+def main() -> int:
+    parsed = parse_issue_meta_surface(state_text())
+    assert parsed is not None
+    assert_issue_meta_surface(parsed)
+
+    with tempfile.TemporaryDirectory(prefix="loopx-issue-meta-surface-") as tmp:
+        registry_path, runtime = write_fixture(Path(tmp))
+        status_payload = run_cli("status", registry_path=registry_path, runtime=runtime)
+        items = status_payload.get("attention_queue", {}).get("items") or []
+        assert len(items) == 1, status_payload
+        item = items[0]
+        assert_issue_meta_surface(item["issue_meta_surface"])
+        assert_issue_meta_surface(item["project_asset"]["issue_meta_surface"])
+
+    print("issue-meta-surface-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -360,10 +360,14 @@ MAX_PROJECT_ASSET_TODO_ITEMS = 3
 MAX_PROJECT_ASSET_TODO_BACKLOG_ITEMS = 8
 MAX_TODO_VISIBILITY_LANE_ITEMS = 16
 MAX_DEFERRED_TODO_VISIBILITY_ITEMS = 8
+MAX_ISSUE_META_SURFACE_ITEMS = 8
+MAX_ISSUE_META_LABELS = 8
 MAX_TODO_INDEX_ITEMS = 240
 MAX_TODO_INDEX_ROLLOUT_EVENTS_PER_GOAL = 500
 TODO_PROJECTION_VIEW_SCHEMA_VERSION = "todo_projection_view_v0"
 TODO_PROJECTION_DETAIL_POINTER_SCHEMA_VERSION = "todo_projection_detail_pointer_v0"
+ISSUE_META_SURFACE_SCHEMA_VERSION = "issue_meta_surface_v0"
+ISSUE_META_SURFACE_ITEM_SCHEMA_VERSION = "issue_meta_surface_item_v0"
 MAX_DEPENDENCY_BLOCKERS = 4
 MAX_AUTONOMOUS_BACKLOG_CANDIDATES = 6
 MAX_SUBAGENT_ACTIVITY_ITEMS = 5
@@ -376,6 +380,10 @@ AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK = 30
 AUTONOMOUS_PRIORITY_PATTERN = re.compile(r"^\s*\[(P[0-4][^\]]*)\]\s*(.+)$", re.IGNORECASE)
 BACKLOG_HYGIENE_SECTION_HEADINGS = ("Next Action", "Operating Lessons")
 BACKLOG_HYGIENE_BULLET_PATTERN = re.compile(r"^\s*(?:[-*]|\d+[.)])\s+(.+?)\s*$")
+ISSUE_META_SURFACE_SECTION_HEADINGS = ("Issue Meta Surface", "Issue/PR Meta Surface")
+ISSUE_META_SURFACE_FIELD_PATTERN = re.compile(
+    r"(?P<key>[a-z_][a-z0-9_-]*)=(?P<value>\"[^\"]+\"|'[^']+'|[^\s]+)"
+)
 BACKLOG_HYGIENE_HINT_PATTERN = re.compile(
     r"(?i)(?:\[p[0-4]\]|todo|backlog|follow[- ]?up|queue|audit|regression|smoke|cadence|mirror|monitor|sub-?agent|待办|回归|审计|修复|检查|推进)"
 )
@@ -4332,6 +4340,117 @@ def active_state_sections(state_text: str, headings: tuple[str, ...]) -> dict[st
     return sections
 
 
+def issue_meta_surface_blocks(lines: list[str]) -> list[str]:
+    blocks: list[str] = []
+    current: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith(("- ", "* ")):
+            if current:
+                blocks.append(" ".join(current))
+            current = [stripped[2:].strip()]
+            continue
+        if current and line.startswith((" ", "\t")):
+            current.append(stripped)
+    if current:
+        blocks.append(" ".join(current))
+    return blocks
+
+
+def issue_meta_public_value(value: Any, *, limit: int = 120) -> str | None:
+    text = public_safe_compact_text(value, limit=limit)
+    if not text:
+        return None
+    if "<" in text or ">" in text:
+        return None
+    return text.strip("\"'")
+
+
+def issue_meta_list(value: Any, *, limit: int = MAX_ISSUE_META_LABELS) -> list[str]:
+    if value is None:
+        return []
+    raw_values = re.split(r"[,;|]", str(value or ""))
+    items: list[str] = []
+    seen: set[str] = set()
+    for raw in raw_values:
+        item = issue_meta_public_value(raw, limit=80)
+        if not item or item in seen:
+            continue
+        seen.add(item)
+        items.append(item)
+        if len(items) >= limit:
+            break
+    return items
+
+
+def parse_issue_meta_surface_block(block: str, *, index: int) -> dict[str, Any] | None:
+    fields: dict[str, str] = {}
+    for match in ISSUE_META_SURFACE_FIELD_PATTERN.finditer(block):
+        key = str(match.group("key") or "").strip().lower().replace("-", "_")
+        value = str(match.group("value") or "").strip().strip("\"'")
+        if key and value:
+            fields[key] = value
+    if not fields:
+        return None
+
+    item: dict[str, Any] = {
+        "schema_version": ISSUE_META_SURFACE_ITEM_SCHEMA_VERSION,
+        "index": index,
+    }
+    alias_map = {
+        "anchor_id": ("anchor_id", "id"),
+        "repo_handle": ("repo_handle", "repo"),
+        "issue_handle": ("issue_handle", "issue", "issue_or_pr", "issue_or_pr_handle"),
+        "owner_route": ("owner_route", "owner"),
+        "related_code_hint": ("related_code_hint", "related_code", "code"),
+        "validation_surface": ("validation_surface", "validation"),
+        "promotion_target": ("promotion_target", "promotion"),
+        "status": ("status",),
+        "freshness": ("freshness",),
+    }
+    for output_key, aliases in alias_map.items():
+        raw_value = next((fields[alias] for alias in aliases if alias in fields), None)
+        value = issue_meta_public_value(raw_value)
+        if value:
+            item[output_key] = value
+    labels = issue_meta_list(fields.get("labels") or fields.get("label"))
+    if labels:
+        item["labels"] = labels
+
+    required = ("repo_handle", "owner_route", "validation_surface", "promotion_target")
+    if not all(item.get(key) for key in required):
+        return None
+    if not item.get("anchor_id"):
+        repo = str(item.get("repo_handle") or "")
+        issue = str(item.get("issue_handle") or "")
+        anchor_basis = "|".join(part for part in (repo, issue, str(index)) if part)
+        item["anchor_id"] = f"issue_anchor_{hashlib.sha1(anchor_basis.encode('utf-8')).hexdigest()[:10]}"
+    return item
+
+
+def parse_issue_meta_surface(state_text: str) -> dict[str, Any] | None:
+    section_map = active_state_sections(state_text, ISSUE_META_SURFACE_SECTION_HEADINGS)
+    for heading in ISSUE_META_SURFACE_SECTION_HEADINGS:
+        lines = section_map.get(heading) or []
+        blocks = issue_meta_surface_blocks(lines)
+        items = [
+            item
+            for index, block in enumerate(blocks, start=1)
+            for item in [parse_issue_meta_surface_block(block, index=index)]
+            if item
+        ]
+        if items:
+            return {
+                "schema_version": ISSUE_META_SURFACE_SCHEMA_VERSION,
+                "source_section": heading,
+                "item_count": len(items),
+                "items": items[:MAX_ISSUE_META_SURFACE_ITEMS],
+            }
+    return None
+
+
 def active_state_section_entries(lines: list[str]) -> list[str]:
     entries: list[str] = []
     current: list[str] = []
@@ -5758,6 +5877,9 @@ def active_state_todo_fields(goal: dict[str, Any]) -> dict[str, Any]:
     except OSError:
         return {}
     fields = parse_active_state_todos(state_text, goal=goal, state_path=state_path)
+    issue_meta_surface = parse_issue_meta_surface(state_text)
+    if issue_meta_surface:
+        fields["issue_meta_surface"] = issue_meta_surface
     next_action_entries = active_state_next_action_entries(state_text, limit=3)
     if next_action_entries:
         fields["active_state_next_action"] = next_action_entries[0]
@@ -6797,6 +6919,13 @@ def build_attention_queue(
                     active_next_action = item.get("active_state_next_action")
                     if active_next_action:
                         item["project_asset"]["active_state_next_action"] = active_next_action
+                    issue_meta_surface = (
+                        item.get("issue_meta_surface")
+                        if isinstance(item.get("issue_meta_surface"), dict)
+                        else None
+                    )
+                    if issue_meta_surface:
+                        item["project_asset"]["issue_meta_surface"] = issue_meta_surface
                     next_action_warning = next_action_projection_warning(
                         active_state_next_action=active_next_action,
                         latest_run_recommended_action=item.get("latest_run_recommended_action"),


### PR DESCRIPTION
## Summary
- add a public-safe issue_meta_surface_v0 projection from active-state Issue Meta Surface bullets
- mirror the projection under project_asset.issue_meta_surface for status consumers
- add a durable smoke fixture plus status contract/product docs

## Validation
- python3 -m py_compile loopx/status.py examples/issue-meta-surface-smoke.py
- python3 examples/issue-meta-surface-smoke.py
- python3 examples/status-markdown-smoke.py
- git diff --check
- loopx check --scan-path loopx/status.py --scan-path examples/issue-meta-surface-smoke.py --scan-path docs/status-data-contract.md --scan-path docs/product/issue-pr-solver-anchor-coordination.md

Note: loopx check reports the existing loopx-meta duplicate index row warning; public boundary scan is clean for the four touched files.