### PR TITLE
Attribute Terminal-Bench compose startup blockers

### DIFF
--- a/examples/benchmark-ecs-developer-tooling-smoke.py
+++ b/examples/benchmark-ecs-developer-tooling-smoke.py
@@ -170,6 +170,142 @@ def main() -> int:
         assert reduced["boundary"]["raw_logs_read"] is False
         assert reduced["boundary"]["private_paths_recorded"] is False
 
+        compose_setup_path = tmp_path / "compose_setup.public.json"
+        compose_setup_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": "terminal_bench_compose_setup_diagnostic_v0",
+                    "status": "blocked",
+                    "failure_class": "environment_setup_failure",
+                    "runner_error_len_bucket": "compact",
+                    "next_diagnostic_action": "repair_terminal_bench_compose_setup",
+                    "compose_setup_failure": True,
+                    "apt_setup_risk_detected": True,
+                    "apt_retry_patch_required": True,
+                    "raw_error_recorded": False,
+                    "raw_logs_read": False,
+                    "raw_task_text_read": False,
+                    "raw_trajectory_read": False,
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        no_rebuild_guard_path = tmp_path / "no_rebuild_guard.public.json"
+        no_rebuild_guard_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": "terminal_bench_no_rebuild_guard_v0",
+                    "ok": False,
+                    "first_blocker": "terminal_bench_no_rebuild_guard_not_applied",
+                    "private_root_recorded": False,
+                    "apply": False,
+                    "manager_file_count": 1,
+                    "patched_file_count": 0,
+                    "files": [
+                        {
+                            "relative_path": "terminal_bench/terminal/docker_compose_manager.py",
+                            "status": "needs_guard_patch",
+                            "patchable": True,
+                            "patched": False,
+                        }
+                    ],
+                    "contract": {
+                        "no_rebuild_implies_compose_no_build": True,
+                        "score_or_task_behavior_changed": False,
+                        "runner_surface_changed": "docker_compose_startup_only",
+                    },
+                    "boundary": {
+                        "raw_logs_read": False,
+                        "raw_task_text_read": False,
+                        "trajectory_read": False,
+                        "private_paths_recorded": False,
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        task_image_bootstrap_path = tmp_path / "task_image_bootstrap.public.json"
+        task_image_bootstrap_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": "terminal_bench_task_image_bootstrap_v0",
+                    "ok": True,
+                    "first_blocker": "",
+                    "execute": False,
+                    "private_work_dir_recorded": False,
+                    "apt_packages": ["tmux", "asciinema"],
+                    "required_commands": ["tmux", "asciinema"],
+                    "apt_mirror_host": "mirrors.tuna.tsinghua.edu.cn",
+                    "security_mirror_host": "mirrors.tuna.tsinghua.edu.cn",
+                    "use_host_network": True,
+                    "timeout_sec": 600,
+                    "build_returncode": None,
+                    "command_checks": {},
+                    "contract": {
+                        "score_or_task_behavior_changed": False,
+                        "runner_surface_changed": "task_image_startup_prerequisites_only",
+                        "case_runtime_agent_install_forbidden": True,
+                    },
+                    "boundary": {
+                        "raw_logs_read": False,
+                        "raw_task_text_read": False,
+                        "trajectory_read": False,
+                        "private_paths_recorded": False,
+                        "credential_values_read": False,
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        attributed = run_json(
+            [
+                "scripts/terminal_bench_compose_startup_reducer.py",
+                "--post-launch-json",
+                str(post_launch_path),
+                "--compose-setup-json",
+                str(compose_setup_path),
+                "--no-rebuild-guard-json",
+                str(no_rebuild_guard_path),
+                "--task-image-bootstrap-json",
+                str(task_image_bootstrap_path),
+            ]
+        )
+        decision = attributed["cause_fix_decision"]
+        assert (
+            decision["schema_version"]
+            == "terminal_bench_compose_cause_fix_decision_v0"
+        )
+        assert decision["classification"] == "no_rebuild_guard_blocker"
+        assert decision["next_action"] == "apply_terminal_bench_no_rebuild_guard"
+        assert attributed["next_action"] == "apply_terminal_bench_no_rebuild_guard"
+        assert "compose_setup_diagnostic_present" in decision["reason_codes"]
+        assert (
+            "terminal_bench_no_rebuild_guard_not_applied"
+            in decision["reason_codes"]
+        )
+        assert (
+            "fast_mirror_bootstrap_fallback_available"
+            in decision["reason_codes"]
+        )
+        assert (
+            attributed["compose_setup_diagnostic"]["boundary"]["raw_logs_read"]
+            is False
+        )
+        assert (
+            attributed["no_rebuild_guard"]["file_statuses"][0]["patchable"]
+            is True
+        )
+        assert (
+            attributed["task_image_bootstrap"]["contract"][
+                "case_runtime_agent_install_forbidden"
+            ]
+            is True
+        )
+        assert attributed["boundary"]["raw_task_text_read"] is False
+
         skillsbench_prewarm = run_json(
             [
                 "scripts/skillsbench_verifier_prewarm_plan.py",

--- a/scripts/terminal_bench_compose_startup_reducer.py
+++ b/scripts/terminal_bench_compose_startup_reducer.py
@@ -73,6 +73,141 @@ POST_LAUNCH_PUBLIC_FIELDS = (
     "stale_active_reconcile_requested",
 )
 
+COMPOSE_SETUP_PUBLIC_FIELDS = (
+    "schema_version",
+    "status",
+    "route",
+    "failure_class",
+    "runner_prerequisite_status",
+    "task_setup_preflight_status",
+    "runner_error_len_bucket",
+    "next_diagnostic_action",
+    "compose_setup_failure",
+    "unclassified_compose_failure",
+    "docker_daemon_unavailable",
+    "volume_mount_failure",
+    "environment_setup_failure",
+    "agent_rounds_started",
+    "official_score_missing",
+    "official_result_json_materialized",
+    "case_attempt_budget_should_count",
+    "runner_launch_preflight_passed",
+    "apt_setup_risk_detected",
+    "apt_retry_patch_required",
+    "staged_task_prepared",
+    "task_skills_removed",
+    "codex_acp_runtime_tools_patch_applied",
+    "resource_cap_applied",
+    "raw_error_recorded",
+    "raw_logs_read",
+    "raw_task_text_read",
+    "raw_trajectory_read",
+)
+
+NO_REBUILD_GUARD_PUBLIC_FIELDS = (
+    "schema_version",
+    "ok",
+    "first_blocker",
+    "private_root_recorded",
+    "apply",
+    "manager_file_count",
+    "patched_file_count",
+)
+
+TASK_IMAGE_BOOTSTRAP_PUBLIC_FIELDS = (
+    "schema_version",
+    "ok",
+    "first_blocker",
+    "execute",
+    "private_work_dir_recorded",
+    "apt_packages",
+    "required_commands",
+    "apt_mirror_host",
+    "security_mirror_host",
+    "use_host_network",
+    "timeout_sec",
+    "build_returncode",
+    "command_checks",
+)
+
+
+def _load_optional_json(path: str | None) -> dict[str, Any]:
+    if not path:
+        return {}
+    return load_json_object(Path(path))
+
+
+def _compact_fields(value: dict[str, Any], fields: tuple[str, ...]) -> dict[str, Any]:
+    return {field: value[field] for field in fields if field in value}
+
+
+def _compact_boundary(value: dict[str, Any]) -> dict[str, bool]:
+    boundary = value.get("boundary")
+    if not isinstance(boundary, dict):
+        boundary = value
+    return {
+        "raw_logs_read": boundary.get("raw_logs_read") is True,
+        "raw_task_text_read": boundary.get("raw_task_text_read") is True,
+        "trajectory_read": boundary.get("trajectory_read") is True,
+        "raw_trajectory_read": boundary.get("raw_trajectory_read") is True,
+        "credential_values_read": boundary.get("credential_values_read") is True,
+        "private_paths_recorded": boundary.get("private_paths_recorded") is True,
+    }
+
+
+def _compact_compose_setup(value: dict[str, Any]) -> dict[str, Any]:
+    compact = _compact_fields(value, COMPOSE_SETUP_PUBLIC_FIELDS)
+    if compact:
+        compact["boundary"] = _compact_boundary(value)
+    return compact
+
+
+def _compact_no_rebuild_guard(value: dict[str, Any]) -> dict[str, Any]:
+    compact = _compact_fields(value, NO_REBUILD_GUARD_PUBLIC_FIELDS)
+    contract = value.get("contract")
+    if isinstance(contract, dict):
+        compact["contract"] = {
+            "no_rebuild_implies_compose_no_build": (
+                contract.get("no_rebuild_implies_compose_no_build") is True
+            ),
+            "score_or_task_behavior_changed": (
+                contract.get("score_or_task_behavior_changed") is True
+            ),
+            "runner_surface_changed": contract.get("runner_surface_changed", ""),
+        }
+    files = value.get("files")
+    if isinstance(files, list):
+        compact["file_statuses"] = [
+            {
+                "status": file.get("status", ""),
+                "patchable": file.get("patchable") is True,
+                "patched": file.get("patched") is True,
+            }
+            for file in files
+            if isinstance(file, dict)
+        ][:8]
+    if compact:
+        compact["boundary"] = _compact_boundary(value)
+    return compact
+
+
+def _compact_task_image_bootstrap(value: dict[str, Any]) -> dict[str, Any]:
+    compact = _compact_fields(value, TASK_IMAGE_BOOTSTRAP_PUBLIC_FIELDS)
+    contract = value.get("contract")
+    if isinstance(contract, dict):
+        compact["contract"] = {
+            "score_or_task_behavior_changed": (
+                contract.get("score_or_task_behavior_changed") is True
+            ),
+            "runner_surface_changed": contract.get("runner_surface_changed", ""),
+            "case_runtime_agent_install_forbidden": (
+                contract.get("case_runtime_agent_install_forbidden") is True
+            ),
+        }
+    if compact:
+        compact["boundary"] = _compact_boundary(value)
+    return compact
+
 
 def _compact_post_launch(post_launch: dict[str, Any]) -> dict[str, Any]:
     compact = {
@@ -110,6 +245,103 @@ def _compact_post_launch(post_launch: dict[str, Any]) -> dict[str, Any]:
     return compact
 
 
+def _reason_codes(
+    *,
+    compact_post_launch: dict[str, Any],
+    compose_setup: dict[str, Any],
+    no_rebuild_guard: dict[str, Any],
+    task_image_bootstrap: dict[str, Any],
+    compose_startup_blocker: bool,
+) -> list[str]:
+    reasons: list[str] = []
+    if compact_post_launch:
+        reasons.append("post_launch_materialization_present")
+    if compose_setup:
+        reasons.append("compose_setup_diagnostic_present")
+    if compose_setup.get("apt_retry_patch_required") is True:
+        reasons.append("apt_retry_patch_required")
+    if compose_setup.get("apt_setup_risk_detected") is True:
+        reasons.append("apt_setup_risk_detected")
+    if no_rebuild_guard:
+        reasons.append("no_rebuild_guard_diagnostic_present")
+    if no_rebuild_guard.get("first_blocker"):
+        reasons.append(str(no_rebuild_guard["first_blocker"]))
+    elif no_rebuild_guard.get("ok") is True:
+        reasons.append("no_rebuild_guard_ready")
+    if task_image_bootstrap:
+        reasons.append("fast_mirror_bootstrap_diagnostic_present")
+    if task_image_bootstrap.get("first_blocker"):
+        reasons.append(str(task_image_bootstrap["first_blocker"]))
+    elif task_image_bootstrap.get("ok") is True:
+        reasons.append("fast_mirror_bootstrap_fallback_available")
+    if compose_startup_blocker:
+        reasons.append("post_launch_compose_startup_blocker")
+    return reasons
+
+
+def _build_cause_fix_decision(
+    *,
+    compact_post_launch: dict[str, Any],
+    compose_setup: dict[str, Any],
+    no_rebuild_guard: dict[str, Any],
+    task_image_bootstrap: dict[str, Any],
+    compose_startup_blocker: bool,
+    base_next_action: str,
+) -> dict[str, Any]:
+    reason_codes = _reason_codes(
+        compact_post_launch=compact_post_launch,
+        compose_setup=compose_setup,
+        no_rebuild_guard=no_rebuild_guard,
+        task_image_bootstrap=task_image_bootstrap,
+        compose_startup_blocker=compose_startup_blocker,
+    )
+    classification = "continue_compact_observation"
+    next_action = base_next_action
+
+    if compact_post_launch.get("ready_for_compact_result_ingest") is True:
+        classification = "compact_result_ready"
+        next_action = "ingest_compact_terminal_bench_result"
+    elif no_rebuild_guard.get("first_blocker"):
+        classification = "no_rebuild_guard_blocker"
+        next_action = "apply_terminal_bench_no_rebuild_guard"
+    elif task_image_bootstrap.get("first_blocker"):
+        classification = "fast_mirror_bootstrap_blocker"
+        next_action = "repair_terminal_bench_fast_mirror_bootstrap"
+    elif (
+        compose_setup.get("apt_retry_patch_required") is True
+        or compose_setup.get("apt_setup_risk_detected") is True
+    ):
+        classification = "fast_mirror_bootstrap_recommended"
+        next_action = "run_terminal_bench_fast_mirror_task_image_bootstrap"
+    elif compose_setup.get("compose_setup_failure") is True:
+        classification = str(
+            compose_setup.get("failure_class") or "compose_setup_failure"
+        )
+        next_action = str(
+            compose_setup.get("next_diagnostic_action")
+            or "repair_terminal_bench_compose_setup"
+        )
+    elif compose_startup_blocker:
+        classification = "post_launch_compose_startup_blocker"
+        next_action = "repair_terminal_bench_compose_startup"
+    elif compact_post_launch.get("resume_recommended") is True:
+        classification = "resume_or_poll_materialized_job"
+        next_action = "resume_or_poll_materialized_job"
+
+    return {
+        "schema_version": "terminal_bench_compose_cause_fix_decision_v0",
+        "classification": classification,
+        "next_action": next_action,
+        "reason_codes": reason_codes,
+        "checked_surfaces": {
+            "post_launch_materialization": bool(compact_post_launch),
+            "compose_setup_diagnostic": bool(compose_setup),
+            "no_rebuild_guard": bool(no_rebuild_guard),
+            "fast_mirror_task_image_bootstrap": bool(task_image_bootstrap),
+        },
+    }
+
+
 def _load_post_launch(args: argparse.Namespace) -> dict[str, Any]:
     if args.post_launch_json:
         return load_json_object(Path(args.post_launch_json))
@@ -126,6 +358,13 @@ def _load_post_launch(args: argparse.Namespace) -> dict[str, Any]:
 def build_reduction(args: argparse.Namespace) -> dict[str, Any]:
     post_launch = _load_post_launch(args)
     compact_post_launch = _compact_post_launch(post_launch)
+    compose_setup = _compact_compose_setup(_load_optional_json(args.compose_setup_json))
+    no_rebuild_guard = _compact_no_rebuild_guard(
+        _load_optional_json(args.no_rebuild_guard_json)
+    )
+    task_image_bootstrap = _compact_task_image_bootstrap(
+        _load_optional_json(args.task_image_bootstrap_json)
+    )
     failure_class = str(
         compact_post_launch.get("compact_failure_class")
         or compact_post_launch.get("first_blocker")
@@ -141,16 +380,42 @@ def build_reduction(args: argparse.Namespace) -> dict[str, Any]:
         next_action = "repair_terminal_bench_compose_startup"
     else:
         next_action = "continue_compact_observation"
+    cause_fix_decision = _build_cause_fix_decision(
+        compact_post_launch=compact_post_launch,
+        compose_setup=compose_setup,
+        no_rebuild_guard=no_rebuild_guard,
+        task_image_bootstrap=task_image_bootstrap,
+        compose_startup_blocker=compose_startup_blocker,
+        base_next_action=next_action,
+    )
+    evidence_surfaces = [
+        name
+        for name, present in {
+            "post_launch_json": bool(args.post_launch_json),
+            "jobs_dir_summary": bool(args.jobs_dir),
+            "compose_setup_json": bool(args.compose_setup_json),
+            "no_rebuild_guard_json": bool(args.no_rebuild_guard_json),
+            "task_image_bootstrap_json": bool(args.task_image_bootstrap_json),
+        }.items()
+        if present
+    ]
 
     return {
         "schema_version": "terminal_bench_compose_startup_reducer_v0",
-        "ok": bool(post_launch),
-        "input_surface": (
-            "post_launch_json" if args.post_launch_json else "jobs_dir_summary"
+        "ok": bool(
+            post_launch or compose_setup or no_rebuild_guard or task_image_bootstrap
         ),
+        "input_surface": (
+            "post_launch_json"
+            if args.post_launch_json
+            else "jobs_dir_summary"
+            if args.jobs_dir
+            else "compact_diagnostics"
+        ),
+        "evidence_surfaces": evidence_surfaces,
         "compose_startup_blocker": compose_startup_blocker,
         "blocker_class": failure_class,
-        "next_action": next_action,
+        "next_action": cause_fix_decision["next_action"],
         "ready_for_compact_result_ingest": (
             compact_post_launch.get("ready_for_compact_result_ingest") is True
         ),
@@ -158,6 +423,10 @@ def build_reduction(args: argparse.Namespace) -> dict[str, Any]:
             compact_post_launch.get("ready_for_compact_failure_marker") is True
         ),
         "post_launch_materialization": compact_post_launch,
+        "compose_setup_diagnostic": compose_setup,
+        "no_rebuild_guard": no_rebuild_guard,
+        "task_image_bootstrap": task_image_bootstrap,
+        "cause_fix_decision": cause_fix_decision,
         "result_finalization_gate": finalization_gate,
         "boundary": {
             "raw_logs_read": False,
@@ -178,6 +447,9 @@ def main() -> int:
         )
     )
     parser.add_argument("--post-launch-json")
+    parser.add_argument("--compose-setup-json")
+    parser.add_argument("--no-rebuild-guard-json")
+    parser.add_argument("--task-image-bootstrap-json")
     parser.add_argument("--jobs-dir")
     parser.add_argument("--job-name")
     parser.add_argument(
@@ -190,8 +462,20 @@ def main() -> int:
     parser.add_argument("--pretty", action="store_true")
     args = parser.parse_args()
 
-    if not args.post_launch_json and not args.jobs_dir:
-        parser.error("provide --post-launch-json or --jobs-dir")
+    if not any(
+        (
+            args.post_launch_json,
+            args.jobs_dir,
+            args.compose_setup_json,
+            args.no_rebuild_guard_json,
+            args.task_image_bootstrap_json,
+        )
+    ):
+        parser.error(
+            "provide at least one of --post-launch-json, --jobs-dir, "
+            "--compose-setup-json, --no-rebuild-guard-json, or "
+            "--task-image-bootstrap-json"
+        )
 
     payload = build_reduction(args)
     rendered = json.dumps(payload, indent=2 if args.pretty else None, sort_keys=True)


### PR DESCRIPTION
## Summary
- extend the Terminal-Bench compose startup reducer to merge compact post-launch, compose setup, no-rebuild guard, and fast-mirror task-image bootstrap diagnostics
- emit a public-safe cause/fix decision with checked surfaces and reason codes
- cover the combined attribution path in the ECS benchmark developer tooling smoke

## Validation
- python3 examples/benchmark-ecs-developer-tooling-smoke.py
- python3 -m py_compile scripts/terminal_bench_compose_startup_reducer.py examples/benchmark-ecs-developer-tooling-smoke.py
- git diff --check
- python3 -m loopx.cli check --scan-path scripts/terminal_bench_compose_startup_reducer.py --scan-path examples/benchmark-ecs-developer-tooling-smoke.py

## Boundary
- Only compact public-safe JSON fields are consumed.
- No raw task text, raw logs, trajectories, verifier output, credentials, private paths, or local run artifacts are committed.