### PR TITLE
Bootstrap SkillsBench goal-start bridge before task

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
@@ -6861,10 +6861,10 @@
             "baseline_failure_scope": "passed",
             "baseline_run_id": "5d3d505e21ca",
             "decision": "paired_treatment_runner_or_setup_repair_required",
-            "failure_class": "skillsbench_host_local_acp_codex_exec_preflight_failed_codex_exec_exit_1",
+            "failure_class": "skillsbench_host_local_acp_codex_exec_failed_codex_exec_first_action_timeout",
             "official_score_delta": null,
             "treatment_failure_scope": "score_missing",
-            "treatment_run_id": "6df25b0a577c"
+            "treatment_run_id": "e1ed1c1ff31b"
           },
           "runs": [
             {
@@ -7731,6 +7731,82 @@
                 "apt_risk_preflight_blocked": false,
                 "apt_setup_risk_detected": true,
                 "staged": false
+              },
+              "verifier_attempt_countable": false
+            },
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "codex_loopx_treatment",
+              "artifact_refs": {
+                "compact_artifact_ref": ".local/private-benchmark-jobs/skillsbench-powerlifting-coef-calc-goal-start-local-20260627T0930Z-goalstart/powerlifting-coef-calc__loopx_goal_start_product_mode/benchmark_run.compact.json"
+              },
+              "attempt_failure_class": "job_materialization_failed",
+              "attempt_failure_label": "skillsbench_host_local_acp_codex_exec_failed_codex_exec_first_action_timeout",
+              "attempt_lifecycle_phase": "runner_accepted_args",
+              "benchmark_id": "skillsbench@1.1",
+              "case_attempt_countable": false,
+              "case_id": "powerlifting-coef-calc",
+              "case_ids": [
+                "powerlifting-coef-calc"
+              ],
+              "codex_acp_runtime_preflight_passed": true,
+              "failure_class": "skillsbench_host_local_acp_codex_exec_failed_codex_exec_first_action_timeout",
+              "failure_labels": [
+                "skillsbench_host_local_acp_codex_exec_failed_codex_exec_first_action_timeout",
+                "skillsbench_host_local_acp_codex_exec_failed",
+                "skillsbench_runner_setup_error",
+                "skillsbench_product_mode_transport_failure",
+                "skillsbench_acp_agent_message_only_no_tool_calls"
+              ],
+              "failure_scope": "score_missing",
+              "job_name": "skillsbench_1_1_powerlifting_coef_calc_loopx_goal_start_product_mode",
+              "launcher_attempt_countable": true,
+              "leaderboard_evidence": false,
+              "loopx_inside_case": true,
+              "max_rounds_budget": 32,
+              "mode": "skillsbench_loopx_goal_start_product_mode_treatment",
+              "model_control_status": "reported_model_from_result_metadata",
+              "notes": "official SkillsBench BenchFlow LoopX goal-start product-mode treatment; compact result only; no raw task/log/trajectory read into public state",
+              "official_feedback_blinded": true,
+              "official_score_attempt_countable": false,
+              "product_mode_lifecycle_contract": {
+                "checkpoint_count": 1,
+                "checkpoint_required": true,
+                "checkpoint_round": 0,
+                "countable_treatment": true,
+                "execution_style": "orchestrated_agentloop_loopx_cli",
+                "orchestrated_driver_counts_as_product_mode": true,
+                "orchestrated_driver_lifecycle_satisfied": true,
+                "required": true,
+                "satisfied": true,
+                "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+                "state_read_count": 1,
+                "state_write_count": 3
+              },
+              "recorded_at": "2026-06-27T19:46:43+08:00",
+              "reward_feedback_forwarded": false,
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-powerlifting-coef-calc-raw-new-goal-start-local-20260627T0812Z",
+              "run_id": "e1ed1c1ff31b",
+              "score_status": "missing",
+              "solver_attempt_countable": false,
+              "source_event_schema": "benchmark_run_v0",
+              "status": "recorded",
+              "submit_eligible": false,
+              "task_staging": {
+                "app_skills_mount_patch_applied": false,
+                "apt_retry_patch_applied": false,
+                "apt_retry_patch_required": false,
+                "apt_risk_preflight_blocked": false,
+                "apt_setup_risk_detected": false,
+                "codex_acp_runtime_tools_patch_applied": false,
+                "include_task_skills": false,
+                "original_task_mutated": false,
+                "staged": true,
+                "task_skills_removed": true
               },
               "verifier_attempt_countable": false
             }
@@ -9261,7 +9337,7 @@
           ]
         }
       },
-      "run_count": 154
+      "run_count": 155
     },
     "swe-marathon": {
       "benchmark_id": "swe-marathon",
@@ -13313,5 +13389,5 @@
     "source_of_truth": "benchmark_run_v0 compact run events",
     "update_rule": "upsert one run entry when a benchmark case is ingested or closed"
   },
-  "updated_at": "2026-06-27T19:33:38+08:00"
+  "updated_at": "2026-06-27T19:46:43+08:00"
 }

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
@@ -5,7 +5,7 @@ benchmark case outcomes and artifact references; it must not contain raw
 logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 
 - schema_version: `benchmark_run_ledger_v0`
-- updated_at: `2026-06-27T19:33:38+08:00`
+- updated_at: `2026-06-27T19:46:43+08:00`
 
 ## Case Decisions
 
@@ -28,7 +28,7 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `skillsbench@1.1` | `organize-messy-files` | `paired_treatment_improved` | `main_table_ready` | - | `7` |
 | `skillsbench@1.1` | `paratransit-routing` | `product_mode_pair_incomplete` | `treatment_official_feedback_not_blinded,treatment_reward_feedback_forwarding_not_disabled,treatment_compact_metrics_m...` | - | `10` |
 | `skillsbench@1.1` | `pddl-airport-planning` | `paired_no_score_uplift` | - | - | `9` |
-| `skillsbench@1.1` | `powerlifting-coef-calc` | `paired_treatment_runner_or_setup_repair_required` | - | - | `14` |
+| `skillsbench@1.1` | `powerlifting-coef-calc` | `paired_treatment_runner_or_setup_repair_required` | - | - | `15` |
 | `skillsbench@1.1` | `react-performance-debugging` | `paired_baseline_runner_or_setup_repair_required` | - | - | `5` |
 | `skillsbench@1.1` | `setup-fuzzing-py` | `baseline_runner_or_setup_repair_required` | - | - | `3` |
 | `skillsbench@1.1` | `software-dependency-audit` | `paired_no_score_uplift` | - | - | `6` |
@@ -209,6 +209,7 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `skillsbench@1.1` | `powerlifting-coef-calc` | `skillsbench_raw_codex_autonomous_max5_baseline` | `case_attempt` | `1.0` | `1` | `1:1*` | `none` | `` |
 | `skillsbench@1.1` | `powerlifting-coef-calc` | `codex_loopx_treatment` | `` | `missing` | `` | `` | `skillsbench_host_local_acp_codex_exec_failed_codex_exec_first_action_timeout` | `` |
 | `skillsbench@1.1` | `powerlifting-coef-calc` | `codex_loopx_treatment` | `` | `missing` | `` | `` | `skillsbench_host_local_acp_codex_exec_preflight_failed_codex_exec_exit_1` | `local-private/skillsbench-powerlifting-explicit-bridge-timeoutprobe-20260627T1048Z/powerlifting-coef-calc__loopx_goal_start_product_mode/benchmark_run.compact.json` |
+| `skillsbench@1.1` | `powerlifting-coef-calc` | `codex_loopx_treatment` | `` | `missing` | `` | `` | `skillsbench_host_local_acp_codex_exec_failed_codex_exec_first_action_timeout` | `.local/private-benchmark-jobs/skillsbench-powerlifting-coef-calc-goal-start-local-20260627T0930Z-goalstart/powerlifting-coef-calc__loopx_goal_start_product_mode/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `react-performance-debugging` | `codex_goal_mode_baseline` | `` | `0.0` | `` | `` | `official_verifier_solution_failure` | `result.json` |
 | `skillsbench@1.1` | `react-performance-debugging` | `loopx_automation_loop_treatment` | `` | `0.0` | `` | `` | `official_verifier_solution_failure` | `` |
 | `skillsbench@1.1` | `react-performance-debugging` | `baseline` | `` | `0.0` | `` | `1:0,2:0` | `official_verifier_solution_failure` | `.local/private-benchmark-jobs/skillsbench-react-performance-debugging-blind-baseline-v0/react-performance-debugging__codex_acp_blind_loop_v0/benchmark_run.compact.json` |

--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -398,6 +398,109 @@ def test_product_mode_initial_prompt_keeps_task_visible_after_lifecycle_gate() -
     assert trace["followup_prompt_count"] == 1, trace
 
 
+def test_goal_start_workflow_driver_bootstraps_bridge_before_task_packet() -> None:
+    trace = {
+        "schema_version": "skillsbench_loopx_controller_trace_v0",
+        "route": "loopx-goal-start-product-mode",
+        "heartbeat_count": 0,
+        "controller_action_decisions": 0,
+        "initial_prompt_count": 0,
+        "followup_prompt_count": 0,
+        "stop_decision_count": 0,
+        "reward_observation_count": 0,
+        "round_rewards": [],
+    }
+    saved_modules = {
+        name: sys.modules.get(name)
+        for name in (
+            "benchflow",
+            "benchflow.sandbox",
+            "benchflow.sandbox.user",
+        )
+    }
+    fake_benchflow = types.ModuleType("benchflow")
+    fake_sandbox = types.ModuleType("benchflow.sandbox")
+    fake_user = types.ModuleType("benchflow.sandbox.user")
+
+    class FakeBaseUser:
+        pass
+
+    class FakeRoundResultBase:
+        pass
+
+    class FakeRoundResult:
+        rewards: dict[str, float] = {}
+        n_tool_calls = 1
+        trajectory: list[object] = []
+
+    fake_user.BaseUser = FakeBaseUser
+    fake_user.RoundResult = FakeRoundResultBase
+    sys.modules["benchflow"] = fake_benchflow
+    sys.modules["benchflow.sandbox"] = fake_sandbox
+    sys.modules["benchflow.sandbox.user"] = fake_user
+    try:
+        user = _build_product_mode_user(
+            route="loopx-goal-start-product-mode",
+            max_rounds=8,
+            trace=trace,
+            plan={
+                "runner_prerequisites": {
+                    "loopx_workflow_lifecycle_checkpoint": True,
+                    "loopx_product_mode_lifecycle_driver_kind": (
+                        "orchestrated_agentloop_loopx_cli"
+                    ),
+                }
+            },
+            case_payload={
+                "canonical_product_mode_lifecycle_driver": True,
+                "planned_todo_count": 3,
+                "selected_p0_todo_id": "todo_goalstart_p0",
+            },
+        )
+    finally:
+        for name, module in saved_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+    bootstrap_prompt = asyncio.run(user.run(0, "Compute the requested coefficient."))
+    assert bootstrap_prompt is not None
+    assert "--- LOOPX PRODUCT-MODE CONTROL PLANE ---" in bootstrap_prompt
+    assert "--- TASK INSTRUCTION ---" not in bootstrap_prompt
+    assert "Compute the requested coefficient." not in bootstrap_prompt
+    assert "FIRST ACTION REQUIRED" in bootstrap_prompt
+    assert "benchmark task instruction will be sent after" in bootstrap_prompt
+    assert trace["product_mode_task_instruction_deferred_until_agent_lifecycle"] is True
+    assert trace["product_mode_task_instruction_sent_initially"] is False
+    assert trace["last_decision"] == "send_goal_start_workflow_bridge_bootstrap_prompt"
+
+    trace.update(
+        {
+            "remote_command_file_bridge_driver_lifecycle_execution_style": (
+                "orchestrated_agentloop_loopx_cli"
+            ),
+            "remote_command_file_bridge_driver_lifecycle_checkpoint_count": 1,
+            "remote_command_file_bridge_driver_lifecycle_success_count": 1,
+            "remote_command_file_bridge_driver_lifecycle_failure_count": 0,
+            "remote_command_file_bridge_driver_lifecycle_loopx_cli_call_count": 4,
+            "remote_command_file_bridge_driver_lifecycle_loopx_state_read_count": 1,
+            "remote_command_file_bridge_driver_lifecycle_loopx_state_write_count": 3,
+            "remote_command_file_bridge_agent_request_count": 1,
+            "remote_command_file_bridge_agent_task_facing_operation_count": 1,
+        }
+    )
+    task_prompt = asyncio.run(
+        user.run(1, "Compute the requested coefficient.", FakeRoundResult())
+    )
+    assert task_prompt is not None
+    assert "--- TASK INSTRUCTION ---" in task_prompt
+    assert "Compute the requested coefficient." in task_prompt
+    assert "The task packet is now available" in task_prompt
+    assert trace["product_mode_task_instruction_sent_after_agent_lifecycle"] is True
+    assert trace["last_decision"] == "send_product_mode_task_instruction_after_agent_lifecycle"
+
+
 def test_loopx_subcommand_family_counts_include_arguments() -> None:
     counts = {
         "todo complete": 2,

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -7100,6 +7100,27 @@ def _build_product_mode_user(
             "closeout."
         )
 
+    def workflow_bootstrap_prompt() -> str:
+        return (
+            "LoopX product-mode treatment round 1. "
+            "You are running inside the official SkillsBench sandbox transport, "
+            "but this local Codex process is outside the scored sandbox. No "
+            "official reward, pass/fail status, verifier error, verifier output, "
+            "or verifier tail will be shown during this run.\n\n"
+            "--- LOOPX PRODUCT-MODE CONTROL PLANE ---\n"
+            "The canonical workflow lifecycle driver has already executed the "
+            "case-local quota/todo/update/refresh checkpoint through the sandbox "
+            "bridge before this prompt. This route simulates `/loopx <task "
+            "objective>` goal start: a compact ranked todo plan and selected P0 "
+            "todo have already been seeded in the case-local LoopX state. "
+            "Do not repeat setup lifecycle, do not solve from prose, and do not "
+            "declare done in this bootstrap round. Your only job in this round "
+            "is to prove task-facing sandbox access: copy and run the bridge "
+            "packet's FIRST ACTION REQUIRED shell command exactly, then briefly "
+            "report that bridge access is available. The benchmark task "
+            "instruction will be sent after that bridge action is observed."
+        )
+
     def solver_activity_prompt(round_number: int) -> str:
         return (
             f"Mandatory product-mode solver checkpoint before round {round_number} "
@@ -7264,7 +7285,7 @@ def _build_product_mode_user(
                             "LoopX lifecycle request before official verifier"
                         )
                     if (
-                        _product_mode_agent_lifecycle_gate_satisfied(trace)
+                        product_mode_entry_lifecycle_gate_satisfied()
                         and not self._task_instruction_sent
                     ):
                         self._task_instruction_sent = True
@@ -7407,12 +7428,23 @@ def _build_product_mode_user(
                     trace["persistent_constraint_protected_paths"] = protected_paths
                 if treatment:
                     prefix = "LoopX product-mode treatment round 1. "
+                    trace["case_goal_state_packet_present"] = True
+                    if workflow_lifecycle_driver and goal_start_product_mode:
+                        self._task_instruction_sent = False
+                        trace[
+                            "product_mode_task_instruction_deferred_until_agent_lifecycle"
+                        ] = True
+                        trace["product_mode_task_instruction_sent_initially"] = False
+                        trace["last_decision"] = (
+                            "send_goal_start_workflow_bridge_bootstrap_prompt"
+                        )
+                        return workflow_bootstrap_prompt()
+
                     self._task_instruction_sent = True
                     trace[
                         "product_mode_task_instruction_deferred_until_agent_lifecycle"
                     ] = False
                     trace["product_mode_task_instruction_sent_initially"] = True
-                    trace["case_goal_state_packet_present"] = True
                     control_clause = (
                         "Use LoopX as your product control plane: create "
                         "a compact goal state, maintain todos, replan when local "


### PR DESCRIPTION
## Summary
- Defer the full task packet for host-local SkillsBench goal-start product-mode until the first sandbox bridge action is observed.
- Send a short bootstrap prompt that only asks Codex to run the bridge packet's FIRST ACTION REQUIRED command.
- Update the powerlifting case ledger with the latest compact public attribution: preflight and bridge passed, but the formal turn hit Codex first-action timeout.

## Validation
- python3 examples/skillsbench-benchmark-run-smoke.py
- python3 examples/benchmark-run-ledger-smoke.py
- python3 examples/skillsbench-goal-start-product-mode-route-smoke.py
- python3 -m py_compile scripts/skillsbench_automation_loop.py examples/skillsbench-benchmark-run-smoke.py
- git diff --check
- public/private boundary diff scan (no secrets, absolute paths, raw logs, raw task text, or raw trajectories)

Note: examples/skillsbench-host-local-launch-plan-smoke.py still fails on main due to a stale source-signature assertion unrelated to this change.