### PR TITLE
Add local state write correctness contract

### DIFF
--- a/docs/reference/protocols/README.md
+++ b/docs/reference/protocols/README.md
@@ -22,6 +22,7 @@ Current contracts:
 - [pr_review_command_v0](pr-review-command-v0.md)
 - [event_sourced_state_contract_v0](event-sourced-state-contract-v0.md)
 - [active_state_structured_projection_v0](active-state-structured-projection-v0.md)
+- [local_state_write_correctness_v0](local-state-write-correctness-v0.md)
 - [rollback_packet_v0](rollback-packet-v0.md)
 - [content_ops_surface_v0](content-ops-surface-v0.md)
 - [x_public_channel_ops_v0](x-public-channel-ops-v0.md)

--- a/docs/reference/protocols/local-state-write-correctness-v0.md
+++ b/docs/reference/protocols/local-state-write-correctness-v0.md
@@ -1,0 +1,154 @@
+# Local State Write Correctness v0
+
+Status: public-safe protocol draft for LoopX local state writes.
+
+LoopX still keeps Markdown active state as the human and agent work surface.
+This contract defines the correctness envelope for any write that changes that
+local state or a derived local control-plane artifact. It is not a new storage
+backend. It is the common packet shape that lets future implementations add
+stronger locks, idempotent retries, optimistic revision checks, and lease
+projection without changing each writer independently.
+
+## Scope
+
+This protocol applies to local LoopX writes such as:
+
+- active-state todo add, update, complete, supersede, and archive operations;
+- `refresh-state` writes that update route, progress, or next action;
+- event-store append operations that later project into active state;
+- review packet or dashboard writeback that records compact local evidence.
+
+It does not grant permission to read private material, publish externally, run
+production actions, bypass human gates, or mutate a remote service. Those remain
+separate boundary decisions.
+
+## Correctness Model
+
+Every local write should be describable as one `write_intent`:
+
+| Field | Meaning |
+| --- | --- |
+| `write_id` | Stable id for this requested logical write. |
+| `goal_id` | The goal boundary. A writer must not lock or revise unrelated goals. |
+| `writer_id` | Registered agent, CLI command, or adapter issuing the write. |
+| `write_class` | Compact operation family such as `todo_update`, `refresh_state`, or `event_append`. |
+| `target_refs` | Goal-local refs such as `todo_id`, `run_id`, or `state_file`. |
+| `idempotency_key` | Deterministic retry key. Replaying the same key must not duplicate the logical effect. |
+| `expected_revision` | Optional optimistic revision/CAS token read before the write. |
+| `lease_ref` | Optional per-todo or per-goal lease that explains why the writer may proceed. |
+
+The lock boundary is per goal by default. A narrower per-todo lock is allowed
+when the write touches only one todo and the writer can prove that no section
+ordering, archive compaction, or shared summary update is affected.
+
+## Required Phases
+
+1. `prepare`: resolve `goal_id`, target refs, current revision, and boundary
+   policy. No write happens here.
+2. `preview`: produce a compact patch summary and safety result.
+3. `apply`: acquire the lock, re-read the revision, reject or merge on mismatch,
+   then write atomically.
+4. `record`: emit compact evidence with applied/skipped/rejected/failed status.
+5. `project`: expose the latest revision, lock boundary, and relevant lease
+   state in status/review packets without copying raw private state.
+
+## Conflict Semantics
+
+- Same `idempotency_key` and same intended effect: return `skipped_duplicate`
+  or `already_applied`.
+- Same target but different idempotency key while lock is held: wait or return
+  `lock_busy`.
+- `expected_revision` mismatch: fail closed with `revision_conflict`, unless
+  the writer can recompute a non-overlapping patch from the fresh revision.
+- Lease expired or held by a different writer: fail closed with
+  `lease_conflict`; do not silently clear another agent's claim.
+- Unsafe payload: reject with `boundary_rejected` and write no local state.
+
+## Example Packet
+
+```json
+{
+  "schema_version": "local_state_write_correctness_v0",
+  "write_intent": {
+    "write_id": "write_todo_123_complete_001",
+    "goal_id": "loopx-meta",
+    "writer_id": "codex-product-capability",
+    "write_class": "todo_update",
+    "target_refs": {
+      "todo_id": "todo_123",
+      "state_file_ref": "registry.goal.state_file"
+    },
+    "idempotency_key": "loopx-meta:todo_123:complete:write_todo_123_complete_001",
+    "expected_revision": {
+      "kind": "active_state_revision",
+      "value": "sha256:before-write"
+    },
+    "lease_ref": {
+      "kind": "todo_claim",
+      "goal_id": "loopx-meta",
+      "todo_id": "todo_123",
+      "claimed_by": "codex-product-capability",
+      "lease_id": "lease_todo_123_codex_product_capability"
+    }
+  },
+  "lock_boundary": {
+    "kind": "per_goal",
+    "lock_key": "goal:loopx-meta",
+    "narrower_lock_allowed": "per_todo_when_patch_is_single_todo_and_order_independent"
+  },
+  "preview": {
+    "mode": "dry_run",
+    "patch_summary": "mark todo_123 done and attach compact evidence",
+    "non_destructive": true,
+    "expected_write_scopes": [
+      "active_state"
+    ]
+  },
+  "apply_result": {
+    "status": "applied",
+    "applied_revision": {
+      "kind": "active_state_revision",
+      "value": "sha256:after-write"
+    },
+    "duplicate_of": null,
+    "conflict": null
+  },
+  "projection": {
+    "status_surface": "todo_123 done",
+    "lease_projection": {
+      "todo_id": "todo_123",
+      "claimed_by": "codex-product-capability",
+      "lease_state": "released_after_done"
+    },
+    "public_boundary": {
+      "raw_logs_copied": false,
+      "private_paths_copied": false,
+      "credentials_copied": false,
+      "production_action_authorized": false
+    }
+  }
+}
+```
+
+## Acceptance Checks
+
+A local-state writer is compatible with this protocol when:
+
+1. it can produce or internally derive a `write_intent` before mutation;
+2. retries with the same `idempotency_key` cannot duplicate todos, evidence, or
+   events;
+3. lock scope is at most per goal unless the operation is proven single-todo and
+   order-independent;
+4. optimistic revision mismatch fails closed or recomputes from the fresh state;
+5. lease projection never lets one agent silently steal another agent's claim;
+6. public status/review packets expose compact revision and lease state without
+   raw local files, private paths, credentials, raw logs, or raw transcripts;
+7. every destructive or external effect remains behind a separate explicit gate.
+
+## Rollout Notes
+
+The first implementation step should be non-destructive: add protocol docs and
+fixture smokes, then adapt one existing writer to emit or validate the compact
+shape in dry-run. Only after parity is proven should LoopX tighten the runtime
+write path with hard idempotency keys, optimistic revision/CAS, or per-goal
+lock metadata.

--- a/examples/local-state-write-correctness-contract-smoke.py
+++ b/examples/local-state-write-correctness-contract-smoke.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Smoke-test the local state write correctness protocol example."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PROTOCOL = REPO_ROOT / "docs" / "reference" / "protocols" / "local-state-write-correctness-v0.md"
+README = REPO_ROOT / "docs" / "reference" / "protocols" / "README.md"
+
+
+def extract_example_packet(text: str) -> dict[str, Any]:
+    marker = "## Example Packet"
+    start = text.index(marker)
+    match = re.search(r"```json\n(.*?)\n```", text[start:], re.DOTALL)
+    assert match, "Example Packet must include a JSON code block"
+    return json.loads(match.group(1))
+
+
+def require_path(packet: dict[str, Any], path: str) -> Any:
+    current: Any = packet
+    for part in path.split("."):
+        assert isinstance(current, dict) and part in current, f"missing {path}"
+        current = current[part]
+    return current
+
+
+def main() -> int:
+    text = PROTOCOL.read_text(encoding="utf-8")
+    readme = README.read_text(encoding="utf-8")
+    packet = extract_example_packet(text)
+
+    assert packet["schema_version"] == "local_state_write_correctness_v0", packet
+    assert "local_state_write_correctness_v0" in readme, "README must list the protocol"
+
+    intent = require_path(packet, "write_intent")
+    for field in (
+        "write_id",
+        "goal_id",
+        "writer_id",
+        "write_class",
+        "target_refs",
+        "idempotency_key",
+        "expected_revision",
+        "lease_ref",
+    ):
+        assert intent.get(field), f"write_intent missing {field}"
+
+    assert require_path(packet, "lock_boundary.kind") == "per_goal"
+    assert require_path(packet, "preview.mode") == "dry_run"
+    assert require_path(packet, "preview.non_destructive") is True
+    assert require_path(packet, "apply_result.status") in {
+        "applied",
+        "already_applied",
+        "skipped_duplicate",
+        "lock_busy",
+        "revision_conflict",
+        "lease_conflict",
+        "boundary_rejected",
+        "failed",
+    }
+
+    lease_projection = require_path(packet, "projection.lease_projection")
+    assert lease_projection["todo_id"] == intent["target_refs"]["todo_id"]
+    assert lease_projection["claimed_by"] == intent["lease_ref"]["claimed_by"]
+
+    boundary = require_path(packet, "projection.public_boundary")
+    for field in (
+        "raw_logs_copied",
+        "private_paths_copied",
+        "credentials_copied",
+        "production_action_authorized",
+    ):
+        assert boundary.get(field) is False, f"unsafe boundary flag {field}"
+
+    required_phrases = [
+        "idempotency_key",
+        "expected_revision",
+        "per goal",
+        "per-todo lock",
+        "lease projection",
+        "revision_conflict",
+        "boundary_rejected",
+    ]
+    compact = " ".join(text.split()).lower()
+    for phrase in required_phrases:
+        assert phrase.lower() in compact, f"protocol missing phrase: {phrase}"
+
+    print("local-state-write-correctness-contract-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds `local_state_write_correctness_v0`, a public protocol for safer LoopX local state writes before deeper runtime changes:

- defines write intent, per-goal lock boundary, idempotency key, optimistic revision/CAS, and lease projection fields;
- documents conflict semantics for duplicate retries, lock contention, revision mismatch, lease conflicts, and boundary rejection;
- adds a non-destructive smoke that parses the protocol JSON example and validates required invariants;
- lists the protocol in the protocol README.

## Validation

- `python3 examples/local-state-write-correctness-contract-smoke.py`
- `python3 examples/todo-concurrent-write-lock-smoke.py`
- `python3 examples/todo-claim-lease-roadmap-smoke.py`
- `python3 -m py_compile examples/local-state-write-correctness-contract-smoke.py`
- `git diff --check`
- `loopx check --scan-path docs/reference/protocols/local-state-write-correctness-v0.md --scan-path docs/reference/protocols/README.md --scan-path examples/local-state-write-correctness-contract-smoke.py`

`loopx check` reports the existing loopx-meta duplicate index warning only; public boundary scan is clean for the changed files.
