### PR TITLE
Add agent lane frontier hint contract

### DIFF
--- a/examples/quota-cleared-blocker-successor-gate-smoke.py
+++ b/examples/quota-cleared-blocker-successor-gate-smoke.py
@@ -232,6 +232,15 @@ def assert_cleared_blocker_requires_successor_replan() -> None:
     assert frontier["quiet_noop_allowed"] is False, frontier
     assert frontier["cleared_without_successor_handoff_gates"][0]["todo_id"] == "todo_review_gate", frontier
     assert frontier["cleared_without_successor_handoff_gates"][0]["gate_state"] == "cleared_without_successor", frontier
+    hint = payload["agent_lane_frontier_hint"]
+    assert hint["schema_version"] == "agent_lane_frontier_hint_v0", hint
+    assert hint["decision"] == "record_no_followup", hint
+    assert hint["source"] == "agent_scope_frontier", hint
+    assert hint["reason_code"] == "cleared_handoff_without_successor", hint
+    assert hint["target_todo_id"] == "todo_review_gate", hint
+    assert hint["quiet_noop_allowed"] is False, hint
+    assert "loopx todo complete" in hint["next_cli_action"], hint
+    assert frontier["frontier_hint"] == hint, frontier
     assert (
         payload["agent_todo_summary"]["current_agent_cleared_without_successor_handoff_count"] == 1
     ), payload

--- a/examples/status-markdown-smoke.py
+++ b/examples/status-markdown-smoke.py
@@ -1444,6 +1444,107 @@ def assert_status_agent_lane_next_action_projection() -> None:
     assert f"asset_agent_todo: {primary_action} claimed_by=codex-main-control scope=goal_all_agents" in markdown, markdown
 
 
+def assert_status_agent_lane_frontier_hint_projection() -> None:
+    goal_id = "agent-lane-frontier-status-fixture"
+    primary_action = "[P0] Continue the primary controller benchmark route."
+    primary_todo = {
+        "schema_version": "todo_item_v0",
+        "todo_id": "todo_primary_route",
+        "index": 1,
+        "role": "agent",
+        "status": "open",
+        "priority": "P0",
+        "task_class": "advancement_task",
+        "claimed_by": "codex-main-control",
+        "text": primary_action,
+    }
+    agent_todos = {
+        "schema_version": "todo_summary_v0",
+        "open_count": 1,
+        "done_count": 0,
+        "total_count": 1,
+        "first_open_items": [primary_todo],
+        "items": [primary_todo],
+    }
+    coordination = {
+        "primary_agent": "codex-main-control",
+        "registered_agents": ["codex-main-control", "codex-side-bypass"],
+    }
+    payload = {
+        "ok": True,
+        "registry": "./fixtures/registry.json",
+        "runtime_root": "./fixtures/runtime",
+        "goal_count": 1,
+        "run_count": 1,
+        "contract": {"ok": True, "summary": {"errors": 0, "warnings": 0, "checks": 0}},
+        "global_registry": {"available": False, "summary": {}},
+        "attention_queue": {
+            "available": True,
+            "item_count": 1,
+            "items": [
+                {
+                    "goal_id": goal_id,
+                    "status": "primary_route_active",
+                    "waiting_on": "codex",
+                    "severity": "action",
+                    "recommended_action": primary_action,
+                    "source": "registry",
+                    "coordination": coordination,
+                    "quota": {
+                        "state": "eligible",
+                        "compute": 1.0,
+                        "window_hours": 24,
+                        "slot_minutes": 1,
+                        "allowed_slots": 10,
+                    },
+                    "agent_todos": agent_todos,
+                    "project_asset": {
+                        "owner": "codex-main-control",
+                        "gate": "none",
+                        "stop_condition": "stop on unsafe workspace or user gate",
+                        "next_action": primary_action,
+                        "agent_todos": project_asset_todo_summary(agent_todos, role="agent"),
+                    },
+                }
+            ],
+        },
+        "run_history": {
+            "goals": [
+                {
+                    "id": goal_id,
+                    "registry_member": True,
+                    "status": "primary_route_active",
+                    "coordination": coordination,
+                    "quota": {
+                        "compute": 1.0,
+                        "window_hours": 24,
+                        "slot_minutes": 1,
+                        "allowed_slots": 10,
+                    },
+                }
+            ]
+        },
+    }
+    attach_agent_lane_next_actions(payload, agent_id="codex-side-bypass")
+    item = payload["attention_queue"]["items"][0]
+    assert "agent_lane_next_action" not in item, item
+    frontier = item["agent_scope_frontier"]
+    assert frontier["action"] == "agent_scope_wait", frontier
+    hint = item["agent_lane_frontier_hint"]
+    assert hint["schema_version"] == "agent_lane_frontier_hint_v0", hint
+    assert hint["decision"] == "quiet_noop_blocker", hint
+    assert hint["source"] == "agent_scope_frontier", hint
+    assert hint["target_todo_id"] == "todo_primary_route", hint
+    projection = payload["agent_lane_next_action_projection"]
+    assert projection["attached_count"] == 0, projection
+    assert projection["frontier_attached_count"] == 1, projection
+    assert projection["frontier_hint_attached_count"] == 1, projection
+    markdown = render_status_markdown(payload)
+    assert "agent_lane_frontier_hint: agent=codex-side-bypass" in markdown, markdown
+    assert "decision=quiet_noop_blocker" in markdown, markdown
+    assert "target_todo_id=todo_primary_route" in markdown, markdown
+
+
 def assert_quota_should_run(
     payload: dict,
     *,
@@ -2261,6 +2362,7 @@ def main() -> int:
     assert_promotion_readiness_full_scan_fallback()
     assert_promotion_readiness_warning_in_quota_guard()
     assert_status_agent_lane_next_action_projection()
+    assert_status_agent_lane_frontier_hint_projection()
     print("status-markdown-smoke ok")
     return 0
 

--- a/examples/work-lane-contract-smoke.py
+++ b/examples/work-lane-contract-smoke.py
@@ -1159,6 +1159,14 @@ def assert_side_agent_waits_when_only_other_agent_has_claimed_work() -> None:
     assert frontier["candidate_counts"]["unclaimed_advancement_count"] == 0, frontier
     assert frontier["candidate_counts"]["other_agent_claimed_advancement_count"] == 1, frontier
     assert frontier["other_claimants"] == ["codex-main-control"], frontier
+    hint = guard["agent_lane_frontier_hint"]
+    assert hint["schema_version"] == "agent_lane_frontier_hint_v0", hint
+    assert hint["decision"] == "quiet_noop_blocker", hint
+    assert hint["source"] == "agent_scope_frontier", hint
+    assert hint["reason_code"] == "blocked_by_other_agent_frontier", hint
+    assert hint["target_todo_id"] == "todo_primary_suite", hint
+    assert hint["quiet_noop_allowed"] is True, hint
+    assert frontier["frontier_hint"] == hint, frontier
     assert "codex-side-bypass" in guard["recommended_action"], guard
     assert "codex-main-control" in guard["recommended_action"], guard
     assert "SWE-Marathon" not in guard["recommended_action"], guard
@@ -1176,6 +1184,7 @@ def assert_side_agent_waits_when_only_other_agent_has_claimed_work() -> None:
     assert "codex-side-bypass has no current/unclaimed" in contract["user_channel"]["reason"], contract
     markdown = render_quota_should_run_markdown(guard)
     assert "agent_scope_frontier: action=agent_scope_wait" in markdown, markdown
+    assert "agent_lane_frontier_hint: decision=quiet_noop_blocker" in markdown, markdown
     assert "quiet_noop_allowed=True" in markdown, markdown
 
 
@@ -1415,6 +1424,14 @@ def assert_side_agent_replans_when_deferred_successor_is_ready() -> None:
     assert frontier["quiet_noop_allowed"] is False, frontier
     assert frontier["requires_replan"] is True, frontier
     assert frontier["deferred_resume_candidates"][0]["todo_id"] == "todo_issue_surface_deferred", frontier
+    hint = guard["agent_lane_frontier_hint"]
+    assert hint["schema_version"] == "agent_lane_frontier_hint_v0", hint
+    assert hint["decision"] == "add_next_advancement", hint
+    assert hint["source"] == "agent_scope_frontier", hint
+    assert hint["reason_code"] == "successor_replan_required", hint
+    assert hint["target_todo_id"] == "todo_issue_surface_deferred", hint
+    assert hint["quiet_noop_allowed"] is False, hint
+    assert frontier["frontier_hint"] == hint, frontier
     assert guard["agent_todo_summary"]["current_agent_deferred_resume_count"] == 1, guard
     obligation = guard["execution_obligation"]
     assert obligation["kind"] == "successor_replan_required", obligation
@@ -1430,6 +1447,7 @@ def assert_side_agent_replans_when_deferred_successor_is_ready() -> None:
     assert guard["automation_liveness"]["automation_action"] == "execute_bounded_work", guard
     markdown = render_quota_should_run_markdown(guard)
     assert "agent_scope_frontier: action=successor_replan_required" in markdown, markdown
+    assert "agent_lane_frontier_hint: decision=add_next_advancement" in markdown, markdown
     assert "agent_scope_deferred_resume_candidates" in markdown, markdown
 
 
@@ -1478,6 +1496,16 @@ def assert_side_agent_can_take_unclaimed_work() -> None:
     assert next_action["todo_id"] == "todo_unclaimed_frontstage", guard
     assert next_action["selected_by"] == "unclaimed_todo", guard
     assert next_action["claim_required_before_work"] is True, guard
+    hint = guard["agent_lane_frontier_hint"]
+    assert hint["schema_version"] == "agent_lane_frontier_hint_v0", hint
+    assert hint["decision"] == "claim_unowned_in_scope", hint
+    assert hint["source"] == "agent_lane_next_action", hint
+    assert hint["reason_code"] == "unclaimed_advancement_selected", hint
+    assert hint["target_todo_id"] == "todo_unclaimed_frontstage", hint
+    assert hint["quiet_noop_allowed"] is False, hint
+    assert "loopx todo claim" in hint["next_cli_action"], hint
+    markdown = render_quota_should_run_markdown(guard)
+    assert "agent_lane_frontier_hint: decision=claim_unowned_in_scope" in markdown, markdown
 
 
 def assert_agent_lane_next_action_prefers_capability_repair_candidate() -> None:

--- a/loopx/cli_commands/status.py
+++ b/loopx/cli_commands/status.py
@@ -250,6 +250,8 @@ def attach_agent_lane_next_actions(payload: dict[str, object], *, agent_id: str)
     if not isinstance(items, list):
         return payload
     attached = 0
+    frontier_attached = 0
+    hint_attached = 0
     for item in items:
         if not isinstance(item, dict):
             continue
@@ -261,18 +263,37 @@ def attach_agent_lane_next_actions(payload: dict[str, object], *, agent_id: str)
         except Exception:
             continue
         next_action = guard.get("agent_lane_next_action")
-        if not isinstance(next_action, dict):
-            continue
-        item["agent_lane_next_action"] = next_action
         project_asset = item.get("project_asset")
-        if isinstance(project_asset, dict):
-            project_asset["agent_lane_next_action"] = next_action
-        attached += 1
-    if attached:
+        changed = False
+        if isinstance(next_action, dict):
+            item["agent_lane_next_action"] = next_action
+            if isinstance(project_asset, dict):
+                project_asset["agent_lane_next_action"] = next_action
+            attached += 1
+            changed = True
+        frontier = guard.get("agent_scope_frontier")
+        if isinstance(frontier, dict):
+            item["agent_scope_frontier"] = frontier
+            if isinstance(project_asset, dict):
+                project_asset["agent_scope_frontier"] = frontier
+            frontier_attached += 1
+            changed = True
+        frontier_hint = guard.get("agent_lane_frontier_hint")
+        if isinstance(frontier_hint, dict):
+            item["agent_lane_frontier_hint"] = frontier_hint
+            if isinstance(project_asset, dict):
+                project_asset["agent_lane_frontier_hint"] = frontier_hint
+            hint_attached += 1
+            changed = True
+        if not changed:
+            continue
+    if attached or frontier_attached or hint_attached:
         payload["agent_lane_next_action_projection"] = {
             "schema_version": "agent_lane_next_action_projection_v0",
             "agent_id": safe_agent_id,
             "attached_count": attached,
+            "frontier_attached_count": frontier_attached,
+            "frontier_hint_attached_count": hint_attached,
             "preserves_goal_next_action": True,
         }
     return payload

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -156,6 +156,7 @@ AGENT_CLAIM_SCOPE_SCHEMA_VERSION = "agent_claim_scope_v0"
 SIDE_AGENT_CLAIM_SCOPE_SCHEMA_VERSION = AGENT_CLAIM_SCOPE_SCHEMA_VERSION
 AGENT_LANE_NEXT_ACTION_SCHEMA_VERSION = "agent_lane_next_action_v0"
 AGENT_SCOPE_FRONTIER_SCHEMA_VERSION = "agent_scope_frontier_v0"
+AGENT_LANE_FRONTIER_HINT_SCHEMA_VERSION = "agent_lane_frontier_hint_v0"
 
 
 class AgentScopeFrontierAction(str, Enum):
@@ -163,6 +164,13 @@ class AgentScopeFrontierAction(str, Enum):
     AGENT_SCOPE_WAIT = "agent_scope_wait"
     REASSIGNMENT_REQUIRED = "reassignment_required"
     SUCCESSOR_REPLAN_REQUIRED = "successor_replan_required"
+
+
+class AgentLaneFrontierHintDecision(str, Enum):
+    CLAIM_UNOWNED_IN_SCOPE = "claim_unowned_in_scope"
+    ADD_NEXT_ADVANCEMENT = "add_next_advancement"
+    RECORD_NO_FOLLOWUP = "record_no_followup"
+    QUIET_NOOP_BLOCKER = "quiet_noop_blocker"
 
 
 DEFAULT_AVAILABLE_CAPABILITIES = (
@@ -2549,6 +2557,157 @@ def _agent_scope_frontier_action(value: Any) -> AgentScopeFrontierAction | None:
         return AgentScopeFrontierAction(str(value or ""))
     except ValueError:
         return None
+
+
+def _first_compact_todo_id(items: Any) -> str | None:
+    if not isinstance(items, list):
+        return None
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        todo_id = normalize_todo_id(item.get("todo_id"))
+        if todo_id:
+            return todo_id
+    return None
+
+
+def _agent_lane_frontier_hint(
+    *,
+    goal_id: str,
+    agent_identity: dict[str, Any] | None,
+    agent_todo_summary: dict[str, Any] | None,
+    agent_lane_next_action: dict[str, Any] | None,
+    agent_scope_frontier: dict[str, Any] | None,
+    work_lane_contract: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    if not isinstance(agent_identity, dict) or agent_identity.get("role") != "side-agent":
+        return None
+    agent_id = normalize_todo_claimed_by(agent_identity.get("agent_id"))
+    if not agent_id:
+        return None
+    primary_agent = normalize_todo_claimed_by(agent_identity.get("primary_agent"))
+
+    def build_hint(
+        decision: AgentLaneFrontierHintDecision,
+        *,
+        source: str,
+        reason_code: str,
+        target_todo_id: str | None = None,
+        quiet_noop_allowed: bool,
+        next_cli_action: str | None = None,
+    ) -> dict[str, Any]:
+        hint: dict[str, Any] = {
+            "schema_version": AGENT_LANE_FRONTIER_HINT_SCHEMA_VERSION,
+            "decision": decision.value,
+            "agent_id": agent_id,
+            "primary_agent": primary_agent,
+            "source": source,
+            "reason_code": reason_code,
+            "quiet_noop_allowed": quiet_noop_allowed,
+            "uses_structured_frontier": True,
+        }
+        if target_todo_id:
+            hint["target_todo_id"] = target_todo_id
+        if next_cli_action:
+            hint["next_cli_action"] = next_cli_action
+        return hint
+
+    if isinstance(agent_lane_next_action, dict):
+        selected_by = str(agent_lane_next_action.get("selected_by") or "")
+        claim_required = agent_lane_next_action.get("claim_required_before_work") is True
+        target_todo_id = normalize_todo_id(agent_lane_next_action.get("todo_id"))
+        if selected_by == "unclaimed_todo" or claim_required:
+            action = None
+            if target_todo_id:
+                action = (
+                    f"loopx todo claim --goal-id {goal_id} --todo-id {target_todo_id} "
+                    f"--claimed-by {agent_id}"
+                )
+            return build_hint(
+                AgentLaneFrontierHintDecision.CLAIM_UNOWNED_IN_SCOPE,
+                source="agent_lane_next_action",
+                reason_code="unclaimed_advancement_selected",
+                target_todo_id=target_todo_id,
+                quiet_noop_allowed=False,
+                next_cli_action=action,
+            )
+
+    frontier = agent_scope_frontier if isinstance(agent_scope_frontier, dict) else {}
+    frontier_action = _agent_scope_frontier_action(frontier.get("action"))
+    if frontier_action == AgentScopeFrontierAction.SUCCESSOR_REPLAN_REQUIRED:
+        cleared_todo_id = _first_compact_todo_id(
+            frontier.get("cleared_without_successor_handoff_gates")
+        )
+        if cleared_todo_id:
+            return build_hint(
+                AgentLaneFrontierHintDecision.RECORD_NO_FOLLOWUP,
+                source="agent_scope_frontier",
+                reason_code="cleared_handoff_without_successor",
+                target_todo_id=cleared_todo_id,
+                quiet_noop_allowed=False,
+                next_cli_action=(
+                    f"loopx todo complete --goal-id {goal_id} --todo-id {cleared_todo_id} "
+                    "--no-follow-up --evidence '<public-safe rationale>'"
+                ),
+            )
+        deferred_todo_id = _first_compact_todo_id(frontier.get("deferred_resume_candidates"))
+        return build_hint(
+            AgentLaneFrontierHintDecision.ADD_NEXT_ADVANCEMENT,
+            source="agent_scope_frontier",
+            reason_code="successor_replan_required",
+            target_todo_id=deferred_todo_id,
+            quiet_noop_allowed=False,
+        )
+
+    if frontier_action in {
+        AgentScopeFrontierAction.AGENT_SCOPE_WAIT,
+        AgentScopeFrontierAction.REASSIGNMENT_REQUIRED,
+    }:
+        blocker_todo_id = _first_compact_todo_id(frontier.get("blocking_handoff_gates"))
+        if not blocker_todo_id:
+            blocker_todo_id = _first_compact_todo_id(frontier.get("other_agent_claimed_items"))
+        if blocker_todo_id:
+            return build_hint(
+                AgentLaneFrontierHintDecision.QUIET_NOOP_BLOCKER,
+                source="agent_scope_frontier",
+                reason_code="blocked_by_other_agent_frontier",
+                target_todo_id=blocker_todo_id,
+                quiet_noop_allowed=True,
+            )
+        return build_hint(
+            AgentLaneFrontierHintDecision.ADD_NEXT_ADVANCEMENT,
+            source="agent_scope_frontier",
+            reason_code="no_current_agent_advancement_todo",
+            quiet_noop_allowed=True,
+        )
+
+    if frontier_action == AgentScopeFrontierAction.AGENT_SCOPE_EXHAUSTED:
+        return build_hint(
+            AgentLaneFrontierHintDecision.ADD_NEXT_ADVANCEMENT,
+            source="agent_scope_frontier",
+            reason_code="agent_scope_exhausted",
+            quiet_noop_allowed=True,
+        )
+
+    if not isinstance(agent_todo_summary, dict):
+        return None
+    current_advancement_count = int(
+        agent_todo_summary.get("current_agent_claimed_advancement_count") or 0
+    )
+    current_monitor_count = int(agent_todo_summary.get("current_agent_claimed_monitor_count") or 0)
+    unclaimed_count = _count_advancement_items(
+        agent_todo_summary.get("unclaimed_priority_open_items"),
+        claimed_by="__unclaimed__",
+    )
+    lane = str(work_lane_contract.get("lane") or "") if isinstance(work_lane_contract, dict) else ""
+    if current_advancement_count == 0 and unclaimed_count == 0 and current_monitor_count > 0:
+        return build_hint(
+            AgentLaneFrontierHintDecision.QUIET_NOOP_BLOCKER,
+            source="agent_todo_summary",
+            reason_code="only_current_agent_monitor_work_remains",
+            quiet_noop_allowed=lane != TODO_TASK_CLASS_ADVANCEMENT,
+        )
+    return None
 
 
 def _agent_scope_deferred_resume_candidates(
@@ -6545,6 +6704,16 @@ def build_quota_should_run(
             work_lane_contract=work_lane_contract,
             candidate_should_run=bool(should_run and normal_delivery_allowed),
         )
+        agent_lane_frontier_hint = _agent_lane_frontier_hint(
+            goal_id=safe_goal_id,
+            agent_identity=agent_identity,
+            agent_todo_summary=agent_todo_summary,
+            agent_lane_next_action=agent_lane_next_action,
+            agent_scope_frontier=agent_scope_frontier,
+            work_lane_contract=work_lane_contract,
+        )
+        if agent_scope_frontier and agent_lane_frontier_hint:
+            agent_scope_frontier["frontier_hint"] = agent_lane_frontier_hint
         if agent_scope_frontier:
             frontier_action = str(agent_scope_frontier.get("effective_action") or "")
             successor_replan_required = (
@@ -6686,6 +6855,8 @@ def build_quota_should_run(
             payload["agent_identity"] = agent_identity
         if agent_lane_next_action:
             payload["agent_lane_next_action"] = agent_lane_next_action
+        if agent_lane_frontier_hint:
+            payload["agent_lane_frontier_hint"] = agent_lane_frontier_hint
         if agent_scope_frontier:
             payload["agent_scope_frontier"] = agent_scope_frontier
         if workspace_guard:
@@ -8005,6 +8176,19 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
         )
         if agent_lane_next_action.get("text"):
             lines.append(f"- agent_lane_next_action_text: {agent_lane_next_action.get('text')}")
+    agent_lane_frontier_hint = (
+        payload.get("agent_lane_frontier_hint")
+        if isinstance(payload.get("agent_lane_frontier_hint"), dict)
+        else {}
+    )
+    if agent_lane_frontier_hint:
+        lines.append(
+            "- agent_lane_frontier_hint: "
+            f"decision={agent_lane_frontier_hint.get('decision')} "
+            f"source={agent_lane_frontier_hint.get('source')} "
+            f"reason_code={agent_lane_frontier_hint.get('reason_code')} "
+            f"target_todo_id={agent_lane_frontier_hint.get('target_todo_id')}"
+        )
     agent_scope_frontier = (
         payload.get("agent_scope_frontier")
         if isinstance(payload.get("agent_scope_frontier"), dict)

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -9633,6 +9633,13 @@ def render_status_markdown(payload: dict[str, Any]) -> str:
             if isinstance(item.get("agent_lane_next_action"), dict)
             else {}
         )
+        agent_lane_frontier_hint = (
+            project_asset.get("agent_lane_frontier_hint")
+            if isinstance(project_asset.get("agent_lane_frontier_hint"), dict)
+            else item.get("agent_lane_frontier_hint")
+            if isinstance(item.get("agent_lane_frontier_hint"), dict)
+            else {}
+        )
         goal_todo_scope_suffix = " scope=goal_all_agents" if agent_lane_next_action else ""
         lines.append(
             "  - project_asset_source: "
@@ -9687,6 +9694,15 @@ def render_status_markdown(payload: dict[str, Any]) -> str:
                     "    - current_agent_todo: "
                     f"agent={agent} todo_id={todo_id} selected_by={selected_by} "
                     f"confidence={confidence} source=agent_lane_next_action action={action}"
+                )
+            if agent_lane_frontier_hint:
+                lines.append(
+                    "    - agent_lane_frontier_hint: "
+                    f"agent={_markdown_scalar(agent_lane_frontier_hint.get('agent_id') or '')} "
+                    f"decision={_markdown_scalar(agent_lane_frontier_hint.get('decision') or '')} "
+                    f"source={_markdown_scalar(agent_lane_frontier_hint.get('source') or '')} "
+                    f"reason_code={_markdown_scalar(agent_lane_frontier_hint.get('reason_code') or '')} "
+                    f"target_todo_id={_markdown_scalar(agent_lane_frontier_hint.get('target_todo_id') or '')}"
                 )
             dreaming_lane_badge = (
                 project_asset.get("dreaming_lane_badge")


### PR DESCRIPTION
## Summary
- add an enum-style agent_lane_frontier_hint to quota should-run for side-agent lane frontiers
- project the hint through status attachment and markdown so heartbeat/dashboard consumers do not parse prose
- cover claim_unowned_in_scope, add_next_advancement, record_no_followup, and quiet_noop_blocker with focused public smokes

## Validation
- python3 -m py_compile loopx/quota.py loopx/cli_commands/status.py loopx/status.py examples/work-lane-contract-smoke.py examples/quota-cleared-blocker-successor-gate-smoke.py examples/status-markdown-smoke.py
- python3 examples/work-lane-contract-smoke.py
- python3 examples/quota-cleared-blocker-successor-gate-smoke.py
- python3 examples/status-markdown-smoke.py
- python3 -m loopx.cli check --scan-path loopx/quota.py --scan-path loopx/cli_commands/status.py --scan-path loopx/status.py --scan-path examples/work-lane-contract-smoke.py --scan-path examples/quota-cleared-blocker-successor-gate-smoke.py --scan-path examples/status-markdown-smoke.py
- git diff --check origin/main..HEAD

Note: loopx check reports the existing loopx-meta duplicate index warning (raw=5674 unique=5670); public boundary scan is clean.