### PR TITLE
Allow benchmark helper runtime self-merges

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,13 @@ focused public smokes, do not launch benchmark jobs, do not change scoring or
 runner behavior for an existing benchmark, and do not include temporary probes,
 raw evidence, private state, credentials, local paths, or generated logs.
 
+Benchmark helper/runtime PRs may also be self-merged after owner authorization
+when they are limited to public benchmark helper code, status/runtime
+observation, reducer/closeout plumbing, or benchmark developer workflow support;
+focused smokes or compile checks pass; public/private boundary scans are clean;
+and the PR does not change benchmark scoring, task semantics, leaderboard or
+submission behavior, permission boundaries, or launch new benchmark jobs.
+
 After self-merging, sync local `main`, leave unrelated untracked local artifacts
 alone, and continue with the next safe project batch.
 


### PR DESCRIPTION
## Summary
- document owner-authorized self-merge eligibility for benchmark helper/runtime PRs
- keep validation and public/private boundary requirements explicit
- exclude scoring, task semantics, leaderboard/submission behavior, permission boundary changes, and benchmark job launches

## Validation
- git diff --check
- loopx check --scan-path AGENTS.md