### PR TITLE
Forward SkillsBench bridge endpoint env

### DIFF
--- a/examples/skillsbench-reverse-channel-bridge-smoke.py
+++ b/examples/skillsbench-reverse-channel-bridge-smoke.py
@@ -134,12 +134,14 @@ def test_json_client_forwards_stdin_to_bridge_command() -> None:
         fake_bridge = root / "fake-json-bridge"
         fake_bridge.write_text(
             """#!/usr/bin/env python3
-import json, sys, time
+import json, os, sys, time
 payload = json.loads(sys.stdin.read() or '{}')
 time.sleep(0.35)
 print(json.dumps({
     'ok': True,
     'operation': payload.get('operation'),
+    'ai_addr_present': bool(os.environ.get('AI_ADDR')),
+    'ai_port_present': bool(os.environ.get('AI_PORT')),
     'raw_task_text_recorded': False,
     'credential_values_recorded': False,
 }))
@@ -186,6 +188,8 @@ print(json.dumps({
             env = os.environ.copy()
             env["LOOPX_REVERSE_CONNECT_TIMEOUT_SEC"] = "0.1"
             env["LOOPX_REVERSE_RESPONSE_TIMEOUT_SEC"] = "5"
+            env["AI_ADDR"] = "127.0.0.1"
+            env["AI_PORT"] = "2022"
             proc = subprocess.run(
                 [str(client)],
                 input=json.dumps({"operation": "exec", "cwd": "/app"}),
@@ -199,6 +203,95 @@ print(json.dumps({
             response = json.loads(proc.stdout)
             assert response["ok"] is True
             assert response["operation"] == "exec"
+            assert response["ai_addr_present"] is True
+            assert response["ai_port_present"] is True
+            assert response["raw_task_text_recorded"] is False
+            assert response["credential_values_recorded"] is False
+        finally:
+            server.wait(timeout=5)
+
+
+def test_json_client_expands_allowed_env_template_for_nested_bridge() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-reverse-json-env-smoke-") as tmp:
+        root = Path(tmp)
+        fake_bridge = root / "fake-nested-json-bridge"
+        fake_bridge.write_text(
+            """#!/usr/bin/env python3
+import json, os, sys
+
+assignments = sys.argv[1:]
+payload = json.loads(sys.stdin.read() or '{}')
+print(json.dumps({
+    'ok': True,
+    'operation': payload.get('operation'),
+    'argv_has_ai_addr': any(item.startswith('AI_ADDR=') for item in assignments),
+    'argv_has_ai_port': any(item.startswith('AI_PORT=') for item in assignments),
+    'argv_has_runtime_root': any(item.startswith('GOAL_HARNESS_REMOTE_BENCH_ROOT=') for item in assignments),
+    'raw_task_text_recorded': False,
+    'credential_values_recorded': False,
+}))
+""",
+            encoding="utf-8",
+        )
+        fake_bridge.chmod(0o700)
+        socket_path = root / "json-env.sock"
+        server = subprocess.Popen(
+            [
+                sys.executable,
+                str(BRIDGE),
+                "serve-json",
+                "--socket",
+                str(socket_path),
+                "--bridge-command",
+                f"{fake_bridge} {{loopx_allowed_env}}",
+                "--once",
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        try:
+            wait_for_socket(socket_path, server)
+            client = root / "json-client"
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(BRIDGE),
+                    "write-client",
+                    "--kind",
+                    "json",
+                    "--socket",
+                    str(socket_path),
+                    "--output",
+                    str(client),
+                ],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            env = os.environ.copy()
+            env["LOOPX_REVERSE_CONNECT_TIMEOUT_SEC"] = "0.1"
+            env["LOOPX_REVERSE_RESPONSE_TIMEOUT_SEC"] = "5"
+            env["AI_ADDR"] = "127.0.0.1"
+            env["AI_PORT"] = "2022"
+            env["GOAL_HARNESS_REMOTE_BENCH_ROOT"] = "/tmp/loopx-bench"
+            proc = subprocess.run(
+                [str(client)],
+                input=json.dumps({"operation": "exec", "cwd": "/app"}),
+                check=False,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            assert proc.returncode == 0, proc.stderr
+            response = json.loads(proc.stdout)
+            assert response["ok"] is True
+            assert response["operation"] == "exec"
+            assert response["argv_has_ai_addr"] is True
+            assert response["argv_has_ai_port"] is True
+            assert response["argv_has_runtime_root"] is True
             assert response["raw_task_text_recorded"] is False
             assert response["credential_values_recorded"] is False
         finally:
@@ -229,6 +322,7 @@ def test_socket_probe_reports_missing_or_orphaned() -> None:
 def main() -> int:
     test_codex_client_writes_last_message_and_rewrites_bridge()
     test_json_client_forwards_stdin_to_bridge_command()
+    test_json_client_expands_allowed_env_template_for_nested_bridge()
     test_socket_probe_reports_missing_or_orphaned()
     print("skillsbench reverse-channel bridge smoke passed")
     return 0

--- a/scripts/skillsbench_reverse_channel_bridge.py
+++ b/scripts/skillsbench_reverse_channel_bridge.py
@@ -13,6 +13,7 @@ import argparse
 import json
 import os
 import re
+import shlex
 import socket
 import subprocess
 import sys
@@ -24,6 +25,7 @@ from typing import Any
 CLIENT_SCHEMA_VERSION = "skillsbench_reverse_channel_client_v0"
 SERVER_RESPONSE_SCHEMA_VERSION = "skillsbench_reverse_channel_response_v0"
 SOCKET_PROBE_SCHEMA_VERSION = "skillsbench_reverse_channel_socket_probe_v0"
+ALLOWED_PAYLOAD_ENV_KEYS = ("AI_ADDR", "AI_PORT", "GOAL_HARNESS_REMOTE_BENCH_ROOT")
 
 
 def _send_json_line(sock: socket.socket, payload: dict[str, Any]) -> None:
@@ -44,13 +46,28 @@ def _recv_json_line(conn: socket.socket) -> dict[str, Any]:
 
 def _safe_env(extra: object) -> dict[str, str]:
     env = os.environ.copy()
+    env.update(_allowed_payload_env(extra))
+    return env
+
+
+def _allowed_payload_env(extra: object) -> dict[str, str]:
+    env: dict[str, str] = {}
     if isinstance(extra, dict):
         for key, value in extra.items():
             if not isinstance(key, str):
                 continue
-            if key in {"AI_ADDR", "AI_PORT", "GOAL_HARNESS_REMOTE_BENCH_ROOT"}:
+            if key in ALLOWED_PAYLOAD_ENV_KEYS:
                 env[key] = str(value)
     return env
+
+
+def _allowed_env_assignments(extra: object) -> str:
+    env = _allowed_payload_env(extra)
+    return " ".join(f"{key}={shlex.quote(value)}" for key, value in env.items())
+
+
+def _bridge_command_with_payload_env(command: str, extra: object) -> str:
+    return command.replace("{loopx_allowed_env}", _allowed_env_assignments(extra))
 
 
 def _replace_output_last_message(args: list[str], replacement: Path) -> str | None:
@@ -153,10 +170,12 @@ def _run_json_bridge_payload(
 ) -> dict[str, Any]:
     timeout = max(1.0, float(default_timeout_sec))
     stdin_text = str(payload.get("stdin") or "")
-    env = _safe_env(payload.get("env"))
+    payload_env = payload.get("env")
+    env = _safe_env(payload_env)
+    command = _bridge_command_with_payload_env(bridge_command, payload_env)
     try:
         proc = subprocess.run(
-            bridge_command,
+            command,
             input=stdin_text,
             text=True,
             stdout=subprocess.PIPE,
@@ -350,7 +369,14 @@ def main(argv: list[str] | None = None) -> int:
 
     json_server = sub.add_parser("serve-json")
     json_server.add_argument("--socket", required=True)
-    json_server.add_argument("--bridge-command", required=True)
+    json_server.add_argument(
+        "--bridge-command",
+        required=True,
+        help=(
+            "Private JSON bridge command. Use {loopx_allowed_env} inside nested "
+            "remote commands to forward AI_ADDR/AI_PORT without logging values."
+        ),
+    )
     json_server.add_argument("--timeout-sec", type=float, default=300.0)
     json_server.add_argument("--once", action="store_true")
 


### PR DESCRIPTION
## Summary
- Allow the reverse-channel JSON bridge server to expand a `{loopx_allowed_env}` placeholder from the client payload env allowlist.
- Keep direct JSON bridge env passthrough behavior and add smoke coverage for nested bridge commands.
- Preserve public/private boundary: tests only return boolean endpoint-presence signals, not endpoint values.

## Why
The formal8 rerun showed the remote command-file bridge probe could fail with sandbox target endpoint env missing. The reverse JSON client already sends the endpoint env from its process, but nested bridge commands such as SSH-backed private bridges need an explicit shell-safe handoff point.

## Validation
- python3 -m py_compile scripts/skillsbench_reverse_channel_bridge.py
- python3 -m py_compile scripts/skillsbench_automation_loop.py loopx/benchmark_adapters/skillsbench_acp_relay.py
- python3 examples/skillsbench-reverse-channel-bridge-smoke.py
- python3 examples/skillsbench-host-local-launch-plan-smoke.py
- python3 examples/skillsbench-benchmark-run-smoke.py
- git diff --check
- staged diff private-boundary scan