### PR TITLE
Add local agent launch dry-run protocol

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -73,6 +73,7 @@ incident report, or launch draft.
 - [Interface budget contract](interface-budget-contract.md)
 - [Host integration surface v0](reference/protocols/host-integration-surface-v0.md)
 - [Codex App host command registry v0](reference/protocols/codex-app-host-command-registry-v0.md)
+- [Local agent launch plan v0](reference/protocols/local-agent-launch-plan-v0.md)
 - [Runtime connector catalog](runtime-connector-catalog.md)
 - [Reward gate direct-write contract](reward-gate-direct-write-contract.md)
 - [Worker bridge install contract](worker-bridge-install-contract.md)

--- a/docs/reference/protocols/README.md
+++ b/docs/reference/protocols/README.md
@@ -23,3 +23,4 @@ Current contracts:
 - [issue_fix_acceptance_loop_v0](issue-fix-acceptance-loop-v0.md)
 - [cs_notes_explore_capability_map_v0](cs-notes-explore-capability-map-v0.md)
 - [value_connector_plan_v0](value-connector-plan-v0.md)
+- [local_agent_launch_plan_v0](local-agent-launch-plan-v0.md)

--- a/docs/reference/protocols/host-integration-surface-v0.md
+++ b/docs/reference/protocols/host-integration-surface-v0.md
@@ -59,7 +59,7 @@ Host integrations should expose read methods that map directly to CLI reads:
 | --- | --- | --- |
 | Health and installation | `loopx doctor` | compact readiness plus missing pieces |
 | Registry and goal boundary | `loopx registry` and `quota should-run` | goal id, adapter status, write scope, registered agents, stop condition |
-| Status and attention queue | `loopx --format json status` | first-screen status, user todos, agent todos, gate state, freshness warnings, optional read-only projections such as `task_graph_projection_v0` |
+| Status and attention queue | `loopx --format json status` | first-screen status, user todos, agent todos, gate state, freshness warnings, optional read-only projections such as `task_graph_projection_v0` and `local_agent_launch_plan_v0` |
 | Quota decision | `loopx --format json quota should-run --goal-id <goal-id> --agent-id <agent-id>` | `interaction_contract`, execution obligation, workspace guard, spend policy |
 | Review packet | `loopx --format json review-packet --goal-id <goal-id>` | human/controller decision packet and agent handoff context |
 | Run history | `loopx history` or status projections | compact run ids, classification, outcome, validation, blocker pointers |
@@ -67,10 +67,10 @@ Host integrations should expose read methods that map directly to CLI reads:
 Read methods return compact control facts. They must not return raw session
 logs, raw benchmark task text, raw trajectories, private document bodies,
 credentials, local absolute paths, or host auth material.
-Optional projections such as `task_graph_projection_v0` and
-`cadence_hint_v0` are read-only inputs to a host integration. They
-do not add graph write authority, change quota gates, or create a new source of
-truth.
+Optional projections such as `task_graph_projection_v0`,
+`local_agent_launch_plan_v0`, and `cadence_hint_v0` are read-only
+inputs to a host integration. They do not add graph write authority, launch
+workers, change quota gates, or create a new source of truth.
 
 ## Controlled Writes
 
@@ -109,7 +109,11 @@ hooks, and MCP clients:
     "visible_surface_required": true
   },
   "lifecycle_reads": ["doctor", "status", "quota_should_run", "review_packet"],
-  "projection_inputs": ["task_graph_projection_v0", "cadence_hint_v0"],
+  "projection_inputs": [
+    "task_graph_projection_v0",
+    "local_agent_launch_plan_v0",
+    "cadence_hint_v0"
+  ],
   "write_capabilities": ["todo_lifecycle", "gate_decision"],
   "optional_write_capabilities": ["task_lease_v0_when_shipped"],
   "cli_fallback": {

--- a/docs/reference/protocols/local-agent-launch-plan-v0.md
+++ b/docs/reference/protocols/local-agent-launch-plan-v0.md
@@ -1,0 +1,176 @@
+# local_agent_launch_plan_v0
+
+`local_agent_launch_plan_v0` is a public-safe dry-run contract for previewing
+how LoopX would assign local agents to a goal before any host starts a worker,
+daemon, server, or external process.
+
+The contract answers a narrow product question: "Given the registered agents,
+current quota decision, and todo projection, what launch plan would the
+operator see?" It is not a launcher, scheduler, task lease store, or permission
+grant.
+
+## Boundary
+
+The source of truth remains:
+
+- the project registry and registered-agent configuration;
+- `quota should-run` and its `interaction_contract`;
+- todo projection, claims, gates, and run history;
+- the active goal state and public/private boundary rules.
+
+The plan may be rendered by a dashboard, Codex App host, or CLI dry-run packet.
+Its machine marker is `mode=dry_run`. It must not start a process, allocate a
+shell, open a daemon connection, call a remote agent service, or write LoopX
+state.
+
+## Shape
+
+```json
+{
+  "schema_version": "local_agent_launch_plan_v0",
+  "mode": "dry_run",
+  "goal_id": "loopx-meta",
+  "primary_agent_id": "codex-main-control",
+  "generated_at": "2026-06-27T04:00:00Z",
+  "configured_agents": [],
+  "role_assignments": [],
+  "launch_preview": [],
+  "status_projection": {},
+  "evidence_projection": {},
+  "future_gates": [],
+  "truth_contract": {
+    "source_of_truth": [
+      "registry",
+      "quota_should_run",
+      "todo_projection",
+      "run_history"
+    ],
+    "plan_is_authoritative": false,
+    "plan_is_executable": false,
+    "write_api": false,
+    "launch_command_allowed": false,
+    "recompute_rule": "Recompute from registry, quota, todos, gates, and run history before each preview."
+  }
+}
+```
+
+## Configured Agents
+
+`configured_agents[]` is the discovered agent list after registry and
+capability gates are applied. Each item should include:
+
+- `agent_id`: registered LoopX agent id;
+- `role`: `primary`, `side_agent`, `reviewer`, `observer`, or `blocked`;
+- `source`: compact configuration source label, such as
+  `registry.coordination.registered_agents`;
+- `scope_summary`: public-safe scope summary;
+- `can_receive_work`: whether quota and capability gates allow the agent to
+  receive a dry-run assignment;
+- `blocked_by`: compact blocker labels when the agent cannot receive work.
+
+Do not copy raw automation prompts, private chat history, local worktree paths,
+or connector payloads into `scope_summary` or `blocked_by`.
+
+## Role Assignments
+
+`role_assignments[]` maps configured agents to lanes that a host can display.
+Required fields:
+
+- `agent_id`;
+- `lane`: `primary_control`, `bounded_delivery`, `review_handoff`,
+  `monitor_only`, or `blocked`;
+- `responsibility`: one compact public-safe sentence;
+- `claim_policy`: how todos should be claimed or reviewed;
+- `handoff_target_agent_id`: optional next reviewer or controller.
+
+Role assignments are advisory preview rows. A real claim still goes through the
+existing todo lifecycle and claim rules.
+
+## Launch Preview
+
+`launch_preview[]` describes what the host would show before a launch. It must
+remain non-executable:
+
+```json
+{
+  "preview_id": "preview_side_agent_delivery",
+  "agent_id": "codex-side-bypass",
+  "todo_id": "todo_public_slice",
+  "next_step_label": "Build the public dry-run fixture slice.",
+  "worktree_policy": "independent_worktree_required",
+  "host_execution": {
+    "will_start_process": false,
+    "tool_call_allowed": false,
+    "shell_command": null,
+    "daemon_required": false,
+    "external_service_call": false
+  }
+}
+```
+
+The preview may name a todo id and the worktree policy, but it must not include
+a runnable shell command, process id, credential, host auth token, or remote
+URL. If a host later adds real local-agent launch support, that is a separate
+contract with explicit server/daemon and permission gates.
+
+## Status And Evidence Projection
+
+`status_projection` gives the first screen:
+
+- `waiting_on`: `agent`, `primary`, `user`, `controller`, `runtime`, or
+  `none`;
+- `next_action`: compact current action;
+- `user_action_required`: boolean;
+- `agent_can_continue`: boolean;
+- `first_agent_todo`: todo id or `null`;
+- `gate_state`: `clear`, `user_todo`, `operator_gate`, `blocked`, or
+  `deferred`;
+- `quota_state`: `eligible`, `throttled`, `operator_gate`, or `blocked`;
+- `launch_state`: `preview_only`, `blocked`, or `future_gated`.
+
+`evidence_projection` gives compact public-safe proof:
+
+- `source_refs`: registry, quota, todo, run, or review-packet ids;
+- `validation_refs`: smoke, check, CI, or review proof ids;
+- `raw_logs_copied`, `raw_transcripts_copied`, `credentials_copied`,
+  `private_paths_copied`: all false for public fixtures;
+- `public_safe_summary`: one compact summary.
+
+Evidence references are join keys, not payloads. They must not embed raw logs,
+full transcripts, private document ids, host URLs, or local absolute paths.
+
+## Future Gates
+
+The following capabilities stay future-gated in v0:
+
+- `server_daemon_launch`: starting or controlling a local LoopX daemon;
+- `external_agent_execution`: starting Codex, Claude, worker, CI, or remote
+  agent processes from this plan;
+- `credentialed_host_actions`: any action that needs host auth, secrets, or
+  production access;
+- `state_write_from_preview`: claiming todos, approving gates, refreshing
+  state, or spending quota from the preview itself.
+
+Each gate should name `state=future_gated` or `state=blocked_without_authority`
+and a compact `required_contract` before it can be enabled.
+
+## Acceptance Checks
+
+A fixture or implementation is acceptable when:
+
+1. `schema_version` is exactly `local_agent_launch_plan_v0`;
+2. `mode` is exactly `dry_run`;
+3. configured-agent discovery includes the primary and at least one non-primary
+   agent when present in the registry source;
+4. each configured agent has a matching role assignment;
+5. every launch preview has `will_start_process=false`,
+   `tool_call_allowed=false`, `shell_command=null`,
+   `external_service_call=false`, and no runnable command text;
+6. status projection exposes waiting actor, next action, user action flag,
+   agent continuation flag, gate, quota, and launch state;
+7. evidence projection contains compact refs and explicitly marks raw logs,
+   transcripts, credentials, and private paths as not copied;
+8. server/daemon launch, external execution, credentialed host actions, and
+   preview writes remain future-gated; and
+9. public fixtures contain no raw transcripts, credentials, private links,
+   local paths, or internal project names.

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -58,6 +58,16 @@ The protocol is defined in
 [`docs/reference/protocols/task-graph-projection-v0.md`](reference/protocols/task-graph-projection-v0.md);
 consumers should ignore the field when absent.
 
+Rows may also include an optional `local_agent_launch_plan` object with
+`schema_version=local_agent_launch_plan_v0`. This is a dry-run preview over
+configured agents, role assignments, non-executable launch preview rows,
+status projection, evidence projection, and future gates. It is read-only and
+must not start local workers, call external agent services, expose shell
+commands, write LoopX state, or grant host authority. The protocol is defined
+in
+[`docs/reference/protocols/local-agent-launch-plan-v0.md`](reference/protocols/local-agent-launch-plan-v0.md);
+consumers should ignore the field when absent.
+
 Loopback status exports include `status_contract.schema_version`. The dashboard
 uses that small protocol marker to detect when `127.0.0.1:8766` is still served
 by an older daemon or release snapshot after the checkout has moved forward. If

--- a/examples/fixtures/local-agent-launch-plan.public.json
+++ b/examples/fixtures/local-agent-launch-plan.public.json
@@ -1,0 +1,185 @@
+{
+  "fixture": "local_agent_launch_plan_public_v0",
+  "ok": true,
+  "attention_queue": {
+    "available": true,
+    "item_count": 1,
+    "items": [
+      {
+        "goal_id": "loopx-meta",
+        "status": "active",
+        "waiting_on": "codex",
+        "severity": "action",
+        "recommended_action": "Preview local agent role assignment before any runtime launcher exists.",
+        "local_agent_launch_plan": {
+          "schema_version": "local_agent_launch_plan_v0",
+          "mode": "dry_run",
+          "goal_id": "loopx-meta",
+          "primary_agent_id": "codex-main-control",
+          "generated_at": "2026-06-27T04:00:00Z",
+          "configured_agents": [
+            {
+              "agent_id": "codex-main-control",
+              "role": "primary",
+              "source": "registry.coordination.registered_agents",
+              "scope_summary": "Primary controller reviews non-small changes and owns final merge decisions.",
+              "can_receive_work": true,
+              "blocked_by": []
+            },
+            {
+              "agent_id": "codex-side-bypass",
+              "role": "side_agent",
+              "source": "registry.coordination.registered_agents",
+              "scope_summary": "Side agent performs independent public-safe validation slices in an isolated worktree.",
+              "can_receive_work": true,
+              "blocked_by": []
+            },
+            {
+              "agent_id": "codex-product-capability",
+              "role": "reviewer",
+              "source": "registry.coordination.registered_agents",
+              "scope_summary": "Product capability agent owns product-surface validation and separate capability gates.",
+              "can_receive_work": false,
+              "blocked_by": [
+                "current_todo_claimed_by_another_agent"
+              ]
+            }
+          ],
+          "role_assignments": [
+            {
+              "agent_id": "codex-main-control",
+              "lane": "primary_control",
+              "responsibility": "Review and merge work that exceeds small self-merge rules.",
+              "claim_policy": "owns_primary_review_todos",
+              "handoff_target_agent_id": null
+            },
+            {
+              "agent_id": "codex-side-bypass",
+              "lane": "bounded_delivery",
+              "responsibility": "Deliver one verifiable public dry-run protocol slice.",
+              "claim_policy": "claim_current_agent_todo_before_delivery",
+              "handoff_target_agent_id": "codex-main-control"
+            },
+            {
+              "agent_id": "codex-product-capability",
+              "lane": "blocked",
+              "responsibility": "Wait for its own capability gate before product-surface validation.",
+              "claim_policy": "do_not_steal_other_agent_todos",
+              "handoff_target_agent_id": null
+            }
+          ],
+          "launch_preview": [
+            {
+              "preview_id": "preview_side_bypass_public_slice",
+              "agent_id": "codex-side-bypass",
+              "todo_id": "todo_a7ebeabb3c0c",
+              "next_step_label": "Build the public local-agent launch dry-run fixture and smoke.",
+              "worktree_policy": "independent_worktree_required",
+              "host_execution": {
+                "will_start_process": false,
+                "tool_call_allowed": false,
+                "shell_command": null,
+                "daemon_required": false,
+                "external_service_call": false
+              }
+            },
+            {
+              "preview_id": "preview_primary_review_handoff",
+              "agent_id": "codex-main-control",
+              "todo_id": "todo_primary_review_local_agent_launch_plan",
+              "next_step_label": "Review the protocol slice if it is not eligible for small self-merge.",
+              "worktree_policy": "no_launcher_worktree_change",
+              "host_execution": {
+                "will_start_process": false,
+                "tool_call_allowed": false,
+                "shell_command": null,
+                "daemon_required": false,
+                "external_service_call": false
+              }
+            }
+          ],
+          "status_projection": {
+            "waiting_on": "agent",
+            "next_action": "Create and validate the public local-agent launch dry-run contract.",
+            "user_action_required": false,
+            "agent_can_continue": true,
+            "first_agent_todo": "todo_a7ebeabb3c0c",
+            "gate_state": "clear",
+            "quota_state": "eligible",
+            "launch_state": "preview_only"
+          },
+          "evidence_projection": {
+            "source_refs": [
+              {
+                "kind": "registry",
+                "id": "registry_goal_loopx_meta"
+              },
+              {
+                "kind": "quota",
+                "id": "quota_should_run_current_agent"
+              },
+              {
+                "kind": "todo",
+                "id": "todo_a7ebeabb3c0c"
+              }
+            ],
+            "validation_refs": [
+              {
+                "kind": "smoke",
+                "id": "local_agent_launch_plan_smoke"
+              }
+            ],
+            "raw_logs_copied": false,
+            "raw_transcripts_copied": false,
+            "credentials_copied": false,
+            "private_paths_copied": false,
+            "public_safe_summary": "The plan previews configured agents, roles, and handoff status without launching a runtime."
+          },
+          "future_gates": [
+            {
+              "capability": "server_daemon_launch",
+              "state": "future_gated",
+              "required_contract": "local_runtime_daemon_launch_v0"
+            },
+            {
+              "capability": "external_agent_execution",
+              "state": "future_gated",
+              "required_contract": "external_agent_execution_gate_v0"
+            },
+            {
+              "capability": "credentialed_host_actions",
+              "state": "blocked_without_authority",
+              "required_contract": "explicit_host_auth_boundary_v0"
+            },
+            {
+              "capability": "state_write_from_preview",
+              "state": "future_gated",
+              "required_contract": "controlled_writeback_preview_v0"
+            }
+          ],
+          "truth_contract": {
+            "source_of_truth": [
+              "registry",
+              "quota_should_run",
+              "todo_projection",
+              "run_history"
+            ],
+            "plan_is_authoritative": false,
+            "plan_is_executable": false,
+            "write_api": false,
+            "launch_command_allowed": false,
+            "recompute_rule": "Recompute from registry, quota, todos, gates, and run history before each preview."
+          },
+          "boundary": {
+            "public_fixture": true,
+            "raw_transcripts_allowed": false,
+            "raw_logs_allowed": false,
+            "credentials_allowed": false,
+            "private_paths_allowed": false,
+            "runtime_launcher_enabled": false
+          }
+        }
+      }
+    ]
+  }
+}

--- a/examples/local-agent-launch-plan-smoke.py
+++ b/examples/local-agent-launch-plan-smoke.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Smoke-test the public local_agent_launch_plan_v0 fixture and contract."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_PATH = REPO_ROOT / "examples" / "fixtures" / "local-agent-launch-plan.public.json"
+CONTRACT_PATH = REPO_ROOT / "docs" / "reference" / "protocols" / "local-agent-launch-plan-v0.md"
+PROTOCOL_INDEX_PATH = REPO_ROOT / "docs" / "reference" / "protocols" / "README.md"
+DOCS_INDEX_PATH = REPO_ROOT / "docs" / "README.md"
+STATUS_CONTRACT_PATH = REPO_ROOT / "docs" / "status-data-contract.md"
+HOST_SURFACE_PATH = REPO_ROOT / "docs" / "reference" / "protocols" / "host-integration-surface-v0.md"
+
+ALLOWED_AGENT_ROLES = {"primary", "side_agent", "reviewer", "observer", "blocked"}
+ALLOWED_ASSIGNMENT_LANES = {
+    "primary_control",
+    "bounded_delivery",
+    "review_handoff",
+    "monitor_only",
+    "blocked",
+}
+ALLOWED_WAITING_ON = {"agent", "primary", "user", "controller", "runtime", "none"}
+ALLOWED_GATE_STATES = {"clear", "user_todo", "operator_gate", "blocked", "deferred"}
+ALLOWED_QUOTA_STATES = {"eligible", "throttled", "operator_gate", "blocked"}
+ALLOWED_LAUNCH_STATES = {"preview_only", "blocked", "future_gated"}
+REQUIRED_SOURCES = {"registry", "quota_should_run", "todo_projection", "run_history"}
+REQUIRED_FUTURE_GATES = {
+    "server_daemon_launch",
+    "external_agent_execution",
+    "credentialed_host_actions",
+    "state_write_from_preview",
+}
+REQUIRED_STATUS_FIELDS = {
+    "waiting_on",
+    "next_action",
+    "user_action_required",
+    "agent_can_continue",
+    "first_agent_todo",
+    "gate_state",
+    "quota_state",
+    "launch_state",
+}
+PRIVATE_PATTERNS = [
+    re.compile(r"/Users/[A-Za-z0-9._-]+/"),
+    re.compile(r"/home/[A-Za-z0-9._-]+/"),
+    re.compile(r"/private/"),
+    re.compile(r"[A-Za-z]:\\\\Users\\\\"),
+    re.compile(r'https?://[^\s"]*(?:corp-only|restricted-host)[^\s"]*'),
+    re.compile(r"\bBearer\s+[A-Za-z0-9._-]+"),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+]
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def assert_public_safe(text: str, label: str) -> None:
+    for pattern in PRIVATE_PATTERNS:
+        if pattern.search(text):
+            raise AssertionError(f"{label} matched private pattern {pattern.pattern!r}")
+
+
+def assert_contains(text: str, needle: str, label: str) -> None:
+    if needle not in text:
+        raise AssertionError(f"{label} missing {needle!r}")
+
+
+def main() -> int:
+    fixture_text = read(FIXTURE_PATH)
+    contract = read(CONTRACT_PATH)
+    protocol_index = read(PROTOCOL_INDEX_PATH)
+    docs_index = read(DOCS_INDEX_PATH)
+    status_contract = read(STATUS_CONTRACT_PATH)
+    host_surface = read(HOST_SURFACE_PATH)
+
+    for label, text in {
+        "fixture": fixture_text,
+        "contract": contract,
+        "protocol index": protocol_index,
+        "docs index": docs_index,
+        "status contract": status_contract,
+        "host surface": host_surface,
+    }.items():
+        assert_public_safe(text, label)
+
+    for needle in [
+        "local_agent_launch_plan_v0",
+        "mode=dry_run",
+        "configured_agents",
+        "role_assignments",
+        "launch_preview",
+        "server_daemon_launch",
+        "external_agent_execution",
+        "credentialed_host_actions",
+        "Status And Evidence Projection",
+    ]:
+        assert_contains(contract, needle, "contract")
+    assert_contains(protocol_index, "local_agent_launch_plan_v0", "protocol index")
+    assert_contains(docs_index, "Local agent launch plan v0", "docs index")
+    assert_contains(status_contract, "local_agent_launch_plan_v0", "status contract")
+    assert_contains(host_surface, "local_agent_launch_plan_v0", "host surface")
+
+    payload = json.loads(fixture_text)
+    item = payload["attention_queue"]["items"][0]
+    plan = item["local_agent_launch_plan"]
+
+    assert plan["schema_version"] == "local_agent_launch_plan_v0", plan
+    assert plan["mode"] == "dry_run", plan
+    assert plan["goal_id"] == item["goal_id"], plan
+    assert plan["primary_agent_id"] == "codex-main-control", plan
+
+    configured_agents = plan["configured_agents"]
+    agent_ids = {agent["agent_id"] for agent in configured_agents}
+    assert "codex-main-control" in agent_ids, configured_agents
+    assert "codex-side-bypass" in agent_ids, configured_agents
+    assert len(agent_ids) == len(configured_agents), configured_agents
+    for agent in configured_agents:
+        assert agent["role"] in ALLOWED_AGENT_ROLES, agent
+        assert agent["source"] == "registry.coordination.registered_agents", agent
+        assert isinstance(agent["scope_summary"], str) and agent["scope_summary"], agent
+        assert isinstance(agent["can_receive_work"], bool), agent
+        assert isinstance(agent["blocked_by"], list), agent
+
+    assignments = plan["role_assignments"]
+    assignment_ids = {assignment["agent_id"] for assignment in assignments}
+    assert agent_ids <= assignment_ids, assignments
+    for assignment in assignments:
+        assert assignment["lane"] in ALLOWED_ASSIGNMENT_LANES, assignment
+        assert isinstance(assignment["responsibility"], str) and assignment["responsibility"], assignment
+        assert isinstance(assignment["claim_policy"], str) and assignment["claim_policy"], assignment
+
+    previews = plan["launch_preview"]
+    assert len(previews) >= 2, previews
+    for preview in previews:
+        assert preview["agent_id"] in agent_ids, preview
+        assert isinstance(preview["next_step_label"], str) and preview["next_step_label"], preview
+        assert preview["worktree_policy"], preview
+        host_execution = preview["host_execution"]
+        assert host_execution["will_start_process"] is False, preview
+        assert host_execution["tool_call_allowed"] is False, preview
+        assert host_execution["shell_command"] is None, preview
+        assert host_execution["daemon_required"] is False, preview
+        assert host_execution["external_service_call"] is False, preview
+
+    status = plan["status_projection"]
+    assert REQUIRED_STATUS_FIELDS <= set(status), status
+    assert status["waiting_on"] in ALLOWED_WAITING_ON, status
+    assert status["gate_state"] in ALLOWED_GATE_STATES, status
+    assert status["quota_state"] in ALLOWED_QUOTA_STATES, status
+    assert status["launch_state"] in ALLOWED_LAUNCH_STATES, status
+    assert status["user_action_required"] is False, status
+    assert status["agent_can_continue"] is True, status
+
+    evidence = plan["evidence_projection"]
+    assert evidence["source_refs"], evidence
+    assert evidence["validation_refs"], evidence
+    for flag in [
+        "raw_logs_copied",
+        "raw_transcripts_copied",
+        "credentials_copied",
+        "private_paths_copied",
+    ]:
+        assert evidence[flag] is False, (flag, evidence)
+    assert isinstance(evidence["public_safe_summary"], str) and evidence["public_safe_summary"], evidence
+
+    future_gates = {gate["capability"]: gate for gate in plan["future_gates"]}
+    assert REQUIRED_FUTURE_GATES <= set(future_gates), future_gates
+    for gate in future_gates.values():
+        assert gate["state"] in {"future_gated", "blocked_without_authority"}, gate
+        assert gate["required_contract"].endswith("_v0"), gate
+
+    truth = plan["truth_contract"]
+    assert set(truth["source_of_truth"]) == REQUIRED_SOURCES, truth
+    assert truth["plan_is_authoritative"] is False, truth
+    assert truth["plan_is_executable"] is False, truth
+    assert truth["write_api"] is False, truth
+    assert truth["launch_command_allowed"] is False, truth
+
+    boundary = plan["boundary"]
+    assert boundary["public_fixture"] is True, boundary
+    assert boundary["runtime_launcher_enabled"] is False, boundary
+    assert boundary["raw_logs_allowed"] is False, boundary
+    assert boundary["raw_transcripts_allowed"] is False, boundary
+    assert boundary["credentials_allowed"] is False, boundary
+    assert boundary["private_paths_allowed"] is False, boundary
+
+    forbidden_keys = {
+        "agent_command",
+        "process_id",
+        "access_token",
+        "credential",
+        "raw_log",
+        "raw_transcript",
+    }
+    fixture_keys = set(json.dumps(payload, sort_keys=True).split('"'))
+    assert not (fixture_keys & forbidden_keys), fixture_keys & forbidden_keys
+
+    print("local-agent-launch-plan-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add local_agent_launch_plan_v0 as a public-safe dry-run protocol for configured-agent discovery, role assignment, non-executable launch preview, status projection, and evidence projection
- add a public fixture and smoke test that keep server/daemon launch, external execution, credentialed host actions, and preview writes future-gated
- link the protocol from status, host integration, and docs indexes

## Validation
- python3 -m json.tool examples/fixtures/local-agent-launch-plan.public.json >/dev/null
- python3 examples/local-agent-launch-plan-smoke.py
- python3 examples/host-integration-surface-smoke.py
- python3 examples/task-graph-projection-fixture-smoke.py
- git diff --cached --check
- loopx check --scan-path docs/reference/protocols/local-agent-launch-plan-v0.md --scan-path examples/fixtures/local-agent-launch-plan.public.json --scan-path examples/local-agent-launch-plan-smoke.py --scan-path docs/status-data-contract.md --scan-path docs/reference/protocols/host-integration-surface-v0.md --scan-path docs/README.md --scan-path docs/reference/protocols/README.md

Note: loopx check reported the existing duplicate run-history index warning for loopx-meta; the public boundary scan for the 7 candidate files is clean.