### PR TITLE
Add public adoption loop contract

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,9 @@ incident report, or launch draft.
 - [Product vision](product/vision.md): long-term product direction, Loop Agent
   definition, maintainer-first management surface, and open-source anchor
   strategy.
+- [Public adoption loop](product/public-adoption-loop.md): docs-first issue
+  and discussion template copy, triage labels, and lightweight external-attempt
+  metrics before any `.github` template write.
 - [Codex CLI TUI-first loop](product/codex-cli-tui-loop.md): first-class
   Codex CLI onboarding target where one visible TUI message starts LoopX, with
   session-attached automation as the preferred follow-up.
@@ -93,6 +96,7 @@ incident report, or launch draft.
 
 - [Product vision](product/vision.md)
 - [Release readiness](product/release-readiness.md)
+- [Public adoption loop](product/public-adoption-loop.md)
 - [Codex CLI TUI-first loop](product/codex-cli-tui-loop.md)
 - [Reward-style replanning hints](product/reward-style-replanning.md)
 - [Frontstage channel and lease roadmap](frontstage-channel-lease-roadmap.md)

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -45,6 +45,9 @@ runtime contract, benchmark route, or launch draft.
 - [Release readiness](release-readiness.md): the v0.x maintainer mental model
   for install/update paths, compatibility smoke gates, release-note checklist,
   and safe-to-depend-on surfaces.
+- [Public adoption loop](public-adoption-loop.md): a docs-first public feedback
+  loop with issue/discussion template copy, triage labels, and lightweight
+  external-attempt metrics before any `.github` template write scope is needed.
 - [Frontstage dashboard interaction baseline](frontstage-dashboard-interaction-baseline.md):
   the two-surface frontend rule for keeping public showcase/homepage work fancy
   and case-driven while the real ops control-plane route stays dense, calm,

--- a/docs/product/public-adoption-loop.md
+++ b/docs/product/public-adoption-loop.md
@@ -1,0 +1,153 @@
+# Public Adoption Loop
+
+Status: docs-first product contract.
+
+LoopX needs a public path for people to try a concrete workflow and report what
+worked without requiring maintainers to install GitHub templates before the
+route is proven. This note defines the template copy, triage labels, and small
+metrics that can later be promoted into `.github` templates if the owner
+approves that write scope.
+
+## When To Use It
+
+Use this loop when someone wants to try LoopX on a public repository workflow
+and the feedback can be represented without private source, private logs,
+credentials, raw transcripts, benchmark task text, or production evidence.
+
+Good first workflows:
+
+- fix or triage a public GitHub issue;
+- review a PR and turn findings into bounded follow-up todos;
+- run an overnight PR-sized refactor with a review packet;
+- keep progress moving when a high-priority item is blocked by a human gate.
+
+Do not use this loop for private customer work, production operations, hidden
+security reports, leaderboard submissions, or any repository where the user
+cannot share a public-safe summary.
+
+## Issue Template Copy
+
+Suggested title:
+
+```text
+Try LoopX on: <workflow name>
+```
+
+Suggested body:
+
+```markdown
+## Workflow
+
+Which LoopX workflow did you try?
+
+- [ ] Public issue fix or triage
+- [ ] PR review-to-fix loop
+- [ ] Overnight PR-sized refactor
+- [ ] Blocked-P0 safe fallback
+- [ ] Other:
+
+## Starting Point
+
+- Repository:
+- Public issue or PR:
+- Command or entry point used:
+- Expected output:
+
+## Result
+
+- What did LoopX produce?
+- What validation ran?
+- What still needed human judgment?
+- Did the loop stop, wait, or continue safely?
+
+## Public-Safe Evidence
+
+Link only public artifacts: PR, issue, docs, compact review packet, or public
+smoke output. Do not paste private logs, credentials, raw transcripts,
+benchmark task text, or local paths.
+
+## Value Signal
+
+- Time saved or avoided rework:
+- Quality signal:
+- User attention required:
+- Would you run this workflow again?
+```
+
+## Discussion Template Copy
+
+Suggested prompt:
+
+```markdown
+What workflow should LoopX make easier next?
+
+Please include:
+
+- the repo scenario;
+- the human decision that currently blocks automation;
+- the smallest public-safe artifact that would prove value;
+- the command or chat entry point you expected to use;
+- any privacy, permission, or publication boundary.
+```
+
+This discussion form is for product signal, not support escalation. If a user
+needs a concrete fix, convert the signal into an issue with a public-safe
+starting point and expected output.
+
+## Triage Labels
+
+Start with labels that explain the workflow and boundary instead of labels that
+promise a solution:
+
+| Label | Meaning |
+| --- | --- |
+| `adoption:try-loopx` | A user is trying LoopX on a public workflow. |
+| `workflow:issue-fix` | Public issue triage, planning, validation, or PR review packet. |
+| `workflow:pr-review` | Review findings should become todo, patch, or owner decision. |
+| `workflow:overnight-refactor` | Long-running refactor that needs resumable state and review packet. |
+| `workflow:blocked-fallback` | A blocked high-priority route needs safe lower-priority progress. |
+| `signal:user-value` | The report contains a concrete value or attention-cost signal. |
+| `gate:needs-owner` | A human decision is required before more action. |
+| `privacy:public-safe` | Evidence is safe to cite publicly. |
+| `privacy:needs-redaction` | Evidence must be reduced before public discussion. |
+| `status:needs-repro` | The workflow is plausible but lacks a reproducible public path. |
+
+Labels are triage hints, not permission. Posting comments, opening PRs,
+publishing screenshots, or editing `.github` templates still needs the normal
+owner and boundary checks.
+
+## Lightweight Metrics
+
+Track metrics as a compact note on the issue or discussion:
+
+- `workflow_type`: issue_fix, pr_review, overnight_refactor,
+  blocked_fallback, or other;
+- `entry_point`: slash_command, codex_cli_tui, codex_app, claude_code, or
+  manual_cli;
+- `artifact_produced`: todo_plan, patch_pr, review_packet, validation_summary,
+  blocker_packet, or none;
+- `validation_state`: not_run, failed, passed, partial, or not_applicable;
+- `human_gate_count`: integer count of concrete user/controller gates;
+- `attention_cost`: low, medium, or high;
+- `would_repeat`: yes, no, or unsure.
+
+The metric note should stay short enough to read without opening raw logs. If a
+case becomes a showcase candidate, promote it through the
+[Issue/PR solver maintainer intake packet](issue-pr-solver-maintainer-intake.md)
+or another public-safe showcase route.
+
+## Promotion To GitHub Templates
+
+This docs-first contract is intentionally inside `docs/**`. To promote it into
+real GitHub issue or discussion templates, first record an owner-approved
+boundary decision for the exact `.github` paths, then add the smallest template
+files that preserve the same public/private boundary.
+
+Until that approval exists, this document is the canonical adoption-loop copy.
+
+## Related Docs
+
+- [Release readiness](release-readiness.md)
+- [Codex CLI packaged install path](codex-cli-packaged-install.md)
+- [Issue/PR solver maintainer intake packet](issue-pr-solver-maintainer-intake.md)
+- [Public/private boundary](../public-private-boundary.md)

--- a/examples/public-adoption-loop-doc-smoke.py
+++ b/examples/public-adoption-loop-doc-smoke.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Validate the docs-first public adoption loop contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC = ROOT / "docs" / "product" / "public-adoption-loop.md"
+DOCS_INDEX = ROOT / "docs" / "README.md"
+PRODUCT_INDEX = ROOT / "docs" / "product" / "README.md"
+
+FORBIDDEN_PUBLIC_STRINGS = [
+    "/Users/",
+    "/private/tmp/",
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "raw_thread",
+    "session_history",
+    "verifier_output_tail",
+    "ACTIVE_GOAL_STATE.md:",
+]
+
+
+def read(path: Path) -> str:
+    if not path.exists():
+        raise AssertionError(f"missing expected file: {path.relative_to(ROOT)}")
+    return path.read_text(encoding="utf-8")
+
+
+def compact(text: str) -> str:
+    return " ".join(text.split())
+
+
+def assert_contains(text: str, needle: str, label: str) -> None:
+    if needle not in text:
+        raise AssertionError(f"{label} missing {needle!r}")
+
+
+def validate_boundary(path: Path) -> None:
+    text = read(path)
+    label = str(path.relative_to(ROOT))
+    for forbidden in FORBIDDEN_PUBLIC_STRINGS:
+        if forbidden in text:
+            raise AssertionError(f"{label} contains forbidden string {forbidden!r}")
+
+
+def main() -> None:
+    for path in [DOC, DOCS_INDEX, PRODUCT_INDEX]:
+        validate_boundary(path)
+
+    doc = compact(read(DOC))
+    for required in [
+        "Status: docs-first product contract.",
+        "## Issue Template Copy",
+        "## Discussion Template Copy",
+        "## Triage Labels",
+        "adoption:try-loopx",
+        "workflow:issue-fix",
+        "privacy:needs-redaction",
+        "## Lightweight Metrics",
+        "workflow_type",
+        "attention_cost",
+        "would_repeat",
+        "## Promotion To GitHub Templates",
+        "owner-approved boundary decision",
+    ]:
+        assert_contains(doc, required, "public adoption loop doc")
+
+    docs_index = read(DOCS_INDEX)
+    product_index = read(PRODUCT_INDEX)
+    assert_contains(docs_index, "product/public-adoption-loop.md", "docs index")
+    assert_contains(product_index, "public-adoption-loop.md", "product index")
+
+    print("public-adoption-loop-doc-smoke ok")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a docs-first public adoption loop contract with issue/discussion template copy, triage labels, and lightweight external-attempt metrics
- make promotion to real GitHub templates depend on an explicit owner-approved .github boundary decision
- link the contract from the docs index and product index
- add a focused public adoption loop doc smoke

## Validation
- python3 examples/public-adoption-loop-doc-smoke.py
- python3 -m py_compile examples/public-adoption-loop-doc-smoke.py
- git diff --check
- python3 -m loopx.cli check --scan-path docs/README.md --scan-path docs/product/README.md --scan-path docs/product/public-adoption-loop.md --scan-path examples/public-adoption-loop-doc-smoke.py

Note: loopx check reported the existing loopx-meta duplicate index rows warning, with the scanned public files clean.