### PR TITLE
Fail closed product-mode bridge auto-wiring

### DIFF
--- a/examples/skillsbench-host-local-launch-plan-smoke.py
+++ b/examples/skillsbench-host-local-launch-plan-smoke.py
@@ -530,6 +530,39 @@ if out:
             probe_only_failure["remote_command_file_bridge_consumption_status"]
             == "sandbox_bridge_auto_wiring_pending"
         )
+        blocked_auto_wiring_full_run = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--skillsbench-root",
+                str(root),
+                "--task-id",
+                "demo-task",
+                "--route",
+                "loopx-product-mode",
+                "--host-local-acp-launch",
+                "--remote-command-file-bridge-ready",
+            ],
+            cwd=REPO_ROOT,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        assert blocked_auto_wiring_full_run.returncode == 2, (
+            blocked_auto_wiring_full_run
+        )
+        auto_wiring_failure = json.loads(blocked_auto_wiring_full_run.stderr)
+        assert auto_wiring_failure["error_type"] == (
+            "SkillsBenchProductModeBridgeAutoWiringPending"
+        ), auto_wiring_failure
+        assert (
+            auto_wiring_failure["remote_command_file_bridge_consumption_status"]
+            == "sandbox_bridge_auto_wiring_pending"
+        ), auto_wiring_failure
+        assert auto_wiring_failure["raw_task_text_read"] is False
+        assert auto_wiring_failure["raw_trajectory_recorded"] is False
         blocked_fixture_solver = subprocess.run(
             [
                 sys.executable,

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -9001,6 +9001,48 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps(payload, indent=2, sort_keys=True), file=sys.stderr)
         return 2
     if (
+        args.route == "loopx-product-mode"
+        and args.host_local_acp_launch
+        and product_host_local_bridge_sandbox_auto_wiring_pending
+        and not args.local_driver_worker_handshake_preflight
+        and not args.plan_only
+        and not args.reduce_only
+    ):
+        payload = {
+            "ok": False,
+            "error_type": "SkillsBenchProductModeBridgeAutoWiringPending",
+            "route": args.route,
+            "reason": (
+                "loopx-product-mode is countable only when the host-local "
+                "agent has an explicit sandbox command/file bridge available "
+                "before the scored case starts. A readiness declaration without "
+                "a solver bridge command leaves sandbox bridge auto-wiring "
+                "pending; prior runs can reach the agent with zero task-facing "
+                "bridge/tool calls, then fail after consuming a scored attempt."
+            ),
+            "next_action": (
+                "rerun with a real --remote-command-file-bridge-solver-command "
+                "and a countable agent bridge command or instrumented wrapper; "
+                "use --plan-only or --local-driver-worker-handshake-preflight "
+                "for non-executing readiness inspection"
+            ),
+            "remote_command_file_bridge_materialized": (
+                product_host_local_bridge_materialized
+            ),
+            "remote_command_file_bridge_command_configured": False,
+            "remote_command_file_bridge_solver_wiring_configured": False,
+            "remote_command_file_bridge_consumed_by_solver": False,
+            "remote_command_file_bridge_consumption_status": (
+                "sandbox_bridge_auto_wiring_pending"
+            ),
+            "raw_logs_recorded": False,
+            "raw_task_text_read": False,
+            "raw_trajectory_recorded": False,
+            "credential_values_recorded": False,
+        }
+        print(json.dumps(payload, indent=2, sort_keys=True), file=sys.stderr)
+        return 2
+    if (
         args.route in {"raw-codex-autonomous-max5", "loopx-product-mode"}
         and args.host_local_acp_launch
         and not (


### PR DESCRIPTION
## Summary
- fail closed loopx-product-mode host-local launches when bridge readiness is only sandbox auto-wiring pending
- keep plan-only / handshake preflight available for non-executing inspection
- add smoke coverage proving full launch blocks before raw task/trajectory reads

## Validation
- python3 -m py_compile scripts/skillsbench_automation_loop.py examples/skillsbench-host-local-launch-plan-smoke.py
- python3 examples/skillsbench-host-local-launch-plan-smoke.py
- organize-messy-files launch shape now returns SkillsBenchProductModeBridgeAutoWiringPending before case launch, with raw_task_text_read=false and raw_trajectory_recorded=false

## Boundary
- no scoring changes
- no benchmark uploads or submissions
- no raw task text, raw trajectories, verifier output tails, credentials, or local private artifacts included