### PR TITLE
Expose SkillsBench bridge failure counters

### DIFF
--- a/examples/skillsbench-host-local-launch-plan-smoke.py
+++ b/examples/skillsbench-host-local-launch-plan-smoke.py
@@ -17,6 +17,8 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.benchmark_adapters.skillsbench_acp_relay import (  # noqa: E402
+    CodexExecConfig,
+    SkillsBenchLocalAcpRelay,
     run_skillsbench_local_acp_relay_probe,
 )
 from scripts.skillsbench_automation_loop import (  # noqa: E402
@@ -463,6 +465,12 @@ output.write_text("fake solver saw bridge packet\\n", encoding="utf-8")
         assert bridge["consumed_by_solver"] is True
         assert bridge["probe_ready"] is True
         assert bridge["operation_count"] >= 4
+        assert bridge["missing_operations"] == []
+        assert bridge["failed_operations"] == []
+        assert bridge["boundary_violations"] == []
+        assert isinstance(bridge["operations"], list)
+        assert bridge["operations"], bridge
+        assert all("kind" in operation for operation in bridge["operations"])
         assert bridge["bridge_command_recorded"] is False
         boundary = bridge_trace["boundary"]
         assert boundary["raw_command_recorded"] is False
@@ -575,6 +583,65 @@ output.write_text("fake solver saw bridge packet\\n", encoding="utf-8")
             ]
             == "solver_prompt_probe_ready"
         )
+        bridge_failure_projection_dir = Path(tmp) / "bridge-failure-projection"
+        bridge_failure_relay = SkillsBenchLocalAcpRelay(
+            CodexExecConfig(
+                route="loopx-product-mode",
+                dataset="skillsbench-v1.1",
+                task_id="demo-task",
+                worker_public_trace_dir=str(bridge_failure_projection_dir),
+            )
+        )
+        bridge_failure_relay._publish_remote_bridge_consumption_trace(
+            {
+                "ready": False,
+                "first_blocker": (
+                    "skillsbench_remote_command_file_bridge_operation_failed"
+                ),
+                "stage": "probe",
+                "response_schema_version": (
+                    "skillsbench_remote_command_file_bridge_probe_response_v0"
+                ),
+                "elapsed_ms": 1234,
+                "operation_count": 4,
+                "required_operations": [
+                    "exec",
+                    "write_file",
+                    "read_file",
+                    "cleanup",
+                ],
+                "missing_operations": [],
+                "failed_operations": ["read_file"],
+                "boundary_violations": [],
+                "operations": [
+                    {"kind": "exec", "label": "exec", "status": "ok"},
+                    {
+                        "kind": "read_file",
+                        "label": "read_file",
+                        "status": "failed",
+                        "content_match": False,
+                    },
+                ],
+                "bridge_command_invoked": True,
+                "raw_command_recorded": False,
+                "raw_stdout_recorded": False,
+                "raw_stderr_recorded": False,
+                "raw_task_text_recorded": False,
+            }
+        )
+        bridge_failure_trace_path = next(
+            bridge_failure_projection_dir.glob("*.compact.json")
+        )
+        bridge_failure_trace = json.loads(
+            bridge_failure_trace_path.read_text(encoding="utf-8")
+        )
+        bridge_failure = bridge_failure_trace["remote_command_file_bridge"]
+        assert bridge_failure["probe_ready"] is False
+        assert bridge_failure["failed_operations"] == ["read_file"]
+        assert bridge_failure["operations"][1]["status"] == "failed"
+        assert bridge_failure["operations"][1]["content_match"] is False
+        assert bridge_failure["bridge_command_recorded"] is False
+        assert bridge_failure_trace["boundary"]["raw_stdout_recorded"] is False
         failing_codex = Path(tmp) / "failing-codex"
         failing_codex.write_text(
             """#!/usr/bin/env python3

--- a/examples/skillsbench-reverse-channel-bridge-smoke.py
+++ b/examples/skillsbench-reverse-channel-bridge-smoke.py
@@ -34,7 +34,7 @@ def test_codex_client_writes_last_message_and_rewrites_bridge() -> None:
         prompt_dump = root / "prompt.txt"
         fake_codex.write_text(
             f"""#!/usr/bin/env python3
-import os, sys
+import os, sys, time
 from pathlib import Path
 
 args = sys.argv[1:]
@@ -44,6 +44,7 @@ if stdin_text:
 prompt = args[-1]
 Path({str(prompt_dump)!r}).write_text(prompt, encoding='utf-8')
 out = Path(args[args.index('--output-last-message') + 1])
+time.sleep(0.35)
 out.write_text('LOOPX_REVERSE_READY\\n', encoding='utf-8')
 print('codex stdout ok')
 print('codex stderr ok', file=sys.stderr)
@@ -92,6 +93,9 @@ print('codex stderr ok', file=sys.stderr)
             )
             remote_last = root / "remote-last-message.txt"
             prompt = "Private bridge command:\n/remote/tmp/bridge\n\nTask"
+            env = os.environ.copy()
+            env["LOOPX_REVERSE_CONNECT_TIMEOUT_SEC"] = "0.1"
+            env["LOOPX_REVERSE_RESPONSE_TIMEOUT_SEC"] = "5"
             proc = subprocess.run(
                 [
                     str(client),
@@ -108,6 +112,7 @@ print('codex stderr ok', file=sys.stderr)
                     prompt,
                 ],
                 check=False,
+                env=env,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
@@ -129,8 +134,9 @@ def test_json_client_forwards_stdin_to_bridge_command() -> None:
         fake_bridge = root / "fake-json-bridge"
         fake_bridge.write_text(
             """#!/usr/bin/env python3
-import json, sys
+import json, sys, time
 payload = json.loads(sys.stdin.read() or '{}')
+time.sleep(0.35)
 print(json.dumps({
     'ok': True,
     'operation': payload.get('operation'),
@@ -177,10 +183,14 @@ print(json.dumps({
                 stderr=subprocess.PIPE,
                 text=True,
             )
+            env = os.environ.copy()
+            env["LOOPX_REVERSE_CONNECT_TIMEOUT_SEC"] = "0.1"
+            env["LOOPX_REVERSE_RESPONSE_TIMEOUT_SEC"] = "5"
             proc = subprocess.run(
                 [str(client)],
                 input=json.dumps({"operation": "exec", "cwd": "/app"}),
                 check=False,
+                env=env,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -70,6 +70,47 @@ def _safe_cwd(value: Any, *, default: str) -> str:
     return text or default
 
 
+def _public_bridge_label(value: Any, *, limit: int = 120) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    text = text.replace("/", "_").replace("\\", "_")
+    text = re.sub(r"[^A-Za-z0-9_.:-]+", "_", text).strip("._:-")
+    return text[:limit]
+
+
+def _public_bridge_label_list(value: Any, *, limit: int = 80) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    labels: list[str] = []
+    for item in value[:12]:
+        label = _public_bridge_label(item, limit=limit)
+        if label:
+            labels.append(label)
+    return labels
+
+
+def _public_bridge_operations(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    operations: list[dict[str, Any]] = []
+    for item in value[:8]:
+        if not isinstance(item, dict):
+            continue
+        operation: dict[str, Any] = {}
+        for field in ("kind", "label", "status"):
+            label = _public_bridge_label(item.get(field), limit=80)
+            if label:
+                operation[field] = label
+        for field in ("exit_code_zero", "content_match"):
+            flag = item.get(field)
+            if isinstance(flag, bool):
+                operation[field] = flag
+        if operation:
+            operations.append(operation)
+    return operations
+
+
 def _codex_exec_failure_category(
     *,
     returncode: int | None,
@@ -904,15 +945,42 @@ raise SystemExit(proc.returncode)
                 "consumed_by_solver": True,
                 "probe_ready": bridge_probe.get("ready") is True,
                 "operation_count": operation_count,
-                "first_blocker": str(bridge_probe.get("first_blocker") or "")[:120],
-                "stage": str(bridge_probe.get("stage") or "")[:80],
+                "first_blocker": _public_bridge_label(
+                    bridge_probe.get("first_blocker"), limit=120
+                ),
+                "stage": _public_bridge_label(bridge_probe.get("stage"), limit=80),
                 "bridge_command_invoked": (
                     bridge_probe.get("bridge_command_invoked") is True
                 ),
                 "bridge_command_recorded": False,
+                "required_operations": _public_bridge_label_list(
+                    bridge_probe.get("required_operations")
+                ),
+                "missing_operations": _public_bridge_label_list(
+                    bridge_probe.get("missing_operations")
+                ),
+                "failed_operations": _public_bridge_label_list(
+                    bridge_probe.get("failed_operations")
+                ),
+                "boundary_violations": _public_bridge_label_list(
+                    bridge_probe.get("boundary_violations")
+                ),
+                "operations": _public_bridge_operations(bridge_probe.get("operations")),
             },
             "boundary": boundary,
         }
+        response_schema_version = _public_bridge_label(
+            bridge_probe.get("response_schema_version"), limit=120
+        )
+        if response_schema_version:
+            trace["remote_command_file_bridge"][
+                "response_schema_version"
+            ] = response_schema_version
+        elapsed_ms = bridge_probe.get("elapsed_ms")
+        if isinstance(elapsed_ms, int) and not isinstance(elapsed_ms, bool):
+            trace["remote_command_file_bridge"]["elapsed_ms"] = max(
+                0, min(elapsed_ms, 600_000)
+            )
         self._write_worker_public_trace(trace)
 
     def _publish_codex_exec_failure_trace(

--- a/scripts/skillsbench_reverse_channel_bridge.py
+++ b/scripts/skillsbench_reverse_channel_bridge.py
@@ -244,6 +244,10 @@ payload = {{
 s=socket.socket(socket.AF_UNIX)
 s.settimeout(float(os.environ.get('LOOPX_REVERSE_CONNECT_TIMEOUT_SEC', '30')))
 s.connect(SOCK)
+s.settimeout(float(os.environ.get(
+    'LOOPX_REVERSE_RESPONSE_TIMEOUT_SEC',
+    os.environ.get('LOOPX_REVERSE_CODEX_TIMEOUT_SEC', '7200'),
+)))
 s.sendall(json.dumps(payload).encode()+b'\\n')
 data=b''
 while not data.endswith(b'\\n'):
@@ -280,6 +284,10 @@ payload = {{
 s=socket.socket(socket.AF_UNIX)
 s.settimeout(float(os.environ.get('LOOPX_REVERSE_CONNECT_TIMEOUT_SEC', '30')))
 s.connect(SOCK)
+s.settimeout(float(os.environ.get(
+    'LOOPX_REVERSE_RESPONSE_TIMEOUT_SEC',
+    os.environ.get('LOOPX_REVERSE_JSON_TIMEOUT_SEC', '300'),
+)))
 s.sendall(json.dumps(payload).encode()+b'\\n')
 data=b''
 while not data.endswith(b'\\n'):


### PR DESCRIPTION
## Summary
- expose public-safe failed/missing bridge operation labels and operation summaries in the SkillsBench host-local solver consumption trace
- split reverse-channel client connect timeout from response timeout so long Codex/JSON responses are not killed by the short socket-connect budget
- cover both fields with host-local and reverse-channel smokes

## Validation
- python3 -m py_compile loopx/benchmark_adapters/skillsbench_acp_relay.py scripts/skillsbench_reverse_channel_bridge.py
- python3 examples/skillsbench-reverse-channel-bridge-smoke.py
- python3 examples/skillsbench-host-local-launch-plan-smoke.py
- python3 examples/skillsbench-benchmark-run-smoke.py
- git diff --check
- diff-only private-material scan