### PR TITLE
Detect repeated monitor targets

### DIFF
--- a/docs/interaction-pattern-catalog.md
+++ b/docs/interaction-pattern-catalog.md
@@ -651,12 +651,18 @@ the evidence needed to decide whether the goal is working.
 
 The agent may append at most one no-spend monitor poll, rerun the guard, and
 then stay quiet. The automation remains alive; monitor-only quiet skips are not
-completion or deletion signals.
+completion or deletion signals. The poll records `quota_monitor_target_v0` so
+the next guard can distinguish a harmless unchanged watch from the same target
+repeating.
 
 Status and diagnose should display unchanged monitor-only work as
 `waiting_on=monitor_signal` with `severity=watch`, while retaining the quota
 decision `effective_action=monitor_quiet_skip`. This keeps the monitor visible
 without making it look like immediate Codex work or a user/controller gate.
+Two consecutive no-spend polls for the same target should project a
+`dead_monitor_repeat` autonomous replan obligation; the agent must write a
+watch-lane expiry, concrete blocker, todo supersede, or successor runnable todo
+before another quiet poll.
 
 **Visual Model**
 
@@ -666,7 +672,9 @@ flowchart TD
   M -->|"no"| C["follow concrete contract"]
   M -->|"yes"| P["append no-spend poll"]
   P --> R["rerun quota guard"]
-  R --> Q["quiet; keep automation active"]
+  R --> D{"same target repeated?"}
+  D -->|"no"| Q["quiet; keep automation active"]
+  D -->|"yes"| A["dead-monitor repair required"]
 ```
 
 **Bad smell**
@@ -679,6 +687,7 @@ watch lane instead of staying quiet or writing a concrete blocker.
 **Validation**
 
 - `examples/heartbeat-quota-flow-smoke.py`
+- `examples/quota-plan-smoke.py`
 - `docs/heartbeat-automation-prompt.md`
 - `docs/archive/incidents/monitor-only-replan-stall-incident-20260621.md`
 
@@ -2120,6 +2129,7 @@ resolved repair; it is an unclosed control-plane loop with better narration.
 
 - `docs/archive/incidents/monitor-only-replan-stall-incident-20260621.md`
 - `skills/loopx-self-repair/references/repair-patterns.md`
+- `examples/heartbeat-quota-flow-smoke.py`
 - future regression that compares before/after frontier fields for repair and
   replan closeout runs.
 

--- a/docs/interaction-pattern-catalog.md
+++ b/docs/interaction-pattern-catalog.md
@@ -659,7 +659,7 @@ Status and diagnose should display unchanged monitor-only work as
 `waiting_on=monitor_signal` with `severity=watch`, while retaining the quota
 decision `effective_action=monitor_quiet_skip`. This keeps the monitor visible
 without making it look like immediate Codex work or a user/controller gate.
-Two consecutive no-spend polls for the same target should project a
+Six consecutive no-spend polls for the same target should project a
 `dead_monitor_repeat` autonomous replan obligation; the agent must write a
 watch-lane expiry, concrete blocker, todo supersede, or successor runnable todo
 before another quiet poll.

--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -386,7 +386,7 @@ loopx --registry "$HOME/.codex/loopx/registry.global.json" quota monitor-poll --
 `recommended_mode=monitor_quiet_until_material_transition`. It appends a
 `quota_monitor_poll` run record, does not mutate the registry, and does not
 append `quota_slot_spent`. The run includes `quota_monitor_target_v0`, a compact
-hash of the public monitor identity. Two consecutive public stalled monitor
+hash of the public monitor identity. Six consecutive public stalled monitor
 records with the same target feed `autonomous_replan_obligation` as
 `dead_monitor_repeat`, so the next independent `quota should-run` may flip to
 `autonomous_replan_required` /

--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -385,11 +385,14 @@ loopx --registry "$HOME/.codex/loopx/registry.global.json" quota monitor-poll --
 `effective_action=monitor_quiet_skip` and
 `recommended_mode=monitor_quiet_until_material_transition`. It appends a
 `quota_monitor_poll` run record, does not mutate the registry, and does not
-append `quota_slot_spent`. Two consecutive public stalled monitor records can
-feed `autonomous_replan_obligation`, so the next independent `quota should-run`
-may flip to `autonomous_replan_required` /
-`execution_obligation.must_attempt_work=true`; the executor should then perform
-one bounded replan slice instead of another quiet skip.
+append `quota_slot_spent`. The run includes `quota_monitor_target_v0`, a compact
+hash of the public monitor identity. Two consecutive public stalled monitor
+records with the same target feed `autonomous_replan_obligation` as
+`dead_monitor_repeat`, so the next independent `quota should-run` may flip to
+`autonomous_replan_required` /
+`execution_obligation.must_attempt_work=true`; the executor should then record a
+watch-lane expiry, concrete blocker, todo supersede, or successor runnable todo
+instead of another quiet skip.
 
 After that bounded replan slice is acknowledged by a compact state run carrying
 `autonomous_replan_ack_v0` and `repair_delta_contract_v0` with

--- a/examples/heartbeat-quota-flow-smoke.py
+++ b/examples/heartbeat-quota-flow-smoke.py
@@ -716,6 +716,22 @@ def main() -> int:
         )
         assert replan_guard["should_run"] is True, replan_guard
         assert replan_guard["heartbeat_recommendation"]["recommended_mode"] == "autonomous_replan_required", replan_guard
+        obligation = replan_guard["autonomous_replan_obligation"]
+        assert obligation["triggers"][0]["kind"] == "dead_monitor_repeat", obligation
+        assert obligation["dead_monitor_detector"]["schema_version"] == "dead_monitor_repeat_v0", obligation
+        assert obligation["dead_monitor_detector"]["required_resolution"] == [
+            "watch_lane_expiry",
+            "blocker",
+            "todo_supersede",
+            "successor_runnable_todo",
+        ], obligation
+        assert obligation["guidance_actions"] == [
+            "set_watch_expiry",
+            "write_blocker",
+            "supersede_monitor",
+            "create_successor",
+        ], obligation
+        assert "watch-lane continuation with expiry" in obligation["recommended_action"], obligation
         assert replan_guard["execution_obligation"]["kind"] == "autonomous_replan_required", replan_guard
         assert replan_guard["execution_obligation"]["must_attempt_work"] is True, replan_guard
         assert replan_guard["automation_liveness"]["automation_action"] == "execute_bounded_work", replan_guard

--- a/examples/heartbeat-quota-flow-smoke.py
+++ b/examples/heartbeat-quota-flow-smoke.py
@@ -676,7 +676,7 @@ def main() -> int:
         assert interaction["cli_channel"]["spend_after_validation"] is False, interaction
         assert "quota monitor-poll" in interaction["cli_channel"]["next_cli_actions"][0], interaction
 
-        for index in range(2):
+        for index in range(5):
             poll_reason = f"fixture monitor poll no material transition {index}"
             poll = run_cli(
                 root,
@@ -703,6 +703,43 @@ def main() -> int:
             assert count_spend_events(runtime) == 0, poll
             assert count_events(runtime, "quota_monitor_poll") == index + 1, poll
 
+        intermediate_guard = run_cli(
+            root,
+            "quota",
+            "should-run",
+            "--goal-id",
+            GOAL_ID,
+            "--scan-path",
+            str(project),
+            registry_path=registry_path,
+            runtime=runtime,
+        )
+        assert intermediate_guard["should_run"] is False, intermediate_guard
+        assert intermediate_guard["effective_action"] == "monitor_quiet_skip", intermediate_guard
+        assert "autonomous_replan_obligation" not in intermediate_guard, intermediate_guard
+
+        poll_reason = "fixture monitor poll no material transition 5"
+        poll = run_cli(
+            root,
+            "quota",
+            "monitor-poll",
+            "--goal-id",
+            GOAL_ID,
+            "--source",
+            "heartbeat",
+            "--reason-summary",
+            poll_reason,
+            "--execute",
+            "--scan-path",
+            str(project),
+            registry_path=registry_path,
+            runtime=runtime,
+        )
+        assert poll["ok"] is True, poll
+        assert poll["classification"] == "quota_monitor_poll", poll
+        assert count_spend_events(runtime) == 0, poll
+        assert count_events(runtime, "quota_monitor_poll") == 6, poll
+
         replan_guard = run_cli(
             root,
             "quota",
@@ -718,7 +755,11 @@ def main() -> int:
         assert replan_guard["heartbeat_recommendation"]["recommended_mode"] == "autonomous_replan_required", replan_guard
         obligation = replan_guard["autonomous_replan_obligation"]
         assert obligation["triggers"][0]["kind"] == "dead_monitor_repeat", obligation
+        assert obligation["stall_threshold"] == 6, obligation
+        assert obligation["triggers"][0]["run_count"] == 6, obligation
+        assert obligation["triggers"][0]["threshold"] == 6, obligation
         assert obligation["dead_monitor_detector"]["schema_version"] == "dead_monitor_repeat_v0", obligation
+        assert obligation["dead_monitor_detector"]["threshold"] == 6, obligation
         assert obligation["dead_monitor_detector"]["required_resolution"] == [
             "watch_lane_expiry",
             "blocker",
@@ -842,6 +883,7 @@ def main() -> int:
         assert ack["ok"] is True, ack
         assert ack.get("delivery_outcome") is None, ack
 
+        post_ack_poll_count = count_events(runtime, "quota_monitor_poll")
         for index in range(2):
             poll = run_cli(
                 root,
@@ -860,7 +902,7 @@ def main() -> int:
             assert poll["ok"] is True, poll
             assert poll["classification"] == "quota_monitor_poll", poll
             assert count_spend_events(runtime) == 1, poll
-            assert count_events(runtime, "quota_monitor_poll") == index + 3, poll
+            assert count_events(runtime, "quota_monitor_poll") == post_ack_poll_count + index + 1, poll
 
         post_ack_guard = run_cli(
             root,

--- a/examples/quota-plan-smoke.py
+++ b/examples/quota-plan-smoke.py
@@ -1988,6 +1988,11 @@ def assert_monitor_poll_event_carries_agent_id() -> None:
 
     assert event["agent_id"] == SCOPED_AGENT_ID, event
     assert event["monitor_event"]["agent_id"] == SCOPED_AGENT_ID, event
+    target = event["monitor_target"]
+    assert target["schema_version"] == "quota_monitor_target_v0", target
+    assert target["target_id"] == event["monitor_event"]["monitor_target"]["target_id"], event
+    assert target["agent_id"] == SCOPED_AGENT_ID, target
+    assert target["effective_action"] == "monitor_quiet_skip", target
 
 
 def main() -> int:

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -157,6 +157,7 @@ SIDE_AGENT_CLAIM_SCOPE_SCHEMA_VERSION = AGENT_CLAIM_SCOPE_SCHEMA_VERSION
 AGENT_LANE_NEXT_ACTION_SCHEMA_VERSION = "agent_lane_next_action_v0"
 AGENT_SCOPE_FRONTIER_SCHEMA_VERSION = "agent_scope_frontier_v0"
 AGENT_LANE_FRONTIER_HINT_SCHEMA_VERSION = "agent_lane_frontier_hint_v0"
+QUOTA_MONITOR_TARGET_SCHEMA_VERSION = "quota_monitor_target_v0"
 
 
 class AgentScopeFrontierAction(str, Enum):
@@ -7324,6 +7325,41 @@ def _quota_decision_agent_id(decision: dict[str, Any]) -> str | None:
     return normalize_todo_claimed_by(agent_identity.get("agent_id"))
 
 
+def _monitor_target_summary(value: Any, *, limit: int = 160) -> str:
+    text = re.sub(r"\s+", " ", str(value or "").strip())
+    if len(text) <= limit:
+        return text
+    return text[: limit - 3].rstrip() + "..."
+
+
+def _quota_monitor_target(before: dict[str, Any], *, monitor_mode: str) -> dict[str, Any]:
+    action_summary = _monitor_target_summary(
+        before.get("recommended_action") or before.get("reason") or "",
+        limit=160,
+    )
+    agent_id = _quota_decision_agent_id(before) or ""
+    parts = {
+        "goal_id": str(before.get("goal_id") or ""),
+        "agent_id": agent_id,
+        "monitor_mode": str(monitor_mode or ""),
+        "effective_action": str(before.get("effective_action") or ""),
+        "action_summary": action_summary,
+    }
+    target_id = hashlib.sha256(
+        json.dumps(parts, ensure_ascii=True, sort_keys=True).encode("utf-8")
+    ).hexdigest()[:16]
+    target: dict[str, Any] = {
+        "schema_version": QUOTA_MONITOR_TARGET_SCHEMA_VERSION,
+        "target_id": target_id,
+        "monitor_mode": parts["monitor_mode"],
+        "effective_action": parts["effective_action"],
+        "action_summary": action_summary,
+    }
+    if agent_id:
+        target["agent_id"] = agent_id
+    return target
+
+
 def _work_lane_reason_codes(work_lane_contract: dict[str, Any]) -> set[str]:
     reason_codes = work_lane_contract.get("reason_codes")
     if not isinstance(reason_codes, list):
@@ -7387,6 +7423,7 @@ def build_quota_monitor_poll_event(
         if external_monitor_poll
         else "monitor_quiet_until_material_transition"
     )
+    monitor_target = _quota_monitor_target(before, monitor_mode=monitor_mode)
     safe_reason_summary = str(reason_summary or "").strip()
     if not safe_reason_summary:
         safe_reason_summary = (
@@ -7409,10 +7446,12 @@ def build_quota_monitor_poll_event(
             else "monitor-only poll unchanged; no quota spend; no material transition"
         ),
         "delivery_outcome": DeliveryOutcome.SURFACE_ONLY.value,
+        "monitor_target": monitor_target,
         "monitor_event": {
             "event_type": QUOTA_MONITOR_POLL_CLASSIFICATION,
             "source": safe_source,
             "monitor_mode": monitor_mode,
+            "monitor_target": monitor_target,
             "reason_summary": safe_reason_summary,
             "before": _compact_quota_decision(before),
         },
@@ -7639,6 +7678,7 @@ def record_quota_monitor_poll(
         "recommended_action": record["recommended_action"],
         "health_check": record["health_check"],
         "delivery_outcome": record["delivery_outcome"],
+        "monitor_target": record["monitor_target"],
         "json_path": str(json_path),
         "markdown_path": str(markdown_path),
     }
@@ -8115,6 +8155,7 @@ def render_quota_monitor_poll_markdown(payload: dict[str, Any]) -> str:
         f"- agent_id: `{payload.get('agent_id') or event.get('agent_id') or ''}`",
         f"- source: `{event.get('source')}`",
         f"- effective_action: `{before.get('effective_action')}`",
+        f"- monitor_target: `{(event.get('monitor_target') or {}).get('target_id') if isinstance(event.get('monitor_target'), dict) else ''}`",
         f"- should_run: `{before.get('should_run')}`",
         f"- self_repair_allowed: `{before.get('self_repair_allowed')}`",
         f"- state: `{before.get('state')}`",

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -416,6 +416,7 @@ MAX_SUBAGENT_SCOPE_ITEMS = 4
 MAX_BACKLOG_HYGIENE_EVIDENCE_ITEMS = 3
 MAX_AUTONOMOUS_REPLAN_TRIGGERS = 3
 AUTONOMOUS_REPLAN_STALL_THRESHOLD = 2
+DEAD_MONITOR_REPEAT_THRESHOLD = 6
 AUTONOMOUS_REPLAN_PERIODIC_RUN_THRESHOLD = 20
 AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK = 30
 AUTONOMOUS_PRIORITY_PATTERN = re.compile(r"^\s*\[(P[0-4][^\]]*)\]\s*(.+)$", re.IGNORECASE)
@@ -5655,7 +5656,11 @@ def build_autonomous_replan_obligation(
     result = {
         "schema_version": AUTONOMOUS_REPLAN_SCHEMA_VERSION,
         "required": True,
-        "stall_threshold": AUTONOMOUS_REPLAN_STALL_THRESHOLD,
+        "stall_threshold": (
+            DEAD_MONITOR_REPEAT_THRESHOLD
+            if dead_monitor_evidence
+            else AUTONOMOUS_REPLAN_STALL_THRESHOLD
+        ),
         "trigger_count": len(evidence),
         "triggers": evidence,
         "guidance_actions": (
@@ -5822,6 +5827,7 @@ def autonomous_replan_obligation_from_runs(
     agent_todos: dict[str, Any] | None,
 ) -> dict[str, Any] | None:
     signals: list[dict[str, Any]] = []
+    signal_scan_limit = max(AUTONOMOUS_REPLAN_STALL_THRESHOLD, DEAD_MONITOR_REPEAT_THRESHOLD)
     for run in latest_runs or []:
         if not isinstance(run, dict):
             continue
@@ -5832,19 +5838,20 @@ def autonomous_replan_obligation_from_runs(
         if not signal:
             break
         signals.append(signal)
-        if len(signals) >= AUTONOMOUS_REPLAN_STALL_THRESHOLD:
+        if len(signals) >= signal_scan_limit:
             break
 
-    if len(signals) < AUTONOMOUS_REPLAN_STALL_THRESHOLD:
+    stall_signals = signals[:AUTONOMOUS_REPLAN_STALL_THRESHOLD]
+    if len(stall_signals) < AUTONOMOUS_REPLAN_STALL_THRESHOLD:
         return autonomous_replan_periodic_review_from_runs(
             latest_runs,
             agent_todos=agent_todos,
         )
 
-    signatures = {str(signal.get("signature") or "") for signal in signals if signal.get("signature")}
+    signatures = {str(signal.get("signature") or "") for signal in stall_signals if signal.get("signature")}
     classifications = {
         str(signal.get("classification") or "")
-        for signal in signals
+        for signal in stall_signals
         if signal.get("classification")
     }
     periodic_review = autonomous_replan_periodic_review_from_runs(
@@ -5853,17 +5860,29 @@ def autonomous_replan_obligation_from_runs(
     )
     if len(signatures) > 1 and len(classifications) > 1:
         return periodic_review
-    if classifications == {"quota_monitor_poll"} and run_history_monitor_wait_already_acknowledged(
-        latest_runs,
-        signal_count=len(signals),
-    ):
-        return periodic_review
-    monitor_target_ids = {
-        str(signal.get("monitor_target_id") or "")
-        for signal in signals
-        if signal.get("monitor_target_id")
-    }
-    if classifications == {"quota_monitor_poll"} and len(monitor_target_ids) == 1:
+    if classifications == {"quota_monitor_poll"}:
+        monitor_signals = signals[:DEAD_MONITOR_REPEAT_THRESHOLD]
+        if len(monitor_signals) < DEAD_MONITOR_REPEAT_THRESHOLD:
+            return periodic_review
+        monitor_classifications = {
+            str(signal.get("classification") or "")
+            for signal in monitor_signals
+            if signal.get("classification")
+        }
+        if monitor_classifications != {"quota_monitor_poll"}:
+            return periodic_review
+        if run_history_monitor_wait_already_acknowledged(
+            latest_runs,
+            signal_count=len(monitor_signals),
+        ):
+            return periodic_review
+        monitor_target_ids = {
+            str(signal.get("monitor_target_id") or "")
+            for signal in monitor_signals
+            if signal.get("monitor_target_id")
+        }
+        if len(monitor_target_ids) != 1:
+            return periodic_review
         monitor_target_id = next(iter(monitor_target_ids))
         evidence = [
             {
@@ -5871,11 +5890,11 @@ def autonomous_replan_obligation_from_runs(
                 "schema_version": DEAD_MONITOR_REPEAT_SCHEMA_VERSION,
                 "section": "run_history",
                 "text": (
-                    f"latest {AUTONOMOUS_REPLAN_STALL_THRESHOLD} monitor polls repeated "
+                    f"latest {DEAD_MONITOR_REPEAT_THRESHOLD} monitor polls repeated "
                     "the same monitor target without a material transition"
                 ),
-                "run_count": len(signals),
-                "threshold": AUTONOMOUS_REPLAN_STALL_THRESHOLD,
+                "run_count": len(monitor_signals),
+                "threshold": DEAD_MONITOR_REPEAT_THRESHOLD,
                 "monitor_target_id": monitor_target_id,
                 "latest_generated_at": signals[0].get("generated_at"),
             }
@@ -5883,7 +5902,7 @@ def autonomous_replan_obligation_from_runs(
         return build_autonomous_replan_obligation(evidence, agent_todos=agent_todos)
 
     action = public_safe_compact_text(
-        signals[0].get("recommended_action") or signals[0].get("classification"),
+        stall_signals[0].get("recommended_action") or stall_signals[0].get("classification"),
         limit=120,
     )
     evidence_text = (
@@ -5895,8 +5914,8 @@ def autonomous_replan_obligation_from_runs(
             "kind": "run_history_no_progress_repeat",
             "section": "run_history",
             "text": evidence_text,
-            "run_count": len(signals),
-            "latest_generated_at": signals[0].get("generated_at"),
+            "run_count": len(stall_signals),
+            "latest_generated_at": stall_signals[0].get("generated_at"),
         }
     ]
     return build_autonomous_replan_obligation(evidence, agent_todos=agent_todos)

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -429,6 +429,7 @@ BACKLOG_HYGIENE_HINT_PATTERN = re.compile(
     r"(?i)(?:\[p[0-4]\]|todo|backlog|follow[- ]?up|queue|audit|regression|smoke|cadence|mirror|monitor|sub-?agent|待办|回归|审计|修复|检查|推进)"
 )
 AUTONOMOUS_REPLAN_SCHEMA_VERSION = "autonomous_replan_obligation_v0"
+DEAD_MONITOR_REPEAT_SCHEMA_VERSION = "dead_monitor_repeat_v0"
 AUTONOMOUS_REPLAN_SECTION_HEADINGS = (
     "Next Action",
     "Operating Lessons",
@@ -5567,6 +5568,10 @@ def build_autonomous_replan_obligation(
     if not evidence:
         return None
 
+    dead_monitor_evidence = next(
+        (item for item in evidence if item.get("kind") == "dead_monitor_repeat"),
+        None,
+    )
     first_open: dict[str, Any] = {}
     if isinstance(agent_todos, dict):
         open_items = agent_todos.get("first_open_items")
@@ -5584,17 +5589,30 @@ def build_autonomous_replan_obligation(
         if first_open.get("priority"):
             action["priority"] = first_open.get("priority")
         todo_actions.append(action)
-    todo_actions.append(
-        {
-            "action": "add",
-            "role": "agent",
-            "priority": "P1",
-            "text": (
-                "write a compact replan record naming trigger, selected next slice, "
-                "validation command, and stop condition"
-            ),
-        }
-    )
+    if dead_monitor_evidence:
+        todo_actions.append(
+            {
+                "action": "add",
+                "role": "agent",
+                "priority": "P1",
+                "text": (
+                    "resolve the repeated monitor target with watch-lane expiry, "
+                    "a concrete blocker, todo supersede, or successor runnable todo"
+                ),
+            }
+        )
+    else:
+        todo_actions.append(
+            {
+                "action": "add",
+                "role": "agent",
+                "priority": "P1",
+                "text": (
+                    "write a compact replan record naming trigger, selected next slice, "
+                    "validation command, and stop condition"
+                ),
+            }
+        )
     if any(item.get("kind") in {"no_progress_streak", "repeated_action_loop"} for item in evidence):
         todo_actions.append(
             {
@@ -5617,7 +5635,13 @@ def build_autonomous_replan_obligation(
             }
         )
 
-    if any(item.get("kind") in {"periodic_review", "periodic_review_due"} for item in evidence):
+    if dead_monitor_evidence:
+        recommended_action = (
+            "resolve a dead monitor loop: record watch-lane continuation with expiry, "
+            "a concrete blocker, todo supersede, or successor runnable todo before "
+            "another quiet monitor poll"
+        )
+    elif any(item.get("kind") in {"periodic_review", "periodic_review_due"} for item in evidence):
         recommended_action = (
             "run a bounded autonomous periodic review: keep, split, add, retire, or ask for "
             "a decision; then update todos and select the next validated slice"
@@ -5628,13 +5652,17 @@ def build_autonomous_replan_obligation(
             "monitor-only or repeated action consumes the eligible turn"
         )
 
-    return {
+    result = {
         "schema_version": AUTONOMOUS_REPLAN_SCHEMA_VERSION,
         "required": True,
         "stall_threshold": AUTONOMOUS_REPLAN_STALL_THRESHOLD,
         "trigger_count": len(evidence),
         "triggers": evidence,
-        "guidance_actions": ["keep", "split", "add", "retire", "ask_decision"],
+        "guidance_actions": (
+            ["set_watch_expiry", "write_blocker", "supersede_monitor", "create_successor"]
+            if dead_monitor_evidence
+            else ["keep", "split", "add", "retire", "ask_decision"]
+        ),
         "todo_actions": todo_actions[:3],
         "next_validation_command": "python3 examples/autonomous-replan-obligation-smoke.py",
         "stop_condition": (
@@ -5643,10 +5671,34 @@ def build_autonomous_replan_obligation(
         ),
         "recommended_action": recommended_action,
     }
+    if dead_monitor_evidence:
+        result["dead_monitor_detector"] = {
+            "schema_version": DEAD_MONITOR_REPEAT_SCHEMA_VERSION,
+            "monitor_target_id": dead_monitor_evidence.get("monitor_target_id"),
+            "run_count": dead_monitor_evidence.get("run_count"),
+            "threshold": dead_monitor_evidence.get("threshold"),
+            "required_resolution": [
+                "watch_lane_expiry",
+                "blocker",
+                "todo_supersede",
+                "successor_runnable_todo",
+            ],
+        }
+    return result
 
 
 def _normalized_run_history_stall_signature(value: str) -> str:
     return re.sub(r"\s+", " ", value.strip().lower())
+
+
+def _run_history_monitor_target(run: dict[str, Any]) -> dict[str, Any] | None:
+    target = run.get("monitor_target")
+    if isinstance(target, dict):
+        return target
+    event = run.get("monitor_event")
+    if isinstance(event, dict) and isinstance(event.get("monitor_target"), dict):
+        return event.get("monitor_target")
+    return None
 
 
 def _run_history_stall_signal(run: dict[str, Any]) -> dict[str, Any] | None:
@@ -5673,13 +5725,22 @@ def _run_history_stall_signal(run: dict[str, Any]) -> dict[str, Any] | None:
     if not combined or not AUTONOMOUS_RUN_HISTORY_STALL_PATTERN.search(combined):
         return None
     action_or_classification = recommended_action or classification
-    return {
+    signal = {
         "classification": classification,
         "generated_at": str(run.get("generated_at") or ""),
         "recommended_action": recommended_action,
         "delivery_outcome": delivery_outcome.value if delivery_outcome else None,
         "signature": _normalized_run_history_stall_signature(action_or_classification),
     }
+    monitor_target = _run_history_monitor_target(run)
+    if monitor_target:
+        signal["monitor_target_id"] = str(monitor_target.get("target_id") or "")
+        signal["monitor_target"] = {
+            key: monitor_target.get(key)
+            for key in ("schema_version", "target_id", "monitor_mode", "effective_action", "agent_id")
+            if monitor_target.get(key)
+        }
+    return signal
 
 
 def run_history_monitor_wait_already_acknowledged(
@@ -5797,6 +5858,29 @@ def autonomous_replan_obligation_from_runs(
         signal_count=len(signals),
     ):
         return periodic_review
+    monitor_target_ids = {
+        str(signal.get("monitor_target_id") or "")
+        for signal in signals
+        if signal.get("monitor_target_id")
+    }
+    if classifications == {"quota_monitor_poll"} and len(monitor_target_ids) == 1:
+        monitor_target_id = next(iter(monitor_target_ids))
+        evidence = [
+            {
+                "kind": "dead_monitor_repeat",
+                "schema_version": DEAD_MONITOR_REPEAT_SCHEMA_VERSION,
+                "section": "run_history",
+                "text": (
+                    f"latest {AUTONOMOUS_REPLAN_STALL_THRESHOLD} monitor polls repeated "
+                    "the same monitor target without a material transition"
+                ),
+                "run_count": len(signals),
+                "threshold": AUTONOMOUS_REPLAN_STALL_THRESHOLD,
+                "monitor_target_id": monitor_target_id,
+                "latest_generated_at": signals[0].get("generated_at"),
+            }
+        ]
+        return build_autonomous_replan_obligation(evidence, agent_todos=agent_todos)
 
     action = public_safe_compact_text(
         signals[0].get("recommended_action") or signals[0].get("classification"),


### PR DESCRIPTION
## Summary
- add a compact quota monitor target identity to monitor-poll records
- project repeated no-spend polls for the same target as a dead-monitor autonomous replan obligation
- document the repair contract and cover it with focused quota/status smokes

## Validation
- python3 examples/heartbeat-quota-flow-smoke.py
- python3 examples/quota-plan-smoke.py
- python3 examples/interaction-pattern-catalog-smoke.py
- python3 examples/autonomous-replan-obligation-smoke.py
- python3 examples/status-neutral-run-window-smoke.py
- python3 -m compileall -q loopx

## Review note
This changes runtime/control-plane monitor-poll and autonomous-replan projection behavior, so I am not self-merging it. It is conceptually independent from PR #733 but may need a small rebase depending on merge order because both touch status/quota repair surfaces.