### PR TITLE
Fix no-follow-up handoff gate state

### DIFF
--- a/docs/interaction-pattern-catalog.md
+++ b/docs/interaction-pattern-catalog.md
@@ -829,6 +829,7 @@ todo list, not only from open lanes, using `todo_handoff_gate_v0`.
 | `blocking` | non-terminal handoff todo for the scoped agent | return `agent_scope_wait`; name the owning reviewer/agent rather than waking the blocked agent for delivery |
 | `cleared_without_successor` | done handoff with no stable successor or supersede link | return `successor_replan_required`; reopen, supersede, or record no-follow-up rationale |
 | `cleared_with_successor` | done handoff linked to a successor via `unblocks_todo_id`, `resume_when`, or `superseded_by` | route to the concrete successor through normal todo selection |
+| `cleared_no_followup` | done handoff carries `no_followup=true` with a compact rationale | keep as terminal history; do not wake the blocked agent for successor replan |
 | `superseded` | handoff todo carries `superseded_by` | keep as history; do not wake the blocked agent from the stale gate |
 | `deferred` | handoff todo is parked behind an unsatisfied resume condition | keep diagnostic visibility; IP-027 owns the ready-deferred resume path |
 

--- a/docs/project-agent-todo-contract.md
+++ b/docs/project-agent-todo-contract.md
@@ -240,9 +240,9 @@ the agent should do one of two things:
 
 - create the next public-safe agent or user todo with `--next-agent-todo`,
   `--next-user-todo`, or a follow-up `todo add`;
-- record a compact no-follow-up rationale in the completion note, explaining why
-  the feature is truly finished and does not need rollout, audit, docs, or
-  product-path proof.
+- record a compact no-follow-up rationale with `--no-follow-up` plus `--note`
+  / `--reason` / `--evidence`, explaining why the feature is truly finished
+  and does not need rollout, audit, docs, or product-path proof.
 
 This keeps the active checklist honest without making LoopX a heavyweight
 project-management state machine.
@@ -405,7 +405,9 @@ carry `schema_version=todo_summary_v0`; individual items carry
 `title`, `archive_state`, `source_section`, `index`, `text`, `task_class`, and
 optional `action_kind`, `claimed_by`, `required_capabilities`, and
 `target_capabilities`. Primary review handoffs may also carry
-`blocks_agent` and `unblocks_todo_id` to show which agent/todo they release.
+`blocks_agent`, `unblocks_todo_id`, and `no_followup=true` to show which
+agent/todo they release and whether a completed handoff intentionally has no
+successor.
 Deferred successors may carry `resume_when`, `resume_condition`, and
 `resume_ready`; `resume_ready=true` means the deferred item should be considered
 for a successor replan before any agent-scoped no-candidate wait, not that

--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -354,6 +354,10 @@ ordinary delivery work. Only when no ready current-agent/unclaimed deferred
 resume exists should agent-scoped quota fall through to `agent_scope_wait`,
 `reassignment_required`, or `scope_exhausted`.
 
+For completed handoff gates, record that rationale structurally as
+`no_followup=true`; status projects the gate as `cleared_no_followup` instead
+of waking the blocked agent with `successor_replan_required`.
+
 External-evidence waits have an additional CLI-level observation contract. When
 the selected goal is `state=waiting`, `waiting_on=external_evidence`, and its
 current lane is a continuous monitor, or when the active state says a

--- a/examples/quota-cleared-blocker-successor-gate-smoke.py
+++ b/examples/quota-cleared-blocker-successor-gate-smoke.py
@@ -31,6 +31,7 @@ def todo_item(
     unblocks_todo_id: str | None = None,
     resume_when: str | None = None,
     superseded_by: str | None = None,
+    no_followup: bool = False,
 ) -> dict:
     item = {
         "todo_id": todo_id,
@@ -51,6 +52,8 @@ def todo_item(
         item["resume_when"] = resume_when
     if superseded_by:
         item["superseded_by"] = superseded_by
+    if no_followup:
+        item["no_followup"] = True
     return item
 
 
@@ -151,6 +154,18 @@ def handoff_review(*, status: str = "open", superseded_by: str | None = None) ->
         blocks_agent=BLOCKED_AGENT,
         unblocks_todo_id="todo_value_explorer_slice",
         superseded_by=superseded_by,
+    )
+
+
+def no_followup_handoff_review() -> dict:
+    return todo_item(
+        todo_id="todo_review_gate",
+        text="[P0-review] Review value explorer handoff and decide next work.",
+        claimed_by=PRIMARY_AGENT,
+        status="done",
+        blocks_agent=BLOCKED_AGENT,
+        unblocks_todo_id="todo_value_explorer_slice",
+        no_followup=True,
     )
 
 
@@ -311,6 +326,24 @@ def assert_superseded_completed_blocker_does_not_wake_agent() -> None:
     assert summary["current_agent_cleared_without_successor_handoff_count"] == 0, payload
 
 
+def assert_no_followup_completed_blocker_does_not_wake_agent() -> None:
+    payload = build_quota_should_run(
+        status_payload(
+            [primary_owned_todo(), no_followup_handoff_review()],
+            recommended_action="No follow-up is required after the review gate.",
+        ),
+        goal_id=GOAL_ID,
+        agent_id=BLOCKED_AGENT,
+    )
+    assert payload["decision"] == "agent_scope_wait", payload
+    assert payload["should_run"] is False, payload
+    summary = payload["agent_todo_summary"]
+    gate = summary["current_agent_handoff_gates"][0]
+    assert gate["gate_state"] == "cleared_no_followup", payload
+    assert gate["no_followup"] is True, payload
+    assert summary["current_agent_cleared_without_successor_handoff_count"] == 0, payload
+
+
 def main() -> int:
     assert_open_blocker_waits_on_owner()
     assert_cleared_blocker_requires_successor_replan()
@@ -318,6 +351,7 @@ def main() -> int:
     assert_existing_successor_runs_normally()
     assert_completed_successor_keeps_old_gate_cleared()
     assert_superseded_completed_blocker_does_not_wake_agent()
+    assert_no_followup_completed_blocker_does_not_wake_agent()
     print("quota-cleared-blocker-successor-gate-smoke ok")
     return 0
 

--- a/examples/todo-lifecycle-cli-smoke.py
+++ b/examples/todo-lifecycle-cli-smoke.py
@@ -277,8 +277,61 @@ def assert_configured_side_agent_handoff() -> None:
         assert "handoff_agent='codex-main-control'" in ignored_review_handoff["error"], ignored_review_handoff
 
 
+def assert_no_followup_cli_metadata() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-todo-no-followup-smoke-") as tmp:
+        root = Path(tmp)
+        registry_path, state_file = write_fixture(root)
+        added = run_cli(
+            registry_path,
+            "todo",
+            "add",
+            "--goal-id",
+            GOAL_ID,
+            "--role",
+            "agent",
+            "--text",
+            "Review completed work that intentionally needs no successor.",
+            "--claimed-by",
+            "codex-main-control",
+            "--task-class",
+            "advancement_task",
+            "--action-kind",
+            "review",
+        )
+        missing_rationale = run_cli_error(
+            registry_path,
+            "todo",
+            "update",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            added["todo_id"],
+            "--no-follow-up",
+        )
+        assert "--no-follow-up requires" in missing_rationale["error"], missing_rationale
+        updated = run_cli(
+            registry_path,
+            "todo",
+            "update",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            added["todo_id"],
+            "--status",
+            "done",
+            "--no-follow-up",
+            "--note",
+            "No rollout or follow-up is needed after validation.",
+        )
+        assert updated["changed"] is True, updated
+        item = next(item for item in parsed_items(state_file) if item["todo_id"] == added["todo_id"])
+        assert item["status"] == "done", item
+        assert item["no_followup"] is True, item
+
+
 def main() -> int:
     assert_configured_side_agent_handoff()
+    assert_no_followup_cli_metadata()
 
     with tempfile.TemporaryDirectory(prefix="loopx-todo-lifecycle-smoke-") as tmp:
         root = Path(tmp)

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -147,6 +147,14 @@ def register_todo_command(subparsers: argparse._SubParsersAction) -> None:
         action="store_true",
         help="For todo update, remove the soft claimed_by owner from the todo.",
     )
+    todo_parser.add_argument(
+        "--no-follow-up",
+        action="store_true",
+        help=(
+            "For todo update/complete, record a structured no-follow-up rationale "
+            "when a completed todo intentionally has no successor."
+        ),
+    )
     todo_parser.add_argument("--next-agent-todo", help="For complete/supersede, atomically add or update the next agent todo.")
     todo_parser.add_argument("--next-user-todo", help="For complete/supersede, atomically add or update the next user todo.")
     todo_parser.add_argument(
@@ -259,6 +267,8 @@ def handle_todo_command(
                 raise ValueError("todo add does not support --next-claimed-by")
             if args.side_agent_self_merged:
                 raise ValueError("todo add does not support --side-agent-self-merged")
+            if args.no_follow_up:
+                raise ValueError("todo add does not support --no-follow-up")
             payload = add_goal_todo(
                 registry_path=registry_path,
                 goal_id=args.goal_id,
@@ -301,6 +311,7 @@ def handle_todo_command(
                     ("--blocks-agent", args.blocks_agent),
                     ("--unblocks-todo-id", args.unblocks_todo_id),
                     ("--resume-when", args.resume_when),
+                    ("--no-follow-up", args.no_follow_up),
                     ("--next-agent-todo", args.next_agent_todo),
                     ("--next-user-todo", args.next_user_todo),
                     ("--next-claimed-by", args.next_claimed_by),
@@ -349,9 +360,12 @@ def handle_todo_command(
                 args.blocks_agent,
                 args.unblocks_todo_id,
                 args.resume_when,
+                args.no_follow_up,
                 args.clear_claim,
             ]):
-                raise ValueError("todo update requires at least one of --text, --status, --note, --evidence, --reason, --task-class, --action-kind, --required-write-scope, --required-capability, --target-capability, --claimed-by, --blocks-agent, --unblocks-todo-id, --resume-when, or --clear-claim")
+                raise ValueError("todo update requires at least one of --text, --status, --note, --evidence, --reason, --task-class, --action-kind, --required-write-scope, --required-capability, --target-capability, --claimed-by, --blocks-agent, --unblocks-todo-id, --resume-when, --no-follow-up, or --clear-claim")
+            if args.no_follow_up and not (args.note or args.reason or args.evidence):
+                raise ValueError("--no-follow-up requires --note, --reason, or --evidence")
             if args.followups:
                 raise ValueError("todo update does not support --follow-up; use `todo capture-followups`")
             if args.next_claimed_by:
@@ -378,6 +392,7 @@ def handle_todo_command(
                 agent_id=args.agent_id,
                 unblocks_todo_id=args.unblocks_todo_id,
                 resume_when=args.resume_when,
+                no_followup=True if args.no_follow_up else None,
                 clear_claim=bool(args.clear_claim),
                 project=Path(args.project).expanduser() if args.project else None,
                 state_file=Path(args.state_file).expanduser() if args.state_file else None,
@@ -390,6 +405,10 @@ def handle_todo_command(
                 raise ValueError("todo complete accepts either --claimed-by or --clear-claim, not both")
             if args.blocks_agent or args.unblocks_todo_id or args.resume_when:
                 raise ValueError("todo complete does not support --blocks-agent, --unblocks-todo-id, or --resume-when; use todo update before completion or side-agent handoff successor metadata")
+            if args.no_follow_up and (args.next_agent_todo or args.next_user_todo):
+                raise ValueError("--no-follow-up cannot be combined with successor todos")
+            if args.no_follow_up and not (args.note or args.evidence):
+                raise ValueError("--no-follow-up requires --note or --evidence")
             if args.followups:
                 raise ValueError("todo complete does not support --follow-up; use `todo capture-followups`")
             payload = complete_goal_todo(
@@ -399,6 +418,7 @@ def handle_todo_command(
                 role=args.role,
                 evidence=args.evidence,
                 note=args.note,
+                no_followup=bool(args.no_follow_up),
                 claimed_by=args.claimed_by,
                 clear_claim=bool(args.clear_claim),
                 next_agent_todo=args.next_agent_todo,
@@ -424,6 +444,8 @@ def handle_todo_command(
                 raise ValueError("todo supersede does not support --clear-claim")
             if args.side_agent_self_merged:
                 raise ValueError("todo supersede does not support --side-agent-self-merged")
+            if args.no_follow_up:
+                raise ValueError("todo supersede does not support --no-follow-up")
             if args.followups:
                 raise ValueError("todo supersede does not support --follow-up; use `todo capture-followups`")
             if args.blocks_agent or args.unblocks_todo_id or args.resume_when:
@@ -450,6 +472,8 @@ def handle_todo_command(
                 raise ValueError("todo archive-completed does not support --next-claimed-by")
             if args.side_agent_self_merged:
                 raise ValueError("todo archive-completed does not support --side-agent-self-merged")
+            if args.no_follow_up:
+                raise ValueError("todo archive-completed does not support --no-follow-up")
             if args.followups:
                 raise ValueError("todo archive-completed does not support --follow-up; use `todo capture-followups`")
             payload = archive_completed_todos(
@@ -481,6 +505,7 @@ def handle_todo_command(
                     ("--blocks-agent", args.blocks_agent),
                     ("--unblocks-todo-id", args.unblocks_todo_id),
                     ("--resume-when", args.resume_when),
+                    ("--no-follow-up", args.no_follow_up),
                     ("--clear-claim", args.clear_claim),
                     ("--next-agent-todo", args.next_agent_todo),
                     ("--next-user-todo", args.next_user_todo),
@@ -524,6 +549,7 @@ def handle_todo_command(
                     ("--blocks-agent", args.blocks_agent),
                     ("--unblocks-todo-id", args.unblocks_todo_id),
                     ("--resume-when", args.resume_when),
+                    ("--no-follow-up", args.no_follow_up),
                     ("--clear-claim", args.clear_claim),
                     ("--next-agent-todo", args.next_agent_todo),
                     ("--next-user-todo", args.next_user_todo),

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -1015,6 +1015,7 @@ def _compact_todo_summary_item(item: dict[str, Any], *, text: str | None = None)
         "resume_when",
         "resume_condition",
         "resume_ready",
+        "no_followup",
     ):
         if item.get(key) is not None:
             compact[key] = item.get(key)

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -68,6 +68,7 @@ from .todo_contract import (
     normalize_todo_blocks_agent,
     normalize_todo_claimed_by,
     normalize_todo_id,
+    normalize_todo_no_followup,
     normalize_todo_resume_when,
     normalize_todo_status,
     normalize_todo_task_class,
@@ -4416,6 +4417,9 @@ def structured_todo_item(
     resume_when = normalize_todo_resume_when(item.get("resume_when"))
     if resume_when:
         normalized["resume_when"] = resume_when
+    no_followup = normalize_todo_no_followup(item.get("no_followup"))
+    if no_followup is not None:
+        normalized["no_followup"] = no_followup
     if priority:
         normalized["priority"] = priority
         normalized["title"] = normalize_todo_text(title)
@@ -4448,6 +4452,7 @@ def compact_todo_item(item: dict[str, Any]) -> dict[str, Any]:
         "resume_when",
         "resume_condition",
         "resume_ready",
+        "no_followup",
         "note",
         "evidence",
         "reason",

--- a/loopx/todo_contract.py
+++ b/loopx/todo_contract.py
@@ -171,6 +171,17 @@ def normalize_todo_resume_when(value: Any) -> str | None:
     return None
 
 
+def normalize_todo_no_followup(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    candidate = compact_todo_text(value).lower()
+    if candidate in {"1", "true", "yes", "y", "no_followup", "no-followup"}:
+        return True
+    if candidate in {"0", "false", "no", "n"}:
+        return False
+    return None
+
+
 def normalize_todo_id(value: Any) -> str | None:
     candidate = str(value or "").strip().lower()
     if candidate and TODO_ID_PATTERN.match(candidate):
@@ -346,6 +357,10 @@ def parse_todo_metadata_line(line: str) -> dict[str, Any] | None:
             resume_when = normalize_todo_resume_when(value)
             if resume_when:
                 metadata["resume_when"] = resume_when
+        elif key == "no_followup":
+            no_followup = normalize_todo_no_followup(value)
+            if no_followup is not None:
+                metadata["no_followup"] = no_followup
         elif key in {"note", "evidence", "reason", "completed_at", "updated_at"}:
             if value:
                 metadata[key] = value
@@ -369,6 +384,7 @@ def format_todo_metadata_line(
     blocks_agent: str | None = None,
     unblocks_todo_id: str | None = None,
     resume_when: str | None = None,
+    no_followup: bool | None = None,
     note: str | None = None,
     evidence: str | None = None,
     reason: str | None = None,
@@ -441,6 +457,8 @@ def format_todo_metadata_line(
         raise ValueError("resume_when must be public-safe, e.g. todo_done:todo_ab12cd34ef56 or pr_merged:#532")
     if normalized_resume_when:
         fields.append(f"resume_when={encode_metadata_value(normalized_resume_when)}")
+    if no_followup is not None:
+        fields.append(f"no_followup={encode_metadata_value('true' if no_followup else 'false')}")
     for key, value in (
         ("note", note),
         ("evidence", evidence),

--- a/loopx/todo_handoff_gate.py
+++ b/loopx/todo_handoff_gate.py
@@ -12,6 +12,7 @@ from .todo_contract import (
     normalize_todo_blocks_agent,
     normalize_todo_claimed_by,
     normalize_todo_id,
+    normalize_todo_no_followup,
     normalize_todo_resume_when,
     normalize_todo_status,
     normalize_todo_task_class,
@@ -26,6 +27,7 @@ class HandoffGateState(str, Enum):
     BLOCKING = "blocking"
     CLEARED_WITHOUT_SUCCESSOR = "cleared_without_successor"
     CLEARED_WITH_SUCCESSOR = "cleared_with_successor"
+    CLEARED_NO_FOLLOWUP = "cleared_no_followup"
     SUPERSEDED = "superseded"
     DEFERRED = "deferred"
 
@@ -97,6 +99,8 @@ def _handoff_gate_state(
         return HandoffGateState.DEFERRED
     if not _todo_done(gate):
         return HandoffGateState.BLOCKING
+    if normalize_todo_no_followup(gate.get("no_followup")) is True:
+        return HandoffGateState.CLEARED_NO_FOLLOWUP
     if successor_ids:
         return HandoffGateState.CLEARED_WITH_SUCCESSOR
     return HandoffGateState.CLEARED_WITHOUT_SUCCESSOR
@@ -126,6 +130,7 @@ def _compact_handoff_gate(
         "claimed_by",
         "unblocks_todo_id",
         "resume_when",
+        "no_followup",
         "superseded_by",
     ):
         value = gate.get(key)

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -30,6 +30,7 @@ from .todo_contract import (
     normalize_todo_blocks_agent,
     normalize_todo_claimed_by,
     normalize_todo_id,
+    normalize_todo_no_followup,
     normalize_todo_resume_when,
     normalize_todo_status,
     parse_todo_metadata_line,
@@ -56,6 +57,7 @@ TODO_METADATA_FIELDS = (
     "blocks_agent",
     "unblocks_todo_id",
     "resume_when",
+    "no_followup",
     "note",
     "evidence",
     "reason",
@@ -323,6 +325,11 @@ def block_metadata(block: dict[str, Any]) -> dict[str, Any]:
             if capabilities:
                 metadata[key] = capabilities
             continue
+        if key == "no_followup":
+            no_followup = normalize_todo_no_followup(value)
+            if no_followup is not None:
+                metadata[key] = no_followup
+            continue
         if str(value or "").strip():
             metadata[key] = str(value).strip()
     return metadata
@@ -351,6 +358,12 @@ def metadata_line_for_block(block: dict[str, Any], updates: dict[str, Any]) -> s
             capabilities = normalize_target_capabilities(value)
             if capabilities:
                 metadata[key] = capabilities
+            else:
+                metadata.pop(key, None)
+        elif key == "no_followup":
+            no_followup = normalize_todo_no_followup(value)
+            if no_followup is not None:
+                metadata[key] = no_followup
             else:
                 metadata.pop(key, None)
         elif str(value).strip():
@@ -730,6 +743,7 @@ def apply_todo_update_to_lines(
     blocks_agent: str | None = None,
     unblocks_todo_id: str | None = None,
     resume_when: str | None = None,
+    no_followup: bool | None = None,
     clear_claim: bool = False,
     claim_only: bool = False,
     updated_at: str,
@@ -794,6 +808,8 @@ def apply_todo_update_to_lines(
         updates["unblocks_todo_id"] = unblocks_todo_id
     if resume_when:
         updates["resume_when"] = resume_when
+    if no_followup is not None:
+        updates["no_followup"] = no_followup
     metadata_line = metadata_line_for_block(block, updates)
     semantic_metadata_changed = todo_metadata_would_change(lines, block, metadata_line)
     if status_changed or text_changed or semantic_metadata_changed:
@@ -823,6 +839,7 @@ def apply_todo_update_to_lines(
         "blocks_agent": normalize_todo_blocks_agent(effective_metadata.get("blocks_agent")),
         "unblocks_todo_id": normalize_todo_id(effective_metadata.get("unblocks_todo_id")),
         "resume_when": normalize_todo_resume_when(effective_metadata.get("resume_when")),
+        "no_followup": normalize_todo_no_followup(effective_metadata.get("no_followup")),
     }
 
 
@@ -847,6 +864,7 @@ def update_goal_todo(
     agent_id: str | None = None,
     unblocks_todo_id: str | None = None,
     resume_when: str | None = None,
+    no_followup: bool | None = None,
     clear_claim: bool = False,
     claim_only: bool = False,
     project: Path | None = None,
@@ -924,6 +942,7 @@ def update_goal_todo(
             blocks_agent=effective_blocks_agent,
             unblocks_todo_id=normalized_unblocks_todo_id,
             resume_when=normalized_resume_when,
+            no_followup=no_followup,
             clear_claim=clear_claim,
             claim_only=claim_only,
             updated_at=updated_at,
@@ -955,6 +974,7 @@ def complete_goal_todo(
     role: str | None = None,
     evidence: str | None = None,
     note: str | None = None,
+    no_followup: bool = False,
     claimed_by: str | None = None,
     clear_claim: bool = False,
     next_agent_todo: str | None = None,
@@ -1053,6 +1073,7 @@ def complete_goal_todo(
             evidence=evidence,
             claimed_by=effective_claimed_by,
             clear_claim=clear_claim,
+            no_followup=True if no_followup else None,
             updated_at=updated_at,
         )
         if next_agent_todo and not effective_next_claimed_by:


### PR DESCRIPTION
## Summary
- add structured `no_followup=true` todo metadata and `loopx todo update/complete --no-follow-up`
- project completed handoff gates with no follow-up as `cleared_no_followup` instead of `successor_replan_required`
- document the contract and cover CLI + quota gate behavior with focused smokes

## Validation
- `python3 -m py_compile loopx/todo_contract.py loopx/todos.py loopx/todo_handoff_gate.py loopx/status.py loopx/quota.py loopx/cli_commands/todo.py examples/quota-cleared-blocker-successor-gate-smoke.py examples/todo-lifecycle-cli-smoke.py`
- `python3 examples/quota-cleared-blocker-successor-gate-smoke.py`
- `python3 examples/todo-lifecycle-cli-smoke.py`
- `git diff --check origin/main...HEAD`
- `python3 -m loopx.cli --format json check --scan-path ...` (public boundary clean; existing duplicate index warning only)
