### PR TITLE
Define event-sourced LoopX state contract

### DIFF
--- a/docs/reference/protocols/README.md
+++ b/docs/reference/protocols/README.md
@@ -15,6 +15,7 @@ Current contracts:
 - [task_graph_projection_v0](task-graph-projection-v0.md)
 - [long_horizon_agent_state_protocol_v0](long-horizon-agent-state-protocol-v0.md)
 - [global_manager_command_v0](global-manager-command-v0.md)
+- [event_sourced_state_contract_v0](event-sourced-state-contract-v0.md)
 - [rollback_packet_v0](rollback-packet-v0.md)
 - [content_ops_surface_v0](content-ops-surface-v0.md)
 - [x_public_channel_ops_v0](x-public-channel-ops-v0.md)

--- a/docs/reference/protocols/event-sourced-state-contract-v0.md
+++ b/docs/reference/protocols/event-sourced-state-contract-v0.md
@@ -1,0 +1,191 @@
+# event_sourced_state_contract_v0
+
+`event_sourced_state_contract_v0` defines how LoopX can keep
+`ACTIVE_GOAL_STATE.md` as the human/agent workbench while moving canonical
+todo and history truth to an append-only event stream.
+
+This is a product/control-plane contract, not an implementation mandate for a
+specific database. Implementations may store the stream as JSONL, SQLite rows,
+or another local-first append-only format as long as replay, ordering,
+privacy, and idempotency behave the same way.
+
+## Role Split
+
+`ACTIVE_GOAL_STATE.md` remains the human/agent workbench. It is the readable
+surface where agents and users can inspect current goals, progress, todos,
+gates, validation surfaces, and next action. It may keep private or
+project-local context when the project has explicitly ignored local state.
+
+Canonical todo/history truth belongs to the event stream:
+
+- Markdown edits are not canonical state changes unless they are converted into
+  events by a LoopX command or a migration/backfill tool.
+- Markdown renderers are projections. They may be regenerated from events and
+  may compact old detail for prompt and review budgets.
+- During migration, the Markdown parser may remain a compatibility fallback,
+  but the event projection should become the preferred source for status,
+  quota, review packets, todo CLI reads, and dashboard exports.
+
+## Canonical Event Stream
+
+Each goal has an ordered event stream. Every event must include:
+
+- `schema_version`: event schema version, starting with
+  `loopx_state_event_v0`;
+- `event_id`: stable unique id for idempotent append and audit;
+- `goal_id`: owning goal id;
+- `event_type`: one of the allowed lifecycle event types;
+- `recorded_at`: producer timestamp in UTC or offset-aware ISO-8601;
+- `append_sequence`: monotonic sequence assigned by the local event store;
+- `producer`: compact source such as `loopx.todo`, `loopx.refresh_state`, or
+  `agent.codex-product-capability`;
+- `privacy`: `public_safe`, `local_private`, or `private_pointer`;
+- `projection_version`: projection contract version expected by the writer;
+- `refs`: compact ids for todo, gate, run, quota, PR, evidence, or parent
+  events;
+- `payload`: event-specific compact data.
+
+`append_sequence` is the final same-priority tie-breaker. If a planner creates
+multiple P0 todos, the planner emits `planner_order`, and the store preserves
+that order through append sequence. UI and prompt projections sort by priority
+first, then `planner_order` when present, then `append_sequence`.
+
+## Event Types
+
+First supported todo/history event types:
+
+| Event type | Purpose |
+| --- | --- |
+| `todo_added` | Add a new todo with role, priority, title, metadata, and planner order. |
+| `todo_claimed` | Record or renew ownership, lease, or `claimed_by`. |
+| `todo_updated` | Update compact metadata that does not rewrite event history. |
+| `todo_blocked` | Mark a todo blocked with a public-safe blocker reason and optional gate refs. |
+| `todo_deferred` | Mark a todo deferred with resume conditions. |
+| `todo_completed` | Close a todo with validation/evidence refs and completion rationale. |
+| `gate_added` | Add a user, owner, operator, or controller gate. |
+| `gate_resolved` | Record approve, reject, or defer for a specific gate. |
+| `run_recorded` | Attach compact run-history status, classification, and delivery outcome. |
+| `refresh_recorded` | Record a state-only or progress refresh summary. |
+| `quota_spent` | Record accounting for automatic compute spend. |
+| `evidence_attached` | Attach compact public-safe evidence refs to a todo, gate, or run. |
+| `projection_rendered` | Record a generated Markdown/status/dashboard projection checksum. |
+| `snapshot_compacted` | Declare a derived snapshot checkpoint without replacing the underlying event lineage. |
+
+Forbidden event styles:
+
+- no event may mutate or delete a prior event;
+- no event may embed raw chat transcripts, raw logs, credentials, or private
+  source bodies in a public-safe stream;
+- no projection may become a write API by accepting state that lacks a matching
+  canonical event.
+
+## Ordering And Idempotency
+
+Replay order is:
+
+1. `append_sequence`;
+2. `recorded_at`;
+3. `event_id` as a deterministic final tie-breaker.
+
+Append is idempotent on `event_id`: re-appending the same event id with the
+same normalized body is a no-op; re-appending it with a different body is a
+conflict. Consumers should ignore duplicate identical events and fail closed on
+conflicting duplicates.
+
+Todo ids, gate ids, and evidence ids are stable references. Events may point to
+parent events through `refs.parent_event_id`, but a child event must not rewrite
+parent payload.
+
+## Projection Rules
+
+The event projection renders:
+
+- current active todos grouped by role and priority;
+- completed todo summaries and archive candidates;
+- user and controller gate inboxes;
+- run-history and refresh timeline summaries;
+- quota spend summaries;
+- review-packet evidence refs;
+- Markdown-compatible `ACTIVE_GOAL_STATE.md` sections.
+
+Projection outputs must carry:
+
+- `schema_version`;
+- `goal_id`;
+- `generated_at`;
+- `source_event_count`;
+- `last_event_id`;
+- `last_append_sequence`;
+- `projection_version`;
+- `source_checksum` or equivalent integrity marker.
+
+A projection may be stale after any lifecycle event. Writers should append the
+event first, then render projection output. Readers should prefer the latest
+projection only when its `last_append_sequence` matches the event store head.
+
+## Privacy Boundary
+
+LoopX should support separate streams or partitioned records:
+
+- `public_safe`: compact state that can be committed or shown in public docs;
+- `local_private`: local state such as project-private active Markdown,
+  private todo details, or local-only evidence notes;
+- `private_pointer`: a compact pointer to private material without copying the
+  material into public state.
+
+`ACTIVE_GOAL_STATE.md` can carry private details when the project keeps it out
+of git. Public docs, fixtures, dashboards, and PR packets must not copy those
+details. Public projections should include only compact labels, ids, redacted
+summaries, omission notes, and validation refs.
+
+Tracked outputs require explicit redaction or compact pointers before
+projecting information from private streams. A project-level LoopX config may
+set defaults such as:
+
+```json
+{
+  "state_privacy": {
+    "active_state": "local_private",
+    "public_projection": "public_safe",
+    "allow_private_links_in_ignored_state": true,
+    "require_redaction_for_tracked_outputs": true
+  }
+}
+```
+
+## Migration And Compatibility
+
+The migration should be staged:
+
+1. Define this contract and smoke-test replay/privacy invariants.
+2. Add a minimal event store and projection API for todo/history events.
+3. Dual-write `loopx todo`, `refresh-state`, quota spend, and gate commands.
+4. Compare event projection against current Markdown parsing.
+5. Prefer event projection for status, quota, review packets, dashboard, and
+   slash-command help.
+6. Keep Markdown rendering as the workbench and compatibility export.
+7. Retire Markdown-as-canonical only after replay and idempotency checks are
+   clean on real local goals.
+
+Migration tools may backfill events from existing Markdown, but each backfilled
+event should mark `producer=loopx.backfill` and include enough source refs to
+explain provenance without copying private raw material into public streams.
+
+## Acceptance Checks
+
+A valid implementation or fixture must prove:
+
+- Markdown remains a workbench/projection, not canonical todo/history truth;
+- `todo_added`, `todo_claimed`, `todo_updated`, `todo_blocked`,
+  `todo_deferred`, and `todo_completed` replay into a deterministic todo
+  projection;
+- same-priority todos preserve planner order and append order;
+- duplicate identical `event_id` append is idempotent;
+- duplicate conflicting `event_id` append fails closed;
+- prior events are never mutated or deleted;
+- projections expose `last_event_id`, `last_append_sequence`, and
+  `projection_version`;
+- public projections do not include local absolute paths, credentials, raw
+  transcripts, raw logs, or private source bodies;
+- ignored/private active state may reference private links, while tracked
+  outputs require explicit redaction or compact pointers.

--- a/docs/state-interaction-model.md
+++ b/docs/state-interaction-model.md
@@ -485,6 +485,12 @@ the append-only event ledger for long-running work. Chat threads, browser
 filters, and local tool outputs may help a worker decide what to do in the
 moment, but they are not the durable source of truth.
 
+The todo/history migration contract is captured in
+[`event_sourced_state_contract_v0`](reference/protocols/event-sourced-state-contract-v0.md):
+`ACTIVE_GOAL_STATE.md` stays the human/agent workbench, while canonical
+todo/history state moves to append-only events with deterministic replay,
+idempotent append, privacy partitions, and Markdown-compatible projections.
+
 The control plane should preserve these event classes:
 
 - **work events**: `refresh-state`, read-only maps, adapter ticks, and progress

--- a/examples/event-sourced-state-contract-smoke.py
+++ b/examples/event-sourced-state-contract-smoke.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Smoke-test event-sourced todo/history contract invariants."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONTRACT = REPO_ROOT / "docs/reference/protocols/event-sourced-state-contract-v0.md"
+PROTOCOL_INDEX = REPO_ROOT / "docs/reference/protocols/README.md"
+STATE_MODEL = REPO_ROOT / "docs/state-interaction-model.md"
+
+
+PUBLIC_FORBIDDEN = (
+    "/Users/",
+    "/home/",
+    "/private/tmp/",
+    "Bearer ",
+    "AKIA",
+)
+
+
+@dataclass
+class EventStore:
+    events_by_id: dict[str, dict[str, Any]] = field(default_factory=dict)
+    events: list[dict[str, Any]] = field(default_factory=list)
+
+    def append(self, event: dict[str, Any]) -> None:
+        event_id = event["event_id"]
+        existing = self.events_by_id.get(event_id)
+        normalized = dict(sorted(event.items()))
+        if existing is not None:
+            if dict(sorted(existing.items())) != normalized:
+                raise ValueError(f"conflicting event_id: {event_id}")
+            return
+        if event.get("event_type") == "event_mutated":
+            raise ValueError("events must not mutate prior events")
+        if "mutates_prior_event_id" in event.get("refs", {}):
+            raise ValueError("events must not mutate prior events")
+        self.events_by_id[event_id] = normalized
+        self.events.append(normalized)
+
+    def replay_todos(self) -> dict[str, Any]:
+        todos: dict[str, dict[str, Any]] = {}
+        completed: list[str] = []
+        for event in sorted(
+            self.events,
+            key=lambda item: (
+                item["append_sequence"],
+                item["recorded_at"],
+                item["event_id"],
+            ),
+        ):
+            event_type = event["event_type"]
+            todo_id = event.get("refs", {}).get("todo_id")
+            if event_type == "todo_added":
+                todos[todo_id] = {
+                    "todo_id": todo_id,
+                    "priority": event["payload"]["priority"],
+                    "role": event["payload"]["role"],
+                    "title": event["payload"]["title"],
+                    "planner_order": event["payload"].get("planner_order"),
+                    "append_sequence": event["append_sequence"],
+                    "status": "open",
+                }
+            elif event_type == "todo_claimed":
+                todos[todo_id]["claimed_by"] = event["payload"]["claimed_by"]
+            elif event_type == "todo_blocked":
+                todos[todo_id]["status"] = "blocked"
+                todos[todo_id]["blocker"] = event["payload"]["reason"]
+            elif event_type == "todo_completed":
+                todos[todo_id]["status"] = "done"
+                completed.append(todo_id)
+
+        open_todos = [
+            todo for todo in todos.values() if todo.get("status") in {"open", "blocked"}
+        ]
+        open_todos.sort(
+            key=lambda todo: (
+                todo["priority"],
+                todo.get("planner_order") or 9999,
+                todo["append_sequence"],
+            )
+        )
+        return {
+            "schema_version": "event_sourced_state_projection_v0",
+            "goal_id": "loopx-meta",
+            "source_event_count": len(self.events),
+            "last_event_id": self.events[-1]["event_id"],
+            "last_append_sequence": self.events[-1]["append_sequence"],
+            "projection_version": "event_sourced_state_contract_v0",
+            "open_todos": open_todos,
+            "completed_todo_ids": completed,
+        }
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_contract_text() -> None:
+    contract = read(CONTRACT)
+    compact = " ".join(contract.split())
+    for required in [
+        "# event_sourced_state_contract_v0",
+        "ACTIVE_GOAL_STATE.md` remains the human/agent workbench",
+        "Markdown edits are not canonical state changes",
+        "append_sequence` is the final same-priority tie-breaker",
+        "public_safe",
+        "local_private",
+        "private_pointer",
+        "last_append_sequence",
+        "projection_version",
+        "raw chat transcripts",
+        "raw logs",
+        "duplicate conflicting `event_id` append fails closed",
+        "Tracked outputs require explicit redaction or compact pointers",
+    ]:
+        assert required in contract, required
+
+    for event_type in [
+        "todo_added",
+        "todo_claimed",
+        "todo_updated",
+        "todo_blocked",
+        "todo_deferred",
+        "todo_completed",
+        "gate_added",
+        "gate_resolved",
+        "run_recorded",
+        "refresh_recorded",
+        "quota_spent",
+        "evidence_attached",
+        "projection_rendered",
+        "snapshot_compacted",
+    ]:
+        assert f"`{event_type}`" in contract, event_type
+
+    for forbidden in PUBLIC_FORBIDDEN:
+        assert forbidden not in compact, forbidden
+
+
+def test_docs_are_linked() -> None:
+    index = read(PROTOCOL_INDEX)
+    state_model = read(STATE_MODEL)
+    assert "event_sourced_state_contract_v0" in index, index
+    assert "event-sourced-state-contract-v0.md" in index, index
+    assert "event_sourced_state_contract_v0" in state_model, state_model
+    assert "ACTIVE_GOAL_STATE.md` stays the human/agent workbench" in state_model
+
+
+def event(
+    event_id: str,
+    event_type: str,
+    append_sequence: int,
+    todo_id: str,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "schema_version": "loopx_state_event_v0",
+        "event_id": event_id,
+        "goal_id": "loopx-meta",
+        "event_type": event_type,
+        "recorded_at": f"2026-06-27T00:00:{append_sequence:02d}Z",
+        "append_sequence": append_sequence,
+        "producer": "loopx.todo",
+        "privacy": "public_safe",
+        "projection_version": "event_sourced_state_contract_v0",
+        "refs": {"todo_id": todo_id},
+        "payload": payload,
+    }
+
+
+def test_replay_order_and_idempotency() -> None:
+    store = EventStore()
+    todo_a = event(
+        "evt-a",
+        "todo_added",
+        1,
+        "todo_a",
+        {
+            "role": "agent",
+            "priority": "P0",
+            "title": "Define event source contract",
+            "planner_order": 1,
+        },
+    )
+    todo_b = event(
+        "evt-b",
+        "todo_added",
+        2,
+        "todo_b",
+        {
+            "role": "agent",
+            "priority": "P0",
+            "title": "Implement event store",
+            "planner_order": 2,
+        },
+    )
+    store.append(todo_b)
+    store.append(todo_a)
+    store.append(todo_a)
+    store.append(
+        event(
+            "evt-claim-a",
+            "todo_claimed",
+            3,
+            "todo_a",
+            {"claimed_by": "codex-product-capability"},
+        )
+    )
+
+    projection = store.replay_todos()
+    assert [todo["todo_id"] for todo in projection["open_todos"]] == [
+        "todo_a",
+        "todo_b",
+    ], projection
+    assert projection["source_event_count"] == 3, projection
+    assert projection["last_event_id"] == "evt-claim-a", projection
+    assert projection["last_append_sequence"] == 3, projection
+    assert projection["projection_version"] == "event_sourced_state_contract_v0"
+
+    conflicting = dict(todo_a)
+    conflicting["payload"] = dict(todo_a["payload"])
+    conflicting["payload"]["title"] = "Rewrite prior event"
+    try:
+        store.append(conflicting)
+    except ValueError as exc:
+        assert "conflicting event_id" in str(exc), exc
+    else:
+        raise AssertionError("conflicting duplicate event id was accepted")
+
+    mutation = event("evt-mutate", "todo_updated", 4, "todo_a", {"title": "mutate"})
+    mutation["refs"]["mutates_prior_event_id"] = "evt-a"
+    try:
+        store.append(mutation)
+    except ValueError as exc:
+        assert "must not mutate prior events" in str(exc), exc
+    else:
+        raise AssertionError("prior-event mutation was accepted")
+
+
+def main() -> int:
+    test_contract_text()
+    test_docs_are_linked()
+    test_replay_order_and_idempotency()
+    print("event-sourced-state-contract-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add event_sourced_state_contract_v0 for moving canonical todo/history truth to append-only events while keeping ACTIVE_GOAL_STATE.md as the human/agent workbench
- link the contract from protocol docs and the state interaction model
- add a smoke covering deterministic replay, same-priority ordering, idempotent append, mutation rejection, and public/private boundary terms

## Validation
- python3 examples/event-sourced-state-contract-smoke.py
- python3 examples/task-graph-projection-fixture-smoke.py
- git diff --check
- git diff --cached --check
- loopx check --scan-path docs/reference/protocols/event-sourced-state-contract-v0.md --scan-path docs/reference/protocols/README.md --scan-path docs/state-interaction-model.md --scan-path examples/event-sourced-state-contract-smoke.py

Note: docs-governance-smoke currently fails on the pre-existing docs root Markdown count threshold; this PR only adds a protocol subdirectory doc and one example smoke.