### PR TITLE
Add delivery batch scale enum

### DIFF
--- a/examples/delivery-batch-scale-enum-smoke.py
+++ b/examples/delivery-batch-scale-enum-smoke.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Smoke-test structured delivery_batch_scale enum enforcement."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.delivery_batch_scale import (  # noqa: E402
+    DELIVERY_BATCH_SCALE_CHOICES,
+    SMALL_DELIVERY_BATCH_SCALES,
+    UNKNOWN_DELIVERY_BATCH_SCALE,
+    DeliveryBatchScale,
+    normalize_delivery_batch_scale,
+    require_delivery_batch_scale,
+)
+from loopx.history import append_benchmark_run  # noqa: E402
+from loopx.state_refresh import refresh_state_run  # noqa: E402
+from loopx.status import delivery_batch_scale_for_run  # noqa: E402
+
+
+GOAL_ID = "delivery-batch-scale-enum-fixture"
+
+
+def write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_fixture(root: Path) -> tuple[Path, Path]:
+    project = root / "project"
+    runtime = root / "runtime"
+    state_file = Path(".codex/goals") / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+    (project / state_file).parent.mkdir(parents=True, exist_ok=True)
+    (project / state_file).write_text(
+        "---\n"
+        "status: active\n"
+        "---\n\n"
+        "# Delivery Batch Scale Fixture\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] Advance one bounded implementation batch.\n\n"
+        "## Next Action\n\n"
+        "- Advance one bounded implementation batch.\n",
+        encoding="utf-8",
+    )
+    registry_path = project / ".loopx" / "registry.json"
+    write_json(
+        registry_path,
+        {
+            "schema_version": 1,
+            "common_runtime_root": str(runtime),
+            "goals": [
+                {
+                    "id": GOAL_ID,
+                    "domain": "enum-fixture",
+                    "status": "active",
+                    "repo": str(project),
+                    "state_file": str(state_file),
+                    "adapter": {"kind": "harness_self_improvement", "status": "connected"},
+                    "quota": {"compute": 1.0, "window_hours": 24},
+                }
+            ],
+        },
+    )
+    return registry_path, runtime
+
+
+def assert_enum_sets() -> None:
+    assert DELIVERY_BATCH_SCALE_CHOICES == (
+        "test_only",
+        "single_surface",
+        "multi_surface",
+        "implementation",
+    )
+    assert require_delivery_batch_scale("multi_surface") == DeliveryBatchScale.MULTI_SURFACE
+    assert normalize_delivery_batch_scale("unknown") is None
+    assert SMALL_DELIVERY_BATCH_SCALES == {
+        DeliveryBatchScale.TEST_ONLY,
+        DeliveryBatchScale.SINGLE_SURFACE,
+    }
+    try:
+        require_delivery_batch_scale("implementation_plus_validation")
+    except ValueError as exc:
+        assert "delivery_batch_scale must be one of:" in str(exc)
+    else:
+        raise AssertionError("invalid delivery batch scale accepted")
+
+
+def assert_refresh_state_enforces_enum(registry_path: Path) -> None:
+    payload = refresh_state_run(
+        registry_path=registry_path,
+        runtime_root_override=None,
+        goal_id=GOAL_ID,
+        project=None,
+        state_file=None,
+        classification="enum_fixture_progress",
+        recommended_action="Advance one bounded implementation batch.",
+        delivery_batch_scale=DeliveryBatchScale.IMPLEMENTATION.value,
+        dry_run=True,
+        sync_global=False,
+    )
+    assert payload["delivery_batch_scale"] == DeliveryBatchScale.IMPLEMENTATION.value, payload
+
+    try:
+        refresh_state_run(
+            registry_path=registry_path,
+            runtime_root_override=None,
+            goal_id=GOAL_ID,
+            project=None,
+            state_file=None,
+            classification="enum_fixture_invalid",
+            recommended_action="Advance one bounded implementation batch.",
+            delivery_batch_scale="implementation_plus_validation",
+            dry_run=True,
+            sync_global=False,
+        )
+    except ValueError as exc:
+        assert "delivery_batch_scale must be one of:" in str(exc)
+    else:
+        raise AssertionError("refresh-state accepted invalid delivery batch scale")
+
+    cli_result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--registry",
+            str(registry_path),
+            "--format",
+            "json",
+            "refresh-state",
+            "--goal-id",
+            GOAL_ID,
+            "--delivery-batch-scale",
+            "implementation_plus_validation",
+            "--dry-run",
+            "--no-global-sync",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    assert cli_result.returncode != 0, cli_result.stdout
+    assert "invalid choice" in cli_result.stderr, cli_result.stderr
+
+
+def assert_history_enforces_enum(registry_path: Path) -> None:
+    compact_run = {
+        "schema_version": "benchmark_run_v0",
+        "benchmark": {"id": "fixture"},
+        "case": {"id": "fixture-case"},
+    }
+    payload = append_benchmark_run(
+        registry_path=registry_path,
+        runtime_root_override=None,
+        goal_id=GOAL_ID,
+        benchmark_run=compact_run,
+        delivery_batch_scale=DeliveryBatchScale.MULTI_SURFACE.value,
+        dry_run=True,
+    )
+    assert payload["delivery_batch_scale"] == DeliveryBatchScale.MULTI_SURFACE.value, payload
+
+    try:
+        append_benchmark_run(
+            registry_path=registry_path,
+            runtime_root_override=None,
+            goal_id=GOAL_ID,
+            benchmark_run=compact_run,
+            delivery_batch_scale="batch_plus_raw_logs",
+            dry_run=True,
+        )
+    except ValueError as exc:
+        assert "delivery_batch_scale must be one of:" in str(exc)
+    else:
+        raise AssertionError("history append accepted invalid delivery batch scale")
+
+
+def assert_status_uses_enum_not_raw_value() -> None:
+    assert (
+        delivery_batch_scale_for_run(
+            {
+                "classification": "runner_batch_fixture",
+                "delivery_batch_scale": DeliveryBatchScale.MULTI_SURFACE.value,
+            }
+        )
+        == DeliveryBatchScale.MULTI_SURFACE.value
+    )
+    assert (
+        delivery_batch_scale_for_run(
+            {
+                "classification": "runner_batch_fixture",
+                "delivery_batch_scale": "batch_plus_raw_logs",
+            }
+        )
+        == UNKNOWN_DELIVERY_BATCH_SCALE
+    )
+    assert (
+        delivery_batch_scale_for_run({"classification": "owner_handoff_consumer_test"})
+        == DeliveryBatchScale.TEST_ONLY.value
+    )
+
+
+def main() -> int:
+    assert_enum_sets()
+    with tempfile.TemporaryDirectory(prefix="delivery-batch-scale-enum-") as tmp:
+        registry_path, _runtime = write_fixture(Path(tmp))
+        assert_refresh_state_enforces_enum(registry_path)
+        assert_history_enforces_enum(registry_path)
+    assert_status_uses_enum_not_raw_value()
+    print("delivery batch scale enum smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/cli_commands/agentissue_runner_flow.py
+++ b/loopx/cli_commands/agentissue_runner_flow.py
@@ -26,10 +26,10 @@ from ..benchmark_adapters.agentissue import (
     materialize_agentissue_codex_cli_runner_target_handoff,
     materialize_agentissue_codex_cli_runner_workflow_check,
 )
+from ..delivery_batch_scale import DELIVERY_BATCH_SCALE_CHOICES
 from ..delivery_outcome import DELIVERY_OUTCOME_CHOICES
 from ..global_registry import sync_project_registry_to_global
 from ..history import append_benchmark_run, render_benchmark_run_append_markdown
-from ..state_refresh import DELIVERY_BATCH_SCALE_CHOICES
 from ..status import compact_benchmark_run
 
 

--- a/loopx/cli_commands/benchmark_review_lifecycle.py
+++ b/loopx/cli_commands/benchmark_review_lifecycle.py
@@ -22,10 +22,10 @@ from ..benchmark_adapters.terminal_bench import (
     TERMINAL_BENCH_MANAGED_CODEX_LOOPX_KWARGS,
     agent_kwargs_from_invocation,
 )
+from ..delivery_batch_scale import DELIVERY_BATCH_SCALE_CHOICES
 from ..delivery_outcome import DELIVERY_OUTCOME_CHOICES
 from ..global_registry import sync_project_registry_to_global
 from ..history import append_benchmark_comparison
-from ..state_refresh import DELIVERY_BATCH_SCALE_CHOICES
 from ..status import (
     compact_benchmark_comparison,
     compact_benchmark_learning_ledger,

--- a/loopx/cli_commands/benchmark_run_ledger.py
+++ b/loopx/cli_commands/benchmark_run_ledger.py
@@ -34,6 +34,7 @@ from ..benchmark_ledger import (
     BENCHMARK_RUN_LEDGER_DEFAULT_PATH,
     update_benchmark_run_ledger,
 )
+from ..delivery_batch_scale import DELIVERY_BATCH_SCALE_CHOICES
 from ..delivery_outcome import DELIVERY_OUTCOME_CHOICES
 from ..global_registry import sync_project_registry_to_global
 from ..history import (
@@ -42,7 +43,6 @@ from ..history import (
     render_benchmark_run_append_markdown,
 )
 from ..paths import resolve_runtime_root
-from ..state_refresh import DELIVERY_BATCH_SCALE_CHOICES
 from ..status import (
     compact_benchmark_run,
 )

--- a/loopx/cli_commands/history.py
+++ b/loopx/cli_commands/history.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from ..benchmark_adapters.agents_last_exam import (
     build_agents_last_exam_result_benchmark_report,
 )
+from ..delivery_batch_scale import DELIVERY_BATCH_SCALE_CHOICES
 from ..delivery_outcome import DELIVERY_OUTCOME_CHOICES
 from ..global_registry import sync_project_registry_to_global
 from ..history import (
@@ -33,7 +34,6 @@ from ..history import (
     render_index_duplicate_repair_markdown,
 )
 from ..paths import resolve_runtime_root
-from ..state_refresh import DELIVERY_BATCH_SCALE_CHOICES
 from ..status import (
     compact_active_user_assisted_pilot,
     compact_benchmark_comparison,

--- a/loopx/cli_commands/project_lifecycle.py
+++ b/loopx/cli_commands/project_lifecycle.py
@@ -4,6 +4,7 @@ import argparse
 from collections.abc import Callable
 from pathlib import Path
 
+from ..delivery_batch_scale import DELIVERY_BATCH_SCALE_CHOICES
 from ..delivery_outcome import DELIVERY_OUTCOME_CHOICES
 from ..feedback import LESSON_KINDS, append_human_reward, compact_reward, render_reward_markdown
 from ..operator_gate import (
@@ -20,7 +21,6 @@ from ..project_map import (
 from ..state_refresh import (
     DEFAULT_REFRESH_ACTION,
     DEFAULT_REFRESH_CLASSIFICATION,
-    DELIVERY_BATCH_SCALE_CHOICES,
     refresh_state_run,
     render_state_refresh_markdown,
 )

--- a/loopx/delivery_batch_scale.py
+++ b/loopx/delivery_batch_scale.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+
+class DeliveryBatchScale(str, Enum):
+    """Structured machine signal for the scale of a delivery run."""
+
+    TEST_ONLY = "test_only"
+    SINGLE_SURFACE = "single_surface"
+    MULTI_SURFACE = "multi_surface"
+    IMPLEMENTATION = "implementation"
+
+
+DELIVERY_BATCH_SCALE_CHOICES = tuple(scale.value for scale in DeliveryBatchScale)
+SMALL_DELIVERY_BATCH_SCALES = frozenset(
+    {
+        DeliveryBatchScale.TEST_ONLY,
+        DeliveryBatchScale.SINGLE_SURFACE,
+    }
+)
+UNKNOWN_DELIVERY_BATCH_SCALE = "unknown"
+
+
+def normalize_delivery_batch_scale(value: Any) -> DeliveryBatchScale | None:
+    if isinstance(value, DeliveryBatchScale):
+        return value
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        return DeliveryBatchScale(text)
+    except ValueError:
+        return None
+
+
+def require_delivery_batch_scale(value: Any) -> DeliveryBatchScale:
+    scale = normalize_delivery_batch_scale(value)
+    if scale is None:
+        raise ValueError("delivery_batch_scale must be one of: " + ", ".join(DELIVERY_BATCH_SCALE_CHOICES))
+    return scale
+
+
+def delivery_batch_scale_value(value: Any) -> str | None:
+    scale = normalize_delivery_batch_scale(value)
+    return scale.value if scale else None

--- a/loopx/history.py
+++ b/loopx/history.py
@@ -9,6 +9,7 @@ from typing import Any, Callable
 
 from .authority import goal_authority_registry_summary
 from .control_plane import compact_control_plane_policy
+from .delivery_batch_scale import require_delivery_batch_scale
 from .delivery_outcome import require_delivery_outcome
 from .doctor import PROMOTION_READINESS_CLASSIFICATIONS
 from .execution_profile import compact_execution_profile
@@ -42,6 +43,10 @@ def now_local() -> str:
 
 def _normalize_optional_delivery_outcome(value: str | None) -> str | None:
     return require_delivery_outcome(value).value if value else None
+
+
+def _normalize_optional_delivery_batch_scale(value: str | None) -> str | None:
+    return require_delivery_batch_scale(value).value if value else None
 
 
 def run_file_stem(generated_at: str) -> str:
@@ -195,6 +200,7 @@ def append_benchmark_run(
     safe_goal_id = validate_goal_id_path_segment(goal_id)
     if benchmark_run.get("schema_version") != "benchmark_run_v0":
         raise ValueError("benchmark run must have schema_version=benchmark_run_v0")
+    delivery_batch_scale = _normalize_optional_delivery_batch_scale(delivery_batch_scale)
     delivery_outcome = _normalize_optional_delivery_outcome(delivery_outcome)
 
     registry = load_registry(registry_path)
@@ -272,6 +278,7 @@ def append_benchmark_result(
     safe_goal_id = validate_goal_id_path_segment(goal_id)
     if benchmark_result.get("schema_version") != "benchmark_result_v0":
         raise ValueError("benchmark result must have schema_version=benchmark_result_v0")
+    delivery_batch_scale = _normalize_optional_delivery_batch_scale(delivery_batch_scale)
     delivery_outcome = _normalize_optional_delivery_outcome(delivery_outcome)
 
     registry = load_registry(registry_path)
@@ -349,6 +356,7 @@ def append_benchmark_comparison(
     safe_goal_id = validate_goal_id_path_segment(goal_id)
     if benchmark_comparison.get("schema_version") != "benchmark_comparison_v0":
         raise ValueError("benchmark comparison must have schema_version=benchmark_comparison_v0")
+    delivery_batch_scale = _normalize_optional_delivery_batch_scale(delivery_batch_scale)
     delivery_outcome = _normalize_optional_delivery_outcome(delivery_outcome)
 
     registry = load_registry(registry_path)
@@ -426,6 +434,7 @@ def append_benchmark_learning_ledger(
     safe_goal_id = validate_goal_id_path_segment(goal_id)
     if benchmark_learning_ledger.get("schema_version") != "benchmark_learning_ledger_v0":
         raise ValueError("benchmark learning ledger must have schema_version=benchmark_learning_ledger_v0")
+    delivery_batch_scale = _normalize_optional_delivery_batch_scale(delivery_batch_scale)
     delivery_outcome = _normalize_optional_delivery_outcome(delivery_outcome)
 
     registry = load_registry(registry_path)
@@ -503,6 +512,7 @@ def append_benchmark_experiment_report(
     safe_goal_id = validate_goal_id_path_segment(goal_id)
     if benchmark_experiment_report.get("schema_version") != "benchmark_experiment_report_v0":
         raise ValueError("benchmark experiment report must have schema_version=benchmark_experiment_report_v0")
+    delivery_batch_scale = _normalize_optional_delivery_batch_scale(delivery_batch_scale)
     delivery_outcome = _normalize_optional_delivery_outcome(delivery_outcome)
 
     registry = load_registry(registry_path)
@@ -580,6 +590,7 @@ def append_active_user_assisted_pilot(
     safe_goal_id = validate_goal_id_path_segment(goal_id)
     if active_user_assisted_pilot.get("schema_version") != "active_user_assisted_pilot_v0":
         raise ValueError("active user assisted pilot must have schema_version=active_user_assisted_pilot_v0")
+    delivery_batch_scale = _normalize_optional_delivery_batch_scale(delivery_batch_scale)
     delivery_outcome = _normalize_optional_delivery_outcome(delivery_outcome)
 
     registry = load_registry(registry_path)

--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from .delivery_batch_scale import DELIVERY_BATCH_SCALE_CHOICES, require_delivery_batch_scale
 from .delivery_outcome import DELIVERY_OUTCOME_CHOICES, require_delivery_outcome
 from .feedback import validate_public_safe_text
 from .file_lock import exclusive_file_lock
@@ -30,7 +31,6 @@ AGENT_LANE_PROGRESS_SCOPE = "agent_lane"
 RECOMMENDED_ACTION_SECTION_LINE_LIMIT = 16
 BULLET_PREFIX_RE = re.compile(r"^(?:[-*]\s+|\d+[.)]\s+)")
 CHECKBOX_PREFIX_RE = re.compile(r"^\[(?P<mark>[ xX])\]\s+")
-DELIVERY_BATCH_SCALE_CHOICES = ("test_only", "single_surface", "multi_surface", "implementation")
 ACTIVE_STATE_NEXT_ACTION_UPDATE_SCHEMA_VERSION = "active_state_next_action_update_v0"
 
 
@@ -483,10 +483,9 @@ def refresh_state_run(
         validate_public_safe_text("agent_lane", normalized_agent_lane)
     if normalized_agent_lane and not normalized_agent_id:
         raise ValueError("--agent-lane requires --agent-id so the lane has an owner")
-    if delivery_batch_scale and delivery_batch_scale not in DELIVERY_BATCH_SCALE_CHOICES:
-        raise ValueError(
-            "delivery_batch_scale must be one of: " + ", ".join(DELIVERY_BATCH_SCALE_CHOICES)
-        )
+    normalized_delivery_batch_scale = (
+        require_delivery_batch_scale(delivery_batch_scale).value if delivery_batch_scale else None
+    )
     normalized_delivery_outcome = (
         require_delivery_outcome(delivery_outcome).value if delivery_outcome else None
     )
@@ -550,7 +549,7 @@ def refresh_state_run(
         recommended_action=action,
         generated_at=generated_at,
         registry_goal=registry_goal,
-        delivery_batch_scale=delivery_batch_scale,
+        delivery_batch_scale=normalized_delivery_batch_scale,
         delivery_outcome=normalized_delivery_outcome,
         agent_id=normalized_agent_id or None,
         agent_lane=normalized_agent_lane or None,
@@ -571,8 +570,8 @@ def refresh_state_run(
         "json_path": str(json_path),
         "markdown_path": str(markdown_path),
     }
-    if delivery_batch_scale:
-        index_record["delivery_batch_scale"] = delivery_batch_scale
+    if normalized_delivery_batch_scale:
+        index_record["delivery_batch_scale"] = normalized_delivery_batch_scale
     if normalized_delivery_outcome:
         index_record["delivery_outcome"] = normalized_delivery_outcome
     if autonomous_replan_recorded:

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -9,6 +9,12 @@ from typing import Any
 
 from .control_plane import compact_control_plane_policy, control_plane_policy_summary
 from .contract import check_contract
+from .delivery_batch_scale import (
+    SMALL_DELIVERY_BATCH_SCALES as STRUCTURED_SMALL_DELIVERY_BATCH_SCALES,
+    UNKNOWN_DELIVERY_BATCH_SCALE,
+    DeliveryBatchScale,
+    normalize_delivery_batch_scale,
+)
 from .delivery_outcome import (
     DELIVERY_OUTCOME_NOT_CONFIGURED,
     DELIVERY_OUTCOME_UNKNOWN,
@@ -242,9 +248,8 @@ DELIVERY_BATCH_SCALE_IMPLEMENTATION_CLASSIFICATION_HINTS = (
     "runner",
 )
 SMALL_DELIVERY_BATCH_SCALES = {
-    "single_surface",
-    "test_only",
-    "unknown",
+    *(scale.value for scale in STRUCTURED_SMALL_DELIVERY_BATCH_SCALES),
+    UNKNOWN_DELIVERY_BATCH_SCALE,
 }
 CONNECTED_ADAPTER_STATUSES = {
     "connected",
@@ -5890,20 +5895,22 @@ def is_custom_post_handoff_work_run(run: dict[str, Any]) -> bool:
 
 
 def delivery_batch_scale_for_run(run: dict[str, Any]) -> str:
-    explicit = str(run.get("delivery_batch_scale") or "").strip()
+    explicit = normalize_delivery_batch_scale(run.get("delivery_batch_scale"))
     if explicit:
-        return explicit
+        return explicit.value
+    if str(run.get("delivery_batch_scale") or "").strip():
+        return UNKNOWN_DELIVERY_BATCH_SCALE
     classification = str(run.get("classification") or "")
     if not classification:
-        return "unknown"
+        return UNKNOWN_DELIVERY_BATCH_SCALE
     normalized = classification.lower()
     if any(hint in normalized for hint in DELIVERY_BATCH_SCALE_TEST_ONLY_CLASSIFICATION_HINTS):
-        return "test_only"
+        return DeliveryBatchScale.TEST_ONLY.value
     if any(hint in normalized for hint in DELIVERY_BATCH_SCALE_MULTI_SURFACE_CLASSIFICATION_HINTS):
-        return "multi_surface"
+        return DeliveryBatchScale.MULTI_SURFACE.value
     if any(hint in normalized for hint in DELIVERY_BATCH_SCALE_IMPLEMENTATION_CLASSIFICATION_HINTS):
-        return "implementation"
-    return "single_surface"
+        return DeliveryBatchScale.IMPLEMENTATION.value
+    return DeliveryBatchScale.SINGLE_SURFACE.value
 
 
 def _classification_contains_any(classification: str, hints: list[Any]) -> bool:


### PR DESCRIPTION
## Summary
- add a structured delivery_batch_scale enum and validation helpers
- route refresh-state, history append APIs, and CLI choices through the shared enum
- make status ignore invalid explicit scale values by returning unknown instead of propagating arbitrary strings
- add a focused delivery-batch-scale enum smoke

## Validation
- python3 examples/delivery-batch-scale-enum-smoke.py
- python3 examples/delivery-outcome-enum-smoke.py
- python3 -m py_compile loopx/delivery_batch_scale.py loopx/history.py loopx/state_refresh.py loopx/status.py loopx/cli_commands/history.py loopx/cli_commands/benchmark_run_ledger.py loopx/cli_commands/agentissue_runner_flow.py loopx/cli_commands/benchmark_review_lifecycle.py loopx/cli_commands/project_lifecycle.py examples/delivery-batch-scale-enum-smoke.py
- python3 examples/cli-project-lifecycle-command-modularization-smoke.py
- python3 examples/benchmark-run-v0-append-cli-smoke.py
- git diff --check

## Notes
- Secret/private scan over candidate paths found only existing public boundary wording and parameter names, not credentials or raw logs.
- python3 examples/status-markdown-smoke.py currently fails on clean origin/main as well: planned-main-control waiting_on is controller while the smoke expects user_or_controller; not introduced by this PR.
