### PR TITLE
Fix agent-scoped gate monitor notifications

### DIFF
--- a/examples/quota-agent-scoped-user-gate-smoke.py
+++ b/examples/quota-agent-scoped-user-gate-smoke.py
@@ -216,6 +216,78 @@ def scoped_no_candidate_status_payload() -> dict:
     }
 
 
+def other_agent_gate_with_non_due_monitor_payload() -> dict:
+    primary_review_gate = todo_item(
+        todo_id="todo_primary_pr_review_gate",
+        text="Review the main-control PR gate before primary merge.",
+        role="user",
+        task_class="user_gate",
+        action_kind="review_pr",
+        blocks_agent="codex-main-control",
+    )
+    primary_agent_todo = todo_item(
+        todo_id="todo_primary_pr_review",
+        text="[P0] Review and merge the primary-control PR.",
+        claimed_by="codex-main-control",
+    )
+    value_monitor = todo_item(
+        todo_id="todo_value_external_signal_monitor",
+        text="[P1-monitor] Monitor value-lane external signal when it becomes due.",
+        task_class="continuous_monitor",
+        claimed_by="codex-value-explorer",
+    )
+    return {
+        "ok": True,
+        "goal_count": 1,
+        "run_count": 0,
+        "attention_queue": {
+            "items": [
+                {
+                    "goal_id": GOAL_ID,
+                    "status": "active_state_user_todo",
+                    "waiting_on": "controller",
+                    "severity": "action",
+                    "source": "active_state",
+                    "recommended_action": "Primary-control PR review gate is pending.",
+                    "quota": {
+                        "compute": 1.0,
+                        "window_hours": 24,
+                        "slot_minutes": 1,
+                        "allowed_slots": 1440,
+                        "spent_slots": 0,
+                        "state": "operator_gate",
+                        "reason": "open user gate",
+                    },
+                    "user_todos": todo_summary_items([primary_review_gate], source_section="User Todo"),
+                    "agent_todos": todo_summary_items(
+                        [primary_agent_todo, value_monitor],
+                        source_section="Agent Todo",
+                    ),
+                }
+            ]
+        },
+        "run_history": {
+            "goals": [
+                {
+                    "id": GOAL_ID,
+                    "registry_member": True,
+                    "status": "active",
+                    "adapter_kind": "fixture_adapter_v0",
+                    "adapter_status": "connected",
+                    "coordination": {
+                        "primary_agent": "codex-main-control",
+                        "registered_agents": [
+                            "codex-main-control",
+                            "codex-value-explorer",
+                        ],
+                    },
+                    "latest_runs": [],
+                }
+            ]
+        },
+    }
+
+
 def assert_other_agent_user_gate_does_not_block_current_agent() -> None:
     payload = build_quota_should_run(
         status_payload(),
@@ -238,6 +310,31 @@ def assert_other_agent_user_gate_does_not_block_current_agent() -> None:
     assert override["from_state"] == "operator_gate", override
     assert override["to_state"] == "eligible", override
     assert payload["agent_lane_next_action"]["todo_id"] == "todo_benchmark_driver", payload
+
+
+def assert_other_agent_user_gate_does_not_notify_non_due_monitor_lane() -> None:
+    payload = build_quota_should_run(
+        other_agent_gate_with_non_due_monitor_payload(),
+        goal_id=GOAL_ID,
+        agent_id="codex-value-explorer",
+    )
+    assert payload["decision"] == "skip", payload
+    assert payload["effective_action"] == "monitor_quiet_skip", payload
+    assert payload["should_run"] is False, payload
+    assert payload["requires_user_action"] is False, payload
+    assert payload["heartbeat_recommendation"]["notify"] == "DONT_NOTIFY", payload
+    assert payload["interaction_contract"]["user_channel"]["action_required"] is False, payload
+    assert payload["interaction_contract"]["user_channel"]["notify"] == "DONT_NOTIFY", payload
+    assert payload["interaction_contract"]["mode"] == "monitor_quiet_skip", payload
+    assert "scoped_user_gate_fallback" not in payload, payload
+    summary = payload["user_todo_summary"]
+    assert summary["open_count"] == 0, summary
+    assert summary["other_agent_scoped_open_count"] == 1, summary
+    assert summary["other_agent_scoped_items"][0]["blocks_agent"] == "codex-main-control", summary
+    agent_summary = payload["agent_todo_summary"]
+    assert agent_summary["current_agent_claimed_monitor_count"] == 1, agent_summary
+    claim_scope = agent_summary["claim_scope"]
+    assert claim_scope["other_agent_claimed_weight"] == "diagnostic_only", claim_scope
 
 
 def assert_target_agent_still_blocks_on_its_user_gate() -> None:
@@ -539,6 +636,7 @@ def assert_agent_without_advancement_candidate_and_only_monitor_work_stays_quiet
 
 def main() -> int:
     assert_other_agent_user_gate_does_not_block_current_agent()
+    assert_other_agent_user_gate_does_not_notify_non_due_monitor_lane()
     assert_target_agent_still_blocks_on_its_user_gate()
     assert_unscoped_user_gate_remains_global()
     assert_unrelated_user_gate_allows_feishu_fallback()

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -2297,6 +2297,24 @@ def _first_executable_todo_text(agent_todo_summary: dict[str, Any] | None) -> st
     return None
 
 
+def _first_monitor_todo_text(agent_todo_summary: dict[str, Any] | None) -> str | None:
+    if not isinstance(agent_todo_summary, dict):
+        return None
+    for key in ("monitor_due_items", "monitor_open_items"):
+        items = agent_todo_summary.get(key) if isinstance(agent_todo_summary.get(key), list) else []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            if not _todo_item_is_actionable_open(item):
+                continue
+            if _todo_task_class(item) != TODO_TASK_CLASS_MONITOR:
+                continue
+            text = _protocol_action_text(item.get("text"), limit=320)
+            if text:
+                return text
+    return None
+
+
 def _agent_scoped_user_gate_override(
     *,
     state: str,
@@ -2321,6 +2339,8 @@ def _agent_scoped_user_gate_override(
     if item.get("operator_question") or item.get("missing_gates"):
         return None
     selected_action = _first_executable_todo_text(agent_todo_summary)
+    if not selected_action:
+        selected_action = _first_monitor_todo_text(agent_todo_summary)
     if not selected_action:
         return None
     agent_id = normalize_todo_claimed_by(agent_identity.get("agent_id"))


### PR DESCRIPTION
## Summary
- allow the agent-scoped user gate override to keep current-agent monitor lanes alive when there is no advancement executable todo
- let the monitor scheduler decide due vs quiet instead of surfacing another agent's user gate as a repeat notification
- add a regression smoke for a main-control PR review gate plus a non-due value-explorer monitor todo

## Validation
- `python3 examples/quota-agent-scoped-user-gate-smoke.py`
- `python3 -m py_compile loopx/quota.py examples/quota-agent-scoped-user-gate-smoke.py`
- `git diff --check`
- `loopx check --scan-path loopx/quota.py --scan-path examples/quota-agent-scoped-user-gate-smoke.py` (passes; pre-existing duplicate-index warning only)

## Review note
This touches quota/control-plane behavior, so I am not self-merging it. The intended contract is: other-agent scoped user gates remain diagnostic-visible, but they should not force `operator_gate_notify` for a current agent whose only work is a non-due monitor lane.
