### PR TITLE
Add cold-path todo detail contract

### DIFF
--- a/docs/reference/protocols/README.md
+++ b/docs/reference/protocols/README.md
@@ -15,6 +15,7 @@ Current contracts:
 - [Codex CLI wrapper action packet v0](protocol-action-packet-codex-cli-wrapper-v0.md)
 - [Action packet router comparison v0](protocol-action-packet-router-comparison-v0.md)
 - [task_graph_projection_v0](task-graph-projection-v0.md)
+- [todo_detail_cold_path_v0](todo-detail-cold-path-v0.md)
 - [long_horizon_agent_state_protocol_v0](long-horizon-agent-state-protocol-v0.md)
 - [global_manager_command_v0](global-manager-command-v0.md)
 - [event_sourced_state_contract_v0](event-sourced-state-contract-v0.md)

--- a/docs/reference/protocols/todo-detail-cold-path-v0.md
+++ b/docs/reference/protocols/todo-detail-cold-path-v0.md
@@ -1,0 +1,118 @@
+# todo_detail_cold_path_v0
+
+`todo_detail_cold_path_v0` is the cold-path detail contract for LoopX todos.
+It lets dashboards, review tools, and agents inspect a complete todo without
+expanding `status`, `quota should-run`, heartbeat prompts, or handoff packets
+past their hot-path budgets.
+
+The hot path remains `todo_summary_v0` plus bounded lanes such as
+`first_open_items`, `executable_backlog_items`, and claim-aware lanes. Those
+lanes answer the dispatch question: "which todo should the current actor look
+at now?" They are not an archival todo store.
+
+## Hot-Path Reference
+
+Hot-path producers may attach only a compact reference when a consumer needs a
+drill-down target:
+
+```json
+{
+  "schema_version": "todo_detail_ref_v0",
+  "goal_id": "loopx-meta",
+  "role": "agent",
+  "todo_id": "todo_1234abcd",
+  "projection": "todo_detail_cold_path_v0",
+  "page_size_hint": 20
+}
+```
+
+The reference is optional. It must not copy notes, evidence bodies, raw logs,
+private paths, verifier output, or full sibling todo lists. A missing reference
+means the consumer can still route from the compact summary.
+
+## Cold-Path Shape
+
+A paged detail response should use this shape:
+
+```json
+{
+  "schema_version": "todo_detail_cold_path_v0",
+  "goal_id": "loopx-meta",
+  "role": "agent",
+  "todo_id": "todo_1234abcd",
+  "generated_at": "2026-06-27T00:00:00Z",
+  "source": {
+    "kind": "active_state_todo",
+    "state_updated_at": "2026-06-27T00:00:00Z"
+  },
+  "todo": {
+    "schema_version": "todo_item_v0",
+    "todo_id": "todo_1234abcd",
+    "role": "agent",
+    "status": "open",
+    "priority": "P1",
+    "title": "Design cold-path todo detail.",
+    "task_class": "advancement_task",
+    "action_kind": "todo_projection_pagination",
+    "claimed_by": "codex-main-control"
+  },
+  "pages": {
+    "current": {
+      "kind": "todo_detail",
+      "items": []
+    },
+    "next_page_token": null
+  },
+  "related": {
+    "sibling_open_count": 12,
+    "blocked_by_user_todo_ids": [],
+    "unblocks_todo_ids": [],
+    "successor_todo_ids": []
+  },
+  "truth_contract": {
+    "source_of_truth": "active_goal_state_and_event_ledger",
+    "projection_is_writable": false,
+    "write_api": false,
+    "refresh_rule": "Requery after any todo, gate, reward, refresh-state, or quota lifecycle event."
+  }
+}
+```
+
+## Paging Rules
+
+- `todo` carries the canonical parsed todo item, not a markdown excerpt.
+- `pages.current.items` may include compact public-safe detail records such as
+  notes, evidence summaries, closeout summaries, and related lifecycle event
+  references.
+- Large note/evidence bodies must be summarized. Raw task text, transcripts,
+  local file paths, credentials, private links, raw verifier output, and raw
+  benchmark trajectories are not valid page items.
+- `next_page_token` is opaque. Consumers must not parse it or infer ordering
+  from it.
+- Producers should make the first page sufficient for human inspection of one
+  todo. Cross-todo list browsing belongs in filtered list endpoints or a
+  dashboard view, not in one todo detail response.
+
+## Ordering And Freshness
+
+The detail response is a projection. It should preserve the active-state todo
+ordering metadata (`index`, `source_section`, `priority`, and `role`) when
+known, but it must not become a second writable ordering store. Consumers must
+treat the detail as stale after any lifecycle event and requery before making a
+new dispatch or merge decision.
+
+## Acceptance Checks
+
+A valid public fixture or implementation must prove:
+
+- `schema_version` is exactly `todo_detail_cold_path_v0`;
+- hot-path surfaces include at most `todo_detail_ref_v0`, never the full
+  detail response;
+- `truth_contract.projection_is_writable=false`;
+- `truth_contract.write_api=false`;
+- the response references exactly one `goal_id`, `role`, and `todo_id`;
+- page tokens are opaque and optional;
+- no local absolute paths, credentials, raw logs, raw transcripts, raw
+  benchmark trajectories, or raw verifier output are projected;
+- consumers can safely ignore both `todo_detail_ref_v0` and
+  `todo_detail_cold_path_v0` when absent.

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -891,6 +891,13 @@ Item fields:
   counts to indicate when more claimed work exists than is expanded in the
   current payload, and richer frontstage views should use a future
   paged/filtered projection instead of forcing larger heartbeat payloads.
+  The canonical todo drill-down contract is
+  `docs/reference/protocols/todo-detail-cold-path-v0.md`: hot-path summaries
+  may carry only a compact `todo_detail_ref_v0` pointer for one selected item,
+  while full notes, evidence summaries, related lifecycle references, and page
+  tokens stay in `todo_detail_cold_path_v0` cold-path responses. Status,
+  quota, heartbeat, and handoff payloads must not inline full todo detail in
+  order to make hidden backlog visible.
   When claimed lanes exceed the cap, producers should avoid raw top-N
   truncation. Sort by priority and source position, group by `claimed_by`, take
   a fair per-claimant slice, then fill remaining slots from the sorted

--- a/examples/todo-detail-cold-path-contract-smoke.py
+++ b/examples/todo-detail-cold-path-contract-smoke.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Smoke-test the todo detail cold-path contract boundary."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PROTOCOL = REPO_ROOT / "docs" / "reference" / "protocols" / "todo-detail-cold-path-v0.md"
+PROTOCOLS_README = REPO_ROOT / "docs" / "reference" / "protocols" / "README.md"
+STATUS_CONTRACT = REPO_ROOT / "docs" / "status-data-contract.md"
+STATUS_SOURCE = REPO_ROOT / "loopx" / "status.py"
+QUOTA_SOURCE = REPO_ROOT / "loopx" / "quota.py"
+HOT_PATH_SMOKE = REPO_ROOT / "examples" / "hot-path-interface-budget-smoke.py"
+
+DETAIL_SCHEMA = "todo_detail_cold_path_v0"
+REF_SCHEMA = "todo_detail_ref_v0"
+PROTOCOL_DOC_NAME = "todo-detail-cold-path-v0.md"
+FORBIDDEN_TEXT = [
+    "/" + "Users/",
+    "/" + "tmp/",
+    "OPEN" + "AI" + "_API" + "_KEY",
+    "ANTH" + "ROPIC" + "_API" + "_KEY",
+    "raw" + "_thread",
+    "session" + "_history",
+    "verifier" + "_output_tail",
+]
+
+
+def assert_no_forbidden_text(text: str) -> None:
+    leaked = [marker for marker in FORBIDDEN_TEXT if marker in text]
+    assert not leaked, leaked
+
+
+def main() -> int:
+    protocol = PROTOCOL.read_text(encoding="utf-8")
+    protocols_readme = PROTOCOLS_README.read_text(encoding="utf-8")
+    status_contract = STATUS_CONTRACT.read_text(encoding="utf-8")
+    status_source = STATUS_SOURCE.read_text(encoding="utf-8")
+    quota_source = QUOTA_SOURCE.read_text(encoding="utf-8")
+    hot_path_smoke = HOT_PATH_SMOKE.read_text(encoding="utf-8")
+
+    required_protocol_text = [
+        DETAIL_SCHEMA,
+        REF_SCHEMA,
+        "Cold-Path Shape",
+        "Paging Rules",
+        "truth_contract.projection_is_writable=false",
+        "truth_contract.write_api=false",
+        "active_goal_state_and_event_ledger",
+        "Raw task text, transcripts",
+        "consumers can safely ignore",
+    ]
+    missing = [item for item in required_protocol_text if item not in protocol]
+    assert not missing, missing
+
+    assert PROTOCOL_DOC_NAME in protocols_readme, PROTOCOL_DOC_NAME
+    assert PROTOCOL_DOC_NAME in status_contract, PROTOCOL_DOC_NAME
+    assert REF_SCHEMA in status_contract, REF_SCHEMA
+    assert DETAIL_SCHEMA in status_contract, DETAIL_SCHEMA
+    status_excerpt_start = status_contract.index(PROTOCOL_DOC_NAME)
+    status_excerpt = status_contract[status_excerpt_start : status_excerpt_start + 700]
+
+    assert DETAIL_SCHEMA not in status_source, "status hot path should not inline todo detail yet"
+    assert DETAIL_SCHEMA not in quota_source, "quota hot path should not inline todo detail yet"
+    assert DETAIL_SCHEMA not in hot_path_smoke, "hot-path budget smoke should not include todo detail"
+
+    for text in (protocol, protocols_readme, status_excerpt):
+        assert_no_forbidden_text(text)
+
+    print("todo-detail-cold-path-contract-smoke ok projection=docs_only")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a public `todo_detail_cold_path_v0` protocol for inspecting full todo detail without expanding status, quota, heartbeat, or handoff hot-path payloads.

## What changed

- Defines `todo_detail_cold_path_v0` and the optional hot-path `todo_detail_ref_v0` pointer.
- Registers the protocol in the protocols README.
- Updates the status data contract so richer todo drill-downs stay behind the cold-path contract instead of forcing larger heartbeat payloads.
- Adds a focused smoke that keeps the contract docs-only for now and verifies the full detail schema is not projected by current status/quota hot paths.

## Validation

- `python3 examples/todo-detail-cold-path-contract-smoke.py`
- `python3 examples/hot-path-interface-budget-smoke.py`
- `loopx check --scan-path docs/reference/protocols/todo-detail-cold-path-v0.md --scan-path docs/reference/protocols/README.md --scan-path docs/status-data-contract.md --scan-path examples/todo-detail-cold-path-contract-smoke.py`
- `git diff --check`

`loopx check` reported no errors and a clean public-boundary scan for the changed files; it only repeated the existing duplicate-index warning.

## Merge posture

This is docs + focused smoke only. It does not change runtime behavior, benchmark scoring, runner behavior, permissions, or hot-path budgets.
