### PR TITLE
Use live lifecycle counters for SkillsBench product mode

### DIFF
--- a/examples/skillsbench-lifecycle-depth-gate-smoke.py
+++ b/examples/skillsbench-lifecycle-depth-gate-smoke.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Smoke-test SkillsBench product-mode live lifecycle counter gating."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.skillsbench_automation_loop import (  # noqa: E402
+    _merge_round_result_trajectory_lifecycle_summary,
+    _product_mode_depth_gate_satisfied,
+)
+
+
+class FakeRoundResult:
+    trajectory = [
+        {
+            "type": "tool_call",
+            "title": "/app/.local/bin/loopx quota should-run --goal-id case --agent-id codex-benchmark-agent",
+            "status": "completed",
+        },
+        {
+            "type": "tool_call",
+            "title": "/app/.local/bin/loopx todo update --goal-id case --todo-id todo_case --status open",
+            "status": "completed",
+        },
+    ]
+
+
+def main() -> None:
+    trace = {"loopx_state_reads": 0, "loopx_state_writes": 0}
+    assert not _product_mode_depth_gate_satisfied(trace)
+    _merge_round_result_trajectory_lifecycle_summary(FakeRoundResult(), trace)
+    assert trace["round_result_trajectory_lifecycle_summary_present"] is True
+    assert trace["round_result_loopx_cli_state_read_count"] == 1
+    assert trace["round_result_loopx_cli_state_write_count"] == 1
+    assert _product_mode_depth_gate_satisfied(trace)
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -3224,6 +3224,18 @@ def build_skillsbench_benchflow_result_benchmark_run(
             "loopx_case_state_writes": controller_counters.get(
                 "loopx_case_state_writes", 0
             ),
+            "round_result_trajectory_lifecycle_summary_present": controller_counters.get(
+                "round_result_trajectory_lifecycle_summary_present", False
+            ),
+            "round_result_loopx_cli_call_count": controller_counters.get(
+                "round_result_loopx_cli_call_count", 0
+            ),
+            "round_result_loopx_cli_state_read_count": controller_counters.get(
+                "round_result_loopx_cli_state_read_count", 0
+            ),
+            "round_result_loopx_cli_state_write_count": controller_counters.get(
+                "round_result_loopx_cli_state_write_count", 0
+            ),
             "heartbeat_count": controller_counters.get("heartbeat_count", 0),
             "controller_trace_present": controller_trace_present,
             "controller_action_decisions": controller_counters.get(

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -117,7 +117,11 @@ from loopx.benchmark_core.loop_protocol import (  # noqa: E402
     build_blind_loop_continuation_prompt,
     build_blind_loop_initial_prompt,
 )
-from loopx.benchmark_trajectory import summarize_public_acp_trajectory
+from loopx.benchmark_trajectory import (
+    loopx_cli_state_usage,
+    normalized_loopx_cli_call,
+    summarize_public_acp_trajectory,
+)
 
 
 class SkillsBenchRunnerInterrupted(RuntimeError):
@@ -4378,6 +4382,72 @@ def _trajectory_text_fragments(value: Any) -> list[str]:
     return fragments
 
 
+def _trajectory_tool_call_titles(value: Any) -> list[str]:
+    titles: list[str] = []
+    if isinstance(value, dict):
+        title = str(value.get("title") or "").strip()
+        event_type = str(value.get("type") or "").strip()
+        if title and (event_type == "tool_call" or "tool" in event_type):
+            titles.append(title)
+        for nested in value.values():
+            titles.extend(_trajectory_tool_call_titles(nested))
+        return titles
+    if isinstance(value, list):
+        for nested in value:
+            titles.extend(_trajectory_tool_call_titles(nested))
+    return titles
+
+
+def _merge_round_result_trajectory_lifecycle_summary(
+    round_result: Any,
+    trace: dict[str, Any],
+) -> None:
+    def trace_int(name: str) -> int:
+        value = trace.get(name, 0)
+        return value if isinstance(value, int) and not isinstance(value, bool) else 0
+
+    trajectory = getattr(round_result, "trajectory", None)
+    if not isinstance(trajectory, list):
+        return
+    read_count = 0
+    write_count = 0
+    call_count = 0
+    for title in _trajectory_tool_call_titles(trajectory):
+        if not re.search(r"(?:^|\s|/)loopx(?:\s|$)", title):
+            continue
+        call = normalized_loopx_cli_call(title, round_index=0)
+        usage = loopx_cli_state_usage(call)
+        call_count += 1
+        if usage == "state_read":
+            read_count += 1
+        elif usage == "state_write":
+            write_count += 1
+    if call_count <= 0:
+        return
+    trace["round_result_trajectory_lifecycle_summary_present"] = True
+    trace["round_result_loopx_cli_call_count"] = max(
+        trace_int("round_result_loopx_cli_call_count"),
+        call_count,
+    )
+    trace["round_result_loopx_cli_state_read_count"] = max(
+        trace_int("round_result_loopx_cli_state_read_count"),
+        read_count,
+    )
+    trace["round_result_loopx_cli_state_write_count"] = max(
+        trace_int("round_result_loopx_cli_state_write_count"),
+        write_count,
+    )
+    trace["loopx_state_reads"] = max(
+        trace_int("loopx_state_reads"),
+        read_count,
+    )
+    trace["loopx_state_writes"] = max(
+        trace_int("loopx_state_writes"),
+        write_count,
+    )
+    trace["raw_round_result_trajectory_recorded"] = False
+
+
 def _round_result_declared_done(round_result: Any) -> bool:
     trajectory = getattr(round_result, "trajectory", None)
     if not isinstance(trajectory, list):
@@ -4861,6 +4931,7 @@ def _build_product_mode_user(
             if round_result is not None:
                 _inc_counter(trace, "official_feedback_blinded_count")
                 if treatment:
+                    _merge_round_result_trajectory_lifecycle_summary(round_result, trace)
                     _merge_acp_trajectory_summary(plan or {}, trace)
                     _merge_host_local_acp_relay_trace_summary(plan or {}, trace)
                     no_tool_calls = _round_result_tool_call_count(round_result) == 0


### PR DESCRIPTION
## Summary
- use live round-result trajectory counters to satisfy the SkillsBench product-mode lifecycle depth gate during the run, instead of waiting for post-run ACP trajectory file reduction
- keep the evidence public-safe: only normalized LoopX CLI state read/write counts are recorded, not raw trajectory bodies, tool output, task text, or verifier output
- surface the live round-result lifecycle counters in the compact interaction counters for future closeout/debug
- add a focused smoke proving quota/read + todo/write CLI calls satisfy the product-mode depth gate

## Root cause
The powerlifting-coef-calc compact trace showed final LoopX CLI state read/write evidence (`loopx_state_reads=37`, `loopx_state_writes=47`) but still recorded repeated lifecycle checkpoint continuations. The controller only learned those counts from the post-run ACP trajectory file summary, after the per-round gate had already fired. The fix feeds public-safe live counters from the current `RoundResult.trajectory` into the same gate before checkpoint decisions.

## Validation
- python3 examples/skillsbench-lifecycle-depth-gate-smoke.py
- python3 examples/skillsbench-benchmark-run-smoke.py
- python3 -m py_compile scripts/skillsbench_automation_loop.py loopx/benchmark_adapters/skillsbench.py examples/skillsbench-lifecycle-depth-gate-smoke.py
- git diff --check

## Boundary
- No benchmark jobs launched
- No raw task text, raw trajectories, verifier output, private logs, credentials, or local evidence committed
