### PR TITLE
docs: backfill citation-check trajectory summary

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/benchmark-case-analysis.json
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-case-analysis.json
@@ -1855,6 +1855,42 @@
           "The treatment used the outer LoopX blind-loop wrapper, but no official reward/pass/fail/verifier feedback was returned to the agent."
         ]
       },
+      "post_stop_policy_raw_rerun": {
+        "schema_version": "skillsbench_compact_public_rerun_summary_v0",
+        "route": "raw_codex_autonomous_max5",
+        "official_score": 1.0,
+        "score_failure_attribution": "none",
+        "case_semantics_changed_by_harness": false,
+        "official_feedback_blinded": true,
+        "reward_feedback_forwarded": false,
+        "trajectory_public_summary": {
+          "schema_version": "skillsbench_acp_trajectory_summary_v0",
+          "attribution_conclusion": "The post-stop-policy raw Codex rerun solved citation-check in one round; the public-safe trajectory summary shows 26 tool calls, zero LoopX CLI calls, and no protected-path edit signal, so this remains a baseline-solved guard rather than uplift evidence.",
+          "private_trajectory_present": true,
+          "raw_text_copied_to_public": false,
+          "raw_task_text_copied_to_public": false,
+          "raw_verifier_output_copied_to_public": false,
+          "host_path_recorded": false,
+          "round_count": 1,
+          "tool_call_count": 26,
+          "loopx_cli_call_count": 0,
+          "loopx_cli_calls": [],
+          "loopx_cli_state_usage_counts": {},
+          "protected_path_edit_signal_count": 0,
+          "protected_path_mention_count": 0,
+          "codex_acp_text_present": false,
+          "codex_acp_text_bytes": 0,
+          "source_compact_run": {
+            "case_id": "citation-check",
+            "route": "raw_codex_autonomous_max5",
+            "official_score": 1.0,
+            "score_failure_attribution": "none",
+            "official_feedback_blinded": true,
+            "reward_feedback_forwarded": false,
+            "case_semantics_changed_by_harness": false
+          }
+        }
+      },
       "canonical_product_mode_every_round_recheck": {
         "schema_version": "skillsbench_canonical_product_mode_recheck_v0",
         "protocol": "canonical_loopx_product_mode_lifecycle_driver",

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-case-analysis.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-case-analysis.md
@@ -67,11 +67,12 @@ public counters; absence from this table means the durable case record does
 not yet contain a public trajectory summary.
 
 - schema_version: `trajectory_public_summary_coverage_v0`
-- summary_count: `2`
-- attribution_conclusion_count: `2`
+- summary_count: `3`
+- attribution_conclusion_count: `3`
 
 | Benchmark | Case | Summary | Rounds | Tools | LoopX CLI | Protected Edits | Attribution |
 | --- | --- | --- | --- | --- | --- | --- | --- |
+| `skillsbench@1.1` | `citation-check` | `post_stop_policy_raw_rerun.trajectory_public_summary` (public-safe) | `1` | `26` | `0` | `0` | `yes` |
 | `skillsbench@1.1` | `debug-trl-grpo` | `trajectory_public_summary` (public-safe) | `5` | `112` | `0` | `2` | `yes` |
 | `skillsbench@1.1` | `paratransit-routing` | `legacy_blind_loop_positive_result.trajectory_public_summary` (public-safe) | `1` | `16` | `0` | `0` | `yes` |
 
@@ -84,11 +85,12 @@ benchmark case records that expose the same public fields. They do not read
 or copy raw trajectories, task text, verifier output, logs, or local paths.
 
 - schema_version: `harness_interaction_public_summary_coverage_v0`
-- summary_count: `11`
+- summary_count: `12`
 - benchmark_ids: `skillsbench@1.1, swe-marathon, terminal-bench@2.0`
 
 | Benchmark | Case | Source | Kind | LoopX CLI | Rounds | Tools | Events | Controller Trace | Lifecycle |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `skillsbench@1.1` | `citation-check` | `post_stop_policy_raw_rerun.trajectory_public_summary` (public-safe) | `trajectory_public_summary` | `0` | `1` | `26` | `0` | `no` | `no` |
 | `skillsbench@1.1` | `debug-trl-grpo` | `trajectory_public_summary` (public-safe) | `trajectory_public_summary` | `0` | `5` | `112` | `0` | `no` | `no` |
 | `skillsbench@1.1` | `llm-prefix-cache-replay` | `native_goal_route_observations` (public-safe) | `native_goal_route_observation` | `0` | `0` | `0` | `0` | `yes` | `no` |
 | `skillsbench@1.1` | `paratransit-routing` | `arms.treatment` (public-safe) | `case_arm` | `1` | `0` | `0` | `0` | `no` | `no` |

--- a/examples/benchmark-case-analysis-smoke.py
+++ b/examples/benchmark-case-analysis-smoke.py
@@ -69,15 +69,20 @@ def test_case_analysis_json() -> None:
     assert trajectory_coverage["schema_version"] == (
         "trajectory_public_summary_coverage_v0"
     ), trajectory_coverage
-    assert trajectory_coverage["summary_count"] == 2, trajectory_coverage
-    assert trajectory_coverage["public_safe_count"] == 2, trajectory_coverage
-    assert trajectory_coverage["attribution_conclusion_count"] == 2, (
+    assert trajectory_coverage["summary_count"] == 3, trajectory_coverage
+    assert trajectory_coverage["public_safe_count"] == 3, trajectory_coverage
+    assert trajectory_coverage["attribution_conclusion_count"] == 3, (
         trajectory_coverage
     )
     coverage_rows = {
         (row["benchmark_id"], row["case_id"], row["summary_path"]): row
         for row in trajectory_coverage["rows"]
     }
+    assert (
+        "skillsbench@1.1",
+        "citation-check",
+        "post_stop_policy_raw_rerun.trajectory_public_summary",
+    ) in coverage_rows, trajectory_coverage
     assert (
         "skillsbench@1.1",
         "debug-trl-grpo",
@@ -1238,6 +1243,8 @@ def test_case_analysis_markdown() -> None:
     assert "`terminal-bench@2.0` | `nginx-request-logging` | `arms.treatment`" in text, text
     assert "native_goal_route_observations" in text, text
     assert "legacy_blind_loop_positive_result.trajectory_public_summary" in text, text
+    assert "post_stop_policy_raw_rerun.trajectory_public_summary" in text, text
+    assert "`citation-check` | `post_stop_policy_raw_rerun.trajectory_public_summary`" in text, text
     assert "`debug-trl-grpo` | `trajectory_public_summary`" in text, text
     assert "current-protocol success-preservation guards" in text, text
     assert "cobol-modernization" in text, text


### PR DESCRIPTION
## Summary
- backfill the public-safe citation-check raw Codex post-stop-policy rerun trajectory summary into case-analysis
- update the generated coverage tables in the case-analysis markdown
- extend the case-analysis smoke coverage for the new public trajectory row

## Validation
- `python3 examples/benchmark-case-analysis-smoke.py`
- `python3 -m py_compile loopx/benchmark_case_analysis.py examples/benchmark-case-analysis-smoke.py`
- `git diff --check`
- `loopx check --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-case-analysis.json --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-case-analysis.md --scan-path examples/benchmark-case-analysis-smoke.py`

## Boundary
No raw task text, raw trajectory body, raw logs, verifier output, local paths, credentials, or private benchmark job paths are copied into public artifacts. This PR only records compact public-safe counters from the existing public summary.
