### PR TITLE
Add event store migration bridge contract

### DIFF
--- a/docs/reference/protocols/event-sourced-state-contract-v0.md
+++ b/docs/reference/protocols/event-sourced-state-contract-v0.md
@@ -160,7 +160,8 @@ The migration should be staged:
 1. Define this contract and smoke-test replay/privacy invariants.
 2. Add a minimal event store and projection API for todo/history events.
 3. Dual-write `loopx todo`, `refresh-state`, quota spend, and gate commands.
-4. Compare event projection against current Markdown parsing.
+4. Compare event projection against current Markdown parsing through
+   `event_store_migration_bridge_v0`.
 5. Prefer event projection for status, quota, review packets, dashboard, and
    slash-command help.
 6. Keep Markdown rendering as the workbench and compatibility export.

--- a/docs/reference/protocols/event-store-migration-bridge-v0.md
+++ b/docs/reference/protocols/event-store-migration-bridge-v0.md
@@ -1,0 +1,87 @@
+# event_store_migration_bridge_v0
+
+`event_store_migration_bridge_v0` is the fail-closed bridge between the
+Markdown active-state read model and a future event projection read model.
+
+It does not make the event projection canonical. It records the gates that must
+be clean before a reviewed runtime change may prefer event projection for
+status, quota, review packets, dashboards, or slash-command reads.
+
+## Contract
+
+The bridge packet is built by
+`loopx.policies.event_store_migration_bridge.build_event_store_migration_bridge`
+and carries:
+
+- `source_of_truth`: currently `markdown_active_state`;
+- `candidate_source`: currently `event_projection`;
+- `stage`: one of `wait_for_event_read_path`, `dual_read_shadow`,
+  `bounded_canary`, or `promotion_candidate`;
+- `promotion_allowed`: always `false` in this bridge contract;
+- `promotion_candidate`: true only when all pre-promotion checks are clean;
+- `checks`: compact booleans for read-path, parity, rollback, canary,
+  idempotency, projection-head, and public-boundary readiness;
+- `missing_for_shadow`, `missing_for_canary`, and `missing_for_promotion`;
+- `dual_read`, `rollback`, and `canary` subcontracts.
+
+## Stages
+
+`wait_for_event_read_path` means the event read path or structured
+active-state projection is not ready. The only safe action is to finish those
+prerequisites.
+
+`dual_read_shadow` means both read models may be compared, but Markdown remains
+the source of truth. Any parity delta must prefer Markdown and record a compact
+delta rather than silently promoting event projection.
+
+`bounded_canary` means parity, rollback, idempotency, projection-head, and
+public-boundary checks are clean enough to run a small read-only canary. The
+canary uses a limited goal set and duration, with event write preference still
+disabled.
+
+`promotion_candidate` means the bridge has enough evidence to propose a
+separate reviewed runtime PR. It is not an automatic promotion state.
+
+## Required Gates
+
+Promotion requires all of these to be clean:
+
+- event read path ready;
+- active-state structured projection ready;
+- dual-read parity clean for todo ids, status, priority/planner order,
+  `claimed_by`, gate refs, and projection head sequence;
+- event projection head matches the event store head;
+- rollback plan recorded;
+- bounded canary passed;
+- idempotency conflicts clean;
+- public boundary clean.
+
+## Rollback
+
+Rollback is mandatory. The fallback source is always the Markdown active-state
+parser until a later reviewed write-path change changes the source of truth.
+
+Rollback triggers include:
+
+- parity delta;
+- projection head mismatch;
+- event append conflict;
+- public boundary warning;
+- canary regression.
+
+The rollback action is to disable event projection preference and keep the
+Markdown parser as canonical read fallback.
+
+## Canary
+
+The bounded canary is read-only:
+
+- small goal limit, default 1;
+- short duration, default 30 minutes;
+- event write path disabled;
+- read preference remains Markdown;
+- observe status todo summaries, quota selected todo, review packet todo refs,
+  dashboard/frontstage projection, and event projection head sequence.
+
+Success requires no parity delta, no idempotency conflict, no private-boundary
+warning, and a one-command-safe rollback.

--- a/examples/event-store-migration-bridge-smoke.py
+++ b/examples/event-store-migration-bridge-smoke.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Smoke-test the event-store migration bridge promotion gates."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.policies.event_store_migration_bridge import (  # noqa: E402
+    EVENT_PROJECTION_SOURCE,
+    MARKDOWN_ACTIVE_STATE_SOURCE,
+    build_event_store_migration_bridge,
+)
+
+
+GOAL_ID = "event-store-migration-bridge-fixture"
+
+
+def test_fail_closed_before_event_read_path() -> None:
+    bridge = build_event_store_migration_bridge(
+        goal_id=GOAL_ID,
+        event_read_path_ready=False,
+        active_state_projection_ready=False,
+    )
+    assert bridge["schema_version"] == "event_store_migration_bridge_v0", bridge
+    assert bridge["source_of_truth"] == MARKDOWN_ACTIVE_STATE_SOURCE, bridge
+    assert bridge["candidate_source"] == EVENT_PROJECTION_SOURCE, bridge
+    assert bridge["stage"] == "wait_for_event_read_path", bridge
+    assert bridge["promotion_allowed"] is False, bridge
+    assert bridge["promotion_candidate"] is False, bridge
+    assert bridge["dual_read"]["enabled"] is False, bridge
+    assert bridge["canary"]["ready"] is False, bridge
+    assert bridge["rollback"]["fallback_source"] == MARKDOWN_ACTIVE_STATE_SOURCE, bridge
+    assert bridge["missing_for_shadow"] == [
+        "event_read_path_ready",
+        "active_state_projection_ready",
+    ], bridge
+    assert "bounded_canary_passed" in bridge["missing_for_promotion"], bridge
+
+
+def test_shadow_mode_requires_parity_and_rollback() -> None:
+    bridge = build_event_store_migration_bridge(
+        goal_id=GOAL_ID,
+        event_read_path_ready=True,
+        active_state_projection_ready=True,
+        dual_read_parity_clean=False,
+        rollback_plan_recorded=False,
+        idempotency_conflicts_clean=False,
+        public_boundary_clean=False,
+    )
+    assert bridge["stage"] == "dual_read_shadow", bridge
+    assert bridge["dual_read"]["enabled"] is True, bridge
+    assert bridge["dual_read"]["failure_policy"] == "prefer_markdown_and_record_parity_delta", bridge
+    assert bridge["promotion_allowed"] is False, bridge
+    assert bridge["canary"]["ready"] is False, bridge
+    assert bridge["missing_for_canary"] == [
+        "dual_read_parity_clean",
+        "event_projection_head_matches_store",
+        "rollback_plan_recorded",
+        "idempotency_conflicts_clean",
+        "public_boundary_clean",
+    ], bridge
+
+
+def test_canary_ready_does_not_promote_automatically() -> None:
+    bridge = build_event_store_migration_bridge(
+        goal_id=GOAL_ID,
+        event_read_path_ready=True,
+        active_state_projection_ready=True,
+        dual_read_parity_clean=True,
+        event_projection_head_matches_store=True,
+        rollback_plan_recorded=True,
+        idempotency_conflicts_clean=True,
+        public_boundary_clean=True,
+        bounded_canary_passed=False,
+        canary_goal_limit=2,
+        canary_duration_minutes=45,
+        evidence_refs=["event-projection-parity-smoke"],
+    )
+    assert bridge["stage"] == "bounded_canary", bridge
+    assert bridge["promotion_candidate"] is False, bridge
+    assert bridge["promotion_allowed"] is False, bridge
+    assert bridge["missing_for_canary"] == [], bridge
+    assert bridge["missing_for_promotion"] == ["bounded_canary_passed"], bridge
+    assert bridge["canary"]["ready"] is True, bridge
+    assert bridge["canary"]["scope"] == {
+        "max_goals": 2,
+        "duration_minutes": 45,
+        "write_path": "disabled",
+        "read_preference": MARKDOWN_ACTIVE_STATE_SOURCE,
+    }, bridge
+    assert bridge["evidence_refs"] == ["event-projection-parity-smoke"], bridge
+
+
+def test_promotion_candidate_still_requires_reviewed_write_path_change() -> None:
+    bridge = build_event_store_migration_bridge(
+        goal_id=GOAL_ID,
+        event_read_path_ready=True,
+        active_state_projection_ready=True,
+        dual_read_parity_clean=True,
+        event_projection_head_matches_store=True,
+        rollback_plan_recorded=True,
+        idempotency_conflicts_clean=True,
+        public_boundary_clean=True,
+        bounded_canary_passed=True,
+    )
+    assert bridge["stage"] == "promotion_candidate", bridge
+    assert bridge["promotion_candidate"] is True, bridge
+    assert bridge["promotion_allowed"] is False, bridge
+    assert bridge["missing_for_promotion"] == [], bridge
+    assert "explicit reviewed write-path change" in bridge["next_action"], bridge
+    assert bridge["rollback"]["recorded"] is True, bridge
+    assert bridge["canary"]["passed"] is True, bridge
+
+
+def main() -> int:
+    test_fail_closed_before_event_read_path()
+    test_shadow_mode_requires_parity_and_rollback()
+    test_canary_ready_does_not_promote_automatically()
+    test_promotion_candidate_still_requires_reviewed_write_path_change()
+    print("event-store-migration-bridge-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/policies/event_store_migration_bridge.py
+++ b/loopx/policies/event_store_migration_bridge.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+EVENT_STORE_MIGRATION_BRIDGE_SCHEMA_VERSION = "event_store_migration_bridge_v0"
+EVENT_STORE_MIGRATION_CANARY_SCHEMA_VERSION = "event_store_migration_canary_v0"
+
+MARKDOWN_ACTIVE_STATE_SOURCE = "markdown_active_state"
+EVENT_PROJECTION_SOURCE = "event_projection"
+
+
+def _compact_text(value: Any) -> str:
+    return " ".join(str(value or "").strip().split())
+
+
+def _bool(value: Any) -> bool:
+    return value is True
+
+
+def build_event_store_migration_bridge(
+    *,
+    goal_id: str,
+    event_read_path_ready: bool,
+    dual_read_parity_clean: bool = False,
+    rollback_plan_recorded: bool = False,
+    bounded_canary_passed: bool = False,
+    idempotency_conflicts_clean: bool = False,
+    public_boundary_clean: bool = False,
+    active_state_projection_ready: bool = False,
+    event_projection_head_matches_store: bool = False,
+    canary_goal_limit: int = 1,
+    canary_duration_minutes: int = 30,
+    evidence_refs: list[str] | None = None,
+) -> dict[str, Any]:
+    """Build a fail-closed migration bridge before event projection promotion."""
+
+    normalized_goal_id = _compact_text(goal_id)
+    if not normalized_goal_id:
+        raise ValueError("goal_id is required")
+    canary_goal_limit = max(1, int(canary_goal_limit or 1))
+    canary_duration_minutes = max(1, int(canary_duration_minutes or 1))
+    evidence = [_compact_text(ref) for ref in (evidence_refs or []) if _compact_text(ref)]
+
+    checks = {
+        "event_read_path_ready": _bool(event_read_path_ready),
+        "active_state_projection_ready": _bool(active_state_projection_ready),
+        "dual_read_parity_clean": _bool(dual_read_parity_clean),
+        "event_projection_head_matches_store": _bool(event_projection_head_matches_store),
+        "rollback_plan_recorded": _bool(rollback_plan_recorded),
+        "bounded_canary_passed": _bool(bounded_canary_passed),
+        "idempotency_conflicts_clean": _bool(idempotency_conflicts_clean),
+        "public_boundary_clean": _bool(public_boundary_clean),
+    }
+    required_for_shadow = [
+        "event_read_path_ready",
+        "active_state_projection_ready",
+    ]
+    required_for_canary = [
+        *required_for_shadow,
+        "dual_read_parity_clean",
+        "event_projection_head_matches_store",
+        "rollback_plan_recorded",
+        "idempotency_conflicts_clean",
+        "public_boundary_clean",
+    ]
+    required_for_promotion = [
+        *required_for_canary,
+        "bounded_canary_passed",
+    ]
+    missing_for_shadow = [key for key in required_for_shadow if not checks[key]]
+    missing_for_canary = [key for key in required_for_canary if not checks[key]]
+    missing_for_promotion = [key for key in required_for_promotion if not checks[key]]
+
+    if missing_for_shadow:
+        stage = "wait_for_event_read_path"
+        next_action = (
+            "finish event read-path prerequisites before dual-read migration work"
+        )
+    elif missing_for_canary:
+        stage = "dual_read_shadow"
+        next_action = (
+            "compare Markdown read model and event projection until parity, rollback, "
+            "idempotency, and public-boundary checks are clean"
+        )
+    elif missing_for_promotion:
+        stage = "bounded_canary"
+        next_action = (
+            "run the bounded canary on a small goal set before promotion"
+        )
+    else:
+        stage = "promotion_candidate"
+        next_action = (
+            "promote event projection only through an explicit reviewed write-path change"
+        )
+
+    return {
+        "schema_version": EVENT_STORE_MIGRATION_BRIDGE_SCHEMA_VERSION,
+        "goal_id": normalized_goal_id,
+        "source_of_truth": MARKDOWN_ACTIVE_STATE_SOURCE,
+        "candidate_source": EVENT_PROJECTION_SOURCE,
+        "stage": stage,
+        "promotion_allowed": False,
+        "promotion_candidate": not missing_for_promotion,
+        "next_action": next_action,
+        "checks": checks,
+        "missing_for_shadow": missing_for_shadow,
+        "missing_for_canary": missing_for_canary,
+        "missing_for_promotion": missing_for_promotion,
+        "dual_read": {
+            "enabled": not missing_for_shadow,
+            "read_order": [
+                MARKDOWN_ACTIVE_STATE_SOURCE,
+                EVENT_PROJECTION_SOURCE,
+            ],
+            "failure_policy": "prefer_markdown_and_record_parity_delta",
+            "required_equality": [
+                "todo ids",
+                "todo status",
+                "priority and planner order",
+                "claimed_by",
+                "gate refs",
+                "projection head sequence",
+            ],
+        },
+        "rollback": {
+            "required": True,
+            "recorded": checks["rollback_plan_recorded"],
+            "fallback_source": MARKDOWN_ACTIVE_STATE_SOURCE,
+            "trigger": [
+                "parity delta",
+                "projection head mismatch",
+                "event append conflict",
+                "public boundary warning",
+                "canary regression",
+            ],
+            "action": "disable event projection preference and keep Markdown parser as canonical read fallback",
+        },
+        "canary": build_event_store_migration_canary(
+            goal_id=normalized_goal_id,
+            ready=not missing_for_canary,
+            passed=checks["bounded_canary_passed"],
+            goal_limit=canary_goal_limit,
+            duration_minutes=canary_duration_minutes,
+            evidence_refs=evidence,
+        ),
+        "evidence_refs": evidence,
+    }
+
+
+def build_event_store_migration_canary(
+    *,
+    goal_id: str,
+    ready: bool,
+    passed: bool = False,
+    goal_limit: int = 1,
+    duration_minutes: int = 30,
+    evidence_refs: list[str] | None = None,
+) -> dict[str, Any]:
+    """Describe the bounded rollout canary for event-store read promotion."""
+
+    normalized_goal_id = _compact_text(goal_id)
+    if not normalized_goal_id:
+        raise ValueError("goal_id is required")
+    goal_limit = max(1, int(goal_limit or 1))
+    duration_minutes = max(1, int(duration_minutes or 1))
+    evidence = [_compact_text(ref) for ref in (evidence_refs or []) if _compact_text(ref)]
+
+    return {
+        "schema_version": EVENT_STORE_MIGRATION_CANARY_SCHEMA_VERSION,
+        "goal_id": normalized_goal_id,
+        "ready": bool(ready),
+        "passed": bool(passed),
+        "scope": {
+            "max_goals": goal_limit,
+            "duration_minutes": duration_minutes,
+            "write_path": "disabled",
+            "read_preference": MARKDOWN_ACTIVE_STATE_SOURCE,
+        },
+        "observe": [
+            "status todo summaries",
+            "quota selected todo",
+            "review packet todo refs",
+            "dashboard/frontstage projection",
+            "event projection head sequence",
+        ],
+        "success_criteria": [
+            "no parity delta",
+            "no idempotency conflict",
+            "no private-boundary warning",
+            "rollback remains one-command safe",
+        ],
+        "failure_policy": "stop canary and keep Markdown parser canonical",
+        "evidence_refs": evidence,
+    }


### PR DESCRIPTION
## Summary
- add a fail-closed event_store_migration_bridge_v0 policy helper under loopx.policies
- define stages for wait_for_event_read_path, dual_read_shadow, bounded_canary, and promotion_candidate
- add a protocol note and connect the existing event-sourced state migration path to this bridge
- add a focused smoke that proves promotion stays disabled until a separate reviewed write-path change

## Validation
- python3 examples/event-store-migration-bridge-smoke.py
- python3 examples/event-sourced-state-api-smoke.py
- python3 -m py_compile loopx/policies/event_store_migration_bridge.py examples/event-store-migration-bridge-smoke.py
- git diff --check
- loopx check --scan-path loopx/policies/event_store_migration_bridge.py --scan-path examples/event-store-migration-bridge-smoke.py --scan-path docs/reference/protocols/event-store-migration-bridge-v0.md --scan-path docs/reference/protocols/event-sourced-state-contract-v0.md

## Boundary
Public boundary scan clean for the changed files. Manual sensitive-word scan only matched existing protocol safety language that forbids credentials/raw logs/private material in public projections. loopx check still reports the pre-existing loopx-meta duplicate-index warning.