### PR TITLE
Add issue-fix workflow contract

### DIFF
--- a/docs/capabilities/issue-fix/README.md
+++ b/docs/capabilities/issue-fix/README.md
@@ -18,6 +18,7 @@ external comments, PRs, merges, or publishes.
 
 ## Protocols
 
+- [`issue_fix_workflow_contract_v0`](protocols/issue-fix-workflow-contract-v0.md)
 - [`issue_fix_acceptance_loop_v0`](protocols/issue-fix-acceptance-loop-v0.md)
 - `github_issue_metadata_preview_v0`
 - `content_ops_issue_fix_metadata_preview_packet_v0`
@@ -42,6 +43,7 @@ metadata boundary.
 ## Validation
 
 ```bash
+python3 examples/issue-fix-workflow-contract-smoke.py
 python3 examples/content-ops-issue-fix-metadata-preview-smoke.py
 python3 examples/content-ops-issue-fix-intake-smoke.py
 python3 examples/issue-fix-acceptance-loop-smoke.py

--- a/docs/capabilities/issue-fix/protocols/issue-fix-workflow-contract-v0.md
+++ b/docs/capabilities/issue-fix/protocols/issue-fix-workflow-contract-v0.md
@@ -1,0 +1,104 @@
+# issue_fix_workflow_contract_v0
+
+`issue_fix_workflow_contract_v0` ties the existing issue-fix surfaces into one
+GitHub issue fix workflow. It is a product contract, not a new state store:
+LoopX still uses metadata preview, intake packets, LoopX todos, caller-approved
+repo branches, validation evidence, review packets, and explicit gates as the
+source of truth.
+
+## User Story
+
+A user gives LoopX a public GitHub issue or PR signal and an approved local
+repository context. LoopX should classify the issue, decompose the work into
+owner/user gates and agent todos, prepare or claim an issue branch, run the
+declared validation, and emit a PR-review-ready packet. LoopX must not read raw
+issue bodies, raw comments, private repro material, create external comments,
+open PRs, merge, publish, or run destructive git without an explicit gate.
+
+## Workflow Stages
+
+1. **Metadata preview:** build `github_issue_metadata_preview_v0` from a public
+   URL, compact reference, mocked metadata, or caller-approved metadata fetch.
+   Allowed fields are repo, issue or PR number, state, title summary, labels,
+   updated timestamp, author association, comment count, and permalink. Body,
+   comment, timeline, event, raw, and provider response fields are gated.
+2. **Intake classification:** build `issue_fix_intake_v0` with issue class,
+   code-context route candidates, owner/user gate projections, and ordered
+   agent todo candidates. The first screen must name `waiting_on`, top agent
+   todo, top gate when present, and next safe action.
+3. **LoopX todo writeback:** convert accepted candidates into durable LoopX
+   todos in priority and dependency order. Typical agent todos are repro smoke,
+   code-context route, branch-local patch, validation, and review-packet
+   readiness. User todos represent gates such as private repro material,
+   external issue comment, PR creation, merge, publish, or repository policy.
+4. **Caller repo branch:** use `issue_fix_caller_repo_branch_packet_v0` only
+   after the caller provides an approved local git repo, base branch, issue
+   branch policy, and validation command. Dry-run mode must not inspect the
+   repo. Execute mode may inspect the approved repo and create or claim a
+   `codex/` issue branch, but must refuse branch switches from dirty state.
+5. **Validation:** record focused validation as pass/fail, exit code, and
+   public-safe label. Validation stdout, stderr, local paths, and raw git output
+   stay out of the packet. A validated fix should prove failing-before and
+   passing-after evidence when that repro path is available.
+6. **PR review packet:** emit `issue_fix_pr_review_packet_v0` only when branch,
+   validation, and repo-relative changed-file evidence are sufficient for human
+   review. The packet is review evidence, not external publication authority.
+7. **Gate handling:** surface concrete gates instead of silently blocking. Safe
+   metadata-only triage, public-code search, and focused smoke drafting may
+   continue when those gates do not cover the selected action.
+
+## Public-Safe Boundary
+
+Packets in this workflow must preserve these boundary flags:
+
+- `issue_body_captured: false`
+- `comment_bodies_captured: false`
+- `response_payload_captured` or `response_payloads_captured: false`
+- `local_paths_captured: false`
+- `external_writes_performed: false`
+- `destructive_git_used: false`
+
+`private_repo_state_read` is `false` for preview, intake, fixtures, and
+caller-repo dry-runs. It may be `true` only for caller-approved
+`caller-repo-branch --execute`, and even then local paths, raw validation
+output, raw git output, and credentials must not be recorded.
+
+## Todo And Gate Shape
+
+Issue-fix todo plans should be small and ordered. For a clear bounded bug, use
+the minimum sufficient plan rather than management filler:
+
+- `[P0] Reproduce or classify the issue from public metadata and approved code
+  context.`
+- `[P0] Patch the selected issue branch and rerun the caller-declared
+  validation.`
+- `[P1] Prepare the PR review packet with repo-relative changed files,
+  validation labels, and remaining gates.`
+
+When several todos have the same priority, planner order plus LoopX write order
+is the tie-breaker. Do not infer a gate from prose alone: write it as a user
+todo or operator gate with the concrete action it blocks.
+
+## Ready Criteria
+
+An issue-fix workflow is PR-review-ready only when all of these are true:
+
+- metadata/intake preserved body-free and comment-free boundaries;
+- accepted todos or gates were written to LoopX state, not left in chat;
+- the issue branch is created or claimed inside the caller-approved repo;
+- the declared validation ran and passed, or the packet clearly says review is
+  not ready yet;
+- changed files are repo-relative and bounded;
+- no external issue comment, PR creation, merge, publish, production action, or
+  destructive git action occurred.
+
+## Related Schemas
+
+- `github_issue_metadata_preview_v0`
+- `content_ops_issue_fix_metadata_preview_packet_v0`
+- `content_ops_issue_fix_intake_packet_v0`
+- `issue_fix_intake_v0`
+- `loopx_todo_writeback_preview_v0`
+- `issue_fix_caller_repo_branch_packet_v0`
+- `issue_fix_validated_fix_artifact_v0`
+- `issue_fix_pr_review_packet_v0`

--- a/examples/issue-fix-workflow-contract-smoke.py
+++ b/examples/issue-fix-workflow-contract-smoke.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Smoke-test the public issue-fix workflow contract."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from loopx.capabilities.issue_fix.acceptance_loop import (  # noqa: E402
+    ISSUE_FIX_CALLER_REPO_BRANCH_PACKET_SCHEMA_VERSION,
+    ISSUE_FIX_VALIDATED_FIX_ARTIFACT_SCHEMA_VERSION,
+    build_issue_fix_caller_repo_branch_packet,
+)
+from loopx.capabilities.issue_fix.intake_surface import (  # noqa: E402
+    CONTENT_OPS_ISSUE_FIX_INTAKE_PACKET_SCHEMA_VERSION,
+    CONTENT_OPS_ISSUE_FIX_METADATA_PREVIEW_PACKET_SCHEMA_VERSION,
+    ISSUE_FIX_INTAKE_SCHEMA_VERSION,
+    build_content_ops_issue_fix_intake_packet,
+    build_content_ops_issue_fix_metadata_preview_packet,
+)
+from loopx.capabilities.issue_fix.metadata_preview import (  # noqa: E402
+    GITHUB_ISSUE_METADATA_PREVIEW_SCHEMA_VERSION,
+)
+
+
+DOC = ROOT / "docs/capabilities/issue-fix/protocols/issue-fix-workflow-contract-v0.md"
+README = ROOT / "docs/capabilities/issue-fix/README.md"
+
+PRIVATE_PATTERNS = [
+    re.compile(r"/Users/[A-Za-z0-9._-]+/"),
+    re.compile(r"/home/[A-Za-z0-9._-]+/"),
+    re.compile(r"/private/"),
+    re.compile(r"[A-Za-z]:\\\\Users\\\\"),
+    re.compile(r"\bBearer\s+[A-Za-z0-9._-]+"),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+]
+
+FORBIDDEN_VALUES = [
+    "raw issue body text that must stay gated",
+    "full issue comment text that must stay gated",
+    "raw provider response payload",
+    "private repro log",
+    "secret-value",
+    "credential-value",
+]
+
+
+def assert_public_safe(payload: dict[str, Any] | str) -> None:
+    text = (
+        payload
+        if isinstance(payload, str)
+        else json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    )
+    for pattern in PRIVATE_PATTERNS:
+        if pattern.search(text):
+            raise AssertionError(f"payload matched private pattern {pattern.pattern!r}")
+    leaked = [value for value in FORBIDDEN_VALUES if value in text]
+    assert not leaked, leaked
+
+
+def assert_ordered(text: str, markers: list[str]) -> None:
+    offset = -1
+    for marker in markers:
+        found = text.find(marker)
+        assert found > offset, f"{marker!r} missing or out of order"
+        offset = found
+
+
+def main() -> int:
+    doc = DOC.read_text(encoding="utf-8")
+    readme = README.read_text(encoding="utf-8")
+    assert doc.startswith("# issue_fix_workflow_contract_v0")
+    assert "issue-fix-workflow-contract-v0.md" in readme
+    assert "python3 examples/issue-fix-workflow-contract-smoke.py" in readme
+    assert_ordered(
+        doc,
+        [
+            "**Metadata preview:**",
+            "**Intake classification:**",
+            "**LoopX todo writeback:**",
+            "**Caller repo branch:**",
+            "**Validation:**",
+            "**PR review packet:**",
+            "**Gate handling:**",
+        ],
+    )
+    for schema in (
+        GITHUB_ISSUE_METADATA_PREVIEW_SCHEMA_VERSION,
+        CONTENT_OPS_ISSUE_FIX_METADATA_PREVIEW_PACKET_SCHEMA_VERSION,
+        CONTENT_OPS_ISSUE_FIX_INTAKE_PACKET_SCHEMA_VERSION,
+        ISSUE_FIX_INTAKE_SCHEMA_VERSION,
+        "loopx_todo_writeback_preview_v0",
+        ISSUE_FIX_CALLER_REPO_BRANCH_PACKET_SCHEMA_VERSION,
+        ISSUE_FIX_VALIDATED_FIX_ARTIFACT_SCHEMA_VERSION,
+        "issue_fix_pr_review_packet_v0",
+    ):
+        assert schema in doc, schema
+    for boundary in (
+        "issue_body_captured: false",
+        "comment_bodies_captured: false",
+        "local_paths_captured: false",
+        "external_writes_performed: false",
+        "destructive_git_used: false",
+    ):
+        assert boundary in doc, boundary
+
+    provider_payload = {
+        "number": 123,
+        "state": "open",
+        "title": "Crash on metadata adapter preview",
+        "labels": [{"name": "bug"}, {"name": "needs-repro"}],
+        "body": "raw issue body text that must stay gated",
+        "comments": ["full issue comment text that must stay gated"],
+        "raw": "raw provider response payload",
+    }
+    metadata = build_content_ops_issue_fix_metadata_preview_packet(
+        url="https://github.com/huangruiteng/loopx/issues/123",
+        provider_payload=provider_payload,
+    )
+    assert metadata["ok"] is True, metadata
+    assert metadata["external_writes_performed"] is False, metadata
+    assert metadata["todo_write_performed"] is False, metadata
+    assert metadata["github_metadata_preview"]["body_captured"] is False, metadata
+    assert metadata["github_metadata_preview"]["comment_bodies_captured"] is False
+    assert metadata["github_metadata_preview"]["gated_provider_fields_present"] == [
+        "body",
+        "comments",
+        "raw",
+    ]
+    previews = metadata["adapter_preview"]["candidate_loopx_todo_writeback_preview"]
+    assert [preview["role"] for preview in previews] == ["agent", "user"], previews
+    assert all(preview["would_write"] is False for preview in previews), previews
+    assert_public_safe(metadata)
+
+    intake = build_content_ops_issue_fix_intake_packet(
+        repo="huangruiteng/loopx",
+        issue_ref="issue_123",
+    )
+    assert intake["ok"] is True, intake
+    issue_intake = intake["issue_fix_intake"]
+    assert issue_intake["first_screen"]["waiting_on"] == "agent", issue_intake
+    assert issue_intake["first_screen"]["user_action_required"] is False, issue_intake
+    assert len(issue_intake["agent_todo_candidates"]) >= 3, issue_intake
+    assert {gate["gate_id"] for gate in issue_intake["gate_projections"]} == {
+        "owner_triage_gate",
+        "private_repro_material_gate",
+    }
+    assert_public_safe(intake)
+
+    dry_run = build_issue_fix_caller_repo_branch_packet(
+        repo_path="/not/read/in/dry/run",
+        url="https://github.com/huangruiteng/loopx/issues/123",
+        base_branch="main",
+        validation_label="python test_calculator.py",
+        execute=False,
+    )
+    assert dry_run["ok"] is True, dry_run
+    assert dry_run["dry_run"] is True, dry_run
+    assert dry_run["private_repo_state_read"] is False, dry_run
+    assert dry_run["local_paths_captured"] is False, dry_run
+    assert dry_run["review_packet"]["ready"] is False, dry_run
+    assert dry_run["review_packet"]["external_pr_created"] is False, dry_run
+    assert dry_run["review_packet"]["merge_performed"] is False, dry_run
+    assert_public_safe(dry_run)
+
+    print("issue-fix-workflow-contract-smoke: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `issue_fix_workflow_contract_v0` tying metadata preview, intake, LoopX todo writeback, caller repo branch, validation, PR review packet, and gates into one issue-fix workflow contract
- index the contract from the issue-fix capability README
- add a focused smoke that checks the doc, schema constants, metadata/intake packets, and caller-repo dry-run boundaries

## Validation
- `python3 examples/issue-fix-workflow-contract-smoke.py`
- `python3 examples/content-ops-issue-fix-metadata-preview-smoke.py`
- `python3 examples/content-ops-issue-fix-intake-smoke.py`
- `python3 examples/issue-fix-acceptance-loop-smoke.py`
- `loopx check --scan-path docs/capabilities/issue-fix --scan-path examples/issue-fix-workflow-contract-smoke.py` (passes; existing duplicate index warning only)

## Boundary
- public docs plus focused smoke only
- no runtime behavior, benchmark scoring, external GitHub write, raw issue body/comment capture, local path evidence, or private state included