### PR TITLE
Add issue fix acceptance loop fixture

### DIFF
--- a/docs/reference/protocols/README.md
+++ b/docs/reference/protocols/README.md
@@ -14,4 +14,5 @@ Current contracts:
 - [Action packet router comparison v0](protocol-action-packet-router-comparison-v0.md)
 - [task_graph_projection_v0](task-graph-projection-v0.md)
 - [content_ops_surface_v0](content-ops-surface-v0.md)
+- [issue_fix_acceptance_loop_v0](issue-fix-acceptance-loop-v0.md)
 - [cs_notes_explore_capability_map_v0](cs-notes-explore-capability-map-v0.md)

--- a/docs/reference/protocols/content-ops-surface-v0.md
+++ b/docs/reference/protocols/content-ops-surface-v0.md
@@ -182,6 +182,18 @@ emits a `loopx_todo_writeback_preview_v0` candidate for the agent todo, but it
 does not write the todo unless a later command explicitly executes that
 writeback.
 
+Metadata preview is only the intake surface. The issue-fix product path should
+continue to an executable acceptance loop:
+
+```bash
+loopx issue-fix acceptance-fixture --format json
+```
+
+That command returns `issue_fix_acceptance_loop_v0` with a validated fix
+artifact: failing repro, minimal patch, passing focused validation, and a
+PR-review-ready evidence packet. See
+[`issue_fix_acceptance_loop_v0`](issue-fix-acceptance-loop-v0.md).
+
 The first reusable public connector adapter is the public-handle observation
 command:
 

--- a/docs/reference/protocols/issue-fix-acceptance-loop-v0.md
+++ b/docs/reference/protocols/issue-fix-acceptance-loop-v0.md
@@ -1,0 +1,70 @@
+# issue_fix_acceptance_loop_v0
+
+`issue_fix_acceptance_loop_v0` is the first executable LoopX protocol for repo
+issue fix work. Its goal is acceptance, not display: given a public issue/PR
+metadata signal, the loop must prove that an agent can move from signal to a
+validated fix artifact.
+
+The initial implementation is a deterministic fixture command:
+
+```bash
+loopx issue-fix acceptance-fixture --format json
+```
+
+The command creates a temporary fixture workspace, runs a focused repro that
+fails, applies a minimal code patch, reruns the same focused validation, and
+returns an `issue_fix_validated_fix_artifact_v0`. The artifact is ready only
+when the repro failed before the patch and validation passed after the patch.
+
+## Product Contract
+
+The user-facing value is the validated repair path:
+
+1. public metadata intake establishes the repo/issue signal without copying
+   issue body text or comment body text;
+2. a repro command proves the bug is currently present;
+3. a code route names the files and reason for the minimal patch;
+4. the patch is applied in the fixture workspace;
+5. focused validation passes;
+6. a PR-review packet is ready, but no external comment, PR creation, merge, or
+   publish action is performed by this fixture.
+
+This keeps the protocol useful for automation while preserving safe defaults.
+The packet is evidence of a completed repair loop, not a substitute for the
+repair loop.
+
+## Public-Safe Fields
+
+The top-level packet must report:
+
+- `external_reads_performed: false`
+- `external_writes_performed: false`
+- `issue_body_captured: false`
+- `comment_bodies_captured: false`
+- `local_paths_captured: false`
+- `private_repo_state_read: false`
+- `destructive_git_used: false`
+
+Validation command output is summarized with pass/fail and exit code only. The
+fixture does not expose stdout, stderr, local temporary paths, or raw provider
+payloads in the artifact.
+
+## Next Promotion
+
+The next implementation step is a real repo-local branch mode. It should accept
+a public issue URL plus an already-approved local repository, create or claim an
+issue branch, derive or run a focused repro, patch code through the agent, run
+validation, and prepare PR evidence. That mode may perform local repository
+reads and branch writes, but it still must not post external comments, create a
+PR, merge, or publish without the caller choosing that action explicitly.
+
+## Smoke
+
+The durable smoke is:
+
+```bash
+python3 examples/issue-fix-acceptance-loop-smoke.py
+```
+
+It exercises the CLI, checks the failure-before/fix-after validation sequence,
+and rejects local path exposure in the public artifact.

--- a/examples/cli-command-module-size-ownership-command-modularization-smoke.py
+++ b/examples/cli-command-module-size-ownership-command-modularization-smoke.py
@@ -49,7 +49,7 @@ STARTER_COMMAND_OWNERS = {
 }
 
 ADD_PARSER_RE = re.compile(
-    r"\.add_parser\(\s*(?:\n\s*)?[\"'](?P<command>[^\"']+)[\"']",
+    r"(?P<receiver>\w+)\.add_parser\(\s*(?:\n\s*)?[\"'](?P<command>[^\"']+)[\"']",
     re.MULTILINE,
 )
 
@@ -105,6 +105,8 @@ def command_registrations() -> dict[str, list[str]]:
     registrations: dict[str, list[str]] = {}
     for path in python_modules():
         for match in ADD_PARSER_RE.finditer(source(path)):
+            if match.group("receiver") != "subparsers":
+                continue
             registrations.setdefault(match.group("command"), []).append(path.name)
     return registrations
 

--- a/examples/issue-fix-acceptance-loop-smoke.py
+++ b/examples/issue-fix-acceptance-loop-smoke.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run_json_command() -> dict[str, Any]:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "issue-fix",
+            "acceptance-fixture",
+            "--format",
+            "json",
+            "--url",
+            "https://github.com/huangruiteng/loopx/issues/123",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+    if result.stderr.strip():
+        raise AssertionError(f"unexpected stderr: {result.stderr}")
+    payload = json.loads(result.stdout)
+    if not isinstance(payload, dict):
+        raise AssertionError("issue-fix acceptance fixture must emit a JSON object")
+    return payload
+
+
+def _walk_values(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, dict):
+        strings: list[str] = []
+        for child in value.values():
+            strings.extend(_walk_values(child))
+        return strings
+    if isinstance(value, list):
+        strings = []
+        for child in value:
+            strings.extend(_walk_values(child))
+        return strings
+    return []
+
+
+def _assert_no_local_paths(payload: dict[str, Any]) -> None:
+    joined = "\n".join(_walk_values(payload))
+    blocked_markers = ("/tmp/", "/private/", str(ROOT))
+    found = [marker for marker in blocked_markers if marker and marker in joined]
+    if found:
+        raise AssertionError(f"fixture artifact exposed local path markers: {found}")
+
+
+def main() -> int:
+    payload = _run_json_command()
+    assert payload["ok"] is True
+    assert payload["schema_version"] == "issue_fix_acceptance_loop_v0"
+    assert payload["external_reads_performed"] is False
+    assert payload["external_writes_performed"] is False
+    assert payload["local_paths_captured"] is False
+    assert payload["destructive_git_used"] is False
+
+    artifact = payload["validated_fix_artifact"]
+    assert artifact["schema_version"] == "issue_fix_validated_fix_artifact_v0"
+    assert artifact["fix_artifact_ready"] is True
+    assert artifact["pr_review_packet_ready"] is True
+    assert artifact["issue_signal"]["body_captured"] is False
+    assert artifact["issue_signal"]["comment_bodies_captured"] is False
+
+    repro_before = artifact["repro_before"]
+    validation_after = artifact["validation_after"]
+    patch = artifact["patch"]
+    assert repro_before["passed"] is False
+    assert repro_before["stdout_captured"] is False
+    assert repro_before["stderr_captured"] is False
+    assert validation_after["passed"] is True
+    assert validation_after["stdout_captured"] is False
+    assert validation_after["stderr_captured"] is False
+    assert patch["patch_applied"] is True
+    assert patch["file"] == "calculator.py"
+    assert patch["local_path_captured"] is False
+    assert patch["destructive_git_used"] is False
+
+    review = artifact["review_packet"]
+    assert review["ready"] is True
+    assert review["external_issue_comment_performed"] is False
+    assert review["external_pr_created"] is False
+    assert review["merge_performed"] is False
+    assert payload["validation"]["ok"] is True
+    _assert_no_local_paths(payload)
+
+    markdown = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "issue-fix",
+            "acceptance-fixture",
+            "--format",
+            "markdown",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    ).stdout
+    assert "LoopX Issue Fix Acceptance Loop" in markdown
+    assert "Validated Fix Artifact" in markdown
+    assert "validation_after_passed: `True`" in markdown
+    print("issue-fix-acceptance-loop-smoke: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -15,6 +15,7 @@ from .cli_commands import (
     handle_doctor_command,
     handle_dreaming_command,
     handle_history_command,
+    handle_issue_fix_command,
     handle_ml_experiment_command,
     handle_project_lifecycle_command,
     handle_quota_command,
@@ -31,6 +32,7 @@ from .cli_commands import (
     register_doctor_command,
     register_dreaming_commands,
     register_history_command,
+    register_issue_fix_commands,
     register_ml_experiment_commands,
     register_project_lifecycle_commands,
     register_quota_command,
@@ -112,6 +114,8 @@ def main(argv: list[str] | None = None) -> int:
     register_support_control_commands(sub, add_subcommand_format)
 
     register_content_ops_commands(sub, add_subcommand_format)
+
+    register_issue_fix_commands(sub, add_subcommand_format)
 
     register_ml_experiment_commands(sub, add_subcommand_format)
 
@@ -207,6 +211,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "content-ops":
         return handle_content_ops_command(args, output_format=output_format, print_payload=print_payload)
+
+    if args.command == "issue-fix":
+        return handle_issue_fix_command(args, output_format=output_format, print_payload=print_payload)
 
     registry_admin_result = handle_registry_admin_command(
         args,

--- a/loopx/cli_commands/__init__.py
+++ b/loopx/cli_commands/__init__.py
@@ -80,6 +80,7 @@ from .content_ops import handle_content_ops_command, register_content_ops_comman
 from .doctor import handle_doctor_command, register_doctor_command
 from .dreaming import handle_dreaming_command, register_dreaming_commands
 from .history import handle_history_command, register_history_command
+from .issue_fix import handle_issue_fix_command, register_issue_fix_commands
 from .ml_experiment import handle_ml_experiment_command, register_ml_experiment_commands
 from .project_lifecycle import (
     handle_project_lifecycle_command,
@@ -195,6 +196,7 @@ __all__ = [
     "handle_doctor_command",
     "handle_dreaming_command",
     "handle_history_command",
+    "handle_issue_fix_command",
     "handle_ml_experiment_command",
     "handle_new_project_prompt_command",
     "handle_project_lifecycle_command",
@@ -234,6 +236,7 @@ __all__ = [
     "register_doctor_command",
     "register_dreaming_commands",
     "register_history_command",
+    "register_issue_fix_commands",
     "register_ml_experiment_commands",
     "register_project_lifecycle_commands",
     "register_quota_command",

--- a/loopx/cli_commands/content_ops.py
+++ b/loopx/cli_commands/content_ops.py
@@ -23,11 +23,9 @@ from ..content_ops_surface import (
     render_content_ops_public_handle_observation_markdown,
     render_content_ops_walkthrough_artifact_markdown,
 )
-from ..issue_fix_intake_surface import (
-    build_content_ops_issue_fix_intake_packet,
-    build_content_ops_issue_fix_metadata_preview_packet,
-    render_content_ops_issue_fix_intake_markdown,
-    render_content_ops_issue_fix_metadata_preview_markdown,
+from .content_ops_issue_fix import (
+    handle_content_ops_issue_fix_command,
+    register_content_ops_issue_fix_commands,
 )
 
 
@@ -99,71 +97,7 @@ def register_content_ops_commands(
         default="2026-06-23T00:00:00Z",
         help="Public-safe generated_at timestamp for the exploration plan.",
     )
-    issue_fix_parser = content_ops_sub.add_parser(
-        "issue-fix-intake",
-        help=(
-            "Build a fixture-only issue_fix_intake_v0 packet from public "
-            "GitHub issue/PR metadata."
-        ),
-    )
-    add_subcommand_format(issue_fix_parser)
-    issue_fix_parser.add_argument(
-        "--repo",
-        default="public_repo_fixture",
-        help="Public-safe repository label for the metadata fixture.",
-    )
-    issue_fix_parser.add_argument(
-        "--issue-ref",
-        default="issue_123_public_metadata_fixture",
-        help="Public-safe issue or PR reference label for the metadata fixture.",
-    )
-    issue_fix_parser.add_argument(
-        "--issue-state",
-        default="open",
-        choices=("open", "closed", "unknown"),
-        help="Public issue state to project into the fixture.",
-    )
-    issue_fix_parser.add_argument(
-        "--generated-at",
-        default="2026-06-23T00:00:00Z",
-        help="Public-safe generated_at timestamp for the issue-fix intake.",
-    )
-    issue_fix_metadata_parser = content_ops_sub.add_parser(
-        "issue-fix-metadata-preview",
-        help=(
-            "Preview public GitHub issue/PR metadata intake with mocked provider "
-            "data and gated body/comment fields."
-        ),
-    )
-    add_subcommand_format(issue_fix_metadata_parser)
-    issue_fix_metadata_parser.add_argument(
-        "--repo",
-        default="public_repo_fixture",
-        help="Public-safe repository label for the metadata preview.",
-    )
-    issue_fix_metadata_parser.add_argument(
-        "--issue-ref",
-        default="issue_123_public_metadata_fixture",
-        help="Public-safe issue or PR reference label for the metadata preview.",
-    )
-    issue_fix_metadata_parser.add_argument(
-        "--url",
-        default=None,
-        help="Optional https://github.com/owner/repo/issues/123 or /pull/123 URL.",
-    )
-    issue_fix_metadata_parser.add_argument(
-        "--metadata-json",
-        default=None,
-        help=(
-            "Path to mocked provider JSON metadata, or '-' for stdin. "
-            "Body/comment fields stay gated and are not copied."
-        ),
-    )
-    issue_fix_metadata_parser.add_argument(
-        "--generated-at",
-        default="2026-06-23T00:00:00Z",
-        help="Public-safe generated_at timestamp for the metadata preview.",
-    )
+    register_content_ops_issue_fix_commands(content_ops_sub, add_subcommand_format)
     observe_parser = content_ops_sub.add_parser(
         "observe-public-handle",
         help="Observe a public platform handle as metadata-only source_item_v0.",
@@ -425,7 +359,10 @@ def handle_content_ops_command(
     print_payload: PrintPayload,
 ) -> int:
     try:
-        if args.content_ops_command == "preview":
+        issue_fix_result = handle_content_ops_issue_fix_command(args)
+        if issue_fix_result is not None:
+            payload, renderer = issue_fix_result
+        elif args.content_ops_command == "preview":
             payload = build_content_ops_preview_packet(generated_at=args.generated_at)
             renderer = render_content_ops_preview_markdown
         elif args.content_ops_command == "exploration-plan":
@@ -434,25 +371,6 @@ def handle_content_ops_command(
                 generated_at=args.generated_at,
             )
             renderer = render_content_ops_exploration_plan_markdown
-        elif args.content_ops_command == "issue-fix-intake":
-            payload = build_content_ops_issue_fix_intake_packet(
-                repo=args.repo,
-                issue_ref=args.issue_ref,
-                issue_state=args.issue_state,
-                generated_at=args.generated_at,
-            )
-            renderer = render_content_ops_issue_fix_intake_markdown
-        elif args.content_ops_command == "issue-fix-metadata-preview":
-            payload = build_content_ops_issue_fix_metadata_preview_packet(
-                repo=args.repo,
-                issue_ref=args.issue_ref,
-                url=args.url,
-                provider_payload=_load_json_object(args.metadata_json)
-                if args.metadata_json
-                else None,
-                generated_at=args.generated_at,
-            )
-            renderer = render_content_ops_issue_fix_metadata_preview_markdown
         elif args.content_ops_command == "observe-public-handle":
             payload = build_content_ops_public_handle_observation_packet(
                 url=args.url,

--- a/loopx/cli_commands/content_ops_issue_fix.py
+++ b/loopx/cli_commands/content_ops_issue_fix.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from ..issue_fix_intake_surface import (
+    build_content_ops_issue_fix_intake_packet,
+    build_content_ops_issue_fix_metadata_preview_packet,
+    render_content_ops_issue_fix_intake_markdown,
+    render_content_ops_issue_fix_metadata_preview_markdown,
+)
+
+
+Renderer = Callable[[dict[str, object]], str]
+AddFormat = Callable[[argparse.ArgumentParser], None]
+
+
+def _load_json_object(path_text: str) -> dict[str, Any]:
+    if path_text == "-":
+        payload = json.loads(sys.stdin.read())
+    else:
+        payload = json.loads(Path(path_text).expanduser().read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path_text} must contain a JSON object")
+    return payload
+
+
+def register_content_ops_issue_fix_commands(
+    content_ops_subparsers: argparse._SubParsersAction,
+    add_subcommand_format: AddFormat,
+) -> None:
+    issue_fix_parser = content_ops_subparsers.add_parser(
+        "issue-fix-intake",
+        help=(
+            "Build a fixture-only issue_fix_intake_v0 packet from public "
+            "GitHub issue/PR metadata."
+        ),
+    )
+    add_subcommand_format(issue_fix_parser)
+    issue_fix_parser.add_argument(
+        "--repo",
+        default="public_repo_fixture",
+        help="Public-safe repository label for the metadata fixture.",
+    )
+    issue_fix_parser.add_argument(
+        "--issue-ref",
+        default="issue_123_public_metadata_fixture",
+        help="Public-safe issue or PR reference label for the metadata fixture.",
+    )
+    issue_fix_parser.add_argument(
+        "--issue-state",
+        default="open",
+        choices=("open", "closed", "unknown"),
+        help="Public issue state to project into the fixture.",
+    )
+    issue_fix_parser.add_argument(
+        "--generated-at",
+        default="2026-06-23T00:00:00Z",
+        help="Public-safe generated_at timestamp for the issue-fix intake.",
+    )
+
+    issue_fix_metadata_parser = content_ops_subparsers.add_parser(
+        "issue-fix-metadata-preview",
+        help=(
+            "Preview public GitHub issue/PR metadata intake with mocked provider "
+            "data and gated body/comment fields."
+        ),
+    )
+    add_subcommand_format(issue_fix_metadata_parser)
+    issue_fix_metadata_parser.add_argument(
+        "--repo",
+        default="public_repo_fixture",
+        help="Public-safe repository label for the metadata preview.",
+    )
+    issue_fix_metadata_parser.add_argument(
+        "--issue-ref",
+        default="issue_123_public_metadata_fixture",
+        help="Public-safe issue or PR reference label for the metadata preview.",
+    )
+    issue_fix_metadata_parser.add_argument(
+        "--url",
+        default=None,
+        help="Optional https://github.com/owner/repo/issues/123 or /pull/123 URL.",
+    )
+    issue_fix_metadata_parser.add_argument(
+        "--metadata-json",
+        default=None,
+        help=(
+            "Path to mocked provider JSON metadata, or '-' for stdin. "
+            "Body/comment fields stay gated and are not copied."
+        ),
+    )
+    issue_fix_metadata_parser.add_argument(
+        "--generated-at",
+        default="2026-06-23T00:00:00Z",
+        help="Public-safe generated_at timestamp for the metadata preview.",
+    )
+
+
+def handle_content_ops_issue_fix_command(
+    args: argparse.Namespace,
+) -> tuple[dict[str, object], Renderer] | None:
+    if args.content_ops_command == "issue-fix-intake":
+        return (
+            build_content_ops_issue_fix_intake_packet(
+                repo=args.repo,
+                issue_ref=args.issue_ref,
+                issue_state=args.issue_state,
+                generated_at=args.generated_at,
+            ),
+            render_content_ops_issue_fix_intake_markdown,
+        )
+    if args.content_ops_command == "issue-fix-metadata-preview":
+        return (
+            build_content_ops_issue_fix_metadata_preview_packet(
+                repo=args.repo,
+                issue_ref=args.issue_ref,
+                url=args.url,
+                provider_payload=_load_json_object(args.metadata_json)
+                if args.metadata_json
+                else None,
+                generated_at=args.generated_at,
+            ),
+            render_content_ops_issue_fix_metadata_preview_markdown,
+        )
+    return None

--- a/loopx/cli_commands/issue_fix.py
+++ b/loopx/cli_commands/issue_fix.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+
+from ..issue_fix_acceptance_loop import (
+    build_issue_fix_acceptance_fixture_packet,
+    render_issue_fix_acceptance_loop_markdown,
+)
+
+
+PrintPayload = Callable[
+    [dict[str, object], str, Callable[[dict[str, object]], str]],
+    None,
+]
+FormatSelector = Callable[..., str]
+AddFormat = Callable[[argparse.ArgumentParser], None]
+
+
+def register_issue_fix_commands(
+    subparsers: argparse._SubParsersAction,
+    add_subcommand_format: AddFormat,
+) -> None:
+    issue_fix_parser = subparsers.add_parser(
+        "issue-fix",
+        help="Run public-safe issue fix acceptance loops.",
+    )
+    issue_fix_sub = issue_fix_parser.add_subparsers(
+        dest="issue_fix_command",
+        required=True,
+    )
+    acceptance_parser = issue_fix_sub.add_parser(
+        "acceptance-fixture",
+        help=(
+            "Run a deterministic fix loop: failing repro, minimal patch, "
+            "focused validation, and PR-review-ready artifact."
+        ),
+    )
+    add_subcommand_format(acceptance_parser)
+    acceptance_parser.add_argument(
+        "--repo",
+        default="public_repo_fixture",
+        help="Public-safe repository label for the issue metadata fixture.",
+    )
+    acceptance_parser.add_argument(
+        "--issue-ref",
+        default="issue_123_public_metadata_fixture",
+        help="Public-safe issue or PR reference label for the fixture.",
+    )
+    acceptance_parser.add_argument(
+        "--url",
+        default=None,
+        help="Optional public GitHub issue or PR URL for metadata parsing.",
+    )
+    acceptance_parser.add_argument(
+        "--generated-at",
+        default="2026-06-23T00:00:00Z",
+        help="Public-safe generated_at timestamp for the fixture artifact.",
+    )
+
+
+def handle_issue_fix_command(
+    args: argparse.Namespace,
+    *,
+    output_format: FormatSelector,
+    print_payload: PrintPayload,
+) -> int:
+    try:
+        if args.issue_fix_command == "acceptance-fixture":
+            payload = build_issue_fix_acceptance_fixture_packet(
+                repo=args.repo,
+                issue_ref=args.issue_ref,
+                url=args.url,
+                generated_at=args.generated_at,
+            )
+            renderer = render_issue_fix_acceptance_loop_markdown
+        else:
+            raise ValueError("issue-fix requires `acceptance-fixture`")
+    except Exception as exc:
+        payload = {
+            "ok": False,
+            "mode": "issue-fix",
+            "error": str(exc),
+        }
+        renderer = render_issue_fix_acceptance_loop_markdown
+    print_payload(payload, output_format(args), renderer)
+    return 0 if payload.get("ok") else 1

--- a/loopx/issue_fix_acceptance_loop.py
+++ b/loopx/issue_fix_acceptance_loop.py
@@ -1,0 +1,339 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from .issue_fix_intake_surface import build_content_ops_issue_fix_metadata_preview_packet
+
+
+ISSUE_FIX_ACCEPTANCE_LOOP_SCHEMA_VERSION = "issue_fix_acceptance_loop_v0"
+ISSUE_FIX_VALIDATED_FIX_ARTIFACT_SCHEMA_VERSION = "issue_fix_validated_fix_artifact_v0"
+
+
+def _sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _run_fixture_smoke(workspace: Path) -> dict[str, Any]:
+    result = subprocess.run(
+        [sys.executable, "test_calculator.py"],
+        cwd=workspace,
+        env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=10,
+    )
+    return {
+        "schema_version": "issue_fix_validation_command_v0",
+        "command_label": "python test_calculator.py",
+        "exit_code": result.returncode,
+        "passed": result.returncode == 0,
+        "stdout_captured": False,
+        "stderr_captured": False,
+        "local_path_captured": False,
+    }
+
+
+def _write_fixture_workspace(workspace: Path) -> None:
+    (workspace / "calculator.py").write_text(
+        "\n".join(
+            [
+                "def add(left, right):",
+                "    return left - right",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (workspace / "test_calculator.py").write_text(
+        "\n".join(
+            [
+                "from calculator import add",
+                "",
+                "",
+                "def main():",
+                "    assert add(2, 3) == 5, 'add should sum two integers'",
+                "",
+                "",
+                "if __name__ == '__main__':",
+                "    main()",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def _apply_fixture_patch(workspace: Path) -> dict[str, Any]:
+    target = workspace / "calculator.py"
+    before = target.read_text(encoding="utf-8")
+    broken = "return left - right"
+    fixed = "return left + right"
+    if broken not in before:
+        raise ValueError("fixture patch expected the known subtraction bug")
+    after = before.replace(broken, fixed, 1)
+    target.write_text(after, encoding="utf-8")
+    shutil.rmtree(workspace / "__pycache__", ignore_errors=True)
+    return {
+        "schema_version": "issue_fix_patch_step_v0",
+        "patch_applied": True,
+        "file": "calculator.py",
+        "change_summary": "replace subtraction with addition in add()",
+        "before_hash": _sha256_text(before),
+        "after_hash": _sha256_text(after),
+        "local_path_captured": False,
+        "destructive_git_used": False,
+    }
+
+
+def build_issue_fix_acceptance_fixture_packet(
+    *,
+    repo: str = "public_repo_fixture",
+    issue_ref: str = "issue_123_public_metadata_fixture",
+    url: str | None = None,
+    generated_at: str | None = "2026-06-23T00:00:00Z",
+) -> dict[str, Any]:
+    """Run a deterministic issue-fix acceptance loop against a temp fixture."""
+
+    metadata_packet = build_content_ops_issue_fix_metadata_preview_packet(
+        repo=repo,
+        issue_ref=issue_ref,
+        url=url,
+        provider_payload={
+            "state": "open",
+            "title": "add() returns the wrong arithmetic result",
+            "labels": [{"name": "bug"}, {"name": "has-repro"}],
+            "comments_count": 0,
+        },
+        generated_at=generated_at,
+    )
+    metadata = dict(metadata_packet["github_metadata_preview"])
+
+    with tempfile.TemporaryDirectory(prefix="loopx-issue-fix-") as tmpdir:
+        workspace = Path(tmpdir)
+        _write_fixture_workspace(workspace)
+        repro_before = _run_fixture_smoke(workspace)
+        route = {
+            "schema_version": "issue_fix_code_route_v0",
+            "route_id": "fixture_calculator_add_route",
+            "selected": True,
+            "source": "public issue labels plus failing repro smoke",
+            "files_examined": ["calculator.py", "test_calculator.py"],
+            "requires_private_repo_state": False,
+            "reads_private_material": False,
+        }
+        patch_step = _apply_fixture_patch(workspace)
+        validation_after = _run_fixture_smoke(workspace)
+
+    artifact = {
+        "schema_version": ISSUE_FIX_VALIDATED_FIX_ARTIFACT_SCHEMA_VERSION,
+        "fix_artifact_ready": validation_after["passed"],
+        "pr_review_packet_ready": validation_after["passed"],
+        "issue_signal": {
+            "repo": metadata["repo"],
+            "issue_ref": metadata["issue_ref"],
+            "kind": metadata["kind"],
+            "labels": metadata["labels"],
+            "body_captured": False,
+            "comment_bodies_captured": False,
+        },
+        "repro_before": repro_before,
+        "code_route": route,
+        "patch": patch_step,
+        "validation_after": validation_after,
+        "review_packet": {
+            "schema_version": "issue_fix_pr_review_packet_v0",
+            "ready": validation_after["passed"],
+            "summary": "Focused fixture repro failed, minimal patch applied, focused validation passed.",
+            "files_changed": ["calculator.py"],
+            "validation_commands": ["python test_calculator.py"],
+            "external_issue_comment_performed": False,
+            "external_pr_created": False,
+            "merge_performed": False,
+        },
+    }
+    steps = [
+        {
+            "step": "metadata_intake",
+            "result": "public metadata preview built without issue body or comments",
+        },
+        {
+            "step": "repro_smoke",
+            "result": "failed before patch" if not repro_before["passed"] else "unexpected pass",
+        },
+        {"step": "code_route", "result": "fixture calculator route selected"},
+        {
+            "step": "patch",
+            "result": "minimal patch applied" if patch_step["patch_applied"] else "not applied",
+        },
+        {
+            "step": "validation",
+            "result": "passed after patch" if validation_after["passed"] else "failed after patch",
+        },
+    ]
+    packet: dict[str, Any] = {
+        "ok": bool(
+            not repro_before["passed"]
+            and patch_step["patch_applied"]
+            and validation_after["passed"]
+        ),
+        "schema_version": ISSUE_FIX_ACCEPTANCE_LOOP_SCHEMA_VERSION,
+        "mode": "issue-fix-acceptance-fixture",
+        "generated_at": generated_at,
+        "workspace_mode": "temporary_fixture",
+        "metadata_preview_schema_version": metadata_packet["schema_version"],
+        "validated_fix_artifact": artifact,
+        "steps": steps,
+        "external_reads_performed": False,
+        "external_writes_performed": False,
+        "issue_body_captured": False,
+        "comment_bodies_captured": False,
+        "local_paths_captured": False,
+        "private_repo_state_read": False,
+        "destructive_git_used": False,
+        "next_safe_action": (
+            "promote this acceptance loop from deterministic fixture to a real "
+            "repo-local issue branch only after a focused repro can be run safely"
+        ),
+    }
+    validation = validate_issue_fix_acceptance_loop_packet(packet)
+    packet["ok"] = bool(packet["ok"] and validation["ok"])
+    packet["validation"] = validation
+    return packet
+
+
+def validate_issue_fix_acceptance_loop_packet(packet: Mapping[str, Any]) -> dict[str, Any]:
+    errors: list[str] = []
+    if packet.get("schema_version") != ISSUE_FIX_ACCEPTANCE_LOOP_SCHEMA_VERSION:
+        errors.append("packet schema_version must be issue_fix_acceptance_loop_v0")
+    for key in (
+        "external_reads_performed",
+        "external_writes_performed",
+        "issue_body_captured",
+        "comment_bodies_captured",
+        "local_paths_captured",
+        "private_repo_state_read",
+        "destructive_git_used",
+    ):
+        if packet.get(key) is not False:
+            errors.append(f"packet {key} must be false")
+
+    artifact = (
+        packet.get("validated_fix_artifact")
+        if isinstance(packet.get("validated_fix_artifact"), Mapping)
+        else {}
+    )
+    if artifact.get("schema_version") != ISSUE_FIX_VALIDATED_FIX_ARTIFACT_SCHEMA_VERSION:
+        errors.append("validated fix artifact has wrong schema")
+    if artifact.get("fix_artifact_ready") is not True:
+        errors.append("validated fix artifact must be ready")
+    repro = artifact.get("repro_before") if isinstance(artifact.get("repro_before"), Mapping) else {}
+    after = (
+        artifact.get("validation_after")
+        if isinstance(artifact.get("validation_after"), Mapping)
+        else {}
+    )
+    patch = artifact.get("patch") if isinstance(artifact.get("patch"), Mapping) else {}
+    if repro.get("passed") is not False:
+        errors.append("repro must fail before patch")
+    if patch.get("patch_applied") is not True:
+        errors.append("patch must be applied")
+    if after.get("passed") is not True:
+        errors.append("validation must pass after patch")
+    for command in (repro, after):
+        if command.get("stdout_captured") is not False:
+            errors.append("validation stdout must not be captured")
+        if command.get("stderr_captured") is not False:
+            errors.append("validation stderr must not be captured")
+        if command.get("local_path_captured") is not False:
+            errors.append("validation local path must not be captured")
+    if patch.get("file") != "calculator.py":
+        errors.append("patch file must be repo-relative")
+    if patch.get("local_path_captured") is not False:
+        errors.append("patch local path must not be captured")
+
+    review = (
+        artifact.get("review_packet")
+        if isinstance(artifact.get("review_packet"), Mapping)
+        else {}
+    )
+    if review.get("ready") is not True:
+        errors.append("review packet must be ready")
+    for key in ("external_issue_comment_performed", "external_pr_created", "merge_performed"):
+        if review.get(key) is not False:
+            errors.append(f"review packet {key} must be false")
+
+    return {
+        "schema_version": "issue_fix_acceptance_loop_validation_v0",
+        "ok": not errors,
+        "errors": errors,
+        "steps_count": len(packet.get("steps") or []),
+        "validated_fix_artifact_ready": artifact.get("fix_artifact_ready") is True,
+    }
+
+
+def render_issue_fix_acceptance_loop_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# LoopX Issue Fix Acceptance Loop",
+        "",
+        f"- ok: `{payload.get('ok')}`",
+        f"- schema_version: `{payload.get('schema_version')}`",
+        f"- workspace_mode: `{payload.get('workspace_mode')}`",
+        f"- external_reads_performed: `{payload.get('external_reads_performed')}`",
+        f"- external_writes_performed: `{payload.get('external_writes_performed')}`",
+        f"- local_paths_captured: `{payload.get('local_paths_captured')}`",
+        f"- destructive_git_used: `{payload.get('destructive_git_used')}`",
+    ]
+    artifact = payload.get("validated_fix_artifact")
+    if isinstance(artifact, Mapping):
+        lines.extend(
+            [
+                "",
+                "## Validated Fix Artifact",
+                "",
+                f"- fix_artifact_ready: `{artifact.get('fix_artifact_ready')}`",
+                f"- pr_review_packet_ready: `{artifact.get('pr_review_packet_ready')}`",
+            ]
+        )
+        repro = artifact.get("repro_before")
+        after = artifact.get("validation_after")
+        patch = artifact.get("patch")
+        if isinstance(repro, Mapping) and isinstance(after, Mapping):
+            lines.extend(
+                [
+                    f"- repro_before_passed: `{repro.get('passed')}`",
+                    f"- validation_after_passed: `{after.get('passed')}`",
+                ]
+            )
+        if isinstance(patch, Mapping):
+            lines.append(f"- patch_file: `{patch.get('file')}`")
+    steps = payload.get("steps")
+    if isinstance(steps, list):
+        lines.extend(["", "## Steps", ""])
+        for step in steps:
+            if isinstance(step, Mapping):
+                lines.append(f"- `{step.get('step')}`: {step.get('result')}")
+    validation = payload.get("validation")
+    if isinstance(validation, Mapping):
+        errors = validation.get("errors") if isinstance(validation.get("errors"), list) else []
+        lines.extend(
+            [
+                "",
+                "## Validation",
+                "",
+                f"- validation_ok: `{validation.get('ok')}`",
+                f"- validated_fix_artifact_ready: `{validation.get('validated_fix_artifact_ready')}`",
+                f"- error_count: `{len(errors)}`",
+            ]
+        )
+    if payload.get("error"):
+        lines.extend(["", "## Error", "", str(payload.get("error"))])
+    return "\n".join(lines) + "\n"


### PR DESCRIPTION
## Summary
- add `loopx issue-fix acceptance-fixture` as an executable repair-loop fixture
- produce an `issue_fix_validated_fix_artifact_v0` only after failing repro, minimal patch, and passing validation
- split content-ops issue-fix CLI registration into its own module to bring `content_ops.py` back under the module-size budget
- document the issue-fix acceptance protocol and link it from the content-ops protocol

## Validation
- `python3 examples/issue-fix-acceptance-loop-smoke.py`
- `python3 examples/content-ops-issue-fix-metadata-preview-smoke.py`
- `python3 examples/content-ops-issue-fix-intake-smoke.py`
- `python3 examples/cli-command-module-size-ownership-command-modularization-smoke.py`
- `python3 examples/cli-starter-dispatch-command-modularization-smoke.py`
- `python3 -m py_compile loopx/issue_fix_acceptance_loop.py loopx/cli_commands/issue_fix.py loopx/cli_commands/content_ops_issue_fix.py loopx/cli_commands/content_ops.py loopx/cli.py loopx/cli_commands/__init__.py examples/issue-fix-acceptance-loop-smoke.py examples/cli-command-module-size-ownership-command-modularization-smoke.py`
- `git diff --check`
- `loopx check --scan-path ...`