### PR TITLE
Use loopx prefix for global slash commands

### DIFF
--- a/docs/reference/protocols/global-manager-command-v0.md
+++ b/docs/reference/protocols/global-manager-command-v0.md
@@ -1,8 +1,8 @@
 # global_manager_command_v0
 
 `global_manager_command_v0` is a read-first protocol for operator commands
-such as `/loop-global-summary`, `/loop-global-gates`, `/loop-global-todos`,
-and `/loop-global-risks`.
+such as `/loopx-global-summary`, `/loopx-global-gates`,
+`/loopx-global-todos`, and `/loopx-global-risks`.
 
 The product goal is to let a user act as a manager across long-running agent
 work: ask for the last day of progress, see blocked decisions, compare agent
@@ -12,7 +12,7 @@ This protocol is not a general chat-command router yet. It defines the
 request, allowed sources, response shape, privacy boundary, and action ladder
 for Codex hosts, CLI wrappers, or dashboard command palettes. The first CLI
 wrapper is `loopx global-summary`, which returns the canonical
-`/loop-global-summary` response.
+`/loopx-global-summary` response.
 
 ## Command Set
 
@@ -20,15 +20,26 @@ Recommended first commands:
 
 | Command | User intent | Default source window |
 | --- | --- | --- |
-| `/loop-global-summary <time range>` | Show progress, completed work, active lanes, and next decisions. | 24 hours |
-| `/loop-global-gates` | Show open user/controller gates and what each blocks. | current state |
-| `/loop-global-todos` | Show top runnable, blocked, deferred-ready, and review todos. | current state |
-| `/loop-global-risks` | Show stale runs, public/private boundary warnings, failing checks, and rollback candidates. | 24 hours |
+| `/loopx-global-summary <time range>` | Show progress, completed work, active lanes, and next decisions. | 24 hours |
+| `/loopx-global-gates` | Show open user/controller gates and what each blocks. | current state |
+| `/loopx-global-todos` | Show top runnable, blocked, deferred-ready, and review todos. | current state |
+| `/loopx-global-risks` | Show stale runs, public/private boundary warnings, failing checks, and rollback candidates. | 24 hours |
 | `/loop-goal-summary <goal id>` | Drill into one goal without scanning unrelated projects. | 24 hours |
 
 Commands are read-only by default. They can propose follow-up actions, but
 they do not approve gates, promote suggested todos, spend quota, merge PRs,
 pause automations, or run destructive operations.
+
+Legacy `/loop-global-*` forms may be accepted as aliases during migration, but
+hosts should canonicalize command packets and user-facing help to the
+`/loopx-global-*` names.
+
+| Legacy alias | Canonical command |
+| --- | --- |
+| `/loop-global-summary` | `/loopx-global-summary` |
+| `/loop-global-gates` | `/loopx-global-gates` |
+| `/loop-global-todos` | `/loopx-global-todos` |
+| `/loop-global-risks` | `/loopx-global-risks` |
 
 Related project-local command: `/loopx <goal text>` is covered by
 [`loopx_goal_command_v0`](loopx-goal-command-v0.md). It is not a global manager
@@ -40,7 +51,8 @@ and then enters the quota-gated automation flow.
 ```json
 {
   "schema_version": "global_manager_command_request_v0",
-  "command": "/loop-global-summary",
+  "command": "/loopx-global-summary",
+  "legacy_aliases": ["/loop-global-summary"],
   "time_range": "24h",
   "goal_filter": ["loopx-meta"],
   "agent_filter": ["codex-main-control", "codex-side-bypass"],
@@ -83,7 +95,7 @@ payloads, credentials, local absolute paths, or private source bodies.
 {
   "schema_version": "global_manager_command_response_v0",
   "request": {
-    "command": "/loop-global-summary",
+    "command": "/loopx-global-summary",
     "time_range": "24h"
   },
   "generated_at": "2026-06-24T00:00:00Z",

--- a/docs/reference/protocols/loopx-goal-command-v0.md
+++ b/docs/reference/protocols/loopx-goal-command-v0.md
@@ -7,7 +7,7 @@
 | `/loopx` | Inspect or preview project connection. | Read-first; ask before bootstrap/connect writes. |
 | `/loopx <goal text>` | Start a concrete goal, plan ranked todos, and enter the LoopX automation flow. | Explicit invocation may write project-local LoopX state and todos. |
 
-This command is intentionally separate from `/loop-global-*`: global commands
+This command is intentionally separate from `/loopx-global-*`: global commands
 summarize and manage visible control-plane state across projects, while
 `/loopx <goal text>` starts or continues one project goal.
 

--- a/examples/bootstrap-command-pack-smoke.py
+++ b/examples/bootstrap-command-pack-smoke.py
@@ -185,7 +185,8 @@ def test_skill_slash_fallback_contract() -> None:
     assert "explicit goal-start intent" in normalized
     assert "planner order plus `todo add` write order" in normalized
     assert "do not silently downgrade `/loopx <goal text>`" in normalized
-    assert "`/loop-global-summary`" in skill_text
+    assert "`/loopx-global-summary`" in skill_text
+    assert "Legacy `/loop-global-*` forms" in normalized
     assert "not project bootstrap commands" in normalized
 
 

--- a/examples/fixtures/global-manager-command.public.json
+++ b/examples/fixtures/global-manager-command.public.json
@@ -2,7 +2,10 @@
   "schema_version": "global_manager_command_response_v0",
   "request": {
     "schema_version": "global_manager_command_request_v0",
-    "command": "/loop-global-summary",
+    "command": "/loopx-global-summary",
+    "legacy_aliases": [
+      "/loop-global-summary"
+    ],
     "time_range": "24h",
     "goal_filter": [
       "loopx-meta"

--- a/examples/global-manager-command-cli-smoke.py
+++ b/examples/global-manager-command-cli-smoke.py
@@ -93,7 +93,8 @@ def main() -> int:
     payload = json.loads(proc.stdout)
     assert payload["schema_version"] == "global_manager_command_response_v0", payload
     request = payload["request"]
-    assert request["command"] == "/loop-global-summary", request
+    assert request["command"] == "/loopx-global-summary", request
+    assert "/loop-global-summary" in request["legacy_aliases"], request
     assert request["cli_command"] == "loopx global-summary", request
     assert request["privacy_mode"] == "public_safe_summary", request
     assert request["dry_run"] is True, request

--- a/examples/global-manager-command-protocol-smoke.py
+++ b/examples/global-manager-command-protocol-smoke.py
@@ -17,11 +17,17 @@ LONG_HORIZON_PATH = (
 FIXTURE_PATH = REPO_ROOT / "examples" / "fixtures" / "global-manager-command.public.json"
 
 REQUIRED_COMMANDS = {
+    "/loopx-global-summary",
+    "/loopx-global-gates",
+    "/loopx-global-todos",
+    "/loopx-global-risks",
+    "/loop-goal-summary",
+}
+LEGACY_COMMAND_ALIASES = {
     "/loop-global-summary",
     "/loop-global-gates",
     "/loop-global-todos",
     "/loop-global-risks",
-    "/loop-goal-summary",
 }
 REJECTED_COMMAND_ALIASES = {
     "/loopx-summary-all",
@@ -82,6 +88,8 @@ def main() -> int:
     assert_contains(long_horizon, "global_manager_command_v0", "long horizon protocol")
     for command in REQUIRED_COMMANDS:
         assert_contains(contract, command, "command set")
+    for command in LEGACY_COMMAND_ALIASES:
+        assert_contains(contract, command, "legacy alias note")
     for command in REJECTED_COMMAND_ALIASES:
         if command in contract:
             raise AssertionError(f"command set should not include superseded alias {command!r}")
@@ -99,6 +107,7 @@ def main() -> int:
     request = payload["request"]
     assert request["schema_version"] == "global_manager_command_request_v0", request
     assert request["command"] in REQUIRED_COMMANDS, request
+    assert "/loop-global-summary" in request.get("legacy_aliases", []), request
     assert request["privacy_mode"] == "public_safe_summary", request
     assert request["dry_run"] is True, request
 

--- a/loopx/cli_commands/summary_all.py
+++ b/loopx/cli_commands/summary_all.py
@@ -29,7 +29,7 @@ def register_summary_all_command(
 ) -> None:
     parser = subparsers.add_parser(
         "global-summary",
-        help="Read a public-safe /loop-global-summary progress digest across visible LoopX goals.",
+        help="Read a public-safe /loopx-global-summary progress digest across visible LoopX goals.",
     )
     add_subcommand_format(parser)
     parser.add_argument("--agent-id", help="Registered agent id for agent-lane quota projection.")
@@ -73,7 +73,8 @@ def handle_summary_all_command(
             "schema_version": "global_manager_command_response_v0",
             "request": {
                 "schema_version": "global_manager_command_request_v0",
-                "command": "/loop-global-summary",
+                "command": "/loopx-global-summary",
+                "legacy_aliases": ["/loop-global-summary"],
                 "privacy_mode": "public_safe_summary",
                 "dry_run": True,
             },

--- a/loopx/summary_all.py
+++ b/loopx/summary_all.py
@@ -11,7 +11,11 @@ from .quota import build_quota_should_run
 from .status import collect_status
 
 
-COMMAND = "/loop-global-summary"
+COMMAND = "/loopx-global-summary"
+LEGACY_COMMAND_ALIASES = {
+    "/loopx-summary-all": COMMAND,
+    "/loop-global-summary": COMMAND,
+}
 SCHEMA_VERSION = "global_manager_command_response_v0"
 
 BOUNDARY = {
@@ -75,7 +79,8 @@ def _parse_datetime(value: object) -> datetime | None:
 
 def _redact_text(value: object, *, limit: int = 260) -> str:
     text = str(value or "").strip()
-    text = text.replace("/loopx-summary-all", "/loop-global-summary")
+    for alias, canonical in LEGACY_COMMAND_ALIASES.items():
+        text = text.replace(alias, canonical)
     for pattern in LOCAL_PATH_PATTERNS:
         text = pattern.sub("<local-path-redacted>", text)
     text = re.sub(r"\s+", " ", text)
@@ -319,6 +324,7 @@ def build_summary_all(
         "request": {
             "schema_version": "global_manager_command_request_v0",
             "command": COMMAND,
+            "legacy_aliases": ["/loop-global-summary"],
             "cli_command": "loopx global-summary",
             "time_range": normalized_range,
             "include": ["progress", "gates", "todos", "risks", "next_actions"],

--- a/skills/loopx-project/SKILL.md
+++ b/skills/loopx-project/SKILL.md
@@ -61,10 +61,12 @@ tie-breaker. For broad or fuzzy product directions, use a small
 public-safe planning set; for clear bounded problems, use the minimum
 sufficient ordered todo plan and avoid management-only filler.
 
-Global manager slash commands such as `/loop-global-summary`,
-`/loop-global-gates`, `/loop-global-todos`, and `/loop-global-risks` are not
+Global manager slash commands such as `/loopx-global-summary`,
+`/loopx-global-gates`, `/loopx-global-todos`, and `/loopx-global-risks` are not
 project bootstrap commands. Route them to the global manager command contract
-or status summary surface instead of `bootstrap-command-pack`.
+or status summary surface instead of `bootstrap-command-pack`. Legacy
+`/loop-global-*` forms may be treated as aliases, but canonical help and
+packets should use `/loopx-global-*`.
 
 ## Register Project Authority And Material Sources
 


### PR DESCRIPTION
## Summary
- rename the global manager slash command canonical forms to `/loopx-global-*`
- keep `/loop-global-*` only as migration aliases in docs and response metadata
- update global-summary payloads, repo skill guidance, fixtures, and smokes

## Validation
- python3 examples/global-manager-command-protocol-smoke.py
- python3 examples/global-manager-command-cli-smoke.py
- python3 examples/bootstrap-command-pack-smoke.py
- python3 -m py_compile loopx/summary_all.py loopx/cli_commands/summary_all.py
- git diff --check
- python3 -m loopx.cli check --scan-path docs/reference/protocols/global-manager-command-v0.md --scan-path docs/reference/protocols/loopx-goal-command-v0.md --scan-path skills/loopx-project/SKILL.md --scan-path loopx/summary_all.py --scan-path loopx/cli_commands/summary_all.py --scan-path examples/global-manager-command-protocol-smoke.py --scan-path examples/bootstrap-command-pack-smoke.py --scan-path examples/global-manager-command-cli-smoke.py --scan-path examples/fixtures/global-manager-command.public.json
