### PR TITLE
Add content-ops public handle observation

### DIFF
--- a/docs/reference/protocols/content-ops-surface-v0.md
+++ b/docs/reference/protocols/content-ops-surface-v0.md
@@ -129,13 +129,34 @@ actions happened. Real connector adapters should first match this packet shape
 before they ingest any public platform metadata or private metadata-only source
 handle.
 
+The first reusable public connector adapter is the public-handle observation
+command:
+
+```bash
+loopx content-ops observe-public-handle \
+  --url https://x.com/OpenAI \
+  --source-item-id source_x_openai_public_handle_20260623 \
+  --format json
+```
+
+It returns `content_ops_public_handle_observation_packet_v0` with a compact
+`source_item_v0`. By default it performs one HEAD-only metadata read against a
+public `https` URL, rejects localhost/private-address/credential-bearing/query
+URLs, does not follow redirects, does not read response content, does not send
+cookies, does not log in, does not write externally, and never grants
+autopublish permission. Deterministic tests and dry routing can use
+`--no-fetch` to build the same packet shape without external reads.
+
 The durable smoke is:
 
 ```bash
 python3 examples/content-ops-surface-fixture-smoke.py
 python3 examples/content-ops-preview-cli-smoke.py
+python3 examples/content-ops-public-handle-observation-smoke.py
 ```
 
 The smoke checks record coverage, source/draft/gate references, first-screen
 projection fields, connector metadata-trial routing, todo candidates,
-no-autopublish policy, and public/private boundary hygiene.
+no-autopublish policy, public/private boundary hygiene, and the public-handle
+adapter's no-content/no-write guarantees. A live X HEAD probe is available only
+when `LOOPX_LIVE_PUBLIC_HANDLE_SMOKE=1` is explicitly set.

--- a/examples/content-ops-public-handle-observation-smoke.py
+++ b/examples/content-ops-public-handle-observation-smoke.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Smoke-test the content-ops public-handle observation CLI."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.content_ops_surface import (  # noqa: E402
+    CONTENT_OPS_PUBLIC_HANDLE_OBSERVATION_PACKET_SCHEMA_VERSION,
+    CONTENT_OPS_PUBLIC_HANDLE_OBSERVATION_SCHEMA_VERSION,
+    SOURCE_ITEM_SCHEMA_VERSION,
+)
+
+
+PRIVATE_PATTERNS = [
+    re.compile(r"/Users/[A-Za-z0-9._-]+/"),
+    re.compile(r"/home/[A-Za-z0-9._-]+/"),
+    re.compile(r"/private/"),
+    re.compile(r"[A-Za-z]:\\\\Users\\\\"),
+    re.compile(r"\bBearer\s+[A-Za-z0-9._-]+"),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+]
+
+
+def assert_public_safe(payload: dict[str, Any]) -> None:
+    text = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    for pattern in PRIVATE_PATTERNS:
+        if pattern.search(text):
+            raise AssertionError(f"payload matched private pattern {pattern.pattern!r}")
+    forbidden_values = [
+        "full chat transcript",
+        "raw platform post body",
+        "secret-value",
+        "credential-value",
+    ]
+    leaked = [value for value in forbidden_values if value in text]
+    assert not leaked, leaked
+
+
+def run_cli(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "loopx.cli", *args],
+        cwd=REPO_ROOT,
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def assert_observation_packet(payload: dict[str, Any], *, fetched: bool) -> None:
+    assert payload["ok"] is True, payload
+    assert (
+        payload["schema_version"]
+        == CONTENT_OPS_PUBLIC_HANDLE_OBSERVATION_PACKET_SCHEMA_VERSION
+    ), payload
+    assert payload["external_reads_performed"] is fetched, payload
+    assert payload["external_writes_performed"] is False, payload
+    assert payload["private_source_bodies_read"] is False, payload
+    assert payload["private_source_content_read"] is False, payload
+    assert payload["autopublish_allowed"] is False, payload
+    assert payload["promotion_target"] == "source_item_v0", payload
+
+    source_item = payload["source_item"]
+    assert source_item["schema_version"] == SOURCE_ITEM_SCHEMA_VERSION, source_item
+    assert source_item["source_item_id"] == "source_x_openai_public_handle_fixture"
+    assert source_item["source_kind"] == "x_public_profile_handle", source_item
+    assert source_item["source_status"] == "public", source_item
+    assert source_item["allowed_use"] == "metadata_only", source_item
+    assert source_item["attribution"] == "x.com/OpenAI", source_item
+
+    observation = payload["observation"]
+    assert (
+        observation["schema_version"]
+        == CONTENT_OPS_PUBLIC_HANDLE_OBSERVATION_SCHEMA_VERSION
+    ), observation
+    assert observation["input_url"] == "https://x.com/OpenAI", observation
+    assert observation["url_host"] == "x.com", observation
+    assert observation["url_path"] == "/OpenAI", observation
+    assert observation["content_bytes_read"] == 0, observation
+    assert observation["external_write_performed"] is False, observation
+    assert observation["login_used"] is False, observation
+    assert observation["cookies_sent"] is False, observation
+    assert observation["private_source_content_read"] is False, observation
+    assert observation["autopublish_allowed"] is False, observation
+    assert_public_safe(payload)
+
+
+def main() -> int:
+    result = run_cli(
+        [
+            "--format",
+            "json",
+            "content-ops",
+            "observe-public-handle",
+            "--url",
+            "https://x.com/OpenAI",
+            "--source-item-id",
+            "source_x_openai_public_handle_fixture",
+            "--no-fetch",
+        ]
+    )
+    payload = json.loads(result.stdout)
+    assert_observation_packet(payload, fetched=False)
+    assert payload["observation"]["http_method"] == "none", payload
+    assert payload["observation"]["observation_status"] == "not_fetched", payload
+
+    markdown = run_cli(
+        [
+            "content-ops",
+            "observe-public-handle",
+            "--url",
+            "https://x.com/OpenAI",
+            "--source-item-id",
+            "source_x_openai_public_handle_fixture",
+            "--no-fetch",
+        ]
+    ).stdout
+    assert "LoopX Content-Ops Public Handle Observation" in markdown, markdown
+    assert "external_writes_performed: `False`" in markdown, markdown
+    assert "content_bytes_read: `0`" in markdown, markdown
+
+    rejected = run_cli(
+        [
+            "--format",
+            "json",
+            "content-ops",
+            "observe-public-handle",
+            "--url",
+            "http://localhost/private",
+            "--source-item-id",
+            "source_bad_local",
+            "--no-fetch",
+        ],
+        check=False,
+    )
+    assert rejected.returncode == 1, rejected
+    rejected_payload = json.loads(rejected.stdout)
+    assert rejected_payload["ok"] is False, rejected_payload
+    assert "https URL" in rejected_payload["error"], rejected_payload
+
+    if os.environ.get("LOOPX_LIVE_PUBLIC_HANDLE_SMOKE") == "1":
+        live = run_cli(
+            [
+                "--format",
+                "json",
+                "content-ops",
+                "observe-public-handle",
+                "--url",
+                "https://x.com/OpenAI",
+                "--source-item-id",
+                "source_x_openai_public_handle_fixture",
+                "--timeout-seconds",
+                "20",
+            ]
+        )
+        live_payload = json.loads(live.stdout)
+        assert_observation_packet(live_payload, fetched=True)
+        assert live_payload["observation"]["http_method"] == "HEAD", live_payload
+        assert isinstance(live_payload["observation"]["http_status"], int), live_payload
+
+    print("content-ops-public-handle-observation-smoke: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/cli_commands/content_ops.py
+++ b/loopx/cli_commands/content_ops.py
@@ -5,7 +5,9 @@ from collections.abc import Callable
 
 from ..content_ops_surface import (
     build_content_ops_preview_packet,
+    build_content_ops_public_handle_observation_packet,
     render_content_ops_preview_markdown,
+    render_content_ops_public_handle_observation_markdown,
 )
 
 
@@ -39,6 +41,53 @@ def register_content_ops_commands(
         default="2026-06-23T00:00:00Z",
         help="Public-safe generated_at timestamp for the synthetic preview fixture.",
     )
+    observe_parser = content_ops_sub.add_parser(
+        "observe-public-handle",
+        help="Observe a public platform handle as metadata-only source_item_v0.",
+    )
+    add_subcommand_format(observe_parser)
+    observe_parser.add_argument(
+        "--url",
+        required=True,
+        help="Public https handle URL to observe with a HEAD-only metadata check.",
+    )
+    observe_parser.add_argument(
+        "--source-item-id",
+        required=True,
+        help="Stable source_item_v0 id to assign to the compact observation.",
+    )
+    observe_parser.add_argument(
+        "--surface",
+        default="x_public_feed",
+        help="Content-ops surface name for this observation.",
+    )
+    observe_parser.add_argument(
+        "--source-kind",
+        default="x_public_profile_handle",
+        help="source_item_v0 source_kind to write into the compact record.",
+    )
+    observe_parser.add_argument(
+        "--freshness",
+        default="fresh",
+        choices=("fresh", "stale", "unknown"),
+        help="Freshness value for the generated source_item_v0.",
+    )
+    observe_parser.add_argument(
+        "--terms-note",
+        default=None,
+        help="Optional public-safe terms/source-boundary note.",
+    )
+    observe_parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=10.0,
+        help="Timeout for the HEAD-only metadata check.",
+    )
+    observe_parser.add_argument(
+        "--no-fetch",
+        action="store_true",
+        help="Build the metadata-only packet without any external read.",
+    )
 
 
 def handle_content_ops_command(
@@ -48,14 +97,31 @@ def handle_content_ops_command(
     print_payload: PrintPayload,
 ) -> int:
     try:
-        if args.content_ops_command != "preview":
-            raise ValueError("content-ops requires the `preview` subcommand")
-        payload = build_content_ops_preview_packet(generated_at=args.generated_at)
+        if args.content_ops_command == "preview":
+            payload = build_content_ops_preview_packet(generated_at=args.generated_at)
+            renderer = render_content_ops_preview_markdown
+        elif args.content_ops_command == "observe-public-handle":
+            payload = build_content_ops_public_handle_observation_packet(
+                url=args.url,
+                source_item_id=args.source_item_id,
+                surface=args.surface,
+                source_kind=args.source_kind,
+                freshness=args.freshness,
+                terms_note=args.terms_note,
+                timeout_seconds=args.timeout_seconds,
+                fetch=not args.no_fetch,
+            )
+            renderer = render_content_ops_public_handle_observation_markdown
+        else:
+            raise ValueError(
+                "content-ops requires `preview` or `observe-public-handle`"
+            )
     except Exception as exc:
         payload = {
             "ok": False,
             "mode": "content-ops",
             "error": str(exc),
         }
-    print_payload(payload, output_format(args), render_content_ops_preview_markdown)
+        renderer = render_content_ops_public_handle_observation_markdown
+    print_payload(payload, output_format(args), renderer)
     return 0 if payload.get("ok") else 1

--- a/loopx/content_ops_surface.py
+++ b/loopx/content_ops_surface.py
@@ -1,13 +1,23 @@
 from __future__ import annotations
 
+import ipaddress
 from collections import Counter
 from collections.abc import Mapping, Sequence
 from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urljoin, urlsplit, urlunsplit
+from urllib.request import HTTPRedirectHandler, Request, build_opener
 
 
 CONTENT_OPS_SURFACE_SCHEMA_VERSION = "content_ops_surface_v0"
 CONTENT_OPS_SURFACE_PROJECTION_SCHEMA_VERSION = "content_ops_surface_projection_v0"
 CONTENT_OPS_PREVIEW_PACKET_SCHEMA_VERSION = "content_ops_preview_packet_v0"
+CONTENT_OPS_PUBLIC_HANDLE_OBSERVATION_PACKET_SCHEMA_VERSION = (
+    "content_ops_public_handle_observation_packet_v0"
+)
+CONTENT_OPS_PUBLIC_HANDLE_OBSERVATION_SCHEMA_VERSION = (
+    "content_ops_public_handle_observation_v0"
+)
 
 SOURCE_ITEM_SCHEMA_VERSION = "source_item_v0"
 ANGLE_CANDIDATE_SCHEMA_VERSION = "angle_candidate_v0"
@@ -100,6 +110,81 @@ def _ids(items: Sequence[Mapping[str, Any]], key: str) -> set[str]:
 
 def _counter(values: Sequence[Any]) -> dict[str, int]:
     return dict(sorted(Counter(str(value) for value in values if value).items()))
+
+
+def _normalise_public_https_url(url: str) -> tuple[str, Any]:
+    text = str(url or "").strip()
+    parsed = urlsplit(text)
+    if parsed.scheme != "https":
+        raise ValueError("public handle observation requires an https URL")
+    if parsed.username or parsed.password:
+        raise ValueError("public handle URL must not include credentials")
+    if parsed.query or parsed.fragment:
+        raise ValueError("public handle URL must not include query or fragment data")
+
+    host = parsed.hostname
+    if not host:
+        raise ValueError("public handle URL must include a host")
+    lowered_host = host.lower().rstrip(".")
+    if lowered_host in {"localhost"} or lowered_host.endswith((".localhost", ".local")):
+        raise ValueError("public handle URL must not target localhost or local hosts")
+    if parsed.port not in (None, 443):
+        raise ValueError("public handle URL must use the default https port")
+
+    try:
+        address = ipaddress.ip_address(lowered_host.strip("[]"))
+    except ValueError:
+        address = None
+    if address is not None and (
+        address.is_private
+        or address.is_loopback
+        or address.is_link_local
+        or address.is_multicast
+        or address.is_reserved
+        or address.is_unspecified
+    ):
+        raise ValueError("public handle URL must not target private or local addresses")
+
+    path = parsed.path or "/"
+    normalised = urlunsplit(("https", parsed.netloc, path, "", ""))
+    return normalised, parsed._replace(path=path, query="", fragment="")
+
+
+class _NoFollowPublicHandleRedirect(HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore[override]
+        _normalise_public_https_url(newurl)
+        return None
+
+
+def _public_handle_attribution(parsed: Any) -> str:
+    path = parsed.path.rstrip("/") or "/"
+    return f"{parsed.hostname}{path}"
+
+
+def _source_item_from_public_handle_observation(
+    *,
+    source_item_id: str,
+    source_kind: str,
+    freshness: str,
+    terms_note: str,
+    parsed_url: Any,
+    observation: Mapping[str, Any],
+) -> dict[str, Any]:
+    return {
+        "schema_version": SOURCE_ITEM_SCHEMA_VERSION,
+        "source_item_id": source_item_id,
+        "source_kind": source_kind,
+        "source_status": "public",
+        "freshness": freshness,
+        "terms_note": terms_note,
+        "allowed_use": "metadata_only",
+        "attribution": _public_handle_attribution(parsed_url),
+        "summary": (
+            "Public handle observed as metadata-only; no source content was "
+            "captured and no external write was attempted."
+        ),
+        "observation": dict(observation),
+    }
 
 
 def _raw_material_key_names(*groups: Sequence[Mapping[str, Any]]) -> list[str]:
@@ -705,6 +790,162 @@ def build_content_ops_preview_packet(
         if isinstance(projection.get("first_screen"), Mapping)
         else None,
     }
+
+
+def build_content_ops_public_handle_observation_packet(
+    *,
+    url: str,
+    source_item_id: str,
+    surface: str = "x_public_feed",
+    source_kind: str = "x_public_profile_handle",
+    freshness: str = "fresh",
+    terms_note: str | None = None,
+    timeout_seconds: float = 10.0,
+    fetch: bool = True,
+) -> dict[str, Any]:
+    """Observe a public handle as a metadata-only ``source_item_v0`` record.
+
+    The live path issues at most one HEAD request. It never reads response
+    content, sends cookies, logs in, posts, or follows redirects.
+    """
+
+    if not str(source_item_id or "").strip():
+        raise ValueError("source_item_id is required")
+    if freshness not in ALLOWED_FRESHNESS:
+        raise ValueError(f"freshness must be one of {sorted(ALLOWED_FRESHNESS)}")
+    if timeout_seconds <= 0:
+        raise ValueError("timeout_seconds must be positive")
+
+    normalised_url, parsed_url = _normalise_public_https_url(url)
+    effective_terms_note = terms_note or (
+        "public metadata-only handle observation; no login, body capture, "
+        "posting, or private source use"
+    )
+    observation: dict[str, Any] = {
+        "schema_version": CONTENT_OPS_PUBLIC_HANDLE_OBSERVATION_SCHEMA_VERSION,
+        "surface": surface,
+        "input_url": normalised_url,
+        "url_effective": normalised_url,
+        "url_host": parsed_url.hostname,
+        "url_path": parsed_url.path,
+        "http_method": "HEAD" if fetch else "none",
+        "http_status": None,
+        "content_type": None,
+        "redirect_location": None,
+        "content_bytes_read": 0,
+        "external_write_performed": False,
+        "login_used": False,
+        "cookies_sent": False,
+        "private_source_content_read": False,
+        "autopublish_allowed": False,
+    }
+
+    if fetch:
+        request = Request(
+            normalised_url,
+            headers={"User-Agent": "loopx-content-ops-public-handle-metadata/0.1"},
+            method="HEAD",
+        )
+        opener = build_opener(_NoFollowPublicHandleRedirect)
+        response = None
+        try:
+            response = opener.open(request, timeout=timeout_seconds)
+            observation["http_status"] = response.getcode()
+            observation["url_effective"] = response.geturl()
+            observation["content_type"] = response.headers.get("Content-Type")
+        except HTTPError as exc:
+            observation["http_status"] = exc.code
+            observation["url_effective"] = exc.geturl()
+            observation["content_type"] = exc.headers.get("Content-Type")
+            location = exc.headers.get("Location")
+            if location:
+                redirect_url = urljoin(normalised_url, location)
+                _normalise_public_https_url(redirect_url)
+                observation["redirect_location"] = redirect_url
+        except URLError as exc:
+            raise RuntimeError(f"public handle HEAD observation failed: {exc.reason}") from exc
+        finally:
+            if response is not None:
+                response.close()
+
+        _normalise_public_https_url(str(observation["url_effective"]))
+    else:
+        observation["observation_status"] = "not_fetched"
+
+    source_item = _source_item_from_public_handle_observation(
+        source_item_id=str(source_item_id).strip(),
+        source_kind=source_kind,
+        freshness=freshness,
+        terms_note=effective_terms_note,
+        parsed_url=parsed_url,
+        observation=observation,
+    )
+    return {
+        "ok": True,
+        "schema_version": CONTENT_OPS_PUBLIC_HANDLE_OBSERVATION_PACKET_SCHEMA_VERSION,
+        "mode": "content-ops-observe-public-handle",
+        "surface": surface,
+        "source_item": source_item,
+        "source_item_schema_version": SOURCE_ITEM_SCHEMA_VERSION,
+        "observation": observation,
+        "external_reads_performed": bool(fetch),
+        "external_read_kind": "http_head" if fetch else "none",
+        "external_writes_performed": False,
+        "private_source_bodies_read": False,
+        "private_source_content_read": False,
+        "autopublish_allowed": False,
+        "promotion_target": "source_item_v0",
+        "next_safe_action": (
+            "promote the compact source_item_v0 into content_ops_surface_v0 "
+            "only after attribution and allowed_use remain metadata_only"
+        ),
+    }
+
+
+def render_content_ops_public_handle_observation_markdown(
+    payload: dict[str, Any],
+) -> str:
+    lines = [
+        "# LoopX Content-Ops Public Handle Observation",
+        "",
+        f"- ok: `{payload.get('ok')}`",
+        f"- schema_version: `{payload.get('schema_version')}`",
+        f"- external_reads_performed: `{payload.get('external_reads_performed')}`",
+        f"- external_writes_performed: `{payload.get('external_writes_performed')}`",
+        f"- private_source_bodies_read: `{payload.get('private_source_bodies_read')}`",
+        f"- autopublish_allowed: `{payload.get('autopublish_allowed')}`",
+    ]
+    source_item = payload.get("source_item")
+    if isinstance(source_item, Mapping):
+        lines.extend(
+            [
+                "",
+                "## Source Item",
+                "",
+                f"- source_item_id: `{source_item.get('source_item_id')}`",
+                f"- source_kind: `{source_item.get('source_kind')}`",
+                f"- source_status: `{source_item.get('source_status')}`",
+                f"- allowed_use: `{source_item.get('allowed_use')}`",
+                f"- attribution: `{source_item.get('attribution')}`",
+            ]
+        )
+    observation = payload.get("observation")
+    if isinstance(observation, Mapping):
+        lines.extend(
+            [
+                "",
+                "## Observation",
+                "",
+                f"- http_method: `{observation.get('http_method')}`",
+                f"- http_status: `{observation.get('http_status')}`",
+                f"- url_effective: `{observation.get('url_effective')}`",
+                f"- content_bytes_read: `{observation.get('content_bytes_read')}`",
+                f"- external_write_performed: `{observation.get('external_write_performed')}`",
+            ]
+        )
+    if payload.get("error"):
+        lines.extend(["", "## Error", "", str(payload.get("error"))])
+    return "\n".join(lines) + "\n"
 
 
 def render_content_ops_preview_markdown(payload: dict[str, Any]) -> str:


### PR DESCRIPTION
## Summary
- add `loopx content-ops observe-public-handle` for metadata-only public handle observations
- emit compact `source_item_v0` records with no content read, no cookies/login, no external writes, and no autopublish
- document the adapter contract and add a deterministic smoke with optional live X HEAD probe

## Validation
- `python3 -m py_compile loopx/content_ops_surface.py loopx/cli_commands/content_ops.py examples/content-ops-public-handle-observation-smoke.py`
- `python3 examples/content-ops-surface-fixture-smoke.py`
- `python3 examples/content-ops-preview-cli-smoke.py`
- `python3 examples/content-ops-public-handle-observation-smoke.py`
- `python3 -m loopx.cli --format json content-ops observe-public-handle --url https://x.com/OpenAI --source-item-id source_x_openai_public_handle_20260623 --timeout-seconds 20`
- `loopx check --scan-path loopx/content_ops_surface.py --scan-path loopx/cli_commands/content_ops.py --scan-path docs/reference/protocols/content-ops-surface-v0.md --scan-path examples/content-ops-public-handle-observation-smoke.py`

LoopX check reported 0 errors and one existing duplicate-index warning for loopx-meta history (`raw=4810 unique=4806`), unrelated to the changed files.