### PR TITLE
Define auto-research lane contract

### DIFF
--- a/docs/product/decentralized-auto-research-showcase.md
+++ b/docs/product/decentralized-auto-research-showcase.md
@@ -45,6 +45,16 @@ The important product phrase is:
 > the control plane, and each agent receives only the frontier it is allowed to
 > attempt.
 
+The executable product contract is split in two:
+
+- `decentralized_auto_research_state_v0` defines the records and projections:
+  contracts, todo-linked hypotheses, evidence events, frontier, evidence graph,
+  and showcase projection.
+- `auto_research_lane_contract_v1` defines decentralized lanes: curator,
+  hypothesis proposer, executor, evaluator/promoter, and product narrator. Each
+  lane contributes typed records through claims and gates; none owns the whole
+  graph.
+
 ## Showcase Candidate
 
 **Title:** Decentralized Auto Research: k-NN Speedup

--- a/docs/reference/protocols/README.md
+++ b/docs/reference/protocols/README.md
@@ -18,6 +18,7 @@ Current contracts:
 - [todo_detail_cold_path_v0](todo-detail-cold-path-v0.md)
 - [long_horizon_agent_state_protocol_v0](long-horizon-agent-state-protocol-v0.md)
 - [decentralized_auto_research_state_v0](decentralized-auto-research-state-v0.md)
+- [auto_research_lane_contract_v1](auto-research-lane-contract-v1.md)
 - [global_manager_command_v0](global-manager-command-v0.md)
 - [pr_review_command_v0](pr-review-command-v0.md)
 - [event_sourced_state_contract_v0](event-sourced-state-contract-v0.md)

--- a/docs/reference/protocols/auto-research-lane-contract-v1.md
+++ b/docs/reference/protocols/auto-research-lane-contract-v1.md
@@ -1,0 +1,135 @@
+# auto_research_lane_contract_v1
+
+`auto_research_lane_contract_v1` defines how LoopX runs auto research with
+several independent agent lanes over one shared control plane. It is a role and
+capability contract, not a new coordinator service.
+
+The contract answers one product question: how can a user get an Arbor-style
+research loop while LoopX stays decentralized?
+
+## Design Principles
+
+- The source of truth is the LoopX graph: todos, claims, rollout events,
+  evidence packets, gates, and read-only projections.
+- Lanes contribute typed records. They do not own the full research tree.
+- Selection is local to the requesting agent through
+  `quota should-run --agent-id ...`.
+- Promotion is a policy decision over evidence, not a persuasive summary.
+- Advisory lanes may shape hypotheses, but only evidence lanes can promote or
+  retire hypotheses.
+
+## Lane Roles
+
+| Role | Capability token | Primary contribution | Writes | Must not |
+| --- | --- | --- | --- | --- |
+| Curator | `research_curator` | Defines or refreshes the public-safe research contract, benchmark pack, metric, protected scope, and novelty boundary. | `research_contract_v0`, domain pack metadata, grounding refs. | Select winners, edit protected evaluators, or own executor queues. |
+| Hypothesis proposer | `hypothesis_proposer` | Proposes grounded, todo-backed hypotheses and parent-child refinements. | `research_hypothesis_v0`, agent todos, grounding refs. | Claim novelty from the same material used for ideation. |
+| Executor | `research_executor` | Runs one claimed hypothesis in an isolated worktree and produces split-aware results. | branch refs, eval result projections, `auto_research_evidence_packet_v0`. | Mutate protected scope, promote results, or hide failed attempts. |
+| Evaluator / promoter | `evaluator_promoter` | Converts scored attempts into promotion, retry, or retirement candidates under the contract policy. | `research_evidence_event_v0`, promotion or retirement candidate projections, gate todos. | Treat dev-only lift as promoted evidence or bypass owner gates. |
+| Product narrator | `product_narrator` | Renders the public-safe case story from projections for Frontstage/showcase surfaces. | `research_showcase_projection_v0`, public docs, screenshots after first-screen review when needed. | Invent metrics, read private source bodies, or mutate source state. |
+
+No lane is privileged. A single Codex session may implement more than one role
+when it has the matching todo claim and boundary, but the graph must still show
+which capability produced which record.
+
+## Lane Claim Packet
+
+Each lane action should be representable as a compact claim packet. This packet
+can live in a todo metadata projection, a rollout event detail, or a future
+kernel API, but it must remain public-safe.
+
+```json
+{
+  "schema_version": "auto_research_lane_claim_v1",
+  "goal_id": "loopx-auto-research-knn",
+  "lane_role": "research_executor",
+  "agent_id": "codex-side-bypass",
+  "todo_id": "todo_auto_research_pack_001",
+  "hypothesis_id": "hyp_pack_partial_selection",
+  "capability_token": "research_executor",
+  "allowed_actions": ["run_dev_attempt", "run_holdout_attempt", "write_evidence_packet"],
+  "write_scope": ["examples/auto_research_knn_pack/**"],
+  "blocked_by": []
+}
+```
+
+The claim packet is not a lock on the full graph. It only explains why this
+agent may take the next bounded action.
+
+## Source And Projection Flow
+
+```mermaid
+flowchart LR
+  Contract["research_contract_v0"]
+  Todo["todo_item_v0 claim"]
+  Hypothesis["research_hypothesis_v0"]
+  Evidence["research_evidence_event_v0"]
+  Graph["research_evidence_graph_v0"]
+  Frontier["decentralized_research_frontier_v0"]
+  Showcase["research_showcase_projection_v0"]
+
+  Contract --> Hypothesis
+  Todo --> Hypothesis
+  Hypothesis --> Evidence
+  Evidence --> Graph
+  Graph --> Frontier
+  Graph --> Showcase
+```
+
+The graph can be rendered as a tree, but it is not owned by a tree manager. A
+lane appends or updates the smallest source record it is authorized to touch;
+projection builders derive frontiers and product views afterward.
+
+## Capability Rules
+
+1. A `research_curator` may create or amend `research_contract_v0` only inside
+   allowed docs/example scopes and with protected scope explicitly named.
+2. A `hypothesis_proposer` may create a hypothesis only when it is backed by an
+   agent todo and has `claimed_by`, `todo_id`, `mechanism_family`, and
+   grounding refs or a clear no-grounding reason.
+3. A `research_executor` may run only the hypothesis selected by current
+   agent-scoped quota or an explicitly claimed successor todo.
+4. An `evaluator_promoter` may promote only when dev evidence, held-out
+   evidence, clean boundary, and required gates are present.
+5. A `product_narrator` may publish only from `research_showcase_projection_v0`
+   and related public-safe refs; first-screen public surface changes still obey
+   the first-screen review gate.
+
+## Gates
+
+| Gate | Applies to | Required signal |
+| --- | --- | --- |
+| Protected boundary gate | Executor and promoter | `protected_scope_clean=true`, no protected file edits. |
+| Held-out gate | Promoter | Held-out metric improves under the contract direction. |
+| Novelty gate | Promoter or narrator | Independent novelty audit ref when claiming research novelty. |
+| Owner gate | Promoter or public narrator | Explicit user/controller gate when merge, publication, or private boundary requires one. |
+| First-screen gate | Product narrator | Preview before changing first viewport, hero, primary CTA, or opening nav. |
+
+## Promotion And Retirement
+
+Promotion and retirement are both useful outcomes:
+
+- promotion candidate: supported or promoted hypothesis with public-safe dev
+  evidence, required holdout/boundary checks, and a todo/branch/evidence ref;
+- retirement candidate: contradicted or retired hypothesis, negative evidence,
+  guardrail failure, or repeated retry exhaustion;
+- retry candidate: unscored but resumable attempt with a branch/ref and
+  `needs_retry` evidence.
+
+The product board should show all three. The user should see which result is
+worth merging, which direction saved future search time by failing clearly, and
+which attempt needs another bounded executor turn.
+
+## Acceptance Checks
+
+An implementation satisfies this lane contract when:
+
+- every lane role above is present as a named capability;
+- every executable hypothesis has `todo_id`, `claimed_by`, and agent-scoped
+  quota selection;
+- promotion and retirement candidates are derived from
+  `research_evidence_graph_v0`, not fixture-only prose;
+- grounded ideation and novelty audit remain separate lanes;
+- no public surface needs a leader or coordinator agent to explain ownership;
+- public docs and projections contain no raw logs, private paths, credentials,
+  internal documents, or raw protected evaluator material.

--- a/docs/reference/protocols/decentralized-auto-research-state-v0.md
+++ b/docs/reference/protocols/decentralized-auto-research-state-v0.md
@@ -49,6 +49,13 @@ LoopX should preserve these product lessons, not Arbor's centralized topology.
 Source state is writable only through LoopX lifecycle commands, project-owned
 state files, or future narrow kernel APIs.
 
+The companion
+[`auto_research_lane_contract_v1`](auto-research-lane-contract-v1.md) defines
+which decentralized agent lanes may create, execute, evaluate, promote, retire,
+or narrate these records. This file defines the record shapes and projections;
+the lane contract defines capability ownership without introducing a leader
+agent.
+
 | Source state | Existing or proposed anchor | Purpose |
 | --- | --- | --- |
 | `research_contract_v0` | proposed packet, registry goal metadata | Public-safe objective, editable scope, protected scope, metric direction, dev/held-out commands, budget, and stopping condition. |
@@ -267,14 +274,17 @@ Already available:
   `research_hypothesis` event plus one `research_evidence` event per split.
   Re-running the same packet skips existing event ids, so heartbeat retries do
   not duplicate evidence.
+- `loopx auto-research frontier --goal-id <goal> --agent-id <agent>` reads
+  `research_hypothesis` and `research_evidence` rollout events back into
+  `research_evidence_graph_v0` and derives promotion/retirement candidates for
+  the live frontier and showcase projection.
 
 Needed next:
 
-- read `research_hypothesis` and `research_evidence` rollout events back into
-  `research_evidence_graph_v0` so live frontier/product surfaces no longer need
-  fixture-only evidence;
-- add a showcase page that reports baseline, dev result, held-out result,
-  retired directions, and LoopX's decentralized coordination pattern.
+- render the lane contract, per-agent frontier, promotion candidates, retirement
+  candidates, and retry candidates in a non-first-screen product board;
+- add a public showcase page that reports baseline, dev result, held-out
+  result, retired directions, and LoopX's decentralized coordination pattern.
 
 ## Acceptance Checks
 

--- a/examples/decentralized-auto-research-protocol-smoke.py
+++ b/examples/decentralized-auto-research-protocol-smoke.py
@@ -14,6 +14,8 @@ import re
 
 ROOT = Path(__file__).resolve().parents[1]
 PROTOCOL = ROOT / "docs/reference/protocols/decentralized-auto-research-state-v0.md"
+LANE_CONTRACT = ROOT / "docs/reference/protocols/auto-research-lane-contract-v1.md"
+PROTOCOL_README = ROOT / "docs/reference/protocols/README.md"
 BLUEPRINT = ROOT / "docs/product/decentralized-auto-research-showcase.md"
 
 
@@ -42,9 +44,12 @@ def _assert_public_safe(text: str, label: str) -> None:
 
 def main() -> None:
     protocol = _read(PROTOCOL)
+    lane_contract = _read(LANE_CONTRACT)
+    protocol_readme = _read(PROTOCOL_README)
     blueprint = _read(BLUEPRINT)
-    combined = protocol + "\n" + blueprint
+    combined = protocol + "\n" + lane_contract + "\n" + protocol_readme + "\n" + blueprint
     compact_protocol = re.sub(r"\s+", " ", protocol)
+    compact_lane_contract = re.sub(r"\s+", " ", lane_contract)
 
     _assert_public_safe(combined, "decentralized auto-research docs")
 
@@ -66,6 +71,31 @@ def main() -> None:
     for term in required_protocol_terms:
         assert term in protocol, f"protocol missing {term!r}"
     assert "No agent owns the whole research tree" in compact_protocol
+    assert "auto_research_lane_contract_v1" in protocol
+    assert "auto_research_lane_contract_v1" in protocol_readme
+
+    required_lane_terms = [
+        "auto_research_lane_contract_v1",
+        "research_curator",
+        "hypothesis_proposer",
+        "research_executor",
+        "evaluator_promoter",
+        "product_narrator",
+        "auto_research_lane_claim_v1",
+        "research_contract_v0",
+        "research_hypothesis_v0",
+        "auto_research_evidence_packet_v0",
+        "research_evidence_event_v0",
+        "research_evidence_graph_v0",
+        "research_showcase_projection_v0",
+        "quota should-run --agent-id",
+        "first-screen review gate",
+    ]
+    for term in required_lane_terms:
+        assert term in lane_contract, f"lane contract missing {term!r}"
+    assert "No lane is privileged" in compact_lane_contract
+    assert "not a lock on the full graph" in compact_lane_contract
+    assert "no public surface needs a leader or coordinator agent" in compact_lane_contract
 
     required_blueprint_terms = [
         "Decentralized Auto Research: k-NN Speedup",
@@ -75,6 +105,12 @@ def main() -> None:
         "Evidence timeline",
         "Promotion decision",
         "no leader agent owns the graph",
+        "auto_research_lane_contract_v1",
+        "curator",
+        "hypothesis proposer",
+        "executor",
+        "evaluator/promoter",
+        "product narrator",
     ]
     for term in required_blueprint_terms:
         assert term in blueprint, f"blueprint missing {term!r}"


### PR DESCRIPTION
## Summary
- add `auto_research_lane_contract_v1` for decentralized auto-research roles and capability boundaries
- connect the lane contract to the existing auto-research state protocol and product showcase blueprint
- extend the protocol smoke so the docs stay LoopX-native, public-safe, and non-leader-agent based

## Validation
- `python3 -m py_compile examples/decentralized-auto-research-protocol-smoke.py`
- `python3 examples/decentralized-auto-research-protocol-smoke.py`
- `git diff --check`
- `loopx check --scan-path docs/reference/protocols/auto-research-lane-contract-v1.md --scan-path docs/reference/protocols/README.md --scan-path docs/reference/protocols/decentralized-auto-research-state-v0.md --scan-path docs/product/decentralized-auto-research-showcase.md --scan-path examples/decentralized-auto-research-protocol-smoke.py`
