### PR TITLE
Add LoopX goal-start slash command contract

### DIFF
--- a/docs/reference/protocols/global-manager-command-v0.md
+++ b/docs/reference/protocols/global-manager-command-v0.md
@@ -30,6 +30,11 @@ Commands are read-only by default. They can propose follow-up actions, but
 they do not approve gates, promote suggested todos, spend quota, merge PRs,
 pause automations, or run destructive operations.
 
+Related project-local command: `/loopx <goal text>` is covered by
+[`loopx_goal_command_v0`](loopx-goal-command-v0.md). It is not a global manager
+command: it starts one project goal, plans ranked todos, writes them in order,
+and then enters the quota-gated automation flow.
+
 ## Request Shape
 
 ```json

--- a/docs/reference/protocols/loopx-goal-command-v0.md
+++ b/docs/reference/protocols/loopx-goal-command-v0.md
@@ -1,0 +1,70 @@
+# loopx_goal_command_v0
+
+`loopx_goal_command_v0` defines the project-local `/loopx` slash command:
+
+| Command | Intent | Mutation policy |
+| --- | --- | --- |
+| `/loopx` | Inspect or preview project connection. | Read-first; ask before bootstrap/connect writes. |
+| `/loopx <goal text>` | Start a concrete goal, plan ranked todos, and enter the LoopX automation flow. | Explicit invocation may write project-local LoopX state and todos. |
+
+This command is intentionally separate from `/loop-global-*`: global commands
+summarize and manage visible control-plane state across projects, while
+`/loopx <goal text>` starts or continues one project goal.
+
+## Goal-Start Flow
+
+When the user provides text after `/loopx`, the host should:
+
+1. Treat the text as explicit user intent to start this project goal.
+2. Connect project-local LoopX state if no matching registry goal exists.
+3. Plan before writing todos.
+4. Write planned todos in exact plan order.
+5. Run `refresh-state`, then `quota should-run`, then start the first bounded
+   segment only when the quota contract allows it.
+
+The command pack preview is still read-only. It describes the commands and
+contracts; the slash invocation is what authorizes project-local state writes.
+
+## Planning Contract
+
+The planner must create an ordered planning checkpoint before any `todo add`,
+but the shape depends on how clear the goal already is:
+
+- `open_ended_product_direction`: broad or fuzzy product directions should
+  produce 2-5 public-safe todo items so the user can see the main lanes,
+  risks, and execution order before LoopX starts working.
+- `clear_bounded_problem`: concrete tasks with a clear success condition should
+  use a planner-sized ordered todo plan. The model should produce enough
+  concise todos to make the approach explicit, without arbitrary item-count
+  caps or management-only filler.
+
+Each new item includes:
+
+- `priority`: `P0`, `P1`, or `P2`;
+- `text`: a short checkbox title beginning with `[P0]`, `[P1]`, or `[P2]`;
+- `task_class`: usually `advancement_task`;
+- `action_kind`: a compact action token such as `implement`, `test`,
+  `review`, `document`, or `investigate`.
+
+At least one new item should be `P0` unless the first useful step is blocked by
+a concrete user gate. User todos are reserved for owner decisions, private
+material, credentials, destructive git, or production authorization.
+
+## Priority Ordering
+
+Priority buckets sort as `P0`, then `P1`, then `P2`. Within the same bucket,
+the planner's list order is the relative priority.
+
+Hosts must preserve that order while running `loopx todo add`. LoopX status and
+quota projections already use todo index as the same-priority tie-breaker, so
+the first written `P0` outranks the second written `P0` without adding a new
+rank field.
+
+## Stop Conditions
+
+Stop and ask the user instead of writing or executing when:
+
+- private source material must be read before a public-safe todo can be formed;
+- credentials or secrets are required;
+- destructive git or production actions are needed;
+- the host cannot execute shell/CLI/tool calls or persist LoopX state.

--- a/examples/bootstrap-command-pack-smoke.py
+++ b/examples/bootstrap-command-pack-smoke.py
@@ -43,6 +43,7 @@ def test_missing_project_stops_before_mutation() -> None:
         assert isinstance(connection, dict)
         assert payload["schema_version"] == "loopx_bootstrap_command_pack_v0"
         assert payload["slash_command"] == "/loopx"
+        assert {"form": "/loopx <goal text>", "mode": "goal_plan_write_and_activate"} in payload["slash_forms"]
         assert payload["read_only"] is True
         assert connection["connection_state"] == "not_connected"
         assert connection["mutation_confirmation_required"] is True
@@ -62,6 +63,64 @@ def test_missing_project_stops_before_mutation() -> None:
         assert "--codex-app-heartbeat ask" in str(next_step["dry_run_command"])
         assert "--dry-run" not in str(next_step["after_confirmation_command"])
         assert "/loopx-summary-all" not in json.dumps(payload)
+
+
+def test_goal_text_invocation_plans_ranked_todos_before_activation() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        project = Path(tmp) / "goal-start-project"
+        project.mkdir()
+        payload = run_json(
+            "bootstrap-command-pack",
+            "--project",
+            str(project),
+            "--goal-id",
+            "goal-start",
+            "--agent-id",
+            "codex-test-agent",
+            "--goal-text",
+            "Ship the lightweight issue triage workflow",
+        )
+
+        assert payload["goal_text"] == "Ship the lightweight issue triage workflow"
+        next_step = payload["recommended_next_step"]
+        assert isinstance(next_step, dict)
+        assert next_step["kind"] == "goal_plan_write_and_activate"
+        assert next_step["requires_user_confirmation"] is False
+        assert next_step["confirmation_source"] == "/loopx <goal text>"
+        assert "--objective 'Ship the lightweight issue triage workflow'" in str(
+            next_step["connect_command_if_needed"]
+        )
+        assert "--no-onboarding-scan" in str(next_step["connect_command_if_needed"])
+
+        goal_start = payload["goal_start_contract"]
+        assert isinstance(goal_start, dict)
+        assert goal_start["schema_version"] == "loopx_goal_start_command_v0"
+        assert goal_start["planner"]["required_before_todo_write"] is True
+        profiles = goal_start["planner"]["profiles"]
+        assert profiles["open_ended_product_direction"]["suggested_items_min"] == 2
+        assert profiles["open_ended_product_direction"]["suggested_items_max"] == 5
+        assert profiles["clear_bounded_problem"]["item_count_policy"] == "planner_sized"
+        assert profiles["clear_bounded_problem"][
+            "may_reuse_current_todo_when_it_already_represents_the_plan"
+        ] is True
+        assert "minimum sufficient ordered todo plan" in goal_start["planner"]["budget_policy"]
+        ordering = goal_start["priority_ordering"]
+        assert ordering["bucket_order"] == ["P0", "P1", "P2"]
+        assert ordering["same_priority_tie_breaker"] == "planner_order_then_todo_write_order"
+        assert "todo index" in ordering["storage_contract"]
+
+        commands = payload["commands"]
+        assert isinstance(commands, dict)
+        plan_prompt = str(commands["goal_start_plan_prompt"])
+        assert "broad or fuzzy product direction uses 2-5" in plan_prompt
+        assert "clear bounded problems use a planner-sized ordered todo plan" in plan_prompt
+        assert "avoid management-only filler" in plan_prompt
+        assert "Every new todo starts with `[P0]`, `[P1]`, or `[P2]`" in plan_prompt
+        assert "Preserve that exact order" in plan_prompt
+        assert "--agent-id codex-test-agent" in str(commands["goal_start_quota_should_run"])
+        assert "Same-priority items use that write order as the tie-breaker" in str(payload["message"])
+        assert not (project / ".loopx").exists()
+        assert not (project / ".codex").exists()
 
 
 def test_connected_project_reuses_existing_state() -> None:
@@ -111,9 +170,30 @@ def test_connected_project_reuses_existing_state() -> None:
         assert "loopx status" in str(payload["commands"])
 
 
+def test_skill_slash_fallback_contract() -> None:
+    skill_text = (REPO_ROOT / "skills" / "loopx-project" / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    normalized = " ".join(skill_text.split())
+
+    assert "## Slash Command Fallback" in skill_text
+    assert "`/loopx`" in skill_text
+    assert "`/loopx <goal text>`" in skill_text
+    assert "loopx bootstrap-command-pack --project ." in skill_text
+    assert '--goal-text "<GOAL_TEXT>"' in skill_text
+    assert "read/status-first" in skill_text
+    assert "explicit goal-start intent" in normalized
+    assert "planner order plus `todo add` write order" in normalized
+    assert "do not silently downgrade `/loopx <goal text>`" in normalized
+    assert "`/loop-global-summary`" in skill_text
+    assert "not project bootstrap commands" in normalized
+
+
 def main() -> int:
     test_missing_project_stops_before_mutation()
+    test_goal_text_invocation_plans_ranked_todos_before_activation()
     test_connected_project_reuses_existing_state()
+    test_skill_slash_fallback_contract()
     print("bootstrap command pack smoke passed")
     return 0
 

--- a/loopx/bootstrap_command_pack.py
+++ b/loopx/bootstrap_command_pack.py
@@ -17,6 +17,7 @@ from .registry import registry_goals, resolve_state_file
 
 SCHEMA_VERSION = "loopx_bootstrap_command_pack_v0"
 CANONICAL_SLASH_COMMAND = "/loopx"
+GOAL_START_SCHEMA_VERSION = "loopx_goal_start_command_v0"
 
 
 def _resolve_project(project: Path) -> Path:
@@ -182,6 +183,125 @@ def _project_command(project: str, command: str) -> str:
     return "\n".join([f"cd {shell_arg(project)}", command])
 
 
+def _goal_start_bootstrap_command(
+    *,
+    project: str,
+    goal_id: str,
+    goal_text: str | None,
+    cli_bin: str,
+) -> str:
+    objective = goal_text or "<exact /loopx goal text>"
+    lines = [
+        f"cd {shell_arg(project)}",
+        f"{shell_arg(cli_bin)} bootstrap \\",
+        "  --project . \\",
+        f"  --goal-id {shell_arg(goal_id)} \\",
+        f"  --objective {shell_arg(objective)} \\",
+        f"  --adapter-kind {shell_arg(DEFAULT_HANDOFF_ADAPTER_KIND)} \\",
+        f"  --adapter-status {shell_arg(DEFAULT_HANDOFF_ADAPTER_STATUS)} \\",
+        "  --no-onboarding-scan \\",
+        "  --codex-app-heartbeat ask",
+    ]
+    return "\n".join(lines)
+
+
+def _goal_start_contract(*, goal_text: str | None, connected: bool) -> dict[str, Any]:
+    return {
+        "schema_version": GOAL_START_SCHEMA_VERSION,
+        "slash_syntax": "/loopx <goal text>",
+        "goal_text": goal_text,
+        "explicit_invocation_confirms_project_local_state_writes": True,
+        "connect_if_needed": True,
+        "bootstrap_policy": "create project-local LoopX state only when no matching registry goal exists",
+        "planner": {
+            "required_before_todo_write": True,
+            "default_profile": "open_ended_product_direction",
+            "profile_selection": (
+                "Use open_ended_product_direction when the user's goal is a broad, "
+                "fuzzy product direction or new initiative. Use clear_bounded_problem "
+                "when the target is a concrete task with a clear success condition. "
+                "In both cases, let the model produce a real ordered plan before writes."
+            ),
+            "profiles": {
+                "open_ended_product_direction": {
+                    "suggested_items_min": 2,
+                    "suggested_items_max": 5,
+                    "intent": (
+                        "turn an ambiguous product direction into public-safe, ranked "
+                        "todo options before execution"
+                    ),
+                },
+                "clear_bounded_problem": {
+                    "item_count_policy": "planner_sized",
+                    "may_reuse_current_todo_when_it_already_represents_the_plan": True,
+                    "intent": (
+                        "make the approach explicit with enough concise ordered todos, "
+                        "without arbitrary caps or management-only filler"
+                    ),
+                },
+            },
+            "allowed_priorities": ["P0", "P1", "P2"],
+            "default_role": "agent",
+            "default_task_class": "advancement_task",
+            "required_fields": ["priority", "text", "task_class", "action_kind"],
+            "public_safe_only": True,
+            "budget_policy": (
+                "For clear bounded problems, planning should sharpen action selection "
+                "rather than crowd out task work; prefer the minimum sufficient ordered "
+                "todo plan over fixed-count filler."
+            ),
+        },
+        "priority_ordering": {
+            "bucket_order": ["P0", "P1", "P2"],
+            "same_priority_tie_breaker": "planner_order_then_todo_write_order",
+            "prompt_constraint": (
+                "Sort planned todos by priority bucket and relative rank before writing. "
+                "For multiple P0/P1/P2 items, earlier items are higher rank; preserve that "
+                "exact order when running todo add commands."
+            ),
+            "storage_contract": (
+                "LoopX status/quota already use todo index as the same-priority tie-breaker, "
+                "so host integrations must write todos in planner order instead of adding "
+                "a separate rank field."
+            ),
+        },
+        "activation": {
+            "after_write": ["refresh-state", "quota should-run"],
+            "begin_automation_when_quota_allows": True,
+            "spend_quota_after_writeback": True,
+        },
+        "connected_at_preview_time": connected,
+        "stop_conditions": [
+            "private material requested before a public-safe todo can be written",
+            "credentials or secrets are required",
+            "destructive git or production operation would be needed",
+            "the host cannot execute shell/CLI/tool calls or persist LoopX state",
+        ],
+    }
+
+
+def _goal_start_prompt(*, goal_text: str | None, goal_id: str, agent_id: str | None) -> str:
+    goal_clause = (
+        f"Goal text: {goal_text}"
+        if goal_text
+        else "Goal text: use the text after `/loopx`; if it is empty, handle bare `/loopx` instead."
+    )
+    agent_clause = f" Use agent id `{agent_id}` for quota/claim commands." if agent_id else ""
+    return f"""Plan before writing todos for `/loopx <goal text>`.
+
+{goal_clause}
+Goal id: {goal_id}.{agent_clause}
+
+Planning rules:
+1. Choose the planning profile: broad or fuzzy product direction uses 2-5 public-safe todos; clear bounded problems use a planner-sized ordered todo plan with enough steps to make the approach explicit.
+2. Plan before any `loopx todo add`; keep each item concise and avoid management-only filler.
+3. Every new todo starts with `[P0]`, `[P1]`, or `[P2]`; include at least one `[P0]` unless the first useful step is blocked by a user gate.
+4. If several todos share the same priority, their listed order is their relative priority. Preserve that exact order when writing them.
+5. Prefer executable Agent Todo items with `task_class=advancement_task`; use User Todo only for concrete owner decisions or private-material gates.
+6. After writing todos, run `loopx refresh-state --goal-id {goal_id}`, then `loopx quota should-run --goal-id {goal_id}` and begin the first allowed bounded segment.
+"""
+
+
 def build_loopx_bootstrap_command_pack(
     *,
     project: Path,
@@ -189,12 +309,15 @@ def build_loopx_bootstrap_command_pack(
     agent_id: str | None,
     cli_bin: str,
     host_surface: str,
+    goal_text: str | None = None,
 ) -> dict[str, Any]:
     inspection = inspect_bootstrap_connection(project, goal_id=goal_id)
     resolved_project = str(inspection["project"])
     resolved_goal_id = str(inspection["goal_id"])
     connected = inspection.get("connection_state") == "connected"
     mutation_confirmation_required = bool(inspection.get("mutation_confirmation_required"))
+    normalized_goal_text = " ".join(goal_text.split()) if goal_text else None
+    explicit_goal_start = bool(normalized_goal_text)
 
     bootstrap_preview_command = _bootstrap_command(
         project=resolved_project,
@@ -216,35 +339,65 @@ def build_loopx_bootstrap_command_pack(
     )
     quota_guard_command = render_quota_guard_command(resolved_goal_id, cli_bin=cli_bin, agent_id=agent_id)
     status_command = _project_command(resolved_project, f"{shell_arg(cli_bin)} status")
+    goal_start_bootstrap_command = _goal_start_bootstrap_command(
+        project=resolved_project,
+        goal_id=resolved_goal_id,
+        goal_text=normalized_goal_text,
+        cli_bin=cli_bin,
+    )
+    goal_start_plan_prompt = _goal_start_prompt(
+        goal_text=normalized_goal_text,
+        goal_id=resolved_goal_id,
+        agent_id=agent_id,
+    )
 
-    recommended_next_step = {
-        "kind": "status_and_loop_activation" if connected else "confirm_before_bootstrap_mutation",
-        "requires_user_confirmation": mutation_confirmation_required,
-        "summary": (
-            "Project is connected; show status, then generate the heartbeat prompt only if the user wants a loop surface."
-            if connected
-            else "Project is not fully connected; show the dry-run preview and ask before running bootstrap/connect."
-        ),
-    }
-    if mutation_confirmation_required:
-        recommended_next_step["dry_run_command"] = bootstrap_preview_command
-        recommended_next_step["after_confirmation_command"] = bootstrap_after_confirmation_command
+    if explicit_goal_start:
+        recommended_next_step = {
+            "kind": "goal_plan_write_and_activate",
+            "requires_user_confirmation": False,
+            "confirmation_source": "/loopx <goal text>",
+            "summary": (
+                "The slash command includes an explicit goal. Connect the project if needed, plan ranked todos, "
+                "write them in exact plan order, refresh state, and enter the quota-gated automation flow."
+            ),
+            "connect_command_if_needed": goal_start_bootstrap_command,
+            "plan_prompt": goal_start_plan_prompt,
+        }
+    else:
+        recommended_next_step = {
+            "kind": "status_and_loop_activation" if connected else "confirm_before_bootstrap_mutation",
+            "requires_user_confirmation": mutation_confirmation_required,
+            "summary": (
+                "Project is connected; show status, then generate the heartbeat prompt only if the user wants a loop surface."
+                if connected
+                else "Project is not fully connected; show the dry-run preview and ask before running bootstrap/connect."
+            ),
+        }
+        if mutation_confirmation_required:
+            recommended_next_step["dry_run_command"] = bootstrap_preview_command
+            recommended_next_step["after_confirmation_command"] = bootstrap_after_confirmation_command
 
     payload: dict[str, Any] = {
         "ok": True,
         "schema_version": SCHEMA_VERSION,
         "slash_command": CANONICAL_SLASH_COMMAND,
+        "slash_forms": [
+            {"form": "/loopx", "mode": "inspect_or_connect_preview"},
+            {"form": "/loopx <goal text>", "mode": "goal_plan_write_and_activate"},
+        ],
         "canonical_cli_command": (
             f"{shell_arg(cli_bin)} bootstrap-command-pack --project {shell_arg(resolved_project)} "
             f"--goal-id {shell_arg(resolved_goal_id)}"
         ),
         "read_only": True,
+        "goal_text": normalized_goal_text,
         "project": resolved_project,
         "goal_id": resolved_goal_id,
         "agent_id": agent_id,
         "host_surface": host_surface,
         "project_connection": inspection,
         "recommended_next_step": recommended_next_step,
+        "goal_start_contract": _goal_start_contract(goal_text=normalized_goal_text, connected=connected),
         "commands": {
             "doctor": f"{shell_arg(cli_bin)} doctor",
             "status": status_command,
@@ -252,6 +405,13 @@ def build_loopx_bootstrap_command_pack(
             "heartbeat_prompt": heartbeat_prompt_command,
             "bootstrap_dry_run_preview": bootstrap_preview_command,
             "bootstrap_after_user_confirmation": bootstrap_after_confirmation_command,
+            "goal_start_connect_if_needed": goal_start_bootstrap_command,
+            "goal_start_plan_prompt": goal_start_plan_prompt,
+            "goal_start_refresh_state": f"{shell_arg(cli_bin)} refresh-state --goal-id {shell_arg(resolved_goal_id)}",
+            "goal_start_quota_should_run": (
+                f"{shell_arg(cli_bin)} quota should-run --goal-id {shell_arg(resolved_goal_id)}"
+                + (f" --agent-id {shell_arg(agent_id)}" if agent_id else "")
+            ),
         },
         "safety_contract": {
             "runs_bootstrap": False,
@@ -259,7 +419,9 @@ def build_loopx_bootstrap_command_pack(
             "writes_state_file": False,
             "creates_heartbeat": False,
             "spends_quota": False,
-            "mutation_requires_user_confirmation": mutation_confirmation_required,
+            "mutation_requires_user_confirmation": mutation_confirmation_required and not explicit_goal_start,
+            "bare_command_mutation_requires_user_confirmation": mutation_confirmation_required,
+            "explicit_goal_start_may_write_project_local_state": explicit_goal_start,
         },
     }
     payload["message"] = render_loopx_bootstrap_command_pack_message(payload)
@@ -276,10 +438,34 @@ def render_loopx_bootstrap_command_pack_message(payload: dict[str, Any]) -> str:
     requires_confirmation = bool(next_step.get("requires_user_confirmation"))
     project = payload.get("project")
     goal_id = payload.get("goal_id")
+    goal_text = payload.get("goal_text")
     state = connection.get("connection_state")
     reason = connection.get("reason")
+    goal_start_contract = payload.get("goal_start_contract")
+    goal_start_contract = goal_start_contract if isinstance(goal_start_contract, dict) else {}
 
-    if requires_confirmation:
+    if goal_text:
+        action = f"""This is an explicit goal-start invocation. Connect project-local LoopX state if needed:
+
+```bash
+{commands.get("goal_start_connect_if_needed", "")}
+```
+
+Then plan before writing todos. Preserve relative priority by write order:
+
+````text
+{commands.get("goal_start_plan_prompt", "")}
+````
+
+Write the planned todos with `loopx todo add` in the exact planned order. Same-priority items use that write order as the tie-breaker.
+
+After todo writeback:
+
+```bash
+{commands.get("goal_start_refresh_state", "")}
+{commands.get("goal_start_quota_should_run", "")}
+```"""
+    elif requires_confirmation:
         action = f"""First show this dry-run preview, then ask me before running the mutation:
 
 ```bash
@@ -304,16 +490,21 @@ Only after I ask for a recurring loop surface, generate the heartbeat body:
 {commands.get("heartbeat_prompt", "")}
 ```"""
 
-    return f"""Handle `{CANONICAL_SLASH_COMMAND}` for this project without hidden mutation.
+    return f"""Handle `{CANONICAL_SLASH_COMMAND}` for this project with explicit mutation boundaries.
 
 Project: `{project}`
 Goal id: `{goal_id}`
+Goal text: `{goal_text or ""}`
 Detected state: `{state}` ({reason})
 
 Rules:
-- This command pack is read-only. Do not run bootstrap/connect, create heartbeat automation, or spend quota while interpreting it.
-- If the project is not fully connected, ask for explicit user confirmation before any command that writes `.loopx/` or `.codex/goals/`.
+- This command pack preview is read-only. Do not run bootstrap/connect, create heartbeat automation, or spend quota while only previewing it.
+- Bare `/loopx` is read/status-first: if the project is not fully connected, ask for explicit user confirmation before any command that writes `.loopx/` or `.codex/goals/`.
+- `/loopx <goal text>` is explicit goal-start intent: it may create project-local LoopX state, but it must run the profile-appropriate planning checkpoint before writing todos.
+- Same-priority todos are ranked by planner order, then by `todo add` write order; preserve the order exactly.
 - If the project is connected, reuse the existing state and show the status/gate/todo snapshot.
+
+Goal-start contract: `{goal_start_contract.get("schema_version")}`
 
 {action}
 
@@ -334,14 +525,20 @@ def render_loopx_bootstrap_command_pack_markdown(payload: dict[str, Any]) -> str
     safety = safety if isinstance(safety, dict) else {}
     commands = payload.get("commands")
     commands = commands if isinstance(commands, dict) else {}
+    goal_start = payload.get("goal_start_contract")
+    goal_start = goal_start if isinstance(goal_start, dict) else {}
+    ordering = goal_start.get("priority_ordering")
+    ordering = ordering if isinstance(ordering, dict) else {}
     return f"""# /loopx Bootstrap Command Pack
 
 Canonical slash command: `{payload.get("slash_command")}`
+Supported forms: `/loopx`, `/loopx <goal text>`
 
 ## Detected Project State
 
 - project: `{payload.get("project")}`
 - goal_id: `{payload.get("goal_id")}`
+- goal_text: `{payload.get("goal_text") or ""}`
 - connection_state: `{connection.get("connection_state")}`
 - reason: `{connection.get("reason")}`
 - registry: `{connection.get("registry")}`
@@ -359,6 +556,13 @@ Canonical slash command: `{payload.get("slash_command")}`
 {payload.get("message", "")}
 ````
 
+## Goal Start Contract
+
+- schema: `{goal_start.get("schema_version")}`
+- planner_required_before_todo_write: `{(goal_start.get("planner") or {}).get("required_before_todo_write") if isinstance(goal_start.get("planner"), dict) else None}`
+- same_priority_tie_breaker: `{ordering.get("same_priority_tie_breaker")}`
+- prompt_constraint: {ordering.get("prompt_constraint")}
+
 ## Key Commands
 
 ```bash
@@ -369,6 +573,10 @@ Canonical slash command: `{payload.get("slash_command")}`
 {commands.get("bootstrap_dry_run_preview", "")}
 ```
 
+```bash
+{commands.get("goal_start_connect_if_needed", "")}
+```
+
 ## Safety Contract
 
 - read_only: `{payload.get("read_only")}`
@@ -376,4 +584,5 @@ Canonical slash command: `{payload.get("slash_command")}`
 - writes_state_file: `{safety.get("writes_state_file")}`
 - creates_heartbeat: `{safety.get("creates_heartbeat")}`
 - spends_quota: `{safety.get("spends_quota")}`
+- explicit_goal_start_may_write_project_local_state: `{safety.get("explicit_goal_start_may_write_project_local_state")}`
 """

--- a/loopx/cli_commands/starter_bootstrap.py
+++ b/loopx/cli_commands/starter_bootstrap.py
@@ -52,6 +52,13 @@ def register_starter_bootstrap_commands(subparsers: argparse._SubParsersAction) 
         help="Host surface where the slash command pack will be exposed.",
     )
     bootstrap_command_pack_parser.add_argument(
+        "--goal-text",
+        help=(
+            "Optional text after /loopx. When present, preview the explicit goal-start flow: "
+            "connect if needed, plan ranked todos, write them in order, then enter quota-gated automation."
+        ),
+    )
+    bootstrap_command_pack_parser.add_argument(
         "--message-only",
         "--copy-only",
         dest="message_only",
@@ -174,6 +181,7 @@ def handle_loopx_bootstrap_command_pack_command(
         agent_id=args.agent_id,
         cli_bin=args.cli_bin,
         host_surface=args.host_surface,
+        goal_text=args.goal_text,
     )
     if bool(getattr(args, "message_only", False)):
         print(str(payload.get("message") or ""))

--- a/skills/loopx-project/SKILL.md
+++ b/skills/loopx-project/SKILL.md
@@ -23,6 +23,49 @@ Do not manually copy one project's registry entry into another project. Local
 `connect` and `refresh-state` should sync into the shared global registry
 automatically.
 
+## Slash Command Fallback
+
+When the visible user message is exactly a LoopX slash command or starts with a
+LoopX slash command plus arguments, do not treat it as ordinary chat.
+
+Recognized project-local commands:
+
+- `/loopx`
+- `/loopx <goal text>`
+
+From the target project root, run the bootstrap command pack before planning or
+writing project state:
+
+```bash
+loopx bootstrap-command-pack --project .
+```
+
+For `/loopx <goal text>`, pass the text after `/loopx` as the explicit
+goal-start objective:
+
+```bash
+loopx bootstrap-command-pack --project . --goal-text "<GOAL_TEXT>"
+```
+
+Include `--goal-id <STABLE_GOAL_ID>` and `--agent-id <REGISTERED_AGENT_ID>` when
+they are known. If `--goal-text` is not available, refresh the local LoopX CLI
+or use the checked-out LoopX repository CLI for validation; do not silently
+downgrade `/loopx <goal text>` into a bare `/loopx` read-only command.
+
+Bare `/loopx` is read/status-first: inspect the returned command pack, stop
+before registry/state writes that require confirmation, and keep quota unspent
+while only previewing the pack. `/loopx <goal text>` is an explicit goal-start
+intent: first produce a concise ordered plan, then write todos in priority
+order, using planner order plus `todo add` write order as the same-priority
+tie-breaker. For broad or fuzzy product directions, use a small
+public-safe planning set; for clear bounded problems, use the minimum
+sufficient ordered todo plan and avoid management-only filler.
+
+Global manager slash commands such as `/loop-global-summary`,
+`/loop-global-gates`, `/loop-global-todos`, and `/loop-global-risks` are not
+project bootstrap commands. Route them to the global manager command contract
+or status summary surface instead of `bootstrap-command-pack`.
+
 ## Register Project Authority And Material Sources
 
 When a project agent discovers a durable design document, research note,


### PR DESCRIPTION
## Summary
- extend the `/loopx` command pack with `/loopx <goal text>` goal-start handling
- define the goal-start planning contract: plan 2-5 public-safe todos, preserve same-priority order by write order, refresh state, then run quota should-run
- document the project-local `/loopx` protocol separately from `/loop-global-*` read-only manager commands

## Validation
- python3 examples/bootstrap-command-pack-smoke.py
- python3 -m py_compile loopx/bootstrap_command_pack.py loopx/cli_commands/starter_bootstrap.py

## Notes
- Bare `/loopx` remains read/status-first and asks before project-local bootstrap/connect writes.
- `/loopx <goal text>` is explicit goal-start intent and may write project-local state after planning.