### PR TITLE
Centralize benchmark lifecycle packet rendering

### DIFF
--- a/loopx/benchmark_case_state.py
+++ b/loopx/benchmark_case_state.py
@@ -280,6 +280,231 @@ def render_benchmark_case_lifecycle_contract_lines(
     return lines
 
 
+def _packet_line(indent: str, key: str, value: object) -> str:
+    rendered = str(value).lower() if isinstance(value, bool) else str(value)
+    return f"{indent}{key}: {rendered}"
+
+
+def build_benchmark_case_lifecycle_packet(
+    *,
+    packet_header: str | None = None,
+    packet_mode: str | None = None,
+    benchmark_family: str | None = None,
+    benchmark_id: str,
+    case_id: str,
+    arm_id: str,
+    max_rounds: int = 5,
+    indent: str = "",
+    include_case_paths: bool = False,
+    include_case_event_log: bool = False,
+    include_cli_commands: bool = True,
+    include_completion_hints: bool = False,
+) -> tuple[str, dict[str, object]]:
+    """Return the shared prompt-facing LoopX case lifecycle packet.
+
+    Benchmark runners differ in the surrounding access packet, but the
+    case-local product-mode lifecycle and CLI commands must stay identical.
+    Keeping this renderer next to the lifecycle contract prevents future CLI
+    parameter drift across SkillsBench, Terminal-Bench, and Harbor workers.
+    """
+
+    contract = benchmark_case_lifecycle_contract(
+        benchmark_id=benchmark_id,
+        case_id=case_id,
+        arm_id=arm_id,
+        max_rounds=max_rounds,
+    )
+    case_goal_id = str(contract["benchmark_case_goal_id"])
+    case_cli_prefix = benchmark_case_loopx_command_prefix(
+        case_cli_path=BENCHMARK_CASE_LOOPX_CLI_PATH,
+        case_registry_path=BENCHMARK_CASE_LOOPX_REGISTRY_PATH,
+        case_runtime_root=BENCHMARK_CASE_LOOPX_RUNTIME_ROOT,
+    )
+
+    lines: list[str] = []
+    if packet_header:
+        lines.append(packet_header)
+    if packet_mode is not None:
+        lines.append(_packet_line(indent, "packet_mode", packet_mode))
+    if benchmark_family is not None:
+        lines.append(_packet_line(indent, "benchmark_family", benchmark_family))
+    lines.extend(
+        [
+            _packet_line(
+                indent,
+                "loopx_formal_treatment_semantics",
+                BENCHMARK_CASE_LOOPX_FORMAL_TREATMENT_SEMANTICS,
+            ),
+            _packet_line(
+                indent,
+                "loopx_canonical_product_mode_lifecycle_driver",
+                True,
+            ),
+            _packet_line(
+                indent,
+                "loopx_product_path_primary_route",
+                BENCHMARK_CASE_LOOPX_PRODUCT_PATH_PRIMARY_ROUTE,
+            ),
+            _packet_line(
+                indent,
+                "loopx_prompt_driven_execution_style",
+                BENCHMARK_CASE_LOOPX_PROMPT_DRIVEN_EXECUTION_STYLE,
+            ),
+            _packet_line(
+                indent,
+                "loopx_workflow_orchestrated_execution_style",
+                BENCHMARK_CASE_LOOPX_ORCHESTRATED_EXECUTION_STYLE,
+            ),
+        ]
+    )
+    if include_case_paths:
+        lines.extend(
+            [
+                _packet_line(
+                    indent,
+                    "loopx_case_cli_path",
+                    BENCHMARK_CASE_LOOPX_CLI_PATH,
+                ),
+                _packet_line(
+                    indent,
+                    "loopx_case_registry_path",
+                    BENCHMARK_CASE_LOOPX_REGISTRY_PATH,
+                ),
+                _packet_line(
+                    indent,
+                    "loopx_case_runtime_root",
+                    BENCHMARK_CASE_LOOPX_RUNTIME_ROOT,
+                ),
+            ]
+        )
+    if include_case_event_log:
+        lines.append(
+            _packet_line(
+                indent,
+                "loopx_case_rollout_event_log_path",
+                benchmark_case_loopx_event_log_path(case_goal_id),
+            )
+        )
+    lines.extend(
+        [
+            _packet_line(
+                indent,
+                "loopx_case_agent_id",
+                BENCHMARK_CASE_LOOPX_AGENT_ID,
+            ),
+            _packet_line(indent, "loopx_case_todo_id", BENCHMARK_CASE_LOOPX_TODO_ID),
+            _packet_line(indent, "loopx_case_todo_seeded_open", True),
+            _packet_line(indent, "loopx_case_todo_preclaimed_by_host", False),
+            _packet_line(indent, "loopx_agent_must_claim_selected_case_todo", True),
+        ]
+    )
+    lines.extend(render_benchmark_case_lifecycle_contract_lines(contract))
+    if include_cli_commands:
+        lines.extend(
+            [
+                _packet_line(
+                    indent,
+                    "loopx_case_command_quota_should_run",
+                    (
+                        f"{case_cli_prefix} quota should-run "
+                        f"--goal-id {shlex.quote(case_goal_id)} "
+                        f"--agent-id {BENCHMARK_CASE_LOOPX_AGENT_ID}"
+                    ),
+                ),
+                _packet_line(
+                    indent,
+                    "loopx_case_command_claim_todo",
+                    (
+                        f"{case_cli_prefix} todo claim "
+                        f"--goal-id {shlex.quote(case_goal_id)} "
+                        f"--todo-id {BENCHMARK_CASE_LOOPX_TODO_ID} "
+                        f"--claimed-by {BENCHMARK_CASE_LOOPX_AGENT_ID}"
+                    ),
+                ),
+                _packet_line(
+                    indent,
+                    "loopx_case_command_status",
+                    (
+                        f"{case_cli_prefix} status --limit 5 "
+                        f"--agent-id {BENCHMARK_CASE_LOOPX_AGENT_ID}"
+                    ),
+                ),
+                _packet_line(
+                    indent,
+                    "loopx_case_command_mark_todo_done_when_complete",
+                    (
+                        f"{case_cli_prefix} todo complete "
+                        f"--goal-id {shlex.quote(case_goal_id)} "
+                        f"--todo-id {BENCHMARK_CASE_LOOPX_TODO_ID} "
+                        f"--claimed-by {BENCHMARK_CASE_LOOPX_AGENT_ID} "
+                        "--evidence local_validation_done"
+                    ),
+                ),
+                _packet_line(
+                    indent,
+                    "loopx_case_command_refresh_state",
+                    (
+                        f"{case_cli_prefix} refresh-state "
+                        f"--goal-id {shlex.quote(case_goal_id)} "
+                        "--classification benchmark_case_agent_progress "
+                        "--delivery-batch-scale implementation "
+                        "--delivery-outcome outcome_progress "
+                        f"--agent-id {BENCHMARK_CASE_LOOPX_AGENT_ID} "
+                        "--agent-lane benchmark_case"
+                    ),
+                ),
+                _packet_line(
+                    indent,
+                    "loopx_case_command_spend_quota",
+                    (
+                        f"{case_cli_prefix} quota spend-slot "
+                        f"--goal-id {shlex.quote(case_goal_id)} "
+                        f"--agent-id {BENCHMARK_CASE_LOOPX_AGENT_ID} "
+                        "--source adapter --execute"
+                    ),
+                ),
+            ]
+        )
+    if include_completion_hints:
+        lines.extend(
+            [
+                _packet_line(
+                    indent,
+                    "loopx_completion_source_of_truth",
+                    "case_local_active_todo",
+                ),
+                _packet_line(
+                    indent,
+                    "before_planning_call_loopx_case_quota_should_run_once",
+                    True,
+                ),
+                _packet_line(
+                    indent,
+                    "before_planning_claim_loopx_case_todo_once",
+                    True,
+                ),
+                _packet_line(indent, "when_task_complete_mark_case_todo_done", True),
+                _packet_line(
+                    indent,
+                    "before_finishing_review_loopx_case_status_or_history_once",
+                    True,
+                ),
+                _packet_line(indent, "separate_completion_file_required", False),
+                _packet_line(
+                    indent,
+                    "host_exit_condition",
+                    "confirmed_no_active_loopx_todo",
+                ),
+                _packet_line(
+                    indent,
+                    "loopx_case_cli_calls_are_part_of_the_treatment_flow",
+                    True,
+                ),
+            ]
+        )
+    return "\n".join(lines), contract
+
+
 def benchmark_case_active_state_seed_text(
     *,
     benchmark_name: str,

--- a/scripts/harbor_host_codex_goal_agent.py
+++ b/scripts/harbor_host_codex_goal_agent.py
@@ -36,21 +36,17 @@ from codex_app_server_goal_driver import (
 )
 from loopx.benchmark_case_state import (
     BENCHMARK_CASE_ACTIVE_STATE_SCHEMA_VERSION,
-    BENCHMARK_CASE_LOOPX_AGENT_ID,
     BENCHMARK_CASE_LOOPX_CLI_PATH,
     BENCHMARK_CASE_LOOPX_FORMAL_TREATMENT_SEMANTICS,
     BENCHMARK_CASE_LOOPX_ORCHESTRATED_EXECUTION_STYLE,
     BENCHMARK_CASE_LOOPX_PRODUCT_PATH_PRIMARY_ROUTE,
-    BENCHMARK_CASE_LOOPX_PROMPT_DRIVEN_EXECUTION_STYLE,
     BENCHMARK_CASE_LOOPX_REGISTRY_PATH,
     BENCHMARK_CASE_LOOPX_RUNTIME_ROOT,
     BENCHMARK_CASE_LOOPX_SCHEDULER_ROUTE,
     BENCHMARK_CASE_LOOPX_TODO_ID,
-    benchmark_case_loopx_command_prefix,
-    benchmark_case_loopx_event_log_path,
+    build_benchmark_case_lifecycle_packet,
     benchmark_case_loopx_install_payload,
     benchmark_case_lifecycle_contract,
-    render_benchmark_case_lifecycle_contract_lines,
 )
 from loopx.benchmark_core.loop_protocol import (
     BLIND_LOOP_DEFAULT_MAX_ROUNDS,
@@ -943,18 +939,15 @@ def build_loopx_access_packet(
     claim = classify_loopx_treatment_claim(
         {"benchmark_loop_contract": loop_contract}
     )
-    case_lifecycle = benchmark_case_lifecycle_contract(
+    case_lifecycle_packet, case_lifecycle = build_benchmark_case_lifecycle_packet(
         benchmark_id=benchmark_id,
         case_id=case_id,
         arm_id=arm_id,
         max_rounds=max_rounds,
-    )
-    case_goal_id = str(case_lifecycle["benchmark_case_goal_id"])
-    case_event_log_path = benchmark_case_loopx_event_log_path(case_goal_id)
-    case_cli_prefix = benchmark_case_loopx_command_prefix(
-        case_cli_path=BENCHMARK_CASE_LOOPX_CLI_PATH,
-        case_registry_path=BENCHMARK_CASE_LOOPX_REGISTRY_PATH,
-        case_runtime_root=BENCHMARK_CASE_LOOPX_RUNTIME_ROOT,
+        include_case_paths=True,
+        include_case_event_log=True,
+        include_cli_commands=cli_enabled,
+        include_completion_hints=cli_enabled,
     )
 
     lines = [
@@ -971,50 +964,22 @@ def build_loopx_access_packet(
         "do_not_record_raw_task_text_logs_trajectories_or_credentials: true",
         "use_loopx_for_planning_checkpoints_and_boundary_awareness_only: false",
         "task_environment_commands_still_must_use_harbor_env_exec_bridge: true",
-        f"loopx_formal_treatment_semantics: {BENCHMARK_CASE_LOOPX_FORMAL_TREATMENT_SEMANTICS}",
-        "loopx_canonical_product_mode_lifecycle_driver: true",
-        f"loopx_prompt_driven_execution_style: {BENCHMARK_CASE_LOOPX_PROMPT_DRIVEN_EXECUTION_STYLE}",
-        f"loopx_workflow_orchestrated_execution_style: {BENCHMARK_CASE_LOOPX_ORCHESTRATED_EXECUTION_STYLE}",
-        f"loopx_product_path_primary_route: {BENCHMARK_CASE_LOOPX_PRODUCT_PATH_PRIMARY_ROUTE}",
         "loopx_prompt_driven_loop_required: true",
         "loopx_scheduler_route_supported_for_smoke_or_fallback: true",
         "loopx_case_local_cli_installed_before_agent: true",
-        f"loopx_case_cli_path: {BENCHMARK_CASE_LOOPX_CLI_PATH}",
-        f"loopx_case_registry_path: {BENCHMARK_CASE_LOOPX_REGISTRY_PATH}",
-        f"loopx_case_runtime_root: {BENCHMARK_CASE_LOOPX_RUNTIME_ROOT}",
-        f"loopx_case_rollout_event_log_path: {case_event_log_path}",
-        f"loopx_case_agent_id: {BENCHMARK_CASE_LOOPX_AGENT_ID}",
-        f"loopx_case_todo_id: {BENCHMARK_CASE_LOOPX_TODO_ID}",
-        "loopx_case_todo_seeded_open: true",
-        "loopx_case_todo_preclaimed_by_host: false",
-        "loopx_agent_must_claim_selected_case_todo: true",
         f"loopx_treatment_evidence_tier: {claim['loopx_treatment_evidence_tier']}",
         f"strict_loopx_treatment_claim_allowed: {str(claim['strict_loopx_treatment_claim_allowed']).lower()}",
         f"loopx_treatment_claim_blocker: {claim['loopx_treatment_claim_blocker']}",
     ]
     lines.extend(render_loop_contract_packet_lines(loop_contract))
-    lines.extend(render_benchmark_case_lifecycle_contract_lines(case_lifecycle))
+    lines.extend(case_lifecycle_packet.splitlines())
     if cli_enabled:
         lines.extend(
             [
                 "primary_loopx_cli_surface: task_environment_case_local_cli",
-                f"loopx_case_command_quota_should_run: {case_cli_prefix} quota should-run --goal-id {shlex.quote(case_goal_id)} --agent-id {BENCHMARK_CASE_LOOPX_AGENT_ID}",
-                f"loopx_case_command_claim_todo: {case_cli_prefix} todo claim --goal-id {shlex.quote(case_goal_id)} --todo-id {BENCHMARK_CASE_LOOPX_TODO_ID} --claimed-by {BENCHMARK_CASE_LOOPX_AGENT_ID}",
-                f"loopx_case_command_status: {case_cli_prefix} status --limit 5 --agent-id {BENCHMARK_CASE_LOOPX_AGENT_ID}",
-                f"loopx_case_command_mark_todo_done_when_complete: {case_cli_prefix} todo complete --goal-id {shlex.quote(case_goal_id)} --todo-id {BENCHMARK_CASE_LOOPX_TODO_ID} --claimed-by {BENCHMARK_CASE_LOOPX_AGENT_ID} --evidence local_validation_done",
-                f"loopx_case_command_refresh_state: {case_cli_prefix} refresh-state --goal-id {shlex.quote(case_goal_id)} --classification benchmark_case_agent_progress --delivery-batch-scale implementation --delivery-outcome outcome_progress --agent-id {BENCHMARK_CASE_LOOPX_AGENT_ID} --agent-lane benchmark_case",
-                f"loopx_case_command_spend_quota: {case_cli_prefix} quota spend-slot --goal-id {shlex.quote(case_goal_id)} --agent-id {BENCHMARK_CASE_LOOPX_AGENT_ID} --source adapter --execute",
-                "loopx_completion_source_of_truth: case_local_active_todo",
-                "before_planning_call_loopx_case_quota_should_run_once: true",
-                "before_planning_claim_loopx_case_todo_once: true",
-                "when_task_complete_mark_case_todo_done: true",
-                "before_finishing_review_loopx_case_status_or_history_once: true",
-                "separate_completion_file_required: false",
-                "host_exit_condition: confirmed_no_active_loopx_todo",
                 f"loopx_global_command_check_optional_context: {base} check --scan-path {scan_path_arg}",
                 f"loopx_global_command_status_optional_context: {base} status --limit 5",
                 f"loopx_global_command_history_optional_context: {base} history --goal-id {goal_id_arg} --limit 5",
-                "loopx_case_cli_calls_are_part_of_the_treatment_flow: true",
             ]
         )
     else:

--- a/scripts/skillsbench_host_codex_goal_worker.py
+++ b/scripts/skillsbench_host_codex_goal_worker.py
@@ -27,18 +27,7 @@ from loopx.benchmark_adapters.skillsbench import (  # noqa: E402
     build_skillsbench_app_server_goal_worker_contract,
 )
 from loopx.benchmark_case_state import (  # noqa: E402
-    BENCHMARK_CASE_LOOPX_AGENT_ID,
-    BENCHMARK_CASE_LOOPX_CLI_PATH,
-    BENCHMARK_CASE_LOOPX_FORMAL_TREATMENT_SEMANTICS,
-    BENCHMARK_CASE_LOOPX_ORCHESTRATED_EXECUTION_STYLE,
-    BENCHMARK_CASE_LOOPX_PRODUCT_PATH_PRIMARY_ROUTE,
-    BENCHMARK_CASE_LOOPX_PROMPT_DRIVEN_EXECUTION_STYLE,
-    BENCHMARK_CASE_LOOPX_REGISTRY_PATH,
-    BENCHMARK_CASE_LOOPX_RUNTIME_ROOT,
-    BENCHMARK_CASE_LOOPX_TODO_ID,
-    benchmark_case_loopx_command_prefix,
-    benchmark_case_lifecycle_contract,
-    render_benchmark_case_lifecycle_contract_lines,
+    build_benchmark_case_lifecycle_packet,
 )
 from loopx.codex_goal_baseline import stable_text_digest  # noqa: E402
 from scripts.codex_app_server_goal_driver import (  # noqa: E402
@@ -79,39 +68,16 @@ def build_loopx_case_lifecycle_packet(
     if args.loopx_access_packet_mode == "none":
         return "", None
     case_id = args.loopx_case_id or args.task_id
-    contract = benchmark_case_lifecycle_contract(
+    return build_benchmark_case_lifecycle_packet(
+        packet_header="skillsbench_loopx_case_lifecycle_packet_v0:",
+        packet_mode=args.loopx_access_packet_mode,
+        benchmark_family="benchflow",
         benchmark_id=args.dataset,
         case_id=case_id,
         arm_id=args.loopx_arm_id,
         max_rounds=args.loopx_max_rounds,
+        indent="  ",
     )
-    case_goal_id = str(contract["benchmark_case_goal_id"])
-    case_cli_prefix = benchmark_case_loopx_command_prefix(
-        case_cli_path=BENCHMARK_CASE_LOOPX_CLI_PATH,
-        case_registry_path=BENCHMARK_CASE_LOOPX_REGISTRY_PATH,
-        case_runtime_root=BENCHMARK_CASE_LOOPX_RUNTIME_ROOT,
-    )
-    lines = [
-        "skillsbench_loopx_case_lifecycle_packet_v0:",
-        f"  packet_mode: {args.loopx_access_packet_mode}",
-        "  benchmark_family: benchflow",
-        f"  loopx_formal_treatment_semantics: {BENCHMARK_CASE_LOOPX_FORMAL_TREATMENT_SEMANTICS}",
-        "  loopx_canonical_product_mode_lifecycle_driver: true",
-        f"  loopx_product_path_primary_route: {BENCHMARK_CASE_LOOPX_PRODUCT_PATH_PRIMARY_ROUTE}",
-        f"  loopx_prompt_driven_execution_style: {BENCHMARK_CASE_LOOPX_PROMPT_DRIVEN_EXECUTION_STYLE}",
-        f"  loopx_workflow_orchestrated_execution_style: {BENCHMARK_CASE_LOOPX_ORCHESTRATED_EXECUTION_STYLE}",
-        "  loopx_case_todo_seeded_open: true",
-        "  loopx_case_todo_preclaimed_by_host: false",
-        "  loopx_agent_must_claim_selected_case_todo: true",
-        f"  loopx_case_command_quota_should_run: {case_cli_prefix} quota should-run --goal-id {case_goal_id} --agent-id {BENCHMARK_CASE_LOOPX_AGENT_ID}",
-        f"  loopx_case_command_claim_todo: {case_cli_prefix} todo claim --goal-id {case_goal_id} --todo-id {BENCHMARK_CASE_LOOPX_TODO_ID} --claimed-by {BENCHMARK_CASE_LOOPX_AGENT_ID}",
-        f"  loopx_case_command_status: {case_cli_prefix} status --limit 5 --agent-id {BENCHMARK_CASE_LOOPX_AGENT_ID}",
-        f"  loopx_case_command_mark_todo_done_when_complete: {case_cli_prefix} todo complete --goal-id {case_goal_id} --todo-id {BENCHMARK_CASE_LOOPX_TODO_ID} --claimed-by {BENCHMARK_CASE_LOOPX_AGENT_ID} --evidence local_validation_done",
-        f"  loopx_case_command_refresh_state: {case_cli_prefix} refresh-state --goal-id {case_goal_id} --classification benchmark_case_agent_progress --delivery-batch-scale implementation --delivery-outcome outcome_progress --agent-id {BENCHMARK_CASE_LOOPX_AGENT_ID} --agent-lane benchmark_case",
-        f"  loopx_case_command_spend_quota: {case_cli_prefix} quota spend-slot --goal-id {case_goal_id} --agent-id {BENCHMARK_CASE_LOOPX_AGENT_ID} --source adapter --execute",
-    ]
-    lines.extend(render_benchmark_case_lifecycle_contract_lines(contract))
-    return "\n".join(lines), contract
 
 
 def _prompt_with_loopx_case_lifecycle_packet(

--- a/scripts/terminal_bench_host_codex_goal_agent.py
+++ b/scripts/terminal_bench_host_codex_goal_agent.py
@@ -33,19 +33,8 @@ from codex_app_server_goal_driver import (
     start_codex_app_server_goal_turn,
 )
 from loopx.benchmark_case_state import (
-    BENCHMARK_CASE_LOOPX_AGENT_ID,
-    BENCHMARK_CASE_LOOPX_CLI_PATH,
-    BENCHMARK_CASE_LOOPX_FORMAL_TREATMENT_SEMANTICS,
-    BENCHMARK_CASE_LOOPX_ORCHESTRATED_EXECUTION_STYLE,
-    BENCHMARK_CASE_LOOPX_PRODUCT_PATH_PRIMARY_ROUTE,
-    BENCHMARK_CASE_LOOPX_PROMPT_DRIVEN_EXECUTION_STYLE,
-    BENCHMARK_CASE_LOOPX_REGISTRY_PATH,
-    BENCHMARK_CASE_LOOPX_RUNTIME_ROOT,
-    BENCHMARK_CASE_LOOPX_TODO_ID,
-    benchmark_case_loopx_command_prefix,
+    build_benchmark_case_lifecycle_packet,
     benchmark_case_loopx_install_payload,
-    benchmark_case_lifecycle_contract,
-    render_benchmark_case_lifecycle_contract_lines,
 )
 
 LONG_RUN_DEFAULT_GOAL_TIMEOUT_SEC = 21600.0
@@ -150,39 +139,16 @@ def build_loopx_case_lifecycle_packet(
 ) -> tuple[str, dict[str, object] | None]:
     if mode != "codex_loopx" or packet_mode == "none":
         return "", None
-    contract = benchmark_case_lifecycle_contract(
+    return build_benchmark_case_lifecycle_packet(
+        packet_header="terminal_bench_loopx_case_lifecycle_packet_v0:",
+        packet_mode=packet_mode,
+        benchmark_family="terminal-bench",
         benchmark_id=benchmark_id,
         case_id=case_id,
         arm_id=arm_id,
         max_rounds=max_rounds,
+        indent="  ",
     )
-    case_goal_id = str(contract["benchmark_case_goal_id"])
-    case_cli_prefix = benchmark_case_loopx_command_prefix(
-        case_cli_path=BENCHMARK_CASE_LOOPX_CLI_PATH,
-        case_registry_path=BENCHMARK_CASE_LOOPX_REGISTRY_PATH,
-        case_runtime_root=BENCHMARK_CASE_LOOPX_RUNTIME_ROOT,
-    )
-    lines = [
-        "terminal_bench_loopx_case_lifecycle_packet_v0:",
-        f"  packet_mode: {packet_mode}",
-        "  benchmark_family: terminal-bench",
-        f"  loopx_formal_treatment_semantics: {BENCHMARK_CASE_LOOPX_FORMAL_TREATMENT_SEMANTICS}",
-        "  loopx_canonical_product_mode_lifecycle_driver: true",
-        f"  loopx_product_path_primary_route: {BENCHMARK_CASE_LOOPX_PRODUCT_PATH_PRIMARY_ROUTE}",
-        f"  loopx_prompt_driven_execution_style: {BENCHMARK_CASE_LOOPX_PROMPT_DRIVEN_EXECUTION_STYLE}",
-        f"  loopx_workflow_orchestrated_execution_style: {BENCHMARK_CASE_LOOPX_ORCHESTRATED_EXECUTION_STYLE}",
-        "  loopx_case_todo_seeded_open: true",
-        "  loopx_case_todo_preclaimed_by_host: false",
-        "  loopx_agent_must_claim_selected_case_todo: true",
-        f"  loopx_case_command_quota_should_run: {case_cli_prefix} quota should-run --goal-id {case_goal_id} --agent-id {BENCHMARK_CASE_LOOPX_AGENT_ID}",
-        f"  loopx_case_command_claim_todo: {case_cli_prefix} todo claim --goal-id {case_goal_id} --todo-id {BENCHMARK_CASE_LOOPX_TODO_ID} --claimed-by {BENCHMARK_CASE_LOOPX_AGENT_ID}",
-        f"  loopx_case_command_status: {case_cli_prefix} status --limit 5 --agent-id {BENCHMARK_CASE_LOOPX_AGENT_ID}",
-        f"  loopx_case_command_mark_todo_done_when_complete: {case_cli_prefix} todo complete --goal-id {case_goal_id} --todo-id {BENCHMARK_CASE_LOOPX_TODO_ID} --claimed-by {BENCHMARK_CASE_LOOPX_AGENT_ID} --evidence local_validation_done",
-        f"  loopx_case_command_refresh_state: {case_cli_prefix} refresh-state --goal-id {case_goal_id} --classification benchmark_case_agent_progress --delivery-batch-scale implementation --delivery-outcome outcome_progress --agent-id {BENCHMARK_CASE_LOOPX_AGENT_ID} --agent-lane benchmark_case",
-        f"  loopx_case_command_spend_quota: {case_cli_prefix} quota spend-slot --goal-id {case_goal_id} --agent-id {BENCHMARK_CASE_LOOPX_AGENT_ID} --source adapter --execute",
-    ]
-    lines.extend(render_benchmark_case_lifecycle_contract_lines(contract))
-    return "\n".join(lines), contract
 
 
 class HostCodexGoalAgent(BaseAgent):


### PR DESCRIPTION
## Summary
- Add a shared `build_benchmark_case_lifecycle_packet` renderer next to the LoopX benchmark case lifecycle contract.
- Switch SkillsBench, Terminal-Bench, and Harbor host adapters to use the shared renderer for case-local lifecycle and CLI command packet text.
- Preserve Harbor-specific access-packet context, bridge notes, and global optional LoopX commands while removing duplicated case lifecycle command templates.

## Validation
- `python3 -m py_compile loopx/benchmark_case_state.py scripts/skillsbench_host_codex_goal_worker.py scripts/terminal_bench_host_codex_goal_agent.py scripts/harbor_host_codex_goal_agent.py`
- `python3 examples/benchmark-case-active-state-contract-smoke.py`
- `python3 examples/terminal-bench-host-codex-goal-agent-smoke.py`
- `python3 examples/skillsbench-benchmark-run-smoke.py`
- `python3 examples/harbor-host-codex-goal-agent-smoke.py`
- `git diff --check`

## Safety / Scope
- No benchmark jobs launched.
- No scoring, verifier, timeout, or runner scheduling behavior changed intentionally.
- No docs, ledger evidence, raw trajectories, local state, or private logs included.
- Pre-stage scan only found expected benchmark sandbox paths such as `/app/.local/bin/loopx` and token-count field names, not credentials.
