### PR TITLE
feat: support PR-merge todo resume conditions

### DIFF
--- a/docs/project-agent-todo-contract.md
+++ b/docs/project-agent-todo-contract.md
@@ -151,9 +151,14 @@ runnable work in the same claim/priority bucket so capability-building todos do
 not require fragile active-state reordering.
 
 Deferred todos may carry a machine-readable resume condition with
-`resume_when=<token>`. The first supported condition is
-`resume_when=todo_done:<todo_id>`, meaning the deferred todo should become a
-successor replan candidate after the referenced todo reaches `status=done`.
+`resume_when=<token>`. Supported conditions are:
+
+- `resume_when=todo_done:<todo_id>`: the deferred todo becomes a successor
+  replan candidate after the referenced todo reaches `status=done`.
+- `resume_when=pr_merged:#532` or
+  `resume_when=pr_merged:owner/repo#532`: the deferred todo becomes a successor
+  candidate after a structured rollout event records that PR merge.
+
 Status and quota expose deferred todos as a visibility lane after sorted open
 todo lanes. This is a deferred gate-resume lane: it is not runnable work, and
 it is not evidence that the current agent has no todo, until an agent reopens,

--- a/docs/reference/protocols/long-horizon-agent-state-protocol-v0.md
+++ b/docs/reference/protocols/long-horizon-agent-state-protocol-v0.md
@@ -228,8 +228,11 @@ Not yet aligned:
 
 - `rollback_packet_v0` is specified and smoke-tested, but no command yet emits
   or executes packets.
-- PR lifecycle resume conditions such as `pr_merged:#532` are not supported;
-  only `resume_when=todo_done:<todo_id>` exists today.
+- PR lifecycle resume conditions are limited to structured rollout-event
+  evidence: `resume_when=pr_merged:#532` and
+  `resume_when=pr_merged:owner/repo#532` can wake deferred todos after the
+  matching `pr_merge` event appears in the local rollout log. LoopX does not
+  infer this from prose.
 - `global_manager_command_v0` is specified and smoke-tested, but no host
   integration or CLI command emits it yet.
 - Historical human-gate impact must be inferred from public-safe evidence.

--- a/examples/todo-contract-smoke.py
+++ b/examples/todo-contract-smoke.py
@@ -9,6 +9,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from loopx.todo_contract import (
+    normalize_todo_resume_when,
     normalize_todo_status,
     todo_done_for_status,
     todo_terminal_for_status,
@@ -18,6 +19,11 @@ from loopx.todo_contract import (
 def main() -> None:
     assert normalize_todo_status("done") == "done"
     assert normalize_todo_status("completed") is None
+    assert normalize_todo_resume_when("pr_merged:#532") == "pr_merged:#532"
+    assert (
+        normalize_todo_resume_when("pr_merged:huangruiteng/loopx#532")
+        == "pr_merged:huangruiteng/loopx#532"
+    )
     assert todo_done_for_status("done")
     assert not todo_done_for_status("completed")
     for value in ("done", "deferred", "completed", "closed", "archived"):

--- a/examples/todo-durability-fixture-smoke.py
+++ b/examples/todo-durability-fixture-smoke.py
@@ -15,6 +15,11 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.status import parse_active_state_todos  # noqa: E402
+from loopx.rollout_event_log import (  # noqa: E402
+    append_rollout_event,
+    build_rollout_event,
+    rollout_event_log_path,
+)
 
 
 GOAL_ID = "todo-durability-fixture-goal"
@@ -25,6 +30,7 @@ FIRST_OPEN_TODO = (
 SECOND_OPEN_TODO = "[P2] Keep the todo archive warning visible in quota should-run."
 ACTIVE_DONE_TODO = "[P2] Prior completed implementation remains in active Agent Todo until archived."
 DEFERRED_TODO = "[P1] Resume the issue surface fixture after CLI extraction stabilizes."
+PR_DEFERRED_TODO = "[P1] Resume the Lark Kanban follow-up after PR #532 merges."
 ARCHIVED_DONE_TODOS = 25
 
 
@@ -68,6 +74,8 @@ def state_text() -> str:
         "  <!-- loopx:todo todo_id=todo_done_cli status=done task_class=advancement_task -->\n"
         f"- [-] {DEFERRED_TODO}\n"
         "  <!-- loopx:todo todo_id=todo_deferred_surface status=deferred task_class=advancement_task claimed_by=codex-product-capability resume_when=todo_done:todo_done_cli -->\n"
+        f"- [-] {PR_DEFERRED_TODO}\n"
+        "  <!-- loopx:todo todo_id=todo_pr_deferred status=deferred task_class=advancement_task claimed_by=codex-side-bypass resume_when=pr_merged:#532 -->\n"
         f"- [ ] {SECOND_OPEN_TODO}\n\n"
         "## Completed Work Archive\n\n"
         f"{archived_lines}"
@@ -84,6 +92,10 @@ def write_fixture(root: Path) -> tuple[Path, Path]:
     state_path.parent.mkdir(parents=True, exist_ok=True)
     state_path.write_text(state_text(), encoding="utf-8")
     registry_path.parent.mkdir(parents=True, exist_ok=True)
+    append_rollout_event(
+        rollout_event_log_path(runtime, GOAL_ID),
+        pr_merged_event(),
+    )
     registry_path.write_text(
         json.dumps(
             {
@@ -121,11 +133,11 @@ def write_fixture(root: Path) -> tuple[Path, Path]:
 
 def assert_parseable_agent_todos(agent_todos: dict) -> None:
     assert agent_todos["schema_version"] == "todo_summary_v0", agent_todos
-    assert agent_todos["total_count"] == 4, agent_todos
+    assert agent_todos["total_count"] == 5, agent_todos
     assert agent_todos["open_count"] == 2, agent_todos
-    assert agent_todos["done_count"] == 2, agent_todos
-    assert agent_todos["deferred_count"] == 1, agent_todos
-    assert [item["index"] for item in agent_todos["first_open_items"]] == [1, 4], agent_todos
+    assert agent_todos["done_count"] == 3, agent_todos
+    assert agent_todos["deferred_count"] == 2, agent_todos
+    assert [item["index"] for item in agent_todos["first_open_items"]] == [1, 5], agent_todos
 
     first_open = agent_todos["first_open_items"][0]
     assert first_open["schema_version"] == "todo_item_v0", first_open
@@ -147,12 +159,22 @@ def assert_parseable_agent_todos(agent_todos: dict) -> None:
     assert second_open["text"] == SECOND_OPEN_TODO, second_open
 
     deferred = agent_todos["deferred_items"][0]
-    assert deferred["todo_id"] == "todo_deferred_surface", deferred
+    deferred_by_id = {item["todo_id"]: item for item in agent_todos["deferred_items"]}
+    assert set(deferred_by_id) == {"todo_deferred_surface", "todo_pr_deferred"}, agent_todos
+    deferred = deferred_by_id["todo_deferred_surface"]
     assert deferred["status"] == "deferred", deferred
     assert deferred["resume_when"] == "todo_done:todo_done_cli", deferred
     assert deferred["resume_ready"] is True, deferred
     assert deferred["resume_condition"]["target_status"] == "done", deferred
-    assert agent_todos["deferred_resume_candidates"][0]["todo_id"] == "todo_deferred_surface", agent_todos
+    pr_deferred = deferred_by_id["todo_pr_deferred"]
+    assert pr_deferred["resume_when"] == "pr_merged:#532", pr_deferred
+    assert pr_deferred["resume_ready"] is True, pr_deferred
+    assert pr_deferred["resume_condition"]["kind"] == "pr_merged", pr_deferred
+    assert pr_deferred["resume_condition"]["pr_number"] == 532, pr_deferred
+    assert pr_deferred["resume_condition"]["pr_repo"] is None, pr_deferred
+    assert pr_deferred["resume_condition"]["matched_pr_ref"] == "huangruiteng/loopx#532", pr_deferred
+    resume_candidate_ids = {item["todo_id"] for item in agent_todos["deferred_resume_candidates"]}
+    assert {"todo_deferred_surface", "todo_pr_deferred"} <= resume_candidate_ids, agent_todos
     if "items" in agent_todos:
         statuses = [item["status"] for item in agent_todos["items"][:3]]
         assert statuses == ["open", "open", "deferred"], agent_todos
@@ -164,8 +186,18 @@ def attention_item(status_payload: dict) -> dict:
     return items[0]
 
 
+def pr_merged_event() -> dict:
+    return build_rollout_event(
+        goal_id=GOAL_ID,
+        event_kind="pr_merge",
+        pr_ref="huangruiteng/loopx#532",
+        status="ready",
+        summary="PR #532 merged and can resume dependent deferred todos.",
+    )
+
+
 def main() -> int:
-    parsed = parse_active_state_todos(state_text())
+    parsed = parse_active_state_todos(state_text(), rollout_events=[pr_merged_event()])
     assert_parseable_agent_todos(parsed["agent_todos"])
 
     with tempfile.TemporaryDirectory(prefix="loopx-todo-durability-") as tmp:
@@ -177,11 +209,14 @@ def main() -> int:
         assert "completed_todo_archive_warning" not in item, item
         assert "completed_todo_archive_warning" not in item["project_asset"], item
         assert item["project_asset"]["agent_todos"]["open"] == 2, item
-        assert item["project_asset"]["agent_todos"]["done"] == 2, item
-        assert item["project_asset"]["agent_todos"]["deferred_count"] == 1, item
+        assert item["project_asset"]["agent_todos"]["done"] == 3, item
+        assert item["project_asset"]["agent_todos"]["deferred_count"] == 2, item
         assert (
-            item["project_asset"]["agent_todos"]["deferred_resume_candidates"][0]["todo_id"]
-            == "todo_deferred_surface"
+            {
+                candidate["todo_id"]
+                for candidate in item["project_asset"]["agent_todos"]["deferred_resume_candidates"]
+            }
+            >= {"todo_deferred_surface", "todo_pr_deferred"}
         ), item
         assert item["project_asset"]["agent_todos"]["next"] == FIRST_OPEN_TODO, item
         assert item["project_asset"]["agent_todos"]["next_index"] == 1, item
@@ -219,8 +254,8 @@ def main() -> int:
         post_lifecycle_item = attention_item(post_lifecycle_status)
         post_agent_todos = post_lifecycle_item["agent_todos"]
         assert post_agent_todos["open_count"] == 2, post_agent_todos
-        assert post_agent_todos["done_count"] == 3, post_agent_todos
-        assert post_agent_todos["deferred_count"] == 1, post_agent_todos
+        assert post_agent_todos["done_count"] == 4, post_agent_todos
+        assert post_agent_todos["deferred_count"] == 2, post_agent_todos
         assert post_agent_todos["first_open_items"][0]["priority"] == "P1", post_agent_todos
         assert post_agent_todos["first_open_items"][0]["todo_id"] == next_todo["todo_id"], post_agent_todos
         assert post_agent_todos["first_open_items"][0]["action_kind"] == "fixture_follow_up", post_agent_todos

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -54,6 +54,8 @@ from .state_projection import (
     state_projection_gap_warning,
 )
 from .todo_contract import (
+    TODO_RESUME_KIND_PR_MERGED,
+    TODO_RESUME_KIND_TODO_DONE,
     TODO_STATUS_OPEN,
     TODO_TASK_CLASS_ADVANCEMENT,
     TODO_TASK_CLASS_MONITOR,
@@ -378,6 +380,19 @@ MAX_ISSUE_META_SURFACE_ITEMS = 8
 MAX_ISSUE_META_LABELS = 8
 MAX_TODO_INDEX_ITEMS = 240
 MAX_TODO_INDEX_ROLLOUT_EVENTS_PER_GOAL = 500
+PR_MERGED_EVENT_KINDS = {
+    "pr_merge",
+    "pr_merged",
+    "pull_request_merge",
+    "pull_request_merged",
+}
+PR_REF_PATTERN = re.compile(
+    r"^(?:(?P<repo>[a-z0-9_.-]{1,80}/[a-z0-9_.-]{1,100}))?#(?P<number>[1-9][0-9]{0,8})$"
+)
+GITHUB_PULL_URL_PATTERN = re.compile(
+    r"^https://github\.com/(?P<repo>[a-z0-9_.-]{1,80}/[a-z0-9_.-]{1,100})/pull/(?P<number>[1-9][0-9]{0,8})/?$",
+    re.IGNORECASE,
+)
 TODO_PROJECTION_VIEW_SCHEMA_VERSION = "todo_projection_view_v0"
 TODO_PROJECTION_DETAIL_POINTER_SCHEMA_VERSION = "todo_projection_detail_pointer_v0"
 ISSUE_META_SURFACE_SCHEMA_VERSION = "issue_meta_surface_v0"
@@ -4496,7 +4511,98 @@ def todo_item_is_deferred(item: dict[str, Any]) -> bool:
     return (normalize_todo_status(item.get("status")) or TODO_STATUS_OPEN) == "deferred"
 
 
-def apply_resume_conditions(items: list[dict[str, Any]]) -> None:
+def normalized_pr_ref_parts(value: Any) -> dict[str, Any] | None:
+    candidate = str(value or "").strip().lower()
+    if not candidate:
+        return None
+    pull_url_match = GITHUB_PULL_URL_PATTERN.match(candidate)
+    if pull_url_match:
+        return {
+            "repo": pull_url_match.group("repo"),
+            "number": int(pull_url_match.group("number")),
+            "normalized": f"{pull_url_match.group('repo')}#{pull_url_match.group('number')}",
+        }
+    match = PR_REF_PATTERN.match(candidate)
+    if not match:
+        return None
+    repo = match.group("repo")
+    number = int(match.group("number"))
+    normalized = f"{repo}#{number}" if repo else f"#{number}"
+    return {"repo": repo, "number": number, "normalized": normalized}
+
+
+def rollout_event_pr_refs(event: dict[str, Any]) -> list[dict[str, Any]]:
+    refs: list[dict[str, Any]] = []
+    code_refs = event.get("code_refs") if isinstance(event.get("code_refs"), dict) else {}
+    for value in (code_refs.get("pr_ref"), event.get("pr_ref")):
+        parsed = normalized_pr_ref_parts(value)
+        if parsed:
+            refs.append(parsed)
+    source_refs = event.get("source_refs")
+    if isinstance(source_refs, list):
+        for source_ref in source_refs:
+            if not isinstance(source_ref, dict):
+                continue
+            if str(source_ref.get("kind") or "").strip().lower() not in {
+                "pull_request",
+                "pr",
+            }:
+                continue
+            parsed = normalized_pr_ref_parts(source_ref.get("ref"))
+            if parsed:
+                refs.append(parsed)
+    unique: list[dict[str, Any]] = []
+    seen: set[tuple[str | None, int]] = set()
+    for ref in refs:
+        key = (ref.get("repo"), int(ref.get("number") or 0))
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(ref)
+    return unique
+
+
+def pr_merged_condition(target: str, rollout_events: list[dict[str, Any]]) -> dict[str, Any]:
+    condition: dict[str, Any] = {
+        "pr_number": None,
+        "pr_repo": None,
+        "source": "rollout_event_log",
+    }
+    target_ref = normalized_pr_ref_parts(target)
+    if not target_ref:
+        condition["invalid_target"] = True
+        return condition
+    condition["pr_number"] = target_ref["number"]
+    if target_ref.get("repo"):
+        condition["pr_repo"] = target_ref["repo"]
+    for event in rollout_events:
+        if not isinstance(event, dict):
+            continue
+        if str(event.get("event_kind") or "").strip().lower() not in PR_MERGED_EVENT_KINDS:
+            continue
+        for event_ref in rollout_event_pr_refs(event):
+            if int(event_ref.get("number") or 0) != int(target_ref["number"]):
+                continue
+            if target_ref.get("repo") and event_ref.get("repo") != target_ref.get("repo"):
+                continue
+            condition.update(
+                {
+                    "satisfied": True,
+                    "matched_event_id": event.get("event_id"),
+                    "matched_event_kind": event.get("event_kind"),
+                    "matched_pr_ref": event_ref.get("normalized"),
+                    "matched_event_at": event.get("recorded_at"),
+                }
+            )
+            return condition
+    return condition
+
+
+def apply_resume_conditions(
+    items: list[dict[str, Any]],
+    *,
+    rollout_events: list[dict[str, Any]] | None = None,
+) -> None:
     by_id = {
         str(item.get("todo_id") or ""): item
         for item in items
@@ -4515,7 +4621,7 @@ def apply_resume_conditions(items: list[dict[str, Any]]) -> None:
         condition["kind"] = kind
         if separator:
             condition["target"] = target
-        if kind == "todo_done" and target:
+        if kind == TODO_RESUME_KIND_TODO_DONE and target:
             target_item = by_id.get(target)
             condition["target_todo_id"] = target
             condition["target_status"] = (
@@ -4524,6 +4630,8 @@ def apply_resume_conditions(items: list[dict[str, Any]]) -> None:
                 else None
             )
             condition["satisfied"] = condition["target_status"] == "done"
+        elif kind == TODO_RESUME_KIND_PR_MERGED and target:
+            condition.update(pr_merged_condition(target, rollout_events or []))
         else:
             condition["unsupported"] = True
         item["resume_condition"] = condition
@@ -4545,6 +4653,7 @@ def compact_todo_group(
     source_section: str | None,
     role: str | None = None,
     preferred_todo_ids: set[str] | None = None,
+    rollout_events: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any] | None:
     if not items:
         return None
@@ -4554,7 +4663,7 @@ def compact_todo_group(
         else item
         for item in items
     ]
-    apply_resume_conditions(items)
+    apply_resume_conditions(items, rollout_events=rollout_events)
     open_items = [item for item in items if not item.get("done")]
     terminal_items = [item for item in items if item.get("done")]
     deferred_items = [item for item in terminal_items if todo_item_is_deferred(item)]
@@ -4721,6 +4830,7 @@ def parse_active_state_todos(
     goal: dict[str, Any] | None = None,
     state_path: Path | None = None,
     preferred_todo_ids: set[str] | None = None,
+    rollout_events: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     role: str | None = None
     source_sections: dict[str, str | None] = {"user": None, "agent": None}
@@ -4770,12 +4880,14 @@ def parse_active_state_todos(
         source_section=source_sections["user"],
         role="user",
         preferred_todo_ids=preferred_todo_ids,
+        rollout_events=rollout_events,
     )
     agent = compact_todo_group(
         items["agent"],
         source_section=source_sections["agent"],
         role="agent",
         preferred_todo_ids=preferred_todo_ids,
+        rollout_events=rollout_events,
     )
     if user:
         result["user_todos"] = user
@@ -6338,7 +6450,11 @@ def build_project_asset(
     return asset
 
 
-def active_state_todo_fields(goal: dict[str, Any]) -> dict[str, Any]:
+def active_state_todo_fields(
+    goal: dict[str, Any],
+    *,
+    runtime_root: Path | None = None,
+) -> dict[str, Any]:
     state_path = resolve_goal_local_path(goal.get("state_file"), goal, fallback_base=Path.cwd())
     if state_path is None or not state_path.exists():
         return {}
@@ -6350,11 +6466,19 @@ def active_state_todo_fields(goal: dict[str, Any]) -> dict[str, Any]:
     preferred_todo_ids: set[str] = set()
     for entry in next_action_entries:
         preferred_todo_ids.update(active_next_action_todo_ids(entry))
+    rollout_events: list[dict[str, Any]] = []
+    goal_id = str(goal.get("id") or "").strip()
+    if runtime_root is not None and goal_id:
+        rollout_events = load_rollout_events(
+            rollout_event_log_path(runtime_root, goal_id),
+            limit=MAX_TODO_INDEX_ROLLOUT_EVENTS_PER_GOAL,
+        )
     fields = parse_active_state_todos(
         state_text,
         goal=goal,
         state_path=state_path,
         preferred_todo_ids=preferred_todo_ids,
+        rollout_events=rollout_events,
     )
     issue_meta_surface = parse_issue_meta_surface(state_text)
     if issue_meta_surface:
@@ -7452,6 +7576,7 @@ def build_attention_queue(
     contract: dict[str, Any],
     history: dict[str, Any],
     global_registry: dict[str, Any],
+    runtime_root: Path | None = None,
 ) -> dict[str, Any]:
     health_items: list[dict[str, Any]] = []
     history_items: list[dict[str, Any]] = []
@@ -7474,7 +7599,7 @@ def build_attention_queue(
         active_state_item: dict[str, Any] | None = None
         current_status_run = latest_run(goal)
         if goal.get("registry_member"):
-            active_state_fields = active_state_todo_fields(goal)
+            active_state_fields = active_state_todo_fields(goal, runtime_root=runtime_root)
             active_state_item = active_state_todo_attention_item(goal, active_state_fields, current_status_run)
         if active_state_item and active_state_item.get("waiting_on") in {"controller", "user_or_controller"}:
             item = active_state_item
@@ -7532,7 +7657,7 @@ def build_attention_queue(
                     item["project_asset"]["stale_latest_run_warning"] = projection_warning
             if goal.get("registry_member"):
                 if active_state_fields is None:
-                    active_state_fields = active_state_todo_fields(goal)
+                    active_state_fields = active_state_todo_fields(goal, runtime_root=runtime_root)
                 item.update(active_state_fields)
                 if isinstance(item.get("project_asset"), dict):
                     active_next_action = item.get("active_state_next_action")
@@ -8627,7 +8752,12 @@ def collect_status(
         scan_roots=scan_roots,
         limit=limit,
     )
-    queue = build_attention_queue(contract=contract, history=history, global_registry=global_registry)
+    queue = build_attention_queue(
+        contract=contract,
+        history=history,
+        global_registry=global_registry,
+        runtime_root=runtime_root,
+    )
     run_history = build_run_history(history, display_limit=display_limit)
     event_ledger_summary = build_event_ledger_summary(history)
     promotion_readiness_summary = build_promotion_readiness_summary(

--- a/loopx/todo_contract.py
+++ b/loopx/todo_contract.py
@@ -13,7 +13,12 @@ TODO_ACTION_KIND_PATTERN = re.compile(r"^[a-z][a-z0-9_-]{0,63}$")
 TODO_ID_PATTERN = re.compile(r"^todo_[a-z0-9_-]{3,64}$")
 TODO_AGENT_CLAIM_PATTERN = re.compile(r"^[a-z][a-z0-9_.:@-]{0,79}$")
 TODO_CAPABILITY_PATTERN = re.compile(r"^[a-z][a-z0-9_:-]{0,63}$")
+TODO_RESUME_KIND_TODO_DONE = "todo_done"
+TODO_RESUME_KIND_PR_MERGED = "pr_merged"
 TODO_RESUME_WHEN_PATTERN = re.compile(r"^[a-z][a-z0-9_-]{0,31}(?::[a-z0-9_.:@-]{1,96})?$")
+TODO_RESUME_PR_MERGED_PATTERN = re.compile(
+    r"^pr_merged:(?:(?:[a-z0-9_.-]{1,80})/(?:[a-z0-9_.-]{1,100}))?#[1-9][0-9]{0,8}$"
+)
 TODO_WRITE_SCOPE_MAX_CHARS = 160
 
 TODO_TASK_CLASS_ADVANCEMENT = "advancement_task"
@@ -159,6 +164,8 @@ def normalize_todo_blocks_agent(value: Any) -> str | None:
 
 def normalize_todo_resume_when(value: Any) -> str | None:
     candidate = compact_todo_text(value).lower()
+    if candidate and TODO_RESUME_PR_MERGED_PATTERN.match(candidate):
+        return candidate
     if candidate and TODO_RESUME_WHEN_PATTERN.match(candidate):
         return candidate
     return None
@@ -431,7 +438,7 @@ def format_todo_metadata_line(
         fields.append(f"unblocks_todo_id={encode_metadata_value(normalized_unblocks_todo_id)}")
     normalized_resume_when = normalize_todo_resume_when(resume_when)
     if resume_when and not normalized_resume_when:
-        raise ValueError("resume_when must be a public-safe token such as todo_done:todo_ab12cd34ef56")
+        raise ValueError("resume_when must be public-safe, e.g. todo_done:todo_ab12cd34ef56 or pr_merged:#532")
     if normalized_resume_when:
         fields.append(f"resume_when={encode_metadata_value(normalized_resume_when)}")
     for key, value in (

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -619,7 +619,7 @@ def add_goal_todo(
             raise ValueError("unblocks_todo_id must use the public token shape todo_<letters-digits-underscore-hyphen>")
         normalized_resume_when = normalize_todo_resume_when(resume_when) if resume_when else None
         if resume_when and not normalized_resume_when:
-            raise ValueError("resume_when must be a public-safe token such as todo_done:todo_ab12cd34ef56")
+            raise ValueError("resume_when must be public-safe, e.g. todo_done:todo_ab12cd34ef56 or pr_merged:#532")
         add_result = add_todo_to_lines(
             lines,
             role=role,
@@ -861,7 +861,7 @@ def update_goal_todo(
             raise ValueError("unblocks_todo_id must use the public token shape todo_<letters-digits-underscore-hyphen>")
         normalized_resume_when = normalize_todo_resume_when(resume_when) if resume_when else None
         if resume_when and not normalized_resume_when:
-            raise ValueError("resume_when must be a public-safe token such as todo_done:todo_ab12cd34ef56")
+            raise ValueError("resume_when must be public-safe, e.g. todo_done:todo_ab12cd34ef56 or pr_merged:#532")
         update_result = apply_todo_update_to_lines(
             lines,
             todo_id=todo_id,


### PR DESCRIPTION
## Summary
- add public-safe `resume_when=pr_merged:#123` and `resume_when=pr_merged:owner/repo#123` normalization
- evaluate PR-merge resume conditions from structured rollout events (`pr_merge` / `code_refs.pr_ref` / pull request source refs) instead of prose parsing or live GitHub polling
- project ready deferred PR-dependent todos through status/quota using the existing `resume_condition` / `resume_ready` / `deferred_resume_candidates` lane

## Validation
- `python3 examples/todo-contract-smoke.py`
- `python3 examples/todo-durability-fixture-smoke.py`
- `python3 examples/work-lane-contract-smoke.py`
- `python3 -m compileall -q loopx/status.py loopx/todo_contract.py loopx/todos.py`
- `git diff --check`

## Review note
Runtime/projection behavior change, so this is opened for primary review instead of self-merged.
