### PR TITLE
Add runtime task graph projection

### DIFF
--- a/docs/reference/protocols/task-graph-projection-v0.md
+++ b/docs/reference/protocols/task-graph-projection-v0.md
@@ -48,10 +48,21 @@ explicitly allows it.
     "write_api": false,
     "recompute_rule": "Recompute from status, active state, gates, leases, and run history after each lifecycle event."
   },
+  "limits": {
+    "user_gate_node_limit": 2,
+    "user_gate_open_count": 5,
+    "user_gate_truncated_count": 3
+  },
   "nodes": [],
   "edges": []
 }
 ```
+
+`limits` explains hot-path truncation. The task graph may expand only the first
+`user_gate_node_limit` open user gate nodes. When more user gates are open,
+`user_gate_open_count` and `user_gate_truncated_count` must say so. Consumers
+that need the complete gate list should use the user todo detail path or full
+review packet fields instead of treating the graph as an exhaustive store.
 
 ## Nodes
 
@@ -60,6 +71,8 @@ Allowed `kind` values are:
 
 - `deliverable`: a todo-backed artifact or implementation step;
 - `gate`: a user, owner, or operator decision point;
+- `gate_summary`: a compact "more gates exist" node used when user gates are
+  truncated from the graph hot path;
 - `lease`: an active claim or worker ownership signal;
 - `validation`: a smoke, check, CI result, or review proof;
 - `repair`: a self-repair or blocker-recovery step;
@@ -73,7 +86,7 @@ Required node fields:
 - `title`;
 - `state`: one of `open`, `ready`, `blocked`, `done`, `waiting`, or `unknown`;
 - `refs`: compact references such as `todo_ids`, `gate_ids`, `lease_ids`,
-  `run_ids`, or `review_packet_ids`.
+  `goal_ids`, `run_ids`, or `review_packet_ids`.
 
 Nodes must not copy raw task text, transcripts, logs, credentials, private file
 paths, or large run artifacts. They should summarize only the relationship
@@ -118,6 +131,9 @@ A valid public fixture or implementation must prove:
 - `mode` is `read_only`;
 - `truth_contract.projection_is_writable=false`;
 - `truth_contract.write_api=false`;
+- `limits.user_gate_node_limit` is present;
+- `limits.user_gate_open_count` is present;
+- `limits.user_gate_truncated_count` is present;
 - every node id is unique;
 - every edge endpoint references an existing node;
 - every node and edge references existing LoopX ids rather than raw

--- a/examples/fixtures/task-graph-projection-status.public.json
+++ b/examples/fixtures/task-graph-projection-status.public.json
@@ -40,6 +40,11 @@
             "write_api": false,
             "recompute_rule": "Recompute from status, active state, gates, leases, and run history after each lifecycle event."
           },
+          "limits": {
+            "user_gate_node_limit": 2,
+            "user_gate_open_count": 1,
+            "user_gate_truncated_count": 0
+          },
           "nodes": [
             {
               "node_id": "node_operator_gate_clear",

--- a/examples/task-graph-projection-fixture-smoke.py
+++ b/examples/task-graph-projection-fixture-smoke.py
@@ -26,6 +26,7 @@ STATE_MODEL_PATH = REPO_ROOT / "docs/state-interaction-model.md"
 ALLOWED_NODE_KINDS = {
     "deliverable",
     "gate",
+    "gate_summary",
     "lease",
     "validation",
     "repair",
@@ -44,6 +45,7 @@ ALLOWED_EDGE_RELATIONS = {
 ALLOWED_REF_KEYS = {
     "todo_ids",
     "gate_ids",
+    "goal_ids",
     "lease_ids",
     "run_ids",
     "review_packet_ids",
@@ -108,6 +110,10 @@ def assert_projection_shape(
     assert truth["event_ledger_is_source_of_truth"] is True, (label, truth)
     assert truth["projection_is_writable"] is False, (label, truth)
     assert truth["write_api"] is False, (label, truth)
+    limits = projection["limits"]
+    assert limits["user_gate_node_limit"] == 2, (label, limits)
+    assert limits["user_gate_open_count"] >= 0, (label, limits)
+    assert limits["user_gate_truncated_count"] >= 0, (label, limits)
 
     nodes = projection["nodes"]
     edges = projection["edges"]
@@ -141,13 +147,38 @@ def assert_runtime_projection_builder() -> None:
         "waiting_on": "controller",
         "recommended_action": "Implement the task graph projection runtime seam.",
         "user_todos": {
+            "open_count": 5,
             "items": [
                 {
                     "todo_id": "todo_review_gate",
                     "text": "[P1] Review runtime projection before merge.",
                     "status": "open",
                     "task_class": "user_gate",
-                }
+                },
+                {
+                    "todo_id": "todo_policy_gate",
+                    "text": "[P1] Confirm task graph cap and truncation policy.",
+                    "status": "open",
+                    "task_class": "user_gate",
+                },
+                {
+                    "todo_id": "todo_dashboard_gate",
+                    "text": "[P2] Decide whether dashboard should expand graph details.",
+                    "status": "open",
+                    "task_class": "user_gate",
+                },
+                {
+                    "todo_id": "todo_packet_gate",
+                    "text": "[P2] Confirm review packet detail path for full gate list.",
+                    "status": "open",
+                    "task_class": "user_gate",
+                },
+                {
+                    "todo_id": "todo_cold_path_gate",
+                    "text": "[P2] Confirm cold path remains the full user todo list.",
+                    "status": "open",
+                    "task_class": "user_gate",
+                },
             ]
         },
         "agent_todos": {
@@ -178,6 +209,17 @@ def assert_runtime_projection_builder() -> None:
     assert_projection_shape(projection, goal_id=goal_id, label="runtime projection", min_nodes=5, min_edges=4)
     kinds = {node["kind"] for node in projection["nodes"]}
     assert {"deliverable", "gate", "lease", "validation", "repair"} <= kinds, projection
+    assert "gate_summary" in kinds, projection
+    gate_nodes = [node for node in projection["nodes"] if node["kind"] == "gate"]
+    summary_nodes = [node for node in projection["nodes"] if node["kind"] == "gate_summary"]
+    assert len(gate_nodes) == 2, projection
+    assert len(summary_nodes) == 1, projection
+    assert summary_nodes[0]["title"] == "3 more open user gates not expanded", summary_nodes
+    assert projection["limits"] == {
+        "user_gate_node_limit": 2,
+        "user_gate_open_count": 5,
+        "user_gate_truncated_count": 3,
+    }, projection["limits"]
     relations = {edge["relation"] for edge in projection["edges"]}
     assert {"blocks", "depends_on", "validates", "repairs"} <= relations, projection
     forbidden_keys = {"write_command", "agent_command", "raw_log", "raw_transcript"}

--- a/examples/task-graph-projection-fixture-smoke.py
+++ b/examples/task-graph-projection-fixture-smoke.py
@@ -5,10 +5,18 @@ from __future__ import annotations
 
 import json
 import re
+import sys
 from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.cli_commands.status import review_packet_handoff_only_payload  # noqa: E402
+from loopx.review_packet import build_review_packet  # noqa: E402
+from loopx.status import build_task_graph_projection  # noqa: E402
+
 FIXTURE_PATH = REPO_ROOT / "examples/fixtures/task-graph-projection-status.public.json"
 CONTRACT_PATH = REPO_ROOT / "docs/reference/protocols/task-graph-projection-v0.md"
 STATUS_CONTRACT_PATH = REPO_ROOT / "docs/status-data-contract.md"
@@ -84,6 +92,123 @@ def assert_refs(refs: object, label: str) -> None:
             assert not value.startswith("/"), (label, key, value)
 
 
+def assert_projection_shape(
+    projection: dict[str, object],
+    *,
+    goal_id: str,
+    label: str,
+    min_nodes: int = 4,
+    min_edges: int = 3,
+) -> None:
+    assert projection["schema_version"] == "task_graph_projection_v0", (label, projection)
+    assert projection["mode"] == "read_only", (label, projection)
+    assert projection["goal_id"] == goal_id, (label, projection)
+    assert set(projection["derived_from"]["source_of_truth"]) == SOURCE_OF_TRUTH, (label, projection)
+    truth = projection["truth_contract"]
+    assert truth["event_ledger_is_source_of_truth"] is True, (label, truth)
+    assert truth["projection_is_writable"] is False, (label, truth)
+    assert truth["write_api"] is False, (label, truth)
+
+    nodes = projection["nodes"]
+    edges = projection["edges"]
+    assert isinstance(nodes, list) and len(nodes) >= min_nodes, (label, nodes)
+    assert isinstance(edges, list) and len(edges) >= min_edges, (label, edges)
+    node_ids = [node["node_id"] for node in nodes]
+    assert len(node_ids) == len(set(node_ids)), (label, node_ids)
+    node_id_set = set(node_ids)
+
+    for node in nodes:
+        assert node["kind"] in ALLOWED_NODE_KINDS, (label, node)
+        assert node["state"] in ALLOWED_NODE_STATES, (label, node)
+        assert isinstance(node["title"], str) and node["title"], (label, node)
+        assert_refs(node.get("refs"), f"{label} node {node['node_id']}")
+
+    for edge in edges:
+        assert edge["relation"] in ALLOWED_EDGE_RELATIONS, (label, edge)
+        assert edge["from_node_id"] in node_id_set, (label, edge)
+        assert edge["to_node_id"] in node_id_set, (label, edge)
+        assert edge["from_node_id"] != edge["to_node_id"], (label, edge)
+        assert isinstance(edge["reason"], str) and edge["reason"], (label, edge)
+        if "refs" in edge:
+            assert_refs(edge["refs"], f"{label} edge {edge['edge_id']}")
+
+
+def assert_runtime_projection_builder() -> None:
+    goal_id = "runtime-task-graph"
+    item = {
+        "goal_id": goal_id,
+        "status": "operator_gate",
+        "waiting_on": "controller",
+        "recommended_action": "Implement the task graph projection runtime seam.",
+        "user_todos": {
+            "items": [
+                {
+                    "todo_id": "todo_review_gate",
+                    "text": "[P1] Review runtime projection before merge.",
+                    "status": "open",
+                    "task_class": "user_gate",
+                }
+            ]
+        },
+        "agent_todos": {
+            "items": [
+                {
+                    "todo_id": "todo_runtime_projection",
+                    "text": "[P1] Implement task graph projection.",
+                    "title": "Implement task graph projection.",
+                    "status": "open",
+                    "claimed_by": "codex-main-control",
+                }
+            ]
+        },
+        "autonomous_replan_obligation": {
+            "schema_version": "autonomous_replan_obligation_v0",
+            "recommended_action": "Recover selected work if it stalls.",
+        },
+    }
+    goal = {"id": goal_id}
+    latest_runs = [
+        {
+            "generated_at": "2026-06-21T13:00:00Z",
+            "classification": "task_graph_projection_runtime_smoke",
+        }
+    ]
+    projection = build_task_graph_projection(item, goal=goal, goal_latest_runs=latest_runs)
+    assert isinstance(projection, dict), projection
+    assert_projection_shape(projection, goal_id=goal_id, label="runtime projection", min_nodes=5, min_edges=4)
+    kinds = {node["kind"] for node in projection["nodes"]}
+    assert {"deliverable", "gate", "lease", "validation", "repair"} <= kinds, projection
+    relations = {edge["relation"] for edge in projection["edges"]}
+    assert {"blocks", "depends_on", "validates", "repairs"} <= relations, projection
+    forbidden_keys = {"write_command", "agent_command", "raw_log", "raw_transcript"}
+    projection_keys = set(json.dumps(projection, sort_keys=True).split('"'))
+    assert not (projection_keys & forbidden_keys), projection_keys & forbidden_keys
+
+    status_payload = {
+        "registry": "./fixtures/registry.json",
+        "runtime_root": "./fixtures/runtime",
+        "attention_queue": {
+            "items": [
+                {
+                    **item,
+                    "task_graph_projection": projection,
+                    "project_asset": {
+                        "next_action": "Implement the task graph projection runtime seam.",
+                        "stop_condition": "stop before write authority or raw evidence export",
+                    },
+                }
+            ]
+        },
+        "run_history": {"goals": [goal]},
+    }
+    packet = build_review_packet(status_payload, goal_id=goal_id)
+    assert packet["ok"] is True, packet
+    assert packet["task_graph_projection"] == projection, packet
+    handoff_only = review_packet_handoff_only_payload(packet)
+    assert "task_graph_projection" not in handoff_only, handoff_only
+    assert_public_safe(json.dumps(packet, sort_keys=True), "runtime review packet")
+
+
 def main() -> int:
     fixture_text = read(FIXTURE_PATH)
     contract = read(CONTRACT_PATH)
@@ -120,41 +245,12 @@ def main() -> int:
     item = payload["attention_queue"]["items"][0]
     projection = item["task_graph_projection"]
 
-    assert projection["schema_version"] == "task_graph_projection_v0", projection
-    assert projection["mode"] == "read_only", projection
-    assert projection["goal_id"] == item["goal_id"], projection
-    assert set(projection["derived_from"]["source_of_truth"]) == SOURCE_OF_TRUTH, projection
-    truth = projection["truth_contract"]
-    assert truth["event_ledger_is_source_of_truth"] is True, truth
-    assert truth["projection_is_writable"] is False, truth
-    assert truth["write_api"] is False, truth
-
-    nodes = projection["nodes"]
-    edges = projection["edges"]
-    assert isinstance(nodes, list) and len(nodes) >= 4, nodes
-    assert isinstance(edges, list) and len(edges) >= 3, edges
-    node_ids = [node["node_id"] for node in nodes]
-    assert len(node_ids) == len(set(node_ids)), node_ids
-    node_id_set = set(node_ids)
-
-    for node in nodes:
-        assert node["kind"] in ALLOWED_NODE_KINDS, node
-        assert node["state"] in ALLOWED_NODE_STATES, node
-        assert isinstance(node["title"], str) and node["title"], node
-        assert_refs(node.get("refs"), f"node {node['node_id']}")
-
-    for edge in edges:
-        assert edge["relation"] in ALLOWED_EDGE_RELATIONS, edge
-        assert edge["from_node_id"] in node_id_set, edge
-        assert edge["to_node_id"] in node_id_set, edge
-        assert edge["from_node_id"] != edge["to_node_id"], edge
-        assert isinstance(edge["reason"], str) and edge["reason"], edge
-        if "refs" in edge:
-            assert_refs(edge["refs"], f"edge {edge['edge_id']}")
+    assert_projection_shape(projection, goal_id=item["goal_id"], label="fixture projection")
 
     forbidden_keys = {"write_command", "agent_command", "raw_log", "raw_transcript"}
     fixture_keys = set(json.dumps(payload, sort_keys=True).split('"'))
     assert not (fixture_keys & forbidden_keys), fixture_keys & forbidden_keys
+    assert_runtime_projection_builder()
 
     print("task-graph-projection-fixture-smoke ok")
     return 0

--- a/loopx/review_packet.py
+++ b/loopx/review_packet.py
@@ -1114,6 +1114,11 @@ def build_review_packet(
         if isinstance(item, dict) and isinstance(item.get("stale_latest_run_warning"), dict)
         else None
     )
+    task_graph_projection = (
+        item.get("task_graph_projection")
+        if isinstance(item, dict) and isinstance(item.get("task_graph_projection"), dict)
+        else None
+    )
     stale_latest_run_lines = stale_latest_run_packet_lines(stale_latest_run_warning)
     command = redact_local_absolute_paths(project_agent_command(status_payload, goal_id, kind, item, goal))
     approved_handoff = operator_gate_approved_handoff(item, goal)
@@ -1217,6 +1222,7 @@ def build_review_packet(
         "handoff_interface_budget": handoff_interface_budget,
         "decision_freshness_warning": freshness_warning,
         "stale_latest_run_warning": stale_latest_run_warning,
+        "task_graph_projection": task_graph_projection,
         "project_asset_source": asset_source,
         "packet": "\n".join(line for line in lines if line),
     }

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -65,6 +65,7 @@ from .todo_contract import (
     TODO_STATUS_OPEN,
     TODO_TASK_CLASS_ADVANCEMENT,
     TODO_TASK_CLASS_MONITOR,
+    TODO_TASK_CLASS_USER_GATE,
     TODO_TASK_PATTERN,
     build_todo_id,
     normalize_todo_action_kind,
@@ -8116,6 +8117,27 @@ def _task_graph_latest_run_node(
     return None
 
 
+def _task_graph_visible_user_gate_items(
+    user_todos: dict[str, Any] | None,
+    *,
+    limit: int,
+) -> tuple[list[dict[str, Any]], int]:
+    visible_items = open_todo_items(
+        user_todos,
+        limit=MAX_STATUS_TODOS_PER_ROLE,
+        text_limit=180,
+        source_keys=("gate_open_items", "first_open_items", "items"),
+    )
+    visible_gate_items = [
+        item for item in visible_items if todo_item_task_class(item) == TODO_TASK_CLASS_USER_GATE
+    ]
+    if visible_gate_items and len(visible_gate_items) == len(visible_items):
+        gate_open_count = max(len(visible_gate_items), todo_summary_open_count(user_todos))
+    else:
+        gate_open_count = len(visible_gate_items)
+    return visible_gate_items[:limit], gate_open_count
+
+
 def build_task_graph_projection(
     item: dict[str, Any],
     *,
@@ -8230,10 +8252,10 @@ def build_task_graph_projection(
                 refs=_task_graph_refs("lease_ids", lease_id),
             )
 
-    user_items = open_todo_items(
-        item.get("user_todos") if isinstance(item.get("user_todos"), dict) else None,
+    user_todo_summary = item.get("user_todos") if isinstance(item.get("user_todos"), dict) else None
+    user_items, user_gate_open_count = _task_graph_visible_user_gate_items(
+        user_todo_summary,
         limit=TASK_GRAPH_MAX_USER_GATE_NODES,
-        text_limit=180,
     )
     for ordinal, todo in enumerate(user_items):
         todo_id = public_safe_compact_text(todo.get("todo_id"), limit=120)
@@ -8254,6 +8276,31 @@ def build_task_graph_projection(
             relation="blocks",
             reason="Open user gate blocks the gated delivery path.",
             refs=_task_graph_refs("gate_ids", gate_id),
+        )
+    user_gate_truncated_count = max(0, user_gate_open_count - len(user_items))
+    if user_gate_truncated_count:
+        summary_node_id = add_node(
+            {
+                "node_id": _task_graph_safe_id(
+                    "node_gate_summary",
+                    f"{goal_id}:{user_gate_truncated_count}:more_user_gates",
+                ),
+                "kind": "gate_summary",
+                "title": f"{user_gate_truncated_count} more open user gates not expanded",
+                "state": "waiting",
+                "refs": _task_graph_refs("goal_ids", goal_id),
+            }
+        )
+        add_edge(
+            edge_id=_task_graph_safe_id(
+                "edge_blocks",
+                f"{summary_node_id}:{selected_node_id}:user_gate_summary",
+            ),
+            from_node_id=summary_node_id,
+            to_node_id=selected_node_id,
+            relation="blocks",
+            reason="Additional open user gates stay on the cold path instead of expanding the task graph hot path.",
+            refs=_task_graph_refs("goal_ids", goal_id),
         )
 
     run_node_id = add_node(
@@ -8320,6 +8367,11 @@ def build_task_graph_projection(
             "projection_is_writable": False,
             "write_api": False,
             "recompute_rule": "Recompute from status, active state, gates, leases, and run history after each lifecycle event.",
+        },
+        "limits": {
+            "user_gate_node_limit": TASK_GRAPH_MAX_USER_GATE_NODES,
+            "user_gate_open_count": user_gate_open_count,
+            "user_gate_truncated_count": user_gate_truncated_count,
         },
         "nodes": nodes,
         "edges": edges,

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -481,6 +481,16 @@ TODO_ARCHIVE_HEADER_MARKERS = (
     "待办归档",
 )
 TODO_ITEM_SCHEMA_VERSION = "todo_item_v0"
+TASK_GRAPH_PROJECTION_SCHEMA_VERSION = "task_graph_projection_v0"
+TASK_GRAPH_SOURCE_OF_TRUTH = [
+    "event_ledger",
+    "active_goal_state",
+    "todos",
+    "gates",
+    "leases",
+    "run_history",
+]
+TASK_GRAPH_MAX_USER_GATE_NODES = 2
 
 
 def normalize_todo_text(text: str, *, limit: int = 500) -> str:
@@ -7990,6 +8000,332 @@ def goal_attention(goal: dict[str, Any]) -> dict[str, Any] | None:
     return None
 
 
+def _task_graph_safe_id(prefix: str, value: Any) -> str:
+    raw = public_safe_compact_text(value, limit=120) or prefix
+    normalized = re.sub(r"[^A-Za-z0-9_]+", "_", raw).strip("_").lower()
+    if not normalized:
+        normalized = hashlib.sha256(str(value).encode("utf-8")).hexdigest()[:10]
+    if len(normalized) > 56:
+        suffix = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:8]
+        normalized = f"{normalized[:47].rstrip('_')}_{suffix}"
+    return f"{prefix}_{normalized}"
+
+
+def _task_graph_ref_values(*values: Any, limit: int = 4) -> list[str]:
+    refs: list[str] = []
+    for value in values:
+        if isinstance(value, list):
+            for nested in _task_graph_ref_values(*value, limit=limit):
+                if nested not in refs:
+                    refs.append(nested)
+                    if len(refs) >= limit:
+                        return refs
+            continue
+        text = public_safe_compact_text(value, limit=120)
+        if not text or text in refs:
+            continue
+        refs.append(text)
+        if len(refs) >= limit:
+            break
+    return refs
+
+
+def _task_graph_refs(key: str, *values: Any) -> dict[str, list[str]] | None:
+    refs = _task_graph_ref_values(*values)
+    if not refs:
+        return None
+    return {key: refs}
+
+
+def _task_graph_todo_state(todo: dict[str, Any], *, waiting_default: bool = False) -> str:
+    status = normalize_todo_status(todo.get("status")) or TODO_STATUS_OPEN
+    if todo.get("done") or todo_done_for_status(status):
+        return "done"
+    if status == "blocked":
+        return "blocked"
+    if status in {"waiting", "deferred"} or waiting_default:
+        return "waiting"
+    return "open"
+
+
+def _task_graph_generated_at(
+    *,
+    goal: dict[str, Any],
+    goal_latest_runs: list[dict[str, Any]],
+) -> str:
+    candidates: list[dict[str, Any]] = [*goal_latest_runs]
+    current_run = latest_run(goal)
+    if isinstance(current_run, dict):
+        candidates.append(current_run)
+    for run in candidates:
+        generated_at = public_safe_compact_text(run.get("generated_at"), limit=80)
+        if generated_at:
+            return generated_at
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _task_graph_active_state_updated_at(item: dict[str, Any], goal: dict[str, Any]) -> str | None:
+    warning = (
+        item.get("stale_latest_run_warning")
+        if isinstance(item.get("stale_latest_run_warning"), dict)
+        else {}
+    )
+    updated_at = public_safe_compact_text(warning.get("active_state_updated_at"), limit=80)
+    if updated_at:
+        return updated_at
+    current_run = latest_run(goal)
+    state = (
+        current_run.get("state")
+        if isinstance(current_run, dict) and isinstance(current_run.get("state"), dict)
+        else {}
+    )
+    frontmatter = state.get("frontmatter") if isinstance(state.get("frontmatter"), dict) else {}
+    return public_safe_compact_text(frontmatter.get("updated_at"), limit=80)
+
+
+def _task_graph_latest_run_node(
+    *,
+    goal_latest_runs: list[dict[str, Any]],
+    selected_todo_id: str | None,
+) -> dict[str, Any] | None:
+    for run in goal_latest_runs:
+        if not isinstance(run, dict):
+            continue
+        run_ref = public_safe_compact_text(
+            run.get("run_id") or run.get("generated_at") or run.get("classification"),
+            limit=120,
+        )
+        classification = public_safe_compact_text(run.get("classification"), limit=120)
+        if not (run_ref or classification):
+            continue
+        refs = _task_graph_refs("run_ids", run_ref or classification)
+        if refs and selected_todo_id:
+            todo_refs = _task_graph_ref_values(selected_todo_id)
+            if todo_refs:
+                refs["todo_ids"] = todo_refs
+        if not refs:
+            continue
+        title = classification or "Latest compact run-history evidence"
+        return {
+            "node_id": _task_graph_safe_id("node_run", run_ref or title),
+            "kind": "validation",
+            "title": f"Latest compact run: {title}",
+            "state": "ready",
+            "refs": refs,
+        }
+    return None
+
+
+def build_task_graph_projection(
+    item: dict[str, Any],
+    *,
+    goal: dict[str, Any],
+    goal_latest_runs: list[dict[str, Any]] | None = None,
+) -> dict[str, Any] | None:
+    """Build a compact read-only graph from already-projected status fields."""
+
+    goal_id = public_safe_compact_text(item.get("goal_id") or goal.get("id"), limit=120)
+    if not goal_id:
+        return None
+    latest_runs = [run for run in goal_latest_runs or [] if isinstance(run, dict)]
+    nodes: list[dict[str, Any]] = []
+    edges: list[dict[str, Any]] = []
+    node_ids: set[str] = set()
+    edge_ids: set[str] = set()
+    refs_by_node_id: dict[str, dict[str, list[str]]] = {}
+
+    def add_node(node: dict[str, Any] | None) -> str | None:
+        if not isinstance(node, dict):
+            return None
+        node_id = str(node.get("node_id") or "")
+        if not node_id:
+            return None
+        if node_id in node_ids:
+            return node_id
+        refs = node.get("refs") if isinstance(node.get("refs"), dict) else None
+        if not refs:
+            return None
+        title = public_safe_compact_text(node.get("title"), limit=160)
+        if not title:
+            return None
+        node["title"] = title
+        node_ids.add(node_id)
+        refs_by_node_id[node_id] = refs
+        nodes.append(node)
+        return node_id
+
+    def add_edge(
+        *,
+        edge_id: str,
+        from_node_id: str | None,
+        to_node_id: str | None,
+        relation: str,
+        reason: str,
+        refs: dict[str, list[str]] | None = None,
+    ) -> None:
+        if not from_node_id or not to_node_id or from_node_id == to_node_id:
+            return
+        if from_node_id not in node_ids or to_node_id not in node_ids or edge_id in edge_ids:
+            return
+        compact_reason = public_safe_compact_text(reason, limit=180)
+        if not compact_reason:
+            return
+        edge: dict[str, Any] = {
+            "edge_id": edge_id,
+            "from_node_id": from_node_id,
+            "to_node_id": to_node_id,
+            "relation": relation,
+            "reason": compact_reason,
+        }
+        if refs:
+            edge["refs"] = refs
+        edge_ids.add(edge_id)
+        edges.append(edge)
+
+    agent_items = open_todo_items(
+        item.get("agent_todos") if isinstance(item.get("agent_todos"), dict) else None,
+        limit=1,
+        text_limit=180,
+    )
+    selected_todo = agent_items[0] if agent_items else None
+    selected_todo_id = public_safe_compact_text(
+        selected_todo.get("todo_id") if isinstance(selected_todo, dict) else None,
+        limit=120,
+    )
+    selected_node_id: str | None = None
+    if isinstance(selected_todo, dict):
+        selected_node_id = add_node(
+            {
+                "node_id": _task_graph_safe_id("node_todo", selected_todo_id or selected_todo.get("text")),
+                "kind": "deliverable",
+                "title": selected_todo.get("title") or selected_todo.get("text"),
+                "state": _task_graph_todo_state(selected_todo),
+                "refs": _task_graph_refs("todo_ids", selected_todo_id),
+                **(
+                    {"owner_agent": selected_todo.get("claimed_by")}
+                    if public_safe_compact_text(selected_todo.get("claimed_by"), limit=80)
+                    else {}
+                ),
+            }
+        )
+        claimed_by = public_safe_compact_text(selected_todo.get("claimed_by"), limit=80)
+        if claimed_by and selected_node_id:
+            lease_id = f"claim:{goal_id}:{selected_todo_id or 'selected'}:{claimed_by}"
+            lease_node_id = add_node(
+                {
+                    "node_id": _task_graph_safe_id("node_lease", lease_id),
+                    "kind": "lease",
+                    "title": f"Claimed by {claimed_by}",
+                    "state": "ready",
+                    "refs": _task_graph_refs("lease_ids", lease_id),
+                    "owner_agent": claimed_by,
+                }
+            )
+            add_edge(
+                edge_id=_task_graph_safe_id("edge_depends", f"{selected_node_id}:{lease_node_id}"),
+                from_node_id=selected_node_id,
+                to_node_id=lease_node_id,
+                relation="depends_on",
+                reason="Selected work depends on its active claim lease.",
+                refs=_task_graph_refs("lease_ids", lease_id),
+            )
+
+    user_items = open_todo_items(
+        item.get("user_todos") if isinstance(item.get("user_todos"), dict) else None,
+        limit=TASK_GRAPH_MAX_USER_GATE_NODES,
+        text_limit=180,
+    )
+    for ordinal, todo in enumerate(user_items):
+        todo_id = public_safe_compact_text(todo.get("todo_id"), limit=120)
+        gate_id = todo_id or f"gate:{goal_id}:user:{ordinal + 1}"
+        gate_node_id = add_node(
+            {
+                "node_id": _task_graph_safe_id("node_gate", gate_id),
+                "kind": "gate",
+                "title": todo.get("title") or todo.get("text") or "Open user gate",
+                "state": _task_graph_todo_state(todo, waiting_default=True),
+                "refs": _task_graph_refs("gate_ids", gate_id),
+            }
+        )
+        add_edge(
+            edge_id=_task_graph_safe_id("edge_blocks", f"{gate_node_id}:{selected_node_id}:{ordinal}"),
+            from_node_id=gate_node_id,
+            to_node_id=selected_node_id,
+            relation="blocks",
+            reason="Open user gate blocks the gated delivery path.",
+            refs=_task_graph_refs("gate_ids", gate_id),
+        )
+
+    run_node_id = add_node(
+        _task_graph_latest_run_node(
+            goal_latest_runs=latest_runs,
+            selected_todo_id=selected_todo_id,
+        )
+    )
+    add_edge(
+        edge_id=_task_graph_safe_id("edge_validates", f"{run_node_id}:{selected_node_id}"),
+        from_node_id=run_node_id,
+        to_node_id=selected_node_id,
+        relation="validates",
+        reason="Latest compact run-history evidence validates or contextualizes the selected work.",
+        refs=refs_by_node_id.get(run_node_id or ""),
+    )
+
+    replan = (
+        item.get("autonomous_replan_obligation")
+        if isinstance(item.get("autonomous_replan_obligation"), dict)
+        else None
+    )
+    if replan and selected_node_id:
+        replan_id = public_safe_compact_text(
+            replan.get("schema_version") or replan.get("kind") or "autonomous_replan_obligation",
+            limit=120,
+        )
+        repair_node_id = add_node(
+            {
+                "node_id": _task_graph_safe_id("node_repair", replan_id),
+                "kind": "repair",
+                "title": replan.get("recommended_action") or replan_id,
+                "state": "ready",
+                "refs": _task_graph_refs("todo_ids", selected_todo_id),
+            }
+        )
+        add_edge(
+            edge_id=_task_graph_safe_id("edge_repairs", f"{repair_node_id}:{selected_node_id}"),
+            from_node_id=repair_node_id,
+            to_node_id=selected_node_id,
+            relation="repairs",
+            reason="Autonomous repair/replan obligation should recover the selected work lane.",
+            refs=_task_graph_refs("todo_ids", selected_todo_id),
+        )
+
+    if not nodes:
+        return None
+    derived_from: dict[str, Any] = {
+        "source_of_truth": TASK_GRAPH_SOURCE_OF_TRUTH,
+        "status_item_goal_id": goal_id,
+        "run_history_window": "compact_latest_runs",
+    }
+    active_state_updated_at = _task_graph_active_state_updated_at(item, goal)
+    if active_state_updated_at:
+        derived_from["active_state_updated_at"] = active_state_updated_at
+    return {
+        "schema_version": TASK_GRAPH_PROJECTION_SCHEMA_VERSION,
+        "mode": "read_only",
+        "goal_id": goal_id,
+        "generated_at": _task_graph_generated_at(goal=goal, goal_latest_runs=latest_runs),
+        "derived_from": derived_from,
+        "truth_contract": {
+            "event_ledger_is_source_of_truth": True,
+            "projection_is_writable": False,
+            "write_api": False,
+            "recompute_rule": "Recompute from status, active state, gates, leases, and run history after each lifecycle event.",
+        },
+        "nodes": nodes,
+        "edges": edges,
+    }
+
+
 def attach_goal_channel_projection(
     item: dict[str, Any],
     *,
@@ -8198,6 +8534,13 @@ def build_attention_queue(
                         interface_budget_cadence=interface_budget_cadence,
                     )
                 normalize_monitor_quiet_attention_display(item)
+            task_graph_projection = build_task_graph_projection(
+                item,
+                goal=goal,
+                goal_latest_runs=goal_latest_runs,
+            )
+            if task_graph_projection:
+                item["task_graph_projection"] = task_graph_projection
             attach_goal_channel_projection(
                 item,
                 goal=goal,


### PR DESCRIPTION
## Summary
- derive optional task_graph_projection_v0 objects from existing status todos, user gates, claim leases, compact run history, and replan obligations
- expose the projection on attention queue items and full review-packet JSON while keeping handoff-only review packets compact
- extend the public task graph smoke to cover runtime builder output plus review-packet full/handoff behavior

## Validation
- python3 examples/task-graph-projection-fixture-smoke.py
- python3 -m compileall -q loopx examples/task-graph-projection-fixture-smoke.py
- python3 -m loopx.cli --format json --registry "/Users/bytedance/.codex/loopx/registry.global.json" status + review-packet spot check: status projection present, full review packet has graph, handoff-only omits graph
- git diff --check

## Known Existing Gap
- python3 examples/review-packet-cli-smoke.py still fails on the pre-existing controller/read-only map suggested-decision wording assertion; this PR does not change that wording path.