### PR TITLE
Classify SkillsBench ACP provider zero activity

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -57,6 +57,7 @@ from scripts.skillsbench_automation_loop import (  # noqa: E402
     PRODUCT_MODE_CASE_STATE_PATH,
     PRODUCT_MODE_CASE_STATE_SCHEMA_VERSION,
     _tail,
+    _apply_agent_message_only_no_tool_calls_attribution,
     _blind_loop_persistent_continuation_clause,
     _build_product_mode_user,
     _product_mode_depth_gate_satisfied,
@@ -1581,6 +1582,34 @@ def write_official_skillsbench_codex_acp_internal_error(root: Path) -> Path:
     return result_path
 
 
+def write_official_skillsbench_codex_acp_provider_zero_activity(root: Path) -> Path:
+    run_dir = root / "official" / "2026-06-23__06-23-26" / "powerlifting__zero"
+    result_path = run_dir / "result.json"
+    write_json(
+        result_path,
+        {
+            "task_name": "powerlifting-coef-calc",
+            "rollout_name": "powerlifting-coef-calc__loopx_product_mode",
+            "rewards": None,
+            "agent": "codex-acp",
+            "agent_name": "@agentclientprotocol/codex-acp",
+            "model": "gpt-5.5",
+            "n_tool_calls": 0,
+            "n_prompts": 1,
+            "error": (
+                "suspected provider api error: agent ended with zero tokens "
+                "and zero tool calls (no scoreable model activity)"
+            ),
+            "error_category": "suspected_api_error",
+            "verifier_error": "verifier timed out after 600.0s",
+            "partial_trajectory": False,
+            "trajectory_source": "acp",
+        },
+    )
+    write_json(run_dir / "timing.json", {"agent_execution": 5.0, "total": 600.0})
+    return result_path
+
+
 def test_skillsbench_official_result_builder() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-result-builder-") as tmp:
         result_path = write_official_skillsbench_result(Path(tmp))
@@ -2176,6 +2205,70 @@ def test_skillsbench_codex_acp_internal_error_attribution() -> None:
             "skillsbench_codex_acp_runtime_preflight"
         ), update
         assert update["case_decision"]["decision"] == "single_arm_recorded", update
+
+
+def test_skillsbench_codex_acp_provider_zero_activity_attribution() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-codex-acp-zero-activity-") as tmp:
+        result_path = write_official_skillsbench_codex_acp_provider_zero_activity(
+            Path(tmp)
+        )
+        compact = compact_benchmark_run(
+            build_skillsbench_benchflow_result_benchmark_run(
+                result_path,
+                route="loopx-product-mode",
+            )
+        )
+        assert compact is not None
+        assert compact["score_failure_attribution"] == (
+            "skillsbench_codex_acp_provider_zero_activity"
+        ), compact
+        assert "skillsbench_codex_acp_provider_error" in compact[
+            "failure_attribution_labels"
+        ], compact
+        assert "skillsbench_acp_zero_tool_call_observed" in compact[
+            "failure_attribution_labels"
+        ], compact
+        assert compact["runner_failure"] == {
+            "exception_type": "skillsbench_codex_acp_provider_zero_activity",
+            "failure_class": "skillsbench_codex_acp_provider_zero_activity",
+            "raw_error_recorded": False,
+            "raw_logs_read": False,
+            "raw_task_text_read": False,
+            "raw_trajectory_read": False,
+            "schema_version": "skillsbench_runner_failure_v0",
+        }, compact
+
+
+def test_skillsbench_no_tool_postprocess_preserves_provider_zero_activity() -> None:
+    compact = {
+        "official_score_status": "missing",
+        "score_failure_attribution": "skillsbench_codex_acp_provider_zero_activity",
+        "first_blocker": "skillsbench_codex_acp_provider_zero_activity",
+        "failure_attribution_labels": [
+            "skillsbench_codex_acp_provider_zero_activity",
+            "skillsbench_codex_acp_provider_error",
+        ],
+        "interaction_counters": {
+            "private_trajectory_event_count": 2,
+            "private_trajectory_round_count": 1,
+            "private_trajectory_tool_call_count": 0,
+            "controller_action_decisions": 1,
+        },
+    }
+
+    assert _apply_agent_message_only_no_tool_calls_attribution(compact) is True
+    assert compact["score_failure_attribution"] == (
+        "skillsbench_codex_acp_provider_zero_activity"
+    ), compact
+    assert compact["first_blocker"] == (
+        "skillsbench_codex_acp_provider_zero_activity"
+    ), compact
+    assert "skillsbench_acp_agent_message_only_no_tool_calls" in compact[
+        "failure_attribution_labels"
+    ], compact
+    assert "skillsbench_agent_behavior_gap" not in compact[
+        "failure_attribution_labels"
+    ], compact
 
 
 def test_skillsbench_codex_acp_post_success_trace_recovers_score() -> None:
@@ -6087,6 +6180,8 @@ if __name__ == "__main__":
     test_skillsbench_codex_acp_glibc_failure_attribution()
     test_skillsbench_codex_acp_launch_preflight_attribution()
     test_skillsbench_codex_acp_internal_error_attribution()
+    test_skillsbench_codex_acp_provider_zero_activity_attribution()
+    test_skillsbench_no_tool_postprocess_preserves_provider_zero_activity()
     test_skillsbench_codex_acp_post_success_trace_recovers_score()
     test_skillsbench_codex_acp_post_success_finalization_route()
     test_skillsbench_docker_task_staging_adds_app_skills_mount()

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -1275,6 +1275,20 @@ def skillsbench_runner_error_attribution(error_text: str) -> tuple[str, str, lis
     """Classify public-safe SkillsBench runner/setup failures."""
 
     text = error_text.lower()
+    if (
+        "suspected provider api error" in text
+        and "zero tokens" in text
+        and "zero tool calls" in text
+    ) or (
+        "agent ended with zero tokens" in text
+        and "no scoreable model activity" in text
+    ):
+        label = "skillsbench_codex_acp_provider_zero_activity"
+        return label, label, [
+            label,
+            "skillsbench_codex_acp_provider_error",
+            "skillsbench_acp_zero_tool_call_observed",
+        ]
     if "acp error -32603" in text and "internal error" in text:
         label = "skillsbench_codex_acp_jsonrpc_internal_error"
         return label, label, [label, "skillsbench_codex_acp_transport_error"]
@@ -2483,9 +2497,12 @@ def build_skillsbench_benchflow_result_benchmark_run(
             "skillsbench_result_json_reward_missing_recovered_from_reward_txt"
         )
     elif verifier_error_text:
-        exception_type = "skillsbench_verifier_error"
-        failure_labels.append("verifier_infrastructure_failure")
-        score_failure_attribution = "verifier_infrastructure_failure"
+        if score_failure_attribution in {"none", "skillsbench_runner_error"}:
+            exception_type = "skillsbench_verifier_error"
+            failure_labels.append("verifier_infrastructure_failure")
+            score_failure_attribution = "verifier_infrastructure_failure"
+        elif "verifier_infrastructure_failure" not in failure_labels:
+            failure_labels.append("verifier_infrastructure_failure")
 
     n_tool_calls = result.get("n_tool_calls")
     tool_calls = n_tool_calls if isinstance(n_tool_calls, int) else 0
@@ -2854,7 +2871,10 @@ def build_skillsbench_benchflow_result_benchmark_run(
         contract_official_score_comparable_to_native_codex = False
         contract_official_score_comparable_to_loopx_treatment = False
         product_mode_lifecycle_contract["countable_treatment"] = False
-        if not official_passed:
+        preserve_primary_attribution = score_failure_attribution in {
+            "skillsbench_codex_acp_provider_zero_activity",
+        }
+        if not official_passed and not preserve_primary_attribution:
             exception_type = label
             score_failure_attribution = label
             runner_score_failure_attribution = label

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -1563,14 +1563,24 @@ def _apply_agent_message_only_no_tool_calls_attribution(
         return False
 
     label = "skillsbench_acp_agent_message_only_no_tool_calls"
-    compact["score_failure_attribution"] = label
-    compact.setdefault("first_blocker", label)
+    current_attribution = str(compact.get("score_failure_attribution") or "")
+    preserve_attributions = {
+        "skillsbench_codex_acp_provider_zero_activity",
+    }
+    if current_attribution not in preserve_attributions:
+        compact["score_failure_attribution"] = label
+        compact.setdefault("first_blocker", label)
+    elif not compact.get("first_blocker"):
+        compact["first_blocker"] = current_attribution
     existing_labels = [
         item
         for item in compact.get("failure_attribution_labels", [])
         if isinstance(item, str)
     ]
-    for item in (label, "skillsbench_agent_behavior_gap"):
+    extra_labels = [label]
+    if current_attribution not in preserve_attributions:
+        extra_labels.append("skillsbench_agent_behavior_gap")
+    for item in extra_labels:
         if item not in existing_labels:
             existing_labels.append(item)
     compact["failure_attribution_labels"] = existing_labels


### PR DESCRIPTION
## Summary
- preserve SkillsBench ACP/provider zero-token zero-tool-call failures as `skillsbench_codex_acp_provider_zero_activity`
- keep verifier/lifecycle labels as secondary evidence instead of overwriting the primary blocker
- add smoke coverage for result reduction and no-tool postprocessing

## Validation
- `git diff --check`
- `python3 -m py_compile scripts/skillsbench_automation_loop.py loopx/benchmark_adapters/skillsbench.py examples/skillsbench-benchmark-run-smoke.py`
- focused provider-zero smokes
- `python3 examples/skillsbench-benchmark-run-smoke.py`
- `loopx check --scan-path loopx/benchmark_adapters/skillsbench.py --scan-path scripts/skillsbench_automation_loop.py --scan-path examples/skillsbench-benchmark-run-smoke.py`

## Boundary
No scoring change, no benchmark launch, no raw trajectories/logs/verifier output, and no local private evidence committed.