### PR TITLE
Restore PR review main risk analysis

### DIFF
--- a/docs/reference/protocols/pr-review-command-v0.md
+++ b/docs/reference/protocols/pr-review-command-v0.md
@@ -20,7 +20,7 @@ workflow or the merge-focused `loopx-pr-merge` skill.
 
 | Command | CLI reference | Intent |
 | --- | --- | --- |
-| `/loopx-pr-review` | `loopx pr-review [--repo owner/repo] [--state open\|merged\|all] [--since ISO]` | List open and merged PRs for the current project or explicit repository and provide a blank five-block review template for each PR. Agentloop reads the PR body/diff and fills the review. |
+| `/loopx-pr-review` | `loopx pr-review [--repo owner/repo] [--state open\|merged\|all] [--since ISO]` | List open and merged PRs for the current project or explicit repository, provide concrete main-regression analysis for each PR, and include a blank five-block template that agentloop fills after reading the selected PR body/diff. |
 
 The slash command must run the CLI first. Agentloop must not reconstruct the
 review window by manually calling `gh pr view` / `gh pr list` for every PR. The
@@ -116,6 +116,7 @@ absolute paths, private source bodies, or hidden CI artifacts.
       "state": "OPEN",
       "review_depth": "docs_and_smoke_review",
       "risk_hint_level": "low",
+      "main_risk_level": "low",
       "why_now": "Open and awaiting reviewer decision."
     }
   ],
@@ -190,6 +191,21 @@ absolute paths, private source bodies, or hidden CI artifacts.
         "basis": ["areas=公开文档 3", "scale=3 files +90/-4", "checks=2 pass"],
         "disclaimer": "Metadata-only hint for queue ordering; agentloop must read the PR diff before judging main risk."
       },
+      "main_regression_analysis": {
+        "schema_version": "main_regression_analysis_v0",
+        "risk_level": "low",
+        "risk_summary": "低 main regression risk across 公开文档 3; 3 file(s), +90/-4; checks=2 pass.",
+        "potential_regressions": [
+          "Runtime regression risk is low, but public guidance or smoke expectations can drift from shipped behavior."
+        ],
+        "bug_risks": [
+          "Docs-only or smoke-only changes can bless stale contracts if examples no longer match the real command path."
+        ],
+        "verification_focus": [
+          "Run `git diff --check` and the touched smoke; compare command examples with current CLI help when syntax is involved."
+        ],
+        "post_merge_review": false
+      },
       "risk_notes": [],
       "evidence_commands": [
         "gh pr view 773 --json title,body,files,commits,statusCheckRollup",
@@ -235,11 +251,14 @@ The packet should let a reviewer move through PRs in order:
 2. Then use `review_groups.merged` for post-merge audit and follow-up quality.
 3. Use `evidence_commands`, key files, changed-file scale, and checks to open
    the actual PR body and diff.
-4. Let agentloop fill the blank five-block template:
+4. Read `main_regression_analysis` before filling risk prose. It is the CLI's
+   concrete, generated view of potential main regressions, bug risks, and
+   focused validation.
+5. Let agentloop fill the blank five-block template:
    `动机`, `改动思路`, `具体改动`, `对主干的风险`, `我的整体评价`.
-5. Treat `metadata_risk_hint` only as queue-ordering metadata. It must not be
+6. Treat `metadata_risk_hint` only as queue-ordering metadata. It must not be
    copied as the final risk judgement.
-6. Decide `approve`, `request changes`, `defer`, or `merge after checks`.
+7. Decide `approve`, `request changes`, `defer`, or `merge after checks`.
 
 A response that only lists `Open` and `Merged` PRs, scale, and recommended next
 order is incomplete for `/loopx-pr-review`; it should continue into the
@@ -265,7 +284,8 @@ A first implementation is acceptable when:
 - `--since` can bound an overnight or release-window review without relying on
   private chat memory;
 - the response includes review sequence, changed-file scope, status checks,
-  key files, risk notes, metadata-only risk hints, evidence commands, explicit
+  key files, risk notes, metadata-only risk hints, concrete
+  `main_regression_analysis`, evidence commands, explicit
   `review_groups.unmerged` / `review_groups.merged`, and a blank five-block
   review template;
 - the packet includes `agent_response_contract.table_only_response_allowed=false`
@@ -280,6 +300,9 @@ A first implementation is acceptable when:
   before writing the review;
 - `metadata_risk_hint` must be repository-generic and must not special-case
   LoopX files or domains;
+- `main_regression_analysis` must be repository-generic, must include
+  `potential_regressions`, `bug_risks`, and `verification_focus`, and must not
+  be replaced by a blank template;
 - live GitHub reads and fixture-based smokes share the same schema;
 - no raw logs, private payloads, credentials, local paths, or private source
   bodies are recorded.

--- a/examples/pr-review-command-smoke.py
+++ b/examples/pr-review-command-smoke.py
@@ -156,8 +156,10 @@ def main() -> int:
     assert any(item["number"] == 775 for item in sequence), sequence
     assert any(item["number"] == 770 and item["state"] == "MERGED" for item in sequence), sequence
     assert sequence[0]["risk_hint_level"] == "low", sequence[0]
+    assert sequence[0]["main_risk_level"] == "low", sequence[0]
     merged_sequence = next(item for item in sequence if item["number"] == 770)
     assert merged_sequence["risk_hint_level"] == "medium", merged_sequence
+    assert merged_sequence["main_risk_level"] == "high", merged_sequence
     first = payload["pull_requests"][0]
     assert first["number"] == 773, first
     assert "newcomer command path" in first["motivation"], first
@@ -180,6 +182,14 @@ def main() -> int:
     assert risk_hint["level"] == "low", risk_hint
     assert "Metadata-only" in risk_hint["disclaimer"], risk_hint
     assert "quota.py" not in json.dumps(risk_hint), risk_hint
+    main_risk = first["main_regression_analysis"]
+    assert main_risk["schema_version"] == "main_regression_analysis_v0", main_risk
+    assert main_risk["risk_level"] == "low", main_risk
+    assert main_risk["post_merge_review"] is False, main_risk
+    assert main_risk["potential_regressions"], main_risk
+    assert main_risk["bug_risks"], main_risk
+    assert main_risk["verification_focus"], main_risk
+    assert "quota.py" not in json.dumps(main_risk), main_risk
     response_contract = payload["agent_response_contract"]
     assert response_contract["schema_version"] == "pr_review_agent_response_contract_v0", response_contract
     assert response_contract["table_only_response_allowed"] is False, response_contract
@@ -206,6 +216,10 @@ def main() -> int:
     merged = next(item for item in payload["pull_requests"] if item["number"] == 770)
     merged_risk_hint = merged["metadata_risk_hint"]
     assert merged_risk_hint["level"] == "medium", merged_risk_hint
+    merged_main_risk = merged["main_regression_analysis"]
+    assert merged_main_risk["risk_level"] == "high", merged_main_risk
+    assert merged_main_risk["post_merge_review"] is True, merged_main_risk
+    assert any("Runtime or CLI behavior" in item for item in merged_main_risk["potential_regressions"]), merged_main_risk
     assert payload["boundary"]["absolute_paths_recorded"] is False, payload["boundary"]
     assert_public_safe(payload)
 

--- a/loopx/pr_review.py
+++ b/loopx/pr_review.py
@@ -476,6 +476,89 @@ def _metadata_risk_hint(pr: dict[str, Any], files: list[dict[str, Any]], checks:
     }
 
 
+def _main_regression_analysis(pr: dict[str, Any], files: list[dict[str, Any]]) -> dict[str, Any]:
+    areas = _area_counts(files)
+    checks = _checks(pr)
+    state = str(pr.get("state") or "").upper()
+    changed = int(pr.get("changedFiles") or len(files) or 0)
+    additions = int(pr.get("additions") or 0)
+    deletions = int(pr.get("deletions") or 0)
+    churn = additions + deletions
+    area_names = {str(item.get("area") or "other") for item in files}
+
+    potential_regressions: list[str] = []
+    bug_risks: list[str] = []
+    verification_focus: list[str] = []
+
+    if "product_runtime" in area_names:
+        potential_regressions.append(
+            "Runtime or CLI behavior can regress: command output, data parsing, scheduling/routing, or public API compatibility may change on main."
+        )
+        bug_risks.append("A small runtime mismatch can break automation, hide actionable work, or make existing scripts parse stale fields.")
+        verification_focus.append("Run the affected CLI/runtime smoke and inspect one representative JSON or markdown packet.")
+    if "app_or_ui_surface" in area_names:
+        potential_regressions.append(
+            "User-facing surfaces can regress: navigation, first-screen hierarchy, responsive layout, or hover/review affordances may change."
+        )
+        bug_risks.append("Fixture data can pass while the browser view hides important review context or renders controls poorly.")
+        verification_focus.append("Run the affected UI/frontstage smoke or capture the route in a browser when presentation changes.")
+    if "ci_or_release" in area_names or "build_or_config" in area_names:
+        potential_regressions.append(
+            "Build, install, or CI behavior can regress: workflow triggers, dependency resolution, or required checks may change for later PRs."
+        )
+        bug_risks.append("A config-only diff can block future validation even when product code is unchanged.")
+        verification_focus.append("Run `git diff --check` and the narrow build/check command that consumes the touched config.")
+    if "public_entry_or_policy" in area_names:
+        potential_regressions.append(
+            "Public entry or policy wording can regress: first-screen promises, maintainer rules, or contributor expectations may drift."
+        )
+        bug_risks.append("A prominent docs change can authorize behavior that the runtime or repository policy does not actually support.")
+        verification_focus.append("Compare the public entry text with current CLI help, AGENTS policy, and any first-screen review gate.")
+    if areas and area_names <= {"public_docs", "test_or_example"}:
+        potential_regressions.append(
+            "Runtime regression risk is low, but public guidance or smoke expectations can drift from shipped behavior."
+        )
+        bug_risks.append("Docs-only or smoke-only changes can bless stale contracts if examples no longer match the real command path.")
+        verification_focus.append("Run `git diff --check` and the touched smoke; compare command examples with current CLI help when syntax is involved.")
+    if not potential_regressions:
+        potential_regressions.append(
+            "Regression shape is unclear from metadata alone; inspect the highest-churn files before approving."
+        )
+        bug_risks.append("Unclassified files may still affect generated assets, packaging, or reviewer workflow assumptions.")
+        verification_focus.append("Review the diff for the top changed files and run the nearest project smoke.")
+
+    if checks.get("failures"):
+        bug_risks.insert(0, "Failing status checks indicate the branch may already break a required validation surface.")
+        verification_focus.insert(0, "Inspect failing checks before merge and rerun them after fixes.")
+    elif checks.get("pending"):
+        bug_risks.append("Pending checks leave merge readiness uncertain.")
+        verification_focus.append("Wait for pending checks or run the equivalent local smoke before merge.")
+    elif not checks.get("total"):
+        bug_risks.append("No status-check rollup was available, so validation coverage must be inferred from local evidence.")
+        verification_focus.append("Run at least one focused local validation command before approving.")
+
+    has_sensitive_area = bool(area_names & {"product_runtime", "app_or_ui_surface", "ci_or_release", "build_or_config"})
+    if checks.get("failures") or changed >= 12 or churn >= 800 or (state == "MERGED" and has_sensitive_area):
+        level = "high"
+    elif has_sensitive_area or checks.get("pending") or not checks.get("total"):
+        level = "medium"
+    else:
+        level = "low"
+
+    return {
+        "schema_version": "main_regression_analysis_v0",
+        "risk_level": level,
+        "risk_summary": (
+            f"{RISK_LEVEL_LABELS.get(level, level)} main regression risk across {_area_phrase(areas)}; "
+            f"{changed} file(s), +{additions}/-{deletions}; checks={_check_brief_phrase(checks)}."
+        ),
+        "potential_regressions": potential_regressions[:5],
+        "bug_risks": bug_risks[:5],
+        "verification_focus": verification_focus[:5],
+        "post_merge_review": state == "MERGED" or bool(pr.get("mergedAt") or pr.get("merged_at")),
+    }
+
+
 def _section(label: str, word_hint: str, instruction: str) -> dict[str, str]:
     return {
         "label": label,
@@ -686,6 +769,7 @@ def _review_priority(pr: dict[str, Any], files: list[dict[str, Any]]) -> tuple[i
 
 
 def _review_sequence_entry(item: dict[str, Any], *, rank: int) -> dict[str, Any]:
+    main_risk = _as_dict(item.get("main_regression_analysis"))
     return {
         "rank": rank,
         "number": item.get("number"),
@@ -694,6 +778,7 @@ def _review_sequence_entry(item: dict[str, Any], *, rank: int) -> dict[str, Any]
         "state": item.get("state"),
         "review_depth": item.get("review_depth"),
         "risk_hint_level": _as_dict(item.get("metadata_risk_hint")).get("level"),
+        "main_risk_level": main_risk.get("risk_level"),
         "why_now": _review_why_now(item),
     }
 
@@ -736,6 +821,7 @@ def _normalize_pr(pr: dict[str, Any]) -> dict[str, Any]:
         "review_depth": _review_depth(files),
         "risk_notes": _risk_notes(pr, files),
         "metadata_risk_hint": _metadata_risk_hint(pr, files, checks),
+        "main_regression_analysis": _main_regression_analysis(pr, files),
         "review_goal": "Fill the five-block review template after reading the PR body and diff.",
         "evidence_commands": [
             f"gh pr view {number} --json title,body,files,commits,statusCheckRollup",
@@ -849,6 +935,7 @@ def build_pr_review_packet(
                 "change_scope",
                 "checks",
                 "metadata_risk_hint",
+                "main_regression_analysis",
                 "risk_notes",
                 "review_sequence",
             ],
@@ -957,7 +1044,8 @@ def render_pr_review_markdown(payload: dict[str, Any]) -> str:
             lines.append(
                 f"{item.get('rank')}. [#{item.get('number')} {item.get('title')}]({item.get('url')}) "
                 f"[{item.get('state')}] - "
-                f"{item.get('review_depth')} / risk_hint=`{item.get('risk_hint_level')}`: {item.get('why_now')}"
+                f"{item.get('review_depth')} / main_risk=`{item.get('main_risk_level')}` "
+                f"/ risk_hint=`{item.get('risk_hint_level')}`: {item.get('why_now')}"
             )
 
     append_group(unmerged)
@@ -971,7 +1059,8 @@ def render_pr_review_markdown(payload: dict[str, Any]) -> str:
         lines.append(
             f"{item.get('rank')}. [#{item.get('number')} {item.get('title')}]({item.get('url')}) "
             f"[{item.get('state')}] - "
-            f"{item.get('review_depth')} / risk_hint=`{item.get('risk_hint_level')}`: {item.get('why_now')}"
+            f"{item.get('review_depth')} / main_risk=`{item.get('main_risk_level')}` "
+            f"/ risk_hint=`{item.get('risk_hint_level')}`: {item.get('why_now')}"
         )
 
     for pr in [item for item in _as_list(payload.get("pull_requests")) if isinstance(item, dict)]:
@@ -1000,6 +1089,20 @@ def render_pr_review_markdown(payload: dict[str, Any]) -> str:
                 f"({'; '.join(str(item) for item in _as_list(risk_hint.get('basis')))})"
             )
             lines.append(f"- risk hint disclaimer: {risk_hint.get('disclaimer')}")
+        main_risk = _as_dict(pr.get("main_regression_analysis"))
+        if main_risk:
+            lines.append(
+                f"- main regression analysis: `{main_risk.get('risk_level')}` - "
+                f"{main_risk.get('risk_summary')}"
+            )
+            for label, key in (
+                ("potential regressions", "potential_regressions"),
+                ("bug risks", "bug_risks"),
+                ("verification focus", "verification_focus"),
+            ):
+                values = [str(item) for item in _as_list(main_risk.get(key)) if item]
+                if values:
+                    lines.append(f"  - {label}: " + "; ".join(values[:3]))
         commits = [item for item in _as_list(pr.get("commit_headlines")) if item]
         if commits:
             lines.append("- commits: " + "; ".join(f"`{item}`" for item in commits))


### PR DESCRIPTION
## Summary
- restores concrete `main_regression_analysis` in `/loopx-pr-review` output after #830 was merged with the blank five-block scaffold contract
- keeps the five-block template empty for agentloop fill-in, while giving humans/controllers generated potential regressions, bug risks, and verification focus
- exposes `main_risk_level` in review sequence/group entries and renders main risk in markdown

## Why follow-up
PR #830 was already merged before the rework commit could land on that PR branch. This is a clean follow-up from current `main` with only the main-risk restoration patch.

## Validation
- `python3 examples/pr-review-command-smoke.py`
- `python3 examples/slash-command-catalog-smoke.py`
- `python3 examples/bootstrap-command-pack-smoke.py`
- `python3 -m py_compile loopx/pr_review.py loopx/slash_commands.py loopx/cli_commands/pr_review.py examples/pr-review-command-smoke.py`
- `git diff --check origin/main...HEAD`
- `loopx check --scan-path loopx/pr_review.py --scan-path examples/pr-review-command-smoke.py --scan-path docs/reference/protocols/pr-review-command-v0.md` (passes; pre-existing duplicate-index warning only)
