### PR TITLE
Guard SkillsBench stdin writes with timeout watchdogs

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -162,6 +162,25 @@ def test_reverse_channel_first_action_timeout_stops_codex_process() -> None:
     assert response["credential_values_recorded"] is False
 
 
+def test_reverse_channel_timeout_survives_blocked_stdin_write() -> None:
+    start = time.monotonic()
+    response = _run_codex_payload(
+        {
+            "args": ["-c", "import time; time.sleep(30)"],
+            "stdin": "x" * 2_000_000,
+            "timeout_sec": 1,
+        },
+        codex_bin=sys.executable,
+        default_timeout_sec=1,
+        prompt_bridge_command=None,
+    )
+    assert time.monotonic() - start < 8
+    assert response["exit_code"] == 124
+    assert response["stderr"] == "codex_exec_timeout\n"
+    assert response["raw_task_text_recorded"] is False
+    assert response["credential_values_recorded"] is False
+
+
 def test_reverse_channel_raw_prompt_does_not_require_bridge_first_action() -> None:
     start = time.monotonic()
     response = _run_codex_payload(
@@ -10012,6 +10031,7 @@ if __name__ == "__main__":
     test_skillsbench_default_blind_loop_budget_is_sixteen()
     test_skillsbench_product_mode_soft_verify_default_is_every_round()
     test_reverse_channel_first_action_timeout_stops_codex_process()
+    test_reverse_channel_timeout_survives_blocked_stdin_write()
     test_reverse_channel_raw_prompt_does_not_require_bridge_first_action()
     test_reverse_channel_bridge_idle_timeout_stops_codex_process()
     test_product_mode_initial_prompt_keeps_task_visible_after_lifecycle_gate()

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -10,6 +10,7 @@ import signal
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 import uuid
 from dataclasses import dataclass
@@ -242,6 +243,31 @@ def _codex_exec_failure_category(
     if returncode is not None:
         return "codex_exec_exit_nonzero"
     return "codex_exec_failed"
+
+
+def _write_process_stdin_async(
+    proc: subprocess.Popen[str],
+    stdin_text: str | None,
+) -> None:
+    """Feed stdin without letting a full pipe bypass timeout watchdogs."""
+
+    if stdin_text is None or proc.stdin is None:
+        return
+    stdin_pipe = proc.stdin
+    proc.stdin = None
+
+    def _writer() -> None:
+        try:
+            stdin_pipe.write(stdin_text)
+            stdin_pipe.close()
+        except (BrokenPipeError, ValueError, OSError):
+            pass
+
+    threading.Thread(
+        target=_writer,
+        name="loopx-skillsbench-acp-stdin-writer",
+        daemon=True,
+    ).start()
 
 
 @dataclass(frozen=True)
@@ -501,12 +527,7 @@ class SkillsBenchLocalAcpRelay:
                         env=codex_env,
                         start_new_session=True,
                     )
-                    if proc.stdin is not None:
-                        try:
-                            proc.stdin.write(codex_stdin_prompt)
-                            proc.stdin.close()
-                        except BrokenPipeError:
-                            pass
+                    _write_process_stdin_async(proc, codex_stdin_prompt)
                     deadline = time.monotonic() + self._config.timeout_sec
                     first_action_deadline = 0.0
                     if (

--- a/scripts/skillsbench_reverse_channel_bridge.py
+++ b/scripts/skillsbench_reverse_channel_bridge.py
@@ -19,6 +19,7 @@ import socket
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 from pathlib import Path
 from typing import Any
@@ -124,6 +125,31 @@ def _communicate_after_stop(proc: subprocess.Popen[str]) -> tuple[str, str]:
         _stop_process_group(proc, sig=signal.SIGKILL)
         stdout_text, stderr_text = proc.communicate(timeout=5)
     return stdout_text or "", stderr_text or ""
+
+
+def _write_process_stdin_async(
+    proc: subprocess.Popen[str],
+    stdin_text: str | None,
+) -> None:
+    """Feed stdin without blocking the watchdog loop on a full pipe."""
+
+    if stdin_text is None or proc.stdin is None:
+        return
+    stdin_pipe = proc.stdin
+    proc.stdin = None
+
+    def _writer() -> None:
+        try:
+            stdin_pipe.write(stdin_text)
+            stdin_pipe.close()
+        except (BrokenPipeError, ValueError, OSError):
+            pass
+
+    threading.Thread(
+        target=_writer,
+        name="loopx-reverse-channel-stdin-writer",
+        daemon=True,
+    ).start()
 
 
 def _read_agent_operations_jsonl(path: Path | None) -> str:
@@ -412,13 +438,7 @@ def _run_codex_payload(
                 env=env,
                 start_new_session=True,
             )
-            if stdin_prompt is not None and proc.stdin is not None:
-                try:
-                    proc.stdin.write(stdin_prompt)
-                    proc.stdin.close()
-                    proc.stdin = None
-                except BrokenPipeError:
-                    proc.stdin = None
+            _write_process_stdin_async(proc, stdin_prompt)
             deadline = time.monotonic() + timeout
             first_action_deadline = 0.0
             if (


### PR DESCRIPTION
## Summary
- feed reverse-channel Codex stdin on a daemon writer thread so watchdog deadlines start even if the child does not drain stdin
- apply the same guard to the SkillsBench local ACP relay
- add a focused smoke for a child process that never reads a large stdin prompt

## Validation
- python3 -m py_compile scripts/skillsbench_reverse_channel_bridge.py loopx/benchmark_adapters/skillsbench_acp_relay.py examples/skillsbench-benchmark-run-smoke.py
- targeted reverse-channel timeout smokes passed

## Scope
Benchmark helper/runtime only. Does not change scoring, task semantics, leaderboard/submission behavior, or launch benchmark jobs.