### PR TITLE
Add todo write correctness dry-run packets

### DIFF
--- a/examples/todo-write-correctness-smoke.py
+++ b/examples/todo-write-correctness-smoke.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Smoke-test todo add/update dry-run write correctness packets."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GOAL_ID = "todo-write-correctness-goal"
+AGENT_ID = "codex-product-capability"
+TODO_TEXT = "Preview a todo write correctness packet before mutating state."
+
+
+def write_fixture(root: Path) -> tuple[Path, Path, Path]:
+    project = root / "project"
+    runtime = root / "runtime"
+    state_file = project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+    registry_path = project / ".loopx" / "registry.json"
+    state_file.parent.mkdir(parents=True)
+    state_file.write_text(
+        "---\n"
+        "status: active\n"
+        "updated_at: 2026-01-01T00:00:00+00:00\n"
+        "---\n\n"
+        "# Todo Write Correctness Fixture\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] Existing todo for update preview.\n"
+        "  <!-- loopx:todo todo_id=todo_existing status=open task_class=advancement_task -->\n",
+        encoding="utf-8",
+    )
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "todo-write-correctness-fixture",
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md",
+                        "adapter": {"kind": "generic_project_goal_v0", "status": "connected"},
+                        "authority_sources": [],
+                        "coordination": {
+                            "registered_agents": ["codex-main-control", AGENT_ID],
+                            "primary_agent": "codex-main-control",
+                        },
+                    }
+                ],
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return registry_path, state_file, project
+
+
+def run_cli(registry_path: Path, *args: str, as_json: bool = True) -> dict | str:
+    command = [
+        sys.executable,
+        "-m",
+        "loopx.cli",
+        "--registry",
+        str(registry_path),
+    ]
+    if as_json:
+        command.extend(["--format", "json"])
+    command.extend(args)
+    result = subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return json.loads(result.stdout) if as_json else result.stdout
+
+
+def assert_packet(
+    payload: dict,
+    *,
+    state_file: Path,
+    project: Path,
+    write_class: str,
+    todo_id: str,
+    claimed_by: str | None,
+) -> dict:
+    packet = payload.get("local_state_write_correctness")
+    assert isinstance(packet, dict), payload
+    assert packet["schema_version"] == "local_state_write_correctness_v0", packet
+    assert str(project) not in json.dumps(packet, ensure_ascii=False), packet
+
+    intent = packet["write_intent"]
+    assert intent["goal_id"] == GOAL_ID, packet
+    assert intent["writer_id"] == "loopx.todo", packet
+    assert intent["write_class"] == write_class, packet
+    assert intent["target_refs"]["state_file_ref"] == "registry.goal.state_file", packet
+    assert intent["target_refs"]["todo_id"] == todo_id, packet
+    assert intent["expected_revision"]["value"] == "sha256:" + hashlib.sha256(
+        state_file.read_text(encoding="utf-8").encode("utf-8")
+    ).hexdigest(), packet
+    assert intent["idempotency_key"].startswith(f"{GOAL_ID}:{write_class}:"), packet
+
+    assert packet["lock_boundary"] == {
+        "kind": "per_goal",
+        "lock_key": f"goal:{GOAL_ID}",
+        "narrower_lock_allowed": "per_todo_when_patch_is_single_todo_and_order_independent",
+    }, packet
+    assert packet["preview"]["mode"] == "dry_run", packet
+    assert packet["preview"]["non_destructive"] is True, packet
+    assert packet["preview"]["expected_write_scopes"] == ["active_state"], packet
+    assert packet["apply_result"]["status"] == "preview_only", packet
+    boundary = packet["projection"]["public_boundary"]
+    assert boundary == {
+        "raw_logs_copied": False,
+        "private_paths_copied": False,
+        "credentials_copied": False,
+        "production_action_authorized": False,
+    }, packet
+
+    if claimed_by:
+        assert intent["lease_ref"]["todo_id"] == todo_id, packet
+        assert intent["lease_ref"]["claimed_by"] == claimed_by, packet
+        assert packet["projection"]["lease_projection"] == {
+            "todo_id": todo_id,
+            "claimed_by": claimed_by,
+            "lease_state": "preview_only",
+        }, packet
+    else:
+        assert intent["lease_ref"] is None, packet
+        assert packet["projection"]["lease_projection"] is None, packet
+    return packet
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="loopx-todo-write-correctness-") as tmp:
+        registry_path, state_file, project = write_fixture(Path(tmp))
+        original = state_file.read_text(encoding="utf-8")
+
+        add_dry_run = run_cli(
+            registry_path,
+            "todo",
+            "add",
+            "--goal-id",
+            GOAL_ID,
+            "--role",
+            "agent",
+            "--text",
+            TODO_TEXT,
+            "--claimed-by",
+            AGENT_ID,
+            "--dry-run",
+        )
+        add_dry_run_repeat = run_cli(
+            registry_path,
+            "todo",
+            "add",
+            "--goal-id",
+            GOAL_ID,
+            "--role",
+            "agent",
+            "--text",
+            TODO_TEXT,
+            "--claimed-by",
+            AGENT_ID,
+            "--dry-run",
+        )
+        assert add_dry_run["dry_run"] is True, add_dry_run
+        assert add_dry_run["added"] is True, add_dry_run
+        assert state_file.read_text(encoding="utf-8") == original
+        add_packet = assert_packet(
+            add_dry_run,
+            state_file=state_file,
+            project=project,
+            write_class="todo_add",
+            todo_id=add_dry_run["todo_id"],
+            claimed_by=AGENT_ID,
+        )
+        repeat_packet = add_dry_run_repeat["local_state_write_correctness"]
+        assert (
+            add_packet["write_intent"]["idempotency_key"]
+            == repeat_packet["write_intent"]["idempotency_key"]
+        )
+
+        add_markdown = run_cli(
+            registry_path,
+            "todo",
+            "add",
+            "--goal-id",
+            GOAL_ID,
+            "--role",
+            "agent",
+            "--text",
+            TODO_TEXT,
+            "--dry-run",
+            as_json=False,
+        )
+        assert "## Local State Write Correctness" in add_markdown, add_markdown
+        assert "status: `preview_only`" in add_markdown, add_markdown
+
+        real_add = run_cli(
+            registry_path,
+            "todo",
+            "add",
+            "--goal-id",
+            GOAL_ID,
+            "--role",
+            "agent",
+            "--text",
+            TODO_TEXT,
+        )
+        assert real_add["dry_run"] is False, real_add
+        assert "local_state_write_correctness" not in real_add, real_add
+
+        update_dry_run = run_cli(
+            registry_path,
+            "todo",
+            "update",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            "todo_existing",
+            "--claimed-by",
+            AGENT_ID,
+            "--note",
+            "Preview update without writing state.",
+            "--dry-run",
+        )
+        assert update_dry_run["dry_run"] is True, update_dry_run
+        assert update_dry_run["changed"] is True, update_dry_run
+        assert_packet(
+            update_dry_run,
+            state_file=state_file,
+            project=project,
+            write_class="todo_update",
+            todo_id="todo_existing",
+            claimed_by=AGENT_ID,
+        )
+        assert "Preview update without writing state." not in state_file.read_text(
+            encoding="utf-8"
+        )
+
+    print("todo-write-correctness-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/local_state_write_correctness.py
+++ b/loopx/local_state_write_correctness.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from typing import Any
 
 
@@ -35,6 +36,8 @@ def build_local_state_write_correctness_dry_run_packet(
     patch_summary: str,
     expected_write_scopes: list[str],
     lease_ref: dict[str, Any] | None = None,
+    lease_projection: dict[str, Any] | None = None,
+    narrower_lock_allowed: str | None = None,
     projection_status_surface: str | None = None,
 ) -> dict[str, Any]:
     """Build the dry-run correctness envelope for a local state writer.
@@ -70,7 +73,7 @@ def build_local_state_write_correctness_dry_run_packet(
         "lock_boundary": {
             "kind": "per_goal",
             "lock_key": f"goal:{goal_id}",
-            "narrower_lock_allowed": "not_for_refresh_state",
+            "narrower_lock_allowed": narrower_lock_allowed or "not_for_refresh_state",
         },
         "preview": {
             "mode": "dry_run",
@@ -86,7 +89,7 @@ def build_local_state_write_correctness_dry_run_packet(
         },
         "projection": {
             "status_surface": projection_status_surface or patch_summary,
-            "lease_projection": None,
+            "lease_projection": lease_projection,
             "public_boundary": {
                 "raw_logs_copied": False,
                 "private_paths_copied": False,
@@ -95,3 +98,72 @@ def build_local_state_write_correctness_dry_run_packet(
             },
         },
     }
+
+
+def _todo_lease_ref(
+    *,
+    goal_id: str,
+    todo_id: str | None,
+    claimed_by: str | None,
+) -> dict[str, str] | None:
+    if not todo_id or not claimed_by:
+        return None
+    safe_todo_id = re.sub(r"[^A-Za-z0-9_]+", "_", todo_id).strip("_") or "todo"
+    safe_claimed_by = re.sub(r"[^A-Za-z0-9_]+", "_", claimed_by).strip("_") or "agent"
+    return {
+        "kind": "todo_claim",
+        "goal_id": goal_id,
+        "todo_id": todo_id,
+        "claimed_by": claimed_by,
+        "lease_id": f"lease_{safe_todo_id}_{safe_claimed_by}",
+    }
+
+
+def _todo_lease_projection(lease_ref: dict[str, str] | None) -> dict[str, str] | None:
+    if not lease_ref:
+        return None
+    return {
+        "todo_id": lease_ref["todo_id"],
+        "claimed_by": lease_ref["claimed_by"],
+        "lease_state": "preview_only",
+    }
+
+
+def build_todo_write_correctness_dry_run_packet(
+    *,
+    goal_id: str,
+    write_class: str,
+    state_text: str,
+    todo_id: str | None,
+    role: str | None,
+    section: str | None,
+    claimed_by: str | None,
+    changed: bool,
+) -> dict[str, Any]:
+    target = todo_id or "new_todo"
+    role_text = role or "unknown_role"
+    effect = "would change active state" if changed else "would leave active state unchanged"
+    patch_summary = f"preview {write_class} for {role_text} todo {target}: {effect}"
+    lease_ref = _todo_lease_ref(
+        goal_id=goal_id,
+        todo_id=todo_id,
+        claimed_by=claimed_by,
+    )
+    return build_local_state_write_correctness_dry_run_packet(
+        goal_id=goal_id,
+        writer_id="loopx.todo",
+        write_class=write_class,
+        state_text=state_text,
+        target_refs={
+            "state_file_ref": "registry.goal.state_file",
+            "todo_id": todo_id,
+            "role": role,
+            "section": section,
+        },
+        patch_summary=patch_summary,
+        expected_write_scopes=["active_state"],
+        lease_ref=lease_ref,
+        lease_projection=_todo_lease_projection(lease_ref),
+        narrower_lock_allowed="per_todo_when_patch_is_single_todo_and_order_independent",
+        projection_status_surface=patch_summary,
+    )

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -12,6 +12,7 @@ from .agent_registry import (
 )
 from .file_lock import exclusive_file_lock
 from .history import load_registry
+from .local_state_write_correctness import build_todo_write_correctness_dry_run_packet
 from .state_refresh import now_local, resolve_goal_state
 from .status import (
     MAX_ACTIVE_DONE_TODOS_BEFORE_ARCHIVE,
@@ -81,6 +82,37 @@ TODO_METADATA_FIELDS = (
     "updated_at",
     "superseded_by",
 )
+
+
+def _attach_todo_write_correctness_dry_run_packet(
+    payload: dict[str, Any],
+    *,
+    goal_id: str,
+    write_class: str,
+    state_text: str,
+) -> dict[str, Any]:
+    if not payload.get("dry_run"):
+        return payload
+    todo_id = normalize_todo_id(str(payload.get("todo_id") or "")) or None
+    claimed_by = normalize_todo_claimed_by(payload.get("claimed_by"))
+    changed = bool(
+        payload.get("changed")
+        or payload.get("added")
+        or payload.get("metadata_updated")
+        or payload.get("completed")
+        or payload.get("superseded")
+    )
+    payload["local_state_write_correctness"] = build_todo_write_correctness_dry_run_packet(
+        goal_id=goal_id,
+        write_class=write_class,
+        state_text=state_text,
+        todo_id=todo_id,
+        role=str(payload.get("role") or ""),
+        section=str(payload.get("section") or ""),
+        claimed_by=claimed_by,
+        changed=changed,
+    )
+    return payload
 TODO_PRIORITY_PREFIX_PATTERN = re.compile(r"^\[(P[0-4])\]\s+", re.IGNORECASE)
 MONITOR_CADENCE_PATTERN = re.compile(
     r"^\s*(?P<count>[1-9][0-9]{0,4})\s*"
@@ -915,7 +947,7 @@ def add_goal_todo(
         if (added or metadata_updated) and not dry_run:
             resolved_state_file.write_text(new_text, encoding="utf-8")
 
-    return {
+    payload = {
         "ok": True,
         "dry_run": dry_run,
         "added": added,
@@ -944,6 +976,12 @@ def add_goal_todo(
         "project": str(resolved_project) if resolved_project else None,
         "updated_at": updated_at if added or metadata_updated else None,
     }
+    return _attach_todo_write_correctness_dry_run_packet(
+        payload,
+        goal_id=goal_id,
+        write_class="todo_add",
+        state_text=original,
+    )
 
 
 def resolve_todo_state(
@@ -1252,7 +1290,8 @@ def update_goal_todo(
             new_text = replace_updated_at(new_text, updated_at)
         if changed and not dry_run:
             resolved_state_file.write_text(new_text, encoding="utf-8")
-    return {
+    write_class = "todo_claim" if claim_only else "todo_update"
+    payload = {
         "ok": True,
         "dry_run": dry_run,
         "changed": changed,
@@ -1263,6 +1302,12 @@ def update_goal_todo(
         "project": str(resolved_project) if resolved_project else None,
         "updated_at": updated_at if changed else None,
     }
+    return _attach_todo_write_correctness_dry_run_packet(
+        payload,
+        goal_id=goal_id,
+        write_class=write_class,
+        state_text=original,
+    )
 
 
 def complete_goal_todo(
@@ -1771,4 +1816,24 @@ def render_todo_markdown(payload: dict[str, Any]) -> str:
     elif "todo" in payload:
         marker = todo_marker_for_status(payload.get("status") or TODO_STATUS_OPEN)
         lines.extend(["", "## Todo", "", f"- [{marker}] {payload.get('todo')}"])
+    correctness = payload.get("local_state_write_correctness")
+    if isinstance(correctness, dict):
+        intent = correctness.get("write_intent") if isinstance(correctness.get("write_intent"), dict) else {}
+        apply_result = (
+            correctness.get("apply_result")
+            if isinstance(correctness.get("apply_result"), dict)
+            else {}
+        )
+        lines.extend(
+            [
+                "",
+                "## Local State Write Correctness",
+                "",
+                f"- schema_version: `{correctness.get('schema_version')}`",
+                f"- write_id: `{intent.get('write_id')}`",
+                f"- write_class: `{intent.get('write_class')}`",
+                f"- idempotency_key: `{intent.get('idempotency_key')}`",
+                f"- status: `{apply_result.get('status')}`",
+            ]
+        )
     return "\n".join(lines)


### PR DESCRIPTION
## Summary
- Add todo add/update dry-run `local_state_write_correctness_v0` packets with stable idempotency key, active-state revision, per-goal lock boundary, and optional todo claim lease projection.
- Keep real todo writes unchanged; the packet is attached only when `dry_run=True`.
- Keep todo command markdown readable by surfacing the packet write id/class/status, and add a focused smoke for add/update previews.

## Validation
- python3 examples/todo-write-correctness-smoke.py
- python3 examples/refresh-state-write-correctness-smoke.py
- python3 examples/local-state-write-correctness-contract-smoke.py
- python3 examples/todo-cli-smoke.py
- python3 examples/todo-lifecycle-cli-smoke.py
- python3 examples/todo-concurrent-write-lock-smoke.py
- python3 -m py_compile loopx/todos.py loopx/local_state_write_correctness.py examples/todo-write-correctness-smoke.py
- git diff --check
- loopx check --scan-path loopx/local_state_write_correctness.py --scan-path loopx/todos.py --scan-path examples/todo-write-correctness-smoke.py

## Boundary
Public-safe local runtime/control-plane contract only. No private docs, raw logs, credentials, production actions, benchmark trajectories, or local state artifacts.