### PR TITLE
Add agent-guided todo suggestion prompt

### DIFF
--- a/docs/reference/protocols/todo-suggestion-prompt-v0.md
+++ b/docs/reference/protocols/todo-suggestion-prompt-v0.md
@@ -1,0 +1,58 @@
+# todo_suggestion_prompt_v0
+
+`todo_suggestion_prompt_v0` is a prompt contract for asking the user's current
+project agent to produce a small candidate todo decision queue.
+
+LoopX does not analyze the repository in this path. LoopX only provides the
+bounded task body, candidate schema, promotion policy, source lanes, and
+frequency limits. The project agent reads the current repo and returns
+`suggested_todos`; those candidates are not formal LoopX todos until the user
+or primary controller promotes one.
+
+## Command
+
+```bash
+loopx todo suggest --goal-id <goal-id> --from recent-repo --from loopx-deferred --limit 3
+```
+
+Useful triggers:
+
+- post-connect onboarding, after the project has a valid LoopX state;
+- explicit user request such as "what looks worth doing next?";
+- no runnable agent todo after status/quota inspection;
+- material repo changes since the last candidate review.
+
+Avoid running this on every heartbeat. The default limit is 3 and the hard cap
+is 5.
+
+## Candidate Shape
+
+The agent's output should use a `suggested_todos` list. Each item uses
+`suggested_todo_candidate_v0`:
+
+```json
+{
+  "schema_version": "suggested_todo_candidate_v0",
+  "candidate_id": "suggested_todo_repo_smoke_gap",
+  "title": "Add a smoke for the new setup path",
+  "why_now": "Recent docs changed the setup flow, but no smoke covers the wording.",
+  "evidence": ["README.md", "examples/project-prompt-smoke.py"],
+  "first_safe_action": "Inspect the existing setup smoke and draft one failing assertion.",
+  "requires_user_decision": false,
+  "risk": "low",
+  "value": "prevents onboarding regressions",
+  "confidence": "medium",
+  "suggested_owner_agent": "codex-main-control",
+  "promotion_preview": "loopx todo add --goal-id <goal-id> --role agent --text '...'"
+}
+```
+
+## Rules
+
+- Candidate generation is read-only by default.
+- A candidate is not a user todo.
+- `requires_user_decision=true` is only for owner choice, protected access,
+  external action, or private material approval.
+- The agent may return an empty list when evidence is weak or already covered.
+- Promotion uses `loopx todo add` after explicit approval; this protocol does
+  not write active state.

--- a/examples/todo-suggestion-prompt-smoke.py
+++ b/examples/todo-suggestion-prompt-smoke.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Smoke-test agent-guided candidate todo suggestion prompts."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GOAL_ID = "todo-suggestion-goal"
+
+
+def write_fixture(root: Path) -> tuple[Path, Path]:
+    project = root / "project"
+    runtime = root / "runtime"
+    state_file = project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+    registry_path = project / ".loopx" / "registry.json"
+    state_file.parent.mkdir(parents=True)
+    state_file.write_text(
+        "---\n"
+        "status: active\n"
+        "updated_at: 2026-01-01T00:00:00+00:00\n"
+        "---\n\n"
+        "# Active Goal State\n\n"
+        "## Objective\n\n"
+        "Exercise todo suggestion prompt generation.\n",
+        encoding="utf-8",
+    )
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "todo-suggestion-fixture",
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": ".codex/goals/todo-suggestion-goal/ACTIVE_GOAL_STATE.md",
+                        "adapter": {"kind": "generic_project_goal_v0", "status": "connected"},
+                        "authority_sources": [],
+                    }
+                ],
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return registry_path, state_file
+
+
+def run_cli(registry_path: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--registry",
+            str(registry_path),
+            *args,
+        ],
+        cwd=REPO_ROOT,
+        check=check,
+        text=True,
+        capture_output=True,
+    )
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="loopx-todo-suggestion-smoke-") as tmp:
+        root = Path(tmp)
+        registry_path, state_file = write_fixture(root)
+        original_state = state_file.read_text(encoding="utf-8")
+
+        result = run_cli(
+            registry_path,
+            "--format",
+            "json",
+            "todo",
+            "suggest",
+            "--goal-id",
+            GOAL_ID,
+            "--project",
+            ".",
+            "--agent-id",
+            "codex-main-control",
+            "--from",
+            "recent-repo",
+            "--from",
+            "loopx-deferred",
+            "--limit",
+            "9",
+            "--trigger",
+            "user-requested",
+        )
+        payload = json.loads(result.stdout)
+        assert payload["ok"] is True, payload
+        assert payload["schema_version"] == "todo_suggestion_prompt_v0", payload
+        assert payload["mode"] == "agent_guided_candidate_todo_queue", payload
+        assert payload["analysis_owner"] == "user_project_agent", payload
+        assert payload["loopx_role"] == "prompt_contract_only", payload
+        assert payload["state_write_performed"] is False, payload
+        assert payload["formal_todos_written"] is False, payload
+        assert payload["effective_limit"] == 5, payload
+        assert payload["max_limit"] == 5, payload
+        assert payload["sources"] == ["recent-repo", "loopx-deferred"], payload
+        assert payload["candidate_queue_field"] == "suggested_todos", payload
+        assert payload["candidate_schema_version"] == "suggested_todo_candidate_v0", payload
+        assert payload["promotion_policy"]["do_not_execute_in_suggestion_turn"] is True, payload
+        task_body = payload["task_body"]
+        assert "LoopX is not analyzing the repository itself" in task_body, task_body
+        assert "Return at most 5 items in a `suggested_todos` list" in task_body, task_body
+        assert "Do not call `loopx todo add`" in task_body, task_body
+        assert "`promotion_preview`" in task_body, task_body
+        assert "`requires_user_decision=true`" in task_body, task_body
+        assert state_file.read_text(encoding="utf-8") == original_state
+
+        markdown = run_cli(
+            registry_path,
+            "todo",
+            "suggest",
+            "--goal-id",
+            GOAL_ID,
+            "--from",
+            "docs-smokes",
+        ).stdout
+        assert "LoopX Todo Suggestion Prompt" in markdown, markdown
+        assert "Agent Task Body" in markdown, markdown
+        assert "Suggested items are decision candidates" in markdown, markdown
+        assert state_file.read_text(encoding="utf-8") == original_state
+
+        rejected = run_cli(
+            registry_path,
+            "--format",
+            "json",
+            "todo",
+            "add",
+            "--goal-id",
+            GOAL_ID,
+            "--role",
+            "agent",
+            "--text",
+            "Do something.",
+            "--agent-id",
+            "codex-main-control",
+            check=False,
+        )
+        assert rejected.returncode == 1, rejected.stdout
+        error_payload = json.loads(rejected.stdout)
+        assert "only supported by `todo suggest`" in error_payload["error"], error_payload
+
+    print("todo-suggestion-prompt-smoke: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -4,6 +4,12 @@ import argparse
 from collections.abc import Callable
 from pathlib import Path
 
+from ..todo_suggestion_prompt import (
+    ALLOWED_TODO_SUGGESTION_SOURCES,
+    ALLOWED_TODO_SUGGESTION_TRIGGERS,
+    build_todo_suggestion_prompt_packet,
+    render_todo_suggestion_prompt_markdown,
+)
 from ..todos import (
     archive_completed_todos,
     add_goal_todo,
@@ -36,12 +42,14 @@ def register_todo_command(subparsers: argparse._SubParsersAction) -> None:
             "complete",
             "supersede",
             "archive-completed",
+            "suggest",
         ],
         default="add",
         help=(
             "Use add to append a checkbox todo, claim to soft-claim by registered "
             "agent id, update/complete/supersede to transition by todo_id, or "
-            "archive-completed to move older completed todos into Completed Work Archive."
+            "archive-completed to move older completed todos into Completed Work Archive. "
+            "Use suggest to generate an agent-facing candidate todo analysis prompt without writing state."
         ),
     )
     todo_parser.add_argument("--goal-id", required=True, help="Goal id whose active state should receive the todo.")
@@ -162,6 +170,29 @@ def register_todo_command(subparsers: argparse._SubParsersAction) -> None:
         default=12,
         help="For archive-completed, keep this many completed todos in the active section.",
     )
+    todo_parser.add_argument(
+        "--agent-id",
+        help="For todo suggest, name the project agent that should perform the repository analysis.",
+    )
+    todo_parser.add_argument(
+        "--from",
+        dest="suggestion_sources",
+        choices=ALLOWED_TODO_SUGGESTION_SOURCES,
+        action="append",
+        help="For todo suggest, include a source lane for agent analysis. Repeat for multiple lanes.",
+    )
+    todo_parser.add_argument(
+        "--limit",
+        dest="suggestion_limit",
+        type=int,
+        help="For todo suggest, maximum candidate count. Values above 5 are clamped to 5.",
+    )
+    todo_parser.add_argument(
+        "--trigger",
+        dest="suggestion_trigger",
+        choices=ALLOWED_TODO_SUGGESTION_TRIGGERS,
+        help="For todo suggest, why this candidate queue is being requested.",
+    )
     todo_parser.add_argument("--project", help="Project root. Defaults to the registry goal repo.")
     todo_parser.add_argument("--state-file", help="Active goal state path. Defaults to the registry goal state_file.")
     todo_parser.add_argument("--dry-run", action="store_true", help="Preview the active-state edit without writing.")
@@ -176,7 +207,21 @@ def handle_todo_command(
     print_payload: PrintPayload,
     append_cli_rollout_event: RolloutEventAppender,
 ) -> int:
+    renderer = (
+        render_todo_suggestion_prompt_markdown
+        if args.todo_command == "suggest"
+        else render_todo_markdown
+    )
     try:
+        if args.todo_command != "suggest" and (
+            args.agent_id
+            or args.suggestion_sources
+            or args.suggestion_limit is not None
+            or args.suggestion_trigger
+        ):
+            raise ValueError(
+                "todo --agent-id, --from, --limit, and --trigger are only supported by `todo suggest`"
+            )
         if args.todo_command == "add":
             if not args.role:
                 raise ValueError("todo add requires --role")
@@ -372,12 +417,61 @@ def handle_todo_command(
                 state_file=Path(args.state_file).expanduser() if args.state_file else None,
                 dry_run=not bool(args.execute),
             )
+        elif args.todo_command == "suggest":
+            unsupported = [
+                flag
+                for flag, value in (
+                    ("--role", args.role),
+                    ("--text", args.text),
+                    ("--todo-id", args.todo_id),
+                    ("--status", args.status),
+                    ("--note", args.note),
+                    ("--evidence", args.evidence),
+                    ("--reason", args.reason),
+                    ("--task-class", args.task_class),
+                    ("--action-kind", args.action_kind),
+                    ("--required-write-scope", args.required_write_scopes),
+                    ("--required-capability", args.required_capabilities),
+                    ("--target-capability", args.target_capabilities),
+                    ("--claimed-by", args.claimed_by),
+                    ("--blocks-agent", args.blocks_agent),
+                    ("--unblocks-todo-id", args.unblocks_todo_id),
+                    ("--resume-when", args.resume_when),
+                    ("--clear-claim", args.clear_claim),
+                    ("--next-agent-todo", args.next_agent_todo),
+                    ("--next-user-todo", args.next_user_todo),
+                    ("--next-claimed-by", args.next_claimed_by),
+                    ("--next-task-class", args.next_task_class),
+                    ("--next-action-kind", args.next_action_kind),
+                    ("--side-agent-self-merged", args.side_agent_self_merged),
+                    ("--state-file", args.state_file),
+                    ("--execute", args.execute),
+                )
+                if value
+            ]
+            if unsupported:
+                raise ValueError(
+                    "todo suggest only accepts --goal-id, optional --project, --agent-id, "
+                    "--from, --limit, --trigger, --dry-run, and --format; unsupported: "
+                    + ", ".join(unsupported)
+                )
+            payload = build_todo_suggestion_prompt_packet(
+                goal_id=args.goal_id,
+                project=Path(args.project).expanduser() if args.project else None,
+                agent_id=args.agent_id,
+                sources=args.suggestion_sources,
+                limit=args.suggestion_limit,
+                trigger=args.suggestion_trigger,
+            )
+            payload["dry_run"] = True
         else:
             raise ValueError("unsupported todo command")
     except Exception as exc:
         payload = {
             "ok": False,
-            "dry_run": not bool(args.execute)
+            "dry_run": True
+            if args.todo_command == "suggest"
+            else not bool(args.execute)
             if args.todo_command == "archive-completed"
             else bool(args.dry_run),
             "added": False,
@@ -417,5 +511,5 @@ def handle_todo_command(
                 "already_exists": bool(payload.get("already_exists")),
             },
         )
-    print_payload(payload, args.format, render_todo_markdown)
+    print_payload(payload, args.format, renderer)
     return 0 if payload.get("ok") else 1

--- a/loopx/todo_suggestion_prompt.py
+++ b/loopx/todo_suggestion_prompt.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+TODO_SUGGESTION_PROMPT_SCHEMA_VERSION = "todo_suggestion_prompt_v0"
+SUGGESTED_TODO_CANDIDATE_SCHEMA_VERSION = "suggested_todo_candidate_v0"
+DEFAULT_SUGGESTION_LIMIT = 3
+MAX_SUGGESTION_LIMIT = 5
+ALLOWED_TODO_SUGGESTION_SOURCES = (
+    "recent-repo",
+    "issues-prs",
+    "failing-checks",
+    "todo-markers",
+    "complexity-hotspots",
+    "loopx-deferred",
+    "docs-smokes",
+)
+DEFAULT_TODO_SUGGESTION_SOURCES = (
+    "recent-repo",
+    "issues-prs",
+    "failing-checks",
+    "todo-markers",
+    "loopx-deferred",
+    "docs-smokes",
+)
+ALLOWED_TODO_SUGGESTION_TRIGGERS = (
+    "user-requested",
+    "post-connect",
+    "no-runnable-todo",
+    "repo-changed",
+)
+
+
+def normalize_suggestion_sources(sources: list[str] | None) -> list[str]:
+    raw_sources = sources or list(DEFAULT_TODO_SUGGESTION_SOURCES)
+    normalized: list[str] = []
+    for source in raw_sources:
+        compact = str(source or "").strip()
+        if compact not in ALLOWED_TODO_SUGGESTION_SOURCES:
+            raise ValueError(f"unsupported todo suggestion source: {compact}")
+        if compact not in normalized:
+            normalized.append(compact)
+    return normalized
+
+
+def effective_suggestion_limit(limit: int | None) -> int:
+    if limit is None:
+        return DEFAULT_SUGGESTION_LIMIT
+    if limit < 1:
+        raise ValueError("todo suggestion --limit must be at least 1")
+    return min(limit, MAX_SUGGESTION_LIMIT)
+
+
+def _project_hint(project: Path | None) -> str:
+    if project is None:
+        return "current project root"
+    return str(project)
+
+
+def build_todo_suggestion_prompt_packet(
+    *,
+    goal_id: str,
+    project: Path | None = None,
+    agent_id: str | None = None,
+    sources: list[str] | None = None,
+    limit: int | None = None,
+    trigger: str | None = None,
+) -> dict[str, Any]:
+    """Build an agent-facing prompt for candidate todo discovery.
+
+    LoopX intentionally does not inspect the repository here. The packet tells
+    the user's current project agent how to perform a bounded read-only analysis
+    and how to return a decision queue without writing formal LoopX todos.
+    """
+
+    if not goal_id.strip():
+        raise ValueError("goal_id is required")
+    selected_sources = normalize_suggestion_sources(sources)
+    selected_trigger = trigger or "user-requested"
+    if selected_trigger not in ALLOWED_TODO_SUGGESTION_TRIGGERS:
+        raise ValueError(f"unsupported todo suggestion trigger: {selected_trigger}")
+    selected_limit = effective_suggestion_limit(limit)
+    requested_limit = limit if limit is not None else DEFAULT_SUGGESTION_LIMIT
+    project_hint = _project_hint(project)
+    agent_label = agent_id or "current project agent"
+    source_text = ", ".join(selected_sources)
+
+    task_body = f"""Generate a bounded candidate todo decision queue for LoopX goal `{goal_id}`.
+
+You are `{agent_label}` operating in the current project. LoopX is only giving
+you the analysis contract; LoopX is not analyzing the repository itself.
+
+Read the current repo and recent project signals in read-only mode. Use these
+source lanes when available: {source_text}. Prefer public-safe evidence such as
+repo-relative paths, commit or PR identifiers, failing check names, TODO/FIXME
+locations, LoopX deferred todo ids, and docs/smoke gaps. Do not include raw logs,
+credentials, private material, local absolute paths, issue bodies, or chat
+transcripts.
+
+Return at most {selected_limit} items in a `suggested_todos` list. These are
+decision candidates, not formal LoopX todos. Do not call `loopx todo add`,
+`loopx todo update`, `loopx todo complete`, or edit LoopX state in this turn.
+If the evidence is weak or already covered by existing runnable todos, return an
+empty list with a short rationale.
+
+Each candidate must use schema `{SUGGESTED_TODO_CANDIDATE_SCHEMA_VERSION}` and
+include: `candidate_id`, `title`, `why_now`, `evidence`, `first_safe_action`,
+`requires_user_decision`, `risk`, `value`, `confidence`, `suggested_owner_agent`,
+and `promotion_preview`. `promotion_preview` should be a public-safe
+`loopx todo add ...` command draft, but it must not be executed unless the user
+or primary controller explicitly promotes the candidate.
+
+Keep user gates separate: a candidate is not a user todo. Only set
+`requires_user_decision=true` when the first safe action genuinely needs owner
+choice, protected access, external action, or private material approval."""
+
+    return {
+        "ok": True,
+        "schema_version": TODO_SUGGESTION_PROMPT_SCHEMA_VERSION,
+        "goal_id": goal_id,
+        "mode": "agent_guided_candidate_todo_queue",
+        "analysis_owner": "user_project_agent",
+        "loopx_role": "prompt_contract_only",
+        "agent_id": agent_id,
+        "project": project_hint,
+        "trigger": selected_trigger,
+        "sources": selected_sources,
+        "requested_limit": requested_limit,
+        "effective_limit": selected_limit,
+        "max_limit": MAX_SUGGESTION_LIMIT,
+        "state_write_performed": False,
+        "formal_todos_written": False,
+        "candidate_queue_field": "suggested_todos",
+        "candidate_schema_version": SUGGESTED_TODO_CANDIDATE_SCHEMA_VERSION,
+        "task_body": task_body,
+        "expected_candidate_fields": [
+            "candidate_id",
+            "title",
+            "why_now",
+            "evidence",
+            "first_safe_action",
+            "requires_user_decision",
+            "risk",
+            "value",
+            "confidence",
+            "suggested_owner_agent",
+            "promotion_preview",
+        ],
+        "promotion_policy": {
+            "default_state": "candidate_only",
+            "who_may_promote": ["user", "primary_controller"],
+            "promotion_command": "loopx todo add --goal-id <goal-id> --role agent --text <approved candidate>",
+            "do_not_execute_in_suggestion_turn": True,
+        },
+        "frequency_policy": {
+            "default_limit": DEFAULT_SUGGESTION_LIMIT,
+            "hard_limit": MAX_SUGGESTION_LIMIT,
+            "recommended_triggers": list(ALLOWED_TODO_SUGGESTION_TRIGGERS),
+            "avoid_every_heartbeat": True,
+        },
+    }
+
+
+def render_todo_suggestion_prompt_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# LoopX Todo Suggestion Prompt",
+        "",
+        f"- ok: `{payload.get('ok')}`",
+        f"- schema_version: `{payload.get('schema_version')}`",
+        f"- goal_id: `{payload.get('goal_id')}`",
+        f"- mode: `{payload.get('mode')}`",
+        f"- analysis_owner: `{payload.get('analysis_owner')}`",
+        f"- loopx_role: `{payload.get('loopx_role')}`",
+        f"- state_write_performed: `{payload.get('state_write_performed')}`",
+        f"- formal_todos_written: `{payload.get('formal_todos_written')}`",
+        f"- effective_limit: `{payload.get('effective_limit')}`",
+        f"- sources: `{', '.join(payload.get('sources') or [])}`",
+        "",
+        "## Agent Task Body",
+        "",
+        "```text",
+        str(payload.get("task_body") or "").rstrip(),
+        "```",
+        "",
+        "## Promotion Policy",
+        "",
+        "- Suggested items are decision candidates, not formal LoopX todos.",
+        "- Only the user or primary controller should promote a candidate.",
+        "- Promotion uses `loopx todo add` after explicit approval.",
+    ]
+    if payload.get("error"):
+        lines.extend(["", "## Error", "", str(payload.get("error"))])
+    return "\n".join(lines) + "\n"


### PR DESCRIPTION
## Summary
- add loopx todo suggest as a prompt contract for the user project agent to produce a bounded suggested_todos decision queue
- keep LoopX out of repository analysis: the command writes no state and marks analysis_owner=user_project_agent
- document todo_suggestion_prompt_v0 and add smoke coverage for JSON/Markdown output, hard limit clamping, and old todo command parameter rejection

## Validation
- python3 examples/todo-suggestion-prompt-smoke.py
- python3 examples/todo-cli-smoke.py
- python3 examples/todo-lifecycle-cli-smoke.py
- python3 -m py_compile loopx/todo_suggestion_prompt.py loopx/cli_commands/todo.py
- git diff --check
- loopx check --scan-path loopx/cli_commands/todo.py --scan-path loopx/todo_suggestion_prompt.py --scan-path examples/todo-suggestion-prompt-smoke.py --scan-path docs/reference/protocols/todo-suggestion-prompt-v0.md