### PR TITLE
Fix profile-scoped side-agent handoff routing

### DIFF
--- a/docs/product/agent-profile-contract.md
+++ b/docs/product/agent-profile-contract.md
@@ -146,6 +146,12 @@ change is small, public-safe, and low risk. Otherwise the side agent should add
 or update a todo claimed by the primary agent for review, verification, and
 merge.
 
+`review_policy.handoff_agent` is the per-agent override for broad side-agent
+completion. It wins over the goal-level `coordination.side_agent_handoff_agent`
+when the completing `claimed_by` matches this profile, so projects can route one
+side-agent lane to a reviewer while another lane returns directly to the
+primary control agent.
+
 ## Projection
 
 `agent_member_v0` should be a read-only status/review-packet projection derived

--- a/docs/project-agent-todo-contract.md
+++ b/docs/project-agent-todo-contract.md
@@ -108,9 +108,11 @@ other registered agents are side agents. Side agents should do repository edits
 only in an independent git worktree/branch, never in the primary checkout. Small
 AGENTS-eligible validated changes may be self-merged when the side agent records
 public-safe evidence; higher-risk or unclear work should create a successor
-handoff todo claimed by the primary agent by default or by
-`coordination.side_agent_handoff_agent` when configured. First register the
-agent ids and primary agent in the goal registry:
+handoff todo claimed by the primary agent by default. A project may route all
+side-agent handoffs through `coordination.side_agent_handoff_agent`, or route a
+specific side-agent through
+`coordination.agent_profiles.<agent_id>.review_policy.handoff_agent`. First
+register the agent ids and primary agent in the goal registry:
 
 `quota should-run --agent-id <side-agent-id>` enforces this as a preflight: when
 the side agent is running from the registered primary checkout, a non-git
@@ -277,13 +279,14 @@ loopx todo complete \
 
 If `--claimed-by` names a side agent, broad side-agent completion defaults to
 requiring a successor handoff todo. By default that successor is claimed by the
-goal's `primary_agent`. A goal may instead set
-`coordination.side_agent_handoff_agent` to another registered agent; in that
-case the successor handoff todo defaults to that agent and `--next-claimed-by`
-is allowed only when it matches the configured handoff owner. Existing
-registry fields named for review are not aliases for this route. This keeps
-broad side-agent handoff visible to the shared control plane without hard-coding
-the primary agent as the only follow-up surface.
+goal's `primary_agent`. A goal may set
+`coordination.side_agent_handoff_agent` to another registered agent for the
+shared default route, and may override that default for a specific side agent
+with `coordination.agent_profiles.<agent_id>.review_policy.handoff_agent`.
+`--next-claimed-by` is allowed only when it matches the resolved handoff owner.
+Existing registry fields named for review are not aliases for this route. This
+keeps broad side-agent handoff visible to the shared control plane without
+hard-coding a single follow-up surface for every side-agent lane.
 
 LoopX does not model "review" as a separate kernel object. Review, verification,
 or continuation are product-level names for a successor todo. The machine

--- a/examples/heartbeat-prompt-smoke.py
+++ b/examples/heartbeat-prompt-smoke.py
@@ -1087,6 +1087,72 @@ def main() -> int:
             cli_profile_scoped_payload
         )
 
+        profile_handoff_registry_path = project / ".loopx" / "profile-handoff-registry.json"
+        profile_handoff_registry_path.write_text(
+            json.dumps(
+                {
+                    "goals": [
+                        {
+                            "id": GOAL_ID,
+                            "domain": "smoke",
+                            "status": "active",
+                            "repo": str(project),
+                            "state_file": f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md",
+                            "adapter": {"kind": "generic_project_goal_v0", "status": "connected"},
+                            "coordination": {
+                                "registered_agents": [
+                                    "codex-main-control",
+                                    "codex-side-bypass",
+                                    "codex-product-capability",
+                                ],
+                                "primary_agent": "codex-main-control",
+                                "side_agent_handoff_agent": "codex-side-bypass",
+                                "agent_profiles": {
+                                    "codex-product-capability": {
+                                        "schema_version": "agent_profile_v0",
+                                        "scope_summary": "product capability and runtime contracts",
+                                        "review_policy": {"handoff_agent": "codex-main-control"},
+                                    }
+                                },
+                            },
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        cli_profile_handoff_json = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "loopx.cli",
+                "--format",
+                "json",
+                "--registry",
+                str(profile_handoff_registry_path),
+                "heartbeat-prompt",
+                "--goal-id",
+                GOAL_ID,
+                "--thin",
+                "--agent-id",
+                "codex-product-capability",
+            ],
+            cwd=REPO_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+        cli_profile_handoff_payload = json.loads(cli_profile_handoff_json)
+        assert cli_profile_handoff_payload["side_agent_handoff_agent"] == "codex-main-control", (
+            cli_profile_handoff_payload
+        )
+        assert "handoff todo claimed_by `codex-side-bypass`" not in cli_profile_handoff_payload["task_body"], (
+            cli_profile_handoff_payload
+        )
+        assert "handoff todo claimed_by `codex-main-control`" in cli_profile_handoff_payload["task_body"], (
+            cli_profile_handoff_payload
+        )
+
         ignored_review_registry_path = project / ".loopx" / "ignored-review-registry.json"
         ignored_review_registry_path.write_text(
             json.dumps(

--- a/examples/todo-lifecycle-cli-smoke.py
+++ b/examples/todo-lifecycle-cli-smoke.py
@@ -276,6 +276,71 @@ def assert_configured_side_agent_handoff() -> None:
         )
         assert "handoff_agent='codex-main-control'" in ignored_review_handoff["error"], ignored_review_handoff
 
+    with tempfile.TemporaryDirectory(prefix="loopx-profile-side-agent-handoff-smoke-") as tmp:
+        root = Path(tmp)
+        registry_path, state_file = write_fixture(root)
+        registry = json.loads(registry_path.read_text(encoding="utf-8"))
+        coordination = registry["goals"][0]["coordination"]
+        coordination["registered_agents"].append("codex-product-capability")
+        coordination["side_agent_handoff_agent"] = "codex-side-bypass"
+        coordination["agent_profiles"] = {
+            "codex-product-capability": {
+                "schema_version": "agent_profile_v0",
+                "review_policy": {"handoff_agent": "codex-main-control"},
+            }
+        }
+        registry_path.write_text(json.dumps(registry, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        profile_handoff_added = run_cli(
+            registry_path,
+            "todo",
+            "add",
+            "--goal-id",
+            GOAL_ID,
+            "--role",
+            "agent",
+            "--text",
+            SIDE_HANDOFF_SOURCE_TODO,
+            "--claimed-by",
+            "codex-product-capability",
+            "--task-class",
+            "advancement_task",
+            "--action-kind",
+            "contract_refine",
+        )
+        profile_handoff_completed = run_cli(
+            registry_path,
+            "todo",
+            "complete",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            profile_handoff_added["todo_id"],
+            "--claimed-by",
+            "codex-product-capability",
+            "--evidence",
+            "product-capability-runtime-contract-diff",
+            "--next-agent-todo",
+            SIDE_HANDOFF_TODO,
+            "--next-claimed-by",
+            "codex-main-control",
+        )
+        assert profile_handoff_completed["changed"] is True, profile_handoff_completed
+        assert profile_handoff_completed["next_todos"][0]["claimed_by"] == "codex-main-control", (
+            profile_handoff_completed
+        )
+        assert profile_handoff_completed["next_todos"][0]["blocks_agent"] == "codex-product-capability", (
+            profile_handoff_completed
+        )
+        assert profile_handoff_completed["next_todos"][0]["unblocks_todo_id"] == profile_handoff_added["todo_id"], (
+            profile_handoff_completed
+        )
+        profile_handoff_successor = next(
+            item
+            for item in parsed_items(state_file)
+            if item["todo_id"] == profile_handoff_completed["next_todos"][0]["todo_id"]
+        )
+        assert profile_handoff_successor["claimed_by"] == "codex-main-control", profile_handoff_successor
+
 
 def assert_no_followup_cli_metadata() -> None:
     with tempfile.TemporaryDirectory(prefix="loopx-todo-no-followup-smoke-") as tmp:

--- a/loopx/agent_registry.py
+++ b/loopx/agent_registry.py
@@ -59,9 +59,32 @@ def primary_agent_id_for_goal(goal: dict[str, Any] | None) -> str | None:
     return None
 
 
-def side_agent_handoff_agent_id_for_goal(goal: dict[str, Any] | None) -> str | None:
+def _agent_profile_handoff_agent_id(profile: dict[str, Any] | None) -> str | None:
+    if not isinstance(profile, dict):
+        return None
+    candidates: list[Any] = []
+    review_policy = profile.get("review_policy")
+    if isinstance(review_policy, dict):
+        candidates.append(review_policy.get("handoff_agent"))
+        candidates.append(review_policy.get("side_agent_handoff_agent"))
+    candidates.append(profile.get("handoff_agent"))
+    candidates.append(profile.get("side_agent_handoff_agent"))
+    for candidate in candidates:
+        agent = normalize_todo_claimed_by(candidate)
+        if agent:
+            return agent
+    return None
+
+
+def side_agent_handoff_agent_id_for_goal(
+    goal: dict[str, Any] | None,
+    agent_id: str | None = None,
+) -> str | None:
     if not isinstance(goal, dict):
         return None
+    profile_handoff_agent = _agent_profile_handoff_agent_id(agent_profile_for_goal(goal, agent_id))
+    if profile_handoff_agent:
+        return profile_handoff_agent
     candidates: list[Any] = []
     coordination = goal.get("coordination")
     if isinstance(coordination, dict):
@@ -121,8 +144,15 @@ def primary_agent_id_from_registry(registry_path: Path, goal_id: str) -> str | N
     return primary_agent_id_for_goal(load_goal_from_registry(registry_path, goal_id))
 
 
-def side_agent_handoff_agent_id_from_registry(registry_path: Path, goal_id: str) -> str | None:
-    return side_agent_handoff_agent_id_for_goal(load_goal_from_registry(registry_path, goal_id))
+def side_agent_handoff_agent_id_from_registry(
+    registry_path: Path,
+    goal_id: str,
+    agent_id: str | None = None,
+) -> str | None:
+    return side_agent_handoff_agent_id_for_goal(
+        load_goal_from_registry(registry_path, goal_id),
+        agent_id=agent_id,
+    )
 
 
 def agent_profile_from_registry(registry_path: Path, goal_id: str, agent_id: str | None) -> dict[str, Any] | None:

--- a/loopx/cli_commands/support_control.py
+++ b/loopx/cli_commands/support_control.py
@@ -300,7 +300,6 @@ def handle_support_control_command(
                 agent_registry_path = Path(active_state_source.removeprefix("registry:"))
             registered_agents = registered_agent_ids_from_registry(agent_registry_path, args.goal_id)
             primary_agent = primary_agent_id_from_registry(agent_registry_path, args.goal_id)
-            side_agent_handoff_agent = side_agent_handoff_agent_id_from_registry(agent_registry_path, args.goal_id)
             effective_agent_id = None
             agent_profile = None
             if args.agent_id:
@@ -311,6 +310,11 @@ def handle_support_control_command(
                     field="agent_id",
                 )
                 agent_profile = agent_profile_from_registry(agent_registry_path, args.goal_id, effective_agent_id)
+            side_agent_handoff_agent = side_agent_handoff_agent_id_from_registry(
+                agent_registry_path,
+                args.goal_id,
+                agent_id=effective_agent_id,
+            )
             payload = build_heartbeat_prompt(
                 goal_id=args.goal_id,
                 active_state=active_state,

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -1241,7 +1241,11 @@ def complete_goal_todo(
         )
         primary_agent = primary_agent_id_from_registry(registry_path, goal_id)
         registered_agents = registered_agent_ids_from_registry(registry_path, goal_id)
-        configured_handoff_agent = side_agent_handoff_agent_id_from_registry(registry_path, goal_id)
+        configured_handoff_agent = side_agent_handoff_agent_id_from_registry(
+            registry_path,
+            goal_id,
+            agent_id=effective_claimed_by,
+        )
         handoff_agent = configured_handoff_agent or primary_agent
         if configured_handoff_agent:
             handoff_agent = require_registered_agent_id(


### PR DESCRIPTION
## Summary
- Resolve side-agent completion handoff owners from the completing agent's `coordination.agent_profiles.<agent_id>.review_policy.handoff_agent` before falling back to goal-level `coordination.side_agent_handoff_agent`.
- Make `heartbeat-prompt --agent-id` render the same profile-scoped handoff owner that `todo complete --claimed-by` enforces.
- Add focused todo lifecycle and heartbeat prompt smokes for a product side-agent whose profile routes handoff back to `codex-main-control` while the goal-level default points elsewhere.
- Document the per-agent handoff override in the agent profile and todo lifecycle contracts.

## Commit grouping
- `eee7cc2` runtime + focused smokes
- `f7dc66b` public contract docs

## Validation
- `python3 examples/todo-lifecycle-cli-smoke.py`
- `python3 examples/heartbeat-prompt-smoke.py`
- `python3 -m py_compile loopx/agent_registry.py loopx/todos.py loopx/cli_commands/support_control.py loopx/heartbeat_prompt.py`
- `git diff --check`
- `loopx check --scan-path loopx/agent_registry.py --scan-path loopx/todos.py --scan-path loopx/cli_commands/support_control.py --scan-path examples/todo-lifecycle-cli-smoke.py --scan-path examples/heartbeat-prompt-smoke.py --scan-path docs/project-agent-todo-contract.md --scan-path docs/product/agent-profile-contract.md` (passes; existing duplicate-index warning only)

## Public/private boundary
- No local state, raw benchmark evidence, credentials, private links, or generated logs included.
