### PR TITLE
Tune agent-scope wait scheduler progression

### DIFF
--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -663,7 +663,7 @@ host multiplies the applied interval by
 `unchanged_poll_backoff_multiplier` until `max_interval_minutes`. Human gates
 can move to `[30, 60, 120]` after the concrete user todo has been surfaced.
 Agent-scope waits use a more conservative adjustment curve such as
-`[10, 20, 30]`, so a 600-second local tick stays close to the existing
+`[10, 20, 30, 60]`, so a 600-second local tick stays close to the existing
 agent-to-agent interaction cadence before cooling further.
 Each hint also carries `reset_policy.schema_version=scheduler_reset_policy_v0`.
 Hosts should compare `reset_policy.identity_snapshot` across unchanged polls

--- a/examples/codex-cli-local-scheduler-tick-smoke.py
+++ b/examples/codex-cli-local-scheduler-tick-smoke.py
@@ -117,8 +117,8 @@ QUOTA_HINT_FIXTURE = {
         "cadence_class": "agent_scope_wait",
         "local_scheduler": {
             "recommended_interval_minutes": 10,
-            "max_interval_minutes": 30,
-            "example_progression_minutes": [10, 20, 30],
+            "max_interval_minutes": 60,
+            "example_progression_minutes": [10, 20, 30, 60],
             "unchanged_poll_limit": 3,
             "after_limit": "stop_tick_loop",
             "final_quota_replan_check": {"enabled": True},
@@ -237,7 +237,7 @@ def main() -> int:
     assert hinted_tick["launchd"]["reset_token"] == "fixture-reset-001", hinted_tick
     assert hinted_tick["launchd"]["reset_interval_seconds"] == 600, hinted_tick
     assert hinted_tick["launchd"]["reset_policy"]["codex_app_initial_rrule"] == "FREQ=MINUTELY;INTERVAL=10", hinted_tick
-    assert hinted_tick["scheduler_hint"]["local_scheduler"]["example_progression_minutes"] == [10, 20, 30], hinted_tick
+    assert hinted_tick["scheduler_hint"]["local_scheduler"]["example_progression_minutes"] == [10, 20, 30, 60], hinted_tick
     assert hinted_tick["scheduler_hint"]["codex_cli_tui"]["final_quota_replan_check"]["enabled"] is True, hinted_tick
 
     with tempfile.TemporaryDirectory(prefix="loopx-codex-cli-scheduler-tick-") as tmp:
@@ -338,7 +338,7 @@ def main() -> int:
         )
         assert "# Codex CLI Local Scheduler Tick" in cli_markdown, cli_markdown
         assert "scheduler_action: `write_precise_blocker`" in cli_markdown, cli_markdown
-        assert "local_progression_minutes: `[10, 20, 30]`" in cli_markdown, cli_markdown
+        assert "local_progression_minutes: `[10, 20, 30, 60]`" in cli_markdown, cli_markdown
         assert "local_unchanged_poll_limit: `3`" in cli_markdown, cli_markdown
         assert "final_quota_replan_check:" in cli_markdown, cli_markdown
         assert "runs_codex: `False`" in cli_markdown, cli_markdown

--- a/examples/quota-agent-scoped-user-gate-smoke.py
+++ b/examples/quota-agent-scoped-user-gate-smoke.py
@@ -504,7 +504,7 @@ def assert_agent_without_advancement_candidate_enters_scope_wait() -> None:
     assert scheduler["action"] == "backoff_until_reassigned", scheduler
     assert scheduler["codex_app"]["recommended_interval_minutes"] == 10, scheduler
     assert scheduler["codex_app"]["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=10", scheduler
-    assert scheduler["codex_app"]["example_progression_minutes"] == [10, 20, 30], scheduler
+    assert scheduler["codex_app"]["example_progression_minutes"] == [10, 20, 30, 60], scheduler
     assert scheduler["codex_cli_tui"]["unchanged_poll_limit"] == 3, scheduler
     assert scheduler["codex_cli_tui"]["final_quota_replan_check"]["enabled"] is True, scheduler
     assert scheduler["claude_code_loop"]["after_limit"] == "stop_loop", scheduler
@@ -516,6 +516,7 @@ def assert_agent_without_advancement_candidate_enters_scope_wait() -> None:
     assert reset["host_state_key"] == "scheduler_hint.reset_policy.reset_token", reset
     assert reset["codex_app_initial_interval_minutes"] == 10, reset
     assert reset["codex_app_initial_rrule"] == "FREQ=MINUTELY;INTERVAL=10", reset
+    assert reset["profile_snapshot"]["codex_app_max_interval_minutes"] == 60, reset
     assert reset["identity_keys"] == scheduler["unchanged_identity_keys"], reset
     assert reset["identity_snapshot"]["agent_identity.agent_id"] == payload["agent_identity"]["agent_id"], reset
     assert "reset_token_changed" in reset["reset_conditions"], reset

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -4192,8 +4192,9 @@ def _scheduler_hint(payload: dict[str, Any]) -> dict[str, Any]:
         cli_limit: int | None,
         claude_limit: int | None,
         multiplier: int = 2,
+        cadence_progression_override: list[int] | None = None,
     ) -> dict[str, Any]:
-        cadence_progression = [
+        cadence_progression = cadence_progression_override or [
             min(codex_interval * (multiplier**step), codex_max)
             for step in range(3)
         ]
@@ -4369,9 +4370,10 @@ def _scheduler_hint(payload: dict[str, Any]) -> dict[str, Any]:
                 "progress, reassignment, or a current-agent todo"
             ),
             codex_interval=10,
-            codex_max=30,
+            codex_max=60,
             cli_limit=3,
             claude_limit=3,
+            cadence_progression_override=[10, 20, 30, 60],
         )
 
     if (


### PR DESCRIPTION
## Summary
- extend the `agent_scope_wait` scheduler progression to `[10, 20, 30, 60]` with a 60-minute max
- keep other scheduler profiles on their existing generated progression behavior
- update the focused scheduler smokes and quota allocation docs

## Validation
- `python3 examples/quota-agent-scoped-user-gate-smoke.py`
- `python3 examples/codex-cli-local-scheduler-tick-smoke.py`
- `python3 examples/quota-plan-smoke.py`
- `git diff --check origin/main...HEAD`
- `loopx check --scan-path loopx/quota.py --scan-path examples/quota-agent-scoped-user-gate-smoke.py --scan-path examples/codex-cli-local-scheduler-tick-smoke.py --scan-path docs/quota-allocation.md`
- `./scripts/loopx ... quota should-run --goal-id loopx-meta --agent-id codex-side-bypass` confirmed `agent_scope_wait` max/progression is `60` / `[10, 20, 30, 60]`

`loopx check` reported the existing duplicate-index run-history warning only; public boundary scan was clean for the 4 touched files.