### PR TITLE
Add ALE launch permission policy

### DIFF
--- a/examples/agents-last-exam-local-launch-packet-smoke.py
+++ b/examples/agents-last-exam-local-launch-packet-smoke.py
@@ -204,6 +204,19 @@ def assert_no_execution(payload: dict[str, object]) -> None:
         "case_goal_state_path",
     ):
         assert field in case_state["proof_fields"], case_state
+    policy = payload["run_permission_policy"]
+    assert isinstance(policy, dict)
+    assert policy["schema_version"] == "run_permission_policy_v0", policy
+    assert policy["policy_id"] == "agents_last_exam_local_launch_no_upload_policy", policy
+    assert policy["no_upload_required"] is True, policy
+    assert policy["submit_allowed"] is False, policy
+    assert policy["leaderboard_claim_allowed"] is False, policy
+    projection = payload["run_permission_quota_projection"]
+    assert isinstance(projection, dict)
+    assert projection["schema_version"] == "run_permission_quota_projection_v0", projection
+    assert projection["delivery_allowed"] is True, projection
+    assert projection["no_upload_required"] is True, projection
+    assert projection["compact_observation_only"] is True, projection
 
 
 def run_fixture_smoke() -> None:

--- a/loopx/benchmark_adapters/agents_last_exam.py
+++ b/loopx/benchmark_adapters/agents_last_exam.py
@@ -23,7 +23,9 @@ from ..benchmark_case_state import (
 from ..benchmark_core import (
     BenchmarkFailureClass,
     build_benchmark_attempt_accounting,
+    build_run_permission_policy,
     canonical_lifecycle,
+    compact_run_permission_policy_for_quota,
 )
 from ..benchmark_core.io import (
     load_json_object as _load_json_object,
@@ -3429,6 +3431,13 @@ def build_agents_last_exam_local_launch_packet(
         if isinstance(runner_readiness.get("runner_probe"), dict)
         else {}
     )
+    run_permission_policy = build_run_permission_policy(
+        policy_id="agents_last_exam_local_launch_no_upload_policy",
+        max_wall_time_minutes=120,
+    )
+    run_permission_projection = compact_run_permission_policy_for_quota(
+        run_permission_policy
+    )
     return {
         "schema_version": AGENTS_LAST_EXAM_LOCAL_LAUNCH_PACKET_SCHEMA_VERSION,
         "benchmark_id": AGENTS_LAST_EXAM_BENCHMARK_ID,
@@ -3496,6 +3505,8 @@ def build_agents_last_exam_local_launch_packet(
             case_state_path=AGENTS_LAST_EXAM_CASE_STATE_PATH,
             initialized_by_launch_packet=False,
         ),
+        "run_permission_policy": run_permission_policy,
+        "run_permission_quota_projection": run_permission_projection,
         "boundary": {
             "local_only": True,
             "no_upload": True,


### PR DESCRIPTION
## Summary
- include `run_permission_policy_v0` in Agents Last Exam local launch packets
- include compact quota projection so controller/status code can read the no-upload launch boundary structurally
- extend the ALE launch-packet smoke to assert no-upload/no-submit policy fields

## Validation
- `python3 examples/agents-last-exam-local-launch-packet-smoke.py`
- `python3 examples/benchmark-core-adapter-contract-smoke.py`
- `python3 examples/cli-agents-last-exam-command-modularization-smoke.py`
- `python3 -m py_compile loopx/benchmark_adapters/agents_last_exam.py examples/agents-last-exam-local-launch-packet-smoke.py`
- `git diff --check`
- `loopx check --scan-path loopx/benchmark_adapters/agents_last_exam.py --scan-path examples/agents-last-exam-local-launch-packet-smoke.py`

## Boundary
- no benchmark job launched
- no scoring, task semantics, leaderboard, submission, upload, or runner execution behavior changed
- no raw task text, trajectories, screenshots, credentials, local private state, or generated benchmark artifacts included