### PR TITLE
Prevent SkillsBench relay codex stdin hangs

### DIFF
--- a/examples/skillsbench-host-local-launch-plan-smoke.py
+++ b/examples/skillsbench-host-local-launch-plan-smoke.py
@@ -188,12 +188,18 @@ def main() -> int:
         fake_codex = Path(tmp) / "fake-codex"
         fake_codex.write_text(
             """#!/usr/bin/env python3
+import select
 import sys
 from pathlib import Path
 
 args = sys.argv[1:]
 if "Private bridge command:" not in args[-1]:
     raise SystemExit(7)
+ready, _, _ = select.select([sys.stdin], [], [], 0.2)
+if not ready:
+    raise SystemExit(8)
+if sys.stdin.read():
+    raise SystemExit(9)
 output = Path(args[args.index("--output-last-message") + 1])
 output.write_text("fake solver saw bridge packet\\n", encoding="utf-8")
 """,

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -252,6 +252,7 @@ class SkillsBenchLocalAcpRelay:
             try:
                 proc = subprocess.run(
                     cmd,
+                    stdin=subprocess.DEVNULL,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
                     text=True,
@@ -403,6 +404,7 @@ Private bridge command:
             try:
                 proc = subprocess.Popen(
                     cmd,
+                    stdin=subprocess.DEVNULL,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
                     text=True,


### PR DESCRIPTION
## Summary
- close stdin for relay-spawned codex exec so it cannot block waiting for ACP stdin
- close stdin for the app-server worker subprocess as the same hygiene rule
- extend the host-local launch smoke so fake Codex must see immediate stdin EOF

## Validation
- python3 -m py_compile loopx/benchmark_adapters/skillsbench_acp_relay.py examples/skillsbench-host-local-launch-plan-smoke.py
- python3 examples/skillsbench-host-local-launch-plan-smoke.py
- git diff --check
- loopx check --scan-path loopx/benchmark_adapters/skillsbench_acp_relay.py --scan-path examples/skillsbench-host-local-launch-plan-smoke.py