### PR TITLE
Add issue-fix workflow planner

### DIFF
--- a/docs/capabilities/issue-fix/README.md
+++ b/docs/capabilities/issue-fix/README.md
@@ -14,12 +14,13 @@ external comments, PRs, merges, or publishes.
 | CLI entry | `loopx issue-fix ...` |
 | Content-ops bridge | `loopx content-ops issue-fix-* ...` |
 | Protocol docs | `docs/capabilities/issue-fix/protocols/` |
-| Smoke | `examples/issue-fix-acceptance-loop-smoke.py` |
+| Smoke | `examples/issue-fix-workflow-plan-smoke.py`, `examples/issue-fix-acceptance-loop-smoke.py` |
 
 ## Protocols
 
 - [`issue_fix_workflow_contract_v0`](protocols/issue-fix-workflow-contract-v0.md)
 - [`issue_fix_acceptance_loop_v0`](protocols/issue-fix-acceptance-loop-v0.md)
+- `issue_fix_workflow_plan_packet_v0`
 - `github_issue_metadata_preview_v0`
 - `content_ops_issue_fix_metadata_preview_packet_v0`
 - `content_ops_issue_fix_intake_packet_v0`
@@ -40,9 +41,22 @@ metadata boundary.
 - External issue comments, PR creation, merge, publish, and destructive git are
   out of scope for this capability.
 
+## Workflow Plan
+
+```bash
+loopx issue-fix workflow-plan --url https://github.com/owner/repo/issues/123
+```
+
+The workflow planner is preview-only. It composes public metadata preview,
+issue intake, branch dry-run planning, validation labels, ordered LoopX todo
+writeback previews, and PR review readiness blockers into one packet. It does
+not write LoopX todos, inspect the local repo in dry-run mode, create external
+comments or PRs, merge, or capture raw issue body/comment material.
+
 ## Validation
 
 ```bash
+python3 examples/issue-fix-workflow-plan-smoke.py
 python3 examples/issue-fix-workflow-contract-smoke.py
 python3 examples/content-ops-issue-fix-metadata-preview-smoke.py
 python3 examples/content-ops-issue-fix-intake-smoke.py

--- a/docs/capabilities/issue-fix/protocols/issue-fix-workflow-contract-v0.md
+++ b/docs/capabilities/issue-fix/protocols/issue-fix-workflow-contract-v0.md
@@ -26,24 +26,28 @@ open PRs, merge, publish, or run destructive git without an explicit gate.
    code-context route candidates, owner/user gate projections, and ordered
    agent todo candidates. The first screen must name `waiting_on`, top agent
    todo, top gate when present, and next safe action.
-3. **LoopX todo writeback:** convert accepted candidates into durable LoopX
+3. **Workflow plan:** build `issue_fix_workflow_plan_packet_v0` to compose the
+   metadata preview, intake, branch dry-run, validation label, ordered LoopX
+   todo writeback preview, gate preview, and PR-review readiness blockers. This
+   stage is preview-only and does not write todos.
+4. **LoopX todo writeback:** convert accepted candidates into durable LoopX
    todos in priority and dependency order. Typical agent todos are repro smoke,
    code-context route, branch-local patch, validation, and review-packet
    readiness. User todos represent gates such as private repro material,
    external issue comment, PR creation, merge, publish, or repository policy.
-4. **Caller repo branch:** use `issue_fix_caller_repo_branch_packet_v0` only
+5. **Caller repo branch:** use `issue_fix_caller_repo_branch_packet_v0` only
    after the caller provides an approved local git repo, base branch, issue
    branch policy, and validation command. Dry-run mode must not inspect the
    repo. Execute mode may inspect the approved repo and create or claim a
    `codex/` issue branch, but must refuse branch switches from dirty state.
-5. **Validation:** record focused validation as pass/fail, exit code, and
+6. **Validation:** record focused validation as pass/fail, exit code, and
    public-safe label. Validation stdout, stderr, local paths, and raw git output
    stay out of the packet. A validated fix should prove failing-before and
    passing-after evidence when that repro path is available.
-6. **PR review packet:** emit `issue_fix_pr_review_packet_v0` only when branch,
+7. **PR review packet:** emit `issue_fix_pr_review_packet_v0` only when branch,
    validation, and repo-relative changed-file evidence are sufficient for human
    review. The packet is review evidence, not external publication authority.
-7. **Gate handling:** surface concrete gates instead of silently blocking. Safe
+8. **Gate handling:** surface concrete gates instead of silently blocking. Safe
    metadata-only triage, public-code search, and focused smoke drafting may
    continue when those gates do not cover the selected action.
 
@@ -98,6 +102,7 @@ An issue-fix workflow is PR-review-ready only when all of these are true:
 - `content_ops_issue_fix_metadata_preview_packet_v0`
 - `content_ops_issue_fix_intake_packet_v0`
 - `issue_fix_intake_v0`
+- `issue_fix_workflow_plan_packet_v0`
 - `loopx_todo_writeback_preview_v0`
 - `issue_fix_caller_repo_branch_packet_v0`
 - `issue_fix_validated_fix_artifact_v0`

--- a/examples/issue-fix-workflow-contract-smoke.py
+++ b/examples/issue-fix-workflow-contract-smoke.py
@@ -85,6 +85,7 @@ def main() -> int:
         [
             "**Metadata preview:**",
             "**Intake classification:**",
+            "**Workflow plan:**",
             "**LoopX todo writeback:**",
             "**Caller repo branch:**",
             "**Validation:**",
@@ -97,6 +98,7 @@ def main() -> int:
         CONTENT_OPS_ISSUE_FIX_METADATA_PREVIEW_PACKET_SCHEMA_VERSION,
         CONTENT_OPS_ISSUE_FIX_INTAKE_PACKET_SCHEMA_VERSION,
         ISSUE_FIX_INTAKE_SCHEMA_VERSION,
+        "issue_fix_workflow_plan_packet_v0",
         "loopx_todo_writeback_preview_v0",
         ISSUE_FIX_CALLER_REPO_BRANCH_PACKET_SCHEMA_VERSION,
         ISSUE_FIX_VALIDATED_FIX_ARTIFACT_SCHEMA_VERSION,

--- a/examples/issue-fix-workflow-plan-smoke.py
+++ b/examples/issue-fix-workflow-plan-smoke.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Smoke-test the issue-fix workflow planner CLI."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from loopx.capabilities.issue_fix.workflow_plan import (  # noqa: E402
+    ISSUE_FIX_WORKFLOW_PLAN_PACKET_SCHEMA_VERSION,
+    build_issue_fix_workflow_plan_packet,
+)
+
+
+PRIVATE_PATTERNS = [
+    re.compile(r"/Users/[A-Za-z0-9._-]+/"),
+    re.compile(r"/home/[A-Za-z0-9._-]+/"),
+    re.compile(r"/private/"),
+    re.compile(r"[A-Za-z]:\\\\Users\\\\"),
+    re.compile(r"\bBearer\s+[A-Za-z0-9._-]+"),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+]
+
+FORBIDDEN_VALUES = [
+    "raw issue body text that must stay gated",
+    "full issue comment text that must stay gated",
+    "raw provider response payload",
+    "secret-value",
+    "credential-value",
+]
+
+
+def assert_public_safe(payload: dict[str, Any] | str) -> None:
+    text = (
+        payload
+        if isinstance(payload, str)
+        else json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    )
+    for pattern in PRIVATE_PATTERNS:
+        if pattern.search(text):
+            raise AssertionError(f"payload matched private pattern {pattern.pattern!r}")
+    leaked = [value for value in FORBIDDEN_VALUES if value in text]
+    assert not leaked, leaked
+
+
+def run_cli(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "loopx.cli", "--format", "json", *args],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+
+
+def assert_workflow_shape(payload: dict[str, Any]) -> None:
+    assert payload["ok"] is True, payload
+    assert payload["schema_version"] == ISSUE_FIX_WORKFLOW_PLAN_PACKET_SCHEMA_VERSION
+    assert payload["mode"] == "issue-fix-workflow-plan"
+    assert payload["external_writes_performed"] is False
+    assert payload["todo_write_performed"] is False
+    assert payload["local_paths_captured"] is False
+    assert payload["private_repo_state_read"] is False
+    assert payload["destructive_git_used"] is False
+    assert payload["issue_body_captured"] is False
+    assert payload["comment_bodies_captured"] is False
+
+    first_screen = payload["first_screen"]
+    assert first_screen["waiting_on"] == "agent", first_screen
+    assert first_screen["user_action_required"] is False, first_screen
+    assert first_screen["agent_can_continue"] is True, first_screen
+
+    todos = payload["ordered_loopx_todo_writeback_preview"]
+    assert len(todos) >= 5, todos
+    assert [todo["planner_order"] for todo in todos] == sorted(
+        todo["planner_order"] for todo in todos
+    )
+    assert [todo["action_kind"] for todo in todos[:4]] == [
+        "issue_fix_public_metadata_classification",
+        "issue_fix_repro_and_route",
+        "issue_fix_branch_validation",
+        "issue_fix_pr_review_packet",
+    ]
+    assert [todo["priority"] for todo in todos[:3]] == ["P0", "P0", "P0"]
+    assert all(todo["would_write"] is False for todo in todos)
+    assert all(todo["requires_execute_flag"] is True for todo in todos)
+
+    review = payload["review_packet_preview"]
+    assert review["schema_version"] == "issue_fix_pr_review_packet_v0", review
+    assert review["ready"] is False, review
+    assert review["external_issue_comment_performed"] is False, review
+    assert review["external_pr_created"] is False, review
+    assert review["merge_performed"] is False, review
+    assert "validation_not_run" in review["readiness_blockers"], review
+
+    validation = payload["validation"]
+    assert validation["ok"] is True, validation
+    assert validation["todo_preview_count"] == len(todos), validation
+    assert_public_safe(payload)
+
+
+def main() -> int:
+    packet = build_issue_fix_workflow_plan_packet(
+        url="https://github.com/huangruiteng/loopx/issues/123",
+        validation_label="python3 examples/focused-smoke.py",
+    )
+    assert_workflow_shape(packet)
+    assert packet["branch_plan"]["status"] == "needs_approved_repo_context", packet
+    assert "approved_repo_context_missing" in packet["review_packet_preview"][
+        "readiness_blockers"
+    ]
+
+    with tempfile.TemporaryDirectory(prefix="loopx-issue-fix-plan-") as tmpdir:
+        tmp = Path(tmpdir)
+        metadata_path = tmp / "metadata.json"
+        metadata_path.write_text(
+            json.dumps(
+                {
+                    "number": 123,
+                    "state": "open",
+                    "title": "Crash on workflow planner",
+                    "labels": [{"name": "bug"}, {"name": "needs-repro"}],
+                    "body": "raw issue body text that must stay gated",
+                    "comments": ["full issue comment text that must stay gated"],
+                    "raw": "raw provider response payload",
+                }
+            ),
+            encoding="utf-8",
+        )
+        result = run_cli(
+            [
+                "issue-fix",
+                "workflow-plan",
+                "--url",
+                "https://github.com/huangruiteng/loopx/issues/123",
+                "--metadata-json",
+                str(metadata_path),
+                "--repo-path",
+                str(tmp / "approved-repo-not-read-in-dry-run"),
+                "--base-branch",
+                "main",
+                "--validation-label",
+                "python3 examples/focused-smoke.py",
+            ]
+        )
+    cli_packet = json.loads(result.stdout)
+    assert_workflow_shape(cli_packet)
+    assert cli_packet["branch_plan"]["status"] == "approved_repo_dry_run", cli_packet
+    assert cli_packet["branch_plan"]["repo_path_captured"] is False, cli_packet
+    assert cli_packet["branch_plan"]["private_repo_state_read"] is False, cli_packet
+    gated = [
+        todo
+        for todo in cli_packet["ordered_loopx_todo_writeback_preview"]
+        if todo["action_kind"] == "approve_github_issue_body_or_comment_read"
+    ]
+    assert len(gated) == 1, cli_packet
+    assert gated[0]["role"] == "user", gated
+    assert gated[0]["priority"] == "P0", gated
+    assert gated[0]["would_write"] is False, gated
+    assert_public_safe(result.stdout)
+
+    markdown = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "issue-fix",
+            "workflow-plan",
+            "--url",
+            "https://github.com/huangruiteng/loopx/issues/123",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    ).stdout
+    assert "# LoopX Issue Fix Workflow Plan" in markdown, markdown
+    assert "Ordered Todo Writeback Preview" in markdown, markdown
+    assert "issue_fix_pr_review_packet" in markdown, markdown
+    assert_public_safe(markdown)
+
+    print("issue-fix-workflow-plan-smoke: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -18,7 +18,7 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
             "Turn a public GitHub issue or PR signal into a caller-approved "
             "local issue branch with validation evidence and a PR-review packet."
         ),
-        "entry_command": "loopx issue-fix caller-repo-branch --repo-path <repo> --execute --format json",
+        "entry_command": "loopx issue-fix workflow-plan --url <github-issue-url> --format json",
         "commands": [
             {
                 "command": "loopx content-ops issue-fix-metadata-preview --url <github-issue-url> --fetch-metadata --format json",
@@ -29,6 +29,11 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
                 "command": "loopx content-ops issue-fix-intake --format json",
                 "purpose": "Project public issue metadata into an issue-fix intake packet.",
                 "write_boundary": "fixture-only; no external read or write",
+            },
+            {
+                "command": "loopx issue-fix workflow-plan --url <github-issue-url> --repo-path <repo> --format json",
+                "purpose": "Compose metadata, intake, ordered LoopX todo previews, validation labels, and PR review readiness blockers.",
+                "write_boundary": "preview-only; no todo write, repo execution, external comment, PR creation, merge, or publish",
             },
             {
                 "command": "loopx issue-fix acceptance-fixture --format json",
@@ -68,6 +73,11 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
                 "doc": "docs/reference/protocols/content-ops-surface-v0.md",
             },
             {
+                "schema_version": "issue_fix_workflow_plan_packet_v0",
+                "module": "loopx.capabilities.issue_fix.workflow_plan",
+                "doc": "docs/capabilities/issue-fix/protocols/issue-fix-workflow-contract-v0.md",
+            },
+            {
                 "schema_version": "issue_fix_acceptance_loop_v0",
                 "module": "loopx.capabilities.issue_fix.acceptance_loop",
                 "doc": "docs/capabilities/issue-fix/protocols/issue-fix-acceptance-loop-v0.md",
@@ -84,12 +94,14 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
             },
         ],
         "smokes": [
+            "python3 examples/issue-fix-workflow-plan-smoke.py",
             "python3 examples/content-ops-issue-fix-metadata-preview-smoke.py",
             "python3 examples/content-ops-issue-fix-intake-smoke.py",
             "python3 examples/issue-fix-acceptance-loop-smoke.py",
         ],
         "docs": [
             "docs/capabilities/issue-fix/README.md",
+            "docs/capabilities/issue-fix/protocols/issue-fix-workflow-contract-v0.md",
             "docs/capabilities/issue-fix/protocols/issue-fix-acceptance-loop-v0.md",
             "docs/reference/protocols/content-ops-surface-v0.md",
             "docs/reference/protocols/issue-fix-acceptance-loop-v0.md",

--- a/loopx/capabilities/issue_fix/cli.py
+++ b/loopx/capabilities/issue_fix/cli.py
@@ -1,13 +1,21 @@
 from __future__ import annotations
 
 import argparse
+import json
+import sys
 from collections.abc import Callable
+from pathlib import Path
+from typing import Any
 
 from .acceptance_loop import (
     build_issue_fix_acceptance_fixture_packet,
     build_issue_fix_caller_repo_branch_packet,
     build_issue_fix_repo_branch_fixture_packet,
     render_issue_fix_acceptance_loop_markdown,
+)
+from .workflow_plan import (
+    build_issue_fix_workflow_plan_packet,
+    render_issue_fix_workflow_plan_markdown,
 )
 
 
@@ -17,6 +25,16 @@ PrintPayload = Callable[
 ]
 FormatSelector = Callable[..., str]
 AddFormat = Callable[[argparse.ArgumentParser], None]
+
+
+def _load_json_object(path_text: str) -> dict[str, Any]:
+    if path_text == "-":
+        payload = json.loads(sys.stdin.read())
+    else:
+        payload = json.loads(Path(path_text).expanduser().read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path_text} must contain a JSON object")
+    return payload
 
 
 def register_issue_fix_commands(
@@ -30,6 +48,79 @@ def register_issue_fix_commands(
     issue_fix_sub = issue_fix_parser.add_subparsers(
         dest="issue_fix_command",
         required=True,
+    )
+    workflow_parser = issue_fix_sub.add_parser(
+        "workflow-plan",
+        help=(
+            "Plan the full issue-fix workflow from public metadata to ordered "
+            "LoopX todos, validation, and PR review packet readiness without writes."
+        ),
+    )
+    add_subcommand_format(workflow_parser)
+    workflow_parser.add_argument(
+        "--repo",
+        default="public_repo_fixture",
+        help="Public-safe repository label for the issue metadata.",
+    )
+    workflow_parser.add_argument(
+        "--issue-ref",
+        default="issue_123_public_metadata_fixture",
+        help="Public-safe issue or PR reference label.",
+    )
+    workflow_parser.add_argument(
+        "--url",
+        default=None,
+        help="Optional https://github.com/owner/repo/issues/123 or /pull/123 URL.",
+    )
+    workflow_parser.add_argument(
+        "--metadata-json",
+        default=None,
+        help=(
+            "Path to mocked provider JSON metadata, or '-' for stdin. "
+            "Body/comment fields stay gated and are not copied."
+        ),
+    )
+    workflow_parser.add_argument(
+        "--fetch-metadata",
+        action="store_true",
+        help=(
+            "Explicitly fetch public GitHub issue/PR metadata with gh api --jq. "
+            "Only body-free metadata fields are captured."
+        ),
+    )
+    workflow_parser.add_argument(
+        "--fetch-timeout-seconds",
+        type=int,
+        default=10,
+        help="Timeout for --fetch-metadata.",
+    )
+    workflow_parser.add_argument(
+        "--repo-path",
+        default=None,
+        help=(
+            "Optional caller-approved local git repository path. Planning keeps "
+            "this as a dry-run and never records the path."
+        ),
+    )
+    workflow_parser.add_argument(
+        "--base-branch",
+        default="main",
+        help="Approved local base branch for the eventual issue branch.",
+    )
+    workflow_parser.add_argument(
+        "--issue-branch",
+        default=None,
+        help="Optional issue branch for the eventual caller-repo execution.",
+    )
+    workflow_parser.add_argument(
+        "--validation-label",
+        default="caller-declared validation",
+        help="Public-safe validation label stored in the workflow plan.",
+    )
+    workflow_parser.add_argument(
+        "--generated-at",
+        default="2026-06-23T00:00:00Z",
+        help="Public-safe generated_at timestamp for the workflow plan.",
     )
     acceptance_parser = issue_fix_sub.add_parser(
         "acceptance-fixture",
@@ -166,7 +257,26 @@ def handle_issue_fix_command(
     print_payload: PrintPayload,
 ) -> int:
     try:
-        if args.issue_fix_command == "acceptance-fixture":
+        if args.issue_fix_command == "workflow-plan":
+            if args.fetch_metadata and args.metadata_json:
+                raise ValueError("--fetch-metadata cannot be combined with --metadata-json")
+            payload = build_issue_fix_workflow_plan_packet(
+                repo=args.repo,
+                issue_ref=args.issue_ref,
+                url=args.url,
+                provider_payload=_load_json_object(args.metadata_json)
+                if args.metadata_json
+                else None,
+                fetch_metadata=args.fetch_metadata,
+                fetch_timeout_seconds=args.fetch_timeout_seconds,
+                repo_path=args.repo_path,
+                base_branch=args.base_branch,
+                issue_branch=args.issue_branch,
+                validation_label=args.validation_label,
+                generated_at=args.generated_at,
+            )
+            renderer = render_issue_fix_workflow_plan_markdown
+        elif args.issue_fix_command == "acceptance-fixture":
             payload = build_issue_fix_acceptance_fixture_packet(
                 repo=args.repo,
                 issue_ref=args.issue_ref,
@@ -199,8 +309,8 @@ def handle_issue_fix_command(
             renderer = render_issue_fix_acceptance_loop_markdown
         else:
             raise ValueError(
-                "issue-fix requires `acceptance-fixture`, `repo-branch-fixture`, "
-                "or `caller-repo-branch`"
+                "issue-fix requires `workflow-plan`, `acceptance-fixture`, "
+                "`repo-branch-fixture`, or `caller-repo-branch`"
             )
     except Exception as exc:
         payload = {
@@ -208,6 +318,10 @@ def handle_issue_fix_command(
             "mode": "issue-fix",
             "error": str(exc),
         }
-        renderer = render_issue_fix_acceptance_loop_markdown
+        renderer = (
+            render_issue_fix_workflow_plan_markdown
+            if getattr(args, "issue_fix_command", None) == "workflow-plan"
+            else render_issue_fix_acceptance_loop_markdown
+        )
     print_payload(payload, output_format(args), renderer)
     return 0 if payload.get("ok") else 1

--- a/loopx/capabilities/issue_fix/workflow_plan.py
+++ b/loopx/capabilities/issue_fix/workflow_plan.py
@@ -1,0 +1,508 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from .acceptance_loop import build_issue_fix_caller_repo_branch_packet
+from .intake_surface import build_content_ops_issue_fix_metadata_preview_packet
+
+
+ISSUE_FIX_WORKFLOW_PLAN_PACKET_SCHEMA_VERSION = "issue_fix_workflow_plan_packet_v0"
+
+
+def _todo_preview(
+    *,
+    planner_order: int,
+    role: str,
+    priority: str,
+    task_class: str,
+    action_kind: str,
+    text: str,
+    depends_on: Sequence[str],
+    blocks: Sequence[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "schema_version": "loopx_todo_writeback_preview_v0",
+        "planner_order": planner_order,
+        "command_preview": "loopx todo add",
+        "role": role,
+        "priority": priority,
+        "status": "preview_only",
+        "task_class": task_class,
+        "action_kind": action_kind,
+        "text": text,
+        "depends_on": list(depends_on),
+        "blocks": list(blocks or []),
+        "would_write": False,
+        "requires_execute_flag": True,
+    }
+
+
+def _branch_plan_from_dry_run(
+    *,
+    repo_path: str | None,
+    repo: str,
+    issue_ref: str,
+    url: str | None,
+    base_branch: str,
+    issue_branch: str | None,
+    validation_label: str,
+    generated_at: str | None,
+) -> dict[str, Any]:
+    if not repo_path:
+        return {
+            "schema_version": "issue_fix_workflow_branch_plan_v0",
+            "status": "needs_approved_repo_context",
+            "repo_label": repo,
+            "base_branch": base_branch,
+            "issue_branch": issue_branch,
+            "branch_ready": False,
+            "repo_path_captured": False,
+            "private_repo_state_read": False,
+            "execute_required_for_branch_claim": True,
+        }
+
+    dry_run = build_issue_fix_caller_repo_branch_packet(
+        repo_path=repo_path,
+        repo=repo,
+        issue_ref=issue_ref,
+        url=url,
+        base_branch=base_branch,
+        issue_branch=issue_branch,
+        validation_label=validation_label,
+        execute=False,
+        generated_at=generated_at,
+    )
+    branch = dry_run.get("caller_repo_branch")
+    if not isinstance(branch, Mapping):
+        raise ValueError("caller repo branch dry-run did not return branch metadata")
+    return {
+        "schema_version": "issue_fix_workflow_branch_plan_v0",
+        "status": "approved_repo_dry_run",
+        "repo_label": branch.get("repo_label"),
+        "base_branch": branch.get("base_branch"),
+        "issue_branch": branch.get("issue_branch"),
+        "branch_action": branch.get("branch_action"),
+        "branch_ready": False,
+        "repo_path_captured": False,
+        "private_repo_state_read": False,
+        "execute_required_for_branch_claim": True,
+        "dry_run_schema_version": dry_run.get("schema_version"),
+    }
+
+
+def build_issue_fix_workflow_plan_packet(
+    *,
+    repo: str = "public_repo_fixture",
+    issue_ref: str = "issue_123_public_metadata_fixture",
+    url: str | None = None,
+    provider_payload: Mapping[str, Any] | None = None,
+    fetch_metadata: bool = False,
+    fetch_timeout_seconds: int = 10,
+    repo_path: str | None = None,
+    base_branch: str = "main",
+    issue_branch: str | None = None,
+    validation_label: str = "caller-declared validation",
+    generated_at: str | None = "2026-06-23T00:00:00Z",
+) -> dict[str, Any]:
+    """Build a public-safe issue-fix workflow plan without writing state."""
+
+    metadata_packet = build_content_ops_issue_fix_metadata_preview_packet(
+        repo=repo,
+        issue_ref=issue_ref,
+        url=url,
+        provider_payload=provider_payload,
+        fetch_metadata=fetch_metadata,
+        fetch_timeout_seconds=fetch_timeout_seconds,
+        generated_at=generated_at,
+    )
+    metadata = metadata_packet["github_metadata_preview"]
+    intake = metadata_packet["issue_fix_intake"]
+    adapter_preview = metadata_packet["adapter_preview"]
+    gated_fields = list(adapter_preview.get("gated_provider_fields_present") or [])
+    branch_plan = _branch_plan_from_dry_run(
+        repo_path=repo_path,
+        repo=str(metadata["repo"]),
+        issue_ref=str(metadata["issue_ref"]),
+        url=url,
+        base_branch=base_branch,
+        issue_branch=issue_branch,
+        validation_label=validation_label,
+        generated_at=generated_at,
+    )
+
+    repo_label = str(metadata["repo"])
+    issue_label = str(metadata["issue_ref"])
+    agent_todos = [
+        _todo_preview(
+            planner_order=1,
+            role="agent",
+            priority="P0",
+            task_class="advancement_task",
+            action_kind="issue_fix_public_metadata_classification",
+            text=(
+                f"[P0] Classify {repo_label} {issue_label} from body-free public "
+                "metadata and pick the first safe repro/code-context route."
+            ),
+            depends_on=[
+                "content_ops_issue_fix_metadata_preview_packet_v0",
+                "issue_fix_intake_v0",
+            ],
+        ),
+        _todo_preview(
+            planner_order=2,
+            role="agent",
+            priority="P0",
+            task_class="advancement_task",
+            action_kind="issue_fix_repro_and_route",
+            text=(
+                "[P0] Create or identify a focused repro smoke, inspect the "
+                "selected repo-relative code route, and stop before private "
+                "repro material or external comments."
+            ),
+            depends_on=["issue_fix_public_metadata_classification"],
+        ),
+        _todo_preview(
+            planner_order=3,
+            role="agent",
+            priority="P0",
+            task_class="advancement_task",
+            action_kind="issue_fix_branch_validation",
+            text=(
+                "[P0] Prepare or claim the approved issue branch and run the "
+                "caller-declared validation label before declaring review readiness."
+            ),
+            depends_on=["issue_fix_repro_and_route"],
+            blocks=["pr_review_packet_ready"],
+        ),
+        _todo_preview(
+            planner_order=4,
+            role="agent",
+            priority="P1",
+            task_class="advancement_task",
+            action_kind="issue_fix_pr_review_packet",
+            text=(
+                "[P1] Emit a PR review packet with repo-relative changed files, "
+                "validation labels, remaining gates, and no external publication."
+            ),
+            depends_on=["issue_fix_branch_validation"],
+        ),
+    ]
+    user_gates = [
+        _todo_preview(
+            planner_order=5,
+            role="user",
+            priority="P1",
+            task_class="user_gate",
+            action_kind="approve_external_issue_publish_or_merge",
+            text=(
+                "[P1] Approve any external issue comment, PR creation, merge, "
+                "publish, or repository-policy exception before LoopX performs it."
+            ),
+            depends_on=["issue_fix_pr_review_packet"],
+            blocks=[
+                "external_issue_comment",
+                "external_pr_creation",
+                "merge",
+                "publish",
+            ],
+        )
+    ]
+    if gated_fields:
+        user_gates.insert(
+            0,
+            _todo_preview(
+                planner_order=5,
+                role="user",
+                priority="P0",
+                task_class="user_gate",
+                action_kind="approve_github_issue_body_or_comment_read",
+                text=(
+                    "[P0] Approve a gated read before LoopX uses GitHub issue "
+                    "body, comment bodies, timeline events, or raw provider payloads."
+                ),
+                depends_on=["content_ops_issue_fix_metadata_preview_packet_v0"],
+                blocks=["private_repro_material_read", "raw_issue_body_read"],
+            )
+            | {"gated_fields": gated_fields},
+        )
+        for offset, gate in enumerate(user_gates, start=5):
+            gate["planner_order"] = offset
+
+    validation_plan = [
+        {
+            "schema_version": "issue_fix_validation_command_v0",
+            "command_label": validation_label,
+            "command_captured": False,
+            "stdout_captured": False,
+            "stderr_captured": False,
+            "local_path_captured": False,
+            "required_for_pr_review": True,
+            "executed": False,
+            "passed": False,
+        }
+    ]
+    readiness_blockers = [
+        "branch_not_executed",
+        "validation_not_run",
+        "repo_relative_changed_files_missing",
+    ]
+    if branch_plan["status"] == "needs_approved_repo_context":
+        readiness_blockers.insert(0, "approved_repo_context_missing")
+    review_packet_preview = {
+        "schema_version": "issue_fix_pr_review_packet_v0",
+        "ready": False,
+        "readiness_blockers": readiness_blockers,
+        "files_changed": [],
+        "validation_commands": [validation_label],
+        "external_issue_comment_performed": False,
+        "external_pr_created": False,
+        "merge_performed": False,
+    }
+    first_screen = {
+        "waiting_on": "agent",
+        "user_action_required": False,
+        "agent_can_continue": True,
+        "top_agent_todo": agent_todos[0],
+        "top_gate": user_gates[0] if gated_fields else None,
+        "next_safe_action": (
+            "write the ordered LoopX todo plan only after the metadata preview "
+            "stays body-free; then run branch/validation work inside the "
+            "caller-approved repo context"
+        ),
+    }
+    packet: dict[str, Any] = {
+        "ok": True,
+        "schema_version": ISSUE_FIX_WORKFLOW_PLAN_PACKET_SCHEMA_VERSION,
+        "mode": "issue-fix-workflow-plan",
+        "generated_at": generated_at,
+        "metadata_preview_schema_version": metadata_packet["schema_version"],
+        "issue_fix_intake_schema_version": intake.get("schema_version"),
+        "issue_signal": {
+            "repo": metadata["repo"],
+            "issue_ref": metadata["issue_ref"],
+            "kind": metadata["kind"],
+            "state": metadata["state"],
+            "labels": metadata["labels"],
+            "body_captured": False,
+            "comment_bodies_captured": False,
+        },
+        "first_screen": first_screen,
+        "branch_plan": branch_plan,
+        "ordered_loopx_todo_writeback_preview": agent_todos + user_gates,
+        "validation_plan": validation_plan,
+        "review_packet_preview": review_packet_preview,
+        "external_reads_performed": bool(metadata_packet["external_reads_performed"]),
+        "external_writes_performed": False,
+        "issue_body_captured": False,
+        "comment_bodies_captured": False,
+        "response_payloads_captured": False,
+        "local_paths_captured": False,
+        "private_repo_state_read": False,
+        "todo_write_performed": False,
+        "destructive_git_used": False,
+        "autopublish_allowed": False,
+        "automerge_allowed": False,
+        "next_safe_action": first_screen["next_safe_action"],
+    }
+    validation = validate_issue_fix_workflow_plan_packet(packet)
+    packet["ok"] = bool(metadata_packet["ok"] and validation["ok"])
+    packet["validation"] = validation
+    return packet
+
+
+def validate_issue_fix_workflow_plan_packet(packet: Mapping[str, Any]) -> dict[str, Any]:
+    errors: list[str] = []
+    if packet.get("schema_version") != ISSUE_FIX_WORKFLOW_PLAN_PACKET_SCHEMA_VERSION:
+        errors.append("packet schema_version must be issue_fix_workflow_plan_packet_v0")
+    for key in (
+        "external_writes_performed",
+        "issue_body_captured",
+        "comment_bodies_captured",
+        "response_payloads_captured",
+        "local_paths_captured",
+        "private_repo_state_read",
+        "todo_write_performed",
+        "destructive_git_used",
+        "autopublish_allowed",
+        "automerge_allowed",
+    ):
+        if packet.get(key) is not False:
+            errors.append(f"packet {key} must be false")
+
+    issue_signal = packet.get("issue_signal")
+    if not isinstance(issue_signal, Mapping):
+        errors.append("issue_signal is required")
+        issue_signal = {}
+    for key in ("repo", "issue_ref", "kind", "state"):
+        if not issue_signal.get(key):
+            errors.append(f"issue_signal {key} is required")
+    if issue_signal.get("body_captured") is not False:
+        errors.append("issue_signal body_captured must be false")
+    if issue_signal.get("comment_bodies_captured") is not False:
+        errors.append("issue_signal comment_bodies_captured must be false")
+
+    branch_plan = packet.get("branch_plan")
+    if not isinstance(branch_plan, Mapping):
+        errors.append("branch_plan is required")
+        branch_plan = {}
+    if branch_plan.get("repo_path_captured") is not False:
+        errors.append("branch_plan repo_path_captured must be false")
+    if branch_plan.get("private_repo_state_read") is not False:
+        errors.append("branch_plan private_repo_state_read must be false")
+
+    previews = packet.get("ordered_loopx_todo_writeback_preview")
+    if not isinstance(previews, Sequence) or isinstance(previews, (str, bytes)):
+        errors.append("ordered_loopx_todo_writeback_preview must be a list")
+        previews = []
+    orders: list[int] = []
+    roles = set()
+    priorities = set()
+    for preview in previews:
+        if not isinstance(preview, Mapping):
+            errors.append("todo preview entries must be objects")
+            continue
+        if preview.get("schema_version") != "loopx_todo_writeback_preview_v0":
+            errors.append("todo preview has wrong schema")
+        if preview.get("would_write") is not False:
+            errors.append("todo preview would_write must be false")
+        if preview.get("requires_execute_flag") is not True:
+            errors.append("todo preview must require execute flag")
+        order = preview.get("planner_order")
+        if isinstance(order, int):
+            orders.append(order)
+        else:
+            errors.append("todo preview planner_order must be an integer")
+        roles.add(preview.get("role"))
+        priorities.add(preview.get("priority"))
+    if orders != sorted(orders):
+        errors.append("todo previews must be ordered by planner_order")
+    if "agent" not in roles:
+        errors.append("at least one agent todo preview is required")
+    if "P0" not in priorities:
+        errors.append("at least one P0 todo preview is required")
+
+    review = packet.get("review_packet_preview")
+    if not isinstance(review, Mapping):
+        errors.append("review_packet_preview is required")
+        review = {}
+    if review.get("schema_version") != "issue_fix_pr_review_packet_v0":
+        errors.append("review packet preview has wrong schema")
+    if review.get("ready") is not False:
+        errors.append("workflow plan preview must not mark PR review ready")
+    if review.get("external_issue_comment_performed") is not False:
+        errors.append("review preview must not perform external issue comments")
+    if review.get("external_pr_created") is not False:
+        errors.append("review preview must not create PRs")
+    if review.get("merge_performed") is not False:
+        errors.append("review preview must not merge")
+
+    return {
+        "ok": not errors,
+        "schema_version": "issue_fix_workflow_plan_validation_v0",
+        "errors": errors,
+        "todo_preview_count": len(previews),
+        "user_gate_preview_count": sum(
+            1
+            for preview in previews
+            if isinstance(preview, Mapping) and preview.get("role") == "user"
+        ),
+        "readiness_blocker_count": len(review.get("readiness_blockers") or []),
+    }
+
+
+def render_issue_fix_workflow_plan_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# LoopX Issue Fix Workflow Plan",
+        "",
+        f"- ok: `{payload.get('ok')}`",
+        f"- schema_version: `{payload.get('schema_version')}`",
+        f"- external_reads_performed: `{payload.get('external_reads_performed')}`",
+        f"- external_writes_performed: `{payload.get('external_writes_performed')}`",
+        f"- todo_write_performed: `{payload.get('todo_write_performed')}`",
+        f"- local_paths_captured: `{payload.get('local_paths_captured')}`",
+        f"- private_repo_state_read: `{payload.get('private_repo_state_read')}`",
+    ]
+    first_screen = payload.get("first_screen")
+    if isinstance(first_screen, Mapping):
+        lines.extend(
+            [
+                "",
+                "## First Screen",
+                "",
+                f"- waiting_on: `{first_screen.get('waiting_on')}`",
+                f"- user_action_required: `{first_screen.get('user_action_required')}`",
+                f"- agent_can_continue: `{first_screen.get('agent_can_continue')}`",
+                f"- next_safe_action: {first_screen.get('next_safe_action')}",
+            ]
+        )
+    issue_signal = payload.get("issue_signal")
+    if isinstance(issue_signal, Mapping):
+        lines.extend(
+            [
+                "",
+                "## Issue Signal",
+                "",
+                f"- repo: `{issue_signal.get('repo')}`",
+                f"- issue_ref: `{issue_signal.get('issue_ref')}`",
+                f"- kind: `{issue_signal.get('kind')}`",
+                f"- state: `{issue_signal.get('state')}`",
+                f"- labels: `{issue_signal.get('labels')}`",
+            ]
+        )
+    branch = payload.get("branch_plan")
+    if isinstance(branch, Mapping):
+        lines.extend(
+            [
+                "",
+                "## Branch Plan",
+                "",
+                f"- status: `{branch.get('status')}`",
+                f"- base_branch: `{branch.get('base_branch')}`",
+                f"- issue_branch: `{branch.get('issue_branch')}`",
+                f"- repo_path_captured: `{branch.get('repo_path_captured')}`",
+                f"- execute_required_for_branch_claim: "
+                f"`{branch.get('execute_required_for_branch_claim')}`",
+            ]
+        )
+    todos = payload.get("ordered_loopx_todo_writeback_preview")
+    if isinstance(todos, Sequence) and not isinstance(todos, (str, bytes)):
+        lines.extend(["", "## Ordered Todo Writeback Preview", ""])
+        for todo in todos:
+            if isinstance(todo, Mapping):
+                lines.append(
+                    f"- `{todo.get('planner_order')}` `{todo.get('role')}` "
+                    f"`{todo.get('priority')}` `{todo.get('action_kind')}`: "
+                    f"would_write=`{todo.get('would_write')}`"
+                )
+    review = payload.get("review_packet_preview")
+    if isinstance(review, Mapping):
+        lines.extend(
+            [
+                "",
+                "## PR Review Packet Preview",
+                "",
+                f"- ready: `{review.get('ready')}`",
+                f"- readiness_blockers: `{review.get('readiness_blockers')}`",
+                f"- external_pr_created: `{review.get('external_pr_created')}`",
+                f"- merge_performed: `{review.get('merge_performed')}`",
+            ]
+        )
+    validation = payload.get("validation")
+    if isinstance(validation, Mapping):
+        errors = validation.get("errors") if isinstance(validation.get("errors"), list) else []
+        lines.extend(
+            [
+                "",
+                "## Validation",
+                "",
+                f"- validation_ok: `{validation.get('ok')}`",
+                f"- todo_preview_count: `{validation.get('todo_preview_count')}`",
+                f"- user_gate_preview_count: `{validation.get('user_gate_preview_count')}`",
+                f"- readiness_blocker_count: `{validation.get('readiness_blocker_count')}`",
+                f"- error_count: `{len(errors)}`",
+            ]
+        )
+    if payload.get("error"):
+        lines.extend(["", "## Error", "", str(payload.get("error"))])
+    return "\n".join(lines) + "\n"


### PR DESCRIPTION
## Summary
- add `loopx issue-fix workflow-plan` as a preview-only orchestrator packet from public issue metadata to ordered LoopX todo previews, validation labels, branch dry-run planning, and PR review readiness blockers
- update issue-fix capability docs/catalog and workflow contract to expose `issue_fix_workflow_plan_packet_v0`
- add focused smoke coverage for gated provider fields, dry-run repo planning, todo order, and public-safe output

## Boundaries
- no LoopX todo writeback is performed by the planner
- no local repo inspection occurs in workflow-plan dry-run mode
- no external issue comment, PR creation, merge, publish, destructive git, raw issue body/comment, provider payload, local path, validation stdout, or stderr is captured

## Validation
- `python3 examples/issue-fix-workflow-plan-smoke.py`
- `python3 examples/issue-fix-workflow-contract-smoke.py`
- `python3 examples/content-ops-issue-fix-metadata-preview-smoke.py`
- `python3 examples/content-ops-issue-fix-intake-smoke.py`
- `python3 examples/issue-fix-acceptance-loop-smoke.py`
- `python3 -m py_compile loopx/capabilities/issue_fix/workflow_plan.py loopx/capabilities/issue_fix/cli.py loopx/capabilities/catalog.py`
- `loopx check --scan-path loopx/capabilities/issue_fix --scan-path docs/capabilities/issue-fix --scan-path examples/issue-fix-workflow-plan-smoke.py --scan-path examples/issue-fix-workflow-contract-smoke.py` (passes with existing duplicate-index warning)
- `git diff --cached --check`