### PR TITLE
docs: clarify other agent requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,12 @@ A successful connection looks like this:
 ### Other Agents And Manual Shell
 
 For Claude Code, Cursor, another terminal agent, or a manual shell, use the
-same no-clone installer:
+same no-clone installer. Be cautious with non-Codex agents: LoopX can only
+drive the agent path if that surface has at least one usable control hook, such
+as shell/CLI execution, a goal/task command, an automation or heartbeat hook,
+or its own loop/scheduler. If the agent has none of those capabilities, LoopX
+can still track the project state, but the user must run the shell commands
+manually.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh | bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -74,7 +74,11 @@ and do not use hidden headless execution.
 
 ### 其他 Agent / 手动 Shell
 
-Claude Code、Cursor、其他终端 agent 或手动 shell 都走同一个 no-clone installer：
+Claude Code、Cursor、其他终端 agent 或手动 shell 都走同一个 no-clone installer。
+但这里要更谨慎：非 Codex agent 只有在至少具备一种可被 LoopX 驱动的控制能力时才适合
+走 agent-first 路径，例如能运行 shell/CLI、支持 goal/task 指令、能接入 automation
+或 heartbeat、或者自身有 loop/scheduler。否则 LoopX 仍可记录项目状态，但用户需要把
+下面的 shell 命令手动跑完。
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh | bash

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -10,6 +10,12 @@ dashboard use, development checks, and command discovery.
 If you already use Codex, Claude Code, Cursor, or another terminal agent, paste
 this into the agent from your project repo:
 
+Compatibility check for non-Codex agents: the agent surface needs at least one
+control hook for LoopX to drive it, such as shell/CLI execution, a goal/task
+command, an automation or heartbeat hook, or its own loop/scheduler. Without
+one of those, use the manual shell commands instead; LoopX can preserve project
+state, but it cannot make an agent continue automatically.
+
 ```text
 Install and connect LoopX for this project end to end. Do not stop at a
 plan.


### PR DESCRIPTION
## Summary
- clarify that non-Codex agents need at least one usable control hook for LoopX to drive them
- document the supported hooks: shell/CLI execution, goal/task command, automation/heartbeat, or a native loop/scheduler
- add the caution to English README, Chinese README, and Getting Started

## Validation
- loopx check --scan-path README.md --scan-path README.zh-CN.md --scan-path docs/guides/getting-started.md
- git diff --check
