### PR TITLE
Add reward lesson projection warnings

### DIFF
--- a/docs/integration.md
+++ b/docs/integration.md
@@ -534,6 +534,27 @@ The run-bound `human_reward` overlay remains the source of truth. Active state
 is only the human-readable pointer and next-action summary; a dashboard Review
 Packet is only an immediate handoff artifact.
 
+For explicit user corrections, add a compact lesson to the same run-bound
+overlay instead of creating a separate memory store:
+
+```bash
+loopx reward \
+  --goal-id project-goal \
+  --decision route_correction \
+  --reward mixed \
+  --reason-summary "fix lifecycle counters before adding more benchmark cases" \
+  --lesson-kind benchmark_protocol \
+  --lesson-summary "Do not expand cases until lifecycle counters are validated" \
+  --lesson-avoid "expand cases before lifecycle counters" \
+  --lesson-prefer "validate lifecycle counters first" \
+  --write-active-state-summary
+```
+
+The lesson is advisory. `loopx status` exposes it under `human_reward`, and
+`loopx quota should-run` warns when a future `recommended_action` appears to
+contradict the lesson. It does not authorize writes, launch benchmarks, or
+replace formal todo/Next Action updates.
+
 The Markdown output includes a `Write Effect` section that summarizes the
 selected run, run-overlay write or preview state, active-state writeback state,
 and the project-agent history lookup before the detailed reward fields.

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -1667,6 +1667,27 @@ The command appends a compact overlay row to the goal's `index.jsonl`. History
 loading merges later rows with the same run key, so feedback can be added
 without rewriting the original run JSON or Markdown payload.
 
+When the operator feedback is a route, priority, benchmark-protocol, safety, or
+operating-rule correction, the overlay may also include a compact lesson:
+
+```bash
+loopx reward \
+  --goal-id example-experiment-goal \
+  --decision route_correction \
+  --reward mixed \
+  --reason-summary "run the driver repair before expanding cases" \
+  --lesson-kind route \
+  --lesson-summary "Do not expand cases before driver repair is validated" \
+  --lesson-avoid "expand cases before driver repair" \
+  --lesson-prefer "validate driver repair first"
+```
+
+`human_reward.lesson` is a warning/rebase signal, not write-control. Status
+exports the compact lesson, and `quota should-run` may emit
+`reward_lesson_projection_warning` when the current `recommended_action`
+overlaps a recent lesson's `avoid` phrase. Agents should then update the
+affected todo or Next Action before continuing.
+
 Both dry-run and append responses include:
 
 ```json

--- a/examples/cli-project-lifecycle-command-modularization-smoke.py
+++ b/examples/cli-project-lifecycle-command-modularization-smoke.py
@@ -198,7 +198,7 @@ def main() -> None:
     for command, options in {
         "refresh-state": ("--delivery-outcome", "--agent-id", "--dry-run"),
         "read-only-map": ("--recommended-action", "--dry-run"),
-        "reward": ("--write-active-state-summary", "--dry-run"),
+        "reward": ("--write-active-state-summary", "--lesson-kind", "--lesson-avoid", "--dry-run"),
         "operator-gate": ("--agent-command", "--no-global-sync"),
     }.items():
         help_text = require_success(run_cli(command, "--help"))
@@ -269,6 +269,14 @@ def main() -> None:
                 "synthetic dry-run reward",
                 "--follow-up",
                 "continue modularization smoke",
+                "--lesson-kind",
+                "route",
+                "--lesson-summary",
+                "Keep modularization dry-run checks ahead of broad lifecycle rewrites.",
+                "--lesson-avoid",
+                "broad lifecycle rewrite before dry-run check",
+                "--lesson-prefer",
+                "modularization dry-run check",
                 "--dry-run",
                 "--format",
                 "json",
@@ -279,6 +287,12 @@ def main() -> None:
         require(
             (reward_payload.get("human_reward") or {}).get("reward") == "positive",
             "reward payload polarity changed",
+        )
+        reward_lesson = (reward_payload.get("human_reward") or {}).get("lesson") or {}
+        require(reward_lesson.get("kind") == "route", "reward lesson kind changed")
+        require(
+            reward_lesson.get("avoid") == ["broad lifecycle rewrite before dry-run check"],
+            "reward lesson avoid changed",
         )
 
         gate_payload = require_json_success(

--- a/examples/reward-lesson-projection-smoke.py
+++ b/examples/reward-lesson-projection-smoke.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Validate human_reward lesson projection into status/quota warnings."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.feedback import compact_reward
+from loopx.quota import build_quota_should_run, render_quota_should_run_markdown
+from loopx.status import compact_human_reward
+
+
+GOAL_ID = "reward-lesson-projection-smoke"
+
+
+def status_payload(reward: dict) -> dict:
+    action = "[P1] Run SkillsBench before fixing the reward lesson projection."
+    agent_todos = {
+        "schema_version": "todo_summary_v0",
+        "source_section": "Agent Todo",
+        "total_count": 1,
+        "open_count": 1,
+        "done_count": 0,
+        "first_open_items": [
+            {
+                "index": 1,
+                "text": action,
+                "role": "agent",
+                "status": "open",
+                "priority": "P1",
+                "task_class": "advancement_task",
+                "action_kind": "run_skillsbench",
+                "todo_id": "todo_reward_lesson_projection",
+            }
+        ],
+    }
+    item = {
+        "goal_id": GOAL_ID,
+        "status": "reward_lesson_projection_smoke",
+        "waiting_on": "codex",
+        "severity": "info",
+        "source": "project_asset",
+        "recommended_action": action,
+        "quota": {
+            "compute": 1.0,
+            "window_hours": 24,
+            "slot_minutes": 1,
+            "allowed_slots": 10,
+            "spent_slots": 0,
+            "state": "eligible",
+            "reason": "eligible fixture",
+        },
+        "project_asset": {
+            "next_action": action,
+            "stop_condition": "stop on private material",
+            "agent_todos": agent_todos,
+        },
+    }
+    return {
+        "ok": True,
+        "attention_queue": {"items": [item]},
+        "run_history": {
+            "goals": [
+                {
+                    "id": GOAL_ID,
+                    "registry_member": True,
+                    "status": "reward_lesson_projection_smoke",
+                    "adapter_kind": "harness_self_improvement",
+                    "adapter_status": "connected-read-only",
+                    "quota": {
+                        "compute": 1.0,
+                        "window_hours": 24,
+                        "slot_minutes": 1,
+                        "allowed_slots": 10,
+                    },
+                    "latest_runs": [
+                        {
+                            "generated_at": "2026-06-24T00:00:00+00:00",
+                            "goal_id": GOAL_ID,
+                            "classification": "human_reward_recorded",
+                            "recommended_action": "Run SkillsBench before fixing the route.",
+                            "human_reward": reward,
+                        }
+                    ],
+                }
+            ]
+        },
+    }
+
+
+def main() -> int:
+    reward = compact_reward(
+        recorded_at="2026-06-24T00:00:00+00:00",
+        decision="route_correction",
+        reward="mixed",
+        reason_summary="User corrected the route: fix durable lesson projection before running more cases.",
+        follow_up="Update the affected todo and next action before benchmark expansion.",
+        lesson={
+            "kind": "route",
+            "summary": "Do not expand benchmark cases before the lesson projection route is fixed.",
+            "avoid": ["Run SkillsBench before fixing"],
+            "prefer": ["fix reward lesson projection"],
+        },
+    )
+    compact = compact_human_reward(reward)
+    assert compact is not None, reward
+    assert compact["lesson"]["schema_version"] == "human_reward_lesson_v0", compact
+    assert compact["lesson"]["kind"] == "route", compact
+    assert compact["lesson"]["avoid"] == ["Run SkillsBench before fixing"], compact
+
+    guard = build_quota_should_run(status_payload(compact), goal_id=GOAL_ID)
+    warning = guard.get("reward_lesson_projection_warning")
+    assert isinstance(warning, dict), guard
+    assert warning["schema_version"] == "reward_lesson_projection_warning_v0", warning
+    assert warning["match_count"] == 1, warning
+    assert "Run SkillsBench" in warning["matches"][0]["avoid"], warning
+    markdown = render_quota_should_run_markdown(guard)
+    assert "reward_lesson_projection_warning" in markdown, markdown
+    assert "reward_lesson_action" in markdown, markdown
+
+    zero_token_reward = compact_reward(
+        recorded_at="2026-06-24T00:00:00+00:00",
+        decision="route_correction",
+        reward="mixed",
+        reason_summary="User correction phrase should not warn when it has no scope tokens.",
+        follow_up=None,
+        lesson={
+            "kind": "route",
+            "summary": "A tokenless avoid phrase should not match every recommended action.",
+            "avoid": ["P0"],
+        },
+    )
+    zero_token_compact = compact_human_reward(zero_token_reward)
+    assert zero_token_compact is not None, zero_token_reward
+    zero_token_guard = build_quota_should_run(status_payload(zero_token_compact), goal_id=GOAL_ID)
+    assert "reward_lesson_projection_warning" not in zero_token_guard, zero_token_guard
+    print("reward-lesson-projection smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/cli_commands/project_lifecycle.py
+++ b/loopx/cli_commands/project_lifecycle.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from pathlib import Path
 
 from ..delivery_outcome import DELIVERY_OUTCOME_CHOICES
-from ..feedback import append_human_reward, compact_reward, render_reward_markdown
+from ..feedback import LESSON_KINDS, append_human_reward, compact_reward, render_reward_markdown
 from ..operator_gate import (
     DEFAULT_OPERATOR_GATE,
     OPERATOR_GATE_DECISIONS,
@@ -177,6 +177,27 @@ def register_project_lifecycle_commands(
     )
     reward_parser.add_argument("--follow-up", help="Optional next handoff or experiment condition.")
     reward_parser.add_argument(
+        "--lesson-kind",
+        choices=sorted(LESSON_KINDS),
+        help="Optional public-safe lesson kind when this reward records an explicit user correction.",
+    )
+    reward_parser.add_argument(
+        "--lesson-summary",
+        help="Short public-safe lesson summary. Required when --lesson-kind is set.",
+    )
+    reward_parser.add_argument(
+        "--lesson-avoid",
+        action="append",
+        default=[],
+        help="Public-safe phrase/action that future recommended_action should avoid. Repeatable.",
+    )
+    reward_parser.add_argument(
+        "--lesson-prefer",
+        action="append",
+        default=[],
+        help="Public-safe phrase/action that future recommended_action should prefer. Repeatable.",
+    )
+    reward_parser.add_argument(
         "--state-file",
         help="Active goal state path for optional summary writeback. Defaults to the registry goal state_file.",
     )
@@ -329,6 +350,14 @@ def handle_project_lifecycle_command(
                 reward=args.reward,
                 reason_summary=args.reason_summary,
                 follow_up=args.follow_up,
+                lesson={
+                    "kind": args.lesson_kind,
+                    "summary": args.lesson_summary,
+                    "avoid": args.lesson_avoid,
+                    "prefer": args.lesson_prefer,
+                }
+                if args.lesson_kind
+                else None,
             )
             payload = append_human_reward(
                 registry_path=registry_path,

--- a/loopx/feedback.py
+++ b/loopx/feedback.py
@@ -12,6 +12,13 @@ from .registry import registry_goals, resolve_state_file
 
 
 REWARD_VALUES = {"positive", "negative", "mixed", "neutral"}
+LESSON_KINDS = {
+    "route",
+    "priority",
+    "benchmark_protocol",
+    "safety_boundary",
+    "operating_rule",
+}
 PRIVATE_TEXT_PATTERNS = (
     re.compile(r"/" + r"Users/"),
     re.compile(r"/" + r"ext_data/"),
@@ -30,6 +37,7 @@ HUMAN_REWARD_FIELDS = (
     "reward",
     "reason_summary",
     "follow_up",
+    "lesson",
 )
 RUN_OVERLAY_FIELDS = (
     "generated_at",
@@ -69,6 +77,7 @@ def compact_reward(
     reward: str,
     reason_summary: str,
     follow_up: str | None,
+    lesson: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     if reward not in REWARD_VALUES:
         raise ValueError(f"reward must be one of: {', '.join(sorted(REWARD_VALUES))}")
@@ -83,6 +92,38 @@ def compact_reward(
     }
     if follow_up:
         payload["follow_up"] = follow_up
+    if lesson:
+        payload["lesson"] = compact_reward_lesson(lesson)
+    return payload
+
+
+def compact_reward_lesson(lesson: dict[str, Any]) -> dict[str, Any]:
+    kind = str(lesson.get("kind") or "").strip()
+    summary = str(lesson.get("summary") or "").strip()
+    if kind not in LESSON_KINDS:
+        raise ValueError(f"lesson kind must be one of: {', '.join(sorted(LESSON_KINDS))}")
+    if not summary:
+        raise ValueError("lesson summary is required when lesson metadata is provided")
+    validate_public_safe_text("lesson summary", summary)
+    payload: dict[str, Any] = {
+        "schema_version": "human_reward_lesson_v0",
+        "kind": kind,
+        "summary": summary,
+    }
+    for field in ("avoid", "prefer"):
+        raw_items = lesson.get(field) or []
+        if isinstance(raw_items, str):
+            raw_items = [raw_items]
+        items: list[str] = []
+        for raw_item in raw_items:
+            item = str(raw_item or "").strip()
+            if not item:
+                continue
+            validate_public_safe_text(f"lesson {field}", item)
+            if item not in items:
+                items.append(item)
+        if items:
+            payload[field] = items[:5]
     return payload
 
 
@@ -145,14 +186,23 @@ def build_reward_coordination(
     follow_up = reward.get("follow_up")
     if follow_up:
         summary = f"{summary} follow_up：{follow_up}"
+    lesson = reward.get("lesson") if isinstance(reward.get("lesson"), dict) else {}
+    if lesson:
+        summary = (
+            f"{summary} lesson[{lesson.get('kind')}]: "
+            f"{lesson.get('summary')}"
+        )
+    visibility = {
+        "source_of_truth": "run_bound_human_reward_overlay",
+        "history_command": f"loopx history --goal-id {goal_id} --limit 3",
+        "active_state_role": "summary_only",
+        "review_packet_role": "optional_handoff_only",
+    }
+    if lesson:
+        visibility["lesson_role"] = "route_warning_only_not_write_control"
     return {
         "active_state_summary": summary,
-        "project_agent_visibility": {
-            "source_of_truth": "run_bound_human_reward_overlay",
-            "history_command": f"loopx history --goal-id {goal_id} --limit 3",
-            "active_state_role": "summary_only",
-            "review_packet_role": "optional_handoff_only",
-        },
+        "project_agent_visibility": visibility,
     }
 
 
@@ -416,6 +466,14 @@ def render_reward_markdown(payload: dict[str, Any]) -> str:
     )
     if reward.get("follow_up"):
         lines.append(f"- follow_up: {reward.get('follow_up')}")
+    lesson = reward.get("lesson") if isinstance(reward.get("lesson"), dict) else {}
+    if lesson:
+        lines.append(f"- lesson_kind: `{lesson.get('kind')}`")
+        lines.append(f"- lesson_summary: {lesson.get('summary')}")
+        for field in ("avoid", "prefer"):
+            values = lesson.get(field) if isinstance(lesson.get(field), list) else []
+            if values:
+                lines.append(f"- lesson_{field}: {', '.join(str(value) for value in values[:5])}")
     if payload.get("active_state_summary"):
         lines.extend(["", "## Active-State Summary", str(payload.get("active_state_summary"))])
     if state_update:

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -5151,6 +5151,95 @@ def _promotion_readiness_warning(status_payload: dict[str, Any]) -> dict[str, An
     }
 
 
+def _recent_reward_lessons(status_payload: dict[str, Any], *, goal_id: str) -> list[dict[str, Any]]:
+    run_history = (
+        status_payload.get("run_history")
+        if isinstance(status_payload.get("run_history"), dict)
+        else {}
+    )
+    goals = run_history.get("goals") if isinstance(run_history.get("goals"), list) else []
+    goal = next(
+        (
+            candidate
+            for candidate in goals
+            if isinstance(candidate, dict) and str(candidate.get("id") or "") == goal_id
+        ),
+        None,
+    )
+    if not isinstance(goal, dict):
+        return []
+    lessons: list[dict[str, Any]] = []
+    for run in goal.get("latest_runs") or []:
+        if not isinstance(run, dict):
+            continue
+        reward = run.get("human_reward") if isinstance(run.get("human_reward"), dict) else {}
+        lesson = reward.get("lesson") if isinstance(reward.get("lesson"), dict) else {}
+        if not lesson:
+            continue
+        lessons.append(
+            {
+                "generated_at": run.get("generated_at"),
+                "decision": reward.get("decision"),
+                "reward": reward.get("reward"),
+                "kind": lesson.get("kind"),
+                "summary": lesson.get("summary"),
+                "avoid": lesson.get("avoid") if isinstance(lesson.get("avoid"), list) else [],
+                "prefer": lesson.get("prefer") if isinstance(lesson.get("prefer"), list) else [],
+            }
+        )
+    return lessons
+
+
+def _reward_lesson_projection_warning(
+    status_payload: dict[str, Any],
+    *,
+    goal_id: str,
+    recommended_action: str | None,
+) -> dict[str, Any] | None:
+    action = str(recommended_action or "").strip()
+    if not action:
+        return None
+    action_lower = action.lower()
+    action_tokens = _action_scope_tokens_from_text(action)
+    matches: list[dict[str, Any]] = []
+    for lesson in _recent_reward_lessons(status_payload, goal_id=goal_id):
+        for avoid in lesson.get("avoid") or []:
+            avoid_text = str(avoid or "").strip()
+            if not avoid_text:
+                continue
+            avoid_tokens = _action_scope_tokens_from_text(avoid_text)
+            exact_match = avoid_text.lower() in action_lower
+            if not exact_match and not avoid_tokens:
+                continue
+            token_overlap = sorted(action_tokens & avoid_tokens)
+            if not exact_match and len(token_overlap) < min(2, len(avoid_tokens)):
+                continue
+            matches.append(
+                {
+                    "generated_at": lesson.get("generated_at"),
+                    "decision": lesson.get("decision"),
+                    "kind": lesson.get("kind"),
+                    "summary": lesson.get("summary"),
+                    "avoid": avoid_text,
+                    "token_overlap": token_overlap[:5],
+                }
+            )
+    if not matches:
+        return None
+    return {
+        "schema_version": "reward_lesson_projection_warning_v0",
+        "source": "run_history.human_reward.lesson",
+        "goal_id": goal_id,
+        "message": (
+            "recommended_action overlaps a recent human_reward lesson avoid rule; "
+            "rebase the route or update the affected todo/next action before continuing"
+        ),
+        "recommended_action": action,
+        "match_count": len(matches),
+        "matches": matches[:3],
+    }
+
+
 def _registry_goal_by_id(status_payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
     registry_value = status_payload.get("registry")
     if not registry_value:
@@ -5858,6 +5947,13 @@ def build_quota_should_run(
         promotion_warning = _promotion_readiness_warning(status_payload)
         if promotion_warning:
             payload["promotion_readiness_warning"] = promotion_warning
+        reward_lesson_warning = _reward_lesson_projection_warning(
+            status_payload,
+            goal_id=safe_goal_id,
+            recommended_action=selected_recommended_action,
+        )
+        if reward_lesson_warning:
+            payload["reward_lesson_projection_warning"] = reward_lesson_warning
         gate_prompt = _build_gate_prompt(item) if state == "operator_gate" else None
         if gate_prompt:
             payload["gate_prompt"] = gate_prompt
@@ -7657,6 +7753,29 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
         )
         if promotion_readiness_warning.get("reason"):
             lines.append(f"- promotion_readiness_reason: {promotion_readiness_warning.get('reason')}")
+    reward_lesson_warning = (
+        payload.get("reward_lesson_projection_warning")
+        if isinstance(payload.get("reward_lesson_projection_warning"), dict)
+        else {}
+    )
+    if reward_lesson_warning:
+        lines.append(
+            "- reward_lesson_projection_warning: "
+            f"matches={reward_lesson_warning.get('match_count')} "
+            f"source={reward_lesson_warning.get('source')}"
+        )
+        if reward_lesson_warning.get("message"):
+            lines.append(f"- reward_lesson_action: {reward_lesson_warning.get('message')}")
+        for match in (reward_lesson_warning.get("matches") or [])[:3]:
+            if not isinstance(match, dict):
+                continue
+            lines.append(
+                "- reward_lesson_match: "
+                f"kind={match.get('kind')} "
+                f"decision={match.get('decision')} "
+                f"avoid={match.get('avoid')} "
+                f"summary={match.get('summary')}"
+            )
     goal_boundary = payload.get("goal_boundary") if isinstance(payload.get("goal_boundary"), dict) else {}
     if goal_boundary:
         adapter = goal_boundary.get("adapter") if isinstance(goal_boundary.get("adapter"), dict) else {}

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -287,6 +287,7 @@ HUMAN_REWARD_COMPACT_FIELDS = (
     "reward",
     "reason_summary",
     "follow_up",
+    "lesson",
 )
 OPERATOR_GATE_COMPACT_FIELDS = (
     "recorded_at",
@@ -7399,6 +7400,13 @@ def compact_human_reward(reward: Any) -> dict[str, Any] | None:
     if not isinstance(reward, dict):
         return None
     compact = {field: reward[field] for field in HUMAN_REWARD_COMPACT_FIELDS if field in reward}
+    lesson = compact.get("lesson")
+    if isinstance(lesson, dict):
+        compact["lesson"] = {
+            field: lesson[field]
+            for field in ("schema_version", "kind", "summary", "avoid", "prefer")
+            if field in lesson
+        }
     return compact or None
 
 
@@ -7498,6 +7506,20 @@ def _append_human_reward_markdown(lines: list[str], goal_id: Any, reward: dict[s
     follow_up = reward.get("follow_up")
     if follow_up:
         lines.append(f"      - follow_up: {_markdown_scalar(follow_up)}")
+    lesson = reward.get("lesson") if isinstance(reward.get("lesson"), dict) else {}
+    if lesson:
+        lines.append(
+            "      - lesson: "
+            f"kind={_markdown_scalar(lesson.get('kind') or '')} "
+            f"summary={_markdown_scalar(lesson.get('summary') or '')}"
+        )
+        for field in ("avoid", "prefer"):
+            values = lesson.get(field) if isinstance(lesson.get(field), list) else []
+            if values:
+                lines.append(
+                    f"        - lesson_{field}: "
+                    + ", ".join(_markdown_scalar(value) for value in values[:5])
+                )
     if goal_id:
         lines.append(
             "      - project_agent_visibility: "

--- a/loopx/status_server.py
+++ b/loopx/status_server.py
@@ -32,6 +32,10 @@ REWARD_REQUEST_FIELDS = {
     "reward",
     "reason_summary",
     "follow_up",
+    "lesson_kind",
+    "lesson_summary",
+    "lesson_avoid",
+    "lesson_prefer",
 }
 REWARD_APPEND_FIELDS = REWARD_REQUEST_FIELDS | {
     "preview_id",
@@ -159,6 +163,16 @@ class StatusRequestHandler(BaseHTTPRequestHandler):
         run_generated_at = body.get("run_generated_at")
         follow_up_value = body.get("follow_up")
         follow_up = str(follow_up_value).strip() if follow_up_value else None
+        lesson_kind = str(body.get("lesson_kind") or "").strip()
+        lesson_summary = str(body.get("lesson_summary") or "").strip()
+        lesson = None
+        if lesson_kind or lesson_summary or body.get("lesson_avoid") or body.get("lesson_prefer"):
+            lesson = {
+                "kind": lesson_kind,
+                "summary": lesson_summary,
+                "avoid": body.get("lesson_avoid") or [],
+                "prefer": body.get("lesson_prefer") or [],
+            }
         if not goal_id:
             raise ValueError("goal_id is required")
         if append and not run_generated_at:
@@ -174,6 +188,7 @@ class StatusRequestHandler(BaseHTTPRequestHandler):
             reward=reward_value,
             reason_summary=reason_summary,
             follow_up=follow_up,
+            lesson=lesson,
         )
         return goal_id, str(run_generated_at).strip() if run_generated_at else None, reward
 


### PR DESCRIPTION
## Summary
- extend run-bound `human_reward` overlays with optional public-safe `lesson` metadata for explicit user corrections
- surface compact lessons through status/quota, including `reward_lesson_projection_warning` when a future recommended action overlaps an avoided route
- document the boundary: lessons are advisory rebase/warning signals, not write-control, benchmark launch authority, or a replacement for todo/Next Action updates

## Validation
- `python3 examples/reward-lesson-projection-smoke.py`
- `python3 examples/cli-project-lifecycle-command-modularization-smoke.py`
- `python3 examples/reward-append-api-smoke.py`
- `python3 -m py_compile loopx/feedback.py loopx/status.py loopx/quota.py loopx/status_server.py loopx/cli_commands/project_lifecycle.py`
- `git diff --check`
- `loopx --format json check --scan-path ...` (public boundary scan clean for 9 files; existing duplicate-index warning only)
- candidate path scan for credentials/private paths/raw benchmark evidence: clean aside from existing detector literals
