### PR TITLE
Add content ops walkthrough artifact

### DIFF
--- a/docs/reference/protocols/content-ops-surface-v0.md
+++ b/docs/reference/protocols/content-ops-surface-v0.md
@@ -224,6 +224,35 @@ private gate packet remains `needs_owner_gate`; this prevents the projection
 from scheduling another metadata trial after a public packet has already been
 collected.
 
+For an operator-visible end-to-end artifact, generate the walkthrough packet:
+
+```bash
+loopx content-ops walkthrough-artifact \
+  --public-handle-url https://x.com/OpenAI \
+  --channel-count 2 \
+  --recent-record-count 50 \
+  --report-count 2 \
+  --api-request-count 54 \
+  --api-path-count /api/channels=1 \
+  --api-path-count /api/messages=1 \
+  --api-path-count /api/channel-state=1 \
+  --api-path-count /api/reports=1 \
+  --api-path-count /api/messages/:id=50 \
+  --private-preview-item-count 12 \
+  --theme-signal "market-risk watch" \
+  --theme-signal "semiconductor earnings pressure" \
+  --format json
+```
+
+It returns `content_ops_walkthrough_artifact_v0`: public source cards, a
+ChatView operator card, aggregate projection, chain steps, draft gate, and a
+private operator preview summary. The preview summary may say how many private
+records were inspected locally and list operator-curated theme labels, but it
+must not persist source content, response payloads, local paths, credentials, or
+publication authority. This is the public-safe artifact shape for showing value:
+the user can see the live private material in the current operator session, while
+the repository records only compact counts, labels, gates, and validation.
+
 The durable smoke is:
 
 ```bash
@@ -233,6 +262,7 @@ python3 examples/content-ops-public-handle-observation-smoke.py
 python3 examples/content-ops-private-connector-gate-smoke.py
 python3 examples/content-ops-packet-aggregation-smoke.py
 python3 examples/content-ops-chatview-report-smoke.py
+python3 examples/content-ops-walkthrough-artifact-smoke.py
 ```
 
 The smoke checks record coverage, source/draft/gate references, first-screen
@@ -243,5 +273,7 @@ connector intake projects an owner gate and a runtime deny policy before any
 private source-content read, and that packet aggregation promotes only compact
 source/gate records into the state surface. The ChatView report smoke verifies
 that a real-trial-shaped operator card remains metadata-only and can be
-aggregated without source bodies or response payloads. A live X HEAD probe is
+aggregated without source bodies or response payloads. The walkthrough smoke
+verifies that the final operator artifact remains public-safe while still
+showing a concrete source-to-surface-to-draft-gate chain. A live X HEAD probe is
 available only when `LOOPX_LIVE_PUBLIC_HANDLE_SMOKE=1` is explicitly set.

--- a/examples/content-ops-walkthrough-artifact-smoke.py
+++ b/examples/content-ops-walkthrough-artifact-smoke.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Smoke-test the public-safe content-ops walkthrough artifact."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.content_ops_surface import (  # noqa: E402
+    CONTENT_OPS_WALKTHROUGH_ARTIFACT_SCHEMA_VERSION,
+)
+
+
+PRIVATE_PATTERNS = [
+    re.compile(r"/Users/[A-Za-z0-9._-]+/"),
+    re.compile(r"/home/[A-Za-z0-9._-]+/"),
+    re.compile(r"/private/"),
+    re.compile(r"[A-Za-z]:\\\\Users\\\\"),
+    re.compile(r"\bBearer\s+[A-Za-z0-9._-]+"),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+]
+
+
+FORBIDDEN_VALUES = [
+    "full chat transcript",
+    "raw platform post body",
+    "secret-value",
+    "credential-value",
+    "source body text",
+    "response payload text",
+]
+
+
+def assert_public_safe(payload: dict[str, Any] | str) -> None:
+    text = (
+        payload
+        if isinstance(payload, str)
+        else json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    )
+    for pattern in PRIVATE_PATTERNS:
+        if pattern.search(text):
+            raise AssertionError(f"payload matched private pattern {pattern.pattern!r}")
+    leaked = [value for value in FORBIDDEN_VALUES if value in text]
+    assert not leaked, leaked
+
+
+def run_cli(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "loopx.cli", *args],
+        cwd=REPO_ROOT,
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+WALKTHROUGH_ARGS = [
+    "content-ops",
+    "walkthrough-artifact",
+    "--public-handle-url",
+    "https://x.com/OpenAI",
+    "--public-source-item-id",
+    "source_x_openai_public_walkthrough_fixture",
+    "--chatview-source-item-id",
+    "source_chatview_metadata_walkthrough_fixture",
+    "--channel-count",
+    "2",
+    "--recent-record-count",
+    "50",
+    "--report-count",
+    "2",
+    "--api-request-count",
+    "54",
+    "--api-path-count",
+    "/api/channels=1",
+    "--api-path-count",
+    "/api/messages=1",
+    "--api-path-count",
+    "/api/channel-state=1",
+    "--api-path-count",
+    "/api/reports=1",
+    "--api-path-count",
+    "/api/messages/:id=50",
+    "--private-preview-item-count",
+    "12",
+    "--theme-signal",
+    "market-risk watch",
+    "--theme-signal",
+    "semiconductor earnings pressure",
+]
+
+
+def main() -> int:
+    result = run_cli(["--format", "json", *WALKTHROUGH_ARGS])
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True, payload
+    assert payload["schema_version"] == CONTENT_OPS_WALKTHROUGH_ARTIFACT_SCHEMA_VERSION
+    assert payload["mode"] == "content-ops-walkthrough-artifact", payload
+    assert payload["public_repo_safe"] is True, payload
+    assert payload["external_reads_performed"] is False, payload
+    assert payload["external_writes_performed"] is False, payload
+    assert payload["private_source_bodies_read"] is False, payload
+    assert payload["private_source_content_read"] is False, payload
+    assert payload["autopublish_allowed"] is False, payload
+
+    operator_artifact = payload["operator_artifact"]
+    assert "explicit gates" in operator_artifact["headline"], operator_artifact
+    source_cards = operator_artifact["source_cards"]
+    assert len(source_cards) == 2, source_cards
+    statuses = {item["source_status"] for item in source_cards}
+    assert statuses == {"public", "private_needs_review"}, statuses
+
+    preview = operator_artifact["private_operator_preview"]
+    assert preview["available_in_current_operator_session"] is True, preview
+    assert preview["sample_record_count"] == 12, preview
+    assert preview["theme_signals"] == [
+        "market-risk watch",
+        "semiconductor earnings pressure",
+    ], preview
+    assert preview["stored_in_repo"] is False, preview
+    assert preview["source_content_recorded"] is False, preview
+    assert preview["response_payload_recorded"] is False, preview
+
+    draft_gate = operator_artifact["draft_gate"]
+    assert draft_gate["publish_status"] == "blocked_until_user_approval", draft_gate
+    assert draft_gate["approval_required"] is True, draft_gate
+    assert draft_gate["autopublish_allowed"] is False, draft_gate
+
+    step_names = [item["step"] for item in payload["chain_steps"]]
+    assert step_names == [
+        "public_signal_intake",
+        "private_connector_operator_card",
+        "aggregate_surface_projection",
+        "draft_publish_gate",
+    ], step_names
+    private_step = payload["chain_steps"][1]
+    assert private_step["owner_gate_required"] is True, private_step
+    assert private_step["observed_shape"]["recent_record_count"] == 50, private_step
+
+    first_screen = payload["aggregation_projection"]["first_screen"]
+    assert first_screen["waiting_on"] == "user", first_screen
+    assert first_screen["user_action_required"] is True, first_screen
+    assert first_screen["agent_can_continue"] is True, first_screen
+
+    packet_summary = payload["packet_summary"]
+    assert packet_summary["source_item_count"] == 2, packet_summary
+    assert packet_summary["owner_gate_required_count"] == 1, packet_summary
+    assert payload["validation"]["ok"] is True, payload["validation"]
+    assert_public_safe(payload)
+
+    markdown = run_cli(WALKTHROUGH_ARGS).stdout
+    assert "LoopX Content-Ops Walkthrough Artifact" in markdown, markdown
+    assert "market-risk watch" in markdown, markdown
+    assert "blocked_until_user_approval" in markdown, markdown
+    assert_public_safe(markdown)
+
+    rejected = run_cli(
+        [
+            "--format",
+            "json",
+            "content-ops",
+            "walkthrough-artifact",
+            "--channel-count",
+            "0",
+            "--recent-record-count",
+            "0",
+            "--report-count",
+            "0",
+            "--api-request-count",
+            "0",
+            "--theme-signal",
+            "https://example.com/not-a-label",
+        ],
+        check=False,
+    )
+    assert rejected.returncode == 1, rejected
+    rejected_payload = json.loads(rejected.stdout)
+    assert rejected_payload["ok"] is False, rejected_payload
+    assert "theme_signal must be a compact public-safe label" in rejected_payload["error"]
+
+    print("content-ops-walkthrough-artifact-smoke: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/cli_commands/content_ops.py
+++ b/loopx/cli_commands/content_ops.py
@@ -13,11 +13,13 @@ from ..content_ops_surface import (
     build_content_ops_preview_packet,
     build_content_ops_private_connector_gate_packet,
     build_content_ops_public_handle_observation_packet,
+    build_content_ops_walkthrough_artifact_packet,
     render_content_ops_chatview_report_markdown,
     render_content_ops_packet_aggregation_markdown,
     render_content_ops_preview_markdown,
     render_content_ops_private_connector_gate_markdown,
     render_content_ops_public_handle_observation_markdown,
+    render_content_ops_walkthrough_artifact_markdown,
 )
 
 
@@ -253,6 +255,76 @@ def register_content_ops_commands(
         default="2026-06-23T00:00:00Z",
         help="Public-safe generated_at timestamp for the ChatView report.",
     )
+    walkthrough_parser = content_ops_sub.add_parser(
+        "walkthrough-artifact",
+        help=(
+            "Build a public-safe X/ChatView connector walkthrough artifact "
+            "from compact metadata packets and owner gates."
+        ),
+    )
+    add_subcommand_format(walkthrough_parser)
+    walkthrough_parser.add_argument(
+        "--public-handle-url",
+        default="https://x.com/OpenAI",
+        help="Public https handle URL to use as the public metadata signal.",
+    )
+    walkthrough_parser.add_argument(
+        "--public-source-item-id",
+        default="source_x_public_handle_walkthrough",
+        help="source_item_v0 id for the public handle signal.",
+    )
+    walkthrough_parser.add_argument(
+        "--chatview-source-item-id",
+        default="source_chatview_metadata_signal_walkthrough",
+        help="source_item_v0 id for the compact ChatView signal.",
+    )
+    walkthrough_parser.add_argument(
+        "--channel-count",
+        type=int,
+        required=True,
+        help="Compact ChatView channel count from an approved private preview.",
+    )
+    walkthrough_parser.add_argument(
+        "--recent-record-count",
+        type=int,
+        required=True,
+        help="Compact recent record count from an approved private preview.",
+    )
+    walkthrough_parser.add_argument(
+        "--report-count",
+        type=int,
+        required=True,
+        help="Compact report count from an approved private preview.",
+    )
+    walkthrough_parser.add_argument(
+        "--api-request-count",
+        type=int,
+        required=True,
+        help="Compact API request count from an approved private preview.",
+    )
+    walkthrough_parser.add_argument(
+        "--api-path-count",
+        action="append",
+        default=[],
+        help="Normalized ChatView API path class count as PATH=COUNT. Repeatable.",
+    )
+    walkthrough_parser.add_argument(
+        "--private-preview-item-count",
+        type=int,
+        default=0,
+        help="Number of private preview records the operator inspected locally.",
+    )
+    walkthrough_parser.add_argument(
+        "--theme-signal",
+        action="append",
+        default=[],
+        help="Public-safe operator-curated theme label. Repeatable.",
+    )
+    walkthrough_parser.add_argument(
+        "--generated-at",
+        default="2026-06-23T00:00:00Z",
+        help="Public-safe generated_at timestamp for the walkthrough artifact.",
+    )
 
 
 def handle_content_ops_command(
@@ -313,11 +385,26 @@ def handle_content_ops_command(
                 generated_at=args.generated_at,
             )
             renderer = render_content_ops_chatview_report_markdown
+        elif args.content_ops_command == "walkthrough-artifact":
+            payload = build_content_ops_walkthrough_artifact_packet(
+                public_handle_url=args.public_handle_url,
+                public_source_item_id=args.public_source_item_id,
+                chatview_source_item_id=args.chatview_source_item_id,
+                channel_count=args.channel_count,
+                recent_record_count=args.recent_record_count,
+                report_count=args.report_count,
+                api_request_count=args.api_request_count,
+                api_path_counts=_parse_path_counts(args.api_path_count),
+                private_preview_item_count=args.private_preview_item_count,
+                theme_signals=args.theme_signal,
+                generated_at=args.generated_at,
+            )
+            renderer = render_content_ops_walkthrough_artifact_markdown
         else:
             raise ValueError(
                 "content-ops requires `preview`, `observe-public-handle`, "
                 "`project-private-connector-gate`, `aggregate-packets`, or "
-                "`project-chatview-report`"
+                "`project-chatview-report`, or `walkthrough-artifact`"
             )
     except Exception as exc:
         payload = {

--- a/loopx/content_ops_surface.py
+++ b/loopx/content_ops_surface.py
@@ -31,6 +31,9 @@ CONTENT_OPS_PACKET_AGGREGATION_SCHEMA_VERSION = "content_ops_packet_aggregation_
 CONTENT_OPS_CHATVIEW_CONNECTOR_REPORT_SCHEMA_VERSION = (
     "content_ops_chatview_connector_report_v0"
 )
+CONTENT_OPS_WALKTHROUGH_ARTIFACT_SCHEMA_VERSION = (
+    "content_ops_walkthrough_artifact_v0"
+)
 
 SOURCE_ITEM_SCHEMA_VERSION = "source_item_v0"
 ANGLE_CANDIDATE_SCHEMA_VERSION = "angle_candidate_v0"
@@ -1214,6 +1217,27 @@ def _normalise_api_path_counts(values: Mapping[str, Any] | None) -> dict[str, in
     return dict(sorted(counts.items()))
 
 
+def _normalise_theme_signals(values: Sequence[str] | None) -> list[str]:
+    signals: list[str] = []
+    for raw_value in values or []:
+        signal = _text(raw_value, limit=80)
+        if not signal:
+            continue
+        lowered = signal.lower()
+        if (
+            "http://" in lowered
+            or "https://" in lowered
+            or "/users/" in lowered
+            or "/private/" in lowered
+            or "bearer " in lowered
+            or "credential" in lowered
+            or "secret" in lowered
+        ):
+            raise ValueError("theme_signal must be a compact public-safe label")
+        signals.append(signal)
+    return signals[:8]
+
+
 def build_content_ops_chatview_report_packet(
     *,
     channel_count: int,
@@ -1674,6 +1698,182 @@ def build_content_ops_packet_aggregation_packet(
     }
 
 
+def build_content_ops_walkthrough_artifact_packet(
+    *,
+    public_handle_url: str,
+    public_source_item_id: str = "source_x_public_handle_walkthrough",
+    public_surface: str = "x_public_feed",
+    public_source_kind: str = "x_public_profile_handle",
+    chatview_source_item_id: str = "source_chatview_metadata_signal_walkthrough",
+    channel_count: int,
+    recent_record_count: int,
+    report_count: int,
+    api_request_count: int,
+    api_path_counts: Mapping[str, Any] | None = None,
+    private_preview_item_count: int = 0,
+    theme_signals: Sequence[str] | None = None,
+    generated_at: str | None = "2026-06-23T00:00:00Z",
+) -> dict[str, Any]:
+    """Build the public-safe operator artifact for the content-ops chain."""
+
+    preview_count = _non_negative_int(
+        private_preview_item_count,
+        "private_preview_item_count",
+    )
+    themes = _normalise_theme_signals(theme_signals)
+    public_packet = build_content_ops_public_handle_observation_packet(
+        url=public_handle_url,
+        source_item_id=public_source_item_id,
+        surface=public_surface,
+        source_kind=public_source_kind,
+        freshness="fresh",
+        terms_note="metadata-only public handle signal for walkthrough artifact",
+        fetch=False,
+    )
+    chatview_packet = build_content_ops_chatview_report_packet(
+        channel_count=channel_count,
+        recent_record_count=recent_record_count,
+        report_count=report_count,
+        api_request_count=api_request_count,
+        api_path_counts=api_path_counts,
+        source_item_id=chatview_source_item_id,
+        generated_at=generated_at,
+    )
+    aggregate = build_content_ops_packet_aggregation_packet(
+        public_handle_packets=[public_packet],
+        private_connector_gate_packets=[chatview_packet],
+        surface_id="content_ops_walkthrough_artifact_surface",
+        generated_at=generated_at,
+    )
+
+    surface = aggregate.get("surface") if isinstance(aggregate.get("surface"), Mapping) else {}
+    projection = (
+        aggregate.get("projection")
+        if isinstance(aggregate.get("projection"), Mapping)
+        else {}
+    )
+    first_screen = (
+        projection.get("first_screen")
+        if isinstance(projection.get("first_screen"), Mapping)
+        else {}
+    )
+    source_items = _as_mappings(surface.get("source_items"))  # type: ignore[arg-type]
+    draft_items = _as_mappings(surface.get("draft_items"))  # type: ignore[arg-type]
+    publish_gates = _as_mappings(surface.get("publish_gates"))  # type: ignore[arg-type]
+    chatview_report = (
+        chatview_packet.get("chatview_report")
+        if isinstance(chatview_packet.get("chatview_report"), Mapping)
+        else {}
+    )
+    chatview_observed = (
+        chatview_report.get("observed_shape")
+        if isinstance(chatview_report.get("observed_shape"), Mapping)
+        else {}
+    )
+    gate = publish_gates[0] if publish_gates else {}
+    draft = draft_items[0] if draft_items else {}
+
+    operator_artifact = {
+        "headline": (
+            "Public and private connector signals can reach a draft plan, but "
+            "private source use and publication stay behind explicit gates."
+        ),
+        "source_cards": [
+            {
+                "source_item_id": item.get("source_item_id"),
+                "source_status": item.get("source_status"),
+                "allowed_use": item.get("allowed_use"),
+                "summary": item.get("summary"),
+            }
+            for item in source_items
+        ],
+        "private_operator_preview": {
+            "available_in_current_operator_session": preview_count > 0,
+            "sample_record_count": preview_count,
+            "theme_signals": themes,
+            "stored_in_repo": False,
+            "source_content_recorded": False,
+            "response_payload_recorded": False,
+        },
+        "draft_gate": {
+            "draft_id": draft.get("draft_id"),
+            "state": draft.get("state"),
+            "publish_gate_id": gate.get("gate_id"),
+            "publish_status": gate.get("status"),
+            "approval_required": gate.get("approval_required"),
+            "autopublish_allowed": gate.get("autopublish_allowed"),
+        },
+        "next_actions": [
+            "review the private connector owner gate before source use",
+            "draft only from source-mapped metadata until approval changes",
+            "ask for final publish approval before any external posting",
+        ],
+    }
+
+    chain_steps = [
+        {
+            "step": "public_signal_intake",
+            "result": "metadata-only public handle packet",
+            "source_item_id": public_source_item_id,
+            "external_write_performed": False,
+        },
+        {
+            "step": "private_connector_operator_card",
+            "result": chatview_report.get("operator_card"),
+            "observed_shape": chatview_observed,
+            "owner_gate_required": True,
+        },
+        {
+            "step": "aggregate_surface_projection",
+            "result": first_screen.get("next_safe_action"),
+            "waiting_on": first_screen.get("waiting_on"),
+            "user_action_required": first_screen.get("user_action_required"),
+        },
+        {
+            "step": "draft_publish_gate",
+            "result": gate.get("status"),
+            "approval_required": gate.get("approval_required"),
+            "autopublish_allowed": gate.get("autopublish_allowed"),
+        },
+    ]
+
+    return {
+        "ok": bool(aggregate.get("ok")),
+        "schema_version": CONTENT_OPS_WALKTHROUGH_ARTIFACT_SCHEMA_VERSION,
+        "mode": "content-ops-walkthrough-artifact",
+        "generated_at": generated_at,
+        "operator_artifact": operator_artifact,
+        "chain_steps": chain_steps,
+        "aggregation_projection": projection,
+        "validation": aggregate.get("validation"),
+        "packet_summary": {
+            "public_packet_schema_version": public_packet.get("schema_version"),
+            "chatview_packet_schema_version": chatview_packet.get("schema_version"),
+            "aggregation_schema_version": aggregate.get("schema_version"),
+            "source_item_count": aggregate.get("input_summary", {}).get(
+                "source_item_count"
+            )
+            if isinstance(aggregate.get("input_summary"), Mapping)
+            else None,
+            "owner_gate_required_count": aggregate.get("input_summary", {}).get(
+                "owner_gate_required_count"
+            )
+            if isinstance(aggregate.get("input_summary"), Mapping)
+            else None,
+        },
+        "external_reads_performed": False,
+        "external_writes_performed": False,
+        "private_source_bodies_read": False,
+        "private_source_content_read": False,
+        "autopublish_allowed": False,
+        "public_repo_safe": True,
+        "next_safe_action": (
+            "show the operator artifact, then collect owner approval before "
+            "private source use or publication"
+        ),
+    }
+
+
 def render_content_ops_packet_aggregation_markdown(payload: dict[str, Any]) -> str:
     lines = [
         "# LoopX Content-Ops Packet Aggregation",
@@ -1723,6 +1923,102 @@ def render_content_ops_packet_aggregation_markdown(payload: dict[str, Any]) -> s
                     "",
                     f"- states: `{connector_trials.get('states')}`",
                     f"- owner_gate_required_count: `{connector_trials.get('owner_gate_required_count')}`",
+                ]
+            )
+    validation = payload.get("validation")
+    if isinstance(validation, Mapping):
+        errors = (
+            validation.get("errors")
+            if isinstance(validation.get("errors"), list)
+            else []
+        )
+        lines.extend(
+            [
+                "",
+                "## Validation",
+                "",
+                f"- validation_ok: `{validation.get('ok')}`",
+                f"- error_count: `{len(errors)}`",
+            ]
+        )
+    if payload.get("error"):
+        lines.extend(["", "## Error", "", str(payload.get("error"))])
+    return "\n".join(lines) + "\n"
+
+
+def render_content_ops_walkthrough_artifact_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# LoopX Content-Ops Walkthrough Artifact",
+        "",
+        f"- ok: `{payload.get('ok')}`",
+        f"- schema_version: `{payload.get('schema_version')}`",
+        f"- public_repo_safe: `{payload.get('public_repo_safe')}`",
+        f"- external_reads_performed: `{payload.get('external_reads_performed')}`",
+        f"- external_writes_performed: `{payload.get('external_writes_performed')}`",
+        f"- private_source_bodies_read: `{payload.get('private_source_bodies_read')}`",
+        f"- private_source_content_read: `{payload.get('private_source_content_read')}`",
+        f"- autopublish_allowed: `{payload.get('autopublish_allowed')}`",
+    ]
+    artifact = payload.get("operator_artifact")
+    if isinstance(artifact, Mapping):
+        lines.extend(["", "## Operator Artifact", "", str(artifact.get("headline") or "")])
+        preview = artifact.get("private_operator_preview")
+        if isinstance(preview, Mapping):
+            lines.extend(
+                [
+                    "",
+                    "## Private Operator Preview",
+                    "",
+                    (
+                        "- available_in_current_operator_session: "
+                        f"`{preview.get('available_in_current_operator_session')}`"
+                    ),
+                    f"- sample_record_count: `{preview.get('sample_record_count')}`",
+                    f"- theme_signals: `{preview.get('theme_signals')}`",
+                    f"- stored_in_repo: `{preview.get('stored_in_repo')}`",
+                    (
+                        "- source_content_recorded: "
+                        f"`{preview.get('source_content_recorded')}`"
+                    ),
+                    (
+                        "- response_payload_recorded: "
+                        f"`{preview.get('response_payload_recorded')}`"
+                    ),
+                ]
+            )
+        draft_gate = artifact.get("draft_gate")
+        if isinstance(draft_gate, Mapping):
+            lines.extend(
+                [
+                    "",
+                    "## Draft Gate",
+                    "",
+                    f"- draft_id: `{draft_gate.get('draft_id')}`",
+                    f"- state: `{draft_gate.get('state')}`",
+                    f"- publish_status: `{draft_gate.get('publish_status')}`",
+                    f"- approval_required: `{draft_gate.get('approval_required')}`",
+                    f"- autopublish_allowed: `{draft_gate.get('autopublish_allowed')}`",
+                ]
+            )
+    chain_steps = payload.get("chain_steps")
+    if isinstance(chain_steps, Sequence) and not isinstance(chain_steps, (str, bytes)):
+        lines.extend(["", "## Chain Steps", ""])
+        for step in chain_steps:
+            if not isinstance(step, Mapping):
+                continue
+            lines.append(f"- `{step.get('step')}`: {step.get('result')}")
+    projection = payload.get("aggregation_projection")
+    if isinstance(projection, Mapping):
+        first_screen = projection.get("first_screen")
+        if isinstance(first_screen, Mapping):
+            lines.extend(
+                [
+                    "",
+                    "## First Screen",
+                    "",
+                    f"- waiting_on: `{first_screen.get('waiting_on')}`",
+                    f"- user_action_required: `{first_screen.get('user_action_required')}`",
+                    f"- next_safe_action: {first_screen.get('next_safe_action')}",
                 ]
             )
     validation = payload.get("validation")


### PR DESCRIPTION
## Summary
- add content-ops walkthrough-artifact to compose public handle metadata, ChatView compact operator card, aggregate projection, and draft/publish gate into one public-safe operator artifact
- keep private live preview represented only by item count and operator-curated theme labels, with no source content or response payload stored
- document the end-to-end X/ChatView -> surface -> draft gate flow and add durable smoke coverage

## Boundary
- no ChatView source content is committed
- no response payloads, credentials, local paths, external writes, or autopublish authority are emitted
- public repo artifact contains compact counts, source cards, theme labels, owner gate, and validation only

## Validation
- python3 -m py_compile loopx/content_ops_surface.py loopx/cli_commands/content_ops.py examples/content-ops-walkthrough-artifact-smoke.py
- python3 examples/content-ops-walkthrough-artifact-smoke.py
- python3 examples/content-ops-chatview-report-smoke.py
- python3 examples/content-ops-packet-aggregation-smoke.py
- python3 examples/content-ops-public-handle-observation-smoke.py
- python3 examples/content-ops-private-connector-gate-smoke.py
- python3 examples/content-ops-preview-cli-smoke.py
- python3 examples/content-ops-surface-fixture-smoke.py
- git diff --check
- loopx check --scan-path loopx/content_ops_surface.py --scan-path loopx/cli_commands/content_ops.py --scan-path examples/content-ops-walkthrough-artifact-smoke.py --scan-path docs/reference/protocols/content-ops-surface-v0.md
