### PR TITLE
Distinguish delivery turn kinds in quota

### DIFF
--- a/examples/work-lane-contract-smoke.py
+++ b/examples/work-lane-contract-smoke.py
@@ -13,6 +13,7 @@ from loopx.quota import build_quota_should_run, render_quota_should_run_markdown
 from loopx.status import (
     TODO_TASK_CLASS_ADVANCEMENT,
     TODO_TASK_CLASS_MONITOR,
+    compact_post_handoff_run,
     normalize_todo_task_class,
 )
 
@@ -180,7 +181,46 @@ def assert_structured_surface_only_run_requires_outcome_followthrough() -> None:
         "outcome_followthrough_required",
     ], lane
     assert lane["outcome_followthrough"]["latest_delivery_outcome"] == "surface_only", lane
+    assert (
+        lane["outcome_followthrough"]["latest_delivery_turn_kind"]
+        == "contract_only_preparation"
+    ), lane
+    assert lane["outcome_followthrough"]["accepted_resolution_kinds"] == [
+        "product_path_execution",
+        "compact_evidence",
+        "blocker_writeback",
+    ], lane
     assert "contract-only" in lane["action"], lane
+    markdown = render_quota_should_run_markdown(guard)
+    assert "work_lane_outcome_followthrough:" in markdown, markdown
+    assert "latest_kind=contract_only_preparation" in markdown, markdown
+
+
+def assert_blocker_writeback_satisfies_contract_followthrough() -> None:
+    compact = compact_post_handoff_run(
+        {
+            "classification": "runner_precise_blocker_writeback",
+            "delivery_batch_scale": "implementation",
+            "delivery_outcome": "outcome_gap",
+            "health_check": "precise blocker writeback: remote runner auth unavailable",
+        }
+    )
+    assert compact["delivery_turn_kind"] == "blocker_writeback", compact
+
+    guard = build_quota_should_run(
+        status_payload(
+            status="runner_blocker_written",
+            next_action="Choose the next independent runnable todo after the blocker.",
+            post_handoff_latest_run=compact,
+        ),
+        goal_id=GOAL_ID,
+    )
+    lane = guard["work_lane_contract"]
+    assert guard["should_run"] is True, guard
+    assert lane["lane"] == "advancement_task", lane
+    assert lane["obligation"] == "advance_one_bounded_segment", lane
+    assert lane["reason_codes"] == ["open_agent_todo"], lane
+    assert "outcome_followthrough" not in lane, lane
 
 
 def assert_contract_word_alone_does_not_trigger_outcome_followthrough() -> None:
@@ -1557,6 +1597,7 @@ def main() -> int:
     assert_dependency_monitor_requires_advancement()
     assert_primary_status_stays_advancement_lane()
     assert_structured_surface_only_run_requires_outcome_followthrough()
+    assert_blocker_writeback_satisfies_contract_followthrough()
     assert_contract_word_alone_does_not_trigger_outcome_followthrough()
     assert_monitor_only_todo_waits_quietly()
     assert_monitor_only_with_user_todo_surfaces_user_action_without_transition()

--- a/loopx/delivery_outcome.py
+++ b/loopx/delivery_outcome.py
@@ -13,7 +13,19 @@ class DeliveryOutcome(str, Enum):
     PRIMARY_GOAL_OUTCOME = "primary_goal_outcome"
 
 
+class DeliveryTurnKind(str, Enum):
+    """Compact public-safe classification for why a delivery turn counts."""
+
+    CONTRACT_ONLY_PREPARATION = "contract_only_preparation"
+    COMPACT_EVIDENCE = "compact_evidence"
+    BLOCKER_WRITEBACK = "blocker_writeback"
+    PRODUCT_PATH_EXECUTION = "product_path_execution"
+    OUTCOME_GAP = "outcome_gap"
+    UNKNOWN = "unknown"
+
+
 DELIVERY_OUTCOME_CHOICES = tuple(outcome.value for outcome in DeliveryOutcome)
+DELIVERY_TURN_KIND_CHOICES = tuple(kind.value for kind in DeliveryTurnKind)
 DELIVERY_OUTCOME_UNKNOWN = "unknown"
 DELIVERY_OUTCOME_NOT_CONFIGURED = "not_configured"
 
@@ -33,6 +45,8 @@ PROGRESS_DELIVERY_OUTCOMES = ACCOUNTABLE_DELIVERY_OUTCOMES
 
 
 def normalize_delivery_outcome(value: Any) -> DeliveryOutcome | None:
+    if isinstance(value, DeliveryOutcome):
+        return value
     text = str(value or "").strip()
     if not text:
         return None
@@ -52,3 +66,79 @@ def require_delivery_outcome(value: Any) -> DeliveryOutcome:
 def delivery_outcome_value(value: Any) -> str | None:
     outcome = normalize_delivery_outcome(value)
     return outcome.value if outcome else None
+
+
+def normalize_delivery_turn_kind(value: Any) -> DeliveryTurnKind | None:
+    if isinstance(value, DeliveryTurnKind):
+        return value
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        return DeliveryTurnKind(text)
+    except ValueError:
+        return None
+
+
+def delivery_turn_kind_for_run(
+    run: dict[str, Any],
+    *,
+    delivery_outcome: Any = None,
+) -> str:
+    """Classify the latest turn without relying on free-form classification text alone."""
+
+    explicit = normalize_delivery_turn_kind(run.get("delivery_turn_kind"))
+    if explicit:
+        return explicit.value
+
+    outcome = normalize_delivery_outcome(
+        delivery_outcome if delivery_outcome is not None else run.get("delivery_outcome")
+    )
+    classification = str(run.get("classification") or "").strip().lower()
+    health_check = str(run.get("health_check") or "").strip().lower()
+    recommended_action = str(run.get("recommended_action") or "").strip().lower()
+    searchable = " ".join(part for part in (classification, health_check, recommended_action) if part)
+
+    if outcome == DeliveryOutcome.PRIMARY_GOAL_OUTCOME:
+        return DeliveryTurnKind.PRODUCT_PATH_EXECUTION.value
+
+    evidence_keys = (
+        "benchmark_run_summary",
+        "benchmark_result_summary",
+        "benchmark_comparison_summary",
+        "benchmark_learning_ledger_summary",
+        "benchmark_experiment_report_summary",
+        "active_user_assisted_pilot_summary",
+        "benchmark_run",
+        "benchmark_result",
+        "benchmark_comparison",
+        "benchmark_learning_ledger",
+        "benchmark_experiment_report",
+        "case_result",
+        "compact_evidence",
+    )
+    if outcome == DeliveryOutcome.OUTCOME_PROGRESS or any(run.get(key) for key in evidence_keys):
+        return DeliveryTurnKind.COMPACT_EVIDENCE.value
+
+    if any(hint in searchable for hint in ("blocker", "blocked", "cannot proceed", "can't proceed")):
+        return DeliveryTurnKind.BLOCKER_WRITEBACK.value
+
+    if outcome == DeliveryOutcome.SURFACE_ONLY or any(
+        hint in classification
+        for hint in (
+            "contract",
+            "prep",
+            "preparation",
+            "protocol",
+            "policy",
+            "surface",
+            "smoke",
+            "setup",
+        )
+    ):
+        return DeliveryTurnKind.CONTRACT_ONLY_PREPARATION.value
+
+    if outcome == DeliveryOutcome.OUTCOME_GAP:
+        return DeliveryTurnKind.OUTCOME_GAP.value
+
+    return DeliveryTurnKind.UNKNOWN.value

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -21,6 +21,8 @@ from .delivery_outcome import (
     ACCOUNTABLE_DELIVERY_OUTCOMES,
     DeliveryOutcome,
     FOLLOWTHROUGH_REQUIRED_DELIVERY_OUTCOMES,
+    DeliveryTurnKind,
+    delivery_turn_kind_for_run,
     normalize_delivery_outcome,
 )
 from .execution_profile import (
@@ -107,6 +109,7 @@ POST_HANDOFF_RUN_COMPACT_FIELDS = (
     "progress_scope",
     "delivery_batch_scale",
     "delivery_outcome",
+    "delivery_turn_kind",
     "health_check",
     "json_exists",
     "markdown_exists",
@@ -466,17 +469,39 @@ def _outcome_followthrough_hint(item: dict[str, Any]) -> dict[str, Any] | None:
         return None
     explicit_required = latest_run.get("outcome_followthrough_required") is True
     delivery_outcome = normalize_delivery_outcome(latest_run.get("delivery_outcome"))
+    delivery_turn_kind = delivery_turn_kind_for_run(
+        latest_run,
+        delivery_outcome=delivery_outcome,
+    )
     if delivery_outcome == DeliveryOutcome.PRIMARY_GOAL_OUTCOME:
         return None
+    if (
+        not explicit_required
+        and delivery_turn_kind == DeliveryTurnKind.BLOCKER_WRITEBACK.value
+    ):
+        return None
     classification = str(latest_run.get("classification") or "").strip()
-    if not explicit_required and delivery_outcome not in FOLLOWTHROUGH_REQUIRED_DELIVERY_OUTCOMES:
+    kind_requires_followthrough = (
+        delivery_turn_kind == DeliveryTurnKind.CONTRACT_ONLY_PREPARATION.value
+    )
+    if (
+        not explicit_required
+        and delivery_outcome not in FOLLOWTHROUGH_REQUIRED_DELIVERY_OUTCOMES
+        and not kind_requires_followthrough
+    ):
         return None
     return {
         "source": "post_handoff_latest_run",
         "required": True,
         "latest_classification": classification,
         "latest_delivery_outcome": delivery_outcome.value if delivery_outcome else None,
+        "latest_delivery_turn_kind": delivery_turn_kind,
         "obligation": "advance_primary_outcome_or_write_blocker",
+        "accepted_resolution_kinds": [
+            DeliveryTurnKind.PRODUCT_PATH_EXECUTION.value,
+            DeliveryTurnKind.COMPACT_EVIDENCE.value,
+            DeliveryTurnKind.BLOCKER_WRITEBACK.value,
+        ],
         "spend_policy": (
             "do not spend for another contract/preparation-only slice; spend only "
             "after validated product-path evidence, benchmark/case evidence, or a "
@@ -7392,6 +7417,18 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
             lines.append(f"- work_lane_monitor_policy: {work_lane_contract.get('monitor_policy')}")
         if work_lane_contract.get("action"):
             lines.append(f"- work_lane_action: {work_lane_contract.get('action')}")
+        outcome_followthrough = (
+            work_lane_contract.get("outcome_followthrough")
+            if isinstance(work_lane_contract.get("outcome_followthrough"), dict)
+            else {}
+        )
+        if outcome_followthrough:
+            lines.append(
+                "- work_lane_outcome_followthrough: "
+                f"latest_outcome={outcome_followthrough.get('latest_delivery_outcome')} "
+                f"latest_kind={outcome_followthrough.get('latest_delivery_turn_kind')} "
+                f"obligation={outcome_followthrough.get('obligation')}"
+            )
     interface_budget_cadence = (
         payload.get("interface_budget_cadence")
         if isinstance(payload.get("interface_budget_cadence"), dict)

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -14,6 +14,7 @@ from .delivery_outcome import (
     DELIVERY_OUTCOME_UNKNOWN,
     DeliveryOutcome,
     PROGRESS_DELIVERY_OUTCOMES,
+    delivery_turn_kind_for_run,
     normalize_delivery_outcome,
 )
 from .doctor import (
@@ -5960,6 +5961,10 @@ def compact_post_handoff_run(run: dict[str, Any], profile: dict[str, Any] | None
     outcome = delivery_outcome_for_run(run, profile)
     if outcome != DELIVERY_OUTCOME_NOT_CONFIGURED:
         compact["delivery_outcome"] = outcome
+    compact["delivery_turn_kind"] = delivery_turn_kind_for_run(
+        run,
+        delivery_outcome=outcome,
+    )
     benchmark_run = compact_benchmark_run(run)
     if benchmark_run:
         compact["benchmark_run_summary"] = benchmark_run
@@ -9328,12 +9333,19 @@ def render_status_markdown(payload: dict[str, Any]) -> str:
                             " "
                             f"outcome={_markdown_scalar(latest_handoff_run.get('delivery_outcome') or '')}"
                         )
+                    turn_kind_suffix = ""
+                    if latest_handoff_run.get("delivery_turn_kind"):
+                        turn_kind_suffix = (
+                            " "
+                            f"turn_kind={_markdown_scalar(latest_handoff_run.get('delivery_turn_kind') or '')}"
+                        )
                     lines.append(
                         "      - post_handoff_run: "
                         f"classification={_markdown_scalar(latest_handoff_run.get('classification') or '')} "
                         f"at={_markdown_scalar(latest_handoff_run.get('generated_at') or '')} "
                         f"scale={_markdown_scalar(latest_handoff_run.get('delivery_batch_scale') or '')}"
                         f"{outcome_suffix}"
+                        f"{turn_kind_suffix}"
                     )
                 recent_handoff_runs = (
                     handoff_readiness.get("post_handoff_recent_runs")
@@ -9352,6 +9364,14 @@ def render_status_markdown(payload: dict[str, Any]) -> str:
                         if isinstance(run, dict) and run.get("delivery_outcome")
                     ]
                     outcome_text = f" outcome={','.join(recent_outcomes)}" if recent_outcomes else ""
+                    recent_turn_kinds = [
+                        _markdown_scalar(str(run.get("delivery_turn_kind") or ""))
+                        for run in recent_handoff_runs
+                        if isinstance(run, dict) and run.get("delivery_turn_kind")
+                    ]
+                    turn_kind_text = (
+                        f" turn_kind={','.join(recent_turn_kinds)}" if recent_turn_kinds else ""
+                    )
                     gap_text = (
                         f" outcome_gap_streak={handoff_readiness.get('post_handoff_outcome_gap_streak')}"
                         if "post_handoff_outcome_gap_streak" in handoff_readiness
@@ -9362,6 +9382,7 @@ def render_status_markdown(payload: dict[str, Any]) -> str:
                         f"{','.join(recent_scales)} "
                         f"small_streak={handoff_readiness.get('post_handoff_small_scale_streak', 0)}"
                         f"{outcome_text}"
+                        f"{turn_kind_text}"
                         f"{gap_text}"
                     )
                 if handoff_readiness.get("next_probe"):


### PR DESCRIPTION
## Summary
- add a shared public-safe delivery_turn_kind classification for post-handoff delivery runs
- project turn kind through status/quota compact payloads and quota markdown
- make contract/preparation-only turns require outcome follow-through while treating precise blocker writeback as an accepted resolution

## Validation
- python3 examples/work-lane-contract-smoke.py
- python3 examples/quota-contract-smoke.py
- python3 examples/quota-plan-smoke.py
- python3 examples/heartbeat-quota-flow-smoke.py
- python3 -m py_compile loopx/delivery_outcome.py loopx/status.py loopx/quota.py examples/work-lane-contract-smoke.py
- git diff --check
- loopx check --scan-path loopx/delivery_outcome.py --scan-path loopx/quota.py --scan-path loopx/status.py --scan-path examples/work-lane-contract-smoke.py

## Notes
- Candidate path scan found no credentials, local state, raw logs, or private artifacts.
- examples/status-markdown-smoke.py currently fails on an unrelated planned-preview waiting_on expectation (controller vs user_or_controller), outside this post-handoff turn-kind slice.