### PR TITLE
Guard delivery turn kind enum handling

### DIFF
--- a/examples/delivery-turn-kind-enum-smoke.py
+++ b/examples/delivery-turn-kind-enum-smoke.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Smoke-test structured delivery_turn_kind enum handling."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.delivery_outcome import (  # noqa: E402
+    DELIVERY_TURN_KIND_CHOICES,
+    DeliveryOutcome,
+    DeliveryTurnKind,
+    delivery_turn_kind_for_run,
+    normalize_delivery_turn_kind,
+    require_delivery_turn_kind,
+)
+from loopx.status import compact_post_handoff_run  # noqa: E402
+
+
+def assert_enum_sets() -> None:
+    assert DELIVERY_TURN_KIND_CHOICES == (
+        "contract_only_preparation",
+        "compact_evidence",
+        "blocker_writeback",
+        "product_path_execution",
+        "outcome_gap",
+        "unknown",
+    )
+    assert require_delivery_turn_kind("compact_evidence") == DeliveryTurnKind.COMPACT_EVIDENCE
+    assert normalize_delivery_turn_kind("contract_v0_delivered") is None
+    try:
+        require_delivery_turn_kind("contract_v0_delivered")
+    except ValueError as exc:
+        assert "delivery_turn_kind must be one of:" in str(exc)
+    else:
+        raise AssertionError("invalid delivery turn kind accepted")
+
+
+def assert_invalid_explicit_kind_does_not_fallback_to_classification() -> None:
+    run = {
+        "classification": "runner_contract_v0_delivered",
+        "delivery_outcome": DeliveryOutcome.SURFACE_ONLY.value,
+        "delivery_turn_kind": "contract_v0_delivered",
+    }
+    assert delivery_turn_kind_for_run(run) == DeliveryTurnKind.UNKNOWN.value
+    assert compact_post_handoff_run(run)["delivery_turn_kind"] == DeliveryTurnKind.UNKNOWN.value
+
+
+def assert_inference_still_works_when_kind_is_absent() -> None:
+    contract_run = {
+        "classification": "runner_contract_v0_delivered",
+        "delivery_outcome": DeliveryOutcome.SURFACE_ONLY.value,
+    }
+    assert (
+        delivery_turn_kind_for_run(contract_run)
+        == DeliveryTurnKind.CONTRACT_ONLY_PREPARATION.value
+    )
+    assert (
+        delivery_turn_kind_for_run({"delivery_outcome": DeliveryOutcome.PRIMARY_GOAL_OUTCOME.value})
+        == DeliveryTurnKind.PRODUCT_PATH_EXECUTION.value
+    )
+
+
+def main() -> int:
+    assert_enum_sets()
+    assert_invalid_explicit_kind_does_not_fallback_to_classification()
+    assert_inference_still_works_when_kind_is_absent()
+    print("delivery turn kind enum smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/delivery_outcome.py
+++ b/loopx/delivery_outcome.py
@@ -80,6 +80,13 @@ def normalize_delivery_turn_kind(value: Any) -> DeliveryTurnKind | None:
         return None
 
 
+def require_delivery_turn_kind(value: Any) -> DeliveryTurnKind:
+    kind = normalize_delivery_turn_kind(value)
+    if kind is None:
+        raise ValueError("delivery_turn_kind must be one of: " + ", ".join(DELIVERY_TURN_KIND_CHOICES))
+    return kind
+
+
 def delivery_turn_kind_for_run(
     run: dict[str, Any],
     *,
@@ -87,9 +94,10 @@ def delivery_turn_kind_for_run(
 ) -> str:
     """Classify the latest turn without relying on free-form classification text alone."""
 
-    explicit = normalize_delivery_turn_kind(run.get("delivery_turn_kind"))
-    if explicit:
-        return explicit.value
+    raw_explicit = str(run.get("delivery_turn_kind") or "").strip()
+    if raw_explicit:
+        explicit = normalize_delivery_turn_kind(raw_explicit)
+        return explicit.value if explicit else DeliveryTurnKind.UNKNOWN.value
 
     outcome = normalize_delivery_outcome(
         delivery_outcome if delivery_outcome is not None else run.get("delivery_outcome")


### PR DESCRIPTION
## Summary
- add a delivery_turn_kind enum helper so invalid turn-kind values have the same typed validation surface as delivery_outcome
- treat an explicit invalid delivery_turn_kind as unknown instead of silently falling back to classification-text inference
- add a focused smoke covering enum choices, invalid explicit values, and inference when the field is absent

## Validation
- python3 examples/delivery-turn-kind-enum-smoke.py
- python3 examples/delivery-outcome-enum-smoke.py
- python3 examples/delivery-batch-scale-enum-smoke.py
- python3 examples/work-lane-contract-smoke.py
- python3 -m py_compile loopx/delivery_outcome.py examples/delivery-turn-kind-enum-smoke.py
- git diff --check

## Boundary
- narrow control-plane enum handling and smoke only
- no benchmark runs, runner behavior, private state, credentials, or raw evidence