### PR TITLE
Expose scheduler reset policy in quota hints

### DIFF
--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -515,6 +515,20 @@ JSON or Markdown decision:
       "unchanged_poll_limit": 3,
       "after_limit": "stop_loop",
       "final_quota_replan_check": {"enabled": true}
+    },
+    "reset_policy": {
+      "schema_version": "scheduler_reset_policy_v0",
+      "reset_to": "profile_initial_interval",
+      "codex_app_initial_interval_minutes": 30,
+      "clear_unchanged_poll_state": true,
+      "reset_conditions": [
+        "quota_identity_snapshot_changed",
+        "scheduler_action_changed",
+        "user_feedback",
+        "new_or_reassigned_todo",
+        "gate_resolved",
+        "material_transition"
+      ]
     }
   },
   "operator_question": "是否同意 project-main-control 先做 read-only map dry-run？",
@@ -641,6 +655,14 @@ can move to `[30, 60, 120]` after the concrete user todo has been surfaced.
 Agent-scope waits use a more conservative adjustment curve such as
 `[10, 20, 30]`, so a 600-second local tick stays close to the existing
 agent-to-agent interaction cadence before cooling further.
+Each hint also carries `reset_policy.schema_version=scheduler_reset_policy_v0`.
+Hosts should compare `reset_policy.identity_snapshot` across unchanged polls
+and reset the unchanged streak whenever the snapshot or scheduler action
+changes. They should also reset when an external event makes the goal
+actionable again, such as user feedback in the thread, a new or reassigned todo,
+a resolved gate, or material evidence transition. A reset applies
+`codex_app_initial_interval_minutes` (and the matching local scheduler initial
+interval) before starting unchanged backoff again; it never spends quota.
 For Codex CLI TUI and Claude Code loops, `unchanged_poll_limit=3` means the
 third unchanged poll triggers `final_quota_replan_check`; if the rerun is still
 unchanged, the loop applies `after_limit`.

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -1204,7 +1204,14 @@ changes, final checks, and loop self-stop never spend quota. Host schedulers
 apply `recommended_interval_minutes` as the next target interval and multiply
 subsequent unchanged intervals by `unchanged_poll_backoff_multiplier` until
 `max_interval_minutes`; `example_progression_minutes` exposes the compact
-human-readable sequence.
+human-readable sequence. The hint also includes
+`reset_policy.schema_version=scheduler_reset_policy_v0`: hosts compare its
+`identity_snapshot` between polls and clear the unchanged/backoff streak when
+that snapshot or scheduler action changes, or when a user reply,
+new/reassigned todo, resolved gate, or material transition makes the goal
+actionable again. The reset moves Codex App/local cadence back to the current
+profile's initial interval before unchanged backoff resumes, and does not spend
+quota.
 The payload also includes `execution_obligation`, which is the compatibility
 entry point for older workers deciding whether a quiet no-op is allowed.
 `heartbeat_recommendation.notify` is only a user-facing notification policy. It

--- a/examples/heartbeat-quota-flow-smoke.py
+++ b/examples/heartbeat-quota-flow-smoke.py
@@ -651,6 +651,13 @@ def main() -> int:
         assert first_guard["scheduler_hint"]["local_scheduler"]["max_interval_minutes"] == 60, first_guard
         assert first_guard["scheduler_hint"]["codex_cli_tui"]["unchanged_poll_limit"] == 3, first_guard
         assert first_guard["scheduler_hint"]["codex_cli_tui"]["final_quota_replan_check"]["enabled"] is True, first_guard
+        reset = first_guard["scheduler_hint"]["reset_policy"]
+        assert reset["schema_version"] == "scheduler_reset_policy_v0", reset
+        assert reset["profile_action"] == "backoff_until_material_transition", reset
+        assert reset["codex_app_initial_interval_minutes"] == 15, reset
+        assert reset["identity_keys"] == first_guard["scheduler_hint"]["unchanged_identity_keys"], reset
+        assert "material_transition" in reset["reset_conditions"], reset
+        assert reset["clear_unchanged_poll_state"] is True, reset
         assert "automation=keep_active_quiet" in first_guard["protocol_action_packet"]["summary"], first_guard
         assert "scheduler=backoff_until_material_transition" in first_guard["protocol_action_packet"]["summary"], first_guard
         assert "pause_allowed=false" in first_guard["protocol_action_packet"]["summary"], first_guard

--- a/examples/quota-agent-scoped-user-gate-smoke.py
+++ b/examples/quota-agent-scoped-user-gate-smoke.py
@@ -291,6 +291,14 @@ def assert_agent_without_advancement_candidate_waits_for_primary() -> None:
     assert scheduler["codex_cli_tui"]["final_quota_replan_check"]["enabled"] is True, scheduler
     assert scheduler["claude_code_loop"]["after_limit"] == "stop_loop", scheduler
     assert scheduler["claude_code_loop"]["unchanged_poll_limit"] == 3, scheduler
+    reset = scheduler["reset_policy"]
+    assert reset["schema_version"] == "scheduler_reset_policy_v0", reset
+    assert reset["profile_action"] == "backoff_until_reassigned", reset
+    assert reset["codex_app_initial_interval_minutes"] == 10, reset
+    assert reset["identity_keys"] == scheduler["unchanged_identity_keys"], reset
+    assert reset["identity_snapshot"]["agent_identity.agent_id"] == payload["agent_identity"]["agent_id"], reset
+    assert "new_or_reassigned_todo" in reset["reset_conditions"], reset
+    assert reset["no_spend_for_reset"] is True, reset
     assert "scheduler=backoff_until_reassigned" in payload["protocol_action_packet"]["summary"], payload
 
 

--- a/examples/quota-plan-smoke.py
+++ b/examples/quota-plan-smoke.py
@@ -1549,16 +1549,26 @@ def assert_heartbeat_recommendation_lifecycle() -> None:
     assert mapped_rec["notify"] == "DONT_NOTIFY", mapped_rec
     assert mapped_decision["execution_obligation"]["must_attempt_work"] is False, mapped_decision
     assert mapped_decision["execution_obligation"]["kind"] == "quiet_noop_if_unchanged", mapped_decision
-    assert mapped_decision["scheduler_hint"]["action"] == "backoff_until_fresh_evidence", mapped_decision
-    assert mapped_decision["scheduler_hint"]["codex_app"]["recommended_interval_minutes"] == 60, mapped_decision
-    assert mapped_decision["scheduler_hint"]["codex_app"]["example_progression_minutes"] == [60, 120, 240], mapped_decision
-    assert mapped_decision["scheduler_hint"]["codex_cli_tui"]["unchanged_poll_limit"] == 3, mapped_decision
-    assert mapped_decision["scheduler_hint"]["codex_cli_tui"]["final_quota_replan_check"]["enabled"] is True, mapped_decision
+    scheduler = mapped_decision["scheduler_hint"]
+    assert scheduler["action"] == "backoff_until_fresh_evidence", mapped_decision
+    assert scheduler["codex_app"]["recommended_interval_minutes"] == 60, mapped_decision
+    assert scheduler["codex_app"]["example_progression_minutes"] == [60, 120, 240], mapped_decision
+    assert scheduler["codex_cli_tui"]["unchanged_poll_limit"] == 3, mapped_decision
+    assert scheduler["codex_cli_tui"]["final_quota_replan_check"]["enabled"] is True, mapped_decision
+    reset = scheduler["reset_policy"]
+    assert reset["schema_version"] == "scheduler_reset_policy_v0", reset
+    assert reset["reset_to"] == "profile_initial_interval", reset
+    assert reset["codex_app_initial_interval_minutes"] == 60, reset
+    assert reset["identity_keys"] == scheduler["unchanged_identity_keys"], reset
+    assert reset["identity_snapshot"]["recommended_action"] == mapped_decision["recommended_action"], reset
+    assert "user_feedback" in reset["reset_conditions"], reset
+    assert "new_or_reassigned_todo" in reset["reset_conditions"], reset
     assert "do not run another dry-run" in mapped_rec["spend_policy"], mapped_rec
     assert "heartbeat_recommendation: mode=mapped_noop_if_unchanged notify=DONT_NOTIFY" in mapped_markdown
     assert "heartbeat_stop_if_unchanged: `True`" in mapped_markdown, mapped_markdown
     assert "scheduler_hint: action=backoff_until_fresh_evidence" in mapped_markdown, mapped_markdown
     assert "codex_app_progression=[60, 120, 240]" in mapped_markdown, mapped_markdown
+    assert "scheduler_reset: reset_to=profile_initial_interval initial_interval=60" in mapped_markdown, mapped_markdown
     assert (
         "execution_obligation: must_attempt_work=False kind=quiet_noop_if_unchanged notify_is_execution_gate=False"
         in mapped_markdown

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -146,6 +146,7 @@ INTERACTION_CONTRACT_SCHEMA_VERSION = "loopx_interaction_contract_v0"
 PROTOCOL_ACTION_PACKET_SCHEMA_VERSION = "protocol_action_packet_v0"
 AUTOMATION_LIVENESS_SCHEMA_VERSION = "automation_liveness_v0"
 SCHEDULER_HINT_SCHEMA_VERSION = "scheduler_hint_v0"
+SCHEDULER_RESET_POLICY_SCHEMA_VERSION = "scheduler_reset_policy_v0"
 CAPABILITY_GATE_SCHEMA_VERSION = "capability_gate_v0"
 SIDE_AGENT_WORKSPACE_GUARD_SCHEMA_VERSION = "side_agent_workspace_guard_v0"
 AGENT_CLAIM_SCOPE_SCHEMA_VERSION = "agent_claim_scope_v0"
@@ -3815,6 +3816,22 @@ def _scheduler_hint(payload: dict[str, Any]) -> dict[str, Any]:
         or execution_obligation.get("spend_policy")
         or heartbeat_recommendation.get("spend_policy")
     )
+    identity_keys = [
+        "goal_id",
+        "agent_identity.agent_id",
+        "effective_action",
+        "heartbeat_recommendation.recommended_mode",
+        "interaction_contract.mode",
+        "recommended_action",
+    ]
+
+    def identity_value(path: str) -> Any:
+        current: Any = payload
+        for part in path.split("."):
+            if not isinstance(current, dict):
+                return None
+            current = current.get(part)
+        return current
 
     def hint(
         *,
@@ -3839,6 +3856,30 @@ def _scheduler_hint(payload: dict[str, Any]) -> dict[str, Any]:
             "if_run_now": "execute_new_quota_contract",
             "if_unchanged": "apply_after_limit_without_spend",
             "spend_policy": "no quota spend for final replan check or loop stop",
+        }
+        reset_policy = {
+            "schema_version": SCHEDULER_RESET_POLICY_SCHEMA_VERSION,
+            "source": "quota.should-run",
+            "reset_to": "profile_initial_interval",
+            "profile_action": action,
+            "codex_app_initial_interval_minutes": codex_interval,
+            "local_scheduler_initial_interval_minutes": codex_interval,
+            "clear_unchanged_poll_state": True,
+            "identity_keys": identity_keys,
+            "identity_snapshot": {
+                key: identity_value(key)
+                for key in identity_keys
+            },
+            "reset_conditions": [
+                "quota_identity_snapshot_changed",
+                "scheduler_action_changed",
+                "user_feedback",
+                "new_or_reassigned_todo",
+                "gate_resolved",
+                "material_transition",
+            ],
+            "after_reset": "apply the current profile initial interval before starting unchanged backoff again",
+            "no_spend_for_reset": True,
         }
         return {
             "schema_version": SCHEDULER_HINT_SCHEMA_VERSION,
@@ -3877,14 +3918,8 @@ def _scheduler_hint(payload: dict[str, Any]) -> dict[str, Any]:
                 "final_quota_replan_check": final_replan_check,
                 "no_spend_for_stop": True,
             },
-            "unchanged_identity_keys": [
-                "goal_id",
-                "agent_identity.agent_id",
-                "effective_action",
-                "heartbeat_recommendation.recommended_mode",
-                "interaction_contract.mode",
-                "recommended_action",
-            ],
+            "unchanged_identity_keys": identity_keys,
+            "reset_policy": reset_policy,
         }
 
     if (
@@ -8191,6 +8226,19 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
         )
         if scheduler_hint.get("reason"):
             lines.append(f"- scheduler_hint_reason: {scheduler_hint.get('reason')}")
+        reset_policy = (
+            scheduler_hint.get("reset_policy")
+            if isinstance(scheduler_hint.get("reset_policy"), dict)
+            else {}
+        )
+        if reset_policy:
+            lines.append(
+                "- scheduler_reset: "
+                f"reset_to={reset_policy.get('reset_to')} "
+                f"initial_interval={reset_policy.get('codex_app_initial_interval_minutes')} "
+                f"identity_keys={reset_policy.get('identity_keys')} "
+                f"conditions={reset_policy.get('reset_conditions')}"
+            )
     protocol_action_packet = (
         payload.get("protocol_action_packet")
         if isinstance(payload.get("protocol_action_packet"), dict)


### PR DESCRIPTION
## Summary
- add `scheduler_hint.reset_policy` so host schedulers can clear unchanged backoff when quota identity, scheduler action, user feedback, todos, gates, or material evidence make work actionable again
- render the reset policy in quota markdown while keeping heartbeat prompts thin and driven by CLI output
- document the scheduler reset semantics and cover mapped noop, agent-scope wait, and monitor wait paths in smokes

## Validation
- `python3 -m py_compile loopx/*.py loopx/cli_commands/*.py`
- `python3 examples/quota-plan-smoke.py`
- `python3 examples/quota-agent-scoped-user-gate-smoke.py`
- `python3 examples/heartbeat-quota-flow-smoke.py`
- `python3 examples/codex-cli-local-scheduler-tick-smoke.py`
- `python3 examples/heartbeat-prompt-smoke.py`
- `python3 -m loopx.cli --format json quota should-run --goal-id loopx-meta --agent-id codex-product-capability`
- `python3 -m loopx.cli quota should-run --goal-id loopx-meta --agent-id codex-product-capability | rg "scheduler_reset|scheduler_hint"`
- `python3 -m loopx.cli check --scan-path ...` on changed public files; clean except existing duplicate index warning
- `git diff --check origin/main...HEAD`

Runtime scheduling contract change; leaving for maintainer review rather than self-merging.