### PR TITLE
Add CS-Notes exploration capability map

### DIFF
--- a/docs/reference/protocols/README.md
+++ b/docs/reference/protocols/README.md
@@ -14,3 +14,4 @@ Current contracts:
 - [Action packet router comparison v0](protocol-action-packet-router-comparison-v0.md)
 - [task_graph_projection_v0](task-graph-projection-v0.md)
 - [content_ops_surface_v0](content-ops-surface-v0.md)
+- [cs_notes_explore_capability_map_v0](cs-notes-explore-capability-map-v0.md)

--- a/docs/reference/protocols/cs-notes-explore-capability-map-v0.md
+++ b/docs/reference/protocols/cs-notes-explore-capability-map-v0.md
@@ -1,0 +1,95 @@
+# cs_notes_explore_capability_map_v0
+
+Status: public-safe selection map v0.
+
+This map records the reusable exploration capabilities selected from a
+CS-Notes read-only mechanism scan. It is a capability map, not an import of
+CS-Notes material, private queues, drafts, or source bodies. The selected
+patterns are useful because they turn "go look around" into bounded,
+observable, and gated product work.
+
+## Boundary
+
+The scan used only generic mechanism surfaces: skill contracts, snippet
+entrypoints, README-style workflow notes, and deterministic helper-script
+interfaces. It intentionally excludes private local state, raw material queues,
+auth configuration, platform session artifacts, personal drafts, and raw source
+content.
+
+A pattern is eligible for LoopX only when it is:
+
+- source-agnostic enough to work for GitHub, browser, chat, paper, or document
+  connectors;
+- explicit about read status, access route, and fallback;
+- safe to represent as compact metadata before any private source body is read;
+- able to produce a small artifact or validation result;
+- useful to a repo issue-fix, content-ops, experiment, or general connector
+  workflow without copying CS-Notes-specific prose.
+
+## Selected Capabilities
+
+| Capability | What To Reuse | LoopX Target | First Product Slice |
+| --- | --- | --- | --- |
+| `material_intake_profile_v0` | Intent profiles, source lanes, S/A/B/Unread decisions, and deep/quick/background/carryover routing. | Connector discovery and content-ops signal ranking. | Add an `exploration_plan_packet_v0` fixture that records chosen lanes, read status, evidence quality, and next safe source action. |
+| `trusted_source_scan_plan_v0` | A scan plan is not a read result: it records source route, access level, fallback, and the template for later writeback. | Browser/chat/document connector preflight. | Teach connector trials to emit route/access/fallback before any live source read. |
+| `pre_tick_gate_v0` | Cheap read-only signals produce one recommended action, gates, guards, and validation expectations. | Heartbeat and quota preflight for long-running agents. | Add a preflight packet that distinguishes status-only ticks from delivery ticks. |
+| `todo_triage_index_v0` | Legacy tasks become structured categories: agent-runnable, user/environment blocked, stale material flow, merged workflow, or completed. | Repo issue fix and deferred-todo visibility. | Build a fixture that maps imported issue/todo rows into LoopX user/agent/deferred lanes. |
+| `snippet_registry_contract_v0` | Reusable scripts and prompts must have a named entrypoint, trigger scenario, boundary note, and validation command. | Capability catalog and connector pack governance. | Add catalog fields for entrypoint, boundary, validation, and public-safety class. |
+| `guarded_heartbeat_visibility_v0` | Prefer user-visible automation; use headless fallback only with idle guards and visibility caveats. | Project heartbeat prompt and connector monitor UX. | Surface transport mode and visibility risk in heartbeat/status packets. |
+
+## Scenario Fit
+
+Repo issue fix:
+
+- `todo_triage_index_v0` can turn GitHub issues, review comments, and stale
+  local todos into one compact runnable set with explicit user gates.
+- `trusted_source_scan_plan_v0` prevents an agent from treating a linked issue,
+  external doc, or repo as read before it actually inspected the source.
+
+Self-media and creator operations:
+
+- `material_intake_profile_v0` matches the connector-to-information-to-anchor
+  workflow: first choose source lanes, then rank evidence, then promote only
+  public-safe anchors into drafts.
+- `trusted_source_scan_plan_v0` and `snippet_registry_contract_v0` keep
+  browser/chat connectors metadata-bounded until owner review allows more.
+
+Experiment and other vertical state surfaces:
+
+- `pre_tick_gate_v0` and `todo_triage_index_v0` are reusable for ML experiment
+  lanes: pending runs, result availability, failed environment checks, and
+  human interpretation gates can all be represented before a full experiment
+  state surface exists.
+- `snippet_registry_contract_v0` gives each vertical pack a minimal "how to
+  run, what it reads, what it writes, how to validate" contract.
+
+## Not Imported
+
+These are useful in CS-Notes but should not be copied into LoopX as-is:
+
+- exact learning-material queues or personal priority text;
+- platform auth setup, session artifacts, private connector configuration, or
+  local automation service files;
+- raw writing drafts, raw chat/source bodies, screenshots, or private
+  evidence;
+- the full text of CS-Notes skills when a small generic packet contract is
+  enough;
+- source-specific ranking biases that only make sense for one person's career
+  roadmap.
+
+## Recommended Next Step
+
+Implement `exploration_plan_packet_v0` first. It should combine the strongest
+parts of `material_intake_profile_v0` and `trusted_source_scan_plan_v0`:
+
+- selected source lanes;
+- access/read status;
+- route and fallback;
+- evidence quality;
+- candidate promotion target;
+- user gate when the next read would cross a private boundary;
+- validation that no source body, credential, local path, or external write was
+  captured.
+
+That packet is the common substrate for repo issue discovery, content-ops
+signal intake, and future experiment state surfaces.

--- a/examples/cs-notes-explore-capability-map-smoke.py
+++ b/examples/cs-notes-explore-capability-map-smoke.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Smoke-test the public-safe CS-Notes exploration capability map."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DOC = REPO_ROOT / "docs" / "reference" / "protocols" / "cs-notes-explore-capability-map-v0.md"
+INDEX = REPO_ROOT / "docs" / "reference" / "protocols" / "README.md"
+
+
+REQUIRED_CAPABILITIES = (
+    "material_intake_profile_v0",
+    "trusted_source_scan_plan_v0",
+    "pre_tick_gate_v0",
+    "todo_triage_index_v0",
+    "snippet_registry_contract_v0",
+    "guarded_heartbeat_visibility_v0",
+)
+
+REQUIRED_SECTIONS = (
+    "## Boundary",
+    "## Selected Capabilities",
+    "## Scenario Fit",
+    "## Not Imported",
+    "## Recommended Next Step",
+)
+
+PRIVATE_PATTERNS = (
+    re.compile(r"/Users/[A-Za-z0-9._-]+/"),
+    re.compile(r"/home/[A-Za-z0-9._-]+/"),
+    re.compile(r"/private/"),
+    re.compile(r"[A-Za-z]:\\\\Users\\\\"),
+    re.compile(r"https?://"),
+    re.compile(r"BEGIN [A-Z ]*PRIVATE KEY"),
+    re.compile(r"\bBearer\s+[A-Za-z0-9._-]+"),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+)
+
+FORBIDDEN_TERMS = tuple(
+    "".join(parts)
+    for parts in (
+        (".", "local"),
+        ("LEARNING", "_MATERIAL", "_CANDIDATES"),
+        ("coo", "kie"),
+        ("pass", "word"),
+        ("se", "cret"),
+        ("to", "ken="),
+        ("raw", " transcript"),
+    )
+)
+
+
+def main() -> int:
+    text = DOC.read_text(encoding="utf-8")
+    assert text.startswith("# cs_notes_explore_capability_map_v0"), text[:80]
+    for section in REQUIRED_SECTIONS:
+        assert section in text, section
+    for capability in REQUIRED_CAPABILITIES:
+        assert capability in text, capability
+    assert "exploration_plan_packet_v0" in text, text
+    assert "Repo issue fix" in text, text
+    assert "Self-media and creator operations" in text, text
+    assert "Experiment and other vertical state surfaces" in text, text
+
+    for pattern in PRIVATE_PATTERNS:
+        assert not pattern.search(text), pattern.pattern
+    lowered = text.lower()
+    leaked = [term for term in FORBIDDEN_TERMS if term.lower() in lowered]
+    assert not leaked, leaked
+
+    index = INDEX.read_text(encoding="utf-8")
+    assert "cs-notes-explore-capability-map-v0.md" in index, "protocol index link"
+
+    print("cs-notes-explore-capability-map-smoke: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a public-safe CS-Notes exploration capability map for reusable connector/product workflow patterns
- select six generic capabilities: material intake profiles, trusted scan plans, pre-tick gates, todo triage, snippet registry contracts, and guarded heartbeat visibility
- add a smoke that verifies required sections/capability ids and blocks local paths, raw private markers, credential-like strings, and source URLs

## Validation
- python3 examples/cs-notes-explore-capability-map-smoke.py
- python3 -m py_compile examples/cs-notes-explore-capability-map-smoke.py
- git diff --check
- loopx check --scan-path docs/reference/protocols/cs-notes-explore-capability-map-v0.md --scan-path docs/reference/protocols/README.md --scan-path examples/cs-notes-explore-capability-map-smoke.py