### PR TITLE
Restore public-safe long-horizon protocol increments

### DIFF
--- a/docs/product/frontstage-dashboard-interaction-baseline.md
+++ b/docs/product/frontstage-dashboard-interaction-baseline.md
@@ -102,6 +102,9 @@ The route currently exposes these durable anchors:
   `frontstage-artifacts`, and `frontstage-timeline` for the operator workspace.
 - `frontstage-showcase-motion-beam` and `frontstage-state-flow-beam` for
   human-gate and state-flow animation checks.
+- `examples/fixtures/long-horizon-self-iteration-rollout.public.json` for a
+  public-safe multi-lane rollout fixture with human gate, handoff, validation,
+  and inferred display bridge coverage.
 
 `npm run smoke:frontstage-browser` remains the visual acceptance check for this
 surface. It captures desktop and mobile screenshots, checks animated showcase
@@ -110,3 +113,6 @@ lane filtering, goal selection, and loopback-source rejection.
 
 `npm run smoke:frontstage-design-baseline` keeps this document, route anchors,
 CSS shell classes, package scripts, and README entry points aligned.
+
+`python3 examples/long-horizon-self-iteration-rollout-fixture-smoke.py` keeps
+the public fixture safe and useful for future timeline consumption.

--- a/docs/product/frontstage-dashboard-interaction-baseline.md
+++ b/docs/product/frontstage-dashboard-interaction-baseline.md
@@ -72,6 +72,22 @@ The ops surface should feel like a working console, not a landing page.
 - Optimize for repeated use: stable dimensions, no horizontal overflow,
   responsive constraints, and reduced-motion fallbacks.
 
+## Frontstage/Status Sufficiency Check
+
+Before building broader long-horizon LoopX UI, the frontstage/status slice is
+sufficient only if it proves three flows:
+
+- Todo-flow review: ops mode renders searchable user and agent todo lanes with
+  reproducible URL-backed filters and a visible result count.
+- Human-gate animation: showcase mode can explain that human judgment stays
+  visible while safe agent lanes continue, with reduced-motion fallbacks.
+- Multi-lane timeline: the surface can distinguish human decision, agent work,
+  and evidence writeback without making browser UI the source of truth.
+
+These checks intentionally stay narrower than future operator workflows. They
+prove that the existing status projection can carry the story before new
+screens add richer review, feed-style triage, or multi-agent launch controls.
+
 ## Current Acceptance Anchors
 
 The route currently exposes these durable anchors:
@@ -84,6 +100,8 @@ The route currently exposes these durable anchors:
   `frontstage-todo-result-count` for reviewable todo projection slices.
 - `frontstage-role-map`, `frontstage-active-claims`, `frontstage-open-gates`,
   `frontstage-artifacts`, and `frontstage-timeline` for the operator workspace.
+- `frontstage-showcase-motion-beam` and `frontstage-state-flow-beam` for
+  human-gate and state-flow animation checks.
 
 `npm run smoke:frontstage-browser` remains the visual acceptance check for this
 surface. It captures desktop and mobile screenshots, checks animated showcase

--- a/docs/reference/protocols/README.md
+++ b/docs/reference/protocols/README.md
@@ -14,6 +14,7 @@ Current contracts:
 - [Action packet router comparison v0](protocol-action-packet-router-comparison-v0.md)
 - [task_graph_projection_v0](task-graph-projection-v0.md)
 - [long_horizon_agent_state_protocol_v0](long-horizon-agent-state-protocol-v0.md)
+- [global_manager_command_v0](global-manager-command-v0.md)
 - [rollback_packet_v0](rollback-packet-v0.md)
 - [content_ops_surface_v0](content-ops-surface-v0.md)
 - [issue_fix_acceptance_loop_v0](issue-fix-acceptance-loop-v0.md)

--- a/docs/reference/protocols/README.md
+++ b/docs/reference/protocols/README.md
@@ -13,6 +13,7 @@ Current contracts:
 - [Codex CLI wrapper action packet v0](protocol-action-packet-codex-cli-wrapper-v0.md)
 - [Action packet router comparison v0](protocol-action-packet-router-comparison-v0.md)
 - [task_graph_projection_v0](task-graph-projection-v0.md)
+- [long_horizon_agent_state_protocol_v0](long-horizon-agent-state-protocol-v0.md)
 - [content_ops_surface_v0](content-ops-surface-v0.md)
 - [issue_fix_acceptance_loop_v0](issue-fix-acceptance-loop-v0.md)
 - [cs_notes_explore_capability_map_v0](cs-notes-explore-capability-map-v0.md)

--- a/docs/reference/protocols/README.md
+++ b/docs/reference/protocols/README.md
@@ -14,6 +14,7 @@ Current contracts:
 - [Action packet router comparison v0](protocol-action-packet-router-comparison-v0.md)
 - [task_graph_projection_v0](task-graph-projection-v0.md)
 - [long_horizon_agent_state_protocol_v0](long-horizon-agent-state-protocol-v0.md)
+- [rollback_packet_v0](rollback-packet-v0.md)
 - [content_ops_surface_v0](content-ops-surface-v0.md)
 - [issue_fix_acceptance_loop_v0](issue-fix-acceptance-loop-v0.md)
 - [cs_notes_explore_capability_map_v0](cs-notes-explore-capability-map-v0.md)

--- a/docs/reference/protocols/global-manager-command-v0.md
+++ b/docs/reference/protocols/global-manager-command-v0.md
@@ -1,0 +1,178 @@
+# global_manager_command_v0
+
+`global_manager_command_v0` is a read-first protocol for operator commands
+such as `/loop-global-summary`, `/loop-global-gates`, `/loop-global-todos`,
+and `/loop-global-risks`.
+
+The product goal is to let a user act as a manager across long-running agent
+work: ask for the last day of progress, see blocked decisions, compare agent
+lanes, and choose the next safe action without reading every thread.
+
+This protocol is not a chat-command router yet. It defines the request,
+allowed sources, response shape, privacy boundary, and action ladder that a
+Codex host, CLI wrapper, or dashboard command palette can implement later.
+
+## Command Set
+
+Recommended first commands:
+
+| Command | User intent | Default source window |
+| --- | --- | --- |
+| `/loop-global-summary <time range>` | Show progress, completed work, active lanes, and next decisions. | 24 hours |
+| `/loop-global-gates` | Show open user/controller gates and what each blocks. | current state |
+| `/loop-global-todos` | Show top runnable, blocked, deferred-ready, and review todos. | current state |
+| `/loop-global-risks` | Show stale runs, public/private boundary warnings, failing checks, and rollback candidates. | 24 hours |
+| `/loop-goal-summary <goal id>` | Drill into one goal without scanning unrelated projects. | 24 hours |
+
+Commands are read-only by default. They can propose follow-up actions, but
+they do not approve gates, promote suggested todos, spend quota, merge PRs,
+pause automations, or run destructive operations.
+
+## Request Shape
+
+```json
+{
+  "schema_version": "global_manager_command_request_v0",
+  "command": "/loop-global-summary",
+  "time_range": "24h",
+  "goal_filter": ["loopx-meta"],
+  "agent_filter": ["codex-main-control", "codex-side-bypass"],
+  "include": ["progress", "gates", "todos", "risks", "next_actions"],
+  "privacy_mode": "public_safe_summary",
+  "dry_run": true
+}
+```
+
+Request rules:
+
+- `privacy_mode` defaults to `public_safe_summary`.
+- `goal_filter` and `agent_filter` narrow the read; omitted filters mean all
+  registered goals or agents visible in the local control plane.
+- `dry_run=true` is the default because the first implementation should be a
+  report, not an executor.
+- Unknown commands must fail closed with a help packet, not a broad status
+  dump.
+
+## Source Reads
+
+Implementations may read only compact LoopX control-plane surfaces:
+
+- global registry and project-local registry entries;
+- `loopx status` / status JSON;
+- `loopx quota plan` and `quota should-run` summaries;
+- active-state todo projections;
+- run history summaries;
+- rollout event log summaries;
+- review packets for explicit goal drilldown.
+
+They must not include raw transcripts, raw benchmark logs, raw connector
+payloads, credentials, local absolute paths, or private source bodies.
+
+## Response Shape
+
+`global_manager_command_response_v0`:
+
+```json
+{
+  "schema_version": "global_manager_command_response_v0",
+  "request": {
+    "command": "/loop-global-summary",
+    "time_range": "24h"
+  },
+  "generated_at": "2026-06-24T00:00:00Z",
+  "summary": {
+    "headline": "Three active goals advanced; one user decision is open.",
+    "progress_count": 3,
+    "open_gate_count": 1,
+    "runnable_todo_count": 4,
+    "risk_count": 2
+  },
+  "lanes": [
+    {
+      "goal_id": "loopx-meta",
+      "agent_id": "codex-product-capability",
+      "status": "eligible",
+      "top_todo_id": "todo_example",
+      "last_event_id": "event_example",
+      "next_safe_action": "Review and merge the public-safe protocol PR."
+    }
+  ],
+  "gates": [
+    {
+      "gate_id": "gate_example",
+      "owner": "user",
+      "blocks": ["todo_example"],
+      "question": "Approve promoting the candidate todo?",
+      "next_safe_action": "Wait for explicit approval."
+    }
+  ],
+  "risks": [
+    {
+      "kind": "public_boundary_warning",
+      "severity": "high",
+      "evidence_refs": ["check_public_boundary"],
+      "next_safe_action": "Run the public/private boundary scan before merge."
+    }
+  ],
+  "actions": [
+    {
+      "action_id": "act_review_pr",
+      "kind": "review",
+      "requires_user_approval": false,
+      "requires_primary_agent": true,
+      "preview": "Ask the primary agent to review the protocol PR."
+    }
+  ],
+  "omissions": [
+    "Raw logs and private connector payloads were intentionally omitted."
+  ]
+}
+```
+
+## Action Ladder
+
+Responses may include actions, but each action must declare its authority:
+
+| Action kind | Default authority |
+| --- | --- |
+| `read_more` | Agent may run another read-only compact command. |
+| `review` | Target reviewer or primary agent owns the review. |
+| `promote_todo` | Requires user/controller approval before `loopx todo add`. |
+| `ask_user` | User-facing question; no delivery on blocked path until answered. |
+| `pause_or_resume` | Requires explicit operator approval. |
+| `merge_or_publish` | Requires repository policy plus clean validation; primary agent owns final decision unless self-merge is explicitly allowed. |
+| `rollback_or_history_rewrite` | Requires a `rollback_packet_v0` and explicit approval. |
+
+The protocol should make it obvious when the user is being asked to decide,
+when a primary agent should review, and when a side agent can safely continue.
+
+## Privacy Boundary
+
+Every response must include or imply these boundary facts:
+
+```json
+{
+  "raw_logs_recorded": false,
+  "raw_transcripts_recorded": false,
+  "raw_connector_payloads_recorded": false,
+  "credential_values_recorded": false,
+  "absolute_paths_recorded": false,
+  "private_source_bodies_recorded": false
+}
+```
+
+If a useful summary needs private material, the command should return a gate
+or omission, not the material itself.
+
+## Acceptance Checks
+
+A first implementation is acceptable when:
+
+- command responses are read-only by default;
+- each command names its compact LoopX source surfaces;
+- gates name owner, blocked todo or scope, question, and next safe action;
+- actions declare approval and ownership requirements;
+- risks carry public-safe evidence refs;
+- no raw logs, transcripts, credentials, local paths, or private source bodies
+  are recorded;
+- `python3 examples/global-manager-command-protocol-smoke.py` passes.

--- a/docs/reference/protocols/long-horizon-agent-state-protocol-v0.md
+++ b/docs/reference/protocols/long-horizon-agent-state-protocol-v0.md
@@ -59,6 +59,7 @@ compress state, but they do not own truth or grant permission.
 | `todo_index_v0` | `loopx/status.py` | Cross-goal todo index from attention queue and rollout events. |
 | `task_graph_projection_v0` | `docs/reference/protocols/task-graph-projection-v0.md` | Optional graph of blocks, validates, repairs, hands off, and supersedes. |
 | `review_packet` | `loopx review-packet`, `loopx/review_packet.py` | Operator-facing gate/review/handoff packet. |
+| `global_manager_command_v0` | `docs/reference/protocols/global-manager-command-v0.md` | Read-first global command response for progress, gates, todos, risks, and next actions. |
 | `frontstage dashboard` | `apps/dashboard/src/views/frontstage-page.tsx` | Dense operator UI for lanes, gates, todos, recent evidence, and risks. |
 
 Projection truth contract:
@@ -229,7 +230,8 @@ Not yet aligned:
   or executes packets.
 - PR lifecycle resume conditions such as `pr_merged:#532` are not supported;
   only `resume_when=todo_done:<todo_id>` exists today.
-- Global manager slash commands have no host integration.
+- `global_manager_command_v0` is specified and smoke-tested, but no host
+  integration or CLI command emits it yet.
 - Historical human-gate impact must be inferred from public-safe evidence.
 - Frontstage does not yet render a full multi-lane self-iteration timeline from
   real status plus rollout events.

--- a/docs/reference/protocols/long-horizon-agent-state-protocol-v0.md
+++ b/docs/reference/protocols/long-horizon-agent-state-protocol-v0.md
@@ -205,6 +205,9 @@ Already aligned:
   todo indexes.
 - `loopx_rollout_event_v0` can carry lane, transition, causality, handoff, and
   code refs for new events.
+- `examples/fixtures/long-horizon-self-iteration-rollout.public.json` gives
+  frontend and protocol tests a compact public-safe fixture with gate, handoff,
+  validation, deferred-resume, evidence, and inferred display-bridge coverage.
 
 Partially aligned:
 
@@ -243,3 +246,5 @@ A protocol implementation or fixture is acceptable when it proves:
   deletion;
 - public fixtures contain no raw logs, raw transcripts, credentials, or local
   absolute paths.
+- `python3 examples/long-horizon-self-iteration-rollout-fixture-smoke.py`
+  passes before a fixture is used as UI input.

--- a/docs/reference/protocols/long-horizon-agent-state-protocol-v0.md
+++ b/docs/reference/protocols/long-horizon-agent-state-protocol-v0.md
@@ -1,0 +1,245 @@
+# long_horizon_agent_state_protocol_v0
+
+`long_horizon_agent_state_protocol_v0` is a shared lifecycle map for
+long-running LoopX agent work. It separates durable source state from
+operator-facing projections, then shows how startup, execution, ending,
+evidence, gates, human feedback, handoffs, and rollback should connect.
+
+This is not a new state store. The source of truth remains the registry, active
+goal state, todos, run history, rollout events, operator gates, and run-bound
+human reward overlays. This protocol gives those existing surfaces one
+implementation-oriented frame.
+
+## Product Outcomes
+
+The protocol exists so LoopX can support these outcomes:
+
+1. A new project can connect quickly without overwriting an existing control
+   plane.
+2. The user sees candidate work and gates before a long loop starts.
+3. Multiple agents can work in lanes without losing ownership, evidence, or
+   review responsibility.
+4. The operator can inspect progress, gates, risk, and next actions from
+   projections instead of reading every chat thread.
+5. Failed or reverted work becomes a compensating state transition, not erased
+   history.
+
+## Source Protocol
+
+Source protocol fields are writable only through LoopX lifecycle commands or
+project-owned state files. Dashboards and showcase fixtures must not mutate
+them directly.
+
+| Source state | Existing anchor | Purpose |
+| --- | --- | --- |
+| `goal_identity` | registry, active state, agent profile docs | Stable `goal_id`, repo, primary agent, side-agent scopes, and write boundary. |
+| `connection_state` | `loopx connect`, `bootstrap`, `doctor`, `sync-global` | Whether the repo is connected, read-only, bootstrapped, stale, or missing local state. |
+| `local_state_boundary` | `.gitignore`, `loopx check`, getting-started docs | Keep `.loopx/`, `.codex/goals/`, `.local/`, raw logs, credentials, and private paths out of public commits. |
+| `todo_item_v0` | `loopx todo`, active-state todo sections, `loopx/status.py` | Formal work unit with role, status, task class, action kind, claim, dependency, resume, and evidence metadata. |
+| `suggested_todo` | `loopx todo suggest`, `todo_suggestion_prompt_v0` | Candidate decision queue; not formal backlog until promoted by user/controller. |
+| `interaction_contract_v0` | `loopx quota should-run`, `docs/quota-allocation.md` | Splits user, agent, and CLI obligations before an automated turn spends compute. |
+| `agent_lane_next_action_v0` | `loopx quota should-run --agent-id ...`, `docs/project-agent-todo-contract.md` | Per-agent selected runnable todo without replacing the goal-level next action. |
+| `side_agent_workspace_guard_v0` | `loopx quota should-run`, side-agent registry scope | Blocks normal delivery until a side agent uses an independent worktree/branch. |
+| `run_history` | `loopx/history.py`, `refresh-state`, `quota spend-slot` | Compact run classifications, delivery outcome, recommended action, evidence, and spend records. |
+| `loopx_rollout_event_v0` | `loopx/rollout_event_log.py` | Append-only public-safe event stream for todo, validation, PR, handoff, quota, repair, and failure events. |
+| `operator_gate` | `loopx operator-gate`, `loopx/review_packet.py`, `loopx/status.py` | User/controller decision point with decision, reason, follow-up, and optional handoff command. |
+| `human_reward` | `loopx reward`, `loopx/history.py`, `loopx/status.py` | Run-bound human judgment overlay; not generic write-control. |
+| `delivery_outcome` | `loopx/delivery_outcome.py`, `loopx/history.py`, `loopx/status.py` | Machine-readable result tier: surface-only, outcome gap, outcome progress, or primary goal outcome. |
+| `rollback_packet_v0` | design only | Future compensating action record linking todo, commit, event, decision, external resource, and validation plan. |
+
+## Projection Protocol
+
+Projection protocol fields are read-only views. They may summarize, rank, and
+compress state, but they do not own truth or grant permission.
+
+| Projection | Existing anchor | Display use |
+| --- | --- | --- |
+| `status_contract_v2` | `loopx status`, `docs/status-data-contract.md` | CLI/dashboard status envelope. |
+| `goal_channel_projection_v0` | `loopx/frontstage.py`, `loopx/status.py` | First-screen goal card: user todos, agent todos, open gates, active claims, latest event, next action. |
+| `todo_index_v0` | `loopx/status.py` | Cross-goal todo index from attention queue and rollout events. |
+| `task_graph_projection_v0` | `docs/reference/protocols/task-graph-projection-v0.md` | Optional graph of blocks, validates, repairs, hands off, and supersedes. |
+| `review_packet` | `loopx review-packet`, `loopx/review_packet.py` | Operator-facing gate/review/handoff packet. |
+| `frontstage dashboard` | `apps/dashboard/src/views/frontstage-page.tsx` | Dense operator UI for lanes, gates, todos, recent evidence, and risks. |
+
+Projection truth contract:
+
+```json
+{
+  "schema_version": "long_horizon_agent_state_protocol_v0",
+  "projection_is_writable": false,
+  "source_of_truth": [
+    "registry",
+    "active_state",
+    "todo_item_v0",
+    "run_history",
+    "rollout_event_log",
+    "operator_gate",
+    "human_reward"
+  ],
+  "write_apis": [
+    "loopx todo",
+    "loopx refresh-state",
+    "loopx operator-gate",
+    "loopx reward",
+    "loopx quota spend-slot"
+  ]
+}
+```
+
+## Lifecycle
+
+### Startup
+
+Startup answers whether the project is connected, who owns the work, and what
+the first safe decision is.
+
+Required source state:
+
+- stable `goal_id`;
+- primary agent and side-agent scope when registered;
+- adapter status and project-local state path;
+- local-state ignore boundary;
+- optional suggested todo queue;
+- optional first formal runnable todo.
+
+Projection requirements:
+
+- show goal id, current user gate, top agent todo, and next safe action;
+- distinguish candidate todo from formal todo;
+- report local-state ignore problems as warnings;
+- install heartbeat only after a connected goal exists.
+
+### Execution
+
+Execution answers whether this turn should run, what exactly should be done,
+who owns it, and when compute can be spent.
+
+Required source state:
+
+- `interaction_contract_v0.user_channel`;
+- `interaction_contract_v0.agent_channel`;
+- `interaction_contract_v0.cli_channel`;
+- selected `agent_lane_next_action_v0`;
+- selected `todo_item_v0`;
+- claim or lane ownership when multiple agents are registered;
+- validation artifact refs after work;
+- compact writeback before quota spend.
+
+Projection requirements:
+
+- user-required work must name concrete user todos or questions;
+- no user todo plus `agent_channel.must_attempt=true` must not become a quiet
+  no-op;
+- safe-bypass work must keep the blocking gate visible;
+- monitor todos stay visible but do not rewrite generic heartbeat prompts;
+- `delivery_outcome` is displayed separately from activity count.
+
+### Ending
+
+Ending answers whether work completed, paused, failed, handed off, or must be
+rolled back.
+
+Required source state:
+
+- `delivery_outcome`;
+- completed, superseded, blocked, or deferred todo status;
+- successor todo or explicit no-follow-up rationale;
+- validation evidence or blocker evidence;
+- PR/commit refs when code changed;
+- handoff target and stop condition when another agent should continue;
+- future `rollback_packet_v0` when state must be compensated.
+
+Projection requirements:
+
+- show the result tier before showing activity volume;
+- keep failed external-resource setup as a partial-success state when a usable
+  resource exists;
+- show handoff/review ownership rather than treating every open todo as global;
+- expose rollback candidates without executing rollback automatically.
+
+## Evidence, Gate, Reward, Handoff
+
+Evidence fields should be compact and public-safe:
+
+- `artifact_refs`: docs, smoke files, fixture files, PRs, commits, dashboards;
+- `validation_commands`: command labels or public-safe paths, not raw logs;
+- `source_refs`: issue/PR ids, public social ids, redacted private connector
+  ids, experiment run handles;
+- `boundary`: booleans proving raw logs, credentials, private paths, and raw
+  transcripts are absent.
+
+Gate fields must include:
+
+- gate owner class: `user`, `controller`, `primary_agent`, or external system;
+- blocked todo or scope;
+- question or decision required;
+- approved/deferred/rejected status;
+- unblocked todo or next safe action when resolved.
+
+Reward fields must remain run-bound:
+
+- judged run id or generated timestamp;
+- decision label and reward polarity;
+- public-safe reason summary;
+- follow-up;
+- optional active-state summary.
+
+Handoff fields must include:
+
+- source agent and target agent;
+- todo ids or scope transferred;
+- stop condition;
+- evidence refs the target needs;
+- whether review or self-merge is allowed.
+
+## Implementation Alignment
+
+Already aligned:
+
+- `loopx quota should-run` emits `interaction_contract_v0` and
+  `agent_lane_next_action_v0`.
+- `loopx todo` supports formal todos, claims, deferred state,
+  `resume_when=todo_done:<todo_id>`, `unblocks_todo_id`, and suggestions.
+- `loopx status` emits `goal_channel_projection_v0`, `todo_index_v0`, compact
+  operator gates, compact human rewards, delivery outcomes, and rollout-event
+  todo indexes.
+- `loopx_rollout_event_v0` can carry lane, transition, causality, handoff, and
+  code refs for new events.
+
+Partially aligned:
+
+- Older rollout events may lack before/after, causality, and handoff fields, so
+  any animation or timeline must mark inferred bridges explicitly.
+- `task_graph_projection_v0` is specified but not yet a stable dashboard input.
+- Commit-to-todo linkage is convention-based through PR text, commit messages,
+  todo evidence, and rollout refs.
+- `todo suggest` produces a prompt packet for the user's agent; it is not a
+  fully autonomous repo analyzer.
+- External-resource partial success is not yet a generic protocol.
+
+Not yet aligned:
+
+- `rollback_packet_v0` has no implementation.
+- PR lifecycle resume conditions such as `pr_merged:#532` are not supported;
+  only `resume_when=todo_done:<todo_id>` exists today.
+- Global manager slash commands have no host integration.
+- Historical human-gate impact must be inferred from public-safe evidence.
+- Frontstage does not yet render a full multi-lane self-iteration timeline from
+  real status plus rollout events.
+
+## Acceptance Checks
+
+A protocol implementation or fixture is acceptable when it proves:
+
+- source and projection state are separated;
+- projections are explicitly read-only;
+- every formal execution step maps to a todo, gate, run, event, or reward;
+- candidate todos are not silently promoted;
+- at least one lane-aware next action can be selected for a registered agent;
+- validation and writeback precede quota spend;
+- human gates name what they block and unblock;
+- handoffs name source agent, target agent, todo scope, and stop condition;
+- rollback is represented as a future compensating action, not as hidden
+  deletion;
+- public fixtures contain no raw logs, raw transcripts, credentials, or local
+  absolute paths.

--- a/docs/reference/protocols/long-horizon-agent-state-protocol-v0.md
+++ b/docs/reference/protocols/long-horizon-agent-state-protocol-v0.md
@@ -45,7 +45,7 @@ them directly.
 | `operator_gate` | `loopx operator-gate`, `loopx/review_packet.py`, `loopx/status.py` | User/controller decision point with decision, reason, follow-up, and optional handoff command. |
 | `human_reward` | `loopx reward`, `loopx/history.py`, `loopx/status.py` | Run-bound human judgment overlay; not generic write-control. |
 | `delivery_outcome` | `loopx/delivery_outcome.py`, `loopx/history.py`, `loopx/status.py` | Machine-readable result tier: surface-only, outcome gap, outcome progress, or primary goal outcome. |
-| `rollback_packet_v0` | design only | Future compensating action record linking todo, commit, event, decision, external resource, and validation plan. |
+| `rollback_packet_v0` | `docs/reference/protocols/rollback-packet-v0.md` | Compensating action record linking todo, commit, event, decision, external resource, and validation plan. |
 
 ## Projection Protocol
 
@@ -208,6 +208,9 @@ Already aligned:
 - `examples/fixtures/long-horizon-self-iteration-rollout.public.json` gives
   frontend and protocol tests a compact public-safe fixture with gate, handoff,
   validation, deferred-resume, evidence, and inferred display-bridge coverage.
+- `rollback_packet_v0` defines how rollback, fix-forward, external cleanup,
+  support requests, and todo compensation are represented before any protected
+  action runs.
 
 Partially aligned:
 
@@ -222,7 +225,8 @@ Partially aligned:
 
 Not yet aligned:
 
-- `rollback_packet_v0` has no implementation.
+- `rollback_packet_v0` is specified and smoke-tested, but no command yet emits
+  or executes packets.
 - PR lifecycle resume conditions such as `pr_merged:#532` are not supported;
   only `resume_when=todo_done:<todo_id>` exists today.
 - Global manager slash commands have no host integration.

--- a/docs/reference/protocols/rollback-packet-v0.md
+++ b/docs/reference/protocols/rollback-packet-v0.md
@@ -1,0 +1,196 @@
+# rollback_packet_v0
+
+`rollback_packet_v0` is the public-safe compensation protocol for long-running
+LoopX work. It describes what must be undone, fixed forward, cleaned up, or
+monitored after a delivery step creates risk. It is a plan and evidence
+packet, not an execution permission.
+
+Rollback in LoopX is broader than `git revert`. A long-horizon task may need to
+compensate repository commits, local state projections, external resources,
+open PRs, cached public surfaces, todo ownership, or user gates. The packet
+keeps those relationships explicit so agents do not erase history, repeat the
+same unsafe action, or leave the operator guessing what remains exposed.
+
+## Product Contract
+
+The packet exists to answer five questions:
+
+1. What visible or durable state is affected?
+2. Which todo, rollout event, commit, PR, or external resource caused it?
+3. Is the next safe action a revert, fix-forward patch, state correction,
+   support request, external cleanup, or monitor?
+4. Who must approve protected or destructive steps?
+5. Which validation and public/private boundary checks prove the compensation
+   is complete?
+
+## Shape
+
+```json
+{
+  "schema_version": "rollback_packet_v0",
+  "packet_id": "rollback_public_boundary_example_v0",
+  "goal_id": "public-long-horizon-loop",
+  "created_at": "2026-06-24T01:20:00+08:00",
+  "trigger": {
+    "kind": "public_boundary_leak",
+    "summary": "A public PR surface exposed context that should remain local.",
+    "todo_ids": ["todo_public_boundary_repair"],
+    "source_event_ids": ["evt_lh_005_minimal_fixture_validated"]
+  },
+  "scope": {
+    "repository_refs": {
+      "commit_refs": ["abcdef1"],
+      "pr_refs": ["huangruiteng/loopx#617"]
+    },
+    "todo_ids": ["todo_public_boundary_repair"],
+    "external_resource_refs": ["github_support_request"],
+    "user_visible_surfaces": ["pull_request", "cached_view"],
+    "local_state_refs": []
+  },
+  "decision": {
+    "owner": "maintainer",
+    "required": true,
+    "reason": "History rewrite and external cached-view removal require explicit owner action.",
+    "default_safe_action": "pause_and_monitor"
+  },
+  "plan": [
+    {
+      "step_id": "clean_main_history",
+      "kind": "history_rewrite",
+      "action": "replace public branch history with a clean equivalent commit set",
+      "requires_gate": true,
+      "destructive": true,
+      "automatable_by_agent": false
+    },
+    {
+      "step_id": "submit_support_request",
+      "kind": "support_request",
+      "action": "ask provider support to remove read-only PR refs and cached views",
+      "requires_gate": true,
+      "destructive": false,
+      "automatable_by_agent": false
+    },
+    {
+      "step_id": "verify_public_boundary",
+      "kind": "validation",
+      "action": "scan normal heads and changed public paths for private markers",
+      "requires_gate": false,
+      "destructive": false,
+      "automatable_by_agent": true
+    }
+  ],
+  "todo_compensation": {
+    "complete_todo_ids": ["todo_submit_support_request"],
+    "add_todos": [
+      {
+        "role": "agent",
+        "task_class": "continuous_monitor",
+        "title": "Verify provider-side cached view removal after support response."
+      }
+    ],
+    "supersede_todo_ids": []
+  },
+  "validation": {
+    "commands": [
+      "git diff --check",
+      "loopx check --scan-path <public-safe-path>",
+      "git ls-remote --heads origin"
+    ],
+    "public_boundary_scan_required": true,
+    "success_criteria": [
+      "normal public heads no longer contain the affected public markers",
+      "provider-owned cached views or read-only refs are removed or tracked by an open external gate",
+      "successor monitor todo exists when external cleanup is pending"
+    ]
+  },
+  "boundary": {
+    "raw_task_text_recorded": false,
+    "raw_logs_recorded": false,
+    "raw_trajectory_recorded": false,
+    "raw_session_transcript_recorded": false,
+    "credential_values_recorded": false,
+    "absolute_paths_recorded": false
+  }
+}
+```
+
+## Kinds
+
+Allowed trigger kinds:
+
+- `validation_regression`;
+- `public_boundary_leak`;
+- `operator_request`;
+- `external_setup_partial_failure`;
+- `wrong_owner_or_lane`;
+- `bad_state_projection`;
+- `release_or_publish_mistake`.
+
+Allowed plan step kinds:
+
+- `git_revert`: create a normal revert commit;
+- `fix_forward`: keep history and add a correcting patch;
+- `history_rewrite`: rewrite public branch history; always protected;
+- `state_compensation`: correct LoopX active state, todo metadata, or rollout
+  event projections;
+- `external_cleanup`: clean up an external resource;
+- `support_request`: ask a provider to remove read-only or cached surfaces;
+- `todo_supersede`: replace stale todos with successor work;
+- `validation`: prove the compensation state.
+
+## Commit And Todo Linkage
+
+Commit-to-todo linkage is the minimum useful rollback anchor. A public PR or
+commit should be traceable to:
+
+- one or more `todo_id` values;
+- one or more rollout event ids when available;
+- validation commands or public-safe evidence refs;
+- successor todos or no-follow-up rationale after completion.
+
+This linkage does not require every commit message to encode every detail. It
+does require enough durable state for a later agent to answer "which todo does
+this commit compensate, supersede, or validate?" without reading private chat
+history.
+
+When linkage is missing, use a rollback packet to create the missing
+compensation todos before touching history.
+
+## Safety Rules
+
+- A rollback packet does not authorize destructive git commands, force pushes,
+  production actions, provider support requests, external deletes, or public
+  comments.
+- `history_rewrite` requires explicit user or maintainer approval and a backup
+  or equivalent recovery point.
+- Provider-owned read-only refs, cached views, or search indexes are external
+  cleanup. If normal repository commands cannot remove them, the packet must
+  keep a user/support gate or monitor todo open.
+- External-resource setup should prefer partial-success preservation over
+  deletion. If a usable board, base, environment, or artifact was created,
+  save the minimum usable local config first, then treat optional enrichment
+  failures as warnings or follow-up work.
+- Fix-forward is preferred when it avoids protected history operations and
+  fully removes user-facing risk.
+- Public fixtures and packets must not include raw logs, raw transcripts,
+  credentials, local absolute paths, or private source bodies.
+
+## Acceptance Checks
+
+A valid packet or implementation must prove:
+
+- `schema_version` is exactly `rollback_packet_v0`;
+- every plan step has `step_id`, `kind`, `action`, `requires_gate`,
+  `destructive`, and `automatable_by_agent`;
+- destructive or provider-owned actions require a gate;
+- the packet links at least one todo, rollout event, commit/PR ref, or external
+  resource ref;
+- todo compensation is explicit when work remains after the rollback step;
+- validation commands are public-safe labels, not raw logs;
+- boundary flags are present and false.
+
+The durable smoke is:
+
+```bash
+python3 examples/rollback-packet-protocol-smoke.py
+```

--- a/examples/dashboard-frontstage-design-baseline-smoke.mjs
+++ b/examples/dashboard-frontstage-design-baseline-smoke.mjs
@@ -47,6 +47,8 @@ includes(productDoc, "## Frontstage/Status Sufficiency Check", "frontstage statu
 includes(productDoc, "Todo-flow review", "todo-flow sufficiency check");
 includes(productDoc, "Human-gate animation", "human-gate animation sufficiency check");
 includes(productDoc, "Multi-lane timeline", "multi-lane timeline sufficiency check");
+includes(productDoc, "long-horizon-self-iteration-rollout.public.json", "long-horizon rollout fixture anchor");
+includes(productDoc, "long-horizon-self-iteration-rollout-fixture-smoke.py", "fixture smoke anchor");
 includes(productDoc, "npm run smoke:frontstage-browser", "visual acceptance anchor");
 includes(productDoc, "npm run smoke:frontstage-design-baseline", "design smoke anchor");
 

--- a/examples/dashboard-frontstage-design-baseline-smoke.mjs
+++ b/examples/dashboard-frontstage-design-baseline-smoke.mjs
@@ -43,6 +43,10 @@ includes(productDoc, "showcase surface can be fancy", "showcase motion allowance
 includes(productDoc, "working console, not a landing page", "ops workspace rule");
 includes(productDoc, "frontstage-ops-workspace-shell", "ops shell anchor");
 includes(productDoc, "frontstage-ops-command-strip", "ops command strip anchor");
+includes(productDoc, "## Frontstage/Status Sufficiency Check", "frontstage status sufficiency section");
+includes(productDoc, "Todo-flow review", "todo-flow sufficiency check");
+includes(productDoc, "Human-gate animation", "human-gate animation sufficiency check");
+includes(productDoc, "Multi-lane timeline", "multi-lane timeline sufficiency check");
 includes(productDoc, "npm run smoke:frontstage-browser", "visual acceptance anchor");
 includes(productDoc, "npm run smoke:frontstage-design-baseline", "design smoke anchor");
 
@@ -64,6 +68,11 @@ includes(frontstageSource, 'data-testid="frontstage-active-claims"', "active cla
 includes(frontstageSource, 'data-testid="frontstage-open-gates"', "open gates anchor");
 includes(frontstageSource, 'data-testid="frontstage-artifacts"', "artifacts anchor");
 includes(frontstageSource, 'data-testid="frontstage-timeline"', "timeline anchor");
+includes(frontstageSource, "human judgment", "human-gate plain-language copy");
+includes(frontstageSource, "agent lanes", "agent-lane showcase copy");
+includes(frontstageSource, "evidence writeback", "evidence writeback showcase copy");
+includes(frontstageSource, 'data-testid="frontstage-showcase-motion-beam"', "human-gate animation beam");
+includes(frontstageSource, 'data-testid="frontstage-state-flow-beam"', "state-flow animation beam");
 excludes(frontstageSource, 'data-testid="frontstage-enable-ops-live"', "public in-page ops switch");
 
 includes(stylesSource, ".frontstage-workspace-shell", "workspace shell CSS");

--- a/examples/fixtures/global-manager-command.public.json
+++ b/examples/fixtures/global-manager-command.public.json
@@ -1,0 +1,107 @@
+{
+  "schema_version": "global_manager_command_response_v0",
+  "request": {
+    "schema_version": "global_manager_command_request_v0",
+    "command": "/loop-global-summary",
+    "time_range": "24h",
+    "goal_filter": [
+      "loopx-meta"
+    ],
+    "agent_filter": [
+      "codex-main-control",
+      "codex-side-bypass",
+      "codex-product-capability"
+    ],
+    "include": [
+      "progress",
+      "gates",
+      "todos",
+      "risks",
+      "next_actions"
+    ],
+    "privacy_mode": "public_safe_summary",
+    "dry_run": true
+  },
+  "generated_at": "2026-06-24T00:00:00Z",
+  "summary": {
+    "headline": "Public-safe protocol work advanced and one primary review remains.",
+    "progress_count": 2,
+    "open_gate_count": 0,
+    "runnable_todo_count": 3,
+    "risk_count": 1
+  },
+  "lanes": [
+    {
+      "goal_id": "loopx-meta",
+      "agent_id": "codex-product-capability",
+      "status": "eligible",
+      "top_todo_id": "todo_public_protocol",
+      "last_event_id": "event_protocol_refresh",
+      "next_safe_action": "Continue with the next public-safe protocol increment after review handoff."
+    },
+    {
+      "goal_id": "loopx-meta",
+      "agent_id": "codex-main-control",
+      "status": "review_requested",
+      "top_todo_id": "todo_primary_review",
+      "last_event_id": "event_review_todo_created",
+      "next_safe_action": "Review and merge the public-safe protocol PR after validation."
+    }
+  ],
+  "gates": [],
+  "todos": [
+    {
+      "todo_id": "todo_primary_review",
+      "role": "agent",
+      "claimed_by": "codex-main-control",
+      "state": "open",
+      "priority": "P0",
+      "title": "Review the public-safe protocol PR."
+    },
+    {
+      "todo_id": "todo_public_protocol",
+      "role": "agent",
+      "claimed_by": "codex-product-capability",
+      "state": "done",
+      "priority": "P0",
+      "title": "Add public-safe long-horizon protocol increments."
+    }
+  ],
+  "risks": [
+    {
+      "kind": "stale_review",
+      "severity": "medium",
+      "evidence_refs": [
+        "pr_review_pending"
+      ],
+      "next_safe_action": "Keep the primary review todo visible until the PR is merged or superseded."
+    }
+  ],
+  "actions": [
+    {
+      "action_id": "act_primary_review",
+      "kind": "review",
+      "requires_user_approval": false,
+      "requires_primary_agent": true,
+      "preview": "Ask the primary agent to review the public-safe protocol PR."
+    },
+    {
+      "action_id": "act_promote_candidate",
+      "kind": "promote_todo",
+      "requires_user_approval": true,
+      "requires_primary_agent": false,
+      "preview": "Promote a suggested todo only after the user or controller accepts it."
+    }
+  ],
+  "omissions": [
+    "Raw logs, raw transcripts, connector payloads, credential values, local paths, and private source bodies were intentionally omitted."
+  ],
+  "boundary": {
+    "raw_logs_recorded": false,
+    "raw_transcripts_recorded": false,
+    "raw_connector_payloads_recorded": false,
+    "credential_values_recorded": false,
+    "absolute_paths_recorded": false,
+    "private_source_bodies_recorded": false
+  }
+}

--- a/examples/fixtures/long-horizon-self-iteration-rollout.public.json
+++ b/examples/fixtures/long-horizon-self-iteration-rollout.public.json
@@ -1,0 +1,505 @@
+{
+  "schema_version": "long_horizon_self_iteration_fixture_v0",
+  "fixture_id": "long_horizon_self_iteration_minimal_rollout_public_v0",
+  "goal_id": "public-long-horizon-loop",
+  "generated_at": "2026-06-24T01:12:00+08:00",
+  "purpose": "Minimal public-safe rollout input for long-horizon agent frontstage development and smoke testing.",
+  "public_boundary": {
+    "raw_task_text_recorded": false,
+    "raw_logs_recorded": false,
+    "raw_trajectory_recorded": false,
+    "raw_session_transcript_recorded": false,
+    "credential_values_recorded": false,
+    "absolute_paths_recorded": false,
+    "private_material_body_recorded": false
+  },
+  "derived_from": {
+    "source_docs": [
+      "docs/reference/protocols/long-horizon-agent-state-protocol-v0.md",
+      "docs/product/frontstage-dashboard-interaction-baseline.md"
+    ],
+    "source_prs": [
+      "https://github.com/huangruiteng/loopx/pull/617"
+    ],
+    "source_policy": "Compact public-safe metadata only; this fixture is not a source-of-truth event ledger."
+  },
+  "truth_contract": {
+    "event_ledger_is_source_of_truth": true,
+    "fixture_is_writable": false,
+    "projection_is_writable": false,
+    "write_authority": "none",
+    "recompute_rule": "Regenerate from active state, rollout events, PR metadata, and public docs; do not edit dashboard state as truth."
+  },
+  "lanes": [
+    {
+      "lane_id": "primary_control",
+      "agent_id": "codex-main-control",
+      "role": "primary",
+      "display_name": "Primary control"
+    },
+    {
+      "lane_id": "product_capability",
+      "agent_id": "codex-product-capability",
+      "role": "side-agent",
+      "display_name": "Product capability"
+    },
+    {
+      "lane_id": "implementation_lane",
+      "agent_id": "codex-side-bypass",
+      "role": "side-agent",
+      "display_name": "Implementation lane"
+    }
+  ],
+  "rollout_events": [
+    {
+      "schema_version": "loopx_rollout_event_v0",
+      "event_id": "evt_lh_001_protocol_contract_ready",
+      "goal_id": "public-long-horizon-loop",
+      "event_kind": "pr_merge",
+      "recorded_at": "2026-06-24T01:12:10+08:00",
+      "agent_id": "codex-product-capability",
+      "todo_id": "todo_protocol_contract",
+      "lane": {
+        "lane_id": "product_capability",
+        "agent_role": "side-agent"
+      },
+      "state_transition": {
+        "from_state": "protocol_draft",
+        "to_state": "protocol_contract_ready"
+      },
+      "causality": {
+        "caused_by": "public_protocol_review",
+        "unblocks": [
+          "todo_minimal_rollout_fixture"
+        ]
+      },
+      "code_refs": {
+        "commit_ref": "bd05500",
+        "pr_ref": "huangruiteng/loopx#617"
+      },
+      "status": "ready",
+      "classification": "long_horizon_protocol_contract_ready",
+      "delivery_outcome": "outcome_progress",
+      "summary": "Long-horizon protocol now separates source-of-truth state from projection state and defines handoff, gate, evidence, and rollback anchors.",
+      "artifact_refs": [
+        "docs/reference/protocols/long-horizon-agent-state-protocol-v0.md"
+      ],
+      "source_refs": [
+        {
+          "kind": "pull_request",
+          "ref": "https://github.com/huangruiteng/loopx/pull/617"
+        }
+      ],
+      "boundary": {
+        "raw_task_text_recorded": false,
+        "raw_logs_recorded": false,
+        "raw_trajectory_recorded": false,
+        "raw_session_transcript_recorded": false,
+        "credential_values_recorded": false,
+        "absolute_paths_recorded": false
+      }
+    },
+    {
+      "schema_version": "loopx_rollout_event_v0",
+      "event_id": "evt_lh_002_fixture_scope_narrowed",
+      "goal_id": "public-long-horizon-loop",
+      "event_kind": "todo_update",
+      "recorded_at": "2026-06-24T01:13:00+08:00",
+      "agent_id": "codex-product-capability",
+      "todo_id": "todo_minimal_rollout_fixture",
+      "lane": {
+        "lane_id": "product_capability",
+        "agent_role": "side-agent"
+      },
+      "state_transition": {
+        "from_state": "full_history_fixture_planned",
+        "to_state": "minimal_rollout_fixture_required"
+      },
+      "causality": {
+        "caused_by": "scope_reduction",
+        "source_event_id": "evt_lh_001_protocol_contract_ready",
+        "decision_id": "decision_minimal_fixture_before_frontstage"
+      },
+      "status": "open",
+      "classification": "todo_scope_refined",
+      "summary": "The fixture scope narrows to a small public-safe rollout sample for frontend and protocol testing.",
+      "artifact_refs": [
+        "examples/fixtures/long-horizon-self-iteration-rollout.public.json"
+      ],
+      "source_refs": [
+        {
+          "kind": "todo",
+          "ref": "todo_minimal_rollout_fixture"
+        }
+      ],
+      "boundary": {
+        "raw_task_text_recorded": false,
+        "raw_logs_recorded": false,
+        "raw_trajectory_recorded": false,
+        "raw_session_transcript_recorded": false,
+        "credential_values_recorded": false,
+        "absolute_paths_recorded": false
+      }
+    },
+    {
+      "schema_version": "loopx_rollout_event_v0",
+      "event_id": "evt_lh_003_frontstage_impl_handoff",
+      "goal_id": "public-long-horizon-loop",
+      "event_kind": "todo_update",
+      "recorded_at": "2026-06-24T01:14:00+08:00",
+      "agent_id": "codex-product-capability",
+      "todo_id": "todo_frontstage_timeline",
+      "lane": {
+        "lane_id": "implementation_lane",
+        "agent_role": "side-agent"
+      },
+      "state_transition": {
+        "from_state": "open_product_capability_claim",
+        "to_state": "deferred_implementation_claim"
+      },
+      "causality": {
+        "caused_by": "frontstage_delegation",
+        "source_event_id": "evt_lh_002_fixture_scope_narrowed",
+        "gate_id": "gate_minimal_rollout_fixture",
+        "decision_id": "decision_frontstage_to_implementation_lane",
+        "blocks": [
+          "todo_frontstage_timeline"
+        ],
+        "unblocks": [
+          "todo_frontstage_timeline_after_fixture"
+        ]
+      },
+      "handoff": {
+        "to_agent_id": "codex-side-bypass"
+      },
+      "status": "deferred",
+      "classification": "frontstage_todo_assigned_to_implementation_lane",
+      "summary": "Frontstage implementation waits for the minimal rollout fixture before broader UI work starts.",
+      "artifact_refs": [
+        "docs/product/frontstage-dashboard-interaction-baseline.md"
+      ],
+      "source_refs": [
+        {
+          "kind": "todo",
+          "ref": "todo_frontstage_timeline"
+        }
+      ],
+      "boundary": {
+        "raw_task_text_recorded": false,
+        "raw_logs_recorded": false,
+        "raw_trajectory_recorded": false,
+        "raw_session_transcript_recorded": false,
+        "credential_values_recorded": false,
+        "absolute_paths_recorded": false
+      }
+    },
+    {
+      "schema_version": "loopx_rollout_event_v0",
+      "event_id": "evt_lh_004_sufficiency_check_deferred",
+      "goal_id": "public-long-horizon-loop",
+      "event_kind": "todo_update",
+      "recorded_at": "2026-06-24T01:15:00+08:00",
+      "agent_id": "codex-product-capability",
+      "todo_id": "todo_frontstage_sufficiency",
+      "lane": {
+        "lane_id": "implementation_lane",
+        "agent_role": "side-agent"
+      },
+      "state_transition": {
+        "from_state": "open_product_capability_claim",
+        "to_state": "deferred_implementation_claim"
+      },
+      "causality": {
+        "caused_by": "fixture_dependency",
+        "source_event_id": "evt_lh_003_frontstage_impl_handoff",
+        "gate_id": "gate_minimal_rollout_fixture",
+        "decision_id": "decision_frontstage_to_implementation_lane",
+        "blocks": [
+          "todo_frontstage_sufficiency"
+        ]
+      },
+      "handoff": {
+        "to_agent_id": "codex-side-bypass"
+      },
+      "status": "deferred",
+      "classification": "frontstage_sufficiency_waits_for_fixture",
+      "summary": "The sufficiency check remains visible as deferred work and resumes after fixture validation.",
+      "artifact_refs": [
+        "examples/fixtures/long-horizon-self-iteration-rollout.public.json"
+      ],
+      "source_refs": [
+        {
+          "kind": "todo",
+          "ref": "todo_frontstage_sufficiency"
+        }
+      ],
+      "boundary": {
+        "raw_task_text_recorded": false,
+        "raw_logs_recorded": false,
+        "raw_trajectory_recorded": false,
+        "raw_session_transcript_recorded": false,
+        "credential_values_recorded": false,
+        "absolute_paths_recorded": false
+      }
+    },
+    {
+      "schema_version": "loopx_rollout_event_v0",
+      "event_id": "evt_lh_005_minimal_fixture_validated",
+      "goal_id": "public-long-horizon-loop",
+      "event_kind": "validation",
+      "recorded_at": "2026-06-24T01:16:00+08:00",
+      "agent_id": "codex-product-capability",
+      "todo_id": "todo_minimal_rollout_fixture",
+      "lane": {
+        "lane_id": "product_capability",
+        "agent_role": "side-agent"
+      },
+      "state_transition": {
+        "from_state": "minimal_rollout_fixture_required",
+        "to_state": "fixture_ready_for_frontstage"
+      },
+      "causality": {
+        "caused_by": "public_fixture_validation",
+        "source_event_id": "evt_lh_002_fixture_scope_narrowed",
+        "unblocks": [
+          "todo_frontstage_sufficiency",
+          "todo_frontstage_timeline"
+        ]
+      },
+      "status": "validated",
+      "classification": "long_horizon_rollout_fixture_ready",
+      "delivery_outcome": "outcome_progress",
+      "summary": "Minimal rollout fixture covers three lanes, a human decision gate, handoff, validation evidence, and one inferred display bridge.",
+      "artifact_refs": [
+        "examples/fixtures/long-horizon-self-iteration-rollout.public.json",
+        "examples/long-horizon-self-iteration-rollout-fixture-smoke.py"
+      ],
+      "source_refs": [
+        {
+          "kind": "fixture",
+          "ref": "examples/fixtures/long-horizon-self-iteration-rollout.public.json"
+        }
+      ],
+      "boundary": {
+        "raw_task_text_recorded": false,
+        "raw_logs_recorded": false,
+        "raw_trajectory_recorded": false,
+        "raw_session_transcript_recorded": false,
+        "credential_values_recorded": false,
+        "absolute_paths_recorded": false
+      }
+    },
+    {
+      "schema_version": "loopx_rollout_event_v0",
+      "event_id": "evt_lh_006_sufficiency_ready",
+      "goal_id": "public-long-horizon-loop",
+      "event_kind": "todo_update",
+      "recorded_at": "2026-06-24T01:17:00+08:00",
+      "agent_id": "codex-product-capability",
+      "todo_id": "todo_frontstage_sufficiency",
+      "lane": {
+        "lane_id": "implementation_lane",
+        "agent_role": "side-agent"
+      },
+      "state_transition": {
+        "from_state": "deferred_implementation_claim",
+        "to_state": "ready_after_fixture"
+      },
+      "causality": {
+        "caused_by": "todo_done:todo_minimal_rollout_fixture",
+        "source_event_id": "evt_lh_005_minimal_fixture_validated",
+        "unblocks": [
+          "todo_frontstage_sufficiency"
+        ]
+      },
+      "handoff": {
+        "to_agent_id": "codex-side-bypass"
+      },
+      "status": "ready",
+      "classification": "frontstage_sufficiency_ready",
+      "summary": "The implementation lane can now test sufficiency against a concrete minimal rollout fixture.",
+      "artifact_refs": [
+        "examples/fixtures/long-horizon-self-iteration-rollout.public.json"
+      ],
+      "boundary": {
+        "raw_task_text_recorded": false,
+        "raw_logs_recorded": false,
+        "raw_trajectory_recorded": false,
+        "raw_session_transcript_recorded": false,
+        "credential_values_recorded": false,
+        "absolute_paths_recorded": false
+      }
+    },
+    {
+      "schema_version": "loopx_rollout_event_v0",
+      "event_id": "evt_lh_007_timeline_ready",
+      "goal_id": "public-long-horizon-loop",
+      "event_kind": "todo_update",
+      "recorded_at": "2026-06-24T01:18:00+08:00",
+      "agent_id": "codex-product-capability",
+      "todo_id": "todo_frontstage_timeline",
+      "lane": {
+        "lane_id": "implementation_lane",
+        "agent_role": "side-agent"
+      },
+      "state_transition": {
+        "from_state": "deferred_implementation_claim",
+        "to_state": "ready_after_fixture"
+      },
+      "causality": {
+        "caused_by": "todo_done:todo_minimal_rollout_fixture",
+        "source_event_id": "evt_lh_005_minimal_fixture_validated",
+        "unblocks": [
+          "todo_frontstage_timeline"
+        ]
+      },
+      "handoff": {
+        "to_agent_id": "codex-side-bypass"
+      },
+      "status": "ready",
+      "classification": "frontstage_timeline_ready",
+      "summary": "The implementation lane can build a multi-lane timeline without reading private state.",
+      "artifact_refs": [
+        "examples/fixtures/long-horizon-self-iteration-rollout.public.json"
+      ],
+      "boundary": {
+        "raw_task_text_recorded": false,
+        "raw_logs_recorded": false,
+        "raw_trajectory_recorded": false,
+        "raw_session_transcript_recorded": false,
+        "credential_values_recorded": false,
+        "absolute_paths_recorded": false
+      }
+    }
+  ],
+  "animation_events": [
+    {
+      "animation_event_id": "anim_protocol_contract",
+      "lane_id": "product_capability",
+      "kind": "deliverable",
+      "title": "Protocol contract ready",
+      "source_event_ids": [
+        "evt_lh_001_protocol_contract_ready"
+      ],
+      "state_transition": {
+        "from_state": "draft",
+        "to_state": "ready"
+      },
+      "confidence": "observed",
+      "display_hint": "solid_edge",
+      "evidence_refs": [
+        "https://github.com/huangruiteng/loopx/pull/617"
+      ]
+    },
+    {
+      "animation_event_id": "anim_frontstage_delegation",
+      "lane_id": "primary_control",
+      "kind": "human_gate",
+      "title": "Operator delegates UI implementation",
+      "source_event_ids": [
+        "evt_lh_003_frontstage_impl_handoff",
+        "evt_lh_004_sufficiency_check_deferred"
+      ],
+      "state_transition": {
+        "from_state": "single lane owns protocol and UI planning",
+        "to_state": "implementation lane resumes after fixture"
+      },
+      "human_effect": {
+        "decision_id": "decision_frontstage_to_implementation_lane",
+        "changes": [
+          "claim_owner",
+          "resume_condition",
+          "handoff_target"
+        ]
+      },
+      "confidence": "observed",
+      "display_hint": "gate_node"
+    },
+    {
+      "animation_event_id": "anim_fixture_validation",
+      "lane_id": "product_capability",
+      "kind": "validation",
+      "title": "Minimal rollout fixture validated",
+      "source_event_ids": [
+        "evt_lh_005_minimal_fixture_validated"
+      ],
+      "state_transition": {
+        "from_state": "fixture_required",
+        "to_state": "fixture_ready"
+      },
+      "confidence": "observed",
+      "display_hint": "solid_edge",
+      "evidence_refs": [
+        "examples/fixtures/long-horizon-self-iteration-rollout.public.json",
+        "examples/long-horizon-self-iteration-rollout-fixture-smoke.py"
+      ]
+    },
+    {
+      "animation_event_id": "anim_sufficiency_unblocked",
+      "lane_id": "implementation_lane",
+      "kind": "handoff",
+      "title": "Sufficiency check resumes",
+      "source_event_ids": [
+        "evt_lh_006_sufficiency_ready"
+      ],
+      "state_transition": {
+        "from_state": "deferred",
+        "to_state": "ready"
+      },
+      "confidence": "inferred_high",
+      "display_hint": "solid_edge"
+    },
+    {
+      "animation_event_id": "anim_timeline_unblocked",
+      "lane_id": "implementation_lane",
+      "kind": "handoff",
+      "title": "Timeline implementation resumes",
+      "source_event_ids": [
+        "evt_lh_007_timeline_ready"
+      ],
+      "state_transition": {
+        "from_state": "deferred",
+        "to_state": "ready"
+      },
+      "confidence": "inferred_high",
+      "display_hint": "solid_edge"
+    },
+    {
+      "animation_event_id": "anim_fixture_to_ui_bridge",
+      "lane_id": "implementation_lane",
+      "kind": "synthetic_bridge",
+      "title": "Fixture-ready to UI-ready display bridge",
+      "source_event_ids": [
+        "evt_lh_005_minimal_fixture_validated",
+        "evt_lh_007_timeline_ready"
+      ],
+      "state_transition": {
+        "from_state": "fixture_ready",
+        "to_state": "ui_implementation_candidate"
+      },
+      "confidence": "synthetic_bridge",
+      "inference_reason": "The actual UI commit does not exist in this fixture yet; the bridge exists only so frontstage can render a future handoff target.",
+      "display_hint": "dashed_edge"
+    }
+  ],
+  "frontend_acceptance": {
+    "minimum_lane_ids": [
+      "primary_control",
+      "product_capability",
+      "implementation_lane"
+    ],
+    "must_render": [
+      "three agent lanes",
+      "one human gate node",
+      "one handoff from product-capability to implementation lane",
+      "one validation event",
+      "one PR or commit evidence reference",
+      "one dashed inferred bridge"
+    ],
+    "recommended_tests": [
+      "fixture schema smoke",
+      "frontstage route smoke",
+      "browser smoke across desktop and mobile once UI consumes this fixture"
+    ]
+  }
+}

--- a/examples/fixtures/rollback-packet.public.json
+++ b/examples/fixtures/rollback-packet.public.json
@@ -1,0 +1,103 @@
+{
+  "schema_version": "rollback_packet_v0",
+  "packet_id": "rollback_public_boundary_example_v0",
+  "goal_id": "public-long-horizon-loop",
+  "created_at": "2026-06-24T01:20:00+08:00",
+  "trigger": {
+    "kind": "public_boundary_leak",
+    "summary": "A public PR surface exposed context that should remain local.",
+    "todo_ids": [
+      "todo_public_boundary_repair"
+    ],
+    "source_event_ids": [
+      "evt_lh_005_minimal_fixture_validated"
+    ]
+  },
+  "scope": {
+    "repository_refs": {
+      "commit_refs": [
+        "abcdef1"
+      ],
+      "pr_refs": [
+        "huangruiteng/loopx#617"
+      ]
+    },
+    "todo_ids": [
+      "todo_public_boundary_repair"
+    ],
+    "external_resource_refs": [
+      "github_support_request"
+    ],
+    "user_visible_surfaces": [
+      "pull_request",
+      "cached_view"
+    ],
+    "local_state_refs": []
+  },
+  "decision": {
+    "owner": "maintainer",
+    "required": true,
+    "reason": "History rewrite and external cached-view removal require explicit owner action.",
+    "default_safe_action": "pause_and_monitor"
+  },
+  "plan": [
+    {
+      "step_id": "clean_main_history",
+      "kind": "history_rewrite",
+      "action": "replace public branch history with a clean equivalent commit set",
+      "requires_gate": true,
+      "destructive": true,
+      "automatable_by_agent": false
+    },
+    {
+      "step_id": "submit_support_request",
+      "kind": "support_request",
+      "action": "ask provider support to remove read-only PR refs and cached views",
+      "requires_gate": true,
+      "destructive": false,
+      "automatable_by_agent": false
+    },
+    {
+      "step_id": "verify_public_boundary",
+      "kind": "validation",
+      "action": "scan normal heads and changed public paths for private markers",
+      "requires_gate": false,
+      "destructive": false,
+      "automatable_by_agent": true
+    }
+  ],
+  "todo_compensation": {
+    "complete_todo_ids": [
+      "todo_submit_support_request"
+    ],
+    "add_todos": [
+      {
+        "role": "agent",
+        "task_class": "continuous_monitor",
+        "title": "Verify provider-side cached view removal after support response."
+      }
+    ],
+    "supersede_todo_ids": []
+  },
+  "validation": {
+    "commands": [
+      "git diff --check",
+      "loopx check --scan-path <public-safe-path>",
+      "git ls-remote --heads origin"
+    ],
+    "public_boundary_scan_required": true,
+    "success_criteria": [
+      "normal public heads no longer contain the affected public markers",
+      "provider-owned cached views or read-only refs are removed or tracked by an open external gate",
+      "successor monitor todo exists when external cleanup is pending"
+    ]
+  },
+  "boundary": {
+    "raw_task_text_recorded": false,
+    "raw_logs_recorded": false,
+    "raw_trajectory_recorded": false,
+    "raw_session_transcript_recorded": false,
+    "credential_values_recorded": false,
+    "absolute_paths_recorded": false
+  }
+}

--- a/examples/global-manager-command-protocol-smoke.py
+++ b/examples/global-manager-command-protocol-smoke.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Smoke-test the public global_manager_command_v0 contract and fixture."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONTRACT_PATH = REPO_ROOT / "docs" / "reference" / "protocols" / "global-manager-command-v0.md"
+INDEX_PATH = REPO_ROOT / "docs" / "reference" / "protocols" / "README.md"
+LONG_HORIZON_PATH = (
+    REPO_ROOT / "docs" / "reference" / "protocols" / "long-horizon-agent-state-protocol-v0.md"
+)
+FIXTURE_PATH = REPO_ROOT / "examples" / "fixtures" / "global-manager-command.public.json"
+
+REQUIRED_COMMANDS = {
+    "/loop-global-summary",
+    "/loop-global-gates",
+    "/loop-global-todos",
+    "/loop-global-risks",
+    "/loop-goal-summary",
+}
+
+REQUIRED_BOUNDARY_FALSE = {
+    "raw_logs_recorded",
+    "raw_transcripts_recorded",
+    "raw_connector_payloads_recorded",
+    "credential_values_recorded",
+    "absolute_paths_recorded",
+    "private_source_bodies_recorded",
+}
+
+PRIVATE_PATTERNS = [
+    re.compile(r"/" + r"Users/[A-Za-z0-9._-]+/"),
+    re.compile(r"/home/[A-Za-z0-9._-]+/"),
+    re.compile(r"/" + "private/"),
+    re.compile(r"[A-Za-z]:\\\\Users\\\\"),
+    re.compile(r"\bBearer\s+[A-Za-z0-9._-]+"),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+    re.compile(r"\b" + "depart" + "ment" + r"\b", re.IGNORECASE),
+    re.compile("\u90e8\u95e8"),
+    re.compile("\u6c47\u62a5"),
+]
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def assert_public_safe(text: str, label: str) -> None:
+    for pattern in PRIVATE_PATTERNS:
+        if pattern.search(text):
+            raise AssertionError(f"{label} matched private pattern {pattern.pattern!r}")
+
+
+def assert_contains(text: str, needle: str, label: str) -> None:
+    if needle not in text:
+        raise AssertionError(f"{label} missing {needle!r}")
+
+
+def main() -> int:
+    contract = read(CONTRACT_PATH)
+    index = read(INDEX_PATH)
+    long_horizon = read(LONG_HORIZON_PATH)
+    fixture_text = read(FIXTURE_PATH)
+
+    for label, text in {
+        "contract": contract,
+        "protocol index": index,
+        "long horizon protocol": long_horizon,
+        "fixture": fixture_text,
+    }.items():
+        assert_public_safe(text, label)
+
+    assert_contains(index, "global_manager_command_v0", "protocol index")
+    assert_contains(long_horizon, "global_manager_command_v0", "long horizon protocol")
+    for command in REQUIRED_COMMANDS:
+        assert_contains(contract, command, "command set")
+    for needle in [
+        "read-only by default",
+        "Action Ladder",
+        "Privacy Boundary",
+        "global_manager_command_response_v0",
+        "python3 examples/global-manager-command-protocol-smoke.py",
+    ]:
+        assert_contains(contract, needle, "global manager command contract")
+
+    payload = json.loads(fixture_text)
+    assert payload["schema_version"] == "global_manager_command_response_v0", payload
+    request = payload["request"]
+    assert request["schema_version"] == "global_manager_command_request_v0", request
+    assert request["command"] in REQUIRED_COMMANDS, request
+    assert request["privacy_mode"] == "public_safe_summary", request
+    assert request["dry_run"] is True, request
+
+    summary = payload["summary"]
+    for key in ("headline", "progress_count", "open_gate_count", "runnable_todo_count", "risk_count"):
+        assert key in summary, summary
+
+    lanes = payload["lanes"]
+    assert lanes and all(item.get("goal_id") and item.get("agent_id") for item in lanes), lanes
+    assert all(item.get("next_safe_action") for item in lanes), lanes
+
+    actions = payload["actions"]
+    assert actions, actions
+    assert any(action["kind"] == "promote_todo" and action["requires_user_approval"] for action in actions)
+    assert any(action["kind"] == "review" and action["requires_primary_agent"] for action in actions)
+
+    boundary = payload["boundary"]
+    for key in REQUIRED_BOUNDARY_FALSE:
+        assert boundary.get(key) is False, (key, boundary)
+
+    omissions = " ".join(payload.get("omissions") or [])
+    assert "Raw logs" in omissions and "private source bodies" in omissions, omissions
+
+    print("global-manager-command-protocol-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/goal-rollout-event-log-smoke.py
+++ b/examples/goal-rollout-event-log-smoke.py
@@ -138,12 +138,50 @@ def main() -> None:
             event_kind="quota_should_run",
             agent_id="codex-main-control",
             todo_id="todo_406bb256efd8",
+            lane_id="main-control",
+            agent_role="primary",
+            gate_id="gate_owner_scope",
+            decision_id="todo_7aadc0a2387a",
+            from_state="waiting",
+            to_state="eligible",
+            caused_by="quota_should_run",
+            source_event_id="event_previous_public",
+            blocks=["todo_blocked_by_gate"],
+            unblocks=["todo_406bb256efd8"],
+            handoff_to="codex-product-capability",
+            commit_ref="abcdef1",
+            pr_ref="huangruiteng/loopx#551",
+            revert_of="event_superseded_public",
             status="eligible",
             summary="Quota allowed one bounded rollout event-log slice.",
             artifact_refs=["docs/benchmark-developer-workflow.md"],
             details={"open_agent_todo_count": 2},
         )
         append_rollout_event(log_path, event)
+        assert event["lane"] == {
+            "lane_id": "main-control",
+            "agent_role": "primary",
+        }, event
+        assert event["state_transition"] == {
+            "from_state": "waiting",
+            "to_state": "eligible",
+        }, event
+        assert event["causality"] == {
+            "caused_by": "quota_should_run",
+            "source_event_id": "event_previous_public",
+            "gate_id": "gate_owner_scope",
+            "decision_id": "todo_7aadc0a2387a",
+            "blocks": ["todo_blocked_by_gate"],
+            "unblocks": ["todo_406bb256efd8"],
+        }, event
+        assert event["handoff"] == {
+            "to_agent_id": "codex-product-capability",
+        }, event
+        assert event["code_refs"] == {
+            "commit_ref": "abcdef1",
+            "pr_ref": "huangruiteng/loopx#551",
+            "revert_of": "event_superseded_public",
+        }, event
 
         result_event = run_script(
             "append",
@@ -163,12 +201,41 @@ def main() -> None:
             "build-cython-ext",
             "--status",
             "precise_blocker",
+            "--lane-id",
+            "product-capability",
+            "--agent-role",
+            "side-agent",
+            "--from-state",
+            "open",
+            "--to-state",
+            "blocked",
+            "--caused-by",
+            "validation",
+            "--gate-id",
+            "gate_public_safe_boundary",
+            "--commit-ref",
+            "bcdef12",
+            "--pr-ref",
+            "huangruiteng/loopx#552",
             "--summary",
             "Compact case result reduced to public-safe failure attribution.",
             "--artifact-ref",
             "docs/research/long-horizon-agent-benchmarks/benchmark-case-analysis.json",
         )
         assert result_event["event_kind"] == "compact_case_result", result_event
+        assert result_event["lane"]["lane_id"] == "product-capability", result_event
+        assert result_event["state_transition"] == {
+            "from_state": "open",
+            "to_state": "blocked",
+        }, result_event
+        assert result_event["causality"]["caused_by"] == "validation", result_event
+        assert result_event["causality"]["gate_id"] == (
+            "gate_public_safe_boundary"
+        ), result_event
+        assert result_event["code_refs"] == {
+            "commit_ref": "bcdef12",
+            "pr_ref": "huangruiteng/loopx#552",
+        }, result_event
         assert_boundary(result_event)
 
         session_root = Path(tmp) / "sessions"
@@ -202,6 +269,14 @@ def main() -> None:
         assert summary["counts_by_kind"]["quota_should_run"] == 1, summary
         assert summary["counts_by_kind"]["compact_case_result"] == 1, summary
         assert summary["counts_by_kind"]["codex_session_observed"] == 1, summary
+        latest_view = summary["recent_events"][0]
+        assert latest_view["lane"]["lane_id"] == "main-control", latest_view
+        assert latest_view["state_transition"]["to_state"] == "eligible", latest_view
+        assert latest_view["causality"]["gate_id"] == "gate_owner_scope", latest_view
+        assert latest_view["code_refs"]["pr_ref"] == "huangruiteng/loopx#551", latest_view
+        assert latest_view["handoff"]["to_agent_id"] == (
+            "codex-product-capability"
+        ), latest_view
         assert_boundary(summary)
         rendered_summary = run_script(
             "summarize",

--- a/examples/long-horizon-agent-state-protocol-smoke.py
+++ b/examples/long-horizon-agent-state-protocol-smoke.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Validate the public long-horizon agent state protocol contract."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PROTOCOL_PATH = (
+    REPO_ROOT
+    / "docs"
+    / "reference"
+    / "protocols"
+    / "long-horizon-agent-state-protocol-v0.md"
+)
+INDEX_PATH = REPO_ROOT / "docs" / "reference" / "protocols" / "README.md"
+
+FORBIDDEN_PRIVATE_PATTERNS = [
+    re.compile(r"/" + r"Users/[A-Za-z0-9._-]+/"),
+    re.compile(r"/home/[A-Za-z0-9._-]+/"),
+    re.compile(r"/" + "private/"),
+    re.compile(r"\b" + "depart" + "ment" + r"\b", re.IGNORECASE),
+    re.compile("\u90e8\u95e8"),
+    re.compile("\u6c47\u62a5"),
+]
+
+
+def assert_contains(source: str, snippet: str, label: str) -> None:
+    if snippet not in source:
+        raise AssertionError(f"missing {label}: {snippet}")
+
+
+def assert_public_safe(source: str) -> None:
+    for pattern in FORBIDDEN_PRIVATE_PATTERNS:
+        if pattern.search(source):
+            raise AssertionError(f"protocol matched private pattern {pattern.pattern!r}")
+
+
+def main() -> int:
+    protocol = PROTOCOL_PATH.read_text(encoding="utf-8")
+    index = INDEX_PATH.read_text(encoding="utf-8")
+    assert_public_safe(protocol)
+    assert_public_safe(index)
+
+    assert_contains(index, "long_horizon_agent_state_protocol_v0", "protocol index")
+    assert_contains(protocol, "## Source Protocol", "source protocol section")
+    assert_contains(protocol, "## Projection Protocol", "projection protocol section")
+    assert_contains(protocol, '"projection_is_writable": false', "read-only projection flag")
+    assert_contains(protocol, "interaction_contract_v0", "interaction contract anchor")
+    assert_contains(protocol, "agent_lane_next_action_v0", "agent lane next action anchor")
+    assert_contains(protocol, "loopx_rollout_event_v0", "rollout event anchor")
+    assert_contains(protocol, "rollback_packet_v0", "rollback future contract")
+    assert_contains(protocol, "candidate todos are not silently promoted", "candidate todo acceptance")
+    print("long-horizon-agent-state-protocol smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/long-horizon-self-iteration-rollout-fixture-smoke.py
+++ b/examples/long-horizon-self-iteration-rollout-fixture-smoke.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Validate the public long-horizon self-iteration rollout fixture."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_PATH = (
+    REPO_ROOT
+    / "examples"
+    / "fixtures"
+    / "long-horizon-self-iteration-rollout.public.json"
+)
+
+PRIVATE_PATTERNS = [
+    re.compile(r"/" + r"Users/[A-Za-z0-9._-]+/"),
+    re.compile(r"/home/[A-Za-z0-9._-]+/"),
+    re.compile(r"/" + "private/"),
+    re.compile(r"[A-Za-z]:\\\\Users\\\\"),
+    re.compile(r"\bBearer\s+[A-Za-z0-9._-]+"),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+    re.compile(r"\b" + "depart" + "ment" + r"\b", re.IGNORECASE),
+    re.compile("\u90e8\u95e8"),
+    re.compile("\u6c47\u62a5"),
+]
+
+REQUIRED_BOUNDARY_FALSE = {
+    "raw_task_text_recorded",
+    "raw_logs_recorded",
+    "raw_trajectory_recorded",
+    "raw_session_transcript_recorded",
+    "credential_values_recorded",
+    "absolute_paths_recorded",
+}
+
+ALLOWED_CONFIDENCE = {
+    "observed",
+    "inferred_high",
+    "inferred_medium",
+    "synthetic_bridge",
+}
+
+
+def assert_public_safe(text: str) -> None:
+    for pattern in PRIVATE_PATTERNS:
+        if pattern.search(text):
+            raise AssertionError(f"fixture matched private pattern {pattern.pattern!r}")
+
+
+def assert_boundary(payload: dict, label: str) -> None:
+    boundary = payload.get("boundary")
+    assert isinstance(boundary, dict), (label, boundary)
+    for key in REQUIRED_BOUNDARY_FALSE:
+        assert boundary.get(key) is False, (label, key, boundary)
+
+
+def main() -> int:
+    fixture_text = FIXTURE_PATH.read_text(encoding="utf-8")
+    assert_public_safe(fixture_text)
+    payload = json.loads(fixture_text)
+
+    assert payload["schema_version"] == "long_horizon_self_iteration_fixture_v0", payload
+    assert payload["goal_id"] == "public-long-horizon-loop", payload
+    assert payload["truth_contract"]["event_ledger_is_source_of_truth"] is True, payload
+    assert payload["truth_contract"]["fixture_is_writable"] is False, payload
+    assert payload["truth_contract"]["projection_is_writable"] is False, payload
+    assert payload["truth_contract"]["write_authority"] == "none", payload
+
+    public_boundary = payload["public_boundary"]
+    for key in REQUIRED_BOUNDARY_FALSE:
+        assert public_boundary.get(key) is False, (key, public_boundary)
+    assert public_boundary.get("private_material_body_recorded") is False, public_boundary
+
+    lanes = {lane["lane_id"]: lane for lane in payload["lanes"]}
+    assert {"primary_control", "product_capability", "implementation_lane"} <= set(
+        lanes
+    ), lanes
+    assert lanes["implementation_lane"]["agent_id"] == "codex-side-bypass", lanes
+
+    rollout_events = payload["rollout_events"]
+    assert len(rollout_events) >= 7, rollout_events
+    event_ids = [event["event_id"] for event in rollout_events]
+    assert len(event_ids) == len(set(event_ids)), event_ids
+    event_lanes = {event.get("lane", {}).get("lane_id") for event in rollout_events}
+    assert {"implementation_lane", "product_capability"} <= event_lanes, event_lanes
+
+    saw_gate = False
+    saw_handoff = False
+    saw_validation = False
+    saw_pr_ref = False
+    saw_deferred_resume = False
+
+    for event in rollout_events:
+        assert event["schema_version"] == "loopx_rollout_event_v0", event
+        assert event["goal_id"] == "public-long-horizon-loop", event
+        assert_boundary(event, event["event_id"])
+        assert event.get("summary"), event
+        assert not any(str(ref).startswith("/") for ref in event.get("artifact_refs", [])), event
+        causality = event.get("causality", {})
+        if causality.get("gate_id") == "gate_minimal_rollout_fixture":
+            saw_gate = True
+        if event.get("handoff", {}).get("to_agent_id") == "codex-side-bypass":
+            saw_handoff = True
+        if event["event_kind"] == "validation":
+            saw_validation = True
+        if event.get("code_refs", {}).get("pr_ref"):
+            saw_pr_ref = True
+        transition = event.get("state_transition", {})
+        if transition.get("from_state", "").startswith("deferred"):
+            saw_deferred_resume = True
+
+    assert saw_gate, "human/fixture gate missing"
+    assert saw_handoff, "side-agent handoff missing"
+    assert saw_validation, "validation event missing"
+    assert saw_pr_ref, "PR evidence missing"
+    assert saw_deferred_resume, "deferred-to-ready transition missing"
+
+    animation_events = payload["animation_events"]
+    assert len(animation_events) >= 6, animation_events
+    animation_ids = [event["animation_event_id"] for event in animation_events]
+    assert len(animation_ids) == len(set(animation_ids)), animation_ids
+    assert any(event["kind"] == "human_gate" for event in animation_events), animation_events
+    assert any(event["display_hint"] == "dashed_edge" for event in animation_events), animation_events
+    assert any(event["confidence"] == "synthetic_bridge" for event in animation_events), animation_events
+    for event in animation_events:
+        assert event["confidence"] in ALLOWED_CONFIDENCE, event
+        assert event["lane_id"] in lanes, event
+        assert event.get("source_event_ids"), event
+
+    must_render = set(payload["frontend_acceptance"]["must_render"])
+    assert "three agent lanes" in must_render, must_render
+    assert "one human gate node" in must_render, must_render
+    assert "one dashed inferred bridge" in must_render, must_render
+
+    print("long-horizon-self-iteration-rollout-fixture smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/rollback-packet-protocol-smoke.py
+++ b/examples/rollback-packet-protocol-smoke.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Smoke-test the public rollback_packet_v0 contract and fixture."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONTRACT_PATH = REPO_ROOT / "docs" / "reference" / "protocols" / "rollback-packet-v0.md"
+INDEX_PATH = REPO_ROOT / "docs" / "reference" / "protocols" / "README.md"
+LONG_HORIZON_PATH = (
+    REPO_ROOT / "docs" / "reference" / "protocols" / "long-horizon-agent-state-protocol-v0.md"
+)
+FIXTURE_PATH = REPO_ROOT / "examples" / "fixtures" / "rollback-packet.public.json"
+
+ALLOWED_TRIGGER_KINDS = {
+    "validation_regression",
+    "public_boundary_leak",
+    "operator_request",
+    "external_setup_partial_failure",
+    "wrong_owner_or_lane",
+    "bad_state_projection",
+    "release_or_publish_mistake",
+}
+
+ALLOWED_STEP_KINDS = {
+    "git_revert",
+    "fix_forward",
+    "history_rewrite",
+    "state_compensation",
+    "external_cleanup",
+    "support_request",
+    "todo_supersede",
+    "validation",
+}
+
+REQUIRED_BOUNDARY_FALSE = {
+    "raw_task_text_recorded",
+    "raw_logs_recorded",
+    "raw_trajectory_recorded",
+    "raw_session_transcript_recorded",
+    "credential_values_recorded",
+    "absolute_paths_recorded",
+}
+
+PRIVATE_PATTERNS = [
+    re.compile(r"/" + r"Users/[A-Za-z0-9._-]+/"),
+    re.compile(r"/home/[A-Za-z0-9._-]+/"),
+    re.compile(r"/" + "private/"),
+    re.compile(r"[A-Za-z]:\\\\Users\\\\"),
+    re.compile(r"\bBearer\s+[A-Za-z0-9._-]+"),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+    re.compile(r"\b" + "depart" + "ment" + r"\b", re.IGNORECASE),
+    re.compile("\u90e8\u95e8"),
+    re.compile("\u6c47\u62a5"),
+]
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def assert_contains(text: str, needle: str, label: str) -> None:
+    if needle not in text:
+        raise AssertionError(f"{label} missing {needle!r}")
+
+
+def assert_public_safe(text: str, label: str) -> None:
+    for pattern in PRIVATE_PATTERNS:
+        if pattern.search(text):
+            raise AssertionError(f"{label} matched private pattern {pattern.pattern!r}")
+
+
+def main() -> int:
+    contract = read(CONTRACT_PATH)
+    index = read(INDEX_PATH)
+    long_horizon = read(LONG_HORIZON_PATH)
+    fixture_text = read(FIXTURE_PATH)
+
+    for label, text in {
+        "contract": contract,
+        "protocol index": index,
+        "long horizon protocol": long_horizon,
+        "fixture": fixture_text,
+    }.items():
+        assert_public_safe(text, label)
+
+    for needle in [
+        "rollback_packet_v0",
+        "Commit And Todo Linkage",
+        "history_rewrite",
+        "explicit user or maintainer approval",
+        "support_request",
+        "todo_compensation",
+        "python3 examples/rollback-packet-protocol-smoke.py",
+    ]:
+        assert_contains(contract, needle, "rollback contract")
+    assert_contains(index, "rollback_packet_v0", "protocol index")
+    assert_contains(long_horizon, "rollback_packet_v0", "long horizon protocol")
+
+    payload = json.loads(fixture_text)
+    assert payload["schema_version"] == "rollback_packet_v0", payload
+    assert payload["trigger"]["kind"] in ALLOWED_TRIGGER_KINDS, payload
+    assert payload["trigger"]["todo_ids"], payload
+    assert payload["trigger"]["source_event_ids"], payload
+    assert payload["scope"]["repository_refs"]["commit_refs"], payload
+    assert payload["scope"]["repository_refs"]["pr_refs"], payload
+    assert payload["scope"]["external_resource_refs"], payload
+    assert payload["decision"]["required"] is True, payload
+
+    plan = payload["plan"]
+    assert isinstance(plan, list) and len(plan) >= 3, plan
+    step_ids = [step["step_id"] for step in plan]
+    assert len(step_ids) == len(set(step_ids)), step_ids
+    for step in plan:
+        assert step["kind"] in ALLOWED_STEP_KINDS, step
+        for key in ("action", "requires_gate", "destructive", "automatable_by_agent"):
+            assert key in step, step
+        if step["destructive"] or step["kind"] in {"history_rewrite", "support_request"}:
+            assert step["requires_gate"] is True, step
+            assert step["automatable_by_agent"] is False, step
+
+    compensation = payload["todo_compensation"]
+    assert compensation["complete_todo_ids"], compensation
+    assert compensation["add_todos"], compensation
+    assert compensation["add_todos"][0]["task_class"] == "continuous_monitor", compensation
+
+    validation = payload["validation"]
+    assert validation["commands"], validation
+    assert validation["public_boundary_scan_required"] is True, validation
+    assert validation["success_criteria"], validation
+
+    boundary = payload["boundary"]
+    for key in REQUIRED_BOUNDARY_FALSE:
+        assert boundary.get(key) is False, (key, boundary)
+
+    print("rollback-packet-protocol-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/rollout_event_log.py
+++ b/loopx/rollout_event_log.py
@@ -148,6 +148,17 @@ def _safe_source_refs(
     return safe_refs
 
 
+def _safe_public_refs(
+    values: Sequence[str] | None, *, field: str
+) -> list[str]:
+    safe_refs: list[str] = []
+    for value in values or []:
+        safe = _safe_public_ref(value, field=field)
+        if safe:
+            safe_refs.append(safe)
+    return safe_refs
+
+
 def _normalized_event_kind(event_kind: str) -> str:
     text = str(event_kind).strip().lower().replace("-", "_")
     if text not in ROLLOUT_EVENT_KINDS:
@@ -184,6 +195,20 @@ def build_rollout_event(
     benchmark_id: str | None = None,
     case_id: str | None = None,
     run_id: str | None = None,
+    lane_id: str | None = None,
+    agent_role: str | None = None,
+    gate_id: str | None = None,
+    decision_id: str | None = None,
+    from_state: str | None = None,
+    to_state: str | None = None,
+    caused_by: str | None = None,
+    source_event_id: str | None = None,
+    blocks: Sequence[str] | None = None,
+    unblocks: Sequence[str] | None = None,
+    handoff_to: str | None = None,
+    commit_ref: str | None = None,
+    pr_ref: str | None = None,
+    revert_of: str | None = None,
     status: str | None = None,
     classification: str | None = None,
     delivery_outcome: str | None = None,
@@ -254,6 +279,58 @@ def build_rollout_event(
         safe = _compact_text(value, limit=500 if key == "summary" else 180, field=key)
         if safe:
             payload[key] = safe
+    lane: dict[str, Any] = {}
+    for key, value in {
+        "lane_id": lane_id,
+        "agent_role": agent_role,
+    }.items():
+        safe = _compact_text(value, limit=180, field=key)
+        if safe:
+            lane[key] = safe
+    if lane:
+        payload["lane"] = lane
+    transition: dict[str, Any] = {}
+    for key, value in {
+        "from_state": from_state,
+        "to_state": to_state,
+    }.items():
+        safe = _compact_text(value, limit=180, field=key)
+        if safe:
+            transition[key] = safe
+    if transition:
+        payload["state_transition"] = transition
+    causality: dict[str, Any] = {}
+    for key, value in {
+        "caused_by": caused_by,
+        "source_event_id": source_event_id,
+        "gate_id": gate_id,
+        "decision_id": decision_id,
+    }.items():
+        safe = _compact_text(value, limit=180, field=key)
+        if safe:
+            causality[key] = safe
+    relation_blocks = _safe_public_refs(blocks, field="blocks")
+    relation_unblocks = _safe_public_refs(unblocks, field="unblocks")
+    if relation_blocks:
+        causality["blocks"] = relation_blocks
+    if relation_unblocks:
+        causality["unblocks"] = relation_unblocks
+    if causality:
+        payload["causality"] = causality
+    code_refs: dict[str, Any] = {}
+    for key, value in {
+        "commit_ref": commit_ref,
+        "pr_ref": pr_ref,
+        "revert_of": revert_of,
+    }.items():
+        safe = _safe_public_ref(value, field=key)
+        if safe:
+            code_refs[key] = safe
+    if code_refs:
+        payload["code_refs"] = code_refs
+    safe_handoff_to = _compact_text(handoff_to, limit=180, field="handoff_to")
+    if safe_handoff_to:
+        payload["handoff"] = {"to_agent_id": safe_handoff_to}
     if safe_labels:
         payload["labels"] = safe_labels
     if safe_artifact_refs:
@@ -318,6 +395,11 @@ def _safe_event_view(event: Mapping[str, Any]) -> dict[str, Any]:
         "benchmark_id",
         "case_id",
         "run_id",
+        "lane",
+        "state_transition",
+        "causality",
+        "code_refs",
+        "handoff",
         "classification",
         "delivery_outcome",
         "summary",

--- a/scripts/goal_rollout_event_log.py
+++ b/scripts/goal_rollout_event_log.py
@@ -53,6 +53,20 @@ def handle_append(args: argparse.Namespace) -> int:
         benchmark_id=args.benchmark_id,
         case_id=args.case_id,
         run_id=args.run_id,
+        lane_id=args.lane_id,
+        agent_role=args.agent_role,
+        gate_id=args.gate_id,
+        decision_id=args.decision_id,
+        from_state=args.from_state,
+        to_state=args.to_state,
+        caused_by=args.caused_by,
+        source_event_id=args.source_event_id,
+        blocks=args.blocks,
+        unblocks=args.unblocks,
+        handoff_to=args.handoff_to,
+        commit_ref=args.commit_ref,
+        pr_ref=args.pr_ref,
+        revert_of=args.revert_of,
         status=args.status,
         classification=args.classification,
         delivery_outcome=args.delivery_outcome,
@@ -117,6 +131,20 @@ def main() -> int:
     append_parser.add_argument("--benchmark-id")
     append_parser.add_argument("--case-id")
     append_parser.add_argument("--run-id")
+    append_parser.add_argument("--lane-id")
+    append_parser.add_argument("--agent-role")
+    append_parser.add_argument("--gate-id")
+    append_parser.add_argument("--decision-id")
+    append_parser.add_argument("--from-state")
+    append_parser.add_argument("--to-state")
+    append_parser.add_argument("--caused-by")
+    append_parser.add_argument("--source-event-id")
+    append_parser.add_argument("--blocks", action="append")
+    append_parser.add_argument("--unblocks", action="append")
+    append_parser.add_argument("--handoff-to")
+    append_parser.add_argument("--commit-ref")
+    append_parser.add_argument("--pr-ref")
+    append_parser.add_argument("--revert-of")
     append_parser.add_argument("--status")
     append_parser.add_argument("--classification")
     append_parser.add_argument("--delivery-outcome")


### PR DESCRIPTION
## Summary
- restores the public-safe rollout event transition metadata from the cleaned PR set: lane, state transition, causality, handoff, and code refs
- adds the generic `long_horizon_agent_state_protocol_v0` contract and smoke coverage for source-vs-projection separation
- restores the frontstage/status sufficiency check in generic operator-facing wording

## Excluded from the cleaned PR set
- old `department-*` fixtures and notes were not restored because their names, ids, source todos, and summaries were tied to private/internal context
- no `.local`, `.codex/goals`, raw logs, cached support drafts, or local absolute paths are included

## Validation
- `python3 -m py_compile loopx/rollout_event_log.py scripts/goal_rollout_event_log.py examples/goal-rollout-event-log-smoke.py examples/long-horizon-agent-state-protocol-smoke.py`
- `python3 examples/goal-rollout-event-log-smoke.py`
- `python3 examples/long-horizon-agent-state-protocol-smoke.py`
- `node examples/dashboard-frontstage-design-baseline-smoke.mjs`
- `git diff --check origin/main..HEAD`
- `loopx check --scan-path docs/reference/protocols/long-horizon-agent-state-protocol-v0.md`
- `loopx check --scan-path docs/product/frontstage-dashboard-interaction-baseline.md`
- public/private keyword scan over changed paths

## Notes
- `loopx check` reported the existing global `loopx-meta` duplicate index-row warning; the changed public files themselves scanned clean.
