### PR TITLE
Preserve SkillsBench reduce-only prerequisites

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -61,6 +61,7 @@ from scripts.skillsbench_automation_loop import (  # noqa: E402
     LOCAL_CODEX_PARTICIPANT_MATERIALIZATION_SCHEMA_VERSION,
     PRODUCT_MODE_CASE_STATE_PATH,
     PRODUCT_MODE_CASE_STATE_SCHEMA_VERSION,
+    RUNNER_PREREQUISITES_PUBLIC_FILENAME,
     SkillsBenchProductModeNoLifecycleRequests,
     _tail,
     _apply_agent_message_only_no_tool_calls_attribution,
@@ -8320,6 +8321,13 @@ def test_skillsbench_main_failure_closeout_preserves_mutated_prerequisites() -> 
         assert payload["compact_closeout_recorded"] is True, payload
         compact_path = Path(payload["compact_benchmark_run_json"])
         compact = json.loads(compact_path.read_text(encoding="utf-8"))
+        prereq_path = (
+            jobs_dir
+            / "skillsbench-prereq-closeout-fixture"
+            / RUNNER_PREREQUISITES_PUBLIC_FILENAME
+        )
+        assert prereq_path.exists(), payload
+        persisted_prereqs = json.loads(prereq_path.read_text(encoding="utf-8"))
         assert_prerequisites_include(
             compact["runner_prerequisites"],
             {
@@ -8330,6 +8338,16 @@ def test_skillsbench_main_failure_closeout_preserves_mutated_prerequisites() -> 
                 "codex_acp_runtime_launch_preflight_stage": (
                     "after_agent_install_before_acp_connect"
                 ),
+                "codex_acp_runtime_launch_preflight_status": "passed",
+                "codex_acp_runtime_launch_preflight_rc": 0,
+                "codex_acp_runtime_launch_preflight_raw_logs_read": False,
+            },
+        )
+        assert_prerequisites_include(
+            persisted_prereqs,
+            {
+                "schema_version": "skillsbench_runner_prerequisites_v0",
+                "codex_acp_runtime_launch_preflight": True,
                 "codex_acp_runtime_launch_preflight_status": "passed",
                 "codex_acp_runtime_launch_preflight_rc": 0,
                 "codex_acp_runtime_launch_preflight_raw_logs_read": False,
@@ -9504,6 +9522,98 @@ def test_skillsbench_reduce_only_preserves_round_reward_trace() -> None:
         assert run["round_rewards"][1]["passed"] is True, run
 
 
+def test_skillsbench_reduce_only_preserves_persisted_public_prerequisites() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-prereq-reduce-main-") as tmp:
+        jobs_dir = Path(tmp) / "jobs"
+        job_name = "skillsbench-prereq-reduce-fixture"
+        rollout_name = "sample-task__loopx_product_mode"
+        run_dir = jobs_dir / job_name / rollout_name
+        write_json(
+            run_dir / "result.json",
+            {
+                "task_name": "sample-task",
+                "rollout_name": rollout_name,
+                "rewards": {"reward": 0.0},
+                "agent": "codex-acp",
+                "agent_name": "codex-acp",
+                "model": "gpt-5.5",
+                "n_tool_calls": 0,
+                "n_prompts": 1,
+                "error": None,
+                "verifier_error": None,
+                "partial_trajectory": False,
+                "trajectory_source": "acp",
+            },
+        )
+        write_json(run_dir / "timing.json", {"total": 4.0})
+        write_json(
+            jobs_dir / job_name / RUNNER_PREREQUISITES_PUBLIC_FILENAME,
+            {
+                "schema_version": "skillsbench_runner_prerequisites_v0",
+                "agent_execution_mode": "host_local_acp",
+                "host_local_acp_launch": True,
+                "host_local_acp_launch_status": "sandbox_installed",
+                "codex_acp_runtime_container_bootstrap": False,
+                "codex_acp_runtime_dependency_preflight": False,
+                "codex_acp_runtime_launch_preflight": True,
+                "codex_acp_runtime_launch_preflight_status": "skipped",
+                "remote_command_file_bridge_consumed_by_solver": True,
+                "remote_command_file_bridge_agent_request_count": 2,
+                "remote_command_file_bridge_agent_loopx_cli_call_count": 6,
+                "remote_command_file_bridge_agent_task_facing_operation_count": 1,
+                "filtered_extra_marker": "FILTERED_PREREQ_MARKER_MUST_NOT_ESCAPE",
+            },
+        )
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            rc = skillsbench_automation_loop_main(
+                [
+                    "--task-id",
+                    "sample-task",
+                    "--route",
+                    "loopx-product-mode",
+                    "--jobs-dir",
+                    str(jobs_dir),
+                    "--job-name",
+                    job_name,
+                    "--rollout-name",
+                    rollout_name,
+                    "--ledger-path",
+                    str(Path(tmp) / "ledger.json"),
+                    "--reduce-only",
+                    "--update-ledger",
+                ]
+            )
+        assert rc == 0, stderr.getvalue()
+        payload = json.loads(stdout.getvalue())
+        compact_path = Path(payload["compact_benchmark_run_json"])
+        compact = json.loads(compact_path.read_text(encoding="utf-8"))
+        prereqs = compact["runner_prerequisites"]
+        assert_prerequisites_include(
+            prereqs,
+            {
+                "schema_version": "skillsbench_runner_prerequisites_v0",
+                "agent_execution_mode": "host_local_acp",
+                "host_local_acp_launch": True,
+                "host_local_acp_launch_status": "sandbox_installed",
+                "codex_acp_runtime_container_bootstrap": False,
+                "codex_acp_runtime_dependency_preflight": False,
+                "codex_acp_runtime_launch_preflight": True,
+                "codex_acp_runtime_launch_preflight_status": "skipped",
+                "remote_command_file_bridge_consumed_by_solver": True,
+                "remote_command_file_bridge_agent_request_count": 2,
+                "remote_command_file_bridge_agent_loopx_cli_call_count": 6,
+                "remote_command_file_bridge_agent_task_facing_operation_count": 1,
+                "reduce_only_prerequisites_source": "persisted_public_job_artifact",
+                "reduce_only_prerequisites_artifact_read": True,
+            },
+        )
+        compact_text = json.dumps(compact, sort_keys=True)
+        assert "container_codex_acp" not in compact_text, compact
+        assert "FILTERED_PREREQ_MARKER_MUST_NOT_ESCAPE" not in compact_text, compact
+
+
 if __name__ == "__main__":
     test_skillsbench_default_blind_loop_budget_is_sixteen()
     test_skillsbench_product_mode_soft_verify_default_is_every_round()
@@ -9631,4 +9741,5 @@ if __name__ == "__main__":
     test_skillsbench_main_redirects_runner_output_to_private_log()
     test_skillsbench_reduce_only_discovers_nested_official_result()
     test_skillsbench_reduce_only_preserves_round_reward_trace()
+    test_skillsbench_reduce_only_preserves_persisted_public_prerequisites()
     print("skillsbench-benchmark-run-smoke: ok")

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -149,6 +149,7 @@ DEFAULT_VERIFIER_PREP_TIMEOUT_SEC = 120
 DEFAULT_SOFT_VERIFIER_TIMEOUT_SEC = 600
 DEFAULT_PRODUCT_MODE_SOFT_VERIFY_POLICY = "every-round"
 DEFAULT_MAX_ROUNDS = 16
+RUNNER_PREREQUISITES_PUBLIC_FILENAME = "runner_prerequisites.public.json"
 HOST_LOCAL_ACP_TARGET_ENV_KEYS = (
     "AI_ADDR",
     "AI_PORT",
@@ -1442,6 +1443,7 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "host_local_acp_codex_exec_failure_category",
         "runner_interruption_kind",
         "runner_interruption_status",
+        "reduce_only_prerequisites_source",
     ):
         raw = value.get(field)
         if isinstance(raw, str) and raw:
@@ -1541,6 +1543,7 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "runner_interrupted_before_official_result",
         "runner_interruption_compact_closeout_expected",
         "runner_interruption_raw_material_recorded",
+        "reduce_only_prerequisites_artifact_read",
     ):
         if isinstance(value.get(field), bool):
             compact[field] = value[field]
@@ -1647,6 +1650,62 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         compact["remote_command_file_bridge_driver_lifecycle_execution_style"] = (
             style[:120]
         )
+    return compact
+
+
+def _runner_prerequisites_public_path(plan: dict[str, Any]) -> Path | None:
+    jobs_dir = str(plan.get("jobs_dir") or "")
+    job_name = str(plan.get("job_name") or "")
+    if not jobs_dir or not job_name:
+        return None
+    return (
+        Path(jobs_dir).expanduser()
+        / job_name
+        / RUNNER_PREREQUISITES_PUBLIC_FILENAME
+    )
+
+
+def _write_public_runner_prerequisites(plan: dict[str, Any]) -> Path | None:
+    compact = _public_runner_prerequisites(plan.get("runner_prerequisites"))
+    if not compact:
+        return None
+    path = _runner_prerequisites_public_path(plan)
+    if path is None:
+        return None
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(compact, indent=2, sort_keys=True, default=_json_default) + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _read_public_runner_prerequisites(plan: dict[str, Any]) -> dict[str, Any]:
+    path = _runner_prerequisites_public_path(plan)
+    if path is None or not path.exists():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(payload, dict):
+        return {}
+    if isinstance(payload.get("runner_prerequisites"), dict):
+        payload = payload["runner_prerequisites"]
+    compact = _public_runner_prerequisites(payload)
+    if compact:
+        compact["reduce_only_prerequisites_source"] = "persisted_public_job_artifact"
+        compact["reduce_only_prerequisites_artifact_read"] = True
+    return compact
+
+
+def _hydrate_reduce_only_public_runner_prerequisites(
+    plan: dict[str, Any],
+) -> dict[str, Any]:
+    compact = _read_public_runner_prerequisites(plan)
+    if not compact:
+        return {}
+    plan["runner_prerequisites"] = compact
     return compact
 
 
@@ -8395,6 +8454,7 @@ def reduce_official_result_after_runner_exception(
         return None
 
     compact = reduce_result(args, result_path, plan)
+    _write_public_runner_prerequisites(plan)
     compact["runner_return_status"] = (
         "official_result_recovered_after_runner_exception"
     )
@@ -8455,6 +8515,7 @@ def build_runner_failure_compact(
         exc,
         cleanup_if_missing=True,
     )
+    _write_public_runner_prerequisites(plan)
 
     exception_type, attribution, labels = skillsbench_runner_error_attribution(
         str(exc)
@@ -9217,6 +9278,7 @@ async def async_main(
 
     ensure_benchflow_runtime(args)
     if args.reduce_only:
+        _hydrate_reduce_only_public_runner_prerequisites(plan)
         result_path = discover_benchflow_result_path(plan)
         if not result_path.exists():
             raise FileNotFoundError(
@@ -9230,6 +9292,7 @@ async def async_main(
             run_benchflow_case_with_private_output(args, plan),
             timeout=args.outer_timeout_sec,
         )
+        _write_public_runner_prerequisites(plan)
     compact = reduce_result(args, result_path, plan)
     compact_path = Path(plan["compact_benchmark_run_json"])
     compact_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- persist public-safe SkillsBench runner prerequisites as `runner_prerequisites.public.json` in the job root
- make `--reduce-only` hydrate runner prerequisites from that persisted job artifact before compact regeneration
- add regression coverage so historical reduce-only compaction cannot fall back to the current default launch-plan prerequisites

## Validation
- `python3 - <<'PY' ... targeted prereq/reduce-only smokes ... PY`
- `python3 -m compileall -q scripts/skillsbench_automation_loop.py examples/skillsbench-benchmark-run-smoke.py`
- `git diff --check`
- `loopx check --scan-path scripts/skillsbench_automation_loop.py --scan-path examples/skillsbench-benchmark-run-smoke.py`

`loopx check` reported the existing duplicate-index warning only; public boundary scan was clean for the two changed files.

## Merge posture
This touches SkillsBench benchmark runner/reducer behavior, so it is intentionally held for maintainer review rather than self-merged.
