### PR TITLE
Fix check boundary policy for private state

### DIFF
--- a/docs/public-private-boundary.md
+++ b/docs/public-private-boundary.md
@@ -66,6 +66,27 @@ Real controller state belongs in ignored local files such as
 public repository may track sanitized templates, fixtures, and compact
 projections, but not the live file that a controller updates on every turn.
 
+`loopx check` treats that as a file-state boundary, not just a path-name
+boundary. Local private state that is not tracked by git may contain private
+document links because it is not a publishable artifact. If that same file is
+tracked by git, it enters the public boundary and is scanned like any other
+publishable file.
+
+Projects that intentionally publish tracked files with private document links
+can opt in through the project registry:
+
+```json
+{
+  "public_boundary": {
+    "tracked_private_doc_urls": "allow"
+  }
+}
+```
+
+This policy only allows `private_doc_url` findings in tracked files. It does
+not allow credentials, tokens, passwords, private IPs, internal task ids, or
+local private paths.
+
 If a runtime-only goal is obsolete, archive its directory rather than copying
 private run payloads into public notes:
 

--- a/examples/check-public-boundary-smoke.py
+++ b/examples/check-public-boundary-smoke.py
@@ -32,6 +32,16 @@ def run_cli(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
     )
 
 
+def run_git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
 def main() -> int:
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)
@@ -89,6 +99,82 @@ def main() -> int:
         errors = public_payload.get("errors") or []
         if not any("public.md" in str(item) and "private_doc_url" in str(item) for item in errors):
             raise AssertionError(public_payload)
+
+        git_project = root / "git-project"
+        git_project.mkdir()
+        init = run_git(git_project, "init")
+        if init.returncode != 0:
+            raise AssertionError(init.stderr or init.stdout)
+        state_file = git_project / ".codex" / "goals" / "demo" / "ACTIVE_GOAL_STATE.md"
+        state_file.parent.mkdir(parents=True)
+        state_file.write_text(f"private_doc_url: {PRIVATE_DOC_MARKER}\n", encoding="utf-8")
+
+        local_state = run_cli(
+            root,
+            "--format",
+            "json",
+            "check",
+            "--scan-path",
+            str(state_file),
+        )
+        if local_state.returncode != 0:
+            raise AssertionError(local_state.stderr or local_state.stdout)
+        local_state_payload = json.loads(local_state.stdout)
+        if not local_state_payload.get("ok"):
+            raise AssertionError(local_state_payload)
+        checks = "\n".join(str(item) for item in local_state_payload.get("checks") or [])
+        if "private state scan skipped: 1 local-private files" not in checks:
+            raise AssertionError(local_state_payload)
+
+        add_state = run_git(git_project, "add", str(state_file.relative_to(git_project)))
+        if add_state.returncode != 0:
+            raise AssertionError(add_state.stderr or add_state.stdout)
+        tracked_state = run_cli(
+            root,
+            "--format",
+            "json",
+            "check",
+            "--scan-path",
+            str(state_file),
+        )
+        if tracked_state.returncode == 0:
+            raise AssertionError(tracked_state.stdout)
+        tracked_state_payload = json.loads(tracked_state.stdout)
+        tracked_errors = tracked_state_payload.get("errors") or []
+        if not any("ACTIVE_GOAL_STATE.md" in str(item) and "private_doc_url" in str(item) for item in tracked_errors):
+            raise AssertionError(tracked_state_payload)
+
+        registry_path = git_project / ".loopx" / "registry.json"
+        registry_path.parent.mkdir(parents=True)
+        registry_path.write_text(
+            json.dumps(
+                {
+                    "public_boundary": {
+                        "tracked_private_doc_urls": "allow",
+                    },
+                    "goals": [],
+                }
+            ),
+            encoding="utf-8",
+        )
+        allowed_state = run_cli(
+            root,
+            "--registry",
+            str(registry_path),
+            "--format",
+            "json",
+            "check",
+            "--scan-path",
+            str(state_file),
+        )
+        if allowed_state.returncode != 0:
+            raise AssertionError(allowed_state.stderr or allowed_state.stdout)
+        allowed_state_payload = json.loads(allowed_state.stdout)
+        if not allowed_state_payload.get("ok"):
+            raise AssertionError(allowed_state_payload)
+        checks = "\n".join(str(item) for item in allowed_state_payload.get("checks") or [])
+        if "public boundary policy allowed: 1 private_doc_url hits" not in checks:
+            raise AssertionError(allowed_state_payload)
 
     print("check-public-boundary-smoke ok")
     return 0

--- a/examples/check-public-boundary-smoke.py
+++ b/examples/check-public-boundary-smoke.py
@@ -144,6 +144,24 @@ def main() -> int:
         if not any("ACTIVE_GOAL_STATE.md" in str(item) and "private_doc_url" in str(item) for item in tracked_errors):
             raise AssertionError(tracked_state_payload)
 
+        tracked_root = run_cli(
+            root,
+            "--format",
+            "json",
+            "check",
+            "--scan-root",
+            str(git_project),
+        )
+        if tracked_root.returncode == 0:
+            raise AssertionError(tracked_root.stdout)
+        tracked_root_payload = json.loads(tracked_root.stdout)
+        tracked_root_errors = tracked_root_payload.get("errors") or []
+        if not any(
+            "ACTIVE_GOAL_STATE.md" in str(item) and "private_doc_url" in str(item)
+            for item in tracked_root_errors
+        ):
+            raise AssertionError(tracked_root_payload)
+
         registry_path = git_project / ".loopx" / "registry.json"
         registry_path.parent.mkdir(parents=True)
         registry_path.write_text(
@@ -175,6 +193,25 @@ def main() -> int:
         checks = "\n".join(str(item) for item in allowed_state_payload.get("checks") or [])
         if "public boundary policy allowed: 1 private_doc_url hits" not in checks:
             raise AssertionError(allowed_state_payload)
+
+        allowed_root = run_cli(
+            root,
+            "--registry",
+            str(registry_path),
+            "--format",
+            "json",
+            "check",
+            "--scan-root",
+            str(git_project),
+        )
+        if allowed_root.returncode != 0:
+            raise AssertionError(allowed_root.stderr or allowed_root.stdout)
+        allowed_root_payload = json.loads(allowed_root.stdout)
+        if not allowed_root_payload.get("ok"):
+            raise AssertionError(allowed_root_payload)
+        checks = "\n".join(str(item) for item in allowed_root_payload.get("checks") or [])
+        if "public boundary policy allowed: 1 private_doc_url hits" not in checks:
+            raise AssertionError(allowed_root_payload)
 
     print("check-public-boundary-smoke ok")
     return 0

--- a/loopx/contract.py
+++ b/loopx/contract.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -51,6 +52,93 @@ DEFAULT_SKIP_DIRS = {
     "node_modules",
     "runtime",
 }
+LOCAL_PRIVATE_STATE_PARTS = {
+    ".codex",
+    ".goal-harness",
+    ".goal-wrapper.local",
+    ".local",
+    ".loopx",
+    "logs",
+    "runtime",
+}
+LOCAL_PRIVATE_STATE_FILE_NAMES = {"ACTIVE_GOAL_STATE.md", "ACTIVE_GOAL_STATE.md.lock"}
+
+
+def _git_probe(path: Path) -> dict[str, Any]:
+    target = path if path.is_dir() else path.parent
+    try:
+        root = subprocess.run(
+            ["git", "-C", str(target), "rev-parse", "--show-toplevel"],
+            text=True,
+            capture_output=True,
+            check=True,
+        ).stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return {"inside_worktree": False, "tracked": False, "ignored": False}
+
+    repo_root = Path(root)
+    try:
+        rel_path = str(path.relative_to(repo_root))
+    except ValueError:
+        rel_path = str(path)
+    tracked = (
+        subprocess.run(
+            ["git", "-C", str(repo_root), "ls-files", "--error-unmatch", "--", rel_path],
+            text=True,
+            capture_output=True,
+            check=False,
+        ).returncode
+        == 0
+    )
+    ignored = (
+        subprocess.run(
+            ["git", "-C", str(repo_root), "check-ignore", "-q", "--", rel_path],
+            text=True,
+            capture_output=True,
+            check=False,
+        ).returncode
+        == 0
+    )
+    return {
+        "inside_worktree": True,
+        "root": str(repo_root),
+        "tracked": tracked,
+        "ignored": ignored,
+    }
+
+
+def _is_local_private_state_path(path: Path) -> bool:
+    parts = set(path.parts)
+    return bool(parts & LOCAL_PRIVATE_STATE_PARTS) or path.name in LOCAL_PRIVATE_STATE_FILE_NAMES
+
+
+def _public_boundary_policy(registry: dict[str, Any]) -> dict[str, str]:
+    policy = registry.get("public_boundary") if isinstance(registry, dict) else None
+    if not isinstance(policy, dict):
+        policy = registry.get("privacy") if isinstance(registry, dict) else None
+    if not isinstance(policy, dict):
+        policy = {}
+
+    tracked_private_doc_urls = "block"
+    raw_mode = (
+        policy.get("tracked_private_doc_urls")
+        or policy.get("private_doc_urls_in_tracked_files")
+    )
+    if str(raw_mode).lower() == "allow" or policy.get("allow_tracked_private_doc_urls") is True:
+        tracked_private_doc_urls = "allow"
+
+    return {
+        "schema_version": "loopx_public_boundary_policy_v0",
+        "tracked_private_doc_urls": tracked_private_doc_urls,
+    }
+
+
+def _hit_allowed_by_policy(name: str, git: dict[str, Any], policy: dict[str, str]) -> bool:
+    if name != "private_doc_url":
+        return False
+    if not git.get("tracked"):
+        return False
+    return policy.get("tracked_private_doc_urls") == "allow"
 
 
 def _index_duplicate_summary(index_path: Path) -> dict[str, Any]:
@@ -136,14 +224,35 @@ def iter_scan_files(scan_root: Path) -> list[Path]:
     return sorted(files)
 
 
-def scan_public_boundary(scan_roots: list[Path]) -> dict[str, Any]:
+def scan_public_boundary(
+    scan_roots: list[Path], *, registry: dict[str, Any] | None = None
+) -> dict[str, Any]:
     hits: list[str] = []
+    allowed_hits: list[str] = []
+    private_state_git_warnings: list[str] = []
+    skipped_private_state_files: list[str] = []
     files: list[Path] = []
+    file_roots: dict[Path, Path] = {}
     for scan_root in scan_roots:
-        files.extend(iter_scan_files(scan_root))
+        display_root = scan_root.parent if scan_root.is_file() else scan_root
+        for file_path in iter_scan_files(scan_root):
+            files.append(file_path)
+            file_roots[file_path] = display_root
     files = sorted(set(files))
+    policy = _public_boundary_policy(registry or {})
 
     for path in files:
+        root = file_roots.get(path, path)
+        git: dict[str, Any] | None = None
+        if _is_local_private_state_path(path):
+            git = _git_probe(path)
+            if not git.get("tracked"):
+                skipped_private_state_files.append(rel_or_abs(path, root))
+                if git.get("inside_worktree") and not git.get("ignored"):
+                    private_state_git_warnings.append(
+                        f"{rel_or_abs(path, root)}: private state should be gitignored"
+                    )
+                continue
         try:
             text = path.read_text(encoding="utf-8")
         except UnicodeDecodeError:
@@ -151,11 +260,22 @@ def scan_public_boundary(scan_roots: list[Path]) -> dict[str, Any]:
         for line_no, line in enumerate(text.splitlines(), start=1):
             for name, pattern in LEAK_PATTERNS.items():
                 if pattern.search(line):
-                    hits.append(f"{rel_or_abs(path, scan_root)}:{line_no}: {name}")
+                    hit = f"{rel_or_abs(path, root)}:{line_no}: {name}"
+                    if name == "private_doc_url":
+                        git = git or _git_probe(path)
+                    if git is not None and _hit_allowed_by_policy(name, git, policy):
+                        allowed_hits.append(hit)
+                    else:
+                        hits.append(hit)
     return {
         "ok": not hits,
         "scan_roots": [str(path) for path in scan_roots],
         "files": len(files),
+        "scanned_files": len(files) - len(skipped_private_state_files),
+        "skipped_private_state_files": skipped_private_state_files,
+        "allowed_hits": allowed_hits,
+        "private_state_git_warnings": private_state_git_warnings,
+        "policy": policy,
         "hits": hits,
     }
 
@@ -234,11 +354,22 @@ def check_contract(
             else:
                 warnings.append(_index_duplicate_warning(item.get("id"), raw, unique))
 
-    boundary = scan_public_boundary(scan_roots)
+    boundary = scan_public_boundary(scan_roots, registry=registry)
     if boundary.get("ok"):
-        checks.append(f"public boundary scan clean: {boundary.get('files')} files")
+        checks.append(f"public boundary scan clean: {boundary.get('scanned_files')} files")
     else:
         errors.extend(str(item) for item in boundary.get("hits") or [])
+    if boundary.get("skipped_private_state_files"):
+        checks.append(
+            "private state scan skipped: "
+            f"{len(boundary.get('skipped_private_state_files') or [])} local-private files"
+        )
+    if boundary.get("allowed_hits"):
+        checks.append(
+            "public boundary policy allowed: "
+            f"{len(boundary.get('allowed_hits') or [])} private_doc_url hits"
+        )
+    warnings.extend(str(item) for item in boundary.get("private_state_git_warnings") or [])
 
     return {
         "ok": not errors,

--- a/loopx/contract.py
+++ b/loopx/contract.py
@@ -65,6 +65,7 @@ LOCAL_PRIVATE_STATE_FILE_NAMES = {"ACTIVE_GOAL_STATE.md", "ACTIVE_GOAL_STATE.md.
 
 
 def _git_probe(path: Path) -> dict[str, Any]:
+    path = path.resolve()
     target = path if path.is_dir() else path.parent
     try:
         root = subprocess.run(
@@ -76,7 +77,7 @@ def _git_probe(path: Path) -> dict[str, Any]:
     except (subprocess.CalledProcessError, FileNotFoundError):
         return {"inside_worktree": False, "tracked": False, "ignored": False}
 
-    repo_root = Path(root)
+    repo_root = Path(root).resolve()
     try:
         rel_path = str(path.relative_to(repo_root))
     except ValueError:
@@ -200,13 +201,57 @@ def _index_duplicate_warning(goal_id: object, raw: int, unique: int) -> str:
     )
 
 
+def _tracked_scan_files(scan_root: Path) -> list[Path]:
+    scan_root = scan_root.resolve()
+    target = scan_root if scan_root.is_dir() else scan_root.parent
+    try:
+        root = subprocess.run(
+            ["git", "-C", str(target), "rev-parse", "--show-toplevel"],
+            text=True,
+            capture_output=True,
+            check=True,
+        ).stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return []
+
+    repo_root = Path(root).resolve()
+    try:
+        rel_root = str(scan_root.resolve().relative_to(repo_root.resolve()))
+    except ValueError:
+        return []
+    if not rel_root:
+        rel_root = "."
+
+    tracked = subprocess.run(
+        ["git", "-C", str(repo_root), "ls-files", "-z", "--", rel_root],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if tracked.returncode != 0:
+        return []
+
+    files: list[Path] = []
+    for rel_path in tracked.stdout.split("\0"):
+        if not rel_path:
+            continue
+        path = (repo_root / rel_path).resolve()
+        if path.name.endswith(".local.json"):
+            continue
+        if path.is_file() and path.suffix in DEFAULT_SCAN_SUFFIXES:
+            files.append(path)
+    return files
+
+
 def iter_scan_files(scan_root: Path) -> list[Path]:
+    scan_root = scan_root.resolve()
     if scan_root.is_file():
         return [scan_root]
     files: list[Path] = []
+    tracked_files = _tracked_scan_files(scan_root)
     root_parts = set(scan_root.parts)
     if any(part in DEFAULT_SKIP_DIRS or part.endswith(".egg-info") for part in root_parts):
-        return files
+        return sorted(tracked_files)
 
     for dir_path, dir_names, file_names in os.walk(scan_root):
         dir_names[:] = [
@@ -216,12 +261,12 @@ def iter_scan_files(scan_root: Path) -> list[Path]:
         ]
         current_dir = Path(dir_path)
         for file_name in file_names:
-            path = current_dir / file_name
+            path = (current_dir / file_name).resolve()
             if path.name.endswith(".local.json"):
                 continue
             if path.suffix in DEFAULT_SCAN_SUFFIXES:
                 files.append(path)
-    return sorted(files)
+    return sorted(set(files + tracked_files))
 
 
 def scan_public_boundary(
@@ -234,8 +279,9 @@ def scan_public_boundary(
     files: list[Path] = []
     file_roots: dict[Path, Path] = {}
     for scan_root in scan_roots:
-        display_root = scan_root.parent if scan_root.is_file() else scan_root
-        for file_path in iter_scan_files(scan_root):
+        resolved_scan_root = scan_root.resolve()
+        display_root = resolved_scan_root.parent if resolved_scan_root.is_file() else resolved_scan_root
+        for file_path in iter_scan_files(resolved_scan_root):
             files.append(file_path)
             file_roots[file_path] = display_root
     files = sorted(set(files))


### PR DESCRIPTION
## Summary
- Treat untracked LoopX local state files as private, non-publishable state during `loopx check` boundary scans.
- Continue scanning tracked files as public-boundary artifacts, with an explicit registry opt-in for tracked `private_doc_url` findings.
- Add smoke coverage for untracked `ACTIVE_GOAL_STATE.md`, tracked state rejection, and registry policy allowance.

## Validation
- `python3 -m py_compile loopx/contract.py examples/check-public-boundary-smoke.py`
- `python3 examples/check-public-boundary-smoke.py`
- `python3 examples/registry-boundary-contract-smoke.py`
- `python3 regression/cli-command-module-contract.py`
- `python3 -m loopx.cli --format json check --scan-path loopx/contract.py --scan-path examples/check-public-boundary-smoke.py --scan-path docs/public-private-boundary.md`

Note: the final `loopx check` reports the pre-existing `loopx-meta` duplicate index warning, with zero errors.