### PR TITLE
Add Terminal-Bench launch attempt accounting

### DIFF
--- a/examples/terminal-bench-private-runner-env-guard-smoke.py
+++ b/examples/terminal-bench-private-runner-env-guard-smoke.py
@@ -56,6 +56,24 @@ def expect_raises(callable_obj, needle: str) -> None:
     raise AssertionError(f"expected ValueError containing {needle!r}")
 
 
+def assert_no_execution_attempt_accounting(payload: dict[str, object]) -> None:
+    attempt_accounting = payload["attempt_accounting"]
+    assert isinstance(attempt_accounting, dict), payload
+    assert (
+        attempt_accounting["schema_version"] == "benchmark_attempt_accounting_v0"
+    ), attempt_accounting
+    assert attempt_accounting["lifecycle_phase"] == "not_started", attempt_accounting
+    assert attempt_accounting["failure_label"] == "", attempt_accounting
+    assert attempt_accounting["failure_class"] == "none", attempt_accounting
+    assert attempt_accounting["launcher_attempt_countable"] is False, attempt_accounting
+    assert attempt_accounting["case_attempt_countable"] is False, attempt_accounting
+    assert attempt_accounting["solver_attempt_countable"] is False, attempt_accounting
+    assert attempt_accounting["verifier_attempt_countable"] is False, attempt_accounting
+    assert (
+        attempt_accounting["official_score_attempt_countable"] is False
+    ), attempt_accounting
+
+
 def main() -> None:
     with tempfile.TemporaryDirectory(prefix="loopx-task-material-") as tmp:
         dataset = Path(tmp) / "terminal-bench-local"
@@ -610,6 +628,7 @@ def main() -> None:
     assert case_run_payload["run_permission_quota_projection"][
         "compact_observation_only"
     ] is True, case_run_payload
+    assert_no_execution_attempt_accounting(case_run_payload)
     assert case_run_payload["launch_summary"][
         "worker_materialization_probe_only"
     ] is False, case_run_payload
@@ -648,6 +667,7 @@ def main() -> None:
     assert managed_case_run_payload["run_permission_quota_projection"][
         "delivery_allowed"
     ] is True, managed_case_run_payload
+    assert_no_execution_attempt_accounting(managed_case_run_payload)
     assert managed_case_run_payload["launch_summary"][
         "loopx_agent_kwargs_present"
     ] is True, managed_case_run_payload

--- a/loopx/benchmark_adapters/terminal_bench.py
+++ b/loopx/benchmark_adapters/terminal_bench.py
@@ -1807,6 +1807,12 @@ def launch_terminal_bench_case_run(
     run_permission_projection = compact_run_permission_policy_for_quota(
         run_permission_policy
     )
+    attempt_accounting = build_benchmark_attempt_accounting(
+        lifecycle=canonical_lifecycle(),
+        failure_label="",
+        failure_class=BenchmarkFailureClass.NONE,
+        official_score_attempted=False,
+    )
 
     parsed_wait_seconds = max(0, int(wait_seconds))
     parsed_materialization_wait_seconds = max(0, int(materialization_wait_seconds))
@@ -1833,6 +1839,7 @@ def launch_terminal_bench_case_run(
         "launch_summary": summary,
         "run_permission_policy": run_permission_policy,
         "run_permission_quota_projection": run_permission_projection,
+        "attempt_accounting": attempt_accounting,
         "command_ref": (
             argv[2]
             if len(argv) > 2 and argv[:2] == ["uvx", "--from"]


### PR DESCRIPTION
Summary:
- Add benchmark_attempt_accounting_v0 to Terminal-Bench case-run launch packets before execution starts.
- Assert dry-run/no-execution packets keep all launcher/case/solver/verifier/official-score attempt flags false.

Validation:
- python3 examples/terminal-bench-private-runner-env-guard-smoke.py
- python3 examples/benchmark-core-adapter-contract-smoke.py
- python3 examples/benchmark-attempt-accounting-smoke.py
- python3 -m py_compile loopx/benchmark_adapters/terminal_bench.py examples/terminal-bench-private-runner-env-guard-smoke.py
- git diff --check
- loopx check --scan-path loopx/benchmark_adapters/terminal_bench.py --scan-path examples/terminal-bench-private-runner-env-guard-smoke.py

Boundary:
- Public benchmark helper/runtime plumbing only.
- No scoring, task semantics, leaderboard/submission behavior, permission boundary, or benchmark job launch changes.
- No raw logs, private state, credentials, or local evidence added.