### PR TITLE
docs: add newcomer command path

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,9 @@ incident report, or launch draft.
 - [Getting started](guides/getting-started.md): agent-first start, manual
   installation, project connection, diagnosis, daily workflow, heartbeats,
   dashboard, development, and command reference.
+- [Newcomer command path](guides/newcomer-command-path.md): the minimal product
+  path for `/loopx`, `/loopx <goal>`, and one CLI quickstart before the full
+  command catalog.
 - [Product vision](product/vision.md): long-term product direction, Loop Agent
   definition, maintainer-first management surface, and open-source anchor
   strategy.
@@ -66,6 +69,7 @@ incident report, or launch draft.
 ### Operator Workflows
 
 - [Getting started](guides/getting-started.md)
+- [Newcomer command path](guides/newcomer-command-path.md)
 - [Integration guide](integration.md)
 - [Benchmark developer workflow](benchmark-developer-workflow.md)
 - [Attention queue](attention-queue.md)

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -5,6 +5,11 @@ README. The root README is now the short product landing page; this page is the
 hands-on path for installation, project connection, diagnosis, heartbeats,
 dashboard use, development checks, and command discovery.
 
+If you are new to LoopX, start with the shorter
+[Newcomer command path](newcomer-command-path.md): it reduces the product
+surface to `/loopx`, `/loopx <goal>`, and one manual CLI quickstart. This page
+keeps the full operator and contributor detail.
+
 ## Codex App And Other Agent Setup
 
 If you already use Codex, Claude Code, Cursor, or another terminal agent, paste
@@ -764,6 +769,11 @@ Start here:
 - [Benchmark long-run design](../research/long-horizon-agent-benchmarks/codex-cli-long-run-benchmark-design.md)
 
 ## Command Reference
+
+New users should start with the
+[Newcomer command path](newcomer-command-path.md). The catalog below is
+reference material for operators and contributors who already know which path
+they are debugging or extending.
 
 ```text
 bootstrap / connect     connect a project-local goal

--- a/docs/guides/newcomer-command-path.md
+++ b/docs/guides/newcomer-command-path.md
@@ -40,11 +40,28 @@ The command pack is a bridge from manual shell setup back to the agent surface:
 paste the generated instruction into Codex, Claude Code, or another compatible
 agent that can run shell commands from the project root.
 
+## Multi-Project Manager Commands
+
+Keep these out of the first two commands, but do show them once a user has more
+than one LoopX project or agent lane:
+
+| Need | Use |
+| --- | --- |
+| See the cross-project progress digest. | `/loopx-global-summary` |
+| See only user or owner gates. | `/loopx-global-gates` |
+| See runnable project-agent work. | `/loopx-global-todos` |
+| See risks and blocked lanes. | `/loopx-global-risks` |
+
+These are manager views. They should summarize and route work across projects;
+they should not replace `/loopx <goal>` as the way to start useful work inside
+one repository.
+
 ## When To Use More Commands
 
 | If you are trying to... | Use this surface first | Only then reach for... |
 | --- | --- | --- |
 | Start work on a goal | `/loopx <goal text>` | `loopx bootstrap-command-pack --goal-text ...` when manually bootstrapping an agent. |
+| Understand several LoopX projects at once | `/loopx-global-summary` | `/loopx-global-gates`, `/loopx-global-todos`, or `/loopx-global-risks` when you need a focused manager view. |
 | Understand why work is paused | `/loopx` | `loopx diagnose --goal-id <goal-id>` when the agent needs a deeper evidence packet. |
 | Review a handoff or gate | The agent's LoopX status summary | `loopx review-packet --goal-id <goal-id>` for a copyable operator packet. |
 | Operate recurring work | Codex App heartbeat or visible Codex CLI goal | `loopx heartbeat-prompt --thin --goal-id <goal-id>` when installing or repairing the loop. |

--- a/docs/guides/newcomer-command-path.md
+++ b/docs/guides/newcomer-command-path.md
@@ -1,0 +1,62 @@
+# Newcomer Command Path
+
+LoopX should feel like one product path before it feels like a CLI catalog.
+For a first-time user, the default surface is:
+
+1. Install or repair the CLI.
+2. Ask an agent to connect the current project.
+3. Use `/loopx <goal>` to start useful work.
+
+The full command set remains available for operators and contributors, but it
+should not be the first thing a newcomer has to understand.
+
+## The Two Commands To Remember
+
+| Need | Use | Expected result |
+| --- | --- | --- |
+| Check whether this project is connected and what is waiting. | `/loopx` | The agent reads LoopX status, gates, todos, and next safe action without starting a new delivery path. |
+| Start a concrete long-running goal. | `/loopx <goal text>` | The agent plans first, writes ordered todos, then advances one bounded, validated slice at a time. |
+
+Examples:
+
+```text
+/loopx fix the open PR review feedback and keep the patch reviewable
+/loopx split this refactor into PR-sized slices and stop at unsafe gates
+```
+
+## One CLI Quickstart
+
+Use this when an agent asks for the manual shell path, or when you are setting
+up a fresh terminal without an agent driving the first step:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
+loopx doctor
+loopx bootstrap-command-pack --project .
+```
+
+The command pack is a bridge from manual shell setup back to the agent surface:
+paste the generated instruction into Codex, Claude Code, or another compatible
+agent that can run shell commands from the project root.
+
+## When To Use More Commands
+
+| If you are trying to... | Use this surface first | Only then reach for... |
+| --- | --- | --- |
+| Start work on a goal | `/loopx <goal text>` | `loopx bootstrap-command-pack --goal-text ...` when manually bootstrapping an agent. |
+| Understand why work is paused | `/loopx` | `loopx diagnose --goal-id <goal-id>` when the agent needs a deeper evidence packet. |
+| Review a handoff or gate | The agent's LoopX status summary | `loopx review-packet --goal-id <goal-id>` for a copyable operator packet. |
+| Operate recurring work | Codex App heartbeat or visible Codex CLI goal | `loopx heartbeat-prompt --thin --goal-id <goal-id>` when installing or repairing the loop. |
+| Debug the control plane | The specific error or blocked todo | `loopx status`, `loopx history`, `loopx quota should-run`, or `loopx check`. |
+
+## Reference Boundary
+
+The command catalog is reference material. Keep it useful, but keep it below
+the product path:
+
+- New users should not need to scan every command before trying LoopX.
+- Public examples should prefer `/loopx <goal>` unless they are teaching
+  installation, debugging, or maintainer workflows.
+- Contributors may still use the full command reference in
+  [Getting started](getting-started.md#command-reference).


### PR DESCRIPTION
## Summary\n- add a short newcomer command path that reduces the product surface to /loopx, /loopx <goal>, and one manual CLI quickstart\n- link it from docs/README and the getting-started guide\n- keep the full command catalog as reference material below the product path\n\n## Boundary\n- docs-only change under docs/**\n- does not alter README, hosted Frontstage, showcase index, or any public first viewport\n- no benchmark/runtime behavior changes\n\n## Validation\n- git diff --check -- docs/guides/newcomer-command-path.md docs/guides/getting-started.md docs/README.md\n- loopx check --scan-path docs/guides/newcomer-command-path.md --scan-path docs/guides/getting-started.md --scan-path docs/README.md\n- public/private keyword scan reviewed; matches are existing boundary guidance only