### PR TITLE
Add auto-research Frontstage board

### DIFF
--- a/apps/dashboard/smoke/frontstage-route-smoke.ts
+++ b/apps/dashboard/smoke/frontstage-route-smoke.ts
@@ -24,6 +24,7 @@ function sourceBetween(source: string, start: string, end: string, label: string
 
 const routerSource = readFileSync("src/router.tsx", "utf8");
 const mainSource = readFileSync("src/main.tsx", "utf8");
+const frontstageAutoResearchSource = readFileSync("src/views/frontstage-auto-research-page.tsx", "utf8");
 const frontstageDeveloperSource = readFileSync("src/views/frontstage-developer-page.tsx", "utf8");
 const frontstageSource = readFileSync("src/views/frontstage-page.tsx", "utf8");
 const stylesSource = readFileSync("src/styles.css", "utf8");
@@ -31,6 +32,7 @@ const dataSource = readFileSync("src/data/goal-channel-frontstage.ts", "utf8");
 const localStatusQuerySource = readFileSync("src/data/local-status-query.ts", "utf8");
 const statusSource = readFileSync("src/data/status.ts", "utf8");
 const catalogSource = readFileSync("../../docs/showcases/showcase-catalog.json", "utf8");
+const autoResearchBoardSource = readFileSync("../../docs/product/auto-research-frontstage-board.public.json", "utf8");
 const rolloutProjectionFixtureSource = readFileSync("../../examples/fixtures/frontstage-rollout-projections.public.json", "utf8");
 const privateTrapFixtureSource = readFileSync("../../examples/fixtures/frontstage-private-status-trap.public.json", "utf8");
 const readmeSource = readFileSync("README.md", "utf8");
@@ -42,6 +44,9 @@ includes(routerSource, "component: FrontstagePage", "frontstage route component"
 includes(routerSource, 'path: "/frontstage/developer"', "frontstage developer route path");
 includes(routerSource, "component: FrontstageDeveloperPage", "frontstage developer route component");
 includes(routerSource, "frontstageDeveloperRoute", "frontstage developer route export");
+includes(routerSource, 'path: "/frontstage/auto-research"', "frontstage auto-research route path");
+includes(routerSource, "component: FrontstageAutoResearchPage", "frontstage auto-research route component");
+includes(routerSource, "frontstageAutoResearchRoute", "frontstage auto-research route export");
 includes(routerSource, "frontstageSearchSchema", "frontstage search schema");
 includes(routerSource, 'mode: z.enum(["showcase", "developer", "ops"]).optional().default("showcase")', "frontstage mode gate");
 includes(routerSource, 'todoLane: z.enum(["all", "user", "agent"]).optional().default("all")', "frontstage todo lane filter search param");
@@ -54,6 +59,40 @@ includes(privateTrapFixtureSource, "GH_FAKE_PRIVATE_PLAN_SUMMARY_ALPHA", "fake-p
 includes(privateTrapFixtureSource, "GH_FAKE_LIVE_STATUS_FEED_BETA", "fake-private live status trap marker");
 includes(privateTrapFixtureSource, "GH_FAKE_PRIVATE_TODO_GAMMA", "fake-private todo trap marker");
 includes(packageSource, '"@tanstack/react-query"', "TanStack Query dependency");
+
+const autoResearchBoard = JSON.parse(autoResearchBoardSource);
+assert(
+  autoResearchBoard.schema_version === "auto_research_frontstage_board_v0",
+  "auto-research board schema version",
+);
+assert(autoResearchBoard.surface.stage === "experimental", "auto-research board remains experimental");
+assert(autoResearchBoard.lane_contract.topology === "decentralized", "auto-research decentralized topology");
+assert(autoResearchBoard.value_metrics.length >= 4, "auto-research board must expose user-value metrics");
+assert(
+  autoResearchBoard.evidence_graph.best_holdout_metric > autoResearchBoard.evidence_graph.metric.baseline,
+  "auto-research board must surface held-out improvement",
+);
+assert(
+  autoResearchBoard.decision_candidates.promotion_candidates.length >= 1,
+  "auto-research board promotion candidate",
+);
+assert(
+  autoResearchBoard.decision_candidates.retirement_candidates.length >= 1,
+  "auto-research board retirement candidate",
+);
+for (const forbidden of [
+  "/Users/",
+  "/private/",
+  "/tmp/",
+  "lark" + "office",
+  "byte" + "dance",
+  "Bearer ",
+  "api_key",
+  "password",
+  "secret",
+]) {
+  excludes(autoResearchBoardSource, forbidden, `auto-research board private marker ${forbidden}`);
+}
 
 includes(mainSource, "QueryClientProvider", "TanStack Query provider");
 includes(mainSource, "new QueryClient", "query client construction");
@@ -376,6 +415,24 @@ includes(readmeSource, "read-only projection", "README read-only projection boun
 includes(readmeSource, "write authority", "README write authority boundary");
 includes(selectionSource, "Multica", "Multica benchmark note");
 includes(selectionSource, "agent board", "agent board benchmark note");
+
+includes(frontstageAutoResearchSource, 'data-testid="frontstage-auto-research-board"', "auto-research board route test id");
+includes(frontstageAutoResearchSource, "autoResearchBoardData", "auto-research board JSON import");
+includes(frontstageAutoResearchSource, "auto-research-frontstage-board.public.json", "auto-research board public fixture");
+includes(frontstageAutoResearchSource, 'data-testid="auto-research-value-metrics"', "auto-research value metrics");
+includes(frontstageAutoResearchSource, 'data-testid="auto-research-contract-commands"', "auto-research runnable command strip");
+includes(frontstageAutoResearchSource, 'data-testid="auto-research-lane-contract"', "auto-research lane contract");
+includes(frontstageAutoResearchSource, 'data-testid="auto-research-frontier"', "auto-research per-agent frontier");
+includes(frontstageAutoResearchSource, 'data-testid="auto-research-evidence-graph"', "auto-research evidence graph");
+includes(frontstageAutoResearchSource, 'data-testid="auto-research-decision-candidates"', "auto-research decision candidates");
+includes(frontstageAutoResearchSource, 'data-testid="auto-research-showcase-projection"', "auto-research showcase projection");
+includes(autoResearchBoardSource, "single leader agent owns the whole hypothesis tree", "auto-research hidden leader anti-pattern");
+includes(autoResearchBoardSource, "Public fixture and protected-evaluator outputs only", "auto-research public boundary");
+includes(frontstageAutoResearchSource, "BoardPanel", "auto-research board panel component");
+excludes(frontstageAutoResearchSource, "<form", "auto-research board write form");
+excludes(frontstageAutoResearchSource, "method=", "auto-research board form method");
+excludes(frontstageAutoResearchSource, "fetchFrontstageStatusPayload", "auto-research board live status dependency");
+excludes(frontstageAutoResearchSource, "statusUrl", "auto-research board status URL dependency");
 
 includes(frontstageDeveloperSource, 'data-testid="frontstage-developer-cockpit"', "developer cockpit route test id");
 includes(frontstageDeveloperSource, "LoopX Projection Developer Cockpit", "developer cockpit title");

--- a/apps/dashboard/src/router.tsx
+++ b/apps/dashboard/src/router.tsx
@@ -7,6 +7,7 @@ import {
 import { z } from "zod";
 
 import { DashboardPage } from "./views/dashboard-page";
+import { FrontstageAutoResearchPage } from "./views/frontstage-auto-research-page";
 import { FrontstageDeveloperPage } from "./views/frontstage-developer-page";
 import { FrontstagePage } from "./views/frontstage-page";
 
@@ -55,7 +56,18 @@ export const frontstageDeveloperRoute = createRoute({
   component: FrontstageDeveloperPage,
 });
 
-const routeTree = rootRoute.addChildren([dashboardRoute, frontstageRoute, frontstageDeveloperRoute]);
+export const frontstageAutoResearchRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/frontstage/auto-research",
+  component: FrontstageAutoResearchPage,
+});
+
+const routeTree = rootRoute.addChildren([
+  dashboardRoute,
+  frontstageRoute,
+  frontstageDeveloperRoute,
+  frontstageAutoResearchRoute,
+]);
 
 function routerBasepathFromViteBase(baseUrl: string) {
   if (!baseUrl || baseUrl === "/" || baseUrl === "./") {

--- a/apps/dashboard/src/views/frontstage-auto-research-page.tsx
+++ b/apps/dashboard/src/views/frontstage-auto-research-page.tsx
@@ -1,0 +1,538 @@
+import {
+  ArrowRight,
+  Bot,
+  CheckCircle2,
+  GitBranch,
+  LayoutDashboard,
+  Network,
+  ShieldCheck,
+  Sparkles,
+  Target,
+  Trophy,
+} from "lucide-react";
+
+import autoResearchBoardData from "../../../../docs/product/auto-research-frontstage-board.public.json";
+import { Badge } from "../components/ui/badge";
+
+type BoardTone = "neutral" | "success" | "warning" | "info" | "danger";
+
+type BoardCommand = {
+  label: string;
+  command: string;
+};
+
+type BoardMetric = {
+  label: string;
+  value: string;
+  baseline: string;
+  interpretation: string;
+  source: string;
+};
+
+type BoardLane = {
+  role_id: string;
+  display_name: string;
+  agent_id: string;
+  responsibility: string;
+  produces: string[];
+  does_not_own: string;
+};
+
+type BoardFrontierItem = {
+  hypothesis_id: string;
+  todo_id: string;
+  mechanism_family: string;
+  next_action?: string;
+  allowed_action?: string;
+  status?: string;
+  why_selected?: string;
+  blocked_by?: string;
+  operator_value?: string;
+};
+
+type BoardEvidenceNode = {
+  hypothesis_id: string;
+  status: string;
+  summary: string;
+  best_dev_metric: number | null;
+  best_holdout_metric: number | null;
+  evidence_boundary: string;
+};
+
+type BoardEvidenceEdge = {
+  from: string;
+  to: string;
+  label: string;
+};
+
+type BoardDecisionCandidate = {
+  hypothesis_id: string;
+  todo_id: string;
+  decision: string;
+  dev_metric?: string;
+  holdout_metric?: string;
+  requires?: string[];
+  reason?: string;
+  user_value?: string;
+};
+
+type AutoResearchBoard = {
+  schema_version: "auto_research_frontstage_board_v0";
+  generated_at: string;
+  surface: {
+    id: string;
+    title: string;
+    subtitle: string;
+    stage: string;
+    positioning: string;
+    public_boundary: string;
+  };
+  research_contract: {
+    goal_id: string;
+    objective: string;
+    editable_scope: string[];
+    protected_scope: string[];
+    metric: {
+      name: string;
+      direction: string;
+      baseline: string;
+    };
+    promotion_policy: string;
+    commands: BoardCommand[];
+  };
+  value_metrics: BoardMetric[];
+  lane_contract: {
+    topology: string;
+    anti_pattern: string;
+    lanes: BoardLane[];
+  };
+  frontier: {
+    agent_id: string;
+    selected: BoardFrontierItem;
+    runnable: BoardFrontierItem[];
+    blocked: BoardFrontierItem[];
+  };
+  evidence_graph: {
+    schema_version: string;
+    goal_id: string;
+    metric: {
+      name: string;
+      direction: string;
+      baseline: number;
+    };
+    best_dev_metric: number;
+    best_holdout_metric: number;
+    holdout_improved: boolean;
+    source_kind: string;
+    nodes: BoardEvidenceNode[];
+    edges: BoardEvidenceEdge[];
+  };
+  decision_candidates: {
+    promotion_candidates: BoardDecisionCandidate[];
+    retry_candidates: BoardDecisionCandidate[];
+    retirement_candidates: BoardDecisionCandidate[];
+  };
+  showcase_projection: {
+    schema_version: string;
+    title: string;
+    primary_claim: string;
+    audience_takeaway: string;
+    public_demo_path: string;
+    next_product_step: string;
+  };
+  quality_gates: string[];
+};
+
+const board = autoResearchBoardData as AutoResearchBoard;
+
+function statusTone(status: string): BoardTone {
+  if (["supported", "promote_after_boundary_scan"].includes(status)) {
+    return "success";
+  }
+  if (["active", "retry_with_executor_lane"].includes(status)) {
+    return "info";
+  }
+  if (["contradicted", "retire_until_exactness_proof"].includes(status)) {
+    return "warning";
+  }
+  return "neutral";
+}
+
+function metricValue(value: number | null) {
+  return value === null ? "not scored" : `${value.toFixed(1)}x`;
+}
+
+function BoardPanel({
+  children,
+  eyebrow,
+  title,
+}: {
+  children: React.ReactNode;
+  eyebrow?: string;
+  title: string;
+}) {
+  return (
+    <section className="rounded-lg border border-zinc-800 bg-zinc-950/80 shadow-sm">
+      <div className="border-b border-zinc-800 px-5 py-4">
+        {eyebrow ? (
+          <div className="mb-2 font-mono text-xs font-semibold uppercase tracking-normal text-sky-300">{eyebrow}</div>
+        ) : null}
+        <h2 className="text-lg font-semibold text-zinc-50">{title}</h2>
+      </div>
+      <div className="p-5">{children}</div>
+    </section>
+  );
+}
+
+function ValueMetrics() {
+  return (
+    <section className="grid gap-3 md:grid-cols-2 xl:grid-cols-4" data-testid="auto-research-value-metrics">
+      {board.value_metrics.map((metric) => (
+        <article className="rounded-lg border border-zinc-800 bg-zinc-950 p-4" key={metric.label}>
+          <div className="flex items-center justify-between gap-3">
+            <div className="text-sm font-semibold text-zinc-300">{metric.label}</div>
+            <Trophy className="h-4 w-4 text-amber-300" />
+          </div>
+          <div className="mt-3 text-3xl font-semibold text-zinc-50">{metric.value}</div>
+          <div className="mt-1 text-xs text-zinc-500">{metric.baseline}</div>
+          <p className="mt-4 text-sm leading-6 text-zinc-400">{metric.interpretation}</p>
+          <div className="mt-4 font-mono text-xs text-zinc-500">{metric.source}</div>
+        </article>
+      ))}
+    </section>
+  );
+}
+
+function ResearchContractPanel() {
+  return (
+    <BoardPanel eyebrow={board.research_contract.goal_id} title="Research Contract">
+      <div className="grid gap-4 xl:grid-cols-[1.1fr_0.9fr]">
+        <div>
+          <p className="text-base leading-7 text-zinc-300">{board.research_contract.objective}</p>
+          <div className="mt-5 grid gap-3 sm:grid-cols-3">
+            <div className="rounded-md border border-zinc-800 bg-zinc-900/70 p-3">
+              <div className="text-xs font-semibold uppercase tracking-normal text-zinc-500">Metric</div>
+              <div className="mt-2 text-sm font-semibold text-zinc-100">{board.research_contract.metric.name}</div>
+              <div className="mt-1 text-xs text-zinc-500">
+                {board.research_contract.metric.direction} from {board.research_contract.metric.baseline}
+              </div>
+            </div>
+            <div className="rounded-md border border-emerald-900/80 bg-emerald-950/20 p-3">
+              <div className="text-xs font-semibold uppercase tracking-normal text-emerald-300">Editable</div>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {board.research_contract.editable_scope.map((item) => (
+                  <Badge key={item} variant="success">{item}</Badge>
+                ))}
+              </div>
+            </div>
+            <div className="rounded-md border border-rose-900/80 bg-rose-950/20 p-3">
+              <div className="text-xs font-semibold uppercase tracking-normal text-rose-300">Protected</div>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {board.research_contract.protected_scope.map((item) => (
+                  <Badge key={item} variant="danger">{item}</Badge>
+                ))}
+              </div>
+            </div>
+          </div>
+          <div className="mt-4 rounded-md border border-zinc-800 bg-zinc-900/60 p-3 text-sm leading-6 text-zinc-300">
+            <span className="font-semibold text-zinc-100">Promotion policy: </span>
+            {board.research_contract.promotion_policy}
+          </div>
+        </div>
+        <div className="space-y-3" data-testid="auto-research-contract-commands">
+          {board.research_contract.commands.map((command) => (
+            <div className="rounded-md border border-zinc-800 bg-black/40 p-3" key={command.label}>
+              <div className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-normal text-sky-300">
+                <Target className="h-3.5 w-3.5" />
+                {command.label}
+              </div>
+              <code className="block whitespace-pre-wrap break-words font-mono text-xs leading-5 text-zinc-300">
+                {command.command}
+              </code>
+            </div>
+          ))}
+        </div>
+      </div>
+    </BoardPanel>
+  );
+}
+
+function LaneContractPanel() {
+  return (
+    <BoardPanel eyebrow={board.lane_contract.topology} title="Decentralized Lane Contract">
+      <div className="mb-4 rounded-md border border-zinc-800 bg-zinc-900/70 p-3 text-sm leading-6 text-zinc-300">
+        <span className="font-semibold text-zinc-100">Avoid: </span>
+        {board.lane_contract.anti_pattern}
+      </div>
+      <div className="grid gap-3 lg:grid-cols-5" data-testid="auto-research-lane-contract">
+        {board.lane_contract.lanes.map((lane) => (
+          <article className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-4" key={lane.role_id}>
+            <div className="flex items-center justify-between gap-2">
+              <Badge variant="info">{lane.role_id}</Badge>
+              <Bot className="h-4 w-4 text-zinc-500" />
+            </div>
+            <h3 className="mt-3 text-base font-semibold text-zinc-50">{lane.display_name}</h3>
+            <div className="mt-1 font-mono text-xs text-zinc-500">{lane.agent_id}</div>
+            <p className="mt-3 text-sm leading-6 text-zinc-400">{lane.responsibility}</p>
+            <div className="mt-4 flex flex-wrap gap-2">
+              {lane.produces.map((item) => (
+                <Badge key={item} variant="neutral">{item}</Badge>
+              ))}
+            </div>
+            <p className="mt-4 text-xs leading-5 text-zinc-500">
+              <span className="font-semibold text-zinc-400">Does not own: </span>
+              {lane.does_not_own}
+            </p>
+          </article>
+        ))}
+      </div>
+    </BoardPanel>
+  );
+}
+
+function FrontierCard({ item, tone }: { item: BoardFrontierItem; tone: BoardTone }) {
+  return (
+    <article className="rounded-lg border border-zinc-800 bg-zinc-900/60 p-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge variant={tone}>{item.hypothesis_id}</Badge>
+        <Badge variant="neutral">{item.todo_id}</Badge>
+      </div>
+      <div className="mt-3 text-sm font-semibold text-zinc-100">{item.mechanism_family}</div>
+      <p className="mt-2 text-sm leading-6 text-zinc-400">
+        {item.why_selected ?? item.next_action ?? item.operator_value ?? item.allowed_action ?? item.blocked_by}
+      </p>
+      {item.blocked_by ? (
+        <div className="mt-3 font-mono text-xs text-amber-300">blocked_by={item.blocked_by}</div>
+      ) : null}
+    </article>
+  );
+}
+
+function FrontierPanel() {
+  return (
+    <BoardPanel eyebrow={`agent ${board.frontier.agent_id}`} title="Per-Agent Frontier">
+      <div className="grid gap-4 lg:grid-cols-3" data-testid="auto-research-frontier">
+        <div>
+          <div className="mb-3 flex items-center gap-2 text-sm font-semibold text-zinc-200">
+            <Sparkles className="h-4 w-4 text-sky-300" />
+            Selected
+          </div>
+          <FrontierCard item={board.frontier.selected} tone="success" />
+        </div>
+        <div>
+          <div className="mb-3 flex items-center gap-2 text-sm font-semibold text-zinc-200">
+            <CheckCircle2 className="h-4 w-4 text-emerald-300" />
+            Runnable
+          </div>
+          <div className="space-y-3">
+            {board.frontier.runnable.map((item) => (
+              <FrontierCard item={item} key={item.hypothesis_id} tone="info" />
+            ))}
+          </div>
+        </div>
+        <div>
+          <div className="mb-3 flex items-center gap-2 text-sm font-semibold text-zinc-200">
+            <ShieldCheck className="h-4 w-4 text-amber-300" />
+            Blocked Or Claimed Elsewhere
+          </div>
+          <div className="space-y-3">
+            {board.frontier.blocked.map((item) => (
+              <FrontierCard item={item} key={item.hypothesis_id} tone="warning" />
+            ))}
+          </div>
+        </div>
+      </div>
+    </BoardPanel>
+  );
+}
+
+function EvidenceGraphPanel() {
+  return (
+    <BoardPanel eyebrow={board.evidence_graph.schema_version} title="Evidence Graph">
+      <div className="mb-5 grid gap-3 md:grid-cols-3" data-testid="auto-research-evidence-summary">
+        <div className="rounded-md border border-zinc-800 bg-zinc-900/70 p-3">
+          <div className="text-xs font-semibold uppercase tracking-normal text-zinc-500">Best dev</div>
+          <div className="mt-2 text-2xl font-semibold text-zinc-50">{metricValue(board.evidence_graph.best_dev_metric)}</div>
+        </div>
+        <div className="rounded-md border border-zinc-800 bg-zinc-900/70 p-3">
+          <div className="text-xs font-semibold uppercase tracking-normal text-zinc-500">Best holdout</div>
+          <div className="mt-2 text-2xl font-semibold text-zinc-50">
+            {metricValue(board.evidence_graph.best_holdout_metric)}
+          </div>
+        </div>
+        <div className="rounded-md border border-zinc-800 bg-zinc-900/70 p-3">
+          <div className="text-xs font-semibold uppercase tracking-normal text-zinc-500">Source kind</div>
+          <div className="mt-2 font-mono text-sm text-zinc-300">{board.evidence_graph.source_kind}</div>
+        </div>
+      </div>
+      <div className="grid gap-3 lg:grid-cols-4" data-testid="auto-research-evidence-graph">
+        {board.evidence_graph.nodes.map((node) => (
+          <article className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-4" key={node.hypothesis_id}>
+            <div className="flex flex-wrap items-center gap-2">
+              <Badge variant={statusTone(node.status)}>{node.status}</Badge>
+              <Badge variant="neutral">{node.hypothesis_id}</Badge>
+            </div>
+            <p className="mt-3 text-sm leading-6 text-zinc-300">{node.summary}</p>
+            <div className="mt-4 grid grid-cols-2 gap-2 text-xs">
+              <div className="rounded-md border border-zinc-800 bg-black/30 p-2">
+                <div className="text-zinc-500">dev</div>
+                <div className="mt-1 font-semibold text-zinc-100">{metricValue(node.best_dev_metric)}</div>
+              </div>
+              <div className="rounded-md border border-zinc-800 bg-black/30 p-2">
+                <div className="text-zinc-500">holdout</div>
+                <div className="mt-1 font-semibold text-zinc-100">{metricValue(node.best_holdout_metric)}</div>
+              </div>
+            </div>
+            <p className="mt-4 text-xs leading-5 text-zinc-500">{node.evidence_boundary}</p>
+          </article>
+        ))}
+      </div>
+      <div className="mt-5 grid gap-2 md:grid-cols-2 xl:grid-cols-4" data-testid="auto-research-evidence-edges">
+        {board.evidence_graph.edges.map((edge) => (
+          <div className="flex items-center gap-2 rounded-md border border-zinc-800 bg-black/30 p-3" key={`${edge.from}-${edge.to}`}>
+            <GitBranch className="h-4 w-4 shrink-0 text-zinc-500" />
+            <div className="min-w-0 text-xs text-zinc-400">
+              <span className="font-mono text-zinc-300">{edge.from}</span>
+              <ArrowRight className="mx-1 inline h-3 w-3" />
+              <span className="font-mono text-zinc-300">{edge.to}</span>
+              <div className="mt-1">{edge.label}</div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </BoardPanel>
+  );
+}
+
+function DecisionColumn({
+  candidates,
+  title,
+}: {
+  candidates: BoardDecisionCandidate[];
+  title: string;
+}) {
+  return (
+    <div className="space-y-3">
+      <div className="text-sm font-semibold text-zinc-200">{title}</div>
+      {candidates.map((candidate) => (
+        <article className="rounded-lg border border-zinc-800 bg-zinc-900/60 p-4" key={candidate.hypothesis_id}>
+          <div className="flex flex-wrap gap-2">
+            <Badge variant={statusTone(candidate.decision)}>{candidate.decision}</Badge>
+            <Badge variant="neutral">{candidate.hypothesis_id}</Badge>
+          </div>
+          <div className="mt-3 font-mono text-xs text-zinc-500">{candidate.todo_id}</div>
+          {candidate.dev_metric || candidate.holdout_metric ? (
+            <div className="mt-4 grid grid-cols-2 gap-2 text-xs">
+              <div className="rounded-md border border-zinc-800 bg-black/30 p-2">
+                <div className="text-zinc-500">dev</div>
+                <div className="mt-1 font-semibold text-zinc-100">{candidate.dev_metric ?? "not scored"}</div>
+              </div>
+              <div className="rounded-md border border-zinc-800 bg-black/30 p-2">
+                <div className="text-zinc-500">holdout</div>
+                <div className="mt-1 font-semibold text-zinc-100">{candidate.holdout_metric ?? "not scored"}</div>
+              </div>
+            </div>
+          ) : null}
+          <p className="mt-4 text-sm leading-6 text-zinc-400">{candidate.user_value ?? candidate.reason}</p>
+          {candidate.requires ? (
+            <div className="mt-4 flex flex-wrap gap-2">
+              {candidate.requires.map((item) => (
+                <Badge key={item} variant="success">{item}</Badge>
+              ))}
+            </div>
+          ) : null}
+        </article>
+      ))}
+    </div>
+  );
+}
+
+function DecisionCandidatesPanel() {
+  return (
+    <BoardPanel eyebrow="promotion policy" title="Decision Candidates">
+      <div className="grid gap-4 lg:grid-cols-3" data-testid="auto-research-decision-candidates">
+        <DecisionColumn candidates={board.decision_candidates.promotion_candidates} title="Promotion" />
+        <DecisionColumn candidates={board.decision_candidates.retry_candidates} title="Retry" />
+        <DecisionColumn candidates={board.decision_candidates.retirement_candidates} title="Retire" />
+      </div>
+    </BoardPanel>
+  );
+}
+
+function ShowcaseProjectionPanel() {
+  return (
+    <BoardPanel eyebrow={board.showcase_projection.schema_version} title={board.showcase_projection.title}>
+      <div className="grid gap-5 lg:grid-cols-[1fr_0.8fr]" data-testid="auto-research-showcase-projection">
+        <div className="space-y-4">
+          <p className="text-lg leading-8 text-zinc-200">{board.showcase_projection.primary_claim}</p>
+          <p className="text-sm leading-6 text-zinc-400">{board.showcase_projection.audience_takeaway}</p>
+          <div className="rounded-md border border-zinc-800 bg-black/30 p-3 text-sm leading-6 text-zinc-300">
+            <span className="font-semibold text-zinc-100">Demo path: </span>
+            {board.showcase_projection.public_demo_path}
+          </div>
+        </div>
+        <div className="rounded-lg border border-zinc-800 bg-zinc-900/60 p-4">
+          <div className="mb-3 flex items-center gap-2 text-sm font-semibold text-zinc-100">
+            <Network className="h-4 w-4 text-sky-300" />
+            Quality Gates
+          </div>
+          <ul className="space-y-3">
+            {board.quality_gates.map((gate) => (
+              <li className="flex items-start gap-3 text-sm leading-6 text-zinc-400" key={gate}>
+                <CheckCircle2 className="mt-1 h-4 w-4 shrink-0 text-emerald-300" />
+                {gate}
+              </li>
+            ))}
+          </ul>
+          <div className="mt-5 rounded-md border border-zinc-800 bg-black/30 p-3 text-sm leading-6 text-zinc-300">
+            <span className="font-semibold text-zinc-100">Next: </span>
+            {board.showcase_projection.next_product_step}
+          </div>
+        </div>
+      </div>
+    </BoardPanel>
+  );
+}
+
+export function FrontstageAutoResearchPage() {
+  return (
+    <main className="min-h-screen bg-[#07080a] px-4 py-5 text-zinc-100 sm:px-6" data-testid="frontstage-auto-research-board">
+      <div className="mx-auto grid max-w-[1500px] gap-5">
+        <section className="rounded-xl border border-zinc-800 bg-[radial-gradient(circle_at_top_left,_rgba(56,189,248,0.16),_transparent_34%),#0b0d12] p-5 shadow-sm">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant="info">{board.surface.stage}</Badge>
+            <Badge variant="neutral">{board.schema_version}</Badge>
+            <Badge variant="success">public-safe projection</Badge>
+          </div>
+          <div className="mt-6 grid gap-5 lg:grid-cols-[1.1fr_0.9fr] lg:items-end">
+            <div>
+              <div className="mb-3 flex items-center gap-2 text-sm font-semibold uppercase tracking-normal text-sky-300">
+                <LayoutDashboard className="h-4 w-4" />
+                Auto Research Frontstage
+              </div>
+              <h1 className="max-w-4xl text-4xl font-semibold leading-tight text-zinc-50 md:text-5xl">
+                {board.surface.title}
+              </h1>
+              <p className="mt-4 max-w-4xl text-lg leading-8 text-zinc-300">{board.surface.positioning}</p>
+            </div>
+            <div className="rounded-lg border border-zinc-800 bg-black/30 p-4 text-sm leading-6 text-zinc-400">
+              <div className="mb-2 flex items-center gap-2 font-semibold text-zinc-100">
+                <ShieldCheck className="h-4 w-4 text-emerald-300" />
+                Boundary
+              </div>
+              {board.surface.public_boundary}
+            </div>
+          </div>
+        </section>
+
+        <ValueMetrics />
+        <ResearchContractPanel />
+        <LaneContractPanel />
+        <FrontierPanel />
+        <EvidenceGraphPanel />
+        <DecisionCandidatesPanel />
+        <ShowcaseProjectionPanel />
+      </div>
+    </main>
+  );
+}

--- a/docs/product/auto-research-frontstage-board.public.json
+++ b/docs/product/auto-research-frontstage-board.public.json
@@ -1,0 +1,258 @@
+{
+  "schema_version": "auto_research_frontstage_board_v0",
+  "generated_at": "2026-06-28T00:00:00Z",
+  "surface": {
+    "id": "loopx_auto_research_knn_board",
+    "title": "Auto Research Product Board",
+    "subtitle": "A public-safe Frontstage board for decentralized k-NN research.",
+    "stage": "experimental",
+    "positioning": "LoopX keeps autonomous research decentralized: every agent sees a claim-compatible frontier, while hypotheses, evidence, retries, and promotion decisions stay in the shared control plane.",
+    "public_boundary": "Public fixture and protected-evaluator outputs only; no raw logs, non-public source docs, credentials, local paths, or hidden leader transcript."
+  },
+  "research_contract": {
+    "goal_id": "loopx-auto-research-knn",
+    "objective": "Improve exact k-nearest-neighbor inference speed while preserving exact neighbor identity.",
+    "editable_scope": ["solution_candidate.py"],
+    "protected_scope": ["protected_eval.py", "solution_baseline.py", "generated dev/holdout data"],
+    "metric": {
+      "name": "deterministic_speedup",
+      "direction": "maximize",
+      "baseline": "1.0x"
+    },
+    "promotion_policy": "Promote only after dev and holdout improvement, exact output, clean protected boundary, and no-upload evidence.",
+    "commands": [
+      {
+        "label": "dev evidence",
+        "command": "python3 examples/auto_research_knn_pack/protected_eval.py --solution examples/auto_research_knn_pack/solution_candidate.py --split dev"
+      },
+      {
+        "label": "holdout evidence",
+        "command": "python3 examples/auto_research_knn_pack/protected_eval.py --solution examples/auto_research_knn_pack/solution_candidate.py --split holdout"
+      }
+    ]
+  },
+  "value_metrics": [
+    {
+      "label": "Held-out speedup",
+      "value": "4.5x",
+      "baseline": "1.0x baseline",
+      "interpretation": "The candidate still improves on the protected holdout split, so the result is not only a dev-set artifact.",
+      "source": "auto_research_knn_eval_result_v0:holdout"
+    },
+    {
+      "label": "Dev to holdout transfer",
+      "value": "4.0x -> 4.5x",
+      "baseline": "dev result before promotion",
+      "interpretation": "The promotion candidate improves across both splits under the same protected metric.",
+      "source": "auto_research_knn_eval_result_v0:dev+holdout"
+    },
+    {
+      "label": "Correctness preserved",
+      "value": "exact neighbors",
+      "baseline": "oracle identity check",
+      "interpretation": "The speedup is only accepted because every query keeps exact nearest-neighbor identity.",
+      "source": "protected_eval.py exactness gate"
+    },
+    {
+      "label": "Protected boundary",
+      "value": "clean",
+      "baseline": "no protected edits, no upload",
+      "interpretation": "The executor can optimize the candidate while the evaluator, data, oracle, and promotion gate stay protected.",
+      "source": "promotion_gate.requires"
+    }
+  ],
+  "lane_contract": {
+    "topology": "decentralized",
+    "anti_pattern": "single leader agent owns the whole hypothesis tree",
+    "lanes": [
+      {
+        "role_id": "curator",
+        "display_name": "Curator",
+        "agent_id": "codex-product-capability",
+        "responsibility": "Keep the research contract, protected scope, and public boundary clear.",
+        "produces": ["research_contract_v0", "scope boundary notes"],
+        "does_not_own": "Experiment execution or promotion by persuasion."
+      },
+      {
+        "role_id": "hypothesis_proposer",
+        "display_name": "Hypothesis proposer",
+        "agent_id": "codex-side-bypass",
+        "responsibility": "Propose todo-linked hypotheses and parent-child refinements.",
+        "produces": ["research_hypothesis_v0", "grounding refs"],
+        "does_not_own": "Novelty claims from the same material used for ideation."
+      },
+      {
+        "role_id": "research_executor",
+        "display_name": "Research executor",
+        "agent_id": "codex-side-bypass",
+        "responsibility": "Run one claimed hypothesis in an isolated worktree and emit split-aware evidence.",
+        "produces": ["auto_research_evidence_packet_v0", "branch refs"],
+        "does_not_own": "Protected files, evaluator behavior, or promotion gates."
+      },
+      {
+        "role_id": "evaluator_promoter",
+        "display_name": "Evaluator / promoter",
+        "agent_id": "codex-product-capability",
+        "responsibility": "Classify scored attempts into promote, retry, or retire using dev and holdout evidence.",
+        "produces": ["promotion candidates", "retirement candidates", "gate todos"],
+        "does_not_own": "Dev-only promotion or hidden bypass of user gates."
+      },
+      {
+        "role_id": "product_narrator",
+        "display_name": "Product narrator",
+        "agent_id": "codex-side-bypass",
+        "responsibility": "Turn the evidence graph into a public showcase without leaking private material.",
+        "produces": ["research_showcase_projection_v0", "Frontstage board"],
+        "does_not_own": "Changing public first screens without owner review."
+      }
+    ]
+  },
+  "frontier": {
+    "agent_id": "codex-side-bypass",
+    "selected": {
+      "hypothesis_id": "hyp_002",
+      "todo_id": "todo_auto_research_002",
+      "status": "active",
+      "mechanism_family": "partial_selection",
+      "allowed_action": "run_dev_attempt",
+      "why_selected": "Claim-compatible, unblocked, and directly tied to the current exact k-NN speedup objective."
+    },
+    "runnable": [
+      {
+        "hypothesis_id": "hyp_002",
+        "todo_id": "todo_auto_research_002",
+        "mechanism_family": "partial_selection",
+        "next_action": "Run dev evidence, then require holdout before promotion."
+      }
+    ],
+    "blocked": [
+      {
+        "hypothesis_id": "hyp_003",
+        "todo_id": "todo_auto_research_003",
+        "mechanism_family": "batch_query_path",
+        "blocked_by": "claimed_by:codex-product-capability",
+        "operator_value": "Shows other-lane work without letting this agent silently steal it."
+      },
+      {
+        "hypothesis_id": "hyp_004",
+        "todo_id": "todo_auto_research_004",
+        "mechanism_family": "approximate_search_guardrail",
+        "blocked_by": "correctness_guardrail_failed",
+        "operator_value": "Keeps a useful negative direction visible so the next agent does not rediscover it."
+      }
+    ]
+  },
+  "evidence_graph": {
+    "schema_version": "research_evidence_graph_v0",
+    "goal_id": "loopx-auto-research-knn",
+    "metric": {
+      "name": "deterministic_speedup",
+      "direction": "maximize",
+      "baseline": 1.0
+    },
+    "best_dev_metric": 4.0,
+    "best_holdout_metric": 4.5,
+    "holdout_improved": true,
+    "source_kind": "public_pack_plus_public_fixture",
+    "nodes": [
+      {
+        "hypothesis_id": "hyp_001",
+        "status": "supported",
+        "summary": "Vectorize exact distance work as the broad mechanism family.",
+        "best_dev_metric": 4.8,
+        "best_holdout_metric": 4.3,
+        "evidence_boundary": "Fixture evidence only; retained as a shape example."
+      },
+      {
+        "hypothesis_id": "hyp_002",
+        "status": "active",
+        "summary": "Use exact partial selection to avoid full distance sorting.",
+        "best_dev_metric": 4.0,
+        "best_holdout_metric": 4.5,
+        "evidence_boundary": "Runnable public pack evidence from protected_eval.py."
+      },
+      {
+        "hypothesis_id": "hyp_003",
+        "status": "active",
+        "summary": "Batch query work so shared array layout setup can be reused.",
+        "best_dev_metric": null,
+        "best_holdout_metric": null,
+        "evidence_boundary": "Claimed future lane; not promoted without split evidence."
+      },
+      {
+        "hypothesis_id": "hyp_004",
+        "status": "contradicted",
+        "summary": "Approximate search is rejected unless exact identity can be preserved.",
+        "best_dev_metric": null,
+        "best_holdout_metric": null,
+        "evidence_boundary": "Negative evidence because correctness guardrail failed."
+      }
+    ],
+    "edges": [
+      {
+        "from": "research_contract",
+        "to": "hyp_001",
+        "label": "opens mechanism family"
+      },
+      {
+        "from": "hyp_001",
+        "to": "hyp_002",
+        "label": "narrows to exact selection"
+      },
+      {
+        "from": "hyp_002",
+        "to": "hyp_003",
+        "label": "future batching refinement"
+      },
+      {
+        "from": "hyp_003",
+        "to": "hyp_004",
+        "label": "negative-control branch"
+      }
+    ]
+  },
+  "decision_candidates": {
+    "promotion_candidates": [
+      {
+        "hypothesis_id": "hyp_002",
+        "todo_id": "todo_auto_research_002",
+        "decision": "promote_after_boundary_scan",
+        "dev_metric": "4.0x",
+        "holdout_metric": "4.5x",
+        "requires": ["boundary_scan", "exact_neighbor_identity", "protected_scope_clean", "no_upload"],
+        "user_value": "A reproducible speedup that survived the protected holdout gate."
+      }
+    ],
+    "retry_candidates": [
+      {
+        "hypothesis_id": "hyp_003",
+        "todo_id": "todo_auto_research_003",
+        "decision": "retry_with_executor_lane",
+        "reason": "Potential product value, but no dev or holdout score yet."
+      }
+    ],
+    "retirement_candidates": [
+      {
+        "hypothesis_id": "hyp_004",
+        "todo_id": "todo_auto_research_004",
+        "decision": "retire_until_exactness_proof",
+        "reason": "Approximate search conflicts with exact output unless a later proof changes the boundary."
+      }
+    ]
+  },
+  "showcase_projection": {
+    "schema_version": "research_showcase_projection_v0",
+    "title": "Decentralized Auto Research: k-NN Speedup",
+    "primary_claim": "LoopX can present an Arbor-style research tree while keeping execution decentralized through todo claims, evidence events, and promotion gates.",
+    "audience_takeaway": "A user can inspect what is runnable now, what is blocked by another lane, what is promotable, and what has been retired without trusting a hidden leader chat.",
+    "public_demo_path": "Run the k-NN pack, emit evidence, append rollout events, then render this board from the evidence graph.",
+    "next_product_step": "Replace fixture-only nodes with live rollout-event projections for every auto-research run."
+  },
+  "quality_gates": [
+    "All promoted work needs dev and holdout evidence.",
+    "Protected scope edits fail the promotion gate.",
+    "Every hypothesis stays todo-linked and agent-scoped.",
+    "Negative evidence remains visible as reusable research memory.",
+    "Public boards render projections, not raw logs or private planning text."
+  ]
+}


### PR DESCRIPTION
## Motivation

Productize the decentralized auto-research path as a public-safe Frontstage board without changing the existing public first screen. The page turns the k-NN auto-research pack into a user-facing surface: research contract, per-agent frontier, evidence graph, promotion/retry/retire candidates, and showcase projection.

## Changes

- Add `docs/product/auto-research-frontstage-board.public.json` as the public-safe board data contract.
- Add `/frontstage/auto-research` as an experimental dashboard route backed by that contract.
- Extend `smoke:frontstage-route` to verify the route, value metrics, decentralized topology, evidence graph, decision candidates, no live status dependency, no write form, and public/private boundary markers.

## First-screen boundary

This PR does not modify the README, hosted Frontstage homepage, showcase index, existing first viewport, primary CTA, or opening navigation. The new board is an unlinked experimental route for reviewable auto-research productization.

## Validation

- `python3 examples/decentralized-auto-research-protocol-smoke.py`
- `python3 examples/decentralized-auto-research-frontier-smoke.py`
- `python3 examples/auto-research-knn-pack-smoke.py`
- `npm run smoke:frontstage-route`
- `npm run build`
- `git diff --check`
- `loopx check --scan-path apps/dashboard/src/views/frontstage-auto-research-page.tsx --scan-path apps/dashboard/src/router.tsx --scan-path apps/dashboard/smoke/frontstage-route-smoke.ts --scan-path docs/product/auto-research-frontstage-board.public.json`

LoopX check warning observed: existing `loopx-meta` duplicate index rows warning; touched-file public boundary scan passed.