### PR TITLE
Add GitHub reply monitor value connector

### DIFF
--- a/docs/capabilities/value-connectors/README.md
+++ b/docs/capabilities/value-connectors/README.md
@@ -36,15 +36,29 @@ loopx value-connectors github-public-probe \
   --format json
 ```
 
+Monitor whether a public maintainer replied after an approved LoopX comment:
+
+```bash
+loopx value-connectors github-reply-monitor \
+  --issue-url https://github.com/owner/repo/issues/1 \
+  --after-comment-url https://github.com/owner/repo/issues/1#issuecomment-123 \
+  --fetch-metadata \
+  --format json
+```
+
 The probe is intentionally metadata-only. It does not read issue bodies,
 comment bodies, timelines, raw provider payloads, auth material, or local paths,
 and it cannot post comments, send messages, create accounts, or publish.
+The reply monitor follows the same boundary: it only captures comment author,
+association, timestamp, and URL metadata, then emits either
+`prepare_public_triage_note` or `wait_no_bump`.
 
 ## Connector Profiles
 
 | Connector | Current state | User can run now | External write behavior |
 | --- | --- | --- | --- |
 | `github_public_channel` | implemented starter | yes | none |
+| `github_public_reply_monitor` | implemented starter | yes | none |
 | `botmail_identity` | host connector profile | install-check only | exact send gate required |
 | `community_channel` | host/browser connector profile | install-check and plan | exact account/message gate required |
 

--- a/docs/reference/protocols/value-connector-plan-v0.md
+++ b/docs/reference/protocols/value-connector-plan-v0.md
@@ -40,6 +40,17 @@ loopx value-connectors github-public-probe \
   --format json
 ```
 
+Detect public maintainer interest after an approved LoopX comment without
+reading comment bodies or bumping the thread:
+
+```bash
+loopx value-connectors github-reply-monitor \
+  --issue-url https://github.com/owner/repo/issues/1 \
+  --after-comment-url https://github.com/owner/repo/issues/1#issuecomment-123 \
+  --fetch-metadata \
+  --format json
+```
+
 Plan a gated external write or account setup before any connector performs it:
 
 ```bash
@@ -64,6 +75,7 @@ loopx value-connectors plan \
 | `connector_call_intent_v0` | One planned connector call with channel, stage, access mode, value axis, metric, success metric, and kill condition. |
 | `connector_approval_gate_v0` | Exact-call approval gate for account setup, external writes, sends, publishing, or private expansion. |
 | `github_public_channel_probe_packet_v0` | Starter connector output for public GitHub issue/PR/discussion metadata. |
+| `github_public_reply_monitor_packet_v0` | Starter connector output for public maintainer reply detection after a LoopX comment. |
 | `value_connector_install_check_packet_v0` | Local install/use checklist for connector starters. |
 
 ## Boundaries
@@ -92,6 +104,12 @@ timeline events, raw provider payloads, auth material, or local paths.
 For discussion URLs, `--fetch-metadata` uses GitHub CLI GraphQL when `gh` is
 installed and authenticated. Without `gh`, users can still run no-fetch mode or
 use `install-check` to see the missing dependency.
+
+`github_public_reply_monitor` accepts a public issue or PR URL and an anchor
+issue-comment URL. Its live mode uses GitHub CLI REST metadata and captures only
+comment author, author association, timestamps, and URL. It detects whether a
+public maintainer/member/collaborator replied after the LoopX comment and
+returns `prepare_public_triage_note`; otherwise it returns `wait_no_bump`.
 
 ## User Value
 

--- a/examples/value-connectors-github-public-probe-smoke.py
+++ b/examples/value-connectors-github-public-probe-smoke.py
@@ -4,9 +4,11 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -17,6 +19,7 @@ if str(REPO_ROOT) not in sys.path:
 
 from loopx.capabilities.value_connectors.github_public import (  # noqa: E402
     GITHUB_PUBLIC_CHANNEL_PROBE_PACKET_SCHEMA_VERSION,
+    GITHUB_PUBLIC_REPLY_MONITOR_PACKET_SCHEMA_VERSION,
     VALUE_CONNECTOR_INSTALL_CHECK_PACKET_SCHEMA_VERSION,
 )
 from loopx.capabilities.value_connectors.planner import (  # noqa: E402
@@ -35,10 +38,11 @@ PRIVATE_PATTERNS = [
 
 FORBIDDEN_VALUES = [
     "raw provider payload",
-    "comment body text",
-    "issue body text",
-    "restricted-value",
-    "sensitive-value",
+        "comment body text",
+        "comment body that must stay gated",
+        "issue body text",
+        "restricted-value",
+        "sensitive-value",
 ]
 
 
@@ -55,11 +59,17 @@ def assert_public_safe(payload: dict[str, Any] | str) -> None:
     assert not leaked, leaked
 
 
-def run_cli(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+def run_cli(
+    args: list[str],
+    *,
+    check: bool = True,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [sys.executable, "-m", "loopx.cli", *args],
         cwd=REPO_ROOT,
         check=check,
+        env=env,
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -98,6 +108,112 @@ def main() -> int:
     assert probe["metadata"] is None, probe
     assert probe["connector_call"]["money_metric"], probe
     assert_public_safe(probe)
+
+    reply_provider = {
+        "comments": [
+            {
+                "author": "loopx-operator",
+                "author_association": "NONE",
+                "created_at": "2026-06-25T06:54:50Z",
+                "updated_at": "2026-06-25T06:54:50Z",
+                "url": "https://github.com/huangruiteng/loopx/issues/670#issuecomment-1",
+                "body": "comment body that must stay gated",
+                "raw": "raw provider payload",
+            },
+            {
+                "author": "maintainer-one",
+                "author_association": "MEMBER",
+                "created_at": "2026-06-25T07:10:00Z",
+                "updated_at": "2026-06-25T07:10:00Z",
+                "url": "https://github.com/huangruiteng/loopx/issues/670#issuecomment-2",
+                "body": "comment body text",
+            },
+        ]
+    }
+    with tempfile.TemporaryDirectory() as tmpdir:
+        reply_path = Path(tmpdir) / "reply-comments.json"
+        reply_path.write_text(json.dumps(reply_provider), encoding="utf-8")
+        reply_monitor = json.loads(
+            run_cli(
+                [
+                    "--format",
+                    "json",
+                    "value-connectors",
+                    "github-reply-monitor",
+                    "--issue-url",
+                    "https://github.com/huangruiteng/loopx/issues/670",
+                    "--after-comment-url",
+                    "https://github.com/huangruiteng/loopx/issues/670#issuecomment-1",
+                    "--metadata-json",
+                    str(reply_path),
+                ]
+            ).stdout
+        )
+    assert reply_monitor["ok"] is True, reply_monitor
+    assert reply_monitor["schema_version"] == GITHUB_PUBLIC_REPLY_MONITOR_PACKET_SCHEMA_VERSION
+    assert reply_monitor["external_reads_performed"] is False, reply_monitor
+    assert reply_monitor["external_writes_performed"] is False, reply_monitor
+    assert reply_monitor["comment_bodies_captured"] is False, reply_monitor
+    assert reply_monitor["raw_provider_payload_captured"] is False, reply_monitor
+    assert reply_monitor["maintainer_reply_count"] == 1, reply_monitor
+    assert reply_monitor["money_signal"] == "public_maintainer_interest", reply_monitor
+    assert reply_monitor["recommended_action"] == "prepare_public_triage_note", reply_monitor
+    assert reply_monitor["validation"]["gated_provider_field_count"] == 3, reply_monitor
+    assert_public_safe(reply_monitor)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        fake_bin = Path(tmpdir)
+        gh = fake_bin / "gh"
+        gh.write_text(
+            "\n".join(
+                [
+                    "#!/usr/bin/env python3",
+                    "import json",
+                    "import sys",
+                    "argv = sys.argv[1:]",
+                    "assert argv[:2] == ['api', '-H'], argv",
+                    "assert 'repos/huangruiteng/loopx/issues/670/comments?per_page=100' in argv, argv",
+                    "assert '--jq' in argv, argv",
+                    "json.dump([",
+                    "  {",
+                    "    'author': 'loopx-operator',",
+                    "    'author_association': 'NONE',",
+                    "    'created_at': '2026-06-25T06:54:50Z',",
+                    "    'updated_at': '2026-06-25T06:54:50Z',",
+                    "    'url': 'https://github.com/huangruiteng/loopx/issues/670#issuecomment-1',",
+                    "  }",
+                    "], sys.stdout)",
+                    "sys.stdout.write('\\n')",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        gh.chmod(0o755)
+        live_env = {**os.environ, "PATH": f"{fake_bin}:{os.environ.get('PATH', '')}"}
+        live_reply_monitor = json.loads(
+            run_cli(
+                [
+                    "--format",
+                    "json",
+                    "value-connectors",
+                    "github-reply-monitor",
+                    "--issue-url",
+                    "https://github.com/huangruiteng/loopx/issues/670",
+                    "--after-comment-url",
+                    "https://github.com/huangruiteng/loopx/issues/670#issuecomment-1",
+                    "--fetch-metadata",
+                ],
+                env=live_env,
+            ).stdout
+        )
+    assert live_reply_monitor["ok"] is True, live_reply_monitor
+    assert live_reply_monitor["external_reads_performed"] is True, live_reply_monitor
+    assert live_reply_monitor["external_writes_performed"] is False, live_reply_monitor
+    assert live_reply_monitor["maintainer_reply_count"] == 0, live_reply_monitor
+    assert live_reply_monitor["recommended_action"] == "wait_no_bump", live_reply_monitor
+    assert live_reply_monitor["comment_bodies_captured"] is False, live_reply_monitor
+    assert live_reply_monitor["validation"]["anchor_found"] is True, live_reply_monitor
+    assert_public_safe(live_reply_monitor)
 
     plan = json.loads(
         run_cli(["--format", "json", "value-connectors", "plan"]).stdout
@@ -162,6 +278,24 @@ def main() -> int:
     assert rejected_payload["schema_version"] == "github_public_channel_probe_error_v0", rejected_payload
     assert "query or fragment" in rejected_payload["error"], rejected_payload
 
+    rejected_reply = run_cli(
+        [
+            "--format",
+            "json",
+            "value-connectors",
+            "github-reply-monitor",
+            "--issue-url",
+            "https://github.com/owner/repo/issues/1",
+            "--after-comment-url",
+            "https://github.com/owner/repo/issues/1#issuecomment-1?x=sensitive-value",
+        ],
+        check=False,
+    )
+    assert rejected_reply.returncode == 1, rejected_reply
+    rejected_reply_payload = json.loads(rejected_reply.stdout)
+    assert rejected_reply_payload["ok"] is False, rejected_reply_payload
+    assert rejected_reply_payload["schema_version"] == "github_public_reply_monitor_error_v0"
+
     rejected_markdown = run_cli(
         [
             "value-connectors",
@@ -186,6 +320,20 @@ def main() -> int:
     assert "LoopX GitHub Public Channel Probe" in markdown, markdown
     assert "external_writes_performed: `False`" in markdown, markdown
     assert_public_safe(markdown)
+
+    reply_markdown = run_cli(
+        [
+            "value-connectors",
+            "github-reply-monitor",
+            "--issue-url",
+            "https://github.com/huangruiteng/loopx/issues/670",
+            "--after-comment-url",
+            "https://github.com/huangruiteng/loopx/issues/670#issuecomment-1",
+        ]
+    ).stdout
+    assert "LoopX GitHub Public Reply Monitor" in reply_markdown, reply_markdown
+    assert "recommended_action: `wait_no_bump`" in reply_markdown, reply_markdown
+    assert_public_safe(reply_markdown)
 
     print("value-connectors-github-public-probe-smoke: ok")
     return 0

--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -217,6 +217,11 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
                 "write_boundary": "public metadata read only; no comments, PRs, account changes, or writes",
             },
             {
+                "command": "loopx value-connectors github-reply-monitor --issue-url <github-issue-or-pr-url> --after-comment-url <github-issue-comment-url> --fetch-metadata --format json",
+                "purpose": "Detect public maintainer replies after a LoopX comment without capturing comment bodies.",
+                "write_boundary": "public comment metadata read only; no comment bodies, thread bump, or external write",
+            },
+            {
                 "command": "loopx value-connectors plan --connector-id <id> ... --format json",
                 "purpose": "Plan gated account setup, external replies, sends, or future connector calls.",
                 "write_boundary": "plan-only; external writes and account setup require exact approval",
@@ -244,6 +249,11 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
                 "doc": "docs/reference/protocols/value-connector-plan-v0.md",
             },
             {
+                "schema_version": "github_public_reply_monitor_packet_v0",
+                "module": "loopx.capabilities.value_connectors.github_public",
+                "doc": "docs/reference/protocols/value-connector-plan-v0.md",
+            },
+            {
                 "schema_version": "value_connector_install_check_packet_v0",
                 "module": "loopx.capabilities.value_connectors.github_public",
                 "doc": "docs/reference/protocols/value-connector-plan-v0.md",
@@ -258,12 +268,13 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
         ],
         "boundaries": [
             "The GitHub starter copies allowlisted public metadata only, not bodies, comments, timelines, raw provider payloads, auth material, or local paths.",
+            "The reply monitor reads or accepts comment metadata only: author, association, timestamps, and URL; it never bumps a thread.",
             "Account signup, email sends, community posts, public replies, private reads, paid services, and production actions remain gated exact-call actions.",
             "Every connector call must include a money, cost, demand, or capability metric plus a kill condition.",
         ],
         "next_real_step": (
-            "Add one more executable starter, such as a reply monitor or host-email "
-            "send-gate adapter, while keeping exact external writes outside LoopX core."
+            "Use reply-monitor signals to graduate only explicit maintainer interest "
+            "into public triage notes or paid-path discovery; otherwise stop without bumps."
         ),
     },
 )

--- a/loopx/capabilities/value_connectors/cli.py
+++ b/loopx/capabilities/value_connectors/cli.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
 import argparse
+import json
+import sys
 from collections.abc import Callable
+from pathlib import Path
 
 from .github_public import (
     build_github_public_channel_probe_packet,
+    build_github_public_reply_monitor_packet,
     build_value_connector_install_check_packet,
     render_github_public_channel_probe_markdown,
+    render_github_public_reply_monitor_markdown,
     render_value_connector_install_check_markdown,
 )
 from .planner import (
@@ -26,6 +31,16 @@ PrintPayload = Callable[
 ]
 FormatSelector = Callable[..., str]
 AddFormat = Callable[[argparse.ArgumentParser], None]
+
+
+def _load_json_object_or_array(path_text: str) -> dict[str, object] | list[object]:
+    if path_text == "-":
+        payload = json.loads(sys.stdin.read())
+    else:
+        payload = json.loads(Path(path_text).expanduser().read_text(encoding="utf-8"))
+    if not isinstance(payload, (dict, list)):
+        raise ValueError(f"{path_text} must contain a JSON object or array")
+    return payload
 
 
 def register_value_connector_commands(
@@ -140,6 +155,49 @@ def register_value_connector_commands(
         default=10.0,
         help="Network/tool timeout for --fetch-metadata.",
     )
+    reply_monitor_parser = sub.add_parser(
+        "github-reply-monitor",
+        help=(
+            "Detect new public maintainer replies after a LoopX issue comment "
+            "without capturing comment bodies."
+        ),
+    )
+    add_subcommand_format(reply_monitor_parser)
+    reply_monitor_parser.add_argument(
+        "--issue-url",
+        required=True,
+        help="Public GitHub issue or PR URL being monitored.",
+    )
+    reply_monitor_parser.add_argument(
+        "--after-comment-url",
+        required=True,
+        help=(
+            "Public GitHub issue comment URL that anchors the monitor window, "
+            "for example https://github.com/owner/repo/issues/1#issuecomment-123."
+        ),
+    )
+    reply_monitor_parser.add_argument(
+        "--metadata-json",
+        default=None,
+        help=(
+            "Path to mocked provider comment metadata JSON, or '-' for stdin. "
+            "Body/raw fields stay gated and are not copied."
+        ),
+    )
+    reply_monitor_parser.add_argument(
+        "--fetch-metadata",
+        action="store_true",
+        help=(
+            "Use gh api to fetch public issue-comment metadata only: author, "
+            "association, timestamps, and URL. Comment bodies are not output."
+        ),
+    )
+    reply_monitor_parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=10.0,
+        help="Network/tool timeout for --fetch-metadata.",
+    )
 
 
 def handle_value_connector_command(
@@ -173,8 +231,29 @@ def handle_value_connector_command(
                 render_github_public_channel_probe_markdown,
             )
             return 0 if payload.get("ok") else 1
+        if args.value_connectors_command == "github-reply-monitor":
+            if args.fetch_metadata and args.metadata_json:
+                raise ValueError("--fetch-metadata cannot be combined with --metadata-json")
+            payload = build_github_public_reply_monitor_packet(
+                issue_url=args.issue_url,
+                after_comment_url=args.after_comment_url,
+                provider_payload=_load_json_object_or_array(args.metadata_json)
+                if args.metadata_json
+                else None,
+                fetch_metadata=args.fetch_metadata,
+                timeout_seconds=args.timeout_seconds,
+            )
+            print_payload(
+                payload,
+                output_format(args),
+                render_github_public_reply_monitor_markdown,
+            )
+            return 0 if payload.get("ok") else 1
         if args.value_connectors_command != "plan":
-            raise ValueError("value-connectors requires `install-check`, `plan`, or `github-public-probe`")
+            raise ValueError(
+                "value-connectors requires `install-check`, `plan`, "
+                "`github-public-probe`, or `github-reply-monitor`"
+            )
         if args.connector_id:
             missing = [
                 name
@@ -225,6 +304,17 @@ def handle_value_connector_command(
                 "external_writes_performed": False,
             }
             print_payload(payload, output_format(args), render_github_public_channel_probe_markdown)
+            return 1
+        if getattr(args, "value_connectors_command", None) == "github-reply-monitor":
+            payload = {
+                "ok": False,
+                "schema_version": "github_public_reply_monitor_error_v0",
+                "mode": "github-public-reply-monitor",
+                "error": str(exc),
+                "external_reads_performed": False,
+                "external_writes_performed": False,
+            }
+            print_payload(payload, output_format(args), render_github_public_reply_monitor_markdown)
             return 1
         payload = {"ok": False, "schema_version": "value_connector_plan_error_v0", "error": str(exc)}
         print_payload(payload, output_format(args), render_value_connector_plan_markdown)

--- a/loopx/capabilities/value_connectors/github_public.py
+++ b/loopx/capabilities/value_connectors/github_public.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import shutil
 import subprocess
+from datetime import datetime, timezone
 from collections.abc import Mapping
 from typing import Any
 from urllib.error import HTTPError, URLError
@@ -15,11 +16,25 @@ GITHUB_PUBLIC_CHANNEL_PROBE_PACKET_SCHEMA_VERSION = (
 )
 GITHUB_PUBLIC_CHANNEL_REF_SCHEMA_VERSION = "github_public_channel_ref_v0"
 GITHUB_PUBLIC_CHANNEL_METADATA_SCHEMA_VERSION = "github_public_channel_metadata_v0"
+GITHUB_PUBLIC_REPLY_MONITOR_PACKET_SCHEMA_VERSION = (
+    "github_public_reply_monitor_packet_v0"
+)
+GITHUB_PUBLIC_REPLY_SIGNAL_SCHEMA_VERSION = "github_public_reply_signal_v0"
 VALUE_CONNECTOR_INSTALL_CHECK_PACKET_SCHEMA_VERSION = (
     "value_connector_install_check_packet_v0"
 )
 
 ALLOWED_GITHUB_REF_TYPES = {"issue", "pull", "discussion"}
+MAINTAINER_ASSOCIATIONS = {"COLLABORATOR", "MEMBER", "OWNER"}
+GITHUB_COMMENT_BODY_KEYS = {
+    "body",
+    "body_text",
+    "comment_body",
+    "comment_bodies",
+    "raw",
+    "response_payload",
+    "timeline",
+}
 
 
 def _normalise_github_url(url: str) -> tuple[str, dict[str, Any]]:
@@ -61,6 +76,46 @@ def _normalise_github_url(url: str) -> tuple[str, dict[str, Any]]:
         "ref_type": ref_type,
         "number": number,
         "url": normalised,
+    }
+
+
+def _normalise_github_issue_comment_url(url: str) -> tuple[str, dict[str, Any]]:
+    text = str(url or "").strip()
+    parsed = urlsplit(text)
+    if parsed.scheme != "https":
+        raise ValueError("GitHub issue comment URL must use https")
+    if parsed.username or parsed.password:
+        raise ValueError("GitHub issue comment URL must not include auth material")
+    if parsed.query:
+        raise ValueError("GitHub issue comment URL must not include query data")
+    if parsed.hostname != "github.com":
+        raise ValueError("GitHub issue comment URL must target github.com")
+    if parsed.port not in (None, 443):
+        raise ValueError("GitHub issue comment URL must use the default https port")
+    if not parsed.fragment.startswith("issuecomment-"):
+        raise ValueError("GitHub issue comment URL must include an issuecomment fragment")
+    raw_comment_id = parsed.fragment.removeprefix("issuecomment-")
+    try:
+        comment_id = int(raw_comment_id)
+    except ValueError as exc:
+        raise ValueError("GitHub issue comment id must be an integer") from exc
+    issue_url, issue_ref = _normalise_github_url(
+        urlunsplit((parsed.scheme, parsed.netloc, parsed.path, "", ""))
+    )
+    if issue_ref["ref_type"] not in {"issue", "pull"}:
+        raise ValueError("GitHub issue comment URL must point at an issue or pull request")
+    normalised_comment_url = urlunsplit(
+        ("https", "github.com", urlsplit(issue_url).path, "", f"issuecomment-{comment_id}")
+    )
+    return normalised_comment_url, {
+        "schema_version": "github_public_issue_comment_ref_v0",
+        "owner": issue_ref["owner"],
+        "repo": issue_ref["repo"],
+        "ref_type": issue_ref["ref_type"],
+        "number": issue_ref["number"],
+        "comment_id": comment_id,
+        "issue_url": issue_url,
+        "comment_url": normalised_comment_url,
     }
 
 
@@ -185,6 +240,270 @@ query($owner:String!, $repo:String!, $number:Int!) {
     }
 
 
+def _fetch_issue_comment_metadata(
+    ref: Mapping[str, Any],
+    *,
+    timeout_seconds: float,
+) -> dict[str, Any]:
+    gh = shutil.which("gh")
+    if not gh:
+        raise RuntimeError("reply monitor metadata fetch requires GitHub CLI `gh`")
+    endpoint = f"repos/{ref['owner']}/{ref['repo']}/issues/{ref['number']}/comments?per_page=100"
+    jq_filter = (
+        "[.[] | {"
+        "author: .user.login, "
+        "author_association: .author_association, "
+        "created_at: .created_at, "
+        "updated_at: .updated_at, "
+        "url: .html_url"
+        "}]"
+    )
+    result = subprocess.run(
+        [
+            gh,
+            "api",
+            "-H",
+            "Accept: application/vnd.github+json",
+            endpoint,
+            "--jq",
+            jq_filter,
+        ],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=timeout_seconds,
+    )
+    if result.returncode != 0:
+        raise RuntimeError("gh issue comments metadata request failed")
+    comments = json.loads(result.stdout)
+    if not isinstance(comments, list):
+        raise RuntimeError("issue comments metadata must be a JSON array")
+    return {"comments": comments}
+
+
+def _parse_github_timestamp(value: Any) -> datetime | None:
+    if not value:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _comment_author(value: Any) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()[:120]
+    if isinstance(value, Mapping):
+        login = value.get("login")
+        if isinstance(login, str) and login.strip():
+            return login.strip()[:120]
+    return None
+
+
+def _comment_url(value: Any) -> str | None:
+    if not value:
+        return None
+    text = str(value).strip()
+    parsed = urlsplit(text)
+    if parsed.scheme != "https" or parsed.hostname != "github.com":
+        return None
+    if parsed.username or parsed.password or parsed.query:
+        return None
+    return urlunsplit(("https", "github.com", parsed.path, "", parsed.fragment))
+
+
+def _provider_comments(provider_payload: Mapping[str, Any] | list[Any] | None) -> list[Any]:
+    if isinstance(provider_payload, list):
+        return list(provider_payload)
+    if not isinstance(provider_payload, Mapping):
+        return []
+    comments = provider_payload.get("comments")
+    if isinstance(comments, list):
+        return list(comments)
+    return []
+
+
+def _normalise_comment_signal(
+    item: Any,
+    *,
+    anchor_url: str,
+    anchor_created_at: datetime | None,
+) -> dict[str, Any] | None:
+    if not isinstance(item, Mapping):
+        return None
+    url = _comment_url(item.get("url") or item.get("html_url"))
+    created_at = item.get("created_at") or item.get("createdAt")
+    created_dt = _parse_github_timestamp(created_at)
+    association = str(
+        item.get("author_association")
+        or item.get("authorAssociation")
+        or item.get("association")
+        or "NONE"
+    ).strip().upper()
+    gated_fields = sorted(
+        str(key) for key in item if str(key).lower() in GITHUB_COMMENT_BODY_KEYS
+    )
+    is_anchor = url == anchor_url
+    is_after_anchor = (
+        bool(anchor_created_at and created_dt and created_dt > anchor_created_at)
+        if not is_anchor
+        else False
+    )
+    return {
+        "schema_version": GITHUB_PUBLIC_REPLY_SIGNAL_SCHEMA_VERSION,
+        "author": _comment_author(item.get("author") or item.get("user")) or "unknown",
+        "author_association": association,
+        "created_at": str(created_at)[:40] if created_at else None,
+        "updated_at": str(item.get("updated_at") or item.get("updatedAt") or "")[:40]
+        or None,
+        "url": url,
+        "is_anchor_comment": is_anchor,
+        "is_after_anchor": is_after_anchor,
+        "is_maintainer_signal": bool(is_after_anchor and association in MAINTAINER_ASSOCIATIONS),
+        "body_captured": False,
+        "comment_body_captured": False,
+        "raw_payload_captured": False,
+        "gated_fields_present": gated_fields,
+    }
+
+
+def build_github_public_reply_monitor_packet(
+    *,
+    issue_url: str,
+    after_comment_url: str,
+    provider_payload: Mapping[str, Any] | list[Any] | None = None,
+    fetch_metadata: bool = False,
+    timeout_seconds: float = 10.0,
+) -> dict[str, Any]:
+    normalised_issue_url, issue_ref = _normalise_github_url(issue_url)
+    if issue_ref["ref_type"] not in {"issue", "pull"}:
+        raise ValueError("--issue-url must point at a GitHub issue or pull request")
+    normalised_comment_url, comment_ref = _normalise_github_issue_comment_url(after_comment_url)
+    same_target = (
+        issue_ref["owner"] == comment_ref["owner"]
+        and issue_ref["repo"] == comment_ref["repo"]
+        and issue_ref["number"] == comment_ref["number"]
+    )
+    if not same_target:
+        raise ValueError("--issue-url and --after-comment-url must point at the same GitHub thread")
+    read_error: str | None = None
+    live_payload: Mapping[str, Any] | None = None
+    if fetch_metadata:
+        try:
+            live_payload = _fetch_issue_comment_metadata(issue_ref, timeout_seconds=timeout_seconds)
+        except (
+            RuntimeError,
+            json.JSONDecodeError,
+            subprocess.TimeoutExpired,
+        ) as exc:
+            read_error = _compact_error(exc)
+
+    payload_source = live_payload if live_payload is not None else provider_payload
+    comments = _provider_comments(payload_source)
+    anchor_created_at: datetime | None = None
+    for item in comments:
+        if isinstance(item, Mapping) and _comment_url(item.get("url") or item.get("html_url")) == normalised_comment_url:
+            anchor_created_at = _parse_github_timestamp(item.get("created_at") or item.get("createdAt"))
+            break
+    signals = [
+        signal
+        for item in comments
+        if (
+            signal := _normalise_comment_signal(
+                item,
+                anchor_url=normalised_comment_url,
+                anchor_created_at=anchor_created_at,
+            )
+        )
+    ]
+    new_replies = [signal for signal in signals if signal["is_after_anchor"]]
+    maintainer_replies = [signal for signal in new_replies if signal["is_maintainer_signal"]]
+    gated_field_count = sum(len(signal["gated_fields_present"]) for signal in signals)
+    metadata_collected = bool(comments)
+    validation_errors: list[str] = []
+    validation_warnings: list[str] = []
+    if read_error:
+        validation_errors.append("metadata read failed; retry with gh auth/tooling or use --metadata-json")
+    if metadata_collected and anchor_created_at is None:
+        validation_errors.append("anchor LoopX comment was not found in comment metadata")
+    if not metadata_collected:
+        validation_warnings.append("no comment metadata was provided; monitor is a reference-only packet")
+    recommended_action = (
+        "prepare_public_triage_note"
+        if maintainer_replies
+        else "wait_no_bump"
+    )
+    money_signal = (
+        "public_maintainer_interest"
+        if maintainer_replies
+        else "no_conversion_signal_yet"
+    )
+    connector_call = {
+        "schema_version": "connector_call_intent_v0",
+        "call_id": f"github_{issue_ref['ref_type']}_{issue_ref['number']}_reply_monitor",
+        "connector_id": "github_public_reply_monitor",
+        "connector_kind": "lead_monitor",
+        "channel": f"GitHub {issue_ref['ref_type']} replies",
+        "stage": "monitor",
+        "target_ref": f"{issue_ref['owner']}/{issue_ref['repo']}#{issue_ref['number']}",
+        "target_url": normalised_issue_url,
+        "access_mode": "public_metadata_only",
+        "external_reads_allowed": True,
+        "external_writes_allowed": False,
+        "external_write_requested": False,
+        "requires_user_approval": False,
+        "approval_gate_id": None,
+        "value_axis": "demand",
+        "money_metric": "public maintainer reply asking for a LoopX triage note or workflow audit",
+        "success_metric": "maintainer reply after the LoopX comment with MEMBER/OWNER/COLLABORATOR association",
+        "kill_condition": "no public maintainer reply appears; do not bump the thread",
+        "promotion_target": "public_triage_note_or_stop",
+    }
+    return {
+        "ok": not validation_errors,
+        "schema_version": GITHUB_PUBLIC_REPLY_MONITOR_PACKET_SCHEMA_VERSION,
+        "mode": "github-public-reply-monitor",
+        "connector_id": "github_public_reply_monitor",
+        "ref": issue_ref,
+        "anchor_comment": comment_ref,
+        "connector_call": connector_call,
+        "external_reads_performed": bool(fetch_metadata),
+        "external_writes_performed": False,
+        "raw_body_captured": False,
+        "comment_bodies_captured": False,
+        "timeline_captured": False,
+        "raw_provider_payload_captured": False,
+        "restricted_material_recorded": False,
+        "autopublish_allowed": False,
+        "reply_signals": signals,
+        "new_public_reply_count": len(new_replies),
+        "maintainer_reply_count": len(maintainer_replies),
+        "money_signal": money_signal,
+        "recommended_action": recommended_action,
+        "stop_condition": "do not bump or draft a triage note until public maintainer interest appears",
+        "read_error": read_error,
+        "validation": {
+            "ok": not validation_errors,
+            "errors": validation_errors,
+            "warnings": validation_warnings,
+            "metadata_collected": metadata_collected,
+            "anchor_found": anchor_created_at is not None,
+            "gated_provider_field_count": gated_field_count,
+            "new_public_reply_count": len(new_replies),
+            "maintainer_reply_count": len(maintainer_replies),
+        },
+    }
+
+
 def build_github_public_channel_probe_packet(
     *,
     url: str,
@@ -262,12 +581,13 @@ def build_value_connector_install_check_packet(
                 "python3 -m pip install -e .",
                 "loopx value-connectors github-public-probe --url https://github.com/owner/repo/issues/1 --format json",
                 "loopx value-connectors github-public-probe --url https://github.com/owner/repo/issues/1 --fetch-metadata --format json",
+                "loopx value-connectors github-reply-monitor --issue-url https://github.com/owner/repo/issues/1 --after-comment-url https://github.com/owner/repo/issues/1#issuecomment-1 --fetch-metadata --format json",
             ],
             "optional_tools": [
                 {
                     "tool": "gh",
                     "installed": shutil.which("gh") is not None,
-                    "needed_for": "discussion metadata fetch",
+                    "needed_for": "discussion metadata fetch and reply-monitor metadata fetch",
                     "install_hint": "Install GitHub CLI and run `gh auth login` if discussion metadata is needed.",
                 }
             ],
@@ -316,6 +636,59 @@ def build_value_connector_install_check_packet(
             "restricted_material_recorded": False,
         },
     }
+
+
+def render_github_public_reply_monitor_markdown(payload: dict[str, Any]) -> str:
+    ref = payload.get("ref") if isinstance(payload.get("ref"), Mapping) else {}
+    validation = payload.get("validation") if isinstance(payload.get("validation"), Mapping) else {}
+    lines = [
+        "# LoopX GitHub Public Reply Monitor",
+        "",
+        f"- ok: `{payload.get('ok')}`",
+        f"- external_reads_performed: `{payload.get('external_reads_performed')}`",
+        f"- external_writes_performed: `{payload.get('external_writes_performed')}`",
+        f"- raw_body_captured: `{payload.get('raw_body_captured')}`",
+        f"- comment_bodies_captured: `{payload.get('comment_bodies_captured')}`",
+        f"- money_signal: `{payload.get('money_signal')}`",
+        f"- recommended_action: `{payload.get('recommended_action')}`",
+        "",
+    ]
+    if ref:
+        lines.insert(
+            3,
+            f"- ref: `{ref.get('owner')}/{ref.get('repo')} {ref.get('ref_type')} #{ref.get('number')}`",
+        )
+    lines.extend(
+        [
+            "## Reply Signals",
+            "",
+            f"- new_public_reply_count: `{payload.get('new_public_reply_count')}`",
+            f"- maintainer_reply_count: `{payload.get('maintainer_reply_count')}`",
+            "",
+        ]
+    )
+    for signal in payload.get("reply_signals") or []:
+        if not isinstance(signal, Mapping) or not signal.get("is_after_anchor"):
+            continue
+        lines.append(
+            "- "
+            f"{signal.get('created_at')} `{signal.get('author_association')}` "
+            f"maintainer_signal=`{signal.get('is_maintainer_signal')}` "
+            f"url={signal.get('url')}"
+        )
+    if payload.get("read_error"):
+        lines.extend(["", "## Read Error", "", str(payload.get("read_error"))])
+    errors = validation.get("errors") if isinstance(validation.get("errors"), list) else []
+    warnings = validation.get("warnings") if isinstance(validation.get("warnings"), list) else []
+    if errors:
+        lines.extend(["", "## Validation Errors", ""])
+        lines.extend(f"- {error}" for error in errors)
+    if warnings:
+        lines.extend(["", "## Validation Warnings", ""])
+        lines.extend(f"- {warning}" for warning in warnings)
+    if payload.get("error"):
+        lines.extend(["", "## Error", "", str(payload.get("error"))])
+    return "\n".join(lines).rstrip() + "\n"
 
 
 def render_github_public_channel_probe_markdown(payload: dict[str, Any]) -> str:


### PR DESCRIPTION
## Summary
- add a github-reply-monitor value connector for watching public issue/PR comment replies after an anchor comment
- keep the connector metadata-only: no comment bodies, raw provider payloads, private URLs, or writes are emitted
- document install/use flow and register the capability catalog surface

## Validation
- python3 examples/value-connectors-github-public-probe-smoke.py
- python3 -m py_compile loopx/capabilities/value_connectors/github_public.py loopx/capabilities/value_connectors/cli.py examples/value-connectors-github-public-probe-smoke.py
- git diff --check
- python3 -m loopx.cli check --scan-path loopx/capabilities/value_connectors --scan-path examples/value-connectors-github-public-probe-smoke.py --scan-path docs/capabilities/value-connectors/README.md --scan-path docs/reference/protocols/value-connector-plan-v0.md --scan-path loopx/capabilities/catalog.py
- python3 -m loopx.cli --format json value-connectors github-reply-monitor --issue-url https://github.com/neovim/neovim/issues/40206 --after-comment-url https://github.com/neovim/neovim/issues/40206#issuecomment-4796648945 --fetch-metadata
