### PR TITLE
Add bounded follow-up todo capture

### DIFF
--- a/examples/todo-capture-followups-smoke.py
+++ b/examples/todo-capture-followups-smoke.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Smoke-test capped public-safe follow-up todo capture."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.status import parse_active_state_todos  # noqa: E402
+
+
+GOAL_ID = "todo-capture-followups-goal"
+FOLLOWUP_ONE = "[P1] Add a public fixture that exercises deferred candidate promotion."
+FOLLOWUP_TWO = "[P1] Document the public operator command summary contract."
+FOLLOWUP_THREE = "[P2] Compare stale open todos against recent validation gaps."
+
+
+def write_fixture(root: Path) -> tuple[Path, Path]:
+    project = root / "project"
+    runtime = root / "runtime"
+    state_file = project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+    registry_path = project / ".loopx" / "registry.json"
+    state_file.parent.mkdir(parents=True)
+    state_file.write_text(
+        "---\n"
+        "status: active\n"
+        "updated_at: 2026-01-01T00:00:00+00:00\n"
+        "---\n\n"
+        "# Active Goal State\n\n"
+        "## Objective\n\n"
+        "Keep follow-up capture bounded.\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] [P1] Preserve the existing agent todo for duplicate detection.\n"
+        "  <!-- loopx:todo todo_id=todo_existing status=open task_class=advancement_task -->\n",
+        encoding="utf-8",
+    )
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "todo-capture-followups-fixture",
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md",
+                        "adapter": {"kind": "generic_project_goal_v0", "status": "connected"},
+                        "authority_sources": [],
+                    }
+                ],
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return registry_path, state_file
+
+
+def run_cli(registry_path: Path, *args: str, check: bool = True) -> dict:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--registry",
+            str(registry_path),
+            "--format",
+            "json",
+            *args,
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    if check and result.returncode != 0:
+        raise AssertionError(result.stderr or result.stdout)
+    return json.loads(result.stdout)
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="loopx-todo-capture-followups-") as tmp:
+        registry_path, state_file = write_fixture(Path(tmp))
+        original = state_file.read_text(encoding="utf-8")
+
+        dry_run = run_cli(
+            registry_path,
+            "todo",
+            "capture-followups",
+            "--goal-id",
+            GOAL_ID,
+            "--follow-up",
+            FOLLOWUP_ONE,
+            "--follow-up",
+            FOLLOWUP_TWO,
+            "--follow-up",
+            FOLLOWUP_THREE,
+            "--evidence",
+            "examples/todo-capture-followups-smoke.py#main",
+            "--action-kind",
+            "implement",
+            "--required-write-scope",
+            "examples/**",
+            "--dry-run",
+        )
+        assert dry_run["ok"] is True, dry_run
+        assert dry_run["dry_run"] is True, dry_run
+        assert dry_run["recorded_count"] == 2, dry_run
+        assert dry_run["skipped_count"] == 1, dry_run
+        assert dry_run["items"][2]["skipped_reason"] == "max_items_exceeded", dry_run
+        assert state_file.read_text(encoding="utf-8") == original
+
+        payload = run_cli(
+            registry_path,
+            "todo",
+            "capture-followups",
+            "--goal-id",
+            GOAL_ID,
+            "--follow-up",
+            FOLLOWUP_ONE,
+            "--follow-up",
+            FOLLOWUP_ONE,
+            "--follow-up",
+            FOLLOWUP_TWO,
+            "--follow-up",
+            "Inspect /private/tmp/raw-output before writing a todo.",
+            "--evidence",
+            "examples/todo-capture-followups-smoke.py#main",
+            "--action-kind",
+            "implement",
+            "--required-write-scope",
+            "examples/**",
+        )
+        assert payload["ok"] is True, payload
+        assert payload["dry_run"] is False, payload
+        assert payload["recorded_count"] == 2, payload
+        assert payload["skipped_count"] == 2, payload
+        assert payload["items"][1]["skipped_reason"] == "duplicate", payload
+        assert payload["items"][3]["skipped_reason"] == "unsafe_boundary:local_absolute_path", payload
+
+        fields = parse_active_state_todos(state_file.read_text(encoding="utf-8"))
+        agent_items = fields["agent_todos"]["items"]
+        texts = [item["text"] for item in agent_items]
+        assert FOLLOWUP_ONE in texts, texts
+        assert FOLLOWUP_TWO in texts, texts
+        assert FOLLOWUP_THREE not in texts, texts
+        assert not any("claimed_by" in item for item in agent_items), agent_items
+        first_followup = next(item for item in agent_items if item["text"] == FOLLOWUP_ONE)
+        assert first_followup["task_class"] == "advancement_task", first_followup
+        assert first_followup["action_kind"] == "implement", first_followup
+        assert first_followup["required_write_scopes"] == ["examples/**"], first_followup
+        assert first_followup["evidence"] == "examples/todo-capture-followups-smoke.py#main", first_followup
+
+        duplicate_again = run_cli(
+            registry_path,
+            "todo",
+            "capture-followups",
+            "--goal-id",
+            GOAL_ID,
+            "--follow-up",
+            FOLLOWUP_ONE,
+            "--evidence",
+            "examples/todo-capture-followups-smoke.py#main",
+        )
+        assert duplicate_again["recorded_count"] == 0, duplicate_again
+        assert duplicate_again["items"][0]["skipped_reason"] == "duplicate", duplicate_again
+
+        unsafe_evidence = run_cli(
+            registry_path,
+            "todo",
+            "capture-followups",
+            "--goal-id",
+            GOAL_ID,
+            "--follow-up",
+            "[P2] This item is otherwise public-safe.",
+            "--evidence",
+            "/private/tmp/raw-evidence.txt",
+            check=False,
+        )
+        assert unsafe_evidence["ok"] is False, unsafe_evidence
+        assert "evidence is not public-safe" in unsafe_evidence["error"], unsafe_evidence
+
+    print("todo-capture-followups-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -10,6 +10,7 @@ from ..todo_suggestion_prompt import (
     build_todo_suggestion_prompt_packet,
     render_todo_suggestion_prompt_markdown,
 )
+from ..todo_followups import capture_followup_todos
 from ..todos import (
     archive_completed_todos,
     add_goal_todo,
@@ -43,18 +44,26 @@ def register_todo_command(subparsers: argparse._SubParsersAction) -> None:
             "supersede",
             "archive-completed",
             "suggest",
+            "capture-followups",
         ],
         default="add",
         help=(
             "Use add to append a checkbox todo, claim to soft-claim by registered "
             "agent id, update/complete/supersede to transition by todo_id, or "
             "archive-completed to move older completed todos into Completed Work Archive. "
-            "Use suggest to generate an agent-facing candidate todo analysis prompt without writing state."
+            "Use suggest to generate an agent-facing candidate todo analysis prompt without writing state. "
+            "Use capture-followups to record a capped public-safe unclaimed follow-up batch."
         ),
     )
     todo_parser.add_argument("--goal-id", required=True, help="Goal id whose active state should receive the todo.")
     todo_parser.add_argument("--role", choices=["user", "agent"], help="Todo owner. Required for add; optional todo_id search scope for lifecycle commands. Defaults to agent for archive-completed.")
     todo_parser.add_argument("--text", help="Todo text. Required for add; keep it short and public-safe enough for local status.")
+    todo_parser.add_argument(
+        "--follow-up",
+        dest="followups",
+        action="append",
+        help="For capture-followups, append one public-safe agent follow-up todo. Repeat up to the requested batch.",
+    )
     todo_parser.add_argument("--todo-id", help="Structured todo id from status/quota, such as todo_ab12cd34ef56.")
     todo_parser.add_argument("--status", choices=["open", "done", "blocked", "deferred"], help="For todo update, set the lifecycle status by todo_id.")
     todo_parser.add_argument("--note", help="Public-safe note to attach to a lifecycle transition.")
@@ -213,7 +222,7 @@ def handle_todo_command(
         else render_todo_markdown
     )
     try:
-        if args.todo_command != "suggest" and (
+        if args.todo_command not in {"suggest", "capture-followups"} and (
             args.agent_id
             or args.suggestion_sources
             or args.suggestion_limit is not None
@@ -223,6 +232,8 @@ def handle_todo_command(
                 "todo --agent-id, --from, --limit, and --trigger are only supported by `todo suggest`"
             )
         if args.todo_command == "add":
+            if args.followups:
+                raise ValueError("todo add does not support --follow-up; use `todo capture-followups`")
             if not args.role:
                 raise ValueError("todo add requires --role")
             if not args.text:
@@ -280,6 +291,7 @@ def handle_todo_command(
                     ("--next-task-class", args.next_task_class),
                     ("--next-action-kind", args.next_action_kind),
                     ("--side-agent-self-merged", args.side_agent_self_merged),
+                    ("--follow-up", args.followups),
                 )
                 if value
             ]
@@ -307,6 +319,7 @@ def handle_todo_command(
                 raise ValueError("todo update accepts either --claimed-by or --clear-claim, not both")
             if not any([
                 args.text,
+                args.followups,
                 args.status,
                 args.note,
                 args.evidence,
@@ -323,6 +336,8 @@ def handle_todo_command(
                 args.clear_claim,
             ]):
                 raise ValueError("todo update requires at least one of --text, --status, --note, --evidence, --reason, --task-class, --action-kind, --required-write-scope, --required-capability, --target-capability, --claimed-by, --blocks-agent, --unblocks-todo-id, --resume-when, or --clear-claim")
+            if args.followups:
+                raise ValueError("todo update does not support --follow-up; use `todo capture-followups`")
             if args.next_claimed_by:
                 raise ValueError("todo update does not support --next-claimed-by")
             if args.side_agent_self_merged:
@@ -358,6 +373,8 @@ def handle_todo_command(
                 raise ValueError("todo complete accepts either --claimed-by or --clear-claim, not both")
             if args.blocks_agent or args.unblocks_todo_id or args.resume_when:
                 raise ValueError("todo complete does not support --blocks-agent, --unblocks-todo-id, or --resume-when; use todo update before completion or side-agent review successor metadata")
+            if args.followups:
+                raise ValueError("todo complete does not support --follow-up; use `todo capture-followups`")
             payload = complete_goal_todo(
                 registry_path=registry_path,
                 goal_id=args.goal_id,
@@ -384,6 +401,8 @@ def handle_todo_command(
                 raise ValueError("todo supersede does not support --claimed-by or --clear-claim")
             if args.side_agent_self_merged:
                 raise ValueError("todo supersede does not support --side-agent-self-merged")
+            if args.followups:
+                raise ValueError("todo supersede does not support --follow-up; use `todo capture-followups`")
             if args.blocks_agent or args.unblocks_todo_id or args.resume_when:
                 raise ValueError("todo supersede does not support --blocks-agent, --unblocks-todo-id, or --resume-when; update the source todo first so the successor can inherit dependency metadata")
             payload = supersede_goal_todo(
@@ -408,6 +427,8 @@ def handle_todo_command(
                 raise ValueError("todo archive-completed does not support --next-claimed-by")
             if args.side_agent_self_merged:
                 raise ValueError("todo archive-completed does not support --side-agent-self-merged")
+            if args.followups:
+                raise ValueError("todo archive-completed does not support --follow-up; use `todo capture-followups`")
             payload = archive_completed_todos(
                 registry_path=registry_path,
                 goal_id=args.goal_id,
@@ -444,6 +465,7 @@ def handle_todo_command(
                     ("--next-task-class", args.next_task_class),
                     ("--next-action-kind", args.next_action_kind),
                     ("--side-agent-self-merged", args.side_agent_self_merged),
+                    ("--follow-up", args.followups),
                     ("--state-file", args.state_file),
                     ("--execute", args.execute),
                 )
@@ -464,6 +486,60 @@ def handle_todo_command(
                 trigger=args.suggestion_trigger,
             )
             payload["dry_run"] = True
+        elif args.todo_command == "capture-followups":
+            if args.role:
+                raise ValueError("todo capture-followups always records agent todos; do not pass --role")
+            if args.claimed_by:
+                raise ValueError("todo capture-followups writes unclaimed todos; do not pass --claimed-by")
+            unsupported = [
+                flag
+                for flag, value in (
+                    ("--todo-id", args.todo_id),
+                    ("--status", args.status),
+                    ("--note", args.note),
+                    ("--reason", args.reason),
+                    ("--blocks-agent", args.blocks_agent),
+                    ("--unblocks-todo-id", args.unblocks_todo_id),
+                    ("--resume-when", args.resume_when),
+                    ("--clear-claim", args.clear_claim),
+                    ("--next-agent-todo", args.next_agent_todo),
+                    ("--next-user-todo", args.next_user_todo),
+                    ("--next-claimed-by", args.next_claimed_by),
+                    ("--next-task-class", args.next_task_class),
+                    ("--next-action-kind", args.next_action_kind),
+                    ("--side-agent-self-merged", args.side_agent_self_merged),
+                    ("--agent-id", args.agent_id),
+                    ("--from", args.suggestion_sources),
+                    ("--limit", args.suggestion_limit),
+                    ("--trigger", args.suggestion_trigger),
+                    ("--execute", args.execute),
+                )
+                if value
+            ]
+            if unsupported:
+                raise ValueError(
+                    "todo capture-followups only accepts --goal-id, --follow-up, optional "
+                    "--text shorthand, --evidence, routing metadata, --project, --state-file, "
+                    "and --dry-run; unsupported: "
+                    + ", ".join(unsupported)
+                )
+            followups = list(args.followups or [])
+            if args.text:
+                followups.append(args.text)
+            payload = capture_followup_todos(
+                registry_path=registry_path,
+                goal_id=args.goal_id,
+                followups=followups,
+                evidence=args.evidence or "",
+                task_class=args.task_class,
+                action_kind=args.action_kind,
+                required_write_scopes=args.required_write_scopes,
+                required_capabilities=args.required_capabilities,
+                target_capabilities=args.target_capabilities,
+                project=Path(args.project).expanduser() if args.project else None,
+                state_file=Path(args.state_file).expanduser() if args.state_file else None,
+                dry_run=bool(args.dry_run),
+            )
         else:
             raise ValueError("unsupported todo command")
     except Exception as exc:
@@ -488,6 +564,7 @@ def handle_todo_command(
         "complete": "todo_complete",
         "supersede": "todo_supersede",
         "archive-completed": "todo_archive_completed",
+        "capture-followups": "todo_capture_followups",
     }
     if payload.get("ok") and not payload.get("dry_run"):
         append_cli_rollout_event(

--- a/loopx/todo_followups.py
+++ b/loopx/todo_followups.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+from .file_lock import exclusive_file_lock
+from .state_refresh import now_local
+from .status import normalize_todo_text
+from .todo_contract import TODO_TASK_CLASS_ADVANCEMENT
+from .todos import (
+    TODO_SECTION_HEADINGS,
+    add_todo_to_lines,
+    replace_updated_at,
+    resolve_todo_state_path,
+    section_bounds,
+    todo_blocks,
+)
+
+
+MAX_CAPTURED_FOLLOWUP_TODOS = 2
+
+_UNSAFE_FOLLOWUP_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("local_absolute_path", re.compile(r"(?i)(?:/Users/|/private/|/var/folders/|file://)")),
+    ("local_state_path", re.compile(r"(?i)(?:^|[\s\"'`])(?:\.local/|\.codex/|\.loopx/)")),
+    ("credential_literal", re.compile(r"(?i)\b(?:api[_-]?key|secret|password|token)\s*[:=]")),
+    ("internal_only_marker", re.compile(r"(?i)\binternal[-_\s]?only\b")),
+)
+
+
+def _unsafe_followup_reason(value: str) -> str | None:
+    for reason, pattern in _UNSAFE_FOLLOWUP_PATTERNS:
+        if pattern.search(value):
+            return reason
+    return None
+
+
+def _compact_text(value: Any) -> str:
+    return " ".join(str(value or "").strip().split())
+
+
+def _existing_agent_todo_texts(lines: list[str]) -> set[str]:
+    bounds = section_bounds(lines, "agent")
+    if not bounds:
+        return set()
+    start, end, section = bounds
+    return {
+        normalize_todo_text(str(block.get("text") or ""))
+        for block in todo_blocks(lines, start, end, role="agent", source_section=section)
+        if block.get("text")
+    }
+
+
+def capture_followup_todos(
+    *,
+    registry_path: Path,
+    goal_id: str,
+    followups: list[str],
+    evidence: str,
+    task_class: str | None = None,
+    action_kind: str | None = None,
+    required_write_scopes: list[str] | None = None,
+    required_capabilities: list[str] | None = None,
+    target_capabilities: list[str] | None = None,
+    project: Path | None = None,
+    state_file: Path | None = None,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    if not followups:
+        raise ValueError("todo capture-followups requires at least one --follow-up")
+    evidence_text = _compact_text(evidence)
+    if not evidence_text:
+        raise ValueError("todo capture-followups requires --evidence with a public-safe pointer")
+    evidence_reason = _unsafe_followup_reason(evidence_text)
+    if evidence_reason:
+        raise ValueError(f"todo capture-followups evidence is not public-safe: {evidence_reason}")
+
+    resolved_project, resolved_state_file = resolve_todo_state_path(
+        registry_path=registry_path,
+        goal_id=goal_id,
+        project=project,
+        state_file=state_file,
+    )
+
+    items: list[dict[str, Any]] = []
+    with exclusive_file_lock(resolved_state_file):
+        original = resolved_state_file.read_text(encoding="utf-8")
+        lines = original.splitlines()
+        existing_texts = _existing_agent_todo_texts(lines)
+        seen_texts: set[str] = set()
+        updated_at = now_local()
+        changed = False
+        recorded_count = 0
+
+        for raw_followup in followups:
+            todo_text = _compact_text(raw_followup)
+            item: dict[str, Any] = {
+                "todo": todo_text,
+                "added": False,
+                "already_exists": False,
+                "skipped": False,
+                "skipped_reason": None,
+            }
+            if not todo_text:
+                item.update({"skipped": True, "skipped_reason": "empty"})
+                items.append(item)
+                continue
+
+            unsafe_reason = _unsafe_followup_reason(todo_text)
+            if unsafe_reason:
+                item.update({"skipped": True, "skipped_reason": f"unsafe_boundary:{unsafe_reason}"})
+                items.append(item)
+                continue
+
+            normalized = normalize_todo_text(todo_text)
+            if normalized in existing_texts or normalized in seen_texts:
+                item.update({"already_exists": True, "skipped": True, "skipped_reason": "duplicate"})
+                items.append(item)
+                continue
+
+            if recorded_count >= MAX_CAPTURED_FOLLOWUP_TODOS:
+                item.update({"skipped": True, "skipped_reason": "max_items_exceeded"})
+                items.append(item)
+                continue
+
+            add_result = add_todo_to_lines(
+                lines,
+                role="agent",
+                text=todo_text,
+                task_class=task_class or TODO_TASK_CLASS_ADVANCEMENT,
+                action_kind=action_kind,
+                required_write_scopes=required_write_scopes,
+                required_capabilities=required_capabilities,
+                target_capabilities=target_capabilities,
+                evidence=evidence_text,
+            )
+            changed = changed or bool(add_result.get("added")) or bool(add_result.get("metadata_updated"))
+            recorded_count += 1
+            seen_texts.add(normalized)
+            item.update(add_result)
+            items.append(item)
+
+        if changed:
+            new_text = "\n".join(lines) + ("\n" if original.endswith("\n") else "")
+            new_text = replace_updated_at(new_text, updated_at)
+            if not dry_run:
+                resolved_state_file.write_text(new_text, encoding="utf-8")
+
+    return {
+        "ok": True,
+        "dry_run": dry_run,
+        "changed": changed,
+        "goal_id": goal_id,
+        "role": "agent",
+        "section": TODO_SECTION_HEADINGS["agent"],
+        "state_file": str(resolved_state_file),
+        "project": str(resolved_project) if resolved_project else None,
+        "max_items": MAX_CAPTURED_FOLLOWUP_TODOS,
+        "requested_count": len(followups),
+        "recorded_count": recorded_count,
+        "skipped_count": sum(1 for item in items if item.get("skipped")),
+        "evidence": evidence_text,
+        "items": items,
+        "updated_at": updated_at if changed else None,
+    }

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -457,6 +457,7 @@ def add_todo_to_lines(
     blocks_agent: str | None = None,
     unblocks_todo_id: str | None = None,
     resume_when: str | None = None,
+    evidence: str | None = None,
 ) -> dict[str, Any]:
     todo_text = normalize_new_todo(text)
     bounds = section_bounds(lines, role)
@@ -496,6 +497,7 @@ def add_todo_to_lines(
             blocks_agent=blocks_agent,
             unblocks_todo_id=unblocks_todo_id,
             resume_when=resume_when,
+            evidence=evidence,
         )
         todo_line = "\n".join([f"- [ ] {todo_text}", metadata_line] if metadata_line else [f"- [ ] {todo_text}"])
         if bounds:
@@ -526,6 +528,8 @@ def add_todo_to_lines(
             updates["unblocks_todo_id"] = unblocks_todo_id
         if resume_when:
             updates["resume_when"] = resume_when
+        if evidence:
+            updates["evidence"] = evidence
         metadata_line = metadata_line_for_block(block, updates)
         metadata_updated = upsert_todo_metadata(lines, block, metadata_line)
         todo_id = str(block.get("todo_id") or "")
@@ -554,6 +558,7 @@ def add_todo_to_lines(
         "blocks_agent": normalize_todo_blocks_agent(effective_metadata.get("blocks_agent")),
         "unblocks_todo_id": normalize_todo_id(effective_metadata.get("unblocks_todo_id")),
         "resume_when": normalize_todo_resume_when(effective_metadata.get("resume_when")),
+        "evidence": effective_metadata.get("evidence") or evidence,
     }
 
 


### PR DESCRIPTION
## Summary
- add a `loopx todo capture-followups` helper that records at most two public-safe unclaimed agent follow-up todos
- filter local/private evidence markers, skip duplicate follow-ups, and preserve evidence pointers in todo metadata
- add a focused smoke covering dry-run, max-item, duplicate, unsafe-boundary, and unclaimed behavior

## Validation
- `python3 -m py_compile loopx/*.py loopx/cli_commands/*.py`
- `python3 examples/todo-capture-followups-smoke.py`
- `python3 examples/todo-cli-smoke.py`
- `python3 examples/todo-lifecycle-cli-smoke.py`
- `git diff --check`