### PR TITLE
docs: record citation-check lifecycle blocker

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
@@ -1510,7 +1510,7 @@
               "baseline_route_valid": true,
               "benchmark_id": "skillsbench@1.1",
               "case_id": "citation-check",
-              "claim_blocker": "baseline_max_rounds_not_5,treatment_max_rounds_not_5,treatment_loopx_lifecycle_not_observed",
+              "claim_blocker": "baseline_max_rounds_not_5,treatment_max_rounds_not_5",
               "comparison_id": "skillsbench_product_mode_main_table_v0",
               "headline_metrics": [
                 "best_score",
@@ -1522,10 +1522,10 @@
               "official_feedback_blinded": true,
               "product_mode_pair_complete": false,
               "schema_version": "benchmark_product_mode_comparison_v0",
-              "treatment_loopx_lifecycle_observed": false,
+              "treatment_loopx_lifecycle_observed": true,
               "treatment_route_valid": true
             },
-            "treatment_run_id": "701ce4d83a22"
+            "treatment_run_id": "2daa003299be"
           },
           "runs": [
             {
@@ -1822,6 +1822,93 @@
               "source_event_schema": "benchmark_run_v0",
               "status": "completed",
               "submit_eligible": false
+            },
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "codex_loopx_treatment",
+              "artifact_refs": {
+                "compact_artifact_ref": "cloud-ecs/skillsbench-citation-check-f737-canonical-20260624T044923Z/jobs/skillsbench-citation-check-f737-canonical-20260624T044923Z-treatment/citation-check__loopx_product_mode/benchmark_run.compact.json"
+              },
+              "attempt_failure_class": "verifier_failed",
+              "attempt_failure_label": "verifier_infrastructure_failure",
+              "attempt_lifecycle_phase": "verifier_scored",
+              "benchmark_id": "skillsbench@1.1",
+              "case_attempt_countable": true,
+              "case_id": "citation-check",
+              "case_ids": [
+                "citation-check"
+              ],
+              "codex_acp_runtime_preflight_passed": true,
+              "failure_class": "skillsbench_acp_agent_message_only_no_tool_calls",
+              "failure_labels": [
+                "skillsbench_runner_error",
+                "verifier_infrastructure_failure",
+                "skillsbench_acp_agent_message_only_no_tool_calls",
+                "skillsbench_agent_behavior_gap"
+              ],
+              "failure_scope": "score_missing",
+              "job_name": "skillsbench_1_1_citation_check_loopx_product_mode",
+              "launcher_attempt_countable": true,
+              "leaderboard_evidence": false,
+              "loop_score_policy": "best_round_for_offline_controller_analysis",
+              "loopx_inside_case": true,
+              "max_rounds_budget": 8,
+              "mode": "skillsbench_loopx_product_mode_treatment",
+              "model_control_status": "reported_model_from_result_metadata",
+              "notes": "citation-check canonical loopx-product-mode lifecycle satisfied/countable with 14 state writes; official score missing due verifier infrastructure plus ACP no-tool-call attribution mismatch",
+              "official_feedback_blinded": true,
+              "official_score_attempt_countable": false,
+              "official_score_policy": "final_workspace_official_result",
+              "product_mode_lifecycle_contract": {
+                "checkpoint_count": 1,
+                "checkpoint_required": true,
+                "checkpoint_round": 1,
+                "countable_treatment": true,
+                "orchestrated_driver_lifecycle_satisfied": false,
+                "required": true,
+                "satisfied": true,
+                "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+                "state_read_count": 2,
+                "state_write_count": 14
+              },
+              "recorded_at": "2026-06-24T13:27:56+08:00",
+              "reward_feedback_forwarded": false,
+              "round_reward_count": 1,
+              "round_rewards": [
+                {
+                  "agent_round": 1,
+                  "passed": false,
+                  "reward_present": false,
+                  "tool_calls": 0
+                }
+              ],
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-citation-check-f737-canonical-20260624T044923Z",
+              "run_id": "2daa003299be",
+              "score_status": "missing",
+              "solver_attempt_countable": true,
+              "source_event_schema": "benchmark_run_v0",
+              "status": "recorded",
+              "submit_eligible": false,
+              "task_staging": {
+                "app_skills_mount_patch_applied": true,
+                "apt_retry_patch_applied": true,
+                "apt_retry_patch_required": true,
+                "apt_risk_preflight_blocked": false,
+                "apt_setup_risk_detected": true,
+                "codex_acp_runtime_tools_patch_applied": true,
+                "include_task_skills": false,
+                "original_task_mutated": false,
+                "resource_cap_patch": {
+                  "applied": false,
+                  "host_cpus": 32.0
+                },
+                "staged": true,
+                "task_skills_removed": true
+              },
+              "verifier_attempt_countable": true
             }
           ]
         },
@@ -8269,7 +8356,7 @@
           ]
         }
       },
-      "run_count": 144
+      "run_count": 145
     },
     "swe-marathon": {
       "benchmark_id": "swe-marathon",
@@ -12321,5 +12408,5 @@
     "source_of_truth": "benchmark_run_v0 compact run events",
     "update_rule": "upsert one run entry when a benchmark case is ingested or closed"
   },
-  "updated_at": "2026-06-24T12:21:20+08:00"
+  "updated_at": "2026-06-24T13:27:56+08:00"
 }

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
@@ -5,7 +5,7 @@ benchmark case outcomes and artifact references; it must not contain raw
 logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 
 - schema_version: `benchmark_run_ledger_v0`
-- updated_at: `2026-06-24T12:21:20+08:00`
+- updated_at: `2026-06-24T13:27:56+08:00`
 
 ## Case Decisions
 
@@ -17,7 +17,7 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `skillsbench@1.1` | `adaptive-cruise-control` | `baseline_runner_or_setup_repair_required` | - | - | `1` |
 | `skillsbench@1.1` | `azure-bgp-oscillation-route-leak` | `product_mode_pair_incomplete` | `treatment_loopx_lifecycle_not_observed` | - | `10` |
 | `skillsbench@1.1` | `bike-rebalance` | `paired_baseline_solved_treatment_preserved` | - | - | `3` |
-| `skillsbench@1.1` | `citation-check` | `product_mode_pair_incomplete` | `baseline_max_rounds_not_5,treatment_max_rounds_not_5,treatment_loopx_lifecycle_not_observed` | - | `6` |
+| `skillsbench@1.1` | `citation-check` | `product_mode_pair_incomplete` | `baseline_max_rounds_not_5,treatment_max_rounds_not_5` | - | `7` |
 | `skillsbench@1.1` | `civ6-adjacency-optimizer` | `paired_no_score_uplift` | - | - | `4` |
 | `skillsbench@1.1` | `dapt-intrusion-detection` | `paired_baseline_setup_preflight_selection_required` | - | - | `5` |
 | `skillsbench@1.1` | `debug-trl-grpo` | `paired_baseline_runner_or_setup_repair_required` | - | - | `9` |
@@ -111,6 +111,7 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `skillsbench@1.1` | `citation-check` | `codex_loopx_treatment` | `` | `1.0` | `1` | `1:1*` | `none` | `.local/private-benchmark-jobs/skillsbench-citation-check-blind-treatment-baseline-safe-v0/citation-check__loopx_blind_loop_baseline_safe_v0/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `citation-check` | `skillsbench_raw_codex_autonomous_max5_baseline` | `` | `1.0` | `` | `1:missing` | `none` | `.local/private-benchmark-jobs/skillsbench-citation-check-canonical-lifecycle-20260622T214741Z-base/citation-check__raw_codex_autonomous_max5/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `citation-check` | `codex_loopx_treatment` | `` | `1.0` | `8` | `1:missing,2:missing,3:missing,4:missing,5:missing,6:missing,7:missing,8:1*` | `none` | `.local/private-benchmark-jobs/skillsbench-citation-check-canonical-lifecycle-20260622T214741Z-test/citation-check__loopx_product_mode/benchmark_run.compact.json` |
+| `skillsbench@1.1` | `citation-check` | `codex_loopx_treatment` | `case_attempt` | `missing` | `` | `1:missing` | `skillsbench_acp_agent_message_only_no_tool_calls` | `cloud-ecs/skillsbench-citation-check-f737-canonical-20260624T044923Z/jobs/skillsbench-citation-check-f737-canonical-20260624T044923Z-treatment/citation-check__loopx_product_mode/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `civ6-adjacency-optimizer` | `codex_goal_mode_baseline` | `` | `0.0` | `` | `` | `official_verifier_solution_failure` | `` |
 | `skillsbench@1.1` | `civ6-adjacency-optimizer` | `loopx_automation_loop_treatment` | `` | `0.0` | `` | `` | `official_verifier_solution_failure` | `` |
 | `skillsbench@1.1` | `civ6-adjacency-optimizer` | `baseline` | `` | `0.0` | `` | `1:0,2:0` | `official_verifier_solution_failure` | `.local/private-benchmark-jobs/skillsbench-civ6-adjacency-optimizer-blind-baseline-v0/civ6-adjacency-optimizer__codex_acp_blind_loop_v0/benchmark_run.compact.json` |


### PR DESCRIPTION
## Summary
- Upserts the latest citation-check canonical loopx-product-mode compact result into the public benchmark run ledger.
- Records that lifecycle was satisfied/countable with nonzero LoopX state writes, while official score remains missing due to verifier infrastructure plus ACP no-tool-call attribution mismatch.
- Removes the stale citation-check lifecycle-not-observed decision reason from the generated case decision summary.

## Validation
- python3 examples/benchmark-run-ledger-smoke.py
- git diff --check
- loopx benchmark run-ledger-check --goal-id loopx-meta --run-ledger-path docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json --limit 20 (passes; still reports an unrelated existing 3d-scan-calc missing ledger catch-up)
- Public/private scan of touched ledger files for local absolute paths, raw logs, raw trajectories, task.md, and credential markers: clean

## Excluded
- Raw task text, trajectories, verifier output, private runner logs, and local .local compact input files are not committed.