### PR TITLE
Add content ops preview CLI

### DIFF
--- a/docs/reference/protocols/content-ops-surface-v0.md
+++ b/docs/reference/protocols/content-ops-surface-v0.md
@@ -114,11 +114,26 @@ The public-safe fixture helper is implemented in
 - `build_content_ops_surface_fixture()`;
 - `validate_content_ops_surface(surface)`;
 - `project_content_ops_surface(surface)`.
+- `build_content_ops_preview_packet()`;
+
+The CLI preview is the first runnable connector-pilot entry point:
+
+```bash
+loopx content-ops preview --format json
+```
+
+It returns `content_ops_preview_packet_v0` with the fixture, projection,
+validation, connector-trial counts, and explicit booleans proving that no
+external reads, external writes, private source-body reads, or autopublish
+actions happened. Real connector adapters should first match this packet shape
+before they ingest any public platform metadata or private metadata-only source
+handle.
 
 The durable smoke is:
 
 ```bash
 python3 examples/content-ops-surface-fixture-smoke.py
+python3 examples/content-ops-preview-cli-smoke.py
 ```
 
 The smoke checks record coverage, source/draft/gate references, first-screen

--- a/examples/content-ops-preview-cli-smoke.py
+++ b/examples/content-ops-preview-cli-smoke.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Smoke-test the content-ops preview CLI."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.content_ops_surface import (  # noqa: E402
+    CONTENT_OPS_PREVIEW_PACKET_SCHEMA_VERSION,
+)
+
+
+PRIVATE_PATTERNS = [
+    re.compile(r"/Users/[A-Za-z0-9._-]+/"),
+    re.compile(r"/home/[A-Za-z0-9._-]+/"),
+    re.compile(r"/private/"),
+    re.compile(r"[A-Za-z]:\\\\Users\\\\"),
+    re.compile(r"\bBearer\s+[A-Za-z0-9._-]+"),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+]
+
+
+def assert_public_safe(payload: dict[str, Any]) -> None:
+    text = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    for pattern in PRIVATE_PATTERNS:
+        if pattern.search(text):
+            raise AssertionError(f"payload matched private pattern {pattern.pattern!r}")
+    forbidden_values = [
+        "full chat transcript",
+        "raw platform post body",
+        "secret-value",
+        "credential-value",
+    ]
+    leaked = [value for value in forbidden_values if value in text]
+    assert not leaked, leaked
+
+
+def run_cli(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "loopx.cli", *args],
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def main() -> int:
+    result = run_cli(["--format", "json", "content-ops", "preview"])
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True, payload
+    assert payload["schema_version"] == CONTENT_OPS_PREVIEW_PACKET_SCHEMA_VERSION, payload
+    assert payload["external_reads_performed"] is False, payload
+    assert payload["external_writes_performed"] is False, payload
+    assert payload["private_source_bodies_read"] is False, payload
+    assert payload["autopublish_allowed"] is False, payload
+
+    connector_trials = payload["connector_trials"]
+    assert connector_trials["count"] == 2, connector_trials
+    assert connector_trials["ready_for_metadata_trial_count"] == 1, connector_trials
+    assert connector_trials["owner_gate_required_count"] == 1, connector_trials
+    assert connector_trials["surfaces"] == {
+        "wechat_private_archive": 1,
+        "x_public_feed": 1,
+    }, connector_trials
+    assert connector_trials["access_modes"] == {
+        "private_metadata_only": 1,
+        "public_metadata_only": 1,
+    }, connector_trials
+
+    todo_candidates = payload["projection"]["todo_candidates"]
+    action_kinds = {candidate["action_kind"] for candidate in todo_candidates}
+    assert "content_ops_connector_metadata_trial" in action_kinds, todo_candidates
+    assert "content_ops_connector_owner_gate" in action_kinds, todo_candidates
+    assert_public_safe(payload)
+
+    markdown = run_cli(["content-ops", "preview"]).stdout
+    assert "LoopX Content-Ops Preview" in markdown, markdown
+    assert "external_reads_performed: `False`" in markdown, markdown
+    assert "owner_gate_required_count: `1`" in markdown, markdown
+
+    print("content-ops-preview-cli-smoke: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -10,6 +10,7 @@ from .cli_commands import (
     handle_benchmark_command,
     handle_bootstrap_connect_command,
     handle_check_command,
+    handle_content_ops_command,
     handle_diagnose_command,
     handle_doctor_command,
     handle_dreaming_command,
@@ -26,6 +27,7 @@ from .cli_commands import (
     handle_worker_bridge_command,
     register_benchmark_command_group,
     register_bootstrap_connect_command,
+    register_content_ops_commands,
     register_doctor_command,
     register_dreaming_commands,
     register_history_command,
@@ -108,6 +110,8 @@ def main(argv: list[str] | None = None) -> int:
     register_worker_bridge_commands(sub, add_subcommand_format)
 
     register_support_control_commands(sub, add_subcommand_format)
+
+    register_content_ops_commands(sub, add_subcommand_format)
 
     register_ml_experiment_commands(sub, add_subcommand_format)
 
@@ -200,6 +204,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "ml-experiment":
         return handle_ml_experiment_command(args, output_format=output_format, print_payload=print_payload)
+
+    if args.command == "content-ops":
+        return handle_content_ops_command(args, output_format=output_format, print_payload=print_payload)
 
     registry_admin_result = handle_registry_admin_command(
         args,

--- a/loopx/cli_commands/__init__.py
+++ b/loopx/cli_commands/__init__.py
@@ -76,6 +76,7 @@ from .bootstrap_connect import (
     handle_bootstrap_connect_command,
     register_bootstrap_connect_command,
 )
+from .content_ops import handle_content_ops_command, register_content_ops_commands
 from .doctor import handle_doctor_command, register_doctor_command
 from .dreaming import handle_dreaming_command, register_dreaming_commands
 from .history import handle_history_command, register_history_command
@@ -188,6 +189,7 @@ __all__ = [
     "handle_codex_cli_visible_driver_run_command",
     "handle_codex_cli_visible_driver_plan_command",
     "handle_codex_cli_visible_session_proof_command",
+    "handle_content_ops_command",
     "handle_diagnose_command",
     "handle_demo_command",
     "handle_doctor_command",
@@ -228,6 +230,7 @@ __all__ = [
     "register_benchmark_run_ledger_maintenance_commands",
     "register_benchmark_run_ledger_parity_commands",
     "register_bootstrap_connect_command",
+    "register_content_ops_commands",
     "register_doctor_command",
     "register_dreaming_commands",
     "register_history_command",

--- a/loopx/cli_commands/content_ops.py
+++ b/loopx/cli_commands/content_ops.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+
+from ..content_ops_surface import (
+    build_content_ops_preview_packet,
+    render_content_ops_preview_markdown,
+)
+
+
+PrintPayload = Callable[
+    [dict[str, object], str, Callable[[dict[str, object]], str]],
+    None,
+]
+FormatSelector = Callable[..., str]
+AddFormat = Callable[[argparse.ArgumentParser], None]
+
+
+def register_content_ops_commands(
+    subparsers: argparse._SubParsersAction,
+    add_subcommand_format: AddFormat,
+) -> None:
+    content_ops_parser = subparsers.add_parser(
+        "content-ops",
+        help="Render public-safe creator/content operations preview packets.",
+    )
+    content_ops_sub = content_ops_parser.add_subparsers(
+        dest="content_ops_command",
+        required=True,
+    )
+    preview_parser = content_ops_sub.add_parser(
+        "preview",
+        help="Preview metadata-only connector trials and content-ops projection.",
+    )
+    add_subcommand_format(preview_parser)
+    preview_parser.add_argument(
+        "--generated-at",
+        default="2026-06-23T00:00:00Z",
+        help="Public-safe generated_at timestamp for the synthetic preview fixture.",
+    )
+
+
+def handle_content_ops_command(
+    args: argparse.Namespace,
+    *,
+    output_format: FormatSelector,
+    print_payload: PrintPayload,
+) -> int:
+    try:
+        if args.content_ops_command != "preview":
+            raise ValueError("content-ops requires the `preview` subcommand")
+        payload = build_content_ops_preview_packet(generated_at=args.generated_at)
+    except Exception as exc:
+        payload = {
+            "ok": False,
+            "mode": "content-ops",
+            "error": str(exc),
+        }
+    print_payload(payload, output_format(args), render_content_ops_preview_markdown)
+    return 0 if payload.get("ok") else 1

--- a/loopx/content_ops_surface.py
+++ b/loopx/content_ops_surface.py
@@ -7,6 +7,7 @@ from typing import Any
 
 CONTENT_OPS_SURFACE_SCHEMA_VERSION = "content_ops_surface_v0"
 CONTENT_OPS_SURFACE_PROJECTION_SCHEMA_VERSION = "content_ops_surface_projection_v0"
+CONTENT_OPS_PREVIEW_PACKET_SCHEMA_VERSION = "content_ops_preview_packet_v0"
 
 SOURCE_ITEM_SCHEMA_VERSION = "source_item_v0"
 ANGLE_CANDIDATE_SCHEMA_VERSION = "angle_candidate_v0"
@@ -673,3 +674,89 @@ def project_content_ops_surface(surface: Mapping[str, Any]) -> dict[str, Any]:
             ),
         },
     }
+
+
+def build_content_ops_preview_packet(
+    *, generated_at: str | None = "2026-06-23T00:00:00Z"
+) -> dict[str, Any]:
+    """Build a public-safe content-ops preview packet.
+
+    The preview uses synthetic/metadata-only connector trial records. It does
+    not read platform timelines, private chat archives, credentials, or source
+    bodies.
+    """
+
+    surface = build_content_ops_surface_fixture(generated_at=generated_at)
+    validation = validate_content_ops_surface(surface)
+    projection = project_content_ops_surface(surface)
+    return {
+        "ok": bool(validation.get("ok")),
+        "schema_version": CONTENT_OPS_PREVIEW_PACKET_SCHEMA_VERSION,
+        "mode": "content-ops-preview",
+        "surface": surface,
+        "projection": projection,
+        "validation": validation,
+        "connector_trials": projection.get("connector_trials"),
+        "external_reads_performed": False,
+        "external_writes_performed": False,
+        "private_source_bodies_read": False,
+        "autopublish_allowed": False,
+        "next_safe_action": projection.get("first_screen", {}).get("next_safe_action")
+        if isinstance(projection.get("first_screen"), Mapping)
+        else None,
+    }
+
+
+def render_content_ops_preview_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# LoopX Content-Ops Preview",
+        "",
+        f"- ok: `{payload.get('ok')}`",
+        f"- schema_version: `{payload.get('schema_version')}`",
+        f"- external_reads_performed: `{payload.get('external_reads_performed')}`",
+        f"- external_writes_performed: `{payload.get('external_writes_performed')}`",
+        f"- private_source_bodies_read: `{payload.get('private_source_bodies_read')}`",
+        f"- autopublish_allowed: `{payload.get('autopublish_allowed')}`",
+    ]
+    projection = payload.get("projection")
+    if isinstance(projection, Mapping):
+        first_screen = projection.get("first_screen")
+        if isinstance(first_screen, Mapping):
+            lines.extend(
+                [
+                    "",
+                    "## First Screen",
+                    "",
+                    f"- waiting_on: `{first_screen.get('waiting_on')}`",
+                    f"- user_action_required: `{first_screen.get('user_action_required')}`",
+                    f"- agent_can_continue: `{first_screen.get('agent_can_continue')}`",
+                    f"- next_safe_action: {first_screen.get('next_safe_action')}",
+                ]
+            )
+        connector_trials = projection.get("connector_trials")
+        if isinstance(connector_trials, Mapping):
+            lines.extend(
+                [
+                    "",
+                    "## Connector Trials",
+                    "",
+                    f"- count: `{connector_trials.get('count')}`",
+                    f"- ready_for_metadata_trial_count: `{connector_trials.get('ready_for_metadata_trial_count')}`",
+                    f"- owner_gate_required_count: `{connector_trials.get('owner_gate_required_count')}`",
+                    f"- surfaces: `{connector_trials.get('surfaces')}`",
+                    f"- access_modes: `{connector_trials.get('access_modes')}`",
+                ]
+            )
+    validation = payload.get("validation")
+    if isinstance(validation, Mapping):
+        errors = validation.get("errors") if isinstance(validation.get("errors"), list) else []
+        lines.extend(
+            [
+                "",
+                "## Validation",
+                "",
+                f"- validation_ok: `{validation.get('ok')}`",
+                f"- error_count: `{len(errors)}`",
+            ]
+        )
+    return "\n".join(lines) + "\n"


### PR DESCRIPTION
## Summary
- add `loopx content-ops preview` for public-safe content-ops connector trial packets
- expose `content_ops_preview_packet_v0` with fixture, projection, validation, connector trial counts, and no-external-action booleans
- add a CLI smoke and document the preview as the first runnable connector-pilot entry point

## Validation
- `python3 examples/content-ops-surface-fixture-smoke.py`
- `python3 examples/content-ops-preview-cli-smoke.py`
- `python3 -m py_compile loopx/content_ops_surface.py loopx/cli.py loopx/cli_commands/__init__.py loopx/cli_commands/content_ops.py examples/content-ops-preview-cli-smoke.py examples/content-ops-surface-fixture-smoke.py`
- `git diff --check`
- `python3 -m loopx.cli --format json content-ops preview`
- `python3 -m loopx.cli content-ops preview --format json`
- `loopx check --scan-path docs/reference/protocols/content-ops-surface-v0.md`
- `loopx check --scan-path loopx/content_ops_surface.py`
- `loopx check --scan-path loopx/cli_commands/content_ops.py`
- `loopx check --scan-path examples/content-ops-preview-cli-smoke.py`

## Boundary
No X login/timeline read, WeChat/chat body read, publication, credentials, raw platform bodies, or private source material are included.