### PR TITLE
Add LoopX global summary command

### DIFF
--- a/docs/reference/protocols/global-manager-command-v0.md
+++ b/docs/reference/protocols/global-manager-command-v0.md
@@ -8,9 +8,11 @@ The product goal is to let a user act as a manager across long-running agent
 work: ask for the last day of progress, see blocked decisions, compare agent
 lanes, and choose the next safe action without reading every thread.
 
-This protocol is not a chat-command router yet. It defines the request,
-allowed sources, response shape, privacy boundary, and action ladder that a
-Codex host, CLI wrapper, or dashboard command palette can implement later.
+This protocol is not a general chat-command router yet. It defines the
+request, allowed sources, response shape, privacy boundary, and action ladder
+for Codex hosts, CLI wrappers, or dashboard command palettes. The first CLI
+wrapper is `loopx global-summary`, which returns the canonical
+`/loop-global-summary` response.
 
 ## Command Set
 

--- a/examples/global-manager-command-cli-smoke.py
+++ b/examples/global-manager-command-cli-smoke.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Smoke-test the public-safe `loopx global-summary` command."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PRIVATE_PATTERNS = [
+    re.compile(r"/" + r"Users/[A-Za-z0-9._-]+/"),
+    re.compile(r"/" + r"private/"),
+    re.compile(r"/tmp/"),
+    re.compile(r"/var/"),
+    re.compile(r"[A-Za-z]:\\\\Users\\\\"),
+]
+
+
+def assert_public_safe(payload: dict[str, object]) -> None:
+    text = json.dumps(payload, ensure_ascii=False)
+    for pattern in PRIVATE_PATTERNS:
+        if pattern.search(text):
+            raise AssertionError(f"global-summary payload leaked private pattern {pattern.pattern!r}")
+    if "/loopx-summary-all" in text:
+        raise AssertionError("global-summary payload should not expose the superseded /loopx-summary-all alias")
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="loopx-global-summary-smoke-") as tmp:
+        root = Path(tmp)
+        runtime = root / "runtime"
+        registry = root / "registry.global.json"
+        registry.write_text(
+            json.dumps(
+                {
+                    "common_runtime_root": str(runtime),
+                    "goals": [
+                        {
+                            "id": "smoke-goal",
+                            "objective": "Smoke global summary.",
+                            "domain": "loopx-smoke",
+                            "status": "active",
+                            "adapter": {"kind": "read_only_project_map_v0", "status": "connected-read-only"},
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
+        )
+        runs = runtime / "goals" / "smoke-goal" / "runs"
+        runs.mkdir(parents=True)
+        runs.joinpath("index.jsonl").write_text(
+            json.dumps(
+                {
+                    "generated_at": "2026-06-26T00:00:00+00:00",
+                    "classification": "smoke_progress",
+                    "recommended_action": "Continue the next public-safe smoke step.",
+                    "json_exists": True,
+                    "markdown_exists": True,
+                },
+                ensure_ascii=False,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "loopx.cli",
+                "--format",
+                "json",
+                "--registry",
+                str(registry),
+                "--runtime-root",
+                str(runtime),
+                "global-summary",
+                "--limit",
+                "5",
+            ],
+            cwd=REPO_ROOT,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+    payload = json.loads(proc.stdout)
+    assert payload["schema_version"] == "global_manager_command_response_v0", payload
+    request = payload["request"]
+    assert request["command"] == "/loop-global-summary", request
+    assert request["cli_command"] == "loopx global-summary", request
+    assert request["privacy_mode"] == "public_safe_summary", request
+    assert request["dry_run"] is True, request
+    assert payload["boundary"]["absolute_paths_recorded"] is False, payload["boundary"]
+    assert "groups" in payload and "recent_progress" in payload["groups"], payload
+    assert_public_safe(payload)
+
+    print("global-manager-command-cli-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/global-manager-command-protocol-smoke.py
+++ b/examples/global-manager-command-protocol-smoke.py
@@ -23,6 +23,9 @@ REQUIRED_COMMANDS = {
     "/loop-global-risks",
     "/loop-goal-summary",
 }
+REJECTED_COMMAND_ALIASES = {
+    "/loopx-summary-all",
+}
 
 REQUIRED_BOUNDARY_FALSE = {
     "raw_logs_recorded",
@@ -79,6 +82,9 @@ def main() -> int:
     assert_contains(long_horizon, "global_manager_command_v0", "long horizon protocol")
     for command in REQUIRED_COMMANDS:
         assert_contains(contract, command, "command set")
+    for command in REJECTED_COMMAND_ALIASES:
+        if command in contract:
+            raise AssertionError(f"command set should not include superseded alias {command!r}")
     for needle in [
         "read-only by default",
         "Action Ladder",

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -35,6 +35,7 @@ from .cli_commands import (
     handle_review_packet_command,
     handle_status_command,
     handle_starter_command,
+    handle_summary_all_command,
     handle_support_control_command,
     handle_todo_command,
     handle_worker_bridge_command,
@@ -51,6 +52,7 @@ from .cli_commands import (
     register_registry_admin_commands,
     register_starter_commands,
     register_status_commands,
+    register_summary_all_command,
     register_support_control_commands,
     register_todo_command,
     register_worker_bridge_commands,
@@ -145,6 +147,7 @@ def main(argv: list[str] | None = None) -> int:
     register_lark_kanban_commands(sub, add_subcommand_format)
 
     register_status_commands(sub, add_subcommand_format)
+    register_summary_all_command(sub, add_subcommand_format)
     register_dreaming_commands(sub, add_subcommand_format)
     register_todo_command(sub)
     register_quota_command(sub)
@@ -325,6 +328,16 @@ def main(argv: list[str] | None = None) -> int:
             output_format=output_format,
             print_payload=print_payload,
         )
+
+    summary_all_result = handle_summary_all_command(
+        args,
+        registry_path=registry_path,
+        runtime_root_arg=args.runtime_root,
+        output_format=output_format,
+        print_payload=print_payload,
+    )
+    if summary_all_result is not None:
+        return summary_all_result
 
     if args.command == "dreaming":
         return handle_dreaming_command(

--- a/loopx/cli_commands/__init__.py
+++ b/loopx/cli_commands/__init__.py
@@ -133,6 +133,7 @@ from .starter_visible_pilot import (
     handle_starter_visible_pilot_command,
     register_starter_visible_pilot_commands,
 )
+from .summary_all import handle_summary_all_command, register_summary_all_command
 from .status import (
     handle_check_command,
     handle_diagnose_command,
@@ -210,6 +211,7 @@ __all__ = [
     "handle_starter_session_runtime_command",
     "handle_starter_visible_driver_command",
     "handle_starter_visible_pilot_command",
+    "handle_summary_all_command",
     "handle_support_control_command",
     "handle_terminal_bench_adapter_command",
     "handle_terminal_bench_environment_result_command",
@@ -247,6 +249,7 @@ __all__ = [
     "register_starter_session_runtime_commands",
     "register_starter_visible_driver_commands",
     "register_starter_visible_pilot_commands",
+    "register_summary_all_command",
     "register_status_commands",
     "register_support_control_commands",
     "register_terminal_bench_adapter_commands",

--- a/loopx/cli_commands/summary_all.py
+++ b/loopx/cli_commands/summary_all.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+from pathlib import Path
+
+from ..summary_all import build_summary_all, render_summary_all_markdown
+
+
+PrintPayload = Callable[
+    [dict[str, object], str, Callable[[dict[str, object]], str]],
+    None,
+]
+FormatSelector = Callable[..., str]
+
+
+def default_public_scan_root() -> str:
+    return str(Path(__file__).resolve().parents[2])
+
+
+def _scan_roots(args: argparse.Namespace) -> list[Path]:
+    scan_roots = [Path(item).expanduser() for item in args.scan_path]
+    return scan_roots or [Path(args.scan_root).expanduser()]
+
+
+def register_summary_all_command(
+    subparsers: argparse._SubParsersAction,
+    add_subcommand_format: Callable[[argparse.ArgumentParser], None],
+) -> None:
+    parser = subparsers.add_parser(
+        "global-summary",
+        help="Read a public-safe /loop-global-summary progress digest across visible LoopX goals.",
+    )
+    add_subcommand_format(parser)
+    parser.add_argument("--agent-id", help="Registered agent id for agent-lane quota projection.")
+    parser.add_argument("--time-range", default="24h", help="Recent progress window, e.g. 24h or 7d.")
+    parser.add_argument("--limit", type=int, default=8, help="Maximum items per digest section.")
+    parser.add_argument(
+        "--scan-root",
+        default=default_public_scan_root(),
+        help="Public files to scan for obvious private material. Defaults to the LoopX install root.",
+    )
+    parser.add_argument(
+        "--scan-path",
+        action="append",
+        default=[],
+        help="Specific public file or directory to scan. Repeatable. Overrides --scan-root when set.",
+    )
+
+
+def handle_summary_all_command(
+    args: argparse.Namespace,
+    *,
+    registry_path: Path,
+    runtime_root_arg: str | None,
+    output_format: FormatSelector,
+    print_payload: PrintPayload,
+) -> int | None:
+    if args.command != "global-summary":
+        return None
+    try:
+        payload = build_summary_all(
+            registry_path=registry_path,
+            runtime_root_override=runtime_root_arg,
+            scan_roots=_scan_roots(args),
+            agent_id=args.agent_id,
+            time_range=args.time_range,
+            limit=max(1, args.limit),
+        )
+    except Exception as exc:
+        payload = {
+            "ok": False,
+            "schema_version": "global_manager_command_response_v0",
+            "request": {
+                "schema_version": "global_manager_command_request_v0",
+                "command": "/loop-global-summary",
+                "privacy_mode": "public_safe_summary",
+                "dry_run": True,
+            },
+            "error": str(exc),
+        }
+    print_payload(payload, output_format(args), render_summary_all_markdown)
+    return 0 if payload.get("ok") else 1

--- a/loopx/summary_all.py
+++ b/loopx/summary_all.py
@@ -1,0 +1,424 @@
+from __future__ import annotations
+
+import re
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from .history import collect_history, load_registry
+from .paths import resolve_runtime_root
+from .quota import build_quota_should_run
+from .status import collect_status
+
+
+COMMAND = "/loop-global-summary"
+SCHEMA_VERSION = "global_manager_command_response_v0"
+
+BOUNDARY = {
+    "raw_logs_recorded": False,
+    "raw_transcripts_recorded": False,
+    "raw_connector_payloads_recorded": False,
+    "credential_values_recorded": False,
+    "absolute_paths_recorded": False,
+    "private_source_bodies_recorded": False,
+}
+
+SOURCE_SURFACES = [
+    "global registry compact status",
+    "status attention queue",
+    "quota should-run summaries",
+    "active-state todo projections",
+    "run history index summaries",
+]
+
+LANE_PRIORITY = {
+    "eligible": 0,
+    "normal_run": 0,
+    "run": 0,
+    "operator_gate": 1,
+    "focus_wait": 1,
+    "waiting": 2,
+    "throttled": 3,
+    "paused": 4,
+    "quota_unavailable": 5,
+}
+
+LOCAL_PATH_PATTERNS = (
+    re.compile(r"/(?:Users|home|private|tmp|var)/[^\s`|,)]+"),
+    re.compile(r"[A-Za-z]:\\\\Users\\\\[^\s`|,)]+"),
+)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _parse_time_range(value: str) -> tuple[str, datetime | None]:
+    normalized = (value or "24h").strip().lower()
+    now = datetime.now(timezone.utc)
+    if normalized.endswith("h") and normalized[:-1].isdigit():
+        return normalized, now - timedelta(hours=int(normalized[:-1]))
+    if normalized.endswith("d") and normalized[:-1].isdigit():
+        return normalized, now - timedelta(days=int(normalized[:-1]))
+    return "24h", now - timedelta(hours=24)
+
+
+def _parse_datetime(value: object) -> datetime | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _redact_text(value: object, *, limit: int = 260) -> str:
+    text = str(value or "").strip()
+    text = text.replace("/loopx-summary-all", "/loop-global-summary")
+    for pattern in LOCAL_PATH_PATTERNS:
+        text = pattern.sub("<local-path-redacted>", text)
+    text = re.sub(r"\s+", " ", text)
+    if len(text) > limit:
+        return text[: max(0, limit - 1)].rstrip() + "…"
+    return text
+
+
+def _as_dict(value: object) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: object) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _first_open_todo(quota_payload: dict[str, Any]) -> dict[str, Any] | None:
+    lane = _as_dict(quota_payload.get("agent_lane_next_action"))
+    if lane:
+        return lane
+    summary = _as_dict(quota_payload.get("agent_todo_summary"))
+    for key in ("first_open_items", "items", "open_items"):
+        for item in _as_list(summary.get(key)):
+            if isinstance(item, dict):
+                return item
+    return None
+
+
+def _goal_agent_id(item: dict[str, Any], quota_payload: dict[str, Any]) -> str | None:
+    lane = _as_dict(quota_payload.get("agent_lane_next_action"))
+    if lane.get("agent_id"):
+        return str(lane.get("agent_id"))
+    agent_identity = _as_dict(quota_payload.get("agent_identity"))
+    if agent_identity.get("agent_id"):
+        return str(agent_identity.get("agent_id"))
+    project_asset = _as_dict(item.get("project_asset"))
+    owner = _as_dict(project_asset.get("owner"))
+    if owner.get("agent_id"):
+        return str(owner.get("agent_id"))
+    return None
+
+
+def _build_goal_quota(
+    status_payload: dict[str, Any],
+    *,
+    goal_id: str,
+    agent_id: str | None,
+) -> dict[str, Any]:
+    try:
+        return build_quota_should_run(status_payload, goal_id=goal_id, agent_id=agent_id)
+    except Exception as exc:
+        return {
+            "ok": False,
+            "goal_id": goal_id,
+            "state": "quota_unavailable",
+            "decision": "quota_unavailable",
+            "reason": _redact_text(exc),
+        }
+
+
+def _lane_from_item(
+    item: dict[str, Any],
+    *,
+    quota_payload: dict[str, Any],
+) -> dict[str, Any]:
+    todo = _first_open_todo(quota_payload)
+    rollout_event = _as_dict(quota_payload.get("rollout_event"))
+    goal_id = str(item.get("goal_id") or quota_payload.get("goal_id") or "")
+    status = str(quota_payload.get("state") or item.get("status") or "unknown")
+    waiting_on = str(item.get("waiting_on") or quota_payload.get("waiting_on") or "")
+    next_action = (
+        quota_payload.get("recommended_action")
+        or item.get("recommended_action")
+        or _as_dict(item.get("project_asset")).get("next_action")
+    )
+    lane: dict[str, Any] = {
+        "goal_id": goal_id,
+        "status": status,
+        "waiting_on": waiting_on,
+        "agent_id": _goal_agent_id(item, quota_payload),
+        "top_todo_id": todo.get("todo_id") if isinstance(todo, dict) else None,
+        "last_event_id": rollout_event.get("event_id"),
+        "next_safe_action": _redact_text(next_action),
+    }
+    return {key: value for key, value in lane.items() if value not in (None, "")}
+
+
+def _gate_from_item(
+    item: dict[str, Any],
+    *,
+    quota_payload: dict[str, Any],
+) -> dict[str, Any] | None:
+    user_channel = _as_dict(_as_dict(quota_payload.get("interaction_contract")).get("user_channel"))
+    user_summary = _as_dict(quota_payload.get("user_todo_summary"))
+    open_count = int(user_summary.get("open_count") or user_summary.get("count") or 0)
+    if not user_channel.get("action_required") and open_count <= 0:
+        return None
+    goal_id = str(item.get("goal_id") or quota_payload.get("goal_id") or "")
+    first_item: dict[str, Any] | None = None
+    for key in ("first_open_items", "items", "open_items"):
+        for candidate in _as_list(user_summary.get(key)):
+            if isinstance(candidate, dict):
+                first_item = candidate
+                break
+        if first_item:
+            break
+    question = (
+        user_channel.get("question")
+        or quota_payload.get("operator_question")
+        or quota_payload.get("gate_prompt")
+        or (first_item or {}).get("text")
+        or item.get("recommended_action")
+    )
+    blocked_todo = (first_item or {}).get("todo_id")
+    return {
+        "gate_id": str(quota_payload.get("gate_id") or f"{goal_id}:user-gate"),
+        "goal_id": goal_id,
+        "owner": "user",
+        "blocks": [blocked_todo] if blocked_todo else [goal_id],
+        "question": _redact_text(question),
+        "next_safe_action": "Wait for the projected user/controller decision before running the blocked path.",
+    }
+
+
+def _todo_from_quota(goal_id: str, quota_payload: dict[str, Any]) -> dict[str, Any] | None:
+    todo = _first_open_todo(quota_payload)
+    if not isinstance(todo, dict):
+        return None
+    return {
+        "todo_id": todo.get("todo_id"),
+        "goal_id": goal_id,
+        "role": todo.get("role") or "agent",
+        "claimed_by": todo.get("claimed_by"),
+        "state": todo.get("status") or "open",
+        "priority": todo.get("priority"),
+        "title": _redact_text(todo.get("title") or todo.get("text")),
+        "next_safe_action": _redact_text(quota_payload.get("recommended_action")),
+    }
+
+
+def _risk_from_finding(finding: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "kind": str(finding.get("kind") or "status_warning"),
+        "severity": str(finding.get("severity") or "info"),
+        "goal_id": finding.get("goal_id"),
+        "evidence_refs": ["status_contract"],
+        "next_safe_action": _redact_text(finding.get("recommended_action") or finding.get("message")),
+    }
+
+
+def _recent_progress(history_payload: dict[str, Any], *, since: datetime | None, limit: int) -> list[dict[str, Any]]:
+    progress: list[dict[str, Any]] = []
+    for run in _as_list(history_payload.get("runs")):
+        if not isinstance(run, dict):
+            continue
+        generated_at = _parse_datetime(run.get("generated_at"))
+        if since and generated_at and generated_at < since:
+            continue
+        progress.append(
+            {
+                "goal_id": run.get("goal_id"),
+                "generated_at": run.get("generated_at"),
+                "classification": _redact_text(run.get("classification"), limit=120),
+                "recommended_action": _redact_text(run.get("recommended_action"), limit=220),
+            }
+        )
+        if len(progress) >= limit:
+            break
+    return progress
+
+
+def _lane_sort_key(lane: dict[str, Any]) -> tuple[int, str]:
+    status = str(lane.get("status") or "unknown")
+    return (LANE_PRIORITY.get(status, 4), str(lane.get("goal_id") or ""))
+
+
+def build_summary_all(
+    *,
+    registry_path: Path,
+    runtime_root_override: str | None,
+    scan_roots: list[Path],
+    agent_id: str | None,
+    time_range: str,
+    limit: int,
+) -> dict[str, Any]:
+    normalized_range, since = _parse_time_range(time_range)
+    status_payload = collect_status(
+        registry_path=registry_path,
+        runtime_root_override=runtime_root_override,
+        scan_roots=scan_roots,
+        limit=max(limit, 1),
+    )
+    registry = load_registry(registry_path)
+    runtime_root = resolve_runtime_root(registry, runtime_root_override)
+    history_payload = collect_history(
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        goal_id=None,
+        limit=max(limit * 2, 5),
+    )
+
+    queue = _as_dict(status_payload.get("attention_queue"))
+    queue_items = [item for item in _as_list(queue.get("items")) if isinstance(item, dict)]
+    lanes: list[dict[str, Any]] = []
+    gates: list[dict[str, Any]] = []
+    todos: list[dict[str, Any]] = []
+    quota_states: dict[str, int] = {}
+    seen_goal_ids: set[str] = set()
+
+    for item in queue_items[: max(limit * 4, 40)]:
+        goal_id = str(item.get("goal_id") or "").strip()
+        if not goal_id or goal_id in seen_goal_ids:
+            continue
+        seen_goal_ids.add(goal_id)
+        quota_payload = _build_goal_quota(status_payload, goal_id=goal_id, agent_id=agent_id)
+        lane = _lane_from_item(item, quota_payload=quota_payload)
+        if lane:
+            lanes.append(lane)
+            quota_states[str(lane.get("status") or "unknown")] = quota_states.get(str(lane.get("status") or "unknown"), 0) + 1
+        gate = _gate_from_item(item, quota_payload=quota_payload)
+        if gate:
+            gates.append(gate)
+        todo = _todo_from_quota(goal_id, quota_payload)
+        if todo:
+            todos.append(todo)
+    lanes.sort(key=_lane_sort_key)
+
+    global_registry = _as_dict(status_payload.get("global_registry"))
+    risks = [_risk_from_finding(item) for item in _as_list(global_registry.get("findings")) if isinstance(item, dict)]
+    recent_progress = _recent_progress(history_payload, since=since, limit=limit)
+
+    runnable_count = sum(1 for lane in lanes if lane.get("status") in {"eligible", "run", "normal_run"})
+    waiting_count = sum(1 for lane in lanes if str(lane.get("waiting_on") or "") in {"controller", "user", "external"})
+    headline = (
+        f"{len(recent_progress)} recent progress items, {len(gates)} open user/controller gates, "
+        f"{len(todos)} runnable or visible todos."
+    )
+    payload: dict[str, Any] = {
+        "ok": True,
+        "schema_version": SCHEMA_VERSION,
+        "request": {
+            "schema_version": "global_manager_command_request_v0",
+            "command": COMMAND,
+            "cli_command": "loopx global-summary",
+            "time_range": normalized_range,
+            "include": ["progress", "gates", "todos", "risks", "next_actions"],
+            "privacy_mode": "public_safe_summary",
+            "dry_run": True,
+        },
+        "generated_at": _now_iso(),
+        "summary": {
+            "headline": headline,
+            "progress_count": len(recent_progress),
+            "open_gate_count": len(gates),
+            "runnable_todo_count": len(todos),
+            "waiting_lane_count": waiting_count,
+            "risk_count": len(risks),
+            "source_surfaces": SOURCE_SURFACES,
+            "quota_states": quota_states,
+        },
+        "groups": {
+            "user_gates": gates[:limit],
+            "runnable_agent_work": [
+                lane for lane in lanes if lane.get("status") in {"eligible", "normal_run", "run"}
+            ][:limit],
+            "waiting_lanes": [
+                lane
+                for lane in lanes
+                if str(lane.get("waiting_on") or "") in {"controller", "user", "external"}
+                or lane.get("status") in {"waiting", "focus_wait", "operator_gate"}
+            ][:limit],
+            "health_risks": risks[:limit],
+            "recent_progress": recent_progress,
+        },
+        "lanes": lanes[:limit],
+        "gates": gates[:limit],
+        "todos": todos[:limit],
+        "risks": risks[:limit],
+        "recent_progress": recent_progress,
+        "actions": [
+            {
+                "action_id": "act_read_goal_detail",
+                "kind": "read_more",
+                "requires_user_approval": False,
+                "requires_primary_agent": False,
+                "preview": "Run `loopx review-packet --goal-id <goal>` or `loopx quota should-run --goal-id <goal>` for one lane.",
+            },
+            {
+                "action_id": "act_ask_user_gate",
+                "kind": "ask_user",
+                "requires_user_approval": False,
+                "requires_primary_agent": False,
+                "preview": "Surface the projected gate question when open_gate_count is non-zero.",
+            },
+        ],
+        "omissions": [
+            "Raw logs, raw transcripts, connector payloads, credential values, local paths, and private source bodies were intentionally omitted.",
+            "Status health findings are summarized without filesystem paths.",
+        ],
+        "boundary": BOUNDARY,
+    }
+    return payload
+
+
+def render_summary_all_markdown(payload: dict[str, Any]) -> str:
+    if not payload.get("ok"):
+        return "# LoopX Global Summary\n\n- ok: `False`\n- error: " + _redact_text(payload.get("error"))
+
+    summary = _as_dict(payload.get("summary"))
+    lines = [
+        "# LoopX Global Summary",
+        "",
+        f"- command: `{_as_dict(payload.get('request')).get('command')}`",
+        f"- time_range: `{_as_dict(payload.get('request')).get('time_range')}`",
+        f"- headline: {summary.get('headline')}",
+        f"- counts: progress=`{summary.get('progress_count')}`, gates=`{summary.get('open_gate_count')}`, todos=`{summary.get('runnable_todo_count')}`, risks=`{summary.get('risk_count')}`",
+        "",
+        "## Lanes",
+    ]
+    for lane in _as_list(payload.get("lanes")):
+        if not isinstance(lane, dict):
+            continue
+        lines.append(
+            "- "
+            f"`{lane.get('goal_id')}` status=`{lane.get('status')}` "
+            f"waiting_on=`{lane.get('waiting_on')}` todo=`{lane.get('top_todo_id')}`: "
+            f"{lane.get('next_safe_action')}"
+        )
+    lines.extend(["", "## Gates"])
+    gates = [item for item in _as_list(payload.get("gates")) if isinstance(item, dict)]
+    if not gates:
+        lines.append("- none")
+    for gate in gates:
+        lines.append(f"- `{gate.get('goal_id')}` owner=`{gate.get('owner')}`: {gate.get('question')}")
+    lines.extend(["", "## Recent Progress"])
+    for item in _as_list(payload.get("recent_progress")):
+        if not isinstance(item, dict):
+            continue
+        lines.append(
+            "- "
+            f"`{item.get('generated_at')}` `{item.get('goal_id')}` "
+            f"`{item.get('classification')}`: {item.get('recommended_action')}"
+        )
+    lines.extend(["", "## Boundary"])
+    lines.append("- raw/private material omitted; local paths are not recorded.")
+    return "\n".join(lines)


### PR DESCRIPTION
## Summary
- add read-only `loopx global-summary` CLI wrapper for the canonical `/loop-global-summary` protocol
- group compact status/quota/history surfaces into lanes, gates, todos, risks, and recent progress
- add CLI smoke coverage and keep the superseded `/loopx-summary-all` alias out of the public command set

## Validation
- `python3 examples/global-manager-command-protocol-smoke.py`
- `python3 examples/global-manager-command-cli-smoke.py`
- `python3 -m py_compile loopx/summary_all.py loopx/cli_commands/summary_all.py loopx/cli.py`
- real `loopx global-summary` JSON preview checked for no local paths and no `/loopx-summary-all` text
- `loopx --format json check --scan-path ...` public boundary scan clean for changed files

## Review
Runtime CLI behavior change; should be reviewed by the primary maintainer before merge.