### PR TITLE
Scope agent work lane routing

### DIFF
--- a/examples/monitor-scheduler-contract-smoke.py
+++ b/examples/monitor-scheduler-contract-smoke.py
@@ -19,7 +19,12 @@ PAST_DUE_AT = "2000-01-01T00:00:00+00:00"
 FUTURE_DUE_AT = "2999-01-01T00:00:00+00:00"
 
 
-def status_payload(*, agent_todo_items: list[dict], status: str = "monitor_scheduler_fixture") -> dict:
+def status_payload(
+    *,
+    agent_todo_items: list[dict],
+    status: str = "monitor_scheduler_fixture",
+    coordination: dict | None = None,
+) -> dict:
     agent_todos = compact_todo_group(
         agent_todo_items,
         source_section="Agent Todo",
@@ -67,7 +72,8 @@ def status_payload(*, agent_todo_items: list[dict], status: str = "monitor_sched
                         "slot_minutes": 1,
                         "allowed_slots": 10,
                     },
-                    "coordination": {
+                    "coordination": coordination
+                    or {
                         "registered_agents": [AGENT_ID],
                         "primary_agent": AGENT_ID,
                     },
@@ -84,6 +90,7 @@ def monitor_item(
     priority: str,
     next_due_at: str,
     target_key: str,
+    claimed_by: str = AGENT_ID,
 ) -> dict:
     return {
         "index": index,
@@ -94,14 +101,14 @@ def monitor_item(
         "priority": priority,
         "task_class": "continuous_monitor",
         "action_kind": "monitor",
-        "claimed_by": AGENT_ID,
+        "claimed_by": claimed_by,
         "target_key": target_key,
         "cadence": "15m",
         "next_due_at": next_due_at,
     }
 
 
-def advancement_item(*, index: int, priority: str = "P1") -> dict:
+def advancement_item(*, index: int, priority: str = "P1", claimed_by: str = AGENT_ID) -> dict:
     return {
         "index": index,
         "text": f"[{priority}] Advance the runtime contract slice with validation.",
@@ -110,15 +117,20 @@ def advancement_item(*, index: int, priority: str = "P1") -> dict:
         "status": "open",
         "priority": priority,
         "task_class": "advancement_task",
-        "claimed_by": AGENT_ID,
+        "claimed_by": claimed_by,
     }
 
 
-def guard_for(items: list[dict]) -> dict:
+def guard_for(
+    items: list[dict],
+    *,
+    agent_id: str = AGENT_ID,
+    coordination: dict | None = None,
+) -> dict:
     return build_quota_should_run(
-        status_payload(agent_todo_items=items),
+        status_payload(agent_todo_items=items, coordination=coordination),
         goal_id=GOAL_ID,
-        agent_id=AGENT_ID,
+        agent_id=agent_id,
     )
 
 
@@ -222,11 +234,76 @@ def assert_multiple_due_monitor_cap_and_order() -> None:
     assert "work_lane_monitor_due: count=3" in markdown, markdown
 
 
+def assert_other_agent_due_monitor_does_not_preempt_current_agent_lane() -> None:
+    other_agent = "codex-main-control"
+    guard = guard_for(
+        [
+            monitor_item(
+                index=1,
+                todo_id="todo_other_due_monitor",
+                priority="P0",
+                next_due_at=PAST_DUE_AT,
+                target_key="other-agent-watch",
+                claimed_by=other_agent,
+            ),
+            advancement_item(index=2, priority="P1"),
+        ],
+        coordination={
+            "registered_agents": [other_agent, AGENT_ID],
+            "primary_agent": other_agent,
+        },
+    )
+    lane = guard["work_lane_contract"]
+    assert lane["lane"] == "advancement_task", lane
+    assert lane["reason_codes"] == ["open_agent_todo"], lane
+    assert lane.get("monitor_due_count", 0) == 0, lane
+    assert "monitor_due_items" not in lane, lane
+    assert guard["agent_todo_summary"]["monitor_due_count"] == 0, guard
+    claim_scope = guard["agent_todo_summary"]["claim_scope"]
+    assert claim_scope["other_agent_claimed_open_count"] == 1, claim_scope
+    assert claim_scope["other_agent_claimed_items"][0]["todo_id"] == "todo_other_due_monitor", claim_scope
+    assert guard["recommended_action"] == advancement_item(index=2, priority="P1")["text"], guard
+
+
+def assert_other_agent_claimed_work_stays_diagnostic_when_no_current_lane() -> None:
+    other_agent = "codex-main-control"
+    guard = guard_for(
+        [
+            monitor_item(
+                index=1,
+                todo_id="todo_other_due_monitor",
+                priority="P0",
+                next_due_at=PAST_DUE_AT,
+                target_key="other-agent-watch",
+                claimed_by=other_agent,
+            ),
+            advancement_item(index=2, priority="P0", claimed_by=other_agent),
+        ],
+        coordination={
+            "registered_agents": [other_agent, AGENT_ID],
+            "primary_agent": other_agent,
+        },
+    )
+    summary = guard["agent_todo_summary"]
+    lane = guard.get("work_lane_contract") or {}
+    assert summary["open_count"] == 0, summary
+    assert summary["first_executable_items"] == [], summary
+    assert summary["monitor_due_count"] == 0, summary
+    assert lane.get("must_attempt_work") is not True, lane
+    claim_scope = summary["claim_scope"]
+    assert claim_scope["selectable_open_count"] == 0, claim_scope
+    assert claim_scope["other_agent_claimed_open_count"] == 2, claim_scope
+    assert claim_scope["other_agent_claimed_weight"] == "diagnostic_only", claim_scope
+    assert guard["recommended_action"] != advancement_item(index=2, priority="P0", claimed_by=other_agent)["text"], guard
+
+
 def main() -> int:
     assert_not_due_monitor_waits_quietly()
     assert_due_monitor_requires_explicit_attempt()
     assert_due_monitor_priority_does_not_steal_advancement_lane()
     assert_multiple_due_monitor_cap_and_order()
+    assert_other_agent_due_monitor_does_not_preempt_current_agent_lane()
+    assert_other_agent_claimed_work_stays_diagnostic_when_no_current_lane()
     print("monitor-scheduler-contract-smoke ok")
     return 0
 

--- a/examples/todo-first-open-summary-smoke.py
+++ b/examples/todo-first-open-summary-smoke.py
@@ -14,7 +14,6 @@ if str(REPO_ROOT) not in sys.path:
 from loopx.quota import build_quota_should_run, render_quota_should_run_markdown  # noqa: E402
 from loopx.review_packet import build_review_packet  # noqa: E402
 from loopx.status import (  # noqa: E402
-    MAX_PROJECT_ASSET_TODO_ITEMS,
     TODO_PROJECTION_DETAIL_POINTER_SCHEMA_VERSION,
     TODO_PROJECTION_VIEW_SCHEMA_VERSION,
     compact_todo_group,
@@ -60,7 +59,7 @@ def build_truncated_todo_group() -> dict:
     assert group is not None, group
     assert group["schema_version"] == "todo_summary_v0", group
     assert len(group["items"]) == 12, group
-    assert [item["index"] for item in group["items"][:3]] == [14, 15, 16], group
+    assert [item["index"] for item in group["items"][:3]] == [17, 14, 15], group
     assert all(not item["done"] for item in group["items"][:4]), group
     assert all(item["done"] for item in group["items"][4:]), group
     assert group["open_count"] == 4, group
@@ -94,7 +93,7 @@ def parse_multiline_deep_open_todo() -> dict:
     )
     group = parse_active_state_todos(state_text)["agent_todos"]
     assert len(group["items"]) == 12, group
-    assert [item["index"] for item in group["items"][:3]] == [14, 15, 16], group
+    assert [item["index"] for item in group["items"][:3]] == [17, 14, 15], group
     assert all(not item["done"] for item in group["items"][:4]), group
     assert all(item["done"] for item in group["items"][4:]), group
     assert group["open_count"] == 4, group
@@ -550,9 +549,9 @@ def assert_claimed_advancement_lanes_preserve_claimants() -> None:
     assert "todo_side_tui" in current_agent_advancement_ids, summary
     assert summary["first_executable_items"][0]["todo_id"] == "todo_side_tui", summary
     assert summary["claim_scope"]["selection_order"] == (
-        "current_agent_claimed_then_unclaimed_then_other_agent_claimed_low_weight"
+        "current_agent_claimed_then_unclaimed"
     ), summary
-    assert summary["claim_scope"]["other_agent_claimed_open_count"] == 12, summary
+    assert summary["claim_scope"]["other_agent_claimed_open_count"] == 11, summary
     assert summary["claim_scope"]["other_agent_claimed_items"][0]["todo_id"] == "todo_primary_1", summary
     assert summary["claim_scope"]["blocked_claimed_items"][0]["todo_id"] == "todo_primary_1", summary
     assert summary["current_agent_claimed_advancement_count"] == 6, summary
@@ -572,7 +571,8 @@ def main() -> int:
         "view": "project_asset_overview",
         "truth": "derived",
         "canonical_source": "attention_queue.items[].agent_todos",
-        "item_limit": MAX_PROJECT_ASSET_TODO_ITEMS,
+        "item_limit": 3,
+        "deferred_item_limit": 8,
     }, asset_summary
     assert asset_summary["detail_pointer"] == {
         "schema_version": TODO_PROJECTION_DETAIL_POINTER_SCHEMA_VERSION,

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -368,6 +368,13 @@ def _external_evidence_poll_signal(
 ) -> dict[str, Any] | None:
     """Detect launched external work whose next safe step is observation."""
 
+    if (
+        isinstance(agent_todo_summary, dict)
+        and _todo_summary_claim_scope_agent_id(agent_todo_summary)
+        and _open_todo_count(agent_todo_summary) <= 0
+    ):
+        return None
+
     project_asset = item.get("project_asset") if isinstance(item.get("project_asset"), dict) else {}
     action_texts = [
         str(value or "").strip()
@@ -531,6 +538,14 @@ def _external_evidence_observation_obligation(
     explicit_wait = state == "waiting" and str(item.get("waiting_on") or "") == "external_evidence"
     poll_signal = _external_evidence_poll_signal(item, agent_todo_summary=agent_todo_summary)
     if not explicit_wait and not poll_signal:
+        return None
+    if (
+        not explicit_wait
+        and poll_signal
+        and isinstance(agent_todo_summary, dict)
+        and _todo_summary_claim_scope_agent_id(agent_todo_summary)
+        and _open_todo_count(agent_todo_summary) <= 0
+    ):
         return None
     if (
         not explicit_wait
@@ -1301,7 +1316,7 @@ def _agent_claim_scoped_open_items(
     unclaimed_items = [item for item in open_items if claim_bucket(item) == 1]
     other_agent_claimed_items = [item for item in open_items if claim_bucket(item) == 2]
     selectable_items = sorted(
-        [*current_agent_items, *unclaimed_items, *other_agent_claimed_items],
+        [*current_agent_items, *unclaimed_items],
         key=lambda item: (claim_bucket(item), *_todo_projection_sort_key(item)),
     )
     claim_scope = {
@@ -1309,12 +1324,12 @@ def _agent_claim_scoped_open_items(
         "agent_id": agent_id,
         "agent_role": str(agent_identity.get("role") or ""),
         "primary_agent": normalize_todo_claimed_by(agent_identity.get("primary_agent")),
-        "selection_order": "current_agent_claimed_then_unclaimed_then_other_agent_claimed_low_weight",
+        "selection_order": "current_agent_claimed_then_unclaimed",
         "selectable_open_count": len(selectable_items),
         "current_agent_claimed_open_count": len(current_agent_items),
         "unclaimed_open_count": len(unclaimed_items),
         "other_agent_claimed_open_count": len(other_agent_claimed_items),
-        "other_agent_claimed_weight": "lower_than_current_claimed_and_unclaimed",
+        "other_agent_claimed_weight": "diagnostic_only",
         "other_agent_claimed_items": [
             _compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
             for item in _claimed_visibility_items(other_agent_claimed_items, limit=3)
@@ -1326,6 +1341,27 @@ def _agent_claim_scoped_open_items(
         ],
     }
     return selectable_items, claim_scope
+
+
+def _todo_item_claimed_by_agent_or_unclaimed(item: dict[str, Any], *, agent_id: str) -> bool:
+    claimed_by = normalize_todo_claimed_by(item.get("claimed_by"))
+    return not claimed_by or claimed_by == agent_id
+
+
+def _agent_scope_selectable_todo_item(
+    item: dict[str, Any],
+    *,
+    agent_identity: dict[str, Any] | None,
+) -> bool:
+    if not isinstance(agent_identity, dict):
+        return True
+    agent_id = normalize_todo_claimed_by(agent_identity.get("agent_id"))
+    if not agent_id:
+        return True
+    blocks_agent = normalize_todo_blocks_agent(item.get("blocks_agent"))
+    if blocks_agent and blocks_agent != agent_id:
+        return False
+    return _todo_item_claimed_by_agent_or_unclaimed(item, agent_id=agent_id)
 
 
 def _agent_scope_filter_user_gate_items(
@@ -1730,6 +1766,7 @@ def _summarize_user_todos(
         item
         for item in monitor_items
         if _todo_item_is_due_monitor(item)
+        if _agent_scope_selectable_todo_item(item, agent_identity=agent_identity)
     ]
     claimed_open_items = [item for item in blocking_open_items if item.get("claimed_by")]
     gate_items = [
@@ -1741,13 +1778,17 @@ def _summarize_user_todos(
         _compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
         for item in (value.get("active_next_action_items") or [])
         if isinstance(item, dict)
+        if _agent_scope_selectable_todo_item(item, agent_identity=agent_identity)
     ] if isinstance(value.get("active_next_action_items"), list) else []
     active_next_action_executable_items = [
         _compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
         for item in (value.get("active_next_action_executable_items") or [])
         if isinstance(item, dict)
+        if _agent_scope_selectable_todo_item(item, agent_identity=agent_identity)
     ] if isinstance(value.get("active_next_action_executable_items"), list) else []
     open_count = value.get("open_count", len(all_open_items))
+    if claim_scope is not None:
+        open_count = len(open_items)
     if agent_scope_filter is not None:
         open_count = len(blocking_open_items)
     summary = {
@@ -1867,19 +1908,24 @@ def _summarize_project_asset_todos(
         item
         for item in monitor_items
         if _todo_item_is_due_monitor(item)
+        if _agent_scope_selectable_todo_item(item, agent_identity=agent_identity)
     ]
     active_next_action_items = [
         _compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
         for item in (value.get("active_next_action_items") or [])
         if isinstance(item, dict)
+        if _agent_scope_selectable_todo_item(item, agent_identity=agent_identity)
     ] if isinstance(value.get("active_next_action_items"), list) else []
     active_next_action_executable_items = [
         _compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
         for item in (value.get("active_next_action_executable_items") or [])
         if isinstance(item, dict)
+        if _agent_scope_selectable_todo_item(item, agent_identity=agent_identity)
     ] if isinstance(value.get("active_next_action_executable_items"), list) else []
     claimed_open_items = [item for item in blocking_open_items if item.get("claimed_by")]
     open_count = value.get("open", value.get("open_count", len(all_open_items)))
+    if claim_scope is not None:
+        open_count = len(open_items)
     if agent_scope_filter is not None:
         open_count = len(blocking_open_items)
     summary = {
@@ -2883,9 +2929,6 @@ def _agent_scope_no_candidate_frontier(
             "cleared_without_successor_handoff_gates": cleared_handoff_gates[:3],
         }
 
-    if not has_advancement_contract:
-        return None
-
     claimed_advancement_items = (
         agent_todo_summary.get("claimed_advancement_open_items")
         if isinstance(agent_todo_summary.get("claimed_advancement_open_items"), list)
@@ -2926,6 +2969,8 @@ def _agent_scope_no_candidate_frontier(
         else {}
     )
     primary_agent = normalize_todo_claimed_by(agent_identity.get("primary_agent"))
+    if not has_advancement_contract and not other_advancement_items:
+        return None
     if other_advancement_items:
         if blocking_review_claimants:
             action = AgentScopeFrontierAction.AGENT_SCOPE_WAIT
@@ -4653,6 +4698,11 @@ def _todo_item_is_due_monitor(item: dict[str, Any], *, now: datetime | None = No
     return next_due_at <= current_time
 
 
+def _todo_summary_claim_scope_agent_id(summary: dict[str, Any]) -> str | None:
+    claim_scope = summary.get("claim_scope") if isinstance(summary.get("claim_scope"), dict) else {}
+    return normalize_todo_claimed_by(claim_scope.get("agent_id"))
+
+
 def _todo_summary_monitor_due_items(summary: dict[str, Any] | None) -> list[dict[str, Any]]:
     if not isinstance(summary, dict):
         return []
@@ -4673,6 +4723,13 @@ def _todo_summary_monitor_due_items(summary: dict[str, Any] | None) -> list[dict
             if isinstance(item, dict)
             if _todo_item_is_due_monitor(item)
         ]
+    agent_id = _todo_summary_claim_scope_agent_id(summary)
+    if agent_id:
+        due_items = [
+            item
+            for item in due_items
+            if _todo_item_claimed_by_agent_or_unclaimed(item, agent_id=agent_id)
+        ]
     return sorted(due_items, key=_todo_projection_sort_key)
 
 
@@ -4683,6 +4740,20 @@ def _todo_summary_monitor_due_count(
 ) -> int:
     if not isinstance(summary, dict):
         return 0
+    agent_id = _todo_summary_claim_scope_agent_id(summary)
+    if agent_id:
+        raw_items = summary.get("monitor_open_items")
+        if isinstance(raw_items, list):
+            return len(
+                [
+                    item
+                    for item in raw_items
+                    if isinstance(item, dict)
+                    if _todo_item_is_due_monitor(item)
+                    if _todo_item_claimed_by_agent_or_unclaimed(item, agent_id=agent_id)
+                ]
+            )
+        return len(due_items if due_items is not None else _todo_summary_monitor_due_items(summary))
     projected_count = summary.get("monitor_due_count")
     if isinstance(projected_count, int):
         return max(0, projected_count)
@@ -4712,7 +4783,27 @@ def _open_todo_task_counts(summary: dict[str, Any] | None) -> dict[str, int]:
     open_count = _open_todo_count(summary)
     classified_items: list[dict[str, Any]] = []
     seen: set[tuple[Any, str]] = set()
+    executable_backlog_items: list[dict[str, Any]] | None = None
+    monitor_open_items: list[dict[str, Any]] | None = None
     if isinstance(summary, dict):
+        raw_executable_backlog = summary.get("executable_backlog_items")
+        if isinstance(raw_executable_backlog, list):
+            executable_backlog_items = [
+                item
+                for item in raw_executable_backlog
+                if isinstance(item, dict)
+                if _todo_item_is_actionable_open(item)
+                if _todo_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
+            ]
+        raw_monitor_open = summary.get("monitor_open_items")
+        if isinstance(raw_monitor_open, list):
+            monitor_open_items = [
+                item
+                for item in raw_monitor_open
+                if isinstance(item, dict)
+                if _todo_item_is_actionable_open(item)
+                if _todo_task_class(item) == TODO_TASK_CLASS_MONITOR
+            ]
         for key in (
             "first_executable_items",
             "first_open_items",
@@ -4732,22 +4823,30 @@ def _open_todo_task_counts(summary: dict[str, Any] | None) -> dict[str, int]:
                     continue
                 seen.add(identity)
                 classified_items.append(item)
-    visible_open = min(open_count, len(classified_items))
-    advancement_visible_count = sum(
-        1
-        for item in classified_items[:visible_open]
-        if _todo_item_is_actionable_open(item)
-        and _todo_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
-    )
-    monitor_visible_count = sum(
-        1
-        for item in classified_items[:visible_open]
-        if _todo_item_is_actionable_open(item)
-        and _todo_task_class(item) == TODO_TASK_CLASS_MONITOR
-    )
+    if executable_backlog_items is not None:
+        advancement_count = len(executable_backlog_items)
+    else:
+        visible_open = min(open_count, len(classified_items))
+        advancement_visible_count = sum(
+            1
+            for item in classified_items[:visible_open]
+            if _todo_item_is_actionable_open(item)
+            and _todo_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
+        )
+        hidden_count = max(0, open_count - visible_open)
+        advancement_count = advancement_visible_count + hidden_count
+    if monitor_open_items is not None:
+        monitor_visible_count = len(monitor_open_items)
+    else:
+        visible_open = min(open_count, len(classified_items))
+        monitor_visible_count = sum(
+            1
+            for item in classified_items[:visible_open]
+            if _todo_item_is_actionable_open(item)
+            and _todo_task_class(item) == TODO_TASK_CLASS_MONITOR
+        )
     monitor_due_count = _todo_summary_monitor_due_count(summary)
-    hidden_count = max(0, open_count - visible_open)
-    advancement_count = advancement_visible_count + hidden_count
+    hidden_count = max(0, open_count - len(classified_items))
     return {
         "open": open_count,
         "advancement": advancement_count,


### PR DESCRIPTION
## Summary
- make agent-scoped todo summaries select only current-agent or unclaimed work; other-agent claimed items stay diagnostic in claim_scope
- filter due monitor and implicit external-evidence routing through the same agent scope so other-agent benchmark monitors cannot become this side-agent's must-run work
- tighten work-lane task counts to use executable backlog facts before falling back to hidden-item estimates

## Validation
- python3 examples/monitor-scheduler-contract-smoke.py
- python3 examples/quota-work-lane-policy-smoke.py
- python3 examples/work-lane-contract-smoke.py
- python3 examples/todo-first-open-summary-smoke.py
- python3 -m py_compile loopx/quota.py examples/monitor-scheduler-contract-smoke.py examples/todo-first-open-summary-smoke.py
- git diff --check
- loopx check --scan-path loopx/quota.py --scan-path examples/monitor-scheduler-contract-smoke.py --scan-path examples/todo-first-open-summary-smoke.py

## Notes
This does not read raw benchmark logs, task text, verifier output, or trajectories. Other-agent claimed work remains visible for diagnosis but is not executable for the current agent lane.