### PR TITLE
Add safe per-project LoopX uninstall

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -326,8 +326,24 @@ Keep three layers separate:
   docs. They can constrain contributors and agents in this repository, but they
   should not silently become global skill policy for every project.
 
-There is no dedicated uninstall command yet. For manual cleanup, remove only
-the reusable surfaces you intend to drop:
+To disconnect only the current project from LoopX, use the project-local
+uninstall command from that project root. It defaults to a dry-run preview and
+refuses to operate directly on the shared global registry:
+
+```bash
+loopx uninstall-project
+loopx uninstall-project --goal-id <goal-id> --archive-state --execute
+```
+
+`uninstall-project` removes the selected goal from `.loopx/registry.json` and
+from the shared global registry only when the global entry's `source_registry`
+points back to this project. It does not uninstall the LoopX CLI and does not
+delete other projects' runtime history. Pass `--archive-state` to move this
+project's `.codex/goals/<goal-id>/` directory under
+`.loopx/archived-project-state/` instead of leaving it in place.
+
+For manual cleanup of the reusable LoopX CLI and skill surfaces, remove only
+the pieces you intend to drop:
 
 ```bash
 rm -f ~/.local/bin/loopx ~/.local/bin/loopx-canary
@@ -760,6 +776,7 @@ upgrade-plan            plan local default-upgrade heartbeat propagation
 review-packet           package a CLI-visible handoff packet
 serve-status            serve local status JSON for the dashboard
 archive-runtime         archive obsolete runtime-only goal history
+uninstall-project       disconnect the current project without removing other projects
 sync-global             merge project registry into the global registry
 check                   run contract and public/private boundary checks
 ```

--- a/examples/cli-registry-admin-command-modularization-smoke.py
+++ b/examples/cli-registry-admin-command-modularization-smoke.py
@@ -66,6 +66,9 @@ def write_fixture(project: Path) -> tuple[Path, Path, Path, Path]:
     doc_registry_path = project / "DOC_REGISTRY.yaml"
     obsolete_runtime = runtime_root / "goals" / "obsolete-runtime-goal" / "runs"
     obsolete_runtime.mkdir(parents=True, exist_ok=True)
+    state_file = project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+    state_file.parent.mkdir(parents=True, exist_ok=True)
+    state_file.write_text("# Registry Admin Smoke State\n", encoding="utf-8")
     (project / "README.md").write_text("# Registry Admin Smoke\n", encoding="utf-8")
 
     goal = {
@@ -150,6 +153,7 @@ def main() -> None:
         'if args.command == "configure-goal":',
         'if args.command == "register-agent":',
         'if args.command == "archive-runtime":',
+        'if args.command == "uninstall-project":',
         'if args.command == "sync-global":',
         'if args.command == "migrate-state":',
         'if args.command == "register-authority-source":',
@@ -165,6 +169,7 @@ def main() -> None:
         "configure-goal",
         "register-agent",
         "archive-runtime",
+        "uninstall-project",
         "sync-global",
         "migrate-state",
         "register-authority-source",
@@ -180,6 +185,7 @@ def main() -> None:
         "configure-goal": ("--quota-compute", "--registered-agent", "--execute"),
         "register-agent": ("--agent-id", "--primary-agent", "--execute"),
         "archive-runtime": ("--archive-root", "--allow-registered", "--execute"),
+        "uninstall-project": ("--goal-id", "--archive-state", "--remove-empty-registry", "--execute"),
         "sync-global": ("--replace-state", "--dry-run"),
         "migrate-state": ("--legacy-registry", "--goal-id-map", "--copy-runtime"),
         "register-authority-source": ("--source-ref", "--boundary", "--no-global-sync"),
@@ -223,6 +229,12 @@ def main() -> None:
         require(archive_payload.get("dry_run") is True, "archive-runtime should dry-run by default")
         require(archive_payload.get("archived") is False, "archive-runtime preview should not move")
         require((runtime_root / "goals" / "obsolete-runtime-goal").exists(), "archive-runtime preview moved source")
+
+        uninstall_payload = run_json(command_prefix, "uninstall-project", "--goal-id", GOAL_ID, "--archive-state")
+        require(uninstall_payload.get("dry_run") is True, "uninstall-project should dry-run by default")
+        require(uninstall_payload.get("wrote_local_registry") is False, "uninstall-project preview should not write local registry")
+        require(uninstall_payload.get("wrote_global_registry") is False, "uninstall-project preview should not write global registry")
+        require(registry_path.read_text(encoding="utf-8") == registry_before, "uninstall-project preview changed registry")
 
         sync_payload = run_json(command_prefix, "sync-global", "--goal-id", GOAL_ID, "--dry-run")
         require(sync_payload.get("dry_run") is True, "sync-global should honor --dry-run")

--- a/examples/project-uninstall-smoke.py
+++ b/examples/project-uninstall-smoke.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Smoke-test per-project LoopX uninstall safety."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TARGET_GOAL_ID = "project-uninstall-target"
+KEEP_GOAL_ID = "project-uninstall-keep"
+OTHER_GOAL_ID = "other-project-goal"
+
+
+def write_json(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def goal(project: Path, registry_path: Path, goal_id: str) -> dict[str, object]:
+    return {
+        "id": goal_id,
+        "objective": f"Fixture {goal_id}.",
+        "domain": "project-uninstall-smoke",
+        "repo": str(project),
+        "state_file": f".codex/goals/{goal_id}/ACTIVE_GOAL_STATE.md",
+        "status": "connected-read-only",
+        "adapter": {"kind": "fixture", "status": "connected-read-only"},
+        "source_registry": str(registry_path),
+    }
+
+
+def write_state(project: Path, goal_id: str) -> None:
+    state = project / ".codex" / "goals" / goal_id / "ACTIVE_GOAL_STATE.md"
+    state.parent.mkdir(parents=True, exist_ok=True)
+    state.write_text(f"# {goal_id}\n", encoding="utf-8")
+
+
+def write_fixture(root: Path) -> tuple[Path, Path, Path, Path]:
+    runtime = root / "runtime"
+    project = root / "project"
+    other_project = root / "other-project"
+    registry_path = project / ".loopx" / "registry.json"
+    other_registry_path = other_project / ".loopx" / "registry.json"
+
+    for goal_id in (TARGET_GOAL_ID, KEEP_GOAL_ID):
+        write_state(project, goal_id)
+    write_state(other_project, OTHER_GOAL_ID)
+
+    local_goals = [
+        goal(project, registry_path, TARGET_GOAL_ID),
+        goal(project, registry_path, KEEP_GOAL_ID),
+    ]
+    write_json(
+        registry_path,
+        {
+            "schema_version": "0.1",
+            "registry_role": "project-local",
+            "common_runtime_root": str(runtime),
+            "goals": local_goals,
+        },
+    )
+    write_json(
+        runtime / "registry.global.json",
+        {
+            "schema_version": "0.1",
+            "registry_role": "global-local",
+            "common_runtime_root": str(runtime),
+            "goals": [
+                *local_goals,
+                goal(other_project, other_registry_path, OTHER_GOAL_ID),
+            ],
+        },
+    )
+    return project, registry_path, runtime, runtime / "registry.global.json"
+
+
+def run_cli(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ, "PYTHONPATH": str(REPO_ROOT)}
+    return subprocess.run(
+        [sys.executable, "-m", "loopx.cli", "--format", "json", *args],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=check,
+    )
+
+
+def payload(result: subprocess.CompletedProcess[str]) -> dict[str, object]:
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise AssertionError(f"expected JSON output, got:\n{result.stdout}\n{result.stderr}") from exc
+
+
+def goal_ids(registry_path: Path) -> list[str]:
+    data = json.loads(registry_path.read_text(encoding="utf-8"))
+    return [str(goal["id"]) for goal in data.get("goals", []) if isinstance(goal, dict)]
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="loopx-project-uninstall-") as tmp:
+        project, registry_path, runtime, global_registry = write_fixture(Path(tmp))
+        local_before = registry_path.read_text(encoding="utf-8")
+        global_before = global_registry.read_text(encoding="utf-8")
+
+        dry_run = payload(
+            run_cli(
+                "--registry",
+                str(registry_path),
+                "--runtime-root",
+                str(runtime),
+                "uninstall-project",
+                "--goal-id",
+                TARGET_GOAL_ID,
+                "--archive-state",
+            )
+        )
+        assert dry_run["ok"] is True, dry_run
+        assert dry_run["dry_run"] is True, dry_run
+        assert dry_run["goal_ids"] == [TARGET_GOAL_ID], dry_run
+        assert dry_run["global_registry_removed_goal_ids"] == [TARGET_GOAL_ID], dry_run
+        assert registry_path.read_text(encoding="utf-8") == local_before
+        assert global_registry.read_text(encoding="utf-8") == global_before
+
+        no_local_fallback = payload(
+            run_cli(
+                "--runtime-root",
+                str(runtime),
+                "uninstall-project",
+                "--goal-id",
+                TARGET_GOAL_ID,
+                check=False,
+            )
+        )
+        assert no_local_fallback["ok"] is False, no_local_fallback
+        assert "project registry does not exist" in no_local_fallback["error"], no_local_fallback
+
+        applied = payload(
+            run_cli(
+                "--registry",
+                str(registry_path),
+                "--runtime-root",
+                str(runtime),
+                "uninstall-project",
+                "--goal-id",
+                TARGET_GOAL_ID,
+                "--archive-state",
+                "--execute",
+            )
+        )
+        assert applied["ok"] is True, applied
+        assert applied["dry_run"] is False, applied
+        assert applied["wrote_local_registry"] is True, applied
+        assert applied["wrote_global_registry"] is True, applied
+        assert applied["global_registry_removed_goal_ids"] == [TARGET_GOAL_ID], applied
+        assert Path(str(applied["local_registry_backup_path"])).exists(), applied
+        assert Path(str(applied["global_registry_backup_path"])).exists(), applied
+        assert goal_ids(registry_path) == [KEEP_GOAL_ID]
+        assert goal_ids(global_registry) == [KEEP_GOAL_ID, OTHER_GOAL_ID]
+        assert not (project / ".codex" / "goals" / TARGET_GOAL_ID).exists()
+        archived = applied["state_actions"][0]["archive_path"]
+        assert Path(str(archived)).exists(), applied
+        assert (project / ".codex" / "goals" / KEEP_GOAL_ID / "ACTIVE_GOAL_STATE.md").exists()
+
+        blocked = payload(
+            run_cli(
+                "--registry",
+                str(global_registry),
+                "--runtime-root",
+                str(runtime),
+                "uninstall-project",
+                "--goal-id",
+                KEEP_GOAL_ID,
+                "--execute",
+                check=False,
+            )
+        )
+        assert blocked["ok"] is False, blocked
+        assert "refused to operate on the global registry" in blocked["error"], blocked
+
+    print("project-uninstall-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -159,6 +159,7 @@ def main(argv: list[str] | None = None) -> int:
             "new-project-prompt",
             "heartbeat-prompt",
             "sync-global",
+            "uninstall-project",
             "version",
         }
         and not user_supplied_registry(argv)

--- a/loopx/cli_commands/registry_admin.py
+++ b/loopx/cli_commands/registry_admin.py
@@ -19,6 +19,7 @@ from ..configure_goal import configure_goal, render_configure_goal_markdown
 from ..global_registry import render_global_sync_markdown, sync_project_registry_to_global
 from ..history import load_registry
 from ..paths import DEFAULT_RUNTIME_ROOT, global_registry_path, resolve_runtime_root
+from ..project_uninstall import render_project_uninstall_markdown, uninstall_project
 from ..registry import registry_goals
 from ..runtime import archive_runtime_goal, render_archive_runtime_markdown
 from ..state_migration import (
@@ -40,6 +41,7 @@ REGISTRY_ADMIN_COMMANDS = {
     "configure-goal",
     "register-agent",
     "archive-runtime",
+    "uninstall-project",
     "sync-global",
     "migrate-state",
     "register-authority-source",
@@ -306,6 +308,32 @@ def register_registry_admin_commands(subparsers: argparse._SubParsersAction) -> 
         help="Actually move the runtime directory. Without this flag the command is a dry-run.",
     )
 
+    uninstall_project_parser = subparsers.add_parser(
+        "uninstall-project",
+        help="Disconnect the current project from LoopX without uninstalling the LoopX CLI or other projects.",
+    )
+    uninstall_project_parser.add_argument(
+        "--goal-id",
+        action="append",
+        default=None,
+        help="Goal id to disconnect. Repeatable; defaults to every goal in this project registry.",
+    )
+    uninstall_project_parser.add_argument(
+        "--archive-state",
+        action="store_true",
+        help="Move each selected project-local .codex/goals/<goal-id> state directory into .loopx/archived-project-state/.",
+    )
+    uninstall_project_parser.add_argument(
+        "--remove-empty-registry",
+        action="store_true",
+        help="Remove .loopx/registry.json when all local goals are uninstalled. A backup is written first on --execute.",
+    )
+    uninstall_project_parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Write registry changes. Without this flag, uninstall-project is a dry-run preview.",
+    )
+
     sync_global_parser = subparsers.add_parser(
         "sync-global",
         help="Merge this project-local registry into the shared global registry.",
@@ -570,6 +598,31 @@ def handle_registry_admin_command(
                 "error": str(exc),
             }
         print_payload(payload, args.format, render_archive_runtime_markdown)
+        return 0 if payload.get("ok") else 1
+
+    if args.command == "uninstall-project":
+        try:
+            payload = uninstall_project(
+                registry_path=registry_path,
+                runtime_root_override=args.runtime_root,
+                goal_ids=args.goal_id,
+                archive_state=bool(args.archive_state),
+                remove_empty_registry=bool(args.remove_empty_registry),
+                execute=bool(args.execute),
+            )
+        except Exception as exc:
+            payload = {
+                "ok": False,
+                "schema_version": "loopx_project_uninstall_v0",
+                "dry_run": not bool(args.execute),
+                "execute": bool(args.execute),
+                "registry": str(registry_path),
+                "goal_ids": args.goal_id or [],
+                "wrote_local_registry": False,
+                "wrote_global_registry": False,
+                "error": str(exc),
+            }
+        print_payload(payload, args.format, render_project_uninstall_markdown)
         return 0 if payload.get("ok") else 1
 
     if args.command == "sync-global":

--- a/loopx/project_uninstall.py
+++ b/loopx/project_uninstall.py
@@ -1,0 +1,391 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .history import load_registry
+from .paths import DEFAULT_RUNTIME_ROOT, global_registry_path, resolve_runtime_root
+from .registry import registry_goals
+from .runtime import validate_goal_id_path_segment
+
+
+def _now_local() -> str:
+    return datetime.now(timezone.utc).astimezone().replace(microsecond=0).isoformat()
+
+
+def _timestamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    temp_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    temp_path.replace(path)
+
+
+def _copy_backup(path: Path, *, label: str, dry_run: bool) -> str | None:
+    if not path.exists():
+        return None
+    backup_path = path.with_name(f"{path.name}.{label}-{_timestamp()}.bak")
+    if not dry_run:
+        shutil.copy2(path, backup_path)
+    return str(backup_path)
+
+
+def _resolve_path(path: Path) -> str:
+    try:
+        return str(path.expanduser().resolve())
+    except OSError:
+        return str(path.expanduser())
+
+
+def _same_path(left: str | Path | None, right: str | Path | None) -> bool:
+    if left is None or right is None:
+        return False
+    return _resolve_path(Path(str(left))) == _resolve_path(Path(str(right)))
+
+
+def _project_root_from_registry(registry_path: Path) -> Path:
+    parent = registry_path.expanduser().parent
+    if parent.name == ".loopx":
+        return parent.parent
+    return parent
+
+
+def _resolve_state_file(goal: dict[str, Any], *, registry_path: Path) -> Path | None:
+    state_file = goal.get("state_file")
+    if not state_file:
+        return None
+    path = Path(str(state_file)).expanduser()
+    if path.is_absolute():
+        return path
+    repo = Path(str(goal.get("repo"))).expanduser() if goal.get("repo") else _project_root_from_registry(registry_path)
+    return repo / path
+
+
+def _unique_destination(path: Path) -> Path:
+    candidate = path
+    suffix = 2
+    while candidate.exists():
+        candidate = path.with_name(f"{path.name}-{suffix}")
+        suffix += 1
+    return candidate
+
+
+def _archive_state_directory(
+    *,
+    goal: dict[str, Any],
+    registry_path: Path,
+    archive_root: Path,
+    timestamp: str,
+    dry_run: bool,
+) -> dict[str, Any]:
+    goal_id = str(goal.get("id") or "")
+    state_file = _resolve_state_file(goal, registry_path=registry_path)
+    if state_file is None:
+        return {
+            "goal_id": goal_id,
+            "action": "no-state-file-recorded",
+            "archived": False,
+        }
+    project_root = _project_root_from_registry(registry_path).resolve()
+    state_dir = state_file.parent
+    try:
+        state_dir_resolved = state_dir.resolve()
+        state_dir_resolved.relative_to(project_root)
+    except (OSError, ValueError):
+        return {
+            "goal_id": goal_id,
+            "state_file": str(state_file),
+            "action": "kept-external-state",
+            "archived": False,
+            "warning": "state file is outside the project root; kept in place",
+        }
+    if not state_dir.exists():
+        return {
+            "goal_id": goal_id,
+            "state_file": str(state_file),
+            "state_dir": str(state_dir),
+            "action": "state-dir-missing",
+            "archived": False,
+        }
+    destination = _unique_destination(archive_root / timestamp / "goals" / goal_id)
+    if not dry_run:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(state_dir), str(destination))
+    return {
+        "goal_id": goal_id,
+        "state_file": str(state_file),
+        "state_dir": str(state_dir),
+        "archive_path": str(destination),
+        "action": "would-move" if dry_run else "moved",
+        "archived": not dry_run,
+    }
+
+
+def _selected_goals(
+    registry: dict[str, Any],
+    *,
+    requested_goal_ids: list[str] | None,
+) -> list[dict[str, Any]]:
+    goals = registry_goals(registry)
+    if not requested_goal_ids:
+        return goals
+    requested = {validate_goal_id_path_segment(goal_id) for goal_id in requested_goal_ids}
+    found = {str(goal.get("id")) for goal in goals if str(goal.get("id")) in requested}
+    missing = sorted(requested - found)
+    if missing:
+        raise ValueError(f"goal id not found in project registry: {', '.join(missing)}")
+    return [goal for goal in goals if str(goal.get("id")) in requested]
+
+
+def _remove_local_goals(
+    registry: dict[str, Any],
+    *,
+    target_goal_ids: set[str],
+) -> tuple[dict[str, Any], int, int]:
+    goals = registry.get("goals")
+    before = len(registry_goals(registry))
+    if not isinstance(goals, list):
+        payload = dict(registry)
+        payload["goals"] = []
+        return payload, before, 0
+    kept = [
+        item
+        for item in goals
+        if not (isinstance(item, dict) and str(item.get("id") or "") in target_goal_ids)
+    ]
+    payload = dict(registry)
+    payload["updated_at"] = _now_local()
+    payload["goals"] = kept
+    after = len([item for item in kept if isinstance(item, dict) and item.get("id")])
+    return payload, before, after
+
+
+def _remove_global_goals(
+    global_registry: dict[str, Any],
+    *,
+    source_registry: Path,
+    target_goal_ids: set[str],
+) -> tuple[dict[str, Any], list[str], list[str], int, int]:
+    goals = global_registry.get("goals")
+    before = len(registry_goals(global_registry))
+    if not isinstance(goals, list):
+        payload = dict(global_registry)
+        payload["goals"] = []
+        return payload, [], [], before, 0
+
+    kept: list[Any] = []
+    removed: list[str] = []
+    skipped_route_mismatch: list[str] = []
+    for item in goals:
+        if not isinstance(item, dict):
+            kept.append(item)
+            continue
+        goal_id = str(item.get("id") or "")
+        if goal_id not in target_goal_ids:
+            kept.append(item)
+            continue
+        if _same_path(item.get("source_registry"), source_registry):
+            removed.append(goal_id)
+            continue
+        skipped_route_mismatch.append(goal_id)
+        kept.append(item)
+
+    payload = dict(global_registry)
+    payload["schema_version"] = str(payload.get("schema_version") or "0.1")
+    payload["updated_at"] = _now_local()
+    payload["goals"] = kept
+    after = len([item for item in kept if isinstance(item, dict) and item.get("id")])
+    return payload, removed, skipped_route_mismatch, before, after
+
+
+def uninstall_project(
+    *,
+    registry_path: Path,
+    runtime_root_override: str | None,
+    goal_ids: list[str] | None,
+    archive_state: bool,
+    remove_empty_registry: bool,
+    execute: bool,
+) -> dict[str, Any]:
+    registry_path = registry_path.expanduser()
+    if not registry_path.exists():
+        raise FileNotFoundError(f"project registry does not exist: {registry_path}")
+    registry_path = registry_path.resolve()
+    project_registry = load_registry(registry_path)
+    runtime_root = resolve_runtime_root(project_registry, runtime_root_override)
+    global_path = global_registry_path(runtime_root)
+    if global_path.exists() and registry_path == global_path.resolve():
+        raise ValueError(
+            "uninstall-project refused to operate on the global registry; "
+            "run it from a project root or pass --registry <project>/.loopx/registry.json"
+        )
+
+    selected = _selected_goals(project_registry, requested_goal_ids=goal_ids)
+    if not selected:
+        raise ValueError("project registry contains no goals to uninstall")
+
+    target_goal_ids = {str(goal.get("id")) for goal in selected if goal.get("id")}
+    timestamp = _timestamp()
+    dry_run = not execute
+    new_project_registry, local_before, local_after = _remove_local_goals(
+        project_registry,
+        target_goal_ids=target_goal_ids,
+    )
+
+    global_registry = load_registry(global_path) if global_path.exists() else {}
+    new_global_registry, global_removed, skipped_route_mismatch, global_before, global_after = _remove_global_goals(
+        global_registry,
+        source_registry=registry_path,
+        target_goal_ids=target_goal_ids,
+    )
+
+    archive_root = registry_path.parent / "archived-project-state"
+    state_actions = (
+        [
+            _archive_state_directory(
+                goal=goal,
+                registry_path=registry_path,
+                archive_root=archive_root,
+                timestamp=timestamp,
+                dry_run=dry_run,
+            )
+            for goal in selected
+        ]
+        if archive_state
+        else [
+            {
+                "goal_id": str(goal.get("id")),
+                "action": "kept",
+                "archived": False,
+            }
+            for goal in selected
+        ]
+    )
+
+    local_backup_path = _copy_backup(registry_path, label="project-uninstall-backup", dry_run=dry_run)
+    global_backup_path = (
+        _copy_backup(global_path, label="project-uninstall-backup", dry_run=dry_run)
+        if global_removed
+        else None
+    )
+
+    wrote_local_registry = False
+    removed_local_registry_file = False
+    wrote_global_registry = False
+    if execute:
+        if remove_empty_registry and local_after == 0:
+            registry_path.unlink()
+            removed_local_registry_file = True
+        else:
+            _write_json(registry_path, new_project_registry)
+            wrote_local_registry = True
+        if global_removed:
+            _write_json(global_path, new_global_registry)
+            wrote_global_registry = True
+
+    return {
+        "ok": True,
+        "schema_version": "loopx_project_uninstall_v0",
+        "dry_run": dry_run,
+        "execute": execute,
+        "registry": str(registry_path),
+        "runtime_root": str(runtime_root or DEFAULT_RUNTIME_ROOT),
+        "global_registry": str(global_path),
+        "goal_ids": sorted(target_goal_ids),
+        "local_registry_goal_count_before": local_before,
+        "local_registry_goal_count_after": local_after,
+        "local_registry_backup_path": local_backup_path,
+        "wrote_local_registry": wrote_local_registry,
+        "removed_local_registry_file": removed_local_registry_file,
+        "global_registry_goal_count_before": global_before,
+        "global_registry_goal_count_after": global_after,
+        "global_registry_removed_goal_ids": sorted(set(global_removed)),
+        "global_registry_skipped_route_mismatch_goal_ids": sorted(set(skipped_route_mismatch)),
+        "global_registry_backup_path": global_backup_path,
+        "wrote_global_registry": wrote_global_registry,
+        "archive_state": archive_state,
+        "state_actions": state_actions,
+        "actions": [
+            {
+                "path": str(registry_path),
+                "action": (
+                    "would-remove-file"
+                    if remove_empty_registry and local_after == 0
+                    else "would-write"
+                )
+                if dry_run
+                else ("removed-file" if removed_local_registry_file else "wrote"),
+            },
+            {
+                "path": str(global_path),
+                "action": "would-write" if dry_run and global_removed else ("wrote" if wrote_global_registry else "kept"),
+            },
+        ],
+        "warnings": (
+            [
+                "matching global route was not found; only project-local state will be changed"
+            ]
+            if not global_removed
+            else []
+        )
+        + (
+            [
+                "one or more global goals with the same id were kept because source_registry did not match this project"
+            ]
+            if skipped_route_mismatch
+            else []
+        ),
+    }
+
+
+def render_project_uninstall_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# LoopX Project Uninstall",
+        "",
+        f"- ok: `{payload.get('ok')}`",
+        f"- dry_run: `{payload.get('dry_run')}`",
+        f"- execute: `{payload.get('execute')}`",
+        f"- registry: `{payload.get('registry')}`",
+        f"- global_registry: `{payload.get('global_registry')}`",
+        f"- goals: `{', '.join(payload.get('goal_ids') or [])}`",
+        f"- local_registry_goal_count: `{payload.get('local_registry_goal_count_before')} -> {payload.get('local_registry_goal_count_after')}`",
+        f"- global_registry_goal_count: `{payload.get('global_registry_goal_count_before')} -> {payload.get('global_registry_goal_count_after')}`",
+        f"- wrote_local_registry: `{payload.get('wrote_local_registry')}`",
+        f"- wrote_global_registry: `{payload.get('wrote_global_registry')}`",
+    ]
+    if payload.get("error"):
+        lines.append(f"- error: {payload.get('error')}")
+        return "\n".join(lines)
+    if payload.get("local_registry_backup_path"):
+        lines.append(f"- local_registry_backup_path: `{payload.get('local_registry_backup_path')}`")
+    if payload.get("global_registry_backup_path"):
+        lines.append(f"- global_registry_backup_path: `{payload.get('global_registry_backup_path')}`")
+
+    removed = payload.get("global_registry_removed_goal_ids") or []
+    if removed:
+        lines.extend(["", "## Removed Global Routes"])
+        lines.extend(f"- {goal_id}" for goal_id in removed)
+    state_actions = payload.get("state_actions") if isinstance(payload.get("state_actions"), list) else []
+    if state_actions:
+        lines.extend(["", "## Local State"])
+        for action in state_actions:
+            if not isinstance(action, dict):
+                continue
+            suffix = f" -> `{action.get('archive_path')}`" if action.get("archive_path") else ""
+            lines.append(f"- {action.get('goal_id')}: `{action.get('action')}`{suffix}")
+            if action.get("warning"):
+                lines.append(f"  - warning: {action.get('warning')}")
+    warnings = payload.get("warnings") if isinstance(payload.get("warnings"), list) else []
+    if warnings:
+        lines.extend(["", "## Warnings"])
+        lines.extend(f"- {warning}" for warning in warnings)
+    if payload.get("dry_run"):
+        lines.extend(["", "Run again with `--execute` to disconnect this project."])
+    return "\n".join(lines)


### PR DESCRIPTION
## Summary
- add `loopx uninstall-project` as a dry-run-by-default project detach command
- refuse direct global-registry uninstall targets and disable global fallback for this command
- remove only global entries whose `source_registry` points at the project registry; optionally archive project-local active state with `--archive-state`
- document per-project uninstall in Getting Started and add durable smokes

## Global state backup
- created local backup before implementation: `/Users/bytedance/.codex/loopx-backups/loopx-global-state-20260623T170546+0800.tgz`
- sha256: `f5e0b3998c59273e50e7e59cb5c1ad78b9dcfa432d6b371b5f41a82146f6448d`

## Validation
- `python3 examples/project-uninstall-smoke.py`
- `python3 examples/cli-registry-admin-command-modularization-smoke.py`
- `python3 examples/connect-route-collision-guard-smoke.py`
- `python3 examples/global-registry-sync-smoke.py`
- `python3 examples/fresh-clone-quickstart-smoke.py`
- `python3 examples/heartbeat-prompt-smoke.py`
- `python3 -m py_compile loopx/project_uninstall.py loopx/cli.py loopx/cli_commands/registry_admin.py`
- `git diff --check HEAD~1 HEAD`
- `loopx check --scan-path loopx/project_uninstall.py --scan-path loopx/cli.py --scan-path loopx/cli_commands/registry_admin.py --scan-path docs/guides/getting-started.md --scan-path examples/project-uninstall-smoke.py --scan-path examples/cli-registry-admin-command-modularization-smoke.py`

LoopX check warning: existing duplicate index rows for loopx-meta; public boundary scan clean for changed files.
