### PR TITLE
feat: add runnable auto-research k-NN pack

### DIFF
--- a/docs/product/decentralized-auto-research-showcase.md
+++ b/docs/product/decentralized-auto-research-showcase.md
@@ -103,7 +103,33 @@ next agent does not rediscover them from scratch.
 
 ## Minimal Reproduction Plan
 
-First fixture-backed slice:
+The runnable pack now lives at `examples/auto_research_knn_pack/`. It provides
+an editable candidate solver, a protected evaluator, deterministic dev/held-out
+splits, and a no-upload boundary.
+
+Run the candidate on the dev split:
+
+```bash
+python3 examples/auto_research_knn_pack/protected_eval.py \
+  --solution examples/auto_research_knn_pack/solution_candidate.py \
+  --split dev
+```
+
+Run the candidate on the held-out split:
+
+```bash
+python3 examples/auto_research_knn_pack/protected_eval.py \
+  --solution examples/auto_research_knn_pack/solution_candidate.py \
+  --split holdout
+```
+
+The current public pack reports exact neighbor identity with deterministic
+protected speedup `4.0x` on dev and `4.5x` on holdout for the partial-selection
+candidate. The metric is a protected ranking-work proxy rather than wall-clock
+time, so it is stable enough for smoke tests while still preserving the product
+shape: dev evidence, held-out promotion evidence, and a clean boundary.
+
+The fixture-backed projection remains the read-only showcase state slice:
 
 ```bash
 loopx --format json auto-research frontier \
@@ -118,19 +144,17 @@ can present a per-agent frontier without one leader agent.
 
 Next reproduction steps:
 
-1. Replace the fixture-only k-NN records with a small runnable benchmark pack
-   owned by LoopX.
-2. Keep `research_contract_v0`, `research_hypothesis_v0`, and
+1. Keep `research_contract_v0`, `research_hypothesis_v0`, and
    `research_evidence_event_v0` as the public-safe record boundary.
-3. Connect projection input to live todo/quota state after the fixture contract
-   is stable.
-4. Keep one local smoke that proves:
+2. Append real run outputs from the runnable pack as `research_evidence_event_v0`
+   records instead of editing fixture numbers by hand.
+3. Keep one local smoke that proves:
    - protected files are not editable;
    - each hypothesis is todo-linked;
    - each evidence event names split and metric;
    - no leader agent owns the graph;
    - held-out promotion is required.
-5. Build the showcase page from fixture evidence, then replace fixture numbers
+4. Build the showcase page from fixture evidence, then replace fixture numbers
    with a real run when available.
 
 ## Kernel/Capability Improvements

--- a/docs/reference/protocols/decentralized-auto-research-state-v0.md
+++ b/docs/reference/protocols/decentralized-auto-research-state-v0.md
@@ -248,15 +248,20 @@ Already available:
   now renders a fixture-backed `decentralized_research_frontier_v0`,
   `research_evidence_graph_v0`, and `research_showcase_projection_v0` without
   launching experiments or depending on a leader agent.
+- `loopx auto-research frontier --goal-id <goal> --agent-id <agent>` now
+  renders a live todo/quota-backed frontier for the current agent from LoopX
+  status projection.
+- `examples/auto_research_knn_pack/` now provides a runnable public k-NN pack
+  with an editable candidate solver, protected evaluator, dev/held-out splits,
+  exactness guard, deterministic speedup metric, no-upload boundary, and smoke
+  coverage.
 
 Needed next:
 
 - expose `research_hypothesis_v0` as a public-safe rollout-event subtype
   beyond fixture projection;
-- connect the frontier projection to live todo/quota status rather than only a
-  public fixture;
-- add a runnable auto-research benchmark fixture modeled on Arbor's k-NN zoo
-  task;
+- append runnable pack outputs as `research_evidence_event_v0` records through
+  a write path rather than hand-maintained fixture evidence;
 - add a showcase page that reports baseline, dev result, held-out result,
   retired directions, and LoopX's decentralized coordination pattern.
 

--- a/examples/auto-research-knn-pack-smoke.py
+++ b/examples/auto-research-knn-pack-smoke.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Smoke-test the public runnable auto-research k-NN pack."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PACK = REPO_ROOT / "examples/auto_research_knn_pack"
+EVAL = PACK / "protected_eval.py"
+BASELINE = PACK / "solution_baseline.py"
+CANDIDATE = PACK / "solution_candidate.py"
+CONTRACT = PACK / "research_contract.json"
+
+
+def run_eval(solution: Path, split: str) -> dict[str, Any]:
+    result = subprocess.run(
+        [sys.executable, str(EVAL), "--solution", str(solution), "--split", split],
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return json.loads(result.stdout)
+
+
+def assert_public_safe(payload: Any) -> None:
+    text = json.dumps(payload, sort_keys=True) if not isinstance(payload, str) else payload
+    forbidden = [
+        "/" + "Users/",
+        "/" + "private/",
+        "/" + "tmp/",
+        "lark" + "office",
+        "byte" + "dance",
+        "http://",
+        "https://",
+        "api" + "_key",
+        "pass" + "word",
+        "sec" + "ret",
+    ]
+    leaked = [needle for needle in forbidden if needle.lower() in text.lower()]
+    assert not leaked, leaked
+
+
+def main() -> None:
+    contract = json.loads(CONTRACT.read_text(encoding="utf-8"))
+    assert contract["schema_version"] == "research_contract_v0", contract
+    assert contract["editable_scope"] == ["solution_candidate.py"], contract
+    assert "protected_eval.py" in contract["protected_scope"], contract
+    assert not set(contract["editable_scope"]).intersection(contract["protected_scope"]), contract
+    assert contract["no_upload"] is True, contract
+    assert_public_safe(contract)
+
+    baseline_dev = run_eval(BASELINE, "dev")
+    candidate_dev = run_eval(CANDIDATE, "dev")
+    candidate_holdout = run_eval(CANDIDATE, "holdout")
+
+    assert baseline_dev["exact"] is True, baseline_dev
+    assert baseline_dev["metric"]["value"] == 1.0, baseline_dev
+    assert baseline_dev["promotion_gate"]["ready_for_split"] is False, baseline_dev
+
+    for payload in [candidate_dev, candidate_holdout]:
+        assert payload["schema_version"] == "auto_research_knn_eval_result_v0", payload
+        assert payload["strategy"] == "partial_selection", payload
+        assert payload["exact"] is True, payload
+        assert payload["protected_scope_clean"] is True, payload
+        assert payload["no_upload"] is True, payload
+        assert payload["eval_status"] == "scored", payload
+        assert payload["primary_metric_status"] == "improved", payload
+        assert payload["metric"]["value"] > 1.0, payload
+        assert payload["promotion_gate"]["ready_for_split"] is True, payload
+        assert_public_safe(payload)
+
+    assert candidate_holdout["metric"]["value"] >= candidate_dev["metric"]["value"], (
+        candidate_dev,
+        candidate_holdout,
+    )
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        external_solution = Path(temp_dir) / "solution_candidate.py"
+        external_solution.write_text(CANDIDATE.read_text(encoding="utf-8"), encoding="utf-8")
+        blocked = subprocess.run(
+            [sys.executable, str(EVAL), "--solution", str(external_solution), "--split", "dev"],
+            cwd=REPO_ROOT,
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        blocked_payload = json.loads(blocked.stdout)
+        assert blocked.returncode == 1, blocked_payload
+        assert blocked_payload["exact"] is True, blocked_payload
+        assert blocked_payload["protected_scope_clean"] is False, blocked_payload
+        assert_public_safe(blocked_payload)
+
+    readme = (PACK / "README.md").read_text(encoding="utf-8")
+    assert "protected evaluator" in readme, readme
+    assert "solution_candidate.py" in readme, readme
+    assert_public_safe(readme)
+
+    print("auto-research-knn-pack-smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/auto_research_knn_pack/README.md
+++ b/examples/auto_research_knn_pack/README.md
@@ -1,0 +1,50 @@
+# Auto Research k-NN Pack
+
+This public pack is a tiny LoopX-native reproduction target for decentralized
+auto research. It turns the fixture-only k-NN showcase into something an agent
+can actually run:
+
+- editable solver: `solution_candidate.py`;
+- protected evaluator and data generation: `protected_eval.py`;
+- baseline solver: `solution_baseline.py`;
+- public contract: `research_contract.json`;
+- deterministic dev and holdout splits.
+
+The task is exact brute-force k-nearest-neighbor inference. A candidate may
+change only the editable solver. The evaluator owns the data, exactness oracle,
+metric, and promotion gate.
+
+## Commands
+
+Baseline:
+
+```bash
+python3 examples/auto_research_knn_pack/protected_eval.py \
+  --solution examples/auto_research_knn_pack/solution_baseline.py \
+  --split dev
+```
+
+Candidate:
+
+```bash
+python3 examples/auto_research_knn_pack/protected_eval.py \
+  --solution examples/auto_research_knn_pack/solution_candidate.py \
+  --split holdout
+```
+
+Smoke:
+
+```bash
+python3 examples/auto-research-knn-pack-smoke.py
+```
+
+## Metric
+
+The primary metric is deterministic protected speedup. The evaluator compares
+the baseline full-sort ranking work against the candidate's declared exact
+partial-selection ranking work. It still checks exact neighbor identities on
+every query before reporting an improved score.
+
+This avoids timing flake while preserving the product point: an autonomous
+research lane can produce dev evidence, holdout evidence, negative evidence, and
+a promotion decision without a leader agent mutating the whole graph.

--- a/examples/auto_research_knn_pack/protected_eval.py
+++ b/examples/auto_research_knn_pack/protected_eval.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any
+
+
+sys.dont_write_bytecode = True
+
+SCHEMA_VERSION = "auto_research_knn_eval_result_v0"
+PACK_DIR = Path(__file__).resolve().parent
+Point = tuple[float, ...]
+
+SPLITS: dict[str, dict[str, int]] = {
+    "dev": {"seed": 17, "train_count": 256, "query_count": 18, "dims": 4, "k": 3},
+    "holdout": {"seed": 31, "train_count": 512, "query_count": 24, "dims": 4, "k": 3},
+}
+
+
+def _point(seed: int, index: int, dims: int) -> Point:
+    values = []
+    for dim in range(dims):
+        raw = (seed * (dim + 5) + index * (dim * 23 + 11) + index * index * (dim + 3)) % 997
+        values.append(raw / 97.0)
+    return tuple(values)
+
+
+def build_split(split: str) -> tuple[list[Point], list[Point], int, dict[str, int]]:
+    if split not in SPLITS:
+        raise ValueError(f"unknown split {split!r}")
+    spec = SPLITS[split]
+    train = [_point(spec["seed"], index, spec["dims"]) for index in range(spec["train_count"])]
+    queries = [
+        _point(spec["seed"] + 101, index, spec["dims"])
+        for index in range(spec["query_count"])
+    ]
+    return train, queries, spec["k"], spec
+
+
+def _squared_distance(left: Point, right: Point) -> float:
+    return sum((a - b) * (a - b) for a, b in zip(left, right))
+
+
+def oracle_knn(train: list[Point], queries: list[Point], k: int) -> list[list[int]]:
+    expected: list[list[int]] = []
+    for query in queries:
+        ranked = sorted((_squared_distance(query, point), index) for index, point in enumerate(train))
+        expected.append([index for _, index in ranked[:k]])
+    return expected
+
+
+def load_solution(path: Path) -> Any:
+    spec = importlib.util.spec_from_file_location("auto_research_knn_solution", path)
+    if spec is None or spec.loader is None:
+        raise ValueError(f"cannot load solution from {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    if not hasattr(module, "solve_knn"):
+        raise ValueError("solution must define solve_knn(train, queries, k)")
+    return module
+
+
+def ranking_work_units(strategy: str, *, train_count: int, query_count: int, k: int) -> int:
+    if strategy == "partial_selection":
+        rank_factor = max(1, math.ceil(math.log2(k + 1)))
+    else:
+        rank_factor = max(1, math.ceil(math.log2(train_count)))
+    return query_count * train_count * rank_factor
+
+
+def evaluate(solution_path: Path, split: str) -> dict[str, Any]:
+    solution_path = solution_path.resolve()
+    train, queries, k, spec = build_split(split)
+    module = load_solution(solution_path)
+    strategy = str(getattr(module, "STRATEGY", "unknown"))
+    expected = oracle_knn(train, queries, k)
+    actual = module.solve_knn(train, queries, k)
+    exact = actual == expected
+
+    baseline_units = ranking_work_units(
+        "full_sort",
+        train_count=spec["train_count"],
+        query_count=spec["query_count"],
+        k=k,
+    )
+    candidate_units = ranking_work_units(
+        strategy,
+        train_count=spec["train_count"],
+        query_count=spec["query_count"],
+        k=k,
+    )
+    speedup = baseline_units / candidate_units if exact else None
+    improved = bool(speedup is not None and speedup > 1.0)
+    protected_scope_clean = solution_path.parent == PACK_DIR and solution_path.name in {
+        "solution_baseline.py",
+        "solution_candidate.py",
+    }
+    promotion_ready = exact and improved and protected_scope_clean
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "split": split,
+        "solution": solution_path.name,
+        "strategy": strategy,
+        "dataset": {
+            "train_count": spec["train_count"],
+            "query_count": spec["query_count"],
+            "dims": spec["dims"],
+            "k": k,
+            "seed": spec["seed"],
+        },
+        "metric": {
+            "name": "deterministic_speedup",
+            "direction": "maximize",
+            "value": round(speedup, 6) if speedup is not None else None,
+            "baseline": 1.0,
+        },
+        "work_units": {
+            "baseline_full_sort": baseline_units,
+            "candidate": candidate_units,
+        },
+        "exact": exact,
+        "protected_scope_clean": protected_scope_clean,
+        "no_upload": True,
+        "eval_status": "scored" if exact else "guardrail_failed",
+        "primary_metric_status": "improved" if improved else ("baseline" if exact else "failed"),
+        "promotion_gate": {
+            "requires": [
+                "exact_neighbor_identity",
+                "dev_and_holdout_improvement",
+                "protected_scope_clean",
+                "no_upload",
+            ],
+            "ready_for_split": promotion_ready,
+        },
+        "artifact_refs": [
+            f"knn_pack:{split}:{strategy}",
+        ],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Protected evaluator for the public LoopX auto-research k-NN pack.")
+    parser.add_argument("--solution", required=True, help="Path to a solution module.")
+    parser.add_argument("--split", choices=sorted(SPLITS), required=True)
+    args = parser.parse_args()
+    payload = evaluate(Path(args.solution), args.split)
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0 if payload["exact"] and payload["protected_scope_clean"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/auto_research_knn_pack/research_contract.json
+++ b/examples/auto_research_knn_pack/research_contract.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "research_contract_v0",
+  "goal_id": "loopx-auto-research-knn",
+  "research_objective": "Improve exact k-nearest-neighbor inference under a protected evaluator.",
+  "editable_scope": [
+    "solution_candidate.py"
+  ],
+  "protected_scope": [
+    "protected_eval.py",
+    "solution_baseline.py",
+    "research_contract.json"
+  ],
+  "metric": {
+    "name": "deterministic_speedup",
+    "direction": "maximize",
+    "baseline": 1.0
+  },
+  "dev_eval": "python3 protected_eval.py --solution solution_candidate.py --split dev",
+  "holdout_eval": "python3 protected_eval.py --solution solution_candidate.py --split holdout",
+  "promotion_policy": "requires_dev_and_holdout_improvement_exactness_and_clean_boundary",
+  "no_upload": true
+}

--- a/examples/auto_research_knn_pack/solution_baseline.py
+++ b/examples/auto_research_knn_pack/solution_baseline.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+
+STRATEGY = "full_sort"
+
+
+Point = tuple[float, ...]
+
+
+def _squared_distance(left: Point, right: Point) -> float:
+    return sum((a - b) * (a - b) for a, b in zip(left, right))
+
+
+def solve_knn(train: list[Point], queries: list[Point], k: int) -> list[list[int]]:
+    """Reference exact k-NN solver using a full distance sort per query."""
+
+    results: list[list[int]] = []
+    for query in queries:
+        ranked = sorted((_squared_distance(query, point), index) for index, point in enumerate(train))
+        results.append([index for _, index in ranked[:k]])
+    return results

--- a/examples/auto_research_knn_pack/solution_candidate.py
+++ b/examples/auto_research_knn_pack/solution_candidate.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import heapq
+
+
+STRATEGY = "partial_selection"
+
+
+Point = tuple[float, ...]
+
+
+def _squared_distance(left: Point, right: Point) -> float:
+    return sum((a - b) * (a - b) for a, b in zip(left, right))
+
+
+def solve_knn(train: list[Point], queries: list[Point], k: int) -> list[list[int]]:
+    """Exact k-NN using partial selection instead of sorting every distance."""
+
+    results: list[list[int]] = []
+    for query in queries:
+        nearest = heapq.nsmallest(
+            k,
+            ((_squared_distance(query, point), index) for index, point in enumerate(train)),
+        )
+        results.append([index for _, index in nearest])
+    return results


### PR DESCRIPTION
## Summary
- add a public runnable k-NN auto-research pack with editable candidate solver, baseline solver, protected evaluator, deterministic dev/holdout splits, and research contract
- add smoke coverage for exactness, protected boundary, no-upload flag, deterministic speedup, and promotion gate behavior
- update auto-research showcase/protocol docs to mark the runnable pack and live frontier as available

## Results
- candidate dev deterministic speedup: 4.0x, exact=true
- candidate holdout deterministic speedup: 4.5x, exact=true
- external same-name solution is rejected by protected_scope_clean=false

## Validation
- python3 examples/auto-research-knn-pack-smoke.py
- python3 examples/decentralized-auto-research-frontier-smoke.py
- python3 examples/decentralized-auto-research-protocol-smoke.py
- python3 -m py_compile examples/auto_research_knn_pack/protected_eval.py examples/auto_research_knn_pack/solution_baseline.py examples/auto_research_knn_pack/solution_candidate.py examples/auto-research-knn-pack-smoke.py
- git diff --check
- loopx check --scan-path examples/auto_research_knn_pack --scan-path examples/auto-research-knn-pack-smoke.py --scan-path docs/product/decentralized-auto-research-showcase.md --scan-path docs/reference/protocols/decentralized-auto-research-state-v0.md

## Merge note
Owner authorized auto-research related self-merge. This PR only touches public docs/examples/smoke and has a clean public/private boundary scan; LoopX check warning is the pre-existing duplicate index rows.