### PR TITLE
Assert SkillsBench ACP arity probe

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -5076,6 +5076,8 @@ def test_host_local_acp_connect_contract_matches_benchflow_runtime() -> None:
         encoding="utf-8"
     )
     assert "def _benchflow_connect_acp_return_arity(target: Any) -> int:" in source
+    assert "return_arity = _benchflow_connect_acp_return_arity(" in source
+    assert "if return_arity >= 4:" in source
     assert "from benchflow.agents.protocol import ACPSessionAdapter" in source
     assert ") -> tuple[Any, ...]:" in source
     assert "session_adapter = ACPSessionAdapter(client)" in source


### PR DESCRIPTION
## Summary
- add a focused SkillsBench smoke assertion that the host-local ACP connect path calls the BenchFlow arity probe
- assert the runtime gates the 4-return-value path with the detected arity

## Validation
- python3 -m py_compile scripts/skillsbench_automation_loop.py examples/skillsbench-benchmark-run-smoke.py
- python3 examples/skillsbench-benchmark-run-smoke.py
- git diff --cached --check
- staged diff public/private boundary scan clean

This is benchmark helper/runtime validation only; it does not change runner behavior, scoring, task semantics, submissions, or permission boundaries.