### PR TITLE
Add Terminal-Bench host launch contract

### DIFF
--- a/examples/benchmark-agent-runtime-layer-smoke.py
+++ b/examples/benchmark-agent-runtime-layer-smoke.py
@@ -90,6 +90,40 @@ def main() -> None:
         assert host_goal["required_host_commands"] == ["codex", "tmux", "docker"]
         assert "--agent-import-path" in host_goal["recommended_tb_args"]
         assert "goal_surface=app_server" in host_goal["recommended_tb_args"]
+        baseline_tb_args = host_goal["recommended_goal_baseline_tb_args"]
+        baseline_tb_text = " ".join(baseline_tb_args)
+        assert "--dataset-path" in baseline_tb_args
+        assert "--task-id" in baseline_tb_args
+        assert "--output-path" in baseline_tb_args
+        assert "--run-id" in baseline_tb_args
+        assert "$RUN_ID" in baseline_tb_args
+        assert "--no-upload-results" in baseline_tb_args
+        assert "--no-rebuild" in baseline_tb_args
+        assert "goal_surface=app_server" in baseline_tb_args
+        assert "HostCodexGoalAgent" in baseline_tb_text
+        treatment_tb_args = host_goal["recommended_loopx_prompt_polling_tb_args"]
+        assert "loopx_mode=codex_loopx" in treatment_tb_args
+        assert "loopx_access_packet_mode=compact" in treatment_tb_args
+        assert "loopx_case_id=<case-id>" in treatment_tb_args
+        assert "loopx_arm_id=loopx_prompt_polling_test" in treatment_tb_args
+        assert "loopx_max_rounds=5" in treatment_tb_args
+        proof_gate = host_goal["official_hello_world_proof_gate"]
+        assert proof_gate["case_id"] == "hello-world"
+        assert "terminal_bench_safe_run_id.py" in proof_gate["safe_run_id_command"]
+        assert "hello-world-host-codex-goal" in proof_gate["safe_run_id_command"]
+        assert proof_gate["no_upload_required"] is True
+        assert proof_gate["runner_or_scorer_behavior_changed"] is False
+        assert "hello-world" in proof_gate["tb_args"]
+        assert "--no-upload-results" in proof_gate["tb_args"]
+        assert "--no-rebuild" in proof_gate["tb_args"]
+        assert "task_image_exists_or_bootstrap_done" in (
+            proof_gate["required_prelaunch_gates"]
+        )
+        assert "terminal_bench_official_result_reducer.py" in (
+            proof_gate["compact_result_reducer"]
+        )
+        assert "--results-json" in proof_gate["compact_result_reducer"]
+        assert "--run-metadata-json" in proof_gate["compact_result_reducer"]
         assert host_goal["goal_surface"] == "app_server"
         assert host_goal["fallback_goal_surface"] == "tui"
         assert "thread/goal/set" in host_goal["preflight_gate"]

--- a/scripts/benchmark_agent_runtime_layer.py
+++ b/scripts/benchmark_agent_runtime_layer.py
@@ -175,6 +175,37 @@ def _harbor_profile(
             "Codex inside the task container."
         )
     if benchmark_id == "terminal-bench":
+        recommended_goal_baseline_tb_args = [
+            "--dataset-path",
+            "<tasks-dir>",
+            "--task-id",
+            "<task-id>",
+            "--output-path",
+            "<run-parent>",
+            "--run-id",
+            "$RUN_ID",
+            "--no-upload-results",
+            "--no-rebuild",
+            "--agent-import-path",
+            "terminal_bench_host_codex_goal_agent:HostCodexGoalAgent",
+            "--agent-kwarg",
+            "goal_surface=app_server",
+            "--agent-kwarg",
+            "goal_timeout_sec=<seconds>",
+        ]
+        recommended_loopx_prompt_polling_tb_args = [
+            *recommended_goal_baseline_tb_args,
+            "--agent-kwarg",
+            "loopx_mode=codex_loopx",
+            "--agent-kwarg",
+            "loopx_access_packet_mode=compact",
+            "--agent-kwarg",
+            "loopx_case_id=<case-id>",
+            "--agent-kwarg",
+            "loopx_arm_id=loopx_prompt_polling_test",
+            "--agent-kwarg",
+            "loopx_max_rounds=5",
+        ]
         runner_fragments["terminal_bench_no_rebuild_guard_command"] = (
             "python3 scripts/terminal_bench_no_rebuild_guard.py "
             "--terminal-bench-root <terminal-bench-checkout> --apply --pretty"
@@ -204,6 +235,35 @@ def _harbor_profile(
                 "--agent-kwarg",
                 "goal_timeout_sec=<seconds>",
             ],
+            "recommended_goal_baseline_tb_args": recommended_goal_baseline_tb_args,
+            "recommended_loopx_prompt_polling_tb_args": (
+                recommended_loopx_prompt_polling_tb_args
+            ),
+            "official_hello_world_proof_gate": {
+                "case_id": "hello-world",
+                "safe_run_id_command": (
+                    "RUN_ID=$(python3 scripts/terminal_bench_safe_run_id.py "
+                    "--prefix hello-world-host-codex-goal | "
+                    "python3 -c 'import json,sys; "
+                    "print(json.load(sys.stdin)[\"safe_run_id\"])')"
+                ),
+                "required_prelaunch_gates": [
+                    "terminal_bench_no_rebuild_guard_applied",
+                    "task_image_exists_or_bootstrap_done",
+                    "codex_app_server_goal_schema_ready",
+                ],
+                "tb_args": [
+                    part.replace("<task-id>", "hello-world")
+                    for part in recommended_goal_baseline_tb_args
+                ],
+                "compact_result_reducer": (
+                    "python3 scripts/terminal_bench_official_result_reducer.py "
+                    "--results-json <results-json> "
+                    "--run-metadata-json <run-metadata-json> --pretty"
+                ),
+                "no_upload_required": True,
+                "runner_or_scorer_behavior_changed": False,
+            },
             "goal_surface": "app_server",
             "fallback_goal_surface": "tui",
             "preflight_gate": (


### PR DESCRIPTION
## Summary
- extend the benchmark runtime-layer plan with Terminal-Bench host Codex Goal baseline and LoopX prompt-polling `tb run` argument contracts
- add an explicit `hello-world` proof gate that ties together safe run ids, no-upload/no-rebuild, app-server Goal mode, prelaunch gates, and compact official-result reduction
- lock the new public contract with the focused runtime-layer smoke

## Validation
- `python3 examples/benchmark-agent-runtime-layer-smoke.py`
- `python3 examples/benchmark-ecs-developer-tooling-smoke.py`
- `python3 examples/terminal-bench-host-codex-goal-agent-smoke.py`
- `loopx check --scan-path scripts/benchmark_agent_runtime_layer.py --scan-path examples/benchmark-agent-runtime-layer-smoke.py`
- `git diff --check`

## Boundary
Contract-only; does not launch a benchmark job, does not change Terminal-Bench task/scorer/runner behavior, and does not include raw logs, raw task text, trajectories, verifier output, credentials, private paths, or local state.
