### PR TITLE
docs: backfill 3d-scan trajectory summaries

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/benchmark-case-analysis.json
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-case-analysis.json
@@ -2062,6 +2062,102 @@
         "soft_verifier_timeout_sec": 180,
         "interpretation": "Canonical product-mode every-round rerun is a good driver proof and non-regression guard: both arms reached official 1.0 in round 1, the treatment produced full LoopX lifecycle closeout counters, and the controller stopped early on the private reward observation without forwarding reward, pass/fail, or verifier output to the agent.",
         "why_not_uplift": "Baseline also solved in round 1, so the pair proves treatment preservation and lifecycle correctness rather than score uplift."
+      },
+      "historical_final_only_lifecycle_trajectory_summaries": {
+        "schema_version": "skillsbench_final_only_lifecycle_trajectory_pair_v0",
+        "evidence_status": "public_controller_trace_counts_only_no_raw_task_text_no_verifier_output_no_local_paths",
+        "why_historical": "This pair predates the later every-round product-mode recheck. Use it for overhead and lifecycle-depth-gap diagnosis, not as the current stop-policy proof.",
+        "baseline": {
+          "route": "raw-codex-autonomous-max5",
+          "official_score": 1.0,
+          "official_feedback_blinded": true,
+          "reward_feedback_forwarded": false,
+          "case_semantics_changed_by_harness": false,
+          "trajectory_public_summary": {
+            "schema_version": "skillsbench_acp_trajectory_summary_v0",
+            "attribution_conclusion": "Historical final-only canonical lifecycle baseline solved 3d-scan-calc at official 1.0 after one agent round with 7 tool calls and no LoopX CLI calls; this confirms the case is baseline-solved rather than uplift evidence.",
+            "private_trajectory_present": true,
+            "raw_text_copied_to_public": false,
+            "raw_task_text_copied_to_public": false,
+            "raw_verifier_output_copied_to_public": false,
+            "host_path_recorded": false,
+            "round_count": 1,
+            "tool_call_count": 7,
+            "loopx_cli_call_count": 0,
+            "loopx_cli_calls": [],
+            "loopx_cli_state_usage_counts": {},
+            "loopx_cli_state_read_count": 0,
+            "loopx_cli_state_write_count": 0,
+            "loopx_case_state_read_count": 0,
+            "loopx_case_state_write_count": 0,
+            "trajectory_action_category_counts": {
+              "execution": 3,
+              "inspection": 3,
+              "tool_other": 1
+            },
+            "protected_path_edit_signal_count": 0,
+            "protected_path_mention_count": 0,
+            "codex_acp_text_present": false,
+            "codex_acp_text_bytes": 0,
+            "source_compact_run": {
+              "case_id": "3d-scan-calc",
+              "route": "raw-codex-autonomous-max5",
+              "official_score": 1.0,
+              "score_failure_attribution": "none",
+              "official_feedback_blinded": true,
+              "reward_feedback_forwarded": false,
+              "case_semantics_changed_by_harness": false
+            }
+          }
+        },
+        "treatment": {
+          "route": "loopx-product-mode",
+          "official_score": 1.0,
+          "official_feedback_blinded": true,
+          "reward_feedback_forwarded": false,
+          "case_semantics_changed_by_harness": true,
+          "trajectory_public_summary": {
+            "schema_version": "skillsbench_acp_trajectory_summary_v0",
+            "attribution_conclusion": "Historical final-only product-mode treatment also reached official 1.0, but only in round 8 with 138 tool calls and 73 LoopX CLI calls; this is success preservation with substantial overhead and a lifecycle-depth-gap signal, superseded for current stop-policy claims by the later every-round recheck.",
+            "private_trajectory_present": true,
+            "raw_text_copied_to_public": false,
+            "raw_task_text_copied_to_public": false,
+            "raw_verifier_output_copied_to_public": false,
+            "host_path_recorded": false,
+            "round_count": 8,
+            "tool_call_count": 138,
+            "loopx_cli_call_count": 73,
+            "loopx_cli_calls": [],
+            "loopx_cli_state_usage_counts": {
+              "other": 2,
+              "state_read": 28,
+              "state_write": 43
+            },
+            "loopx_cli_state_read_count": 28,
+            "loopx_cli_state_write_count": 43,
+            "loopx_case_state_read_count": 0,
+            "loopx_case_state_write_count": 0,
+            "trajectory_action_category_counts": {
+              "execution": 21,
+              "inspection": 42,
+              "loopx_cli": 73,
+              "tool_other": 2
+            },
+            "protected_path_edit_signal_count": 0,
+            "protected_path_mention_count": 0,
+            "codex_acp_text_present": false,
+            "codex_acp_text_bytes": 0,
+            "source_compact_run": {
+              "case_id": "3d-scan-calc",
+              "route": "loopx-product-mode",
+              "official_score": 1.0,
+              "score_failure_attribution": "none",
+              "official_feedback_blinded": true,
+              "reward_feedback_forwarded": false,
+              "case_semantics_changed_by_harness": true
+            }
+          }
+        }
       }
     },
     {

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-case-analysis.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-case-analysis.md
@@ -67,11 +67,13 @@ public counters; absence from this table means the durable case record does
 not yet contain a public trajectory summary.
 
 - schema_version: `trajectory_public_summary_coverage_v0`
-- summary_count: `3`
-- attribution_conclusion_count: `3`
+- summary_count: `5`
+- attribution_conclusion_count: `5`
 
 | Benchmark | Case | Summary | Rounds | Tools | LoopX CLI | Protected Edits | Attribution |
 | --- | --- | --- | --- | --- | --- | --- | --- |
+| `skillsbench@1.1` | `3d-scan-calc` | `historical_final_only_lifecycle_trajectory_summaries.baseline.trajectory_public_summary` (public-safe) | `1` | `7` | `0` | `0` | `yes` |
+| `skillsbench@1.1` | `3d-scan-calc` | `historical_final_only_lifecycle_trajectory_summaries.treatment.trajectory_public_summary` (public-safe) | `8` | `138` | `73` | `0` | `yes` |
 | `skillsbench@1.1` | `citation-check` | `post_stop_policy_raw_rerun.trajectory_public_summary` (public-safe) | `1` | `26` | `0` | `0` | `yes` |
 | `skillsbench@1.1` | `debug-trl-grpo` | `trajectory_public_summary` (public-safe) | `5` | `112` | `0` | `2` | `yes` |
 | `skillsbench@1.1` | `paratransit-routing` | `legacy_blind_loop_positive_result.trajectory_public_summary` (public-safe) | `1` | `16` | `0` | `0` | `yes` |
@@ -85,11 +87,13 @@ benchmark case records that expose the same public fields. They do not read
 or copy raw trajectories, task text, verifier output, logs, or local paths.
 
 - schema_version: `harness_interaction_public_summary_coverage_v0`
-- summary_count: `12`
+- summary_count: `14`
 - benchmark_ids: `skillsbench@1.1, swe-marathon, terminal-bench@2.0`
 
 | Benchmark | Case | Source | Kind | LoopX CLI | Rounds | Tools | Events | Controller Trace | Lifecycle |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `skillsbench@1.1` | `3d-scan-calc` | `historical_final_only_lifecycle_trajectory_summaries.baseline.trajectory_public_summary` (public-safe) | `trajectory_public_summary` | `0` | `1` | `7` | `7` | `no` | `no` |
+| `skillsbench@1.1` | `3d-scan-calc` | `historical_final_only_lifecycle_trajectory_summaries.treatment.trajectory_public_summary` (public-safe) | `trajectory_public_summary` | `73` | `8` | `138` | `211` | `no` | `no` |
 | `skillsbench@1.1` | `citation-check` | `post_stop_policy_raw_rerun.trajectory_public_summary` (public-safe) | `trajectory_public_summary` | `0` | `1` | `26` | `0` | `no` | `no` |
 | `skillsbench@1.1` | `debug-trl-grpo` | `trajectory_public_summary` (public-safe) | `trajectory_public_summary` | `0` | `5` | `112` | `0` | `no` | `no` |
 | `skillsbench@1.1` | `llm-prefix-cache-replay` | `native_goal_route_observations` (public-safe) | `native_goal_route_observation` | `0` | `0` | `0` | `0` | `yes` | `no` |
@@ -1595,6 +1599,14 @@ Canonical product-mode every-round recheck:
   calls `2`, todo closeout calls `6`
 - host-local ACP Codex exec preflight: `passed`
 
+Historical final-only lifecycle trajectory summary:
+
+- baseline summary: `1` round, `7` tool calls, `0` LoopX CLI calls
+- treatment summary: `8` rounds, `138` tool calls, `73` LoopX CLI calls
+- treatment LoopX CLI state usage: `28` reads, `43` writes, `2` other
+- case-local state access in that historical public trace: `0` reads, `0`
+  writes
+
 Interpretation:
 
 The old record said the case was solvable by baseline, but it did not answer
@@ -1613,6 +1625,12 @@ an 8-round budget but stopped after round 1 because the private verifier
 observed reward `1.0`; the reward/pass/fail/verifier output was not forwarded
 to the agent. In treatment, the full case-local lifecycle was visible through
 state read/write, refresh, spend, and todo-closeout counters.
+
+The historical final-only lifecycle trace is kept only as overhead and
+lifecycle-depth-gap evidence. It predates the every-round recheck, and it shows
+that the older product-mode treatment preserved final official success but
+needed all `8` rounds and substantial LoopX CLI activity. It should not be used
+as the current stop-policy proof.
 
 Why it matters:
 

--- a/examples/benchmark-case-analysis-smoke.py
+++ b/examples/benchmark-case-analysis-smoke.py
@@ -69,9 +69,9 @@ def test_case_analysis_json() -> None:
     assert trajectory_coverage["schema_version"] == (
         "trajectory_public_summary_coverage_v0"
     ), trajectory_coverage
-    assert trajectory_coverage["summary_count"] == 3, trajectory_coverage
-    assert trajectory_coverage["public_safe_count"] == 3, trajectory_coverage
-    assert trajectory_coverage["attribution_conclusion_count"] == 3, (
+    assert trajectory_coverage["summary_count"] == 5, trajectory_coverage
+    assert trajectory_coverage["public_safe_count"] == 5, trajectory_coverage
+    assert trajectory_coverage["attribution_conclusion_count"] == 5, (
         trajectory_coverage
     )
     coverage_rows = {
@@ -83,6 +83,31 @@ def test_case_analysis_json() -> None:
         "citation-check",
         "post_stop_policy_raw_rerun.trajectory_public_summary",
     ) in coverage_rows, trajectory_coverage
+    assert (
+        "skillsbench@1.1",
+        "3d-scan-calc",
+        (
+            "historical_final_only_lifecycle_trajectory_summaries"
+            ".baseline.trajectory_public_summary"
+        ),
+    ) in coverage_rows, trajectory_coverage
+    scan_treatment_trajectory = coverage_rows[
+        (
+            "skillsbench@1.1",
+            "3d-scan-calc",
+            (
+                "historical_final_only_lifecycle_trajectory_summaries"
+                ".treatment.trajectory_public_summary"
+            ),
+        )
+    ]
+    assert scan_treatment_trajectory["round_count"] == 8, scan_treatment_trajectory
+    assert scan_treatment_trajectory["tool_call_count"] == 138, (
+        scan_treatment_trajectory
+    )
+    assert scan_treatment_trajectory["loopx_cli_call_count"] == 73, (
+        scan_treatment_trajectory
+    )
     assert (
         "skillsbench@1.1",
         "debug-trl-grpo",
@@ -1245,6 +1270,8 @@ def test_case_analysis_markdown() -> None:
     assert "legacy_blind_loop_positive_result.trajectory_public_summary" in text, text
     assert "post_stop_policy_raw_rerun.trajectory_public_summary" in text, text
     assert "`citation-check` | `post_stop_policy_raw_rerun.trajectory_public_summary`" in text, text
+    assert "historical_final_only_lifecycle_trajectory_summaries" in text, text
+    assert "`3d-scan-calc` | `historical_final_only_lifecycle_trajectory_summaries.treatment.trajectory_public_summary`" in text, text
     assert "`debug-trl-grpo` | `trajectory_public_summary`" in text, text
     assert "current-protocol success-preservation guards" in text, text
     assert "cobol-modernization" in text, text


### PR DESCRIPTION
## Summary

- add public-safe historical final-only ACP trajectory summaries for `3d-scan-calc`
- mark the pair as overhead / lifecycle-depth-gap evidence, not current stop-policy proof
- regenerate public trajectory and harness coverage tables and extend the case-analysis smoke

## Validation

- `python3 examples/benchmark-case-analysis-smoke.py`
- `python3 -m py_compile loopx/benchmark_case_analysis.py examples/benchmark-case-analysis-smoke.py`
- `git diff --check`
- `loopx check --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-case-analysis.json --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-case-analysis.md --scan-path examples/benchmark-case-analysis-smoke.py`

## Boundary

Only compact public counters are added. No raw task text, raw trajectories, verifier output tails, local paths, credentials, or private benchmark artifact paths are committed.
