### PR TITLE
Fix SkillsBench goal-start host-local attribution

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
@@ -1694,10 +1694,11 @@
           "latest_decision": {
             "baseline_failure_scope": "passed",
             "baseline_run_id": "2297b9236dc2",
-            "decision": "paired_treatment_regressed",
+            "decision": "paired_treatment_runner_or_setup_repair_required",
+            "failure_class": "skillsbench_host_local_acp_codex_exec_failed_codex_exec_bridge_idle_timeout",
             "official_score_delta": -1.0,
-            "treatment_failure_scope": "case_or_solution",
-            "treatment_run_id": "0c5ac5e7b1b2"
+            "treatment_failure_scope": "runner_or_setup",
+            "treatment_run_id": "d563af7a6ede"
           },
           "runs": [
             {
@@ -2433,6 +2434,186 @@
                 "task_skills_removed": true
               },
               "verifier_attempt_countable": true
+            },
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": true,
+              "agent_model": "gpt-5.5",
+              "arm_id": "codex_loopx_treatment",
+              "artifact_refs": {
+                "compact_artifact_ref": ".local/private-benchmark-jobs/skillsbench-citation-check-goal-start-local-20260627T0735Z/citation-check__loopx_goal_start_product_mode/benchmark_run.compact.json"
+              },
+              "attempt_failure_class": "job_materialization_failed",
+              "attempt_failure_label": "skillsbench_host_local_acp_codex_exec_failed_codex_exec_bridge_idle_timeout",
+              "attempt_lifecycle_phase": "runner_accepted_args",
+              "benchmark_id": "skillsbench@1.1",
+              "best_reward_round": 1,
+              "best_round_is_final": true,
+              "best_round_passed": false,
+              "best_round_reward": 0.0,
+              "case_attempt_countable": false,
+              "case_id": "citation-check",
+              "case_ids": [
+                "citation-check"
+              ],
+              "codex_acp_runtime_preflight_passed": true,
+              "declared_done_round": 13,
+              "declared_done_score": 0.0,
+              "failure_class": "skillsbench_host_local_acp_codex_exec_failed_codex_exec_bridge_idle_timeout",
+              "failure_labels": [
+                "skillsbench_product_mode_declared_done_below_passing_reward",
+                "skillsbench_agent_premature_done_signal",
+                "skillsbench_host_local_acp_codex_exec_failed_codex_exec_bridge_idle_timeout",
+                "skillsbench_host_local_acp_codex_exec_failed",
+                "skillsbench_runner_setup_error",
+                "skillsbench_product_mode_transport_failure"
+              ],
+              "failure_scope": "runner_or_setup",
+              "final_round": 13,
+              "final_round_passed": false,
+              "final_round_reward": 0.0,
+              "job_name": "skillsbench_1_1_citation_check_loopx_goal_start_product_mode",
+              "launcher_attempt_countable": true,
+              "leaderboard_evidence": false,
+              "loop_score_policy": "best_round_for_offline_controller_analysis",
+              "loopx_inside_case": true,
+              "max_rounds_budget": 16,
+              "mode": "skillsbench_loopx_goal_start_product_mode_treatment",
+              "model_control_status": "reported_model_from_result_metadata",
+              "model_warning_labels": [
+                "skillsbench_host_local_acp_idle_timeout_after_countable_closeout",
+                "skillsbench_host_local_acp_codex_exec_failed"
+              ],
+              "notes": "official SkillsBench BenchFlow LoopX goal-start product-mode treatment; compact result only; no raw task/log/trajectory read into public state",
+              "official_feedback_blinded": true,
+              "official_passed": false,
+              "official_score": 0.0,
+              "official_score_attempt_countable": false,
+              "official_score_policy": "final_workspace_official_result",
+              "product_mode_lifecycle_contract": {
+                "checkpoint_count": 14,
+                "checkpoint_required": true,
+                "checkpoint_round": 0,
+                "countable_treatment": true,
+                "execution_style": "orchestrated_agentloop_loopx_cli",
+                "orchestrated_driver_counts_as_product_mode": true,
+                "orchestrated_driver_lifecycle_satisfied": true,
+                "required": true,
+                "satisfied": true,
+                "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+                "state_read_count": 14,
+                "state_write_count": 42
+              },
+              "recorded_at": "2026-06-27T19:33:38+08:00",
+              "reward_feedback_forwarded": false,
+              "round_reward_count": 12,
+              "round_rewards": [
+                {
+                  "agent_round": 1,
+                  "passed": false,
+                  "reward": 0.0,
+                  "reward_present": true,
+                  "tool_calls": 0
+                },
+                {
+                  "agent_round": 2,
+                  "passed": false,
+                  "reward": 0.0,
+                  "reward_present": true,
+                  "tool_calls": 0
+                },
+                {
+                  "agent_round": 3,
+                  "passed": false,
+                  "reward": 0.0,
+                  "reward_present": true,
+                  "tool_calls": 0
+                },
+                {
+                  "agent_round": 4,
+                  "passed": false,
+                  "reward": 0.0,
+                  "reward_present": true,
+                  "tool_calls": 0
+                },
+                {
+                  "agent_round": 5,
+                  "passed": false,
+                  "reward": 0.0,
+                  "reward_present": true,
+                  "tool_calls": 0
+                },
+                {
+                  "agent_round": 6,
+                  "passed": false,
+                  "reward": 0.0,
+                  "reward_present": true,
+                  "tool_calls": 0
+                },
+                {
+                  "agent_round": 7,
+                  "passed": false,
+                  "reward": 0.0,
+                  "reward_present": true,
+                  "tool_calls": 0
+                },
+                {
+                  "agent_round": 8,
+                  "passed": false,
+                  "reward": 0.0,
+                  "reward_present": true,
+                  "tool_calls": 0
+                },
+                {
+                  "agent_round": 9,
+                  "passed": false,
+                  "reward": 0.0,
+                  "reward_present": true,
+                  "tool_calls": 0
+                },
+                {
+                  "agent_round": 10,
+                  "passed": false,
+                  "reward": 0.0,
+                  "reward_present": true,
+                  "tool_calls": 0
+                },
+                {
+                  "agent_round": 11,
+                  "passed": false,
+                  "reward": 0.0,
+                  "reward_present": true,
+                  "tool_calls": 0
+                },
+                {
+                  "agent_round": 12,
+                  "passed": false,
+                  "reward": 0.0,
+                  "reward_present": true,
+                  "tool_calls": 0
+                }
+              ],
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-citation-check-goal-start-local-20260627T0735Z",
+              "run_id": "d563af7a6ede",
+              "score_status": "failed",
+              "solver_attempt_countable": false,
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false,
+              "task_staging": {
+                "app_skills_mount_patch_applied": true,
+                "apt_retry_patch_applied": true,
+                "apt_retry_patch_required": false,
+                "apt_risk_preflight_blocked": false,
+                "apt_setup_risk_detected": false,
+                "codex_acp_runtime_tools_patch_applied": true,
+                "include_task_skills": false,
+                "original_task_mutated": false,
+                "staged": true,
+                "task_skills_removed": true
+              },
+              "verifier_attempt_countable": false
             }
           ]
         },
@@ -9080,7 +9261,7 @@
           ]
         }
       },
-      "run_count": 153
+      "run_count": 154
     },
     "swe-marathon": {
       "benchmark_id": "swe-marathon",
@@ -13132,5 +13313,5 @@
     "source_of_truth": "benchmark_run_v0 compact run events",
     "update_rule": "upsert one run entry when a benchmark case is ingested or closed"
   },
-  "updated_at": "2026-06-27T18:41:05+08:00"
+  "updated_at": "2026-06-27T19:33:38+08:00"
 }

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
@@ -5,7 +5,7 @@ benchmark case outcomes and artifact references; it must not contain raw
 logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 
 - schema_version: `benchmark_run_ledger_v0`
-- updated_at: `2026-06-27T18:41:05+08:00`
+- updated_at: `2026-06-27T19:33:38+08:00`
 
 ## Case Decisions
 
@@ -17,7 +17,7 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `skillsbench@1.1` | `adaptive-cruise-control` | `baseline_runner_or_setup_repair_required` | - | - | `1` |
 | `skillsbench@1.1` | `azure-bgp-oscillation-route-leak` | `product_mode_pair_incomplete` | `treatment_loopx_lifecycle_not_observed` | - | `10` |
 | `skillsbench@1.1` | `bike-rebalance` | `paired_baseline_solved_treatment_preserved` | - | - | `3` |
-| `skillsbench@1.1` | `citation-check` | `paired_treatment_regressed` | - | - | `10` |
+| `skillsbench@1.1` | `citation-check` | `paired_treatment_runner_or_setup_repair_required` | - | - | `11` |
 | `skillsbench@1.1` | `civ6-adjacency-optimizer` | `paired_no_score_uplift` | - | - | `4` |
 | `skillsbench@1.1` | `dapt-intrusion-detection` | `paired_baseline_setup_preflight_selection_required` | - | - | `5` |
 | `skillsbench@1.1` | `debug-trl-grpo` | `paired_baseline_runner_or_setup_repair_required` | - | - | `9` |
@@ -117,6 +117,7 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `skillsbench@1.1` | `citation-check` | `codex_loopx_treatment` | `case_attempt` | `0.0` | `` | `1:0` | `official_verifier_solution_failure` | `` |
 | `skillsbench@1.1` | `citation-check` | `codex_loopx_treatment` | `case_attempt` | `0.0` | `` | `1:0,2:0,3:0,4:0,5:0,6:0,7:0,8:0,9:0,10:0,11:0,12:0` | `official_score_zero_case_failure` | `` |
 | `skillsbench@1.1` | `citation-check` | `skillsbench_raw_codex_autonomous_max5_baseline` | `case_attempt` | `1.0` | `1` | `1:1*` | `none` | `` |
+| `skillsbench@1.1` | `citation-check` | `codex_loopx_treatment` | `` | `0.0` | `` | `1:0,2:0,3:0,4:0,5:0,6:0,7:0,8:0,9:0,10:0,11:0,12:0` | `skillsbench_host_local_acp_codex_exec_failed_codex_exec_bridge_idle_timeout` | `.local/private-benchmark-jobs/skillsbench-citation-check-goal-start-local-20260627T0735Z/citation-check__loopx_goal_start_product_mode/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `civ6-adjacency-optimizer` | `codex_goal_mode_baseline` | `` | `0.0` | `` | `` | `official_verifier_solution_failure` | `` |
 | `skillsbench@1.1` | `civ6-adjacency-optimizer` | `loopx_automation_loop_treatment` | `` | `0.0` | `` | `` | `official_verifier_solution_failure` | `` |
 | `skillsbench@1.1` | `civ6-adjacency-optimizer` | `baseline` | `` | `0.0` | `` | `1:0,2:0` | `official_verifier_solution_failure` | `.local/private-benchmark-jobs/skillsbench-civ6-adjacency-optimizer-blind-baseline-v0/civ6-adjacency-optimizer__codex_acp_blind_loop_v0/benchmark_run.compact.json` |

--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -6755,6 +6755,101 @@ def test_skillsbench_host_local_idle_timeout_after_closeout_is_countable() -> No
         assert accounting["failure_class"] == "solver_failed", accounting
 
 
+def test_goal_start_host_local_requires_codex_exec_preflight_by_default() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-goal-start-preflight-") as tmp:
+        args = parse_args(
+            [
+                "--task-id",
+                "citation-check",
+                "--route",
+                "loopx-goal-start-product-mode",
+                "--host-local-acp-launch",
+                "--jobs-dir",
+                str(Path(tmp) / "jobs"),
+                "--job-name",
+                "skillsbench-goal-start-preflight-fixture",
+            ]
+        )
+        plan = build_plan(args)
+        prereqs = plan["runner_prerequisites"]
+        assert (
+            prereqs["host_local_acp_codex_exec_preflight_requested"] is True
+        ), prereqs
+        assert prereqs["host_local_acp_codex_exec_preflight_status"] == "pending", (
+            prereqs
+        )
+
+
+def test_goal_start_host_exec_failure_overrides_zero_score_recovery() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-goal-start-host-failure-") as tmp:
+        args = parse_args(
+            [
+                "--task-id",
+                "citation-check",
+                "--route",
+                "loopx-goal-start-product-mode",
+                "--jobs-dir",
+                str(Path(tmp) / "jobs"),
+                "--job-name",
+                "skillsbench-goal-start-host-failure-fixture",
+            ]
+        )
+        plan = build_plan(args)
+        plan["runner_prerequisites"].update(
+            {
+                "agent_execution_mode": "host_local_acp",
+                "host_local_acp_codex_exec_failure_trace_present": True,
+                "host_local_acp_codex_exec_failure_trace_count": 1,
+                "host_local_acp_codex_exec_failure_category": (
+                    "codex_exec_bridge_idle_timeout"
+                ),
+            }
+        )
+        result_path = Path(plan["result_json"])
+        write_json(
+            result_path,
+            {
+                "task_name": "citation-check",
+                "rollout_name": "citation-check__loopx_goal_start_product_mode",
+                "rewards": None,
+                "agent": "codex-acp",
+                "agent_name": "codex-acp",
+                "model": "gpt-5.5",
+                "n_tool_calls": 0,
+                "n_prompts": 13,
+                "error": "ACP error -32002: local codex execution timeout",
+                "verifier_error": None,
+                "partial_trajectory": False,
+                "trajectory_source": "acp",
+            },
+        )
+        verifier_dir = result_path.with_name("verifier")
+        verifier_dir.mkdir(parents=True, exist_ok=True)
+        (verifier_dir / "reward.txt").write_text("0.0\n", encoding="utf-8")
+        compact = reduce_result(args, result_path, plan)
+        expected = (
+            "skillsbench_host_local_acp_codex_exec_failed_"
+            "codex_exec_bridge_idle_timeout"
+        )
+        assert compact["official_score_status"] == "completed", compact
+        assert compact["official_score"] == 0.0, compact
+        assert compact["score_failure_attribution"] == expected, compact
+        assert compact["runner_failure"]["failure_class"] == expected, compact
+        assert "official_score_zero_case_failure" not in compact[
+            "failure_attribution_labels"
+        ], compact
+        assert "skillsbench_product_mode_transport_failure" in compact[
+            "failure_attribution_labels"
+        ], compact
+        accounting = compact["attempt_accounting"]
+        assert accounting["failure_class"] == "job_materialization_failed", accounting
+        assert accounting["failure_label"] == expected, accounting
+        assert accounting["case_attempt_countable"] is False, accounting
+        assert accounting["solver_attempt_countable"] is False, accounting
+        assert accounting["verifier_attempt_countable"] is False, accounting
+        assert accounting["official_score_attempt_countable"] is False, accounting
+
+
 def test_skillsbench_product_mode_declared_done_below_passing_reward_is_compacted() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-declared-done-low-score-") as tmp:
         root = Path(tmp)
@@ -9854,6 +9949,8 @@ if __name__ == "__main__":
     test_skillsbench_product_mode_solver_activity_gap_overrides_zero_score()
     test_skillsbench_product_mode_first_action_timeout_is_uncountable()
     test_skillsbench_host_local_idle_timeout_after_closeout_is_countable()
+    test_goal_start_host_local_requires_codex_exec_preflight_by_default()
+    test_goal_start_host_exec_failure_overrides_zero_score_recovery()
     test_skillsbench_product_mode_declared_done_below_passing_reward_is_compacted()
     test_skillsbench_declared_done_missing_reward_status_is_compacted()
     test_skillsbench_product_mode_declared_done_without_closeout_overrides_verifier_error()

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -1078,6 +1078,19 @@ def _host_local_acp_codex_exec_preflight_command(
     return command
 
 
+def _host_local_acp_codex_exec_preflight_should_run(
+    args: argparse.Namespace,
+) -> bool:
+    """Return whether the host-local Codex exec path must be probed first."""
+
+    if bool(getattr(args, "host_local_acp_codex_exec_preflight", False)):
+        return True
+    return bool(
+        getattr(args, "host_local_acp_launch", False)
+        and _is_goal_start_product_mode_route(str(getattr(args, "route", "") or ""))
+    )
+
+
 def _host_local_acp_codex_exec_preflight_requires_bridge_action(
     args: argparse.Namespace,
 ) -> bool:
@@ -2962,7 +2975,78 @@ def _apply_agent_message_only_no_tool_calls_attribution(
     for item in extra_labels:
         if item not in existing_labels:
             existing_labels.append(item)
+        compact["failure_attribution_labels"] = existing_labels
+    return True
+
+
+def _apply_host_local_acp_prereq_failure_attribution(
+    compact: dict[str, Any],
+    runner_prerequisites: dict[str, Any],
+) -> bool:
+    """Prefer structured host-local Codex exec failures over zero-score labels."""
+
+    official_score = compact.get("official_score")
+    if (
+        isinstance(official_score, (int, float))
+        and not isinstance(official_score, bool)
+        and official_score >= 1.0
+    ):
+        return False
+
+    prereq_failure = _runner_prerequisite_failure_attribution(runner_prerequisites)
+    if prereq_failure is None:
+        return False
+    _exception_type, label, labels = prereq_failure
+    if not (
+        label.startswith("skillsbench_host_local_acp_codex_exec_failed")
+        or label.startswith("skillsbench_host_local_acp_codex_exec_preflight_failed")
+    ):
+        return False
+
+    compact["score_failure_attribution"] = label
+    compact["first_blocker"] = label
+    compact["official_score_comparable_to_native_codex"] = False
+    compact["official_score_comparable_to_loopx_treatment"] = False
+    existing_labels = [
+        item
+        for item in compact.get("failure_attribution_labels", [])
+        if isinstance(item, str)
+        and item
+        not in {
+            "official_score_zero_case_failure",
+            "official_verifier_solution_failure",
+            "verifier_infrastructure_failure",
+        }
+    ]
+    extra_labels = list(labels)
+    if compact.get("product_mode") is True:
+        extra_labels.append("skillsbench_product_mode_transport_failure")
+    for item in extra_labels:
+        if item and item not in existing_labels:
+            existing_labels.append(item)
     compact["failure_attribution_labels"] = existing_labels
+    runner_failure = compact.get("runner_failure")
+    if isinstance(runner_failure, dict):
+        runner_failure["exception_type"] = label
+        runner_failure["failure_class"] = label
+    attempt_accounting = compact.get("attempt_accounting")
+    if isinstance(attempt_accounting, dict):
+        attempt_accounting["failure_class"] = "job_materialization_failed"
+        attempt_accounting["failure_label"] = label
+        attempt_accounting["lifecycle_phase"] = "runner_accepted_args"
+        for key in (
+            "case_attempt_countable",
+            "solver_attempt_countable",
+            "verifier_attempt_countable",
+            "official_score_attempt_countable",
+        ):
+            attempt_accounting[key] = False
+        attempts = attempt_accounting.get("attempts")
+        if isinstance(attempts, dict):
+            for key in ("case", "solver", "verifier", "official_score"):
+                attempt = attempts.get(key)
+                if isinstance(attempt, dict):
+                    attempt["countable"] = False
     return True
 
 
@@ -4679,12 +4763,12 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
                 _is_goal_start_product_mode_route(args.route)
             ),
             "host_local_acp_codex_exec_preflight_requested": bool(
-                args.host_local_acp_codex_exec_preflight
+                _host_local_acp_codex_exec_preflight_should_run(args)
             ),
             "host_local_acp_codex_exec_preflight_ready": False,
             "host_local_acp_codex_exec_preflight_status": (
                 "pending"
-                if args.host_local_acp_codex_exec_preflight
+                if _host_local_acp_codex_exec_preflight_should_run(args)
                 else "not_requested"
             ),
             "host_local_acp_codex_exec_preflight_attempt_count": 0,
@@ -8392,6 +8476,10 @@ def reduce_result(
     if runner_prerequisites:
         compact["runner_prerequisites"] = runner_prerequisites
         _sync_relay_closeout_counts_into_compact(compact, runner_prerequisites)
+        _apply_host_local_acp_prereq_failure_attribution(
+            compact,
+            runner_prerequisites,
+        )
     prereq_failure = _runner_prerequisite_failure_attribution(
         plan.get("runner_prerequisites")
     )
@@ -8860,8 +8948,8 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
             "loopx-blind-loop-treatment is the historical SkillsBench "
             "alias for the same polling semantics; codex-acp-blind-loop-baseline "
             "is the ordinary Codex no-goal baseline with the same loop budget; "
-            "raw-codex-autonomous-max5 and loopx-product-mode are the "
-            "main-table product-mode comparison routes; "
+            "raw-codex-autonomous-max5 and loopx-goal-start-product-mode are "
+            "the main-table raw/new comparison routes; "
             "loopx-goal-start-product-mode adds /loopx goal-start planning "
             "with a compact ranked todo plan before selected-P0 lifecycle; "
             "codex-app-server-goal-baseline is the native Codex Goal baseline "
@@ -9333,7 +9421,7 @@ async def async_main(
         )
 
     if (
-        args.host_local_acp_codex_exec_preflight
+        _host_local_acp_codex_exec_preflight_should_run(args)
         and args.host_local_acp_launch
         and not args.reduce_only
     ):


### PR DESCRIPTION
## Summary
- require host-local Codex exec preflight by default for SkillsBench goal-start product-mode runs
- prefer structured host-local ACP exec/preflight failures over generic zero-score solver labels when reducing completed 0.0 results
- update citation-check ledger status to runner/setup repair required for the observed bridge idle timeout case

## Validation
- python3 examples/skillsbench-benchmark-run-smoke.py
- python3 examples/benchmark-run-ledger-smoke.py
- python3 -m py_compile scripts/skillsbench_automation_loop.py examples/skillsbench-benchmark-run-smoke.py loopx/benchmark_adapters/skillsbench.py
- git diff --check

No benchmark jobs or uploads launched; reduce-only compact/ledger update only.