### PR TITLE
Add explicit GitHub issue metadata fetch

### DIFF
--- a/docs/reference/protocols/content-ops-surface-v0.md
+++ b/docs/reference/protocols/content-ops-surface-v0.md
@@ -182,6 +182,22 @@ emits a `loopx_todo_writeback_preview_v0` candidate for the agent todo, but it
 does not write the todo unless a later command explicitly executes that
 writeback.
 
+A live public metadata read is available only as an explicit opt-in:
+
+```bash
+loopx content-ops issue-fix-metadata-preview \
+  --url https://github.com/owner/repo/issues/123 \
+  --fetch-metadata \
+  --format json
+```
+
+The opt-in path uses `gh api --jq` to emit only the body-free metadata fields
+consumed by the packet. The public artifact records `external_reads_performed:
+true` and `adapter_preview.live_read_performed: true`, but issue bodies,
+comment bodies, timeline events, raw provider responses, stdout/stderr, local
+paths, todo writes, external comments, PR creation, merge, and publish actions
+remain outside the artifact.
+
 Metadata preview is only the intake surface. The issue-fix product path should
 continue to an executable acceptance loop:
 

--- a/examples/content-ops-issue-fix-metadata-preview-smoke.py
+++ b/examples/content-ops-issue-fix-metadata-preview-smoke.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import subprocess
 import sys
@@ -54,11 +55,17 @@ def assert_public_safe(payload: dict[str, Any] | str) -> None:
     assert not leaked, leaked
 
 
-def run_cli(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+def run_cli(
+    args: list[str],
+    *,
+    check: bool = True,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [sys.executable, "-m", "loopx.cli", *args],
         cwd=REPO_ROOT,
         check=check,
+        env=env,
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -173,6 +180,85 @@ def main() -> int:
     assert reference_only["adapter_preview"]["input_mode"] == "reference_only"
     assert reference_only["validation"]["gated_provider_field_count"] == 0
     assert_public_safe(reference_only)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        fake_bin = Path(tmpdir)
+        gh = fake_bin / "gh"
+        gh.write_text(
+            "\n".join(
+                [
+                    "#!/usr/bin/env python3",
+                    "import json",
+                    "import sys",
+                    "argv = sys.argv[1:]",
+                    "assert argv[:2] == ['api', '-H'], argv",
+                    "assert 'repos/huangruiteng/loopx/issues/123' in argv, argv",
+                    "assert '--jq' in argv, argv",
+                    "json.dump({",
+                    "  'number': 123,",
+                    "  'state': 'open',",
+                    "  'title': 'Crash on metadata adapter preview',",
+                    "  'labels': ['bug', 'needs-repro'],",
+                    "  'updated_at': '2026-06-23T00:00:00Z',",
+                    "  'author_association': 'CONTRIBUTOR',",
+                    "  'comments_count': 2,",
+                    "  'kind': 'issue',",
+                    "}, sys.stdout)",
+                    "sys.stdout.write('\\n')",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        gh.chmod(0o755)
+        live_env = {**os.environ, "PATH": f"{fake_bin}:{os.environ.get('PATH', '')}"}
+        live_payload = json.loads(
+            run_cli(
+                [
+                    "--format",
+                    "json",
+                    "content-ops",
+                    "issue-fix-metadata-preview",
+                    "--url",
+                    "https://github.com/huangruiteng/loopx/issues/123",
+                    "--fetch-metadata",
+                ],
+                env=live_env,
+            ).stdout
+        )
+    assert live_payload["ok"] is True, live_payload
+    assert live_payload["external_reads_performed"] is True, live_payload
+    assert live_payload["private_source_bodies_read"] is False, live_payload
+    assert live_payload["github_metadata_preview"]["provider_mode"] == "live_metadata"
+    assert live_payload["github_metadata_preview"]["body_captured"] is False
+    assert live_payload["github_metadata_preview"]["comment_bodies_captured"] is False
+    assert live_payload["github_metadata_preview"]["gated_provider_fields_present"] == []
+    assert live_payload["adapter_preview"]["provider"] == "github"
+    assert live_payload["adapter_preview"]["input_mode"] == "live_metadata"
+    assert live_payload["adapter_preview"]["live_read_performed"] is True
+    assert live_payload["adapter_preview"]["live_read_allowed_by_default"] is False
+    assert live_payload["issue_fix_intake"]["boundary"]["external_reads_performed"] is True
+    assert live_payload["issue_fix_intake"]["boundary"]["issue_body_captured"] is False
+    assert live_payload["issue_fix_intake"]["boundary"]["comment_bodies_captured"] is False
+    assert_public_safe(live_payload)
+
+    rejected_fetch_mix = run_cli(
+        [
+            "--format",
+            "json",
+            "content-ops",
+            "issue-fix-metadata-preview",
+            "--url",
+            "https://github.com/huangruiteng/loopx/issues/123",
+            "--metadata-json",
+            "-",
+            "--fetch-metadata",
+        ],
+        check=False,
+    )
+    assert rejected_fetch_mix.returncode == 1, rejected_fetch_mix
+    rejected_fetch_mix_payload = json.loads(rejected_fetch_mix.stdout)
+    assert rejected_fetch_mix_payload["ok"] is False, rejected_fetch_mix_payload
+    assert "cannot be combined" in rejected_fetch_mix_payload["error"]
 
     markdown = run_cli(["content-ops", "issue-fix-metadata-preview"]).stdout
     assert "LoopX Repo Issue Fix Metadata Preview" in markdown, markdown

--- a/loopx/cli_commands/content_ops_issue_fix.py
+++ b/loopx/cli_commands/content_ops_issue_fix.py
@@ -95,6 +95,20 @@ def register_content_ops_issue_fix_commands(
         ),
     )
     issue_fix_metadata_parser.add_argument(
+        "--fetch-metadata",
+        action="store_true",
+        help=(
+            "Explicitly fetch public GitHub issue/PR metadata with gh api --jq. "
+            "Only body-free metadata fields are captured."
+        ),
+    )
+    issue_fix_metadata_parser.add_argument(
+        "--fetch-timeout-seconds",
+        type=int,
+        default=10,
+        help="Timeout for --fetch-metadata.",
+    )
+    issue_fix_metadata_parser.add_argument(
         "--generated-at",
         default="2026-06-23T00:00:00Z",
         help="Public-safe generated_at timestamp for the metadata preview.",
@@ -115,6 +129,8 @@ def handle_content_ops_issue_fix_command(
             render_content_ops_issue_fix_intake_markdown,
         )
     if args.content_ops_command == "issue-fix-metadata-preview":
+        if args.fetch_metadata and args.metadata_json:
+            raise ValueError("--fetch-metadata cannot be combined with --metadata-json")
         return (
             build_content_ops_issue_fix_metadata_preview_packet(
                 repo=args.repo,
@@ -123,6 +139,8 @@ def handle_content_ops_issue_fix_command(
                 provider_payload=_load_json_object(args.metadata_json)
                 if args.metadata_json
                 else None,
+                fetch_metadata=args.fetch_metadata,
+                fetch_timeout_seconds=args.fetch_timeout_seconds,
                 generated_at=args.generated_at,
             ),
             render_content_ops_issue_fix_metadata_preview_markdown,

--- a/loopx/issue_fix_intake_surface.py
+++ b/loopx/issue_fix_intake_surface.py
@@ -2,13 +2,20 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from typing import Any
-from urllib.parse import urlsplit, urlunsplit
 
 from .content_ops_surface import (
     EXPLORATION_PLAN_SCHEMA_VERSION,
     _as_mappings,
     _normalise_exploration_label,
     build_content_ops_exploration_plan_packet,
+)
+from .issue_fix_metadata_preview import (
+    ALLOWED_ISSUE_FIX_INTAKE_STATES,
+    GITHUB_BODY_OR_COMMENT_KEYS,
+    GITHUB_ISSUE_METADATA_PREVIEW_SCHEMA_VERSION,
+    fetch_github_issue_metadata_payload,
+    github_metadata_from_provider_payload,
+    normalise_github_issue_reference,
 )
 
 
@@ -19,148 +26,8 @@ CONTENT_OPS_ISSUE_FIX_METADATA_PREVIEW_PACKET_SCHEMA_VERSION = (
     "content_ops_issue_fix_metadata_preview_packet_v0"
 )
 ISSUE_FIX_INTAKE_SCHEMA_VERSION = "issue_fix_intake_v0"
-GITHUB_ISSUE_METADATA_PREVIEW_SCHEMA_VERSION = "github_issue_metadata_preview_v0"
 
-ALLOWED_ISSUE_FIX_INTAKE_STATES = {"open", "closed", "unknown"}
 ALLOWED_ISSUE_FIX_ROUTE_STATUSES = {"candidate", "blocked_until_gate", "selected"}
-GITHUB_BODY_OR_COMMENT_KEYS = {
-    "body",
-    "body_text",
-    "comments",
-    "comment_bodies",
-    "timeline",
-    "events",
-    "raw",
-    "response_payload",
-}
-
-
-def _normalise_github_issue_reference(
-    *,
-    repo: str | None = None,
-    issue_ref: str | None = None,
-    url: str | None = None,
-) -> dict[str, Any]:
-    if url:
-        parsed = urlsplit(str(url).strip())
-        if parsed.scheme != "https":
-            raise ValueError("GitHub issue URL must use https")
-        if parsed.username or parsed.password:
-            raise ValueError("GitHub issue URL must not include credentials")
-        host = (parsed.hostname or "").lower().rstrip(".")
-        if host != "github.com":
-            raise ValueError("GitHub issue URL must use github.com")
-        if parsed.query or parsed.fragment:
-            raise ValueError("GitHub issue URL must not include query or fragment data")
-        parts = [part for part in parsed.path.split("/") if part]
-        if len(parts) != 4 or parts[2] not in {"issues", "pull"}:
-            raise ValueError("GitHub issue URL must look like /owner/repo/issues/123")
-        if not parts[3].isdigit():
-            raise ValueError("GitHub issue or PR number must be numeric")
-        repo_label = _normalise_exploration_label(f"{parts[0]}/{parts[1]}", "repo")
-        issue_label = f"{parts[2]}_{parts[3]}"
-        permalink = urlunsplit(("https", "github.com", "/" + "/".join(parts), "", ""))
-        return {
-            "repo": repo_label,
-            "issue_ref": issue_label,
-            "kind": "pull_request" if parts[2] == "pull" else "issue",
-            "number": int(parts[3]),
-            "permalink": permalink,
-        }
-
-    repo_label = _normalise_exploration_label(repo, "repo")
-    issue_label = _normalise_exploration_label(issue_ref, "issue_ref")
-    number = None
-    digits = "".join(ch for ch in issue_label if ch.isdigit())
-    if digits:
-        number = int(digits)
-    return {
-        "repo": repo_label,
-        "issue_ref": issue_label,
-        "kind": "issue",
-        "number": number,
-        "permalink": None,
-    }
-
-
-def _provider_payload_labels(payload: Mapping[str, Any]) -> list[str]:
-    labels: list[str] = []
-    raw_labels = payload.get("labels")
-    if not isinstance(raw_labels, Sequence) or isinstance(raw_labels, (str, bytes)):
-        return labels
-    for item in raw_labels:
-        if isinstance(item, Mapping):
-            label = _normalise_exploration_label(item.get("name"), "label")
-        else:
-            label = _normalise_exploration_label(item, "label")
-        if label and label not in labels:
-            labels.append(label)
-    return labels[:12]
-
-
-def _safe_int(value: Any) -> int | None:
-    if isinstance(value, bool):
-        return None
-    try:
-        number = int(value)
-    except (TypeError, ValueError):
-        return None
-    return number if number >= 0 else None
-
-
-def _github_metadata_from_provider_payload(
-    *,
-    reference: Mapping[str, Any],
-    provider_payload: Mapping[str, Any] | None,
-) -> tuple[dict[str, Any], list[str]]:
-    payload = provider_payload or {}
-    gated_keys = sorted(
-        str(key) for key in payload if str(key).lower() in GITHUB_BODY_OR_COMMENT_KEYS
-    )
-    labels = _provider_payload_labels(payload) or ["needs-triage"]
-    state = str(payload.get("state") or "unknown").strip().lower()
-    if state not in ALLOWED_ISSUE_FIX_INTAKE_STATES:
-        state = "unknown"
-    number = _safe_int(payload.get("number"))
-    if number is None:
-        number = reference.get("number") if isinstance(reference.get("number"), int) else None
-    comments_count = _safe_int(payload.get("comments_count"))
-    if comments_count is None:
-        comments_count = _safe_int(payload.get("comments"))
-    metadata = {
-        "schema_version": GITHUB_ISSUE_METADATA_PREVIEW_SCHEMA_VERSION,
-        "provider": "github",
-        "provider_mode": "mocked_metadata" if provider_payload else "reference_only",
-        "repo": reference["repo"],
-        "issue_ref": reference["issue_ref"],
-        "kind": payload.get("kind") or reference["kind"],
-        "number": number,
-        "state": state,
-        "title_summary": (
-            _normalise_exploration_label(payload.get("title"), "title")
-            if payload.get("title")
-            else "public GitHub issue metadata preview"
-        ),
-        "labels": labels,
-        "updated_at": _normalise_exploration_label(payload.get("updated_at"), "updated_at")
-        if payload.get("updated_at")
-        else None,
-        "author_association": _normalise_exploration_label(
-            payload.get("author_association"),
-            "author_association",
-        )
-        if payload.get("author_association")
-        else "unknown",
-        "comments_count": comments_count,
-        "permalink": reference.get("permalink"),
-        "body_captured": False,
-        "comment_bodies_captured": False,
-        "response_payload_captured": False,
-        "local_path_captured": False,
-        "private_repo_state_read": False,
-        "gated_provider_fields_present": gated_keys,
-    }
-    return metadata, gated_keys
 
 
 def build_content_ops_issue_fix_intake_packet(
@@ -382,18 +249,32 @@ def build_content_ops_issue_fix_metadata_preview_packet(
     issue_ref: str | None = "issue_123_public_metadata_fixture",
     url: str | None = None,
     provider_payload: Mapping[str, Any] | None = None,
+    fetch_metadata: bool = False,
+    fetch_timeout_seconds: int = 10,
     generated_at: str | None = "2026-06-23T00:00:00Z",
 ) -> dict[str, Any]:
     """Build a mocked GitHub metadata adapter preview for issue-fix intake."""
 
-    reference = _normalise_github_issue_reference(
+    reference = normalise_github_issue_reference(
         repo=repo,
         issue_ref=issue_ref,
         url=url,
     )
-    metadata, gated_keys = _github_metadata_from_provider_payload(
+    if fetch_metadata and provider_payload:
+        raise ValueError("--fetch-metadata cannot be combined with --metadata-json")
+    live_read_performed = False
+    provider_mode: str | None = None
+    if fetch_metadata:
+        provider_payload = fetch_github_issue_metadata_payload(
+            reference,
+            timeout_seconds=fetch_timeout_seconds,
+        )
+        live_read_performed = True
+        provider_mode = "live_metadata"
+    metadata, gated_keys = github_metadata_from_provider_payload(
         reference=reference,
         provider_payload=provider_payload,
+        provider_mode=provider_mode,
     )
     intake_packet = build_content_ops_issue_fix_intake_packet(
         repo=metadata["repo"],
@@ -445,9 +326,15 @@ def build_content_ops_issue_fix_metadata_preview_packet(
     adapter_preview = {
         "schema_version": "github_issue_metadata_adapter_preview_v0",
         "adapter": "github_issue_metadata",
-        "provider": "mock",
-        "input_mode": "mocked_provider_payload" if provider_payload else "reference_only",
-        "live_read_performed": False,
+        "provider": "github" if live_read_performed else "mock",
+        "input_mode": (
+            "live_metadata"
+            if live_read_performed
+            else "mocked_provider_payload"
+            if provider_payload
+            else "reference_only"
+        ),
+        "live_read_performed": live_read_performed,
         "live_read_allowed_by_default": False,
         "default_allowed_fields": [
             "repo",
@@ -475,12 +362,12 @@ def build_content_ops_issue_fix_metadata_preview_packet(
         "top_agent_todo": candidate_todo_writeback_preview[0],
         "top_gate": gated_field_todos[0] if gated_field_todos else None,
         "next_safe_action": (
-            "review the mocked public GitHub metadata preview, then write the "
+            "review the public GitHub metadata preview, then write the "
             "candidate LoopX agent todo only after metadata fields stay body-free"
         ),
     }
     intake["boundary"] = {
-        "external_reads_performed": False,
+        "external_reads_performed": live_read_performed,
         "external_writes_performed": False,
         "issue_body_captured": False,
         "comment_bodies_captured": False,
@@ -499,7 +386,7 @@ def build_content_ops_issue_fix_metadata_preview_packet(
         "issue_fix_intake": intake,
         "github_metadata_preview": metadata,
         "adapter_preview": adapter_preview,
-        "external_reads_performed": False,
+        "external_reads_performed": live_read_performed,
         "external_writes_performed": False,
         "private_source_bodies_read": False,
         "private_source_content_read": False,
@@ -666,8 +553,15 @@ def validate_content_ops_issue_fix_metadata_preview_packet(
             "packet schema_version must be "
             "content_ops_issue_fix_metadata_preview_packet_v0"
         )
+    adapter_preview = (
+        packet.get("adapter_preview")
+        if isinstance(packet.get("adapter_preview"), Mapping)
+        else {}
+    )
+    live_read_performed = adapter_preview.get("live_read_performed") is True
+    if packet.get("external_reads_performed") is not live_read_performed:
+        errors.append("packet external_reads_performed must match live_read_performed")
     for key in (
-        "external_reads_performed",
         "external_writes_performed",
         "private_source_bodies_read",
         "private_source_content_read",
@@ -702,15 +596,12 @@ def validate_content_ops_issue_fix_metadata_preview_packet(
         if metadata.get(key) is not False:
             errors.append(f"github metadata {key} must be false")
 
-    adapter_preview = (
-        packet.get("adapter_preview")
-        if isinstance(packet.get("adapter_preview"), Mapping)
-        else {}
-    )
-    if adapter_preview.get("provider") != "mock":
-        errors.append("adapter preview provider must be mock")
-    if adapter_preview.get("live_read_performed") is not False:
-        errors.append("adapter preview live_read_performed must be false")
+    if adapter_preview.get("provider") not in {"mock", "github"}:
+        errors.append("adapter preview provider must be mock or github")
+    if adapter_preview.get("provider") == "mock" and live_read_performed:
+        errors.append("mock adapter preview must not mark live_read_performed")
+    if adapter_preview.get("provider") == "github" and not live_read_performed:
+        errors.append("github adapter preview must mark live_read_performed")
     if adapter_preview.get("live_read_allowed_by_default") is not False:
         errors.append("adapter preview live_read_allowed_by_default must be false")
 
@@ -737,8 +628,9 @@ def validate_content_ops_issue_fix_metadata_preview_packet(
     boundary = (
         intake.get("boundary") if isinstance(intake.get("boundary"), Mapping) else {}
     )
+    if boundary.get("external_reads_performed") is not live_read_performed:
+        errors.append("boundary.external_reads_performed must match live_read_performed")
     for key in (
-        "external_reads_performed",
         "external_writes_performed",
         "issue_body_captured",
         "comment_bodies_captured",

--- a/loopx/issue_fix_metadata_preview.py
+++ b/loopx/issue_fix_metadata_preview.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Mapping, Sequence
+from typing import Any
+from urllib.parse import quote, urlsplit, urlunsplit
+
+from .content_ops_surface import _normalise_exploration_label
+
+
+GITHUB_ISSUE_METADATA_PREVIEW_SCHEMA_VERSION = "github_issue_metadata_preview_v0"
+
+GITHUB_BODY_OR_COMMENT_KEYS = {
+    "body",
+    "body_text",
+    "comments",
+    "comment_bodies",
+    "timeline",
+    "events",
+    "raw",
+    "response_payload",
+}
+
+ALLOWED_ISSUE_FIX_INTAKE_STATES = {"open", "closed", "unknown"}
+
+
+def normalise_github_issue_reference(
+    *,
+    repo: str | None = None,
+    issue_ref: str | None = None,
+    url: str | None = None,
+) -> dict[str, Any]:
+    if url:
+        parsed = urlsplit(str(url).strip())
+        if parsed.scheme != "https":
+            raise ValueError("GitHub issue URL must use https")
+        if parsed.username or parsed.password:
+            raise ValueError("GitHub issue URL must not include credentials")
+        host = (parsed.hostname or "").lower().rstrip(".")
+        if host != "github.com":
+            raise ValueError("GitHub issue URL must use github.com")
+        if parsed.query or parsed.fragment:
+            raise ValueError("GitHub issue URL must not include query or fragment data")
+        parts = [part for part in parsed.path.split("/") if part]
+        if len(parts) != 4 or parts[2] not in {"issues", "pull"}:
+            raise ValueError("GitHub issue URL must look like /owner/repo/issues/123")
+        if not parts[3].isdigit():
+            raise ValueError("GitHub issue or PR number must be numeric")
+        repo_label = _normalise_exploration_label(f"{parts[0]}/{parts[1]}", "repo")
+        issue_label = f"{parts[2]}_{parts[3]}"
+        permalink = urlunsplit(("https", "github.com", "/" + "/".join(parts), "", ""))
+        return {
+            "repo": repo_label,
+            "issue_ref": issue_label,
+            "kind": "pull_request" if parts[2] == "pull" else "issue",
+            "number": int(parts[3]),
+            "permalink": permalink,
+        }
+
+    repo_label = _normalise_exploration_label(repo, "repo")
+    issue_label = _normalise_exploration_label(issue_ref, "issue_ref")
+    number = None
+    digits = "".join(ch for ch in issue_label if ch.isdigit())
+    if digits:
+        number = int(digits)
+    return {
+        "repo": repo_label,
+        "issue_ref": issue_label,
+        "kind": "issue",
+        "number": number,
+        "permalink": None,
+    }
+
+
+def _provider_payload_labels(payload: Mapping[str, Any]) -> list[str]:
+    labels: list[str] = []
+    raw_labels = payload.get("labels")
+    if not isinstance(raw_labels, Sequence) or isinstance(raw_labels, (str, bytes)):
+        return labels
+    for item in raw_labels:
+        if isinstance(item, Mapping):
+            label = _normalise_exploration_label(item.get("name"), "label")
+        else:
+            label = _normalise_exploration_label(item, "label")
+        if label and label not in labels:
+            labels.append(label)
+    return labels[:12]
+
+
+def _safe_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        number = int(value)
+    except (TypeError, ValueError):
+        return None
+    return number if number >= 0 else None
+
+
+def github_metadata_from_provider_payload(
+    *,
+    reference: Mapping[str, Any],
+    provider_payload: Mapping[str, Any] | None,
+    provider_mode: str | None = None,
+) -> tuple[dict[str, Any], list[str]]:
+    payload = provider_payload or {}
+    gated_keys = sorted(
+        str(key) for key in payload if str(key).lower() in GITHUB_BODY_OR_COMMENT_KEYS
+    )
+    labels = _provider_payload_labels(payload) or ["needs-triage"]
+    state = str(payload.get("state") or "unknown").strip().lower()
+    if state not in ALLOWED_ISSUE_FIX_INTAKE_STATES:
+        state = "unknown"
+    number = _safe_int(payload.get("number"))
+    if number is None:
+        number = reference.get("number") if isinstance(reference.get("number"), int) else None
+    comments_count = _safe_int(payload.get("comments_count"))
+    if comments_count is None:
+        comments_count = _safe_int(payload.get("comments"))
+    mode = provider_mode or ("mocked_metadata" if provider_payload else "reference_only")
+    metadata = {
+        "schema_version": GITHUB_ISSUE_METADATA_PREVIEW_SCHEMA_VERSION,
+        "provider": "github",
+        "provider_mode": mode,
+        "repo": reference["repo"],
+        "issue_ref": reference["issue_ref"],
+        "kind": payload.get("kind") or reference["kind"],
+        "number": number,
+        "state": state,
+        "title_summary": (
+            _normalise_exploration_label(payload.get("title"), "title")
+            if payload.get("title")
+            else "public GitHub issue metadata preview"
+        ),
+        "labels": labels,
+        "updated_at": _normalise_exploration_label(payload.get("updated_at"), "updated_at")
+        if payload.get("updated_at")
+        else None,
+        "author_association": _normalise_exploration_label(
+            payload.get("author_association"),
+            "author_association",
+        )
+        if payload.get("author_association")
+        else "unknown",
+        "comments_count": comments_count,
+        "permalink": reference.get("permalink"),
+        "body_captured": False,
+        "comment_bodies_captured": False,
+        "response_payload_captured": False,
+        "local_path_captured": False,
+        "private_repo_state_read": False,
+        "gated_provider_fields_present": gated_keys,
+    }
+    return metadata, gated_keys
+
+
+def fetch_github_issue_metadata_payload(
+    reference: Mapping[str, Any],
+    *,
+    timeout_seconds: int = 10,
+) -> dict[str, Any]:
+    repo = str(reference.get("repo") or "")
+    number = reference.get("number")
+    if "/" not in repo or not isinstance(number, int):
+        raise ValueError("--fetch-metadata requires a numeric GitHub issue or PR URL")
+    owner, repo_name = repo.split("/", 1)
+    endpoint = f"repos/{quote(owner, safe='')}/{quote(repo_name, safe='')}/issues/{number}"
+    jq_filter = (
+        "{"
+        "number: .number, "
+        "state: .state, "
+        "title: .title, "
+        "labels: [.labels[]?.name], "
+        "updated_at: .updated_at, "
+        "author_association: .author_association, "
+        "comments_count: .comments, "
+        "kind: (if .pull_request then \"pull_request\" else \"issue\" end)"
+        "}"
+    )
+    result = subprocess.run(
+        [
+            "gh",
+            "api",
+            "-H",
+            "Accept: application/vnd.github+json",
+            endpoint,
+            "--jq",
+            jq_filter,
+        ],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=timeout_seconds,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            "GitHub metadata fetch failed; install/authenticate gh or use --metadata-json"
+        )
+    payload = json.loads(result.stdout)
+    if not isinstance(payload, dict):
+        raise ValueError("GitHub metadata fetch must return a JSON object")
+    return payload


### PR DESCRIPTION
## Summary
- Split GitHub issue metadata preview helpers out of `issue_fix_intake_surface.py` into `issue_fix_metadata_preview.py`.
- Add explicit `loopx content-ops issue-fix-metadata-preview --fetch-metadata` opt-in using `gh api --jq` to emit only body-free public metadata fields.
- Keep default reference/mocked-provider behavior non-live, reject `--metadata-json` + `--fetch-metadata`, and preserve body/comment/raw fields as gated rather than captured.

## Validation
- `python3 examples/content-ops-issue-fix-metadata-preview-smoke.py`
- `python3 examples/content-ops-issue-fix-intake-smoke.py`
- `python3 -m py_compile loopx/issue_fix_intake_surface.py loopx/issue_fix_metadata_preview.py loopx/cli_commands/content_ops_issue_fix.py examples/content-ops-issue-fix-metadata-preview-smoke.py`
- `python3 examples/check-public-boundary-smoke.py --scan-path loopx/issue_fix_intake_surface.py --scan-path loopx/issue_fix_metadata_preview.py --scan-path loopx/cli_commands/content_ops_issue_fix.py --scan-path examples/content-ops-issue-fix-metadata-preview-smoke.py --scan-path docs/reference/protocols/content-ops-surface-v0.md`
- `git diff --check origin/main...HEAD`

## Known Non-Blocking Baseline
- `python3 examples/repo-python-line-budget-smoke.py` still fails on pre-existing large files; this patch moves metadata helpers into a 203-line module and reduces `issue_fix_intake_surface.py` to 832 lines.

## Safety
- The live path is opt-in only and uses a body-free `gh api --jq` projection.
- The durable smoke uses a fake `gh` executable, so CI does not need network/auth for this path.
- No issue body/comment/timeline/raw provider payload, stdout/stderr, local path, todo write, external comment, PR creation, merge, or publish action is captured/performed.