### PR TITLE
Add LoopX slash command onboarding help

### DIFF
--- a/docs/reference/protocols/loopx-goal-command-v0.md
+++ b/docs/reference/protocols/loopx-goal-command-v0.md
@@ -24,6 +24,10 @@ When the user provides text after `/loopx`, the host should:
 
 The command pack preview is still read-only. It describes the commands and
 contracts; the slash invocation is what authorizes project-local state writes.
+New-user surfaces should also show the compact slash command catalog from the
+command pack, or the equivalent `loopx slash-commands` CLI help, so users can
+discover `/loopx`, `/loopx <goal text>`, and the `/loopx-global-*` read-only
+manager commands.
 
 ## Planning Contract
 

--- a/examples/bootstrap-command-pack-smoke.py
+++ b/examples/bootstrap-command-pack-smoke.py
@@ -44,6 +44,18 @@ def test_missing_project_stops_before_mutation() -> None:
         assert payload["schema_version"] == "loopx_bootstrap_command_pack_v0"
         assert payload["slash_command"] == "/loopx"
         assert {"form": "/loopx <goal text>", "mode": "goal_plan_write_and_activate"} in payload["slash_forms"]
+        slash_catalog = payload["available_slash_commands"]
+        assert isinstance(slash_catalog, dict)
+        assert slash_catalog["schema_version"] == "loopx_slash_command_catalog_v0"
+        command_names = {item["command"] for item in slash_catalog["commands"]}
+        assert "/loopx" in command_names
+        assert "/loopx <goal text>" in command_names
+        assert "/loopx-global-summary" in command_names
+        assert "/loopx-global-gates" in command_names
+        onboarding = payload["onboarding_hint"]
+        assert onboarding["tell_new_users"] is True
+        assert "LoopX command surface is available. Useful commands:" in onboarding["suggested_user_note"]
+        assert "loopx slash-commands" in onboarding["suggested_user_note"]
         assert payload["read_only"] is True
         assert connection["connection_state"] == "not_connected"
         assert connection["mutation_confirmation_required"] is True
@@ -187,6 +199,7 @@ def test_skill_slash_fallback_contract() -> None:
     assert "do not silently downgrade `/loopx <goal text>`" in normalized
     assert "`/loopx-global-summary`" in skill_text
     assert "Legacy `/loop-global-*` forms" in normalized
+    assert "loopx slash-commands" in skill_text
     assert "not project bootstrap commands" in normalized
 
 

--- a/examples/slash-command-catalog-smoke.py
+++ b/examples/slash-command-catalog-smoke.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Smoke-test the LoopX slash command catalog and CLI help."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "loopx.cli", *args],
+        cwd=REPO_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+
+
+def main() -> int:
+    payload = json.loads(run_cli("--format", "json", "slash-commands").stdout)
+    assert payload["schema_version"] == "loopx_slash_command_catalog_v0", payload
+    assert payload["canonical_prefix"] == "/loopx", payload
+    commands = {item["command"]: item for item in payload["commands"]}
+    for command in [
+        "/loopx",
+        "/loopx <goal text>",
+        "/loopx-global-summary",
+        "/loopx-global-gates",
+        "/loopx-global-todos",
+        "/loopx-global-risks",
+    ]:
+        assert command in commands, commands
+    assert "/loop-global-summary" in commands["/loopx-global-summary"]["legacy_aliases"]
+    assert "/loopx-summary-all" not in json.dumps(payload)
+    onboarding = payload["onboarding"]
+    assert onboarding["tell_new_users"] is True, onboarding
+    assert "CLI help: `loopx slash-commands`." in onboarding["suggested_user_note"], onboarding
+
+    compact = json.loads(run_cli("--format", "json", "slash-commands", "--no-legacy-aliases").stdout)
+    compact_text = json.dumps(compact)
+    assert "/loop-global-summary" not in compact_text, compact
+
+    markdown = run_cli("slash-commands").stdout
+    assert "# LoopX Slash Commands" in markdown, markdown
+    assert "`/loopx-global-summary`" in markdown, markdown
+    assert "`loopx global-summary`" in markdown, markdown
+    assert "`/loopx-summary-all`" not in markdown, markdown
+
+    top_help = run_cli("--help").stdout
+    assert "slash-commands" in top_help, top_help
+
+    print("slash-command-catalog-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/bootstrap_command_pack.py
+++ b/loopx/bootstrap_command_pack.py
@@ -13,6 +13,7 @@ from .project_prompt import (
     shell_arg,
 )
 from .registry import registry_goals, resolve_state_file
+from .slash_commands import build_slash_command_catalog
 
 
 SCHEMA_VERSION = "loopx_bootstrap_command_pack_v0"
@@ -350,6 +351,7 @@ def build_loopx_bootstrap_command_pack(
         goal_id=resolved_goal_id,
         agent_id=agent_id,
     )
+    slash_command_catalog = build_slash_command_catalog(cli_bin=cli_bin)
 
     if explicit_goal_start:
         recommended_next_step = {
@@ -396,6 +398,8 @@ def build_loopx_bootstrap_command_pack(
         "agent_id": agent_id,
         "host_surface": host_surface,
         "project_connection": inspection,
+        "available_slash_commands": slash_command_catalog,
+        "onboarding_hint": slash_command_catalog["onboarding"],
         "recommended_next_step": recommended_next_step,
         "goal_start_contract": _goal_start_contract(goal_text=normalized_goal_text, connected=connected),
         "commands": {
@@ -443,6 +447,8 @@ def render_loopx_bootstrap_command_pack_message(payload: dict[str, Any]) -> str:
     reason = connection.get("reason")
     goal_start_contract = payload.get("goal_start_contract")
     goal_start_contract = goal_start_contract if isinstance(goal_start_contract, dict) else {}
+    onboarding = payload.get("onboarding_hint")
+    onboarding = onboarding if isinstance(onboarding, dict) else {}
 
     if goal_text:
         action = f"""This is an explicit goal-start invocation. Connect project-local LoopX state if needed:
@@ -506,6 +512,12 @@ Rules:
 
 Goal-start contract: `{goal_start_contract.get("schema_version")}`
 
+Suggested new-user note:
+
+```text
+{onboarding.get("suggested_user_note", "")}
+```
+
 {action}
 
 For ongoing work after the project is connected, use the quota guard:
@@ -525,6 +537,10 @@ def render_loopx_bootstrap_command_pack_markdown(payload: dict[str, Any]) -> str
     safety = safety if isinstance(safety, dict) else {}
     commands = payload.get("commands")
     commands = commands if isinstance(commands, dict) else {}
+    onboarding = payload.get("onboarding_hint")
+    onboarding = onboarding if isinstance(onboarding, dict) else {}
+    slash_catalog = payload.get("available_slash_commands")
+    slash_catalog = slash_catalog if isinstance(slash_catalog, dict) else {}
     goal_start = payload.get("goal_start_contract")
     goal_start = goal_start if isinstance(goal_start, dict) else {}
     ordering = goal_start.get("priority_ordering")
@@ -549,6 +565,14 @@ Supported forms: `/loopx`, `/loopx <goal text>`
 - kind: `{next_step.get("kind")}`
 - requires_user_confirmation: `{next_step.get("requires_user_confirmation")}`
 - summary: {next_step.get("summary")}
+
+## New User Command Hint
+
+````text
+{onboarding.get("suggested_user_note", "")}
+````
+
+- CLI help: `{(slash_catalog.get("help") or {}).get("cli_command") if isinstance(slash_catalog.get("help"), dict) else "loopx slash-commands"}`
 
 ## Paste Message
 

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -33,6 +33,7 @@ from .cli_commands import (
     handle_quota_command,
     handle_registry_admin_command,
     handle_review_packet_command,
+    handle_slash_commands_command,
     handle_status_command,
     handle_starter_command,
     handle_summary_all_command,
@@ -50,6 +51,7 @@ from .cli_commands import (
     register_project_lifecycle_commands,
     register_quota_command,
     register_registry_admin_commands,
+    register_slash_commands_command,
     register_starter_commands,
     register_status_commands,
     register_summary_all_command,
@@ -148,6 +150,7 @@ def main(argv: list[str] | None = None) -> int:
 
     register_status_commands(sub, add_subcommand_format)
     register_summary_all_command(sub, add_subcommand_format)
+    register_slash_commands_command(sub, add_subcommand_format)
     register_dreaming_commands(sub, add_subcommand_format)
     register_todo_command(sub)
     register_quota_command(sub)
@@ -178,6 +181,7 @@ def main(argv: list[str] | None = None) -> int:
             "demo",
             "doctor",
             "new-project-prompt",
+            "slash-commands",
             "heartbeat-prompt",
             "sync-global",
             "uninstall-project",
@@ -339,6 +343,14 @@ def main(argv: list[str] | None = None) -> int:
     )
     if summary_all_result is not None:
         return summary_all_result
+
+    slash_commands_result = handle_slash_commands_command(
+        args,
+        output_format=output_format,
+        print_payload=print_payload,
+    )
+    if slash_commands_result is not None:
+        return slash_commands_result
 
     if args.command == "dreaming":
         return handle_dreaming_command(

--- a/loopx/cli_commands/__init__.py
+++ b/loopx/cli_commands/__init__.py
@@ -91,6 +91,7 @@ from .registry_admin import (
     handle_registry_admin_command,
     register_registry_admin_commands,
 )
+from .slash_commands import handle_slash_commands_command, register_slash_commands_command
 from .starter import (
     handle_demo_command,
     handle_starter_command,
@@ -206,6 +207,7 @@ __all__ = [
     "handle_quota_command",
     "handle_registry_admin_command",
     "handle_review_packet_command",
+    "handle_slash_commands_command",
     "handle_status_command",
     "handle_starter_command",
     "handle_starter_bootstrap_command",
@@ -245,6 +247,7 @@ __all__ = [
     "register_project_lifecycle_commands",
     "register_quota_command",
     "register_registry_admin_commands",
+    "register_slash_commands_command",
     "register_starter_commands",
     "register_starter_bootstrap_commands",
     "register_starter_scheduler_commands",

--- a/loopx/cli_commands/slash_commands.py
+++ b/loopx/cli_commands/slash_commands.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+
+from ..slash_commands import build_slash_command_catalog, render_slash_command_catalog_markdown
+
+
+PrintPayload = Callable[
+    [dict[str, object], str, Callable[[dict[str, object]], str]],
+    None,
+]
+FormatSelector = Callable[..., str]
+
+
+def register_slash_commands_command(
+    subparsers: argparse._SubParsersAction,
+    add_subcommand_format: Callable[[argparse.ArgumentParser], None],
+) -> None:
+    parser = subparsers.add_parser(
+        "slash-commands",
+        help="List LoopX chat slash commands, onboarding hints, and CLI references.",
+    )
+    add_subcommand_format(parser)
+    parser.add_argument(
+        "--cli-bin",
+        default="loopx",
+        help="LoopX CLI binary name to show in command references.",
+    )
+    parser.add_argument(
+        "--no-legacy-aliases",
+        action="store_true",
+        help="Hide legacy /loop-global-* aliases from the command catalog.",
+    )
+
+
+def handle_slash_commands_command(
+    args: argparse.Namespace,
+    *,
+    output_format: FormatSelector,
+    print_payload: PrintPayload,
+) -> int | None:
+    if args.command != "slash-commands":
+        return None
+    payload = build_slash_command_catalog(
+        cli_bin=args.cli_bin,
+        include_legacy_aliases=not bool(args.no_legacy_aliases),
+    )
+    print_payload(payload, output_format(args), render_slash_command_catalog_markdown)
+    return 0

--- a/loopx/cli_commands/summary_all.py
+++ b/loopx/cli_commands/summary_all.py
@@ -29,7 +29,7 @@ def register_summary_all_command(
 ) -> None:
     parser = subparsers.add_parser(
         "global-summary",
-        help="Read a public-safe /loopx-global-summary progress digest across visible LoopX goals.",
+        help="Read a public-safe /loopx-global-summary progress digest; see `loopx slash-commands` for slash help.",
     )
     add_subcommand_format(parser)
     parser.add_argument("--agent-id", help="Registered agent id for agent-lane quota projection.")

--- a/loopx/slash_commands.py
+++ b/loopx/slash_commands.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+SCHEMA_VERSION = "loopx_slash_command_catalog_v0"
+
+
+def _command(
+    *,
+    command: str,
+    scope: str,
+    intent: str,
+    mutation_policy: str,
+    cli_reference: str,
+    legacy_aliases: list[str] | None = None,
+    implementation_status: str = "available",
+) -> dict[str, Any]:
+    item: dict[str, Any] = {
+        "command": command,
+        "scope": scope,
+        "intent": intent,
+        "mutation_policy": mutation_policy,
+        "cli_reference": cli_reference,
+        "implementation_status": implementation_status,
+    }
+    if legacy_aliases:
+        item["legacy_aliases"] = legacy_aliases
+    return item
+
+
+def build_slash_command_catalog(
+    *,
+    cli_bin: str = "loopx",
+    include_legacy_aliases: bool = True,
+) -> dict[str, Any]:
+    legacy_summary = ["/loop-global-summary"] if include_legacy_aliases else []
+    legacy_gates = ["/loop-global-gates"] if include_legacy_aliases else []
+    legacy_todos = ["/loop-global-todos"] if include_legacy_aliases else []
+    legacy_risks = ["/loop-global-risks"] if include_legacy_aliases else []
+    commands = [
+        _command(
+            command="/loopx",
+            scope="project",
+            intent="Inspect or preview this project's LoopX connection, status, gates, and next safe action.",
+            mutation_policy="read_first; ask before bootstrap/connect writes",
+            cli_reference=f"{cli_bin} bootstrap-command-pack --project .",
+        ),
+        _command(
+            command="/loopx <goal text>",
+            scope="project",
+            intent="Start a concrete project goal: plan ordered todos, write them in priority order, then enter the quota-gated loop.",
+            mutation_policy="explicit goal-start intent may write project-local LoopX state after planning",
+            cli_reference=f"{cli_bin} bootstrap-command-pack --project . --goal-text '<goal text>'",
+        ),
+        _command(
+            command="/loopx-global-summary",
+            scope="global",
+            intent="Read a progress digest across visible LoopX goals.",
+            mutation_policy="read_only",
+            cli_reference=f"{cli_bin} global-summary",
+            legacy_aliases=legacy_summary,
+        ),
+        _command(
+            command="/loopx-global-gates",
+            scope="global",
+            intent="List open user/controller gates and what each blocks.",
+            mutation_policy="read_only",
+            cli_reference=f"{cli_bin} slash-commands; use {cli_bin} global-summary for the current compact global packet",
+            legacy_aliases=legacy_gates,
+            implementation_status="host_command_defined",
+        ),
+        _command(
+            command="/loopx-global-todos",
+            scope="global",
+            intent="List top runnable, blocked, deferred-ready, and review todos across visible goals.",
+            mutation_policy="read_only",
+            cli_reference=f"{cli_bin} slash-commands; use {cli_bin} global-summary for the current compact global packet",
+            legacy_aliases=legacy_todos,
+            implementation_status="host_command_defined",
+        ),
+        _command(
+            command="/loopx-global-risks",
+            scope="global",
+            intent="Show stale runs, boundary risks, failing checks, and rollback candidates.",
+            mutation_policy="read_only",
+            cli_reference=f"{cli_bin} slash-commands; use {cli_bin} global-summary for the current compact global packet",
+            legacy_aliases=legacy_risks,
+            implementation_status="host_command_defined",
+        ),
+    ]
+    return {
+        "ok": True,
+        "schema_version": SCHEMA_VERSION,
+        "canonical_prefix": "/loopx",
+        "commands": commands,
+        "onboarding": {
+            "tell_new_users": True,
+            "suggested_user_note": render_onboarding_slash_command_note(commands, cli_bin=cli_bin),
+        },
+        "help": {
+            "cli_command": f"{cli_bin} slash-commands",
+            "legacy_alias_policy": "legacy /loop-global-* forms may be accepted during migration, but help should show /loopx-global-* as canonical",
+        },
+    }
+
+
+def render_onboarding_slash_command_note(commands: list[dict[str, Any]], *, cli_bin: str = "loopx") -> str:
+    command_by_name = {str(item.get("command")): item for item in commands}
+    project = command_by_name.get("/loopx", {})
+    goal = command_by_name.get("/loopx <goal text>", {})
+    return "\n".join(
+        [
+            "LoopX command surface is available. Useful commands:",
+            f"- `/loopx`: {project.get('intent', 'inspect this project')}",
+            f"- `/loopx <goal text>`: {goal.get('intent', 'start a concrete project goal')}",
+            "- `/loopx-global-summary`: read the global progress digest.",
+            "- `/loopx-global-gates`, `/loopx-global-todos`, `/loopx-global-risks`: inspect manager-level gates, work, and risks.",
+            f"CLI help: `{cli_bin} slash-commands`.",
+        ]
+    )
+
+
+def render_slash_command_catalog_markdown(payload: dict[str, Any]) -> str:
+    if not payload.get("ok"):
+        return "# LoopX Slash Commands\n\n- ok: `False`"
+    lines = [
+        "# LoopX Slash Commands",
+        "",
+        str(payload.get("onboarding", {}).get("suggested_user_note") or ""),
+        "",
+        "| Command | Scope | Intent | Mutation policy | CLI reference |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for item in payload.get("commands") or []:
+        if not isinstance(item, dict):
+            continue
+        legacy = item.get("legacy_aliases") or []
+        intent = str(item.get("intent") or "")
+        if legacy:
+            intent += " Legacy aliases: " + ", ".join(f"`{alias}`" for alias in legacy) + "."
+        lines.append(
+            "| "
+            f"`{item.get('command')}` | "
+            f"{item.get('scope')} | "
+            f"{intent} | "
+            f"{item.get('mutation_policy')} | "
+            f"`{item.get('cli_reference')}` |"
+        )
+    lines.extend(
+        [
+            "",
+            "Global manager commands are read-only by default. Project-local `/loopx <goal text>` is the only slash form here that can authorize project-local state writes, and it must plan before writing todos.",
+        ]
+    )
+    return "\n".join(lines)

--- a/skills/loopx-project/SKILL.md
+++ b/skills/loopx-project/SKILL.md
@@ -68,6 +68,23 @@ or status summary surface instead of `bootstrap-command-pack`. Legacy
 `/loop-global-*` forms may be treated as aliases, but canonical help and
 packets should use `/loopx-global-*`.
 
+When a user has just connected a project or receives a bootstrap command pack
+for the first time, briefly tell them the usable commands instead of assuming
+they will inspect CLI help:
+
+- `/loopx`: inspect or preview this project's LoopX connection/status.
+- `/loopx <goal text>`: start a concrete goal with a plan-before-todo-write
+  flow.
+- `/loopx-global-summary`: read the global progress digest.
+- `/loopx-global-gates`, `/loopx-global-todos`, `/loopx-global-risks`: inspect
+  manager-level gates, work, and risks.
+
+For command-line discovery, use:
+
+```bash
+loopx slash-commands
+```
+
 ## Register Project Authority And Material Sources
 
 When a project agent discovers a durable design document, research note,


### PR DESCRIPTION
## Summary
- add a shared LoopX slash command catalog for `/loopx`, `/loopx <goal text>`, and `/loopx-global-*`
- surface the catalog in `bootstrap-command-pack` as a new-user onboarding hint
- add `loopx slash-commands` CLI help plus smoke coverage

## Validation
- python3 examples/slash-command-catalog-smoke.py
- python3 examples/bootstrap-command-pack-smoke.py
- python3 examples/global-manager-command-cli-smoke.py
- python3 examples/global-manager-command-protocol-smoke.py
- python3 -m py_compile loopx/slash_commands.py loopx/bootstrap_command_pack.py loopx/cli.py loopx/cli_commands/slash_commands.py loopx/cli_commands/summary_all.py
- git diff --check origin/main...HEAD
- python3 -m loopx.cli check --scan-path docs/reference/protocols/loopx-goal-command-v0.md --scan-path skills/loopx-project/SKILL.md --scan-path loopx/slash_commands.py --scan-path loopx/bootstrap_command_pack.py --scan-path loopx/cli.py --scan-path loopx/cli_commands/slash_commands.py --scan-path loopx/cli_commands/summary_all.py --scan-path loopx/cli_commands/__init__.py --scan-path examples/bootstrap-command-pack-smoke.py --scan-path examples/slash-command-catalog-smoke.py
