### PR TITLE
Add Codex App host command registry contract

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -72,6 +72,7 @@ incident report, or launch draft.
 - [Session runtime to LoopX projection v0](reference/protocols/session-runtime-loopx-projection-v0.md)
 - [Interface budget contract](interface-budget-contract.md)
 - [Host integration surface v0](reference/protocols/host-integration-surface-v0.md)
+- [Codex App host command registry v0](reference/protocols/codex-app-host-command-registry-v0.md)
 - [Runtime connector catalog](runtime-connector-catalog.md)
 - [Reward gate direct-write contract](reward-gate-direct-write-contract.md)
 - [Worker bridge install contract](worker-bridge-install-contract.md)

--- a/docs/reference/protocols/README.md
+++ b/docs/reference/protocols/README.md
@@ -8,6 +8,7 @@ Current contracts:
 - [Action packet decision v0](protocol-action-packet-decision-v0.md)
 - [Decision Scope v0](decision-scope-v0.md)
 - [Host integration surface v0](host-integration-surface-v0.md)
+- [codex_app_host_command_registry_v0](codex-app-host-command-registry-v0.md)
 - [Session runtime to LoopX projection v0](session-runtime-loopx-projection-v0.md)
 - [Session runtime controlled writeback v0](session-runtime-controlled-writeback-v0.md)
 - [Codex CLI wrapper action packet v0](protocol-action-packet-codex-cli-wrapper-v0.md)

--- a/docs/reference/protocols/codex-app-host-command-registry-v0.md
+++ b/docs/reference/protocols/codex-app-host-command-registry-v0.md
@@ -1,0 +1,182 @@
+# codex_app_host_command_registry_v0
+
+`codex_app_host_command_registry_v0` defines how a host such as Codex App
+should recognize LoopX slash commands before they become ordinary agent chat.
+The host owns parsing, project-root resolution, permission framing, and the
+structured handoff packet. LoopX CLI remains the source of truth.
+
+This contract sits above:
+
+- [`loopx_goal_command_v0`](loopx-goal-command-v0.md) for project-local
+  `/loopx` and `/loopx <goal text>`.
+- [`global_manager_command_v0`](global-manager-command-v0.md) for read-only
+  `/loopx-global-*` manager commands.
+- [`host_integration_surface_v0`](host-integration-surface-v0.md) for general
+  host lifecycle reads and controlled writes.
+
+It is not a replacement for the CLI, a hidden automation runner, or a broad
+natural-language router.
+
+## Command Registry
+
+The host registry should expose this minimal command set:
+
+| Command | Canonical target | Default authority |
+| --- | --- | --- |
+| `/loopx` | `loopx bootstrap-command-pack --project .` | Read/status-first. |
+| `/loopx <goal text>` | `loopx bootstrap-command-pack --project . --goal-text "<goal text>"` | Explicit project-local goal-start intent. |
+| `/loopx-global-summary` | `global_manager_command_v0` summary request | Read-only global control-plane digest. |
+| `/loopx-global-gates` | `global_manager_command_v0` gates request | Read-only gate inbox. |
+| `/loopx-global-todos` | `global_manager_command_v0` todos request | Read-only work queue view. |
+| `/loopx-global-risks` | `global_manager_command_v0` risks request | Read-only risk view. |
+
+Legacy `/loop-global-*` forms may be accepted during migration, but the host
+must canonicalize packets, help, and user-visible labels to `/loopx-global-*`.
+Do not add extra summary aliases; `/loopx-global-summary` is the canonical
+global progress digest.
+
+Example registry entry:
+
+```json
+{
+  "schema_version": "codex_app_host_command_registry_v0",
+  "host_kind": "codex_app",
+  "commands": [
+    {
+      "command": "/loopx",
+      "kind": "project_bootstrap_preview",
+      "protocol": "loopx_goal_command_v0",
+      "cli_baseline": "loopx bootstrap-command-pack --project .",
+      "mutation_policy": "read_first"
+    },
+    {
+      "command": "/loopx <goal text>",
+      "kind": "project_goal_start",
+      "protocol": "loopx_goal_command_v0",
+      "cli_baseline": "loopx bootstrap-command-pack --project . --goal-text \"<goal text>\"",
+      "mutation_policy": "explicit_goal_start"
+    },
+    {
+      "command": "/loopx-global-summary",
+      "kind": "global_manager_summary",
+      "protocol": "global_manager_command_v0",
+      "legacy_aliases": ["/loop-global-summary"],
+      "mutation_policy": "read_only"
+    }
+  ],
+  "unknown_command_policy": "fail_closed_with_slash_help"
+}
+```
+
+## Host Parse Rules
+
+The host should parse LoopX slash commands before the agent prompt sees the
+message:
+
+1. Match only an exact command token at the beginning of the visible user
+   message.
+2. Canonicalize legacy `/loop-global-*` aliases to `/loopx-global-*`.
+3. Treat `/loopx` with no trailing text as bootstrap/status preview.
+4. Treat text after `/loopx` as explicit goal-start text. Preserve the exact
+   user goal text in the handoff packet, but quote it safely for CLI display.
+5. Fail closed for unknown `/loopx-*` commands and return `loopx slash-commands`
+   help instead of falling through to ordinary chat.
+
+Skill-level recognition may remain a fallback, but the preferred product path
+is host parsing. Prompt-only recognition is useful for early testing but can be
+polluted by conversation history and should not be the long-term authority.
+
+## Project Root And Agent Identity
+
+Project-local commands require a resolved project root. The host may use the
+current workspace, selected file, or explicit project parameter, but it must not
+scan unrelated home directories or guess from private paths.
+
+Required fields:
+
+| Field | Rule |
+| --- | --- |
+| `project_root` | Absolute local root for CLI execution; omit from public packets. |
+| `project_root_label` | Public-safe label such as repo name or `current workspace`. |
+| `goal_id` | Use the registry goal id when known; otherwise let `bootstrap-command-pack` infer or propose one. |
+| `agent_id` | Registered LoopX agent id when the host is acting for an agent. |
+| `host_surface` | `chat_box`, `command_palette`, `codex_cli_tui`, or another compact host label. |
+
+If the host cannot resolve a project root, `/loopx` and `/loopx <goal text>`
+must produce a setup/help packet, not state writes. Global commands may still
+run against the shared global registry when available.
+
+## Handoff Packet
+
+After parsing, the host hands the agent or CLI a compact packet:
+
+```json
+{
+  "schema_version": "codex_app_host_command_handoff_v0",
+  "command": "/loopx",
+  "raw_command": "/loopx design an issue-fix workflow",
+  "canonical_command": "/loopx <goal text>",
+  "goal_text": "design an issue-fix workflow",
+  "host_surface": "chat_box",
+  "project_root_label": "current workspace",
+  "goal_id": "loopx-meta",
+  "agent_id": "codex-product-capability",
+  "protocol": "loopx_goal_command_v0",
+  "cli_preview": "loopx bootstrap-command-pack --project . --goal-text \"<goal text>\"",
+  "authority": {
+    "read_allowed": true,
+    "project_local_write_allowed": true,
+    "global_control_write_allowed": false,
+    "production_action_allowed": false
+  },
+  "next_step": "run_bootstrap_command_pack_then_plan_before_todo_write"
+}
+```
+
+The packet may be rendered to the agent prompt, passed to a tool call, or used
+to run the CLI directly. It must not contain raw transcripts, credentials,
+private document bodies, or local absolute paths in user-visible output.
+
+## Permission Boundary
+
+Host command parsing does not grant new LoopX authority. It only converts
+visible user intent into the existing CLI lifecycle:
+
+- `/loopx` can read status and preview command packs. It stops before writes
+  that need confirmation.
+- `/loopx <goal text>` is explicit intent to start a project-local LoopX goal:
+  plan first, write ordered todos, refresh state, run `quota should-run`, and
+  execute only when the guard allows.
+- `/loopx-global-*` commands are read-only and must not approve gates, add
+  todos, spend quota, merge PRs, publish externally, or pause/resume loops.
+- Destructive git, credentials, private material reads, production actions, and
+  external publication still require explicit user/controller approval.
+
+## CLI Fallback
+
+Every host command must expose a deterministic CLI fallback:
+
+```bash
+loopx slash-commands
+loopx bootstrap-command-pack --project .
+loopx bootstrap-command-pack --project . --goal-text "<goal text>"
+loopx global-summary
+loopx --format json --registry "$HOME/.codex/loopx/registry.global.json" quota should-run --goal-id <goal-id> --agent-id <agent-id>
+```
+
+If host command parsing is unavailable, the user or a skill fallback can still
+run these commands and preserve the same LoopX state machine.
+
+## Acceptance Checks
+
+A host command registry implementation is acceptable when:
+
+1. `/loopx` and `/loopx <goal text>` route to `loopx_goal_command_v0`.
+2. `/loopx-global-summary`, `/loopx-global-gates`, `/loopx-global-todos`, and
+   `/loopx-global-risks` route to `global_manager_command_v0`.
+3. Legacy `/loop-global-*` inputs canonicalize to `/loopx-global-*`.
+4. Unknown `/loopx-*` commands fail closed with `loopx slash-commands` help.
+5. The handoff packet includes project root label, optional goal id, agent id,
+   protocol, authority, and CLI fallback, without public local absolute paths.
+6. Host parsing is treated as the preferred path, while skill-level recognition
+   remains only a compatibility fallback.

--- a/docs/reference/protocols/host-integration-surface-v0.md
+++ b/docs/reference/protocols/host-integration-surface-v0.md
@@ -13,6 +13,11 @@ invariants. It does not prove that any adapter is installed, and it does not
 grant write authority beyond the existing CLI-equivalent LoopX
 lifecycle.
 
+Codex App slash command parsing is covered by
+[`codex_app_host_command_registry_v0`](codex-app-host-command-registry-v0.md):
+the host recognizes `/loopx`, `/loopx <goal text>`, and `/loopx-global-*`
+before ordinary chat, then hands off to the same CLI-backed lifecycle.
+
 ## Roles
 
 | Surface | Job | Must Not Do |

--- a/examples/codex-app-host-command-registry-smoke.py
+++ b/examples/codex-app-host-command-registry-smoke.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Smoke-test the Codex App host command registry contract."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONTRACT_PATH = REPO_ROOT / "docs" / "reference" / "protocols" / "codex-app-host-command-registry-v0.md"
+INDEX_PATH = REPO_ROOT / "docs" / "reference" / "protocols" / "README.md"
+DOCS_INDEX_PATH = REPO_ROOT / "docs" / "README.md"
+HOST_SURFACE_PATH = REPO_ROOT / "docs" / "reference" / "protocols" / "host-integration-surface-v0.md"
+
+REQUIRED_CANONICAL_COMMANDS = {
+    "/loopx",
+    "/loopx <goal text>",
+    "/loopx-global-summary",
+    "/loopx-global-gates",
+    "/loopx-global-todos",
+    "/loopx-global-risks",
+}
+
+REQUIRED_LEGACY_ALIASES = {
+    "/loop-global-summary",
+}
+
+REJECTED_ALIASES = {
+    "/loopx-summary-all",
+}
+
+PRIVATE_PATTERNS = [
+    re.compile(r"/" + r"Users/[A-Za-z0-9._-]+/"),
+    re.compile(r"/home/[A-Za-z0-9._-]+/"),
+    re.compile(r"/" + r"private/tmp/"),
+    re.compile(r"[A-Za-z]:\\\\Users\\\\"),
+    re.compile(r"\bBearer\s+[A-Za-z0-9._-]+"),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+]
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def assert_public_safe(text: str, label: str) -> None:
+    for pattern in PRIVATE_PATTERNS:
+        if pattern.search(text):
+            raise AssertionError(f"{label} matched private pattern {pattern.pattern!r}")
+
+
+def json_blocks(markdown: str) -> list[dict]:
+    blocks: list[dict] = []
+    for match in re.finditer(r"```json\n(.*?)\n```", markdown, flags=re.S):
+        blocks.append(json.loads(match.group(1)))
+    return blocks
+
+
+def assert_contains(text: str, needle: str, label: str) -> None:
+    if needle not in text:
+        raise AssertionError(f"{label} missing {needle!r}")
+
+
+def main() -> int:
+    contract = read(CONTRACT_PATH)
+    index = read(INDEX_PATH)
+    docs_index = read(DOCS_INDEX_PATH)
+    host_surface = read(HOST_SURFACE_PATH)
+
+    for label, text in {
+        "contract": contract,
+        "protocol index": index,
+        "docs index": docs_index,
+        "host surface": host_surface,
+    }.items():
+        assert_public_safe(text, label)
+
+    assert_contains(index, "codex_app_host_command_registry_v0", "protocol index")
+    assert_contains(docs_index, "Codex App host command registry v0", "docs index")
+    assert_contains(host_surface, "codex_app_host_command_registry_v0", "host surface")
+
+    for command in REQUIRED_CANONICAL_COMMANDS:
+        assert_contains(contract, command, "canonical command set")
+    for alias in REQUIRED_LEGACY_ALIASES:
+        assert_contains(contract, alias, "legacy alias note")
+    for alias in REJECTED_ALIASES:
+        if alias in contract:
+            raise AssertionError(f"contract should not mention superseded alias {alias!r}")
+
+    for needle in [
+        "loopx bootstrap-command-pack --project .",
+        "loopx bootstrap-command-pack --project . --goal-text",
+        "loopx slash-commands",
+        "loopx_goal_command_v0",
+        "global_manager_command_v0",
+        "fail_closed_with_slash_help",
+        "skill-level recognition",
+    ]:
+        assert_contains(contract, needle, "host command registry contract")
+
+    blocks = json_blocks(contract)
+    registry = next(item for item in blocks if item.get("schema_version") == "codex_app_host_command_registry_v0")
+    assert registry["host_kind"] == "codex_app", registry
+    commands = {item["command"]: item for item in registry["commands"]}
+    assert commands["/loopx"]["mutation_policy"] == "read_first", commands
+    assert commands["/loopx <goal text>"]["mutation_policy"] == "explicit_goal_start", commands
+    assert commands["/loopx-global-summary"]["protocol"] == "global_manager_command_v0", commands
+    assert commands["/loopx-global-summary"]["legacy_aliases"] == ["/loop-global-summary"], commands
+    assert registry["unknown_command_policy"] == "fail_closed_with_slash_help", registry
+
+    handoff = next(item for item in blocks if item.get("schema_version") == "codex_app_host_command_handoff_v0")
+    assert handoff["canonical_command"] == "/loopx <goal text>", handoff
+    assert handoff["project_root_label"] == "current workspace", handoff
+    assert handoff["authority"]["project_local_write_allowed"] is True, handoff
+    assert handoff["authority"]["global_control_write_allowed"] is False, handoff
+    assert "project_root" not in handoff, handoff
+    assert "private" not in json.dumps(handoff).lower(), handoff
+
+    print("codex-app-host-command-registry-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add `codex_app_host_command_registry_v0` for host-level parsing of `/loopx`, `/loopx <goal text>`, and canonical `/loopx-global-*` commands.
- Link the contract from the protocol/docs indexes and the existing host integration surface.
- Add a focused smoke covering canonical commands, legacy alias canonicalization, handoff packet shape, CLI fallback, and public/private boundary checks.

## Validation
- `python3 examples/codex-app-host-command-registry-smoke.py`
- `python3 examples/slash-command-catalog-smoke.py`
- `python3 examples/global-manager-command-protocol-smoke.py`
- `python3 -m py_compile examples/codex-app-host-command-registry-smoke.py`
- `git diff --check`
- `git diff --cached --check`
- `loopx check --scan-path docs/reference/protocols/codex-app-host-command-registry-v0.md --scan-path docs/reference/protocols/README.md --scan-path docs/README.md --scan-path docs/reference/protocols/host-integration-surface-v0.md --scan-path examples/codex-app-host-command-registry-smoke.py` (existing duplicate-index warning only)

## Notes
- This is a contract-only PR. It does not implement host runtime parsing or change LoopX command execution.
