### PR TITLE
Add content ops exploration plan packet

### DIFF
--- a/docs/reference/protocols/content-ops-surface-v0.md
+++ b/docs/reference/protocols/content-ops-surface-v0.md
@@ -129,6 +129,22 @@ actions happened. Real connector adapters should first match this packet shape
 before they ingest any public platform metadata or private metadata-only source
 handle.
 
+Before a real connector even decides what to read, the generic exploration
+planner can render the selected source lanes, access/read status, route,
+fallback, evidence quality, promotion target, and owner gates:
+
+```bash
+loopx content-ops exploration-plan --format json
+```
+
+It returns `content_ops_exploration_plan_packet_v0` with an
+`exploration_plan_v0` fixture. This is the first reusable primitive selected
+from the CS-Notes exploration capability map: repo issues, public social
+signals, private chat metadata, and experiment result counters can all be
+represented as lanes before source bodies, response payloads, local paths, or
+external writes are captured. Private or raw-material lanes must project a
+concrete user gate rather than silently becoming readable work.
+
 The first reusable public connector adapter is the public-handle observation
 command:
 

--- a/docs/reference/protocols/cs-notes-explore-capability-map-v0.md
+++ b/docs/reference/protocols/cs-notes-explore-capability-map-v0.md
@@ -79,8 +79,15 @@ These are useful in CS-Notes but should not be copied into LoopX as-is:
 
 ## Recommended Next Step
 
-Implement `exploration_plan_packet_v0` first. It should combine the strongest
-parts of `material_intake_profile_v0` and `trusted_source_scan_plan_v0`:
+Implement `exploration_plan_packet_v0` first. The initial fixture entrypoint is
+now:
+
+```bash
+loopx content-ops exploration-plan --format json
+```
+
+It combines the strongest parts of `material_intake_profile_v0` and
+`trusted_source_scan_plan_v0`:
 
 - selected source lanes;
 - access/read status;

--- a/examples/content-ops-exploration-plan-smoke.py
+++ b/examples/content-ops-exploration-plan-smoke.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Smoke-test the fixture-only content-ops exploration plan packet."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.content_ops_surface import (  # noqa: E402
+    CONTENT_OPS_EXPLORATION_PLAN_PACKET_SCHEMA_VERSION,
+    EXPLORATION_PLAN_SCHEMA_VERSION,
+)
+
+
+PRIVATE_PATTERNS = [
+    re.compile(r"/Users/[A-Za-z0-9._-]+/"),
+    re.compile(r"/home/[A-Za-z0-9._-]+/"),
+    re.compile(r"/private/"),
+    re.compile(r"[A-Za-z]:\\\\Users\\\\"),
+    re.compile(r"\bBearer\s+[A-Za-z0-9._-]+"),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+]
+
+FORBIDDEN_VALUES = [
+    "full chat transcript",
+    "raw platform post body",
+    "secret-value",
+    "credential-value",
+    "response payload text",
+    "source body text",
+]
+
+
+def assert_public_safe(payload: dict[str, Any] | str) -> None:
+    text = (
+        payload
+        if isinstance(payload, str)
+        else json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    )
+    for pattern in PRIVATE_PATTERNS:
+        if pattern.search(text):
+            raise AssertionError(f"payload matched private pattern {pattern.pattern!r}")
+    leaked = [value for value in FORBIDDEN_VALUES if value in text]
+    assert not leaked, leaked
+
+
+def run_cli(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "loopx.cli", *args],
+        cwd=REPO_ROOT,
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def main() -> int:
+    result = run_cli(["--format", "json", "content-ops", "exploration-plan"])
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True, payload
+    assert payload["schema_version"] == CONTENT_OPS_EXPLORATION_PLAN_PACKET_SCHEMA_VERSION
+    assert payload["mode"] == "content-ops-exploration-plan", payload
+    assert payload["external_reads_performed"] is False, payload
+    assert payload["external_writes_performed"] is False, payload
+    assert payload["private_source_bodies_read"] is False, payload
+    assert payload["private_source_content_read"] is False, payload
+    assert payload["local_paths_captured"] is False, payload
+    assert payload["autopublish_allowed"] is False, payload
+
+    plan = payload["exploration_plan"]
+    assert plan["schema_version"] == EXPLORATION_PLAN_SCHEMA_VERSION, plan
+    assert plan["lane_counts"]["total"] == 4, plan["lane_counts"]
+    assert plan["lane_counts"]["user_gate_required"] == 2, plan["lane_counts"]
+    assert plan["first_screen"]["waiting_on"] == "user", plan["first_screen"]
+    assert plan["first_screen"]["agent_can_continue"] is True, plan["first_screen"]
+    assert plan["truth_contract"]["private_boundary_crossing_requires_user_gate"] is True
+
+    lanes = plan["selected_source_lanes"]
+    lane_ids = {lane["lane_id"] for lane in lanes}
+    assert lane_ids == {
+        "repo_issue_public_metadata",
+        "public_social_signal_metadata",
+        "private_chat_metadata_gate",
+        "experiment_compact_result_metadata",
+    }, lane_ids
+    for lane in lanes:
+        assert lane["source_body_captured"] is False, lane
+        assert lane["response_payload_captured"] is False, lane
+        assert lane["local_path_captured"] is False, lane
+        assert lane["external_write_allowed"] is False, lane
+        assert lane["route"], lane
+        assert lane["fallback"], lane
+        assert lane["promotion_target"], lane
+        if lane["requires_user_gate"]:
+            assert lane.get("user_gate", {}).get("question"), lane
+
+    validation = payload["validation"]
+    assert validation["ok"] is True, validation
+    assert validation["lane_count"] == 4, validation
+    assert validation["errors"] == [], validation
+    assert_public_safe(payload)
+
+    markdown = run_cli(["content-ops", "exploration-plan"]).stdout
+    assert "LoopX Content-Ops Exploration Plan" in markdown, markdown
+    assert "private_chat_metadata_gate" in markdown, markdown
+    assert "experiment_compact_result_metadata" in markdown, markdown
+    assert_public_safe(markdown)
+
+    rejected = run_cli(
+        [
+            "--format",
+            "json",
+            "content-ops",
+            "exploration-plan",
+            "--scenario",
+            "https://example.com/not-a-label",
+        ],
+        check=False,
+    )
+    assert rejected.returncode == 1, rejected
+    rejected_payload = json.loads(rejected.stdout)
+    assert rejected_payload["ok"] is False, rejected_payload
+    assert "scenario must be a compact public-safe label" in rejected_payload["error"]
+
+    print("content-ops-exploration-plan-smoke: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/cli_commands/content_ops.py
+++ b/loopx/cli_commands/content_ops.py
@@ -9,12 +9,14 @@ from typing import Any
 
 from ..content_ops_surface import (
     build_content_ops_chatview_report_packet,
+    build_content_ops_exploration_plan_packet,
     build_content_ops_packet_aggregation_packet,
     build_content_ops_preview_packet,
     build_content_ops_private_connector_gate_packet,
     build_content_ops_public_handle_observation_packet,
     build_content_ops_walkthrough_artifact_packet,
     render_content_ops_chatview_report_markdown,
+    render_content_ops_exploration_plan_markdown,
     render_content_ops_packet_aggregation_markdown,
     render_content_ops_preview_markdown,
     render_content_ops_private_connector_gate_markdown,
@@ -72,6 +74,24 @@ def register_content_ops_commands(
         "--generated-at",
         default="2026-06-23T00:00:00Z",
         help="Public-safe generated_at timestamp for the synthetic preview fixture.",
+    )
+    exploration_plan_parser = content_ops_sub.add_parser(
+        "exploration-plan",
+        help=(
+            "Build a fixture-only exploration_plan_v0 packet before connector "
+            "source reads."
+        ),
+    )
+    add_subcommand_format(exploration_plan_parser)
+    exploration_plan_parser.add_argument(
+        "--scenario",
+        default="mixed_connector_product_workflow",
+        help="Public-safe scenario label for the exploration plan fixture.",
+    )
+    exploration_plan_parser.add_argument(
+        "--generated-at",
+        default="2026-06-23T00:00:00Z",
+        help="Public-safe generated_at timestamp for the exploration plan.",
     )
     observe_parser = content_ops_sub.add_parser(
         "observe-public-handle",
@@ -337,6 +357,12 @@ def handle_content_ops_command(
         if args.content_ops_command == "preview":
             payload = build_content_ops_preview_packet(generated_at=args.generated_at)
             renderer = render_content_ops_preview_markdown
+        elif args.content_ops_command == "exploration-plan":
+            payload = build_content_ops_exploration_plan_packet(
+                scenario=args.scenario,
+                generated_at=args.generated_at,
+            )
+            renderer = render_content_ops_exploration_plan_markdown
         elif args.content_ops_command == "observe-public-handle":
             payload = build_content_ops_public_handle_observation_packet(
                 url=args.url,
@@ -402,9 +428,10 @@ def handle_content_ops_command(
             renderer = render_content_ops_walkthrough_artifact_markdown
         else:
             raise ValueError(
-                "content-ops requires `preview`, `observe-public-handle`, "
-                "`project-private-connector-gate`, `aggregate-packets`, or "
-                "`project-chatview-report`, or `walkthrough-artifact`"
+                "content-ops requires `preview`, `exploration-plan`, "
+                "`observe-public-handle`, `project-private-connector-gate`, "
+                "`aggregate-packets`, `project-chatview-report`, or "
+                "`walkthrough-artifact`"
             )
     except Exception as exc:
         payload = {

--- a/loopx/content_ops_surface.py
+++ b/loopx/content_ops_surface.py
@@ -34,6 +34,10 @@ CONTENT_OPS_CHATVIEW_CONNECTOR_REPORT_SCHEMA_VERSION = (
 CONTENT_OPS_WALKTHROUGH_ARTIFACT_SCHEMA_VERSION = (
     "content_ops_walkthrough_artifact_v0"
 )
+CONTENT_OPS_EXPLORATION_PLAN_PACKET_SCHEMA_VERSION = (
+    "content_ops_exploration_plan_packet_v0"
+)
+EXPLORATION_PLAN_SCHEMA_VERSION = "exploration_plan_v0"
 
 SOURCE_ITEM_SCHEMA_VERSION = "source_item_v0"
 ANGLE_CANDIDATE_SCHEMA_VERSION = "angle_candidate_v0"
@@ -98,6 +102,18 @@ ALLOWED_CONNECTOR_ACCESS_MODES = {
     "private_metadata_only",
     "synthetic_fixture_only",
 }
+ALLOWED_EXPLORATION_READ_STATUSES = {
+    "metadata_ready",
+    "not_read",
+    "blocked_until_owner_gate",
+    "compact_result_ready",
+}
+ALLOWED_EXPLORATION_EVIDENCE_QUALITIES = {
+    "primary_source_metadata",
+    "metadata_only",
+    "not_evidence_until_approved",
+    "compact_result_metadata",
+}
 
 
 def _as_mappings(values: Sequence[Mapping[str, Any]] | None) -> list[dict[str, Any]]:
@@ -127,6 +143,24 @@ def _ids(items: Sequence[Mapping[str, Any]], key: str) -> set[str]:
 
 def _counter(values: Sequence[Any]) -> dict[str, int]:
     return dict(sorted(Counter(str(value) for value in values if value).items()))
+
+
+def _normalise_exploration_label(value: Any, label: str) -> str:
+    text = _text(value, limit=80)
+    if not text:
+        raise ValueError(f"{label} is required")
+    lowered = text.lower()
+    if (
+        "http://" in lowered
+        or "https://" in lowered
+        or "/users/" in lowered
+        or "/private/" in lowered
+        or "bearer " in lowered
+        or "credential" in lowered
+        or "secret" in lowered
+    ):
+        raise ValueError(f"{label} must be a compact public-safe label")
+    return text
 
 
 def _normalise_public_https_url(url: str) -> tuple[str, Any]:
@@ -924,6 +958,304 @@ def build_content_ops_preview_packet(
         if isinstance(projection.get("first_screen"), Mapping)
         else None,
     }
+
+
+def build_content_ops_exploration_plan_packet(
+    *,
+    scenario: str = "mixed_connector_product_workflow",
+    generated_at: str | None = "2026-06-23T00:00:00Z",
+) -> dict[str, Any]:
+    """Build a fixture-only exploration plan packet.
+
+    The plan expresses source lanes, read status, gates, and promotion targets
+    before any connector reads source bodies or performs external writes.
+    """
+
+    scenario_label = _normalise_exploration_label(
+        scenario,
+        "scenario",
+    )
+    source_lanes = [
+        {
+            "lane_id": "repo_issue_public_metadata",
+            "surface": "repo_issue_fix",
+            "source_kind": "github_issue_or_pr",
+            "source_status": "public",
+            "access_mode": "public_metadata_only",
+            "read_status": "metadata_ready",
+            "route": "GitHub CLI or issue API metadata read",
+            "fallback": "browser permalink metadata or ask for a stable issue URL",
+            "evidence_quality": "primary_source_metadata",
+            "promotion_target": "loopx_agent_todo_candidate",
+            "requires_user_gate": False,
+            "source_body_captured": False,
+            "response_payload_captured": False,
+            "local_path_captured": False,
+            "external_write_allowed": False,
+        },
+        {
+            "lane_id": "public_social_signal_metadata",
+            "surface": "content_ops_signal_intake",
+            "source_kind": "public_social_handle",
+            "source_status": "public",
+            "access_mode": "public_metadata_only",
+            "read_status": "not_read",
+            "route": "HEAD-only public handle metadata probe",
+            "fallback": "operator-provided public permalink metadata",
+            "evidence_quality": "metadata_only",
+            "promotion_target": "source_item_v0",
+            "requires_user_gate": False,
+            "source_body_captured": False,
+            "response_payload_captured": False,
+            "local_path_captured": False,
+            "external_write_allowed": False,
+        },
+        {
+            "lane_id": "private_chat_metadata_gate",
+            "surface": "content_ops_private_material",
+            "source_kind": "private_chat_connector",
+            "source_status": "private_needs_review",
+            "access_mode": "private_metadata_only",
+            "read_status": "blocked_until_owner_gate",
+            "route": "owner-gate projection before connector read",
+            "fallback": "owner supplies compact count and topic labels",
+            "evidence_quality": "not_evidence_until_approved",
+            "promotion_target": "source_item_v0_after_owner_gate",
+            "requires_user_gate": True,
+            "user_gate": {
+                "role": "user",
+                "action_kind": "approve_private_metadata_intake",
+                "question": (
+                    "Approve metadata-only private connector intake, reject it, "
+                    "or narrow the source handle before source content use."
+                ),
+                "blocks": [
+                    "source content read",
+                    "source quote",
+                    "source summary",
+                    "external posting",
+                ],
+            },
+            "source_body_captured": False,
+            "response_payload_captured": False,
+            "local_path_captured": False,
+            "external_write_allowed": False,
+        },
+        {
+            "lane_id": "experiment_compact_result_metadata",
+            "surface": "experiment_state_surface",
+            "source_kind": "ml_experiment_run",
+            "source_status": "unpublished",
+            "access_mode": "synthetic_fixture_only",
+            "read_status": "compact_result_ready",
+            "route": "experiment reducer emits compact status counters",
+            "fallback": "operator supplies public-safe result card",
+            "evidence_quality": "compact_result_metadata",
+            "promotion_target": "experiment_state_surface_candidate",
+            "requires_user_gate": True,
+            "user_gate": {
+                "role": "user",
+                "action_kind": "approve_raw_experiment_material_use",
+                "question": (
+                    "Approve any raw experiment material read; compact status "
+                    "metadata can be used without raw logs."
+                ),
+                "blocks": [
+                    "raw run log read",
+                    "private dataset sample read",
+                    "credential or environment dump",
+                ],
+            },
+            "source_body_captured": False,
+            "response_payload_captured": False,
+            "local_path_captured": False,
+            "external_write_allowed": False,
+        },
+    ]
+    validation = validate_content_ops_exploration_plan_lanes(source_lanes)
+    user_gate_lanes = [
+        lane for lane in source_lanes if bool(lane.get("requires_user_gate"))
+    ]
+    plan = {
+        "schema_version": EXPLORATION_PLAN_SCHEMA_VERSION,
+        "scenario": scenario_label,
+        "generated_at": generated_at,
+        "selected_source_lanes": source_lanes,
+        "lane_counts": {
+            "total": len(source_lanes),
+            "user_gate_required": len(user_gate_lanes),
+            "metadata_ready": sum(
+                1 for lane in source_lanes if lane.get("read_status") == "metadata_ready"
+            ),
+            "blocked_until_owner_gate": sum(
+                1
+                for lane in source_lanes
+                if lane.get("read_status") == "blocked_until_owner_gate"
+            ),
+        },
+        "promotion_targets": _counter(
+            [lane.get("promotion_target") for lane in source_lanes]
+        ),
+        "first_screen": {
+            "waiting_on": "user" if user_gate_lanes else "agent",
+            "user_action_required": bool(user_gate_lanes),
+            "agent_can_continue": True,
+            "top_agent_action": (
+                "promote metadata-ready public lanes or ask concrete owner gates "
+                "before private/raw source use"
+            ),
+            "top_user_gate": user_gate_lanes[0].get("user_gate")
+            if user_gate_lanes
+            else None,
+        },
+        "boundary": {
+            "external_reads_performed": False,
+            "external_writes_performed": False,
+            "source_bodies_captured": False,
+            "response_payloads_captured": False,
+            "local_paths_captured": False,
+            "autopublish_allowed": False,
+        },
+        "truth_contract": {
+            "plan_is_writable": False,
+            "source_lanes_are_candidates": True,
+            "promotion_requires_target_surface_validation": True,
+            "private_boundary_crossing_requires_user_gate": True,
+        },
+    }
+    return {
+        "ok": bool(validation.get("ok")),
+        "schema_version": CONTENT_OPS_EXPLORATION_PLAN_PACKET_SCHEMA_VERSION,
+        "mode": "content-ops-exploration-plan",
+        "exploration_plan": plan,
+        "validation": validation,
+        "external_reads_performed": False,
+        "external_writes_performed": False,
+        "private_source_bodies_read": False,
+        "private_source_content_read": False,
+        "local_paths_captured": False,
+        "autopublish_allowed": False,
+        "next_safe_action": plan["first_screen"]["top_agent_action"],
+    }
+
+
+def validate_content_ops_exploration_plan_lanes(
+    source_lanes: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    errors: list[str] = []
+    if not source_lanes:
+        errors.append("at least one source lane is required")
+    seen_ids: set[str] = set()
+    for index, lane in enumerate(source_lanes):
+        lane_id = str(lane.get("lane_id") or "").strip()
+        if not lane_id:
+            errors.append(f"lane {index + 1}: lane_id is required")
+        elif lane_id in seen_ids:
+            errors.append(f"lane {index + 1}: duplicate lane_id {lane_id}")
+        seen_ids.add(lane_id)
+        if lane.get("source_status") not in ALLOWED_SOURCE_STATUSES:
+            errors.append(
+                f"{lane_id or index + 1}: source_status must be one of "
+                f"{sorted(ALLOWED_SOURCE_STATUSES)}"
+            )
+        if lane.get("access_mode") not in ALLOWED_CONNECTOR_ACCESS_MODES:
+            errors.append(
+                f"{lane_id or index + 1}: access_mode must be one of "
+                f"{sorted(ALLOWED_CONNECTOR_ACCESS_MODES)}"
+            )
+        if lane.get("read_status") not in ALLOWED_EXPLORATION_READ_STATUSES:
+            errors.append(
+                f"{lane_id or index + 1}: read_status must be one of "
+                f"{sorted(ALLOWED_EXPLORATION_READ_STATUSES)}"
+            )
+        if lane.get("evidence_quality") not in ALLOWED_EXPLORATION_EVIDENCE_QUALITIES:
+            errors.append(
+                f"{lane_id or index + 1}: evidence_quality must be one of "
+                f"{sorted(ALLOWED_EXPLORATION_EVIDENCE_QUALITIES)}"
+            )
+        if not str(lane.get("route") or "").strip():
+            errors.append(f"{lane_id or index + 1}: route is required")
+        if not str(lane.get("fallback") or "").strip():
+            errors.append(f"{lane_id or index + 1}: fallback is required")
+        if not str(lane.get("promotion_target") or "").strip():
+            errors.append(f"{lane_id or index + 1}: promotion_target is required")
+        if bool(lane.get("source_body_captured")):
+            errors.append(f"{lane_id or index + 1}: source_body_captured must be false")
+        if bool(lane.get("response_payload_captured")):
+            errors.append(
+                f"{lane_id or index + 1}: response_payload_captured must be false"
+            )
+        if bool(lane.get("local_path_captured")):
+            errors.append(f"{lane_id or index + 1}: local_path_captured must be false")
+        if bool(lane.get("external_write_allowed")):
+            errors.append(f"{lane_id or index + 1}: external_write_allowed must be false")
+        if bool(lane.get("requires_user_gate")) and not isinstance(
+            lane.get("user_gate"), Mapping
+        ):
+            errors.append(f"{lane_id or index + 1}: user_gate is required")
+    return {
+        "schema_version": "content_ops_exploration_plan_validation_v0",
+        "ok": not errors,
+        "errors": errors,
+        "lane_count": len(source_lanes),
+    }
+
+
+def render_content_ops_exploration_plan_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# LoopX Content-Ops Exploration Plan",
+        "",
+        f"- ok: `{payload.get('ok')}`",
+        f"- schema_version: `{payload.get('schema_version')}`",
+        f"- external_reads_performed: `{payload.get('external_reads_performed')}`",
+        f"- external_writes_performed: `{payload.get('external_writes_performed')}`",
+        f"- private_source_bodies_read: `{payload.get('private_source_bodies_read')}`",
+        f"- local_paths_captured: `{payload.get('local_paths_captured')}`",
+        f"- autopublish_allowed: `{payload.get('autopublish_allowed')}`",
+    ]
+    plan = payload.get("exploration_plan")
+    if isinstance(plan, Mapping):
+        first_screen = plan.get("first_screen")
+        if isinstance(first_screen, Mapping):
+            lines.extend(
+                [
+                    "",
+                    "## First Screen",
+                    "",
+                    f"- waiting_on: `{first_screen.get('waiting_on')}`",
+                    f"- user_action_required: `{first_screen.get('user_action_required')}`",
+                    f"- agent_can_continue: `{first_screen.get('agent_can_continue')}`",
+                    f"- top_agent_action: {first_screen.get('top_agent_action')}",
+                ]
+            )
+        lanes = plan.get("selected_source_lanes")
+        if isinstance(lanes, Sequence) and not isinstance(lanes, (str, bytes)):
+            lines.extend(["", "## Source Lanes", ""])
+            for lane in lanes:
+                if not isinstance(lane, Mapping):
+                    continue
+                lines.extend(
+                    [
+                        f"- `{lane.get('lane_id')}`: status=`{lane.get('source_status')}`, "
+                        f"read=`{lane.get('read_status')}`, "
+                        f"promotion=`{lane.get('promotion_target')}`, "
+                        f"user_gate=`{lane.get('requires_user_gate')}`",
+                    ]
+                )
+    validation = payload.get("validation")
+    if isinstance(validation, Mapping):
+        errors = validation.get("errors") if isinstance(validation.get("errors"), list) else []
+        lines.extend(
+            [
+                "",
+                "## Validation",
+                "",
+                f"- validation_ok: `{validation.get('ok')}`",
+                f"- lane_count: `{validation.get('lane_count')}`",
+                f"- error_count: `{len(errors)}`",
+            ]
+        )
+    return "\n".join(lines) + "\n"
 
 
 def build_content_ops_public_handle_observation_packet(


### PR DESCRIPTION
## Summary
- add content_ops_exploration_plan_packet_v0 / exploration_plan_v0 fixture builder and renderer
- expose loopx content-ops exploration-plan as a no-read/no-write planning packet before connector source access
- cover repo issue, public social signal, private chat metadata gate, and experiment compact result lanes
- document the command in content-ops protocol docs and update the CS-Notes capability map with the implemented entrypoint

## Validation
- python3 examples/content-ops-exploration-plan-smoke.py
- python3 -m py_compile loopx/content_ops_surface.py loopx/cli_commands/content_ops.py examples/content-ops-exploration-plan-smoke.py
- python3 examples/content-ops-preview-cli-smoke.py
- python3 examples/content-ops-public-handle-observation-smoke.py
- python3 examples/content-ops-private-connector-gate-smoke.py
- python3 examples/content-ops-packet-aggregation-smoke.py
- python3 examples/content-ops-chatview-report-smoke.py
- python3 examples/content-ops-walkthrough-artifact-smoke.py
- python3 examples/cs-notes-explore-capability-map-smoke.py
- python3 -m loopx.cli --format json content-ops exploration-plan
- git diff --check
- loopx check --scan-path loopx/content_ops_surface.py --scan-path loopx/cli_commands/content_ops.py --scan-path docs/reference/protocols/content-ops-surface-v0.md --scan-path docs/reference/protocols/cs-notes-explore-capability-map-v0.md --scan-path examples/content-ops-exploration-plan-smoke.py