### PR TITLE
Tune scheduler hint cadence profiles

### DIFF
--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -503,8 +503,8 @@ JSON or Markdown decision:
     "schema_version": "scheduler_hint_v0",
     "action": "backoff_waiting_for_user",
     "codex_app": {
-      "recommended_interval_minutes": 60,
-      "example_progression_minutes": [60, 120, 240]
+      "recommended_interval_minutes": 30,
+      "example_progression_minutes": [30, 60, 120]
     },
     "codex_cli_tui": {
       "unchanged_poll_limit": 3,
@@ -629,15 +629,18 @@ The response also includes `scheduler_hint.schema_version=scheduler_hint_v0`.
 That hint is not a delivery permission. It is the cross-runtime wait policy:
 `run_now` keeps the active cadence for required work; `backoff_waiting_for_user`
 slows Codex App and stops CLI/Claude loops after repeated unchanged polls;
-`backoff_until_reassigned` handles side-agent primary-review waits;
+`backoff_until_reassigned` handles side-agent primary-review waits without
+dropping agent-to-agent handoff cadence too quickly;
 `backoff_until_material_transition` handles monitor-only quiet polls; and
 `backoff_until_fresh_evidence` handles mapped or post-handoff no-op waits.
 For Codex App and local schedulers, `recommended_interval_minutes` is the next
 target interval; if the same `unchanged_identity_keys` remain unchanged, the
 host multiplies the applied interval by
-`unchanged_poll_backoff_multiplier` until `max_interval_minutes`. For example,
-an agent-scope wait with `[30, 60, 120]` means a 600-second local tick should
-move to 1800 seconds, then 3600 seconds, then cap at 7200 seconds.
+`unchanged_poll_backoff_multiplier` until `max_interval_minutes`. Human gates
+can move to `[30, 60, 120]` after the concrete user todo has been surfaced.
+Agent-scope waits use a more conservative adjustment curve such as
+`[10, 20, 30]`, so a 600-second local tick stays close to the existing
+agent-to-agent interaction cadence before cooling further.
 For Codex CLI TUI and Claude Code loops, `unchanged_poll_limit=3` means the
 third unchanged poll triggers `final_quota_replan_check`; if the rerun is still
 unchanged, the loop applies `after_limit`.

--- a/examples/codex-cli-local-scheduler-tick-smoke.py
+++ b/examples/codex-cli-local-scheduler-tick-smoke.py
@@ -116,9 +116,9 @@ QUOTA_HINT_FIXTURE = {
         "action": "backoff_until_reassigned",
         "cadence_class": "agent_scope_wait",
         "local_scheduler": {
-            "recommended_interval_minutes": 30,
-            "max_interval_minutes": 120,
-            "example_progression_minutes": [30, 60, 120],
+            "recommended_interval_minutes": 10,
+            "max_interval_minutes": 30,
+            "example_progression_minutes": [10, 20, 30],
             "unchanged_poll_limit": 3,
             "after_limit": "stop_tick_loop",
             "final_quota_replan_check": {"enabled": True},
@@ -227,8 +227,8 @@ def main() -> int:
 
     hinted_tick = build_tick(FALLBACK_HELP_FIXTURE, quota_payload=QUOTA_HINT_FIXTURE)
     assert hinted_tick["scheduler_hint"]["action"] == "backoff_until_reassigned", hinted_tick
-    assert hinted_tick["launchd"]["recommended_interval_seconds"] == 1800, hinted_tick
-    assert hinted_tick["scheduler_hint"]["local_scheduler"]["example_progression_minutes"] == [30, 60, 120], hinted_tick
+    assert hinted_tick["launchd"]["recommended_interval_seconds"] == 600, hinted_tick
+    assert hinted_tick["scheduler_hint"]["local_scheduler"]["example_progression_minutes"] == [10, 20, 30], hinted_tick
     assert hinted_tick["scheduler_hint"]["codex_cli_tui"]["final_quota_replan_check"]["enabled"] is True, hinted_tick
 
     with tempfile.TemporaryDirectory(prefix="loopx-codex-cli-scheduler-tick-") as tmp:
@@ -268,7 +268,7 @@ def main() -> int:
         assert_boundary(cli_json)
         assert cli_json["scheduler_action"] == "write_precise_blocker", cli_json
         assert cli_json["scheduler_hint"]["action"] == "backoff_until_reassigned", cli_json
-        assert cli_json["launchd"]["recommended_interval_seconds"] == 1800, cli_json
+        assert cli_json["launchd"]["recommended_interval_seconds"] == 600, cli_json
 
         cli_proof_json = json.loads(
             run_cli(
@@ -329,7 +329,7 @@ def main() -> int:
         )
         assert "# Codex CLI Local Scheduler Tick" in cli_markdown, cli_markdown
         assert "scheduler_action: `write_precise_blocker`" in cli_markdown, cli_markdown
-        assert "local_progression_minutes: `[30, 60, 120]`" in cli_markdown, cli_markdown
+        assert "local_progression_minutes: `[10, 20, 30]`" in cli_markdown, cli_markdown
         assert "local_unchanged_poll_limit: `3`" in cli_markdown, cli_markdown
         assert "final_quota_replan_check:" in cli_markdown, cli_markdown
         assert "runs_codex: `False`" in cli_markdown, cli_markdown

--- a/examples/quota-agent-scoped-user-gate-smoke.py
+++ b/examples/quota-agent-scoped-user-gate-smoke.py
@@ -285,8 +285,8 @@ def assert_agent_without_advancement_candidate_waits_for_primary() -> None:
     scheduler = payload["scheduler_hint"]
     assert scheduler["schema_version"] == "scheduler_hint_v0", scheduler
     assert scheduler["action"] == "backoff_until_reassigned", scheduler
-    assert scheduler["codex_app"]["recommended_interval_minutes"] == 30, scheduler
-    assert scheduler["codex_app"]["example_progression_minutes"] == [30, 60, 120], scheduler
+    assert scheduler["codex_app"]["recommended_interval_minutes"] == 10, scheduler
+    assert scheduler["codex_app"]["example_progression_minutes"] == [10, 20, 30], scheduler
     assert scheduler["codex_cli_tui"]["unchanged_poll_limit"] == 3, scheduler
     assert scheduler["codex_cli_tui"]["final_quota_replan_check"]["enabled"] is True, scheduler
     assert scheduler["claude_code_loop"]["after_limit"] == "stop_loop", scheduler

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -3936,8 +3936,8 @@ def _scheduler_hint(payload: dict[str, Any]) -> dict[str, Any]:
                 "concrete todo or gate, external loops should stop repeating the "
                 "same quiet poll"
             ),
-            codex_interval=60,
-            codex_max=240,
+            codex_interval=30,
+            codex_max=120,
             cli_limit=3,
             claude_limit=3,
         )
@@ -3947,12 +3947,13 @@ def _scheduler_hint(payload: dict[str, Any]) -> dict[str, Any]:
             action="backoff_until_reassigned",
             cadence_class="agent_scope_wait",
             reason=(
-                "this registered agent has no in-scope advancement candidate; poll "
-                "less often until primary review, reassignment, or a current-agent "
-                "todo appears"
+                "this registered agent has no in-scope advancement candidate; "
+                "agent-to-agent handoffs may change quickly, so stay closer to "
+                "the prior scheduler cadence while waiting for primary review, "
+                "reassignment, or a current-agent todo"
             ),
-            codex_interval=30,
-            codex_max=120,
+            codex_interval=10,
+            codex_max=30,
             cli_limit=3,
             claude_limit=3,
         )


### PR DESCRIPTION
## Summary
- set human gate scheduler hints to 30/60/120 minutes after surfacing concrete user work
- keep agent-scope primary-review waits closer to agent interaction cadence with 10/20/30 minutes
- update scheduler smoke coverage and quota docs

## Validation
- python3 examples/codex-cli-local-scheduler-tick-smoke.py
- python3 examples/quota-agent-scoped-user-gate-smoke.py
- python3 examples/quota-plan-smoke.py
- python3 examples/heartbeat-quota-flow-smoke.py
- python3 examples/work-lane-contract-smoke.py
- python3 examples/heartbeat-prompt-smoke.py
- python3 -m py_compile loopx/*.py loopx/cli_commands/*.py
- git diff --check
- loopx check --scan-path loopx/quota.py --scan-path examples/codex-cli-local-scheduler-tick-smoke.py --scan-path examples/quota-agent-scoped-user-gate-smoke.py --scan-path docs/quota-allocation.md