### PR TITLE
Document rollout state partitioning

### DIFF
--- a/docs/reference/protocols/long-horizon-agent-state-protocol-v0.md
+++ b/docs/reference/protocols/long-horizon-agent-state-protocol-v0.md
@@ -87,6 +87,49 @@ Projection truth contract:
 }
 ```
 
+## State Partitioning For Concurrent Agents
+
+Concurrent agents share one source-of-truth event stream per goal. LoopX should
+not fork truth just because a primary agent, side agent, benchmark case, or UI
+view wants a narrower timeline.
+
+Canonical source:
+
+- one registry entry and active goal state for the goal;
+- one append-only run history for compact lifecycle records;
+- one append-only `loopx_rollout_event_v0` log for todo, validation, PR, handoff,
+  quota, repair, and failure events;
+- formal todos as durable work units, including `claimed_by`, `task_class`,
+  `action_kind`, `resume_when`, and `unblocks_todo_id` when present.
+
+Derived views:
+
+- per-agent views filter by `agent_id`, `lane.lane_id`, `claimed_by`, and
+  selected `agent_lane_next_action_v0`;
+- per-todo views filter by `todo_id` and lifecycle transition events;
+- per-case or benchmark views filter by `case_id`, `benchmark_id`, and
+  validation/result events;
+- per-run views filter by `run_id`, `source_event_id`, and compact causality
+  refs.
+
+Derived views are read-only indexes. They may cache, rank, or summarize, but
+they must carry source refs back to canonical events and must be recomputable
+from the registry, active state, run history, rollout events, and reward
+overlays. A derived view must not become a separate active-state file, alternate
+run history, or dashboard-owned write path.
+
+Use an agent-lane projection when the agent shares the same goal, repo boundary,
+todo backlog, and operator policy, and only needs a scoped next action or
+timeline. Use an independent state file only when the work has a distinct
+`goal_id`, durable objective, protected boundary, owner policy, or backlog that
+would be misleading if compressed into the parent goal's `Next Action`.
+
+Every new rollout event that should participate in concurrent-agent views should
+try to include at least one stable join key: `agent_id`, `todo_id`, `run_id`,
+`lane.lane_id`, `case_id`, or `benchmark_id`. Events that cannot expose a join
+key may still be recorded, but projections should label any bridge from them as
+inferred rather than observed.
+
 ## Lifecycle
 
 ### Startup
@@ -208,7 +251,8 @@ Already aligned:
   code refs for new events.
 - `examples/fixtures/long-horizon-self-iteration-rollout.public.json` gives
   frontend and protocol tests a compact public-safe fixture with gate, handoff,
-  validation, deferred-resume, evidence, and inferred display-bridge coverage.
+  validation, deferred-resume, evidence, state partitioning, derived views, and
+  inferred display-bridge coverage.
 - `rollback_packet_v0` defines how rollback, fix-forward, external cleanup,
   support requests, and todo compensation are represented before any protected
   action runs.
@@ -248,6 +292,9 @@ A protocol implementation or fixture is acceptable when it proves:
 - every formal execution step maps to a todo, gate, run, event, or reward;
 - candidate todos are not silently promoted;
 - at least one lane-aware next action can be selected for a registered agent;
+- per-agent, per-todo, per-case, and per-run views are read-only derived
+  indexes over one canonical event stream;
+- an agent-lane projection is not confused with an independent state file;
 - validation and writeback precede quota spend;
 - human gates name what they block and unblock;
 - handoffs name source agent, target agent, todo scope, and stop condition;

--- a/examples/fixtures/long-horizon-self-iteration-rollout.public.json
+++ b/examples/fixtures/long-horizon-self-iteration-rollout.public.json
@@ -30,6 +30,82 @@
     "write_authority": "none",
     "recompute_rule": "Regenerate from active state, rollout events, PR metadata, and public docs; do not edit dashboard state as truth."
   },
+  "state_partitioning": {
+    "schema_version": "long_horizon_state_partitioning_v0",
+    "canonical_stream": {
+      "goal_id": "public-long-horizon-loop",
+      "source_surfaces": [
+        "registry",
+        "active_state",
+        "run_history",
+        "rollout_event_log",
+        "human_reward"
+      ],
+      "event_stream_count": 1,
+      "write_authority": "loopx_lifecycle_commands"
+    },
+    "derived_view_contract": {
+      "views_are_writable": false,
+      "must_reference_canonical_events": true,
+      "recompute_rule": "Filter and rank canonical events by stable join keys; never fork truth into per-agent state unless the goal identity or boundary changes."
+    },
+    "independent_state_file_rule": {
+      "use_agent_lane_projection_when": "same goal_id, repo boundary, backlog, and operator policy; only the selected next action or timeline is scoped",
+      "use_independent_state_when": "distinct goal_id, durable objective, protected boundary, owner policy, or backlog would be misleading inside the parent goal"
+    }
+  },
+  "derived_views": [
+    {
+      "view_id": "agent_codex_product_capability",
+      "view_kind": "per_agent",
+      "filter_keys": {
+        "agent_id": "codex-product-capability",
+        "lane_id": "product_capability"
+      },
+      "source_event_ids": [
+        "evt_lh_001_protocol_contract_ready",
+        "evt_lh_002_fixture_scope_narrowed",
+        "evt_lh_005_minimal_fixture_validated"
+      ],
+      "projection_is_writable": false
+    },
+    {
+      "view_id": "todo_frontstage_timeline",
+      "view_kind": "per_todo",
+      "filter_keys": {
+        "todo_id": "todo_frontstage_timeline"
+      },
+      "source_event_ids": [
+        "evt_lh_003_frontstage_impl_handoff",
+        "evt_lh_007_timeline_ready"
+      ],
+      "projection_is_writable": false
+    },
+    {
+      "view_id": "case_public_frontstage_rollout",
+      "view_kind": "per_case",
+      "filter_keys": {
+        "case_id": "public_frontstage_rollout"
+      },
+      "source_event_ids": [
+        "evt_lh_005_minimal_fixture_validated",
+        "evt_lh_006_sufficiency_ready",
+        "evt_lh_007_timeline_ready"
+      ],
+      "projection_is_writable": false
+    },
+    {
+      "view_id": "run_frontstage_validation",
+      "view_kind": "per_run",
+      "filter_keys": {
+        "run_id": "run_frontstage_fixture_validation"
+      },
+      "source_event_ids": [
+        "evt_lh_005_minimal_fixture_validated"
+      ],
+      "projection_is_writable": false
+    }
+  ],
   "lanes": [
     {
       "lane_id": "primary_control",
@@ -107,6 +183,8 @@
       "recorded_at": "2026-06-24T01:13:00+08:00",
       "agent_id": "codex-product-capability",
       "todo_id": "todo_minimal_rollout_fixture",
+      "case_id": "public_frontstage_rollout",
+      "run_id": "run_frontstage_fixture_validation",
       "lane": {
         "lane_id": "product_capability",
         "agent_role": "side-agent"
@@ -250,6 +328,8 @@
       "recorded_at": "2026-06-24T01:16:00+08:00",
       "agent_id": "codex-product-capability",
       "todo_id": "todo_minimal_rollout_fixture",
+      "case_id": "public_frontstage_rollout",
+      "run_id": "run_frontstage_fixture_validation",
       "lane": {
         "lane_id": "product_capability",
         "agent_role": "side-agent"
@@ -297,6 +377,7 @@
       "recorded_at": "2026-06-24T01:17:00+08:00",
       "agent_id": "codex-product-capability",
       "todo_id": "todo_frontstage_sufficiency",
+      "case_id": "public_frontstage_rollout",
       "lane": {
         "lane_id": "implementation_lane",
         "agent_role": "side-agent"
@@ -338,6 +419,7 @@
       "recorded_at": "2026-06-24T01:18:00+08:00",
       "agent_id": "codex-product-capability",
       "todo_id": "todo_frontstage_timeline",
+      "case_id": "public_frontstage_rollout",
       "lane": {
         "lane_id": "implementation_lane",
         "agent_role": "side-agent"

--- a/examples/long-horizon-self-iteration-rollout-fixture-smoke.py
+++ b/examples/long-horizon-self-iteration-rollout-fixture-smoke.py
@@ -70,6 +70,16 @@ def main() -> int:
     assert payload["truth_contract"]["projection_is_writable"] is False, payload
     assert payload["truth_contract"]["write_authority"] == "none", payload
 
+    state_partitioning = payload["state_partitioning"]
+    assert state_partitioning["schema_version"] == "long_horizon_state_partitioning_v0", state_partitioning
+    canonical_stream = state_partitioning["canonical_stream"]
+    assert canonical_stream["goal_id"] == payload["goal_id"], state_partitioning
+    assert canonical_stream["event_stream_count"] == 1, state_partitioning
+    assert "rollout_event_log" in canonical_stream["source_surfaces"], state_partitioning
+    derived_contract = state_partitioning["derived_view_contract"]
+    assert derived_contract["views_are_writable"] is False, state_partitioning
+    assert derived_contract["must_reference_canonical_events"] is True, state_partitioning
+
     public_boundary = payload["public_boundary"]
     for key in REQUIRED_BOUNDARY_FALSE:
         assert public_boundary.get(key) is False, (key, public_boundary)
@@ -85,8 +95,45 @@ def main() -> int:
     assert len(rollout_events) >= 7, rollout_events
     event_ids = [event["event_id"] for event in rollout_events]
     assert len(event_ids) == len(set(event_ids)), event_ids
+    events_by_id = {event["event_id"]: event for event in rollout_events}
     event_lanes = {event.get("lane", {}).get("lane_id") for event in rollout_events}
     assert {"implementation_lane", "product_capability"} <= event_lanes, event_lanes
+
+    derived_views = payload["derived_views"]
+    assert {view["view_kind"] for view in derived_views} == {
+        "per_agent",
+        "per_todo",
+        "per_case",
+        "per_run",
+    }, derived_views
+    for view in derived_views:
+        assert view["projection_is_writable"] is False, view
+        source_event_ids = view["source_event_ids"]
+        assert source_event_ids, view
+        for event_id in source_event_ids:
+            assert event_id in events_by_id, (view, event_id)
+        filter_keys = view["filter_keys"]
+        if view["view_kind"] == "per_agent":
+            assert any(
+                event.get("agent_id") == filter_keys["agent_id"]
+                or event.get("lane", {}).get("lane_id") == filter_keys["lane_id"]
+                for event in (events_by_id[event_id] for event_id in source_event_ids)
+            ), view
+        if view["view_kind"] == "per_todo":
+            assert all(
+                events_by_id[event_id].get("todo_id") == filter_keys["todo_id"]
+                for event_id in source_event_ids
+            ), view
+        if view["view_kind"] == "per_case":
+            assert all(
+                events_by_id[event_id].get("case_id") == filter_keys["case_id"]
+                for event_id in source_event_ids
+            ), view
+        if view["view_kind"] == "per_run":
+            assert all(
+                events_by_id[event_id].get("run_id") == filter_keys["run_id"]
+                for event_id in source_event_ids
+            ), view
 
     saw_gate = False
     saw_handoff = False


### PR DESCRIPTION
## Summary
- document the one canonical event stream plus read-only derived view contract for concurrent agents
- extend the public long-horizon rollout fixture with state_partitioning and derived_views examples
- strengthen the fixture smoke so per-agent/per-todo/per-case/per-run views must reference canonical rollout events and stable join keys

## Validation
- python3 examples/long-horizon-self-iteration-rollout-fixture-smoke.py
- python3 -m json.tool examples/fixtures/long-horizon-self-iteration-rollout.public.json
- python3 -m compileall -q examples/long-horizon-self-iteration-rollout-fixture-smoke.py
- git diff --check

## Self-merge rationale
Docs/fixture/smoke only. No runtime behavior, benchmark runner behavior, scoring, raw evidence, private state, credentials, local paths, or generated logs.