### PR TITLE
Guard SkillsBench reverse-channel bridge launch

### DIFF
--- a/examples/skillsbench-host-local-launch-plan-smoke.py
+++ b/examples/skillsbench-host-local-launch-plan-smoke.py
@@ -54,9 +54,81 @@ def main() -> int:
         assert prerequisites["host_local_acp_launch"] is True
         assert prerequisites["host_local_acp_launch_status"] == "pending"
         assert prerequisites["remote_command_file_bridge_materialized"] is True
+        assert prerequisites["remote_command_file_bridge_consumed_by_solver"] is False
+        assert (
+            prerequisites["remote_command_file_bridge_consumption_status"]
+            == "probe_only_not_solver_wired"
+        )
         assert prerequisites["container_codex_acp_install_skipped"] is False
         assert plan["public_boundary"]["leaderboard_upload"] is False
         assert plan["public_boundary"]["public_submission"] is False
+        blocked = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--skillsbench-root",
+                str(root),
+                "--task-id",
+                "demo-task",
+                "--route",
+                "loopx-product-mode",
+                "--host-local-acp-launch",
+                "--remote-command-file-bridge-ready",
+            ],
+            cwd=REPO_ROOT,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        assert blocked.returncode == 2, blocked
+        failure = json.loads(blocked.stderr)
+        assert failure["error_type"] == (
+            "SkillsBenchReverseChannelBridgeNotSolverWired"
+        ), failure
+        assert failure["remote_command_file_bridge_materialized"] is True
+        assert failure["remote_command_file_bridge_consumed_by_solver"] is False
+        assert failure["raw_logs_recorded"] is False
+        assert failure["raw_task_text_read"] is False
+        preflight = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--skillsbench-root",
+                str(root),
+                "--task-id",
+                "demo-task",
+                "--route",
+                "loopx-product-mode",
+                "--local-driver-worker-handshake-preflight",
+                "--local-codex-cli-participant-ready",
+                "--local-acp-relay-probe",
+                "--host-local-acp-transport-probe",
+                "--host-local-acp-launch",
+                "--remote-command-file-bridge-probe",
+                "--remote-command-file-bridge-probe-command",
+                f"{sys.executable} {REPO_ROOT / 'scripts' / 'skillsbench_remote_command_file_bridge.py'} --serve-probe",
+            ],
+            cwd=REPO_ROOT,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        assert preflight.returncode == 0, preflight.stderr
+        preflight_payload = json.loads(preflight.stdout)
+        assert (
+            preflight_payload.get("error_type")
+            != "SkillsBenchReverseChannelBridgeNotSolverWired"
+        ), preflight_payload
+        assert (
+            preflight_payload["local_driver_contract"][
+                "remote_command_file_bridge_materialized"
+            ]
+            is True
+        ), preflight_payload
     print("skillsbench host-local ACP launch plan smoke passed")
     return 0
 

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -2362,9 +2362,15 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
     loopx_source_mount = _loopx_source_mount_contract(args)
     requires_preinstalled_runtime = bool(agent_runtime_layer.get("required"))
     is_app_server_goal_route = route == "codex-app-server-goal-baseline"
-    app_server_goal_bridge_ready = bool(
+    remote_command_file_bridge_materialized = bool(
         args.remote_command_file_bridge_ready
         or args.remote_command_file_bridge_probe
+    )
+    remote_command_file_bridge_consumed_by_solver = False
+    remote_command_file_bridge_consumption_status = (
+        "probe_only_not_solver_wired"
+        if remote_command_file_bridge_materialized
+        else "missing"
     )
     app_server_goal_worker_contract = (
         build_skillsbench_app_server_goal_worker_contract(
@@ -2407,8 +2413,7 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
         "include_task_skills": bool(args.include_task_skills),
         "host_local_acp_launch": bool(args.host_local_acp_launch),
         "remote_command_file_bridge_ready": bool(
-            args.remote_command_file_bridge_ready
-            or args.remote_command_file_bridge_probe
+            remote_command_file_bridge_materialized
         ),
         "benchflow_agent_runtime_layer": agent_runtime_layer,
         "loopx_source_mount": loopx_source_mount,
@@ -2498,8 +2503,13 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
                 True if is_app_server_goal_route else requires_preinstalled_runtime
             ),
             "remote_command_file_bridge_materialized": bool(
-                args.remote_command_file_bridge_ready
-                or args.remote_command_file_bridge_probe
+                remote_command_file_bridge_materialized
+            ),
+            "remote_command_file_bridge_consumed_by_solver": (
+                remote_command_file_bridge_consumed_by_solver
+            ),
+            "remote_command_file_bridge_consumption_status": (
+                remote_command_file_bridge_consumption_status
             ),
             "preinstalled_benchflow_agent_runtime_required": (
                 requires_preinstalled_runtime
@@ -2561,7 +2571,7 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
                 bool(app_server_goal_worker_contract)
             ),
             "codex_app_server_goal_worker_remote_command_file_bridge_ready": (
-                app_server_goal_bridge_ready
+                remote_command_file_bridge_materialized
                 if app_server_goal_worker_contract
                 else False
             ),
@@ -5433,6 +5443,40 @@ def main(argv: list[str] | None = None) -> int:
             }
             print(json.dumps(payload, indent=2, sort_keys=True), file=sys.stderr)
             return 2
+    if (
+        args.route in {"raw-codex-autonomous-max5", "loopx-product-mode"}
+        and args.host_local_acp_launch
+        and (
+            args.remote_command_file_bridge_ready
+            or args.remote_command_file_bridge_probe
+        )
+        and not args.local_driver_worker_handshake_preflight
+        and not args.plan_only
+    ):
+        payload = {
+            "ok": False,
+            "error_type": "SkillsBenchReverseChannelBridgeNotSolverWired",
+            "route": args.route,
+            "reason": (
+                "the remote command/file bridge probe is materialized, but this "
+                "product-mode host-local ACP route does not yet pass that bridge "
+                "into the solver turn; launching would only prove the relay/probe "
+                "layer, not a countable reverse-channel treatment"
+            ),
+            "next_action": (
+                "wire the remote command/file bridge into the solver worker or "
+                "use a route whose compact public trace proves nonzero bridge "
+                "read/write during the agent turn before launching a scored case"
+            ),
+            "remote_command_file_bridge_materialized": True,
+            "remote_command_file_bridge_consumed_by_solver": False,
+            "raw_logs_recorded": False,
+            "raw_task_text_read": False,
+            "raw_trajectory_recorded": False,
+            "credential_values_recorded": False,
+        }
+        print(json.dumps(payload, indent=2, sort_keys=True), file=sys.stderr)
+        return 2
     if args.local_codex_participant_ping:
         payload = materialize_local_codex_participant(
             codex_bin=args.local_codex_bin,


### PR DESCRIPTION
## Summary
- expose whether a materialized remote command/file bridge is actually consumed by the solver turn
- fail closed for product-mode host-local ACP launches that declare a remote bridge before bridge-to-solver wiring exists
- extend the host-local launch smoke so probe-ready cannot be mistaken for a countable reverse-channel treatment

## Validation
- `git diff --check origin/main..HEAD`
- `python3 -m py_compile scripts/skillsbench_automation_loop.py examples/skillsbench-host-local-launch-plan-smoke.py`
- `python3 examples/skillsbench-host-local-launch-plan-smoke.py`
- `loopx check --scan-path scripts/skillsbench_automation_loop.py --scan-path examples/skillsbench-host-local-launch-plan-smoke.py`

## Boundary
No benchmark launch, no scoring change, no raw logs, no task text, no trajectories, no credentials, and no local/private paths committed.