### PR TITLE
Guard Lark Kanban todo status projection

### DIFF
--- a/examples/lark-kanban-control-plane-smoke.py
+++ b/examples/lark-kanban-control-plane-smoke.py
@@ -16,9 +16,12 @@ if str(REPO_ROOT) not in sys.path:
 
 from loopx.lark_kanban import (  # noqa: E402
     CLAIM_UNCLAIMED,
+    STATUS_CLAIMED,
+    STATUS_USER_GATE,
     STATUS_REVIEW,
     STATUS_TODO,
     LarkKanbanConfig,
+    _lark_record_from_todo_block,
     build_create_board_plan,
     default_lark_kanban_config_path,
     lark_kanban_feasibility_cases,
@@ -323,6 +326,9 @@ def main() -> int:
                     "- [ ] [P2] Wire conservative board sync",
                     "  <!-- loopx: todo_id=todo_agent_sync status=open task_class=advancement_task action_kind=sync_board required_write_scopes=loopx claimed_by=codex-main-control -->",
                     "",
+                    "- [ ] [P1] Keep malformed metadata executable",
+                    "  <!-- loopx: todo_id=todo_agent_malformed status=blocked_typo task_class=user_gate_typo action_kind=sync_board claimed_by=codex-main-control -->",
+                    "",
                 ]
             ),
             encoding="utf-8",
@@ -352,11 +358,50 @@ def main() -> int:
             execute=False,
         )
         assert sync_payload["ok"] is True, sync_payload
-        assert sync_payload["todo_count"] == 2, sync_payload
+        assert sync_payload["todo_count"] == 3, sync_payload
         assert any(item["values"]["Status"] == "User Gate" for item in sync_payload["records"]), sync_payload
+        malformed = next(
+            item for item in sync_payload["records"] if item["todo_id"] == "todo_agent_malformed"
+        )
+        assert malformed["values"]["Status"] == STATUS_CLAIMED, malformed
+        assert malformed["values"]["Task Class"] == "advancement_task", malformed
+        assert malformed["values"]["Run History"].endswith("status=open"), malformed
         assert all(item["values"]["Workdir"] == "" for item in sync_payload["records"]), sync_payload
         assert str(root) not in json.dumps(sync_payload["records"], ensure_ascii=False), sync_payload
         assert all(item["command"]["executed"] is False for item in sync_payload["records"]), sync_payload
+
+    sink_record = _lark_record_from_todo_block(
+        {
+            "role": "agent",
+            "status": "blocked_typo",
+            "task_class": "user_gate_typo",
+            "claimed_by": "codex-main-control",
+            "text": "[P1] Keep malformed sink input executable",
+            "todo_id": "todo_sink_malformed",
+        },
+        goal_id="goal_lark_sync_fixture",
+        state_file=Path("active-state.md"),
+        priority="P1",
+    )
+    assert sink_record["Status"] == STATUS_CLAIMED, sink_record
+    assert sink_record["Task Class"] == "advancement_task", sink_record
+    assert sink_record["User Gate"] == "", sink_record
+    assert sink_record["Run History"].endswith("status=open"), sink_record
+
+    user_sink_record = _lark_record_from_todo_block(
+        {
+            "role": "user",
+            "status": "open",
+            "task_class": "advancement_task_typo",
+            "text": "[P1] Choose board target",
+            "todo_id": "todo_user_target",
+        },
+        goal_id="goal_lark_sync_fixture",
+        state_file=Path("active-state.md"),
+        priority="P1",
+    )
+    assert user_sink_record["Status"] == STATUS_USER_GATE, user_sink_record
+    assert user_sink_record["Task Class"] == "user_gate", user_sink_record
 
     print("lark-kanban-control-plane-smoke: ok")
     return 0

--- a/loopx/lark_kanban.py
+++ b/loopx/lark_kanban.py
@@ -10,6 +10,18 @@ from pathlib import Path
 from typing import Any, Callable, Optional
 from urllib.parse import parse_qs, urlparse
 
+from .todo_contract import (
+    TODO_STATUS_BLOCKED,
+    TODO_STATUS_DEFERRED,
+    TODO_STATUS_DONE,
+    TODO_STATUS_OPEN,
+    TODO_TASK_CLASS_ADVANCEMENT,
+    TODO_TASK_CLASS_BLOCKER,
+    TODO_TASK_CLASS_USER_GATE,
+    normalize_explicit_todo_task_class,
+    normalize_todo_status,
+)
+
 
 LARK_KANBAN_SCHEMA_VERSION = "loopx_lark_kanban_control_plane_v0"
 LARK_KANBAN_HEARTBEAT_VERSION = "loopx_lark_kanban_heartbeat_v0"
@@ -2038,15 +2050,18 @@ def _lark_record_from_todo_block(
     priority: str,
 ) -> dict[str, Any]:
     role = str(block.get("role") or "agent")
-    status = str(block.get("status") or "").strip()
-    task_class = str(block.get("task_class") or ("user_gate" if role == "user" else "advancement_task")).strip()
+    raw_status = str(block.get("status") or "").strip()
+    status = normalize_todo_status(raw_status) or TODO_STATUS_OPEN
+    task_class = normalize_explicit_todo_task_class(block.get("task_class")) or (
+        TODO_TASK_CLASS_USER_GATE if role == "user" else TODO_TASK_CLASS_ADVANCEMENT
+    )
     claimed_by = str(block.get("claimed_by") or "").strip()
     lark_status = STATUS_TODO
-    if block.get("done") or status == "done":
+    if block.get("done") or status == TODO_STATUS_DONE:
         lark_status = STATUS_DONE
-    elif status == "blocked" or task_class == "blocker":
+    elif status == TODO_STATUS_BLOCKED or task_class == TODO_TASK_CLASS_BLOCKER:
         lark_status = STATUS_BLOCKED
-    elif role == "user" or task_class == "user_gate" or status == "deferred":
+    elif role == "user" or task_class == TODO_TASK_CLASS_USER_GATE or status == TODO_STATUS_DEFERRED:
         lark_status = STATUS_USER_GATE
     elif claimed_by:
         lark_status = STATUS_CLAIMED
@@ -2076,7 +2091,7 @@ def _lark_record_from_todo_block(
         "User Gate": text if lark_status == STATUS_USER_GATE else "",
         "Handoff": f"Synced from LoopX active state: {state_file.name}",
         "Evidence": evidence,
-        "Run History": f"synced from LoopX todo status={status or 'open'}",
+        "Run History": f"synced from LoopX todo status={status}",
         "Worker Command": "",
         "Workdir": "",
         "Last Error": "",


### PR DESCRIPTION
## Summary
- Normalize LoopX todo status/task_class at the Lark Kanban projection sink using the central todo contract.
- Treat malformed status/task_class metadata as open/default class instead of projecting false Blocked/User Gate board states.
- Extend the existing Lark Kanban control-plane smoke with malformed metadata and direct sink coverage.

## Validation
- python3 examples/lark-kanban-control-plane-smoke.py
- python3 -m loopx.cli --format json lark-kanban schema
- python3 examples/work-lane-contract-smoke.py
- python3 -m py_compile loopx/lark_kanban.py examples/lark-kanban-control-plane-smoke.py
- git diff --check

## Safety
- Explicit path staging only.
- No raw benchmark logs, trajectories, verifier output, credentials, local private state, or production actions.
