### PR TITLE
Scope user gates by authoring agent

### DIFF
--- a/docs/project-agent-todo-contract.md
+++ b/docs/project-agent-todo-contract.md
@@ -88,13 +88,20 @@ A `todo_id` is a structured work item inside that goal. LoopX does not
 currently model issues as a separate runtime object.
 
 Multiple agents may share the same project control plane. A todo can carry a
-soft owner with `claimed_by`, but the todo itself should not carry the agent's
-scope. Scope belongs in the automation prompt or sub-agent handoff; the agent
-uses that scope to decide which open todo it may claim. Each goal should have
-one `coordination.primary_agent`: the primary agent owns final review,
-verification, merge, publication, and reassignment decisions. All other
-registered agents are side agents. Side agents should do repository edits only
-in an independent git worktree/branch, never in the primary checkout. Small
+soft owner with `claimed_by`, but ordinary agent todos should not restate the
+agent's broad prompt scope. Scope belongs in the automation prompt or sub-agent
+handoff; the agent uses that scope to decide which open todo it may claim.
+User-gate todos are different: when a user decision only unlocks one registered
+agent or lane, record the blocked agent explicitly with `blocks_agent` so quota
+does not stop unrelated agents. For convenience, `todo add/update --role user
+--task-class user_gate --agent-id <agent>` defaults `blocks_agent` to that agent
+when `--blocks-agent` is omitted. Omit `--agent-id` and `--blocks-agent` only
+for a genuine goal-wide user gate.
+
+Each goal should have one `coordination.primary_agent`: the primary agent owns
+final review, verification, merge, publication, and reassignment decisions. All
+other registered agents are side agents. Side agents should do repository edits
+only in an independent git worktree/branch, never in the primary checkout. Small
 AGENTS-eligible validated changes may be self-merged when the side agent records
 public-safe evidence; higher-risk or unclear work should create a successor
 handoff todo claimed by the primary agent by default or by

--- a/examples/todo-cli-smoke.py
+++ b/examples/todo-cli-smoke.py
@@ -15,10 +15,12 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.status import parse_active_state_todos  # noqa: E402
+from loopx.quota import build_quota_should_run  # noqa: E402
 
 
 GOAL_ID = "todo-cli-goal"
 USER_TODO = "Review the owner decision checklist before approving delivery."
+SCOPED_USER_GATE = "Choose the side-agent publishing channel before posting externally."
 AGENT_TODO = "Summarize the read-only evidence after the user checklist is done."
 UPDATED_AGENT_TODO = "Publish the compact evidence summary after validation passes."
 
@@ -139,6 +141,27 @@ def main() -> int:
         assert duplicate["already_exists"] is True, duplicate
         assert state_file.read_text(encoding="utf-8").count(USER_TODO) == 1
 
+        scoped_gate = run_cli(
+            registry_path,
+            "todo",
+            "add",
+            "--goal-id",
+            GOAL_ID,
+            "--role",
+            "user",
+            "--text",
+            SCOPED_USER_GATE,
+            "--task-class",
+            "user_gate",
+            "--action-kind",
+            "approve_publish_channel",
+            "--agent-id",
+            "codex-side-bypass",
+        )
+        assert scoped_gate["added"] is True, scoped_gate
+        assert scoped_gate["agent_id"] == "codex-side-bypass", scoped_gate
+        assert scoped_gate["blocks_agent"] == "codex-side-bypass", scoped_gate
+
         agent_payload = run_cli(registry_path, "todo", "add", "--goal-id", GOAL_ID, "--role", "agent", "--text", AGENT_TODO)
         assert agent_payload["added"] is True, agent_payload
         legacy_agent = run_cli(
@@ -210,6 +233,11 @@ def main() -> int:
         fields = parse_active_state_todos(state_file.read_text(encoding="utf-8"))
         assert fields["user_todos"]["items"][0]["text"] == USER_TODO, fields
         assert fields["user_todos"]["items"][0]["todo_id"].startswith("todo_"), fields
+        scoped_user_item = next(
+            item for item in fields["user_todos"]["items"] if item["text"] == SCOPED_USER_GATE
+        )
+        assert scoped_user_item["task_class"] == "user_gate", fields
+        assert scoped_user_item["blocks_agent"] == "codex-side-bypass", fields
         assert fields["agent_todos"]["items"][0]["text"] == AGENT_TODO, fields
         assert fields["agent_todos"]["items"][0]["todo_id"].startswith("todo_"), fields
         assert fields["agent_todos"]["items"][0]["task_class"] == "advancement_task", fields
@@ -223,6 +251,56 @@ def main() -> int:
         ], fields
         assert fields["user_todos"]["source_section"] == "User Todo / Owner Review Reading Queue", fields
         assert fields["agent_todos"]["source_section"] == "Agent Todo", fields
+
+        status_payload = {
+            "ok": True,
+            "goal_count": 1,
+            "run_count": 0,
+            "attention_queue": {
+                "items": [
+                    {
+                        "goal_id": GOAL_ID,
+                        "status": "active_state_user_todo",
+                        "waiting_on": "controller",
+                        "severity": "action",
+                        "quota": {
+                            "compute": 1.0,
+                            "window_hours": 24,
+                            "slot_minutes": 1,
+                            "allowed_slots": 1440,
+                            "spent_slots": 0,
+                            "state": "operator_gate",
+                            "reason": "open user gate",
+                        },
+                        "user_todos": fields["user_todos"],
+                        "agent_todos": fields["agent_todos"],
+                    }
+                ]
+            },
+            "run_history": {
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "registry_member": True,
+                        "status": "active",
+                        "adapter_kind": "fixture_adapter_v0",
+                        "adapter_status": "connected",
+                        "coordination": {
+                            "registered_agents": ["codex-main-control", "codex-side-bypass"],
+                            "primary_agent": "codex-main-control",
+                        },
+                        "latest_runs": [],
+                    }
+                ]
+            },
+        }
+        main_quota = build_quota_should_run(
+            status_payload,
+            goal_id=GOAL_ID,
+            agent_id="codex-main-control",
+        )
+        assert main_quota["user_todo_summary"]["other_agent_scoped_open_count"] == 1, main_quota
+        assert main_quota["user_todo_summary"]["open_count"] == 1, main_quota
 
         missing_claim = run_cli_error(
             registry_path,

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -183,7 +183,12 @@ def register_todo_command(subparsers: argparse._SubParsersAction) -> None:
     )
     todo_parser.add_argument(
         "--agent-id",
-        help="For todo suggest, name the project agent that should perform the repository analysis.",
+        help=(
+            "For todo add/update on role=user task-class=user_gate, mark the "
+            "authoring registered agent; when --blocks-agent is omitted, the "
+            "gate blocks this agent. For todo suggest, name the project agent "
+            "that should perform the repository analysis."
+        ),
     )
     todo_parser.add_argument(
         "--from",
@@ -224,14 +229,22 @@ def handle_todo_command(
         else render_todo_markdown
     )
     try:
+        agent_id_allowed_for_gate_authoring = (
+            args.todo_command in {"add", "update"}
+            and args.role == "user"
+            and args.task_class == "user_gate"
+        )
         if args.todo_command not in {"suggest", "capture-followups"} and (
-            args.agent_id
+            (args.agent_id and not agent_id_allowed_for_gate_authoring)
             or args.suggestion_sources
             or args.suggestion_limit is not None
             or args.suggestion_trigger
         ):
             raise ValueError(
-                "todo --agent-id, --from, --limit, and --trigger are only supported by `todo suggest`"
+                "todo --agent-id is supported by `todo suggest` and by "
+                "`todo add/update --role user --task-class user_gate` for "
+                "agent-scoped user gates; --from, --limit, and --trigger are "
+                "only supported by `todo suggest`"
             )
         if args.todo_command == "add":
             if args.followups:
@@ -258,6 +271,7 @@ def handle_todo_command(
                 target_capabilities=args.target_capabilities,
                 claimed_by=args.claimed_by,
                 blocks_agent=args.blocks_agent,
+                agent_id=args.agent_id,
                 unblocks_todo_id=args.unblocks_todo_id,
                 resume_when=args.resume_when,
                 project=Path(args.project).expanduser() if args.project else None,
@@ -361,6 +375,7 @@ def handle_todo_command(
                 target_capabilities=args.target_capabilities,
                 claimed_by=args.claimed_by,
                 blocks_agent=args.blocks_agent,
+                agent_id=args.agent_id,
                 unblocks_todo_id=args.unblocks_todo_id,
                 resume_when=args.resume_when,
                 clear_claim=bool(args.clear_claim),
@@ -580,7 +595,7 @@ def handle_todo_command(
             registry_path=registry_path,
             runtime_root_arg=runtime_root_arg,
             event_kind=todo_event_kinds.get(args.todo_command, "todo_update"),
-            agent_id=args.claimed_by,
+            agent_id=args.agent_id or args.claimed_by,
             todo_id=args.todo_id or str(payload.get("todo_id") or "").strip() or None,
             status=str(payload.get("status") or args.todo_command or "").strip(),
             summary=(

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -20,6 +20,7 @@ from .status import (
 from .todo_contract import (
     TODO_STATUS_DONE,
     TODO_STATUS_OPEN,
+    TODO_TASK_CLASS_USER_GATE,
     TODO_TASK_PATTERN,
     build_todo_id,
     format_todo_metadata_line,
@@ -579,6 +580,7 @@ def add_goal_todo(
     target_capabilities: list[str] | None = None,
     claimed_by: str | None = None,
     blocks_agent: str | None = None,
+    agent_id: str | None = None,
     unblocks_todo_id: str | None = None,
     resume_when: str | None = None,
     project: Path | None = None,
@@ -608,14 +610,32 @@ def add_goal_todo(
             if claimed_by
             else None
         )
+        effective_agent_id = (
+            require_registered_agent_id(
+                registry_path=registry_path,
+                goal_id=goal_id,
+                agent_id=agent_id,
+                field="agent_id",
+            )
+            if agent_id
+            else None
+        )
+        inferred_blocks_agent = blocks_agent
+        if (
+            effective_agent_id
+            and not inferred_blocks_agent
+            and role == "user"
+            and task_class == TODO_TASK_CLASS_USER_GATE
+        ):
+            inferred_blocks_agent = effective_agent_id
         effective_blocks_agent = (
             require_registered_agent_id(
                 registry_path=registry_path,
                 goal_id=goal_id,
-                agent_id=blocks_agent,
+                agent_id=inferred_blocks_agent,
                 field="blocks_agent",
             )
-            if blocks_agent
+            if inferred_blocks_agent
             else None
         )
         normalized_unblocks_todo_id = normalize_todo_id(unblocks_todo_id) if unblocks_todo_id else None
@@ -664,6 +684,7 @@ def add_goal_todo(
         "required_capabilities": add_result.get("required_capabilities"),
         "target_capabilities": add_result.get("target_capabilities"),
         "claimed_by": add_result.get("claimed_by"),
+        "agent_id": effective_agent_id,
         "blocks_agent": add_result.get("blocks_agent"),
         "unblocks_todo_id": add_result.get("unblocks_todo_id"),
         "resume_when": add_result.get("resume_when"),
@@ -823,6 +844,7 @@ def update_goal_todo(
     target_capabilities: list[str] | None = None,
     claimed_by: str | None = None,
     blocks_agent: str | None = None,
+    agent_id: str | None = None,
     unblocks_todo_id: str | None = None,
     resume_when: str | None = None,
     clear_claim: bool = False,
@@ -850,14 +872,32 @@ def update_goal_todo(
             if claimed_by
             else None
         )
+        effective_agent_id = (
+            require_registered_agent_id(
+                registry_path=registry_path,
+                goal_id=goal_id,
+                agent_id=agent_id,
+                field="agent_id",
+            )
+            if agent_id
+            else None
+        )
+        inferred_blocks_agent = blocks_agent
+        if (
+            effective_agent_id
+            and not inferred_blocks_agent
+            and role == "user"
+            and task_class == TODO_TASK_CLASS_USER_GATE
+        ):
+            inferred_blocks_agent = effective_agent_id
         effective_blocks_agent = (
             require_registered_agent_id(
                 registry_path=registry_path,
                 goal_id=goal_id,
-                agent_id=blocks_agent,
+                agent_id=inferred_blocks_agent,
                 field="blocks_agent",
             )
-            if blocks_agent
+            if inferred_blocks_agent
             else None
         )
         normalized_unblocks_todo_id = normalize_todo_id(unblocks_todo_id) if unblocks_todo_id else None
@@ -899,6 +939,7 @@ def update_goal_todo(
         "dry_run": dry_run,
         "changed": changed,
         "goal_id": goal_id,
+        "agent_id": effective_agent_id,
         **update_result,
         "state_file": str(resolved_state_file),
         "project": str(resolved_project) if resolved_project else None,


### PR DESCRIPTION
## Summary
- allow `todo add/update --role user --task-class user_gate --agent-id <agent>` to author an agent-scoped user gate
- infer `blocks_agent=<agent>` when the user gate has an authoring agent and no explicit `--blocks-agent`
- document the user-gate scope rule and cover it in `todo-cli-smoke`

## Root Cause
A side-lane user gate could be authored as a goal-wide user todo with no `blocks_agent` or `claimed_by`. Quota then treated it as an operator gate for every agent, including the benchmark primary agent, even though the blocked decision belonged to another registered agent/lane.

## Validation
- `python3 examples/todo-cli-smoke.py`
- `python3 examples/quota-agent-scoped-user-gate-smoke.py`
- `python3 examples/refresh-state-agent-lane-scope-smoke.py`
- `python3 examples/todo-lifecycle-cli-smoke.py`
- `python3 examples/quota-contract-smoke.py`
- `python3 examples/quota-plan-smoke.py`
- `python3 -m py_compile loopx/todos.py loopx/cli_commands/todo.py`
- `git diff --check`
- `python3 -m loopx.cli --format json check --scan-path loopx/todos.py --scan-path loopx/cli_commands/todo.py --scan-path examples/todo-cli-smoke.py --scan-path docs/project-agent-todo-contract.md`

Note: `examples/todo-first-open-summary-smoke.py` still fails on clean `origin/main` with a pre-existing todo ordering assertion mismatch, so it is not included in this fix batch.
