### PR TITLE
Fix SkillsBench orchestrated lifecycle counting

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -4074,6 +4074,7 @@ def test_skillsbench_product_mode_lifecycle_checkpoint_is_compacted() -> None:
             "agent_operation_trace_required": False,
             "agent_operation_trace_satisfied": False,
             "agent_operation_trace_missing": False,
+            "orchestrated_driver_lifecycle_satisfied": False,
             "agent_bridge_state_read_count": 0,
             "agent_bridge_state_write_count": 0,
             "driver_lifecycle_state_read_count": 0,
@@ -4102,6 +4103,8 @@ def test_skillsbench_product_mode_lifecycle_checkpoint_is_compacted() -> None:
                 ),
                 "remote_command_file_bridge_driver_lifecycle_checkpoint_count": 1,
                 "remote_command_file_bridge_driver_lifecycle_request_count": 4,
+                "remote_command_file_bridge_driver_lifecycle_success_count": 4,
+                "remote_command_file_bridge_driver_lifecycle_failure_count": 0,
                 "remote_command_file_bridge_driver_lifecycle_loopx_cli_call_count": 4,
                 "remote_command_file_bridge_driver_lifecycle_loopx_state_read_count": 1,
                 "remote_command_file_bridge_driver_lifecycle_loopx_state_write_count": 3,
@@ -4142,6 +4145,9 @@ def test_skillsbench_product_mode_lifecycle_checkpoint_is_compacted() -> None:
         external_agent_controller_trace = dict(driver_controller_trace)
         external_agent_controller_trace.update(
             {
+                "remote_command_file_bridge_driver_lifecycle_execution_style": (
+                    "prompt_driven_loopx_cli"
+                ),
                 "remote_command_file_bridge_agent_command_configured": True,
                 "remote_command_file_bridge_agent_command_instrumented": False,
                 "remote_command_file_bridge_agent_operation_trace_required": True,
@@ -4191,6 +4197,55 @@ def test_skillsbench_product_mode_lifecycle_checkpoint_is_compacted() -> None:
             "skillsbench_remote_bridge_agent_operation_trace_missing"
             in external_agent_compact["failure_attribution_labels"]
         ), external_agent_compact
+        orchestrated_no_request_controller_trace = dict(driver_controller_trace)
+        orchestrated_no_request_controller_trace.update(
+            {
+                "remote_command_file_bridge_agent_command_configured": True,
+                "remote_command_file_bridge_agent_command_instrumented": True,
+                "remote_command_file_bridge_agent_operation_trace_required": True,
+                "remote_command_file_bridge_agent_operation_trace_satisfied": False,
+                "remote_command_file_bridge_agent_operation_trace_status": (
+                    "agent_operation_trace_present_no_requests"
+                ),
+                "remote_command_file_bridge_agent_operation_trace_count": 1,
+                "remote_command_file_bridge_agent_request_count": 0,
+                "remote_command_file_bridge_agent_loopx_state_read_count": 0,
+                "remote_command_file_bridge_agent_loopx_state_write_count": 0,
+            }
+        )
+        orchestrated_no_request_compact = compact_benchmark_run(
+            build_skillsbench_benchflow_result_benchmark_run(
+                result_path,
+                route="loopx-product-mode",
+                controller_trace=orchestrated_no_request_controller_trace,
+            )
+        )
+        assert orchestrated_no_request_compact is not None
+        orchestrated_no_request_contract = orchestrated_no_request_compact[
+            "product_mode_lifecycle_contract"
+        ]
+        assert orchestrated_no_request_contract["satisfied"] is True, (
+            orchestrated_no_request_compact
+        )
+        assert orchestrated_no_request_contract["countable_treatment"] is True, (
+            orchestrated_no_request_compact
+        )
+        assert (
+            orchestrated_no_request_contract[
+                "orchestrated_driver_lifecycle_satisfied"
+            ]
+            is True
+        ), orchestrated_no_request_contract
+        assert (
+            orchestrated_no_request_contract["agent_operation_trace_required"]
+            is False
+        ), orchestrated_no_request_contract
+        assert orchestrated_no_request_contract.get("missing_reason", "") == "", (
+            orchestrated_no_request_contract
+        )
+        assert "skillsbench_remote_bridge_agent_no_requests" not in (
+            orchestrated_no_request_compact["failure_attribution_labels"]
+        ), orchestrated_no_request_compact
         no_request_controller_trace = dict(external_agent_controller_trace)
         no_request_controller_trace.update(
             {
@@ -4975,6 +5030,62 @@ def test_skillsbench_runner_failure_compact_attributes_agent_no_requests() -> No
             "failure_attribution_labels"
         ], compact
         assert "case-local LoopX lifecycle request" not in json.dumps(compact), compact
+
+
+def test_skillsbench_product_mode_pass_clears_generic_runner_error() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-pass-runner-error-") as tmp:
+        root = Path(tmp)
+        result_path = write_official_skillsbench_result(root, reward=1.0)
+        payload = json.loads(result_path.read_text(encoding="utf-8"))
+        payload["error"] = "generic runner closeout noise after official scoring"
+        write_json(result_path, payload)
+        controller_trace = {
+            "schema_version": "skillsbench_loopx_controller_trace_v0",
+            "publicness": "public_counts_only_no_task_text_no_verifier_output",
+            "loopx_automation_loop": True,
+            "product_mode": True,
+            "official_feedback_blinded": True,
+            "reward_feedback_forwarded": False,
+            "remote_command_file_bridge_driver_lifecycle_trace_count": 1,
+            "remote_command_file_bridge_driver_lifecycle_execution_style": (
+                "orchestrated_agentloop_loopx_cli"
+            ),
+            "remote_command_file_bridge_driver_lifecycle_checkpoint_count": 1,
+            "remote_command_file_bridge_driver_lifecycle_success_count": 4,
+            "remote_command_file_bridge_driver_lifecycle_failure_count": 0,
+            "remote_command_file_bridge_driver_lifecycle_loopx_cli_call_count": 4,
+            "remote_command_file_bridge_driver_lifecycle_loopx_state_read_count": 1,
+            "remote_command_file_bridge_driver_lifecycle_loopx_state_write_count": 3,
+            "remote_command_file_bridge_agent_operation_trace_required": True,
+            "remote_command_file_bridge_agent_operation_trace_satisfied": False,
+            "remote_command_file_bridge_agent_operation_trace_status": (
+                "agent_operation_trace_present_no_requests"
+            ),
+            "remote_command_file_bridge_agent_operation_trace_count": 1,
+            "remote_command_file_bridge_agent_request_count": 0,
+            "remote_command_file_bridge_agent_loopx_state_read_count": 0,
+            "remote_command_file_bridge_agent_loopx_state_write_count": 0,
+        }
+        compact = compact_benchmark_run(
+            build_skillsbench_benchflow_result_benchmark_run(
+                result_path,
+                route="loopx-product-mode",
+                controller_trace=controller_trace,
+            )
+        )
+        assert compact is not None
+        assert compact["official_score"] == 1.0, compact
+        assert compact["score_failure_attribution"] == "none", compact
+        assert compact.get("failure_attribution_labels", []) == [], compact
+        assert compact.get("runner_failure") is None, compact
+        assert (
+            compact["product_mode_lifecycle_contract"]["countable_treatment"]
+            is True
+        ), compact
+        assert (
+            "skillsbench_runner_error_after_official_pass_ignored"
+            in compact["model_control"]["warning_labels"]
+        ), compact
 
 
 def test_skillsbench_runner_failure_prefers_structured_preflight_blocker() -> None:
@@ -6772,6 +6883,7 @@ if __name__ == "__main__":
     test_skillsbench_product_mode_declared_done_is_compacted()
     test_skillsbench_product_mode_lifecycle_checkpoint_is_compacted()
     test_skillsbench_product_mode_no_tool_lifecycle_abort_is_compacted()
+    test_skillsbench_product_mode_pass_clears_generic_runner_error()
     test_skillsbench_product_mode_case_state_usage_is_compacted()
     test_skillsbench_product_mode_legacy_case_state_path_is_not_compacted()
     test_skillsbench_round_trace_records_best_round_score()

--- a/examples/skillsbench-host-local-launch-plan-smoke.py
+++ b/examples/skillsbench-host-local-launch-plan-smoke.py
@@ -19,12 +19,17 @@ if str(REPO_ROOT) not in sys.path:
 from loopx.benchmark_adapters.skillsbench_acp_relay import (  # noqa: E402
     CodexExecConfig,
     SkillsBenchLocalAcpRelay,
+    SKILLSBENCH_LOCAL_ACP_RELAY_READY_MARKER,
     run_skillsbench_local_acp_relay_probe,
 )
 from scripts.skillsbench_automation_loop import (  # noqa: E402
     _apply_agent_message_only_no_tool_calls_attribution,
+    _host_local_acp_docker_bridge_command,
     _host_local_acp_launch_command,
+    _host_local_acp_target_env,
     _merge_host_local_acp_relay_trace_summary,
+    _public_runner_prerequisites,
+    _replace_option_value,
     _run_host_local_acp_codex_exec_preflight,
     build_runner_failure_compact,
     ensure_benchflow_runtime,
@@ -33,6 +38,9 @@ from scripts.skillsbench_automation_loop import (  # noqa: E402
 SCRIPT = REPO_ROOT / "scripts" / "skillsbench_automation_loop.py"
 RELAY_SCRIPT = REPO_ROOT / "scripts" / "skillsbench_local_acp_relay.py"
 BRIDGE_SCRIPT = REPO_ROOT / "scripts" / "skillsbench_remote_command_file_bridge.py"
+DOCKER_BRIDGE_SCRIPT = (
+    REPO_ROOT / "scripts" / "skillsbench_docker_command_file_bridge.py"
+)
 
 
 def main() -> int:
@@ -41,11 +49,75 @@ def main() -> int:
     assert "getattr(\n        benchflow_rollout_module, \"connect_acp\", _MISSING" in source
     assert "if original_rollout_connect_acp is not _MISSING:" in source
     assert "_filter_kwargs_for_signature(RolloutConfig, rollout_config_kwargs)" in source
+    assert "env=target_env" in source
+    assert "del (\n            env," not in source
+    target_env = _host_local_acp_target_env(
+        {
+            "AI_ADDR": "127.0.0.1",
+            "AI_PORT": 2022,
+            "GOAL_HARNESS_REMOTE_BENCH_ROOT": "/tmp/bench",
+            "SECRET_TOKEN": "must-not-forward",
+        }
+    )
+    assert target_env == {
+        "AI_ADDR": "127.0.0.1",
+        "AI_PORT": "2022",
+        "GOAL_HARNESS_REMOTE_BENCH_ROOT": "/tmp/bench",
+    }
+    replaced = _replace_option_value(
+        ["relay", "--remote-command-file-bridge-command", "old", "--keep", "x"],
+        "--remote-command-file-bridge-command",
+        "new",
+    )
+    assert replaced == [
+        "relay",
+        "--remote-command-file-bridge-command",
+        "new",
+        "--keep",
+        "x",
+    ]
     with tempfile.TemporaryDirectory(prefix="gh-skillsbench-plan-") as tmp:
         root = Path(tmp) / "skillsbench"
         task = root / "tasks" / "demo-task" / "environment"
         task.mkdir(parents=True)
         (task / "Dockerfile").write_text("FROM ubuntu:22.04\n", encoding="utf-8")
+        compose_file = Path(tmp) / "docker-compose.yaml"
+        compose_file.write_text("services:\n  main:\n    image: ubuntu:22.04\n", encoding="utf-8")
+        fake_env = SimpleNamespace(
+            _docker_compose_paths=[compose_file],
+            environment_dir=Path(tmp),
+            session_id="Demo.Session",
+        )
+        docker_plan = {"jobs_dir": tmp, "job_name": "bridge-job", "runner_prerequisites": {}}
+        docker_bridge_command = _host_local_acp_docker_bridge_command(
+            fake_env,
+            SimpleNamespace(loopx_source_dir=str(REPO_ROOT)),
+            docker_plan,
+        )
+        assert docker_bridge_command is not None
+        assert str(DOCKER_BRIDGE_SCRIPT) in docker_bridge_command
+        assert "--project-name demo-session" in docker_bridge_command
+        assert "--compose-file" in docker_bridge_command
+        assert "SECRET_TOKEN" not in docker_bridge_command
+        public_prerequisites = _public_runner_prerequisites(
+            {
+                **docker_plan["runner_prerequisites"],
+                "host_local_acp_target_env_forwarded": True,
+                "host_local_acp_target_env_key_count": 2,
+                "host_local_acp_target_env_keys": [
+                    "AI_ADDR",
+                    "AI_PORT",
+                    "SECRET_TOKEN",
+                ],
+            }
+        )
+        assert public_prerequisites["host_local_acp_sandbox_bridge_configured"] is True
+        assert public_prerequisites["host_local_acp_sandbox_bridge_mode"] == "docker_compose"
+        assert public_prerequisites["host_local_acp_sandbox_bridge_compose_file_count"] == 1
+        assert public_prerequisites["host_local_acp_target_env_keys"] == [
+            "AI_ADDR",
+            "AI_PORT",
+        ]
         original_import = builtins.__import__
 
         def fake_import(name, *args, **kwargs):
@@ -383,6 +455,8 @@ args = sys.argv[1:]
 prompt = args[-1]
 if "Private bridge command:" not in prompt:
     raise SystemExit(7)
+if """ + repr(SKILLSBENCH_LOCAL_ACP_RELAY_READY_MARKER) + """ not in prompt:
+    raise SystemExit(11)
 bridge_command = prompt.split("Private bridge command:", 1)[1].strip().splitlines()[0]
 if not bridge_command:
     raise SystemExit(10)

--- a/examples/skillsbench-reverse-channel-bridge-smoke.py
+++ b/examples/skillsbench-reverse-channel-bridge-smoke.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import os
+import socket
 import subprocess
 import sys
 import tempfile
@@ -25,6 +26,15 @@ def wait_for_socket(path: Path, proc: subprocess.Popen[str]) -> None:
             return
         time.sleep(0.05)
     raise AssertionError(f"socket did not appear: {path}")
+
+
+def connect_only_probe(path: Path) -> None:
+    sock = socket.socket(socket.AF_UNIX)
+    try:
+        sock.settimeout(1)
+        sock.connect(str(path))
+    finally:
+        sock.close()
 
 
 def test_codex_client_writes_last_message_and_rewrites_bridge() -> None:
@@ -73,6 +83,8 @@ print('codex stderr ok', file=sys.stderr)
         )
         try:
             wait_for_socket(socket_path, server)
+            connect_only_probe(socket_path)
+            assert server.poll() is None
             client = root / "codex-client"
             subprocess.run(
                 [
@@ -167,6 +179,8 @@ print(json.dumps({
         )
         try:
             wait_for_socket(socket_path, server)
+            connect_only_probe(socket_path)
+            assert server.poll() is None
             client = root / "json-client"
             subprocess.run(
                 [

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -8,6 +8,7 @@ from typing import Any, Iterable
 
 from ..benchmark_case_state import (
     BENCHMARK_CASE_ACTIVE_STATE_SCHEMA_VERSION,
+    BENCHMARK_CASE_LOOPX_ORCHESTRATED_EXECUTION_STYLE,
     benchmark_case_active_state_path,
 )
 from ..benchmark_core import (
@@ -2686,11 +2687,45 @@ def build_skillsbench_benchflow_result_benchmark_run(
         return value if isinstance(value, int) and not isinstance(value, bool) else 0
 
     product_mode_lifecycle_required = bool(route == "loopx-product-mode")
-    remote_agent_operation_trace_required = (
+    workflow_execution_style = controller_counters.get(
+        "remote_command_file_bridge_driver_lifecycle_execution_style"
+    )
+    driver_lifecycle_read_count = _controller_public_count(
+        "remote_command_file_bridge_driver_lifecycle_loopx_state_read_count"
+    )
+    driver_lifecycle_write_count = _controller_public_count(
+        "remote_command_file_bridge_driver_lifecycle_loopx_state_write_count"
+    )
+    driver_lifecycle_checkpoint_count = _controller_public_count(
+        "remote_command_file_bridge_driver_lifecycle_checkpoint_count"
+    )
+    driver_lifecycle_success_count = _controller_public_count(
+        "remote_command_file_bridge_driver_lifecycle_success_count"
+    )
+    driver_lifecycle_failure_count = _controller_public_count(
+        "remote_command_file_bridge_driver_lifecycle_failure_count"
+    )
+    driver_lifecycle_loopx_cli_call_count = _controller_public_count(
+        "remote_command_file_bridge_driver_lifecycle_loopx_cli_call_count"
+    )
+    orchestrated_driver_lifecycle_satisfied = bool(
+        workflow_execution_style == BENCHMARK_CASE_LOOPX_ORCHESTRATED_EXECUTION_STYLE
+        and driver_lifecycle_checkpoint_count > 0
+        and driver_lifecycle_success_count > 0
+        and driver_lifecycle_failure_count == 0
+        and driver_lifecycle_loopx_cli_call_count > 0
+        and driver_lifecycle_read_count > 0
+        and driver_lifecycle_write_count > 0
+    )
+    remote_agent_operation_trace_required_raw = (
         controller_counters.get(
             "remote_command_file_bridge_agent_operation_trace_required"
         )
         is True
+    )
+    remote_agent_operation_trace_required = bool(
+        remote_agent_operation_trace_required_raw
+        and not orchestrated_driver_lifecycle_satisfied
     )
     remote_agent_operation_trace_satisfied = (
         controller_counters.get(
@@ -2717,12 +2752,6 @@ def build_skillsbench_benchflow_result_benchmark_run(
     )
     agent_bridge_lifecycle_write_count = _controller_public_count(
         "remote_command_file_bridge_agent_loopx_state_write_count"
-    )
-    driver_lifecycle_read_count = _controller_public_count(
-        "remote_command_file_bridge_driver_lifecycle_loopx_state_read_count"
-    )
-    driver_lifecycle_write_count = _controller_public_count(
-        "remote_command_file_bridge_driver_lifecycle_loopx_state_write_count"
     )
     lifecycle_read_sources = [
         _controller_public_count("loopx_state_reads"),
@@ -2791,6 +2820,9 @@ def build_skillsbench_benchflow_result_benchmark_run(
         "agent_operation_trace_satisfied": remote_agent_operation_trace_satisfied,
         "agent_operation_trace_status": remote_agent_operation_trace_status,
         "agent_operation_trace_missing": remote_agent_operation_trace_missing,
+        "orchestrated_driver_lifecycle_satisfied": (
+            orchestrated_driver_lifecycle_satisfied
+        ),
         "agent_bridge_state_read_count": agent_bridge_lifecycle_read_count,
         "agent_bridge_state_write_count": agent_bridge_lifecycle_write_count,
         "driver_lifecycle_state_read_count": driver_lifecycle_read_count,
@@ -2810,9 +2842,6 @@ def build_skillsbench_benchflow_result_benchmark_run(
         if product_mode_lifecycle_missing
         else "",
     }
-    workflow_execution_style = controller_counters.get(
-        "remote_command_file_bridge_driver_lifecycle_execution_style"
-    )
     if isinstance(workflow_execution_style, str) and workflow_execution_style:
         product_mode_lifecycle_contract["execution_style"] = workflow_execution_style
     user_loop_final_verify_recovery_triggered = bool(
@@ -3088,6 +3117,17 @@ def build_skillsbench_benchflow_result_benchmark_run(
             and "skillsbench_reward_artifact_missing" not in failure_labels
         ):
             failure_labels.append("skillsbench_reward_artifact_missing")
+    elif (
+        official_passed
+        and score_failure_attribution == "skillsbench_runner_error"
+        and failure_labels == ["skillsbench_runner_error"]
+    ):
+        warning_labels.append("skillsbench_runner_error_after_official_pass_ignored")
+        exception_type = "none"
+        score_failure_attribution = "none"
+        runner_score_failure_attribution = "none"
+        failure_labels = []
+        runner_failure = None
 
     native_goal_worker_trace_count = controller_counters.get(
         "native_goal_worker_trace_count", 0

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -39,6 +39,10 @@ SKILLSBENCH_HOST_LOCAL_ACP_TRANSPORT_PROBE_SCHEMA_VERSION = (
 SKILLSBENCH_LOCAL_ACP_RELAY_READY_MARKER = (
     "LOOPX_SKILLSBENCH_LOCAL_ACP_RELAY_READY"
 )
+SKILLSBENCH_LOCAL_ACP_RELAY_HEALTH_PROMPT = (
+    "LoopX relay health check. Reply exactly "
+    f"{SKILLSBENCH_LOCAL_ACP_RELAY_READY_MARKER} and end the turn."
+)
 
 
 def _json_rpc_result(message_id: Any, result: dict[str, Any]) -> dict[str, Any]:
@@ -1526,7 +1530,12 @@ def run_skillsbench_local_acp_relay_probe(
                 "method": "session/prompt",
                 "params": {
                     "sessionId": session_id,
-                    "prompt": [{"type": "text", "text": "relay handshake probe"}],
+                    "prompt": [
+                        {
+                            "type": "text",
+                            "text": SKILLSBENCH_LOCAL_ACP_RELAY_HEALTH_PROMPT,
+                        }
+                    ],
                 },
             },
             timeout_at=started + timeout_sec,
@@ -1624,7 +1633,10 @@ def run_skillsbench_host_local_acp_transport_probe(
                 request_count += 1
                 await step("set_model", client.set_model("probe-model"))
                 request_count += 1
-                prompt = await step("prompt", client.prompt("relay handshake probe"))
+                prompt = await step(
+                    "prompt",
+                    client.prompt(SKILLSBENCH_LOCAL_ACP_RELAY_HEALTH_PROMPT),
+                )
                 request_count += 1
                 agent_name = str(getattr(initialize.agent_info, "name", "") or "")
                 session_id = str(getattr(session, "session_id", "") or "")

--- a/loopx/benchmark_ledger.py
+++ b/loopx/benchmark_ledger.py
@@ -403,6 +403,7 @@ def _compact_product_mode_lifecycle_contract(value: Any) -> dict[str, Any]:
         "satisfied",
         "countable_treatment",
         "checkpoint_required",
+        "orchestrated_driver_lifecycle_satisfied",
     ):
         if isinstance(value.get(field), bool):
             compact[field] = value[field]

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -736,6 +736,7 @@ def _compact_product_mode_lifecycle_contract(value: Any) -> dict[str, Any]:
         "agent_operation_trace_required",
         "agent_operation_trace_satisfied",
         "agent_operation_trace_missing",
+        "orchestrated_driver_lifecycle_satisfied",
     ):
         if isinstance(value.get(field), bool):
             compact[field] = value[field]

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -82,6 +82,7 @@ from loopx.benchmark_case_state import (  # noqa: E402
     BENCHMARK_CASE_LOOPX_REGISTRY_PATH,
     BENCHMARK_CASE_LOOPX_RUNTIME_ROOT,
     BENCHMARK_CASE_LOOPX_SOURCE_MOUNT_TARGET,
+    BENCHMARK_CASE_LOOPX_ORCHESTRATED_EXECUTION_STYLE,
     BENCHMARK_CASE_LOOPX_TODO_ID,
     benchmark_case_loopx_command_prefix,
     benchmark_case_loopx_install_payload,
@@ -138,6 +139,11 @@ DEFAULT_TIMEOUT_SEC = 7200
 DEFAULT_VERIFIER_PREP_TIMEOUT_SEC = 120
 DEFAULT_PRODUCT_MODE_SOFT_VERIFY_POLICY = "final-only"
 DEFAULT_MAX_ROUNDS = 8
+HOST_LOCAL_ACP_TARGET_ENV_KEYS = (
+    "AI_ADDR",
+    "AI_PORT",
+    "GOAL_HARNESS_REMOTE_BENCH_ROOT",
+)
 _MISSING = object()
 SUPPORTED_ROUTES = (
     CODEX_ACP_BLIND_LOOP_BASELINE_ROUTE,
@@ -787,6 +793,65 @@ def _host_local_acp_launch_command(
     return command
 
 
+def _host_local_acp_target_env(agent_env: object) -> dict[str, str]:
+    if not isinstance(agent_env, dict):
+        return {}
+    target_env: dict[str, str] = {}
+    for key in HOST_LOCAL_ACP_TARGET_ENV_KEYS:
+        value = agent_env.get(key)
+        if value is None:
+            continue
+        target_env[key] = str(value)
+    return target_env
+
+
+def _replace_option_value(command: list[str], option: str, value: str) -> list[str]:
+    updated = list(command)
+    for index, item in enumerate(updated[:-1]):
+        if item == option:
+            updated[index + 1] = value
+    return updated
+
+
+def _host_local_acp_docker_bridge_command(
+    env: Any,
+    args: argparse.Namespace,
+    plan: dict[str, Any],
+) -> str | None:
+    compose_paths = getattr(env, "_docker_compose_paths", None)
+    environment_dir = getattr(env, "environment_dir", None)
+    session_id = getattr(env, "session_id", None)
+    if not compose_paths or environment_dir is None or not isinstance(session_id, str):
+        return None
+
+    try:
+        project_dir = str(Path(environment_dir).resolve().absolute())
+        compose_files = [str(Path(path).resolve().absolute()) for path in compose_paths]
+    except (TypeError, OSError):
+        return None
+    if not compose_files:
+        return None
+
+    project_name = session_id.lower().replace(".", "-")
+    prerequisites = plan.setdefault("runner_prerequisites", {})
+    prerequisites["host_local_acp_sandbox_bridge_configured"] = True
+    prerequisites["host_local_acp_sandbox_bridge_mode"] = "docker_compose"
+    prerequisites["host_local_acp_sandbox_bridge_compose_file_count"] = len(
+        compose_files
+    )
+    prerequisites["host_local_acp_sandbox_bridge_path_recorded"] = False
+    bridge_script = Path(args.loopx_source_dir or REPO_ROOT) / "scripts" / (
+        "skillsbench_docker_command_file_bridge.py"
+    )
+    command = [sys.executable, str(bridge_script)]
+    command.extend(["--project-name", project_name])
+    command.extend(["--project-dir", project_dir])
+    for compose_file in compose_files:
+        command.extend(["--compose-file", compose_file])
+    command.extend(["--service", "main"])
+    return shlex.join(command)
+
+
 def _host_local_acp_codex_exec_preflight_command(
     args: argparse.Namespace,
     plan: dict[str, Any],
@@ -1025,6 +1090,7 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "benchflow_setup_stall_cleanup_status",
         "remote_command_file_bridge_consumption_status",
         "remote_command_file_bridge_agent_operation_trace_status",
+        "host_local_acp_sandbox_bridge_mode",
         "host_local_acp_codex_exec_preflight_status",
         "host_local_acp_codex_exec_preflight_stage",
         "host_local_acp_codex_exec_preflight_first_blocker",
@@ -1041,6 +1107,9 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "codex_acp_runtime_launch_preflight",
         "codex_acp_runtime_launch_preflight_raw_logs_read",
         "host_local_acp_launch",
+        "host_local_acp_sandbox_bridge_configured",
+        "host_local_acp_sandbox_bridge_path_recorded",
+        "host_local_acp_target_env_forwarded",
         "host_local_acp_codex_exec_preflight_requested",
         "host_local_acp_codex_exec_preflight_ready",
         "container_codex_acp_install_skipped",
@@ -1143,11 +1212,20 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "remote_command_file_bridge_driver_lifecycle_loopx_cli_call_count",
         "remote_command_file_bridge_driver_lifecycle_loopx_state_read_count",
         "remote_command_file_bridge_driver_lifecycle_loopx_state_write_count",
+        "host_local_acp_sandbox_bridge_compose_file_count",
+        "host_local_acp_target_env_key_count",
         "host_local_acp_codex_exec_preflight_attempt_count",
         "host_local_acp_codex_exec_failure_trace_count",
     ):
         if isinstance(value.get(field), int) and not isinstance(value.get(field), bool):
             compact[field] = value[field]
+    target_keys = value.get("host_local_acp_target_env_keys")
+    if isinstance(target_keys, list):
+        compact["host_local_acp_target_env_keys"] = [
+            key
+            for key in target_keys
+            if isinstance(key, str) and key in HOST_LOCAL_ACP_TARGET_ENV_KEYS
+        ][: len(HOST_LOCAL_ACP_TARGET_ENV_KEYS)]
     for field in (
         "remote_command_file_bridge_agent_operation_counts",
         "remote_command_file_bridge_agent_loopx_subcommand_counts",
@@ -1744,6 +1822,26 @@ def _runner_prerequisite_failure_attribution(
     if not isinstance(value, dict):
         return None
 
+    def count(key: str) -> int:
+        raw = value.get(key)
+        if isinstance(raw, int) and not isinstance(raw, bool):
+            return max(0, raw)
+        return 0
+
+    orchestrated_driver_lifecycle_satisfied = bool(
+        value.get("remote_command_file_bridge_driver_lifecycle_execution_style")
+        == BENCHMARK_CASE_LOOPX_ORCHESTRATED_EXECUTION_STYLE
+        and count("remote_command_file_bridge_driver_lifecycle_checkpoint_count") > 0
+        and count("remote_command_file_bridge_driver_lifecycle_success_count") > 0
+        and count("remote_command_file_bridge_driver_lifecycle_failure_count") == 0
+        and count("remote_command_file_bridge_driver_lifecycle_loopx_cli_call_count")
+        > 0
+        and count("remote_command_file_bridge_driver_lifecycle_loopx_state_read_count")
+        > 0
+        and count("remote_command_file_bridge_driver_lifecycle_loopx_state_write_count")
+        > 0
+    )
+
     if (
         value.get("benchflow_setup_stall_timeout_triggered") is True
         and value.get("benchflow_setup_stall_before_agent_lifecycle") is True
@@ -1805,6 +1903,7 @@ def _runner_prerequisite_failure_attribution(
 
     if (
         value.get("remote_command_file_bridge_agent_operation_trace_required") is True
+        and not orchestrated_driver_lifecycle_satisfied
         and value.get("remote_command_file_bridge_agent_operation_trace_satisfied")
         is False
     ):
@@ -5001,9 +5100,7 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
         **_ignored: Any,
     ) -> tuple[Any, Any, Any, str]:
         del (
-            env,
             agent_launch,
-            agent_env,
             sandbox_user,
             rollout_dir,
             environment,
@@ -5015,10 +5112,39 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
 
         prerequisites = plan.setdefault("runner_prerequisites", {})
         prerequisites["host_local_acp_launch_status"] = "connecting"
+        local_acp_command = list(host_local_acp_command)
+        sandbox_bridge_command = _host_local_acp_docker_bridge_command(
+            env,
+            args,
+            plan,
+        )
+        if sandbox_bridge_command:
+            local_acp_command = _replace_option_value(
+                local_acp_command,
+                "--remote-command-file-bridge-command",
+                sandbox_bridge_command,
+            )
+            local_acp_command = _replace_option_value(
+                local_acp_command,
+                "--remote-command-file-bridge-agent-command",
+                sandbox_bridge_command,
+            )
+        else:
+            prerequisites.setdefault(
+                "host_local_acp_sandbox_bridge_mode",
+                "configured_command_fallback",
+            )
+            prerequisites.setdefault("host_local_acp_sandbox_bridge_configured", False)
+            prerequisites.setdefault("host_local_acp_sandbox_bridge_path_recorded", False)
+        target_env = _host_local_acp_target_env(agent_env)
+        prerequisites["host_local_acp_target_env_forwarded"] = bool(target_env)
+        prerequisites["host_local_acp_target_env_key_count"] = len(target_env)
+        prerequisites["host_local_acp_target_env_keys"] = sorted(target_env)
         client = ACPClient(
             StdioTransport(
-                command=host_local_acp_command[0],
-                args=host_local_acp_command[1:],
+                command=local_acp_command[0],
+                args=local_acp_command[1:],
+                env=target_env,
                 cwd=str(REPO_ROOT),
             )
         )

--- a/scripts/skillsbench_docker_command_file_bridge.py
+++ b/scripts/skillsbench_docker_command_file_bridge.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+"""Docker-compose backed SkillsBench command/file bridge.
+
+The bridge implements the same stdin/stdout JSON contract as the remote
+command-file bridge, but targets a live local BenchFlow Docker sandbox through
+``docker compose exec`` instead of SSH. It is intentionally private-output
+oriented: raw command/file output may be returned to the agent, while public
+traces consume only the bounded operation status fields emitted by the probe.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.benchmark_adapters.skillsbench_remote_bridge import (  # noqa: E402
+    SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_PROBE_REQUEST_SCHEMA_VERSION,
+    build_skillsbench_remote_command_file_bridge_probe_response,
+)
+
+
+MARKER_CONTENT = "loopx-skillsbench-docker-bridge-probe"
+OPERATION_RESPONSE_SCHEMA_VERSION = (
+    "skillsbench_remote_command_file_bridge_operation_response_v0"
+)
+MAX_CAPTURE_BYTES = 200_000
+
+
+def _json_response(payload: dict[str, Any]) -> int:
+    print(json.dumps(payload, sort_keys=True))
+    return 0
+
+
+def _safe_path(value: Any, *, allow_file: bool = True) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError("path_missing")
+    if "\x00" in text or not text.startswith("/"):
+        raise ValueError("path_invalid")
+    allowed_roots = ("/app", "/tmp")
+    if not any(text == root or text.startswith(root + "/") for root in allowed_roots):
+        raise ValueError("path_outside_allowed_roots")
+    if not allow_file and text == "/app":
+        raise ValueError("path_refuses_app_root")
+    return text
+
+
+def _bounded_text(data: bytes, *, limit: int) -> tuple[str, bool]:
+    clipped = data[:limit]
+    return clipped.decode("utf-8", errors="replace"), len(data) > limit
+
+
+def _operation_response(
+    *,
+    ok: bool,
+    operation: str,
+    first_blocker: str | None = None,
+    **extra: Any,
+) -> dict[str, Any]:
+    payload = {
+        "schema_version": OPERATION_RESPONSE_SCHEMA_VERSION,
+        "ok": ok,
+        "operation": operation,
+        "first_blocker": first_blocker,
+        "raw_task_text_recorded": False,
+        "credential_values_recorded": False,
+        "upload_performed": False,
+        "submit_performed": False,
+    }
+    payload.update(extra)
+    return payload
+
+
+class DockerCommandFileBridge:
+    def __init__(
+        self,
+        *,
+        project_name: str,
+        project_dir: str,
+        compose_files: list[str],
+        service: str,
+    ) -> None:
+        self.project_name = project_name
+        self.project_dir = project_dir
+        self.compose_files = compose_files
+        self.service = service
+
+    def _compose_base(self) -> list[str]:
+        command = [
+            "docker",
+            "compose",
+            "-p",
+            self.project_name,
+            "--project-directory",
+            self.project_dir,
+        ]
+        for compose_file in self.compose_files:
+            command.extend(["-f", compose_file])
+        return command
+
+    def _compose_exec(
+        self,
+        shell_command: str,
+        *,
+        cwd: str | None = None,
+        stdin: bytes | None = None,
+        timeout_seconds: int = 30,
+    ) -> subprocess.CompletedProcess[bytes]:
+        command = [*self._compose_base(), "exec", "-T"]
+        if cwd:
+            command.extend(["-w", cwd])
+        command.extend([self.service, "bash", "-lc", shell_command])
+        return subprocess.run(
+            command,
+            input=stdin,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout_seconds + 10,
+            check=False,
+        )
+
+    def run_operation(self, request: dict[str, Any]) -> int:
+        operation = str(request.get("operation") or "").strip()
+        if operation not in {"exec", "read_file", "write_file", "cleanup"}:
+            return _json_response(
+                _operation_response(
+                    ok=False,
+                    operation=operation or "unknown",
+                    first_blocker="operation_invalid",
+                )
+            )
+        timeout_seconds = max(1, min(int(request.get("timeout_sec") or 30), 300))
+        try:
+            if operation == "exec":
+                return self._run_exec(request, timeout_seconds)
+            if operation == "read_file":
+                return self._run_read_file(request, timeout_seconds)
+            if operation == "write_file":
+                return self._run_write_file(request, timeout_seconds)
+            return self._run_cleanup(request, timeout_seconds)
+        except subprocess.TimeoutExpired:
+            return _json_response(
+                _operation_response(
+                    ok=False,
+                    operation=operation,
+                    first_blocker="operation_timeout",
+                )
+            )
+        except ValueError as exc:
+            return _json_response(
+                _operation_response(
+                    ok=False,
+                    operation=operation,
+                    first_blocker=str(exc) or "request_invalid",
+                )
+            )
+
+    def _run_exec(self, request: dict[str, Any], timeout_seconds: int) -> int:
+        cwd = _safe_path(request.get("cwd") or "/app")
+        command = str(request.get("command") or "").strip()
+        if not command:
+            raise ValueError("command_missing")
+        proc = self._compose_exec(
+            "timeout "
+            + shlex.quote(str(timeout_seconds))
+            + " sh -lc "
+            + shlex.quote(command),
+            cwd=cwd,
+            timeout_seconds=timeout_seconds,
+        )
+        stdout, stdout_truncated = _bounded_text(proc.stdout, limit=MAX_CAPTURE_BYTES)
+        stderr, stderr_truncated = _bounded_text(proc.stderr, limit=MAX_CAPTURE_BYTES)
+        return _json_response(
+            _operation_response(
+                ok=proc.returncode == 0,
+                operation="exec",
+                first_blocker=None if proc.returncode == 0 else "exec_failed",
+                exit_code=proc.returncode,
+                stdout=stdout,
+                stderr=stderr,
+                stdout_truncated=stdout_truncated,
+                stderr_truncated=stderr_truncated,
+            )
+        )
+
+    def _run_read_file(self, request: dict[str, Any], timeout_seconds: int) -> int:
+        path = _safe_path(request.get("path"))
+        max_bytes = max(
+            1,
+            min(int(request.get("max_bytes") or MAX_CAPTURE_BYTES), MAX_CAPTURE_BYTES),
+        )
+        proc = self._compose_exec(
+            "dd if=" + shlex.quote(path) + " bs=1 count=" + shlex.quote(str(max_bytes)),
+            timeout_seconds=timeout_seconds,
+        )
+        content, truncated = _bounded_text(proc.stdout, limit=max_bytes)
+        stderr, stderr_truncated = _bounded_text(proc.stderr, limit=MAX_CAPTURE_BYTES)
+        return _json_response(
+            _operation_response(
+                ok=proc.returncode == 0,
+                operation="read_file",
+                first_blocker=None if proc.returncode == 0 else "read_file_failed",
+                exit_code=proc.returncode,
+                content=content,
+                content_truncated=truncated,
+                stderr=stderr,
+                stderr_truncated=stderr_truncated,
+            )
+        )
+
+    def _run_write_file(self, request: dict[str, Any], timeout_seconds: int) -> int:
+        path = _safe_path(request.get("path"))
+        content = str(request.get("content") or "")
+        proc = self._compose_exec(
+            "mkdir -p "
+            + shlex.quote(str(Path(path).parent))
+            + " && cat > "
+            + shlex.quote(path),
+            stdin=content.encode("utf-8"),
+            timeout_seconds=timeout_seconds,
+        )
+        stderr, stderr_truncated = _bounded_text(proc.stderr, limit=MAX_CAPTURE_BYTES)
+        return _json_response(
+            _operation_response(
+                ok=proc.returncode == 0,
+                operation="write_file",
+                first_blocker=None if proc.returncode == 0 else "write_file_failed",
+                exit_code=proc.returncode,
+                bytes_written=len(content.encode("utf-8")),
+                stderr=stderr,
+                stderr_truncated=stderr_truncated,
+            )
+        )
+
+    def _run_cleanup(self, request: dict[str, Any], timeout_seconds: int) -> int:
+        path = _safe_path(request.get("path"), allow_file=False)
+        proc = self._compose_exec(
+            "rm -rf -- " + shlex.quote(path),
+            timeout_seconds=timeout_seconds,
+        )
+        stderr, stderr_truncated = _bounded_text(proc.stderr, limit=MAX_CAPTURE_BYTES)
+        return _json_response(
+            _operation_response(
+                ok=proc.returncode == 0,
+                operation="cleanup",
+                first_blocker=None if proc.returncode == 0 else "cleanup_failed",
+                exit_code=proc.returncode,
+                stderr=stderr,
+                stderr_truncated=stderr_truncated,
+            )
+        )
+
+    def probe(self, timeout_seconds: int) -> tuple[list[dict[str, Any]], str | None]:
+        probe_dir = "/tmp/loopx-skillsbench-command-file-bridge"
+        marker = probe_dir + "/marker.txt"
+        exec_proc = self._compose_exec(
+            "mkdir -p "
+            + shlex.quote(probe_dir)
+            + " && test -d "
+            + shlex.quote(probe_dir),
+            timeout_seconds=timeout_seconds,
+        )
+        write_proc = self._compose_exec(
+            "mkdir -p " + shlex.quote(probe_dir) + " && cat > " + shlex.quote(marker),
+            stdin=MARKER_CONTENT.encode("utf-8"),
+            timeout_seconds=timeout_seconds,
+        )
+        read_proc = self._compose_exec(
+            "cat " + shlex.quote(marker),
+            timeout_seconds=timeout_seconds,
+        )
+        cleanup_proc = self._compose_exec(
+            "rm -f " + shlex.quote(marker),
+            timeout_seconds=timeout_seconds,
+        )
+        read_text, _ = _bounded_text(read_proc.stdout, limit=MAX_CAPTURE_BYTES)
+        operations = [
+            {
+                "kind": "exec",
+                "label": "bounded_noop_command",
+                "status": "ok" if exec_proc.returncode == 0 else "failed",
+                "exit_code_zero": exec_proc.returncode == 0,
+            },
+            {
+                "kind": "write_file",
+                "label": "probe_marker_write",
+                "status": "ok" if write_proc.returncode == 0 else "failed",
+            },
+            {
+                "kind": "read_file",
+                "label": "probe_marker_read",
+                "status": (
+                    "ok"
+                    if read_proc.returncode == 0 and read_text == MARKER_CONTENT
+                    else "failed"
+                ),
+                "content_match": read_proc.returncode == 0
+                and read_text == MARKER_CONTENT,
+            },
+            {
+                "kind": "cleanup",
+                "label": "probe_marker_cleanup",
+                "status": "ok" if cleanup_proc.returncode == 0 else "failed",
+            },
+        ]
+        failed = [item["kind"] for item in operations if item["status"] != "ok"]
+        blocker = None if not failed else f"skillsbench_docker_bridge_{failed[0]}_failed"
+        return operations, blocker
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--project-name", required=True)
+    parser.add_argument("--project-dir", required=True)
+    parser.add_argument("--compose-file", action="append", required=True)
+    parser.add_argument("--service", default="main")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    bridge = DockerCommandFileBridge(
+        project_name=args.project_name,
+        project_dir=args.project_dir,
+        compose_files=list(args.compose_file or []),
+        service=args.service,
+    )
+    try:
+        request = json.loads(sys.stdin.read() or "{}")
+    except json.JSONDecodeError:
+        response = build_skillsbench_remote_command_file_bridge_probe_response(
+            ready=False,
+            first_blocker="skillsbench_remote_command_file_bridge_request_invalid",
+            stage="parse_request",
+        )
+        return _json_response(response)
+    if "operation" in request:
+        return bridge.run_operation(request)
+    if (
+        request.get("schema_version")
+        != SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_PROBE_REQUEST_SCHEMA_VERSION
+    ):
+        response = build_skillsbench_remote_command_file_bridge_probe_response(
+            ready=False,
+            first_blocker="skillsbench_remote_command_file_bridge_request_schema_invalid",
+            stage="validate_request",
+        )
+        return _json_response(response)
+    timeout_seconds = max(1, min(int(request.get("timeout_sec") or 30), 300))
+    operations, blocker = bridge.probe(timeout_seconds)
+    response = build_skillsbench_remote_command_file_bridge_probe_response(
+        ready=blocker is None and all(item["status"] == "ok" for item in operations),
+        operations=operations,
+        first_blocker=blocker,
+        stage="docker_compose_probe",
+    )
+    return _json_response(response)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/skillsbench_reverse_channel_bridge.py
+++ b/scripts/skillsbench_reverse_channel_bridge.py
@@ -229,6 +229,8 @@ def _serve_socket(
             with conn:
                 try:
                     payload = _recv_json_line(conn)
+                    if not payload:
+                        continue
                     response = handler(payload)
                 except Exception as exc:  # keep client deterministic
                     response = {
@@ -239,7 +241,12 @@ def _serve_socket(
                         "raw_task_text_recorded": False,
                         "credential_values_recorded": False,
                     }
-                _send_json_line(conn, response)
+                try:
+                    _send_json_line(conn, response)
+                except (BrokenPipeError, ConnectionResetError):
+                    if once:
+                        return 1
+                    continue
             if once:
                 return 0
     finally:


### PR DESCRIPTION
## Summary
- Add a docker-compose backed command/file bridge for host-local SkillsBench ACP runs so the local relay can execute inside the live BenchFlow sandbox without relying on missing `AI_ADDR`/`AI_PORT` env forwarding.
- Treat `orchestrated_agentloop_loopx_cli` driver lifecycle evidence as a valid LoopX product-mode lifecycle when public counters show checkpoint plus successful LoopX CLI read/write activity.
- Keep prompt-driven product mode strict: missing agent operation traces or zero agent bridge requests still make prompt-driven runs uncountable.
- Clear generic post-score runner-error attribution when official score passes and the product lifecycle contract is countable.

## Validation
- `python3 -m py_compile scripts/skillsbench_automation_loop.py scripts/skillsbench_docker_command_file_bridge.py loopx/benchmark_adapters/skillsbench.py loopx/benchmark_adapters/skillsbench_acp_relay.py loopx/status.py loopx/benchmark_ledger.py examples/skillsbench-benchmark-run-smoke.py examples/skillsbench-host-local-launch-plan-smoke.py examples/skillsbench-reverse-channel-bridge-smoke.py scripts/skillsbench_reverse_channel_bridge.py`
- `python3 examples/skillsbench-benchmark-run-smoke.py`
- `python3 examples/skillsbench-host-local-launch-plan-smoke.py`
- `python3 examples/skillsbench-reverse-channel-bridge-smoke.py`
- Remote ECS: same core smoke suite passed in the PR #622 source checkout.
- Remote reduce-only on the completed `organize-messy-files` formal8 result: official score `1.0`, lifecycle contract `satisfied=true/countable_treatment=true`, execution style `orchestrated_agentloop_loopx_cli`, score failure attribution `none`, no failure labels.

## Boundary
- No raw task text, raw trajectories, verifier output tails, credentials, or local private artifact paths are added to committed files.
- The remote reduce-only validation used existing public compact/result artifacts only; no leaderboard upload or submission.
