### PR TITLE
Align agent-lane recommended action projection

### DIFF
--- a/examples/refresh-state-agent-lane-scope-smoke.py
+++ b/examples/refresh-state-agent-lane-scope-smoke.py
@@ -17,6 +17,7 @@ from loopx.status import collect_status
 
 GOAL_ID = "refresh-state-agent-lane-goal"
 PRIMARY_ACTION = "Run the primary benchmark bootstrap hardening slice."
+PRIMARY_AGENT_LANE_ACTION = "Continue the primary adapter lifecycle rollout repair."
 SIDE_ACTION = "Polish the hosted frontstage showcase for external developers."
 
 
@@ -139,12 +140,59 @@ def main() -> None:
             item = next(item for item in items if item["goal_id"] == GOAL_ID)
             assert item["status"] == "terminal_bench_primary_ready", item
             assert item["recommended_action"] == PRIMARY_ACTION, item
+            assert item["latest_run_recommended_action"] == PRIMARY_ACTION, item
+            assert item["latest_run_recommended_action_source"] == "latest_status_run", item
             lane = item["agent_lane_recommendation"]
             assert lane["progress_scope"] == "agent_lane", lane
             assert lane["agent_id"] == "codex-side-bypass", lane
             assert lane["agent_lane"] == "productization_frontstage", lane
             assert lane["recommended_action"] == SIDE_ACTION, lane
             assert item["project_asset"]["agent_lane_recommendation"] == lane, item
+
+            state_refresh.now_local = lambda: "2026-06-20T00:02:00+00:00"
+            primary_lane_payload = state_refresh.refresh_state_run(
+                registry_path=registry_path,
+                runtime_root_override=str(runtime),
+                goal_id=GOAL_ID,
+                project=project,
+                state_file=None,
+                classification="adapter_lifecycle_primary_lane_next",
+                recommended_action=PRIMARY_AGENT_LANE_ACTION,
+                next_action=PRIMARY_AGENT_LANE_ACTION,
+                delivery_batch_scale="single_surface",
+                delivery_outcome="outcome_progress",
+                agent_id="codex-main-control",
+                agent_lane="adapter_lifecycle_rollout",
+                dry_run=False,
+                sync_global=False,
+            )
+            assert primary_lane_payload["progress_scope"] == "agent_lane", primary_lane_payload
+            assert primary_lane_payload["agent_id"] == "codex-main-control", primary_lane_payload
+
+            primary_lane_status = collect_status(
+                registry_path=registry_path,
+                runtime_root_override=str(runtime),
+                scan_roots=[project],
+                limit=5,
+            )
+            primary_lane_item = next(
+                item
+                for item in primary_lane_status["attention_queue"]["items"]
+                if item["goal_id"] == GOAL_ID
+            )
+            assert primary_lane_item["status"] == "terminal_bench_primary_ready", primary_lane_item
+            assert primary_lane_item["recommended_action"] == PRIMARY_ACTION, primary_lane_item
+            assert (
+                primary_lane_item["active_state_next_action"] == PRIMARY_AGENT_LANE_ACTION
+            ), primary_lane_item
+            assert (
+                primary_lane_item["latest_run_recommended_action"] == PRIMARY_AGENT_LANE_ACTION
+            ), primary_lane_item
+            assert (
+                primary_lane_item["latest_run_recommended_action_source"]
+                == "agent_lane_recommendation"
+            ), primary_lane_item
+            assert "next_action_projection_warning" not in primary_lane_item, primary_lane_item
     finally:
         state_refresh.now_local = original_now_local
 

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -77,6 +77,7 @@ from .rollout_event_log import load_rollout_events, rollout_event_log_path
 from .session_runtime import SESSION_RUNTIME_READONLY_PROJECTION_SCHEMA_VERSION
 from .state_projection import (
     active_state_next_action_entries,
+    actions_are_projection_aligned,
     next_action_projection_warning,
     state_projection_gap_warning,
 )
@@ -8039,6 +8040,50 @@ def compact_agent_lane_recommendation(run: dict[str, Any] | None) -> dict[str, A
     return compact
 
 
+def latest_run_recommended_action_for_projection(
+    *,
+    current_status_run: dict[str, Any] | None,
+    agent_lane_recommendation: dict[str, Any] | None,
+    active_state_next_action: Any = None,
+    limit: int = 320,
+) -> tuple[str | None, str | None]:
+    latest_action = public_safe_compact_text(
+        current_status_run.get("recommended_action")
+        if isinstance(current_status_run, dict)
+        else None,
+        limit=limit,
+    )
+    if not isinstance(agent_lane_recommendation, dict):
+        return latest_action, "latest_status_run" if latest_action else None
+
+    lane_action = public_safe_compact_text(
+        agent_lane_recommendation.get("recommended_action"),
+        limit=limit,
+    )
+    if not lane_action:
+        return latest_action, "latest_status_run" if latest_action else None
+    if not active_state_next_action or not actions_are_projection_aligned(
+        active_state_next_action,
+        lane_action,
+    ):
+        return latest_action, "latest_status_run" if latest_action else None
+
+    latest_aligned = bool(
+        latest_action
+        and actions_are_projection_aligned(active_state_next_action, latest_action)
+    )
+    lane_dt = parse_timestamp(agent_lane_recommendation.get("generated_at"))
+    latest_dt = parse_timestamp(
+        current_status_run.get("generated_at")
+        if isinstance(current_status_run, dict)
+        else None
+    )
+    lane_is_newer = bool(lane_dt and latest_dt and lane_dt >= latest_dt)
+    if not latest_action or not latest_aligned or lane_is_newer:
+        return lane_action, "agent_lane_recommendation"
+    return latest_action, "latest_status_run"
+
+
 def latest_run(goal: dict[str, Any]) -> dict[str, Any] | None:
     status_run = goal.get("latest_status_run")
     if isinstance(status_run, dict) and not is_status_neutral_run(status_run):
@@ -8639,23 +8684,33 @@ def build_attention_queue(
             if not item:
                 item = active_state_item
         if item:
-            latest_run_action = public_safe_compact_text(
-                current_status_run.get("recommended_action")
-                if isinstance(current_status_run, dict)
-                else None,
-                limit=320,
+            agent_lane_recommendation = compact_agent_lane_recommendation(
+                latest_agent_lane_run(goal)
+            )
+            active_state_next_action = (
+                active_state_fields.get("active_state_next_action")
+                if isinstance(active_state_fields, dict)
+                else None
+            )
+            latest_run_action, latest_run_action_source = latest_run_recommended_action_for_projection(
+                current_status_run=current_status_run,
+                agent_lane_recommendation=agent_lane_recommendation,
+                active_state_next_action=active_state_next_action,
             )
             if latest_run_action:
                 item["latest_run_recommended_action"] = latest_run_action
+                if latest_run_action_source:
+                    item["latest_run_recommended_action_source"] = latest_run_action_source
                 if isinstance(item.get("project_asset"), dict):
                     item["project_asset"]["latest_run_recommended_action"] = latest_run_action
+                    if latest_run_action_source:
+                        item["project_asset"][
+                            "latest_run_recommended_action_source"
+                        ] = latest_run_action_source
             control_plane = compact_control_plane_policy(goal.get("control_plane"))
             if control_plane:
                 item["control_plane"] = control_plane
             goal_latest_runs = goal.get("latest_runs") if isinstance(goal.get("latest_runs"), list) else []
-            agent_lane_recommendation = compact_agent_lane_recommendation(
-                latest_agent_lane_run(goal)
-            )
             if agent_lane_recommendation:
                 item["agent_lane_recommendation"] = agent_lane_recommendation
             subagent_activity = subagent_activity_for_goal(goal)


### PR DESCRIPTION
## Summary
- Promote an agent-lane recommended action into latest_run_recommended_action only when it aligns with the active-state Next Action.
- Preserve stale/non-aligned latest status-run actions for unrelated side-agent lane refreshes.
- Extend refresh-state agent-lane smoke coverage for side-lane isolation and primary-lane promotion.

## Validation
- python3 examples/refresh-state-agent-lane-scope-smoke.py
- python3 examples/next-action-projection-contract-smoke.py
- python3 examples/status-neutral-run-window-smoke.py
- python3 -m py_compile loopx/status.py examples/refresh-state-agent-lane-scope-smoke.py
- git diff --check
- loopx check --scan-path loopx/status.py --scan-path examples/refresh-state-agent-lane-scope-smoke.py (public boundary clean; existing duplicate-index warning only)

## Notes
- This touches core status/quota projection behavior, so I am not self-merging it by default.
- Excluded local/private state, raw benchmark evidence, credentials, and generated logs.