### PR TITLE
Add host integration plugin plan

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -72,6 +72,7 @@ incident report, or launch draft.
 - [Session runtime to LoopX projection v0](reference/protocols/session-runtime-loopx-projection-v0.md)
 - [Interface budget contract](interface-budget-contract.md)
 - [Host integration surface v0](reference/protocols/host-integration-surface-v0.md)
+- [Host integration plugin plan v0](reference/protocols/host-integration-plugin-plan-v0.md)
 - [Codex App host command registry v0](reference/protocols/codex-app-host-command-registry-v0.md)
 - [Local agent launch plan v0](reference/protocols/local-agent-launch-plan-v0.md)
 - [Runtime connector catalog](runtime-connector-catalog.md)

--- a/docs/reference/protocols/README.md
+++ b/docs/reference/protocols/README.md
@@ -8,6 +8,7 @@ Current contracts:
 - [Action packet decision v0](protocol-action-packet-decision-v0.md)
 - [Decision Scope v0](decision-scope-v0.md)
 - [Host integration surface v0](host-integration-surface-v0.md)
+- [host_integration_plugin_plan_v0](host-integration-plugin-plan-v0.md)
 - [codex_app_host_command_registry_v0](codex-app-host-command-registry-v0.md)
 - [Session runtime to LoopX projection v0](session-runtime-loopx-projection-v0.md)
 - [Session runtime controlled writeback v0](session-runtime-controlled-writeback-v0.md)

--- a/docs/reference/protocols/host-integration-plugin-plan-v0.md
+++ b/docs/reference/protocols/host-integration-plugin-plan-v0.md
@@ -1,0 +1,168 @@
+# Host Integration Plugin Plan v0
+
+`host_integration_plugin_plan_v0` describes the product path from today's
+skill-level LoopX slash-command fallback to a host-owned command registry
+plugin. It is a planning contract, not a shipped plugin manifest.
+
+The goal is to let a host such as Codex App recognize `/loopx` commands,
+install or refresh the thin heartbeat body, apply `scheduler_hint`, and protect
+private runtime data while keeping LoopX CLI as the source of truth.
+
+This plan composes existing contracts:
+
+- [`codex_app_host_command_registry_v0`](codex-app-host-command-registry-v0.md)
+  for `/loopx`, `/loopx <goal text>`, and `/loopx-global-*` parsing.
+- [`host_integration_surface_v0`](host-integration-surface-v0.md) for lifecycle
+  reads, controlled writes, CLI fallback, and public/private boundaries.
+- [`session_runtime_loopx_projection_v0`](session-runtime-loopx-projection-v0.md)
+  for compact runtime projections without raw transcripts.
+
+## Non Goals
+
+- Do not replace the CLI or make a host-specific state machine authoritative.
+- Do not store raw transcripts, raw tool output, credentials, billing data,
+  local absolute paths, or private project material in LoopX public state.
+- Do not treat a chat slash command as approval for destructive git,
+  production actions, private-material reads, external publication, or reward
+  writes.
+- Do not make hidden headless execution the default for visible TUI workflows.
+
+## Plugin Capability Set
+
+The eventual host plugin should be small and explicit:
+
+| Capability | Host Responsibility | LoopX Source Of Truth |
+| --- | --- | --- |
+| Command registry | Parse `/loopx`, `/loopx <goal text>`, `/loopx-global-*`, and legacy aliases before ordinary chat. | `loopx slash-commands`, `bootstrap-command-pack`, global manager commands. |
+| Project identity | Resolve the workspace root, public-safe root label, goal id, and registered agent id. | Registry goal entry and `quota should-run` agent identity checks. |
+| Lifecycle reads | Surface status, quota, review packet, and command-pack output as compact host packets. | CLI JSON from `status`, `quota should-run`, `review-packet`, and `bootstrap-command-pack`. |
+| Controlled writes | Offer only CLI-equivalent todo/gate/reward/refresh/spend operations, with dry-run when required. | LoopX CLI commands and active-state/event ledger writes. |
+| Automation install | Create or refresh the host heartbeat using `heartbeat-prompt --thin` and scoped agent identity. | Generated heartbeat prompt and registry coordination fields. |
+| Scheduler adapter | Apply `scheduler_hint.codex_app.recommended_rrule` and reset cadence when `reset_policy.reset_token` changes. | `quota should-run.scheduler_hint`. |
+| Privacy guard | Redact local paths and reject raw transcript/session-file/credential payloads. | Public/private boundary plus host projection boundary checks. |
+
+## Phased Path
+
+### Phase 0: Skill Fallback
+
+Agents recognize `/loopx` and `/loopx <goal text>` through the `loopx-project`
+skill and call `loopx bootstrap-command-pack`. This is good enough for early
+testing, but it is prompt-level behavior and can be polluted by conversation
+history.
+
+Exit criteria:
+
+- `/loopx` stays read/status-first.
+- `/loopx <goal text>` produces an ordered plan before writing todos.
+- The fallback always shows the CLI command that a host plugin should call.
+
+### Phase 1: Host Command Alias
+
+The host parses the slash command and passes a structured handoff packet to the
+agent or directly to the CLI. The packet contains command kind, goal text,
+public-safe project label, optional goal id, registered agent id, authority
+flags, and CLI fallback. It does not include local absolute paths in public
+output.
+
+Exit criteria:
+
+- `/loopx-global-summary`, `/loopx-global-gates`, `/loopx-global-todos`, and
+  `/loopx-global-risks` are read-only global manager commands.
+- Unknown `/loopx-*` commands fail closed with `loopx slash-commands` help.
+- The host still falls back to the CLI when parsing or command execution is
+  unavailable.
+
+### Phase 2: Heartbeat Installer
+
+After a project is connected, the host can offer to install or refresh the
+recurring LoopX heartbeat. It should generate the thin scoped task body:
+
+```bash
+loopx heartbeat-prompt --thin --goal-id <goal-id> \
+  --agent-id <registered-agent-id> \
+  --agent-scope "<public-safe agent scope>"
+```
+
+The plugin should not hand-copy project-specific policy into the automation.
+It should store only host-owned scheduling metadata, such as the current
+`reset_token`, last applied RRULE, and unchanged-poll state.
+
+Exit criteria:
+
+- Missing agent identity fails closed when the goal has registered agents.
+- Updating a heartbeat body does not spend quota.
+- The host can show the generated body or a compact install packet before
+  writing automation settings.
+
+### Phase 3: Scheduler Hint Adapter
+
+The host applies `quota should-run.scheduler_hint` after each heartbeat result:
+
+- `run_now` restores or keeps active cadence.
+- wait/backoff states update the RRULE toward the recommended interval.
+- `reset_policy.reset_token` changes clear unchanged-poll state and restore the
+  initial RRULE before starting a new backoff progression.
+- Codex CLI TUI and Claude Code loops run the final quota/replan check before
+  self-stop.
+
+Cadence-only updates, reset-to-initial changes, final checks, and self-stop
+decisions do not spend quota. Delivery turns spend only after validation and
+durable writeback.
+
+### Phase 4: Controlled Write Tools
+
+The plugin may expose controlled writes only after the CLI-equivalent command
+and preview path are documented. Todo lifecycle and state refresh can be
+available earlier; gate decisions, human reward, lease writes, production
+actions, and browser/frontstage-triggered writes require stricter preview and
+approval semantics.
+
+Exit criteria:
+
+- Each write advertises its CLI fallback.
+- Missing authority returns a structured blocker.
+- Host approval does not impersonate user reward or controller approval.
+
+## Acceptance Matrix
+
+| Scenario | Required Result |
+| --- | --- |
+| `/loopx` in a connected project | Host returns a read/status-first command pack and does not write state. |
+| `/loopx fix issue triage` | Host preserves goal text, runs bootstrap command pack, writes ordered todos only through explicit goal-start flow. |
+| `/loopx-global-summary` | Host returns a read-only global digest and cannot mutate project state. |
+| Unknown `/loopx-debug-me` | Host fails closed with `loopx slash-commands` help. |
+| Missing registered agent id | Heartbeat install/refresh fails closed for coordinated goals. |
+| Scheduler reset token changed | Host restores initial RRULE and clears unchanged-poll state without spending quota. |
+| Raw transcript offered to plugin | Plugin rejects or redacts the payload and records no raw transcript in public state. |
+| CLI unavailable | Plugin reports install/doctor blocker instead of inventing a host-only state transition. |
+
+## Minimal Public Fixture Shape
+
+```json
+{
+  "schema_version": "host_integration_plugin_plan_v0",
+  "host_kind": "codex_app",
+  "command_registry": "codex_app_host_command_registry_v0",
+  "automation": {
+    "heartbeat_prompt_mode": "thin",
+    "requires_agent_identity": true,
+    "scheduler_hint_source": "quota_should_run"
+  },
+  "privacy": {
+    "raw_transcripts_accepted": false,
+    "credentials_accepted": false,
+    "public_local_paths_allowed": false
+  },
+  "fallbacks": ["loopx slash-commands", "loopx doctor", "loopx bootstrap-command-pack"]
+}
+```
+
+## Open Implementation Questions
+
+- Which host API owns command registry installation and command palette labels?
+- Should automation install be an explicit host action, a LoopX CLI helper, or
+  both?
+- How should the host expose `scheduler_hint` state so the user can understand
+  backoff and reset without reading JSON?
+- What is the smallest tool surface for controlled writes that remains useful
+  without creating a second LoopX runtime?

--- a/examples/host-integration-plugin-plan-smoke.py
+++ b/examples/host-integration-plugin-plan-smoke.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Smoke-test the host integration plugin plan contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PLAN = REPO_ROOT / "docs" / "reference" / "protocols" / "host-integration-plugin-plan-v0.md"
+PROTOCOL_INDEX = REPO_ROOT / "docs" / "reference" / "protocols" / "README.md"
+DOCS_INDEX = REPO_ROOT / "docs" / "README.md"
+
+
+def require(text: str, snippets: list[str], *, source: Path) -> None:
+    compact = " ".join(text.split())
+    missing = [
+        snippet
+        for snippet in snippets
+        if snippet not in text and " ".join(snippet.split()) not in compact
+    ]
+    assert not missing, f"{source}: missing {missing}"
+
+
+def main() -> int:
+    plan = PLAN.read_text(encoding="utf-8")
+    protocol_index = PROTOCOL_INDEX.read_text(encoding="utf-8")
+    docs_index = DOCS_INDEX.read_text(encoding="utf-8")
+
+    require(
+        plan,
+        [
+            "host_integration_plugin_plan_v0",
+            "skill-level LoopX slash-command fallback",
+            "host-owned command registry",
+            "not a shipped plugin manifest",
+            "LoopX CLI as the source of truth",
+            "codex_app_host_command_registry_v0",
+            "host_integration_surface_v0",
+            "session_runtime_loopx_projection_v0",
+            "## Plugin Capability Set",
+            "## Phased Path",
+            "### Phase 0: Skill Fallback",
+            "### Phase 1: Host Command Alias",
+            "### Phase 2: Heartbeat Installer",
+            "### Phase 3: Scheduler Hint Adapter",
+            "### Phase 4: Controlled Write Tools",
+            "## Acceptance Matrix",
+            "loopx heartbeat-prompt --thin --goal-id <goal-id>",
+            "scheduler_hint.codex_app.recommended_rrule",
+            "reset_policy.reset_token",
+            "does not spend quota",
+            "Raw transcript offered to plugin",
+            "Plugin rejects or redacts the payload",
+            "CLI unavailable",
+            "install/doctor blocker",
+            "raw_transcripts_accepted",
+            "credentials_accepted",
+            "public_local_paths_allowed",
+        ],
+        source=PLAN,
+    )
+    require(
+        plan,
+        [
+            "Do not replace the CLI",
+            "Do not store raw transcripts",
+            "Do not treat a chat slash command as approval",
+            "Do not make hidden headless execution the default",
+            "Unknown `/loopx-debug-me`",
+            "fails closed with `loopx slash-commands` help",
+        ],
+        source=PLAN,
+    )
+    assert plan.index("### Phase 0: Skill Fallback") < plan.index("### Phase 1: Host Command Alias")
+    assert plan.index("### Phase 1: Host Command Alias") < plan.index("### Phase 2: Heartbeat Installer")
+    assert plan.index("### Phase 2: Heartbeat Installer") < plan.index("### Phase 3: Scheduler Hint Adapter")
+    assert plan.index("### Phase 3: Scheduler Hint Adapter") < plan.index("### Phase 4: Controlled Write Tools")
+    assert "raw transcript material" not in plan.lower()
+
+    require(
+        protocol_index,
+        ["host_integration_plugin_plan_v0", "host-integration-plugin-plan-v0.md"],
+        source=PROTOCOL_INDEX,
+    )
+    require(
+        docs_index,
+        ["Host integration plugin plan v0", "reference/protocols/host-integration-plugin-plan-v0.md"],
+        source=DOCS_INDEX,
+    )
+    print("host-integration-plugin-plan-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a public protocol plan for the host integration plugin path from skill fallback to host command registry, heartbeat installer, scheduler_hint adapter, and controlled write tools
- link the plan from the docs and protocol indexes
- add a focused smoke covering phase order, privacy boundaries, scheduler reset semantics, CLI fallback, and index links

## Validation
- python3 examples/host-integration-plugin-plan-smoke.py
- python3 examples/host-integration-surface-smoke.py
- python3 examples/codex-app-host-command-registry-smoke.py
- python3 -m py_compile examples/host-integration-plugin-plan-smoke.py
- git diff --check
- loopx check --scan-path docs/reference/protocols/host-integration-plugin-plan-v0.md --scan-path examples/host-integration-plugin-plan-smoke.py --scan-path docs/reference/protocols/README.md --scan-path docs/README.md

## Self-merge assessment
Docs + focused smoke only; no runtime/API behavior, benchmark runner, permission, production, raw evidence, private state, credentials, local paths, or generated logs.