### PR TITLE
Guard benchmark status polling against argv leakage

### DIFF
--- a/docs/benchmark-developer-workflow.md
+++ b/docs/benchmark-developer-workflow.md
@@ -120,9 +120,10 @@ python3 scripts/benchmark_run_status_snapshot.py \
   --pretty
 ```
 
-The snapshot reports `status.env`, pid liveness, compact result summaries,
+The snapshot reports `status.env`, pid-file liveness, compact result summaries,
 standard artifact presence, and optional keyword booleans for tmux captures. It
-does not emit task text, trajectories, raw logs, or capture content. With
+does not run `ps`, read process cmdline/argv, or emit task text, trajectories,
+raw logs, or capture content. With
 `--record-rollout-event`, it also appends one aggregate `benchmark_status`
 event to the rollout log so the control plane can see that a poll happened
 without seeing host paths or capture text.

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -2264,7 +2264,14 @@ may use it to decide whether a run should continue polling, unload/disable a
 local `launchd` label, or write a precise missing-handle blocker before any
 rerun. It must be derived from compact artifacts, pid liveness, and run labels
 only; it must not expose raw logs, task text, trajectories, scheduler payloads,
-or local paths.
+or local paths. Snapshots may also include
+`runs[].process_polling.schema_version=benchmark_process_polling_v0` to make
+the polling boundary explicit. That object records that polling used the
+private pid file and compact artifacts only; it must keep
+`process_table_read=false`, `cmdline_read=false`, `argv_read=false`, and
+`raw_process_payload_recorded=false` so benchmark task prompts embedded in
+worker argv cannot leak into status, rollout logs, chat summaries, or
+control-plane projections.
 
 ## Boundary
 

--- a/examples/benchmark-run-status-snapshot-smoke.py
+++ b/examples/benchmark-run-status-snapshot-smoke.py
@@ -47,6 +47,10 @@ def main() -> int:
             "Working\nsecret raw transcript should never be emitted\n",
             encoding="utf-8",
         )
+        (run / "cmdline.private.txt").write_text(
+            "codex exec solve TASK_PROMPT_SHOULD_NOT_APPEAR_IN_SNAPSHOT\n",
+            encoding="utf-8",
+        )
         (run / "result.compact.json").write_text(
             json.dumps(
                 {
@@ -115,6 +119,10 @@ def main() -> int:
         assert payload["schema_version"] == "benchmark_run_status_snapshot_v0"
         assert payload["boundary"]["raw_logs_emitted"] is False
         assert payload["boundary"]["local_paths_recorded"] is False
+        assert payload["boundary"]["process_table_read"] is False
+        assert payload["boundary"]["process_cmdline_read"] is False
+        assert payload["boundary"]["process_argv_read"] is False
+        assert payload["boundary"]["process_argv_emitted"] is False
         assert payload["run_root_recorded"] is False
         item = payload["runs"][0]
         running_item = payload["runs"][1]
@@ -122,6 +130,12 @@ def main() -> int:
         assert item["status"] == "rc=0"
         assert item["run_dir_recorded"] is False
         assert item["pid_alive"] is True
+        assert item["process_polling"]["schema_version"] == "benchmark_process_polling_v0"
+        assert item["process_polling"]["mode"] == "pid_file_liveness_only"
+        assert item["process_polling"]["process_table_read"] is False
+        assert item["process_polling"]["cmdline_read"] is False
+        assert item["process_polling"]["argv_read"] is False
+        assert item["process_polling"]["raw_process_payload_recorded"] is False
         summaries = [result["summary"] for result in item["compact_results"]]
         assert any(summary.get("official_score") == 1.0 for summary in summaries)
         goal_summaries = [
@@ -163,7 +177,20 @@ def main() -> int:
         assert failure_policy["cleanup_required"] is True
         assert failure_policy["blocker_required_before_rerun"] is False
         assert "secret raw transcript" not in proc.stdout
+        assert "TASK_PROMPT_SHOULD_NOT_APPEAR_IN_SNAPSHOT" not in proc.stdout
         assert str(root) not in proc.stdout
+        script_source = SCRIPT.read_text(encoding="utf-8")
+        forbidden_process_polling = [
+            "subprocess.run",
+            "subprocess.check_output",
+            "pgrep",
+            "/proc/",
+            "process_iter",
+        ]
+        leaked_polling = [
+            item for item in forbidden_process_polling if item in script_source
+        ]
+        assert not leaked_polling, leaked_polling
 
         runtime_root = root / "runtime"
         rollout_proc = subprocess.run(
@@ -213,6 +240,10 @@ def main() -> int:
         assert event["details"]["cleanup_required_count"] == 2, event
         assert event["details"]["monitor_poll_allowed_count"] == 1, event
         assert event["details"]["blocker_required_count"] == 0, event
+        assert event["details"]["process_table_read"] is False, event
+        assert event["details"]["process_cmdline_read"] is False, event
+        assert event["details"]["process_argv_read"] is False, event
+        assert event["details"]["process_argv_emitted"] is False, event
         assert event["boundary"]["raw_logs_recorded"] is False, event
         assert event["boundary"]["absolute_paths_recorded"] is False, event
 

--- a/scripts/benchmark_run_status_snapshot.py
+++ b/scripts/benchmark_run_status_snapshot.py
@@ -125,6 +125,16 @@ def snapshot_run(
         "label": label,
         "run_dir_recorded": False,
         "exists": run_dir.exists(),
+        "process_polling": {
+            "schema_version": "benchmark_process_polling_v0",
+            "mode": "pid_file_liveness_only",
+            "pid_file_checked": False,
+            "process_table_read": False,
+            "cmdline_read": False,
+            "argv_read": False,
+            "comm_recorded": False,
+            "raw_process_payload_recorded": False,
+        },
     }
     if not run_dir.exists():
         return item
@@ -133,10 +143,13 @@ def snapshot_run(
     item["status"] = _read_text(status_file).strip() if status_file.exists() else "running/no-status"
 
     pid_file = run_dir / "pid.private"
+    item["process_polling"]["pid_file_checked"] = pid_file.exists()
     if pid_file.exists():
         pid_text = _read_text(pid_file).strip()
         item["pid"] = pid_text
         item["pid_alive"] = _pid_alive(pid_text)
+        item["process_polling"]["pid_present"] = bool(pid_text)
+        item["process_polling"]["pid_alive"] = item["pid_alive"]
 
     item["compact_results"] = [
         _compact_summary(path, run_dir)
@@ -186,6 +199,10 @@ def build_snapshot(
             "raw_logs_emitted": False,
             "capture_content_emitted": False,
             "local_paths_recorded": False,
+            "process_table_read": False,
+            "process_cmdline_read": False,
+            "process_argv_read": False,
+            "process_argv_emitted": False,
         },
         "runs": [
             snapshot_run(
@@ -264,6 +281,10 @@ def _snapshot_rollout_details(payload: dict[str, Any]) -> dict[str, Any]:
             and run["observable_handle_policy"].get("blocker_required_before_rerun")
             is True
         ),
+        "process_table_read": False,
+        "process_cmdline_read": False,
+        "process_argv_read": False,
+        "process_argv_emitted": False,
     }
 
 


### PR DESCRIPTION
## Summary

Adds an explicit benchmark process polling boundary so status snapshots and rollout events stay on public-safe pid/status/artifact handles and never inspect or emit process cmdline/argv.

## What changed

- `benchmark_run_status_snapshot.py` now emits `benchmark_process_polling_v0` per run and top-level boundary flags for process table, cmdline, and argv reads/emission.
- The benchmark status snapshot smoke plants an argv-like task prompt marker and asserts it never appears in snapshot output or rollout events.
- The smoke also checks the snapshot helper does not introduce `ps`/`pgrep`/`/proc`/process-iterator polling paths.
- Status and benchmark developer workflow docs now document the pid-file-only polling boundary.

## Validation

- `python3 examples/benchmark-run-status-snapshot-smoke.py`
- `python3 -m compileall -q scripts/benchmark_run_status_snapshot.py loopx/benchmark_core/observable_handles.py`
- `git diff --check`
- `loopx check --scan-path scripts/benchmark_run_status_snapshot.py --scan-path examples/benchmark-run-status-snapshot-smoke.py --scan-path docs/status-data-contract.md --scan-path docs/benchmark-developer-workflow.md`

`loopx check` reported no errors and a clean public-boundary scan for the changed files; it only repeated the existing duplicate-index warning.

## Merge posture

Hold for maintainer review. This touches a benchmark status helper/runtime surface, so it is not a docs-only self-merge even though the change is narrow and validated.
