### PR TITLE
Add issue-fix command-pack guidance

### DIFF
--- a/docs/capabilities/issue-fix/README.md
+++ b/docs/capabilities/issue-fix/README.md
@@ -41,6 +41,41 @@ metadata boundary.
 - External issue comments, PR creation, merge, publish, and destructive git are
   out of scope for this capability.
 
+## Conversational `/loopx` Entry
+
+When the user starts from a chat box or command palette, use the project-local
+goal command first:
+
+```text
+/loopx Fix https://github.com/owner/repo/issues/123
+```
+
+The host or skill fallback should run the command pack preview with the exact
+goal text:
+
+```bash
+loopx bootstrap-command-pack --project . \
+  --goal-text "Fix https://github.com/owner/repo/issues/123"
+```
+
+For a GitHub issue/PR fix goal, the command pack points to the issue-fix
+workflow planner before todo writeback:
+
+```bash
+loopx issue-fix workflow-plan \
+  --url https://github.com/owner/repo/issues/123 \
+  --repo-path <approved-repo> \
+  --validation-label "<validation command>" \
+  --format json
+```
+
+The workflow-plan output is still preview-only. Accepted candidates become
+ordered LoopX todos: public metadata/intake, repro or route selection,
+branch-local patch and validation, then PR review packet readiness. Concrete
+owner actions become explicit user gates, including private repro material,
+issue body/comment reads, external issue comments, PR creation, merge, publish,
+destructive git, production actions, and repository-policy approvals.
+
 ## Workflow Plan
 
 ```bash

--- a/docs/reference/protocols/loopx-goal-command-v0.md
+++ b/docs/reference/protocols/loopx-goal-command-v0.md
@@ -64,6 +64,28 @@ quota projections already use todo index as the same-priority tie-breaker, so
 the first written `P0` outranks the second written `P0` without adding a new
 rank field.
 
+## Issue-Fix Domain Route
+
+When `/loopx <goal text>` contains a public GitHub issue/PR URL or an explicit
+issue-fix intent, the planner should preview the dedicated capability route
+before writing todos:
+
+```bash
+loopx issue-fix workflow-plan \
+  --url <github-issue-or-pr-url> \
+  --repo-path <approved-repo> \
+  --validation-label "<validation command>" \
+  --format json
+```
+
+The preview maps public metadata, intake classification, branch planning,
+validation labels, todo writeback previews, and PR review readiness blockers
+into the `/loopx <goal text>` planning checkpoint. Accepted candidates are then
+written with `loopx todo add` in priority and planner order. User todos or
+operator gates must cover private repro material, issue body/comment reads,
+external issue comments, PR creation, merge, publish, destructive git,
+production actions, and repository-policy approvals.
+
 ## Stop Conditions
 
 Stop and ask the user instead of writing or executing when:

--- a/examples/bootstrap-command-pack-smoke.py
+++ b/examples/bootstrap-command-pack-smoke.py
@@ -129,8 +129,22 @@ def test_goal_text_invocation_plans_ranked_todos_before_activation() -> None:
         assert "avoid management-only filler" in plan_prompt
         assert "Every new todo starts with `[P0]`, `[P1]`, or `[P2]`" in plan_prompt
         assert "Preserve that exact order" in plan_prompt
+        assert "GitHub issue/PR fix" in plan_prompt
+        assert "loopx issue-fix workflow-plan" in plan_prompt
+        assert "external comments, PR creation, merge, publish" in plan_prompt
+        assert "issue_fix_workflow_plan_template" in commands
+        issue_fix_template = str(commands["issue_fix_workflow_plan_template"])
+        assert "issue-fix workflow-plan" in issue_fix_template
+        assert "--url <github-issue-or-pr-url>" in issue_fix_template
+        assert "--repo-path <approved-repo>" in issue_fix_template
+        assert "--validation-label '<validation command>'" in issue_fix_template
         assert "--agent-id codex-test-agent" in str(commands["goal_start_quota_should_run"])
         assert "Same-priority items use that write order as the tie-breaker" in str(payload["message"])
+        assert "preview the issue-fix route before todo writeback" in str(payload["message"])
+        domain_routes = goal_start["domain_route_hints"]
+        assert domain_routes["issue_fix_workflow"]["when"].startswith("goal text contains")
+        assert "workflow-plan" in domain_routes["issue_fix_workflow"]["preview_command"]
+        assert "explicit gates" in domain_routes["issue_fix_workflow"]["writeback"]
         assert not (project / ".loopx").exists()
         assert not (project / ".codex").exists()
 

--- a/examples/issue-fix-workflow-contract-smoke.py
+++ b/examples/issue-fix-workflow-contract-smoke.py
@@ -33,6 +33,7 @@ from loopx.capabilities.issue_fix.metadata_preview import (  # noqa: E402
 
 DOC = ROOT / "docs/capabilities/issue-fix/protocols/issue-fix-workflow-contract-v0.md"
 README = ROOT / "docs/capabilities/issue-fix/README.md"
+LOOPX_GOAL_COMMAND = ROOT / "docs" / "reference" / "protocols" / "loopx-goal-command-v0.md"
 
 PRIVATE_PATTERNS = [
     re.compile(r"/Users/[A-Za-z0-9._-]+/"),
@@ -77,9 +78,23 @@ def assert_ordered(text: str, markers: list[str]) -> None:
 def main() -> int:
     doc = DOC.read_text(encoding="utf-8")
     readme = README.read_text(encoding="utf-8")
+    loopx_goal_command = LOOPX_GOAL_COMMAND.read_text(encoding="utf-8")
     assert doc.startswith("# issue_fix_workflow_contract_v0")
     assert "issue-fix-workflow-contract-v0.md" in readme
     assert "python3 examples/issue-fix-workflow-contract-smoke.py" in readme
+    assert "## Conversational `/loopx` Entry" in readme
+    assert "/loopx Fix https://github.com/owner/repo/issues/123" in readme
+    assert "loopx bootstrap-command-pack --project ." in readme
+    assert "--goal-text \"Fix https://github.com/owner/repo/issues/123\"" in readme
+    assert "loopx issue-fix workflow-plan" in readme
+    assert "ordered LoopX todos" in readme
+    assert "PR review packet readiness" in readme
+    assert "explicit user gates" in readme
+    assert "## Issue-Fix Domain Route" in loopx_goal_command
+    assert "loopx issue-fix workflow-plan" in loopx_goal_command
+    assert "before writing todos" in loopx_goal_command
+    assert "priority and planner order" in loopx_goal_command
+    assert "operator gates must cover private repro material" in loopx_goal_command
     assert_ordered(
         doc,
         [

--- a/loopx/bootstrap_command_pack.py
+++ b/loopx/bootstrap_command_pack.py
@@ -271,6 +271,20 @@ def _goal_start_contract(*, goal_text: str | None, connected: bool) -> dict[str,
             "begin_automation_when_quota_allows": True,
             "spend_quota_after_writeback": True,
         },
+        "domain_route_hints": {
+            "issue_fix_workflow": {
+                "when": "goal text contains a public GitHub issue/PR URL or asks for an issue-fix workflow",
+                "preview_command": (
+                    "loopx issue-fix workflow-plan --url <github-issue-or-pr-url> "
+                    "--repo-path <approved-repo> --validation-label '<validation command>' --format json"
+                ),
+                "writeback": (
+                    "turn accepted workflow-plan candidates into ordered LoopX agent/user todos; "
+                    "private repro material, issue body/comment reads, external comments, PR creation, "
+                    "merge, publish, destructive git, and production actions stay explicit gates"
+                ),
+            }
+        },
         "connected_at_preview_time": connected,
         "stop_conditions": [
             "private material requested before a public-safe todo can be written",
@@ -300,6 +314,7 @@ Planning rules:
 4. If several todos share the same priority, their listed order is their relative priority. Preserve that exact order when writing them.
 5. Prefer executable Agent Todo items with `task_class=advancement_task`; use User Todo only for concrete owner decisions or private-material gates.
 6. After writing todos, run `loopx refresh-state --goal-id {goal_id}`, then `loopx quota should-run --goal-id {goal_id}` and begin the first allowed bounded segment.
+7. If the goal is a GitHub issue/PR fix, first preview `loopx issue-fix workflow-plan --url <github-issue-or-pr-url> --repo-path <approved-repo> --validation-label '<validation command>' --format json`; convert accepted preview candidates into ordered todos and keep private repro material, body/comment reads, external comments, PR creation, merge, publish, destructive git, and production actions as explicit gates.
 """
 
 
@@ -416,6 +431,13 @@ def build_loopx_bootstrap_command_pack(
                 f"{shell_arg(cli_bin)} quota should-run --goal-id {shell_arg(resolved_goal_id)}"
                 + (f" --agent-id {shell_arg(agent_id)}" if agent_id else "")
             ),
+            "issue_fix_workflow_plan_template": (
+                f"{shell_arg(cli_bin)} issue-fix workflow-plan "
+                "--url <github-issue-or-pr-url> "
+                "--repo-path <approved-repo> "
+                "--validation-label '<validation command>' "
+                "--format json"
+            ),
         },
         "safety_contract": {
             "runs_bootstrap": False,
@@ -464,6 +486,14 @@ Then plan before writing todos. Preserve relative priority by write order:
 ````
 
 Write the planned todos with `loopx todo add` in the exact planned order. Same-priority items use that write order as the tie-breaker.
+
+For GitHub issue/PR fix goals, preview the issue-fix route before todo writeback:
+
+```bash
+{commands.get("issue_fix_workflow_plan_template", "")}
+```
+
+Accepted preview candidates become ordered Agent/User todos. Private repro material, issue body/comment reads, external comments, PR creation, merge, publish, destructive git, and production actions stay explicit gates.
 
 After todo writeback:
 
@@ -599,6 +629,10 @@ Supported forms: `/loopx`, `/loopx <goal text>`
 
 ```bash
 {commands.get("goal_start_connect_if_needed", "")}
+```
+
+```bash
+{commands.get("issue_fix_workflow_plan_template", "")}
 ```
 
 ## Safety Contract


### PR DESCRIPTION
## Summary
- add issue-fix domain-route guidance to `/loopx <goal text>` command-pack output without changing mutation behavior
- document the conversational path from `/loopx Fix <GitHub issue>` to `loopx issue-fix workflow-plan`, ordered LoopX todos, validation, PR review packet readiness, and explicit gates
- extend bootstrap-command-pack and issue-fix workflow contract smokes

## Validation
- python3 examples/bootstrap-command-pack-smoke.py
- python3 examples/issue-fix-workflow-contract-smoke.py
- python3 examples/issue-fix-workflow-plan-smoke.py
- python3 -m py_compile loopx/bootstrap_command_pack.py examples/bootstrap-command-pack-smoke.py examples/issue-fix-workflow-contract-smoke.py
- git diff --cached --check
- loopx check --scan-path loopx/bootstrap_command_pack.py --scan-path docs/capabilities/issue-fix/README.md --scan-path docs/reference/protocols/loopx-goal-command-v0.md --scan-path examples/bootstrap-command-pack-smoke.py --scan-path examples/issue-fix-workflow-contract-smoke.py

## Review note
Not self-merging because this changes runtime command-pack JSON/message output, even though it remains read-only and public-safe.