### PR TITLE
Update SkillsBench goal-start ledger status

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
@@ -6680,10 +6680,10 @@
             "baseline_failure_scope": "passed",
             "baseline_run_id": "5d3d505e21ca",
             "decision": "paired_treatment_runner_or_setup_repair_required",
-            "failure_class": "skillsbench_host_local_acp_codex_exec_failed_codex_exec_first_action_timeout",
+            "failure_class": "skillsbench_host_local_acp_codex_exec_preflight_failed_codex_exec_exit_1",
             "official_score_delta": null,
             "treatment_failure_scope": "score_missing",
-            "treatment_run_id": "bf47fab7dcc0"
+            "treatment_run_id": "6df25b0a577c"
           },
           "runs": [
             {
@@ -7502,6 +7502,54 @@
                 "original_task_mutated": false,
                 "staged": true,
                 "task_skills_removed": true
+              },
+              "verifier_attempt_countable": false
+            },
+            {
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "codex_loopx_treatment",
+              "artifact_refs": {
+                "compact_artifact_ref": "local-private/skillsbench-powerlifting-explicit-bridge-timeoutprobe-20260627T1048Z/powerlifting-coef-calc__loopx_goal_start_product_mode/benchmark_run.compact.json"
+              },
+              "attempt_failure_class": "none",
+              "attempt_failure_label": "not_run_adapter_skeleton",
+              "attempt_lifecycle_phase": "not_started",
+              "benchmark_id": "skillsbench@1.1",
+              "case_attempt_countable": false,
+              "case_id": "powerlifting-coef-calc",
+              "case_ids": [
+                "powerlifting-coef-calc"
+              ],
+              "codex_acp_runtime_preflight_passed": false,
+              "failure_class": "skillsbench_host_local_acp_codex_exec_preflight_failed_codex_exec_exit_1",
+              "failure_labels": [
+                "skillsbench_host_local_acp_codex_exec_preflight_failed_codex_exec_exit_1",
+                "skillsbench_runner_setup_error"
+              ],
+              "failure_scope": "score_missing",
+              "job_name": "skillsbench-powerlifting-explicit-bridge-timeoutprobe-20260627T1048Z",
+              "launcher_attempt_countable": false,
+              "leaderboard_evidence": false,
+              "loopx_inside_case": true,
+              "mode": "skillsbench_loopx_goal_start_product_mode_treatment",
+              "notes": "explicit bridge command probe: pre-case host-local Codex exec preflight failed with public-safe codex_exec_exit_1 classification; no raw task/log/trajectory read into public state",
+              "official_score_attempt_countable": false,
+              "recorded_at": "2026-06-27T18:41:05+08:00",
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-powerlifting-coef-calc-goal-start-explicit-bridge-preflight-20260627T1048Z",
+              "run_id": "6df25b0a577c",
+              "score_status": "missing",
+              "solver_attempt_countable": false,
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false,
+              "task_staging": {
+                "apt_retry_patch_required": true,
+                "apt_risk_preflight_blocked": false,
+                "apt_setup_risk_detected": true,
+                "staged": false
               },
               "verifier_attempt_countable": false
             }
@@ -9032,7 +9080,7 @@
           ]
         }
       },
-      "run_count": 152
+      "run_count": 153
     },
     "swe-marathon": {
       "benchmark_id": "swe-marathon",
@@ -13084,5 +13132,5 @@
     "source_of_truth": "benchmark_run_v0 compact run events",
     "update_rule": "upsert one run entry when a benchmark case is ingested or closed"
   },
-  "updated_at": "2026-06-27T17:55:18+08:00"
+  "updated_at": "2026-06-27T18:41:05+08:00"
 }

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
@@ -5,7 +5,7 @@ benchmark case outcomes and artifact references; it must not contain raw
 logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 
 - schema_version: `benchmark_run_ledger_v0`
-- updated_at: `2026-06-27T17:55:18+08:00`
+- updated_at: `2026-06-27T18:41:05+08:00`
 
 ## Case Decisions
 
@@ -28,7 +28,7 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `skillsbench@1.1` | `organize-messy-files` | `paired_treatment_improved` | `main_table_ready` | - | `7` |
 | `skillsbench@1.1` | `paratransit-routing` | `product_mode_pair_incomplete` | `treatment_official_feedback_not_blinded,treatment_reward_feedback_forwarding_not_disabled,treatment_compact_metrics_m...` | - | `10` |
 | `skillsbench@1.1` | `pddl-airport-planning` | `paired_no_score_uplift` | - | - | `9` |
-| `skillsbench@1.1` | `powerlifting-coef-calc` | `paired_treatment_runner_or_setup_repair_required` | - | - | `13` |
+| `skillsbench@1.1` | `powerlifting-coef-calc` | `paired_treatment_runner_or_setup_repair_required` | - | - | `14` |
 | `skillsbench@1.1` | `react-performance-debugging` | `paired_baseline_runner_or_setup_repair_required` | - | - | `5` |
 | `skillsbench@1.1` | `setup-fuzzing-py` | `baseline_runner_or_setup_repair_required` | - | - | `3` |
 | `skillsbench@1.1` | `software-dependency-audit` | `paired_no_score_uplift` | - | - | `6` |
@@ -207,6 +207,7 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `skillsbench@1.1` | `powerlifting-coef-calc` | `codex_loopx_treatment` | `` | `0.0` | `` | `1:missing,2:missing,3:missing,4:missing,5:missing,6:missing,7:missing,8:0` | `official_verifier_solution_failure` | `.local/private-benchmark-jobs/skillsbench-powerlifting-coef-calc-canonical-lifecycle-20260622T221910Z-test/powerlifting-coef-calc__loopx_product_mode/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `powerlifting-coef-calc` | `skillsbench_raw_codex_autonomous_max5_baseline` | `case_attempt` | `1.0` | `1` | `1:1*` | `none` | `` |
 | `skillsbench@1.1` | `powerlifting-coef-calc` | `codex_loopx_treatment` | `` | `missing` | `` | `` | `skillsbench_host_local_acp_codex_exec_failed_codex_exec_first_action_timeout` | `` |
+| `skillsbench@1.1` | `powerlifting-coef-calc` | `codex_loopx_treatment` | `` | `missing` | `` | `` | `skillsbench_host_local_acp_codex_exec_preflight_failed_codex_exec_exit_1` | `local-private/skillsbench-powerlifting-explicit-bridge-timeoutprobe-20260627T1048Z/powerlifting-coef-calc__loopx_goal_start_product_mode/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `react-performance-debugging` | `codex_goal_mode_baseline` | `` | `0.0` | `` | `` | `official_verifier_solution_failure` | `result.json` |
 | `skillsbench@1.1` | `react-performance-debugging` | `loopx_automation_loop_treatment` | `` | `0.0` | `` | `` | `official_verifier_solution_failure` | `` |
 | `skillsbench@1.1` | `react-performance-debugging` | `baseline` | `` | `0.0` | `` | `1:0,2:0` | `official_verifier_solution_failure` | `.local/private-benchmark-jobs/skillsbench-react-performance-debugging-blind-baseline-v0/react-performance-debugging__codex_acp_blind_loop_v0/benchmark_run.compact.json` |


### PR DESCRIPTION
## Summary
- update the public SkillsBench run ledger with the latest `powerlifting-coef-calc` goal-start probe
- record the current blocker as `skillsbench_host_local_acp_codex_exec_preflight_failed_codex_exec_exit_1`
- keep the artifact reference public-safe and compact-only; no raw task/log/trajectory material is included

## Validation
- `python3 examples/benchmark-run-ledger-smoke.py`
- `loopx benchmark run-ledger-check --goal-id loopx-meta --run-ledger-path docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json --limit 20`
- `git diff --check`
- `loopx check --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json`
