### PR TITLE
Accept Harbor reducer wrapper in run ledger upsert

### DIFF
--- a/examples/cli-benchmark-run-ledger-command-modularization-smoke.py
+++ b/examples/cli-benchmark-run-ledger-command-modularization-smoke.py
@@ -132,6 +132,41 @@ def main() -> int:
         if upsert_payload["read_boundary"].get("raw_logs_read") is not False:
             raise AssertionError(upsert_payload)
 
+        harbor_wrapper_path = temp_root / "harbor-wrapper.json"
+        harbor_wrapper_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": "harbor_job_result_reducer_v0",
+                    "ok": True,
+                    "compact_benchmark_run": terminal_payload,
+                },
+                ensure_ascii=False,
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        harbor_wrapper_result = run_cli(
+            "--format",
+            "json",
+            "benchmark",
+            "run-ledger-upsert",
+            "--benchmark-run-json",
+            str(harbor_wrapper_path),
+            "--run-ledger-path",
+            str(temp_root / "harbor-wrapper-ledger.json"),
+        )
+        if harbor_wrapper_result.returncode != 0:
+            raise AssertionError(
+                harbor_wrapper_result.stderr or harbor_wrapper_result.stdout
+            )
+        harbor_wrapper_payload = payload_from(harbor_wrapper_result)
+        if harbor_wrapper_payload.get("ok") is not True:
+            raise AssertionError(harbor_wrapper_payload)
+        if harbor_wrapper_payload.get("input_kind") != "harbor_job_result_reducer_v0":
+            raise AssertionError(harbor_wrapper_payload)
+        if harbor_wrapper_payload["read_boundary"].get("raw_logs_read") is not False:
+            raise AssertionError(harbor_wrapper_payload)
+
         post_launch = {
             "schema_version": "terminal_bench_post_launch_materialization_v0",
             "checked": True,

--- a/loopx/cli_commands/benchmark_run_ledger_maintenance.py
+++ b/loopx/cli_commands/benchmark_run_ledger_maintenance.py
@@ -32,6 +32,18 @@ BENCHMARK_RUN_LEDGER_MAINTENANCE_COMMANDS = {
 }
 
 
+def _compact_benchmark_run_input(
+    payload: dict[str, object],
+) -> tuple[dict[str, object] | None, str]:
+    """Return compact benchmark_run_v0 plus the public-safe input kind."""
+
+    if payload.get("schema_version") == "harbor_job_result_reducer_v0":
+        compact = payload.get("compact_benchmark_run")
+        if isinstance(compact, dict):
+            return compact_benchmark_run(compact), "harbor_job_result_reducer_v0"
+    return compact_benchmark_run(payload), "benchmark_run_v0"
+
+
 def render_benchmark_run_ledger_upsert_markdown(payload: dict[str, object]) -> str:
     ledger = (
         payload.get("benchmark_run_ledger")
@@ -294,12 +306,13 @@ def handle_benchmark_run_ledger_maintenance_command(
                 raise ValueError("ledger input JSON must contain an object")
 
             if args.benchmark_run_json:
-                benchmark_run = compact_benchmark_run(run_input)
+                benchmark_run, input_kind = _compact_benchmark_run_input(run_input)
                 if not benchmark_run:
                     raise ValueError(
-                        "--benchmark-run-json did not contain a compactable benchmark_run_v0 object"
+                        "--benchmark-run-json did not contain a compactable "
+                        "benchmark_run_v0 object or harbor_job_result_reducer_v0 "
+                        "wrapper with compact_benchmark_run"
                     )
-                input_kind = "benchmark_run_v0"
             else:
                 benchmark_run = compact_benchmark_post_launch_materialization(
                     run_input


### PR DESCRIPTION
## Summary
- allow `loopx benchmark run-ledger-upsert --benchmark-run-json` to accept `harbor_job_result_reducer_v0` wrapper JSON by unwrapping `compact_benchmark_run`
- preserve existing direct `benchmark_run_v0` and post-launch ingestion behavior
- add focused CLI smoke coverage for wrapper ingestion and compact-only read boundary

## Validation
- `python3 examples/cli-benchmark-run-ledger-command-modularization-smoke.py`
- `python3 -m py_compile loopx/cli_commands/benchmark_run_ledger_maintenance.py examples/cli-benchmark-run-ledger-command-modularization-smoke.py`
- `git diff --check`
- public/private boundary scan on touched files

## Boundary
- benchmark helper/runtime only
- no scoring, task semantics, leaderboard/submission, permission boundary, or benchmark launch behavior changes
- no raw logs, task text, trajectory, verifier output, credentials, private state, generated logs, or local paths committed
