### PR TITLE
Add SkillsBench goal-start product-mode route

### DIFF
--- a/examples/benchmark-case-active-state-contract-smoke.py
+++ b/examples/benchmark-case-active-state-contract-smoke.py
@@ -29,6 +29,8 @@ from loopx.benchmark_case_state import (  # noqa: E402
     BENCHMARK_CASE_ACTIVE_STATE_PROOF_FIELDS,
     BENCHMARK_CASE_ACTIVE_STATE_SCHEMA_VERSION,
     BENCHMARK_CASE_LIFECYCLE_SCHEMA_VERSION,
+    BENCHMARK_CASE_LOOPX_GOAL_START_SELECTED_TODO_ID,
+    BENCHMARK_CASE_LOOPX_GOAL_START_TODO_IDS,
     BENCHMARK_CASE_LOOPX_TODO_ID,
     benchmark_case_active_state_init_contract,
     benchmark_case_active_state_path,
@@ -166,6 +168,37 @@ def test_case_loopx_install_payload_uses_official_product_lifecycle() -> None:
     assert "/Users/" not in command
 
 
+def test_goal_start_product_mode_seeds_ranked_plan_before_todos() -> None:
+    payload = benchmark_case_loopx_install_payload(
+        benchmark_id="skillsbench",
+        case_id="planning-granularity",
+        arm_id="loopx_goal_start_product_mode",
+        route="loopx-goal-start-product-mode",
+        max_rounds=16,
+        goal_start_product_mode=True,
+    )
+    assert payload["goal_start_product_mode"] is True
+    assert payload["goal_start_plan_observed"] is True
+    assert payload["planner_before_todo_write"] is True
+    assert payload["planned_todo_count"] == 3
+    assert payload["planned_p0_count"] == 1
+    assert payload["planned_todo_ids"] == list(BENCHMARK_CASE_LOOPX_GOAL_START_TODO_IDS)
+    assert payload["case_todo_id"] == BENCHMARK_CASE_LOOPX_GOAL_START_SELECTED_TODO_ID
+    assert payload["selected_p0_todo_id"] == BENCHMARK_CASE_LOOPX_GOAL_START_SELECTED_TODO_ID
+    assert payload["selected_todo_claimed"] is False
+    assert payload["selected_todo_updated_before_solver"] is False
+    assert payload["selected_todo_completed_before_spend"] is False
+    assert payload["non_selected_todos_preserved_open_or_deferred"] is True
+    command = str(payload["command"])
+    assert " bootstrap-command-pack " in command
+    assert " --goal-text " in command
+    assert command.count(" todo add ") == 3
+    assert command.index("bootstrap-command-pack") < command.index(" todo add ")
+    for todo_id in BENCHMARK_CASE_LOOPX_GOAL_START_TODO_IDS:
+        assert todo_id in command
+    assert "/Users/" not in command
+
+
 def test_case_loopx_install_command_uses_real_loopx_lifecycle() -> None:
     with tempfile.TemporaryDirectory(prefix="loopx-case-install-") as tmp:
         root = Path(tmp)
@@ -249,6 +282,64 @@ def test_case_loopx_install_command_uses_real_loopx_lifecycle() -> None:
         assert any('"event_kind": "quota_should_run"' in line or '"event_kind":"quota_should_run"' in line for line in event_lines)
         assert any('"event_kind": "todo_claim"' in line or '"event_kind":"todo_claim"' in line for line in event_lines)
         assert all("raw_task_text" not in line or "false" in line for line in event_lines)
+
+
+def test_goal_start_install_command_seeds_three_ranked_todos() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-goal-start-install-") as tmp:
+        root = Path(tmp)
+        state_path = root / ".codex" / "goals" / "goal-start-case" / "ACTIVE_GOAL_STATE.md"
+        cli_path = root / ".local" / "bin" / "loopx"
+        registry_path = root / ".loopx" / "registry.json"
+        runtime_root = root / ".loopx" / "runtime"
+        goal_doc_path = root / ".loopx" / "LOOPX_CASE_GOAL.md"
+        command = benchmark_case_loopx_install_command(
+            benchmark_id="skillsbench",
+            case_id="goal-start-case",
+            route="loopx-goal-start-product-mode",
+            max_rounds=16,
+            goal_id="goal-start-case",
+            case_state_path=str(state_path),
+            content="",
+            case_cli_path=str(cli_path),
+            case_registry_path=str(registry_path),
+            case_runtime_root=str(runtime_root),
+            case_goal_doc_path=str(goal_doc_path),
+            case_project_root=str(root),
+            case_home=str(root),
+            goal_start_product_mode=True,
+        )
+        subprocess.run(
+            ["bash", "-lc", command],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        status = subprocess.run(
+            [
+                str(cli_path),
+                "--registry",
+                str(registry_path),
+                "--runtime-root",
+                str(runtime_root),
+                "--format",
+                "json",
+                "status",
+                "--agent-id",
+                "codex-benchmark-agent",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        status_payload = json.loads(status.stdout)
+        items = status_payload["attention_queue"]["items"][0]["agent_todos"][
+            "backlog_items"
+        ]
+        ids = {item["todo_id"] for item in items}
+        assert set(BENCHMARK_CASE_LOOPX_GOAL_START_TODO_IDS).issubset(ids)
+        assert status_payload["attention_queue"]["items"][0]["agent_lane_next_action"][
+            "todo_id"
+        ] == BENCHMARK_CASE_LOOPX_GOAL_START_SELECTED_TODO_ID
 
 
 def test_case_loopx_install_command_uses_source_wrapper_without_local_installer() -> None:
@@ -377,7 +468,9 @@ if __name__ == "__main__":
     test_seed_text_uses_real_loopx_active_state_shape()
     test_seed_write_command_uses_canonical_path()
     test_case_loopx_install_payload_uses_official_product_lifecycle()
+    test_goal_start_product_mode_seeds_ranked_plan_before_todos()
     test_case_loopx_install_command_uses_real_loopx_lifecycle()
+    test_goal_start_install_command_seeds_three_ranked_todos()
     test_case_loopx_install_command_uses_source_wrapper_without_local_installer()
     test_case_lifecycle_contract_is_per_case_arm()
     test_ale_launch_packet_reuses_shared_contract()

--- a/examples/benchmark-loop-protocol-smoke.py
+++ b/examples/benchmark-loop-protocol-smoke.py
@@ -13,6 +13,7 @@ if str(REPO_ROOT) not in sys.path:
 from loopx.benchmark_core.loop_protocol import (
     BLIND_LOOP_DEFAULT_MAX_ROUNDS,
     LOOPX_BLIND_LOOP_TREATMENT_ROUTE,
+    LOOPX_GOAL_START_PRODUCT_MODE_ROUTE,
     LOOPX_PACKET_ONLY_OBSERVATION_ROUTE,
     LOOPX_PROMPT_POLLING_TEST_ROUTE,
     MAX5_BLIND_LOOP_NO_FEEDBACK_PROTOCOL_ID,
@@ -63,6 +64,16 @@ def main() -> int:
     assert raw_product["protocol_id"] == PRODUCT_MODE_MAX5_NO_FEEDBACK_PROTOCOL_ID
     assert raw_product["product_mode"] is True
     assert raw_product["official_feedback_blinded"] is True
+    goal_start_product = build_benchmark_loop_contract(
+        route=LOOPX_GOAL_START_PRODUCT_MODE_ROUTE,
+        max_rounds=5,
+    )
+    assert (
+        goal_start_product["protocol_id"]
+        == PRODUCT_MODE_MAX5_NO_FEEDBACK_PROTOCOL_ID
+    )
+    assert goal_start_product["product_mode"] is True
+    assert goal_start_product["official_feedback_blinded"] is True
 
     product_contract = build_product_mode_main_table_comparison_contract()
     assert product_contract["protocol_id"] == PRODUCT_MODE_MAX5_NO_FEEDBACK_PROTOCOL_ID
@@ -86,6 +97,26 @@ def main() -> int:
             "continue_after_declared_done_below_passing_reward"
         ]
         is True
+    )
+
+    goal_start_contract = build_product_mode_main_table_comparison_contract(
+        treatment_route=LOOPX_GOAL_START_PRODUCT_MODE_ROUTE,
+    )
+    assert (
+        goal_start_contract["treatment_arm"]["route"]
+        == LOOPX_GOAL_START_PRODUCT_MODE_ROUTE
+    )
+    assert (
+        goal_start_contract["treatment_arm"]["arm_id"]
+        == "loopx_goal_start_product_mode"
+    )
+    assert (
+        goal_start_contract["treatment_arm"]["agent_surface"]
+        == "loopx_goal_start_plan_todo_lifecycle_cli"
+    )
+    assert (
+        goal_start_contract["treatment_arm"]["contract"]["protocol_id"]
+        == PRODUCT_MODE_MAX5_NO_FEEDBACK_PROTOCOL_ID
     )
 
     trace = build_benchmark_loop_controller_trace(

--- a/examples/skillsbench-goal-start-product-mode-route-smoke.py
+++ b/examples/skillsbench-goal-start-product-mode-route-smoke.py
@@ -11,6 +11,139 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
+def _assert_control_score_surface() -> None:
+    sys.path.insert(0, str(REPO_ROOT))
+    from scripts.skillsbench_automation_loop import (
+        _build_case_event_timeline,
+        _build_goal_start_product_mode_control_score,
+    )
+    from loopx.benchmark_adapters.skillsbench import (
+        _skillsbench_controller_trace_counters,
+    )
+    from loopx.status import (
+        _compact_benchmark_interaction_counters,
+        _compact_benchmark_runner_prerequisites,
+    )
+
+    compact = {
+        "product_mode": True,
+        "interaction_counters": {
+            "goal_start_product_mode": True,
+            "goal_start_plan_observed": True,
+            "planned_todo_count": 3,
+            "planned_p0_count": 1,
+            "planner_before_todo_write": True,
+            "same_priority_order_preserved": True,
+            "selected_p0_todo_id": "todo_public_solver",
+            "selected_todo_claimed": True,
+            "selected_todo_updated_before_solver": True,
+            "non_selected_todos_preserved_open_or_deferred": True,
+            "remote_command_file_bridge_agent_successful_loopx_subcommand_counts": {
+                "todo complete": 1,
+                "quota spend-slot": 1,
+            },
+            "remote_command_file_bridge_agent_quota_spend_slot_count": 1,
+        },
+        "product_mode_lifecycle_contract": {
+            "agent_bridge_quota_spend_slot_count": 1,
+        },
+    }
+    plan = {
+        "runner_prerequisites": {
+            "goal_start_product_mode": True,
+            "goal_start_plan_required": True,
+            "goal_start_planned_todo_count_expected": 3,
+            "goal_start_selected_p0_lifecycle_required": True,
+        },
+    }
+    control_score = _build_goal_start_product_mode_control_score(compact, plan)
+    assert control_score["satisfied"] is True, control_score
+    assert control_score["score"] == 1.0, control_score
+    assert control_score["raw_material_recorded"] is False, control_score
+    assert control_score["selected_todo_completed_before_spend"] is True, control_score
+    compact["goal_start_product_mode_control_score"] = control_score
+    timeline = _build_case_event_timeline(compact, plan)
+    events = timeline["events"]
+    goal_start_events = [
+        event
+        for event in events
+        if event["phase"] == "goal_start_plan"
+    ]
+    assert len(goal_start_events) == 1, timeline
+    goal_start = goal_start_events[0]
+    assert goal_start["status"] == "satisfied", goal_start
+    assert goal_start["planned_todo_count"] == 3, goal_start
+    assert goal_start["selected_p0_todo_id"] == "todo_public_solver", goal_start
+    assert timeline["raw_material_recorded"] is False, timeline
+
+    continuation_compact = {
+        "product_mode": True,
+        "interaction_counters": {
+            "goal_start_product_mode": True,
+            "goal_start_plan_observed": True,
+            "planned_todo_count": 3,
+            "planned_p0_count": 1,
+            "planner_before_todo_write": True,
+            "same_priority_order_preserved": True,
+            "selected_p0_todo_id": "todo_public_solver",
+            "selected_todo_claimed": True,
+            "selected_todo_updated_before_solver": True,
+            "non_selected_todos_preserved_open_or_deferred": True,
+            "product_mode_declared_done_below_passing_reward": True,
+            "product_mode_declared_done_below_passing_reward_count": 1,
+            "last_decision": "send_product_mode_success_or_budget_continuation_after_declared_done",
+        },
+    }
+    continuation_score = _build_goal_start_product_mode_control_score(
+        continuation_compact,
+        plan,
+    )
+    assert continuation_score["premature_done_signal_count"] == 1, continuation_score
+    assert continuation_score["premature_done_stop_reason"] == "", continuation_score
+    assert any(
+        item["name"] == "no_premature_done_stop" and item["satisfied"] is True
+        for item in continuation_score["component_results"]
+    ), continuation_score
+
+    controller_trace = {
+        "schema_version": "skillsbench_loopx_controller_trace_v0",
+        "goal_start_product_mode": True,
+        "goal_start_plan_observed": True,
+        "planned_todo_count": 3,
+        "planned_p0_count": 1,
+        "planner_before_todo_write": True,
+        "same_priority_order_preserved": True,
+        "selected_p0_todo_id": "todo_public_solver",
+        "non_selected_todos_preserved_open_or_deferred": True,
+        "remote_command_file_bridge_driver_lifecycle_command_counts": {
+            "todo claim": 1,
+            "todo update": 1,
+        },
+        "remote_command_file_bridge_agent_successful_loopx_subcommand_counts": {
+            "todo complete": 1,
+            "quota spend-slot": 1,
+        },
+    }
+    projected = _skillsbench_controller_trace_counters(controller_trace)
+    assert projected["selected_todo_claimed"] is True, projected
+    assert projected["selected_todo_updated_before_solver"] is True, projected
+    assert projected["selected_todo_completed_before_spend"] is True, projected
+    compacted_counters = _compact_benchmark_interaction_counters(projected)
+    assert compacted_counters["selected_p0_todo_id"] == "todo_public_solver"
+    assert compacted_counters["planned_todo_count"] == 3
+    assert (
+        compacted_counters[
+            "remote_command_file_bridge_agent_successful_loopx_subcommand_counts"
+        ]["todo complete"]
+        == 1
+    )
+    compacted_prerequisites = _compact_benchmark_runner_prerequisites(
+        plan["runner_prerequisites"]
+    )
+    assert compacted_prerequisites["goal_start_plan_required"] is True
+    assert compacted_prerequisites["goal_start_planned_todo_count_expected"] == 3
+
+
 def main() -> int:
     result = subprocess.run(
         [
@@ -41,6 +174,7 @@ def main() -> int:
     assert prerequisites["benchflow_intermediate_soft_verify_policy"] == "every-round"
     assert plan["public_boundary"]["public_raw_prompt"] is False, plan
     assert plan["public_boundary"]["public_raw_trajectory"] is False, plan
+    _assert_control_score_surface()
     print("skillsbench-goal-start-product-mode-route-smoke ok")
     return 0
 

--- a/examples/skillsbench-goal-start-product-mode-route-smoke.py
+++ b/examples/skillsbench-goal-start-product-mode-route-smoke.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Smoke-test the SkillsBench goal-start product-mode route plan surface."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def main() -> int:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "scripts" / "skillsbench_automation_loop.py"),
+            "--route",
+            "loopx-goal-start-product-mode",
+            "--task-id",
+            "planning-granularity",
+            "--plan-only",
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True, payload
+    assert payload["plan_only"] is True, payload
+    plan = payload["launch_plan"]
+    assert plan["route"] == "loopx-goal-start-product-mode", plan
+    assert plan["rollout_name"].endswith("__loopx_goal_start_product_mode"), plan
+    prerequisites = plan["runner_prerequisites"]
+    assert prerequisites["goal_start_product_mode"] is True, prerequisites
+    assert prerequisites["goal_start_plan_required"] is True, prerequisites
+    assert prerequisites["goal_start_planned_todo_count_expected"] == 3, prerequisites
+    assert prerequisites["goal_start_selected_p0_lifecycle_required"] is True, prerequisites
+    assert prerequisites["benchflow_intermediate_soft_verify_policy"] == "every-round"
+    assert plan["public_boundary"]["public_raw_prompt"] is False, plan
+    assert plan["public_boundary"]["public_raw_trajectory"] is False, plan
+    print("skillsbench-goal-start-product-mode-route-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/skillsbench-goal-start-product-mode-route-smoke.py
+++ b/examples/skillsbench-goal-start-product-mode-route-smoke.py
@@ -6,9 +6,96 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _assert_adapter_route_contract_surface() -> None:
+    sys.path.insert(0, str(REPO_ROOT))
+    from loopx.benchmark_adapters.skillsbench import (
+        build_skillsbench_benchflow_result_benchmark_run,
+        build_skillsbench_benchmark_run,
+        skillsbench_route_contract,
+    )
+
+    route = "loopx-goal-start-product-mode"
+    contract = skillsbench_route_contract(route)
+    assert contract["mode"] == "skillsbench_loopx_goal_start_product_mode_treatment"
+    assert contract["arm_id"] == "loopx_goal_start_product_mode"
+    assert contract["product_mode"] is True, contract
+    assert contract["loopx_inside_case"] is True, contract
+    assert contract["loopx_automation_loop"] is True, contract
+    assert "ranked_todo_plan" in contract["skillsbench_route_semantics"], contract
+
+    skeleton = build_skillsbench_benchmark_run(route=route)
+    assert skeleton["route"] == route, skeleton
+    assert skeleton["mode"] == contract["mode"], skeleton
+    assert skeleton["source_runner"] == contract["source_runner"], skeleton
+    counters = skeleton["interaction_counters"]
+    assert counters["product_mode"] is True, counters
+    assert counters["case_goal_state_packet_present"] is True, counters
+    assert counters["case_goal_state_init_required"] is True, counters
+    assert counters["goal_start_product_mode"] is True, counters
+    assert counters["declared_done_requires_no_remaining_goals"] is True, counters
+    policy = skeleton["episode_policy"]
+    assert policy["outer_controller"] == "loopx_goal_start_product_mode", policy
+    assert policy["inner_case_actor"] == "ordinary_codex_acp_agent", policy
+    kwargs_keys = skeleton["agent"]["kwargs_keys"]
+    assert "loopx_goal_start_product_mode" in kwargs_keys, kwargs_keys
+    assert "ranked_todo_plan_selected_p0_lifecycle" in kwargs_keys, kwargs_keys
+
+    controller_trace = {
+        "schema_version": "skillsbench_loopx_controller_trace_v0",
+        "product_mode": True,
+        "goal_start_product_mode": True,
+        "goal_start_plan_observed": True,
+        "planned_todo_count": 3,
+        "planned_p0_count": 1,
+        "planner_before_todo_write": True,
+        "same_priority_order_preserved": True,
+        "selected_p0_todo_id": "todo_public_solver",
+        "non_selected_todos_preserved_open_or_deferred": True,
+        "remote_command_file_bridge_driver_lifecycle_command_counts": {
+            "todo claim": 1,
+            "todo update": 1,
+        },
+        "remote_command_file_bridge_driver_lifecycle_failure_count": 0,
+    }
+    with tempfile.TemporaryDirectory() as temp_dir:
+        result_path = Path(temp_dir) / "result.json"
+        result_path.write_text(
+            json.dumps(
+                {
+                    "task_name": "planning-granularity",
+                    "agent": "codex-acp",
+                    "model": "gpt-5.5",
+                    "rollout_name": "planning-granularity__loopx_goal_start_product_mode",
+                    "rewards": {"reward": 0},
+                    "n_tool_calls": 0,
+                }
+            ),
+            encoding="utf-8",
+        )
+        reduced = build_skillsbench_benchflow_result_benchmark_run(
+            result_path,
+            route=route,
+            controller_trace=controller_trace,
+        )
+    reduced_counters = reduced["interaction_counters"]
+    assert reduced_counters["goal_start_product_mode"] is True, reduced_counters
+    assert reduced_counters["goal_start_plan_observed"] is True, reduced_counters
+    assert reduced_counters["planned_todo_count"] == 3, reduced_counters
+    assert reduced_counters["planned_p0_count"] == 1, reduced_counters
+    assert reduced_counters["selected_p0_todo_id"] == "todo_public_solver"
+    assert reduced_counters["selected_todo_claimed"] is True, reduced_counters
+    assert (
+        reduced_counters["selected_todo_updated_before_solver"] is True
+    ), reduced_counters
+    assert (
+        reduced_counters["non_selected_todos_preserved_open_or_deferred"] is True
+    ), reduced_counters
 
 
 def _assert_control_score_surface() -> None:
@@ -174,6 +261,7 @@ def main() -> int:
     assert prerequisites["benchflow_intermediate_soft_verify_policy"] == "every-round"
     assert plan["public_boundary"]["public_raw_prompt"] is False, plan
     assert plan["public_boundary"]["public_raw_trajectory"] is False, plan
+    _assert_adapter_route_contract_surface()
     _assert_control_score_surface()
     print("skillsbench-goal-start-product-mode-route-smoke ok")
     return 0

--- a/examples/skillsbench-host-local-launch-plan-smoke.py
+++ b/examples/skillsbench-host-local-launch-plan-smoke.py
@@ -530,6 +530,39 @@ if out:
             probe_only_failure["remote_command_file_bridge_consumption_status"]
             == "sandbox_bridge_auto_wiring_pending"
         )
+        blocked_auto_wiring_full_run = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--skillsbench-root",
+                str(root),
+                "--task-id",
+                "demo-task",
+                "--route",
+                "loopx-goal-start-product-mode",
+                "--host-local-acp-launch",
+                "--remote-command-file-bridge-ready",
+            ],
+            cwd=REPO_ROOT,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        assert blocked_auto_wiring_full_run.returncode == 2, (
+            blocked_auto_wiring_full_run
+        )
+        auto_wiring_failure = json.loads(blocked_auto_wiring_full_run.stderr)
+        assert auto_wiring_failure["error_type"] == (
+            "SkillsBenchProductModeBridgeAutoWiringPending"
+        ), auto_wiring_failure
+        assert (
+            auto_wiring_failure["remote_command_file_bridge_consumption_status"]
+            == "sandbox_bridge_auto_wiring_pending"
+        ), auto_wiring_failure
+        assert auto_wiring_failure["raw_task_text_read"] is False
+        assert auto_wiring_failure["raw_trajectory_recorded"] is False
         blocked_fixture_solver = subprocess.run(
             [
                 sys.executable,

--- a/examples/skillsbench-host-local-launch-plan-smoke.py
+++ b/examples/skillsbench-host-local-launch-plan-smoke.py
@@ -1096,6 +1096,50 @@ raise SystemExit(125)
             exit125_controller_trace["host_local_acp_codex_exec_failure_category"]
             == "codex_exec_exit_125"
         )
+        network_exit125_codex = Path(tmp) / "network-exit125-codex"
+        network_exit125_codex.write_text(
+            """#!/usr/bin/env python3
+import sys
+
+print(
+    "failed to refresh available models: stream disconnected before completion",
+    file=sys.stderr,
+)
+raise SystemExit(125)
+""",
+            encoding="utf-8",
+        )
+        network_exit125_codex.chmod(0o755)
+        network_exit125_trace_dir = Path(tmp) / "relay-network-exit125-traces"
+        network_exit125_probe = run_skillsbench_local_acp_relay_probe(
+            [
+                sys.executable,
+                str(RELAY_SCRIPT),
+                "--codex-bin",
+                str(network_exit125_codex),
+                "--route",
+                "loopx-product-mode",
+                "--dataset",
+                "skillsbench-v1.1",
+                "--task-id",
+                "demo-task",
+                "--worker-public-trace-dir",
+                str(network_exit125_trace_dir),
+            ],
+            timeout_sec=20,
+        )
+        assert network_exit125_probe["ready"] is False, network_exit125_probe
+        network_exit125_failure = json.loads(
+            next(network_exit125_trace_dir.glob("*.compact.json")).read_text(
+                encoding="utf-8"
+            )
+        )
+        network_exit125_process = network_exit125_failure["codex_exec_process"]
+        assert network_exit125_process["returncode"] == 125
+        assert network_exit125_process["failure_category"] == (
+            "codex_network_or_api_unreachable"
+        )
+        assert network_exit125_process["raw_stderr_recorded"] is False
         exit1_codex = Path(tmp) / "exit1-codex"
         exit1_codex.write_text(
             """#!/usr/bin/env python3

--- a/examples/skillsbench-host-local-launch-plan-smoke.py
+++ b/examples/skillsbench-host-local-launch-plan-smoke.py
@@ -530,6 +530,39 @@ if out:
             probe_only_failure["remote_command_file_bridge_consumption_status"]
             == "sandbox_bridge_auto_wiring_pending"
         )
+        blocked_auto_wiring_full_run = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--skillsbench-root",
+                str(root),
+                "--task-id",
+                "demo-task",
+                "--route",
+                "loopx-product-mode",
+                "--host-local-acp-launch",
+                "--remote-command-file-bridge-ready",
+            ],
+            cwd=REPO_ROOT,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        assert blocked_auto_wiring_full_run.returncode == 2, (
+            blocked_auto_wiring_full_run
+        )
+        auto_wiring_failure = json.loads(blocked_auto_wiring_full_run.stderr)
+        assert auto_wiring_failure["error_type"] == (
+            "SkillsBenchProductModeBridgeAutoWiringPending"
+        ), auto_wiring_failure
+        assert (
+            auto_wiring_failure["remote_command_file_bridge_consumption_status"]
+            == "sandbox_bridge_auto_wiring_pending"
+        ), auto_wiring_failure
+        assert auto_wiring_failure["raw_task_text_read"] is False
+        assert auto_wiring_failure["raw_trajectory_recorded"] is False
         blocked_fixture_solver = subprocess.run(
             [
                 sys.executable,

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -1877,6 +1877,44 @@ def _skillsbench_controller_trace_counters(
             return value
         return 0
 
+    def successful_subcommand_count(command: str) -> int:
+        counts = controller_trace.get(
+            "remote_command_file_bridge_agent_successful_loopx_subcommand_counts"
+        )
+        if not isinstance(counts, dict):
+            return 0
+        value = counts.get(command)
+        if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+            return value
+        return 0
+
+    def driver_command_count(command: str) -> int:
+        counts = controller_trace.get(
+            "remote_command_file_bridge_driver_lifecycle_command_counts"
+        )
+        if not isinstance(counts, dict):
+            return 0
+        value = counts.get(command)
+        if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+            return value
+        return 0
+
+    def count_map(key: str) -> dict[str, int]:
+        raw = controller_trace.get(key)
+        if not isinstance(raw, dict):
+            return {}
+        counts: dict[str, int] = {}
+        for name, value in raw.items():
+            if (
+                isinstance(name, str)
+                and name
+                and isinstance(value, int)
+                and not isinstance(value, bool)
+                and value >= 0
+            ):
+                counts[name[:80]] = value
+        return dict(sorted(counts.items()))
+
     def max_direct_or_subcommands(key: str, commands: tuple[str, ...]) -> int:
         direct = count(key)
         derived = sum(subcommand_count(command) for command in commands)
@@ -1925,6 +1963,33 @@ def _skillsbench_controller_trace_counters(
                 first_success_round = int(record["agent_round"])
                 break
 
+    driver_lifecycle_command_successful = (
+        count("remote_command_file_bridge_driver_lifecycle_failure_count") == 0
+    )
+    selected_todo_claimed = bool(
+        controller_trace.get("selected_todo_claimed") is True
+        or successful_subcommand_count("todo claim") > 0
+        or (
+            driver_lifecycle_command_successful
+            and driver_command_count("todo claim") > 0
+        )
+    )
+    selected_todo_updated_before_solver = bool(
+        controller_trace.get("selected_todo_updated_before_solver") is True
+        or successful_subcommand_count("todo update") > 0
+        or (
+            driver_lifecycle_command_successful
+            and driver_command_count("todo update") > 0
+        )
+    )
+    selected_todo_completed_before_spend = bool(
+        controller_trace.get("selected_todo_completed_before_spend") is True
+        or (
+            successful_subcommand_count("todo complete") > 0
+            and successful_subcommand_count("quota spend-slot") > 0
+        )
+    )
+
     counters: dict[str, Any] = {
         "controller_trace_present": True,
         "controller_trace_schema_version": schema_version,
@@ -1952,6 +2017,25 @@ def _skillsbench_controller_trace_counters(
         is True,
         "blind_loop": controller_trace.get("blind_loop") is True,
         "product_mode": controller_trace.get("product_mode") is True,
+        "goal_start_product_mode": controller_trace.get("goal_start_product_mode")
+        is True,
+        "goal_start_plan_observed": controller_trace.get("goal_start_plan_observed")
+        is True,
+        "planner_before_todo_write": controller_trace.get("planner_before_todo_write")
+        is True,
+        "same_priority_order_preserved": controller_trace.get(
+            "same_priority_order_preserved"
+        )
+        is True,
+        "selected_todo_claimed": selected_todo_claimed,
+        "selected_todo_updated_before_solver": selected_todo_updated_before_solver,
+        "selected_todo_completed_before_spend": selected_todo_completed_before_spend,
+        "non_selected_todos_preserved_open_or_deferred": controller_trace.get(
+            "non_selected_todos_preserved_open_or_deferred"
+        )
+        is True,
+        "planned_todo_count": count("planned_todo_count"),
+        "planned_p0_count": count("planned_p0_count"),
         "case_goal_state_packet_present": controller_trace.get(
             "case_goal_state_packet_present"
         )
@@ -2249,6 +2333,20 @@ def _skillsbench_controller_trace_counters(
     )
     if last_decision:
         counters["last_decision"] = last_decision
+    selected_p0_todo_id = _skillsbench_public_safe_label(
+        controller_trace.get("selected_p0_todo_id") or ""
+    )
+    if selected_p0_todo_id:
+        counters["selected_p0_todo_id"] = selected_p0_todo_id
+    for source_key in (
+        "remote_command_file_bridge_agent_loopx_subcommand_counts",
+        "remote_command_file_bridge_agent_successful_loopx_subcommand_counts",
+        "remote_command_file_bridge_driver_lifecycle_command_counts",
+        "remote_command_file_bridge_driver_lifecycle_returncode_counts",
+    ):
+        counts = count_map(source_key)
+        if counts:
+            counters[source_key] = counts
     init_status = _skillsbench_public_safe_label(
         controller_trace.get("case_goal_state_init_status") or ""
     )

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -28,6 +28,15 @@ SKILLSBENCH_PRODUCT_MODE_CASE_GOAL_ID = "skillsbench-case"
 SKILLSBENCH_PRODUCT_MODE_CASE_STATE_PATH = benchmark_case_active_state_path(
     SKILLSBENCH_PRODUCT_MODE_CASE_GOAL_ID
 )
+SKILLSBENCH_RAW_CODEX_AUTONOMOUS_ROUTE = "raw-codex-autonomous-max5"
+SKILLSBENCH_LOOPX_PRODUCT_MODE_ROUTE = "loopx-product-mode"
+SKILLSBENCH_LOOPX_GOAL_START_PRODUCT_MODE_ROUTE = "loopx-goal-start-product-mode"
+SKILLSBENCH_LOOPX_PRODUCT_MODE_TREATMENT_ROUTES = frozenset(
+    {
+        SKILLSBENCH_LOOPX_PRODUCT_MODE_ROUTE,
+        SKILLSBENCH_LOOPX_GOAL_START_PRODUCT_MODE_ROUTE,
+    }
+)
 SKILLSBENCH_ROUTES = (
     "codex-acp-blind-loop-baseline",
     "loopx-blind-loop-treatment",
@@ -36,8 +45,9 @@ SKILLSBENCH_ROUTES = (
     "codex-goal-mode-baseline",
     "automation-loop-treatment",
     "curated-skills-baseline",
-    "raw-codex-autonomous-max5",
-    "loopx-product-mode",
+    SKILLSBENCH_RAW_CODEX_AUTONOMOUS_ROUTE,
+    SKILLSBENCH_LOOPX_PRODUCT_MODE_ROUTE,
+    SKILLSBENCH_LOOPX_GOAL_START_PRODUCT_MODE_ROUTE,
 )
 SKILLSBENCH_DEFAULT_ROUTE = "loopx-blind-loop-treatment"
 
@@ -75,9 +85,30 @@ SKILLSBENCH_VERIFIER_DEPENDENCY_PREWARM_SCOPES = (
     "derived_sandbox_image",
 )
 SKILLSBENCH_LOCAL_DRIVER_A2A_PAIR_ROUTES = (
-    "raw-codex-autonomous-max5",
-    "loopx-product-mode",
+    SKILLSBENCH_RAW_CODEX_AUTONOMOUS_ROUTE,
+    SKILLSBENCH_LOOPX_PRODUCT_MODE_ROUTE,
+    SKILLSBENCH_LOOPX_GOAL_START_PRODUCT_MODE_ROUTE,
 )
+
+
+def _is_skillsbench_loopx_product_mode_treatment_route(route: str) -> bool:
+    return route in SKILLSBENCH_LOOPX_PRODUCT_MODE_TREATMENT_ROUTES
+
+
+def _is_skillsbench_goal_start_product_mode_route(route: str) -> bool:
+    return route == SKILLSBENCH_LOOPX_GOAL_START_PRODUCT_MODE_ROUTE
+
+
+def _skillsbench_product_mode_arm_id(route: str) -> str:
+    if _is_skillsbench_goal_start_product_mode_route(route):
+        return "loopx_goal_start_product_mode"
+    return "loopx_product_mode"
+
+
+def _skillsbench_product_mode_outer_controller(route: str) -> str:
+    if _is_skillsbench_goal_start_product_mode_route(route):
+        return "loopx_goal_start_product_mode"
+    return "loopx_product_mode"
 
 
 def _skillsbench_public_safe_label(value: Any, *, limit: int = 120) -> str | None:
@@ -183,7 +214,7 @@ def skillsbench_route_contract(route: str) -> dict[str, Any]:
                 "verifier output to the in-case agent during the loop"
             ),
         }
-    if route == "raw-codex-autonomous-max5":
+    if route == SKILLSBENCH_RAW_CODEX_AUTONOMOUS_ROUTE:
         return {
             "mode": "skillsbench_raw_codex_autonomous_max5_baseline",
             "arm_id": "raw_codex_autonomous_max5",
@@ -211,17 +242,30 @@ def skillsbench_route_contract(route: str) -> dict[str, Any]:
                 "returned during execution"
             ),
         }
-    if route == "loopx-product-mode":
+    if _is_skillsbench_loopx_product_mode_treatment_route(route):
+        goal_start_product_mode = _is_skillsbench_goal_start_product_mode_route(route)
         return {
-            "mode": "skillsbench_loopx_product_mode_treatment",
-            "arm_id": "loopx_product_mode",
-            "source_runner": "loopx_skillsbench_canonical_product_lifecycle_driver",
+            "mode": (
+                "skillsbench_loopx_goal_start_product_mode_treatment"
+                if goal_start_product_mode
+                else "skillsbench_loopx_product_mode_treatment"
+            ),
+            "arm_id": _skillsbench_product_mode_arm_id(route),
+            "source_runner": (
+                "loopx_skillsbench_goal_start_product_lifecycle_driver"
+                if goal_start_product_mode
+                else "loopx_skillsbench_canonical_product_lifecycle_driver"
+            ),
             "inner_codex_goal_mode": False,
             "native_goal_mode_requested": False,
             "native_goal_mode_invoked": False,
             "native_goal_mode_confirmation_status": "not_requested",
             "codex_acp_protocol_used": True,
-            "skillsbench_route_semantics": "codex_agent_with_loopx_state_todo_replan_cli_no_reward_feedback",
+            "skillsbench_route_semantics": (
+                "codex_agent_with_loopx_goal_start_ranked_todo_plan_selected_p0_lifecycle_no_reward_feedback"
+                if goal_start_product_mode
+                else "codex_agent_with_loopx_state_todo_replan_cli_no_reward_feedback"
+            ),
             "curated_skills_visible": False,
             "loopx_automation_loop": True,
             "loopx_inside_case": True,
@@ -234,9 +278,16 @@ def skillsbench_route_contract(route: str) -> dict[str, Any]:
             "official_score_comparable_to_loopx_treatment": True,
             "first_blocker": "none",
             "next_action": (
-                "run LoopX product-mode treatment with goal state, todos, "
-                "replan/status writeback, and LoopX CLI/ledger surfaces; do not "
-                "return official reward or verifier feedback during execution"
+                "run LoopX goal-start product-mode treatment with a compact ranked "
+                "todo plan, selected P0 todo lifecycle, replan/status writeback, "
+                "and LoopX CLI/ledger surfaces; do not return official reward or "
+                "verifier feedback during execution"
+                if goal_start_product_mode
+                else (
+                    "run LoopX product-mode treatment with goal state, todos, "
+                    "replan/status writeback, and LoopX CLI/ledger surfaces; do not "
+                    "return official reward or verifier feedback during execution"
+                )
             ),
         }
     if route == "codex-goal-mode-baseline":
@@ -1512,6 +1563,10 @@ def build_skillsbench_benchmark_run(
         raise ValueError(f"unsupported SkillsBench route: {route}")
     contract = skillsbench_route_contract(route)
     job_name = skillsbench_job_name(dataset, task_id, route)
+    is_product_mode_treatment = _is_skillsbench_loopx_product_mode_treatment_route(
+        route
+    )
+    is_goal_start_product_mode = _is_skillsbench_goal_start_product_mode_route(route)
     validation: dict[str, Any] = {
         "cli_skeleton_present": True,
         "skillsbench_route_declared": True,
@@ -1577,14 +1632,18 @@ def build_skillsbench_benchmark_run(
                 if route == "raw-codex-autonomous-max5"
                 else [
                     "ordinary_codex_cli_actor",
-                    "loopx_product_mode",
-                    "goal_state_todos_replan_cli",
+                    "loopx_goal_start_product_mode"
+                    if is_goal_start_product_mode
+                    else "loopx_product_mode",
+                    "ranked_todo_plan_selected_p0_lifecycle"
+                    if is_goal_start_product_mode
+                    else "goal_state_todos_replan_cli",
                     "official_feedback_withheld",
                     "fixture_only",
                     "no_upload",
                     "single_task_planned",
                 ]
-                if route == "loopx-product-mode"
+                if is_product_mode_treatment
                 else [
                     "ordinary_codex_cli_actor",
                     "loopx_prompt_polling_test",
@@ -1655,26 +1714,30 @@ def build_skillsbench_benchmark_run(
             "loopx_case_state_reads": 0,
             "loopx_case_state_writes": 0,
             "heartbeat_count": 0,
-            "case_goal_state_packet_present": route == "loopx-product-mode",
-            "case_goal_state_init_required": route == "loopx-product-mode",
+            "case_goal_state_packet_present": is_product_mode_treatment,
+            "case_goal_state_init_required": is_product_mode_treatment,
             "case_goal_state_initialized_before_agent": False,
             "case_goal_state_init_status": (
                 "not_run_adapter_skeleton"
-                if route == "loopx-product-mode"
+                if is_product_mode_treatment
                 else ""
             ),
             "case_goal_state_schema_version": (
                 BENCHMARK_CASE_ACTIVE_STATE_SCHEMA_VERSION
-                if route == "loopx-product-mode"
+                if is_product_mode_treatment
                 else ""
             ),
             "case_goal_state_path": (
                 SKILLSBENCH_PRODUCT_MODE_CASE_STATE_PATH
-                if route == "loopx-product-mode"
+                if is_product_mode_treatment
                 else ""
             ),
-            "declared_done_requires_no_remaining_goals": route
-            == "loopx-product-mode",
+            "declared_done_requires_no_remaining_goals": is_product_mode_treatment,
+            "goal_start_product_mode": is_goal_start_product_mode,
+            "goal_start_plan_observed": False,
+            "planned_todo_count": 0,
+            "planned_p0_count": 0,
+            "selected_p0_todo_id": "",
             "case_result_writeback": "not_run_adapter_skeleton",
             "counter_trust_level": "adapter_contract_fixture",
         },
@@ -1686,8 +1749,8 @@ def build_skillsbench_benchmark_run(
                 if route == "loopx-prompt-polling-test"
                 else "loopx_blind_automation_loop"
                 if route == "loopx-blind-loop-treatment"
-                else "loopx_product_mode"
-                if route == "loopx-product-mode"
+                else _skillsbench_product_mode_outer_controller(route)
+                if is_product_mode_treatment
                 else "reward_feedback_automation_loop_ablation"
                 if route == "automation-loop-treatment"
                 else "raw_codex_autonomous_max5"
@@ -1707,7 +1770,7 @@ def build_skillsbench_benchmark_run(
                     "loopx-prompt-polling-test",
                     "codex-acp-blind-loop-baseline",
                     "raw-codex-autonomous-max5",
-                    "loopx-product-mode",
+                    *SKILLSBENCH_LOOPX_PRODUCT_MODE_TREATMENT_ROUTES,
                 }
                 else "codex_acp_goal_prompt_request_unconfirmed_native_goal_mode"
                 if route == "codex-goal-mode-baseline"
@@ -2750,8 +2813,8 @@ def build_skillsbench_benchflow_result_benchmark_run(
         if route == "loopx-blind-loop-treatment"
         else "loopx_prompt_polling_loop"
         if route == "loopx-prompt-polling-test"
-        else "loopx_product_mode"
-        if route == "loopx-product-mode"
+        else _skillsbench_product_mode_outer_controller(route)
+        if _is_skillsbench_loopx_product_mode_treatment_route(route)
         else "reward_feedback_automation_loop_ablation"
         if route == "automation-loop-treatment"
         else "raw_codex_autonomous_max5"
@@ -2771,7 +2834,7 @@ def build_skillsbench_benchflow_result_benchmark_run(
             "loopx-prompt-polling-test",
             "codex-acp-blind-loop-baseline",
             "raw-codex-autonomous-max5",
-            "loopx-product-mode",
+            *SKILLSBENCH_LOOPX_PRODUCT_MODE_TREATMENT_ROUTES,
         }
         else "codex_acp_goal_prompt_request_unconfirmed_native_goal_mode"
         if route == "codex-goal-mode-baseline"
@@ -2909,7 +2972,9 @@ def build_skillsbench_benchflow_result_benchmark_run(
         value = trajectory_summary.get(name, 0)
         return value if isinstance(value, int) and not isinstance(value, bool) else 0
 
-    product_mode_lifecycle_required = bool(route == "loopx-product-mode")
+    product_mode_lifecycle_required = _is_skillsbench_loopx_product_mode_treatment_route(
+        route
+    )
     workflow_execution_style = controller_counters.get(
         "remote_command_file_bridge_driver_lifecycle_execution_style"
     )
@@ -3364,7 +3429,7 @@ def build_skillsbench_benchflow_result_benchmark_run(
             "skillsbench_host_local_acp_codex_exec_failed",
             "skillsbench_runner_setup_error",
             "skillsbench_product_mode_transport_failure"
-            if route == "loopx-product-mode"
+            if _is_skillsbench_loopx_product_mode_treatment_route(route)
             else "",
         ):
             if item and item not in failure_labels:
@@ -3786,6 +3851,35 @@ def build_skillsbench_benchflow_result_benchmark_run(
             ),
             "controller_blind_loop": controller_counters.get("blind_loop", False),
             "product_mode": controller_counters.get("product_mode", False),
+            "goal_start_product_mode": controller_counters.get(
+                "goal_start_product_mode", False
+            ),
+            "goal_start_plan_observed": controller_counters.get(
+                "goal_start_plan_observed", False
+            ),
+            "planned_todo_count": controller_counters.get("planned_todo_count", 0),
+            "planned_p0_count": controller_counters.get("planned_p0_count", 0),
+            "planner_before_todo_write": controller_counters.get(
+                "planner_before_todo_write", False
+            ),
+            "same_priority_order_preserved": controller_counters.get(
+                "same_priority_order_preserved", False
+            ),
+            "selected_p0_todo_id": controller_counters.get(
+                "selected_p0_todo_id", ""
+            ),
+            "selected_todo_claimed": controller_counters.get(
+                "selected_todo_claimed", False
+            ),
+            "selected_todo_updated_before_solver": controller_counters.get(
+                "selected_todo_updated_before_solver", False
+            ),
+            "selected_todo_completed_before_spend": controller_counters.get(
+                "selected_todo_completed_before_spend", False
+            ),
+            "non_selected_todos_preserved_open_or_deferred": controller_counters.get(
+                "non_selected_todos_preserved_open_or_deferred", False
+            ),
             "case_goal_state_packet_present": controller_counters.get(
                 "case_goal_state_packet_present", False
             ),

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -191,6 +191,24 @@ def _codex_exec_failure_category(
         or ("create_connection" in text and "socket" in text)
     ):
         return "codex_reverse_channel_unavailable"
+    if any(
+        token in text
+        for token in (
+            "failed to refresh available models",
+            "stream disconnected before completion",
+            "error sending request",
+            "request error",
+        )
+    ) and any(
+        token in text
+        for token in (
+            "chatgpt.com",
+            "api.openai.com",
+            "backend-api",
+            "available models",
+        )
+    ):
+        return "codex_network_or_api_unreachable"
     if "hit your usage limit" in text or "usage limit" in text:
         return "codex_usage_limit"
     if "codex_exec_first_action_timeout" in text:

--- a/loopx/benchmark_case_state.py
+++ b/loopx/benchmark_case_state.py
@@ -44,6 +44,32 @@ BENCHMARK_CASE_LOOPX_TODO_ID = build_todo_id(
     index=1,
     text=BENCHMARK_CASE_LOOPX_TODO_TEXT,
 )
+BENCHMARK_CASE_LOOPX_GOAL_START_TODO_TEXTS = (
+    BENCHMARK_CASE_LOOPX_TODO_TEXT,
+    (
+        "Validate the benchmark solution locally and keep public-safe LoopX "
+        "evidence before final closeout."
+    ),
+    (
+        "Close out the selected solver todo only after validation, then "
+        "refresh state and spend quota once."
+    ),
+)
+BENCHMARK_CASE_LOOPX_GOAL_START_TODO_IDS = tuple(
+    build_todo_id(
+        role="agent",
+        source_section="Agent Todo",
+        index=index,
+        text=text,
+    )
+    for index, text in enumerate(
+        BENCHMARK_CASE_LOOPX_GOAL_START_TODO_TEXTS,
+        start=1,
+    )
+)
+BENCHMARK_CASE_LOOPX_GOAL_START_SELECTED_TODO_ID = (
+    BENCHMARK_CASE_LOOPX_GOAL_START_TODO_IDS[0]
+)
 BENCHMARK_CASE_LOOPX_FORMAL_TREATMENT_SEMANTICS = "loopx-product-mode"
 BENCHMARK_CASE_LOOPX_PROMPT_DRIVEN_EXECUTION_STYLE = "prompt_driven_loopx_cli"
 BENCHMARK_CASE_LOOPX_ORCHESTRATED_EXECUTION_STYLE = (
@@ -673,6 +699,7 @@ def benchmark_case_loopx_install_command(
     case_agent_id: str = BENCHMARK_CASE_LOOPX_AGENT_ID,
     case_todo_text: str = BENCHMARK_CASE_LOOPX_TODO_TEXT,
     case_todo_id: str = BENCHMARK_CASE_LOOPX_TODO_ID,
+    goal_start_product_mode: bool = False,
 ) -> str:
     """Return the official case-local LoopX product-mode install command.
 
@@ -711,7 +738,6 @@ def benchmark_case_loopx_install_command(
     )
     runtime_root = shlex.quote(case_runtime_root)
     installer_url = shlex.quote(BENCHMARK_CASE_LOOPX_OFFICIAL_INSTALLER_URL)
-    todo_text = shlex.quote(case_todo_text)
     bootstrap_cmd = (
         f"{cli_prefix} bootstrap "
         f"--project {project_root} "
@@ -733,13 +759,58 @@ def benchmark_case_loopx_install_command(
         f"--primary-agent {shlex.quote(case_agent_id)} "
         "--execute"
     )
-    todo_add_cmd = (
-        f"{cli_prefix} todo add "
+    goal_start_pack_cmd = (
+        f"{cli_prefix} bootstrap-command-pack "
+        f"--project {project_root} "
         f"--goal-id {shlex.quote(goal_id)} "
-        "--role agent "
-        f"--text {todo_text} "
-        "--task-class advancement_task "
-        "--action-kind solve_benchmark_case"
+        f"--agent-id {shlex.quote(case_agent_id)} "
+        "--host-surface shell "
+        "--message-only "
+        "--goal-text "
+        f"{shlex.quote('Solve the current benchmark task with a compact LoopX ranked todo plan.')}"
+    )
+    if goal_start_product_mode:
+        if len(BENCHMARK_CASE_LOOPX_GOAL_START_TODO_TEXTS) != len(
+            BENCHMARK_CASE_LOOPX_GOAL_START_TODO_IDS
+        ):
+            raise ValueError("goal-start todo text/id contract length mismatch")
+        todo_specs = [
+            (
+                text,
+                todo_id,
+                "solve_benchmark_case"
+                if index == 0
+                else "validate_benchmark_case"
+                if index == 1
+                else "closeout_benchmark_case",
+            )
+            for index, (text, todo_id) in enumerate(
+                zip(
+                    BENCHMARK_CASE_LOOPX_GOAL_START_TODO_TEXTS,
+                    BENCHMARK_CASE_LOOPX_GOAL_START_TODO_IDS,
+                )
+            )
+        ]
+    else:
+        todo_specs = [(case_todo_text, case_todo_id, "solve_benchmark_case")]
+    todo_add_cmds = []
+    for planned_todo_text, planned_todo_id, action_kind in todo_specs:
+        todo_add_cmds.append(
+            f"{cli_prefix} todo add "
+            f"--goal-id {shlex.quote(goal_id)} "
+            "--role agent "
+            f"--todo-id {shlex.quote(planned_todo_id)} "
+            f"--text {shlex.quote(planned_todo_text)} "
+            "--task-class advancement_task "
+            f"--action-kind {shlex.quote(action_kind)}"
+        )
+    todo_add_cmd = "\n".join(todo_add_cmds)
+    goal_start_plan_cmd = (
+        "echo 'loopx_case_init_phase:goal_start_plan' >&2\n"
+        f"{goal_start_pack_cmd} >/tmp/loopx_goal_start_command_pack.txt\n"
+        "test -s /tmp/loopx_goal_start_command_pack.txt\n"
+        if goal_start_product_mode
+        else ""
     )
     quota_cmd = (
         f"{cli_prefix} quota should-run "
@@ -815,6 +886,7 @@ def benchmark_case_loopx_install_command(
         f"{bootstrap_cmd}\n"
         "echo 'loopx_case_init_phase:configure_goal' >&2\n"
         f"{configure_cmd}\n"
+        f"{goal_start_plan_cmd}"
         "echo 'loopx_case_init_phase:todo_add' >&2\n"
         f"{todo_add_cmd}\n"
         "echo 'loopx_case_init_phase:quota_should_run' >&2\n"
@@ -840,6 +912,7 @@ def benchmark_case_loopx_install_payload(
     case_loopx_source_path: str | None = None,
     case_agent_id: str = BENCHMARK_CASE_LOOPX_AGENT_ID,
     case_todo_id: str = BENCHMARK_CASE_LOOPX_TODO_ID,
+    goal_start_product_mode: bool = False,
 ) -> dict[str, object]:
     """Return the case-local GH install/state/todo launch payload."""
 
@@ -860,6 +933,21 @@ def benchmark_case_loopx_install_payload(
         case_state_path=case_state_path,
     )
     case_rollout_event_log_path = benchmark_case_loopx_event_log_path(goal_id)
+    planned_todo_texts = (
+        BENCHMARK_CASE_LOOPX_GOAL_START_TODO_TEXTS
+        if goal_start_product_mode
+        else (BENCHMARK_CASE_LOOPX_TODO_TEXT,)
+    )
+    planned_todo_ids = (
+        BENCHMARK_CASE_LOOPX_GOAL_START_TODO_IDS
+        if goal_start_product_mode
+        else (case_todo_id,)
+    )
+    selected_todo_id = (
+        BENCHMARK_CASE_LOOPX_GOAL_START_SELECTED_TODO_ID
+        if goal_start_product_mode
+        else case_todo_id
+    )
     return {
         "schema_version": BENCHMARK_CASE_ACTIVE_STATE_SCHEMA_VERSION,
         "install_flow_schema_version": (
@@ -883,11 +971,26 @@ def benchmark_case_loopx_install_payload(
         "case_loopx_source_install_requested": bool(case_loopx_source_path),
         "case_rollout_event_log_path": case_rollout_event_log_path,
         "case_agent_id": case_agent_id,
-        "case_todo_id": case_todo_id,
+        "case_todo_id": selected_todo_id,
         "case_todo_text_public_safe": BENCHMARK_CASE_LOOPX_TODO_TEXT,
         "case_todo_seeded": True,
         "case_todo_preclaimed": False,
         "case_todo_seeded_by": "loopx todo add",
+        "goal_start_product_mode": goal_start_product_mode,
+        "goal_start_plan_observed": goal_start_product_mode,
+        "planner_before_todo_write": goal_start_product_mode,
+        "planned_todo_count": len(planned_todo_ids),
+        "planned_todo_ids": list(planned_todo_ids),
+        "planned_todo_texts_public_safe": list(planned_todo_texts),
+        "planned_p0_count": 1 if goal_start_product_mode else 0,
+        "same_priority_order_preserved": goal_start_product_mode,
+        "selected_p0_todo_id": selected_todo_id,
+        "selected_todo_claimed": False,
+        "selected_todo_updated_before_solver": False,
+        "selected_todo_completed_before_spend": False,
+        "non_selected_todos_preserved_open_or_deferred": (
+            goal_start_product_mode
+        ),
         "install_flow_required": True,
         "prompt_driven_route_required": True,
         "product_path_primary_route": (
@@ -916,7 +1019,8 @@ def benchmark_case_loopx_install_payload(
             case_goal_doc_path=BENCHMARK_CASE_LOOPX_GOAL_DOC_PATH,
             case_agent_id=case_agent_id,
             case_todo_text=BENCHMARK_CASE_LOOPX_TODO_TEXT,
-            case_todo_id=case_todo_id,
+            case_todo_id=selected_todo_id,
+            goal_start_product_mode=goal_start_product_mode,
         ),
         "raw_task_text_required_for_init": False,
         "raw_logs_recorded": False,

--- a/loopx/benchmark_core/loop_protocol.py
+++ b/loopx/benchmark_core/loop_protocol.py
@@ -22,6 +22,7 @@ LOOPX_PROMPT_POLLING_TEST_ROUTE = "loopx-prompt-polling-test"
 AUTOMATION_LOOP_TREATMENT_ROUTE = "automation-loop-treatment"
 RAW_CODEX_AUTONOMOUS_MAX5_ROUTE = "raw-codex-autonomous-max5"
 LOOPX_PRODUCT_MODE_ROUTE = "loopx-product-mode"
+LOOPX_GOAL_START_PRODUCT_MODE_ROUTE = "loopx-goal-start-product-mode"
 CODEX_APP_SERVER_GOAL_BASELINE_ROUTE = "codex-app-server-goal-baseline"
 LOOPX_PACKET_ONLY_OBSERVATION_ROUTE = (
     "loopx-packet-only-observation"
@@ -41,6 +42,7 @@ NO_REWARD_FEEDBACK_ROUTES = frozenset(
         LOOPX_PROMPT_POLLING_TEST_ROUTE,
         RAW_CODEX_AUTONOMOUS_MAX5_ROUTE,
         LOOPX_PRODUCT_MODE_ROUTE,
+        LOOPX_GOAL_START_PRODUCT_MODE_ROUTE,
         CODEX_APP_SERVER_GOAL_BASELINE_ROUTE,
     }
 )
@@ -48,6 +50,13 @@ PRODUCT_MODE_ROUTES = frozenset(
     {
         RAW_CODEX_AUTONOMOUS_MAX5_ROUTE,
         LOOPX_PRODUCT_MODE_ROUTE,
+        LOOPX_GOAL_START_PRODUCT_MODE_ROUTE,
+    }
+)
+LOOPX_PRODUCT_MODE_TREATMENT_ROUTES = frozenset(
+    {
+        LOOPX_PRODUCT_MODE_ROUTE,
+        LOOPX_GOAL_START_PRODUCT_MODE_ROUTE,
     }
 )
 
@@ -160,8 +169,18 @@ def build_product_mode_main_table_comparison_contract(
         route=treatment_route,
         max_rounds=budget,
         protocol_id=PRODUCT_MODE_MAX5_NO_FEEDBACK_PROTOCOL_ID
-        if treatment_route == LOOPX_PRODUCT_MODE_ROUTE
+        if treatment_route in LOOPX_PRODUCT_MODE_TREATMENT_ROUTES
         else None,
+    )
+    treatment_arm_id = (
+        "loopx_goal_start_product_mode"
+        if treatment_route == LOOPX_GOAL_START_PRODUCT_MODE_ROUTE
+        else "loopx_product_mode"
+    )
+    treatment_agent_surface = (
+        "loopx_goal_start_plan_todo_lifecycle_cli"
+        if treatment_route == LOOPX_GOAL_START_PRODUCT_MODE_ROUTE
+        else "loopx_state_todo_replan_cli"
     )
     return {
         "schema_version": BENCHMARK_PRODUCT_MODE_COMPARISON_SCHEMA_VERSION,
@@ -179,12 +198,12 @@ def build_product_mode_main_table_comparison_contract(
         },
         "treatment_arm": {
             "route": treatment_route,
-            "arm_id": "loopx_product_mode",
+            "arm_id": treatment_arm_id,
             "contract": treatment_contract,
             "loopx_state_todo_replan_cli_required": True,
             "case_local_loopx_state_required": True,
             "loopx_cli_required": True,
-            "agent_surface": "loopx_state_todo_replan_cli",
+            "agent_surface": treatment_agent_surface,
         },
         "policy_gate": {
             "same_benchmark_and_case_required": True,

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -762,6 +762,14 @@ def _compact_benchmark_interaction_counters(value: Any) -> dict[str, Any]:
         "inner_codex_goal_mode",
         "curated_skills_visible",
         "product_mode",
+        "goal_start_product_mode",
+        "goal_start_plan_observed",
+        "planner_before_todo_write",
+        "same_priority_order_preserved",
+        "selected_todo_claimed",
+        "selected_todo_updated_before_solver",
+        "selected_todo_completed_before_spend",
+        "non_selected_todos_preserved_open_or_deferred",
         "blind_loop",
         "case_goal_state_packet_present",
         "case_goal_state_init_required",
@@ -828,6 +836,8 @@ def _compact_benchmark_interaction_counters(value: Any) -> dict[str, Any]:
         "controller_official_success_observation_count",
         "controller_first_success_round",
         "declared_done_round",
+        "planned_todo_count",
+        "planned_p0_count",
         "product_mode_lifecycle_checkpoint_count",
         "product_mode_lifecycle_checkpoint_round",
         "product_mode_solver_activity_gap_count",
@@ -969,11 +979,20 @@ def _compact_benchmark_interaction_counters(value: Any) -> dict[str, Any]:
         "trajectory_action_category_counts",
         "loopx_cli_state_usage_counts",
         "remote_command_file_bridge_agent_returncode_counts",
+        "remote_command_file_bridge_agent_loopx_subcommand_counts",
         "remote_command_file_bridge_agent_successful_loopx_subcommand_counts",
+        "remote_command_file_bridge_driver_lifecycle_command_counts",
+        "remote_command_file_bridge_driver_lifecycle_returncode_counts",
     ):
         calls = _compact_numeric_map(value.get(field))
         if calls:
             compact[field] = calls
+    selected_p0_todo_id = public_safe_compact_text(
+        value.get("selected_p0_todo_id"),
+        limit=100,
+    )
+    if selected_p0_todo_id:
+        compact["selected_p0_todo_id"] = selected_p0_todo_id
     raw_loopx_cli_calls = value.get("loopx_cli_calls")
     if isinstance(raw_loopx_cli_calls, dict):
         calls = _compact_numeric_map(raw_loopx_cli_calls)
@@ -1517,6 +1536,9 @@ def _compact_benchmark_runner_prerequisites(value: Any) -> dict[str, Any]:
         "benchflow_intermediate_soft_verify_timeout_cleanup_raw_logs_read",
         "benchflow_intermediate_soft_verify_orphan_cleanup_requested",
         "benchflow_intermediate_soft_verify_orphan_cleanup_raw_logs_read",
+        "goal_start_product_mode",
+        "goal_start_plan_required",
+        "goal_start_selected_p0_lifecycle_required",
         "benchflow_verifier_prep_timeout_override_enabled",
         "benchflow_verifier_prep_timeout_raw_command_recorded",
         "benchflow_final_verifier_timeout_enabled",
@@ -1574,6 +1596,7 @@ def _compact_benchmark_runner_prerequisites(value: Any) -> dict[str, Any]:
         "benchflow_setup_stall_cleanup_term_sent_count",
         "benchflow_setup_stall_cleanup_kill_sent_count",
         "benchflow_setup_stall_cleanup_alive_after_count",
+        "goal_start_planned_todo_count_expected",
         "remote_command_file_bridge_solver_trace_count",
         "remote_command_file_bridge_solver_probe_ready_count",
         "remote_command_file_bridge_solver_operation_count",
@@ -1599,6 +1622,16 @@ def _compact_benchmark_runner_prerequisites(value: Any) -> dict[str, Any]:
     ):
         if isinstance(value.get(field), int) and not isinstance(value.get(field), bool):
             compact[field] = value[field]
+    for field in (
+        "remote_command_file_bridge_agent_operation_counts",
+        "remote_command_file_bridge_agent_loopx_subcommand_counts",
+        "remote_command_file_bridge_agent_successful_loopx_subcommand_counts",
+        "remote_command_file_bridge_driver_lifecycle_command_counts",
+        "remote_command_file_bridge_driver_lifecycle_returncode_counts",
+    ):
+        calls = _compact_numeric_map(value.get(field))
+        if calls:
+            compact[field] = calls
     return compact
 
 

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -9415,6 +9415,49 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps(payload, indent=2, sort_keys=True), file=sys.stderr)
         return 2
     if (
+        _is_loopx_product_mode_route(args.route)
+        and args.host_local_acp_launch
+        and product_host_local_bridge_sandbox_auto_wiring_pending
+        and not args.local_driver_worker_handshake_preflight
+        and not args.plan_only
+        and not args.reduce_only
+    ):
+        payload = {
+            "ok": False,
+            "error_type": "SkillsBenchProductModeBridgeAutoWiringPending",
+            "route": args.route,
+            "reason": (
+                "LoopX product-mode routes are countable only when the "
+                "host-local agent has an explicit sandbox command/file bridge "
+                "available before the scored case starts. A readiness "
+                "declaration without a solver bridge command leaves sandbox "
+                "bridge auto-wiring pending; prior runs can reach the agent "
+                "with zero task-facing bridge/tool calls, then fail after "
+                "consuming a scored attempt."
+            ),
+            "next_action": (
+                "rerun with a real --remote-command-file-bridge-solver-command "
+                "and a countable agent bridge command or instrumented wrapper; "
+                "use --plan-only or --local-driver-worker-handshake-preflight "
+                "for non-executing readiness inspection"
+            ),
+            "remote_command_file_bridge_materialized": (
+                product_host_local_bridge_materialized
+            ),
+            "remote_command_file_bridge_command_configured": False,
+            "remote_command_file_bridge_solver_wiring_configured": False,
+            "remote_command_file_bridge_consumed_by_solver": False,
+            "remote_command_file_bridge_consumption_status": (
+                "sandbox_bridge_auto_wiring_pending"
+            ),
+            "raw_logs_recorded": False,
+            "raw_task_text_read": False,
+            "raw_trajectory_recorded": False,
+            "credential_values_recorded": False,
+        }
+        print(json.dumps(payload, indent=2, sort_keys=True), file=sys.stderr)
+        return 2
+    if (
         args.route in PRODUCT_MODE_CONTROLLER_ROUTES
         and args.host_local_acp_launch
         and not (

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -9001,6 +9001,48 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps(payload, indent=2, sort_keys=True), file=sys.stderr)
         return 2
     if (
+        args.route == "loopx-product-mode"
+        and args.host_local_acp_launch
+        and product_host_local_bridge_sandbox_auto_wiring_pending
+        and not args.local_driver_worker_handshake_preflight
+        and not args.plan_only
+        and not args.reduce_only
+    ):
+        payload = {
+            "ok": False,
+            "error_type": "SkillsBenchProductModeBridgeAutoWiringPending",
+            "route": args.route,
+            "reason": (
+                "loopx-product-mode is countable only when the host-local "
+                "agent has an explicit sandbox command/file bridge available "
+                "before the scored case starts. A readiness declaration without "
+                "a solver bridge command leaves sandbox bridge auto-wiring "
+                "pending; prior runs can reach the agent with zero task-facing "
+                "bridge/tool calls, then fail after consuming a scored attempt."
+            ),
+            "next_action": (
+                "rerun with a real --remote-command-file-bridge-solver-command "
+                "and a countable agent bridge command or instrumented wrapper; "
+                "use --plan-only or --local-driver-worker-handshake-preflight "
+                "for non-executing readiness inspection"
+            ),
+            "remote_command_file_bridge_materialized": (
+                product_host_local_bridge_materialized
+            ),
+            "remote_command_file_bridge_command_configured": False,
+            "remote_command_file_bridge_solver_wiring_configured": False,
+            "remote_command_file_bridge_consumed_by_solver": False,
+            "remote_command_file_bridge_consumption_status": (
+                "sandbox_bridge_auto_wiring_pending"
+            ),
+            "raw_logs_recorded": False,
+            "raw_task_text_read": False,
+            "raw_trajectory_recorded": False,
+            "credential_values_recorded": False,
+        }
+        print(json.dumps(payload, indent=2, sort_keys=True), file=sys.stderr)
+        return 2
+    if (
         args.route in {"raw-codex-autonomous-max5", "loopx-product-mode"}
         and args.host_local_acp_launch
         and not (

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -114,6 +114,7 @@ from loopx.benchmark_core.loop_protocol import (  # noqa: E402
     CODEX_ACP_BLIND_LOOP_BASELINE_ROUTE,
     CODEX_APP_SERVER_GOAL_BASELINE_ROUTE,
     LOOPX_BLIND_LOOP_TREATMENT_ROUTE,
+    LOOPX_GOAL_START_PRODUCT_MODE_ROUTE,
     LOOPX_PRODUCT_MODE_ROUTE,
     LOOPX_PROMPT_POLLING_TEST_ROUTE,
     RAW_CODEX_AUTONOMOUS_MAX5_ROUTE,
@@ -160,6 +161,7 @@ SUPPORTED_ROUTES = (
     LOOPX_PROMPT_POLLING_TEST_ROUTE,
     RAW_CODEX_AUTONOMOUS_MAX5_ROUTE,
     LOOPX_PRODUCT_MODE_ROUTE,
+    LOOPX_GOAL_START_PRODUCT_MODE_ROUTE,
     CODEX_APP_SERVER_GOAL_BASELINE_ROUTE,
     "codex-goal-mode-baseline",
     AUTOMATION_LOOP_TREATMENT_ROUTE,
@@ -178,13 +180,39 @@ PRODUCT_MODE_CASE_STATE_PATH = benchmark_case_active_state_path(
     PRODUCT_MODE_CASE_GOAL_ID
 )
 PRODUCT_MODE_CASE_STATE_SCHEMA_VERSION = BENCHMARK_CASE_ACTIVE_STATE_SCHEMA_VERSION
+LOOPX_PRODUCT_MODE_FAMILY_ROUTES = frozenset(
+    {
+        LOOPX_PRODUCT_MODE_ROUTE,
+        LOOPX_GOAL_START_PRODUCT_MODE_ROUTE,
+    }
+)
+PRODUCT_MODE_CONTROLLER_ROUTES = frozenset(
+    {
+        RAW_CODEX_AUTONOMOUS_MAX5_ROUTE,
+        *LOOPX_PRODUCT_MODE_FAMILY_ROUTES,
+    }
+)
+
+
+def _is_loopx_product_mode_route(route: str) -> bool:
+    return route in LOOPX_PRODUCT_MODE_FAMILY_ROUTES
+
+
+def _is_goal_start_product_mode_route(route: str) -> bool:
+    return route == LOOPX_GOAL_START_PRODUCT_MODE_ROUTE
+
+
+def _product_mode_arm_id_for_route(route: str) -> str:
+    if _is_goal_start_product_mode_route(route):
+        return "loopx_goal_start_product_mode"
+    return "loopx_product_mode"
 
 
 def product_mode_soft_verify_policy_for_route(
     route: str,
     requested_policy: str,
 ) -> str:
-    if route in {"raw-codex-autonomous-max5", "loopx-product-mode"}:
+    if route in PRODUCT_MODE_CONTROLLER_ROUTES:
         return requested_policy
     return "every-round"
 
@@ -753,7 +781,7 @@ def _host_local_acp_launch_command(
     if args.model:
         command.extend(["--model", args.model])
     if (
-        args.route in {"raw-codex-autonomous-max5", "loopx-product-mode"}
+        args.route in PRODUCT_MODE_CONTROLLER_ROUTES
         and args.host_local_acp_launch
         and args.remote_command_file_bridge_solver_command
         and (
@@ -776,14 +804,15 @@ def _host_local_acp_launch_command(
                     args.remote_command_file_bridge_agent_command,
                 ]
         )
-        if args.route == "loopx-product-mode":
+        if _is_loopx_product_mode_route(args.route):
             payload = benchmark_case_loopx_install_payload(
                 benchmark_id="skillsbench",
                 case_id=args.task_id,
-                arm_id="loopx_product_mode",
+                arm_id=_product_mode_arm_id_for_route(args.route),
                 route=args.route,
                 max_rounds=args.max_rounds,
                 case_loopx_source_path=_loopx_case_source_path_for_container(args),
+                goal_start_product_mode=_is_goal_start_product_mode_route(args.route),
             )
             command.extend(
                 [
@@ -809,17 +838,18 @@ def _host_local_acp_launch_command(
                 ]
             )
     if (
-        args.route == "loopx-product-mode"
+        _is_loopx_product_mode_route(args.route)
         and args.host_local_acp_launch
         and "--loopx-workflow-lifecycle-checkpoint" not in command
     ):
         payload = benchmark_case_loopx_install_payload(
             benchmark_id="skillsbench",
             case_id=args.task_id,
-            arm_id="loopx_product_mode",
+            arm_id=_product_mode_arm_id_for_route(args.route),
             route=args.route,
             max_rounds=args.max_rounds,
             case_loopx_source_path=_loopx_case_source_path_for_container(args),
+            goal_start_product_mode=_is_goal_start_product_mode_route(args.route),
         )
         command.extend(
             [
@@ -1018,7 +1048,7 @@ def _host_local_acp_codex_exec_preflight_requires_bridge_action(
     return bool(
         getattr(args, "host_local_acp_launch", False)
         and str(getattr(args, "route", "") or "")
-        in {"raw-codex-autonomous-max5", "loopx-product-mode"}
+        in PRODUCT_MODE_CONTROLLER_ROUTES
         and str(getattr(args, "remote_command_file_bridge_solver_command", "") or "")
         and (
             bool(getattr(args, "remote_command_file_bridge_ready", False))
@@ -1288,7 +1318,7 @@ def _loopx_source_mount_contract(args: argparse.Namespace) -> dict[str, Any]:
     source_dir = Path(str(source_arg)).expanduser() if source_arg else None
     disabled = bool(getattr(args, "no_loopx_source_mount", False))
     requested = (
-        args.route == LOOPX_PRODUCT_MODE_ROUTE
+        _is_loopx_product_mode_route(args.route)
         and args.sandbox == "docker"
         and not disabled
         and source_dir is not None
@@ -3984,7 +4014,9 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
         rollout_suffix = "loopx_prompt_polling_test"
     elif route == LOOPX_BLIND_LOOP_TREATMENT_ROUTE:
         rollout_suffix = "loopx_blind_loop"
-    elif route == "loopx-product-mode":
+    elif route == LOOPX_GOAL_START_PRODUCT_MODE_ROUTE:
+        rollout_suffix = "loopx_goal_start_product_mode"
+    elif route == LOOPX_PRODUCT_MODE_ROUTE:
         rollout_suffix = "loopx_product_mode"
     elif route == "raw-codex-autonomous-max5":
         rollout_suffix = "raw_codex_autonomous_max5"
@@ -4031,18 +4063,18 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
     )
     remote_command_file_bridge_solver_wiring_configured = bool(
         args.host_local_acp_launch
-        and route in {"raw-codex-autonomous-max5", "loopx-product-mode"}
+        and route in PRODUCT_MODE_CONTROLLER_ROUTES
         and remote_command_file_bridge_materialized
         and remote_command_file_bridge_solver_command_configured
     )
     remote_command_file_bridge_sandbox_auto_wiring_pending = bool(
         args.host_local_acp_launch
-        and route in {"raw-codex-autonomous-max5", "loopx-product-mode"}
+        and route in PRODUCT_MODE_CONTROLLER_ROUTES
         and remote_command_file_bridge_materialized
         and not remote_command_file_bridge_solver_command_configured
     )
     remote_command_file_bridge_agent_operation_trace_required = bool(
-        route == "loopx-product-mode"
+        _is_loopx_product_mode_route(route)
         and (
             remote_command_file_bridge_solver_wiring_configured
             or remote_command_file_bridge_sandbox_auto_wiring_pending
@@ -4216,14 +4248,24 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
                 "pending" if args.host_local_acp_launch else "not_requested"
             ),
             "loopx_workflow_lifecycle_checkpoint": bool(
-                args.route == "loopx-product-mode" and args.host_local_acp_launch
+                _is_loopx_product_mode_route(args.route)
+                and args.host_local_acp_launch
             ),
             "loopx_product_mode_lifecycle_driver_kind": (
                 BENCHMARK_CASE_LOOPX_ORCHESTRATED_EXECUTION_STYLE
-                if args.route == "loopx-product-mode" and args.host_local_acp_launch
+                if _is_loopx_product_mode_route(args.route)
+                and args.host_local_acp_launch
                 else BENCHMARK_CASE_LOOPX_PROMPT_DRIVEN_EXECUTION_STYLE
-                if args.route == "loopx-product-mode"
+                if _is_loopx_product_mode_route(args.route)
                 else "not_applicable"
+            ),
+            "goal_start_product_mode": _is_goal_start_product_mode_route(args.route),
+            "goal_start_plan_required": _is_goal_start_product_mode_route(args.route),
+            "goal_start_planned_todo_count_expected": (
+                3 if _is_goal_start_product_mode_route(args.route) else 0
+            ),
+            "goal_start_selected_p0_lifecycle_required": (
+                _is_goal_start_product_mode_route(args.route)
             ),
             "host_local_acp_codex_exec_preflight_requested": bool(
                 args.host_local_acp_codex_exec_preflight
@@ -4771,24 +4813,36 @@ def _new_controller_trace(route: str, *, max_rounds: int | None = None) -> dict[
         max_rounds=max_rounds,
         schema_version="skillsbench_loopx_controller_trace_v0",
     )
+    loopx_product_mode = _is_loopx_product_mode_route(route)
+    goal_start_product_mode = _is_goal_start_product_mode_route(route)
     trace.update(
         {
         "case_goal_state_packet_present": False,
-        "case_goal_state_init_required": route == LOOPX_PRODUCT_MODE_ROUTE,
+        "case_goal_state_init_required": loopx_product_mode,
         "case_goal_state_initialized_before_agent": False,
         "case_goal_state_init_status": "not_applicable",
         "case_goal_state_path": (
             PRODUCT_MODE_CASE_STATE_PATH
-            if route == LOOPX_PRODUCT_MODE_ROUTE
+            if loopx_product_mode
             else ""
         ),
         "case_goal_state_schema_version": (
             PRODUCT_MODE_CASE_STATE_SCHEMA_VERSION
-            if route == LOOPX_PRODUCT_MODE_ROUTE
+            if loopx_product_mode
             else ""
         ),
-        "declared_done_requires_no_remaining_goals": route
-        == LOOPX_PRODUCT_MODE_ROUTE,
+        "declared_done_requires_no_remaining_goals": loopx_product_mode,
+        "goal_start_product_mode": goal_start_product_mode,
+        "goal_start_plan_observed": False,
+        "planned_todo_count": 0,
+        "planned_p0_count": 0,
+        "planner_before_todo_write": False,
+        "same_priority_order_preserved": False,
+        "selected_p0_todo_id": "",
+        "selected_todo_claimed": False,
+        "selected_todo_updated_before_solver": False,
+        "selected_todo_completed_before_spend": False,
+        "non_selected_todos_preserved_open_or_deferred": False,
         "agent_declared_done": False,
         "agent_declared_no_remaining_goals": False,
         "declared_done_round": None,
@@ -6371,7 +6425,8 @@ def _build_product_mode_user(
 ):
     from benchflow.sandbox.user import BaseUser, RoundResult
 
-    treatment = route == "loopx-product-mode"
+    treatment = _is_loopx_product_mode_route(route)
+    goal_start_product_mode = _is_goal_start_product_mode_route(route)
     payload = case_payload or {}
     case_state_path = str(
         payload.get("case_state_path") or PRODUCT_MODE_CASE_STATE_PATH
@@ -6379,6 +6434,8 @@ def _build_product_mode_user(
     case_goal_id = str(payload.get("benchmark_case_goal_id") or PRODUCT_MODE_CASE_GOAL_ID)
     case_agent_id = str(payload.get("case_agent_id") or BENCHMARK_CASE_LOOPX_AGENT_ID)
     case_todo_id = str(payload.get("case_todo_id") or BENCHMARK_CASE_LOOPX_TODO_ID)
+    planned_todo_count = payload.get("planned_todo_count")
+    selected_p0_todo_id = str(payload.get("selected_p0_todo_id") or case_todo_id)
     case_cli_prefix = benchmark_case_loopx_command_prefix(
         case_cli_path=str(payload.get("case_cli_path") or "/app/.local/bin/loopx"),
         case_registry_path=str(payload.get("case_registry_path") or "/app/.loopx/registry.json"),
@@ -6402,6 +6459,23 @@ def _build_product_mode_user(
     )
 
     def treatment_state_contract() -> str:
+        goal_start_clause = ""
+        if goal_start_product_mode:
+            planned_count = (
+                planned_todo_count
+                if isinstance(planned_todo_count, int)
+                and not isinstance(planned_todo_count, bool)
+                and planned_todo_count > 0
+                else 3
+            )
+            goal_start_clause = (
+                "This route simulates `/loopx <task objective>` goal start: "
+                f"a compact ranked {planned_count}-todo plan must exist before "
+                "todo writes, "
+                f"with selected runnable P0 todo `{selected_p0_todo_id}` entering "
+                "the lifecycle. Non-selected todos remain open or deferred until "
+                "the selected P0 is validated. "
+            )
         if workflow_lifecycle_driver:
             return (
                 "LoopX product-mode lifecycle contract: official case-local "
@@ -6411,7 +6485,9 @@ def _build_product_mode_user(
                 "canonical workflow lifecycle driver has already executed the "
                 "case-local `quota should-run`, `todo claim`, `todo update`, "
                 "and `refresh-state` checkpoint through the sandbox bridge "
-                "before this prompt. Do not repeat that setup checkpoint as "
+                "before this prompt. "
+                f"{goal_start_clause}"
+                "Do not repeat that setup checkpoint as "
                 "your first action. The benchmark task remains the primary "
                 "objective; LoopX commands track control-plane state and do "
                 "not themselves complete the task. Before prose planning, "
@@ -6440,6 +6516,7 @@ def _build_product_mode_user(
             "the first control-plane action, run the following commands inside "
             "the scored sandbox, then wait for the scheduler to send the task "
             "packet. "
+            f"{goal_start_clause}"
             "Before reading, planning, solving, or answering the task, your first "
             "agent action must be a shell/tool call that sends the case-local "
             "LoopX CLI commands through the available sandbox bridge; a prose-only "
@@ -7058,7 +7135,7 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
             prerequisites["remote_command_file_bridge_consumption_status"] = (
                 "solver_wiring_configured_pending_prompt"
             )
-            if args.route == "loopx-product-mode":
+            if _is_loopx_product_mode_route(args.route):
                 prerequisites[
                     "remote_command_file_bridge_agent_operation_trace_required"
                 ] = True
@@ -7171,15 +7248,16 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
         prerequisites["codex_acp_runtime_launch_preflight_status"] = "passed"
 
     async def seed_product_mode_case_state(env: Any) -> None:
-        if args.route != "loopx-product-mode":
+        if not _is_loopx_product_mode_route(args.route):
             return
         payload = benchmark_case_loopx_install_payload(
             benchmark_id="skillsbench",
             case_id=args.task_id,
-            arm_id="loopx_product_mode",
+            arm_id=_product_mode_arm_id_for_route(args.route),
             route=args.route,
             max_rounds=args.max_rounds,
             case_loopx_source_path=_loopx_case_source_path_for_container(args),
+            goal_start_product_mode=_is_goal_start_product_mode_route(args.route),
         )
         trace = controller_trace if isinstance(controller_trace, dict) else {}
         trace["case_goal_state_init_required"] = True
@@ -7208,6 +7286,20 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
         trace["loopx_case_todo_id"] = payload.get("case_todo_id") or ""
         trace["loopx_case_todo_seeded"] = bool(payload.get("case_todo_seeded"))
         trace["loopx_case_todo_preclaimed"] = bool(payload.get("case_todo_preclaimed"))
+        for key in (
+            "goal_start_product_mode",
+            "goal_start_plan_observed",
+            "planned_todo_count",
+            "planned_p0_count",
+            "planner_before_todo_write",
+            "same_priority_order_preserved",
+            "selected_p0_todo_id",
+            "selected_todo_claimed",
+            "selected_todo_updated_before_solver",
+            "selected_todo_completed_before_spend",
+            "non_selected_todos_preserved_open_or_deferred",
+        ):
+            trace[key] = payload.get(key)
         trace["case_goal_state_initialized_before_agent"] = False
         result = await env.exec(str(payload["command"]), timeout_sec=180)
         trace["case_goal_state_init_rc"] = int(result.return_code)
@@ -7230,7 +7322,7 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
         trace["loopx_case_cli_installed_before_agent"] = True
 
     async def ensure_loopx_source_available(env: Any) -> None:
-        if args.route != LOOPX_PRODUCT_MODE_ROUTE:
+        if not _is_loopx_product_mode_route(args.route):
             return
         prerequisites = plan.setdefault("runner_prerequisites", {})
         source_contract = _loopx_source_mount_contract(args)
@@ -7512,7 +7604,7 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
                     getattr(self, "_task", None),
                     include_task_skills=cfg.include_task_skills,
                 )
-            if args.route == "loopx-product-mode":
+            if _is_loopx_product_mode_route(args.route):
                 prerequisites["host_local_acp_install_stage"] = (
                     "loopx_source_upload_fallback"
                 )
@@ -7536,7 +7628,7 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
                 await benchflow_rollout_module.lockdown_paths(
                     self._env, self._effective_locked
                 )
-            if args.route == "loopx-product-mode":
+            if _is_loopx_product_mode_route(args.route):
                 prerequisites["host_local_acp_install_stage"] = "seed_loopx_case_state"
                 if isinstance(controller_trace, dict):
                     controller_trace["case_goal_state_init_invocation_stage"] = (
@@ -7596,14 +7688,15 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
     controller_user = None
     controller_trace: dict[str, Any] | None = None
     product_mode_case_payload: dict[str, Any] | None = None
-    if args.route == "loopx-product-mode":
+    if _is_loopx_product_mode_route(args.route):
         product_mode_case_payload = benchmark_case_loopx_install_payload(
             benchmark_id="skillsbench",
             case_id=args.task_id,
-            arm_id="loopx_product_mode",
+            arm_id=_product_mode_arm_id_for_route(args.route),
             route=args.route,
             max_rounds=args.max_rounds,
             case_loopx_source_path=_loopx_case_source_path_for_container(args),
+            goal_start_product_mode=_is_goal_start_product_mode_route(args.route),
         )
     if args.route == "automation-loop-treatment":
         controller_trace = _new_controller_trace(args.route, max_rounds=args.max_rounds)
@@ -7623,10 +7716,7 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
             trace=controller_trace,
             treatment_prompt_style=args.treatment_prompt_style,
         )
-    elif args.route in {
-        "raw-codex-autonomous-max5",
-        "loopx-product-mode",
-    }:
+    elif args.route in PRODUCT_MODE_CONTROLLER_ROUTES:
         controller_trace = _new_controller_trace(args.route, max_rounds=args.max_rounds)
         controller_user = _build_product_mode_user(
             route=args.route,
@@ -7668,7 +7758,7 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
         or args.require_preinstalled_benchflow_agent_runtime
         else [ensure_codex_acp_runtime_deps]
     )
-    if args.route == "loopx-product-mode" and not args.host_local_acp_launch:
+    if _is_loopx_product_mode_route(args.route) and not args.host_local_acp_launch:
         pre_agent_hooks.append(seed_product_mode_case_state)
 
     agent_env: dict[str, str] = {}
@@ -8173,8 +8263,10 @@ def update_ledger(
         if args.route == LOOPX_BLIND_LOOP_TREATMENT_ROUTE
         else "Codex ACP blind-loop baseline"
         if args.route == "codex-acp-blind-loop-baseline"
+        else "LoopX goal-start product-mode treatment"
+        if args.route == LOOPX_GOAL_START_PRODUCT_MODE_ROUTE
         else "LoopX product-mode treatment"
-        if args.route == "loopx-product-mode"
+        if args.route == LOOPX_PRODUCT_MODE_ROUTE
         else "raw Codex autonomous max5 baseline"
         if args.route == "raw-codex-autonomous-max5"
         else "LoopX reward-feedback ablation"
@@ -8207,6 +8299,7 @@ def append_history(args: argparse.Namespace, compact_path: Path) -> dict[str, An
         "loopx-prompt-polling-test": "skillsbench_loopx_prompt_polling_test_result_v0",
         "codex-acp-blind-loop-baseline": "skillsbench_codex_acp_blind_loop_baseline_result_v0",
         "loopx-product-mode": "skillsbench_loopx_product_mode_result_v0",
+        "loopx-goal-start-product-mode": "skillsbench_loopx_goal_start_product_mode_result_v0",
         "raw-codex-autonomous-max5": "skillsbench_raw_codex_autonomous_max5_result_v0",
         "automation-loop-treatment": "skillsbench_reward_feedback_ablation_result_v0",
         "codex-app-server-goal-baseline": "skillsbench_codex_app_server_goal_baseline_result_v0",
@@ -8325,6 +8418,8 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
             "is the ordinary Codex no-goal baseline with the same loop budget; "
             "raw-codex-autonomous-max5 and loopx-product-mode are the "
             "main-table product-mode comparison routes; "
+            "loopx-goal-start-product-mode adds /loopx goal-start planning "
+            "with a compact ranked todo plan before selected-P0 lifecycle; "
             "codex-app-server-goal-baseline is the native Codex Goal baseline "
             "contract using app-server thread/goal/set/get and turn/start; "
             "codex-goal-mode-baseline sends one /goal-prefixed prompt request "
@@ -8921,13 +9016,13 @@ def main(argv: list[str] | None = None) -> int:
         args.remote_command_file_bridge_solver_command
     )
     product_host_local_bridge_sandbox_auto_wiring_pending = bool(
-        args.route in {"raw-codex-autonomous-max5", "loopx-product-mode"}
+        args.route in PRODUCT_MODE_CONTROLLER_ROUTES
         and args.host_local_acp_launch
         and product_host_local_bridge_materialized
         and not product_host_local_bridge_command_configured
     )
     if (
-        args.route == "loopx-product-mode"
+        _is_loopx_product_mode_route(args.route)
         and not args.host_local_acp_launch
         and not args.local_driver_worker_handshake_preflight
         and not args.plan_only
@@ -8938,11 +9033,10 @@ def main(argv: list[str] | None = None) -> int:
             "error_type": "SkillsBenchProductModeCanonicalDriverRequired",
             "route": args.route,
             "reason": (
-                "loopx-product-mode is the formal LoopX treatment route and "
-                "must use the canonical host-local ACP lifecycle driver. A "
-                "container-local codex-acp fallback can solve the task but "
-                "cannot produce the required case-local quota/todo/update/"
-                "refresh/spend lifecycle evidence."
+                "LoopX product-mode treatment routes must use the canonical "
+                "host-local ACP lifecycle driver. A container-local codex-acp "
+                "fallback can solve the task but cannot produce the required "
+                "case-local quota/todo/update/refresh/spend lifecycle evidence."
             ),
             "next_action": (
                 "rerun with --host-local-acp-launch and a materialized "
@@ -8964,7 +9058,7 @@ def main(argv: list[str] | None = None) -> int:
         )
     )
     if (
-        args.route in {"raw-codex-autonomous-max5", "loopx-product-mode"}
+        args.route in PRODUCT_MODE_CONTROLLER_ROUTES
         and args.host_local_acp_launch
         and product_host_local_bridge_fixture_solver
         and not args.local_driver_worker_handshake_preflight
@@ -9001,7 +9095,7 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps(payload, indent=2, sort_keys=True), file=sys.stderr)
         return 2
     if (
-        args.route in {"raw-codex-autonomous-max5", "loopx-product-mode"}
+        args.route in PRODUCT_MODE_CONTROLLER_ROUTES
         and args.host_local_acp_launch
         and not (
             product_host_local_bridge_materialized

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -1519,6 +1519,9 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "benchflow_intermediate_soft_verify_timeout_cleanup_raw_logs_read",
         "benchflow_intermediate_soft_verify_orphan_cleanup_requested",
         "benchflow_intermediate_soft_verify_orphan_cleanup_raw_logs_read",
+        "goal_start_product_mode",
+        "goal_start_plan_required",
+        "goal_start_selected_p0_lifecycle_required",
         "benchflow_verifier_prep_timeout_override_enabled",
         "benchflow_verifier_prep_timeout_raw_command_recorded",
         "benchflow_final_verifier_timeout_enabled",
@@ -1576,6 +1579,7 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "benchflow_setup_stall_cleanup_term_sent_count",
         "benchflow_setup_stall_cleanup_kill_sent_count",
         "benchflow_setup_stall_cleanup_alive_after_count",
+        "goal_start_planned_todo_count_expected",
         "remote_command_file_bridge_solver_trace_count",
         "remote_command_file_bridge_solver_probe_ready_count",
         "remote_command_file_bridge_solver_operation_count",
@@ -1619,6 +1623,7 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
     for field in (
         "remote_command_file_bridge_agent_operation_counts",
         "remote_command_file_bridge_agent_loopx_subcommand_counts",
+        "remote_command_file_bridge_agent_successful_loopx_subcommand_counts",
         "remote_command_file_bridge_driver_lifecycle_command_counts",
         "remote_command_file_bridge_driver_lifecycle_returncode_counts",
     ):
@@ -2934,6 +2939,260 @@ def _append_case_timeline_event(
     events.append(entry)
 
 
+def _goal_start_public_count_map(value: Any) -> dict[str, int]:
+    if not isinstance(value, dict):
+        return {}
+    compact: dict[str, int] = {}
+    for key, count in value.items():
+        if (
+            isinstance(key, str)
+            and key
+            and isinstance(count, int)
+            and not isinstance(count, bool)
+            and count >= 0
+        ):
+            compact[key[:80]] = count
+    return compact
+
+
+def _goal_start_subcommand_count(
+    families: tuple[str, ...],
+    *maps: Any,
+) -> int:
+    return max(
+        (
+            _subcommand_family_count(_goal_start_public_count_map(item), *families)
+            for item in maps
+        ),
+        default=0,
+    )
+
+
+def _build_goal_start_product_mode_control_score(
+    compact: dict[str, Any],
+    plan: dict[str, Any],
+) -> dict[str, Any]:
+    """Summarize goal-start control-plane closure from public compact counters."""
+
+    counters = (
+        compact.get("interaction_counters")
+        if isinstance(compact.get("interaction_counters"), dict)
+        else {}
+    )
+    runner_prerequisites = _public_runner_prerequisites(
+        plan.get("runner_prerequisites")
+    )
+    compact_runner_prerequisites = compact.get("runner_prerequisites")
+    if isinstance(compact_runner_prerequisites, dict):
+        runner_prerequisites.update(compact_runner_prerequisites)
+    lifecycle_contract = (
+        compact.get("product_mode_lifecycle_contract")
+        if isinstance(compact.get("product_mode_lifecycle_contract"), dict)
+        else {}
+    )
+
+    required = bool(
+        counters.get("goal_start_product_mode") is True
+        or runner_prerequisites.get("goal_start_product_mode") is True
+        or runner_prerequisites.get("goal_start_plan_required") is True
+    )
+    if not required:
+        return {}
+
+    agent_successful_subcommands = counters.get(
+        "remote_command_file_bridge_agent_successful_loopx_subcommand_counts"
+    )
+    agent_requested_subcommands = counters.get(
+        "remote_command_file_bridge_agent_loopx_subcommand_counts"
+    )
+    prereq_agent_successful_subcommands = runner_prerequisites.get(
+        "remote_command_file_bridge_agent_successful_loopx_subcommand_counts"
+    )
+    prereq_agent_requested_subcommands = runner_prerequisites.get(
+        "remote_command_file_bridge_agent_loopx_subcommand_counts"
+    )
+    driver_commands = counters.get(
+        "remote_command_file_bridge_driver_lifecycle_command_counts"
+    )
+    prereq_driver_commands = runner_prerequisites.get(
+        "remote_command_file_bridge_driver_lifecycle_command_counts"
+    )
+    driver_failure_count = _case_timeline_max_int(
+        counters.get("remote_command_file_bridge_driver_lifecycle_failure_count"),
+        runner_prerequisites.get(
+            "remote_command_file_bridge_driver_lifecycle_failure_count"
+        ),
+    )
+    driver_commands_count_as_successful = driver_failure_count == 0
+
+    selected_p0_todo_id = _case_timeline_safe_string(
+        counters.get("selected_p0_todo_id")
+        or runner_prerequisites.get("selected_p0_todo_id"),
+        limit=100,
+    )
+    planned_todo_count = _case_timeline_max_int(counters.get("planned_todo_count"))
+    expected_todo_count = _case_timeline_max_int(
+        runner_prerequisites.get("goal_start_planned_todo_count_expected")
+    )
+    planned_p0_count = _case_timeline_max_int(counters.get("planned_p0_count"))
+    closeout_spend_count = _case_timeline_max_int(
+        counters.get("remote_command_file_bridge_agent_quota_spend_slot_count"),
+        runner_prerequisites.get(
+            "remote_command_file_bridge_agent_quota_spend_slot_count"
+        ),
+        lifecycle_contract.get("agent_bridge_quota_spend_slot_count"),
+    )
+
+    agent_claim_count = _goal_start_subcommand_count(
+        ("todo claim",),
+        agent_successful_subcommands,
+        prereq_agent_successful_subcommands,
+        agent_requested_subcommands,
+        prereq_agent_requested_subcommands,
+    )
+    agent_update_count = _goal_start_subcommand_count(
+        ("todo update",),
+        agent_successful_subcommands,
+        prereq_agent_successful_subcommands,
+        agent_requested_subcommands,
+        prereq_agent_requested_subcommands,
+    )
+    agent_complete_count = _goal_start_subcommand_count(
+        ("todo complete",),
+        agent_successful_subcommands,
+        prereq_agent_successful_subcommands,
+        agent_requested_subcommands,
+        prereq_agent_requested_subcommands,
+    )
+    agent_spend_count = _goal_start_subcommand_count(
+        ("quota spend-slot",),
+        agent_successful_subcommands,
+        prereq_agent_successful_subcommands,
+        agent_requested_subcommands,
+        prereq_agent_requested_subcommands,
+    )
+    driver_claim_count = (
+        _goal_start_subcommand_count(("todo claim",), driver_commands, prereq_driver_commands)
+        if driver_commands_count_as_successful
+        else 0
+    )
+    driver_update_count = (
+        _goal_start_subcommand_count(("todo update",), driver_commands, prereq_driver_commands)
+        if driver_commands_count_as_successful
+        else 0
+    )
+
+    selected_todo_claimed = bool(
+        counters.get("selected_todo_claimed") is True
+        or agent_claim_count > 0
+        or driver_claim_count > 0
+    )
+    selected_todo_updated_before_solver = bool(
+        counters.get("selected_todo_updated_before_solver") is True
+        or agent_update_count > 0
+        or driver_update_count > 0
+    )
+    selected_todo_spend_observed = bool(closeout_spend_count > 0 or agent_spend_count > 0)
+    selected_todo_completed_before_spend = bool(
+        counters.get("selected_todo_completed_before_spend") is True
+        or (agent_complete_count > 0 and selected_todo_spend_observed)
+    )
+    last_decision = _case_timeline_safe_string(counters.get("last_decision"), limit=100)
+    premature_done_signal_count = _case_timeline_max_int(
+        counters.get("product_mode_declared_done_below_passing_reward_count")
+    )
+    premature_done_stop_reason = ""
+    if (
+        counters.get("product_mode_declared_done_below_passing_reward") is True
+        and last_decision.startswith("stop_after")
+        and "below_passing_reward" in last_decision
+    ):
+        premature_done_stop_reason = (
+            last_decision or "declared_done_below_passing_reward"
+        )
+
+    component_results = [
+        {
+            "name": "plan_observed",
+            "satisfied": counters.get("goal_start_plan_observed") is True,
+        },
+        {
+            "name": "planned_todo_count",
+            "satisfied": bool(
+                planned_todo_count > 0
+                and (expected_todo_count == 0 or planned_todo_count >= expected_todo_count)
+            ),
+        },
+        {"name": "planned_p0_count", "satisfied": planned_p0_count > 0},
+        {
+            "name": "planner_before_todo_write",
+            "satisfied": counters.get("planner_before_todo_write") is True,
+        },
+        {
+            "name": "same_priority_order_preserved",
+            "satisfied": counters.get("same_priority_order_preserved") is True,
+        },
+        {"name": "selected_p0_todo_id", "satisfied": bool(selected_p0_todo_id)},
+        {"name": "selected_todo_claimed", "satisfied": selected_todo_claimed},
+        {
+            "name": "selected_todo_updated_before_solver",
+            "satisfied": selected_todo_updated_before_solver,
+        },
+        {
+            "name": "selected_todo_completed_before_spend",
+            "satisfied": selected_todo_completed_before_spend,
+        },
+        {
+            "name": "selected_todo_spend_observed",
+            "satisfied": selected_todo_spend_observed,
+        },
+        {
+            "name": "non_selected_todos_preserved_open_or_deferred",
+            "satisfied": (
+                counters.get("non_selected_todos_preserved_open_or_deferred") is True
+            ),
+        },
+        {"name": "no_premature_done_stop", "satisfied": not premature_done_stop_reason},
+    ]
+    satisfied_count = sum(1 for item in component_results if item["satisfied"])
+    component_count = len(component_results)
+    score = round(satisfied_count / component_count, 3) if component_count else 0.0
+    return {
+        "schema_version": "skillsbench_goal_start_product_mode_control_score_v0",
+        "required": True,
+        "satisfied": satisfied_count == component_count,
+        "score": score,
+        "component_count": component_count,
+        "satisfied_component_count": satisfied_count,
+        "raw_material_recorded": False,
+        "goal_start_plan_observed": counters.get("goal_start_plan_observed") is True,
+        "planned_todo_count": planned_todo_count,
+        "planned_todo_count_expected": expected_todo_count,
+        "planned_p0_count": planned_p0_count,
+        "planner_before_todo_write": counters.get("planner_before_todo_write") is True,
+        "same_priority_order_preserved": (
+            counters.get("same_priority_order_preserved") is True
+        ),
+        "selected_p0_todo_id": selected_p0_todo_id,
+        "selected_todo_claimed": selected_todo_claimed,
+        "selected_todo_updated_before_solver": selected_todo_updated_before_solver,
+        "selected_todo_completed_before_spend": selected_todo_completed_before_spend,
+        "selected_todo_spend_observed": selected_todo_spend_observed,
+        "non_selected_todos_preserved_open_or_deferred": (
+            counters.get("non_selected_todos_preserved_open_or_deferred") is True
+        ),
+        "premature_done_signal_count": premature_done_signal_count,
+        "premature_done_stop_reason": premature_done_stop_reason,
+        "agent_todo_claim_count": agent_claim_count,
+        "agent_todo_update_count": agent_update_count,
+        "agent_todo_complete_count": agent_complete_count,
+        "agent_quota_spend_slot_count": max(closeout_spend_count, agent_spend_count),
+        "driver_todo_claim_count": driver_claim_count,
+        "driver_todo_update_count": driver_update_count,
+        "component_results": component_results,
+    }
+
+
 def _build_case_event_timeline(
     compact: dict[str, Any],
     plan: dict[str, Any],
@@ -2990,6 +3249,61 @@ def _build_case_event_timeline(
             counters.get("case_goal_state_initialized_before_agent") is True
         ),
     )
+
+    goal_start_control_score = (
+        compact.get("goal_start_product_mode_control_score")
+        if isinstance(compact.get("goal_start_product_mode_control_score"), dict)
+        else _build_goal_start_product_mode_control_score(compact, plan)
+    )
+    if goal_start_control_score:
+        if goal_start_control_score.get("satisfied") is True:
+            goal_start_status = "satisfied"
+        elif goal_start_control_score.get("goal_start_plan_observed") is True:
+            goal_start_status = "partial"
+        else:
+            goal_start_status = "missing"
+        _append_case_timeline_event(
+            events,
+            phase="goal_start_plan",
+            event="ranked_todo_plan_selected_p0_lifecycle",
+            status=goal_start_status,
+            control_score=goal_start_control_score.get("score"),
+            planned_todo_count=goal_start_control_score.get("planned_todo_count"),
+            planned_todo_count_expected=goal_start_control_score.get(
+                "planned_todo_count_expected"
+            ),
+            planned_p0_count=goal_start_control_score.get("planned_p0_count"),
+            planner_before_todo_write=goal_start_control_score.get(
+                "planner_before_todo_write"
+            ),
+            same_priority_order_preserved=goal_start_control_score.get(
+                "same_priority_order_preserved"
+            ),
+            selected_p0_todo_id=goal_start_control_score.get("selected_p0_todo_id"),
+            selected_todo_claimed=goal_start_control_score.get(
+                "selected_todo_claimed"
+            ),
+            selected_todo_updated_before_solver=goal_start_control_score.get(
+                "selected_todo_updated_before_solver"
+            ),
+            selected_todo_completed_before_spend=goal_start_control_score.get(
+                "selected_todo_completed_before_spend"
+            ),
+            selected_todo_spend_observed=goal_start_control_score.get(
+                "selected_todo_spend_observed"
+            ),
+            non_selected_todos_preserved_open_or_deferred=(
+                goal_start_control_score.get(
+                    "non_selected_todos_preserved_open_or_deferred"
+                )
+            ),
+            premature_done_signal_count=goal_start_control_score.get(
+                "premature_done_signal_count"
+            ),
+            premature_done_stop_reason=goal_start_control_score.get(
+                "premature_done_stop_reason"
+            ),
+        )
 
     driver_checkpoint_count = _case_timeline_max_int(
         counters.get("remote_command_file_bridge_driver_lifecycle_checkpoint_count"),
@@ -8050,6 +8364,12 @@ def reduce_result(
     runner_output_capture = _public_runner_output_capture(plan)
     if runner_output_capture:
         compact["runner_output_capture"] = runner_output_capture
+    goal_start_control_score = _build_goal_start_product_mode_control_score(
+        compact,
+        plan,
+    )
+    if goal_start_control_score:
+        compact["goal_start_product_mode_control_score"] = goal_start_control_score
     compact["case_event_timeline"] = _build_case_event_timeline(compact, plan)
     return compact
 


### PR DESCRIPTION
## Summary
- add a separate `loopx-goal-start-product-mode` SkillsBench route for /loopx goal-start planning plus selected-P0 lifecycle
- seed a compact 3-todo ranked plan while keeping the selected P0 solver todo on the existing stable lifecycle id
- expose public-safe goal-start counters and add focused protocol/case-state/plan-only smokes

## Validation
- `python3 -m py_compile loopx/benchmark_core/loop_protocol.py loopx/benchmark_case_state.py scripts/skillsbench_automation_loop.py examples/benchmark-loop-protocol-smoke.py examples/benchmark-case-active-state-contract-smoke.py examples/skillsbench-goal-start-product-mode-route-smoke.py`
- `python3 examples/benchmark-loop-protocol-smoke.py`
- `python3 examples/benchmark-case-active-state-contract-smoke.py`
- `python3 examples/skillsbench-goal-start-product-mode-route-smoke.py`
- `loopx check --scan-path loopx/benchmark_core/loop_protocol.py --scan-path loopx/benchmark_case_state.py --scan-path scripts/skillsbench_automation_loop.py --scan-path examples/benchmark-loop-protocol-smoke.py --scan-path examples/benchmark-case-active-state-contract-smoke.py --scan-path examples/skillsbench-goal-start-product-mode-route-smoke.py`

## Boundary
- no benchmark jobs launched
- no raw task text, raw trajectories, verifier output, credentials, or local artifact paths committed
- existing `loopx-product-mode` route remains as the single-todo lifecycle control arm