### PR TITLE
Add main risk analysis to pr review

### DIFF
--- a/docs/reference/protocols/pr-review-command-v0.md
+++ b/docs/reference/protocols/pr-review-command-v0.md
@@ -16,7 +16,7 @@ push, spend LoopX quota, or mark LoopX todos complete.
 
 | Command | CLI reference | Intent |
 | --- | --- | --- |
-| `/loopx-pr-review` | `loopx pr-review [--repo owner/repo] [--state open\|merged\|all] [--since ISO]` | List open and merged PRs for the current project or explicit repository and build a guided review packet with motivation, change scope, checks, risks, and review prompts. |
+| `/loopx-pr-review` | `loopx pr-review [--repo owner/repo] [--state open\|merged\|all] [--since ISO]` | List open and merged PRs for the current project or explicit repository and build a guided review packet with motivation, change scope, checks, main regression risk, and review prompts. |
 
 ## Source Reads
 
@@ -26,9 +26,11 @@ Implementations may read compact public PR surfaces:
   and review decision;
 - PR body summary;
 - changed-file list and diff scale;
-- commit headlines;
 - status-check rollup;
 - merge-state metadata.
+
+Commit headlines may be used as optional single-PR deep-review evidence, but
+the default window review should not require fetching them for every PR.
 
 They must not include raw logs, private connector payloads, credentials, local
 absolute paths, private source bodies, or hidden CI artifacts.
@@ -75,6 +77,7 @@ absolute paths, private source bodies, or hidden CI artifacts.
       "url": "https://github.com/owner/repo/pull/773",
       "state": "OPEN",
       "review_depth": "docs_and_smoke_review",
+      "main_risk_level": "low",
       "why_now": "Open and awaiting reviewer decision."
     }
   ],
@@ -86,8 +89,24 @@ absolute paths, private source bodies, or hidden CI artifacts.
       "areas": {"public_docs": 3},
       "checks": {"summary": "2 successful check(s)."},
       "risk_notes": [],
+      "main_regression_analysis": {
+        "schema_version": "main_regression_analysis_v0",
+        "risk_level": "low",
+        "risk_summary": "low main regression risk across public_docs; 3 file(s), +90/-4.",
+        "potential_regressions": [
+          "Runtime regression risk is low, but public guidance or smoke expectations can drift from shipped behavior."
+        ],
+        "bug_risks": [
+          "Docs-only or smoke-only changes can bless stale contracts if the example no longer matches the real CLI/runtime path."
+        ],
+        "verification_focus": [
+          "Run `git diff --check` and the touched smoke; compare docs examples with current CLI help when command syntax is involved."
+        ],
+        "post_merge_review": false
+      },
       "review_prompts": [
-        "What user or maintainer value does this PR unlock now?"
+        "What user or maintainer value does this PR unlock now?",
+        "What could regress on main, and which focused validation would catch it?"
       ]
     }
   ],
@@ -105,8 +124,10 @@ The packet should let a reviewer move through PRs in order:
 
 1. Read the motivation and decide whether the PR should exist.
 2. Compare the touched areas and key files with that scope.
-3. Inspect validation and risk notes before approval or merge handoff.
-4. Decide `approve`, `request changes`, `defer`, or `merge after checks`.
+3. Inspect validation, risk notes, and `main_regression_analysis`.
+4. Decide which regression class matters most on main and which focused
+   validation would catch it.
+5. Decide `approve`, `request changes`, `defer`, or `merge after checks`.
 
 ## Acceptance Checks
 
@@ -121,7 +142,7 @@ A first implementation is acceptable when:
 - `--since` can bound an overnight or release-window review without relying on
   private chat memory;
 - the response includes review sequence, motivation, changed-file scope,
-  status checks, risk notes, and review prompts;
+  status checks, risk notes, main regression analysis, and review prompts;
 - live GitHub reads and fixture-based smokes share the same schema;
 - no raw logs, private payloads, credentials, local paths, or private source
   bodies are recorded.

--- a/examples/pr-review-command-smoke.py
+++ b/examples/pr-review-command-smoke.py
@@ -13,6 +13,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT))
 
+import loopx.pr_review as pr_review_module
 from loopx.pr_review import _github_search_date
 
 FIXTURE = REPO_ROOT / "examples" / "fixtures" / "pr-review.public.json"
@@ -46,6 +47,41 @@ def assert_public_safe(payload: dict[str, object]) -> None:
 def main() -> int:
     assert _github_search_date("2026-06-28T00:00:00+08:00") == "2026-06-27"
     assert _github_search_date("2026-06-28T00:00:00Z") == "2026-06-28"
+    calls: list[list[str]] = []
+
+    def fake_run_gh_json(args: list[str], *, cwd: Path | None = None) -> object:
+        calls.append(args)
+        assert args[:2] == ["pr", "list"], calls
+        assert "--search" in args and "updated:>=2026-06-27" in args, args
+        return [
+            {
+                "number": 900,
+                "title": "Runtime review fixture",
+                "url": "https://github.com/owner/repo/pull/900",
+                "state": "OPEN",
+                "updatedAt": "2026-06-28T00:01:00Z",
+                "files": [{"path": "loopx/status.py", "additions": 4, "deletions": 1}],
+                "changedFiles": 1,
+                "additions": 4,
+                "deletions": 1,
+                "statusCheckRollup": [],
+            }
+        ]
+
+    original_run_gh_json = pr_review_module._run_gh_json
+    try:
+        pr_review_module._run_gh_json = fake_run_gh_json
+        fetched = pr_review_module.fetch_github_pull_requests(
+            repo="owner/repo",
+            limit=10,
+            state_filter="all",
+            since="2026-06-28T00:00:00+08:00",
+        )
+    finally:
+        pr_review_module._run_gh_json = original_run_gh_json
+    assert len(calls) == 1, calls
+    assert fetched[0]["number"] == 900, fetched
+    assert fetched[0]["files"][0]["path"] == "loopx/status.py", fetched
 
     payload = json.loads(
         run_cli("--format", "json", "pr-review", "--fixture", str(FIXTURE), "--limit", "5").stdout
@@ -71,11 +107,24 @@ def main() -> int:
     assert sequence[0]["number"] == 773, sequence
     assert sequence[-1]["number"] == 775, sequence
     assert any(item["number"] == 770 and item["state"] == "MERGED" for item in sequence), sequence
+    assert sequence[0]["main_risk_level"] == "low", sequence[0]
+    merged_sequence = next(item for item in sequence if item["number"] == 770)
+    assert merged_sequence["main_risk_level"] == "high", merged_sequence
     first = payload["pull_requests"][0]
     assert first["number"] == 773, first
     assert "newcomer command path" in first["motivation"], first
     assert first["checks"]["counts"]["success"] == 2, first["checks"]
     assert "public_docs" in first["areas"], first["areas"]
+    main_risk = first["main_regression_analysis"]
+    assert main_risk["schema_version"] == "main_regression_analysis_v0", main_risk
+    assert main_risk["risk_level"] == "low", main_risk
+    assert any("Runtime regression risk is low" in item for item in main_risk["potential_regressions"]), main_risk
+    merged = next(item for item in payload["pull_requests"] if item["number"] == 770)
+    merged_main_risk = merged["main_regression_analysis"]
+    assert merged_main_risk["risk_level"] == "high", merged_main_risk
+    assert merged_main_risk["post_merge_review"] is True, merged_main_risk
+    assert any("Control-plane routing" in item for item in merged_main_risk["potential_regressions"]), merged_main_risk
+    assert any("post-merge" in item for item in merged_main_risk["verification_focus"]), merged_main_risk
     assert payload["boundary"]["absolute_paths_recorded"] is False, payload["boundary"]
     assert_public_safe(payload)
 
@@ -119,6 +168,10 @@ def main() -> int:
     assert "current gh repository" not in markdown, markdown
     assert "state_filter: `all`" in markdown, markdown
     assert "merged=`" in markdown, markdown
+    assert "main_risk=`low`" in markdown, markdown
+    assert "main regression risk:" in markdown, markdown
+    assert "potential main regressions:" in markdown, markdown
+    assert "verification focus:" in markdown, markdown
     assert "## Review Sequence" in markdown, markdown
     assert "PR #773" in markdown, markdown
     assert "review prompts" in markdown, markdown

--- a/loopx/pr_review.py
+++ b/loopx/pr_review.py
@@ -24,7 +24,6 @@ SOURCE_SURFACES = [
     "GitHub pull request metadata",
     "GitHub pull request body summary",
     "GitHub pull request changed-file list",
-    "GitHub pull request commit headlines",
     "GitHub pull request status check rollup",
 ]
 
@@ -181,6 +180,13 @@ def fetch_github_pull_requests(
         "updatedAt",
         "closedAt",
         "mergedAt",
+        "mergeCommit",
+        "body",
+        "files",
+        "changedFiles",
+        "additions",
+        "deletions",
+        "statusCheckRollup",
     ]
     fetch_limit = max(1, limit)
     if since:
@@ -203,56 +209,10 @@ def fetch_github_pull_requests(
     if not isinstance(rows, list):
         return []
 
-    view_fields = [
-        "number",
-        "title",
-        "url",
-        "state",
-        "isDraft",
-        "reviewDecision",
-        "mergeStateStatus",
-        "mergeable",
-        "headRefName",
-        "baseRefName",
-        "author",
-        "updatedAt",
-        "closedAt",
-        "mergedAt",
-        "mergeCommit",
-        "body",
-        "files",
-        "commits",
-        "changedFiles",
-        "additions",
-        "deletions",
-        "statusCheckRollup",
-    ]
     detailed: list[dict[str, Any]] = []
     for row in rows:
         if not isinstance(row, dict):
             continue
-        number = row.get("number")
-        if not number:
-            continue
-        try:
-            view = _run_gh_json(
-                [
-                    "pr",
-                    "view",
-                    str(number),
-                    "--json",
-                    ",".join(view_fields),
-                    *repo_args,
-                ],
-                cwd=cwd,
-            )
-            if isinstance(view, dict):
-                merged = {**row, **view}
-                if _include_pr_in_window(merged, since=since):
-                    detailed.append(merged)
-                continue
-        except Exception:
-            pass
         if _include_pr_in_window(row, since=since):
             detailed.append(row)
     return detailed
@@ -458,6 +418,110 @@ def _risk_notes(pr: dict[str, Any], files: list[dict[str, Any]]) -> list[str]:
     return notes
 
 
+def _file_paths(files: list[dict[str, Any]]) -> list[str]:
+    return [str(item.get("path") or "") for item in files if item.get("path")]
+
+
+def _matches_any(path: str, prefixes: tuple[str, ...]) -> bool:
+    return any(path.startswith(prefix) for prefix in prefixes)
+
+
+def _main_regression_analysis(pr: dict[str, Any], files: list[dict[str, Any]]) -> dict[str, Any]:
+    paths = _file_paths(files)
+    areas = _area_counts(files)
+    checks = _checks(pr)
+    state = str(pr.get("state") or "").upper()
+    changed = int(pr.get("changedFiles") or len(files) or 0)
+    additions = int(pr.get("additions") or 0)
+    deletions = int(pr.get("deletions") or 0)
+
+    potential_regressions: list[str] = []
+    bug_risks: list[str] = []
+    verification_focus: list[str] = []
+
+    if any(path.startswith(("loopx/quota.py", "loopx/status.py", "loopx/todos.py", "loopx/todo_contract.py")) for path in paths):
+        potential_regressions.append(
+            "Control-plane routing can regress: user gates, agent lane selection, monitor due projection, or quota spend/no-spend decisions may change on main."
+        )
+        bug_risks.append("A small projection mismatch can strand automation behind a wrong gate or hide runnable work.")
+        verification_focus.append("Run focused quota/status/todo smokes and inspect one live quota/status packet after merge.")
+    if any(path.startswith("loopx/cli_commands/") or path == "loopx/cli.py" for path in paths):
+        potential_regressions.append(
+            "CLI compatibility can regress: flags, JSON schema, markdown output, or shell-facing command examples may change for existing users."
+        )
+        bug_risks.append("Existing automation may parse older fields or rely on previous default command behavior.")
+        verification_focus.append("Run the affected CLI smoke plus one live command against public-safe GitHub metadata or fixture data.")
+    if any(path.startswith("loopx/benchmark_adapters/") or "skillsbench" in path.lower() or "terminal_bench" in path.lower() for path in paths):
+        potential_regressions.append(
+            "Benchmark launch or attribution behavior can regress: readiness blockers, attempt accounting, runner boundaries, or public/private evidence filtering may shift."
+        )
+        bug_risks.append("A benchmark helper change can misclassify a blocked launch as an attempted run, or expose raw benchmark evidence if boundaries slip.")
+        verification_focus.append("Run the adapter's focused public smoke; avoid raw task text, trajectories, verifier output, and private logs.")
+    if any(_matches_any(path, UI_PREFIXES) for path in paths):
+        potential_regressions.append(
+            "Frontstage/dashboard rendering can regress: routes, first viewport, responsive layout, hover affordances, or public-safe projection display may change."
+        )
+        bug_risks.append("A visual or routing change may look correct in fixture data but fail in the browser or hide important review context.")
+        verification_focus.append("Run browser/frontstage smoke or capture the affected route when the first screen or interaction changes.")
+    if any(path.startswith(".github/workflows/") or path.endswith(("pyproject.toml", "package.json", "uv.lock")) for path in paths):
+        potential_regressions.append(
+            "Build, install, or CI behavior can regress: dependency resolution, workflow triggers, or required checks may change for main."
+        )
+        bug_risks.append("A config-only diff can block future PR validation even when runtime code is unchanged.")
+        verification_focus.append("Check workflow syntax or the smallest install/build command that exercises the changed config.")
+    if areas and set(areas) <= {"public_docs", "test_or_example"}:
+        potential_regressions.append(
+            "Runtime regression risk is low, but public guidance or smoke expectations can drift from shipped behavior."
+        )
+        bug_risks.append("Docs-only or smoke-only changes can bless stale contracts if the example no longer matches the real CLI/runtime path.")
+        verification_focus.append("Run `git diff --check` and the touched smoke; compare docs examples with current CLI help when command syntax is involved.")
+    if not potential_regressions:
+        potential_regressions.append("Main impact is localized to the touched files; verify the stated scope matches the diff before merge.")
+        bug_risks.append("Unknown-area changes may still affect consumers if they alter shared data, examples, or public contracts.")
+        verification_focus.append("Review changed files directly and run the narrowest smoke that exercises the touched surface.")
+
+    if checks.get("failures"):
+        bug_risks.append("Failing checks are present; merging would carry known red validation into main.")
+    elif checks.get("pending"):
+        bug_risks.append("Pending checks leave main-risk unresolved until they complete.")
+    elif not checks.get("total"):
+        bug_risks.append("No status-check rollup was available; rely on explicit local validation evidence before merge.")
+
+    if changed >= 12 or additions + deletions >= 800:
+        bug_risks.append("Large diff size increases reviewer miss risk; split by area or require stronger smoke coverage.")
+        verification_focus.append("Review by area buckets and confirm each high-risk area has direct validation.")
+
+    if state == "MERGED":
+        verification_focus.append("Because this is already merged, prioritize post-merge canary, regression symptoms, and follow-up todos over merge readiness.")
+    else:
+        verification_focus.append("Before merge, confirm branch policy, conflict state, public/private boundary, and required checks.")
+
+    high_area = (
+        any(path.startswith(("loopx/quota.py", "loopx/status.py", "loopx/todos.py", "loopx/todo_contract.py")) for path in paths)
+        or any(path.startswith("loopx/benchmark_adapters/") for path in paths)
+        or bool(checks.get("failures"))
+    )
+    if high_area or changed >= 12 or additions + deletions >= 800:
+        risk_level = "high"
+    elif any(str(item.get("area")) in {"product_runtime", "app_or_ui_surface", "ci_or_release", "build_or_config"} for item in files):
+        risk_level = "medium"
+    else:
+        risk_level = "low"
+
+    return {
+        "schema_version": "main_regression_analysis_v0",
+        "risk_level": risk_level,
+        "risk_summary": _redact_text(
+            f"{risk_level} main regression risk across {', '.join(sorted(areas)) or 'unknown'}; "
+            f"{changed} file(s), +{additions}/-{deletions}."
+        ),
+        "potential_regressions": potential_regressions[:5],
+        "bug_risks": bug_risks[:6],
+        "verification_focus": verification_focus[:6],
+        "post_merge_review": state == "MERGED",
+    }
+
+
 def _review_depth(files: list[dict[str, Any]]) -> str:
     areas = {str(item.get("area") or "") for item in files}
     if "product_runtime" in areas:
@@ -538,10 +602,12 @@ def _normalize_pr(pr: dict[str, Any]) -> dict[str, Any]:
         "checks": checks,
         "review_depth": _review_depth(files),
         "risk_notes": _risk_notes(pr, files),
+        "main_regression_analysis": _main_regression_analysis(pr, files),
         "review_prompts": [
             "What user or maintainer value does this PR unlock now?",
             "Do the touched files match that stated scope?",
             "Are validation evidence and risk boundaries strong enough for merge?",
+            "What could regress on main, and which focused validation would catch it?",
         ],
         "evidence_commands": [
             f"gh pr view {number} --json title,body,files,commits,statusCheckRollup",
@@ -580,6 +646,7 @@ def build_pr_review_packet(
             "url": item.get("url"),
             "state": item.get("state"),
             "review_depth": item.get("review_depth"),
+            "main_risk_level": _as_dict(item.get("main_regression_analysis")).get("risk_level"),
             "why_now": _review_why_now(item),
         }
         for index, item in enumerate(normalized, start=1)
@@ -621,7 +688,14 @@ def build_pr_review_packet(
                 "state_filter": normalized_state_filter,
             },
             "source": source,
-            "include": ["motivation", "change_scope", "checks", "risk_notes", "review_sequence"],
+            "include": [
+                "motivation",
+                "change_scope",
+                "checks",
+                "risk_notes",
+                "main_regression_analysis",
+                "review_sequence",
+            ],
             "privacy_mode": "public_safe_github_metadata",
             "dry_run": True,
         },
@@ -708,7 +782,7 @@ def render_pr_review_markdown(payload: dict[str, Any]) -> str:
         lines.append(
             f"{item.get('rank')}. [#{item.get('number')} {item.get('title')}]({item.get('url')}) "
             f"[{item.get('state')}] - "
-            f"{item.get('review_depth')}: {item.get('why_now')}"
+            f"{item.get('review_depth')} / main_risk=`{item.get('main_risk_level')}`: {item.get('why_now')}"
         )
 
     for pr in [item for item in _as_list(payload.get("pull_requests")) if isinstance(item, dict)]:
@@ -738,6 +812,26 @@ def render_pr_review_markdown(payload: dict[str, Any]) -> str:
                 lines.append(f"  - `{item.get('path')}` ({item.get('area')})")
         risks = [item for item in _as_list(pr.get("risk_notes")) if item]
         lines.append("- risk notes: " + ("; ".join(str(item) for item in risks) if risks else "none"))
+        main_risk = _as_dict(pr.get("main_regression_analysis"))
+        if main_risk:
+            lines.append(
+                f"- main regression risk: `{main_risk.get('risk_level')}` - {main_risk.get('risk_summary')}"
+            )
+            regressions = [item for item in _as_list(main_risk.get("potential_regressions")) if item]
+            if regressions:
+                lines.append("- potential main regressions:")
+                for item in regressions[:4]:
+                    lines.append(f"  - {item}")
+            bug_risks = [item for item in _as_list(main_risk.get("bug_risks")) if item]
+            if bug_risks:
+                lines.append("- bug risks:")
+                for item in bug_risks[:4]:
+                    lines.append(f"  - {item}")
+            verification = [item for item in _as_list(main_risk.get("verification_focus")) if item]
+            if verification:
+                lines.append("- verification focus:")
+                for item in verification[:4]:
+                    lines.append(f"  - {item}")
         prompts = [item for item in _as_list(pr.get("review_prompts")) if item]
         if prompts:
             lines.append("- review prompts: " + " / ".join(str(item) for item in prompts))


### PR DESCRIPTION
## Summary
- add `main_regression_analysis_v0` to each `/loopx-pr-review` PR item, including risk level, likely main regressions, bug risks, verification focus, and post-merge review marker
- include `main_risk_level` in the review sequence and markdown output so reviewers can triage open and already-merged PRs by main risk
- avoid the previous N+1 live GitHub detail fetch by reading files/checks/body in the list query; keep commit headlines as optional single-PR deep-review evidence
- document the richer review contract and lock the UTC search-day plus single-list-fetch behavior in the smoke

## Live dogfood
`loopx pr-review --repo huangruiteng/loopx --state all --since 2026-06-28T00:00:00+08:00 --limit 60` returned in 3.83s:
- 45 PRs in window
- 6 open, 39 merged
- main risk distribution: high 24, medium 12, low 9

## Validation
- `python3 examples/pr-review-command-smoke.py`
- `python3 -m py_compile loopx/pr_review.py examples/pr-review-command-smoke.py`
- `git diff --check`
- `loopx check --scan-path loopx/pr_review.py --scan-path examples/pr-review-command-smoke.py --scan-path docs/reference/protocols/pr-review-command-v0.md`

`loopx check` warning only: existing duplicate index rows warning for loopx-meta; public boundary scan clean for the 3 changed files.
