### PR TITLE
Prefer event projection for status todo reads

### DIFF
--- a/examples/event-sourced-status-read-path-smoke.py
+++ b/examples/event-sourced-status-read-path-smoke.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Validate that status todo reads prefer event projection with Markdown fallback."""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.event_sourced_state import (  # noqa: E402
+    AppendOnlyStateEventStore,
+    TODO_ADDED,
+    TODO_CLAIMED,
+    make_state_event,
+)
+from loopx.status import active_state_todo_fields  # noqa: E402
+
+
+GOAL_ID = "event-sourced-status-read-fixture"
+
+
+def write_active_state(state_path: Path) -> None:
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        "\n".join(
+            [
+                "# Fixture State",
+                "",
+                "## Next Action",
+                "",
+                "- Keep the current status read path stable.",
+                "",
+                "## Agent Todo",
+                "",
+                "- [ ] [P2] Stale Markdown todo that should lose to events.",
+                "  <!-- loopx:todo todo_id=todo_markdown_stale status=open task_class=advancement_task action_kind=stale -->",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def append_event_todos(event_log: Path) -> None:
+    store = AppendOnlyStateEventStore(event_log)
+    store.append(
+        make_state_event(
+            event_id="evt-add-agent-status-read",
+            goal_id=GOAL_ID,
+            event_type=TODO_ADDED,
+            refs={"todo_id": "todo_event_status_read"},
+            payload={
+                "role": "agent",
+                "priority": "P0",
+                "title": "Prefer event projection for status todo reads",
+                "planner_order": 1,
+                "task_class": "advancement_task",
+                "action_kind": "event_projection_read_path",
+            },
+            producer="event-sourced-status-read-path-smoke",
+            recorded_at="2026-06-27T00:00:01Z",
+        )
+    )
+    store.append(
+        make_state_event(
+            event_id="evt-claim-agent-status-read",
+            goal_id=GOAL_ID,
+            event_type=TODO_CLAIMED,
+            refs={"todo_id": "todo_event_status_read"},
+            payload={"claimed_by": "codex-product-capability"},
+            producer="event-sourced-status-read-path-smoke",
+            recorded_at="2026-06-27T00:00:02Z",
+        )
+    )
+
+
+def event_todo_ids(fields: dict) -> list[str]:
+    agent_todos = fields.get("agent_todos") or {}
+    return [str(item.get("todo_id") or "") for item in agent_todos.get("items") or []]
+
+
+def test_event_projection_preferred() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-event-status-") as tmp:
+        project = Path(tmp)
+        state_path = project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+        write_active_state(state_path)
+        append_event_todos(state_path.with_name("events.jsonl"))
+
+        goal = {
+            "id": GOAL_ID,
+            "repo": str(project),
+            "state_file": f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md",
+        }
+        fields = active_state_todo_fields(goal)
+        assert fields["state_event_projection"]["source"] == "event_log", fields
+        assert fields["state_event_projection"]["last_append_sequence"] == 2, fields
+        assert event_todo_ids(fields) == ["todo_event_status_read"], fields
+        assert "todo_markdown_stale" not in event_todo_ids(fields), fields
+        assert fields["agent_todos"]["items"][0]["claimed_by"] == "codex-product-capability", fields
+
+
+def test_markdown_fallback_without_valid_event_log() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-event-status-fallback-") as tmp:
+        project = Path(tmp)
+        state_path = project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+        write_active_state(state_path)
+        goal = {
+            "id": GOAL_ID,
+            "repo": str(project),
+            "state_file": f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md",
+        }
+
+        fields = active_state_todo_fields(goal)
+        assert event_todo_ids(fields) == ["todo_markdown_stale"], fields
+        assert "state_event_projection" not in fields, fields
+
+        state_path.with_name("events.jsonl").write_text("{not json\n", encoding="utf-8")
+        corrupted_fields = active_state_todo_fields(goal)
+        assert event_todo_ids(corrupted_fields) == ["todo_markdown_stale"], corrupted_fields
+        assert corrupted_fields["state_event_projection_warning"]["fallback"] == "markdown_active_state", (
+            corrupted_fields
+        )
+
+
+def main() -> int:
+    test_event_projection_preferred()
+    test_markdown_fallback_without_valid_event_log()
+    print("event-sourced-status-read-path-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -34,6 +34,12 @@ from .execution_profile import (
     execution_profile_outcome_floor,
     execution_profile_summary,
 )
+from .event_sourced_state import (
+    AppendOnlyStateEventStore,
+    StateEventError,
+    build_state_projection,
+    render_active_state_sections,
+)
 from .frontstage import build_goal_channel_projection
 from .handoff_budget import handoff_budget_contract
 from .history import collect_history, load_registry
@@ -95,6 +101,7 @@ CODEX_READY_CLASSIFICATIONS = {
     "monitor_todo_repeat_dedupe_deployed",
 }
 STATUS_NEUTRAL_CLASSIFICATIONS = HISTORY_STATUS_NEUTRAL_CLASSIFICATIONS
+STATE_EVENT_LOG_BASENAME = "events.jsonl"
 STATUS_CONTROL_PLANE_CONTEXT_LIMIT = 20
 AGENT_LANE_PROGRESS_SCOPE = "agent_lane"
 HANDOFF_READY_CLASSIFICATIONS = {
@@ -5255,6 +5262,73 @@ def parse_active_state_todos(
     return result
 
 
+def state_event_log_candidates(goal: dict[str, Any], *, state_path: Path) -> list[Path]:
+    candidates: list[Path] = []
+    for key in ("state_event_log", "state_events_file", "event_log"):
+        resolved = resolve_goal_local_path(goal.get(key), goal, fallback_base=state_path.parent)
+        if resolved is not None:
+            candidates.append(resolved)
+    candidates.append(state_path.with_name(STATE_EVENT_LOG_BASENAME))
+
+    unique: list[Path] = []
+    seen: set[str] = set()
+    for path in candidates:
+        key = str(path.expanduser())
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(path)
+    return unique
+
+
+def active_state_event_projection_fields(
+    goal: dict[str, Any],
+    *,
+    state_path: Path,
+    preferred_todo_ids: set[str] | None = None,
+    rollout_events: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    goal_id = str(goal.get("id") or "").strip()
+    for event_log_path in state_event_log_candidates(goal, state_path=state_path):
+        if not event_log_path.exists():
+            continue
+        try:
+            events = AppendOnlyStateEventStore(event_log_path).load()
+            if not events:
+                continue
+            projection = build_state_projection(events, goal_id=goal_id or None)
+            projection_markdown = render_active_state_sections(projection)
+            fields = parse_active_state_todos(
+                projection_markdown,
+                goal=goal,
+                state_path=state_path,
+                preferred_todo_ids=preferred_todo_ids,
+                rollout_events=rollout_events,
+            )
+        except (OSError, StateEventError) as exc:
+            return {
+                "state_event_projection_warning": {
+                    "schema_version": "event_sourced_state_read_warning_v0",
+                    "source": "event_log",
+                    "event_log": event_log_path.name,
+                    "fallback": "markdown_active_state",
+                    "reason": type(exc).__name__,
+                }
+            }
+        if fields:
+            fields["state_event_projection"] = {
+                "schema_version": "event_sourced_state_status_projection_v0",
+                "source": "event_log",
+                "event_log": event_log_path.name,
+                "source_event_count": projection.get("source_event_count"),
+                "last_event_id": projection.get("last_event_id"),
+                "last_append_sequence": projection.get("last_append_sequence"),
+                "projection_version": projection.get("projection_version"),
+            }
+            return fields
+    return {}
+
+
 def active_state_sections(state_text: str, headings: tuple[str, ...]) -> dict[str, list[str]]:
     wanted = {heading.lower(): heading for heading in headings}
     current: str | None = None
@@ -6832,13 +6906,24 @@ def active_state_todo_fields(
             rollout_event_log_path(runtime_root, goal_id),
             limit=MAX_TODO_INDEX_ROLLOUT_EVENTS_PER_GOAL,
         )
-    fields = parse_active_state_todos(
-        state_text,
-        goal=goal,
+    event_fields = active_state_event_projection_fields(
+        goal,
         state_path=state_path,
         preferred_todo_ids=preferred_todo_ids,
         rollout_events=rollout_events,
     )
+    if event_fields.get("user_todos") or event_fields.get("agent_todos"):
+        fields = event_fields
+    else:
+        fields = parse_active_state_todos(
+            state_text,
+            goal=goal,
+            state_path=state_path,
+            preferred_todo_ids=preferred_todo_ids,
+            rollout_events=rollout_events,
+        )
+        if event_fields:
+            fields.update(event_fields)
     issue_meta_surface = parse_issue_meta_surface(state_text)
     if issue_meta_surface:
         fields["issue_meta_surface"] = issue_meta_surface


### PR DESCRIPTION
## Summary
- Prefer the append-only state event projection for status todo reads when a goal-local event log exists.
- Keep Markdown `ACTIVE_GOAL_STATE.md` parsing as the compatibility fallback when no valid event log is present.
- Add a focused smoke that proves event projection wins over stale Markdown and corrupted/missing event logs fall back safely.

## Stack
- Stacked on #716 (`codex/event-store-api-20260627`) because this read-path migration depends on the event store/projection API.

## Validation
- `python3 examples/event-sourced-status-read-path-smoke.py`
- `python3 examples/event-sourced-state-api-smoke.py`
- `python3 -m py_compile loopx/status.py loopx/event_sourced_state.py examples/event-sourced-status-read-path-smoke.py`
- `python3 examples/state-projection-gap-smoke.py`
- `python3 examples/review-packet-smoke.py`
- `git diff --check`
- `git diff --cached --check`
- `loopx check --scan-path loopx/status.py --scan-path examples/event-sourced-status-read-path-smoke.py` (existing duplicate-index warning only)
