### PR TITLE
Fix SkillsBench bridge solver contract

### DIFF
--- a/docs/benchmark-developer-workflow.md
+++ b/docs/benchmark-developer-workflow.md
@@ -1469,6 +1469,12 @@ task text, paths, credentials, logs, trajectories, uploads, or submissions.
 local fake bridge for smoke tests and adapter development. It is not evidence
 that a real remote executor is ready.
 
+For a scored split-control launch, the readiness probe is not the solver
+bridge. Pass a separate private `--remote-command-file-bridge-solver-command`
+only when that command can operate on the scored BenchFlow sandbox. The runner
+must fail closed when only a probe command is configured, and it must reject the
+repo fake probe helper as a solver command.
+
 ## Evidence Contract
 
 Benchmark evidence may include:

--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -41,6 +41,7 @@ from loopx.benchmark_adapters.skillsbench_acp_relay import (  # noqa: E402
 from loopx.benchmark_adapters.skillsbench_remote_bridge import (  # noqa: E402
     SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_PROBE_SCHEMA_VERSION,
     run_skillsbench_remote_command_file_bridge_probe,
+    skillsbench_remote_command_file_bridge_command_is_fixture_probe,
 )
 from loopx.status import compact_benchmark_run  # noqa: E402
 from scripts.skillsbench_automation_loop import (  # noqa: E402
@@ -318,6 +319,10 @@ def test_skillsbench_remote_command_file_bridge_probe_fake_bridge_ready() -> Non
         str(REPO_ROOT / "scripts/skillsbench_remote_command_file_bridge.py"),
         "--serve-probe",
     ]
+    assert skillsbench_remote_command_file_bridge_command_is_fixture_probe(command)
+    assert not skillsbench_remote_command_file_bridge_command_is_fixture_probe(
+        [sys.executable, "private-skillsbench-sandbox-bridge", "--serve-probe"]
+    )
     payload = run_skillsbench_remote_command_file_bridge_probe(command)
     assert payload["ready"] is True, payload
     assert (

--- a/examples/skillsbench-host-local-launch-plan-smoke.py
+++ b/examples/skillsbench-host-local-launch-plan-smoke.py
@@ -103,6 +103,7 @@ def main() -> int:
         assert failure["remote_command_file_bridge_consumed_by_solver"] is False
         assert failure["raw_logs_recorded"] is False
         assert failure["raw_task_text_read"] is False
+        assert failure["remote_command_file_bridge_probe_command_configured"] is False
         assert failure["remote_command_file_bridge_command_configured"] is False
         preflight = subprocess.run(
             [
@@ -142,7 +143,99 @@ def main() -> int:
             ]
             is True
         ), preflight_payload
+        blocked_probe_only = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--skillsbench-root",
+                str(root),
+                "--task-id",
+                "demo-task",
+                "--route",
+                "loopx-product-mode",
+                "--host-local-acp-launch",
+                "--remote-command-file-bridge-probe",
+                "--remote-command-file-bridge-probe-command",
+                f"{sys.executable} {BRIDGE_SCRIPT} --serve-probe",
+            ],
+            cwd=REPO_ROOT,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        assert blocked_probe_only.returncode == 2, blocked_probe_only
+        probe_only_failure = json.loads(blocked_probe_only.stderr)
+        assert probe_only_failure["error_type"] == (
+            "SkillsBenchReverseChannelBridgeNotSolverWired"
+        ), probe_only_failure
+        assert (
+            probe_only_failure["remote_command_file_bridge_probe_command_configured"]
+            is True
+        )
+        assert (
+            probe_only_failure["remote_command_file_bridge_command_configured"]
+            is False
+        )
+        blocked_fixture_solver = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--skillsbench-root",
+                str(root),
+                "--task-id",
+                "demo-task",
+                "--route",
+                "loopx-product-mode",
+                "--host-local-acp-launch",
+                "--remote-command-file-bridge-ready",
+                "--remote-command-file-bridge-solver-command",
+                f"{sys.executable} {BRIDGE_SCRIPT} --serve-probe",
+            ],
+            cwd=REPO_ROOT,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        assert blocked_fixture_solver.returncode == 2, blocked_fixture_solver
+        fixture_failure = json.loads(blocked_fixture_solver.stderr)
+        assert fixture_failure["error_type"] == (
+            "SkillsBenchReverseChannelBridgeFixtureOnlySolverCommand"
+        ), fixture_failure
         bridge_command = f"{sys.executable} {BRIDGE_SCRIPT} --serve-probe"
+        solver_bridge = Path(tmp) / "fake-solver-bridge"
+        solver_bridge.write_text(
+            f"""#!/usr/bin/env python3
+import json
+import sys
+
+sys.path.insert(0, {str(REPO_ROOT)!r})
+from loopx.benchmark_adapters.skillsbench_remote_bridge import (
+    SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_PROBE_REQUEST_SCHEMA_VERSION,
+    build_skillsbench_remote_command_file_bridge_probe_response,
+)
+
+request = json.loads(sys.stdin.read() or "{{}}")
+if request.get("schema_version") == SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_PROBE_REQUEST_SCHEMA_VERSION:
+    print(json.dumps(build_skillsbench_remote_command_file_bridge_probe_response(
+        ready=True,
+        operations=[
+            {{"kind": "exec", "label": "bounded_noop_command", "status": "ok", "exit_code_zero": True}},
+            {{"kind": "write_file", "label": "probe_marker_write", "status": "ok"}},
+            {{"kind": "read_file", "label": "probe_marker_read", "status": "ok", "content_match": True}},
+            {{"kind": "cleanup", "label": "probe_marker_cleanup", "status": "ok"}},
+        ],
+    ), sort_keys=True))
+else:
+    print(json.dumps({{"ok": True, "operation": request.get("operation"), "stdout": "bridge-used\\n", "stderr": "", "exit_code": 0}}, sort_keys=True))
+""",
+            encoding="utf-8",
+        )
+        solver_bridge.chmod(0o755)
+        solver_bridge_command = str(solver_bridge)
         wired_plan_proc = subprocess.run(
             [
                 sys.executable,
@@ -157,6 +250,8 @@ def main() -> int:
                 "--remote-command-file-bridge-probe",
                 "--remote-command-file-bridge-probe-command",
                 bridge_command,
+                "--remote-command-file-bridge-solver-command",
+                solver_bridge_command,
                 "--plan-only",
             ],
             cwd=REPO_ROOT,
@@ -195,6 +290,8 @@ from pathlib import Path
 args = sys.argv[1:]
 if "Private bridge command:" not in args[-1]:
     raise SystemExit(7)
+if '"operation":"exec"' not in args[-1]:
+    raise SystemExit(10)
 ready, _, _ = select.select([sys.stdin], [], [], 0.2)
 if not ready:
     raise SystemExit(8)
@@ -222,7 +319,7 @@ output.write_text("fake solver saw bridge packet\\n", encoding="utf-8")
                 "--worker-public-trace-dir",
                 str(trace_dir),
                 "--remote-command-file-bridge-command",
-                bridge_command,
+                solver_bridge_command,
                 "--remote-command-file-bridge-timeout-sec",
                 "5",
             ],

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -290,7 +290,12 @@ class SkillsBenchLocalAcpRelay:
 LoopX SkillsBench remote workspace bridge:
 - This local Codex process is outside the scored SkillsBench sandbox.
 - Use the command below as a private JSON bridge for sandbox exec, file write, file read, and cleanup operations.
-- Send JSON requests on stdin and read compact JSON responses on stdout.
+- Send one JSON request on stdin and read one private JSON response on stdout.
+- Request examples:
+  - {{"operation":"exec","cwd":"/app","command":"pwd","timeout_sec":10}}
+  - {{"operation":"read_file","path":"/app/path/to/file","max_bytes":20000}}
+  - {{"operation":"write_file","path":"/app/path/to/file","content":"..."}}
+  - {{"operation":"cleanup","path":"/app/path/to/temp"}}
 - Do not upload, submit, expose credentials, quote the bridge command in final output, or record raw stdout/stderr/task text in public artifacts.
 - The bridge readiness probe completed with ready=true and operation_count={operation_count}.
 

--- a/loopx/benchmark_adapters/skillsbench_remote_bridge.py
+++ b/loopx/benchmark_adapters/skillsbench_remote_bridge.py
@@ -210,6 +210,28 @@ def run_skillsbench_remote_command_file_bridge_probe(
         )
 
 
+def skillsbench_remote_command_file_bridge_command_is_fixture_probe(
+    command: str | list[str] | tuple[str, ...] | None,
+) -> bool:
+    """Return True when a command is the repo's fixture-only probe helper.
+
+    The probe helper intentionally proves only the public-safe stdin/stdout
+    readiness contract. It must not be injected as the private solver bridge for
+    a countable SkillsBench run, because it cannot operate on the scored
+    sandbox workspace.
+    """
+
+    if not command:
+        return False
+    try:
+        argv = _command_to_argv(command)
+    except ValueError:
+        return False
+    if "--serve-probe" not in argv:
+        return False
+    return any(part.endswith("skillsbench_remote_command_file_bridge.py") for part in argv)
+
+
 def _payload_from_bridge_response(
     response: dict[str, Any],
     *,

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -1006,6 +1006,7 @@ def _compact_benchmark_runner_prerequisites(value: Any) -> dict[str, Any]:
         "host_local_acp_launch",
         "remote_command_file_bridge_materialized",
         "remote_command_file_bridge_command_configured",
+        "remote_command_file_bridge_probe_command_configured",
         "remote_command_file_bridge_solver_wiring_configured",
         "remote_command_file_bridge_consumed_by_solver",
         "remote_command_file_bridge_solver_trace_dir_present",

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -98,6 +98,7 @@ from loopx.benchmark_adapters.skillsbench_acp_relay import (  # noqa: E402
 )
 from loopx.benchmark_adapters.skillsbench_remote_bridge import (  # noqa: E402
     run_skillsbench_remote_command_file_bridge_probe,
+    skillsbench_remote_command_file_bridge_command_is_fixture_probe,
 )
 from loopx.benchmark_core.loop_protocol import (  # noqa: E402
     AUTOMATION_LOOP_TREATMENT_ROUTE,
@@ -702,7 +703,7 @@ def _host_local_acp_launch_command(
     if (
         args.route in {"raw-codex-autonomous-max5", "loopx-product-mode"}
         and args.host_local_acp_launch
-        and args.remote_command_file_bridge_probe_command
+        and args.remote_command_file_bridge_solver_command
         and (
             args.remote_command_file_bridge_ready
             or args.remote_command_file_bridge_probe
@@ -711,7 +712,7 @@ def _host_local_acp_launch_command(
         command.extend(
             [
                 "--remote-command-file-bridge-command",
-                args.remote_command_file_bridge_probe_command,
+                args.remote_command_file_bridge_solver_command,
                 "--remote-command-file-bridge-timeout-sec",
                 str(args.remote_command_file_bridge_probe_timeout_sec),
             ]
@@ -867,6 +868,7 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "benchflow_agent_install_skipped_by_runtime_layer",
         "remote_command_file_bridge_materialized",
         "remote_command_file_bridge_command_configured",
+        "remote_command_file_bridge_probe_command_configured",
         "remote_command_file_bridge_solver_wiring_configured",
         "remote_command_file_bridge_consumed_by_solver",
         "remote_command_file_bridge_solver_trace_dir_present",
@@ -2401,14 +2403,17 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
         args.remote_command_file_bridge_ready
         or args.remote_command_file_bridge_probe
     )
-    remote_command_file_bridge_command_configured = bool(
+    remote_command_file_bridge_probe_command_configured = bool(
         args.remote_command_file_bridge_probe_command
+    )
+    remote_command_file_bridge_solver_command_configured = bool(
+        args.remote_command_file_bridge_solver_command
     )
     remote_command_file_bridge_solver_wiring_configured = bool(
         args.host_local_acp_launch
         and route in {"raw-codex-autonomous-max5", "loopx-product-mode"}
         and remote_command_file_bridge_materialized
-        and remote_command_file_bridge_command_configured
+        and remote_command_file_bridge_solver_command_configured
     )
     remote_command_file_bridge_consumed_by_solver = False
     if remote_command_file_bridge_solver_wiring_configured:
@@ -2558,7 +2563,10 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
                 remote_command_file_bridge_materialized
             ),
             "remote_command_file_bridge_command_configured": bool(
-                remote_command_file_bridge_command_configured
+                remote_command_file_bridge_solver_command_configured
+            ),
+            "remote_command_file_bridge_probe_command_configured": bool(
+                remote_command_file_bridge_probe_command_configured
             ),
             "remote_command_file_bridge_solver_wiring_configured": bool(
                 remote_command_file_bridge_solver_wiring_configured
@@ -5439,6 +5447,16 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--remote-command-file-bridge-solver-command",
+        default=None,
+        help=(
+            "Private command injected into host-local product-mode solver prompts "
+            "to operate on the scored SkillsBench sandbox. This is separate from "
+            "the public-safe probe command; fixture-only probe helpers must not "
+            "be used here."
+        ),
+    )
+    parser.add_argument(
         "--remote-command-file-bridge-probe-timeout-sec",
         type=float,
         default=10.0,
@@ -5625,9 +5643,54 @@ def main(argv: list[str] | None = None) -> int:
         args.remote_command_file_bridge_ready
         or args.remote_command_file_bridge_probe
     )
-    product_host_local_bridge_command_configured = bool(
+    product_host_local_bridge_probe_command_configured = bool(
         args.remote_command_file_bridge_probe_command
     )
+    product_host_local_bridge_command_configured = bool(
+        args.remote_command_file_bridge_solver_command
+    )
+    product_host_local_bridge_fixture_solver = (
+        skillsbench_remote_command_file_bridge_command_is_fixture_probe(
+            args.remote_command_file_bridge_solver_command
+        )
+    )
+    if (
+        args.route in {"raw-codex-autonomous-max5", "loopx-product-mode"}
+        and args.host_local_acp_launch
+        and product_host_local_bridge_fixture_solver
+        and not args.local_driver_worker_handshake_preflight
+        and not args.plan_only
+    ):
+        payload = {
+            "ok": False,
+            "error_type": "SkillsBenchReverseChannelBridgeFixtureOnlySolverCommand",
+            "route": args.route,
+            "reason": (
+                "the configured solver bridge is the repo fixture-only probe "
+                "helper. That helper validates readiness but cannot execute, "
+                "read, write, or clean up inside the scored BenchFlow sandbox."
+            ),
+            "next_action": (
+                "use a real sandbox workspace bridge or switch to the cloud-host "
+                "co-located product path; do not inject the fixture probe command "
+                "into the solver prompt"
+            ),
+            "remote_command_file_bridge_materialized": (
+                product_host_local_bridge_materialized
+            ),
+            "remote_command_file_bridge_probe_command_configured": (
+                product_host_local_bridge_probe_command_configured
+            ),
+            "remote_command_file_bridge_command_configured": True,
+            "remote_command_file_bridge_solver_wiring_configured": False,
+            "remote_command_file_bridge_consumed_by_solver": False,
+            "raw_logs_recorded": False,
+            "raw_task_text_read": False,
+            "raw_trajectory_recorded": False,
+            "credential_values_recorded": False,
+        }
+        print(json.dumps(payload, indent=2, sort_keys=True), file=sys.stderr)
+        return 2
     if (
         args.route in {"raw-codex-autonomous-max5", "loopx-product-mode"}
         and args.host_local_acp_launch
@@ -5655,6 +5718,9 @@ def main(argv: list[str] | None = None) -> int:
             ),
             "remote_command_file_bridge_materialized": (
                 product_host_local_bridge_materialized
+            ),
+            "remote_command_file_bridge_probe_command_configured": (
+                product_host_local_bridge_probe_command_configured
             ),
             "remote_command_file_bridge_command_configured": (
                 product_host_local_bridge_command_configured


### PR DESCRIPTION
## Summary
- separate SkillsBench remote bridge readiness probes from solver bridge commands
- block host-local product-mode runs when only a probe command is configured or when the repo fixture probe is injected as a solver bridge
- document the contract and add smokes covering probe-only, fixture-only solver, and explicit solver bridge wiring

## Root Cause
The host-local product-mode path was using the public-safe fixture probe command as if it were the private solver workspace bridge. The probe helper only validates stdin/stdout readiness; it cannot operate on the scored BenchFlow sandbox. That made real cases look launched while the solver had no usable workspace/state IO path.

## Validation
- python3 -m py_compile loopx/benchmark_adapters/skillsbench_remote_bridge.py loopx/benchmark_adapters/skillsbench_acp_relay.py scripts/skillsbench_automation_loop.py examples/skillsbench-host-local-launch-plan-smoke.py examples/skillsbench-benchmark-run-smoke.py
- python3 examples/skillsbench-host-local-launch-plan-smoke.py
- python3 examples/skillsbench-benchmark-run-smoke.py
- git diff --check
