### PR TITLE
Auto-wire SkillsBench host-local sandbox bridge

### DIFF
--- a/examples/skillsbench-host-local-launch-plan-smoke.py
+++ b/examples/skillsbench-host-local-launch-plan-smoke.py
@@ -31,6 +31,7 @@ from scripts.skillsbench_automation_loop import (  # noqa: E402
     _public_runner_prerequisites,
     _replace_option_value,
     _run_host_local_acp_codex_exec_preflight,
+    _set_option_value,
     build_runner_failure_compact,
     ensure_benchflow_runtime,
 )
@@ -50,6 +51,7 @@ def main() -> int:
     assert "if original_rollout_connect_acp is not _MISSING:" in source
     assert "_filter_kwargs_for_signature(RolloutConfig, rollout_config_kwargs)" in source
     assert "env=target_env" in source
+    assert "local_acp_command = _set_option_value(" in source
     assert "del (\n            env," not in source
     target_env = _host_local_acp_target_env(
         {
@@ -75,6 +77,18 @@ def main() -> int:
         "new",
         "--keep",
         "x",
+    ]
+    appended = _set_option_value(
+        ["relay", "--keep", "x"],
+        "--remote-command-file-bridge-command",
+        "generated",
+    )
+    assert appended == [
+        "relay",
+        "--keep",
+        "x",
+        "--remote-command-file-bridge-command",
+        "generated",
     ]
     with tempfile.TemporaryDirectory(prefix="gh-skillsbench-plan-") as tmp:
         root = Path(tmp) / "skillsbench"
@@ -204,7 +218,7 @@ def main() -> int:
         )
         heartbeat_index = launch_command.index("--stream-heartbeat-interval-sec")
         assert launch_command[heartbeat_index + 1] == "15.0"
-        blocked = subprocess.run(
+        auto_wiring_plan_proc = subprocess.run(
             [
                 sys.executable,
                 str(SCRIPT),
@@ -216,6 +230,7 @@ def main() -> int:
                 "loopx-product-mode",
                 "--host-local-acp-launch",
                 "--remote-command-file-bridge-ready",
+                "--plan-only",
             ],
             cwd=REPO_ROOT,
             stdout=subprocess.PIPE,
@@ -224,17 +239,27 @@ def main() -> int:
             timeout=30,
             check=False,
         )
-        assert blocked.returncode == 2, blocked
-        failure = json.loads(blocked.stderr)
-        assert failure["error_type"] == (
-            "SkillsBenchReverseChannelBridgeNotSolverWired"
-        ), failure
-        assert failure["remote_command_file_bridge_materialized"] is True
-        assert failure["remote_command_file_bridge_consumed_by_solver"] is False
-        assert failure["raw_logs_recorded"] is False
-        assert failure["raw_task_text_read"] is False
-        assert failure["remote_command_file_bridge_probe_command_configured"] is False
-        assert failure["remote_command_file_bridge_command_configured"] is False
+        assert auto_wiring_plan_proc.returncode == 0, auto_wiring_plan_proc.stderr
+        auto_wiring_plan = json.loads(auto_wiring_plan_proc.stdout)["launch_plan"]
+        auto_wiring_prerequisites = auto_wiring_plan["runner_prerequisites"]
+        assert (
+            auto_wiring_prerequisites["remote_command_file_bridge_materialized"]
+            is True
+        )
+        assert (
+            auto_wiring_prerequisites["remote_command_file_bridge_command_configured"]
+            is False
+        )
+        assert (
+            auto_wiring_prerequisites[
+                "remote_command_file_bridge_agent_operation_trace_required"
+            ]
+            is True
+        )
+        assert (
+            auto_wiring_prerequisites["remote_command_file_bridge_consumption_status"]
+            == "sandbox_bridge_auto_wiring_pending"
+        )
         preflight = subprocess.run(
             [
                 sys.executable,
@@ -287,6 +312,7 @@ def main() -> int:
                 "--remote-command-file-bridge-probe",
                 "--remote-command-file-bridge-probe-command",
                 f"{sys.executable} {BRIDGE_SCRIPT} --serve-probe",
+                "--plan-only",
             ],
             cwd=REPO_ROOT,
             stdout=subprocess.PIPE,
@@ -295,11 +321,9 @@ def main() -> int:
             timeout=30,
             check=False,
         )
-        assert blocked_probe_only.returncode == 2, blocked_probe_only
-        probe_only_failure = json.loads(blocked_probe_only.stderr)
-        assert probe_only_failure["error_type"] == (
-            "SkillsBenchReverseChannelBridgeNotSolverWired"
-        ), probe_only_failure
+        assert blocked_probe_only.returncode == 0, blocked_probe_only.stderr
+        probe_only_plan = json.loads(blocked_probe_only.stdout)["launch_plan"]
+        probe_only_failure = probe_only_plan["runner_prerequisites"]
         assert (
             probe_only_failure["remote_command_file_bridge_probe_command_configured"]
             is True
@@ -307,6 +331,10 @@ def main() -> int:
         assert (
             probe_only_failure["remote_command_file_bridge_command_configured"]
             is False
+        )
+        assert (
+            probe_only_failure["remote_command_file_bridge_consumption_status"]
+            == "sandbox_bridge_auto_wiring_pending"
         )
         blocked_fixture_solver = subprocess.run(
             [

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -817,6 +817,13 @@ def _replace_option_value(command: list[str], option: str, value: str) -> list[s
     return updated
 
 
+def _set_option_value(command: list[str], option: str, value: str) -> list[str]:
+    updated = _replace_option_value(command, option, value)
+    if option in updated:
+        return updated
+    return [*updated, option, value]
+
+
 def _host_local_acp_docker_bridge_command(
     env: Any,
     args: argparse.Namespace,
@@ -2939,9 +2946,18 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
         and remote_command_file_bridge_materialized
         and remote_command_file_bridge_solver_command_configured
     )
+    remote_command_file_bridge_sandbox_auto_wiring_pending = bool(
+        args.host_local_acp_launch
+        and route in {"raw-codex-autonomous-max5", "loopx-product-mode"}
+        and remote_command_file_bridge_materialized
+        and not remote_command_file_bridge_solver_command_configured
+    )
     remote_command_file_bridge_agent_operation_trace_required = bool(
         route == "loopx-product-mode"
-        and remote_command_file_bridge_solver_wiring_configured
+        and (
+            remote_command_file_bridge_solver_wiring_configured
+            or remote_command_file_bridge_sandbox_auto_wiring_pending
+        )
     )
     remote_command_file_bridge_agent_command_instrumented = bool(
         remote_command_file_bridge_solver_wiring_configured
@@ -2972,6 +2988,10 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
     if remote_command_file_bridge_solver_wiring_configured:
         remote_command_file_bridge_consumption_status = (
             "solver_wiring_configured_pending_prompt"
+        )
+    elif remote_command_file_bridge_sandbox_auto_wiring_pending:
+        remote_command_file_bridge_consumption_status = (
+            "sandbox_bridge_auto_wiring_pending"
         )
     elif remote_command_file_bridge_materialized:
         remote_command_file_bridge_consumption_status = "probe_only_not_solver_wired"
@@ -5190,16 +5210,29 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
             plan,
         )
         if sandbox_bridge_command:
-            local_acp_command = _replace_option_value(
+            local_acp_command = _set_option_value(
                 local_acp_command,
                 "--remote-command-file-bridge-command",
                 sandbox_bridge_command,
             )
-            local_acp_command = _replace_option_value(
+            local_acp_command = _set_option_value(
                 local_acp_command,
                 "--remote-command-file-bridge-agent-command",
                 sandbox_bridge_command,
             )
+            prerequisites["remote_command_file_bridge_command_configured"] = True
+            prerequisites["remote_command_file_bridge_agent_command_configured"] = True
+            prerequisites["remote_command_file_bridge_solver_wiring_configured"] = True
+            prerequisites["remote_command_file_bridge_consumption_status"] = (
+                "solver_wiring_configured_pending_prompt"
+            )
+            if args.route == "loopx-product-mode":
+                prerequisites[
+                    "remote_command_file_bridge_agent_operation_trace_required"
+                ] = True
+                prerequisites[
+                    "remote_command_file_bridge_agent_operation_trace_status"
+                ] = "external_agent_command_relay_wrapped_pending_trace"
         else:
             prerequisites.setdefault(
                 "host_local_acp_sandbox_bridge_mode",
@@ -6852,6 +6885,12 @@ def main(argv: list[str] | None = None) -> int:
     product_host_local_bridge_command_configured = bool(
         args.remote_command_file_bridge_solver_command
     )
+    product_host_local_bridge_sandbox_auto_wiring_pending = bool(
+        args.route in {"raw-codex-autonomous-max5", "loopx-product-mode"}
+        and args.host_local_acp_launch
+        and product_host_local_bridge_materialized
+        and not product_host_local_bridge_command_configured
+    )
     product_host_local_bridge_fixture_solver = (
         skillsbench_remote_command_file_bridge_command_is_fixture_probe(
             args.remote_command_file_bridge_solver_command
@@ -6899,7 +6938,10 @@ def main(argv: list[str] | None = None) -> int:
         and args.host_local_acp_launch
         and not (
             product_host_local_bridge_materialized
-            and product_host_local_bridge_command_configured
+            and (
+                product_host_local_bridge_command_configured
+                or product_host_local_bridge_sandbox_auto_wiring_pending
+            )
         )
         and not args.local_driver_worker_handshake_preflight
         and not args.plan_only
@@ -6912,7 +6954,9 @@ def main(argv: list[str] | None = None) -> int:
                 "product-mode host-local ACP runs execute Codex on the host while "
                 "the scored workspace lives in the BenchFlow sandbox; a materialized "
                 "remote command/file bridge and its private solver command are both "
-                "required before this is a countable reverse-channel treatment"
+                "required before this is a countable reverse-channel treatment, unless "
+                "the BenchFlow sandbox docker bridge can be generated after environment "
+                "materialization"
             ),
             "next_action": (
                 "wire the remote command/file bridge into the solver worker or "


### PR DESCRIPTION
## Summary\n- add a set-option helper so the host-local ACP relay command can append a generated sandbox bridge when no explicit solver bridge flag was provided\n- mark sandbox auto-wiring as pending in launch plans instead of misclassifying it as probe-only/not-wired\n- update the host-local launch smoke to cover auto-wiring and keep fixture solver rejection behavior separate\n\n## Validation\n- python3 examples/skillsbench-host-local-launch-plan-smoke.py\n- python3 examples/skillsbench-benchmark-run-smoke.py\n- python3 -m py_compile scripts/skillsbench_automation_loop.py examples/skillsbench-host-local-launch-plan-smoke.py\n- git diff --check\n\n## Benchmark note\nA follow-up organize-messy-files validation reached compact output but was blocked before case execution by remote Codex transport/network availability on ECS. The driver-side sandbox bridge plan now reports sandbox_bridge_auto_wiring_pending as intended; the remaining blocker is the Codex reverse-channel path, not this bridge append bug.