### PR TITLE
Extract execution obligation policy helper

### DIFF
--- a/examples/execution-obligation-policy-smoke.py
+++ b/examples/execution-obligation-policy-smoke.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Smoke-test the extracted execution-obligation policy helper."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.policies.execution_obligation import build_execution_obligation  # noqa: E402
+
+
+def obligation(
+    *,
+    should_run: bool = True,
+    effective_action: str = "normal_run",
+    recommendation: dict | None = None,
+    work_lane_contract: dict | None = None,
+    external_evidence_observation: dict | None = None,
+    successor_replan_mode: str = "successor_replan_required",
+) -> dict:
+    return build_execution_obligation(
+        should_run=should_run,
+        effective_action=effective_action,
+        heartbeat_recommendation=recommendation or {},
+        work_lane_contract=work_lane_contract,
+        external_evidence_observation=external_evidence_observation,
+        successor_replan_mode=successor_replan_mode,
+    )
+
+
+def assert_exact_mode(
+    name: str,
+    payload: dict,
+    *,
+    kind: str,
+    minimum: str | None,
+    contract: str | None = None,
+    delivery_allowed: bool | None = None,
+) -> None:
+    assert payload["kind"] == kind, (name, payload)
+    assert payload["must_attempt_work"] is True, (name, payload)
+    assert payload["notify_is_execution_gate"] is False, (name, payload)
+    if minimum is None:
+        assert "minimum" not in payload, (name, payload)
+    else:
+        assert payload["minimum"] == minimum, (name, payload)
+    if contract is not None:
+        assert payload["contract"] == contract, (name, payload)
+    if delivery_allowed is not None:
+        assert payload["delivery_allowed"] is delivery_allowed, (name, payload)
+
+
+def main() -> int:
+    side_agent = obligation(
+        recommendation={
+            "recommended_mode": "repair_side_agent_workspace",
+            "spend_policy": "no spend until relocated",
+        }
+    )
+    assert_exact_mode(
+        "side-agent-workspace",
+        side_agent,
+        kind="side_agent_workspace_repair",
+        minimum="one_workspace_move_then_guard_rerun",
+        contract="side_agent_workspace_guard",
+        delivery_allowed=False,
+    )
+    assert side_agent["spend_policy"] == "no spend until relocated", side_agent
+
+    evidence = obligation(
+        should_run=False,
+        external_evidence_observation={
+            "required": True,
+            "spend_policy": "no spend until observed",
+        },
+    )
+    assert_exact_mode(
+        "external-evidence",
+        evidence,
+        kind="external_evidence_observation_required",
+        minimum="one_read_only_observation_or_compact_blocker",
+        contract="external_evidence_observation",
+        delivery_allowed=False,
+    )
+    assert evidence["spend_policy"] == "no spend until observed", evidence
+
+    quiet = obligation(
+        recommendation={"stop_if_unchanged": True},
+    )
+    assert quiet == {
+        "must_attempt_work": False,
+        "kind": "quiet_noop_if_unchanged",
+        "notify_is_execution_gate": False,
+        "reason": (
+            "this mode allows a quiet no-op only after confirming the current state "
+            "source is unchanged and no concrete safe handoff exists"
+        ),
+    }, quiet
+
+    replan = obligation(
+        recommendation={
+            "recommended_mode": "autonomous_replan_required",
+            "replan_obligation": {"stall_threshold": 6},
+        }
+    )
+    assert_exact_mode(
+        "autonomous-replan",
+        replan,
+        kind="autonomous_replan_required",
+        minimum="one_bounded_replan_segment",
+    )
+    assert replan["stall_threshold"] == 6, replan
+
+    successor = obligation(
+        recommendation={
+            "recommended_mode": "custom_successor_mode",
+            "spend_policy": "spend after projection repair",
+        },
+        successor_replan_mode="custom_successor_mode",
+    )
+    assert_exact_mode(
+        "successor-replan",
+        successor,
+        kind="custom_successor_mode",
+        minimum="one_successor_replan_or_no_followup_writeback",
+        contract="deferred_resume_projection",
+        delivery_allowed=False,
+    )
+    assert successor["spend_policy"] == "spend after projection repair", successor
+
+    state_gap = obligation(
+        recommendation={
+            "recommended_mode": "repair_state_projection_gap",
+            "spend_policy": "spend after projection repair",
+        }
+    )
+    assert_exact_mode(
+        "state-projection-gap",
+        state_gap,
+        kind="state_projection_gap_repair",
+        minimum="one_replan_or_todo_expansion_or_blocker_writeback_segment",
+        contract="state_projection_gap",
+        delivery_allowed=False,
+    )
+
+    boundary = obligation(
+        recommendation={"recommended_mode": "repair_boundary_projection"}
+    )
+    assert_exact_mode(
+        "boundary-projection",
+        boundary,
+        kind="boundary_projection_repair",
+        minimum="one_boundary_projection_or_blocker_writeback_segment",
+        contract="goal_boundary.write_scope",
+        delivery_allowed=False,
+    )
+
+    capability = obligation(
+        recommendation={"recommended_mode": "repair_capability_bridge"}
+    )
+    assert_exact_mode(
+        "capability-bridge",
+        capability,
+        kind="capability_bridge_repair",
+        minimum="one_bridge_or_environment_repair_or_blocker_writeback_segment",
+        contract="capability_gate",
+        delivery_allowed=False,
+    )
+
+    work_lane = obligation(
+        recommendation={"recommended_mode": "follow_work_lane_contract"},
+        work_lane_contract={
+            "obligation": "advance_one_bounded_segment",
+            "must_attempt_work": True,
+        },
+    )
+    assert work_lane == {
+        "must_attempt_work": True,
+        "kind": "work_lane_contract",
+        "contract": "work_lane_contract",
+        "contract_obligation": "advance_one_bounded_segment",
+        "notify_is_execution_gate": False,
+        "reason": (
+            "work_lane_contract.obligation is the machine execution contract; "
+            "heartbeat_recommendation is explanatory"
+        ),
+    }, work_lane
+
+    generic_run = obligation(
+        recommendation={"recommended_mode": "steering_audit_then_one_step"},
+        effective_action="normal_run",
+    )
+    assert generic_run == {
+        "must_attempt_work": True,
+        "kind": "normal_run",
+        "minimum": "one_bounded_segment",
+        "notify_is_execution_gate": False,
+        "reason": (
+            "should_run=true means a Codex-actionable turn exists; heartbeat notify "
+            "only controls whether to interrupt the user"
+        ),
+    }, generic_run
+
+    generic_skip = obligation(
+        should_run=False,
+        effective_action="quota_wait",
+        recommendation={"recommended_mode": "wait"},
+    )
+    assert generic_skip == {
+        "must_attempt_work": False,
+        "kind": "quota_wait",
+        "notify_is_execution_gate": False,
+        "reason": (
+            "should_run=false blocks delivery unless an explicit safe-bypass or "
+            "self-repair action is exposed"
+        ),
+    }, generic_skip
+
+    print("execution-obligation-policy-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/policies/execution_obligation.py
+++ b/loopx/policies/execution_obligation.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+SUCCESSOR_REPLAN_REQUIRED_MODE = "successor_replan_required"
+
+
+def build_execution_obligation(
+    *,
+    should_run: bool,
+    effective_action: str,
+    heartbeat_recommendation: dict[str, Any],
+    work_lane_contract: dict[str, Any] | None = None,
+    external_evidence_observation: dict[str, Any] | None = None,
+    successor_replan_mode: str = SUCCESSOR_REPLAN_REQUIRED_MODE,
+) -> dict[str, Any]:
+    """Separate the worker execution contract from user-facing notification."""
+
+    recommended_mode = str(heartbeat_recommendation.get("recommended_mode") or "")
+    work_lane_contract = work_lane_contract if isinstance(work_lane_contract, dict) else {}
+    external_evidence_observation = (
+        external_evidence_observation
+        if isinstance(external_evidence_observation, dict)
+        else {}
+    )
+    if should_run and recommended_mode == "repair_side_agent_workspace":
+        return {
+            "must_attempt_work": True,
+            "kind": "side_agent_workspace_repair",
+            "minimum": "one_workspace_move_then_guard_rerun",
+            "delivery_allowed": False,
+            "notify_is_execution_gate": False,
+            "contract": "side_agent_workspace_guard",
+            "contract_obligation": (
+                "do not edit repository files from the registered primary checkout; "
+                "create or switch to an independent worktree/branch, then rerun "
+                "quota should-run with the same agent id"
+            ),
+            "spend_policy": heartbeat_recommendation.get("spend_policy"),
+            "reason": (
+                "side-agent identity is active while the current workspace is the "
+                "registered primary checkout"
+            ),
+        }
+    if external_evidence_observation.get("required") is True:
+        return {
+            "must_attempt_work": True,
+            "kind": "external_evidence_observation_required",
+            "minimum": "one_read_only_observation_or_compact_blocker",
+            "delivery_allowed": False,
+            "notify_is_execution_gate": False,
+            "contract": "external_evidence_observation",
+            "contract_obligation": (
+                "verify the watched controller/thread/job/marker/writeback handle; "
+                "if it is absent or never launched, write a compact blocker instead "
+                "of treating the poll as unchanged evidence"
+            ),
+            "spend_policy": external_evidence_observation.get("spend_policy"),
+            "reason": (
+                "waiting external evidence still requires a read-only observation "
+                "contract before a quiet no-op is allowed"
+            ),
+        }
+    if heartbeat_recommendation.get("stop_if_unchanged"):
+        return {
+            "must_attempt_work": False,
+            "kind": "quiet_noop_if_unchanged",
+            "notify_is_execution_gate": False,
+            "reason": (
+                "this mode allows a quiet no-op only after confirming the current state "
+                "source is unchanged and no concrete safe handoff exists"
+            ),
+        }
+    if should_run and recommended_mode == "autonomous_replan_required":
+        replan_obligation = (
+            heartbeat_recommendation.get("replan_obligation")
+            if isinstance(heartbeat_recommendation.get("replan_obligation"), dict)
+            else {}
+        )
+        return {
+            "must_attempt_work": True,
+            "kind": "autonomous_replan_required",
+            "minimum": "one_bounded_replan_segment",
+            "notify_is_execution_gate": False,
+            "stall_threshold": replan_obligation.get("stall_threshold"),
+            "contract_obligation": "apply autonomous_replan_obligation before monitor-only work",
+            "reason": (
+                "autonomous_replan_obligation is a machine execution contract; "
+                "quiet no-op is not allowed until the replan slice is validated or blocked"
+            ),
+        }
+    if should_run and recommended_mode == successor_replan_mode:
+        return {
+            "must_attempt_work": True,
+            "kind": successor_replan_mode,
+            "minimum": "one_successor_replan_or_no_followup_writeback",
+            "delivery_allowed": False,
+            "notify_is_execution_gate": False,
+            "contract": "deferred_resume_projection",
+            "contract_obligation": (
+                "reopen or supersede the ready deferred successor, or record a "
+                "public-safe no-follow-up rationale before another quiet no-op"
+            ),
+            "spend_policy": heartbeat_recommendation.get("spend_policy"),
+            "reason": (
+                "a deferred successor resume condition is satisfied; the agent must "
+                "repair the todo projection before normal delivery"
+            ),
+        }
+    if should_run and recommended_mode == "repair_state_projection_gap":
+        return {
+            "must_attempt_work": True,
+            "kind": "state_projection_gap_repair",
+            "minimum": "one_replan_or_todo_expansion_or_blocker_writeback_segment",
+            "delivery_allowed": False,
+            "notify_is_execution_gate": False,
+            "contract": "state_projection_gap",
+            "contract_obligation": (
+                "repair the active-state projection before normal delivery: expand "
+                "Next Action into open Agent Todo/User Todo or write a compact blocker"
+            ),
+            "spend_policy": heartbeat_recommendation.get("spend_policy"),
+            "reason": (
+                "should_run=true exposed actionable prose but no open todo projection; "
+                "normal bounded delivery is blocked until projection is repaired"
+            ),
+        }
+    if should_run and recommended_mode == "repair_boundary_projection":
+        return {
+            "must_attempt_work": True,
+            "kind": "boundary_projection_repair",
+            "minimum": "one_boundary_projection_or_blocker_writeback_segment",
+            "delivery_allowed": False,
+            "notify_is_execution_gate": False,
+            "contract": "goal_boundary.write_scope",
+            "contract_obligation": (
+                "do not execute the selected write; repair goal_boundary.write_scope "
+                "projection, rewrite the selected todo within boundary, or create a "
+                "concrete user/controller gate"
+            ),
+            "spend_policy": heartbeat_recommendation.get("spend_policy"),
+            "reason": (
+                "selected executable todo requires a write scope that the current "
+                "goal_boundary does not project"
+            ),
+        }
+    if should_run and recommended_mode == "repair_capability_bridge":
+        return {
+            "must_attempt_work": True,
+            "kind": "capability_bridge_repair",
+            "minimum": "one_bridge_or_environment_repair_or_blocker_writeback_segment",
+            "delivery_allowed": False,
+            "notify_is_execution_gate": False,
+            "contract": "capability_gate",
+            "contract_obligation": (
+                "do not execute the selected capability-blocked todo; repair or "
+                "materialize the missing bridge/capability, rewrite the todo to an "
+                "available capability, or write a compact blocker"
+            ),
+            "spend_policy": heartbeat_recommendation.get("spend_policy"),
+            "reason": (
+                "all executable todos require unavailable bridge-style capabilities, "
+                "but a bounded bridge repair may be attempted"
+            ),
+        }
+    if should_run and work_lane_contract:
+        return {
+            "must_attempt_work": bool(work_lane_contract.get("must_attempt_work", should_run)),
+            "kind": "work_lane_contract",
+            "contract": "work_lane_contract",
+            "contract_obligation": work_lane_contract.get("obligation"),
+            "notify_is_execution_gate": False,
+            "reason": (
+                "work_lane_contract.obligation is the machine execution contract; "
+                "heartbeat_recommendation is explanatory"
+            ),
+        }
+    if should_run:
+        return {
+            "must_attempt_work": True,
+            "kind": effective_action or recommended_mode or "bounded_delivery",
+            "minimum": "one_bounded_segment",
+            "notify_is_execution_gate": False,
+            "reason": (
+                "should_run=true means a Codex-actionable turn exists; heartbeat notify "
+                "only controls whether to interrupt the user"
+            ),
+        }
+    return {
+        "must_attempt_work": False,
+        "kind": effective_action or recommended_mode or "skip",
+        "notify_is_execution_gate": False,
+        "reason": (
+            "should_run=false blocks delivery unless an explicit safe-bypass or "
+            "self-repair action is exposed"
+        ),
+    }

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -30,6 +30,7 @@ from .execution_profile import (
 )
 from .long_task_cadence import long_task_cadence_hint_summary
 from .orchestration import compact_orchestration_policy, orchestration_policy_summary
+from .policies.execution_obligation import build_execution_obligation
 from .policies.outcome_followthrough import build_outcome_followthrough_hint
 from .policies.scheduler_hint import build_scheduler_hint
 from .policies.work_lane import (
@@ -5471,187 +5472,14 @@ def _execution_obligation(
     work_lane_contract: dict[str, Any] | None = None,
     external_evidence_observation: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Separate the worker execution contract from user-facing notification."""
-
-    recommended_mode = str(heartbeat_recommendation.get("recommended_mode") or "")
-    work_lane_contract = work_lane_contract if isinstance(work_lane_contract, dict) else {}
-    external_evidence_observation = (
-        external_evidence_observation
-        if isinstance(external_evidence_observation, dict)
-        else {}
+    return build_execution_obligation(
+        should_run=should_run,
+        effective_action=effective_action,
+        heartbeat_recommendation=heartbeat_recommendation,
+        work_lane_contract=work_lane_contract,
+        external_evidence_observation=external_evidence_observation,
+        successor_replan_mode=AgentScopeFrontierAction.SUCCESSOR_REPLAN_REQUIRED.value,
     )
-    if should_run and recommended_mode == "repair_side_agent_workspace":
-        return {
-            "must_attempt_work": True,
-            "kind": "side_agent_workspace_repair",
-            "minimum": "one_workspace_move_then_guard_rerun",
-            "delivery_allowed": False,
-            "notify_is_execution_gate": False,
-            "contract": "side_agent_workspace_guard",
-            "contract_obligation": (
-                "do not edit repository files from the registered primary checkout; "
-                "create or switch to an independent worktree/branch, then rerun "
-                "quota should-run with the same agent id"
-            ),
-            "spend_policy": heartbeat_recommendation.get("spend_policy"),
-            "reason": (
-                "side-agent identity is active while the current workspace is the "
-                "registered primary checkout"
-            ),
-        }
-    if external_evidence_observation.get("required") is True:
-        return {
-            "must_attempt_work": True,
-            "kind": "external_evidence_observation_required",
-            "minimum": "one_read_only_observation_or_compact_blocker",
-            "delivery_allowed": False,
-            "notify_is_execution_gate": False,
-            "contract": "external_evidence_observation",
-            "contract_obligation": (
-                "verify the watched controller/thread/job/marker/writeback handle; "
-                "if it is absent or never launched, write a compact blocker instead "
-                "of treating the poll as unchanged evidence"
-            ),
-            "spend_policy": external_evidence_observation.get("spend_policy"),
-            "reason": (
-                "waiting external evidence still requires a read-only observation "
-                "contract before a quiet no-op is allowed"
-            ),
-        }
-    if heartbeat_recommendation.get("stop_if_unchanged"):
-        return {
-            "must_attempt_work": False,
-            "kind": "quiet_noop_if_unchanged",
-            "notify_is_execution_gate": False,
-            "reason": (
-                "this mode allows a quiet no-op only after confirming the current state "
-                "source is unchanged and no concrete safe handoff exists"
-            ),
-        }
-    if should_run and recommended_mode == "autonomous_replan_required":
-        replan_obligation = (
-            heartbeat_recommendation.get("replan_obligation")
-            if isinstance(heartbeat_recommendation.get("replan_obligation"), dict)
-            else {}
-        )
-        return {
-            "must_attempt_work": True,
-            "kind": "autonomous_replan_required",
-            "minimum": "one_bounded_replan_segment",
-            "notify_is_execution_gate": False,
-            "stall_threshold": replan_obligation.get("stall_threshold"),
-            "contract_obligation": "apply autonomous_replan_obligation before monitor-only work",
-            "reason": (
-                "autonomous_replan_obligation is a machine execution contract; "
-                "quiet no-op is not allowed until the replan slice is validated or blocked"
-            ),
-        }
-    if should_run and recommended_mode == AgentScopeFrontierAction.SUCCESSOR_REPLAN_REQUIRED.value:
-        return {
-            "must_attempt_work": True,
-            "kind": AgentScopeFrontierAction.SUCCESSOR_REPLAN_REQUIRED.value,
-            "minimum": "one_successor_replan_or_no_followup_writeback",
-            "delivery_allowed": False,
-            "notify_is_execution_gate": False,
-            "contract": "deferred_resume_projection",
-            "contract_obligation": (
-                "reopen or supersede the ready deferred successor, or record a "
-                "public-safe no-follow-up rationale before another quiet no-op"
-            ),
-            "spend_policy": heartbeat_recommendation.get("spend_policy"),
-            "reason": (
-                "a deferred successor resume condition is satisfied; the agent must "
-                "repair the todo projection before normal delivery"
-            ),
-        }
-    if should_run and recommended_mode == "repair_state_projection_gap":
-        return {
-            "must_attempt_work": True,
-            "kind": "state_projection_gap_repair",
-            "minimum": "one_replan_or_todo_expansion_or_blocker_writeback_segment",
-            "delivery_allowed": False,
-            "notify_is_execution_gate": False,
-            "contract": "state_projection_gap",
-            "contract_obligation": (
-                "repair the active-state projection before normal delivery: expand "
-                "Next Action into open Agent Todo/User Todo or write a compact blocker"
-            ),
-            "spend_policy": heartbeat_recommendation.get("spend_policy"),
-            "reason": (
-                "should_run=true exposed actionable prose but no open todo projection; "
-                "normal bounded delivery is blocked until projection is repaired"
-            ),
-        }
-    if should_run and recommended_mode == "repair_boundary_projection":
-        return {
-            "must_attempt_work": True,
-            "kind": "boundary_projection_repair",
-            "minimum": "one_boundary_projection_or_blocker_writeback_segment",
-            "delivery_allowed": False,
-            "notify_is_execution_gate": False,
-            "contract": "goal_boundary.write_scope",
-            "contract_obligation": (
-                "do not execute the selected write; repair goal_boundary.write_scope "
-                "projection, rewrite the selected todo within boundary, or create a "
-                "concrete user/controller gate"
-            ),
-            "spend_policy": heartbeat_recommendation.get("spend_policy"),
-            "reason": (
-                "selected executable todo requires a write scope that the current "
-                "goal_boundary does not project"
-            ),
-        }
-    if should_run and recommended_mode == "repair_capability_bridge":
-        return {
-            "must_attempt_work": True,
-            "kind": "capability_bridge_repair",
-            "minimum": "one_bridge_or_environment_repair_or_blocker_writeback_segment",
-            "delivery_allowed": False,
-            "notify_is_execution_gate": False,
-            "contract": "capability_gate",
-            "contract_obligation": (
-                "do not execute the selected capability-blocked todo; repair or "
-                "materialize the missing bridge/capability, rewrite the todo to an "
-                "available capability, or write a compact blocker"
-            ),
-            "spend_policy": heartbeat_recommendation.get("spend_policy"),
-            "reason": (
-                "all executable todos require unavailable bridge-style capabilities, "
-                "but a bounded bridge repair may be attempted"
-            ),
-        }
-    if should_run and work_lane_contract:
-        return {
-            "must_attempt_work": bool(work_lane_contract.get("must_attempt_work", should_run)),
-            "kind": "work_lane_contract",
-            "contract": "work_lane_contract",
-            "contract_obligation": work_lane_contract.get("obligation"),
-            "notify_is_execution_gate": False,
-            "reason": (
-                "work_lane_contract.obligation is the machine execution contract; "
-                "heartbeat_recommendation is explanatory"
-            ),
-        }
-    if should_run:
-        return {
-            "must_attempt_work": True,
-            "kind": effective_action or recommended_mode or "bounded_delivery",
-            "minimum": "one_bounded_segment",
-            "notify_is_execution_gate": False,
-            "reason": (
-                "should_run=true means a Codex-actionable turn exists; heartbeat notify "
-                "only controls whether to interrupt the user"
-            ),
-        }
-    return {
-        "must_attempt_work": False,
-        "kind": effective_action or recommended_mode or "skip",
-        "notify_is_execution_gate": False,
-        "reason": (
-            "should_run=false blocks delivery unless an explicit safe-bypass or "
-            "self-repair action is exposed"
-        ),
-    }
 
 
 def build_quota_plan(status_payload: dict[str, Any], *, mode: str = "status") -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- extract quota execution-obligation payload construction into loopx.policies.execution_obligation
- keep quota.py as a thin wrapper that passes the existing successor frontier enum value
- add a focused smoke that exercises side-agent workspace repair, external evidence observation, quiet noop, autonomous replan, successor replan, projection repairs, work-lane contract, generic run, and generic skip payloads

## Validation
- python3 examples/execution-obligation-policy-smoke.py
- python3 examples/work-lane-contract-smoke.py
- python3 examples/quota-plan-smoke.py
- python3 examples/heartbeat-quota-flow-smoke.py
- python3 -m py_compile loopx/quota.py loopx/policies/execution_obligation.py examples/execution-obligation-policy-smoke.py
- git diff --check
- loopx check --scan-path loopx/quota.py --scan-path loopx/policies/execution_obligation.py --scan-path examples/execution-obligation-policy-smoke.py

## Boundary
Public boundary scan clean for the changed files. loopx check reported one pre-existing duplicate index warning for loopx-meta run history; no new boundary errors.