### PR TITLE
Add release readiness mental model

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ LoopX 把一次静态 goal 变成能持续流转的动态 loop：该等人的地
 [Capability Surface](#capability-surface) ·
 [Getting Started](docs/guides/getting-started.md) · [Showcases](docs/showcases/README.md) ·
 [Hosted Frontstage](https://huangruiteng.github.io/loopx/frontstage/) ·
+[Release Readiness](docs/product/release-readiness.md) ·
 [Update Notes](docs/update-notes/README.md) ·
 [Community](#community--feedback) · [Product Vision](docs/product/vision.md) · [Architecture](docs/architecture.md) ·
 [Dashboard](apps/dashboard/README.md) · [简体中文](README.zh-CN.md)
@@ -480,6 +481,9 @@ contract.
 - [Documentation index](docs/README.md): stable docs grouped by audience.
 - [Update notes](docs/update-notes/README.md): public-safe two-week progress
   notes, archive, and publication automation plan.
+- [Release readiness](docs/product/release-readiness.md): v0.x install/update
+  paths, compatibility smoke gate, release-note checklist, and safe-to-depend-on
+  surfaces.
 - [Architecture](docs/architecture.md): lifetime-goal invariant and core
   control-plane shape.
 - [State interaction model](docs/state-interaction-model.md): actor boundaries,

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,9 @@ incident report, or launch draft.
   frontend-ready case metadata.
 - [Update notes](update-notes/README.md): two-week public progress notes,
   archive governance, and publication automation design.
+- [Release readiness](product/release-readiness.md): v0.x install/update paths,
+  compatibility smoke gate, release-note checklist, and safe-to-depend-on
+  surfaces.
 - [Benchmark developer workflow](benchmark-developer-workflow.md): how to run,
   observe, and ingest benchmark slices as a developer-facing product workflow.
 - [State interaction model](state-interaction-model.md): user, agent, and state
@@ -89,6 +92,7 @@ incident report, or launch draft.
 ### Product Direction
 
 - [Product vision](product/vision.md)
+- [Release readiness](product/release-readiness.md)
 - [Codex CLI TUI-first loop](product/codex-cli-tui-loop.md)
 - [Reward-style replanning hints](product/reward-style-replanning.md)
 - [Frontstage channel and lease roadmap](frontstage-channel-lease-roadmap.md)

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -42,6 +42,9 @@ runtime contract, benchmark route, or launch draft.
   the compact release note and smoke contract that prove the packaged installer,
   fresh-project bootstrap message, bootstrap bundle, and proof fixtures stay
   aligned before no-clone install is advertised as the default user path.
+- [Release readiness](release-readiness.md): the v0.x maintainer mental model
+  for install/update paths, compatibility smoke gates, release-note checklist,
+  and safe-to-depend-on surfaces.
 - [Frontstage dashboard interaction baseline](frontstage-dashboard-interaction-baseline.md):
   the two-surface frontend rule for keeping public showcase/homepage work fancy
   and case-driven while the real ops control-plane route stays dense, calm,

--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -1,0 +1,113 @@
+# Release Readiness
+
+Status: v0.x maintainer contract.
+
+LoopX can move quickly without making every merged PR feel like a product
+release. This note defines the small mental model maintainers should use before
+promoting a release snapshot, recommending an install path, or telling users
+which control-plane surfaces are safe to build on.
+
+## Supported Install And Update Paths
+
+For a first-time user, prefer the no-clone archive installer:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
+loopx doctor
+```
+
+For a user who already installed from the archive, update through the explicit
+CLI flow:
+
+```bash
+loopx update --check
+loopx update --dry-run
+loopx update --execute
+loopx doctor
+```
+
+For contributors, keep the clone-plus-canary path:
+
+```bash
+git clone https://github.com/huangruiteng/loopx ~/loopx
+~/loopx/scripts/install-local.sh
+loopx doctor
+loopx-canary doctor
+```
+
+The no-clone path is the user default. The clone-plus-canary path is the
+maintainer validation path.
+
+## Compatibility Gate
+
+Before a release snapshot is promoted or a public guide tells users to depend
+on a new surface, run the smallest gate that covers the touched surface:
+
+```bash
+python3 -m py_compile loopx/*.py
+python3 examples/codex-cli-no-clone-release-verification-smoke.py
+python3 examples/fresh-clone-quickstart-smoke.py
+python3 examples/loopx-update-smoke.py
+python3 examples/release-readiness-doc-smoke.py
+git diff --check
+loopx check --scan-path README.md --scan-path docs/ --scan-path examples/
+```
+
+This is not a universal full suite. Add focused smokes for the changed command,
+projection, or workflow. Do not require benchmark raw logs, raw task text,
+trajectories, verifier output, credentials, or local private artifact paths as
+release evidence.
+
+## What Is Safe To Depend On
+
+Treat these v0.x surfaces as stable enough for user guides, examples, and
+host integrations when their focused smokes pass:
+
+- `loopx doctor`, `loopx update`, `loopx check`, and the no-clone installer;
+- project lifecycle commands: `bootstrap`, `connect`, `status`,
+  `refresh-state`, `registry`, and `sync-global`;
+- todo lifecycle commands: `todo add`, `todo claim`, `todo update`,
+  `todo complete`, `todo list`, `todo supersede`, and `todo archive`;
+- control-plane read paths: `quota should-run`, `quota spend-slot`,
+  `review-packet`, `heartbeat-prompt --thin`, task graph projection, and cold
+  todo detail references;
+- public slash command names: `/loopx`, `/loopx <goal>`,
+  `/loopx-global-summary`, `/loopx-global-gates`, `/loopx-global-todos`, and
+  `/loopx-global-risks`;
+- ignored local state boundaries under `~/.codex/loopx`, project-local registry
+  files, and project-local active-state workbench files recognized by
+  `loopx doctor`, `loopx status`, and `loopx check`.
+
+Treat these as experimental until their contract docs say otherwise:
+
+- benchmark runner behavior, scoring, upload, and raw task execution routes;
+- host-plugin command registry implementations beyond the published protocol
+  contract;
+- frontstage/dashboard presentation details that are not part of the public
+  status data contract;
+- monitor scheduler cadence fields while they are still rolling out across
+  todo creation, quota projection, writeback, and migration.
+
+## Release Note Checklist
+
+Every public release note or update note should answer:
+
+- What user-visible capability became more dependable?
+- Which install/update path should a new user follow?
+- Which commands, docs, or smokes prove the claim?
+- Are there compatibility or migration notes for existing local state?
+- Which surfaces are still experimental or intentionally excluded?
+- Did the public/private scan run on the changed docs, examples, and workflow
+  files?
+
+The note should link to durable docs or PRs when useful, but public git history
+and shipped CLI behavior remain the source of truth.
+
+## Related Docs
+
+- [Codex CLI packaged install path](codex-cli-packaged-install.md)
+- [Codex CLI no-clone release verification](codex-cli-no-clone-release-verification.md)
+- [Getting started](../guides/getting-started.md)
+- [Update notes](../update-notes/README.md)
+- [Public/private boundary](../public-private-boundary.md)

--- a/examples/release-readiness-doc-smoke.py
+++ b/examples/release-readiness-doc-smoke.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Validate the public release-readiness doc wiring."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC = ROOT / "docs" / "product" / "release-readiness.md"
+README = ROOT / "README.md"
+DOCS_INDEX = ROOT / "docs" / "README.md"
+PRODUCT_INDEX = ROOT / "docs" / "product" / "README.md"
+
+FORBIDDEN_PUBLIC_STRINGS = [
+    "/Users/",
+    "/private/tmp/",
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "raw_thread",
+    "session_history",
+    "verifier_output_tail",
+    "ACTIVE_GOAL_STATE.md:",
+]
+
+
+def read(path: Path) -> str:
+    if not path.exists():
+        raise AssertionError(f"missing expected file: {path.relative_to(ROOT)}")
+    return path.read_text(encoding="utf-8")
+
+
+def compact(text: str) -> str:
+    return " ".join(text.split())
+
+
+def assert_contains(text: str, needle: str, label: str) -> None:
+    if needle not in text:
+        raise AssertionError(f"{label} missing {needle!r}")
+
+
+def validate_boundary(path: Path) -> None:
+    text = read(path)
+    label = str(path.relative_to(ROOT))
+    for forbidden in FORBIDDEN_PUBLIC_STRINGS:
+        if forbidden in text:
+            raise AssertionError(f"{label} contains forbidden string {forbidden!r}")
+
+
+def main() -> None:
+    for path in [DOC, README, DOCS_INDEX, PRODUCT_INDEX]:
+        validate_boundary(path)
+
+    doc = compact(read(DOC))
+    for required in [
+        "Status: v0.x maintainer contract.",
+        "## Supported Install And Update Paths",
+        "loopx update --check",
+        "loopx update --dry-run",
+        "loopx update --execute",
+        "## Compatibility Gate",
+        "examples/codex-cli-no-clone-release-verification-smoke.py",
+        "examples/release-readiness-doc-smoke.py",
+        "## What Is Safe To Depend On",
+        "loopx doctor",
+        "quota should-run",
+        "/loopx-global-summary",
+        "benchmark runner behavior, scoring, upload",
+        "## Release Note Checklist",
+        "public/private scan",
+    ]:
+        assert_contains(doc, required, "release-readiness doc")
+
+    root_readme = read(README)
+    docs_index = read(DOCS_INDEX)
+    product_index = read(PRODUCT_INDEX)
+    assert_contains(root_readme, "docs/product/release-readiness.md", "root README")
+    assert_contains(docs_index, "product/release-readiness.md", "docs index")
+    assert_contains(product_index, "release-readiness.md", "product index")
+
+    print("release-readiness-doc-smoke ok")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a v0.x release-readiness mental model covering install/update paths, compatibility gates, release-note checklist, and safe-to-depend-on surfaces
- link the release-readiness doc from the root README, docs index, and product index
- add a thin public doc smoke for the new wiring and boundary checks

## Validation
- python3 examples/release-readiness-doc-smoke.py
- python3 -m py_compile examples/release-readiness-doc-smoke.py
- git diff --check
- python3 -m loopx.cli check --scan-path README.md --scan-path docs/README.md --scan-path docs/product/README.md --scan-path docs/product/release-readiness.md --scan-path examples/release-readiness-doc-smoke.py

Note: loopx check reported the existing loopx-meta duplicate index rows warning, with the scanned public files clean.