### PR TITLE
Wire SkillsBench bridge into solver turn

### DIFF
--- a/examples/skillsbench-host-local-launch-plan-smoke.py
+++ b/examples/skillsbench-host-local-launch-plan-smoke.py
@@ -11,7 +11,19 @@ from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.benchmark_adapters.skillsbench_acp_relay import (  # noqa: E402
+    run_skillsbench_local_acp_relay_probe,
+)
+from scripts.skillsbench_automation_loop import (  # noqa: E402
+    _merge_host_local_acp_relay_trace_summary,
+)
+
 SCRIPT = REPO_ROOT / "scripts" / "skillsbench_automation_loop.py"
+RELAY_SCRIPT = REPO_ROOT / "scripts" / "skillsbench_local_acp_relay.py"
+BRIDGE_SCRIPT = REPO_ROOT / "scripts" / "skillsbench_remote_command_file_bridge.py"
 
 
 def main() -> int:
@@ -91,6 +103,7 @@ def main() -> int:
         assert failure["remote_command_file_bridge_consumed_by_solver"] is False
         assert failure["raw_logs_recorded"] is False
         assert failure["raw_task_text_read"] is False
+        assert failure["remote_command_file_bridge_command_configured"] is False
         preflight = subprocess.run(
             [
                 sys.executable,
@@ -129,6 +142,136 @@ def main() -> int:
             ]
             is True
         ), preflight_payload
+        bridge_command = f"{sys.executable} {BRIDGE_SCRIPT} --serve-probe"
+        wired_plan_proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--skillsbench-root",
+                str(root),
+                "--task-id",
+                "demo-task",
+                "--route",
+                "loopx-product-mode",
+                "--host-local-acp-launch",
+                "--remote-command-file-bridge-probe",
+                "--remote-command-file-bridge-probe-command",
+                bridge_command,
+                "--plan-only",
+            ],
+            cwd=REPO_ROOT,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        assert wired_plan_proc.returncode == 0, wired_plan_proc.stderr
+        wired_plan = json.loads(wired_plan_proc.stdout)["launch_plan"]
+        wired_prerequisites = wired_plan["runner_prerequisites"]
+        assert wired_plan["host_local_acp_relay_trace_dir"], wired_plan
+        assert wired_prerequisites["remote_command_file_bridge_materialized"] is True
+        assert (
+            wired_prerequisites["remote_command_file_bridge_command_configured"]
+            is True
+        )
+        assert (
+            wired_prerequisites[
+                "remote_command_file_bridge_solver_wiring_configured"
+            ]
+            is True
+        )
+        assert (
+            wired_prerequisites["remote_command_file_bridge_consumption_status"]
+            == "solver_wiring_configured_pending_prompt"
+        )
+        fake_codex = Path(tmp) / "fake-codex"
+        fake_codex.write_text(
+            """#!/usr/bin/env python3
+import sys
+from pathlib import Path
+
+args = sys.argv[1:]
+if "Private bridge command:" not in args[-1]:
+    raise SystemExit(7)
+output = Path(args[args.index("--output-last-message") + 1])
+output.write_text("fake solver saw bridge packet\\n", encoding="utf-8")
+""",
+            encoding="utf-8",
+        )
+        fake_codex.chmod(0o755)
+        trace_dir = Path(tmp) / "relay-traces"
+        relay_probe = run_skillsbench_local_acp_relay_probe(
+            [
+                sys.executable,
+                str(RELAY_SCRIPT),
+                "--codex-bin",
+                str(fake_codex),
+                "--route",
+                "loopx-product-mode",
+                "--worker-public-trace-dir",
+                str(trace_dir),
+                "--remote-command-file-bridge-command",
+                bridge_command,
+                "--remote-command-file-bridge-timeout-sec",
+                "5",
+            ],
+            timeout_sec=20,
+        )
+        assert relay_probe["ready"] is True, relay_probe
+        trace_files = sorted(trace_dir.glob("*.compact.json"))
+        assert trace_files, relay_probe
+        bridge_trace = json.loads(trace_files[0].read_text(encoding="utf-8"))
+        assert (
+            bridge_trace["schema_version"]
+            == "skillsbench_host_local_acp_relay_public_trace_v0"
+        )
+        assert bridge_trace["trace_kind"] == (
+            "remote_command_file_bridge_solver_consumption"
+        )
+        bridge = bridge_trace["remote_command_file_bridge"]
+        assert bridge["consumed_by_solver"] is True
+        assert bridge["probe_ready"] is True
+        assert bridge["operation_count"] >= 4
+        assert bridge["bridge_command_recorded"] is False
+        boundary = bridge_trace["boundary"]
+        assert boundary["raw_command_recorded"] is False
+        assert boundary["raw_stdout_recorded"] is False
+        assert boundary["raw_stderr_recorded"] is False
+        assert boundary["raw_task_text_recorded"] is False
+        assert boundary["host_paths_recorded"] is False
+        assert boundary["remote_paths_recorded"] is False
+        controller_trace = {"schema_version": "skillsbench_loopx_controller_trace_v0"}
+        reducer_plan = {
+            "host_local_acp_relay_trace_dir": str(trace_dir),
+            "runner_prerequisites": {
+                "remote_command_file_bridge_solver_wiring_configured": True
+            },
+        }
+        _merge_host_local_acp_relay_trace_summary(reducer_plan, controller_trace)
+        assert (
+            controller_trace["remote_command_file_bridge_consumed_by_solver"]
+            is True
+        )
+        assert (
+            controller_trace["remote_command_file_bridge_solver_public_trace_read"]
+            is True
+        )
+        assert controller_trace["remote_command_file_bridge_solver_trace_count"] == 1
+        assert (
+            controller_trace["remote_command_file_bridge_solver_probe_ready_count"]
+            == 1
+        )
+        assert (
+            controller_trace["remote_command_file_bridge_solver_operation_count"]
+            >= 4
+        )
+        assert (
+            reducer_plan["runner_prerequisites"][
+                "remote_command_file_bridge_consumption_status"
+            ]
+            == "solver_prompt_probe_ready"
+        )
     print("skillsbench host-local ACP launch plan smoke passed")
     return 0
 

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -1996,6 +1996,31 @@ def _skillsbench_controller_trace_counters(
         "native_goal_worker_assistant_message_present_count": count(
             "native_goal_worker_assistant_message_present_count"
         ),
+        "remote_command_file_bridge_consumed_by_solver": controller_trace.get(
+            "remote_command_file_bridge_consumed_by_solver"
+        )
+        is True,
+        "remote_command_file_bridge_solver_trace_dir_present": controller_trace.get(
+            "remote_command_file_bridge_solver_trace_dir_present"
+        )
+        is True,
+        "remote_command_file_bridge_solver_public_trace_read": controller_trace.get(
+            "remote_command_file_bridge_solver_public_trace_read"
+        )
+        is True,
+        "remote_command_file_bridge_solver_raw_material_recorded": controller_trace.get(
+            "remote_command_file_bridge_solver_raw_material_recorded"
+        )
+        is True,
+        "remote_command_file_bridge_solver_trace_count": count(
+            "remote_command_file_bridge_solver_trace_count"
+        ),
+        "remote_command_file_bridge_solver_probe_ready_count": count(
+            "remote_command_file_bridge_solver_probe_ready_count"
+        ),
+        "remote_command_file_bridge_solver_operation_count": count(
+            "remote_command_file_bridge_solver_operation_count"
+        ),
         "heartbeat_count": count("heartbeat_count"),
         "raw_task_text_recorded": controller_trace.get("raw_task_text_recorded")
         is True,
@@ -3230,6 +3255,42 @@ def build_skillsbench_benchflow_result_benchmark_run(
                     "native_goal_worker_assistant_message_present_count", 0
                 )
             ),
+            "remote_command_file_bridge_consumed_by_solver": (
+                controller_counters.get(
+                    "remote_command_file_bridge_consumed_by_solver", False
+                )
+            ),
+            "remote_command_file_bridge_solver_trace_dir_present": (
+                controller_counters.get(
+                    "remote_command_file_bridge_solver_trace_dir_present", False
+                )
+            ),
+            "remote_command_file_bridge_solver_public_trace_read": (
+                controller_counters.get(
+                    "remote_command_file_bridge_solver_public_trace_read", False
+                )
+            ),
+            "remote_command_file_bridge_solver_raw_material_recorded": (
+                controller_counters.get(
+                    "remote_command_file_bridge_solver_raw_material_recorded",
+                    False,
+                )
+            ),
+            "remote_command_file_bridge_solver_trace_count": (
+                controller_counters.get(
+                    "remote_command_file_bridge_solver_trace_count", 0
+                )
+            ),
+            "remote_command_file_bridge_solver_probe_ready_count": (
+                controller_counters.get(
+                    "remote_command_file_bridge_solver_probe_ready_count", 0
+                )
+            ),
+            "remote_command_file_bridge_solver_operation_count": (
+                controller_counters.get(
+                    "remote_command_file_bridge_solver_operation_count", 0
+                )
+            ),
             "loopx_case_state_path_count": trajectory_summary.get(
                 "loopx_case_state_path_count", 0
             ),
@@ -3317,6 +3378,31 @@ def build_skillsbench_benchflow_result_benchmark_run(
                 "native_goal_worker_prompt_received_count", 0
             ),
             "native_goal_worker_trace_status": native_goal_worker_trace_status,
+            "remote_command_file_bridge_consumed_by_solver": (
+                controller_counters.get(
+                    "remote_command_file_bridge_consumed_by_solver", False
+                )
+            ),
+            "remote_command_file_bridge_solver_public_trace_read": (
+                controller_counters.get(
+                    "remote_command_file_bridge_solver_public_trace_read", False
+                )
+            ),
+            "remote_command_file_bridge_solver_trace_count": (
+                controller_counters.get(
+                    "remote_command_file_bridge_solver_trace_count", 0
+                )
+            ),
+            "remote_command_file_bridge_solver_probe_ready_count": (
+                controller_counters.get(
+                    "remote_command_file_bridge_solver_probe_ready_count", 0
+                )
+            ),
+            "remote_command_file_bridge_solver_operation_count": (
+                controller_counters.get(
+                    "remote_command_file_bridge_solver_operation_count", 0
+                )
+            ),
         },
         "authorization": {
             "real_case_execution_authorized": True,

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -14,6 +14,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, TextIO
 
+from loopx.benchmark_adapters.skillsbench_remote_bridge import (
+    run_skillsbench_remote_command_file_bridge_probe,
+)
+
 
 SKILLSBENCH_LOCAL_ACP_RELAY_SCHEMA_VERSION = "skillsbench_local_acp_relay_v0"
 SKILLSBENCH_LOCAL_ACP_RELAY_PROBE_SCHEMA_VERSION = (
@@ -61,6 +65,7 @@ class CodexExecConfig:
     codex_bin: str = "codex"
     sandbox: str = "workspace-write"
     model: str | None = None
+    route: str = "unknown"
     timeout_sec: int = 7200
     dry_run_response: str | None = None
     app_server_goal_worker: bool = False
@@ -72,6 +77,8 @@ class CodexExecConfig:
     stream_heartbeat_interval_sec: float = 120.0
     reasoning_effort: str | None = "high"
     worker_public_trace_dir: str | None = None
+    remote_command_file_bridge_command: str | None = None
+    remote_command_file_bridge_timeout_sec: float = 10.0
 
 
 class SkillsBenchLocalAcpRelay:
@@ -208,9 +215,23 @@ class SkillsBenchLocalAcpRelay:
                 session_id=session_id,
                 stdout=stdout,
             )
-        cwd = _safe_cwd(session.get("cwd"), default=os.getcwd())
         with tempfile.TemporaryDirectory(prefix="gh-skillsbench-acp-") as tmp:
-            output_path = Path(tmp) / "last-message.txt"
+            tmp_path = Path(tmp)
+            output_path = tmp_path / "last-message.txt"
+            prompt_for_codex = prompt_text
+            cwd = _safe_cwd(session.get("cwd"), default=os.getcwd())
+            if self._config.remote_command_file_bridge_command:
+                bridge_probe = self._consume_remote_bridge_for_solver()
+                self._publish_remote_bridge_consumption_trace(bridge_probe)
+                if bridge_probe.get("ready") is not True:
+                    raise RuntimeError("remote command/file bridge probe failed")
+                local_cwd = tmp_path / "local-codex-cwd"
+                local_cwd.mkdir(parents=True, exist_ok=True)
+                cwd = str(local_cwd)
+                prompt_for_codex = self._prompt_with_remote_bridge_packet(
+                    prompt_text,
+                    bridge_probe=bridge_probe,
+                )
             cmd = [
                 self._config.codex_bin,
                 "exec",
@@ -227,7 +248,7 @@ class SkillsBenchLocalAcpRelay:
             model = self._config.model or session.get("model")
             if model:
                 cmd.extend(["--model", str(model)])
-            cmd.append(prompt_text)
+            cmd.append(prompt_for_codex)
             try:
                 proc = subprocess.run(
                     cmd,
@@ -246,6 +267,83 @@ class SkillsBenchLocalAcpRelay:
             except OSError as exc:
                 raise RuntimeError("local codex final message missing") from exc
             return response or "local codex returned an empty final message"
+
+    def _consume_remote_bridge_for_solver(self) -> dict[str, Any]:
+        return run_skillsbench_remote_command_file_bridge_probe(
+            self._config.remote_command_file_bridge_command,
+            timeout_sec=self._config.remote_command_file_bridge_timeout_sec,
+        )
+
+    def _prompt_with_remote_bridge_packet(
+        self,
+        prompt_text: str,
+        *,
+        bridge_probe: dict[str, Any],
+    ) -> str:
+        operation_count = bridge_probe.get("operation_count")
+        if not isinstance(operation_count, int) or isinstance(operation_count, bool):
+            operation_count = 0
+        bridge_command = self._config.remote_command_file_bridge_command or ""
+        packet = f"""
+
+LoopX SkillsBench remote workspace bridge:
+- This local Codex process is outside the scored SkillsBench sandbox.
+- Use the command below as a private JSON bridge for sandbox exec, file write, file read, and cleanup operations.
+- Send JSON requests on stdin and read compact JSON responses on stdout.
+- Do not upload, submit, expose credentials, quote the bridge command in final output, or record raw stdout/stderr/task text in public artifacts.
+- The bridge readiness probe completed with ready=true and operation_count={operation_count}.
+
+Private bridge command:
+{bridge_command}
+""".strip()
+        return f"{packet}\n\n{prompt_text}"
+
+    def _publish_remote_bridge_consumption_trace(
+        self,
+        bridge_probe: dict[str, Any],
+    ) -> None:
+        if not self._config.worker_public_trace_dir:
+            return
+        operation_count = bridge_probe.get("operation_count")
+        if not isinstance(operation_count, int) or isinstance(operation_count, bool):
+            operation_count = 0
+        boundary = {
+            "raw_command_recorded": bridge_probe.get("raw_command_recorded") is True,
+            "raw_stdout_recorded": bridge_probe.get("raw_stdout_recorded") is True,
+            "raw_stderr_recorded": bridge_probe.get("raw_stderr_recorded") is True,
+            "raw_task_text_recorded": bridge_probe.get("raw_task_text_recorded") is True,
+            "raw_logs_recorded": bridge_probe.get("raw_logs_recorded") is True,
+            "raw_trajectory_recorded": bridge_probe.get("raw_trajectory_recorded") is True,
+            "credential_values_recorded": (
+                bridge_probe.get("credential_values_recorded") is True
+            ),
+            "host_paths_recorded": bridge_probe.get("host_paths_recorded") is True,
+            "remote_paths_recorded": bridge_probe.get("remote_paths_recorded") is True,
+            "upload_performed": bridge_probe.get("upload_performed") is True,
+            "submit_performed": bridge_probe.get("submit_performed") is True,
+        }
+        trace = {
+            "schema_version": "skillsbench_host_local_acp_relay_public_trace_v0",
+            "ok": bridge_probe.get("ready") is True,
+            "route": self._config.route,
+            "trace_kind": "remote_command_file_bridge_solver_consumption",
+            "benchmark_id": self._config.dataset,
+            "task_id": self._config.task_id,
+            "remote_command_file_bridge": {
+                "schema_version": "skillsbench_remote_command_file_bridge_solver_consumption_v0",
+                "consumed_by_solver": True,
+                "probe_ready": bridge_probe.get("ready") is True,
+                "operation_count": operation_count,
+                "first_blocker": str(bridge_probe.get("first_blocker") or "")[:120],
+                "stage": str(bridge_probe.get("stage") or "")[:80],
+                "bridge_command_invoked": (
+                    bridge_probe.get("bridge_command_invoked") is True
+                ),
+                "bridge_command_recorded": False,
+            },
+            "boundary": boundary,
+        }
+        self._write_worker_public_trace(trace)
 
     def _run_app_server_goal_worker(
         self,

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -132,6 +132,8 @@ BENCHMARK_VALIDATION_NEUTRAL_FALSE_FIELDS = {
     "native_goal_worker_trace_dir_present",
     "native_goal_worker_public_trace_read",
     "native_goal_worker_trace_observed",
+    "remote_command_file_bridge_consumed_by_solver",
+    "remote_command_file_bridge_solver_public_trace_read",
     "loopx_controller_trace_present",
     "leaderboard_claim_allowed",
     "official_score_claim_allowed",
@@ -540,6 +542,10 @@ def _compact_benchmark_interaction_counters(value: Any) -> dict[str, Any]:
         "native_goal_worker_trace_dir_present",
         "native_goal_worker_public_trace_read",
         "native_goal_worker_raw_material_recorded",
+        "remote_command_file_bridge_consumed_by_solver",
+        "remote_command_file_bridge_solver_trace_dir_present",
+        "remote_command_file_bridge_solver_public_trace_read",
+        "remote_command_file_bridge_solver_raw_material_recorded",
     ):
         if isinstance(value.get(field), bool):
             compact[field] = value[field]
@@ -607,6 +613,9 @@ def _compact_benchmark_interaction_counters(value: Any) -> dict[str, Any]:
         "native_goal_worker_turn_start_count",
         "native_goal_worker_turn_completed_observed_count",
         "native_goal_worker_assistant_message_present_count",
+        "remote_command_file_bridge_solver_trace_count",
+        "remote_command_file_bridge_solver_probe_ready_count",
+        "remote_command_file_bridge_solver_operation_count",
     ):
         if isinstance(value.get(field), int) and not isinstance(value.get(field), bool):
             compact[field] = value[field]
@@ -976,6 +985,7 @@ def _compact_benchmark_runner_prerequisites(value: Any) -> dict[str, Any]:
         "benchflow_user_loop_recovery_stage",
         "benchflow_intermediate_soft_verify_policy",
         "benchflow_setup_stall_cleanup_status",
+        "remote_command_file_bridge_consumption_status",
     ):
         text = public_safe_compact_text(value.get(field), limit=180)
         if text:
@@ -995,6 +1005,12 @@ def _compact_benchmark_runner_prerequisites(value: Any) -> dict[str, Any]:
         "benchflow_agent_runtime_mount_source_recorded",
         "host_local_acp_launch",
         "remote_command_file_bridge_materialized",
+        "remote_command_file_bridge_command_configured",
+        "remote_command_file_bridge_solver_wiring_configured",
+        "remote_command_file_bridge_consumed_by_solver",
+        "remote_command_file_bridge_solver_trace_dir_present",
+        "remote_command_file_bridge_solver_public_trace_read",
+        "remote_command_file_bridge_solver_raw_material_recorded",
         "codex_app_server_goal_worker_adapter_present",
         "codex_app_server_goal_worker_turn_start_required",
         "codex_app_server_goal_worker_goal_get_required",
@@ -1042,6 +1058,9 @@ def _compact_benchmark_runner_prerequisites(value: Any) -> dict[str, Any]:
         "benchflow_setup_stall_cleanup_term_sent_count",
         "benchflow_setup_stall_cleanup_kill_sent_count",
         "benchflow_setup_stall_cleanup_alive_after_count",
+        "remote_command_file_bridge_solver_trace_count",
+        "remote_command_file_bridge_solver_probe_ready_count",
+        "remote_command_file_bridge_solver_operation_count",
     ):
         if isinstance(value.get(field), int) and not isinstance(value.get(field), bool):
             compact[field] = value[field]
@@ -2163,6 +2182,10 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
         "native_goal_worker_trace_dir_present",
         "native_goal_worker_public_trace_read",
         "native_goal_worker_raw_material_recorded",
+        "remote_command_file_bridge_consumed_by_solver",
+        "remote_command_file_bridge_solver_trace_dir_present",
+        "remote_command_file_bridge_solver_public_trace_read",
+        "remote_command_file_bridge_solver_raw_material_recorded",
         "strict_loopx_treatment_claim_allowed",
         "controller_trace_present",
     ):
@@ -2202,6 +2225,9 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
         "native_goal_worker_turn_start_count",
         "native_goal_worker_turn_completed_observed_count",
         "native_goal_worker_assistant_message_present_count",
+        "remote_command_file_bridge_solver_trace_count",
+        "remote_command_file_bridge_solver_probe_ready_count",
+        "remote_command_file_bridge_solver_operation_count",
         "controller_max_round_observed",
         "controller_max_rounds_budget",
         "controller_initial_prompt_count",

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -661,6 +661,7 @@ def _host_local_acp_launch_command(
     if "--dry-run-response" in command:
         index = command.index("--dry-run-response")
         del command[index : index + 2]
+    relay_trace_dir = str(plan.get("host_local_acp_relay_trace_dir") or "")
     if args.route == "codex-app-server-goal-baseline":
         worker_trace_dir = str(plan.get("app_server_goal_worker_trace_dir") or "")
         command.extend(
@@ -682,8 +683,12 @@ def _host_local_acp_launch_command(
         )
         if worker_trace_dir:
             command.extend(["--worker-public-trace-dir", worker_trace_dir])
+    elif relay_trace_dir:
+        command.extend(["--worker-public-trace-dir", relay_trace_dir])
     command.extend(
         [
+            "--route",
+            args.route,
             "--codex-bin",
             args.local_codex_bin,
             "--sandbox",
@@ -694,6 +699,23 @@ def _host_local_acp_launch_command(
     )
     if args.model:
         command.extend(["--model", args.model])
+    if (
+        args.route in {"raw-codex-autonomous-max5", "loopx-product-mode"}
+        and args.host_local_acp_launch
+        and args.remote_command_file_bridge_probe_command
+        and (
+            args.remote_command_file_bridge_ready
+            or args.remote_command_file_bridge_probe
+        )
+    ):
+        command.extend(
+            [
+                "--remote-command-file-bridge-command",
+                args.remote_command_file_bridge_probe_command,
+                "--remote-command-file-bridge-timeout-sec",
+                str(args.remote_command_file_bridge_probe_timeout_sec),
+            ]
+        )
     return command
 
 
@@ -830,6 +852,7 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "benchflow_user_loop_recovery_stage",
         "benchflow_intermediate_soft_verify_policy",
         "benchflow_setup_stall_cleanup_status",
+        "remote_command_file_bridge_consumption_status",
     ):
         raw = value.get(field)
         if isinstance(raw, str) and raw:
@@ -843,6 +866,12 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "container_codex_acp_install_skipped",
         "benchflow_agent_install_skipped_by_runtime_layer",
         "remote_command_file_bridge_materialized",
+        "remote_command_file_bridge_command_configured",
+        "remote_command_file_bridge_solver_wiring_configured",
+        "remote_command_file_bridge_consumed_by_solver",
+        "remote_command_file_bridge_solver_trace_dir_present",
+        "remote_command_file_bridge_solver_public_trace_read",
+        "remote_command_file_bridge_solver_raw_material_recorded",
         "preinstalled_benchflow_agent_runtime_required",
         "benchflow_agent_runtime_layer_ready",
         "codex_acp_runtime_dependency_setup_skipped",
@@ -899,6 +928,9 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "benchflow_setup_stall_cleanup_term_sent_count",
         "benchflow_setup_stall_cleanup_kill_sent_count",
         "benchflow_setup_stall_cleanup_alive_after_count",
+        "remote_command_file_bridge_solver_trace_count",
+        "remote_command_file_bridge_solver_probe_ready_count",
+        "remote_command_file_bridge_solver_operation_count",
     ):
         if isinstance(value.get(field), int) and not isinstance(value.get(field), bool):
             compact[field] = value[field]
@@ -2353,6 +2385,9 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
     app_server_goal_worker_trace_dir = (
         jobs_dir / job_name / "app_server_goal_worker_traces"
     )
+    host_local_acp_relay_trace_dir = (
+        jobs_dir / job_name / "host_local_acp_relay_traces"
+    )
     task_path = Path(args.skillsbench_root).expanduser() / "tasks" / task_id
     setup_preflight = skillsbench_task_setup_preflight(
         task_path=task_path,
@@ -2366,12 +2401,24 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
         args.remote_command_file_bridge_ready
         or args.remote_command_file_bridge_probe
     )
-    remote_command_file_bridge_consumed_by_solver = False
-    remote_command_file_bridge_consumption_status = (
-        "probe_only_not_solver_wired"
-        if remote_command_file_bridge_materialized
-        else "missing"
+    remote_command_file_bridge_command_configured = bool(
+        args.remote_command_file_bridge_probe_command
     )
+    remote_command_file_bridge_solver_wiring_configured = bool(
+        args.host_local_acp_launch
+        and route in {"raw-codex-autonomous-max5", "loopx-product-mode"}
+        and remote_command_file_bridge_materialized
+        and remote_command_file_bridge_command_configured
+    )
+    remote_command_file_bridge_consumed_by_solver = False
+    if remote_command_file_bridge_solver_wiring_configured:
+        remote_command_file_bridge_consumption_status = (
+            "solver_wiring_configured_pending_prompt"
+        )
+    elif remote_command_file_bridge_materialized:
+        remote_command_file_bridge_consumption_status = "probe_only_not_solver_wired"
+    else:
+        remote_command_file_bridge_consumption_status = "missing"
     app_server_goal_worker_contract = (
         build_skillsbench_app_server_goal_worker_contract(
             dataset=args.dataset,
@@ -2428,6 +2475,11 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
         "app_server_goal_worker_trace_dir": (
             str(app_server_goal_worker_trace_dir)
             if is_app_server_goal_route
+            else ""
+        ),
+        "host_local_acp_relay_trace_dir": (
+            str(host_local_acp_relay_trace_dir)
+            if args.host_local_acp_launch and not is_app_server_goal_route
             else ""
         ),
         "ledger_path": str(Path(args.ledger_path).expanduser()),
@@ -2505,12 +2557,24 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
             "remote_command_file_bridge_materialized": bool(
                 remote_command_file_bridge_materialized
             ),
+            "remote_command_file_bridge_command_configured": bool(
+                remote_command_file_bridge_command_configured
+            ),
+            "remote_command_file_bridge_solver_wiring_configured": bool(
+                remote_command_file_bridge_solver_wiring_configured
+            ),
             "remote_command_file_bridge_consumed_by_solver": (
                 remote_command_file_bridge_consumed_by_solver
             ),
             "remote_command_file_bridge_consumption_status": (
                 remote_command_file_bridge_consumption_status
             ),
+            "remote_command_file_bridge_solver_trace_dir_present": False,
+            "remote_command_file_bridge_solver_public_trace_read": False,
+            "remote_command_file_bridge_solver_raw_material_recorded": False,
+            "remote_command_file_bridge_solver_trace_count": 0,
+            "remote_command_file_bridge_solver_probe_ready_count": 0,
+            "remote_command_file_bridge_solver_operation_count": 0,
             "preinstalled_benchflow_agent_runtime_required": (
                 requires_preinstalled_runtime
             ),
@@ -3121,6 +3185,118 @@ def _merge_app_server_goal_worker_trace_summary(
     trace["native_goal_worker_raw_material_recorded"] = raw_material_recorded
     if worker_trace_count:
         trace["last_decision"] = "host_app_server_goal_worker_trace_recorded"
+
+
+def _merge_host_local_acp_relay_trace_summary(
+    plan: dict[str, Any],
+    trace: dict[str, Any] | None,
+) -> None:
+    if not isinstance(trace, dict):
+        return
+    raw_trace_dir = plan.get("host_local_acp_relay_trace_dir")
+    if not isinstance(raw_trace_dir, str) or not raw_trace_dir.strip():
+        return
+    trace_dir = Path(raw_trace_dir)
+    files = sorted(trace_dir.glob("*.compact.json")) if trace_dir.exists() else []
+    solver_trace_count = 0
+    probe_ready_count = 0
+    operation_count = 0
+    raw_material_recorded = False
+    for path in files:
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if (
+            payload.get("schema_version")
+            != "skillsbench_host_local_acp_relay_public_trace_v0"
+        ):
+            continue
+        if payload.get("trace_kind") != "remote_command_file_bridge_solver_consumption":
+            continue
+        bridge = (
+            payload.get("remote_command_file_bridge")
+            if isinstance(payload.get("remote_command_file_bridge"), dict)
+            else {}
+        )
+        solver_trace_count += 1
+        if bridge.get("probe_ready") is True:
+            probe_ready_count += 1
+        bridge_operations = bridge.get("operation_count")
+        if isinstance(bridge_operations, int) and not isinstance(
+            bridge_operations, bool
+        ):
+            operation_count += max(0, bridge_operations)
+        boundary = (
+            payload.get("boundary")
+            if isinstance(payload.get("boundary"), dict)
+            else {}
+        )
+        raw_material_recorded = raw_material_recorded or any(
+            boundary.get(field) is True
+            for field in (
+                "raw_command_recorded",
+                "raw_stdout_recorded",
+                "raw_stderr_recorded",
+                "raw_task_text_recorded",
+                "raw_logs_recorded",
+                "raw_trajectory_recorded",
+                "credential_values_recorded",
+                "host_paths_recorded",
+                "remote_paths_recorded",
+                "upload_performed",
+                "submit_performed",
+            )
+        )
+    consumed_by_solver = solver_trace_count > 0 and probe_ready_count > 0
+    trace["remote_command_file_bridge_solver_trace_dir_present"] = trace_dir.exists()
+    trace["remote_command_file_bridge_solver_public_trace_read"] = (
+        solver_trace_count > 0
+    )
+    trace["remote_command_file_bridge_consumed_by_solver"] = consumed_by_solver
+    trace["remote_command_file_bridge_solver_trace_count"] = solver_trace_count
+    trace["remote_command_file_bridge_solver_probe_ready_count"] = probe_ready_count
+    trace["remote_command_file_bridge_solver_operation_count"] = operation_count
+    trace["remote_command_file_bridge_solver_raw_material_recorded"] = (
+        raw_material_recorded
+    )
+    prerequisites = plan.setdefault("runner_prerequisites", {})
+    prerequisites["remote_command_file_bridge_solver_trace_dir_present"] = (
+        trace_dir.exists()
+    )
+    prerequisites["remote_command_file_bridge_solver_public_trace_read"] = (
+        solver_trace_count > 0
+    )
+    prerequisites["remote_command_file_bridge_consumed_by_solver"] = (
+        consumed_by_solver
+    )
+    prerequisites["remote_command_file_bridge_solver_trace_count"] = (
+        solver_trace_count
+    )
+    prerequisites["remote_command_file_bridge_solver_probe_ready_count"] = (
+        probe_ready_count
+    )
+    prerequisites["remote_command_file_bridge_solver_operation_count"] = (
+        operation_count
+    )
+    prerequisites["remote_command_file_bridge_solver_raw_material_recorded"] = (
+        raw_material_recorded
+    )
+    if consumed_by_solver:
+        prerequisites["remote_command_file_bridge_consumption_status"] = (
+            "solver_prompt_probe_ready"
+        )
+        trace["last_decision"] = "remote_command_file_bridge_solver_trace_recorded"
+    elif solver_trace_count:
+        prerequisites["remote_command_file_bridge_consumption_status"] = (
+            "solver_prompt_probe_failed"
+        )
+    elif prerequisites.get("remote_command_file_bridge_solver_wiring_configured"):
+        prerequisites["remote_command_file_bridge_consumption_status"] = (
+            "solver_trace_missing"
+        )
 
 
 def _round_count_key(round_index: int) -> str:
@@ -4549,6 +4725,7 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
             )
         _merge_acp_trajectory_summary(plan, controller_trace)
         _merge_app_server_goal_worker_trace_summary(plan, controller_trace)
+        _merge_host_local_acp_relay_trace_summary(plan, controller_trace)
         _write_controller_trace(plan, controller_trace)
     if result_path is None:
         result_path = discover_benchflow_result_path(plan)
@@ -4572,6 +4749,7 @@ def reduce_result(
     controller_trace = _read_controller_trace(plan)
     _merge_acp_trajectory_summary(plan, controller_trace)
     _merge_app_server_goal_worker_trace_summary(plan, controller_trace)
+    _merge_host_local_acp_relay_trace_summary(plan, controller_trace)
     _write_controller_trace(plan, controller_trace)
 
     benchmark_run = build_skillsbench_benchflow_result_benchmark_run(
@@ -5443,12 +5621,19 @@ def main(argv: list[str] | None = None) -> int:
             }
             print(json.dumps(payload, indent=2, sort_keys=True), file=sys.stderr)
             return 2
+    product_host_local_bridge_materialized = bool(
+        args.remote_command_file_bridge_ready
+        or args.remote_command_file_bridge_probe
+    )
+    product_host_local_bridge_command_configured = bool(
+        args.remote_command_file_bridge_probe_command
+    )
     if (
         args.route in {"raw-codex-autonomous-max5", "loopx-product-mode"}
         and args.host_local_acp_launch
-        and (
-            args.remote_command_file_bridge_ready
-            or args.remote_command_file_bridge_probe
+        and not (
+            product_host_local_bridge_materialized
+            and product_host_local_bridge_command_configured
         )
         and not args.local_driver_worker_handshake_preflight
         and not args.plan_only
@@ -5458,17 +5643,23 @@ def main(argv: list[str] | None = None) -> int:
             "error_type": "SkillsBenchReverseChannelBridgeNotSolverWired",
             "route": args.route,
             "reason": (
-                "the remote command/file bridge probe is materialized, but this "
-                "product-mode host-local ACP route does not yet pass that bridge "
-                "into the solver turn; launching would only prove the relay/probe "
-                "layer, not a countable reverse-channel treatment"
+                "product-mode host-local ACP runs execute Codex on the host while "
+                "the scored workspace lives in the BenchFlow sandbox; a materialized "
+                "remote command/file bridge and its private solver command are both "
+                "required before this is a countable reverse-channel treatment"
             ),
             "next_action": (
                 "wire the remote command/file bridge into the solver worker or "
                 "use a route whose compact public trace proves nonzero bridge "
                 "read/write during the agent turn before launching a scored case"
             ),
-            "remote_command_file_bridge_materialized": True,
+            "remote_command_file_bridge_materialized": (
+                product_host_local_bridge_materialized
+            ),
+            "remote_command_file_bridge_command_configured": (
+                product_host_local_bridge_command_configured
+            ),
+            "remote_command_file_bridge_solver_wiring_configured": False,
             "remote_command_file_bridge_consumed_by_solver": False,
             "raw_logs_recorded": False,
             "raw_task_text_read": False,

--- a/scripts/skillsbench_local_acp_relay.py
+++ b/scripts/skillsbench_local_acp_relay.py
@@ -37,6 +37,11 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help="Optional model passed to local codex exec.",
     )
     parser.add_argument(
+        "--route",
+        default="unknown",
+        help="Public route label used in compact relay trace files.",
+    )
+    parser.add_argument(
         "--timeout-sec",
         type=int,
         default=7200,
@@ -93,10 +98,26 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "--worker-public-trace-dir",
         default=None,
         help=(
-            "Optional directory for public-safe host app-server Goal worker "
-            "compact traces. Response text and raw app-server streams are not "
-            "written there."
+            "Optional directory for public-safe relay or host app-server Goal "
+            "worker compact traces. Response text, bridge commands, raw "
+            "stdout/stderr, and raw app-server streams are not written there."
         ),
+    )
+    parser.add_argument(
+        "--remote-command-file-bridge-command",
+        default=None,
+        help=(
+            "Private command used by host-local ACP product-mode runs to reach "
+            "the scored SkillsBench sandbox through a bounded command/file "
+            "bridge. The command is injected only into the private solver "
+            "prompt and is never written to public compact traces."
+        ),
+    )
+    parser.add_argument(
+        "--remote-command-file-bridge-timeout-sec",
+        type=float,
+        default=10.0,
+        help="Timeout for the per-prompt remote command/file bridge readiness probe.",
     )
     return parser.parse_args(argv)
 
@@ -108,6 +129,7 @@ def main(argv: list[str] | None = None) -> int:
             codex_bin=args.codex_bin,
             sandbox=args.sandbox,
             model=args.model,
+            route=args.route,
             timeout_sec=args.timeout_sec,
             dry_run_response=args.dry_run_response,
             app_server_goal_worker=args.app_server_goal_worker,
@@ -119,6 +141,12 @@ def main(argv: list[str] | None = None) -> int:
             worker_script=args.worker_script,
             stream_heartbeat_interval_sec=args.stream_heartbeat_interval_sec,
             worker_public_trace_dir=args.worker_public_trace_dir,
+            remote_command_file_bridge_command=(
+                args.remote_command_file_bridge_command
+            ),
+            remote_command_file_bridge_timeout_sec=(
+                args.remote_command_file_bridge_timeout_sec
+            ),
         )
     )
     return relay.serve()


### PR DESCRIPTION
## Summary
- pass the SkillsBench remote command/file bridge into host-local ACP solver turns for product-mode routes
- publish public-safe solver bridge consumption traces and reduce them into controller/compact counters
- keep full host-local product-mode launches fail-closed unless both bridge materialization and solver command wiring are configured

## Validation
- python3 -m py_compile loopx/benchmark_adapters/skillsbench_acp_relay.py scripts/skillsbench_local_acp_relay.py scripts/skillsbench_automation_loop.py loopx/benchmark_adapters/skillsbench.py loopx/status.py examples/skillsbench-host-local-launch-plan-smoke.py
- python3 examples/skillsbench-host-local-launch-plan-smoke.py
- python3 examples/skillsbench-benchmark-run-smoke.py
- git diff --check
- loopx check --scan-path loopx/benchmark_adapters/skillsbench_acp_relay.py --scan-path scripts/skillsbench_local_acp_relay.py --scan-path scripts/skillsbench_automation_loop.py --scan-path loopx/benchmark_adapters/skillsbench.py --scan-path loopx/status.py --scan-path examples/skillsbench-host-local-launch-plan-smoke.py