### PR TITLE
Document benchmark adapter rollout matrix

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/benchmark-core-adapter-contract-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-core-adapter-contract-v0.md
@@ -88,6 +88,20 @@ Completed slices:
     shared failure taxonomy that keeps runner startup/materialization blockers
     out of case-attempt accounting.
 
+## Adapter Rollout Matrix
+
+This table is the public-safe rollout ledger for the shared adapter contract.
+It records which benchmark family owns the generic lifecycle stages through an
+adapter, and which stage should be migrated next. Benchmark-specific runner
+details must stay in the adapter column, not in `benchmark_core`.
+
+| Benchmark family | Adapter module | Current generic lifecycle coverage | Next migration slice |
+| --- | --- | --- | --- |
+| Terminal-Bench | `loopx.benchmark_adapters.terminal_bench` | First migration target. Public configuration, private-runner launch/materialization helpers, access packets, bridge traces, Harbor reducers, timeout policy, and compact validation policy are adapter-owned. | Adopt `benchmark_attempt_accounting_v0` and `run_permission_policy_v0` in the public launch/result packets before adding new Terminal-Bench runner behavior. |
+| SkillsBench | `loopx.benchmark_adapters.skillsbench` plus ACP relay helpers | Route contracts, arm semantics, job names, public-safe setup failure attribution, case-local product lifecycle, and compact reducer surfaces are adapter-owned. | Map goal-start `/loopx` raw/new runs into the same launch/observe/ingest/classify/ledger fields after solver output and new-arm compact artifacts are available. |
+| ALE | `loopx.benchmark_adapters.agents_last_exam` | Public configuration, local runner/source readiness, launch packets, validation gates, CUA/Codex-route helpers, and task-material/result-report helpers are adapter-owned. | Add attempt accounting and permission-policy fields to local launch/readiness packets before any new ALE run path is promoted. |
+| SWE-Marathon | no dedicated adapter yet | Current evidence remains in public-safe research packets and run ledger rows, not in a reusable adapter module. | Create the adapter only after a second SWE-Marathon route needs shared launch/observe/ingest behavior; until then, do not add SWE-specific conventions to `benchmark_core`. |
+
 Next slices:
 
 1. Keep `benchmark.py` as the compatibility facade until callers are migrated

--- a/examples/benchmark-core-adapter-contract-smoke.py
+++ b/examples/benchmark-core-adapter-contract-smoke.py
@@ -254,6 +254,21 @@ def test_benchmark_facade_has_no_shadowed_top_level_definitions() -> None:
     assert duplicates == []
 
 
+def test_adapter_rollout_matrix_records_current_migration_order() -> None:
+    doc = (
+        REPO_ROOT
+        / "docs"
+        / "research"
+        / "long-horizon-agent-benchmarks"
+        / "benchmark-core-adapter-contract-v0.md"
+    ).read_text(encoding="utf-8")
+    assert "## Adapter Rollout Matrix" in doc
+    assert "| Terminal-Bench | `loopx.benchmark_adapters.terminal_bench` | First migration target." in doc
+    assert "Map goal-start `/loopx` raw/new runs into the same launch/observe/ingest/classify/ledger fields" in doc
+    assert "| SWE-Marathon | no dedicated adapter yet |" in doc
+    assert "do not add SWE-specific conventions to `benchmark_core`" in doc
+
+
 def main() -> int:
     assert_adapter(FixtureAdapter())
     test_process_started_is_not_case_entry()
@@ -265,6 +280,7 @@ def main() -> int:
     test_benchmark_adapter_modules_own_public_config()
     test_benchmark_adapter_modules_own_helper_surfaces()
     test_benchmark_facade_has_no_shadowed_top_level_definitions()
+    test_adapter_rollout_matrix_records_current_migration_order()
     print("benchmark-core-adapter-contract-smoke ok")
     return 0
 


### PR DESCRIPTION
## Summary
- add a public adapter rollout matrix to the benchmark core adapter contract
- record Terminal-Bench as the first migration target and keep SkillsBench goal-start work blocked on solver output/new-arm compact artifacts
- clarify that SWE-Marathon should not leak benchmark-specific conventions into benchmark_core before a dedicated adapter exists

## Validation
- python3 examples/benchmark-core-adapter-contract-smoke.py
- python3 -m py_compile examples/benchmark-core-adapter-contract-smoke.py loopx/benchmark_core/adapter.py loopx/benchmark_core/lifecycle.py
- git diff --check --cached
- loopx check --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-core-adapter-contract-v0.md --scan-path examples/benchmark-core-adapter-contract-smoke.py

## Boundary
- public docs and focused smoke only
- no runner/scoring/task semantics changed
- no benchmark job launched
- no raw logs, task text, trajectories, verifier output, local paths, credentials, or generated artifacts committed