### PR TITLE
Require heartbeat opt-in during LoopX onboarding

### DIFF
--- a/examples/onboarding-connect-candidates-smoke.py
+++ b/examples/onboarding-connect-candidates-smoke.py
@@ -105,21 +105,30 @@ def assert_default_onboarding(project: Path, runtime: Path) -> None:
     assert "validation_plan" in candidate_kinds, candidates
     assert payload["onboarding_acceptance_required"] is True, payload
     assert payload["autonomous_advance_choice_required"] is True, payload
+    assert payload["heartbeat_opt_in_required"] is True, payload
+    assert payload["host_loop_activation_required"] is True, payload
+    assert "heartbeat=yes" in payload["heartbeat_opt_in_instruction"], payload
     assert payload["onboarding_todos_written"] is True, payload
     assert len(payload["accept_candidate_commands"]) == len(candidates), payload
 
     registry_path = project / ".loopx" / "registry.json"
     status_payload = run_cli("--registry", str(registry_path), "status")
     status_item = status_payload["attention_queue"]["items"][0]
-    assert "Present the onboarding scan" in status_item["recommended_action"], status_item
-    assert "Present the onboarding scan" in status_item["project_asset"]["next_action"], status_item
+    user_todo_title = status_item["user_todos"]["items"][0]["title"]
+    assert "Choose which proposed onboarding agent todos" in status_item["recommended_action"], status_item
+    assert "Codex App heartbeat" in status_item["recommended_action"], status_item
+    assert "heartbeat=yes/no" in user_todo_title, status_item
+    assert "Codex App heartbeat" in status_item["project_asset"]["next_action"], status_item
+    assert "Codex App heartbeat" in status_item["active_state_next_action"], status_item
     assert status_item["user_todos"]["open_count"] == 1, status_item
     assert status_item["agent_todos"]["open_count"] == 1, status_item
 
     quota_payload = run_cli("--registry", str(registry_path), "quota", "should-run", "--goal-id", goal_id)
-    assert quota_payload["should_run"] is True, quota_payload
+    assert quota_payload["should_run"] is False, quota_payload
+    assert quota_payload["effective_action"] == "operator_gate_notify", quota_payload
     assert quota_payload["requires_user_action"] is True, quota_payload
-    assert "Present the onboarding scan" in quota_payload["recommended_action"], quota_payload
+    assert "Codex App heartbeat" in quota_payload["recommended_action"], quota_payload
+    assert "heartbeat=yes/no" in quota_payload["gate_prompt"], quota_payload
     assert quota_payload["user_todo_summary"]["open_count"] == 1, quota_payload
     assert quota_payload["agent_todo_summary"]["open_count"] == 1, quota_payload
 
@@ -128,9 +137,14 @@ def assert_default_onboarding(project: Path, runtime: Path) -> None:
     assert "## Proposed Onboarding Candidates" in text, text
     assert "Candidate agent todos: `requires user selection before delivery work`" in text, text
     assert "Autonomous advancement: `requires an explicit user yes/no choice`" in text, text
+    assert (
+        "Codex App heartbeat: `requires explicit heartbeat=yes/no before a recurring "
+        "Codex App automation is installed`" in text
+    ), text
     assert "## User Todo / Owner Review Reading Queue" in text, text
     assert "## Agent Todo" in text, text
-    assert "accepted numbers plus autonomous=yes/no" in text, text
+    assert "accepted numbers plus autonomous=yes/no plus heartbeat=yes/no" in text, text
+    assert "identity-scoped `loopx heartbeat-prompt --thin`" in text, text
 
     todos = parse_active_state_todos(text)
     user_items = todos.get("user_todos", {}).get("items", [])
@@ -157,14 +171,21 @@ def assert_preauthorized_onboarding(project: Path, runtime: Path) -> None:
         "README.md",
         "--accept-onboarding-agent-todos",
         "--begin-autonomous-advance",
+        "--codex-app-heartbeat",
+        "yes",
         "--no-global-sync",
     )
     assert payload["ok"] is True, payload
+    assert payload["codex_app_heartbeat"] == "yes", payload
     assert payload["onboarding_acceptance_required"] is False, payload
     assert payload["autonomous_advance_choice_required"] is False, payload
+    assert payload["heartbeat_opt_in_required"] is False, payload
+    assert payload["host_loop_activation_required"] is True, payload
+    assert "preauthorized" in payload["heartbeat_opt_in_instruction"], payload
     text = state_text(project, goal_id)
     assert "Candidate agent todos: `accepted and written into Agent Todo`" in text, text
     assert "Autonomous advancement: `allowed after accepted agent todos and a fresh quota guard`" in text, text
+    assert "Codex App heartbeat: `explicitly preauthorized" in text, text
     assert "Choose which proposed onboarding agent todos" not in text, text
 
     todos = parse_active_state_todos(text)
@@ -178,6 +199,58 @@ def assert_preauthorized_onboarding(project: Path, runtime: Path) -> None:
     assert "validation_plan" in kinds, agent_items
 
 
+def assert_autonomy_preauth_still_requires_heartbeat_choice(project: Path, runtime: Path) -> None:
+    goal_id = "onboarding-smoke-autonomy-with-heartbeat-gate"
+    payload = run_cli(
+        "--runtime-root",
+        str(runtime),
+        "bootstrap",
+        "--project",
+        str(project),
+        "--goal-id",
+        goal_id,
+        "--objective",
+        "Exercise autonomous preauthorization without heartbeat preauthorization.",
+        "--goal-doc",
+        "README.md",
+        "--accept-onboarding-agent-todos",
+        "--begin-autonomous-advance",
+        "--no-global-sync",
+    )
+    assert payload["ok"] is True, payload
+    assert payload["codex_app_heartbeat"] == "ask", payload
+    assert payload["onboarding_acceptance_required"] is False, payload
+    assert payload["autonomous_advance_choice_required"] is False, payload
+    assert payload["heartbeat_opt_in_required"] is True, payload
+    assert payload["host_loop_activation_required"] is True, payload
+    assert "heartbeat=yes" in payload["heartbeat_opt_in_instruction"], payload
+
+    registry_path = project / ".loopx" / "registry.json"
+    quota_payload = run_cli("--registry", str(registry_path), "quota", "should-run", "--goal-id", goal_id)
+    assert quota_payload["effective_action"] == "operator_gate_notify", quota_payload
+    assert quota_payload["normal_delivery_allowed"] is False, quota_payload
+    assert quota_payload["requires_user_action"] is True, quota_payload
+    assert quota_payload["interaction_contract"]["user_channel"]["notify"] == "NOTIFY", quota_payload
+    assert "heartbeat=yes/no" in quota_payload["gate_prompt"], quota_payload
+
+    text = state_text(project, goal_id)
+    assert "Candidate agent todos: `accepted and written into Agent Todo`" in text, text
+    assert "Autonomous advancement: `allowed after accepted agent todos and a fresh quota guard`" in text, text
+    assert (
+        "Codex App heartbeat: `requires explicit heartbeat=yes/no before a recurring "
+        "Codex App automation is installed`" in text
+    ), text
+    assert "reply with heartbeat=yes/no" in text, text
+    assert "identity-scoped `loopx heartbeat-prompt --thin`" in text, text
+
+    todos = parse_active_state_todos(text)
+    user_items = todos.get("user_todos", {}).get("items", [])
+    agent_items = todos["agent_todos"]["items"]
+    assert len(user_items) == 1, user_items
+    assert action_kinds(user_items) == {"onboarding_decision"}, user_items
+    assert "onboarding_todo_review" in action_kinds(agent_items), agent_items
+
+
 def main() -> int:
     with tempfile.TemporaryDirectory(prefix="loopx-onboarding-smoke-") as tmp:
         root = Path(tmp)
@@ -185,6 +258,7 @@ def main() -> int:
         project = make_project(root, "fixture-project")
         assert_default_onboarding(project, runtime)
         assert_preauthorized_onboarding(project, runtime)
+        assert_autonomy_preauth_still_requires_heartbeat_choice(project, runtime)
 
     print("onboarding-connect-candidates-smoke ok")
     return 0

--- a/loopx/bootstrap.py
+++ b/loopx/bootstrap.py
@@ -31,6 +31,29 @@ NO_CLONE_INSTALL_REPAIR_COMMAND = (
     'export PATH="$HOME/.local/bin:$PATH"\n'
     "loopx doctor"
 )
+HEARTBEAT_OPT_IN_STATUS_REQUIRED = (
+    "requires explicit heartbeat=yes/no before a recurring Codex App automation is installed"
+)
+HEARTBEAT_OPT_IN_STATUS_PREAUTHORIZED = (
+    "explicitly preauthorized; create or update the host loop before claiming recurring automation is active"
+)
+HEARTBEAT_OPT_IN_STATUS_DECLINED = (
+    "explicitly declined; keep the goal manual or on-demand unless the user later opts in"
+)
+HEARTBEAT_OPT_IN_INSTRUCTION = (
+    "Ask the user whether to enable the Codex App heartbeat. heartbeat=yes means create or update a recurring "
+    "Codex App automation from an identity-scoped `loopx heartbeat-prompt --thin` task body; heartbeat=no means "
+    "keep the goal manual or on-demand."
+)
+HEARTBEAT_OPT_IN_PREAUTHORIZED_INSTRUCTION = (
+    "The user preauthorized the Codex App heartbeat. Create or update the recurring automation from an "
+    "identity-scoped `loopx heartbeat-prompt --thin` task body before claiming recurring automation is active."
+)
+HEARTBEAT_OPT_IN_DECLINED_INSTRUCTION = (
+    "The user declined the Codex App heartbeat. Do not install recurring automation; keep the goal manual or "
+    "on-demand unless the user later opts in."
+)
+CODEX_APP_HEARTBEAT_CHOICES = {"ask", "yes", "no"}
 
 
 def slugify_goal_id(value: str) -> str:
@@ -83,11 +106,51 @@ def onboarding_candidates(onboarding_scan: dict[str, Any] | None) -> list[dict[s
     return [candidate for candidate in candidates if isinstance(candidate, dict)]
 
 
+def normalize_codex_app_heartbeat(value: str | None) -> str:
+    choice = (value or "ask").strip().lower()
+    if choice not in CODEX_APP_HEARTBEAT_CHOICES:
+        raise ValueError("codex_app_heartbeat must be one of: ask, yes, no")
+    return choice
+
+
+def heartbeat_opt_in_required(
+    *,
+    onboarding_scan: dict[str, Any] | None,
+    codex_app_heartbeat: str,
+) -> bool:
+    return bool(onboarding_scan and codex_app_heartbeat == "ask")
+
+
+def host_loop_activation_required(
+    *,
+    onboarding_scan: dict[str, Any] | None,
+    codex_app_heartbeat: str,
+) -> bool:
+    return bool(onboarding_scan and codex_app_heartbeat in {"ask", "yes"})
+
+
+def heartbeat_status(codex_app_heartbeat: str) -> str:
+    if codex_app_heartbeat == "yes":
+        return HEARTBEAT_OPT_IN_STATUS_PREAUTHORIZED
+    if codex_app_heartbeat == "no":
+        return HEARTBEAT_OPT_IN_STATUS_DECLINED
+    return HEARTBEAT_OPT_IN_STATUS_REQUIRED
+
+
+def heartbeat_instruction(codex_app_heartbeat: str) -> str | None:
+    if codex_app_heartbeat == "yes":
+        return HEARTBEAT_OPT_IN_PREAUTHORIZED_INSTRUCTION
+    if codex_app_heartbeat == "no":
+        return HEARTBEAT_OPT_IN_DECLINED_INSTRUCTION
+    return HEARTBEAT_OPT_IN_INSTRUCTION
+
+
 def render_onboarding_state_markdown(
     *,
     onboarding_scan: dict[str, Any] | None,
     accept_onboarding_agent_todos: bool,
     begin_autonomous_advance: bool,
+    codex_app_heartbeat: str,
 ) -> str:
     if not onboarding_scan:
         return ""
@@ -126,6 +189,7 @@ def render_onboarding_state_markdown(
         f"- Validation signal files: `{', '.join(validation_paths) or 'none'}`.",
         f"- Candidate agent todos: `{acceptance_status}`.",
         f"- Autonomous advancement: `{autonomous_status}`.",
+        f"- Codex App heartbeat: `{heartbeat_status(codex_app_heartbeat)}`.",
         "",
         "## Proposed Onboarding Candidates",
         "",
@@ -149,46 +213,48 @@ def onboarding_user_todo_text(
     *,
     acceptance_required: bool,
     autonomous_choice_required: bool,
+    heartbeat_choice_required: bool,
 ) -> str | None:
-    if acceptance_required and autonomous_choice_required:
-        return (
-            "[P1] Choose which proposed onboarding agent todos to accept and whether Codex may "
-            "start autonomous advancement; reply with accepted numbers plus autonomous=yes/no."
-        )
+    decisions: list[str] = []
+    reply_parts: list[str] = []
     if acceptance_required:
-        return (
-            "[P1] Choose which proposed onboarding agent todos to accept; autonomous advancement "
-            "is already allowed after accepted todos are written and quota permits."
-        )
+        decisions.append("which proposed onboarding agent todos to accept")
+        reply_parts.append("accepted numbers")
     if autonomous_choice_required:
-        return (
-            "[P1] Decide whether Codex may start autonomous advancement now that onboarding "
-            "agent todos were accepted; reply autonomous=yes/no."
-        )
-    return None
+        decisions.append("whether Codex may start autonomous advancement")
+        reply_parts.append("autonomous=yes/no")
+    if heartbeat_choice_required:
+        decisions.append("whether to enable the Codex App heartbeat")
+        reply_parts.append("heartbeat=yes/no")
+    if not decisions:
+        return None
+    verb = "Choose" if acceptance_required else "Decide"
+    return f"[P1] {verb} {' and '.join(decisions)}; reply with {' plus '.join(reply_parts)}."
 
 
 def onboarding_agent_review_todo_text(
     *,
     acceptance_required: bool,
     autonomous_choice_required: bool,
+    heartbeat_choice_required: bool,
 ) -> str | None:
-    if not acceptance_required and not autonomous_choice_required:
+    if not acceptance_required and not autonomous_choice_required and not heartbeat_choice_required:
         return None
-    if acceptance_required and autonomous_choice_required:
-        return (
-            "[P1] Present the onboarding scan, ask which candidate agent todos to accept, "
-            "and ask whether autonomous advancement may start before delivery work."
-        )
+    prompts: list[str] = []
     if acceptance_required:
-        return (
-            "[P1] Present the onboarding scan and ask which candidate agent todos to accept "
-            "before starting the pre-authorized autonomous advancement path."
+        prompts.append("which candidate agent todos to accept")
+    if autonomous_choice_required:
+        prompts.append("whether autonomous advancement may start")
+    if heartbeat_choice_required:
+        prompts.append("whether to enable the Codex App heartbeat")
+    prefix = "Present the onboarding scan and ask " if acceptance_required else "Ask "
+    text = f"[P1] {prefix}{', '.join(prompts)} before delivery work."
+    if heartbeat_choice_required:
+        text += (
+            " If heartbeat=yes, create or update the Codex App heartbeat from an identity-scoped "
+            "`loopx heartbeat-prompt --thin` task body before claiming recurring automation is active."
         )
-    return (
-        "[P1] Ask whether autonomous advancement may start from the accepted onboarding "
-        "agent todos before delivery work."
-    )
+    return text
 
 
 def onboarding_next_action(
@@ -196,23 +262,42 @@ def onboarding_next_action(
     onboarding_scan: dict[str, Any] | None,
     accept_onboarding_agent_todos: bool,
     begin_autonomous_advance: bool,
+    codex_app_heartbeat: str,
 ) -> str:
     if not onboarding_scan:
         return "Run `loopx check` against the project registry and decide the first project-specific adapter signal."
-    if not accept_onboarding_agent_todos:
-        if begin_autonomous_advance:
-            return (
-                "Ask the user which proposed onboarding agent todos to accept; once accepted, run the quota guard "
-                "and begin the first accepted todo because autonomous advancement was pre-authorized."
+    need_heartbeat_choice = codex_app_heartbeat == "ask"
+    if not accept_onboarding_agent_todos or not begin_autonomous_advance or need_heartbeat_choice:
+        asks: list[str] = []
+        if not accept_onboarding_agent_todos:
+            asks.append("which proposed onboarding agent todos to accept")
+        if not begin_autonomous_advance:
+            asks.append("whether Codex may start autonomous advancement")
+        if need_heartbeat_choice:
+            asks.append("whether to enable the Codex App heartbeat")
+        follow_up = "then write accepted choices and refresh state before delivery work."
+        heartbeat_follow_up = ""
+        if need_heartbeat_choice:
+            heartbeat_follow_up = (
+                " If heartbeat=yes, create or update the recurring automation from an identity-scoped "
+                "`loopx heartbeat-prompt --thin` task body."
             )
-        return (
-            "Show the proposed onboarding agent todos, ask which to accept, ask whether Codex may start autonomous "
-            "advancement, then write accepted todos and refresh state before any delivery work."
+        elif codex_app_heartbeat == "yes":
+            heartbeat_follow_up = (
+                " Create or update the preauthorized recurring automation from an identity-scoped "
+                "`loopx heartbeat-prompt --thin` task body."
+            )
+        autonomous_follow_up = (
+            " If autonomous=yes, run the quota guard and execute the first accepted onboarding agent todo."
+            if not begin_autonomous_advance
+            else " Run the quota guard and execute the first accepted onboarding agent todo once accepted choices permit."
         )
-    if not begin_autonomous_advance:
+        return f"Ask the user {', '.join(asks)}, {follow_up}{heartbeat_follow_up}{autonomous_follow_up}"
+    if codex_app_heartbeat == "yes":
         return (
-            "Ask whether Codex may start autonomous advancement; if yes, run the quota guard and execute the first "
-            "accepted onboarding agent todo, otherwise stop after refresh-state."
+            "Create or update the Codex App heartbeat from an identity-scoped `loopx heartbeat-prompt --thin` task "
+            "body, run the quota guard, execute the first accepted onboarding Agent Todo as a bounded segment, write "
+            "evidence, complete or update the todo, and refresh state."
         )
     return (
         "Run the quota guard, execute the first accepted onboarding Agent Todo as a bounded segment, write evidence, "
@@ -226,6 +311,7 @@ def apply_onboarding_todos_to_state(
     onboarding_scan: dict[str, Any] | None,
     accept_onboarding_agent_todos: bool,
     begin_autonomous_advance: bool,
+    codex_app_heartbeat: str,
 ) -> str:
     if not onboarding_scan:
         return text
@@ -245,9 +331,11 @@ def apply_onboarding_todos_to_state(
 
     acceptance_required = not accept_onboarding_agent_todos
     autonomous_choice_required = not begin_autonomous_advance
+    heartbeat_choice_required = codex_app_heartbeat == "ask"
     user_todo = onboarding_user_todo_text(
         acceptance_required=acceptance_required,
         autonomous_choice_required=autonomous_choice_required,
+        heartbeat_choice_required=heartbeat_choice_required,
     )
     if user_todo:
         add_todo_to_lines(
@@ -260,6 +348,7 @@ def apply_onboarding_todos_to_state(
     agent_todo = onboarding_agent_review_todo_text(
         acceptance_required=acceptance_required,
         autonomous_choice_required=autonomous_choice_required,
+        heartbeat_choice_required=heartbeat_choice_required,
     )
     if agent_todo:
         add_todo_to_lines(
@@ -283,6 +372,7 @@ def render_state_markdown(
     onboarding_scan: dict[str, Any] | None = None,
     accept_onboarding_agent_todos: bool = False,
     begin_autonomous_advance: bool = False,
+    codex_app_heartbeat: str = "ask",
 ) -> str:
     safe_objective = objective.replace('"', '\\"')
     profile_summary = execution_profile_summary(execution_profile)
@@ -290,12 +380,14 @@ def render_state_markdown(
         onboarding_scan=onboarding_scan,
         accept_onboarding_agent_todos=accept_onboarding_agent_todos,
         begin_autonomous_advance=begin_autonomous_advance,
+        codex_app_heartbeat=codex_app_heartbeat,
     )
     onboarding_block = f"\n{onboarding_markdown}\n" if onboarding_markdown else ""
     next_action = onboarding_next_action(
         onboarding_scan=onboarding_scan,
         accept_onboarding_agent_todos=accept_onboarding_agent_todos,
         begin_autonomous_advance=begin_autonomous_advance,
+        codex_app_heartbeat=codex_app_heartbeat,
     )
     state_text = f"""---
 status: active
@@ -353,6 +445,7 @@ adapter_id: {goal_id}
         onboarding_scan=onboarding_scan,
         accept_onboarding_agent_todos=accept_onboarding_agent_todos,
         begin_autonomous_advance=begin_autonomous_advance,
+        codex_app_heartbeat=codex_app_heartbeat,
     )
 
 
@@ -502,6 +595,7 @@ def bootstrap_project(
     onboarding_scan_enabled: bool = True,
     accept_onboarding_agent_todos: bool = False,
     begin_autonomous_advance: bool = False,
+    codex_app_heartbeat: str = "ask",
     onboarding_max_commits: int = 5,
     onboarding_max_status_paths: int = 12,
     onboarding_max_top_level_files: int = 24,
@@ -511,6 +605,7 @@ def bootstrap_project(
     allow_global_route_replacement: bool = False,
 ) -> dict[str, Any]:
     project = project.expanduser().resolve()
+    codex_app_heartbeat = normalize_codex_app_heartbeat(codex_app_heartbeat)
     registry_path = registry_path.expanduser()
     if not registry_path.is_absolute():
         registry_path = project / registry_path
@@ -594,6 +689,14 @@ def bootstrap_project(
         )
 
     candidates = onboarding_candidates(onboarding_scan)
+    heartbeat_required = heartbeat_opt_in_required(
+        onboarding_scan=onboarding_scan,
+        codex_app_heartbeat=codex_app_heartbeat,
+    )
+    host_loop_required = host_loop_activation_required(
+        onboarding_scan=onboarding_scan,
+        codex_app_heartbeat=codex_app_heartbeat,
+    )
     accept_candidate_commands = [
         todo_add_command(
             project=project,
@@ -643,8 +746,14 @@ def bootstrap_project(
                 "onboarding_agent_todo_candidates": candidates,
                 "accept_onboarding_agent_todos": accept_onboarding_agent_todos,
                 "begin_autonomous_advance": begin_autonomous_advance,
+                "codex_app_heartbeat": codex_app_heartbeat,
                 "onboarding_acceptance_required": bool(onboarding_scan and not accept_onboarding_agent_todos),
                 "autonomous_advance_choice_required": bool(onboarding_scan and not begin_autonomous_advance),
+                "heartbeat_opt_in_required": heartbeat_required,
+                "host_loop_activation_required": host_loop_required,
+                "heartbeat_opt_in_instruction": (
+                    heartbeat_instruction(codex_app_heartbeat) if onboarding_scan else None
+                ),
                 "onboarding_todos_written": False,
                 "accept_candidate_commands": accept_candidate_commands,
                 "global_sync": global_sync,
@@ -676,6 +785,7 @@ def bootstrap_project(
                     onboarding_scan=onboarding_scan,
                     accept_onboarding_agent_todos=accept_onboarding_agent_todos,
                     begin_autonomous_advance=begin_autonomous_advance,
+                    codex_app_heartbeat=codex_app_heartbeat,
                 ),
                 encoding="utf-8",
             )
@@ -705,8 +815,12 @@ def bootstrap_project(
         "onboarding_agent_todo_candidates": candidates,
         "accept_onboarding_agent_todos": accept_onboarding_agent_todos,
         "begin_autonomous_advance": begin_autonomous_advance,
+        "codex_app_heartbeat": codex_app_heartbeat,
         "onboarding_acceptance_required": bool(onboarding_scan and not accept_onboarding_agent_todos),
         "autonomous_advance_choice_required": bool(onboarding_scan and not begin_autonomous_advance),
+        "heartbeat_opt_in_required": heartbeat_required,
+        "host_loop_activation_required": host_loop_required,
+        "heartbeat_opt_in_instruction": heartbeat_instruction(codex_app_heartbeat) if onboarding_scan else None,
         "onboarding_todos_written": bool(
             onboarding_scan and state_action in {"created", "replaced"} and not dry_run
         ),
@@ -763,6 +877,9 @@ def render_bootstrap_markdown(payload: dict[str, Any]) -> str:
         f"- execution_profile: `{execution_profile_text}`",
         f"- onboarding_acceptance_required: `{payload.get('onboarding_acceptance_required')}`",
         f"- autonomous_advance_choice_required: `{payload.get('autonomous_advance_choice_required')}`",
+        f"- codex_app_heartbeat: `{payload.get('codex_app_heartbeat')}`",
+        f"- heartbeat_opt_in_required: `{payload.get('heartbeat_opt_in_required')}`",
+        f"- host_loop_activation_required: `{payload.get('host_loop_activation_required')}`",
         f"- onboarding_todos_written: `{payload.get('onboarding_todos_written')}`",
         f"- global_sync: `{(payload.get('global_sync') or {}).get('wrote')}`",
         "",
@@ -833,13 +950,18 @@ def render_bootstrap_markdown(payload: dict[str, Any]) -> str:
         lines.extend(
             [
                 "",
-                "## Autonomy Choice",
-                (
-                    "- Ask the user whether Codex may start autonomous advancement. If yes, run the quota guard "
-                    "and execute the first accepted Agent Todo; if no, stop after writing accepted todos and refresh-state."
-                ),
+                "## Autonomy And Heartbeat Choice",
             ]
         )
+        instruction = payload.get("heartbeat_opt_in_instruction")
+        if instruction:
+            lines.append(f"- heartbeat_opt_in_instruction: {instruction}")
+        if payload.get("autonomous_advance_choice_required"):
+            lines.append(
+                "- Ask the user whether Codex may start autonomous advancement. If autonomous=yes, run the quota "
+                "guard and execute the first accepted Agent Todo; if autonomous=no, stop after writing accepted todos "
+                "and refresh-state."
+            )
 
     lines.extend(["", "## Next Commands"])
     for command in payload.get("next_commands") or []:

--- a/loopx/cli_commands/bootstrap_connect.py
+++ b/loopx/cli_commands/bootstrap_connect.py
@@ -116,6 +116,15 @@ def register_bootstrap_connect_command(subparsers: argparse._SubParsersAction) -
         help="Record that Codex may begin from accepted onboarding agent todos after the quota guard permits work.",
     )
     bootstrap_parser.add_argument(
+        "--codex-app-heartbeat",
+        choices=["ask", "yes", "no"],
+        default="ask",
+        help=(
+            "Codex App recurring heartbeat choice for onboarding. Default ask creates a user gate; "
+            "yes/no records an explicit operator decision for headless setup."
+        ),
+    )
+    bootstrap_parser.add_argument(
         "--onboarding-max-commits",
         type=int,
         default=5,
@@ -194,6 +203,7 @@ def handle_bootstrap_connect_command(
             onboarding_scan_enabled=not bool(args.no_onboarding_scan),
             accept_onboarding_agent_todos=bool(args.accept_onboarding_agent_todos),
             begin_autonomous_advance=bool(args.begin_autonomous_advance),
+            codex_app_heartbeat=str(args.codex_app_heartbeat),
             onboarding_max_commits=args.onboarding_max_commits,
             onboarding_max_status_paths=args.onboarding_max_status_paths,
             onboarding_max_top_level_files=args.onboarding_max_top_level_files,


### PR DESCRIPTION
## Summary
- surface Codex App heartbeat opt-in as an explicit first-connect onboarding gate
- add bootstrap JSON/Markdown fields for heartbeat/host-loop activation requirements
- update onboarding smoke to require heartbeat=yes/no projection and operator-gate quota behavior

## Root Cause
New connect/bootstrap treated registry registration and quota visibility as sufficient setup evidence, but did not project the host-loop heartbeat decision as a concrete user gate. A newly connected agent could therefore report LoopX as connected and defer heartbeat installation instead of explicitly asking the user whether to enable recurring Codex App automation.

## Validation
- python3 -m py_compile loopx/bootstrap.py loopx/cli_commands/bootstrap_connect.py
- python3 -m py_compile loopx/bootstrap.py examples/onboarding-connect-candidates-smoke.py
- python3 examples/onboarding-connect-candidates-smoke.py
- git diff --check