### PR TITLE
Fix pr-review since timezone search

### DIFF
--- a/examples/pr-review-command-smoke.py
+++ b/examples/pr-review-command-smoke.py
@@ -11,6 +11,10 @@ from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.pr_review import _github_search_date
+
 FIXTURE = REPO_ROOT / "examples" / "fixtures" / "pr-review.public.json"
 PRIVATE_PATTERNS = [
     re.compile(r"/" + r"Users/[A-Za-z0-9._-]+/"),
@@ -40,6 +44,9 @@ def assert_public_safe(payload: dict[str, object]) -> None:
 
 
 def main() -> int:
+    assert _github_search_date("2026-06-28T00:00:00+08:00") == "2026-06-27"
+    assert _github_search_date("2026-06-28T00:00:00Z") == "2026-06-28"
+
     payload = json.loads(
         run_cli("--format", "json", "pr-review", "--fixture", str(FIXTURE), "--limit", "5").stdout
     )

--- a/loopx/pr_review.py
+++ b/loopx/pr_review.py
@@ -125,7 +125,7 @@ def _parse_timestamp(value: object) -> datetime | None:
 def _github_search_date(value: object) -> str | None:
     parsed = _parse_timestamp(value)
     if parsed:
-        return parsed.date().isoformat()
+        return parsed.astimezone(timezone.utc).date().isoformat()
     text = str(value or "").strip()
     if re.fullmatch(r"\d{4}-\d{2}-\d{2}", text):
         return text


### PR DESCRIPTION
## Summary
- convert `--since` timestamps to UTC date before building the GitHub `updated:>=...` coarse search
- keep exact timestamp filtering unchanged after fetching PR details
- add smoke coverage for `2026-06-28T00:00:00+08:00` mapping to the UTC search date `2026-06-27`

## Validation
- `python3 examples/pr-review-command-smoke.py`
- `python3 -m py_compile loopx/pr_review.py examples/pr-review-command-smoke.py`
- `git diff --check`
- `loopx check --scan-path loopx/pr_review.py --scan-path examples/pr-review-command-smoke.py`
- live check: `loopx pr-review --repo huangruiteng/loopx --state all --since 2026-06-28T00:00:00+08:00 --limit 50` returned 44 PRs: 6 open, 38 merged

## Boundary
- public-safe CLI bug fix only
- no private state, raw logs, credentials, or generated artifacts
