### PR TITLE
Preserve SkillsBench failure closeout metadata

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -4311,6 +4311,16 @@ def test_skillsbench_apt_risk_preflight_blocks_full_run_without_benchflow() -> N
             / "benchmark_run.compact.json"
         )
         compact = json.loads(compact_path.read_text(encoding="utf-8"))
+        assert compact["task_id"] == "setup-fuzzing-py", compact
+        assert compact["case_id"] == "setup-fuzzing-py", compact
+        assert compact["route"] == "codex-acp-blind-loop-baseline", compact
+        assert compact["run_group_id"] == "setup-fuzzing-py-apt-risk-preflight", (
+            compact
+        )
+        assert compact["job_name"] == "setup-fuzzing-py-apt-risk-preflight", compact
+        assert compact["rollout_name"] == "setup-fuzzing-py__codex_acp_blind_loop", (
+            compact
+        )
         assert compact["score_failure_attribution"] == (
             "skillsbench_docker_apt_setup_risk_preflight_blocked"
         ), compact
@@ -7537,6 +7547,15 @@ def test_skillsbench_runner_failure_compact_closeout() -> None:
         assert compact["source_runner"] == (
             "official_skillsbench_benchflow_launch_failure"
         ), compact
+        assert compact["task_id"] == "debug-trl-grpo", compact
+        assert compact["case_id"] == "debug-trl-grpo", compact
+        assert compact["route"] == "codex-goal-mode-baseline", compact
+        assert compact["job_name"] == "skillsbench-debug-trl-grpo-failure-fixture", (
+            compact
+        )
+        assert compact["rollout_name"] == "debug-trl-grpo__codex_goal_mode_baseline", (
+            compact
+        )
         assert compact["mode"] == "codex_goal_mode_baseline", compact
         assert compact["real_run"] is True, compact
         assert compact["official_score_status"] == "missing", compact

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -4523,6 +4523,7 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
             else "codex-acp"
         ),
         "model": args.model,
+        "run_group_id": str(args.run_group_id or ""),
         "sandbox": args.sandbox,
         "max_rounds": args.max_rounds,
         "treatment_prompt_style": args.treatment_prompt_style,
@@ -8622,6 +8623,15 @@ def build_runner_failure_compact(
     reduced = compact_benchmark_run(compact)
     if reduced is None:
         raise RuntimeError("SkillsBench runner failure reducer produced non-compact run")
+    closeout_metadata = {
+        "task_id": args.task_id,
+        "route": args.route,
+        "run_group_id": args.run_group_id or plan.get("run_group_id"),
+        "rollout_name": plan.get("rollout_name"),
+    }
+    for key, value in closeout_metadata.items():
+        if value:
+            reduced[key] = str(value)
     runner_output_capture = _public_runner_output_capture(plan)
     if runner_output_capture:
         reduced["runner_output_capture"] = runner_output_capture


### PR DESCRIPTION
## Summary
- keep SkillsBench runner-failure compact closeouts tagged with task_id, route, run_group_id, and rollout_name after reduction
- include run_group_id in the public launch plan metadata
- extend focused SkillsBench closeout smokes to guard the metadata

## Scope
Benchmark helper/runtime observation only. This does not change benchmark scoring, task semantics, leaderboard/submission behavior, permission boundaries, or launch new benchmark jobs.

## Validation
- python3 -m py_compile scripts/skillsbench_automation_loop.py examples/skillsbench-benchmark-run-smoke.py
- targeted closeout metadata smokes: test_skillsbench_apt_risk_preflight_blocks_full_run_without_benchflow, test_skillsbench_runner_failure_compact_closeout
- python3 -m loopx.cli check --scan-path scripts/skillsbench_automation_loop.py --scan-path examples/skillsbench-benchmark-run-smoke.py
- git diff --check

Note: full examples/skillsbench-benchmark-run-smoke.py currently fails before this patch area on an existing local-driver mini-pair route expectation mismatch; the targeted closeout metadata smokes pass.
