### PR TITLE
Add ALE launch attempt accounting

### DIFF
--- a/examples/agents-last-exam-local-launch-packet-smoke.py
+++ b/examples/agents-last-exam-local-launch-packet-smoke.py
@@ -217,6 +217,21 @@ def assert_no_execution(payload: dict[str, object]) -> None:
     assert projection["delivery_allowed"] is True, projection
     assert projection["no_upload_required"] is True, projection
     assert projection["compact_observation_only"] is True, projection
+    attempt_accounting = payload["attempt_accounting"]
+    assert isinstance(attempt_accounting, dict)
+    assert (
+        attempt_accounting["schema_version"] == "benchmark_attempt_accounting_v0"
+    ), attempt_accounting
+    assert attempt_accounting["lifecycle_phase"] == "not_started", attempt_accounting
+    assert attempt_accounting["failure_label"] == "", attempt_accounting
+    assert attempt_accounting["failure_class"] == "none", attempt_accounting
+    assert attempt_accounting["launcher_attempt_countable"] is False, attempt_accounting
+    assert attempt_accounting["case_attempt_countable"] is False, attempt_accounting
+    assert attempt_accounting["solver_attempt_countable"] is False, attempt_accounting
+    assert attempt_accounting["verifier_attempt_countable"] is False, attempt_accounting
+    assert (
+        attempt_accounting["official_score_attempt_countable"] is False
+    ), attempt_accounting
 
 
 def run_fixture_smoke() -> None:

--- a/loopx/benchmark_adapters/agents_last_exam.py
+++ b/loopx/benchmark_adapters/agents_last_exam.py
@@ -3438,6 +3438,12 @@ def build_agents_last_exam_local_launch_packet(
     run_permission_projection = compact_run_permission_policy_for_quota(
         run_permission_policy
     )
+    attempt_accounting = build_benchmark_attempt_accounting(
+        lifecycle=canonical_lifecycle(),
+        failure_label="",
+        failure_class=BenchmarkFailureClass.NONE,
+        official_score_attempted=False,
+    )
     return {
         "schema_version": AGENTS_LAST_EXAM_LOCAL_LAUNCH_PACKET_SCHEMA_VERSION,
         "benchmark_id": AGENTS_LAST_EXAM_BENCHMARK_ID,
@@ -3507,6 +3513,7 @@ def build_agents_last_exam_local_launch_packet(
         ),
         "run_permission_policy": run_permission_policy,
         "run_permission_quota_projection": run_permission_projection,
+        "attempt_accounting": attempt_accounting,
         "boundary": {
             "local_only": True,
             "no_upload": True,


### PR DESCRIPTION
## Summary
- Add benchmark_attempt_accounting_v0 to ALE local no-execution launch packets.
- Keep readiness blockers separate from attempt failure attribution so blocked launch packets do not count as launcher/case/solver/verifier/official-score attempts.
- Extend the ALE launch packet smoke to assert the public attempt-accounting projection for both Python API and CLI paths.

## Validation
- python3 examples/agents-last-exam-local-launch-packet-smoke.py
- python3 examples/benchmark-core-adapter-contract-smoke.py
- python3 examples/cli-agents-last-exam-command-modularization-smoke.py
- python3 -m py_compile loopx/benchmark_adapters/agents_last_exam.py examples/agents-last-exam-local-launch-packet-smoke.py
- git diff --check
- loopx check --scan-path loopx/benchmark_adapters/agents_last_exam.py --scan-path examples/agents-last-exam-local-launch-packet-smoke.py

## Boundary
- Excluded local/private state, raw benchmark logs, trajectories, verifier output, credentials, and local paths.
- No benchmark job launch, task semantics, scoring, leaderboard submission, or permission-boundary change.