### PR TITLE
Preserve SkillsBench bridge response blockers

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -442,6 +442,57 @@ def test_skillsbench_remote_command_file_bridge_probe_fake_bridge_ready() -> Non
         assert forbidden not in text, forbidden
 
 
+def test_skillsbench_remote_command_file_bridge_probe_preserves_response_blocker() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        fake_bridge = Path(tmp) / "fake-bridge-failure.py"
+        fake_bridge.write_text(
+            f"""#!/usr/bin/env python3
+import json
+import sys
+
+sys.path.insert(0, {str(REPO_ROOT)!r})
+from loopx.benchmark_adapters.skillsbench_remote_bridge import (
+    build_skillsbench_remote_command_file_bridge_probe_response,
+)
+
+print(json.dumps(build_skillsbench_remote_command_file_bridge_probe_response(
+    ready=False,
+    first_blocker="skillsbench_remote_bridge_target_env_missing",
+    stage="remote_ssh_probe",
+    operations=[
+        {{"kind": "exec", "label": "bounded_noop_command", "status": "blocked", "exit_code_zero": False}},
+        {{"kind": "write_file", "label": "probe_marker_write", "status": "blocked"}},
+        {{"kind": "read_file", "label": "probe_marker_read", "status": "blocked", "content_match": False}},
+        {{"kind": "cleanup", "label": "probe_marker_cleanup", "status": "blocked"}},
+    ],
+), sort_keys=True))
+""",
+            encoding="utf-8",
+        )
+        fake_bridge.chmod(0o755)
+
+        payload = run_skillsbench_remote_command_file_bridge_probe(
+            [sys.executable, str(fake_bridge)]
+        )
+
+    assert payload["ready"] is False, payload
+    assert (
+        payload["first_blocker"]
+        == "skillsbench_remote_command_file_bridge_operation_failed"
+    ), payload
+    assert (
+        payload["response_first_blocker"]
+        == "skillsbench_remote_bridge_target_env_missing"
+    ), payload
+    assert payload["failed_operations"] == [
+        "exec",
+        "write_file",
+        "read_file",
+        "cleanup",
+    ], payload
+    assert payload["stage"] == "remote_ssh_probe", payload
+
+
 def test_skillsbench_worker_handshake_preflight_accepts_bridge_probe() -> None:
     command = [
         sys.executable,
@@ -6673,6 +6724,7 @@ if __name__ == "__main__":
     test_skillsbench_worker_handshake_preflight_distinguishes_remote_bridge()
     test_skillsbench_remote_command_file_bridge_probe_requires_command()
     test_skillsbench_remote_command_file_bridge_probe_fake_bridge_ready()
+    test_skillsbench_remote_command_file_bridge_probe_preserves_response_blocker()
     test_skillsbench_worker_handshake_preflight_accepts_bridge_probe()
     test_skillsbench_local_acp_relay_probe_completes_stdio_handshake()
     test_skillsbench_host_local_acp_transport_probe_uses_benchflow_client()

--- a/examples/skillsbench-host-local-launch-plan-smoke.py
+++ b/examples/skillsbench-host-local-launch-plan-smoke.py
@@ -598,6 +598,9 @@ output.write_text("fake solver saw bridge packet\\n", encoding="utf-8")
                 "first_blocker": (
                     "skillsbench_remote_command_file_bridge_operation_failed"
                 ),
+                "response_first_blocker": (
+                    "skillsbench_remote_bridge_target_env_missing"
+                ),
                 "stage": "probe",
                 "response_schema_version": (
                     "skillsbench_remote_command_file_bridge_probe_response_v0"
@@ -637,6 +640,10 @@ output.write_text("fake solver saw bridge packet\\n", encoding="utf-8")
         )
         bridge_failure = bridge_failure_trace["remote_command_file_bridge"]
         assert bridge_failure["probe_ready"] is False
+        assert (
+            bridge_failure["response_first_blocker"]
+            == "skillsbench_remote_bridge_target_env_missing"
+        )
         assert bridge_failure["failed_operations"] == ["read_file"]
         assert bridge_failure["operations"][1]["status"] == "failed"
         assert bridge_failure["operations"][1]["content_match"] is False

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -1209,6 +1209,7 @@ def _skillsbench_public_remote_command_file_bridge_probe(
     for field in (
         "schema_version",
         "first_blocker",
+        "response_first_blocker",
         "stage",
         "request_schema_version",
         "response_schema_version",

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -948,6 +948,9 @@ raise SystemExit(proc.returncode)
                 "first_blocker": _public_bridge_label(
                     bridge_probe.get("first_blocker"), limit=120
                 ),
+                "response_first_blocker": _public_bridge_label(
+                    bridge_probe.get("response_first_blocker"), limit=120
+                ),
                 "stage": _public_bridge_label(bridge_probe.get("stage"), limit=80),
                 "bridge_command_invoked": (
                     bridge_probe.get("bridge_command_invoked") is True

--- a/loopx/benchmark_adapters/skillsbench_remote_bridge.py
+++ b/loopx/benchmark_adapters/skillsbench_remote_bridge.py
@@ -344,11 +344,15 @@ def _bridge_probe_payload(
                 op_summaries.append(summary)
 
     response_schema = None
+    response_first_blocker = None
     if isinstance(response, dict):
         response_schema = _public_safe_label(response.get("schema_version"), limit=120)
+        response_first_blocker = _public_safe_label(
+            response.get("first_blocker"), limit=120
+        )
 
     elapsed = max(0, min(int(elapsed_ms), 600_000))
-    return {
+    payload = {
         "schema_version": SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_PROBE_SCHEMA_VERSION,
         "ready": ready,
         "first_blocker": _public_safe_label(first_blocker, limit=120)
@@ -387,6 +391,9 @@ def _bridge_probe_payload(
         "upload_performed": False,
         "submit_performed": False,
     }
+    if response_first_blocker:
+        payload["response_first_blocker"] = response_first_blocker
+    return payload
 
 
 def _command_to_argv(command: str | list[str] | tuple[str, ...]) -> list[str]:


### PR DESCRIPTION
## Summary
- Preserve the bridge response first blocker as public-safe response_first_blocker when remote command-file bridge operations fail.
- Project that field into host-local ACP relay worker traces and benchmark compact traces.
- Add smokes for failed bridge response projection and host-local trace preservation.

## Context
A formal8 SkillsBench rerun reached the solver bridge probe, but all bridge operations were blocked. The public trace previously collapsed the lower-level bridge reason into skillsbench_remote_command_file_bridge_operation_failed, which made the next repair step less direct. This keeps the aggregate blocker while preserving the bridge-side blocker label.

## Validation
- python3 -m py_compile loopx/benchmark_adapters/skillsbench_remote_bridge.py loopx/benchmark_adapters/skillsbench_acp_relay.py loopx/benchmark_adapters/skillsbench.py
- python3 examples/skillsbench-benchmark-run-smoke.py
- python3 examples/skillsbench-host-local-launch-plan-smoke.py
- python3 examples/skillsbench-reverse-channel-bridge-smoke.py
- git diff --check
- diff-only private boundary scan