### PR TITLE
Add auto-research demo supervisor plan

### DIFF
--- a/docs/product/decentralized-auto-research-showcase.md
+++ b/docs/product/decentralized-auto-research-showcase.md
@@ -220,6 +220,41 @@ The append step writes one `research_hypothesis` rollout event and one
 `research_evidence` event per split. It skips existing event ids on retry, which
 keeps heartbeat-driven lanes replayable.
 
+## Local Demo Supervisor
+
+The short-term multi-agent demo should be inspectable before it launches
+anything. The supervisor command therefore starts as a dry-run packet: it plans
+a visible tmux layout for multiple Codex CLI lanes, but it does not start tmux,
+launch Codex, read session files, write LoopX state, or spend quota.
+
+```bash
+loopx --format json auto-research demo-supervisor \
+  --goal-id loopx-auto-research-knn
+```
+
+The packet has two important product properties:
+
+- the supervisor is a host shell layout, not a leader agent;
+- every lane receives its own `quota should-run` and `auto-research frontier`
+  command, so work routing still comes from LoopX state, todo claims, gates,
+  and evidence graph projections.
+
+Operators can pass explicit lanes when rehearsing a real local demo:
+
+```bash
+loopx --format json auto-research demo-supervisor \
+  --goal-id loopx-auto-research-knn \
+  --agent codex-side-bypass:hypothesis-runner \
+  --agent codex-product-capability:evidence-promoter \
+  --agent codex-main-control:control-plane-guard
+```
+
+The generated shell plan uses environment placeholders such as `LOOPX_PROJECT`,
+`LOOPX_REGISTRY`, and `LOOPX_RUNTIME_ROOT` instead of embedding local absolute
+paths. A future `--execute` path must remain user-visible: attach to tmux
+before accepting any Codex prompt, preserve manual interrupt, and keep same-
+session prompt injection blocked until visible-attach and idle evidence pass.
+
 Next reproduction steps:
 
 1. Keep `research_contract_v0`, `research_hypothesis_v0`, and

--- a/examples/auto-research-demo-supervisor-smoke.py
+++ b/examples/auto-research-demo-supervisor-smoke.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Smoke-test the dry-run auto-research demo supervisor packet."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.capabilities.auto_research import (  # noqa: E402
+    AUTO_RESEARCH_DEMO_SUPERVISOR_SCHEMA_VERSION,
+    build_auto_research_demo_supervisor_plan,
+)
+
+
+GOAL_ID = "loopx-auto-research-knn"
+LANES = [
+    "codex-side-bypass:hypothesis-runner",
+    "codex-product-capability:evidence-promoter",
+    "codex-main-control:control-plane-guard",
+]
+
+
+def assert_no_private_surface(payload: dict[str, Any]) -> None:
+    text = json.dumps(payload, sort_keys=True)
+    forbidden = [
+        "/" + "Users/",
+        "/" + "private/",
+        "/" + "tmp/",
+        "lark" + "office",
+        "byte" + "dance",
+        "http" + "://",
+        "https" + "://",
+        "api" + "_key",
+        "pass" + "word",
+        "sec" + "ret",
+    ]
+    leaked = [needle for needle in forbidden if needle.lower() in text.lower()]
+    assert not leaked, leaked
+
+
+def assert_supervisor_contract(payload: dict[str, Any]) -> None:
+    assert payload["ok"] is True, payload
+    assert payload["schema_version"] == AUTO_RESEARCH_DEMO_SUPERVISOR_SCHEMA_VERSION, payload
+    assert payload["mode"] == "dry_run", payload
+    assert payload["goal_id"] == GOAL_ID, payload
+    assert payload["coordination_model"]["leader_agent_required"] is False, payload
+    assert payload["coordination_model"]["supervisor_role"] == "host_shell_layout_only", payload
+
+    lanes = payload["lanes"]
+    assert [lane["lane_id"] for lane in lanes] == [
+        "hypothesis-runner",
+        "evidence-promoter",
+        "control-plane-guard",
+    ], payload
+    for lane in lanes:
+        assert "quota should-run" in lane["quota_guard"], lane
+        assert f"--agent-id {lane['agent_id']}" in lane["quota_guard"], lane
+        assert "auto-research frontier" in lane["frontier"], lane
+        assert "codex-cli-bootstrap-message" in lane["bootstrap_message"], lane
+        assert lane["visible_codex_tui"] == "codex", lane
+
+    start_script = "\n".join(payload["commands"]["start_script"])
+    assert "tmux new-session" in start_script, start_script
+    assert "tmux new-window" in start_script, start_script
+    assert "LOOPX_PROJECT" in start_script, start_script
+    assert "codex-cli-bootstrap-message" in start_script, start_script
+    assert "auto-research frontier" in start_script, start_script
+    assert payload["commands"]["attach"] == "tmux attach -t loopx-auto-research", payload
+
+    boundary = payload["boundary"]
+    assert boundary["dry_run_plan_only"] is True, payload
+    assert boundary["starts_tmux"] is False, payload
+    assert boundary["runs_codex"] is False, payload
+    assert boundary["reads_raw_transcripts"] is False, payload
+    assert boundary["reads_session_files"] is False, payload
+    assert boundary["reads_credentials"] is False, payload
+    assert boundary["mutates_codex_session"] is False, payload
+    assert boundary["writes_loopx_state"] is False, payload
+    assert boundary["spends_loopx_quota"] is False, payload
+    assert payload["future_gates"][0]["capability"] == "execute_start_script", payload
+    assert_no_private_surface(payload)
+
+
+def run_cli_json() -> dict[str, Any]:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--format",
+            "json",
+            "auto-research",
+            "demo-supervisor",
+            "--goal-id",
+            GOAL_ID,
+            "--agent",
+            LANES[0],
+            "--agent",
+            LANES[1],
+            "--agent",
+            LANES[2],
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def main() -> int:
+    payload = build_auto_research_demo_supervisor_plan(
+        goal_id=GOAL_ID,
+        agent_specs=LANES,
+    )
+    assert_supervisor_contract(payload)
+
+    cli_payload = run_cli_json()
+    assert_supervisor_contract(cli_payload)
+
+    markdown = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "auto-research",
+            "demo-supervisor",
+            "--goal-id",
+            GOAL_ID,
+            "--agent",
+            LANES[0],
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert "# LoopX Auto Research Demo Supervisor" in markdown, markdown
+    assert "leader_agent_required: `False`" in markdown, markdown
+    assert "tmux attach -t loopx-auto-research" in markdown, markdown
+
+    print("auto-research-demo-supervisor-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/capabilities/auto_research/__init__.py
+++ b/loopx/capabilities/auto_research/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from .core import (
     AUTO_RESEARCH_DEFAULT_GOAL_ID,
     AUTO_RESEARCH_DEFAULT_OBJECTIVE,
+    AUTO_RESEARCH_DEMO_SUPERVISOR_SCHEMA_VERSION,
     AUTO_RESEARCH_FIXTURE_SCHEMA_VERSION,
     AUTO_RESEARCH_PROJECTION_SCHEMA_VERSION,
     AUTO_RESEARCH_QUICKSTART_SCHEMA_VERSION,
@@ -18,6 +19,7 @@ from .core import (
     RESEARCH_SHOWCASE_PROJECTION_SCHEMA_VERSION,
     AUTO_RESEARCH_EVIDENCE_PACKET_SCHEMA_VERSION,
     AUTO_RESEARCH_ROLLOUT_APPEND_SCHEMA_VERSION,
+    build_auto_research_demo_supervisor_plan,
     build_auto_research_quickstart,
     build_auto_research_projection,
     build_auto_research_evidence_packet,
@@ -43,6 +45,7 @@ from .core import (
 __all__ = [
     "AUTO_RESEARCH_DEFAULT_GOAL_ID",
     "AUTO_RESEARCH_DEFAULT_OBJECTIVE",
+    "AUTO_RESEARCH_DEMO_SUPERVISOR_SCHEMA_VERSION",
     "AUTO_RESEARCH_FIXTURE_SCHEMA_VERSION",
     "AUTO_RESEARCH_PROJECTION_SCHEMA_VERSION",
     "AUTO_RESEARCH_QUICKSTART_SCHEMA_VERSION",
@@ -58,6 +61,7 @@ __all__ = [
     "RESEARCH_SHOWCASE_PROJECTION_SCHEMA_VERSION",
     "AUTO_RESEARCH_EVIDENCE_PACKET_SCHEMA_VERSION",
     "AUTO_RESEARCH_ROLLOUT_APPEND_SCHEMA_VERSION",
+    "build_auto_research_demo_supervisor_plan",
     "build_auto_research_quickstart",
     "build_auto_research_projection",
     "build_auto_research_evidence_packet",

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -10,6 +10,7 @@ from . import (
     AUTO_RESEARCH_DEFAULT_OBJECTIVE,
     AUTO_RESEARCH_QUICKSTART_TEMPLATE,
     AUTO_RESEARCH_ROLLOUT_APPEND_SCHEMA_VERSION,
+    build_auto_research_demo_supervisor_plan,
     build_auto_research_quickstart,
     build_auto_research_rollout_events,
     build_live_auto_research_projection,
@@ -142,6 +143,34 @@ def register_auto_research_commands(
         help="Preview rollout events without appending them.",
     )
 
+    demo_supervisor_parser = auto_research_sub.add_parser(
+        "demo-supervisor",
+        help="Plan a dry-run tmux/Codex-CLI supervisor for decentralized auto-research lanes.",
+    )
+    add_subcommand_format(demo_supervisor_parser)
+    demo_supervisor_parser.add_argument(
+        "--goal-id",
+        default=AUTO_RESEARCH_DEFAULT_GOAL_ID,
+        help="Research goal id whose frontier each lane should inspect.",
+    )
+    demo_supervisor_parser.add_argument(
+        "--agent",
+        action="append",
+        default=[],
+        help=(
+            "Agent/lane pair as agent_id:lane_id. Repeat for each visible lane. "
+            "Omit to use the default LoopX auto-research demo lane set."
+        ),
+    )
+    demo_supervisor_parser.add_argument(
+        "--session-name",
+        default="loopx-auto-research",
+        help="Public-safe tmux session name for the generated dry-run script.",
+    )
+    demo_supervisor_parser.add_argument("--cli-bin", default="loopx", help="LoopX CLI executable name.")
+    demo_supervisor_parser.add_argument("--codex-bin", default="codex", help="Codex CLI executable name.")
+    demo_supervisor_parser.add_argument("--tmux-bin", default="tmux", help="tmux executable name.")
+
 
 def _append_auto_research_rollout_events(
     *,
@@ -270,9 +299,19 @@ def handle_auto_research_command(
                 runtime_root_arg=runtime_root_arg,
                 dry_run=args.dry_run,
             )
+        elif args.auto_research_command == "demo-supervisor":
+            payload = build_auto_research_demo_supervisor_plan(
+                goal_id=args.goal_id,
+                agent_specs=args.agent,
+                session_name=args.session_name,
+                cli_bin=args.cli_bin,
+                codex_bin=args.codex_bin,
+                tmux_bin=args.tmux_bin,
+            )
         else:
             raise ValueError(
-                "auto-research requires the `quickstart`, `frontier`, `evidence`, or `append-evidence` subcommand"
+                "auto-research requires the `quickstart`, `frontier`, `evidence`, "
+                "`append-evidence`, or `demo-supervisor` subcommand"
             )
     except Exception as exc:
         payload = {

--- a/loopx/capabilities/auto_research/core.py
+++ b/loopx/capabilities/auto_research/core.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import math
 import re
+import shlex
 from pathlib import Path
 from typing import Any, Iterable
 
@@ -20,10 +21,33 @@ AUTO_RESEARCH_PROJECTION_SCHEMA_VERSION = "decentralized_auto_research_projectio
 AUTO_RESEARCH_EVIDENCE_PACKET_SCHEMA_VERSION = "auto_research_evidence_packet_v0"
 AUTO_RESEARCH_ROLLOUT_APPEND_SCHEMA_VERSION = "auto_research_rollout_append_v0"
 AUTO_RESEARCH_QUICKSTART_SCHEMA_VERSION = "auto_research_quickstart_v0"
+AUTO_RESEARCH_DEMO_SUPERVISOR_SCHEMA_VERSION = "auto_research_demo_supervisor_plan_v0"
 AUTO_RESEARCH_DEFAULT_GOAL_ID = "loopx-auto-research-knn"
 AUTO_RESEARCH_DEFAULT_OBJECTIVE = "Improve exact k-nearest-neighbor inference under a protected evaluator."
 AUTO_RESEARCH_QUICKSTART_TEMPLATE = "knn-exact"
 ROLLOUT_EVIDENCE_GRAPH_SOURCE_KIND = "loopx_rollout_event_log"
+AUTO_RESEARCH_DEMO_DEFAULT_LANES = (
+    (
+        "codex-side-bypass",
+        "hypothesis-runner",
+        "Claim the next runnable hypothesis and run dev evidence without owning promotion.",
+    ),
+    (
+        "codex-product-capability",
+        "evidence-promoter",
+        "Read scored evidence, promotion candidates, and product metric gaps.",
+    ),
+    (
+        "codex-main-control",
+        "control-plane-guard",
+        "Guard repo, review, merge, and user-gate boundaries without acting as a research leader.",
+    ),
+    (
+        "codex-value-explorer",
+        "research-narrator",
+        "Turn accepted evidence into public-safe showcase and value-metric summaries.",
+    ),
+)
 
 HYPOTHESIS_STATUSES = {
     "proposed",
@@ -521,6 +545,217 @@ def _relative_pack_dir(value: Any) -> Path:
     if any(part in {"", ".", ".."} for part in path.parts):
         raise ValueError("output_dir must not contain current or parent-directory markers")
     return path
+
+
+def _shell_arg(value: str) -> str:
+    return shlex.quote(value)
+
+
+def _demo_lane_specs(agent_specs: Iterable[str] | None) -> list[dict[str, str]]:
+    raw_specs = list(agent_specs or [])
+    parsed_specs: list[tuple[str, str, str]] = []
+    if raw_specs:
+        for index, raw in enumerate(raw_specs, start=1):
+            text = _compact_public_text(raw, field="agent[]", max_len=180)
+            if ":" in text:
+                agent_id, lane_id = text.split(":", 1)
+            else:
+                agent_id = text
+                lane_id = f"research-lane-{index}"
+            parsed_specs.append(
+                (
+                    _compact_public_token(agent_id, field="agent_id"),
+                    _compact_public_token(lane_id, field="lane_id"),
+                    "Work from the shared LoopX frontier for this lane; do not assume a leader agent.",
+                )
+            )
+    else:
+        parsed_specs = list(AUTO_RESEARCH_DEMO_DEFAULT_LANES)
+
+    lanes: list[dict[str, str]] = []
+    seen_agents: set[str] = set()
+    seen_lanes: set[str] = set()
+    for agent_id, lane_id, responsibility in parsed_specs:
+        if agent_id in seen_agents:
+            raise ValueError(f"duplicate agent_id in demo supervisor lane plan: {agent_id}")
+        if lane_id in seen_lanes:
+            raise ValueError(f"duplicate lane_id in demo supervisor lane plan: {lane_id}")
+        seen_agents.add(agent_id)
+        seen_lanes.add(lane_id)
+        lanes.append(
+            {
+                "agent_id": agent_id,
+                "lane_id": lane_id,
+                "responsibility": _compact_public_text(
+                    responsibility,
+                    field="lane.responsibility",
+                    max_len=180,
+                ),
+            }
+        )
+    return lanes
+
+
+def _env_quota_command(*, cli_bin: str, goal_id: str, agent_id: str) -> str:
+    return (
+        f"{_shell_arg(cli_bin)} --format json "
+        "--registry \"$LOOPX_REGISTRY\" --runtime-root \"$LOOPX_RUNTIME_ROOT\" "
+        f"quota should-run --goal-id {_shell_arg(goal_id)} --agent-id {_shell_arg(agent_id)}"
+    )
+
+
+def _env_frontier_command(*, cli_bin: str, goal_id: str, agent_id: str) -> str:
+    return (
+        f"{_shell_arg(cli_bin)} --format json "
+        "--registry \"$LOOPX_REGISTRY\" --runtime-root \"$LOOPX_RUNTIME_ROOT\" "
+        f"auto-research frontier --goal-id {_shell_arg(goal_id)} --agent-id {_shell_arg(agent_id)}"
+    )
+
+
+def _env_bootstrap_command(*, cli_bin: str, goal_id: str, agent_id: str) -> str:
+    return (
+        f"{_shell_arg(cli_bin)} codex-cli-bootstrap-message "
+        "--project \"$LOOPX_PROJECT\" "
+        f"--goal-id {_shell_arg(goal_id)} --agent-id {_shell_arg(agent_id)}"
+    )
+
+
+def build_auto_research_demo_supervisor_plan(
+    *,
+    goal_id: str = AUTO_RESEARCH_DEFAULT_GOAL_ID,
+    agent_specs: Iterable[str] | None = None,
+    session_name: str = "loopx-auto-research",
+    cli_bin: str = "loopx",
+    codex_bin: str = "codex",
+    tmux_bin: str = "tmux",
+) -> dict[str, Any]:
+    """Build a dry-run tmux/Codex-CLI supervisor plan for auto research.
+
+    The supervisor is a host convenience packet, not a leader agent. It gives a
+    user one place to inspect the shell script that would open visible panes for
+    several decentralized lanes. The default packet does not start tmux, launch
+    Codex, read session files, write LoopX state, or spend quota.
+    """
+
+    goal = _compact_public_token(goal_id, field="goal_id")
+    session = _compact_public_token(session_name, field="session_name")
+    cli = _compact_public_token(cli_bin, field="cli_bin")
+    codex = _compact_public_token(codex_bin, field="codex_bin")
+    tmux = _compact_public_token(tmux_bin, field="tmux_bin")
+    lanes = _demo_lane_specs(agent_specs)
+
+    pane_plans: list[dict[str, Any]] = []
+    for lane in lanes:
+        agent_id = lane["agent_id"]
+        lane_id = lane["lane_id"]
+        quota_command = _env_quota_command(cli_bin=cli, goal_id=goal, agent_id=agent_id)
+        frontier_command = _env_frontier_command(cli_bin=cli, goal_id=goal, agent_id=agent_id)
+        bootstrap_command = _env_bootstrap_command(cli_bin=cli, goal_id=goal, agent_id=agent_id)
+        pane_plans.append(
+            {
+                "lane_id": lane_id,
+                "agent_id": agent_id,
+                "responsibility": lane["responsibility"],
+                "window_name": lane_id,
+                "quota_guard": quota_command,
+                "frontier": frontier_command,
+                "bootstrap_message": bootstrap_command,
+                "visible_codex_tui": codex,
+                "start_sequence": [
+                    "run quota_guard and stop when user_channel.action_required=true",
+                    "render the lane frontier from LoopX state",
+                    "print the public-safe bootstrap message for this visible TUI",
+                    "start Codex CLI visibly; do not inject hidden prompts into an existing session",
+                ],
+            }
+        )
+
+    env_lines = [
+        "set -euo pipefail",
+        ": ${LOOPX_PROJECT:?set LOOPX_PROJECT to the repo root before running}",
+        ": ${LOOPX_REGISTRY:?set LOOPX_REGISTRY to the LoopX registry path before running}",
+        ": ${LOOPX_RUNTIME_ROOT:?set LOOPX_RUNTIME_ROOT to the LoopX runtime root before running}",
+    ]
+    start_script = [
+        *env_lines,
+        f"{_shell_arg(tmux)} new-session -d -s {_shell_arg(session)} -n frontier",
+        (
+            f"{_shell_arg(tmux)} send-keys -t {_shell_arg(session)}:frontier "
+            f"{_shell_arg(_env_frontier_command(cli_bin=cli, goal_id=goal, agent_id=lanes[0]['agent_id']))} C-m"
+        ),
+    ]
+    for pane in pane_plans:
+        lane_id = str(pane["lane_id"])
+        lane_command = (
+            f"cd \"$LOOPX_PROJECT\"; {pane['quota_guard']}; {pane['frontier']}; "
+            f"{pane['bootstrap_message']}; {pane['visible_codex_tui']}"
+        )
+        start_script.extend(
+            [
+                f"{_shell_arg(tmux)} new-window -d -t {_shell_arg(session)} -n {_shell_arg(lane_id)}",
+                f"{_shell_arg(tmux)} send-keys -t {_shell_arg(session)}:{_shell_arg(lane_id)} {_shell_arg(lane_command)} C-m",
+            ]
+        )
+    attach_command = f"{_shell_arg(tmux)} attach -t {_shell_arg(session)}"
+
+    return {
+        "ok": True,
+        "schema_version": AUTO_RESEARCH_DEMO_SUPERVISOR_SCHEMA_VERSION,
+        "mode": "dry_run",
+        "goal_id": goal,
+        "session_name": session,
+        "coordination_model": {
+            "leader_agent_required": False,
+            "supervisor_role": "host_shell_layout_only",
+            "source_of_truth": [
+                "quota_should_run",
+                "todo_claims",
+                "auto_research_frontier",
+                "research_evidence_graph",
+            ],
+            "decentralized_rule": "each lane reads its own quota/frontier projection and writes back through normal LoopX todo/evidence APIs",
+        },
+        "lanes": pane_plans,
+        "commands": {
+            "start_script": start_script,
+            "attach": attach_command,
+            "stop": f"{_shell_arg(tmux)} kill-session -t {_shell_arg(session)}",
+        },
+        "future_gates": [
+            {
+                "capability": "execute_start_script",
+                "state": "future_gated",
+                "required_contract": "explicit user shell authority plus visible tmux attach before Codex starts",
+            },
+            {
+                "capability": "same_session_prompt_injection",
+                "state": "blocked_without_visible_attach_proof",
+                "required_contract": "codex_cli_visible_attach_acceptance_v0 with fresh idle guard",
+            },
+            {
+                "capability": "state_write_from_supervisor",
+                "state": "not_allowed",
+                "required_contract": "normal LoopX CLI todo/evidence/writeback commands only",
+            },
+        ],
+        "boundary": {
+            "dry_run_plan_only": True,
+            "starts_tmux": False,
+            "runs_codex": False,
+            "reads_raw_transcripts": False,
+            "reads_session_files": False,
+            "reads_credentials": False,
+            "mutates_codex_session": False,
+            "writes_loopx_state": False,
+            "spends_loopx_quota": False,
+            "external_service_call": False,
+        },
+        "operator_notes": [
+            "Set LOOPX_PROJECT, LOOPX_REGISTRY, and LOOPX_RUNTIME_ROOT in the user shell before running the script.",
+            "Attach to tmux before accepting any Codex prompt so every lane stays visible and interruptible.",
+            "Use the printed quota/frontier packet in each pane to decide whether that lane should continue, ask, or stop.",
+        ],
+    }
 
 
 def _quickstart_contract(*, goal_id: str, objective: str) -> dict[str, Any]:
@@ -1758,6 +1993,44 @@ def render_auto_research_markdown(payload: dict[str, object]) -> str:
             if not isinstance(item, dict):
                 continue
             lines.append(f"- {item.get('label')}: `{item.get('command')}`")
+        return "\n".join(lines) + "\n"
+    if payload.get("schema_version") == AUTO_RESEARCH_DEMO_SUPERVISOR_SCHEMA_VERSION:
+        lanes = payload.get("lanes") or []
+        commands = payload.get("commands") if isinstance(payload.get("commands"), dict) else {}
+        coordination = (
+            payload.get("coordination_model")
+            if isinstance(payload.get("coordination_model"), dict)
+            else {}
+        )
+        lines = [
+            "# LoopX Auto Research Demo Supervisor",
+            "",
+            f"- schema: `{payload.get('schema_version')}`",
+            f"- mode: `{payload.get('mode')}`",
+            f"- goal_id: `{payload.get('goal_id')}`",
+            f"- session: `{payload.get('session_name')}`",
+            f"- leader_agent_required: `{coordination.get('leader_agent_required')}`",
+            f"- lanes: `{len(lanes)}`",
+            "",
+            "## Lanes",
+        ]
+        for item in lanes:
+            if not isinstance(item, dict):
+                continue
+            lines.append(
+                f"- `{item.get('lane_id')}` / `{item.get('agent_id')}`: {item.get('responsibility')}"
+            )
+        lines.extend(["", "## Shell Plan", ""])
+        for line in commands.get("start_script") or []:
+            lines.append(f"- `{line}`")
+        lines.extend(
+            [
+                "",
+                "## Attach",
+                "",
+                f"`{commands.get('attach')}`",
+            ]
+        )
         return "\n".join(lines) + "\n"
     if payload.get("schema_version") == AUTO_RESEARCH_EVIDENCE_PACKET_SCHEMA_VERSION:
         summary = payload["summary"]  # type: ignore[index]


### PR DESCRIPTION
## Summary
- Add `loopx auto-research demo-supervisor` as a dry-run tmux/Codex-CLI supervisor packet for decentralized auto-research lanes.
- The packet plans visible lane panes, per-agent quota/frontier/bootstrap commands, and attach/stop shell lines while keeping execution future-gated.
- Document the local demo supervisor in the decentralized auto-research showcase blueprint and add a focused smoke.

## Validation
- `python3 examples/auto-research-demo-supervisor-smoke.py`
- `python3 examples/auto-research-quickstart-smoke.py`
- `python3 examples/decentralized-auto-research-frontier-smoke.py`
- `python3 -m py_compile loopx/capabilities/auto_research/core.py loopx/capabilities/auto_research/cli.py loopx/capabilities/auto_research/__init__.py`
- `git diff --check origin/main...HEAD`
- `loopx check --scan-path docs/product/decentralized-auto-research-showcase.md --scan-path loopx/capabilities/auto_research/__init__.py --scan-path loopx/capabilities/auto_research/cli.py --scan-path loopx/capabilities/auto_research/core.py --scan-path examples/auto-research-demo-supervisor-smoke.py`

## Boundary
This is a dry-run-first local demo planner. It does not start tmux, launch Codex, read session files, inject hidden prompts, write LoopX state, spend quota, or call external services. The supervisor is a host shell layout, not a leader agent; each lane still routes through its own LoopX quota/frontier projection.
