### PR TITLE
Raise smoke review threshold to 500 lines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,7 +137,7 @@ dated research note, candidate ranking packet, temporary run review, or
 transitional benchmark decision. Preserve that information in the research doc
 itself, and cover shared invariants with a data-driven aggregate smoke.
 
-When a smoke grows beyond roughly 300 lines, re-check whether it is really one
+When a smoke grows beyond roughly 500 lines, re-check whether it is really one
 test. Prefer splitting reusable logic into product modules and keeping the
 smoke as a thin public behavior check. Large integration smokes are acceptable
 only when they cover a real end-to-end adapter contract that smaller unit tests


### PR DESCRIPTION
## Summary
- update AGENTS smoke retention guidance to re-check smoke structure after roughly 500 lines instead of 300
- preserve the existing guidance to split reusable logic and keep smokes thin

## Validation
- git diff --check
- rg confirmed only the 500-line threshold remains