### PR TITLE
Fix SkillsBench host-local ACP connect contract

### DIFF
--- a/examples/skillsbench-host-local-launch-plan-smoke.py
+++ b/examples/skillsbench-host-local-launch-plan-smoke.py
@@ -52,6 +52,10 @@ def main() -> int:
     assert "def _filter_kwargs_for_signature(" in source
     assert "getattr(\n        benchflow_rollout_module, \"connect_acp\", _MISSING" in source
     assert "if original_rollout_connect_acp is not _MISSING:" in source
+    assert "from benchflow.agents.protocol import ACPSessionAdapter" in source
+    assert ") -> tuple[Any, Any, Any, str]:" in source
+    assert "session_adapter = ACPSessionAdapter(client)" in source
+    assert "return client, session, session_adapter, agent_name" in source
     assert "_filter_kwargs_for_signature(RolloutConfig, rollout_config_kwargs)" in source
     assert "env=target_env" in source
     assert "local_acp_command = _set_option_value(" in source
@@ -282,6 +286,7 @@ if out:
                 local_codex_bin="codex",
                 local_codex_exec_timeout_sec=7200,
                 local_codex_sandbox="workspace-write",
+                max_rounds=24,
                 model=None,
                 remote_command_file_bridge_probe=False,
                 remote_command_file_bridge_probe_timeout_sec=5.0,
@@ -289,6 +294,7 @@ if out:
                 remote_command_file_bridge_agent_command=None,
                 remote_command_file_bridge_solver_command=None,
                 route="loopx-product-mode",
+                sandbox="docker",
                 task_id="demo-task",
             ),
             {"host_local_acp_relay_trace_dir": str(Path(tmp) / "trace")},

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -5947,7 +5947,7 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
         reasoning_effort: str | None = None,
         mcp_servers: list[Any] | None = None,
         **_ignored: Any,
-    ) -> tuple[Any, Any, str]:
+    ) -> tuple[Any, Any, Any, str]:
         del (
             agent_launch,
             sandbox_user,
@@ -5957,6 +5957,7 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
         )
         from benchflow.acp.client import ACPClient
         from benchflow.acp.transport import StdioTransport
+        from benchflow.agents.protocol import ACPSessionAdapter
 
         prerequisites = plan.setdefault("runner_prerequisites", {})
         prerequisites["host_local_acp_launch_status"] = "connecting"
@@ -6024,6 +6025,7 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
             )
             if model:
                 await asyncio.wait_for(client.set_model(model), timeout=60)
+            session_adapter = ACPSessionAdapter(client)
             prerequisites["host_local_acp_launch_status"] = "connected"
             if isinstance(controller_trace, dict):
                 controller_trace["native_goal_worker_route"] = (
@@ -6036,7 +6038,7 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
                 controller_trace["last_decision"] = (
                     "host_app_server_goal_worker_connected"
                 )
-            return client, session, agent_name
+            return client, session, session_adapter, agent_name
         except Exception:
             prerequisites["host_local_acp_launch_status"] = "failed"
             with contextlib.suppress(Exception):


### PR DESCRIPTION
## Summary
- update the SkillsBench host-local ACP connector to return the current BenchFlow four-value connect tuple
- wrap the ACP client in BenchFlow's ACPSessionAdapter so rollout can use the session contract
- add launch-plan smoke assertions for the connect tuple contract and refresh the fake args fixture

## Why
A latest-main SkillsBench loopx-product-mode run reached host-local ACP, passed reverse-channel preflight, then failed before agent/tool execution with `not enough values to unpack (expected 4, got 3)`. BenchFlow now expects `(client, session, session_adapter, agent_name)` from `connect_acp`; LoopX's host-local override still returned the old three-value tuple.

## Validation
- `python3 -m py_compile scripts/skillsbench_automation_loop.py`
- `python3 examples/skillsbench-host-local-launch-plan-smoke.py`
- `git diff --check`

No raw benchmark logs, trajectories, verifier output, credentials, or local/private paths are included.