### PR TITLE
docs: map Arbor into decentralized auto research

### DIFF
--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -11,6 +11,10 @@ runtime contract, benchmark route, or launch draft.
 - [Core control-plane graphs](core-control-plane/README.md): the paired
   interaction catalog lens, state definitions, and state machine that keep
   product explanation, runtime projection, and validation aligned.
+- [Decentralized auto-research showcase blueprint](decentralized-auto-research-showcase.md):
+  Arbor-inspired but LoopX-native design for turning research hypotheses into
+  todo-linked, agent-scoped, evidence-backed work without adding a single
+  leader agent.
 - [Server-client product shape](server-client-product-shape.md): the medium-term
   product model where the server owns durable state, signal inbox, selected
   anchors, delivery/planning queue boundaries, performance-review summaries,

--- a/docs/product/decentralized-auto-research-showcase.md
+++ b/docs/product/decentralized-auto-research-showcase.md
@@ -103,13 +103,28 @@ next agent does not rediscover them from scratch.
 
 ## Minimal Reproduction Plan
 
-1. Package a public-safe mini benchmark fixture under docs or examples, modeled
-   on Arbor's k-NN task but owned by LoopX.
-2. Add `research_contract_v0`, `research_hypothesis_v0`, and
-   `research_evidence_event_v0` fixture records.
-3. Add a CLI preview that reads the fixture and emits
-   `decentralized_research_frontier_v0` for two agents.
-4. Run one local smoke that proves:
+First fixture-backed slice:
+
+```bash
+loopx --format json auto-research frontier \
+  --fixture examples/fixtures/decentralized-auto-research-knn.public.json \
+  --agent-id codex-side-bypass
+```
+
+This renders `decentralized_research_frontier_v0`,
+`research_evidence_graph_v0`, and `research_showcase_projection_v0` from a
+public fixture. It does not launch experiments; it proves that the state shape
+can present a per-agent frontier without one leader agent.
+
+Next reproduction steps:
+
+1. Replace the fixture-only k-NN records with a small runnable benchmark pack
+   owned by LoopX.
+2. Keep `research_contract_v0`, `research_hypothesis_v0`, and
+   `research_evidence_event_v0` as the public-safe record boundary.
+3. Connect projection input to live todo/quota state after the fixture contract
+   is stable.
+4. Keep one local smoke that proves:
    - protected files are not editable;
    - each hypothesis is todo-linked;
    - each evidence event names split and metric;

--- a/docs/product/decentralized-auto-research-showcase.md
+++ b/docs/product/decentralized-auto-research-showcase.md
@@ -1,0 +1,162 @@
+# Decentralized Auto-Research Showcase Blueprint
+
+This note turns the Arbor review into a LoopX product path. Arbor's public
+showcase is strong because it is concrete: a benchmark, a hypothesis tree,
+dev/held-out scores, replayable events, and a final report. LoopX should aim
+for the same clarity while keeping its own architecture: decentralized agents
+over one shared control plane, not one leader Coordinator.
+
+## What Arbor Demonstrates
+
+Arbor's public materials show a repeatable autonomous research loop:
+
+- a Research Contract that names objective, editable files, protected harness,
+  metric, budget, and review mode;
+- an Idea Tree where hypotheses record status, evidence, score, branch, retry
+  status, grounding, and related-work audit;
+- isolated executor worktrees for each experiment;
+- a dev metric for iteration and a held-out metric for promotion;
+- replay/report/export surfaces that make the run inspectable;
+- a benchmark zoo, including `algotune_knn`, that is small enough for a user to
+  watch end to end.
+
+The Arbor `algotune_knn` demo is especially useful for LoopX because it is
+public-safe, deterministic, CPU-only, and easy to explain: optimize a k-nearest
+neighbors solver without editing the protected evaluator. Arbor reports an
+example six-cycle improvement from roughly baseline speed to multi-x speedup,
+with held-out validation.
+
+## LoopX Adaptation
+
+LoopX should reproduce the product value, not the topology.
+
+| Arbor shape | LoopX version |
+| --- | --- |
+| Coordinator-mediated tree management. | Kernel-owned evidence graph plus per-agent frontier projections. |
+| Executors receive ideas from Coordinator. | Agents claim todo-backed hypotheses through `quota should-run --agent-id`. |
+| Idea Tree is the durable memory. | `research_hypothesis_v0` plus `research_evidence_event_v0` in the shared state graph. |
+| Merge/prune decided by Coordinator. | Promotion policy, held-out evidence, operator gates, and todo lifecycle decide. |
+| Dashboard shows one run. | Frontstage shows lanes, claims, evidence, promotion candidates, and blockers. |
+
+The important product phrase is:
+
+> LoopX lets multiple agents run an autonomous research search without a
+> leader agent: hypotheses, evidence, retries, and promotion decisions live in
+> the control plane, and each agent receives only the frontier it is allowed to
+> attempt.
+
+## Showcase Candidate
+
+**Title:** Decentralized Auto Research: k-NN Speedup
+
+**Public task:** make a brute-force k-nearest-neighbors solver faster while
+preserving exact output.
+
+**Inputs:**
+
+- editable: `solution.py`;
+- protected: `eval.py`, `task.py`, generated dev/test data;
+- metric: `speedup`, higher is better;
+- dev command: `bash eval.sh dev`;
+- held-out command: `bash eval.sh test`;
+- starting result: baseline around `1.0x`;
+- expected value metric: best held-out speedup, plus number of useful negative
+  directions retained as future priors.
+
+**LoopX surfaces to show:**
+
+1. Research Contract card: objective, editable/protected scopes, metric, budget.
+2. Decentralized frontier: which agent claimed which hypothesis, which ones are
+   blocked or retired, and why.
+3. Evidence timeline: attempts, dev score, held-out score, branch/ref, retry
+   status.
+4. Promotion decision: what got promoted, which alternatives were retired, and
+   which evidence proves the boundary.
+5. Report: concise public-safe final summary with commands and artifacts.
+
+## Candidate Hypothesis Graph
+
+This graph is a fixture target, not a claim that LoopX has already achieved the
+numbers. It gives the showcase a concrete shape to reproduce.
+
+```mermaid
+graph TD
+  ROOT["Research contract: exact k-NN speedup"]
+  H1["hyp_001: vectorize pairwise distances"]
+  H2["hyp_002: partial selection with argpartition"]
+  H3["hyp_003: GEMM distance expansion"]
+  H4["hyp_004: batch query path"]
+  H5["hyp_005: dtype / contiguous array tuning"]
+  H6["hyp_006: approximate search (retire if correctness fails)"]
+
+  ROOT --> H1
+  H1 --> H2
+  H2 --> H3
+  H3 --> H4
+  H4 --> H5
+  H4 --> H6
+```
+
+The user-facing point is not the exact technique. The point is that LoopX
+retains the failed or bounded directions as explicit negative evidence, so the
+next agent does not rediscover them from scratch.
+
+## Minimal Reproduction Plan
+
+1. Package a public-safe mini benchmark fixture under docs or examples, modeled
+   on Arbor's k-NN task but owned by LoopX.
+2. Add `research_contract_v0`, `research_hypothesis_v0`, and
+   `research_evidence_event_v0` fixture records.
+3. Add a CLI preview that reads the fixture and emits
+   `decentralized_research_frontier_v0` for two agents.
+4. Run one local smoke that proves:
+   - protected files are not editable;
+   - each hypothesis is todo-linked;
+   - each evidence event names split and metric;
+   - no leader agent owns the graph;
+   - held-out promotion is required.
+5. Build the showcase page from fixture evidence, then replace fixture numbers
+   with a real run when available.
+
+## Kernel/Capability Improvements
+
+P0 candidates:
+
+- **Research hypothesis ledger in core state.** Promote the existing
+  `hypothesis_ledger_v0` idea from the ML domain pack into a generic,
+  todo-linked research hypothesis shape.
+- **Per-agent research frontier projection.** Extend status/quota projection so
+  a current agent sees only claim-compatible hypotheses and promotion
+  candidates, while other-agent claims remain visible context.
+- **Retry semantics.** Add `needs_retry` as a reusable outcome for
+  incomplete/unscored research attempts, preserving branch/evidence refs.
+- **Split-aware evidence.** Make dev/held-out split labels first-class in
+  evidence events and showcase projections.
+
+P1 candidates:
+
+- **Grounded ideation / novelty audit separation.** Add two explicit source
+  lanes so research input and novelty checking cannot contaminate each other.
+- **Benchmark-zoo-style pack.** Add a `loopx research scaffold` path that turns
+  a small optimization task into a protected benchmark pack.
+- **Replay/export surface.** Convert evidence graph events into a static HTML
+  replay for public-safe showcases.
+
+## Design Guardrails
+
+- The control plane may select a frontier; it must not become a hidden leader.
+- Agents may propose and execute hypotheses within their claim/scope.
+- Promotion requires evidence and gate policy, not a persuasive chat summary.
+- A user can inspect every branch of the research graph from source refs.
+- Public showcase pages must distinguish "fixture target" from "achieved run".
+- Private docs, internal links, raw logs, credentials, local paths, and raw
+  benchmark traces stay out of public artifacts.
+
+## Suggested Public Narrative
+
+LoopX does for autonomous research what it already does for long-running
+engineering agents: it turns a noisy loop into a managed control plane. The
+novel part is that research hypotheses become first-class work items with
+claims, evidence, retry state, and promotion gates. The result can look like an
+Arbor-style hypothesis tree to the user, while the implementation remains
+LoopX-native and decentralized.

--- a/docs/reference/protocols/README.md
+++ b/docs/reference/protocols/README.md
@@ -17,6 +17,7 @@ Current contracts:
 - [task_graph_projection_v0](task-graph-projection-v0.md)
 - [todo_detail_cold_path_v0](todo-detail-cold-path-v0.md)
 - [long_horizon_agent_state_protocol_v0](long-horizon-agent-state-protocol-v0.md)
+- [decentralized_auto_research_state_v0](decentralized-auto-research-state-v0.md)
 - [global_manager_command_v0](global-manager-command-v0.md)
 - [pr_review_command_v0](pr-review-command-v0.md)
 - [event_sourced_state_contract_v0](event-sourced-state-contract-v0.md)

--- a/docs/reference/protocols/decentralized-auto-research-state-v0.md
+++ b/docs/reference/protocols/decentralized-auto-research-state-v0.md
@@ -244,12 +244,19 @@ Already available:
   `dataset_window_contract_v0`, and advisory result packets.
 - `long_horizon_agent_state_protocol_v0` already defines source/projection
   separation and concurrent lane views.
+- `loopx auto-research frontier --fixture <public.json> --agent-id <agent>`
+  now renders a fixture-backed `decentralized_research_frontier_v0`,
+  `research_evidence_graph_v0`, and `research_showcase_projection_v0` without
+  launching experiments or depending on a leader agent.
 
 Needed next:
 
-- expose `research_hypothesis_v0` as a public-safe rollout-event subtype;
-- add a frontier projection that joins hypothesis status with agent/todo claim;
-- add a small auto-research benchmark fixture modeled on Arbor's k-NN zoo task;
+- expose `research_hypothesis_v0` as a public-safe rollout-event subtype
+  beyond fixture projection;
+- connect the frontier projection to live todo/quota status rather than only a
+  public fixture;
+- add a runnable auto-research benchmark fixture modeled on Arbor's k-NN zoo
+  task;
 - add a showcase page that reports baseline, dev result, held-out result,
   retired directions, and LoopX's decentralized coordination pattern.
 

--- a/docs/reference/protocols/decentralized-auto-research-state-v0.md
+++ b/docs/reference/protocols/decentralized-auto-research-state-v0.md
@@ -1,0 +1,268 @@
+# decentralized_auto_research_state_v0
+
+`decentralized_auto_research_state_v0` is a LoopX protocol for running
+autonomous research without introducing a single leader agent. It borrows the
+useful parts of Arbor's public design, especially durable hypothesis state,
+worktree isolation, dev/held-out evaluation, and replayable evidence, but maps
+them onto LoopX's shared control plane: todos, claims, quota, run history,
+rollout events, gates, and read-only projections.
+
+The goal is to let multiple agents explore research hypotheses in parallel
+while preserving provenance, ownership, and promotion rules. No agent owns the
+whole research tree. The source of truth is the append-only state graph; each
+agent sees a scoped frontier through `quota should-run --agent-id ...`.
+
+## Arbor Signals To Preserve
+
+Primary public Arbor surfaces reviewed:
+
+- `README.md`: Arbor frames the work as autonomous research through
+  hypothesis-tree refinement, with a Coordinator, Executors, worktrees,
+  held-out validation, reports, replay, and a benchmark zoo.
+- `docs/how-it-works.md`: the six-step cycle is observe, ideate, select,
+  experiment, evaluate, backpropagate, then merge or prune.
+- `src/coordinator/idea_tree.py`: each node records hypothesis, status,
+  insight, result, score split, test score, branch ref, grounding,
+  related-work audit, eval status, stop reason, and attempt count.
+- `src/coordinator/tools/executor_run.py`: executor outcomes distinguish
+  scored success from `needs_retry` for timeout, max-turn, eval-crash, or
+  unparseable reports, while preserving branch/report/diff for continuation.
+- `docs/search.md`: grounded ideation and novelty audit are separate lanes;
+  text fetched to inspire an idea is not reused to certify novelty.
+- `arbor-zoo/algotune_knn`: the showcase benchmark packages an editable
+  solver, protected harness, dev/test split, provenance, and one `score:` line.
+
+LoopX should preserve these product lessons, not Arbor's centralized topology.
+
+## Non-Goals
+
+- Do not add a LoopX-wide "research director" agent that owns all planning.
+- Do not replace todos, run history, or rollout events with a second research
+  database.
+- Do not let a showcase dashboard mutate source state.
+- Do not treat an advisory grounded-search result as proof of novelty.
+- Do not merge or publish a research result without held-out evidence or an
+  explicit gate when the boundary requires one.
+
+## Source Protocol
+
+Source state is writable only through LoopX lifecycle commands, project-owned
+state files, or future narrow kernel APIs.
+
+| Source state | Existing or proposed anchor | Purpose |
+| --- | --- | --- |
+| `research_contract_v0` | proposed packet, registry goal metadata | Public-safe objective, editable scope, protected scope, metric direction, dev/held-out commands, budget, and stopping condition. |
+| `todo_item_v0` | `loopx todo` | Formal executable work, user gate, blocker, or monitor. Research work remains todo-backed. |
+| `research_hypothesis_v0` | proposed rollout event and optional domain pack | A hypothesis node linked to a todo, parent hypothesis, agent lane, mechanism family, and current status. |
+| `research_evidence_event_v0` | proposed `loopx_rollout_event_v0` specialization | Append-only evidence for an attempt: score, split, command label, branch, artifact refs, eval status, and boundary facts. |
+| `dataset_window_contract_v0` | `loopx/ml_experiment.py` | Train/dev/held-out window or split contract, including missing-window policy. |
+| `agent_lane_next_action_v0` | `quota should-run --agent-id ...` | The current agent's selected frontier item; it does not replace the global state graph. |
+| `operator_gate` | `loopx operator-gate`, review packet | Promotion, merge, private-material, or showcase-publication decision. |
+| `human_reward` | `loopx reward` | Run-bound owner judgment, not general write permission. |
+
+### `research_contract_v0`
+
+```json
+{
+  "schema_version": "research_contract_v0",
+  "goal_id": "loopx-meta",
+  "research_objective": "optimize a benchmark task under a protected evaluator",
+  "editable_scope": ["solution.py"],
+  "protected_scope": ["eval.py", "task.py", "data/**"],
+  "metric": {"name": "speedup", "direction": "maximize"},
+  "dev_eval": {"label": "eval_dev", "command_label": "bash eval.sh dev"},
+  "holdout_eval": {"label": "eval_test", "command_label": "bash eval.sh test"},
+  "promotion_policy": "requires_holdout_improvement_and_clean_boundary",
+  "budget": {"max_attempts": 8, "max_parallel_lanes": 3}
+}
+```
+
+### `research_hypothesis_v0`
+
+```json
+{
+  "schema_version": "research_hypothesis_v0",
+  "goal_id": "loopx-meta",
+  "hypothesis_id": "hyp_0004",
+  "parent_hypothesis_id": "hyp_0002",
+  "todo_id": "todo_123",
+  "lane_id": "agent:codex-side-bypass",
+  "claimed_by": "codex-side-bypass",
+  "mechanism_family": "vectorized_distance_kernel",
+  "hypothesis": "Batch query points through a shared index to reduce per-query overhead.",
+  "status": "active",
+  "frontier_rank": 2,
+  "source_refs": ["research_contract:knn_speedup"],
+  "grounding_refs": [],
+  "novelty_audit_ref": null
+}
+```
+
+Status vocabulary:
+
+| Status | Meaning |
+| --- | --- |
+| `proposed` | Drafted but not yet accepted into executable work. |
+| `active` | Runnable frontier item, normally backed by an open agent todo. |
+| `running` | Claimed attempt is in progress. |
+| `needs_retry` | Attempt produced no trustworthy score but left resumable evidence. |
+| `supported` | Dev evidence supports the hypothesis; not yet promoted. |
+| `contradicted` | Evidence shows regression or guardrail failure. |
+| `promoted` | Held-out evidence and promotion policy accepted it into the current best artifact. |
+| `retired` | No longer worth exploring, but retained as negative evidence. |
+
+### `research_evidence_event_v0`
+
+```json
+{
+  "schema_version": "research_evidence_event_v0",
+  "goal_id": "loopx-meta",
+  "hypothesis_id": "hyp_0004",
+  "todo_id": "todo_123",
+  "agent_id": "codex-side-bypass",
+  "attempt": 1,
+  "split": "dev",
+  "metric": {"name": "speedup", "value": 11.4, "direction": "maximize"},
+  "baseline_metric": 8.7,
+  "primary_metric_status": "improved",
+  "eval_status": "scored",
+  "code_ref": "codex/research-hyp-0004",
+  "artifact_refs": ["experiment:hyp_0004/report", "diff:hyp_0004"],
+  "protected_scope_clean": true,
+  "private_artifacts_recorded": false,
+  "raw_logs_recorded": false
+}
+```
+
+`needs_retry` is first-class evidence, not a generic failure:
+
+```json
+{
+  "schema_version": "research_evidence_event_v0",
+  "hypothesis_id": "hyp_0005",
+  "eval_status": "failed_to_run",
+  "stop_reason": "max_turns",
+  "attempt": 1,
+  "code_ref": "codex/research-hyp-0005",
+  "resume_policy": "resume_from_code_ref_or_retire",
+  "primary_metric_status": "inconclusive"
+}
+```
+
+## Projection Protocol
+
+Projection state is read-only. It may rank frontiers for display, but it must
+carry source refs and remain recomputable from source state.
+
+| Projection | Purpose |
+| --- | --- |
+| `decentralized_research_frontier_v0` | Per-agent queue of runnable or blocked hypotheses after quota, claim, capability, and boundary checks. |
+| `research_evidence_graph_v0` | Read-only graph joining hypotheses, todos, attempts, branches, metrics, gates, and promotion decisions. |
+| `research_showcase_projection_v0` | Public-safe view for a case page: objective, baseline, best result, attempt timeline, dev/held-out split, and reusable LoopX pattern. |
+
+### `decentralized_research_frontier_v0`
+
+```json
+{
+  "schema_version": "decentralized_research_frontier_v0",
+  "goal_id": "loopx-meta",
+  "agent_id": "codex-side-bypass",
+  "selected": {
+    "hypothesis_id": "hyp_0004",
+    "todo_id": "todo_123",
+    "reason": "current-agent claim and dev evidence gap",
+    "allowed_action": "run_dev_attempt"
+  },
+  "blocked": [
+    {
+      "hypothesis_id": "hyp_0002",
+      "blocked_by": "claimed_by:codex-product-capability",
+      "visible_as_context": true
+    }
+  ],
+  "promotion_candidates": [
+    {
+      "hypothesis_id": "hyp_0004",
+      "requires": ["holdout_eval", "boundary_scan"]
+    }
+  ]
+}
+```
+
+This projection intentionally replaces a centralized Coordinator decision. The
+kernel selects only what the current agent may attempt; the agent still does
+semantic implementation within its allowed boundary.
+
+## Decentralized Cycle
+
+Arbor's cycle maps to LoopX as a distributed control loop:
+
+| Arbor concept | LoopX decentralized equivalent |
+| --- | --- |
+| Observe | Agent reads `quota should-run`, active state, selected frontier, evidence graph, and relevant source docs. |
+| Ideate | Any authorized lane may propose `research_hypothesis_v0` as a todo-backed candidate. |
+| Select | `quota should-run --agent-id` filters by claim, gate, capability, and boundary. |
+| Dispatch | The selected agent works in its own worktree and writes evidence. |
+| Backpropagate | A deterministic projection summarizes supported/contradicted lessons into the evidence graph; no single agent rewrites global truth. |
+| Decide | Promotion policy plus operator gates decide merge, retire, retry, or continue. |
+
+## Search Lanes
+
+LoopX should adopt Arbor's separation of search lanes:
+
+| Lane | When | Authority | Writes |
+| --- | --- | --- | --- |
+| `grounded_ideation` | Before or during hypothesis proposal | Advisory input to a candidate hypothesis. | `grounding_refs` on the hypothesis. |
+| `novelty_audit` | After a hypothesis has real evidence | Advisory contribution/overlap check. | `novelty_audit_ref` and evidence note. |
+
+The two lanes must not share fetched text as proof. If a source shaped the idea,
+it can be cited as grounding, but a later novelty audit must run an independent
+source pass before claiming novelty.
+
+## Promotion Policy
+
+A research hypothesis is promotable only when:
+
+1. the editable/protected scope boundary is clean;
+2. dev evidence is scored and public-safe;
+3. held-out evidence satisfies the metric direction and margin;
+4. required user/controller gates are resolved;
+5. the promoted artifact has a branch or commit ref;
+6. the evidence graph records negative evidence for close alternatives.
+
+Promotion is a state transition, not a chat conclusion. It should write a
+todo completion, evidence event, and optional promotion gate/reward overlay.
+
+## Integration With Existing LoopX
+
+Already available:
+
+- `todo_item_v0` has claims, task classes, action kinds, blockers, user gates,
+  and resume conditions.
+- `agent_lane_next_action_v0` scopes work per registered agent.
+- `loopx/ml_experiment.py` already has `hypothesis_ledger_v0`,
+  `dataset_window_contract_v0`, and advisory result packets.
+- `long_horizon_agent_state_protocol_v0` already defines source/projection
+  separation and concurrent lane views.
+
+Needed next:
+
+- expose `research_hypothesis_v0` as a public-safe rollout-event subtype;
+- add a frontier projection that joins hypothesis status with agent/todo claim;
+- add a small auto-research benchmark fixture modeled on Arbor's k-NN zoo task;
+- add a showcase page that reports baseline, dev result, held-out result,
+  retired directions, and LoopX's decentralized coordination pattern.
+
+## Acceptance Checks
+
+An implementation is acceptable when:
+
+- no single agent is required to own or mutate the full hypothesis graph;
+- every executable hypothesis is linked to a todo and claim;
+- per-agent frontier selection is derived from quota/status, not chat memory;
+- `needs_retry` keeps resumable evidence instead of collapsing into `done`;
+- grounded ideation and novelty audit are separated;
+- held-out promotion is explicit;
+- public projections contain no raw logs, private paths, credentials, or raw
+  internal documents;
+- the showcase can be rendered from public-safe evidence refs.

--- a/examples/decentralized-auto-research-frontier-smoke.py
+++ b/examples/decentralized-auto-research-frontier-smoke.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Smoke-test decentralized auto-research fixture projection."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.auto_research import (  # noqa: E402
+    AUTO_RESEARCH_PROJECTION_SCHEMA_VERSION,
+    RESEARCH_EVIDENCE_GRAPH_SCHEMA_VERSION,
+    RESEARCH_FRONTIER_SCHEMA_VERSION,
+    RESEARCH_SHOWCASE_PROJECTION_SCHEMA_VERSION,
+    build_auto_research_projection,
+    load_auto_research_fixture,
+)
+
+
+FIXTURE = REPO_ROOT / "examples/fixtures/decentralized-auto-research-knn.public.json"
+
+
+def assert_no_private_surface(payload: dict[str, Any]) -> None:
+    text = json.dumps(payload, sort_keys=True)
+    forbidden = [
+        "/" + "Users/",
+        "/" + "private/",
+        "/" + "tmp/",
+        "lark" + "office",
+        "byte" + "dance",
+        "http://",
+        "https://",
+        "s3://",
+        "tos://",
+        "hdfs://",
+        "api" + "_key",
+        "pass" + "word",
+        "sec" + "ret",
+    ]
+    leaked = [needle for needle in forbidden if needle.lower() in text.lower()]
+    assert not leaked, leaked
+
+
+def run_cli(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "loopx.cli", *args],
+        cwd=REPO_ROOT,
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def main() -> None:
+    fixture = load_auto_research_fixture(FIXTURE)
+    payload = build_auto_research_projection(fixture, agent_id="codex-side-bypass")
+    assert payload["ok"], payload
+    assert payload["schema_version"] == AUTO_RESEARCH_PROJECTION_SCHEMA_VERSION, payload
+    assert payload["frontier"]["schema_version"] == RESEARCH_FRONTIER_SCHEMA_VERSION, payload
+    assert payload["evidence_graph"]["schema_version"] == RESEARCH_EVIDENCE_GRAPH_SCHEMA_VERSION, payload
+    assert payload["showcase_projection"]["schema_version"] == RESEARCH_SHOWCASE_PROJECTION_SCHEMA_VERSION, payload
+    assert payload["frontier"]["agent_id"] == "codex-side-bypass", payload
+    assert payload["frontier"]["selected"]["hypothesis_id"] == "hyp_002", payload
+    assert payload["frontier"]["selected"]["allowed_action"] == "run_dev_attempt", payload
+    assert payload["frontier"]["blocked"][0]["blocked_by"] == "claimed_by:codex-product-capability", payload
+    assert payload["evidence_graph"]["holdout_improved"] is True, payload
+    assert payload["evidence_graph"]["negative_evidence_count"] == 1, payload
+    assert payload["showcase_projection"]["decentralized_pattern"].startswith("todo_linked"), payload
+    assert payload["public_boundary"]["raw_logs_recorded"] is False, payload
+    assert payload["public_boundary"]["private_artifacts_recorded"] is False, payload
+    assert_no_private_surface(payload)
+
+    result = run_cli(
+        [
+            "--format",
+            "json",
+            "auto-research",
+            "frontier",
+            "--fixture",
+            str(FIXTURE),
+            "--agent-id",
+            "codex-side-bypass",
+        ]
+    )
+    cli_payload = json.loads(result.stdout)
+    assert cli_payload["ok"], cli_payload
+    assert cli_payload["frontier"]["selected"]["todo_id"] == "todo_auto_research_002", cli_payload
+    assert_no_private_surface(cli_payload)
+
+    bad_fixture = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    bad_fixture["evidence_events"][0]["artifact_refs"] = ["/" + "Users/example/raw.log"]
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as handle:
+        json.dump(bad_fixture, handle)
+        bad_path = handle.name
+    blocked = run_cli(
+        [
+            "--format",
+            "json",
+            "auto-research",
+            "frontier",
+            "--fixture",
+            bad_path,
+            "--agent-id",
+            "codex-side-bypass",
+        ],
+        check=False,
+    )
+    assert blocked.returncode == 1, blocked.stdout
+    blocked_payload = json.loads(blocked.stdout)
+    assert blocked_payload["ok"] is False, blocked_payload
+    assert "public alias" in blocked_payload["error"], blocked_payload
+
+    docs = (REPO_ROOT / "docs/reference/protocols/decentralized-auto-research-state-v0.md").read_text(
+        encoding="utf-8"
+    )
+    assert "decentralized_research_frontier_v0" in docs, docs
+    assert "research_showcase_projection_v0" in docs, docs
+
+    print("decentralized-auto-research-frontier-smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/decentralized-auto-research-protocol-smoke.py
+++ b/examples/decentralized-auto-research-protocol-smoke.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Smoke-check the decentralized auto-research protocol docs.
+
+This guards the durable product contract: Arbor-inspired auto research must
+remain LoopX-native and decentralized, with todo-linked hypotheses,
+agent-scoped frontiers, split-aware evidence, and no public/private leakage.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PROTOCOL = ROOT / "docs/reference/protocols/decentralized-auto-research-state-v0.md"
+BLUEPRINT = ROOT / "docs/product/decentralized-auto-research-showcase.md"
+
+
+PRIVATE_MARKERS = [
+    "byte" + "dance",
+    "lark" + "office",
+    "fei" + "shu.cn",
+    "/" + "Users" + "/",
+    "/" + "private" + "/",
+    "api" + "_key",
+    "pass" + "word",
+    "sec" + "ret",
+]
+
+
+def _read(path: Path) -> str:
+    assert path.exists(), f"missing {path}"
+    return path.read_text(encoding="utf-8")
+
+
+def _assert_public_safe(text: str, label: str) -> None:
+    lower = text.lower()
+    for marker in PRIVATE_MARKERS:
+        assert marker.lower() not in lower, f"{label} leaks private marker {marker!r}"
+
+
+def main() -> None:
+    protocol = _read(PROTOCOL)
+    blueprint = _read(BLUEPRINT)
+    combined = protocol + "\n" + blueprint
+    compact_protocol = re.sub(r"\s+", " ", protocol)
+
+    _assert_public_safe(combined, "decentralized auto-research docs")
+
+    required_protocol_terms = [
+        "decentralized_auto_research_state_v0",
+        "research_contract_v0",
+        "research_hypothesis_v0",
+        "research_evidence_event_v0",
+        "decentralized_research_frontier_v0",
+        "agent_lane_next_action_v0",
+        "claimed_by",
+        "todo_id",
+        "agent_id",
+        "needs_retry",
+        "held-out",
+        "grounded_ideation",
+        "novelty_audit",
+    ]
+    for term in required_protocol_terms:
+        assert term in protocol, f"protocol missing {term!r}"
+    assert "No agent owns the whole research tree" in compact_protocol
+
+    required_blueprint_terms = [
+        "Decentralized Auto Research: k-NN Speedup",
+        "not a claim that LoopX has already achieved",
+        "Research Contract card",
+        "Decentralized frontier",
+        "Evidence timeline",
+        "Promotion decision",
+        "no leader agent owns the graph",
+    ]
+    for term in required_blueprint_terms:
+        assert term in blueprint, f"blueprint missing {term!r}"
+
+    forbidden_patterns = [
+        r"single leader agent owns",
+        r"leader agent owns the full",
+        r"leader agent.*full hypothesis graph",
+        r"central Coordinator owns",
+        r"Coordinator owns the tree",
+        r"Coordinator.*promotion decisions live",
+        r"single agent owns the whole research tree",
+    ]
+    for pattern in forbidden_patterns:
+        assert not re.search(pattern, combined, re.IGNORECASE), (
+            f"docs drifted toward centralized wording: {pattern}"
+        )
+
+    assert "not one leader Coordinator" in blueprint or "no leader agent" in blueprint
+    print("decentralized auto-research protocol smoke passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/fixtures/decentralized-auto-research-knn.public.json
+++ b/examples/fixtures/decentralized-auto-research-knn.public.json
@@ -1,0 +1,130 @@
+{
+  "schema_version": "decentralized_auto_research_fixture_v0",
+  "generated_at": "2026-06-28T00:00:00Z",
+  "research_contract": {
+    "schema_version": "research_contract_v0",
+    "goal_id": "loopx-auto-research-knn",
+    "research_objective": "Improve exact k-nearest-neighbor inference speed under a protected evaluator.",
+    "editable_scope": ["solution.py"],
+    "protected_scope": ["eval.py", "task.py", "generated_data"],
+    "metric": {
+      "name": "speedup",
+      "direction": "maximize",
+      "baseline": 1.0
+    },
+    "dev_eval": "eval_dev_alias",
+    "holdout_eval": "eval_holdout_alias",
+    "promotion_policy": "requires_holdout_improvement_and_clean_boundary"
+  },
+  "agents": ["codex-side-bypass", "codex-product-capability"],
+  "hypotheses": [
+    {
+      "schema_version": "research_hypothesis_v0",
+      "hypothesis_id": "hyp_001",
+      "parent_hypothesis_id": null,
+      "todo_id": "todo_auto_research_001",
+      "claimed_by": "codex-side-bypass",
+      "mechanism_family": "vectorized_distance_kernel",
+      "hypothesis": "Vectorize pairwise distance calculation while preserving exact nearest-neighbor output.",
+      "status": "supported",
+      "grounding_refs": ["grounding_public_numpy_vectorization"],
+      "novelty_audit_ref": "novelty_audit_public_exact_knn",
+      "blocked_by": []
+    },
+    {
+      "schema_version": "research_hypothesis_v0",
+      "hypothesis_id": "hyp_002",
+      "parent_hypothesis_id": "hyp_001",
+      "todo_id": "todo_auto_research_002",
+      "claimed_by": "codex-side-bypass",
+      "mechanism_family": "partial_selection",
+      "hypothesis": "Use partial selection to avoid a full distance sort for each query.",
+      "status": "active",
+      "grounding_refs": ["grounding_public_selection_algorithms"],
+      "novelty_audit_ref": null,
+      "blocked_by": []
+    },
+    {
+      "schema_version": "research_hypothesis_v0",
+      "hypothesis_id": "hyp_003",
+      "parent_hypothesis_id": "hyp_002",
+      "todo_id": "todo_auto_research_003",
+      "claimed_by": "codex-product-capability",
+      "mechanism_family": "batch_query_path",
+      "hypothesis": "Batch query points so shared array layout work is reused across requests.",
+      "status": "active",
+      "grounding_refs": ["grounding_public_batching"],
+      "novelty_audit_ref": null,
+      "blocked_by": []
+    },
+    {
+      "schema_version": "research_hypothesis_v0",
+      "hypothesis_id": "hyp_004",
+      "parent_hypothesis_id": "hyp_003",
+      "todo_id": "todo_auto_research_004",
+      "claimed_by": "codex-side-bypass",
+      "mechanism_family": "approximate_search_guardrail",
+      "hypothesis": "Try approximate search only as a negative control because exact output is required.",
+      "status": "contradicted",
+      "grounding_refs": ["grounding_public_ann_tradeoff"],
+      "novelty_audit_ref": "novelty_audit_public_ann_exactness",
+      "blocked_by": ["correctness_guardrail_failed"]
+    }
+  ],
+  "evidence_events": [
+    {
+      "schema_version": "research_evidence_event_v0",
+      "hypothesis_id": "hyp_001",
+      "todo_id": "todo_auto_research_001",
+      "agent_id": "codex-side-bypass",
+      "attempt": 1,
+      "split": "dev",
+      "metric": {
+        "name": "speedup",
+        "value": 4.8,
+        "direction": "maximize"
+      },
+      "baseline_metric": 1.0,
+      "eval_status": "scored",
+      "primary_metric_status": "improved",
+      "artifact_refs": ["experiment_hyp001_report", "diff_hyp001"],
+      "protected_scope_clean": true
+    },
+    {
+      "schema_version": "research_evidence_event_v0",
+      "hypothesis_id": "hyp_001",
+      "todo_id": "todo_auto_research_001",
+      "agent_id": "codex-side-bypass",
+      "attempt": 2,
+      "split": "holdout",
+      "metric": {
+        "name": "speedup",
+        "value": 4.3,
+        "direction": "maximize"
+      },
+      "baseline_metric": 1.0,
+      "eval_status": "scored",
+      "primary_metric_status": "improved",
+      "artifact_refs": ["experiment_hyp001_holdout_report"],
+      "protected_scope_clean": true
+    },
+    {
+      "schema_version": "research_evidence_event_v0",
+      "hypothesis_id": "hyp_004",
+      "todo_id": "todo_auto_research_004",
+      "agent_id": "codex-side-bypass",
+      "attempt": 1,
+      "split": "dev",
+      "metric": {
+        "name": "speedup",
+        "value": null,
+        "direction": "maximize"
+      },
+      "baseline_metric": 1.0,
+      "eval_status": "guardrail_failed",
+      "primary_metric_status": "failed",
+      "artifact_refs": ["experiment_hyp004_guardrail_note"],
+      "protected_scope_clean": true
+    }
+  ]
+}

--- a/loopx/auto_research.py
+++ b/loopx/auto_research.py
@@ -1,0 +1,453 @@
+from __future__ import annotations
+
+import json
+import math
+import re
+from pathlib import Path
+from typing import Any, Iterable
+
+
+AUTO_RESEARCH_FIXTURE_SCHEMA_VERSION = "decentralized_auto_research_fixture_v0"
+RESEARCH_CONTRACT_SCHEMA_VERSION = "research_contract_v0"
+RESEARCH_HYPOTHESIS_SCHEMA_VERSION = "research_hypothesis_v0"
+RESEARCH_EVIDENCE_EVENT_SCHEMA_VERSION = "research_evidence_event_v0"
+RESEARCH_FRONTIER_SCHEMA_VERSION = "decentralized_research_frontier_v0"
+RESEARCH_EVIDENCE_GRAPH_SCHEMA_VERSION = "research_evidence_graph_v0"
+RESEARCH_SHOWCASE_PROJECTION_SCHEMA_VERSION = "research_showcase_projection_v0"
+AUTO_RESEARCH_PROJECTION_SCHEMA_VERSION = "decentralized_auto_research_projection_v0"
+
+HYPOTHESIS_STATUSES = {
+    "proposed",
+    "active",
+    "running",
+    "needs_retry",
+    "supported",
+    "contradicted",
+    "promoted",
+    "retired",
+}
+EVIDENCE_STATUSES = {
+    "scored",
+    "failed_to_run",
+    "guardrail_failed",
+    "inconclusive",
+}
+METRIC_DIRECTIONS = {"maximize", "minimize"}
+
+_TOKEN_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_.:-]{0,95}$")
+_ABSOLUTE_PATH_RE = re.compile(
+    r"(^|[\s:=])(?:"
+    + "/" + "Users/"
+    + "|/" + "private/"
+    + "|/" + "tmp/"
+    + "|~[/\\s]|[A-Za-z]:\\\\)"
+)
+_URL_OR_REMOTE_PATH_RE = re.compile(r"(?i)\b(?:file|s3|gs|tos|hdfs)://")
+_PRIVATE_MARKER_TERMS = [
+    "author" + "ization:",
+    r"bearer\s+[A-Za-z0-9._-]+",
+    r"api[_-]?" + "key",
+    "pass" + "word",
+    "sec" + "ret",
+    r"begin (?:rsa |open)?private " + "key",
+    "lark" + "office",
+    r"fei" + r"shu\.cn",
+    "byte" + "dance",
+]
+_PRIVATE_MARKER_RE = re.compile(r"(?i)(" + "|".join(_PRIVATE_MARKER_TERMS) + ")")
+
+
+def _compact_public_text(value: Any, *, field: str, max_len: int = 240) -> str:
+    text = " ".join(str(value or "").strip().split())
+    if not text:
+        raise ValueError(f"{field} must be non-empty")
+    if len(text) > max_len:
+        raise ValueError(f"{field} is too long for a compact public-safe field")
+    if ".." in text:
+        raise ValueError(f"{field} must not contain parent-directory markers")
+    if _ABSOLUTE_PATH_RE.search(text) or text.startswith(("/", "~")):
+        raise ValueError(f"{field} must use a public alias, not a local/private path")
+    if _URL_OR_REMOTE_PATH_RE.search(text):
+        raise ValueError(f"{field} must use a public alias, not a raw remote path")
+    if _PRIVATE_MARKER_RE.search(text):
+        raise ValueError(f"{field} contains a private or credential-like marker")
+    return text
+
+
+def _compact_public_token(value: Any, *, field: str) -> str:
+    token = _compact_public_text(value, field=field, max_len=96)
+    if not _TOKEN_RE.match(token):
+        raise ValueError(
+            f"{field} must be a compact public token using letters, digits, dot, colon, dash, or underscore"
+        )
+    return token
+
+
+def _compact_public_text_list(values: Iterable[Any] | None, *, field: str) -> list[str]:
+    return [_compact_public_text(value, field=f"{field}[]") for value in values or []]
+
+
+def _finite_float(value: float | int | str | None, *, field: str) -> float | None:
+    if value is None:
+        return None
+    number = float(value)
+    if not math.isfinite(number):
+        raise ValueError(f"{field} must be finite")
+    return number
+
+
+def _json_obj(value: Any, *, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{field} must be a JSON object")
+    return value
+
+
+def _json_list(value: Any, *, field: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise ValueError(f"{field} must be a JSON list")
+    return value
+
+
+def _metric_improved(
+    *,
+    value: float | None,
+    baseline: float | None,
+    direction: str,
+) -> bool:
+    if value is None or baseline is None:
+        return False
+    return value > baseline if direction == "maximize" else value < baseline
+
+
+def _metric_rank_key(value: float | None, *, direction: str) -> float:
+    if value is None:
+        return float("-inf")
+    return value if direction == "maximize" else -value
+
+
+def load_auto_research_fixture(path: str | Path) -> dict[str, Any]:
+    payload = json.loads(Path(path).expanduser().read_text(encoding="utf-8"))
+    return validate_auto_research_fixture(payload)
+
+
+def validate_auto_research_fixture(payload: dict[str, Any]) -> dict[str, Any]:
+    payload = _json_obj(payload, field="fixture")
+    schema = _compact_public_token(payload.get("schema_version"), field="schema_version")
+    if schema != AUTO_RESEARCH_FIXTURE_SCHEMA_VERSION:
+        raise ValueError(f"schema_version must be {AUTO_RESEARCH_FIXTURE_SCHEMA_VERSION}")
+
+    contract = validate_research_contract(_json_obj(payload.get("research_contract"), field="research_contract"))
+    hypotheses = [
+        validate_research_hypothesis(_json_obj(item, field="hypotheses[]"))
+        for item in _json_list(payload.get("hypotheses"), field="hypotheses")
+    ]
+    evidence_events = [
+        validate_research_evidence_event(_json_obj(item, field="evidence_events[]"))
+        for item in _json_list(payload.get("evidence_events"), field="evidence_events")
+    ]
+
+    hypothesis_ids = {item["hypothesis_id"] for item in hypotheses}
+    todo_ids = {item["todo_id"] for item in hypotheses if item.get("todo_id")}
+    for item in evidence_events:
+        if item["hypothesis_id"] not in hypothesis_ids:
+            raise ValueError(f"evidence references unknown hypothesis_id {item['hypothesis_id']}")
+        if item.get("todo_id") and item["todo_id"] not in todo_ids:
+            raise ValueError(f"evidence references unknown todo_id {item['todo_id']}")
+
+    agents = [
+        _compact_public_token(value, field="agents[]")
+        for value in _json_list(payload.get("agents"), field="agents")
+    ]
+
+    return {
+        "schema_version": schema,
+        "generated_at": _compact_public_text(payload.get("generated_at"), field="generated_at"),
+        "research_contract": contract,
+        "agents": agents,
+        "hypotheses": hypotheses,
+        "evidence_events": evidence_events,
+        "raw_logs_recorded": False,
+        "private_artifacts_recorded": False,
+    }
+
+
+def validate_research_contract(contract: dict[str, Any]) -> dict[str, Any]:
+    schema = _compact_public_token(contract.get("schema_version"), field="research_contract.schema_version")
+    if schema != RESEARCH_CONTRACT_SCHEMA_VERSION:
+        raise ValueError(f"research_contract.schema_version must be {RESEARCH_CONTRACT_SCHEMA_VERSION}")
+    metric = _json_obj(contract.get("metric"), field="research_contract.metric")
+    direction = _compact_public_token(metric.get("direction"), field="metric.direction")
+    if direction not in METRIC_DIRECTIONS:
+        raise ValueError("metric.direction must be maximize or minimize")
+    return {
+        "schema_version": schema,
+        "goal_id": _compact_public_token(contract.get("goal_id"), field="goal_id"),
+        "research_objective": _compact_public_text(contract.get("research_objective"), field="research_objective"),
+        "editable_scope": _compact_public_text_list(contract.get("editable_scope"), field="editable_scope"),
+        "protected_scope": _compact_public_text_list(contract.get("protected_scope"), field="protected_scope"),
+        "metric": {
+            "name": _compact_public_token(metric.get("name"), field="metric.name"),
+            "direction": direction,
+            "baseline": _finite_float(metric.get("baseline"), field="metric.baseline"),
+        },
+        "dev_eval": _compact_public_text(contract.get("dev_eval"), field="dev_eval"),
+        "holdout_eval": _compact_public_text(contract.get("holdout_eval"), field="holdout_eval"),
+        "promotion_policy": _compact_public_token(contract.get("promotion_policy"), field="promotion_policy"),
+    }
+
+
+def validate_research_hypothesis(item: dict[str, Any]) -> dict[str, Any]:
+    schema = _compact_public_token(item.get("schema_version"), field="hypothesis.schema_version")
+    if schema != RESEARCH_HYPOTHESIS_SCHEMA_VERSION:
+        raise ValueError(f"hypothesis.schema_version must be {RESEARCH_HYPOTHESIS_SCHEMA_VERSION}")
+    status = _compact_public_token(item.get("status"), field="hypothesis.status")
+    if status not in HYPOTHESIS_STATUSES:
+        raise ValueError(f"hypothesis.status must be one of {', '.join(sorted(HYPOTHESIS_STATUSES))}")
+    return {
+        "schema_version": schema,
+        "hypothesis_id": _compact_public_token(item.get("hypothesis_id"), field="hypothesis_id"),
+        "parent_hypothesis_id": (
+            _compact_public_token(item.get("parent_hypothesis_id"), field="parent_hypothesis_id")
+            if item.get("parent_hypothesis_id")
+            else None
+        ),
+        "todo_id": _compact_public_token(item.get("todo_id"), field="todo_id"),
+        "claimed_by": _compact_public_token(item.get("claimed_by"), field="claimed_by"),
+        "mechanism_family": _compact_public_text(item.get("mechanism_family"), field="mechanism_family"),
+        "hypothesis": _compact_public_text(item.get("hypothesis"), field="hypothesis"),
+        "status": status,
+        "grounding_refs": _compact_public_text_list(item.get("grounding_refs"), field="grounding_refs"),
+        "novelty_audit_ref": (
+            _compact_public_text(item.get("novelty_audit_ref"), field="novelty_audit_ref")
+            if item.get("novelty_audit_ref")
+            else None
+        ),
+        "blocked_by": _compact_public_text_list(item.get("blocked_by"), field="blocked_by"),
+    }
+
+
+def validate_research_evidence_event(item: dict[str, Any]) -> dict[str, Any]:
+    schema = _compact_public_token(item.get("schema_version"), field="evidence.schema_version")
+    if schema != RESEARCH_EVIDENCE_EVENT_SCHEMA_VERSION:
+        raise ValueError(f"evidence.schema_version must be {RESEARCH_EVIDENCE_EVENT_SCHEMA_VERSION}")
+    eval_status = _compact_public_token(item.get("eval_status"), field="eval_status")
+    if eval_status not in EVIDENCE_STATUSES:
+        raise ValueError(f"eval_status must be one of {', '.join(sorted(EVIDENCE_STATUSES))}")
+    metric = _json_obj(item.get("metric"), field="evidence.metric")
+    direction = _compact_public_token(metric.get("direction"), field="evidence.metric.direction")
+    if direction not in METRIC_DIRECTIONS:
+        raise ValueError("evidence.metric.direction must be maximize or minimize")
+    return {
+        "schema_version": schema,
+        "hypothesis_id": _compact_public_token(item.get("hypothesis_id"), field="hypothesis_id"),
+        "todo_id": _compact_public_token(item.get("todo_id"), field="todo_id"),
+        "agent_id": _compact_public_token(item.get("agent_id"), field="agent_id"),
+        "attempt": int(item.get("attempt") or 1),
+        "split": _compact_public_token(item.get("split"), field="split"),
+        "metric": {
+            "name": _compact_public_token(metric.get("name"), field="evidence.metric.name"),
+            "value": _finite_float(metric.get("value"), field="evidence.metric.value"),
+            "direction": direction,
+        },
+        "baseline_metric": _finite_float(item.get("baseline_metric"), field="baseline_metric"),
+        "eval_status": eval_status,
+        "primary_metric_status": _compact_public_token(
+            item.get("primary_metric_status"),
+            field="primary_metric_status",
+        ),
+        "artifact_refs": _compact_public_text_list(item.get("artifact_refs"), field="artifact_refs"),
+        "protected_scope_clean": bool(item.get("protected_scope_clean")),
+        "raw_logs_recorded": False,
+        "private_artifacts_recorded": False,
+    }
+
+
+def build_auto_research_projection(
+    fixture: dict[str, Any],
+    *,
+    agent_id: str,
+) -> dict[str, Any]:
+    fixture = validate_auto_research_fixture(fixture)
+    agent = _compact_public_token(agent_id, field="agent_id")
+    contract = fixture["research_contract"]
+    direction = contract["metric"]["direction"]
+    baseline = contract["metric"]["baseline"]
+    hypotheses = fixture["hypotheses"]
+    events = fixture["evidence_events"]
+
+    runnable_statuses = {"active", "needs_retry"}
+    selected = None
+    blocked: list[dict[str, Any]] = []
+    runnable: list[dict[str, Any]] = []
+    for item in hypotheses:
+        item_summary = {
+            "hypothesis_id": item["hypothesis_id"],
+            "todo_id": item["todo_id"],
+            "claimed_by": item["claimed_by"],
+            "status": item["status"],
+            "mechanism_family": item["mechanism_family"],
+        }
+        if item["claimed_by"] == agent and item["status"] in runnable_statuses and not item["blocked_by"]:
+            runnable.append(item_summary | {"allowed_action": "run_dev_attempt"})
+            selected = selected or runnable[-1]
+        elif item["claimed_by"] != agent and item["status"] in runnable_statuses:
+            blocked.append(item_summary | {"blocked_by": f"claimed_by:{item['claimed_by']}"})
+        elif item["blocked_by"]:
+            blocked.append(item_summary | {"blocked_by": ",".join(item["blocked_by"])})
+
+    promotion_candidates = []
+    for item in hypotheses:
+        item_events = [event for event in events if event["hypothesis_id"] == item["hypothesis_id"]]
+        dev_best = _best_metric(item_events, split="dev", direction=direction)
+        holdout_best = _best_metric(item_events, split="holdout", direction=direction)
+        if item["status"] in {"supported", "promoted"} or _metric_improved(
+            value=dev_best,
+            baseline=baseline,
+            direction=direction,
+        ):
+            requires = ["boundary_scan"]
+            if not _metric_improved(value=holdout_best, baseline=baseline, direction=direction):
+                requires.append("holdout_eval")
+            promotion_candidates.append(
+                {
+                    "hypothesis_id": item["hypothesis_id"],
+                    "todo_id": item["todo_id"],
+                    "dev_metric": dev_best,
+                    "holdout_metric": holdout_best,
+                    "requires": requires,
+                }
+            )
+
+    frontier = {
+        "schema_version": RESEARCH_FRONTIER_SCHEMA_VERSION,
+        "goal_id": contract["goal_id"],
+        "agent_id": agent,
+        "selected": selected,
+        "runnable": runnable,
+        "blocked": blocked,
+        "promotion_candidates": promotion_candidates,
+    }
+    evidence_graph = build_research_evidence_graph(fixture)
+    showcase_projection = build_research_showcase_projection(fixture, evidence_graph=evidence_graph)
+    return {
+        "ok": True,
+        "schema_version": AUTO_RESEARCH_PROJECTION_SCHEMA_VERSION,
+        "source_schema_version": fixture["schema_version"],
+        "frontier": frontier,
+        "evidence_graph": evidence_graph,
+        "showcase_projection": showcase_projection,
+        "public_boundary": {
+            "raw_logs_recorded": False,
+            "private_artifacts_recorded": False,
+            "source": "public_fixture",
+        },
+    }
+
+
+def _best_metric(events: list[dict[str, Any]], *, split: str, direction: str) -> float | None:
+    values = [
+        event["metric"]["value"]
+        for event in events
+        if event["split"] == split and event["eval_status"] == "scored"
+    ]
+    if not values:
+        return None
+    return max(values, key=lambda value: _metric_rank_key(value, direction=direction))
+
+
+def build_research_evidence_graph(fixture: dict[str, Any]) -> dict[str, Any]:
+    contract = fixture["research_contract"]
+    direction = contract["metric"]["direction"]
+    events = fixture["evidence_events"]
+    baseline = contract["metric"]["baseline"]
+    scored_events = [event for event in events if event["eval_status"] == "scored"]
+    best_dev = _best_metric(scored_events, split="dev", direction=direction)
+    best_holdout = _best_metric(scored_events, split="holdout", direction=direction)
+    return {
+        "schema_version": RESEARCH_EVIDENCE_GRAPH_SCHEMA_VERSION,
+        "goal_id": contract["goal_id"],
+        "hypothesis_count": len(fixture["hypotheses"]),
+        "evidence_event_count": len(events),
+        "todo_ids": sorted({item["todo_id"] for item in fixture["hypotheses"]}),
+        "agent_ids": sorted({item["claimed_by"] for item in fixture["hypotheses"]}),
+        "baseline_metric": baseline,
+        "best_dev_metric": best_dev,
+        "best_holdout_metric": best_holdout,
+        "holdout_improved": _metric_improved(value=best_holdout, baseline=baseline, direction=direction),
+        "negative_evidence_count": len(
+            [
+                event
+                for event in events
+                if event["primary_metric_status"] in {"regressed", "failed", "inconclusive"}
+                or event["eval_status"] != "scored"
+            ]
+        ),
+        "needs_retry_count": len([item for item in fixture["hypotheses"] if item["status"] == "needs_retry"]),
+        "nodes": [
+            {
+                "hypothesis_id": item["hypothesis_id"],
+                "parent_hypothesis_id": item["parent_hypothesis_id"],
+                "todo_id": item["todo_id"],
+                "claimed_by": item["claimed_by"],
+                "status": item["status"],
+            }
+            for item in fixture["hypotheses"]
+        ],
+    }
+
+
+def build_research_showcase_projection(
+    fixture: dict[str, Any],
+    *,
+    evidence_graph: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    contract = fixture["research_contract"]
+    graph = evidence_graph or build_research_evidence_graph(fixture)
+    promoted = [
+        item["hypothesis_id"]
+        for item in fixture["hypotheses"]
+        if item["status"] == "promoted"
+    ]
+    retired = [
+        item["hypothesis_id"]
+        for item in fixture["hypotheses"]
+        if item["status"] in {"retired", "contradicted"}
+    ]
+    return {
+        "schema_version": RESEARCH_SHOWCASE_PROJECTION_SCHEMA_VERSION,
+        "title": "Decentralized Auto Research: k-NN Speedup",
+        "goal_id": contract["goal_id"],
+        "objective": contract["research_objective"],
+        "metric": contract["metric"],
+        "baseline_metric": graph["baseline_metric"],
+        "best_dev_metric": graph["best_dev_metric"],
+        "best_holdout_metric": graph["best_holdout_metric"],
+        "holdout_improved": graph["holdout_improved"],
+        "promoted_hypotheses": promoted,
+        "retired_or_contradicted_hypotheses": retired,
+        "negative_evidence_count": graph["negative_evidence_count"],
+        "decentralized_pattern": "todo_linked_hypotheses_agent_scoped_frontier_shared_evidence_graph",
+    }
+
+
+def render_auto_research_projection_markdown(payload: dict[str, object]) -> str:
+    if not payload.get("ok"):
+        return f"# LoopX Auto Research\n\n- ok: `False`\n- error: `{payload.get('error')}`\n"
+    frontier = payload["frontier"]  # type: ignore[index]
+    graph = payload["evidence_graph"]  # type: ignore[index]
+    showcase = payload["showcase_projection"]  # type: ignore[index]
+    selected = frontier.get("selected") if isinstance(frontier, dict) else None
+    lines = [
+        "# LoopX Auto Research Frontier",
+        "",
+        f"- schema: `{payload.get('schema_version')}`",
+        f"- agent_id: `{frontier.get('agent_id')}`",
+        f"- title: {showcase.get('title')}",
+        f"- selected: `{selected.get('hypothesis_id') if isinstance(selected, dict) else 'none'}`",
+        f"- hypotheses: `{graph.get('hypothesis_count')}`",
+        f"- evidence events: `{graph.get('evidence_event_count')}`",
+        f"- best dev metric: `{graph.get('best_dev_metric')}`",
+        f"- best holdout metric: `{graph.get('best_holdout_metric')}`",
+        f"- holdout improved: `{graph.get('holdout_improved')}`",
+    ]
+    return "\n".join(lines) + "\n"

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -21,6 +21,7 @@ from .capabilities.value_connectors.cli import (
 from .cli_commands import (
     handle_benchmark_command,
     handle_bootstrap_connect_command,
+    handle_auto_research_command,
     handle_capability_command,
     handle_check_command,
     handle_diagnose_command,
@@ -43,6 +44,7 @@ from .cli_commands import (
     handle_worker_bridge_command,
     register_benchmark_command_group,
     register_bootstrap_connect_command,
+    register_auto_research_commands,
     register_capability_commands,
     register_doctor_command,
     register_dreaming_commands,
@@ -140,6 +142,8 @@ def main(argv: list[str] | None = None) -> int:
     register_value_connector_commands(sub, add_subcommand_format)
 
     register_ml_experiment_commands(sub, add_subcommand_format)
+
+    register_auto_research_commands(sub, add_subcommand_format)
 
     register_registry_admin_commands(sub)
 
@@ -245,6 +249,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "ml-experiment":
         return handle_ml_experiment_command(args, output_format=output_format, print_payload=print_payload)
+
+    if args.command == "auto-research":
+        return handle_auto_research_command(args, output_format=output_format, print_payload=print_payload)
 
     if args.command == "content-ops":
         return handle_content_ops_command(args, output_format=output_format, print_payload=print_payload)

--- a/loopx/cli_commands/__init__.py
+++ b/loopx/cli_commands/__init__.py
@@ -44,6 +44,7 @@ from .agentissue_runner_flow import (
     handle_agentissue_runner_flow_command,
     register_agentissue_runner_flow_commands,
 )
+from .auto_research import handle_auto_research_command, register_auto_research_commands
 from .benchmark_boundary import (
     handle_benchmark_boundary_command,
     register_benchmark_boundary_commands,
@@ -169,6 +170,7 @@ __all__ = [
     "handle_agents_last_exam_task_material_command",
     "handle_agents_last_exam_validation_gate_command",
     "handle_agentissue_runner_flow_command",
+    "handle_auto_research_command",
     "handle_benchmark_boundary_command",
     "handle_benchmark_command",
     "handle_benchmark_review_lifecycle_command",
@@ -232,6 +234,7 @@ __all__ = [
     "register_agents_last_exam_task_material_commands",
     "register_agents_last_exam_validation_gate_commands",
     "register_agentissue_runner_flow_commands",
+    "register_auto_research_commands",
     "register_benchmark_boundary_commands",
     "register_benchmark_command_group",
     "register_benchmark_review_lifecycle_commands",

--- a/loopx/cli_commands/auto_research.py
+++ b/loopx/cli_commands/auto_research.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+
+from ..auto_research import (
+    build_auto_research_projection,
+    load_auto_research_fixture,
+    render_auto_research_projection_markdown,
+)
+
+
+PrintPayload = Callable[
+    [dict[str, object], str, Callable[[dict[str, object]], str]],
+    None,
+]
+FormatSelector = Callable[..., str]
+AddFormat = Callable[[argparse.ArgumentParser], None]
+
+
+def register_auto_research_commands(
+    subparsers: argparse._SubParsersAction,
+    add_subcommand_format: AddFormat,
+) -> None:
+    auto_research_parser = subparsers.add_parser(
+        "auto-research",
+        help="Project public-safe decentralized auto-research fixtures.",
+    )
+    auto_research_sub = auto_research_parser.add_subparsers(
+        dest="auto_research_command",
+        required=True,
+    )
+    frontier_parser = auto_research_sub.add_parser(
+        "frontier",
+        help="Render a per-agent decentralized research frontier from a public fixture.",
+    )
+    add_subcommand_format(frontier_parser)
+    frontier_parser.add_argument(
+        "--fixture",
+        required=True,
+        help="Path to a decentralized_auto_research_fixture_v0 JSON file.",
+    )
+    frontier_parser.add_argument(
+        "--agent-id",
+        required=True,
+        help="Agent id whose runnable frontier should be projected.",
+    )
+
+
+def handle_auto_research_command(
+    args: argparse.Namespace,
+    *,
+    output_format: FormatSelector,
+    print_payload: PrintPayload,
+) -> int:
+    try:
+        if args.auto_research_command != "frontier":
+            raise ValueError("auto-research requires the `frontier` subcommand")
+        fixture = load_auto_research_fixture(args.fixture)
+        payload = build_auto_research_projection(
+            fixture,
+            agent_id=args.agent_id,
+        )
+    except Exception as exc:
+        payload = {
+            "ok": False,
+            "mode": "auto-research",
+            "error": str(exc),
+        }
+    print_payload(payload, output_format(args), render_auto_research_projection_markdown)
+    return 0 if payload.get("ok") else 1


### PR DESCRIPTION
## Summary
- add a decentralized auto-research state protocol that maps Arbor's useful public ideas into LoopX-native source/projection state
- add a product showcase blueprint for reproducing an Arbor-style k-NN auto-research case without introducing a leader agent
- add a focused smoke that guards todo-linked hypotheses, agent-scoped frontiers, split-aware evidence, public boundary hygiene, and decentralized wording

## Validation
- python3 examples/decentralized-auto-research-protocol-smoke.py
- loopx check --scan-path docs/reference/protocols/decentralized-auto-research-state-v0.md --scan-path docs/product/decentralized-auto-research-showcase.md --scan-path examples/decentralized-auto-research-protocol-smoke.py
- git diff --cached --check && git diff --check

## Boundary
- public docs/protocol/smoke only
- no runtime behavior changes
- no private docs, raw logs, local paths, or credentials included