### PR TITLE
Preserve dynamic reverse bridge commands

### DIFF
--- a/examples/skillsbench-reverse-channel-bridge-smoke.py
+++ b/examples/skillsbench-reverse-channel-bridge-smoke.py
@@ -134,8 +134,138 @@ print('codex stderr ok', file=sys.stderr)
             assert "codex stderr ok" in proc.stderr
             assert remote_last.read_text(encoding="utf-8") == "LOOPX_REVERSE_READY\n"
             rewritten = prompt_dump.read_text(encoding="utf-8")
-            assert str(local_bridge) in rewritten
+            assert "loopx-local-prompt-bridge" in rewritten
+            assert str(local_bridge) not in rewritten
             assert "/remote/tmp/bridge" not in rewritten
+        finally:
+            server.wait(timeout=5)
+
+
+def test_codex_bridge_template_preserves_dynamic_private_command() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-reverse-bridge-template-") as tmp:
+        root = Path(tmp)
+        fake_codex = root / "fake-codex"
+        fake_bridge = root / "fake-json-bridge"
+        bridge_args = root / "bridge-args.json"
+        fake_bridge.write_text(
+            f"""#!/usr/bin/env python3
+import json, sys
+Path = __import__('pathlib').Path
+Path({str(bridge_args)!r}).write_text(json.dumps(sys.argv[1:]), encoding='utf-8')
+payload = json.loads(sys.stdin.read() or '{{}}')
+print(json.dumps({{
+    'ok': True,
+    'operation': payload.get('operation'),
+    'raw_task_text_recorded': False,
+    'credential_values_recorded': False,
+}}))
+""",
+            encoding="utf-8",
+        )
+        fake_bridge.chmod(0o700)
+        fake_codex.write_text(
+            """#!/usr/bin/env python3
+import json, os, subprocess, sys
+from pathlib import Path
+
+args = sys.argv[1:]
+prompt = next(
+    (item for item in args if 'Private bridge command:\\n' in item),
+    '\\n'.join(args),
+)
+bridge = prompt.split('Private bridge command:\\n', 1)[1].split('\\n', 1)[0]
+env = os.environ.copy()
+env['AI_ADDR'] = '127.0.0.1'
+env['AI_PORT'] = '2022'
+proc = subprocess.run(
+    [bridge],
+    input=json.dumps({'operation': 'exec', 'cwd': '/app', 'command': 'pwd'}),
+    text=True,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+    env=env,
+    check=False,
+)
+sys.stdout.write(proc.stdout)
+sys.stderr.write(proc.stderr)
+out = Path(args[args.index('--output-last-message') + 1])
+out.write_text('LOOPX_REVERSE_TEMPLATE_READY\\n', encoding='utf-8')
+raise SystemExit(proc.returncode)
+""",
+            encoding="utf-8",
+        )
+        fake_codex.chmod(0o700)
+        socket_path = root / "codex.sock"
+        server = subprocess.Popen(
+            [
+                sys.executable,
+                str(BRIDGE),
+                "serve-codex",
+                "--socket",
+                str(socket_path),
+                "--codex-bin",
+                str(fake_codex),
+                "--prompt-bridge-command",
+                f"{fake_bridge} {{private_bridge_command_sh}} {{loopx_allowed_env}}",
+                "--once",
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        try:
+            wait_for_socket(socket_path, server)
+            client = root / "codex-client"
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(BRIDGE),
+                    "write-client",
+                    "--kind",
+                    "codex",
+                    "--socket",
+                    str(socket_path),
+                    "--output",
+                    str(client),
+                ],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            remote_last = root / "remote-last-message.txt"
+            dynamic_bridge = "/remote/tmp/dynamic bridge --compose-file /tmp/c.yml"
+            prompt = f"Private bridge command:\n{dynamic_bridge}\n\nTask"
+            proc = subprocess.run(
+                [
+                    str(client),
+                    "exec",
+                    "--ephemeral",
+                    "--skip-git-repo-check",
+                    "--sandbox",
+                    "read-only",
+                    "-C",
+                    "/remote/tmp/workspace",
+                    "--output-last-message",
+                    str(remote_last),
+                    "--json",
+                    prompt,
+                ],
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            assert proc.returncode == 0, proc.stderr
+            response = json.loads(proc.stdout)
+            assert response["ok"] is True
+            argv = json.loads(bridge_args.read_text(encoding="utf-8"))
+            assert dynamic_bridge in argv
+            assert any(item.startswith("AI_ADDR=") for item in argv), argv
+            assert any(item.startswith("AI_PORT=") for item in argv), argv
+            assert remote_last.read_text(encoding="utf-8") == (
+                "LOOPX_REVERSE_TEMPLATE_READY\n"
+            )
         finally:
             server.wait(timeout=5)
 
@@ -335,6 +465,7 @@ def test_socket_probe_reports_missing_or_orphaned() -> None:
 
 def main() -> int:
     test_codex_client_writes_last_message_and_rewrites_bridge()
+    test_codex_bridge_template_preserves_dynamic_private_command()
     test_json_client_forwards_stdin_to_bridge_command()
     test_json_client_expands_allowed_env_template_for_nested_bridge()
     test_socket_probe_reports_missing_or_orphaned()

--- a/scripts/skillsbench_reverse_channel_bridge.py
+++ b/scripts/skillsbench_reverse_channel_bridge.py
@@ -93,6 +93,14 @@ def _replace_remote_cwd(args: list[str], replacement: Path) -> str | None:
     return None
 
 
+def _extract_private_bridge_command(prompt: str) -> str | None:
+    match = re.search(r"Private bridge command:\n([^\n]+)", prompt)
+    if not match:
+        return None
+    text = match.group(1).strip()
+    return text or None
+
+
 def _rewrite_private_bridge_command(prompt: str, replacement: str | None) -> str:
     if not replacement:
         return prompt
@@ -104,6 +112,7 @@ def _write_instrumented_prompt_bridge(
     *,
     tmp_path: Path,
     bridge_command: str,
+    private_bridge_command: str | None,
 ) -> tuple[Path, Path]:
     """Wrap a local prompt bridge and emit public-safe agent operation records."""
 
@@ -113,6 +122,7 @@ def _write_instrumented_prompt_bridge(
 from __future__ import annotations
 
 import json
+import os
 import re
 import shlex
 import subprocess
@@ -120,7 +130,32 @@ import sys
 from pathlib import Path
 
 SUMMARY_PATH = Path({str(summary_path)!r})
-BRIDGE_COMMAND = {bridge_command!r}
+BRIDGE_COMMAND_TEMPLATE = {bridge_command!r}
+PRIVATE_BRIDGE_COMMAND = {private_bridge_command!r}
+
+def allowed_env_assignments() -> str:
+    keys = (
+        "AI_ADDR",
+        "AI_PORT",
+        "GOAL_HARNESS_REMOTE_BENCH_ROOT",
+        "LOOPX_REMOTE_AGENT_OPS_SUMMARY_PATH",
+    )
+    return " ".join(
+        f"{{key}}={{shlex.quote(os.environ.get(key, ''))}}"
+        for key in keys
+        if os.environ.get(key)
+    )
+
+def bridge_command() -> str:
+    command = BRIDGE_COMMAND_TEMPLATE
+    private_bridge = PRIVATE_BRIDGE_COMMAND or ""
+    command = command.replace("{{private_bridge_command}}", private_bridge)
+    command = command.replace(
+        "{{private_bridge_command_sh}}",
+        shlex.quote(private_bridge),
+    )
+    command = command.replace("{{loopx_allowed_env}}", allowed_env_assignments())
+    return command
 
 def loopx_subcommands(command: str) -> list[str]:
     try:
@@ -186,7 +221,7 @@ record["task_facing_operation"] = bool(
     or (operation == "exec" and not subcommands)
 )
 proc = subprocess.run(
-    BRIDGE_COMMAND,
+    bridge_command(),
     input=raw,
     text=True,
     stdout=subprocess.PIPE,
@@ -235,10 +270,12 @@ def _run_codex_payload(
         _replace_remote_cwd(args, local_cwd)
         agent_operations_summary_path: Path | None = None
         if prompt_bridge_command and args:
+            private_bridge_command = _extract_private_bridge_command(args[-1])
             instrumented_bridge, agent_operations_summary_path = (
                 _write_instrumented_prompt_bridge(
                     tmp_path=tmp_path,
                     bridge_command=prompt_bridge_command,
+                    private_bridge_command=private_bridge_command,
                 )
             )
             args[-1] = _rewrite_private_bridge_command(


### PR DESCRIPTION
## Summary
- preserve the original dynamic private bridge command when reverse-channel Codex rewrites the prompt bridge
- add template expansion for `{private_bridge_command}`, `{private_bridge_command_sh}`, and `{loopx_allowed_env}` inside the instrumented prompt bridge wrapper
- update the reverse-channel smoke so the prompt exposes only the instrumented wrapper while the downstream bridge still receives the dynamic sandbox command and allowed env

## Why
After PR #640, the next SkillsBench validation needs a remote/reverse-channel product-mode run. The remote runner can auto-generate the sandbox docker bridge only after BenchFlow materializes the case. The local Codex prompt rewrite previously replaced that dynamic command with a fixed wrapper, so the wrapper had no generic way to get back to the current sandbox.

## Validation
- python3 -m py_compile scripts/skillsbench_reverse_channel_bridge.py examples/skillsbench-reverse-channel-bridge-smoke.py
- python3 examples/skillsbench-reverse-channel-bridge-smoke.py
- git diff --check
- candidate-path boundary scan: only `raw_task_text_recorded: False` guards and ordinary variable names matched; no credentials, private paths, raw logs, or raw trajectories included

## Boundary
No benchmark job launched in this PR. No raw task text, trajectory, verifier output, socket paths, credentials, or local private state are committed.
