### PR TITLE
Align gate prompt with scoped user todos

### DIFF
--- a/examples/protocol-action-packet-smoke.py
+++ b/examples/protocol-action-packet-smoke.py
@@ -175,6 +175,7 @@ def user_todo(
     *,
     task_class: str | None = None,
     action_kind: str | None = None,
+    claimed_by: str | None = None,
 ) -> dict:
     item = {
         "index": index,
@@ -187,6 +188,8 @@ def user_todo(
         item["task_class"] = task_class
     if action_kind:
         item["action_kind"] = action_kind
+    if claimed_by:
+        item["claimed_by"] = claimed_by
     return item
 
 
@@ -310,6 +313,49 @@ def assert_monitor_only_packet_keeps_user_todo_pending() -> None:
     assert contract["agent_channel"]["quiet_noop_allowed"] is False, contract
 
 
+def assert_agent_scoped_gate_prompt_matches_scoped_summary() -> None:
+    payload = status_payload(
+        status="operator_gate_fixture",
+        agent_todos=[
+            todo(1, MONITOR_TODO, priority="P2", task_class="continuous_monitor"),
+        ],
+        user_todos=[
+            user_todo(
+                82,
+                "[P0-decision] Review/merge PR #807 or explicitly authorize admin-bypass merge.",
+                task_class="user_gate",
+                action_kind="review_pr",
+                claimed_by="codex-main-control",
+            )
+        ],
+    )
+    payload["attention_queue"]["items"][0]["quota"]["state"] = "operator_gate"
+    payload["run_history"]["goals"][0]["coordination"] = {
+        "primary_agent": "codex-main-control",
+        "registered_agents": [
+            "codex-main-control",
+            "codex-product-capability",
+        ],
+    }
+    guard = build_quota_should_run(
+        payload,
+        goal_id=GOAL_ID,
+        agent_id="codex-product-capability",
+    )
+    user_summary = guard["user_todo_summary"]
+    assert user_summary["open_count"] == 0, user_summary
+    assert user_summary["other_agent_scoped_open_count"] == 1, user_summary
+    gate_prompt = guard["gate_prompt"]
+    assert "当前 agent 无阻塞用户待办" in gate_prompt, gate_prompt
+    assert "其他 agent/global 用户待办：1 项" in gate_prompt, gate_prompt
+    assert "用户待办：0 项未完成" not in gate_prompt, gate_prompt
+    assert "用户待办：1 项未完成" not in gate_prompt, gate_prompt
+    assert "PR #807" in gate_prompt, gate_prompt
+    contract = guard["interaction_contract"]
+    assert contract["mode"] == "user_gate", contract
+    assert contract["user_channel"]["action_required"] is True, contract
+
+
 def assert_explicit_non_gating_user_todo_stays_quiet() -> None:
     guard = build_quota_should_run(
         status_payload(
@@ -431,6 +477,7 @@ def main() -> None:
     assert_advancement_packet_keeps_user_todo_pending()
     assert_explicit_user_gate_still_allows_independent_agent_action()
     assert_monitor_only_packet_keeps_user_todo_pending()
+    assert_agent_scoped_gate_prompt_matches_scoped_summary()
     assert_explicit_non_gating_user_todo_stays_quiet()
     assert_monitor_only_packet_allows_quiet_noop()
     assert_executable_recommended_action_overrides_monitor_todo()

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -4539,7 +4539,11 @@ def _automation_prompt_upgrade(
     }
 
 
-def _build_gate_prompt(item: dict[str, Any]) -> str | None:
+def _build_gate_prompt(
+    item: dict[str, Any],
+    *,
+    user_todo_summary: dict[str, Any] | None = None,
+) -> str | None:
     question = str(item.get("operator_question") or "").strip()
     recommended_action = str(item.get("recommended_action") or "").strip()
     next_handoff_condition = str(item.get("next_handoff_condition") or "").strip()
@@ -4548,14 +4552,30 @@ def _build_gate_prompt(item: dict[str, Any]) -> str | None:
         for gate in (item.get("missing_gates") if isinstance(item.get("missing_gates"), list) else [])
         if str(gate).strip()
     ]
-    user_todo_summary = _summarize_user_todos(item.get("user_todos"))
+    if user_todo_summary is None:
+        user_todo_summary = _summarize_user_todos(item.get("user_todos"))
     first_open = (
         user_todo_summary.get("first_open_items")
         if isinstance(user_todo_summary, dict) and isinstance(user_todo_summary.get("first_open_items"), list)
         else []
     )
+    other_agent_scoped_items = (
+        user_todo_summary.get("other_agent_scoped_items")
+        if isinstance(user_todo_summary, dict)
+        and isinstance(user_todo_summary.get("other_agent_scoped_items"), list)
+        else []
+    )
 
-    if not any([question, recommended_action, next_handoff_condition, missing_gates, first_open]):
+    if not any(
+        [
+            question,
+            recommended_action,
+            next_handoff_condition,
+            missing_gates,
+            first_open,
+            other_agent_scoped_items,
+        ]
+    ):
         return None
 
     lines = ["请用户/控制器确认当前 gate："]
@@ -4571,6 +4591,16 @@ def _build_gate_prompt(item: dict[str, Any]) -> str | None:
         open_count = user_todo_summary.get("open_count")
         lines.append(f"- 用户待办：{open_count} 项未完成，优先确认：")
         for todo in first_open:
+            index = todo.get("index")
+            prefix = f"  {index}. " if index is not None else "  - "
+            lines.append(f"{prefix}{todo.get('text')}")
+    elif isinstance(user_todo_summary, dict) and other_agent_scoped_items:
+        scoped_count = user_todo_summary.get("other_agent_scoped_open_count")
+        all_open_count = user_todo_summary.get("all_open_count")
+        count = scoped_count if scoped_count is not None else len(other_agent_scoped_items)
+        suffix = f"（全局共 {all_open_count} 项）" if all_open_count is not None else ""
+        lines.append(f"- 当前 agent 无阻塞用户待办；其他 agent/global 用户待办：{count} 项{suffix}，优先确认：")
+        for todo in other_agent_scoped_items[:3]:
             index = todo.get("index")
             prefix = f"  {index}. " if index is not None else "  - "
             lines.append(f"{prefix}{todo.get('text')}")
@@ -6699,7 +6729,11 @@ def build_quota_should_run(
         )
         if reward_lesson_warning:
             payload["reward_lesson_projection_warning"] = reward_lesson_warning
-        gate_prompt = _build_gate_prompt(item) if state == "operator_gate" else None
+        gate_prompt = (
+            _build_gate_prompt(item, user_todo_summary=user_todo_summary)
+            if state == "operator_gate"
+            else None
+        )
         if gate_prompt:
             payload["gate_prompt"] = gate_prompt
             payload["notify_user_on_gate"] = True


### PR DESCRIPTION
## Summary
- make operator gate prompts use the same agent-scoped user todo summary already returned in quota payloads
- when current-agent blocking user todos are filtered to zero but other-agent/global gates remain visible, label them explicitly as other-agent/global instead of implying they are current-agent blockers
- add protocol action packet smoke coverage for the scoped gate prompt contract

## Validation
- python3 examples/protocol-action-packet-smoke.py
- python3 -m py_compile loopx/quota.py examples/protocol-action-packet-smoke.py
- git diff --check
- loopx check --scan-path loopx/quota.py --scan-path examples/protocol-action-packet-smoke.py