### PR TITLE
Compact quota scheduler reset policy

### DIFF
--- a/docs/interface-budget-contract.md
+++ b/docs/interface-budget-contract.md
@@ -10,7 +10,7 @@ and size/count budgets.
 | --- | --- | --- | --- | --- | --- | --- |
 | `heartbeat_prompt_json` | heartbeat automation | wake and route one bounded turn | `quota should-run`, `status`, or `review-packet --handoff-only` | `json_chars <= 3500` plus `interface_budget.within_budget=true` | `nested_keys <= 40` | `top_level_keys <= 30` |
 | `review_packet_handoff_only_json` | project-agent handoff | forward the smallest sufficient task packet | full `review-packet` or run-history artifact | `json_chars <= 3000` plus `handoff_interface_budget.within_budget=true` | `nested_keys <= 40` | `top_level_keys <= 18` |
-| `quota_should_run_json` | quota guard | decide whether the selected goal may spend compute | `status`, `history`, or active state | `json_chars <= 14000` | `nested_keys <= 340` | `top_level_keys <= 50` |
+| `quota_should_run_json` | quota guard | decide whether the selected goal may spend compute | `status`, `history`, or active state | `json_chars <= 12500` | `nested_keys <= 310` | `top_level_keys <= 50` |
 | `dashboard_status_json` | operator dashboard | render first-screen operator state | `history`, run artifacts, or project-local adapter output | `json_chars <= 18000` | `nested_keys <= 260` | `top_level_keys <= 20` |
 
 These budgets are intentionally about the machine payloads, not the full
@@ -67,3 +67,12 @@ Do not add a heartbeat prompt branch for this cadence. Store exact measurements
 in run history, project only this compact decision summary, and rerun the smoke
 when `overdue=true` or when a prompt/status/quota/review-packet/dashboard
 contract changes.
+
+Scheduler reset policy budget:
+
+`quota should-run.scheduler_hint.reset_policy` is a host-action summary, not a
+debug snapshot. It carries the reset token, host state key, initial Codex App
+RRULE, unchanged-state clear flag, and short identity/profile signatures needed
+to detect reset transitions. Full identity/profile snapshots stay off the hot
+path; use status, history, active state, or a focused regression fixture when
+debugging why a reset token changed.

--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -532,16 +532,15 @@ JSON or Markdown decision:
     "reset_policy": {
       "schema_version": "scheduler_reset_policy_v0",
       "reset_to": "profile_initial_interval",
+      "reset_token": "0123456789abcdef",
+      "host_state_key": "scheduler_hint.reset_policy.reset_token",
       "codex_app_initial_interval_minutes": 30,
+      "codex_app_initial_rrule": "FREQ=MINUTELY;INTERVAL=30",
       "clear_unchanged_poll_state": true,
-      "reset_conditions": [
-        "quota_identity_snapshot_changed",
-        "scheduler_action_changed",
-        "user_feedback",
-        "new_or_reassigned_todo",
-        "gate_resolved",
-        "material_transition"
-      ]
+      "identity_key_count": 6,
+      "identity_signature": "123456789abc",
+      "profile_signature": "abcdef123456",
+      "reset_condition_summary": "token_changed|user_feedback|new_or_reassigned_todo|gate_or_material_transition|active_work_projected"
     }
   },
   "operator_question": "是否同意 project-main-control 先做 read-only map dry-run？",
@@ -669,11 +668,14 @@ Agent-scope waits use a more conservative adjustment curve such as
 `[10, 20, 30, 60]`, so a 600-second local tick stays close to the existing
 agent-to-agent interaction cadence before cooling further.
 Each hint also carries `reset_policy.schema_version=scheduler_reset_policy_v0`.
-Hosts should compare `reset_policy.identity_snapshot` across unchanged polls
-and reset the unchanged streak whenever the snapshot or scheduler action
-changes. They should also reset when an external event makes the goal
-actionable again, such as user feedback in the thread, a new or reassigned todo,
-a resolved gate, or material evidence transition. A reset applies
+Hosts should cache and compare `reset_policy.reset_token` across unchanged
+polls and reset the unchanged streak whenever the token changes. The token is
+derived from scheduler action plus the current identity/profile inputs, while
+the hot path only exposes short `identity_signature` and `profile_signature`
+debug aids instead of full snapshots. Hosts should also reset when an external
+event makes the goal actionable again, such as user feedback in the thread, a
+new or reassigned todo, a resolved gate, or material evidence transition. A
+reset applies
 `codex_app_initial_interval_minutes` (and the matching local scheduler initial
 interval) before starting unchanged backoff again; it never spends quota.
 For Codex App heartbeats, hosts and agents should use
@@ -681,8 +683,9 @@ For Codex App heartbeats, hosts and agents should use
 `reset_policy.codex_app_initial_rrule` when the stored
 `reset_policy.reset_token` changes. This gives host runtimes a compact state key
 instead of requiring them to diff the whole quota payload. The token is derived
-from scheduler action, `identity_snapshot`, and `profile_snapshot`, so a changed
-initial RRULE or scheduler profile also produces a new generation. User
+from scheduler action plus identity/profile inputs, so a changed initial RRULE
+or scheduler profile also produces a new generation without projecting full
+snapshots in `quota should-run` JSON. User
 feedback, newly runnable work, reassignment, or material evidence should
 therefore restore the automation to the current profile's initial interval
 before backoff resumes.

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -1216,12 +1216,13 @@ subsequent unchanged intervals by `unchanged_poll_backoff_multiplier` until
 `max_interval_minutes`; `example_progression_minutes` exposes the compact
 human-readable sequence. The hint also includes
 `reset_policy.schema_version=scheduler_reset_policy_v0`: hosts compare its
-`identity_snapshot` between polls and clear the unchanged/backoff streak when
-that snapshot or scheduler action changes, or when a user reply,
-new/reassigned todo, resolved gate, or material transition makes the goal
-actionable again. The reset moves Codex App/local cadence back to the current
-profile's initial interval before unchanged backoff resumes, and does not spend
-quota.
+`reset_token` between polls and clear the unchanged/backoff streak when that
+token changes, or when a user reply, new/reassigned todo, resolved gate, or
+material transition makes the goal actionable again. The token is derived from
+scheduler action plus identity/profile inputs, while the hot path carries only
+short identity/profile signatures instead of full snapshots. The reset moves
+Codex App/local cadence back to the current profile's initial interval before
+unchanged backoff resumes, and does not spend quota.
 Codex App heartbeats should apply `codex_app.recommended_rrule` for ordinary
 cadence updates. They should cache only
 `reset_policy.reset_token` plus the automation id when possible; when that token
@@ -1229,8 +1230,8 @@ changes, or when user feedback/new work/reassignment/material evidence makes the
 goal active again, update the heartbeat RRULE to
 `reset_policy.codex_app_initial_rrule` and clear unchanged-poll state before
 starting a new backoff progression. The token is generated from scheduler
-action, `identity_snapshot`, and `profile_snapshot`, so hosts do not need to
-diff the whole payload to notice an initial-RRULE/profile generation change.
+action plus identity/profile inputs, so hosts do not need to diff the whole
+payload to notice an initial-RRULE/profile generation change.
 The payload also includes `execution_obligation`, which is the compatibility
 entry point for older workers deciding whether a quiet no-op is allowed.
 `heartbeat_recommendation.notify` is only a user-facing notification policy. It

--- a/examples/heartbeat-quota-flow-smoke.py
+++ b/examples/heartbeat-quota-flow-smoke.py
@@ -659,10 +659,15 @@ def main() -> int:
         assert reset["host_state_key"] == "scheduler_hint.reset_policy.reset_token", reset
         assert reset["codex_app_initial_interval_minutes"] == 15, reset
         assert reset["codex_app_initial_rrule"] == "FREQ=MINUTELY;INTERVAL=15", reset
-        assert reset["identity_keys"] == first_guard["scheduler_hint"]["unchanged_identity_keys"], reset
-        assert "reset_token_changed" in reset["reset_conditions"], reset
-        assert "material_transition" in reset["reset_conditions"], reset
-        assert "active_work_projected" in reset["reset_conditions"], reset
+        assert reset["identity_key_count"] == len(first_guard["scheduler_hint"]["unchanged_identity_keys"]), reset
+        assert len(reset["identity_signature"]) == 12, reset
+        assert len(reset["profile_signature"]) == 12, reset
+        assert "identity_snapshot" not in reset, reset
+        assert "profile_snapshot" not in reset, reset
+        assert "identity_keys" not in reset, reset
+        assert "token_changed" in reset["reset_condition_summary"], reset
+        assert "material_transition" in reset["reset_condition_summary"], reset
+        assert "active_work_projected" in reset["reset_condition_summary"], reset
         assert reset["clear_unchanged_poll_state"] is True, reset
         first_reset_token = reset["reset_token"]
         assert "automation=keep_active_quiet" in first_guard["protocol_action_packet"]["summary"], first_guard
@@ -783,7 +788,7 @@ def main() -> int:
         replan_reset = replan_guard["scheduler_hint"]["reset_policy"]
         assert replan_reset["codex_app_initial_rrule"] == "FREQ=MINUTELY;INTERVAL=3", replan_reset
         assert replan_reset["reset_token"] != first_reset_token, replan_reset
-        assert "active_work_projected" in replan_reset["reset_conditions"], replan_reset
+        assert "active_work_projected" in replan_reset["reset_condition_summary"], replan_reset
         assert "automation=execute_bounded_work" in replan_guard["protocol_action_packet"]["summary"], replan_guard
         interaction = replan_guard["interaction_contract"]
         assert interaction["mode"] == "autonomous_replan", interaction

--- a/examples/hot-path-interface-budget-smoke.py
+++ b/examples/hot-path-interface-budget-smoke.py
@@ -52,8 +52,8 @@ SURFACE_BUDGETS = {
         "owner": "quota guard",
         "consumer": "decide whether the selected goal may spend compute",
         "cold_path": "status, history, or active state",
-        "max_json_chars": 14_000,
-        "max_nested_keys": 340,
+        "max_json_chars": 12_500,
+        "max_nested_keys": 310,
         "max_top_level_keys": 50,
     },
     "dashboard_status_json": {
@@ -285,6 +285,16 @@ def main() -> int:
         heartbeat_payload = build_heartbeat_prompt(goal_id=GOAL_ID, thin=True)
 
         assert quota_payload["should_run"] is True, quota_payload
+        reset_policy = quota_payload["scheduler_hint"]["reset_policy"]
+        assert reset_policy["reset_token"], reset_policy
+        assert reset_policy["codex_app_initial_rrule"], reset_policy
+        assert reset_policy["host_state_key"] == "scheduler_hint.reset_policy.reset_token", reset_policy
+        assert "identity_snapshot" not in reset_policy, reset_policy
+        assert "profile_snapshot" not in reset_policy, reset_policy
+        assert "identity_keys" not in reset_policy, reset_policy
+        assert "profile" not in reset_policy, reset_policy
+        assert len(reset_policy["identity_signature"]) == 12, reset_policy
+        assert len(reset_policy["profile_signature"]) == 12, reset_policy
         assert handoff_payload["within_budget"] is True, handoff_payload
         summaries = [
             assert_surface("heartbeat_prompt_json", heartbeat_payload),

--- a/examples/quota-agent-scoped-user-gate-smoke.py
+++ b/examples/quota-agent-scoped-user-gate-smoke.py
@@ -516,12 +516,16 @@ def assert_agent_without_advancement_candidate_enters_scope_wait() -> None:
     assert reset["host_state_key"] == "scheduler_hint.reset_policy.reset_token", reset
     assert reset["codex_app_initial_interval_minutes"] == 10, reset
     assert reset["codex_app_initial_rrule"] == "FREQ=MINUTELY;INTERVAL=10", reset
-    assert reset["profile_snapshot"]["codex_app_max_interval_minutes"] == 60, reset
-    assert reset["identity_keys"] == scheduler["unchanged_identity_keys"], reset
-    assert reset["identity_snapshot"]["agent_identity.agent_id"] == payload["agent_identity"]["agent_id"], reset
-    assert "reset_token_changed" in reset["reset_conditions"], reset
-    assert "new_or_reassigned_todo" in reset["reset_conditions"], reset
-    assert "active_work_projected" in reset["reset_conditions"], reset
+    assert scheduler["codex_app"]["max_interval_minutes"] == 60, scheduler
+    assert reset["identity_key_count"] == len(scheduler["unchanged_identity_keys"]), reset
+    assert len(reset["identity_signature"]) == 12, reset
+    assert len(reset["profile_signature"]) == 12, reset
+    assert "identity_snapshot" not in reset, reset
+    assert "profile_snapshot" not in reset, reset
+    assert "identity_keys" not in reset, reset
+    assert "token_changed" in reset["reset_condition_summary"], reset
+    assert "new_or_reassigned_todo" in reset["reset_condition_summary"], reset
+    assert "active_work_projected" in reset["reset_condition_summary"], reset
     assert reset["no_spend_for_reset"] is True, reset
     assert "scheduler=backoff_until_reassigned" in payload["protocol_action_packet"]["summary"], payload
 

--- a/examples/quota-plan-smoke.py
+++ b/examples/quota-plan-smoke.py
@@ -38,21 +38,53 @@ from loopx.quota import (  # noqa: E402
 SCOPED_AGENT_ID = "codex-side-bypass"
 
 
-def expected_scheduler_reset_token(scheduler: dict) -> str:
-    reset = scheduler["reset_policy"]
-    token_payload = {
-        "action": scheduler["action"],
-        "identity_snapshot": reset["identity_snapshot"],
-        "profile_snapshot": reset["profile_snapshot"],
+def _nested_value(payload: dict, path: str):
+    current = payload
+    for part in path.split("."):
+        if not isinstance(current, dict):
+            return None
+        current = current.get(part)
+    return current
+
+
+def scheduler_reset_profile_snapshot(scheduler: dict) -> dict:
+    codex_app = scheduler["codex_app"]
+    local_scheduler = scheduler["local_scheduler"]
+    claude_code_loop = scheduler["claude_code_loop"]
+    return {
+        "cadence_class": scheduler["cadence_class"],
+        "codex_app_initial_interval_minutes": codex_app["recommended_interval_minutes"],
+        "codex_app_initial_rrule": codex_app["recommended_rrule"],
+        "codex_app_max_interval_minutes": codex_app["max_interval_minutes"],
+        "unchanged_poll_backoff_multiplier": codex_app["unchanged_poll_backoff_multiplier"],
+        "local_scheduler_unchanged_poll_limit": local_scheduler["unchanged_poll_limit"],
+        "claude_code_loop_unchanged_poll_limit": claude_code_loop["unchanged_poll_limit"],
     }
+
+
+def _short_hash(value: dict, length: int) -> str:
     return hashlib.sha256(
         json.dumps(
-            token_payload,
+            value,
             ensure_ascii=True,
             sort_keys=True,
             default=str,
         ).encode("utf-8")
-    ).hexdigest()[:16]
+    ).hexdigest()[:length]
+
+
+def expected_scheduler_reset_token(scheduler: dict, payload: dict) -> str:
+    identity_snapshot = {
+        key: _nested_value(payload, key)
+        for key in scheduler["unchanged_identity_keys"]
+    }
+    profile_snapshot = scheduler_reset_profile_snapshot(scheduler)
+    token_payload = {
+        "action": scheduler["action"],
+        "identity_snapshot": identity_snapshot,
+        "profile_snapshot": profile_snapshot,
+    }
+    return _short_hash(token_payload, 16)
 
 
 def goal(
@@ -1578,20 +1610,33 @@ def assert_heartbeat_recommendation_lifecycle() -> None:
     assert reset["schema_version"] == "scheduler_reset_policy_v0", reset
     assert reset["reset_to"] == "profile_initial_interval", reset
     assert isinstance(reset["reset_token"], str) and len(reset["reset_token"]) == 16, reset
-    assert reset["reset_token"] == expected_scheduler_reset_token(scheduler), reset
+    assert reset["reset_token"] == expected_scheduler_reset_token(scheduler, mapped_decision), reset
     assert reset["host_state_key"] == "scheduler_hint.reset_policy.reset_token", reset
     assert reset["codex_app_initial_interval_minutes"] == 60, reset
     assert reset["codex_app_initial_rrule"] == "FREQ=MINUTELY;INTERVAL=60", reset
-    assert reset["profile_snapshot"]["cadence_class"] == "unchanged_noop", reset
-    assert reset["profile_snapshot"]["codex_app_initial_rrule"] == "FREQ=MINUTELY;INTERVAL=60", reset
-    assert reset["profile_snapshot"]["codex_app_max_interval_minutes"] == 240, reset
-    assert reset["profile_snapshot"]["unchanged_poll_backoff_multiplier"] == 2, reset
-    assert reset["identity_keys"] == scheduler["unchanged_identity_keys"], reset
-    assert reset["identity_snapshot"]["recommended_action"] == mapped_decision["recommended_action"], reset
-    assert "reset_token_changed" in reset["reset_conditions"], reset
-    assert "user_feedback" in reset["reset_conditions"], reset
-    assert "new_or_reassigned_todo" in reset["reset_conditions"], reset
-    assert "active_work_projected" in reset["reset_conditions"], reset
+    assert reset["identity_key_count"] == len(scheduler["unchanged_identity_keys"]), reset
+    assert len(reset["identity_signature"]) == 12, reset
+    assert len(reset["profile_signature"]) == 12, reset
+    assert "identity_snapshot" not in reset, reset
+    assert "profile_snapshot" not in reset, reset
+    assert "identity_keys" not in reset, reset
+    assert "profile" not in reset, reset
+    profile_snapshot = scheduler_reset_profile_snapshot(scheduler)
+    assert profile_snapshot["cadence_class"] == "unchanged_noop", profile_snapshot
+    assert profile_snapshot["codex_app_initial_rrule"] == "FREQ=MINUTELY;INTERVAL=60", profile_snapshot
+    assert profile_snapshot["codex_app_max_interval_minutes"] == 240, profile_snapshot
+    assert profile_snapshot["unchanged_poll_backoff_multiplier"] == 2, profile_snapshot
+    assert reset["profile_signature"] == _short_hash(profile_snapshot, 12), reset
+    identity_snapshot = {
+        key: _nested_value(mapped_decision, key)
+        for key in scheduler["unchanged_identity_keys"]
+    }
+    assert identity_snapshot["recommended_action"] == mapped_decision["recommended_action"], identity_snapshot
+    assert reset["identity_signature"] == _short_hash(identity_snapshot, 12), reset
+    assert "token_changed" in reset["reset_condition_summary"], reset
+    assert "user_feedback" in reset["reset_condition_summary"], reset
+    assert "new_or_reassigned_todo" in reset["reset_condition_summary"], reset
+    assert "active_work_projected" in reset["reset_condition_summary"], reset
     assert "do not run another dry-run" in mapped_rec["spend_policy"], mapped_rec
     assert "heartbeat_recommendation: mode=mapped_noop_if_unchanged notify=DONT_NOTIFY" in mapped_markdown
     assert "heartbeat_stop_if_unchanged: `True`" in mapped_markdown, mapped_markdown

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -4395,6 +4395,22 @@ def _scheduler_hint(payload: dict[str, Any]) -> dict[str, Any]:
                 default=str,
             ).encode("utf-8")
         ).hexdigest()[:16]
+        identity_signature = hashlib.sha256(
+            json.dumps(
+                identity_snapshot,
+                ensure_ascii=True,
+                sort_keys=True,
+                default=str,
+            ).encode("utf-8")
+        ).hexdigest()[:12]
+        profile_signature = hashlib.sha256(
+            json.dumps(
+                profile_snapshot,
+                ensure_ascii=True,
+                sort_keys=True,
+                default=str,
+            ).encode("utf-8")
+        ).hexdigest()[:12]
         reset_policy = {
             "schema_version": SCHEDULER_RESET_POLICY_SCHEMA_VERSION,
             "source": "quota.should-run",
@@ -4406,21 +4422,12 @@ def _scheduler_hint(payload: dict[str, Any]) -> dict[str, Any]:
             "codex_app_initial_rrule": codex_rrule,
             "local_scheduler_initial_interval_minutes": codex_interval,
             "clear_unchanged_poll_state": True,
-            "identity_keys": identity_keys,
-            "identity_snapshot": identity_snapshot,
-            "profile_snapshot": profile_snapshot,
-            "reset_conditions": [
-                "reset_token_changed",
-                "quota_identity_snapshot_changed",
-                "scheduler_action_changed",
-                "user_feedback",
-                "new_or_reassigned_todo",
-                "gate_resolved",
-                "material_transition",
-                "active_work_projected",
-            ],
-            "after_reset": "apply the current profile initial interval before starting unchanged backoff again",
-            "codex_app_apply": "if a stored reset_token differs, update the heartbeat RRULE to codex_app_initial_rrule and clear unchanged poll state before applying new backoff",
+            "identity_key_count": len(identity_keys),
+            "identity_signature": identity_signature,
+            "profile_signature": profile_signature,
+            "reset_condition_summary": "token_changed|user_feedback|new_or_reassigned_todo|gate_or_material_transition|active_work_projected",
+            "after_reset": "apply_initial_interval_before_backoff",
+            "codex_app_apply": "update_rrule_to_initial_and_clear_unchanged_state_on_token_change",
             "no_spend_for_reset": True,
         }
         return {
@@ -8868,8 +8875,10 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
                 f"initial_interval={reset_policy.get('codex_app_initial_interval_minutes')} "
                 f"initial_rrule={reset_policy.get('codex_app_initial_rrule')} "
                 f"reset_generation={reset_policy.get('reset_token')} "
-                f"identity_keys={reset_policy.get('identity_keys')} "
-                f"conditions={reset_policy.get('reset_conditions')}"
+                f"identity_key_count={reset_policy.get('identity_key_count')} "
+                f"identity_signature={reset_policy.get('identity_signature')} "
+                f"profile_signature={reset_policy.get('profile_signature')} "
+                f"conditions={reset_policy.get('reset_condition_summary')}"
             )
     protocol_action_packet = (
         payload.get("protocol_action_packet")


### PR DESCRIPTION
## Summary
- compact quota scheduler reset_policy by removing full identity/profile snapshots from the should-run hot path
- keep host reset semantics via reset_token, initial RRULE, host state key, clear-unchanged flag, and identity/profile signatures
- tighten quota_should_run_json interface budget from 14KB/340 nested keys to 12.5KB/310 nested keys and update protocol docs/smokes

## Validation
- python3 examples/hot-path-interface-budget-smoke.py
- python3 examples/status-quota-perf-budget-smoke.py
- python3 examples/quota-plan-smoke.py
- python3 examples/heartbeat-quota-flow-smoke.py
- python3 examples/quota-agent-scoped-user-gate-smoke.py
- python3 examples/codex-cli-local-scheduler-tick-smoke.py
- python3 examples/heartbeat-prompt-smoke.py
- python3 -m compileall -q loopx/quota.py
- loopx check --scan-path loopx/quota.py --scan-path docs/interface-budget-contract.md --scan-path docs/quota-allocation.md --scan-path docs/status-data-contract.md --scan-path examples/hot-path-interface-budget-smoke.py --scan-path examples/quota-plan-smoke.py --scan-path examples/heartbeat-quota-flow-smoke.py --scan-path examples/quota-agent-scoped-user-gate-smoke.py

Note: loopx check reports the existing loopx-meta duplicate-index warning only; public boundary scan is clean for the 8 touched files.