### PR TITLE
Require goal-start follow-up bridge activity

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -391,9 +391,14 @@ def test_product_mode_initial_prompt_keeps_task_visible_after_lifecycle_gate() -
     assert task_prompt is not None
     assert "--- TASK INSTRUCTION ---" not in task_prompt
     assert "The task packet is now available" not in task_prompt
-    assert "Continue from your LoopX case state" in task_prompt
+    assert "Mandatory product-mode solver checkpoint" in task_prompt
+    assert "task-facing sandbox bridge operation" in task_prompt
+    assert "selected P0 closeout sequence" in task_prompt
     assert "official reward" in task_prompt
-    assert trace["last_decision"] == "send_product_mode_scheduled_continuation", trace
+    assert (
+        trace["last_decision"]
+        == "send_product_mode_solver_activity_continuation"
+    ), trace
     assert trace.get("product_mode_task_instruction_sent_after_agent_lifecycle") is not True
     assert trace["followup_prompt_count"] == 1, trace
 
@@ -1930,7 +1935,8 @@ def test_product_mode_declared_done_requires_solver_activity_after_driver_lifecy
         )
         assert prompt is not None, trace
         assert "Mandatory product-mode solver checkpoint" in prompt
-        assert "full agent closeout evidence" in prompt
+        assert "selected P0 solver/closeout evidence" in prompt
+        assert "task-facing sandbox bridge operation" in prompt
         assert "todo complete" in prompt
         assert "benchmark_case_agent_closeout" in prompt
         assert "quota spend-slot" in prompt
@@ -2595,7 +2601,16 @@ def test_product_mode_workflow_driver_task_bridge_activity_avoids_no_tool_abort(
         )
     )
     assert prompt is not None, trace
-    assert trace["last_decision"] == "send_product_mode_scheduled_continuation", trace
+    assert "Mandatory product-mode solver checkpoint" in prompt
+    assert "task-facing sandbox bridge operation" in prompt
+    assert "selected P0 closeout sequence" in prompt
+    assert (
+        trace["last_decision"]
+        == "send_product_mode_solver_activity_continuation"
+    ), trace
+    assert trace["product_mode_solver_activity_gap"] is True, trace
+    assert trace["product_mode_solver_activity_gap_count"] == 1, trace
+    assert trace["product_mode_solver_activity_gap_round"] == 1, trace
     assert trace.get("product_mode_no_tool_call_lifecycle_abort") is not True, trace
     assert trace.get("product_mode_no_lifecycle_request_abort") is not True, trace
     assert trace["followup_prompt_count"] == 1, trace

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -7126,15 +7126,21 @@ def _build_product_mode_user(
             f"Mandatory product-mode solver checkpoint before round {round_number} "
             "continues. The previous round produced enough LoopX lifecycle "
             "evidence to make the treatment countable, but it did not produce "
-            "the full agent closeout evidence: task-facing validation plus "
+            "the selected P0 solver/closeout evidence. The next agent turn "
+            "must start with either a task-facing sandbox bridge operation "
+            "from `/app`, or, if local validation already proves the selected "
+            "P0 is complete, the selected P0 closeout sequence: "
             "`todo complete`, `refresh-state`, and `quota spend-slot "
             "--source adapter --execute`. Read-only LoopX calls such as "
             "`quota should-run`, or state edits without a spend event, are not "
-            "enough to declare completion. This is not official verifier "
-            "feedback and says nothing about task success. Before declaring "
-            "done, use the available sandbox tool or command-file bridge to "
-            "inspect the task workspace, make or verify the required changes, "
-            "then run this exact case-local closeout sequence from `/app`:\n\n"
+            "enough to declare completion. This is not official reward, "
+            "pass/fail, or verifier feedback and says nothing about task "
+            "success. If the task is not "
+            "complete, use the available sandbox tool or command-file bridge "
+            "to inspect the task workspace, make or verify the required "
+            "changes, and continue solving. If local evidence shows the "
+            "selected P0 is complete, run this exact case-local closeout "
+            "sequence from `/app`:\n\n"
             f"{closeout_commands(round_number)}"
             "Do not answer with prose only, and only end with "
             f"{DECLARED_DONE_MARKER} after meaningful local task work or "
@@ -7416,6 +7422,26 @@ def _build_product_mode_user(
                 _inc_counter(trace, "stop_decision_count")
                 trace["last_decision"] = "stop_after_product_mode_budget"
                 return None
+            if (
+                treatment
+                and round_result is not None
+                and self._task_instruction_sent
+                and product_mode_entry_lifecycle_gate_satisfied()
+                and not _product_mode_solver_activity_observed(
+                    trace,
+                    round_result,
+                )
+            ):
+                _record_product_mode_solver_activity_gap(
+                    trace,
+                    agent_round=round,
+                )
+                _inc_counter(trace, "controller_action_decisions")
+                _inc_counter(trace, "followup_prompt_count")
+                trace["last_decision"] = (
+                    "send_product_mode_solver_activity_continuation"
+                )
+                return solver_activity_prompt(round + 1)
             if round == 0:
                 _inc_counter(trace, "controller_action_decisions")
                 _inc_counter(trace, "initial_prompt_count")


### PR DESCRIPTION
## Summary
- Require goal-start product-mode follow-up to ask for task-facing bridge activity or selected P0 closeout when lifecycle is countable but solver/closeout evidence is still missing.
- Keep the prompt blinded to official reward/pass-fail/verifier details while preserving the task-success target boundary.
- Update SkillsBench smoke coverage for the new solver-activity continuation decision.

## Validation
- python3 -m py_compile scripts/skillsbench_automation_loop.py examples/skillsbench-benchmark-run-smoke.py
- python3 examples/skillsbench-benchmark-run-smoke.py
- python3 examples/skillsbench-goal-start-product-mode-route-smoke.py
- git diff --check

## Boundary
- Public benchmark helper/runtime behavior only.
- No scoring, task semantics, leaderboard/submission behavior, permission boundary, raw logs, or private evidence changes.
