### PR TITLE
docs: add core control-plane graph map

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,9 @@ incident report, or launch draft.
 - [Product vision](product/vision.md): long-term product direction, Loop Agent
   definition, maintainer-first management surface, and open-source anchor
   strategy.
+- [Core control-plane graphs](product/core-control-plane/README.md): the
+  interaction catalog lens, state definitions, and state machine in one
+  product/runtime map.
 - [Public adoption loop](product/public-adoption-loop.md): docs-first issue
   and discussion template copy, triage labels, and lightweight external-attempt
   metrics before any `.github` template write.
@@ -61,6 +64,7 @@ incident report, or launch draft.
 ### Concepts
 
 - [Architecture](architecture.md)
+- [Core control-plane graphs](product/core-control-plane/README.md)
 - [State interaction model](state-interaction-model.md)
 - [Interaction pattern catalog](interaction-pattern-catalog.md)
 - [Field-derived patterns](field-derived-patterns.md)

--- a/docs/interaction-pattern-catalog.md
+++ b/docs/interaction-pattern-catalog.md
@@ -10,6 +10,12 @@ reveals a reusable interaction shape. Each pattern should be specific enough to
 drive implementation, tests, and dashboard copy without requiring future agents
 to mine chat history.
 
+For the short product map that keeps the catalog, state definitions, and state
+machine aligned, see
+[`docs/product/core-control-plane/`](product/core-control-plane/). The catalog
+below remains the detailed IP registry; the core map is the graph lens that
+connects those IPs to runtime states and legal transitions.
+
 ## Pattern Template
 
 Each pattern should answer:

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -8,6 +8,9 @@ runtime contract, benchmark route, or launch draft.
   long-running agent work, centered on Loop Agents, maintainer-first management,
   Agent Work Feed review, performance review, high-value open-source anchors,
   and office-operations connector showcases.
+- [Core control-plane graphs](core-control-plane/README.md): the paired
+  interaction catalog lens, state definitions, and state machine that keep
+  product explanation, runtime projection, and validation aligned.
 - [Server-client product shape](server-client-product-shape.md): the medium-term
   product model where the server owns durable state, signal inbox, selected
   anchors, delivery/planning queue boundaries, performance-review summaries,

--- a/docs/product/core-control-plane/README.md
+++ b/docs/product/core-control-plane/README.md
@@ -1,0 +1,64 @@
+# Core Control-Plane Graphs
+
+This folder keeps the three product diagrams that should move together when
+LoopX learns a new long-running agent behavior:
+
+- [Interaction catalog lens](interaction-catalog.md): what reusable
+  human/agent pattern is happening?
+- [State definitions](state-definitions.md): which durable state body or
+  derived runtime state names the situation?
+- [State machine](state-machine.md): which transition is legal next, and who
+  owns it?
+
+The older detailed documents remain the canonical reference for full protocol
+detail:
+
+- [`docs/interaction-pattern-catalog.md`](../../interaction-pattern-catalog.md)
+  is the complete interaction-pattern registry.
+- [`docs/state-interaction-model.md`](../../state-interaction-model.md) is the
+  architecture-level state model.
+
+This folder is the shorter control-plane map. It exists so product surfaces,
+runtime code, smokes, and agent instructions share one picture instead of
+rediscovering state from chat history or private planning notes.
+
+## Three-Lens Contract
+
+```mermaid
+flowchart LR
+  C["Interaction catalog lens<br/>pattern, user value, channels"] --> D["State definitions<br/>stores, runtime states, invariants"]
+  D --> M["State machine<br/>allowed transitions and owners"]
+  M --> C
+  C --> P["Product surfaces<br/>README, frontstage, review packets"]
+  D --> R["Runtime projections<br/>status, quota, todo, event ledger"]
+  M --> V["Validation<br/>smokes, fixtures, boundary checks"]
+```
+
+Each lens answers a different question:
+
+| Lens | Primary Question | Failure If Missing |
+| --- | --- | --- |
+| Catalog | What repeatable human-agent situation are we handling? | Every incident becomes a one-off prompt branch. |
+| State definitions | What is the compact state name and source of truth? | Agents argue from prose instead of durable fields. |
+| State machine | What transition is allowed and who owns it? | Automation either spins, stalls, or bypasses a real gate. |
+
+## Refinement Rule
+
+When a new good case, bad case, or product insight appears:
+
+1. Add or refine the catalog pattern first. Name the user value, trigger,
+   user channel, agent channel, state anchors, and validation.
+2. Add a state definition only if the concept is reusable and observable from
+   LoopX state or projection. Do not add a state just to label one incident.
+3. Add a state-machine transition only when a runtime or operator surface can
+   make the transition deterministically from public-safe state.
+4. Add a focused smoke or fixture when the behavior protects a hot path,
+   public/private boundary, scheduler decision, or projection invariant.
+
+## Boundary
+
+These files must remain public-safe. Do not copy private document links,
+internal planning context, raw transcripts, raw benchmark logs, credentials,
+local absolute paths, or one-off status narratives into this folder. Convert
+private learning into general product language and compact state names before
+committing it.

--- a/docs/product/core-control-plane/interaction-catalog.md
+++ b/docs/product/core-control-plane/interaction-catalog.md
@@ -1,0 +1,91 @@
+# Interaction Catalog Lens
+
+The full interaction registry lives in
+[`docs/interaction-pattern-catalog.md`](../../interaction-pattern-catalog.md).
+This file is the core graph lens over that registry: it maps the hot-path
+patterns to state definitions and state-machine transitions so a product
+surface can explain the behavior without duplicating the entire catalog.
+
+## Pattern Lens Schema
+
+Every durable pattern should be expressible as:
+
+```text
+interaction_pattern_lens_v0 = {
+  pattern_id,
+  family,
+  user_value,
+  trigger,
+  state_anchors[],
+  transition_anchors[],
+  user_channel,
+  agent_channel,
+  evidence_shape,
+  bad_case,
+  validation
+}
+```
+
+The schema deliberately joins product and runtime language:
+
+- `user_value` explains why a user, maintainer, or leader should care.
+- `state_anchors` name the state definitions that make the pattern observable.
+- `transition_anchors` name the state-machine edge that keeps the behavior
+  deterministic.
+- `user_channel` and `agent_channel` keep human interruption separate from
+  agent execution.
+- `evidence_shape` says what proof is enough without copying private raw data.
+
+## Core Pattern Map
+
+| ID | Pattern | User Value | State Anchors | Transition Anchors | Validation |
+| --- | --- | --- | --- | --- | --- |
+| IP-001 | Bounded Delivery | One agent turn creates a validated artifact, blocker, or state update instead of just narrating progress. | `Todo`, `Run Snapshot`, `Evidence Bundle`, `WritebackSpend` | `Eligible -> BoundedDelivery -> WritebackSpend -> Ready` | `examples/heartbeat-quota-flow-smoke.py` |
+| IP-002 | Blocked Priority With Safe Fallback | A blocked P0 stays visible while safe P1/P2 value continues. | `Gate`, `Todo`, `ScopedUserGateFallback`, `Evidence Bundle` | `QuotaCheck -> ScopedUserGateFallback -> WritebackSpend` | `examples/showcase-0617-blocked-p0-safe-rotation-smoke.py` |
+| IP-003 | Scoped Gate With Safe Fallback | A user decision blocks only the lane or action it actually governs. | `Gate`, `Decision Scope`, `Todo`, `ScopedUserGateFallback` | `GateOpen -> ScopeCheck -> RunIndependentFallback` | `examples/quota-agent-scoped-user-gate-smoke.py` |
+| IP-004 | Concrete User Todo Projection | The user sees the exact question or action instead of a vague owner wait. | `Gate`, `Todo`, `Projection` | `QuotaCheck -> UserGate -> Ready` | `examples/user-todo-review-material-smoke.py` |
+| IP-005 | State Projection Gap | The system repairs stale or missing machine state before ordinary delivery. | `Projection`, `ProjectionGap`, `Event Ledger` | `QuotaCheck -> Repair -> Ready` | `examples/state-projection-gap-smoke.py` |
+| IP-007 | Outcome Floor Recovery | Repeated surface work is forced back to outcome-scale proof or a blocker. | `Run Snapshot`, `FocusWait`, `Evidence Bundle` | `QuotaCheck -> FocusWait -> BoundedRecovery` | `examples/blocker-push-runtime-smoke.py` |
+| IP-008 | Monitor Quiet Skip | Watch-only work stays alive without spending quota on unchanged polls. | `Todo`, `MonitorQuietSkip`, `Run Snapshot` | `QuotaCheck -> MonitorQuiet -> Ready` | `examples/monitor-scheduler-contract-smoke.py` |
+| IP-021 | Per-Todo Capability Gate | Missing runtime capability blocks only the affected candidate, not the entire goal. | `Todo`, `CapabilityGate`, `Projection` | `QuotaCheck -> CapabilityGate -> Repair/AskOwner/RunCandidate` | `examples/capability-gate-smoke.py` |
+| IP-026 | Agent-Scoped No-Candidate Gap | A side agent with no in-scope work waits quietly instead of inventing delivery. | `Claim`, `AgentScopeWait`, `Projection` | `QuotaCheck -> AgentScopeWait -> Ready` | `examples/refresh-state-agent-lane-scope-smoke.py` |
+| IP-029 | Handoff Todo Gate State | Cross-agent review and handoff become todo lifecycle, not hidden chat memory. | `Claim`, `Dependency / Resume`, `Handoff`, `Gate` | `OwnerRouteWait -> OwnerDecisionRecorded -> HandoffGateCleared` | `examples/status-markdown-smoke.py` |
+
+## Pattern Families As A Graph
+
+```mermaid
+flowchart TB
+  Work["Work Routing<br/>deliver, recover, fallback, stay quiet"]
+  Human["Human Decision<br/>gate, reward, approval, deferral"]
+  Boundary["State And Boundary<br/>projection, scope, lease, capability"]
+  Evidence["Evidence Lifecycle<br/>external handles and validated proof"]
+  Planning["Planning Governance<br/>replan, cadence, future work"]
+
+  Work -->|uses| D["State definitions"]
+  Human -->|opens/resolves| D
+  Boundary -->|repairs| D
+  Evidence -->|validates| D
+  Planning -->|creates successor todos| D
+  D --> M["State machine"]
+  M --> Work
+  M --> Human
+  M --> Boundary
+  M --> Evidence
+  M --> Planning
+```
+
+## Refinement Guidance
+
+Refine the catalog when a new case changes one of these things:
+
+- A different user-visible value appears, such as saving review time,
+  protecting a write boundary, or preserving long-running evidence.
+- A pattern needs a new state anchor, such as `AgentScopeWait` or
+  `ProjectionGap`, to be machine-visible.
+- A state-machine edge changes, such as allowing a scoped fallback while a
+  user gate remains open.
+- Validation becomes possible with a public-safe smoke or fixture.
+
+Do not create a new pattern only because a new UI card, PR packet, dashboard
+row, or automation prompt needs different wording. First ask whether the row is
+just a new projection of an existing pattern.

--- a/docs/product/core-control-plane/state-definitions.md
+++ b/docs/product/core-control-plane/state-definitions.md
@@ -1,0 +1,74 @@
+# State Definitions
+
+LoopX state should be small, observable, and reusable. A state definition is
+valid only when a future agent or product surface can answer: where does this
+state come from, who can change it, and what transition does it allow?
+
+This file keeps public-safe definitions for the core state bodies and runtime
+states used by the interaction catalog and state machine.
+
+## Canonical State Bodies
+
+| State Body | Source Of Truth | Primary Writer | Meaning | Must Not Mean |
+| --- | --- | --- | --- | --- |
+| Registry | Project/global registry | `connect`, project setup, registry sync | Goal identity, active-state path, runtime root, registered agents, primary owner, and runtime routing. | A promise that automation has already run. |
+| Active State Workbench | Active goal state projection or Markdown workbench | LoopX lifecycle commands and controlled agent writeback | Human-readable current goal, progress, todos, gates, validation notes, and next action. | Canonical truth when an event/todo projection says otherwise. |
+| Todo | Todo projection or event stream | `loopx todo` and compatible lifecycle writers | Smallest executable or waiting unit, with role, priority, status, task class, action kind, capability hints, and evidence refs. | A full project plan or a hidden chat reminder. |
+| Claim | Todo metadata, lease projection, or event stream | `loopx todo claim`, owner reassignment, lease refresh | Soft ownership and routing signal for one agent or lane. | A lock that permits ignoring better evidence or current gates. |
+| Gate / Decision Scope | User todo, operator gate, or quota interaction contract | User/controller decision writers | Concrete authority still needed, including the scope it blocks and how it can be resolved. | A global stop sign unless explicitly scoped as global. |
+| Dependency / Resume | Todo metadata and event refs | Todo lifecycle writers | Wait condition, unblock relation, successor relation, or supersession chain. | A reason to lose the original task after waiting. |
+| Evidence Bundle | Todo/run/event refs | Agent writeback, reducers, validation tools | Compact proof, artifact refs, source refs, validation result, blocker, or rollback anchor. | Raw private logs, transcripts, credentials, or unsupported claims. |
+| Run Snapshot | Run history | Adapter, refresh-state, execution wrappers | What one bounded turn saw, attempted, recommended, and delivered. | The whole project memory. |
+| Event Ledger | Append-only events | LoopX lifecycle commands | Ordered lifecycle facts for todos, gates, runs, evidence, quota, projections, and rollbacks. | A mutable note file. |
+| Projection | Status, quota, frontstage, review packet, dashboard | Projection builders | Read-only rendering of source facts for one consumer. | A write API or source of truth. |
+
+## Derived Runtime States
+
+These states are derived from the state bodies above. They are useful for
+status, quota, scheduler, frontstage, review packets, and agent prompts.
+
+| Runtime State | Derived From | Meaning | Agent Behavior | User Behavior |
+| --- | --- | --- | --- | --- |
+| `eligible` | Registry + active state + todo + quota | There is runnable or repairable work and no active gate covers the selected action. | Deliver one bounded segment, validate, write back. | Usually no interruption. |
+| `bounded_delivery` | `eligible` plus selected todo | The current turn should create an artifact, blocker, evidence observation, or state update. | Must attempt; spend only after validated writeback. | Review only if result needs approval. |
+| `user_gate` / `operator_gate` | Gate + decision scope + interaction contract | A human/controller decision blocks the selected action. | Ask or notify the concrete gate; do not run the gated path. | Answer, defer, reject, or redirect the decision. |
+| `scoped_user_gate_fallback` | Gate + independent todo + decision scope | A gate remains open, but another action is independent and safe. | Surface the gate, run only the independent fallback, validate. | See the gate without being forced to answer before fallback work. |
+| `agent_scope_wait` | Todo claims, blocks_agent, handoff gate, agent id | The current agent has no in-scope runnable candidate, or another owner holds the blocker. | Stay active and quiet; wait for reassignment, unblock, or new scoped work. | Usually no interruption. |
+| `waiting` / `external_evidence_observation` | Waiting metadata, monitor todo, external handle | Work depends on terminal external evidence or compact observation. | Observe only bounded public-safe handles; write blocker if no handle exists. | Supply missing handle only when asked concretely. |
+| `monitor_quiet_skip` | Continuous monitor todo + cadence metadata | The monitor is not due or has no material transition. | Append at most one no-spend poll when contracted, then stay quiet. | No interruption. |
+| `focus_wait` | Outcome floor, handoff readiness, delivery outcome | The lane needs outcome-scale evidence, clean baseline, or fresh owner evidence before ordinary delivery. | Recover the named evidence or report a blocker. | Decide only if the blocker is owner-held. |
+| `blocked_health` | Registry/projection/boundary checks | Control-plane health is broken enough that delivery would be unsafe. | Repair if allowed; otherwise stop with a concrete blocker. | Review only concrete repair gates. |
+| `workspace_guard` | Agent profile + current worktree + requested goal | The agent is in the wrong checkout or missing the required isolated lane. | Relocate or write a concrete workspace blocker before quota work. | No interruption unless relocation needs owner action. |
+| `capability_gate` | Todo required capabilities + host/runtime capabilities | Some candidates need capabilities the current host lacks. | Run a runnable candidate, repair a bridge, or ask for owner-held capability. | Provide credentials or protected access only through a concrete gate. |
+| `throttled` / `paused` | Quota ledger or explicit pause | The goal should not spend automatic compute now. | Stay quiet. | Resume or add quota if desired. |
+| `writeback_spend` | Validated artifact/blocker/evidence + quota contract | The turn produced durable value and may account for one spend. | Write state/history, then spend exactly once. | No interruption. |
+| `done` / `archived` | Todo/goal terminal state | No required work remains for that unit. | Stop or create successor only when needed. | Review final summary if surfaced. |
+| `projection_gap` | Projection mismatch, stale sink, missing concrete todo | A display or prompt projection is incomplete or conflicts with source state. | Repair source/projection before using the stale view. | No vague gate; ask only for missing concrete user input. |
+
+## Channel Invariant
+
+User and agent channels can disagree without contradiction. For example,
+`scoped_user_gate_fallback` intentionally means:
+
+```text
+user_channel.action_required = true
+agent_channel.must_attempt = true
+agent_channel.selected_action = independent_fallback
+```
+
+The user channel names the open decision. The agent channel names the safe work
+that does not depend on that decision. A projection is wrong when it collapses
+these into one boolean and either blocks all work or hides the gate.
+
+## Definition Checklist
+
+Before adding a new state name:
+
+1. Identify the source state body or projection field.
+2. Identify who can write the source.
+3. Identify the legal next transition.
+4. Identify whether the user must be interrupted, notified, or left alone.
+5. Identify a public-safe evidence shape and validation path.
+
+If any item is missing, prefer refining a catalog pattern or projection field
+over adding a new state.

--- a/docs/product/core-control-plane/state-machine.md
+++ b/docs/product/core-control-plane/state-machine.md
@@ -1,0 +1,131 @@
+# State Machine
+
+This is the product-level state machine for one LoopX heartbeat or manual tick.
+It is not a new store. It is a deterministic view over registry, active state,
+todos, gates, run history, quota, event ledger, and projections.
+
+## Top-Level Machine
+
+```mermaid
+stateDiagram-v2
+  [*] --> Registered
+  Registered --> Ready: registry + active state resolved
+  Ready --> QuotaCheck: heartbeat / manual tick / slash command
+
+  QuotaCheck --> BoundedDelivery: eligible + runnable candidate
+  QuotaCheck --> ScopedGateFallback: scoped gate + independent fallback
+  QuotaCheck --> UserGate: gate covers selected action
+  QuotaCheck --> ExternalEvidenceWait: external handle pending
+  QuotaCheck --> MonitorQuiet: monitor not due or unchanged
+  QuotaCheck --> AgentScopeWait: current agent has no scoped candidate
+  QuotaCheck --> FocusWait: outcome floor or fresh-evidence floor
+  QuotaCheck --> Repair: projection, boundary, workspace, or capability drift
+  QuotaCheck --> ThrottledPaused: quota exhausted or paused
+
+  BoundedDelivery --> WritebackSpend: artifact / blocker / evidence validated
+  ScopedGateFallback --> WritebackSpend: fallback validated
+  FocusWait --> WritebackSpend: recovery evidence validated
+  Repair --> WritebackSpend: repair delta validated
+
+  UserGate --> Ready: decision recorded
+  ExternalEvidenceWait --> Ready: terminal evidence or blocker written
+  MonitorQuiet --> Ready: no-spend liveness preserved
+  AgentScopeWait --> Ready: reassigned / unblocked / new todo projected
+  ThrottledPaused --> Ready: quota restored or pause lifted
+
+  WritebackSpend --> Ready: refresh-state + spend when allowed
+  WritebackSpend --> Done: terminal goal/todo outcome
+  Done --> [*]
+```
+
+## Transition Table
+
+| From | Guard | To | Required Writeback |
+| --- | --- | --- | --- |
+| `Registered` | Registry entry and active-state route resolve. | `Ready` | None, or registry repair event if resolution changed. |
+| `Ready` | A host tick or user command asks whether work should run. | `QuotaCheck` | None before the guard. |
+| `QuotaCheck` | Runnable candidate and no covering gate. | `BoundedDelivery` | Selected todo/run evidence after validation. |
+| `QuotaCheck` | A gate is open but does not cover the selected fallback. | `ScopedGateFallback` | Gate remains visible; fallback evidence after validation. |
+| `QuotaCheck` | Gate covers the selected action. | `UserGate` | Concrete user/controller decision, defer, rejection, or successor todo. |
+| `QuotaCheck` | External evidence is pending or a launched handle must be observed. | `ExternalEvidenceWait` | Terminal evidence, compact observation, or blocker. |
+| `QuotaCheck` | Monitor-only work is not due or unchanged. | `MonitorQuiet` | At most one no-spend monitor-poll event when contracted. |
+| `QuotaCheck` | Current agent has no scoped candidate or waits on another owner. | `AgentScopeWait` | No spend; wait for todo lifecycle, reassignment, or unblock event. |
+| `QuotaCheck` | Outcome floor or fresh-evidence floor blocks ordinary delivery. | `FocusWait` | Recovery evidence or blocker. |
+| `QuotaCheck` | Source/projection/boundary/workspace/capability is inconsistent. | `Repair` | Repair delta, blocker, or concrete gate. |
+| `QuotaCheck` | Quota exhausted or explicitly paused. | `ThrottledPaused` | None until quota/pause changes. |
+| `BoundedDelivery` | Work validated. | `WritebackSpend` | Artifact, code/doc ref, test result, blocker, or evidence ref. |
+| `WritebackSpend` | Todo/goal terminal. | `Done` | Completion rationale and archive/successor state. |
+| `WritebackSpend` | More work remains. | `Ready` | Refreshed projection and one spend when the contract allows it. |
+
+## Gate Scope Submachine
+
+```mermaid
+flowchart TD
+  G["Gate open"] --> S{"does scope cover selected action?"}
+  S -->|"yes"| A["ask concrete decision"]
+  S -->|"no"| F["keep gate visible; run independent fallback"]
+  S -->|"ambiguous"| R["repair projection or ask controller"]
+  A -->|"approve"| U["unblock gated todo"]
+  A -->|"reject"| X["supersede or create compensation todo"]
+  A -->|"defer"| D["deferred resume_when"]
+  F --> V["validate fallback"]
+  V --> W["write fallback evidence and spend once"]
+```
+
+The key rule: a gate is scoped authority, not a global boolean. If the scope is
+ambiguous, the machine goes to repair; it does not guess from prose.
+
+## Todo Lifecycle Submachine
+
+```mermaid
+stateDiagram-v2
+  [*] --> Suggested
+  Suggested --> Open: promoted
+  Open --> Claimed: claimed_by set
+  Claimed --> Running: quota allows bounded delivery
+  Running --> Done: validation/evidence accepted
+  Done --> SuccessorOpen: follow-up required
+  Done --> Archived: no follow-up required
+  Open --> Blocked: concrete blocker
+  Open --> Deferred: resume_when
+  Deferred --> ResumeReady: condition satisfied
+  ResumeReady --> SuccessorReplan: reopen, supersede, or no-follow-up rationale
+  Open --> Superseded: replacement todo
+  Superseded --> ReplacementOpen
+```
+
+`Running` is derived from quota and run history. It should not become a new
+mandatory persistent todo status unless the event stream explicitly models it.
+
+## Projection Sink Submachine
+
+```mermaid
+flowchart LR
+  S["Canonical state bodies"] --> B["Projection builder"]
+  B -->|"fresh and complete"| V["Read-only view"]
+  B -->|"missing, stale, conflicting"| G["Projection gap"]
+  G --> R["repair source or builder"]
+  R --> B
+  V -->|"user action"| W["LoopX write API"]
+  W --> S
+```
+
+Frontstage, review packets, status cards, manager summaries, and external
+kanban rows are projection sinks. They can make state understandable, but all
+state-changing actions return through LoopX write APIs.
+
+## Catalog Linkage
+
+| Machine Edge | Catalog Patterns |
+| --- | --- |
+| `QuotaCheck -> BoundedDelivery` | IP-001 Bounded Delivery |
+| `QuotaCheck -> ScopedGateFallback` | IP-002 Blocked Priority With Safe Fallback; IP-003 Scoped Gate With Safe Fallback |
+| `QuotaCheck -> UserGate` | IP-004 Concrete User Todo Projection |
+| `QuotaCheck -> Repair` | IP-005 State Projection Gap; IP-021 Per-Todo Capability Gate |
+| `QuotaCheck -> FocusWait` | IP-007 Outcome Floor Recovery |
+| `QuotaCheck -> MonitorQuiet` | IP-008 Monitor Quiet Skip |
+| `QuotaCheck -> AgentScopeWait` | IP-026 Agent-Scoped No-Candidate Gap; IP-029 Handoff Todo Gate State |
+
+If a new interaction pattern cannot point to a state-machine edge, it is
+probably a product note, a UI variant, or a private incident label rather than
+a core control-plane pattern.

--- a/docs/state-interaction-model.md
+++ b/docs/state-interaction-model.md
@@ -14,6 +14,11 @@ For concrete recurring situations, maintain
 defines actor boundaries and stores; the pattern catalog records good cases,
 bad cases, expected user/agent channels, and validation references.
 
+The compact product graph for this relationship lives in
+[`docs/product/core-control-plane/`](product/core-control-plane/). It keeps the
+interaction catalog lens, state definitions, and state machine together so new
+patterns can be refined without creating a second control-plane vocabulary.
+
 ## Actors
 
 ### Goal

--- a/examples/core-control-plane-diagrams-smoke.py
+++ b/examples/core-control-plane-diagrams-smoke.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Validate the public core-control-plane diagram docs stay linked and safe."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC_DIR = ROOT / "docs" / "product" / "core-control-plane"
+
+FILES = [
+    DOC_DIR / "README.md",
+    DOC_DIR / "interaction-catalog.md",
+    DOC_DIR / "state-definitions.md",
+    DOC_DIR / "state-machine.md",
+]
+
+FORBIDDEN_PUBLIC_STRINGS = [
+    "bytedance",
+    "larkoffice",
+    "EAAtdvU1bokXbyxXdv7cDAAbnSb",
+    "/Users/",
+    "/private/tmp",
+    "127.0.0.1",
+    "localhost",
+    "appSecret",
+    "accessToken",
+]
+
+
+def read(path: Path) -> str:
+    assert path.exists(), f"missing doc: {path}"
+    return path.read_text(encoding="utf-8")
+
+
+def main() -> None:
+    docs = {path.name: read(path) for path in FILES}
+    combined = "\n".join(docs.values())
+
+    for text in FORBIDDEN_PUBLIC_STRINGS:
+        assert text.lower() not in combined.lower(), f"private marker leaked: {text}"
+
+    readme = docs["README.md"]
+    for filename in ("interaction-catalog.md", "state-definitions.md", "state-machine.md"):
+        assert f"]({filename})" in readme, f"README does not link {filename}"
+
+    assert "interaction_pattern_lens_v0" in docs["interaction-catalog.md"]
+    assert "Core Pattern Map" in docs["interaction-catalog.md"]
+    assert "State Definitions" in docs["state-definitions.md"]
+    assert "Canonical State Bodies" in docs["state-definitions.md"]
+    assert "Derived Runtime States" in docs["state-definitions.md"]
+    assert "Top-Level Machine" in docs["state-machine.md"]
+    assert "Gate Scope Submachine" in docs["state-machine.md"]
+    assert "Projection Sink Submachine" in docs["state-machine.md"]
+    assert "```mermaid" in combined
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add docs/product/core-control-plane as the shared home for the interaction catalog lens, state definitions, and state machine
- link the new core graph folder from the docs and product indexes plus the existing catalog/state-model docs
- add a focused smoke that checks the core graph docs remain linked and public-safe

## Validation
- python3 examples/core-control-plane-diagrams-smoke.py
- git diff --check
- loopx check --scan-path docs/product/core-control-plane
- public/private marker scan over changed docs

## Boundary
- public docs and one focused validation smoke only
- no runtime/API behavior, benchmark adapter, Lark Kanban, permission, destructive git, or production-action changes
- no private document links, local paths, raw logs, credentials, or internal context committed