### PR TITLE
Fix handoff gates with completed successors

### DIFF
--- a/examples/quota-cleared-blocker-successor-gate-smoke.py
+++ b/examples/quota-cleared-blocker-successor-gate-smoke.py
@@ -163,6 +163,26 @@ def value_successor() -> dict:
     )
 
 
+def completed_value_successor() -> dict:
+    return todo_item(
+        todo_id="todo_value_successor",
+        text="[P0] Completed value exploration successor for the reviewed scope.",
+        claimed_by=BLOCKED_AGENT,
+        status="done",
+        unblocks_todo_id="todo_review_gate",
+    )
+
+
+def followup_review_gate() -> dict:
+    return todo_item(
+        todo_id="todo_followup_review_gate",
+        text="[P0-review] Review the follow-up value connector PR.",
+        claimed_by=PRIMARY_AGENT,
+        blocks_agent=BLOCKED_AGENT,
+        unblocks_todo_id="todo_value_successor",
+    )
+
+
 def assert_open_blocker_waits_on_owner() -> None:
     payload = build_quota_should_run(
         status_payload(
@@ -239,6 +259,38 @@ def assert_existing_successor_runs_normally() -> None:
     assert "agent_scope_frontier" not in payload, payload
 
 
+def assert_completed_successor_keeps_old_gate_cleared() -> None:
+    payload = build_quota_should_run(
+        status_payload(
+            [
+                handoff_review(status="done"),
+                completed_value_successor(),
+                followup_review_gate(),
+            ],
+            recommended_action="Wait for the follow-up value connector review.",
+        ),
+        goal_id=GOAL_ID,
+        agent_id=BLOCKED_AGENT,
+    )
+    assert payload["decision"] == "agent_scope_wait", payload
+    frontier = payload["agent_scope_frontier"]
+    assert frontier["action"] == "agent_scope_wait", frontier
+    assert (
+        frontier["blocking_handoff_gates"][0]["todo_id"] == "todo_followup_review_gate"
+    ), frontier
+    summary = payload["agent_todo_summary"]
+    by_id = {
+        item["todo_id"]: item
+        for item in summary["current_agent_handoff_gates"]
+        if item.get("todo_id")
+    }
+    assert by_id["todo_review_gate"]["gate_state"] == "cleared_with_successor", summary
+    assert by_id["todo_review_gate"]["successor_todo_ids"] == [
+        "todo_value_successor"
+    ], summary
+    assert summary["current_agent_cleared_without_successor_handoff_count"] == 0, payload
+
+
 def assert_superseded_completed_blocker_does_not_wake_agent() -> None:
     payload = build_quota_should_run(
         status_payload(
@@ -264,6 +316,7 @@ def main() -> int:
     assert_cleared_blocker_requires_successor_replan()
     assert_status_summary_projects_handoff_gate_state()
     assert_existing_successor_runs_normally()
+    assert_completed_successor_keeps_old_gate_cleared()
     assert_superseded_completed_blocker_does_not_wake_agent()
     print("quota-cleared-blocker-successor-gate-smoke ok")
     return 0

--- a/loopx/todo_handoff_gate.py
+++ b/loopx/todo_handoff_gate.py
@@ -41,12 +41,6 @@ def _todo_done(item: dict[str, Any]) -> bool:
     return item.get("done") is True or todo_done_for_status(_todo_status(item))
 
 
-def _todo_actionable_open(item: dict[str, Any]) -> bool:
-    if _todo_done(item):
-        return False
-    return _todo_status(item) == TODO_STATUS_OPEN
-
-
 def _todo_text(item: dict[str, Any]) -> str:
     return str(item.get("text") or "").strip()
 
@@ -65,8 +59,6 @@ def _successor_todo_ids(
         return successor_ids
 
     for item in items:
-        if not _todo_actionable_open(item):
-            continue
         if normalize_todo_task_class(
             item.get("task_class"),
             text=_todo_text(item),


### PR DESCRIPTION
## Summary
- treat any linked advancement successor as a stable handoff successor, even after the successor is already completed
- prevent done review gates from re-waking a side agent as cleared_without_successor after downstream work has finished
- add smoke coverage for the exact completed-successor plus follow-up-review case

## Validation
- python3 examples/quota-cleared-blocker-successor-gate-smoke.py
- python3 -m py_compile loopx/todo_handoff_gate.py examples/quota-cleared-blocker-successor-gate-smoke.py
- git diff --check
- python3 -m loopx.cli check --scan-path loopx/todo_handoff_gate.py --scan-path examples/quota-cleared-blocker-successor-gate-smoke.py
- python3 -m loopx.cli --format json --registry "/Users/bytedance/.codex/loopx/registry.global.json" quota should-run --goal-id loopx-meta --agent-id codex-value-explorer
- loopx --format json --registry "/Users/bytedance/.codex/loopx/registry.global.json" quota should-run --goal-id loopx-meta --agent-id codex-value-explorer
