### PR TITLE
Clarify LoopX maintainer product narrative

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,8 +11,9 @@ incident report, or launch draft.
 - [Getting started](guides/getting-started.md): agent-first start, manual
   installation, project connection, diagnosis, daily workflow, heartbeats,
   dashboard, development, and command reference.
-- [Product vision](product/vision.md): long-term product direction and the
-  creator-operator medium-term case.
+- [Product vision](product/vision.md): long-term product direction, Loop Agent
+  definition, maintainer-first management surface, and open-source anchor
+  strategy.
 - [Codex CLI TUI-first loop](product/codex-cli-tui-loop.md): first-class
   Codex CLI onboarding target where one visible TUI message starts LoopX, with
   session-attached automation as the preferred follow-up.
@@ -75,6 +76,7 @@ incident report, or launch draft.
 - [Codex CLI TUI-first loop](product/codex-cli-tui-loop.md)
 - [Reward-style replanning hints](product/reward-style-replanning.md)
 - [Frontstage channel and lease roadmap](frontstage-channel-lease-roadmap.md)
+- [Non-technical operator status model](product/nontechnical-operator-status-model.md)
 - [Long-task cadence policy](long-task-cadence-policy.md)
 - [Dreaming exploration lane](dreaming-exploration-lane.md)
 - [Session runtime control-plane adapter](session-runtime-control-plane-adapter.md)

--- a/docs/outreach/public-launch-narrative-draft.md
+++ b/docs/outreach/public-launch-narrative-draft.md
@@ -17,6 +17,12 @@ Its strongest public position is:
 > work waits explicitly, while independent safe lanes keep moving with
 > evidence.
 
+An even more concrete way to say this for early users:
+
+> LoopX helps a maintainer manage Loop Agents as always-running digital
+> workers: pick the right anchors, keep gates visible, review evidence, and
+> decide what should improve next.
+
 The important product detail is not that the harness stores more state. It is
 that the state becomes actionable:
 
@@ -29,9 +35,33 @@ that the state becomes actionable:
 - the next agent can inherit the decision instead of reconstructing it from
   chat history.
 
+## Public-Safe Primary Case
+
+The strongest first public story should be maintainer-first management, not a
+domain-specific solver UI.
+
+A maintainer has several long-running agent lanes: product docs, showcase
+cards, open-source collaboration candidates, issue / PR pilot ideas, and
+private strategy inputs. Without a control plane, the maintainer becomes the
+scheduler: reading chats, remembering which agent owns which lane, deciding
+what still matters, and asking "continue?" again and again.
+
+LoopX should make that work visible:
+
+1. Incoming signals enter a compact signal inbox.
+2. The maintainer or policy selects a small number of high-value anchors.
+3. Each anchor gets an owner, allowed action, evidence boundary, and stop
+   condition.
+4. Agent work writes back evidence instead of raw traces.
+5. Human feedback becomes performance-review signal: value, quality, control,
+   cost, and learning.
+
+This is the core public claim: LoopX is not another executor. It is the
+management surface for long-running agent work.
+
 ## Public-Safe Good Case
 
-A useful public-safe example is a long-horizon benchmark rotation.
+A useful supporting example is a long-horizon benchmark rotation.
 
 The agent was rotating across Terminal-Bench, SkillsBench, and Agents' Last
 Exam style work. One benchmark family became source-ready, but the next real
@@ -54,6 +84,29 @@ choice. LoopX should make the user decision explicit while still using
 the agent turn on safe validated work. The operator sees both facts: what needs
 their decision, and why the agent is still allowed to make progress elsewhere.
 
+## Public-Safe Office Operations Case
+
+Another supporting story is office operations: social research, chat/context
+review, draft preparation, and outreach follow-up.
+
+The risky version of this story says "the agent writes more posts." That is too
+shallow. The better story is:
+
+1. Connectors bring in information from browser channels, local chat archives,
+   issues, docs, or tasks.
+2. LoopX turns information into selected signals and anchors instead of a noisy
+   stream.
+3. The agent proposes a draft, reply, follow-up, or research note.
+4. A human scores usefulness, taste, risk, and source quality.
+5. Publishing or outreach remains a gate.
+6. The Loop Agent review records what became a qualified conversation,
+   accepted insight, useful draft, or rejected path.
+
+This makes office operations a good acquisition story because many teams feel
+information overload before they feel a need for another agent framework.
+LoopX should claim the management loop: more relevant signals, better feedback,
+clearer gates, and evidence-backed improvement.
+
 ## Message Architecture
 
 The external story can be compressed into three claims:
@@ -62,8 +115,9 @@ The external story can be compressed into three claims:
    recoverable, reviewable, and bounded.
 2. Human-in-the-loop is not frequent confirmation. It is durable user intent,
    gate, reward, and boundary state that future agent turns can inherit.
-3. Good long-running automation needs a control plane for objective, evidence,
-   fallback, quota, and publication safety.
+3. Good long-running automation needs a maintainer surface for signal intake,
+   anchor selection, evidence, fallback, quota, performance review, and
+   publication safety.
 
 This lets the project stay distinct from generic agent frameworks:
 
@@ -77,11 +131,18 @@ This lets the project stay distinct from generic agent frameworks:
 Public README and PR copy may claim:
 
 - LoopX makes user and agent work lanes explicit.
+- LoopX helps maintainers manage Loop Agents through signal inbox, selected
+  anchors, gates, evidence, and performance review.
 - A gated high-priority lane can coexist with safe fallback work.
 - Fallback work is audited as fallback.
 - Quota spend happens only after validated delivery or compact blocker
   writeback.
 - Public/private boundary checks are part of the product surface.
+- Open-source issue / PR pilots can be used as high-value anchors when the
+  implementation ownership, evidence boundary, and showcase consent are clear.
+- Office-operations pilots can use browser, chat, issue, doc, and task
+  connectors as information inputs, while publish/outreach actions remain
+  explicit human gates.
 
 Public copy should not claim:
 
@@ -95,6 +156,13 @@ Public copy should not claim:
 
 Useful next public assets:
 
+- a maintainer-first management screenshot with signal inbox, anchors, active
+  lanes, gates, evidence, and performance-review notes;
+- a public-safe open-source anchor packet template for issue / PR solver
+  pilots;
+- a public-safe office-operations connector storyboard that measures accepted
+  signals, qualified conversations, useful drafts, feedback learning, and
+  boundary correctness instead of raw article count;
 - a fake benchmark-rotation demo that shows `user_gate + safe_fallback`;
 - a README screenshot or status fixture where the blocked gate and fallback are
   both visible;

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -5,11 +5,14 @@ runtime contract, benchmark route, or launch draft.
 
 - [Product vision](vision.md): how LoopX grows from an engineering
   control plane into a human-friendly dynamic goal control plane for
-  long-running agent work, including the creator-operator productization case.
+  long-running agent work, centered on Loop Agents, maintainer-first management,
+  Agent Work Feed review, performance review, high-value open-source anchors,
+  and office-operations connector showcases.
 - [Server-client product shape](server-client-product-shape.md): the medium-term
-  product model where the server owns durable state, delivery/planning queue
-  boundaries, and governed proposal promotion, the client acts as the user's
-  intent proxy, and executor loops perform bounded work with evidence writeback.
+  product model where the server owns durable state, signal inbox, selected
+  anchors, delivery/planning queue boundaries, performance-review summaries,
+  and governed proposal promotion, the client acts as the maintainer proxy, and
+  executor loops perform bounded work with evidence writeback.
 - [Codex CLI TUI-first LoopX loop](codex-cli-tui-loop.md): the
   first-class Codex CLI product contract where one TUI message starts the Goal
   Harness loop, later automation tries to steer the same visible session, and
@@ -74,8 +77,10 @@ runtime contract, benchmark route, or launch draft.
   review handoff policy, while keeping todo ownership in `claimed_by` and future
   leases.
 - [Non-technical operator status model](nontechnical-operator-status-model.md):
-  first-screen card model for people who need to understand agent progress,
-  blockers, next moves, and feedback paths without reading logs or CLI output.
+  first-screen Agent Work Feed and card model for people who need to review
+  agent outputs, progress, blockers, next moves, signal inbox, anchor
+  selection, performance review, and feedback paths without reading logs or CLI
+  output.
 - [Intelligent management surface](intelligent-management-surface.md):
   maintainer-first product design for signal inbox, selected anchors, agent
   lanes, review feed, and performance review so long-running Loop Agents can be

--- a/docs/product/nontechnical-operator-status-model.md
+++ b/docs/product/nontechnical-operator-status-model.md
@@ -19,6 +19,70 @@ creator-operator cases. The copy can change by domain, but the control-plane
 objects stay the same: goal, gate, todo, evidence, safe side path, run history,
 quota, and feedback.
 
+The first real target user is the maintainer/operator of Loop Agents. That
+person is not only asking "what did the agent do?" They are asking:
+
+- what external signals deserve attention;
+- which signals should become high-value anchors;
+- which agent lane owns the next step;
+- whether the agent is becoming more useful or merely busier;
+- where human judgment should change the loop.
+
+## Adoption Modes
+
+The status surface should support two adoption modes.
+
+### Read-Only Review Mode
+
+In read-only mode, the user can connect existing agent work without adopting
+the LoopX control loop. The surface ingests public or consented artifacts such
+as issues, pull requests, documents, run summaries, compact logs, or manually
+entered feedback. It then shows a reviewable summary and captures human scores.
+
+This mode should not mutate the agent's plan. Its product value is measurement:
+the maintainer can see whether the agent created useful work, respected
+boundaries, consumed attention responsibly, and improved over time.
+
+### LoopX Writeback Mode
+
+In writeback mode, the same feedback becomes control-plane input. Scores and
+comments can turn into gates, todo changes, selected anchors, reward notes,
+scope corrections, or next improvement targets. The important contract is that
+the display surface does not silently convert taste or fuzzy feedback into
+hard policy. It must show what will be written back and why.
+
+This two-step adoption path keeps the product easy to try while preserving the
+larger LoopX promise: review first, then controlled improvement.
+
+## Agent Work Feed
+
+The default interaction should feel like reviewing a feed of agent work cards,
+not like operating a backend console. A user should be able to "swipe through"
+recent outputs and give low-friction feedback while still keeping every card
+auditable.
+
+A work card represents a reviewed output, not a raw todo:
+
+- `Output`: what the agent produced.
+- `Why now`: why this deserves attention instead of staying in history.
+- `Evidence`: artifact, validation, source boundary, or blocker.
+- `Cost`: token/quota cost and user-attention cost when available.
+- `Next proposal`: continue, stop, validate, promote, or ask.
+- `Feedback`: structured buttons that write to review state.
+
+The feed should prioritize management value:
+
+- unresolved human gates;
+- high-value but uncertain outputs;
+- expensive repeated work patterns;
+- evidence gaps before promotion;
+- cards that may become anchors, showcases, or public-safe examples.
+
+The feed must stay inspectable. A card can be lightweight on the first screen,
+but the user should be able to open the evidence, PR, run summary, boundary
+note, or review history behind it. Otherwise the surface becomes attractive
+but untrustworthy.
+
 ## Design Principles
 
 1. **Start with user meaning, not runtime internals.** The first screen should
@@ -32,11 +96,37 @@ quota, and feedback.
 4. **Treat feedback as a structured transition.** User feedback should become
    a gate decision, preference hint, todo change, or product-improvement note,
    not an untracked chat memory.
-5. **Prefer one next action.** The first screen can link to a backlog, but it
+5. **Review performance, not just status.** A Loop Agent should show where it
+   created value, where it lost points, what feedback changed, and what it
+   should improve next.
+6. **Make feedback cheap but structured.** The user should be able to dismiss,
+   approve, correct, promote, or gate a work card without reading a long run
+   report first.
+7. **Prefer one next action.** The first screen can link to a backlog, but it
    should name the next concrete thing that will happen or the exact question
    that needs a human answer.
 
 ## Card Set
+
+### Work Feed
+
+Purpose: let the user quickly review recent agent outputs and turn fuzzy
+judgment into structured feedback.
+
+Suggested fields:
+
+- `Card type`: progress, blocker, proposal, evidence, anchor candidate,
+  showcase candidate, or boundary warning.
+- `Summary`: one or two sentences of what the agent produced.
+- `Proof`: compact evidence and validation state.
+- `Cost`: token/quota cost, elapsed time, and attention cost where known.
+- `Suggested action`: continue, validate, promote, defer, stop, or ask.
+- `Feedback actions`: useful, not useful, wrong direction, evidence missing,
+  promote to anchor, private/risky.
+
+The feed is the primary review surface. Other cards can appear as card details
+or filters, but the first screen should help the user clear the highest-value
+review items quickly.
 
 ### Goal Snapshot
 
@@ -73,6 +163,41 @@ Suggested fields:
 This card should never claim outcome progress from a surface-only change. If a
 turn only prepared a contract or doc, say that plainly and point to the next
 outcome-bearing step.
+
+### Signal Inbox
+
+Purpose: show which outside signals entered the loop and whether any are worth
+turning into work.
+
+Suggested fields:
+
+- `Signal`: issue, PR, review comment, failing check, chat feedback, doc
+  change, benchmark result, or user note.
+- `Source`: public artifact, private source, connector, or manual entry.
+- `Fit`: ignore, monitor, candidate anchor, ask owner, or create todo.
+- `Boundary`: public-safe, private, requires owner review, or not usable.
+
+This card is quiet by default. It should avoid turning every signal into work.
+The maintainer should see the few signals that might change priorities.
+
+### Anchor Selection
+
+Purpose: identify the small number of high-value anchors worth driving.
+
+Suggested fields:
+
+- `Anchor`: public issue, PR, failing check, stale review, user request,
+  showcase candidate, or internal management question.
+- `Why this matters`: credible pain, repeated workflow, public evidence, or
+  strategic value.
+- `Allowed action`: observe, route owner, diagnose, open PR, write proposal, or
+  ask human.
+- `Owner split`: LoopX maintainer, collaborator, repo maintainer, or adapter.
+- `Exit`: accepted, rejected, merged, blocked, unsafe, or showcase candidate.
+
+For open-source issue / PR pilots, this card is the bridge between growth and
+control. LoopX does not need to implement every solver; it needs to choose
+anchors well and keep the evidence reviewable.
 
 ### Current Work
 
@@ -159,6 +284,49 @@ feedback can shape replanning, but private chat should not become public
 evidence, and soft preferences should remain distinguishable from safety,
 permission, or compliance gates.
 
+### Performance Review
+
+Purpose: help the maintainer judge whether the Loop Agent is improving.
+
+Suggested fields:
+
+- `Value`: what useful artifact or decision was created.
+- `Quality`: accepted, corrected, rejected, blocked, or needs review.
+- `Control`: whether gates, scope, and boundaries were respected.
+- `Cost`: quota or attention spent relative to value.
+- `Learning`: what should change next time.
+
+This is the main way fuzzy human feedback becomes durable without pretending it
+is a benchmark score. The review can stay lightweight, but it must be tied to
+evidence and a next improvement target.
+
+### Project-Level Reward
+
+Single-task benchmarks can measure whether an agent solved one task. They do
+not fully measure whether a long-running agent created useful value across a
+complex project. The management surface should therefore expose a
+project-level reward model:
+
+```text
+reward = f(quantity, quality, token cost, user attention cost)
+```
+
+The fields have different sources:
+
+- `Quantity`: completed tasks, accepted anchors, merged PRs, resolved
+  blockers, or other countable outputs.
+- `Quality`: human review, maintainer score, accepted/rejected outcomes,
+  correction rate, and evidence quality.
+- `Token cost`: run and quota accounting.
+- `User attention cost`: user gates, review requests, clarification turns,
+  approval steps, and manual interventions.
+
+This is where the intelligent display surface becomes more than a dashboard:
+it supplies the missing quality signal. A user can first connect existing
+agent work in read-only mode, score the work, and see whether the agent is
+creating value. After LoopX writeback is enabled, the same score can adjust
+gates, todos, anchors, reward notes, and next improvement targets.
+
 ## State Mapping
 
 The first screen should be generated from existing LoopX projections
@@ -168,11 +336,14 @@ before adding new UI state.
 | --- | --- |
 | Goal Snapshot | registry goal, active state objective, latest status classification |
 | Since Last Check | run history, refresh-state delivery outcome, validation evidence |
+| Signal Inbox | connector events, user feedback, issue/PR metadata, doc changes |
+| Anchor Selection | planning queue proposals, promoted todos, future anchor packets |
 | Current Work | agent todos, `claimed_by`, future `agent_profile_v0`, future leases |
 | Blocker Or Gate | user todos, operator gate, interaction contract, goal boundary |
 | Next Agent Move | quota decision, recommended action, next action, stop condition |
 | What I Need From You | user todo summary and concrete operator question |
 | Feedback Capture | reward overlay, gate command, todo update, future feedback signal |
+| Performance Review | run evidence, reward overlays, outcome classification, cost summary |
 
 Missing fields should degrade gracefully. For example, before hard leases exist,
 show `claimed_by` as soft ownership and avoid claiming exclusive execution.
@@ -217,10 +388,14 @@ The first implementation of this model is ready when:
 - a public-safe status mock can render all cards from synthetic or existing
   compact LoopX projections;
 - open user todos appear as concrete questions, not generic "owner gate" copy;
+- signal inbox and anchor selection can represent at least one public-safe
+  issue/PR pilot without requiring a custom issue-fix UI;
 - no-open-user-todo states render quietly without false urgency;
 - side-agent ownership and review handoff are visible without overriding quota
   or gate decisions;
 - feedback buttons map to explicit control-plane effects;
+- performance-review notes stay evidence-backed and distinguish value,
+  quality, control, cost, and learning;
 - private evidence, raw traces, credentials, and internal links cannot appear
   in the public card payload.
 

--- a/docs/product/server-client-product-shape.md
+++ b/docs/product/server-client-product-shape.md
@@ -26,6 +26,8 @@ long-running facts become coherent:
   history;
 - registered agent identity, role, scope, worktree policy, and review handoff
   defaults;
+- maintainer-facing signal inbox, selected anchors, and performance-review
+  summaries;
 - per-todo claim and future lease state;
 - quota, spend, idempotency, and concurrency policy;
 - compact public/private boundary summaries;
@@ -44,6 +46,13 @@ The server should stay conservative. Planning lanes may rank candidate todos,
 surface refactor warnings, or propose evidence probes, but they do not execute
 protected work, read private material, or spend delivery quota until promoted
 through the normal gate, quota, and boundary path.
+
+For the maintainer-first product surface, the server should treat external
+signals as candidates before they become work. A GitHub issue, pull request,
+failing check, Lark feedback, or document change can enter the signal inbox;
+only selected high-value anchors become todos, owner-routing requests, or
+showcase candidates. This keeps "always running" from turning into "always
+busy."
 
 ### Delivery And Planning Queues
 
@@ -151,7 +160,7 @@ agent runtime
 
 ### Client
 
-The client is the user's agent-facing proxy. It turns human intent into
+The client is the maintainer's agent-facing proxy. It turns human intent into
 governed control-plane transitions and turns raw agent activity back into an
 operator-readable surface.
 
@@ -159,7 +168,10 @@ The client can be a CLI, dashboard, Lark document workflow, browser UI, or host
 adapter. The important product responsibility is the same:
 
 - explain what the goal is trying to accomplish now;
+- show the signal inbox and selected high-value anchors;
 - show what happened, what is blocked, and what will happen next;
+- show whether a Loop Agent is earning value, respecting control, and staying
+  cost-aware;
 - collect user judgment, taste, approval, rejection, deferral, or reward;
 - translate that input into gates, preferences, todo changes, or handoffs;
 - route executor loops toward the current state without embedding stale policy;
@@ -168,6 +180,12 @@ adapter. The important product responsibility is the same:
 This is why the client is more than intent classification. It is a product
 surface for long-running work: it carries context, permission, feedback,
 visibility, and trust.
+
+Issue / PR solver pilots should therefore appear first as anchor-management
+flows, not as a separate issue-fix product. The client can show: why this issue
+or PR is worth acting on, who owns implementation, what action is allowed, what
+evidence will be accepted, and whether the outcome can graduate into public
+showcase material.
 
 ### Executor Loop
 
@@ -207,6 +225,42 @@ into an agent instruction. The executor should not bypass the client by hiding
 important decisions in chat or local memory. LoopX exists so user
 judgment, agent work, evidence, and future planning remain visible in the same
 control plane.
+
+## Decoupled Display And Control
+
+The intelligent display surface can be adopted before the full LoopX control
+loop. This separation matters for early users and partner teams.
+
+In **display-only mode**, the server or local state store can ingest agent work
+products and review signals without owning the executor's next action:
+
+```text
+external agent artifacts
+  -> signal / evidence ingestion
+  -> review_event_v0
+  -> performance_review_v0
+  -> maintainer dashboard
+```
+
+This mode quantifies value but does not steer execution. It is appropriate for
+existing Codex, Claude Code, OpenViking-style solver, office-operations, or
+internal agent workflows where the user first wants to inspect and score work.
+
+In **LoopX control mode**, accepted review output becomes governed state:
+
+```text
+performance_review_v0
+  -> gate / todo / anchor / reward / preference writeback
+  -> quota and boundary checked LoopX work
+  -> new evidence
+  -> next review event
+```
+
+Both modes should live in one product system and preferably one repository for
+now. The code boundary should still be explicit: the display app may run
+read-only, while writeback paths must call LoopX schemas, gates, quota, and
+boundary checks. This lets frontend collaborators build a polished surface
+without accidentally creating a second source of truth.
 
 ## Capability Boundaries
 
@@ -253,10 +307,18 @@ The first product slices should remain small and compatible with CLI-only mode.
    signals, or proposed todos that can receive user feedback and later produce
    `feedback_signal_v0`, `todo_update`, `anchor_update`, or
    `performance_review_note`.
-9. **`advisory_summary_v0`**: optional model-backed summary of recent state,
+9. **`anchor_candidate_v0`**: selected external signals that may become work.
+   The minimal record should include source kind, public/private boundary,
+   reason to care, allowed action, owner split, stop condition, expected
+   evidence, and showcase-consent status.
+10. **`project_level_reward_v0`**: aggregate value estimate for long-running
+   agent work across a project. It combines quantity, human-scored quality,
+   token spend, and user-attention spend so benchmark evidence can be compared
+   with maintainer value without reducing everything to a single task score.
+11. **`advisory_summary_v0`**: optional model-backed summary of recent state,
    used only for wording or clustering. It is default-off for control and cannot
    mutate state unless converted into a typed object above.
-10. **`handoff_packet_v0`**: compact executor input that carries the selected
+12. **`handoff_packet_v0`**: compact executor input that carries the selected
    todo, stop condition, validation expectation, boundary notes, and writeback
    target without copying the whole project history.
 
@@ -280,7 +342,8 @@ The near-term roadmap should therefore prefer:
 - local concurrency correctness before broad server scheduling;
 - side-agent scope and worktree policy before autonomous multi-agent merging;
 - planning proposals before background execution;
-- user feedback modeling before personalization claims.
+- user feedback and performance-review modeling before personalization claims;
+- anchor selection before domain-specific solver UIs.
 
 The product promise stays the same across these layers: make the human decision
 explicit, keep safe side work moving when it is independent, and make every

--- a/docs/product/vision.md
+++ b/docs/product/vision.md
@@ -8,8 +8,11 @@ control plane: a way to turn a static agent goal into long-running, reviewable
 state that stays understandable and recoverable across many turns.
 
 The long-term product should help humans who do not want to inspect prompts,
-logs, or traces. A user should be able to run multiple agents across tools and
-off-hours, then open a first screen and understand:
+logs, or traces. The first customer is the maintainer/operator of a Loop Agent:
+someone who needs to manage always-running digital workers, external signals,
+human gates, evidence, and value over time. A user should be able to run
+multiple agents across tools and off-hours, then open a first screen and
+understand:
 
 - what the agent has done;
 - what the agent is doing now;
@@ -17,6 +20,23 @@ off-hours, then open a first screen and understand:
 - what will happen next;
 - what the agent needs from the user;
 - how user feedback changes the plan.
+
+## Loop Agent
+
+A Loop Agent is an always-running digital worker with:
+
+- a relatively stable responsibility;
+- a relatively consistent work objective;
+- external signals it watches or receives;
+- work products that match its responsibility;
+- organized evidence of what it did and why it mattered;
+- human feedback through a lightweight performance-review loop;
+- explicit focus and cost controls.
+
+LoopX should not try to make every worker smarter by hiding more autonomy in
+the executor. It should make the worker more manageable: selectable work,
+visible gates, bounded execution, compact evidence, reviewable outcomes, and
+clear next improvement targets.
 
 ## First-Screen Copy
 
@@ -37,6 +57,130 @@ primary and side agents can continue bounded work, while human gates,
 capability gates, quota, evidence, and project boundaries remain explicit. In
 that sense, LoopX is not just a longer prompt or a bigger todo list; it
 is the dynamic goal state around executor loops.
+
+## Maintainer-First Management Surface
+
+The highest-priority product surface is an intelligent management view for the
+maintainer/operator. It should answer:
+
+- what signals arrived since the last check;
+- which signals are high-value anchors worth acting on;
+- which Loop Agent owns each active lane;
+- which human gates need attention;
+- what evidence proves progress or explains a stop;
+- where the agent earned or lost performance-review credit;
+- what next management action matters most.
+
+This surface comes before a domain-specific issue-fix UI. Open-source issue and
+PR work is valuable because it creates visible artifacts and measurable
+feedback, but it should feed the maintainer surface rather than define the
+whole product.
+
+### Agent Work Feed
+
+The ideal first interaction is closer to a recommendation feed than to a
+project dashboard. The user should be able to review agent work the way they
+review a stream of cards: quickly decide whether each output was useful,
+misdirected, risky, or worth turning into the next anchor.
+
+The feed item is not a raw task and not a raw log. It is an agent work card:
+
+- what the agent produced;
+- why the card deserves attention now;
+- what evidence backs the claim;
+- what it cost in quota or user attention;
+- what the agent proposes next;
+- which one-tap feedback choices are available.
+
+Useful feedback should be lightweight but structured:
+
+- useful; continue this direction;
+- not useful; lower this pattern's priority;
+- wrong direction; correct the goal or reward;
+- evidence is insufficient; add validation;
+- promote to anchor, showcase, or follow-up todo;
+- risky or private; trigger boundary review or a gate.
+
+This turns performance review from a periodic report into a continuous
+human-in-the-loop signal. LoopX should sort the feed for management value, not
+addiction: unresolved gates, high-value uncertain work, expensive repeated
+patterns, evidence gaps, and showcase candidates should surface before routine
+activity.
+
+## Display Surface Adoption Path
+
+The intelligent display surface and the LoopX control loop should be
+decoupled at adoption time, but designed to grow together.
+
+The first step can be read-only:
+
+- ingest existing agent artifacts, issues, PRs, docs, run summaries, or chat
+  feedback;
+- show what the agent did, what evidence exists, and what deserves review;
+- let the maintainer score value, quality, control, cost, and learning;
+- produce a performance-review summary without changing the agent's next
+  action.
+
+This mode is useful even before a team adopts LoopX. It gives a maintainer a
+low-friction way to inspect and quantify whether an always-running agent is
+useful.
+
+The second step is control writeback:
+
+- accepted feedback becomes gates, todo changes, preference hints, reward
+  notes, or anchor selection;
+- low-quality work becomes blocker evidence, scope correction, or next
+  improvement targets;
+- selected anchors become bounded LoopX work with explicit evidence and stop
+  conditions.
+
+In short, the display surface makes agent work visible and reviewable; LoopX
+makes that review change the next loop. The two surfaces can be adopted in
+sequence, but they should share schemas such as `signal_v0`, `anchor_v0`,
+`review_event_v0`, and `performance_review_v0`.
+
+## Open-Source Anchors
+
+Open-source issue / PR solver pilots are strong value-proof candidates when
+they are chosen as high-value anchors:
+
+- visible public artifact: issue, PR, failing check, stale review, or conflict;
+- credible maintainer pain;
+- bounded risk and clear stop conditions;
+- measurable outcome: routed, diagnosed, fixed, merged, rejected, or gated;
+- public-safe story potential.
+
+LoopX's maintainer-side role is to choose anchors, define the candidate packet,
+record the evidence boundary, capture human review signals, and graduate
+approved outcomes into showcase material. The actual solver implementation may
+belong to a repo-specific collaborator or adapter.
+
+## Office Operations Connectors
+
+Office and content-operations workflows are another useful showcase lane. The
+point is not to make an agent produce more posts. The point is to show that a
+Loop Agent can connect to more information surfaces, select higher-quality
+signals, propose useful actions, and learn from human feedback.
+
+A public-safe workflow can look like:
+
+```text
+connector
+  -> information
+  -> signal / trend / anchor candidate
+  -> draft or action proposal
+  -> human scoring / feedback
+  -> optional publish or outreach gate
+  -> performance review / next improvement
+```
+
+Good connector examples include browser-based social research, local-first chat
+archive search, issue / PR metadata, meeting notes, task systems, and document
+changes. Publishing or outreach should remain explicitly gated.
+
+The right metrics are not raw draft count. Better signals are accepted anchors,
+useful insights, qualified conversations, user-rated draft quality, feedback
+learning, source-boundary correctness, and cost per useful signal.
 
 ## Creator-Operator Case
 
@@ -61,21 +205,22 @@ feedback, boundaries, and next actions.
 
 ## Productization Tracks
 
-The current roadmap for this case should land as four public-safe tracks:
+The current roadmap should land as four public-safe tracks:
 
-1. **Creator-operator case spec**: write the scenario as a concrete public
-   showcase with synthetic or redacted evidence. The case should explain the
-   user's job-to-be-done, the agent's long-running loop, where human taste or
-   publishing judgment gates progress, and what LoopX contributes.
+1. **Maintainer management surface**: design first-screen cards for signal
+   inbox, selected anchors, active lanes, gates, evidence quality, performance
+   review, value/cost trend, and next management action.
 2. **Non-technical operator status model**: design first-screen cards that say
    what happened, what is happening, where the agent is blocked, what comes
    next, and what user feedback would change. This model should avoid internal
    CLI jargon and translate control-plane state into plain language.
-3. **Fake-data demo storyboard**: prototype a frontend-ready flow for trend
-   discovery, preference mapping, insight extraction, draft queues, material
-   libraries, feedback, and controlled replanning. The first demo should use
-   synthetic or public-safe data.
-4. **Feedback and boundary contract**: define how user feedback becomes gates,
+3. **Open-source anchor packet**: define how an issue, PR, failing check, stale
+   review, or conflict becomes a candidate with owner, risk, allowed action,
+   evidence boundary, human gate, and showcase consent.
+4. **Office-operations connector showcase**: prototype a public-safe
+   connector-to-signal-to-feedback loop using synthetic or consented data, with
+   an explicit publish/outreach gate and metrics beyond article count.
+5. **Feedback and boundary contract**: define how user feedback becomes gates,
    preferences, todo updates, or product-improvement notes while preserving
    source attribution, platform terms, no-autopublish gates, and private
    creative-material boundaries.


### PR DESCRIPTION
## Summary
- sharpen the product narrative around Loop Agents, maintainer-first management, Agent Work Feed review, signal inbox, anchor selection, and performance review
- add read-only review vs LoopX writeback adoption modes for early external validation
- update product index and launch narrative to reflect public-safe open-source anchor and office-operations connector stories

## Review / value judgment
Positive value: this is product/documentation only and turns recent strategy discussion into durable public docs. It preserves existing main docs and resolves conflicts by keeping the newer intelligent-management links.

## Validation
- `git diff --check --cached`
- `loopx check --scan-path docs/README.md --scan-path docs/outreach/public-launch-narrative-draft.md --scan-path docs/product/README.md --scan-path docs/product/nontechnical-operator-status-model.md --scan-path docs/product/server-client-product-shape.md --scan-path docs/product/vision.md`
- private/sensitive marker scan clean

## Excluded / deprecated
- dashboard/frontstage and todo index changes were already present on `origin/main`, so they were not duplicated here.