### PR TITLE
Repair quota monitor-poll writeback

### DIFF
--- a/examples/monitor-poll-writeback-smoke.py
+++ b/examples/monitor-poll-writeback-smoke.py
@@ -7,6 +7,7 @@ import json
 import subprocess
 import sys
 import tempfile
+from datetime import datetime, timezone
 from pathlib import Path
 
 
@@ -24,17 +25,40 @@ TARGET_KEY = "update-note-draft-pr"
 OTHER_TARGET_KEY = "other-monitor-target"
 
 
+def write_promotion_readiness(runtime: Path) -> None:
+    runs_dir = runtime / "goals" / GOAL_ID / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    generated_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    json_path = runs_dir / "readiness.json"
+    markdown_path = runs_dir / "readiness.md"
+    record = {
+        "generated_at": generated_at,
+        "goal_id": GOAL_ID,
+        "classification": "canary_promotion_readiness_smoke_group",
+        "delivery_batch_scale": "multi_surface",
+        "delivery_outcome": "primary_goal_outcome",
+        "recommended_action": "fixture promotion readiness is fresh",
+        "json_path": str(json_path),
+        "markdown_path": str(markdown_path),
+    }
+    json_path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    markdown_path.write_text("# Canary promotion readiness\n", encoding="utf-8")
+    (runs_dir / "index.jsonl").write_text(json.dumps(record, sort_keys=True) + "\n", encoding="utf-8")
+
+
 def write_fixture(
     root: Path,
     *,
     selected_target_key: str | None = TARGET_KEY,
     include_other_monitor: bool = False,
+    include_user_gate: bool = False,
 ) -> tuple[Path, Path]:
     project = root / "project"
     runtime = root / "runtime"
     state_file = project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
     registry_path = project / ".loopx" / "registry.json"
     state_file.parent.mkdir(parents=True)
+    write_promotion_readiness(runtime)
     monitor_metadata = (
         f"target_key={selected_target_key} "
         if selected_target_key
@@ -56,6 +80,31 @@ def write_fixture(
         "material_change=false "
         "-->\n"
         if include_other_monitor
+        else ""
+    )
+    gated_advancement = (
+        "- [ ] [P1] Prepare the gated publication packet.\n"
+        "  <!-- loopx:todo "
+        "todo_id=todo_monitorpollblocked "
+        "status=open "
+        "task_class=advancement_task "
+        f"claimed_by={AGENT_ID} "
+        "-->\n"
+        if include_user_gate
+        else ""
+    )
+    user_gate = (
+        "\n## User Todo\n\n"
+        "- [ ] [P0-user] Review the unrelated publication gate.\n"
+        "  <!-- loopx:todo "
+        "todo_id=todo_monitorpollgate "
+        "status=open "
+        "task_class=user_gate "
+        "action_kind=review_publication_gate "
+        f"blocks_agent={AGENT_ID} "
+        "unblocks_todo_id=todo_monitorpollblocked "
+        "-->\n"
+        if include_user_gate
         else ""
     )
     state_file.write_text(
@@ -81,7 +130,9 @@ def write_fixture(
         "consecutive_no_change=1 "
         "material_change=false "
         "-->\n"
-        f"{other_monitor}",
+        f"{other_monitor}"
+        f"{gated_advancement}"
+        f"{user_gate}",
         encoding="utf-8",
     )
     registry_path.parent.mkdir(parents=True)
@@ -115,6 +166,7 @@ def write_fixture(
 
 
 def run_cli(registry_path: Path, *args: str) -> dict:
+    scan_args = ["--scan-path", str(Path(__file__).resolve())] if args[:1] == ("quota",) else []
     result = subprocess.run(
         [
             sys.executable,
@@ -125,6 +177,7 @@ def run_cli(registry_path: Path, *args: str) -> dict:
             "--format",
             "json",
             *args,
+            *scan_args,
         ],
         cwd=REPO_ROOT,
         check=True,
@@ -135,6 +188,7 @@ def run_cli(registry_path: Path, *args: str) -> dict:
 
 
 def run_cli_expect_error(registry_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    scan_args = ["--scan-path", str(Path(__file__).resolve())] if args[:1] == ("quota",) else []
     result = subprocess.run(
         [
             sys.executable,
@@ -145,6 +199,7 @@ def run_cli_expect_error(registry_path: Path, *args: str) -> subprocess.Complete
             "--format",
             "json",
             *args,
+            *scan_args,
         ],
         cwd=REPO_ROOT,
         check=False,
@@ -177,6 +232,14 @@ def run_index_records(registry_path: Path) -> list[dict]:
         json.loads(line)
         for line in index_path.read_text(encoding="utf-8").splitlines()
         if line.strip()
+    ]
+
+
+def monitor_poll_records(registry_path: Path) -> list[dict]:
+    return [
+        record
+        for record in run_index_records(registry_path)
+        if record.get("classification") == "quota_monitor_poll"
     ]
 
 
@@ -231,7 +294,7 @@ def assert_unchanged_writeback() -> None:
         assert payload["classification"] == "quota_monitor_poll", payload
         assert payload["delivery_outcome"] == "surface_only", payload
         assert "no quota spend" in payload["health_check"], payload
-        records = run_index_records(registry_path)
+        records = monitor_poll_records(registry_path)
         assert [record["classification"] for record in records] == ["quota_monitor_poll"], records
 
 
@@ -273,9 +336,51 @@ def assert_material_transition_followup() -> None:
         ]
         assert successors, agent_todos(state_file)
         assert successors[0]["task_class"] == "advancement_task", successors[0]
-        records = run_index_records(registry_path)
+        records = monitor_poll_records(registry_path)
         assert [record["classification"] for record in records] == ["quota_monitor_poll"], records
         assert records[0]["delivery_outcome"] == "outcome_progress", records[0]
+
+
+def assert_due_monitor_poll_allowed_with_open_user_gate() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-monitor-poll-user-gate-") as tmp:
+        registry_path, state_file = write_fixture(Path(tmp), include_user_gate=True)
+        quota = run_cli(
+            registry_path,
+            "quota",
+            "should-run",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_ID,
+        )
+        assert quota["requires_user_action"] is True, quota
+        contract = quota.get("work_lane_contract")
+        assert isinstance(contract, dict), quota
+        assert contract.get("obligation") == "attempt_due_monitor", quota
+
+        payload = run_cli(
+            registry_path,
+            "quota",
+            "monitor-poll",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_ID,
+            "--todo-id",
+            TODO_ID,
+            "--target-key",
+            TARGET_KEY,
+            "--result-hash",
+            "old",
+            "--execute",
+        )
+        assert payload["ok"] is True, payload
+        assert payload["agent_id"] == AGENT_ID, payload
+        assert payload["todo_id"] == TODO_ID, payload
+        assert payload["target_key"] == TARGET_KEY, payload
+        item = find_todo(state_file, TODO_ID)
+        assert item["consecutive_no_change"] == "2", item
+        assert item["next_due_at"] != "2026-01-01T00:00:00+00:00", item
 
 
 def assert_target_key_cannot_hijack_selected_due_monitor() -> None:
@@ -308,12 +413,13 @@ def assert_target_key_cannot_hijack_selected_due_monitor() -> None:
         other = find_todo(state_file, "todo_monitorpoll111")
         assert selected["result_hash"] == "old", selected
         assert other["result_hash"] == "old", other
-        assert run_index_records(registry_path) == [], run_index_records(registry_path)
+        assert monitor_poll_records(registry_path) == [], run_index_records(registry_path)
 
 
 def main() -> int:
     assert_unchanged_writeback()
     assert_material_transition_followup()
+    assert_due_monitor_poll_allowed_with_open_user_gate()
     assert_target_key_cannot_hijack_selected_due_monitor()
     return 0
 

--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -196,6 +196,17 @@ def handle_quota_command(
                 "source": "quota",
                 "recommended_action": "fix quota/status collection before spending automatic compute",
             }
+            if args.quota_command == "monitor-poll":
+                payload.update(
+                    {
+                        "source": args.source,
+                        "agent_id": args.agent_id,
+                        "todo_id": args.todo_id,
+                        "target_key": args.target_key,
+                        "result_hash": args.result_hash,
+                        "material_change": bool(args.material_change),
+                    }
+                )
         else:
             payload = {
                 "ok": False,

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -7121,9 +7121,14 @@ def _allows_due_monitor_poll(
     todo_id: str | None = None,
     target_key: str | None = None,
 ) -> bool:
-    if decision.get("should_run") is not True:
+    contract = (
+        decision.get("work_lane_contract")
+        if isinstance(decision.get("work_lane_contract"), dict)
+        else {}
+    )
+    if contract.get("obligation") != "attempt_due_monitor":
         return False
-    if decision.get("requires_user_action") is True:
+    if contract.get("must_attempt_work") is not True:
         return False
     item = _quota_decision_due_monitor_item(decision)
     if not item:
@@ -7583,30 +7588,31 @@ def record_quota_monitor_poll(
     before = build_quota_should_run(status_payload, goal_id=safe_goal_id, agent_id=agent_id)
     normalized_todo_id = normalize_todo_id(todo_id) if todo_id else None
     safe_target_key = str(target_key or "").strip() or None
+    safe_result_hash = str(result_hash or "").strip() or None
+
+    def failure(reason: str) -> dict[str, Any]:
+        return {
+            "ok": False,
+            "mode": "monitor-poll",
+            "dry_run": not execute,
+            "goal_id": safe_goal_id,
+            "appended": False,
+            "registry_mutated": False,
+            "source": str(source or DEFAULT_SLOT_SPEND_SOURCE).strip() or DEFAULT_SLOT_SPEND_SOURCE,
+            "agent_id": normalize_todo_claimed_by(agent_id),
+            "todo_id": normalized_todo_id,
+            "target_key": safe_target_key,
+            "result_hash": safe_result_hash,
+            "material_change": material_change,
+            "reason": reason,
+            "before": before,
+            "after": None,
+        }
+
     if material_change and not (normalized_todo_id or safe_target_key):
-        return {
-            "ok": False,
-            "mode": "monitor-poll",
-            "dry_run": not execute,
-            "goal_id": safe_goal_id,
-            "appended": False,
-            "registry_mutated": False,
-            "reason": "`quota monitor-poll --material-change` requires --todo-id or --target-key",
-            "before": before,
-            "after": None,
-        }
+        return failure("`quota monitor-poll --material-change` requires --todo-id or --target-key")
     if (next_agent_todo or next_user_todo) and not material_change:
-        return {
-            "ok": False,
-            "mode": "monitor-poll",
-            "dry_run": not execute,
-            "goal_id": safe_goal_id,
-            "appended": False,
-            "registry_mutated": False,
-            "reason": "`--next-agent-todo` and `--next-user-todo` require --material-change",
-            "before": before,
-            "after": None,
-        }
+        return failure("`--next-agent-todo` and `--next-user-todo` require --material-change")
     due_monitor_poll = _allows_due_monitor_poll(
         before,
         todo_id=normalized_todo_id,
@@ -7617,20 +7623,10 @@ def record_quota_monitor_poll(
         and not _allows_no_spend_external_monitor_poll(before)
         and not due_monitor_poll
     ):
-        return {
-            "ok": False,
-            "mode": "monitor-poll",
-            "dry_run": not execute,
-            "goal_id": safe_goal_id,
-            "appended": False,
-            "registry_mutated": False,
-            "reason": (
-                "monitor-poll requires monitor_quiet_skip, due monitor todo, "
-                "or external monitor observation"
-            ),
-            "before": before,
-            "after": None,
-        }
+        return failure(
+            "monitor-poll requires monitor_quiet_skip, due monitor todo, "
+            "or external monitor observation"
+        )
 
     generated_at = _now_local()
     todo_writeback = None

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -148,7 +148,7 @@ def inherit_todo_priority(next_text: str, source_text: str | None) -> str:
 def normalize_monitor_metadata(metadata: dict[str, Any] | None) -> dict[str, str]:
     normalized: dict[str, str] = {}
     for key, value in (metadata or {}).items():
-        if key not in {"target_key", "cadence", "next_due_at"}:
+        if key not in TODO_MONITOR_METADATA_FIELDS:
             continue
         candidate = str(value or "").strip()
         if candidate:
@@ -157,6 +157,15 @@ def normalize_monitor_metadata(metadata: dict[str, Any] | None) -> dict[str, str
         raise ValueError("--cadence must look like 30m, 2h, or 1d")
     if "next_due_at" in normalized and parse_timestamp(normalized["next_due_at"]) is None:
         raise ValueError("--next-due-at must be an ISO timestamp")
+    if "last_checked_at" in normalized and parse_timestamp(normalized["last_checked_at"]) is None:
+        raise ValueError("--last-checked-at must be an ISO timestamp")
+    if "consecutive_no_change" in normalized:
+        try:
+            int(normalized["consecutive_no_change"])
+        except ValueError as exc:
+            raise ValueError("--consecutive-no-change must be an integer") from exc
+    if "material_change" in normalized and normalized["material_change"] not in {"true", "false"}:
+        raise ValueError("--material-change metadata must be true or false")
     return normalized
 
 


### PR DESCRIPTION
## Summary
- allow quota monitor-poll when the work-lane contract selects a due continuous_monitor todo, even if an unrelated operator gate keeps top-level should_run=false
- preserve monitor-poll CLI target metadata in fail-closed payloads
- persist monitor writeback metadata fields such as result_hash, last_checked_at, consecutive_no_change, and material_change
- extend the monitor-poll smoke to cover open user-gate plus due-monitor writeback and target-key hijack protection

## Validation
- python3 examples/monitor-poll-writeback-smoke.py
- python3 examples/work-lane-contract-smoke.py
- python3 examples/heartbeat-quota-flow-smoke.py
- python3 examples/todo-write-correctness-smoke.py
- python3 examples/quota-agent-scoped-user-gate-smoke.py
- python3 -m py_compile loopx/quota.py loopx/todos.py loopx/cli_commands/quota.py examples/monitor-poll-writeback-smoke.py
- git diff --check
- loopx check --scan-path loopx/quota.py --scan-path loopx/todos.py --scan-path loopx/cli_commands/quota.py --scan-path examples/monitor-poll-writeback-smoke.py