### PR TITLE
Add content-ops private connector owner gate

### DIFF
--- a/docs/reference/protocols/content-ops-surface-v0.md
+++ b/docs/reference/protocols/content-ops-surface-v0.md
@@ -147,16 +147,38 @@ cookies, does not log in, does not write externally, and never grants
 autopublish permission. Deterministic tests and dry routing can use
 `--no-fetch` to build the same packet shape without external reads.
 
+Private connectors use a gate-projection command before any source access:
+
+```bash
+loopx content-ops project-private-connector-gate \
+  --connector-id chatlog_alpha_chatview \
+  --connector-name chatlog-alpha/chatview \
+  --surface wechat_private_archive \
+  --proposed-source-item-id source_wechat_metadata_signal_001 \
+  --format json
+```
+
+It returns `content_ops_private_connector_gate_packet_v0` with an
+`owner_gate`, a metadata-only `source_item_v0` placeholder, and a concrete
+`user_todo_projection`. It performs no external read, no private source-content
+read, no external write, and no publish action. The only safe next action is to
+surface the owner decision: approve metadata-only intake, reject it, or request
+a narrower source handle. Real chatlog-alpha/chatview ingestion must stay
+behind that gate.
+
 The durable smoke is:
 
 ```bash
 python3 examples/content-ops-surface-fixture-smoke.py
 python3 examples/content-ops-preview-cli-smoke.py
 python3 examples/content-ops-public-handle-observation-smoke.py
+python3 examples/content-ops-private-connector-gate-smoke.py
 ```
 
 The smoke checks record coverage, source/draft/gate references, first-screen
 projection fields, connector metadata-trial routing, todo candidates,
 no-autopublish policy, public/private boundary hygiene, and the public-handle
-adapter's no-content/no-write guarantees. A live X HEAD probe is available only
-when `LOOPX_LIVE_PUBLIC_HANDLE_SMOKE=1` is explicitly set.
+adapter's no-content/no-write guarantees. It also verifies that private
+connector intake projects an owner gate before any private source-content read.
+A live X HEAD probe is available only when
+`LOOPX_LIVE_PUBLIC_HANDLE_SMOKE=1` is explicitly set.

--- a/examples/content-ops-private-connector-gate-smoke.py
+++ b/examples/content-ops-private-connector-gate-smoke.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Smoke-test the content-ops private connector owner-gate CLI."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.content_ops_surface import (  # noqa: E402
+    CONTENT_OPS_PRIVATE_CONNECTOR_GATE_PACKET_SCHEMA_VERSION,
+    CONTENT_OPS_PRIVATE_CONNECTOR_OWNER_GATE_SCHEMA_VERSION,
+    SOURCE_ITEM_SCHEMA_VERSION,
+)
+
+
+PRIVATE_PATTERNS = [
+    re.compile(r"/Users/[A-Za-z0-9._-]+/"),
+    re.compile(r"/home/[A-Za-z0-9._-]+/"),
+    re.compile(r"/private/"),
+    re.compile(r"[A-Za-z]:\\\\Users\\\\"),
+    re.compile(r"\bBearer\s+[A-Za-z0-9._-]+"),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+]
+
+
+def assert_public_safe(payload: dict[str, Any]) -> None:
+    text = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    for pattern in PRIVATE_PATTERNS:
+        if pattern.search(text):
+            raise AssertionError(f"payload matched private pattern {pattern.pattern!r}")
+    forbidden_values = [
+        "full chat transcript",
+        "raw platform post body",
+        "secret-value",
+        "credential-value",
+    ]
+    leaked = [value for value in forbidden_values if value in text]
+    assert not leaked, leaked
+
+
+def run_cli(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "loopx.cli", *args],
+        cwd=REPO_ROOT,
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def main() -> int:
+    result = run_cli(
+        [
+            "--format",
+            "json",
+            "content-ops",
+            "project-private-connector-gate",
+        ]
+    )
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True, payload
+    assert (
+        payload["schema_version"]
+        == CONTENT_OPS_PRIVATE_CONNECTOR_GATE_PACKET_SCHEMA_VERSION
+    ), payload
+    assert payload["owner_gate_required"] is True, payload
+    assert payload["external_reads_performed"] is False, payload
+    assert payload["external_writes_performed"] is False, payload
+    assert payload["private_source_bodies_read"] is False, payload
+    assert payload["private_source_content_read"] is False, payload
+    assert payload["autopublish_allowed"] is False, payload
+
+    connector = payload["connector"]
+    assert connector["connector_id"] == "chatlog_alpha_chatview", connector
+    assert connector["connector_name"] == "chatlog-alpha/chatview", connector
+    assert connector["access_mode"] == "private_metadata_only", connector
+    assert connector["source_status"] == "private_needs_review", connector
+    assert connector["allowed_use"] == "metadata_only", connector
+
+    gate = payload["owner_gate"]
+    assert (
+        gate["schema_version"]
+        == CONTENT_OPS_PRIVATE_CONNECTOR_OWNER_GATE_SCHEMA_VERSION
+    ), gate
+    assert gate["status"] == "blocked_until_user_approval", gate
+    assert gate["approval_required"] is True, gate
+    assert "source content read" in gate["forbidden_until_approved"], gate
+    assert "autopublish" in gate["forbidden_until_approved"], gate
+
+    source_item = payload["source_item"]
+    assert source_item["schema_version"] == SOURCE_ITEM_SCHEMA_VERSION, source_item
+    assert source_item["source_status"] == "private_needs_review", source_item
+    assert source_item["allowed_use"] == "metadata_only", source_item
+    assert source_item["owner_gate"]["gate_id"] == gate["gate_id"], source_item
+
+    todo = payload["user_todo_projection"]
+    assert todo["role"] == "user", todo
+    assert todo["action_kind"] == "content_ops_private_connector_owner_gate", todo
+    assert todo["gate_id"] == gate["gate_id"], todo
+    assert "before LoopX reads any private source content" in todo["title"], todo
+    assert_public_safe(payload)
+
+    markdown = run_cli(
+        [
+            "content-ops",
+            "project-private-connector-gate",
+        ]
+    ).stdout
+    assert "LoopX Content-Ops Private Connector Gate" in markdown, markdown
+    assert "owner_gate_required: `True`" in markdown, markdown
+    assert "external_reads_performed: `False`" in markdown, markdown
+    assert "private_source_bodies_read: `False`" in markdown, markdown
+
+    rejected = run_cli(
+        [
+            "--format",
+            "json",
+            "content-ops",
+            "project-private-connector-gate",
+            "--proposed-source-item-id",
+            "",
+        ],
+        check=False,
+    )
+    assert rejected.returncode == 1, rejected
+    rejected_payload = json.loads(rejected.stdout)
+    assert rejected_payload["ok"] is False, rejected_payload
+    assert "proposed_source_item_id is required" in rejected_payload["error"]
+
+    print("content-ops-private-connector-gate-smoke: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/cli_commands/content_ops.py
+++ b/loopx/cli_commands/content_ops.py
@@ -5,8 +5,10 @@ from collections.abc import Callable
 
 from ..content_ops_surface import (
     build_content_ops_preview_packet,
+    build_content_ops_private_connector_gate_packet,
     build_content_ops_public_handle_observation_packet,
     render_content_ops_preview_markdown,
+    render_content_ops_private_connector_gate_markdown,
     render_content_ops_public_handle_observation_markdown,
 )
 
@@ -88,6 +90,47 @@ def register_content_ops_commands(
         action="store_true",
         help="Build the metadata-only packet without any external read.",
     )
+    private_gate_parser = content_ops_sub.add_parser(
+        "project-private-connector-gate",
+        help="Project an owner gate before private connector metadata intake.",
+    )
+    add_subcommand_format(private_gate_parser)
+    private_gate_parser.add_argument(
+        "--connector-id",
+        default="chatlog_alpha_chatview",
+        help="Stable connector id for the private metadata-only gate.",
+    )
+    private_gate_parser.add_argument(
+        "--connector-name",
+        default="chatlog-alpha/chatview",
+        help="Human-readable connector name for the owner gate.",
+    )
+    private_gate_parser.add_argument(
+        "--surface",
+        default="wechat_private_archive",
+        help="Content-ops surface name for this private connector.",
+    )
+    private_gate_parser.add_argument(
+        "--proposed-source-item-id",
+        default="source_wechat_metadata_signal_001",
+        help="source_item_v0 id to reserve after owner approval.",
+    )
+    private_gate_parser.add_argument(
+        "--source-kind",
+        default="wechat_private_connector_metadata",
+        help="source_item_v0 source_kind for the metadata-only placeholder.",
+    )
+    private_gate_parser.add_argument(
+        "--owner-label",
+        default="WeChat archive owner",
+        help="Public-safe owner label to show in the gate packet.",
+    )
+    private_gate_parser.add_argument(
+        "--freshness",
+        default="unknown",
+        choices=("fresh", "stale", "unknown"),
+        help="Freshness value for the metadata-only placeholder.",
+    )
 
 
 def handle_content_ops_command(
@@ -112,9 +155,21 @@ def handle_content_ops_command(
                 fetch=not args.no_fetch,
             )
             renderer = render_content_ops_public_handle_observation_markdown
+        elif args.content_ops_command == "project-private-connector-gate":
+            payload = build_content_ops_private_connector_gate_packet(
+                connector_id=args.connector_id,
+                connector_name=args.connector_name,
+                surface=args.surface,
+                proposed_source_item_id=args.proposed_source_item_id,
+                source_kind=args.source_kind,
+                owner_label=args.owner_label,
+                freshness=args.freshness,
+            )
+            renderer = render_content_ops_private_connector_gate_markdown
         else:
             raise ValueError(
-                "content-ops requires `preview` or `observe-public-handle`"
+                "content-ops requires `preview`, `observe-public-handle`, or "
+                "`project-private-connector-gate`"
             )
     except Exception as exc:
         payload = {
@@ -122,6 +177,6 @@ def handle_content_ops_command(
             "mode": "content-ops",
             "error": str(exc),
         }
-        renderer = render_content_ops_public_handle_observation_markdown
+        renderer = render_content_ops_private_connector_gate_markdown
     print_payload(payload, output_format(args), renderer)
     return 0 if payload.get("ok") else 1

--- a/loopx/content_ops_surface.py
+++ b/loopx/content_ops_surface.py
@@ -18,6 +18,12 @@ CONTENT_OPS_PUBLIC_HANDLE_OBSERVATION_PACKET_SCHEMA_VERSION = (
 CONTENT_OPS_PUBLIC_HANDLE_OBSERVATION_SCHEMA_VERSION = (
     "content_ops_public_handle_observation_v0"
 )
+CONTENT_OPS_PRIVATE_CONNECTOR_GATE_PACKET_SCHEMA_VERSION = (
+    "content_ops_private_connector_gate_packet_v0"
+)
+CONTENT_OPS_PRIVATE_CONNECTOR_OWNER_GATE_SCHEMA_VERSION = (
+    "content_ops_private_connector_owner_gate_v0"
+)
 
 SOURCE_ITEM_SCHEMA_VERSION = "source_item_v0"
 ANGLE_CANDIDATE_SCHEMA_VERSION = "angle_candidate_v0"
@@ -184,6 +190,35 @@ def _source_item_from_public_handle_observation(
             "captured and no external write was attempted."
         ),
         "observation": dict(observation),
+    }
+
+
+def _source_item_from_private_connector_gate(
+    *,
+    source_item_id: str,
+    source_kind: str,
+    freshness: str,
+    connector_name: str,
+    owner_label: str,
+    gate: Mapping[str, Any],
+) -> dict[str, Any]:
+    return {
+        "schema_version": SOURCE_ITEM_SCHEMA_VERSION,
+        "source_item_id": source_item_id,
+        "source_kind": source_kind,
+        "source_status": "private_needs_review",
+        "freshness": freshness,
+        "terms_note": (
+            "private connector metadata-only placeholder; owner approval is "
+            "required before any source content read, quote, summary, or publication"
+        ),
+        "allowed_use": "metadata_only",
+        "attribution": f"{owner_label} via {connector_name}",
+        "summary": (
+            "Private connector is represented only as an owner-gated metadata "
+            "signal; no source content was read or copied."
+        ),
+        "owner_gate": dict(gate),
     }
 
 
@@ -941,6 +976,161 @@ def render_content_ops_public_handle_observation_markdown(
                 f"- url_effective: `{observation.get('url_effective')}`",
                 f"- content_bytes_read: `{observation.get('content_bytes_read')}`",
                 f"- external_write_performed: `{observation.get('external_write_performed')}`",
+            ]
+        )
+    if payload.get("error"):
+        lines.extend(["", "## Error", "", str(payload.get("error"))])
+    return "\n".join(lines) + "\n"
+
+
+def build_content_ops_private_connector_gate_packet(
+    *,
+    connector_id: str = "chatlog_alpha_chatview",
+    connector_name: str = "chatlog-alpha/chatview",
+    surface: str = "wechat_private_archive",
+    proposed_source_item_id: str = "source_wechat_metadata_signal_001",
+    source_kind: str = "wechat_private_connector_metadata",
+    owner_label: str = "WeChat archive owner",
+    freshness: str = "unknown",
+) -> dict[str, Any]:
+    """Project a concrete owner gate before private connector intake.
+
+    This packet is a routing artifact only. It does not connect to private
+    sources, read source content, quote material, or authorize publication.
+    """
+
+    if not str(connector_id or "").strip():
+        raise ValueError("connector_id is required")
+    if not str(proposed_source_item_id or "").strip():
+        raise ValueError("proposed_source_item_id is required")
+    if freshness not in ALLOWED_FRESHNESS:
+        raise ValueError(f"freshness must be one of {sorted(ALLOWED_FRESHNESS)}")
+
+    gate_id = f"owner_gate_{str(connector_id).strip()}"
+    gate = {
+        "schema_version": CONTENT_OPS_PRIVATE_CONNECTOR_OWNER_GATE_SCHEMA_VERSION,
+        "gate_id": gate_id,
+        "connector_id": str(connector_id).strip(),
+        "connector_name": str(connector_name).strip(),
+        "surface": surface,
+        "status": "blocked_until_user_approval",
+        "approval_required": True,
+        "owner_label": str(owner_label).strip(),
+        "requested_decision": "approve_metadata_only_intake_or_reject",
+        "approval_options": [
+            "approve metadata-only intake",
+            "reject connector intake",
+            "request a narrower source handle",
+        ],
+        "forbidden_until_approved": [
+            "source content read",
+            "source quote",
+            "source summary",
+            "external posting",
+            "autopublish",
+        ],
+        "allowed_before_approval": [
+            "store this compact gate packet",
+            "display the owner question",
+            "prepare fixture-only smoke coverage",
+        ],
+    }
+    source_item = _source_item_from_private_connector_gate(
+        source_item_id=str(proposed_source_item_id).strip(),
+        source_kind=source_kind,
+        freshness=freshness,
+        connector_name=str(connector_name).strip(),
+        owner_label=str(owner_label).strip(),
+        gate=gate,
+    )
+    user_todo_projection = {
+        "role": "user",
+        "action_kind": "content_ops_private_connector_owner_gate",
+        "title": (
+            f"Approve, reject, or narrow metadata-only intake for {connector_name} "
+            "before LoopX reads any private source content."
+        ),
+        "gate_id": gate_id,
+        "connector_id": str(connector_id).strip(),
+        "source_item_id": source_item["source_item_id"],
+        "validation_surface": "owner decision recorded before private source use",
+    }
+    return {
+        "ok": True,
+        "schema_version": CONTENT_OPS_PRIVATE_CONNECTOR_GATE_PACKET_SCHEMA_VERSION,
+        "mode": "content-ops-project-private-connector-gate",
+        "surface": surface,
+        "connector": {
+            "connector_id": str(connector_id).strip(),
+            "connector_name": str(connector_name).strip(),
+            "access_mode": "private_metadata_only",
+            "source_status": "private_needs_review",
+            "allowed_use": "metadata_only",
+            "promotion_target": "source_item_v0_after_owner_gate",
+        },
+        "owner_gate": gate,
+        "source_item": source_item,
+        "user_todo_projection": user_todo_projection,
+        "external_reads_performed": False,
+        "external_writes_performed": False,
+        "private_source_bodies_read": False,
+        "private_source_content_read": False,
+        "autopublish_allowed": False,
+        "owner_gate_required": True,
+        "next_safe_action": (
+            "surface the projected owner gate; do not read private source content "
+            "until an owner decision updates the gate"
+        ),
+    }
+
+
+def render_content_ops_private_connector_gate_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# LoopX Content-Ops Private Connector Gate",
+        "",
+        f"- ok: `{payload.get('ok')}`",
+        f"- schema_version: `{payload.get('schema_version')}`",
+        f"- owner_gate_required: `{payload.get('owner_gate_required')}`",
+        f"- external_reads_performed: `{payload.get('external_reads_performed')}`",
+        f"- external_writes_performed: `{payload.get('external_writes_performed')}`",
+        f"- private_source_bodies_read: `{payload.get('private_source_bodies_read')}`",
+        f"- autopublish_allowed: `{payload.get('autopublish_allowed')}`",
+    ]
+    connector = payload.get("connector")
+    if isinstance(connector, Mapping):
+        lines.extend(
+            [
+                "",
+                "## Connector",
+                "",
+                f"- connector_id: `{connector.get('connector_id')}`",
+                f"- connector_name: `{connector.get('connector_name')}`",
+                f"- access_mode: `{connector.get('access_mode')}`",
+                f"- allowed_use: `{connector.get('allowed_use')}`",
+            ]
+        )
+    gate = payload.get("owner_gate")
+    if isinstance(gate, Mapping):
+        lines.extend(
+            [
+                "",
+                "## Owner Gate",
+                "",
+                f"- gate_id: `{gate.get('gate_id')}`",
+                f"- status: `{gate.get('status')}`",
+                f"- approval_required: `{gate.get('approval_required')}`",
+                f"- requested_decision: `{gate.get('requested_decision')}`",
+            ]
+        )
+    todo = payload.get("user_todo_projection")
+    if isinstance(todo, Mapping):
+        lines.extend(
+            [
+                "",
+                "## User Todo Projection",
+                "",
+                f"- action_kind: `{todo.get('action_kind')}`",
+                f"- title: {todo.get('title')}",
             ]
         )
     if payload.get("error"):


### PR DESCRIPTION
## Summary
- add `loopx content-ops project-private-connector-gate` for private connector owner-gate projection
- model chatlog-alpha/chatview as private metadata-only intake behind an explicit owner decision
- emit `owner_gate`, metadata-only `source_item_v0` placeholder, and concrete `user_todo_projection` without reading private source content
- document the command and add a durable smoke

## Validation
- `python3 -m py_compile loopx/content_ops_surface.py loopx/cli_commands/content_ops.py examples/content-ops-private-connector-gate-smoke.py`
- `python3 examples/content-ops-private-connector-gate-smoke.py`
- `python3 examples/content-ops-preview-cli-smoke.py`
- `python3 examples/content-ops-public-handle-observation-smoke.py`
- `python3 -m loopx.cli --format json content-ops project-private-connector-gate`
- `git diff --check`
- `loopx check --scan-path loopx/content_ops_surface.py --scan-path loopx/cli_commands/content_ops.py --scan-path docs/reference/protocols/content-ops-surface-v0.md --scan-path examples/content-ops-private-connector-gate-smoke.py`

LoopX check reported 0 errors and one existing duplicate-index warning for loopx-meta history (`raw=4815 unique=4811`), unrelated to the changed files.