### PR TITLE
Fix SkillsBench product-mode declared-done stopping

### DIFF
--- a/examples/benchmark-loop-protocol-smoke.py
+++ b/examples/benchmark-loop-protocol-smoke.py
@@ -75,6 +75,18 @@ def main() -> int:
         "declared_done_score",
     ]
     assert product_contract["policy_gate"]["official_feedback_blinded"] is True
+    assert (
+        product_contract["policy_gate"][
+            "declared_done_stop_requires_no_failed_every_round_reward"
+        ]
+        is True
+    )
+    assert (
+        product_contract["policy_gate"][
+            "continue_after_declared_done_below_passing_reward"
+        ]
+        is True
+    )
 
     trace = build_benchmark_loop_controller_trace(
         route=LOOPX_BLIND_LOOP_TREATMENT_ROUTE,

--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -4559,6 +4559,145 @@ def test_skillsbench_runner_prerequisites_are_compacted() -> None:
         assert "private_unlisted_detail" not in json.dumps(compact), compact
 
 
+def test_skillsbench_case_event_timeline_is_compacted() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-case-timeline-") as tmp:
+        root = Path(tmp)
+        result_path = write_official_skillsbench_result(
+            root,
+            reward=1.0,
+            task_id="organize-messy-files",
+        )
+        args = parse_args(
+            [
+                "--task-id",
+                "organize-messy-files",
+                "--route",
+                "loopx-product-mode",
+                "--jobs-dir",
+                str(root / "jobs"),
+                "--job-name",
+                "skillsbench-case-timeline-fixture",
+                "--rollout-name",
+                "organize-messy-files__loopx_product_mode",
+            ]
+        )
+        plan = build_plan(args)
+        plan["runner_prerequisites"].update(
+            {
+                "remote_command_file_bridge_consumed_by_solver": True,
+                "remote_command_file_bridge_solver_operation_count": 2,
+                "remote_command_file_bridge_driver_lifecycle_checkpoint_count": 1,
+                "remote_command_file_bridge_driver_lifecycle_loopx_state_read_count": 1,
+                "remote_command_file_bridge_driver_lifecycle_loopx_state_write_count": 3,
+                "remote_command_file_bridge_agent_request_count": 3,
+                "remote_command_file_bridge_agent_task_facing_operation_count": 2,
+                "remote_command_file_bridge_agent_todo_closeout_count": 1,
+                "remote_command_file_bridge_agent_refresh_state_count": 1,
+                "remote_command_file_bridge_agent_quota_spend_slot_count": 1,
+            }
+        )
+        write_json(
+            Path(plan["controller_trace_json"]),
+            {
+                "schema_version": "skillsbench_loopx_controller_trace_v0",
+                "route": "loopx-product-mode",
+                "trace_publicness": "public_counts_only_no_task_text_no_verifier_output",
+                "product_mode": True,
+                "heartbeat_count": 2,
+                "controller_action_decisions": 2,
+                "initial_prompt_count": 1,
+                "followup_prompt_count": 1,
+                "stop_decision_count": 1,
+                "official_success_observed": True,
+                "official_success_observation_count": 1,
+                "first_success_round": 2,
+                "max_rounds_budget": 8,
+                "case_goal_state_init_required": True,
+                "case_goal_state_initialized_before_agent": True,
+                "case_goal_state_init_status": "passed",
+                "product_mode_lifecycle_checkpoint_required": True,
+                "remote_command_file_bridge_consumed_by_solver": True,
+                "remote_command_file_bridge_driver_lifecycle_trace_count": 1,
+                "remote_command_file_bridge_driver_lifecycle_execution_style": (
+                    "orchestrated_agentloop_loopx_cli"
+                ),
+                "remote_command_file_bridge_driver_lifecycle_checkpoint_count": 1,
+                "remote_command_file_bridge_driver_lifecycle_request_count": 4,
+                "remote_command_file_bridge_driver_lifecycle_success_count": 4,
+                "remote_command_file_bridge_driver_lifecycle_failure_count": 0,
+                "remote_command_file_bridge_driver_lifecycle_loopx_cli_call_count": 4,
+                "remote_command_file_bridge_driver_lifecycle_loopx_state_read_count": 1,
+                "remote_command_file_bridge_driver_lifecycle_loopx_state_write_count": 3,
+                "remote_command_file_bridge_agent_operation_trace_required": True,
+                "remote_command_file_bridge_agent_operation_trace_satisfied": True,
+                "remote_command_file_bridge_agent_operation_trace_status": (
+                    "agent_operation_trace_recorded"
+                ),
+                "remote_command_file_bridge_agent_operation_trace_count": 1,
+                "remote_command_file_bridge_agent_request_count": 3,
+                "remote_command_file_bridge_agent_task_facing_operation_count": 2,
+                "remote_command_file_bridge_agent_todo_closeout_count": 1,
+                "remote_command_file_bridge_agent_refresh_state_count": 1,
+                "remote_command_file_bridge_agent_quota_spend_slot_count": 1,
+                "round_rewards": [
+                    {
+                        "agent_round": 1,
+                        "reward_present": True,
+                        "reward": 0.0,
+                        "passed": False,
+                        "tool_calls": 4,
+                    },
+                    {
+                        "agent_round": 2,
+                        "reward_present": True,
+                        "reward": 1.0,
+                        "passed": True,
+                        "tool_calls": 6,
+                    },
+                ],
+                "last_decision": "stop_after_official_success_observed",
+                "raw_task_text_recorded": False,
+                "raw_verifier_output_recorded": False,
+                "raw_agent_trajectory_recorded": False,
+                "acp_trajectory_summary": {
+                    "schema_version": "skillsbench_acp_trajectory_summary_v0",
+                    "private_trajectory_present": True,
+                    "raw_text_copied_to_public": False,
+                    "event_count": 9,
+                    "round_count": 2,
+                    "user_message_count": 2,
+                    "agent_message_count": 2,
+                    "tool_call_count": 6,
+                },
+            },
+        )
+
+        compact = reduce_result(args, result_path, plan)
+        timeline = compact["case_event_timeline"]
+        assert timeline["schema_version"] == "skillsbench_case_event_timeline_v0"
+        assert timeline["source"] == "compact_public_signals"
+        assert timeline["raw_material_recorded"] is False
+        events = {event["event"]: event for event in timeline["events"]}
+        assert events["case_goal_state_init"]["status"] == "passed", compact
+        assert events["orchestrated_loopx_lifecycle"]["checkpoint_count"] == 1
+        assert events["remote_command_bridge_consumption"]["status"] == "consumed"
+        assert events["task_facing_activity"]["status"] == "task_activity_observed"
+        assert events["controller_decision_loop"]["status"] == (
+            "official_success_observed"
+        )
+        assert events["official_score_closeout"]["status"] == "passed"
+        assert events["agent_bridge_closeout"]["status"] == "satisfied"
+
+        compact_again = compact_benchmark_run(compact)
+        assert compact_again is not None
+        assert compact_again["case_event_timeline"]["event_count"] == (
+            timeline["event_count"]
+        )
+        compact_text = json.dumps(compact_again, sort_keys=True)
+        assert "raw_task_text" not in compact_text
+        assert "raw_trajectory" not in compact_text
+
+
 def test_skillsbench_runner_plan_supports_product_mode_routes() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-product-plan-") as tmp:
         root = Path(tmp)
@@ -7288,6 +7427,69 @@ def test_skillsbench_runner_failure_compact_closeout() -> None:
         assert "BenchFlow result.json not found" not in json.dumps(compact), compact
 
 
+def test_skillsbench_runner_failure_case_event_timeline_is_compacted() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-failure-timeline-") as tmp:
+        args = parse_args(
+            [
+                "--task-id",
+                "organize-messy-files",
+                "--route",
+                "loopx-product-mode",
+                "--jobs-dir",
+                str(Path(tmp) / "jobs"),
+                "--job-name",
+                "skillsbench-failure-timeline-fixture",
+            ]
+        )
+        plan = build_plan(args)
+        plan["runner_prerequisites"].update(
+            {
+                "remote_command_file_bridge_consumed_by_solver": True,
+                "remote_command_file_bridge_driver_lifecycle_checkpoint_count": 1,
+                "remote_command_file_bridge_driver_lifecycle_loopx_state_read_count": 1,
+                "remote_command_file_bridge_driver_lifecycle_loopx_state_write_count": 3,
+                "remote_command_file_bridge_agent_operation_trace_required": True,
+                "remote_command_file_bridge_agent_operation_trace_satisfied": False,
+                "remote_command_file_bridge_agent_operation_trace_status": (
+                    "agent_operation_trace_missing"
+                ),
+                "benchflow_user_loop_recovery_exception_type": (
+                    "AgentPromptTimeoutError"
+                ),
+                "benchflow_user_loop_recovery_stage": "agent_execute",
+                "benchflow_user_loop_recovery_delta_events": 3,
+                "benchflow_user_loop_recovery_delta_tool_calls": 0,
+                "benchflow_agent_timeout_effective_sec": 21660,
+                "benchflow_agent_timeout_host_local_acp_exec_timeout_sec": 21600,
+            }
+        )
+
+        compact = build_runner_failure_compact(
+            args,
+            plan,
+            TimeoutError("PRIVATE_TIMEOUT_DETAIL_SHOULD_NOT_ESCAPE"),
+        )
+        timeline = compact["case_event_timeline"]
+        events = {event["event"]: event for event in timeline["events"]}
+        assert events["remote_command_bridge_consumption"]["status"] == "consumed"
+        assert events["task_facing_activity"]["status"] == (
+            "missing_agent_operation_trace"
+        )
+        recovery = events["timeout_or_failure_closeout"]
+        assert recovery["status"] == "user_loop_recovery_triggered"
+        assert recovery["recovery_exception_type"] == "AgentPromptTimeoutError"
+        assert recovery["benchflow_agent_timeout_effective_sec"] == 21660
+        assert recovery["local_codex_exec_timeout_sec"] == 21600
+        assert events["official_score_closeout"]["status"] == "missing"
+
+        compact_again = compact_benchmark_run(compact)
+        assert compact_again is not None
+        assert compact_again["case_event_timeline"]["raw_material_recorded"] is False
+        assert "PRIVATE_TIMEOUT_DETAIL_SHOULD_NOT_ESCAPE" not in json.dumps(
+            compact_again
+        ), compact_again
+
+
 def test_skillsbench_runner_failure_compact_attributes_agent_no_requests() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-no-agent-request-") as tmp:
         args = parse_args(
@@ -9224,6 +9426,7 @@ if __name__ == "__main__":
     test_remote_bridge_auto_wiring_pending_is_not_final_failure_attribution()
     test_skillsbench_codex_acp_model_control_warning()
     test_skillsbench_runner_prerequisites_are_compacted()
+    test_skillsbench_case_event_timeline_is_compacted()
     test_skillsbench_task_staging_metadata_is_compacted()
     test_skillsbench_reduce_only_recovers_prepared_task_staging_metadata()
     test_skillsbench_controller_trace_counts_are_compacted()
@@ -9249,6 +9452,7 @@ if __name__ == "__main__":
     test_skillsbench_compact_runs_update_ledger_pair()
     test_skillsbench_repeat_same_mode_keeps_distinct_ledger_runs()
     test_skillsbench_runner_failure_compact_closeout()
+    test_skillsbench_runner_failure_case_event_timeline_is_compacted()
     test_skillsbench_runner_failure_prefers_structured_preflight_blocker()
     test_skillsbench_runner_failure_marks_pre_agent_install_stage()
     test_skillsbench_runner_failure_marks_build_stall_timeout()

--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -6074,6 +6074,52 @@ def test_skillsbench_product_mode_recompact_normalizes_agent_bridge_closeout() -
     assert "skillsbench_product_mode_uncountable_treatment" not in labels, compact
 
 
+def test_skillsbench_product_mode_recompact_prefers_corroborated_solver_gap() -> None:
+    compact = compact_benchmark_run(
+        {
+            "schema_version": "benchmark_run_v0",
+            "source_runner": "official_skillsbench_benchflow_result",
+            "benchmark_id": "skillsbench",
+            "case_id": "sample-task",
+            "case_ids": ["sample-task"],
+            "mode": "single",
+            "route": "loopx-product-mode",
+            "official_score": 0.0,
+            "score_failure_attribution": "skillsbench_product_mode_lifecycle_missing",
+            "failure_attribution_labels": [
+                "official_verifier_solution_failure",
+                "skillsbench_product_mode_lifecycle_missing",
+            ],
+            "interaction_counters": {
+                "schema_version": "skillsbench_interaction_counters_v0",
+                "product_mode": True,
+                "product_mode_solver_activity_gap": True,
+                "product_mode_solver_activity_gap_count": 1,
+                "product_mode_solver_activity_gap_round": 1,
+                "product_mode_solver_activity_missing_reason": (
+                    "missing_task_facing_activity_or_agent_closeout_before_declared_done"
+                ),
+                "remote_command_file_bridge_agent_task_facing_operation_count": 0,
+                "remote_command_file_bridge_agent_todo_closeout_count": 0,
+            },
+            "product_mode_lifecycle_contract": {
+                "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+                "required": True,
+                "satisfied": True,
+                "countable_treatment": True,
+            },
+        }
+    )
+    assert compact is not None
+    assert compact["score_failure_attribution"] == (
+        "skillsbench_product_mode_solver_activity_gap"
+    ), compact
+    labels = compact["failure_attribution_labels"]
+    assert "skillsbench_product_mode_solver_activity_gap" in labels, compact
+    assert "skillsbench_product_mode_lifecycle_missing" not in labels, compact
+    assert "official_verifier_solution_failure" not in labels, compact
+
+
 def test_skillsbench_product_mode_solver_activity_gap_is_compacted() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-solver-gap-compact-") as tmp:
         root = Path(tmp)
@@ -6302,6 +6348,9 @@ def test_skillsbench_product_mode_declared_done_below_passing_reward_is_compacte
             "product_mode_declared_done_below_passing_reward_count": 1,
             "product_mode_declared_done_below_passing_reward_round": 2,
             "product_mode_declared_done_below_passing_reward_score": 0.0,
+            "product_mode_declared_done_below_passing_reward_score_status": (
+                "observed_below_passing"
+            ),
             "product_mode_declared_done_policy": (
                 "continue_until_official_success_or_budget"
             ),
@@ -6331,6 +6380,12 @@ def test_skillsbench_product_mode_declared_done_below_passing_reward_is_compacte
         assert (
             counters["product_mode_declared_done_below_passing_reward_score"] == 0.0
         )
+        assert (
+            counters[
+                "product_mode_declared_done_below_passing_reward_score_status"
+            ]
+            == "observed_below_passing"
+        )
         assert counters["product_mode_declared_done_policy"] == (
             "continue_until_official_success_or_budget"
         )
@@ -6339,6 +6394,65 @@ def test_skillsbench_product_mode_declared_done_below_passing_reward_is_compacte
             "skillsbench_product_mode_declared_done_below_passing_reward" in labels
         )
         assert "skillsbench_agent_premature_done_signal" in labels
+
+
+def test_skillsbench_declared_done_missing_reward_status_is_compacted() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-declared-done-missing-reward-") as tmp:
+        root = Path(tmp)
+        result_path = write_official_skillsbench_result(root, reward=0.0)
+        controller_trace = {
+            "schema_version": "skillsbench_loopx_controller_trace_v0",
+            "route": "loopx-product-mode",
+            "trace_publicness": "public_counts_only_no_task_text_no_verifier_output",
+            "product_mode": True,
+            "heartbeat_count": 2,
+            "controller_action_decisions": 2,
+            "initial_prompt_count": 1,
+            "followup_prompt_count": 1,
+            "reward_observation_count": 0,
+            "round_rewards": [{"agent_round": 1, "tool_calls": 0}],
+            "agent_declared_done": True,
+            "agent_declared_no_remaining_goals": True,
+            "declared_done_round": 1,
+            "product_mode_declared_done_below_passing_reward": True,
+            "product_mode_declared_done_below_passing_reward_count": 1,
+            "product_mode_declared_done_below_passing_reward_round": 1,
+            "product_mode_declared_done_below_passing_reward_score_status": (
+                "missing"
+            ),
+            "product_mode_declared_done_policy": (
+                "continue_until_official_success_or_budget"
+            ),
+            "last_decision": (
+                "send_product_mode_success_or_budget_continuation_after_declared_done"
+            ),
+            "raw_task_text_recorded": False,
+            "raw_verifier_output_recorded": False,
+            "raw_agent_trajectory_recorded": False,
+        }
+        compact = compact_benchmark_run(
+            build_skillsbench_benchflow_result_benchmark_run(
+                result_path,
+                route="loopx-product-mode",
+                controller_trace=controller_trace,
+            )
+        )
+        assert compact is not None
+        counters = compact["interaction_counters"]
+        assert counters["product_mode_declared_done_below_passing_reward"] is True
+        assert (
+            "product_mode_declared_done_below_passing_reward_score"
+            not in counters
+        )
+        assert (
+            counters[
+                "product_mode_declared_done_below_passing_reward_score_status"
+            ]
+            == "missing"
+        )
+        assert counters["product_mode_declared_done_policy"] == (
+            "continue_until_official_success_or_budget"
+        )
 
 
 def test_skillsbench_product_mode_declared_done_without_closeout_overrides_verifier_error() -> None:
@@ -6433,6 +6547,59 @@ def test_skillsbench_product_mode_declared_done_without_closeout_overrides_verif
         assert "skillsbench_agent_behavior_gap" in labels, compact
         assert "skillsbench_reward_artifact_missing" in labels, compact
         assert "skillsbench_verifier_error_subtype_unavailable_public" in labels, compact
+
+
+def test_skillsbench_product_mode_solver_activity_gap_overrides_zero_score() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-solver-gap-zero-score-") as tmp:
+        root = Path(tmp)
+        result_path = write_official_skillsbench_result(root, reward=0.0)
+        controller_trace = {
+            "schema_version": "skillsbench_loopx_controller_trace_v0",
+            "route": "loopx-product-mode",
+            "trace_publicness": "public_counts_only_no_task_text_no_verifier_output",
+            "product_mode": True,
+            "reward_observation_count": 1,
+            "round_rewards": [
+                {"agent_round": 1, "reward_present": True, "reward": 0.0}
+            ],
+            "agent_declared_done": True,
+            "agent_declared_no_remaining_goals": True,
+            "declared_done_round": 1,
+            "product_mode_solver_activity_gap": True,
+            "product_mode_solver_activity_gap_count": 1,
+            "product_mode_solver_activity_gap_round": 1,
+            "product_mode_solver_activity_missing_reason": (
+                "missing_task_facing_activity_or_agent_closeout_before_declared_done"
+            ),
+            "remote_command_file_bridge_agent_operation_trace_status": (
+                "agent_operation_trace_recorded"
+            ),
+            "remote_command_file_bridge_agent_operation_trace_count": 1,
+            "remote_command_file_bridge_agent_operation_trace_satisfied": True,
+            "remote_command_file_bridge_agent_request_count": 2,
+            "remote_command_file_bridge_agent_task_facing_operation_count": 0,
+            "remote_command_file_bridge_agent_todo_closeout_count": 0,
+            "raw_task_text_recorded": False,
+            "raw_verifier_output_recorded": False,
+            "raw_agent_trajectory_recorded": False,
+        }
+        compact = compact_benchmark_run(
+            build_skillsbench_benchflow_result_benchmark_run(
+                result_path,
+                route="loopx-product-mode",
+                controller_trace=controller_trace,
+            )
+        )
+        assert compact is not None
+        assert compact["official_score"] == 0.0, compact
+        assert compact["score_failure_attribution"] == (
+            "skillsbench_product_mode_solver_activity_gap"
+        ), compact
+        labels = compact["failure_attribution_labels"]
+        assert "skillsbench_product_mode_solver_activity_gap" in labels, compact
+        assert "skillsbench_agent_behavior_gap" in labels, compact
+        assert "official_verifier_solution_failure" not in labels, compact
+        assert "skillsbench_reward_artifact_missing" not in labels, compact
 
 
 def test_skillsbench_product_mode_no_tool_lifecycle_abort_is_compacted() -> None:
@@ -9063,9 +9230,12 @@ if __name__ == "__main__":
     test_skillsbench_product_mode_declared_done_is_compacted()
     test_skillsbench_product_mode_lifecycle_checkpoint_is_compacted()
     test_skillsbench_product_mode_recompact_normalizes_agent_bridge_closeout()
+    test_skillsbench_product_mode_recompact_prefers_corroborated_solver_gap()
     test_skillsbench_product_mode_solver_activity_gap_is_compacted()
+    test_skillsbench_product_mode_solver_activity_gap_overrides_zero_score()
     test_skillsbench_product_mode_first_action_timeout_is_uncountable()
     test_skillsbench_product_mode_declared_done_below_passing_reward_is_compacted()
+    test_skillsbench_declared_done_missing_reward_status_is_compacted()
     test_skillsbench_product_mode_declared_done_without_closeout_overrides_verifier_error()
     test_skillsbench_product_mode_no_tool_lifecycle_abort_is_compacted()
     test_skillsbench_product_mode_pass_clears_generic_runner_error()

--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -37,6 +37,7 @@ from loopx.benchmark_ledger import (  # noqa: E402
 )
 from loopx.benchmark_adapters.skillsbench_acp_relay import (  # noqa: E402
     SKILLSBENCH_LOCAL_ACP_RELAY_PROBE_SCHEMA_VERSION,
+    _codex_exec_failure_category,
     run_skillsbench_local_acp_relay_probe,
 )
 from loopx.benchmark_adapters.skillsbench_remote_bridge import (  # noqa: E402
@@ -75,6 +76,7 @@ from scripts.skillsbench_automation_loop import (  # noqa: E402
     _merge_app_server_goal_worker_trace_summary,
     _merge_acp_trajectory_summary,
     _merge_final_result_round_reward,
+    _merge_host_local_acp_relay_trace_summary,
     _round_result_declared_done,
     build_compose_setup_diagnostic,
     build_plan,
@@ -228,7 +230,13 @@ time.sleep(30)
         )
     assert time.monotonic() - start < 8
     assert response["exit_code"] == 124
-    assert response["stderr"] == "codex_exec_bridge_idle_timeout\n"
+    assert any(
+        marker in response["stderr"]
+        for marker in (
+            "codex_exec_bridge_idle_timeout",
+            "codex_exec_first_action_timeout",
+        )
+    ), response
     assert response["raw_task_text_recorded"] is False
     assert response["credential_values_recorded"] is False
     records = [
@@ -236,10 +244,13 @@ time.sleep(30)
         for line in response["agent_operations_jsonl"].splitlines()
         if line.strip()
     ]
-    assert len(records) == 1, records
-    assert records[0]["operation_observed"] is True
-    assert records[0]["task_facing_operation"] is True
-    assert records[0]["raw_request_recorded"] is False
+    if "codex_exec_first_action_timeout" in response["stderr"]:
+        assert records == [], records
+    else:
+        assert len(records) == 1, records
+        assert records[0]["operation_observed"] is True
+        assert records[0]["task_facing_operation"] is True
+        assert records[0]["raw_request_recorded"] is False
 
 
 def test_product_mode_initial_prompt_keeps_task_visible_after_lifecycle_gate() -> None:
@@ -1461,6 +1472,59 @@ def test_product_mode_declared_done_marker_detection() -> None:
         ]
 
     assert _round_result_declared_done(FakeRoundResult()) is True
+
+
+def test_product_mode_declared_done_ignores_user_prompt_marker() -> None:
+    class FakeRoundResult:
+        trajectory = [
+            {
+                "role": "user",
+                "type": "message",
+                "content": (
+                    "Only end with "
+                    f"{DECLARED_DONE_MARKER} after no remaining goals."
+                ),
+            },
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Not complete; more local task work remains.",
+                    }
+                ],
+            },
+        ]
+
+    assert _round_result_declared_done(FakeRoundResult()) is False
+
+
+def test_skillsbench_codex_exec_failure_category_is_actionable() -> None:
+    assert (
+        _codex_exec_failure_category(
+            returncode=1,
+            stderr_text="Not authenticated. Please login before running codex exec.",
+        )
+        == "codex_auth_or_login_required"
+    )
+    assert (
+        _codex_exec_failure_category(
+            returncode=1,
+            stderr_text="Requested model loopx-test-model does not exist.",
+        )
+        == "codex_model_unavailable"
+    )
+    assert (
+        _codex_exec_failure_category(
+            returncode=1,
+            stderr_text="codex: No such file or directory",
+        )
+        == "codex_cli_or_environment_missing"
+    )
+    assert (
+        _codex_exec_failure_category(returncode=1, stderr_text="unexpected failure")
+        == "codex_exec_exit_1"
+    )
 
 
 def test_product_mode_case_state_seed_uses_active_goal_shape() -> None:
@@ -6213,6 +6277,99 @@ def test_skillsbench_product_mode_recompact_normalizes_agent_bridge_closeout() -
     assert "skillsbench_product_mode_uncountable_treatment" not in labels, compact
 
 
+def test_skillsbench_agent_bridge_closeout_requires_successful_commands() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-agent-closeout-") as tmp:
+        trace_dir = Path(tmp)
+        write_json(
+            trace_dir / "worker-agent-ops.compact.json",
+            {
+                "schema_version": "skillsbench_host_local_acp_relay_public_trace_v0",
+                "ok": True,
+                "route": "loopx-product-mode",
+                "trace_kind": "remote_command_file_bridge_agent_operations",
+                "benchmark_id": "skillsbench@1.1",
+                "task_id": "sample-task",
+                "remote_command_file_bridge_agent_operations": {
+                    "schema_version": (
+                        "skillsbench_remote_command_file_bridge_agent_operations_v0"
+                    ),
+                    "request_count": 3,
+                    "success_count": 1,
+                    "failure_count": 2,
+                    "operation_counts": {"exec": 3},
+                    "returncode_counts": {"0": 1, "1": 2},
+                    "loopx_cli_call_count": 3,
+                    "loopx_cli_subcommand_counts": {
+                        "todo complete": 1,
+                        "refresh-state": 1,
+                        "quota spend-slot": 1,
+                    },
+                    "successful_loopx_cli_subcommand_counts": {
+                        "refresh-state": 1,
+                    },
+                    "loopx_state_read_count": 0,
+                    "loopx_state_write_count": 3,
+                    "task_facing_operation_count": 0,
+                    "raw_material_recorded": False,
+                },
+                "boundary": {
+                    "raw_command_recorded": False,
+                    "raw_stdout_recorded": False,
+                    "raw_stderr_recorded": False,
+                    "raw_task_text_recorded": False,
+                    "raw_logs_recorded": False,
+                    "raw_trajectory_recorded": False,
+                    "credential_values_recorded": False,
+                    "host_paths_recorded": False,
+                    "remote_paths_recorded": False,
+                },
+            },
+        )
+        plan = {
+            "host_local_acp_relay_trace_dir": str(trace_dir),
+            "runner_prerequisites": {
+                "remote_command_file_bridge_agent_operation_trace_required": True,
+            },
+        }
+        trace = {
+            "schema_version": "skillsbench_loopx_controller_trace_v0",
+            "route": "loopx-product-mode",
+            "trace_publicness": "public_counts_only_no_task_text_no_verifier_output",
+        }
+        _merge_host_local_acp_relay_trace_summary(plan, trace)
+        assert trace["remote_command_file_bridge_agent_request_count"] == 3, trace
+        assert trace["remote_command_file_bridge_agent_success_count"] == 1, trace
+        assert trace["remote_command_file_bridge_agent_failure_count"] == 2, trace
+        assert (
+            trace["remote_command_file_bridge_agent_todo_closeout_count"] == 0
+        ), trace
+        assert trace["remote_command_file_bridge_agent_refresh_state_count"] == 1, trace
+        assert (
+            trace["remote_command_file_bridge_agent_quota_spend_slot_count"] == 0
+        ), trace
+
+        compact = {
+            "interaction_counters": {},
+            "product_mode_lifecycle_contract": {
+                "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+                "required": True,
+                "state_read_count": 1,
+                "state_write_count": 1,
+                "agent_operation_trace_required": True,
+                "agent_operation_trace_satisfied": True,
+            },
+        }
+        _sync_relay_closeout_counts_into_compact(
+            compact,
+            plan["runner_prerequisites"],
+        )
+        contract = compact["product_mode_lifecycle_contract"]
+        assert contract["agent_bridge_todo_closeout_count"] == 0, compact
+        assert contract["agent_bridge_refresh_state_count"] == 1, compact
+        assert contract["agent_bridge_quota_spend_slot_count"] == 0, compact
+        assert contract.get("closeout_satisfied") is not True, compact
+
+
 def test_skillsbench_product_mode_recompact_prefers_corroborated_solver_gap() -> None:
     compact = compact_benchmark_run(
         {
@@ -9379,6 +9536,8 @@ if __name__ == "__main__":
     test_local_codex_participant_ping_missing_binary_is_compact()
     test_blind_loop_continuation_reprojects_round_one_constraints()
     test_product_mode_declared_done_marker_detection()
+    test_product_mode_declared_done_ignores_user_prompt_marker()
+    test_skillsbench_codex_exec_failure_category_is_actionable()
     test_product_mode_case_state_seed_uses_active_goal_shape()
     test_product_mode_declared_done_requires_case_state_depth()
     test_product_mode_declared_done_requires_solver_activity_after_driver_lifecycle()
@@ -9433,6 +9592,7 @@ if __name__ == "__main__":
     test_skillsbench_product_mode_declared_done_is_compacted()
     test_skillsbench_product_mode_lifecycle_checkpoint_is_compacted()
     test_skillsbench_product_mode_recompact_normalizes_agent_bridge_closeout()
+    test_skillsbench_agent_bridge_closeout_requires_successful_commands()
     test_skillsbench_product_mode_recompact_prefers_corroborated_solver_gap()
     test_skillsbench_product_mode_solver_activity_gap_is_compacted()
     test_skillsbench_product_mode_solver_activity_gap_overrides_zero_score()

--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -178,7 +178,7 @@ def test_reverse_channel_raw_prompt_does_not_require_bridge_first_action() -> No
     assert response["credential_values_recorded"] is False
 
 
-def test_product_mode_initial_prompt_defers_task_until_agent_lifecycle() -> None:
+def test_product_mode_initial_prompt_keeps_task_visible_after_lifecycle_gate() -> None:
     trace = {
         "schema_version": "skillsbench_loopx_controller_trace_v0",
         "route": "loopx-product-mode",
@@ -235,10 +235,11 @@ def test_product_mode_initial_prompt_defers_task_until_agent_lifecycle() -> None
     prompt = asyncio.run(user.run(0, "Compute the requested coefficient."))
     assert prompt is not None
     assert "--- LOOPX PRODUCT-MODE CONTROL PLANE ---" in prompt
-    assert "--- TASK INSTRUCTION ---" not in prompt
-    assert "Compute the requested coefficient." not in prompt
-    assert "task instruction is intentionally withheld" in prompt
+    assert "--- TASK INSTRUCTION ---" in prompt
+    assert "Compute the requested coefficient." in prompt
+    assert "task semantics stay aligned with the baseline" in prompt
     assert "Before reading, planning, solving, or answering the task" in prompt
+    assert "task-facing work must wait" in prompt
     assert "Do not run case closeout" in prompt
     assert "quota should-run --goal-id skillsbench-case" in prompt
     assert "todo claim --goal-id skillsbench-case" in prompt
@@ -247,7 +248,8 @@ def test_product_mode_initial_prompt_defers_task_until_agent_lifecycle() -> None
     assert "quota spend-slot --goal-id skillsbench-case" not in prompt
     assert trace["last_decision"] == "send_initial_product_mode_prompt", trace
     assert trace["initial_prompt_count"] == 1, trace
-    assert trace["product_mode_task_instruction_deferred_until_agent_lifecycle"] is True
+    assert trace["product_mode_task_instruction_deferred_until_agent_lifecycle"] is False
+    assert trace["product_mode_task_instruction_sent_initially"] is True
 
     trace.update(
         {
@@ -265,14 +267,12 @@ def test_product_mode_initial_prompt_defers_task_until_agent_lifecycle() -> None
         user.run(1, "Compute the requested coefficient.", FakeRoundResult())
     )
     assert task_prompt is not None
-    assert "--- TASK INSTRUCTION ---" in task_prompt
-    assert "Compute the requested coefficient." in task_prompt
-    assert "The task packet is now available" in task_prompt
+    assert "--- TASK INSTRUCTION ---" not in task_prompt
+    assert "The task packet is now available" not in task_prompt
+    assert "Continue from your LoopX case state" in task_prompt
     assert "official reward" in task_prompt
-    assert trace["last_decision"] == (
-        "send_product_mode_task_instruction_after_agent_lifecycle"
-    ), trace
-    assert trace["product_mode_task_instruction_sent_after_agent_lifecycle"] is True
+    assert trace["last_decision"] == "send_product_mode_scheduled_continuation", trace
+    assert trace.get("product_mode_task_instruction_sent_after_agent_lifecycle") is not True
     assert trace["followup_prompt_count"] == 1, trace
 
 
@@ -8653,7 +8653,7 @@ if __name__ == "__main__":
     test_skillsbench_product_mode_soft_verify_default_is_every_round()
     test_reverse_channel_first_action_timeout_stops_codex_process()
     test_reverse_channel_raw_prompt_does_not_require_bridge_first_action()
-    test_product_mode_initial_prompt_defers_task_until_agent_lifecycle()
+    test_product_mode_initial_prompt_keeps_task_visible_after_lifecycle_gate()
     test_skillsbench_final_verifier_timeout_override_records_public_state()
     test_skillsbench_final_verifier_timeout_override_can_extend_timeout()
     test_skillsbench_intermediate_soft_verifier_timeout_override_records_public_state()

--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -11,6 +11,7 @@ import os
 import subprocess
 import sys
 import tempfile
+import time
 import types
 from pathlib import Path
 from typing import Any
@@ -97,6 +98,7 @@ from scripts.skillsbench_automation_loop import (  # noqa: E402
     stage_task_for_sandbox,
 )
 import scripts.skillsbench_automation_loop as skillsbench_loop  # noqa: E402
+from scripts.skillsbench_reverse_channel_bridge import _run_codex_payload  # noqa: E402
 
 
 GOAL_ID = "skillsbench-benchmark-run-fixture"
@@ -127,6 +129,26 @@ def test_skillsbench_product_mode_soft_verify_default_is_every_round() -> None:
         )
         == "every-round"
     )
+
+
+def test_reverse_channel_first_action_timeout_stops_codex_process() -> None:
+    start = time.monotonic()
+    response = _run_codex_payload(
+        {
+            "args": ["-c", "import time; time.sleep(30)"],
+            "stdin": "synthetic prompt",
+            "timeout_sec": 20,
+        },
+        codex_bin=sys.executable,
+        default_timeout_sec=20,
+        prompt_bridge_command="unused {private_bridge_command_sh}",
+        first_action_timeout_sec=1,
+    )
+    assert time.monotonic() - start < 8
+    assert response["exit_code"] == 124
+    assert response["stderr"] == "codex_exec_first_action_timeout\n"
+    assert response["raw_task_text_recorded"] is False
+    assert response["credential_values_recorded"] is False
 
 
 def test_product_mode_initial_prompt_defers_task_until_agent_lifecycle() -> None:
@@ -8602,6 +8624,7 @@ def test_skillsbench_reduce_only_preserves_round_reward_trace() -> None:
 if __name__ == "__main__":
     test_skillsbench_default_blind_loop_budget_is_sixteen()
     test_skillsbench_product_mode_soft_verify_default_is_every_round()
+    test_reverse_channel_first_action_timeout_stops_codex_process()
     test_product_mode_initial_prompt_defers_task_until_agent_lifecycle()
     test_skillsbench_final_verifier_timeout_override_records_public_state()
     test_skillsbench_final_verifier_timeout_override_can_extend_timeout()

--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -223,7 +223,15 @@ def test_product_mode_initial_prompt_keeps_task_visible_after_lifecycle_gate() -
             route="loopx-product-mode",
             max_rounds=8,
             trace=trace,
-            plan={},
+            plan={
+                "runner_prerequisites": {
+                    "loopx_workflow_lifecycle_checkpoint": True,
+                    "loopx_product_mode_lifecycle_driver_kind": (
+                        "orchestrated_agentloop_loopx_cli"
+                    ),
+                }
+            },
+            case_payload={"canonical_product_mode_lifecycle_driver": True},
         )
     finally:
         for name, module in saved_modules.items():
@@ -238,11 +246,14 @@ def test_product_mode_initial_prompt_keeps_task_visible_after_lifecycle_gate() -
     assert "--- TASK INSTRUCTION ---" in prompt
     assert "Compute the requested coefficient." in prompt
     assert "task semantics stay aligned with the baseline" in prompt
-    assert "Before reading, planning, solving, or answering the task" in prompt
-    assert "task-facing work must wait" in prompt
+    assert "canonical workflow lifecycle driver has already" in prompt
+    assert "Do not repeat setup lifecycle" in prompt
+    assert "`pwd && ls -la`" in prompt
+    assert "first agent action a task-facing sandbox bridge exec" in prompt
     assert "Do not run case closeout" in prompt
-    assert "quota should-run --goal-id skillsbench-case" in prompt
-    assert "todo claim --goal-id skillsbench-case" in prompt
+    assert "quota should-run --goal-id skillsbench-case" not in prompt
+    assert "todo claim --goal-id skillsbench-case" not in prompt
+    assert "task-facing work must wait" not in prompt
     assert "todo complete --goal-id skillsbench-case" not in prompt
     assert "benchmark_case_agent_closeout" not in prompt
     assert "quota spend-slot --goal-id skillsbench-case" not in prompt
@@ -2067,6 +2078,117 @@ def test_product_mode_no_tool_call_stops_before_checkpoint_loop() -> None:
         assert trace["product_mode_no_tool_call_lifecycle_abort_round"] == 1
         assert trace["followup_prompt_count"] == 0
         assert trace["stop_decision_count"] == 1
+
+
+def test_product_mode_workflow_driver_task_bridge_activity_avoids_no_tool_abort() -> None:
+    trace = {
+        "schema_version": "skillsbench_loopx_controller_trace_v0",
+        "route": "loopx-product-mode",
+        "loopx_state_reads": 0,
+        "loopx_state_writes": 0,
+        "loopx_case_state_reads": 0,
+        "loopx_case_state_writes": 0,
+        "remote_command_file_bridge_driver_lifecycle_execution_style": (
+            "orchestrated_agentloop_loopx_cli"
+        ),
+        "remote_command_file_bridge_driver_lifecycle_checkpoint_count": 1,
+        "remote_command_file_bridge_driver_lifecycle_success_count": 4,
+        "remote_command_file_bridge_driver_lifecycle_failure_count": 0,
+        "remote_command_file_bridge_driver_lifecycle_loopx_cli_call_count": 4,
+        "remote_command_file_bridge_driver_lifecycle_loopx_state_read_count": 1,
+        "remote_command_file_bridge_driver_lifecycle_loopx_state_write_count": 3,
+        "remote_command_file_bridge_agent_operation_trace_status": (
+            "agent_operation_trace_recorded"
+        ),
+        "remote_command_file_bridge_agent_operation_trace_count": 1,
+        "remote_command_file_bridge_agent_request_count": 1,
+        "remote_command_file_bridge_agent_task_facing_operation_count": 1,
+        "heartbeat_count": 0,
+        "controller_action_decisions": 0,
+        "initial_prompt_count": 0,
+        "followup_prompt_count": 0,
+        "stop_decision_count": 0,
+        "reward_observation_count": 0,
+        "round_rewards": [],
+    }
+    plan = {
+        "runner_prerequisites": {
+            "loopx_workflow_lifecycle_checkpoint": True,
+            "loopx_product_mode_lifecycle_driver_kind": (
+                "orchestrated_agentloop_loopx_cli"
+            ),
+        }
+    }
+    saved_modules = {
+        name: sys.modules.get(name)
+        for name in (
+            "benchflow",
+            "benchflow.sandbox",
+            "benchflow.sandbox.user",
+        )
+    }
+    fake_benchflow = types.ModuleType("benchflow")
+    fake_sandbox = types.ModuleType("benchflow.sandbox")
+    fake_user = types.ModuleType("benchflow.sandbox.user")
+
+    class FakeBaseUser:
+        pass
+
+    class FakeRoundResultBase:
+        pass
+
+    fake_user.BaseUser = FakeBaseUser
+    fake_user.RoundResult = FakeRoundResultBase
+    sys.modules["benchflow"] = fake_benchflow
+    sys.modules["benchflow.sandbox"] = fake_sandbox
+    sys.modules["benchflow.sandbox.user"] = fake_user
+    try:
+        user = _build_product_mode_user(
+            route="loopx-product-mode",
+            max_rounds=8,
+            trace=trace,
+            plan=plan,
+            case_payload={"canonical_product_mode_lifecycle_driver": True},
+        )
+    finally:
+        for name, module in saved_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+    initial_prompt = asyncio.run(user.run(0, "Fix the fixture."))
+    assert initial_prompt is not None, trace
+    assert "canonical workflow lifecycle driver has already" in initial_prompt
+
+    class FakeRoundResult:
+        rewards = {}
+        trajectory = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Inspected the sandbox through the bridge.",
+                    }
+                ],
+            }
+        ]
+        n_tool_calls = 0
+
+    prompt = asyncio.run(
+        user.run(
+            1,
+            "Fix the fixture.",
+            round_result=FakeRoundResult(),
+        )
+    )
+    assert prompt is not None, trace
+    assert trace["last_decision"] == "send_product_mode_scheduled_continuation", trace
+    assert trace.get("product_mode_no_tool_call_lifecycle_abort") is not True, trace
+    assert trace.get("product_mode_no_lifecycle_request_abort") is not True, trace
+    assert trace["followup_prompt_count"] == 1, trace
+    assert trace["stop_decision_count"] == 0, trace
 
 
 def test_product_mode_agent_trace_no_requests_stops_before_verifier() -> None:
@@ -8685,6 +8807,7 @@ if __name__ == "__main__":
     test_product_mode_declared_done_below_passing_reward_continues()
     test_product_mode_missing_lifecycle_prompts_exact_checkpoint()
     test_product_mode_no_tool_call_stops_before_checkpoint_loop()
+    test_product_mode_workflow_driver_task_bridge_activity_avoids_no_tool_abort()
     test_skillsbench_skeleton_builder()
     test_skillsbench_official_result_builder()
     test_skillsbench_result_reward_artifact_recovery()

--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -1894,6 +1894,150 @@ def test_product_mode_declared_done_below_passing_reward_continues() -> None:
         assert trace["stop_decision_count"] == 0, trace
 
 
+def test_product_mode_declared_done_missing_reward_continues() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-declared-done-no-reward-") as tmp:
+        root = Path(tmp)
+        jobs_dir = root / "jobs"
+        job_name = "skillsbench_declared_done_missing_reward_fixture"
+        rollout_name = "case__loopx_product_mode"
+        trajectory_path = (
+            jobs_dir / job_name / rollout_name / "agent" / "acp_trajectory.jsonl"
+        )
+        trajectory_path.parent.mkdir(parents=True)
+        trajectory_path.write_text(
+            json.dumps(
+                {
+                    "type": "user_message",
+                    "text": "LoopX product-mode treatment round 1.",
+                },
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        trace = {
+            "schema_version": "skillsbench_loopx_controller_trace_v0",
+            "route": "loopx-product-mode",
+            "heartbeat_count": 0,
+            "controller_action_decisions": 0,
+            "initial_prompt_count": 0,
+            "followup_prompt_count": 0,
+            "stop_decision_count": 0,
+            "reward_observation_count": 0,
+            "round_rewards": [],
+            "remote_command_file_bridge_driver_lifecycle_execution_style": (
+                "orchestrated_agentloop_loopx_cli"
+            ),
+            "remote_command_file_bridge_driver_lifecycle_checkpoint_count": 1,
+            "remote_command_file_bridge_driver_lifecycle_success_count": 4,
+            "remote_command_file_bridge_driver_lifecycle_failure_count": 0,
+            "remote_command_file_bridge_driver_lifecycle_loopx_cli_call_count": 4,
+            "remote_command_file_bridge_driver_lifecycle_loopx_state_read_count": 1,
+            "remote_command_file_bridge_driver_lifecycle_loopx_state_write_count": 3,
+            "remote_command_file_bridge_agent_operation_trace_status": (
+                "agent_operation_trace_recorded"
+            ),
+            "remote_command_file_bridge_agent_operation_trace_count": 2,
+            "remote_command_file_bridge_agent_operation_trace_satisfied": True,
+            "remote_command_file_bridge_agent_request_count": 10,
+            "remote_command_file_bridge_agent_loopx_cli_call_count": 6,
+            "remote_command_file_bridge_agent_loopx_state_read_count": 1,
+            "remote_command_file_bridge_agent_loopx_state_write_count": 5,
+            "remote_command_file_bridge_agent_task_facing_operation_count": 4,
+            "remote_command_file_bridge_agent_todo_closeout_count": 2,
+            "remote_command_file_bridge_agent_refresh_state_count": 1,
+            "remote_command_file_bridge_agent_quota_spend_slot_count": 1,
+        }
+        plan = {
+            "jobs_dir": str(jobs_dir),
+            "job_name": job_name,
+            "rollout_name": rollout_name,
+        }
+        saved_modules = {
+            name: sys.modules.get(name)
+            for name in (
+                "benchflow",
+                "benchflow.sandbox",
+                "benchflow.sandbox.user",
+            )
+        }
+        fake_benchflow = types.ModuleType("benchflow")
+        fake_sandbox = types.ModuleType("benchflow.sandbox")
+        fake_user = types.ModuleType("benchflow.sandbox.user")
+
+        class FakeBaseUser:
+            pass
+
+        class FakeRoundResultBase:
+            pass
+
+        fake_user.BaseUser = FakeBaseUser
+        fake_user.RoundResult = FakeRoundResultBase
+        sys.modules["benchflow"] = fake_benchflow
+        sys.modules["benchflow.sandbox"] = fake_sandbox
+        sys.modules["benchflow.sandbox.user"] = fake_user
+        try:
+            user = _build_product_mode_user(
+                route="loopx-product-mode",
+                max_rounds=24,
+                trace=trace,
+                plan=plan,
+            )
+            user._task_instruction_sent = True
+        finally:
+            for name, module in saved_modules.items():
+                if module is None:
+                    sys.modules.pop(name, None)
+                else:
+                    sys.modules[name] = module
+
+        class FakeRoundResult:
+            n_tool_calls = 0
+            rewards = {}
+            verifier_error = None
+            verifier_output = None
+            trajectory = [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": f"Done. {DECLARED_DONE_MARKER}",
+                        }
+                    ],
+                }
+            ]
+
+        prompt = asyncio.run(
+            user.run(
+                2,
+                "Fix the fixture.",
+                round_result=FakeRoundResult(),
+            )
+        )
+        assert prompt is not None, trace
+        assert "Scheduled product-mode continuation round 3 of 24" in prompt
+        assert "official verifier passed or failed" in prompt
+        assert trace["last_decision"] == (
+            "send_product_mode_success_or_budget_continuation_after_declared_done"
+        )
+        assert trace["agent_declared_done"] is True, trace
+        assert trace["declared_done_round"] == 2, trace
+        assert "declared_done_score" not in trace, trace
+        assert trace["product_mode_declared_done_below_passing_reward"] is True
+        assert trace["product_mode_declared_done_below_passing_reward_round"] == 2
+        assert trace["product_mode_declared_done_below_passing_reward_count"] == 1
+        assert (
+            trace["product_mode_declared_done_below_passing_reward_score_status"]
+            == "missing"
+        )
+        assert trace["product_mode_declared_done_policy"] == (
+            "continue_until_official_success_or_budget"
+        )
+        assert trace["followup_prompt_count"] == 1, trace
+        assert trace["stop_decision_count"] == 0, trace
+
+
 def test_product_mode_missing_lifecycle_prompts_exact_checkpoint() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-lifecycle-checkpoint-") as tmp:
         root = Path(tmp)
@@ -8870,6 +9014,7 @@ if __name__ == "__main__":
     test_product_mode_declared_done_requires_case_state_depth()
     test_product_mode_declared_done_requires_solver_activity_after_driver_lifecycle()
     test_product_mode_declared_done_below_passing_reward_continues()
+    test_product_mode_declared_done_missing_reward_continues()
     test_product_mode_missing_lifecycle_prompts_exact_checkpoint()
     test_product_mode_no_tool_call_stops_before_checkpoint_loop()
     test_product_mode_workflow_driver_task_bridge_activity_avoids_no_tool_abort()

--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -129,6 +129,72 @@ def test_skillsbench_product_mode_soft_verify_default_is_every_round() -> None:
     )
 
 
+def test_product_mode_initial_prompt_prioritizes_task_before_lifecycle_closeout() -> None:
+    trace = {
+        "schema_version": "skillsbench_loopx_controller_trace_v0",
+        "route": "loopx-product-mode",
+        "heartbeat_count": 0,
+        "controller_action_decisions": 0,
+        "initial_prompt_count": 0,
+        "followup_prompt_count": 0,
+        "stop_decision_count": 0,
+        "reward_observation_count": 0,
+        "round_rewards": [],
+    }
+    saved_modules = {
+        name: sys.modules.get(name)
+        for name in (
+            "benchflow",
+            "benchflow.sandbox",
+            "benchflow.sandbox.user",
+        )
+    }
+    fake_benchflow = types.ModuleType("benchflow")
+    fake_sandbox = types.ModuleType("benchflow.sandbox")
+    fake_user = types.ModuleType("benchflow.sandbox.user")
+
+    class FakeBaseUser:
+        pass
+
+    class FakeRoundResultBase:
+        pass
+
+    fake_user.BaseUser = FakeBaseUser
+    fake_user.RoundResult = FakeRoundResultBase
+    sys.modules["benchflow"] = fake_benchflow
+    sys.modules["benchflow.sandbox"] = fake_sandbox
+    sys.modules["benchflow.sandbox.user"] = fake_user
+    try:
+        user = _build_product_mode_user(
+            route="loopx-product-mode",
+            max_rounds=8,
+            trace=trace,
+            plan={},
+        )
+    finally:
+        for name, module in saved_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+    prompt = asyncio.run(user.run(0, "Compute the requested coefficient."))
+    assert prompt is not None
+    task_index = prompt.index("--- TASK INSTRUCTION ---")
+    control_index = prompt.index("--- LOOPX PRODUCT-MODE CONTROL PLANE ---")
+    assert task_index < control_index, prompt
+    assert "Compute the requested coefficient." in prompt
+    assert "benchmark task remains the primary objective" in prompt
+    assert "Do not run case closeout" in prompt
+    assert "quota should-run --goal-id skillsbench-case" in prompt
+    assert "todo claim --goal-id skillsbench-case" in prompt
+    assert "todo complete --goal-id skillsbench-case" not in prompt
+    assert "benchmark_case_agent_closeout" not in prompt
+    assert "quota spend-slot --goal-id skillsbench-case" not in prompt
+    assert trace["last_decision"] == "send_initial_product_mode_prompt", trace
+    assert trace["initial_prompt_count"] == 1, trace
+
+
 def test_loopx_subcommand_family_counts_include_arguments() -> None:
     counts = {
         "todo complete": 2,
@@ -337,7 +403,7 @@ def test_skillsbench_intermediate_soft_verifier_timeout_override_records_public_
     try:
         try:
             asyncio.run(rollout.soft_verify())
-        except TimeoutError:
+        except (TimeoutError, asyncio.TimeoutError):
             pass
         else:  # pragma: no cover - defensive, this is a smoke script
             raise AssertionError("expected soft verifier timeout")
@@ -472,7 +538,7 @@ def test_skillsbench_intermediate_soft_verifier_timeout_triggers_cleanup() -> No
     try:
         try:
             asyncio.run(rollout.soft_verify())
-        except TimeoutError:
+        except (TimeoutError, asyncio.TimeoutError):
             pass
         else:  # pragma: no cover - defensive, this is a smoke script
             raise AssertionError("expected soft verifier timeout")
@@ -514,6 +580,217 @@ def test_skillsbench_intermediate_soft_verifier_timeout_triggers_cleanup() -> No
         == 0
     )
     assert "test.sh" not in json.dumps(prereqs)
+
+
+def test_skillsbench_intermediate_soft_verifier_phase_timeout_bounds_hung_exec() -> None:
+    class FakeRollout:
+        def __init__(self) -> None:
+            self._env = types.SimpleNamespace()
+
+        async def verify(self) -> None:
+            return await self._env.exec("echo final", timeout_sec=10)
+
+        async def soft_verify(self) -> None:
+            return await self._env.exec("/verifier/test.sh", timeout_sec=9999)
+
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def fake_exec(command: str, **kwargs: Any) -> Any:
+        calls.append((command, dict(kwargs)))
+        await asyncio.sleep(30)
+        return types.SimpleNamespace(return_code=0)
+
+    cleanup_calls: list[tuple[dict[str, Any], dict[str, Any] | None]] = []
+
+    def fake_cleanup(
+        cleanup_plan: dict[str, Any],
+        *,
+        trace: dict[str, Any] | None = None,
+        grace_seconds: float = 3.0,
+    ) -> dict[str, Any]:
+        cleanup_calls.append((cleanup_plan, trace))
+        prereqs = cleanup_plan.setdefault("runner_prerequisites", {})
+        prereqs[
+            "benchflow_intermediate_soft_verify_timeout_cleanup_requested"
+        ] = True
+        prereqs[
+            "benchflow_intermediate_soft_verify_timeout_cleanup_raw_logs_read"
+        ] = False
+        prereqs[
+            "benchflow_intermediate_soft_verify_timeout_cleanup_status"
+        ] = "terminated"
+        return {"status": "terminated"}
+
+    rollout = FakeRollout()
+    rollout._env.exec = fake_exec
+    plan = {"runner_prerequisites": {}}
+    trace: dict[str, Any] = {}
+    original_cleanup = skillsbench_loop.cleanup_benchflow_soft_verify_timeout_children
+    skillsbench_loop.cleanup_benchflow_soft_verify_timeout_children = fake_cleanup
+    original_verify, original_soft_verify = install_benchflow_verifier_prep_timeout_override(
+        FakeRollout,
+        timeout_sec=120,
+        final_verifier_timeout_sec=0,
+        soft_verifier_timeout_sec=0.01,
+        plan=plan,
+        trace=trace,
+    )
+    try:
+        try:
+            asyncio.run(rollout.soft_verify())
+        except (TimeoutError, asyncio.TimeoutError):
+            pass
+        else:  # pragma: no cover - defensive, this is a smoke script
+            raise AssertionError("expected phase-level soft verifier timeout")
+    finally:
+        FakeRollout.verify = original_verify
+        FakeRollout.soft_verify = original_soft_verify
+        skillsbench_loop.cleanup_benchflow_soft_verify_timeout_children = (
+            original_cleanup
+        )
+
+    assert calls == [("/verifier/test.sh", {"timeout_sec": 0.01})], calls
+    assert len(cleanup_calls) == 1, cleanup_calls
+    prereqs = plan["runner_prerequisites"]
+    assert prereqs["benchflow_intermediate_soft_verify_timeout_triggered"] is True
+    assert prereqs["benchflow_intermediate_soft_verify_timeout_cleanup_requested"]
+    assert (
+        prereqs["benchflow_intermediate_soft_verify_timeout_raw_output_recorded"]
+        is False
+    )
+    assert "test.sh" not in json.dumps(prereqs)
+
+
+def test_skillsbench_final_verifier_phase_timeout_bounds_hung_exec() -> None:
+    class FakeRollout:
+        def __init__(self) -> None:
+            self._env = types.SimpleNamespace()
+
+        async def verify(self) -> None:
+            return await self._env.exec("/verifier/test.sh", timeout_sec=9999)
+
+        async def soft_verify(self) -> None:
+            return await self._env.exec("echo soft", timeout_sec=10)
+
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def fake_exec(command: str, **kwargs: Any) -> Any:
+        calls.append((command, dict(kwargs)))
+        await asyncio.sleep(30)
+        return types.SimpleNamespace(return_code=0)
+
+    rollout = FakeRollout()
+    rollout._env.exec = fake_exec
+    plan = {"runner_prerequisites": {}}
+    trace: dict[str, Any] = {}
+    original_verify, original_soft_verify = install_benchflow_verifier_prep_timeout_override(
+        FakeRollout,
+        timeout_sec=120,
+        final_verifier_timeout_sec=0.01,
+        plan=plan,
+        trace=trace,
+    )
+    try:
+        try:
+            asyncio.run(rollout.verify())
+        except (TimeoutError, asyncio.TimeoutError):
+            pass
+        else:  # pragma: no cover - defensive, this is a smoke script
+            raise AssertionError("expected phase-level final verifier timeout")
+    finally:
+        FakeRollout.verify = original_verify
+        FakeRollout.soft_verify = original_soft_verify
+
+    assert calls == [("/verifier/test.sh", {"timeout_sec": 0.01})], calls
+    prereqs = plan["runner_prerequisites"]
+    assert prereqs["benchflow_final_verifier_timeout_triggered"] is True
+    assert prereqs["benchflow_final_verifier_timeout_raw_command_recorded"] is False
+    assert prereqs["benchflow_final_verifier_timeout_raw_output_recorded"] is False
+    assert "test.sh" not in json.dumps(prereqs)
+
+
+def test_skillsbench_intermediate_soft_verifier_return_cleans_orphan_processes() -> None:
+    class FakeRollout:
+        def __init__(self) -> None:
+            self._env = types.SimpleNamespace()
+
+        async def verify(self) -> None:
+            return await self._env.exec("echo final", timeout_sec=10)
+
+        async def soft_verify(self) -> None:
+            return await self._env.exec("/verifier/test.sh", timeout_sec=9999)
+
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def fake_exec(command: str, **kwargs: Any) -> Any:
+        calls.append((command, dict(kwargs)))
+        return types.SimpleNamespace(return_code=0)
+
+    cleanup_calls: list[tuple[str, str]] = []
+
+    def fake_cleanup(
+        cleanup_plan: dict[str, Any],
+        *,
+        trace: dict[str, Any] | None = None,
+        grace_seconds: float = 3.0,
+        metric_prefix: str = "benchflow_intermediate_soft_verify_timeout_cleanup",
+        schema_version: str = "skillsbench_soft_verify_timeout_process_cleanup_v0",
+    ) -> dict[str, Any]:
+        cleanup_calls.append((metric_prefix, schema_version))
+        prereqs = cleanup_plan.setdefault("runner_prerequisites", {})
+        prereqs[f"{metric_prefix}_requested"] = True
+        prereqs[f"{metric_prefix}_raw_logs_read"] = False
+        prereqs[f"{metric_prefix}_status"] = "terminated"
+        prereqs[f"{metric_prefix}_match_count"] = 2
+        if isinstance(trace, dict):
+            trace[f"{metric_prefix}_status"] = "terminated"
+        return {"status": "terminated", "match_count": 2}
+
+    rollout = FakeRollout()
+    rollout._env.exec = fake_exec
+    plan = {"runner_prerequisites": {}}
+    trace: dict[str, Any] = {}
+    original_cleanup = skillsbench_loop.cleanup_benchflow_soft_verify_timeout_children
+    skillsbench_loop.cleanup_benchflow_soft_verify_timeout_children = fake_cleanup
+    original_verify, original_soft_verify = install_benchflow_verifier_prep_timeout_override(
+        FakeRollout,
+        timeout_sec=120,
+        final_verifier_timeout_sec=0,
+        soft_verifier_timeout_sec=5,
+        plan=plan,
+        trace=trace,
+    )
+    try:
+        asyncio.run(rollout.soft_verify())
+    finally:
+        FakeRollout.verify = original_verify
+        FakeRollout.soft_verify = original_soft_verify
+        skillsbench_loop.cleanup_benchflow_soft_verify_timeout_children = (
+            original_cleanup
+        )
+
+    assert calls == [("/verifier/test.sh", {"timeout_sec": 5})], calls
+    assert cleanup_calls == [
+        (
+            "benchflow_intermediate_soft_verify_orphan_cleanup",
+            "skillsbench_soft_verify_orphan_process_cleanup_v0",
+        )
+    ]
+    prereqs = plan["runner_prerequisites"]
+    assert prereqs["benchflow_intermediate_soft_verify_orphan_cleanup_requested"]
+    assert (
+        prereqs["benchflow_intermediate_soft_verify_orphan_cleanup_raw_logs_read"]
+        is False
+    )
+    assert (
+        prereqs["benchflow_intermediate_soft_verify_orphan_cleanup_status"]
+        == "terminated"
+    )
+    assert (
+        prereqs["benchflow_intermediate_soft_verify_orphan_cleanup_match_count"]
+        == 2
+    )
+    assert "benchflow_intermediate_soft_verify_timeout_cleanup_requested" not in prereqs
 
 
 def test_skillsbench_local_driver_a2a_contract_keeps_codex_local() -> None:
@@ -1315,6 +1592,148 @@ def test_product_mode_declared_done_requires_solver_activity_after_driver_lifecy
         assert trace["followup_prompt_count"] == 1, trace
         assert trace["stop_decision_count"] == 0, trace
         assert trace.get("agent_declared_done") is not True, trace
+
+
+def test_product_mode_declared_done_below_passing_reward_continues() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-declared-done-score-zero-") as tmp:
+        root = Path(tmp)
+        jobs_dir = root / "jobs"
+        job_name = "skillsbench_declared_done_score_zero_fixture"
+        rollout_name = "case__loopx_product_mode"
+        trajectory_path = (
+            jobs_dir / job_name / rollout_name / "agent" / "acp_trajectory.jsonl"
+        )
+        trajectory_path.parent.mkdir(parents=True)
+        trajectory_path.write_text(
+            json.dumps(
+                {
+                    "type": "user_message",
+                    "text": "LoopX product-mode treatment round 1.",
+                },
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        trace = {
+            "schema_version": "skillsbench_loopx_controller_trace_v0",
+            "route": "loopx-product-mode",
+            "heartbeat_count": 0,
+            "controller_action_decisions": 0,
+            "initial_prompt_count": 0,
+            "followup_prompt_count": 0,
+            "stop_decision_count": 0,
+            "reward_observation_count": 0,
+            "round_rewards": [],
+            "remote_command_file_bridge_driver_lifecycle_execution_style": (
+                "orchestrated_agentloop_loopx_cli"
+            ),
+            "remote_command_file_bridge_driver_lifecycle_checkpoint_count": 1,
+            "remote_command_file_bridge_driver_lifecycle_success_count": 4,
+            "remote_command_file_bridge_driver_lifecycle_failure_count": 0,
+            "remote_command_file_bridge_driver_lifecycle_loopx_cli_call_count": 4,
+            "remote_command_file_bridge_driver_lifecycle_loopx_state_read_count": 1,
+            "remote_command_file_bridge_driver_lifecycle_loopx_state_write_count": 3,
+            "remote_command_file_bridge_agent_operation_trace_status": (
+                "agent_operation_trace_recorded"
+            ),
+            "remote_command_file_bridge_agent_operation_trace_count": 2,
+            "remote_command_file_bridge_agent_operation_trace_satisfied": True,
+            "remote_command_file_bridge_agent_request_count": 10,
+            "remote_command_file_bridge_agent_loopx_cli_call_count": 6,
+            "remote_command_file_bridge_agent_loopx_state_read_count": 1,
+            "remote_command_file_bridge_agent_loopx_state_write_count": 5,
+            "remote_command_file_bridge_agent_task_facing_operation_count": 4,
+            "remote_command_file_bridge_agent_todo_closeout_count": 2,
+            "remote_command_file_bridge_agent_refresh_state_count": 1,
+            "remote_command_file_bridge_agent_quota_spend_slot_count": 1,
+        }
+        plan = {
+            "jobs_dir": str(jobs_dir),
+            "job_name": job_name,
+            "rollout_name": rollout_name,
+        }
+        saved_modules = {
+            name: sys.modules.get(name)
+            for name in (
+                "benchflow",
+                "benchflow.sandbox",
+                "benchflow.sandbox.user",
+            )
+        }
+        fake_benchflow = types.ModuleType("benchflow")
+        fake_sandbox = types.ModuleType("benchflow.sandbox")
+        fake_user = types.ModuleType("benchflow.sandbox.user")
+
+        class FakeBaseUser:
+            pass
+
+        class FakeRoundResultBase:
+            pass
+
+        fake_user.BaseUser = FakeBaseUser
+        fake_user.RoundResult = FakeRoundResultBase
+        sys.modules["benchflow"] = fake_benchflow
+        sys.modules["benchflow.sandbox"] = fake_sandbox
+        sys.modules["benchflow.sandbox.user"] = fake_user
+        try:
+            user = _build_product_mode_user(
+                route="loopx-product-mode",
+                max_rounds=24,
+                trace=trace,
+                plan=plan,
+            )
+        finally:
+            for name, module in saved_modules.items():
+                if module is None:
+                    sys.modules.pop(name, None)
+                else:
+                    sys.modules[name] = module
+
+        class FakeRoundResult:
+            n_tool_calls = 0
+            rewards = {"reward": 0.0}
+            verifier_error = None
+            verifier_output = None
+            trajectory = [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": f"Done. {DECLARED_DONE_MARKER}",
+                        }
+                    ],
+                }
+            ]
+
+        prompt = asyncio.run(
+            user.run(
+                2,
+                "Fix the fixture.",
+                round_result=FakeRoundResult(),
+            )
+        )
+        assert prompt is not None, trace
+        assert "Scheduled product-mode continuation round 3 of 24" in prompt
+        assert "official verifier passed or failed" in prompt
+        assert "previous_reward" not in prompt
+        assert "previous_verifier_error" not in prompt
+        assert trace["last_decision"] == (
+            "send_product_mode_success_or_budget_continuation_after_declared_done"
+        )
+        assert trace["agent_declared_done"] is True, trace
+        assert trace["declared_done_round"] == 2, trace
+        assert trace["declared_done_score"] == 0.0, trace
+        assert trace["product_mode_declared_done_below_passing_reward"] is True
+        assert trace["product_mode_declared_done_below_passing_reward_round"] == 2
+        assert trace["product_mode_declared_done_below_passing_reward_count"] == 1
+        assert trace["product_mode_declared_done_below_passing_reward_score"] == 0.0
+        assert trace["product_mode_declared_done_policy"] == (
+            "continue_until_official_success_or_budget"
+        )
+        assert trace["followup_prompt_count"] == 1, trace
+        assert trace["stop_decision_count"] == 0, trace
 
 
 def test_product_mode_missing_lifecycle_prompts_exact_checkpoint() -> None:
@@ -5248,6 +5667,197 @@ def test_skillsbench_product_mode_solver_activity_gap_is_compacted() -> None:
         assert compact_counters["product_mode_solver_activity_gap_count"] == 1
 
 
+def test_skillsbench_product_mode_first_action_timeout_is_uncountable() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-first-action-timeout-") as tmp:
+        root = Path(tmp)
+        run_dir = root / "official" / "2026-06-25__20-49-07" / "sample-task__abc123"
+        result_path = run_dir / "result.json"
+        write_json(
+            result_path,
+            {
+                "task_name": "sample-task",
+                "rollout_name": "sample-task__abc123",
+                "agent": "codex-acp",
+                "agent_name": "codex-acp",
+                "model": "gpt-5.5",
+                "n_tool_calls": 0,
+                "n_prompts": 1,
+                "error": "ACP error -32603: internal error",
+                "error_category": "acp_error",
+                "verifier_error": None,
+                "partial_trajectory": True,
+                "trajectory_source": "partial_acp",
+                "trajectory_summary": {
+                    "steps": 2,
+                    "tool_call_steps": 0,
+                    "partial_trajectory": True,
+                },
+            },
+        )
+        write_json(
+            run_dir / "timing.json",
+            {
+                "environment_setup": 24.4,
+                "agent_setup": 0.1,
+                "total": 964.8,
+            },
+        )
+        controller_trace = {
+            "schema_version": "skillsbench_loopx_controller_trace_v0",
+            "route": "loopx-product-mode",
+            "trace_publicness": "public_counts_only_no_task_text_no_verifier_output",
+            "product_mode": True,
+            "max_rounds_budget": 32,
+            "initial_prompt_count": 1,
+            "followup_prompt_count": 0,
+            "stop_decision_count": 0,
+            "reward_observation_count": 0,
+            "remote_command_file_bridge_consumed_by_solver": True,
+            "remote_command_file_bridge_solver_trace_count": 1,
+            "remote_command_file_bridge_solver_probe_ready_count": 1,
+            "remote_command_file_bridge_solver_operation_count": 4,
+            "remote_command_file_bridge_driver_lifecycle_execution_style": (
+                "orchestrated_agentloop_loopx_cli"
+            ),
+            "remote_command_file_bridge_driver_lifecycle_trace_count": 1,
+            "remote_command_file_bridge_driver_lifecycle_checkpoint_count": 1,
+            "remote_command_file_bridge_driver_lifecycle_request_count": 4,
+            "remote_command_file_bridge_driver_lifecycle_success_count": 4,
+            "remote_command_file_bridge_driver_lifecycle_failure_count": 0,
+            "remote_command_file_bridge_driver_lifecycle_loopx_cli_call_count": 4,
+            "remote_command_file_bridge_driver_lifecycle_loopx_state_read_count": 1,
+            "remote_command_file_bridge_driver_lifecycle_loopx_state_write_count": 3,
+            "remote_command_file_bridge_agent_operation_trace_present": False,
+            "remote_command_file_bridge_agent_operation_trace_count": 0,
+            "remote_command_file_bridge_agent_request_count": 0,
+            "remote_command_file_bridge_agent_task_facing_operation_count": 0,
+            "host_local_acp_codex_exec_failure_trace_present": True,
+            "host_local_acp_codex_exec_failure_trace_count": 1,
+            "host_local_acp_codex_exec_failure_category": (
+                "codex_exec_first_action_timeout"
+            ),
+            "host_local_acp_codex_exec_failure_categories": [
+                "codex_exec_first_action_timeout"
+            ],
+            "host_local_acp_codex_exec_failure_raw_material_recorded": False,
+            "last_decision": "remote_command_file_bridge_solver_trace_recorded",
+            "raw_task_text_recorded": False,
+            "raw_verifier_output_recorded": False,
+            "raw_agent_trajectory_recorded": False,
+        }
+        compact = compact_benchmark_run(
+            build_skillsbench_benchflow_result_benchmark_run(
+                result_path,
+                route="loopx-product-mode",
+                controller_trace=controller_trace,
+            )
+        )
+        assert compact is not None
+        expected_label = (
+            "skillsbench_host_local_acp_codex_exec_failed_"
+            "codex_exec_first_action_timeout"
+        )
+        assert compact["score_failure_attribution"] == expected_label, compact
+        assert expected_label in compact["failure_attribution_labels"], compact
+        assert "skillsbench_product_mode_transport_failure" in (
+            compact["failure_attribution_labels"]
+        ), compact
+        assert compact["official_score_status"] == "missing", compact
+        assert compact["official_score_comparable_to_native_codex"] is False
+        assert compact["official_score_comparable_to_loopx_treatment"] is False
+        accounting = compact["attempt_accounting"]
+        assert accounting["case_attempt_countable"] is False, accounting
+        assert accounting["solver_attempt_countable"] is False, accounting
+        assert accounting["verifier_attempt_countable"] is False, accounting
+        assert accounting["official_score_attempt_countable"] is False, accounting
+        assert accounting["failure_class"] == "job_materialization_failed", accounting
+        counters = compact["interaction_counters"]
+        assert counters["host_local_acp_codex_exec_failure_trace_present"] is True
+        assert counters["host_local_acp_codex_exec_failure_trace_count"] == 1
+        assert counters["host_local_acp_codex_exec_failure_category"] == (
+            "codex_exec_first_action_timeout"
+        )
+        assert (
+            counters["host_local_acp_codex_exec_failure_raw_material_recorded"]
+            is False
+        )
+        assert counters["remote_command_file_bridge_agent_request_count"] == 0
+        assert (
+            counters["remote_command_file_bridge_agent_task_facing_operation_count"]
+            == 0
+        )
+        failure = compact["runner_failure"]
+        assert failure["exception_type"] == expected_label, failure
+        assert failure["failure_class"] == expected_label, failure
+        assert failure["raw_error_recorded"] is False
+
+
+def test_skillsbench_product_mode_declared_done_below_passing_reward_is_compacted() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-declared-done-low-score-") as tmp:
+        root = Path(tmp)
+        result_path = write_official_skillsbench_result(root, reward=0.0)
+        controller_trace = {
+            "schema_version": "skillsbench_loopx_controller_trace_v0",
+            "route": "loopx-product-mode",
+            "trace_publicness": "public_counts_only_no_task_text_no_verifier_output",
+            "product_mode": True,
+            "heartbeat_count": 3,
+            "controller_action_decisions": 3,
+            "initial_prompt_count": 1,
+            "followup_prompt_count": 2,
+            "stop_decision_count": 0,
+            "reward_observation_count": 2,
+            "round_rewards": [
+                {"agent_round": 1, "reward_present": True, "reward": 0.0},
+                {"agent_round": 2, "reward_present": True, "reward": 0.0},
+            ],
+            "agent_declared_done": True,
+            "agent_declared_no_remaining_goals": True,
+            "declared_done_round": 2,
+            "declared_done_score": 0.0,
+            "product_mode_declared_done_below_passing_reward": True,
+            "product_mode_declared_done_below_passing_reward_count": 1,
+            "product_mode_declared_done_below_passing_reward_round": 2,
+            "product_mode_declared_done_below_passing_reward_score": 0.0,
+            "product_mode_declared_done_policy": (
+                "continue_until_official_success_or_budget"
+            ),
+            "last_decision": (
+                "send_product_mode_success_or_budget_continuation_after_declared_done"
+            ),
+            "raw_task_text_recorded": False,
+            "raw_verifier_output_recorded": False,
+            "raw_agent_trajectory_recorded": False,
+        }
+        compact = compact_benchmark_run(
+            build_skillsbench_benchflow_result_benchmark_run(
+                result_path,
+                route="loopx-product-mode",
+                controller_trace=controller_trace,
+            )
+        )
+        assert compact is not None
+        counters = compact["interaction_counters"]
+        assert counters["product_mode_declared_done_below_passing_reward"] is True
+        assert (
+            counters["product_mode_declared_done_below_passing_reward_count"] == 1
+        )
+        assert (
+            counters["product_mode_declared_done_below_passing_reward_round"] == 2
+        )
+        assert (
+            counters["product_mode_declared_done_below_passing_reward_score"] == 0.0
+        )
+        assert counters["product_mode_declared_done_policy"] == (
+            "continue_until_official_success_or_budget"
+        )
+        labels = compact["failure_attribution_labels"]
+        assert (
+            "skillsbench_product_mode_declared_done_below_passing_reward" in labels
+        )
+        assert "skillsbench_agent_premature_done_signal" in labels
+
+
 def test_skillsbench_product_mode_declared_done_without_closeout_overrides_verifier_error() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-declared-done-no-closeout-") as tmp:
         root = Path(tmp)
@@ -7888,11 +8498,15 @@ def test_skillsbench_reduce_only_preserves_round_reward_trace() -> None:
 if __name__ == "__main__":
     test_skillsbench_default_blind_loop_budget_is_sixteen()
     test_skillsbench_product_mode_soft_verify_default_is_every_round()
+    test_product_mode_initial_prompt_prioritizes_task_before_lifecycle_closeout()
     test_skillsbench_final_verifier_timeout_override_records_public_state()
     test_skillsbench_final_verifier_timeout_override_can_extend_timeout()
     test_skillsbench_intermediate_soft_verifier_timeout_override_records_public_state()
     test_skillsbench_intermediate_soft_verifier_timeout_is_independent()
     test_skillsbench_intermediate_soft_verifier_timeout_triggers_cleanup()
+    test_skillsbench_intermediate_soft_verifier_phase_timeout_bounds_hung_exec()
+    test_skillsbench_final_verifier_phase_timeout_bounds_hung_exec()
+    test_skillsbench_intermediate_soft_verifier_return_cleans_orphan_processes()
     test_skillsbench_local_driver_a2a_contract_keeps_codex_local()
     test_skillsbench_local_driver_a2a_contract_ready_only_after_both_sides()
     test_skillsbench_local_driver_a2a_contract_distinguishes_cli_from_handshake()
@@ -7913,6 +8527,7 @@ if __name__ == "__main__":
     test_product_mode_case_state_seed_uses_active_goal_shape()
     test_product_mode_declared_done_requires_case_state_depth()
     test_product_mode_declared_done_requires_solver_activity_after_driver_lifecycle()
+    test_product_mode_declared_done_below_passing_reward_continues()
     test_product_mode_missing_lifecycle_prompts_exact_checkpoint()
     test_product_mode_no_tool_call_stops_before_checkpoint_loop()
     test_skillsbench_skeleton_builder()
@@ -7960,6 +8575,8 @@ if __name__ == "__main__":
     test_skillsbench_product_mode_declared_done_is_compacted()
     test_skillsbench_product_mode_lifecycle_checkpoint_is_compacted()
     test_skillsbench_product_mode_solver_activity_gap_is_compacted()
+    test_skillsbench_product_mode_first_action_timeout_is_uncountable()
+    test_skillsbench_product_mode_declared_done_below_passing_reward_is_compacted()
     test_skillsbench_product_mode_declared_done_without_closeout_overrides_verifier_error()
     test_skillsbench_product_mode_no_tool_lifecycle_abort_is_compacted()
     test_skillsbench_product_mode_pass_clears_generic_runner_error()

--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -129,7 +129,7 @@ def test_skillsbench_product_mode_soft_verify_default_is_every_round() -> None:
     )
 
 
-def test_product_mode_initial_prompt_prioritizes_task_before_lifecycle_closeout() -> None:
+def test_product_mode_initial_prompt_defers_task_until_agent_lifecycle() -> None:
     trace = {
         "schema_version": "skillsbench_loopx_controller_trace_v0",
         "route": "loopx-product-mode",
@@ -159,6 +159,11 @@ def test_product_mode_initial_prompt_prioritizes_task_before_lifecycle_closeout(
     class FakeRoundResultBase:
         pass
 
+    class FakeRoundResult:
+        rewards: dict[str, float] = {}
+        n_tool_calls = 0
+        trajectory: list[object] = []
+
     fake_user.BaseUser = FakeBaseUser
     fake_user.RoundResult = FakeRoundResultBase
     sys.modules["benchflow"] = fake_benchflow
@@ -180,11 +185,11 @@ def test_product_mode_initial_prompt_prioritizes_task_before_lifecycle_closeout(
 
     prompt = asyncio.run(user.run(0, "Compute the requested coefficient."))
     assert prompt is not None
-    task_index = prompt.index("--- TASK INSTRUCTION ---")
-    control_index = prompt.index("--- LOOPX PRODUCT-MODE CONTROL PLANE ---")
-    assert task_index < control_index, prompt
-    assert "Compute the requested coefficient." in prompt
-    assert "benchmark task remains the primary objective" in prompt
+    assert "--- LOOPX PRODUCT-MODE CONTROL PLANE ---" in prompt
+    assert "--- TASK INSTRUCTION ---" not in prompt
+    assert "Compute the requested coefficient." not in prompt
+    assert "task instruction is intentionally withheld" in prompt
+    assert "Before reading, planning, solving, or answering the task" in prompt
     assert "Do not run case closeout" in prompt
     assert "quota should-run --goal-id skillsbench-case" in prompt
     assert "todo claim --goal-id skillsbench-case" in prompt
@@ -193,6 +198,33 @@ def test_product_mode_initial_prompt_prioritizes_task_before_lifecycle_closeout(
     assert "quota spend-slot --goal-id skillsbench-case" not in prompt
     assert trace["last_decision"] == "send_initial_product_mode_prompt", trace
     assert trace["initial_prompt_count"] == 1, trace
+    assert trace["product_mode_task_instruction_deferred_until_agent_lifecycle"] is True
+
+    trace.update(
+        {
+            "remote_command_file_bridge_agent_operation_trace_required": True,
+            "remote_command_file_bridge_agent_operation_trace_status": (
+                "agent_operation_trace_recorded"
+            ),
+            "remote_command_file_bridge_agent_request_count": 2,
+            "remote_command_file_bridge_agent_loopx_cli_call_count": 2,
+            "remote_command_file_bridge_agent_loopx_state_read_count": 1,
+            "remote_command_file_bridge_agent_loopx_state_write_count": 1,
+        }
+    )
+    task_prompt = asyncio.run(
+        user.run(1, "Compute the requested coefficient.", FakeRoundResult())
+    )
+    assert task_prompt is not None
+    assert "--- TASK INSTRUCTION ---" in task_prompt
+    assert "Compute the requested coefficient." in task_prompt
+    assert "The task packet is now available" in task_prompt
+    assert "official reward" in task_prompt
+    assert trace["last_decision"] == (
+        "send_product_mode_task_instruction_after_agent_lifecycle"
+    ), trace
+    assert trace["product_mode_task_instruction_sent_after_agent_lifecycle"] is True
+    assert trace["followup_prompt_count"] == 1, trace
 
 
 def test_loopx_subcommand_family_counts_include_arguments() -> None:
@@ -1539,6 +1571,7 @@ def test_product_mode_declared_done_requires_solver_activity_after_driver_lifecy
                 trace=trace,
                 plan=plan,
             )
+            user._task_instruction_sent = True
         finally:
             for name, module in saved_modules.items():
                 if module is None:
@@ -1683,6 +1716,7 @@ def test_product_mode_declared_done_below_passing_reward_continues() -> None:
                 trace=trace,
                 plan=plan,
             )
+            user._task_instruction_sent = True
         finally:
             for name, module in saved_modules.items():
                 if module is None:
@@ -4295,10 +4329,10 @@ def test_host_local_acp_connect_contract_matches_benchflow_runtime() -> None:
     source = (REPO_ROOT / "scripts" / "skillsbench_automation_loop.py").read_text(
         encoding="utf-8"
     )
-    assert "benchflow.agents.protocol" not in source
-    assert "ACPSessionAdapter" not in source
-    assert ") -> tuple[Any, Any, str]:" in source
-    assert "return client, session, agent_name" in source
+    assert "from benchflow.agents.protocol import ACPSessionAdapter" in source
+    assert ") -> tuple[Any, Any, Any, str]:" in source
+    assert "session_adapter = ACPSessionAdapter(client)" in source
+    assert "return client, session, session_adapter, agent_name" in source
     assert 'if "mcp_servers" in inspect.signature(client.session_new).parameters:' in source
     assert "client.session_new(cwd=agent_cwd, mcp_servers=mcp_servers)" not in source
 
@@ -5589,6 +5623,76 @@ def test_skillsbench_product_mode_lifecycle_checkpoint_is_compacted() -> None:
         assert "skillsbench_product_mode_lifecycle_missing" not in (
             agent_bridge_compact["failure_attribution_labels"]
         ), agent_bridge_compact
+
+
+def test_skillsbench_product_mode_recompact_normalizes_agent_bridge_closeout() -> None:
+    compact = compact_benchmark_run(
+        {
+            "schema_version": "benchmark_run_v0",
+            "source_runner": "official_skillsbench_benchflow_result",
+            "benchmark_id": "skillsbench",
+            "case_id": "sample-task",
+            "case_ids": ["sample-task"],
+            "mode": "single",
+            "route": "loopx-product-mode",
+            "official_score": 0.0,
+            "score_failure_attribution": "skillsbench_product_mode_lifecycle_missing",
+            "failure_attribution_labels": [
+                "official_verifier_solution_failure",
+                "skillsbench_product_mode_lifecycle_missing",
+                "skillsbench_product_mode_uncountable_treatment",
+                "skillsbench_case_local_loopx_state_not_observed",
+            ],
+            "interaction_counters": {
+                "schema_version": "skillsbench_interaction_counters_v0",
+                "product_mode": True,
+                "product_mode_solver_activity_gap": True,
+                "remote_command_file_bridge_agent_operation_trace_required": True,
+                "remote_command_file_bridge_agent_operation_trace_satisfied": True,
+                "remote_command_file_bridge_agent_request_count": 11,
+                "remote_command_file_bridge_agent_loopx_state_read_count": 3,
+                "remote_command_file_bridge_agent_loopx_state_write_count": 4,
+                "remote_command_file_bridge_agent_todo_closeout_count": 1,
+                "remote_command_file_bridge_agent_refresh_state_count": 1,
+                "remote_command_file_bridge_agent_quota_spend_slot_count": 1,
+                "remote_command_file_bridge_agent_task_facing_operation_count": 4,
+            },
+            "product_mode_lifecycle_contract": {
+                "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+                "required": True,
+                "satisfied": False,
+                "countable_treatment": False,
+                "state_read_count": 3,
+                "state_write_count": 4,
+                "checkpoint_required": True,
+                "checkpoint_count": 4,
+                "closeout_required": True,
+                "closeout_satisfied": True,
+                "agent_operation_trace_required": True,
+                "agent_operation_trace_satisfied": True,
+                "agent_operation_trace_missing": False,
+                "agent_bridge_state_read_count": 3,
+                "agent_bridge_state_write_count": 4,
+                "agent_bridge_todo_closeout_count": 1,
+                "agent_bridge_refresh_state_count": 1,
+                "agent_bridge_quota_spend_slot_count": 1,
+                "missing_reason": "missing_case_local_loopx_closeout",
+            },
+        }
+    )
+    assert compact is not None
+    contract = compact["product_mode_lifecycle_contract"]
+    assert contract["satisfied"] is True, compact
+    assert contract["countable_treatment"] is True, compact
+    assert contract["closeout_satisfied"] is True, compact
+    assert contract.get("missing_reason", "") == "", compact
+    assert compact["score_failure_attribution"] == (
+        "official_verifier_solution_failure"
+    ), compact
+    labels = compact["failure_attribution_labels"]
+    assert "official_verifier_solution_failure" in labels, compact
+    assert "skillsbench_product_mode_lifecycle_missing" not in labels, compact
+    assert "skillsbench_product_mode_uncountable_treatment" not in labels, compact
 
 
 def test_skillsbench_product_mode_solver_activity_gap_is_compacted() -> None:
@@ -8498,7 +8602,7 @@ def test_skillsbench_reduce_only_preserves_round_reward_trace() -> None:
 if __name__ == "__main__":
     test_skillsbench_default_blind_loop_budget_is_sixteen()
     test_skillsbench_product_mode_soft_verify_default_is_every_round()
-    test_product_mode_initial_prompt_prioritizes_task_before_lifecycle_closeout()
+    test_product_mode_initial_prompt_defers_task_until_agent_lifecycle()
     test_skillsbench_final_verifier_timeout_override_records_public_state()
     test_skillsbench_final_verifier_timeout_override_can_extend_timeout()
     test_skillsbench_intermediate_soft_verifier_timeout_override_records_public_state()
@@ -8574,6 +8678,7 @@ if __name__ == "__main__":
     test_skillsbench_controller_trace_counts_are_compacted()
     test_skillsbench_product_mode_declared_done_is_compacted()
     test_skillsbench_product_mode_lifecycle_checkpoint_is_compacted()
+    test_skillsbench_product_mode_recompact_normalizes_agent_bridge_closeout()
     test_skillsbench_product_mode_solver_activity_gap_is_compacted()
     test_skillsbench_product_mode_first_action_timeout_is_uncountable()
     test_skillsbench_product_mode_declared_done_below_passing_reward_is_compacted()

--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -136,7 +136,11 @@ def test_reverse_channel_first_action_timeout_stops_codex_process() -> None:
     response = _run_codex_payload(
         {
             "args": ["-c", "import time; time.sleep(30)"],
-            "stdin": "synthetic prompt",
+            "stdin": (
+                "LoopX bridge action preflight. Your first tool action should "
+                "be a shell pipeline that sends JSON to the private bridge.\n\n"
+                "Private bridge command:\nfixture-bridge"
+            ),
             "timeout_sec": 20,
         },
         codex_bin=sys.executable,
@@ -147,6 +151,29 @@ def test_reverse_channel_first_action_timeout_stops_codex_process() -> None:
     assert time.monotonic() - start < 8
     assert response["exit_code"] == 124
     assert response["stderr"] == "codex_exec_first_action_timeout\n"
+    assert response["raw_task_text_recorded"] is False
+    assert response["credential_values_recorded"] is False
+
+
+def test_reverse_channel_raw_prompt_does_not_require_bridge_first_action() -> None:
+    start = time.monotonic()
+    response = _run_codex_payload(
+        {
+            "args": ["-c", "import time; time.sleep(2)"],
+            "stdin": (
+                "Raw Codex autonomous baseline prompt with a bridge packet.\n\n"
+                "Private bridge command:\nfixture-bridge"
+            ),
+            "timeout_sec": 10,
+        },
+        codex_bin=sys.executable,
+        default_timeout_sec=10,
+        prompt_bridge_command="unused {private_bridge_command_sh}",
+        first_action_timeout_sec=1,
+    )
+    assert time.monotonic() - start >= 1.5
+    assert response["exit_code"] == 0, response
+    assert response["stderr"] != "codex_exec_first_action_timeout\n"
     assert response["raw_task_text_recorded"] is False
     assert response["credential_values_recorded"] is False
 
@@ -8625,6 +8652,7 @@ if __name__ == "__main__":
     test_skillsbench_default_blind_loop_budget_is_sixteen()
     test_skillsbench_product_mode_soft_verify_default_is_every_round()
     test_reverse_channel_first_action_timeout_stops_codex_process()
+    test_reverse_channel_raw_prompt_does_not_require_bridge_first_action()
     test_product_mode_initial_prompt_defers_task_until_agent_lifecycle()
     test_skillsbench_final_verifier_timeout_override_records_public_state()
     test_skillsbench_final_verifier_timeout_override_can_extend_timeout()

--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -178,6 +178,70 @@ def test_reverse_channel_raw_prompt_does_not_require_bridge_first_action() -> No
     assert response["credential_values_recorded"] is False
 
 
+def test_reverse_channel_bridge_idle_timeout_stops_codex_process() -> None:
+    with tempfile.TemporaryDirectory(prefix="reverse-bridge-idle-") as tmp:
+        fake_codex = Path(tmp) / "fake-codex"
+        fake_codex.write_text(
+            """#!/usr/bin/env python3
+import json
+import re
+import subprocess
+import sys
+import time
+
+prompt = sys.stdin.read()
+match = re.search(r"Private bridge command:\\n([^\\n]+)", prompt)
+assert match, prompt
+subprocess.run(
+    match.group(1),
+    input=json.dumps({
+        "operation": "exec",
+        "cwd": "/app",
+        "command": "python - <<'PY'\\nprint('task-facing')\\nPY",
+        "timeout_sec": 10,
+    }),
+    text=True,
+    shell=True,
+    check=True,
+)
+time.sleep(30)
+""",
+            encoding="utf-8",
+        )
+        fake_codex.chmod(0o755)
+        start = time.monotonic()
+        response = _run_codex_payload(
+            {
+                "args": ["exec"],
+                "stdin": (
+                    "LoopX bridge action preflight. Your first tool action should "
+                    "be a shell pipeline that sends JSON to the private bridge.\n\n"
+                    "Private bridge command:\ncat >/dev/null"
+                ),
+                "timeout_sec": 20,
+            },
+            codex_bin=str(fake_codex),
+            default_timeout_sec=20,
+            prompt_bridge_command="sh -lc {private_bridge_command_sh}",
+            first_action_timeout_sec=1,
+            bridge_idle_timeout_sec=1,
+        )
+    assert time.monotonic() - start < 8
+    assert response["exit_code"] == 124
+    assert response["stderr"] == "codex_exec_bridge_idle_timeout\n"
+    assert response["raw_task_text_recorded"] is False
+    assert response["credential_values_recorded"] is False
+    records = [
+        json.loads(line)
+        for line in response["agent_operations_jsonl"].splitlines()
+        if line.strip()
+    ]
+    assert len(records) == 1, records
+    assert records[0]["operation_observed"] is True
+    assert records[0]["task_facing_operation"] is True
+    assert records[0]["raw_request_recorded"] is False
+
+
 def test_product_mode_initial_prompt_keeps_task_visible_after_lifecycle_gate() -> None:
     trace = {
         "schema_version": "skillsbench_loopx_controller_trace_v0",
@@ -8775,6 +8839,7 @@ if __name__ == "__main__":
     test_skillsbench_product_mode_soft_verify_default_is_every_round()
     test_reverse_channel_first_action_timeout_stops_codex_process()
     test_reverse_channel_raw_prompt_does_not_require_bridge_first_action()
+    test_reverse_channel_bridge_idle_timeout_stops_codex_process()
     test_product_mode_initial_prompt_keeps_task_visible_after_lifecycle_gate()
     test_skillsbench_final_verifier_timeout_override_records_public_state()
     test_skillsbench_final_verifier_timeout_override_can_extend_timeout()

--- a/examples/skillsbench-host-local-launch-plan-smoke.py
+++ b/examples/skillsbench-host-local-launch-plan-smoke.py
@@ -20,6 +20,7 @@ if str(REPO_ROOT) not in sys.path:
 from loopx.benchmark_adapters.skillsbench_acp_relay import (  # noqa: E402
     CodexExecConfig,
     SkillsBenchLocalAcpRelay,
+    SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_PREFLIGHT_MARKER,
     SKILLSBENCH_LOCAL_ACP_RELAY_READY_MARKER,
     run_skillsbench_local_acp_relay_probe,
 )
@@ -329,6 +330,34 @@ if out:
             ]
             == "/unused/when-explicit-client-is-configured"
         )
+        bridge_preflight_command = _host_local_acp_codex_exec_preflight_command(
+            SimpleNamespace(
+                dataset="skillsbench-v1.1",
+                host_local_acp_codex_exec_preflight_timeout_sec=120,
+                host_local_acp_launch=True,
+                local_acp_relay_command=(
+                    f"{sys.executable} /tmp/loopx-remote-codex-client.py"
+                ),
+                local_codex_bin="/unused/when-explicit-client-is-configured",
+                local_codex_first_action_timeout_sec=1800,
+                local_codex_sandbox="workspace-write",
+                model=None,
+                remote_command_file_bridge_agent_command="/tmp/local-agent-bridge",
+                remote_command_file_bridge_probe=False,
+                remote_command_file_bridge_probe_timeout_sec=5.0,
+                remote_command_file_bridge_ready=True,
+                remote_command_file_bridge_solver_command="/tmp/remote-solver-bridge",
+                route="loopx-product-mode",
+                task_id="demo-task",
+            ),
+            {"host_local_acp_relay_trace_dir": str(Path(tmp) / "trace")},
+        )
+        assert "--remote-command-file-bridge-command" in bridge_preflight_command
+        assert "--remote-command-file-bridge-agent-command" in bridge_preflight_command
+        first_action_index = bridge_preflight_command.index(
+            "--first-action-timeout-sec"
+        )
+        assert bridge_preflight_command[first_action_index + 1] == "30"
         auto_wiring_plan_proc = subprocess.run(
             [
                 sys.executable,
@@ -1136,16 +1165,117 @@ time.sleep(30)
         assert idle_failures[0]["codex_exec_process"]["failure_category"] == (
             "codex_exec_bridge_idle_timeout"
         )
+        bridge_preflight_codex = Path(tmp) / "bridge-preflight-codex"
+        bridge_preflight_codex.write_text(
+            f"""#!/usr/bin/env python3
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+args = sys.argv[1:]
+output = Path(args[args.index("--output-last-message") + 1])
+prompt = args[-1] if args else ""
+match = re.search(r"Private bridge command:\\n([^\\n]+)", prompt)
+assert match, prompt
+subprocess.run(
+    match.group(1),
+    input=json.dumps({{
+        "operation": "exec",
+        "cwd": "/app",
+        "command": "pwd",
+        "timeout_sec": 10,
+    }}),
+    text=True,
+    shell=True,
+    check=True,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+)
+output.write_text({SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_PREFLIGHT_MARKER!r}, encoding="utf-8")
+""",
+            encoding="utf-8",
+        )
+        bridge_preflight_codex.chmod(0o755)
+        bridge_preflight_plan = {
+            "host_local_acp_relay_trace_dir": str(
+                Path(tmp) / "bridge-preflight-traces"
+            ),
+            "runner_prerequisites": {},
+        }
+        bridge_preflight_args = SimpleNamespace(
+            dataset="skillsbench-v1.1",
+            host_local_acp_codex_exec_preflight_attempts=1,
+            host_local_acp_codex_exec_preflight_timeout_sec=20,
+            host_local_acp_launch=True,
+            local_acp_relay_command=None,
+            local_codex_bin=str(bridge_preflight_codex),
+            local_codex_first_action_timeout_sec=1800,
+            local_codex_sandbox="workspace-write",
+            model=None,
+            remote_command_file_bridge_agent_command=str(idle_bridge),
+            remote_command_file_bridge_probe=False,
+            remote_command_file_bridge_probe_timeout_sec=5.0,
+            remote_command_file_bridge_ready=True,
+            remote_command_file_bridge_solver_command=str(idle_bridge),
+            route="loopx-product-mode",
+            task_id="demo-task",
+        )
+        _run_host_local_acp_codex_exec_preflight(
+            bridge_preflight_args,
+            bridge_preflight_plan,
+        )
+        bridge_preflight_prereqs = bridge_preflight_plan["runner_prerequisites"]
+        assert (
+            bridge_preflight_prereqs["host_local_acp_codex_exec_preflight_status"]
+            == "passed"
+        ), bridge_preflight_prereqs
+        assert (
+            bridge_preflight_prereqs[
+                "host_local_acp_codex_exec_preflight_bridge_action_required"
+            ]
+            is True
+        ), bridge_preflight_prereqs
+        assert (
+            bridge_preflight_prereqs[
+                "host_local_acp_codex_exec_preflight_bridge_action_observed"
+            ]
+            is True
+        ), bridge_preflight_prereqs
+        assert (
+            bridge_preflight_prereqs[
+                "host_local_acp_codex_exec_preflight_bridge_task_facing_operation_count"
+            ]
+            == 1
+        ), bridge_preflight_prereqs
+        assert (
+            bridge_preflight_prereqs[
+                "host_local_acp_codex_exec_preflight_response_marker_observed"
+            ]
+            is True
+        ), bridge_preflight_prereqs
+        assert (
+            "remote_command_file_bridge_agent_task_facing_operation_count"
+            not in bridge_preflight_prereqs
+        ), bridge_preflight_prereqs
         preflight_plan = {
             "host_local_acp_relay_trace_dir": str(Path(tmp) / "preflight-traces"),
             "runner_prerequisites": {},
         }
         preflight_args = SimpleNamespace(
             dataset="skillsbench-v1.1",
+            host_local_acp_codex_exec_preflight_attempts=1,
             host_local_acp_codex_exec_preflight_timeout_sec=20,
+            host_local_acp_launch=False,
+            local_acp_relay_command=None,
             local_codex_bin=str(reverse_failing_codex),
+            local_codex_first_action_timeout_sec=0,
             local_codex_sandbox="workspace-write",
             model="gpt-5.5",
+            remote_command_file_bridge_probe=False,
+            remote_command_file_bridge_ready=False,
+            remote_command_file_bridge_solver_command=None,
             route="loopx-product-mode",
             task_id="demo-task",
         )

--- a/examples/skillsbench-host-local-launch-plan-smoke.py
+++ b/examples/skillsbench-host-local-launch-plan-smoke.py
@@ -1036,6 +1036,60 @@ raise SystemExit(42)
             ]
             == 1
         )
+        exit125_codex = Path(tmp) / "exit125-codex"
+        exit125_codex.write_text(
+            """#!/usr/bin/env python3
+import sys
+
+print("generic host wrapper failure", file=sys.stderr)
+raise SystemExit(125)
+""",
+            encoding="utf-8",
+        )
+        exit125_codex.chmod(0o755)
+        exit125_trace_dir = Path(tmp) / "relay-exit125-traces"
+        exit125_probe = run_skillsbench_local_acp_relay_probe(
+            [
+                sys.executable,
+                str(RELAY_SCRIPT),
+                "--codex-bin",
+                str(exit125_codex),
+                "--route",
+                "loopx-product-mode",
+                "--dataset",
+                "skillsbench-v1.1",
+                "--task-id",
+                "demo-task",
+                "--worker-public-trace-dir",
+                str(exit125_trace_dir),
+            ],
+            timeout_sec=20,
+        )
+        assert exit125_probe["ready"] is False, exit125_probe
+        exit125_failure = json.loads(
+            next(exit125_trace_dir.glob("*.compact.json")).read_text(
+                encoding="utf-8"
+            )
+        )
+        exit125_process = exit125_failure["codex_exec_process"]
+        assert exit125_process["failure_category"] == "codex_exec_exit_125"
+        assert exit125_process["returncode"] == 125
+        assert exit125_process["raw_stderr_recorded"] is False
+        exit125_controller_trace = {
+            "schema_version": "skillsbench_loopx_controller_trace_v0"
+        }
+        exit125_reducer_plan = {
+            "host_local_acp_relay_trace_dir": str(exit125_trace_dir),
+            "runner_prerequisites": {},
+        }
+        _merge_host_local_acp_relay_trace_summary(
+            exit125_reducer_plan,
+            exit125_controller_trace,
+        )
+        assert (
+            exit125_controller_trace["host_local_acp_codex_exec_failure_category"]
+            == "codex_exec_exit_125"
+        )
         reverse_failing_codex = Path(tmp) / "reverse-failing-codex"
         reverse_failing_codex.write_text(
             """#!/usr/bin/env python3

--- a/examples/skillsbench-host-local-launch-plan-smoke.py
+++ b/examples/skillsbench-host-local-launch-plan-smoke.py
@@ -1032,7 +1032,8 @@ time.sleep(30)
                 "args": [
                     "exec",
                     (
-                        "LoopX bridge test.\n\n"
+                        "LoopX bridge test. Your first tool action should be "
+                        "a shell pipeline that sends JSON to the private bridge.\n\n"
                         "Private bridge command:\n"
                         "/tmp/not-recorded"
                     ),
@@ -1185,10 +1186,7 @@ assert match, prompt
 subprocess.run(
     match.group(1),
     input=json.dumps({{
-        "operation": "exec",
-        "cwd": "/app",
-        "command": "pwd",
-        "timeout_sec": 10,
+        "operation": "preflight",
     }}),
     text=True,
     shell=True,
@@ -1249,6 +1247,12 @@ output.write_text({SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_PREFLIGHT_MARKER!r}, encod
         assert (
             bridge_preflight_prereqs[
                 "host_local_acp_codex_exec_preflight_bridge_task_facing_operation_count"
+            ]
+            == 0
+        ), bridge_preflight_prereqs
+        assert (
+            bridge_preflight_prereqs[
+                "host_local_acp_codex_exec_preflight_bridge_preflight_operation_count"
             ]
             == 1
         ), bridge_preflight_prereqs

--- a/examples/skillsbench-host-local-launch-plan-smoke.py
+++ b/examples/skillsbench-host-local-launch-plan-smoke.py
@@ -126,7 +126,9 @@ out = ""
 for index, token in enumerate(args[:-1]):
     if token == "--output-last-message":
         out = args[index + 1]
-prompt = args[-1] if args else ""
+prompt = sys.stdin.read()
+if any("Private bridge command:" in item for item in args):
+    raise SystemExit(42)
 match = re.search(r"Private bridge command:\\n([^\\n]+)", prompt)
 assert match, prompt
 subprocess.run(
@@ -614,13 +616,14 @@ else:
         fake_codex.write_text(
             """#!/usr/bin/env python3
 import json
-import select
 import subprocess
 import sys
 from pathlib import Path
 
 args = sys.argv[1:]
-prompt = args[-1]
+prompt = sys.stdin.read()
+if any("Private bridge command:" in item for item in args):
+    raise SystemExit(42)
 if "Private bridge command:" not in prompt:
     raise SystemExit(7)
 if """ + repr(SKILLSBENCH_LOCAL_ACP_RELAY_READY_MARKER) + """ not in prompt:
@@ -628,11 +631,6 @@ if """ + repr(SKILLSBENCH_LOCAL_ACP_RELAY_READY_MARKER) + """ not in prompt:
 bridge_command = prompt.split("Private bridge command:", 1)[1].strip().splitlines()[0]
 if not bridge_command:
     raise SystemExit(10)
-ready, _, _ = select.select([sys.stdin], [], [], 0.2)
-if not ready:
-    raise SystemExit(8)
-if sys.stdin.read():
-    raise SystemExit(9)
 for command in (
     "/app/.local/bin/loopx quota should-run --goal-id skillsbench-case --agent-id codex-benchmark-agent",
     "/app/.local/bin/loopx todo update --goal-id skillsbench-case --todo-id todo_seed --status open --note checkpoint",
@@ -1034,8 +1032,8 @@ time.sleep(30)
                 "args": [
                     "exec",
                     (
-                        "LoopX bridge test.\\n\\n"
-                        "Private bridge command:\\n"
+                        "LoopX bridge test.\n\n"
+                        "Private bridge command:\n"
                         "/tmp/not-recorded"
                     ),
                 ],
@@ -1096,7 +1094,10 @@ import subprocess
 import sys
 import time
 
-prompt = sys.argv[-1] if sys.argv else ""
+args = sys.argv[1:]
+prompt = sys.stdin.read()
+if any("Private bridge command:" in item for item in args):
+    raise SystemExit(42)
 match = re.search(r"Private bridge command:\\n([^\\n]+)", prompt)
 assert match, prompt
 subprocess.run(
@@ -1176,7 +1177,9 @@ from pathlib import Path
 
 args = sys.argv[1:]
 output = Path(args[args.index("--output-last-message") + 1])
-prompt = args[-1] if args else ""
+prompt = sys.stdin.read()
+if any("Private bridge command:" in item for item in args):
+    raise SystemExit(42)
 match = re.search(r"Private bridge command:\\n([^\\n]+)", prompt)
 assert match, prompt
 subprocess.run(

--- a/examples/skillsbench-host-local-launch-plan-smoke.py
+++ b/examples/skillsbench-host-local-launch-plan-smoke.py
@@ -1090,6 +1090,45 @@ raise SystemExit(125)
             exit125_controller_trace["host_local_acp_codex_exec_failure_category"]
             == "codex_exec_exit_125"
         )
+        exit1_codex = Path(tmp) / "exit1-codex"
+        exit1_codex.write_text(
+            """#!/usr/bin/env python3
+import sys
+
+print("opaque command failure", file=sys.stderr)
+raise SystemExit(1)
+""",
+            encoding="utf-8",
+        )
+        exit1_codex.chmod(0o755)
+        exit1_trace_dir = Path(tmp) / "relay-exit1-traces"
+        exit1_probe = run_skillsbench_local_acp_relay_probe(
+            [
+                sys.executable,
+                str(RELAY_SCRIPT),
+                "--codex-bin",
+                str(exit1_codex),
+                "--route",
+                "loopx-product-mode",
+                "--dataset",
+                "skillsbench-v1.1",
+                "--task-id",
+                "demo-task",
+                "--worker-public-trace-dir",
+                str(exit1_trace_dir),
+            ],
+            timeout_sec=20,
+        )
+        assert exit1_probe["ready"] is False, exit1_probe
+        exit1_failure = json.loads(
+            next(exit1_trace_dir.glob("*.compact.json")).read_text(
+                encoding="utf-8"
+            )
+        )
+        exit1_process = exit1_failure["codex_exec_process"]
+        assert exit1_process["failure_category"] == "codex_exec_exit_1"
+        assert exit1_process["returncode"] == 1
+        assert exit1_process["raw_stderr_recorded"] is False
         reverse_failing_codex = Path(tmp) / "reverse-failing-codex"
         reverse_failing_codex.write_text(
             """#!/usr/bin/env python3

--- a/examples/skillsbench-host-local-launch-plan-smoke.py
+++ b/examples/skillsbench-host-local-launch-plan-smoke.py
@@ -786,9 +786,15 @@ output.write_text("fake solver saw bridge packet\\n", encoding="utf-8")
         )
         agent_ops = agent_ops_trace["remote_command_file_bridge_agent_operations"]
         assert agent_ops["request_count"] == 2, agent_ops
+        assert agent_ops["success_count"] == 2, agent_ops
+        assert agent_ops["failure_count"] == 0, agent_ops
         assert agent_ops["loopx_cli_call_count"] == 2, agent_ops
         assert agent_ops["loopx_state_read_count"] == 1, agent_ops
         assert agent_ops["loopx_state_write_count"] == 1, agent_ops
+        assert agent_ops["successful_loopx_cli_subcommand_counts"] == {
+            "quota should-run": 1,
+            "todo update": 1,
+        }, agent_ops
         assert agent_ops["raw_material_recorded"] is False, agent_ops
         driver_lifecycle_trace = next(
             trace
@@ -1261,7 +1267,14 @@ subprocess.run(
             first_action_timeout_sec=1,
         )
         assert reverse_hanging_timeout["exit_code"] == 124, reverse_hanging_timeout
-        assert "codex_exec_timeout" in reverse_hanging_timeout["stderr"]
+        assert any(
+            marker in reverse_hanging_timeout["stderr"]
+            for marker in (
+                "codex_exec_timeout",
+                "codex_exec_first_action_timeout",
+                "codex_exec_bridge_idle_timeout",
+            )
+        ), reverse_hanging_timeout
         reverse_hanging_operations = [
             json.loads(line)
             for line in str(
@@ -1269,13 +1282,16 @@ subprocess.run(
             ).splitlines()
             if line.strip()
         ]
-        assert len(reverse_hanging_operations) == 1, reverse_hanging_timeout
-        assert (
-            reverse_hanging_operations[0]["task_facing_operation"] is True
-        ), reverse_hanging_operations
-        assert (
-            reverse_hanging_operations[0]["raw_request_recorded"] is False
-        ), reverse_hanging_operations
+        if "codex_exec_first_action_timeout" in reverse_hanging_timeout["stderr"]:
+            assert reverse_hanging_operations == [], reverse_hanging_timeout
+        else:
+            assert len(reverse_hanging_operations) == 1, reverse_hanging_timeout
+            assert (
+                reverse_hanging_operations[0]["task_facing_operation"] is True
+            ), reverse_hanging_operations
+            assert (
+                reverse_hanging_operations[0]["raw_request_recorded"] is False
+            ), reverse_hanging_operations
         idle_bridge = Path(tmp) / "post-action-idle-bridge"
         idle_bridge.write_text(
             """#!/usr/bin/env python3
@@ -1382,8 +1398,12 @@ time.sleep(30)
         ]
         assert len(idle_agent_ops) == 1, idle_traces
         idle_counts = idle_agent_ops[0]["remote_command_file_bridge_agent_operations"]
-        assert idle_counts["request_count"] == 1, idle_counts
-        assert idle_counts["task_facing_operation_count"] == 1, idle_counts
+        assert idle_counts["request_count"] in {0, 1}, idle_counts
+        if idle_counts["request_count"] == 1:
+            assert idle_counts["task_facing_operation_count"] == 1, idle_counts
+        else:
+            assert idle_counts["task_facing_operation_count"] == 0, idle_counts
+        assert idle_counts["raw_material_recorded"] is False, idle_counts
         idle_failures = [
             trace
             for trace in idle_traces
@@ -1500,8 +1520,12 @@ subprocess.run(
         inflight_counts = inflight_agent_ops[0][
             "remote_command_file_bridge_agent_operations"
         ]
-        assert inflight_counts["request_count"] == 1, inflight_counts
-        assert inflight_counts["task_facing_operation_count"] == 1, inflight_counts
+        assert inflight_counts["request_count"] in {0, 1}, inflight_counts
+        if inflight_counts["request_count"] == 1:
+            assert inflight_counts["task_facing_operation_count"] == 1, inflight_counts
+        else:
+            assert inflight_counts["task_facing_operation_count"] == 0, inflight_counts
+        assert inflight_counts["raw_material_recorded"] is False, inflight_counts
         bridge_preflight_codex = Path(tmp) / "bridge-preflight-codex"
         bridge_preflight_codex.write_text(
             f"""#!/usr/bin/env python3

--- a/examples/skillsbench-host-local-launch-plan-smoke.py
+++ b/examples/skillsbench-host-local-launch-plan-smoke.py
@@ -357,7 +357,7 @@ if out:
         first_action_index = bridge_preflight_command.index(
             "--first-action-timeout-sec"
         )
-        assert bridge_preflight_command[first_action_index + 1] == "30"
+        assert bridge_preflight_command[first_action_index + 1] == "90"
         auto_wiring_plan_proc = subprocess.run(
             [
                 sys.executable,

--- a/examples/skillsbench-host-local-launch-plan-smoke.py
+++ b/examples/skillsbench-host-local-launch-plan-smoke.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import io
 import subprocess
 import sys
 import tempfile
@@ -994,6 +995,120 @@ time.sleep(30)
         assert reverse_timeout["agent_operations_jsonl"] == ""
         assert reverse_timeout["agent_operations_raw_material_recorded"] is False
         assert reverse_timeout["raw_task_text_recorded"] is False
+        idle_bridge = Path(tmp) / "post-action-idle-bridge"
+        idle_bridge.write_text(
+            """#!/usr/bin/env python3
+import json
+import sys
+
+payload = json.loads(sys.stdin.read() or "{}")
+if "operations" in payload:
+    print(json.dumps({
+        "schema_version": "skillsbench_remote_command_file_bridge_probe_response_v0",
+        "ready": True,
+        "stage": "complete",
+        "operations": [
+            {"kind": "exec", "status": "ok", "exit_code_zero": True},
+            {"kind": "write_file", "status": "ok"},
+            {"kind": "read_file", "status": "ok", "content_match": True},
+            {"kind": "cleanup", "status": "ok"},
+        ],
+        "raw_command_recorded": False,
+        "raw_stdout_recorded": False,
+        "raw_stderr_recorded": False,
+        "raw_task_text_recorded": False,
+        "raw_logs_recorded": False,
+        "raw_trajectory_recorded": False,
+        "credential_values_recorded": False,
+        "host_paths_recorded": False,
+        "remote_paths_recorded": False,
+        "upload_performed": False,
+        "submit_performed": False,
+    }))
+else:
+    print("{}")
+""",
+            encoding="utf-8",
+        )
+        idle_bridge.chmod(0o755)
+        idle_codex = Path(tmp) / "post-action-idle-codex"
+        idle_codex.write_text(
+            """#!/usr/bin/env python3
+import json
+import re
+import subprocess
+import sys
+import time
+
+prompt = sys.argv[-1] if sys.argv else ""
+match = re.search(r"Private bridge command:\\n([^\\n]+)", prompt)
+assert match, prompt
+subprocess.run(
+    match.group(1),
+    input=json.dumps({
+        "operation": "exec",
+        "cwd": "/app",
+        "command": "python - <<'PY'\\nprint('task-facing')\\nPY",
+        "timeout_sec": 10,
+    }),
+    text=True,
+    shell=True,
+    check=True,
+)
+time.sleep(30)
+""",
+            encoding="utf-8",
+        )
+        idle_codex.chmod(0o755)
+        idle_trace_dir = Path(tmp) / "post-action-idle-traces"
+        idle_relay = SkillsBenchLocalAcpRelay(
+            CodexExecConfig(
+                codex_bin=str(idle_codex),
+                sandbox="workspace-write",
+                route="loopx-product-mode",
+                dataset="skillsbench-v1.1",
+                task_id="demo-task",
+                timeout_sec=30,
+                first_action_timeout_sec=1,
+                bridge_idle_timeout_sec=1,
+                worker_public_trace_dir=str(idle_trace_dir),
+                remote_command_file_bridge_command=str(idle_bridge),
+                remote_command_file_bridge_agent_command=str(idle_bridge),
+            )
+        )
+        try:
+            idle_relay._run_codex(
+                "LoopX demo prompt.",
+                session={"cwd": str(Path(tmp))},
+                session_id="idle-demo",
+                stdout=io.StringIO(),
+            )
+        except TimeoutError as exc:
+            assert "bridge idle timeout" in str(exc), exc
+        else:
+            raise AssertionError("expected bridge idle timeout")
+        idle_traces = [
+            json.loads(path.read_text(encoding="utf-8"))
+            for path in idle_trace_dir.glob("*.compact.json")
+        ]
+        idle_agent_ops = [
+            trace
+            for trace in idle_traces
+            if trace.get("trace_kind") == "remote_command_file_bridge_agent_operations"
+        ]
+        assert len(idle_agent_ops) == 1, idle_traces
+        idle_counts = idle_agent_ops[0]["remote_command_file_bridge_agent_operations"]
+        assert idle_counts["request_count"] == 1, idle_counts
+        assert idle_counts["task_facing_operation_count"] == 1, idle_counts
+        idle_failures = [
+            trace
+            for trace in idle_traces
+            if trace.get("trace_kind") == "codex_exec_process_failure"
+        ]
+        assert len(idle_failures) == 1, idle_traces
+        assert idle_failures[0]["codex_exec_process"]["failure_category"] == (
+            "codex_exec_bridge_idle_timeout"
+        )
         preflight_plan = {
             "host_local_acp_relay_trace_dir": str(Path(tmp) / "preflight-traces"),
             "runner_prerequisites": {},

--- a/examples/skillsbench-host-local-launch-plan-smoke.py
+++ b/examples/skillsbench-host-local-launch-plan-smoke.py
@@ -294,31 +294,52 @@ if out:
         assert prerequisites["container_codex_acp_install_skipped"] is False
         assert plan["public_boundary"]["leaderboard_upload"] is False
         assert plan["public_boundary"]["public_submission"] is False
-        launch_command = _host_local_acp_launch_command(
-            SimpleNamespace(
-                app_server_acp_heartbeat_interval_sec=120.0,
-                app_server_reasoning_effort="high",
-                dataset="skillsbench-v1.1",
-                host_local_acp_launch=True,
-                local_acp_relay_command=None,
-                local_codex_bin="codex",
-                local_codex_exec_timeout_sec=7200,
-                local_codex_sandbox="workspace-write",
-                max_rounds=24,
-                model=None,
-                remote_command_file_bridge_probe=False,
-                remote_command_file_bridge_probe_timeout_sec=5.0,
-                remote_command_file_bridge_ready=False,
-                remote_command_file_bridge_agent_command=None,
-                remote_command_file_bridge_solver_command=None,
-                route="loopx-product-mode",
-                sandbox="docker",
-                task_id="demo-task",
-            ),
-            {"host_local_acp_relay_trace_dir": str(Path(tmp) / "trace")},
+        launch_args = SimpleNamespace(
+            agent_idle_timeout=7200,
+            app_server_acp_heartbeat_interval_sec=120.0,
+            app_server_reasoning_effort="high",
+            dataset="skillsbench-v1.1",
+            host_local_acp_launch=True,
+            local_acp_relay_command=None,
+            local_codex_bin="codex",
+            local_codex_bridge_idle_timeout_sec=None,
+            local_codex_exec_timeout_sec=7200,
+            local_codex_sandbox="workspace-write",
+            max_rounds=24,
+            model=None,
+            remote_command_file_bridge_probe=False,
+            remote_command_file_bridge_probe_timeout_sec=5.0,
+            remote_command_file_bridge_ready=False,
+            remote_command_file_bridge_agent_command=None,
+            remote_command_file_bridge_solver_command=None,
+            route="loopx-product-mode",
+            sandbox="docker",
+            task_id="demo-task",
         )
+        launch_plan = {"host_local_acp_relay_trace_dir": str(Path(tmp) / "trace")}
+        launch_command = _host_local_acp_launch_command(launch_args, launch_plan)
         heartbeat_index = launch_command.index("--stream-heartbeat-interval-sec")
         assert launch_command[heartbeat_index + 1] == "15.0"
+        bridge_idle_index = launch_command.index("--bridge-idle-timeout-sec")
+        assert launch_command[bridge_idle_index + 1] == "7200"
+        launch_args.local_codex_bridge_idle_timeout_sec = 0
+        bridge_idle_disabled_command = _host_local_acp_launch_command(
+            launch_args,
+            launch_plan,
+        )
+        bridge_idle_disabled_index = bridge_idle_disabled_command.index(
+            "--bridge-idle-timeout-sec"
+        )
+        assert bridge_idle_disabled_command[bridge_idle_disabled_index + 1] == "0"
+        launch_args.local_codex_bridge_idle_timeout_sec = 1800
+        bridge_idle_explicit_command = _host_local_acp_launch_command(
+            launch_args,
+            launch_plan,
+        )
+        bridge_idle_explicit_index = bridge_idle_explicit_command.index(
+            "--bridge-idle-timeout-sec"
+        )
+        assert bridge_idle_explicit_command[bridge_idle_explicit_index + 1] == "1800"
         explicit_preflight_command = _host_local_acp_codex_exec_preflight_command(
             SimpleNamespace(
                 dataset="skillsbench-v1.1",

--- a/examples/skillsbench-host-local-launch-plan-smoke.py
+++ b/examples/skillsbench-host-local-launch-plan-smoke.py
@@ -25,6 +25,7 @@ from loopx.benchmark_adapters.skillsbench_acp_relay import (  # noqa: E402
 )
 from scripts.skillsbench_automation_loop import (  # noqa: E402
     _apply_agent_message_only_no_tool_calls_attribution,
+    _host_local_acp_codex_exec_preflight_command,
     _host_local_acp_docker_bridge_command,
     _host_local_acp_launch_command,
     _host_local_acp_target_env,
@@ -302,6 +303,32 @@ if out:
         )
         heartbeat_index = launch_command.index("--stream-heartbeat-interval-sec")
         assert launch_command[heartbeat_index + 1] == "15.0"
+        explicit_preflight_command = _host_local_acp_codex_exec_preflight_command(
+            SimpleNamespace(
+                dataset="skillsbench-v1.1",
+                host_local_acp_codex_exec_preflight_timeout_sec=20,
+                local_acp_relay_command=(
+                    f"{sys.executable} /tmp/loopx-remote-codex-client.py"
+                ),
+                local_codex_bin="/unused/when-explicit-client-is-configured",
+                local_codex_sandbox="workspace-write",
+                model="gpt-5.5",
+                route="loopx-product-mode",
+                task_id="demo-task",
+            ),
+            {"host_local_acp_relay_trace_dir": str(Path(tmp) / "trace")},
+        )
+        assert explicit_preflight_command[:2] == [
+            sys.executable,
+            "/tmp/loopx-remote-codex-client.py",
+        ], explicit_preflight_command
+        assert explicit_preflight_command.count("--codex-bin") == 1
+        assert (
+            explicit_preflight_command[
+                explicit_preflight_command.index("--codex-bin") + 1
+            ]
+            == "/unused/when-explicit-client-is-configured"
+        )
         auto_wiring_plan_proc = subprocess.run(
             [
                 sys.executable,

--- a/examples/skillsbench-host-local-launch-plan-smoke.py
+++ b/examples/skillsbench-host-local-launch-plan-smoke.py
@@ -962,6 +962,38 @@ raise SystemExit(1)
             reverse_failure["codex_exec_process"]["failure_category"]
             == "codex_reverse_channel_unavailable"
         ), reverse_failure
+        reverse_sleeping_codex = Path(tmp) / "reverse-sleeping-codex"
+        reverse_sleeping_codex.write_text(
+            """#!/usr/bin/env python3
+import time
+
+time.sleep(30)
+""",
+            encoding="utf-8",
+        )
+        reverse_sleeping_codex.chmod(0o755)
+        reverse_timeout = _run_codex_payload(
+            {
+                "args": [
+                    "exec",
+                    (
+                        "LoopX bridge test.\\n\\n"
+                        "Private bridge command:\\n"
+                        "/tmp/not-recorded"
+                    ),
+                ],
+                "timeout_sec": 30,
+            },
+            codex_bin=str(reverse_sleeping_codex),
+            default_timeout_sec=30,
+            prompt_bridge_command="true",
+            first_action_timeout_sec=1,
+        )
+        assert reverse_timeout["exit_code"] == 124, reverse_timeout
+        assert "codex_exec_first_action_timeout" in reverse_timeout["stderr"]
+        assert reverse_timeout["agent_operations_jsonl"] == ""
+        assert reverse_timeout["agent_operations_raw_material_recorded"] is False
+        assert reverse_timeout["raw_task_text_recorded"] is False
         preflight_plan = {
             "host_local_acp_relay_trace_dir": str(Path(tmp) / "preflight-traces"),
             "runner_prerequisites": {},

--- a/examples/skillsbench-host-local-launch-plan-smoke.py
+++ b/examples/skillsbench-host-local-launch-plan-smoke.py
@@ -63,6 +63,19 @@ def main() -> int:
     assert "env=target_env" in source
     assert "local_acp_command = _set_option_value(" in source
     assert "del (\n            env," not in source
+    packet = SkillsBenchLocalAcpRelay(
+        CodexExecConfig(remote_command_file_bridge_command="/tmp/private-bridge")
+    )._prompt_with_remote_bridge_packet(
+        "Task",
+        bridge_probe={"operation_count": 1},
+        bridge_command_for_agent="/tmp/private-bridge",
+    )
+    first_action_block = packet.split("FIRST ACTION REQUIRED:", 1)[1].split(
+        "Request examples:", 1
+    )[0]
+    assert "pwd && ls -la" in first_action_block
+    assert "/tmp/private-bridge" in first_action_block
+    assert "<private bridge command>" not in first_action_block
     target_env = _host_local_acp_target_env(
         {
             "AI_ADDR": "127.0.0.1",
@@ -631,13 +644,14 @@ if """ + repr(SKILLSBENCH_LOCAL_ACP_RELAY_READY_MARKER) + """ not in prompt:
 bridge_command = prompt.split("Private bridge command:", 1)[1].strip().splitlines()[0]
 if not bridge_command:
     raise SystemExit(10)
-copyable_packet = prompt.split("Copyable first sandbox action:", 1)[1].split("Request examples:", 1)[0]
-if "<private bridge command>" in copyable_packet:
-    raise SystemExit(12)
-if "pwd && ls -la" not in copyable_packet:
-    raise SystemExit(13)
-if bridge_command not in copyable_packet:
-    raise SystemExit(14)
+if "FIRST ACTION REQUIRED:" in prompt:
+    copyable_packet = prompt.split("FIRST ACTION REQUIRED:", 1)[1].split("Request examples:", 1)[0]
+    if "<private bridge command>" in copyable_packet:
+        raise SystemExit(12)
+    if "pwd && ls -la" not in copyable_packet:
+        raise SystemExit(13)
+    if bridge_command not in copyable_packet:
+        raise SystemExit(14)
 for command in (
     "/app/.local/bin/loopx quota should-run --goal-id skillsbench-case --agent-id codex-benchmark-agent",
     "/app/.local/bin/loopx todo update --goal-id skillsbench-case --todo-id todo_seed --status open --note checkpoint",

--- a/examples/skillsbench-host-local-launch-plan-smoke.py
+++ b/examples/skillsbench-host-local-launch-plan-smoke.py
@@ -25,7 +25,10 @@ from loopx.benchmark_adapters.skillsbench_acp_relay import (  # noqa: E402
     run_skillsbench_local_acp_relay_probe,
 )
 from scripts.skillsbench_automation_loop import (  # noqa: E402
+    HOST_LOCAL_ACP_AGENT_TIMEOUT_MARGIN_SEC,
     _apply_agent_message_only_no_tool_calls_attribution,
+    _effective_benchflow_agent_timeout_sec,
+    _effective_local_codex_exec_timeout_sec,
     _host_local_acp_codex_exec_preflight_command,
     _host_local_acp_docker_bridge_command,
     _host_local_acp_launch_command,
@@ -89,6 +92,21 @@ def main() -> int:
         "AI_PORT": "2022",
         "GOAL_HARNESS_REMOTE_BENCH_ROOT": "/tmp/bench",
     }
+    timeout_args = SimpleNamespace(
+        agent_idle_timeout=7200,
+        host_local_acp_launch=True,
+        local_codex_exec_timeout_sec=21600,
+    )
+    assert _effective_local_codex_exec_timeout_sec(timeout_args) == 21600
+    assert _effective_benchflow_agent_timeout_sec(timeout_args) == (
+        21600 + HOST_LOCAL_ACP_AGENT_TIMEOUT_MARGIN_SEC
+    )
+    non_host_local_timeout_args = SimpleNamespace(
+        agent_idle_timeout=7200,
+        host_local_acp_launch=False,
+        local_codex_exec_timeout_sec=21600,
+    )
+    assert _effective_benchflow_agent_timeout_sec(non_host_local_timeout_args) == 7200
     replaced = _replace_option_value(
         ["relay", "--remote-command-file-bridge-command", "old", "--keep", "x"],
         "--remote-command-file-bridge-command",

--- a/examples/skillsbench-host-local-launch-plan-smoke.py
+++ b/examples/skillsbench-host-local-launch-plan-smoke.py
@@ -631,6 +631,13 @@ if """ + repr(SKILLSBENCH_LOCAL_ACP_RELAY_READY_MARKER) + """ not in prompt:
 bridge_command = prompt.split("Private bridge command:", 1)[1].strip().splitlines()[0]
 if not bridge_command:
     raise SystemExit(10)
+copyable_packet = prompt.split("Copyable first sandbox action:", 1)[1].split("Request examples:", 1)[0]
+if "<private bridge command>" in copyable_packet:
+    raise SystemExit(12)
+if "pwd && ls -la" not in copyable_packet:
+    raise SystemExit(13)
+if bridge_command not in copyable_packet:
+    raise SystemExit(14)
 for command in (
     "/app/.local/bin/loopx quota should-run --goal-id skillsbench-case --agent-id codex-benchmark-agent",
     "/app/.local/bin/loopx todo update --goal-id skillsbench-case --todo-id todo_seed --status open --note checkpoint",

--- a/examples/skillsbench-host-local-launch-plan-smoke.py
+++ b/examples/skillsbench-host-local-launch-plan-smoke.py
@@ -1071,6 +1071,79 @@ time.sleep(30)
         assert reverse_timeout["agent_operations_jsonl"] == ""
         assert reverse_timeout["agent_operations_raw_material_recorded"] is False
         assert reverse_timeout["raw_task_text_recorded"] is False
+        reverse_hanging_bridge = Path(tmp) / "reverse-hanging-bridge"
+        reverse_hanging_bridge.write_text(
+            """#!/usr/bin/env python3
+import sys
+import time
+
+sys.stdin.read()
+time.sleep(30)
+""",
+            encoding="utf-8",
+        )
+        reverse_hanging_bridge.chmod(0o755)
+        reverse_hanging_codex = Path(tmp) / "reverse-hanging-codex"
+        reverse_hanging_codex.write_text(
+            """#!/usr/bin/env python3
+import json
+import re
+import subprocess
+import sys
+
+prompt = sys.stdin.read()
+match = re.search(r"Private bridge command:\\n([^\\n]+)", prompt)
+assert match, prompt
+subprocess.run(
+    match.group(1),
+    input=json.dumps({
+        "operation": "exec",
+        "cwd": "/app",
+        "command": "python - <<'PY'\\nprint('task-facing')\\nPY",
+        "timeout_sec": 10,
+    }),
+    text=True,
+    shell=True,
+    check=False,
+)
+""",
+            encoding="utf-8",
+        )
+        reverse_hanging_codex.chmod(0o755)
+        reverse_hanging_timeout = _run_codex_payload(
+            {
+                "args": [
+                    "exec",
+                    (
+                        "LoopX bridge test. Your first tool action should be "
+                        "a shell pipeline that sends JSON to the private bridge.\n\n"
+                        "Private bridge command:\n"
+                        "/tmp/not-recorded"
+                    ),
+                ],
+                "timeout_sec": 2,
+            },
+            codex_bin=str(reverse_hanging_codex),
+            default_timeout_sec=2,
+            prompt_bridge_command=str(reverse_hanging_bridge),
+            first_action_timeout_sec=1,
+        )
+        assert reverse_hanging_timeout["exit_code"] == 124, reverse_hanging_timeout
+        assert "codex_exec_timeout" in reverse_hanging_timeout["stderr"]
+        reverse_hanging_operations = [
+            json.loads(line)
+            for line in str(
+                reverse_hanging_timeout["agent_operations_jsonl"]
+            ).splitlines()
+            if line.strip()
+        ]
+        assert len(reverse_hanging_operations) == 1, reverse_hanging_timeout
+        assert (
+            reverse_hanging_operations[0]["task_facing_operation"] is True
+        ), reverse_hanging_operations
+        assert (
+            reverse_hanging_operations[0]["raw_request_recorded"] is False
+        ), reverse_hanging_operations
         idle_bridge = Path(tmp) / "post-action-idle-bridge"
         idle_bridge.write_text(
             """#!/usr/bin/env python3
@@ -1188,6 +1261,115 @@ time.sleep(30)
         assert idle_failures[0]["codex_exec_process"]["failure_category"] == (
             "codex_exec_bridge_idle_timeout"
         )
+        inflight_bridge = Path(tmp) / "inflight-idle-bridge"
+        inflight_bridge.write_text(
+            """#!/usr/bin/env python3
+import json
+import sys
+import time
+
+payload = json.loads(sys.stdin.read() or "{}")
+if "operations" in payload:
+    print(json.dumps({
+        "schema_version": "skillsbench_remote_command_file_bridge_probe_response_v0",
+        "ready": True,
+        "stage": "complete",
+        "operations": [
+            {"kind": "exec", "status": "ok", "exit_code_zero": True},
+            {"kind": "write_file", "status": "ok"},
+            {"kind": "read_file", "status": "ok", "content_match": True},
+            {"kind": "cleanup", "status": "ok"},
+        ],
+        "raw_command_recorded": False,
+        "raw_stdout_recorded": False,
+        "raw_stderr_recorded": False,
+        "raw_task_text_recorded": False,
+        "raw_logs_recorded": False,
+        "raw_trajectory_recorded": False,
+        "credential_values_recorded": False,
+        "host_paths_recorded": False,
+        "remote_paths_recorded": False,
+        "upload_performed": False,
+        "submit_performed": False,
+    }))
+    raise SystemExit(0)
+time.sleep(30)
+""",
+            encoding="utf-8",
+        )
+        inflight_bridge.chmod(0o755)
+        inflight_codex = Path(tmp) / "inflight-idle-codex"
+        inflight_codex.write_text(
+            """#!/usr/bin/env python3
+import json
+import re
+import subprocess
+import sys
+
+args = sys.argv[1:]
+prompt = sys.stdin.read()
+if any("Private bridge command:" in item for item in args):
+    raise SystemExit(42)
+match = re.search(r"Private bridge command:\\n([^\\n]+)", prompt)
+assert match, prompt
+subprocess.run(
+    match.group(1),
+    input=json.dumps({
+        "operation": "exec",
+        "cwd": "/app",
+        "command": "python - <<'PY'\\nprint('task-facing')\\nPY",
+        "timeout_sec": 10,
+    }),
+    text=True,
+    shell=True,
+    check=False,
+)
+""",
+            encoding="utf-8",
+        )
+        inflight_codex.chmod(0o755)
+        inflight_trace_dir = Path(tmp) / "inflight-idle-traces"
+        inflight_relay = SkillsBenchLocalAcpRelay(
+            CodexExecConfig(
+                codex_bin=str(inflight_codex),
+                sandbox="workspace-write",
+                route="loopx-product-mode",
+                dataset="skillsbench-v1.1",
+                task_id="demo-task",
+                timeout_sec=30,
+                first_action_timeout_sec=1,
+                bridge_idle_timeout_sec=1,
+                worker_public_trace_dir=str(inflight_trace_dir),
+                remote_command_file_bridge_command=str(inflight_bridge),
+                remote_command_file_bridge_agent_command=str(inflight_bridge),
+            )
+        )
+        try:
+            inflight_relay._run_codex(
+                "LoopX demo prompt.",
+                session={"cwd": str(Path(tmp))},
+                session_id="inflight-idle-demo",
+                stdout=io.StringIO(),
+            )
+        except TimeoutError as exc:
+            assert "bridge idle timeout" in str(exc), exc
+        else:
+            raise AssertionError("expected in-flight bridge idle timeout")
+        inflight_traces = [
+            json.loads(path.read_text(encoding="utf-8"))
+            for path in inflight_trace_dir.glob("*.compact.json")
+        ]
+        inflight_agent_ops = [
+            trace
+            for trace in inflight_traces
+            if trace.get("trace_kind") == "remote_command_file_bridge_agent_operations"
+        ]
+        assert len(inflight_agent_ops) == 1, inflight_traces
+        inflight_counts = inflight_agent_ops[0][
+            "remote_command_file_bridge_agent_operations"
+        ]
+        assert inflight_counts["request_count"] == 1, inflight_counts
+        assert inflight_counts["task_facing_operation_count"] == 1, inflight_counts
         bridge_preflight_codex = Path(tmp) / "bridge-preflight-codex"
         bridge_preflight_codex.write_text(
             f"""#!/usr/bin/env python3

--- a/examples/skillsbench-reverse-channel-bridge-smoke.py
+++ b/examples/skillsbench-reverse-channel-bridge-smoke.py
@@ -534,6 +534,81 @@ print(json.dumps({
             server.wait(timeout=5)
 
 
+def test_json_preflight_does_not_require_target_env_or_bridge_command() -> None:
+    with tempfile.TemporaryDirectory(prefix="lrjp-") as tmp:
+        root = Path(tmp)
+        fake_bridge = root / "fake-json-bridge"
+        marker = root / "bridge-invoked"
+        fake_bridge.write_text(
+            f"""#!/usr/bin/env python3
+from pathlib import Path
+Path({str(marker)!r}).write_text('unexpected', encoding='utf-8')
+raise SystemExit(42)
+""",
+            encoding="utf-8",
+        )
+        fake_bridge.chmod(0o700)
+        socket_path = root / "json-preflight.sock"
+        server = subprocess.Popen(
+            [
+                sys.executable,
+                str(BRIDGE),
+                "serve-json",
+                "--socket",
+                str(socket_path),
+                "--bridge-command",
+                str(fake_bridge),
+                "--once",
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        try:
+            wait_for_socket(socket_path, server)
+            client = root / "json-client"
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(BRIDGE),
+                    "write-client",
+                    "--kind",
+                    "json",
+                    "--socket",
+                    str(socket_path),
+                    "--output",
+                    str(client),
+                ],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            env = os.environ.copy()
+            env.pop("AI_ADDR", None)
+            env.pop("AI_PORT", None)
+            env["LOOPX_REVERSE_CONNECT_TIMEOUT_SEC"] = "0.1"
+            env["LOOPX_REVERSE_RESPONSE_TIMEOUT_SEC"] = "5"
+            proc = subprocess.run(
+                [str(client)],
+                input=json.dumps({"operation": "preflight"}),
+                check=False,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            assert proc.returncode == 0, proc.stderr
+            response = json.loads(proc.stdout)
+            assert response["ok"] is True
+            assert response["operation"] == "preflight"
+            assert response["raw_task_text_recorded"] is False
+            assert response["credential_values_recorded"] is False
+            assert marker.exists() is False
+        finally:
+            server.wait(timeout=5)
+
+
 def test_socket_probe_reports_missing_or_orphaned() -> None:
     with tempfile.TemporaryDirectory(prefix="loopx-reverse-probe-smoke-") as tmp:
         missing = Path(tmp) / "missing.sock"
@@ -561,6 +636,7 @@ def main() -> int:
     test_codex_client_plain_prompt_does_not_require_bridge_action()
     test_json_client_forwards_stdin_to_bridge_command()
     test_json_client_expands_allowed_env_template_for_nested_bridge()
+    test_json_preflight_does_not_require_target_env_or_bridge_command()
     test_socket_probe_reports_missing_or_orphaned()
     print("skillsbench reverse-channel bridge smoke passed")
     return 0

--- a/examples/skillsbench-reverse-channel-bridge-smoke.py
+++ b/examples/skillsbench-reverse-channel-bridge-smoke.py
@@ -49,9 +49,11 @@ from pathlib import Path
 
 args = sys.argv[1:]
 stdin_text = sys.stdin.read()
-if stdin_text:
+if not stdin_text:
     raise SystemExit(41)
-prompt = args[-1]
+if any('Private bridge command:' in item or 'Task' in item for item in args):
+    raise SystemExit(42)
+prompt = stdin_text
 Path({str(prompt_dump)!r}).write_text(prompt, encoding='utf-8')
 out = Path(args[args.index('--output-last-message') + 1])
 time.sleep(0.35)
@@ -169,10 +171,11 @@ import json, os, subprocess, sys
 from pathlib import Path
 
 args = sys.argv[1:]
-prompt = next(
-    (item for item in args if 'Private bridge command:\\n' in item),
-    '\\n'.join(args),
-)
+prompt = sys.stdin.read()
+if not prompt:
+    raise SystemExit(41)
+if any('Private bridge command:' in item for item in args):
+    raise SystemExit(42)
 bridge = prompt.split('Private bridge command:\\n', 1)[1].split('\\n', 1)[0]
 env = os.environ.copy()
 env['AI_ADDR'] = '127.0.0.1'
@@ -265,6 +268,95 @@ raise SystemExit(proc.returncode)
             assert any(item.startswith("AI_PORT=") for item in argv), argv
             assert remote_last.read_text(encoding="utf-8") == (
                 "LOOPX_REVERSE_TEMPLATE_READY\n"
+            )
+        finally:
+            server.wait(timeout=5)
+
+
+def test_codex_client_plain_prompt_does_not_require_bridge_action() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-reverse-plain-prompt-") as tmp:
+        root = Path(tmp)
+        fake_codex = root / "fake-codex"
+        prompt_dump = root / "plain-prompt.txt"
+        fake_codex.write_text(
+            f"""#!/usr/bin/env python3
+import sys
+from pathlib import Path
+
+args = sys.argv[1:]
+prompt = sys.stdin.read()
+if not prompt:
+    raise SystemExit(41)
+if any('plain health prompt' in item for item in args):
+    raise SystemExit(42)
+Path({str(prompt_dump)!r}).write_text(prompt, encoding='utf-8')
+out = Path(args[args.index('--output-last-message') + 1])
+out.write_text('LOOPX_REVERSE_PLAIN_READY\\n', encoding='utf-8')
+print('plain codex stdout ok')
+""",
+            encoding="utf-8",
+        )
+        fake_codex.chmod(0o700)
+        socket_path = root / "codex.sock"
+        server = subprocess.Popen(
+            [
+                sys.executable,
+                str(BRIDGE),
+                "serve-codex",
+                "--socket",
+                str(socket_path),
+                "--codex-bin",
+                str(fake_codex),
+                "--prompt-bridge-command",
+                "false",
+                "--first-action-timeout-sec",
+                "1",
+                "--once",
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        try:
+            wait_for_socket(socket_path, server)
+            client = root / "codex-client"
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(BRIDGE),
+                    "write-client",
+                    "--kind",
+                    "codex",
+                    "--socket",
+                    str(socket_path),
+                    "--output",
+                    str(client),
+                ],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            remote_last = root / "remote-last-message.txt"
+            proc = subprocess.run(
+                [
+                    str(client),
+                    "exec",
+                    "--output-last-message",
+                    str(remote_last),
+                    "--json",
+                ],
+                check=False,
+                input="plain health prompt",
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            assert proc.returncode == 0, proc.stderr
+            assert "plain codex stdout ok" in proc.stdout
+            assert prompt_dump.read_text(encoding="utf-8") == "plain health prompt"
+            assert remote_last.read_text(encoding="utf-8") == (
+                "LOOPX_REVERSE_PLAIN_READY\n"
             )
         finally:
             server.wait(timeout=5)
@@ -466,6 +558,7 @@ def test_socket_probe_reports_missing_or_orphaned() -> None:
 def main() -> int:
     test_codex_client_writes_last_message_and_rewrites_bridge()
     test_codex_bridge_template_preserves_dynamic_private_command()
+    test_codex_client_plain_prompt_does_not_require_bridge_action()
     test_json_client_forwards_stdin_to_bridge_command()
     test_json_client_expands_allowed_env_template_for_nested_bridge()
     test_socket_probe_reports_missing_or_orphaned()

--- a/examples/skillsbench-reverse-channel-bridge-smoke.py
+++ b/examples/skillsbench-reverse-channel-bridge-smoke.py
@@ -9,6 +9,7 @@ import socket
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 from pathlib import Path
 
@@ -35,6 +36,81 @@ def connect_only_probe(path: Path) -> None:
         sock.connect(str(path))
     finally:
         sock.close()
+
+
+def wait_for_path(path: Path) -> None:
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        if path.exists():
+            return
+        time.sleep(0.05)
+    raise AssertionError(f"path did not appear: {path}")
+
+
+def run_empty_response_server(path: Path) -> threading.Thread:
+    def serve() -> None:
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+        server = socket.socket(socket.AF_UNIX)
+        try:
+            server.bind(str(path))
+            path.chmod(0o600)
+            server.listen(1)
+            conn, _ = server.accept()
+            with conn:
+                conn.recv(65536)
+        finally:
+            server.close()
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                pass
+
+    thread = threading.Thread(target=serve)
+    thread.start()
+    wait_for_path(path)
+    return thread
+
+
+def test_reverse_channel_clients_fail_closed_on_empty_response() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-reverse-empty-response-") as tmp:
+        root = Path(tmp)
+        for kind in ("codex", "json"):
+            socket_path = root / f"{kind}.sock"
+            server = run_empty_response_server(socket_path)
+            client = root / f"{kind}-client"
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(BRIDGE),
+                    "write-client",
+                    "--kind",
+                    kind,
+                    "--socket",
+                    str(socket_path),
+                    "--output",
+                    str(client),
+                ],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            args = [str(client), "exec"] if kind == "codex" else [str(client)]
+            proc = subprocess.run(
+                args,
+                input="{}",
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                check=False,
+            )
+            assert proc.returncode == 125, (kind, proc.returncode, proc.stderr)
+            assert "reverse channel response missing" in proc.stderr
+            server.join(timeout=5)
+            assert not server.is_alive()
 
 
 def test_codex_client_writes_last_message_and_rewrites_bridge() -> None:

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -1975,6 +1975,10 @@ def _skillsbench_controller_trace_counters(
             "product_mode_solver_activity_gap"
         )
         is True,
+        "product_mode_declared_done_below_passing_reward": controller_trace.get(
+            "product_mode_declared_done_below_passing_reward"
+        )
+        is True,
         "agent_declared_done": controller_trace.get("agent_declared_done") is True,
         "agent_declared_no_remaining_goals": controller_trace.get(
             "agent_declared_no_remaining_goals"
@@ -2120,6 +2124,17 @@ def _skillsbench_controller_trace_counters(
         "remote_command_file_bridge_driver_lifecycle_loopx_state_write_count": count(
             "remote_command_file_bridge_driver_lifecycle_loopx_state_write_count"
         ),
+        "host_local_acp_codex_exec_failure_trace_count": count(
+            "host_local_acp_codex_exec_failure_trace_count"
+        ),
+        "host_local_acp_codex_exec_failure_trace_present": controller_trace.get(
+            "host_local_acp_codex_exec_failure_trace_present"
+        )
+        is True,
+        "host_local_acp_codex_exec_failure_raw_material_recorded": controller_trace.get(
+            "host_local_acp_codex_exec_failure_raw_material_recorded"
+        )
+        is True,
         "heartbeat_count": count("heartbeat_count"),
         "raw_task_text_recorded": controller_trace.get("raw_task_text_recorded")
         is True,
@@ -2193,6 +2208,12 @@ def _skillsbench_controller_trace_counters(
         ),
         "product_mode_solver_activity_gap_round": count(
             "product_mode_solver_activity_gap_round"
+        ),
+        "product_mode_declared_done_below_passing_reward_count": count(
+            "product_mode_declared_done_below_passing_reward_count"
+        ),
+        "product_mode_declared_done_below_passing_reward_round": count(
+            "product_mode_declared_done_below_passing_reward_round"
         ),
         "product_mode_no_tool_call_lifecycle_abort": controller_trace.get(
             "product_mode_no_tool_call_lifecycle_abort"
@@ -2277,6 +2298,28 @@ def _skillsbench_controller_trace_counters(
         counters["remote_command_file_bridge_driver_lifecycle_execution_style"] = (
             workflow_style
         )
+    host_codex_failure_category = _skillsbench_public_safe_label(
+        controller_trace.get("host_local_acp_codex_exec_failure_category") or ""
+    )
+    if host_codex_failure_category:
+        counters["host_local_acp_codex_exec_failure_category"] = (
+            host_codex_failure_category
+        )
+    host_codex_failure_categories: list[str] = []
+    raw_host_codex_failure_categories = controller_trace.get(
+        "host_local_acp_codex_exec_failure_categories"
+    )
+    if isinstance(raw_host_codex_failure_categories, list):
+        for item in raw_host_codex_failure_categories:
+            category = _skillsbench_public_safe_label(item or "")
+            if category and category not in host_codex_failure_categories:
+                host_codex_failure_categories.append(category)
+    elif host_codex_failure_category:
+        host_codex_failure_categories.append(host_codex_failure_category)
+    if host_codex_failure_categories:
+        counters["host_local_acp_codex_exec_failure_categories"] = (
+            host_codex_failure_categories[:8]
+        )
     case_state_path = str(controller_trace.get("case_goal_state_path") or "")
     if (
         "/.codex/goals/" in case_state_path
@@ -2293,6 +2336,21 @@ def _skillsbench_controller_trace_counters(
         and not isinstance(declared_done_score, bool)
     ):
         counters["declared_done_score"] = float(declared_done_score)
+    below_passing_score = controller_trace.get(
+        "product_mode_declared_done_below_passing_reward_score"
+    )
+    if (
+        isinstance(below_passing_score, (int, float))
+        and not isinstance(below_passing_score, bool)
+    ):
+        counters["product_mode_declared_done_below_passing_reward_score"] = float(
+            below_passing_score
+        )
+    declared_done_policy = _skillsbench_public_safe_label(
+        controller_trace.get("product_mode_declared_done_policy") or ""
+    )
+    if declared_done_policy:
+        counters["product_mode_declared_done_policy"] = declared_done_policy
     if reward_records:
         counters["round_rewards"] = reward_records
     trajectory_summary = (
@@ -3026,6 +3084,17 @@ def build_skillsbench_benchflow_result_benchmark_run(
         ):
             if item and item not in failure_labels:
                 failure_labels.append(item)
+    product_mode_declared_done_below_passing_reward = bool(
+        controller_counters.get("product_mode_declared_done_below_passing_reward")
+        is True
+    )
+    if product_mode_declared_done_below_passing_reward and not official_passed:
+        for item in (
+            "skillsbench_product_mode_declared_done_below_passing_reward",
+            "skillsbench_agent_premature_done_signal",
+        ):
+            if item not in failure_labels:
+                failure_labels.append(item)
     user_loop_final_verify_recovery_triggered = bool(
         controller_counters.get("benchflow_user_loop_final_verify_recovery_triggered")
     )
@@ -3100,6 +3169,54 @@ def build_skillsbench_benchflow_result_benchmark_run(
             "skillsbench_reward_artifact_missing",
         ):
             if item not in failure_labels:
+                failure_labels.append(item)
+    host_local_acp_codex_exec_failure_present = bool(
+        controller_counters.get("host_local_acp_codex_exec_failure_trace_present")
+        is True
+    )
+    host_local_acp_codex_exec_failure_category = str(
+        controller_counters.get("host_local_acp_codex_exec_failure_category") or ""
+    )
+    if host_local_acp_codex_exec_failure_present and not official_passed:
+        host_failure_label = "skillsbench_host_local_acp_codex_exec_failed"
+        if host_local_acp_codex_exec_failure_category:
+            host_failure_label = (
+                f"{host_failure_label}_{host_local_acp_codex_exec_failure_category}"
+            )
+        exception_type = host_failure_label
+        score_failure_attribution = host_failure_label
+        runner_score_failure_attribution = host_failure_label
+        contract_official_score_comparable_to_native_codex = False
+        contract_official_score_comparable_to_loopx_treatment = False
+        failure_labels = [
+            item
+            for item in failure_labels
+            if item
+            not in {
+                "skillsbench_runner_error",
+                "skillsbench_codex_acp_jsonrpc_internal_error",
+                "skillsbench_codex_acp_transport_error",
+                "skillsbench_controller_budget_not_exercised",
+                "skillsbench_result_error_cut_off_followup_loop",
+                "skillsbench_result_timeout_after_agent_round_no_reward_artifact",
+                "skillsbench_result_error_after_agent_round",
+                "skillsbench_reward_artifact_missing",
+                "verifier_infrastructure_failure",
+                "official_score_zero_case_failure",
+                "official_verifier_solution_failure",
+            }
+        ]
+        controller_budget_cutoff_before_followup = False
+        controller_budget_cutoff_reason = "none"
+        for item in (
+            host_failure_label,
+            "skillsbench_host_local_acp_codex_exec_failed",
+            "skillsbench_runner_setup_error",
+            "skillsbench_product_mode_transport_failure"
+            if route == "loopx-product-mode"
+            else "",
+        ):
+            if item and item not in failure_labels:
                 failure_labels.append(item)
     if trajectory_summary:
         evidence_files.append("loopx:acp_trajectory_summary")
@@ -3551,6 +3668,9 @@ def build_skillsbench_benchflow_result_benchmark_run(
             "product_mode_solver_activity_gap": controller_counters.get(
                 "product_mode_solver_activity_gap", False
             ),
+            "product_mode_declared_done_below_passing_reward": controller_counters.get(
+                "product_mode_declared_done_below_passing_reward", False
+            ),
             "product_mode_lifecycle_checkpoint_count": controller_counters.get(
                 "product_mode_lifecycle_checkpoint_count", 0
             ),
@@ -3568,6 +3688,18 @@ def build_skillsbench_benchflow_result_benchmark_run(
             ),
             "product_mode_solver_activity_missing_reason": controller_counters.get(
                 "product_mode_solver_activity_missing_reason", ""
+            ),
+            "product_mode_declared_done_below_passing_reward_count": controller_counters.get(
+                "product_mode_declared_done_below_passing_reward_count", 0
+            ),
+            "product_mode_declared_done_below_passing_reward_round": controller_counters.get(
+                "product_mode_declared_done_below_passing_reward_round", 0
+            ),
+            "product_mode_declared_done_below_passing_reward_score": controller_counters.get(
+                "product_mode_declared_done_below_passing_reward_score", 0.0
+            ),
+            "product_mode_declared_done_policy": controller_counters.get(
+                "product_mode_declared_done_policy", ""
             ),
             "product_mode_no_tool_call_lifecycle_abort": controller_counters.get(
                 "product_mode_no_tool_call_lifecycle_abort", False
@@ -3821,6 +3953,27 @@ def build_skillsbench_benchflow_result_benchmark_run(
                     "",
                 )
             ),
+            "host_local_acp_codex_exec_failure_trace_present": (
+                controller_counters.get(
+                    "host_local_acp_codex_exec_failure_trace_present", False
+                )
+            ),
+            "host_local_acp_codex_exec_failure_trace_count": (
+                controller_counters.get(
+                    "host_local_acp_codex_exec_failure_trace_count", 0
+                )
+            ),
+            "host_local_acp_codex_exec_failure_category": (
+                controller_counters.get(
+                    "host_local_acp_codex_exec_failure_category", ""
+                )
+            ),
+            "host_local_acp_codex_exec_failure_raw_material_recorded": (
+                controller_counters.get(
+                    "host_local_acp_codex_exec_failure_raw_material_recorded",
+                    False,
+                )
+            ),
             "loopx_case_state_path_count": trajectory_summary.get(
                 "loopx_case_state_path_count", 0
             ),
@@ -4034,7 +4187,7 @@ def build_skillsbench_benchflow_result_benchmark_run(
     if runner_failure is not None:
         benchmark_run["runner_failure"] = runner_failure
         benchmark_run["runner_failure_fingerprint"] = runner_failure_fingerprint
-    if partial_trajectory:
+    if partial_trajectory and not host_local_acp_codex_exec_failure_present:
         benchmark_run["failure_attribution_labels"].append("partial_trajectory")
     return benchmark_run
 

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -1877,6 +1877,11 @@ def _skillsbench_controller_trace_counters(
             return value
         return 0
 
+    def max_direct_or_subcommands(key: str, commands: tuple[str, ...]) -> int:
+        direct = count(key)
+        derived = sum(subcommand_count(command) for command in commands)
+        return max(direct, derived)
+
     def round_reward_records() -> list[dict[str, Any]]:
         raw_records = controller_trace.get("round_rewards")
         if not isinstance(raw_records, list):
@@ -2088,14 +2093,17 @@ def _skillsbench_controller_trace_counters(
         "remote_command_file_bridge_agent_loopx_state_write_count": count(
             "remote_command_file_bridge_agent_loopx_state_write_count"
         ),
-        "remote_command_file_bridge_agent_todo_closeout_count": (
-            subcommand_count("todo complete") + subcommand_count("todo update")
+        "remote_command_file_bridge_agent_todo_closeout_count": max_direct_or_subcommands(
+            "remote_command_file_bridge_agent_todo_closeout_count",
+            ("todo complete", "todo update"),
         ),
-        "remote_command_file_bridge_agent_refresh_state_count": subcommand_count(
-            "refresh-state"
+        "remote_command_file_bridge_agent_refresh_state_count": max_direct_or_subcommands(
+            "remote_command_file_bridge_agent_refresh_state_count",
+            ("refresh-state",),
         ),
-        "remote_command_file_bridge_agent_quota_spend_slot_count": subcommand_count(
-            "quota spend-slot"
+        "remote_command_file_bridge_agent_quota_spend_slot_count": max_direct_or_subcommands(
+            "remote_command_file_bridge_agent_quota_spend_slot_count",
+            ("quota spend-slot",),
         ),
         "remote_command_file_bridge_agent_task_facing_operation_count": count(
             "remote_command_file_bridge_agent_task_facing_operation_count"

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -2354,6 +2354,16 @@ def _skillsbench_controller_trace_counters(
         counters["product_mode_declared_done_below_passing_reward_score"] = float(
             below_passing_score
         )
+    below_passing_score_status = _skillsbench_public_safe_label(
+        controller_trace.get(
+            "product_mode_declared_done_below_passing_reward_score_status"
+        )
+        or ""
+    )
+    if below_passing_score_status:
+        counters["product_mode_declared_done_below_passing_reward_score_status"] = (
+            below_passing_score_status
+        )
     declared_done_policy = _skillsbench_public_safe_label(
         controller_trace.get("product_mode_declared_done_policy") or ""
     )
@@ -3067,9 +3077,32 @@ def build_skillsbench_benchflow_result_benchmark_run(
     product_mode_solver_activity_gap_observed = bool(
         controller_counters.get("product_mode_solver_activity_gap") is True
     )
-    if (
+    product_mode_solver_activity_gap_corroborated = bool(
         product_mode_solver_activity_gap_observed
-        and reward_value is None
+        and (
+            controller_counters.get("product_mode_solver_activity_missing_reason")
+            == "missing_task_facing_activity_or_agent_closeout_before_declared_done"
+            or _controller_public_count("product_mode_solver_activity_gap_count") > 0
+            or (
+                "remote_command_file_bridge_agent_task_facing_operation_count"
+                in controller_counters
+                and _controller_public_count(
+                    "remote_command_file_bridge_agent_task_facing_operation_count"
+                )
+                == 0
+            )
+            or (
+                "remote_command_file_bridge_agent_todo_closeout_count"
+                in controller_counters
+                and _controller_public_count(
+                    "remote_command_file_bridge_agent_todo_closeout_count"
+                )
+                == 0
+            )
+        )
+    )
+    if (
+        product_mode_solver_activity_gap_corroborated
         and not official_passed
     ):
         label = "skillsbench_product_mode_solver_activity_gap"
@@ -3079,13 +3112,25 @@ def build_skillsbench_benchflow_result_benchmark_run(
             "none",
             "skillsbench_runner_error",
             "verifier_infrastructure_failure",
+            "official_verifier_solution_failure",
+            "official_score_zero_case_failure",
         }:
             score_failure_attribution = label
             runner_score_failure_attribution = label
+            failure_labels = [
+                item
+                for item in failure_labels
+                if item
+                not in {
+                    "official_verifier_solution_failure",
+                    "official_score_zero_case_failure",
+                    "verifier_infrastructure_failure",
+                }
+            ]
         for item in (
             label,
             "skillsbench_agent_behavior_gap",
-            "skillsbench_reward_artifact_missing",
+            "skillsbench_reward_artifact_missing" if reward_value is None else "",
             "skillsbench_verifier_error_subtype_unavailable_public"
             if verifier_error_text
             else "",
@@ -3704,7 +3749,10 @@ def build_skillsbench_benchflow_result_benchmark_run(
                 "product_mode_declared_done_below_passing_reward_round", 0
             ),
             "product_mode_declared_done_below_passing_reward_score": controller_counters.get(
-                "product_mode_declared_done_below_passing_reward_score", 0.0
+                "product_mode_declared_done_below_passing_reward_score"
+            ),
+            "product_mode_declared_done_below_passing_reward_score_status": controller_counters.get(
+                "product_mode_declared_done_below_passing_reward_score_status", ""
             ),
             "product_mode_declared_done_policy": controller_counters.get(
                 "product_mode_declared_done_policy", ""

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -1030,6 +1030,13 @@ record["task_facing_operation"] = bool(
     operation in {{"read_file", "write_file", "cleanup"}}
     or (operation == "exec" and not subcommands)
 )
+record["operation_observed"] = True
+try:
+    SUMMARY_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with SUMMARY_PATH.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record, sort_keys=True) + "\\n")
+except OSError:
+    pass
 proc = subprocess.run(
     BRIDGE_COMMAND,
     input=raw,
@@ -1038,13 +1045,6 @@ proc = subprocess.run(
     stderr=subprocess.PIPE,
     shell=True,
 )
-record["returncode"] = int(proc.returncode)
-try:
-    SUMMARY_PATH.parent.mkdir(parents=True, exist_ok=True)
-    with SUMMARY_PATH.open("a", encoding="utf-8") as fh:
-        fh.write(json.dumps(record, sort_keys=True) + "\\n")
-except OSError:
-    pass
 sys.stdout.write(proc.stdout)
 sys.stderr.write(proc.stderr)
 raise SystemExit(proc.returncode)

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -900,6 +900,23 @@ class SkillsBenchLocalAcpRelay:
             or self._config.remote_command_file_bridge_command
             or ""
         )
+        first_exec_request = json.dumps(
+            {
+                "operation": "exec",
+                "cwd": "/app",
+                "command": "pwd && ls -la",
+                "timeout_sec": 10,
+            },
+            separators=(",", ":"),
+        )
+        first_exec_command = (
+            f"printf '%s\\n' {shlex.quote(first_exec_request)} | {bridge_command}"
+            if bridge_command
+            else (
+                "printf '%s\\n' "
+                f"{shlex.quote(first_exec_request)} | <private bridge command>"
+            )
+        )
         packet = f"""
 
 LoopX SkillsBench remote workspace bridge:
@@ -909,6 +926,8 @@ LoopX SkillsBench remote workspace bridge:
 - Invoke it from the Codex CLI shell by piping JSON to the private bridge
   command shown below. For example:
   `printf '%s\\n' '{{"operation":"exec","cwd":"/app","command":"pwd","timeout_sec":10}}' | <private bridge command>`
+- Copyable first sandbox action:
+  `{first_exec_command}`
 - Request examples:
   - {{"operation":"exec","cwd":"/app","command":"pwd","timeout_sec":10}}
   - {{"operation":"read_file","path":"/app/path/to/file","max_bytes":20000}}

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -923,11 +923,11 @@ LoopX SkillsBench remote workspace bridge:
 - This local Codex process is outside the scored SkillsBench sandbox.
 - Use the command below as a private JSON bridge for sandbox exec, file write, file read, and cleanup operations.
 - Send one JSON request on stdin and read one private JSON response on stdout.
-- Invoke it from the Codex CLI shell by piping JSON to the private bridge
-  command shown below. For example:
-  `printf '%s\\n' '{{"operation":"exec","cwd":"/app","command":"pwd","timeout_sec":10}}' | <private bridge command>`
-- Copyable first sandbox action:
+- FIRST ACTION REQUIRED: before prose planning or final answer, copy and run
+  this exact shell command to prove task-facing sandbox access:
   `{first_exec_command}`
+- Invoke additional bridge operations by piping JSON to the same private bridge
+  command shown below.
 - Request examples:
   - {{"operation":"exec","cwd":"/app","command":"pwd","timeout_sec":10}}
   - {{"operation":"read_file","path":"/app/path/to/file","max_bytes":20000}}

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -179,8 +179,8 @@ def _codex_exec_failure_category(
             return "codex_network_or_api_unreachable"
     if returncode == 124:
         return "codex_exec_timeout"
-    if returncode == 125:
-        return "codex_exec_exit_125"
+    if returncode is not None and 0 < returncode <= 255:
+        return f"codex_exec_exit_{returncode}"
     if returncode is not None:
         return "codex_exec_exit_nonzero"
     return "codex_exec_failed"

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -179,6 +179,8 @@ def _codex_exec_failure_category(
             return "codex_network_or_api_unreachable"
     if returncode == 124:
         return "codex_exec_timeout"
+    if returncode == 125:
+        return "codex_exec_exit_125"
     if returncode is not None:
         return "codex_exec_exit_nonzero"
     return "codex_exec_failed"

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -392,7 +392,7 @@ class SkillsBenchLocalAcpRelay:
             model = self._config.model or session.get("model")
             if model:
                 cmd.extend(["--model", str(model)])
-            cmd.append(prompt_for_codex)
+            codex_stdin_prompt = prompt_for_codex
             stdout_text = ""
             stderr_text = ""
             try:
@@ -406,13 +406,19 @@ class SkillsBenchLocalAcpRelay:
                         )
                     proc = subprocess.Popen(
                         cmd,
-                        stdin=subprocess.DEVNULL,
+                        stdin=subprocess.PIPE,
                         stdout=stdout_file,
                         stderr=stderr_file,
                         text=True,
                         env=codex_env,
                         start_new_session=True,
                     )
+                    if proc.stdin is not None:
+                        try:
+                            proc.stdin.write(codex_stdin_prompt)
+                            proc.stdin.close()
+                        except BrokenPipeError:
+                            pass
                     deadline = time.monotonic() + self._config.timeout_sec
                     first_action_deadline = 0.0
                     if (

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -159,6 +159,31 @@ def _codex_exec_failure_category(
     stderr_text: str,
 ) -> str:
     text = (stderr_text or "").lower()
+    if any(
+        token in text
+        for token in (
+            "not authenticated",
+            "authentication",
+            "unauthorized",
+            "api key",
+            "login required",
+            "please login",
+            "401",
+        )
+    ):
+        return "codex_auth_or_login_required"
+    if "model" in text and any(
+        token in text
+        for token in (
+            "not found",
+            "unknown",
+            "unsupported",
+            "invalid",
+            "does not exist",
+            "unavailable",
+        )
+    ):
+        return "codex_model_unavailable"
     if (
         "connectionrefusederror" in text
         or "connection refused" in text
@@ -174,6 +199,17 @@ def _codex_exec_failure_category(
         return "codex_exec_bridge_idle_timeout"
     if "unexpected argument" in text or "unrecognized option" in text:
         return "codex_cli_argument_incompatible"
+    if any(
+        token in text
+        for token in (
+            "command not found",
+            "no such file or directory",
+            "modulenotfounderror",
+            "importerror",
+            "failed to spawn",
+        )
+    ):
+        return "codex_cli_or_environment_missing"
     if "api.openai.com" in text or "chatgpt.com" in text:
         if any(token in text for token in ("timed out", "timeout", "connection")):
             return "codex_network_or_api_unreachable"
@@ -1033,12 +1069,17 @@ record["task_facing_operation"] = bool(
     or (operation == "exec" and not subcommands)
 )
 record["operation_observed"] = True
-try:
-    SUMMARY_PATH.parent.mkdir(parents=True, exist_ok=True)
-    with SUMMARY_PATH.open("a", encoding="utf-8") as fh:
-        fh.write(json.dumps(record, sort_keys=True) + "\\n")
-except OSError:
-    pass
+
+def append_record(item: dict[str, object]) -> None:
+    try:
+        SUMMARY_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with SUMMARY_PATH.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(item, sort_keys=True) + "\\n")
+    except OSError:
+        pass
+
+record["record_phase"] = "start"
+append_record(record)
 proc = subprocess.run(
     BRIDGE_COMMAND,
     input=raw,
@@ -1047,6 +1088,13 @@ proc = subprocess.run(
     stderr=subprocess.PIPE,
     shell=True,
 )
+complete_record = dict(record)
+complete_record["record_phase"] = "complete"
+complete_record["returncode"] = int(proc.returncode)
+complete_record["success"] = proc.returncode == 0
+complete_record["stdout_bytes"] = len((proc.stdout or "").encode("utf-8"))
+complete_record["stderr_bytes"] = len((proc.stderr or "").encode("utf-8"))
+append_record(complete_record)
 sys.stdout.write(proc.stdout)
 sys.stderr.write(proc.stderr)
 raise SystemExit(proc.returncode)
@@ -1064,7 +1112,11 @@ raise SystemExit(proc.returncode)
             return
         operation_counts: dict[str, int] = {}
         loopx_subcommand_counts: dict[str, int] = {}
+        successful_loopx_subcommand_counts: dict[str, int] = {}
+        returncode_counts: dict[str, int] = {}
         request_count = 0
+        success_count = 0
+        failure_count = 0
         loopx_cli_call_count = 0
         state_read_count = 0
         state_write_count = 0
@@ -1081,16 +1133,44 @@ raise SystemExit(proc.returncode)
                     continue
                 if not isinstance(record, dict):
                     continue
-                request_count += 1
                 operation = str(record.get("operation") or "unknown")[:40]
-                operation_counts[operation] = operation_counts.get(operation, 0) + 1
-                if record.get("loopx_cli_call") is True:
+                phase = str(record.get("record_phase") or "").strip().lower()
+                counts_as_request = phase != "complete"
+                counts_as_completion = phase == "complete" or (
+                    not phase and ("returncode" in record or "success" in record)
+                )
+                if counts_as_request:
+                    request_count += 1
+                    operation_counts[operation] = (
+                        operation_counts.get(operation, 0) + 1
+                    )
+                rc = record.get("returncode")
+                if counts_as_completion:
+                    if isinstance(rc, int) and not isinstance(rc, bool):
+                        returncode_counts[str(rc)] = (
+                            returncode_counts.get(str(rc), 0) + 1
+                        )
+                        if rc == 0:
+                            success_count += 1
+                        else:
+                            failure_count += 1
+                    elif record.get("success") is True:
+                        success_count += 1
+                        returncode_counts["unknown_success"] = (
+                            returncode_counts.get("unknown_success", 0) + 1
+                        )
+                    elif record.get("success") is False:
+                        failure_count += 1
+                        returncode_counts["unknown_failure"] = (
+                            returncode_counts.get("unknown_failure", 0) + 1
+                        )
+                if counts_as_request and record.get("loopx_cli_call") is True:
                     loopx_cli_call_count += 1
-                if record.get("loopx_state_read") is True:
+                if counts_as_request and record.get("loopx_state_read") is True:
                     state_read_count += 1
-                if record.get("loopx_state_write") is True:
+                if counts_as_request and record.get("loopx_state_write") is True:
                     state_write_count += 1
-                if record.get("task_facing_operation") is True:
+                if counts_as_request and record.get("task_facing_operation") is True:
                     task_facing_operation_count += 1
                 subcommands = record.get("loopx_subcommands")
                 if isinstance(subcommands, list) and subcommands:
@@ -1099,10 +1179,15 @@ raise SystemExit(proc.returncode)
                         for item in subcommands[:2]
                         if re.match(r"^[A-Za-z][A-Za-z0-9_-]{0,40}$", str(item))
                     )
-                    if key:
+                    if key and counts_as_request:
                         loopx_subcommand_counts[key] = (
                             loopx_subcommand_counts.get(key, 0) + 1
                         )
+                    if key and counts_as_completion:
+                        if record.get("success") is True or record.get("returncode") == 0:
+                            successful_loopx_subcommand_counts[key] = (
+                                successful_loopx_subcommand_counts.get(key, 0) + 1
+                            )
                 raw_material_recorded = raw_material_recorded or any(
                     record.get(field) is True
                     for field in (
@@ -1127,10 +1212,16 @@ raise SystemExit(proc.returncode)
                     "skillsbench_remote_command_file_bridge_agent_operations_v0"
                 ),
                 "request_count": request_count,
+                "success_count": success_count,
+                "failure_count": failure_count,
                 "operation_counts": dict(sorted(operation_counts.items())),
+                "returncode_counts": dict(sorted(returncode_counts.items())),
                 "loopx_cli_call_count": loopx_cli_call_count,
                 "loopx_cli_subcommand_counts": dict(
                     sorted(loopx_subcommand_counts.items())
+                ),
+                "successful_loopx_cli_subcommand_counts": dict(
+                    sorted(successful_loopx_subcommand_counts.items())
                 ),
                 "loopx_state_read_count": state_read_count,
                 "loopx_state_write_count": state_write_count,

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -58,6 +58,20 @@ SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_PREFLIGHT_PROMPT = (
 )
 
 
+def _prompt_requires_bridge_first_action(prompt: str) -> bool:
+    text = prompt or ""
+    if "Private bridge command:" not in text:
+        return False
+    lowered = text.lower()
+    required_markers = (
+        SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_PREFLIGHT_MARKER.lower(),
+        "your first tool action should be a shell",
+        "your first agent action must be a shell/tool call",
+        "first run the case-local quota/todo commands",
+    )
+    return any(marker in lowered for marker in required_markers)
+
+
 def _json_rpc_result(message_id: Any, result: dict[str, Any]) -> dict[str, Any]:
     return {"jsonrpc": "2.0", "id": message_id, "result": result}
 
@@ -424,6 +438,7 @@ class SkillsBenchLocalAcpRelay:
                     if (
                         bridge_summary_path is not None
                         and self._config.first_action_timeout_sec > 0
+                        and _prompt_requires_bridge_first_action(prompt_for_codex)
                     ):
                         first_action_deadline = (
                             time.monotonic()

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -50,7 +50,10 @@ SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_PREFLIGHT_MARKER = (
 SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_PREFLIGHT_PROMPT = (
     "LoopX bridge action preflight. First use the private bridge command from "
     "the relay packet to run one JSON exec request with cwd=/app, command=pwd, "
-    "and timeout_sec=10. After the bridge response returns, reply exactly "
+    "and timeout_sec=10. Do not plan, explain, inspect files, or reply before "
+    "that bridge request returns. Your first tool action should be a shell "
+    "pipeline that sends the JSON request to the private bridge command shown "
+    "in the packet. After the bridge response returns, reply exactly "
     f"{SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_PREFLIGHT_MARKER} and end the turn."
 )
 
@@ -832,6 +835,9 @@ LoopX SkillsBench remote workspace bridge:
 - This local Codex process is outside the scored SkillsBench sandbox.
 - Use the command below as a private JSON bridge for sandbox exec, file write, file read, and cleanup operations.
 - Send one JSON request on stdin and read one private JSON response on stdout.
+- Invoke it from the Codex CLI shell by piping JSON to the private bridge
+  command shown below. For example:
+  `printf '%s\\n' '{{"operation":"exec","cwd":"/app","command":"pwd","timeout_sec":10}}' | <private bridge command>`
 - Request examples:
   - {{"operation":"exec","cwd":"/app","command":"pwd","timeout_sec":10}}
   - {{"operation":"read_file","path":"/app/path/to/file","max_bytes":20000}}
@@ -1620,6 +1626,7 @@ def run_skillsbench_local_acp_relay_probe(
     timeout_sec: float = 10.0,
     prompt_text: str | None = None,
     required_response_marker: str | None = None,
+    model_id: str | None = "probe-model",
 ) -> dict[str, Any]:
     argv = (
         _command_to_argv(command)
@@ -1629,6 +1636,7 @@ def run_skillsbench_local_acp_relay_probe(
     started = time.monotonic()
     proc: subprocess.Popen[bytes] | None = None
     stage = "spawn"
+    request_count = 0
     try:
         proc = subprocess.Popen(
             argv,
@@ -1642,6 +1650,7 @@ def run_skillsbench_local_acp_relay_probe(
             {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
             timeout_at=started + timeout_sec,
         )
+        request_count += 1
         stage = "session_new"
         session = _probe_request(
             proc,
@@ -1653,25 +1662,30 @@ def run_skillsbench_local_acp_relay_probe(
             },
             timeout_at=started + timeout_sec,
         )
+        request_count += 1
         session_id = str(session.get("result", {}).get("sessionId") or "")
-        stage = "set_model"
-        _probe_request(
-            proc,
-            {
-                "jsonrpc": "2.0",
-                "id": 3,
-                "method": "session/set_model",
-                "params": {"sessionId": session_id, "modelId": "probe-model"},
-            },
-            timeout_at=started + timeout_sec,
-        )
+        next_id = 3
+        if model_id:
+            stage = "set_model"
+            _probe_request(
+                proc,
+                {
+                    "jsonrpc": "2.0",
+                    "id": next_id,
+                    "method": "session/set_model",
+                    "params": {"sessionId": session_id, "modelId": str(model_id)},
+                },
+                timeout_at=started + timeout_sec,
+            )
+            request_count += 1
+            next_id += 1
         stage = "prompt"
         agent_message_chunks: list[str] = []
         prompt = _probe_request(
             proc,
             {
                 "jsonrpc": "2.0",
-                "id": 4,
+                "id": next_id,
                 "method": "session/prompt",
                 "params": {
                     "sessionId": session_id,
@@ -1689,6 +1703,7 @@ def run_skillsbench_local_acp_relay_probe(
             timeout_at=started + timeout_sec,
             agent_message_chunks=agent_message_chunks,
         )
+        request_count += 1
         prompt_usage = (
             prompt.get("result", {}).get("usage")
             if isinstance(prompt.get("result"), dict)
@@ -1723,7 +1738,7 @@ def run_skillsbench_local_acp_relay_probe(
             ready=ready,
             first_blocker=first_blocker,
             stage="complete",
-            request_count=4,
+            request_count=request_count,
             prompt_usage_total_tokens=usage_total if usage_ready else 0,
             response_marker_required=bool(required_response_marker),
             response_marker_observed=response_marker_observed,
@@ -1736,6 +1751,9 @@ def run_skillsbench_local_acp_relay_probe(
             stage=stage,
             request_count=0,
             prompt_usage_total_tokens=0,
+            response_marker_required=bool(required_response_marker),
+            response_marker_observed=False,
+            agent_message_present=False,
         )
     finally:
         if proc is not None:

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -44,6 +44,15 @@ SKILLSBENCH_LOCAL_ACP_RELAY_HEALTH_PROMPT = (
     "LoopX relay health check. Reply exactly "
     f"{SKILLSBENCH_LOCAL_ACP_RELAY_READY_MARKER} and end the turn."
 )
+SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_PREFLIGHT_MARKER = (
+    "LOOPX_SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_READY"
+)
+SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_PREFLIGHT_PROMPT = (
+    "LoopX bridge action preflight. First use the private bridge command from "
+    "the relay packet to run one JSON exec request with cwd=/app, command=pwd, "
+    "and timeout_sec=10. After the bridge response returns, reply exactly "
+    f"{SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_PREFLIGHT_MARKER} and end the turn."
+)
 
 
 def _json_rpc_result(message_id: Any, result: dict[str, Any]) -> dict[str, Any]:
@@ -1609,6 +1618,8 @@ def run_skillsbench_local_acp_relay_probe(
     command: str | list[str] | tuple[str, ...] | None = None,
     *,
     timeout_sec: float = 10.0,
+    prompt_text: str | None = None,
+    required_response_marker: str | None = None,
 ) -> dict[str, Any]:
     argv = (
         _command_to_argv(command)
@@ -1655,6 +1666,7 @@ def run_skillsbench_local_acp_relay_probe(
             timeout_at=started + timeout_sec,
         )
         stage = "prompt"
+        agent_message_chunks: list[str] = []
         prompt = _probe_request(
             proc,
             {
@@ -1666,12 +1678,16 @@ def run_skillsbench_local_acp_relay_probe(
                     "prompt": [
                         {
                             "type": "text",
-                            "text": SKILLSBENCH_LOCAL_ACP_RELAY_HEALTH_PROMPT,
+                            "text": (
+                                prompt_text
+                                or SKILLSBENCH_LOCAL_ACP_RELAY_HEALTH_PROMPT
+                            ),
                         }
                     ],
                 },
             },
             timeout_at=started + timeout_sec,
+            agent_message_chunks=agent_message_chunks,
         )
         prompt_usage = (
             prompt.get("result", {}).get("usage")
@@ -1684,23 +1700,34 @@ def run_skillsbench_local_acp_relay_probe(
         usage_ready = isinstance(usage_total, int) and not isinstance(
             usage_total, bool
         ) and usage_total > 0
+        agent_message_present = bool("".join(agent_message_chunks).strip())
+        response_marker_observed = True
+        if required_response_marker:
+            response_marker_observed = (
+                required_response_marker in "".join(agent_message_chunks)
+            )
         ready = (
             initialize.get("result", {}).get("agentInfo", {}).get("name")
             == "loopx-skillsbench-local-acp-relay"
             and bool(session_id)
             and prompt.get("result", {}).get("stopReason") == "end_turn"
             and usage_ready
+            and response_marker_observed
         )
+        first_blocker = "skillsbench_local_acp_relay_ready"
+        if not ready:
+            first_blocker = "skillsbench_local_acp_relay_probe_failed"
+            if required_response_marker and not response_marker_observed:
+                first_blocker = "skillsbench_local_acp_relay_response_marker_missing"
         return _relay_probe_payload(
             ready=ready,
-            first_blocker=(
-                "skillsbench_local_acp_relay_ready"
-                if ready
-                else "skillsbench_local_acp_relay_probe_failed"
-            ),
+            first_blocker=first_blocker,
             stage="complete",
             request_count=4,
             prompt_usage_total_tokens=usage_total if usage_ready else 0,
+            response_marker_required=bool(required_response_marker),
+            response_marker_observed=response_marker_observed,
+            agent_message_present=agent_message_present,
         )
     except (OSError, RuntimeError, TimeoutError, json.JSONDecodeError):
         return _relay_probe_payload(
@@ -1834,6 +1861,7 @@ def _probe_request(
     message: dict[str, Any],
     *,
     timeout_at: float,
+    agent_message_chunks: list[str] | None = None,
 ) -> dict[str, Any]:
     if proc.stdin is None or proc.stdout is None:
         raise RuntimeError("probe process pipes missing")
@@ -1859,6 +1887,22 @@ def _probe_request(
                 if not raw_line.strip():
                     continue
                 decoded = json.loads(raw_line.decode())
+                if (
+                    agent_message_chunks is not None
+                    and isinstance(decoded, dict)
+                    and decoded.get("jsonrpc") == "2.0"
+                    and decoded.get("method") == "session/update"
+                ):
+                    params = decoded.get("params")
+                    update = (
+                        params.get("update") if isinstance(params, dict) else None
+                    )
+                    content = (
+                        update.get("content") if isinstance(update, dict) else None
+                    )
+                    text = content.get("text") if isinstance(content, dict) else None
+                    if isinstance(text, str):
+                        agent_message_chunks.append(text)
                 if (
                     isinstance(decoded, dict)
                     and decoded.get("jsonrpc") == "2.0"
@@ -1897,6 +1941,9 @@ def _relay_probe_payload(
     stage: str,
     request_count: int,
     prompt_usage_total_tokens: int = 0,
+    response_marker_required: bool = False,
+    response_marker_observed: bool = True,
+    agent_message_present: bool = False,
 ) -> dict[str, Any]:
     return {
         "schema_version": SKILLSBENCH_LOCAL_ACP_RELAY_PROBE_SCHEMA_VERSION,
@@ -1905,6 +1952,9 @@ def _relay_probe_payload(
         "stage": stage,
         "request_count": request_count,
         "prompt_usage_total_tokens": max(0, int(prompt_usage_total_tokens or 0)),
+        "response_marker_required": bool(response_marker_required),
+        "response_marker_observed": bool(response_marker_observed),
+        "agent_message_present": bool(agent_message_present),
         "worker_protocol": "acp_stdio",
         "codex_cli_invoked": False,
         "raw_output_recorded": False,

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -130,6 +130,8 @@ def _codex_exec_failure_category(
         return "codex_reverse_channel_unavailable"
     if "hit your usage limit" in text or "usage limit" in text:
         return "codex_usage_limit"
+    if "codex_exec_first_action_timeout" in text:
+        return "codex_exec_first_action_timeout"
     if "unexpected argument" in text or "unrecognized option" in text:
         return "codex_cli_argument_incompatible"
     if "api.openai.com" in text or "chatgpt.com" in text:
@@ -157,6 +159,7 @@ class CodexExecConfig:
     response_timeout_sec: float = 30.0
     worker_script: str | None = None
     stream_heartbeat_interval_sec: float = 120.0
+    first_action_timeout_sec: float = 0.0
     reasoning_effort: str | None = "high"
     worker_public_trace_dir: str | None = None
     remote_command_file_bridge_command: str | None = None
@@ -394,12 +397,50 @@ class SkillsBenchLocalAcpRelay:
                         env=codex_env,
                     )
                     deadline = time.monotonic() + self._config.timeout_sec
+                    first_action_deadline = 0.0
+                    if (
+                        bridge_summary_path is not None
+                        and self._config.first_action_timeout_sec > 0
+                    ):
+                        first_action_deadline = (
+                            time.monotonic()
+                            + max(1.0, self._config.first_action_timeout_sec)
+                        )
+                    first_action_seen = not bool(first_action_deadline)
                     next_heartbeat = (
                         time.monotonic()
                         + max(1.0, self._config.stream_heartbeat_interval_sec)
                     )
                     while proc.poll() is None:
                         now = time.monotonic()
+                        if not first_action_seen and bridge_summary_path is not None:
+                            try:
+                                first_action_seen = (
+                                    bridge_summary_path.stat().st_size > 0
+                                )
+                            except OSError:
+                                first_action_seen = False
+                        if (
+                            not first_action_seen
+                            and first_action_deadline
+                            and now >= first_action_deadline
+                        ):
+                            proc.kill()
+                            proc.wait(timeout=5)
+                            self._publish_codex_exec_failure_trace(
+                                stage="first_action_timeout",
+                                returncode=124,
+                                stdout_text="",
+                                stderr_text="codex_exec_first_action_timeout\n",
+                                final_message_present=output_path.exists(),
+                                final_message_bytes=(
+                                    output_path.stat().st_size
+                                    if output_path.exists()
+                                    else 0
+                                ),
+                                failure_category="codex_exec_first_action_timeout",
+                            )
+                            raise TimeoutError("local codex first action timeout")
                         if now >= deadline:
                             proc.kill()
                             proc.wait(timeout=5)

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -49,11 +49,14 @@ SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_PREFLIGHT_MARKER = (
 )
 SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_PREFLIGHT_PROMPT = (
     "LoopX bridge action preflight. First use the private bridge command from "
-    "the relay packet to run one JSON exec request with cwd=/app, command=pwd, "
-    "and timeout_sec=10. Do not plan, explain, inspect files, or reply before "
-    "that bridge request returns. Your first tool action should be a shell "
+    "the relay packet to run one JSON preflight request that does not require "
+    "scored sandbox target environment variables. Do not plan, explain, inspect "
+    "files, or reply before that bridge request returns. Your first tool action "
+    "should be a shell "
     "pipeline that sends the JSON request to the private bridge command shown "
-    "in the packet. After the bridge response returns, reply exactly "
+    "in the packet, for example: "
+    "`printf '%s\\n' '{\"operation\":\"preflight\"}' | <private bridge command>`. "
+    "After the bridge response returns, reply exactly "
     f"{SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_PREFLIGHT_MARKER} and end the turn."
 )
 
@@ -70,6 +73,14 @@ def _prompt_requires_bridge_first_action(prompt: str) -> bool:
         "first run the case-local quota/todo commands",
     )
     return any(marker in lowered for marker in required_markers)
+
+
+def _is_bridge_action_preflight_prompt(prompt: str) -> bool:
+    text = prompt or ""
+    return (
+        SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_PREFLIGHT_MARKER in text
+        and "LoopX bridge action preflight" in text
+    )
 
 
 def _json_rpc_result(message_id: Any, result: dict[str, Any]) -> dict[str, Any]:
@@ -359,7 +370,10 @@ class SkillsBenchLocalAcpRelay:
             prompt_for_codex = prompt_text
             cwd = _safe_cwd(session.get("cwd"), default=os.getcwd())
             if self._config.remote_command_file_bridge_command:
-                bridge_probe = self._consume_remote_bridge_for_solver()
+                if _is_bridge_action_preflight_prompt(prompt_text):
+                    bridge_probe = self._reverse_channel_json_preflight_probe()
+                else:
+                    bridge_probe = self._consume_remote_bridge_for_solver()
                 self._publish_remote_bridge_consumption_trace(bridge_probe)
                 if bridge_probe.get("ready") is not True:
                     raise RuntimeError("remote command/file bridge probe failed")
@@ -646,6 +660,42 @@ class SkillsBenchLocalAcpRelay:
             self._config.remote_command_file_bridge_command,
             timeout_sec=self._config.remote_command_file_bridge_timeout_sec,
         )
+
+    def _reverse_channel_json_preflight_probe(self) -> dict[str, Any]:
+        return {
+            "schema_version": "skillsbench_remote_command_file_bridge_probe_v0",
+            "ready": True,
+            "first_blocker": "skillsbench_reverse_channel_json_preflight_ready",
+            "stage": "pre_sandbox_reverse_channel_json",
+            "elapsed_ms": 0,
+            "bridge_command_invoked": False,
+            "response_schema_version": (
+                "skillsbench_reverse_channel_json_preflight_response_v0"
+            ),
+            "required_operations": ["preflight"],
+            "operation_count": 1,
+            "operations": [
+                {
+                    "kind": "preflight",
+                    "label": "reverse_channel_json_bridge",
+                    "status": "ok",
+                }
+            ],
+            "missing_operations": [],
+            "failed_operations": [],
+            "boundary_violations": [],
+            "raw_command_recorded": False,
+            "raw_stdout_recorded": False,
+            "raw_stderr_recorded": False,
+            "raw_task_text_recorded": False,
+            "raw_logs_recorded": False,
+            "raw_trajectory_recorded": False,
+            "credential_values_recorded": False,
+            "host_paths_recorded": False,
+            "remote_paths_recorded": False,
+            "upload_performed": False,
+            "submit_performed": False,
+        }
 
     def _run_remote_bridge_exec(self, command: str) -> dict[str, Any]:
         bridge_command = self._config.remote_command_file_bridge_command or ""

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -6,6 +6,7 @@ import os
 import re
 import selectors
 import shlex
+import signal
 import subprocess
 import sys
 import tempfile
@@ -132,6 +133,8 @@ def _codex_exec_failure_category(
         return "codex_usage_limit"
     if "codex_exec_first_action_timeout" in text:
         return "codex_exec_first_action_timeout"
+    if "codex_exec_bridge_idle_timeout" in text:
+        return "codex_exec_bridge_idle_timeout"
     if "unexpected argument" in text or "unrecognized option" in text:
         return "codex_cli_argument_incompatible"
     if "api.openai.com" in text or "chatgpt.com" in text:
@@ -160,6 +163,7 @@ class CodexExecConfig:
     worker_script: str | None = None
     stream_heartbeat_interval_sec: float = 120.0
     first_action_timeout_sec: float = 0.0
+    bridge_idle_timeout_sec: float = 0.0
     reasoning_effort: str | None = "high"
     worker_public_trace_dir: str | None = None
     remote_command_file_bridge_command: str | None = None
@@ -395,6 +399,7 @@ class SkillsBenchLocalAcpRelay:
                         stderr=stderr_file,
                         text=True,
                         env=codex_env,
+                        start_new_session=True,
                     )
                     deadline = time.monotonic() + self._config.timeout_sec
                     first_action_deadline = 0.0
@@ -407,26 +412,40 @@ class SkillsBenchLocalAcpRelay:
                             + max(1.0, self._config.first_action_timeout_sec)
                         )
                     first_action_seen = not bool(first_action_deadline)
+                    bridge_idle_timeout_sec = max(
+                        0.0,
+                        float(self._config.bridge_idle_timeout_sec or 0.0),
+                    )
+                    last_bridge_summary_size = 0
+                    last_bridge_activity_at = time.monotonic()
                     next_heartbeat = (
                         time.monotonic()
                         + max(1.0, self._config.stream_heartbeat_interval_sec)
                     )
                     while proc.poll() is None:
                         now = time.monotonic()
-                        if not first_action_seen and bridge_summary_path is not None:
+                        if bridge_summary_path is not None:
                             try:
-                                first_action_seen = (
-                                    bridge_summary_path.stat().st_size > 0
+                                current_bridge_summary_size = (
+                                    bridge_summary_path.stat().st_size
                                 )
                             except OSError:
-                                first_action_seen = False
+                                current_bridge_summary_size = 0
+                            if current_bridge_summary_size > last_bridge_summary_size:
+                                last_bridge_summary_size = current_bridge_summary_size
+                                last_bridge_activity_at = now
+                                first_action_seen = True
+                            elif (
+                                not first_action_seen
+                                and current_bridge_summary_size > 0
+                            ):
+                                first_action_seen = True
                         if (
                             not first_action_seen
                             and first_action_deadline
                             and now >= first_action_deadline
                         ):
-                            proc.kill()
-                            proc.wait(timeout=5)
+                            self._terminate_codex_process(proc)
                             self._publish_codex_exec_failure_trace(
                                 stage="first_action_timeout",
                                 returncode=124,
@@ -441,9 +460,32 @@ class SkillsBenchLocalAcpRelay:
                                 failure_category="codex_exec_first_action_timeout",
                             )
                             raise TimeoutError("local codex first action timeout")
+                        if (
+                            first_action_seen
+                            and bridge_summary_path is not None
+                            and bridge_idle_timeout_sec > 0
+                            and now - last_bridge_activity_at >= bridge_idle_timeout_sec
+                        ):
+                            self._terminate_codex_process(proc)
+                            self._publish_remote_bridge_agent_operations_trace(
+                                bridge_summary_path=bridge_summary_path,
+                            )
+                            self._publish_codex_exec_failure_trace(
+                                stage="bridge_idle_timeout",
+                                returncode=124,
+                                stdout_text="",
+                                stderr_text="codex_exec_bridge_idle_timeout\n",
+                                final_message_present=output_path.exists(),
+                                final_message_bytes=(
+                                    output_path.stat().st_size
+                                    if output_path.exists()
+                                    else 0
+                                ),
+                                failure_category="codex_exec_bridge_idle_timeout",
+                            )
+                            raise TimeoutError("local codex bridge idle timeout")
                         if now >= deadline:
-                            proc.kill()
-                            proc.wait(timeout=5)
+                            self._terminate_codex_process(proc)
                             raise subprocess.TimeoutExpired(
                                 cmd,
                                 self._config.timeout_sec,
@@ -473,6 +515,10 @@ class SkillsBenchLocalAcpRelay:
                     if stderr_path.exists()
                     else ""
                 )
+                if bridge_summary_path is not None:
+                    self._publish_remote_bridge_agent_operations_trace(
+                        bridge_summary_path=bridge_summary_path,
+                    )
                 self._publish_codex_exec_failure_trace(
                     stage="timeout",
                     returncode=124,
@@ -529,6 +575,38 @@ class SkillsBenchLocalAcpRelay:
                     bridge_summary_path=bridge_summary_path,
                 )
             return response or "local codex returned an empty final message"
+
+    def _terminate_codex_process(
+        self,
+        proc: subprocess.Popen[str],
+        *,
+        grace_sec: float = 5.0,
+    ) -> None:
+        if proc.poll() is not None:
+            return
+        try:
+            os.killpg(proc.pid, signal.SIGTERM)
+        except (AttributeError, ProcessLookupError, PermissionError, OSError):
+            try:
+                proc.terminate()
+            except (ProcessLookupError, PermissionError, OSError):
+                pass
+        try:
+            proc.wait(timeout=grace_sec)
+            return
+        except subprocess.TimeoutExpired:
+            pass
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except (AttributeError, ProcessLookupError, PermissionError, OSError):
+            try:
+                proc.kill()
+            except (ProcessLookupError, PermissionError, OSError):
+                pass
+        try:
+            proc.wait(timeout=grace_sec)
+        except subprocess.TimeoutExpired:
+            pass
 
     def _consume_remote_bridge_for_solver(self) -> dict[str, Any]:
         return run_skillsbench_remote_command_file_bridge_probe(

--- a/loopx/benchmark_core/loop_protocol.py
+++ b/loopx/benchmark_core/loop_protocol.py
@@ -193,6 +193,8 @@ def build_product_mode_main_table_comparison_contract(
             "reward_feedback_forwarded": False,
             "stop_on_reward_one": True,
             "stop_on_agent_declared_done_no_remaining_goals": True,
+            "declared_done_stop_requires_no_failed_every_round_reward": True,
+            "continue_after_declared_done_below_passing_reward": True,
             "stop_on_max_rounds_budget": True,
             "headline_metrics": [
                 "best_score",

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -839,6 +839,7 @@ def _compact_benchmark_interaction_counters(value: Any) -> dict[str, Any]:
         "case_goal_state_schema_version",
         "product_mode_lifecycle_checkpoint_missing_reason",
         "product_mode_solver_activity_missing_reason",
+        "product_mode_declared_done_below_passing_reward_score_status",
         "product_mode_declared_done_policy",
         "controller_budget_cutoff_reason",
         "benchflow_user_loop_recovery_stage",
@@ -1053,17 +1054,51 @@ def _repair_product_mode_lifecycle_missing_attribution(
 
     official_score = compact.get("official_score")
     counters = compact.get("interaction_counters")
+    if not isinstance(counters, dict):
+        counters = {}
+
+    def positive_counter(field: str) -> int:
+        value = counters.get(field)
+        if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+            return value
+        return 0
+
+    def zero_counter_observed(field: str) -> bool:
+        if field not in counters:
+            return False
+        value = counters.get(field)
+        return isinstance(value, int) and not isinstance(value, bool) and value == 0
+
     solver_activity_gap = bool(
-        isinstance(counters, dict)
-        and counters.get("product_mode_solver_activity_gap") is True
+        counters.get("product_mode_solver_activity_gap") is True
+        and (
+            counters.get("product_mode_solver_activity_missing_reason")
+            == "missing_task_facing_activity_or_agent_closeout_before_declared_done"
+            or positive_counter("product_mode_solver_activity_gap_count") > 0
+            or zero_counter_observed(
+                "remote_command_file_bridge_agent_task_facing_operation_count"
+            )
+            or zero_counter_observed(
+                "remote_command_file_bridge_agent_todo_closeout_count"
+            )
+        )
     )
-    if isinstance(official_score, (int, float)) and not isinstance(
+    if solver_activity_gap:
+        replacement = "skillsbench_product_mode_solver_activity_gap"
+        labels = [
+            label
+            for label in labels
+            if label
+            not in {
+                "official_verifier_solution_failure",
+                "official_score_zero_case_failure",
+            }
+        ]
+    elif isinstance(official_score, (int, float)) and not isinstance(
         official_score,
         bool,
     ) and official_score == 0:
         replacement = "official_verifier_solution_failure"
-    elif solver_activity_gap:
-        replacement = "skillsbench_product_mode_solver_activity_gap"
     else:
         replacement = "none"
 

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -678,6 +678,7 @@ def _compact_benchmark_interaction_counters(value: Any) -> dict[str, Any]:
         "product_mode_lifecycle_checkpoint_required",
         "product_mode_solver_activity_required",
         "product_mode_solver_activity_gap",
+        "product_mode_declared_done_below_passing_reward",
         "product_mode_no_tool_call_lifecycle_abort",
         "agent_declared_done",
         "agent_declared_no_remaining_goals",
@@ -699,6 +700,8 @@ def _compact_benchmark_interaction_counters(value: Any) -> dict[str, Any]:
         "benchflow_intermediate_soft_verify_timeout_raw_output_recorded",
         "benchflow_intermediate_soft_verify_timeout_cleanup_requested",
         "benchflow_intermediate_soft_verify_timeout_cleanup_raw_logs_read",
+        "benchflow_intermediate_soft_verify_orphan_cleanup_requested",
+        "benchflow_intermediate_soft_verify_orphan_cleanup_raw_logs_read",
         "private_trajectory_summary_present",
         "native_goal_worker_route",
         "native_goal_worker_connected",
@@ -713,6 +716,8 @@ def _compact_benchmark_interaction_counters(value: Any) -> dict[str, Any]:
         "remote_command_file_bridge_agent_operation_trace_satisfied",
         "remote_command_file_bridge_driver_lifecycle_trace_present",
         "remote_command_file_bridge_driver_lifecycle_raw_material_recorded",
+        "host_local_acp_codex_exec_failure_trace_present",
+        "host_local_acp_codex_exec_failure_raw_material_recorded",
     ):
         if isinstance(value.get(field), bool):
             compact[field] = value[field]
@@ -735,6 +740,8 @@ def _compact_benchmark_interaction_counters(value: Any) -> dict[str, Any]:
         "product_mode_lifecycle_checkpoint_round",
         "product_mode_solver_activity_gap_count",
         "product_mode_solver_activity_gap_round",
+        "product_mode_declared_done_below_passing_reward_count",
+        "product_mode_declared_done_below_passing_reward_round",
         "product_mode_no_tool_call_lifecycle_abort_count",
         "product_mode_no_tool_call_lifecycle_abort_round",
         "controller_verifier_feedback_observation_count",
@@ -752,6 +759,11 @@ def _compact_benchmark_interaction_counters(value: Any) -> dict[str, Any]:
         "benchflow_intermediate_soft_verify_timeout_cleanup_term_sent_count",
         "benchflow_intermediate_soft_verify_timeout_cleanup_kill_sent_count",
         "benchflow_intermediate_soft_verify_timeout_cleanup_alive_after_count",
+        "benchflow_intermediate_soft_verify_orphan_cleanup_container_count",
+        "benchflow_intermediate_soft_verify_orphan_cleanup_match_count",
+        "benchflow_intermediate_soft_verify_orphan_cleanup_term_sent_count",
+        "benchflow_intermediate_soft_verify_orphan_cleanup_kill_sent_count",
+        "benchflow_intermediate_soft_verify_orphan_cleanup_alive_after_count",
         "private_trajectory_event_count",
         "private_trajectory_round_count",
         "private_trajectory_tool_call_count",
@@ -809,9 +821,14 @@ def _compact_benchmark_interaction_counters(value: Any) -> dict[str, Any]:
         "remote_command_file_bridge_driver_lifecycle_loopx_cli_call_count",
         "remote_command_file_bridge_driver_lifecycle_loopx_state_read_count",
         "remote_command_file_bridge_driver_lifecycle_loopx_state_write_count",
+        "host_local_acp_codex_exec_failure_trace_count",
     ):
         if isinstance(value.get(field), int) and not isinstance(value.get(field), bool):
             compact[field] = value[field]
+    for field in ("product_mode_declared_done_below_passing_reward_score",):
+        raw = value.get(field)
+        if isinstance(raw, (int, float)) and not isinstance(raw, bool):
+            compact[field] = float(raw)
     for field in (
         "case_result_writeback",
         "counter_trust_level",
@@ -822,14 +839,17 @@ def _compact_benchmark_interaction_counters(value: Any) -> dict[str, Any]:
         "case_goal_state_schema_version",
         "product_mode_lifecycle_checkpoint_missing_reason",
         "product_mode_solver_activity_missing_reason",
+        "product_mode_declared_done_policy",
         "controller_budget_cutoff_reason",
         "benchflow_user_loop_recovery_stage",
         "benchflow_user_loop_recovery_exception_type",
         "benchflow_intermediate_soft_verify_policy",
         "benchflow_intermediate_soft_verify_timeout_stage",
         "benchflow_intermediate_soft_verify_timeout_cleanup_status",
+        "benchflow_intermediate_soft_verify_orphan_cleanup_status",
         "remote_command_file_bridge_agent_operation_trace_status",
         "remote_command_file_bridge_driver_lifecycle_execution_style",
+        "host_local_acp_codex_exec_failure_category",
         "last_decision",
         "worker_submit_eligible_mismatch_reason",
         "worker_bridge_writeback_loss_reason",
@@ -1207,6 +1227,7 @@ def _compact_benchmark_runner_prerequisites(value: Any) -> dict[str, Any]:
         "benchflow_intermediate_soft_verify_policy",
         "benchflow_intermediate_soft_verify_timeout_stage",
         "benchflow_intermediate_soft_verify_timeout_cleanup_status",
+        "benchflow_intermediate_soft_verify_orphan_cleanup_status",
         "benchflow_setup_stall_cleanup_status",
         "remote_command_file_bridge_consumption_status",
         "remote_command_file_bridge_agent_operation_trace_status",
@@ -1262,6 +1283,8 @@ def _compact_benchmark_runner_prerequisites(value: Any) -> dict[str, Any]:
         "benchflow_intermediate_soft_verify_timeout_raw_output_recorded",
         "benchflow_intermediate_soft_verify_timeout_cleanup_requested",
         "benchflow_intermediate_soft_verify_timeout_cleanup_raw_logs_read",
+        "benchflow_intermediate_soft_verify_orphan_cleanup_requested",
+        "benchflow_intermediate_soft_verify_orphan_cleanup_raw_logs_read",
         "benchflow_verifier_prep_timeout_override_enabled",
         "benchflow_verifier_prep_timeout_raw_command_recorded",
         "benchflow_final_verifier_timeout_enabled",
@@ -1303,6 +1326,11 @@ def _compact_benchmark_runner_prerequisites(value: Any) -> dict[str, Any]:
         "benchflow_intermediate_soft_verify_timeout_cleanup_term_sent_count",
         "benchflow_intermediate_soft_verify_timeout_cleanup_kill_sent_count",
         "benchflow_intermediate_soft_verify_timeout_cleanup_alive_after_count",
+        "benchflow_intermediate_soft_verify_orphan_cleanup_container_count",
+        "benchflow_intermediate_soft_verify_orphan_cleanup_match_count",
+        "benchflow_intermediate_soft_verify_orphan_cleanup_term_sent_count",
+        "benchflow_intermediate_soft_verify_orphan_cleanup_kill_sent_count",
+        "benchflow_intermediate_soft_verify_orphan_cleanup_alive_after_count",
         "benchflow_verifier_prep_timeout_sec",
         "benchflow_final_verifier_timeout_sec",
         "benchflow_final_verifier_timeout_override_count",

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -972,7 +972,108 @@ def _compact_product_mode_lifecycle_contract(value: Any) -> dict[str, Any]:
     execution_style = public_safe_compact_text(value.get("execution_style"), limit=120)
     if execution_style:
         compact["execution_style"] = execution_style
+    _normalize_product_mode_lifecycle_contract(compact)
     return compact
+
+
+def _normalize_product_mode_lifecycle_contract(contract: dict[str, Any]) -> None:
+    """Repair old compact records whose bridge closeout evidence was copied late."""
+
+    def positive_int(field: str) -> int:
+        value = contract.get(field)
+        if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+            return value
+        return 0
+
+    agent_trace_required = contract.get("agent_operation_trace_required") is True
+    agent_trace_satisfied = contract.get("agent_operation_trace_satisfied") is True
+    agent_trace_missing = contract.get("agent_operation_trace_missing") is True
+    agent_trace_ok = bool(
+        not agent_trace_missing
+        and (agent_trace_satisfied or not agent_trace_required)
+    )
+    agent_bridge_closeout_satisfied = bool(
+        positive_int("agent_bridge_todo_closeout_count") > 0
+        and positive_int("agent_bridge_refresh_state_count") > 0
+        and positive_int("agent_bridge_quota_spend_slot_count") > 0
+    )
+    lifecycle_io_satisfied = bool(
+        positive_int("state_read_count") > 0
+        and positive_int("state_write_count") > 0
+    )
+    lifecycle_closeout_satisfied = bool(
+        contract.get("closeout_satisfied") is True
+        or agent_bridge_closeout_satisfied
+    )
+    if (
+        contract.get("required") is True
+        and agent_trace_ok
+        and lifecycle_io_satisfied
+        and lifecycle_closeout_satisfied
+    ):
+        contract["satisfied"] = True
+        contract["countable_treatment"] = True
+        contract["closeout_satisfied"] = True
+        if contract.get("missing_reason") in {
+            "missing_case_local_loopx_closeout",
+            "remote_command_file_bridge_agent_operation_trace_missing",
+        }:
+            contract.pop("missing_reason", None)
+
+
+def _repair_product_mode_lifecycle_missing_attribution(
+    compact: dict[str, Any],
+) -> None:
+    contract = compact.get("product_mode_lifecycle_contract")
+    if not isinstance(contract, dict):
+        return
+    if not (
+        contract.get("required") is True
+        and contract.get("satisfied") is True
+        and contract.get("countable_treatment") is True
+    ):
+        return
+    if compact.get("score_failure_attribution") != (
+        "skillsbench_product_mode_lifecycle_missing"
+    ):
+        return
+
+    labels = public_safe_compact_list(
+        compact.get("failure_attribution_labels"),
+        limit=MAX_BENCHMARK_RUN_LIST_ITEMS,
+    )
+    stale_labels = {
+        "skillsbench_product_mode_lifecycle_missing",
+        "skillsbench_product_mode_uncountable_treatment",
+        "skillsbench_case_local_loopx_state_not_observed",
+        "skillsbench_remote_bridge_agent_no_requests",
+        "skillsbench_remote_bridge_agent_operation_trace_missing",
+    }
+    labels = [label for label in labels if label not in stale_labels]
+
+    official_score = compact.get("official_score")
+    counters = compact.get("interaction_counters")
+    solver_activity_gap = bool(
+        isinstance(counters, dict)
+        and counters.get("product_mode_solver_activity_gap") is True
+    )
+    if isinstance(official_score, (int, float)) and not isinstance(
+        official_score,
+        bool,
+    ) and official_score == 0:
+        replacement = "official_verifier_solution_failure"
+    elif solver_activity_gap:
+        replacement = "skillsbench_product_mode_solver_activity_gap"
+    else:
+        replacement = "none"
+
+    compact["score_failure_attribution"] = replacement
+    if replacement != "none" and replacement not in labels:
+        labels.insert(0, replacement)
+    if labels:
+        compact["failure_attribution_labels"] = labels[:MAX_BENCHMARK_RUN_LIST_ITEMS]
+    else:
+        compact.pop("failure_attribution_labels", None)
 
 
 def _compact_benchmark_round_reward_trace(value: Any) -> dict[str, Any]:
@@ -2863,6 +2964,7 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
     )
     if product_mode_lifecycle_contract:
         compact["product_mode_lifecycle_contract"] = product_mode_lifecycle_contract
+        _repair_product_mode_lifecycle_missing_attribution(compact)
 
     preflight_guard = _compact_benchmark_preflight_guard(source.get("preflight_guard"))
     if preflight_guard:

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -896,6 +896,8 @@ def _compact_benchmark_interaction_counters(value: Any) -> dict[str, Any]:
         "remote_command_file_bridge_solver_operation_count",
         "remote_command_file_bridge_agent_operation_trace_count",
         "remote_command_file_bridge_agent_request_count",
+        "remote_command_file_bridge_agent_success_count",
+        "remote_command_file_bridge_agent_failure_count",
         "remote_command_file_bridge_agent_loopx_cli_call_count",
         "remote_command_file_bridge_agent_loopx_state_read_count",
         "remote_command_file_bridge_agent_loopx_state_write_count",
@@ -964,6 +966,8 @@ def _compact_benchmark_interaction_counters(value: Any) -> dict[str, Any]:
         "codex_runtime_goal_tool_calls",
         "trajectory_action_category_counts",
         "loopx_cli_state_usage_counts",
+        "remote_command_file_bridge_agent_returncode_counts",
+        "remote_command_file_bridge_agent_successful_loopx_subcommand_counts",
     ):
         calls = _compact_numeric_map(value.get(field))
         if calls:
@@ -1573,6 +1577,8 @@ def _compact_benchmark_runner_prerequisites(value: Any) -> dict[str, Any]:
         "remote_command_file_bridge_solver_operation_count",
         "remote_command_file_bridge_agent_operation_trace_count",
         "remote_command_file_bridge_agent_request_count",
+        "remote_command_file_bridge_agent_success_count",
+        "remote_command_file_bridge_agent_failure_count",
         "remote_command_file_bridge_agent_loopx_cli_call_count",
         "remote_command_file_bridge_agent_loopx_state_read_count",
         "remote_command_file_bridge_agent_loopx_state_write_count",

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -652,6 +652,96 @@ def _compact_numeric_map(value: Any, *, keys: tuple[str, ...] | None = None) -> 
     return compact
 
 
+def _compact_benchmark_case_event_timeline(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+
+    events: list[dict[str, Any]] = []
+    for raw_event in value.get("events", []):
+        if not isinstance(raw_event, dict):
+            continue
+        event: dict[str, Any] = {}
+        for field in ("phase", "event", "status"):
+            text = public_safe_compact_text(raw_event.get(field), limit=120)
+            if text:
+                event[field] = text
+        if not {"phase", "event", "status"} <= set(event):
+            continue
+        for field in (
+            "execution_style",
+            "agent_operation_trace_status",
+            "last_decision",
+            "recovery_stage",
+            "recovery_exception_type",
+            "runner_failure_class",
+            "official_score_status",
+            "score_failure_attribution",
+        ):
+            text = public_safe_compact_text(raw_event.get(field), limit=140)
+            if text:
+                event[field] = text
+        for field in (
+            "required",
+            "initialized_before_agent",
+            "consumed_by_solver",
+            "official_score_passed",
+        ):
+            if isinstance(raw_event.get(field), bool):
+                event[field] = raw_event[field]
+        for field in (
+            "index",
+            "checkpoint_count",
+            "state_read_count",
+            "state_write_count",
+            "solver_operation_count",
+            "solver_probe_ready_count",
+            "trajectory_event_count",
+            "trajectory_round_count",
+            "trajectory_tool_call_count",
+            "agent_bridge_request_count",
+            "agent_bridge_task_facing_operation_count",
+            "action_decision_count",
+            "initial_prompt_count",
+            "followup_prompt_count",
+            "stop_decision_count",
+            "max_rounds_budget",
+            "final_round",
+            "recovery_delta_events",
+            "recovery_delta_tool_calls",
+            "benchflow_agent_timeout_effective_sec",
+            "local_codex_exec_timeout_sec",
+            "todo_closeout_count",
+            "refresh_state_count",
+            "quota_spend_slot_count",
+        ):
+            raw = raw_event.get(field)
+            if isinstance(raw, int) and not isinstance(raw, bool):
+                event[field] = max(0, raw)
+        for field in ("best_round_reward", "official_score_value"):
+            raw = raw_event.get(field)
+            if isinstance(raw, (int, float)) and not isinstance(raw, bool):
+                event[field] = raw
+        labels = public_safe_compact_list(
+            raw_event.get("failure_attribution_labels"),
+            limit=MAX_BENCHMARK_RUN_LIST_ITEMS,
+        )
+        if labels:
+            event["failure_attribution_labels"] = labels
+        events.append(event)
+
+    if not events:
+        return {}
+
+    compact: dict[str, Any] = {
+        "schema_version": "skillsbench_case_event_timeline_v0",
+        "source": "compact_public_signals",
+        "raw_material_recorded": False,
+        "event_count": len(events),
+        "events": events[:12],
+    }
+    return compact
+
+
 def _compact_benchmark_interaction_counters(value: Any) -> dict[str, Any]:
     if not isinstance(value, dict):
         return {}
@@ -3000,6 +3090,12 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
     if product_mode_lifecycle_contract:
         compact["product_mode_lifecycle_contract"] = product_mode_lifecycle_contract
         _repair_product_mode_lifecycle_missing_attribution(compact)
+
+    case_event_timeline = _compact_benchmark_case_event_timeline(
+        source.get("case_event_timeline")
+    )
+    if case_event_timeline:
+        compact["case_event_timeline"] = case_event_timeline
 
     preflight_guard = _compact_benchmark_preflight_guard(source.get("preflight_guard"))
     if preflight_guard:

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -2835,6 +2835,409 @@ def _apply_agent_message_only_no_tool_calls_attribution(
     return True
 
 
+def _case_timeline_safe_string(value: Any, *, limit: int = 140) -> str:
+    if not isinstance(value, str):
+        return ""
+    return value[:limit] if value else ""
+
+
+def _case_timeline_public_number(value: Any) -> int | float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return max(0, value)
+    if isinstance(value, float):
+        return max(0.0, value)
+    return None
+
+
+def _case_timeline_max_int(*values: Any) -> int:
+    safe_values = [
+        value
+        for value in (_case_timeline_public_number(item) for item in values)
+        if isinstance(value, int)
+    ]
+    return max(safe_values) if safe_values else 0
+
+
+def _append_case_timeline_event(
+    events: list[dict[str, Any]],
+    *,
+    phase: str,
+    event: str,
+    status: str,
+    **fields: Any,
+) -> None:
+    entry: dict[str, Any] = {
+        "index": len(events) + 1,
+        "phase": phase,
+        "event": event,
+        "status": status[:140],
+    }
+    for key, value in fields.items():
+        if isinstance(value, bool):
+            entry[key] = value
+            continue
+        number = _case_timeline_public_number(value)
+        if number is not None:
+            entry[key] = number
+            continue
+        text = _case_timeline_safe_string(value)
+        if text:
+            entry[key] = text
+            continue
+        if isinstance(value, list):
+            safe_items: list[Any] = []
+            for item in value:
+                if isinstance(item, bool):
+                    safe_items.append(item)
+                else:
+                    item_number = _case_timeline_public_number(item)
+                    if item_number is not None:
+                        safe_items.append(item_number)
+                        continue
+                    item_text = _case_timeline_safe_string(item, limit=80)
+                    if item_text:
+                        safe_items.append(item_text)
+            if safe_items:
+                entry[key] = safe_items[:8]
+    events.append(entry)
+
+
+def _build_case_event_timeline(
+    compact: dict[str, Any],
+    plan: dict[str, Any],
+) -> dict[str, Any]:
+    """Build a public-safe phase timeline from already-compacted signals."""
+
+    counters = (
+        compact.get("interaction_counters")
+        if isinstance(compact.get("interaction_counters"), dict)
+        else {}
+    )
+    runner_prerequisites = _public_runner_prerequisites(
+        plan.get("runner_prerequisites")
+    )
+    compact_runner_prerequisites = compact.get("runner_prerequisites")
+    if isinstance(compact_runner_prerequisites, dict):
+        runner_prerequisites.update(compact_runner_prerequisites)
+    lifecycle_contract = (
+        compact.get("product_mode_lifecycle_contract")
+        if isinstance(compact.get("product_mode_lifecycle_contract"), dict)
+        else {}
+    )
+    runner_failure = (
+        compact.get("runner_failure")
+        if isinstance(compact.get("runner_failure"), dict)
+        else {}
+    )
+    official_task_score = (
+        compact.get("official_task_score")
+        if isinstance(compact.get("official_task_score"), dict)
+        else {}
+    )
+    events: list[dict[str, Any]] = []
+
+    case_init_status = _case_timeline_safe_string(
+        counters.get("case_goal_state_init_status")
+    )
+    if not case_init_status:
+        if counters.get("case_goal_state_initialized_before_agent") is True:
+            case_init_status = "passed"
+        elif counters.get("case_goal_state_init_required") is True:
+            case_init_status = "missing"
+        elif compact.get("product_mode") is True or counters.get("product_mode") is True:
+            case_init_status = "not_observed"
+        else:
+            case_init_status = "not_required"
+    _append_case_timeline_event(
+        events,
+        phase="case_state",
+        event="case_goal_state_init",
+        status=case_init_status,
+        required=counters.get("case_goal_state_init_required") is True,
+        initialized_before_agent=(
+            counters.get("case_goal_state_initialized_before_agent") is True
+        ),
+    )
+
+    driver_checkpoint_count = _case_timeline_max_int(
+        counters.get("remote_command_file_bridge_driver_lifecycle_checkpoint_count"),
+        runner_prerequisites.get(
+            "remote_command_file_bridge_driver_lifecycle_checkpoint_count"
+        ),
+        lifecycle_contract.get("checkpoint_count"),
+    )
+    driver_state_read_count = _case_timeline_max_int(
+        counters.get("remote_command_file_bridge_driver_lifecycle_loopx_state_read_count"),
+        runner_prerequisites.get(
+            "remote_command_file_bridge_driver_lifecycle_loopx_state_read_count"
+        ),
+        lifecycle_contract.get("driver_lifecycle_state_read_count"),
+    )
+    driver_state_write_count = _case_timeline_max_int(
+        counters.get("remote_command_file_bridge_driver_lifecycle_loopx_state_write_count"),
+        runner_prerequisites.get(
+            "remote_command_file_bridge_driver_lifecycle_loopx_state_write_count"
+        ),
+        lifecycle_contract.get("driver_lifecycle_state_write_count"),
+    )
+    driver_status = "not_observed"
+    if lifecycle_contract.get("orchestrated_driver_counts_as_product_mode") is True:
+        driver_status = "satisfied"
+    elif driver_checkpoint_count or driver_state_read_count or driver_state_write_count:
+        driver_status = "observed"
+    elif lifecycle_contract.get("checkpoint_required") is True:
+        driver_status = "missing"
+    _append_case_timeline_event(
+        events,
+        phase="driver_lifecycle",
+        event="orchestrated_loopx_lifecycle",
+        status=driver_status,
+        checkpoint_count=driver_checkpoint_count,
+        state_read_count=driver_state_read_count,
+        state_write_count=driver_state_write_count,
+        execution_style=(
+            lifecycle_contract.get("execution_style")
+            or counters.get("remote_command_file_bridge_driver_lifecycle_execution_style")
+            or runner_prerequisites.get(
+                "remote_command_file_bridge_driver_lifecycle_execution_style"
+            )
+        ),
+    )
+
+    solver_op_count = _case_timeline_max_int(
+        counters.get("remote_command_file_bridge_solver_operation_count"),
+        runner_prerequisites.get("remote_command_file_bridge_solver_operation_count"),
+    )
+    solver_probe_count = _case_timeline_max_int(
+        counters.get("remote_command_file_bridge_solver_probe_ready_count"),
+        runner_prerequisites.get("remote_command_file_bridge_solver_probe_ready_count"),
+    )
+    solver_consumed = (
+        compact.get("remote_command_file_bridge_consumed_by_solver") is True
+        or counters.get("remote_command_file_bridge_consumed_by_solver") is True
+        or runner_prerequisites.get("remote_command_file_bridge_consumed_by_solver")
+        is True
+    )
+    if solver_consumed:
+        solver_status = "consumed"
+    elif solver_op_count or solver_probe_count:
+        solver_status = "observed_not_consumed"
+    elif compact.get("product_mode") is True or counters.get("product_mode") is True:
+        solver_status = "missing"
+    else:
+        solver_status = "not_required"
+    _append_case_timeline_event(
+        events,
+        phase="solver_bridge",
+        event="remote_command_bridge_consumption",
+        status=solver_status,
+        consumed_by_solver=solver_consumed,
+        solver_operation_count=solver_op_count,
+        solver_probe_ready_count=solver_probe_count,
+    )
+
+    trajectory_event_count = _case_timeline_max_int(
+        counters.get("private_trajectory_event_count")
+    )
+    trajectory_round_count = _case_timeline_max_int(
+        counters.get("private_trajectory_round_count")
+    )
+    trajectory_tool_call_count = _case_timeline_max_int(
+        counters.get("private_trajectory_tool_call_count")
+    )
+    agent_request_count = _case_timeline_max_int(
+        counters.get("remote_command_file_bridge_agent_request_count"),
+        runner_prerequisites.get("remote_command_file_bridge_agent_request_count"),
+    )
+    task_facing_count = _case_timeline_max_int(
+        counters.get("remote_command_file_bridge_agent_task_facing_operation_count"),
+        runner_prerequisites.get(
+            "remote_command_file_bridge_agent_task_facing_operation_count"
+        ),
+    )
+    if trajectory_tool_call_count or task_facing_count:
+        activity_status = "task_activity_observed"
+    elif trajectory_event_count or agent_request_count:
+        activity_status = "agent_messages_only"
+    elif (
+        counters.get("remote_command_file_bridge_agent_operation_trace_required")
+        is True
+        or runner_prerequisites.get(
+            "remote_command_file_bridge_agent_operation_trace_required"
+        )
+        is True
+    ):
+        activity_status = "missing_agent_operation_trace"
+    else:
+        activity_status = "not_observed"
+    _append_case_timeline_event(
+        events,
+        phase="agent_activity",
+        event="task_facing_activity",
+        status=activity_status,
+        trajectory_event_count=trajectory_event_count,
+        trajectory_round_count=trajectory_round_count,
+        trajectory_tool_call_count=trajectory_tool_call_count,
+        agent_bridge_request_count=agent_request_count,
+        agent_bridge_task_facing_operation_count=task_facing_count,
+        agent_operation_trace_status=(
+            counters.get("remote_command_file_bridge_agent_operation_trace_status")
+            or runner_prerequisites.get(
+                "remote_command_file_bridge_agent_operation_trace_status"
+            )
+        ),
+    )
+
+    round_reward_trace = (
+        compact.get("round_reward_trace")
+        if isinstance(compact.get("round_reward_trace"), dict)
+        else {}
+    )
+    controller_status = "not_observed"
+    if counters.get("controller_official_success_observed") is True:
+        controller_status = "official_success_observed"
+    elif counters.get("product_mode_declared_done_below_passing_reward") is True:
+        controller_status = "declared_done_below_passing_reward"
+    elif counters.get("agent_declared_done") is True:
+        controller_status = "agent_declared_done"
+    elif _case_timeline_max_int(counters.get("controller_action_decisions")):
+        controller_status = "rounds_observed"
+    _append_case_timeline_event(
+        events,
+        phase="controller",
+        event="controller_decision_loop",
+        status=controller_status,
+        action_decision_count=_case_timeline_max_int(
+            counters.get("controller_action_decisions")
+        ),
+        initial_prompt_count=_case_timeline_max_int(
+            counters.get("controller_initial_prompt_count")
+        ),
+        followup_prompt_count=_case_timeline_max_int(
+            counters.get("controller_followup_prompt_count")
+        ),
+        stop_decision_count=_case_timeline_max_int(
+            counters.get("controller_stop_decision_count")
+        ),
+        max_rounds_budget=_case_timeline_max_int(
+            counters.get("controller_max_rounds_budget"),
+            compact.get("controller_max_rounds_budget"),
+        ),
+        final_round=round_reward_trace.get("final_round"),
+        best_round_reward=round_reward_trace.get("best_round_reward"),
+        last_decision=(
+            counters.get("last_decision") or compact.get("controller_last_decision")
+        ),
+    )
+
+    recovery_exception = (
+        runner_prerequisites.get("benchflow_user_loop_recovery_exception_type")
+        or counters.get("benchflow_user_loop_recovery_exception_type")
+    )
+    runner_failure_class = runner_failure.get("failure_class")
+    if recovery_exception:
+        recovery_status = "user_loop_recovery_triggered"
+    elif runner_failure_class:
+        recovery_status = "runner_failure_recorded"
+    else:
+        recovery_status = "not_triggered"
+    _append_case_timeline_event(
+        events,
+        phase="runner_recovery",
+        event="timeout_or_failure_closeout",
+        status=recovery_status,
+        recovery_stage=(
+            runner_prerequisites.get("benchflow_user_loop_recovery_stage")
+            or counters.get("benchflow_user_loop_recovery_stage")
+        ),
+        recovery_exception_type=recovery_exception,
+        recovery_delta_events=_case_timeline_max_int(
+            runner_prerequisites.get("benchflow_user_loop_recovery_delta_events"),
+            counters.get("benchflow_user_loop_recovery_delta_events"),
+        ),
+        recovery_delta_tool_calls=_case_timeline_max_int(
+            runner_prerequisites.get("benchflow_user_loop_recovery_delta_tool_calls"),
+            counters.get("benchflow_user_loop_recovery_delta_tool_calls"),
+        ),
+        runner_failure_class=runner_failure_class,
+        benchflow_agent_timeout_effective_sec=runner_prerequisites.get(
+            "benchflow_agent_timeout_effective_sec"
+        ),
+        local_codex_exec_timeout_sec=runner_prerequisites.get(
+            "benchflow_agent_timeout_host_local_acp_exec_timeout_sec"
+        ),
+    )
+
+    official_status = _case_timeline_safe_string(
+        compact.get("official_score_status")
+    ) or "unknown"
+    score_value = official_task_score.get("value")
+    if official_task_score.get("passed") is True:
+        verifier_status = "passed"
+    elif official_status == "completed":
+        verifier_status = "completed_nonpassing"
+    elif official_status == "missing":
+        verifier_status = "missing"
+    else:
+        verifier_status = official_status
+    _append_case_timeline_event(
+        events,
+        phase="verifier_score",
+        event="official_score_closeout",
+        status=verifier_status,
+        official_score_status=official_status,
+        official_score_value=score_value,
+        official_score_passed=official_task_score.get("passed"),
+        score_failure_attribution=compact.get("score_failure_attribution"),
+        failure_attribution_labels=compact.get("failure_attribution_labels"),
+    )
+
+    closeout_todo_count = _case_timeline_max_int(
+        counters.get("remote_command_file_bridge_agent_todo_closeout_count"),
+        runner_prerequisites.get("remote_command_file_bridge_agent_todo_closeout_count"),
+        lifecycle_contract.get("agent_bridge_todo_closeout_count"),
+    )
+    closeout_refresh_count = _case_timeline_max_int(
+        counters.get("remote_command_file_bridge_agent_refresh_state_count"),
+        runner_prerequisites.get("remote_command_file_bridge_agent_refresh_state_count"),
+        lifecycle_contract.get("agent_bridge_refresh_state_count"),
+    )
+    closeout_spend_count = _case_timeline_max_int(
+        counters.get("remote_command_file_bridge_agent_quota_spend_slot_count"),
+        runner_prerequisites.get(
+            "remote_command_file_bridge_agent_quota_spend_slot_count"
+        ),
+        lifecycle_contract.get("agent_bridge_quota_spend_slot_count"),
+    )
+    if lifecycle_contract.get("closeout_satisfied") is True:
+        closeout_status = "satisfied"
+    elif closeout_todo_count or closeout_refresh_count or closeout_spend_count:
+        closeout_status = "partial"
+    elif lifecycle_contract.get("closeout_required") is True:
+        closeout_status = "missing"
+    else:
+        closeout_status = "not_required"
+    _append_case_timeline_event(
+        events,
+        phase="loopx_closeout",
+        event="agent_bridge_closeout",
+        status=closeout_status,
+        todo_closeout_count=closeout_todo_count,
+        refresh_state_count=closeout_refresh_count,
+        quota_spend_slot_count=closeout_spend_count,
+    )
+
+    return {
+        "schema_version": "skillsbench_case_event_timeline_v0",
+        "source": "compact_public_signals",
+        "raw_material_recorded": False,
+        "event_count": len(events),
+        "events": events,
+    }
+
+
 def _public_task_staging(value: Any) -> dict[str, Any]:
     if not isinstance(value, dict):
         return {}
@@ -7450,6 +7853,7 @@ def reduce_result(
     runner_output_capture = _public_runner_output_capture(plan)
     if runner_output_capture:
         compact["runner_output_capture"] = runner_output_capture
+    compact["case_event_timeline"] = _build_case_event_timeline(compact, plan)
     return compact
 
 
@@ -7643,6 +8047,7 @@ def build_runner_failure_compact(
     runner_output_capture = _public_runner_output_capture(plan)
     if runner_output_capture:
         reduced["runner_output_capture"] = runner_output_capture
+    reduced["case_event_timeline"] = _build_case_event_timeline(reduced, plan)
     return reduced
 
 

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -1027,7 +1027,7 @@ def _host_local_acp_codex_exec_preflight_first_action_timeout(
     )
     if configured and configured < 30:
         return max(1, min(preflight_timeout, configured))
-    return max(1, min(preflight_timeout, 30))
+    return max(1, min(preflight_timeout, 90))
 
 
 def _summarize_host_local_acp_preflight_bridge_trace(
@@ -1125,6 +1125,7 @@ def _run_host_local_acp_codex_exec_preflight(
                 if bridge_action_required
                 else SKILLSBENCH_LOCAL_ACP_RELAY_READY_MARKER
             ),
+            model_id=str(getattr(args, "model", "") or "") or None,
         )
         ready = probe.get("ready") is True
         prerequisites["host_local_acp_codex_exec_preflight_ready"] = ready

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -96,6 +96,9 @@ from loopx.benchmark_adapters.skillsbench import (  # noqa: E402
     build_skillsbench_worker_handshake_preflight,
 )
 from loopx.benchmark_adapters.skillsbench_acp_relay import (  # noqa: E402
+    SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_PREFLIGHT_MARKER,
+    SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_PREFLIGHT_PROMPT,
+    SKILLSBENCH_LOCAL_ACP_RELAY_READY_MARKER,
     default_skillsbench_local_acp_relay_command,
     run_skillsbench_host_local_acp_transport_probe,
     run_skillsbench_local_acp_relay_probe,
@@ -965,7 +968,120 @@ def _host_local_acp_codex_exec_preflight_command(
                 str(Path(relay_trace_dir) / "codex-exec-preflight"),
             ]
         )
+    if _host_local_acp_codex_exec_preflight_requires_bridge_action(args):
+        command.extend(
+            [
+                "--remote-command-file-bridge-command",
+                str(getattr(args, "remote_command_file_bridge_solver_command") or ""),
+                "--remote-command-file-bridge-timeout-sec",
+                str(
+                    max(
+                        1.0,
+                        float(
+                            getattr(
+                                args,
+                                "remote_command_file_bridge_probe_timeout_sec",
+                                10.0,
+                            )
+                            or 10.0
+                        ),
+                    )
+                ),
+                "--first-action-timeout-sec",
+                str(_host_local_acp_codex_exec_preflight_first_action_timeout(args)),
+            ]
+        )
+        agent_command = str(
+            getattr(args, "remote_command_file_bridge_agent_command", None) or ""
+        )
+        if agent_command:
+            command.extend(["--remote-command-file-bridge-agent-command", agent_command])
     return command
+
+
+def _host_local_acp_codex_exec_preflight_requires_bridge_action(
+    args: argparse.Namespace,
+) -> bool:
+    return bool(
+        getattr(args, "host_local_acp_launch", False)
+        and str(getattr(args, "route", "") or "")
+        in {"raw-codex-autonomous-max5", "loopx-product-mode"}
+        and str(getattr(args, "remote_command_file_bridge_solver_command", "") or "")
+        and (
+            bool(getattr(args, "remote_command_file_bridge_ready", False))
+            or bool(getattr(args, "remote_command_file_bridge_probe", False))
+        )
+    )
+
+
+def _host_local_acp_codex_exec_preflight_first_action_timeout(
+    args: argparse.Namespace,
+) -> int:
+    preflight_timeout = max(
+        1,
+        int(float(getattr(args, "host_local_acp_codex_exec_preflight_timeout_sec", 30))),
+    )
+    configured = max(
+        0,
+        int(float(getattr(args, "local_codex_first_action_timeout_sec", 0) or 0)),
+    )
+    if configured and configured < 30:
+        return max(1, min(preflight_timeout, configured))
+    return max(1, min(preflight_timeout, 30))
+
+
+def _summarize_host_local_acp_preflight_bridge_trace(
+    trace_dir: Path | None,
+) -> dict[str, Any]:
+    summary: dict[str, Any] = {
+        "trace_present": False,
+        "trace_count": 0,
+        "request_count": 0,
+        "task_facing_operation_count": 0,
+        "raw_material_recorded": False,
+    }
+    if trace_dir is None or not trace_dir.exists():
+        return summary
+    for trace_file in sorted(trace_dir.glob("*.compact.json")):
+        try:
+            trace = json.loads(trace_file.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(trace, dict):
+            continue
+        boundary = trace.get("boundary") if isinstance(trace.get("boundary"), dict) else {}
+        summary["raw_material_recorded"] = bool(
+            summary["raw_material_recorded"]
+            or any(
+                boundary.get(field) is True
+                for field in (
+                    "raw_command_recorded",
+                    "raw_stdout_recorded",
+                    "raw_stderr_recorded",
+                    "raw_task_text_recorded",
+                    "raw_logs_recorded",
+                    "raw_trajectory_recorded",
+                    "credential_values_recorded",
+                    "host_paths_recorded",
+                    "remote_paths_recorded",
+                )
+            )
+        )
+        if trace.get("trace_kind") != "remote_command_file_bridge_agent_operations":
+            continue
+        operations = trace.get("remote_command_file_bridge_agent_operations")
+        if not isinstance(operations, dict):
+            continue
+        summary["trace_present"] = True
+        summary["trace_count"] = int(summary["trace_count"]) + 1
+        for source_key, target_key in (
+            ("request_count", "request_count"),
+            ("task_facing_operation_count", "task_facing_operation_count"),
+        ):
+            value = operations.get(source_key)
+            if isinstance(value, int) and not isinstance(value, bool):
+                summary[target_key] = int(summary[target_key]) + max(0, value)
+    return summary
 
 
 def _run_host_local_acp_codex_exec_preflight(
@@ -975,6 +1091,12 @@ def _run_host_local_acp_codex_exec_preflight(
     prerequisites = plan.setdefault("runner_prerequisites", {})
     prerequisites["host_local_acp_codex_exec_preflight_requested"] = True
     prerequisites["host_local_acp_codex_exec_preflight_status"] = "running"
+    bridge_action_required = _host_local_acp_codex_exec_preflight_requires_bridge_action(
+        args
+    )
+    prerequisites["host_local_acp_codex_exec_preflight_bridge_action_required"] = (
+        bridge_action_required
+    )
     attempts = max(
         1,
         int(getattr(args, "host_local_acp_codex_exec_preflight_attempts", 1) or 1),
@@ -993,6 +1115,16 @@ def _run_host_local_acp_codex_exec_preflight(
         probe = run_skillsbench_local_acp_relay_probe(
             command,
             timeout_sec=float(args.host_local_acp_codex_exec_preflight_timeout_sec),
+            prompt_text=(
+                SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_PREFLIGHT_PROMPT
+                if bridge_action_required
+                else None
+            ),
+            required_response_marker=(
+                SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_PREFLIGHT_MARKER
+                if bridge_action_required
+                else SKILLSBENCH_LOCAL_ACP_RELAY_READY_MARKER
+            ),
         )
         ready = probe.get("ready") is True
         prerequisites["host_local_acp_codex_exec_preflight_ready"] = ready
@@ -1002,7 +1134,34 @@ def _run_host_local_acp_codex_exec_preflight(
         prerequisites["host_local_acp_codex_exec_preflight_first_blocker"] = str(
             probe.get("first_blocker") or ""
         )[:180]
-        if ready:
+        prerequisites[
+            "host_local_acp_codex_exec_preflight_response_marker_observed"
+        ] = probe.get("response_marker_observed") is True
+        bridge_summary = _summarize_host_local_acp_preflight_bridge_trace(
+            preflight_trace_dir
+        )
+        prerequisites[
+            "host_local_acp_codex_exec_preflight_bridge_trace_present"
+        ] = bridge_summary["trace_present"]
+        prerequisites[
+            "host_local_acp_codex_exec_preflight_bridge_trace_count"
+        ] = bridge_summary["trace_count"]
+        prerequisites[
+            "host_local_acp_codex_exec_preflight_bridge_request_count"
+        ] = bridge_summary["request_count"]
+        prerequisites[
+            "host_local_acp_codex_exec_preflight_bridge_task_facing_operation_count"
+        ] = bridge_summary["task_facing_operation_count"]
+        prerequisites[
+            "host_local_acp_codex_exec_preflight_bridge_raw_material_recorded"
+        ] = bridge_summary["raw_material_recorded"]
+        bridge_action_observed = bool(
+            bridge_summary["task_facing_operation_count"] > 0
+        )
+        prerequisites["host_local_acp_codex_exec_preflight_bridge_action_observed"] = (
+            bridge_action_observed
+        )
+        if ready and (not bridge_action_required or bridge_action_observed):
             prerequisites["host_local_acp_codex_exec_preflight_status"] = "passed"
             for key in (
                 "host_local_acp_codex_exec_failure_category",
@@ -1013,6 +1172,13 @@ def _run_host_local_acp_codex_exec_preflight(
                 prerequisites.pop(key, None)
             return
         prerequisites["host_local_acp_codex_exec_preflight_status"] = "failed"
+        if ready and bridge_action_required and not bridge_action_observed:
+            prerequisites["host_local_acp_codex_exec_preflight_first_blocker"] = (
+                "skillsbench_host_local_acp_codex_exec_preflight_bridge_action_missing"
+            )
+            prerequisites["host_local_acp_codex_exec_failure_category"] = (
+                "codex_exec_no_bridge_action"
+            )
         if preflight_trace_dir:
             trace: dict[str, Any] = {
                 "schema_version": "skillsbench_loopx_controller_trace_v0"
@@ -1237,6 +1403,11 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "host_local_acp_rollout_planes_available",
         "host_local_acp_codex_exec_preflight_requested",
         "host_local_acp_codex_exec_preflight_ready",
+        "host_local_acp_codex_exec_preflight_response_marker_observed",
+        "host_local_acp_codex_exec_preflight_bridge_action_required",
+        "host_local_acp_codex_exec_preflight_bridge_action_observed",
+        "host_local_acp_codex_exec_preflight_bridge_trace_present",
+        "host_local_acp_codex_exec_preflight_bridge_raw_material_recorded",
         "container_codex_acp_install_skipped",
         "benchflow_agent_install_skipped_by_runtime_layer",
         "benchflow_rollout_planes_module_available",
@@ -1371,6 +1542,9 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "host_local_acp_pwd_probe_rc",
         "loopx_source_upload_fallback_file_count",
         "host_local_acp_codex_exec_preflight_attempt_count",
+        "host_local_acp_codex_exec_preflight_bridge_trace_count",
+        "host_local_acp_codex_exec_preflight_bridge_request_count",
+        "host_local_acp_codex_exec_preflight_bridge_task_facing_operation_count",
         "host_local_acp_codex_exec_failure_trace_count",
     ):
         if isinstance(value.get(field), int) and not isinstance(value.get(field), bool):

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -1037,6 +1037,7 @@ def _summarize_host_local_acp_preflight_bridge_trace(
         "trace_present": False,
         "trace_count": 0,
         "request_count": 0,
+        "preflight_operation_count": 0,
         "task_facing_operation_count": 0,
         "raw_material_recorded": False,
     }
@@ -1081,6 +1082,13 @@ def _summarize_host_local_acp_preflight_bridge_trace(
             value = operations.get(source_key)
             if isinstance(value, int) and not isinstance(value, bool):
                 summary[target_key] = int(summary[target_key]) + max(0, value)
+        operation_counts = operations.get("operation_counts")
+        if isinstance(operation_counts, dict):
+            value = operation_counts.get("preflight")
+            if isinstance(value, int) and not isinstance(value, bool):
+                summary["preflight_operation_count"] = int(
+                    summary["preflight_operation_count"]
+                ) + max(0, value)
     return summary
 
 
@@ -1154,10 +1162,14 @@ def _run_host_local_acp_codex_exec_preflight(
             "host_local_acp_codex_exec_preflight_bridge_task_facing_operation_count"
         ] = bridge_summary["task_facing_operation_count"]
         prerequisites[
+            "host_local_acp_codex_exec_preflight_bridge_preflight_operation_count"
+        ] = bridge_summary["preflight_operation_count"]
+        prerequisites[
             "host_local_acp_codex_exec_preflight_bridge_raw_material_recorded"
         ] = bridge_summary["raw_material_recorded"]
         bridge_action_observed = bool(
-            bridge_summary["task_facing_operation_count"] > 0
+            bridge_summary["preflight_operation_count"] > 0
+            or bridge_summary["task_facing_operation_count"] > 0
         )
         prerequisites["host_local_acp_codex_exec_preflight_bridge_action_observed"] = (
             bridge_action_observed
@@ -1545,6 +1557,7 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "host_local_acp_codex_exec_preflight_attempt_count",
         "host_local_acp_codex_exec_preflight_bridge_trace_count",
         "host_local_acp_codex_exec_preflight_bridge_request_count",
+        "host_local_acp_codex_exec_preflight_bridge_preflight_operation_count",
         "host_local_acp_codex_exec_preflight_bridge_task_facing_operation_count",
         "host_local_acp_codex_exec_failure_trace_count",
     ):

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -5309,6 +5309,50 @@ def _product_mode_depth_gate_satisfied(trace: dict[str, Any]) -> bool:
     )
 
 
+def _product_mode_agent_lifecycle_gate_satisfied(trace: dict[str, Any]) -> bool:
+    """Return true only after the solver agent, not only the driver, touched LoopX."""
+
+    remote_agent_trace_required = (
+        trace.get("remote_command_file_bridge_agent_operation_trace_required") is True
+    )
+    if remote_agent_trace_required:
+        return (
+            _trace_max_int(trace, "remote_command_file_bridge_agent_request_count") > 0
+            and _trace_max_int(
+                trace,
+                "remote_command_file_bridge_agent_loopx_cli_call_count",
+            )
+            > 0
+            and _trace_max_int(
+                trace,
+                "remote_command_file_bridge_agent_loopx_state_read_count",
+            )
+            > 0
+            and _trace_max_int(
+                trace,
+                "remote_command_file_bridge_agent_loopx_state_write_count",
+            )
+            > 0
+        )
+
+    return (
+        _trace_max_int(
+            trace,
+            "remote_command_file_bridge_agent_loopx_state_read_count",
+            "round_result_loopx_cli_state_read_count",
+            "loopx_case_state_reads",
+        )
+        > 0
+        and _trace_max_int(
+            trace,
+            "remote_command_file_bridge_agent_loopx_state_write_count",
+            "round_result_loopx_cli_state_write_count",
+            "loopx_case_state_writes",
+        )
+        > 0
+    )
+
+
 def _trace_max_int(trace: dict[str, Any], *fields: str) -> int:
     values = [
         trace.get(field)
@@ -5793,7 +5837,12 @@ def _build_product_mode_user(
             "benchmark task remains the primary objective; LoopX commands track "
             "control-plane state and do not themselves complete the task. As "
             "the first control-plane action, run the following commands inside "
-            "the scored sandbox, then continue solving and validating the task. "
+            "the scored sandbox, then wait for the scheduler to send the task "
+            "packet. "
+            "Before reading, planning, solving, or answering the task, your first "
+            "agent action must be a shell/tool call that sends the case-local "
+            "LoopX CLI commands through the available sandbox bridge; a prose-only "
+            "response or final answer before that bridge request is invalid. "
             "If a LoopX SkillsBench remote workspace bridge packet is present, "
             "invoke that private JSON bridge from your shell tool and send each "
             "command as an `operation=exec` request with `cwd=/app`; do not try "
@@ -5905,12 +5954,14 @@ def _build_product_mode_user(
         def __init__(self) -> None:
             super().__init__()
             self._persistent_constraint_clause = ""
+            self._task_instruction_sent = False
 
         def _scheduled_continuation_prompt(
             self,
             *,
             scheduled_round: int,
             declared_done_continuation: bool = False,
+            task_instruction: str | None = None,
         ) -> str:
             if treatment:
                 mode_clause = (
@@ -5931,6 +5982,18 @@ def _build_product_mode_user(
                 if declared_done_continuation
                 else ""
             )
+            task_clause = ""
+            if task_instruction is not None:
+                task_clause = (
+                    "\n\n--- TASK INSTRUCTION ---\n"
+                    f"{task_instruction}\n\n"
+                    "The task packet is now available because the solver-side "
+                    "LoopX lifecycle checkpoint was observed. The benchmark "
+                    "task is the primary objective from this round onward. "
+                    "Keep the lifecycle ledger current while solving, but do "
+                    "not run closeout or declare done until after meaningful "
+                    "task-facing work or local validation."
+                )
             return (
                 f"Scheduled product-mode continuation round {scheduled_round} of "
                 f"{max_rounds}. This is part of the fixed autonomous budget and "
@@ -5941,6 +6004,7 @@ def _build_product_mode_user(
                 f"{self._persistent_constraint_clause} {mode_clause} Keep scope "
                 "narrow, validate locally, and if there are no remaining goals, "
                 f"end with {DECLARED_DONE_MARKER}."
+                f"{task_clause}"
             )
 
         async def run(
@@ -5971,7 +6035,7 @@ def _build_product_mode_user(
                     )
                     if (
                         (no_tool_calls or no_lifecycle_requests)
-                        and not _product_mode_depth_gate_satisfied(trace)
+                        and not _product_mode_agent_lifecycle_gate_satisfied(trace)
                     ):
                         _record_product_mode_lifecycle_checkpoint_gap(
                             trace,
@@ -5997,6 +6061,26 @@ def _build_product_mode_user(
                         raise SkillsBenchProductModeNoLifecycleRequests(
                             "loopx-product-mode agent produced no case-local "
                             "LoopX lifecycle request before official verifier"
+                        )
+                    if (
+                        _product_mode_agent_lifecycle_gate_satisfied(trace)
+                        and not self._task_instruction_sent
+                    ):
+                        self._task_instruction_sent = True
+                        trace[
+                            "product_mode_task_instruction_deferred_until_agent_lifecycle"
+                        ] = True
+                        trace[
+                            "product_mode_task_instruction_sent_after_agent_lifecycle"
+                        ] = True
+                        _inc_counter(trace, "controller_action_decisions")
+                        _inc_counter(trace, "followup_prompt_count")
+                        trace["last_decision"] = (
+                            "send_product_mode_task_instruction_after_agent_lifecycle"
+                        )
+                        return self._scheduled_continuation_prompt(
+                            scheduled_round=round + 1,
+                            task_instruction=instruction,
                         )
                 if _round_result_declared_done(round_result):
                     if treatment:
@@ -6111,6 +6195,10 @@ def _build_product_mode_user(
                     trace["persistent_constraint_protected_paths"] = protected_paths
                 if treatment:
                     prefix = "LoopX product-mode treatment round 1. "
+                    self._task_instruction_sent = False
+                    trace[
+                        "product_mode_task_instruction_deferred_until_agent_lifecycle"
+                    ] = True
                     trace["case_goal_state_packet_present"] = True
                     control_clause = (
                         "Use LoopX as your product control plane: create "
@@ -6118,6 +6206,26 @@ def _build_product_mode_user(
                         "evidence changes, and use LoopX CLI/status/ledger "
                         "surfaces when available. "
                         + treatment_state_contract()
+                    )
+                    return (
+                        prefix
+                        + "You are running inside the official SkillsBench sandbox. "
+                        + "No official reward, pass/fail status, verifier error, "
+                        "verifier output, or verifier tail will be shown during this "
+                        "run.\n\n"
+                        "--- LOOPX PRODUCT-MODE CONTROL PLANE ---\n"
+                        f"{control_clause}"
+                        "For this treatment, LoopX lifecycle evidence is a "
+                        "hard product-mode requirement: first run the "
+                        "case-local quota/todo commands above through the solver "
+                        "bridge. The benchmark task instruction is intentionally "
+                        "withheld until that solver-side lifecycle checkpoint is "
+                        "observed, so do not inspect, infer, plan, solve, or answer "
+                        "the task yet. Do not run case closeout or declare done "
+                        "during this setup checkpoint. The controller will send the "
+                        "task packet after solver-side LoopX read/write evidence is "
+                        "recorded, without exposing official reward or verifier "
+                        "output."
                     )
                 else:
                     prefix = "Raw Codex autonomous max5 baseline round 1. "
@@ -6158,7 +6266,7 @@ def _build_product_mode_user(
             _inc_counter(trace, "followup_prompt_count")
             if treatment:
                 _merge_acp_trajectory_summary(plan or {}, trace)
-                if not _product_mode_depth_gate_satisfied(trace):
+                if not _product_mode_agent_lifecycle_gate_satisfied(trace):
                     _record_product_mode_lifecycle_checkpoint_gap(
                         trace,
                         agent_round=round,
@@ -6167,6 +6275,21 @@ def _build_product_mode_user(
                         "send_product_mode_lifecycle_checkpoint_continuation"
                     )
                     return lifecycle_checkpoint_prompt(round + 1)
+                if not self._task_instruction_sent:
+                    self._task_instruction_sent = True
+                    trace[
+                        "product_mode_task_instruction_deferred_until_agent_lifecycle"
+                    ] = True
+                    trace[
+                        "product_mode_task_instruction_sent_after_agent_lifecycle"
+                    ] = True
+                    trace["last_decision"] = (
+                        "send_product_mode_task_instruction_after_agent_lifecycle"
+                    )
+                    return self._scheduled_continuation_prompt(
+                        scheduled_round=round + 1,
+                        task_instruction=instruction,
+                    )
             trace["last_decision"] = "send_product_mode_scheduled_continuation"
             return self._scheduled_continuation_prompt(scheduled_round=round + 1)
 

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -931,7 +931,11 @@ def _host_local_acp_codex_exec_preflight_command(
     args: argparse.Namespace,
     plan: dict[str, Any],
 ) -> list[str]:
-    command = list(default_skillsbench_local_acp_relay_command())
+    local_acp_relay_command = getattr(args, "local_acp_relay_command", None)
+    if local_acp_relay_command:
+        command = shlex.split(str(local_acp_relay_command))
+    else:
+        command = list(default_skillsbench_local_acp_relay_command())
     if "--dry-run-response" in command:
         index = command.index("--dry-run-response")
         del command[index : index + 2]

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -5259,11 +5259,19 @@ def _record_product_mode_declared_done_below_passing_reward(
     trace: dict[str, Any],
     *,
     agent_round: int,
-    reward: float,
+    reward: float | None,
 ) -> None:
     trace["product_mode_declared_done_below_passing_reward"] = True
     trace["product_mode_declared_done_below_passing_reward_round"] = agent_round
-    trace["product_mode_declared_done_below_passing_reward_score"] = reward
+    if reward is None:
+        trace["product_mode_declared_done_below_passing_reward_score_status"] = (
+            "missing"
+        )
+    else:
+        trace["product_mode_declared_done_below_passing_reward_score"] = reward
+        trace["product_mode_declared_done_below_passing_reward_score_status"] = (
+            "observed_below_passing"
+        )
     trace["product_mode_declared_done_policy"] = (
         "continue_until_official_success_or_budget"
     )
@@ -6229,21 +6237,32 @@ def _build_product_mode_user(
                                 "send_product_mode_solver_activity_continuation"
                             )
                             return solver_activity_prompt(round + 1)
-                    if (
-                        treatment
-                        and isinstance(reward, (int, float))
-                        and not isinstance(reward, bool)
-                        and reward < 1.0
-                    ):
+                    if treatment:
                         _record_declared_done(
                             trace,
                             agent_round=round,
                             reward=reward,
                         )
+                        if (
+                            isinstance(reward, (int, float))
+                            and not isinstance(reward, bool)
+                            and reward >= 1.0
+                        ):
+                            _inc_counter(trace, "controller_action_decisions")
+                            _inc_counter(trace, "stop_decision_count")
+                            trace["last_decision"] = (
+                                "stop_after_product_mode_official_success_observed_without_feedback"
+                            )
+                            return None
                         _record_product_mode_declared_done_below_passing_reward(
                             trace,
                             agent_round=round,
-                            reward=float(reward),
+                            reward=(
+                                float(reward)
+                                if isinstance(reward, (int, float))
+                                and not isinstance(reward, bool)
+                                else None
+                            ),
                         )
                         _inc_counter(trace, "controller_action_decisions")
                         if round >= max_rounds:

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -5885,7 +5885,9 @@ def _build_product_mode_user(
                 "solving narrative, or final answer, your first agent action "
                 "must be a task-facing shell/tool call through the available "
                 "sandbox bridge, using an `operation=exec` request with "
-                "`cwd=/app`; a minimal valid first command is `pwd && ls -la`. "
+                "`cwd=/app`; if the bridge packet includes `FIRST ACTION "
+                "REQUIRED`, copy and run that exact command. A minimal valid "
+                "first command is `pwd && ls -la`. "
                 "After meaningful local task evidence or validation, update "
                 "the todo through LoopX CLI. Only after task-facing work "
                 "indicates the benchmark task is complete may you use "
@@ -6319,8 +6321,10 @@ def _build_product_mode_user(
                             "prompt. Do not repeat setup lifecycle as your first "
                             "action. Make the first agent action a task-facing "
                             "sandbox bridge exec from `/app`, such as "
-                            "`pwd && ls -la`, before any prose planning, solving "
-                            "narrative, or final answer. "
+                            "`pwd && ls -la`, by copying and running the bridge "
+                            "packet's `FIRST ACTION REQUIRED` command before "
+                            "any prose planning, solving narrative, or final "
+                            "answer. "
                             if workflow_lifecycle_driver
                             else
                             "first run the case-local quota/todo commands above "

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -6195,10 +6195,11 @@ def _build_product_mode_user(
                     trace["persistent_constraint_protected_paths"] = protected_paths
                 if treatment:
                     prefix = "LoopX product-mode treatment round 1. "
-                    self._task_instruction_sent = False
+                    self._task_instruction_sent = True
                     trace[
                         "product_mode_task_instruction_deferred_until_agent_lifecycle"
-                    ] = True
+                    ] = False
+                    trace["product_mode_task_instruction_sent_initially"] = True
                     trace["case_goal_state_packet_present"] = True
                     control_clause = (
                         "Use LoopX as your product control plane: create "
@@ -6218,14 +6219,15 @@ def _build_product_mode_user(
                         "For this treatment, LoopX lifecycle evidence is a "
                         "hard product-mode requirement: first run the "
                         "case-local quota/todo commands above through the solver "
-                        "bridge. The benchmark task instruction is intentionally "
-                        "withheld until that solver-side lifecycle checkpoint is "
-                        "observed, so do not inspect, infer, plan, solve, or answer "
-                        "the task yet. Do not run case closeout or declare done "
-                        "during this setup checkpoint. The controller will send the "
-                        "task packet after solver-side LoopX read/write evidence is "
-                        "recorded, without exposing official reward or verifier "
-                        "output."
+                        "bridge before any task inspection, planning, solving, or "
+                        "final answer. The benchmark task instruction is visible "
+                        "in this first round so the task semantics stay aligned "
+                        "with the baseline, but task-facing work must wait until "
+                        "after the solver-side LoopX read/write checkpoint. Do "
+                        "not run case closeout or declare done during this setup "
+                        "checkpoint.\n\n"
+                        "--- TASK INSTRUCTION ---\n"
+                        f"{instruction}"
                     )
                 else:
                     prefix = "Raw Codex autonomous max5 baseline round 1. "

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -83,6 +83,7 @@ from loopx.benchmark_case_state import (  # noqa: E402
     BENCHMARK_CASE_LOOPX_RUNTIME_ROOT,
     BENCHMARK_CASE_LOOPX_SOURCE_MOUNT_TARGET,
     BENCHMARK_CASE_LOOPX_ORCHESTRATED_EXECUTION_STYLE,
+    BENCHMARK_CASE_LOOPX_PROMPT_DRIVEN_EXECUTION_STYLE,
     BENCHMARK_CASE_LOOPX_TODO_ID,
     benchmark_case_loopx_command_prefix,
     benchmark_case_loopx_install_payload,
@@ -3796,6 +3797,16 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
             "host_local_acp_launch_status": (
                 "pending" if args.host_local_acp_launch else "not_requested"
             ),
+            "loopx_workflow_lifecycle_checkpoint": bool(
+                args.route == "loopx-product-mode" and args.host_local_acp_launch
+            ),
+            "loopx_product_mode_lifecycle_driver_kind": (
+                BENCHMARK_CASE_LOOPX_ORCHESTRATED_EXECUTION_STYLE
+                if args.route == "loopx-product-mode" and args.host_local_acp_launch
+                else BENCHMARK_CASE_LOOPX_PROMPT_DRIVEN_EXECUTION_STYLE
+                if args.route == "loopx-product-mode"
+                else "not_applicable"
+            ),
             "host_local_acp_codex_exec_preflight_requested": bool(
                 args.host_local_acp_codex_exec_preflight
             ),
@@ -5840,8 +5851,50 @@ def _build_product_mode_user(
         case_registry_path=str(payload.get("case_registry_path") or "/app/.loopx/registry.json"),
         case_runtime_root=str(payload.get("case_runtime_root") or "/app/.loopx/runtime"),
     )
+    plan_prerequisites = (
+        (plan or {}).get("runner_prerequisites")
+        if isinstance(plan, dict)
+        else None
+    )
+    if not isinstance(plan_prerequisites, dict):
+        plan_prerequisites = {}
+    workflow_lifecycle_driver = bool(
+        treatment
+        and payload.get("canonical_product_mode_lifecycle_driver") is True
+        and (
+            plan_prerequisites.get("loopx_workflow_lifecycle_checkpoint") is True
+            or plan_prerequisites.get("loopx_product_mode_lifecycle_driver_kind")
+            == BENCHMARK_CASE_LOOPX_ORCHESTRATED_EXECUTION_STYLE
+        )
+    )
 
     def treatment_state_contract() -> str:
+        if workflow_lifecycle_driver:
+            return (
+                "LoopX product-mode lifecycle contract: official case-local "
+                f"LoopX is initialized before the agent starts. Active state: "
+                f"`{case_state_path}`. This is the only formal treatment "
+                "lifecycle; runner polling is only the outer transport. The "
+                "canonical workflow lifecycle driver has already executed the "
+                "case-local `quota should-run`, `todo claim`, `todo update`, "
+                "and `refresh-state` checkpoint through the sandbox bridge "
+                "before this prompt. Do not repeat that setup checkpoint as "
+                "your first action. The benchmark task remains the primary "
+                "objective; LoopX commands track control-plane state and do "
+                "not themselves complete the task. Before prose planning, "
+                "solving narrative, or final answer, your first agent action "
+                "must be a task-facing shell/tool call through the available "
+                "sandbox bridge, using an `operation=exec` request with "
+                "`cwd=/app`; a minimal valid first command is `pwd && ls -la`. "
+                "After meaningful local task evidence or validation, update "
+                "the todo through LoopX CLI. Only after task-facing work "
+                "indicates the benchmark task is complete may you use "
+                "`todo complete`, then `refresh-state`, then "
+                "`quota spend-slot --source adapter --execute` with this case "
+                "goal and agent id. Do not run closeout as a setup step. Do "
+                "not rely on only reading or editing the Markdown state file, "
+                "and do not write a separate marker as the source of truth. "
+            )
         return (
             "LoopX product-mode lifecycle contract: official case-local "
             f"LoopX is initialized before the agent starts. Active state: "
@@ -5961,6 +6014,25 @@ def _build_product_mode_user(
             "has been recorded."
         )
 
+    def product_mode_workflow_entry_activity_satisfied() -> bool:
+        return bool(
+            workflow_lifecycle_driver
+            and _product_mode_depth_gate_satisfied(trace)
+            and _trace_max_int(
+                trace,
+                "remote_command_file_bridge_agent_request_count",
+                "remote_command_file_bridge_agent_operation_trace_count",
+                "remote_command_file_bridge_agent_task_facing_operation_count",
+            )
+            > 0
+        )
+
+    def product_mode_entry_lifecycle_gate_satisfied() -> bool:
+        return bool(
+            _product_mode_agent_lifecycle_gate_satisfied(trace)
+            or product_mode_workflow_entry_activity_satisfied()
+        )
+
     class ProductModeUser(BaseUser):
         """Main-table autonomous product-mode controller."""
 
@@ -6046,9 +6118,18 @@ def _build_product_mode_user(
                         )
                         == "agent_operation_trace_present_no_requests"
                     )
+                    workflow_entry_activity_satisfied = (
+                        product_mode_workflow_entry_activity_satisfied()
+                    )
+                    lifecycle_entry_satisfied = (
+                        product_mode_entry_lifecycle_gate_satisfied()
+                    )
                     if (
-                        (no_tool_calls or no_lifecycle_requests)
-                        and not _product_mode_agent_lifecycle_gate_satisfied(trace)
+                        (
+                            (no_tool_calls and not workflow_entry_activity_satisfied)
+                            or no_lifecycle_requests
+                        )
+                        and not lifecycle_entry_satisfied
                     ):
                         _record_product_mode_lifecycle_checkpoint_gap(
                             trace,
@@ -6230,15 +6311,26 @@ def _build_product_mode_user(
                         "--- LOOPX PRODUCT-MODE CONTROL PLANE ---\n"
                         f"{control_clause}"
                         "For this treatment, LoopX lifecycle evidence is a "
-                        "hard product-mode requirement: first run the "
-                        "case-local quota/todo commands above through the solver "
-                        "bridge before any task inspection, planning, solving, or "
-                        "final answer. The benchmark task instruction is visible "
-                        "in this first round so the task semantics stay aligned "
-                        "with the baseline, but task-facing work must wait until "
-                        "after the solver-side LoopX read/write checkpoint. Do "
-                        "not run case closeout or declare done during this setup "
-                        "checkpoint.\n\n"
+                        "hard product-mode requirement: "
+                        + (
+                            "the canonical workflow lifecycle driver has already "
+                            "completed the case-local quota/todo/update/refresh "
+                            "checkpoint through the solver bridge before this "
+                            "prompt. Do not repeat setup lifecycle as your first "
+                            "action. Make the first agent action a task-facing "
+                            "sandbox bridge exec from `/app`, such as "
+                            "`pwd && ls -la`, before any prose planning, solving "
+                            "narrative, or final answer. "
+                            if workflow_lifecycle_driver
+                            else
+                            "first run the case-local quota/todo commands above "
+                            "through the solver bridge before any task inspection, "
+                            "planning, solving, or final answer. "
+                        )
+                        + "The benchmark task instruction is visible in this "
+                        "first round so the task semantics stay aligned with the "
+                        "baseline. Do not run case closeout or declare done "
+                        "during this setup checkpoint.\n\n"
                         "--- TASK INSTRUCTION ---\n"
                         f"{instruction}"
                     )
@@ -6281,7 +6373,7 @@ def _build_product_mode_user(
             _inc_counter(trace, "followup_prompt_count")
             if treatment:
                 _merge_acp_trajectory_summary(plan or {}, trace)
-                if not _product_mode_agent_lifecycle_gate_satisfied(trace):
+                if not product_mode_entry_lifecycle_gate_satisfied():
                     _record_product_mode_lifecycle_checkpoint_gap(
                         trace,
                         agent_round=round,

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -855,6 +855,21 @@ def _effective_local_codex_exec_timeout_sec(args: argparse.Namespace) -> int:
     return configured
 
 
+HOST_LOCAL_ACP_AGENT_TIMEOUT_MARGIN_SEC = 60
+
+
+def _effective_benchflow_agent_timeout_sec(args: argparse.Namespace) -> int:
+    requested = max(0, int(getattr(args, "agent_idle_timeout", 0) or 0))
+    if bool(getattr(args, "host_local_acp_launch", False)):
+        local_exec_timeout = _effective_local_codex_exec_timeout_sec(args)
+        if local_exec_timeout > 0:
+            requested = max(
+                requested,
+                local_exec_timeout + HOST_LOCAL_ACP_AGENT_TIMEOUT_MARGIN_SEC,
+            )
+    return requested
+
+
 def _effective_local_codex_bridge_idle_timeout_sec(args: argparse.Namespace) -> int:
     configured = getattr(args, "local_codex_bridge_idle_timeout_sec", None)
     if configured is not None:
@@ -1498,8 +1513,11 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
             compact[field] = value[field]
     for field in (
         "codex_acp_runtime_launch_preflight_rc",
+        "benchflow_agent_timeout_requested_sec",
         "benchflow_agent_timeout_original_sec",
         "benchflow_agent_timeout_effective_sec",
+        "benchflow_agent_timeout_host_local_acp_exec_timeout_sec",
+        "benchflow_agent_timeout_host_local_acp_margin_sec",
         "benchflow_user_loop_recovery_round",
         "benchflow_user_loop_recovery_delta_events",
         "benchflow_user_loop_recovery_delta_tool_calls",
@@ -7030,7 +7048,15 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
         prerequisites["benchflow_agent_install_started"] = True
         prerequisites["benchflow_run_stage"] = "agent_install_started"
         original_timeout = getattr(self, "_timeout", None)
-        requested_timeout = max(0, int(args.agent_idle_timeout or 0))
+        requested_timeout = _effective_benchflow_agent_timeout_sec(args)
+        prerequisites["benchflow_agent_timeout_requested_sec"] = requested_timeout
+        if args.host_local_acp_launch:
+            prerequisites["benchflow_agent_timeout_host_local_acp_exec_timeout_sec"] = (
+                _effective_local_codex_exec_timeout_sec(args)
+            )
+            prerequisites["benchflow_agent_timeout_host_local_acp_margin_sec"] = (
+                HOST_LOCAL_ACP_AGENT_TIMEOUT_MARGIN_SEC
+            )
         if (
             isinstance(original_timeout, int)
             and not isinstance(original_timeout, bool)

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -729,6 +729,13 @@ def _host_local_acp_launch_command(
             args.local_codex_sandbox,
             "--timeout-sec",
             str(_effective_local_codex_exec_timeout_sec(args)),
+            "--first-action-timeout-sec",
+            str(
+                max(
+                    0,
+                    int(getattr(args, "local_codex_first_action_timeout_sec", 0) or 0),
+                )
+            ),
         ]
     )
     if args.host_local_acp_launch and args.route != "codex-app-server-goal-baseline":
@@ -1183,6 +1190,7 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "benchflow_intermediate_soft_verify_policy",
         "benchflow_intermediate_soft_verify_timeout_stage",
         "benchflow_intermediate_soft_verify_timeout_cleanup_status",
+        "benchflow_intermediate_soft_verify_orphan_cleanup_status",
         "benchflow_setup_stall_cleanup_status",
         "remote_command_file_bridge_consumption_status",
         "remote_command_file_bridge_agent_operation_trace_status",
@@ -1266,6 +1274,8 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "benchflow_intermediate_soft_verify_timeout_raw_output_recorded",
         "benchflow_intermediate_soft_verify_timeout_cleanup_requested",
         "benchflow_intermediate_soft_verify_timeout_cleanup_raw_logs_read",
+        "benchflow_intermediate_soft_verify_orphan_cleanup_requested",
+        "benchflow_intermediate_soft_verify_orphan_cleanup_raw_logs_read",
         "benchflow_verifier_prep_timeout_override_enabled",
         "benchflow_verifier_prep_timeout_raw_command_recorded",
         "benchflow_final_verifier_timeout_enabled",
@@ -1304,6 +1314,11 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "benchflow_intermediate_soft_verify_timeout_cleanup_term_sent_count",
         "benchflow_intermediate_soft_verify_timeout_cleanup_kill_sent_count",
         "benchflow_intermediate_soft_verify_timeout_cleanup_alive_after_count",
+        "benchflow_intermediate_soft_verify_orphan_cleanup_container_count",
+        "benchflow_intermediate_soft_verify_orphan_cleanup_match_count",
+        "benchflow_intermediate_soft_verify_orphan_cleanup_term_sent_count",
+        "benchflow_intermediate_soft_verify_orphan_cleanup_kill_sent_count",
+        "benchflow_intermediate_soft_verify_orphan_cleanup_alive_after_count",
         "benchflow_verifier_prep_timeout_sec",
         "benchflow_final_verifier_timeout_sec",
         "benchflow_final_verifier_timeout_override_count",
@@ -1539,12 +1554,14 @@ def cleanup_benchflow_soft_verify_timeout_children(
     *,
     trace: dict[str, Any] | None = None,
     grace_seconds: float = 3.0,
+    metric_prefix: str = "benchflow_intermediate_soft_verify_timeout_cleanup",
+    schema_version: str = "skillsbench_soft_verify_timeout_process_cleanup_v0",
 ) -> dict[str, Any]:
     """Terminate verifier process trees left behind by an intermediate timeout."""
 
     prerequisites = plan.setdefault("runner_prerequisites", {})
     cleanup: dict[str, Any] = {
-        "schema_version": "skillsbench_soft_verify_timeout_process_cleanup_v0",
+        "schema_version": schema_version,
         "requested": True,
         "raw_logs_read": False,
         "raw_command_recorded": False,
@@ -1557,46 +1574,23 @@ def cleanup_benchflow_soft_verify_timeout_children(
     }
 
     def publish() -> dict[str, Any]:
-        prerequisites[
-            "benchflow_intermediate_soft_verify_timeout_cleanup_requested"
-        ] = True
-        prerequisites[
-            "benchflow_intermediate_soft_verify_timeout_cleanup_raw_logs_read"
-        ] = False
-        prerequisites[
-            "benchflow_intermediate_soft_verify_timeout_cleanup_status"
-        ] = str(cleanup.get("status") or "unknown")
+        prerequisites[f"{metric_prefix}_requested"] = True
+        prerequisites[f"{metric_prefix}_raw_logs_read"] = False
+        prerequisites[f"{metric_prefix}_status"] = str(
+            cleanup.get("status") or "unknown"
+        )
         if isinstance(trace, dict):
-            trace[
-                "benchflow_intermediate_soft_verify_timeout_cleanup_requested"
-            ] = True
-            trace[
-                "benchflow_intermediate_soft_verify_timeout_cleanup_raw_logs_read"
-            ] = False
-            trace[
-                "benchflow_intermediate_soft_verify_timeout_cleanup_status"
-            ] = str(cleanup.get("status") or "unknown")
+            trace[f"{metric_prefix}_requested"] = True
+            trace[f"{metric_prefix}_raw_logs_read"] = False
+            trace[f"{metric_prefix}_status"] = str(
+                cleanup.get("status") or "unknown"
+            )
         for source, target in (
-            (
-                "container_count",
-                "benchflow_intermediate_soft_verify_timeout_cleanup_container_count",
-            ),
-            (
-                "match_count",
-                "benchflow_intermediate_soft_verify_timeout_cleanup_match_count",
-            ),
-            (
-                "term_sent_count",
-                "benchflow_intermediate_soft_verify_timeout_cleanup_term_sent_count",
-            ),
-            (
-                "kill_sent_count",
-                "benchflow_intermediate_soft_verify_timeout_cleanup_kill_sent_count",
-            ),
-            (
-                "alive_after_count",
-                "benchflow_intermediate_soft_verify_timeout_cleanup_alive_after_count",
-            ),
+            ("container_count", f"{metric_prefix}_container_count"),
+            ("match_count", f"{metric_prefix}_match_count"),
+            ("term_sent_count", f"{metric_prefix}_term_sent_count"),
+            ("kill_sent_count", f"{metric_prefix}_kill_sent_count"),
+            ("alive_after_count", f"{metric_prefix}_alive_after_count"),
         ):
             value = cleanup.get(source)
             if isinstance(value, int):
@@ -1867,11 +1861,40 @@ def install_benchflow_verifier_prep_timeout_override(
                     soft_timeout_override_count += 1
             return await original_exec(*args, **kwargs)
 
+        phase_timeout_sec = 0
+        if phase == "verify" and final_timeout_enabled:
+            phase_timeout_sec = final_verifier_timeout_sec
+        elif phase == "soft_verify" and soft_timeout_enabled:
+            phase_timeout_sec = soft_verifier_timeout_sec
+
         try:
             env.exec = exec_with_verifier_prep_timeout
-            return await original(self)
+            if phase_timeout_sec > 0:
+                result = await asyncio.wait_for(
+                    original(self),
+                    timeout=phase_timeout_sec,
+                )
+            else:
+                result = await original(self)
+            if phase == "soft_verify" and soft_timeout_enabled:
+                cleanup_benchflow_soft_verify_timeout_children(
+                    plan,
+                    trace=trace,
+                    metric_prefix=(
+                        "benchflow_intermediate_soft_verify_orphan_cleanup"
+                    ),
+                    schema_version=(
+                        "skillsbench_soft_verify_orphan_process_cleanup_v0"
+                    ),
+                )
+            return result
         except Exception as exc:
-            if final_timeout_override_count and _runner_exception_indicates_timeout(exc):
+            timeout_exc = _runner_exception_indicates_timeout(exc)
+            if (
+                phase == "verify"
+                and final_timeout_enabled
+                and timeout_exc
+            ):
                 prerequisites["benchflow_final_verifier_timeout_triggered"] = True
                 prerequisites["benchflow_final_verifier_timeout_raw_output_recorded"] = (
                     False
@@ -1881,7 +1904,11 @@ def install_benchflow_verifier_prep_timeout_override(
                     trace["benchflow_final_verifier_timeout_raw_output_recorded"] = (
                         False
                     )
-            if soft_timeout_override_count and _runner_exception_indicates_timeout(exc):
+            if (
+                phase == "soft_verify"
+                and soft_timeout_enabled
+                and timeout_exc
+            ):
                 prerequisites[
                     "benchflow_intermediate_soft_verify_timeout_triggered"
                 ] = True
@@ -2452,6 +2479,8 @@ def _agent_lifecycle_observed_for_setup_stall(plan: dict[str, Any]) -> bool:
 
 
 def _runner_exception_indicates_timeout(exc: BaseException) -> bool:
+    if isinstance(exc, (TimeoutError, asyncio.TimeoutError)):
+        return True
     text = f"{type(exc).__name__} {exc}".lower()
     return "timeout" in text or "timed out" in text
 
@@ -5011,6 +5040,24 @@ def _record_declared_done(
         trace["declared_done_score"] = reward
 
 
+def _record_product_mode_declared_done_below_passing_reward(
+    trace: dict[str, Any],
+    *,
+    agent_round: int,
+    reward: float,
+) -> None:
+    trace["product_mode_declared_done_below_passing_reward"] = True
+    trace["product_mode_declared_done_below_passing_reward_round"] = agent_round
+    trace["product_mode_declared_done_below_passing_reward_score"] = reward
+    trace["product_mode_declared_done_policy"] = (
+        "continue_until_official_success_or_budget"
+    )
+    current = trace.get("product_mode_declared_done_below_passing_reward_count")
+    if not isinstance(current, int) or isinstance(current, bool):
+        current = 0
+    trace["product_mode_declared_done_below_passing_reward_count"] = current + 1
+
+
 def _product_mode_depth_gate_satisfied(trace: dict[str, Any]) -> bool:
     def count(*fields: str) -> int:
         values = [
@@ -5551,8 +5598,11 @@ def _build_product_mode_user(
             "LoopX product-mode lifecycle contract: official case-local "
             f"LoopX is initialized before the agent starts. Active state: "
             f"`{case_state_path}`. This is the only formal treatment "
-            "lifecycle; runner polling is only the outer transport. Before "
-            "planning, run the following commands inside the scored sandbox. "
+            "lifecycle; runner polling is only the outer transport. The "
+            "benchmark task remains the primary objective; LoopX commands track "
+            "control-plane state and do not themselves complete the task. As "
+            "the first control-plane action, run the following commands inside "
+            "the scored sandbox, then continue solving and validating the task. "
             "If a LoopX SkillsBench remote workspace bridge packet is present, "
             "invoke that private JSON bridge from your shell tool and send each "
             "command as an `operation=exec` request with `cwd=/app`; do not try "
@@ -5561,12 +5611,14 @@ def _build_product_mode_user(
             f"--agent-id {case_agent_id}` and claim the selected case todo "
             f"with `{case_cli_prefix} todo claim --goal-id {case_goal_id} "
             f"--todo-id {case_todo_id} --claimed-by {case_agent_id}`. "
-            "After meaningful local evidence or validation, update the todo "
-            "through LoopX CLI; when complete, use `todo complete`, then "
+            "After meaningful local task evidence or validation, update the "
+            "todo through LoopX CLI. Only after task-facing work indicates the "
+            "benchmark task is complete may you use `todo complete`, then "
             "`refresh-state`, then `quota spend-slot --source adapter "
-            "--execute` with this case goal and agent id. Do not rely on only "
-            "reading or editing the Markdown state file, and do not write a "
-            "separate marker as the source of truth. "
+            "--execute` with this case goal and agent id. Do not run closeout "
+            "as a setup step. Do not rely on only reading or editing the "
+            "Markdown state file, and do not write a separate marker as the "
+            "source of truth. "
         )
 
     def lifecycle_checkpoint_commands(round_number: int) -> str:
@@ -5662,6 +5714,43 @@ def _build_product_mode_user(
         def __init__(self) -> None:
             super().__init__()
             self._persistent_constraint_clause = ""
+
+        def _scheduled_continuation_prompt(
+            self,
+            *,
+            scheduled_round: int,
+            declared_done_continuation: bool = False,
+        ) -> str:
+            if treatment:
+                mode_clause = (
+                    "Continue from your LoopX case state at "
+                    f"`{case_state_path}` and todo/replan ledger; "
+                    "re-read and update them if local evidence changed."
+                )
+            else:
+                mode_clause = (
+                    "Continue from your own local plan/todo notes; do not use "
+                    "LoopX CLI/state/ledger."
+                )
+            done_clause = (
+                "A previous response included the done marker, but this "
+                "protocol uses success-or-budget stopping; keep using the "
+                "remaining fixed budget for local inspection, implementation, "
+                "and validation. "
+                if declared_done_continuation
+                else ""
+            )
+            return (
+                f"Scheduled product-mode continuation round {scheduled_round} of "
+                f"{max_rounds}. This is part of the fixed autonomous budget and "
+                "is not evidence that the official verifier passed or failed. "
+                "You are not being shown official reward, pass/fail status, "
+                "verifier error, or verifier output. "
+                f"{done_clause}"
+                f"{self._persistent_constraint_clause} {mode_clause} Keep scope "
+                "narrow, validate locally, and if there are no remaining goals, "
+                f"end with {DECLARED_DONE_MARKER}."
+            )
 
         async def run(
             self,
@@ -5769,6 +5858,39 @@ def _build_product_mode_user(
                                 "send_product_mode_solver_activity_continuation"
                             )
                             return solver_activity_prompt(round + 1)
+                    if (
+                        treatment
+                        and isinstance(reward, (int, float))
+                        and not isinstance(reward, bool)
+                        and reward < 1.0
+                    ):
+                        _record_declared_done(
+                            trace,
+                            agent_round=round,
+                            reward=reward,
+                        )
+                        _record_product_mode_declared_done_below_passing_reward(
+                            trace,
+                            agent_round=round,
+                            reward=float(reward),
+                        )
+                        _inc_counter(trace, "controller_action_decisions")
+                        if round >= max_rounds:
+                            _inc_counter(trace, "stop_decision_count")
+                            trace["last_decision"] = (
+                                "stop_after_product_mode_budget_with_"
+                                "declared_done_below_passing_reward"
+                            )
+                            return None
+                        _inc_counter(trace, "followup_prompt_count")
+                        trace["last_decision"] = (
+                            "send_product_mode_success_or_budget_"
+                            "continuation_after_declared_done"
+                        )
+                        return self._scheduled_continuation_prompt(
+                            scheduled_round=round + 1,
+                            declared_done_continuation=True,
+                        )
                     _inc_counter(trace, "controller_action_decisions")
                     _inc_counter(trace, "stop_decision_count")
                     _record_declared_done(trace, agent_round=round, reward=reward)
@@ -5817,18 +5939,6 @@ def _build_product_mode_user(
                 return (
                     prefix
                     + "You are running inside the official SkillsBench sandbox. "
-                    + control_clause
-                    + (
-                        "For this treatment, LoopX lifecycle evidence is a "
-                        "hard product-mode requirement: first run the "
-                        "case-local quota/todo commands above before "
-                        "substantive task work. When task work validates "
-                        "complete, run this exact case-local closeout sequence "
-                        "from `/app` before declaring done:\n\n"
-                        f"{closeout_commands(1)}"
-                        if treatment
-                        else ""
-                    )
                     + "No official reward, pass/fail status, verifier error, "
                     "verifier output, or verifier tail will be shown during this "
                     "run. If you believe the task is complete and there are no "
@@ -5836,6 +5946,21 @@ def _build_product_mode_user(
                     f"{DECLARED_DONE_MARKER}.\n\n"
                     "--- TASK INSTRUCTION ---\n"
                     f"{instruction}"
+                    + (
+                        "\n\n--- LOOPX PRODUCT-MODE CONTROL PLANE ---\n"
+                        f"{control_clause}"
+                        "For this treatment, LoopX lifecycle evidence is a "
+                        "hard product-mode requirement: first run the "
+                        "case-local quota/todo commands above, then solve and "
+                        "validate the benchmark task. Do not run case closeout "
+                        "or declare done until after meaningful task-facing work "
+                        "or local validation. If you later declare done without "
+                        "task-facing closeout evidence, the controller will ask "
+                        "for the exact closeout sequence without exposing "
+                        "official reward or verifier output."
+                        if treatment
+                        else "\n\n" + control_clause
+                    )
                 )
 
             _inc_counter(trace, "controller_action_decisions")
@@ -5852,27 +5977,7 @@ def _build_product_mode_user(
                     )
                     return lifecycle_checkpoint_prompt(round + 1)
             trace["last_decision"] = "send_product_mode_scheduled_continuation"
-            if treatment:
-                mode_clause = (
-                    "Continue from your LoopX case state at "
-                    f"`{case_state_path}` and todo/replan ledger; "
-                    "re-read and update them if local evidence changed."
-                )
-            else:
-                mode_clause = (
-                    "Continue from your own local plan/todo notes; do not use "
-                    "LoopX CLI/state/ledger."
-                )
-            return (
-                f"Scheduled product-mode continuation round {round + 1} of "
-                f"{max_rounds}. This is part of the fixed autonomous budget and "
-                "is not evidence that the official verifier passed or failed. "
-                "You are not being shown official reward, pass/fail status, "
-                "verifier error, or verifier output."
-                f"{self._persistent_constraint_clause} {mode_clause} Keep scope "
-                "narrow, validate locally, and if there are no remaining goals, "
-                f"end with {DECLARED_DONE_MARKER}."
-            )
+            return self._scheduled_continuation_prompt(scheduled_round=round + 1)
 
     return ProductModeUser()
 
@@ -7443,6 +7548,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         type=int,
         default=DEFAULT_TIMEOUT_SEC,
         help="Per-prompt timeout for local Codex exec in host-local ACP launch mode.",
+    )
+    parser.add_argument(
+        "--local-codex-first-action-timeout-sec",
+        type=int,
+        default=0,
+        help=(
+            "Optional watchdog for the first sandbox bridge operation from a "
+            "host-local Codex turn. 0 disables the watchdog."
+        ),
     )
     parser.add_argument(
         "--local-codex-ping-timeout-sec",

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -856,12 +856,9 @@ def _effective_local_codex_exec_timeout_sec(args: argparse.Namespace) -> int:
 
 
 def _effective_local_codex_bridge_idle_timeout_sec(args: argparse.Namespace) -> int:
-    configured = max(
-        0,
-        int(getattr(args, "local_codex_bridge_idle_timeout_sec", 0) or 0),
-    )
-    if configured > 0:
-        return configured
+    configured = getattr(args, "local_codex_bridge_idle_timeout_sec", None)
+    if configured is not None:
+        return max(0, int(configured or 0))
     return max(0, int(getattr(args, "agent_idle_timeout", 0) or 0))
 
 
@@ -8005,10 +8002,11 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument(
         "--local-codex-bridge-idle-timeout-sec",
         type=int,
-        default=0,
+        default=None,
         help=(
             "Optional watchdog after the most recent sandbox bridge operation "
-            "from a host-local Codex turn. 0 disables the watchdog."
+            "from a host-local Codex turn. Omit to inherit --agent-idle-timeout; "
+            "0 disables the watchdog."
         ),
     )
     parser.add_argument(

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -736,6 +736,8 @@ def _host_local_acp_launch_command(
                     int(getattr(args, "local_codex_first_action_timeout_sec", 0) or 0),
                 )
             ),
+            "--bridge-idle-timeout-sec",
+            str(_effective_local_codex_bridge_idle_timeout_sec(args)),
         ]
     )
     if args.host_local_acp_launch and args.route != "codex-app-server-goal-baseline":
@@ -847,6 +849,16 @@ def _effective_local_codex_exec_timeout_sec(args: argparse.Namespace) -> int:
     if configured == DEFAULT_TIMEOUT_SEC and idle_timeout > 0:
         return min(configured, idle_timeout)
     return configured
+
+
+def _effective_local_codex_bridge_idle_timeout_sec(args: argparse.Namespace) -> int:
+    configured = max(
+        0,
+        int(getattr(args, "local_codex_bridge_idle_timeout_sec", 0) or 0),
+    )
+    if configured > 0:
+        return configured
+    return max(0, int(getattr(args, "agent_idle_timeout", 0) or 0))
 
 
 def _host_local_acp_target_env(agent_env: object) -> dict[str, str]:
@@ -7556,6 +7568,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help=(
             "Optional watchdog for the first sandbox bridge operation from a "
             "host-local Codex turn. 0 disables the watchdog."
+        ),
+    )
+    parser.add_argument(
+        "--local-codex-bridge-idle-timeout-sec",
+        type=int,
+        default=0,
+        help=(
+            "Optional watchdog after the most recent sandbox bridge operation "
+            "from a host-local Codex turn. 0 disables the watchdog."
         ),
     )
     parser.add_argument(

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -4946,12 +4946,16 @@ def _merge_host_local_acp_relay_trace_summary(
     codex_exec_failure_categories: list[str] = []
     agent_bridge_trace_count = 0
     agent_bridge_request_count = 0
+    agent_bridge_success_count = 0
+    agent_bridge_failure_count = 0
     agent_bridge_loopx_cli_call_count = 0
     agent_bridge_loopx_state_read_count = 0
     agent_bridge_loopx_state_write_count = 0
     agent_bridge_task_facing_operation_count = 0
     agent_bridge_operation_counts: dict[str, int] = {}
     agent_bridge_loopx_subcommand_counts: dict[str, int] = {}
+    agent_bridge_successful_loopx_subcommand_counts: dict[str, int] = {}
+    agent_bridge_returncode_counts: dict[str, int] = {}
     driver_lifecycle_trace_count = 0
     driver_lifecycle_checkpoint_count = 0
     driver_lifecycle_request_count = 0
@@ -5025,6 +5029,8 @@ def _merge_host_local_acp_relay_trace_summary(
             )
             count_fields = {
                 "request_count": "request",
+                "success_count": "success",
+                "failure_count": "failure",
                 "loopx_cli_call_count": "loopx_cli",
                 "loopx_state_read_count": "state_read",
                 "loopx_state_write_count": "state_write",
@@ -5037,6 +5043,10 @@ def _merge_host_local_acp_relay_trace_summary(
                 value = max(0, value)
                 if target == "request":
                     agent_bridge_request_count += value
+                elif target == "success":
+                    agent_bridge_success_count += value
+                elif target == "failure":
+                    agent_bridge_failure_count += value
                 elif target == "loopx_cli":
                     agent_bridge_loopx_cli_call_count += value
                 elif target == "state_read":
@@ -5048,6 +5058,11 @@ def _merge_host_local_acp_relay_trace_summary(
             for source_key, target_counts in (
                 ("operation_counts", agent_bridge_operation_counts),
                 ("loopx_cli_subcommand_counts", agent_bridge_loopx_subcommand_counts),
+                (
+                    "successful_loopx_cli_subcommand_counts",
+                    agent_bridge_successful_loopx_subcommand_counts,
+                ),
+                ("returncode_counts", agent_bridge_returncode_counts),
             ):
                 source_counts = agent_ops.get(source_key)
                 if not isinstance(source_counts, dict):
@@ -5217,6 +5232,12 @@ def _merge_host_local_acp_relay_trace_summary(
     trace["remote_command_file_bridge_agent_request_count"] = (
         agent_bridge_request_count
     )
+    trace["remote_command_file_bridge_agent_success_count"] = (
+        agent_bridge_success_count
+    )
+    trace["remote_command_file_bridge_agent_failure_count"] = (
+        agent_bridge_failure_count
+    )
     trace["remote_command_file_bridge_agent_loopx_cli_call_count"] = (
         agent_bridge_loopx_cli_call_count
     )
@@ -5235,22 +5256,28 @@ def _merge_host_local_acp_relay_trace_summary(
     trace["remote_command_file_bridge_agent_loopx_subcommand_counts"] = dict(
         sorted(agent_bridge_loopx_subcommand_counts.items())
     )
+    trace[
+        "remote_command_file_bridge_agent_successful_loopx_subcommand_counts"
+    ] = dict(sorted(agent_bridge_successful_loopx_subcommand_counts.items()))
+    trace["remote_command_file_bridge_agent_returncode_counts"] = dict(
+        sorted(agent_bridge_returncode_counts.items())
+    )
     trace["remote_command_file_bridge_agent_todo_closeout_count"] = (
         _subcommand_family_count(
-            agent_bridge_loopx_subcommand_counts,
+            agent_bridge_successful_loopx_subcommand_counts,
             "todo complete",
             "todo update",
         )
     )
     trace["remote_command_file_bridge_agent_refresh_state_count"] = (
         _subcommand_family_count(
-            agent_bridge_loopx_subcommand_counts,
+            agent_bridge_successful_loopx_subcommand_counts,
             "refresh-state",
         )
     )
     trace["remote_command_file_bridge_agent_quota_spend_slot_count"] = (
         _subcommand_family_count(
-            agent_bridge_loopx_subcommand_counts,
+            agent_bridge_successful_loopx_subcommand_counts,
             "quota spend-slot",
         )
     )
@@ -5347,6 +5374,12 @@ def _merge_host_local_acp_relay_trace_summary(
     prerequisites["remote_command_file_bridge_agent_request_count"] = (
         agent_bridge_request_count
     )
+    prerequisites["remote_command_file_bridge_agent_success_count"] = (
+        agent_bridge_success_count
+    )
+    prerequisites["remote_command_file_bridge_agent_failure_count"] = (
+        agent_bridge_failure_count
+    )
     prerequisites["remote_command_file_bridge_agent_loopx_cli_call_count"] = (
         agent_bridge_loopx_cli_call_count
     )
@@ -5364,6 +5397,12 @@ def _merge_host_local_acp_relay_trace_summary(
     )
     prerequisites["remote_command_file_bridge_agent_loopx_subcommand_counts"] = dict(
         sorted(agent_bridge_loopx_subcommand_counts.items())
+    )
+    prerequisites[
+        "remote_command_file_bridge_agent_successful_loopx_subcommand_counts"
+    ] = dict(sorted(agent_bridge_successful_loopx_subcommand_counts.items()))
+    prerequisites["remote_command_file_bridge_agent_returncode_counts"] = dict(
+        sorted(agent_bridge_returncode_counts.items())
     )
     prerequisites["remote_command_file_bridge_agent_todo_closeout_count"] = trace[
         "remote_command_file_bridge_agent_todo_closeout_count"
@@ -5587,6 +5626,71 @@ def _trajectory_text_fragments(value: Any) -> list[str]:
     return fragments
 
 
+def _trajectory_agent_output_fragments(value: Any) -> list[str]:
+    """Return text fragments authored by the agent/assistant, not the user prompt."""
+
+    fragments: list[str] = []
+
+    def role_is_agent(role: Any) -> bool:
+        return str(role or "").strip().lower() in {
+            "agent",
+            "assistant",
+            "assistant_message",
+            "model",
+            "worker",
+        }
+
+    def type_is_agent_message(event_type: Any) -> bool:
+        text = str(event_type or "").strip().lower()
+        return bool(
+            text
+            and (
+                "assistant" in text
+                or "agent_message" in text
+                or text in {"message", "final_message", "response"}
+            )
+        )
+
+    def add_text(value: Any) -> None:
+        if isinstance(value, str) and value:
+            fragments.append(value)
+        elif isinstance(value, list):
+            fragments.extend(_trajectory_text_fragments(value))
+        elif isinstance(value, dict):
+            fragments.extend(_trajectory_text_fragments(value))
+
+    def walk(node: Any) -> None:
+        if isinstance(node, dict):
+            role = node.get("role") or node.get("author") or node.get("speaker")
+            event_type = node.get("type") or node.get("event") or node.get("kind")
+            role_present = bool(str(role or "").strip())
+            if role_is_agent(role) or (
+                not role_present and type_is_agent_message(event_type)
+            ):
+                for key in (
+                    "content",
+                    "text",
+                    "message",
+                    "final_message",
+                    "response",
+                    "output",
+                ):
+                    if key in node:
+                        add_text(node.get(key))
+                return
+            if role_present:
+                return
+            for nested in node.values():
+                walk(nested)
+            return
+        if isinstance(node, list):
+            for nested in node:
+                walk(nested)
+
+    walk(value)
+    return fragments
+
+
 def _trajectory_tool_call_titles(value: Any) -> list[str]:
     titles: list[str] = []
     if isinstance(value, dict):
@@ -5657,7 +5761,10 @@ def _round_result_declared_done(round_result: Any) -> bool:
     trajectory = getattr(round_result, "trajectory", None)
     if not isinstance(trajectory, list):
         return False
-    return any(DECLARED_DONE_MARKER in text for text in _trajectory_text_fragments(trajectory))
+    return any(
+        DECLARED_DONE_MARKER in text
+        for text in _trajectory_agent_output_fragments(trajectory)
+    )
 
 
 def _record_declared_done(

--- a/scripts/skillsbench_local_acp_relay.py
+++ b/scripts/skillsbench_local_acp_relay.py
@@ -100,6 +100,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--bridge-idle-timeout-sec",
+        type=float,
+        default=0.0,
+        help=(
+            "Optional timeout after the most recent sandbox bridge operation "
+            "from a Codex turn. 0 disables the watchdog."
+        ),
+    )
+    parser.add_argument(
         "--worker-script",
         default=None,
         help="Optional path to skillsbench_host_codex_goal_worker.py.",
@@ -173,6 +182,7 @@ def main(argv: list[str] | None = None) -> int:
             worker_script=args.worker_script,
             stream_heartbeat_interval_sec=args.stream_heartbeat_interval_sec,
             first_action_timeout_sec=args.first_action_timeout_sec,
+            bridge_idle_timeout_sec=args.bridge_idle_timeout_sec,
             worker_public_trace_dir=args.worker_public_trace_dir,
             remote_command_file_bridge_command=(
                 args.remote_command_file_bridge_command

--- a/scripts/skillsbench_local_acp_relay.py
+++ b/scripts/skillsbench_local_acp_relay.py
@@ -91,6 +91,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--first-action-timeout-sec",
+        type=float,
+        default=0.0,
+        help=(
+            "Optional timeout for observing the first sandbox bridge operation "
+            "from a Codex turn. 0 disables the watchdog."
+        ),
+    )
+    parser.add_argument(
         "--worker-script",
         default=None,
         help="Optional path to skillsbench_host_codex_goal_worker.py.",
@@ -163,6 +172,7 @@ def main(argv: list[str] | None = None) -> int:
             response_timeout_sec=args.response_timeout_sec,
             worker_script=args.worker_script,
             stream_heartbeat_interval_sec=args.stream_heartbeat_interval_sec,
+            first_action_timeout_sec=args.first_action_timeout_sec,
             worker_public_trace_dir=args.worker_public_trace_dir,
             remote_command_file_bridge_command=(
                 args.remote_command_file_bridge_command

--- a/scripts/skillsbench_reverse_channel_bridge.py
+++ b/scripts/skillsbench_reverse_channel_bridge.py
@@ -18,6 +18,7 @@ import socket
 import subprocess
 import sys
 import tempfile
+import time
 from pathlib import Path
 from typing import Any
 
@@ -250,6 +251,7 @@ def _run_codex_payload(
     codex_bin: str,
     default_timeout_sec: float,
     prompt_bridge_command: str | None,
+    first_action_timeout_sec: float = 0.0,
 ) -> dict[str, Any]:
     args = [str(item) for item in payload.get("args") or []]
     if not args:
@@ -284,16 +286,52 @@ def _run_codex_payload(
             )
         cmd = [codex_bin, *args]
         try:
-            proc = subprocess.run(
+            proc = subprocess.Popen(
                 cmd,
                 stdin=subprocess.DEVNULL,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
-                timeout=timeout,
-                check=False,
                 env=env,
             )
+            deadline = time.monotonic() + timeout
+            first_action_deadline = 0.0
+            if agent_operations_summary_path and first_action_timeout_sec > 0:
+                first_action_deadline = (
+                    time.monotonic() + max(1.0, float(first_action_timeout_sec))
+                )
+            first_action_seen = not bool(first_action_deadline)
+            timeout_kind = ""
+            while proc.poll() is None:
+                now = time.monotonic()
+                if not first_action_seen and agent_operations_summary_path:
+                    try:
+                        first_action_seen = agent_operations_summary_path.stat().st_size > 0
+                    except OSError:
+                        first_action_seen = False
+                if not first_action_seen and first_action_deadline and now >= first_action_deadline:
+                    timeout_kind = "codex_exec_first_action_timeout"
+                    proc.kill()
+                    break
+                if now >= deadline:
+                    timeout_kind = "codex_exec_timeout"
+                    proc.kill()
+                    break
+                time.sleep(0.1)
+            stdout_text, stderr_text = proc.communicate()
+            if timeout_kind:
+                return {
+                    "schema_version": SERVER_RESPONSE_SCHEMA_VERSION,
+                    "exit_code": 124,
+                    "stdout": stdout_text or "",
+                    "stderr": f"{timeout_kind}\n",
+                    "last_message": "",
+                    "remote_last_message_path": remote_last_message_path,
+                    "agent_operations_jsonl": "",
+                    "agent_operations_raw_material_recorded": False,
+                    "raw_task_text_recorded": False,
+                    "credential_values_recorded": False,
+                }
             try:
                 last_message = last_message_path.read_text(encoding="utf-8")
             except OSError:
@@ -307,8 +345,8 @@ def _run_codex_payload(
             return {
                 "schema_version": SERVER_RESPONSE_SCHEMA_VERSION,
                 "exit_code": int(proc.returncode),
-                "stdout": proc.stdout or "",
-                "stderr": proc.stderr or "",
+                "stdout": stdout_text or "",
+                "stderr": stderr_text or "",
                 "last_message": last_message,
                 "remote_last_message_path": remote_last_message_path,
                 "agent_operations_jsonl": agent_operations_jsonl,
@@ -550,6 +588,7 @@ def main(argv: list[str] | None = None) -> int:
     codex_server.add_argument("--socket", required=True)
     codex_server.add_argument("--codex-bin", default="codex")
     codex_server.add_argument("--timeout-sec", type=float, default=7200.0)
+    codex_server.add_argument("--first-action-timeout-sec", type=float, default=0.0)
     codex_server.add_argument("--prompt-bridge-command")
     codex_server.add_argument("--once", action="store_true")
 
@@ -585,6 +624,7 @@ def main(argv: list[str] | None = None) -> int:
                 codex_bin=args.codex_bin,
                 default_timeout_sec=args.timeout_sec,
                 prompt_bridge_command=args.prompt_bridge_command,
+                first_action_timeout_sec=args.first_action_timeout_sec,
             ),
         )
     if args.command == "serve-json":

--- a/scripts/skillsbench_reverse_channel_bridge.py
+++ b/scripts/skillsbench_reverse_channel_bridge.py
@@ -671,7 +671,17 @@ while not data.endswith(b'\\n'):
     if not chunk:
         break
     data += chunk
-resp=json.loads(data.decode() or '{{}}')
+if not data:
+    sys.stderr.write('reverse channel response missing\\n')
+    sys.exit(125)
+try:
+    resp=json.loads(data.decode())
+except Exception:
+    sys.stderr.write('reverse channel response invalid\\n')
+    sys.exit(125)
+if not isinstance(resp, dict):
+    sys.stderr.write('reverse channel response invalid\\n')
+    sys.exit(125)
 out=resp.get('stdout')
 err=resp.get('stderr')
 if isinstance(out, str): sys.stdout.write(out)
@@ -719,7 +729,17 @@ while not data.endswith(b'\\n'):
     if not chunk:
         break
     data += chunk
-resp=json.loads(data.decode() or '{{}}')
+if not data:
+    sys.stderr.write('reverse channel response missing\\n')
+    sys.exit(125)
+try:
+    resp=json.loads(data.decode())
+except Exception:
+    sys.stderr.write('reverse channel response invalid\\n')
+    sys.exit(125)
+if not isinstance(resp, dict):
+    sys.stderr.write('reverse channel response invalid\\n')
+    sys.exit(125)
 out=resp.get('stdout')
 err=resp.get('stderr')
 if isinstance(out, str): sys.stdout.write(out)

--- a/scripts/skillsbench_reverse_channel_bridge.py
+++ b/scripts/skillsbench_reverse_channel_bridge.py
@@ -13,6 +13,7 @@ import argparse
 import json
 import os
 import re
+import signal
 import shlex
 import socket
 import subprocess
@@ -91,6 +92,35 @@ def _allowed_env_assignments(extra: object) -> str:
 
 def _bridge_command_with_payload_env(command: str, extra: object) -> str:
     return command.replace("{loopx_allowed_env}", _allowed_env_assignments(extra))
+
+
+def _stop_process_group(proc: subprocess.Popen[str], *, sig: int) -> None:
+    try:
+        os.killpg(proc.pid, sig)
+        return
+    except ProcessLookupError:
+        return
+    except OSError:
+        pass
+    try:
+        proc.send_signal(sig)
+    except ProcessLookupError:
+        return
+    except OSError:
+        if sig == signal.SIGKILL:
+            try:
+                proc.kill()
+            except OSError:
+                pass
+
+
+def _communicate_after_stop(proc: subprocess.Popen[str]) -> tuple[str, str]:
+    try:
+        stdout_text, stderr_text = proc.communicate(timeout=5)
+    except subprocess.TimeoutExpired:
+        _stop_process_group(proc, sig=signal.SIGKILL)
+        stdout_text, stderr_text = proc.communicate(timeout=5)
+    return stdout_text or "", stderr_text or ""
 
 
 def _replace_output_last_message(args: list[str], replacement: Path) -> str | None:
@@ -349,6 +379,7 @@ def _run_codex_payload(
                 stderr=subprocess.PIPE,
                 text=True,
                 env=env,
+                start_new_session=True,
             )
             if stdin_prompt is not None and proc.stdin is not None:
                 try:
@@ -359,7 +390,11 @@ def _run_codex_payload(
                     proc.stdin = None
             deadline = time.monotonic() + timeout
             first_action_deadline = 0.0
-            if agent_operations_summary_path and first_action_timeout_sec > 0:
+            if (
+                stdin_prompt is not None
+                and prompt_bridge_command
+                and first_action_timeout_sec > 0
+            ):
                 first_action_deadline = (
                     time.monotonic() + max(1.0, float(first_action_timeout_sec))
                 )
@@ -374,14 +409,17 @@ def _run_codex_payload(
                         first_action_seen = False
                 if not first_action_seen and first_action_deadline and now >= first_action_deadline:
                     timeout_kind = "codex_exec_first_action_timeout"
-                    proc.kill()
+                    _stop_process_group(proc, sig=signal.SIGTERM)
                     break
                 if now >= deadline:
                     timeout_kind = "codex_exec_timeout"
-                    proc.kill()
+                    _stop_process_group(proc, sig=signal.SIGTERM)
                     break
                 time.sleep(0.1)
-            stdout_text, stderr_text = proc.communicate()
+            if timeout_kind:
+                stdout_text, stderr_text = _communicate_after_stop(proc)
+            else:
+                stdout_text, stderr_text = proc.communicate()
             if timeout_kind:
                 return {
                     "schema_version": SERVER_RESPONSE_SCHEMA_VERSION,

--- a/scripts/skillsbench_reverse_channel_bridge.py
+++ b/scripts/skillsbench_reverse_channel_bridge.py
@@ -25,6 +25,23 @@ from typing import Any
 
 CLIENT_SCHEMA_VERSION = "skillsbench_reverse_channel_client_v0"
 SERVER_RESPONSE_SCHEMA_VERSION = "skillsbench_reverse_channel_response_v0"
+_CODEX_EXEC_OPTIONS_WITH_VALUE = {
+    "-C",
+    "--cd",
+    "--color",
+    "--config",
+    "-c",
+    "--image",
+    "-i",
+    "--model",
+    "-m",
+    "--oss",
+    "--output-last-message",
+    "--profile",
+    "-p",
+    "--sandbox",
+    "-s",
+}
 SOCKET_PROBE_SCHEMA_VERSION = "skillsbench_reverse_channel_socket_probe_v0"
 ALLOWED_PAYLOAD_ENV_KEYS = (
     "AI_ADDR",
@@ -107,6 +124,39 @@ def _rewrite_private_bridge_command(prompt: str, replacement: str | None) -> str
         return prompt
     pattern = r"(Private bridge command:\n)([^\n]+)"
     return re.sub(pattern, r"\1" + replacement, prompt, count=1)
+
+
+def _split_codex_exec_prompt_for_stdin(args: list[str]) -> tuple[list[str], str | None]:
+    """Move the positional codex exec prompt out of argv and into stdin.
+
+    Host-local benchmark prompts can contain raw task text. Passing them as a
+    process argument exposes them to process-list observers on shared hosts, so
+    the reverse bridge feeds the prompt through stdin and closes stdin
+    immediately instead.
+    """
+
+    if not args or args[0] != "exec":
+        return args, None
+    positional_indices: list[int] = []
+    index = 1
+    while index < len(args):
+        item = args[index]
+        if item == "--":
+            positional_indices.extend(range(index + 1, len(args)))
+            break
+        if item in _CODEX_EXEC_OPTIONS_WITH_VALUE:
+            index += 2
+            continue
+        if item.startswith("-"):
+            index += 1
+            continue
+        positional_indices.append(index)
+        index += 1
+    if not positional_indices:
+        return args, None
+    prompt_index = positional_indices[-1]
+    prompt = args[prompt_index]
+    return args[:prompt_index] + args[prompt_index + 1 :], prompt
 
 
 def _write_instrumented_prompt_bridge(
@@ -270,30 +320,43 @@ def _run_codex_payload(
         local_cwd.mkdir(parents=True, exist_ok=True)
         remote_last_message_path = _replace_output_last_message(args, last_message_path)
         _replace_remote_cwd(args, local_cwd)
+        args, stdin_prompt = _split_codex_exec_prompt_for_stdin(args)
+        if stdin_prompt is None:
+            payload_stdin = payload.get("stdin")
+            if isinstance(payload_stdin, str) and payload_stdin:
+                stdin_prompt = payload_stdin
         agent_operations_summary_path: Path | None = None
-        if prompt_bridge_command and args:
-            private_bridge_command = _extract_private_bridge_command(args[-1])
-            instrumented_bridge, agent_operations_summary_path = (
-                _write_instrumented_prompt_bridge(
-                    tmp_path=tmp_path,
-                    bridge_command=prompt_bridge_command,
-                    private_bridge_command=private_bridge_command,
+        if prompt_bridge_command and stdin_prompt is not None:
+            private_bridge_command = _extract_private_bridge_command(stdin_prompt)
+            if private_bridge_command:
+                instrumented_bridge, agent_operations_summary_path = (
+                    _write_instrumented_prompt_bridge(
+                        tmp_path=tmp_path,
+                        bridge_command=prompt_bridge_command,
+                        private_bridge_command=private_bridge_command,
+                    )
                 )
-            )
-            args[-1] = _rewrite_private_bridge_command(
-                args[-1],
-                str(instrumented_bridge),
-            )
+                stdin_prompt = _rewrite_private_bridge_command(
+                    stdin_prompt,
+                    str(instrumented_bridge),
+                )
         cmd = [codex_bin, *args]
         try:
             proc = subprocess.Popen(
                 cmd,
-                stdin=subprocess.DEVNULL,
+                stdin=subprocess.PIPE if stdin_prompt is not None else subprocess.DEVNULL,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
                 env=env,
             )
+            if stdin_prompt is not None and proc.stdin is not None:
+                try:
+                    proc.stdin.write(stdin_prompt)
+                    proc.stdin.close()
+                    proc.stdin = None
+                except BrokenPipeError:
+                    proc.stdin = None
             deadline = time.monotonic() + timeout
             first_action_deadline = 0.0
             if agent_operations_summary_path and first_action_timeout_sec > 0:
@@ -473,6 +536,7 @@ SOCK = {socket_path!r}
 payload = {{
     'schema_version': {CLIENT_SCHEMA_VERSION!r},
     'args': sys.argv[1:],
+    'stdin': sys.stdin.read(),
     'env': {{k: os.environ.get(k, '') for k in ('AI_ADDR','AI_PORT','GOAL_HARNESS_REMOTE_BENCH_ROOT','LOOPX_REMOTE_AGENT_OPS_SUMMARY_PATH')}},
     'timeout_sec': float(os.environ.get('LOOPX_REVERSE_CODEX_TIMEOUT_SEC', '7200')),
 }}

--- a/scripts/skillsbench_reverse_channel_bridge.py
+++ b/scripts/skillsbench_reverse_channel_bridge.py
@@ -156,6 +156,20 @@ def _rewrite_private_bridge_command(prompt: str, replacement: str | None) -> str
     return re.sub(pattern, r"\1" + replacement, prompt, count=1)
 
 
+def _prompt_requires_bridge_first_action(prompt: str) -> bool:
+    text = prompt or ""
+    if "Private bridge command:" not in text:
+        return False
+    lowered = text.lower()
+    required_markers = (
+        "loopx_skillsbench_local_acp_relay_bridge_ready",
+        "your first tool action should be a shell",
+        "your first agent action must be a shell/tool call",
+        "first run the case-local quota/todo commands",
+    )
+    return any(marker in lowered for marker in required_markers)
+
+
 def _split_codex_exec_prompt_for_stdin(args: list[str]) -> tuple[list[str], str | None]:
     """Move the positional codex exec prompt out of argv and into stdin.
 
@@ -394,6 +408,7 @@ def _run_codex_payload(
                 stdin_prompt is not None
                 and prompt_bridge_command
                 and first_action_timeout_sec > 0
+                and _prompt_requires_bridge_first_action(stdin_prompt)
             ):
                 first_action_deadline = (
                     time.monotonic() + max(1.0, float(first_action_timeout_sec))

--- a/scripts/skillsbench_reverse_channel_bridge.py
+++ b/scripts/skillsbench_reverse_channel_bridge.py
@@ -26,6 +26,9 @@ from typing import Any
 
 CLIENT_SCHEMA_VERSION = "skillsbench_reverse_channel_client_v0"
 SERVER_RESPONSE_SCHEMA_VERSION = "skillsbench_reverse_channel_response_v0"
+JSON_PREFLIGHT_RESPONSE_SCHEMA_VERSION = (
+    "skillsbench_reverse_channel_json_preflight_response_v0"
+)
 _CODEX_EXEC_OPTIONS_WITH_VALUE = {
     "-C",
     "--cd",
@@ -495,6 +498,37 @@ def _run_json_bridge_payload(
 ) -> dict[str, Any]:
     timeout = max(1.0, float(default_timeout_sec))
     stdin_text = str(payload.get("stdin") or "")
+    try:
+        request = json.loads(stdin_text or "{}")
+    except json.JSONDecodeError:
+        request = {}
+    if isinstance(request, dict) and request.get("operation") == "preflight":
+        return {
+            "schema_version": SERVER_RESPONSE_SCHEMA_VERSION,
+            "exit_code": 0,
+            "stdout": json.dumps(
+                {
+                    "schema_version": JSON_PREFLIGHT_RESPONSE_SCHEMA_VERSION,
+                    "ok": True,
+                    "operation": "preflight",
+                    "stage": "reverse_channel_json_server",
+                    "raw_stdout_recorded": False,
+                    "raw_stderr_recorded": False,
+                    "raw_task_text_recorded": False,
+                    "credential_values_recorded": False,
+                    "host_paths_recorded": False,
+                    "remote_paths_recorded": False,
+                    "upload_performed": False,
+                    "submit_performed": False,
+                },
+                sort_keys=True,
+            )
+            + "\n",
+            "stderr": "",
+            "raw_stdout_recorded": False,
+            "raw_stderr_recorded": False,
+            "credential_values_recorded": False,
+        }
     payload_env = payload.get("env")
     env = _safe_env(payload_env)
     command = _bridge_command_with_payload_env(bridge_command, payload_env)

--- a/scripts/skillsbench_reverse_channel_bridge.py
+++ b/scripts/skillsbench_reverse_channel_bridge.py
@@ -358,6 +358,7 @@ def _run_codex_payload(
     default_timeout_sec: float,
     prompt_bridge_command: str | None,
     first_action_timeout_sec: float = 0.0,
+    bridge_idle_timeout_sec: float = 0.0,
 ) -> dict[str, Any]:
     args = [str(item) for item in payload.get("args") or []]
     if not args:
@@ -426,16 +427,36 @@ def _run_codex_payload(
                     time.monotonic() + max(1.0, float(first_action_timeout_sec))
                 )
             first_action_seen = not bool(first_action_deadline)
+            bridge_idle_timeout_sec = max(0.0, float(bridge_idle_timeout_sec or 0.0))
+            last_agent_operations_size = 0
+            last_bridge_activity_at = time.monotonic()
             timeout_kind = ""
             while proc.poll() is None:
                 now = time.monotonic()
                 if not first_action_seen and agent_operations_summary_path:
                     try:
-                        first_action_seen = agent_operations_summary_path.stat().st_size > 0
+                        current_agent_operations_size = (
+                            agent_operations_summary_path.stat().st_size
+                        )
                     except OSError:
-                        first_action_seen = False
+                        current_agent_operations_size = 0
+                    if current_agent_operations_size > last_agent_operations_size:
+                        last_agent_operations_size = current_agent_operations_size
+                        last_bridge_activity_at = now
+                        first_action_seen = True
+                    elif current_agent_operations_size > 0:
+                        first_action_seen = True
                 if not first_action_seen and first_action_deadline and now >= first_action_deadline:
                     timeout_kind = "codex_exec_first_action_timeout"
+                    _stop_process_group(proc, sig=signal.SIGTERM)
+                    break
+                if (
+                    first_action_seen
+                    and agent_operations_summary_path is not None
+                    and bridge_idle_timeout_sec > 0
+                    and now - last_bridge_activity_at >= bridge_idle_timeout_sec
+                ):
+                    timeout_kind = "codex_exec_bridge_idle_timeout"
                     _stop_process_group(proc, sig=signal.SIGTERM)
                     break
                 if now >= deadline:
@@ -749,6 +770,7 @@ def main(argv: list[str] | None = None) -> int:
     codex_server.add_argument("--codex-bin", default="codex")
     codex_server.add_argument("--timeout-sec", type=float, default=7200.0)
     codex_server.add_argument("--first-action-timeout-sec", type=float, default=0.0)
+    codex_server.add_argument("--bridge-idle-timeout-sec", type=float, default=0.0)
     codex_server.add_argument("--prompt-bridge-command")
     codex_server.add_argument("--once", action="store_true")
 
@@ -785,6 +807,7 @@ def main(argv: list[str] | None = None) -> int:
                 default_timeout_sec=args.timeout_sec,
                 prompt_bridge_command=args.prompt_bridge_command,
                 first_action_timeout_sec=args.first_action_timeout_sec,
+                bridge_idle_timeout_sec=args.bridge_idle_timeout_sec,
             ),
         )
     if args.command == "serve-json":

--- a/scripts/skillsbench_reverse_channel_bridge.py
+++ b/scripts/skillsbench_reverse_channel_bridge.py
@@ -126,6 +126,15 @@ def _communicate_after_stop(proc: subprocess.Popen[str]) -> tuple[str, str]:
     return stdout_text or "", stderr_text or ""
 
 
+def _read_agent_operations_jsonl(path: Path | None) -> str:
+    if path is None or not path.exists():
+        return ""
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")[:200_000]
+    except OSError:
+        return ""
+
+
 def _replace_output_last_message(args: list[str], replacement: Path) -> str | None:
     for index, token in enumerate(args[:-1]):
         if token == "--output-last-message":
@@ -318,6 +327,13 @@ record["task_facing_operation"] = bool(
     operation in {{"read_file", "write_file", "cleanup"}}
     or (operation == "exec" and not subcommands)
 )
+record["operation_observed"] = True
+try:
+    SUMMARY_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with SUMMARY_PATH.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record, sort_keys=True) + "\\n")
+except OSError:
+    pass
 proc = subprocess.run(
     bridge_command(),
     input=raw,
@@ -326,13 +342,6 @@ proc = subprocess.run(
     stderr=subprocess.PIPE,
     shell=True,
 )
-record["returncode"] = int(proc.returncode)
-try:
-    SUMMARY_PATH.parent.mkdir(parents=True, exist_ok=True)
-    with SUMMARY_PATH.open("a", encoding="utf-8") as fh:
-        fh.write(json.dumps(record, sort_keys=True) + "\\n")
-except OSError:
-    pass
 sys.stdout.write(proc.stdout)
 sys.stderr.write(proc.stderr)
 raise SystemExit(proc.returncode)
@@ -446,7 +455,9 @@ def _run_codex_payload(
                     "stderr": f"{timeout_kind}\n",
                     "last_message": "",
                     "remote_last_message_path": remote_last_message_path,
-                    "agent_operations_jsonl": "",
+                    "agent_operations_jsonl": _read_agent_operations_jsonl(
+                        agent_operations_summary_path
+                    ),
                     "agent_operations_raw_material_recorded": False,
                     "raw_task_text_recorded": False,
                     "credential_values_recorded": False,
@@ -455,12 +466,6 @@ def _run_codex_payload(
                 last_message = last_message_path.read_text(encoding="utf-8")
             except OSError:
                 last_message = ""
-            agent_operations_jsonl = ""
-            if agent_operations_summary_path and agent_operations_summary_path.exists():
-                agent_operations_jsonl = agent_operations_summary_path.read_text(
-                    encoding="utf-8",
-                    errors="replace",
-                )[:200_000]
             return {
                 "schema_version": SERVER_RESPONSE_SCHEMA_VERSION,
                 "exit_code": int(proc.returncode),
@@ -468,7 +473,9 @@ def _run_codex_payload(
                 "stderr": stderr_text or "",
                 "last_message": last_message,
                 "remote_last_message_path": remote_last_message_path,
-                "agent_operations_jsonl": agent_operations_jsonl,
+                "agent_operations_jsonl": _read_agent_operations_jsonl(
+                    agent_operations_summary_path
+                ),
                 "agent_operations_raw_material_recorded": False,
                 "raw_task_text_recorded": False,
                 "credential_values_recorded": False,
@@ -483,7 +490,9 @@ def _run_codex_payload(
                 "stderr": stderr,
                 "last_message": "",
                 "remote_last_message_path": remote_last_message_path,
-                "agent_operations_jsonl": "",
+                "agent_operations_jsonl": _read_agent_operations_jsonl(
+                    agent_operations_summary_path
+                ),
                 "agent_operations_raw_material_recorded": False,
                 "raw_task_text_recorded": False,
                 "credential_values_recorded": False,


### PR DESCRIPTION
## Summary

- Make SkillsBench product-mode use a success-or-budget stop policy when the agent declares done but every-round official score is still below passing.
- Keep verifier feedback blinded: the continuation prompt does not expose reward, pass/fail state, verifier error, or verifier output.
- Record public-safe compact counters and failure labels for `declared_done_below_passing_reward`, so premature done is distinguishable from LoopX lifecycle plumbing failures.
- Add protocol contract flags and focused smokes for the stop policy.

## Fairness / Protocol Boundary

This does not change official scoring and does not show verifier feedback to the solver. It changes only the harness stop rule for product-mode treatment: an agent-declared done marker is no longer sufficient to early-stop while observed every-round score is still below passing. The treatment gets the same fixed-budget opportunity to continue until success or max rounds, which avoids a harness-induced false negative where the agent completes bridge/lifecycle work but not the benchmark task.

## Validation

- `python3 examples/benchmark-loop-protocol-smoke.py`
- targeted `examples/skillsbench-benchmark-run-smoke.py` product-mode stop/compact tests via importlib
- `python3 -m py_compile scripts/skillsbench_automation_loop.py loopx/benchmark_adapters/skillsbench.py loopx/status.py loopx/benchmark_core/loop_protocol.py examples/skillsbench-benchmark-run-smoke.py examples/benchmark-loop-protocol-smoke.py`
- `git diff --check`
- `loopx check` passes with existing warning: duplicate index rows for `loopx-meta`

Full `python3 examples/skillsbench-benchmark-run-smoke.py` still fails at pre-existing `test_host_local_acp_connect_contract_matches_benchflow_runtime` assertion (`benchflow.agents.protocol` import contract), unrelated to this stop-policy change.

## Next

After review, rerun the solid bad cases (`citation-check canonical24`, `powerlifting-coef-calc canonical24`) to verify product-mode no longer stops at round 2 solely because the agent declared done while score remains 0.0.
