### PR TITLE
Add monitor scheduler smoke coverage

### DIFF
--- a/examples/autonomous-replan-obligation-smoke.py
+++ b/examples/autonomous-replan-obligation-smoke.py
@@ -100,6 +100,7 @@ def write_fixture(
     *,
     include_replan_signals: bool,
     include_run_history_stalls: bool = False,
+    monitor_poll_repeat_count: int = 0,
     periodic_run_count: int = 0,
     include_recent_replan_ack: bool = False,
 ) -> tuple[Path, Path]:
@@ -181,7 +182,7 @@ def write_fixture(
         + "\n",
         encoding="utf-8",
     )
-    if include_run_history_stalls or periodic_run_count or include_recent_replan_ack:
+    if include_run_history_stalls or monitor_poll_repeat_count or periodic_run_count or include_recent_replan_ack:
         runs_dir = runtime / "goals" / GOAL_ID / "runs"
         if include_recent_replan_ack:
             append_run_record(
@@ -204,6 +205,27 @@ def write_fixture(
                             "auto_evidence": [],
                             "accepted_without_delta": False,
                         },
+                    },
+                },
+            )
+    if monitor_poll_repeat_count:
+        runs_dir = runtime / "goals" / GOAL_ID / "runs"
+        for offset in range(monitor_poll_repeat_count):
+            minute = monitor_poll_repeat_count - offset
+            append_run_record(
+                runs_dir,
+                {
+                    "generated_at": f"2026-01-01T00:{minute:02d}:00+00:00",
+                    "classification": "quota_monitor_poll",
+                    "recommended_action": "monitor poll unchanged; no material transition",
+                    "health_check": "quota monitor poll unchanged; no material transition",
+                    "delivery_outcome": "surface_only",
+                    "monitor_target": {
+                        "schema_version": "quota_monitor_target_v0",
+                        "target_id": "repeat-monitor-target",
+                        "monitor_mode": "due_monitor_observed_without_material_transition",
+                        "effective_action": "normal_run",
+                        "agent_id": "codex-product-capability",
                     },
                 },
             )
@@ -311,6 +333,49 @@ def assert_replan_obligation_projected_from_run_history() -> None:
         assert guard["execution_obligation"]["kind"] == "autonomous_replan_required", guard
         assert guard["automation_liveness"]["automation_action"] == "execute_bounded_work", guard
         assert guard["automation_liveness"]["pause_allowed"] is False, guard
+
+
+def assert_dead_monitor_repeat_requires_six_same_target_polls() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-dead-monitor-repeat-") as tmp:
+        registry_path, runtime = write_fixture(
+            Path(tmp),
+            include_replan_signals=False,
+            monitor_poll_repeat_count=5,
+        )
+        status_payload = run_cli("status", registry_path=registry_path, runtime=runtime)
+        item = attention_item(status_payload)
+        assert "autonomous_replan_obligation" not in item, item
+        assert "autonomous_replan_obligation" not in item["project_asset"], item
+        guard = run_cli("quota", "should-run", "--goal-id", GOAL_ID, registry_path=registry_path, runtime=runtime)
+        assert "autonomous_replan_obligation" not in guard, guard
+        assert guard["heartbeat_recommendation"]["recommended_mode"] != "autonomous_replan_required", guard
+
+    with tempfile.TemporaryDirectory(prefix="loopx-dead-monitor-repeat-") as tmp:
+        registry_path, runtime = write_fixture(
+            Path(tmp),
+            include_replan_signals=False,
+            monitor_poll_repeat_count=6,
+        )
+        status_payload = run_cli("status", registry_path=registry_path, runtime=runtime)
+        item = attention_item(status_payload)
+        obligation = item["project_asset"]["autonomous_replan_obligation"]
+        detector = obligation["dead_monitor_detector"]
+        assert obligation["schema_version"] == "autonomous_replan_obligation_v0", obligation
+        assert obligation["required"] is True, obligation
+        assert obligation["stall_threshold"] == 6, obligation
+        assert obligation["trigger_count"] == 1, obligation
+        assert obligation["triggers"][0]["kind"] == "dead_monitor_repeat", obligation
+        assert obligation["triggers"][0]["run_count"] == 6, obligation
+        assert detector["schema_version"] == "dead_monitor_repeat_v0", detector
+        assert detector["monitor_target_id"] == "repeat-monitor-target", detector
+        assert detector["run_count"] == 6, detector
+        assert detector["threshold"] == 6, detector
+
+        guard = run_cli("quota", "should-run", "--goal-id", GOAL_ID, registry_path=registry_path, runtime=runtime)
+        assert guard["autonomous_replan_obligation"] == obligation, guard
+        assert guard["heartbeat_recommendation"]["recommended_mode"] == "autonomous_replan_required", guard
+        assert guard["execution_obligation"]["kind"] == "autonomous_replan_required", guard
+        assert guard["execution_obligation"]["stall_threshold"] == 6, guard
 
 
 def assert_periodic_replan_obligation_projected_from_run_history() -> None:
@@ -519,6 +584,7 @@ def main() -> int:
     USE_SUBPROCESS_CLI = "--subprocess-cli" in argv
     assert_replan_obligation_projected()
     assert_replan_obligation_projected_from_run_history()
+    assert_dead_monitor_repeat_requires_six_same_target_polls()
     assert_periodic_replan_obligation_projected_from_run_history()
     assert_no_periodic_replan_before_threshold_or_after_ack()
     assert_validated_classification_without_ack_does_not_clear_replan()

--- a/examples/monitor-poll-writeback-smoke.py
+++ b/examples/monitor-poll-writeback-smoke.py
@@ -167,6 +167,19 @@ def find_todo(state_file: Path, todo_id: str) -> dict:
     raise AssertionError(f"missing todo {todo_id}")
 
 
+def run_index_records(registry_path: Path) -> list[dict]:
+    registry = json.loads(registry_path.read_text(encoding="utf-8"))
+    runtime = Path(str(registry["common_runtime_root"]))
+    index_path = runtime / "goals" / GOAL_ID / "runs" / "index.jsonl"
+    if not index_path.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in index_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
 def assert_due_monitor_selected(registry_path: Path, *, due_count: int = 1) -> None:
     quota = run_cli(
         registry_path,
@@ -215,6 +228,11 @@ def assert_unchanged_writeback() -> None:
         assert item["last_checked_at"], item
         assert item["next_due_at"] != "2026-01-01T00:00:00+00:00", item
         assert item["material_change"] == "false", item
+        assert payload["classification"] == "quota_monitor_poll", payload
+        assert payload["delivery_outcome"] == "surface_only", payload
+        assert "no quota spend" in payload["health_check"], payload
+        records = run_index_records(registry_path)
+        assert [record["classification"] for record in records] == ["quota_monitor_poll"], records
 
 
 def assert_material_transition_followup() -> None:
@@ -255,6 +273,9 @@ def assert_material_transition_followup() -> None:
         ]
         assert successors, agent_todos(state_file)
         assert successors[0]["task_class"] == "advancement_task", successors[0]
+        records = run_index_records(registry_path)
+        assert [record["classification"] for record in records] == ["quota_monitor_poll"], records
+        assert records[0]["delivery_outcome"] == "outcome_progress", records[0]
 
 
 def assert_target_key_cannot_hijack_selected_due_monitor() -> None:
@@ -266,7 +287,7 @@ def assert_target_key_cannot_hijack_selected_due_monitor() -> None:
         )
         assert_due_monitor_selected(registry_path, due_count=2)
 
-        run_cli_expect_error(
+        result = run_cli_expect_error(
             registry_path,
             "quota",
             "monitor-poll",
@@ -280,10 +301,14 @@ def assert_target_key_cannot_hijack_selected_due_monitor() -> None:
             "new",
             "--execute",
         )
+        payload = json.loads(result.stdout)
+        assert payload["ok"] is False, payload
+        assert "monitor-poll requires" in payload["reason"], payload
         selected = find_todo(state_file, TODO_ID)
         other = find_todo(state_file, "todo_monitorpoll111")
         assert selected["result_hash"] == "old", selected
         assert other["result_hash"] == "old", other
+        assert run_index_records(registry_path) == [], run_index_records(registry_path)
 
 
 def main() -> int:

--- a/examples/monitor-scheduler-contract-smoke.py
+++ b/examples/monitor-scheduler-contract-smoke.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Smoke-test scheduled monitor lane routing without growing the large lane smoke."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.quota import build_quota_should_run, render_quota_should_run_markdown  # noqa: E402
+from loopx.status import compact_todo_group  # noqa: E402
+
+
+GOAL_ID = "monitor-scheduler-fixture"
+AGENT_ID = "codex-product-capability"
+PAST_DUE_AT = "2000-01-01T00:00:00+00:00"
+FUTURE_DUE_AT = "2999-01-01T00:00:00+00:00"
+
+
+def status_payload(*, agent_todo_items: list[dict], status: str = "monitor_scheduler_fixture") -> dict:
+    agent_todos = compact_todo_group(
+        agent_todo_items,
+        source_section="Agent Todo",
+        role="agent",
+    )
+    return {
+        "ok": True,
+        "attention_queue": {
+            "items": [
+                {
+                    "goal_id": GOAL_ID,
+                    "status": status,
+                    "waiting_on": "codex",
+                    "severity": "info",
+                    "source": "project_asset",
+                    "recommended_action": "Route scheduled monitor todos from structured metadata.",
+                    "quota": {
+                        "compute": 1.0,
+                        "window_hours": 24,
+                        "slot_minutes": 1,
+                        "allowed_slots": 10,
+                        "spent_slots": 0,
+                        "state": "eligible",
+                        "reason": "eligible fixture",
+                    },
+                    "project_asset": {
+                        "next_action": "Route scheduled monitor todos from structured metadata.",
+                        "stop_condition": "stop on private material",
+                        "agent_todos": agent_todos,
+                    },
+                }
+            ]
+        },
+        "run_history": {
+            "goals": [
+                {
+                    "id": GOAL_ID,
+                    "registry_member": True,
+                    "status": status,
+                    "adapter_kind": "harness_self_improvement",
+                    "adapter_status": "connected-read-only",
+                    "quota": {
+                        "compute": 1.0,
+                        "window_hours": 24,
+                        "slot_minutes": 1,
+                        "allowed_slots": 10,
+                    },
+                    "coordination": {
+                        "registered_agents": [AGENT_ID],
+                        "primary_agent": AGENT_ID,
+                    },
+                }
+            ]
+        },
+    }
+
+
+def monitor_item(
+    *,
+    index: int,
+    todo_id: str,
+    priority: str,
+    next_due_at: str,
+    target_key: str,
+) -> dict:
+    return {
+        "index": index,
+        "text": f"[{priority}] Monitor {target_key} and write back only material transitions.",
+        "todo_id": todo_id,
+        "role": "agent",
+        "status": "open",
+        "priority": priority,
+        "task_class": "continuous_monitor",
+        "action_kind": "monitor",
+        "claimed_by": AGENT_ID,
+        "target_key": target_key,
+        "cadence": "15m",
+        "next_due_at": next_due_at,
+    }
+
+
+def advancement_item(*, index: int, priority: str = "P1") -> dict:
+    return {
+        "index": index,
+        "text": f"[{priority}] Advance the runtime contract slice with validation.",
+        "todo_id": f"todo_adv_{index}",
+        "role": "agent",
+        "status": "open",
+        "priority": priority,
+        "task_class": "advancement_task",
+        "claimed_by": AGENT_ID,
+    }
+
+
+def guard_for(items: list[dict]) -> dict:
+    return build_quota_should_run(
+        status_payload(agent_todo_items=items),
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+    )
+
+
+def assert_not_due_monitor_waits_quietly() -> None:
+    guard = guard_for(
+        [
+            monitor_item(
+                index=1,
+                todo_id="todo_monitor_wait",
+                priority="P1",
+                next_due_at=FUTURE_DUE_AT,
+                target_key="update-note-draft-pr",
+            )
+        ]
+    )
+    lane = guard["work_lane_contract"]
+    assert guard["decision"] == "skip", guard
+    assert guard["effective_action"] == "monitor_quiet_skip", guard
+    assert lane["obligation"] == "quiet_until_material_monitor_transition", lane
+    assert lane["must_attempt_work"] is False, lane
+    assert guard["agent_todo_summary"]["monitor_due_count"] == 0, guard
+
+
+def assert_due_monitor_requires_explicit_attempt() -> None:
+    guard = guard_for(
+        [
+            monitor_item(
+                index=1,
+                todo_id="todo_monitor_due",
+                priority="P1",
+                next_due_at=PAST_DUE_AT,
+                target_key="update-note-draft-pr",
+            )
+        ]
+    )
+    lane = guard["work_lane_contract"]
+    assert guard["decision"] == "run", guard
+    assert guard["effective_action"] == "normal_run", guard
+    assert lane["monitor_kind"] == "todo_monitor_due", lane
+    assert lane["obligation"] == "attempt_due_monitor", lane
+    assert lane["must_attempt_work"] is True, lane
+    assert lane["selected_todo_id"] == "todo_monitor_due", lane
+    assert guard["interaction_contract"]["agent_channel"]["must_attempt"] is True, guard
+    assert guard["interaction_contract"]["agent_channel"]["quiet_noop_allowed"] is False, guard
+
+
+def assert_due_monitor_priority_does_not_steal_advancement_lane() -> None:
+    guard = guard_for(
+        [
+            monitor_item(
+                index=1,
+                todo_id="todo_monitor_due_p2",
+                priority="P2",
+                next_due_at=PAST_DUE_AT,
+                target_key="low-priority-watch",
+            ),
+            advancement_item(index=2, priority="P1"),
+        ]
+    )
+    lane = guard["work_lane_contract"]
+    assert lane["lane"] == "advancement_task", lane
+    assert lane["reason_codes"] == ["open_agent_todo", "due_monitor_context"], lane
+    assert guard["agent_todo_summary"]["monitor_due_count"] == 1, guard
+
+
+def assert_multiple_due_monitor_cap_and_order() -> None:
+    guard = guard_for(
+        [
+            monitor_item(
+                index=5,
+                todo_id="todo_monitor_due_p1",
+                priority="P1",
+                next_due_at=PAST_DUE_AT,
+                target_key="p1-watch",
+            ),
+            monitor_item(
+                index=9,
+                todo_id="todo_monitor_due_p0_late",
+                priority="P0",
+                next_due_at=PAST_DUE_AT,
+                target_key="p0-late-watch",
+            ),
+            monitor_item(
+                index=3,
+                todo_id="todo_monitor_due_p0_first",
+                priority="P0",
+                next_due_at=PAST_DUE_AT,
+                target_key="p0-first-watch",
+            ),
+        ]
+    )
+    lane = guard["work_lane_contract"]
+    assert lane["obligation"] == "attempt_due_monitor", lane
+    assert lane["monitor_due_count"] == 3, lane
+    assert len(lane["monitor_due_items"]) == 1, lane
+    assert lane["monitor_due_items"][0]["todo_id"] == "todo_monitor_due_p0_first", lane
+    assert lane["selected_todo_id"] == "todo_monitor_due_p0_first", lane
+    assert guard["agent_todo_summary"]["monitor_due_count"] == 3, guard
+    assert len(guard["agent_todo_summary"]["monitor_due_items"]) == 1, guard
+    markdown = render_quota_should_run_markdown(guard)
+    assert "work_lane_monitor_due: count=3" in markdown, markdown
+
+
+def main() -> int:
+    assert_not_due_monitor_waits_quietly()
+    assert_due_monitor_requires_explicit_attempt()
+    assert_due_monitor_priority_does_not_steal_advancement_lane()
+    assert_multiple_due_monitor_cap_and_order()
+    print("monitor-scheduler-contract-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -8181,8 +8181,8 @@ def record_quota_monitor_poll(
             "appended": False,
             "registry_mutated": False,
             "reason": (
-                before.get("reason")
-                or "monitor-poll requires monitor_quiet_skip, due monitor todo, or external monitor observation"
+                "monitor-poll requires monitor_quiet_skip, due monitor todo, "
+                "or external monitor observation"
             ),
             "before": before,
             "after": None,


### PR DESCRIPTION
## Summary
- add a focused monitor scheduler contract smoke for not-due quiet skip, due monitor must-attempt routing, priority interaction with advancement work, and multiple-due monitor cap/order behavior
- extend monitor-poll writeback smoke to assert no-spend run-index evidence, material-transition outcome, and target-key hijack rejection
- extend autonomous replan smoke to enforce the six same-target quota_monitor_poll threshold before dead-monitor replan obligation
- tighten monitor-poll failure reason when the current quota decision is not an allowed monitor observation

## Validation
- python3 -m py_compile loopx/quota.py loopx/status.py loopx/cli_commands/quota.py examples/monitor-poll-writeback-smoke.py examples/monitor-scheduler-contract-smoke.py examples/autonomous-replan-obligation-smoke.py
- python3 examples/monitor-scheduler-contract-smoke.py
- python3 examples/monitor-poll-writeback-smoke.py
- python3 examples/autonomous-replan-obligation-smoke.py
- python3 examples/work-lane-contract-smoke.py
- git diff --check
- loopx check --scan-path loopx/quota.py --scan-path loopx/status.py --scan-path loopx/cli_commands/quota.py --scan-path examples/monitor-poll-writeback-smoke.py --scan-path examples/monitor-scheduler-contract-smoke.py --scan-path examples/autonomous-replan-obligation-smoke.py

LoopX check warning only: existing duplicate loopx-meta index rows raw=5739 unique=5735.