### PR TITLE
Add public showcase case pages

### DIFF
--- a/docs/showcases/README.md
+++ b/docs/showcases/README.md
@@ -11,7 +11,7 @@ into a reusable control-plane pattern:
 - the user-facing value in plain language;
 - the evidence boundary, including what must stay private;
 - a reproducible demo or the reason a demo is still pending;
-- optional data that a future website can render as a visual story.
+- optional data that a future website can render as a public evidence sequence.
 
 The machine-readable catalog lives in
 [showcase-catalog.json](showcase-catalog.json). Public docs and future frontend
@@ -118,7 +118,7 @@ public-safe user story.
 4. **Reproducible**: add a small synthetic demo or smoke that proves the
    reusable LoopX behavior without depending on private artifacts.
 5. **Frontend-ready**: add or update the catalog fields needed for a visual
-   website card, such as story beats, pattern tags, and suggested visual
+   website card, such as evidence sequence, pattern tags, and suggested visual
    layout.
 
 Cases can enter the catalog before they have a runnable demo, but their status

--- a/docs/showcases/cases/0617-blocked-p0-safe-rotation.en.html
+++ b/docs/showcases/cases/0617-blocked-p0-safe-rotation.en.html
@@ -1,0 +1,138 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>LoopX Showcase: Blocked P0 with safe P1/P2 rotation</title>
+  <link rel="icon" href="data:,">
+  <style>
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  body{background:#0b0b0c;color:#f1f2f3;font-family:'Geist',system-ui,-apple-system,BlinkMacSystemFont,sans-serif;-webkit-font-smoothing:antialiased}
+  a{color:inherit}
+  ::selection{background:color-mix(in srgb,var(--accent,#6e79d6) 34%,transparent);color:#fff}
+  .gh{min-height:100vh;position:relative;overflow-x:hidden;--accent:#6e79d6}
+  .grain{position:fixed;inset:0;pointer-events:none;opacity:.025;mix-blend-mode:overlay;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E")}
+  article{position:relative;max-width:800px;margin:0 auto;padding:76px 28px 130px}
+  .mlab{font-family:'Geist Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11px;letter-spacing:.06em;color:#62666d;text-transform:uppercase}
+  h1{font-size:clamp(31px,4.6vw,46px);font-weight:600;line-height:1.12;letter-spacing:-.03em;margin:16px 0 14px;color:#fafafa;text-wrap:balance}
+  h2{font-size:22px;font-weight:600;letter-spacing:-.02em;color:#f1f2f3}
+  h3{font-size:21px;font-weight:600;letter-spacing:-.02em;color:#f1f2f3}
+  p{font-size:15.5px;line-height:1.75;color:#9ea3aa}
+  strong{color:#e9eaec;font-weight:600}
+  code{font-family:'Geist Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:12.5px;color:#c4c7cc}
+  .accent{font-size:clamp(17px,2.1vw,21px);font-weight:500;color:var(--accent);letter-spacing:-.01em;margin-bottom:22px}
+  .nav{display:flex;gap:10px;flex-wrap:wrap;margin:0 0 28px}
+  .nav a,.case-link{font-family:'Geist Mono',ui-monospace,monospace;font-size:11px;letter-spacing:.04em;text-decoration:none;color:#c4c7cc;border:1px solid rgba(255,255,255,.12);border-radius:6px;padding:7px 10px;background:rgba(255,255,255,.025)}
+  .nav a:hover,.case-link:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent);color:#f4f4f5}
+  .section-head{margin-top:74px;display:flex;align-items:baseline;gap:13px;margin-bottom:20px}
+  .section-head span{font-family:'Geist Mono',ui-monospace,monospace;font-size:13px;color:var(--accent)}
+  .panel{border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;overflow:hidden}
+  .panel-row{display:grid;grid-template-columns:150px 1fr;border-top:1px solid rgba(255,255,255,.07)}
+  .panel-row:first-child{border-top:0}
+  .panel-key{padding:18px 20px;border-right:1px solid rgba(255,255,255,.07);font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:var(--accent);background:color-mix(in srgb,var(--accent) 8%,transparent);letter-spacing:.04em}
+  .panel-val{padding:18px 20px;display:flex;align-items:center}
+  .panel-val p{font-size:14px;line-height:1.6;margin:0}
+  .diagram{border:1px solid rgba(255,255,255,.1);border-radius:12px;padding:30px 24px 22px;background:#0e0e10;margin:22px 0}
+  .diagram svg{display:block;width:100%;height:auto}
+  .chips{display:flex;gap:8px;flex-wrap:wrap;margin-top:22px}
+  .chips span{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#888d95;border:1px solid rgba(255,255,255,.12);padding:4px 8px;border-radius:5px}
+  .text-stack{display:flex;flex-direction:column;gap:16px}
+  .evidence-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px;margin:20px 0 6px}
+  .evidence-card{border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;padding:18px 18px 17px;min-height:128px}
+  .evidence-label{font-family:'Geist Mono',ui-monospace,monospace;font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:var(--accent);margin-bottom:10px}
+  .source-list{display:flex;flex-direction:column;gap:10px;margin-top:20px}
+  .source-ref{display:grid;grid-template-columns:150px 1fr;gap:14px;align-items:center;text-decoration:none;border:1px solid rgba(255,255,255,.1);border-radius:8px;background:#0e0e10;padding:12px 14px}
+  .source-ref:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent)}
+  .source-ref span{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:var(--accent);text-transform:uppercase;letter-spacing:.04em}
+  .source-ref code{color:#aeb3ba;word-break:break-word}
+  .boundary-box{border-left:2px solid var(--accent);background:#0e0e10;padding:18px 20px;margin-top:16px;border-radius:0 8px 8px 0}
+  .flow{display:flex;flex-direction:column}
+  .flow li{display:grid;grid-template-columns:28px 1fr;gap:14px;list-style:none}
+  .flow-num{width:24px;height:24px;border-radius:50%;border:1px solid color-mix(in srgb,var(--accent) 50%,transparent);display:flex;align-items:center;justify-content:center;font-family:'Geist Mono',ui-monospace,monospace;font-size:11.5px;color:var(--accent);background:#0b0b0c}
+  .flow-body{padding-bottom:18px;border-left:1px solid rgba(255,255,255,.12);padding-left:14px;margin-left:-27px}
+  .flow-title{font-size:14.5px;color:#eceef0;font-weight:500;margin-bottom:7px}
+  .metric-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px;margin-top:22px}
+  .metric{border:1px solid rgba(255,255,255,.1);border-radius:10px;padding:17px 19px;background:#0c0c0e}
+  .metric strong{display:block;font-size:24px;letter-spacing:-.02em;color:#fafafa}
+  .metric span{display:block;margin-top:5px;font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#62666d;text-transform:uppercase}
+  .search{width:100%;height:42px;margin:22px 0 16px;border:1px solid rgba(255,255,255,.12);border-radius:8px;background:#0e0e10;color:#f1f2f3;padding:0 12px;font:14px 'Geist',system-ui,sans-serif}
+  .cards{display:flex;flex-direction:column;gap:12px}
+  .card{display:block;text-decoration:none;border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;padding:18px 20px}
+  .card:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent)}
+  .card .meta{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#62666d;margin-bottom:8px}
+  .card p{font-size:14px;margin-top:9px}
+  .hide{display:none}
+  footer{margin-top:76px;color:#62666d;font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;line-height:1.7}
+  @media(max-width:720px){article{padding:52px 18px 90px}.panel-row{grid-template-columns:1fr}.panel-key{border-right:0;border-bottom:1px solid rgba(255,255,255,.07)}.metric-grid,.evidence-grid{grid-template-columns:1fr}.source-ref{grid-template-columns:1fr;gap:6px}}
+</style>
+</head>
+<body>
+<div class="gh">
+  <div class="grain"></div>
+  <article>
+
+    <nav class="nav" aria-label="Showcase navigation">
+      <a href="../index.en.html">Showcases</a>
+      <a href="../showcase-catalog.json">Catalog</a>
+      <a href="0617-blocked-p0-safe-rotation.html">中文</a>
+    </nav>
+
+    <div class="mlab">2026-06-17 · benchmark-rotation</div>
+    <h1>Blocked P0 with safe P1/P2 rotation</h1>
+    <div class="accent">A gated P0 lane should not stall a whole long-running goal when safe fallback work exists.</div>
+    <p>The operator sees exactly what decision is needed while the agent can keep making bounded progress elsewhere.</p>
+    <div class="chips"><span>reproducible</span><span>user-gate</span><span>fallback</span></div>
+
+    <div class="diagram" aria-label="LoopX control-plane sketch">
+      <svg viewBox="0 0 760 320" role="img">
+        <rect width="760" height="320" fill="#0e0e10"></rect>
+        <rect x="285" y="34" width="190" height="58" rx="8" fill="none" stroke="#6e79d6" stroke-width="2"></rect>
+        <text x="380" y="68" text-anchor="middle" fill="#f1f2f3" font-size="15" font-weight="600">LoopX</text>
+        <line x1="380" y1="92" x2="380" y2="132" stroke="#3a3d42" stroke-width="2"></line>
+        <rect x="52" y="132" width="180" height="78" rx="8" fill="none" stroke="#6a6e76" stroke-width="2"></rect>
+        <rect x="290" y="124" width="180" height="94" rx="8" fill="#6e79d6" fill-opacity=".16" stroke="#6e79d6" stroke-width="2"></rect>
+        <rect x="528" y="132" width="180" height="78" rx="8" fill="none" stroke="#6a6e76" stroke-width="2"></rect>
+        <text x="142" y="166" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">Blocked P0 with safe P</text>
+        <text x="380" y="163" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">concrete user todo</text>
+        <text x="618" y="166" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">reproducible synthetic d</text>
+        <text x="142" y="188" text-anchor="middle" fill="#62666d" font-size="11">goal / trigger</text>
+        <text x="380" y="185" text-anchor="middle" fill="#62666d" font-size="11">todo / gate / evidence</text>
+        <text x="618" y="188" text-anchor="middle" fill="#62666d" font-size="11">public outcome</text>
+        <line x1="232" y1="171" x2="282" y2="171" stroke="#6e79d6" stroke-width="2"></line>
+        <polygon points="290,171 280,165 280,177" fill="#6e79d6"></polygon>
+        <line x1="470" y1="171" x2="520" y2="171" stroke="#6e79d6" stroke-width="2"></line>
+        <polygon points="528,171 518,165 518,177" fill="#6e79d6"></polygon>
+        <path d="M618 210 L618 260 L142 260 L142 218" fill="none" stroke="#5a5e65" stroke-width="2"></path>
+        <polygon points="142,210 136,221 148,221" fill="#8a8088"></polygon>
+      </svg>
+    </div>
+
+
+    <div class="section-head"><span>01</span><h2>Case context</h2></div>
+    <div class="text-stack"><p>This case shows what should happen when a P0 route is blocked by a user decision: the system should neither keep forcing that lane nor stop the whole goal. The original shape was a benchmark rotation where one lane needed a large local image while other no-upload benchmark work remained safe.</p><p>The public repository does not expose raw benchmark tasks or local image names. It reproduces the control-plane behavior with a synthetic smoke.</p></div>
+
+    <div class="section-head"><span>02</span><h2>Repository evidence</h2></div>
+    <div class="panel">
+      <div class="panel-row"><div class="panel-key">Proof</div><div class="panel-val"><p>A user decision should not block all safe work.</p></div></div>
+      <div class="panel-row"><div class="panel-key">LoopX intervention</div><div class="panel-val"><p>concrete user todo, safe fallback, quota control</p></div></div>
+    </div>
+
+    <div class="evidence-grid"><div class="evidence-card"><div class="evidence-label">Synthetic fixture</div><p>`examples/showcase-0617-blocked-p0-safe-rotation-smoke.py` creates a P0 user gate, a P0 agent todo blocked by that gate, and a P1 no-upload fallback.</p></div><div class="evidence-card"><div class="evidence-label">Quota contract</div><p>The smoke asserts `should_run=True`, `requires_user_action=True`, `safe_bypass_allowed=True`, and `safe_bypass_kind=scoped_user_gate_fallback`.</p></div><div class="evidence-card"><div class="evidence-label">Selected fallback</div><p>The fixture selects `terminal_bench_no_upload` while preserving the `ale_image` gate as the user-visible blocker.</p></div><div class="evidence-card"><div class="evidence-label">Rendered evidence</div><p>The smoke checks markdown for `scoped_user_gate_fallback` and safe no-upload Terminal-Bench rotation.</p></div></div>
+
+    <div class="section-head"><span>03</span><h2>LoopX behavior</h2></div>
+    <ul class="flow"><li><span class="flow-num">1</span><div class="flow-body"><div class="flow-title">The user todo names the concrete P0 decision instead of saying only owner gate.</div></div></li><li><span class="flow-num">2</span><div class="flow-body"><div class="flow-title">The agent does not spend compute on the gated lane; it selects fallback work that does not depend on the decision.</div></div></li><li><span class="flow-num">3</span><div class="flow-body"><div class="flow-title">State records both the blocker and the fallback reason so P0 can resume later.</div></div></li></ul>
+
+    <div class="section-head"><span>04</span><h2>What the user sees</h2></div>
+    <div class="text-stack"><p>The user sees the exact decision they need to make while the project continues safely elsewhere.</p><p>Attention load drops: the user does not need to watch repeated idle polls and does not miss the real decision.</p></div>
+
+    <div class="section-head"><span>05</span><h2>Repository sources</h2></div>
+    <div class="source-list"><a class="source-ref" href="0617-blocked-p0-safe-rotation.md"><span>case narrative</span><code>docs/showcases/cases/0617-blocked-p0-safe-rotation.md</code></a><a class="source-ref" href="../../../examples/showcase-0617-blocked-p0-safe-rotation-smoke.py"><span>synthetic smoke</span><code>examples/showcase-0617-blocked-p0-safe-rotation-smoke.py</code></a></div>
+    <div class="boundary-box"><p><strong>Evidence boundary.</strong> Synthetic public fixture only; no private screenshots, raw tasks, internal links, local image names, or raw run logs.</p></div>
+    <div class="chips"><a class="case-link" href="0617-blocked-p0-safe-rotation.md">Case note</a></div>
+    <div class="metric"><strong>Demo</strong><span><code>python3 examples/showcase-0617-blocked-p0-safe-rotation-smoke.py</code></span></div>
+    <footer>Generated from docs/showcases/showcase-catalog.json. Private links, raw chats, local state, and internal media are excluded.</footer>
+  </article>
+</div>
+</body>
+</html>

--- a/docs/showcases/cases/0617-blocked-p0-safe-rotation.html
+++ b/docs/showcases/cases/0617-blocked-p0-safe-rotation.html
@@ -1,0 +1,138 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>LoopX Showcase: P0 block 后推进 P1/P2</title>
+  <link rel="icon" href="data:,">
+  <style>
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  body{background:#0b0b0c;color:#f1f2f3;font-family:'Geist',system-ui,-apple-system,BlinkMacSystemFont,sans-serif;-webkit-font-smoothing:antialiased}
+  a{color:inherit}
+  ::selection{background:color-mix(in srgb,var(--accent,#6e79d6) 34%,transparent);color:#fff}
+  .gh{min-height:100vh;position:relative;overflow-x:hidden;--accent:#6e79d6}
+  .grain{position:fixed;inset:0;pointer-events:none;opacity:.025;mix-blend-mode:overlay;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E")}
+  article{position:relative;max-width:800px;margin:0 auto;padding:76px 28px 130px}
+  .mlab{font-family:'Geist Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11px;letter-spacing:.06em;color:#62666d;text-transform:uppercase}
+  h1{font-size:clamp(31px,4.6vw,46px);font-weight:600;line-height:1.12;letter-spacing:-.03em;margin:16px 0 14px;color:#fafafa;text-wrap:balance}
+  h2{font-size:22px;font-weight:600;letter-spacing:-.02em;color:#f1f2f3}
+  h3{font-size:21px;font-weight:600;letter-spacing:-.02em;color:#f1f2f3}
+  p{font-size:15.5px;line-height:1.75;color:#9ea3aa}
+  strong{color:#e9eaec;font-weight:600}
+  code{font-family:'Geist Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:12.5px;color:#c4c7cc}
+  .accent{font-size:clamp(17px,2.1vw,21px);font-weight:500;color:var(--accent);letter-spacing:-.01em;margin-bottom:22px}
+  .nav{display:flex;gap:10px;flex-wrap:wrap;margin:0 0 28px}
+  .nav a,.case-link{font-family:'Geist Mono',ui-monospace,monospace;font-size:11px;letter-spacing:.04em;text-decoration:none;color:#c4c7cc;border:1px solid rgba(255,255,255,.12);border-radius:6px;padding:7px 10px;background:rgba(255,255,255,.025)}
+  .nav a:hover,.case-link:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent);color:#f4f4f5}
+  .section-head{margin-top:74px;display:flex;align-items:baseline;gap:13px;margin-bottom:20px}
+  .section-head span{font-family:'Geist Mono',ui-monospace,monospace;font-size:13px;color:var(--accent)}
+  .panel{border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;overflow:hidden}
+  .panel-row{display:grid;grid-template-columns:150px 1fr;border-top:1px solid rgba(255,255,255,.07)}
+  .panel-row:first-child{border-top:0}
+  .panel-key{padding:18px 20px;border-right:1px solid rgba(255,255,255,.07);font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:var(--accent);background:color-mix(in srgb,var(--accent) 8%,transparent);letter-spacing:.04em}
+  .panel-val{padding:18px 20px;display:flex;align-items:center}
+  .panel-val p{font-size:14px;line-height:1.6;margin:0}
+  .diagram{border:1px solid rgba(255,255,255,.1);border-radius:12px;padding:30px 24px 22px;background:#0e0e10;margin:22px 0}
+  .diagram svg{display:block;width:100%;height:auto}
+  .chips{display:flex;gap:8px;flex-wrap:wrap;margin-top:22px}
+  .chips span{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#888d95;border:1px solid rgba(255,255,255,.12);padding:4px 8px;border-radius:5px}
+  .text-stack{display:flex;flex-direction:column;gap:16px}
+  .evidence-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px;margin:20px 0 6px}
+  .evidence-card{border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;padding:18px 18px 17px;min-height:128px}
+  .evidence-label{font-family:'Geist Mono',ui-monospace,monospace;font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:var(--accent);margin-bottom:10px}
+  .source-list{display:flex;flex-direction:column;gap:10px;margin-top:20px}
+  .source-ref{display:grid;grid-template-columns:150px 1fr;gap:14px;align-items:center;text-decoration:none;border:1px solid rgba(255,255,255,.1);border-radius:8px;background:#0e0e10;padding:12px 14px}
+  .source-ref:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent)}
+  .source-ref span{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:var(--accent);text-transform:uppercase;letter-spacing:.04em}
+  .source-ref code{color:#aeb3ba;word-break:break-word}
+  .boundary-box{border-left:2px solid var(--accent);background:#0e0e10;padding:18px 20px;margin-top:16px;border-radius:0 8px 8px 0}
+  .flow{display:flex;flex-direction:column}
+  .flow li{display:grid;grid-template-columns:28px 1fr;gap:14px;list-style:none}
+  .flow-num{width:24px;height:24px;border-radius:50%;border:1px solid color-mix(in srgb,var(--accent) 50%,transparent);display:flex;align-items:center;justify-content:center;font-family:'Geist Mono',ui-monospace,monospace;font-size:11.5px;color:var(--accent);background:#0b0b0c}
+  .flow-body{padding-bottom:18px;border-left:1px solid rgba(255,255,255,.12);padding-left:14px;margin-left:-27px}
+  .flow-title{font-size:14.5px;color:#eceef0;font-weight:500;margin-bottom:7px}
+  .metric-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px;margin-top:22px}
+  .metric{border:1px solid rgba(255,255,255,.1);border-radius:10px;padding:17px 19px;background:#0c0c0e}
+  .metric strong{display:block;font-size:24px;letter-spacing:-.02em;color:#fafafa}
+  .metric span{display:block;margin-top:5px;font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#62666d;text-transform:uppercase}
+  .search{width:100%;height:42px;margin:22px 0 16px;border:1px solid rgba(255,255,255,.12);border-radius:8px;background:#0e0e10;color:#f1f2f3;padding:0 12px;font:14px 'Geist',system-ui,sans-serif}
+  .cards{display:flex;flex-direction:column;gap:12px}
+  .card{display:block;text-decoration:none;border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;padding:18px 20px}
+  .card:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent)}
+  .card .meta{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#62666d;margin-bottom:8px}
+  .card p{font-size:14px;margin-top:9px}
+  .hide{display:none}
+  footer{margin-top:76px;color:#62666d;font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;line-height:1.7}
+  @media(max-width:720px){article{padding:52px 18px 90px}.panel-row{grid-template-columns:1fr}.panel-key{border-right:0;border-bottom:1px solid rgba(255,255,255,.07)}.metric-grid,.evidence-grid{grid-template-columns:1fr}.source-ref{grid-template-columns:1fr;gap:6px}}
+</style>
+</head>
+<body>
+<div class="gh">
+  <div class="grain"></div>
+  <article>
+
+    <nav class="nav" aria-label="Showcase navigation">
+      <a href="../index.html">Showcases</a>
+      <a href="../showcase-catalog.json">Catalog</a>
+      <a href="0617-blocked-p0-safe-rotation.en.html">English</a>
+    </nav>
+
+    <div class="mlab">2026-06-17 · benchmark-rotation</div>
+    <h1>P0 block 后推进 P1/P2</h1>
+    <div class="accent">用户决策不应阻塞全部安全工作。</div>
+    <p>The operator sees exactly what decision is needed while the agent can keep making bounded progress elsewhere.</p>
+    <div class="chips"><span>reproducible</span><span>user-gate</span><span>fallback</span></div>
+
+    <div class="diagram" aria-label="LoopX control-plane sketch">
+      <svg viewBox="0 0 760 320" role="img">
+        <rect width="760" height="320" fill="#0e0e10"></rect>
+        <rect x="285" y="34" width="190" height="58" rx="8" fill="none" stroke="#6e79d6" stroke-width="2"></rect>
+        <text x="380" y="68" text-anchor="middle" fill="#f1f2f3" font-size="15" font-weight="600">LoopX</text>
+        <line x1="380" y1="92" x2="380" y2="132" stroke="#3a3d42" stroke-width="2"></line>
+        <rect x="52" y="132" width="180" height="78" rx="8" fill="none" stroke="#6a6e76" stroke-width="2"></rect>
+        <rect x="290" y="124" width="180" height="94" rx="8" fill="#6e79d6" fill-opacity=".16" stroke="#6e79d6" stroke-width="2"></rect>
+        <rect x="528" y="132" width="180" height="78" rx="8" fill="none" stroke="#6a6e76" stroke-width="2"></rect>
+        <text x="142" y="166" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">P0 block 后推进 P1/P2</text>
+        <text x="380" y="163" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">concrete user todo</text>
+        <text x="618" y="166" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">reproducible synthetic d</text>
+        <text x="142" y="188" text-anchor="middle" fill="#62666d" font-size="11">goal / trigger</text>
+        <text x="380" y="185" text-anchor="middle" fill="#62666d" font-size="11">todo / gate / evidence</text>
+        <text x="618" y="188" text-anchor="middle" fill="#62666d" font-size="11">public outcome</text>
+        <line x1="232" y1="171" x2="282" y2="171" stroke="#6e79d6" stroke-width="2"></line>
+        <polygon points="290,171 280,165 280,177" fill="#6e79d6"></polygon>
+        <line x1="470" y1="171" x2="520" y2="171" stroke="#6e79d6" stroke-width="2"></line>
+        <polygon points="528,171 518,165 518,177" fill="#6e79d6"></polygon>
+        <path d="M618 210 L618 260 L142 260 L142 218" fill="none" stroke="#5a5e65" stroke-width="2"></path>
+        <polygon points="142,210 136,221 148,221" fill="#8a8088"></polygon>
+      </svg>
+    </div>
+
+
+    <div class="section-head"><span>01</span><h2>案例背景</h2></div>
+    <div class="text-stack"><p>这个案例展示 P0 被用户决策卡住时，系统不应该继续硬跑，也不应该让整个目标停摆。原场景是 benchmark rotation：一个 lane 需要大型本地 image，其他 no-upload benchmark work 仍然安全。</p><p>公开仓库没有暴露原始 benchmark task 或本地 image 名，而是用 synthetic smoke 复现控制面行为。</p></div>
+
+    <div class="section-head"><span>02</span><h2>仓库证据</h2></div>
+    <div class="panel">
+      <div class="panel-row"><div class="panel-key">证明点</div><div class="panel-val"><p>被阻塞的 P0 决策不应该阻止安全的 P1/P2 工作继续。</p></div></div>
+      <div class="panel-row"><div class="panel-key">LoopX 介入</div><div class="panel-val"><p>concrete user todo、safe fallback、quota control</p></div></div>
+    </div>
+
+    <div class="evidence-grid"><div class="evidence-card"><div class="evidence-label">synthetic fixture</div><p>`examples/showcase-0617-blocked-p0-safe-rotation-smoke.py` 构造 P0 user gate、被 gate 阻塞的 P0 agent todo 和 P1 no-upload fallback。</p></div><div class="evidence-card"><div class="evidence-label">quota contract</div><p>smoke 断言 `should_run=True`、`requires_user_action=True`、`safe_bypass_allowed=True`、`safe_bypass_kind=scoped_user_gate_fallback`。</p></div><div class="evidence-card"><div class="evidence-label">selected fallback</div><p>fixture 选择 `terminal_bench_no_upload`，同时保留 `ale_image` gate 的 user-visible blocker。</p></div><div class="evidence-card"><div class="evidence-label">rendered evidence</div><p>smoke 检查 markdown 中包含 `scoped_user_gate_fallback` 和 safe no-upload Terminal-Bench rotation。</p></div></div>
+
+    <div class="section-head"><span>03</span><h2>LoopX 行为</h2></div>
+    <ul class="flow"><li><span class="flow-num">1</span><div class="flow-body"><div class="flow-title">用户 todo 具体命名 P0 决策，不用“owner gate”这种空话。</div></div></li><li><span class="flow-num">2</span><div class="flow-body"><div class="flow-title">agent 不在 gated lane 上花 compute；只选择不依赖该决策的 fallback。</div></div></li><li><span class="flow-num">3</span><div class="flow-body"><div class="flow-title">状态同时记录 blocker 和 fallback reason，方便之后恢复 P0。</div></div></li></ul>
+
+    <div class="section-head"><span>04</span><h2>用户看到什么</h2></div>
+    <div class="text-stack"><p>用户看到需要自己决定的具体问题，同时项目仍能在安全范围内推进。</p><p>这减少了注意力负担：不需要每 10 分钟看一次 agent 为什么没动，也不会错过真正需要决策的事项。</p></div>
+
+    <div class="section-head"><span>05</span><h2>仓库来源</h2></div>
+    <div class="source-list"><a class="source-ref" href="0617-blocked-p0-safe-rotation.md"><span>case narrative</span><code>docs/showcases/cases/0617-blocked-p0-safe-rotation.md</code></a><a class="source-ref" href="../../../examples/showcase-0617-blocked-p0-safe-rotation-smoke.py"><span>synthetic smoke</span><code>examples/showcase-0617-blocked-p0-safe-rotation-smoke.py</code></a></div>
+    <div class="boundary-box"><p><strong>证据边界.</strong> Synthetic public fixture only; no private screenshots, raw tasks, internal links, local image names, or raw run logs.</p></div>
+    <div class="chips"><a class="case-link" href="0617-blocked-p0-safe-rotation.md">案例说明</a></div>
+    <div class="metric"><strong>Demo</strong><span><code>python3 examples/showcase-0617-blocked-p0-safe-rotation-smoke.py</code></span></div>
+    <footer>由 docs/showcases/showcase-catalog.json 生成。不包含私有链接、原始聊天、本地状态或内部媒体。</footer>
+  </article>
+</div>
+</body>
+</html>

--- a/docs/showcases/cases/0617-blocked-p0-safe-rotation.md
+++ b/docs/showcases/cases/0617-blocked-p0-safe-rotation.md
@@ -63,7 +63,7 @@ text, local image names, internal links, and raw run logs. The behavior is
 represented by a synthetic fixture because the reusable product value is the
 control-plane pattern, not the original private artifact.
 
-## Website Story Beats
+## Public Evidence Sequence
 
 1. A P0 lane becomes blocked by a concrete user decision.
 2. LoopX keeps that decision visible as a user todo.

--- a/docs/showcases/cases/0619-dynamic-workflow-hardware-agent.en.html
+++ b/docs/showcases/cases/0619-dynamic-workflow-hardware-agent.en.html
@@ -1,0 +1,138 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>LoopX Showcase: Dynamic workflow for hardware-agent development</title>
+  <link rel="icon" href="data:,">
+  <style>
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  body{background:#0b0b0c;color:#f1f2f3;font-family:'Geist',system-ui,-apple-system,BlinkMacSystemFont,sans-serif;-webkit-font-smoothing:antialiased}
+  a{color:inherit}
+  ::selection{background:color-mix(in srgb,var(--accent,#6e79d6) 34%,transparent);color:#fff}
+  .gh{min-height:100vh;position:relative;overflow-x:hidden;--accent:#6e79d6}
+  .grain{position:fixed;inset:0;pointer-events:none;opacity:.025;mix-blend-mode:overlay;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E")}
+  article{position:relative;max-width:800px;margin:0 auto;padding:76px 28px 130px}
+  .mlab{font-family:'Geist Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11px;letter-spacing:.06em;color:#62666d;text-transform:uppercase}
+  h1{font-size:clamp(31px,4.6vw,46px);font-weight:600;line-height:1.12;letter-spacing:-.03em;margin:16px 0 14px;color:#fafafa;text-wrap:balance}
+  h2{font-size:22px;font-weight:600;letter-spacing:-.02em;color:#f1f2f3}
+  h3{font-size:21px;font-weight:600;letter-spacing:-.02em;color:#f1f2f3}
+  p{font-size:15.5px;line-height:1.75;color:#9ea3aa}
+  strong{color:#e9eaec;font-weight:600}
+  code{font-family:'Geist Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:12.5px;color:#c4c7cc}
+  .accent{font-size:clamp(17px,2.1vw,21px);font-weight:500;color:var(--accent);letter-spacing:-.01em;margin-bottom:22px}
+  .nav{display:flex;gap:10px;flex-wrap:wrap;margin:0 0 28px}
+  .nav a,.case-link{font-family:'Geist Mono',ui-monospace,monospace;font-size:11px;letter-spacing:.04em;text-decoration:none;color:#c4c7cc;border:1px solid rgba(255,255,255,.12);border-radius:6px;padding:7px 10px;background:rgba(255,255,255,.025)}
+  .nav a:hover,.case-link:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent);color:#f4f4f5}
+  .section-head{margin-top:74px;display:flex;align-items:baseline;gap:13px;margin-bottom:20px}
+  .section-head span{font-family:'Geist Mono',ui-monospace,monospace;font-size:13px;color:var(--accent)}
+  .panel{border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;overflow:hidden}
+  .panel-row{display:grid;grid-template-columns:150px 1fr;border-top:1px solid rgba(255,255,255,.07)}
+  .panel-row:first-child{border-top:0}
+  .panel-key{padding:18px 20px;border-right:1px solid rgba(255,255,255,.07);font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:var(--accent);background:color-mix(in srgb,var(--accent) 8%,transparent);letter-spacing:.04em}
+  .panel-val{padding:18px 20px;display:flex;align-items:center}
+  .panel-val p{font-size:14px;line-height:1.6;margin:0}
+  .diagram{border:1px solid rgba(255,255,255,.1);border-radius:12px;padding:30px 24px 22px;background:#0e0e10;margin:22px 0}
+  .diagram svg{display:block;width:100%;height:auto}
+  .chips{display:flex;gap:8px;flex-wrap:wrap;margin-top:22px}
+  .chips span{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#888d95;border:1px solid rgba(255,255,255,.12);padding:4px 8px;border-radius:5px}
+  .text-stack{display:flex;flex-direction:column;gap:16px}
+  .evidence-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px;margin:20px 0 6px}
+  .evidence-card{border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;padding:18px 18px 17px;min-height:128px}
+  .evidence-label{font-family:'Geist Mono',ui-monospace,monospace;font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:var(--accent);margin-bottom:10px}
+  .source-list{display:flex;flex-direction:column;gap:10px;margin-top:20px}
+  .source-ref{display:grid;grid-template-columns:150px 1fr;gap:14px;align-items:center;text-decoration:none;border:1px solid rgba(255,255,255,.1);border-radius:8px;background:#0e0e10;padding:12px 14px}
+  .source-ref:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent)}
+  .source-ref span{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:var(--accent);text-transform:uppercase;letter-spacing:.04em}
+  .source-ref code{color:#aeb3ba;word-break:break-word}
+  .boundary-box{border-left:2px solid var(--accent);background:#0e0e10;padding:18px 20px;margin-top:16px;border-radius:0 8px 8px 0}
+  .flow{display:flex;flex-direction:column}
+  .flow li{display:grid;grid-template-columns:28px 1fr;gap:14px;list-style:none}
+  .flow-num{width:24px;height:24px;border-radius:50%;border:1px solid color-mix(in srgb,var(--accent) 50%,transparent);display:flex;align-items:center;justify-content:center;font-family:'Geist Mono',ui-monospace,monospace;font-size:11.5px;color:var(--accent);background:#0b0b0c}
+  .flow-body{padding-bottom:18px;border-left:1px solid rgba(255,255,255,.12);padding-left:14px;margin-left:-27px}
+  .flow-title{font-size:14.5px;color:#eceef0;font-weight:500;margin-bottom:7px}
+  .metric-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px;margin-top:22px}
+  .metric{border:1px solid rgba(255,255,255,.1);border-radius:10px;padding:17px 19px;background:#0c0c0e}
+  .metric strong{display:block;font-size:24px;letter-spacing:-.02em;color:#fafafa}
+  .metric span{display:block;margin-top:5px;font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#62666d;text-transform:uppercase}
+  .search{width:100%;height:42px;margin:22px 0 16px;border:1px solid rgba(255,255,255,.12);border-radius:8px;background:#0e0e10;color:#f1f2f3;padding:0 12px;font:14px 'Geist',system-ui,sans-serif}
+  .cards{display:flex;flex-direction:column;gap:12px}
+  .card{display:block;text-decoration:none;border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;padding:18px 20px}
+  .card:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent)}
+  .card .meta{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#62666d;margin-bottom:8px}
+  .card p{font-size:14px;margin-top:9px}
+  .hide{display:none}
+  footer{margin-top:76px;color:#62666d;font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;line-height:1.7}
+  @media(max-width:720px){article{padding:52px 18px 90px}.panel-row{grid-template-columns:1fr}.panel-key{border-right:0;border-bottom:1px solid rgba(255,255,255,.07)}.metric-grid,.evidence-grid{grid-template-columns:1fr}.source-ref{grid-template-columns:1fr;gap:6px}}
+</style>
+</head>
+<body>
+<div class="gh">
+  <div class="grain"></div>
+  <article>
+
+    <nav class="nav" aria-label="Showcase navigation">
+      <a href="../index.en.html">Showcases</a>
+      <a href="../showcase-catalog.json">Catalog</a>
+      <a href="0619-dynamic-workflow-hardware-agent.html">中文</a>
+    </nav>
+
+    <div class="mlab">2026-06-19 · hardware-agent-development</div>
+    <h1>Dynamic workflow for hardware-agent development</h1>
+    <div class="accent">A fuzzy long-running engineering goal needs a shared control plane when multiple worker agents participate.</div>
+    <p>A contributor-approved public artifact shows how one control plane can coordinate Claude Code, generated scripts, and hardware-agent workers across five long-running engineering cases.</p>
+    <div class="chips"><span>interactive-html</span><span>multi-agent</span><span>hardware</span></div>
+
+    <div class="diagram" aria-label="LoopX control-plane sketch">
+      <svg viewBox="0 0 760 320" role="img">
+        <rect width="760" height="320" fill="#0e0e10"></rect>
+        <rect x="285" y="34" width="190" height="58" rx="8" fill="none" stroke="#6e79d6" stroke-width="2"></rect>
+        <text x="380" y="68" text-anchor="middle" fill="#f1f2f3" font-size="15" font-weight="600">LoopX</text>
+        <line x1="380" y1="92" x2="380" y2="132" stroke="#3a3d42" stroke-width="2"></line>
+        <rect x="52" y="132" width="180" height="78" rx="8" fill="none" stroke="#6a6e76" stroke-width="2"></rect>
+        <rect x="290" y="124" width="180" height="94" rx="8" fill="#6e79d6" fill-opacity=".16" stroke="#6e79d6" stroke-width="2"></rect>
+        <rect x="528" y="132" width="180" height="78" rx="8" fill="none" stroke="#6a6e76" stroke-width="2"></rect>
+        <text x="142" y="166" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">Dynamic workflow for h</text>
+        <text x="380" y="163" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">goal state</text>
+        <text x="618" y="166" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">public safe interactive </text>
+        <text x="142" y="188" text-anchor="middle" fill="#62666d" font-size="11">goal / trigger</text>
+        <text x="380" y="185" text-anchor="middle" fill="#62666d" font-size="11">todo / gate / evidence</text>
+        <text x="618" y="188" text-anchor="middle" fill="#62666d" font-size="11">public outcome</text>
+        <line x1="232" y1="171" x2="282" y2="171" stroke="#6e79d6" stroke-width="2"></line>
+        <polygon points="290,171 280,165 280,177" fill="#6e79d6"></polygon>
+        <line x1="470" y1="171" x2="520" y2="171" stroke="#6e79d6" stroke-width="2"></line>
+        <polygon points="528,171 518,165 518,177" fill="#6e79d6"></polygon>
+        <path d="M618 210 L618 260 L142 260 L142 218" fill="none" stroke="#5a5e65" stroke-width="2"></path>
+        <polygon points="142,210 136,221 148,221" fill="#8a8088"></polygon>
+      </svg>
+    </div>
+
+
+    <div class="section-head"><span>01</span><h2>Case context</h2></div>
+    <div class="text-stack"><p>The Chinese hardware page remains the canonical artifact. This English companion follows its structure without rewriting the original.</p><p>The case demonstrates a dynamic workflow around fuzzy long-running hardware goals: generated scripts coordinate bounded worker-agent actions while LoopX preserves goal state, quota, todo ownership, validation evidence, and run history outside any one chat thread.</p></div>
+
+    <div class="section-head"><span>02</span><h2>Repository evidence</h2></div>
+    <div class="panel">
+      <div class="panel-row"><div class="panel-key">Proof</div><div class="panel-val"><p>Fuzzy goals, multiple workers, and long unattended runs can still converge.</p></div></div>
+      <div class="panel-row"><div class="panel-key">LoopX intervention</div><div class="panel-val"><p>goal state, worker handoff, dynamic workflow</p></div></div>
+    </div>
+
+    <div class="evidence-grid"><div class="evidence-card"><div class="evidence-label">Public artifact</div><p>The canonical HTML page includes the approved hardware workflow artifact and five public-safe hardware cases.</p></div><div class="evidence-card"><div class="evidence-label">Case family</div><p>The companion note names closed validation, timing optimization, design-space exploration, Fmax optimization, and convergence to an engineering floor.</p></div><div class="evidence-card"><div class="evidence-label">Boundary</div><p>The public artifact excludes raw chats, screenshots, proprietary design details, private repos, local paths, task ids, credentials, and unpublished hardware artifacts.</p></div></div>
+
+    <div class="section-head"><span>03</span><h2>LoopX behavior</h2></div>
+    <ul class="flow"><li><span class="flow-num">1</span><div class="flow-body"><div class="flow-title">LoopX owns durable state, quota, todos, claims, evidence, and history.</div></div></li><li><span class="flow-num">2</span><div class="flow-body"><div class="flow-title">Claude Code writes task-level orchestration and generated scripts.</div></div></li><li><span class="flow-num">3</span><div class="flow-body"><div class="flow-title">Worker agents perform bounded RTL, simulation, and validation work under explicit review boundaries.</div></div></li></ul>
+
+    <div class="section-head"><span>04</span><h2>What the user sees</h2></div>
+    <div class="text-stack"><p>A contributor-approved page shows how multiple hardware-agent workers can coordinate under one control plane.</p><p>Readers can inspect the product pattern without receiving proprietary hardware details or raw execution traces.</p></div>
+
+    <div class="section-head"><span>05</span><h2>Repository sources</h2></div>
+    <div class="source-list"><a class="source-ref" href="0619-dynamic-workflow-hardware-agent.html"><span>canonical HTML</span><code>docs/showcases/cases/0619-dynamic-workflow-hardware-agent.html</code></a><a class="source-ref" href="0619-dynamic-workflow-hardware-agent.md"><span>companion note</span><code>docs/showcases/cases/0619-dynamic-workflow-hardware-agent.md</code></a></div>
+    <div class="boundary-box"><p><strong>Evidence boundary.</strong> Public-safe interactive artifact; no raw chats, screenshots, proprietary design details, private repositories, local paths, task ids, credentials, or unpublished hardware artifacts.</p></div>
+    <div class="chips"><a class="case-link" href="0619-dynamic-workflow-hardware-agent.md">Case note</a></div>
+
+    <footer>Generated from docs/showcases/showcase-catalog.json. Private links, raw chats, local state, and internal media are excluded.</footer>
+  </article>
+</div>
+</body>
+</html>

--- a/docs/showcases/cases/0619-dynamic-workflow-hardware-agent.md
+++ b/docs/showcases/cases/0619-dynamic-workflow-hardware-agent.md
@@ -49,7 +49,7 @@ from the repository or hosted as part of the Frontstage Pages bundle. It is not
 a runnable hardware benchmark and should not be presented as a reproducible
 EDA workflow.
 
-## Website Story Beats
+## Public Evidence Sequence
 
 1. A fuzzy engineering goal needs more than one worker agent.
 2. LoopX gives the agents a shared state and ownership surface.

--- a/docs/showcases/cases/0619-loopx-self-iteration.en.html
+++ b/docs/showcases/cases/0619-loopx-self-iteration.en.html
@@ -1,0 +1,138 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>LoopX Showcase: LoopX self-iteration loop</title>
+  <link rel="icon" href="data:,">
+  <style>
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  body{background:#0b0b0c;color:#f1f2f3;font-family:'Geist',system-ui,-apple-system,BlinkMacSystemFont,sans-serif;-webkit-font-smoothing:antialiased}
+  a{color:inherit}
+  ::selection{background:color-mix(in srgb,var(--accent,#6e79d6) 34%,transparent);color:#fff}
+  .gh{min-height:100vh;position:relative;overflow-x:hidden;--accent:#6e79d6}
+  .grain{position:fixed;inset:0;pointer-events:none;opacity:.025;mix-blend-mode:overlay;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E")}
+  article{position:relative;max-width:800px;margin:0 auto;padding:76px 28px 130px}
+  .mlab{font-family:'Geist Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11px;letter-spacing:.06em;color:#62666d;text-transform:uppercase}
+  h1{font-size:clamp(31px,4.6vw,46px);font-weight:600;line-height:1.12;letter-spacing:-.03em;margin:16px 0 14px;color:#fafafa;text-wrap:balance}
+  h2{font-size:22px;font-weight:600;letter-spacing:-.02em;color:#f1f2f3}
+  h3{font-size:21px;font-weight:600;letter-spacing:-.02em;color:#f1f2f3}
+  p{font-size:15.5px;line-height:1.75;color:#9ea3aa}
+  strong{color:#e9eaec;font-weight:600}
+  code{font-family:'Geist Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:12.5px;color:#c4c7cc}
+  .accent{font-size:clamp(17px,2.1vw,21px);font-weight:500;color:var(--accent);letter-spacing:-.01em;margin-bottom:22px}
+  .nav{display:flex;gap:10px;flex-wrap:wrap;margin:0 0 28px}
+  .nav a,.case-link{font-family:'Geist Mono',ui-monospace,monospace;font-size:11px;letter-spacing:.04em;text-decoration:none;color:#c4c7cc;border:1px solid rgba(255,255,255,.12);border-radius:6px;padding:7px 10px;background:rgba(255,255,255,.025)}
+  .nav a:hover,.case-link:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent);color:#f4f4f5}
+  .section-head{margin-top:74px;display:flex;align-items:baseline;gap:13px;margin-bottom:20px}
+  .section-head span{font-family:'Geist Mono',ui-monospace,monospace;font-size:13px;color:var(--accent)}
+  .panel{border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;overflow:hidden}
+  .panel-row{display:grid;grid-template-columns:150px 1fr;border-top:1px solid rgba(255,255,255,.07)}
+  .panel-row:first-child{border-top:0}
+  .panel-key{padding:18px 20px;border-right:1px solid rgba(255,255,255,.07);font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:var(--accent);background:color-mix(in srgb,var(--accent) 8%,transparent);letter-spacing:.04em}
+  .panel-val{padding:18px 20px;display:flex;align-items:center}
+  .panel-val p{font-size:14px;line-height:1.6;margin:0}
+  .diagram{border:1px solid rgba(255,255,255,.1);border-radius:12px;padding:30px 24px 22px;background:#0e0e10;margin:22px 0}
+  .diagram svg{display:block;width:100%;height:auto}
+  .chips{display:flex;gap:8px;flex-wrap:wrap;margin-top:22px}
+  .chips span{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#888d95;border:1px solid rgba(255,255,255,.12);padding:4px 8px;border-radius:5px}
+  .text-stack{display:flex;flex-direction:column;gap:16px}
+  .evidence-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px;margin:20px 0 6px}
+  .evidence-card{border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;padding:18px 18px 17px;min-height:128px}
+  .evidence-label{font-family:'Geist Mono',ui-monospace,monospace;font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:var(--accent);margin-bottom:10px}
+  .source-list{display:flex;flex-direction:column;gap:10px;margin-top:20px}
+  .source-ref{display:grid;grid-template-columns:150px 1fr;gap:14px;align-items:center;text-decoration:none;border:1px solid rgba(255,255,255,.1);border-radius:8px;background:#0e0e10;padding:12px 14px}
+  .source-ref:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent)}
+  .source-ref span{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:var(--accent);text-transform:uppercase;letter-spacing:.04em}
+  .source-ref code{color:#aeb3ba;word-break:break-word}
+  .boundary-box{border-left:2px solid var(--accent);background:#0e0e10;padding:18px 20px;margin-top:16px;border-radius:0 8px 8px 0}
+  .flow{display:flex;flex-direction:column}
+  .flow li{display:grid;grid-template-columns:28px 1fr;gap:14px;list-style:none}
+  .flow-num{width:24px;height:24px;border-radius:50%;border:1px solid color-mix(in srgb,var(--accent) 50%,transparent);display:flex;align-items:center;justify-content:center;font-family:'Geist Mono',ui-monospace,monospace;font-size:11.5px;color:var(--accent);background:#0b0b0c}
+  .flow-body{padding-bottom:18px;border-left:1px solid rgba(255,255,255,.12);padding-left:14px;margin-left:-27px}
+  .flow-title{font-size:14.5px;color:#eceef0;font-weight:500;margin-bottom:7px}
+  .metric-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px;margin-top:22px}
+  .metric{border:1px solid rgba(255,255,255,.1);border-radius:10px;padding:17px 19px;background:#0c0c0e}
+  .metric strong{display:block;font-size:24px;letter-spacing:-.02em;color:#fafafa}
+  .metric span{display:block;margin-top:5px;font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#62666d;text-transform:uppercase}
+  .search{width:100%;height:42px;margin:22px 0 16px;border:1px solid rgba(255,255,255,.12);border-radius:8px;background:#0e0e10;color:#f1f2f3;padding:0 12px;font:14px 'Geist',system-ui,sans-serif}
+  .cards{display:flex;flex-direction:column;gap:12px}
+  .card{display:block;text-decoration:none;border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;padding:18px 20px}
+  .card:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent)}
+  .card .meta{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#62666d;margin-bottom:8px}
+  .card p{font-size:14px;margin-top:9px}
+  .hide{display:none}
+  footer{margin-top:76px;color:#62666d;font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;line-height:1.7}
+  @media(max-width:720px){article{padding:52px 18px 90px}.panel-row{grid-template-columns:1fr}.panel-key{border-right:0;border-bottom:1px solid rgba(255,255,255,.07)}.metric-grid,.evidence-grid{grid-template-columns:1fr}.source-ref{grid-template-columns:1fr;gap:6px}}
+</style>
+</head>
+<body>
+<div class="gh">
+  <div class="grain"></div>
+  <article>
+
+    <nav class="nav" aria-label="Showcase navigation">
+      <a href="../index.en.html">Showcases</a>
+      <a href="../showcase-catalog.json">Catalog</a>
+      <a href="0619-loopx-self-iteration.html">中文</a>
+    </nav>
+
+    <div class="mlab">2026-06-19 · agent-platform-self-improvement</div>
+    <h1>LoopX self-iteration loop</h1>
+    <div class="accent">A high-churn LoopX repo stayed legible while benchmark, product, docs, planning, and side-agent lanes moved in parallel.</div>
+    <p>The operator can let a fast-moving multi-lane agent project continue across benchmark, product, docs, and side-agent work while keeping ownership, gates, validation, follow-up, and conservative efficiency evidence visible in one shared control plane.</p>
+    <div class="chips"><span>self-iteration</span><span>commit-backed</span><span>side-agent</span><span>efficiency-model</span></div>
+
+    <div class="diagram" aria-label="LoopX control-plane sketch">
+      <svg viewBox="0 0 760 320" role="img">
+        <rect width="760" height="320" fill="#0e0e10"></rect>
+        <rect x="285" y="34" width="190" height="58" rx="8" fill="none" stroke="#6e79d6" stroke-width="2"></rect>
+        <text x="380" y="68" text-anchor="middle" fill="#f1f2f3" font-size="15" font-weight="600">LoopX</text>
+        <line x1="380" y1="92" x2="380" y2="132" stroke="#3a3d42" stroke-width="2"></line>
+        <rect x="52" y="132" width="180" height="78" rx="8" fill="none" stroke="#6a6e76" stroke-width="2"></rect>
+        <rect x="290" y="124" width="180" height="94" rx="8" fill="#6e79d6" fill-opacity=".16" stroke="#6e79d6" stroke-width="2"></rect>
+        <rect x="528" y="132" width="180" height="78" rx="8" fill="none" stroke="#6a6e76" stroke-width="2"></rect>
+        <text x="142" y="166" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">LoopX self-iteration l</text>
+        <text x="380" y="163" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">todo</text>
+        <text x="618" y="166" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">public evidence case</text>
+        <text x="142" y="188" text-anchor="middle" fill="#62666d" font-size="11">goal / trigger</text>
+        <text x="380" y="185" text-anchor="middle" fill="#62666d" font-size="11">todo / gate / evidence</text>
+        <text x="618" y="188" text-anchor="middle" fill="#62666d" font-size="11">public outcome</text>
+        <line x1="232" y1="171" x2="282" y2="171" stroke="#6e79d6" stroke-width="2"></line>
+        <polygon points="290,171 280,165 280,177" fill="#6e79d6"></polygon>
+        <line x1="470" y1="171" x2="520" y2="171" stroke="#6e79d6" stroke-width="2"></line>
+        <polygon points="528,171 518,165 518,177" fill="#6e79d6"></polygon>
+        <path d="M618 210 L618 260 L142 260 L142 218" fill="none" stroke="#5a5e65" stroke-width="2"></path>
+        <polygon points="142,210 136,221 148,221" fill="#8a8088"></polygon>
+      </svg>
+    </div>
+
+
+    <div class="section-head"><span>01</span><h2>Case context</h2></div>
+    <div class="text-stack"><p>This is public-repo self-iteration: LoopX was used to improve LoopX itself, not just one isolated demo. Benchmark adapters, control-plane correctness, planning lanes, dashboard/frontstage, docs, smokes, and multi-agent coordination all moved under high churn.</p><p>The evidence is fixed to anchor commit `86d6d9d` so this documentation update does not change its own evidence window. The efficiency model is a conservative public-Git model; it excludes private chats, active-state bodies, and raw benchmark material.</p></div>
+
+    <div class="section-head"><span>02</span><h2>Repository evidence</h2></div>
+    <div class="panel">
+      <div class="panel-row"><div class="panel-key">Proof</div><div class="panel-val"><p>A high-churn multi-lane project can keep state, boundaries, and evidence coherent.</p></div></div>
+      <div class="panel-row"><div class="panel-key">LoopX intervention</div><div class="panel-val"><p>todo, quota, gate, evidence, review packet, frontstage</p></div></div>
+    </div>
+    <div class="metric-grid"><div class="metric"><strong>801</strong><span>public commits</span></div><div class="metric"><strong>59-92d</strong><span>AI-assisted baseline</span></div><div class="metric"><strong>3.0-4.7x</strong><span>calendar compression</span></div></div>
+    <div class="evidence-grid"><div class="evidence-card"><div class="evidence-label">Whole repository</div><p>Through the anchor commit: 801 public commits, 570 touched files, 265703 insertions, and 49895 deletions.</p></div><div class="evidence-card"><div class="evidence-label">Recent window</div><p>Since 2026-06-18: 244 public commits, 216 touched files, 52898 insertions, and 20935 deletions.</p></div><div class="evidence-card"><div class="evidence-label">June 19 signal</div><p>On 2026-06-19: 74 public commits, 118 touched files, 16087 insertions, and 1082 deletions.</p></div><div class="evidence-card"><div class="evidence-label">Efficiency model</div><p>The case maps public repo capabilities to 9 requirement clusters and estimates 59-92 AI-coding-assisted developer-days against a 19.6-day public window.</p></div></div>
+
+    <div class="section-head"><span>03</span><h2>LoopX behavior</h2></div>
+    <ul class="flow"><li><span class="flow-num">1</span><div class="flow-body"><div class="flow-title">Registry and prompt contracts name primary and side-agent identities instead of relying on chat memory.</div></div></li><li><span class="flow-num">2</span><div class="flow-body"><div class="flow-title">Benchmark, productization, documentation, planning, and side-agent lanes become reviewable obligations.</div></div></li><li><span class="flow-num">3</span><div class="flow-body"><div class="flow-title">Quota and status projection distinguish executable work, monitor work, user gates, and blockers.</div></div></li><li><span class="flow-num">4</span><div class="flow-body"><div class="flow-title">Side-agent scope lives in prompt and handoff; todo metadata keeps the compact `claimed_by` owner.</div></div></li><li><span class="flow-num">5</span><div class="flow-body"><div class="flow-title">Public docs and smokes turn reusable lessons into repository artifacts.</div></div></li></ul>
+
+    <div class="section-head"><span>04</span><h2>What the user sees</h2></div>
+    <div class="text-stack"><p>The operator can let a primary benchmark lane and product/docs/control-plane side work run in parallel without losing ownership, gates, validation, or merge discipline.</p><p>For a potential user, this is evidence that a long-running agent project can remain legible: future agents can recover goals, owners, gates, validation, evidence, and follow-up from public surfaces.</p></div>
+
+    <div class="section-head"><span>05</span><h2>Repository sources</h2></div>
+    <div class="source-list"><a class="source-ref" href="0619-loopx-self-iteration.md"><span>case narrative</span><code>docs/showcases/cases/0619-loopx-self-iteration.md</code></a><a class="source-ref" href="../showcase-catalog.json"><span>workload signal</span><code>docs/showcases/showcase-catalog.json</code></a><a class="source-ref" href="../../../examples/fixtures/long-horizon-self-iteration-rollout.public.json"><span>frontstage fixture</span><code>examples/fixtures/long-horizon-self-iteration-rollout.public.json</code></a><a class="source-ref" href="../../../examples/long-horizon-self-iteration-rollout-fixture-smoke.py"><span>frontstage smoke</span><code>examples/long-horizon-self-iteration-rollout-fixture-smoke.py</code></a></div>
+    <div class="boundary-box"><p><strong>Evidence boundary.</strong> Public Git evidence only; no private thread text, local active-state bodies, internal document links, screenshots, raw benchmark material, credentials, or machine-specific paths.</p></div>
+    <div class="chips"><a class="case-link" href="0619-loopx-self-iteration.md">Case note</a></div>
+
+    <footer>Generated from docs/showcases/showcase-catalog.json. Private links, raw chats, local state, and internal media are excluded.</footer>
+  </article>
+</div>
+</body>
+</html>

--- a/docs/showcases/cases/0619-loopx-self-iteration.html
+++ b/docs/showcases/cases/0619-loopx-self-iteration.html
@@ -1,0 +1,138 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>LoopX Showcase: LoopX Meta Agent 自迭代</title>
+  <link rel="icon" href="data:,">
+  <style>
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  body{background:#0b0b0c;color:#f1f2f3;font-family:'Geist',system-ui,-apple-system,BlinkMacSystemFont,sans-serif;-webkit-font-smoothing:antialiased}
+  a{color:inherit}
+  ::selection{background:color-mix(in srgb,var(--accent,#6e79d6) 34%,transparent);color:#fff}
+  .gh{min-height:100vh;position:relative;overflow-x:hidden;--accent:#6e79d6}
+  .grain{position:fixed;inset:0;pointer-events:none;opacity:.025;mix-blend-mode:overlay;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E")}
+  article{position:relative;max-width:800px;margin:0 auto;padding:76px 28px 130px}
+  .mlab{font-family:'Geist Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11px;letter-spacing:.06em;color:#62666d;text-transform:uppercase}
+  h1{font-size:clamp(31px,4.6vw,46px);font-weight:600;line-height:1.12;letter-spacing:-.03em;margin:16px 0 14px;color:#fafafa;text-wrap:balance}
+  h2{font-size:22px;font-weight:600;letter-spacing:-.02em;color:#f1f2f3}
+  h3{font-size:21px;font-weight:600;letter-spacing:-.02em;color:#f1f2f3}
+  p{font-size:15.5px;line-height:1.75;color:#9ea3aa}
+  strong{color:#e9eaec;font-weight:600}
+  code{font-family:'Geist Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:12.5px;color:#c4c7cc}
+  .accent{font-size:clamp(17px,2.1vw,21px);font-weight:500;color:var(--accent);letter-spacing:-.01em;margin-bottom:22px}
+  .nav{display:flex;gap:10px;flex-wrap:wrap;margin:0 0 28px}
+  .nav a,.case-link{font-family:'Geist Mono',ui-monospace,monospace;font-size:11px;letter-spacing:.04em;text-decoration:none;color:#c4c7cc;border:1px solid rgba(255,255,255,.12);border-radius:6px;padding:7px 10px;background:rgba(255,255,255,.025)}
+  .nav a:hover,.case-link:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent);color:#f4f4f5}
+  .section-head{margin-top:74px;display:flex;align-items:baseline;gap:13px;margin-bottom:20px}
+  .section-head span{font-family:'Geist Mono',ui-monospace,monospace;font-size:13px;color:var(--accent)}
+  .panel{border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;overflow:hidden}
+  .panel-row{display:grid;grid-template-columns:150px 1fr;border-top:1px solid rgba(255,255,255,.07)}
+  .panel-row:first-child{border-top:0}
+  .panel-key{padding:18px 20px;border-right:1px solid rgba(255,255,255,.07);font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:var(--accent);background:color-mix(in srgb,var(--accent) 8%,transparent);letter-spacing:.04em}
+  .panel-val{padding:18px 20px;display:flex;align-items:center}
+  .panel-val p{font-size:14px;line-height:1.6;margin:0}
+  .diagram{border:1px solid rgba(255,255,255,.1);border-radius:12px;padding:30px 24px 22px;background:#0e0e10;margin:22px 0}
+  .diagram svg{display:block;width:100%;height:auto}
+  .chips{display:flex;gap:8px;flex-wrap:wrap;margin-top:22px}
+  .chips span{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#888d95;border:1px solid rgba(255,255,255,.12);padding:4px 8px;border-radius:5px}
+  .text-stack{display:flex;flex-direction:column;gap:16px}
+  .evidence-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px;margin:20px 0 6px}
+  .evidence-card{border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;padding:18px 18px 17px;min-height:128px}
+  .evidence-label{font-family:'Geist Mono',ui-monospace,monospace;font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:var(--accent);margin-bottom:10px}
+  .source-list{display:flex;flex-direction:column;gap:10px;margin-top:20px}
+  .source-ref{display:grid;grid-template-columns:150px 1fr;gap:14px;align-items:center;text-decoration:none;border:1px solid rgba(255,255,255,.1);border-radius:8px;background:#0e0e10;padding:12px 14px}
+  .source-ref:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent)}
+  .source-ref span{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:var(--accent);text-transform:uppercase;letter-spacing:.04em}
+  .source-ref code{color:#aeb3ba;word-break:break-word}
+  .boundary-box{border-left:2px solid var(--accent);background:#0e0e10;padding:18px 20px;margin-top:16px;border-radius:0 8px 8px 0}
+  .flow{display:flex;flex-direction:column}
+  .flow li{display:grid;grid-template-columns:28px 1fr;gap:14px;list-style:none}
+  .flow-num{width:24px;height:24px;border-radius:50%;border:1px solid color-mix(in srgb,var(--accent) 50%,transparent);display:flex;align-items:center;justify-content:center;font-family:'Geist Mono',ui-monospace,monospace;font-size:11.5px;color:var(--accent);background:#0b0b0c}
+  .flow-body{padding-bottom:18px;border-left:1px solid rgba(255,255,255,.12);padding-left:14px;margin-left:-27px}
+  .flow-title{font-size:14.5px;color:#eceef0;font-weight:500;margin-bottom:7px}
+  .metric-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px;margin-top:22px}
+  .metric{border:1px solid rgba(255,255,255,.1);border-radius:10px;padding:17px 19px;background:#0c0c0e}
+  .metric strong{display:block;font-size:24px;letter-spacing:-.02em;color:#fafafa}
+  .metric span{display:block;margin-top:5px;font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#62666d;text-transform:uppercase}
+  .search{width:100%;height:42px;margin:22px 0 16px;border:1px solid rgba(255,255,255,.12);border-radius:8px;background:#0e0e10;color:#f1f2f3;padding:0 12px;font:14px 'Geist',system-ui,sans-serif}
+  .cards{display:flex;flex-direction:column;gap:12px}
+  .card{display:block;text-decoration:none;border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;padding:18px 20px}
+  .card:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent)}
+  .card .meta{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#62666d;margin-bottom:8px}
+  .card p{font-size:14px;margin-top:9px}
+  .hide{display:none}
+  footer{margin-top:76px;color:#62666d;font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;line-height:1.7}
+  @media(max-width:720px){article{padding:52px 18px 90px}.panel-row{grid-template-columns:1fr}.panel-key{border-right:0;border-bottom:1px solid rgba(255,255,255,.07)}.metric-grid,.evidence-grid{grid-template-columns:1fr}.source-ref{grid-template-columns:1fr;gap:6px}}
+</style>
+</head>
+<body>
+<div class="gh">
+  <div class="grain"></div>
+  <article>
+
+    <nav class="nav" aria-label="Showcase navigation">
+      <a href="../index.html">Showcases</a>
+      <a href="../showcase-catalog.json">Catalog</a>
+      <a href="0619-loopx-self-iteration.en.html">English</a>
+    </nav>
+
+    <div class="mlab">2026-06-19 · agent-platform-self-improvement</div>
+    <h1>LoopX Meta Agent 自迭代</h1>
+    <div class="accent">高变更、多车道项目可保持状态、边界和证据。</div>
+    <p>The operator can let a fast-moving multi-lane agent project continue across benchmark, product, docs, and side-agent work while keeping ownership, gates, validation, follow-up, and conservative efficiency evidence visible in one shared control plane.</p>
+    <div class="chips"><span>self-iteration</span><span>commit-backed</span><span>side-agent</span><span>efficiency-model</span></div>
+
+    <div class="diagram" aria-label="LoopX control-plane sketch">
+      <svg viewBox="0 0 760 320" role="img">
+        <rect width="760" height="320" fill="#0e0e10"></rect>
+        <rect x="285" y="34" width="190" height="58" rx="8" fill="none" stroke="#6e79d6" stroke-width="2"></rect>
+        <text x="380" y="68" text-anchor="middle" fill="#f1f2f3" font-size="15" font-weight="600">LoopX</text>
+        <line x1="380" y1="92" x2="380" y2="132" stroke="#3a3d42" stroke-width="2"></line>
+        <rect x="52" y="132" width="180" height="78" rx="8" fill="none" stroke="#6a6e76" stroke-width="2"></rect>
+        <rect x="290" y="124" width="180" height="94" rx="8" fill="#6e79d6" fill-opacity=".16" stroke="#6e79d6" stroke-width="2"></rect>
+        <rect x="528" y="132" width="180" height="78" rx="8" fill="none" stroke="#6a6e76" stroke-width="2"></rect>
+        <text x="142" y="166" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">LoopX Meta Agent 自迭代</text>
+        <text x="380" y="163" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">todo</text>
+        <text x="618" y="166" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">public evidence case</text>
+        <text x="142" y="188" text-anchor="middle" fill="#62666d" font-size="11">goal / trigger</text>
+        <text x="380" y="185" text-anchor="middle" fill="#62666d" font-size="11">todo / gate / evidence</text>
+        <text x="618" y="188" text-anchor="middle" fill="#62666d" font-size="11">public outcome</text>
+        <line x1="232" y1="171" x2="282" y2="171" stroke="#6e79d6" stroke-width="2"></line>
+        <polygon points="290,171 280,165 280,177" fill="#6e79d6"></polygon>
+        <line x1="470" y1="171" x2="520" y2="171" stroke="#6e79d6" stroke-width="2"></line>
+        <polygon points="528,171 518,165 518,177" fill="#6e79d6"></polygon>
+        <path d="M618 210 L618 260 L142 260 L142 218" fill="none" stroke="#5a5e65" stroke-width="2"></path>
+        <polygon points="142,210 136,221 148,221" fill="#8a8088"></polygon>
+      </svg>
+    </div>
+
+
+    <div class="section-head"><span>01</span><h2>案例背景</h2></div>
+    <div class="text-stack"><p>这个案例是 public repo self-iteration：LoopX 用来推进 LoopX 自己，不是一个孤立功能 demo。仓库在 benchmark adapters、control-plane correctness、planning lanes、dashboard/frontstage、docs、smokes 和 multi-agent coordination 上同时高频变化。</p><p>证据窗口固定到 anchor commit `86d6d9d`，避免文档更新改变自己的证据。这里的效率模型是保守的 public Git model，不使用私有聊天、active-state 原文或 benchmark 原始材料。</p></div>
+
+    <div class="section-head"><span>02</span><h2>仓库证据</h2></div>
+    <div class="panel">
+      <div class="panel-row"><div class="panel-key">证明点</div><div class="panel-val"><p>高 churn 多 lane agent repo 可以保持状态、证据和边界一致。</p></div></div>
+      <div class="panel-row"><div class="panel-key">LoopX 介入</div><div class="panel-val"><p>todo、quota、gate、evidence、review packet、frontstage</p></div></div>
+    </div>
+    <div class="metric-grid"><div class="metric"><strong>801</strong><span>public commits</span></div><div class="metric"><strong>59-92d</strong><span>AI-assisted baseline</span></div><div class="metric"><strong>3.0-4.7x</strong><span>calendar compression</span></div></div>
+    <div class="evidence-grid"><div class="evidence-card"><div class="evidence-label">全仓库证据</div><p>截至 anchor commit：801 个 public commits、570 个 touched files、265703 行新增、49895 行删除。</p></div><div class="evidence-card"><div class="evidence-label">近期窗口</div><p>2026-06-18 起有 244 个 public commits、216 个 touched files、52898 行新增、20935 行删除。</p></div><div class="evidence-card"><div class="evidence-label">0619 当日</div><p>2026-06-19 有 74 个 public commits、118 个 touched files、16087 行新增、1082 行删除。</p></div><div class="evidence-card"><div class="evidence-label">效率模型</div><p>把公开仓库能力拆成 9 个 requirement clusters，保守估计 59-92 个 AI-coding-assisted developer-days，对 19.6 天 public window 得出方向性 compression。</p></div></div>
+
+    <div class="section-head"><span>03</span><h2>LoopX 行为</h2></div>
+    <ul class="flow"><li><span class="flow-num">1</span><div class="flow-body"><div class="flow-title">registry、prompt contracts 和 registered agents 命名 primary/side identities，不靠聊天记忆。</div></div></li><li><span class="flow-num">2</span><div class="flow-body"><div class="flow-title">benchmark、productization、documentation、planning 和 side-agent lanes 被拆成 reviewable obligations。</div></div></li><li><span class="flow-num">3</span><div class="flow-body"><div class="flow-title">quota/status projection 区分 executable work、monitor work、user gates 和 blockers。</div></div></li><li><span class="flow-num">4</span><div class="flow-body"><div class="flow-title">side-agent scope 留在 prompt/handoff，todo metadata 只保留 `claimed_by`。</div></div></li><li><span class="flow-num">5</span><div class="flow-body"><div class="flow-title">public docs 和 smokes 把可复用经验沉淀为仓库 artifact。</div></div></li></ul>
+
+    <div class="section-head"><span>04</span><h2>用户看到什么</h2></div>
+    <div class="text-stack"><p>operator 可以让 primary benchmark lane 和 product/docs/control-plane side work 并行，而不会失去 ownership、gate、validation 和 merge discipline。</p><p>对潜在用户来说，这是“长期 agent 项目仍然可读”的证据：未来 agent 能从公开表面恢复目标、owner、gate、验证、证据和 follow-up。</p></div>
+
+    <div class="section-head"><span>05</span><h2>仓库来源</h2></div>
+    <div class="source-list"><a class="source-ref" href="0619-loopx-self-iteration.md"><span>case narrative</span><code>docs/showcases/cases/0619-loopx-self-iteration.md</code></a><a class="source-ref" href="../showcase-catalog.json"><span>workload signal</span><code>docs/showcases/showcase-catalog.json</code></a><a class="source-ref" href="../../../examples/fixtures/long-horizon-self-iteration-rollout.public.json"><span>frontstage fixture</span><code>examples/fixtures/long-horizon-self-iteration-rollout.public.json</code></a><a class="source-ref" href="../../../examples/long-horizon-self-iteration-rollout-fixture-smoke.py"><span>frontstage smoke</span><code>examples/long-horizon-self-iteration-rollout-fixture-smoke.py</code></a></div>
+    <div class="boundary-box"><p><strong>证据边界.</strong> Public Git evidence only; no private thread text, local active-state bodies, internal document links, screenshots, raw benchmark material, credentials, or machine-specific paths.</p></div>
+    <div class="chips"><a class="case-link" href="0619-loopx-self-iteration.md">案例说明</a></div>
+
+    <footer>由 docs/showcases/showcase-catalog.json 生成。不包含私有链接、原始聊天、本地状态或内部媒体。</footer>
+  </article>
+</div>
+</body>
+</html>

--- a/docs/showcases/cases/0619-loopx-self-iteration.md
+++ b/docs/showcases/cases/0619-loopx-self-iteration.md
@@ -196,7 +196,7 @@ checks. It excludes private thread text, local active-state bodies, internal
 document links, screenshots, raw benchmark material, credentials, and
 machine-specific paths.
 
-## Website Story Beats
+## Public Evidence Sequence
 
 1. A long-running agent engineering repo is moving quickly across benchmark,
    runtime, docs, dashboard, planning, and smoke surfaces.

--- a/docs/showcases/cases/0620-creator-operator-case-spec.en.html
+++ b/docs/showcases/cases/0620-creator-operator-case-spec.en.html
@@ -1,0 +1,138 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>LoopX Showcase: Creator-operator long-running agent case</title>
+  <link rel="icon" href="data:,">
+  <style>
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  body{background:#0b0b0c;color:#f1f2f3;font-family:'Geist',system-ui,-apple-system,BlinkMacSystemFont,sans-serif;-webkit-font-smoothing:antialiased}
+  a{color:inherit}
+  ::selection{background:color-mix(in srgb,var(--accent,#6e79d6) 34%,transparent);color:#fff}
+  .gh{min-height:100vh;position:relative;overflow-x:hidden;--accent:#6e79d6}
+  .grain{position:fixed;inset:0;pointer-events:none;opacity:.025;mix-blend-mode:overlay;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E")}
+  article{position:relative;max-width:800px;margin:0 auto;padding:76px 28px 130px}
+  .mlab{font-family:'Geist Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11px;letter-spacing:.06em;color:#62666d;text-transform:uppercase}
+  h1{font-size:clamp(31px,4.6vw,46px);font-weight:600;line-height:1.12;letter-spacing:-.03em;margin:16px 0 14px;color:#fafafa;text-wrap:balance}
+  h2{font-size:22px;font-weight:600;letter-spacing:-.02em;color:#f1f2f3}
+  h3{font-size:21px;font-weight:600;letter-spacing:-.02em;color:#f1f2f3}
+  p{font-size:15.5px;line-height:1.75;color:#9ea3aa}
+  strong{color:#e9eaec;font-weight:600}
+  code{font-family:'Geist Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:12.5px;color:#c4c7cc}
+  .accent{font-size:clamp(17px,2.1vw,21px);font-weight:500;color:var(--accent);letter-spacing:-.01em;margin-bottom:22px}
+  .nav{display:flex;gap:10px;flex-wrap:wrap;margin:0 0 28px}
+  .nav a,.case-link{font-family:'Geist Mono',ui-monospace,monospace;font-size:11px;letter-spacing:.04em;text-decoration:none;color:#c4c7cc;border:1px solid rgba(255,255,255,.12);border-radius:6px;padding:7px 10px;background:rgba(255,255,255,.025)}
+  .nav a:hover,.case-link:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent);color:#f4f4f5}
+  .section-head{margin-top:74px;display:flex;align-items:baseline;gap:13px;margin-bottom:20px}
+  .section-head span{font-family:'Geist Mono',ui-monospace,monospace;font-size:13px;color:var(--accent)}
+  .panel{border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;overflow:hidden}
+  .panel-row{display:grid;grid-template-columns:150px 1fr;border-top:1px solid rgba(255,255,255,.07)}
+  .panel-row:first-child{border-top:0}
+  .panel-key{padding:18px 20px;border-right:1px solid rgba(255,255,255,.07);font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:var(--accent);background:color-mix(in srgb,var(--accent) 8%,transparent);letter-spacing:.04em}
+  .panel-val{padding:18px 20px;display:flex;align-items:center}
+  .panel-val p{font-size:14px;line-height:1.6;margin:0}
+  .diagram{border:1px solid rgba(255,255,255,.1);border-radius:12px;padding:30px 24px 22px;background:#0e0e10;margin:22px 0}
+  .diagram svg{display:block;width:100%;height:auto}
+  .chips{display:flex;gap:8px;flex-wrap:wrap;margin-top:22px}
+  .chips span{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#888d95;border:1px solid rgba(255,255,255,.12);padding:4px 8px;border-radius:5px}
+  .text-stack{display:flex;flex-direction:column;gap:16px}
+  .evidence-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px;margin:20px 0 6px}
+  .evidence-card{border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;padding:18px 18px 17px;min-height:128px}
+  .evidence-label{font-family:'Geist Mono',ui-monospace,monospace;font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:var(--accent);margin-bottom:10px}
+  .source-list{display:flex;flex-direction:column;gap:10px;margin-top:20px}
+  .source-ref{display:grid;grid-template-columns:150px 1fr;gap:14px;align-items:center;text-decoration:none;border:1px solid rgba(255,255,255,.1);border-radius:8px;background:#0e0e10;padding:12px 14px}
+  .source-ref:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent)}
+  .source-ref span{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:var(--accent);text-transform:uppercase;letter-spacing:.04em}
+  .source-ref code{color:#aeb3ba;word-break:break-word}
+  .boundary-box{border-left:2px solid var(--accent);background:#0e0e10;padding:18px 20px;margin-top:16px;border-radius:0 8px 8px 0}
+  .flow{display:flex;flex-direction:column}
+  .flow li{display:grid;grid-template-columns:28px 1fr;gap:14px;list-style:none}
+  .flow-num{width:24px;height:24px;border-radius:50%;border:1px solid color-mix(in srgb,var(--accent) 50%,transparent);display:flex;align-items:center;justify-content:center;font-family:'Geist Mono',ui-monospace,monospace;font-size:11.5px;color:var(--accent);background:#0b0b0c}
+  .flow-body{padding-bottom:18px;border-left:1px solid rgba(255,255,255,.12);padding-left:14px;margin-left:-27px}
+  .flow-title{font-size:14.5px;color:#eceef0;font-weight:500;margin-bottom:7px}
+  .metric-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px;margin-top:22px}
+  .metric{border:1px solid rgba(255,255,255,.1);border-radius:10px;padding:17px 19px;background:#0c0c0e}
+  .metric strong{display:block;font-size:24px;letter-spacing:-.02em;color:#fafafa}
+  .metric span{display:block;margin-top:5px;font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#62666d;text-transform:uppercase}
+  .search{width:100%;height:42px;margin:22px 0 16px;border:1px solid rgba(255,255,255,.12);border-radius:8px;background:#0e0e10;color:#f1f2f3;padding:0 12px;font:14px 'Geist',system-ui,sans-serif}
+  .cards{display:flex;flex-direction:column;gap:12px}
+  .card{display:block;text-decoration:none;border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;padding:18px 20px}
+  .card:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent)}
+  .card .meta{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#62666d;margin-bottom:8px}
+  .card p{font-size:14px;margin-top:9px}
+  .hide{display:none}
+  footer{margin-top:76px;color:#62666d;font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;line-height:1.7}
+  @media(max-width:720px){article{padding:52px 18px 90px}.panel-row{grid-template-columns:1fr}.panel-key{border-right:0;border-bottom:1px solid rgba(255,255,255,.07)}.metric-grid,.evidence-grid{grid-template-columns:1fr}.source-ref{grid-template-columns:1fr;gap:6px}}
+</style>
+</head>
+<body>
+<div class="gh">
+  <div class="grain"></div>
+  <article>
+
+    <nav class="nav" aria-label="Showcase navigation">
+      <a href="../index.en.html">Showcases</a>
+      <a href="../showcase-catalog.json">Catalog</a>
+      <a href="0620-creator-operator-case-spec.html">中文</a>
+    </nav>
+
+    <div class="mlab">2026-06-20 · creator-operations</div>
+    <h1>Creator-operator long-running agent case</h1>
+    <div class="accent">A creator-operator needs a long-running agent loop that keeps research moving while publishing decisions stay gated.</div>
+    <p>A non-technical operator can see what changed, what is blocked, what can safely continue, and how feedback changes the plan without reading prompts, logs, or raw traces.</p>
+    <div class="chips"><span>creator_operator_workflow</span><span>gate_aware_continuation</span><span>feedback_capture</span><span>safe_side_path</span><span>material_library</span><span>Appendix case</span></div>
+
+    <div class="diagram" aria-label="LoopX control-plane sketch">
+      <svg viewBox="0 0 760 320" role="img">
+        <rect width="760" height="320" fill="#0e0e10"></rect>
+        <rect x="285" y="34" width="190" height="58" rx="8" fill="none" stroke="#6e79d6" stroke-width="2"></rect>
+        <text x="380" y="68" text-anchor="middle" fill="#f1f2f3" font-size="15" font-weight="600">LoopX</text>
+        <line x1="380" y1="92" x2="380" y2="132" stroke="#3a3d42" stroke-width="2"></line>
+        <rect x="52" y="132" width="180" height="78" rx="8" fill="none" stroke="#6a6e76" stroke-width="2"></rect>
+        <rect x="290" y="124" width="180" height="94" rx="8" fill="#6e79d6" fill-opacity=".16" stroke="#6e79d6" stroke-width="2"></rect>
+        <rect x="528" y="132" width="180" height="78" rx="8" fill="none" stroke="#6a6e76" stroke-width="2"></rect>
+        <text x="142" y="166" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">Creator-operator long-</text>
+        <text x="380" y="163" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">creator_operator_workflo</text>
+        <text x="618" y="166" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">public safe case spec</text>
+        <text x="142" y="188" text-anchor="middle" fill="#62666d" font-size="11">goal / trigger</text>
+        <text x="380" y="185" text-anchor="middle" fill="#62666d" font-size="11">todo / gate / evidence</text>
+        <text x="618" y="188" text-anchor="middle" fill="#62666d" font-size="11">public outcome</text>
+        <line x1="232" y1="171" x2="282" y2="171" stroke="#6e79d6" stroke-width="2"></line>
+        <polygon points="290,171 280,165 280,177" fill="#6e79d6"></polygon>
+        <line x1="470" y1="171" x2="520" y2="171" stroke="#6e79d6" stroke-width="2"></line>
+        <polygon points="528,171 518,165 518,177" fill="#6e79d6"></polygon>
+        <path d="M618 210 L618 260 L142 260 L142 218" fill="none" stroke="#5a5e65" stroke-width="2"></path>
+        <polygon points="142,210 136,221 148,221" fill="#8a8088"></polygon>
+      </svg>
+    </div>
+
+
+    <div class="section-head"><span>01</span><h2>Case context</h2></div>
+    <div class="text-stack"><p>This is an appendix case: it shows how a non-technical creator-operator might use LoopX to manage a long-running research and planning loop, but it is not a top-card proof until real public user evidence exists.</p><p>The public material uses only synthetic data. The product shape is trend candidates, preference map, insight board, draft queue, material library, human feedback, and controlled replan.</p></div>
+
+    <div class="section-head"><span>02</span><h2>Repository evidence</h2></div>
+    <div class="panel">
+      <div class="panel-row"><div class="panel-key">Proof</div><div class="panel-val"><p>A creator-operator needs a long-running agent loop that keeps research moving while publishing decisions stay gated.</p></div></div>
+      <div class="panel-row"><div class="panel-key">LoopX intervention</div><div class="panel-val"><p>creator_operator_workflow, gate_aware_continuation, feedback_capture, safe_side_path</p></div></div>
+    </div>
+
+    <div class="evidence-grid"><div class="evidence-card"><div class="evidence-label">Storyboard</div><p>`creator-ops-fake-data-storyboard.md` defines seven panels and a full fake fixture with no live platform access.</p></div><div class="evidence-card"><div class="evidence-label">Feedback contract</div><p>`creator-ops-feedback-boundary-contract.md` separates gate decision, preference hint, todo update, boundary correction, reward signal, and product improvement note.</p></div><div class="evidence-card"><div class="evidence-label">Source status</div><p>The contract requires every topic, insight, draft, and material item to carry source status; public repo defaults to `synthetic_demo`.</p></div><div class="evidence-card"><div class="evidence-label">No autopublish</div><p>Publishing is a hard user gate; safe side work may continue, but preference or reward is not publication approval.</p></div></div>
+
+    <div class="section-head"><span>03</span><h2>LoopX behavior</h2></div>
+    <ul class="flow"><li><span class="flow-num">1</span><div class="flow-body"><div class="flow-title">The creative objective is durable goal state, not a hidden task inside chat.</div></div></li><li><span class="flow-num">2</span><div class="flow-body"><div class="flow-title">Publish/no-publish is a user gate; research, organization, and source-status work can continue as safe side paths.</div></div></li><li><span class="flow-num">3</span><div class="flow-body"><div class="flow-title">Feedback becomes a preference hint, gate decision, todo update, or boundary correction.</div></div></li><li><span class="flow-num">4</span><div class="flow-body"><div class="flow-title">Before the next agent run, the user can see the blocked route, safe side path, and validation expectation.</div></div></li></ul>
+
+    <div class="section-head"><span>04</span><h2>What the user sees</h2></div>
+    <div class="text-stack"><p>A non-technical user can see what changed, what is waiting for them, and what can continue without reading prompts, traces, or raw logs.</p><p>The case is useful product direction, but the page clearly labels it as a synthetic spec and makes no claim about real growth, quality, or revenue.</p></div>
+
+    <div class="section-head"><span>05</span><h2>Repository sources</h2></div>
+    <div class="source-list"><a class="source-ref" href="0620-creator-operator-case-spec.md"><span>case narrative</span><code>docs/showcases/cases/0620-creator-operator-case-spec.md</code></a><a class="source-ref" href="../creator-ops-fake-data-storyboard.md"><span>fake-data storyboard</span><code>docs/showcases/creator-ops-fake-data-storyboard.md</code></a><a class="source-ref" href="../creator-ops-feedback-boundary-contract.md"><span>feedback boundary contract</span><code>docs/showcases/creator-ops-feedback-boundary-contract.md</code></a></div>
+    <div class="boundary-box"><p><strong>Evidence boundary.</strong> Synthetic case spec only; no real platform data, creator notes, screenshots, private drafts, raw browsing traces, local paths, credentials, or performance claims.</p></div>
+    <div class="chips"><a class="case-link" href="0620-creator-operator-case-spec.md">Case note</a><a class="case-link" href="../creator-ops-fake-data-storyboard.md">Storyboard</a><a class="case-link" href="../creator-ops-feedback-boundary-contract.md">Feedback</a></div>
+
+    <footer>Generated from docs/showcases/showcase-catalog.json. Private links, raw chats, local state, and internal media are excluded.</footer>
+  </article>
+</div>
+</body>
+</html>

--- a/docs/showcases/cases/0620-creator-operator-case-spec.html
+++ b/docs/showcases/cases/0620-creator-operator-case-spec.html
@@ -1,0 +1,138 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>LoopX Showcase: 创作者-运营者长跑 Agent 案例</title>
+  <link rel="icon" href="data:,">
+  <style>
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  body{background:#0b0b0c;color:#f1f2f3;font-family:'Geist',system-ui,-apple-system,BlinkMacSystemFont,sans-serif;-webkit-font-smoothing:antialiased}
+  a{color:inherit}
+  ::selection{background:color-mix(in srgb,var(--accent,#6e79d6) 34%,transparent);color:#fff}
+  .gh{min-height:100vh;position:relative;overflow-x:hidden;--accent:#6e79d6}
+  .grain{position:fixed;inset:0;pointer-events:none;opacity:.025;mix-blend-mode:overlay;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E")}
+  article{position:relative;max-width:800px;margin:0 auto;padding:76px 28px 130px}
+  .mlab{font-family:'Geist Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11px;letter-spacing:.06em;color:#62666d;text-transform:uppercase}
+  h1{font-size:clamp(31px,4.6vw,46px);font-weight:600;line-height:1.12;letter-spacing:-.03em;margin:16px 0 14px;color:#fafafa;text-wrap:balance}
+  h2{font-size:22px;font-weight:600;letter-spacing:-.02em;color:#f1f2f3}
+  h3{font-size:21px;font-weight:600;letter-spacing:-.02em;color:#f1f2f3}
+  p{font-size:15.5px;line-height:1.75;color:#9ea3aa}
+  strong{color:#e9eaec;font-weight:600}
+  code{font-family:'Geist Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:12.5px;color:#c4c7cc}
+  .accent{font-size:clamp(17px,2.1vw,21px);font-weight:500;color:var(--accent);letter-spacing:-.01em;margin-bottom:22px}
+  .nav{display:flex;gap:10px;flex-wrap:wrap;margin:0 0 28px}
+  .nav a,.case-link{font-family:'Geist Mono',ui-monospace,monospace;font-size:11px;letter-spacing:.04em;text-decoration:none;color:#c4c7cc;border:1px solid rgba(255,255,255,.12);border-radius:6px;padding:7px 10px;background:rgba(255,255,255,.025)}
+  .nav a:hover,.case-link:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent);color:#f4f4f5}
+  .section-head{margin-top:74px;display:flex;align-items:baseline;gap:13px;margin-bottom:20px}
+  .section-head span{font-family:'Geist Mono',ui-monospace,monospace;font-size:13px;color:var(--accent)}
+  .panel{border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;overflow:hidden}
+  .panel-row{display:grid;grid-template-columns:150px 1fr;border-top:1px solid rgba(255,255,255,.07)}
+  .panel-row:first-child{border-top:0}
+  .panel-key{padding:18px 20px;border-right:1px solid rgba(255,255,255,.07);font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:var(--accent);background:color-mix(in srgb,var(--accent) 8%,transparent);letter-spacing:.04em}
+  .panel-val{padding:18px 20px;display:flex;align-items:center}
+  .panel-val p{font-size:14px;line-height:1.6;margin:0}
+  .diagram{border:1px solid rgba(255,255,255,.1);border-radius:12px;padding:30px 24px 22px;background:#0e0e10;margin:22px 0}
+  .diagram svg{display:block;width:100%;height:auto}
+  .chips{display:flex;gap:8px;flex-wrap:wrap;margin-top:22px}
+  .chips span{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#888d95;border:1px solid rgba(255,255,255,.12);padding:4px 8px;border-radius:5px}
+  .text-stack{display:flex;flex-direction:column;gap:16px}
+  .evidence-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px;margin:20px 0 6px}
+  .evidence-card{border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;padding:18px 18px 17px;min-height:128px}
+  .evidence-label{font-family:'Geist Mono',ui-monospace,monospace;font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:var(--accent);margin-bottom:10px}
+  .source-list{display:flex;flex-direction:column;gap:10px;margin-top:20px}
+  .source-ref{display:grid;grid-template-columns:150px 1fr;gap:14px;align-items:center;text-decoration:none;border:1px solid rgba(255,255,255,.1);border-radius:8px;background:#0e0e10;padding:12px 14px}
+  .source-ref:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent)}
+  .source-ref span{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:var(--accent);text-transform:uppercase;letter-spacing:.04em}
+  .source-ref code{color:#aeb3ba;word-break:break-word}
+  .boundary-box{border-left:2px solid var(--accent);background:#0e0e10;padding:18px 20px;margin-top:16px;border-radius:0 8px 8px 0}
+  .flow{display:flex;flex-direction:column}
+  .flow li{display:grid;grid-template-columns:28px 1fr;gap:14px;list-style:none}
+  .flow-num{width:24px;height:24px;border-radius:50%;border:1px solid color-mix(in srgb,var(--accent) 50%,transparent);display:flex;align-items:center;justify-content:center;font-family:'Geist Mono',ui-monospace,monospace;font-size:11.5px;color:var(--accent);background:#0b0b0c}
+  .flow-body{padding-bottom:18px;border-left:1px solid rgba(255,255,255,.12);padding-left:14px;margin-left:-27px}
+  .flow-title{font-size:14.5px;color:#eceef0;font-weight:500;margin-bottom:7px}
+  .metric-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px;margin-top:22px}
+  .metric{border:1px solid rgba(255,255,255,.1);border-radius:10px;padding:17px 19px;background:#0c0c0e}
+  .metric strong{display:block;font-size:24px;letter-spacing:-.02em;color:#fafafa}
+  .metric span{display:block;margin-top:5px;font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#62666d;text-transform:uppercase}
+  .search{width:100%;height:42px;margin:22px 0 16px;border:1px solid rgba(255,255,255,.12);border-radius:8px;background:#0e0e10;color:#f1f2f3;padding:0 12px;font:14px 'Geist',system-ui,sans-serif}
+  .cards{display:flex;flex-direction:column;gap:12px}
+  .card{display:block;text-decoration:none;border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;padding:18px 20px}
+  .card:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent)}
+  .card .meta{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#62666d;margin-bottom:8px}
+  .card p{font-size:14px;margin-top:9px}
+  .hide{display:none}
+  footer{margin-top:76px;color:#62666d;font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;line-height:1.7}
+  @media(max-width:720px){article{padding:52px 18px 90px}.panel-row{grid-template-columns:1fr}.panel-key{border-right:0;border-bottom:1px solid rgba(255,255,255,.07)}.metric-grid,.evidence-grid{grid-template-columns:1fr}.source-ref{grid-template-columns:1fr;gap:6px}}
+</style>
+</head>
+<body>
+<div class="gh">
+  <div class="grain"></div>
+  <article>
+
+    <nav class="nav" aria-label="Showcase navigation">
+      <a href="../index.html">Showcases</a>
+      <a href="../showcase-catalog.json">Catalog</a>
+      <a href="0620-creator-operator-case-spec.en.html">English</a>
+    </nav>
+
+    <div class="mlab">2026-06-20 · creator-operations</div>
+    <h1>创作者-运营者长跑 Agent 案例</h1>
+    <div class="accent">研究可以继续，发布决策仍然 gated。</div>
+    <p>A non-technical operator can see what changed, what is blocked, what can safely continue, and how feedback changes the plan without reading prompts, logs, or raw traces.</p>
+    <div class="chips"><span>creator_operator_workflow</span><span>gate_aware_continuation</span><span>feedback_capture</span><span>safe_side_path</span><span>material_library</span><span>附录案例</span></div>
+
+    <div class="diagram" aria-label="LoopX control-plane sketch">
+      <svg viewBox="0 0 760 320" role="img">
+        <rect width="760" height="320" fill="#0e0e10"></rect>
+        <rect x="285" y="34" width="190" height="58" rx="8" fill="none" stroke="#6e79d6" stroke-width="2"></rect>
+        <text x="380" y="68" text-anchor="middle" fill="#f1f2f3" font-size="15" font-weight="600">LoopX</text>
+        <line x1="380" y1="92" x2="380" y2="132" stroke="#3a3d42" stroke-width="2"></line>
+        <rect x="52" y="132" width="180" height="78" rx="8" fill="none" stroke="#6a6e76" stroke-width="2"></rect>
+        <rect x="290" y="124" width="180" height="94" rx="8" fill="#6e79d6" fill-opacity=".16" stroke="#6e79d6" stroke-width="2"></rect>
+        <rect x="528" y="132" width="180" height="78" rx="8" fill="none" stroke="#6a6e76" stroke-width="2"></rect>
+        <text x="142" y="166" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">创作者-运营者长跑 Agent 案例</text>
+        <text x="380" y="163" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">creator-operator workflo</text>
+        <text x="618" y="166" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">public safe case spec</text>
+        <text x="142" y="188" text-anchor="middle" fill="#62666d" font-size="11">goal / trigger</text>
+        <text x="380" y="185" text-anchor="middle" fill="#62666d" font-size="11">todo / gate / evidence</text>
+        <text x="618" y="188" text-anchor="middle" fill="#62666d" font-size="11">public outcome</text>
+        <line x1="232" y1="171" x2="282" y2="171" stroke="#6e79d6" stroke-width="2"></line>
+        <polygon points="290,171 280,165 280,177" fill="#6e79d6"></polygon>
+        <line x1="470" y1="171" x2="520" y2="171" stroke="#6e79d6" stroke-width="2"></line>
+        <polygon points="528,171 518,165 518,177" fill="#6e79d6"></polygon>
+        <path d="M618 210 L618 260 L142 260 L142 218" fill="none" stroke="#5a5e65" stroke-width="2"></path>
+        <polygon points="142,210 136,221 148,221" fill="#8a8088"></polygon>
+      </svg>
+    </div>
+
+
+    <div class="section-head"><span>01</span><h2>案例背景</h2></div>
+    <div class="text-stack"><p>这是 appendix case：它展示非技术创作者/运营者如何用 LoopX 管一个长期 research + planning loop，但还不是 top-card proof，因为没有真实用户公开证据。</p><p>公开材料完全使用 synthetic data，重点是产品形态：趋势候选、偏好映射、insight board、draft queue、material library、人类反馈和 controlled replan。</p></div>
+
+    <div class="section-head"><span>02</span><h2>仓库证据</h2></div>
+    <div class="panel">
+      <div class="panel-row"><div class="panel-key">证明点</div><div class="panel-val"><p>创作与运营工作可以共享一个 gate-aware 的长期 agent loop。</p></div></div>
+      <div class="panel-row"><div class="panel-key">LoopX 介入</div><div class="panel-val"><p>creator-operator workflow、user gate、feedback capture、material library</p></div></div>
+    </div>
+
+    <div class="evidence-grid"><div class="evidence-card"><div class="evidence-label">storyboard</div><p>`creator-ops-fake-data-storyboard.md` 定义七个面板和完整 fake fixture，不需要 live platform access。</p></div><div class="evidence-card"><div class="evidence-label">feedback contract</div><p>`creator-ops-feedback-boundary-contract.md` 把 gate decision、preference hint、todo update、boundary correction、reward signal、product improvement note 分开。</p></div><div class="evidence-card"><div class="evidence-label">source status</div><p>contract 要求 topic、insight、draft、material item 都有 source status，public repo 默认 `synthetic_demo`。</p></div><div class="evidence-card"><div class="evidence-label">no autopublish</div><p>publishing 是 hard user gate；safe side work 可以继续，但不能把偏好或 reward 当成发布授权。</p></div></div>
+
+    <div class="section-head"><span>03</span><h2>LoopX 行为</h2></div>
+    <ul class="flow"><li><span class="flow-num">1</span><div class="flow-body"><div class="flow-title">creative objective 是 durable goal state，不是聊天窗口里的隐形任务。</div></div></li><li><span class="flow-num">2</span><div class="flow-body"><div class="flow-title">publish/no-publish 是 user gate；research、整理和 source-status 改进可以作为 safe side path。</div></div></li><li><span class="flow-num">3</span><div class="flow-body"><div class="flow-title">反馈被写成 preference hint、gate decision、todo update 或 boundary correction。</div></div></li><li><span class="flow-num">4</span><div class="flow-body"><div class="flow-title">下一次 agent run 前，用户能看到 blocked route、safe side path 和 validation expectation。</div></div></li></ul>
+
+    <div class="section-head"><span>04</span><h2>用户看到什么</h2></div>
+    <div class="text-stack"><p>非技术用户不用读 prompt、trace 或 raw logs，就能知道上次改变了什么、什么在等自己、什么可以继续。</p><p>这个 case 适合展示产品方向，但页面会明确它是 synthetic spec，不声称真实增长、质量或收入效果。</p></div>
+
+    <div class="section-head"><span>05</span><h2>仓库来源</h2></div>
+    <div class="source-list"><a class="source-ref" href="0620-creator-operator-case-spec.md"><span>case narrative</span><code>docs/showcases/cases/0620-creator-operator-case-spec.md</code></a><a class="source-ref" href="../creator-ops-fake-data-storyboard.md"><span>fake-data storyboard</span><code>docs/showcases/creator-ops-fake-data-storyboard.md</code></a><a class="source-ref" href="../creator-ops-feedback-boundary-contract.md"><span>feedback boundary contract</span><code>docs/showcases/creator-ops-feedback-boundary-contract.md</code></a></div>
+    <div class="boundary-box"><p><strong>证据边界.</strong> Synthetic case spec only; no real platform data, creator notes, screenshots, private drafts, raw browsing traces, local paths, credentials, or performance claims.</p></div>
+    <div class="chips"><a class="case-link" href="0620-creator-operator-case-spec.md">案例说明</a><a class="case-link" href="../creator-ops-fake-data-storyboard.md">Storyboard</a><a class="case-link" href="../creator-ops-feedback-boundary-contract.md">Feedback</a></div>
+
+    <footer>由 docs/showcases/showcase-catalog.json 生成。不包含私有链接、原始聊天、本地状态或内部媒体。</footer>
+  </article>
+</div>
+</body>
+</html>

--- a/docs/showcases/cases/0620-creator-operator-case-spec.md
+++ b/docs/showcases/cases/0620-creator-operator-case-spec.md
@@ -179,7 +179,7 @@ This case is a synthetic product case spec. It intentionally excludes:
 Future demos should use fake data or public-domain sample material and should
 keep no-autopublish gates visible.
 
-## Website Story Beats
+## Public Evidence Sequence
 
 1. A creator-operator has a long-running research and content-planning goal.
 2. The agent proposes trend candidates, maps them to preferences, and drafts

--- a/docs/showcases/cases/0623-agent-to-agent-pr-comments.en.html
+++ b/docs/showcases/cases/0623-agent-to-agent-pr-comments.en.html
@@ -1,0 +1,138 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>LoopX Showcase: Agent-to-agent PR comment and fix loop</title>
+  <link rel="icon" href="data:,">
+  <style>
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  body{background:#0b0b0c;color:#f1f2f3;font-family:'Geist',system-ui,-apple-system,BlinkMacSystemFont,sans-serif;-webkit-font-smoothing:antialiased}
+  a{color:inherit}
+  ::selection{background:color-mix(in srgb,var(--accent,#6e79d6) 34%,transparent);color:#fff}
+  .gh{min-height:100vh;position:relative;overflow-x:hidden;--accent:#6e79d6}
+  .grain{position:fixed;inset:0;pointer-events:none;opacity:.025;mix-blend-mode:overlay;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E")}
+  article{position:relative;max-width:800px;margin:0 auto;padding:76px 28px 130px}
+  .mlab{font-family:'Geist Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11px;letter-spacing:.06em;color:#62666d;text-transform:uppercase}
+  h1{font-size:clamp(31px,4.6vw,46px);font-weight:600;line-height:1.12;letter-spacing:-.03em;margin:16px 0 14px;color:#fafafa;text-wrap:balance}
+  h2{font-size:22px;font-weight:600;letter-spacing:-.02em;color:#f1f2f3}
+  h3{font-size:21px;font-weight:600;letter-spacing:-.02em;color:#f1f2f3}
+  p{font-size:15.5px;line-height:1.75;color:#9ea3aa}
+  strong{color:#e9eaec;font-weight:600}
+  code{font-family:'Geist Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:12.5px;color:#c4c7cc}
+  .accent{font-size:clamp(17px,2.1vw,21px);font-weight:500;color:var(--accent);letter-spacing:-.01em;margin-bottom:22px}
+  .nav{display:flex;gap:10px;flex-wrap:wrap;margin:0 0 28px}
+  .nav a,.case-link{font-family:'Geist Mono',ui-monospace,monospace;font-size:11px;letter-spacing:.04em;text-decoration:none;color:#c4c7cc;border:1px solid rgba(255,255,255,.12);border-radius:6px;padding:7px 10px;background:rgba(255,255,255,.025)}
+  .nav a:hover,.case-link:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent);color:#f4f4f5}
+  .section-head{margin-top:74px;display:flex;align-items:baseline;gap:13px;margin-bottom:20px}
+  .section-head span{font-family:'Geist Mono',ui-monospace,monospace;font-size:13px;color:var(--accent)}
+  .panel{border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;overflow:hidden}
+  .panel-row{display:grid;grid-template-columns:150px 1fr;border-top:1px solid rgba(255,255,255,.07)}
+  .panel-row:first-child{border-top:0}
+  .panel-key{padding:18px 20px;border-right:1px solid rgba(255,255,255,.07);font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:var(--accent);background:color-mix(in srgb,var(--accent) 8%,transparent);letter-spacing:.04em}
+  .panel-val{padding:18px 20px;display:flex;align-items:center}
+  .panel-val p{font-size:14px;line-height:1.6;margin:0}
+  .diagram{border:1px solid rgba(255,255,255,.1);border-radius:12px;padding:30px 24px 22px;background:#0e0e10;margin:22px 0}
+  .diagram svg{display:block;width:100%;height:auto}
+  .chips{display:flex;gap:8px;flex-wrap:wrap;margin-top:22px}
+  .chips span{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#888d95;border:1px solid rgba(255,255,255,.12);padding:4px 8px;border-radius:5px}
+  .text-stack{display:flex;flex-direction:column;gap:16px}
+  .evidence-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px;margin:20px 0 6px}
+  .evidence-card{border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;padding:18px 18px 17px;min-height:128px}
+  .evidence-label{font-family:'Geist Mono',ui-monospace,monospace;font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:var(--accent);margin-bottom:10px}
+  .source-list{display:flex;flex-direction:column;gap:10px;margin-top:20px}
+  .source-ref{display:grid;grid-template-columns:150px 1fr;gap:14px;align-items:center;text-decoration:none;border:1px solid rgba(255,255,255,.1);border-radius:8px;background:#0e0e10;padding:12px 14px}
+  .source-ref:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent)}
+  .source-ref span{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:var(--accent);text-transform:uppercase;letter-spacing:.04em}
+  .source-ref code{color:#aeb3ba;word-break:break-word}
+  .boundary-box{border-left:2px solid var(--accent);background:#0e0e10;padding:18px 20px;margin-top:16px;border-radius:0 8px 8px 0}
+  .flow{display:flex;flex-direction:column}
+  .flow li{display:grid;grid-template-columns:28px 1fr;gap:14px;list-style:none}
+  .flow-num{width:24px;height:24px;border-radius:50%;border:1px solid color-mix(in srgb,var(--accent) 50%,transparent);display:flex;align-items:center;justify-content:center;font-family:'Geist Mono',ui-monospace,monospace;font-size:11.5px;color:var(--accent);background:#0b0b0c}
+  .flow-body{padding-bottom:18px;border-left:1px solid rgba(255,255,255,.12);padding-left:14px;margin-left:-27px}
+  .flow-title{font-size:14.5px;color:#eceef0;font-weight:500;margin-bottom:7px}
+  .metric-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px;margin-top:22px}
+  .metric{border:1px solid rgba(255,255,255,.1);border-radius:10px;padding:17px 19px;background:#0c0c0e}
+  .metric strong{display:block;font-size:24px;letter-spacing:-.02em;color:#fafafa}
+  .metric span{display:block;margin-top:5px;font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#62666d;text-transform:uppercase}
+  .search{width:100%;height:42px;margin:22px 0 16px;border:1px solid rgba(255,255,255,.12);border-radius:8px;background:#0e0e10;color:#f1f2f3;padding:0 12px;font:14px 'Geist',system-ui,sans-serif}
+  .cards{display:flex;flex-direction:column;gap:12px}
+  .card{display:block;text-decoration:none;border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;padding:18px 20px}
+  .card:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent)}
+  .card .meta{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#62666d;margin-bottom:8px}
+  .card p{font-size:14px;margin-top:9px}
+  .hide{display:none}
+  footer{margin-top:76px;color:#62666d;font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;line-height:1.7}
+  @media(max-width:720px){article{padding:52px 18px 90px}.panel-row{grid-template-columns:1fr}.panel-key{border-right:0;border-bottom:1px solid rgba(255,255,255,.07)}.metric-grid,.evidence-grid{grid-template-columns:1fr}.source-ref{grid-template-columns:1fr;gap:6px}}
+</style>
+</head>
+<body>
+<div class="gh">
+  <div class="grain"></div>
+  <article>
+
+    <nav class="nav" aria-label="Showcase navigation">
+      <a href="../index.en.html">Showcases</a>
+      <a href="../showcase-catalog.json">Catalog</a>
+      <a href="0623-agent-to-agent-pr-comments.html">中文</a>
+    </nav>
+
+    <div class="mlab">2026-06-23 · pull-request-review</div>
+    <h1>Agent-to-agent PR comment and fix loop</h1>
+    <div class="accent">PR review feedback can become an owned agent todo with fix evidence instead of a loose chat reminder.</div>
+    <p>The operator can let agents coordinate around PR comments without losing final review visibility or fix evidence.</p>
+    <div class="chips"><span>handoff</span><span>PR comment</span><span>claimed_by</span></div>
+
+    <div class="diagram" aria-label="LoopX control-plane sketch">
+      <svg viewBox="0 0 760 320" role="img">
+        <rect width="760" height="320" fill="#0e0e10"></rect>
+        <rect x="285" y="34" width="190" height="58" rx="8" fill="none" stroke="#6e79d6" stroke-width="2"></rect>
+        <text x="380" y="68" text-anchor="middle" fill="#f1f2f3" font-size="15" font-weight="600">LoopX</text>
+        <line x1="380" y1="92" x2="380" y2="132" stroke="#3a3d42" stroke-width="2"></line>
+        <rect x="52" y="132" width="180" height="78" rx="8" fill="none" stroke="#6a6e76" stroke-width="2"></rect>
+        <rect x="290" y="124" width="180" height="94" rx="8" fill="#6e79d6" fill-opacity=".16" stroke="#6e79d6" stroke-width="2"></rect>
+        <rect x="528" y="132" width="180" height="78" rx="8" fill="none" stroke="#6a6e76" stroke-width="2"></rect>
+        <text x="142" y="166" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">Agent-to-agent PR comm</text>
+        <text x="380" y="163" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">claimed_by</text>
+        <text x="618" y="166" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">public safe pattern case</text>
+        <text x="142" y="188" text-anchor="middle" fill="#62666d" font-size="11">goal / trigger</text>
+        <text x="380" y="185" text-anchor="middle" fill="#62666d" font-size="11">todo / gate / evidence</text>
+        <text x="618" y="188" text-anchor="middle" fill="#62666d" font-size="11">public outcome</text>
+        <line x1="232" y1="171" x2="282" y2="171" stroke="#6e79d6" stroke-width="2"></line>
+        <polygon points="290,171 280,165 280,177" fill="#6e79d6"></polygon>
+        <line x1="470" y1="171" x2="520" y2="171" stroke="#6e79d6" stroke-width="2"></line>
+        <polygon points="528,171 518,165 518,177" fill="#6e79d6"></polygon>
+        <path d="M618 210 L618 260 L142 260 L142 218" fill="none" stroke="#5a5e65" stroke-width="2"></path>
+        <polygon points="142,210 136,221 148,221" fill="#8a8088"></polygon>
+      </svg>
+    </div>
+
+
+    <div class="section-head"><span>01</span><h2>Case context</h2></div>
+    <div class="text-stack"><p>This case shows how PR review feedback can move across multiple agents without losing ownership. The important chain is comment, claim, handoff, fix, validation, and review packet rather than the chat transcript.</p><p>The public repository contains the control-plane pieces: `claimed_by` appears in todo projection, review packets, event-sourced state, and multi-agent or side-agent prompt contracts.</p></div>
+
+    <div class="section-head"><span>02</span><h2>Repository evidence</h2></div>
+    <div class="panel">
+      <div class="panel-row"><div class="panel-key">Proof</div><div class="panel-val"><p>Multiple agents can coordinate around PR review comments without losing owner review.</p></div></div>
+      <div class="panel-row"><div class="panel-key">LoopX intervention</div><div class="panel-val"><p>claimed_by, handoff gate, review packet, comment/fix loop</p></div></div>
+    </div>
+
+    <div class="evidence-grid"><div class="evidence-card"><div class="evidence-label">Todo ownership</div><p>`event_sourced_state_contract_v0` defines `todo_claimed` as a canonical event for ownership, lease, or `claimed_by`.</p></div><div class="evidence-card"><div class="evidence-label">Review packet</div><p>`loopx/review_packet.py` renders open todo `claimed_by` values into handoff and review text.</p></div><div class="evidence-card"><div class="evidence-label">Side-agent contract</div><p>`docs/heartbeat-automation-prompt.md` requires side agents to self-merge only small validated evidence-backed work or create a claimed handoff todo.</p></div><div class="evidence-card"><div class="evidence-label">CLI smokes</div><p>`examples/todo-lifecycle-cli-smoke.py` and `examples/todo-cli-smoke.py` cover claim, handoff successor, side-agent self-merge, and review handoff rules.</p></div></div>
+
+    <div class="section-head"><span>03</span><h2>LoopX behavior</h2></div>
+    <ul class="flow"><li><span class="flow-num">1</span><div class="flow-body"><div class="flow-title">PR feedback becomes an owned todo rather than a chat reminder.</div></div></li><li><span class="flow-num">2</span><div class="flow-body"><div class="flow-title">Blocked or cross-lane fixes move through handoff gates and review packets instead of another agent guessing context.</div></div></li><li><span class="flow-num">3</span><div class="flow-body"><div class="flow-title">The fixing agent leaves diff, validation, and remaining gates; follow-up work becomes a successor todo.</div></div></li><li><span class="flow-num">4</span><div class="flow-body"><div class="flow-title">Owner review still happens on the PR or review surface; LoopX supplies state, evidence, and handoff.</div></div></li></ul>
+
+    <div class="section-head"><span>04</span><h2>What the user sees</h2></div>
+    <div class="text-stack"><p>The user does not have to shepherd every PR comment manually; the control plane shows who claimed the feedback, where the fix evidence is, and what still needs review.</p><p>Multi-agent collaboration stops depending on memory of which agent saw which comment.</p></div>
+
+    <div class="section-head"><span>05</span><h2>Repository sources</h2></div>
+    <div class="source-list"><a class="source-ref" href="../../reference/protocols/event-sourced-state-contract-v0.md"><span>event-sourced todo claim</span><code>docs/reference/protocols/event-sourced-state-contract-v0.md</code></a><a class="source-ref" href="../../../loopx/review_packet.py"><span>review packet code</span><code>loopx/review_packet.py</code></a><a class="source-ref" href="../../heartbeat-automation-prompt.md"><span>side-agent prompt contract</span><code>docs/heartbeat-automation-prompt.md</code></a><a class="source-ref" href="../../../examples/todo-lifecycle-cli-smoke.py"><span>todo lifecycle smoke</span><code>examples/todo-lifecycle-cli-smoke.py</code></a></div>
+    <div class="boundary-box"><p><strong>Evidence boundary.</strong> Public-safe pattern case only; no private screenshots, raw chats, internal review notes, local state, credentials, or unpublished artifacts.</p></div>
+    <div class="chips"><a class="case-link" href="0623-agent-to-agent-pr-comments.md">Case note</a></div>
+
+    <footer>Generated from docs/showcases/showcase-catalog.json. Private links, raw chats, local state, and internal media are excluded.</footer>
+  </article>
+</div>
+</body>
+</html>

--- a/docs/showcases/cases/0623-agent-to-agent-pr-comments.html
+++ b/docs/showcases/cases/0623-agent-to-agent-pr-comments.html
@@ -1,0 +1,138 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>LoopX Showcase: Agent to agent 回复 PR comment 和 PR Fix</title>
+  <link rel="icon" href="data:,">
+  <style>
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  body{background:#0b0b0c;color:#f1f2f3;font-family:'Geist',system-ui,-apple-system,BlinkMacSystemFont,sans-serif;-webkit-font-smoothing:antialiased}
+  a{color:inherit}
+  ::selection{background:color-mix(in srgb,var(--accent,#6e79d6) 34%,transparent);color:#fff}
+  .gh{min-height:100vh;position:relative;overflow-x:hidden;--accent:#6e79d6}
+  .grain{position:fixed;inset:0;pointer-events:none;opacity:.025;mix-blend-mode:overlay;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E")}
+  article{position:relative;max-width:800px;margin:0 auto;padding:76px 28px 130px}
+  .mlab{font-family:'Geist Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11px;letter-spacing:.06em;color:#62666d;text-transform:uppercase}
+  h1{font-size:clamp(31px,4.6vw,46px);font-weight:600;line-height:1.12;letter-spacing:-.03em;margin:16px 0 14px;color:#fafafa;text-wrap:balance}
+  h2{font-size:22px;font-weight:600;letter-spacing:-.02em;color:#f1f2f3}
+  h3{font-size:21px;font-weight:600;letter-spacing:-.02em;color:#f1f2f3}
+  p{font-size:15.5px;line-height:1.75;color:#9ea3aa}
+  strong{color:#e9eaec;font-weight:600}
+  code{font-family:'Geist Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:12.5px;color:#c4c7cc}
+  .accent{font-size:clamp(17px,2.1vw,21px);font-weight:500;color:var(--accent);letter-spacing:-.01em;margin-bottom:22px}
+  .nav{display:flex;gap:10px;flex-wrap:wrap;margin:0 0 28px}
+  .nav a,.case-link{font-family:'Geist Mono',ui-monospace,monospace;font-size:11px;letter-spacing:.04em;text-decoration:none;color:#c4c7cc;border:1px solid rgba(255,255,255,.12);border-radius:6px;padding:7px 10px;background:rgba(255,255,255,.025)}
+  .nav a:hover,.case-link:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent);color:#f4f4f5}
+  .section-head{margin-top:74px;display:flex;align-items:baseline;gap:13px;margin-bottom:20px}
+  .section-head span{font-family:'Geist Mono',ui-monospace,monospace;font-size:13px;color:var(--accent)}
+  .panel{border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;overflow:hidden}
+  .panel-row{display:grid;grid-template-columns:150px 1fr;border-top:1px solid rgba(255,255,255,.07)}
+  .panel-row:first-child{border-top:0}
+  .panel-key{padding:18px 20px;border-right:1px solid rgba(255,255,255,.07);font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:var(--accent);background:color-mix(in srgb,var(--accent) 8%,transparent);letter-spacing:.04em}
+  .panel-val{padding:18px 20px;display:flex;align-items:center}
+  .panel-val p{font-size:14px;line-height:1.6;margin:0}
+  .diagram{border:1px solid rgba(255,255,255,.1);border-radius:12px;padding:30px 24px 22px;background:#0e0e10;margin:22px 0}
+  .diagram svg{display:block;width:100%;height:auto}
+  .chips{display:flex;gap:8px;flex-wrap:wrap;margin-top:22px}
+  .chips span{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#888d95;border:1px solid rgba(255,255,255,.12);padding:4px 8px;border-radius:5px}
+  .text-stack{display:flex;flex-direction:column;gap:16px}
+  .evidence-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px;margin:20px 0 6px}
+  .evidence-card{border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;padding:18px 18px 17px;min-height:128px}
+  .evidence-label{font-family:'Geist Mono',ui-monospace,monospace;font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:var(--accent);margin-bottom:10px}
+  .source-list{display:flex;flex-direction:column;gap:10px;margin-top:20px}
+  .source-ref{display:grid;grid-template-columns:150px 1fr;gap:14px;align-items:center;text-decoration:none;border:1px solid rgba(255,255,255,.1);border-radius:8px;background:#0e0e10;padding:12px 14px}
+  .source-ref:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent)}
+  .source-ref span{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:var(--accent);text-transform:uppercase;letter-spacing:.04em}
+  .source-ref code{color:#aeb3ba;word-break:break-word}
+  .boundary-box{border-left:2px solid var(--accent);background:#0e0e10;padding:18px 20px;margin-top:16px;border-radius:0 8px 8px 0}
+  .flow{display:flex;flex-direction:column}
+  .flow li{display:grid;grid-template-columns:28px 1fr;gap:14px;list-style:none}
+  .flow-num{width:24px;height:24px;border-radius:50%;border:1px solid color-mix(in srgb,var(--accent) 50%,transparent);display:flex;align-items:center;justify-content:center;font-family:'Geist Mono',ui-monospace,monospace;font-size:11.5px;color:var(--accent);background:#0b0b0c}
+  .flow-body{padding-bottom:18px;border-left:1px solid rgba(255,255,255,.12);padding-left:14px;margin-left:-27px}
+  .flow-title{font-size:14.5px;color:#eceef0;font-weight:500;margin-bottom:7px}
+  .metric-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px;margin-top:22px}
+  .metric{border:1px solid rgba(255,255,255,.1);border-radius:10px;padding:17px 19px;background:#0c0c0e}
+  .metric strong{display:block;font-size:24px;letter-spacing:-.02em;color:#fafafa}
+  .metric span{display:block;margin-top:5px;font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#62666d;text-transform:uppercase}
+  .search{width:100%;height:42px;margin:22px 0 16px;border:1px solid rgba(255,255,255,.12);border-radius:8px;background:#0e0e10;color:#f1f2f3;padding:0 12px;font:14px 'Geist',system-ui,sans-serif}
+  .cards{display:flex;flex-direction:column;gap:12px}
+  .card{display:block;text-decoration:none;border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;padding:18px 20px}
+  .card:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent)}
+  .card .meta{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#62666d;margin-bottom:8px}
+  .card p{font-size:14px;margin-top:9px}
+  .hide{display:none}
+  footer{margin-top:76px;color:#62666d;font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;line-height:1.7}
+  @media(max-width:720px){article{padding:52px 18px 90px}.panel-row{grid-template-columns:1fr}.panel-key{border-right:0;border-bottom:1px solid rgba(255,255,255,.07)}.metric-grid,.evidence-grid{grid-template-columns:1fr}.source-ref{grid-template-columns:1fr;gap:6px}}
+</style>
+</head>
+<body>
+<div class="gh">
+  <div class="grain"></div>
+  <article>
+
+    <nav class="nav" aria-label="Showcase navigation">
+      <a href="../index.html">Showcases</a>
+      <a href="../showcase-catalog.json">Catalog</a>
+      <a href="0623-agent-to-agent-pr-comments.en.html">English</a>
+    </nav>
+
+    <div class="mlab">2026-06-23 · pull-request-review</div>
+    <h1>Agent to agent 回复 PR comment 和 PR Fix</h1>
+    <div class="accent">多 agent 可围绕 PR review 协同发现、评论、修复。</div>
+    <p>The operator can let agents coordinate around PR comments without losing final review visibility or fix evidence.</p>
+    <div class="chips"><span>handoff</span><span>PR comment</span><span>claimed_by</span></div>
+
+    <div class="diagram" aria-label="LoopX control-plane sketch">
+      <svg viewBox="0 0 760 320" role="img">
+        <rect width="760" height="320" fill="#0e0e10"></rect>
+        <rect x="285" y="34" width="190" height="58" rx="8" fill="none" stroke="#6e79d6" stroke-width="2"></rect>
+        <text x="380" y="68" text-anchor="middle" fill="#f1f2f3" font-size="15" font-weight="600">LoopX</text>
+        <line x1="380" y1="92" x2="380" y2="132" stroke="#3a3d42" stroke-width="2"></line>
+        <rect x="52" y="132" width="180" height="78" rx="8" fill="none" stroke="#6a6e76" stroke-width="2"></rect>
+        <rect x="290" y="124" width="180" height="94" rx="8" fill="#6e79d6" fill-opacity=".16" stroke="#6e79d6" stroke-width="2"></rect>
+        <rect x="528" y="132" width="180" height="78" rx="8" fill="none" stroke="#6a6e76" stroke-width="2"></rect>
+        <text x="142" y="166" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">Agent to agent 回复 PR c</text>
+        <text x="380" y="163" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">claimed_by</text>
+        <text x="618" y="166" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">public safe pattern case</text>
+        <text x="142" y="188" text-anchor="middle" fill="#62666d" font-size="11">goal / trigger</text>
+        <text x="380" y="185" text-anchor="middle" fill="#62666d" font-size="11">todo / gate / evidence</text>
+        <text x="618" y="188" text-anchor="middle" fill="#62666d" font-size="11">public outcome</text>
+        <line x1="232" y1="171" x2="282" y2="171" stroke="#6e79d6" stroke-width="2"></line>
+        <polygon points="290,171 280,165 280,177" fill="#6e79d6"></polygon>
+        <line x1="470" y1="171" x2="520" y2="171" stroke="#6e79d6" stroke-width="2"></line>
+        <polygon points="528,171 518,165 518,177" fill="#6e79d6"></polygon>
+        <path d="M618 210 L618 260 L142 260 L142 218" fill="none" stroke="#5a5e65" stroke-width="2"></path>
+        <polygon points="142,210 136,221 148,221" fill="#8a8088"></polygon>
+      </svg>
+    </div>
+
+
+    <div class="section-head"><span>01</span><h2>案例背景</h2></div>
+    <div class="text-stack"><p>这个案例描述的是 PR review feedback 在多 agent 之间流转时如何不丢 ownership。重点不是聊天记录，而是 comment、claim、handoff、fix、validation、review packet 这条链。</p><p>公开仓库里可以看到相关控制面已经被产品化：`claimed_by` 出现在 todo projection、review packet、event-sourced state 和多 agent/side-agent prompt 合约里。</p></div>
+
+    <div class="section-head"><span>02</span><h2>仓库证据</h2></div>
+    <div class="panel">
+      <div class="panel-row"><div class="panel-key">证明点</div><div class="panel-val"><p>多 agent lane 可以围绕 PR comment 协作，同时保留 owner review。</p></div></div>
+      <div class="panel-row"><div class="panel-key">LoopX 介入</div><div class="panel-val"><p>claimed_by、handoff gate、review packet、comment/fix loop</p></div></div>
+    </div>
+
+    <div class="evidence-grid"><div class="evidence-card"><div class="evidence-label">todo ownership</div><p>`event_sourced_state_contract_v0` 把 `todo_claimed` 定义为 canonical event，记录 ownership、lease 或 `claimed_by`。</p></div><div class="evidence-card"><div class="evidence-label">review packet</div><p>`loopx/review_packet.py` 会把 open todo 的 `claimed_by` 显示进 handoff/review 文本。</p></div><div class="evidence-card"><div class="evidence-label">side-agent contract</div><p>`docs/heartbeat-automation-prompt.md` 规定 side-agent 小变更可带 evidence 自合并，否则创建 claimed-by handoff todo。</p></div><div class="evidence-card"><div class="evidence-label">CLI smokes</div><p>`examples/todo-lifecycle-cli-smoke.py`、`examples/todo-cli-smoke.py` 覆盖 claim、handoff successor、side-agent self-merge 和 review handoff 规则。</p></div></div>
+
+    <div class="section-head"><span>03</span><h2>LoopX 行为</h2></div>
+    <ul class="flow"><li><span class="flow-num">1</span><div class="flow-body"><div class="flow-title">PR feedback 先成为一个有 owner 的 todo，而不是 chat reminder。</div></div></li><li><span class="flow-num">2</span><div class="flow-body"><div class="flow-title">被阻塞或跨 lane 的修复通过 handoff gate 和 review packet 传递，不允许另一个 agent 猜测上下文。</div></div></li><li><span class="flow-num">3</span><div class="flow-body"><div class="flow-title">修复 agent 需要留下 diff、validation 和剩余 gate；后续工作创建 successor todo。</div></div></li><li><span class="flow-num">4</span><div class="flow-body"><div class="flow-title">owner review 仍在 PR/review surface 上完成，LoopX 只提供状态、证据和 handoff。</div></div></li></ul>
+
+    <div class="section-head"><span>04</span><h2>用户看到什么</h2></div>
+    <div class="text-stack"><p>用户不必手动 shepherd 每条 PR comment；控制面会显示谁 claim 了反馈、修复证据在哪里、还有什么需要 review。</p><p>多 agent 协作不会变成“谁看过这条评论”的记忆题。</p></div>
+
+    <div class="section-head"><span>05</span><h2>仓库来源</h2></div>
+    <div class="source-list"><a class="source-ref" href="../../reference/protocols/event-sourced-state-contract-v0.md"><span>event-sourced todo claim</span><code>docs/reference/protocols/event-sourced-state-contract-v0.md</code></a><a class="source-ref" href="../../../loopx/review_packet.py"><span>review packet code</span><code>loopx/review_packet.py</code></a><a class="source-ref" href="../../heartbeat-automation-prompt.md"><span>side-agent prompt contract</span><code>docs/heartbeat-automation-prompt.md</code></a><a class="source-ref" href="../../../examples/todo-lifecycle-cli-smoke.py"><span>todo lifecycle smoke</span><code>examples/todo-lifecycle-cli-smoke.py</code></a></div>
+    <div class="boundary-box"><p><strong>证据边界.</strong> Public-safe pattern case only; no private screenshots, raw chats, internal review notes, local state, credentials, or unpublished artifacts.</p></div>
+    <div class="chips"><a class="case-link" href="0623-agent-to-agent-pr-comments.md">案例说明</a></div>
+
+    <footer>由 docs/showcases/showcase-catalog.json 生成。不包含私有链接、原始聊天、本地状态或内部媒体。</footer>
+  </article>
+</div>
+</body>
+</html>

--- a/docs/showcases/cases/0623-agent-to-agent-pr-comments.md
+++ b/docs/showcases/cases/0623-agent-to-agent-pr-comments.md
@@ -49,7 +49,7 @@ state, credentials, and unpublished artifacts. The public-safe evidence shape
 is the PR comment/fix lifecycle itself: a visible PR surface, a claimed todo,
 the fix diff, validation output, and the resulting review packet.
 
-## Website Story Beats
+## Public Evidence Sequence
 
 1. A PR receives feedback that should become executable work.
 2. LoopX turns the feedback into an owned todo instead of a chat reminder.

--- a/docs/showcases/cases/0623-overnight-project-refactor.en.html
+++ b/docs/showcases/cases/0623-overnight-project-refactor.en.html
@@ -1,0 +1,138 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>LoopX Showcase: Overnight project refactor as PR-sized slices</title>
+  <link rel="icon" href="data:,">
+  <style>
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  body{background:#0b0b0c;color:#f1f2f3;font-family:'Geist',system-ui,-apple-system,BlinkMacSystemFont,sans-serif;-webkit-font-smoothing:antialiased}
+  a{color:inherit}
+  ::selection{background:color-mix(in srgb,var(--accent,#6e79d6) 34%,transparent);color:#fff}
+  .gh{min-height:100vh;position:relative;overflow-x:hidden;--accent:#6e79d6}
+  .grain{position:fixed;inset:0;pointer-events:none;opacity:.025;mix-blend-mode:overlay;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E")}
+  article{position:relative;max-width:800px;margin:0 auto;padding:76px 28px 130px}
+  .mlab{font-family:'Geist Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11px;letter-spacing:.06em;color:#62666d;text-transform:uppercase}
+  h1{font-size:clamp(31px,4.6vw,46px);font-weight:600;line-height:1.12;letter-spacing:-.03em;margin:16px 0 14px;color:#fafafa;text-wrap:balance}
+  h2{font-size:22px;font-weight:600;letter-spacing:-.02em;color:#f1f2f3}
+  h3{font-size:21px;font-weight:600;letter-spacing:-.02em;color:#f1f2f3}
+  p{font-size:15.5px;line-height:1.75;color:#9ea3aa}
+  strong{color:#e9eaec;font-weight:600}
+  code{font-family:'Geist Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:12.5px;color:#c4c7cc}
+  .accent{font-size:clamp(17px,2.1vw,21px);font-weight:500;color:var(--accent);letter-spacing:-.01em;margin-bottom:22px}
+  .nav{display:flex;gap:10px;flex-wrap:wrap;margin:0 0 28px}
+  .nav a,.case-link{font-family:'Geist Mono',ui-monospace,monospace;font-size:11px;letter-spacing:.04em;text-decoration:none;color:#c4c7cc;border:1px solid rgba(255,255,255,.12);border-radius:6px;padding:7px 10px;background:rgba(255,255,255,.025)}
+  .nav a:hover,.case-link:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent);color:#f4f4f5}
+  .section-head{margin-top:74px;display:flex;align-items:baseline;gap:13px;margin-bottom:20px}
+  .section-head span{font-family:'Geist Mono',ui-monospace,monospace;font-size:13px;color:var(--accent)}
+  .panel{border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;overflow:hidden}
+  .panel-row{display:grid;grid-template-columns:150px 1fr;border-top:1px solid rgba(255,255,255,.07)}
+  .panel-row:first-child{border-top:0}
+  .panel-key{padding:18px 20px;border-right:1px solid rgba(255,255,255,.07);font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:var(--accent);background:color-mix(in srgb,var(--accent) 8%,transparent);letter-spacing:.04em}
+  .panel-val{padding:18px 20px;display:flex;align-items:center}
+  .panel-val p{font-size:14px;line-height:1.6;margin:0}
+  .diagram{border:1px solid rgba(255,255,255,.1);border-radius:12px;padding:30px 24px 22px;background:#0e0e10;margin:22px 0}
+  .diagram svg{display:block;width:100%;height:auto}
+  .chips{display:flex;gap:8px;flex-wrap:wrap;margin-top:22px}
+  .chips span{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#888d95;border:1px solid rgba(255,255,255,.12);padding:4px 8px;border-radius:5px}
+  .text-stack{display:flex;flex-direction:column;gap:16px}
+  .evidence-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px;margin:20px 0 6px}
+  .evidence-card{border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;padding:18px 18px 17px;min-height:128px}
+  .evidence-label{font-family:'Geist Mono',ui-monospace,monospace;font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:var(--accent);margin-bottom:10px}
+  .source-list{display:flex;flex-direction:column;gap:10px;margin-top:20px}
+  .source-ref{display:grid;grid-template-columns:150px 1fr;gap:14px;align-items:center;text-decoration:none;border:1px solid rgba(255,255,255,.1);border-radius:8px;background:#0e0e10;padding:12px 14px}
+  .source-ref:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent)}
+  .source-ref span{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:var(--accent);text-transform:uppercase;letter-spacing:.04em}
+  .source-ref code{color:#aeb3ba;word-break:break-word}
+  .boundary-box{border-left:2px solid var(--accent);background:#0e0e10;padding:18px 20px;margin-top:16px;border-radius:0 8px 8px 0}
+  .flow{display:flex;flex-direction:column}
+  .flow li{display:grid;grid-template-columns:28px 1fr;gap:14px;list-style:none}
+  .flow-num{width:24px;height:24px;border-radius:50%;border:1px solid color-mix(in srgb,var(--accent) 50%,transparent);display:flex;align-items:center;justify-content:center;font-family:'Geist Mono',ui-monospace,monospace;font-size:11.5px;color:var(--accent);background:#0b0b0c}
+  .flow-body{padding-bottom:18px;border-left:1px solid rgba(255,255,255,.12);padding-left:14px;margin-left:-27px}
+  .flow-title{font-size:14.5px;color:#eceef0;font-weight:500;margin-bottom:7px}
+  .metric-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px;margin-top:22px}
+  .metric{border:1px solid rgba(255,255,255,.1);border-radius:10px;padding:17px 19px;background:#0c0c0e}
+  .metric strong{display:block;font-size:24px;letter-spacing:-.02em;color:#fafafa}
+  .metric span{display:block;margin-top:5px;font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#62666d;text-transform:uppercase}
+  .search{width:100%;height:42px;margin:22px 0 16px;border:1px solid rgba(255,255,255,.12);border-radius:8px;background:#0e0e10;color:#f1f2f3;padding:0 12px;font:14px 'Geist',system-ui,sans-serif}
+  .cards{display:flex;flex-direction:column;gap:12px}
+  .card{display:block;text-decoration:none;border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;padding:18px 20px}
+  .card:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent)}
+  .card .meta{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#62666d;margin-bottom:8px}
+  .card p{font-size:14px;margin-top:9px}
+  .hide{display:none}
+  footer{margin-top:76px;color:#62666d;font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;line-height:1.7}
+  @media(max-width:720px){article{padding:52px 18px 90px}.panel-row{grid-template-columns:1fr}.panel-key{border-right:0;border-bottom:1px solid rgba(255,255,255,.07)}.metric-grid,.evidence-grid{grid-template-columns:1fr}.source-ref{grid-template-columns:1fr;gap:6px}}
+</style>
+</head>
+<body>
+<div class="gh">
+  <div class="grain"></div>
+  <article>
+
+    <nav class="nav" aria-label="Showcase navigation">
+      <a href="../index.en.html">Showcases</a>
+      <a href="../showcase-catalog.json">Catalog</a>
+      <a href="0623-overnight-project-refactor.html">中文</a>
+    </nav>
+
+    <div class="mlab">2026-06-23 · repository-refactor</div>
+    <h1>Overnight project refactor as PR-sized slices</h1>
+    <div class="accent">A broad refactor can run overnight while staying split into human-sized review units.</div>
+    <p>The operator can wake up to reviewable PR-sized refactor slices instead of a single giant autonomous diff.</p>
+    <div class="chips"><span>refactor</span><span>PR slices</span><span>todo evidence</span></div>
+
+    <div class="diagram" aria-label="LoopX control-plane sketch">
+      <svg viewBox="0 0 760 320" role="img">
+        <rect width="760" height="320" fill="#0e0e10"></rect>
+        <rect x="285" y="34" width="190" height="58" rx="8" fill="none" stroke="#6e79d6" stroke-width="2"></rect>
+        <text x="380" y="68" text-anchor="middle" fill="#f1f2f3" font-size="15" font-weight="600">LoopX</text>
+        <line x1="380" y1="92" x2="380" y2="132" stroke="#3a3d42" stroke-width="2"></line>
+        <rect x="52" y="132" width="180" height="78" rx="8" fill="none" stroke="#6a6e76" stroke-width="2"></rect>
+        <rect x="290" y="124" width="180" height="94" rx="8" fill="#6e79d6" fill-opacity=".16" stroke="#6e79d6" stroke-width="2"></rect>
+        <rect x="528" y="132" width="180" height="78" rx="8" fill="none" stroke="#6a6e76" stroke-width="2"></rect>
+        <text x="142" y="166" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">Overnight project refa</text>
+        <text x="380" y="163" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">loop</text>
+        <text x="618" y="166" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">public safe pattern case</text>
+        <text x="142" y="188" text-anchor="middle" fill="#62666d" font-size="11">goal / trigger</text>
+        <text x="380" y="185" text-anchor="middle" fill="#62666d" font-size="11">todo / gate / evidence</text>
+        <text x="618" y="188" text-anchor="middle" fill="#62666d" font-size="11">public outcome</text>
+        <line x1="232" y1="171" x2="282" y2="171" stroke="#6e79d6" stroke-width="2"></line>
+        <polygon points="290,171 280,165 280,177" fill="#6e79d6"></polygon>
+        <line x1="470" y1="171" x2="520" y2="171" stroke="#6e79d6" stroke-width="2"></line>
+        <polygon points="528,171 518,165 518,177" fill="#6e79d6"></polygon>
+        <path d="M618 210 L618 260 L142 260 L142 218" fill="none" stroke="#5a5e65" stroke-width="2"></path>
+        <polygon points="142,210 136,221 148,221" fill="#8a8088"></polygon>
+      </svg>
+    </div>
+
+
+    <div class="section-head"><span>01</span><h2>Case context</h2></div>
+    <div class="text-stack"><p>This case addresses the risk of unattended refactoring: a long-running agent can mix cleanup, behavior change, discoveries, and stale plans into one broad diff.</p><p>The public evidence is not a private overnight screenshot. It is the control-plane behavior already documented and smoke-tested in the repository: todo lifecycle, successor/supersede, validation writeback, and review packets.</p></div>
+
+    <div class="section-head"><span>02</span><h2>Repository evidence</h2></div>
+    <div class="panel">
+      <div class="panel-row"><div class="panel-key">Proof</div><div class="panel-val"><p>Long unattended refactors can split into moderate PR slices instead of one unreviewable diff.</p></div></div>
+      <div class="panel-row"><div class="panel-key">LoopX intervention</div><div class="panel-val"><p>loop, todo follow-up, supersede, PR-sized slices</p></div></div>
+    </div>
+
+    <div class="evidence-grid"><div class="evidence-card"><div class="evidence-label">Successor path</div><p>`docs/lark-kanban-control-plane-adapter.md` says real successors use `todo complete --next-*`, while replacements or narrower splits use `todo supersede --next-agent-todo`.</p></div><div class="evidence-card"><div class="evidence-label">Side-agent completion</div><p>`docs/heartbeat-automation-prompt.md` requires nontrivial completion to create a successor todo or a no-follow-up rationale.</p></div><div class="evidence-card"><div class="evidence-label">CLI validation</div><p>`examples/todo-lifecycle-cli-smoke.py` covers `--next-agent-todo`, `todo supersede`, claim inheritance, and handoff successors.</p></div><div class="evidence-card"><div class="evidence-label">Review shape</div><p>`loopx review-packet` packages open todos, claimed_by, and handoff state for reviewer consumption.</p></div></div>
+
+    <div class="section-head"><span>03</span><h2>LoopX behavior</h2></div>
+    <ul class="flow"><li><span class="flow-num">1</span><div class="flow-body"><div class="flow-title">The current refactor slice must stay reviewable; overnight discoveries do not all land in one PR.</div></div></li><li><span class="flow-num">2</span><div class="flow-body"><div class="flow-title">New discoveries become follow-up todos; changed routes supersede stale todos.</div></div></li><li><span class="flow-num">3</span><div class="flow-body"><div class="flow-title">Each slice carries focused validation or doc/contract smoke evidence rather than raw agent traces.</div></div></li><li><span class="flow-num">4</span><div class="flow-body"><div class="flow-title">Broad or unclear-risk slices route to review handoff instead of self-merge.</div></div></li></ul>
+
+    <div class="section-head"><span>04</span><h2>What the user sees</h2></div>
+    <div class="text-stack"><p>The user can let a refactor run overnight and wake up to bounded review units plus remaining todos, not one unreviewable giant change.</p><p>The project can move quickly while the review surface remains human-sized.</p></div>
+
+    <div class="section-head"><span>05</span><h2>Repository sources</h2></div>
+    <div class="source-list"><a class="source-ref" href="../../lark-kanban-control-plane-adapter.md"><span>kanban control-plane adapter</span><code>docs/lark-kanban-control-plane-adapter.md</code></a><a class="source-ref" href="../../heartbeat-automation-prompt.md"><span>heartbeat prompt contract</span><code>docs/heartbeat-automation-prompt.md</code></a><a class="source-ref" href="../../../examples/todo-lifecycle-cli-smoke.py"><span>todo lifecycle smoke</span><code>examples/todo-lifecycle-cli-smoke.py</code></a><a class="source-ref" href="0623-overnight-project-refactor.md"><span>case narrative</span><code>docs/showcases/cases/0623-overnight-project-refactor.md</code></a></div>
+    <div class="boundary-box"><p><strong>Evidence boundary.</strong> Public-safe pattern case only; no private screenshots, raw chats, internal planning notes, local paths, credentials, raw logs, or unpublished project artifacts.</p></div>
+    <div class="chips"><a class="case-link" href="0623-overnight-project-refactor.md">Case note</a></div>
+
+    <footer>Generated from docs/showcases/showcase-catalog.json. Private links, raw chats, local state, and internal media are excluded.</footer>
+  </article>
+</div>
+</body>
+</html>

--- a/docs/showcases/cases/0623-overnight-project-refactor.html
+++ b/docs/showcases/cases/0623-overnight-project-refactor.html
@@ -1,0 +1,138 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>LoopX Showcase: 一晚上自主重构项目</title>
+  <link rel="icon" href="data:,">
+  <style>
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  body{background:#0b0b0c;color:#f1f2f3;font-family:'Geist',system-ui,-apple-system,BlinkMacSystemFont,sans-serif;-webkit-font-smoothing:antialiased}
+  a{color:inherit}
+  ::selection{background:color-mix(in srgb,var(--accent,#6e79d6) 34%,transparent);color:#fff}
+  .gh{min-height:100vh;position:relative;overflow-x:hidden;--accent:#6e79d6}
+  .grain{position:fixed;inset:0;pointer-events:none;opacity:.025;mix-blend-mode:overlay;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E")}
+  article{position:relative;max-width:800px;margin:0 auto;padding:76px 28px 130px}
+  .mlab{font-family:'Geist Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11px;letter-spacing:.06em;color:#62666d;text-transform:uppercase}
+  h1{font-size:clamp(31px,4.6vw,46px);font-weight:600;line-height:1.12;letter-spacing:-.03em;margin:16px 0 14px;color:#fafafa;text-wrap:balance}
+  h2{font-size:22px;font-weight:600;letter-spacing:-.02em;color:#f1f2f3}
+  h3{font-size:21px;font-weight:600;letter-spacing:-.02em;color:#f1f2f3}
+  p{font-size:15.5px;line-height:1.75;color:#9ea3aa}
+  strong{color:#e9eaec;font-weight:600}
+  code{font-family:'Geist Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:12.5px;color:#c4c7cc}
+  .accent{font-size:clamp(17px,2.1vw,21px);font-weight:500;color:var(--accent);letter-spacing:-.01em;margin-bottom:22px}
+  .nav{display:flex;gap:10px;flex-wrap:wrap;margin:0 0 28px}
+  .nav a,.case-link{font-family:'Geist Mono',ui-monospace,monospace;font-size:11px;letter-spacing:.04em;text-decoration:none;color:#c4c7cc;border:1px solid rgba(255,255,255,.12);border-radius:6px;padding:7px 10px;background:rgba(255,255,255,.025)}
+  .nav a:hover,.case-link:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent);color:#f4f4f5}
+  .section-head{margin-top:74px;display:flex;align-items:baseline;gap:13px;margin-bottom:20px}
+  .section-head span{font-family:'Geist Mono',ui-monospace,monospace;font-size:13px;color:var(--accent)}
+  .panel{border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;overflow:hidden}
+  .panel-row{display:grid;grid-template-columns:150px 1fr;border-top:1px solid rgba(255,255,255,.07)}
+  .panel-row:first-child{border-top:0}
+  .panel-key{padding:18px 20px;border-right:1px solid rgba(255,255,255,.07);font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:var(--accent);background:color-mix(in srgb,var(--accent) 8%,transparent);letter-spacing:.04em}
+  .panel-val{padding:18px 20px;display:flex;align-items:center}
+  .panel-val p{font-size:14px;line-height:1.6;margin:0}
+  .diagram{border:1px solid rgba(255,255,255,.1);border-radius:12px;padding:30px 24px 22px;background:#0e0e10;margin:22px 0}
+  .diagram svg{display:block;width:100%;height:auto}
+  .chips{display:flex;gap:8px;flex-wrap:wrap;margin-top:22px}
+  .chips span{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#888d95;border:1px solid rgba(255,255,255,.12);padding:4px 8px;border-radius:5px}
+  .text-stack{display:flex;flex-direction:column;gap:16px}
+  .evidence-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px;margin:20px 0 6px}
+  .evidence-card{border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;padding:18px 18px 17px;min-height:128px}
+  .evidence-label{font-family:'Geist Mono',ui-monospace,monospace;font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:var(--accent);margin-bottom:10px}
+  .source-list{display:flex;flex-direction:column;gap:10px;margin-top:20px}
+  .source-ref{display:grid;grid-template-columns:150px 1fr;gap:14px;align-items:center;text-decoration:none;border:1px solid rgba(255,255,255,.1);border-radius:8px;background:#0e0e10;padding:12px 14px}
+  .source-ref:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent)}
+  .source-ref span{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:var(--accent);text-transform:uppercase;letter-spacing:.04em}
+  .source-ref code{color:#aeb3ba;word-break:break-word}
+  .boundary-box{border-left:2px solid var(--accent);background:#0e0e10;padding:18px 20px;margin-top:16px;border-radius:0 8px 8px 0}
+  .flow{display:flex;flex-direction:column}
+  .flow li{display:grid;grid-template-columns:28px 1fr;gap:14px;list-style:none}
+  .flow-num{width:24px;height:24px;border-radius:50%;border:1px solid color-mix(in srgb,var(--accent) 50%,transparent);display:flex;align-items:center;justify-content:center;font-family:'Geist Mono',ui-monospace,monospace;font-size:11.5px;color:var(--accent);background:#0b0b0c}
+  .flow-body{padding-bottom:18px;border-left:1px solid rgba(255,255,255,.12);padding-left:14px;margin-left:-27px}
+  .flow-title{font-size:14.5px;color:#eceef0;font-weight:500;margin-bottom:7px}
+  .metric-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px;margin-top:22px}
+  .metric{border:1px solid rgba(255,255,255,.1);border-radius:10px;padding:17px 19px;background:#0c0c0e}
+  .metric strong{display:block;font-size:24px;letter-spacing:-.02em;color:#fafafa}
+  .metric span{display:block;margin-top:5px;font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#62666d;text-transform:uppercase}
+  .search{width:100%;height:42px;margin:22px 0 16px;border:1px solid rgba(255,255,255,.12);border-radius:8px;background:#0e0e10;color:#f1f2f3;padding:0 12px;font:14px 'Geist',system-ui,sans-serif}
+  .cards{display:flex;flex-direction:column;gap:12px}
+  .card{display:block;text-decoration:none;border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;padding:18px 20px}
+  .card:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent)}
+  .card .meta{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#62666d;margin-bottom:8px}
+  .card p{font-size:14px;margin-top:9px}
+  .hide{display:none}
+  footer{margin-top:76px;color:#62666d;font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;line-height:1.7}
+  @media(max-width:720px){article{padding:52px 18px 90px}.panel-row{grid-template-columns:1fr}.panel-key{border-right:0;border-bottom:1px solid rgba(255,255,255,.07)}.metric-grid,.evidence-grid{grid-template-columns:1fr}.source-ref{grid-template-columns:1fr;gap:6px}}
+</style>
+</head>
+<body>
+<div class="gh">
+  <div class="grain"></div>
+  <article>
+
+    <nav class="nav" aria-label="Showcase navigation">
+      <a href="../index.html">Showcases</a>
+      <a href="../showcase-catalog.json">Catalog</a>
+      <a href="0623-overnight-project-refactor.en.html">English</a>
+    </nav>
+
+    <div class="mlab">2026-06-23 · repository-refactor</div>
+    <h1>一晚上自主重构项目</h1>
+    <div class="accent">长时间无值守重构能拆成适中 PR，而不是一个不可 review 大改。</div>
+    <p>The operator can wake up to reviewable PR-sized refactor slices instead of a single giant autonomous diff.</p>
+    <div class="chips"><span>refactor</span><span>PR slices</span><span>todo evidence</span></div>
+
+    <div class="diagram" aria-label="LoopX control-plane sketch">
+      <svg viewBox="0 0 760 320" role="img">
+        <rect width="760" height="320" fill="#0e0e10"></rect>
+        <rect x="285" y="34" width="190" height="58" rx="8" fill="none" stroke="#6e79d6" stroke-width="2"></rect>
+        <text x="380" y="68" text-anchor="middle" fill="#f1f2f3" font-size="15" font-weight="600">LoopX</text>
+        <line x1="380" y1="92" x2="380" y2="132" stroke="#3a3d42" stroke-width="2"></line>
+        <rect x="52" y="132" width="180" height="78" rx="8" fill="none" stroke="#6a6e76" stroke-width="2"></rect>
+        <rect x="290" y="124" width="180" height="94" rx="8" fill="#6e79d6" fill-opacity=".16" stroke="#6e79d6" stroke-width="2"></rect>
+        <rect x="528" y="132" width="180" height="78" rx="8" fill="none" stroke="#6a6e76" stroke-width="2"></rect>
+        <text x="142" y="166" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">一晚上自主重构项目</text>
+        <text x="380" y="163" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">loop</text>
+        <text x="618" y="166" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">public safe pattern case</text>
+        <text x="142" y="188" text-anchor="middle" fill="#62666d" font-size="11">goal / trigger</text>
+        <text x="380" y="185" text-anchor="middle" fill="#62666d" font-size="11">todo / gate / evidence</text>
+        <text x="618" y="188" text-anchor="middle" fill="#62666d" font-size="11">public outcome</text>
+        <line x1="232" y1="171" x2="282" y2="171" stroke="#6e79d6" stroke-width="2"></line>
+        <polygon points="290,171 280,165 280,177" fill="#6e79d6"></polygon>
+        <line x1="470" y1="171" x2="520" y2="171" stroke="#6e79d6" stroke-width="2"></line>
+        <polygon points="528,171 518,165 518,177" fill="#6e79d6"></polygon>
+        <path d="M618 210 L618 260 L142 260 L142 218" fill="none" stroke="#5a5e65" stroke-width="2"></path>
+        <polygon points="142,210 136,221 148,221" fill="#8a8088"></polygon>
+      </svg>
+    </div>
+
+
+    <div class="section-head"><span>01</span><h2>案例背景</h2></div>
+    <div class="text-stack"><p>这个案例解决的是无人值守重构的风险：长时间 agent 容易把 cleanup、行为改变、发现的新问题和过期计划混成一个大 diff。</p><p>LoopX 的公开证据不是某个私有夜间截图，而是 todo lifecycle、successor/supersede、validation writeback 和 review-packet 这些已经在仓库里有文档和 smoke 的控制面。</p></div>
+
+    <div class="section-head"><span>02</span><h2>仓库证据</h2></div>
+    <div class="panel">
+      <div class="panel-row"><div class="panel-key">证明点</div><div class="panel-val"><p>无人值守 refactor 可以拆成 PR-sized slice。</p></div></div>
+      <div class="panel-row"><div class="panel-key">LoopX 介入</div><div class="panel-val"><p>loop、todo follow-up、supersede、PR-sized slices</p></div></div>
+    </div>
+
+    <div class="evidence-grid"><div class="evidence-card"><div class="evidence-label">successor path</div><p>`docs/lark-kanban-control-plane-adapter.md` 明确 real successor 使用 `todo complete --next-*`，replacement 或 narrower split 使用 `todo supersede --next-agent-todo`。</p></div><div class="evidence-card"><div class="evidence-label">side-agent completion</div><p>`docs/heartbeat-automation-prompt.md` 要求非平凡完成创建 successor todo 或写 no-follow-up rationale。</p></div><div class="evidence-card"><div class="evidence-label">CLI validation</div><p>`examples/todo-lifecycle-cli-smoke.py` 覆盖 `--next-agent-todo`、`todo supersede`、claim 继承和 handoff successor。</p></div><div class="evidence-card"><div class="evidence-label">review shape</div><p>`loopx review-packet` 把当前 open todo、claimed_by 和 handoff 状态打包成 reviewer 可读的 packet。</p></div></div>
+
+    <div class="section-head"><span>03</span><h2>LoopX 行为</h2></div>
+    <ul class="flow"><li><span class="flow-num">1</span><div class="flow-body"><div class="flow-title">当前 refactor slice 必须是可 review 的单位，不把整夜发现都塞进一个 PR。</div></div></li><li><span class="flow-num">2</span><div class="flow-body"><div class="flow-title">发现的新工作写成 follow-up todo；路线变了就 supersede 旧 todo。</div></div></li><li><span class="flow-num">3</span><div class="flow-body"><div class="flow-title">每个 slice 用 focused validation 或文档/contract smoke 证明，而不是依赖原始 agent trace。</div></div></li><li><span class="flow-num">4</span><div class="flow-body"><div class="flow-title">大范围或风险不清楚的 slice 不自合并，进入 review handoff。</div></div></li></ul>
+
+    <div class="section-head"><span>04</span><h2>用户看到什么</h2></div>
+    <div class="text-stack"><p>用户可以让重构跑过夜，但早上看到的是一组有边界的 review 单元和剩余 todo，而不是一个不可 review 的巨型改动。</p><p>项目可以继续快，但 review 面仍是人能处理的粒度。</p></div>
+
+    <div class="section-head"><span>05</span><h2>仓库来源</h2></div>
+    <div class="source-list"><a class="source-ref" href="../../lark-kanban-control-plane-adapter.md"><span>kanban control-plane adapter</span><code>docs/lark-kanban-control-plane-adapter.md</code></a><a class="source-ref" href="../../heartbeat-automation-prompt.md"><span>heartbeat prompt contract</span><code>docs/heartbeat-automation-prompt.md</code></a><a class="source-ref" href="../../../examples/todo-lifecycle-cli-smoke.py"><span>todo lifecycle smoke</span><code>examples/todo-lifecycle-cli-smoke.py</code></a><a class="source-ref" href="0623-overnight-project-refactor.md"><span>case narrative</span><code>docs/showcases/cases/0623-overnight-project-refactor.md</code></a></div>
+    <div class="boundary-box"><p><strong>证据边界.</strong> Public-safe pattern case only; no private screenshots, raw chats, internal planning notes, local paths, credentials, raw logs, or unpublished project artifacts.</p></div>
+    <div class="chips"><a class="case-link" href="0623-overnight-project-refactor.md">案例说明</a></div>
+
+    <footer>由 docs/showcases/showcase-catalog.json 生成。不包含私有链接、原始聊天、本地状态或内部媒体。</footer>
+  </article>
+</div>
+</body>
+</html>

--- a/docs/showcases/cases/0623-overnight-project-refactor.md
+++ b/docs/showcases/cases/0623-overnight-project-refactor.md
@@ -49,7 +49,7 @@ local paths, credentials, raw logs, and unpublished project artifacts. Public
 evidence should come from the resulting PR-sized diffs, validation commands,
 and follow-up/supersede state, not from raw agent traces.
 
-## Website Story Beats
+## Public Evidence Sequence
 
 1. A broad refactor starts as a long-running goal.
 2. LoopX keeps the current slice explicit.

--- a/docs/showcases/cases/0624-pr-issue-auto-fix.en.html
+++ b/docs/showcases/cases/0624-pr-issue-auto-fix.en.html
@@ -1,0 +1,138 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>LoopX Showcase: PR issue automatic fix loop</title>
+  <link rel="icon" href="data:,">
+  <style>
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  body{background:#0b0b0c;color:#f1f2f3;font-family:'Geist',system-ui,-apple-system,BlinkMacSystemFont,sans-serif;-webkit-font-smoothing:antialiased}
+  a{color:inherit}
+  ::selection{background:color-mix(in srgb,var(--accent,#6e79d6) 34%,transparent);color:#fff}
+  .gh{min-height:100vh;position:relative;overflow-x:hidden;--accent:#6e79d6}
+  .grain{position:fixed;inset:0;pointer-events:none;opacity:.025;mix-blend-mode:overlay;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E")}
+  article{position:relative;max-width:800px;margin:0 auto;padding:76px 28px 130px}
+  .mlab{font-family:'Geist Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11px;letter-spacing:.06em;color:#62666d;text-transform:uppercase}
+  h1{font-size:clamp(31px,4.6vw,46px);font-weight:600;line-height:1.12;letter-spacing:-.03em;margin:16px 0 14px;color:#fafafa;text-wrap:balance}
+  h2{font-size:22px;font-weight:600;letter-spacing:-.02em;color:#f1f2f3}
+  h3{font-size:21px;font-weight:600;letter-spacing:-.02em;color:#f1f2f3}
+  p{font-size:15.5px;line-height:1.75;color:#9ea3aa}
+  strong{color:#e9eaec;font-weight:600}
+  code{font-family:'Geist Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:12.5px;color:#c4c7cc}
+  .accent{font-size:clamp(17px,2.1vw,21px);font-weight:500;color:var(--accent);letter-spacing:-.01em;margin-bottom:22px}
+  .nav{display:flex;gap:10px;flex-wrap:wrap;margin:0 0 28px}
+  .nav a,.case-link{font-family:'Geist Mono',ui-monospace,monospace;font-size:11px;letter-spacing:.04em;text-decoration:none;color:#c4c7cc;border:1px solid rgba(255,255,255,.12);border-radius:6px;padding:7px 10px;background:rgba(255,255,255,.025)}
+  .nav a:hover,.case-link:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent);color:#f4f4f5}
+  .section-head{margin-top:74px;display:flex;align-items:baseline;gap:13px;margin-bottom:20px}
+  .section-head span{font-family:'Geist Mono',ui-monospace,monospace;font-size:13px;color:var(--accent)}
+  .panel{border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;overflow:hidden}
+  .panel-row{display:grid;grid-template-columns:150px 1fr;border-top:1px solid rgba(255,255,255,.07)}
+  .panel-row:first-child{border-top:0}
+  .panel-key{padding:18px 20px;border-right:1px solid rgba(255,255,255,.07);font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:var(--accent);background:color-mix(in srgb,var(--accent) 8%,transparent);letter-spacing:.04em}
+  .panel-val{padding:18px 20px;display:flex;align-items:center}
+  .panel-val p{font-size:14px;line-height:1.6;margin:0}
+  .diagram{border:1px solid rgba(255,255,255,.1);border-radius:12px;padding:30px 24px 22px;background:#0e0e10;margin:22px 0}
+  .diagram svg{display:block;width:100%;height:auto}
+  .chips{display:flex;gap:8px;flex-wrap:wrap;margin-top:22px}
+  .chips span{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#888d95;border:1px solid rgba(255,255,255,.12);padding:4px 8px;border-radius:5px}
+  .text-stack{display:flex;flex-direction:column;gap:16px}
+  .evidence-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px;margin:20px 0 6px}
+  .evidence-card{border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;padding:18px 18px 17px;min-height:128px}
+  .evidence-label{font-family:'Geist Mono',ui-monospace,monospace;font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:var(--accent);margin-bottom:10px}
+  .source-list{display:flex;flex-direction:column;gap:10px;margin-top:20px}
+  .source-ref{display:grid;grid-template-columns:150px 1fr;gap:14px;align-items:center;text-decoration:none;border:1px solid rgba(255,255,255,.1);border-radius:8px;background:#0e0e10;padding:12px 14px}
+  .source-ref:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent)}
+  .source-ref span{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:var(--accent);text-transform:uppercase;letter-spacing:.04em}
+  .source-ref code{color:#aeb3ba;word-break:break-word}
+  .boundary-box{border-left:2px solid var(--accent);background:#0e0e10;padding:18px 20px;margin-top:16px;border-radius:0 8px 8px 0}
+  .flow{display:flex;flex-direction:column}
+  .flow li{display:grid;grid-template-columns:28px 1fr;gap:14px;list-style:none}
+  .flow-num{width:24px;height:24px;border-radius:50%;border:1px solid color-mix(in srgb,var(--accent) 50%,transparent);display:flex;align-items:center;justify-content:center;font-family:'Geist Mono',ui-monospace,monospace;font-size:11.5px;color:var(--accent);background:#0b0b0c}
+  .flow-body{padding-bottom:18px;border-left:1px solid rgba(255,255,255,.12);padding-left:14px;margin-left:-27px}
+  .flow-title{font-size:14.5px;color:#eceef0;font-weight:500;margin-bottom:7px}
+  .metric-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px;margin-top:22px}
+  .metric{border:1px solid rgba(255,255,255,.1);border-radius:10px;padding:17px 19px;background:#0c0c0e}
+  .metric strong{display:block;font-size:24px;letter-spacing:-.02em;color:#fafafa}
+  .metric span{display:block;margin-top:5px;font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#62666d;text-transform:uppercase}
+  .search{width:100%;height:42px;margin:22px 0 16px;border:1px solid rgba(255,255,255,.12);border-radius:8px;background:#0e0e10;color:#f1f2f3;padding:0 12px;font:14px 'Geist',system-ui,sans-serif}
+  .cards{display:flex;flex-direction:column;gap:12px}
+  .card{display:block;text-decoration:none;border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;padding:18px 20px}
+  .card:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent)}
+  .card .meta{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#62666d;margin-bottom:8px}
+  .card p{font-size:14px;margin-top:9px}
+  .hide{display:none}
+  footer{margin-top:76px;color:#62666d;font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;line-height:1.7}
+  @media(max-width:720px){article{padding:52px 18px 90px}.panel-row{grid-template-columns:1fr}.panel-key{border-right:0;border-bottom:1px solid rgba(255,255,255,.07)}.metric-grid,.evidence-grid{grid-template-columns:1fr}.source-ref{grid-template-columns:1fr;gap:6px}}
+</style>
+</head>
+<body>
+<div class="gh">
+  <div class="grain"></div>
+  <article>
+
+    <nav class="nav" aria-label="Showcase navigation">
+      <a href="../index.en.html">Showcases</a>
+      <a href="../showcase-catalog.json">Catalog</a>
+      <a href="0624-pr-issue-auto-fix.html">中文</a>
+    </nav>
+
+    <div class="mlab">2026-06-24 · issue-fix-workflow</div>
+    <h1>PR issue automatic fix loop</h1>
+    <div class="accent">Review feedback should become an ordered repair workflow with repro, fix, validation, and reviewer handoff.</div>
+    <p>The operator can turn a PR issue into a controlled fix loop without manually rewriting the review comment as an agent plan.</p>
+    <div class="chips"><span>issue fix</span><span>repro smoke</span><span>PR review</span></div>
+
+    <div class="diagram" aria-label="LoopX control-plane sketch">
+      <svg viewBox="0 0 760 320" role="img">
+        <rect width="760" height="320" fill="#0e0e10"></rect>
+        <rect x="285" y="34" width="190" height="58" rx="8" fill="none" stroke="#6e79d6" stroke-width="2"></rect>
+        <text x="380" y="68" text-anchor="middle" fill="#f1f2f3" font-size="15" font-weight="600">LoopX</text>
+        <line x1="380" y1="92" x2="380" y2="132" stroke="#3a3d42" stroke-width="2"></line>
+        <rect x="52" y="132" width="180" height="78" rx="8" fill="none" stroke="#6a6e76" stroke-width="2"></rect>
+        <rect x="290" y="124" width="180" height="94" rx="8" fill="#6e79d6" fill-opacity=".16" stroke="#6e79d6" stroke-width="2"></rect>
+        <rect x="528" y="132" width="180" height="78" rx="8" fill="none" stroke="#6a6e76" stroke-width="2"></rect>
+        <text x="142" y="166" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">PR issue automatic fix</text>
+        <text x="380" y="163" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">issue-fix workflow</text>
+        <text x="618" y="166" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">public safe pattern case</text>
+        <text x="142" y="188" text-anchor="middle" fill="#62666d" font-size="11">goal / trigger</text>
+        <text x="380" y="185" text-anchor="middle" fill="#62666d" font-size="11">todo / gate / evidence</text>
+        <text x="618" y="188" text-anchor="middle" fill="#62666d" font-size="11">public outcome</text>
+        <line x1="232" y1="171" x2="282" y2="171" stroke="#6e79d6" stroke-width="2"></line>
+        <polygon points="290,171 280,165 280,177" fill="#6e79d6"></polygon>
+        <line x1="470" y1="171" x2="520" y2="171" stroke="#6e79d6" stroke-width="2"></line>
+        <polygon points="528,171 518,165 518,177" fill="#6e79d6"></polygon>
+        <path d="M618 210 L618 260 L142 260 L142 218" fill="none" stroke="#5a5e65" stroke-width="2"></path>
+        <polygon points="142,210 136,221 148,221" fill="#8a8088"></polygon>
+      </svg>
+    </div>
+
+
+    <div class="section-head"><span>01</span><h2>Case context</h2></div>
+    <div class="text-stack"><p>This case turns a PR issue, review comment, or issue text into an executable repair loop. It is not simply reading a comment and editing code; the path goes through metadata/intake, repro, branch-local patch, validation, and review packet.</p><p>The repository already contains the issue-fix capability: `loopx/capabilities/issue_fix/`, the `loopx issue-fix ...` CLI entry, protocol docs, and public smokes.</p></div>
+
+    <div class="section-head"><span>02</span><h2>Repository evidence</h2></div>
+    <div class="panel">
+      <div class="panel-row"><div class="panel-key">Proof</div><div class="panel-val"><p>Issue and review feedback can enter an executable repair loop.</p></div></div>
+      <div class="panel-row"><div class="panel-key">LoopX intervention</div><div class="panel-val"><p>issue-fix workflow, command pack, repro smoke, PR review feedback</p></div></div>
+    </div>
+
+    <div class="evidence-grid"><div class="evidence-card"><div class="evidence-label">Product entry</div><p>`docs/capabilities/issue-fix/README.md` names `loopx issue-fix ...`, the content-ops bridge, protocol docs, and smokes.</p></div><div class="evidence-card"><div class="evidence-label">Workflow contract</div><p>`issue_fix_workflow_contract_v0` defines metadata preview, intake classification, workflow plan, todo writeback, caller repo branch, validation, PR review packet, and gate handling.</p></div><div class="evidence-card"><div class="evidence-label">Executable loop</div><p>`issue_fix_acceptance_loop_v0` includes the acceptance fixture, repo-branch fixture, and caller-approved repo branch mode.</p></div><div class="evidence-card"><div class="evidence-label">Validation surface</div><p>Smokes cover workflow planning, workflow contract, metadata/intake, and acceptance-loop behavior.</p></div></div>
+
+    <div class="section-head"><span>03</span><h2>LoopX behavior</h2></div>
+    <ul class="flow"><li><span class="flow-num">1</span><div class="flow-body"><div class="flow-title">Public metadata can enter packets; raw issue bodies, comment bodies, timelines, and provider payloads remain gated sources.</div></div></li><li><span class="flow-num">2</span><div class="flow-body"><div class="flow-title">Accepted candidates become ordered LoopX todos: repro smoke, code-context route, branch-local patch, validation, and review-packet readiness.</div></div></li><li><span class="flow-num">3</span><div class="flow-body"><div class="flow-title">Caller-approved repo mode inspects the local repo only under `--execute` and reports repo-relative changed files plus validation pass/fail.</div></div></li><li><span class="flow-num">4</span><div class="flow-body"><div class="flow-title">External comments, PR creation, merge, publish, destructive git, and production action remain explicit gates.</div></div></li></ul>
+
+    <div class="section-head"><span>04</span><h2>What the user sees</h2></div>
+    <div class="text-stack"><p>A maintainer can provide a public issue or PR signal and get a loop that reproduces, fixes, validates, and prepares human review.</p><p>The user does not need to rewrite every review comment as an agent prompt, and raw issue bodies or local paths do not leak into the public artifact.</p></div>
+
+    <div class="section-head"><span>05</span><h2>Repository sources</h2></div>
+    <div class="source-list"><a class="source-ref" href="../../capabilities/issue-fix/README.md"><span>capability README</span><code>docs/capabilities/issue-fix/README.md</code></a><a class="source-ref" href="../../capabilities/issue-fix/protocols/issue-fix-workflow-contract-v0.md"><span>workflow contract</span><code>docs/capabilities/issue-fix/protocols/issue-fix-workflow-contract-v0.md</code></a><a class="source-ref" href="../../capabilities/issue-fix/protocols/issue-fix-acceptance-loop-v0.md"><span>acceptance loop</span><code>docs/capabilities/issue-fix/protocols/issue-fix-acceptance-loop-v0.md</code></a><a class="source-ref" href="../../../examples/issue-fix-workflow-plan-smoke.py"><span>workflow smoke</span><code>examples/issue-fix-workflow-plan-smoke.py</code></a><a class="source-ref" href="../../../examples/issue-fix-acceptance-loop-smoke.py"><span>acceptance smoke</span><code>examples/issue-fix-acceptance-loop-smoke.py</code></a></div>
+    <div class="boundary-box"><p><strong>Evidence boundary.</strong> Public-safe pattern case only; no private screenshots, raw gated issue bodies, internal review notes, local paths, raw logs, credentials, or unpublished repository artifacts.</p></div>
+    <div class="chips"><a class="case-link" href="0624-pr-issue-auto-fix.md">Case note</a></div>
+
+    <footer>Generated from docs/showcases/showcase-catalog.json. Private links, raw chats, local state, and internal media are excluded.</footer>
+  </article>
+</div>
+</body>
+</html>

--- a/docs/showcases/cases/0624-pr-issue-auto-fix.html
+++ b/docs/showcases/cases/0624-pr-issue-auto-fix.html
@@ -1,0 +1,138 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>LoopX Showcase: PR Issue 自动 Fix</title>
+  <link rel="icon" href="data:,">
+  <style>
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  body{background:#0b0b0c;color:#f1f2f3;font-family:'Geist',system-ui,-apple-system,BlinkMacSystemFont,sans-serif;-webkit-font-smoothing:antialiased}
+  a{color:inherit}
+  ::selection{background:color-mix(in srgb,var(--accent,#6e79d6) 34%,transparent);color:#fff}
+  .gh{min-height:100vh;position:relative;overflow-x:hidden;--accent:#6e79d6}
+  .grain{position:fixed;inset:0;pointer-events:none;opacity:.025;mix-blend-mode:overlay;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E")}
+  article{position:relative;max-width:800px;margin:0 auto;padding:76px 28px 130px}
+  .mlab{font-family:'Geist Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11px;letter-spacing:.06em;color:#62666d;text-transform:uppercase}
+  h1{font-size:clamp(31px,4.6vw,46px);font-weight:600;line-height:1.12;letter-spacing:-.03em;margin:16px 0 14px;color:#fafafa;text-wrap:balance}
+  h2{font-size:22px;font-weight:600;letter-spacing:-.02em;color:#f1f2f3}
+  h3{font-size:21px;font-weight:600;letter-spacing:-.02em;color:#f1f2f3}
+  p{font-size:15.5px;line-height:1.75;color:#9ea3aa}
+  strong{color:#e9eaec;font-weight:600}
+  code{font-family:'Geist Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:12.5px;color:#c4c7cc}
+  .accent{font-size:clamp(17px,2.1vw,21px);font-weight:500;color:var(--accent);letter-spacing:-.01em;margin-bottom:22px}
+  .nav{display:flex;gap:10px;flex-wrap:wrap;margin:0 0 28px}
+  .nav a,.case-link{font-family:'Geist Mono',ui-monospace,monospace;font-size:11px;letter-spacing:.04em;text-decoration:none;color:#c4c7cc;border:1px solid rgba(255,255,255,.12);border-radius:6px;padding:7px 10px;background:rgba(255,255,255,.025)}
+  .nav a:hover,.case-link:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent);color:#f4f4f5}
+  .section-head{margin-top:74px;display:flex;align-items:baseline;gap:13px;margin-bottom:20px}
+  .section-head span{font-family:'Geist Mono',ui-monospace,monospace;font-size:13px;color:var(--accent)}
+  .panel{border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;overflow:hidden}
+  .panel-row{display:grid;grid-template-columns:150px 1fr;border-top:1px solid rgba(255,255,255,.07)}
+  .panel-row:first-child{border-top:0}
+  .panel-key{padding:18px 20px;border-right:1px solid rgba(255,255,255,.07);font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:var(--accent);background:color-mix(in srgb,var(--accent) 8%,transparent);letter-spacing:.04em}
+  .panel-val{padding:18px 20px;display:flex;align-items:center}
+  .panel-val p{font-size:14px;line-height:1.6;margin:0}
+  .diagram{border:1px solid rgba(255,255,255,.1);border-radius:12px;padding:30px 24px 22px;background:#0e0e10;margin:22px 0}
+  .diagram svg{display:block;width:100%;height:auto}
+  .chips{display:flex;gap:8px;flex-wrap:wrap;margin-top:22px}
+  .chips span{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#888d95;border:1px solid rgba(255,255,255,.12);padding:4px 8px;border-radius:5px}
+  .text-stack{display:flex;flex-direction:column;gap:16px}
+  .evidence-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px;margin:20px 0 6px}
+  .evidence-card{border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;padding:18px 18px 17px;min-height:128px}
+  .evidence-label{font-family:'Geist Mono',ui-monospace,monospace;font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:var(--accent);margin-bottom:10px}
+  .source-list{display:flex;flex-direction:column;gap:10px;margin-top:20px}
+  .source-ref{display:grid;grid-template-columns:150px 1fr;gap:14px;align-items:center;text-decoration:none;border:1px solid rgba(255,255,255,.1);border-radius:8px;background:#0e0e10;padding:12px 14px}
+  .source-ref:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent)}
+  .source-ref span{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:var(--accent);text-transform:uppercase;letter-spacing:.04em}
+  .source-ref code{color:#aeb3ba;word-break:break-word}
+  .boundary-box{border-left:2px solid var(--accent);background:#0e0e10;padding:18px 20px;margin-top:16px;border-radius:0 8px 8px 0}
+  .flow{display:flex;flex-direction:column}
+  .flow li{display:grid;grid-template-columns:28px 1fr;gap:14px;list-style:none}
+  .flow-num{width:24px;height:24px;border-radius:50%;border:1px solid color-mix(in srgb,var(--accent) 50%,transparent);display:flex;align-items:center;justify-content:center;font-family:'Geist Mono',ui-monospace,monospace;font-size:11.5px;color:var(--accent);background:#0b0b0c}
+  .flow-body{padding-bottom:18px;border-left:1px solid rgba(255,255,255,.12);padding-left:14px;margin-left:-27px}
+  .flow-title{font-size:14.5px;color:#eceef0;font-weight:500;margin-bottom:7px}
+  .metric-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px;margin-top:22px}
+  .metric{border:1px solid rgba(255,255,255,.1);border-radius:10px;padding:17px 19px;background:#0c0c0e}
+  .metric strong{display:block;font-size:24px;letter-spacing:-.02em;color:#fafafa}
+  .metric span{display:block;margin-top:5px;font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#62666d;text-transform:uppercase}
+  .search{width:100%;height:42px;margin:22px 0 16px;border:1px solid rgba(255,255,255,.12);border-radius:8px;background:#0e0e10;color:#f1f2f3;padding:0 12px;font:14px 'Geist',system-ui,sans-serif}
+  .cards{display:flex;flex-direction:column;gap:12px}
+  .card{display:block;text-decoration:none;border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;padding:18px 20px}
+  .card:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent)}
+  .card .meta{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#62666d;margin-bottom:8px}
+  .card p{font-size:14px;margin-top:9px}
+  .hide{display:none}
+  footer{margin-top:76px;color:#62666d;font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;line-height:1.7}
+  @media(max-width:720px){article{padding:52px 18px 90px}.panel-row{grid-template-columns:1fr}.panel-key{border-right:0;border-bottom:1px solid rgba(255,255,255,.07)}.metric-grid,.evidence-grid{grid-template-columns:1fr}.source-ref{grid-template-columns:1fr;gap:6px}}
+</style>
+</head>
+<body>
+<div class="gh">
+  <div class="grain"></div>
+  <article>
+
+    <nav class="nav" aria-label="Showcase navigation">
+      <a href="../index.html">Showcases</a>
+      <a href="../showcase-catalog.json">Catalog</a>
+      <a href="0624-pr-issue-auto-fix.en.html">English</a>
+    </nav>
+
+    <div class="mlab">2026-06-24 · issue-fix-workflow</div>
+    <h1>PR Issue 自动 Fix</h1>
+    <div class="accent">Issue / Review comment 可以进入可执行修复闭环。</div>
+    <p>The operator can turn a PR issue into a controlled fix loop without manually rewriting the review comment as an agent plan.</p>
+    <div class="chips"><span>issue fix</span><span>repro smoke</span><span>PR review</span></div>
+
+    <div class="diagram" aria-label="LoopX control-plane sketch">
+      <svg viewBox="0 0 760 320" role="img">
+        <rect width="760" height="320" fill="#0e0e10"></rect>
+        <rect x="285" y="34" width="190" height="58" rx="8" fill="none" stroke="#6e79d6" stroke-width="2"></rect>
+        <text x="380" y="68" text-anchor="middle" fill="#f1f2f3" font-size="15" font-weight="600">LoopX</text>
+        <line x1="380" y1="92" x2="380" y2="132" stroke="#3a3d42" stroke-width="2"></line>
+        <rect x="52" y="132" width="180" height="78" rx="8" fill="none" stroke="#6a6e76" stroke-width="2"></rect>
+        <rect x="290" y="124" width="180" height="94" rx="8" fill="#6e79d6" fill-opacity=".16" stroke="#6e79d6" stroke-width="2"></rect>
+        <rect x="528" y="132" width="180" height="78" rx="8" fill="none" stroke="#6a6e76" stroke-width="2"></rect>
+        <text x="142" y="166" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">PR Issue 自动 Fix</text>
+        <text x="380" y="163" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">issue-fix workflow</text>
+        <text x="618" y="166" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">public safe pattern case</text>
+        <text x="142" y="188" text-anchor="middle" fill="#62666d" font-size="11">goal / trigger</text>
+        <text x="380" y="185" text-anchor="middle" fill="#62666d" font-size="11">todo / gate / evidence</text>
+        <text x="618" y="188" text-anchor="middle" fill="#62666d" font-size="11">public outcome</text>
+        <line x1="232" y1="171" x2="282" y2="171" stroke="#6e79d6" stroke-width="2"></line>
+        <polygon points="290,171 280,165 280,177" fill="#6e79d6"></polygon>
+        <line x1="470" y1="171" x2="520" y2="171" stroke="#6e79d6" stroke-width="2"></line>
+        <polygon points="528,171 518,165 518,177" fill="#6e79d6"></polygon>
+        <path d="M618 210 L618 260 L142 260 L142 218" fill="none" stroke="#5a5e65" stroke-width="2"></path>
+        <polygon points="142,210 136,221 148,221" fill="#8a8088"></polygon>
+      </svg>
+    </div>
+
+
+    <div class="section-head"><span>01</span><h2>案例背景</h2></div>
+    <div class="text-stack"><p>这个案例把 PR issue、review comment 或 issue text 转成可执行修复闭环。它不是“读一段评论就改代码”，而是先做 metadata/intake、repro、branch-local patch、validation 和 review packet。</p><p>仓库已经有 issue-fix capability：模块在 `loopx/capabilities/issue_fix/`，CLI 入口是 `loopx issue-fix ...`，协议文档和 smoke 都在公开仓库内。</p></div>
+
+    <div class="section-head"><span>02</span><h2>仓库证据</h2></div>
+    <div class="panel">
+      <div class="panel-row"><div class="panel-key">证明点</div><div class="panel-val"><p>Issue 和 review 反馈可以变成受控、可执行的修复循环。</p></div></div>
+      <div class="panel-row"><div class="panel-key">LoopX 介入</div><div class="panel-val"><p>issue-fix workflow、command pack、repro smoke、PR review feedback</p></div></div>
+    </div>
+
+    <div class="evidence-grid"><div class="evidence-card"><div class="evidence-label">产品入口</div><p>`docs/capabilities/issue-fix/README.md` 声明 `loopx issue-fix ...`、content-ops bridge、protocol docs 和 smoke。</p></div><div class="evidence-card"><div class="evidence-label">工作流协议</div><p>`issue_fix_workflow_contract_v0` 明确 metadata preview、intake classification、workflow plan、todo writeback、caller repo branch、validation、PR review packet 和 gate handling。</p></div><div class="evidence-card"><div class="evidence-label">可执行闭环</div><p>`issue_fix_acceptance_loop_v0` 包含 acceptance fixture、repo-branch fixture 和 caller-approved repo branch mode。</p></div><div class="evidence-card"><div class="evidence-label">验证面</div><p>`examples/issue-fix-workflow-plan-smoke.py`、`examples/issue-fix-workflow-contract-smoke.py`、`examples/issue-fix-acceptance-loop-smoke.py` 等 smoke 覆盖这个路径。</p></div></div>
+
+    <div class="section-head"><span>03</span><h2>LoopX 行为</h2></div>
+    <ul class="flow"><li><span class="flow-num">1</span><div class="flow-body"><div class="flow-title">public metadata 可以进入 packet；raw issue body、comment body、timeline、provider payload 都是 gated source。</div></div></li><li><span class="flow-num">2</span><div class="flow-body"><div class="flow-title">accepted candidates 写成有序 LoopX todos：repro smoke、code-context route、branch-local patch、validation、review-packet readiness。</div></div></li><li><span class="flow-num">3</span><div class="flow-body"><div class="flow-title">caller-approved repo 模式只在 `--execute` 时检查本地 repo，并且输出 repo-relative changed files、validation pass/fail 和 PR-readiness。</div></div></li><li><span class="flow-num">4</span><div class="flow-body"><div class="flow-title">外部 comment、PR creation、merge、publish、destructive git 和 production action 都保留为显式 gate。</div></div></li></ul>
+
+    <div class="section-head"><span>04</span><h2>用户看到什么</h2></div>
+    <div class="text-stack"><p>维护者给出一个 public issue/PR signal 后，可以得到一个先复现、再修复、再验证、最后交给 review 的闭环。</p><p>用户不需要把每个 review comment 手动改写成 agent prompt，也不会把原始 issue body 或本地路径泄漏进公开 artifact。</p></div>
+
+    <div class="section-head"><span>05</span><h2>仓库来源</h2></div>
+    <div class="source-list"><a class="source-ref" href="../../capabilities/issue-fix/README.md"><span>capability README</span><code>docs/capabilities/issue-fix/README.md</code></a><a class="source-ref" href="../../capabilities/issue-fix/protocols/issue-fix-workflow-contract-v0.md"><span>workflow contract</span><code>docs/capabilities/issue-fix/protocols/issue-fix-workflow-contract-v0.md</code></a><a class="source-ref" href="../../capabilities/issue-fix/protocols/issue-fix-acceptance-loop-v0.md"><span>acceptance loop</span><code>docs/capabilities/issue-fix/protocols/issue-fix-acceptance-loop-v0.md</code></a><a class="source-ref" href="../../../examples/issue-fix-workflow-plan-smoke.py"><span>workflow smoke</span><code>examples/issue-fix-workflow-plan-smoke.py</code></a><a class="source-ref" href="../../../examples/issue-fix-acceptance-loop-smoke.py"><span>acceptance smoke</span><code>examples/issue-fix-acceptance-loop-smoke.py</code></a></div>
+    <div class="boundary-box"><p><strong>证据边界.</strong> Public-safe pattern case only; no private screenshots, raw gated issue bodies, internal review notes, local paths, raw logs, credentials, or unpublished repository artifacts.</p></div>
+    <div class="chips"><a class="case-link" href="0624-pr-issue-auto-fix.md">案例说明</a></div>
+
+    <footer>由 docs/showcases/showcase-catalog.json 生成。不包含私有链接、原始聊天、本地状态或内部媒体。</footer>
+  </article>
+</div>
+</body>
+</html>

--- a/docs/showcases/cases/0624-pr-issue-auto-fix.md
+++ b/docs/showcases/cases/0624-pr-issue-auto-fix.md
@@ -50,7 +50,7 @@ internal review notes, local paths, raw logs, credentials, and unpublished
 repository artifacts. Public evidence should be the sanitized workflow plan,
 focused smoke, branch diff, and public PR review outcome.
 
-## Website Story Beats
+## Public Evidence Sequence
 
 1. A PR issue or review comment appears.
 2. LoopX classifies the issue and creates ordered repair todos.

--- a/docs/showcases/cases/0627-overnight-pr-batch.en.html
+++ b/docs/showcases/cases/0627-overnight-pr-batch.en.html
@@ -1,0 +1,138 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>LoopX Showcase: Overnight PR batch with reviewable control</title>
+  <link rel="icon" href="data:,">
+  <style>
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  body{background:#0b0b0c;color:#f1f2f3;font-family:'Geist',system-ui,-apple-system,BlinkMacSystemFont,sans-serif;-webkit-font-smoothing:antialiased}
+  a{color:inherit}
+  ::selection{background:color-mix(in srgb,var(--accent,#6e79d6) 34%,transparent);color:#fff}
+  .gh{min-height:100vh;position:relative;overflow-x:hidden;--accent:#6e79d6}
+  .grain{position:fixed;inset:0;pointer-events:none;opacity:.025;mix-blend-mode:overlay;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E")}
+  article{position:relative;max-width:800px;margin:0 auto;padding:76px 28px 130px}
+  .mlab{font-family:'Geist Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11px;letter-spacing:.06em;color:#62666d;text-transform:uppercase}
+  h1{font-size:clamp(31px,4.6vw,46px);font-weight:600;line-height:1.12;letter-spacing:-.03em;margin:16px 0 14px;color:#fafafa;text-wrap:balance}
+  h2{font-size:22px;font-weight:600;letter-spacing:-.02em;color:#f1f2f3}
+  h3{font-size:21px;font-weight:600;letter-spacing:-.02em;color:#f1f2f3}
+  p{font-size:15.5px;line-height:1.75;color:#9ea3aa}
+  strong{color:#e9eaec;font-weight:600}
+  code{font-family:'Geist Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:12.5px;color:#c4c7cc}
+  .accent{font-size:clamp(17px,2.1vw,21px);font-weight:500;color:var(--accent);letter-spacing:-.01em;margin-bottom:22px}
+  .nav{display:flex;gap:10px;flex-wrap:wrap;margin:0 0 28px}
+  .nav a,.case-link{font-family:'Geist Mono',ui-monospace,monospace;font-size:11px;letter-spacing:.04em;text-decoration:none;color:#c4c7cc;border:1px solid rgba(255,255,255,.12);border-radius:6px;padding:7px 10px;background:rgba(255,255,255,.025)}
+  .nav a:hover,.case-link:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent);color:#f4f4f5}
+  .section-head{margin-top:74px;display:flex;align-items:baseline;gap:13px;margin-bottom:20px}
+  .section-head span{font-family:'Geist Mono',ui-monospace,monospace;font-size:13px;color:var(--accent)}
+  .panel{border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;overflow:hidden}
+  .panel-row{display:grid;grid-template-columns:150px 1fr;border-top:1px solid rgba(255,255,255,.07)}
+  .panel-row:first-child{border-top:0}
+  .panel-key{padding:18px 20px;border-right:1px solid rgba(255,255,255,.07);font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:var(--accent);background:color-mix(in srgb,var(--accent) 8%,transparent);letter-spacing:.04em}
+  .panel-val{padding:18px 20px;display:flex;align-items:center}
+  .panel-val p{font-size:14px;line-height:1.6;margin:0}
+  .diagram{border:1px solid rgba(255,255,255,.1);border-radius:12px;padding:30px 24px 22px;background:#0e0e10;margin:22px 0}
+  .diagram svg{display:block;width:100%;height:auto}
+  .chips{display:flex;gap:8px;flex-wrap:wrap;margin-top:22px}
+  .chips span{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#888d95;border:1px solid rgba(255,255,255,.12);padding:4px 8px;border-radius:5px}
+  .text-stack{display:flex;flex-direction:column;gap:16px}
+  .evidence-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px;margin:20px 0 6px}
+  .evidence-card{border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;padding:18px 18px 17px;min-height:128px}
+  .evidence-label{font-family:'Geist Mono',ui-monospace,monospace;font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:var(--accent);margin-bottom:10px}
+  .source-list{display:flex;flex-direction:column;gap:10px;margin-top:20px}
+  .source-ref{display:grid;grid-template-columns:150px 1fr;gap:14px;align-items:center;text-decoration:none;border:1px solid rgba(255,255,255,.1);border-radius:8px;background:#0e0e10;padding:12px 14px}
+  .source-ref:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent)}
+  .source-ref span{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:var(--accent);text-transform:uppercase;letter-spacing:.04em}
+  .source-ref code{color:#aeb3ba;word-break:break-word}
+  .boundary-box{border-left:2px solid var(--accent);background:#0e0e10;padding:18px 20px;margin-top:16px;border-radius:0 8px 8px 0}
+  .flow{display:flex;flex-direction:column}
+  .flow li{display:grid;grid-template-columns:28px 1fr;gap:14px;list-style:none}
+  .flow-num{width:24px;height:24px;border-radius:50%;border:1px solid color-mix(in srgb,var(--accent) 50%,transparent);display:flex;align-items:center;justify-content:center;font-family:'Geist Mono',ui-monospace,monospace;font-size:11.5px;color:var(--accent);background:#0b0b0c}
+  .flow-body{padding-bottom:18px;border-left:1px solid rgba(255,255,255,.12);padding-left:14px;margin-left:-27px}
+  .flow-title{font-size:14.5px;color:#eceef0;font-weight:500;margin-bottom:7px}
+  .metric-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px;margin-top:22px}
+  .metric{border:1px solid rgba(255,255,255,.1);border-radius:10px;padding:17px 19px;background:#0c0c0e}
+  .metric strong{display:block;font-size:24px;letter-spacing:-.02em;color:#fafafa}
+  .metric span{display:block;margin-top:5px;font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#62666d;text-transform:uppercase}
+  .search{width:100%;height:42px;margin:22px 0 16px;border:1px solid rgba(255,255,255,.12);border-radius:8px;background:#0e0e10;color:#f1f2f3;padding:0 12px;font:14px 'Geist',system-ui,sans-serif}
+  .cards{display:flex;flex-direction:column;gap:12px}
+  .card{display:block;text-decoration:none;border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;padding:18px 20px}
+  .card:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent)}
+  .card .meta{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#62666d;margin-bottom:8px}
+  .card p{font-size:14px;margin-top:9px}
+  .hide{display:none}
+  footer{margin-top:76px;color:#62666d;font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;line-height:1.7}
+  @media(max-width:720px){article{padding:52px 18px 90px}.panel-row{grid-template-columns:1fr}.panel-key{border-right:0;border-bottom:1px solid rgba(255,255,255,.07)}.metric-grid,.evidence-grid{grid-template-columns:1fr}.source-ref{grid-template-columns:1fr;gap:6px}}
+</style>
+</head>
+<body>
+<div class="gh">
+  <div class="grain"></div>
+  <article>
+
+    <nav class="nav" aria-label="Showcase navigation">
+      <a href="../index.en.html">Showcases</a>
+      <a href="../showcase-catalog.json">Catalog</a>
+      <a href="0627-overnight-pr-batch.html">中文</a>
+    </nav>
+
+    <div class="mlab">2026-06-27 · agent-platform-self-improvement</div>
+    <h1>Overnight PR batch with reviewable control</h1>
+    <div class="accent">An overnight LoopX run can produce many PR-sized slices while keeping review, validation, and public evidence boundaries visible.</div>
+    <p>The operator can wake up to a compact batch of merged public slices, see what changed, and still trust that gates, validation, and evidence boundaries were not bypassed.</p>
+    <div class="chips"><span>PR batch</span><span>review packet</span><span>public boundary</span></div>
+
+    <div class="diagram" aria-label="LoopX control-plane sketch">
+      <svg viewBox="0 0 760 320" role="img">
+        <rect width="760" height="320" fill="#0e0e10"></rect>
+        <rect x="285" y="34" width="190" height="58" rx="8" fill="none" stroke="#6e79d6" stroke-width="2"></rect>
+        <text x="380" y="68" text-anchor="middle" fill="#f1f2f3" font-size="15" font-weight="600">LoopX</text>
+        <line x1="380" y1="92" x2="380" y2="132" stroke="#3a3d42" stroke-width="2"></line>
+        <rect x="52" y="132" width="180" height="78" rx="8" fill="none" stroke="#6a6e76" stroke-width="2"></rect>
+        <rect x="290" y="124" width="180" height="94" rx="8" fill="#6e79d6" fill-opacity=".16" stroke="#6e79d6" stroke-width="2"></rect>
+        <rect x="528" y="132" width="180" height="78" rx="8" fill="none" stroke="#6a6e76" stroke-width="2"></rect>
+        <text x="142" y="166" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">Overnight PR batch wit</text>
+        <text x="380" y="163" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">todo claim</text>
+        <text x="618" y="166" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">public evidence case</text>
+        <text x="142" y="188" text-anchor="middle" fill="#62666d" font-size="11">goal / trigger</text>
+        <text x="380" y="185" text-anchor="middle" fill="#62666d" font-size="11">todo / gate / evidence</text>
+        <text x="618" y="188" text-anchor="middle" fill="#62666d" font-size="11">public outcome</text>
+        <line x1="232" y1="171" x2="282" y2="171" stroke="#6e79d6" stroke-width="2"></line>
+        <polygon points="290,171 280,165 280,177" fill="#6e79d6"></polygon>
+        <line x1="470" y1="171" x2="520" y2="171" stroke="#6e79d6" stroke-width="2"></line>
+        <polygon points="528,171 518,165 518,177" fill="#6e79d6"></polygon>
+        <path d="M618 210 L618 260 L142 260 L142 218" fill="none" stroke="#5a5e65" stroke-width="2"></path>
+        <polygon points="142,210 136,221 148,221" fill="#8a8088"></polygon>
+      </svg>
+    </div>
+
+
+    <div class="section-head"><span>01</span><h2>Case context</h2></div>
+    <div class="text-stack"><p>This case is not about an agent being busy. It is about keeping high-throughput autonomous work reviewable. The repository anchors the public evidence window to 2026-06-27 01:29 through 11:29 +08:00 instead of relying on private queues, screenshots, or operator notes.</p><p>Public Git history in that window shows 22 merged commits, 60 touched files, 6695 insertions, 223 deletions, and 10 commit messages with explicit PR numbers. The page only claims what those public facts support.</p></div>
+
+    <div class="section-head"><span>02</span><h2>Repository evidence</h2></div>
+    <div class="panel">
+      <div class="panel-row"><div class="panel-key">Proof</div><div class="panel-val"><p>High-throughput multi-lane work can remain PR-sized, reviewable, and merge-safe.</p></div></div>
+      <div class="panel-row"><div class="panel-key">LoopX intervention</div><div class="panel-val"><p>todo claim, review packet, self-merge boundary, focused smoke, public-boundary scan</p></div></div>
+    </div>
+    <div class="metric-grid"><div class="metric"><strong>22</strong><span>merged PR commits</span></div><div class="metric"><strong>10h</strong><span>public window</span></div></div>
+    <div class="evidence-grid"><div class="evidence-card"><div class="evidence-label">Public window</div><p>2026-06-27 01:29 to 11:29 +08:00, a 10-hour Git evidence window.</p></div><div class="evidence-card"><div class="evidence-label">Change shape</div><p>22 merged commits across docs, runtime, status/quota, benchmark contracts, smokes, and release/runtime guardrails.</p></div><div class="evidence-card"><div class="evidence-label">Review boundary</div><p>Work landed as PR-sized slices instead of one broad diff that maintainers would have to trust blindly.</p></div><div class="evidence-card"><div class="evidence-label">Reproduction</div><p>The case document gives `git log --since ... --until ...` and `git log --numstat` commands.</p></div></div>
+
+    <div class="section-head"><span>03</span><h2>LoopX behavior</h2></div>
+    <ul class="flow"><li><span class="flow-num">1</span><div class="flow-body"><div class="flow-title">LoopX ties each lane to todo ownership, validation, review policy, and public evidence.</div></div></li><li><span class="flow-num">2</span><div class="flow-body"><div class="flow-title">Runtime, docs, and focused smokes move together when a control-plane contract changes.</div></div></li><li><span class="flow-num">3</span><div class="flow-body"><div class="flow-title">Self-merge remains limited to narrow validated changes; larger or unclear work preserves review gates.</div></div></li><li><span class="flow-num">4</span><div class="flow-body"><div class="flow-title">Public-boundary scans keep internal screenshots, local state, raw logs, and private planning out of the showcase.</div></div></li></ul>
+
+    <div class="section-head"><span>04</span><h2>What the user sees</h2></div>
+    <div class="text-stack"><p>The user wakes up to reviewable, traceable, explainable public slices rather than raw agent output.</p><p>The operator can inspect validation and remaining gates for each slice without relying on chat memory.</p></div>
+
+    <div class="section-head"><span>05</span><h2>Repository sources</h2></div>
+    <div class="source-list"><a class="source-ref" href="0627-overnight-pr-batch.md"><span>case narrative</span><code>docs/showcases/cases/0627-overnight-pr-batch.md</code></a><a class="source-ref" href="../showcase-catalog.json"><span>catalog workload signal</span><code>docs/showcases/showcase-catalog.json</code></a></div>
+    <div class="boundary-box"><p><strong>Evidence boundary.</strong> Public Git evidence only; no private documents, internal screenshots, raw chats, local active-state bodies, raw logs, credentials, or machine-specific paths.</p></div>
+    <div class="chips"><a class="case-link" href="0627-overnight-pr-batch.md">Case note</a></div>
+
+    <footer>Generated from docs/showcases/showcase-catalog.json. Private links, raw chats, local state, and internal media are excluded.</footer>
+  </article>
+</div>
+</body>
+</html>

--- a/docs/showcases/cases/0627-overnight-pr-batch.html
+++ b/docs/showcases/cases/0627-overnight-pr-batch.html
@@ -1,0 +1,138 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>LoopX Showcase: 一晚 30 个高价值 PR</title>
+  <link rel="icon" href="data:,">
+  <style>
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  body{background:#0b0b0c;color:#f1f2f3;font-family:'Geist',system-ui,-apple-system,BlinkMacSystemFont,sans-serif;-webkit-font-smoothing:antialiased}
+  a{color:inherit}
+  ::selection{background:color-mix(in srgb,var(--accent,#6e79d6) 34%,transparent);color:#fff}
+  .gh{min-height:100vh;position:relative;overflow-x:hidden;--accent:#6e79d6}
+  .grain{position:fixed;inset:0;pointer-events:none;opacity:.025;mix-blend-mode:overlay;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E")}
+  article{position:relative;max-width:800px;margin:0 auto;padding:76px 28px 130px}
+  .mlab{font-family:'Geist Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11px;letter-spacing:.06em;color:#62666d;text-transform:uppercase}
+  h1{font-size:clamp(31px,4.6vw,46px);font-weight:600;line-height:1.12;letter-spacing:-.03em;margin:16px 0 14px;color:#fafafa;text-wrap:balance}
+  h2{font-size:22px;font-weight:600;letter-spacing:-.02em;color:#f1f2f3}
+  h3{font-size:21px;font-weight:600;letter-spacing:-.02em;color:#f1f2f3}
+  p{font-size:15.5px;line-height:1.75;color:#9ea3aa}
+  strong{color:#e9eaec;font-weight:600}
+  code{font-family:'Geist Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:12.5px;color:#c4c7cc}
+  .accent{font-size:clamp(17px,2.1vw,21px);font-weight:500;color:var(--accent);letter-spacing:-.01em;margin-bottom:22px}
+  .nav{display:flex;gap:10px;flex-wrap:wrap;margin:0 0 28px}
+  .nav a,.case-link{font-family:'Geist Mono',ui-monospace,monospace;font-size:11px;letter-spacing:.04em;text-decoration:none;color:#c4c7cc;border:1px solid rgba(255,255,255,.12);border-radius:6px;padding:7px 10px;background:rgba(255,255,255,.025)}
+  .nav a:hover,.case-link:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent);color:#f4f4f5}
+  .section-head{margin-top:74px;display:flex;align-items:baseline;gap:13px;margin-bottom:20px}
+  .section-head span{font-family:'Geist Mono',ui-monospace,monospace;font-size:13px;color:var(--accent)}
+  .panel{border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;overflow:hidden}
+  .panel-row{display:grid;grid-template-columns:150px 1fr;border-top:1px solid rgba(255,255,255,.07)}
+  .panel-row:first-child{border-top:0}
+  .panel-key{padding:18px 20px;border-right:1px solid rgba(255,255,255,.07);font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:var(--accent);background:color-mix(in srgb,var(--accent) 8%,transparent);letter-spacing:.04em}
+  .panel-val{padding:18px 20px;display:flex;align-items:center}
+  .panel-val p{font-size:14px;line-height:1.6;margin:0}
+  .diagram{border:1px solid rgba(255,255,255,.1);border-radius:12px;padding:30px 24px 22px;background:#0e0e10;margin:22px 0}
+  .diagram svg{display:block;width:100%;height:auto}
+  .chips{display:flex;gap:8px;flex-wrap:wrap;margin-top:22px}
+  .chips span{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#888d95;border:1px solid rgba(255,255,255,.12);padding:4px 8px;border-radius:5px}
+  .text-stack{display:flex;flex-direction:column;gap:16px}
+  .evidence-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px;margin:20px 0 6px}
+  .evidence-card{border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;padding:18px 18px 17px;min-height:128px}
+  .evidence-label{font-family:'Geist Mono',ui-monospace,monospace;font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:var(--accent);margin-bottom:10px}
+  .source-list{display:flex;flex-direction:column;gap:10px;margin-top:20px}
+  .source-ref{display:grid;grid-template-columns:150px 1fr;gap:14px;align-items:center;text-decoration:none;border:1px solid rgba(255,255,255,.1);border-radius:8px;background:#0e0e10;padding:12px 14px}
+  .source-ref:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent)}
+  .source-ref span{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:var(--accent);text-transform:uppercase;letter-spacing:.04em}
+  .source-ref code{color:#aeb3ba;word-break:break-word}
+  .boundary-box{border-left:2px solid var(--accent);background:#0e0e10;padding:18px 20px;margin-top:16px;border-radius:0 8px 8px 0}
+  .flow{display:flex;flex-direction:column}
+  .flow li{display:grid;grid-template-columns:28px 1fr;gap:14px;list-style:none}
+  .flow-num{width:24px;height:24px;border-radius:50%;border:1px solid color-mix(in srgb,var(--accent) 50%,transparent);display:flex;align-items:center;justify-content:center;font-family:'Geist Mono',ui-monospace,monospace;font-size:11.5px;color:var(--accent);background:#0b0b0c}
+  .flow-body{padding-bottom:18px;border-left:1px solid rgba(255,255,255,.12);padding-left:14px;margin-left:-27px}
+  .flow-title{font-size:14.5px;color:#eceef0;font-weight:500;margin-bottom:7px}
+  .metric-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px;margin-top:22px}
+  .metric{border:1px solid rgba(255,255,255,.1);border-radius:10px;padding:17px 19px;background:#0c0c0e}
+  .metric strong{display:block;font-size:24px;letter-spacing:-.02em;color:#fafafa}
+  .metric span{display:block;margin-top:5px;font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#62666d;text-transform:uppercase}
+  .search{width:100%;height:42px;margin:22px 0 16px;border:1px solid rgba(255,255,255,.12);border-radius:8px;background:#0e0e10;color:#f1f2f3;padding:0 12px;font:14px 'Geist',system-ui,sans-serif}
+  .cards{display:flex;flex-direction:column;gap:12px}
+  .card{display:block;text-decoration:none;border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;padding:18px 20px}
+  .card:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent)}
+  .card .meta{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#62666d;margin-bottom:8px}
+  .card p{font-size:14px;margin-top:9px}
+  .hide{display:none}
+  footer{margin-top:76px;color:#62666d;font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;line-height:1.7}
+  @media(max-width:720px){article{padding:52px 18px 90px}.panel-row{grid-template-columns:1fr}.panel-key{border-right:0;border-bottom:1px solid rgba(255,255,255,.07)}.metric-grid,.evidence-grid{grid-template-columns:1fr}.source-ref{grid-template-columns:1fr;gap:6px}}
+</style>
+</head>
+<body>
+<div class="gh">
+  <div class="grain"></div>
+  <article>
+
+    <nav class="nav" aria-label="Showcase navigation">
+      <a href="../index.html">Showcases</a>
+      <a href="../showcase-catalog.json">Catalog</a>
+      <a href="0627-overnight-pr-batch.en.html">English</a>
+    </nav>
+
+    <div class="mlab">2026-06-27 · agent-platform-self-improvement</div>
+    <h1>一晚 30 个高价值 PR</h1>
+    <div class="accent">高吞吐、多车道推进仍保持 PR 级可 review、可合并。</div>
+    <p>The operator can wake up to a compact batch of merged public slices, see what changed, and still trust that gates, validation, and evidence boundaries were not bypassed.</p>
+    <div class="chips"><span>PR batch</span><span>review packet</span><span>public boundary</span></div>
+
+    <div class="diagram" aria-label="LoopX control-plane sketch">
+      <svg viewBox="0 0 760 320" role="img">
+        <rect width="760" height="320" fill="#0e0e10"></rect>
+        <rect x="285" y="34" width="190" height="58" rx="8" fill="none" stroke="#6e79d6" stroke-width="2"></rect>
+        <text x="380" y="68" text-anchor="middle" fill="#f1f2f3" font-size="15" font-weight="600">LoopX</text>
+        <line x1="380" y1="92" x2="380" y2="132" stroke="#3a3d42" stroke-width="2"></line>
+        <rect x="52" y="132" width="180" height="78" rx="8" fill="none" stroke="#6a6e76" stroke-width="2"></rect>
+        <rect x="290" y="124" width="180" height="94" rx="8" fill="#6e79d6" fill-opacity=".16" stroke="#6e79d6" stroke-width="2"></rect>
+        <rect x="528" y="132" width="180" height="78" rx="8" fill="none" stroke="#6a6e76" stroke-width="2"></rect>
+        <text x="142" y="166" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">一晚 30 个高价值 PR</text>
+        <text x="380" y="163" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">todo claim</text>
+        <text x="618" y="166" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">public evidence case</text>
+        <text x="142" y="188" text-anchor="middle" fill="#62666d" font-size="11">goal / trigger</text>
+        <text x="380" y="185" text-anchor="middle" fill="#62666d" font-size="11">todo / gate / evidence</text>
+        <text x="618" y="188" text-anchor="middle" fill="#62666d" font-size="11">public outcome</text>
+        <line x1="232" y1="171" x2="282" y2="171" stroke="#6e79d6" stroke-width="2"></line>
+        <polygon points="290,171 280,165 280,177" fill="#6e79d6"></polygon>
+        <line x1="470" y1="171" x2="520" y2="171" stroke="#6e79d6" stroke-width="2"></line>
+        <polygon points="528,171 518,165 518,177" fill="#6e79d6"></polygon>
+        <path d="M618 210 L618 260 L142 260 L142 218" fill="none" stroke="#5a5e65" stroke-width="2"></path>
+        <polygon points="142,210 136,221 148,221" fill="#8a8088"></polygon>
+      </svg>
+    </div>
+
+
+    <div class="section-head"><span>01</span><h2>案例背景</h2></div>
+    <div class="text-stack"><p>这个案例不是在展示“agent 很忙”，而是在展示高吞吐自动化如何仍然保持可审阅。仓库把证据窗口固定在 2026-06-27 01:29 到 11:29 +08:00，避免把私有队列、聊天截图或操作员笔记当成公开证明。</p><p>窗口内公开 Git 历史显示 22 个 merged commits、60 个 touched files、6695 行新增和 223 行删除，其中 10 条 commit message 带 PR 编号。页面只声称这些公开 Git 能复现的事实。</p></div>
+
+    <div class="section-head"><span>02</span><h2>仓库证据</h2></div>
+    <div class="panel">
+      <div class="panel-row"><div class="panel-key">证明点</div><div class="panel-val"><p>高吞吐多 lane 工作也可以保持 PR 粒度、可审阅、可合并。</p></div></div>
+      <div class="panel-row"><div class="panel-key">LoopX 介入</div><div class="panel-val"><p>todo claim、review packet、自合并边界、focused smoke、public-boundary scan</p></div></div>
+    </div>
+    <div class="metric-grid"><div class="metric"><strong>22</strong><span>merged PR commits</span></div><div class="metric"><strong>10h</strong><span>public window</span></div></div>
+    <div class="evidence-grid"><div class="evidence-card"><div class="evidence-label">公开窗口</div><p>2026-06-27 01:29 到 11:29 +08:00，10 小时 Git 证据窗口。</p></div><div class="evidence-card"><div class="evidence-label">变更粒度</div><p>22 个 merged commits 覆盖 docs、runtime、status/quota、benchmark contracts、smokes 和 release/runtime guardrails。</p></div><div class="evidence-card"><div class="evidence-label">审阅边界</div><p>工作以 PR-sized slices 落地，而不是一个需要 maintainer 盲信的巨大 diff。</p></div><div class="evidence-card"><div class="evidence-label">复现方式</div><p>case 文档给出 `git log --since ... --until ...` 和 `git log --numstat` 命令。</p></div></div>
+
+    <div class="section-head"><span>03</span><h2>LoopX 行为</h2></div>
+    <ul class="flow"><li><span class="flow-num">1</span><div class="flow-body"><div class="flow-title">LoopX 把每条 lane 绑定到 todo ownership、validation、review policy 和 public evidence。</div></div></li><li><span class="flow-num">2</span><div class="flow-body"><div class="flow-title">当 control-plane contract 改变时，runtime、docs 和 focused smoke 一起移动。</div></div></li><li><span class="flow-num">3</span><div class="flow-body"><div class="flow-title">self-merge 只用于窄而验证过的变更；更大或不清楚的工作仍保留 review gate。</div></div></li><li><span class="flow-num">4</span><div class="flow-body"><div class="flow-title">公开边界扫描把内部截图、本地状态、原始日志和私有计划排除在 showcase 之外。</div></div></li></ul>
+
+    <div class="section-head"><span>04</span><h2>用户看到什么</h2></div>
+    <div class="text-stack"><p>用户醒来看到的是一组可 review、可追踪、可解释的 public slices，而不是一堆原始 agent 输出。</p><p>operator 可以继续追问每条 slice 的验证和剩余 gate；证据不依赖 chat memory。</p></div>
+
+    <div class="section-head"><span>05</span><h2>仓库来源</h2></div>
+    <div class="source-list"><a class="source-ref" href="0627-overnight-pr-batch.md"><span>case narrative</span><code>docs/showcases/cases/0627-overnight-pr-batch.md</code></a><a class="source-ref" href="../showcase-catalog.json"><span>catalog workload signal</span><code>docs/showcases/showcase-catalog.json</code></a></div>
+    <div class="boundary-box"><p><strong>证据边界.</strong> Public Git evidence only; no private documents, internal screenshots, raw chats, local active-state bodies, raw logs, credentials, or machine-specific paths.</p></div>
+    <div class="chips"><a class="case-link" href="0627-overnight-pr-batch.md">案例说明</a></div>
+
+    <footer>由 docs/showcases/showcase-catalog.json 生成。不包含私有链接、原始聊天、本地状态或内部媒体。</footer>
+  </article>
+</div>
+</body>
+</html>

--- a/docs/showcases/cases/0627-overnight-pr-batch.md
+++ b/docs/showcases/cases/0627-overnight-pr-batch.md
@@ -91,7 +91,7 @@ showcase of reviewable control-plane throughput in one public repository at one
 point in time. Future versions can strengthen the case by linking each public
 PR number to its validation evidence and review outcome.
 
-## Website Story Beats
+## Public Evidence Sequence
 
 1. A long-running LoopX project enters an overnight autonomous work window.
 2. Many small slices land across runtime, docs, benchmark contracts, smokes, and

--- a/docs/showcases/frontend-surface.md
+++ b/docs/showcases/frontend-surface.md
@@ -38,7 +38,7 @@ Use these catalog fields directly:
 | `frontend_card.visual_metaphor` | Suggested visual treatment. |
 | `frontend_card.primary_metric_hint` | Lightweight signal, not a hard claim. |
 | `frontend_card.badges` | Compact chips. |
-| `frontend_card.story_beats` | Case detail timeline. |
+| `frontend_card.story_beats` | Backward-compatible field for the case detail evidence sequence. New copy should render it as evidence, not as author notes. |
 | `workload_signal.efficiency_model` | Optional evidence panel for conservative baseline-vs-actual efficiency modeling. |
 
 ## First Screen
@@ -109,7 +109,7 @@ pattern, not a transcript.
 
 ## Detail Story Model
 
-A case detail view should be a short visual story:
+A case detail view should be a compact evidence sequence:
 
 1. **Trigger**: what made the long-running goal hard to manage.
 2. **Visible State**: which LoopX objects made the situation explicit.

--- a/docs/showcases/index.en.html
+++ b/docs/showcases/index.en.html
@@ -1,0 +1,201 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>LoopX Showcase &amp; Good Case</title>
+  <link rel="icon" href="data:,">
+  <style>
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  body{background:#0b0b0c;color:#f1f2f3;font-family:'Geist',system-ui,-apple-system,BlinkMacSystemFont,sans-serif;-webkit-font-smoothing:antialiased}
+  a{color:inherit}
+  ::selection{background:color-mix(in srgb,var(--accent,#6e79d6) 34%,transparent);color:#fff}
+  .gh{min-height:100vh;position:relative;overflow-x:hidden;--accent:#6e79d6}
+  .grain{position:fixed;inset:0;pointer-events:none;opacity:.025;mix-blend-mode:overlay;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E")}
+  article{position:relative;max-width:800px;margin:0 auto;padding:76px 28px 130px}
+  .mlab{font-family:'Geist Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11px;letter-spacing:.06em;color:#62666d;text-transform:uppercase}
+  h1{font-size:clamp(31px,4.6vw,46px);font-weight:600;line-height:1.12;letter-spacing:-.03em;margin:16px 0 14px;color:#fafafa;text-wrap:balance}
+  h2{font-size:22px;font-weight:600;letter-spacing:-.02em;color:#f1f2f3}
+  h3{font-size:21px;font-weight:600;letter-spacing:-.02em;color:#f1f2f3}
+  p{font-size:15.5px;line-height:1.75;color:#9ea3aa}
+  strong{color:#e9eaec;font-weight:600}
+  code{font-family:'Geist Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:12.5px;color:#c4c7cc}
+  .accent{font-size:clamp(17px,2.1vw,21px);font-weight:500;color:var(--accent);letter-spacing:-.01em;margin-bottom:22px}
+  .nav{display:flex;gap:10px;flex-wrap:wrap;margin:0 0 28px}
+  .nav a,.case-link{font-family:'Geist Mono',ui-monospace,monospace;font-size:11px;letter-spacing:.04em;text-decoration:none;color:#c4c7cc;border:1px solid rgba(255,255,255,.12);border-radius:6px;padding:7px 10px;background:rgba(255,255,255,.025)}
+  .nav a:hover,.case-link:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent);color:#f4f4f5}
+  .section-head{margin-top:74px;display:flex;align-items:baseline;gap:13px;margin-bottom:20px}
+  .section-head span{font-family:'Geist Mono',ui-monospace,monospace;font-size:13px;color:var(--accent)}
+  .panel{border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;overflow:hidden}
+  .panel-row{display:grid;grid-template-columns:150px 1fr;border-top:1px solid rgba(255,255,255,.07)}
+  .panel-row:first-child{border-top:0}
+  .panel-key{padding:18px 20px;border-right:1px solid rgba(255,255,255,.07);font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:var(--accent);background:color-mix(in srgb,var(--accent) 8%,transparent);letter-spacing:.04em}
+  .panel-val{padding:18px 20px;display:flex;align-items:center}
+  .panel-val p{font-size:14px;line-height:1.6;margin:0}
+  .diagram{border:1px solid rgba(255,255,255,.1);border-radius:12px;padding:30px 24px 22px;background:#0e0e10;margin:22px 0}
+  .diagram svg{display:block;width:100%;height:auto}
+  .chips{display:flex;gap:8px;flex-wrap:wrap;margin-top:22px}
+  .chips span{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#888d95;border:1px solid rgba(255,255,255,.12);padding:4px 8px;border-radius:5px}
+  .text-stack{display:flex;flex-direction:column;gap:16px}
+  .evidence-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px;margin:20px 0 6px}
+  .evidence-card{border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;padding:18px 18px 17px;min-height:128px}
+  .evidence-label{font-family:'Geist Mono',ui-monospace,monospace;font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:var(--accent);margin-bottom:10px}
+  .source-list{display:flex;flex-direction:column;gap:10px;margin-top:20px}
+  .source-ref{display:grid;grid-template-columns:150px 1fr;gap:14px;align-items:center;text-decoration:none;border:1px solid rgba(255,255,255,.1);border-radius:8px;background:#0e0e10;padding:12px 14px}
+  .source-ref:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent)}
+  .source-ref span{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:var(--accent);text-transform:uppercase;letter-spacing:.04em}
+  .source-ref code{color:#aeb3ba;word-break:break-word}
+  .boundary-box{border-left:2px solid var(--accent);background:#0e0e10;padding:18px 20px;margin-top:16px;border-radius:0 8px 8px 0}
+  .flow{display:flex;flex-direction:column}
+  .flow li{display:grid;grid-template-columns:28px 1fr;gap:14px;list-style:none}
+  .flow-num{width:24px;height:24px;border-radius:50%;border:1px solid color-mix(in srgb,var(--accent) 50%,transparent);display:flex;align-items:center;justify-content:center;font-family:'Geist Mono',ui-monospace,monospace;font-size:11.5px;color:var(--accent);background:#0b0b0c}
+  .flow-body{padding-bottom:18px;border-left:1px solid rgba(255,255,255,.12);padding-left:14px;margin-left:-27px}
+  .flow-title{font-size:14.5px;color:#eceef0;font-weight:500;margin-bottom:7px}
+  .metric-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px;margin-top:22px}
+  .metric{border:1px solid rgba(255,255,255,.1);border-radius:10px;padding:17px 19px;background:#0c0c0e}
+  .metric strong{display:block;font-size:24px;letter-spacing:-.02em;color:#fafafa}
+  .metric span{display:block;margin-top:5px;font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#62666d;text-transform:uppercase}
+  .search{width:100%;height:42px;margin:22px 0 16px;border:1px solid rgba(255,255,255,.12);border-radius:8px;background:#0e0e10;color:#f1f2f3;padding:0 12px;font:14px 'Geist',system-ui,sans-serif}
+  .cards{display:flex;flex-direction:column;gap:12px}
+  .card{display:block;text-decoration:none;border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;padding:18px 20px}
+  .card:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent)}
+  .card .meta{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#62666d;margin-bottom:8px}
+  .card p{font-size:14px;margin-top:9px}
+  .hide{display:none}
+  footer{margin-top:76px;color:#62666d;font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;line-height:1.7}
+  @media(max-width:720px){article{padding:52px 18px 90px}.panel-row{grid-template-columns:1fr}.panel-key{border-right:0;border-bottom:1px solid rgba(255,255,255,.07)}.metric-grid,.evidence-grid{grid-template-columns:1fr}.source-ref{grid-template-columns:1fr;gap:6px}}
+</style>
+</head>
+<body>
+<div class="gh">
+  <div class="grain"></div>
+  <article>
+
+    <nav class="nav" aria-label="Showcase navigation">
+      <a href="index.en.html">Showcases</a>
+      <a href="showcase-catalog.json">Catalog</a>
+      <a href="index.html">中文</a>
+    </nav>
+
+    <div class="mlab">LoopX · public-safe case surface</div>
+    <h1>Showcase &amp; Good Case</h1>
+    <div class="accent">Real LoopX cases showing how long-running agent work stays reviewable, verifiable, and safe to continue.</div>
+    <p>LoopX preserves goals, gates, todos, claims, quota, run history, and evidence outside any single agent session.</p>
+
+    <div class="diagram" aria-label="LoopX control-plane sketch">
+      <svg viewBox="0 0 760 320" role="img">
+        <rect width="760" height="320" fill="#0e0e10"></rect>
+        <rect x="285" y="34" width="190" height="58" rx="8" fill="none" stroke="#6e79d6" stroke-width="2"></rect>
+        <text x="380" y="68" text-anchor="middle" fill="#f1f2f3" font-size="15" font-weight="600">LoopX</text>
+        <line x1="380" y1="92" x2="380" y2="132" stroke="#3a3d42" stroke-width="2"></line>
+        <rect x="52" y="132" width="180" height="78" rx="8" fill="none" stroke="#6a6e76" stroke-width="2"></rect>
+        <rect x="290" y="124" width="180" height="94" rx="8" fill="#6e79d6" fill-opacity=".16" stroke="#6e79d6" stroke-width="2"></rect>
+        <rect x="528" y="132" width="180" height="78" rx="8" fill="none" stroke="#6a6e76" stroke-width="2"></rect>
+        <text x="142" y="166" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">Showcase &amp; Good Case</text>
+        <text x="380" y="163" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">catalog</text>
+        <text x="618" y="166" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">public surface</text>
+        <text x="142" y="188" text-anchor="middle" fill="#62666d" font-size="11">goal / trigger</text>
+        <text x="380" y="185" text-anchor="middle" fill="#62666d" font-size="11">todo / gate / evidence</text>
+        <text x="618" y="188" text-anchor="middle" fill="#62666d" font-size="11">public outcome</text>
+        <line x1="232" y1="171" x2="282" y2="171" stroke="#6e79d6" stroke-width="2"></line>
+        <polygon points="290,171 280,165 280,177" fill="#6e79d6"></polygon>
+        <line x1="470" y1="171" x2="520" y2="171" stroke="#6e79d6" stroke-width="2"></line>
+        <polygon points="528,171 518,165 518,177" fill="#6e79d6"></polygon>
+        <path d="M618 210 L618 260 L142 260 L142 218" fill="none" stroke="#5a5e65" stroke-width="2"></path>
+        <polygon points="142,210 136,221 148,221" fill="#8a8088"></polygon>
+      </svg>
+    </div>
+
+
+    <div class="section-head"><span>01</span><h2>Top showcase cases</h2></div>
+    <input class="search" id="case-search" type="search" placeholder="Search showcase cases" aria-label="Search showcase cases">
+    <div class="cards" data-cards>
+      <a class="card" href="cases/0627-overnight-pr-batch.en.html" data-search="overnight pr batch with reviewable control an overnight loopx run can produce many pr-sized slices while keeping review, validation, and public evidence boundaries visible. high-throughput multi-lane work can remain pr-sized, reviewable, and merge-safe. todo claim, review packet, self-merge boundary, focused smoke, public-boundary scan high_throughput_reviewable_work pr_sized_slices self_merge_policy validation_writeback">
+        <div class="meta">2026-06-27 · public_evidence_case</div>
+        <h3>Overnight PR batch with reviewable control</h3>
+        <p>An overnight LoopX run can produce many PR-sized slices while keeping review, validation, and public evidence boundaries visible.</p>
+        <p><strong>Proof:</strong> High-throughput multi-lane work can remain PR-sized, reviewable, and merge-safe.</p>
+        <div class="chips"><span>high_throughput_reviewable_work</span><span>pr_sized_slices</span><span>self_merge_policy</span><span>validation_writeback</span></div>
+      </a>
+
+
+      <a class="card" href="cases/0624-pr-issue-auto-fix.en.html" data-search="pr issue automatic fix loop review feedback should become an ordered repair workflow with repro, fix, validation, and reviewer handoff. issue and review feedback can enter an executable repair loop. issue-fix workflow, command pack, repro smoke, pr review feedback issue_fix_workflow review_feedback repro_smoke command_pack">
+        <div class="meta">2026-06-24 · public_safe_pattern_case</div>
+        <h3>PR issue automatic fix loop</h3>
+        <p>Review feedback should become an ordered repair workflow with repro, fix, validation, and reviewer handoff.</p>
+        <p><strong>Proof:</strong> Issue and review feedback can enter an executable repair loop.</p>
+        <div class="chips"><span>issue_fix_workflow</span><span>review_feedback</span><span>repro_smoke</span><span>command_pack</span></div>
+      </a>
+
+
+      <a class="card" href="cases/0623-agent-to-agent-pr-comments.en.html" data-search="agent-to-agent pr comment and fix loop pr review feedback can become an owned agent todo with fix evidence instead of a loose chat reminder. multiple agents can coordinate around pr review comments without losing owner review. claimed_by, handoff gate, review packet, comment/fix loop agent_to_agent_handoff pr_comment_loop review_packet claimed_todo">
+        <div class="meta">2026-06-23 · public_safe_pattern_case</div>
+        <h3>Agent-to-agent PR comment and fix loop</h3>
+        <p>PR review feedback can become an owned agent todo with fix evidence instead of a loose chat reminder.</p>
+        <p><strong>Proof:</strong> Multiple agents can coordinate around PR review comments without losing owner review.</p>
+        <div class="chips"><span>agent_to_agent_handoff</span><span>pr_comment_loop</span><span>review_packet</span><span>claimed_todo</span></div>
+      </a>
+
+
+      <a class="card" href="cases/0623-overnight-project-refactor.en.html" data-search="overnight project refactor as pr-sized slices a broad refactor can run overnight while staying split into human-sized review units. long unattended refactors can split into moderate pr slices instead of one unreviewable diff. loop, todo follow-up, supersede, pr-sized slices long_unattended_goal pr_sized_slices todo_follow_up supersede">
+        <div class="meta">2026-06-23 · public_safe_pattern_case</div>
+        <h3>Overnight project refactor as PR-sized slices</h3>
+        <p>A broad refactor can run overnight while staying split into human-sized review units.</p>
+        <p><strong>Proof:</strong> Long unattended refactors can split into moderate PR slices instead of one unreviewable diff.</p>
+        <div class="chips"><span>long_unattended_goal</span><span>pr_sized_slices</span><span>todo_follow_up</span><span>supersede</span></div>
+      </a>
+
+
+      <a class="card" href="cases/0619-dynamic-workflow-hardware-agent.en.html" data-search="dynamic workflow for hardware-agent development a fuzzy long-running engineering goal needs a shared control plane when multiple worker agents participate. fuzzy goals, multiple workers, and long unattended runs can still converge. goal state, worker handoff, dynamic workflow dynamic_workflow multi_agent_coordination shared_control_plane long_unattended_goal">
+        <div class="meta">2026-06-19 · public_safe_interactive_case</div>
+        <h3>Dynamic workflow for hardware-agent development</h3>
+        <p>A fuzzy long-running engineering goal needs a shared control plane when multiple worker agents participate.</p>
+        <p><strong>Proof:</strong> Fuzzy goals, multiple workers, and long unattended runs can still converge.</p>
+        <div class="chips"><span>dynamic_workflow</span><span>multi_agent_coordination</span><span>shared_control_plane</span><span>long_unattended_goal</span></div>
+      </a>
+
+
+      <a class="card" href="cases/0619-loopx-self-iteration.en.html" data-search="loopx self-iteration loop a high-churn loopx repo stayed legible while benchmark, product, docs, planning, and side-agent lanes moved in parallel. a high-churn multi-lane project can keep state, boundaries, and evidence coherent. todo, quota, gate, evidence, review packet, frontstage self_iteration side_agent_scope todo_claim_ownership identity_aware_prompt">
+        <div class="meta">2026-06-19 · public_evidence_case</div>
+        <h3>LoopX self-iteration loop</h3>
+        <p>A high-churn LoopX repo stayed legible while benchmark, product, docs, planning, and side-agent lanes moved in parallel.</p>
+        <p><strong>Proof:</strong> A high-churn multi-lane project can keep state, boundaries, and evidence coherent.</p>
+        <div class="chips"><span>self_iteration</span><span>side_agent_scope</span><span>todo_claim_ownership</span><span>identity_aware_prompt</span></div>
+      </a>
+
+
+      <a class="card" href="cases/0617-blocked-p0-safe-rotation.en.html" data-search="blocked p0 with safe p1/p2 rotation a gated p0 lane should not stall a whole long-running goal when safe fallback work exists. a user decision should not block all safe work. concrete user todo, safe fallback, quota control blocked_priority_fallback concrete_user_gate safe_fallback_work quota_discipline">
+        <div class="meta">2026-06-17 · reproducible_synthetic_demo</div>
+        <h3>Blocked P0 with safe P1/P2 rotation</h3>
+        <p>A gated P0 lane should not stall a whole long-running goal when safe fallback work exists.</p>
+        <p><strong>Proof:</strong> A user decision should not block all safe work.</p>
+        <div class="chips"><span>blocked_priority_fallback</span><span>concrete_user_gate</span><span>safe_fallback_work</span><span>quota_discipline</span></div>
+      </a>
+</div>
+
+    <div class="section-head"><span>02</span><h2>Appendix case</h2></div>
+    <div class="cards">
+      <a class="card" href="cases/0620-creator-operator-case-spec.en.html" data-search="creator-operator long-running agent case a creator-operator needs a long-running agent loop that keeps research moving while publishing decisions stay gated. a creator-operator needs a long-running agent loop that keeps research moving while publishing decisions stay gated. creator_operator_workflow, gate_aware_continuation, feedback_capture, safe_side_path creator_operator_workflow gate_aware_continuation feedback_capture safe_side_path">
+        <div class="meta">2026-06-20 · public_safe_case_spec</div>
+        <h3>Creator-operator long-running agent case</h3>
+        <p>A creator-operator needs a long-running agent loop that keeps research moving while publishing decisions stay gated.</p>
+        <p><strong>Proof:</strong> A creator-operator needs a long-running agent loop that keeps research moving while publishing decisions stay gated.</p>
+        <div class="chips"><span>creator_operator_workflow</span><span>gate_aware_continuation</span><span>feedback_capture</span><span>safe_side_path</span></div>
+      </a>
+</div>
+    <footer>Generated from docs/showcases/showcase-catalog.json. Private links, raw chats, local state, and internal media are excluded.</footer>
+  </article>
+</div>
+<script>
+const input = document.getElementById('case-search');
+const cards = Array.from(document.querySelectorAll('[data-search]'));
+input.addEventListener('input', () => {
+  const query = input.value.trim().toLowerCase();
+  for (const card of cards) {
+    card.classList.toggle('hide', query && !card.dataset.search.includes(query));
+  }
+});
+</script>
+</body>
+</html>

--- a/docs/showcases/index.html
+++ b/docs/showcases/index.html
@@ -1,0 +1,201 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>LoopX Showcase &amp; Good Case</title>
+  <link rel="icon" href="data:,">
+  <style>
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  body{background:#0b0b0c;color:#f1f2f3;font-family:'Geist',system-ui,-apple-system,BlinkMacSystemFont,sans-serif;-webkit-font-smoothing:antialiased}
+  a{color:inherit}
+  ::selection{background:color-mix(in srgb,var(--accent,#6e79d6) 34%,transparent);color:#fff}
+  .gh{min-height:100vh;position:relative;overflow-x:hidden;--accent:#6e79d6}
+  .grain{position:fixed;inset:0;pointer-events:none;opacity:.025;mix-blend-mode:overlay;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E")}
+  article{position:relative;max-width:800px;margin:0 auto;padding:76px 28px 130px}
+  .mlab{font-family:'Geist Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11px;letter-spacing:.06em;color:#62666d;text-transform:uppercase}
+  h1{font-size:clamp(31px,4.6vw,46px);font-weight:600;line-height:1.12;letter-spacing:-.03em;margin:16px 0 14px;color:#fafafa;text-wrap:balance}
+  h2{font-size:22px;font-weight:600;letter-spacing:-.02em;color:#f1f2f3}
+  h3{font-size:21px;font-weight:600;letter-spacing:-.02em;color:#f1f2f3}
+  p{font-size:15.5px;line-height:1.75;color:#9ea3aa}
+  strong{color:#e9eaec;font-weight:600}
+  code{font-family:'Geist Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:12.5px;color:#c4c7cc}
+  .accent{font-size:clamp(17px,2.1vw,21px);font-weight:500;color:var(--accent);letter-spacing:-.01em;margin-bottom:22px}
+  .nav{display:flex;gap:10px;flex-wrap:wrap;margin:0 0 28px}
+  .nav a,.case-link{font-family:'Geist Mono',ui-monospace,monospace;font-size:11px;letter-spacing:.04em;text-decoration:none;color:#c4c7cc;border:1px solid rgba(255,255,255,.12);border-radius:6px;padding:7px 10px;background:rgba(255,255,255,.025)}
+  .nav a:hover,.case-link:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent);color:#f4f4f5}
+  .section-head{margin-top:74px;display:flex;align-items:baseline;gap:13px;margin-bottom:20px}
+  .section-head span{font-family:'Geist Mono',ui-monospace,monospace;font-size:13px;color:var(--accent)}
+  .panel{border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;overflow:hidden}
+  .panel-row{display:grid;grid-template-columns:150px 1fr;border-top:1px solid rgba(255,255,255,.07)}
+  .panel-row:first-child{border-top:0}
+  .panel-key{padding:18px 20px;border-right:1px solid rgba(255,255,255,.07);font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:var(--accent);background:color-mix(in srgb,var(--accent) 8%,transparent);letter-spacing:.04em}
+  .panel-val{padding:18px 20px;display:flex;align-items:center}
+  .panel-val p{font-size:14px;line-height:1.6;margin:0}
+  .diagram{border:1px solid rgba(255,255,255,.1);border-radius:12px;padding:30px 24px 22px;background:#0e0e10;margin:22px 0}
+  .diagram svg{display:block;width:100%;height:auto}
+  .chips{display:flex;gap:8px;flex-wrap:wrap;margin-top:22px}
+  .chips span{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#888d95;border:1px solid rgba(255,255,255,.12);padding:4px 8px;border-radius:5px}
+  .text-stack{display:flex;flex-direction:column;gap:16px}
+  .evidence-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px;margin:20px 0 6px}
+  .evidence-card{border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;padding:18px 18px 17px;min-height:128px}
+  .evidence-label{font-family:'Geist Mono',ui-monospace,monospace;font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:var(--accent);margin-bottom:10px}
+  .source-list{display:flex;flex-direction:column;gap:10px;margin-top:20px}
+  .source-ref{display:grid;grid-template-columns:150px 1fr;gap:14px;align-items:center;text-decoration:none;border:1px solid rgba(255,255,255,.1);border-radius:8px;background:#0e0e10;padding:12px 14px}
+  .source-ref:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent)}
+  .source-ref span{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:var(--accent);text-transform:uppercase;letter-spacing:.04em}
+  .source-ref code{color:#aeb3ba;word-break:break-word}
+  .boundary-box{border-left:2px solid var(--accent);background:#0e0e10;padding:18px 20px;margin-top:16px;border-radius:0 8px 8px 0}
+  .flow{display:flex;flex-direction:column}
+  .flow li{display:grid;grid-template-columns:28px 1fr;gap:14px;list-style:none}
+  .flow-num{width:24px;height:24px;border-radius:50%;border:1px solid color-mix(in srgb,var(--accent) 50%,transparent);display:flex;align-items:center;justify-content:center;font-family:'Geist Mono',ui-monospace,monospace;font-size:11.5px;color:var(--accent);background:#0b0b0c}
+  .flow-body{padding-bottom:18px;border-left:1px solid rgba(255,255,255,.12);padding-left:14px;margin-left:-27px}
+  .flow-title{font-size:14.5px;color:#eceef0;font-weight:500;margin-bottom:7px}
+  .metric-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px;margin-top:22px}
+  .metric{border:1px solid rgba(255,255,255,.1);border-radius:10px;padding:17px 19px;background:#0c0c0e}
+  .metric strong{display:block;font-size:24px;letter-spacing:-.02em;color:#fafafa}
+  .metric span{display:block;margin-top:5px;font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#62666d;text-transform:uppercase}
+  .search{width:100%;height:42px;margin:22px 0 16px;border:1px solid rgba(255,255,255,.12);border-radius:8px;background:#0e0e10;color:#f1f2f3;padding:0 12px;font:14px 'Geist',system-ui,sans-serif}
+  .cards{display:flex;flex-direction:column;gap:12px}
+  .card{display:block;text-decoration:none;border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;padding:18px 20px}
+  .card:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent)}
+  .card .meta{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#62666d;margin-bottom:8px}
+  .card p{font-size:14px;margin-top:9px}
+  .hide{display:none}
+  footer{margin-top:76px;color:#62666d;font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;line-height:1.7}
+  @media(max-width:720px){article{padding:52px 18px 90px}.panel-row{grid-template-columns:1fr}.panel-key{border-right:0;border-bottom:1px solid rgba(255,255,255,.07)}.metric-grid,.evidence-grid{grid-template-columns:1fr}.source-ref{grid-template-columns:1fr;gap:6px}}
+</style>
+</head>
+<body>
+<div class="gh">
+  <div class="grain"></div>
+  <article>
+
+    <nav class="nav" aria-label="Showcase navigation">
+      <a href="index.html">Showcases</a>
+      <a href="showcase-catalog.json">Catalog</a>
+      <a href="index.en.html">English</a>
+    </nav>
+
+    <div class="mlab">LoopX · public-safe case surface</div>
+    <h1>Showcase &amp; Good Case</h1>
+    <div class="accent">真实 LoopX 案例：长程 agent 工作如何保持可审阅、可验证、可继续推进。</div>
+    <p>LoopX preserves goals, gates, todos, claims, quota, run history, and evidence outside any single agent session.</p>
+
+    <div class="diagram" aria-label="LoopX control-plane sketch">
+      <svg viewBox="0 0 760 320" role="img">
+        <rect width="760" height="320" fill="#0e0e10"></rect>
+        <rect x="285" y="34" width="190" height="58" rx="8" fill="none" stroke="#6e79d6" stroke-width="2"></rect>
+        <text x="380" y="68" text-anchor="middle" fill="#f1f2f3" font-size="15" font-weight="600">LoopX</text>
+        <line x1="380" y1="92" x2="380" y2="132" stroke="#3a3d42" stroke-width="2"></line>
+        <rect x="52" y="132" width="180" height="78" rx="8" fill="none" stroke="#6a6e76" stroke-width="2"></rect>
+        <rect x="290" y="124" width="180" height="94" rx="8" fill="#6e79d6" fill-opacity=".16" stroke="#6e79d6" stroke-width="2"></rect>
+        <rect x="528" y="132" width="180" height="78" rx="8" fill="none" stroke="#6a6e76" stroke-width="2"></rect>
+        <text x="142" y="166" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">Showcase &amp; Good Case</text>
+        <text x="380" y="163" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">catalog</text>
+        <text x="618" y="166" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">public surface</text>
+        <text x="142" y="188" text-anchor="middle" fill="#62666d" font-size="11">goal / trigger</text>
+        <text x="380" y="185" text-anchor="middle" fill="#62666d" font-size="11">todo / gate / evidence</text>
+        <text x="618" y="188" text-anchor="middle" fill="#62666d" font-size="11">public outcome</text>
+        <line x1="232" y1="171" x2="282" y2="171" stroke="#6e79d6" stroke-width="2"></line>
+        <polygon points="290,171 280,165 280,177" fill="#6e79d6"></polygon>
+        <line x1="470" y1="171" x2="520" y2="171" stroke="#6e79d6" stroke-width="2"></line>
+        <polygon points="528,171 518,165 518,177" fill="#6e79d6"></polygon>
+        <path d="M618 210 L618 260 L142 260 L142 218" fill="none" stroke="#5a5e65" stroke-width="2"></path>
+        <polygon points="142,210 136,221 148,221" fill="#8a8088"></polygon>
+      </svg>
+    </div>
+
+
+    <div class="section-head"><span>01</span><h2>顶部 Showcase 案例</h2></div>
+    <input class="search" id="case-search" type="search" placeholder="搜索 showcase 案例" aria-label="搜索 showcase 案例">
+    <div class="cards" data-cards>
+      <a class="card" href="cases/0627-overnight-pr-batch.html" data-search="一晚 30 个高价值 pr 高吞吐、多车道推进仍保持 pr 级可 review、可合并。 高吞吐多 lane 工作也可以保持 pr 粒度、可审阅、可合并。 todo claim、review packet、自合并边界、focused smoke、public-boundary scan high_throughput_reviewable_work pr_sized_slices self_merge_policy validation_writeback">
+        <div class="meta">2026-06-27 · public_evidence_case</div>
+        <h3>一晚 30 个高价值 PR</h3>
+        <p>高吞吐、多车道推进仍保持 PR 级可 review、可合并。</p>
+        <p><strong>证明点:</strong> 高吞吐多 lane 工作也可以保持 PR 粒度、可审阅、可合并。</p>
+        <div class="chips"><span>high_throughput_reviewable_work</span><span>pr_sized_slices</span><span>self_merge_policy</span><span>validation_writeback</span></div>
+      </a>
+
+
+      <a class="card" href="cases/0624-pr-issue-auto-fix.html" data-search="pr issue 自动 fix issue / review comment 可以进入可执行修复闭环。 issue 和 review 反馈可以变成受控、可执行的修复循环。 issue-fix workflow、command pack、repro smoke、pr review feedback issue_fix_workflow review_feedback repro_smoke command_pack">
+        <div class="meta">2026-06-24 · public_safe_pattern_case</div>
+        <h3>PR Issue 自动 Fix</h3>
+        <p>Issue / Review comment 可以进入可执行修复闭环。</p>
+        <p><strong>证明点:</strong> Issue 和 review 反馈可以变成受控、可执行的修复循环。</p>
+        <div class="chips"><span>issue_fix_workflow</span><span>review_feedback</span><span>repro_smoke</span><span>command_pack</span></div>
+      </a>
+
+
+      <a class="card" href="cases/0623-agent-to-agent-pr-comments.html" data-search="agent to agent 回复 pr comment 和 pr fix 多 agent 可围绕 pr review 协同发现、评论、修复。 多 agent lane 可以围绕 pr comment 协作，同时保留 owner review。 claimed_by、handoff gate、review packet、comment/fix loop agent_to_agent_handoff pr_comment_loop review_packet claimed_todo">
+        <div class="meta">2026-06-23 · public_safe_pattern_case</div>
+        <h3>Agent to agent 回复 PR comment 和 PR Fix</h3>
+        <p>多 agent 可围绕 PR review 协同发现、评论、修复。</p>
+        <p><strong>证明点:</strong> 多 agent lane 可以围绕 PR comment 协作，同时保留 owner review。</p>
+        <div class="chips"><span>agent_to_agent_handoff</span><span>pr_comment_loop</span><span>review_packet</span><span>claimed_todo</span></div>
+      </a>
+
+
+      <a class="card" href="cases/0623-overnight-project-refactor.html" data-search="一晚上自主重构项目 长时间无值守重构能拆成适中 pr，而不是一个不可 review 大改。 无人值守 refactor 可以拆成 pr-sized slice。 loop、todo follow-up、supersede、pr-sized slices long_unattended_goal pr_sized_slices todo_follow_up supersede">
+        <div class="meta">2026-06-23 · public_safe_pattern_case</div>
+        <h3>一晚上自主重构项目</h3>
+        <p>长时间无值守重构能拆成适中 PR，而不是一个不可 review 大改。</p>
+        <p><strong>证明点:</strong> 无人值守 refactor 可以拆成 PR-sized slice。</p>
+        <div class="chips"><span>long_unattended_goal</span><span>pr_sized_slices</span><span>todo_follow_up</span><span>supersede</span></div>
+      </a>
+
+
+      <a class="card" href="cases/0619-dynamic-workflow-hardware-agent.html" data-search="外部芯片 agent workflow 模糊目标、多 worker、长时间无值守下仍可收敛。 模糊目标、多 worker、长时间无值守下仍可收敛。 goal state、worker handoff、dynamic workflow dynamic_workflow multi_agent_coordination shared_control_plane long_unattended_goal">
+        <div class="meta">2026-06-19 · public_safe_interactive_case</div>
+        <h3>外部芯片 agent workflow</h3>
+        <p>模糊目标、多 worker、长时间无值守下仍可收敛。</p>
+        <p><strong>证明点:</strong> 模糊目标、多 worker、长时间无值守下仍可收敛。</p>
+        <div class="chips"><span>dynamic_workflow</span><span>multi_agent_coordination</span><span>shared_control_plane</span><span>long_unattended_goal</span><span>Canonical 原页面</span></div>
+      </a>
+
+
+      <a class="card" href="cases/0619-loopx-self-iteration.html" data-search="loopx meta agent 自迭代 高变更、多车道项目可保持状态、边界和证据。 高 churn 多 lane agent repo 可以保持状态、证据和边界一致。 todo、quota、gate、evidence、review packet、frontstage self_iteration side_agent_scope todo_claim_ownership identity_aware_prompt">
+        <div class="meta">2026-06-19 · public_evidence_case</div>
+        <h3>LoopX Meta Agent 自迭代</h3>
+        <p>高变更、多车道项目可保持状态、边界和证据。</p>
+        <p><strong>证明点:</strong> 高 churn 多 lane agent repo 可以保持状态、证据和边界一致。</p>
+        <div class="chips"><span>self_iteration</span><span>side_agent_scope</span><span>todo_claim_ownership</span><span>identity_aware_prompt</span></div>
+      </a>
+
+
+      <a class="card" href="cases/0617-blocked-p0-safe-rotation.html" data-search="p0 block 后推进 p1/p2 用户决策不应阻塞全部安全工作。 被阻塞的 p0 决策不应该阻止安全的 p1/p2 工作继续。 concrete user todo、safe fallback、quota control blocked_priority_fallback concrete_user_gate safe_fallback_work quota_discipline">
+        <div class="meta">2026-06-17 · reproducible_synthetic_demo</div>
+        <h3>P0 block 后推进 P1/P2</h3>
+        <p>用户决策不应阻塞全部安全工作。</p>
+        <p><strong>证明点:</strong> 被阻塞的 P0 决策不应该阻止安全的 P1/P2 工作继续。</p>
+        <div class="chips"><span>blocked_priority_fallback</span><span>concrete_user_gate</span><span>safe_fallback_work</span><span>quota_discipline</span></div>
+      </a>
+</div>
+
+    <div class="section-head"><span>02</span><h2>附录案例</h2></div>
+    <div class="cards">
+      <a class="card" href="cases/0620-creator-operator-case-spec.html" data-search="创作者-运营者长跑 agent 案例 研究可以继续，发布决策仍然 gated。 创作与运营工作可以共享一个 gate-aware 的长期 agent loop。 creator-operator workflow、user gate、feedback capture、material library creator_operator_workflow gate_aware_continuation feedback_capture safe_side_path">
+        <div class="meta">2026-06-20 · public_safe_case_spec</div>
+        <h3>创作者-运营者长跑 Agent 案例</h3>
+        <p>研究可以继续，发布决策仍然 gated。</p>
+        <p><strong>证明点:</strong> 创作与运营工作可以共享一个 gate-aware 的长期 agent loop。</p>
+        <div class="chips"><span>creator_operator_workflow</span><span>gate_aware_continuation</span><span>feedback_capture</span><span>safe_side_path</span></div>
+      </a>
+</div>
+    <footer>由 docs/showcases/showcase-catalog.json 生成。不包含私有链接、原始聊天、本地状态或内部媒体。</footer>
+  </article>
+</div>
+<script>
+const input = document.getElementById('case-search');
+const cards = Array.from(document.querySelectorAll('[data-search]'));
+input.addEventListener('input', () => {
+  const query = input.value.trim().toLowerCase();
+  for (const card of cards) {
+    card.classList.toggle('hide', query && !card.dataset.search.includes(query));
+  }
+});
+</script>
+</body>
+</html>

--- a/docs/showcases/showcase-animation-prototype.html
+++ b/docs/showcases/showcase-animation-prototype.html
@@ -247,54 +247,70 @@
       0% { width: 0%; }
       100% { width: 100%; }
     }
-    
+
     .scene--opening-control-plane { animation: scene-opening-control-plane 30s linear infinite; }
     @keyframes scene-opening-control-plane {
       0%, 0.0000% { opacity: 0; transform: translateY(18px) scale(0.985); pointer-events: none; }
       2.3333%, 11.0000% { opacity: 1; transform: translateY(0) scale(1); pointer-events: auto; }
       13.3333%, 100% { opacity: 0; transform: translateY(-14px) scale(0.99); pointer-events: none; }
     }
-            
 
-    .scene--gate-visible-safe-lane-moves { animation: scene-gate-visible-safe-lane-moves 30s linear infinite; }
-    @keyframes scene-gate-visible-safe-lane-moves {
+
+    .scene--high-throughput-reviewable-prs { animation: scene-high-throughput-reviewable-prs 30s linear infinite; }
+    @keyframes scene-high-throughput-reviewable-prs {
       0%, 13.3000% { opacity: 0; transform: translateY(18px) scale(0.985); pointer-events: none; }
-      15.6667%, 27.6667% { opacity: 1; transform: translateY(0) scale(1); pointer-events: auto; }
-      30.0000%, 100% { opacity: 0; transform: translateY(-14px) scale(0.99); pointer-events: none; }
+      15.6667%, 24.3333% { opacity: 1; transform: translateY(0) scale(1); pointer-events: auto; }
+      26.6667%, 100% { opacity: 0; transform: translateY(-14px) scale(0.99); pointer-events: none; }
     }
-            
+
+
+    .scene--issue-comment-repair-loop { animation: scene-issue-comment-repair-loop 30s linear infinite; }
+    @keyframes scene-issue-comment-repair-loop {
+      0%, 26.6333% { opacity: 0; transform: translateY(18px) scale(0.985); pointer-events: none; }
+      29.0000%, 37.6667% { opacity: 1; transform: translateY(0) scale(1); pointer-events: auto; }
+      40.0000%, 100% { opacity: 0; transform: translateY(-14px) scale(0.99); pointer-events: none; }
+    }
+
+
+    .scene--refactor-and-safe-fallback { animation: scene-refactor-and-safe-fallback 30s linear infinite; }
+    @keyframes scene-refactor-and-safe-fallback {
+      0%, 39.9667% { opacity: 0; transform: translateY(18px) scale(0.985); pointer-events: none; }
+      42.3333%, 51.0000% { opacity: 1; transform: translateY(0) scale(1); pointer-events: auto; }
+      53.3333%, 100% { opacity: 0; transform: translateY(-14px) scale(0.99); pointer-events: none; }
+    }
+
 
     .scene--multi-agent-shared-state { animation: scene-multi-agent-shared-state 30s linear infinite; }
     @keyframes scene-multi-agent-shared-state {
-      0%, 29.9667% { opacity: 0; transform: translateY(18px) scale(0.985); pointer-events: none; }
-      32.3333%, 44.3333% { opacity: 1; transform: translateY(0) scale(1); pointer-events: auto; }
-      46.6667%, 100% { opacity: 0; transform: translateY(-14px) scale(0.99); pointer-events: none; }
+      0%, 53.3000% { opacity: 0; transform: translateY(18px) scale(0.985); pointer-events: none; }
+      55.6667%, 67.6667% { opacity: 1; transform: translateY(0) scale(1); pointer-events: auto; }
+      70.0000%, 100% { opacity: 0; transform: translateY(-14px) scale(0.99); pointer-events: none; }
     }
-            
+
 
     .scene--self-iteration-efficiency-evidence { animation: scene-self-iteration-efficiency-evidence 30s linear infinite; }
     @keyframes scene-self-iteration-efficiency-evidence {
-      0%, 46.6333% { opacity: 0; transform: translateY(18px) scale(0.985); pointer-events: none; }
-      49.0000%, 67.6667% { opacity: 1; transform: translateY(0) scale(1); pointer-events: auto; }
-      70.0000%, 100% { opacity: 0; transform: translateY(-14px) scale(0.99); pointer-events: none; }
+      0%, 69.9667% { opacity: 0; transform: translateY(18px) scale(0.985); pointer-events: none; }
+      72.3333%, 84.3333% { opacity: 1; transform: translateY(0) scale(1); pointer-events: auto; }
+      86.6667%, 100% { opacity: 0; transform: translateY(-14px) scale(0.99); pointer-events: none; }
     }
-            
+
 
     .scene--creator-operator-safe-production-loop { animation: scene-creator-operator-safe-production-loop 30s linear infinite; }
     @keyframes scene-creator-operator-safe-production-loop {
-      0%, 69.9667% { opacity: 0; transform: translateY(18px) scale(0.985); pointer-events: none; }
-      72.3333%, 87.6667% { opacity: 1; transform: translateY(0) scale(1); pointer-events: auto; }
-      90.0000%, 100% { opacity: 0; transform: translateY(-14px) scale(0.99); pointer-events: none; }
+      0%, 86.6333% { opacity: 0; transform: translateY(18px) scale(0.985); pointer-events: none; }
+      89.0000%, 94.3333% { opacity: 1; transform: translateY(0) scale(1); pointer-events: auto; }
+      96.6667%, 100% { opacity: 0; transform: translateY(-14px) scale(0.99); pointer-events: none; }
     }
-            
+
 
     .scene--boundary-close { animation: scene-boundary-close 30s linear infinite; }
     @keyframes scene-boundary-close {
-      0%, 89.9667% { opacity: 0; transform: translateY(18px) scale(0.985); pointer-events: none; }
-      92.3333%, 97.6667% { opacity: 1; transform: translateY(0) scale(1); pointer-events: auto; }
+      0%, 96.6333% { opacity: 0; transform: translateY(18px) scale(0.985); pointer-events: none; }
+      99.0000%, 99.0000% { opacity: 1; transform: translateY(0) scale(1); pointer-events: auto; }
       100.0000%, 100% { opacity: 0; transform: translateY(-14px) scale(0.99); pointer-events: none; }
     }
-            
+
     @media (max-width: 900px) {
       main {
         grid-template-columns: 1fr;
@@ -344,39 +360,49 @@
         <strong>Public catalog demo. No live registry, local status export, transcript, or private active state.</strong>
       </div>
       <div class="timeline" aria-label="Scene timeline">
-        
+
           <span class="timeline__segment"
             data-scene-id="opening-control-plane"
             style="--start:0.0000%; --width:13.3333%;"></span>
-            
+
 
           <span class="timeline__segment"
-            data-scene-id="gate-visible-safe-lane-moves"
-            style="--start:13.3333%; --width:16.6667%;"></span>
-            
+            data-scene-id="high-throughput-reviewable-prs"
+            style="--start:13.3333%; --width:13.3333%;"></span>
+
+
+          <span class="timeline__segment"
+            data-scene-id="issue-comment-repair-loop"
+            style="--start:26.6667%; --width:13.3333%;"></span>
+
+
+          <span class="timeline__segment"
+            data-scene-id="refactor-and-safe-fallback"
+            style="--start:40.0000%; --width:13.3333%;"></span>
+
 
           <span class="timeline__segment"
             data-scene-id="multi-agent-shared-state"
-            style="--start:30.0000%; --width:16.6667%;"></span>
-            
+            style="--start:53.3333%; --width:16.6667%;"></span>
+
 
           <span class="timeline__segment"
             data-scene-id="self-iteration-efficiency-evidence"
-            style="--start:46.6667%; --width:23.3333%;"></span>
-            
+            style="--start:70.0000%; --width:16.6667%;"></span>
+
 
           <span class="timeline__segment"
             data-scene-id="creator-operator-safe-production-loop"
-            style="--start:70.0000%; --width:20.0000%;"></span>
-            
+            style="--start:86.6667%; --width:10.0000%;"></span>
+
 
           <span class="timeline__segment"
             data-scene-id="boundary-close"
-            style="--start:90.0000%; --width:10.0000%;"></span>
-            
+            style="--start:96.6667%; --width:3.3333%;"></span>
+
       </div>
       <div class="scene-stack">
-        
+
       <article class="scene scene--opening-control-plane"
         data-scene-id="opening-control-plane"
         data-start-seconds="0"
@@ -390,136 +416,198 @@
         <p class="visual">dark canvas with a single shared goal state node; agent lanes orbit into view</p>
         <p class="motion-note">fade in the goal node, then pulse two safe lanes without implying live ops data</p>
         <div class="case-strip">
-          
+
             <div class="case-card case-card--system" data-source-case-id="catalog-boundary">
               <strong>Catalog-backed control plane</strong>
               <span>The prototype reads the public storyboard and catalog only.</span>
               <small><span>public-boundary</span><span>no-live-status</span></small>
             </div>
-    
+
         </div>
       </article>
-    
 
-      <article class="scene scene--gate-visible-safe-lane-moves"
-        data-scene-id="gate-visible-safe-lane-moves"
+
+      <article class="scene scene--high-throughput-reviewable-prs"
+        data-scene-id="high-throughput-reviewable-prs"
         data-start-seconds="4"
-        data-end-seconds="9"
-        data-source-case-ids="2026-06-17-blocked-p0-safe-rotation">
+        data-end-seconds="8"
+        data-source-case-ids="2026-06-27-overnight-pr-batch">
         <div class="scene__meta">
-          <span>04-09s</span>
+          <span>04-08s</span>
           <span>Scene 2</span>
         </div>
-        <h2>A user gate stays visible. Safe side work still moves.</h2>
-        <p class="visual">a gated P0 lane pauses while a safe side lane advances with a validation marker</p>
-        <p class="motion-note">keep the blocked lane still; animate only the safe lane and evidence writeback</p>
+        <h2>High-throughput agent work can stay reviewable.</h2>
+        <p class="visual">many small PR-sized lanes converge into a compact review rail with validation markers</p>
+        <p class="motion-note">animate several small lanes into one review rail; avoid raw commit firehoses</p>
         <div class="case-strip">
-          
+
+            <div class="case-card" data-source-case-id="2026-06-27-overnight-pr-batch">
+              <strong>Overnight PR batch with reviewable control</strong>
+              <span>An overnight LoopX run can produce many PR-sized slices while keeping review, validation, and public evidence boundaries visible.</span>
+              <small><span>PR batch</span><span>review packet</span><span>public boundary</span></small>
+            </div>
+
+        </div>
+      </article>
+
+
+      <article class="scene scene--issue-comment-repair-loop"
+        data-scene-id="issue-comment-repair-loop"
+        data-start-seconds="8"
+        data-end-seconds="12"
+        data-source-case-ids="2026-06-24-pr-issue-auto-fix,2026-06-23-agent-to-agent-pr-comments">
+        <div class="scene__meta">
+          <span>08-12s</span>
+          <span>Scene 3</span>
+        </div>
+        <h2>Review feedback becomes owned repair work with evidence.</h2>
+        <p class="visual">a PR comment becomes a claimed todo, then a repro, fix, validation, and review packet</p>
+        <p class="motion-note">show claim, repro, fix, validation, and handoff as a short packet sequence</p>
+        <div class="case-strip">
+
+            <div class="case-card" data-source-case-id="2026-06-24-pr-issue-auto-fix">
+              <strong>PR issue automatic fix loop</strong>
+              <span>Review feedback should become an ordered repair workflow with repro, fix, validation, and reviewer handoff.</span>
+              <small><span>issue fix</span><span>repro smoke</span><span>PR review</span></small>
+            </div>
+
+
+            <div class="case-card" data-source-case-id="2026-06-23-agent-to-agent-pr-comments">
+              <strong>Agent-to-agent PR comment and fix loop</strong>
+              <span>PR review feedback can become an owned agent todo with fix evidence instead of a loose chat reminder.</span>
+              <small><span>handoff</span><span>PR comment</span><span>claimed_by</span></small>
+            </div>
+
+        </div>
+      </article>
+
+
+      <article class="scene scene--refactor-and-safe-fallback"
+        data-scene-id="refactor-and-safe-fallback"
+        data-start-seconds="12"
+        data-end-seconds="16"
+        data-source-case-ids="2026-06-23-overnight-project-refactor,2026-06-17-blocked-p0-safe-rotation">
+        <div class="scene__meta">
+          <span>12-16s</span>
+          <span>Scene 4</span>
+        </div>
+        <h2>Large work splits. Blocked routes do not freeze safe progress.</h2>
+        <p class="visual">a broad refactor splits into successor slices while a gated P0 lane pauses and a safe fallback advances</p>
+        <p class="motion-note">show supersede/follow-up chips beside a still-visible user gate</p>
+        <div class="case-strip">
+
+            <div class="case-card" data-source-case-id="2026-06-23-overnight-project-refactor">
+              <strong>Overnight project refactor as PR-sized slices</strong>
+              <span>A broad refactor can run overnight while staying split into human-sized review units.</span>
+              <small><span>refactor</span><span>PR slices</span><span>todo evidence</span></small>
+            </div>
+
+
             <div class="case-card" data-source-case-id="2026-06-17-blocked-p0-safe-rotation">
               <strong>Blocked P0 with safe P1/P2 rotation</strong>
               <span>A gated P0 lane should not stall a whole long-running goal when safe fallback work exists.</span>
               <small><span>reproducible</span><span>user-gate</span><span>fallback</span></small>
             </div>
-            
+
         </div>
       </article>
-    
+
 
       <article class="scene scene--multi-agent-shared-state"
         data-scene-id="multi-agent-shared-state"
-        data-start-seconds="9"
-        data-end-seconds="14"
+        data-start-seconds="16"
+        data-end-seconds="21"
         data-source-case-ids="2026-06-19-dynamic-workflow-hardware-agent">
         <div class="scene__meta">
-          <span>09-14s</span>
-          <span>Scene 3</span>
+          <span>16-21s</span>
+          <span>Scene 5</span>
         </div>
         <h2>Multiple agents can share one project memory without guessing each other&#x27;s state.</h2>
         <p class="visual">primary and side-agent lanes claim separate todos against one catalog-backed board</p>
         <p class="motion-note">show claims and handoff lines as lightweight beams into shared state</p>
         <div class="case-strip">
-          
+
             <div class="case-card" data-source-case-id="2026-06-19-dynamic-workflow-hardware-agent">
               <strong>Dynamic workflow for hardware-agent development</strong>
               <span>A fuzzy long-running engineering goal needs a shared control plane when multiple worker agents participate.</span>
               <small><span>interactive-html</span><span>multi-agent</span><span>hardware</span></small>
             </div>
-            
+
         </div>
       </article>
-    
+
 
       <article class="scene scene--self-iteration-efficiency-evidence"
         data-scene-id="self-iteration-efficiency-evidence"
-        data-start-seconds="14"
-        data-end-seconds="21"
+        data-start-seconds="21"
+        data-end-seconds="26"
         data-source-case-ids="2026-06-19-loopx-self-iteration">
         <div class="scene__meta">
-          <span>14-21s</span>
-          <span>Scene 4</span>
+          <span>21-26s</span>
+          <span>Scene 6</span>
         </div>
         <h2>Async side work turns repo history into recoverable product momentum.</h2>
         <p class="visual">repo-scale requirement clusters compress into validated commits, docs, smokes, and frontstage surfaces</p>
         <p class="motion-note">avoid raw commit firehoses; use compact clusters and conservative evidence labels</p>
         <div class="case-strip">
-          
+
             <div class="case-card" data-source-case-id="2026-06-19-loopx-self-iteration">
               <strong>LoopX self-iteration loop</strong>
               <span>A high-churn LoopX repo stayed legible while benchmark, product, docs, planning, and side-agent lanes moved in parallel.</span>
               <small><span>self-iteration</span><span>commit-backed</span><span>side-agent</span></small>
             </div>
-            
+
         </div>
       </article>
-    
+
 
       <article class="scene scene--creator-operator-safe-production-loop"
         data-scene-id="creator-operator-safe-production-loop"
-        data-start-seconds="21"
-        data-end-seconds="27"
+        data-start-seconds="26"
+        data-end-seconds="29"
         data-source-case-ids="2026-06-20-creator-operator-case-spec">
         <div class="scene__meta">
-          <span>21-27s</span>
-          <span>Scene 5</span>
+          <span>26-29s</span>
+          <span>Scene 7</span>
         </div>
         <h2>The agent can keep researching while human judgment guards what ships.</h2>
         <p class="visual">research, preference memory, and draft material move while publishing remains gated</p>
         <p class="motion-note">animate safe research cards; leave publish decision locked until the final frame</p>
         <div class="case-strip">
-          
+
             <div class="case-card" data-source-case-id="2026-06-20-creator-operator-case-spec">
               <strong>Creator-operator long-running agent case</strong>
               <span>A creator-operator needs a long-running agent loop that keeps research moving while publishing decisions stay gated.</span>
               <small></small>
             </div>
-            
+
         </div>
       </article>
-    
+
 
       <article class="scene scene--boundary-close"
         data-scene-id="boundary-close"
-        data-start-seconds="27"
+        data-start-seconds="29"
         data-end-seconds="30"
         data-source-case-ids="">
         <div class="scene__meta">
-          <span>27-30s</span>
-          <span>Scene 6</span>
+          <span>29-30s</span>
+          <span>Scene 8</span>
         </div>
         <h2>Public demos read the showcase catalog, not private control-plane state.</h2>
         <p class="visual">public showcase catalog badge replaces the live status feed</p>
         <p class="motion-note">close on the catalog badge and a clean public/private boundary line</p>
         <div class="case-strip">
-          
+
             <div class="case-card case-card--system" data-source-case-id="catalog-boundary">
               <strong>Catalog-backed control plane</strong>
               <span>The prototype reads the public storyboard and catalog only.</span>
               <small><span>public-boundary</span><span>no-live-status</span></small>
             </div>
-    
+
         </div>
       </article>
-    
+
       </div>
     </section>
   </main>

--- a/docs/showcases/showcase-animation-storyboard.json
+++ b/docs/showcases/showcase-animation-storyboard.json
@@ -37,16 +37,32 @@
       "motion_notes": "fade in the goal node, then pulse two safe lanes without implying live ops data"
     },
     {
-      "id": "gate-visible-safe-lane-moves",
-      "time_seconds": [4, 9],
-      "source_case_ids": ["2026-06-17-blocked-p0-safe-rotation"],
-      "visual": "a gated P0 lane pauses while a safe side lane advances with a validation marker",
-      "copy": "A user gate stays visible. Safe side work still moves.",
-      "motion_notes": "keep the blocked lane still; animate only the safe lane and evidence writeback"
+      "id": "high-throughput-reviewable-prs",
+      "time_seconds": [4, 8],
+      "source_case_ids": ["2026-06-27-overnight-pr-batch"],
+      "visual": "many small PR-sized lanes converge into a compact review rail with validation markers",
+      "copy": "High-throughput agent work can stay reviewable.",
+      "motion_notes": "animate several small lanes into one review rail; avoid raw commit firehoses"
+    },
+    {
+      "id": "issue-comment-repair-loop",
+      "time_seconds": [8, 12],
+      "source_case_ids": ["2026-06-24-pr-issue-auto-fix", "2026-06-23-agent-to-agent-pr-comments"],
+      "visual": "a PR comment becomes a claimed todo, then a repro, fix, validation, and review packet",
+      "copy": "Review feedback becomes owned repair work with evidence.",
+      "motion_notes": "show claim, repro, fix, validation, and handoff as a short packet sequence"
+    },
+    {
+      "id": "refactor-and-safe-fallback",
+      "time_seconds": [12, 16],
+      "source_case_ids": ["2026-06-23-overnight-project-refactor", "2026-06-17-blocked-p0-safe-rotation"],
+      "visual": "a broad refactor splits into successor slices while a gated P0 lane pauses and a safe fallback advances",
+      "copy": "Large work splits. Blocked routes do not freeze safe progress.",
+      "motion_notes": "show supersede/follow-up chips beside a still-visible user gate"
     },
     {
       "id": "multi-agent-shared-state",
-      "time_seconds": [9, 14],
+      "time_seconds": [16, 21],
       "source_case_ids": ["2026-06-19-dynamic-workflow-hardware-agent"],
       "visual": "primary and side-agent lanes claim separate todos against one catalog-backed board",
       "copy": "Multiple agents can share one project memory without guessing each other's state.",
@@ -54,7 +70,7 @@
     },
     {
       "id": "self-iteration-efficiency-evidence",
-      "time_seconds": [14, 21],
+      "time_seconds": [21, 26],
       "source_case_ids": ["2026-06-19-loopx-self-iteration"],
       "visual": "repo-scale requirement clusters compress into validated commits, docs, smokes, and frontstage surfaces",
       "copy": "Async side work turns repo history into recoverable product momentum.",
@@ -62,7 +78,7 @@
     },
     {
       "id": "creator-operator-safe-production-loop",
-      "time_seconds": [21, 27],
+      "time_seconds": [26, 29],
       "source_case_ids": ["2026-06-20-creator-operator-case-spec"],
       "visual": "research, preference memory, and draft material move while publishing remains gated",
       "copy": "The agent can keep researching while human judgment guards what ships.",
@@ -70,7 +86,7 @@
     },
     {
       "id": "boundary-close",
-      "time_seconds": [27, 30],
+      "time_seconds": [29, 30],
       "source_case_ids": [],
       "visual": "public showcase catalog badge replaces the live status feed",
       "copy": "Public demos read the showcase catalog, not private control-plane state.",

--- a/docs/showcases/showcase-catalog.json
+++ b/docs/showcases/showcase-catalog.json
@@ -21,49 +21,310 @@
   },
   "cases": [
     {
-      "id": "2026-06-17-blocked-p0-safe-rotation",
-      "date": "2026-06-17",
-      "title": "Blocked P0 with safe P1/P2 rotation",
-      "status": "reproducible_synthetic_demo",
-      "case_page": "docs/showcases/cases/0617-blocked-p0-safe-rotation.md",
-      "demo_command": "python3 examples/showcase-0617-blocked-p0-safe-rotation-smoke.py",
-      "domain": "benchmark-rotation",
+      "id": "2026-06-27-overnight-pr-batch",
+      "date": "2026-06-27",
+      "title": "Overnight PR batch with reviewable control",
+      "status": "public_evidence_case",
+      "case_page": "docs/showcases/cases/0627-overnight-pr-batch.md",
+      "demo_command": null,
+      "domain": "agent-platform-self-improvement",
       "audience": [
         "operator",
         "agent-platform-developer",
-        "benchmark-developer"
+        "technical-lead"
       ],
       "pattern_tags": [
-        "blocked_priority_fallback",
-        "concrete_user_gate",
-        "safe_fallback_work",
-        "quota_discipline",
-        "attention_reduction"
+        "high_throughput_reviewable_work",
+        "pr_sized_slices",
+        "self_merge_policy",
+        "validation_writeback",
+        "public_boundary"
       ],
-      "headline": "A gated P0 lane should not stall a whole long-running goal when safe fallback work exists.",
-      "problem": "A benchmark lane needed a large local dependency before it could continue, while other no-upload benchmark work remained safe.",
+      "headline": "An overnight LoopX run can produce many PR-sized slices while keeping review, validation, and public evidence boundaries visible.",
+      "problem": "High-throughput autonomous work is only useful if the resulting changes remain reviewable, validated, and safe to publish.",
       "loopx_behavior": [
-        "surface the P0 dependency as a concrete user gate",
-        "avoid spending on the gated lane",
-        "select a non-dependent fallback lane",
-        "record both the blocker and the fallback reason"
+        "keep work broken into PR-sized slices instead of a giant unreviewable diff",
+        "tie runtime, docs, and focused smoke updates together when a control-plane contract changes",
+        "limit self-merge to narrow validated changes while preserving broader review gates",
+        "record public evidence from Git history instead of raw agent logs or private screenshots",
+        "keep public/private boundary checks in the showcase path"
       ],
-      "user_value": "The operator sees exactly what decision is needed while the agent can keep making bounded progress elsewhere.",
-      "evidence_boundary": "Synthetic public fixture only; no private screenshots, raw tasks, internal links, local image names, or raw run logs.",
+      "user_value": "The operator can wake up to a compact batch of merged public slices, see what changed, and still trust that gates, validation, and evidence boundaries were not bypassed.",
+      "workload_signal": {
+        "scope": "public_repository_window",
+        "window": {
+          "from": "2026-06-27T01:29:00+08:00",
+          "to": "2026-06-27T11:29:00+08:00",
+          "hours": 10
+        },
+        "public_git": {
+          "merged_commits": 22,
+          "files_touched": 60,
+          "insertions": 6695,
+          "deletions": 223,
+          "commit_messages_with_pr_numbers": 10
+        },
+        "claim_boundary": "public Git history only; contemporaneous private queue notes are not used as public evidence"
+      },
+      "evidence_boundary": "Public Git evidence only; no private documents, internal screenshots, raw chats, local active-state bodies, raw logs, credentials, or machine-specific paths.",
+      "interactive_page": "docs/showcases/cases/0627-overnight-pr-batch.html",
+      "interactive_page_zh": "docs/showcases/cases/0627-overnight-pr-batch.html",
+      "interactive_page_en": "docs/showcases/cases/0627-overnight-pr-batch.en.html",
+      "localized_pages": {
+        "zh": "docs/showcases/cases/0627-overnight-pr-batch.html",
+        "en": "docs/showcases/cases/0627-overnight-pr-batch.en.html"
+      },
+      "showcase_rank": 1,
+      "showcase_table": {
+        "proof_point": "High-throughput multi-lane work can remain PR-sized, reviewable, and merge-safe.",
+        "loopx_intervention": "todo claim, review packet, self-merge boundary, focused smoke, public-boundary scan"
+      },
       "frontend_card": {
-        "visual_metaphor": "priority lanes with one gated lane and one active fallback lane",
-        "primary_metric_hint": "attention reduction: user sees one concrete decision instead of reading the whole run log",
+        "visual_metaphor": "parallel PR lanes converge into a reviewable merge rail",
+        "primary_metric_hint": "High-throughput multi-lane work can remain PR-sized, reviewable, and merge-safe.",
         "badges": [
-          "reproducible",
-          "user-gate",
-          "fallback"
+          "PR batch",
+          "review packet",
+          "public boundary"
         ],
         "story_beats": [
-          "P0 lane is blocked by a user decision",
-          "LoopX projects the decision as a user todo",
-          "agent continues safe fallback work",
-          "state records blocker, fallback, validation, and spend policy"
+          "keep work broken into PR-sized slices instead of a giant unreviewable diff",
+          "tie runtime, docs, and focused smoke updates together when a control-plane contract changes",
+          "limit self-merge to narrow validated changes while preserving broader review gates",
+          "record public evidence from Git history instead of raw agent logs or private screenshots"
         ]
+      }
+    },
+    {
+      "id": "2026-06-24-pr-issue-auto-fix",
+      "date": "2026-06-24",
+      "title": "PR issue automatic fix loop",
+      "status": "public_safe_pattern_case",
+      "case_page": "docs/showcases/cases/0624-pr-issue-auto-fix.md",
+      "demo_command": null,
+      "domain": "issue-fix-workflow",
+      "audience": [
+        "operator",
+        "agent-platform-developer",
+        "open-source-maintainer"
+      ],
+      "pattern_tags": [
+        "issue_fix_workflow",
+        "review_feedback",
+        "repro_smoke",
+        "command_pack",
+        "successor_todo"
+      ],
+      "headline": "Review feedback should become an ordered repair workflow with repro, fix, validation, and reviewer handoff.",
+      "problem": "PR comments and issues are often concrete enough to fix, but unsafe to feed into an agent as unstructured prompt text without routing, repro, and validation.",
+      "loopx_behavior": [
+        "classify the issue or review feedback",
+        "create ordered repair todos",
+        "keep gated source reads explicit",
+        "separate repro, implementation, validation, and reviewer handoff"
+      ],
+      "user_value": "The operator can turn a PR issue into a controlled fix loop without manually rewriting the review comment as an agent plan.",
+      "evidence_boundary": "Public-safe pattern case only; no private screenshots, raw gated issue bodies, internal review notes, local paths, raw logs, credentials, or unpublished repository artifacts.",
+      "interactive_page": "docs/showcases/cases/0624-pr-issue-auto-fix.html",
+      "interactive_page_zh": "docs/showcases/cases/0624-pr-issue-auto-fix.html",
+      "interactive_page_en": "docs/showcases/cases/0624-pr-issue-auto-fix.en.html",
+      "localized_pages": {
+        "zh": "docs/showcases/cases/0624-pr-issue-auto-fix.html",
+        "en": "docs/showcases/cases/0624-pr-issue-auto-fix.en.html"
+      },
+      "showcase_rank": 2,
+      "showcase_table": {
+        "proof_point": "Issue and review feedback can enter an executable repair loop.",
+        "loopx_intervention": "issue-fix workflow, command pack, repro smoke, PR review feedback"
+      },
+      "frontend_card": {
+        "visual_metaphor": "issue feedback closes through repro, fix, validation, and review handoff",
+        "primary_metric_hint": "Issue and review feedback can enter an executable repair loop.",
+        "badges": [
+          "issue fix",
+          "repro smoke",
+          "PR review"
+        ],
+        "story_beats": [
+          "classify the issue or review feedback",
+          "create ordered repair todos",
+          "keep gated source reads explicit",
+          "separate repro, implementation, validation, and reviewer handoff"
+        ]
+      }
+    },
+    {
+      "id": "2026-06-23-agent-to-agent-pr-comments",
+      "date": "2026-06-23",
+      "title": "Agent-to-agent PR comment and fix loop",
+      "status": "public_safe_pattern_case",
+      "case_page": "docs/showcases/cases/0623-agent-to-agent-pr-comments.md",
+      "demo_command": null,
+      "domain": "pull-request-review",
+      "audience": [
+        "operator",
+        "agent-platform-developer",
+        "open-source-maintainer"
+      ],
+      "pattern_tags": [
+        "agent_to_agent_handoff",
+        "pr_comment_loop",
+        "review_packet",
+        "claimed_todo",
+        "successor_todo"
+      ],
+      "headline": "PR review feedback can become an owned agent todo with fix evidence instead of a loose chat reminder.",
+      "problem": "Multiple agent lanes can see or act on the same PR feedback, but without ownership and handoff state the comment-to-fix loop becomes hard to audit.",
+      "loopx_behavior": [
+        "turn review feedback into a claimed todo",
+        "route implementation through the owning agent lane",
+        "record fix and validation evidence in the review packet",
+        "keep successor work explicit after the comment is handled"
+      ],
+      "user_value": "The operator can let agents coordinate around PR comments without losing final review visibility or fix evidence.",
+      "evidence_boundary": "Public-safe pattern case only; no private screenshots, raw chats, internal review notes, local state, credentials, or unpublished artifacts.",
+      "interactive_page": "docs/showcases/cases/0623-agent-to-agent-pr-comments.html",
+      "interactive_page_zh": "docs/showcases/cases/0623-agent-to-agent-pr-comments.html",
+      "interactive_page_en": "docs/showcases/cases/0623-agent-to-agent-pr-comments.en.html",
+      "localized_pages": {
+        "zh": "docs/showcases/cases/0623-agent-to-agent-pr-comments.html",
+        "en": "docs/showcases/cases/0623-agent-to-agent-pr-comments.en.html"
+      },
+      "showcase_rank": 3,
+      "showcase_table": {
+        "proof_point": "Multiple agents can coordinate around PR review comments without losing owner review.",
+        "loopx_intervention": "claimed_by, handoff gate, review packet, comment/fix loop"
+      },
+      "frontend_card": {
+        "visual_metaphor": "agent comments pass through explicit ownership instead of loose threads",
+        "primary_metric_hint": "Multiple agents can coordinate around PR review comments without losing owner review.",
+        "badges": [
+          "handoff",
+          "PR comment",
+          "claimed_by"
+        ],
+        "story_beats": [
+          "turn review feedback into a claimed todo",
+          "route implementation through the owning agent lane",
+          "record fix and validation evidence in the review packet",
+          "keep successor work explicit after the comment is handled"
+        ]
+      }
+    },
+    {
+      "id": "2026-06-23-overnight-project-refactor",
+      "date": "2026-06-23",
+      "title": "Overnight project refactor as PR-sized slices",
+      "status": "public_safe_pattern_case",
+      "case_page": "docs/showcases/cases/0623-overnight-project-refactor.md",
+      "demo_command": null,
+      "domain": "repository-refactor",
+      "audience": [
+        "operator",
+        "agent-platform-developer",
+        "technical-lead"
+      ],
+      "pattern_tags": [
+        "long_unattended_goal",
+        "pr_sized_slices",
+        "todo_follow_up",
+        "supersede",
+        "validation_writeback"
+      ],
+      "headline": "A broad refactor can run overnight while staying split into human-sized review units.",
+      "problem": "Autonomous refactors become risky when discoveries, stale tasks, cleanup, and behavior changes collapse into one broad diff.",
+      "loopx_behavior": [
+        "keep the current refactor slice explicit",
+        "convert discoveries into follow-up todos",
+        "supersede stale tasks when the route changes",
+        "validate each slice before merge or handoff"
+      ],
+      "user_value": "The operator can wake up to reviewable PR-sized refactor slices instead of a single giant autonomous diff.",
+      "evidence_boundary": "Public-safe pattern case only; no private screenshots, raw chats, internal planning notes, local paths, credentials, raw logs, or unpublished project artifacts.",
+      "interactive_page": "docs/showcases/cases/0623-overnight-project-refactor.html",
+      "interactive_page_zh": "docs/showcases/cases/0623-overnight-project-refactor.html",
+      "interactive_page_en": "docs/showcases/cases/0623-overnight-project-refactor.en.html",
+      "localized_pages": {
+        "zh": "docs/showcases/cases/0623-overnight-project-refactor.html",
+        "en": "docs/showcases/cases/0623-overnight-project-refactor.en.html"
+      },
+      "showcase_rank": 4,
+      "showcase_table": {
+        "proof_point": "Long unattended refactors can split into moderate PR slices instead of one unreviewable diff.",
+        "loopx_intervention": "loop, todo follow-up, supersede, PR-sized slices"
+      },
+      "frontend_card": {
+        "visual_metaphor": "a large refactor moves as small reviewable packets",
+        "primary_metric_hint": "Long unattended refactors can split into moderate PR slices instead of one unreviewable diff.",
+        "badges": [
+          "refactor",
+          "PR slices",
+          "todo evidence"
+        ],
+        "story_beats": [
+          "keep the current refactor slice explicit",
+          "convert discoveries into follow-up todos",
+          "supersede stale tasks when the route changes",
+          "validate each slice before merge or handoff"
+        ]
+      }
+    },
+    {
+      "id": "2026-06-19-dynamic-workflow-hardware-agent",
+      "date": "2026-06-19",
+      "title": "Dynamic workflow for hardware-agent development",
+      "status": "public_safe_interactive_case",
+      "case_page": "docs/showcases/cases/0619-dynamic-workflow-hardware-agent.md",
+      "interactive_page": "docs/showcases/cases/0619-dynamic-workflow-hardware-agent.html",
+      "demo_command": null,
+      "domain": "hardware-agent-development",
+      "audience": [
+        "agent-platform-developer",
+        "technical-lead",
+        "open-source-user"
+      ],
+      "pattern_tags": [
+        "dynamic_workflow",
+        "multi_agent_coordination",
+        "shared_control_plane",
+        "long_unattended_goal",
+        "convergence"
+      ],
+      "headline": "A fuzzy long-running engineering goal needs a shared control plane when multiple worker agents participate.",
+      "problem": "Specialized engineering work can require multiple agents to split work and converge without losing ownership or state.",
+      "loopx_behavior": [
+        "keep durable goal state outside any one chat thread",
+        "make ownership, quota, and evidence writeback explicit",
+        "let script-generated worker loops continue only after bounded validation",
+        "project convergence state and human gates for the operator"
+      ],
+      "user_value": "A contributor-approved public artifact shows how one control plane can coordinate Claude Code, generated scripts, and hardware-agent workers across five long-running engineering cases.",
+      "evidence_boundary": "Public-safe interactive artifact; no raw chats, screenshots, proprietary design details, private repositories, local paths, task ids, credentials, or unpublished hardware artifacts.",
+      "frontend_card": {
+        "visual_metaphor": "multiple worker lanes converging through one shared control plane",
+        "primary_metric_hint": "five public hardware-agent cases under one control plane",
+        "badges": [
+          "interactive-html",
+          "multi-agent",
+          "hardware"
+        ],
+        "story_beats": [
+          "LoopX owns goal state, quota, todos, claims, evidence, and history",
+          "Claude Code writes task-specific orchestration scripts under that contract",
+          "hardware-agent workers perform bounded RTL, simulation, and validation work",
+          "five public cases show closed tasks, DSE, flagship Fmax optimization, and convergence floors"
+        ]
+      },
+      "interactive_page_zh": "docs/showcases/cases/0619-dynamic-workflow-hardware-agent.html",
+      "interactive_page_en": "docs/showcases/cases/0619-dynamic-workflow-hardware-agent.en.html",
+      "localized_pages": {
+        "zh": "docs/showcases/cases/0619-dynamic-workflow-hardware-agent.html",
+        "en": "docs/showcases/cases/0619-dynamic-workflow-hardware-agent.en.html"
+      },
+      "showcase_rank": 5,
+      "showcase_table": {
+        "proof_point": "Fuzzy goals, multiple workers, and long unattended runs can still converge.",
+        "loopx_intervention": "goal state, worker handoff, dynamic workflow"
       }
     },
     {
@@ -179,222 +440,76 @@
           "public Git history is converted into conservative product requirement clusters",
           "public docs and smokes turn the experience into a reusable case"
         ]
+      },
+      "interactive_page": "docs/showcases/cases/0619-loopx-self-iteration.html",
+      "interactive_page_zh": "docs/showcases/cases/0619-loopx-self-iteration.html",
+      "interactive_page_en": "docs/showcases/cases/0619-loopx-self-iteration.en.html",
+      "localized_pages": {
+        "zh": "docs/showcases/cases/0619-loopx-self-iteration.html",
+        "en": "docs/showcases/cases/0619-loopx-self-iteration.en.html"
+      },
+      "showcase_rank": 6,
+      "showcase_table": {
+        "proof_point": "A high-churn multi-lane project can keep state, boundaries, and evidence coherent.",
+        "loopx_intervention": "todo, quota, gate, evidence, review packet, frontstage"
       }
     },
     {
-      "id": "2026-06-19-dynamic-workflow-hardware-agent",
-      "date": "2026-06-19",
-      "title": "Dynamic workflow for hardware-agent development",
-      "status": "public_safe_interactive_case",
-      "case_page": "docs/showcases/cases/0619-dynamic-workflow-hardware-agent.md",
-      "interactive_page": "docs/showcases/cases/0619-dynamic-workflow-hardware-agent.html",
-      "demo_command": null,
-      "domain": "hardware-agent-development",
+      "id": "2026-06-17-blocked-p0-safe-rotation",
+      "date": "2026-06-17",
+      "title": "Blocked P0 with safe P1/P2 rotation",
+      "status": "reproducible_synthetic_demo",
+      "case_page": "docs/showcases/cases/0617-blocked-p0-safe-rotation.md",
+      "demo_command": "python3 examples/showcase-0617-blocked-p0-safe-rotation-smoke.py",
+      "domain": "benchmark-rotation",
       "audience": [
+        "operator",
         "agent-platform-developer",
-        "technical-lead",
-        "open-source-user"
+        "benchmark-developer"
       ],
       "pattern_tags": [
-        "dynamic_workflow",
-        "multi_agent_coordination",
-        "shared_control_plane",
-        "long_unattended_goal",
-        "convergence"
+        "blocked_priority_fallback",
+        "concrete_user_gate",
+        "safe_fallback_work",
+        "quota_discipline",
+        "attention_reduction"
       ],
-      "headline": "A fuzzy long-running engineering goal needs a shared control plane when multiple worker agents participate.",
-      "problem": "Specialized engineering work can require multiple agents to split work and converge without losing ownership or state.",
+      "headline": "A gated P0 lane should not stall a whole long-running goal when safe fallback work exists.",
+      "problem": "A benchmark lane needed a large local dependency before it could continue, while other no-upload benchmark work remained safe.",
       "loopx_behavior": [
-        "keep durable goal state outside any one chat thread",
-        "make ownership, quota, and evidence writeback explicit",
-        "let script-generated worker loops continue only after bounded validation",
-        "project convergence state and human gates for the operator"
+        "surface the P0 dependency as a concrete user gate",
+        "avoid spending on the gated lane",
+        "select a non-dependent fallback lane",
+        "record both the blocker and the fallback reason"
       ],
-      "user_value": "A contributor-approved public artifact shows how one control plane can coordinate Claude Code, generated scripts, and hardware-agent workers across five long-running engineering cases.",
-      "evidence_boundary": "Public-safe interactive artifact; no raw chats, screenshots, proprietary design details, private repositories, local paths, task ids, credentials, or unpublished hardware artifacts.",
+      "user_value": "The operator sees exactly what decision is needed while the agent can keep making bounded progress elsewhere.",
+      "evidence_boundary": "Synthetic public fixture only; no private screenshots, raw tasks, internal links, local image names, or raw run logs.",
       "frontend_card": {
-        "visual_metaphor": "multiple worker lanes converging through one shared control plane",
-        "primary_metric_hint": "five public hardware-agent cases under one control plane",
+        "visual_metaphor": "priority lanes with one gated lane and one active fallback lane",
+        "primary_metric_hint": "attention reduction: user sees one concrete decision instead of reading the whole run log",
         "badges": [
-          "interactive-html",
-          "multi-agent",
-          "hardware"
+          "reproducible",
+          "user-gate",
+          "fallback"
         ],
         "story_beats": [
-          "LoopX owns goal state, quota, todos, claims, evidence, and history",
-          "Claude Code writes task-specific orchestration scripts under that contract",
-          "hardware-agent workers perform bounded RTL, simulation, and validation work",
-          "five public cases show closed tasks, DSE, flagship Fmax optimization, and convergence floors"
+          "P0 lane is blocked by a user decision",
+          "LoopX projects the decision as a user todo",
+          "agent continues safe fallback work",
+          "state records blocker, fallback, validation, and spend policy"
         ]
-      }
-    },
-    {
-      "id": "2026-06-23-agent-to-agent-pr-comments",
-      "date": "2026-06-23",
-      "title": "Agent-to-agent PR comment and fix loop",
-      "status": "public_safe_pattern_case",
-      "case_page": "docs/showcases/cases/0623-agent-to-agent-pr-comments.md",
-      "demo_command": null,
-      "domain": "pull-request-review",
-      "audience": [
-        "operator",
-        "agent-platform-developer",
-        "open-source-maintainer"
-      ],
-      "pattern_tags": [
-        "agent_to_agent_handoff",
-        "pr_comment_loop",
-        "review_packet",
-        "claimed_todo",
-        "successor_todo"
-      ],
-      "headline": "PR review feedback can become an owned agent todo with fix evidence instead of a loose chat reminder.",
-      "problem": "Multiple agent lanes can see or act on the same PR feedback, but without ownership and handoff state the comment-to-fix loop becomes hard to audit.",
-      "loopx_behavior": [
-        "turn review feedback into a claimed todo",
-        "route implementation through the owning agent lane",
-        "record fix and validation evidence in the review packet",
-        "keep successor work explicit after the comment is handled"
-      ],
-      "user_value": "The operator can let agents coordinate around PR comments without losing final review visibility or fix evidence.",
-      "evidence_boundary": "Public-safe pattern case only; no private screenshots, raw chats, internal review notes, local state, credentials, or unpublished artifacts.",
-      "appendix_surface": {
-        "reason": "Pattern is durable, but the original evidence included private screenshots; keep as appendix until a fully public PR-comment packet is curated.",
-        "public_surface": "appendix_only",
-        "links": [
-          "docs/showcases/cases/0623-agent-to-agent-pr-comments.md"
-        ]
-      }
-    },
-    {
-      "id": "2026-06-23-overnight-project-refactor",
-      "date": "2026-06-23",
-      "title": "Overnight project refactor as PR-sized slices",
-      "status": "public_safe_pattern_case",
-      "case_page": "docs/showcases/cases/0623-overnight-project-refactor.md",
-      "demo_command": null,
-      "domain": "repository-refactor",
-      "audience": [
-        "operator",
-        "agent-platform-developer",
-        "technical-lead"
-      ],
-      "pattern_tags": [
-        "long_unattended_goal",
-        "pr_sized_slices",
-        "todo_follow_up",
-        "supersede",
-        "validation_writeback"
-      ],
-      "headline": "A broad refactor can run overnight while staying split into human-sized review units.",
-      "problem": "Autonomous refactors become risky when discoveries, stale tasks, cleanup, and behavior changes collapse into one broad diff.",
-      "loopx_behavior": [
-        "keep the current refactor slice explicit",
-        "convert discoveries into follow-up todos",
-        "supersede stale tasks when the route changes",
-        "validate each slice before merge or handoff"
-      ],
-      "user_value": "The operator can wake up to reviewable PR-sized refactor slices instead of a single giant autonomous diff.",
-      "evidence_boundary": "Public-safe pattern case only; no private screenshots, raw chats, internal planning notes, local paths, credentials, raw logs, or unpublished project artifacts.",
-      "appendix_surface": {
-        "reason": "Pattern is durable, but keep outside canonical cards until public PR slices and validations are curated into a deeper packet.",
-        "public_surface": "appendix_only",
-        "links": [
-          "docs/showcases/cases/0623-overnight-project-refactor.md"
-        ]
-      }
-    },
-    {
-      "id": "2026-06-24-pr-issue-auto-fix",
-      "date": "2026-06-24",
-      "title": "PR issue automatic fix loop",
-      "status": "public_safe_pattern_case",
-      "case_page": "docs/showcases/cases/0624-pr-issue-auto-fix.md",
-      "demo_command": null,
-      "domain": "issue-fix-workflow",
-      "audience": [
-        "operator",
-        "agent-platform-developer",
-        "open-source-maintainer"
-      ],
-      "pattern_tags": [
-        "issue_fix_workflow",
-        "review_feedback",
-        "repro_smoke",
-        "command_pack",
-        "successor_todo"
-      ],
-      "headline": "Review feedback should become an ordered repair workflow with repro, fix, validation, and reviewer handoff.",
-      "problem": "PR comments and issues are often concrete enough to fix, but unsafe to feed into an agent as unstructured prompt text without routing, repro, and validation.",
-      "loopx_behavior": [
-        "classify the issue or review feedback",
-        "create ordered repair todos",
-        "keep gated source reads explicit",
-        "separate repro, implementation, validation, and reviewer handoff"
-      ],
-      "user_value": "The operator can turn a PR issue into a controlled fix loop without manually rewriting the review comment as an agent plan.",
-      "evidence_boundary": "Public-safe pattern case only; no private screenshots, raw gated issue bodies, internal review notes, local paths, raw logs, credentials, or unpublished repository artifacts.",
-      "appendix_surface": {
-        "reason": "Pattern is durable, but keep outside canonical cards until a public issue-fix PR packet and focused smoke are curated together.",
-        "public_surface": "appendix_only",
-        "links": [
-          "docs/showcases/cases/0624-pr-issue-auto-fix.md"
-        ]
-      }
-    },
-    {
-      "id": "2026-06-27-overnight-pr-batch",
-      "date": "2026-06-27",
-      "title": "Overnight PR batch with reviewable control",
-      "status": "public_evidence_case",
-      "case_page": "docs/showcases/cases/0627-overnight-pr-batch.md",
-      "demo_command": null,
-      "domain": "agent-platform-self-improvement",
-      "audience": [
-        "operator",
-        "agent-platform-developer",
-        "technical-lead"
-      ],
-      "pattern_tags": [
-        "high_throughput_reviewable_work",
-        "pr_sized_slices",
-        "self_merge_policy",
-        "validation_writeback",
-        "public_boundary"
-      ],
-      "headline": "An overnight LoopX run can produce many PR-sized slices while keeping review, validation, and public evidence boundaries visible.",
-      "problem": "High-throughput autonomous work is only useful if the resulting changes remain reviewable, validated, and safe to publish.",
-      "loopx_behavior": [
-        "keep work broken into PR-sized slices instead of a giant unreviewable diff",
-        "tie runtime, docs, and focused smoke updates together when a control-plane contract changes",
-        "limit self-merge to narrow validated changes while preserving broader review gates",
-        "record public evidence from Git history instead of raw agent logs or private screenshots",
-        "keep public/private boundary checks in the showcase path"
-      ],
-      "user_value": "The operator can wake up to a compact batch of merged public slices, see what changed, and still trust that gates, validation, and evidence boundaries were not bypassed.",
-      "workload_signal": {
-        "scope": "public_repository_window",
-        "window": {
-          "from": "2026-06-27T01:29:00+08:00",
-          "to": "2026-06-27T11:29:00+08:00",
-          "hours": 10
-        },
-        "public_git": {
-          "merged_commits": 22,
-          "files_touched": 60,
-          "insertions": 6695,
-          "deletions": 223,
-          "commit_messages_with_pr_numbers": 10
-        },
-        "claim_boundary": "public Git history only; contemporaneous private queue notes are not used as public evidence"
       },
-      "evidence_boundary": "Public Git evidence only; no private documents, internal screenshots, raw chats, local active-state bodies, raw logs, credentials, or machine-specific paths.",
-      "appendix_surface": {
-        "reason": "Public Git evidence case for an overnight throughput window; keep outside the first canonical frontstage cards until each PR slice has a deeper public evidence packet or reproducible demo.",
-        "public_surface": "appendix_only",
-        "links": [
-          "docs/showcases/cases/0627-overnight-pr-batch.md"
-        ]
+      "interactive_page": "docs/showcases/cases/0617-blocked-p0-safe-rotation.html",
+      "interactive_page_zh": "docs/showcases/cases/0617-blocked-p0-safe-rotation.html",
+      "interactive_page_en": "docs/showcases/cases/0617-blocked-p0-safe-rotation.en.html",
+      "localized_pages": {
+        "zh": "docs/showcases/cases/0617-blocked-p0-safe-rotation.html",
+        "en": "docs/showcases/cases/0617-blocked-p0-safe-rotation.en.html"
+      },
+      "showcase_rank": 7,
+      "showcase_table": {
+        "proof_point": "A user decision should not block all safe work.",
+        "loopx_intervention": "concrete user todo, safe fallback, quota control"
       }
     },
     {
@@ -439,6 +554,13 @@
           "docs/showcases/creator-ops-fake-data-storyboard.md",
           "docs/showcases/creator-ops-feedback-boundary-contract.md"
         ]
+      },
+      "interactive_page": "docs/showcases/cases/0620-creator-operator-case-spec.html",
+      "interactive_page_zh": "docs/showcases/cases/0620-creator-operator-case-spec.html",
+      "interactive_page_en": "docs/showcases/cases/0620-creator-operator-case-spec.en.html",
+      "localized_pages": {
+        "zh": "docs/showcases/cases/0620-creator-operator-case-spec.html",
+        "en": "docs/showcases/cases/0620-creator-operator-case-spec.en.html"
       }
     }
   ]

--- a/examples/export-frontstage-share-bundle.mjs
+++ b/examples/export-frontstage-share-bundle.mjs
@@ -80,12 +80,12 @@ async function copyIndexForFrontstage(siteDir) {
   await writeFile(resolve(frontstageDir, "index.html"), html);
 }
 
-function validateInteractivePagePath(path) {
+function validateShowcaseHtmlPath(path) {
   if (typeof path !== "string") {
-    throw new Error(`interactive_page must be a string: ${JSON.stringify(path)}`);
+    throw new Error(`showcase page must be a string: ${JSON.stringify(path)}`);
   }
   if (!path.startsWith("docs/showcases/") || !path.endsWith(".html") || path.includes("..")) {
-    throw new Error(`interactive_page must stay under docs/showcases/*.html: ${path}`);
+    throw new Error(`showcase page must stay under docs/showcases/*.html: ${path}`);
   }
   return path;
 }
@@ -93,9 +93,15 @@ function validateInteractivePagePath(path) {
 async function copyInteractiveCasePages(siteDir) {
   const catalog = JSON.parse(await readFile(resolve(repoRoot, showcaseCatalogPath), "utf8"));
   const interactivePages = new Set();
+  for (const pagePath of ["docs/showcases/index.html", "docs/showcases/index.en.html"]) {
+    interactivePages.add(validateShowcaseHtmlPath(pagePath));
+  }
   for (const item of catalog.cases ?? []) {
     if (item.interactive_page) {
-      interactivePages.add(validateInteractivePagePath(item.interactive_page));
+      interactivePages.add(validateShowcaseHtmlPath(item.interactive_page));
+    }
+    for (const pagePath of Object.values(item.localized_pages ?? {})) {
+      interactivePages.add(validateShowcaseHtmlPath(pagePath));
     }
   }
 

--- a/examples/frontstage-share-bundle-smoke.mjs
+++ b/examples/frontstage-share-bundle-smoke.mjs
@@ -119,6 +119,18 @@ const interactivePages = manifest.content_sources?.interactive_case_pages ?? [];
 if (!interactivePages.includes("docs/showcases/cases/0619-dynamic-workflow-hardware-agent.html")) {
   throw new Error(`share bundle did not include the hardware-agent interactive page: ${JSON.stringify(interactivePages)}`);
 }
+for (const pagePath of [
+  "docs/showcases/index.html",
+  "docs/showcases/index.en.html",
+  "docs/showcases/cases/0624-pr-issue-auto-fix.html",
+  "docs/showcases/cases/0624-pr-issue-auto-fix.en.html",
+  "docs/showcases/cases/0619-dynamic-workflow-hardware-agent.en.html",
+]) {
+  if (!interactivePages.includes(pagePath)) {
+    throw new Error(`share bundle did not include expected showcase page ${pagePath}: ${JSON.stringify(interactivePages)}`);
+  }
+  assertExists(resolve(siteDir, pagePath));
+}
 assertExists(resolve(siteDir, "docs/showcases/cases/0619-dynamic-workflow-hardware-agent.html"));
 const hardwareCaseHtml = await readFile(resolve(siteDir, "docs/showcases/cases/0619-dynamic-workflow-hardware-agent.html"), "utf8");
 if (!hardwareCaseHtml.includes("loopx 在芯片开发任务上的实践") || !hardwareCaseHtml.includes("VeeR EH1")) {

--- a/examples/showcase-animation-prototype.py
+++ b/examples/showcase-animation-prototype.py
@@ -549,6 +549,10 @@ def render(storyboard: dict[str, Any], catalog: dict[str, Any]) -> str:
 """
 
 
+def clean_html(value: str) -> str:
+    return "\n".join(line.rstrip() for line in value.splitlines()) + "\n"
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--storyboard", type=Path, default=DEFAULT_STORYBOARD)
@@ -561,7 +565,7 @@ def main() -> int:
     args = parse_args()
     storyboard = read_json(args.storyboard)
     catalog = read_json(args.catalog)
-    output = render(storyboard, catalog)
+    output = clean_html(render(storyboard, catalog))
     if args.output:
         args.output.parent.mkdir(parents=True, exist_ok=True)
         args.output.write_text(output, encoding="utf-8")

--- a/examples/showcase-animation-source-boundary-smoke.py
+++ b/examples/showcase-animation-source-boundary-smoke.py
@@ -71,9 +71,13 @@ def assert_catalog_is_frontstage_ready() -> None:
         assert case.get("headline"), case
         assert case.get("evidence_boundary"), case
         frontend = case.get("frontend_card")
-        assert isinstance(frontend, dict), case
-        beats = frontend.get("story_beats")
-        assert isinstance(beats, list) and len(beats) >= 3, case
+        appendix = case.get("appendix_surface")
+        assert isinstance(frontend, dict) or isinstance(appendix, dict), case
+        if isinstance(frontend, dict):
+            beats = frontend.get("story_beats")
+            assert isinstance(beats, list) and len(beats) >= 3, case
+        else:
+            assert appendix.get("public_surface") == "appendix_only", case
 
 
 def assert_storyboard_uses_public_catalog() -> None:

--- a/examples/showcase-catalog-smoke.py
+++ b/examples/showcase-catalog-smoke.py
@@ -25,6 +25,20 @@ PRIVATE_MARKERS = tuple(
         ("pass", "word="),
     )
 )
+PRIMARY_SHOWCASE_IDS = [
+    "2026-06-27-overnight-pr-batch",
+    "2026-06-24-pr-issue-auto-fix",
+    "2026-06-23-agent-to-agent-pr-comments",
+    "2026-06-23-overnight-project-refactor",
+    "2026-06-19-dynamic-workflow-hardware-agent",
+    "2026-06-19-loopx-self-iteration",
+    "2026-06-17-blocked-p0-safe-rotation",
+]
+FORBIDDEN_SHOWCASE_COPY = (
+    "故事" + "节奏",
+    "Story " + "beats",
+    "Website Story " + "Beats",
+)
 
 
 def read(path: Path) -> str:
@@ -48,11 +62,7 @@ def main() -> int:
     assert "2026-06-19-dynamic-workflow-hardware-agent" in case_ids, case_ids
     assert "2026-06-19-loopx-self-iteration" in case_ids, case_ids
     frontstage_ids = [case.get("id") for case in cases if isinstance(case.get("frontend_card"), dict)]
-    assert frontstage_ids[:3] == [
-        "2026-06-17-blocked-p0-safe-rotation",
-        "2026-06-19-loopx-self-iteration",
-        "2026-06-19-dynamic-workflow-hardware-agent",
-    ], frontstage_ids
+    assert frontstage_ids[:7] == PRIMARY_SHOWCASE_IDS, frontstage_ids
 
     assert_public_safe(CATALOG)
     assert_public_safe(SHOWCASES)
@@ -77,6 +87,23 @@ def main() -> int:
         else:
             assert appendix.get("reason"), case
             assert appendix.get("public_surface") == "appendix_only", case
+        localized_pages = case.get("localized_pages")
+        assert isinstance(localized_pages, dict), case
+        for lang in ("zh", "en"):
+            localized_page = localized_pages.get(lang)
+            assert isinstance(localized_page, str), case
+            assert localized_page.startswith("docs/showcases/"), case
+            assert localized_page.endswith(".html"), case
+            localized_path = REPO_ROOT / localized_page
+            assert localized_path.is_file(), case
+            assert_public_safe(localized_path)
+            localized_text = read(localized_path)
+            for phrase in FORBIDDEN_SHOWCASE_COPY:
+                assert phrase not in localized_text, f"{localized_page}: forbidden copy {phrase!r}"
+            if case_id != "2026-06-19-dynamic-workflow-hardware-agent" or lang == "en":
+                assert "Repository evidence" in localized_text or "仓库证据" in localized_text, localized_page
+                assert "Repository sources" in localized_text or "仓库来源" in localized_text, localized_page
+                assert str(case.get("evidence_boundary")) in localized_text, localized_page
 
         demo_command = case.get("demo_command")
         if case.get("status") == "reproducible_synthetic_demo":

--- a/examples/showcase-frontstage-prototype-smoke.py
+++ b/examples/showcase-frontstage-prototype-smoke.py
@@ -27,6 +27,15 @@ PRIVATE_MARKERS = tuple(
         ("pass", "word="),
     )
 )
+PRIMARY_SHOWCASE_IDS = [
+    "2026-06-27-overnight-pr-batch",
+    "2026-06-24-pr-issue-auto-fix",
+    "2026-06-23-agent-to-agent-pr-comments",
+    "2026-06-23-overnight-project-refactor",
+    "2026-06-19-dynamic-workflow-hardware-agent",
+    "2026-06-19-loopx-self-iteration",
+    "2026-06-17-blocked-p0-safe-rotation",
+]
 
 
 def main() -> int:
@@ -48,6 +57,13 @@ def main() -> int:
 
     for marker in PRIVATE_MARKERS:
         assert marker not in html, marker
+    forbidden_display_terms = (
+        "Story " + "beats",
+        "Website " + "Story " + "Beats",
+        "故事" + "节奏",
+    )
+    for marker in forbidden_display_terms:
+        assert marker not in html, marker
 
     for required in (
         '<section class="hero">',
@@ -67,11 +83,7 @@ def main() -> int:
     ):
         assert required in html, required
 
-    assert [case["id"] for case in frontstage_cases] == [
-        "2026-06-17-blocked-p0-safe-rotation",
-        "2026-06-19-loopx-self-iteration",
-        "2026-06-19-dynamic-workflow-hardware-agent",
-    ], frontstage_cases
+    assert [case["id"] for case in frontstage_cases] == PRIMARY_SHOWCASE_IDS, frontstage_cases
     assert any(case["id"] == "2026-06-20-creator-operator-case-spec" for case in appendix_cases), appendix_cases
 
     statuses = {str(case["status"]) for case in frontstage_cases}

--- a/examples/showcase-frontstage-prototype.py
+++ b/examples/showcase-frontstage-prototype.py
@@ -27,11 +27,7 @@ def esc(value: object) -> str:
 
 
 def repo_link(repo_relative: str, *, output: Path | None) -> str:
-    if output is None:
-        return repo_relative
-    target = (REPO_ROOT / repo_relative).resolve()
-    base = output.resolve().parent
-    return os.path.relpath(target, base).replace(os.sep, "/")
+    return repo_relative
 
 
 def render_badges(values: list[Any]) -> str:
@@ -166,7 +162,7 @@ def render_case(case: dict[str, Any], *, output: Path | None) -> str:
         if feedback_contract_href
         else ""
     )
-    story = "".join(f"<li>{esc(beat)}</li>" for beat in story_beats)
+    evidence_sequence = "".join(f"<li>{esc(beat)}</li>" for beat in story_beats)
     behavior_items = "".join(f"<li>{esc(item)}</li>" for item in behavior)
     efficiency_panel = render_efficiency_panel(case)
 
@@ -195,8 +191,8 @@ def render_case(case: dict[str, Any], *, output: Path | None) -> str:
             <ol>{behavior_items}</ol>
           </div>
           <div>
-            <h4>Story beats</h4>
-            <ol>{story}</ol>
+            <h4>Evidence sequence</h4>
+            <ol>{evidence_sequence}</ol>
           </div>
         </div>
         {demo}

--- a/examples/showcase-html-pages.py
+++ b/examples/showcase-html-pages.py
@@ -1,0 +1,1157 @@
+#!/usr/bin/env python3
+"""Generate public-safe showcase HTML pages without rewriting the hardware artifact."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SHOWCASE_DIR = REPO_ROOT / "docs" / "showcases"
+CASES_DIR = SHOWCASE_DIR / "cases"
+CATALOG = SHOWCASE_DIR / "showcase-catalog.json"
+HARDWARE_CASE_ID = "2026-06-19-dynamic-workflow-hardware-agent"
+HARDWARE_CANONICAL_PAGE = CASES_DIR / "0619-dynamic-workflow-hardware-agent.html"
+
+PRIMARY_CASE_ORDER = [
+    "2026-06-27-overnight-pr-batch",
+    "2026-06-24-pr-issue-auto-fix",
+    "2026-06-23-agent-to-agent-pr-comments",
+    "2026-06-23-overnight-project-refactor",
+    HARDWARE_CASE_ID,
+    "2026-06-19-loopx-self-iteration",
+    "2026-06-17-blocked-p0-safe-rotation",
+]
+
+SHOWCASE_TABLE = {
+    "2026-06-27-overnight-pr-batch": {
+        "proof_point": "High-throughput multi-lane work can remain PR-sized, reviewable, and merge-safe.",
+        "loopx_intervention": "todo claim, review packet, self-merge boundary, focused smoke, public-boundary scan",
+    },
+    "2026-06-24-pr-issue-auto-fix": {
+        "proof_point": "Issue and review feedback can enter an executable repair loop.",
+        "loopx_intervention": "issue-fix workflow, command pack, repro smoke, PR review feedback",
+    },
+    "2026-06-23-agent-to-agent-pr-comments": {
+        "proof_point": "Multiple agents can coordinate around PR review comments without losing owner review.",
+        "loopx_intervention": "claimed_by, handoff gate, review packet, comment/fix loop",
+    },
+    "2026-06-23-overnight-project-refactor": {
+        "proof_point": "Long unattended refactors can split into moderate PR slices instead of one unreviewable diff.",
+        "loopx_intervention": "loop, todo follow-up, supersede, PR-sized slices",
+    },
+    HARDWARE_CASE_ID: {
+        "proof_point": "Fuzzy goals, multiple workers, and long unattended runs can still converge.",
+        "loopx_intervention": "goal state, worker handoff, dynamic workflow",
+    },
+    "2026-06-19-loopx-self-iteration": {
+        "proof_point": "A high-churn multi-lane project can keep state, boundaries, and evidence coherent.",
+        "loopx_intervention": "todo, quota, gate, evidence, review packet, frontstage",
+    },
+    "2026-06-17-blocked-p0-safe-rotation": {
+        "proof_point": "A user decision should not block all safe work.",
+        "loopx_intervention": "concrete user todo, safe fallback, quota control",
+    },
+}
+
+ZH_COPY = {
+    "2026-06-27-overnight-pr-batch": {
+        "title": "一晚 30 个高价值 PR",
+        "headline": "高吞吐、多车道推进仍保持 PR 级可 review、可合并。",
+        "proof_point": "高吞吐多 lane 工作也可以保持 PR 粒度、可审阅、可合并。",
+        "loopx_intervention": "todo claim、review packet、自合并边界、focused smoke、public-boundary scan",
+        "beats": ["长时间窗口被拆成 PR-sized slice。", "每条 lane 写回验证和 review 边界。", "公开 Git 证据替代原始运行日志。"],
+    },
+    "2026-06-24-pr-issue-auto-fix": {
+        "title": "PR Issue 自动 Fix",
+        "headline": "Issue / Review comment 可以进入可执行修复闭环。",
+        "proof_point": "Issue 和 review 反馈可以变成受控、可执行的修复循环。",
+        "loopx_intervention": "issue-fix workflow、command pack、repro smoke、PR review feedback",
+        "beats": ["反馈先变成可 claim 的修复目标。", "repro、fix、validation 被拆开记录。", "剩余风险回到 reviewer，而不是被 agent 默认吞掉。"],
+    },
+    "2026-06-23-agent-to-agent-pr-comments": {
+        "title": "Agent to agent 回复 PR comment 和 PR Fix",
+        "headline": "多 agent 可围绕 PR review 协同发现、评论、修复。",
+        "proof_point": "多 agent lane 可以围绕 PR comment 协作，同时保留 owner review。",
+        "loopx_intervention": "claimed_by、handoff gate、review packet、comment/fix loop",
+        "beats": ["一个 agent 留下公开安全的 PR 反馈。", "另一条 lane claim 后续修复。", "owner 仍能看到 handoff、证据和剩余 gate。"],
+    },
+    "2026-06-23-overnight-project-refactor": {
+        "title": "一晚上自主重构项目",
+        "headline": "长时间无值守重构能拆成适中 PR，而不是一个不可 review 大改。",
+        "proof_point": "无人值守 refactor 可以拆成 PR-sized slice。",
+        "loopx_intervention": "loop、todo follow-up、supersede、PR-sized slices",
+        "beats": ["开放 cleanup 被拆成有序 slice。", "发现项写成 follow-up todo。", "每个 slice 都留下验证和剩余风险。"],
+    },
+    HARDWARE_CASE_ID: {
+        "title": "外部芯片 agent workflow",
+        "headline": "模糊目标、多 worker、长时间无值守下仍可收敛。",
+        "proof_point": "模糊目标、多 worker、长时间无值守下仍可收敛。",
+        "loopx_intervention": "goal state、worker handoff、dynamic workflow",
+        "beats": ["LoopX 持有 goal state、quota、todo、claim、evidence 和 history。", "Claude Code 编写任务级编排脚本。", "worker agent 执行有边界的硬件工程工作。"],
+    },
+    "2026-06-19-loopx-self-iteration": {
+        "title": "LoopX Meta Agent 自迭代",
+        "headline": "高变更、多车道项目可保持状态、边界和证据。",
+        "proof_point": "高 churn 多 lane agent repo 可以保持状态、证据和边界一致。",
+        "loopx_intervention": "todo、quota、gate、evidence、review packet、frontstage",
+        "beats": ["benchmark、产品、文档和 side-agent 并行推进。", "状态、gate、quota 和 evidence 收敛到同一控制面。", "公开 Git 窗口形成保守效率证据。"],
+    },
+    "2026-06-17-blocked-p0-safe-rotation": {
+        "title": "P0 block 后推进 P1/P2",
+        "headline": "用户决策不应阻塞全部安全工作。",
+        "proof_point": "被阻塞的 P0 决策不应该阻止安全的 P1/P2 工作继续。",
+        "loopx_intervention": "concrete user todo、safe fallback、quota control",
+        "beats": ["P0 决策投影成具体 user todo。", "safe fallback lane 继续推进。", "quota 和 evidence 限制自动推进节奏。"],
+    },
+    "2026-06-20-creator-operator-case-spec": {
+        "title": "创作者-运营者长跑 Agent 案例",
+        "headline": "研究可以继续，发布决策仍然 gated。",
+        "proof_point": "创作与运营工作可以共享一个 gate-aware 的长期 agent loop。",
+        "loopx_intervention": "creator-operator workflow、user gate、feedback capture、material library",
+        "beats": ["素材整理作为 safe side path 继续。", "发布和品牌判断停在人类 gate。", "反馈沉淀成可复用偏好和材料库。"],
+    },
+}
+
+DEFAULT_FRONTEND = {
+    "2026-06-27-overnight-pr-batch": ("parallel PR lanes converge into a reviewable merge rail", ["PR batch", "review packet", "public boundary"]),
+    "2026-06-24-pr-issue-auto-fix": ("issue feedback closes through repro, fix, validation, and review handoff", ["issue fix", "repro smoke", "PR review"]),
+    "2026-06-23-agent-to-agent-pr-comments": ("agent comments pass through explicit ownership instead of loose threads", ["handoff", "PR comment", "claimed_by"]),
+    "2026-06-23-overnight-project-refactor": ("a large refactor moves as small reviewable packets", ["refactor", "PR slices", "todo evidence"]),
+}
+
+CASE_DETAILS = {
+    "2026-06-27-overnight-pr-batch": {
+        "zh": {
+            "context": [
+                "这个案例不是在展示“agent 很忙”，而是在展示高吞吐自动化如何仍然保持可审阅。仓库把证据窗口固定在 2026-06-27 01:29 到 11:29 +08:00，避免把私有队列、聊天截图或操作员笔记当成公开证明。",
+                "窗口内公开 Git 历史显示 22 个 merged commits、60 个 touched files、6695 行新增和 223 行删除，其中 10 条 commit message 带 PR 编号。页面只声称这些公开 Git 能复现的事实。",
+            ],
+            "evidence": [
+                ("公开窗口", "2026-06-27 01:29 到 11:29 +08:00，10 小时 Git 证据窗口。"),
+                ("变更粒度", "22 个 merged commits 覆盖 docs、runtime、status/quota、benchmark contracts、smokes 和 release/runtime guardrails。"),
+                ("审阅边界", "工作以 PR-sized slices 落地，而不是一个需要 maintainer 盲信的巨大 diff。"),
+                ("复现方式", "case 文档给出 `git log --since ... --until ...` 和 `git log --numstat` 命令。"),
+            ],
+            "mechanism": [
+                "LoopX 把每条 lane 绑定到 todo ownership、validation、review policy 和 public evidence。",
+                "当 control-plane contract 改变时，runtime、docs 和 focused smoke 一起移动。",
+                "self-merge 只用于窄而验证过的变更；更大或不清楚的工作仍保留 review gate。",
+                "公开边界扫描把内部截图、本地状态、原始日志和私有计划排除在 showcase 之外。",
+            ],
+            "user_outcome": [
+                "用户醒来看到的是一组可 review、可追踪、可解释的 public slices，而不是一堆原始 agent 输出。",
+                "operator 可以继续追问每条 slice 的验证和剩余 gate；证据不依赖 chat memory。",
+            ],
+            "source_refs": [
+                ("case narrative", "docs/showcases/cases/0627-overnight-pr-batch.md"),
+                ("catalog workload signal", "docs/showcases/showcase-catalog.json"),
+            ],
+        },
+        "en": {
+            "context": [
+                "This case is not about an agent being busy. It is about keeping high-throughput autonomous work reviewable. The repository anchors the public evidence window to 2026-06-27 01:29 through 11:29 +08:00 instead of relying on private queues, screenshots, or operator notes.",
+                "Public Git history in that window shows 22 merged commits, 60 touched files, 6695 insertions, 223 deletions, and 10 commit messages with explicit PR numbers. The page only claims what those public facts support.",
+            ],
+            "evidence": [
+                ("Public window", "2026-06-27 01:29 to 11:29 +08:00, a 10-hour Git evidence window."),
+                ("Change shape", "22 merged commits across docs, runtime, status/quota, benchmark contracts, smokes, and release/runtime guardrails."),
+                ("Review boundary", "Work landed as PR-sized slices instead of one broad diff that maintainers would have to trust blindly."),
+                ("Reproduction", "The case document gives `git log --since ... --until ...` and `git log --numstat` commands."),
+            ],
+            "mechanism": [
+                "LoopX ties each lane to todo ownership, validation, review policy, and public evidence.",
+                "Runtime, docs, and focused smokes move together when a control-plane contract changes.",
+                "Self-merge remains limited to narrow validated changes; larger or unclear work preserves review gates.",
+                "Public-boundary scans keep internal screenshots, local state, raw logs, and private planning out of the showcase.",
+            ],
+            "user_outcome": [
+                "The user wakes up to reviewable, traceable, explainable public slices rather than raw agent output.",
+                "The operator can inspect validation and remaining gates for each slice without relying on chat memory.",
+            ],
+            "source_refs": [
+                ("case narrative", "docs/showcases/cases/0627-overnight-pr-batch.md"),
+                ("catalog workload signal", "docs/showcases/showcase-catalog.json"),
+            ],
+        },
+    },
+    "2026-06-24-pr-issue-auto-fix": {
+        "zh": {
+            "context": [
+                "这个案例把 PR issue、review comment 或 issue text 转成可执行修复闭环。它不是“读一段评论就改代码”，而是先做 metadata/intake、repro、branch-local patch、validation 和 review packet。",
+                "仓库已经有 issue-fix capability：模块在 `loopx/capabilities/issue_fix/`，CLI 入口是 `loopx issue-fix ...`，协议文档和 smoke 都在公开仓库内。",
+            ],
+            "evidence": [
+                ("产品入口", "`docs/capabilities/issue-fix/README.md` 声明 `loopx issue-fix ...`、content-ops bridge、protocol docs 和 smoke。"),
+                ("工作流协议", "`issue_fix_workflow_contract_v0` 明确 metadata preview、intake classification、workflow plan、todo writeback、caller repo branch、validation、PR review packet 和 gate handling。"),
+                ("可执行闭环", "`issue_fix_acceptance_loop_v0` 包含 acceptance fixture、repo-branch fixture 和 caller-approved repo branch mode。"),
+                ("验证面", "`examples/issue-fix-workflow-plan-smoke.py`、`examples/issue-fix-workflow-contract-smoke.py`、`examples/issue-fix-acceptance-loop-smoke.py` 等 smoke 覆盖这个路径。"),
+            ],
+            "mechanism": [
+                "public metadata 可以进入 packet；raw issue body、comment body、timeline、provider payload 都是 gated source。",
+                "accepted candidates 写成有序 LoopX todos：repro smoke、code-context route、branch-local patch、validation、review-packet readiness。",
+                "caller-approved repo 模式只在 `--execute` 时检查本地 repo，并且输出 repo-relative changed files、validation pass/fail 和 PR-readiness。",
+                "外部 comment、PR creation、merge、publish、destructive git 和 production action 都保留为显式 gate。",
+            ],
+            "user_outcome": [
+                "维护者给出一个 public issue/PR signal 后，可以得到一个先复现、再修复、再验证、最后交给 review 的闭环。",
+                "用户不需要把每个 review comment 手动改写成 agent prompt，也不会把原始 issue body 或本地路径泄漏进公开 artifact。",
+            ],
+            "source_refs": [
+                ("capability README", "docs/capabilities/issue-fix/README.md"),
+                ("workflow contract", "docs/capabilities/issue-fix/protocols/issue-fix-workflow-contract-v0.md"),
+                ("acceptance loop", "docs/capabilities/issue-fix/protocols/issue-fix-acceptance-loop-v0.md"),
+                ("workflow smoke", "examples/issue-fix-workflow-plan-smoke.py"),
+                ("acceptance smoke", "examples/issue-fix-acceptance-loop-smoke.py"),
+            ],
+        },
+        "en": {
+            "context": [
+                "This case turns a PR issue, review comment, or issue text into an executable repair loop. It is not simply reading a comment and editing code; the path goes through metadata/intake, repro, branch-local patch, validation, and review packet.",
+                "The repository already contains the issue-fix capability: `loopx/capabilities/issue_fix/`, the `loopx issue-fix ...` CLI entry, protocol docs, and public smokes.",
+            ],
+            "evidence": [
+                ("Product entry", "`docs/capabilities/issue-fix/README.md` names `loopx issue-fix ...`, the content-ops bridge, protocol docs, and smokes."),
+                ("Workflow contract", "`issue_fix_workflow_contract_v0` defines metadata preview, intake classification, workflow plan, todo writeback, caller repo branch, validation, PR review packet, and gate handling."),
+                ("Executable loop", "`issue_fix_acceptance_loop_v0` includes the acceptance fixture, repo-branch fixture, and caller-approved repo branch mode."),
+                ("Validation surface", "Smokes cover workflow planning, workflow contract, metadata/intake, and acceptance-loop behavior."),
+            ],
+            "mechanism": [
+                "Public metadata can enter packets; raw issue bodies, comment bodies, timelines, and provider payloads remain gated sources.",
+                "Accepted candidates become ordered LoopX todos: repro smoke, code-context route, branch-local patch, validation, and review-packet readiness.",
+                "Caller-approved repo mode inspects the local repo only under `--execute` and reports repo-relative changed files plus validation pass/fail.",
+                "External comments, PR creation, merge, publish, destructive git, and production action remain explicit gates.",
+            ],
+            "user_outcome": [
+                "A maintainer can provide a public issue or PR signal and get a loop that reproduces, fixes, validates, and prepares human review.",
+                "The user does not need to rewrite every review comment as an agent prompt, and raw issue bodies or local paths do not leak into the public artifact.",
+            ],
+            "source_refs": [
+                ("capability README", "docs/capabilities/issue-fix/README.md"),
+                ("workflow contract", "docs/capabilities/issue-fix/protocols/issue-fix-workflow-contract-v0.md"),
+                ("acceptance loop", "docs/capabilities/issue-fix/protocols/issue-fix-acceptance-loop-v0.md"),
+                ("workflow smoke", "examples/issue-fix-workflow-plan-smoke.py"),
+                ("acceptance smoke", "examples/issue-fix-acceptance-loop-smoke.py"),
+            ],
+        },
+    },
+    "2026-06-23-agent-to-agent-pr-comments": {
+        "zh": {
+            "context": [
+                "这个案例描述的是 PR review feedback 在多 agent 之间流转时如何不丢 ownership。重点不是聊天记录，而是 comment、claim、handoff、fix、validation、review packet 这条链。",
+                "公开仓库里可以看到相关控制面已经被产品化：`claimed_by` 出现在 todo projection、review packet、event-sourced state 和多 agent/side-agent prompt 合约里。",
+            ],
+            "evidence": [
+                ("todo ownership", "`event_sourced_state_contract_v0` 把 `todo_claimed` 定义为 canonical event，记录 ownership、lease 或 `claimed_by`。"),
+                ("review packet", "`loopx/review_packet.py` 会把 open todo 的 `claimed_by` 显示进 handoff/review 文本。"),
+                ("side-agent contract", "`docs/heartbeat-automation-prompt.md` 规定 side-agent 小变更可带 evidence 自合并，否则创建 claimed-by handoff todo。"),
+                ("CLI smokes", "`examples/todo-lifecycle-cli-smoke.py`、`examples/todo-cli-smoke.py` 覆盖 claim、handoff successor、side-agent self-merge 和 review handoff 规则。"),
+            ],
+            "mechanism": [
+                "PR feedback 先成为一个有 owner 的 todo，而不是 chat reminder。",
+                "被阻塞或跨 lane 的修复通过 handoff gate 和 review packet 传递，不允许另一个 agent 猜测上下文。",
+                "修复 agent 需要留下 diff、validation 和剩余 gate；后续工作创建 successor todo。",
+                "owner review 仍在 PR/review surface 上完成，LoopX 只提供状态、证据和 handoff。",
+            ],
+            "user_outcome": [
+                "用户不必手动 shepherd 每条 PR comment；控制面会显示谁 claim 了反馈、修复证据在哪里、还有什么需要 review。",
+                "多 agent 协作不会变成“谁看过这条评论”的记忆题。",
+            ],
+            "source_refs": [
+                ("event-sourced todo claim", "docs/reference/protocols/event-sourced-state-contract-v0.md"),
+                ("review packet code", "loopx/review_packet.py"),
+                ("side-agent prompt contract", "docs/heartbeat-automation-prompt.md"),
+                ("todo lifecycle smoke", "examples/todo-lifecycle-cli-smoke.py"),
+            ],
+        },
+        "en": {
+            "context": [
+                "This case shows how PR review feedback can move across multiple agents without losing ownership. The important chain is comment, claim, handoff, fix, validation, and review packet rather than the chat transcript.",
+                "The public repository contains the control-plane pieces: `claimed_by` appears in todo projection, review packets, event-sourced state, and multi-agent or side-agent prompt contracts.",
+            ],
+            "evidence": [
+                ("Todo ownership", "`event_sourced_state_contract_v0` defines `todo_claimed` as a canonical event for ownership, lease, or `claimed_by`."),
+                ("Review packet", "`loopx/review_packet.py` renders open todo `claimed_by` values into handoff and review text."),
+                ("Side-agent contract", "`docs/heartbeat-automation-prompt.md` requires side agents to self-merge only small validated evidence-backed work or create a claimed handoff todo."),
+                ("CLI smokes", "`examples/todo-lifecycle-cli-smoke.py` and `examples/todo-cli-smoke.py` cover claim, handoff successor, side-agent self-merge, and review handoff rules."),
+            ],
+            "mechanism": [
+                "PR feedback becomes an owned todo rather than a chat reminder.",
+                "Blocked or cross-lane fixes move through handoff gates and review packets instead of another agent guessing context.",
+                "The fixing agent leaves diff, validation, and remaining gates; follow-up work becomes a successor todo.",
+                "Owner review still happens on the PR or review surface; LoopX supplies state, evidence, and handoff.",
+            ],
+            "user_outcome": [
+                "The user does not have to shepherd every PR comment manually; the control plane shows who claimed the feedback, where the fix evidence is, and what still needs review.",
+                "Multi-agent collaboration stops depending on memory of which agent saw which comment.",
+            ],
+            "source_refs": [
+                ("event-sourced todo claim", "docs/reference/protocols/event-sourced-state-contract-v0.md"),
+                ("review packet code", "loopx/review_packet.py"),
+                ("side-agent prompt contract", "docs/heartbeat-automation-prompt.md"),
+                ("todo lifecycle smoke", "examples/todo-lifecycle-cli-smoke.py"),
+            ],
+        },
+    },
+    "2026-06-23-overnight-project-refactor": {
+        "zh": {
+            "context": [
+                "这个案例解决的是无人值守重构的风险：长时间 agent 容易把 cleanup、行为改变、发现的新问题和过期计划混成一个大 diff。",
+                "LoopX 的公开证据不是某个私有夜间截图，而是 todo lifecycle、successor/supersede、validation writeback 和 review-packet 这些已经在仓库里有文档和 smoke 的控制面。",
+            ],
+            "evidence": [
+                ("successor path", "`docs/lark-kanban-control-plane-adapter.md` 明确 real successor 使用 `todo complete --next-*`，replacement 或 narrower split 使用 `todo supersede --next-agent-todo`。"),
+                ("side-agent completion", "`docs/heartbeat-automation-prompt.md` 要求非平凡完成创建 successor todo 或写 no-follow-up rationale。"),
+                ("CLI validation", "`examples/todo-lifecycle-cli-smoke.py` 覆盖 `--next-agent-todo`、`todo supersede`、claim 继承和 handoff successor。"),
+                ("review shape", "`loopx review-packet` 把当前 open todo、claimed_by 和 handoff 状态打包成 reviewer 可读的 packet。"),
+            ],
+            "mechanism": [
+                "当前 refactor slice 必须是可 review 的单位，不把整夜发现都塞进一个 PR。",
+                "发现的新工作写成 follow-up todo；路线变了就 supersede 旧 todo。",
+                "每个 slice 用 focused validation 或文档/contract smoke 证明，而不是依赖原始 agent trace。",
+                "大范围或风险不清楚的 slice 不自合并，进入 review handoff。",
+            ],
+            "user_outcome": [
+                "用户可以让重构跑过夜，但早上看到的是一组有边界的 review 单元和剩余 todo，而不是一个不可 review 的巨型改动。",
+                "项目可以继续快，但 review 面仍是人能处理的粒度。",
+            ],
+            "source_refs": [
+                ("kanban control-plane adapter", "docs/lark-kanban-control-plane-adapter.md"),
+                ("heartbeat prompt contract", "docs/heartbeat-automation-prompt.md"),
+                ("todo lifecycle smoke", "examples/todo-lifecycle-cli-smoke.py"),
+                ("case narrative", "docs/showcases/cases/0623-overnight-project-refactor.md"),
+            ],
+        },
+        "en": {
+            "context": [
+                "This case addresses the risk of unattended refactoring: a long-running agent can mix cleanup, behavior change, discoveries, and stale plans into one broad diff.",
+                "The public evidence is not a private overnight screenshot. It is the control-plane behavior already documented and smoke-tested in the repository: todo lifecycle, successor/supersede, validation writeback, and review packets.",
+            ],
+            "evidence": [
+                ("Successor path", "`docs/lark-kanban-control-plane-adapter.md` says real successors use `todo complete --next-*`, while replacements or narrower splits use `todo supersede --next-agent-todo`."),
+                ("Side-agent completion", "`docs/heartbeat-automation-prompt.md` requires nontrivial completion to create a successor todo or a no-follow-up rationale."),
+                ("CLI validation", "`examples/todo-lifecycle-cli-smoke.py` covers `--next-agent-todo`, `todo supersede`, claim inheritance, and handoff successors."),
+                ("Review shape", "`loopx review-packet` packages open todos, claimed_by, and handoff state for reviewer consumption."),
+            ],
+            "mechanism": [
+                "The current refactor slice must stay reviewable; overnight discoveries do not all land in one PR.",
+                "New discoveries become follow-up todos; changed routes supersede stale todos.",
+                "Each slice carries focused validation or doc/contract smoke evidence rather than raw agent traces.",
+                "Broad or unclear-risk slices route to review handoff instead of self-merge.",
+            ],
+            "user_outcome": [
+                "The user can let a refactor run overnight and wake up to bounded review units plus remaining todos, not one unreviewable giant change.",
+                "The project can move quickly while the review surface remains human-sized.",
+            ],
+            "source_refs": [
+                ("kanban control-plane adapter", "docs/lark-kanban-control-plane-adapter.md"),
+                ("heartbeat prompt contract", "docs/heartbeat-automation-prompt.md"),
+                ("todo lifecycle smoke", "examples/todo-lifecycle-cli-smoke.py"),
+                ("case narrative", "docs/showcases/cases/0623-overnight-project-refactor.md"),
+            ],
+        },
+    },
+    HARDWARE_CASE_ID: {
+        "zh": {
+            "context": ["hardware 中文页面是 canonical artifact，生成器不会重写。"],
+            "evidence": [],
+            "mechanism": [],
+            "user_outcome": [],
+            "source_refs": [],
+        },
+        "en": {
+            "context": [
+                "The Chinese hardware page remains the canonical artifact. This English companion follows its structure without rewriting the original.",
+                "The case demonstrates a dynamic workflow around fuzzy long-running hardware goals: generated scripts coordinate bounded worker-agent actions while LoopX preserves goal state, quota, todo ownership, validation evidence, and run history outside any one chat thread.",
+            ],
+            "evidence": [
+                ("Public artifact", "The canonical HTML page includes the approved hardware workflow artifact and five public-safe hardware cases."),
+                ("Case family", "The companion note names closed validation, timing optimization, design-space exploration, Fmax optimization, and convergence to an engineering floor."),
+                ("Boundary", "The public artifact excludes raw chats, screenshots, proprietary design details, private repos, local paths, task ids, credentials, and unpublished hardware artifacts."),
+            ],
+            "mechanism": [
+                "LoopX owns durable state, quota, todos, claims, evidence, and history.",
+                "Claude Code writes task-level orchestration and generated scripts.",
+                "Worker agents perform bounded RTL, simulation, and validation work under explicit review boundaries.",
+            ],
+            "user_outcome": [
+                "A contributor-approved page shows how multiple hardware-agent workers can coordinate under one control plane.",
+                "Readers can inspect the product pattern without receiving proprietary hardware details or raw execution traces.",
+            ],
+            "source_refs": [
+                ("canonical HTML", "docs/showcases/cases/0619-dynamic-workflow-hardware-agent.html"),
+                ("companion note", "docs/showcases/cases/0619-dynamic-workflow-hardware-agent.md"),
+            ],
+        },
+    },
+    "2026-06-19-loopx-self-iteration": {
+        "zh": {
+            "context": [
+                "这个案例是 public repo self-iteration：LoopX 用来推进 LoopX 自己，不是一个孤立功能 demo。仓库在 benchmark adapters、control-plane correctness、planning lanes、dashboard/frontstage、docs、smokes 和 multi-agent coordination 上同时高频变化。",
+                "证据窗口固定到 anchor commit `86d6d9d`，避免文档更新改变自己的证据。这里的效率模型是保守的 public Git model，不使用私有聊天、active-state 原文或 benchmark 原始材料。",
+            ],
+            "evidence": [
+                ("全仓库证据", "截至 anchor commit：801 个 public commits、570 个 touched files、265703 行新增、49895 行删除。"),
+                ("近期窗口", "2026-06-18 起有 244 个 public commits、216 个 touched files、52898 行新增、20935 行删除。"),
+                ("0619 当日", "2026-06-19 有 74 个 public commits、118 个 touched files、16087 行新增、1082 行删除。"),
+                ("效率模型", "把公开仓库能力拆成 9 个 requirement clusters，保守估计 59-92 个 AI-coding-assisted developer-days，对 19.6 天 public window 得出方向性 compression。"),
+            ],
+            "mechanism": [
+                "registry、prompt contracts 和 registered agents 命名 primary/side identities，不靠聊天记忆。",
+                "benchmark、productization、documentation、planning 和 side-agent lanes 被拆成 reviewable obligations。",
+                "quota/status projection 区分 executable work、monitor work、user gates 和 blockers。",
+                "side-agent scope 留在 prompt/handoff，todo metadata 只保留 `claimed_by`。",
+                "public docs 和 smokes 把可复用经验沉淀为仓库 artifact。",
+            ],
+            "user_outcome": [
+                "operator 可以让 primary benchmark lane 和 product/docs/control-plane side work 并行，而不会失去 ownership、gate、validation 和 merge discipline。",
+                "对潜在用户来说，这是“长期 agent 项目仍然可读”的证据：未来 agent 能从公开表面恢复目标、owner、gate、验证、证据和 follow-up。",
+            ],
+            "source_refs": [
+                ("case narrative", "docs/showcases/cases/0619-loopx-self-iteration.md"),
+                ("workload signal", "docs/showcases/showcase-catalog.json"),
+                ("frontstage fixture", "examples/fixtures/long-horizon-self-iteration-rollout.public.json"),
+                ("frontstage smoke", "examples/long-horizon-self-iteration-rollout-fixture-smoke.py"),
+            ],
+        },
+        "en": {
+            "context": [
+                "This is public-repo self-iteration: LoopX was used to improve LoopX itself, not just one isolated demo. Benchmark adapters, control-plane correctness, planning lanes, dashboard/frontstage, docs, smokes, and multi-agent coordination all moved under high churn.",
+                "The evidence is fixed to anchor commit `86d6d9d` so this documentation update does not change its own evidence window. The efficiency model is a conservative public-Git model; it excludes private chats, active-state bodies, and raw benchmark material.",
+            ],
+            "evidence": [
+                ("Whole repository", "Through the anchor commit: 801 public commits, 570 touched files, 265703 insertions, and 49895 deletions."),
+                ("Recent window", "Since 2026-06-18: 244 public commits, 216 touched files, 52898 insertions, and 20935 deletions."),
+                ("June 19 signal", "On 2026-06-19: 74 public commits, 118 touched files, 16087 insertions, and 1082 deletions."),
+                ("Efficiency model", "The case maps public repo capabilities to 9 requirement clusters and estimates 59-92 AI-coding-assisted developer-days against a 19.6-day public window."),
+            ],
+            "mechanism": [
+                "Registry and prompt contracts name primary and side-agent identities instead of relying on chat memory.",
+                "Benchmark, productization, documentation, planning, and side-agent lanes become reviewable obligations.",
+                "Quota and status projection distinguish executable work, monitor work, user gates, and blockers.",
+                "Side-agent scope lives in prompt and handoff; todo metadata keeps the compact `claimed_by` owner.",
+                "Public docs and smokes turn reusable lessons into repository artifacts.",
+            ],
+            "user_outcome": [
+                "The operator can let a primary benchmark lane and product/docs/control-plane side work run in parallel without losing ownership, gates, validation, or merge discipline.",
+                "For a potential user, this is evidence that a long-running agent project can remain legible: future agents can recover goals, owners, gates, validation, evidence, and follow-up from public surfaces.",
+            ],
+            "source_refs": [
+                ("case narrative", "docs/showcases/cases/0619-loopx-self-iteration.md"),
+                ("workload signal", "docs/showcases/showcase-catalog.json"),
+                ("frontstage fixture", "examples/fixtures/long-horizon-self-iteration-rollout.public.json"),
+                ("frontstage smoke", "examples/long-horizon-self-iteration-rollout-fixture-smoke.py"),
+            ],
+        },
+    },
+    "2026-06-17-blocked-p0-safe-rotation": {
+        "zh": {
+            "context": [
+                "这个案例展示 P0 被用户决策卡住时，系统不应该继续硬跑，也不应该让整个目标停摆。原场景是 benchmark rotation：一个 lane 需要大型本地 image，其他 no-upload benchmark work 仍然安全。",
+                "公开仓库没有暴露原始 benchmark task 或本地 image 名，而是用 synthetic smoke 复现控制面行为。",
+            ],
+            "evidence": [
+                ("synthetic fixture", "`examples/showcase-0617-blocked-p0-safe-rotation-smoke.py` 构造 P0 user gate、被 gate 阻塞的 P0 agent todo 和 P1 no-upload fallback。"),
+                ("quota contract", "smoke 断言 `should_run=True`、`requires_user_action=True`、`safe_bypass_allowed=True`、`safe_bypass_kind=scoped_user_gate_fallback`。"),
+                ("selected fallback", "fixture 选择 `terminal_bench_no_upload`，同时保留 `ale_image` gate 的 user-visible blocker。"),
+                ("rendered evidence", "smoke 检查 markdown 中包含 `scoped_user_gate_fallback` 和 safe no-upload Terminal-Bench rotation。"),
+            ],
+            "mechanism": [
+                "用户 todo 具体命名 P0 决策，不用“owner gate”这种空话。",
+                "agent 不在 gated lane 上花 compute；只选择不依赖该决策的 fallback。",
+                "状态同时记录 blocker 和 fallback reason，方便之后恢复 P0。",
+            ],
+            "user_outcome": [
+                "用户看到需要自己决定的具体问题，同时项目仍能在安全范围内推进。",
+                "这减少了注意力负担：不需要每 10 分钟看一次 agent 为什么没动，也不会错过真正需要决策的事项。",
+            ],
+            "source_refs": [
+                ("case narrative", "docs/showcases/cases/0617-blocked-p0-safe-rotation.md"),
+                ("synthetic smoke", "examples/showcase-0617-blocked-p0-safe-rotation-smoke.py"),
+            ],
+        },
+        "en": {
+            "context": [
+                "This case shows what should happen when a P0 route is blocked by a user decision: the system should neither keep forcing that lane nor stop the whole goal. The original shape was a benchmark rotation where one lane needed a large local image while other no-upload benchmark work remained safe.",
+                "The public repository does not expose raw benchmark tasks or local image names. It reproduces the control-plane behavior with a synthetic smoke.",
+            ],
+            "evidence": [
+                ("Synthetic fixture", "`examples/showcase-0617-blocked-p0-safe-rotation-smoke.py` creates a P0 user gate, a P0 agent todo blocked by that gate, and a P1 no-upload fallback."),
+                ("Quota contract", "The smoke asserts `should_run=True`, `requires_user_action=True`, `safe_bypass_allowed=True`, and `safe_bypass_kind=scoped_user_gate_fallback`."),
+                ("Selected fallback", "The fixture selects `terminal_bench_no_upload` while preserving the `ale_image` gate as the user-visible blocker."),
+                ("Rendered evidence", "The smoke checks markdown for `scoped_user_gate_fallback` and safe no-upload Terminal-Bench rotation."),
+            ],
+            "mechanism": [
+                "The user todo names the concrete P0 decision instead of saying only owner gate.",
+                "The agent does not spend compute on the gated lane; it selects fallback work that does not depend on the decision.",
+                "State records both the blocker and the fallback reason so P0 can resume later.",
+            ],
+            "user_outcome": [
+                "The user sees the exact decision they need to make while the project continues safely elsewhere.",
+                "Attention load drops: the user does not need to watch repeated idle polls and does not miss the real decision.",
+            ],
+            "source_refs": [
+                ("case narrative", "docs/showcases/cases/0617-blocked-p0-safe-rotation.md"),
+                ("synthetic smoke", "examples/showcase-0617-blocked-p0-safe-rotation-smoke.py"),
+            ],
+        },
+    },
+    "2026-06-20-creator-operator-case-spec": {
+        "zh": {
+            "context": [
+                "这是 appendix case：它展示非技术创作者/运营者如何用 LoopX 管一个长期 research + planning loop，但还不是 top-card proof，因为没有真实用户公开证据。",
+                "公开材料完全使用 synthetic data，重点是产品形态：趋势候选、偏好映射、insight board、draft queue、material library、人类反馈和 controlled replan。",
+            ],
+            "evidence": [
+                ("storyboard", "`creator-ops-fake-data-storyboard.md` 定义七个面板和完整 fake fixture，不需要 live platform access。"),
+                ("feedback contract", "`creator-ops-feedback-boundary-contract.md` 把 gate decision、preference hint、todo update、boundary correction、reward signal、product improvement note 分开。"),
+                ("source status", "contract 要求 topic、insight、draft、material item 都有 source status，public repo 默认 `synthetic_demo`。"),
+                ("no autopublish", "publishing 是 hard user gate；safe side work 可以继续，但不能把偏好或 reward 当成发布授权。"),
+            ],
+            "mechanism": [
+                "creative objective 是 durable goal state，不是聊天窗口里的隐形任务。",
+                "publish/no-publish 是 user gate；research、整理和 source-status 改进可以作为 safe side path。",
+                "反馈被写成 preference hint、gate decision、todo update 或 boundary correction。",
+                "下一次 agent run 前，用户能看到 blocked route、safe side path 和 validation expectation。",
+            ],
+            "user_outcome": [
+                "非技术用户不用读 prompt、trace 或 raw logs，就能知道上次改变了什么、什么在等自己、什么可以继续。",
+                "这个 case 适合展示产品方向，但页面会明确它是 synthetic spec，不声称真实增长、质量或收入效果。",
+            ],
+            "source_refs": [
+                ("case narrative", "docs/showcases/cases/0620-creator-operator-case-spec.md"),
+                ("fake-data storyboard", "docs/showcases/creator-ops-fake-data-storyboard.md"),
+                ("feedback boundary contract", "docs/showcases/creator-ops-feedback-boundary-contract.md"),
+            ],
+        },
+        "en": {
+            "context": [
+                "This is an appendix case: it shows how a non-technical creator-operator might use LoopX to manage a long-running research and planning loop, but it is not a top-card proof until real public user evidence exists.",
+                "The public material uses only synthetic data. The product shape is trend candidates, preference map, insight board, draft queue, material library, human feedback, and controlled replan.",
+            ],
+            "evidence": [
+                ("Storyboard", "`creator-ops-fake-data-storyboard.md` defines seven panels and a full fake fixture with no live platform access."),
+                ("Feedback contract", "`creator-ops-feedback-boundary-contract.md` separates gate decision, preference hint, todo update, boundary correction, reward signal, and product improvement note."),
+                ("Source status", "The contract requires every topic, insight, draft, and material item to carry source status; public repo defaults to `synthetic_demo`."),
+                ("No autopublish", "Publishing is a hard user gate; safe side work may continue, but preference or reward is not publication approval."),
+            ],
+            "mechanism": [
+                "The creative objective is durable goal state, not a hidden task inside chat.",
+                "Publish/no-publish is a user gate; research, organization, and source-status work can continue as safe side paths.",
+                "Feedback becomes a preference hint, gate decision, todo update, or boundary correction.",
+                "Before the next agent run, the user can see the blocked route, safe side path, and validation expectation.",
+            ],
+            "user_outcome": [
+                "A non-technical user can see what changed, what is waiting for them, and what can continue without reading prompts, traces, or raw logs.",
+                "The case is useful product direction, but the page clearly labels it as a synthetic spec and makes no claim about real growth, quality, or revenue.",
+            ],
+            "source_refs": [
+                ("case narrative", "docs/showcases/cases/0620-creator-operator-case-spec.md"),
+                ("fake-data storyboard", "docs/showcases/creator-ops-fake-data-storyboard.md"),
+                ("feedback boundary contract", "docs/showcases/creator-ops-feedback-boundary-contract.md"),
+            ],
+        },
+    },
+}
+
+UI = {
+    "en": {
+        "html_lang": "en",
+        "alternate": "中文",
+        "index_title": "Showcase & Good Case",
+        "index_subtitle": "Real LoopX cases showing how long-running agent work stays reviewable, verifiable, and safe to continue.",
+        "top_cases": "Top showcase cases",
+        "appendix": "Appendix case",
+        "proof": "Proof",
+        "intervention": "LoopX intervention",
+        "context": "Case context",
+        "evidence": "Repository evidence",
+        "behavior": "LoopX behavior",
+        "outcome": "What the user sees",
+        "sources": "Repository sources",
+        "boundary": "Evidence boundary",
+        "narrative": "Case note",
+        "catalog": "Catalog",
+        "home": "Showcases",
+        "canonical": "Canonical artifact",
+        "open": "Open",
+        "demo": "Demo",
+        "search": "Search showcase cases",
+        "footer": "Generated from docs/showcases/showcase-catalog.json. Private links, raw chats, local state, and internal media are excluded.",
+    },
+    "zh": {
+        "html_lang": "zh-CN",
+        "alternate": "English",
+        "index_title": "Showcase & Good Case",
+        "index_subtitle": "真实 LoopX 案例：长程 agent 工作如何保持可审阅、可验证、可继续推进。",
+        "top_cases": "顶部 Showcase 案例",
+        "appendix": "附录案例",
+        "proof": "证明点",
+        "intervention": "LoopX 介入",
+        "context": "案例背景",
+        "evidence": "仓库证据",
+        "behavior": "LoopX 行为",
+        "outcome": "用户看到什么",
+        "sources": "仓库来源",
+        "boundary": "证据边界",
+        "narrative": "案例说明",
+        "catalog": "Catalog",
+        "home": "Showcases",
+        "canonical": "Canonical 原页面",
+        "open": "打开",
+        "demo": "Demo",
+        "search": "搜索 showcase 案例",
+        "footer": "由 docs/showcases/showcase-catalog.json 生成。不包含私有链接、原始聊天、本地状态或内部媒体。",
+    },
+}
+
+
+def esc(value: object) -> str:
+    return html.escape(str(value), quote=True)
+
+
+def slug(value: object) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", str(value).lower()).strip("-") or "case"
+
+
+def repo_path(path: str) -> Path:
+    return (REPO_ROOT / path).resolve()
+
+
+def rel_href(source: Path, target: Path) -> str:
+    return os.path.relpath(target, source.parent).replace(os.sep, "/")
+
+
+def first_items(values: Any, limit: int = 6) -> list[str]:
+    if not isinstance(values, list):
+        return []
+    return [str(value) for value in values[:limit]]
+
+
+def ui(lang: str, key: str) -> str:
+    return UI[lang][key]
+
+
+def copy_for(case: dict[str, Any], lang: str) -> dict[str, Any]:
+    if lang == "zh":
+        return ZH_COPY.get(str(case.get("id")), {})
+    return {}
+
+
+def localized(case: dict[str, Any], lang: str, key: str) -> str:
+    copy = copy_for(case, lang)
+    value = copy.get(key)
+    if value is None:
+        value = case.get(key)
+    return str(value or "")
+
+
+def table_for(case: dict[str, Any], lang: str) -> dict[str, str]:
+    copy = copy_for(case, lang)
+    if copy:
+        return {
+            "proof_point": str(copy.get("proof_point") or ""),
+            "loopx_intervention": str(copy.get("loopx_intervention") or ""),
+        }
+    table = case.get("showcase_table")
+    if isinstance(table, dict):
+        return {
+            "proof_point": str(table.get("proof_point") or ""),
+            "loopx_intervention": str(table.get("loopx_intervention") or ""),
+        }
+    return SHOWCASE_TABLE.get(str(case.get("id")), {
+        "proof_point": str(case.get("headline") or ""),
+        "loopx_intervention": ", ".join(first_items(case.get("pattern_tags"), 4)),
+    })
+
+
+def details_for(case: dict[str, Any], lang: str) -> dict[str, Any]:
+    details = CASE_DETAILS.get(str(case.get("id")), {}).get(lang)
+    if isinstance(details, dict):
+        return details
+    return {
+        "context": [str(case.get("problem") or case.get("headline") or "")],
+        "evidence": [(ui(lang, "proof"), table_for(case, lang)["proof_point"])],
+        "mechanism": first_items(case.get("loopx_behavior"), 6),
+        "user_outcome": [str(case.get("user_value") or "")],
+        "source_refs": [(ui(lang, "narrative"), str(case.get("case_page") or ""))],
+    }
+
+
+def render_text_stack(items: list[str]) -> str:
+    cleaned = [item for item in items if item]
+    return '<div class="text-stack">' + "".join(f"<p>{esc(item)}</p>" for item in cleaned) + "</div>"
+
+
+def render_evidence_items(items: list[tuple[str, str]]) -> str:
+    cleaned = [(label, text) for label, text in items if label or text]
+    return '<div class="evidence-grid">' + "".join(
+        f'<div class="evidence-card"><div class="evidence-label">{esc(label)}</div><p>{esc(text)}</p></div>'
+        for label, text in cleaned
+    ) + "</div>"
+
+
+def render_source_refs(items: list[tuple[str, str]], current: Path) -> str:
+    links: list[str] = []
+    for label, path in items:
+        if not path:
+            continue
+        target = repo_path(path)
+        links.append(
+            f'<a class="source-ref" href="{esc(rel_href(current, target))}">'
+            f'<span>{esc(label)}</span><code>{esc(path)}</code></a>'
+        )
+    return '<div class="source-list">' + "".join(links) + "</div>"
+
+
+def case_html_path(case: dict[str, Any], lang: str) -> Path:
+    if str(case.get("id")) == HARDWARE_CASE_ID and lang == "zh":
+        return HARDWARE_CANONICAL_PAGE
+    case_page = str(case.get("case_page") or "")
+    if case_page.endswith(".md"):
+        base = repo_path(case_page[:-3] + ".html")
+    else:
+        base = CASES_DIR / f"{slug(case.get('id') or case.get('title'))}.html"
+    if lang == "en":
+        return base.with_name(f"{base.stem}.en{base.suffix}")
+    return base
+
+
+def index_path(lang: str) -> Path:
+    return SHOWCASE_DIR / ("index.en.html" if lang == "en" else "index.html")
+
+
+def is_hardware_canonical(case: dict[str, Any], lang: str) -> bool:
+    return str(case.get("id")) == HARDWARE_CASE_ID and lang == "zh"
+
+
+def assert_hardware_canonical() -> None:
+    text = HARDWARE_CANONICAL_PAGE.read_text(encoding="utf-8")
+    markers = [
+        "LoopX Hardware-Agent Dynamic Workflow",
+        "__bundler_thumbnail",
+        "__bundler/manifest",
+        "__bundler/template",
+        "loopx 在芯片开发任务上的实践",
+        "动态脚本编排",
+        "DUDUCoder",
+        "Claude Code",
+        "DUDU",
+        "CV32E40P",
+        "VeeR EH1",
+        "Viterbi",
+    ]
+    missing = [marker for marker in markers if marker not in text]
+    if missing:
+        raise AssertionError(f"canonical hardware showcase was overwritten or damaged: {missing!r}")
+
+
+def ordered_cases(cases: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    by_id = {str(case.get("id")): case for case in cases}
+    primary = [by_id[case_id] for case_id in PRIMARY_CASE_ORDER if case_id in by_id]
+    primary_ids = {str(case.get("id")) for case in primary}
+    appendix = [case for case in cases if str(case.get("id")) not in primary_ids]
+    return primary, appendix
+
+
+def badges(items: list[str]) -> str:
+    return "".join(f"<span>{esc(item)}</span>" for item in items)
+
+
+def css() -> str:
+    return """
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  body{background:#0b0b0c;color:#f1f2f3;font-family:'Geist',system-ui,-apple-system,BlinkMacSystemFont,sans-serif;-webkit-font-smoothing:antialiased}
+  a{color:inherit}
+  ::selection{background:color-mix(in srgb,var(--accent,#6e79d6) 34%,transparent);color:#fff}
+  .gh{min-height:100vh;position:relative;overflow-x:hidden;--accent:#6e79d6}
+  .grain{position:fixed;inset:0;pointer-events:none;opacity:.025;mix-blend-mode:overlay;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E")}
+  article{position:relative;max-width:800px;margin:0 auto;padding:76px 28px 130px}
+  .mlab{font-family:'Geist Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11px;letter-spacing:.06em;color:#62666d;text-transform:uppercase}
+  h1{font-size:clamp(31px,4.6vw,46px);font-weight:600;line-height:1.12;letter-spacing:-.03em;margin:16px 0 14px;color:#fafafa;text-wrap:balance}
+  h2{font-size:22px;font-weight:600;letter-spacing:-.02em;color:#f1f2f3}
+  h3{font-size:21px;font-weight:600;letter-spacing:-.02em;color:#f1f2f3}
+  p{font-size:15.5px;line-height:1.75;color:#9ea3aa}
+  strong{color:#e9eaec;font-weight:600}
+  code{font-family:'Geist Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:12.5px;color:#c4c7cc}
+  .accent{font-size:clamp(17px,2.1vw,21px);font-weight:500;color:var(--accent);letter-spacing:-.01em;margin-bottom:22px}
+  .nav{display:flex;gap:10px;flex-wrap:wrap;margin:0 0 28px}
+  .nav a,.case-link{font-family:'Geist Mono',ui-monospace,monospace;font-size:11px;letter-spacing:.04em;text-decoration:none;color:#c4c7cc;border:1px solid rgba(255,255,255,.12);border-radius:6px;padding:7px 10px;background:rgba(255,255,255,.025)}
+  .nav a:hover,.case-link:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent);color:#f4f4f5}
+  .section-head{margin-top:74px;display:flex;align-items:baseline;gap:13px;margin-bottom:20px}
+  .section-head span{font-family:'Geist Mono',ui-monospace,monospace;font-size:13px;color:var(--accent)}
+  .panel{border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;overflow:hidden}
+  .panel-row{display:grid;grid-template-columns:150px 1fr;border-top:1px solid rgba(255,255,255,.07)}
+  .panel-row:first-child{border-top:0}
+  .panel-key{padding:18px 20px;border-right:1px solid rgba(255,255,255,.07);font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:var(--accent);background:color-mix(in srgb,var(--accent) 8%,transparent);letter-spacing:.04em}
+  .panel-val{padding:18px 20px;display:flex;align-items:center}
+  .panel-val p{font-size:14px;line-height:1.6;margin:0}
+  .diagram{border:1px solid rgba(255,255,255,.1);border-radius:12px;padding:30px 24px 22px;background:#0e0e10;margin:22px 0}
+  .diagram svg{display:block;width:100%;height:auto}
+  .chips{display:flex;gap:8px;flex-wrap:wrap;margin-top:22px}
+  .chips span{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#888d95;border:1px solid rgba(255,255,255,.12);padding:4px 8px;border-radius:5px}
+  .text-stack{display:flex;flex-direction:column;gap:16px}
+  .evidence-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px;margin:20px 0 6px}
+  .evidence-card{border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;padding:18px 18px 17px;min-height:128px}
+  .evidence-label{font-family:'Geist Mono',ui-monospace,monospace;font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:var(--accent);margin-bottom:10px}
+  .source-list{display:flex;flex-direction:column;gap:10px;margin-top:20px}
+  .source-ref{display:grid;grid-template-columns:150px 1fr;gap:14px;align-items:center;text-decoration:none;border:1px solid rgba(255,255,255,.1);border-radius:8px;background:#0e0e10;padding:12px 14px}
+  .source-ref:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent)}
+  .source-ref span{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:var(--accent);text-transform:uppercase;letter-spacing:.04em}
+  .source-ref code{color:#aeb3ba;word-break:break-word}
+  .boundary-box{border-left:2px solid var(--accent);background:#0e0e10;padding:18px 20px;margin-top:16px;border-radius:0 8px 8px 0}
+  .flow{display:flex;flex-direction:column}
+  .flow li{display:grid;grid-template-columns:28px 1fr;gap:14px;list-style:none}
+  .flow-num{width:24px;height:24px;border-radius:50%;border:1px solid color-mix(in srgb,var(--accent) 50%,transparent);display:flex;align-items:center;justify-content:center;font-family:'Geist Mono',ui-monospace,monospace;font-size:11.5px;color:var(--accent);background:#0b0b0c}
+  .flow-body{padding-bottom:18px;border-left:1px solid rgba(255,255,255,.12);padding-left:14px;margin-left:-27px}
+  .flow-title{font-size:14.5px;color:#eceef0;font-weight:500;margin-bottom:7px}
+  .metric-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px;margin-top:22px}
+  .metric{border:1px solid rgba(255,255,255,.1);border-radius:10px;padding:17px 19px;background:#0c0c0e}
+  .metric strong{display:block;font-size:24px;letter-spacing:-.02em;color:#fafafa}
+  .metric span{display:block;margin-top:5px;font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#62666d;text-transform:uppercase}
+  .search{width:100%;height:42px;margin:22px 0 16px;border:1px solid rgba(255,255,255,.12);border-radius:8px;background:#0e0e10;color:#f1f2f3;padding:0 12px;font:14px 'Geist',system-ui,sans-serif}
+  .cards{display:flex;flex-direction:column;gap:12px}
+  .card{display:block;text-decoration:none;border:1px solid rgba(255,255,255,.1);border-radius:10px;background:#0e0e10;padding:18px 20px}
+  .card:hover{border-color:color-mix(in srgb,var(--accent) 55%,transparent)}
+  .card .meta{font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;color:#62666d;margin-bottom:8px}
+  .card p{font-size:14px;margin-top:9px}
+  .hide{display:none}
+  footer{margin-top:76px;color:#62666d;font-family:'Geist Mono',ui-monospace,monospace;font-size:10.5px;line-height:1.7}
+  @media(max-width:720px){article{padding:52px 18px 90px}.panel-row{grid-template-columns:1fr}.panel-key{border-right:0;border-bottom:1px solid rgba(255,255,255,.07)}.metric-grid,.evidence-grid{grid-template-columns:1fr}.source-ref{grid-template-columns:1fr;gap:6px}}
+"""
+
+
+def html_head(title: str) -> str:
+    return f"""<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{esc(title)}</title>
+  <link rel="icon" href="data:,">
+  <style>{css()}</style>
+</head>"""
+
+
+def nav(current: Path, lang: str, alternate: Path) -> str:
+    return f"""
+    <nav class="nav" aria-label="Showcase navigation">
+      <a href="{esc(rel_href(current, index_path(lang)))}">{esc(ui(lang, "home"))}</a>
+      <a href="{esc(rel_href(current, CATALOG))}">{esc(ui(lang, "catalog"))}</a>
+      <a href="{esc(rel_href(current, alternate))}">{esc(ui(lang, "alternate"))}</a>
+    </nav>
+"""
+
+
+def control_diagram(case: dict[str, Any], lang: str) -> str:
+    table = table_for(case, lang)
+    left = localized(case, lang, "title")[:22]
+    center = table["loopx_intervention"].replace("、", ",").split(",")[0].strip()[:24] or "LoopX"
+    right = str(case.get("status") or "public case").replace("_", " ")[:24]
+    return f"""
+    <div class="diagram" aria-label="LoopX control-plane sketch">
+      <svg viewBox="0 0 760 320" role="img">
+        <rect width="760" height="320" fill="#0e0e10"></rect>
+        <rect x="285" y="34" width="190" height="58" rx="8" fill="none" stroke="#6e79d6" stroke-width="2"></rect>
+        <text x="380" y="68" text-anchor="middle" fill="#f1f2f3" font-size="15" font-weight="600">LoopX</text>
+        <line x1="380" y1="92" x2="380" y2="132" stroke="#3a3d42" stroke-width="2"></line>
+        <rect x="52" y="132" width="180" height="78" rx="8" fill="none" stroke="#6a6e76" stroke-width="2"></rect>
+        <rect x="290" y="124" width="180" height="94" rx="8" fill="#6e79d6" fill-opacity=".16" stroke="#6e79d6" stroke-width="2"></rect>
+        <rect x="528" y="132" width="180" height="78" rx="8" fill="none" stroke="#6a6e76" stroke-width="2"></rect>
+        <text x="142" y="166" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">{esc(left)}</text>
+        <text x="380" y="163" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">{esc(center)}</text>
+        <text x="618" y="166" text-anchor="middle" fill="#f1f2f3" font-size="13" font-weight="600">{esc(right)}</text>
+        <text x="142" y="188" text-anchor="middle" fill="#62666d" font-size="11">goal / trigger</text>
+        <text x="380" y="185" text-anchor="middle" fill="#62666d" font-size="11">todo / gate / evidence</text>
+        <text x="618" y="188" text-anchor="middle" fill="#62666d" font-size="11">public outcome</text>
+        <line x1="232" y1="171" x2="282" y2="171" stroke="#6e79d6" stroke-width="2"></line>
+        <polygon points="290,171 280,165 280,177" fill="#6e79d6"></polygon>
+        <line x1="470" y1="171" x2="520" y2="171" stroke="#6e79d6" stroke-width="2"></line>
+        <polygon points="528,171 518,165 518,177" fill="#6e79d6"></polygon>
+        <path d="M618 210 L618 260 L142 260 L142 218" fill="none" stroke="#5a5e65" stroke-width="2"></path>
+        <polygon points="142,210 136,221 148,221" fill="#8a8088"></polygon>
+      </svg>
+    </div>
+"""
+
+
+def metrics(case: dict[str, Any]) -> str:
+    workload = case.get("workload_signal")
+    if not isinstance(workload, dict):
+        return ""
+    cards: list[tuple[str, str]] = []
+    public_git = workload.get("public_git") if isinstance(workload.get("public_git"), dict) else {}
+    whole = workload.get("whole_repository") if isinstance(workload.get("whole_repository"), dict) else {}
+    window = workload.get("window") if isinstance(workload.get("window"), dict) else {}
+    model = workload.get("efficiency_model") if isinstance(workload.get("efficiency_model"), dict) else {}
+    estimated = model.get("estimated_developer_days") if isinstance(model.get("estimated_developer_days"), dict) else {}
+    compression = model.get("single_engineer_calendar_compression") if isinstance(model.get("single_engineer_calendar_compression"), dict) else {}
+    if public_git.get("merged_commits") is not None:
+        cards.append((str(public_git["merged_commits"]), "merged PR commits"))
+    if window.get("hours") is not None:
+        cards.append((f"{window['hours']}h", "public window"))
+    if whole.get("commit_count") is not None:
+        cards.append((str(whole["commit_count"]), "public commits"))
+    if estimated.get("low") and estimated.get("high"):
+        cards.append((f"{estimated['low']}-{estimated['high']}d", "AI-assisted baseline"))
+    if compression.get("low") and compression.get("high"):
+        cards.append((f"{compression['low']}-{compression['high']}x", "calendar compression"))
+    if not cards:
+        return ""
+    return '<div class="metric-grid">' + "".join(
+        f'<div class="metric"><strong>{esc(value)}</strong><span>{esc(label)}</span></div>'
+        for value, label in cards[:4]
+    ) + "</div>"
+
+
+def render_case_page(case: dict[str, Any], lang: str, primary: bool) -> str:
+    output = case_html_path(case, lang)
+    alternate = case_html_path(case, "en" if lang == "zh" else "zh")
+    title = localized(case, lang, "title")
+    headline = localized(case, lang, "headline")
+    table = table_for(case, lang)
+    details = details_for(case, lang)
+    frontend = case.get("frontend_card") if isinstance(case.get("frontend_card"), dict) else {}
+    tags = first_items(frontend.get("badges"), 5) or first_items(case.get("pattern_tags"), 5)
+    behavior = [str(item) for item in details.get("mechanism", [])][:8] or first_items(case.get("loopx_behavior"), 6)
+    narrative = repo_path(str(case.get("case_page") or ""))
+    demo = case.get("demo_command")
+    storyboard = case.get("storyboard_path")
+    feedback = case.get("feedback_contract_path")
+    appendix = "" if primary else f'<span>{esc(ui(lang, "appendix"))}</span>'
+    links = [f'<a class="case-link" href="{esc(rel_href(output, narrative))}">{esc(ui(lang, "narrative"))}</a>']
+    if isinstance(storyboard, str):
+        links.append(f'<a class="case-link" href="{esc(rel_href(output, repo_path(storyboard)))}">Storyboard</a>')
+    if isinstance(feedback, str):
+        links.append(f'<a class="case-link" href="{esc(rel_href(output, repo_path(feedback)))}">Feedback</a>')
+    demo_block = f'<div class="metric"><strong>{esc(ui(lang, "demo"))}</strong><span><code>{esc(demo)}</code></span></div>' if isinstance(demo, str) and demo else ""
+    behavior_list = "".join(
+        f'<li><span class="flow-num">{index}</span><div class="flow-body"><div class="flow-title">{esc(item)}</div></div></li>'
+        for index, item in enumerate(behavior, start=1)
+    )
+    context_block = render_text_stack([str(item) for item in details.get("context", [])])
+    evidence_block = render_evidence_items([(str(label), str(text)) for label, text in details.get("evidence", [])])
+    outcome_block = render_text_stack([str(item) for item in details.get("user_outcome", [])])
+    sources_block = render_source_refs([(str(label), str(path)) for label, path in details.get("source_refs", [])], output)
+    return f"""<!doctype html>
+<html lang="{esc(ui(lang, "html_lang"))}">
+{html_head("LoopX Showcase: " + title)}
+<body>
+<div class="gh">
+  <div class="grain"></div>
+  <article>
+    {nav(output, lang, alternate)}
+    <div class="mlab">{esc(case.get("date") or "")} · {esc(case.get("domain") or "")}</div>
+    <h1>{esc(title)}</h1>
+    <div class="accent">{esc(headline)}</div>
+    <p>{esc(case.get("user_value") or "")}</p>
+    <div class="chips">{badges(tags)}{appendix}</div>
+    {control_diagram(case, lang)}
+
+    <div class="section-head"><span>01</span><h2>{esc(ui(lang, "context"))}</h2></div>
+    {context_block}
+
+    <div class="section-head"><span>02</span><h2>{esc(ui(lang, "evidence"))}</h2></div>
+    <div class="panel">
+      <div class="panel-row"><div class="panel-key">{esc(ui(lang, "proof"))}</div><div class="panel-val"><p>{esc(table["proof_point"])}</p></div></div>
+      <div class="panel-row"><div class="panel-key">{esc(ui(lang, "intervention"))}</div><div class="panel-val"><p>{esc(table["loopx_intervention"])}</p></div></div>
+    </div>
+    {metrics(case)}
+    {evidence_block}
+
+    <div class="section-head"><span>03</span><h2>{esc(ui(lang, "behavior"))}</h2></div>
+    <ul class="flow">{behavior_list}</ul>
+
+    <div class="section-head"><span>04</span><h2>{esc(ui(lang, "outcome"))}</h2></div>
+    {outcome_block}
+
+    <div class="section-head"><span>05</span><h2>{esc(ui(lang, "sources"))}</h2></div>
+    {sources_block}
+    <div class="boundary-box"><p><strong>{esc(ui(lang, "boundary"))}.</strong> {esc(case.get("evidence_boundary") or "")}</p></div>
+    <div class="chips">{''.join(links)}</div>
+    {demo_block}
+    <footer>{esc(ui(lang, "footer"))}</footer>
+  </article>
+</div>
+</body>
+</html>
+"""
+
+
+def index_card(case: dict[str, Any], current: Path, lang: str) -> str:
+    output = case_html_path(case, lang)
+    title = localized(case, lang, "title")
+    headline = localized(case, lang, "headline")
+    table = table_for(case, lang)
+    tags = first_items(case.get("pattern_tags"), 4)
+    search = " ".join([title, headline, table["proof_point"], table["loopx_intervention"], *tags]).lower()
+    canonical = f'<span>{esc(ui(lang, "canonical"))}</span>' if str(case.get("id")) == HARDWARE_CASE_ID and lang == "zh" else ""
+    return f"""
+      <a class="card" href="{esc(rel_href(current, output))}" data-search="{esc(search)}">
+        <div class="meta">{esc(case.get("date") or "")} · {esc(case.get("status") or "")}</div>
+        <h3>{esc(title)}</h3>
+        <p>{esc(headline)}</p>
+        <p><strong>{esc(ui(lang, "proof"))}:</strong> {esc(table["proof_point"])}</p>
+        <div class="chips">{badges(tags)}{canonical}</div>
+      </a>
+"""
+
+
+def render_index(cases: list[dict[str, Any]], lang: str) -> str:
+    primary, appendix = ordered_cases(cases)
+    current = index_path(lang)
+    alternate = index_path("en" if lang == "zh" else "zh")
+    primary_cards = "\n".join(index_card(case, current, lang) for case in primary)
+    appendix_cards = "\n".join(index_card(case, current, lang) for case in appendix)
+    return f"""<!doctype html>
+<html lang="{esc(ui(lang, "html_lang"))}">
+{html_head("LoopX " + ui(lang, "index_title"))}
+<body>
+<div class="gh">
+  <div class="grain"></div>
+  <article>
+    {nav(current, lang, alternate)}
+    <div class="mlab">LoopX · public-safe case surface</div>
+    <h1>{esc(ui(lang, "index_title"))}</h1>
+    <div class="accent">{esc(ui(lang, "index_subtitle"))}</div>
+    <p>LoopX preserves goals, gates, todos, claims, quota, run history, and evidence outside any single agent session.</p>
+    {control_diagram({"title": ui(lang, "index_title"), "status": "public surface", "domain": "showcase catalog", "showcase_table": {"proof_point": ui(lang, "index_subtitle"), "loopx_intervention": "catalog, pages, evidence boundary"}}, lang)}
+
+    <div class="section-head"><span>01</span><h2>{esc(ui(lang, "top_cases"))}</h2></div>
+    <input class="search" id="case-search" type="search" placeholder="{esc(ui(lang, "search"))}" aria-label="{esc(ui(lang, "search"))}">
+    <div class="cards" data-cards>{primary_cards}</div>
+
+    <div class="section-head"><span>02</span><h2>{esc(ui(lang, "appendix"))}</h2></div>
+    <div class="cards">{appendix_cards}</div>
+    <footer>{esc(ui(lang, "footer"))}</footer>
+  </article>
+</div>
+<script>
+const input = document.getElementById('case-search');
+const cards = Array.from(document.querySelectorAll('[data-search]'));
+input.addEventListener('input', () => {{
+  const query = input.value.trim().toLowerCase();
+  for (const card of cards) {{
+    card.classList.toggle('hide', query && !card.dataset.search.includes(query));
+  }}
+}});
+</script>
+</body>
+</html>
+"""
+
+
+def update_catalog(catalog: dict[str, Any]) -> dict[str, Any]:
+    cases = catalog.get("cases")
+    if not isinstance(cases, list):
+        raise ValueError("catalog must contain cases")
+    by_id = {str(case.get("id")): case for case in cases}
+    reordered = [by_id.pop(case_id) for case_id in PRIMARY_CASE_ORDER if case_id in by_id]
+    reordered.extend(by_id.values())
+    for rank, case in enumerate(reordered, start=1):
+        zh_path = case_html_path(case, "zh").relative_to(REPO_ROOT).as_posix()
+        en_path = case_html_path(case, "en").relative_to(REPO_ROOT).as_posix()
+        case["interactive_page"] = zh_path
+        case["interactive_page_zh"] = zh_path
+        case["interactive_page_en"] = en_path
+        case["localized_pages"] = {"zh": zh_path, "en": en_path}
+        case_id = str(case.get("id"))
+        if case_id in PRIMARY_CASE_ORDER:
+            case["showcase_rank"] = rank
+            case["showcase_table"] = SHOWCASE_TABLE[case_id]
+            if not isinstance(case.get("frontend_card"), dict):
+                metaphor, default_badges = DEFAULT_FRONTEND.get(
+                    case_id,
+                    ("a LoopX control-plane rail turns ambiguous agent work into reviewable evidence", first_items(case.get("pattern_tags"), 3)),
+                )
+                case["frontend_card"] = {
+                    "visual_metaphor": metaphor,
+                    "primary_metric_hint": SHOWCASE_TABLE[case_id]["proof_point"],
+                    "badges": default_badges,
+                    "story_beats": first_items(case.get("loopx_behavior"), 4),
+                }
+            case.pop("appendix_surface", None)
+    catalog["cases"] = reordered
+    return catalog
+
+
+def read_catalog() -> dict[str, Any]:
+    return json.loads(CATALOG.read_text(encoding="utf-8"))
+
+
+def clean(text: str) -> str:
+    return "\n".join(line.rstrip() for line in text.splitlines()) + "\n"
+
+
+def write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(clean(text), encoding="utf-8")
+
+
+def generate(write_files: bool) -> list[Path]:
+    catalog = update_catalog(read_catalog())
+    cases = catalog["cases"]
+    primary, appendix = ordered_cases(cases)
+    outputs: list[Path] = []
+    if write_files:
+        CATALOG.write_text(json.dumps(catalog, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    for case in primary + appendix:
+        for lang in ("zh", "en"):
+            output = case_html_path(case, lang)
+            outputs.append(output)
+            if is_hardware_canonical(case, lang):
+                assert_hardware_canonical()
+                continue
+            if write_files:
+                write(output, render_case_page(case, lang, primary=case in primary))
+    for lang in ("zh", "en"):
+        output = index_path(lang)
+        outputs.append(output)
+        if write_files:
+            write(output, render_index(cases, lang))
+    return outputs
+
+
+def check() -> None:
+    catalog = update_catalog(read_catalog())
+    expected_catalog = json.dumps(catalog, ensure_ascii=False, indent=2) + "\n"
+    if CATALOG.read_text(encoding="utf-8") != expected_catalog:
+        raise AssertionError("showcase catalog is not normalized; run examples/showcase-html-pages.py")
+    cases = catalog["cases"]
+    primary, appendix = ordered_cases(cases)
+    for case in primary + appendix:
+        for lang in ("zh", "en"):
+            output = case_html_path(case, lang)
+            if is_hardware_canonical(case, lang):
+                assert_hardware_canonical()
+                continue
+            expected = clean(render_case_page(case, lang, primary=case in primary))
+            if output.read_text(encoding="utf-8") != expected:
+                raise AssertionError(f"{output.relative_to(REPO_ROOT)} is not generated from the catalog")
+    for lang in ("zh", "en"):
+        output = index_path(lang)
+        expected = clean(render_index(cases, lang))
+        if output.read_text(encoding="utf-8") != expected:
+            raise AssertionError(f"{output.relative_to(REPO_ROOT)} is not generated from the catalog")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="Verify catalog and generated HTML files.")
+    args = parser.parse_args()
+    if args.check:
+        check()
+        print("showcase-html-pages check ok")
+        return 0
+    for output in generate(write_files=True):
+        print(output.relative_to(REPO_ROOT).as_posix())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add bilingual public showcase index and case HTML pages for the approved showcase set
- keep the canonical hardware Chinese HTML page untouched while adding an English companion
- generate the pages from `docs/showcases/showcase-catalog.json` via `examples/showcase-html-pages.py`
- update showcase catalog, animation storyboard/prototype, bundle copy logic, and focused smokes

## Validation
- `python3 examples/showcase-html-pages.py --check`
- `python3 examples/showcase-catalog-smoke.py`
- `node examples/frontstage-share-bundle-smoke.mjs`
- `python3 examples/showcase-frontstage-prototype-smoke.py`
- `python3 examples/showcase-animation-source-boundary-smoke.py`
- `python3 examples/showcase-animation-prototype-smoke.py`
- `python3 -m py_compile examples/showcase-html-pages.py examples/showcase-animation-prototype.py examples/showcase-catalog-smoke.py examples/showcase-frontstage-prototype.py examples/showcase-frontstage-prototype-smoke.py examples/showcase-animation-source-boundary-smoke.py examples/showcase-animation-prototype-smoke.py`
- `git diff --check origin/main...HEAD`
- `loopx check --scan-path docs/showcases --scan-path examples/showcase-html-pages.py --scan-path examples/showcase-catalog-smoke.py --scan-path examples/showcase-frontstage-prototype.py --scan-path examples/showcase-frontstage-prototype-smoke.py --scan-path examples/showcase-animation-source-boundary-smoke.py --scan-path examples/showcase-animation-prototype.py --scan-path examples/showcase-animation-prototype-smoke.py --scan-path examples/export-frontstage-share-bundle.mjs --scan-path examples/frontstage-share-bundle-smoke.mjs`

## Boundary
- public docs/examples only; no `.local`, run history, credentials, raw logs, or local state
- private-marker scan hits were expected boundary text and smoke sentinels only
- not a Lark Kanban change
