### PR TITLE
Default Codex App heartbeat onboarding to 3 minutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ already exists, reuse it and do not create or overwrite a goal; if the project
 is not connected, prefer `loopx connect`, and use `loopx bootstrap` only when
 goal state clearly needs initialization. Ensure `.loopx/`, `.codex/goals/`,
 and `.local/` are ignored. After the project is connected, set or refresh this
-thread's heartbeat automation from `loopx heartbeat-prompt --thin`. Then stop
-and report the goal id, current user gate, top agent todo, and next safe
-action.
+thread's heartbeat automation to run every 3 minutes using the task body from
+`loopx heartbeat-prompt --thin`. Then stop and report the goal id, current user
+gate, top agent todo, and next safe action.
 ```
 
 The generated heartbeat body is the recurring Codex App work surface:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -43,9 +43,9 @@ curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/ins
 请复用，不要新建或覆盖 goal；如果尚未接入，优先用 `loopx connect`，只有明确
 缺少 goal 状态且需要初始化时才用 `loopx bootstrap`。确保 `.loopx/`、
 `.codex/goals/`、`.local/` 不会被提交。项目连接后，用
-`loopx heartbeat-prompt --thin` 设置或刷新这个 Codex App heartbeat。然后停止，
-不要在接入这轮开始长任务；只汇报 goal id、当前 user gate、top agent todo 和
-下一步安全动作。
+`loopx heartbeat-prompt --thin` 生成 task body，并设置或刷新这个 Codex App
+heartbeat 为每 3 分钟运行一次。然后停止，不要在接入这轮开始长任务；只汇报
+goal id、当前 user gate、top agent todo 和下一步安全动作。
 ```
 
 recurring heartbeat body 由 CLI 生成：

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -29,7 +29,8 @@ Then run `loopx doctor`. Work only from the current project root:
 2. If the project is not connected, prefer `loopx connect`; use
    `loopx bootstrap` only when goal state clearly needs initialization.
 3. Ensure `.loopx/`, `.codex/goals/`, and `.local/` are ignored.
-4. Set up the thin LoopX heartbeat for this surface.
+4. Set up the thin LoopX heartbeat for this surface. For Codex App, default
+   the recurring automation to every 3 minutes.
 5. Stop after setup and report the goal id, current user gate, top agent todo,
    and next safe action.
 
@@ -95,7 +96,7 @@ setup turn should not spend quota for delivery unless the user explicitly asks
 it to do delivery in the setup turn. The agent should still generate
 `heartbeat-prompt --thin` and install that body into the surface during setup:
 Codex CLI gets `/goal <thin task_body>`, while Codex App gets a heartbeat
-automation body.
+automation body that runs every 3 minutes.
 
 Once `loopx` is installed, generate a stricter repo-specific setup
 message:
@@ -567,7 +568,9 @@ loopx quota spend-slot \
 Do not append spend for quiet `should_run=false` skips, preflight failures, or
 pure dry-run previews.
 
-Generate a guarded Codex App heartbeat body:
+Generate a guarded Codex App heartbeat body. First-run Codex App onboarding
+should install this body on a 3-minute cadence unless the user explicitly asks
+for a different interval:
 
 ```bash
 loopx heartbeat-prompt --thin --goal-id your-project-goal

--- a/docs/heartbeat-automation-prompt.md
+++ b/docs/heartbeat-automation-prompt.md
@@ -443,10 +443,12 @@ Do not ask for permissions when the current Codex session is already trusted.
 ## Minimal User-Facing Form
 
 When creating a heartbeat in Codex App, keep the visible instruction short and
-put the lifecycle in the automation task body:
+put the lifecycle in the automation task body. The default onboarding cadence
+is every 3 minutes; choose a different interval only when the user explicitly
+asks:
 
 ```text
-Create a heartbeat automation every <INTERVAL> for the current thread.
+Create a heartbeat automation every 3 minutes for the current thread.
 
 Task:
 Advance <GOAL_ID> using <ACTIVE_GOAL_STATE_PATH>. Before any delivery work,

--- a/docs/new-project-codex-prompt.md
+++ b/docs/new-project-codex-prompt.md
@@ -180,8 +180,8 @@ loopx new-project-prompt \
 
    只把输出的 handoff 交给目标项目 agent；完整 review packet 留给 operator view /
    evidence drill-down。
-6. 如果要给这个项目设置 recurring Codex App heartbeat，不要手抄 guard 和
-   spend 协议；先生成 task body，再把输出复制进 automation：
+6. 如果要给这个项目设置 recurring Codex App heartbeat，默认每 3 分钟一次；不要手抄
+   guard 和 spend 协议；先生成 task body，再把输出复制进 automation：
 
    ```bash
    loopx heartbeat-prompt \

--- a/docs/product/codex-cli-tui-loop.md
+++ b/docs/product/codex-cli-tui-loop.md
@@ -39,8 +39,8 @@ report the goal id, current user gate, top agent todo, and next safe action.
 That text should be a Codex CLI-native setup path for the same lifecycle App
 uses: setup first, including immediate installation of the thin loop prompt into
 the surface. In Codex CLI the loop is `/goal <thin task_body>`; in Codex App
-the loop is heartbeat automation `<thin task_body>`. The message should be
-enough for a terminal agent to:
+the loop is heartbeat automation every 3 minutes with `<thin task_body>`. The
+message should be enough for a terminal agent to:
 
 - run `loopx doctor`;
 - install or repair the local CLI if it is missing, using the no-clone archive

--- a/examples/codex-cli-bootstrap-message-smoke.py
+++ b/examples/codex-cli-bootstrap-message-smoke.py
@@ -59,6 +59,7 @@ def assert_message_contract(payload: dict[str, object]) -> None:
     assert "--format json heartbeat-prompt" in str(payload["heartbeat_prompt_json_command"]), payload
     assert payload["codex_cli_goal_prefix"] == "/goal ", payload
     assert payload["codex_app_loop_surface"] == "heartbeat automation task_body", payload
+    assert payload["codex_app_default_heartbeat_cadence"] == "3 minutes", payload
     assert "--agent-scope 'Codex CLI /goal visible TUI loop'" in str(payload["heartbeat_prompt_command"]), payload
     checklist = payload["first_run_validation_checklist"]
     assert isinstance(checklist, list) and len(checklist) >= 5, payload
@@ -118,13 +119,14 @@ def assert_docs_surface_codex_cli_quickstart() -> None:
     assert "Hidden `codex exec` is not the default bootstrap path" in normalized_readme, readme
     assert "paste one setup message" in normalized_readme, readme
     assert "heartbeat setup, and status check" in normalized_readme, readme
+    assert "heartbeat automation to run every 3 minutes" in normalized_readme, readme
     assert "set the current Codex CLI goal to `/goal <thin task_body>`" in normalized_readme, readme
     assert "reuse it" in normalized_readme, readme
     assert "loopx codex-cli-bootstrap-message --project . --goal-id <goal-id>" not in readme, readme
     assert "report the goal id, current user gate, top agent todo, and next safe action" in normalized_readme, readme
     assert "first-run path should not require you to understand registry paths" in normalized_getting_started, getting_started
     assert "setup-first rewrite of the App onboarding experience" in normalized_getting_started, getting_started
-    assert "Codex App gets a heartbeat automation body" in normalized_getting_started, getting_started
+    assert "Codex App gets a heartbeat automation body that runs every 3 minutes" in normalized_getting_started, getting_started
     assert "transcript-free validation checklist" in normalized_getting_started, getting_started
     assert "installs the thin LoopX goal/heartbeat body immediately" in normalized_product_contract, product_contract
     assert "optional automation checks after the setup path works" in normalized_getting_started, getting_started
@@ -173,6 +175,7 @@ def main() -> int:
     assert "Copy the block below into Codex CLI TUI" in cli_markdown, cli_markdown
     assert "setup message, not the reusable heartbeat body" in cli_markdown, cli_markdown
     assert "`/goal <thin task_body>`" in cli_markdown, cli_markdown
+    assert "Codex App automation every 3 minutes" in cli_markdown, cli_markdown
     assert "heartbeat-prompt --thin" in cli_markdown, cli_markdown
     assert "Fresh Repo Install Repair" in cli_markdown, cli_markdown
     assert "Post-Bootstrap Thin Loop Prompt" in cli_markdown, cli_markdown

--- a/examples/heartbeat-prompt-smoke.py
+++ b/examples/heartbeat-prompt-smoke.py
@@ -646,8 +646,10 @@ def main() -> int:
     getting_started = GETTING_STARTED.read_text(encoding="utf-8")
     assert "docs/guides/getting-started.md" in readme, readme
     assert "loopx heartbeat-prompt --thin" in readme, readme
+    assert "heartbeat automation to run every 3 minutes" in readme, readme
     assert "loopx quota spend-slot" in readme, readme
     assert "Generate a guarded Codex App heartbeat body" in getting_started, getting_started
+    assert "3-minute cadence" in getting_started, getting_started
     assert "loopx heartbeat-prompt --thin" in getting_started, getting_started
     assert "loopx heartbeat-prompt --compact" in getting_started, getting_started
     assert "loopx-canary" in getting_started, getting_started
@@ -656,6 +658,7 @@ def main() -> int:
     assert "safe-bypass or self-repair hints" in getting_started, getting_started
     assert "../heartbeat-automation-prompt.md" in getting_started, getting_started
     assert "execution_obligation" in doc, doc
+    assert "Create a heartbeat automation every 3 minutes" in doc, doc
     assert "must_attempt_work=true" in doc, doc
     assert "not an execution gate" in normalized(doc), doc
     assert "loopx heartbeat-prompt" in doc, doc
@@ -681,7 +684,7 @@ def main() -> int:
     assert "Two Prompt Layers" in doc, doc
     assert "Visible goal text" in doc, doc
     assert "Heartbeat automation task body" in doc, doc
-    assert "Do not use LoopX as an autonomous production controller" in readme, readme
+    assert "LoopX is not an autonomous production controller" in readme, readme
     assert "loopx heartbeat-prompt" in project_skill, project_skill
     assert "--compact" in project_skill, project_skill
     assert "--brief" in project_skill, project_skill

--- a/examples/project-prompt-smoke.py
+++ b/examples/project-prompt-smoke.py
@@ -75,6 +75,7 @@ SPEND_MUST_HAVE = (
 )
 HEARTBEAT_PROMPT_MUST_HAVE = (
     "如果要给这个项目设置 recurring Codex App heartbeat",
+    "默认每 3 分钟一次",
     "loopx heartbeat-prompt",
     "--active-state .codex/goals/",
     "再把输出复制进 automation",

--- a/loopx/project_prompt.py
+++ b/loopx/project_prompt.py
@@ -285,7 +285,7 @@ def build_codex_cli_bootstrap_message(
         f"{cli_bin} doctor passed after no-clone install repair or existing install",
         "repo bootstrap/connect completed conservatively or a concrete install/connect blocker was shown",
         f"thin heartbeat task_body generated from {cli_bin} heartbeat-prompt --thin, not hand-written",
-        "current loop surface configured from the thin task_body: Codex CLI /goal or Codex App automation",
+        "current loop surface configured from the thin task_body: Codex CLI /goal or Codex App automation every 3 minutes",
         "quota/status guard checked with the registered agent id when available after bootstrap/connect",
         "current goal, concrete user gate or none, top todos, and next safe action shown in the TUI",
         "no raw Codex transcripts, session files, credentials, private paths, stdout, or stderr persisted",
@@ -317,6 +317,7 @@ def build_codex_cli_bootstrap_message(
         "heartbeat_prompt_json_command": heartbeat_prompt_json_command,
         "codex_cli_goal_prefix": "/goal ",
         "codex_app_loop_surface": "heartbeat automation task_body",
+        "codex_app_default_heartbeat_cadence": "3 minutes",
         "quota_guard_command": quota_guard_command,
         "refresh_command": refresh_command,
         "quota_spend_command": quota_spend_command,
@@ -471,7 +472,8 @@ heartbeat prompt. Complete the setup in order: install or repair LoopX
 if needed; bootstrap/connect this project; then configure the current loop
 surface from the generated thin heartbeat prompt. For Codex CLI, set the
 current TUI goal to `/goal ` plus the thin `task_body`. For Codex App, set or
-refresh the heartbeat automation to that same thin `task_body`. If the current
+refresh the heartbeat automation to run every 3 minutes with that same thin
+`task_body`. If the current
 surface cannot be mutated from this session, show the exact pasteable `/goal`
 or automation body and report that as a concrete user gate; do not claim setup
 success.
@@ -486,7 +488,7 @@ Success criteria for this first setup turn:
 - If LoopX is already installed and this repo is already connected,
   reuse the existing install/state and do not reinstall or duplicate bootstrap.
 - Configure the loop target after bootstrap: Codex CLI `/goal <thin task_body>`
-  or Codex App heartbeat automation `<thin task_body>`.
+  or Codex App heartbeat automation every 3 minutes with `<thin task_body>`.
 - Show me the current goal id, concrete user gate if any, top user todo if any,
   top agent todo, and next safe action.
 - Do not do longer delivery work in the setup turn unless I explicitly ask; the
@@ -518,7 +520,8 @@ hand-write or copy an old heartbeat body:
 
 Read `task_body` from the JSON result. Then configure the current surface:
 - Codex CLI TUI: set the current goal to `/goal ` followed by that `task_body`.
-- Codex App: set or update the heartbeat automation body to that `task_body`.
+- Codex App: set or update the heartbeat automation to run every 3 minutes
+  with that `task_body`.
 
 For review, the Markdown form is:
 
@@ -713,7 +716,7 @@ def render_prompt_text(
 ```
 
    只把输出的 handoff 交给目标项目 agent；完整 review packet 留给 operator view / evidence drill-down。
-7. 如果要给这个项目设置 recurring Codex App heartbeat，不要手抄 guard 和 spend 协议；先生成 task body，再把输出复制进 automation：
+7. 如果要给这个项目设置 recurring Codex App heartbeat，默认每 3 分钟一次；不要手抄 guard 和 spend 协议；先生成 task body，再把输出复制进 automation：
 
 ```bash
 {cli_bin} heartbeat-prompt --goal-id {goal_id} --active-state .codex/goals/{goal_id}/ACTIVE_GOAL_STATE.md
@@ -786,7 +789,8 @@ def render_codex_cli_bootstrap_message_markdown(payload: dict[str, Any]) -> str:
         goal_mode_note = (
             "\nThe generated block is a setup message, not the reusable heartbeat body. "
             "After install/bootstrap, it tells the agent to set Codex CLI goal mode "
-            "to `/goal <thin task_body>` or Codex App automation to `<thin task_body>`.\n"
+            "to `/goal <thin task_body>` or Codex App automation every 3 minutes "
+            "with `<thin task_body>`.\n"
         )
     return f"""# Codex CLI LoopX Bootstrap Message
 
@@ -815,7 +819,7 @@ Generate the thin task body after the project is connected:
 ```
 
 - Codex CLI TUI loop: set `/goal <task_body>`.
-- Codex App loop: set heartbeat automation body to `<task_body>`.
+- Codex App loop: set heartbeat automation every 3 minutes with `<task_body>`.
 
 ## Transcript-Free Validation Checklist
 


### PR DESCRIPTION
## Summary
- make Codex App onboarding prompts install thin heartbeat automations on a 3-minute cadence by default
- propagate that cadence into generated bootstrap/new-project prompts and shipped docs
- add smoke coverage for the default cadence across docs and generated payloads

## Validation
- python3 examples/codex-cli-bootstrap-message-smoke.py
- python3 examples/project-prompt-smoke.py
- python3 examples/heartbeat-prompt-smoke.py
- python3 examples/fresh-clone-quickstart-smoke.py
- python3 -m py_compile loopx/project_prompt.py
- git diff --check HEAD~1 HEAD
- loopx check --scan-path README.md --scan-path README.zh-CN.md --scan-path docs/guides/getting-started.md --scan-path docs/heartbeat-automation-prompt.md --scan-path docs/new-project-codex-prompt.md --scan-path docs/product/codex-cli-tui-loop.md --scan-path loopx/project_prompt.py --scan-path examples/codex-cli-bootstrap-message-smoke.py --scan-path examples/project-prompt-smoke.py --scan-path examples/heartbeat-prompt-smoke.py

LoopX check warning: existing duplicate index rows for loopx-meta; public boundary scan clean for changed files.