### PR TITLE
Fix SkillsBench relay task trace attribution

### DIFF
--- a/examples/skillsbench-host-local-launch-plan-smoke.py
+++ b/examples/skillsbench-host-local-launch-plan-smoke.py
@@ -209,6 +209,10 @@ output.write_text("fake solver saw bridge packet\\n", encoding="utf-8")
                 str(fake_codex),
                 "--route",
                 "loopx-product-mode",
+                "--dataset",
+                "skillsbench-v1.1",
+                "--task-id",
+                "demo-task",
                 "--worker-public-trace-dir",
                 str(trace_dir),
                 "--remote-command-file-bridge-command",
@@ -229,6 +233,8 @@ output.write_text("fake solver saw bridge packet\\n", encoding="utf-8")
         assert bridge_trace["trace_kind"] == (
             "remote_command_file_bridge_solver_consumption"
         )
+        assert bridge_trace["benchmark_id"] == "skillsbench-v1.1"
+        assert bridge_trace["task_id"] == "demo-task"
         bridge = bridge_trace["remote_command_file_bridge"]
         assert bridge["consumed_by_solver"] is True
         assert bridge["probe_ready"] is True

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -667,10 +667,6 @@ def _host_local_acp_launch_command(
         command.extend(
             [
                 "--app-server-goal-worker",
-                "--dataset",
-                args.dataset,
-                "--task-id",
-                args.task_id,
                 "--approval-policy",
                 "never",
                 "--reasoning-effort",
@@ -689,6 +685,10 @@ def _host_local_acp_launch_command(
         [
             "--route",
             args.route,
+            "--dataset",
+            args.dataset,
+            "--task-id",
+            args.task_id,
             "--codex-bin",
             args.local_codex_bin,
             "--sandbox",


### PR DESCRIPTION
## Summary
- pass canonical dataset/task-id through the host-local ACP relay command for all routes
- keep app-server as the same relay/runtime path without duplicate task args
- extend the host-local launch smoke so public bridge-consumption traces must preserve the current case id

## Validation
- python3 -m py_compile scripts/skillsbench_automation_loop.py examples/skillsbench-host-local-launch-plan-smoke.py
- python3 examples/skillsbench-host-local-launch-plan-smoke.py
- git diff --check
- loopx check --scan-path scripts/skillsbench_automation_loop.py --scan-path examples/skillsbench-host-local-launch-plan-smoke.py