### PR TITLE
Preserve active next-action todo in quota candidates

### DIFF
--- a/examples/work-lane-contract-smoke.py
+++ b/examples/work-lane-contract-smoke.py
@@ -13,6 +13,7 @@ from loopx.quota import build_quota_should_run, render_quota_should_run_markdown
 from loopx.status import (
     TODO_TASK_CLASS_ADVANCEMENT,
     TODO_TASK_CLASS_MONITOR,
+    compact_todo_group,
     compact_post_handoff_run,
     normalize_todo_task_class,
 )
@@ -1593,6 +1594,87 @@ def assert_agent_lane_next_action_prefers_explicit_next_action_todo_id() -> None
     assert "agent_lane_next_action: todo_id=todo_parity_slice" in markdown, markdown
 
 
+def assert_active_next_action_todo_survives_compact_candidate_limits() -> None:
+    filler_items = [
+        {
+            "index": index,
+            "text": f"[P1] Retained filler todo {index}.",
+            "role": "agent",
+            "status": "open",
+            "priority": "P1",
+            "task_class": "advancement_task",
+            "claimed_by": "codex-main-control",
+            "todo_id": f"todo_filler_{index}",
+            "required_capabilities": ["shell"],
+        }
+        for index in range(1, 20)
+    ]
+    target_action = (
+        "[P1] Debug SkillsBench product-mode lifecycle counter semantics before "
+        "expanding more cases."
+    )
+    target_item = {
+        "index": 20,
+        "text": target_action,
+        "role": "agent",
+        "status": "open",
+        "priority": "P1",
+        "task_class": "advancement_task",
+        "action_kind": "skillsbench_lifecycle_observer_counter_semantics",
+        "claimed_by": "codex-main-control",
+        "todo_id": "todo_skillsbench_lifecycle",
+        "required_capabilities": ["shell"],
+    }
+    agent_todos = compact_todo_group(
+        [*filler_items, target_item],
+        source_section="Agent Todo",
+        role="agent",
+        preferred_todo_ids={"todo_skillsbench_lifecycle"},
+    )
+    assert agent_todos is not None
+    assert all(
+        item.get("todo_id") != "todo_skillsbench_lifecycle"
+        for item in agent_todos["executable_backlog_items"]
+    ), agent_todos
+    assert agent_todos["active_next_action_executable_items"][0]["todo_id"] == (
+        "todo_skillsbench_lifecycle"
+    ), agent_todos
+
+    payload = status_payload(
+        status="active_next_action_candidate_limit_projection",
+        next_action=(
+            "codex-main-control: advance todo_skillsbench_lifecycle by debugging "
+            "SkillsBench product-mode lifecycle observation semantics."
+        ),
+        coordination={
+            "primary_agent": "codex-main-control",
+            "registered_agents": ["codex-main-control"],
+        },
+        agent_todo_items=[],
+    )
+    item = payload["attention_queue"]["items"][0]
+    item["agent_todos"] = agent_todos
+    item["project_asset"]["agent_todos"] = agent_todos
+
+    guard = build_quota_should_run(
+        payload,
+        goal_id=GOAL_ID,
+        agent_id="codex-main-control",
+    )
+    next_action = guard["agent_lane_next_action"]
+    assert next_action["todo_id"] == "todo_skillsbench_lifecycle", guard
+    assert next_action["selected_by"] == "active_next_action_todo", guard
+    assert next_action["source"] == (
+        "agent_todo_summary.active_next_action_executable_items"
+    ), next_action
+    assert guard["recommended_action"] == target_action, guard
+    primary_action = guard["interaction_contract"]["agent_channel"]["primary_action"]
+    assert primary_action.startswith("todo_skillsbench_lifecycle:"), guard
+    assert "Debug SkillsBench product-mode lifecycle" in primary_action, guard
+    markdown = render_quota_should_run_markdown(guard)
+    assert "agent_lane_next_action: todo_id=todo_skillsbench_lifecycle" in markdown, markdown
+
+
 def main() -> int:
     assert_dependency_monitor_requires_advancement()
     assert_primary_status_stays_advancement_lane()
@@ -1624,6 +1706,7 @@ def main() -> int:
     assert_agent_lane_next_action_prefers_capability_repair_candidate()
     assert_primary_agent_prioritizes_claimed_review_handoff()
     assert_agent_lane_next_action_prefers_explicit_next_action_todo_id()
+    assert_active_next_action_todo_survives_compact_candidate_limits()
     print("work-lane-contract-smoke ok")
     return 0
 

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -1073,9 +1073,25 @@ def _capability_gate(
 ) -> dict[str, Any] | None:
     if not isinstance(agent_todo_summary, dict):
         return None
+    active_next_action_executable_items = agent_todo_summary.get(
+        "active_next_action_executable_items"
+    )
     executable_backlog_items = agent_todo_summary.get("executable_backlog_items")
     first_executable_items = agent_todo_summary.get("first_executable_items")
-    if isinstance(executable_backlog_items, list) and executable_backlog_items:
+    if (
+        isinstance(active_next_action_executable_items, list)
+        and active_next_action_executable_items
+    ):
+        raw_items = [
+            *active_next_action_executable_items,
+            *(
+                executable_backlog_items
+                if isinstance(executable_backlog_items, list)
+                else []
+            ),
+        ]
+        source = "agent_todo_summary.active_next_action_executable_items"
+    elif isinstance(executable_backlog_items, list) and executable_backlog_items:
         raw_items = executable_backlog_items
         source = "agent_todo_summary.executable_backlog_items"
     elif isinstance(first_executable_items, list) and first_executable_items:
@@ -1084,6 +1100,21 @@ def _capability_gate(
     else:
         raw_items = []
         source = "agent_todo_summary.executable_backlog_items"
+    deduped_raw_items: list[Any] = []
+    seen_raw: set[tuple[str, str]] = set()
+    for item in raw_items:
+        if not isinstance(item, dict):
+            deduped_raw_items.append(item)
+            continue
+        identity = (
+            str(item.get("todo_id") or ""),
+            str(item.get("text") or "").strip(),
+        )
+        if identity in seen_raw:
+            continue
+        seen_raw.add(identity)
+        deduped_raw_items.append(item)
+    raw_items = deduped_raw_items
     candidates = [
         item
         for item in raw_items
@@ -1574,6 +1605,8 @@ def _deferred_visibility_lanes(
 
 def _todo_summary_source_items(value: dict[str, Any]) -> list[dict[str, Any]]:
     source_keys = (
+        "active_next_action_items",
+        "active_next_action_executable_items",
         "first_open_items",
         "backlog_items",
         "unclaimed_priority_open_items",
@@ -1662,6 +1695,16 @@ def _summarize_user_todos(
         for item in open_items
         if _is_user_gate_todo_item(item)
     ]
+    active_next_action_items = [
+        _compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
+        for item in (value.get("active_next_action_items") or [])
+        if isinstance(item, dict)
+    ] if isinstance(value.get("active_next_action_items"), list) else []
+    active_next_action_executable_items = [
+        _compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
+        for item in (value.get("active_next_action_executable_items") or [])
+        if isinstance(item, dict)
+    ] if isinstance(value.get("active_next_action_executable_items"), list) else []
     open_count = value.get("open_count", len(all_open_items))
     if agent_scope_filter is not None:
         open_count = len(blocking_open_items)
@@ -1675,6 +1718,8 @@ def _summarize_user_todos(
         "first_executable_items": executable_items[:3],
         "gate_open_items": gate_items[:3],
         "monitor_open_items": monitor_items,
+        "active_next_action_items": active_next_action_items,
+        "active_next_action_executable_items": active_next_action_executable_items,
         "backlog_items": open_items[:TODO_BACKLOG_ITEM_LIMIT],
         "executable_backlog_items": executable_items[:TODO_BACKLOG_ITEM_LIMIT],
     }
@@ -1768,6 +1813,16 @@ def _summarize_project_asset_todos(
         if _todo_item_is_actionable_open(item)
         if _todo_task_class(item) == TODO_TASK_CLASS_MONITOR
     ]
+    active_next_action_items = [
+        _compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
+        for item in (value.get("active_next_action_items") or [])
+        if isinstance(item, dict)
+    ] if isinstance(value.get("active_next_action_items"), list) else []
+    active_next_action_executable_items = [
+        _compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
+        for item in (value.get("active_next_action_executable_items") or [])
+        if isinstance(item, dict)
+    ] if isinstance(value.get("active_next_action_executable_items"), list) else []
     claimed_open_items = [item for item in blocking_open_items if item.get("claimed_by")]
     open_count = value.get("open", value.get("open_count", len(all_open_items)))
     if agent_scope_filter is not None:
@@ -1781,6 +1836,8 @@ def _summarize_project_asset_todos(
         "first_open_items": open_items[:3],
         "first_executable_items": executable_items[:3],
         "monitor_open_items": monitor_items,
+        "active_next_action_items": active_next_action_items,
+        "active_next_action_executable_items": active_next_action_executable_items,
         "backlog_items": open_items[:TODO_BACKLOG_ITEM_LIMIT],
         "executable_backlog_items": executable_items[:TODO_BACKLOG_ITEM_LIMIT],
     }
@@ -2152,6 +2209,14 @@ def _agent_lane_next_action(
         return None
 
     candidate_sources: list[tuple[str, list[Any]]] = []
+    candidate_sources.append(
+        (
+            "agent_todo_summary.active_next_action_executable_items",
+            agent_todo_summary.get("active_next_action_executable_items")
+            if isinstance(agent_todo_summary.get("active_next_action_executable_items"), list)
+            else [],
+        )
+    )
     if isinstance(capability_gate, dict) and capability_gate.get("action") == "run":
         candidate_sources.append(
             (
@@ -2558,7 +2623,10 @@ def _selected_action_with_agent_lane(
 ) -> Any:
     if not isinstance(agent_lane_next_action, dict):
         return selected_action
-    if agent_lane_next_action.get("source") != "capability_gate.runnable_candidates":
+    if agent_lane_next_action.get("source") not in {
+        "capability_gate.runnable_candidates",
+        "agent_todo_summary.active_next_action_executable_items",
+    }:
         return selected_action
     selected_by = agent_lane_next_action.get("selected_by")
     confidence = agent_lane_next_action.get("confidence")
@@ -2941,6 +3009,15 @@ def _user_channel_action_required(payload: dict[str, Any]) -> bool:
 
 def _protocol_first_candidate_action(payload: dict[str, Any]) -> str | None:
     goal_id = str(payload.get("goal_id") or "")
+    agent_lane_next_action = (
+        payload.get("agent_lane_next_action")
+        if isinstance(payload.get("agent_lane_next_action"), dict)
+        else {}
+    )
+    lane_text = _protocol_action_label(agent_lane_next_action.get("text"))
+    if lane_text:
+        todo_id = str(agent_lane_next_action.get("todo_id") or "").strip()
+        return f"{todo_id}: {lane_text}" if todo_id else lane_text
     capability_gate = (
         payload.get("capability_gate")
         if isinstance(payload.get("capability_gate"), dict)

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -4394,6 +4394,20 @@ def compact_todo_item(item: dict[str, Any]) -> dict[str, Any]:
     return compact
 
 
+def compact_active_next_action_todo_item(item: dict[str, Any]) -> dict[str, Any]:
+    compact = compact_todo_item(item)
+    for key in (
+        "note",
+        "evidence",
+        "reason",
+        "completed_at",
+        "updated_at",
+        "superseded_by",
+    ):
+        compact.pop(key, None)
+    return compact
+
+
 def todo_item_task_class(item: dict[str, Any]) -> str:
     return normalize_todo_task_class(
         item.get("task_class"),
@@ -4511,11 +4525,21 @@ def apply_resume_conditions(items: list[dict[str, Any]]) -> None:
         item["resume_ready"] = bool(condition.get("satisfied"))
 
 
+def active_next_action_todo_ids(value: Any) -> set[str]:
+    todo_ids: set[str] = set()
+    for match in re.findall(r"\btodo_[A-Za-z0-9_-]+\b", str(value or "")):
+        todo_id = normalize_todo_id(match)
+        if todo_id:
+            todo_ids.add(todo_id)
+    return todo_ids
+
+
 def compact_todo_group(
     items: list[dict[str, Any]],
     *,
     source_section: str | None,
     role: str | None = None,
+    preferred_todo_ids: set[str] | None = None,
 ) -> dict[str, Any] | None:
     if not items:
         return None
@@ -4562,6 +4586,21 @@ def compact_todo_group(
         for item in claimed_open_items
         if todo_item_is_actionable_open(item)
         if todo_item_task_class(item) == TODO_TASK_CLASS_MONITOR
+    ]
+    preferred_ids = {
+        todo_id
+        for todo_id in (preferred_todo_ids or set())
+        if normalize_todo_id(todo_id)
+    }
+    active_next_action_items = [
+        item
+        for item in projected_open_items
+        if normalize_todo_id(item.get("todo_id")) in preferred_ids
+    ]
+    active_next_action_executable_items = [
+        item
+        for item in executable_items
+        if normalize_todo_id(item.get("todo_id")) in preferred_ids
     ]
     summary = {
         "schema_version": "todo_summary_v0",
@@ -4623,6 +4662,16 @@ def compact_todo_group(
         ][:MAX_DEFERRED_TODO_VISIBILITY_ITEMS],
         "items": budgeted_items[:MAX_STATUS_TODOS_PER_ROLE],
     }
+    if active_next_action_items:
+        summary["active_next_action_items"] = [
+            compact_active_next_action_todo_item(item)
+            for item in active_next_action_items
+        ]
+    if active_next_action_executable_items:
+        summary["active_next_action_executable_items"] = [
+            compact_active_next_action_todo_item(item)
+            for item in active_next_action_executable_items
+        ]
     if claimed_open_items:
         summary["claimed_open_count"] = len(claimed_open_items)
         summary["unclaimed_open_count"] = len(open_items) - len(claimed_open_items)
@@ -4661,7 +4710,13 @@ def redacted_status_todo_fields(fields: dict[str, Any]) -> dict[str, Any]:
     return redacted
 
 
-def parse_active_state_todos(state_text: str, *, goal: dict[str, Any] | None = None, state_path: Path | None = None) -> dict[str, Any]:
+def parse_active_state_todos(
+    state_text: str,
+    *,
+    goal: dict[str, Any] | None = None,
+    state_path: Path | None = None,
+    preferred_todo_ids: set[str] | None = None,
+) -> dict[str, Any]:
     role: str | None = None
     source_sections: dict[str, str | None] = {"user": None, "agent": None}
     items: dict[str, list[dict[str, Any]]] = {"user": [], "agent": []}
@@ -4705,8 +4760,18 @@ def parse_active_state_todos(state_text: str, *, goal: dict[str, Any] | None = N
             current_todo["text"] = normalize_todo_text(f"{current_todo.get('text', '')} {continuation}")
 
     result: dict[str, Any] = {}
-    user = compact_todo_group(items["user"], source_section=source_sections["user"], role="user")
-    agent = compact_todo_group(items["agent"], source_section=source_sections["agent"], role="agent")
+    user = compact_todo_group(
+        items["user"],
+        source_section=source_sections["user"],
+        role="user",
+        preferred_todo_ids=preferred_todo_ids,
+    )
+    agent = compact_todo_group(
+        items["agent"],
+        source_section=source_sections["agent"],
+        role="agent",
+        preferred_todo_ids=preferred_todo_ids,
+    )
     if user:
         result["user_todos"] = user
     if agent:
@@ -5440,7 +5505,12 @@ def project_asset_todo_summary(
     ]
     if executable_items:
         summary["first_executable_items"] = executable_items[:MAX_PROJECT_ASSET_TODO_ITEMS]
-    for lane in ("gate_open_items", "current_agent_claimed_open_items"):
+    for lane in (
+        "gate_open_items",
+        "current_agent_claimed_open_items",
+        "active_next_action_items",
+        "active_next_action_executable_items",
+    ):
         lane_items = todo_lane_items(
             todos,
             lane,
@@ -6271,11 +6341,19 @@ def active_state_todo_fields(goal: dict[str, Any]) -> dict[str, Any]:
         state_text = state_path.read_text(encoding="utf-8")
     except OSError:
         return {}
-    fields = parse_active_state_todos(state_text, goal=goal, state_path=state_path)
+    next_action_entries = active_state_next_action_entries(state_text, limit=3)
+    preferred_todo_ids: set[str] = set()
+    for entry in next_action_entries:
+        preferred_todo_ids.update(active_next_action_todo_ids(entry))
+    fields = parse_active_state_todos(
+        state_text,
+        goal=goal,
+        state_path=state_path,
+        preferred_todo_ids=preferred_todo_ids,
+    )
     issue_meta_surface = parse_issue_meta_surface(state_text)
     if issue_meta_surface:
         fields["issue_meta_surface"] = issue_meta_surface
-    next_action_entries = active_state_next_action_entries(state_text, limit=3)
     if next_action_entries:
         fields["active_state_next_action"] = next_action_entries[0]
         fields["active_state_next_action_entries"] = next_action_entries


### PR DESCRIPTION
## Summary
- preserve the todo explicitly named by active-state Next Action in compact status via active_next_action_items / active_next_action_executable_items
- teach quota candidate selection, capability gate, and interaction contract primary_action to prefer that preserved lane before truncated backlog candidates
- add a focused work-lane smoke for an active Next Action todo beyond the normal compact candidate windows

## Validation
- python3 examples/work-lane-contract-smoke.py
- python3 examples/quota-agent-scoped-user-gate-smoke.py
- python3 -m py_compile loopx/status.py loopx/quota.py examples/work-lane-contract-smoke.py
- git diff --check
- real loopx-meta quota check now projects todo_bfa55a4beff1 from agent_todo_summary.active_next_action_executable_items

## Boundary
- staged only loopx/status.py, loopx/quota.py, and examples/work-lane-contract-smoke.py
- no raw benchmark logs, task text, trajectories, verifier output, local state, or credentials included
