### PR TITLE
Add ChatView content ops report command

### DIFF
--- a/docs/reference/protocols/content-ops-surface-v0.md
+++ b/docs/reference/protocols/content-ops-surface-v0.md
@@ -181,6 +181,30 @@ approval. Before approval, the runtime policy forbids paths such as
 limited to storing the compact gate packet, surfacing the owner question, and
 fixture-only smoke coverage.
 
+Once an owner explicitly approves a bounded ChatView trial, turn only the
+approved counts and path classes into a visible operator card:
+
+```bash
+loopx content-ops project-chatview-report \
+  --channel-count 2 \
+  --recent-record-count 50 \
+  --report-count 5 \
+  --api-request-count 54 \
+  --api-path-count /api/channels=1 \
+  --api-path-count /api/messages=1 \
+  --api-path-count /api/channel-state=1 \
+  --api-path-count /api/reports=1 \
+  --api-path-count /api/messages/:id=50 \
+  --format json
+```
+
+It returns an aggregation-compatible
+`content_ops_private_connector_gate_packet_v0` with a
+`content_ops_chatview_connector_report_v0` operator card. The command does not
+open ChatView, does not save response payloads, does not emit source bodies, and
+does not authorize publication. Its output can be passed directly to
+`aggregate-packets` as a `--private-gate-packet-json` input.
+
 Connector packets can then be aggregated into the compact state surface:
 
 ```bash
@@ -208,6 +232,7 @@ python3 examples/content-ops-preview-cli-smoke.py
 python3 examples/content-ops-public-handle-observation-smoke.py
 python3 examples/content-ops-private-connector-gate-smoke.py
 python3 examples/content-ops-packet-aggregation-smoke.py
+python3 examples/content-ops-chatview-report-smoke.py
 ```
 
 The smoke checks record coverage, source/draft/gate references, first-screen
@@ -216,5 +241,7 @@ no-autopublish policy, public/private boundary hygiene, and the public-handle
 adapter's no-content/no-write guarantees. It also verifies that private
 connector intake projects an owner gate and a runtime deny policy before any
 private source-content read, and that packet aggregation promotes only compact
-source/gate records into the state surface. A live X HEAD probe is available
-only when `LOOPX_LIVE_PUBLIC_HANDLE_SMOKE=1` is explicitly set.
+source/gate records into the state surface. The ChatView report smoke verifies
+that a real-trial-shaped operator card remains metadata-only and can be
+aggregated without source bodies or response payloads. A live X HEAD probe is
+available only when `LOOPX_LIVE_PUBLIC_HANDLE_SMOKE=1` is explicitly set.

--- a/examples/content-ops-chatview-report-smoke.py
+++ b/examples/content-ops-chatview-report-smoke.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Smoke-test the ChatView report command and aggregation path."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.content_ops_surface import (  # noqa: E402
+    CONTENT_OPS_CHATVIEW_CONNECTOR_REPORT_SCHEMA_VERSION,
+    CONTENT_OPS_PRIVATE_CONNECTOR_GATE_PACKET_SCHEMA_VERSION,
+)
+
+
+PRIVATE_PATTERNS = [
+    re.compile(r"/Users/[A-Za-z0-9._-]+/"),
+    re.compile(r"/home/[A-Za-z0-9._-]+/"),
+    re.compile(r"/private/"),
+    re.compile(r"[A-Za-z]:\\\\Users\\\\"),
+    re.compile(r"\bBearer\s+[A-Za-z0-9._-]+"),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+]
+
+
+def assert_public_safe(payload: dict[str, Any]) -> None:
+    text = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    for pattern in PRIVATE_PATTERNS:
+        if pattern.search(text):
+            raise AssertionError(f"payload matched private pattern {pattern.pattern!r}")
+    forbidden_values = [
+        "full chat transcript",
+        "raw platform post body",
+        "secret-value",
+        "credential-value",
+        "source body text",
+        "response payload text",
+    ]
+    leaked = [value for value in forbidden_values if value in text]
+    assert not leaked, leaked
+
+
+def run_cli(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "loopx.cli", *args],
+        cwd=REPO_ROOT,
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+CHATVIEW_ARGS = [
+    "content-ops",
+    "project-chatview-report",
+    "--channel-count",
+    "2",
+    "--recent-record-count",
+    "50",
+    "--report-count",
+    "5",
+    "--api-request-count",
+    "54",
+    "--api-path-count",
+    "/api/channels=1",
+    "--api-path-count",
+    "/api/messages=1",
+    "--api-path-count",
+    "/api/channel-state=1",
+    "--api-path-count",
+    "/api/reports=1",
+    "--api-path-count",
+    "/api/messages/:id=50",
+    "--source-item-id",
+    "source_chatview_metadata_signal_live_fixture",
+]
+
+
+def main() -> int:
+    result = run_cli(["--format", "json", *CHATVIEW_ARGS])
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True, payload
+    assert payload["schema_version"] == CONTENT_OPS_PRIVATE_CONNECTOR_GATE_PACKET_SCHEMA_VERSION
+    assert payload["mode"] == "content-ops-project-chatview-report", payload
+    assert payload["aggregation_ready"] is True, payload
+    assert payload["external_reads_performed"] is False, payload
+    assert payload["external_writes_performed"] is False, payload
+    assert payload["private_source_bodies_read"] is False, payload
+    assert payload["private_source_content_read"] is False, payload
+    assert payload["autopublish_allowed"] is False, payload
+
+    report = payload["chatview_report"]
+    assert (
+        report["schema_version"] == CONTENT_OPS_CHATVIEW_CONNECTOR_REPORT_SCHEMA_VERSION
+    ), report
+    assert report["operator_card"] == (
+        "2 channels, 50 recent records, 5 reports detected; "
+        "private source use remains gated."
+    ), report
+    observed = report["observed_shape"]
+    assert observed["channel_count"] == 2, observed
+    assert observed["recent_record_count"] == 50, observed
+    assert observed["report_count"] == 5, observed
+    assert observed["api_request_count"] == 54, observed
+    assert observed["api_path_counts"]["/api/messages/:id"] == 50, observed
+    boundary = report["boundary"]
+    assert boundary["source_bodies_saved"] is False, boundary
+    assert boundary["response_payloads_saved"] is False, boundary
+    assert boundary["external_write_performed"] is False, boundary
+    assert boundary["autopublish_allowed"] is False, boundary
+
+    source_item = payload["source_item"]
+    assert source_item["source_status"] == "private_needs_review", source_item
+    assert source_item["allowed_use"] == "metadata_only", source_item
+    assert "No source body or response payload was saved." in source_item["summary"]
+
+    markdown = run_cli(CHATVIEW_ARGS).stdout
+    assert "LoopX Content-Ops ChatView Report" in markdown, markdown
+    assert "2 channels, 50 recent records, 5 reports detected" in markdown, markdown
+    assert "source_bodies_saved: `False`" in markdown, markdown
+    assert_public_safe(payload)
+
+    public_packet = run_cli(
+        [
+            "--format",
+            "json",
+            "content-ops",
+            "observe-public-handle",
+            "--url",
+            "https://x.com/OpenAI",
+            "--source-item-id",
+            "source_x_openai_public_handle_fixture",
+            "--no-fetch",
+        ]
+    ).stdout
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        public_path = tmp_path / "public-packet.json"
+        chatview_path = tmp_path / "chatview-report.json"
+        public_path.write_text(public_packet, encoding="utf-8")
+        chatview_path.write_text(result.stdout, encoding="utf-8")
+        aggregated = run_cli(
+            [
+                "--format",
+                "json",
+                "content-ops",
+                "aggregate-packets",
+                "--public-packet-json",
+                str(public_path),
+                "--private-gate-packet-json",
+                str(chatview_path),
+            ]
+        )
+    aggregate_payload = json.loads(aggregated.stdout)
+    assert aggregate_payload["ok"] is True, aggregate_payload
+    assert aggregate_payload["input_summary"]["private_connector_gate_packet_count"] == 1
+    assert aggregate_payload["projection"]["connector_trials"][
+        "owner_gate_required_count"
+    ] == 1
+    assert_public_safe(aggregate_payload)
+
+    rejected = run_cli(
+        [
+            "--format",
+            "json",
+            "content-ops",
+            "project-chatview-report",
+            "--channel-count",
+            "-1",
+            "--recent-record-count",
+            "0",
+            "--report-count",
+            "0",
+            "--api-request-count",
+            "0",
+        ],
+        check=False,
+    )
+    assert rejected.returncode == 1, rejected
+    rejected_payload = json.loads(rejected.stdout)
+    assert rejected_payload["ok"] is False, rejected_payload
+    assert "channel_count must be non-negative" in rejected_payload["error"]
+
+    print("content-ops-chatview-report-smoke: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/cli_commands/content_ops.py
+++ b/loopx/cli_commands/content_ops.py
@@ -8,10 +8,12 @@ from pathlib import Path
 from typing import Any
 
 from ..content_ops_surface import (
+    build_content_ops_chatview_report_packet,
     build_content_ops_packet_aggregation_packet,
     build_content_ops_preview_packet,
     build_content_ops_private_connector_gate_packet,
     build_content_ops_public_handle_observation_packet,
+    render_content_ops_chatview_report_markdown,
     render_content_ops_packet_aggregation_markdown,
     render_content_ops_preview_markdown,
     render_content_ops_private_connector_gate_markdown,
@@ -35,6 +37,16 @@ def _load_json_object(path_text: str) -> dict[str, Any]:
     if not isinstance(payload, dict):
         raise ValueError(f"{path_text} must contain a JSON object")
     return payload
+
+
+def _parse_path_counts(values: list[str]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for value in values:
+        if "=" not in value:
+            raise ValueError("--api-path-count must use PATH=COUNT")
+        path, raw_count = value.split("=", 1)
+        counts[path.strip()] = int(raw_count.strip())
+    return counts
 
 
 def register_content_ops_commands(
@@ -183,6 +195,64 @@ def register_content_ops_commands(
         default="2026-06-23T00:00:00Z",
         help="Public-safe generated_at timestamp for the aggregate surface.",
     )
+    chatview_parser = content_ops_sub.add_parser(
+        "project-chatview-report",
+        help=(
+            "Project a public-safe ChatView operator card as an "
+            "aggregation-compatible private connector gate packet."
+        ),
+    )
+    add_subcommand_format(chatview_parser)
+    chatview_parser.add_argument(
+        "--channel-count",
+        type=int,
+        required=True,
+        help="Compact channel collection count from the approved ChatView trial.",
+    )
+    chatview_parser.add_argument(
+        "--recent-record-count",
+        type=int,
+        required=True,
+        help="Compact recent record count from the approved ChatView trial.",
+    )
+    chatview_parser.add_argument(
+        "--report-count",
+        type=int,
+        required=True,
+        help="Compact report collection count from the approved ChatView trial.",
+    )
+    chatview_parser.add_argument(
+        "--api-request-count",
+        type=int,
+        required=True,
+        help="Total API request count observed during the approved ChatView trial.",
+    )
+    chatview_parser.add_argument(
+        "--api-path-count",
+        action="append",
+        default=[],
+        help="Normalized ChatView API path class count as PATH=COUNT. Repeatable.",
+    )
+    chatview_parser.add_argument(
+        "--connector-url",
+        default="https://chatview.zaynjarvis.com/",
+        help="Approved ChatView connector URL; must be public https.",
+    )
+    chatview_parser.add_argument(
+        "--source-item-id",
+        default="source_chatview_metadata_signal_001",
+        help="source_item_v0 id to reserve for the compact ChatView signal.",
+    )
+    chatview_parser.add_argument(
+        "--owner-label",
+        default="ChatView owner",
+        help="Public-safe owner label to show in the gate packet.",
+    )
+    chatview_parser.add_argument(
+        "--generated-at",
+        default="2026-06-23T00:00:00Z",
+        help="Public-safe generated_at timestamp for the ChatView report.",
+    )
 
 
 def handle_content_ops_command(
@@ -230,10 +300,24 @@ def handle_content_ops_command(
                 generated_at=args.generated_at,
             )
             renderer = render_content_ops_packet_aggregation_markdown
+        elif args.content_ops_command == "project-chatview-report":
+            payload = build_content_ops_chatview_report_packet(
+                channel_count=args.channel_count,
+                recent_record_count=args.recent_record_count,
+                report_count=args.report_count,
+                api_request_count=args.api_request_count,
+                api_path_counts=_parse_path_counts(args.api_path_count),
+                connector_url=args.connector_url,
+                source_item_id=args.source_item_id,
+                owner_label=args.owner_label,
+                generated_at=args.generated_at,
+            )
+            renderer = render_content_ops_chatview_report_markdown
         else:
             raise ValueError(
                 "content-ops requires `preview`, `observe-public-handle`, "
-                "`project-private-connector-gate`, or `aggregate-packets`"
+                "`project-private-connector-gate`, `aggregate-packets`, or "
+                "`project-chatview-report`"
             )
     except Exception as exc:
         payload = {

--- a/loopx/content_ops_surface.py
+++ b/loopx/content_ops_surface.py
@@ -28,6 +28,9 @@ CONTENT_OPS_CONNECTOR_RUNTIME_POLICY_SCHEMA_VERSION = (
     "content_ops_connector_runtime_policy_v0"
 )
 CONTENT_OPS_PACKET_AGGREGATION_SCHEMA_VERSION = "content_ops_packet_aggregation_v0"
+CONTENT_OPS_CHATVIEW_CONNECTOR_REPORT_SCHEMA_VERSION = (
+    "content_ops_chatview_connector_report_v0"
+)
 
 SOURCE_ITEM_SCHEMA_VERSION = "source_item_v0"
 ANGLE_CANDIDATE_SCHEMA_VERSION = "angle_candidate_v0"
@@ -1194,6 +1197,125 @@ def build_content_ops_private_connector_gate_packet(
     }
 
 
+def _non_negative_int(value: int, label: str) -> int:
+    count = int(value)
+    if count < 0:
+        raise ValueError(f"{label} must be non-negative")
+    return count
+
+
+def _normalise_api_path_counts(values: Mapping[str, Any] | None) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for raw_path, raw_count in (values or {}).items():
+        path = str(raw_path or "").strip()
+        if not path.startswith("/api/"):
+            raise ValueError("ChatView API path counts must use /api/ path classes")
+        counts[path] = _non_negative_int(int(raw_count), f"api path count for {path}")
+    return dict(sorted(counts.items()))
+
+
+def build_content_ops_chatview_report_packet(
+    *,
+    channel_count: int,
+    recent_record_count: int,
+    report_count: int,
+    api_request_count: int,
+    api_path_counts: Mapping[str, Any] | None = None,
+    connector_url: str = "https://chatview.zaynjarvis.com/",
+    source_item_id: str = "source_chatview_metadata_signal_001",
+    owner_label: str = "ChatView owner",
+    generated_at: str | None = "2026-06-23T00:00:00Z",
+) -> dict[str, Any]:
+    """Build a public-safe ChatView report that remains aggregation-compatible."""
+
+    channels = _non_negative_int(channel_count, "channel_count")
+    recent_records = _non_negative_int(recent_record_count, "recent_record_count")
+    reports = _non_negative_int(report_count, "report_count")
+    api_requests = _non_negative_int(api_request_count, "api_request_count")
+    path_counts = _normalise_api_path_counts(api_path_counts)
+    if not str(source_item_id or "").strip():
+        raise ValueError("source_item_id is required")
+    normalised_url, _parsed = _normalise_public_https_url(connector_url)
+
+    operator_card = (
+        f"{channels} channels, {recent_records} recent records, {reports} reports "
+        "detected; private source use remains gated."
+    )
+    packet = build_content_ops_private_connector_gate_packet(
+        connector_id="chatlog_alpha_chatview",
+        connector_name="chatlog-alpha/chatview",
+        surface="wechat_private_archive",
+        proposed_source_item_id=str(source_item_id).strip(),
+        source_kind="wechat_private_connector_metadata",
+        owner_label=owner_label,
+        freshness="fresh",
+    )
+    source_item = packet.get("source_item")
+    if isinstance(source_item, dict):
+        source_item["summary"] = (
+            "ChatView metadata signal: "
+            f"{operator_card} No source body or response payload was saved."
+        )
+        source_item["terms_note"] = (
+            "metadata-only ChatView connector report; owner approval is required "
+            "before any source content read, quote, summary, or publication"
+        )
+    user_todo = packet.get("user_todo_projection")
+    if isinstance(user_todo, dict):
+        user_todo["title"] = (
+            "Approve, reject, or narrow ChatView metadata use before LoopX reads "
+            "any private source content."
+        )
+        user_todo["validation_surface"] = (
+            "owner decision recorded after reviewing the public-safe operator card"
+        )
+
+    report = {
+        "schema_version": CONTENT_OPS_CHATVIEW_CONNECTOR_REPORT_SCHEMA_VERSION,
+        "generated_at": generated_at,
+        "connector_url": normalised_url,
+        "operator_card": operator_card,
+        "observed_shape": {
+            "channel_count": channels,
+            "recent_record_count": recent_records,
+            "report_count": reports,
+            "api_request_count": api_requests,
+            "api_path_counts": path_counts,
+        },
+        "aggregation": {
+            "aggregation_ready": True,
+            "private_gate_packet_schema_version": (
+                CONTENT_OPS_PRIVATE_CONNECTOR_GATE_PACKET_SCHEMA_VERSION
+            ),
+            "source_item_id": str(source_item_id).strip(),
+        },
+        "boundary": {
+            "source_bodies_saved": False,
+            "response_payloads_saved": False,
+            "external_write_performed": False,
+            "autopublish_allowed": False,
+        },
+    }
+    packet.update(
+        {
+            "mode": "content-ops-project-chatview-report",
+            "chatview_report": report,
+            "operator_card": operator_card,
+            "aggregation_ready": True,
+            "external_reads_performed": False,
+            "external_writes_performed": False,
+            "private_source_bodies_read": False,
+            "private_source_content_read": False,
+            "autopublish_allowed": False,
+            "next_safe_action": (
+                "aggregate this private gate packet with public source packets, "
+                "or ask the owner to approve a narrower ChatView source handle"
+            ),
+        }
+    )
+    return packet
+
+
 def _require_packet_flag(payload: Mapping[str, Any], key: str, expected: Any) -> None:
     if payload.get(key) != expected:
         raise ValueError(f"packet {key} must be {expected!r}")
@@ -1617,6 +1739,72 @@ def render_content_ops_packet_aggregation_markdown(payload: dict[str, Any]) -> s
                 "",
                 f"- validation_ok: `{validation.get('ok')}`",
                 f"- error_count: `{len(errors)}`",
+            ]
+        )
+    if payload.get("error"):
+        lines.extend(["", "## Error", "", str(payload.get("error"))])
+    return "\n".join(lines) + "\n"
+
+
+def render_content_ops_chatview_report_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# LoopX Content-Ops ChatView Report",
+        "",
+        f"- ok: `{payload.get('ok')}`",
+        f"- schema_version: `{payload.get('schema_version')}`",
+        f"- aggregation_ready: `{payload.get('aggregation_ready')}`",
+        f"- external_reads_performed: `{payload.get('external_reads_performed')}`",
+        f"- external_writes_performed: `{payload.get('external_writes_performed')}`",
+        f"- private_source_bodies_read: `{payload.get('private_source_bodies_read')}`",
+        f"- private_source_content_read: `{payload.get('private_source_content_read')}`",
+        f"- autopublish_allowed: `{payload.get('autopublish_allowed')}`",
+    ]
+    report = payload.get("chatview_report")
+    if isinstance(report, Mapping):
+        lines.extend(
+            [
+                "",
+                "## Operator Card",
+                "",
+                str(report.get("operator_card") or payload.get("operator_card") or ""),
+            ]
+        )
+        observed_shape = report.get("observed_shape")
+        if isinstance(observed_shape, Mapping):
+            lines.extend(
+                [
+                    "",
+                    "## Observed Shape",
+                    "",
+                    f"- channel_count: `{observed_shape.get('channel_count')}`",
+                    f"- recent_record_count: `{observed_shape.get('recent_record_count')}`",
+                    f"- report_count: `{observed_shape.get('report_count')}`",
+                    f"- api_request_count: `{observed_shape.get('api_request_count')}`",
+                    f"- api_path_counts: `{observed_shape.get('api_path_counts')}`",
+                ]
+            )
+        boundary = report.get("boundary")
+        if isinstance(boundary, Mapping):
+            lines.extend(
+                [
+                    "",
+                    "## Boundary",
+                    "",
+                    f"- source_bodies_saved: `{boundary.get('source_bodies_saved')}`",
+                    f"- response_payloads_saved: `{boundary.get('response_payloads_saved')}`",
+                    f"- external_write_performed: `{boundary.get('external_write_performed')}`",
+                    f"- autopublish_allowed: `{boundary.get('autopublish_allowed')}`",
+                ]
+            )
+    todo = payload.get("user_todo_projection")
+    if isinstance(todo, Mapping):
+        lines.extend(
+            [
+                "",
+                "## User Todo Projection",
+                "",
+                f"- action_kind: `{todo.get('action_kind')}`",
+                f"- title: {todo.get('title')}",
             ]
         )
     if payload.get("error"):


### PR DESCRIPTION
## Summary
- add content-ops project-chatview-report to turn approved ChatView compact counts and API path classes into a public-safe operator card
- emit an aggregation-compatible content_ops_private_connector_gate_packet_v0 with nested content_ops_chatview_connector_report_v0 metadata
- document the workflow and add a durable smoke proving no source bodies or raw response payloads are saved

## Boundary
- command does not open ChatView
- no source bodies, raw response payloads, credentials, local paths, external writes, or autopublish are emitted
- output can be passed to aggregate-packets as a private gate packet

## Validation
- python3 -m py_compile loopx/content_ops_surface.py loopx/cli_commands/content_ops.py examples/content-ops-chatview-report-smoke.py
- python3 examples/content-ops-chatview-report-smoke.py
- python3 examples/content-ops-surface-fixture-smoke.py
- python3 examples/content-ops-preview-cli-smoke.py
- python3 examples/content-ops-public-handle-observation-smoke.py
- python3 examples/content-ops-private-connector-gate-smoke.py
- python3 examples/content-ops-packet-aggregation-smoke.py
- git diff --check
- loopx check --scan-path loopx/content_ops_surface.py --scan-path loopx/cli_commands/content_ops.py --scan-path examples/content-ops-chatview-report-smoke.py --scan-path docs/reference/protocols/content-ops-surface-v0.md
