### PR TITLE
Fix refresh-state Next Action default

### DIFF
--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -593,6 +593,11 @@ slice. If the active-state and latest-run actions differ,
 `next_action_projection_warning` asks the executor to explicitly write back the
 intended durable route with `refresh-state --next-action` or keep treating the
 signals as distinct.
+`refresh-state` records `recommended_action_source` so hosts can tell whether a
+run recommendation came from an explicit argument, durable `## Next Action`, an
+Agent Todo compatibility fallback, or the generic default. Dispatch still comes
+from `agent_lane_next_action` / todo projection, not from shared `## Next Action`
+alone.
 When `agent_lane_next_action.selected_by=unclaimed_todo`, the payload marks
 `claim_required_before_work=true`; executors must claim the todo before editing
 or launching delivery work.

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -945,14 +945,21 @@ as Codex-ready work: the controller state changed, and the next agent turn
 should inspect the refreshed active state before continuing.
 If the refresh command was run without `--recommended-action`, the compact
 `recommended_action` should be the first public-safe item from the refreshed
-active state's `## Next Action`, including wrapped continuation lines;
-otherwise it falls back to a generic refresh notice.
+active state's `## Next Action`, including wrapped continuation lines; only when
+that durable section is absent should it fall back to the first open Agent Todo,
+and finally to a generic refresh notice. The record includes
+`recommended_action_source` (`explicit_arg`, `active_state_next_action`,
+`agent_todo_fallback`, or `default_refresh_action`) so consumers can distinguish
+run guidance from durable-state projection and last-resort compatibility
+fallback.
 `--recommended-action` describes the appended run record; it does not rewrite
 the active state's durable `## Next Action`. To intentionally change that
 durable route, run `refresh-state --next-action <public-safe action>`. Status
 projections may expose both `active_state_next_action` and
 `latest_run_recommended_action`; when they differ, `next_action_projection_warning`
 marks the drift instead of silently choosing one as the only truth.
+Executable dispatch should use `agent_lane_next_action` / todo projection rather
+than treating shared `## Next Action` as a per-agent work item.
 
 When a refresh is scoped with `--agent-id`, the run records
 `progress_scope=agent_lane`. This is a side-lane note, not a project-level

--- a/examples/heartbeat-quota-flow-smoke.py
+++ b/examples/heartbeat-quota-flow-smoke.py
@@ -13,6 +13,16 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 GOAL_ID = "heartbeat-flow-main-control"
 LONG_NEXT_ACTION_TAIL = "without truncating the final private-safe boundary sentence."
+EXPECTED_AGENT_TODO_ACTION = "[P1] Run one bounded heartbeat marker and validate the compact result."
+EXPECTED_NEXT_ACTION = (
+    "Run one bounded heartbeat marker, preserve the wrapped next-action "
+    "continuation across more than eight public-safe lines, keep the current "
+    "owner gate context intact, keep the validation context intact, keep the "
+    "quota accounting context intact, keep the project-agent handoff context "
+    "intact, keep the public/private boundary context intact, keep the "
+    "status-queue routing context intact, keep the review packet context "
+    "intact, and finish without truncating the final private-safe boundary sentence."
+)
 
 
 def run_cli(root: Path, *args: str, registry_path: Path, runtime: Path) -> dict:
@@ -545,8 +555,7 @@ def main() -> int:
         )
         assert refresh["ok"] is True, refresh
         assert refresh["appended"] is True, refresh
-        expected_action = "[P1] Run one bounded heartbeat marker and validate the compact result."
-        assert refresh["recommended_action"] == expected_action, refresh
+        assert refresh["recommended_action"] == EXPECTED_NEXT_ACTION, refresh
         assert LONG_NEXT_ACTION_TAIL in " ".join(refresh["state"]["next_action"]), refresh
         assert count_spend_events(runtime) == 0
 
@@ -590,12 +599,17 @@ def main() -> int:
         assert follow_up["status"] == "state_refreshed", follow_up
         assert follow_up["quota"]["spent_slots"] == 1, follow_up
         assert follow_up["quota"]["allowed_slots"] == 2, follow_up
-        expected_action = "[P1] Run one bounded heartbeat marker and validate the compact result."
-        assert follow_up["recommended_action"] == expected_action, follow_up
+        assert follow_up["recommended_action"] == EXPECTED_AGENT_TODO_ACTION, follow_up
+        assert follow_up["active_state_next_action"].startswith(
+            "Run one bounded heartbeat marker, preserve the wrapped next-action"
+        ), follow_up
+        assert follow_up["latest_run_recommended_action"].startswith(
+            "Run one bounded heartbeat marker, preserve the wrapped next-action"
+        ), follow_up
         interaction = follow_up["interaction_contract"]
-        assert interaction["agent_channel"]["primary_action"] == expected_action, interaction
+        assert interaction["agent_channel"]["primary_action"] == EXPECTED_AGENT_TODO_ACTION, interaction
         assert "state_action_projection_warning" not in follow_up, follow_up
-        assert "agent_action=" + expected_action in follow_up["protocol_action_packet"]["summary"], follow_up
+        assert "agent_action=" + EXPECTED_AGENT_TODO_ACTION in follow_up["protocol_action_packet"]["summary"], follow_up
         assert registry_path.read_text(encoding="utf-8") == registry_before
 
     with tempfile.TemporaryDirectory(prefix="loopx-heartbeat-operator-gate-") as tmp:

--- a/examples/heartbeat-quota-flow-smoke.py
+++ b/examples/heartbeat-quota-flow-smoke.py
@@ -556,6 +556,7 @@ def main() -> int:
         assert refresh["ok"] is True, refresh
         assert refresh["appended"] is True, refresh
         assert refresh["recommended_action"] == EXPECTED_NEXT_ACTION, refresh
+        assert refresh["recommended_action_source"] == "active_state_next_action", refresh
         assert LONG_NEXT_ACTION_TAIL in " ".join(refresh["state"]["next_action"]), refresh
         assert count_spend_events(runtime) == 0
 

--- a/examples/next-action-projection-contract-smoke.py
+++ b/examples/next-action-projection-contract-smoke.py
@@ -117,6 +117,20 @@ def main() -> None:
             registry_path, runtime, project, state_path = write_fixture(Path(raw_tmp))
 
             state_refresh.now_local = lambda: "2026-06-22T00:01:00+00:00"
+            implicit_payload = state_refresh.refresh_state_run(
+                registry_path=registry_path,
+                runtime_root_override=str(runtime),
+                goal_id=GOAL_ID,
+                project=project,
+                state_file=None,
+                classification="state_refreshed",
+                recommended_action=None,
+                dry_run=True,
+                sync_global=False,
+            )
+            assert implicit_payload["recommended_action"] == ACTIVE_NEXT_ACTION, implicit_payload
+            assert implicit_payload.get("active_state_next_action_update") is None, implicit_payload
+
             default_payload = state_refresh.refresh_state_run(
                 registry_path=registry_path,
                 runtime_root_override=str(runtime),

--- a/examples/next-action-projection-contract-smoke.py
+++ b/examples/next-action-projection-contract-smoke.py
@@ -23,7 +23,7 @@ UPDATED_RUN_RECOMMENDATION = "Validate the vliw repair slice and then write comp
 SIDE_AGENT_ACTION = "Polish the hosted frontstage public case card."
 
 
-def write_fixture(root: Path) -> tuple[Path, Path, Path, Path]:
+def write_fixture(root: Path, *, include_next_action: bool = True) -> tuple[Path, Path, Path, Path]:
     project = root / "project"
     runtime = root / "runtime"
     state_file = f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
@@ -31,6 +31,12 @@ def write_fixture(root: Path) -> tuple[Path, Path, Path, Path]:
     registry_path = project / ".loopx" / "registry.json"
 
     state_path.parent.mkdir(parents=True)
+    next_action_section = (
+        "## Next Action\n\n"
+        f"- {ACTIVE_NEXT_ACTION}\n\n"
+        if include_next_action
+        else ""
+    )
     state_path.write_text(
         "---\n"
         "status: active\n"
@@ -46,8 +52,7 @@ def write_fixture(root: Path) -> tuple[Path, Path, Path, Path]:
         f"- [ ] [P1] {SIDE_AGENT_ACTION}\n"
         "  <!-- loopx:todo todo_id=todo_side status=open "
         "task_class=advancement_task claimed_by=codex-side-bypass -->\n\n"
-        "## Next Action\n\n"
-        f"- {ACTIVE_NEXT_ACTION}\n\n"
+        f"{next_action_section}"
         "## Progress Ledger\n\n"
         "- Fixture initialized.\n",
         encoding="utf-8",
@@ -129,6 +134,9 @@ def main() -> None:
                 sync_global=False,
             )
             assert implicit_payload["recommended_action"] == ACTIVE_NEXT_ACTION, implicit_payload
+            assert (
+                implicit_payload["recommended_action_source"] == "active_state_next_action"
+            ), implicit_payload
             assert implicit_payload.get("active_state_next_action_update") is None, implicit_payload
 
             default_payload = state_refresh.refresh_state_run(
@@ -143,6 +151,7 @@ def main() -> None:
                 sync_global=False,
             )
             assert default_payload["recommended_action"] == RUN_RECOMMENDATION, default_payload
+            assert default_payload["recommended_action_source"] == "explicit_arg", default_payload
             assert default_payload.get("active_state_next_action_update") is None, default_payload
             assert_state_next_action(state_path, ACTIVE_NEXT_ACTION)
             assert RUN_RECOMMENDATION not in state_text(state_path), state_text(state_path)
@@ -171,6 +180,7 @@ def main() -> None:
                 sync_global=False,
             )
             update = explicit_payload["active_state_next_action_update"]
+            assert explicit_payload["recommended_action_source"] == "explicit_arg", explicit_payload
             assert update["updated"] is True, explicit_payload
             assert update["next_action"] == UPDATED_NEXT_ACTION, explicit_payload
             assert_state_next_action(state_path, UPDATED_NEXT_ACTION)
@@ -199,6 +209,31 @@ def main() -> None:
             assert "latest_run_recommended_action" in status_markdown, status_markdown
             assert "active_state_next_action" in quota_markdown, quota_markdown
             assert "latest_run_recommended_action" in quota_markdown, quota_markdown
+
+        with tempfile.TemporaryDirectory(prefix="loopx-next-action-fallback-") as raw_tmp:
+            registry_path, runtime, project, _state_path = write_fixture(
+                Path(raw_tmp),
+                include_next_action=False,
+            )
+
+            fallback_payload = state_refresh.refresh_state_run(
+                registry_path=registry_path,
+                runtime_root_override=str(runtime),
+                goal_id=GOAL_ID,
+                project=project,
+                state_file=None,
+                classification="state_refreshed",
+                recommended_action=None,
+                dry_run=True,
+                sync_global=False,
+            )
+            assert (
+                fallback_payload["recommended_action"]
+                == "[P0] Validate the primary public PoC control-plane lane."
+            ), fallback_payload
+            assert (
+                fallback_payload["recommended_action_source"] == "agent_todo_fallback"
+            ), fallback_payload
     finally:
         state_refresh.now_local = original_now_local
 

--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -340,9 +340,6 @@ def section_list_items(lines: list[str]) -> list[str]:
 
 
 def derive_recommended_action(state_text: str) -> str:
-    agent_todo_action = first_open_agent_todo_action(state_text)
-    if agent_todo_action:
-        return agent_todo_action
     lines = extract_section_lines(state_text, "Next Action", limit=RECOMMENDED_ACTION_SECTION_LINE_LIMIT)
     for index, line in enumerate(lines):
         action = first_action_item(lines, index)
@@ -353,6 +350,9 @@ def derive_recommended_action(state_text: str) -> str:
         except ValueError:
             continue
         return action
+    agent_todo_action = first_open_agent_todo_action(state_text)
+    if agent_todo_action:
+        return agent_todo_action
     return DEFAULT_REFRESH_ACTION
 
 

--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -27,6 +27,10 @@ from .todo_contract import (
 
 DEFAULT_REFRESH_CLASSIFICATION = "state_refreshed"
 DEFAULT_REFRESH_ACTION = "inspect refreshed active goal state and continue the next bounded progress segment"
+RECOMMENDED_ACTION_SOURCE_EXPLICIT = "explicit_arg"
+RECOMMENDED_ACTION_SOURCE_ACTIVE_NEXT_ACTION = "active_state_next_action"
+RECOMMENDED_ACTION_SOURCE_AGENT_TODO_FALLBACK = "agent_todo_fallback"
+RECOMMENDED_ACTION_SOURCE_DEFAULT = "default_refresh_action"
 AGENT_LANE_PROGRESS_SCOPE = "agent_lane"
 RECOMMENDED_ACTION_SECTION_LINE_LIMIT = 16
 BULLET_PREFIX_RE = re.compile(r"^(?:[-*]\s+|\d+[.)]\s+)")
@@ -339,7 +343,7 @@ def section_list_items(lines: list[str]) -> list[str]:
     return items
 
 
-def derive_recommended_action(state_text: str) -> str:
+def derive_recommended_action_with_source(state_text: str) -> tuple[str, str]:
     lines = extract_section_lines(state_text, "Next Action", limit=RECOMMENDED_ACTION_SECTION_LINE_LIMIT)
     for index, line in enumerate(lines):
         action = first_action_item(lines, index)
@@ -349,11 +353,15 @@ def derive_recommended_action(state_text: str) -> str:
             validate_public_safe_text("derived recommended_action", action)
         except ValueError:
             continue
-        return action
+        return action, RECOMMENDED_ACTION_SOURCE_ACTIVE_NEXT_ACTION
     agent_todo_action = first_open_agent_todo_action(state_text)
     if agent_todo_action:
-        return agent_todo_action
-    return DEFAULT_REFRESH_ACTION
+        return agent_todo_action, RECOMMENDED_ACTION_SOURCE_AGENT_TODO_FALLBACK
+    return DEFAULT_REFRESH_ACTION, RECOMMENDED_ACTION_SOURCE_DEFAULT
+
+
+def derive_recommended_action(state_text: str) -> str:
+    return derive_recommended_action_with_source(state_text)[0]
 
 
 def resolve_goal_state(
@@ -387,6 +395,7 @@ def build_state_refresh_record(
     state_text: str,
     classification: str,
     recommended_action: str,
+    recommended_action_source: str,
     generated_at: str,
     registry_goal: dict[str, Any] | None,
     delivery_batch_scale: str | None = None,
@@ -409,6 +418,7 @@ def build_state_refresh_record(
         "goal_id": goal_id,
         "classification": classification,
         "recommended_action": recommended_action,
+        "recommended_action_source": recommended_action_source,
         "health_check": (
             f"state_file 1/1; registry_goal {1 if registry_goal else 0}/1; "
             f"authority_sources {len(authority_sources)}"
@@ -536,6 +546,7 @@ def render_state_refresh_markdown(payload: dict[str, Any]) -> str:
         [
             "",
             "## Recommended Action",
+            f"- source: `{payload.get('recommended_action_source')}`",
             str(payload.get("recommended_action") or ""),
         ]
     )
@@ -637,7 +648,11 @@ def refresh_state_run(
                 resolved_state_file.write_text(updated_state_text, encoding="utf-8")
             state_text = updated_state_text if state_updated else locked_state_text
 
-    action = recommended_action or derive_recommended_action(state_text)
+    if recommended_action:
+        action = recommended_action
+        recommended_action_source = RECOMMENDED_ACTION_SOURCE_EXPLICIT
+    else:
+        action, recommended_action_source = derive_recommended_action_with_source(state_text)
     validate_public_safe_text("recommended_action", action)
     repair_delta_contract: dict[str, Any] | None = None
     requested_classification = classification
@@ -659,6 +674,7 @@ def refresh_state_run(
         state_text=state_text,
         classification=classification,
         recommended_action=action,
+        recommended_action_source=recommended_action_source,
         generated_at=generated_at,
         registry_goal=registry_goal,
         delivery_batch_scale=normalized_delivery_batch_scale,
@@ -696,6 +712,7 @@ def refresh_state_run(
         "goal_id": safe_goal_id,
         "classification": classification,
         "recommended_action": action,
+        "recommended_action_source": recommended_action_source,
         "health_check": record["health_check"],
         "json_path": str(json_path),
         "markdown_path": str(markdown_path),
@@ -728,6 +745,7 @@ def refresh_state_run(
         "autonomous_replan_recorded_requested": bool(autonomous_replan_recorded),
         "repair_delta_contract": repair_delta_contract,
         "recommended_action": action,
+        "recommended_action_source": recommended_action_source,
         "active_state_next_action_update": active_state_next_action_update,
         "generated_at": generated_at,
         "health_check": record["health_check"],


### PR DESCRIPTION
## Summary
- make refresh-state derive its default recommended_action from durable ## Next Action before falling back to open Agent Todo
- keep quota free to select the runnable Agent Todo while exposing active/latest action projections side by side
- extend Next Action projection and heartbeat quota smokes to cover the contract

## Validation
- python3 -m py_compile loopx/state_refresh.py examples/next-action-projection-contract-smoke.py examples/heartbeat-quota-flow-smoke.py
- python3 examples/next-action-projection-contract-smoke.py
- python3 examples/heartbeat-quota-flow-smoke.py
- python3 examples/delivery-outcome-enum-smoke.py
- python3 -m loopx.cli check --scan-path loopx/state_refresh.py --scan-path examples/next-action-projection-contract-smoke.py --scan-path examples/heartbeat-quota-flow-smoke.py
- git diff --check

Note: loopx check reported the existing loopx-meta duplicate index warning (raw=5671 unique=5667); public boundary scan was clean.