### PR TITLE
docs: add FrontierSWE ECS no-execution launch packet

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/README.md
+++ b/docs/research/long-horizon-agent-benchmarks/README.md
@@ -132,6 +132,12 @@ work still belongs in the existing code, examples, and contract documents:
   official repo, public Codex leaderboard surface, 20-hour task framing,
   current runner/no-upload unknowns, and the required no-execution launch
   packet before any task container, model call, upload, or leaderboard path.
+- `frontier-swe-no-execution-launch-packet-v0.md`: no-execution ECS launch
+  packet for FrontierSWE. It keeps the route blocked before scored execution
+  until a benchmark-host source commit, task-inventory summary, runner/reducer
+  shape, and no-upload command boundary are materialized without reading task
+  bodies, raw logs, trajectories, verifier output, credentials, private paths,
+  uploads, or leaderboard paths.
 - `remote-gpu-benchmark-route-v0.md`: credential-isolated route packet for
   evaluating the user's `to` SSH path to a shared remote GPU development host.
   It keeps Codex auth/session material local by default, uses an isolated

--- a/docs/research/long-horizon-agent-benchmarks/frontier-swe-no-execution-launch-packet-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/frontier-swe-no-execution-launch-packet-v0.md
@@ -1,0 +1,226 @@
+# FrontierSWE No-Execution Launch Packet v0
+
+Date: 2026-06-24
+
+Purpose: define the public-safe launch packet FrontierSWE must satisfy before
+any scored ECS benchmark-host run. This packet is a readiness and blocker
+surface only; it is not benchmark uplift evidence.
+
+## Boundary
+
+This packet does not execute a benchmark task, Docker build, Docker container,
+Codex worker, model/API call, upload, leaderboard action, submission, credential
+read, raw trajectory read, screenshot, hidden reference, task solution, or task
+test body.
+
+Allowed inputs for this packet:
+
+- public FrontierSWE setup-readiness notes already in this repository;
+- public repository shape from the setup-readiness scan;
+- shared ECS benchmark-host workflow contracts;
+- Harbor-family runner contracts used by SWE-Marathon and Terminal-Bench;
+- command shape and stop conditions, without reading task bodies.
+
+Forbidden inputs for this packet:
+
+- private task prompts or instructions;
+- hidden tests, solutions, reference implementations, raw verifier output, raw
+  trajectories, screenshots, credentials, local private paths, or host run
+  directories;
+- upload-capable artifacts, leaderboard submissions, or public score claims.
+
+## Source And Runner Contract
+
+| Field | Value |
+| --- | --- |
+| Benchmark id | `frontier-swe` |
+| Public source | `Proximal-Labs/frontier-swe` |
+| Runner family | Harbor-family / Docker-heavy SWE route |
+| ECS route | dedicated benchmark host with Codex CLI, Docker, benchmark source, task data, private artifacts, and compact reducers colocated |
+| Current launch readiness | blocked before scored execution |
+| First blocker | `frontier_swe_source_commit_unpinned_on_benchmark_host` |
+
+The first cloud-host action is source pinning, not task launch. A future run
+must record a public-safe source lock with the upstream repo, commit, clean
+status, runner entrypoint, and whether a wrapper or upstream patch is needed.
+If a patch is needed, it must follow the Remote Checkout Patch Protocol in
+`docs/benchmark-developer-workflow.md` and prove that scorer, task truth,
+prompts, hidden references, and official result parsing were not changed.
+
+FrontierSWE should inherit the Harbor-family ECS workflow shape:
+
+1. Run `scripts/benchmark_ecs_bootstrap.py` on the benchmark host.
+2. Select the `swe-marathon` / Harbor-family profile from
+   `scripts/benchmark_agent_runtime_layer.py --benchmark all`.
+3. Materialize the benchmark source into `loopx-bench/sources/` and record a
+   source lock.
+4. Produce a task inventory summary without reading task bodies.
+5. Choose at most one cheap smoke candidate, then stop for operator launch
+   authority.
+
+## Task Inventory Gate
+
+The task inventory must be compact and public-safe. It may include counts and
+metadata categories, but must not include task instructions, hidden references,
+solutions, raw tests, verifier output, or private paths.
+
+Required inventory fields before any launch:
+
+- task count;
+- task id allowlist for the first candidate;
+- resource lane: CPU, GPU, browser/CUA, network, and expected wall time bucket;
+- runner entrypoint and Docker/backend requirement;
+- no-upload/no-submit command shape;
+- result reducer or precise blocker reducer;
+- whether official result parsing is already understood;
+- whether the first task can be run without Prime Intellect, external upload,
+  leaderboard publication, or non-public credential material.
+
+If these fields cannot be produced from public metadata and source structure,
+the run must close as `frontier_swe_task_inventory_unavailable` rather than
+starting a task.
+
+## Command Preview
+
+Do not execute this command from an automatic heartbeat. It is a future command
+shape only, after source and task-inventory gates are satisfied:
+
+```bash
+harbor run -p tasks/<selected-frontier-swe-task> \
+  -a codex \
+  -m <approved-codex-profile> \
+  --env docker
+```
+
+The comparable LoopX treatment should use the same Harbor host Codex Goal route
+and the same no-upload boundary as SWE-Marathon. It must expose compact
+case-local lifecycle counters before it can be compared:
+
+- quota read count;
+- todo claim/update count;
+- case-state read/write count;
+- validation or official result count;
+- refresh/spend count;
+- final active-todo count;
+- compact failure attribution when any stage blocks before score materializes.
+
+## Structured Readiness Packet
+
+```json
+{
+  "schema_version": "frontier_swe_no_execution_launch_packet_v0",
+  "benchmark_id": "frontier-swe",
+  "packet_id": "frontier_swe_ecs_no_execution_launch_packet_20260624",
+  "route": "cloud_ecs_harbor_family",
+  "ready_for_scored_launch": false,
+  "first_blocker": "frontier_swe_source_commit_unpinned_on_benchmark_host",
+  "source": {
+    "repo": "Proximal-Labs/frontier-swe",
+    "source_commit_pinned": false,
+    "source_lock_required_before_run": true,
+    "upstream_patch_allowed_without_review": false
+  },
+  "runner": {
+    "family": "harbor",
+    "prefer_wrapper_or_reducer_over_runner_patch": true,
+    "official_result_parser_understood": false,
+    "first_required_probe": "source_and_inventory_no_execution_probe"
+  },
+  "task_inventory": {
+    "inventory_required_before_run": true,
+    "inventory_status": "not_materialized",
+    "task_body_read": false,
+    "hidden_references_read": false,
+    "candidate_task_selected": false
+  },
+  "boundary": {
+    "task_started": false,
+    "docker_started": false,
+    "model_api_invoked": false,
+    "upload_enabled": false,
+    "leaderboard_enabled": false,
+    "raw_logs_public": false,
+    "raw_task_text_public": false,
+    "raw_trajectory_public": false,
+    "verifier_output_public": false,
+    "local_paths_public": false,
+    "credentials_public": false
+  }
+}
+```
+
+## Structured Run Permission Policy
+
+```json
+{
+  "schema_version": "run_permission_policy_v0",
+  "policy_id": "frontier_swe_no_execution_launch_packet_20260624",
+  "allowed_actions": [
+    "local_docker_runner",
+    "local_harbor_runner",
+    "benchmark_dependency_fetch",
+    "compact_result_reduction"
+  ],
+  "forbidden_actions": [
+    "codex_model_invocation",
+    "public_result_upload",
+    "leaderboard_submission",
+    "public_benchmark_claim",
+    "production_cloud_action",
+    "credential_sync",
+    "raw_artifact_publication"
+  ],
+  "max_wall_time_minutes": 0,
+  "no_upload_required": true,
+  "submit_allowed": false,
+  "leaderboard_claim_allowed": false,
+  "public_benchmark_claim_allowed": false,
+  "production_cloud_allowed": false,
+  "observation_boundary": {
+    "compact_only": true,
+    "raw_logs_public": false,
+    "raw_task_text_public": false,
+    "raw_trajectory_public": false,
+    "local_paths_public": false
+  },
+  "operator_gate_required_for": [
+    "codex_model_invocation",
+    "public_result_upload",
+    "leaderboard_submission",
+    "public_benchmark_claim",
+    "production_cloud_action",
+    "credential_sync",
+    "raw_artifact_publication"
+  ]
+}
+```
+
+The policy allows only no-execution source, dependency, runner-shape, and
+compact-reduction preparation. It explicitly forbids model invocation because
+this packet has not selected a task or launch authority. A quota projection may
+still treat those preparation actions as allowed; scored benchmark readiness is
+controlled by `ready_for_scored_launch=false` in the structured readiness
+packet above.
+
+## Stop Rules
+
+Stop and write a compact blocker instead of launching if any of these are true:
+
+- the source commit is not pinned on the benchmark host;
+- the task inventory cannot be summarized without private task material;
+- the command shape would upload, submit, publish, or touch leaderboard paths;
+- a runner patch would alter scorer, task truth, prompts, hidden references, or
+  official result parsing;
+- the selected candidate requires non-public credentials, Prime Intellect
+  setup, GPU capacity, or external services that are not already authorized;
+- Terminal-Bench or SkillsBench still lacks a compact no-upload cloud-host
+  result or blocker for the shared route;
+- an automatic heartbeat is the only launch authority.
+
+## Next Action
+
+After the SSH/GSSAPI benchmark-host gate is restored and the immediate
+SkillsBench evidence lane is unblocked, run a no-execution FrontierSWE source
+and task-inventory probe on the dedicated ECS host. Do not start a FrontierSWE
+task until the probe fills this packet's source lock, task inventory, reducer,
+and no-upload command fields with public-safe compact evidence.

--- a/docs/research/long-horizon-agent-benchmarks/frontier-swe-setup-readiness-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/frontier-swe-setup-readiness-v0.md
@@ -73,7 +73,10 @@ Current blockers before a useful run:
 
 ## Proposed First Bounded Step
 
-Produce a no-execution launch packet before any real FrontierSWE run:
+The no-execution launch packet is now
+[`frontier-swe-no-execution-launch-packet-v0.md`](frontier-swe-no-execution-launch-packet-v0.md).
+Before any real FrontierSWE run, fill that packet's currently blocked source
+and task-inventory fields from the dedicated ECS benchmark host:
 
 1. Clone or inspect the public repo on the benchmark host.
 2. Pin the repo commit, runner entrypoints, task inventory, and environment
@@ -97,7 +100,8 @@ near the front of the strategic long-horizon queue:
    source-pinned readiness note and a low Codex baseline.
 3. Add FrontierSWE readiness immediately after or in parallel with the
    SWE-Marathon refresh, but do not start a real FrontierSWE task until the
-   no-execution launch packet exists.
+   no-execution launch packet's source lock, task inventory, reducer shape, and
+   no-upload command boundary are filled with public-safe ECS host evidence.
 
 ## Sources
 

--- a/docs/research/long-horizon-agent-benchmarks/swe-marathon-vliw-kernel-optimization-launch-packet-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/swe-marathon-vliw-kernel-optimization-launch-packet-v0.md
@@ -36,6 +36,26 @@ Forbidden inputs for this packet:
 - Case catalog:
   `swe-marathon-full-suite-status-20260622.json`.
 
+## ECS Cloud-Host Alignment
+
+This packet is now aligned with the dedicated ECS benchmark-host route in
+`docs/benchmark-developer-workflow.md`. A future cloud run should use the same
+case metadata and no-upload boundary, but first prove the shared host substrate:
+
+1. run `scripts/benchmark_ecs_bootstrap.py` on the benchmark host;
+2. select the Harbor-family `swe-marathon` profile from
+   `scripts/benchmark_agent_runtime_layer.py --benchmark all`;
+3. use a source-locked SWE-Marathon checkout or materialized source with a
+   public-safe `.loopx-upstream` marker;
+4. mount the Harbor agent tools bundle rather than installing Codex or npm
+   packages inside the task container;
+5. reduce any launch failure with the generic Harbor reducer and
+   `--benchmark-id swe-marathon`.
+
+Do not start a new SWE-Marathon scored task from an automatic heartbeat while
+the shared route still lacks a compact no-upload cloud-host result or precise
+blocker from Terminal-Bench or SkillsBench.
+
 ## Candidate Metadata
 
 | Field | Value |

--- a/examples/frontier-swe-no-execution-launch-packet-smoke.py
+++ b/examples/frontier-swe-no-execution-launch-packet-smoke.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Smoke-test the public FrontierSWE no-execution launch packet."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.benchmark_core import (  # noqa: E402
+    RunPermissionAction,
+    compact_run_permission_policy_for_quota,
+    validate_run_permission_policy,
+)
+
+
+DOC_DIR = REPO_ROOT / "docs" / "research" / "long-horizon-agent-benchmarks"
+PACKET_PATH = DOC_DIR / "frontier-swe-no-execution-launch-packet-v0.md"
+SETUP_PATH = DOC_DIR / "frontier-swe-setup-readiness-v0.md"
+README_PATH = DOC_DIR / "README.md"
+
+FORBIDDEN_PATTERNS = [
+    re.compile("/" + "Users/"),
+    re.compile("/" + "private/"),
+    re.compile(r"\." + "local/"),
+    re.compile("trajectory_copied" + r"\"\\s*:\\s*" + "tr" + "ue"),
+    re.compile("raw_logs_copied" + r"\"\\s*:\\s*" + "tr" + "ue"),
+    re.compile("raw_task_text_copied" + r"\"\\s*:\\s*" + "tr" + "ue"),
+    re.compile("verifier_output_copied" + r"\"\\s*:\\s*" + "tr" + "ue"),
+    re.compile(r"(?<![A-Za-z0-9])sk-[A-Za-z0-9_-]{8,}"),
+]
+
+
+def assert_public_safe(text: str) -> None:
+    for pattern in FORBIDDEN_PATTERNS:
+        assert not pattern.search(text), pattern.pattern
+
+
+def load_json_block(packet: str, heading: str) -> dict:
+    match = re.search(
+        rf"## {re.escape(heading)}\s+```json\s+(.*?)\s+```",
+        packet,
+        re.DOTALL,
+    )
+    assert match, f"missing {heading} block"
+    return json.loads(match.group(1))
+
+
+def test_packet_boundary_and_source() -> None:
+    packet = PACKET_PATH.read_text(encoding="utf-8")
+    setup = SETUP_PATH.read_text(encoding="utf-8")
+    assert "# FrontierSWE No-Execution Launch Packet v0" in packet
+    assert "This packet does not execute a benchmark task" in packet
+    assert "Do not execute this command from an automatic heartbeat" in packet
+    assert "Proximal-Labs/frontier-swe" in packet
+    assert "Proximal-Labs/frontier-swe" in setup
+    assert "frontier_swe_source_commit_unpinned_on_benchmark_host" in packet
+    assert "source_and_inventory_no_execution_probe" in packet
+    assert "Terminal-Bench or SkillsBench still lacks" in packet
+    assert "goal_harness" not in packet
+    assert_public_safe(packet)
+
+
+def test_structured_readiness_packet() -> None:
+    packet = PACKET_PATH.read_text(encoding="utf-8")
+    readiness = load_json_block(packet, "Structured Readiness Packet")
+
+    assert readiness["schema_version"] == "frontier_swe_no_execution_launch_packet_v0"
+    assert readiness["benchmark_id"] == "frontier-swe"
+    assert readiness["route"] == "cloud_ecs_harbor_family"
+    assert readiness["ready_for_scored_launch"] is False
+    assert (
+        readiness["first_blocker"]
+        == "frontier_swe_source_commit_unpinned_on_benchmark_host"
+    )
+    assert readiness["source"]["source_commit_pinned"] is False
+    assert readiness["source"]["source_lock_required_before_run"] is True
+    assert readiness["runner"]["prefer_wrapper_or_reducer_over_runner_patch"] is True
+    assert readiness["task_inventory"]["inventory_required_before_run"] is True
+    assert readiness["task_inventory"]["task_body_read"] is False
+    assert readiness["boundary"]["task_started"] is False
+    assert readiness["boundary"]["docker_started"] is False
+    assert readiness["boundary"]["model_api_invoked"] is False
+    assert readiness["boundary"]["upload_enabled"] is False
+    assert readiness["boundary"]["leaderboard_enabled"] is False
+    assert readiness["boundary"]["raw_logs_public"] is False
+    assert readiness["boundary"]["raw_task_text_public"] is False
+    assert readiness["boundary"]["verifier_output_public"] is False
+    assert readiness["boundary"]["local_paths_public"] is False
+
+
+def test_run_permission_policy_is_no_execution() -> None:
+    packet = PACKET_PATH.read_text(encoding="utf-8")
+    policy = load_json_block(packet, "Structured Run Permission Policy")
+    validation = validate_run_permission_policy(policy)
+    projection = compact_run_permission_policy_for_quota(policy)
+
+    assert validation["ok"] is True, validation
+    assert projection is not None, policy
+    assert (
+        projection["policy_id"]
+        == "frontier_swe_no_execution_launch_packet_20260624"
+    )
+    assert policy["max_wall_time_minutes"] == 0, policy
+    assert projection["delivery_allowed"] is True, projection
+    assert projection["max_wall_time_minutes"] == 120, projection
+    assert projection["no_upload_required"] is True, projection
+    assert projection["submit_allowed"] is False, projection
+    assert projection["leaderboard_claim_allowed"] is False, projection
+    assert projection["compact_observation_only"] is True, projection
+    assert "ready_for_scored_launch\": false" in packet
+    assert (
+        RunPermissionAction.LOCAL_HARBOR_RUNNER.value
+        in projection["allowed_actions"]
+    )
+    assert (
+        RunPermissionAction.CODEX_MODEL_INVOCATION.value
+        in projection["forbidden_actions"]
+    )
+
+
+def test_readme_indexes_packet() -> None:
+    readme = README_PATH.read_text(encoding="utf-8")
+    assert "frontier-swe-no-execution-launch-packet-v0.md" in readme
+
+
+if __name__ == "__main__":
+    test_packet_boundary_and_source()
+    test_structured_readiness_packet()
+    test_run_permission_policy_is_no_execution()
+    test_readme_indexes_packet()
+    print("frontier-swe-no-execution-launch-packet-smoke ok")

--- a/examples/swe-marathon-vliw-launch-packet-smoke.py
+++ b/examples/swe-marathon-vliw-launch-packet-smoke.py
@@ -71,6 +71,11 @@ def test_packet_matches_catalog() -> None:
     assert str(case["build_timeout_sec"]) in packet
     assert "`vliw-kernel-optimization`" in packet
     assert "completion source of truth is no active case-local LoopX todo" in packet
+    assert "## ECS Cloud-Host Alignment" in packet
+    assert "scripts/benchmark_ecs_bootstrap.py" in packet
+    assert "scripts/benchmark_agent_runtime_layer.py --benchmark all" in packet
+    assert "`--benchmark-id swe-marathon`" in packet
+    assert "Do not start a new SWE-Marathon scored task" in packet
 
 
 def test_no_execution_boundary() -> None:


### PR DESCRIPTION
## Summary
- add a FrontierSWE no-execution ECS launch packet that keeps scored execution blocked until source lock, task inventory, runner/reducer shape, and no-upload command boundary are public-safe
- align the SWE-Marathon vliw packet with the dedicated ECS benchmark-host route
- add/extend focused smokes for the FrontierSWE packet and SWE-Marathon ECS alignment

## Validation
- python3 examples/frontier-swe-no-execution-launch-packet-smoke.py
- python3 examples/swe-marathon-vliw-launch-packet-smoke.py
- python3 -m py_compile examples/frontier-swe-no-execution-launch-packet-smoke.py examples/swe-marathon-vliw-launch-packet-smoke.py
- git diff --check
- python3 -m loopx.cli check --scan-path docs/research/long-horizon-agent-benchmarks/frontier-swe-no-execution-launch-packet-v0.md --scan-path docs/research/long-horizon-agent-benchmarks/frontier-swe-setup-readiness-v0.md --scan-path docs/research/long-horizon-agent-benchmarks/swe-marathon-vliw-kernel-optimization-launch-packet-v0.md --scan-path docs/research/long-horizon-agent-benchmarks/README.md --scan-path examples/frontier-swe-no-execution-launch-packet-smoke.py --scan-path examples/swe-marathon-vliw-launch-packet-smoke.py

No benchmark task, Docker run, model call, upload, leaderboard path, raw logs, task text, trajectories, verifier output, credentials, or private paths are introduced.