### PR TITLE
Fix status watch routing for monitor classifications

### DIFF
--- a/examples/status-watch-routing-attribute-smoke.py
+++ b/examples/status-watch-routing-attribute-smoke.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Smoke-test status watch routing uses explicit attributes, not monitor names."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from loopx.status import goal_attention  # noqa: E402
+
+
+def attention_for(run: dict[str, object]) -> dict[str, object]:
+    item = goal_attention(
+        {
+            "id": "status-watch-routing-fixture",
+            "registry_member": True,
+            "adapter_status": "connected-read-only",
+            "latest_status_run": run,
+            "latest_runs": [run],
+        }
+    )
+    assert item is not None, run
+    return item
+
+
+def main() -> int:
+    product_monitor_run = {
+        "classification": "monitor_due_scheduler_todos_planned",
+        "recommended_action": "Implement monitor scheduler runtime routing.",
+        "json_exists": True,
+        "markdown_exists": True,
+        "delivery_outcome": "surface_only",
+    }
+    product_item = attention_for(product_monitor_run)
+    assert product_item["waiting_on"] == "codex", product_item
+    assert product_item["severity"] == "action", product_item
+
+    explicit_external_run = {
+        "classification": "runtime_result_pending",
+        "waiting_on": "external_evidence",
+        "recommended_action": "Observe the external worker result.",
+        "json_exists": True,
+        "markdown_exists": True,
+        "delivery_outcome": "surface_only",
+    }
+    explicit_item = attention_for(explicit_external_run)
+    assert explicit_item["waiting_on"] == "external_evidence", explicit_item
+    assert explicit_item["severity"] == "watch", explicit_item
+
+    legacy_external_run = {
+        "classification": "external_evidence_observation_contract_validated_v0",
+        "recommended_action": "Observe the external result channel.",
+        "json_exists": True,
+        "markdown_exists": True,
+        "delivery_outcome": "surface_only",
+    }
+    legacy_item = attention_for(legacy_external_run)
+    assert legacy_item["waiting_on"] == "external_evidence", legacy_item
+    assert legacy_item["severity"] == "watch", legacy_item
+
+    print("status-watch-routing-attribute-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -131,7 +131,10 @@ REGISTRY_WAITING_ON_OVERRIDES = {
     "codex",
     "external_evidence",
 }
-WATCH_CLASSIFICATION_PREFIXES = ("await_", "monitor_", "external_evidence_observation_")
+LEGACY_EXTERNAL_EVIDENCE_CLASSIFICATION_PREFIXES = (
+    "await_",
+    "external_evidence_observation_",
+)
 MONITOR_SIGNAL_WAITING_ON = "monitor_signal"
 MONITOR_DISPLAY_SCHEMA_VERSION = "monitor_quiet_display_v0"
 MONITOR_DISPLAY_STOP_CONDITION = (
@@ -6615,6 +6618,33 @@ def is_handoff_ready_run(run: dict[str, Any]) -> bool:
     )
 
 
+def run_has_external_evidence_watch_signal(run: dict[str, Any]) -> bool:
+    """Return true only for explicit external-evidence watch state.
+
+    Feature names may legitimately start with words such as "monitor"; routing
+    to an external-evidence wait must come from structured state or explicit
+    legacy external-evidence classifications, not broad classification prefixes.
+    """
+
+    waiting_on = str(run.get("waiting_on") or "").strip()
+    execution_waiting_on = str(run.get("execution_waiting_on") or "").strip()
+    if waiting_on == "external_evidence" or execution_waiting_on == "external_evidence":
+        return True
+    if isinstance(run.get("external_evidence_observation"), dict):
+        return True
+    monitor_event = run.get("monitor_event")
+    if isinstance(monitor_event, dict):
+        event_waiting_on = str(monitor_event.get("waiting_on") or "").strip()
+        monitor_mode = str(monitor_event.get("monitor_mode") or "").strip()
+        monitor_kind = str(monitor_event.get("monitor_kind") or "").strip()
+        if event_waiting_on == "external_evidence":
+            return True
+        if monitor_mode.startswith("external_") or monitor_kind == "external_evidence":
+            return True
+    classification = str(run.get("classification") or "")
+    return classification.startswith(LEGACY_EXTERNAL_EVIDENCE_CLASSIFICATION_PREFIXES)
+
+
 def is_custom_post_handoff_work_run(run: dict[str, Any]) -> bool:
     classification = str(run.get("classification") or "")
     if not classification:
@@ -6625,7 +6655,7 @@ def is_custom_post_handoff_work_run(run: dict[str, Any]) -> bool:
         return False
     if classification in USER_OR_CONTROLLER_CLASSIFICATIONS or classification in BLOCKING_CLASSIFICATIONS:
         return False
-    if classification.startswith(WATCH_CLASSIFICATION_PREFIXES):
+    if run_has_external_evidence_watch_signal(run):
         return False
     return True
 
@@ -8110,7 +8140,7 @@ def goal_attention(goal: dict[str, Any]) -> dict[str, Any] | None:
             **attention_fields,
             **lifecycle_fields,
         )
-    if classification.startswith(WATCH_CLASSIFICATION_PREFIXES):
+    if run_has_external_evidence_watch_signal(current_run):
         return attention_item(
             goal_id=goal_id,
             status=classification,
@@ -9155,7 +9185,7 @@ def event_ledger_event_class(run: dict[str, Any]) -> str:
         return "decision"
     if classification in EVENT_LEDGER_EVIDENCE_CLASSIFICATIONS:
         return "evidence"
-    if classification.startswith(WATCH_CLASSIFICATION_PREFIXES):
+    if run_has_external_evidence_watch_signal(run):
         return "evidence"
     if any(hint in classification for hint in EVENT_LEDGER_EVIDENCE_HINTS):
         return "evidence"


### PR DESCRIPTION
## Summary
- Route status external-evidence watch decisions through explicit run attributes instead of the broad `monitor_` classification prefix.
- Preserve legacy `await_` and `external_evidence_observation_` classification compatibility.
- Add a focused smoke proving `monitor_due_scheduler_*` product/runtime classifications remain codex-actionable while explicit external-evidence signals still route to watch.

## Root Cause
`status.goal_attention` treated every latest-run classification beginning with `monitor_` as `waiting_on=external_evidence`. That made product/runtime work such as `monitor_scheduler_v0` look like an external watch even though `agent_todo_summary` had runnable advancement todos. Quota then projected `external_evidence_observation` and blocked delivery before `agent_lane_next_action` could run.

## Validation
- `python3 examples/status-watch-routing-attribute-smoke.py`
- `python3 examples/heartbeat-quota-flow-smoke.py`
- `python3 examples/work-lane-contract-smoke.py`
- `python3 -m loopx.cli --format json --registry "$HOME/.codex/loopx/registry.global.json" status --limit 20` verified `loopx-meta` now projects `waiting_on=codex` under local code.
- `python3 -m loopx.cli --format json --registry "$HOME/.codex/loopx/registry.global.json" quota should-run --goal-id loopx-meta --agent-id codex-product-capability` verified local code returns `state=eligible`, `effective_action=normal_run`, `mode=bounded_delivery`, `lane_next=todo_2eb6ba1f28a7`.
- `python3 -m compileall loopx`
- `loopx check --scan-path docs --scan-path examples --scan-path loopx --scan-path scripts` (warning only: existing loopx-meta duplicate index rows)
- `git diff --check`

## Boundary
Only touches runtime status routing and one public smoke. No private state, raw benchmark logs, credentials, or local evidence are included.