### PR TITLE
Isolate release wrapper imports from caller cwd

### DIFF
--- a/examples/release-wrapper-import-isolation-smoke.py
+++ b/examples/release-wrapper-import-isolation-smoke.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Smoke-test that the release wrapper is not shadowed by the caller cwd."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="loopx-release-wrapper-") as tmp:
+        root = Path(tmp)
+        release = root / "releases" / "20260624T000000Z"
+        stale = root / "stale-checkout"
+        wrapper = release / "scripts" / "loopx"
+        wrapper.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(REPO_ROOT / "scripts" / "loopx", wrapper)
+        wrapper.chmod(0o755)
+
+        _write(release / "loopx" / "__init__.py", "")
+        _write(
+            release / "loopx" / "cli.py",
+            "\n".join(
+                [
+                    "from __future__ import annotations",
+                    "import json",
+                    "import os",
+                    "from pathlib import Path",
+                    "",
+                    "payload = {",
+                    "    'source': 'release',",
+                    "    'cwd_basename': Path.cwd().name,",
+                    "    'argv0_basename': Path(__import__('sys').argv[0]).name,",
+                    "    'argv_tail': __import__('sys').argv[1:],",
+                    "    'module_file_inside_release': str(Path(__file__).resolve()).startswith(os.environ['LOOPX_RELEASE_ROOT']),",
+                    "}",
+                    "print(json.dumps(payload, sort_keys=True))",
+                ]
+            )
+            + "\n",
+        )
+        _write(stale / "loopx" / "__init__.py", "")
+        _write(
+            stale / "loopx" / "cli.py",
+            "raise SystemExit('stale checkout shadowed release wrapper')\n",
+        )
+
+        env = dict(os.environ)
+        env["PYTHONPATH"] = str(stale)
+        completed = subprocess.run(
+            [str(wrapper), "--sentinel"],
+            cwd=stale,
+            env=env,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        payload = json.loads(completed.stdout)
+        assert payload["source"] == "release", payload
+        assert payload["cwd_basename"] == stale.name, payload
+        assert payload["argv0_basename"] == "loopx", payload
+        assert payload["argv_tail"] == ["--sentinel"], payload
+        assert payload["module_file_inside_release"] is True, payload
+
+    print("release-wrapper-import-isolation-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/loopx
+++ b/scripts/loopx
@@ -17,5 +17,24 @@ if [[ -z "$python_bin" ]]; then
   python_bin="python3"
 fi
 
+export LOOPX_RELEASE_ROOT="$repo_root"
 export PYTHONPATH="$repo_root${PYTHONPATH:+:$PYTHONPATH}"
-exec "$python_bin" -m loopx.cli "$@"
+exec "$python_bin" -c '
+import os
+import runpy
+import sys
+
+release_root = os.environ["LOOPX_RELEASE_ROOT"]
+cwd = os.getcwd()
+filtered_path = []
+for entry in sys.path:
+    if entry in ("", "."):
+        continue
+    absolute = os.path.abspath(entry)
+    if absolute in {cwd, release_root}:
+        continue
+    filtered_path.append(entry)
+sys.path[:] = [release_root, *filtered_path]
+sys.argv[0] = os.path.join(release_root, "scripts", "loopx")
+runpy.run_module("loopx.cli", run_name="__main__")
+' "$@"


### PR DESCRIPTION
## Summary
- make `scripts/loopx` import `loopx.cli` from the release root while preserving the caller working directory
- filter caller cwd entries from `sys.path` before executing the CLI module
- add a smoke that creates a stale checkout with a shadowing `loopx/cli.py` and proves the release wrapper still loads the release copy

## Validation
- `python3 examples/release-wrapper-import-isolation-smoke.py`
- `python3 -m py_compile examples/release-wrapper-import-isolation-smoke.py && git diff --check`
- `python3 -m loopx.cli check --scan-path scripts/loopx --scan-path examples/release-wrapper-import-isolation-smoke.py`
- `/private/tmp/loopx-split-skillsbench-20260623/scripts/loopx doctor` from `/tmp`
- focused private/evidence scan over changed files found no credentials, private state, raw logs, trajectories, verifier output, or local run roots

## Boundary
No benchmark raw evidence, verifier tails, credentials, local `.local` state, or generated run logs are included.