### PR TITLE
Update powerlifting goal-start ledger

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
@@ -6861,10 +6861,10 @@
             "baseline_failure_scope": "passed",
             "baseline_run_id": "5d3d505e21ca",
             "decision": "paired_treatment_runner_or_setup_repair_required",
-            "failure_class": "skillsbench_host_local_acp_codex_exec_failed_codex_exec_first_action_timeout",
+            "failure_class": "skillsbench_host_local_acp_codex_exec_failed_codex_exec_bridge_idle_timeout",
             "official_score_delta": null,
             "treatment_failure_scope": "score_missing",
-            "treatment_run_id": "e1ed1c1ff31b"
+            "treatment_run_id": "4b73e2e07137"
           },
           "runs": [
             {
@@ -7791,6 +7791,91 @@
               "round_success_observed": false,
               "run_group_id": "skillsbench-powerlifting-coef-calc-raw-new-goal-start-local-20260627T0812Z",
               "run_id": "e1ed1c1ff31b",
+              "score_status": "missing",
+              "solver_attempt_countable": false,
+              "source_event_schema": "benchmark_run_v0",
+              "status": "recorded",
+              "submit_eligible": false,
+              "task_staging": {
+                "app_skills_mount_patch_applied": false,
+                "apt_retry_patch_applied": false,
+                "apt_retry_patch_required": false,
+                "apt_risk_preflight_blocked": false,
+                "apt_setup_risk_detected": false,
+                "codex_acp_runtime_tools_patch_applied": false,
+                "include_task_skills": false,
+                "original_task_mutated": false,
+                "staged": true,
+                "task_skills_removed": true
+              },
+              "verifier_attempt_countable": false
+            },
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "codex_loopx_treatment",
+              "artifact_refs": {
+                "compact_artifact_ref": ".local/private-benchmark-jobs/skillsbench-powerlifting-coef-calc-goal-start-local-20260627T1246Z-goalstart/powerlifting-coef-calc__loopx_goal_start_product_mode/benchmark_run.compact.json"
+              },
+              "attempt_failure_class": "job_materialization_failed",
+              "attempt_failure_label": "skillsbench_host_local_acp_codex_exec_failed_codex_exec_bridge_idle_timeout",
+              "attempt_lifecycle_phase": "runner_accepted_args",
+              "benchmark_id": "skillsbench@1.1",
+              "case_attempt_countable": false,
+              "case_id": "powerlifting-coef-calc",
+              "case_ids": [
+                "powerlifting-coef-calc"
+              ],
+              "codex_acp_runtime_preflight_passed": true,
+              "failure_class": "skillsbench_host_local_acp_codex_exec_failed_codex_exec_bridge_idle_timeout",
+              "failure_labels": [
+                "skillsbench_host_local_acp_codex_exec_failed_codex_exec_bridge_idle_timeout",
+                "skillsbench_host_local_acp_codex_exec_failed",
+                "skillsbench_runner_setup_error",
+                "skillsbench_product_mode_transport_failure"
+              ],
+              "failure_scope": "score_missing",
+              "job_name": "skillsbench_1_1_powerlifting_coef_calc_loopx_goal_start_product_mode",
+              "launcher_attempt_countable": true,
+              "leaderboard_evidence": false,
+              "loop_score_policy": "best_round_for_offline_controller_analysis",
+              "loopx_inside_case": true,
+              "max_rounds_budget": 32,
+              "mode": "skillsbench_loopx_goal_start_product_mode_treatment",
+              "model_control_status": "reported_model_from_result_metadata",
+              "notes": "official SkillsBench BenchFlow LoopX goal-start product-mode treatment; compact result only; no raw task/log/trajectory read into public state",
+              "official_feedback_blinded": true,
+              "official_score_attempt_countable": false,
+              "official_score_policy": "final_workspace_official_result",
+              "product_mode_lifecycle_contract": {
+                "checkpoint_count": 2,
+                "checkpoint_required": true,
+                "checkpoint_round": 0,
+                "countable_treatment": true,
+                "execution_style": "orchestrated_agentloop_loopx_cli",
+                "orchestrated_driver_counts_as_product_mode": true,
+                "orchestrated_driver_lifecycle_satisfied": true,
+                "required": true,
+                "satisfied": true,
+                "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+                "state_read_count": 2,
+                "state_write_count": 6
+              },
+              "recorded_at": "2026-06-27T21:16:06+08:00",
+              "reward_feedback_forwarded": false,
+              "round_reward_count": 1,
+              "round_rewards": [
+                {
+                  "agent_round": 1,
+                  "passed": false,
+                  "reward_present": false,
+                  "tool_calls": 0
+                }
+              ],
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-powerlifting-coef-calc-raw-new-goal-start-local-20260627T0812Z",
+              "run_id": "4b73e2e07137",
               "score_status": "missing",
               "solver_attempt_countable": false,
               "source_event_schema": "benchmark_run_v0",
@@ -9337,7 +9422,7 @@
           ]
         }
       },
-      "run_count": 155
+      "run_count": 156
     },
     "swe-marathon": {
       "benchmark_id": "swe-marathon",
@@ -13389,5 +13474,5 @@
     "source_of_truth": "benchmark_run_v0 compact run events",
     "update_rule": "upsert one run entry when a benchmark case is ingested or closed"
   },
-  "updated_at": "2026-06-27T19:46:43+08:00"
+  "updated_at": "2026-06-27T21:16:06+08:00"
 }

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
@@ -5,7 +5,7 @@ benchmark case outcomes and artifact references; it must not contain raw
 logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 
 - schema_version: `benchmark_run_ledger_v0`
-- updated_at: `2026-06-27T19:46:43+08:00`
+- updated_at: `2026-06-27T21:16:06+08:00`
 
 ## Case Decisions
 
@@ -28,7 +28,7 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `skillsbench@1.1` | `organize-messy-files` | `paired_treatment_improved` | `main_table_ready` | - | `7` |
 | `skillsbench@1.1` | `paratransit-routing` | `product_mode_pair_incomplete` | `treatment_official_feedback_not_blinded,treatment_reward_feedback_forwarding_not_disabled,treatment_compact_metrics_m...` | - | `10` |
 | `skillsbench@1.1` | `pddl-airport-planning` | `paired_no_score_uplift` | - | - | `9` |
-| `skillsbench@1.1` | `powerlifting-coef-calc` | `paired_treatment_runner_or_setup_repair_required` | - | - | `15` |
+| `skillsbench@1.1` | `powerlifting-coef-calc` | `paired_treatment_runner_or_setup_repair_required` | - | - | `16` |
 | `skillsbench@1.1` | `react-performance-debugging` | `paired_baseline_runner_or_setup_repair_required` | - | - | `5` |
 | `skillsbench@1.1` | `setup-fuzzing-py` | `baseline_runner_or_setup_repair_required` | - | - | `3` |
 | `skillsbench@1.1` | `software-dependency-audit` | `paired_no_score_uplift` | - | - | `6` |
@@ -210,6 +210,7 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `skillsbench@1.1` | `powerlifting-coef-calc` | `codex_loopx_treatment` | `` | `missing` | `` | `` | `skillsbench_host_local_acp_codex_exec_failed_codex_exec_first_action_timeout` | `` |
 | `skillsbench@1.1` | `powerlifting-coef-calc` | `codex_loopx_treatment` | `` | `missing` | `` | `` | `skillsbench_host_local_acp_codex_exec_preflight_failed_codex_exec_exit_1` | `local-private/skillsbench-powerlifting-explicit-bridge-timeoutprobe-20260627T1048Z/powerlifting-coef-calc__loopx_goal_start_product_mode/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `powerlifting-coef-calc` | `codex_loopx_treatment` | `` | `missing` | `` | `` | `skillsbench_host_local_acp_codex_exec_failed_codex_exec_first_action_timeout` | `.local/private-benchmark-jobs/skillsbench-powerlifting-coef-calc-goal-start-local-20260627T0930Z-goalstart/powerlifting-coef-calc__loopx_goal_start_product_mode/benchmark_run.compact.json` |
+| `skillsbench@1.1` | `powerlifting-coef-calc` | `codex_loopx_treatment` | `` | `missing` | `` | `1:missing` | `skillsbench_host_local_acp_codex_exec_failed_codex_exec_bridge_idle_timeout` | `.local/private-benchmark-jobs/skillsbench-powerlifting-coef-calc-goal-start-local-20260627T1246Z-goalstart/powerlifting-coef-calc__loopx_goal_start_product_mode/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `react-performance-debugging` | `codex_goal_mode_baseline` | `` | `0.0` | `` | `` | `official_verifier_solution_failure` | `result.json` |
 | `skillsbench@1.1` | `react-performance-debugging` | `loopx_automation_loop_treatment` | `` | `0.0` | `` | `` | `official_verifier_solution_failure` | `` |
 | `skillsbench@1.1` | `react-performance-debugging` | `baseline` | `` | `0.0` | `` | `1:0,2:0` | `official_verifier_solution_failure` | `.local/private-benchmark-jobs/skillsbench-react-performance-debugging-blind-baseline-v0/react-performance-debugging__codex_acp_blind_loop_v0/benchmark_run.compact.json` |


### PR DESCRIPTION
Summary
- Record the latest SkillsBench powerlifting-coef-calc goal-start treatment compact result.
- Keep the run classified as treatment runner/setup repair required with score missing and bridge idle timeout attribution.
- Preserve public/private boundary: compact artifact reference only, no raw task text, logs, trajectories, verifier output, credentials, uploads, or absolute paths.

Validation
- python3 examples/benchmark-run-ledger-smoke.py
- python3 examples/benchmark-case-analysis-smoke.py
- git diff --check
- Boundary scan for absolute/private paths, credentials, raw task/log/trajectory, and verifier output markers.