### PR TITLE
Centralize todo terminal status checks

### DIFF
--- a/examples/todo-contract-smoke.py
+++ b/examples/todo-contract-smoke.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Smoke-test public todo status contract helpers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from loopx.todo_contract import (
+    normalize_todo_status,
+    todo_done_for_status,
+    todo_terminal_for_status,
+)
+
+
+def main() -> None:
+    assert normalize_todo_status("done") == "done"
+    assert normalize_todo_status("completed") is None
+    assert todo_done_for_status("done")
+    assert not todo_done_for_status("completed")
+    for value in ("done", "deferred", "completed", "closed", "archived"):
+        assert todo_terminal_for_status(value), value
+    for value in ("open", "blocked", "", None):
+        assert not todo_terminal_for_status(value), value
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/todo_contract.py
+++ b/loopx/todo_contract.py
@@ -38,6 +38,7 @@ TODO_STATUS_VALUES = {
     TODO_STATUS_DEFERRED,
 }
 TODO_TERMINAL_STATUS_VALUES = {TODO_STATUS_DONE, TODO_STATUS_DEFERRED}
+TODO_LEGACY_TERMINAL_STATUS_VALUES = {"completed", "closed", "archived"}
 
 TODO_ACTION_KIND_ADVANCEMENT_VALUES = {
     "advance",
@@ -249,6 +250,14 @@ def normalize_todo_status(value: Any) -> str | None:
 
 def todo_done_for_status(status: Any) -> bool:
     return normalize_todo_status(status) in TODO_TERMINAL_STATUS_VALUES
+
+
+def todo_terminal_for_status(status: Any) -> bool:
+    candidate = str(status or "").strip().lower()
+    return (
+        normalize_todo_status(candidate) in TODO_TERMINAL_STATUS_VALUES
+        or candidate in TODO_LEGACY_TERMINAL_STATUS_VALUES
+    )
 
 
 def todo_status_from_marker(marker: Any) -> str:

--- a/scripts/harbor_host_codex_goal_agent.py
+++ b/scripts/harbor_host_codex_goal_agent.py
@@ -60,6 +60,7 @@ from loopx.benchmark_core.loop_protocol import (
     classify_loopx_treatment_claim,
     render_loop_contract_packet_lines,
 )
+from loopx.todo_contract import todo_terminal_for_status
 
 LONG_RUN_DEFAULT_GOAL_TIMEOUT_SEC = 21600.0
 
@@ -344,9 +345,7 @@ def _case_scheduler_closeout_summary(
     }
     if result_kind == "timeout_blocker":
         closeout["timeout_preserves_open_todo"] = (
-            not case_todo
-            or str(case_todo.get("status") or "").strip().lower()
-            not in {"done", "completed", "closed"}
+            not case_todo or not todo_terminal_for_status(case_todo.get("status"))
         )
     return closeout
 
@@ -392,9 +391,8 @@ def _case_scheduler_active_todo_exit_state(trace: dict[str, Any]) -> dict[str, A
         if isinstance(agent_summary.get("case_todo"), dict)
         else {}
     )
-    terminal_statuses = {"done", "completed", "closed", "archived"}
     case_status = str(case_todo.get("status") or "").strip().lower()
-    case_todo_active = bool(case_status and case_status not in terminal_statuses)
+    case_todo_active = bool(case_status and not todo_terminal_for_status(case_status))
     agent_open_count = _todo_open_count(agent_summary)
     user_open_count = _todo_open_count(user_summary)
     agent_has_active = case_todo_active or (
@@ -605,12 +603,7 @@ def _build_solution_phase_counters(
         or closeout.get("case_todo_status")
         or ""
     )
-    self_declared_done_count = 1 if case_todo_status.lower() in {
-        "done",
-        "completed",
-        "closed",
-        "archived",
-    } else 0
+    self_declared_done_count = 1 if todo_terminal_for_status(case_todo_status) else 0
     loopx_cli_count = bridge_phase_counts.get("loopx_cli", 0)
     task_command_count = sum(
         count


### PR DESCRIPTION
## Summary
- add a centralized todo terminal-status helper that recognizes canonical terminal statuses plus legacy external terminal statuses without widening the canonical todo status enum
- update the Harbor host goal agent to use that helper for case-local active-todo exit and solution phase counters
- add a focused todo contract smoke

## Validation
- python3 examples/todo-contract-smoke.py
- python3 examples/work-lane-contract-smoke.py
- python3 -m py_compile loopx/todo_contract.py scripts/harbor_host_codex_goal_agent.py examples/todo-contract-smoke.py
- git diff --check

## Boundary
- Public runtime/helper and validation smoke only
- No private state, raw benchmark logs, raw trajectories, credentials, or local evidence included