### PR TITLE
Add update notes draft PR automation

### DIFF
--- a/.github/workflows/update-notes.yml
+++ b/.github/workflows/update-notes.yml
@@ -1,0 +1,91 @@
+name: Biweekly Update Notes
+
+on:
+  workflow_dispatch:
+    inputs:
+      since:
+        description: "Optional window start date, YYYY-MM-DD"
+        required: false
+        type: string
+      until:
+        description: "Optional window end date, YYYY-MM-DD"
+        required: false
+        type: string
+      force:
+        description: "Generate even if the inferred window is not due yet"
+        required: false
+        default: false
+        type: boolean
+  schedule:
+    # Runs weekly; the generator is the biweekly gate and no-ops until a window closes.
+    - cron: "17 3 * * 0"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: biweekly-update-notes
+  cancel-in-progress: false
+
+jobs:
+  draft-update-note-pr:
+    if: github.repository == 'huangruiteng/loopx'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate update note draft
+        id: generate
+        env:
+          UPDATE_NOTES_SINCE: ${{ inputs.since }}
+          UPDATE_NOTES_UNTIL: ${{ inputs.until }}
+          UPDATE_NOTES_FORCE: ${{ inputs.force }}
+        run: |
+          set -euo pipefail
+          cmd=(python3 scripts/update_notes_release_job.py)
+          if [[ -n "${UPDATE_NOTES_SINCE}" || -n "${UPDATE_NOTES_UNTIL}" ]]; then
+            cmd+=(--since "${UPDATE_NOTES_SINCE}" --until "${UPDATE_NOTES_UNTIL}")
+          fi
+          if [[ "${UPDATE_NOTES_FORCE}" == "true" ]]; then
+            cmd+=(--force)
+          fi
+          "${cmd[@]}"
+
+      - name: Validate update-note archive
+        if: steps.generate.outputs.changed == 'true'
+        run: |
+          python3 -m py_compile scripts/update_notes_release_job.py examples/update-notes-archive-smoke.py
+          python3 examples/update-notes-archive-smoke.py
+          git diff --check
+          python3 -m loopx.cli check \
+            --scan-path .github/workflows/update-notes.yml \
+            --scan-path scripts/update_notes_release_job.py \
+            --scan-path docs/update-notes \
+            --scan-path examples/update-notes-archive-smoke.py
+
+      - name: Open update-note PR
+        if: steps.generate.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: codex/biweekly-update-notes-${{ steps.generate.outputs.window_slug }}
+          delete-branch: true
+          draft: true
+          title: Add biweekly update note ${{ steps.generate.outputs.window }}
+          commit-message: Add biweekly update note ${{ steps.generate.outputs.window }}
+          body: |
+            ## Summary
+            - generated the next public-safe biweekly update-note source draft from public git history
+            - updated the update-note archive and latest pointer
+
+            This workflow does not use an LLM. Treat the generated note as a factual source packet and draft PR; a maintainer or LoopX agent should refine the narrative before marking this PR ready.
+
+            ## Validation
+            - python3 -m py_compile scripts/update_notes_release_job.py examples/update-notes-archive-smoke.py
+            - python3 examples/update-notes-archive-smoke.py
+            - git diff --check
+            - python3 -m loopx.cli check --scan-path .github/workflows/update-notes.yml --scan-path scripts/update_notes_release_job.py --scan-path docs/update-notes --scan-path examples/update-notes-archive-smoke.py

--- a/docs/update-notes/README.md
+++ b/docs/update-notes/README.md
@@ -35,5 +35,6 @@ operator-only state are intentionally excluded.
 ## Automation
 
 See [Biweekly update-note automation](automation.md) for the recommended
-publication path. The short version: use a separate release-note job that opens
-a reviewable PR, not custom logic inside the active LoopX heartbeat.
+publication path. The short version: `.github/workflows/update-notes.yml` runs
+a separate release-note job that opens a reviewable PR, not custom logic inside
+the active LoopX heartbeat.

--- a/docs/update-notes/automation.md
+++ b/docs/update-notes/automation.md
@@ -22,26 +22,37 @@ Mixing the two would create avoidable friction:
 
 ## Recommended Shape
 
-Use a dedicated release-note job that opens a PR. It can live as a GitHub
-Actions workflow, an external scheduled worker, or a thin `loopx update-notes`
-CLI subcommand once the generator is stable.
+Use a dedicated release-note job that opens a draft PR. The repository ships
+the first version as `.github/workflows/update-notes.yml`, backed by
+`scripts/update_notes_release_job.py`. A future `loopx update-notes` CLI
+subcommand can wrap the same contract once the generator is stable.
+
+The GitHub Action does not have an LLM. It should therefore generate a factual
+source draft from public git history, not pretend to write final narrative. A
+maintainer or LoopX agent should refine the draft PR before marking it ready.
 
 The job should:
 
-1. Determine the next window from `docs/update-notes/README.md`.
-2. Collect public git history and merged PR titles for that window.
+1. Determine the next window from existing note filenames in
+   `docs/update-notes/`.
+2. Collect public git history for that window.
 3. Group changes into stable product themes rather than dumping commit logs.
 4. Write a new note under `docs/update-notes/`.
 5. Update the archive table and latest-note pointer.
 6. Keep the root README as a compact pointer, not a long changelog.
 7. Run the update-note smoke and `loopx check` over the touched public docs.
-8. Open a reviewable PR instead of pushing directly to `main`.
+8. Open a reviewable draft PR instead of pushing directly to `main`.
 
 ## Trigger Policy
 
-The cadence is anchored to the initial public scaffold on 2026-05-31. The job
-should run every two weeks after a window closes, with `workflow_dispatch` for
-manual repair or backfill.
+The cadence is anchored to the initial public scaffold on 2026-05-31. GitHub
+Actions cron cannot express a reviewable "every two weeks after this anchored
+window closes" rule cleanly, so the workflow runs weekly and lets the generator
+be the biweekly gate. If the next window is not due, the script exits without
+changes and no PR is opened.
+
+Manual `workflow_dispatch` supports repair and backfill through optional
+`since`, `until`, and `force` inputs.
 
 The recommended first scheduled publication after this archive is for
 2026-06-28 to 2026-07-11, opened for review on or after 2026-07-12.
@@ -55,12 +66,20 @@ The recommended first scheduled publication after this archive is for
 - Keep generated notes short enough to review manually.
 - Fail closed if the generator cannot determine the prior window.
 - Prefer opening a draft PR when classification confidence is low.
+- Do not require an LLM secret for the default job.
 - Treat update notes as a summary surface. They do not replace git history,
   review packets, or LoopX state.
 
 ## Future CLI Contract
 
-A future CLI surface could look like:
+The current project-level command is:
+
+```bash
+python3 scripts/update_notes_release_job.py --dry-run
+python3 scripts/update_notes_release_job.py --since 2026-06-28 --until 2026-07-11 --force
+```
+
+A future CLI surface could wrap the same generator:
 
 ```bash
 loopx update-notes plan --since 2026-06-28 --until 2026-07-11
@@ -68,6 +87,8 @@ loopx update-notes write --since 2026-06-28 --until 2026-07-11 --dry-run
 loopx update-notes write --since 2026-06-28 --until 2026-07-11 --open-pr
 ```
 
-The first implementation should stay dry-run first. Publishing remains a
-reviewed PR until the public/private boundary and grouping quality are proven
-stable.
+Publishing remains a reviewed PR until the public/private boundary and grouping
+quality are proven stable. If the project later wants fully written prose from
+CI, add an explicit optional LLM step with a repository secret and fail closed
+when that secret is absent; keep the deterministic source-draft mode as the
+default.

--- a/examples/update-notes-archive-smoke.py
+++ b/examples/update-notes-archive-smoke.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import re
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -12,10 +13,9 @@ DOCS_INDEX = ROOT / "docs" / "README.md"
 NOTES_DIR = ROOT / "docs" / "update-notes"
 NOTES_INDEX = NOTES_DIR / "README.md"
 AUTOMATION = NOTES_DIR / "automation.md"
-NOTE_FILES = [
-    NOTES_DIR / "2026-05-31-to-2026-06-13.md",
-    NOTES_DIR / "2026-06-14-to-2026-06-27.md",
-]
+WORKFLOW = ROOT / ".github" / "workflows" / "update-notes.yml"
+GENERATOR = ROOT / "scripts" / "update_notes_release_job.py"
+NOTE_FILE_RE = re.compile(r"\d{4}-\d{2}-\d{2}-to-\d{4}-\d{2}-\d{2}\.md$")
 
 FORBIDDEN_PUBLIC_STRINGS = [
     "/Users/",
@@ -52,21 +52,31 @@ def validate_public_boundary(path: Path) -> None:
         assert_not_contains(text, forbidden, label)
 
 
+def note_files() -> list[Path]:
+    files = sorted(path for path in NOTES_DIR.glob("*.md") if NOTE_FILE_RE.match(path.name))
+    if len(files) < 2:
+        raise AssertionError("expected at least two archived update notes")
+    return files
+
+
 def validate_indexes() -> None:
     root_readme = read(README)
     docs_index = read(DOCS_INDEX)
     notes_index = read(NOTES_INDEX)
+    files = note_files()
 
     assert_contains(root_readme, "docs/update-notes/README.md", "root README")
     assert_contains(docs_index, "update-notes/README.md", "docs README")
-    assert_contains(notes_index, "2026-06-14-to-2026-06-27.md", "notes index")
-    assert_contains(notes_index, "2026-05-31-to-2026-06-13.md", "notes index")
+    for note in files:
+        assert_contains(notes_index, note.name, "notes index")
+    assert_contains(notes_index, files[-1].name, "notes index latest")
     assert_contains(notes_index, "automation.md", "notes index")
-    assert_contains(notes_index, "2026-06-28 to 2026-07-11", "notes index")
+    if not re.search(r"Next expected window: \d{4}-\d{2}-\d{2} to \d{4}-\d{2}-\d{2}\.", notes_index):
+        raise AssertionError("notes index missing next expected window")
 
 
 def validate_notes() -> None:
-    for note in NOTE_FILES:
+    for note in note_files():
         text = read(note)
         label = str(note.relative_to(ROOT))
         assert_contains(text, "# Biweekly Update Note:", label)
@@ -75,30 +85,46 @@ def validate_notes() -> None:
         assert_contains(text, "## What Shipped", label)
         assert_contains(text, "## Validation And Public Boundary", label)
 
-    latest = read(NOTE_FILES[-1])
-    assert_contains(latest, "`/loopx <goal>`", "latest note")
-    assert_contains(latest, "issue-fix", "latest note")
-    assert_contains(latest, "Task graph", "latest note")
-
 
 def validate_automation_plan() -> None:
     text = read(AUTOMATION)
     assert_contains(text, "separate publication workflow", "automation plan")
+    assert_contains(text, ".github/workflows/update-notes.yml", "automation plan")
+    assert_contains(text, "scripts/update_notes_release_job.py", "automation plan")
     assert_contains(text, "custom behavior", "automation plan")
     assert_contains(text, "active heartbeat", "automation plan")
     assert_contains(text, "workflow_dispatch", "automation plan")
-    assert_contains(text, "Open a reviewable PR", "automation plan")
+    assert_contains(text, "since", "automation plan")
+    assert_contains(text, "until", "automation plan")
+    assert_contains(text, "Open a reviewable draft PR", "automation plan")
     assert_contains(text, "2026-07-12", "automation plan")
     assert_contains(text, "--dry-run", "automation plan")
     assert_contains(text, "--open-pr", "automation plan")
 
 
+def validate_project_automation() -> None:
+    workflow = read(WORKFLOW)
+    generator = read(GENERATOR)
+    assert_contains(workflow, "schedule:", "update notes workflow")
+    assert_contains(workflow, "workflow_dispatch:", "update notes workflow")
+    assert_contains(workflow, "fetch-depth: 0", "update notes workflow")
+    assert_contains(workflow, "scripts/update_notes_release_job.py", "update notes workflow")
+    assert_contains(workflow, "peter-evans/create-pull-request", "update notes workflow")
+    assert_contains(workflow, "draft: true", "update notes workflow")
+    assert_contains(generator, "def infer_next_window", "update notes generator")
+    assert_contains(generator, "def collect_commits", "update notes generator")
+    assert_contains(generator, "GITHUB_OUTPUT", "update notes generator")
+    assert_contains(generator, "does not use an LLM", "update notes generator")
+    assert_contains(generator, "does not include private operator state", "update notes generator")
+
+
 def main() -> None:
-    for path in [README, DOCS_INDEX, NOTES_INDEX, AUTOMATION, *NOTE_FILES]:
+    for path in [README, DOCS_INDEX, NOTES_INDEX, AUTOMATION, WORKFLOW, GENERATOR, *note_files()]:
         validate_public_boundary(path)
     validate_indexes()
     validate_notes()
     validate_automation_plan()
+    validate_project_automation()
     print("update notes archive smoke: ok")
 
 

--- a/scripts/update_notes_release_job.py
+++ b/scripts/update_notes_release_job.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""Generate the next public-safe biweekly LoopX update note.
+
+This script is intentionally deterministic and source-limited: it reads the
+public repository history plus docs/update-notes/README.md, writes a draft note,
+and updates the archive pointers. It does not read LoopX runtime state, chat
+history, local private files, raw benchmark traces, or credentials.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+from dataclasses import dataclass
+from datetime import date, timedelta
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTES_DIR = ROOT / "docs" / "update-notes"
+NOTES_INDEX = NOTES_DIR / "README.md"
+WINDOW_RE = re.compile(r"(?P<since>\d{4}-\d{2}-\d{2})-to-(?P<until>\d{4}-\d{2}-\d{2})\.md$")
+
+
+@dataclass(frozen=True)
+class Window:
+    since: date
+    until: date
+
+    @property
+    def label(self) -> str:
+        return f"{self.since.isoformat()} to {self.until.isoformat()}"
+
+    @property
+    def filename(self) -> str:
+        return f"{self.since.isoformat()}-to-{self.until.isoformat()}.md"
+
+    @property
+    def slug(self) -> str:
+        return f"{self.since.isoformat()}-to-{self.until.isoformat()}"
+
+    @property
+    def open_after(self) -> date:
+        return self.until + timedelta(days=1)
+
+    @property
+    def next_window(self) -> "Window":
+        next_since = self.until + timedelta(days=1)
+        return Window(next_since, next_since + timedelta(days=13))
+
+
+@dataclass(frozen=True)
+class Commit:
+    sha: str
+    subject: str
+
+
+THEMES: list[tuple[str, tuple[str, ...], str]] = [
+    (
+        "Issue-fix workflow",
+        ("issue-fix", "issue fix", "github issue", "review packet"),
+        "Issue-fix and PR review flows became more repeatable.",
+    ),
+    (
+        "Benchmark workflow",
+        ("skillsbench", "terminal-bench", "benchmark", "harbor", "verifier"),
+        "Benchmark and runner contracts became easier to validate and explain.",
+    ),
+    (
+        "Control plane reliability",
+        ("quota", "scheduler", "gate", "todo", "task graph", "refresh-state"),
+        "Quota, gates, todos, and scheduler behavior became more explicit.",
+    ),
+    (
+        "Host and slash commands",
+        ("slash", "host", "codex", "/loopx", "command", "launch"),
+        "Host entry points and command contracts became clearer.",
+    ),
+    (
+        "Evented state and read paths",
+        ("event", "read path", "projection", "history", "cold-path"),
+        "State projection and history read paths moved toward durable contracts.",
+    ),
+    (
+        "Docs and public surface",
+        ("docs", "readme", "showcase", "frontstage", "update note", "catalog"),
+        "Public docs, showcases, and release communication improved.",
+    ),
+]
+
+
+def run_git(args: list[str]) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return result.stdout
+
+
+def parse_date(value: str) -> date:
+    return date.fromisoformat(value)
+
+
+def note_windows() -> list[Window]:
+    windows: list[Window] = []
+    for path in NOTES_DIR.glob("*.md"):
+        match = WINDOW_RE.match(path.name)
+        if not match:
+            continue
+        windows.append(Window(parse_date(match.group("since")), parse_date(match.group("until"))))
+    return sorted(windows, key=lambda item: item.since)
+
+
+def infer_next_window() -> Window:
+    windows = note_windows()
+    if not windows:
+        anchor = date(2026, 5, 31)
+        return Window(anchor, anchor + timedelta(days=13))
+    return windows[-1].next_window
+
+
+def collect_commits(window: Window) -> list[Commit]:
+    output = run_git(
+        [
+            "log",
+            f"--since={window.since.isoformat()}T00:00:00",
+            f"--until={window.until.isoformat()}T23:59:59",
+            "--pretty=format:%h%x09%s",
+        ]
+    )
+    commits: list[Commit] = []
+    seen_subjects: set[str] = set()
+    for line in output.splitlines():
+        if "\t" not in line:
+            continue
+        sha, subject = line.split("\t", 1)
+        subject = subject.strip()
+        if not subject or subject.startswith("Merge pull request "):
+            continue
+        key = subject.lower()
+        if key in seen_subjects:
+            continue
+        seen_subjects.add(key)
+        commits.append(Commit(sha=sha, subject=subject))
+    return commits
+
+
+def classify_commits(commits: list[Commit]) -> dict[str, list[Commit]]:
+    grouped: dict[str, list[Commit]] = {theme: [] for theme, _, _ in THEMES}
+    grouped["Other public changes"] = []
+    for commit in commits:
+        lowered = commit.subject.lower()
+        for theme, needles, _summary in THEMES:
+            if any(needle in lowered for needle in needles):
+                grouped[theme].append(commit)
+                break
+        else:
+            grouped["Other public changes"].append(commit)
+    return {theme: values for theme, values in grouped.items() if values}
+
+
+def bulletize(commits: list[Commit], limit: int = 8) -> list[str]:
+    bullets = [f"- `{commit.sha}` {commit.subject}" for commit in commits[:limit]]
+    remaining = len(commits) - limit
+    if remaining > 0:
+        bullets.append(f"- ...and {remaining} more public commits in this theme.")
+    return bullets
+
+
+def focus_for(grouped: dict[str, list[Commit]]) -> str:
+    themes = [theme for theme in grouped if theme != "Other public changes"]
+    if not themes:
+        return "Public repository maintenance and documentation."
+    return ", ".join(themes[:4]) + "."
+
+
+def render_note(window: Window, commits: list[Commit]) -> str:
+    grouped = classify_commits(commits)
+    highlight_lines = []
+    for theme, _needles, summary in THEMES:
+        if theme in grouped:
+            highlight_lines.append(f"- {summary}")
+    if grouped.get("Other public changes"):
+        highlight_lines.append("- Additional public repository changes shipped in smaller maintenance slices.")
+    if not highlight_lines:
+        highlight_lines.append("- No public commits were found for this window; review the draft before publishing.")
+
+    sections: list[str] = []
+    for theme, values in grouped.items():
+        sections.append(f"### {theme}\n\n" + "\n".join(bulletize(values)))
+    if not sections:
+        sections.append("### Public change review\n\n- No public commits were collected for this window.")
+
+    return "\n".join(
+        [
+            f"# Biweekly Update Note: {window.label}",
+            "",
+            "## Source Boundary",
+            "",
+            f"This note summarizes public repository history from {window.since.isoformat()} "
+            f"through {window.until.isoformat()}. It uses public commit history, shipped docs, "
+            "examples, and smoke tests. It does not include private operator state, raw "
+            "benchmark evidence, private links, local paths, or credentials.",
+            "",
+            "## Highlights",
+            "",
+            "\n".join(highlight_lines),
+            "",
+            "## What Shipped",
+            "",
+            "\n\n".join(sections),
+            "",
+            "## Validation And Public Boundary",
+            "",
+            "This source draft is generated by `scripts/update_notes_release_job.py` from "
+            "public git history. The generator does not use an LLM; treat the output as a "
+            "factual packet for maintainer or LoopX-agent editing before publication. Before "
+            "merging the generated PR, run the update-note smoke, `git diff --check`, and "
+            "LoopX public boundary scan over the touched files.",
+            "",
+            "## Next Window",
+            "",
+            f"The next expected window is {window.next_window.label}.",
+            "",
+        ]
+    )
+
+
+def replace_latest(index_text: str, window: Window) -> str:
+    latest_line = f"- [{window.label}]({window.filename})"
+    pattern = re.compile(r"(## Latest\n\n)(?:- \[[^\n]+\]\([^)]+\)\n?)", re.MULTILINE)
+    if pattern.search(index_text):
+        return pattern.sub(rf"\1{latest_line}\n", index_text)
+    return index_text.replace("## Latest\n\n", f"## Latest\n\n{latest_line}\n\n")
+
+
+def update_archive(index_text: str, window: Window, focus: str) -> str:
+    row = f"| {window.label} | [Read note]({window.filename}) | {focus} |"
+    if row in index_text or window.filename in index_text:
+        return index_text
+    marker = "| --- | --- | --- |\n"
+    if marker not in index_text:
+        raise SystemExit("docs/update-notes/README.md archive table marker not found")
+    return index_text.replace(marker, marker + row + "\n", 1)
+
+
+def update_next_expected(index_text: str, window: Window) -> str:
+    next_label = window.next_window.label
+    pattern = re.compile(r"Next expected window: \d{4}-\d{2}-\d{2} to \d{4}-\d{2}-\d{2}\.")
+    replacement = f"Next expected window: {next_label}."
+    if pattern.search(index_text):
+        return pattern.sub(replacement, index_text)
+    return index_text
+
+
+def write_github_output(values: dict[str, str]) -> None:
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if not output_path:
+        return
+    with open(output_path, "a", encoding="utf-8") as handle:
+        for key, value in values.items():
+            handle.write(f"{key}={value}\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--since", help="Window start date, YYYY-MM-DD.")
+    parser.add_argument("--until", help="Window end date, YYYY-MM-DD.")
+    parser.add_argument("--today", default=date.today().isoformat(), help="Current date for due checks.")
+    parser.add_argument("--force", action="store_true", help="Write even before the inferred open-after date.")
+    parser.add_argument("--overwrite", action="store_true", help="Overwrite an existing note file.")
+    parser.add_argument("--dry-run", action="store_true", help="Print the plan without writing files.")
+    args = parser.parse_args()
+
+    if bool(args.since) != bool(args.until):
+        raise SystemExit("--since and --until must be provided together")
+
+    window = (
+        Window(parse_date(args.since), parse_date(args.until))
+        if args.since and args.until
+        else infer_next_window()
+    )
+    today = parse_date(args.today)
+    note_path = NOTES_DIR / window.filename
+
+    if today < window.open_after and not args.force:
+        print(f"update notes: window {window.label} is not due until {window.open_after}")
+        write_github_output({"changed": "false", "window": window.label, "window_slug": window.slug})
+        return
+
+    if note_path.exists() and not args.overwrite:
+        print(f"update notes: {note_path.relative_to(ROOT)} already exists")
+        write_github_output({"changed": "false", "window": window.label, "window_slug": window.slug})
+        return
+
+    commits = collect_commits(window)
+    grouped = classify_commits(commits)
+    note = render_note(window, commits)
+    focus = focus_for(grouped)
+    index_text = NOTES_INDEX.read_text(encoding="utf-8")
+    index_text = replace_latest(index_text, window)
+    index_text = update_archive(index_text, window, focus)
+    index_text = update_next_expected(index_text, window)
+
+    print(f"update notes: window={window.label} commits={len(commits)} file={note_path.relative_to(ROOT)}")
+    if args.dry_run:
+        print(note)
+        write_github_output({"changed": "false", "window": window.label, "window_slug": window.slug})
+        return
+
+    note_path.write_text(note, encoding="utf-8")
+    NOTES_INDEX.write_text(index_text, encoding="utf-8")
+    write_github_output(
+        {
+            "changed": "true",
+            "window": window.label,
+            "window_slug": window.slug,
+            "note_file": str(note_path.relative_to(ROOT)),
+        }
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that periodically prepares a biweekly update-note draft PR
- add a deterministic public-history generator for update-note source drafts
- update update-note docs to make the no-LLM boundary explicit: the workflow opens a draft PR/source packet, not final prose
- extend the update-note smoke so future notes are discovered dynamically and the project automation stays wired

## No-LLM boundary
The scheduled Action does not call an LLM. It groups public git history into a factual source draft and opens a draft PR. A maintainer or LoopX agent should refine the narrative before marking the PR ready. A future optional LLM step would require an explicit repository secret and should fail closed when absent.

## Validation
- `python3 -m py_compile scripts/update_notes_release_job.py examples/update-notes-archive-smoke.py`
- `python3 examples/update-notes-archive-smoke.py`
- `python3 scripts/update_notes_release_job.py --today 2026-07-11 --dry-run`
- `python3 scripts/update_notes_release_job.py --today 2026-07-12 --dry-run`
- `git diff --check`
- `python3 -m loopx.cli check --scan-path .github/workflows/update-notes.yml --scan-path scripts/update_notes_release_job.py --scan-path docs/update-notes --scan-path examples/update-notes-archive-smoke.py`
