### PR TITLE
Fix SkillsBench solved-or-budget loop policy

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -9019,13 +9019,14 @@ def test_skillsbench_result_timeout_after_loopx_lifecycle_is_attributed() -> Non
         ), compact
 
 
-def test_skillsbench_user_loop_recovery_preserves_final_verify_path() -> None:
-    with tempfile.TemporaryDirectory(prefix="skillsbench-user-loop-recovery-") as tmp:
+def test_skillsbench_user_loop_soft_verify_exception_continues_to_next_round() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-user-loop-soft-verify-") as tmp:
         rollout_dir = Path(tmp)
         plan = {"runner_prerequisites": {}}
         trace: dict[str, Any] = {
             "schema_version": "skillsbench_loopx_controller_trace_v0",
         }
+        seen_rounds: list[tuple[int, str | None]] = []
 
         fake_benchflow = types.ModuleType("benchflow")
         fake_sandbox = types.ModuleType("benchflow.sandbox")
@@ -9060,6 +9061,14 @@ def test_skillsbench_user_loop_recovery_preserves_final_verify_path() -> None:
                 round_result: Any | None = None,
             ) -> str | None:
                 assert instruction == "fixture instruction"
+                seen_rounds.append(
+                    (
+                        round,
+                        getattr(round_result, "verifier_error", None)
+                        if round_result is not None
+                        else None,
+                    )
+                )
                 if round == 0:
                     return "continue without verifier feedback"
                 return None
@@ -9127,17 +9136,41 @@ def test_skillsbench_user_loop_recovery_preserves_final_verify_path() -> None:
         assert fake_rollout.disconnected is True
         assert prerequisites["benchflow_user_loop_final_verify_recovery_enabled"] is True
         assert (
-            prerequisites["benchflow_user_loop_final_verify_recovery_triggered"]
+            prerequisites.get("benchflow_user_loop_final_verify_recovery_triggered")
+            is not True
+        )
+        assert (
+            prerequisites["benchflow_user_loop_soft_verify_exception_continued"]
             is True
         )
-        assert prerequisites["benchflow_user_loop_recovery_stage"] == "soft_verify"
-        assert prerequisites["benchflow_user_loop_recovery_exception_type"] == (
+        assert prerequisites["benchflow_user_loop_soft_verify_exception_stage"] == (
+            "soft_verify"
+        )
+        assert prerequisites["benchflow_user_loop_soft_verify_exception_type"] == (
             "TimeoutError"
         )
-        assert prerequisites["benchflow_user_loop_recovery_delta_events"] == 2
-        assert prerequisites["benchflow_user_loop_recovery_delta_tool_calls"] == 1
-        assert prerequisites["benchflow_user_loop_recovery_raw_error_recorded"] is False
-        assert trace["benchflow_user_loop_recovery_preserved_final_verify"] is True
+        assert prerequisites["benchflow_user_loop_soft_verify_exception_count"] == 1
+        assert prerequisites["benchflow_user_loop_soft_verify_exception_round"] == 0
+        assert (
+            prerequisites["benchflow_user_loop_soft_verify_exception_delta_events"]
+            == 2
+        )
+        assert (
+            prerequisites[
+                "benchflow_user_loop_soft_verify_exception_delta_tool_calls"
+            ]
+            == 1
+        )
+        assert (
+            prerequisites[
+                "benchflow_user_loop_soft_verify_exception_raw_error_recorded"
+            ]
+            is False
+        )
+        assert seen_rounds == [
+            (0, None),
+            (1, "public_safe_soft_verify_exception_after_agent_round"),
+        ]
         rounds_log = (rollout_dir / "user_rounds.jsonl").read_text(encoding="utf-8")
         assert "public_safe_soft_verify_exception_after_agent_round" in rounds_log
         assert "PRIVATE_PATH_SHOULD_NOT_ESCAPE" not in rounds_log
@@ -10095,7 +10128,7 @@ if __name__ == "__main__":
     test_skillsbench_main_recovers_official_result_after_runner_exception()
     test_skillsbench_main_recovers_missing_reward_with_structured_prereq_blocker()
     test_skillsbench_result_timeout_after_loopx_lifecycle_is_attributed()
-    test_skillsbench_user_loop_recovery_preserves_final_verify_path()
+    test_skillsbench_user_loop_soft_verify_exception_continues_to_next_round()
     test_skillsbench_final_verify_timeout_after_user_loop_recovery_is_attributed()
     test_skillsbench_verifier_prep_timeout_override_is_public_safe()
     test_skillsbench_main_marks_empty_acp_trajectory_after_host_install()

--- a/examples/skillsbench-host-local-launch-plan-smoke.py
+++ b/examples/skillsbench-host-local-launch-plan-smoke.py
@@ -24,6 +24,9 @@ from loopx.benchmark_adapters.skillsbench_acp_relay import (  # noqa: E402
     SKILLSBENCH_LOCAL_ACP_RELAY_READY_MARKER,
     run_skillsbench_local_acp_relay_probe,
 )
+from loopx.benchmark_adapters.skillsbench_remote_bridge import (  # noqa: E402
+    build_skillsbench_remote_command_file_bridge_probe_request,
+)
 from scripts.skillsbench_automation_loop import (  # noqa: E402
     HOST_LOCAL_ACP_AGENT_TIMEOUT_MARGIN_SEC,
     _apply_agent_message_only_no_tool_calls_attribution,
@@ -59,7 +62,7 @@ def main() -> int:
     assert "getattr(\n        benchflow_rollout_module, \"connect_acp\", _MISSING" in source
     assert "if original_rollout_connect_acp is not _MISSING:" in source
     assert "from benchflow.agents.protocol import ACPSessionAdapter" in source
-    assert ") -> tuple[Any, Any, Any, str]:" in source
+    assert ") -> tuple[Any, ...]:" in source
     assert "session_adapter = ACPSessionAdapter(client)" in source
     assert "return client, session, session_adapter, agent_name" in source
     assert "_filter_kwargs_for_signature(RolloutConfig, rollout_config_kwargs)" in source
@@ -79,6 +82,58 @@ def main() -> int:
     assert "pwd && ls -la" in first_action_block
     assert "/tmp/private-bridge" in first_action_block
     assert "<private bridge command>" not in first_action_block
+    with tempfile.TemporaryDirectory(prefix="skillsbench-agent-probe-count-") as tmp:
+        tmp_path = Path(tmp)
+        fake_bridge = tmp_path / "fake-bridge"
+        fake_bridge.write_text(
+            """#!/usr/bin/env python3
+import json
+import sys
+
+json.loads(sys.stdin.read() or "{}")
+print(json.dumps({"ok": True, "stdout": "", "stderr": "", "exit_code": 0}))
+""",
+            encoding="utf-8",
+        )
+        fake_bridge.chmod(0o755)
+        trace_dir = tmp_path / "traces"
+        relay = SkillsBenchLocalAcpRelay(
+            CodexExecConfig(
+                remote_command_file_bridge_command=str(fake_bridge),
+                worker_public_trace_dir=str(trace_dir),
+            )
+        )
+        summary_path = tmp_path / "summary.jsonl"
+        wrapper_path = relay._write_instrumented_bridge_wrapper(
+            tmp_path=tmp_path,
+            summary_path=summary_path,
+            bridge_command=str(fake_bridge),
+        )
+        proc = subprocess.run(
+            [str(wrapper_path)],
+            input=json.dumps(build_skillsbench_remote_command_file_bridge_probe_request()),
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=10,
+            check=False,
+        )
+        assert proc.returncode == 0, proc
+        relay._publish_remote_bridge_agent_operations_trace(
+            bridge_summary_path=summary_path
+        )
+        traces = [
+            json.loads(path.read_text(encoding="utf-8"))
+            for path in trace_dir.glob("*.compact.json")
+        ]
+        agent_ops = [
+            trace["remote_command_file_bridge_agent_operations"]
+            for trace in traces
+            if trace.get("trace_kind") == "remote_command_file_bridge_agent_operations"
+        ]
+        assert len(agent_ops) == 1, traces
+        assert agent_ops[0]["probe_operation_count"] == 1, agent_ops
+        assert agent_ops[0]["task_facing_operation_count"] == 0, agent_ops
     target_env = _host_local_acp_target_env(
         {
             "AI_ADDR": "127.0.0.1",
@@ -1765,6 +1820,7 @@ output.write_text({SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_PREFLIGHT_MARKER!r}, encod
                 build_stall_timeout_sec=0,
                 dataset="skillsbench-v1.1",
                 model=None,
+                run_group_id=None,
                 route="loopx-product-mode",
                 task_id="demo-task",
             ),

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -2254,6 +2254,9 @@ def _skillsbench_controller_trace_counters(
         "remote_command_file_bridge_agent_task_facing_operation_count": count(
             "remote_command_file_bridge_agent_task_facing_operation_count"
         ),
+        "remote_command_file_bridge_agent_probe_operation_count": count(
+            "remote_command_file_bridge_agent_probe_operation_count"
+        ),
         "remote_command_file_bridge_driver_lifecycle_trace_count": count(
             "remote_command_file_bridge_driver_lifecycle_trace_count"
         ),
@@ -2336,6 +2339,34 @@ def _skillsbench_controller_trace_counters(
         ),
         "benchflow_user_loop_recovery_delta_tool_calls": count(
             "benchflow_user_loop_recovery_delta_tool_calls"
+        ),
+        "benchflow_user_loop_soft_verify_exception_continued": controller_trace.get(
+            "benchflow_user_loop_soft_verify_exception_continued"
+        )
+        is True,
+        "benchflow_user_loop_soft_verify_exception_raw_error_recorded": controller_trace.get(
+            "benchflow_user_loop_soft_verify_exception_raw_error_recorded"
+        )
+        is True,
+        "benchflow_user_loop_soft_verify_exception_stage": str(
+            controller_trace.get("benchflow_user_loop_soft_verify_exception_stage")
+            or ""
+        )[:120],
+        "benchflow_user_loop_soft_verify_exception_type": str(
+            controller_trace.get("benchflow_user_loop_soft_verify_exception_type")
+            or ""
+        )[:120],
+        "benchflow_user_loop_soft_verify_exception_count": count(
+            "benchflow_user_loop_soft_verify_exception_count"
+        ),
+        "benchflow_user_loop_soft_verify_exception_round": count(
+            "benchflow_user_loop_soft_verify_exception_round"
+        ),
+        "benchflow_user_loop_soft_verify_exception_delta_events": count(
+            "benchflow_user_loop_soft_verify_exception_delta_events"
+        ),
+        "benchflow_user_loop_soft_verify_exception_delta_tool_calls": count(
+            "benchflow_user_loop_soft_verify_exception_delta_tool_calls"
         ),
         "benchflow_intermediate_soft_verify_final_only": controller_trace.get(
             "benchflow_intermediate_soft_verify_final_only"
@@ -3855,6 +3886,38 @@ def build_skillsbench_benchflow_result_benchmark_run(
                 "benchflow_user_loop_recovery_delta_tool_calls",
                 0,
             ),
+            "benchflow_user_loop_soft_verify_exception_continued": controller_counters.get(
+                "benchflow_user_loop_soft_verify_exception_continued",
+                False,
+            ),
+            "benchflow_user_loop_soft_verify_exception_raw_error_recorded": controller_counters.get(
+                "benchflow_user_loop_soft_verify_exception_raw_error_recorded",
+                False,
+            ),
+            "benchflow_user_loop_soft_verify_exception_stage": controller_counters.get(
+                "benchflow_user_loop_soft_verify_exception_stage",
+                "",
+            ),
+            "benchflow_user_loop_soft_verify_exception_type": controller_counters.get(
+                "benchflow_user_loop_soft_verify_exception_type",
+                "",
+            ),
+            "benchflow_user_loop_soft_verify_exception_count": controller_counters.get(
+                "benchflow_user_loop_soft_verify_exception_count",
+                0,
+            ),
+            "benchflow_user_loop_soft_verify_exception_round": controller_counters.get(
+                "benchflow_user_loop_soft_verify_exception_round",
+                0,
+            ),
+            "benchflow_user_loop_soft_verify_exception_delta_events": controller_counters.get(
+                "benchflow_user_loop_soft_verify_exception_delta_events",
+                0,
+            ),
+            "benchflow_user_loop_soft_verify_exception_delta_tool_calls": controller_counters.get(
+                "benchflow_user_loop_soft_verify_exception_delta_tool_calls",
+                0,
+            ),
             "benchflow_intermediate_soft_verify_policy": controller_counters.get(
                 "benchflow_intermediate_soft_verify_policy",
                 "",
@@ -4188,6 +4251,11 @@ def build_skillsbench_benchflow_result_benchmark_run(
             "remote_command_file_bridge_agent_task_facing_operation_count": (
                 controller_counters.get(
                     "remote_command_file_bridge_agent_task_facing_operation_count", 0
+                )
+            ),
+            "remote_command_file_bridge_agent_probe_operation_count": (
+                controller_counters.get(
+                    "remote_command_file_bridge_agent_probe_operation_count", 0
                 )
             ),
             "remote_command_file_bridge_driver_lifecycle_trace_count": (

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -1026,6 +1026,14 @@ from pathlib import Path
 
 SUMMARY_PATH = Path({str(summary_path)!r})
 BRIDGE_COMMAND = {command!r}
+PROBE_REQUEST_SCHEMA_VERSION = "skillsbench_remote_command_file_bridge_probe_request_v0"
+PROBE_OPERATION_LABELS = {{
+    "bounded_noop_command",
+    "probe_marker_write",
+    "probe_marker_read",
+    "probe_marker_cleanup",
+}}
+PROBE_PATH_LABELS = {{"bridge_probe_marker"}}
 
 def loopx_subcommands(command: str) -> list[str]:
     try:
@@ -1074,6 +1082,24 @@ except Exception:
     payload = {{}}
 operation = payload.get("operation") if isinstance(payload, dict) else ""
 record["operation"] = operation if isinstance(operation, str) else "unknown"
+operation_label = payload.get("label") if isinstance(payload, dict) else ""
+path_label = payload.get("path_label") if isinstance(payload, dict) else ""
+if isinstance(operation_label, str) and operation_label:
+    record["operation_label"] = operation_label[:80]
+if isinstance(path_label, str) and path_label:
+    record["path_label"] = path_label[:80]
+bridge_probe_operation = bool(
+    isinstance(payload, dict)
+    and (
+        payload.get("schema_version") == PROBE_REQUEST_SCHEMA_VERSION
+        or payload.get("probe_id") == "skillsbench_remote_command_file_bridge_probe"
+        or (
+            isinstance(operation_label, str)
+            and operation_label in PROBE_OPERATION_LABELS
+        )
+        or (isinstance(path_label, str) and path_label in PROBE_PATH_LABELS)
+    )
+)
 subcommands: list[str] = []
 if isinstance(payload, dict) and payload.get("operation") == "exec":
     command_text = payload.get("command")
@@ -1087,9 +1113,13 @@ record["loopx_state_write"] = bool(subcommands and (
     or subcommands[:2] == ["quota", "spend-slot"]
 ))
 record["task_facing_operation"] = bool(
-    operation in {{"read_file", "write_file", "cleanup"}}
-    or (operation == "exec" and not subcommands)
+    not bridge_probe_operation
+    and (
+        operation in {{"read_file", "write_file", "cleanup"}}
+        or (operation == "exec" and not subcommands)
+    )
 )
+record["bridge_probe_operation"] = bridge_probe_operation
 record["operation_observed"] = True
 
 def append_record(item: dict[str, object]) -> None:
@@ -1143,6 +1173,7 @@ raise SystemExit(proc.returncode)
         state_read_count = 0
         state_write_count = 0
         task_facing_operation_count = 0
+        probe_operation_count = 0
         raw_material_recorded = False
         if bridge_summary_path.exists():
             for line in bridge_summary_path.read_text(
@@ -1194,6 +1225,8 @@ raise SystemExit(proc.returncode)
                     state_write_count += 1
                 if counts_as_request and record.get("task_facing_operation") is True:
                     task_facing_operation_count += 1
+                if counts_as_request and record.get("bridge_probe_operation") is True:
+                    probe_operation_count += 1
                 subcommands = record.get("loopx_subcommands")
                 if isinstance(subcommands, list) and subcommands:
                     key = " ".join(
@@ -1248,6 +1281,7 @@ raise SystemExit(proc.returncode)
                 "loopx_state_read_count": state_read_count,
                 "loopx_state_write_count": state_write_count,
                 "task_facing_operation_count": task_facing_operation_count,
+                "probe_operation_count": probe_operation_count,
                 "raw_material_recorded": raw_material_recorded,
             },
             "boundary": {

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -1474,6 +1474,8 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "codex_app_server_goal_worker_plan_schema",
         "benchflow_user_loop_recovery_exception_type",
         "benchflow_user_loop_recovery_stage",
+        "benchflow_user_loop_soft_verify_exception_type",
+        "benchflow_user_loop_soft_verify_exception_stage",
         "benchflow_intermediate_soft_verify_policy",
         "benchflow_intermediate_soft_verify_timeout_stage",
         "benchflow_intermediate_soft_verify_timeout_cleanup_status",
@@ -1561,6 +1563,8 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "benchflow_user_loop_recovery_after_agent_activity",
         "benchflow_user_loop_recovery_raw_error_recorded",
         "benchflow_user_loop_recovery_preserved_final_verify",
+        "benchflow_user_loop_soft_verify_exception_continued",
+        "benchflow_user_loop_soft_verify_exception_raw_error_recorded",
         "benchflow_intermediate_soft_verify_final_only",
         "benchflow_intermediate_soft_verify_raw_output_recorded",
         "benchflow_intermediate_soft_verify_timeout_enabled",
@@ -1607,6 +1611,10 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "benchflow_user_loop_recovery_round",
         "benchflow_user_loop_recovery_delta_events",
         "benchflow_user_loop_recovery_delta_tool_calls",
+        "benchflow_user_loop_soft_verify_exception_count",
+        "benchflow_user_loop_soft_verify_exception_round",
+        "benchflow_user_loop_soft_verify_exception_delta_events",
+        "benchflow_user_loop_soft_verify_exception_delta_tool_calls",
         "benchflow_intermediate_soft_verify_call_count",
         "benchflow_intermediate_soft_verify_skipped_count",
         "benchflow_intermediate_soft_verify_timeout_sec",
@@ -1642,6 +1650,7 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "remote_command_file_bridge_agent_loopx_state_read_count",
         "remote_command_file_bridge_agent_loopx_state_write_count",
         "remote_command_file_bridge_agent_task_facing_operation_count",
+        "remote_command_file_bridge_agent_probe_operation_count",
         "remote_command_file_bridge_agent_todo_closeout_count",
         "remote_command_file_bridge_agent_refresh_state_count",
         "remote_command_file_bridge_agent_quota_spend_slot_count",
@@ -2389,6 +2398,47 @@ def _mark_user_loop_final_verify_recovery(
         trace["last_decision"] = "break_after_agent_round_preserve_final_verify"
 
 
+def _mark_user_loop_soft_verify_exception_continuation(
+    *,
+    plan: dict[str, Any],
+    trace: dict[str, Any] | None,
+    round_num: int,
+    exception: Exception,
+    delta_events: int,
+    delta_tool_calls: int,
+) -> None:
+    prerequisites = plan.setdefault("runner_prerequisites", {})
+    fields: dict[str, Any] = {
+        "benchflow_user_loop_soft_verify_exception_continued": True,
+        "benchflow_user_loop_soft_verify_exception_raw_error_recorded": False,
+        "benchflow_user_loop_soft_verify_exception_stage": "soft_verify",
+        "benchflow_user_loop_soft_verify_exception_type": type(exception).__name__,
+        "benchflow_user_loop_soft_verify_exception_round": round_num,
+        "benchflow_user_loop_soft_verify_exception_delta_events": max(
+            0,
+            delta_events,
+        ),
+        "benchflow_user_loop_soft_verify_exception_delta_tool_calls": max(
+            0,
+            delta_tool_calls,
+        ),
+    }
+    current = prerequisites.get("benchflow_user_loop_soft_verify_exception_count")
+    if not isinstance(current, int) or isinstance(current, bool):
+        current = 0
+    fields["benchflow_user_loop_soft_verify_exception_count"] = current + 1
+    prerequisites.update(fields)
+    if isinstance(trace, dict):
+        trace_current = trace.get("benchflow_user_loop_soft_verify_exception_count")
+        if not isinstance(trace_current, int) or isinstance(trace_current, bool):
+            trace_current = 0
+        trace_fields = dict(fields)
+        trace_fields["benchflow_user_loop_soft_verify_exception_count"] = (
+            trace_current + 1
+        )
+        trace.update(trace_fields)
+
+
 def install_benchflow_user_loop_final_verify_recovery(
     rollout_cls: Any,
     *,
@@ -2559,27 +2609,18 @@ def install_benchflow_user_loop_final_verify_recovery(
                     )
                     rewards, verifier_output, verifier_error = await self.soft_verify()
             except Exception as exc:
-                _mark_user_loop_final_verify_recovery(
+                _mark_user_loop_soft_verify_exception_continuation(
                     plan=plan,
                     trace=trace,
-                    stage="soft_verify",
                     round_num=round_num,
                     exception=exc,
                     delta_events=len(round_trajectory),
                     delta_tool_calls=round_tools,
                 )
-                rounds_log.append(
-                    {
-                        "round": round_num,
-                        "rewards": None,
-                        "verifier_error": "public_safe_soft_verify_exception_after_agent_round",
-                        "soft_verify_policy": intermediate_soft_verify_policy,
-                        "soft_verify_skipped": False,
-                        "n_tool_calls": round_tools,
-                        "n_trajectory_events": len(round_trajectory),
-                    }
-                )
-                break
+                rewards = None
+                verifier_output = None
+                verifier_error = "public_safe_soft_verify_exception_after_agent_round"
+                soft_verify_skipped = False
             finally:
                 if cfg.oracle_access:
                     await self._env.exec(
@@ -5501,6 +5542,7 @@ def _merge_host_local_acp_relay_trace_summary(
     agent_bridge_loopx_state_read_count = 0
     agent_bridge_loopx_state_write_count = 0
     agent_bridge_task_facing_operation_count = 0
+    agent_bridge_probe_operation_count = 0
     agent_bridge_operation_counts: dict[str, int] = {}
     agent_bridge_loopx_subcommand_counts: dict[str, int] = {}
     agent_bridge_successful_loopx_subcommand_counts: dict[str, int] = {}
@@ -5584,6 +5626,7 @@ def _merge_host_local_acp_relay_trace_summary(
                 "loopx_state_read_count": "state_read",
                 "loopx_state_write_count": "state_write",
                 "task_facing_operation_count": "task_facing",
+                "probe_operation_count": "probe",
             }
             for field, target in count_fields.items():
                 value = agent_ops.get(field)
@@ -5604,6 +5647,8 @@ def _merge_host_local_acp_relay_trace_summary(
                     agent_bridge_loopx_state_write_count += value
                 elif target == "task_facing":
                     agent_bridge_task_facing_operation_count += value
+                elif target == "probe":
+                    agent_bridge_probe_operation_count += value
             for source_key, target_counts in (
                 ("operation_counts", agent_bridge_operation_counts),
                 ("loopx_cli_subcommand_counts", agent_bridge_loopx_subcommand_counts),
@@ -5799,6 +5844,9 @@ def _merge_host_local_acp_relay_trace_summary(
     trace["remote_command_file_bridge_agent_task_facing_operation_count"] = (
         agent_bridge_task_facing_operation_count
     )
+    trace["remote_command_file_bridge_agent_probe_operation_count"] = (
+        agent_bridge_probe_operation_count
+    )
     trace["remote_command_file_bridge_agent_operation_counts"] = dict(
         sorted(agent_bridge_operation_counts.items())
     )
@@ -5940,6 +5988,9 @@ def _merge_host_local_acp_relay_trace_summary(
     )
     prerequisites["remote_command_file_bridge_agent_task_facing_operation_count"] = (
         agent_bridge_task_facing_operation_count
+    )
+    prerequisites["remote_command_file_bridge_agent_probe_operation_count"] = (
+        agent_bridge_probe_operation_count
     )
     prerequisites["remote_command_file_bridge_agent_operation_counts"] = dict(
         sorted(agent_bridge_operation_counts.items())


### PR DESCRIPTION
## Summary
- keep SkillsBench user loops running after intermediate soft_verify exceptions by treating them as missing reward for that round instead of final-verify recovery stops
- expose public counters for continued soft_verify exceptions in runner prerequisites and compact outputs
- separate remote bridge probe operations from task-facing solver activity and add probe-operation counters

## Validation
- python3 -m py_compile scripts/skillsbench_automation_loop.py loopx/benchmark_adapters/skillsbench_acp_relay.py loopx/benchmark_adapters/skillsbench.py examples/skillsbench-benchmark-run-smoke.py examples/skillsbench-host-local-launch-plan-smoke.py
- python3 examples/skillsbench-benchmark-run-smoke.py
- python3 examples/skillsbench-host-local-launch-plan-smoke.py
- python3 examples/benchmark-run-ledger-smoke.py
- python3 examples/benchmark-case-analysis-smoke.py
- git diff --check

## Boundary
- public helper/runtime and durable smoke changes only
- no raw task text, raw trajectories, raw logs, credentials, local benchmark artifacts, or private rollout evidence included