### PR TITLE
Revert "Remove default Lark card footer"

### DIFF
--- a/examples/lark-message-card-smoke.py
+++ b/examples/lark-message-card-smoke.py
@@ -25,6 +25,7 @@ def main() -> int:
         "**Done**\n- Validated card formatting",
         title="LoopX result",
         template="green",
+        footer="LoopX automated reply",
     )
 
     assert card["config"] == {"wide_screen_mode": True, "enable_forward": True}, card
@@ -34,14 +35,11 @@ def main() -> int:
         "tag": "div",
         "text": {"tag": "lark_md", "content": "**Done**\n- Validated card formatting"},
     }, card
-    assert all(element["tag"] != "note" for element in card["elements"]), card
-    assert all(element["tag"] != "hr" for element in card["elements"]), card
-    footer_card = build_lark_markdown_reply_card("body", footer="LoopX automated reply")
-    assert footer_card["elements"][1]["tag"] == "hr", footer_card
-    assert footer_card["elements"][2] == {
+    assert card["elements"][1]["tag"] == "hr", card
+    assert card["elements"][2] == {
         "tag": "note",
         "elements": [{"tag": "plain_text", "content": "LoopX automated reply"}],
-    }, footer_card
+    }, card
     escaped_newline_content = build_lark_markdown_reply_card("first\\nsecond")["elements"][0]["text"]["content"]
     assert "\\n" not in escaped_newline_content, escaped_newline_content
     assert "first\nsecond" in escaped_newline_content, escaped_newline_content

--- a/loopx/capabilities/lark/message_card.py
+++ b/loopx/capabilities/lark/message_card.py
@@ -36,34 +36,9 @@ def build_lark_markdown_reply_card(
     *,
     title: str = "LoopX result",
     template: str = "blue",
-    footer: str | None = None,
+    footer: str = "LoopX automated reply",
     max_markdown_chars: int = DEFAULT_MAX_MARKDOWN_CHARS,
 ) -> dict[str, Any]:
-    elements: list[dict[str, Any]] = [
-        {
-            "tag": "div",
-            "text": {
-                "tag": "lark_md",
-                "content": compact_markdown(markdown, max_chars=max_markdown_chars),
-            },
-        },
-    ]
-    footer_text = compact_plain_text(footer, max_chars=DEFAULT_FOOTER_MAX_CHARS)
-    if footer_text:
-        elements.extend(
-            [
-                {"tag": "hr"},
-                {
-                    "tag": "note",
-                    "elements": [
-                        {
-                            "tag": "plain_text",
-                            "content": footer_text,
-                        }
-                    ],
-                },
-            ]
-        )
     return {
         "config": {"wide_screen_mode": True, "enable_forward": True},
         "header": {
@@ -73,7 +48,25 @@ def build_lark_markdown_reply_card(
                 "content": compact_plain_text(title, max_chars=DEFAULT_TITLE_MAX_CHARS),
             },
         },
-        "elements": elements,
+        "elements": [
+            {
+                "tag": "div",
+                "text": {
+                    "tag": "lark_md",
+                    "content": compact_markdown(markdown, max_chars=max_markdown_chars),
+                },
+            },
+            {"tag": "hr"},
+            {
+                "tag": "note",
+                "elements": [
+                    {
+                        "tag": "plain_text",
+                        "content": compact_plain_text(footer, max_chars=DEFAULT_FOOTER_MAX_CHARS),
+                    }
+                ],
+            },
+        ],
     }
 
 


### PR DESCRIPTION
## Summary

-

## Issue Or Task

- Closes #
- Contributor task ID:

## Validation

- [ ] `python3 -m py_compile loopx/*.py`
- [ ] `loopx check --scan-root .`
- [ ] Other:

## Boundary Checklist

- [ ] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [ ] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [ ] I kept the change scoped to the linked issue/task.
