### PR TITLE
Route side-agent waits to blocking review owner

### DIFF
--- a/docs/interaction-pattern-catalog.md
+++ b/docs/interaction-pattern-catalog.md
@@ -1524,7 +1524,8 @@ machine states:
 - `scope_exhausted`: no current-agent or unclaimed candidate matches the
   registered agent profile and boundary;
 - `primary_review_wait`: the remaining useful step is review, merge,
-  reassignment, or decision by the primary agent/controller;
+  reassignment, or decision by the primary agent/controller, or by the
+  explicitly claimed reviewer that blocks the current agent's handoff;
 - `reassignment_required`: useful work exists, but ownership must be changed
   before this agent may treat it as its lane.
 

--- a/examples/work-lane-contract-smoke.py
+++ b/examples/work-lane-contract-smoke.py
@@ -1179,6 +1179,63 @@ def assert_side_agent_waits_when_only_other_agent_has_claimed_work() -> None:
     assert "quiet_noop_allowed=True" in markdown, markdown
 
 
+def assert_side_agent_wait_mentions_blocking_review_owner() -> None:
+    primary_action = "[P0] Run SkillsBench matrix and record compact results."
+    review_action = (
+        "[P1-review] codex-side-bypass review the agent permission replay packet."
+    )
+    guard = build_quota_should_run(
+        status_payload(
+            status="value_explorer_side_bypass_review_wait",
+            next_action=primary_action,
+            coordination={
+                "primary_agent": "codex-main-control",
+                "registered_agents": [
+                    "codex-main-control",
+                    "codex-side-bypass",
+                    "codex-value-explorer",
+                ],
+            },
+            agent_todo_items=[
+                {
+                    "index": 1,
+                    "text": primary_action,
+                    "role": "agent",
+                    "status": "open",
+                    "priority": "P0",
+                    "task_class": "advancement_task",
+                    "claimed_by": "codex-main-control",
+                    "todo_id": "todo_primary_suite",
+                    "required_capabilities": ["shell"],
+                },
+                {
+                    "index": 2,
+                    "text": review_action,
+                    "role": "agent",
+                    "status": "open",
+                    "priority": "P1-review",
+                    "task_class": "advancement_task",
+                    "action_kind": "side_bypass_review_agent_permission_replay_packet",
+                    "claimed_by": "codex-side-bypass",
+                    "blocks_agent": "codex-value-explorer",
+                    "todo_id": "todo_side_bypass_review",
+                },
+            ],
+        ),
+        goal_id=GOAL_ID,
+        agent_id="codex-value-explorer",
+    )
+    assert guard["decision"] == "primary_review_wait", guard
+    assert guard["should_run"] is False, guard
+    frontier = guard["agent_scope_frontier"]
+    assert frontier["action"] == "primary_review_wait", frontier
+    assert frontier["blocking_review_claimants"] == ["codex-side-bypass"], frontier
+    assert frontier["candidate_counts"]["other_agent_claimed_advancement_count"] == 2
+    assert "codex-side-bypass" in guard["recommended_action"], guard
+    assert "codex-main-control" not in guard["recommended_action"], guard
+    assert "blocking handoff" in guard["interaction_contract"]["agent_channel"]["primary_action"], guard
+
+
 def assert_scoped_user_gate_does_not_steal_other_agent_fallback() -> None:
     gated_action = (
         "[P0] Sync the local long-horizon protocol packet into the approved "
@@ -1753,6 +1810,7 @@ def main() -> int:
     assert_launch_then_poll_todo_without_handle_routes_to_advancement()
     assert_side_agent_next_action_projects_without_stealing_goal_next_action()
     assert_side_agent_waits_when_only_other_agent_has_claimed_work()
+    assert_side_agent_wait_mentions_blocking_review_owner()
     assert_scoped_user_gate_does_not_steal_other_agent_fallback()
     assert_side_agent_replans_when_deferred_successor_is_ready()
     assert_side_agent_can_take_unclaimed_work()

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -2601,6 +2601,19 @@ def _agent_scope_no_candidate_frontier(
             if claimed_by
         }
     )
+    blocking_review_items = [
+        item
+        for item in other_advancement_items
+        if normalize_todo_claimed_by(item.get("blocks_agent")) == agent_id
+    ]
+    blocking_review_claimants = sorted(
+        {
+            claimed_by
+            for item in blocking_review_items
+            for claimed_by in [normalize_todo_claimed_by(item.get("claimed_by"))]
+            if claimed_by
+        }
+    )
     claim_scope = (
         agent_todo_summary.get("claim_scope")
         if isinstance(agent_todo_summary.get("claim_scope"), dict)
@@ -2608,21 +2621,34 @@ def _agent_scope_no_candidate_frontier(
     )
     primary_agent = normalize_todo_claimed_by(agent_identity.get("primary_agent"))
     if other_advancement_items:
-        action = (
-            AgentScopeFrontierAction.PRIMARY_REVIEW_WAIT
-            if primary_agent and primary_agent in other_claimants
-            else AgentScopeFrontierAction.REASSIGNMENT_REQUIRED
-        )
-        owner = primary_agent or ", ".join(other_claimants) or "the owning agent"
-        reason = (
-            f"current side-agent {agent_id} has no current/unclaimed advancement "
-            f"candidate; visible advancement work is claimed by {owner}"
-        )
-        recommended_action = (
-            f"Keep {agent_id} active but quiet: wait for {owner} to review, merge, "
-            "reassign, or create a concrete current-agent/unclaimed advancement todo "
-            "before delivery."
-        )
+        if blocking_review_claimants:
+            action = AgentScopeFrontierAction.PRIMARY_REVIEW_WAIT
+            owner = ", ".join(blocking_review_claimants)
+            reason = (
+                f"current side-agent {agent_id} has no current/unclaimed advancement "
+                f"candidate; blocking review work is claimed by {owner}"
+            )
+            recommended_action = (
+                f"Keep {agent_id} active but quiet: wait for {owner} to review the "
+                "blocking handoff, reassign it, or create a concrete current-agent/"
+                "unclaimed advancement todo before delivery."
+            )
+        else:
+            action = (
+                AgentScopeFrontierAction.PRIMARY_REVIEW_WAIT
+                if primary_agent and primary_agent in other_claimants
+                else AgentScopeFrontierAction.REASSIGNMENT_REQUIRED
+            )
+            owner = primary_agent or ", ".join(other_claimants) or "the owning agent"
+            reason = (
+                f"current side-agent {agent_id} has no current/unclaimed advancement "
+                f"candidate; visible advancement work is claimed by {owner}"
+            )
+            recommended_action = (
+                f"Keep {agent_id} active but quiet: wait for {owner} to review, merge, "
+                "reassign, or create a concrete current-agent/unclaimed advancement todo "
+                "before delivery."
+            )
     else:
         action = AgentScopeFrontierAction.AGENT_SCOPE_EXHAUSTED
         reason = (
@@ -2654,6 +2680,7 @@ def _agent_scope_no_candidate_frontier(
             ),
         },
         "other_claimants": other_claimants,
+        "blocking_review_claimants": blocking_review_claimants,
         "other_agent_claimed_items": [
             _compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
             for item in other_advancement_items[:3]


### PR DESCRIPTION
## Summary
- Prefer explicit blocking review owners when a side agent has no in-scope candidate and another agent todo has blocks_agent=<current agent>.
- Keep ordinary primary-review wait behavior unchanged when there is no blocking review gate.
- Add a work-lane smoke for value-explorer waiting on codex-side-bypass instead of defaulting the message to codex-main-control.

## Validation
- python3 examples/work-lane-contract-smoke.py
- python3 -m py_compile loopx/quota.py examples/work-lane-contract-smoke.py
- python3 -m compileall -q loopx
- PYTHONPATH=. python3 -m loopx.cli --format json --registry "/Users/bytedance/.codex/loopx/registry.global.json" quota should-run --goal-id loopx-meta --agent-id codex-value-explorer | jq '{should_run,effective_action,reason,recommended_action,blocking_claimants:(.agent_scope_frontier.blocking_review_claimants // null)}'
- git diff --check
- loopx check --scan-path loopx/quota.py --scan-path examples/work-lane-contract-smoke.py

## Boundary
- Public code + durable smoke only.
- No private state, raw logs, credentials, local artifact paths, or production actions.