### PR TITLE
Add long-task cadence status projection

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -89,7 +89,7 @@ incident report, or launch draft.
 - [Reward-style replanning hints](product/reward-style-replanning.md)
 - [Frontstage channel and lease roadmap](frontstage-channel-lease-roadmap.md)
 - [Non-technical operator status model](product/nontechnical-operator-status-model.md)
-- [Long-task cadence policy](long-task-cadence-policy.md)
+- [Long-task cadence hint](long-task-cadence-policy.md)
 - [Dreaming exploration lane](dreaming-exploration-lane.md)
 - [Session runtime control-plane adapter](session-runtime-control-plane-adapter.md)
 - [Codex subagent orchestration](codex-subagent-orchestration.md)

--- a/docs/dashboard-budget-governance-contract.md
+++ b/docs/dashboard-budget-governance-contract.md
@@ -73,6 +73,6 @@ capabilities, and source warnings, but it must not mutate project truth directly
 
 - [Quota allocation](quota-allocation.md)
 - [Status data contract](status-data-contract.md)
-- [Long-task cadence policy](long-task-cadence-policy.md)
+- [Long-task cadence hint](long-task-cadence-policy.md)
 - [Frontstage dashboard interaction baseline](product/frontstage-dashboard-interaction-baseline.md)
 - [Runtime connector catalog](runtime-connector-catalog.md)

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -754,7 +754,7 @@ Start here:
 - [Project agent todo contract](../project-agent-todo-contract.md)
 - [Quota allocation](../quota-allocation.md)
 - [Heartbeat automation prompt](../heartbeat-automation-prompt.md)
-- [Long-task cadence policy](../long-task-cadence-policy.md)
+- [Long-task cadence hint](../long-task-cadence-policy.md)
 - [Public/private boundary](../public-private-boundary.md)
 - [Benchmark developer workflow](../benchmark-developer-workflow.md)
 - [Public launch narrative draft](../outreach/public-launch-narrative-draft.md)

--- a/docs/interaction-pattern-catalog.md
+++ b/docs/interaction-pattern-catalog.md
@@ -246,7 +246,7 @@ Replanning, dreaming, cadence, and future-work writeback.
 | --- | --- | --- | --- | --- | --- |
 | P0 | IP-013 | Autonomous Replan Vs Advisory Dreaming | Agent/controller plus user when promoted | ask only for promotion/decision | repair stalled delivery; keep dreaming proposal non-executable |
 | P1 | IP-024 | Repair Delta Contract | Agent/controller | no interruption unless repair creates a user todo | self-repair/replan must change the machine-visible frontier or record a no-op/blocker |
-| P1 | IP-010 | Cadence Widening | Agent/controller | no interruption by default | widen next work segment when turns become too small |
+| P1 | IP-010 | Cadence Hint | Agent/controller | no interruption by default | surface a low-confidence hint when turns look too thin |
 | P1 | IP-018 | Plan To Todo Writeback | Agent plus LoopX | no interruption unless a user todo is created | write user-facing plans into todos, Next Action, or refresh-state |
 
 ## Visual Model
@@ -2118,42 +2118,44 @@ resolved repair; it is an unclosed control-plane loop with better narration.
 - future regression that compares before/after frontier fields for repair and
   replan closeout runs.
 
-#### IP-010 Cadence Widening
+#### IP-010 Cadence Hint
 
 **Trigger**
 
-- recent eligible turns have a small-step streak;
+- recent eligible turns have a thin-progress streak;
 - delivery repeatedly lands as `single_surface`, status-only, or shallow docs
   without a coherent artifact;
 - no safety boundary prevents a larger segment.
 
 **Expected behavior**
 
-The controller widens the next eligible turn according to the configured
-cadence preset. For the default `long` preset, a turn should usually include an
-artifact, focused validation, and state writeback.
+The controller treats the derived cadence hint as a low-confidence steering
+signal. When the hint says `thin_progress` with recommendation `widen`, the
+next eligible turn should usually include an artifact, focused validation, and
+state writeback, or write a blocker explaining why widening is unsafe.
 
 **Visual Model**
 
 ```mermaid
 flowchart TD
-  R["recent turns"] --> S{"small-step streak >= threshold?"}
+  R["recent turns"] --> S{"thin-progress streak >= threshold?"}
   S -->|"no"| C["keep current cadence"]
   S -->|"yes"| B{"safe to widen?"}
   B -->|"no"| G["ask gate or write blocker"]
-  B -->|"yes"| W["widen next segment by preset"]
+  B -->|"yes"| W["widen next eligible segment"]
   W --> D["artifact + validation + writeback"]
 ```
 
 **Bad smell**
 
 The agent's native long-task ability is degraded because the control plane keeps
-asking it to do tiny heartbeat-shaped steps.
+asking it to do tiny heartbeat-shaped steps, or the host treats a derived hint
+as a hard permission or timing policy.
 
 **Validation**
 
 - `docs/long-task-cadence-policy.md`
-- future status/quota preset projection smoke.
+- `examples/long-task-cadence-policy-smoke.py`
 
 #### IP-018 Plan To Todo Writeback
 

--- a/docs/long-task-cadence-policy.md
+++ b/docs/long-task-cadence-policy.md
@@ -1,165 +1,111 @@
-# Long-Task Cadence Policy
+# Long-Task Cadence Hint
 
-LoopX should preserve the native long-horizon strength of an agent loop.
-Heartbeat automation is useful because it keeps goals alive, but it can also
-train the controller into tiny status-only turns if every wakeup is treated as a
-small independent task. The cadence policy describes how product surfaces and
-future server runners should choose the size of an agent work segment.
+LoopX should not let a recurring heartbeat turn long-running agent work into
+tiny status-only turns. The cadence hint is a small, derived signal that tells a
+host or controller whether recent work looks blocked, thin, material, or
+unknown.
 
-## Problem
+It is intentionally not a scheduler policy. Quota, gates, goal boundaries,
+permissions, public/private scans, and user/controller decisions remain the
+source of truth.
 
-A recurring heartbeat can fragment work in two bad ways:
+## Why It Exists
 
-- the agent spends most turns restating status or editing state without a
-  validated artifact;
-- a blocked high-priority item causes the controller to drift into unrelated
-  low-value work without telling the operator what remains blocked.
+Heartbeat automation is useful because it keeps goals alive, but frequent
+wakeups can fragment work when every turn is treated as a separate tiny task.
+The hint helps product surfaces notice patterns such as:
 
-The right behavior is not simply "run longer." The control plane should widen a
-turn only when the selected work is safe, in scope, and likely to produce a
-coherent artifact. User gates, credentials, private material, destructive git,
-production actions, paid resource boundaries, and public benchmark submissions
-still stop or ask.
+- repeated status or single-surface writeback without a coherent artifact;
+- a real gate where widening would be unsafe;
+- recent validated progress where the current cadence can stay as-is;
+- missing or incomplete metadata where the product should avoid strong claims.
 
-## Product Presets
-
-LoopX should expose a small preset set instead of making users tune many
-heuristics directly:
-
-| Preset | Intended Use | Minimum Segment |
-| --- | --- | --- |
-| `ultra-long` | unattended research, benchmark sweeps, migration campaigns | finish a coherent milestone or write a hard blocker |
-| `long` | default for trusted heartbeat goals and product-mode benchmark work | implementation plus focused validation plus state writeback |
-| `medium` | active collaboration where the user expects visible progress often | one reviewable artifact or one repaired control-plane contract |
-| `short` | diagnosis, review, or gate-heavy work | one narrow inspection, repair, or explicit question |
-
-The default for connected autonomous goals should be `long`: a single wakeup
-should usually deliver code/docs plus validation/writeback, not a small status
-mutation. Interactive UI sessions can present `medium` as a friendlier default
-while still letting advanced users opt into `long` or `ultra-long`.
-
-Preset selection should be explicit in product surfaces:
-
-- connected autonomous goals default to `long`;
-- visible TUI sessions default to `medium` unless the user installs a recurring
-  goal loop;
-- diagnosis, PR review, and gate-heavy work should use `short`;
-- `ultra-long` requires an explicit user/controller opt-in and a current
-  boundary contract that allows the larger segment.
-
-## Signals
-
-The policy should be based on public-safe control-plane signals, not raw
-conversation transcripts or raw local logs:
-
-- `delivery_batch_scale`: whether recent turns were `single_surface`,
-  `multi_surface`, or `implementation`;
-- `delivery_outcome`: whether recent turns produced `primary_goal_outcome`,
-  `outcome_progress`, a blocker, or monitor-only status;
-- small-step streak: consecutive eligible turns that did not produce an
-  implementation, durable design, validated evidence, or blocker;
-- compact turn duration: scheduler-visible elapsed minutes for a completed
-  turn, rounded or bucketed so it does not expose transcripts or local logs;
-- progress granularity: a compact enum such as `status_only`,
-  `single_surface`, `multi_surface`, `implementation_plus_validation`, or
-  `milestone`;
-- validation/writeback ratio: whether artifacts are routinely validated and
-  reflected into active state/history;
-- user-gate projection: whether a higher-priority blocked item is surfaced
-  while lower-priority safe work continues;
-- interface-budget cadence: whether status surfaces remain fresh without
-  turning freshness checks into the main work.
-
-## Too-Small Batch Detection
-
-Each completed eligible heartbeat can contribute one compact sample:
-
-```json
-{
-  "turn_duration_minutes": 11,
-  "progress_granularity": "single_surface",
-  "delivery_batch_scale": "single_surface",
-  "delivery_outcome": "surface_only",
-  "validated_artifact": false,
-  "state_writeback": true
-}
-```
-
-The controller should mark `too_small_heartbeat_batch=true` only when all of
-these are true:
-
-- the goal was eligible and no user/controller gate blocked the selected path;
-- the same preset and boundary contract still apply;
-- the recent streak is below the preset's minimum segment;
-- the turn did not write a hard blocker explaining why widening was unsafe.
-
-For the default `long` preset, the minimum useful batch is
-`implementation_plus_validation_writeback`: one coherent artifact, targeted
-validation, and LoopX writeback. A docs-only batch can still satisfy
-`long` when the selected todo is a durable design contract and the matching
-smoke or public boundary check passes. Status-only refreshes, repeated brief
-checks, and unvalidated single-surface edits should increment the too-small
-streak.
-
-## Controller Behavior
-
-When a goal is eligible and safe, the controller should run a steering audit
-before delivery, then choose one bounded segment at the preset's scale.
-
-If the small-step streak crosses the profile threshold, the next eligible turn
-should widen the minimum segment. For `long`, that means one coherent artifact
-plus targeted validation and state writeback. For `ultra-long`, it can mean a
-larger milestone, but only while the same boundary contract remains valid.
-
-If a high-priority task is blocked and a lower-priority fallback is safe, the
-controller may continue the fallback, but the blocked priority must remain
-visible in quota/status/heartbeat output. The fallback is not allowed to become
-the main story silently.
-
-If the selected action requires a write scope that is missing from
-`goal_boundary.write_scope`, the next action should become boundary projection
-repair or a concrete user/controller gate. Cadence widening must not paper over
-a stale checkpointed decision.
-
-When `too_small_heartbeat_batch=true`, the next eligible turn should widen or
-write a blocker. It should not spend another quota slot on a pure status
-mutation unless the quota guard says monitor-only quiet skip or a user gate is
-the actual state.
+The hint should steer the next turn gently. It must not grant permissions, skip
+gates, authorize destructive git, start production actions, copy private
+material, or expose conversation transcripts, raw local logs, credentials,
+benchmark task text, verifier output, or local absolute paths.
 
 ## Public Fields
 
-A future status/quota projection can carry these compact fields:
+Status and quota may expose this compact projection:
 
 ```json
 {
-  "long_task_cadence": {
-    "schema_version": "long_task_cadence_policy_v0",
-    "cadence_preset": "long",
-    "preset_source": "connected_autonomous_default",
-    "turn_duration_minutes": 11,
-    "progress_granularity": "single_surface",
-    "small_step_streak": 2,
-    "too_small_heartbeat_batch": true,
-    "recommended_batch_granularity": "implementation_plus_validation_writeback",
-    "widen_next_turn": true,
-    "blocked_priority_fallback_visible": true
+  "long_task_cadence_hint": {
+    "schema_version": "cadence_hint_v0",
+    "signal": "thin_progress",
+    "recommendation": "widen",
+    "reason_codes": ["repeated_surface_only"]
   }
 }
 ```
 
-These fields are policy hints. They do not grant permissions and do not replace
-the existing quota, interaction contract, goal boundary, or public/private scan.
+Stable fields:
 
-## Rollout
+| Field | Values | Meaning |
+| --- | --- | --- |
+| `schema_version` | `cadence_hint_v0` | The public projection shape. |
+| `signal` | `blocked`, `thin_progress`, `material_progress`, `unknown` | What the recent control-plane evidence suggests. |
+| `recommendation` | `wait`, `widen`, `keep` | A lightweight host/controller hint. |
+| `reason_codes` | compact strings | Machine-readable explanation for the signal. |
 
-1. Keep the current `execution_profile` fields as the compatibility layer.
-2. Add preset-derived projections to status/quota after the benchmark adapters
-   stop carrying benchmark-specific state shapes.
-3. Teach heartbeat prompts to say when a turn is being widened because recent
-   work was too small.
-4. Move rolling metrics into the future server runner so the product can offer
-   stable "ultra-long / long / medium / short" controls without each agent
-   inventing its own heuristic.
+Typical examples:
 
-The current smoke for this design is
+```json
+{
+  "schema_version": "cadence_hint_v0",
+  "signal": "blocked",
+  "recommendation": "wait",
+  "reason_codes": ["quota_state_operator_gate", "open_user_todos_visible"]
+}
+```
+
+```json
+{
+  "schema_version": "cadence_hint_v0",
+  "signal": "material_progress",
+  "recommendation": "keep",
+  "reason_codes": ["implementation_plus_validation_latest_turn"]
+}
+```
+
+```json
+{
+  "schema_version": "cadence_hint_v0",
+  "signal": "unknown",
+  "recommendation": "keep",
+  "reason_codes": ["missing_recent_runs"]
+}
+```
+
+## How It Is Derived
+
+The hint is derived from existing public-safe control-plane metadata:
+
+- recent run `delivery_batch_scale`, `delivery_outcome`, and
+  `delivery_turn_kind`;
+- the configured execution profile's small-step threshold;
+- quota state;
+- whether open user todos are already visible.
+
+The current "thin progress" detector is deliberately conservative. It is based
+on agent writeback metadata, not a perfect measure of actual agent-loop runtime.
+Elapsed wall time may become an optional future input, but it should not be the
+primary judge: a short validated fix can be valuable, and a long turn can still
+be stuck.
+
+## Controller Use
+
+- `blocked` + `wait`: do not widen; show the concrete gate or blocker.
+- `thin_progress` + `widen`: the next eligible turn should try for a coherent
+  artifact plus validation/writeback, or write a blocker explaining why widening
+  is unsafe.
+- `thin_progress` + `keep`: the latest turn was small, but the streak is not yet
+  strong enough to steer the next turn.
+- `material_progress` + `keep`: recent work produced a broader artifact,
+  validation, or milestone.
+- `unknown` + `keep`: metadata is missing or insufficient; avoid strong
+  automation changes.
+
+The current smoke for this contract is
 `python3 examples/long-task-cadence-policy-smoke.py`.

--- a/docs/reference/protocols/host-integration-surface-v0.md
+++ b/docs/reference/protocols/host-integration-surface-v0.md
@@ -68,7 +68,7 @@ Read methods return compact control facts. They must not return raw session
 logs, raw benchmark task text, raw trajectories, private document bodies,
 credentials, local absolute paths, or host auth material.
 Optional projections such as `task_graph_projection_v0` and
-`long_task_cadence_policy_v0` are read-only inputs to a host integration. They
+`cadence_hint_v0` are read-only inputs to a host integration. They
 do not add graph write authority, change quota gates, or create a new source of
 truth.
 
@@ -109,7 +109,7 @@ hooks, and MCP clients:
     "visible_surface_required": true
   },
   "lifecycle_reads": ["doctor", "status", "quota_should_run", "review_packet"],
-  "projection_inputs": ["task_graph_projection_v0", "long_task_cadence_policy_v0"],
+  "projection_inputs": ["task_graph_projection_v0", "cadence_hint_v0"],
   "write_capabilities": ["todo_lifecycle", "gate_decision"],
   "optional_write_capabilities": ["task_lease_v0_when_shipped"],
   "cli_fallback": {

--- a/examples/host-integration-surface-smoke.py
+++ b/examples/host-integration-surface-smoke.py
@@ -53,7 +53,7 @@ def main() -> int:
             "loopx todo complete",
             "loopx quota spend-slot",
             "task_graph_projection_v0",
-            "long_task_cadence_policy_v0",
+            "cadence_hint_v0",
             "do not add graph write authority",
             "task_lease_v0_when_shipped",
             "Browser/frontstage/server writes remain non-authoritative",

--- a/examples/long-task-cadence-policy-smoke.py
+++ b/examples/long-task-cadence-policy-smoke.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
-"""Smoke-test the long-task cadence policy contract."""
+"""Smoke-test the long-task cadence hint contract."""
 
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 
@@ -12,23 +14,15 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.long_task_cadence import (  # noqa: E402
-    LONG_TASK_CADENCE_SCHEMA_VERSION,
-    build_long_task_cadence_policy,
+    LONG_TASK_CADENCE_HINT_SCHEMA_VERSION,
+    build_long_task_cadence_hint,
 )
+from loopx.quota import build_quota_should_run  # noqa: E402
 
 POLICY_PATH = REPO_ROOT / "docs/long-task-cadence-policy.md"
 DOCS_INDEX = REPO_ROOT / "docs/README.md"
 GETTING_STARTED = REPO_ROOT / "docs/guides/getting-started.md"
 INTERACTION_PATTERN = REPO_ROOT / "docs/interaction-pattern-catalog.md"
-
-PRESETS = ["ultra-long", "long", "medium", "short"]
-GRANULARITIES = [
-    "status_only",
-    "single_surface",
-    "multi_surface",
-    "implementation_plus_validation",
-    "milestone",
-]
 
 
 def read(path: Path) -> str:
@@ -40,7 +34,7 @@ def compact(text: str) -> str:
 
 
 def assert_contains(text: str, needle: str, label: str) -> None:
-    if needle not in text:
+    if needle not in text and needle not in compact(text):
         raise AssertionError(f"{label} missing {needle!r}")
 
 
@@ -51,61 +45,55 @@ def extract_json_block(text: str) -> dict:
     return json.loads(text[body_start:end])
 
 
-def assert_runtime_projection() -> None:
-    recent_runs = [
-        {
-            "generated_at": "2026-06-26T00:02:00Z",
-            "delivery_batch_scale": "single_surface",
-            "delivery_outcome": "surface_only",
-            "delivery_turn_kind": "contract_only_preparation",
-            "duration_s": 660,
-        },
-        {
-            "generated_at": "2026-06-26T00:01:00Z",
-            "delivery_batch_scale": "single_surface",
-            "delivery_outcome": "surface_only",
-            "delivery_turn_kind": "contract_only_preparation",
-            "duration_s": 300,
-        },
-    ]
-    cadence = build_long_task_cadence_policy(
+def single_surface_run() -> dict:
+    return {
+        "generated_at": "2026-06-26T00:02:00Z",
+        "delivery_batch_scale": "single_surface",
+        "delivery_outcome": "surface_only",
+        "delivery_turn_kind": "contract_only_preparation",
+    }
+
+
+def assert_runtime_hint() -> None:
+    recent_runs = [single_surface_run(), single_surface_run()]
+    hint = build_long_task_cadence_hint(
         latest_runs=recent_runs,
         quota_state="eligible",
         user_todo_open_count=1,
     )
-    assert cadence["schema_version"] == LONG_TASK_CADENCE_SCHEMA_VERSION, cadence
-    assert cadence["cadence_preset"] == "long", cadence
-    assert cadence["preset_source"] == "connected_autonomous_default", cadence
-    assert cadence["turn_duration_minutes"] == 11, cadence
-    assert cadence["progress_granularity"] == "single_surface", cadence
-    assert cadence["small_step_streak"] == 2, cadence
-    assert cadence["too_small_heartbeat_batch"] is True, cadence
-    assert cadence["widen_next_turn"] is True, cadence
-    assert cadence["blocked_priority_fallback_visible"] is True, cadence
+    assert hint == {
+        "schema_version": LONG_TASK_CADENCE_HINT_SCHEMA_VERSION,
+        "signal": "thin_progress",
+        "recommendation": "widen",
+        "reason_codes": ["repeated_surface_only"],
+    }, hint
 
-    gated = build_long_task_cadence_policy(
+    gated = build_long_task_cadence_hint(
         latest_runs=recent_runs,
         quota_state="operator_gate",
         user_todo_open_count=1,
     )
-    assert gated["too_small_heartbeat_batch"] is True, gated
-    assert gated["widen_next_turn"] is False, gated
+    assert gated == {
+        "schema_version": LONG_TASK_CADENCE_HINT_SCHEMA_VERSION,
+        "signal": "blocked",
+        "recommendation": "wait",
+        "reason_codes": ["quota_state_operator_gate", "open_user_todos_visible"],
+    }, gated
 
-    custom_profile = {
-        "cadence": "short",
-        "degradation_policy": {"small_scale_streak_threshold": 3},
-    }
-    below_threshold = build_long_task_cadence_policy(
+    custom_profile = {"degradation_policy": {"small_scale_streak_threshold": 3}}
+    below_threshold = build_long_task_cadence_hint(
         execution_profile=custom_profile,
         latest_runs=recent_runs,
         quota_state="eligible",
     )
-    assert below_threshold["cadence_preset"] == "short", below_threshold
-    assert below_threshold["preset_source"] == "execution_profile.cadence", below_threshold
-    assert below_threshold["too_small_heartbeat_batch"] is False, below_threshold
-    assert below_threshold["recommended_batch_granularity"] == "single_surface", below_threshold
+    assert below_threshold == {
+        "schema_version": LONG_TASK_CADENCE_HINT_SCHEMA_VERSION,
+        "signal": "thin_progress",
+        "recommendation": "keep",
+        "reason_codes": ["single_surface_latest_turn"],
+    }, below_threshold
 
-    progress = build_long_task_cadence_policy(
+    material = build_long_task_cadence_hint(
         latest_runs=[
             {
                 "delivery_batch_scale": "implementation",
@@ -115,65 +103,155 @@ def assert_runtime_projection() -> None:
         ],
         quota_state="eligible",
     )
-    assert progress["progress_granularity"] == "milestone", progress
-    assert progress["small_step_streak"] == 0, progress
-    assert progress["widen_next_turn"] is False, progress
+    assert material == {
+        "schema_version": LONG_TASK_CADENCE_HINT_SCHEMA_VERSION,
+        "signal": "material_progress",
+        "recommendation": "keep",
+        "reason_codes": ["milestone_latest_turn"],
+    }, material
+
+    unknown = build_long_task_cadence_hint(latest_runs=[], quota_state="eligible")
+    assert unknown == {
+        "schema_version": LONG_TASK_CADENCE_HINT_SCHEMA_VERSION,
+        "signal": "unknown",
+        "recommendation": "keep",
+        "reason_codes": ["missing_recent_runs"],
+    }, unknown
+
+
+def assert_status_and_quota_projection() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-cadence-hint-") as tmp:
+        root = Path(tmp)
+        runtime = root / "runtime"
+        project = root / "project"
+        registry = project / ".loopx" / "registry.json"
+        state = project / ".codex" / "goals" / "cadence" / "ACTIVE_GOAL_STATE.md"
+        state.parent.mkdir(parents=True)
+        registry.parent.mkdir(parents=True)
+        state.write_text(
+            "\n".join(
+                [
+                    "# Active Goal State",
+                    "",
+                    "- Goal ID: cadence",
+                    "- Status: active",
+                    "- Agent ID: codex-cadence",
+                    "",
+                    "## Objective",
+                    "Validate cadence hint projection.",
+                    "",
+                    "## Latest Run",
+                    "- Run ID: run_thin_2",
+                    "- Agent: codex-cadence",
+                    "- Generated At: 2026-06-26T00:02:00Z",
+                    "- Classification: heartbeat_refresh",
+                    "- Delivery Outcome: surface_only",
+                    "- Delivery Turn Kind: contract_only_preparation",
+                    "- Delivery Batch Scale: single_surface",
+                    "",
+                    "## Run History",
+                    "| run_id | agent | generated_at | classification | delivery_outcome | delivery_turn_kind | delivery_batch_scale | notes |",
+                    "| --- | --- | --- | --- | --- | --- | --- | --- |",
+                    "| run_thin_2 | codex-cadence | 2026-06-26T00:02:00Z | heartbeat_refresh | surface_only | contract_only_preparation | single_surface | state writeback |",
+                    "| run_thin_1 | codex-cadence | 2026-06-26T00:01:00Z | heartbeat_refresh | surface_only | contract_only_preparation | single_surface | state writeback |",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        registry.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "updated_at": "2026-06-26T00:03:00Z",
+                    "common_runtime_root": str(runtime),
+                    "goals": [
+                        {
+                            "id": "cadence",
+                            "domain": "cadence-smoke",
+                            "status": "active",
+                            "repo": str(project),
+                            "state_file": ".codex/goals/cadence/ACTIVE_GOAL_STATE.md",
+                            "agent_id": "codex-cadence",
+                            "coordination": {
+                                "primary_agent": "codex-cadence",
+                                "registered_agents": ["codex-cadence"],
+                            },
+                            "adapter": {
+                                "kind": "cadence_hint_fixture_v0",
+                                "status": "active",
+                            },
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        status = subprocess.check_output(
+            [
+                sys.executable,
+                "-m",
+                "loopx.cli",
+                "--format",
+                "json",
+                "--registry",
+                str(registry),
+                "status",
+            ],
+            cwd=REPO_ROOT,
+            text=True,
+        )
+        status_payload = json.loads(status)
+        item = status_payload["attention_queue"]["items"][0]
+        hint = item["project_asset"]["long_task_cadence_hint"]
+        assert hint["schema_version"] == "cadence_hint_v0", hint
+        assert hint["signal"] == "blocked", hint
+        assert hint["recommendation"] == "wait", hint
+        assert hint["reason_codes"] == ["quota_state_operator_gate"], hint
+
+        quota_payload = build_quota_should_run(
+            status_payload,
+            goal_id="cadence",
+            agent_id="codex-cadence",
+        )
+        assert quota_payload["long_task_cadence_hint"] == hint, quota_payload
 
 
 def main() -> int:
     policy = read(POLICY_PATH)
-    policy_compact = compact(policy)
     docs_index = read(DOCS_INDEX)
     getting_started = read(GETTING_STARTED)
     interaction = read(INTERACTION_PATTERN)
 
-    for preset in PRESETS:
-        assert_contains(policy, f"`{preset}`", "policy preset table")
-
     for required in [
-        "connected autonomous goals default to `long`",
-        "visible TUI sessions default to `medium`",
-        "`ultra-long` requires an explicit user/controller opt-in",
-        "compact turn duration",
-        "progress granularity",
-        "Too-Small Batch Detection",
-        "too_small_heartbeat_batch=true",
-        "implementation_plus_validation_writeback",
-        "validated_artifact",
-        "state_writeback",
-        "blocked_priority_fallback_visible",
-        "They do not grant permissions",
+        "Long-Task Cadence Hint",
+        "not a scheduler policy",
+        "`cadence_hint_v0`",
+        "`blocked`, `thin_progress`, `material_progress`, `unknown`",
+        "`wait`, `widen`, `keep`",
+        "not a perfect measure of actual agent-loop runtime",
+        "conversation transcripts",
+        "raw local logs",
+        "credentials",
+        "local absolute paths",
     ]:
         assert_contains(policy, required, "policy")
 
-    for granularity in GRANULARITIES:
-        assert_contains(policy, granularity, "progress granularity")
-
     projection = extract_json_block(policy)
-    cadence = projection["long_task_cadence"]
-    assert cadence["schema_version"] == "long_task_cadence_policy_v0", cadence
-    assert cadence["cadence_preset"] == "long", cadence
-    assert cadence["preset_source"] == "connected_autonomous_default", cadence
-    assert isinstance(cadence["turn_duration_minutes"], int), cadence
-    assert cadence["progress_granularity"] in GRANULARITIES, cadence
-    assert cadence["small_step_streak"] >= 2, cadence
-    assert cadence["too_small_heartbeat_batch"] is True, cadence
-    assert cadence["widen_next_turn"] is True, cadence
+    hint = projection["long_task_cadence_hint"]
+    assert hint == {
+        "schema_version": "cadence_hint_v0",
+        "signal": "thin_progress",
+        "recommendation": "widen",
+        "reason_codes": ["repeated_surface_only"],
+    }, hint
 
-    for forbidden in [
-        "conversation transcript",
-        "raw local logs",
-        "credentials",
-        "production actions",
-        "still stop or ask",
-    ]:
-        assert_contains(policy_compact, forbidden, "safety boundary")
-
-    assert_contains(docs_index, "Long-task cadence policy", "docs index")
-    assert_contains(getting_started, "Long-task cadence policy", "getting started")
-    assert_contains(interaction, "IP-010 Cadence Widening", "interaction pattern")
-    assert_contains(interaction, "small-step streak", "interaction pattern")
-    assert_runtime_projection()
+    assert_contains(docs_index, "Long-task cadence hint", "docs index")
+    assert_contains(getting_started, "Long-task cadence hint", "getting started")
+    assert_contains(interaction, "IP-010 Cadence Hint", "interaction pattern")
+    assert_contains(interaction, "thin-progress streak", "interaction pattern")
+    assert_runtime_hint()
+    assert_status_and_quota_projection()
 
     print("long-task-cadence-policy-smoke ok")
     return 0

--- a/examples/long-task-cadence-policy-smoke.py
+++ b/examples/long-task-cadence-policy-smoke.py
@@ -4,10 +4,18 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.long_task_cadence import (  # noqa: E402
+    LONG_TASK_CADENCE_SCHEMA_VERSION,
+    build_long_task_cadence_policy,
+)
+
 POLICY_PATH = REPO_ROOT / "docs/long-task-cadence-policy.md"
 DOCS_INDEX = REPO_ROOT / "docs/README.md"
 GETTING_STARTED = REPO_ROOT / "docs/guides/getting-started.md"
@@ -41,6 +49,75 @@ def extract_json_block(text: str) -> dict:
     body_start = text.index("\n", start) + 1
     end = text.index("```", body_start)
     return json.loads(text[body_start:end])
+
+
+def assert_runtime_projection() -> None:
+    recent_runs = [
+        {
+            "generated_at": "2026-06-26T00:02:00Z",
+            "delivery_batch_scale": "single_surface",
+            "delivery_outcome": "surface_only",
+            "delivery_turn_kind": "contract_only_preparation",
+            "duration_s": 660,
+        },
+        {
+            "generated_at": "2026-06-26T00:01:00Z",
+            "delivery_batch_scale": "single_surface",
+            "delivery_outcome": "surface_only",
+            "delivery_turn_kind": "contract_only_preparation",
+            "duration_s": 300,
+        },
+    ]
+    cadence = build_long_task_cadence_policy(
+        latest_runs=recent_runs,
+        quota_state="eligible",
+        user_todo_open_count=1,
+    )
+    assert cadence["schema_version"] == LONG_TASK_CADENCE_SCHEMA_VERSION, cadence
+    assert cadence["cadence_preset"] == "long", cadence
+    assert cadence["preset_source"] == "connected_autonomous_default", cadence
+    assert cadence["turn_duration_minutes"] == 11, cadence
+    assert cadence["progress_granularity"] == "single_surface", cadence
+    assert cadence["small_step_streak"] == 2, cadence
+    assert cadence["too_small_heartbeat_batch"] is True, cadence
+    assert cadence["widen_next_turn"] is True, cadence
+    assert cadence["blocked_priority_fallback_visible"] is True, cadence
+
+    gated = build_long_task_cadence_policy(
+        latest_runs=recent_runs,
+        quota_state="operator_gate",
+        user_todo_open_count=1,
+    )
+    assert gated["too_small_heartbeat_batch"] is True, gated
+    assert gated["widen_next_turn"] is False, gated
+
+    custom_profile = {
+        "cadence": "short",
+        "degradation_policy": {"small_scale_streak_threshold": 3},
+    }
+    below_threshold = build_long_task_cadence_policy(
+        execution_profile=custom_profile,
+        latest_runs=recent_runs,
+        quota_state="eligible",
+    )
+    assert below_threshold["cadence_preset"] == "short", below_threshold
+    assert below_threshold["preset_source"] == "execution_profile.cadence", below_threshold
+    assert below_threshold["too_small_heartbeat_batch"] is False, below_threshold
+    assert below_threshold["recommended_batch_granularity"] == "single_surface", below_threshold
+
+    progress = build_long_task_cadence_policy(
+        latest_runs=[
+            {
+                "delivery_batch_scale": "implementation",
+                "delivery_outcome": "primary_goal_outcome",
+                "delivery_turn_kind": "product_path_execution",
+            }
+        ],
+        quota_state="eligible",
+    )
+    assert progress["progress_granularity"] == "milestone", progress
+    assert progress["small_step_streak"] == 0, progress
+    assert progress["widen_next_turn"] is False, progress
 
 
 def main() -> int:
@@ -96,6 +173,7 @@ def main() -> int:
     assert_contains(getting_started, "Long-task cadence policy", "getting started")
     assert_contains(interaction, "IP-010 Cadence Widening", "interaction pattern")
     assert_contains(interaction, "small-step streak", "interaction pattern")
+    assert_runtime_projection()
 
     print("long-task-cadence-policy-smoke ok")
     return 0

--- a/loopx/long_task_cadence.py
+++ b/loopx/long_task_cadence.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .delivery_batch_scale import DeliveryBatchScale, normalize_delivery_batch_scale
+from .delivery_outcome import (
+    DeliveryOutcome,
+    DeliveryTurnKind,
+    normalize_delivery_outcome,
+    normalize_delivery_turn_kind,
+)
+from .execution_profile import compact_execution_profile, execution_profile_threshold
+
+
+LONG_TASK_CADENCE_SCHEMA_VERSION = "long_task_cadence_policy_v0"
+
+CADENCE_PRESETS = frozenset({"ultra-long", "long", "medium", "short"})
+DEFAULT_CADENCE_PRESET = "long"
+DEFAULT_PRESET_SOURCE = "connected_autonomous_default"
+
+RECOMMENDED_BATCH_GRANULARITY = {
+    "ultra-long": "milestone",
+    "long": "implementation_plus_validation_writeback",
+    "medium": "multi_surface",
+    "short": "single_surface",
+}
+NON_WIDENING_QUOTA_STATES = frozenset(
+    {
+        "blocked",
+        "blocked_health",
+        "focus_wait",
+        "monitor_only",
+        "operator_gate",
+        "paused",
+        "throttled",
+        "user_gate",
+        "waiting",
+    }
+)
+SMALL_PROGRESS_GRANULARITIES = frozenset({"status_only", "single_surface"})
+RUN_DURATION_MINUTE_FIELDS = ("turn_duration_minutes", "duration_minutes", "elapsed_minutes")
+RUN_DURATION_SECOND_FIELDS = ("duration_s", "duration_seconds", "elapsed_s", "elapsed_seconds")
+RUN_DURATION_MILLISECOND_FIELDS = ("duration_ms", "elapsed_ms")
+
+
+def _positive_number(value: Any) -> float | None:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if parsed < 0:
+        return None
+    return parsed
+
+
+def _duration_minutes(run: dict[str, Any]) -> int | None:
+    for field in RUN_DURATION_MINUTE_FIELDS:
+        parsed = _positive_number(run.get(field))
+        if parsed is not None:
+            return max(1, round(parsed))
+    for field in RUN_DURATION_SECOND_FIELDS:
+        parsed = _positive_number(run.get(field))
+        if parsed is not None:
+            return max(1, round(parsed / 60))
+    for field in RUN_DURATION_MILLISECOND_FIELDS:
+        parsed = _positive_number(run.get(field))
+        if parsed is not None:
+            return max(1, round(parsed / 60000))
+    return None
+
+
+def _cadence_preset(profile: dict[str, Any]) -> tuple[str, str]:
+    cadence = str(profile.get("cadence") or "").strip()
+    if cadence in CADENCE_PRESETS:
+        return cadence, "execution_profile.cadence"
+    return DEFAULT_CADENCE_PRESET, DEFAULT_PRESET_SOURCE
+
+
+def _progress_granularity(run: dict[str, Any] | None) -> str:
+    if not isinstance(run, dict) or not run:
+        return "status_only"
+
+    outcome = normalize_delivery_outcome(run.get("delivery_outcome"))
+    turn_kind = normalize_delivery_turn_kind(run.get("delivery_turn_kind"))
+    scale = normalize_delivery_batch_scale(run.get("delivery_batch_scale"))
+
+    if outcome == DeliveryOutcome.PRIMARY_GOAL_OUTCOME:
+        return "milestone"
+    if outcome == DeliveryOutcome.OUTCOME_PROGRESS:
+        return "implementation_plus_validation"
+    if turn_kind == DeliveryTurnKind.PRODUCT_PATH_EXECUTION:
+        return "implementation_plus_validation"
+    if scale == DeliveryBatchScale.IMPLEMENTATION:
+        return "implementation_plus_validation"
+    if scale == DeliveryBatchScale.MULTI_SURFACE or turn_kind == DeliveryTurnKind.COMPACT_EVIDENCE:
+        return "multi_surface"
+    if scale in {DeliveryBatchScale.TEST_ONLY, DeliveryBatchScale.SINGLE_SURFACE}:
+        return "single_surface"
+    if turn_kind == DeliveryTurnKind.CONTRACT_ONLY_PREPARATION:
+        return "single_surface"
+    return "status_only"
+
+
+def _small_step_streak(runs: list[dict[str, Any]]) -> int:
+    streak = 0
+    for run in runs:
+        turn_kind = normalize_delivery_turn_kind(run.get("delivery_turn_kind"))
+        if turn_kind == DeliveryTurnKind.BLOCKER_WRITEBACK:
+            break
+        if _progress_granularity(run) not in SMALL_PROGRESS_GRANULARITIES:
+            break
+        streak += 1
+    return streak
+
+
+def _recent_runs(
+    *,
+    latest_runs: list[dict[str, Any]] | None,
+    handoff_readiness: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    readiness = handoff_readiness if isinstance(handoff_readiness, dict) else {}
+    compact_runs = (
+        readiness.get("post_handoff_recent_runs")
+        if isinstance(readiness.get("post_handoff_recent_runs"), list)
+        else []
+    )
+    if compact_runs:
+        return [run for run in compact_runs if isinstance(run, dict)]
+    latest_run = readiness.get("post_handoff_latest_run")
+    if isinstance(latest_run, dict) and latest_run:
+        return [latest_run]
+    runs = [run for run in latest_runs or [] if isinstance(run, dict)]
+    if runs:
+        return runs
+    return []
+
+
+def build_long_task_cadence_policy(
+    *,
+    execution_profile: dict[str, Any] | None = None,
+    latest_runs: list[dict[str, Any]] | None = None,
+    handoff_readiness: dict[str, Any] | None = None,
+    quota_state: str | None = None,
+    user_todo_open_count: int | None = None,
+) -> dict[str, Any]:
+    """Build a compact, public-safe cadence hint from existing control signals."""
+
+    profile = compact_execution_profile(execution_profile)
+    cadence_preset, preset_source = _cadence_preset(profile)
+    runs = _recent_runs(latest_runs=latest_runs, handoff_readiness=handoff_readiness)
+    latest_run = runs[0] if runs else {}
+    threshold = execution_profile_threshold(profile)
+    small_step_streak = _small_step_streak(runs)
+    too_small = small_step_streak >= threshold
+    normalized_quota_state = str(quota_state or "").strip()
+    blocked_priority_fallback_visible = bool(user_todo_open_count and user_todo_open_count > 0)
+
+    cadence: dict[str, Any] = {
+        "schema_version": LONG_TASK_CADENCE_SCHEMA_VERSION,
+        "cadence_preset": cadence_preset,
+        "preset_source": preset_source,
+        "progress_granularity": _progress_granularity(latest_run),
+        "small_step_streak": small_step_streak,
+        "too_small_heartbeat_batch": too_small,
+        "recommended_batch_granularity": RECOMMENDED_BATCH_GRANULARITY[cadence_preset],
+        "widen_next_turn": too_small
+        and (
+            not normalized_quota_state
+            or normalized_quota_state not in NON_WIDENING_QUOTA_STATES
+        ),
+        "blocked_priority_fallback_visible": blocked_priority_fallback_visible,
+    }
+    duration = _duration_minutes(latest_run)
+    if duration is not None:
+        cadence["turn_duration_minutes"] = duration
+    return cadence
+
+
+def long_task_cadence_summary(value: Any) -> str:
+    if not isinstance(value, dict):
+        return ""
+    duration = value.get("turn_duration_minutes")
+    duration_text = f" duration_min={duration}" if duration is not None else ""
+    return (
+        f"preset={value.get('cadence_preset')} "
+        f"source={value.get('preset_source')} "
+        f"granularity={value.get('progress_granularity')} "
+        f"small_streak={value.get('small_step_streak')} "
+        f"too_small={value.get('too_small_heartbeat_batch')} "
+        f"widen_next={value.get('widen_next_turn')} "
+        f"recommended={value.get('recommended_batch_granularity')} "
+        f"blocked_priority_visible={value.get('blocked_priority_fallback_visible')}"
+        f"{duration_text}"
+    )

--- a/loopx/long_task_cadence.py
+++ b/loopx/long_task_cadence.py
@@ -12,19 +12,9 @@ from .delivery_outcome import (
 from .execution_profile import compact_execution_profile, execution_profile_threshold
 
 
-LONG_TASK_CADENCE_SCHEMA_VERSION = "long_task_cadence_policy_v0"
+LONG_TASK_CADENCE_HINT_SCHEMA_VERSION = "cadence_hint_v0"
 
-CADENCE_PRESETS = frozenset({"ultra-long", "long", "medium", "short"})
-DEFAULT_CADENCE_PRESET = "long"
-DEFAULT_PRESET_SOURCE = "connected_autonomous_default"
-
-RECOMMENDED_BATCH_GRANULARITY = {
-    "ultra-long": "milestone",
-    "long": "implementation_plus_validation_writeback",
-    "medium": "multi_surface",
-    "short": "single_surface",
-}
-NON_WIDENING_QUOTA_STATES = frozenset(
+BLOCKED_QUOTA_STATES = frozenset(
     {
         "blocked",
         "blocked_health",
@@ -38,42 +28,9 @@ NON_WIDENING_QUOTA_STATES = frozenset(
     }
 )
 SMALL_PROGRESS_GRANULARITIES = frozenset({"status_only", "single_surface"})
-RUN_DURATION_MINUTE_FIELDS = ("turn_duration_minutes", "duration_minutes", "elapsed_minutes")
-RUN_DURATION_SECOND_FIELDS = ("duration_s", "duration_seconds", "elapsed_s", "elapsed_seconds")
-RUN_DURATION_MILLISECOND_FIELDS = ("duration_ms", "elapsed_ms")
-
-
-def _positive_number(value: Any) -> float | None:
-    try:
-        parsed = float(value)
-    except (TypeError, ValueError):
-        return None
-    if parsed < 0:
-        return None
-    return parsed
-
-
-def _duration_minutes(run: dict[str, Any]) -> int | None:
-    for field in RUN_DURATION_MINUTE_FIELDS:
-        parsed = _positive_number(run.get(field))
-        if parsed is not None:
-            return max(1, round(parsed))
-    for field in RUN_DURATION_SECOND_FIELDS:
-        parsed = _positive_number(run.get(field))
-        if parsed is not None:
-            return max(1, round(parsed / 60))
-    for field in RUN_DURATION_MILLISECOND_FIELDS:
-        parsed = _positive_number(run.get(field))
-        if parsed is not None:
-            return max(1, round(parsed / 60000))
-    return None
-
-
-def _cadence_preset(profile: dict[str, Any]) -> tuple[str, str]:
-    cadence = str(profile.get("cadence") or "").strip()
-    if cadence in CADENCE_PRESETS:
-        return cadence, "execution_profile.cadence"
-    return DEFAULT_CADENCE_PRESET, DEFAULT_PRESET_SOURCE
+MATERIAL_PROGRESS_GRANULARITIES = frozenset(
+    {"multi_surface", "implementation_plus_validation", "milestone"}
+)
 
 
 def _progress_granularity(run: dict[str, Any] | None) -> str:
@@ -135,7 +92,18 @@ def _recent_runs(
     return []
 
 
-def build_long_task_cadence_policy(
+def _reason_from_granularity(granularity: str) -> str:
+    return f"{granularity}_latest_turn"
+
+
+def _blocked_reason(quota_state: str, user_todo_open_count: int | None) -> list[str]:
+    reasons = [f"quota_state_{quota_state}"]
+    if user_todo_open_count and user_todo_open_count > 0:
+        reasons.append("open_user_todos_visible")
+    return reasons
+
+
+def build_long_task_cadence_hint(
     *,
     execution_profile: dict[str, Any] | None = None,
     latest_runs: list[dict[str, Any]] | None = None,
@@ -143,52 +111,78 @@ def build_long_task_cadence_policy(
     quota_state: str | None = None,
     user_todo_open_count: int | None = None,
 ) -> dict[str, Any]:
-    """Build a compact, public-safe cadence hint from existing control signals."""
+    """Build a small, public-safe cadence hint from existing control signals."""
 
     profile = compact_execution_profile(execution_profile)
-    cadence_preset, preset_source = _cadence_preset(profile)
     runs = _recent_runs(latest_runs=latest_runs, handoff_readiness=handoff_readiness)
     latest_run = runs[0] if runs else {}
     threshold = execution_profile_threshold(profile)
     small_step_streak = _small_step_streak(runs)
-    too_small = small_step_streak >= threshold
     normalized_quota_state = str(quota_state or "").strip()
-    blocked_priority_fallback_visible = bool(user_todo_open_count and user_todo_open_count > 0)
 
-    cadence: dict[str, Any] = {
-        "schema_version": LONG_TASK_CADENCE_SCHEMA_VERSION,
-        "cadence_preset": cadence_preset,
-        "preset_source": preset_source,
-        "progress_granularity": _progress_granularity(latest_run),
-        "small_step_streak": small_step_streak,
-        "too_small_heartbeat_batch": too_small,
-        "recommended_batch_granularity": RECOMMENDED_BATCH_GRANULARITY[cadence_preset],
-        "widen_next_turn": too_small
-        and (
-            not normalized_quota_state
-            or normalized_quota_state not in NON_WIDENING_QUOTA_STATES
-        ),
-        "blocked_priority_fallback_visible": blocked_priority_fallback_visible,
+    if normalized_quota_state in BLOCKED_QUOTA_STATES:
+        return {
+            "schema_version": LONG_TASK_CADENCE_HINT_SCHEMA_VERSION,
+            "signal": "blocked",
+            "recommendation": "wait",
+            "reason_codes": _blocked_reason(normalized_quota_state, user_todo_open_count),
+        }
+
+    if not runs:
+        return {
+            "schema_version": LONG_TASK_CADENCE_HINT_SCHEMA_VERSION,
+            "signal": "unknown",
+            "recommendation": "keep",
+            "reason_codes": ["missing_recent_runs"],
+        }
+
+    granularity = _progress_granularity(latest_run)
+    if granularity in SMALL_PROGRESS_GRANULARITIES:
+        recommendation = "widen" if small_step_streak >= threshold else "keep"
+        reason = "repeated_surface_only" if recommendation == "widen" else _reason_from_granularity(granularity)
+        return {
+            "schema_version": LONG_TASK_CADENCE_HINT_SCHEMA_VERSION,
+            "signal": "thin_progress",
+            "recommendation": recommendation,
+            "reason_codes": [reason],
+        }
+
+    if granularity in MATERIAL_PROGRESS_GRANULARITIES:
+        return {
+            "schema_version": LONG_TASK_CADENCE_HINT_SCHEMA_VERSION,
+            "signal": "material_progress",
+            "recommendation": "keep",
+            "reason_codes": [_reason_from_granularity(granularity)],
+        }
+
+    return {
+        "schema_version": LONG_TASK_CADENCE_HINT_SCHEMA_VERSION,
+        "signal": "unknown",
+        "recommendation": "keep",
+        "reason_codes": [_reason_from_granularity(granularity)],
     }
-    duration = _duration_minutes(latest_run)
-    if duration is not None:
-        cadence["turn_duration_minutes"] = duration
-    return cadence
+
+
+def build_long_task_cadence_policy(**kwargs: Any) -> dict[str, Any]:
+    """Compatibility wrapper for older callers while this projection rolls out."""
+
+    return build_long_task_cadence_hint(**kwargs)
+
+
+def long_task_cadence_hint_summary(value: Any) -> str:
+    if not isinstance(value, dict):
+        return ""
+    reason_codes = value.get("reason_codes")
+    if isinstance(reason_codes, list):
+        reason_text = ",".join(str(reason) for reason in reason_codes)
+    else:
+        reason_text = ""
+    return (
+        f"signal={value.get('signal')} "
+        f"recommendation={value.get('recommendation')} "
+        f"reasons={reason_text}"
+    )
 
 
 def long_task_cadence_summary(value: Any) -> str:
-    if not isinstance(value, dict):
-        return ""
-    duration = value.get("turn_duration_minutes")
-    duration_text = f" duration_min={duration}" if duration is not None else ""
-    return (
-        f"preset={value.get('cadence_preset')} "
-        f"source={value.get('preset_source')} "
-        f"granularity={value.get('progress_granularity')} "
-        f"small_streak={value.get('small_step_streak')} "
-        f"too_small={value.get('too_small_heartbeat_batch')} "
-        f"widen_next={value.get('widen_next_turn')} "
-        f"recommended={value.get('recommended_batch_granularity')} "
-        f"blocked_priority_visible={value.get('blocked_priority_fallback_visible')}"
-        f"{duration_text}"
-    )
+    return long_task_cadence_hint_summary(value)

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -31,6 +31,7 @@ from .execution_profile import (
     execution_profile_summary,
     outcome_floor_threshold,
 )
+from .long_task_cadence import long_task_cadence_summary
 from .orchestration import compact_orchestration_policy, orchestration_policy_summary
 from .state_projection import is_user_wait_text, next_action_projection_warning
 from .todo_contract import (
@@ -6630,6 +6631,15 @@ def build_quota_should_run(
             )
             if project_asset
             else None,
+            "long_task_cadence": (
+                project_asset.get("long_task_cadence")
+                if project_asset and isinstance(project_asset.get("long_task_cadence"), dict)
+                else (
+                    item.get("long_task_cadence")
+                    if isinstance(item.get("long_task_cadence"), dict)
+                    else None
+                )
+            ),
             "handoff_readiness": item.get("handoff_readiness"),
             "heartbeat_recommendation": heartbeat_recommendation,
             "execution_obligation": _execution_obligation(
@@ -8320,6 +8330,13 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
     )
     if execution_profile:
         lines.append(f"- execution_profile: {execution_profile_summary(execution_profile)}")
+    long_task_cadence = (
+        payload.get("long_task_cadence")
+        if isinstance(payload.get("long_task_cadence"), dict)
+        else {}
+    )
+    if long_task_cadence:
+        lines.append(f"- long_task_cadence: {long_task_cadence_summary(long_task_cadence)}")
     control_plane = payload.get("control_plane") if isinstance(payload.get("control_plane"), dict) else None
     if control_plane:
         lines.append(f"- control_plane: {control_plane_policy_summary(control_plane)}")

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -31,7 +31,7 @@ from .execution_profile import (
     execution_profile_summary,
     outcome_floor_threshold,
 )
-from .long_task_cadence import long_task_cadence_summary
+from .long_task_cadence import long_task_cadence_hint_summary
 from .orchestration import compact_orchestration_policy, orchestration_policy_summary
 from .state_projection import is_user_wait_text, next_action_projection_warning
 from .todo_contract import (
@@ -6631,12 +6631,12 @@ def build_quota_should_run(
             )
             if project_asset
             else None,
-            "long_task_cadence": (
-                project_asset.get("long_task_cadence")
-                if project_asset and isinstance(project_asset.get("long_task_cadence"), dict)
+            "long_task_cadence_hint": (
+                project_asset.get("long_task_cadence_hint")
+                if project_asset and isinstance(project_asset.get("long_task_cadence_hint"), dict)
                 else (
-                    item.get("long_task_cadence")
-                    if isinstance(item.get("long_task_cadence"), dict)
+                    item.get("long_task_cadence_hint")
+                    if isinstance(item.get("long_task_cadence_hint"), dict)
                     else None
                 )
             ),
@@ -8330,13 +8330,15 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
     )
     if execution_profile:
         lines.append(f"- execution_profile: {execution_profile_summary(execution_profile)}")
-    long_task_cadence = (
-        payload.get("long_task_cadence")
-        if isinstance(payload.get("long_task_cadence"), dict)
+    long_task_cadence_hint = (
+        payload.get("long_task_cadence_hint")
+        if isinstance(payload.get("long_task_cadence_hint"), dict)
         else {}
     )
-    if long_task_cadence:
-        lines.append(f"- long_task_cadence: {long_task_cadence_summary(long_task_cadence)}")
+    if long_task_cadence_hint:
+        lines.append(
+            f"- long_task_cadence_hint: {long_task_cadence_hint_summary(long_task_cadence_hint)}"
+        )
     control_plane = payload.get("control_plane") if isinstance(payload.get("control_plane"), dict) else None
     if control_plane:
         lines.append(f"- control_plane: {control_plane_policy_summary(control_plane)}")

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -45,7 +45,7 @@ from .handoff_budget import handoff_budget_contract
 from .history import collect_history, load_registry
 from .history import STATUS_NEUTRAL_CLASSIFICATIONS as HISTORY_STATUS_NEUTRAL_CLASSIFICATIONS
 from .interface_budget import interface_budget_cadence_for_runs
-from .long_task_cadence import build_long_task_cadence_policy, long_task_cadence_summary
+from .long_task_cadence import build_long_task_cadence_hint, long_task_cadence_hint_summary
 from .materials import extract_review_materials
 from .operator_gate import DEFAULT_OPERATOR_GATE, default_operator_question, normalize_operator_question
 from .orchestration import compact_orchestration_policy, orchestration_policy_summary
@@ -6859,7 +6859,7 @@ def enrich_project_asset(
             user_todo_open_count = int(project_asset["user_todos"].get("open_count"))
         except (TypeError, ValueError):
             user_todo_open_count = None
-    cadence = build_long_task_cadence_policy(
+    cadence_hint = build_long_task_cadence_hint(
         execution_profile=(
             project_asset.get("execution_profile")
             if isinstance(project_asset.get("execution_profile"), dict)
@@ -6870,8 +6870,8 @@ def enrich_project_asset(
         quota_state=quota_state or None,
         user_todo_open_count=user_todo_open_count,
     )
-    project_asset["long_task_cadence"] = cadence
-    item["long_task_cadence"] = cadence
+    project_asset["long_task_cadence_hint"] = cadence_hint
+    item["long_task_cadence_hint"] = cadence_hint
 
 
 def build_project_asset(
@@ -9712,15 +9712,15 @@ def render_status_markdown(payload: dict[str, Any]) -> str:
                     "    - execution_profile: "
                     f"{_markdown_scalar(execution_profile_summary(asset_execution_profile))}"
                 )
-            long_task_cadence = (
-                project_asset.get("long_task_cadence")
-                if isinstance(project_asset.get("long_task_cadence"), dict)
+            long_task_cadence_hint = (
+                project_asset.get("long_task_cadence_hint")
+                if isinstance(project_asset.get("long_task_cadence_hint"), dict)
                 else None
             )
-            if long_task_cadence:
+            if long_task_cadence_hint:
                 lines.append(
-                    "    - long_task_cadence: "
-                    f"{_markdown_scalar(long_task_cadence_summary(long_task_cadence))}"
+                    "    - long_task_cadence_hint: "
+                    f"{_markdown_scalar(long_task_cadence_hint_summary(long_task_cadence_hint))}"
                 )
             asset_orchestration = (
                 project_asset.get("orchestration")

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -45,6 +45,7 @@ from .handoff_budget import handoff_budget_contract
 from .history import collect_history, load_registry
 from .history import STATUS_NEUTRAL_CLASSIFICATIONS as HISTORY_STATUS_NEUTRAL_CLASSIFICATIONS
 from .interface_budget import interface_budget_cadence_for_runs
+from .long_task_cadence import build_long_task_cadence_policy, long_task_cadence_summary
 from .materials import extract_review_materials
 from .operator_gate import DEFAULT_OPERATOR_GATE, default_operator_question, normalize_operator_question
 from .orchestration import compact_orchestration_policy, orchestration_policy_summary
@@ -6842,6 +6843,35 @@ def enrich_project_asset(
     readiness = project_asset_handoff_readiness(item, latest_runs=latest_runs)
     if readiness:
         item["handoff_readiness"] = readiness
+    quota_state = ""
+    if isinstance(quota, dict):
+        quota_state = str(quota.get("state") or "").strip()
+    if not quota_state and isinstance(project_asset.get("quota"), dict):
+        quota_state = str(project_asset["quota"].get("state") or "").strip()
+    user_todo_open_count = None
+    if isinstance(user_todos, dict):
+        try:
+            user_todo_open_count = int(user_todos.get("open_count"))
+        except (TypeError, ValueError):
+            user_todo_open_count = None
+    elif isinstance(project_asset.get("user_todos"), dict):
+        try:
+            user_todo_open_count = int(project_asset["user_todos"].get("open_count"))
+        except (TypeError, ValueError):
+            user_todo_open_count = None
+    cadence = build_long_task_cadence_policy(
+        execution_profile=(
+            project_asset.get("execution_profile")
+            if isinstance(project_asset.get("execution_profile"), dict)
+            else None
+        ),
+        latest_runs=latest_runs,
+        handoff_readiness=readiness,
+        quota_state=quota_state or None,
+        user_todo_open_count=user_todo_open_count,
+    )
+    project_asset["long_task_cadence"] = cadence
+    item["long_task_cadence"] = cadence
 
 
 def build_project_asset(
@@ -9681,6 +9711,16 @@ def render_status_markdown(payload: dict[str, Any]) -> str:
                 lines.append(
                     "    - execution_profile: "
                     f"{_markdown_scalar(execution_profile_summary(asset_execution_profile))}"
+                )
+            long_task_cadence = (
+                project_asset.get("long_task_cadence")
+                if isinstance(project_asset.get("long_task_cadence"), dict)
+                else None
+            )
+            if long_task_cadence:
+                lines.append(
+                    "    - long_task_cadence: "
+                    f"{_markdown_scalar(long_task_cadence_summary(long_task_cadence))}"
                 )
             asset_orchestration = (
                 project_asset.get("orchestration")


### PR DESCRIPTION
## Summary
- add a shared `long_task_cadence_policy_v0` projection builder from compact delivery/handoff signals
- surface the projection in `loopx status` project assets and `quota should-run` payload/markdown
- extend the long-task cadence smoke to validate runtime behavior, gate-aware `widen_next_turn`, preset derivation, and progress granularity

## Boundary
- read-only projection only; does not change quota decisions, grant permissions, or read raw transcripts/logs
- prefers compact handoff readiness runs when available, falling back to provided compact run samples
- keeps existing benchmark scoring/runner behavior unchanged

## Validation
- `python3 examples/long-task-cadence-policy-smoke.py`
- `python3 -m compileall -q loopx examples/long-task-cadence-policy-smoke.py`
- `git diff --check`
- `python3 -m loopx.cli --format json --registry "$HOME/.codex/loopx/registry.global.json" quota should-run --goal-id loopx-meta --agent-id codex-main-control`
