### PR TITLE
Add projected todo list read path

### DIFF
--- a/examples/todo-list-event-projection-smoke.py
+++ b/examples/todo-list-event-projection-smoke.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Smoke-test `loopx todo list` event projection preference and Markdown fallback."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.event_sourced_state import (  # noqa: E402
+    AppendOnlyStateEventStore,
+    TODO_ADDED,
+    TODO_COMPLETED,
+    make_state_event,
+)
+
+
+GOAL_ID = "todo-list-event-projection-fixture"
+
+
+def write_fixture(root: Path) -> tuple[Path, Path, Path]:
+    project = root / "project"
+    runtime = root / "runtime"
+    state_file = project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+    event_log = state_file.with_name("events.jsonl")
+    registry_path = project / ".loopx" / "registry.json"
+    state_file.parent.mkdir(parents=True)
+    state_file.write_text(
+        "---\n"
+        "status: active\n"
+        "updated_at: 2026-01-01T00:00:00+00:00\n"
+        "---\n\n"
+        "# Active Goal State\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] [P1] Markdown fallback todo\n"
+        "  <!-- loopx:todo todo_id=todo_markdown status=open task_class=advancement_task -->\n",
+        encoding="utf-8",
+    )
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "todo-list-fixture",
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md",
+                        "state_event_log": f".codex/goals/{GOAL_ID}/events.jsonl",
+                        "adapter": {"kind": "generic_project_goal_v0", "status": "connected"},
+                        "authority_sources": [],
+                    }
+                ],
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return registry_path, state_file, event_log
+
+
+def event(event_id: str, event_type: str, todo_id: str, payload: dict) -> dict:
+    return make_state_event(
+        event_id=event_id,
+        goal_id=GOAL_ID,
+        event_type=event_type,
+        refs={"todo_id": todo_id},
+        payload=payload,
+        recorded_at=f"2026-06-27T00:00:{len(event_id):02d}Z",
+        producer="todo-list-event-projection-smoke",
+    )
+
+
+def run_cli(registry_path: Path, *args: str) -> dict:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--registry",
+            str(registry_path),
+            "--format",
+            "json",
+            *args,
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return json.loads(result.stdout)
+
+
+def write_events(event_log: Path) -> None:
+    store = AppendOnlyStateEventStore(event_log)
+    store.append(
+        event(
+            "evt-open",
+            TODO_ADDED,
+            "todo_event_open",
+            {
+                "role": "agent",
+                "priority": "P0",
+                "title": "Projected open todo",
+                "planner_order": 1,
+                "task_class": "advancement_task",
+                "action_kind": "implement",
+            },
+        )
+    )
+    store.append(
+        event(
+            "evt-done",
+            TODO_ADDED,
+            "todo_event_done",
+            {
+                "role": "agent",
+                "priority": "P1",
+                "title": "Projected completed todo",
+                "planner_order": 2,
+                "task_class": "advancement_task",
+            },
+        )
+    )
+    store.append(
+        event(
+            "evt-complete",
+            TODO_COMPLETED,
+            "todo_event_done",
+            {"evidence": "projection smoke"},
+        )
+    )
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="loopx-todo-list-projection-") as tmp:
+        registry_path, _, event_log = write_fixture(Path(tmp))
+        write_events(event_log)
+
+        projected = run_cli(registry_path, "todo", "list", "--goal-id", GOAL_ID, "--role", "agent")
+        assert projected["ok"] is True, projected
+        assert projected["read_only"] is True, projected
+        assert projected["source"] == "event_projection", projected
+        assert projected["todo_count"] == 2, projected
+        assert [item["todo_id"] for item in projected["todos"]] == [
+            "todo_event_open",
+            "todo_event_done",
+        ], projected
+        assert "todo_markdown" not in json.dumps(projected, sort_keys=True), projected
+        assert projected["state_event_projection"]["source_event_count"] == 3, projected
+
+        done_only = run_cli(
+            registry_path,
+            "todo",
+            "list",
+            "--goal-id",
+            GOAL_ID,
+            "--role",
+            "agent",
+            "--status",
+            "done",
+        )
+        assert done_only["source"] == "event_projection", done_only
+        assert done_only["todo_count"] == 1, done_only
+        assert done_only["todos"][0]["todo_id"] == "todo_event_done", done_only
+
+        event_log.unlink()
+        fallback = run_cli(registry_path, "todo", "list", "--goal-id", GOAL_ID, "--role", "agent")
+        assert fallback["source"] == "markdown_active_state", fallback
+        assert fallback["todo_count"] == 1, fallback
+        assert fallback["todos"][0]["todo_id"] == "todo_markdown", fallback
+
+    print("todo-list-event-projection-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -15,6 +15,7 @@ from ..todos import (
     archive_completed_todos,
     add_goal_todo,
     complete_goal_todo,
+    list_goal_todos,
     render_todo_markdown,
     supersede_goal_todo,
     update_goal_todo,
@@ -38,6 +39,7 @@ def register_todo_command(subparsers: argparse._SubParsersAction) -> None:
         nargs="?",
         choices=[
             "add",
+            "list",
             "claim",
             "update",
             "complete",
@@ -49,7 +51,7 @@ def register_todo_command(subparsers: argparse._SubParsersAction) -> None:
         default="add",
         help=(
             "Use add to append a checkbox todo, claim to soft-claim by registered "
-            "agent id, update/complete/supersede to transition by todo_id, or "
+            "agent id, list to read projected todos, update/complete/supersede to transition by todo_id, or "
             "archive-completed to move older completed todos into Completed Work Archive. "
             "Use suggest to generate an agent-facing candidate todo analysis prompt without writing state. "
             "Use capture-followups to record a capped public-safe unclaimed follow-up batch."
@@ -266,7 +268,57 @@ def handle_todo_command(
                 "`todo add/update` for user gates; --from, --limit, and "
                 "--trigger are only supported by `todo suggest`"
             )
-        if args.todo_command == "add":
+        if args.todo_command == "list":
+            unsupported = [
+                flag
+                for flag, value in (
+                    ("--text", args.text),
+                    ("--follow-up", args.followups),
+                    ("--todo-id", args.todo_id),
+                    ("--note", args.note),
+                    ("--evidence", args.evidence),
+                    ("--reason", args.reason),
+                    ("--task-class", args.task_class),
+                    ("--action-kind", args.action_kind),
+                    ("--required-write-scope", args.required_write_scopes),
+                    ("--required-capability", args.required_capabilities),
+                    ("--target-capability", args.target_capabilities),
+                    ("--claimed-by", args.claimed_by),
+                    ("--blocks-agent", args.blocks_agent),
+                    ("--global-gate", args.global_gate),
+                    ("--unblocks-todo-id", args.unblocks_todo_id),
+                    ("--resume-when", args.resume_when),
+                    ("--clear-claim", args.clear_claim),
+                    ("--no-follow-up", args.no_follow_up),
+                    ("--next-agent-todo", args.next_agent_todo),
+                    ("--next-user-todo", args.next_user_todo),
+                    ("--next-claimed-by", args.next_claimed_by),
+                    ("--next-task-class", args.next_task_class),
+                    ("--next-action-kind", args.next_action_kind),
+                    ("--side-agent-self-merged", args.side_agent_self_merged),
+                    ("--agent-id", args.agent_id),
+                    ("--from", args.suggestion_sources),
+                    ("--limit", args.suggestion_limit),
+                    ("--trigger", args.suggestion_trigger),
+                    ("--execute", args.execute),
+                )
+                if value
+            ]
+            if unsupported:
+                raise ValueError(
+                    "todo list only accepts --goal-id, optional --role, --status, "
+                    "--project, --state-file, --dry-run, and --format; unsupported: "
+                    + ", ".join(unsupported)
+                )
+            payload = list_goal_todos(
+                registry_path=registry_path,
+                goal_id=args.goal_id,
+                role=args.role,
+                status=args.status,
+                project=Path(args.project).expanduser() if args.project else None,
+                state_file=Path(args.state_file).expanduser() if args.state_file else None,
+            )
+        elif args.todo_command == "add":
             if args.followups:
                 raise ValueError("todo add does not support --follow-up; use `todo capture-followups`")
             if not args.role:

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -15,7 +15,10 @@ from .history import load_registry
 from .state_refresh import now_local, resolve_goal_state
 from .status import (
     MAX_ACTIVE_DONE_TODOS_BEFORE_ARCHIVE,
+    active_state_event_projection_fields,
+    compact_todo_group,
     normalize_todo_text,
+    parse_active_state_todos,
     todo_role_for_heading,
 )
 from .todo_contract import (
@@ -257,6 +260,114 @@ def todo_blocks(
         ensure_block_identity(current, role=role, source_section=source_section)
         blocks.append(current)
     return blocks
+
+
+def todo_item_status(item: dict[str, Any]) -> str:
+    status = normalize_todo_status(item.get("status"))
+    if status:
+        return status
+    return TODO_STATUS_DONE if item.get("done") else TODO_STATUS_OPEN
+
+
+def empty_todo_summary(*, role: str) -> dict[str, Any]:
+    return {
+        "schema_version": "todo_summary_v0",
+        "role": role,
+        "source_section": TODO_SECTION_HEADINGS[role],
+        "total_count": 0,
+        "open_count": 0,
+        "done_count": 0,
+        "items": [],
+        "first_open_items": [],
+    }
+
+
+def filtered_todo_summary(
+    summary: dict[str, Any] | None,
+    *,
+    role: str,
+    status: str | None = None,
+) -> dict[str, Any]:
+    items = list((summary or {}).get("items") or [])
+    normalized_status = normalize_todo_status(status)
+    if normalized_status:
+        items = [item for item in items if todo_item_status(item) == normalized_status]
+    source_section = str((summary or {}).get("source_section") or TODO_SECTION_HEADINGS[role])
+    return compact_todo_group(items, source_section=source_section, role=role) or empty_todo_summary(role=role)
+
+
+def list_goal_todos(
+    *,
+    registry_path: Path,
+    goal_id: str,
+    role: str | None = None,
+    status: str | None = None,
+    project: Path | None = None,
+    state_file: Path | None = None,
+) -> dict[str, Any]:
+    registry = load_registry(registry_path)
+    goal, resolved_project, resolved_state_file = resolve_goal_state(
+        registry=registry,
+        goal_id=goal_id,
+        project_override=project,
+        state_file_override=state_file,
+    )
+    if goal is None:
+        raise ValueError(f"goal {goal_id!r} is not present in the registry")
+    if not resolved_state_file.exists():
+        raise ValueError(f"active state file does not exist: {resolved_state_file}")
+
+    projection_fields = active_state_event_projection_fields(
+        goal,
+        state_path=resolved_state_file,
+    )
+    projection_has_todos = bool(
+        projection_fields.get("user_todos") or projection_fields.get("agent_todos")
+    )
+    if projection_has_todos:
+        fields = projection_fields
+        source = "event_projection"
+    else:
+        fields = parse_active_state_todos(
+            resolved_state_file.read_text(encoding="utf-8"),
+            goal=goal,
+            state_path=resolved_state_file,
+        )
+        source = "markdown_active_state"
+
+    roles = [role] if role else ["user", "agent"]
+    summaries: dict[str, dict[str, Any]] = {}
+    todos: list[dict[str, Any]] = []
+    for item_role in roles:
+        key = f"{item_role}_todos"
+        summary = filtered_todo_summary(
+            fields.get(key) if isinstance(fields, dict) else None,
+            role=item_role,
+            status=status,
+        )
+        summaries[key] = summary
+        todos.extend(summary.get("items") or [])
+
+    payload: dict[str, Any] = {
+        "ok": True,
+        "dry_run": True,
+        "read_only": True,
+        "command": "list",
+        "goal_id": goal_id,
+        "role": role or "all",
+        "status_filter": normalize_todo_status(status) if status else None,
+        "source": source,
+        "todo_count": len(todos),
+        "todos": todos,
+        "state_file": str(resolved_state_file),
+        "project": str(resolved_project) if resolved_project else None,
+    }
+    payload.update(summaries)
+    if source == "event_projection" and projection_fields.get("state_event_projection"):
+        payload["state_event_projection"] = projection_fields["state_event_projection"]
+    if projection_fields.get("state_event_projection_warning"):
+        payload["state_event_projection_warning"] = projection_fields["state_event_projection_warning"]
+    return payload
 
 
 def insert_archive_blocks(lines: list[str], blocks: list[list[str]]) -> None:
@@ -1472,6 +1583,55 @@ def archive_completed_todos(
 
 
 def render_todo_markdown(payload: dict[str, Any]) -> str:
+    if payload.get("command") == "list":
+        lines = [
+            "# LoopX Todo List",
+            "",
+            f"- ok: `{payload.get('ok')}`",
+            f"- read_only: `{payload.get('read_only')}`",
+            f"- goal_id: `{payload.get('goal_id')}`",
+            f"- role: `{payload.get('role')}`",
+            f"- status_filter: `{payload.get('status_filter')}`",
+            f"- source: `{payload.get('source')}`",
+            f"- todo_count: `{payload.get('todo_count')}`",
+            f"- state_file: `{payload.get('state_file')}`",
+        ]
+        projection = payload.get("state_event_projection")
+        if isinstance(projection, dict):
+            lines.extend(
+                [
+                    f"- event_log: `{projection.get('event_log')}`",
+                    f"- source_event_count: `{projection.get('source_event_count')}`",
+                    f"- last_event_id: `{projection.get('last_event_id')}`",
+                ]
+            )
+        for key, heading in (
+            ("user_todos", "User Todo"),
+            ("agent_todos", "Agent Todo"),
+        ):
+            summary = payload.get(key)
+            if not isinstance(summary, dict):
+                continue
+            lines.extend(["", f"## {heading}", ""])
+            items = summary.get("items") or []
+            if not items:
+                lines.append("- none")
+                continue
+            for item in items:
+                if not isinstance(item, dict):
+                    continue
+                marker = todo_marker_for_status(item.get("status") or TODO_STATUS_OPEN)
+                text = item.get("text") or item.get("title") or ""
+                metadata = []
+                for metadata_key in ("todo_id", "status", "task_class", "action_kind", "claimed_by"):
+                    if item.get(metadata_key):
+                        metadata.append(f"{metadata_key}={item.get(metadata_key)}")
+                suffix = f" <!-- {' '.join(metadata)} -->" if metadata else ""
+                lines.append(f"- [{marker}] {text}{suffix}")
+        if payload.get("error"):
+            lines.append(f"- error: {payload.get('error')}")
+        return "\n".join(lines)
+
     lines = [
         "# LoopX Todo",
         "",


### PR DESCRIPTION
## Summary
- add a read-only `loopx todo list` command for projected todo reads
- prefer append-only state event projection when `events.jsonl` is available
- fall back to Markdown active state when the event log is absent or empty
- add a focused smoke covering projection preference, status filtering, and Markdown fallback

## Validation
- `python3 examples/todo-list-event-projection-smoke.py`
- `python3 examples/todo-cli-smoke.py`
- `python3 examples/event-sourced-status-read-path-smoke.py`
- `python3 -m py_compile loopx/todos.py loopx/cli_commands/todo.py examples/todo-list-event-projection-smoke.py`
- `git diff --check`
- `loopx check --scan-path loopx/todos.py --scan-path loopx/cli_commands/todo.py --scan-path examples/todo-list-event-projection-smoke.py`

## Notes
This is runtime CLI behavior, so I am not self-merging it from the side-agent lane. It should get primary review before merge.