### PR TITLE
Classify missing SkillsBench product lifecycle evidence

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -3525,11 +3525,38 @@ def test_skillsbench_product_mode_lifecycle_checkpoint_is_compacted() -> None:
         assert counters["product_mode_lifecycle_checkpoint_missing_reason"] == (
             "missing_case_local_loopx_state_read_or_write"
         )
+        assert compact["score_failure_attribution"] == (
+            "skillsbench_product_mode_lifecycle_missing"
+        ), compact
+        assert compact["official_score_comparable_to_native_codex"] is False, compact
+        assert compact["official_score_comparable_to_loopx_treatment"] is False, compact
+        assert "skillsbench_product_mode_uncountable_treatment" in compact[
+            "failure_attribution_labels"
+        ], compact
+        lifecycle_contract = compact["product_mode_lifecycle_contract"]
+        assert lifecycle_contract == {
+            "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+            "required": True,
+            "satisfied": False,
+            "countable_treatment": False,
+            "state_read_count": 0,
+            "state_write_count": 0,
+            "checkpoint_required": True,
+            "checkpoint_count": 1,
+            "checkpoint_round": 1,
+            "missing_reason": "missing_case_local_loopx_state_read_or_write",
+        }, compact
         compact_again = compact_benchmark_run(compact)
         assert compact_again is not None
         compact_counters = compact_again["interaction_counters"]
         assert compact_counters["product_mode_lifecycle_checkpoint_required"] is True
         assert compact_counters["product_mode_lifecycle_checkpoint_count"] == 1
+        assert compact_again["score_failure_attribution"] == (
+            "skillsbench_product_mode_lifecycle_missing"
+        ), compact_again
+        assert compact_again["product_mode_lifecycle_contract"] == (
+            lifecycle_contract
+        ), compact_again
 
 
 def test_skillsbench_product_mode_case_state_usage_is_compacted() -> None:

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -2542,6 +2542,72 @@ def build_skillsbench_benchflow_result_benchmark_run(
         controller_max_rounds_budget, bool
     ):
         controller_max_rounds_budget = 0
+
+    def _controller_public_count(name: str) -> int:
+        value = controller_counters.get(name, 0)
+        return value if isinstance(value, int) and not isinstance(value, bool) else 0
+
+    def _trajectory_public_count(name: str) -> int:
+        value = trajectory_summary.get(name, 0)
+        return value if isinstance(value, int) and not isinstance(value, bool) else 0
+
+    product_mode_lifecycle_required = bool(route == "loopx-product-mode")
+    product_mode_lifecycle_read_count = max(
+        _controller_public_count("loopx_state_reads"),
+        _controller_public_count("loopx_case_state_reads"),
+        _trajectory_public_count("loopx_cli_state_read_count"),
+        _trajectory_public_count("loopx_case_state_read_count"),
+    )
+    product_mode_lifecycle_write_count = max(
+        _controller_public_count("loopx_state_writes"),
+        _controller_public_count("loopx_case_state_writes"),
+        _trajectory_public_count("loopx_cli_state_write_count"),
+        _trajectory_public_count("loopx_case_state_write_count"),
+    )
+    product_mode_lifecycle_checkpoint_required = bool(
+        controller_counters.get("product_mode_lifecycle_checkpoint_required")
+    )
+    product_mode_lifecycle_checkpoint_count = _controller_public_count(
+        "product_mode_lifecycle_checkpoint_count"
+    )
+    product_mode_lifecycle_attempt_observed = bool(
+        product_mode_lifecycle_checkpoint_required
+        or product_mode_lifecycle_checkpoint_count > 0
+        or controller_followup_prompt_count > 0
+        or controller_stop_decision_count > 0
+        or controller_max_rounds_budget > 1
+    )
+    product_mode_lifecycle_satisfied = bool(
+        not product_mode_lifecycle_required
+        or (
+            product_mode_lifecycle_read_count > 0
+            and product_mode_lifecycle_write_count > 0
+        )
+    )
+    product_mode_lifecycle_missing = bool(
+        product_mode_lifecycle_required
+        and controller_trace_present
+        and product_mode_lifecycle_attempt_observed
+        and not product_mode_lifecycle_satisfied
+    )
+    product_mode_lifecycle_contract = {
+        "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+        "required": product_mode_lifecycle_required,
+        "satisfied": product_mode_lifecycle_satisfied,
+        "countable_treatment": not product_mode_lifecycle_missing,
+        "state_read_count": product_mode_lifecycle_read_count,
+        "state_write_count": product_mode_lifecycle_write_count,
+        "checkpoint_required": product_mode_lifecycle_checkpoint_required,
+        "checkpoint_count": product_mode_lifecycle_checkpoint_count,
+        "checkpoint_round": controller_counters.get(
+            "product_mode_lifecycle_checkpoint_round", 0
+        ),
+        "missing_reason": controller_counters.get(
+            "product_mode_lifecycle_checkpoint_missing_reason", ""
+        )
+        if product_mode_lifecycle_missing
+        else "",
+    }
     user_loop_final_verify_recovery_triggered = bool(
         controller_counters.get("benchflow_user_loop_final_verify_recovery_triggered")
     )
@@ -2773,6 +2839,40 @@ def build_skillsbench_benchflow_result_benchmark_run(
         validation_scope = (
             "official_benchflow_result_json_plus_loopx_controller_trace"
         )
+    if product_mode_lifecycle_missing:
+        label = "skillsbench_product_mode_lifecycle_missing"
+        contract_official_score_comparable_to_native_codex = False
+        contract_official_score_comparable_to_loopx_treatment = False
+        product_mode_lifecycle_contract["countable_treatment"] = False
+        if not official_passed:
+            exception_type = label
+            score_failure_attribution = label
+            runner_score_failure_attribution = label
+            failure_labels = [
+                item
+                for item in failure_labels
+                if item
+                not in {
+                    "skillsbench_runner_error",
+                    "verifier_infrastructure_failure",
+                    "official_score_zero_case_failure",
+                }
+            ]
+            if runner_failure is not None:
+                runner_failure["exception_type"] = label
+                runner_failure["failure_class"] = label
+        for item in (
+            label,
+            "skillsbench_product_mode_uncountable_treatment",
+            "skillsbench_case_local_loopx_state_not_observed",
+        ):
+            if item not in failure_labels:
+                failure_labels.append(item)
+        if (
+            reward_value is None
+            and "skillsbench_reward_artifact_missing" not in failure_labels
+        ):
+            failure_labels.append("skillsbench_reward_artifact_missing")
 
     native_goal_worker_trace_count = controller_counters.get(
         "native_goal_worker_trace_count", 0
@@ -3126,6 +3226,7 @@ def build_skillsbench_benchflow_result_benchmark_run(
             "controller_trace_recorded": controller_trace_present,
             "does_not_upload_or_submit": True,
         },
+        "product_mode_lifecycle_contract": product_mode_lifecycle_contract,
         "trials": [
             {
                 "task_id": task_id,
@@ -3208,6 +3309,7 @@ def build_skillsbench_benchflow_result_benchmark_run(
             "reward_feedback_forwarded": contract_reward_feedback_forwarded,
             "official_score_comparable_to_native_codex": contract_official_score_comparable_to_native_codex,
             "official_score_comparable_to_loopx_treatment": contract_official_score_comparable_to_loopx_treatment,
+            "product_mode_lifecycle": product_mode_lifecycle_contract,
             "leaderboard_evidence": False,
         },
         "evidence_files": evidence_files,

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -692,6 +692,36 @@ def _compact_benchmark_interaction_counters(value: Any) -> dict[str, Any]:
     return compact
 
 
+def _compact_product_mode_lifecycle_contract(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+
+    compact: dict[str, Any] = {}
+    schema = public_safe_compact_text(value.get("schema_version"), limit=100)
+    if schema:
+        compact["schema_version"] = schema
+    for field in (
+        "required",
+        "satisfied",
+        "countable_treatment",
+        "checkpoint_required",
+    ):
+        if isinstance(value.get(field), bool):
+            compact[field] = value[field]
+    for field in (
+        "state_read_count",
+        "state_write_count",
+        "checkpoint_count",
+        "checkpoint_round",
+    ):
+        if isinstance(value.get(field), int) and not isinstance(value.get(field), bool):
+            compact[field] = value[field]
+    missing_reason = public_safe_compact_text(value.get("missing_reason"), limit=140)
+    if missing_reason:
+        compact["missing_reason"] = missing_reason
+    return compact
+
+
 def _compact_benchmark_round_reward_trace(value: Any) -> dict[str, Any]:
     if not isinstance(value, dict):
         return {}
@@ -2497,6 +2527,12 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
     episode_policy = _compact_benchmark_episode_policy(source.get("episode_policy"))
     if episode_policy:
         compact["episode_policy"] = episode_policy
+
+    product_mode_lifecycle_contract = _compact_product_mode_lifecycle_contract(
+        source.get("product_mode_lifecycle_contract")
+    )
+    if product_mode_lifecycle_contract:
+        compact["product_mode_lifecycle_contract"] = product_mode_lifecycle_contract
 
     preflight_guard = _compact_benchmark_preflight_guard(source.get("preflight_guard"))
     if preflight_guard:


### PR DESCRIPTION
## Summary
- classify loopx-product-mode runs with controller trace but zero case-local LoopX lifecycle reads/writes as uncountable treatments
- expose a compact `product_mode_lifecycle_contract` so case ledgers/debuggers can explain the missing evidence
- preserve post-success score recovery: successful controller-trace reward recovery keeps score attribution while still marking treatment countability false

## Validation
- `python3 -m py_compile loopx/benchmark_adapters/skillsbench.py loopx/status.py examples/skillsbench-benchmark-run-smoke.py`
- focused lifecycle/recovery smoke via importlib
- `python3 examples/skillsbench-benchmark-run-smoke.py`
- `git diff --check`
- `loopx check --scan-path loopx/benchmark_adapters/skillsbench.py --scan-path loopx/status.py --scan-path examples/skillsbench-benchmark-run-smoke.py`

## Boundary
- no benchmark jobs launched
- no raw task text, trajectories, verifier output tails, credentials, or local/private run artifacts included