### PR TITLE
Add Terminal-Bench case-run permission policy

### DIFF
--- a/examples/terminal-bench-private-runner-env-guard-smoke.py
+++ b/examples/terminal-bench-private-runner-env-guard-smoke.py
@@ -586,6 +586,30 @@ def main() -> None:
     assert case_run_payload["boundary"]["model_api_expected"] is False, case_run_payload
     assert case_run_payload["boundary"]["raw_logs_read"] is False, case_run_payload
     assert case_run_payload["boundary"]["command_argv_recorded"] is False, case_run_payload
+    assert case_run_payload["run_permission_policy"]["schema_version"] == (
+        "run_permission_policy_v0"
+    ), case_run_payload
+    assert case_run_payload["run_permission_policy"]["policy_id"] == (
+        "terminal_bench_case_run_no_upload_policy"
+    ), case_run_payload
+    assert case_run_payload["run_permission_policy"]["no_upload_required"] is True, (
+        case_run_payload
+    )
+    assert case_run_payload["run_permission_policy"]["submit_allowed"] is False, (
+        case_run_payload
+    )
+    assert case_run_payload["run_permission_policy"][
+        "leaderboard_claim_allowed"
+    ] is False, case_run_payload
+    assert case_run_payload["run_permission_quota_projection"][
+        "schema_version"
+    ] == "run_permission_quota_projection_v0", case_run_payload
+    assert case_run_payload["run_permission_quota_projection"][
+        "delivery_allowed"
+    ] is True, case_run_payload
+    assert case_run_payload["run_permission_quota_projection"][
+        "compact_observation_only"
+    ] is True, case_run_payload
     assert case_run_payload["launch_summary"][
         "worker_materialization_probe_only"
     ] is False, case_run_payload
@@ -618,6 +642,12 @@ def main() -> None:
     assert managed_case_run_payload["boundary"]["task_solver_invoked"] is False, (
         managed_case_run_payload
     )
+    assert managed_case_run_payload["run_permission_policy"]["schema_version"] == (
+        "run_permission_policy_v0"
+    ), managed_case_run_payload
+    assert managed_case_run_payload["run_permission_quota_projection"][
+        "delivery_allowed"
+    ] is True, managed_case_run_payload
     assert managed_case_run_payload["launch_summary"][
         "loopx_agent_kwargs_present"
     ] is True, managed_case_run_payload

--- a/loopx/benchmark_adapters/terminal_bench.py
+++ b/loopx/benchmark_adapters/terminal_bench.py
@@ -14,7 +14,9 @@ from typing import Any, Iterable, Mapping, Sequence
 from ..benchmark_core import (
     BenchmarkFailureClass,
     build_benchmark_attempt_accounting,
+    build_run_permission_policy,
     canonical_lifecycle,
+    compact_run_permission_policy_for_quota,
 )
 from ..benchmark_core.io import (
     load_json_object as _load_json_object,
@@ -1798,6 +1800,13 @@ def launch_terminal_bench_case_run(
         raise ValueError("Terminal-Bench case run requires no-upload/no-submit boundary")
     if summary.get("worker_materialization_probe_only") is True:
         raise ValueError("Terminal-Bench case run summary unexpectedly probe-only")
+    run_permission_policy = build_run_permission_policy(
+        policy_id="terminal_bench_case_run_no_upload_policy",
+        max_wall_time_minutes=120,
+    )
+    run_permission_projection = compact_run_permission_policy_for_quota(
+        run_permission_policy
+    )
 
     parsed_wait_seconds = max(0, int(wait_seconds))
     parsed_materialization_wait_seconds = max(0, int(materialization_wait_seconds))
@@ -1822,6 +1831,8 @@ def launch_terminal_bench_case_run(
         "resume_after_materialization": bool(resume_after_materialization),
         "resume_after_materialization_attempted": False,
         "launch_summary": summary,
+        "run_permission_policy": run_permission_policy,
+        "run_permission_quota_projection": run_permission_projection,
         "command_ref": (
             argv[2]
             if len(argv) > 2 and argv[:2] == ["uvx", "--from"]


### PR DESCRIPTION
## Summary
- include `run_permission_policy_v0` in Terminal-Bench case-run launch packets
- include compact quota projection so control-plane code can read delivery permission structurally
- extend the Terminal-Bench private-runner smoke to assert no-upload/no-submit policy fields

## Validation
- `python3 examples/terminal-bench-private-runner-env-guard-smoke.py`
- `python3 examples/benchmark-core-adapter-contract-smoke.py`
- `python3 -m py_compile loopx/benchmark_adapters/terminal_bench.py examples/terminal-bench-private-runner-env-guard-smoke.py`
- `git diff --check`
- `loopx check --scan-path loopx/benchmark_adapters/terminal_bench.py --scan-path examples/terminal-bench-private-runner-env-guard-smoke.py`

## Boundary
- no benchmark job launched
- no scoring, task semantics, leaderboard, submission, or upload behavior changed
- no raw logs, task text, trajectories, credentials, local paths, or generated benchmark artifacts included