### PR TITLE
Add benchmark launch observable handle metadata

### DIFF
--- a/examples/agents-last-exam-local-launch-packet-smoke.py
+++ b/examples/agents-last-exam-local-launch-packet-smoke.py
@@ -155,6 +155,53 @@ def assert_no_execution(payload: dict[str, object]) -> None:
     assert launch_packet["will_capture_screenshot"] is False
     assert launch_packet["will_record_credentials"] is False
     assert launch_packet["will_record_local_paths"] is False
+    handle_registration = payload["observable_handle_registration"]
+    assert isinstance(handle_registration, dict)
+    assert (
+        handle_registration["schema_version"]
+        == "benchmark_launch_observable_handle_v0"
+    ), handle_registration
+    assert handle_registration["benchmark_id"] == "agents-last-exam"
+    assert handle_registration["launch_mode"] == "no_execution_launch_packet"
+    assert handle_registration["will_execute"] is False
+    assert handle_registration["monitor_poll_allowed"] is False
+    observable_handle = handle_registration["observable_handle"]
+    assert isinstance(observable_handle, dict)
+    assert observable_handle["kind"] == "job_basename"
+    assert observable_handle["state"] == "not_started"
+    assert observable_handle["job_basename"].startswith("agents-last-exam-")
+    assert "/" not in observable_handle["job_basename"]
+    assert observable_handle["pid_recorded"] is False
+    assert observable_handle["pid_alive"] is None
+    assert observable_handle["raw_handle_payload_recorded"] is False
+    assert observable_handle["private_handle_values_recorded"] is False
+    poll_command = handle_registration["allowed_poll_command"]
+    assert isinstance(poll_command, dict)
+    assert poll_command["command_label"] == "benchmark_run_status_snapshot"
+    assert poll_command["argv_recorded"] is False
+    assert poll_command["raw_command_recorded"] is False
+    assert poll_command["requires_private_paths"] is False
+    assert handle_registration["compact_artifact_refs"] == [
+        "run.compact.json",
+        "eval.compact.json",
+        "events.compact.json",
+    ]
+    handle_boundary = handle_registration["read_boundary"]
+    assert isinstance(handle_boundary, dict)
+    assert handle_boundary["compact_only"] is True
+    assert handle_boundary["raw_logs_read"] is False
+    assert handle_boundary["raw_task_text_read"] is False
+    assert handle_boundary["raw_artifacts_read"] is False
+    assert handle_boundary["trajectory_read"] is False
+    assert handle_boundary["local_paths_recorded"] is False
+    assert handle_boundary["private_handle_values_recorded"] is False
+    registration_boundary = handle_registration["boundary"]
+    assert isinstance(registration_boundary, dict)
+    assert registration_boundary["raw_logs_recorded"] is False
+    assert registration_boundary["raw_task_text_recorded"] is False
+    assert registration_boundary["raw_trajectory_recorded"] is False
+    assert registration_boundary["local_paths_recorded"] is False
+    assert registration_boundary["scheduler_payload_recorded"] is False
     boundary = payload["boundary"]
     assert isinstance(boundary, dict)
     assert boundary["container_started"] is False

--- a/loopx/benchmark_adapters/agents_last_exam.py
+++ b/loopx/benchmark_adapters/agents_last_exam.py
@@ -23,6 +23,7 @@ from ..benchmark_case_state import (
 from ..benchmark_core import (
     BenchmarkFailureClass,
     build_benchmark_attempt_accounting,
+    build_benchmark_launch_observable_handle,
     build_run_permission_policy,
     canonical_lifecycle,
     compact_run_permission_policy_for_quota,
@@ -3444,11 +3445,37 @@ def build_agents_last_exam_local_launch_packet(
         failure_class=BenchmarkFailureClass.NONE,
         official_score_attempted=False,
     )
+    task_public_id = (
+        _agents_last_exam_public_id(selected_task_id, limit=160)
+        or "metadata_only_candidate"
+    )
+    task_job_id = task_public_id.replace("/", "-")
+    observable_handle_registration = build_benchmark_launch_observable_handle(
+        benchmark_id=AGENTS_LAST_EXAM_BENCHMARK_ID,
+        launch_mode="no_execution_launch_packet",
+        run_label=f"{AGENTS_LAST_EXAM_BENCHMARK_ID}-{task_job_id}-dry-run",
+        job_basename=f"{AGENTS_LAST_EXAM_BENCHMARK_ID}-{task_job_id}-dry-run",
+        process_state="not_started",
+        compact_artifact_refs=(
+            "run.compact.json",
+            "eval.compact.json",
+            "events.compact.json",
+        ),
+        allowed_poll_command="benchmark_run_status_snapshot",
+        scheduler_kind="manual_operator",
+        will_execute=False,
+        read_boundary={
+            "compact_only": True,
+            "task_text_read": False,
+            "raw_artifacts_read": False,
+            "local_paths_recorded": False,
+            "private_handle_values_recorded": False,
+        },
+    )
     return {
         "schema_version": AGENTS_LAST_EXAM_LOCAL_LAUNCH_PACKET_SCHEMA_VERSION,
         "benchmark_id": AGENTS_LAST_EXAM_BENCHMARK_ID,
-        "task_id": _agents_last_exam_public_id(selected_task_id, limit=160)
-        or "metadata_only_candidate",
+        "task_id": task_public_id,
         "snapshot": _agents_last_exam_public_id(snapshot, limit=80)
         or AGENTS_LAST_EXAM_DEFAULT_SNAPSHOT,
         "ready": ready,
@@ -3505,6 +3532,7 @@ def build_agents_last_exam_local_launch_packet(
             "will_record_credentials": False,
             "will_record_local_paths": False,
         },
+        "observable_handle_registration": observable_handle_registration,
         "case_state_init_contract": benchmark_case_active_state_init_contract(
             benchmark_id=AGENTS_LAST_EXAM_BENCHMARK_ID,
             goal_id=AGENTS_LAST_EXAM_CASE_GOAL_ID,

--- a/loopx/benchmark_core/__init__.py
+++ b/loopx/benchmark_core/__init__.py
@@ -64,7 +64,9 @@ from .io import (
     optional_positive_int,
 )
 from .observable_handles import (
+    BENCHMARK_LAUNCH_OBSERVABLE_HANDLE_SCHEMA_VERSION,
     BENCHMARK_OBSERVABLE_HANDLE_POLICY_SCHEMA_VERSION,
+    build_benchmark_launch_observable_handle,
     build_benchmark_observable_handle_policy,
 )
 from .parity import (
@@ -111,6 +113,7 @@ __all__ = [
     "BENCHMARK_LIFECYCLE_STATE_SCHEMA_VERSION",
     "BENCHMARK_LOOP_CONTROLLER_TRACE_SCHEMA_VERSION",
     "BENCHMARK_LOOP_PROTOCOL_SCHEMA_VERSION",
+    "BENCHMARK_LAUNCH_OBSERVABLE_HANDLE_SCHEMA_VERSION",
     "BENCHMARK_OBSERVABLE_HANDLE_POLICY_SCHEMA_VERSION",
     "BENCHMARK_PRODUCT_MODE_COMPARISON_SCHEMA_VERSION",
     "BENCHMARK_ROUND_ARTIFACT_RESTORE_PLAN_SCHEMA_VERSION",
@@ -128,6 +131,7 @@ __all__ = [
     "build_benchmark_attempt_accounting",
     "build_benchmark_loop_contract",
     "build_benchmark_loop_controller_trace",
+    "build_benchmark_launch_observable_handle",
     "build_benchmark_observable_handle_policy",
     "build_round_artifact_restore_plan",
     "build_benchmark_candidate_source_boundary",

--- a/loopx/benchmark_core/observable_handles.py
+++ b/loopx/benchmark_core/observable_handles.py
@@ -1,11 +1,165 @@
 from __future__ import annotations
 
+import re
 from typing import Any, Mapping
 
 
 BENCHMARK_OBSERVABLE_HANDLE_POLICY_SCHEMA_VERSION = (
     "benchmark_observable_handle_policy_v0"
 )
+BENCHMARK_LAUNCH_OBSERVABLE_HANDLE_SCHEMA_VERSION = (
+    "benchmark_launch_observable_handle_v0"
+)
+
+
+_DEFAULT_LAUNCH_READ_BOUNDARY = {
+    "compact_only": True,
+    "raw_logs_read": False,
+    "raw_task_text_read": False,
+    "raw_artifacts_read": False,
+    "trajectory_read": False,
+    "local_paths_recorded": False,
+    "private_handle_values_recorded": False,
+    "scheduler_payload_recorded": False,
+}
+
+_LAUNCH_PROCESS_STATES = {
+    "not_started",
+    "queued",
+    "starting",
+    "running",
+    "ended",
+    "missing",
+    "not_found",
+    "unknown",
+}
+
+
+def _public_safe_label(value: Any, *, fallback: str = "", limit: int = 120) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return fallback
+    text = text.replace("\\", "/").split("/")[-1]
+    text = re.sub(r"[^A-Za-z0-9._:-]+", "-", text).strip("-._:")
+    if not text:
+        return fallback
+    return text[:limit]
+
+
+def _public_safe_ref_items(values: Any, *, limit: int = 12) -> list[str]:
+    if values is None:
+        return []
+    if isinstance(values, str):
+        items = [values]
+    else:
+        try:
+            items = list(values)
+        except TypeError:
+            items = [values]
+    safe_items: list[str] = []
+    for item in items:
+        safe = _public_safe_label(item, limit=160)
+        if safe and safe not in safe_items:
+            safe_items.append(safe)
+        if len(safe_items) >= limit:
+            break
+    return safe_items
+
+
+def _launch_read_boundary(read_boundary: Mapping[str, Any] | None) -> dict[str, bool]:
+    boundary = dict(_DEFAULT_LAUNCH_READ_BOUNDARY)
+    if not isinstance(read_boundary, Mapping):
+        return boundary
+    if read_boundary.get("task_text_read") is True:
+        boundary["raw_task_text_read"] = True
+    if read_boundary.get("raw_logs_read") is True:
+        boundary["raw_logs_read"] = True
+    if read_boundary.get("raw_artifacts_read") is True:
+        boundary["raw_artifacts_read"] = True
+    if read_boundary.get("trajectory_read") is True:
+        boundary["trajectory_read"] = True
+    if read_boundary.get("local_paths_recorded") is True:
+        boundary["local_paths_recorded"] = True
+    if read_boundary.get("private_handle_values_recorded") is True:
+        boundary["private_handle_values_recorded"] = True
+    if read_boundary.get("compact_only") is False:
+        boundary["compact_only"] = False
+    return boundary
+
+
+def build_benchmark_launch_observable_handle(
+    *,
+    benchmark_id: str,
+    launch_mode: str,
+    run_label: str | None = None,
+    job_basename: str | None = None,
+    process_state: str = "not_started",
+    pid_recorded: bool = False,
+    pid_alive: bool | None = None,
+    compact_artifact_refs: Any = None,
+    allowed_poll_command: str = "benchmark_run_status_snapshot",
+    scheduler_kind: str = "manual",
+    will_execute: bool = False,
+    read_boundary: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return public-safe launch handle metadata for benchmark artifacts.
+
+    Launch artifacts should expose enough shape for a heartbeat or developer to
+    poll the run without preserving raw scheduler payloads, shell argv, local
+    paths, logs, task text, trajectories, or private handle values.
+    """
+
+    state = _public_safe_label(process_state, fallback="unknown", limit=40)
+    if state not in _LAUNCH_PROCESS_STATES:
+        state = "unknown"
+    safe_job_basename = _public_safe_label(job_basename or run_label, limit=160)
+    safe_run_label = _public_safe_label(run_label or safe_job_basename, limit=160)
+    poll_label = _public_safe_label(
+        allowed_poll_command,
+        fallback="benchmark_run_status_snapshot",
+        limit=120,
+    )
+    refs = _public_safe_ref_items(compact_artifact_refs)
+    monitor_poll_allowed = will_execute is True and state in {
+        "queued",
+        "starting",
+        "running",
+    }
+    return {
+        "schema_version": BENCHMARK_LAUNCH_OBSERVABLE_HANDLE_SCHEMA_VERSION,
+        "benchmark_id": _public_safe_label(benchmark_id, fallback="benchmark", limit=80),
+        "launch_mode": _public_safe_label(launch_mode, fallback="unknown", limit=80),
+        "scheduler_kind": _public_safe_label(scheduler_kind, fallback="manual", limit=80),
+        "will_execute": will_execute is True,
+        "observable_handle": {
+            "kind": "pid_file" if pid_recorded else "job_basename",
+            "state": state,
+            "run_label": safe_run_label,
+            "job_basename": safe_job_basename,
+            "pid_recorded": pid_recorded is True,
+            "pid_alive": pid_alive if isinstance(pid_alive, bool) else None,
+            "raw_handle_payload_recorded": False,
+            "private_handle_values_recorded": False,
+        },
+        "compact_artifact_refs": refs,
+        "compact_artifact_ref_count": len(refs),
+        "allowed_poll_command": {
+            "command_label": poll_label,
+            "argv_recorded": False,
+            "raw_command_recorded": False,
+            "requires_private_paths": False,
+        },
+        "monitor_poll_allowed": monitor_poll_allowed,
+        "read_boundary": _launch_read_boundary(read_boundary),
+        "boundary": {
+            "raw_logs_recorded": False,
+            "raw_task_text_recorded": False,
+            "raw_trajectory_recorded": False,
+            "local_paths_recorded": False,
+            "scheduler_payload_recorded": False,
+            "credential_values_recorded": False,
+        },
+    }
 
 
 _RESULT_CLOSEOUT_STATUS_VALUES = {


### PR DESCRIPTION
## Summary
- add a public-safe benchmark launch observable-handle registration helper
- export the helper from benchmark_core
- attach observable_handle_registration to ALE no-execution launch packets and cover it in the focused smoke

## Validation
- python3 examples/agents-last-exam-local-launch-packet-smoke.py
- python3 examples/benchmark-run-status-snapshot-smoke.py
- python3 -m py_compile loopx/benchmark_core/observable_handles.py loopx/benchmark_core/__init__.py loopx/benchmark_adapters/agents_last_exam.py examples/agents-last-exam-local-launch-packet-smoke.py
- git diff --cached --check

## Boundary
- benchmark helper/runtime only
- no benchmark job launch
- no scoring, task semantics, leaderboard/submission, or permission-boundary change
- no raw logs, trajectories, local paths, credentials, or private handle values recorded