### PR TITLE
Extract outcome followthrough policy helper

### DIFF
--- a/examples/outcome-followthrough-policy-smoke.py
+++ b/examples/outcome-followthrough-policy-smoke.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.policies.outcome_followthrough import build_outcome_followthrough_hint
+
+
+def assert_none(latest_run: dict[str, object] | None) -> None:
+    assert build_outcome_followthrough_hint(latest_run) is None
+
+
+def assert_hint(
+    latest_run: dict[str, object],
+    *,
+    outcome: str | None,
+    turn_kind: str,
+) -> None:
+    hint = build_outcome_followthrough_hint(latest_run)
+    assert hint is not None
+    assert hint == {
+        "source": "post_handoff_latest_run",
+        "required": True,
+        "latest_classification": str(latest_run.get("classification") or "").strip(),
+        "latest_delivery_outcome": outcome,
+        "latest_delivery_turn_kind": turn_kind,
+        "obligation": "advance_primary_outcome_or_write_blocker",
+        "accepted_resolution_kinds": [
+            "product_path_execution",
+            "compact_evidence",
+            "blocker_writeback",
+        ],
+        "spend_policy": (
+            "do not spend for another contract/preparation-only slice; spend only "
+            "after validated product-path evidence, benchmark/case evidence, or a "
+            "precise blocker writeback"
+        ),
+    }
+
+
+def main() -> None:
+    assert_none(None)
+    assert_none({})
+    assert_none({"delivery_outcome": "primary_goal_outcome", "classification": "done"})
+    assert_none(
+        {
+            "classification": "blocked by owner gate",
+            "recommended_action": "cannot proceed until review",
+        }
+    )
+
+    assert_hint(
+        {"delivery_outcome": "surface_only", "classification": "policy smoke"},
+        outcome="surface_only",
+        turn_kind="contract_only_preparation",
+    )
+    assert_hint(
+        {"delivery_outcome": "outcome_gap", "classification": "needs product evidence"},
+        outcome="outcome_gap",
+        turn_kind="outcome_gap",
+    )
+    assert_hint(
+        {
+            "outcome_followthrough_required": True,
+            "classification": "blocked but explicitly requires followthrough",
+        },
+        outcome=None,
+        turn_kind="blocker_writeback",
+    )
+    assert_hint(
+        {"classification": "contract-only preparation"},
+        outcome=None,
+        turn_kind="contract_only_preparation",
+    )
+    print("outcome-followthrough-policy-smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/policies/outcome_followthrough.py
+++ b/loopx/policies/outcome_followthrough.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from typing import Any
+
+from ..delivery_outcome import (
+    DeliveryOutcome,
+    DeliveryTurnKind,
+    FOLLOWTHROUGH_REQUIRED_DELIVERY_OUTCOMES,
+    delivery_turn_kind_for_run,
+    normalize_delivery_outcome,
+)
+
+
+def build_outcome_followthrough_hint(
+    latest_run: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Build the follow-through obligation for a post-handoff latest run.
+
+    The helper intentionally preserves the quota payload shape. It only moves
+    the policy decision out of the quota builder so future rule changes can be
+    tested without touching the broader status/quota extraction path.
+    """
+
+    if not isinstance(latest_run, dict) or not latest_run:
+        return None
+
+    explicit_required = latest_run.get("outcome_followthrough_required") is True
+    delivery_outcome = normalize_delivery_outcome(latest_run.get("delivery_outcome"))
+    delivery_turn_kind = delivery_turn_kind_for_run(
+        latest_run,
+        delivery_outcome=delivery_outcome,
+    )
+    if delivery_outcome == DeliveryOutcome.PRIMARY_GOAL_OUTCOME:
+        return None
+    if (
+        not explicit_required
+        and delivery_turn_kind == DeliveryTurnKind.BLOCKER_WRITEBACK.value
+    ):
+        return None
+
+    classification = str(latest_run.get("classification") or "").strip()
+    kind_requires_followthrough = (
+        delivery_turn_kind == DeliveryTurnKind.CONTRACT_ONLY_PREPARATION.value
+    )
+    if (
+        not explicit_required
+        and delivery_outcome not in FOLLOWTHROUGH_REQUIRED_DELIVERY_OUTCOMES
+        and not kind_requires_followthrough
+    ):
+        return None
+
+    return {
+        "source": "post_handoff_latest_run",
+        "required": True,
+        "latest_classification": classification,
+        "latest_delivery_outcome": delivery_outcome.value if delivery_outcome else None,
+        "latest_delivery_turn_kind": delivery_turn_kind,
+        "obligation": "advance_primary_outcome_or_write_blocker",
+        "accepted_resolution_kinds": [
+            DeliveryTurnKind.PRODUCT_PATH_EXECUTION.value,
+            DeliveryTurnKind.COMPACT_EVIDENCE.value,
+            DeliveryTurnKind.BLOCKER_WRITEBACK.value,
+        ],
+        "spend_policy": (
+            "do not spend for another contract/preparation-only slice; spend only "
+            "after validated product-path evidence, benchmark/case evidence, or a "
+            "precise blocker writeback"
+        ),
+    }

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -21,9 +21,6 @@ from .control_plane import (
 from .delivery_outcome import (
     ACCOUNTABLE_DELIVERY_OUTCOMES,
     DeliveryOutcome,
-    FOLLOWTHROUGH_REQUIRED_DELIVERY_OUTCOMES,
-    DeliveryTurnKind,
-    delivery_turn_kind_for_run,
     normalize_delivery_outcome,
 )
 from .execution_profile import (
@@ -33,6 +30,7 @@ from .execution_profile import (
 )
 from .long_task_cadence import long_task_cadence_hint_summary
 from .orchestration import compact_orchestration_policy, orchestration_policy_summary
+from .policies.outcome_followthrough import build_outcome_followthrough_hint
 from .policies.scheduler_hint import build_scheduler_hint
 from .policies.work_lane import (
     WORK_LANE_CONTRACT_SCHEMA_VERSION,
@@ -481,50 +479,7 @@ def _post_handoff_latest_run(item: dict[str, Any]) -> dict[str, Any]:
 
 
 def _outcome_followthrough_hint(item: dict[str, Any]) -> dict[str, Any] | None:
-    latest_run = _post_handoff_latest_run(item)
-    if not latest_run:
-        return None
-    explicit_required = latest_run.get("outcome_followthrough_required") is True
-    delivery_outcome = normalize_delivery_outcome(latest_run.get("delivery_outcome"))
-    delivery_turn_kind = delivery_turn_kind_for_run(
-        latest_run,
-        delivery_outcome=delivery_outcome,
-    )
-    if delivery_outcome == DeliveryOutcome.PRIMARY_GOAL_OUTCOME:
-        return None
-    if (
-        not explicit_required
-        and delivery_turn_kind == DeliveryTurnKind.BLOCKER_WRITEBACK.value
-    ):
-        return None
-    classification = str(latest_run.get("classification") or "").strip()
-    kind_requires_followthrough = (
-        delivery_turn_kind == DeliveryTurnKind.CONTRACT_ONLY_PREPARATION.value
-    )
-    if (
-        not explicit_required
-        and delivery_outcome not in FOLLOWTHROUGH_REQUIRED_DELIVERY_OUTCOMES
-        and not kind_requires_followthrough
-    ):
-        return None
-    return {
-        "source": "post_handoff_latest_run",
-        "required": True,
-        "latest_classification": classification,
-        "latest_delivery_outcome": delivery_outcome.value if delivery_outcome else None,
-        "latest_delivery_turn_kind": delivery_turn_kind,
-        "obligation": "advance_primary_outcome_or_write_blocker",
-        "accepted_resolution_kinds": [
-            DeliveryTurnKind.PRODUCT_PATH_EXECUTION.value,
-            DeliveryTurnKind.COMPACT_EVIDENCE.value,
-            DeliveryTurnKind.BLOCKER_WRITEBACK.value,
-        ],
-        "spend_policy": (
-            "do not spend for another contract/preparation-only slice; spend only "
-            "after validated product-path evidence, benchmark/case evidence, or a "
-            "precise blocker writeback"
-        ),
-    }
+    return build_outcome_followthrough_hint(_post_handoff_latest_run(item))
 
 
 def _work_lane_contract(


### PR DESCRIPTION
## Summary
- Extract the outcome-followthrough hint policy from quota.py into a pure helper under loopx/policies/.
- Keep quota.py as a thin extraction wrapper so the emitted payload shape stays unchanged.
- Add a focused smoke covering primary-goal no-op, blocker filtering, explicit follow-through, surface-only, and outcome-gap cases.

## Validation
- python3 examples/outcome-followthrough-policy-smoke.py
- python3 examples/work-lane-contract-smoke.py
- python3 examples/quota-plan-smoke.py
- python3 examples/heartbeat-quota-flow-smoke.py
- python3 -m py_compile loopx/quota.py loopx/policies/outcome_followthrough.py examples/outcome-followthrough-policy-smoke.py
- git diff --check
- loopx check --scan-path loopx/quota.py --scan-path loopx/policies/outcome_followthrough.py --scan-path examples/outcome-followthrough-policy-smoke.py

## Boundary
Public-safe runtime refactor plus durable smoke only. No private docs, raw benchmark logs, credentials, local state, or generated artifacts.