### PR TITLE
Add refresh-state write correctness dry-run packet

### DIFF
--- a/docs/reference/protocols/local-state-write-correctness-v0.md
+++ b/docs/reference/protocols/local-state-write-correctness-v0.md
@@ -63,6 +63,9 @@ ordering, archive compaction, or shared summary update is affected.
 - Lease expired or held by a different writer: fail closed with
   `lease_conflict`; do not silently clear another agent's claim.
 - Unsafe payload: reject with `boundary_rejected` and write no local state.
+- Dry-run preview without mutation: return `preview_only` and include the same
+  write intent, lock boundary, revision, and expected write scopes that a real
+  apply would need.
 
 ## Example Packet
 

--- a/examples/local-state-write-correctness-contract-smoke.py
+++ b/examples/local-state-write-correctness-contract-smoke.py
@@ -62,6 +62,7 @@ def main() -> int:
         "revision_conflict",
         "lease_conflict",
         "boundary_rejected",
+        "preview_only",
         "failed",
     }
 

--- a/examples/refresh-state-write-correctness-smoke.py
+++ b/examples/refresh-state-write-correctness-smoke.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Smoke-test refresh-state dry-run write correctness packets."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import loopx.state_refresh as state_refresh
+
+
+GOAL_ID = "refresh-state-write-correctness-goal"
+GENERATED_AT = "2026-01-02T00:00:00+00:00"
+
+
+def write_fixture(root: Path) -> tuple[Path, Path, Path]:
+    project = root / "project"
+    runtime = root / "runtime"
+    state_file = f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    state_path = project / state_file
+    registry_path = project / ".loopx" / "registry.json"
+
+    state_path.parent.mkdir(parents=True)
+    state_path.write_text(
+        "---\n"
+        "status: active\n"
+        "owner_mode: goal\n"
+        'objective: "Preview refresh-state write correctness."\n'
+        "updated_at: 2026-01-02T00:00:00+00:00\n"
+        "---\n\n"
+        "# Refresh State Write Correctness Fixture\n\n"
+        "## Next Action\n\n"
+        "- Keep the current route stable.\n",
+        encoding="utf-8",
+    )
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "updated_at": GENERATED_AT,
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "refresh-state-write-correctness-fixture",
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": state_file,
+                        "adapter": {"kind": "fixture", "status": "connected-read-only"},
+                        "authority_sources": [],
+                    }
+                ],
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return registry_path, runtime, project
+
+
+def dry_run_payload(registry_path: Path, runtime: Path, project: Path) -> dict:
+    return state_refresh.refresh_state_run(
+        registry_path=registry_path,
+        runtime_root_override=str(runtime),
+        goal_id=GOAL_ID,
+        project=project,
+        state_file=None,
+        classification="state_refreshed",
+        recommended_action="preview refresh-state correctness packet",
+        next_action="Review the dry-run packet before writing local state.",
+        delivery_batch_scale="single_surface",
+        delivery_outcome="surface_only",
+        dry_run=True,
+        sync_global=False,
+    )
+
+
+def main() -> None:
+    original_now_local = state_refresh.now_local
+    try:
+        state_refresh.now_local = lambda: GENERATED_AT
+        with tempfile.TemporaryDirectory(prefix="loopx-refresh-write-correctness-") as raw_tmp:
+            registry_path, runtime, project = write_fixture(Path(raw_tmp))
+            first = dry_run_payload(registry_path, runtime, project)
+            second = dry_run_payload(registry_path, runtime, project)
+
+            assert first["dry_run"] is True, first
+            assert first["appended"] is False, first
+            packet = first.get("local_state_write_correctness")
+            assert isinstance(packet, dict), first
+            assert packet["schema_version"] == "local_state_write_correctness_v0", packet
+
+            intent = packet["write_intent"]
+            assert intent["goal_id"] == GOAL_ID, packet
+            assert intent["writer_id"] == "loopx.refresh-state", packet
+            assert intent["write_class"] == "refresh_state", packet
+            assert intent["target_refs"]["state_file_ref"] == "registry.goal.state_file", packet
+            assert intent["target_refs"]["run_history_ref"] == "runtime.goal.runs", packet
+            assert intent["target_refs"]["global_registry_ref"] is None, packet
+            expected_revision = "sha256:" + hashlib.sha256(
+                (project / f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md").read_text(
+                    encoding="utf-8"
+                ).encode("utf-8")
+            ).hexdigest()
+            assert intent["expected_revision"]["value"] == expected_revision, packet
+            assert (
+                intent["idempotency_key"]
+                == second["local_state_write_correctness"]["write_intent"]["idempotency_key"]
+            )
+
+            preview = packet["preview"]
+            assert preview["mode"] == "dry_run", packet
+            assert preview["non_destructive"] is True, packet
+            assert preview["expected_write_scopes"] == ["active_state", "runtime_history"], packet
+            assert "append refresh-state run" in preview["patch_summary"], packet
+
+            assert packet["lock_boundary"]["kind"] == "per_goal", packet
+            assert packet["apply_result"]["status"] == "preview_only", packet
+            boundary = packet["projection"]["public_boundary"]
+            assert boundary == {
+                "raw_logs_copied": False,
+                "private_paths_copied": False,
+                "credentials_copied": False,
+                "production_action_authorized": False,
+            }, packet
+            assert str(project) not in json.dumps(packet, ensure_ascii=False), packet
+
+            markdown = state_refresh.render_state_refresh_markdown(first)
+            assert "local_state_write_correctness" in markdown, markdown
+            assert "status=preview_only" in markdown, markdown
+    finally:
+        state_refresh.now_local = original_now_local
+
+    print("refresh-state-write-correctness-smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/local_state_write_correctness.py
+++ b/loopx/local_state_write_correctness.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+
+LOCAL_STATE_WRITE_CORRECTNESS_SCHEMA_VERSION = "local_state_write_correctness_v0"
+
+
+def active_state_revision(state_text: str) -> dict[str, str]:
+    return {
+        "kind": "active_state_revision",
+        "value": "sha256:" + hashlib.sha256(state_text.encode("utf-8")).hexdigest(),
+    }
+
+
+def stable_write_digest(payload: dict[str, Any]) -> str:
+    encoded = json.dumps(
+        payload,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def build_local_state_write_correctness_dry_run_packet(
+    *,
+    goal_id: str,
+    writer_id: str,
+    write_class: str,
+    state_text: str,
+    target_refs: dict[str, Any],
+    patch_summary: str,
+    expected_write_scopes: list[str],
+    lease_ref: dict[str, Any] | None = None,
+    projection_status_surface: str | None = None,
+) -> dict[str, Any]:
+    """Build the dry-run correctness envelope for a local state writer.
+
+    The packet uses logical refs rather than local absolute paths so it can be
+    safely projected by status/review surfaces. Callers remain responsible for
+    the actual lock, write, and rollout-event behavior.
+    """
+
+    intent_seed = {
+        "goal_id": goal_id,
+        "writer_id": writer_id,
+        "write_class": write_class,
+        "target_refs": target_refs,
+        "patch_summary": patch_summary,
+        "expected_write_scopes": expected_write_scopes,
+        "lease_ref": lease_ref,
+    }
+    digest = stable_write_digest(intent_seed)
+    write_id = f"write_{write_class}_{digest[:16]}"
+    return {
+        "schema_version": LOCAL_STATE_WRITE_CORRECTNESS_SCHEMA_VERSION,
+        "write_intent": {
+            "write_id": write_id,
+            "goal_id": goal_id,
+            "writer_id": writer_id,
+            "write_class": write_class,
+            "target_refs": target_refs,
+            "idempotency_key": f"{goal_id}:{write_class}:{digest}",
+            "expected_revision": active_state_revision(state_text),
+            "lease_ref": lease_ref,
+        },
+        "lock_boundary": {
+            "kind": "per_goal",
+            "lock_key": f"goal:{goal_id}",
+            "narrower_lock_allowed": "not_for_refresh_state",
+        },
+        "preview": {
+            "mode": "dry_run",
+            "patch_summary": patch_summary,
+            "non_destructive": True,
+            "expected_write_scopes": expected_write_scopes,
+        },
+        "apply_result": {
+            "status": "preview_only",
+            "applied_revision": None,
+            "duplicate_of": None,
+            "conflict": None,
+        },
+        "projection": {
+            "status_surface": projection_status_surface or patch_summary,
+            "lease_projection": None,
+            "public_boundary": {
+                "raw_logs_copied": False,
+                "private_paths_copied": False,
+                "credentials_copied": False,
+                "production_action_authorized": False,
+            },
+        },
+    }

--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -13,6 +13,7 @@ from .feedback import validate_public_safe_text
 from .file_lock import exclusive_file_lock
 from .global_registry import sync_project_registry_to_global
 from .history import load_registry, reserve_unique_run_paths, unique_run_paths
+from .local_state_write_correctness import build_local_state_write_correctness_dry_run_packet
 from .paths import resolve_runtime_root
 from .registry import registry_goals, resolve_state_file
 from .runtime import validate_goal_id_path_segment
@@ -533,6 +534,27 @@ def render_state_refresh_markdown(payload: dict[str, Any]) -> str:
                 f"- active_state_next_action: {next_action_update.get('next_action')}"
             )
 
+    write_correctness = (
+        payload.get("local_state_write_correctness")
+        if isinstance(payload.get("local_state_write_correctness"), dict)
+        else {}
+    )
+    if write_correctness:
+        intent = write_correctness.get("write_intent") if isinstance(write_correctness.get("write_intent"), dict) else {}
+        preview = write_correctness.get("preview") if isinstance(write_correctness.get("preview"), dict) else {}
+        apply_result = (
+            write_correctness.get("apply_result")
+            if isinstance(write_correctness.get("apply_result"), dict)
+            else {}
+        )
+        lines.append(
+            "- local_state_write_correctness: "
+            f"schema={write_correctness.get('schema_version')} "
+            f"write_class={intent.get('write_class')} "
+            f"status={apply_result.get('status')} "
+            f"non_destructive={preview.get('non_destructive')}"
+        )
+
     global_sync = payload.get("global_sync") if isinstance(payload.get("global_sync"), dict) else {}
     if global_sync:
         lines.extend(
@@ -624,12 +646,14 @@ def refresh_state_run(
     if not resolved_state_file.exists():
         raise FileNotFoundError(f"state file does not exist: {resolved_state_file}")
     state_text = resolved_state_file.read_text(encoding="utf-8")
+    expected_write_state_text = state_text
     normalized_next_action = normalize_next_action_text(next_action) if next_action else None
     generated_at = now_local()
     active_state_next_action_update: dict[str, Any] | None = None
     if normalized_next_action:
         with exclusive_file_lock(resolved_state_file):
             locked_state_text = resolved_state_file.read_text(encoding="utf-8")
+            expected_write_state_text = locked_state_text
             updated_state_text, state_updated = replace_next_action_section(
                 locked_state_text,
                 next_action=normalized_next_action,
@@ -754,6 +778,36 @@ def refresh_state_run(
         "index_path": str(index_path),
         **record,
     }
+    if dry_run:
+        expected_write_scopes = ["runtime_history"]
+        if active_state_next_action_update and active_state_next_action_update.get("would_update"):
+            expected_write_scopes.insert(0, "active_state")
+        if sync_global:
+            expected_write_scopes.append("global_registry")
+        patch_parts = [f"append refresh-state run classification={classification}"]
+        if active_state_next_action_update:
+            if active_state_next_action_update.get("would_update"):
+                patch_parts.append("preview active-state Next Action update")
+            else:
+                patch_parts.append("preserve active-state Next Action")
+        if sync_global:
+            patch_parts.append("sync public-safe registry projection")
+        payload["local_state_write_correctness"] = build_local_state_write_correctness_dry_run_packet(
+            goal_id=safe_goal_id,
+            writer_id=normalized_agent_id or "loopx.refresh-state",
+            write_class="refresh_state",
+            state_text=expected_write_state_text,
+            target_refs={
+                "state_file_ref": "registry.goal.state_file",
+                "run_history_ref": "runtime.goal.runs",
+                "index_ref": "runtime.goal.runs.index",
+                "global_registry_ref": "runtime.registry.global" if sync_global else None,
+            },
+            patch_summary="; ".join(patch_parts),
+            expected_write_scopes=expected_write_scopes,
+            lease_ref=None,
+            projection_status_surface=f"refresh-state dry-run: {classification}",
+        )
     if not dry_run:
         runs_dir.mkdir(parents=True, exist_ok=True)
         json_path, markdown_path = reserve_unique_run_paths(runs_dir, generated_at)


### PR DESCRIPTION
## Summary
- add a reusable `local_state_write_correctness_v0` dry-run packet builder
- attach the packet to `refresh-state --dry-run` so one existing local-state writer now exposes write intent, lock boundary, expected revision, expected write scopes, and safety projection
- keep real refresh-state writes unchanged; the packet is dry-run-only in this slice
- extend the protocol with `preview_only` for non-mutating previews and add a focused refresh-state writer smoke

## Validation
- python3 examples/refresh-state-write-correctness-smoke.py
- python3 examples/local-state-write-correctness-contract-smoke.py
- python3 examples/refresh-state-agent-lane-scope-smoke.py
- python3 examples/refresh-state-unique-run-path-smoke.py
- python3 examples/state-projection-gap-smoke.py
- PYTHONPATH=. python3 -m loopx.cli --format json refresh-state --goal-id loopx-meta --classification state_refreshed --recommended-action "preview refresh-state local write correctness packet" --delivery-batch-scale single_surface --delivery-outcome surface_only --dry-run --no-global-sync
- python3 -m py_compile loopx/local_state_write_correctness.py loopx/state_refresh.py examples/refresh-state-write-correctness-smoke.py examples/local-state-write-correctness-contract-smoke.py
- git diff --check
- loopx check --scan-path loopx/local_state_write_correctness.py --scan-path loopx/state_refresh.py --scan-path examples/refresh-state-write-correctness-smoke.py --scan-path examples/local-state-write-correctness-contract-smoke.py --scan-path docs/reference/protocols/local-state-write-correctness-v0.md

## Boundary
Public boundary scan clean for touched files. Literal scan only hit explicit protocol safety flags such as credentials_copied=false and production_action_authorized=false.