### PR TITLE
Add SkillsBench lifecycle bridge counters

### DIFF
--- a/examples/benchmark-loop-protocol-smoke.py
+++ b/examples/benchmark-loop-protocol-smoke.py
@@ -179,6 +179,27 @@ def main() -> int:
     assert shallow_pair["main_table_claim_allowed"] is False, shallow_pair
     assert "treatment_loopx_lifecycle_not_observed" in shallow_pair["claim_blocker"]
 
+    orchestrated_treatment = dict(shallow_treatment)
+    orchestrated_treatment["product_mode_lifecycle_contract"] = {
+        "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+        "required": True,
+        "satisfied": True,
+        "countable_treatment": True,
+        "state_read_count": 1,
+        "state_write_count": 3,
+        "execution_style": "orchestrated_agentloop_loopx_cli",
+    }
+    orchestrated_pair = classify_product_mode_main_table_pair(
+        baseline_run=baseline_run,
+        treatment_run=orchestrated_treatment,
+    )
+    assert orchestrated_pair["main_table_claim_allowed"] is True, (
+        orchestrated_pair
+    )
+    assert orchestrated_pair["treatment_loopx_lifecycle_observed"] is True, (
+        orchestrated_pair
+    )
+
     final_score_only_baseline = dict(baseline_run)
     final_score_only_baseline.pop("round_rewards")
     final_score_only_pair = classify_product_mode_main_table_pair(

--- a/examples/benchmark-run-ledger-smoke.py
+++ b/examples/benchmark-run-ledger-smoke.py
@@ -990,6 +990,43 @@ def test_skillsbench_product_mode_pair_blocks_shallow_lifecycle() -> None:
         rendered = render_benchmark_run_ledger_markdown(ledger)
         assert "treatment_loopx_lifecycle_not_observed" in rendered, rendered
 
+    orchestrated_treatment = dict(treatment)
+    orchestrated_treatment["product_mode_lifecycle_contract"] = {
+        "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+        "required": True,
+        "satisfied": True,
+        "countable_treatment": True,
+        "state_read_count": 1,
+        "state_write_count": 3,
+        "execution_style": "orchestrated_agentloop_loopx_cli",
+    }
+    with tempfile.TemporaryDirectory(
+        prefix="benchmark-run-ledger-product-pair-orchestrated-"
+    ) as tmp:
+        root = Path(tmp)
+        ledger_path = root / "ledger.json"
+        update_benchmark_run_ledger(
+            ledger_path=ledger_path,
+            benchmark_run=baseline,
+            run_group_id="product-pair-orchestrated-ledger-smoke",
+            cwd=root,
+        )
+        update_benchmark_run_ledger(
+            ledger_path=ledger_path,
+            benchmark_run=orchestrated_treatment,
+            run_group_id="product-pair-orchestrated-ledger-smoke",
+            cwd=root,
+        )
+        ledger = load_benchmark_run_ledger(ledger_path)
+        case = ledger["benchmarks"]["skillsbench@1.1"]["cases"][
+            "shallow-citation-check"
+        ]
+        pair = case["latest_decision"]["product_mode_main_table_pair"]
+        assert pair["treatment_loopx_lifecycle_observed"] is True, pair
+        assert "treatment_loopx_lifecycle_not_observed" not in pair[
+            "claim_blocker"
+        ], pair
+
 
 def test_raw_max5_baseline_does_not_force_product_pair_without_product_treatment() -> None:
     baseline = {

--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -57,6 +57,7 @@ from scripts.skillsbench_automation_loop import (  # noqa: E402
     LOCAL_CODEX_PARTICIPANT_MATERIALIZATION_SCHEMA_VERSION,
     PRODUCT_MODE_CASE_STATE_PATH,
     PRODUCT_MODE_CASE_STATE_SCHEMA_VERSION,
+    SkillsBenchProductModeNoLifecycleRequests,
     _tail,
     _apply_agent_message_only_no_tool_calls_attribution,
     _blind_loop_persistent_continuation_clause,
@@ -1016,14 +1017,18 @@ def test_product_mode_no_tool_call_stops_before_checkpoint_loop() -> None:
             ]
             n_tool_calls = 0
 
-        prompt = asyncio.run(
-            user.run(
-                1,
-                "Fix the fixture.",
-                round_result=FakeRoundResult(),
+        try:
+            asyncio.run(
+                user.run(
+                    1,
+                    "Fix the fixture.",
+                    round_result=FakeRoundResult(),
+                )
             )
-        )
-        assert prompt is None, trace
+        except SkillsBenchProductModeNoLifecycleRequests as exc:
+            assert "no case-local LoopX lifecycle request" in str(exc)
+        else:
+            raise AssertionError("product-mode no-tool round must stop early")
         assert (
             trace["last_decision"]
             == "stop_after_product_mode_no_tool_calls_without_lifecycle"
@@ -1036,6 +1041,152 @@ def test_product_mode_no_tool_call_stops_before_checkpoint_loop() -> None:
         assert trace["product_mode_no_tool_call_lifecycle_abort_round"] == 1
         assert trace["followup_prompt_count"] == 0
         assert trace["stop_decision_count"] == 1
+
+
+def test_product_mode_agent_trace_no_requests_stops_before_verifier() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-no-agent-requests-") as tmp:
+        root = Path(tmp)
+        jobs_dir = root / "jobs"
+        job_name = "skillsbench_no_agent_requests_fixture"
+        rollout_name = "case__loopx_product_mode"
+        trace_dir = root / "public-traces"
+        trace_dir.mkdir(parents=True)
+        write_json(
+            trace_dir / "agent-ops.compact.json",
+            {
+                "schema_version": "skillsbench_host_local_acp_relay_public_trace_v0",
+                "trace_kind": "remote_command_file_bridge_agent_operations",
+                "boundary": {
+                    "raw_command_recorded": False,
+                    "raw_stdout_recorded": False,
+                    "raw_stderr_recorded": False,
+                    "raw_task_text_recorded": False,
+                    "raw_logs_recorded": False,
+                    "raw_trajectory_recorded": False,
+                    "credential_values_recorded": False,
+                    "host_paths_recorded": False,
+                    "remote_paths_recorded": False,
+                    "upload_performed": False,
+                    "submit_performed": False,
+                },
+                "remote_command_file_bridge_agent_operations": {
+                    "request_count": 0,
+                    "loopx_cli_call_count": 0,
+                    "loopx_state_read_count": 0,
+                    "loopx_state_write_count": 0,
+                    "operation_counts": {},
+                    "loopx_cli_subcommand_counts": {},
+                    "raw_material_recorded": False,
+                },
+            },
+        )
+        trace = {
+            "schema_version": "skillsbench_loopx_controller_trace_v0",
+            "route": "loopx-product-mode",
+            "loopx_state_reads": 0,
+            "loopx_state_writes": 0,
+            "loopx_case_state_reads": 0,
+            "loopx_case_state_writes": 0,
+            "heartbeat_count": 0,
+            "controller_action_decisions": 0,
+            "initial_prompt_count": 0,
+            "followup_prompt_count": 0,
+            "stop_decision_count": 0,
+            "reward_observation_count": 0,
+            "round_rewards": [],
+        }
+        plan = {
+            "jobs_dir": str(jobs_dir),
+            "job_name": job_name,
+            "rollout_name": rollout_name,
+            "host_local_acp_relay_trace_dir": str(trace_dir),
+            "runner_prerequisites": {
+                "remote_command_file_bridge_agent_command_configured": True,
+                "remote_command_file_bridge_agent_operation_trace_required": True,
+            },
+        }
+        saved_modules = {
+            name: sys.modules.get(name)
+            for name in (
+                "benchflow",
+                "benchflow.sandbox",
+                "benchflow.sandbox.user",
+            )
+        }
+        fake_benchflow = types.ModuleType("benchflow")
+        fake_sandbox = types.ModuleType("benchflow.sandbox")
+        fake_user = types.ModuleType("benchflow.sandbox.user")
+
+        class FakeBaseUser:
+            pass
+
+        class FakeRoundResultBase:
+            pass
+
+        fake_user.BaseUser = FakeBaseUser
+        fake_user.RoundResult = FakeRoundResultBase
+        sys.modules["benchflow"] = fake_benchflow
+        sys.modules["benchflow.sandbox"] = fake_sandbox
+        sys.modules["benchflow.sandbox.user"] = fake_user
+        try:
+            user = _build_product_mode_user(
+                route="loopx-product-mode",
+                max_rounds=8,
+                trace=trace,
+                plan=plan,
+            )
+        finally:
+            for name, module in saved_modules.items():
+                if module is None:
+                    sys.modules.pop(name, None)
+                else:
+                    sys.modules[name] = module
+
+        class FakeRoundResult:
+            rewards = {}
+            trajectory = [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "I used ordinary tools, but not LoopX.",
+                        }
+                    ],
+                }
+            ]
+            n_tool_calls = 2
+
+        try:
+            asyncio.run(
+                user.run(
+                    1,
+                    "Fix the fixture.",
+                    round_result=FakeRoundResult(),
+                )
+            )
+        except SkillsBenchProductModeNoLifecycleRequests as exc:
+            assert "no case-local LoopX lifecycle request" in str(exc)
+        else:
+            raise AssertionError("product-mode no-request trace must stop early")
+        assert (
+            trace["last_decision"]
+            == "stop_after_product_mode_agent_no_lifecycle_requests"
+        ), trace
+        assert trace["remote_command_file_bridge_agent_operation_trace_status"] == (
+            "agent_operation_trace_present_no_requests"
+        )
+        assert trace["remote_command_file_bridge_agent_operation_trace_count"] == 1
+        assert trace["remote_command_file_bridge_agent_request_count"] == 0
+        assert trace["product_mode_no_lifecycle_request_abort"] is True
+        assert trace["product_mode_no_lifecycle_request_abort_count"] == 1
+        assert trace["product_mode_no_lifecycle_request_abort_round"] == 1
+        assert trace.get("product_mode_no_tool_call_lifecycle_abort") is not True
+        assert trace["followup_prompt_count"] == 0
+        assert trace["stop_decision_count"] == 1
+        assert plan["runner_prerequisites"][
+            "remote_command_file_bridge_agent_operation_trace_status"
+        ] == "agent_operation_trace_present_no_requests"
 
 
 def write_json(path: Path, payload: dict[str, Any]) -> None:
@@ -3869,6 +4020,13 @@ def test_skillsbench_product_mode_lifecycle_checkpoint_is_compacted() -> None:
             "state_write_count": 0,
             "checkpoint_required": True,
             "checkpoint_count": 1,
+            "agent_operation_trace_required": False,
+            "agent_operation_trace_satisfied": False,
+            "agent_operation_trace_missing": False,
+            "agent_bridge_state_read_count": 0,
+            "agent_bridge_state_write_count": 0,
+            "driver_lifecycle_state_read_count": 0,
+            "driver_lifecycle_state_write_count": 0,
             "checkpoint_round": 1,
             "missing_reason": "missing_case_local_loopx_state_read_or_write",
         }, compact
@@ -3883,6 +4041,140 @@ def test_skillsbench_product_mode_lifecycle_checkpoint_is_compacted() -> None:
         assert compact_again["product_mode_lifecycle_contract"] == (
             lifecycle_contract
         ), compact_again
+        driver_controller_trace = dict(controller_trace)
+        driver_controller_trace.update(
+            {
+                "product_mode_lifecycle_checkpoint_missing_reason": "",
+                "remote_command_file_bridge_driver_lifecycle_trace_count": 1,
+                "remote_command_file_bridge_driver_lifecycle_execution_style": (
+                    "orchestrated_agentloop_loopx_cli"
+                ),
+                "remote_command_file_bridge_driver_lifecycle_checkpoint_count": 1,
+                "remote_command_file_bridge_driver_lifecycle_request_count": 4,
+                "remote_command_file_bridge_driver_lifecycle_loopx_cli_call_count": 4,
+                "remote_command_file_bridge_driver_lifecycle_loopx_state_read_count": 1,
+                "remote_command_file_bridge_driver_lifecycle_loopx_state_write_count": 3,
+            }
+        )
+        driver_compact = compact_benchmark_run(
+            build_skillsbench_benchflow_result_benchmark_run(
+                result_path,
+                route="loopx-product-mode",
+                controller_trace=driver_controller_trace,
+            )
+        )
+        assert driver_compact is not None
+        driver_contract = driver_compact["product_mode_lifecycle_contract"]
+        assert driver_contract["satisfied"] is True, driver_compact
+        assert driver_contract["countable_treatment"] is True, driver_compact
+        assert driver_contract["state_read_count"] == 1, driver_compact
+        assert driver_contract["state_write_count"] == 3, driver_compact
+        assert driver_contract["execution_style"] == (
+            "orchestrated_agentloop_loopx_cli"
+        ), driver_compact
+        driver_counters = driver_compact["interaction_counters"]
+        assert (
+            driver_counters[
+                "remote_command_file_bridge_driver_lifecycle_loopx_state_read_count"
+            ]
+            == 1
+        ), driver_compact
+        assert (
+            driver_counters[
+                "remote_command_file_bridge_driver_lifecycle_loopx_state_write_count"
+            ]
+            == 3
+        ), driver_compact
+        assert "skillsbench_product_mode_lifecycle_missing" not in driver_compact[
+            "failure_attribution_labels"
+        ], driver_compact
+        external_agent_controller_trace = dict(driver_controller_trace)
+        external_agent_controller_trace.update(
+            {
+                "remote_command_file_bridge_agent_command_configured": True,
+                "remote_command_file_bridge_agent_command_instrumented": False,
+                "remote_command_file_bridge_agent_operation_trace_required": True,
+                "remote_command_file_bridge_agent_operation_trace_satisfied": False,
+                "remote_command_file_bridge_agent_operation_trace_status": (
+                    "agent_operation_trace_missing"
+                ),
+                "remote_command_file_bridge_agent_operation_trace_count": 0,
+                "remote_command_file_bridge_agent_request_count": 0,
+                "remote_command_file_bridge_agent_loopx_state_read_count": 0,
+                "remote_command_file_bridge_agent_loopx_state_write_count": 0,
+            }
+        )
+        external_agent_compact = compact_benchmark_run(
+            build_skillsbench_benchflow_result_benchmark_run(
+                result_path,
+                route="loopx-product-mode",
+                controller_trace=external_agent_controller_trace,
+            )
+        )
+        assert external_agent_compact is not None
+        external_agent_contract = external_agent_compact[
+            "product_mode_lifecycle_contract"
+        ]
+        assert external_agent_contract["satisfied"] is False, external_agent_compact
+        assert external_agent_contract["countable_treatment"] is False, (
+            external_agent_compact
+        )
+        assert (
+            external_agent_contract["agent_operation_trace_required"] is True
+        ), external_agent_contract
+        assert (
+            external_agent_contract["agent_operation_trace_missing"] is True
+        ), external_agent_contract
+        assert external_agent_contract["state_read_count"] == 0, (
+            external_agent_contract
+        )
+        assert external_agent_contract["state_write_count"] == 0, (
+            external_agent_contract
+        )
+        assert external_agent_contract["driver_lifecycle_state_read_count"] == 1
+        assert external_agent_contract["driver_lifecycle_state_write_count"] == 3
+        assert external_agent_contract["missing_reason"] == (
+            "remote_command_file_bridge_agent_operation_trace_missing"
+        )
+        assert (
+            "skillsbench_remote_bridge_agent_operation_trace_missing"
+            in external_agent_compact["failure_attribution_labels"]
+        ), external_agent_compact
+        no_request_controller_trace = dict(external_agent_controller_trace)
+        no_request_controller_trace.update(
+            {
+                "remote_command_file_bridge_agent_operation_trace_status": (
+                    "agent_operation_trace_present_no_requests"
+                ),
+                "remote_command_file_bridge_agent_operation_trace_count": 1,
+            }
+        )
+        no_request_compact = compact_benchmark_run(
+            build_skillsbench_benchflow_result_benchmark_run(
+                result_path,
+                route="loopx-product-mode",
+                controller_trace=no_request_controller_trace,
+            )
+        )
+        assert no_request_compact is not None
+        no_request_contract = no_request_compact[
+            "product_mode_lifecycle_contract"
+        ]
+        assert no_request_contract["satisfied"] is False, no_request_compact
+        assert no_request_contract["countable_treatment"] is False, (
+            no_request_compact
+        )
+        assert no_request_contract["missing_reason"] == (
+            "remote_command_file_bridge_agent_no_requests"
+        )
+        assert (
+            "skillsbench_remote_bridge_agent_no_requests"
+            in no_request_compact["failure_attribution_labels"]
+        ), no_request_compact
+        assert (
+            "skillsbench_remote_bridge_agent_operation_trace_missing"
+            not in no_request_compact["failure_attribution_labels"]
+        ), no_request_compact
 
 
 def test_skillsbench_product_mode_no_tool_lifecycle_abort_is_compacted() -> None:
@@ -4569,6 +4861,69 @@ def test_skillsbench_runner_failure_compact_closeout() -> None:
             in compact["stop_conditions"]
         ), compact
         assert "BenchFlow result.json not found" not in json.dumps(compact), compact
+
+
+def test_skillsbench_runner_failure_compact_attributes_agent_no_requests() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-no-agent-request-") as tmp:
+        args = parse_args(
+            [
+                "--task-id",
+                "organize-messy-files",
+                "--route",
+                "loopx-product-mode",
+                "--jobs-dir",
+                str(Path(tmp) / "jobs"),
+                "--job-name",
+                "skillsbench-organize-messy-files-no-agent-request-fixture",
+            ]
+        )
+        plan = build_plan(args)
+        plan["runner_prerequisites"].update(
+            {
+                "remote_command_file_bridge_agent_operation_trace_required": True,
+                "remote_command_file_bridge_agent_operation_trace_satisfied": False,
+                "remote_command_file_bridge_agent_operation_trace_status": (
+                    "agent_operation_trace_present_no_requests"
+                ),
+                "remote_command_file_bridge_agent_operation_trace_count": 1,
+                "remote_command_file_bridge_agent_request_count": 0,
+                "remote_command_file_bridge_agent_loopx_cli_call_count": 0,
+                "remote_command_file_bridge_agent_loopx_state_read_count": 0,
+                "remote_command_file_bridge_agent_loopx_state_write_count": 0,
+            }
+        )
+        compact = build_runner_failure_compact(
+            args,
+            plan,
+            SkillsBenchProductModeNoLifecycleRequests(
+                "loopx-product-mode agent produced no tool or case-local "
+                "LoopX lifecycle request before official verifier"
+            ),
+        )
+        assert compact["official_score_status"] == "missing", compact
+        assert compact["first_blocker"] == (
+            "skillsbench_remote_bridge_agent_no_requests"
+        ), compact
+        assert compact["score_failure_attribution"] == (
+            "skillsbench_remote_bridge_agent_no_requests"
+        ), compact
+        assert (
+            compact["runner_failure"]["failure_class"]
+            == "skillsbench_remote_bridge_agent_no_requests"
+        ), compact
+        assert (
+            compact["runner_prerequisites"][
+                "remote_command_file_bridge_agent_operation_trace_status"
+            ]
+            == "agent_operation_trace_present_no_requests"
+        ), compact
+        assert "skillsbench_remote_bridge_agent_no_requests" in compact[
+            "failure_attribution_labels"
+        ], compact
+        assert "skillsbench_remote_bridge_agent_operation_trace_missing" not in compact[
+            "failure_attribution_labels"
+        ], compact
+        assert "case-local LoopX lifecycle request" not in json.dumps(compact), compact
 
 
 def test_skillsbench_runner_failure_prefers_structured_preflight_blocker() -> None:

--- a/examples/skillsbench-host-local-launch-plan-smoke.py
+++ b/examples/skillsbench-host-local-launch-plan-smoke.py
@@ -7,7 +7,9 @@ import json
 import subprocess
 import sys
 import tempfile
+import builtins
 from pathlib import Path
+from types import SimpleNamespace
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -18,7 +20,12 @@ from loopx.benchmark_adapters.skillsbench_acp_relay import (  # noqa: E402
     run_skillsbench_local_acp_relay_probe,
 )
 from scripts.skillsbench_automation_loop import (  # noqa: E402
+    _apply_agent_message_only_no_tool_calls_attribution,
+    _host_local_acp_launch_command,
     _merge_host_local_acp_relay_trace_summary,
+    _run_host_local_acp_codex_exec_preflight,
+    build_runner_failure_compact,
+    ensure_benchflow_runtime,
 )
 
 SCRIPT = REPO_ROOT / "scripts" / "skillsbench_automation_loop.py"
@@ -37,6 +44,32 @@ def main() -> int:
         task = root / "tasks" / "demo-task" / "environment"
         task.mkdir(parents=True)
         (task / "Dockerfile").write_text("FROM ubuntu:22.04\n", encoding="utf-8")
+        original_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "benchflow":
+                raise ModuleNotFoundError(
+                    "No module named 'benchflow'", name="benchflow"
+                )
+            return original_import(name, *args, **kwargs)
+
+        builtins.__import__ = fake_import
+        try:
+            try:
+                ensure_benchflow_runtime(
+                    SimpleNamespace(
+                        plan_only=False,
+                        reduce_only=False,
+                        skillsbench_root=str(root),
+                    )
+                )
+            except RuntimeError as exc:
+                assert "benchflow runtime unavailable" in str(exc)
+                assert "skillsbench-root .venv/bin/python is missing" in str(exc)
+            else:
+                raise AssertionError("missing benchflow runtime should fail closed")
+        finally:
+            builtins.__import__ = original_import
         proc = subprocess.run(
             [
                 sys.executable,
@@ -74,6 +107,29 @@ def main() -> int:
         assert prerequisites["container_codex_acp_install_skipped"] is False
         assert plan["public_boundary"]["leaderboard_upload"] is False
         assert plan["public_boundary"]["public_submission"] is False
+        launch_command = _host_local_acp_launch_command(
+            SimpleNamespace(
+                app_server_acp_heartbeat_interval_sec=120.0,
+                app_server_reasoning_effort="high",
+                dataset="skillsbench-v1.1",
+                host_local_acp_launch=True,
+                local_acp_relay_command=None,
+                local_codex_bin="codex",
+                local_codex_exec_timeout_sec=7200,
+                local_codex_sandbox="workspace-write",
+                model=None,
+                remote_command_file_bridge_probe=False,
+                remote_command_file_bridge_probe_timeout_sec=5.0,
+                remote_command_file_bridge_ready=False,
+                remote_command_file_bridge_agent_command=None,
+                remote_command_file_bridge_solver_command=None,
+                route="loopx-product-mode",
+                task_id="demo-task",
+            ),
+            {"host_local_acp_relay_trace_dir": str(Path(tmp) / "trace")},
+        )
+        heartbeat_index = launch_command.index("--stream-heartbeat-interval-sec")
+        assert launch_command[heartbeat_index + 1] == "15.0"
         blocked = subprocess.run(
             [
                 sys.executable,
@@ -252,6 +308,8 @@ else:
                 bridge_command,
                 "--remote-command-file-bridge-solver-command",
                 solver_bridge_command,
+                "--remote-command-file-bridge-agent-command",
+                "python3 managed-local-agent-bridge.py",
                 "--plan-only",
             ],
             cwd=REPO_ROOT,
@@ -272,6 +330,36 @@ else:
         )
         assert (
             wired_prerequisites[
+                "remote_command_file_bridge_agent_command_configured"
+            ]
+            is True
+        )
+        assert (
+            wired_prerequisites[
+                "remote_command_file_bridge_agent_command_instrumented"
+            ]
+            is True
+        )
+        assert (
+            wired_prerequisites[
+                "remote_command_file_bridge_agent_operation_trace_required"
+            ]
+            is True
+        )
+        assert (
+            wired_prerequisites[
+                "remote_command_file_bridge_agent_operation_trace_satisfied"
+            ]
+            is False
+        )
+        assert (
+            wired_prerequisites[
+                "remote_command_file_bridge_agent_operation_trace_status"
+            ]
+            == "external_agent_command_relay_wrapped_pending_trace"
+        )
+        assert (
+            wired_prerequisites[
                 "remote_command_file_bridge_solver_wiring_configured"
             ]
             is True
@@ -283,20 +371,36 @@ else:
         fake_codex = Path(tmp) / "fake-codex"
         fake_codex.write_text(
             """#!/usr/bin/env python3
+import json
 import select
+import subprocess
 import sys
 from pathlib import Path
 
 args = sys.argv[1:]
-if "Private bridge command:" not in args[-1]:
+prompt = args[-1]
+if "Private bridge command:" not in prompt:
     raise SystemExit(7)
-if '"operation":"exec"' not in args[-1]:
+bridge_command = prompt.split("Private bridge command:", 1)[1].strip().splitlines()[0]
+if not bridge_command:
     raise SystemExit(10)
 ready, _, _ = select.select([sys.stdin], [], [], 0.2)
 if not ready:
     raise SystemExit(8)
 if sys.stdin.read():
     raise SystemExit(9)
+for command in (
+    "/app/.local/bin/loopx quota should-run --goal-id skillsbench-case --agent-id codex-benchmark-agent",
+    "/app/.local/bin/loopx todo update --goal-id skillsbench-case --todo-id todo_seed --status open --note checkpoint",
+):
+    subprocess.run(
+        [bridge_command],
+        input=json.dumps({"operation": "exec", "cwd": "/app", "command": command}),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
 output = Path(args[args.index("--output-last-message") + 1])
 output.write_text("fake solver saw bridge packet\\n", encoding="utf-8")
 """,
@@ -320,15 +424,32 @@ output.write_text("fake solver saw bridge packet\\n", encoding="utf-8")
                 str(trace_dir),
                 "--remote-command-file-bridge-command",
                 solver_bridge_command,
+                "--remote-command-file-bridge-agent-command",
+                solver_bridge_command,
                 "--remote-command-file-bridge-timeout-sec",
                 "5",
+                "--loopx-workflow-lifecycle-checkpoint",
+                "--loopx-case-goal-id",
+                "skillsbench-case",
+                "--loopx-case-agent-id",
+                "codex-benchmark-agent",
+                "--loopx-case-todo-id",
+                "todo_seed",
             ],
             timeout_sec=20,
         )
         assert relay_probe["ready"] is True, relay_probe
         trace_files = sorted(trace_dir.glob("*.compact.json"))
-        assert trace_files, relay_probe
-        bridge_trace = json.loads(trace_files[0].read_text(encoding="utf-8"))
+        assert len(trace_files) >= 3, relay_probe
+        traces = [
+            json.loads(path.read_text(encoding="utf-8"))
+            for path in trace_files
+        ]
+        bridge_trace = next(
+            trace
+            for trace in traces
+            if trace.get("trace_kind") == "remote_command_file_bridge_solver_consumption"
+        )
         assert (
             bridge_trace["schema_version"]
             == "skillsbench_host_local_acp_relay_public_trace_v0"
@@ -350,6 +471,37 @@ output.write_text("fake solver saw bridge packet\\n", encoding="utf-8")
         assert boundary["raw_task_text_recorded"] is False
         assert boundary["host_paths_recorded"] is False
         assert boundary["remote_paths_recorded"] is False
+        agent_ops_trace = next(
+            trace
+            for trace in traces
+            if trace.get("trace_kind") == "remote_command_file_bridge_agent_operations"
+        )
+        agent_ops = agent_ops_trace["remote_command_file_bridge_agent_operations"]
+        assert agent_ops["request_count"] == 2, agent_ops
+        assert agent_ops["loopx_cli_call_count"] == 2, agent_ops
+        assert agent_ops["loopx_state_read_count"] == 1, agent_ops
+        assert agent_ops["loopx_state_write_count"] == 1, agent_ops
+        assert agent_ops["raw_material_recorded"] is False, agent_ops
+        driver_lifecycle_trace = next(
+            trace
+            for trace in traces
+            if trace.get("trace_kind")
+            == "remote_command_file_bridge_driver_lifecycle_checkpoint"
+        )
+        driver_lifecycle = driver_lifecycle_trace[
+            "remote_command_file_bridge_driver_lifecycle_checkpoint"
+        ]
+        assert (
+            driver_lifecycle["execution_style"]
+            == "orchestrated_agentloop_loopx_cli"
+        ), driver_lifecycle
+        assert driver_lifecycle["checkpoint_count"] == 1, driver_lifecycle
+        assert driver_lifecycle["request_count"] == 4, driver_lifecycle
+        assert driver_lifecycle["failure_count"] == 0, driver_lifecycle
+        assert driver_lifecycle["loopx_cli_call_count"] == 4, driver_lifecycle
+        assert driver_lifecycle["loopx_state_read_count"] == 1, driver_lifecycle
+        assert driver_lifecycle["loopx_state_write_count"] == 3, driver_lifecycle
+        assert driver_lifecycle["raw_material_recorded"] is False, driver_lifecycle
         controller_trace = {"schema_version": "skillsbench_loopx_controller_trace_v0"}
         reducer_plan = {
             "host_local_acp_relay_trace_dir": str(trace_dir),
@@ -376,11 +528,251 @@ output.write_text("fake solver saw bridge packet\\n", encoding="utf-8")
             >= 4
         )
         assert (
+            controller_trace[
+                "remote_command_file_bridge_agent_operation_trace_count"
+            ]
+            == 1
+        )
+        assert (
+            controller_trace[
+                "remote_command_file_bridge_agent_loopx_state_read_count"
+            ]
+            == 1
+        )
+        assert (
+            controller_trace[
+                "remote_command_file_bridge_agent_loopx_state_write_count"
+            ]
+            == 1
+        )
+        assert (
+            controller_trace[
+                "remote_command_file_bridge_driver_lifecycle_trace_count"
+            ]
+            == 1
+        )
+        assert (
+            controller_trace[
+                "remote_command_file_bridge_driver_lifecycle_checkpoint_count"
+            ]
+            == 1
+        )
+        assert (
+            controller_trace[
+                "remote_command_file_bridge_driver_lifecycle_loopx_state_read_count"
+            ]
+            == 1
+        )
+        assert (
+            controller_trace[
+                "remote_command_file_bridge_driver_lifecycle_loopx_state_write_count"
+            ]
+            == 3
+        )
+        assert (
             reducer_plan["runner_prerequisites"][
                 "remote_command_file_bridge_consumption_status"
             ]
             == "solver_prompt_probe_ready"
         )
+        failing_codex = Path(tmp) / "failing-codex"
+        failing_codex.write_text(
+            """#!/usr/bin/env python3
+import sys
+
+print("hit your usage limit", file=sys.stderr)
+raise SystemExit(42)
+""",
+            encoding="utf-8",
+        )
+        failing_codex.chmod(0o755)
+        failure_trace_dir = Path(tmp) / "relay-failure-traces"
+        failing_probe = run_skillsbench_local_acp_relay_probe(
+            [
+                sys.executable,
+                str(RELAY_SCRIPT),
+                "--codex-bin",
+                str(failing_codex),
+                "--route",
+                "loopx-product-mode",
+                "--dataset",
+                "skillsbench-v1.1",
+                "--task-id",
+                "demo-task",
+                "--worker-public-trace-dir",
+                str(failure_trace_dir),
+            ],
+            timeout_sec=20,
+        )
+        assert failing_probe["ready"] is False, failing_probe
+        failure_trace_files = sorted(failure_trace_dir.glob("*.compact.json"))
+        assert len(failure_trace_files) == 1, failure_trace_files
+        failure_trace = json.loads(
+            failure_trace_files[0].read_text(encoding="utf-8")
+        )
+        assert failure_trace["trace_kind"] == "codex_exec_process_failure"
+        process = failure_trace["codex_exec_process"]
+        assert process["failure_category"] == "codex_usage_limit"
+        assert process["returncode"] == 42
+        assert process["stderr_bytes"] > 0
+        assert process["raw_stderr_recorded"] is False
+        assert process["raw_task_text_recorded"] is False
+        failure_controller_trace = {
+            "schema_version": "skillsbench_loopx_controller_trace_v0"
+        }
+        failure_reducer_plan = {
+            "host_local_acp_relay_trace_dir": str(failure_trace_dir),
+            "runner_prerequisites": {},
+        }
+        _merge_host_local_acp_relay_trace_summary(
+            failure_reducer_plan,
+            failure_controller_trace,
+        )
+        assert (
+            failure_controller_trace[
+                "host_local_acp_codex_exec_failure_trace_present"
+            ]
+            is True
+        )
+        assert (
+            failure_controller_trace["host_local_acp_codex_exec_failure_category"]
+            == "codex_usage_limit"
+        )
+        assert (
+            failure_reducer_plan["runner_prerequisites"][
+                "host_local_acp_codex_exec_failure_trace_count"
+            ]
+            == 1
+        )
+        reverse_failing_codex = Path(tmp) / "reverse-failing-codex"
+        reverse_failing_codex.write_text(
+            """#!/usr/bin/env python3
+import sys
+
+print("ConnectionRefusedError: [Errno 111] Connection refused", file=sys.stderr)
+raise SystemExit(1)
+""",
+            encoding="utf-8",
+        )
+        reverse_failing_codex.chmod(0o755)
+        reverse_failure_trace_dir = Path(tmp) / "reverse-failure-traces"
+        reverse_probe = run_skillsbench_local_acp_relay_probe(
+            [
+                sys.executable,
+                str(RELAY_SCRIPT),
+                "--codex-bin",
+                str(reverse_failing_codex),
+                "--route",
+                "loopx-product-mode",
+                "--dataset",
+                "skillsbench-v1.1",
+                "--task-id",
+                "demo-task",
+                "--model",
+                "gpt-5.5",
+                "--worker-public-trace-dir",
+                str(reverse_failure_trace_dir),
+            ],
+            timeout_sec=20,
+        )
+        assert reverse_probe["ready"] is False, reverse_probe
+        reverse_failure = json.loads(
+            next(reverse_failure_trace_dir.glob("*.compact.json")).read_text(
+                encoding="utf-8"
+            )
+        )
+        assert (
+            reverse_failure["codex_exec_process"]["failure_category"]
+            == "codex_reverse_channel_unavailable"
+        ), reverse_failure
+        preflight_plan = {
+            "host_local_acp_relay_trace_dir": str(Path(tmp) / "preflight-traces"),
+            "runner_prerequisites": {},
+        }
+        preflight_args = SimpleNamespace(
+            dataset="skillsbench-v1.1",
+            host_local_acp_codex_exec_preflight_timeout_sec=20,
+            local_codex_bin=str(reverse_failing_codex),
+            local_codex_sandbox="workspace-write",
+            model="gpt-5.5",
+            route="loopx-product-mode",
+            task_id="demo-task",
+        )
+        try:
+            _run_host_local_acp_codex_exec_preflight(preflight_args, preflight_plan)
+        except RuntimeError as exc:
+            assert "codex exec preflight failed" in str(exc)
+        else:
+            raise AssertionError("reverse-channel preflight should fail closed")
+        preflight_prereqs = preflight_plan["runner_prerequisites"]
+        assert (
+            preflight_prereqs["host_local_acp_codex_exec_preflight_status"]
+            == "failed"
+        ), preflight_prereqs
+        assert (
+            preflight_prereqs["host_local_acp_codex_exec_failure_category"]
+            == "codex_reverse_channel_unavailable"
+        ), preflight_prereqs
+        compact_failure = {
+            "score_failure_attribution": (
+                "skillsbench_host_local_acp_codex_exec_failed_codex_usage_limit"
+            ),
+            "interaction_counters": {
+                "private_trajectory_event_count": 1,
+                "private_trajectory_round_count": 1,
+                "private_trajectory_tool_call_count": 0,
+                "controller_action_decisions": 1,
+            },
+            "failure_attribution_labels": [],
+        }
+        assert _apply_agent_message_only_no_tool_calls_attribution(compact_failure)
+        assert compact_failure["score_failure_attribution"] == (
+            "skillsbench_host_local_acp_codex_exec_failed_codex_usage_limit"
+        )
+        assert compact_failure["first_blocker"] == (
+            "skillsbench_host_local_acp_codex_exec_failed_codex_usage_limit"
+        )
+        assert "skillsbench_agent_behavior_gap" not in (
+            compact_failure["failure_attribution_labels"]
+        )
+        interruption_compact = build_runner_failure_compact(
+            SimpleNamespace(
+                build_stall_timeout_sec=0,
+                dataset="skillsbench-v1.1",
+                model=None,
+                route="loopx-product-mode",
+                task_id="demo-task",
+            ),
+            {
+                "compact_benchmark_run_json": str(
+                    Path(tmp) / "interrupted-compact.json"
+                ),
+                "runner_prerequisites": {
+                    "schema_version": "skillsbench_runner_prerequisites_v0",
+                    "agent_execution_mode": "host_local_acp",
+                },
+            },
+            KeyboardInterrupt(),
+        )
+        assert interruption_compact["score_failure_attribution"] == (
+            "skillsbench_runner_interrupted_before_official_result"
+        ), interruption_compact
+        assert "skillsbench_compact_closeout_recorded" in (
+            interruption_compact["failure_attribution_labels"]
+        )
+        interruption_prereqs = interruption_compact["runner_prerequisites"]
+        assert interruption_prereqs["runner_interrupted_before_official_result"] is True
+        assert interruption_prereqs["runner_interruption_kind"] == (
+            "keyboard_interrupt"
+        )
+        assert (
+            interruption_prereqs["runner_interruption_raw_material_recorded"]
+            is False
+        )
+        assert interruption_compact["validation"]["runner_failure_compact_recorded"]
+        assert interruption_compact["validation"]["no_raw_logs_read"]
+        assert interruption_compact["validation"]["no_raw_task_text_read"]
+        assert interruption_compact["validation"]["no_raw_trajectory_read"]
     print("skillsbench host-local ACP launch plan smoke passed")
     return 0
 

--- a/examples/skillsbench-reverse-channel-bridge-smoke.py
+++ b/examples/skillsbench-reverse-channel-bridge-smoke.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Smoke-test the SkillsBench reverse-channel bridge helper."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BRIDGE = REPO_ROOT / "scripts" / "skillsbench_reverse_channel_bridge.py"
+
+
+def wait_for_socket(path: Path, proc: subprocess.Popen[str]) -> None:
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            raise AssertionError(f"server exited early: {proc.returncode}")
+        if path.exists():
+            return
+        time.sleep(0.05)
+    raise AssertionError(f"socket did not appear: {path}")
+
+
+def test_codex_client_writes_last_message_and_rewrites_bridge() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-reverse-bridge-smoke-") as tmp:
+        root = Path(tmp)
+        fake_codex = root / "fake-codex"
+        prompt_dump = root / "prompt.txt"
+        fake_codex.write_text(
+            f"""#!/usr/bin/env python3
+import os, sys
+from pathlib import Path
+
+args = sys.argv[1:]
+stdin_text = sys.stdin.read()
+if stdin_text:
+    raise SystemExit(41)
+prompt = args[-1]
+Path({str(prompt_dump)!r}).write_text(prompt, encoding='utf-8')
+out = Path(args[args.index('--output-last-message') + 1])
+out.write_text('LOOPX_REVERSE_READY\\n', encoding='utf-8')
+print('codex stdout ok')
+print('codex stderr ok', file=sys.stderr)
+""",
+            encoding="utf-8",
+        )
+        fake_codex.chmod(0o700)
+        socket_path = root / "codex.sock"
+        local_bridge = root / "local-json-bridge"
+        server = subprocess.Popen(
+            [
+                sys.executable,
+                str(BRIDGE),
+                "serve-codex",
+                "--socket",
+                str(socket_path),
+                "--codex-bin",
+                str(fake_codex),
+                "--prompt-bridge-command",
+                str(local_bridge),
+                "--once",
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        try:
+            wait_for_socket(socket_path, server)
+            client = root / "codex-client"
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(BRIDGE),
+                    "write-client",
+                    "--kind",
+                    "codex",
+                    "--socket",
+                    str(socket_path),
+                    "--output",
+                    str(client),
+                ],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            remote_last = root / "remote-last-message.txt"
+            prompt = "Private bridge command:\n/remote/tmp/bridge\n\nTask"
+            proc = subprocess.run(
+                [
+                    str(client),
+                    "exec",
+                    "--ephemeral",
+                    "--skip-git-repo-check",
+                    "--sandbox",
+                    "read-only",
+                    "-C",
+                    "/remote/tmp/does-not-exist-on-local-host",
+                    "--output-last-message",
+                    str(remote_last),
+                    "--json",
+                    prompt,
+                ],
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            assert proc.returncode == 0, proc.stderr
+            assert "codex stdout ok" in proc.stdout
+            assert "codex stderr ok" in proc.stderr
+            assert remote_last.read_text(encoding="utf-8") == "LOOPX_REVERSE_READY\n"
+            rewritten = prompt_dump.read_text(encoding="utf-8")
+            assert str(local_bridge) in rewritten
+            assert "/remote/tmp/bridge" not in rewritten
+        finally:
+            server.wait(timeout=5)
+
+
+def test_json_client_forwards_stdin_to_bridge_command() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-reverse-json-smoke-") as tmp:
+        root = Path(tmp)
+        fake_bridge = root / "fake-json-bridge"
+        fake_bridge.write_text(
+            """#!/usr/bin/env python3
+import json, sys
+payload = json.loads(sys.stdin.read() or '{}')
+print(json.dumps({
+    'ok': True,
+    'operation': payload.get('operation'),
+    'raw_task_text_recorded': False,
+    'credential_values_recorded': False,
+}))
+""",
+            encoding="utf-8",
+        )
+        fake_bridge.chmod(0o700)
+        socket_path = root / "json.sock"
+        server = subprocess.Popen(
+            [
+                sys.executable,
+                str(BRIDGE),
+                "serve-json",
+                "--socket",
+                str(socket_path),
+                "--bridge-command",
+                str(fake_bridge),
+                "--once",
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        try:
+            wait_for_socket(socket_path, server)
+            client = root / "json-client"
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(BRIDGE),
+                    "write-client",
+                    "--kind",
+                    "json",
+                    "--socket",
+                    str(socket_path),
+                    "--output",
+                    str(client),
+                ],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            proc = subprocess.run(
+                [str(client)],
+                input=json.dumps({"operation": "exec", "cwd": "/app"}),
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            assert proc.returncode == 0, proc.stderr
+            response = json.loads(proc.stdout)
+            assert response["ok"] is True
+            assert response["operation"] == "exec"
+            assert response["raw_task_text_recorded"] is False
+            assert response["credential_values_recorded"] is False
+        finally:
+            server.wait(timeout=5)
+
+
+def test_socket_probe_reports_missing_or_orphaned() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-reverse-probe-smoke-") as tmp:
+        missing = Path(tmp) / "missing.sock"
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(BRIDGE),
+                "probe-socket",
+                "--socket",
+                str(missing),
+            ],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        payload = json.loads(proc.stdout)
+        assert payload["ready"] is False
+        assert payload["first_blocker"] == "skillsbench_reverse_channel_socket_missing"
+
+
+def main() -> int:
+    test_codex_client_writes_last_message_and_rewrites_bridge()
+    test_json_client_forwards_stdin_to_bridge_command()
+    test_socket_probe_reports_missing_or_orphaned()
+    print("skillsbench reverse-channel bridge smoke passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -2021,6 +2021,67 @@ def _skillsbench_controller_trace_counters(
         "remote_command_file_bridge_solver_operation_count": count(
             "remote_command_file_bridge_solver_operation_count"
         ),
+        "remote_command_file_bridge_agent_operation_trace_count": count(
+            "remote_command_file_bridge_agent_operation_trace_count"
+        ),
+        "remote_command_file_bridge_agent_command_configured": controller_trace.get(
+            "remote_command_file_bridge_agent_command_configured"
+        )
+        is True,
+        "remote_command_file_bridge_agent_command_instrumented": controller_trace.get(
+            "remote_command_file_bridge_agent_command_instrumented"
+        )
+        is True,
+        "remote_command_file_bridge_agent_operation_trace_required": controller_trace.get(
+            "remote_command_file_bridge_agent_operation_trace_required"
+        )
+        is True,
+        "remote_command_file_bridge_agent_operation_trace_satisfied": controller_trace.get(
+            "remote_command_file_bridge_agent_operation_trace_satisfied"
+        )
+        is True,
+        "remote_command_file_bridge_agent_operation_trace_status": str(
+            controller_trace.get(
+                "remote_command_file_bridge_agent_operation_trace_status"
+            )
+            or ""
+        )[:120],
+        "remote_command_file_bridge_agent_request_count": count(
+            "remote_command_file_bridge_agent_request_count"
+        ),
+        "remote_command_file_bridge_agent_loopx_cli_call_count": count(
+            "remote_command_file_bridge_agent_loopx_cli_call_count"
+        ),
+        "remote_command_file_bridge_agent_loopx_state_read_count": count(
+            "remote_command_file_bridge_agent_loopx_state_read_count"
+        ),
+        "remote_command_file_bridge_agent_loopx_state_write_count": count(
+            "remote_command_file_bridge_agent_loopx_state_write_count"
+        ),
+        "remote_command_file_bridge_driver_lifecycle_trace_count": count(
+            "remote_command_file_bridge_driver_lifecycle_trace_count"
+        ),
+        "remote_command_file_bridge_driver_lifecycle_checkpoint_count": count(
+            "remote_command_file_bridge_driver_lifecycle_checkpoint_count"
+        ),
+        "remote_command_file_bridge_driver_lifecycle_request_count": count(
+            "remote_command_file_bridge_driver_lifecycle_request_count"
+        ),
+        "remote_command_file_bridge_driver_lifecycle_success_count": count(
+            "remote_command_file_bridge_driver_lifecycle_success_count"
+        ),
+        "remote_command_file_bridge_driver_lifecycle_failure_count": count(
+            "remote_command_file_bridge_driver_lifecycle_failure_count"
+        ),
+        "remote_command_file_bridge_driver_lifecycle_loopx_cli_call_count": count(
+            "remote_command_file_bridge_driver_lifecycle_loopx_cli_call_count"
+        ),
+        "remote_command_file_bridge_driver_lifecycle_loopx_state_read_count": count(
+            "remote_command_file_bridge_driver_lifecycle_loopx_state_read_count"
+        ),
+        "remote_command_file_bridge_driver_lifecycle_loopx_state_write_count": count(
+            "remote_command_file_bridge_driver_lifecycle_loopx_state_write_count"
+        ),
         "heartbeat_count": count("heartbeat_count"),
         "raw_task_text_recorded": controller_trace.get("raw_task_text_recorded")
         is True,
@@ -2099,6 +2160,16 @@ def _skillsbench_controller_trace_counters(
         "product_mode_no_tool_call_lifecycle_abort_round": count(
             "product_mode_no_tool_call_lifecycle_abort_round"
         ),
+        "product_mode_no_lifecycle_request_abort": controller_trace.get(
+            "product_mode_no_lifecycle_request_abort"
+        )
+        is True,
+        "product_mode_no_lifecycle_request_abort_count": count(
+            "product_mode_no_lifecycle_request_abort_count"
+        ),
+        "product_mode_no_lifecycle_request_abort_round": count(
+            "product_mode_no_lifecycle_request_abort_round"
+        ),
     }
     last_decision = _skillsbench_public_safe_label(
         controller_trace.get("last_decision") or ""
@@ -2144,6 +2215,16 @@ def _skillsbench_controller_trace_counters(
     if lifecycle_missing_reason:
         counters["product_mode_lifecycle_checkpoint_missing_reason"] = (
             lifecycle_missing_reason
+        )
+    workflow_style = _skillsbench_public_safe_label(
+        controller_trace.get(
+            "remote_command_file_bridge_driver_lifecycle_execution_style"
+        )
+        or ""
+    )
+    if workflow_style:
+        counters["remote_command_file_bridge_driver_lifecycle_execution_style"] = (
+            workflow_style
         )
     case_state_path = str(controller_trace.get("case_goal_state_path") or "")
     if (
@@ -2604,23 +2685,75 @@ def build_skillsbench_benchflow_result_benchmark_run(
         return value if isinstance(value, int) and not isinstance(value, bool) else 0
 
     product_mode_lifecycle_required = bool(route == "loopx-product-mode")
-    product_mode_lifecycle_read_count = max(
+    remote_agent_operation_trace_required = (
+        controller_counters.get(
+            "remote_command_file_bridge_agent_operation_trace_required"
+        )
+        is True
+    )
+    remote_agent_operation_trace_satisfied = (
+        controller_counters.get(
+            "remote_command_file_bridge_agent_operation_trace_satisfied"
+        )
+        is True
+    )
+    remote_agent_operation_trace_status = str(
+        controller_counters.get(
+            "remote_command_file_bridge_agent_operation_trace_status", ""
+        )
+    )
+    remote_agent_operation_trace_missing = bool(
+        remote_agent_operation_trace_required
+        and not remote_agent_operation_trace_satisfied
+    )
+    remote_agent_operation_trace_no_requests = bool(
+        remote_agent_operation_trace_missing
+        and remote_agent_operation_trace_status
+        == "agent_operation_trace_present_no_requests"
+    )
+    agent_bridge_lifecycle_read_count = _controller_public_count(
+        "remote_command_file_bridge_agent_loopx_state_read_count"
+    )
+    agent_bridge_lifecycle_write_count = _controller_public_count(
+        "remote_command_file_bridge_agent_loopx_state_write_count"
+    )
+    driver_lifecycle_read_count = _controller_public_count(
+        "remote_command_file_bridge_driver_lifecycle_loopx_state_read_count"
+    )
+    driver_lifecycle_write_count = _controller_public_count(
+        "remote_command_file_bridge_driver_lifecycle_loopx_state_write_count"
+    )
+    lifecycle_read_sources = [
         _controller_public_count("loopx_state_reads"),
         _controller_public_count("loopx_case_state_reads"),
+        agent_bridge_lifecycle_read_count,
         _trajectory_public_count("loopx_cli_state_read_count"),
         _trajectory_public_count("loopx_case_state_read_count"),
-    )
-    product_mode_lifecycle_write_count = max(
+    ]
+    lifecycle_write_sources = [
         _controller_public_count("loopx_state_writes"),
         _controller_public_count("loopx_case_state_writes"),
+        agent_bridge_lifecycle_write_count,
         _trajectory_public_count("loopx_cli_state_write_count"),
         _trajectory_public_count("loopx_case_state_write_count"),
-    )
+    ]
+    if not remote_agent_operation_trace_required:
+        lifecycle_read_sources.append(driver_lifecycle_read_count)
+        lifecycle_write_sources.append(driver_lifecycle_write_count)
+    product_mode_lifecycle_read_count = max(lifecycle_read_sources)
+    product_mode_lifecycle_write_count = max(lifecycle_write_sources)
     product_mode_lifecycle_checkpoint_required = bool(
         controller_counters.get("product_mode_lifecycle_checkpoint_required")
+        or _controller_public_count(
+            "remote_command_file_bridge_driver_lifecycle_trace_count"
+        )
+        > 0
     )
-    product_mode_lifecycle_checkpoint_count = _controller_public_count(
-        "product_mode_lifecycle_checkpoint_count"
+    product_mode_lifecycle_checkpoint_count = max(
+        _controller_public_count("product_mode_lifecycle_checkpoint_count"),
+        _controller_public_count(
+            "remote_command_file_bridge_driver_lifecycle_checkpoint_count"
+        ),
     )
     product_mode_lifecycle_attempt_observed = bool(
         product_mode_lifecycle_checkpoint_required
@@ -2632,6 +2765,8 @@ def build_skillsbench_benchflow_result_benchmark_run(
     product_mode_lifecycle_satisfied = bool(
         not product_mode_lifecycle_required
         or (
+            not remote_agent_operation_trace_missing
+            and
             product_mode_lifecycle_read_count > 0
             and product_mode_lifecycle_write_count > 0
         )
@@ -2651,15 +2786,34 @@ def build_skillsbench_benchflow_result_benchmark_run(
         "state_write_count": product_mode_lifecycle_write_count,
         "checkpoint_required": product_mode_lifecycle_checkpoint_required,
         "checkpoint_count": product_mode_lifecycle_checkpoint_count,
+        "agent_operation_trace_required": remote_agent_operation_trace_required,
+        "agent_operation_trace_satisfied": remote_agent_operation_trace_satisfied,
+        "agent_operation_trace_status": remote_agent_operation_trace_status,
+        "agent_operation_trace_missing": remote_agent_operation_trace_missing,
+        "agent_bridge_state_read_count": agent_bridge_lifecycle_read_count,
+        "agent_bridge_state_write_count": agent_bridge_lifecycle_write_count,
+        "driver_lifecycle_state_read_count": driver_lifecycle_read_count,
+        "driver_lifecycle_state_write_count": driver_lifecycle_write_count,
         "checkpoint_round": controller_counters.get(
             "product_mode_lifecycle_checkpoint_round", 0
         ),
-        "missing_reason": controller_counters.get(
-            "product_mode_lifecycle_checkpoint_missing_reason", ""
+        "missing_reason": (
+            "remote_command_file_bridge_agent_no_requests"
+            if remote_agent_operation_trace_no_requests
+            else "remote_command_file_bridge_agent_operation_trace_missing"
+            if remote_agent_operation_trace_missing
+            else controller_counters.get(
+                "product_mode_lifecycle_checkpoint_missing_reason", ""
+            )
         )
         if product_mode_lifecycle_missing
         else "",
     }
+    workflow_execution_style = controller_counters.get(
+        "remote_command_file_bridge_driver_lifecycle_execution_style"
+    )
+    if isinstance(workflow_execution_style, str) and workflow_execution_style:
+        product_mode_lifecycle_contract["execution_style"] = workflow_execution_style
     user_loop_final_verify_recovery_triggered = bool(
         controller_counters.get("benchflow_user_loop_final_verify_recovery_triggered")
     )
@@ -2684,7 +2838,7 @@ def build_skillsbench_benchflow_result_benchmark_run(
             "skillsbench_controller_budget_not_exercised",
             "skillsbench_result_error_cut_off_followup_loop",
         ):
-            if item not in failure_labels:
+            if item and item not in failure_labels:
                 failure_labels.append(item)
     if (
         error_text
@@ -2920,6 +3074,11 @@ def build_skillsbench_benchflow_result_benchmark_run(
             label,
             "skillsbench_product_mode_uncountable_treatment",
             "skillsbench_case_local_loopx_state_not_observed",
+            "skillsbench_remote_bridge_agent_no_requests"
+            if remote_agent_operation_trace_no_requests
+            else "skillsbench_remote_bridge_agent_operation_trace_missing"
+            if remote_agent_operation_trace_missing
+            else "",
         ):
             if item not in failure_labels:
                 failure_labels.append(item)
@@ -3289,6 +3448,90 @@ def build_skillsbench_benchflow_result_benchmark_run(
             "remote_command_file_bridge_solver_operation_count": (
                 controller_counters.get(
                     "remote_command_file_bridge_solver_operation_count", 0
+                )
+            ),
+            "remote_command_file_bridge_agent_operation_trace_count": (
+                controller_counters.get(
+                    "remote_command_file_bridge_agent_operation_trace_count", 0
+                )
+            ),
+            "remote_command_file_bridge_agent_request_count": (
+                controller_counters.get(
+                    "remote_command_file_bridge_agent_request_count", 0
+                )
+            ),
+            "remote_command_file_bridge_agent_loopx_cli_call_count": (
+                controller_counters.get(
+                    "remote_command_file_bridge_agent_loopx_cli_call_count", 0
+                )
+            ),
+            "remote_command_file_bridge_agent_loopx_state_read_count": (
+                controller_counters.get(
+                    "remote_command_file_bridge_agent_loopx_state_read_count", 0
+                )
+            ),
+            "remote_command_file_bridge_agent_loopx_state_write_count": (
+                controller_counters.get(
+                    "remote_command_file_bridge_agent_loopx_state_write_count", 0
+                )
+            ),
+            "remote_command_file_bridge_driver_lifecycle_trace_count": (
+                controller_counters.get(
+                    "remote_command_file_bridge_driver_lifecycle_trace_count", 0
+                )
+            ),
+            "remote_command_file_bridge_driver_lifecycle_checkpoint_count": (
+                controller_counters.get(
+                    "remote_command_file_bridge_driver_lifecycle_checkpoint_count",
+                    0,
+                )
+            ),
+            "remote_command_file_bridge_driver_lifecycle_request_count": (
+                controller_counters.get(
+                    "remote_command_file_bridge_driver_lifecycle_request_count", 0
+                )
+            ),
+            "remote_command_file_bridge_driver_lifecycle_success_count": (
+                controller_counters.get(
+                    "remote_command_file_bridge_driver_lifecycle_success_count", 0
+                )
+            ),
+            "remote_command_file_bridge_driver_lifecycle_failure_count": (
+                controller_counters.get(
+                    "remote_command_file_bridge_driver_lifecycle_failure_count", 0
+                )
+            ),
+            "remote_command_file_bridge_driver_lifecycle_loopx_cli_call_count": (
+                controller_counters.get(
+                    (
+                        "remote_command_file_bridge_driver_lifecycle_"
+                        "loopx_cli_call_count"
+                    ),
+                    0,
+                )
+            ),
+            "remote_command_file_bridge_driver_lifecycle_loopx_state_read_count": (
+                controller_counters.get(
+                    (
+                        "remote_command_file_bridge_driver_lifecycle_"
+                        "loopx_state_read_count"
+                    ),
+                    0,
+                )
+            ),
+            "remote_command_file_bridge_driver_lifecycle_loopx_state_write_count": (
+                controller_counters.get(
+                    (
+                        "remote_command_file_bridge_driver_lifecycle_"
+                        "loopx_state_write_count"
+                    ),
+                    0,
+                )
+            ),
+            "remote_command_file_bridge_driver_lifecycle_execution_style": (
+                controller_counters.get(
+                    "remote_command_file_bridge_driver_lifecycle_execution_style",
+                    "",
                 )
             ),
             "loopx_case_state_path_count": trajectory_summary.get(

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import re
 import selectors
 import shlex
 import subprocess
@@ -14,6 +15,15 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, TextIO
 
+from loopx.benchmark_case_state import (
+    BENCHMARK_CASE_LOOPX_AGENT_ID,
+    BENCHMARK_CASE_LOOPX_CLI_PATH,
+    BENCHMARK_CASE_LOOPX_REGISTRY_PATH,
+    BENCHMARK_CASE_LOOPX_RUNTIME_ROOT,
+    BENCHMARK_CASE_LOOPX_TODO_ID,
+    benchmark_case_goal_id,
+    benchmark_case_loopx_command_prefix,
+)
 from loopx.benchmark_adapters.skillsbench_remote_bridge import (
     run_skillsbench_remote_command_file_bridge_probe,
 )
@@ -60,6 +70,33 @@ def _safe_cwd(value: Any, *, default: str) -> str:
     return text or default
 
 
+def _codex_exec_failure_category(
+    *,
+    returncode: int | None,
+    stderr_text: str,
+) -> str:
+    text = (stderr_text or "").lower()
+    if (
+        "connectionrefusederror" in text
+        or "connection refused" in text
+        or "failed to establish a new connection" in text
+        or ("create_connection" in text and "socket" in text)
+    ):
+        return "codex_reverse_channel_unavailable"
+    if "hit your usage limit" in text or "usage limit" in text:
+        return "codex_usage_limit"
+    if "unexpected argument" in text or "unrecognized option" in text:
+        return "codex_cli_argument_incompatible"
+    if "api.openai.com" in text or "chatgpt.com" in text:
+        if any(token in text for token in ("timed out", "timeout", "connection")):
+            return "codex_network_or_api_unreachable"
+    if returncode == 124:
+        return "codex_exec_timeout"
+    if returncode is not None:
+        return "codex_exec_exit_nonzero"
+    return "codex_exec_failed"
+
+
 @dataclass(frozen=True)
 class CodexExecConfig:
     codex_bin: str = "codex"
@@ -78,7 +115,15 @@ class CodexExecConfig:
     reasoning_effort: str | None = "high"
     worker_public_trace_dir: str | None = None
     remote_command_file_bridge_command: str | None = None
+    remote_command_file_bridge_agent_command: str | None = None
     remote_command_file_bridge_timeout_sec: float = 10.0
+    loopx_workflow_lifecycle_checkpoint: bool = False
+    loopx_case_goal_id: str = "skillsbench-case"
+    loopx_case_agent_id: str = BENCHMARK_CASE_LOOPX_AGENT_ID
+    loopx_case_todo_id: str = BENCHMARK_CASE_LOOPX_TODO_ID
+    loopx_case_cli_path: str = BENCHMARK_CASE_LOOPX_CLI_PATH
+    loopx_case_registry_path: str = BENCHMARK_CASE_LOOPX_REGISTRY_PATH
+    loopx_case_runtime_root: str = BENCHMARK_CASE_LOOPX_RUNTIME_ROOT
 
 
 class SkillsBenchLocalAcpRelay:
@@ -94,6 +139,7 @@ class SkillsBenchLocalAcpRelay:
         self._config = config
         self._sessions: dict[str, dict[str, Any]] = {}
         self._published_lifecycle_stages: set[str] = set()
+        self._workflow_checkpoint_count = 0
 
     def serve(self, stdin: TextIO = sys.stdin, stdout: TextIO = sys.stdout) -> int:
         for line in stdin:
@@ -196,7 +242,19 @@ class SkillsBenchLocalAcpRelay:
                 },
             },
         )
-        return _json_rpc_result(message_id, {"stopReason": "end_turn"})
+        output_tokens = max(1, len(response_text.encode("utf-8")) // 4)
+        input_tokens = max(1, len(prompt_text.encode("utf-8")) // 4)
+        return _json_rpc_result(
+            message_id,
+            {
+                "stopReason": "end_turn",
+                "usage": {
+                    "inputTokens": input_tokens,
+                    "outputTokens": output_tokens,
+                    "totalTokens": input_tokens + output_tokens,
+                },
+            },
+        )
 
     def _run_codex(
         self,
@@ -218,6 +276,8 @@ class SkillsBenchLocalAcpRelay:
         with tempfile.TemporaryDirectory(prefix="gh-skillsbench-acp-") as tmp:
             tmp_path = Path(tmp)
             output_path = tmp_path / "last-message.txt"
+            stdout_path = tmp_path / "codex-stdout.txt"
+            stderr_path = tmp_path / "codex-stderr.txt"
             prompt_for_codex = prompt_text
             cwd = _safe_cwd(session.get("cwd"), default=os.getcwd())
             if self._config.remote_command_file_bridge_command:
@@ -228,10 +288,30 @@ class SkillsBenchLocalAcpRelay:
                 local_cwd = tmp_path / "local-codex-cwd"
                 local_cwd.mkdir(parents=True, exist_ok=True)
                 cwd = str(local_cwd)
+                bridge_summary_path = tmp_path / "remote-bridge-agent-ops.jsonl"
+                agent_bridge_command = (
+                    self._config.remote_command_file_bridge_agent_command
+                    or self._config.remote_command_file_bridge_command
+                    or ""
+                )
+                instrumented_bridge = self._write_instrumented_bridge_wrapper(
+                    tmp_path=tmp_path,
+                    summary_path=bridge_summary_path,
+                    bridge_command=agent_bridge_command,
+                )
+                bridge_command_for_agent = str(instrumented_bridge)
+                if self._config.loopx_workflow_lifecycle_checkpoint:
+                    self._workflow_checkpoint_count += 1
+                    self._run_loopx_workflow_lifecycle_checkpoint(
+                        checkpoint_index=self._workflow_checkpoint_count,
+                    )
                 prompt_for_codex = self._prompt_with_remote_bridge_packet(
                     prompt_text,
                     bridge_probe=bridge_probe,
+                    bridge_command_for_agent=bridge_command_for_agent,
                 )
+            else:
+                bridge_summary_path = None
             cmd = [
                 self._config.codex_bin,
                 "exec",
@@ -249,24 +329,113 @@ class SkillsBenchLocalAcpRelay:
             if model:
                 cmd.extend(["--model", str(model)])
             cmd.append(prompt_for_codex)
+            stdout_text = ""
+            stderr_text = ""
             try:
-                proc = subprocess.run(
-                    cmd,
-                    stdin=subprocess.DEVNULL,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                    text=True,
-                    timeout=self._config.timeout_sec,
-                    check=False,
-                )
+                with stdout_path.open("w", encoding="utf-8") as stdout_file, stderr_path.open(
+                    "w", encoding="utf-8"
+                ) as stderr_file:
+                    proc = subprocess.Popen(
+                        cmd,
+                        stdin=subprocess.DEVNULL,
+                        stdout=stdout_file,
+                        stderr=stderr_file,
+                        text=True,
+                    )
+                    deadline = time.monotonic() + self._config.timeout_sec
+                    next_heartbeat = (
+                        time.monotonic()
+                        + max(1.0, self._config.stream_heartbeat_interval_sec)
+                    )
+                    while proc.poll() is None:
+                        now = time.monotonic()
+                        if now >= deadline:
+                            proc.kill()
+                            proc.wait(timeout=5)
+                            raise subprocess.TimeoutExpired(
+                                cmd,
+                                self._config.timeout_sec,
+                            )
+                        if now >= next_heartbeat:
+                            self._write_worker_heartbeat(
+                                stdout,
+                                session_id=session_id,
+                                text="local codex exec still running",
+                            )
+                            next_heartbeat = (
+                                now
+                                + max(
+                                    1.0,
+                                    self._config.stream_heartbeat_interval_sec,
+                                )
+                            )
+                        time.sleep(0.2)
             except subprocess.TimeoutExpired as exc:
+                stdout_text = (
+                    stdout_path.read_text(encoding="utf-8", errors="replace")
+                    if stdout_path.exists()
+                    else ""
+                )
+                stderr_text = (
+                    stderr_path.read_text(encoding="utf-8", errors="replace")
+                    if stderr_path.exists()
+                    else ""
+                )
+                self._publish_codex_exec_failure_trace(
+                    stage="timeout",
+                    returncode=124,
+                    stdout_text=stdout_text,
+                    stderr_text=stderr_text,
+                    final_message_present=output_path.exists(),
+                    final_message_bytes=(
+                        output_path.stat().st_size if output_path.exists() else 0
+                    ),
+                )
                 raise TimeoutError from exc
+            stdout_text = (
+                stdout_path.read_text(encoding="utf-8", errors="replace")
+                if stdout_path.exists()
+                else ""
+            )
+            stderr_text = (
+                stderr_path.read_text(encoding="utf-8", errors="replace")
+                if stderr_path.exists()
+                else ""
+            )
             if proc.returncode != 0:
-                raise RuntimeError("local codex execution failed")
+                category = _codex_exec_failure_category(
+                    returncode=proc.returncode,
+                    stderr_text=stderr_text,
+                )
+                self._publish_codex_exec_failure_trace(
+                    stage="exit_nonzero",
+                    returncode=proc.returncode,
+                    stdout_text=stdout_text,
+                    stderr_text=stderr_text,
+                    final_message_present=output_path.exists(),
+                    final_message_bytes=(
+                        output_path.stat().st_size if output_path.exists() else 0
+                    ),
+                    failure_category=category,
+                )
+                raise RuntimeError(f"local codex execution failed: {category}")
             try:
                 response = output_path.read_text(encoding="utf-8").strip()
             except OSError as exc:
+                self._publish_codex_exec_failure_trace(
+                    stage="final_message_missing",
+                    returncode=proc.returncode,
+                    stdout_text=stdout_text,
+                    stderr_text=stderr_text,
+                    final_message_present=False,
+                    final_message_bytes=0,
+                    failure_category="codex_final_message_missing",
+                )
                 raise RuntimeError("local codex final message missing") from exc
+            if bridge_summary_path is not None:
+                self._publish_remote_bridge_agent_operations_trace(
+                    bridge_summary_path=bridge_summary_path,
+                )
             return response or "local codex returned an empty final message"
 
     def _consume_remote_bridge_for_solver(self) -> dict[str, Any]:
@@ -275,16 +444,209 @@ class SkillsBenchLocalAcpRelay:
             timeout_sec=self._config.remote_command_file_bridge_timeout_sec,
         )
 
+    def _run_remote_bridge_exec(self, command: str) -> dict[str, Any]:
+        bridge_command = self._config.remote_command_file_bridge_command or ""
+        request = {
+            "operation": "exec",
+            "cwd": "/app",
+            "command": command,
+            "timeout_sec": max(10.0, self._config.remote_command_file_bridge_timeout_sec),
+        }
+        started = time.monotonic()
+        proc = subprocess.run(
+            bridge_command,
+            input=json.dumps(request),
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            shell=True,
+            timeout=max(10.0, self._config.remote_command_file_bridge_timeout_sec + 5),
+            check=False,
+        )
+        return {
+            "returncode": int(proc.returncode),
+            "stdout_bytes": len((proc.stdout or "").encode("utf-8")),
+            "stderr_bytes": len((proc.stderr or "").encode("utf-8")),
+            "elapsed_ms": int((time.monotonic() - started) * 1000),
+            "raw_stdout_recorded": False,
+            "raw_stderr_recorded": False,
+            "raw_command_recorded": False,
+        }
+
+    def _run_loopx_workflow_lifecycle_checkpoint(
+        self,
+        *,
+        checkpoint_index: int,
+    ) -> None:
+        case_goal_id = self._config.loopx_case_goal_id or benchmark_case_goal_id(
+            self._config.task_id
+        )
+        case_agent_id = self._config.loopx_case_agent_id or BENCHMARK_CASE_LOOPX_AGENT_ID
+        case_todo_id = self._config.loopx_case_todo_id or BENCHMARK_CASE_LOOPX_TODO_ID
+        cli_prefix = benchmark_case_loopx_command_prefix(
+            case_cli_path=self._config.loopx_case_cli_path,
+            case_registry_path=self._config.loopx_case_registry_path,
+            case_runtime_root=self._config.loopx_case_runtime_root,
+        )
+        note = shlex.quote(
+            f"workflow driver lifecycle checkpoint {checkpoint_index}"
+        )
+        evidence = shlex.quote(
+            "public-safe orchestrated checkpoint: case-local LoopX state touched"
+        )
+        commands = [
+            (
+                "quota should-run",
+                "read",
+                f"{cli_prefix} quota should-run --goal-id {shlex.quote(case_goal_id)} "
+                f"--agent-id {shlex.quote(case_agent_id)}",
+            ),
+            (
+                "todo claim",
+                "write",
+                f"{cli_prefix} todo claim --goal-id {shlex.quote(case_goal_id)} "
+                f"--todo-id {shlex.quote(case_todo_id)} "
+                f"--claimed-by {shlex.quote(case_agent_id)}",
+            ),
+            (
+                "todo update",
+                "write",
+                f"{cli_prefix} todo update --goal-id {shlex.quote(case_goal_id)} "
+                f"--todo-id {shlex.quote(case_todo_id)} --status open "
+                f"--note {note} --evidence {evidence} "
+                f"--claimed-by {shlex.quote(case_agent_id)}",
+            ),
+            (
+                "refresh-state",
+                "write",
+                f"{cli_prefix} refresh-state --goal-id {shlex.quote(case_goal_id)} "
+                "--classification benchmark_case_lifecycle_checkpoint "
+                "--delivery-batch-scale single_surface "
+                "--delivery-outcome surface_only "
+                f"--agent-id {shlex.quote(case_agent_id)} "
+                "--agent-lane benchmark_case --no-global-sync",
+            ),
+        ]
+        command_results: list[dict[str, Any]] = []
+        failures = 0
+        for command_name, io_kind, command in commands:
+            try:
+                result = self._run_remote_bridge_exec(command)
+            except (OSError, subprocess.SubprocessError, TimeoutError) as exc:
+                result = {
+                    "returncode": 124 if isinstance(exc, TimeoutError) else 1,
+                    "stdout_bytes": 0,
+                    "stderr_bytes": 0,
+                    "elapsed_ms": 0,
+                    "raw_stdout_recorded": False,
+                    "raw_stderr_recorded": False,
+                    "raw_command_recorded": False,
+                }
+            result["command_name"] = command_name
+            result["io_kind"] = io_kind
+            command_results.append(result)
+            if result.get("returncode") != 0:
+                failures += 1
+                break
+        self._publish_loopx_workflow_lifecycle_checkpoint_trace(
+            checkpoint_index=checkpoint_index,
+            command_results=command_results,
+            failure_count=failures,
+        )
+        if failures:
+            raise RuntimeError("LoopX workflow lifecycle checkpoint failed")
+
+    def _publish_loopx_workflow_lifecycle_checkpoint_trace(
+        self,
+        *,
+        checkpoint_index: int,
+        command_results: list[dict[str, Any]],
+        failure_count: int,
+    ) -> None:
+        if not self._config.worker_public_trace_dir:
+            return
+        command_counts: dict[str, int] = {}
+        returncode_counts: dict[str, int] = {}
+        state_read_count = 0
+        state_write_count = 0
+        for result in command_results:
+            name = str(result.get("command_name") or "unknown")[:80]
+            command_counts[name] = command_counts.get(name, 0) + 1
+            rc = result.get("returncode")
+            if isinstance(rc, int) and not isinstance(rc, bool):
+                key = str(rc)
+            else:
+                key = "unknown"
+            returncode_counts[key] = returncode_counts.get(key, 0) + 1
+            io_kind = result.get("io_kind")
+            if io_kind == "read":
+                state_read_count += 1
+            elif io_kind == "write":
+                state_write_count += 1
+        raw_material_recorded = any(
+            result.get(field) is True
+            for result in command_results
+            for field in (
+                "raw_command_recorded",
+                "raw_stdout_recorded",
+                "raw_stderr_recorded",
+            )
+        )
+        trace = {
+            "schema_version": "skillsbench_host_local_acp_relay_public_trace_v0",
+            "ok": failure_count == 0,
+            "route": self._config.route,
+            "trace_kind": "remote_command_file_bridge_driver_lifecycle_checkpoint",
+            "benchmark_id": self._config.dataset,
+            "task_id": self._config.task_id,
+            "remote_command_file_bridge_driver_lifecycle_checkpoint": {
+                "schema_version": (
+                    "skillsbench_remote_command_file_bridge_driver_lifecycle_v0"
+                ),
+                "execution_style": "orchestrated_agentloop_loopx_cli",
+                "checkpoint_index": checkpoint_index,
+                "checkpoint_count": 1,
+                "request_count": len(command_results),
+                "success_count": len(command_results) - max(0, failure_count),
+                "failure_count": max(0, failure_count),
+                "loopx_cli_call_count": len(command_results),
+                "loopx_state_read_count": state_read_count,
+                "loopx_state_write_count": state_write_count,
+                "command_counts": dict(sorted(command_counts.items())),
+                "returncode_counts": dict(sorted(returncode_counts.items())),
+                "raw_material_recorded": raw_material_recorded,
+            },
+            "boundary": {
+                "raw_command_recorded": False,
+                "raw_stdout_recorded": False,
+                "raw_stderr_recorded": False,
+                "raw_task_text_recorded": False,
+                "raw_logs_recorded": False,
+                "raw_trajectory_recorded": False,
+                "credential_values_recorded": False,
+                "host_paths_recorded": False,
+                "remote_paths_recorded": False,
+                "upload_performed": False,
+                "submit_performed": False,
+            },
+        }
+        self._write_worker_public_trace(trace)
+
     def _prompt_with_remote_bridge_packet(
         self,
         prompt_text: str,
         *,
         bridge_probe: dict[str, Any],
+        bridge_command_for_agent: str | None = None,
     ) -> str:
         operation_count = bridge_probe.get("operation_count")
         if not isinstance(operation_count, int) or isinstance(operation_count, bool):
             operation_count = 0
-        bridge_command = self._config.remote_command_file_bridge_command or ""
+        bridge_command = (
+            bridge_command_for_agent
+            or self._config.remote_command_file_bridge_command
+            or ""
+        )
         packet = f"""
 
 LoopX SkillsBench remote workspace bridge:
@@ -298,11 +660,213 @@ LoopX SkillsBench remote workspace bridge:
   - {{"operation":"cleanup","path":"/app/path/to/temp"}}
 - Do not upload, submit, expose credentials, quote the bridge command in final output, or record raw stdout/stderr/task text in public artifacts.
 - The bridge readiness probe completed with ready=true and operation_count={operation_count}.
+- If a LoopX product-mode lifecycle contract is present later in this prompt,
+  execute its case-local LoopX CLI commands through this JSON bridge
+  (`operation=exec`, `cwd=/app`) before prose planning or final answer. A
+  prose-only response without bridge requests is not a valid product-mode turn.
 
 Private bridge command:
 {bridge_command}
 """.strip()
         return f"{packet}\n\n{prompt_text}"
+
+    def _write_instrumented_bridge_wrapper(
+        self,
+        *,
+        tmp_path: Path,
+        summary_path: Path,
+        bridge_command: str | None = None,
+    ) -> Path:
+        wrapper_path = tmp_path / "loopx-remote-bridge"
+        command = bridge_command or self._config.remote_command_file_bridge_command or ""
+        script = f"""#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import re
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+SUMMARY_PATH = Path({str(summary_path)!r})
+BRIDGE_COMMAND = {command!r}
+
+def loopx_subcommands(command: str) -> list[str]:
+    try:
+        tokens = shlex.split(command or "")
+    except ValueError:
+        tokens = (command or "").split()
+    idx = -1
+    for i, token in enumerate(tokens):
+        if token == "loopx" or token.endswith("/loopx"):
+            idx = i
+            break
+    if idx < 0:
+        return []
+    out: list[str] = []
+    skip = False
+    for token in tokens[idx + 1:]:
+        if skip:
+            skip = False
+            continue
+        if token.startswith("--"):
+            if "=" not in token and token in {{"--goal-id", "--todo-id", "--claimed-by", "--status", "--note", "--evidence", "--classification", "--registry", "--runtime-root", "--slots", "--source"}}:
+                skip = True
+            continue
+        if token.startswith("-"):
+            continue
+        if re.match(r"^[A-Za-z][A-Za-z0-9_-]{{0,40}}$", token):
+            out.append(token)
+            if len(out) >= 2:
+                break
+    return out
+
+raw = sys.stdin.read()
+record: dict[str, object] = {{
+    "schema_version": "skillsbench_remote_bridge_agent_operation_v0",
+    "raw_request_recorded": False,
+    "raw_stdout_recorded": False,
+    "raw_stderr_recorded": False,
+    "raw_task_text_recorded": False,
+    "credential_values_recorded": False,
+    "host_paths_recorded": False,
+    "remote_paths_recorded": False,
+}}
+try:
+    payload = json.loads(raw)
+except Exception:
+    payload = {{}}
+operation = payload.get("operation") if isinstance(payload, dict) else ""
+record["operation"] = operation if isinstance(operation, str) else "unknown"
+subcommands: list[str] = []
+if isinstance(payload, dict) and payload.get("operation") == "exec":
+    command_text = payload.get("command")
+    if isinstance(command_text, str):
+        subcommands = loopx_subcommands(command_text)
+record["loopx_cli_call"] = bool(subcommands)
+record["loopx_subcommands"] = subcommands[:2]
+record["loopx_state_read"] = subcommands[:2] in (["quota", "should-run"], ["status"], ["diagnose"])
+record["loopx_state_write"] = bool(subcommands and (
+    subcommands[0] in {{"todo", "refresh-state"}}
+    or subcommands[:2] == ["quota", "spend-slot"]
+))
+proc = subprocess.run(
+    BRIDGE_COMMAND,
+    input=raw,
+    text=True,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+    shell=True,
+)
+record["returncode"] = int(proc.returncode)
+try:
+    SUMMARY_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with SUMMARY_PATH.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record, sort_keys=True) + "\\n")
+except OSError:
+    pass
+sys.stdout.write(proc.stdout)
+sys.stderr.write(proc.stderr)
+raise SystemExit(proc.returncode)
+"""
+        wrapper_path.write_text(script, encoding="utf-8")
+        wrapper_path.chmod(0o700)
+        return wrapper_path
+
+    def _publish_remote_bridge_agent_operations_trace(
+        self,
+        *,
+        bridge_summary_path: Path,
+    ) -> None:
+        if not self._config.worker_public_trace_dir:
+            return
+        operation_counts: dict[str, int] = {}
+        loopx_subcommand_counts: dict[str, int] = {}
+        request_count = 0
+        loopx_cli_call_count = 0
+        state_read_count = 0
+        state_write_count = 0
+        raw_material_recorded = False
+        if bridge_summary_path.exists():
+            for line in bridge_summary_path.read_text(
+                encoding="utf-8",
+                errors="replace",
+            ).splitlines():
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(record, dict):
+                    continue
+                request_count += 1
+                operation = str(record.get("operation") or "unknown")[:40]
+                operation_counts[operation] = operation_counts.get(operation, 0) + 1
+                if record.get("loopx_cli_call") is True:
+                    loopx_cli_call_count += 1
+                if record.get("loopx_state_read") is True:
+                    state_read_count += 1
+                if record.get("loopx_state_write") is True:
+                    state_write_count += 1
+                subcommands = record.get("loopx_subcommands")
+                if isinstance(subcommands, list) and subcommands:
+                    key = " ".join(
+                        str(item)
+                        for item in subcommands[:2]
+                        if re.match(r"^[A-Za-z][A-Za-z0-9_-]{0,40}$", str(item))
+                    )
+                    if key:
+                        loopx_subcommand_counts[key] = (
+                            loopx_subcommand_counts.get(key, 0) + 1
+                        )
+                raw_material_recorded = raw_material_recorded or any(
+                    record.get(field) is True
+                    for field in (
+                        "raw_request_recorded",
+                        "raw_stdout_recorded",
+                        "raw_stderr_recorded",
+                        "raw_task_text_recorded",
+                        "credential_values_recorded",
+                        "host_paths_recorded",
+                        "remote_paths_recorded",
+                    )
+                )
+        trace = {
+            "schema_version": "skillsbench_host_local_acp_relay_public_trace_v0",
+            "ok": True,
+            "route": self._config.route,
+            "trace_kind": "remote_command_file_bridge_agent_operations",
+            "benchmark_id": self._config.dataset,
+            "task_id": self._config.task_id,
+            "remote_command_file_bridge_agent_operations": {
+                "schema_version": (
+                    "skillsbench_remote_command_file_bridge_agent_operations_v0"
+                ),
+                "request_count": request_count,
+                "operation_counts": dict(sorted(operation_counts.items())),
+                "loopx_cli_call_count": loopx_cli_call_count,
+                "loopx_cli_subcommand_counts": dict(
+                    sorted(loopx_subcommand_counts.items())
+                ),
+                "loopx_state_read_count": state_read_count,
+                "loopx_state_write_count": state_write_count,
+                "raw_material_recorded": raw_material_recorded,
+            },
+            "boundary": {
+                "raw_command_recorded": False,
+                "raw_stdout_recorded": False,
+                "raw_stderr_recorded": False,
+                "raw_task_text_recorded": False,
+                "raw_logs_recorded": False,
+                "raw_trajectory_recorded": False,
+                "credential_values_recorded": False,
+                "host_paths_recorded": False,
+                "remote_paths_recorded": False,
+                "upload_performed": False,
+                "submit_performed": False,
+            },
+        }
+        self._write_worker_public_trace(trace)
 
     def _publish_remote_bridge_consumption_trace(
         self,
@@ -348,6 +912,73 @@ Private bridge command:
                 "bridge_command_recorded": False,
             },
             "boundary": boundary,
+        }
+        self._write_worker_public_trace(trace)
+
+    def _publish_codex_exec_failure_trace(
+        self,
+        *,
+        stage: str,
+        returncode: int | None,
+        stdout_text: str,
+        stderr_text: str,
+        final_message_present: bool,
+        final_message_bytes: int,
+        failure_category: str | None = None,
+    ) -> None:
+        if not self._config.worker_public_trace_dir:
+            return
+        safe_stage = "".join(
+            ch if ch.isalnum() or ch == "_" else "_"
+            for ch in str(stage or "").strip().lower()
+        )
+        if not safe_stage:
+            safe_stage = "codex_exec_failed"
+        category = failure_category or _codex_exec_failure_category(
+            returncode=returncode,
+            stderr_text=stderr_text,
+        )
+        trace = {
+            "schema_version": "skillsbench_host_local_acp_relay_public_trace_v0",
+            "ok": False,
+            "route": self._config.route,
+            "trace_kind": "codex_exec_process_failure",
+            "benchmark_id": self._config.dataset,
+            "task_id": self._config.task_id,
+            "codex_exec_process": {
+                "schema_version": "skillsbench_codex_exec_process_failure_v0",
+                "stage": safe_stage,
+                "failure_category": str(category or "codex_exec_failed")[:120],
+                "returncode": (
+                    returncode
+                    if isinstance(returncode, int)
+                    and not isinstance(returncode, bool)
+                    else None
+                ),
+                "stdout_bytes": len((stdout_text or "").encode("utf-8")),
+                "stderr_bytes": len((stderr_text or "").encode("utf-8")),
+                "final_message_present": bool(final_message_present),
+                "final_message_bytes": max(0, int(final_message_bytes or 0)),
+                "raw_stdout_recorded": False,
+                "raw_stderr_recorded": False,
+                "raw_task_text_recorded": False,
+                "raw_trajectory_recorded": False,
+                "credential_values_recorded": False,
+                "host_paths_recorded": False,
+            },
+            "boundary": {
+                "raw_command_recorded": False,
+                "raw_stdout_recorded": False,
+                "raw_stderr_recorded": False,
+                "raw_task_text_recorded": False,
+                "raw_logs_recorded": False,
+                "raw_trajectory_recorded": False,
+                "credential_values_recorded": False,
+                "host_paths_recorded": False,
+                "remote_paths_recorded": False,
+                "upload_performed": False,
+                "submit_performed": False,
+            },
         }
         self._write_worker_public_trace(trace)
 
@@ -829,11 +1460,23 @@ def run_skillsbench_local_acp_relay_probe(
             },
             timeout_at=started + timeout_sec,
         )
+        prompt_usage = (
+            prompt.get("result", {}).get("usage")
+            if isinstance(prompt.get("result"), dict)
+            else {}
+        )
+        usage_total = (
+            prompt_usage.get("totalTokens") if isinstance(prompt_usage, dict) else None
+        )
+        usage_ready = isinstance(usage_total, int) and not isinstance(
+            usage_total, bool
+        ) and usage_total > 0
         ready = (
             initialize.get("result", {}).get("agentInfo", {}).get("name")
             == "loopx-skillsbench-local-acp-relay"
             and bool(session_id)
             and prompt.get("result", {}).get("stopReason") == "end_turn"
+            and usage_ready
         )
         return _relay_probe_payload(
             ready=ready,
@@ -844,6 +1487,7 @@ def run_skillsbench_local_acp_relay_probe(
             ),
             stage="complete",
             request_count=4,
+            prompt_usage_total_tokens=usage_total if usage_ready else 0,
         )
     except (OSError, RuntimeError, TimeoutError, json.JSONDecodeError):
         return _relay_probe_payload(
@@ -851,6 +1495,7 @@ def run_skillsbench_local_acp_relay_probe(
             first_blocker=f"skillsbench_local_acp_relay_{stage}_failed",
             stage=stage,
             request_count=0,
+            prompt_usage_total_tokens=0,
         )
     finally:
         if proc is not None:
@@ -1035,6 +1680,7 @@ def _relay_probe_payload(
     first_blocker: str,
     stage: str,
     request_count: int,
+    prompt_usage_total_tokens: int = 0,
 ) -> dict[str, Any]:
     return {
         "schema_version": SKILLSBENCH_LOCAL_ACP_RELAY_PROBE_SCHEMA_VERSION,
@@ -1042,6 +1688,7 @@ def _relay_probe_payload(
         "first_blocker": first_blocker,
         "stage": stage,
         "request_count": request_count,
+        "prompt_usage_total_tokens": max(0, int(prompt_usage_total_tokens or 0)),
         "worker_protocol": "acp_stdio",
         "codex_cli_invoked": False,
         "raw_output_recorded": False,

--- a/loopx/benchmark_core/loop_protocol.py
+++ b/loopx/benchmark_core/loop_protocol.py
@@ -327,6 +327,13 @@ def _run_has_headline_metrics(run: dict[str, Any]) -> bool:
 
 
 def _loopx_product_lifecycle_observed(run: dict[str, Any]) -> bool:
+    lifecycle_contract = run.get("product_mode_lifecycle_contract")
+    if isinstance(lifecycle_contract, dict):
+        if (
+            lifecycle_contract.get("satisfied") is True
+            and lifecycle_contract.get("countable_treatment") is not False
+        ):
+            return True
     if run.get("loopx_prompt_driven_lifecycle_observed") is True:
         return True
     for key in (

--- a/loopx/benchmark_ledger.py
+++ b/loopx/benchmark_ledger.py
@@ -391,6 +391,39 @@ def _compact_product_mode_pair_review(review: dict[str, Any]) -> dict[str, Any]:
     return compact
 
 
+def _compact_product_mode_lifecycle_contract(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    compact: dict[str, Any] = {}
+    schema = _compact_text(value.get("schema_version"), limit=100)
+    if schema:
+        compact["schema_version"] = schema
+    for field in (
+        "required",
+        "satisfied",
+        "countable_treatment",
+        "checkpoint_required",
+    ):
+        if isinstance(value.get(field), bool):
+            compact[field] = value[field]
+    for field in (
+        "state_read_count",
+        "state_write_count",
+        "checkpoint_count",
+        "checkpoint_round",
+    ):
+        raw = value.get(field)
+        if isinstance(raw, int) and not isinstance(raw, bool):
+            compact[field] = max(0, raw)
+    missing_reason = _compact_text(value.get("missing_reason"), limit=140)
+    if missing_reason:
+        compact["missing_reason"] = missing_reason
+    execution_style = _compact_text(value.get("execution_style"), limit=120)
+    if execution_style:
+        compact["execution_style"] = execution_style
+    return compact
+
+
 def _terminal_bench_case_id_from_job_name(
     *,
     benchmark_id: str,
@@ -1332,6 +1365,11 @@ def build_benchmark_run_ledger_entry(
         else None,
         "source_event_schema": source_schema,
     }
+    product_mode_lifecycle_contract = _compact_product_mode_lifecycle_contract(
+        benchmark_run.get("product_mode_lifecycle_contract")
+    )
+    if product_mode_lifecycle_contract:
+        entry["product_mode_lifecycle_contract"] = product_mode_lifecycle_contract
     attempt_accounting = (
         benchmark_run.get("attempt_accounting")
         if isinstance(benchmark_run.get("attempt_accounting"), dict)

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -546,6 +546,8 @@ def _compact_benchmark_interaction_counters(value: Any) -> dict[str, Any]:
         "remote_command_file_bridge_solver_trace_dir_present",
         "remote_command_file_bridge_solver_public_trace_read",
         "remote_command_file_bridge_solver_raw_material_recorded",
+        "remote_command_file_bridge_driver_lifecycle_trace_present",
+        "remote_command_file_bridge_driver_lifecycle_raw_material_recorded",
     ):
         if isinstance(value.get(field), bool):
             compact[field] = value[field]
@@ -616,6 +618,19 @@ def _compact_benchmark_interaction_counters(value: Any) -> dict[str, Any]:
         "remote_command_file_bridge_solver_trace_count",
         "remote_command_file_bridge_solver_probe_ready_count",
         "remote_command_file_bridge_solver_operation_count",
+        "remote_command_file_bridge_agent_operation_trace_count",
+        "remote_command_file_bridge_agent_request_count",
+        "remote_command_file_bridge_agent_loopx_cli_call_count",
+        "remote_command_file_bridge_agent_loopx_state_read_count",
+        "remote_command_file_bridge_agent_loopx_state_write_count",
+        "remote_command_file_bridge_driver_lifecycle_trace_count",
+        "remote_command_file_bridge_driver_lifecycle_checkpoint_count",
+        "remote_command_file_bridge_driver_lifecycle_request_count",
+        "remote_command_file_bridge_driver_lifecycle_success_count",
+        "remote_command_file_bridge_driver_lifecycle_failure_count",
+        "remote_command_file_bridge_driver_lifecycle_loopx_cli_call_count",
+        "remote_command_file_bridge_driver_lifecycle_loopx_state_read_count",
+        "remote_command_file_bridge_driver_lifecycle_loopx_state_write_count",
     ):
         if isinstance(value.get(field), int) and not isinstance(value.get(field), bool):
             compact[field] = value[field]
@@ -632,6 +647,7 @@ def _compact_benchmark_interaction_counters(value: Any) -> dict[str, Any]:
         "benchflow_user_loop_recovery_stage",
         "benchflow_user_loop_recovery_exception_type",
         "benchflow_intermediate_soft_verify_policy",
+        "remote_command_file_bridge_driver_lifecycle_execution_style",
         "last_decision",
         "worker_submit_eligible_mismatch_reason",
         "worker_bridge_writeback_loss_reason",
@@ -717,6 +733,9 @@ def _compact_product_mode_lifecycle_contract(value: Any) -> dict[str, Any]:
         "satisfied",
         "countable_treatment",
         "checkpoint_required",
+        "agent_operation_trace_required",
+        "agent_operation_trace_satisfied",
+        "agent_operation_trace_missing",
     ):
         if isinstance(value.get(field), bool):
             compact[field] = value[field]
@@ -725,12 +744,25 @@ def _compact_product_mode_lifecycle_contract(value: Any) -> dict[str, Any]:
         "state_write_count",
         "checkpoint_count",
         "checkpoint_round",
+        "agent_bridge_state_read_count",
+        "agent_bridge_state_write_count",
+        "driver_lifecycle_state_read_count",
+        "driver_lifecycle_state_write_count",
     ):
         if isinstance(value.get(field), int) and not isinstance(value.get(field), bool):
             compact[field] = value[field]
     missing_reason = public_safe_compact_text(value.get("missing_reason"), limit=140)
     if missing_reason:
         compact["missing_reason"] = missing_reason
+    trace_status = public_safe_compact_text(
+        value.get("agent_operation_trace_status"),
+        limit=120,
+    )
+    if trace_status:
+        compact["agent_operation_trace_status"] = trace_status
+    execution_style = public_safe_compact_text(value.get("execution_style"), limit=120)
+    if execution_style:
+        compact["execution_style"] = execution_style
     return compact
 
 
@@ -986,6 +1018,10 @@ def _compact_benchmark_runner_prerequisites(value: Any) -> dict[str, Any]:
         "benchflow_intermediate_soft_verify_policy",
         "benchflow_setup_stall_cleanup_status",
         "remote_command_file_bridge_consumption_status",
+        "remote_command_file_bridge_agent_operation_trace_status",
+        "remote_command_file_bridge_driver_lifecycle_execution_style",
+        "runner_interruption_kind",
+        "runner_interruption_status",
     ):
         text = public_safe_compact_text(value.get(field), limit=180)
         if text:
@@ -1006,12 +1042,19 @@ def _compact_benchmark_runner_prerequisites(value: Any) -> dict[str, Any]:
         "host_local_acp_launch",
         "remote_command_file_bridge_materialized",
         "remote_command_file_bridge_command_configured",
+        "remote_command_file_bridge_agent_command_configured",
+        "remote_command_file_bridge_agent_command_instrumented",
         "remote_command_file_bridge_probe_command_configured",
         "remote_command_file_bridge_solver_wiring_configured",
         "remote_command_file_bridge_consumed_by_solver",
         "remote_command_file_bridge_solver_trace_dir_present",
         "remote_command_file_bridge_solver_public_trace_read",
         "remote_command_file_bridge_solver_raw_material_recorded",
+        "remote_command_file_bridge_agent_operation_trace_required",
+        "remote_command_file_bridge_agent_operation_trace_satisfied",
+        "remote_command_file_bridge_agent_operation_trace_present",
+        "remote_command_file_bridge_driver_lifecycle_trace_present",
+        "remote_command_file_bridge_driver_lifecycle_raw_material_recorded",
         "codex_app_server_goal_worker_adapter_present",
         "codex_app_server_goal_worker_turn_start_required",
         "codex_app_server_goal_worker_goal_get_required",
@@ -1044,6 +1087,9 @@ def _compact_benchmark_runner_prerequisites(value: Any) -> dict[str, Any]:
         "benchflow_setup_stall_task_cancel_timeout",
         "benchflow_setup_stall_cleanup_requested",
         "benchflow_setup_stall_cleanup_raw_logs_read",
+        "runner_interrupted_before_official_result",
+        "runner_interruption_compact_closeout_expected",
+        "runner_interruption_raw_material_recorded",
     ):
         if isinstance(value.get(field), bool):
             compact[field] = value[field]
@@ -1068,6 +1114,19 @@ def _compact_benchmark_runner_prerequisites(value: Any) -> dict[str, Any]:
         "remote_command_file_bridge_solver_trace_count",
         "remote_command_file_bridge_solver_probe_ready_count",
         "remote_command_file_bridge_solver_operation_count",
+        "remote_command_file_bridge_agent_operation_trace_count",
+        "remote_command_file_bridge_agent_request_count",
+        "remote_command_file_bridge_agent_loopx_cli_call_count",
+        "remote_command_file_bridge_agent_loopx_state_read_count",
+        "remote_command_file_bridge_agent_loopx_state_write_count",
+        "remote_command_file_bridge_driver_lifecycle_trace_count",
+        "remote_command_file_bridge_driver_lifecycle_checkpoint_count",
+        "remote_command_file_bridge_driver_lifecycle_request_count",
+        "remote_command_file_bridge_driver_lifecycle_success_count",
+        "remote_command_file_bridge_driver_lifecycle_failure_count",
+        "remote_command_file_bridge_driver_lifecycle_loopx_cli_call_count",
+        "remote_command_file_bridge_driver_lifecycle_loopx_state_read_count",
+        "remote_command_file_bridge_driver_lifecycle_loopx_state_write_count",
     ):
         if isinstance(value.get(field), int) and not isinstance(value.get(field), bool):
             compact[field] = value[field]

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -78,8 +78,11 @@ if str(REPO_ROOT) not in sys.path:
 from loopx.benchmark_case_state import (  # noqa: E402
     BENCHMARK_CASE_ACTIVE_STATE_SCHEMA_VERSION,
     BENCHMARK_CASE_LOOPX_AGENT_ID,
-    BENCHMARK_CASE_LOOPX_TODO_ID,
+    BENCHMARK_CASE_LOOPX_CLI_PATH,
+    BENCHMARK_CASE_LOOPX_REGISTRY_PATH,
+    BENCHMARK_CASE_LOOPX_RUNTIME_ROOT,
     BENCHMARK_CASE_LOOPX_SOURCE_MOUNT_TARGET,
+    BENCHMARK_CASE_LOOPX_TODO_ID,
     benchmark_case_loopx_command_prefix,
     benchmark_case_loopx_install_payload,
     benchmark_case_active_state_path,
@@ -114,6 +117,15 @@ from loopx.benchmark_core.loop_protocol import (  # noqa: E402
     build_blind_loop_initial_prompt,
 )
 from loopx.benchmark_trajectory import summarize_public_acp_trajectory
+
+
+class SkillsBenchRunnerInterrupted(RuntimeError):
+    """Public-safe interruption used to force compact runner closeout."""
+
+
+class SkillsBenchProductModeNoLifecycleRequests(RuntimeError):
+    """Product-mode agent made no required case-local LoopX lifecycle request."""
+
 
 DEFAULT_SKILLSBENCH_ROOT = REPO_ROOT / ".local/benchmark/externals/skillsbench"
 DEFAULT_LEDGER = (
@@ -340,8 +352,18 @@ def ensure_benchflow_runtime(args: argparse.Namespace) -> None:
 
     venv_python = Path(args.skillsbench_root).expanduser() / ".venv/bin/python"
     current_python = Path(sys.executable)
-    if not venv_python.exists() or _same_executable(venv_python, current_python):
-        raise
+    if not venv_python.exists():
+        raise RuntimeError(
+            "SkillsBench benchflow runtime unavailable: benchflow import failed "
+            "and skillsbench-root .venv/bin/python is missing; pass "
+            "--skillsbench-root pointing at a prepared SkillsBench checkout"
+        ) from None
+    if _same_executable(venv_python, current_python):
+        raise RuntimeError(
+            "SkillsBench benchflow runtime unavailable: benchflow import failed "
+            "and skillsbench-root .venv/bin/python resolves to the current "
+            "Python executable"
+        ) from None
     os.execv(
         str(venv_python),
         [str(venv_python), str(Path(__file__).resolve()), *sys.argv[1:]],
@@ -698,6 +720,12 @@ def _host_local_acp_launch_command(
             str(args.local_codex_exec_timeout_sec),
         ]
     )
+    if args.host_local_acp_launch and args.route != "codex-app-server-goal-baseline":
+        heartbeat_interval = min(
+            max(1.0, float(args.app_server_acp_heartbeat_interval_sec)),
+            15.0,
+        )
+        command.extend(["--stream-heartbeat-interval-sec", str(heartbeat_interval)])
     if args.model:
         command.extend(["--model", args.model])
     if (
@@ -717,7 +745,149 @@ def _host_local_acp_launch_command(
                 str(args.remote_command_file_bridge_probe_timeout_sec),
             ]
         )
+        if args.remote_command_file_bridge_agent_command:
+            command.extend(
+                [
+                    "--remote-command-file-bridge-agent-command",
+                    args.remote_command_file_bridge_agent_command,
+                ]
+            )
+        if args.route == "loopx-product-mode":
+            payload = benchmark_case_loopx_install_payload(
+                benchmark_id="skillsbench",
+                case_id=args.task_id,
+                arm_id="loopx_product_mode",
+                route=args.route,
+                max_rounds=args.max_rounds,
+                case_loopx_source_path=_loopx_case_source_path_for_container(args),
+            )
+            command.extend(
+                [
+                    "--loopx-workflow-lifecycle-checkpoint",
+                    "--loopx-case-goal-id",
+                    str(payload.get("benchmark_case_goal_id") or ""),
+                    "--loopx-case-agent-id",
+                    str(payload.get("case_agent_id") or BENCHMARK_CASE_LOOPX_AGENT_ID),
+                    "--loopx-case-todo-id",
+                    str(payload.get("case_todo_id") or BENCHMARK_CASE_LOOPX_TODO_ID),
+                    "--loopx-case-cli-path",
+                    str(payload.get("case_cli_path") or BENCHMARK_CASE_LOOPX_CLI_PATH),
+                    "--loopx-case-registry-path",
+                    str(
+                        payload.get("case_registry_path")
+                        or BENCHMARK_CASE_LOOPX_REGISTRY_PATH
+                    ),
+                    "--loopx-case-runtime-root",
+                    str(
+                        payload.get("case_runtime_root")
+                        or BENCHMARK_CASE_LOOPX_RUNTIME_ROOT
+                    ),
+                ]
+            )
     return command
+
+
+def _host_local_acp_codex_exec_preflight_command(
+    args: argparse.Namespace,
+    plan: dict[str, Any],
+) -> list[str]:
+    command = list(default_skillsbench_local_acp_relay_command())
+    if "--dry-run-response" in command:
+        index = command.index("--dry-run-response")
+        del command[index : index + 2]
+    command.extend(
+        [
+            "--route",
+            args.route,
+            "--dataset",
+            args.dataset,
+            "--task-id",
+            args.task_id,
+            "--codex-bin",
+            args.local_codex_bin,
+            "--sandbox",
+            args.local_codex_sandbox,
+            "--timeout-sec",
+            str(max(1, int(args.host_local_acp_codex_exec_preflight_timeout_sec))),
+        ]
+    )
+    if args.model:
+        command.extend(["--model", args.model])
+    relay_trace_dir = str(plan.get("host_local_acp_relay_trace_dir") or "")
+    if relay_trace_dir:
+        command.extend(
+            [
+                "--worker-public-trace-dir",
+                str(Path(relay_trace_dir) / "codex-exec-preflight"),
+            ]
+        )
+    return command
+
+
+def _run_host_local_acp_codex_exec_preflight(
+    args: argparse.Namespace,
+    plan: dict[str, Any],
+) -> None:
+    prerequisites = plan.setdefault("runner_prerequisites", {})
+    prerequisites["host_local_acp_codex_exec_preflight_requested"] = True
+    prerequisites["host_local_acp_codex_exec_preflight_status"] = "running"
+    attempts = max(
+        1,
+        int(getattr(args, "host_local_acp_codex_exec_preflight_attempts", 1) or 1),
+    )
+    command = _host_local_acp_codex_exec_preflight_command(args, plan)
+    relay_trace_dir = str(plan.get("host_local_acp_relay_trace_dir") or "")
+    preflight_trace_dir = (
+        Path(relay_trace_dir) / "codex-exec-preflight" if relay_trace_dir else None
+    )
+    for attempt in range(1, attempts + 1):
+        prerequisites["host_local_acp_codex_exec_preflight_attempt_count"] = attempt
+        if preflight_trace_dir:
+            preflight_trace_dir.mkdir(parents=True, exist_ok=True)
+            for trace_file in preflight_trace_dir.glob("*.compact.json"):
+                trace_file.unlink(missing_ok=True)
+        probe = run_skillsbench_local_acp_relay_probe(
+            command,
+            timeout_sec=float(args.host_local_acp_codex_exec_preflight_timeout_sec),
+        )
+        ready = probe.get("ready") is True
+        prerequisites["host_local_acp_codex_exec_preflight_ready"] = ready
+        prerequisites["host_local_acp_codex_exec_preflight_stage"] = str(
+            probe.get("stage") or ""
+        )[:180]
+        prerequisites["host_local_acp_codex_exec_preflight_first_blocker"] = str(
+            probe.get("first_blocker") or ""
+        )[:180]
+        if ready:
+            prerequisites["host_local_acp_codex_exec_preflight_status"] = "passed"
+            for key in (
+                "host_local_acp_codex_exec_failure_category",
+                "host_local_acp_codex_exec_failure_categories",
+                "host_local_acp_codex_exec_failure_trace_count",
+                "host_local_acp_codex_exec_failure_trace_present",
+            ):
+                prerequisites.pop(key, None)
+            return
+        prerequisites["host_local_acp_codex_exec_preflight_status"] = "failed"
+        if preflight_trace_dir:
+            trace: dict[str, Any] = {
+                "schema_version": "skillsbench_loopx_controller_trace_v0"
+            }
+            preflight_plan = {
+                "host_local_acp_relay_trace_dir": str(preflight_trace_dir),
+                "runner_prerequisites": prerequisites,
+            }
+            _merge_host_local_acp_relay_trace_summary(preflight_plan, trace)
+        category = str(
+            prerequisites.get("host_local_acp_codex_exec_failure_category") or ""
+        )
+        if (
+            category == "codex_reverse_channel_unavailable"
+            and attempt < attempts
+        ):
+            time.sleep(2.0)
+            continue
+        raise RuntimeError("host-local ACP codex exec preflight failed")
 
 
 def _benchflow_agent_runtime_layer_contract(args: argparse.Namespace) -> dict[str, Any]:
@@ -854,6 +1024,13 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "benchflow_intermediate_soft_verify_policy",
         "benchflow_setup_stall_cleanup_status",
         "remote_command_file_bridge_consumption_status",
+        "remote_command_file_bridge_agent_operation_trace_status",
+        "host_local_acp_codex_exec_preflight_status",
+        "host_local_acp_codex_exec_preflight_stage",
+        "host_local_acp_codex_exec_preflight_first_blocker",
+        "host_local_acp_codex_exec_failure_category",
+        "runner_interruption_kind",
+        "runner_interruption_status",
     ):
         raw = value.get(field)
         if isinstance(raw, str) and raw:
@@ -864,16 +1041,27 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "codex_acp_runtime_launch_preflight",
         "codex_acp_runtime_launch_preflight_raw_logs_read",
         "host_local_acp_launch",
+        "host_local_acp_codex_exec_preflight_requested",
+        "host_local_acp_codex_exec_preflight_ready",
         "container_codex_acp_install_skipped",
         "benchflow_agent_install_skipped_by_runtime_layer",
         "remote_command_file_bridge_materialized",
         "remote_command_file_bridge_command_configured",
+        "remote_command_file_bridge_agent_command_configured",
+        "remote_command_file_bridge_agent_command_instrumented",
         "remote_command_file_bridge_probe_command_configured",
         "remote_command_file_bridge_solver_wiring_configured",
         "remote_command_file_bridge_consumed_by_solver",
         "remote_command_file_bridge_solver_trace_dir_present",
         "remote_command_file_bridge_solver_public_trace_read",
         "remote_command_file_bridge_solver_raw_material_recorded",
+        "remote_command_file_bridge_agent_operation_trace_required",
+        "remote_command_file_bridge_agent_operation_trace_satisfied",
+        "remote_command_file_bridge_agent_operation_trace_present",
+        "remote_command_file_bridge_driver_lifecycle_trace_present",
+        "host_local_acp_codex_exec_failure_trace_present",
+        "host_local_acp_codex_exec_failure_raw_material_recorded",
+        "remote_command_file_bridge_driver_lifecycle_raw_material_recorded",
         "preinstalled_benchflow_agent_runtime_required",
         "benchflow_agent_runtime_layer_ready",
         "codex_acp_runtime_dependency_setup_skipped",
@@ -913,6 +1101,9 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "benchflow_setup_stall_task_cancel_timeout",
         "benchflow_setup_stall_cleanup_requested",
         "benchflow_setup_stall_cleanup_raw_logs_read",
+        "runner_interrupted_before_official_result",
+        "runner_interruption_compact_closeout_expected",
+        "runner_interruption_raw_material_recorded",
     ):
         if isinstance(value.get(field), bool):
             compact[field] = value[field]
@@ -939,9 +1130,50 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "remote_command_file_bridge_solver_trace_count",
         "remote_command_file_bridge_solver_probe_ready_count",
         "remote_command_file_bridge_solver_operation_count",
+        "remote_command_file_bridge_agent_operation_trace_count",
+        "remote_command_file_bridge_agent_request_count",
+        "remote_command_file_bridge_agent_loopx_cli_call_count",
+        "remote_command_file_bridge_agent_loopx_state_read_count",
+        "remote_command_file_bridge_agent_loopx_state_write_count",
+        "remote_command_file_bridge_driver_lifecycle_trace_count",
+        "remote_command_file_bridge_driver_lifecycle_checkpoint_count",
+        "remote_command_file_bridge_driver_lifecycle_request_count",
+        "remote_command_file_bridge_driver_lifecycle_success_count",
+        "remote_command_file_bridge_driver_lifecycle_failure_count",
+        "remote_command_file_bridge_driver_lifecycle_loopx_cli_call_count",
+        "remote_command_file_bridge_driver_lifecycle_loopx_state_read_count",
+        "remote_command_file_bridge_driver_lifecycle_loopx_state_write_count",
+        "host_local_acp_codex_exec_preflight_attempt_count",
+        "host_local_acp_codex_exec_failure_trace_count",
     ):
         if isinstance(value.get(field), int) and not isinstance(value.get(field), bool):
             compact[field] = value[field]
+    for field in (
+        "remote_command_file_bridge_agent_operation_counts",
+        "remote_command_file_bridge_agent_loopx_subcommand_counts",
+        "remote_command_file_bridge_driver_lifecycle_command_counts",
+        "remote_command_file_bridge_driver_lifecycle_returncode_counts",
+    ):
+        raw_counts = value.get(field)
+        if not isinstance(raw_counts, dict):
+            continue
+        counts: dict[str, int] = {}
+        for key, count in raw_counts.items():
+            if (
+                isinstance(key, str)
+                and key
+                and isinstance(count, int)
+                and not isinstance(count, bool)
+                and count >= 0
+            ):
+                counts[key[:80]] = count
+        if counts:
+            compact[field] = dict(sorted(counts.items()))
+    style = value.get("remote_command_file_bridge_driver_lifecycle_execution_style")
+    if isinstance(style, str) and style:
+        compact["remote_command_file_bridge_driver_lifecycle_execution_style"] = (
+            style[:120]
+        )
     return compact
 
 
@@ -1523,6 +1755,14 @@ def _runner_prerequisite_failure_attribution(
             "skillsbench_environment_setup_error",
         ]
 
+    if value.get("runner_interrupted_before_official_result") is True:
+        label = "skillsbench_runner_interrupted_before_official_result"
+        return label, label, [
+            label,
+            "skillsbench_compact_closeout_recorded",
+            "skillsbench_runner_error",
+        ]
+
     if value.get("benchflow_final_verifier_timeout_triggered") is True:
         label = "skillsbench_final_verifier_timeout"
         return label, label, [
@@ -1555,6 +1795,72 @@ def _runner_prerequisite_failure_attribution(
     if value.get("host_local_acp_launch_status") == "failed":
         label = "skillsbench_host_local_acp_launch_failed"
         return label, label, [label, "skillsbench_runner_setup_error"]
+
+    if value.get("host_local_acp_codex_exec_preflight_status") == "failed":
+        category = str(value.get("host_local_acp_codex_exec_failure_category") or "")
+        label = "skillsbench_host_local_acp_codex_exec_preflight_failed"
+        if category:
+            label = f"{label}_{category}"
+        return label, label, [label, "skillsbench_runner_setup_error"]
+
+    if (
+        value.get("remote_command_file_bridge_agent_operation_trace_required") is True
+        and value.get("remote_command_file_bridge_agent_operation_trace_satisfied")
+        is False
+    ):
+        status = str(
+            value.get("remote_command_file_bridge_agent_operation_trace_status") or ""
+        )
+        trace_count = value.get("remote_command_file_bridge_agent_operation_trace_count")
+        request_count = value.get("remote_command_file_bridge_agent_request_count")
+        if (
+            status == "agent_operation_trace_present_no_requests"
+            or (
+                isinstance(trace_count, int)
+                and not isinstance(trace_count, bool)
+                and trace_count > 0
+                and (
+                    not isinstance(request_count, int)
+                    or isinstance(request_count, bool)
+                    or request_count <= 0
+                )
+            )
+        ):
+            label = "skillsbench_remote_bridge_agent_no_requests"
+            return (
+                label,
+                label,
+                [
+                    label,
+                    "skillsbench_product_mode_uncountable_treatment",
+                    "skillsbench_product_mode_lifecycle_missing",
+                ],
+            )
+        label = "skillsbench_remote_bridge_agent_operation_trace_missing"
+        return (
+            label,
+            label,
+            [
+                label,
+                "skillsbench_product_mode_uncountable_treatment",
+                "skillsbench_runner_setup_error",
+            ],
+        )
+
+    if value.get("host_local_acp_codex_exec_failure_trace_present") is True:
+        category = str(value.get("host_local_acp_codex_exec_failure_category") or "")
+        label = "skillsbench_host_local_acp_codex_exec_failed"
+        if category:
+            label = f"{label}_{category}"
+        return (
+            label,
+            label,
+            [
+                label,
+                "skillsbench_host_local_acp_codex_exec_failed",
+                "skillsbench_runner_setup_error",
+            ],
+        )
 
     if value.get("host_local_acp_launch_status") == "sandbox_install_failed":
         label = "skillsbench_host_local_acp_sandbox_install_failed"
@@ -1611,6 +1917,37 @@ def _agent_lifecycle_observed_for_setup_stall(plan: dict[str, Any]) -> bool:
 def _runner_exception_indicates_timeout(exc: BaseException) -> bool:
     text = f"{type(exc).__name__} {exc}".lower()
     return "timeout" in text or "timed out" in text
+
+
+def _runner_exception_indicates_interruption(exc: BaseException) -> bool:
+    return isinstance(exc, (KeyboardInterrupt, SkillsBenchRunnerInterrupted))
+
+
+def _ensure_runner_interruption_prerequisites(
+    plan: dict[str, Any],
+    exc: BaseException,
+) -> None:
+    if not _runner_exception_indicates_interruption(exc):
+        return
+
+    raw_prerequisites = plan.setdefault("runner_prerequisites", {})
+    kind = (
+        "sigterm"
+        if isinstance(exc, SkillsBenchRunnerInterrupted)
+        else "keyboard_interrupt"
+    )
+    raw_prerequisites.setdefault(
+        "benchflow_run_stage", "interrupted_before_official_result"
+    )
+    raw_prerequisites.setdefault("runner_interrupted_before_official_result", True)
+    raw_prerequisites.setdefault("runner_interruption_kind", kind)
+    raw_prerequisites.setdefault(
+        "runner_interruption_status", "compact_closeout_required"
+    )
+    raw_prerequisites.setdefault(
+        "runner_interruption_compact_closeout_expected", True
+    )
+    raw_prerequisites.setdefault("runner_interruption_raw_material_recorded", False)
 
 
 def _ensure_setup_stall_timeout_prerequisites(
@@ -1676,7 +2013,13 @@ def _apply_agent_message_only_no_tool_calls_attribution(
     preserve_attributions = {
         "skillsbench_codex_acp_provider_zero_activity",
     }
-    if current_attribution not in preserve_attributions:
+    preserve_current_attribution = (
+        current_attribution in preserve_attributions
+        or current_attribution.startswith(
+            "skillsbench_host_local_acp_codex_exec_failed"
+        )
+    )
+    if not preserve_current_attribution:
         compact["score_failure_attribution"] = label
         compact.setdefault("first_blocker", label)
     elif not compact.get("first_blocker"):
@@ -1687,7 +2030,7 @@ def _apply_agent_message_only_no_tool_calls_attribution(
         if isinstance(item, str)
     ]
     extra_labels = [label]
-    if current_attribution not in preserve_attributions:
+    if not preserve_current_attribution:
         extra_labels.append("skillsbench_agent_behavior_gap")
     for item in extra_labels:
         if item not in existing_labels:
@@ -2484,12 +2827,44 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
     remote_command_file_bridge_solver_command_configured = bool(
         args.remote_command_file_bridge_solver_command
     )
+    remote_command_file_bridge_agent_command_configured = bool(
+        args.remote_command_file_bridge_agent_command
+    )
     remote_command_file_bridge_solver_wiring_configured = bool(
         args.host_local_acp_launch
         and route in {"raw-codex-autonomous-max5", "loopx-product-mode"}
         and remote_command_file_bridge_materialized
         and remote_command_file_bridge_solver_command_configured
     )
+    remote_command_file_bridge_agent_operation_trace_required = bool(
+        route == "loopx-product-mode"
+        and remote_command_file_bridge_solver_wiring_configured
+    )
+    remote_command_file_bridge_agent_command_instrumented = bool(
+        remote_command_file_bridge_solver_wiring_configured
+    )
+    if not remote_command_file_bridge_agent_operation_trace_required:
+        remote_command_file_bridge_agent_operation_trace_status = "not_required"
+    elif not remote_command_file_bridge_agent_command_configured:
+        remote_command_file_bridge_agent_operation_trace_status = (
+            "relay_generated_wrapper_pending_prompt"
+        )
+    elif remote_command_file_bridge_agent_command_instrumented:
+        if (
+            remote_command_file_bridge_agent_command_configured
+            and not args.remote_command_file_bridge_agent_command_instrumented
+        ):
+            remote_command_file_bridge_agent_operation_trace_status = (
+                "external_agent_command_relay_wrapped_pending_trace"
+            )
+        else:
+            remote_command_file_bridge_agent_operation_trace_status = (
+                "external_agent_command_declared_instrumented_pending_trace"
+            )
+    else:
+        remote_command_file_bridge_agent_operation_trace_status = (
+            "external_agent_command_uninstrumented"
+        )
     remote_command_file_bridge_consumed_by_solver = False
     if remote_command_file_bridge_solver_wiring_configured:
         remote_command_file_bridge_consumption_status = (
@@ -2628,6 +3003,18 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
             "host_local_acp_launch_status": (
                 "pending" if args.host_local_acp_launch else "not_requested"
             ),
+            "host_local_acp_codex_exec_preflight_requested": bool(
+                args.host_local_acp_codex_exec_preflight
+            ),
+            "host_local_acp_codex_exec_preflight_ready": False,
+            "host_local_acp_codex_exec_preflight_status": (
+                "pending"
+                if args.host_local_acp_codex_exec_preflight
+                else "not_requested"
+            ),
+            "host_local_acp_codex_exec_preflight_attempt_count": 0,
+            "host_local_acp_codex_exec_preflight_stage": "",
+            "host_local_acp_codex_exec_preflight_first_blocker": "",
             "container_codex_acp_install_skipped": (
                 True if is_app_server_goal_route else requires_preinstalled_runtime
             ),
@@ -2639,6 +3026,19 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
             ),
             "remote_command_file_bridge_command_configured": bool(
                 remote_command_file_bridge_solver_command_configured
+            ),
+            "remote_command_file_bridge_agent_command_configured": bool(
+                remote_command_file_bridge_agent_command_configured
+            ),
+            "remote_command_file_bridge_agent_command_instrumented": bool(
+                remote_command_file_bridge_agent_command_instrumented
+            ),
+            "remote_command_file_bridge_agent_operation_trace_required": bool(
+                remote_command_file_bridge_agent_operation_trace_required
+            ),
+            "remote_command_file_bridge_agent_operation_trace_satisfied": False,
+            "remote_command_file_bridge_agent_operation_trace_status": (
+                remote_command_file_bridge_agent_operation_trace_status
             ),
             "remote_command_file_bridge_probe_command_configured": bool(
                 remote_command_file_bridge_probe_command_configured
@@ -3288,6 +3688,26 @@ def _merge_host_local_acp_relay_trace_summary(
     solver_trace_count = 0
     probe_ready_count = 0
     operation_count = 0
+    codex_exec_failure_trace_count = 0
+    codex_exec_failure_categories: list[str] = []
+    agent_bridge_trace_count = 0
+    agent_bridge_request_count = 0
+    agent_bridge_loopx_cli_call_count = 0
+    agent_bridge_loopx_state_read_count = 0
+    agent_bridge_loopx_state_write_count = 0
+    agent_bridge_operation_counts: dict[str, int] = {}
+    agent_bridge_loopx_subcommand_counts: dict[str, int] = {}
+    driver_lifecycle_trace_count = 0
+    driver_lifecycle_checkpoint_count = 0
+    driver_lifecycle_request_count = 0
+    driver_lifecycle_success_count = 0
+    driver_lifecycle_failure_count = 0
+    driver_lifecycle_loopx_cli_call_count = 0
+    driver_lifecycle_loopx_state_read_count = 0
+    driver_lifecycle_loopx_state_write_count = 0
+    driver_lifecycle_command_counts: dict[str, int] = {}
+    driver_lifecycle_returncode_counts: dict[str, int] = {}
+    driver_lifecycle_execution_style = ""
     raw_material_recorded = False
     for path in files:
         try:
@@ -3301,26 +3721,152 @@ def _merge_host_local_acp_relay_trace_summary(
             != "skillsbench_host_local_acp_relay_public_trace_v0"
         ):
             continue
-        if payload.get("trace_kind") != "remote_command_file_bridge_solver_consumption":
-            continue
-        bridge = (
-            payload.get("remote_command_file_bridge")
-            if isinstance(payload.get("remote_command_file_bridge"), dict)
-            else {}
-        )
-        solver_trace_count += 1
-        if bridge.get("probe_ready") is True:
-            probe_ready_count += 1
-        bridge_operations = bridge.get("operation_count")
-        if isinstance(bridge_operations, int) and not isinstance(
-            bridge_operations, bool
-        ):
-            operation_count += max(0, bridge_operations)
         boundary = (
             payload.get("boundary")
             if isinstance(payload.get("boundary"), dict)
             else {}
         )
+        trace_kind = payload.get("trace_kind")
+        if trace_kind == "remote_command_file_bridge_solver_consumption":
+            bridge = (
+                payload.get("remote_command_file_bridge")
+                if isinstance(payload.get("remote_command_file_bridge"), dict)
+                else {}
+            )
+            solver_trace_count += 1
+            if bridge.get("probe_ready") is True:
+                probe_ready_count += 1
+            bridge_operations = bridge.get("operation_count")
+            if isinstance(bridge_operations, int) and not isinstance(
+                bridge_operations, bool
+            ):
+                operation_count += max(0, bridge_operations)
+        elif trace_kind == "codex_exec_process_failure":
+            process = (
+                payload.get("codex_exec_process")
+                if isinstance(payload.get("codex_exec_process"), dict)
+                else {}
+            )
+            codex_exec_failure_trace_count += 1
+            category = process.get("failure_category")
+            if (
+                isinstance(category, str)
+                and category
+                and category not in codex_exec_failure_categories
+            ):
+                codex_exec_failure_categories.append(category[:120])
+        elif trace_kind == "remote_command_file_bridge_agent_operations":
+            agent_ops = (
+                payload.get("remote_command_file_bridge_agent_operations")
+                if isinstance(
+                    payload.get("remote_command_file_bridge_agent_operations"),
+                    dict,
+                )
+                else {}
+            )
+            agent_bridge_trace_count += 1
+            raw_material_recorded = raw_material_recorded or (
+                agent_ops.get("raw_material_recorded") is True
+            )
+            count_fields = {
+                "request_count": "request",
+                "loopx_cli_call_count": "loopx_cli",
+                "loopx_state_read_count": "state_read",
+                "loopx_state_write_count": "state_write",
+            }
+            for field, target in count_fields.items():
+                value = agent_ops.get(field)
+                if not isinstance(value, int) or isinstance(value, bool):
+                    value = 0
+                value = max(0, value)
+                if target == "request":
+                    agent_bridge_request_count += value
+                elif target == "loopx_cli":
+                    agent_bridge_loopx_cli_call_count += value
+                elif target == "state_read":
+                    agent_bridge_loopx_state_read_count += value
+                elif target == "state_write":
+                    agent_bridge_loopx_state_write_count += value
+            for source_key, target_counts in (
+                ("operation_counts", agent_bridge_operation_counts),
+                ("loopx_cli_subcommand_counts", agent_bridge_loopx_subcommand_counts),
+            ):
+                source_counts = agent_ops.get(source_key)
+                if not isinstance(source_counts, dict):
+                    continue
+                for key, value in source_counts.items():
+                    if not isinstance(key, str) or not key:
+                        continue
+                    if not isinstance(value, int) or isinstance(value, bool):
+                        continue
+                    safe_key = key[:80]
+                    target_counts[safe_key] = (
+                        target_counts.get(safe_key, 0) + max(0, value)
+                    )
+        elif trace_kind == "remote_command_file_bridge_driver_lifecycle_checkpoint":
+            checkpoint = (
+                payload.get("remote_command_file_bridge_driver_lifecycle_checkpoint")
+                if isinstance(
+                    payload.get(
+                        "remote_command_file_bridge_driver_lifecycle_checkpoint"
+                    ),
+                    dict,
+                )
+                else {}
+            )
+            driver_lifecycle_trace_count += 1
+            raw_material_recorded = raw_material_recorded or (
+                checkpoint.get("raw_material_recorded") is True
+            )
+            style = checkpoint.get("execution_style")
+            if isinstance(style, str) and style and not driver_lifecycle_execution_style:
+                driver_lifecycle_execution_style = style[:120]
+            count_fields = {
+                "checkpoint_count": "checkpoint",
+                "request_count": "request",
+                "success_count": "success",
+                "failure_count": "failure",
+                "loopx_cli_call_count": "loopx_cli",
+                "loopx_state_read_count": "state_read",
+                "loopx_state_write_count": "state_write",
+            }
+            for field, target in count_fields.items():
+                value = checkpoint.get(field)
+                if not isinstance(value, int) or isinstance(value, bool):
+                    value = 0
+                value = max(0, value)
+                if target == "checkpoint":
+                    driver_lifecycle_checkpoint_count += value
+                elif target == "request":
+                    driver_lifecycle_request_count += value
+                elif target == "success":
+                    driver_lifecycle_success_count += value
+                elif target == "failure":
+                    driver_lifecycle_failure_count += value
+                elif target == "loopx_cli":
+                    driver_lifecycle_loopx_cli_call_count += value
+                elif target == "state_read":
+                    driver_lifecycle_loopx_state_read_count += value
+                elif target == "state_write":
+                    driver_lifecycle_loopx_state_write_count += value
+            for source_key, target_counts in (
+                ("command_counts", driver_lifecycle_command_counts),
+                ("returncode_counts", driver_lifecycle_returncode_counts),
+            ):
+                source_counts = checkpoint.get(source_key)
+                if not isinstance(source_counts, dict):
+                    continue
+                for key, value in source_counts.items():
+                    if not isinstance(key, str) or not key:
+                        continue
+                    if not isinstance(value, int) or isinstance(value, bool):
+                        continue
+                    safe_key = key[:80]
+                    target_counts[safe_key] = (
+                        target_counts.get(safe_key, 0) + max(0, value)
+                    )
+        else:
+            continue
         raw_material_recorded = raw_material_recorded or any(
             boundary.get(field) is True
             for field in (
@@ -3349,7 +3895,124 @@ def _merge_host_local_acp_relay_trace_summary(
     trace["remote_command_file_bridge_solver_raw_material_recorded"] = (
         raw_material_recorded
     )
+    trace["host_local_acp_codex_exec_failure_trace_count"] = (
+        codex_exec_failure_trace_count
+    )
+    trace["host_local_acp_codex_exec_failure_trace_present"] = (
+        codex_exec_failure_trace_count > 0
+    )
+    trace["host_local_acp_codex_exec_failure_categories"] = (
+        codex_exec_failure_categories
+    )
+    trace["host_local_acp_codex_exec_failure_category"] = (
+        codex_exec_failure_categories[0] if codex_exec_failure_categories else ""
+    )
+    trace["host_local_acp_codex_exec_failure_raw_material_recorded"] = (
+        raw_material_recorded
+    )
+    trace["remote_command_file_bridge_agent_operation_trace_count"] = (
+        agent_bridge_trace_count
+    )
+    trace["remote_command_file_bridge_agent_operation_trace_present"] = (
+        agent_bridge_trace_count > 0
+    )
     prerequisites = plan.setdefault("runner_prerequisites", {})
+    agent_trace_required = (
+        prerequisites.get("remote_command_file_bridge_agent_operation_trace_required")
+        is True
+    )
+    agent_trace_satisfied = bool(
+        (not agent_trace_required)
+        or (
+            agent_bridge_trace_count > 0
+            and agent_bridge_request_count > 0
+        )
+    )
+    if agent_trace_required:
+        if agent_trace_satisfied:
+            agent_trace_status = "agent_operation_trace_recorded"
+        elif agent_bridge_trace_count > 0:
+            agent_trace_status = "agent_operation_trace_present_no_requests"
+        else:
+            agent_trace_status = "agent_operation_trace_missing"
+    else:
+        agent_trace_status = str(
+            prerequisites.get("remote_command_file_bridge_agent_operation_trace_status")
+            or "not_required"
+        )
+    trace["remote_command_file_bridge_agent_command_configured"] = (
+        prerequisites.get("remote_command_file_bridge_agent_command_configured") is True
+    )
+    trace["remote_command_file_bridge_agent_command_instrumented"] = (
+        prerequisites.get("remote_command_file_bridge_agent_command_instrumented")
+        is True
+    )
+    trace["remote_command_file_bridge_agent_operation_trace_required"] = (
+        agent_trace_required
+    )
+    trace["remote_command_file_bridge_agent_operation_trace_satisfied"] = (
+        agent_trace_satisfied
+    )
+    trace["remote_command_file_bridge_agent_operation_trace_status"] = (
+        agent_trace_status
+    )
+    trace["remote_command_file_bridge_agent_request_count"] = (
+        agent_bridge_request_count
+    )
+    trace["remote_command_file_bridge_agent_loopx_cli_call_count"] = (
+        agent_bridge_loopx_cli_call_count
+    )
+    trace["remote_command_file_bridge_agent_loopx_state_read_count"] = (
+        agent_bridge_loopx_state_read_count
+    )
+    trace["remote_command_file_bridge_agent_loopx_state_write_count"] = (
+        agent_bridge_loopx_state_write_count
+    )
+    trace["remote_command_file_bridge_agent_operation_counts"] = dict(
+        sorted(agent_bridge_operation_counts.items())
+    )
+    trace["remote_command_file_bridge_agent_loopx_subcommand_counts"] = dict(
+        sorted(agent_bridge_loopx_subcommand_counts.items())
+    )
+    trace["remote_command_file_bridge_driver_lifecycle_trace_count"] = (
+        driver_lifecycle_trace_count
+    )
+    trace["remote_command_file_bridge_driver_lifecycle_trace_present"] = (
+        driver_lifecycle_trace_count > 0
+    )
+    trace["remote_command_file_bridge_driver_lifecycle_execution_style"] = (
+        driver_lifecycle_execution_style
+    )
+    trace["remote_command_file_bridge_driver_lifecycle_checkpoint_count"] = (
+        driver_lifecycle_checkpoint_count
+    )
+    trace["remote_command_file_bridge_driver_lifecycle_request_count"] = (
+        driver_lifecycle_request_count
+    )
+    trace["remote_command_file_bridge_driver_lifecycle_success_count"] = (
+        driver_lifecycle_success_count
+    )
+    trace["remote_command_file_bridge_driver_lifecycle_failure_count"] = (
+        driver_lifecycle_failure_count
+    )
+    trace["remote_command_file_bridge_driver_lifecycle_loopx_cli_call_count"] = (
+        driver_lifecycle_loopx_cli_call_count
+    )
+    trace["remote_command_file_bridge_driver_lifecycle_loopx_state_read_count"] = (
+        driver_lifecycle_loopx_state_read_count
+    )
+    trace["remote_command_file_bridge_driver_lifecycle_loopx_state_write_count"] = (
+        driver_lifecycle_loopx_state_write_count
+    )
+    trace["remote_command_file_bridge_driver_lifecycle_command_counts"] = dict(
+        sorted(driver_lifecycle_command_counts.items())
+    )
+    trace["remote_command_file_bridge_driver_lifecycle_returncode_counts"] = dict(
+        sorted(driver_lifecycle_returncode_counts.items())
+    )
+    trace["remote_command_file_bridge_driver_lifecycle_raw_material_recorded"] = (
+        raw_material_recorded
+    )
     prerequisites["remote_command_file_bridge_solver_trace_dir_present"] = (
         trace_dir.exists()
     )
@@ -3371,6 +4034,93 @@ def _merge_host_local_acp_relay_trace_summary(
     prerequisites["remote_command_file_bridge_solver_raw_material_recorded"] = (
         raw_material_recorded
     )
+    prerequisites["host_local_acp_codex_exec_failure_trace_count"] = (
+        codex_exec_failure_trace_count
+    )
+    prerequisites["host_local_acp_codex_exec_failure_trace_present"] = (
+        codex_exec_failure_trace_count > 0
+    )
+    prerequisites["host_local_acp_codex_exec_failure_categories"] = (
+        codex_exec_failure_categories
+    )
+    prerequisites["host_local_acp_codex_exec_failure_category"] = (
+        codex_exec_failure_categories[0] if codex_exec_failure_categories else ""
+    )
+    prerequisites["host_local_acp_codex_exec_failure_raw_material_recorded"] = (
+        raw_material_recorded
+    )
+    prerequisites["remote_command_file_bridge_agent_operation_trace_count"] = (
+        agent_bridge_trace_count
+    )
+    prerequisites["remote_command_file_bridge_agent_operation_trace_present"] = (
+        agent_bridge_trace_count > 0
+    )
+    prerequisites["remote_command_file_bridge_agent_operation_trace_required"] = (
+        agent_trace_required
+    )
+    prerequisites["remote_command_file_bridge_agent_operation_trace_satisfied"] = (
+        agent_trace_satisfied
+    )
+    prerequisites["remote_command_file_bridge_agent_operation_trace_status"] = (
+        agent_trace_status
+    )
+    prerequisites["remote_command_file_bridge_agent_request_count"] = (
+        agent_bridge_request_count
+    )
+    prerequisites["remote_command_file_bridge_agent_loopx_cli_call_count"] = (
+        agent_bridge_loopx_cli_call_count
+    )
+    prerequisites["remote_command_file_bridge_agent_loopx_state_read_count"] = (
+        agent_bridge_loopx_state_read_count
+    )
+    prerequisites["remote_command_file_bridge_agent_loopx_state_write_count"] = (
+        agent_bridge_loopx_state_write_count
+    )
+    prerequisites["remote_command_file_bridge_agent_operation_counts"] = dict(
+        sorted(agent_bridge_operation_counts.items())
+    )
+    prerequisites["remote_command_file_bridge_agent_loopx_subcommand_counts"] = dict(
+        sorted(agent_bridge_loopx_subcommand_counts.items())
+    )
+    prerequisites["remote_command_file_bridge_driver_lifecycle_trace_count"] = (
+        driver_lifecycle_trace_count
+    )
+    prerequisites["remote_command_file_bridge_driver_lifecycle_trace_present"] = (
+        driver_lifecycle_trace_count > 0
+    )
+    prerequisites["remote_command_file_bridge_driver_lifecycle_execution_style"] = (
+        driver_lifecycle_execution_style
+    )
+    prerequisites["remote_command_file_bridge_driver_lifecycle_checkpoint_count"] = (
+        driver_lifecycle_checkpoint_count
+    )
+    prerequisites["remote_command_file_bridge_driver_lifecycle_request_count"] = (
+        driver_lifecycle_request_count
+    )
+    prerequisites["remote_command_file_bridge_driver_lifecycle_success_count"] = (
+        driver_lifecycle_success_count
+    )
+    prerequisites["remote_command_file_bridge_driver_lifecycle_failure_count"] = (
+        driver_lifecycle_failure_count
+    )
+    prerequisites[
+        "remote_command_file_bridge_driver_lifecycle_loopx_cli_call_count"
+    ] = driver_lifecycle_loopx_cli_call_count
+    prerequisites[
+        "remote_command_file_bridge_driver_lifecycle_loopx_state_read_count"
+    ] = driver_lifecycle_loopx_state_read_count
+    prerequisites[
+        "remote_command_file_bridge_driver_lifecycle_loopx_state_write_count"
+    ] = driver_lifecycle_loopx_state_write_count
+    prerequisites["remote_command_file_bridge_driver_lifecycle_command_counts"] = (
+        dict(sorted(driver_lifecycle_command_counts.items()))
+    )
+    prerequisites[
+        "remote_command_file_bridge_driver_lifecycle_returncode_counts"
+    ] = dict(sorted(driver_lifecycle_returncode_counts.items()))
+    prerequisites[
+        "remote_command_file_bridge_driver_lifecycle_raw_material_recorded"
+    ] = raw_material_recorded
     if consumed_by_solver:
         prerequisites["remote_command_file_bridge_consumption_status"] = (
             "solver_prompt_probe_ready"
@@ -3626,6 +4376,19 @@ def _record_product_mode_no_tool_call_lifecycle_abort(
     if not isinstance(current, int) or isinstance(current, bool):
         current = 0
     trace["product_mode_no_tool_call_lifecycle_abort_count"] = current + 1
+
+
+def _record_product_mode_no_lifecycle_request_abort(
+    trace: dict[str, Any],
+    *,
+    agent_round: int,
+) -> None:
+    trace["product_mode_no_lifecycle_request_abort"] = True
+    trace["product_mode_no_lifecycle_request_abort_round"] = agent_round
+    current = trace.get("product_mode_no_lifecycle_request_abort_count")
+    if not isinstance(current, int) or isinstance(current, bool):
+        current = 0
+    trace["product_mode_no_lifecycle_request_abort_count"] = current + 1
 
 
 def _trajectory_candidate_paths(plan: dict[str, Any]) -> list[Path]:
@@ -3919,7 +4682,11 @@ def _build_product_mode_user(
             f"LoopX is initialized before the agent starts. Active state: "
             f"`{case_state_path}`. This is the only formal treatment "
             "lifecycle; runner polling is only the outer transport. Before "
-            "planning, run "
+            "planning, run the following commands inside the scored sandbox. "
+            "If a LoopX SkillsBench remote workspace bridge packet is present, "
+            "invoke that private JSON bridge from your shell tool and send each "
+            "command as an `operation=exec` request with `cwd=/app`; do not try "
+            "to run `/app/...` commands directly in the host-local temp cwd. "
             f"`{case_cli_prefix} quota should-run --goal-id {case_goal_id} "
             f"--agent-id {case_agent_id}` and claim the selected case todo "
             f"with `{case_cli_prefix} todo claim --goal-id {case_goal_id} "
@@ -3996,24 +4763,43 @@ def _build_product_mode_user(
                 _inc_counter(trace, "official_feedback_blinded_count")
                 if treatment:
                     _merge_acp_trajectory_summary(plan or {}, trace)
+                    _merge_host_local_acp_relay_trace_summary(plan or {}, trace)
+                    no_tool_calls = _round_result_tool_call_count(round_result) == 0
+                    no_lifecycle_requests = (
+                        trace.get(
+                            "remote_command_file_bridge_agent_operation_trace_status"
+                        )
+                        == "agent_operation_trace_present_no_requests"
+                    )
                     if (
-                        _round_result_tool_call_count(round_result) == 0
+                        (no_tool_calls or no_lifecycle_requests)
                         and not _product_mode_depth_gate_satisfied(trace)
                     ):
                         _record_product_mode_lifecycle_checkpoint_gap(
                             trace,
                             agent_round=round,
                         )
-                        _record_product_mode_no_tool_call_lifecycle_abort(
-                            trace,
-                            agent_round=round,
-                        )
+                        if no_tool_calls:
+                            _record_product_mode_no_tool_call_lifecycle_abort(
+                                trace,
+                                agent_round=round,
+                            )
+                        if no_lifecycle_requests:
+                            _record_product_mode_no_lifecycle_request_abort(
+                                trace,
+                                agent_round=round,
+                            )
                         _inc_counter(trace, "controller_action_decisions")
                         _inc_counter(trace, "stop_decision_count")
                         trace["last_decision"] = (
-                            "stop_after_product_mode_no_tool_calls_without_lifecycle"
+                            "stop_after_product_mode_agent_no_lifecycle_requests"
+                            if no_lifecycle_requests
+                            else "stop_after_product_mode_no_tool_calls_without_lifecycle"
                         )
-                        return None
+                        raise SkillsBenchProductModeNoLifecycleRequests(
+                            "loopx-product-mode agent produced no case-local "
+                            "LoopX lifecycle request before official verifier"
+                        )
                 if _round_result_declared_done(round_result):
                     if treatment:
                         if not _product_mode_depth_gate_satisfied(trace):
@@ -5024,6 +5810,7 @@ def build_runner_failure_compact(
     from loopx.status import compact_benchmark_run
 
     plan.setdefault("runner_prerequisites", {})
+    _ensure_runner_interruption_prerequisites(plan, exc)
     _ensure_setup_stall_timeout_prerequisites(
         args,
         plan,
@@ -5250,6 +6037,45 @@ def append_history(args: argparse.Namespace, compact_path: Path) -> dict[str, An
         "registry_exists": registry_exists,
         "raw_cli_output_recorded": False,
     }
+
+
+def _build_runner_exception_closeout_payload(
+    args: argparse.Namespace,
+    plan: dict[str, Any],
+    exc: BaseException,
+) -> tuple[dict[str, Any], int]:
+    recovered_payload = reduce_official_result_after_runner_exception(args, plan, exc)
+    if recovered_payload is not None:
+        return recovered_payload, 0
+
+    closeout_recorded = False
+    try:
+        compact = build_runner_failure_compact(args, plan, exc)
+        compact_path = Path(plan["compact_benchmark_run_json"])
+        compact_path.parent.mkdir(parents=True, exist_ok=True)
+        compact_path.write_text(
+            json.dumps(compact, indent=2, sort_keys=True, default=_json_default)
+            + "\n",
+            encoding="utf-8",
+        )
+        ledger_update = update_ledger(args, compact, compact_path=compact_path)
+        history_append = append_history(args, compact_path)
+        closeout_recorded = True
+    except Exception:
+        compact_path = None
+        ledger_update = None
+        history_append = None
+    payload = {
+        "ok": False,
+        "error_type": type(exc).__name__,
+        "error_recorded": closeout_recorded,
+        "compact_closeout_recorded": closeout_recorded,
+        "task_id": args.task_id,
+        "compact_benchmark_run_json": str(compact_path) if compact_path else None,
+        "ledger_update": ledger_update,
+        "history_append": history_append,
+    }
+    return payload, 0 if closeout_recorded else 1
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
@@ -5529,6 +6355,31 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--host-local-acp-codex-exec-preflight",
+        action="store_true",
+        help=(
+            "Before a full host-local ACP task launch, run a task-free relay "
+            "prompt through the configured local Codex exec command. Use this "
+            "for remote reverse-channel product-mode runs so a missing Codex "
+            "reverse server fails before BenchFlow starts a scored case."
+        ),
+    )
+    parser.add_argument(
+        "--host-local-acp-codex-exec-preflight-timeout-sec",
+        type=float,
+        default=120.0,
+        help="Timeout for --host-local-acp-codex-exec-preflight.",
+    )
+    parser.add_argument(
+        "--host-local-acp-codex-exec-preflight-attempts",
+        type=int,
+        default=3,
+        help=(
+            "Number of task-free Codex exec preflight attempts. Retries are "
+            "only useful for transient reverse-channel readiness races."
+        ),
+    )
+    parser.add_argument(
         "--benchflow-agent-runtime-dir",
         default=None,
         help=(
@@ -5580,6 +6431,27 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
             "to operate on the scored SkillsBench sandbox. This is separate from "
             "the public-safe probe command; fixture-only probe helpers must not "
             "be used here."
+        ),
+    )
+    parser.add_argument(
+        "--remote-command-file-bridge-agent-command",
+        default=None,
+        help=(
+            "Optional private command injected into the local Codex solver "
+            "prompt when --remote-command-file-bridge-solver-command is only "
+            "valid from the remote relay host. The command text is never "
+            "written to public compact traces."
+        ),
+    )
+    parser.add_argument(
+        "--remote-command-file-bridge-agent-command-instrumented",
+        action="store_true",
+        help=(
+            "Compatibility declaration for externally instrumented agent bridge "
+            "commands. The host-local relay still wraps explicit agent bridge "
+            "commands with its own public-safe operation counter; countable "
+            "product-mode treatment continues to require nonzero agent lifecycle "
+            "requests, not only driver checkpoints."
         ),
     )
     parser.add_argument(
@@ -5655,6 +6527,13 @@ async def async_main(
             "skillsbench apt setup risk preflight blocked: "
             "apt-based Docker setup risk detected before full case run"
         )
+
+    if (
+        args.host_local_acp_codex_exec_preflight
+        and args.host_local_acp_launch
+        and not args.reduce_only
+    ):
+        _run_host_local_acp_codex_exec_preflight(args, plan)
 
     ensure_benchflow_runtime(args)
     if args.reduce_only:
@@ -5895,50 +6774,45 @@ def main(argv: list[str] | None = None) -> int:
         )
         print(json.dumps(payload, indent=2, sort_keys=True, default=_json_default))
         return 0
-    closeout_recorded = False
     if args.run_group_id is None:
         args.run_group_id = (
             f"skillsbench-{args.task_id}-{args.route}-{_now_stamp()}"
         )
     plan = build_plan(args)
+    previous_sigterm_handler = signal.getsignal(signal.SIGTERM)
+
+    def _closeout_sigterm_handler(signum: int, frame: Any) -> None:
+        raise SkillsBenchRunnerInterrupted(
+            "skillsbench_runner_received_sigterm_before_official_result"
+        )
+
+    signal.signal(signal.SIGTERM, _closeout_sigterm_handler)
     try:
         payload = asyncio.run(async_main(args, plan=plan))
-    except Exception as exc:
-        recovered_payload = reduce_official_result_after_runner_exception(
+    except (KeyboardInterrupt, SkillsBenchRunnerInterrupted) as exc:
+        payload, returncode = _build_runner_exception_closeout_payload(
             args, plan, exc
         )
-        if recovered_payload is not None:
-            print(json.dumps(recovered_payload, indent=2, sort_keys=True))
-            return 0
-        try:
-            compact = build_runner_failure_compact(args, plan, exc)
-            compact_path = Path(plan["compact_benchmark_run_json"])
-            compact_path.parent.mkdir(parents=True, exist_ok=True)
-            compact_path.write_text(
-                json.dumps(compact, indent=2, sort_keys=True, default=_json_default)
-                + "\n",
-                encoding="utf-8",
-            )
-            ledger_update = update_ledger(args, compact, compact_path=compact_path)
-            history_append = append_history(args, compact_path)
-            closeout_recorded = True
-        except Exception:
-            compact = None
-            compact_path = None
-            ledger_update = None
-            history_append = None
-        payload = {
-            "ok": False,
-            "error_type": type(exc).__name__,
-            "error_recorded": closeout_recorded,
-            "compact_closeout_recorded": closeout_recorded,
-            "task_id": args.task_id,
-            "compact_benchmark_run_json": str(compact_path) if compact_path else None,
-            "ledger_update": ledger_update,
-            "history_append": history_append,
-        }
-        print(json.dumps(payload, indent=2, sort_keys=True), file=sys.stderr)
-        return 0 if closeout_recorded else 1
+        output_stream = (
+            sys.stdout
+            if payload.get("recovered_after_runner_exception") is True
+            else sys.stderr
+        )
+        print(json.dumps(payload, indent=2, sort_keys=True), file=output_stream)
+        return returncode
+    except Exception as exc:
+        payload, returncode = _build_runner_exception_closeout_payload(
+            args, plan, exc
+        )
+        output_stream = (
+            sys.stdout
+            if payload.get("recovered_after_runner_exception") is True
+            else sys.stderr
+        )
+        print(json.dumps(payload, indent=2, sort_keys=True), file=output_stream)
+        return returncode
+    finally:
+        signal.signal(signal.SIGTERM, previous_sigterm_handler)
     print(json.dumps(payload, indent=2, sort_keys=True, default=_json_default))
     return 0
 

--- a/scripts/skillsbench_local_acp_relay.py
+++ b/scripts/skillsbench_local_acp_relay.py
@@ -16,6 +16,7 @@ from loopx.benchmark_adapters.skillsbench_acp_relay import (  # noqa: E402
     CodexExecConfig,
     SkillsBenchLocalAcpRelay,
 )
+from loopx.benchmark_case_state import BENCHMARK_CASE_LOOPX_TODO_ID  # noqa: E402
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
@@ -107,10 +108,17 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "--remote-command-file-bridge-command",
         default=None,
         help=(
-            "Private command used by host-local ACP product-mode runs to reach "
-            "the scored SkillsBench sandbox through a bounded command/file "
-            "bridge. The command is injected only into the private solver "
-            "prompt and is never written to public compact traces."
+            "Private command used by the relay/driver to reach the scored "
+            "SkillsBench sandbox through a bounded command/file bridge."
+        ),
+    )
+    parser.add_argument(
+        "--remote-command-file-bridge-agent-command",
+        default=None,
+        help=(
+            "Optional bridge command injected into the private local Codex "
+            "prompt. Use this when the relay runs remotely but Codex exec runs "
+            "on the controller host through a reverse channel."
         ),
     )
     parser.add_argument(
@@ -119,6 +127,21 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         default=10.0,
         help="Timeout for the per-prompt remote command/file bridge readiness probe.",
     )
+    parser.add_argument(
+        "--loopx-workflow-lifecycle-checkpoint",
+        action="store_true",
+        help=(
+            "For loopx-product-mode host-local ACP runs, execute a public-safe "
+            "workflow-style case-local LoopX quota/todo/refresh checkpoint "
+            "through the remote bridge before each Codex prompt."
+        ),
+    )
+    parser.add_argument("--loopx-case-goal-id", default="skillsbench-case")
+    parser.add_argument("--loopx-case-agent-id", default="codex-benchmark-agent")
+    parser.add_argument("--loopx-case-todo-id", default=BENCHMARK_CASE_LOOPX_TODO_ID)
+    parser.add_argument("--loopx-case-cli-path", default="/app/.local/bin/loopx")
+    parser.add_argument("--loopx-case-registry-path", default="/app/.loopx/registry.json")
+    parser.add_argument("--loopx-case-runtime-root", default="/app/.loopx/runtime")
     return parser.parse_args(argv)
 
 
@@ -144,9 +167,21 @@ def main(argv: list[str] | None = None) -> int:
             remote_command_file_bridge_command=(
                 args.remote_command_file_bridge_command
             ),
+            remote_command_file_bridge_agent_command=(
+                args.remote_command_file_bridge_agent_command
+            ),
             remote_command_file_bridge_timeout_sec=(
                 args.remote_command_file_bridge_timeout_sec
             ),
+            loopx_workflow_lifecycle_checkpoint=(
+                args.loopx_workflow_lifecycle_checkpoint
+            ),
+            loopx_case_goal_id=args.loopx_case_goal_id,
+            loopx_case_agent_id=args.loopx_case_agent_id,
+            loopx_case_todo_id=args.loopx_case_todo_id,
+            loopx_case_cli_path=args.loopx_case_cli_path,
+            loopx_case_registry_path=args.loopx_case_registry_path,
+            loopx_case_runtime_root=args.loopx_case_runtime_root,
         )
     )
     return relay.serve()

--- a/scripts/skillsbench_reverse_channel_bridge.py
+++ b/scripts/skillsbench_reverse_channel_bridge.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+"""Serve restartable SkillsBench reverse-channel bridge endpoints.
+
+The split-control SkillsBench route sometimes needs a remote benchmark host to
+call back into a local Codex CLI.  This helper keeps that bridge explicit and
+testable: client wrappers speak one JSON line over a Unix socket, while local
+servers execute Codex or a sandbox JSON bridge without recording raw task data.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import socket
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+CLIENT_SCHEMA_VERSION = "skillsbench_reverse_channel_client_v0"
+SERVER_RESPONSE_SCHEMA_VERSION = "skillsbench_reverse_channel_response_v0"
+SOCKET_PROBE_SCHEMA_VERSION = "skillsbench_reverse_channel_socket_probe_v0"
+
+
+def _send_json_line(sock: socket.socket, payload: dict[str, Any]) -> None:
+    sock.sendall(json.dumps(payload, separators=(",", ":")).encode() + b"\n")
+
+
+def _recv_json_line(conn: socket.socket) -> dict[str, Any]:
+    data = b""
+    while not data.endswith(b"\n"):
+        chunk = conn.recv(65536)
+        if not chunk:
+            break
+        data += chunk
+    if not data:
+        return {}
+    return json.loads(data.decode("utf-8"))
+
+
+def _safe_env(extra: object) -> dict[str, str]:
+    env = os.environ.copy()
+    if isinstance(extra, dict):
+        for key, value in extra.items():
+            if not isinstance(key, str):
+                continue
+            if key in {"AI_ADDR", "AI_PORT", "GOAL_HARNESS_REMOTE_BENCH_ROOT"}:
+                env[key] = str(value)
+    return env
+
+
+def _replace_output_last_message(args: list[str], replacement: Path) -> str | None:
+    for index, token in enumerate(args[:-1]):
+        if token == "--output-last-message":
+            original = args[index + 1]
+            args[index + 1] = str(replacement)
+            return original
+    return None
+
+
+def _replace_remote_cwd(args: list[str], replacement: Path) -> str | None:
+    for index, token in enumerate(args[:-1]):
+        if token in {"-C", "--cwd"}:
+            original = args[index + 1]
+            args[index + 1] = str(replacement)
+            return original
+    return None
+
+
+def _rewrite_private_bridge_command(prompt: str, replacement: str | None) -> str:
+    if not replacement:
+        return prompt
+    pattern = r"(Private bridge command:\n)([^\n]+)"
+    return re.sub(pattern, r"\1" + replacement, prompt, count=1)
+
+
+def _run_codex_payload(
+    payload: dict[str, Any],
+    *,
+    codex_bin: str,
+    default_timeout_sec: float,
+    prompt_bridge_command: str | None,
+) -> dict[str, Any]:
+    args = [str(item) for item in payload.get("args") or []]
+    if not args:
+        args = ["exec", "--help"]
+    if args and args[0] == "exec":
+        args[0] = "exec"
+    timeout = payload.get("timeout_sec")
+    if not isinstance(timeout, (int, float)) or isinstance(timeout, bool):
+        timeout = default_timeout_sec
+    timeout = max(1.0, min(float(timeout), max(float(default_timeout_sec), 1.0)))
+    env = _safe_env(payload.get("env"))
+    with tempfile.TemporaryDirectory(prefix="loopx-reverse-codex-") as tmp:
+        tmp_path = Path(tmp)
+        last_message_path = tmp_path / "last-message.txt"
+        local_cwd = tmp_path / "cwd"
+        local_cwd.mkdir(parents=True, exist_ok=True)
+        remote_last_message_path = _replace_output_last_message(args, last_message_path)
+        _replace_remote_cwd(args, local_cwd)
+        if prompt_bridge_command and args:
+            args[-1] = _rewrite_private_bridge_command(args[-1], prompt_bridge_command)
+        cmd = [codex_bin, *args]
+        try:
+            proc = subprocess.run(
+                cmd,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=timeout,
+                check=False,
+                env=env,
+            )
+            try:
+                last_message = last_message_path.read_text(encoding="utf-8")
+            except OSError:
+                last_message = ""
+            return {
+                "schema_version": SERVER_RESPONSE_SCHEMA_VERSION,
+                "exit_code": int(proc.returncode),
+                "stdout": proc.stdout or "",
+                "stderr": proc.stderr or "",
+                "last_message": last_message,
+                "remote_last_message_path": remote_last_message_path,
+                "raw_task_text_recorded": False,
+                "credential_values_recorded": False,
+            }
+        except subprocess.TimeoutExpired as exc:
+            stdout = exc.stdout if isinstance(exc.stdout, str) else ""
+            stderr = exc.stderr if isinstance(exc.stderr, str) else ""
+            return {
+                "schema_version": SERVER_RESPONSE_SCHEMA_VERSION,
+                "exit_code": 124,
+                "stdout": stdout,
+                "stderr": stderr,
+                "last_message": "",
+                "remote_last_message_path": remote_last_message_path,
+                "raw_task_text_recorded": False,
+                "credential_values_recorded": False,
+            }
+
+
+def _run_json_bridge_payload(
+    payload: dict[str, Any],
+    *,
+    bridge_command: str,
+    default_timeout_sec: float,
+) -> dict[str, Any]:
+    timeout = max(1.0, float(default_timeout_sec))
+    stdin_text = str(payload.get("stdin") or "")
+    env = _safe_env(payload.get("env"))
+    try:
+        proc = subprocess.run(
+            bridge_command,
+            input=stdin_text,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            shell=True,
+            timeout=timeout,
+            check=False,
+            env=env,
+        )
+        return {
+            "schema_version": SERVER_RESPONSE_SCHEMA_VERSION,
+            "exit_code": int(proc.returncode),
+            "stdout": proc.stdout or "",
+            "stderr": proc.stderr or "",
+            "raw_stdout_recorded": False,
+            "raw_stderr_recorded": False,
+            "credential_values_recorded": False,
+        }
+    except subprocess.TimeoutExpired as exc:
+        stdout = exc.stdout if isinstance(exc.stdout, str) else ""
+        stderr = exc.stderr if isinstance(exc.stderr, str) else ""
+        return {
+            "schema_version": SERVER_RESPONSE_SCHEMA_VERSION,
+            "exit_code": 124,
+            "stdout": stdout,
+            "stderr": stderr,
+            "raw_stdout_recorded": False,
+            "raw_stderr_recorded": False,
+            "credential_values_recorded": False,
+        }
+
+
+def _serve_socket(
+    socket_path: Path,
+    *,
+    once: bool,
+    handler: Any,
+) -> int:
+    socket_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        socket_path.unlink()
+    except FileNotFoundError:
+        pass
+    server = socket.socket(socket.AF_UNIX)
+    server.bind(str(socket_path))
+    socket_path.chmod(0o600)
+    server.listen(8)
+    try:
+        while True:
+            conn, _ = server.accept()
+            with conn:
+                try:
+                    payload = _recv_json_line(conn)
+                    response = handler(payload)
+                except Exception as exc:  # keep client deterministic
+                    response = {
+                        "schema_version": SERVER_RESPONSE_SCHEMA_VERSION,
+                        "exit_code": 1,
+                        "stdout": "",
+                        "stderr": type(exc).__name__,
+                        "raw_task_text_recorded": False,
+                        "credential_values_recorded": False,
+                    }
+                _send_json_line(conn, response)
+            if once:
+                return 0
+    finally:
+        server.close()
+        try:
+            socket_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _write_codex_client(socket_path: str, output_path: Path) -> None:
+    script = f"""#!/usr/bin/env python3
+import json, os, socket, sys
+SOCK = {socket_path!r}
+payload = {{
+    'schema_version': {CLIENT_SCHEMA_VERSION!r},
+    'args': sys.argv[1:],
+    'env': {{k: os.environ.get(k, '') for k in ('AI_ADDR','AI_PORT','GOAL_HARNESS_REMOTE_BENCH_ROOT')}},
+    'timeout_sec': float(os.environ.get('LOOPX_REVERSE_CODEX_TIMEOUT_SEC', '7200')),
+}}
+s=socket.socket(socket.AF_UNIX)
+s.settimeout(float(os.environ.get('LOOPX_REVERSE_CONNECT_TIMEOUT_SEC', '30')))
+s.connect(SOCK)
+s.sendall(json.dumps(payload).encode()+b'\\n')
+data=b''
+while not data.endswith(b'\\n'):
+    chunk=s.recv(65536)
+    if not chunk:
+        break
+    data += chunk
+resp=json.loads(data.decode() or '{{}}')
+out=resp.get('stdout')
+err=resp.get('stderr')
+if isinstance(out, str): sys.stdout.write(out)
+if isinstance(err, str): sys.stderr.write(err)
+last=resp.get('last_message')
+remote_path=resp.get('remote_last_message_path')
+if isinstance(last, str) and isinstance(remote_path, str) and remote_path:
+    os.makedirs(os.path.dirname(remote_path) or '.', exist_ok=True)
+    with open(remote_path, 'w', encoding='utf-8') as fh:
+        fh.write(last)
+sys.exit(int(resp.get('exit_code') or 0))
+"""
+    output_path.write_text(script, encoding="utf-8")
+    output_path.chmod(0o700)
+
+
+def _write_json_client(socket_path: str, output_path: Path) -> None:
+    script = f"""#!/usr/bin/env python3
+import json, os, socket, sys
+SOCK = {socket_path!r}
+payload = {{
+    'schema_version': {CLIENT_SCHEMA_VERSION!r},
+    'stdin': sys.stdin.read(),
+    'env': {{k: os.environ.get(k, '') for k in ('AI_ADDR','AI_PORT','GOAL_HARNESS_REMOTE_BENCH_ROOT')}},
+}}
+s=socket.socket(socket.AF_UNIX)
+s.settimeout(float(os.environ.get('LOOPX_REVERSE_CONNECT_TIMEOUT_SEC', '30')))
+s.connect(SOCK)
+s.sendall(json.dumps(payload).encode()+b'\\n')
+data=b''
+while not data.endswith(b'\\n'):
+    chunk=s.recv(65536)
+    if not chunk:
+        break
+    data += chunk
+resp=json.loads(data.decode() or '{{}}')
+out=resp.get('stdout')
+err=resp.get('stderr')
+if isinstance(out, str): sys.stdout.write(out)
+if isinstance(err, str): sys.stderr.write(err)
+sys.exit(int(resp.get('exit_code') or 0))
+"""
+    output_path.write_text(script, encoding="utf-8")
+    output_path.chmod(0o700)
+
+
+def _probe_socket(socket_path: Path, *, timeout_sec: float) -> dict[str, Any]:
+    sock = socket.socket(socket.AF_UNIX)
+    sock.settimeout(timeout_sec)
+    try:
+        sock.connect(str(socket_path))
+        return {
+            "schema_version": SOCKET_PROBE_SCHEMA_VERSION,
+            "ready": True,
+            "first_blocker": "skillsbench_reverse_channel_socket_ready",
+            "raw_output_recorded": False,
+            "credential_values_recorded": False,
+        }
+    except FileNotFoundError:
+        blocker = "skillsbench_reverse_channel_socket_missing"
+    except ConnectionRefusedError:
+        blocker = "skillsbench_reverse_channel_socket_orphaned"
+    except TimeoutError:
+        blocker = "skillsbench_reverse_channel_socket_timeout"
+    except OSError:
+        blocker = "skillsbench_reverse_channel_socket_connect_failed"
+    finally:
+        sock.close()
+    return {
+        "schema_version": SOCKET_PROBE_SCHEMA_VERSION,
+        "ready": False,
+        "first_blocker": blocker,
+        "raw_output_recorded": False,
+        "credential_values_recorded": False,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    codex_server = sub.add_parser("serve-codex")
+    codex_server.add_argument("--socket", required=True)
+    codex_server.add_argument("--codex-bin", default="codex")
+    codex_server.add_argument("--timeout-sec", type=float, default=7200.0)
+    codex_server.add_argument("--prompt-bridge-command")
+    codex_server.add_argument("--once", action="store_true")
+
+    json_server = sub.add_parser("serve-json")
+    json_server.add_argument("--socket", required=True)
+    json_server.add_argument("--bridge-command", required=True)
+    json_server.add_argument("--timeout-sec", type=float, default=300.0)
+    json_server.add_argument("--once", action="store_true")
+
+    write_client = sub.add_parser("write-client")
+    write_client.add_argument("--kind", choices=("codex", "json"), required=True)
+    write_client.add_argument("--socket", required=True)
+    write_client.add_argument("--output", required=True)
+
+    probe = sub.add_parser("probe-socket")
+    probe.add_argument("--socket", required=True)
+    probe.add_argument("--timeout-sec", type=float, default=3.0)
+
+    args = parser.parse_args(argv)
+    if args.command == "serve-codex":
+        return _serve_socket(
+            Path(args.socket),
+            once=bool(args.once),
+            handler=lambda payload: _run_codex_payload(
+                payload,
+                codex_bin=args.codex_bin,
+                default_timeout_sec=args.timeout_sec,
+                prompt_bridge_command=args.prompt_bridge_command,
+            ),
+        )
+    if args.command == "serve-json":
+        return _serve_socket(
+            Path(args.socket),
+            once=bool(args.once),
+            handler=lambda payload: _run_json_bridge_payload(
+                payload,
+                bridge_command=args.bridge_command,
+                default_timeout_sec=args.timeout_sec,
+            ),
+        )
+    if args.command == "write-client":
+        output = Path(args.output)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        if args.kind == "codex":
+            _write_codex_client(args.socket, output)
+        else:
+            _write_json_client(args.socket, output)
+        print(json.dumps({"ok": True, "kind": args.kind, "raw_path_recorded": False}))
+        return 0
+    if args.command == "probe-socket":
+        print(json.dumps(_probe_socket(Path(args.socket), timeout_sec=args.timeout_sec), sort_keys=True))
+        return 0
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add public-safe SkillsBench/LoopX lifecycle counters for host-local ACP and product-mode runs, including solver consumption, agent operation traces, bridge checkpoints, and case-local state IO.
- Fail closed/reroute runs that have no agent request, no tool IO, no state IO, or reverse-channel/Codex transport failure evidence instead of letting them look like normal product-mode attempts.
- Add a restartable reverse-channel helper for remote SkillsBench runs where the worker must call back into local Codex/JSON bridge wrappers.

## Commit split
1. `Add SkillsBench lifecycle bridge counters`: runtime/adapter/status/ledger behavior plus durable public smokes.
2. `Add restartable SkillsBench reverse bridge helper`: isolated helper and smoke, split so reviewers can judge the extra bridge surface independently.

## Validation
- `python3 -m py_compile scripts/skillsbench_automation_loop.py scripts/skillsbench_local_acp_relay.py scripts/skillsbench_reverse_channel_bridge.py loopx/benchmark_adapters/skillsbench.py loopx/benchmark_adapters/skillsbench_acp_relay.py loopx/benchmark_core/loop_protocol.py loopx/benchmark_ledger.py loopx/status.py examples/skillsbench-reverse-channel-bridge-smoke.py examples/skillsbench-benchmark-run-smoke.py examples/skillsbench-host-local-launch-plan-smoke.py examples/benchmark-run-ledger-smoke.py examples/benchmark-loop-protocol-smoke.py`
- `python3 examples/skillsbench-reverse-channel-bridge-smoke.py`
- `python3 examples/skillsbench-host-local-launch-plan-smoke.py`
- `python3 examples/skillsbench-benchmark-run-smoke.py`
- `python3 examples/benchmark-run-ledger-smoke.py`
- `python3 examples/benchmark-loop-protocol-smoke.py`
- `git diff --check HEAD~2..HEAD`

## Boundary notes
- Excludes `.local`, raw benchmark logs, raw trajectories, verifier output, credentials, patch backups, and private job artifacts.
- Private-boundary scan only found expected public fixtures/env variable names such as fake `/Users/example` paths, forbidden-string assertions, `.local` default work roots, and `AI_ADDR`/`AI_PORT` variable names.

## Next verification
- Run one recently successful SkillsBench case on the updated remote runner and require compact counters to show solver consumed, nonzero agent request/tool evidence, and nonzero case-local LoopX state read/write before expanding to more cases.
