### PR TITLE
Add content ops packet aggregation

### DIFF
--- a/docs/reference/protocols/content-ops-surface-v0.md
+++ b/docs/reference/protocols/content-ops-surface-v0.md
@@ -181,6 +181,25 @@ approval. Before approval, the runtime policy forbids paths such as
 limited to storing the compact gate packet, surfacing the owner question, and
 fixture-only smoke coverage.
 
+Connector packets can then be aggregated into the compact state surface:
+
+```bash
+loopx content-ops aggregate-packets \
+  --public-packet-json public-handle-packet.json \
+  --private-gate-packet-json private-connector-gate-packet.json \
+  --surface-id content_ops_connector_packet_aggregation \
+  --format json
+```
+
+It returns `content_ops_packet_aggregation_v0` with a generated
+`content_ops_surface_v0`, its read-only projection, validation details, and
+boundary booleans. The aggregation does not re-open connector URLs, read source
+bodies, read private material, write externally, or authorize publication. A
+public packet becomes a `metadata_packet_collected` connector trial, while a
+private gate packet remains `needs_owner_gate`; this prevents the projection
+from scheduling another metadata trial after a public packet has already been
+collected.
+
 The durable smoke is:
 
 ```bash
@@ -188,6 +207,7 @@ python3 examples/content-ops-surface-fixture-smoke.py
 python3 examples/content-ops-preview-cli-smoke.py
 python3 examples/content-ops-public-handle-observation-smoke.py
 python3 examples/content-ops-private-connector-gate-smoke.py
+python3 examples/content-ops-packet-aggregation-smoke.py
 ```
 
 The smoke checks record coverage, source/draft/gate references, first-screen
@@ -195,5 +215,6 @@ projection fields, connector metadata-trial routing, todo candidates,
 no-autopublish policy, public/private boundary hygiene, and the public-handle
 adapter's no-content/no-write guarantees. It also verifies that private
 connector intake projects an owner gate and a runtime deny policy before any
-private source-content read. A live X HEAD probe is available only when
-`LOOPX_LIVE_PUBLIC_HANDLE_SMOKE=1` is explicitly set.
+private source-content read, and that packet aggregation promotes only compact
+source/gate records into the state surface. A live X HEAD probe is available
+only when `LOOPX_LIVE_PUBLIC_HANDLE_SMOKE=1` is explicitly set.

--- a/examples/content-ops-packet-aggregation-smoke.py
+++ b/examples/content-ops-packet-aggregation-smoke.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Smoke-test content-ops packet aggregation into a surface projection."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.content_ops_surface import (  # noqa: E402
+    CONTENT_OPS_PACKET_AGGREGATION_SCHEMA_VERSION,
+    CONTENT_OPS_SURFACE_PROJECTION_SCHEMA_VERSION,
+    CONTENT_OPS_SURFACE_SCHEMA_VERSION,
+)
+
+
+PRIVATE_PATTERNS = [
+    re.compile(r"/Users/[A-Za-z0-9._-]+/"),
+    re.compile(r"/home/[A-Za-z0-9._-]+/"),
+    re.compile(r"/private/"),
+    re.compile(r"[A-Za-z]:\\\\Users\\\\"),
+    re.compile(r"\bBearer\s+[A-Za-z0-9._-]+"),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+]
+
+
+def assert_public_safe(payload: dict[str, Any]) -> None:
+    text = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    for pattern in PRIVATE_PATTERNS:
+        if pattern.search(text):
+            raise AssertionError(f"payload matched private pattern {pattern.pattern!r}")
+    forbidden_values = [
+        "full chat transcript",
+        "raw platform post body",
+        "secret-value",
+        "credential-value",
+    ]
+    leaked = [value for value in forbidden_values if value in text]
+    assert not leaked, leaked
+
+
+def run_cli(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "loopx.cli", *args],
+        cwd=REPO_ROOT,
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def main() -> int:
+    public_packet = run_cli(
+        [
+            "--format",
+            "json",
+            "content-ops",
+            "observe-public-handle",
+            "--url",
+            "https://x.com/OpenAI",
+            "--source-item-id",
+            "source_x_openai_public_handle_fixture",
+            "--no-fetch",
+        ]
+    ).stdout
+    private_packet = run_cli(
+        [
+            "--format",
+            "json",
+            "content-ops",
+            "project-private-connector-gate",
+        ]
+    ).stdout
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        public_path = tmp_path / "public-packet.json"
+        private_path = tmp_path / "private-gate.json"
+        public_path.write_text(public_packet, encoding="utf-8")
+        private_path.write_text(private_packet, encoding="utf-8")
+
+        result = run_cli(
+            [
+                "--format",
+                "json",
+                "content-ops",
+                "aggregate-packets",
+                "--public-packet-json",
+                str(public_path),
+                "--private-gate-packet-json",
+                str(private_path),
+                "--surface-id",
+                "content_ops_packet_aggregation_smoke",
+            ]
+        )
+        markdown = run_cli(
+            [
+                "content-ops",
+                "aggregate-packets",
+                "--public-packet-json",
+                str(public_path),
+                "--private-gate-packet-json",
+                str(private_path),
+            ]
+        ).stdout
+        assert "LoopX Content-Ops Packet Aggregation" in markdown, markdown
+        assert "owner_gate_required_count: `1`" in markdown, markdown
+
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True, payload
+    assert payload["schema_version"] == CONTENT_OPS_PACKET_AGGREGATION_SCHEMA_VERSION
+    assert payload["external_reads_performed"] is False, payload
+    assert payload["external_writes_performed"] is False, payload
+    assert payload["private_source_bodies_read"] is False, payload
+    assert payload["private_source_content_read"] is False, payload
+    assert payload["autopublish_allowed"] is False, payload
+
+    summary = payload["input_summary"]
+    assert summary["public_handle_packet_count"] == 1, summary
+    assert summary["private_connector_gate_packet_count"] == 1, summary
+    assert summary["source_item_count"] == 2, summary
+    assert summary["owner_gate_required_count"] == 1, summary
+
+    surface = payload["surface"]
+    assert surface["schema_version"] == CONTENT_OPS_SURFACE_SCHEMA_VERSION, surface
+    assert surface["surface_id"] == "content_ops_packet_aggregation_smoke", surface
+    assert surface["boundary"]["public_safe"] is True, surface
+    assert surface["boundary"]["connector_bodies_are_source_of_truth"] is False, surface
+
+    projection = payload["projection"]
+    assert (
+        projection["schema_version"] == CONTENT_OPS_SURFACE_PROJECTION_SCHEMA_VERSION
+    ), projection
+    first_screen = projection["first_screen"]
+    assert first_screen["user_action_required"] is True, first_screen
+    assert first_screen["agent_can_continue"] is True, first_screen
+    assert first_screen["source_review_required_count"] == 2, first_screen
+    assert first_screen["publish_decision_count"] == 1, first_screen
+
+    connector_trials = projection["connector_trials"]
+    assert connector_trials["count"] == 2, connector_trials
+    assert connector_trials["states"] == {
+        "metadata_packet_collected": 1,
+        "needs_owner_gate": 1,
+    }, connector_trials
+    assert connector_trials["ready_for_metadata_trial_count"] == 0, connector_trials
+    assert connector_trials["owner_gate_required_count"] == 1, connector_trials
+
+    todo_candidates = projection["todo_candidates"]
+    action_kinds = {candidate["action_kind"] for candidate in todo_candidates}
+    assert "content_ops_draft_from_angle" in action_kinds, todo_candidates
+    assert "content_ops_source_review" in action_kinds, todo_candidates
+    assert "content_ops_publish_gate" in action_kinds, todo_candidates
+    assert "content_ops_connector_owner_gate" in action_kinds, todo_candidates
+    assert "content_ops_connector_metadata_trial" not in action_kinds, todo_candidates
+
+    rejected = run_cli(
+        [
+            "--format",
+            "json",
+            "content-ops",
+            "aggregate-packets",
+        ],
+        check=False,
+    )
+    assert rejected.returncode == 1, rejected
+    rejected_payload = json.loads(rejected.stdout)
+    assert rejected_payload["ok"] is False, rejected_payload
+    assert "at least one public handle observation packet" in rejected_payload["error"]
+
+    assert_public_safe(payload)
+    print("content-ops-packet-aggregation-smoke: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/cli_commands/content_ops.py
+++ b/loopx/cli_commands/content_ops.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
 import argparse
+import json
+import sys
 from collections.abc import Callable
+from pathlib import Path
+from typing import Any
 
 from ..content_ops_surface import (
+    build_content_ops_packet_aggregation_packet,
     build_content_ops_preview_packet,
     build_content_ops_private_connector_gate_packet,
     build_content_ops_public_handle_observation_packet,
+    render_content_ops_packet_aggregation_markdown,
     render_content_ops_preview_markdown,
     render_content_ops_private_connector_gate_markdown,
     render_content_ops_public_handle_observation_markdown,
@@ -19,6 +25,16 @@ PrintPayload = Callable[
 ]
 FormatSelector = Callable[..., str]
 AddFormat = Callable[[argparse.ArgumentParser], None]
+
+
+def _load_json_object(path_text: str) -> dict[str, Any]:
+    if path_text == "-":
+        payload = json.loads(sys.stdin.read())
+    else:
+        payload = json.loads(Path(path_text).expanduser().read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path_text} must contain a JSON object")
+    return payload
 
 
 def register_content_ops_commands(
@@ -131,6 +147,42 @@ def register_content_ops_commands(
         choices=("fresh", "stale", "unknown"),
         help="Freshness value for the metadata-only placeholder.",
     )
+    aggregate_parser = content_ops_sub.add_parser(
+        "aggregate-packets",
+        help=(
+            "Aggregate public source_item packets and private owner_gate packets "
+            "into a compact content_ops_surface_v0 projection."
+        ),
+    )
+    add_subcommand_format(aggregate_parser)
+    aggregate_parser.add_argument(
+        "--public-packet-json",
+        action="append",
+        default=[],
+        help=(
+            "Path to a content_ops_public_handle_observation_packet_v0 JSON object. "
+            "Repeat for multiple public source packets. Use '-' to read stdin."
+        ),
+    )
+    aggregate_parser.add_argument(
+        "--private-gate-packet-json",
+        action="append",
+        default=[],
+        help=(
+            "Path to a content_ops_private_connector_gate_packet_v0 JSON object. "
+            "Repeat for multiple private connector gates."
+        ),
+    )
+    aggregate_parser.add_argument(
+        "--surface-id",
+        default="content_ops_connector_packet_aggregation",
+        help="Stable surface_id for the generated content_ops_surface_v0.",
+    )
+    aggregate_parser.add_argument(
+        "--generated-at",
+        default="2026-06-23T00:00:00Z",
+        help="Public-safe generated_at timestamp for the aggregate surface.",
+    )
 
 
 def handle_content_ops_command(
@@ -166,10 +218,22 @@ def handle_content_ops_command(
                 freshness=args.freshness,
             )
             renderer = render_content_ops_private_connector_gate_markdown
+        elif args.content_ops_command == "aggregate-packets":
+            payload = build_content_ops_packet_aggregation_packet(
+                public_handle_packets=[
+                    _load_json_object(path) for path in args.public_packet_json
+                ],
+                private_connector_gate_packets=[
+                    _load_json_object(path) for path in args.private_gate_packet_json
+                ],
+                surface_id=args.surface_id,
+                generated_at=args.generated_at,
+            )
+            renderer = render_content_ops_packet_aggregation_markdown
         else:
             raise ValueError(
-                "content-ops requires `preview`, `observe-public-handle`, or "
-                "`project-private-connector-gate`"
+                "content-ops requires `preview`, `observe-public-handle`, "
+                "`project-private-connector-gate`, or `aggregate-packets`"
             )
     except Exception as exc:
         payload = {

--- a/loopx/content_ops_surface.py
+++ b/loopx/content_ops_surface.py
@@ -27,6 +27,7 @@ CONTENT_OPS_PRIVATE_CONNECTOR_OWNER_GATE_SCHEMA_VERSION = (
 CONTENT_OPS_CONNECTOR_RUNTIME_POLICY_SCHEMA_VERSION = (
     "content_ops_connector_runtime_policy_v0"
 )
+CONTENT_OPS_PACKET_AGGREGATION_SCHEMA_VERSION = "content_ops_packet_aggregation_v0"
 
 SOURCE_ITEM_SCHEMA_VERSION = "source_item_v0"
 ANGLE_CANDIDATE_SCHEMA_VERSION = "angle_candidate_v0"
@@ -81,6 +82,7 @@ ALLOWED_PUBLISH_GATE_STATUSES = {
 }
 ALLOWED_CONNECTOR_TRIAL_STATES = {
     "candidate",
+    "metadata_packet_collected",
     "ready_for_metadata_trial",
     "needs_owner_gate",
     "blocked",
@@ -1190,6 +1192,436 @@ def build_content_ops_private_connector_gate_packet(
             "until an owner decision updates the gate"
         ),
     }
+
+
+def _require_packet_flag(payload: Mapping[str, Any], key: str, expected: Any) -> None:
+    if payload.get(key) != expected:
+        raise ValueError(f"packet {key} must be {expected!r}")
+
+
+def _connector_trial_from_public_packet(
+    packet: Mapping[str, Any],
+    index: int,
+) -> dict[str, Any]:
+    source_item = packet.get("source_item")
+    if not isinstance(source_item, Mapping):
+        raise ValueError("public handle packet must include source_item")
+    observation = (
+        packet.get("observation")
+        if isinstance(packet.get("observation"), Mapping)
+        else {}
+    )
+    runtime_policy = (
+        packet.get("runtime_policy")
+        if isinstance(packet.get("runtime_policy"), Mapping)
+        else {}
+    )
+    surface = str(packet.get("surface") or observation.get("surface") or "public_feed")
+    source_item_id = str(source_item.get("source_item_id") or "").strip()
+    if not source_item_id:
+        raise ValueError("public handle packet source_item_id is required")
+    return {
+        "schema_version": CONNECTOR_TRIAL_SCHEMA_VERSION,
+        "trial_id": f"trial_public_packet_{index + 1}",
+        "surface": surface,
+        "tool_hint": str(
+            runtime_policy.get("connector_name") or "public metadata connector"
+        ),
+        "access_mode": "public_metadata_only",
+        "source_status": str(source_item.get("source_status") or "public"),
+        "freshness": str(source_item.get("freshness") or "unknown"),
+        "allowed_use": str(source_item.get("allowed_use") or "metadata_only"),
+        "trial_state": "metadata_packet_collected",
+        "proposed_source_item_id": source_item_id,
+        "terms_note": str(
+            source_item.get("terms_note")
+            or "metadata-only public source packet already collected"
+        ),
+        "promotion_target": "source_item_v0",
+        "requires_user_gate": False,
+        "external_write_allowed": False,
+    }
+
+
+def _connector_trial_from_private_gate_packet(
+    packet: Mapping[str, Any],
+    index: int,
+) -> dict[str, Any]:
+    connector = (
+        packet.get("connector")
+        if isinstance(packet.get("connector"), Mapping)
+        else {}
+    )
+    source_item = packet.get("source_item")
+    if not isinstance(source_item, Mapping):
+        raise ValueError("private connector gate packet must include source_item")
+    source_item_id = str(source_item.get("source_item_id") or "").strip()
+    if not source_item_id:
+        raise ValueError("private connector gate source_item_id is required")
+    return {
+        "schema_version": CONNECTOR_TRIAL_SCHEMA_VERSION,
+        "trial_id": f"trial_private_gate_packet_{index + 1}",
+        "surface": str(
+            packet.get("surface") or connector.get("surface") or "private_archive"
+        ),
+        "tool_hint": str(
+            connector.get("connector_name") or "private metadata connector"
+        ),
+        "access_mode": "private_metadata_only",
+        "source_status": "private_needs_review",
+        "freshness": str(source_item.get("freshness") or "unknown"),
+        "allowed_use": "metadata_only",
+        "trial_state": "needs_owner_gate",
+        "proposed_source_item_id": source_item_id,
+        "terms_note": str(
+            source_item.get("terms_note")
+            or "private connector metadata remains gated before source use"
+        ),
+        "promotion_target": "source_item_v0_after_owner_gate",
+        "requires_user_gate": True,
+        "external_write_allowed": False,
+    }
+
+
+def build_content_ops_surface_from_connector_packets(
+    *,
+    public_handle_packets: Sequence[Mapping[str, Any]],
+    private_connector_gate_packets: Sequence[Mapping[str, Any]],
+    surface_id: str = "content_ops_connector_packet_aggregation",
+    generated_at: str | None = "2026-06-23T00:00:00Z",
+) -> dict[str, Any]:
+    """Aggregate connector packets into a compact content-ops state surface."""
+
+    public_packets = [dict(packet) for packet in public_handle_packets]
+    private_packets = [dict(packet) for packet in private_connector_gate_packets]
+    if not public_packets:
+        raise ValueError("at least one public handle observation packet is required")
+    if not private_packets:
+        raise ValueError("at least one private connector gate packet is required")
+
+    source_items: list[dict[str, Any]] = []
+    connector_trials: list[dict[str, Any]] = []
+
+    for index, packet in enumerate(public_packets):
+        if (
+            packet.get("schema_version")
+            != CONTENT_OPS_PUBLIC_HANDLE_OBSERVATION_PACKET_SCHEMA_VERSION
+        ):
+            raise ValueError(
+                "public packet schema_version must be "
+                "content_ops_public_handle_observation_packet_v0"
+            )
+        _require_packet_flag(packet, "ok", True)
+        _require_packet_flag(packet, "external_writes_performed", False)
+        _require_packet_flag(packet, "private_source_content_read", False)
+        _require_packet_flag(packet, "autopublish_allowed", False)
+        runtime_policy = (
+            packet.get("runtime_policy")
+            if isinstance(packet.get("runtime_policy"), Mapping)
+            else {}
+        )
+        if runtime_policy.get("safe_default") != "head_only_metadata_probe":
+            raise ValueError("public packet runtime policy must be HEAD-only")
+        if runtime_policy.get("browser_open_allowed_before_gate") is not False:
+            raise ValueError("public packet must not allow browser open before gate")
+        source_item = packet.get("source_item")
+        if not isinstance(source_item, Mapping):
+            raise ValueError("public packet must include source_item")
+        source_items.append(dict(source_item))
+        connector_trials.append(_connector_trial_from_public_packet(packet, index))
+
+    for index, packet in enumerate(private_packets):
+        if (
+            packet.get("schema_version")
+            != CONTENT_OPS_PRIVATE_CONNECTOR_GATE_PACKET_SCHEMA_VERSION
+        ):
+            raise ValueError(
+                "private gate packet schema_version must be "
+                "content_ops_private_connector_gate_packet_v0"
+            )
+        _require_packet_flag(packet, "ok", True)
+        _require_packet_flag(packet, "owner_gate_required", True)
+        _require_packet_flag(packet, "external_reads_performed", False)
+        _require_packet_flag(packet, "external_writes_performed", False)
+        _require_packet_flag(packet, "private_source_content_read", False)
+        _require_packet_flag(packet, "autopublish_allowed", False)
+        runtime_policy = (
+            packet.get("runtime_policy")
+            if isinstance(packet.get("runtime_policy"), Mapping)
+            else {}
+        )
+        if runtime_policy.get("safe_default") != "gate_projection_only":
+            raise ValueError("private packet runtime policy must be gate-only")
+        if runtime_policy.get("browser_open_allowed_before_gate") is not False:
+            raise ValueError("private packet must not allow browser open before gate")
+        source_item = packet.get("source_item")
+        if not isinstance(source_item, Mapping):
+            raise ValueError("private gate packet must include source_item")
+        source_items.append(dict(source_item))
+        connector_trials.append(_connector_trial_from_private_gate_packet(packet, index))
+
+    public_source_ids = [
+        str(item.get("source_item_id"))
+        for item in source_items
+        if item.get("source_status") == "public"
+    ]
+    private_source_ids = [
+        str(item.get("source_item_id"))
+        for item in source_items
+        if item.get("source_status") == "private_needs_review"
+    ]
+    aggregate_angle_id = "angle_connector_packet_aggregation"
+    publish_gate_id = "publish_gate_connector_packet_aggregation"
+    draft_id = "draft_connector_packet_aggregation_outline"
+
+    angle_candidates = [
+        {
+            "schema_version": ANGLE_CANDIDATE_SCHEMA_VERSION,
+            "angle_id": aggregate_angle_id,
+            "source_item_ids": public_source_ids,
+            "audience": "creator operators evaluating bounded automation",
+            "topic": "connector-bounded content operations",
+            "novelty": "combines public metadata packets with explicit private owner gates",
+            "preference_fit": "medium",
+            "evidence_quality": "metadata_only_connector_packet",
+            "decision": "draft",
+        }
+    ]
+    if private_source_ids:
+        angle_candidates.append(
+            {
+                "schema_version": ANGLE_CANDIDATE_SCHEMA_VERSION,
+                "angle_id": "angle_private_connector_source_quote",
+                "source_item_ids": private_source_ids,
+                "audience": "creator operators evaluating bounded automation",
+                "topic": "private connector source quote",
+            "novelty": "blocked by private-source owner gate",
+            "preference_fit": "unknown",
+            "evidence_quality": "needs_owner_review",
+            "decision": "reject",
+            "rejection_reason": (
+                "private connector material cannot be quoted or summarized "
+                "before owner approval"
+            ),
+            }
+        )
+
+    draft_items = [
+        {
+            "schema_version": DRAFT_ITEM_SCHEMA_VERSION,
+            "draft_id": draft_id,
+            "angle_id": aggregate_angle_id,
+            "state": "outline",
+            "source_map": [
+                {"source_item_id": source_id, "use": "metadata-only premise"}
+                for source_id in public_source_ids
+            ],
+            "preference_hints": [
+                "explain connector value as bounded signal intake",
+                "keep private-source use and publishing behind explicit gates",
+            ],
+            "publish_gate_id": publish_gate_id,
+            "validation_surface": (
+                "public source map present; private connector represented only by owner gate"
+            ),
+        }
+    ]
+    feedback_signals = [
+        {
+            "schema_version": FEEDBACK_SIGNAL_SCHEMA_VERSION,
+            "feedback_id": "feedback_connector_packet_boundary",
+            "target_id": private_source_ids[0],
+            "signal": "private_connector_stays_gated",
+            "effect": "source_boundary_correction",
+            "writes_todo": True,
+            "summary": "Private connector packets remain owner-gated before source use.",
+        }
+    ]
+    publish_gates = [
+        {
+            "schema_version": PUBLISH_GATE_SCHEMA_VERSION,
+            "gate_id": publish_gate_id,
+            "draft_id": draft_id,
+            "status": "blocked_until_user_approval",
+            "approval_required": True,
+            "autopublish_allowed": False,
+            "required_review": [
+                "source attribution",
+                "private connector owner gate",
+                "tone/style",
+                "final publish destination",
+            ],
+        }
+    ]
+    material_memory = [
+        {
+            "schema_version": MATERIAL_MEMORY_SCHEMA_VERSION,
+            "memory_id": f"memory_{source_id}",
+            "source_item_id": source_id,
+            "attribution": "content-ops packet aggregation",
+            "reuse_boundary": "metadata_only_public_handle",
+            "rejected_angles": ["angle_private_connector_source_quote"],
+            "preference_hints": ["bounded connector intake before drafting"],
+        }
+        for source_id in public_source_ids
+    ]
+    material_memory.extend(
+        {
+            "schema_version": MATERIAL_MEMORY_SCHEMA_VERSION,
+            "memory_id": f"memory_{source_id}",
+            "source_item_id": source_id,
+            "attribution": "content-ops private connector gate",
+            "reuse_boundary": "private_owner_gate_required",
+            "rejected_angles": ["angle_private_connector_source_quote"],
+            "preference_hints": ["do not quote or summarize before owner approval"],
+        }
+        for source_id in private_source_ids
+    )
+
+    return {
+        "schema_version": CONTENT_OPS_SURFACE_SCHEMA_VERSION,
+        "surface_id": surface_id,
+        "generated_at": generated_at,
+        "mode": "compact_state_surface",
+        "source_items": source_items,
+        "angle_candidates": angle_candidates,
+        "draft_items": draft_items,
+        "feedback_signals": feedback_signals,
+        "publish_gates": publish_gates,
+        "material_memory": material_memory,
+        "connector_trials": connector_trials,
+        "operator_states": [
+            "waiting_for_source_review",
+            "ready_to_draft",
+            "waiting_for_feedback",
+            "ready_for_publish_decision",
+            "safe_side_work_available",
+        ],
+        "boundary": {
+            "public_safe": True,
+            "raw_private_material_recorded": False,
+            "raw_platform_data_recorded": False,
+            "credentials_recorded": False,
+            "autopublish_allowed": False,
+            "publish_requires_user_gate": True,
+            "connector_bodies_are_source_of_truth": False,
+        },
+    }
+
+
+def build_content_ops_packet_aggregation_packet(
+    *,
+    public_handle_packets: Sequence[Mapping[str, Any]],
+    private_connector_gate_packets: Sequence[Mapping[str, Any]],
+    surface_id: str = "content_ops_connector_packet_aggregation",
+    generated_at: str | None = "2026-06-23T00:00:00Z",
+) -> dict[str, Any]:
+    surface = build_content_ops_surface_from_connector_packets(
+        public_handle_packets=public_handle_packets,
+        private_connector_gate_packets=private_connector_gate_packets,
+        surface_id=surface_id,
+        generated_at=generated_at,
+    )
+    validation = validate_content_ops_surface(surface)
+    projection = project_content_ops_surface(surface)
+    return {
+        "ok": bool(validation.get("ok")),
+        "schema_version": CONTENT_OPS_PACKET_AGGREGATION_SCHEMA_VERSION,
+        "mode": "content-ops-aggregate-packets",
+        "surface": surface,
+        "projection": projection,
+        "validation": validation,
+        "input_summary": {
+            "public_handle_packet_count": len(public_handle_packets),
+            "private_connector_gate_packet_count": len(private_connector_gate_packets),
+            "source_item_count": len(surface.get("source_items") or []),
+            "owner_gate_required_count": projection.get("connector_trials", {}).get(
+                "owner_gate_required_count"
+            )
+            if isinstance(projection.get("connector_trials"), Mapping)
+            else None,
+        },
+        "external_reads_performed": False,
+        "external_writes_performed": False,
+        "private_source_bodies_read": False,
+        "private_source_content_read": False,
+        "autopublish_allowed": False,
+        "next_safe_action": projection.get("first_screen", {}).get("next_safe_action")
+        if isinstance(projection.get("first_screen"), Mapping)
+        else None,
+    }
+
+
+def render_content_ops_packet_aggregation_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# LoopX Content-Ops Packet Aggregation",
+        "",
+        f"- ok: `{payload.get('ok')}`",
+        f"- schema_version: `{payload.get('schema_version')}`",
+        f"- external_reads_performed: `{payload.get('external_reads_performed')}`",
+        f"- external_writes_performed: `{payload.get('external_writes_performed')}`",
+        f"- private_source_bodies_read: `{payload.get('private_source_bodies_read')}`",
+        f"- private_source_content_read: `{payload.get('private_source_content_read')}`",
+        f"- autopublish_allowed: `{payload.get('autopublish_allowed')}`",
+    ]
+    input_summary = payload.get("input_summary")
+    if isinstance(input_summary, Mapping):
+        lines.extend(
+            [
+                "",
+                "## Inputs",
+                "",
+                f"- public_handle_packet_count: `{input_summary.get('public_handle_packet_count')}`",
+                f"- private_connector_gate_packet_count: `{input_summary.get('private_connector_gate_packet_count')}`",
+                f"- source_item_count: `{input_summary.get('source_item_count')}`",
+                f"- owner_gate_required_count: `{input_summary.get('owner_gate_required_count')}`",
+            ]
+        )
+    projection = payload.get("projection")
+    if isinstance(projection, Mapping):
+        first_screen = projection.get("first_screen")
+        if isinstance(first_screen, Mapping):
+            lines.extend(
+                [
+                    "",
+                    "## First Screen",
+                    "",
+                    f"- waiting_on: `{first_screen.get('waiting_on')}`",
+                    f"- user_action_required: `{first_screen.get('user_action_required')}`",
+                    f"- agent_can_continue: `{first_screen.get('agent_can_continue')}`",
+                    f"- next_safe_action: {first_screen.get('next_safe_action')}",
+                ]
+            )
+        connector_trials = projection.get("connector_trials")
+        if isinstance(connector_trials, Mapping):
+            lines.extend(
+                [
+                    "",
+                    "## Connector Trials",
+                    "",
+                    f"- states: `{connector_trials.get('states')}`",
+                    f"- owner_gate_required_count: `{connector_trials.get('owner_gate_required_count')}`",
+                ]
+            )
+    validation = payload.get("validation")
+    if isinstance(validation, Mapping):
+        errors = (
+            validation.get("errors")
+            if isinstance(validation.get("errors"), list)
+            else []
+        )
+        lines.extend(
+            [
+                "",
+                "## Validation",
+                "",
+                f"- validation_ok: `{validation.get('ok')}`",
+                f"- error_count: `{len(errors)}`",
+            ]
+        )
+    if payload.get("error"):
+        lines.extend(["", "## Error", "", str(payload.get("error"))])
+    return "\n".join(lines) + "\n"
 
 
 def render_content_ops_private_connector_gate_markdown(payload: dict[str, Any]) -> str:


### PR DESCRIPTION
## Summary
- add content_ops_packet_aggregation_v0 to combine public handle observation packets and private connector owner-gate packets into a compact content_ops_surface_v0
- add loopx content-ops aggregate-packets CLI for file-based public/private packet inputs
- keep public packets as metadata_packet_collected and private packets as needs_owner_gate, preserving no raw source reads, no external writes, and no autopublish
- document the aggregation command and add a durable smoke

## Validation
- python3 -m py_compile loopx/content_ops_surface.py loopx/cli_commands/content_ops.py examples/content-ops-packet-aggregation-smoke.py
- python3 examples/content-ops-packet-aggregation-smoke.py
- python3 examples/content-ops-surface-fixture-smoke.py
- python3 examples/content-ops-preview-cli-smoke.py
- python3 examples/content-ops-public-handle-observation-smoke.py
- python3 examples/content-ops-private-connector-gate-smoke.py
- git diff --check
- loopx check --scan-path loopx/content_ops_surface.py --scan-path loopx/cli_commands/content_ops.py --scan-path examples/content-ops-packet-aggregation-smoke.py --scan-path docs/reference/protocols/content-ops-surface-v0.md

## Boundary
- Aggregation reads only compact JSON packets supplied by the operator/agent path.
- It does not open connector URLs, read source bodies, read private material, write externally, or authorize publication.