### PR TITLE
Add monitor-poll todo writeback API

### DIFF
--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -381,13 +381,33 @@ no-spend stall evidence with:
 loopx --registry "$HOME/.codex/loopx/registry.global.json" quota monitor-poll --goal-id <GOAL_ID> --source heartbeat --execute
 ```
 
-`quota monitor-poll` is valid only when the current guard is
-`effective_action=monitor_quiet_skip` and
-`recommended_mode=monitor_quiet_until_material_transition`. It appends a
-`quota_monitor_poll` run record, does not mutate the registry, and does not
-append `quota_slot_spent`. The run includes `quota_monitor_target_v0`, a compact
-hash of the public monitor identity. Six consecutive public stalled monitor
-records with the same target feed `autonomous_replan_obligation` as
+`quota monitor-poll` is valid when the current guard is a quiet monitor skip,
+an external-evidence observation, or a due `continuous_monitor` todo selected
+by `work_lane_contract.obligation=attempt_due_monitor`. For due monitor todos,
+pass `--todo-id` or `--target-key` plus a public `--result-hash`; unchanged
+polls update `last_checked_at`, `next_due_at`, and
+`consecutive_no_change` without appending `quota_slot_spent`:
+
+```bash
+loopx quota monitor-poll --goal-id <GOAL_ID> \
+  --todo-id <TODO_ID> --result-hash <HASH> --execute
+```
+
+When a poll sees a material transition, add `--material-change` and optionally
+`--next-agent-todo` or `--next-user-todo` so the monitor produces a concrete
+follow-up instead of staying as an opaque watch:
+
+```bash
+loopx quota monitor-poll --goal-id <GOAL_ID> \
+  --target-key <TARGET_KEY> --result-hash <HASH> --material-change \
+  --next-agent-todo "<PUBLIC_SAFE_FOLLOW_UP>" --execute
+```
+
+The command appends a `quota_monitor_poll` run record, does not mutate the
+registry, and does not append `quota_slot_spent`. The run includes
+`quota_monitor_target_v0`, a compact hash of the public monitor identity. Six
+consecutive public stalled monitor records with the same target feed
+`autonomous_replan_obligation` as
 `dead_monitor_repeat`, so the next independent `quota should-run` may flip to
 `autonomous_replan_required` /
 `execution_obligation.must_attempt_work=true`; the executor should then record a

--- a/examples/monitor-poll-writeback-smoke.py
+++ b/examples/monitor-poll-writeback-smoke.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Smoke-test monitor-poll todo metadata writeback."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.status import parse_active_state_todos  # noqa: E402
+
+
+GOAL_ID = "monitor-poll-writeback-fixture"
+AGENT_ID = "codex-product-capability"
+TODO_ID = "todo_monitorpoll000"
+TARGET_KEY = "update-note-draft-pr"
+
+
+def write_fixture(root: Path) -> tuple[Path, Path]:
+    project = root / "project"
+    runtime = root / "runtime"
+    state_file = project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+    registry_path = project / ".loopx" / "registry.json"
+    state_file.parent.mkdir(parents=True)
+    state_file.write_text(
+        "---\n"
+        "status: active\n"
+        "updated_at: 2026-01-01T00:00:00+00:00\n"
+        "---\n\n"
+        "# Active Goal State\n\n"
+        "## Objective\n\n"
+        "Exercise due monitor poll writeback.\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] [P0] Poll the update-note draft PR for material changes.\n"
+        "  <!-- loopx:todo "
+        f"todo_id={TODO_ID} "
+        "status=open "
+        "task_class=continuous_monitor "
+        "action_kind=poll "
+        f"claimed_by={AGENT_ID} "
+        f"target_key={TARGET_KEY} "
+        "cadence=15m "
+        "next_due_at=2026-01-01T00:00:00+00:00 "
+        "result_hash=old "
+        "consecutive_no_change=1 "
+        "material_change=false "
+        "-->\n",
+        encoding="utf-8",
+    )
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "monitor-poll-writeback",
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md",
+                        "adapter": {"kind": "generic_project_goal_v0", "status": "connected"},
+                        "coordination": {
+                            "registered_agents": [AGENT_ID],
+                            "primary_agent": AGENT_ID,
+                        },
+                    }
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return registry_path, state_file
+
+
+def run_cli(registry_path: Path, *args: str) -> dict:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--registry",
+            str(registry_path),
+            "--format",
+            "json",
+            *args,
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return json.loads(result.stdout)
+
+
+def agent_todos(state_file: Path) -> list[dict]:
+    fields = parse_active_state_todos(state_file.read_text(encoding="utf-8"))
+    return fields["agent_todos"]["items"]
+
+
+def find_todo(state_file: Path, todo_id: str) -> dict:
+    for item in agent_todos(state_file):
+        if item.get("todo_id") == todo_id:
+            return item
+    raise AssertionError(f"missing todo {todo_id}")
+
+
+def assert_due_monitor_selected(registry_path: Path) -> None:
+    quota = run_cli(
+        registry_path,
+        "quota",
+        "should-run",
+        "--goal-id",
+        GOAL_ID,
+        "--agent-id",
+        AGENT_ID,
+    )
+    assert quota["should_run"] is True, quota
+    contract = quota.get("work_lane_contract")
+    assert isinstance(contract, dict), quota
+    assert contract.get("obligation") == "attempt_due_monitor", quota
+    assert contract.get("selected_todo_id") == TODO_ID, quota
+    assert contract.get("monitor_due_count") == 1, quota
+
+
+def assert_unchanged_writeback() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-monitor-poll-unchanged-") as tmp:
+        registry_path, state_file = write_fixture(Path(tmp))
+        assert_due_monitor_selected(registry_path)
+
+        payload = run_cli(
+            registry_path,
+            "quota",
+            "monitor-poll",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_ID,
+            "--todo-id",
+            TODO_ID,
+            "--result-hash",
+            "old",
+            "--execute",
+        )
+        assert payload["ok"] is True, payload
+        assert payload["appended"] is True, payload
+        writeback = payload["todo_writeback"]
+        assert writeback["todo_id"] == TODO_ID, payload
+        assert writeback["consecutive_no_change"] == 2, payload
+        item = find_todo(state_file, TODO_ID)
+        assert item["result_hash"] == "old", item
+        assert item["consecutive_no_change"] == "2", item
+        assert item["last_checked_at"], item
+        assert item["next_due_at"] != "2026-01-01T00:00:00+00:00", item
+        assert item["material_change"] == "false", item
+
+
+def assert_material_transition_followup() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-monitor-poll-material-") as tmp:
+        registry_path, state_file = write_fixture(Path(tmp))
+        assert_due_monitor_selected(registry_path)
+
+        payload = run_cli(
+            registry_path,
+            "quota",
+            "monitor-poll",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_ID,
+            "--target-key",
+            TARGET_KEY,
+            "--result-hash",
+            "new",
+            "--material-change",
+            "--next-agent-todo",
+            "Review the material monitor transition and prepare a public-safe packet.",
+            "--execute",
+        )
+        assert payload["ok"] is True, payload
+        assert payload["material_change"] is True, payload
+        writeback = payload["todo_writeback"]
+        assert writeback["consecutive_no_change"] == 0, payload
+        assert writeback["next_todos"], payload
+        monitor = find_todo(state_file, TODO_ID)
+        assert monitor["result_hash"] == "new", monitor
+        assert monitor["consecutive_no_change"] == "0", monitor
+        assert monitor["material_change"] == "true", monitor
+        successors = [
+            item
+            for item in agent_todos(state_file)
+            if item.get("unblocks_todo_id") == TODO_ID
+        ]
+        assert successors, agent_todos(state_file)
+        assert successors[0]["task_class"] == "advancement_task", successors[0]
+
+
+def main() -> int:
+    assert_unchanged_writeback()
+    assert_material_transition_followup()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -71,6 +71,15 @@ def register_quota_command(subparsers: argparse._SubParsersAction) -> None:
     quota_parser.add_argument("--source", choices=["heartbeat", "controller", "adapter"], default="heartbeat", help="Source label for `quota spend-slot`.")
     quota_parser.add_argument("--void-generated-at", help="generated_at timestamp of the quota_slot_spent run to void.")
     quota_parser.add_argument("--reason-summary", help="Public-safe reason for `quota void-slot`.")
+    quota_parser.add_argument("--todo-id", help="Monitor todo id for `quota monitor-poll` metadata writeback.")
+    quota_parser.add_argument("--target-key", help="Stable monitor target key for `quota monitor-poll` metadata writeback.")
+    quota_parser.add_argument("--result-hash", help="Public-safe result hash observed by `quota monitor-poll`.")
+    quota_parser.add_argument("--material-change", action="store_true", help="Mark a monitor poll as a material transition instead of unchanged evidence.")
+    quota_parser.add_argument("--cadence", help="Monitor cadence used to compute the next due timestamp, e.g. 30m, 2h, or 1d.")
+    quota_parser.add_argument("--next-due-at", help="Explicit ISO timestamp for the next monitor poll.")
+    quota_parser.add_argument("--next-agent-todo", help="Agent follow-up todo to add when `--material-change` is set.")
+    quota_parser.add_argument("--next-user-todo", help="User gate todo to add when `--material-change` is set.")
+    quota_parser.add_argument("--next-claimed-by", help="Registered agent id to claim the `--next-agent-todo` follow-up.")
     quota_parser.add_argument("--dry-run", action="store_true", help="Keep quota accounting writes as preview-only. This is the default.")
     quota_parser.add_argument("--execute", action="store_true", help="Append the compact quota accounting runtime event for spend-slot or void-slot.")
     quota_parser.add_argument(
@@ -125,10 +134,20 @@ def handle_quota_command(
             payload = record_quota_monitor_poll(
                 status_payload,
                 goal_id=args.goal_id,
+                registry_path=registry_path,
                 execute=bool(args.execute),
                 source=args.source,
                 reason_summary=args.reason_summary,
                 agent_id=args.agent_id,
+                todo_id=args.todo_id,
+                target_key=args.target_key,
+                result_hash=args.result_hash,
+                material_change=bool(args.material_change),
+                cadence=args.cadence,
+                next_due_at=args.next_due_at,
+                next_agent_todo=args.next_agent_todo,
+                next_user_todo=args.next_user_todo,
+                next_claimed_by=args.next_claimed_by,
             )
         elif args.quota_command == "spend-slot":
             if not args.goal_id:
@@ -241,6 +260,8 @@ def handle_quota_command(
                 "appended": bool(payload.get("appended")),
                 "slots": payload.get("slots") or "",
                 "source": payload.get("source") or "",
+                "todo_id": payload.get("todo_id") or "",
+                "target_key": payload.get("target_key") or "",
             },
             allow_failed=args.quota_command == "should-run",
         )

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -7592,20 +7592,283 @@ def _allows_no_spend_external_monitor_poll(decision: dict[str, Any]) -> bool:
     return bool(decision.get("external_evidence_observation"))
 
 
+MONITOR_CADENCE_PATTERN = re.compile(
+    r"^\s*(?P<count>[1-9][0-9]{0,4})\s*"
+    r"(?P<unit>s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days)\s*$",
+    re.IGNORECASE,
+)
+
+
+def _parse_monitor_counter(value: Any) -> int:
+    try:
+        return max(0, int(str(value or "0").strip()))
+    except ValueError:
+        return 0
+
+
+def _monitor_cadence_delta(value: Any) -> timedelta | None:
+    candidate = str(value or "").strip()
+    if not candidate:
+        return None
+    match = MONITOR_CADENCE_PATTERN.match(candidate)
+    if not match:
+        return None
+    count = int(match.group("count"))
+    unit = match.group("unit").lower()
+    if unit.startswith("s"):
+        return timedelta(seconds=count)
+    if unit.startswith("m"):
+        return timedelta(minutes=count)
+    if unit.startswith("h"):
+        return timedelta(hours=count)
+    return timedelta(days=count)
+
+
+def _monitor_next_due_at(
+    *,
+    generated_at: str,
+    cadence: Any = None,
+    explicit_next_due_at: Any = None,
+) -> str | None:
+    explicit = str(explicit_next_due_at or "").strip()
+    if explicit:
+        if _parse_timestamp(explicit) is None:
+            raise ValueError("--next-due-at must be an ISO timestamp")
+        return explicit
+    delta = _monitor_cadence_delta(cadence)
+    if delta is None:
+        return None
+    checked_at = _parse_timestamp(generated_at)
+    if checked_at is None:
+        checked_at = datetime.now(timezone.utc)
+    return (checked_at + delta).astimezone().replace(microsecond=0).isoformat()
+
+
+def _quota_decision_due_monitor_item(decision: dict[str, Any]) -> dict[str, Any]:
+    item = (
+        decision.get("agent_lane_next_action")
+        if isinstance(decision.get("agent_lane_next_action"), dict)
+        else {}
+    )
+    if _todo_task_class(item) != TODO_TASK_CLASS_MONITOR:
+        item = {}
+    if item:
+        return item
+    contract = (
+        decision.get("work_lane_contract")
+        if isinstance(decision.get("work_lane_contract"), dict)
+        else {}
+    )
+    selected_todo_id = normalize_todo_id(contract.get("selected_todo_id"))
+    due_items = contract.get("monitor_due_items") if isinstance(contract.get("monitor_due_items"), list) else []
+    for due_item in due_items:
+        if not isinstance(due_item, dict):
+            continue
+        if selected_todo_id and normalize_todo_id(due_item.get("todo_id")) != selected_todo_id:
+            continue
+        if _todo_task_class(due_item) == TODO_TASK_CLASS_MONITOR:
+            return due_item
+    return item
+
+
+def _allows_due_monitor_poll(
+    decision: dict[str, Any],
+    *,
+    todo_id: str | None = None,
+    target_key: str | None = None,
+) -> bool:
+    if decision.get("should_run") is not True:
+        return False
+    if decision.get("requires_user_action") is True:
+        return False
+    item = _quota_decision_due_monitor_item(decision)
+    if not item:
+        return False
+    if todo_id and normalize_todo_id(item.get("todo_id")) != normalize_todo_id(todo_id):
+        return False
+    if target_key:
+        item_target_key = str(item.get("target_key") or "").strip()
+        if item_target_key and item_target_key != str(target_key).strip():
+            return False
+    return True
+
+
+def _resolve_monitor_todo_item(
+    *,
+    registry_path: Path,
+    goal_id: str,
+    todo_id: str | None = None,
+    target_key: str | None = None,
+) -> dict[str, Any]:
+    from .todos import list_goal_todos
+
+    normalized_todo_id = normalize_todo_id(todo_id) if todo_id else None
+    safe_target_key = str(target_key or "").strip()
+    if not normalized_todo_id and not safe_target_key:
+        raise ValueError("monitor todo writeback requires --todo-id or --target-key")
+    payload = list_goal_todos(registry_path=registry_path, goal_id=goal_id, role="agent")
+    matches: list[dict[str, Any]] = []
+    for item in payload.get("todos") if isinstance(payload.get("todos"), list) else []:
+        if not isinstance(item, dict):
+            continue
+        if normalized_todo_id and normalize_todo_id(item.get("todo_id")) == normalized_todo_id:
+            matches.append(item)
+            continue
+        if safe_target_key and str(item.get("target_key") or "").strip() == safe_target_key:
+            matches.append(item)
+    if not matches:
+        target = normalized_todo_id or safe_target_key
+        raise ValueError(f"monitor todo target {target!r} was not found")
+    if len(matches) > 1:
+        raise ValueError(f"monitor target_key {safe_target_key!r} matched multiple todos; pass --todo-id")
+    item = matches[0]
+    if _todo_task_class(item) != TODO_TASK_CLASS_MONITOR:
+        raise ValueError("monitor-poll todo writeback target must be task_class=continuous_monitor")
+    return item
+
+
+def _write_monitor_poll_todo_state(
+    *,
+    registry_path: Path,
+    goal_id: str,
+    generated_at: str,
+    execute: bool,
+    todo_id: str | None = None,
+    target_key: str | None = None,
+    result_hash: str | None = None,
+    material_change: bool = False,
+    cadence: str | None = None,
+    next_due_at: str | None = None,
+    reason_summary: str | None = None,
+    next_agent_todo: str | None = None,
+    next_user_todo: str | None = None,
+    next_claimed_by: str | None = None,
+    agent_id: str | None = None,
+) -> dict[str, Any] | None:
+    from .todos import add_goal_todo, update_goal_todo
+
+    if not todo_id and not target_key:
+        return None
+    safe_result_hash = str(result_hash or "").strip()
+    if not safe_result_hash:
+        raise ValueError("monitor todo writeback requires --result-hash")
+    item = _resolve_monitor_todo_item(
+        registry_path=registry_path,
+        goal_id=goal_id,
+        todo_id=todo_id,
+        target_key=target_key,
+    )
+    resolved_todo_id = normalize_todo_id(item.get("todo_id"))
+    if not resolved_todo_id:
+        raise ValueError("resolved monitor todo has no stable todo_id")
+    safe_target_key = str(target_key or item.get("target_key") or "").strip()
+    effective_cadence = str(cadence or item.get("cadence") or "").strip()
+    effective_next_due_at = _monitor_next_due_at(
+        generated_at=generated_at,
+        cadence=effective_cadence,
+        explicit_next_due_at=next_due_at,
+    )
+    if not material_change and not effective_next_due_at:
+        raise ValueError(
+            "unchanged monitor todo writeback requires --next-due-at or a parseable cadence such as 30m/2h/1d"
+        )
+    previous_hash = str(item.get("result_hash") or "").strip()
+    previous_no_change = _parse_monitor_counter(item.get("consecutive_no_change"))
+    consecutive_no_change = (
+        0
+        if material_change or (previous_hash and previous_hash != safe_result_hash)
+        else previous_no_change + 1
+    )
+    monitor_metadata: dict[str, Any] = {
+        "last_checked_at": generated_at,
+        "result_hash": safe_result_hash,
+        "consecutive_no_change": str(consecutive_no_change),
+        "material_change": "true" if material_change else "false",
+    }
+    if safe_target_key:
+        monitor_metadata["target_key"] = safe_target_key
+    if effective_cadence:
+        monitor_metadata["cadence"] = effective_cadence
+    if effective_next_due_at:
+        monitor_metadata["next_due_at"] = effective_next_due_at
+    update_result = update_goal_todo(
+        registry_path=registry_path,
+        goal_id=goal_id,
+        todo_id=resolved_todo_id,
+        role="agent",
+        reason=reason_summary,
+        monitor_metadata=monitor_metadata,
+        dry_run=not execute,
+    )
+    next_results: list[dict[str, Any]] = []
+    if material_change and next_agent_todo:
+        next_results.append(
+            add_goal_todo(
+                registry_path=registry_path,
+                goal_id=goal_id,
+                role="agent",
+                text=next_agent_todo,
+                task_class=TODO_TASK_CLASS_ADVANCEMENT,
+                action_kind="advance",
+                claimed_by=next_claimed_by,
+                unblocks_todo_id=resolved_todo_id,
+                dry_run=not execute,
+            )
+        )
+    if material_change and next_user_todo:
+        next_results.append(
+            add_goal_todo(
+                registry_path=registry_path,
+                goal_id=goal_id,
+                role="user",
+                text=next_user_todo,
+                task_class=TODO_TASK_CLASS_USER_GATE,
+                action_kind="gate",
+                agent_id=agent_id,
+                unblocks_todo_id=resolved_todo_id,
+                dry_run=not execute,
+            )
+        )
+    return {
+        "schema_version": "monitor_poll_todo_writeback_v0",
+        "dry_run": not execute,
+        "goal_id": goal_id,
+        "todo_id": resolved_todo_id,
+        "target_key": safe_target_key or None,
+        "result_hash": safe_result_hash,
+        "material_change": material_change,
+        "consecutive_no_change": consecutive_no_change,
+        "last_checked_at": generated_at,
+        "next_due_at": effective_next_due_at,
+        "cadence": effective_cadence or None,
+        "todo_update": update_result,
+        "next_todos": next_results,
+    }
+
+
 def build_quota_monitor_poll_event(
     before: dict[str, Any],
     *,
     source: str = DEFAULT_SLOT_SPEND_SOURCE,
     generated_at: str | None = None,
     reason_summary: str | None = None,
+    todo_id: str | None = None,
+    target_key: str | None = None,
+    result_hash: str | None = None,
+    material_change: bool = False,
 ) -> dict[str, Any]:
     safe_source = str(source or DEFAULT_SLOT_SPEND_SOURCE).strip()
     if safe_source not in VALID_SLOT_SPEND_SOURCES:
         raise ValueError(f"quota monitor-poll source must be one of: {', '.join(sorted(VALID_SLOT_SPEND_SOURCES))}")
     external_monitor_poll = _allows_no_spend_external_monitor_poll(before)
-    if before.get("effective_action") != "monitor_quiet_skip" and not external_monitor_poll:
+    due_monitor_poll = _allows_due_monitor_poll(
+        before,
+        todo_id=todo_id,
+        target_key=target_key,
+    )
+    if before.get("effective_action") != "monitor_quiet_skip" and not external_monitor_poll and not due_monitor_poll:
         raise ValueError(
-            "quota monitor-poll requires a monitor_quiet_skip or external monitor observation decision"
+            "quota monitor-poll requires a monitor_quiet_skip, due monitor todo, or external monitor observation decision"
         )
     recommendation = (
         before.get("heartbeat_recommendation")
@@ -7615,12 +7878,21 @@ def build_quota_monitor_poll_event(
     if (
         recommendation.get("recommended_mode") != "monitor_quiet_until_material_transition"
         and not external_monitor_poll
+        and not due_monitor_poll
     ):
         raise ValueError("quota monitor-poll requires monitor_quiet_until_material_transition mode")
     monitor_mode = (
         "external_monitor_observed_without_material_transition"
         if external_monitor_poll
-        else "monitor_quiet_until_material_transition"
+        else (
+            "due_monitor_material_transition"
+            if due_monitor_poll and material_change
+            else (
+                "due_monitor_observed_without_material_transition"
+                if due_monitor_poll
+                else "monitor_quiet_until_material_transition"
+            )
+        )
     )
     monitor_target = _quota_monitor_target(before, monitor_mode=monitor_mode)
     safe_reason_summary = str(reason_summary or "").strip()
@@ -7640,11 +7912,23 @@ def build_quota_monitor_poll_event(
         "classification": QUOTA_MONITOR_POLL_CLASSIFICATION,
         "recommended_action": before.get("recommended_action") or recommendation.get("reason") or before.get("reason"),
         "health_check": (
-            "external monitor observation unchanged; no quota spend; no material transition"
+            "due monitor material transition observed; follow-up state updated; no quota spend by monitor-poll"
+            if due_monitor_poll and material_change
+            else (
+                "due monitor observation unchanged; no quota spend; next due updated"
+                if due_monitor_poll
+                else (
+                    "external monitor observation unchanged; no quota spend; no material transition"
             if external_monitor_poll
             else "monitor-only poll unchanged; no quota spend; no material transition"
+                )
+            )
         ),
-        "delivery_outcome": DeliveryOutcome.SURFACE_ONLY.value,
+        "delivery_outcome": (
+            DeliveryOutcome.OUTCOME_PROGRESS.value
+            if due_monitor_poll and material_change
+            else DeliveryOutcome.SURFACE_ONLY.value
+        ),
         "monitor_target": monitor_target,
         "monitor_event": {
             "event_type": QUOTA_MONITOR_POLL_CLASSIFICATION,
@@ -7652,6 +7936,10 @@ def build_quota_monitor_poll_event(
             "monitor_mode": monitor_mode,
             "monitor_target": monitor_target,
             "reason_summary": safe_reason_summary,
+            "material_change": material_change,
+            "todo_id": normalize_todo_id(todo_id) if todo_id else None,
+            "target_key": str(target_key or "").strip() or None,
+            "result_hash": str(result_hash or "").strip() or None,
             "before": _compact_quota_decision(before),
         },
     }
@@ -7832,14 +8120,59 @@ def record_quota_monitor_poll(
     status_payload: dict[str, Any],
     *,
     goal_id: str,
+    registry_path: Path | None = None,
     execute: bool = False,
     source: str = DEFAULT_SLOT_SPEND_SOURCE,
     reason_summary: str | None = None,
     agent_id: str | None = None,
+    todo_id: str | None = None,
+    target_key: str | None = None,
+    result_hash: str | None = None,
+    material_change: bool = False,
+    cadence: str | None = None,
+    next_due_at: str | None = None,
+    next_agent_todo: str | None = None,
+    next_user_todo: str | None = None,
+    next_claimed_by: str | None = None,
 ) -> dict[str, Any]:
     safe_goal_id = _validate_goal_id_path_segment(str(goal_id or ""))
     before = build_quota_should_run(status_payload, goal_id=safe_goal_id, agent_id=agent_id)
-    if before.get("effective_action") != "monitor_quiet_skip" and not _allows_no_spend_external_monitor_poll(before):
+    normalized_todo_id = normalize_todo_id(todo_id) if todo_id else None
+    safe_target_key = str(target_key or "").strip() or None
+    if material_change and not (normalized_todo_id or safe_target_key):
+        return {
+            "ok": False,
+            "mode": "monitor-poll",
+            "dry_run": not execute,
+            "goal_id": safe_goal_id,
+            "appended": False,
+            "registry_mutated": False,
+            "reason": "`quota monitor-poll --material-change` requires --todo-id or --target-key",
+            "before": before,
+            "after": None,
+        }
+    if (next_agent_todo or next_user_todo) and not material_change:
+        return {
+            "ok": False,
+            "mode": "monitor-poll",
+            "dry_run": not execute,
+            "goal_id": safe_goal_id,
+            "appended": False,
+            "registry_mutated": False,
+            "reason": "`--next-agent-todo` and `--next-user-todo` require --material-change",
+            "before": before,
+            "after": None,
+        }
+    due_monitor_poll = _allows_due_monitor_poll(
+        before,
+        todo_id=normalized_todo_id,
+        target_key=safe_target_key,
+    )
+    if (
+        before.get("effective_action") != "monitor_quiet_skip"
+        and not _allows_no_spend_external_monitor_poll(before)
+        and not due_monitor_poll
+    ):
         return {
             "ok": False,
             "mode": "monitor-poll",
@@ -7849,19 +8182,63 @@ def record_quota_monitor_poll(
             "registry_mutated": False,
             "reason": (
                 before.get("reason")
-                or "monitor-poll requires monitor_quiet_skip or external monitor observation"
+                or "monitor-poll requires monitor_quiet_skip, due monitor todo, or external monitor observation"
             ),
             "before": before,
             "after": None,
         }
 
     generated_at = _now_local()
+    todo_writeback = None
+    if normalized_todo_id or safe_target_key:
+        if registry_path is None:
+            raise ValueError("monitor todo writeback requires registry_path")
+        todo_writeback = _write_monitor_poll_todo_state(
+            registry_path=registry_path,
+            goal_id=safe_goal_id,
+            generated_at=generated_at,
+            execute=execute,
+            todo_id=normalized_todo_id,
+            target_key=safe_target_key,
+            result_hash=result_hash,
+            material_change=material_change,
+            cadence=cadence,
+            next_due_at=next_due_at,
+            reason_summary=reason_summary,
+            next_agent_todo=next_agent_todo,
+            next_user_todo=next_user_todo,
+            next_claimed_by=next_claimed_by,
+            agent_id=agent_id,
+        )
     record = build_quota_monitor_poll_event(
         before,
         source=source,
         generated_at=generated_at,
         reason_summary=reason_summary,
+        todo_id=(todo_writeback or {}).get("todo_id") or normalized_todo_id,
+        target_key=(todo_writeback or {}).get("target_key") or safe_target_key,
+        result_hash=(todo_writeback or {}).get("result_hash") or result_hash,
+        material_change=material_change,
     )
+    if todo_writeback:
+        record["monitor_event"]["todo_writeback"] = {
+            key: value
+            for key, value in todo_writeback.items()
+            if key
+            in {
+                "schema_version",
+                "dry_run",
+                "goal_id",
+                "todo_id",
+                "target_key",
+                "result_hash",
+                "material_change",
+                "consecutive_no_change",
+                "last_checked_at",
+                "next_due_at",
+                "cadence",
+            }
+        }
     raw_runtime_root = status_payload.get("runtime_root")
     if not raw_runtime_root:
         raise ValueError("status payload does not include runtime_root")
@@ -7883,6 +8260,12 @@ def record_quota_monitor_poll(
     }
     if record.get("agent_id"):
         index_record["agent_id"] = record["agent_id"]
+    if record["monitor_event"].get("todo_id"):
+        index_record["todo_id"] = record["monitor_event"]["todo_id"]
+    if record["monitor_event"].get("target_key"):
+        index_record["target_key"] = record["monitor_event"]["target_key"]
+    if record["monitor_event"].get("material_change"):
+        index_record["material_change"] = record["monitor_event"]["material_change"]
 
     after_status = deepcopy(status_payload)
     if execute:
@@ -7913,7 +8296,11 @@ def record_quota_monitor_poll(
         "classification": QUOTA_MONITOR_POLL_CLASSIFICATION,
         "generated_at": generated_at,
         "agent_id": record.get("agent_id"),
+        "todo_id": record["monitor_event"].get("todo_id"),
+        "target_key": record["monitor_event"].get("target_key"),
+        "material_change": record["monitor_event"].get("material_change"),
         "monitor_event": record["monitor_event"],
+        "todo_writeback": todo_writeback,
         "health_check": record["health_check"],
         "delivery_outcome": record["delivery_outcome"],
         "json_path": str(json_path),
@@ -8346,6 +8733,7 @@ def render_quota_slot_preview_markdown(payload: dict[str, Any]) -> str:
 def render_quota_monitor_poll_markdown(payload: dict[str, Any]) -> str:
     event = payload.get("monitor_event") if isinstance(payload.get("monitor_event"), dict) else {}
     before = event.get("before") if isinstance(event.get("before"), dict) else {}
+    todo_writeback = event.get("todo_writeback") if isinstance(event.get("todo_writeback"), dict) else {}
     lines = [
         "# LoopX Quota Monitor Poll",
         "",
@@ -8355,12 +8743,23 @@ def render_quota_monitor_poll_markdown(payload: dict[str, Any]) -> str:
         f"- source: `{event.get('source')}`",
         f"- effective_action: `{before.get('effective_action')}`",
         f"- monitor_target: `{(event.get('monitor_target') or {}).get('target_id') if isinstance(event.get('monitor_target'), dict) else ''}`",
+        f"- todo_id: `{event.get('todo_id') or ''}`",
+        f"- target_key: `{event.get('target_key') or ''}`",
+        f"- material_change: `{event.get('material_change')}`",
         f"- should_run: `{before.get('should_run')}`",
         f"- self_repair_allowed: `{before.get('self_repair_allowed')}`",
         f"- state: `{before.get('state')}`",
         f"- health_check: {payload.get('health_check')}",
         f"- reason: {event.get('reason_summary')}",
     ]
+    if todo_writeback:
+        lines.append(
+            "- todo_writeback: "
+            f"dry_run={todo_writeback.get('dry_run')} "
+            f"consecutive_no_change={todo_writeback.get('consecutive_no_change')} "
+            f"last_checked_at={todo_writeback.get('last_checked_at')} "
+            f"next_due_at={todo_writeback.get('next_due_at')}"
+        )
     return "\n".join(lines)
 
 

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -22,6 +22,7 @@ from .status import (
     todo_role_for_heading,
 )
 from .todo_contract import (
+    TODO_MONITOR_METADATA_FIELDS,
     TODO_STATUS_DONE,
     TODO_STATUS_OPEN,
     TODO_TASK_CLASS_USER_GATE,
@@ -925,6 +926,7 @@ def apply_todo_update_to_lines(
     unblocks_todo_id: str | None = None,
     resume_when: str | None = None,
     no_followup: bool | None = None,
+    monitor_metadata: dict[str, Any] | None = None,
     clear_claim: bool = False,
     claim_only: bool = False,
     updated_at: str,
@@ -993,6 +995,9 @@ def apply_todo_update_to_lines(
         updates["resume_when"] = resume_when
     if no_followup is not None:
         updates["no_followup"] = no_followup
+    for key, value in (monitor_metadata or {}).items():
+        if key in TODO_MONITOR_METADATA_FIELDS:
+            updates[key] = value
     metadata_line = metadata_line_for_block(block, updates)
     semantic_metadata_changed = todo_metadata_would_change(lines, block, metadata_line)
     if status_changed or text_changed or semantic_metadata_changed:
@@ -1050,6 +1055,7 @@ def update_goal_todo(
     unblocks_todo_id: str | None = None,
     resume_when: str | None = None,
     no_followup: bool | None = None,
+    monitor_metadata: dict[str, Any] | None = None,
     clear_claim: bool = False,
     claim_only: bool = False,
     project: Path | None = None,
@@ -1169,6 +1175,7 @@ def update_goal_todo(
             unblocks_todo_id=normalized_unblocks_todo_id,
             resume_when=normalized_resume_when,
             no_followup=no_followup,
+            monitor_metadata=monitor_metadata,
             clear_claim=clear_claim,
             claim_only=claim_only,
             updated_at=updated_at,


### PR DESCRIPTION
## Summary
- Extend `quota monitor-poll` so due `continuous_monitor` todos can write back `last_checked_at`, `next_due_at`, `result_hash`, `consecutive_no_change`, and `material_change`.
- Support material transition follow-ups via optional next agent/user todos while keeping unchanged polls no-spend.
- Document the monitor-poll contract and add a focused smoke for unchanged and material-transition writeback.

## Validation
- `python3 -m py_compile loopx/quota.py loopx/todos.py loopx/cli_commands/quota.py examples/monitor-poll-writeback-smoke.py`
- `python3 examples/monitor-poll-writeback-smoke.py`
- `python3 examples/work-lane-contract-smoke.py`
- `git diff --check`
- `loopx check --scan-path loopx/quota.py --scan-path loopx/todos.py --scan-path loopx/cli_commands/quota.py --scan-path docs/quota-allocation.md --scan-path examples/monitor-poll-writeback-smoke.py`

Stacked on #761 because this consumes `work_lane_contract.obligation=attempt_due_monitor`. Runtime/control-plane change, so leaving for primary review/merge.