### PR TITLE
Fix scoped fallback claim filtering

### DIFF
--- a/examples/work-lane-contract-smoke.py
+++ b/examples/work-lane-contract-smoke.py
@@ -1138,6 +1138,74 @@ def assert_side_agent_waits_when_only_other_agent_has_claimed_work() -> None:
     assert "quiet_noop_allowed=True" in markdown, markdown
 
 
+def assert_scoped_user_gate_does_not_steal_other_agent_fallback() -> None:
+    gated_action = (
+        "[P0] Sync the local long-horizon protocol packet into the approved "
+        "Lark Kanban target."
+    )
+    primary_fallback = "[P0] Review and merge PR #623 for follow-up capture."
+    guard = build_quota_should_run(
+        status_payload(
+            status="side_agent_scoped_gate_other_agent_fallback",
+            next_action=gated_action,
+            coordination={
+                "primary_agent": "codex-main-control",
+                "registered_agents": ["codex-main-control", "codex-product-capability"],
+            },
+            user_todo_items=[
+                {
+                    "index": 1,
+                    "text": (
+                        "[P0-user] Choose the Lark Kanban target for local "
+                        "long-horizon protocol management."
+                    ),
+                    "role": "user",
+                    "status": "open",
+                    "priority": "P0",
+                    "task_class": "user_gate",
+                    "action_kind": "lark_kanban_target_decision",
+                    "todo_id": "todo_lark_gate",
+                },
+            ],
+            agent_todo_items=[
+                {
+                    "index": 1,
+                    "text": gated_action,
+                    "role": "agent",
+                    "status": "open",
+                    "priority": "P0",
+                    "task_class": "advancement_task",
+                    "action_kind": "lark_kanban_target_decision",
+                    "claimed_by": "codex-main-control",
+                    "todo_id": "todo_product_kanban_sync",
+                    "required_capabilities": ["shell"],
+                },
+                {
+                    "index": 2,
+                    "text": primary_fallback,
+                    "role": "agent",
+                    "status": "open",
+                    "priority": "P0",
+                    "task_class": "advancement_task",
+                    "action_kind": "review",
+                    "claimed_by": "codex-main-control",
+                    "todo_id": "todo_primary_review_623",
+                    "required_capabilities": ["shell"],
+                },
+            ],
+        ),
+        goal_id=GOAL_ID,
+        agent_id="codex-product-capability",
+    )
+    assert "scoped_user_gate_fallback" not in guard, guard
+    assert guard["safe_bypass_kind"] != "scoped_user_gate_fallback", guard
+    assert guard["interaction_contract"]["agent_channel"]["must_attempt"] is False, guard
+    assert guard["interaction_contract"]["agent_channel"]["delivery_allowed"] is False, guard
+    assert "todo_primary_review_623" not in guard.get("recommended_action", ""), guard
+    markdown = render_quota_should_run_markdown(guard)
+    assert "scoped_user_gate_fallback" not in markdown, markdown
+
+
 def assert_side_agent_replans_when_deferred_successor_is_ready() -> None:
     deferred_action = "[P1] Continue the issue meta surface fixture implementation."
     payload = status_payload(
@@ -1509,6 +1577,7 @@ def main() -> int:
     assert_launch_then_poll_todo_without_handle_routes_to_advancement()
     assert_side_agent_next_action_projects_without_stealing_goal_next_action()
     assert_side_agent_waits_when_only_other_agent_has_claimed_work()
+    assert_scoped_user_gate_does_not_steal_other_agent_fallback()
     assert_side_agent_replans_when_deferred_successor_is_ready()
     assert_side_agent_can_take_unclaimed_work()
     assert_agent_lane_next_action_prefers_capability_repair_candidate()

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -1903,6 +1903,18 @@ def _scoped_user_gate_fallback(
         else []
     )
     executable_items = [item for item in executable_items if isinstance(item, dict)]
+    claim_scope = (
+        agent_todo_summary.get("claim_scope")
+        if isinstance(agent_todo_summary.get("claim_scope"), dict)
+        else None
+    )
+    if claim_scope:
+        agent_id = normalize_todo_claimed_by(claim_scope.get("agent_id"))
+        executable_items = [
+            item
+            for item in executable_items
+            if normalize_todo_claimed_by(item.get("claimed_by")) in {"", agent_id}
+        ]
     if len(executable_items) < 2:
         return None
 


### PR DESCRIPTION
## Summary
- Prevent scoped user-gate fallback from treating other-agent claimed todos as executable fallback work for the current side agent.
- Add a regression covering a side-agent heartbeat with an open user gate where all non-gated fallback work is claimed by another agent.

## Root Cause
`scoped_user_gate_fallback` read `agent_todo_summary.executable_backlog_items`, which are claim-ordered but still include other-agent claimed items for visibility. That could make a side-agent heartbeat report `must_attempt=true` and `quiet_noop_allowed=false` even when this agent had no current/unclaimed advancement candidate.

## Validation
- `python3 -m py_compile loopx/quota.py`
- `python3 examples/work-lane-contract-smoke.py`
- `python3 examples/quota-plan-smoke.py`
- `git diff --check`
