### PR TITLE
Preserve approved review-packet handoff commands

### DIFF
--- a/examples/review-packet-cli-smoke.py
+++ b/examples/review-packet-cli-smoke.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 import tempfile
 from collections.abc import Iterator
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -202,7 +203,7 @@ def approved_command_with_local_paths(root: Path) -> str:
 def append_operator_gate_approval_fixture(root: Path) -> None:
     run_dir = root / "runtime" / "goals" / GOAL_ID / "runs"
     run_dir.mkdir(parents=True, exist_ok=True)
-    generated_at = "2026-01-01T00:01:00+00:00"
+    generated_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
     compact_time = generated_at.replace("-", "").replace(":", "")
     json_path = run_dir / f"{compact_time}-operator-gate.json"
     markdown_path = run_dir / f"{compact_time}-operator-gate.md"
@@ -235,6 +236,18 @@ def append_operator_gate_approval_fixture(root: Path) -> None:
             )
             + "\n"
         )
+
+
+def mark_owner_review_todo_done(root: Path) -> None:
+    state_path = root / "project" / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+    text = state_path.read_text(encoding="utf-8")
+    state_path.write_text(
+        text.replace(
+            "- [ ] Read owner review worksheet first.",
+            "- [x] Read owner review worksheet first.",
+        ),
+        encoding="utf-8",
+    )
 
 
 def run_cli(root: Path, registry_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
@@ -998,7 +1011,7 @@ def main() -> int:
         assert "类型：Controller" in packet, packet
         assert "材料：authority/material: topics=2, materials=4, repositories=2, owner_review_required=1, stale=1, current_authority=1, risk=low（仅脱敏计数；不含内部链接、路径或正文。）" in packet, packet
         assert "待办：Read owner review worksheet first.（先处理/暂缓再判 gate）" in packet, packet
-        assert f"建议判断：先确认待办；完成后：同意 {GOAL_ID} 先做 read-only map dry-run；不授权写入或生产动作。" in packet, packet
+        assert f"建议判断：先确认待办；完成后：同意 {GOAL_ID} 先做只读 controller dry-run；不授权写入或生产动作。" in packet, packet
         assert f"回复：同意 {GOAL_ID} 先做 read-only map dry-run / 暂不同意 + 一句话原因。" in packet, packet
         assert f"--reason-summary '同意 {GOAL_ID} 先做 read-only map dry-run，不授权写入或生产动作'" in packet, packet
         assert "【用户本地 Gate 记录草稿】" in packet, packet
@@ -1127,6 +1140,7 @@ def main() -> int:
             "controller handoff-only subcommand-format json",
         )
 
+        mark_owner_review_todo_done(root)
         append_operator_gate_approval_fixture(root)
         before_files = sorted(path.name for path in run_dir.iterdir())
         approved_markdown_result = run_cli(

--- a/loopx/review_packet.py
+++ b/loopx/review_packet.py
@@ -897,7 +897,11 @@ def project_agent_command(
 ) -> str:
     if kind == "reward":
         return build_history_command(status_payload, goal_id)
-    if isinstance(item, dict) and item.get("agent_command") and kind in {"controller", "codex"}:
+    if (
+        isinstance(item, dict)
+        and item.get("agent_command")
+        and (kind in {"controller", "codex"} or operator_gate_approved_handoff(item, goal))
+    ):
         return str(item.get("agent_command"))
     if kind == "controller":
         return build_read_only_map_command(status_payload, goal_id)
@@ -1115,8 +1119,9 @@ def build_review_packet(
         else None
     )
     stale_latest_run_lines = stale_latest_run_packet_lines(stale_latest_run_warning)
-    command = redact_local_absolute_paths(project_agent_command(status_payload, goal_id, kind, item, goal))
     approved_handoff = operator_gate_approved_handoff(item, goal)
+    command = redact_local_absolute_paths(project_agent_command(status_payload, goal_id, kind, item, goal))
+    effective_kind = "codex" if approved_handoff else kind
     delivery_handoff = connected_delivery_handoff(item, goal) and kind == "codex"
     gate_commands = operator_gate_decision_commands(status_payload, goal_id) if kind == "controller" else {}
     gate_command = gate_commands.get("approve") if gate_commands else None
@@ -1152,7 +1157,7 @@ def build_review_packet(
         "focus_wait": "Focus Wait",
         "evidence": "Evidence",
         "health": "Health",
-    }.get(kind, "Status")
+    }.get(effective_kind, "Status")
     lines = [
         "【LoopX Review Packet】",
         f"目标：{goal_id}",
@@ -1194,7 +1199,7 @@ def build_review_packet(
     return {
         "ok": True,
         "goal_id": goal_id,
-        "kind": kind,
+        "kind": effective_kind,
         "waiting_on": item.get("waiting_on") if isinstance(item, dict) else None,
         "status": item.get("status") if isinstance(item, dict) else goal.get("status") if isinstance(goal, dict) else None,
         "review_url": review_url,


### PR DESCRIPTION
## Summary
- keep approved operator-gate handoffs on the approved agent_command even when the queue item is otherwise status-shaped
- render approved handoffs as Codex packets so JSON and markdown agree with the handoff path
- refresh the Review Packet CLI smoke fixture so open owner todos block handoff first, then a completed todo plus fresh approval exercises the approved handoff path

## Validation
- python3 examples/review-packet-cli-smoke.py
- python3 examples/benchmark-developer-workflow-doc-smoke.py
- python3 examples/install-local-smoke.py
- python3 examples/review-packet-smoke.py
- python3 -m py_compile loopx/review_packet.py
- git diff --check
- loopx check --scan-path loopx/review_packet.py --scan-path examples/review-packet-cli-smoke.py

## Worktree Triage Notes
- The dirty codex/skillsbench-agent-write-gate worktree carried stale diffs for benchmark workflow and self-repair CLI-contract changes that are already present on origin/main.
- Empty hardcopy artifacts are excluded from this PR.
- README/control-plane SVG changes are also already represented on current main and are not included here.

## Merge Policy
This PR includes a small runtime behavior fix, not just benchmark helper/runtime cleanup, so I am not self-merging it without maintainer approval.