### PR TITLE
Add monitor cadence todo CLI metadata

### DIFF
--- a/examples/todo-cli-smoke.py
+++ b/examples/todo-cli-smoke.py
@@ -23,6 +23,9 @@ USER_TODO = "Review the owner decision checklist before approving delivery."
 SCOPED_USER_GATE = "Choose the side-agent publishing channel before posting externally."
 AGENT_TODO = "Summarize the read-only evidence after the user checklist is done."
 UPDATED_AGENT_TODO = "Publish the compact evidence summary after validation passes."
+MONITOR_TODO = "Monitor the release-note draft PR until the next scheduled check."
+MONITOR_DUE_AT = "2026-01-02T00:00:00+00:00"
+MONITOR_NEXT_DUE_AT = "2026-01-03T00:00:00+00:00"
 
 
 def write_fixture(root: Path, *, register_agents: bool = True) -> tuple[Path, Path]:
@@ -252,6 +255,72 @@ def main() -> int:
         assert fields["user_todos"]["source_section"] == "User Todo / Owner Review Reading Queue", fields
         assert fields["agent_todos"]["source_section"] == "Agent Todo", fields
 
+        monitor_payload = run_cli(
+            registry_path,
+            "todo",
+            "add",
+            "--goal-id",
+            GOAL_ID,
+            "--role",
+            "agent",
+            "--text",
+            MONITOR_TODO,
+            "--task-class",
+            "continuous_monitor",
+            "--action-kind",
+            "release_note_draft_monitor",
+            "--monitor-target-key",
+            "release-note-draft-pr",
+            "--cadence",
+            "1d",
+            "--next-due-at",
+            MONITOR_DUE_AT,
+            "--claimed-by",
+            "codex-side-bypass",
+        )
+        assert monitor_payload["added"] is True, monitor_payload
+        assert monitor_payload["target_key"] == "release-note-draft-pr", monitor_payload
+        assert monitor_payload["cadence"] == "1d", monitor_payload
+        assert monitor_payload["next_due_at"] == MONITOR_DUE_AT, monitor_payload
+        monitor_update = run_cli(
+            registry_path,
+            "todo",
+            "update",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            monitor_payload["todo_id"],
+            "--cadence",
+            "2d",
+            "--next-due-at",
+            MONITOR_NEXT_DUE_AT,
+            "--note",
+            "Rescheduled after a quiet check.",
+        )
+        assert monitor_update["changed"] is True, monitor_update
+        assert monitor_update["cadence"] == "2d", monitor_update
+        assert monitor_update["next_due_at"] == MONITOR_NEXT_DUE_AT, monitor_update
+        invalid_monitor_schedule = run_cli_error(
+            registry_path,
+            "todo",
+            "update",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            agent_payload["todo_id"],
+            "--cadence",
+            "1d",
+        )
+        assert "monitor schedule metadata requires" in invalid_monitor_schedule["error"], invalid_monitor_schedule
+        fields = parse_active_state_todos(state_file.read_text(encoding="utf-8"))
+        monitor_item = next(
+            item for item in fields["agent_todos"]["items"] if item["text"] == MONITOR_TODO
+        )
+        assert monitor_item["task_class"] == "continuous_monitor", fields
+        assert monitor_item["target_key"] == "release-note-draft-pr", fields
+        assert monitor_item["cadence"] == "2d", fields
+        assert monitor_item["next_due_at"] == MONITOR_NEXT_DUE_AT, fields
+
         status_payload = {
             "ok": True,
             "goal_count": 1,
@@ -358,7 +427,9 @@ def main() -> int:
         claimed_fields = parse_active_state_todos(state_file.read_text(encoding="utf-8"))
         claimed_item = claimed_fields["agent_todos"]["items"][0]
         assert claimed_item["claimed_by"] == "codex-main-control", claimed_item
-        assert claimed_fields["agent_todos"]["claimed_open_count"] == 1, claimed_fields
+        assert claimed_fields["agent_todos"]["claimed_open_count"] == 2, claimed_fields
+        assert claimed_fields["agent_todos"]["claimed_advancement_open_count"] == 1, claimed_fields
+        assert claimed_fields["agent_todos"]["claimed_monitor_open_count"] == 1, claimed_fields
         assert claimed_fields["agent_todos"]["unclaimed_open_count"] == 0, claimed_fields
 
         preserve_claim_payload = run_cli(
@@ -440,7 +511,11 @@ def main() -> int:
         assert "status=done" in after_update, after_update
         assert "Validated%20compact%20evidence%20summary." in after_update, after_update
         updated_fields = parse_active_state_todos(after_update)
-        updated_agent_item = updated_fields["agent_todos"]["items"][0]
+        updated_agent_item = next(
+            item
+            for item in updated_fields["agent_todos"]["items"]
+            if item["todo_id"] == metadata_payload["todo_id"]
+        )
         assert updated_agent_item["text"] == UPDATED_AGENT_TODO, updated_agent_item
         assert updated_agent_item["status"] == "done", updated_agent_item
         assert updated_agent_item["done"] is True, updated_agent_item

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -154,6 +154,29 @@ def register_todo_command(subparsers: argparse._SubParsersAction) -> None:
         ),
     )
     todo_parser.add_argument(
+        "--monitor-target-key",
+        dest="monitor_target_key",
+        help=(
+            "For agent continuous_monitor add/update, declare the stable public-safe "
+            "watch target key, such as github-pr-123 or update-note-draft-pr."
+        ),
+    )
+    todo_parser.add_argument(
+        "--cadence",
+        help=(
+            "For agent continuous_monitor add/update, declare the monitor cadence, "
+            "such as 30m, 2h, or 1d."
+        ),
+    )
+    todo_parser.add_argument(
+        "--next-due-at",
+        dest="next_due_at",
+        help=(
+            "For agent continuous_monitor add/update, declare the next due ISO "
+            "timestamp; due monitor scheduling is based on this field."
+        ),
+    )
+    todo_parser.add_argument(
         "--clear-claim",
         action="store_true",
         help="For todo update, remove the soft claimed_by owner from the todo.",
@@ -288,6 +311,9 @@ def handle_todo_command(
                     ("--global-gate", args.global_gate),
                     ("--unblocks-todo-id", args.unblocks_todo_id),
                     ("--resume-when", args.resume_when),
+                    ("--monitor-target-key", args.monitor_target_key),
+                    ("--cadence", args.cadence),
+                    ("--next-due-at", args.next_due_at),
                     ("--clear-claim", args.clear_claim),
                     ("--no-follow-up", args.no_follow_up),
                     ("--next-agent-todo", args.next_agent_todo),
@@ -349,6 +375,11 @@ def handle_todo_command(
                 agent_id=args.agent_id,
                 unblocks_todo_id=args.unblocks_todo_id,
                 resume_when=args.resume_when,
+                monitor_metadata={
+                    "target_key": args.monitor_target_key,
+                    "cadence": args.cadence,
+                    "next_due_at": args.next_due_at,
+                },
                 project=Path(args.project).expanduser() if args.project else None,
                 state_file=Path(args.state_file).expanduser() if args.state_file else None,
                 dry_run=bool(args.dry_run),
@@ -377,6 +408,9 @@ def handle_todo_command(
                     ("--global-gate", args.global_gate),
                     ("--unblocks-todo-id", args.unblocks_todo_id),
                     ("--resume-when", args.resume_when),
+                    ("--monitor-target-key", args.monitor_target_key),
+                    ("--cadence", args.cadence),
+                    ("--next-due-at", args.next_due_at),
                     ("--no-follow-up", args.no_follow_up),
                     ("--next-agent-todo", args.next_agent_todo),
                     ("--next-user-todo", args.next_user_todo),
@@ -428,9 +462,12 @@ def handle_todo_command(
                 args.unblocks_todo_id,
                 args.resume_when,
                 args.no_follow_up,
+                args.monitor_target_key,
+                args.cadence,
+                args.next_due_at,
                 args.clear_claim,
             ]):
-                raise ValueError("todo update requires at least one of --text, --status, --note, --evidence, --reason, --task-class, --action-kind, --required-write-scope, --required-capability, --target-capability, --claimed-by, --blocks-agent, --global-gate, --unblocks-todo-id, --resume-when, --no-follow-up, or --clear-claim")
+                raise ValueError("todo update requires at least one of --text, --status, --note, --evidence, --reason, --task-class, --action-kind, --required-write-scope, --required-capability, --target-capability, --claimed-by, --blocks-agent, --global-gate, --unblocks-todo-id, --resume-when, --monitor-target-key, --cadence, --next-due-at, --no-follow-up, or --clear-claim")
             if args.no_follow_up and not (args.note or args.reason or args.evidence):
                 raise ValueError("--no-follow-up requires --note, --reason, or --evidence")
             if args.followups:
@@ -461,6 +498,11 @@ def handle_todo_command(
                 unblocks_todo_id=args.unblocks_todo_id,
                 resume_when=args.resume_when,
                 no_followup=True if args.no_follow_up else None,
+                monitor_metadata={
+                    "target_key": args.monitor_target_key,
+                    "cadence": args.cadence,
+                    "next_due_at": args.next_due_at,
+                },
                 clear_claim=bool(args.clear_claim),
                 project=Path(args.project).expanduser() if args.project else None,
                 state_file=Path(args.state_file).expanduser() if args.state_file else None,
@@ -473,6 +515,8 @@ def handle_todo_command(
                 raise ValueError("todo complete accepts either --claimed-by or --clear-claim, not both")
             if args.blocks_agent or args.global_gate or args.unblocks_todo_id or args.resume_when:
                 raise ValueError("todo complete does not support --blocks-agent, --global-gate, --unblocks-todo-id, or --resume-when; use todo update before completion or side-agent handoff successor metadata")
+            if args.monitor_target_key or args.cadence or args.next_due_at:
+                raise ValueError("todo complete does not support monitor schedule metadata; use todo update before completion")
             if args.no_follow_up and (args.next_agent_todo or args.next_user_todo):
                 raise ValueError("--no-follow-up cannot be combined with successor todos")
             if args.no_follow_up and not (args.note or args.evidence):
@@ -518,6 +562,8 @@ def handle_todo_command(
                 raise ValueError("todo supersede does not support --follow-up; use `todo capture-followups`")
             if args.blocks_agent or args.global_gate or args.unblocks_todo_id or args.resume_when:
                 raise ValueError("todo supersede does not support --blocks-agent, --global-gate, --unblocks-todo-id, or --resume-when; update the source todo first so the successor can inherit dependency metadata")
+            if args.monitor_target_key or args.cadence or args.next_due_at:
+                raise ValueError("todo supersede does not support monitor schedule metadata; use todo update before supersede")
             payload = supersede_goal_todo(
                 registry_path=registry_path,
                 goal_id=args.goal_id,
@@ -574,6 +620,9 @@ def handle_todo_command(
                     ("--global-gate", args.global_gate),
                     ("--unblocks-todo-id", args.unblocks_todo_id),
                     ("--resume-when", args.resume_when),
+                    ("--monitor-target-key", args.monitor_target_key),
+                    ("--cadence", args.cadence),
+                    ("--next-due-at", args.next_due_at),
                     ("--no-follow-up", args.no_follow_up),
                     ("--clear-claim", args.clear_claim),
                     ("--next-agent-todo", args.next_agent_todo),
@@ -619,6 +668,9 @@ def handle_todo_command(
                     ("--global-gate", args.global_gate),
                     ("--unblocks-todo-id", args.unblocks_todo_id),
                     ("--resume-when", args.resume_when),
+                    ("--monitor-target-key", args.monitor_target_key),
+                    ("--cadence", args.cadence),
+                    ("--next-due-at", args.next_due_at),
                     ("--no-follow-up", args.no_follow_up),
                     ("--clear-claim", args.clear_claim),
                     ("--next-agent-todo", args.next_agent_todo),

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -19,6 +19,7 @@ from .status import (
     compact_todo_group,
     normalize_todo_text,
     parse_active_state_todos,
+    parse_timestamp,
     todo_role_for_heading,
 )
 from .todo_contract import (
@@ -81,6 +82,11 @@ TODO_METADATA_FIELDS = (
     "superseded_by",
 )
 TODO_PRIORITY_PREFIX_PATTERN = re.compile(r"^\[(P[0-4])\]\s+", re.IGNORECASE)
+MONITOR_CADENCE_PATTERN = re.compile(
+    r"^\s*(?P<count>[1-9][0-9]{0,4})\s*"
+    r"(?P<unit>s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days)\s*$",
+    re.IGNORECASE,
+)
 
 
 def normalize_new_todo(text: str) -> str:
@@ -105,6 +111,37 @@ def inherit_todo_priority(next_text: str, source_text: str | None) -> str:
     if not source_priority:
         return normalized
     return f"[{source_priority}] {normalized}"
+
+
+def normalize_monitor_metadata(metadata: dict[str, Any] | None) -> dict[str, str]:
+    normalized: dict[str, str] = {}
+    for key, value in (metadata or {}).items():
+        if key not in {"target_key", "cadence", "next_due_at"}:
+            continue
+        candidate = str(value or "").strip()
+        if candidate:
+            normalized[key] = candidate
+    if "cadence" in normalized and not MONITOR_CADENCE_PATTERN.match(normalized["cadence"]):
+        raise ValueError("--cadence must look like 30m, 2h, or 1d")
+    if "next_due_at" in normalized and parse_timestamp(normalized["next_due_at"]) is None:
+        raise ValueError("--next-due-at must be an ISO timestamp")
+    return normalized
+
+
+def require_monitor_metadata_scope(
+    *,
+    monitor_metadata: dict[str, Any] | None,
+    role: str,
+    task_class: str | None,
+) -> dict[str, str]:
+    normalized = normalize_monitor_metadata(monitor_metadata)
+    if not normalized:
+        return {}
+    if role != "agent" or task_class != "continuous_monitor":
+        raise ValueError(
+            "monitor schedule metadata requires --role agent --task-class continuous_monitor"
+        )
+    return normalized
 
 
 def resolve_todo_state_path(
@@ -610,9 +647,15 @@ def add_todo_to_lines(
     global_gate: bool | None = None,
     unblocks_todo_id: str | None = None,
     resume_when: str | None = None,
+    monitor_metadata: dict[str, Any] | None = None,
     evidence: str | None = None,
 ) -> dict[str, Any]:
     todo_text = normalize_new_todo(text)
+    normalized_monitor_metadata = require_monitor_metadata_scope(
+        monitor_metadata=monitor_metadata,
+        role=role,
+        task_class=task_class,
+    )
     bounds = section_bounds(lines, role)
     section = bounds[2] if bounds else TODO_SECTION_HEADINGS[role]
     existing_blocks = (
@@ -651,6 +694,7 @@ def add_todo_to_lines(
             global_gate=global_gate,
             unblocks_todo_id=unblocks_todo_id,
             resume_when=resume_when,
+            **normalized_monitor_metadata,
             evidence=evidence,
         )
         todo_line = "\n".join([f"- [ ] {todo_text}", metadata_line] if metadata_line else [f"- [ ] {todo_text}"])
@@ -684,6 +728,7 @@ def add_todo_to_lines(
             updates["unblocks_todo_id"] = unblocks_todo_id
         if resume_when:
             updates["resume_when"] = resume_when
+        updates.update(normalized_monitor_metadata)
         if evidence:
             updates["evidence"] = evidence
         metadata_line = metadata_line_for_block(block, updates)
@@ -715,6 +760,9 @@ def add_todo_to_lines(
         "global_gate": normalize_todo_global_gate(effective_metadata.get("global_gate")),
         "unblocks_todo_id": normalize_todo_id(effective_metadata.get("unblocks_todo_id")),
         "resume_when": normalize_todo_resume_when(effective_metadata.get("resume_when")),
+        "target_key": effective_metadata.get("target_key"),
+        "cadence": effective_metadata.get("cadence"),
+        "next_due_at": effective_metadata.get("next_due_at"),
         "evidence": effective_metadata.get("evidence") or evidence,
     }
 
@@ -765,6 +813,7 @@ def add_goal_todo(
     agent_id: str | None = None,
     unblocks_todo_id: str | None = None,
     resume_when: str | None = None,
+    monitor_metadata: dict[str, Any] | None = None,
     project: Path | None = None,
     state_file: Path | None = None,
     dry_run: bool = False,
@@ -836,6 +885,11 @@ def add_goal_todo(
         normalized_resume_when = normalize_todo_resume_when(resume_when) if resume_when else None
         if resume_when and not normalized_resume_when:
             raise ValueError("resume_when must be public-safe, e.g. todo_done:todo_ab12cd34ef56 or pr_merged:#532")
+        normalized_monitor_metadata = require_monitor_metadata_scope(
+            monitor_metadata=monitor_metadata,
+            role=role,
+            task_class=task_class,
+        )
         add_result = add_todo_to_lines(
             lines,
             role=role,
@@ -850,6 +904,7 @@ def add_goal_todo(
             global_gate=True if global_gate else None,
             unblocks_todo_id=normalized_unblocks_todo_id,
             resume_when=normalized_resume_when,
+            monitor_metadata=normalized_monitor_metadata,
         )
         added = bool(add_result["added"])
         metadata_updated = bool(add_result["metadata_updated"])
@@ -882,6 +937,9 @@ def add_goal_todo(
         "global_gate": add_result.get("global_gate"),
         "unblocks_todo_id": add_result.get("unblocks_todo_id"),
         "resume_when": add_result.get("resume_when"),
+        "target_key": add_result.get("target_key"),
+        "cadence": add_result.get("cadence"),
+        "next_due_at": add_result.get("next_due_at"),
         "state_file": str(resolved_state_file),
         "project": str(resolved_project) if resolved_project else None,
         "updated_at": updated_at if added or metadata_updated else None,
@@ -1029,6 +1087,9 @@ def apply_todo_update_to_lines(
         "unblocks_todo_id": normalize_todo_id(effective_metadata.get("unblocks_todo_id")),
         "resume_when": normalize_todo_resume_when(effective_metadata.get("resume_when")),
         "no_followup": normalize_todo_no_followup(effective_metadata.get("no_followup")),
+        "target_key": effective_metadata.get("target_key"),
+        "cadence": effective_metadata.get("cadence"),
+        "next_due_at": effective_metadata.get("next_due_at"),
     }
 
 
@@ -1155,6 +1216,11 @@ def update_goal_todo(
         normalized_resume_when = normalize_todo_resume_when(resume_when) if resume_when else None
         if resume_when and not normalized_resume_when:
             raise ValueError("resume_when must be public-safe, e.g. todo_done:todo_ab12cd34ef56 or pr_merged:#532")
+        normalized_monitor_metadata = require_monitor_metadata_scope(
+            monitor_metadata=monitor_metadata,
+            role=target_role,
+            task_class=target_task_class,
+        )
         update_result = apply_todo_update_to_lines(
             lines,
             todo_id=todo_id,
@@ -1175,7 +1241,7 @@ def update_goal_todo(
             unblocks_todo_id=normalized_unblocks_todo_id,
             resume_when=normalized_resume_when,
             no_followup=no_followup,
-            monitor_metadata=monitor_metadata,
+            monitor_metadata=normalized_monitor_metadata,
             clear_claim=clear_claim,
             claim_only=claim_only,
             updated_at=updated_at,
@@ -1638,7 +1704,16 @@ def render_todo_markdown(payload: dict[str, Any]) -> str:
                 marker = todo_marker_for_status(item.get("status") or TODO_STATUS_OPEN)
                 text = item.get("text") or item.get("title") or ""
                 metadata = []
-                for metadata_key in ("todo_id", "status", "task_class", "action_kind", "claimed_by"):
+                for metadata_key in (
+                    "todo_id",
+                    "status",
+                    "task_class",
+                    "action_kind",
+                    "claimed_by",
+                    "target_key",
+                    "cadence",
+                    "next_due_at",
+                ):
                     if item.get(metadata_key):
                         metadata.append(f"{metadata_key}={item.get(metadata_key)}")
                 suffix = f" <!-- {' '.join(metadata)} -->" if metadata else ""
@@ -1682,6 +1757,9 @@ def render_todo_markdown(payload: dict[str, Any]) -> str:
                 f"- blocks_agent: `{payload.get('blocks_agent')}`",
                 f"- global_gate: `{payload.get('global_gate')}`",
                 f"- resume_when: `{payload.get('resume_when')}`",
+                f"- target_key: `{payload.get('target_key')}`",
+                f"- cadence: `{payload.get('cadence')}`",
+                f"- next_due_at: `{payload.get('next_due_at')}`",
             ]
         )
     if payload.get("error"):


### PR DESCRIPTION
## Summary
- add todo CLI flags for continuous monitor scheduling metadata: --monitor-target-key, --cadence, and --next-due-at
- validate that monitor schedule metadata only applies to agent continuous_monitor todos
- extend todo-cli smoke to cover add/update projection and reject schedule metadata on advancement todos

## Validation
- python3 examples/todo-cli-smoke.py
- python3 -m py_compile loopx/todos.py loopx/cli_commands/todo.py examples/todo-cli-smoke.py
- git diff --check
- loopx check --scan-path loopx/todos.py --scan-path loopx/cli_commands/todo.py --scan-path examples/todo-cli-smoke.py

Runtime/CLI behavior change: leaving for main-control review before merge.