### PR TITLE
Extend pr review to merged windows

### DIFF
--- a/docs/reference/protocols/global-manager-command-v0.md
+++ b/docs/reference/protocols/global-manager-command-v0.md
@@ -24,7 +24,7 @@ Recommended first commands:
 | `/loopx-global-gates` | Show open user/controller gates and what each blocks. | current state |
 | `/loopx-global-todos` | Show top runnable, blocked, deferred-ready, and review todos. | current state |
 | `/loopx-global-risks` | Show stale runs, public/private boundary warnings, failing checks, and rollback candidates. | 24 hours |
-| `/loopx-pr-review` | Walk the current project's or explicit repository's unmerged GitHub PRs one by one with motivation, scope, checks, risks, and review prompts. | current open PRs |
+| `/loopx-pr-review` | Walk the current project's or explicit repository's open and merged GitHub PRs one by one with motivation, scope, checks, risks, and review prompts. | current open + merged PRs, optionally bounded by `--since` |
 | `/loop-goal-summary <goal id>` | Drill into one goal without scanning unrelated projects. | 24 hours |
 
 Commands are read-only by default. They can propose follow-up actions, but
@@ -49,7 +49,7 @@ and then enters the quota-gated automation flow.
 
 Related repo-review command: `/loopx-pr-review` is covered by
 [`pr_review_command_v0`](pr-review-command-v0.md). It is read-only and helps a
-human review open PRs in the caller's current project or an explicit
+human review open and merged PRs in the caller's current project or an explicit
 `--repo owner/repo` target; it does not approve, comment, merge, or spend quota.
 
 ## Request Shape

--- a/docs/reference/protocols/pr-review-command-v0.md
+++ b/docs/reference/protocols/pr-review-command-v0.md
@@ -1,8 +1,8 @@
 # pr_review_command_v0
 
 `pr_review_command_v0` defines the `/loopx-pr-review` command. It helps a
-user review unmerged pull requests one by one by turning public GitHub PR
-metadata into a guided review queue.
+user review open and recently merged pull requests one by one by turning public
+GitHub PR metadata into a guided review queue.
 
 The reviewed repository is the caller's current GitHub project by default, as
 resolved by `gh`, or the explicit `--repo owner/repo` target. LoopX's own
@@ -16,13 +16,14 @@ push, spend LoopX quota, or mark LoopX todos complete.
 
 | Command | CLI reference | Intent |
 | --- | --- | --- |
-| `/loopx-pr-review` | `loopx pr-review [--repo owner/repo]` | List open PRs for the current project or explicit repository and build a guided review packet with motivation, change scope, checks, risks, and review prompts. |
+| `/loopx-pr-review` | `loopx pr-review [--repo owner/repo] [--state open\|merged\|all] [--since ISO]` | List open and merged PRs for the current project or explicit repository and build a guided review packet with motivation, change scope, checks, risks, and review prompts. |
 
 ## Source Reads
 
 Implementations may read compact public PR surfaces:
 
-- pull request title, number, URL, branch, author, state, and review decision;
+- pull request title, number, URL, branch, author, lifecycle state, merge time,
+  and review decision;
 - PR body summary;
 - changed-file list and diff scale;
 - commit headlines;
@@ -42,17 +43,23 @@ absolute paths, private source bodies, or hidden CI artifacts.
   "request": {
     "schema_version": "loopx_pr_review_command_request_v0",
     "command": "/loopx-pr-review",
-    "cli_command": "loopx pr-review [--repo owner/repo]",
+    "cli_command": "loopx pr-review [--repo owner/repo] [--state open|merged|all] [--since ISO]",
     "repository": "owner/repo",
     "limit": 10,
+    "state_filter": "all",
+    "since": "2026-06-28T00:00:00Z",
+    "window": {"state_filter": "all", "since": "2026-06-28T00:00:00Z"},
     "source": "github_cli",
     "privacy_mode": "public_safe_github_metadata",
     "dry_run": true
   },
   "summary": {
-    "headline": "5 open PR(s) found; 5 need review attention.",
-    "open_pr_count": 5,
-    "review_attention_count": 5,
+    "headline": "8 PR(s) in review window: 3 open, 5 merged; 8 need review attention.",
+    "total_pr_count": 8,
+    "open_pr_count": 3,
+    "merged_pr_count": 5,
+    "review_attention_count": 8,
+    "post_merge_review_count": 5,
     "draft_count": 0,
     "recommended_first_pr": {
       "rank": 1,
@@ -66,6 +73,7 @@ absolute paths, private source bodies, or hidden CI artifacts.
       "number": 773,
       "title": "docs: add newcomer command path",
       "url": "https://github.com/owner/repo/pull/773",
+      "state": "OPEN",
       "review_depth": "docs_and_smoke_review",
       "why_now": "Open and awaiting reviewer decision."
     }
@@ -108,6 +116,10 @@ A first implementation is acceptable when:
 - `loopx pr-review` returns `loopx_pr_review_command_response_v0`;
 - default live reads use the caller's current `gh` repository, while
   `--repo owner/repo` can review another GitHub project;
+- `--state all` includes merged PRs in the same packet, while `--state open`
+  preserves the old open-only review queue;
+- `--since` can bound an overnight or release-window review without relying on
+  private chat memory;
 - the response includes review sequence, motivation, changed-file scope,
   status checks, risk notes, and review prompts;
 - live GitHub reads and fixture-based smokes share the same schema;

--- a/examples/fixtures/pr-review.public.json
+++ b/examples/fixtures/pr-review.public.json
@@ -83,6 +83,36 @@
         {"messageHeadline": "draft: explore PR review cards"}
       ],
       "statusCheckRollup": []
+    },
+    {
+      "number": 770,
+      "title": "runtime: align quota gate prompt",
+      "url": "https://github.com/huangruiteng/loopx/pull/770",
+      "state": "MERGED",
+      "author": {"login": "huangruiteng"},
+      "baseRefName": "main",
+      "headRefName": "codex/quota-gate-prompt-alignment",
+      "updatedAt": "2026-06-27T12:25:00Z",
+      "closedAt": "2026-06-27T12:25:00Z",
+      "mergedAt": "2026-06-27T12:25:00Z",
+      "mergeCommit": {"oid": "abc1234def5678"},
+      "isDraft": false,
+      "reviewDecision": "REVIEW_REQUIRED",
+      "mergeStateStatus": "UNKNOWN",
+      "body": "Aligns quota gate prompt wording with scoped user todo projection and keeps merged PRs visible for post-merge review.",
+      "changedFiles": 2,
+      "additions": 60,
+      "deletions": 8,
+      "files": [
+        {"path": "loopx/quota.py", "additions": 42, "deletions": 6},
+        {"path": "examples/protocol-action-packet-smoke.py", "additions": 18, "deletions": 2}
+      ],
+      "commits": [
+        {"messageHeadline": "runtime: align gate prompt with scoped todos"}
+      ],
+      "statusCheckRollup": [
+        {"name": "quota-smoke", "status": "COMPLETED", "conclusion": "SUCCESS"}
+      ]
     }
   ]
 }

--- a/examples/pr-review-command-smoke.py
+++ b/examples/pr-review-command-smoke.py
@@ -46,16 +46,24 @@ def main() -> int:
     assert payload["schema_version"] == "loopx_pr_review_command_response_v0", payload
     request = payload["request"]
     assert request["command"] == "/loopx-pr-review", request
-    assert request["cli_command"] == "loopx pr-review [--repo owner/repo]", request
+    assert (
+        request["cli_command"]
+        == "loopx pr-review [--repo owner/repo] [--state open|merged|all] [--since ISO]"
+    ), request
     assert request["privacy_mode"] == "public_safe_github_metadata", request
     assert request["dry_run"] is True, request
     assert request["repository"] == "huangruiteng/loopx", request
+    assert request["state_filter"] == "all", request
+    assert payload["summary"]["total_pr_count"] == 4, payload["summary"]
     assert payload["summary"]["open_pr_count"] == 3, payload["summary"]
+    assert payload["summary"]["merged_pr_count"] == 1, payload["summary"]
+    assert payload["summary"]["post_merge_review_count"] == 1, payload["summary"]
     assert payload["summary"]["review_attention_count"] == 3, payload["summary"]
     assert payload["summary"]["draft_count"] == 1, payload["summary"]
     sequence = payload["review_sequence"]
     assert sequence[0]["number"] == 773, sequence
     assert sequence[-1]["number"] == 775, sequence
+    assert any(item["number"] == 770 and item["state"] == "MERGED" for item in sequence), sequence
     first = payload["pull_requests"][0]
     assert first["number"] == 773, first
     assert "newcomer command path" in first["motivation"], first
@@ -64,9 +72,46 @@ def main() -> int:
     assert payload["boundary"]["absolute_paths_recorded"] is False, payload["boundary"]
     assert_public_safe(payload)
 
+    open_only = json.loads(
+        run_cli(
+            "--format",
+            "json",
+            "pr-review",
+            "--fixture",
+            str(FIXTURE),
+            "--state",
+            "open",
+            "--limit",
+            "5",
+        ).stdout
+    )
+    assert open_only["summary"]["total_pr_count"] == 3, open_only["summary"]
+    assert open_only["summary"]["merged_pr_count"] == 0, open_only["summary"]
+
+    windowed = json.loads(
+        run_cli(
+            "--format",
+            "json",
+            "pr-review",
+            "--fixture",
+            str(FIXTURE),
+            "--since",
+            "2026-06-27T12:20:00Z",
+            "--limit",
+            "5",
+        ).stdout
+    )
+    assert windowed["request"]["since"] == "2026-06-27T12:20:00Z", windowed["request"]
+    assert windowed["summary"]["total_pr_count"] == 3, windowed["summary"]
+    assert windowed["summary"]["open_pr_count"] == 2, windowed["summary"]
+    assert windowed["summary"]["merged_pr_count"] == 1, windowed["summary"]
+    assert any(item["number"] == 770 for item in windowed["review_sequence"]), windowed["review_sequence"]
+
     markdown = run_cli("pr-review", "--fixture", str(FIXTURE), "--limit", "1").stdout
     assert "# Project PR Review Queue" in markdown, markdown
     assert "current gh repository" not in markdown, markdown
+    assert "state_filter: `all`" in markdown, markdown
+    assert "merged=`" in markdown, markdown
     assert "## Review Sequence" in markdown, markdown
     assert "PR #773" in markdown, markdown
     assert "review prompts" in markdown, markdown

--- a/examples/slash-command-catalog-smoke.py
+++ b/examples/slash-command-catalog-smoke.py
@@ -53,7 +53,7 @@ def main() -> int:
     assert "`/loopx-global-summary`" in markdown, markdown
     assert "`loopx global-summary`" in markdown, markdown
     assert "`/loopx-pr-review`" in markdown, markdown
-    assert "`loopx pr-review [--repo owner/repo]`" in markdown, markdown
+    assert "`loopx pr-review [--repo owner/repo] [--state open\\|merged\\|all] [--since ISO]`" in markdown, markdown
     assert "`/loopx-summary-all`" not in markdown, markdown
 
     top_help = run_cli("--help").stdout

--- a/loopx/cli_commands/pr_review.py
+++ b/loopx/cli_commands/pr_review.py
@@ -8,6 +8,7 @@ from ..pr_review import (
     build_pr_review_packet,
     fetch_github_pull_requests,
     load_pr_fixture,
+    normalize_pr_state_filter,
     render_pr_review_markdown,
     resolve_current_github_repository,
 )
@@ -26,14 +27,24 @@ def register_pr_review_command(
 ) -> None:
     parser = subparsers.add_parser(
         "pr-review",
-        help="Build a public-safe /loopx-pr-review queue for the current project's open pull requests.",
+        help="Build a public-safe /loopx-pr-review queue for the current project's open and merged pull requests.",
     )
     add_subcommand_format(parser)
     parser.add_argument(
         "--repo",
         help="GitHub owner/repo to review. Defaults to the current project's gh repository context.",
     )
-    parser.add_argument("--limit", type=int, default=10, help="Maximum open PRs to include.")
+    parser.add_argument("--limit", type=int, default=10, help="Maximum PRs to include.")
+    parser.add_argument(
+        "--state",
+        choices=("open", "merged", "all"),
+        default="all",
+        help="PR lifecycle state to include. Defaults to all so merged PRs remain reviewable.",
+    )
+    parser.add_argument(
+        "--since",
+        help="Only include PRs active since this ISO timestamp or YYYY-MM-DD date.",
+    )
     parser.add_argument(
         "--fixture",
         help="Read public-safe PR metadata from a JSON fixture instead of live gh output.",
@@ -57,12 +68,19 @@ def handle_pr_review_command(
             source = "fixture"
         else:
             repository = repository or resolve_current_github_repository()
-            pull_requests = fetch_github_pull_requests(repo=repository, limit=max(1, args.limit))
+            pull_requests = fetch_github_pull_requests(
+                repo=repository,
+                limit=max(1, args.limit),
+                state_filter=normalize_pr_state_filter(args.state),
+                since=args.since,
+            )
         payload = build_pr_review_packet(
             pull_requests=pull_requests,
             repository=repository,
             limit=max(1, args.limit),
             source=source,
+            state_filter=normalize_pr_state_filter(args.state),
+            since=args.since,
         )
     except Exception as exc:
         payload = {
@@ -71,9 +89,11 @@ def handle_pr_review_command(
             "request": {
                 "schema_version": "loopx_pr_review_command_request_v0",
                 "command": "/loopx-pr-review",
-                "cli_command": "loopx pr-review [--repo owner/repo]",
+                "cli_command": "loopx pr-review [--repo owner/repo] [--state open|merged|all] [--since ISO]",
                 "repository": args.repo,
                 "limit": max(1, args.limit),
+                "state_filter": normalize_pr_state_filter(args.state),
+                "since": args.since,
                 "source": "fixture" if args.fixture else "github_cli",
                 "privacy_mode": "public_safe_github_metadata",
                 "dry_run": True,

--- a/loopx/pr_review.py
+++ b/loopx/pr_review.py
@@ -109,17 +109,69 @@ def resolve_current_github_repository(*, cwd: Path | None = None) -> str | None:
     return str(payload.get("nameWithOwner") or "") or None
 
 
+def _parse_timestamp(value: object) -> datetime | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _github_search_date(value: object) -> str | None:
+    parsed = _parse_timestamp(value)
+    if parsed:
+        return parsed.date().isoformat()
+    text = str(value or "").strip()
+    if re.fullmatch(r"\d{4}-\d{2}-\d{2}", text):
+        return text
+    return None
+
+
+def _pr_window_timestamp(pr: dict[str, Any]) -> datetime | None:
+    return (
+        _parse_timestamp(pr.get("mergedAt") or pr.get("merged_at"))
+        or _parse_timestamp(pr.get("closedAt") or pr.get("closed_at"))
+        or _parse_timestamp(pr.get("updatedAt") or pr.get("updated_at"))
+    )
+
+
+def _include_pr_in_window(pr: dict[str, Any], *, since: object | None) -> bool:
+    since_dt = _parse_timestamp(since)
+    if since_dt is None:
+        return True
+    activity_dt = _pr_window_timestamp(pr)
+    return bool(activity_dt and activity_dt >= since_dt)
+
+
+def normalize_pr_state_filter(value: object) -> str:
+    state = str(value or "all").strip().lower()
+    return state if state in {"open", "merged", "all"} else "all"
+
+
 def fetch_github_pull_requests(
     *,
     repo: str | None,
     limit: int,
     cwd: Path | None = None,
+    state_filter: str = "all",
+    since: str | None = None,
 ) -> list[dict[str, Any]]:
     repo_args = ["--repo", repo] if repo else []
+    normalized_state = normalize_pr_state_filter(state_filter)
+    search_args: list[str] = []
+    search_date = _github_search_date(since)
+    if search_date:
+        search_args = ["--search", f"updated:>={search_date}"]
     list_fields = [
         "number",
         "title",
         "url",
+        "state",
         "isDraft",
         "reviewDecision",
         "mergeStateStatus",
@@ -127,17 +179,23 @@ def fetch_github_pull_requests(
         "baseRefName",
         "author",
         "updatedAt",
+        "closedAt",
+        "mergedAt",
     ]
+    fetch_limit = max(1, limit)
+    if since:
+        fetch_limit = max(fetch_limit, min(100, fetch_limit * 3))
     rows = _run_gh_json(
         [
             "pr",
             "list",
             "--state",
-            "open",
+            normalized_state,
             "--limit",
-            str(max(1, limit)),
+            str(fetch_limit),
             "--json",
             ",".join(list_fields),
+            *search_args,
             *repo_args,
         ],
         cwd=cwd,
@@ -149,6 +207,7 @@ def fetch_github_pull_requests(
         "number",
         "title",
         "url",
+        "state",
         "isDraft",
         "reviewDecision",
         "mergeStateStatus",
@@ -157,6 +216,9 @@ def fetch_github_pull_requests(
         "baseRefName",
         "author",
         "updatedAt",
+        "closedAt",
+        "mergedAt",
+        "mergeCommit",
         "body",
         "files",
         "commits",
@@ -185,11 +247,14 @@ def fetch_github_pull_requests(
                 cwd=cwd,
             )
             if isinstance(view, dict):
-                detailed.append({**row, **view})
+                merged = {**row, **view}
+                if _include_pr_in_window(merged, since=since):
+                    detailed.append(merged)
                 continue
         except Exception:
             pass
-        detailed.append(row)
+        if _include_pr_in_window(row, since=since):
+            detailed.append(row)
     return detailed
 
 
@@ -371,9 +436,14 @@ def _checks(pr: dict[str, Any]) -> dict[str, Any]:
 
 def _risk_notes(pr: dict[str, Any], files: list[dict[str, Any]]) -> list[str]:
     notes: list[str] = []
+    state = str(pr.get("state") or "").upper()
+    if state == "MERGED" or pr.get("mergedAt") or pr.get("merged_at"):
+        notes.append("Already merged: review for post-merge quality, regression risk, and follow-up work.")
+    elif state in {"CLOSED"}:
+        notes.append("Closed without a merge signal; review only if it still informs a replacement path.")
     if pr.get("isDraft"):
         notes.append("Draft PR: review may be advisory until it is marked ready.")
-    if str(pr.get("mergeStateStatus") or "").upper() not in {"", "CLEAN", "HAS_HOOKS", "UNKNOWN"}:
+    if state != "MERGED" and str(pr.get("mergeStateStatus") or "").upper() not in {"", "CLEAN", "HAS_HOOKS", "UNKNOWN"}:
         notes.append(f"Merge state is {pr.get('mergeStateStatus')}; check conflict or branch-protection details.")
     if any(str(item.get("path") or "").startswith(RUNTIME_OR_CLI_PREFIXES) for item in files):
         notes.append("Touches runtime, app, CLI, or automation paths; review behavior and compatibility before merge.")
@@ -400,28 +470,35 @@ def _review_depth(files: list[dict[str, Any]]) -> str:
 
 
 def _parse_updated_epoch(value: object) -> float:
-    text = str(value or "").strip()
-    if not text:
-        return 0.0
-    try:
-        return datetime.fromisoformat(text.replace("Z", "+00:00")).timestamp()
-    except ValueError:
-        return 0.0
+    parsed = _parse_timestamp(value)
+    return parsed.timestamp() if parsed else 0.0
 
 
 def _review_priority(pr: dict[str, Any], files: list[dict[str, Any]]) -> tuple[int, float]:
     is_draft = bool(pr.get("isDraft") or pr.get("is_draft"))
     review_decision = str(pr.get("reviewDecision") or pr.get("review_decision") or "").upper()
-    updated_at = pr.get("updatedAt") or pr.get("updated_at")
+    state = str(pr.get("state") or "").upper()
+    activity_at = (
+        pr.get("mergedAt")
+        or pr.get("merged_at")
+        or pr.get("closedAt")
+        or pr.get("closed_at")
+        or pr.get("updatedAt")
+        or pr.get("updated_at")
+    )
     if is_draft:
         bucket = 4
+    elif state == "MERGED":
+        bucket = 3
+    elif state == "CLOSED":
+        bucket = 5
     elif review_decision in {"", "REVIEW_REQUIRED", "CHANGES_REQUESTED", "UNKNOWN"}:
         bucket = 0
     elif _review_depth(files) == "runtime_behavior_review":
         bucket = 1
     else:
         bucket = 2
-    return (bucket, -_parse_updated_epoch(updated_at))
+    return (bucket, -_parse_updated_epoch(activity_at))
 
 
 def _normalize_pr(pr: dict[str, Any]) -> dict[str, Any]:
@@ -429,12 +506,21 @@ def _normalize_pr(pr: dict[str, Any]) -> dict[str, Any]:
     checks = _checks(pr)
     number = pr.get("number")
     url = pr.get("url") or (f"https://github.com/pull/{number}" if number else "")
+    raw_state = str(pr.get("state") or "").upper()
+    if not raw_state:
+        raw_state = "MERGED" if pr.get("mergedAt") or pr.get("merged_at") else "OPEN"
+    merge_commit = pr.get("mergeCommit") or pr.get("merge_commit")
+    merge_commit_oid = _as_dict(merge_commit).get("oid") if isinstance(merge_commit, dict) else None
     item: dict[str, Any] = {
         "number": number,
         "title": _redact_text(pr.get("title"), limit=180),
         "url": _redact_text(url, limit=220),
+        "state": raw_state,
         "author": _redact_text(_as_dict(pr.get("author")).get("login") or pr.get("author"), limit=80),
         "updated_at": pr.get("updatedAt"),
+        "closed_at": pr.get("closedAt"),
+        "merged_at": pr.get("mergedAt"),
+        "merge_commit": _redact_text(merge_commit_oid, limit=80) if merge_commit_oid else None,
         "base_ref": _redact_text(pr.get("baseRefName"), limit=80),
         "head_ref": _redact_text(pr.get("headRefName"), limit=120),
         "is_draft": bool(pr.get("isDraft")),
@@ -473,30 +559,51 @@ def build_pr_review_packet(
     repository: str | None,
     limit: int,
     source: str,
+    state_filter: str = "all",
+    since: str | None = None,
 ) -> dict[str, Any]:
-    normalized = [_normalize_pr(item) for item in pull_requests[: max(1, limit)]]
-    normalized.sort(key=lambda item: _review_priority(item, item.get("key_files") or []))
+    normalized_state_filter = normalize_pr_state_filter(state_filter)
+    normalized_all = [_normalize_pr(item) for item in pull_requests]
+    normalized_all = [
+        item
+        for item in normalized_all
+        if (normalized_state_filter == "all" or str(item.get("state") or "").lower() == normalized_state_filter)
+        and _include_pr_in_window(item, since=since)
+    ]
+    normalized_all.sort(key=lambda item: _review_priority(item, item.get("key_files") or []))
+    normalized = normalized_all[: max(1, limit)]
     review_sequence = [
         {
             "rank": index,
             "number": item.get("number"),
             "title": item.get("title"),
             "url": item.get("url"),
+            "state": item.get("state"),
             "review_depth": item.get("review_depth"),
             "why_now": _review_why_now(item),
         }
         for index, item in enumerate(normalized, start=1)
     ]
-    review_required = [
+    open_review_required = [
         item
         for item in normalized
-        if str(item.get("review_decision") or "").upper() in {"", "REVIEW_REQUIRED", "CHANGES_REQUESTED", "UNKNOWN"}
+        if str(item.get("state") or "").upper() == "OPEN"
+        and not item.get("is_draft")
+        and str(item.get("review_decision") or "").upper() in {"", "REVIEW_REQUIRED", "CHANGES_REQUESTED", "UNKNOWN"}
     ]
+    merged_items = [item for item in normalized if str(item.get("state") or "").upper() == "MERGED"]
+    closed_items = [item for item in normalized if str(item.get("state") or "").upper() == "CLOSED"]
     first = review_sequence[0] if review_sequence else None
+    review_attention_count = len(open_review_required) + len(merged_items)
+    open_items = [item for item in normalized if str(item.get("state") or "").upper() == "OPEN"]
     headline = (
-        f"{len(normalized)} open PR(s) found; {len(review_required)} need review attention."
+        (
+            f"{len(normalized)} PR(s) in review window: "
+            f"{len(open_items)} open, "
+            f"{len(merged_items)} merged; {review_attention_count} need review attention."
+        )
         if normalized
-        else "No open pull requests found."
+        else "No pull requests found for the requested review window."
     )
     return {
         "ok": True,
@@ -504,9 +611,15 @@ def build_pr_review_packet(
         "request": {
             "schema_version": "loopx_pr_review_command_request_v0",
             "command": COMMAND,
-            "cli_command": "loopx pr-review [--repo owner/repo]",
+            "cli_command": "loopx pr-review [--repo owner/repo] [--state open|merged|all] [--since ISO]",
             "repository": repository,
             "limit": max(1, limit),
+            "state_filter": normalized_state_filter,
+            "since": since,
+            "window": {
+                "since": since,
+                "state_filter": normalized_state_filter,
+            },
             "source": source,
             "include": ["motivation", "change_scope", "checks", "risk_notes", "review_sequence"],
             "privacy_mode": "public_safe_github_metadata",
@@ -515,8 +628,13 @@ def build_pr_review_packet(
         "generated_at": _now_iso(),
         "summary": {
             "headline": headline,
-            "open_pr_count": len(normalized),
-            "review_attention_count": len(review_required),
+            "total_pr_count": len(normalized),
+            "open_pr_count": len(open_items),
+            "merged_pr_count": len(merged_items),
+            "closed_pr_count": len(closed_items),
+            "review_attention_count": review_attention_count,
+            "open_review_attention_count": len(open_review_required),
+            "post_merge_review_count": len(merged_items),
             "draft_count": sum(1 for item in normalized if item.get("is_draft")),
             "source_surfaces": SOURCE_SURFACES,
             "recommended_first_pr": first,
@@ -548,6 +666,11 @@ def build_pr_review_packet(
 
 
 def _review_why_now(item: dict[str, Any]) -> str:
+    state = str(item.get("state") or "").upper()
+    if state == "MERGED":
+        return "Merged in the review window; audit outcome, validation, and follow-up quality."
+    if state == "CLOSED":
+        return "Closed without a merge signal; check whether a replacement or cleanup is needed."
     if item.get("is_draft"):
         return "Draft PR; skim for early direction but do not treat as merge-ready."
     decision = str(item.get("review_decision") or "").upper()
@@ -571,8 +694,10 @@ def render_pr_review_markdown(payload: dict[str, Any]) -> str:
         "",
         f"- command: `{request.get('command')}`",
         f"- repository: `{request.get('repository') or 'current gh repository'}`",
+        f"- state_filter: `{request.get('state_filter') or 'all'}`",
+        f"- since: `{request.get('since') or 'not set'}`",
         f"- headline: {summary.get('headline')}",
-        f"- counts: open=`{summary.get('open_pr_count')}`, review_attention=`{summary.get('review_attention_count')}`, draft=`{summary.get('draft_count')}`",
+        f"- counts: total=`{summary.get('total_pr_count')}`, open=`{summary.get('open_pr_count')}`, merged=`{summary.get('merged_pr_count')}`, review_attention=`{summary.get('review_attention_count')}`, draft=`{summary.get('draft_count')}`",
         "",
         "## Review Sequence",
     ]
@@ -581,7 +706,8 @@ def render_pr_review_markdown(payload: dict[str, Any]) -> str:
         lines.append("- none")
     for item in sequence:
         lines.append(
-            f"{item.get('rank')}. [#{item.get('number')} {item.get('title')}]({item.get('url')}) - "
+            f"{item.get('rank')}. [#{item.get('number')} {item.get('title')}]({item.get('url')}) "
+            f"[{item.get('state')}] - "
             f"{item.get('review_depth')}: {item.get('why_now')}"
         )
 
@@ -592,6 +718,8 @@ def render_pr_review_markdown(payload: dict[str, Any]) -> str:
                 f"## PR #{pr.get('number')}: {pr.get('title')}",
                 "",
                 f"- url: {pr.get('url')}",
+                f"- state: `{pr.get('state')}`",
+                f"- merged_at: `{pr.get('merged_at') or 'n/a'}`",
                 f"- branch: `{pr.get('head_ref')}` -> `{pr.get('base_ref')}`",
                 f"- status: review=`{pr.get('review_decision')}`, merge=`{pr.get('merge_state')}`, draft=`{pr.get('is_draft')}`",
                 f"- motivation: {pr.get('motivation')}",

--- a/loopx/slash_commands.py
+++ b/loopx/slash_commands.py
@@ -91,9 +91,9 @@ def build_slash_command_catalog(
         _command(
             command="/loopx-pr-review",
             scope="repo",
-            intent="List unmerged pull requests for the current project or explicit --repo target and generate a guided review queue with motivation, change scope, checks, risks, and per-PR review prompts.",
+            intent="List open and merged pull requests for the current project or explicit --repo target and generate a guided review queue with motivation, change scope, checks, risks, and per-PR review prompts.",
             mutation_policy="read_only; does not comment, approve, merge, or spend quota",
-            cli_reference=f"{cli_bin} pr-review [--repo owner/repo]",
+            cli_reference=f"{cli_bin} pr-review [--repo owner/repo] [--state open|merged|all] [--since ISO]",
         ),
     ]
     return {
@@ -123,10 +123,14 @@ def render_onboarding_slash_command_note(commands: list[dict[str, Any]], *, cli_
             f"- `/loopx <goal text>`: {goal.get('intent', 'start a concrete project goal')}",
             "- `/loopx-global-summary`: read the global progress digest.",
             "- `/loopx-global-gates`, `/loopx-global-todos`, `/loopx-global-risks`: inspect manager-level gates, work, and risks.",
-            "- `/loopx-pr-review`: review the current project's unmerged PRs one by one with motivation, scope, checks, and risks.",
+            "- `/loopx-pr-review`: review the current project's open and merged PRs one by one with motivation, scope, checks, and risks.",
             f"CLI help: `{cli_bin} slash-commands`.",
         ]
     )
+
+
+def _markdown_table_cell(value: Any) -> str:
+    return str(value or "").replace("\n", " ").replace("|", "\\|")
 
 
 def render_slash_command_catalog_markdown(payload: dict[str, Any]) -> str:
@@ -149,11 +153,11 @@ def render_slash_command_catalog_markdown(payload: dict[str, Any]) -> str:
             intent += " Legacy aliases: " + ", ".join(f"`{alias}`" for alias in legacy) + "."
         lines.append(
             "| "
-            f"`{item.get('command')}` | "
-            f"{item.get('scope')} | "
-            f"{intent} | "
-            f"{item.get('mutation_policy')} | "
-            f"`{item.get('cli_reference')}` |"
+            f"`{_markdown_table_cell(item.get('command'))}` | "
+            f"{_markdown_table_cell(item.get('scope'))} | "
+            f"{_markdown_table_cell(intent)} | "
+            f"{_markdown_table_cell(item.get('mutation_policy'))} | "
+            f"`{_markdown_table_cell(item.get('cli_reference'))}` |"
         )
     lines.extend(
         [


### PR DESCRIPTION
## Summary
- extend `/loopx-pr-review` / `loopx pr-review` to include open and merged PRs by default
- add `--state open|merged|all` and `--since ISO` so overnight/release-window review can include already merged work
- include lifecycle fields, merged counts, post-merge review rationale, docs, fixture coverage, and slash catalog updates

## Validation
- `python3 examples/pr-review-command-smoke.py`
- `python3 examples/slash-command-catalog-smoke.py`
- `python3 -m py_compile loopx/pr_review.py loopx/cli_commands/pr_review.py loopx/slash_commands.py examples/pr-review-command-smoke.py examples/slash-command-catalog-smoke.py`
- `git diff --check`
- `loopx check --scan-path ...` (warnings only: existing duplicate loopx-meta index rows)
- live GitHub metadata check: `loopx pr-review --repo huangruiteng/loopx --state merged --since 2026-06-28T00:00:00+08:00 --limit 5` returned 5 merged PRs in the review window

## Boundary
- Uses public-safe GitHub PR metadata only
- No comments, approvals, merges, quota spend, private connector payloads, raw logs, or local state included
