### PR TITLE
Add auto-research quickstart command

### DIFF
--- a/docs/product/decentralized-auto-research-showcase.md
+++ b/docs/product/decentralized-auto-research-showcase.md
@@ -113,6 +113,31 @@ next agent does not rediscover them from scratch.
 
 ## Minimal Reproduction Plan
 
+New users should not have to learn the full command matrix first. The
+quickstart path starts from one read-only command that returns the research
+contract, the files that would be created, and the first runnable hypothesis for
+the current agent:
+
+```bash
+loopx --format json auto-research quickstart \
+  --agent-id codex-side-bypass
+```
+
+When the preview is acceptable, explicitly create the protected starter pack:
+
+```bash
+loopx --format json auto-research quickstart \
+  --agent-id codex-side-bypass \
+  --output-dir auto_research_knn_pack \
+  --execute
+```
+
+This writes a k-NN research pack with one editable candidate file, a protected
+baseline/evaluator, and a `research_contract_v0`. The command also returns the
+next dev/holdout/evidence commands, so an agent can continue from a concrete
+hypothesis instead of choosing among `frontier`, `evidence`, and
+`append-evidence` manually.
+
 The runnable pack now lives at `examples/auto_research_knn_pack/`. It provides
 an editable candidate solver, a protected evaluator, deterministic dev/held-out
 splits, and a no-upload boundary.

--- a/examples/auto-research-quickstart-smoke.py
+++ b/examples/auto-research-quickstart-smoke.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.capabilities.auto_research import (
+    AUTO_RESEARCH_QUICKSTART_SCHEMA_VERSION,
+    build_auto_research_quickstart,
+)
+
+
+def _run_json(command: list[str], *, cwd: Path) -> dict[str, object]:
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        preview = build_auto_research_quickstart(
+            agent_id="codex-side-bypass",
+            output_dir="auto_research_knn_pack",
+            execute=False,
+            cwd=root,
+        )
+        assert preview["schema_version"] == AUTO_RESEARCH_QUICKSTART_SCHEMA_VERSION
+        assert preview["mode"] == "dry_run"
+        assert not (root / "auto_research_knn_pack").exists()
+
+        created = build_auto_research_quickstart(
+            agent_id="codex-side-bypass",
+            output_dir="auto_research_knn_pack",
+            execute=True,
+            cwd=root,
+        )
+        assert created["mode"] == "execute"
+        pack = root / "auto_research_knn_pack"
+        assert (pack / "research_contract.json").exists()
+        assert (pack / "protected_eval.py").exists()
+        assert (pack / "solution_candidate.py").exists()
+
+        dev = _run_json(
+            [
+                sys.executable,
+                "protected_eval.py",
+                "--solution",
+                "solution_candidate.py",
+                "--split",
+                "dev",
+            ],
+            cwd=pack,
+        )
+        holdout = _run_json(
+            [
+                sys.executable,
+                "protected_eval.py",
+                "--solution",
+                "solution_candidate.py",
+                "--split",
+                "holdout",
+            ],
+            cwd=pack,
+        )
+        assert dev["exact"] is True
+        assert holdout["exact"] is True
+        assert dev["metric"]["value"] == 4.0
+        assert holdout["metric"]["value"] == 4.5
+        assert dev["protected_scope_clean"] is True
+        assert holdout["protected_scope_clean"] is True
+    print("auto-research quickstart smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/capabilities/auto_research/__init__.py
+++ b/loopx/capabilities/auto_research/__init__.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
 from .core import (
+    AUTO_RESEARCH_DEFAULT_GOAL_ID,
+    AUTO_RESEARCH_DEFAULT_OBJECTIVE,
     AUTO_RESEARCH_FIXTURE_SCHEMA_VERSION,
     AUTO_RESEARCH_PROJECTION_SCHEMA_VERSION,
+    AUTO_RESEARCH_QUICKSTART_SCHEMA_VERSION,
+    AUTO_RESEARCH_QUICKSTART_TEMPLATE,
     EVIDENCE_STATUSES,
     HYPOTHESIS_STATUSES,
     METRIC_DIRECTIONS,
@@ -14,6 +18,7 @@ from .core import (
     RESEARCH_SHOWCASE_PROJECTION_SCHEMA_VERSION,
     AUTO_RESEARCH_EVIDENCE_PACKET_SCHEMA_VERSION,
     AUTO_RESEARCH_ROLLOUT_APPEND_SCHEMA_VERSION,
+    build_auto_research_quickstart,
     build_auto_research_projection,
     build_auto_research_evidence_packet,
     build_auto_research_rollout_events,
@@ -36,8 +41,12 @@ from .core import (
 )
 
 __all__ = [
+    "AUTO_RESEARCH_DEFAULT_GOAL_ID",
+    "AUTO_RESEARCH_DEFAULT_OBJECTIVE",
     "AUTO_RESEARCH_FIXTURE_SCHEMA_VERSION",
     "AUTO_RESEARCH_PROJECTION_SCHEMA_VERSION",
+    "AUTO_RESEARCH_QUICKSTART_SCHEMA_VERSION",
+    "AUTO_RESEARCH_QUICKSTART_TEMPLATE",
     "EVIDENCE_STATUSES",
     "HYPOTHESIS_STATUSES",
     "METRIC_DIRECTIONS",
@@ -49,6 +58,7 @@ __all__ = [
     "RESEARCH_SHOWCASE_PROJECTION_SCHEMA_VERSION",
     "AUTO_RESEARCH_EVIDENCE_PACKET_SCHEMA_VERSION",
     "AUTO_RESEARCH_ROLLOUT_APPEND_SCHEMA_VERSION",
+    "build_auto_research_quickstart",
     "build_auto_research_projection",
     "build_auto_research_evidence_packet",
     "build_auto_research_rollout_events",

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -6,7 +6,11 @@ from collections.abc import Callable
 from pathlib import Path
 
 from . import (
+    AUTO_RESEARCH_DEFAULT_GOAL_ID,
+    AUTO_RESEARCH_DEFAULT_OBJECTIVE,
+    AUTO_RESEARCH_QUICKSTART_TEMPLATE,
     AUTO_RESEARCH_ROLLOUT_APPEND_SCHEMA_VERSION,
+    build_auto_research_quickstart,
     build_auto_research_rollout_events,
     build_live_auto_research_projection,
     build_auto_research_projection,
@@ -46,6 +50,43 @@ def register_auto_research_commands(
         dest="auto_research_command",
         required=True,
     )
+    quickstart_parser = auto_research_sub.add_parser(
+        "quickstart",
+        help="Preview or create a protected starter pack for decentralized auto-research.",
+    )
+    add_subcommand_format(quickstart_parser)
+    quickstart_parser.add_argument(
+        "--agent-id",
+        required=True,
+        help="Agent id that should receive the first runnable hypothesis.",
+    )
+    quickstart_parser.add_argument(
+        "--goal-id",
+        default=AUTO_RESEARCH_DEFAULT_GOAL_ID,
+        help="Research goal id for the generated contract.",
+    )
+    quickstart_parser.add_argument(
+        "--objective",
+        default=AUTO_RESEARCH_DEFAULT_OBJECTIVE,
+        help="Compact public-safe research objective for the generated contract.",
+    )
+    quickstart_parser.add_argument(
+        "--output-dir",
+        default="auto_research_knn_pack",
+        help="Relative output directory for --execute. Refuses to overwrite an existing pack.",
+    )
+    quickstart_parser.add_argument(
+        "--template",
+        choices=[AUTO_RESEARCH_QUICKSTART_TEMPLATE],
+        default=AUTO_RESEARCH_QUICKSTART_TEMPLATE,
+        help="Starter pack template.",
+    )
+    quickstart_parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Write the starter pack. Omit for a read-only preview.",
+    )
+
     frontier_parser = auto_research_sub.add_parser(
         "frontier",
         help="Render a per-agent decentralized research frontier from a public fixture or live LoopX state.",
@@ -164,7 +205,17 @@ def handle_auto_research_command(
     print_payload: PrintPayload,
 ) -> int:
     try:
-        if args.auto_research_command == "frontier":
+        if args.auto_research_command == "quickstart":
+            payload = build_auto_research_quickstart(
+                agent_id=args.agent_id,
+                goal_id=args.goal_id,
+                objective=args.objective,
+                output_dir=args.output_dir,
+                template=args.template,
+                execute=args.execute,
+                cwd=Path.cwd(),
+            )
+        elif args.auto_research_command == "frontier":
             if bool(args.fixture) == bool(args.goal_id):
                 raise ValueError("auto-research frontier requires exactly one of --fixture or --goal-id")
             if args.fixture:
@@ -220,7 +271,9 @@ def handle_auto_research_command(
                 dry_run=args.dry_run,
             )
         else:
-            raise ValueError("auto-research requires the `frontier`, `evidence`, or `append-evidence` subcommand")
+            raise ValueError(
+                "auto-research requires the `quickstart`, `frontier`, `evidence`, or `append-evidence` subcommand"
+            )
     except Exception as exc:
         payload = {
             "ok": False,

--- a/loopx/capabilities/auto_research/core.py
+++ b/loopx/capabilities/auto_research/core.py
@@ -19,6 +19,10 @@ RESEARCH_SHOWCASE_PROJECTION_SCHEMA_VERSION = "research_showcase_projection_v0"
 AUTO_RESEARCH_PROJECTION_SCHEMA_VERSION = "decentralized_auto_research_projection_v0"
 AUTO_RESEARCH_EVIDENCE_PACKET_SCHEMA_VERSION = "auto_research_evidence_packet_v0"
 AUTO_RESEARCH_ROLLOUT_APPEND_SCHEMA_VERSION = "auto_research_rollout_append_v0"
+AUTO_RESEARCH_QUICKSTART_SCHEMA_VERSION = "auto_research_quickstart_v0"
+AUTO_RESEARCH_DEFAULT_GOAL_ID = "loopx-auto-research-knn"
+AUTO_RESEARCH_DEFAULT_OBJECTIVE = "Improve exact k-nearest-neighbor inference under a protected evaluator."
+AUTO_RESEARCH_QUICKSTART_TEMPLATE = "knn-exact"
 ROLLOUT_EVIDENCE_GRAPH_SOURCE_KIND = "loopx_rollout_event_log"
 
 HYPOTHESIS_STATUSES = {
@@ -501,6 +505,433 @@ def validate_auto_research_evidence_packet(payload: dict[str, Any]) -> dict[str,
             "raw_logs_recorded": False,
             "private_artifacts_recorded": False,
             "source": "public_eval_result_projection",
+        },
+    }
+
+
+def _relative_pack_dir(value: Any) -> Path:
+    text = _compact_public_text(value, field="output_dir", max_len=160)
+    if "\\" in text:
+        raise ValueError("output_dir must use forward-slash relative paths")
+    path = Path(text)
+    if path.is_absolute():
+        raise ValueError("output_dir must be relative")
+    if not path.parts:
+        raise ValueError("output_dir must be non-empty")
+    if any(part in {"", ".", ".."} for part in path.parts):
+        raise ValueError("output_dir must not contain current or parent-directory markers")
+    return path
+
+
+def _quickstart_contract(*, goal_id: str, objective: str) -> dict[str, Any]:
+    contract = validate_research_contract(
+        {
+            "schema_version": RESEARCH_CONTRACT_SCHEMA_VERSION,
+            "goal_id": goal_id,
+            "research_objective": objective,
+            "editable_scope": ["solution_candidate.py"],
+            "protected_scope": [
+                "protected_eval.py",
+                "solution_baseline.py",
+                "research_contract.json",
+            ],
+            "metric": {
+                "name": "deterministic_speedup",
+                "direction": "maximize",
+                "baseline": 1.0,
+            },
+            "dev_eval": "python3 protected_eval.py --solution solution_candidate.py --split dev",
+            "holdout_eval": "python3 protected_eval.py --solution solution_candidate.py --split holdout",
+            "promotion_policy": "requires_dev_and_holdout_improvement_exactness_and_clean_boundary",
+        }
+    )
+    contract["no_upload"] = True
+    return contract
+
+
+_QUICKSTART_PROTECTED_EVAL = '''#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any
+
+
+sys.dont_write_bytecode = True
+
+SCHEMA_VERSION = "auto_research_knn_eval_result_v0"
+PACK_DIR = Path(__file__).resolve().parent
+Point = tuple[float, ...]
+
+SPLITS: dict[str, dict[str, int]] = {
+    "dev": {"seed": 17, "train_count": 256, "query_count": 18, "dims": 4, "k": 3},
+    "holdout": {"seed": 31, "train_count": 512, "query_count": 24, "dims": 4, "k": 3},
+}
+
+
+def _point(seed: int, index: int, dims: int) -> Point:
+    values = []
+    for dim in range(dims):
+        raw = (seed * (dim + 5) + index * (dim * 23 + 11) + index * index * (dim + 3)) % 997
+        values.append(raw / 97.0)
+    return tuple(values)
+
+
+def build_split(split: str) -> tuple[list[Point], list[Point], int, dict[str, int]]:
+    if split not in SPLITS:
+        raise ValueError(f"unknown split {split!r}")
+    spec = SPLITS[split]
+    train = [_point(spec["seed"], index, spec["dims"]) for index in range(spec["train_count"])]
+    queries = [
+        _point(spec["seed"] + 101, index, spec["dims"])
+        for index in range(spec["query_count"])
+    ]
+    return train, queries, spec["k"], spec
+
+
+def _squared_distance(left: Point, right: Point) -> float:
+    return sum((a - b) * (a - b) for a, b in zip(left, right))
+
+
+def oracle_knn(train: list[Point], queries: list[Point], k: int) -> list[list[int]]:
+    expected: list[list[int]] = []
+    for query in queries:
+        ranked = sorted((_squared_distance(query, point), index) for index, point in enumerate(train))
+        expected.append([index for _, index in ranked[:k]])
+    return expected
+
+
+def load_solution(path: Path) -> Any:
+    spec = importlib.util.spec_from_file_location("auto_research_knn_solution", path)
+    if spec is None or spec.loader is None:
+        raise ValueError(f"cannot load solution from {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    if not hasattr(module, "solve_knn"):
+        raise ValueError("solution must define solve_knn(train, queries, k)")
+    return module
+
+
+def ranking_work_units(strategy: str, *, train_count: int, query_count: int, k: int) -> int:
+    if strategy == "partial_selection":
+        rank_factor = max(1, math.ceil(math.log2(k + 1)))
+    else:
+        rank_factor = max(1, math.ceil(math.log2(train_count)))
+    return query_count * train_count * rank_factor
+
+
+def evaluate(solution_path: Path, split: str) -> dict[str, Any]:
+    solution_path = solution_path.resolve()
+    train, queries, k, spec = build_split(split)
+    module = load_solution(solution_path)
+    strategy = str(getattr(module, "STRATEGY", "unknown"))
+    expected = oracle_knn(train, queries, k)
+    actual = module.solve_knn(train, queries, k)
+    exact = actual == expected
+
+    baseline_units = ranking_work_units(
+        "full_sort",
+        train_count=spec["train_count"],
+        query_count=spec["query_count"],
+        k=k,
+    )
+    candidate_units = ranking_work_units(
+        strategy,
+        train_count=spec["train_count"],
+        query_count=spec["query_count"],
+        k=k,
+    )
+    speedup = baseline_units / candidate_units if exact else None
+    improved = bool(speedup is not None and speedup > 1.0)
+    protected_scope_clean = solution_path.parent == PACK_DIR and solution_path.name in {
+        "solution_baseline.py",
+        "solution_candidate.py",
+    }
+    promotion_ready = exact and improved and protected_scope_clean
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "split": split,
+        "solution": solution_path.name,
+        "strategy": strategy,
+        "dataset": {
+            "train_count": spec["train_count"],
+            "query_count": spec["query_count"],
+            "dims": spec["dims"],
+            "k": k,
+            "seed": spec["seed"],
+        },
+        "metric": {
+            "name": "deterministic_speedup",
+            "direction": "maximize",
+            "value": round(speedup, 6) if speedup is not None else None,
+            "baseline": 1.0,
+        },
+        "work_units": {
+            "baseline_full_sort": baseline_units,
+            "candidate": candidate_units,
+        },
+        "exact": exact,
+        "protected_scope_clean": protected_scope_clean,
+        "no_upload": True,
+        "eval_status": "scored" if exact else "guardrail_failed",
+        "primary_metric_status": "improved" if improved else ("baseline" if exact else "failed"),
+        "promotion_gate": {
+            "requires": [
+                "exact_neighbor_identity",
+                "dev_and_holdout_improvement",
+                "protected_scope_clean",
+                "no_upload",
+            ],
+            "ready_for_split": promotion_ready,
+        },
+        "artifact_refs": [
+            f"knn_pack:{split}:{strategy}",
+        ],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Protected evaluator for the public LoopX auto-research k-NN pack.")
+    parser.add_argument("--solution", required=True, help="Path to a solution module.")
+    parser.add_argument("--split", choices=sorted(SPLITS), required=True)
+    args = parser.parse_args()
+    payload = evaluate(Path(args.solution), args.split)
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0 if payload["exact"] and payload["protected_scope_clean"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+'''
+
+
+_QUICKSTART_SOLUTION_BASELINE = '''from __future__ import annotations
+
+
+STRATEGY = "full_sort"
+
+
+Point = tuple[float, ...]
+
+
+def _squared_distance(left: Point, right: Point) -> float:
+    return sum((a - b) * (a - b) for a, b in zip(left, right))
+
+
+def solve_knn(train: list[Point], queries: list[Point], k: int) -> list[list[int]]:
+    """Reference exact k-NN solver using a full distance sort per query."""
+
+    results: list[list[int]] = []
+    for query in queries:
+        ranked = sorted((_squared_distance(query, point), index) for index, point in enumerate(train))
+        results.append([index for _, index in ranked[:k]])
+    return results
+'''
+
+
+_QUICKSTART_SOLUTION_CANDIDATE = '''from __future__ import annotations
+
+import heapq
+
+
+STRATEGY = "partial_selection"
+
+
+Point = tuple[float, ...]
+
+
+def _squared_distance(left: Point, right: Point) -> float:
+    return sum((a - b) * (a - b) for a, b in zip(left, right))
+
+
+def solve_knn(train: list[Point], queries: list[Point], k: int) -> list[list[int]]:
+    """Exact k-NN using partial selection instead of sorting every distance."""
+
+    results: list[list[int]] = []
+    for query in queries:
+        nearest = heapq.nsmallest(
+            k,
+            ((_squared_distance(query, point), index) for index, point in enumerate(train)),
+        )
+        results.append([index for _, index in nearest])
+    return results
+'''
+
+
+_QUICKSTART_README = '''# LoopX Auto Research k-NN Pack
+
+This generated pack is a public-safe starter for a decentralized auto-research
+run. Edit only `solution_candidate.py`; keep `protected_eval.py`,
+`solution_baseline.py`, and `research_contract.json` unchanged.
+
+Run dev:
+
+```bash
+python3 protected_eval.py --solution solution_candidate.py --split dev
+```
+
+Run holdout:
+
+```bash
+python3 protected_eval.py --solution solution_candidate.py --split holdout
+```
+
+Promotion requires exact neighbor identity, dev and holdout improvement, clean
+protected scope, and no upload/private artifacts.
+'''
+
+
+def _quickstart_template_files(contract: dict[str, Any]) -> dict[str, str]:
+    return {
+        "research_contract.json": json.dumps(contract, indent=2, sort_keys=True) + "\n",
+        "protected_eval.py": _QUICKSTART_PROTECTED_EVAL,
+        "solution_baseline.py": _QUICKSTART_SOLUTION_BASELINE,
+        "solution_candidate.py": _QUICKSTART_SOLUTION_CANDIDATE,
+        "README.md": _QUICKSTART_README,
+    }
+
+
+def _quickstart_file_summary(
+    *,
+    pack_dir: Path,
+    files: dict[str, str],
+    write_status: str,
+) -> list[dict[str, Any]]:
+    protected_names = {"protected_eval.py", "solution_baseline.py", "research_contract.json"}
+    role_by_name = {
+        "README.md": "operator_notes",
+        "protected_eval.py": "protected_evaluator",
+        "research_contract.json": "research_contract",
+        "solution_baseline.py": "protected_baseline",
+        "solution_candidate.py": "editable_candidate",
+    }
+    return [
+        {
+            "path": f"{pack_dir.as_posix()}/{name}",
+            "role": role_by_name.get(name, "pack_file"),
+            "protected": name in protected_names,
+            "write_status": write_status,
+        }
+        for name in sorted(files)
+    ]
+
+
+def build_auto_research_quickstart(
+    *,
+    agent_id: str,
+    goal_id: str = AUTO_RESEARCH_DEFAULT_GOAL_ID,
+    objective: str = AUTO_RESEARCH_DEFAULT_OBJECTIVE,
+    output_dir: str = "auto_research_knn_pack",
+    template: str = AUTO_RESEARCH_QUICKSTART_TEMPLATE,
+    execute: bool = False,
+    cwd: Path | None = None,
+) -> dict[str, Any]:
+    """Create or preview the public k-NN auto-research starter contract.
+
+    The default mode is read-only. `execute=True` writes a protected evaluator
+    pack below the current working directory and refuses to overwrite an
+    existing pack, so heartbeat agents can preview the next hypothesis without
+    producing local artifacts by accident.
+    """
+
+    agent = _compact_public_token(agent_id, field="agent_id")
+    goal = _compact_public_token(goal_id, field="goal_id")
+    objective_text = _compact_public_text(objective, field="objective", max_len=240)
+    selected_template = _compact_public_token(template, field="template")
+    if selected_template != AUTO_RESEARCH_QUICKSTART_TEMPLATE:
+        raise ValueError(f"template must be {AUTO_RESEARCH_QUICKSTART_TEMPLATE}")
+    pack_dir = _relative_pack_dir(output_dir)
+    contract = _quickstart_contract(goal_id=goal, objective=objective_text)
+    files = _quickstart_template_files(contract)
+    dev_command = (
+        f"python3 {pack_dir.as_posix()}/protected_eval.py "
+        f"--solution {pack_dir.as_posix()}/solution_candidate.py --split dev"
+    )
+    holdout_command = (
+        f"python3 {pack_dir.as_posix()}/protected_eval.py "
+        f"--solution {pack_dir.as_posix()}/solution_candidate.py --split holdout"
+    )
+    hypothesis = validate_research_hypothesis(
+        {
+            "schema_version": RESEARCH_HYPOTHESIS_SCHEMA_VERSION,
+            "hypothesis_id": "hyp_quickstart_partial_selection",
+            "todo_id": "todo_auto_research_quickstart_001",
+            "claimed_by": agent,
+            "mechanism_family": "partial_selection",
+            "hypothesis": "Use exact partial selection to avoid full distance sorting.",
+            "status": "active",
+            "grounding_refs": ["quickstart:knn_exact_pack"],
+            "blocked_by": [],
+        }
+    )
+    write_status = "would_write"
+    if execute:
+        root = (cwd or Path.cwd()).resolve()
+        target_dir = (root / pack_dir).resolve()
+        try:
+            target_dir.relative_to(root)
+        except ValueError as exc:
+            raise ValueError("output_dir must resolve inside the current working directory") from exc
+        if target_dir.exists():
+            raise ValueError(f"output_dir already exists: {pack_dir.as_posix()}")
+        target_dir.mkdir(parents=True)
+        for name, contents in files.items():
+            target = target_dir / name
+            target.write_text(contents, encoding="utf-8")
+            if name == "protected_eval.py":
+                target.chmod(0o755)
+        write_status = "created"
+    file_summary = _quickstart_file_summary(
+        pack_dir=pack_dir,
+        files=files,
+        write_status=write_status,
+    )
+    return {
+        "ok": True,
+        "schema_version": AUTO_RESEARCH_QUICKSTART_SCHEMA_VERSION,
+        "mode": "execute" if execute else "dry_run",
+        "template": selected_template,
+        "research_contract": contract,
+        "pack_dir": pack_dir.as_posix(),
+        "files": file_summary,
+        "next_runnable_hypothesis": hypothesis | {
+            "allowed_action": "run_dev_attempt",
+            "run_command": dev_command,
+        },
+        "next_commands": [
+            {
+                "label": "create_pack",
+                "command": (
+                    f"loopx --format json auto-research quickstart --agent-id {agent} "
+                    f"--goal-id {goal} --output-dir {pack_dir.as_posix()} --execute"
+                ),
+                "required_when": "dry_run",
+            },
+            {"label": "run_dev", "command": dev_command},
+            {"label": "run_holdout", "command": holdout_command},
+            {
+                "label": "record_evidence",
+                "command": (
+                    "loopx --format json auto-research evidence "
+                    f"--contract {pack_dir.as_posix()}/research_contract.json "
+                    "--eval-result dev-result.public.json --eval-result holdout-result.public.json "
+                    "--hypothesis-id hyp_quickstart_partial_selection "
+                    "--todo-id todo_auto_research_quickstart_001 "
+                    f"--agent-id {agent} --claimed-by {agent} "
+                    "--mechanism-family partial_selection "
+                    '--hypothesis "Use exact partial selection to avoid full distance sorting."'
+                ),
+            },
+        ],
+        "public_boundary": {
+            "raw_logs_recorded": False,
+            "private_artifacts_recorded": False,
+            "absolute_paths_recorded": False,
+            "source": "generated_public_quickstart_contract",
         },
     }
 
@@ -1306,6 +1737,28 @@ def render_auto_research_projection_markdown(payload: dict[str, object]) -> str:
 def render_auto_research_markdown(payload: dict[str, object]) -> str:
     if not payload.get("ok"):
         return f"# LoopX Auto Research\n\n- ok: `False`\n- error: `{payload.get('error')}`\n"
+    if payload.get("schema_version") == AUTO_RESEARCH_QUICKSTART_SCHEMA_VERSION:
+        contract = payload["research_contract"]  # type: ignore[index]
+        hypothesis = payload["next_runnable_hypothesis"]  # type: ignore[index]
+        commands = payload.get("next_commands") or []
+        lines = [
+            "# LoopX Auto Research Quickstart",
+            "",
+            f"- schema: `{payload.get('schema_version')}`",
+            f"- mode: `{payload.get('mode')}`",
+            f"- pack_dir: `{payload.get('pack_dir')}`",
+            f"- goal_id: `{contract.get('goal_id')}`",
+            f"- objective: {contract.get('research_objective')}",
+            f"- next hypothesis: `{hypothesis.get('hypothesis_id')}`",
+            f"- allowed action: `{hypothesis.get('allowed_action')}`",
+            "",
+            "## Next Commands",
+        ]
+        for item in commands:
+            if not isinstance(item, dict):
+                continue
+            lines.append(f"- {item.get('label')}: `{item.get('command')}`")
+        return "\n".join(lines) + "\n"
     if payload.get("schema_version") == AUTO_RESEARCH_EVIDENCE_PACKET_SCHEMA_VERSION:
         summary = payload["summary"]  # type: ignore[index]
         hypothesis = payload["hypothesis"]  # type: ignore[index]


### PR DESCRIPTION
## Summary
- add `loopx auto-research quickstart` as a read-only-first newcomer entry for decentralized auto research
- let `--execute` scaffold a protected k-NN research pack with contract, evaluator, baseline, editable candidate, and next commands
- document the newcomer path and add a focused smoke covering dry-run, pack creation, and dev/holdout protected evals

## Validation
- `python3 -m py_compile loopx/capabilities/auto_research/core.py loopx/capabilities/auto_research/cli.py loopx/capabilities/auto_research/__init__.py examples/auto-research-quickstart-smoke.py`
- `python3 -m loopx.cli --format json auto-research quickstart --agent-id codex-side-bypass`
- `python3 examples/auto-research-quickstart-smoke.py`
- CLI execute temp pack with dev=4.0 and holdout=4.5
- `git diff --check`
- `loopx check --scan-path loopx/capabilities/auto_research --scan-path docs/product/decentralized-auto-research-showcase.md --scan-path examples/auto-research-quickstart-smoke.py` (public boundary clean; existing duplicate-index warning only)

## Boundary
- no raw logs, credentials, local paths, private docs, or internal context included
- quickstart default is dry-run; local files are only written with explicit `--execute` and existing output dirs are refused