### PR TITLE
Stabilize scoped todos and SkillsBench runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,9 @@ adapters, smoke tests, public docs, or commit/push workflows, use the
 For small, low-risk PRs, maintainers may self-merge after validation when all
 of the following are true:
 
+Here, "自合并" means: 自己 review/refine, then admin-bypass merge after the
+required validation and authorization.
+
 - the PR only touches public docs, contributor metadata, or narrow cleanup;
 - the change is single-purpose and easy to review from the diff;
 - required checks or focused smokes have passed;

--- a/docs/project-agent-todo-contract.md
+++ b/docs/project-agent-todo-contract.md
@@ -82,6 +82,11 @@ inserts the metadata comment instead of creating a duplicate checkbox.
 lanes for owner input and concrete blockers; quota/executor code must not treat
 them as advancement work.
 
+For scheduled monitors, keep the contract minimal: `--next-due-at` is the first
+eligible time, `--cadence` is the retry interval, `--monitor-target-key` is the
+stable idempotency key, and optional `--expires-at` is the hard stop after
+which the monitor must not catch up.
+
 Terminology: a `goal_id` is the LoopX control-plane boundary: registry
 entry, active-state file, quota lane, status projection, and run-history stream.
 A `todo_id` is a structured work item inside that goal. LoopX does not
@@ -101,6 +106,30 @@ for a lane-scoped decision or `global_gate=true` / `--global-gate` for a
 genuine goal-wide owner gate. Unscoped multi-agent user gates are an authoring
 error because every registered agent would otherwise see another lane's
 question as its own stop condition.
+
+When a user gate only blocks one concrete action, add the blocked todo id with
+`unblocks_todo_id=<todo_id>`. When multiple todos share the same broad
+`action_kind`, use the schema-backed decision-scope fields instead of relying
+on title/body token overlap:
+
+```bash
+loopx todo add \
+  --goal-id <goal-id> \
+  --role user \
+  --task-class user_gate \
+  --agent-id codex-main-control \
+  --decision-scope direction:action:benchmark_target_choice \
+  --text "Choose the benchmark target before running that case."
+
+loopx todo update \
+  --goal-id <goal-id> \
+  --todo-id <agent-todo-id> \
+  --required-decision-scope direction:action:benchmark_target_choice
+```
+
+Quota treats a gate as covering an agent todo when `decision_scope` matches or
+dominates one of that todo's `required_decision_scopes`; otherwise the todo is
+independent and can be selected as a safe fallback when the boundary permits it.
 
 Each goal should have one `coordination.primary_agent`: the primary agent owns
 final review, verification, merge, publication, and reassignment decisions. All

--- a/docs/reference/protocols/decision-scope-v0.md
+++ b/docs/reference/protocols/decision-scope-v0.md
@@ -44,6 +44,21 @@ small in v0:
 If the relation is ambiguous, status/quota must repair projection or ask the
 user/controller; it must not infer permission from prose.
 
+### Markdown metadata compact form
+
+Todo metadata stores decision scopes as a compact public-safe token instead of
+inline JSON:
+
+```md
+<!-- loopx:todo decision_scope=direction:action:benchmark_target_choice -->
+<!-- loopx:todo required_decision_scopes=direction:action:benchmark_target_choice -->
+```
+
+The token is `kind:granularity:scope_key`. `decision_scope` is singular on a
+user gate; `required_decision_scopes` may contain a comma-separated list on an
+agent todo. Status/quota normalize those tokens back into
+`decision_scope_v0` objects before evaluating gate coverage.
+
 ### `safety_class`
 
 Attached to agent work candidates and selected actions.
@@ -117,7 +132,8 @@ runtime.
 
 1. **Contract only:** document this schema and keep current behavior unchanged.
 2. **State authoring:** teach todo/gate write paths to accept and preserve
-   `decision_scope`, `required_decision_scopes`, and `safety_class`.
+   `decision_scope` and `required_decision_scopes`. `safety_class` remains a
+   later authoring field.
 3. **Projection:** surface the fields in status, quota, review packets, and
    frontstage local ops mode.
 4. **Hot path:** make status/quota prefer structured scope relation over text

--- a/docs/reference/protocols/task-graph-projection-v0.md
+++ b/docs/reference/protocols/task-graph-projection-v0.md
@@ -102,12 +102,30 @@ Edges describe why one node affects another. Allowed `relation` values are:
 - `blocks`;
 - `validates`;
 - `repairs`;
+- `audits`;
+- `continues`;
 - `hands_off_to`;
 - `supersedes`.
 
 Each edge must name `from_node_id`, `to_node_id`, `relation`, and a compact
 public-safe `reason`. Edges may carry the same compact `refs` object as nodes.
 An edge does not grant permission to run a command or mutate state.
+
+`repairs`, `audits`, and `continues` are lineage relations, not lifecycle
+commands. They are derived from existing run history, todo/gate metadata, and
+compact blocker or validation writebacks:
+
+- `repairs` says a repair or replan node is intended to recover a selected
+  work lane.
+- `audits` says compact run-history evidence reviews, checks, or bounds a
+  selected work lane.
+- `continues` says compact run-history evidence is a continuation of a selected
+  work lane.
+
+These relations may help a dashboard or reviewer explain why a work item is
+still active, stale, repaired, or safe to hand off. They must not create a graph
+resume command, mutate todo status, or replace freshness checks against current
+quota, gates, claims, and run history.
 
 ## Write Boundary
 
@@ -140,6 +158,8 @@ A valid public fixture or implementation must prove:
 - every edge endpoint references an existing node;
 - every node and edge references existing LoopX ids rather than raw
   private material;
+- repair, audit, and continuation relations are rendered only as derived
+  read-only lineage over existing todos, gates, leases, and compact run ids;
 - no local absolute paths, credentials, raw transcripts, or raw logs are
   projected;
 - status/review-packet consumers can safely ignore the field when absent.

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
@@ -69,30 +69,11 @@
           "latest_decision": {
             "baseline_failure_scope": "passed",
             "baseline_run_id": "fac3a39fdd9a",
-            "decision": "paired_baseline_solved_treatment_preserved",
-            "official_score_delta": 0.0,
-            "product_mode_main_table_pair": {
-              "baseline_route_valid": true,
-              "benchmark_id": "skillsbench@1.1",
-              "case_id": "3d-scan-calc",
-              "claim_blocker": "none",
-              "comparison_id": "skillsbench_product_mode_main_table_v0",
-              "headline_metrics": [
-                "best_score",
-                "final_score",
-                "first_success_round",
-                "declared_done_score"
-              ],
-              "main_table_claim_allowed": true,
-              "max_rounds_budget": 8,
-              "official_feedback_blinded": true,
-              "product_mode_pair_complete": true,
-              "schema_version": "benchmark_product_mode_comparison_v0",
-              "treatment_loopx_lifecycle_observed": true,
-              "treatment_route_valid": true
-            },
-            "treatment_failure_scope": "passed",
-            "treatment_run_id": "10d4a914cccc"
+            "decision": "paired_treatment_runner_or_setup_repair_required",
+            "failure_class": "skillsbench_host_local_acp_codex_exec_failed_codex_exec_bridge_idle_timeout",
+            "official_score_delta": -1.0,
+            "treatment_failure_scope": "runner_or_setup",
+            "treatment_run_id": "decbde35b3b4"
           },
           "runs": [
             {
@@ -537,6 +518,261 @@
                 "task_skills_removed": true
               },
               "verifier_attempt_countable": true
+            },
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "codex_loopx_treatment",
+              "attempt_failure_class": "job_materialization_failed",
+              "attempt_failure_label": "skillsbench_product_mode_lifecycle_missing",
+              "attempt_lifecycle_phase": "runner_accepted_args",
+              "benchmark_id": "skillsbench@1.1",
+              "case_attempt_countable": false,
+              "case_id": "3d-scan-calc",
+              "case_ids": [
+                "3d-scan-calc"
+              ],
+              "codex_acp_runtime_preflight_passed": true,
+              "failure_class": "skillsbench_acp_agent_message_only_no_tool_calls",
+              "failure_labels": [
+                "skillsbench_host_local_acp_codex_exec_failed_codex_network_or_api_unreachable",
+                "skillsbench_host_local_acp_codex_exec_failed",
+                "skillsbench_runner_setup_error",
+                "skillsbench_product_mode_transport_failure",
+                "skillsbench_product_mode_lifecycle_missing",
+                "skillsbench_acp_agent_message_only_no_tool_calls",
+                "skillsbench_agent_behavior_gap"
+              ],
+              "failure_scope": "score_missing",
+              "job_name": "skillsbench_1_1_3d_scan_calc_loopx_goal_start_product_mode",
+              "launcher_attempt_countable": true,
+              "leaderboard_evidence": false,
+              "loopx_inside_case": true,
+              "max_rounds_budget": 16,
+              "mode": "skillsbench_loopx_goal_start_product_mode_treatment",
+              "model_control_status": "reported_model_from_result_metadata",
+              "notes": "official SkillsBench BenchFlow LoopX goal-start product-mode treatment; compact result only; no raw task/log/trajectory read into public state",
+              "official_feedback_blinded": true,
+              "official_score_attempt_countable": false,
+              "product_mode_lifecycle_contract": {
+                "checkpoint_count": 1,
+                "checkpoint_required": true,
+                "checkpoint_round": 0,
+                "countable_treatment": false,
+                "execution_style": "orchestrated_agentloop_loopx_cli",
+                "missing_reason": "remote_command_file_bridge_agent_no_requests",
+                "orchestrated_driver_counts_as_product_mode": false,
+                "orchestrated_driver_lifecycle_satisfied": true,
+                "required": true,
+                "satisfied": false,
+                "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+                "state_read_count": 0,
+                "state_write_count": 0
+              },
+              "recorded_at": "2026-06-28T13:57:12+08:00",
+              "reward_feedback_forwarded": false,
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-3d-scan-goalstart-closeoutfix-20260628T055555Z",
+              "run_id": "df1d62653fac",
+              "score_status": "missing",
+              "solver_attempt_countable": false,
+              "source_event_schema": "benchmark_run_v0",
+              "status": "recorded",
+              "submit_eligible": false,
+              "task_staging": {
+                "app_skills_mount_patch_applied": true,
+                "apt_retry_patch_applied": true,
+                "apt_retry_patch_required": true,
+                "apt_risk_preflight_blocked": false,
+                "apt_setup_risk_detected": true,
+                "codex_acp_runtime_tools_patch_applied": true,
+                "include_task_skills": false,
+                "original_task_mutated": false,
+                "resource_cap_patch": {
+                  "applied": false,
+                  "host_cpus": 32.0
+                },
+                "staged": true,
+                "task_skills_removed": true
+              },
+              "verifier_attempt_countable": false
+            },
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "codex_loopx_treatment",
+              "attempt_failure_class": "job_materialization_failed",
+              "attempt_failure_label": "skillsbench_host_local_acp_codex_exec_failed_codex_exec_bridge_idle_timeout",
+              "attempt_lifecycle_phase": "runner_accepted_args",
+              "benchmark_id": "skillsbench@1.1",
+              "best_reward_round": 1,
+              "best_round_is_final": true,
+              "best_round_passed": false,
+              "best_round_reward": 0.0,
+              "case_attempt_countable": false,
+              "case_id": "3d-scan-calc",
+              "case_ids": [
+                "3d-scan-calc"
+              ],
+              "codex_acp_runtime_preflight_passed": true,
+              "failure_class": "skillsbench_host_local_acp_codex_exec_failed_codex_exec_bridge_idle_timeout",
+              "failure_labels": [
+                "skillsbench_product_mode_solver_activity_gap",
+                "skillsbench_agent_behavior_gap",
+                "skillsbench_host_local_acp_codex_exec_failed_codex_exec_bridge_idle_timeout",
+                "skillsbench_host_local_acp_codex_exec_failed",
+                "skillsbench_runner_setup_error",
+                "skillsbench_product_mode_transport_failure"
+              ],
+              "failure_scope": "runner_or_setup",
+              "final_round": 15,
+              "final_round_passed": false,
+              "final_round_reward": 0.0,
+              "job_name": "skillsbench_1_1_3d_scan_calc_loopx_goal_start_product_mode",
+              "launcher_attempt_countable": true,
+              "leaderboard_evidence": false,
+              "loop_score_policy": "best_round_for_offline_controller_analysis",
+              "loopx_inside_case": true,
+              "max_rounds_budget": 16,
+              "mode": "skillsbench_loopx_goal_start_product_mode_treatment",
+              "model_control_status": "reported_model_from_result_metadata",
+              "notes": "official SkillsBench BenchFlow LoopX goal-start product-mode treatment; compact result only; no raw task/log/trajectory read into public state",
+              "official_feedback_blinded": true,
+              "official_passed": false,
+              "official_score": 0.0,
+              "official_score_attempt_countable": false,
+              "official_score_policy": "final_workspace_official_result",
+              "product_mode_lifecycle_contract": {
+                "checkpoint_count": 16,
+                "checkpoint_required": true,
+                "checkpoint_round": 0,
+                "countable_treatment": false,
+                "execution_style": "orchestrated_agentloop_loopx_cli",
+                "orchestrated_driver_counts_as_product_mode": false,
+                "orchestrated_driver_lifecycle_satisfied": true,
+                "required": true,
+                "satisfied": false,
+                "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+                "state_read_count": 0,
+                "state_write_count": 0
+              },
+              "recorded_at": "2026-06-28T15:08:52+08:00",
+              "reward_feedback_forwarded": false,
+              "round_reward_count": 12,
+              "round_rewards": [
+                {
+                  "agent_round": 1,
+                  "passed": false,
+                  "reward": 0.0,
+                  "reward_present": true,
+                  "tool_calls": 0
+                },
+                {
+                  "agent_round": 2,
+                  "passed": false,
+                  "reward": 0.0,
+                  "reward_present": true,
+                  "tool_calls": 0
+                },
+                {
+                  "agent_round": 3,
+                  "passed": false,
+                  "reward": 0.0,
+                  "reward_present": true,
+                  "tool_calls": 0
+                },
+                {
+                  "agent_round": 4,
+                  "passed": false,
+                  "reward": 0.0,
+                  "reward_present": true,
+                  "tool_calls": 0
+                },
+                {
+                  "agent_round": 5,
+                  "passed": false,
+                  "reward": 0.0,
+                  "reward_present": true,
+                  "tool_calls": 0
+                },
+                {
+                  "agent_round": 6,
+                  "passed": false,
+                  "reward": 0.0,
+                  "reward_present": true,
+                  "tool_calls": 0
+                },
+                {
+                  "agent_round": 7,
+                  "passed": false,
+                  "reward": 0.0,
+                  "reward_present": true,
+                  "tool_calls": 0
+                },
+                {
+                  "agent_round": 8,
+                  "passed": false,
+                  "reward": 0.0,
+                  "reward_present": true,
+                  "tool_calls": 0
+                },
+                {
+                  "agent_round": 9,
+                  "passed": false,
+                  "reward": 0.0,
+                  "reward_present": true,
+                  "tool_calls": 0
+                },
+                {
+                  "agent_round": 10,
+                  "passed": false,
+                  "reward": 0.0,
+                  "reward_present": true,
+                  "tool_calls": 0
+                },
+                {
+                  "agent_round": 11,
+                  "passed": false,
+                  "reward": 0.0,
+                  "reward_present": true,
+                  "tool_calls": 0
+                },
+                {
+                  "agent_round": 12,
+                  "passed": false,
+                  "reward": 0.0,
+                  "reward_present": true,
+                  "tool_calls": 0
+                }
+              ],
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-3d-scan-goalstart-closeoutfix-revchan-20260628T060046Z",
+              "run_id": "decbde35b3b4",
+              "score_status": "failed",
+              "solver_attempt_countable": false,
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false,
+              "task_staging": {
+                "app_skills_mount_patch_applied": true,
+                "apt_retry_patch_applied": true,
+                "apt_retry_patch_required": true,
+                "apt_risk_preflight_blocked": false,
+                "apt_setup_risk_detected": true,
+                "codex_acp_runtime_tools_patch_applied": true,
+                "include_task_skills": false,
+                "original_task_mutated": false,
+                "resource_cap_patch": {
+                  "applied": false,
+                  "host_cpus": 32.0
+                },
+                "staged": true,
+                "task_skills_removed": true
+              },
+              "verifier_attempt_countable": false
             }
           ]
         },
@@ -9500,7 +9736,7 @@
           ]
         }
       },
-      "run_count": 157
+      "run_count": 159
     },
     "swe-marathon": {
       "benchmark_id": "swe-marathon",
@@ -13552,5 +13788,5 @@
     "source_of_truth": "benchmark_run_v0 compact run events",
     "update_rule": "upsert one run entry when a benchmark case is ingested or closed"
   },
-  "updated_at": "2026-06-27T22:10:04+08:00"
+  "updated_at": "2026-06-28T15:08:52+08:00"
 }

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
@@ -5,14 +5,14 @@ benchmark case outcomes and artifact references; it must not contain raw
 logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 
 - schema_version: `benchmark_run_ledger_v0`
-- updated_at: `2026-06-27T22:10:04+08:00`
+- updated_at: `2026-06-28T15:08:52+08:00`
 
 ## Case Decisions
 
 | Benchmark | Case | Decision | Product Pair | Case Routing | Runs |
 | --- | --- | --- | --- | --- | --- |
 | `skillsbench-cloud-oracle-sanity@v0` | `hello-world` | `single_arm_recorded` | - | - | `1` |
-| `skillsbench@1.1` | `3d-scan-calc` | `paired_baseline_solved_treatment_preserved` | `main_table_ready` | - | `7` |
+| `skillsbench@1.1` | `3d-scan-calc` | `paired_treatment_runner_or_setup_repair_required` | - | - | `9` |
 | `skillsbench@1.1` | `ada-bathroom-plan-repair` | `paired_baseline_solved_treatment_preserved` | - | - | `4` |
 | `skillsbench@1.1` | `adaptive-cruise-control` | `baseline_runner_or_setup_repair_required` | - | - | `1` |
 | `skillsbench@1.1` | `azure-bgp-oscillation-route-leak` | `product_mode_pair_incomplete` | `treatment_loopx_lifecycle_not_observed` | - | `10` |
@@ -90,6 +90,8 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `skillsbench@1.1` | `3d-scan-calc` | `skillsbench_raw_codex_autonomous_max5_baseline` | `` | `1.0` | `` | `1:missing` | `none` | `.local/private-benchmark-jobs/skillsbench-3d-scan-calc-canonical-lifecycle-20260622T225336Z-base/3d-scan-calc__raw_codex_autonomous_max5/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `3d-scan-calc` | `skillsbench_raw_codex_autonomous_max5_baseline` | `case_attempt` | `1.0` | `1` | `1:1*` | `none` | `` |
 | `skillsbench@1.1` | `3d-scan-calc` | `codex_loopx_treatment` | `case_attempt` | `1.0` | `1` | `1:1*` | `none` | `` |
+| `skillsbench@1.1` | `3d-scan-calc` | `codex_loopx_treatment` | `` | `missing` | `` | `` | `skillsbench_acp_agent_message_only_no_tool_calls` | `` |
+| `skillsbench@1.1` | `3d-scan-calc` | `codex_loopx_treatment` | `` | `0.0` | `` | `1:0,2:0,3:0,4:0,5:0,6:0,7:0,8:0,9:0,10:0,11:0,12:0` | `skillsbench_host_local_acp_codex_exec_failed_codex_exec_bridge_idle_timeout` | `` |
 | `skillsbench@1.1` | `ada-bathroom-plan-repair` | `codex_goal_mode_baseline` | `` | `missing` | `` | `` | `skillsbench_codex_acp_launch_failed` | `.local/private-benchmark-jobs/skillsbench-ada-bathroom-plan-repair-pair-20260615T2346CST/ada-bathroom-plan-repair__codex_goal_mode_baseline_20260615T2346CST/ada-bathroom-plan-repair__codex_goal_mode_baseline/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `ada-bathroom-plan-repair` | `codex_goal_mode_baseline` | `` | `missing` | `` | `` | `skillsbench_codex_acp_binary_missing` | `.local/private-benchmark-jobs/skillsbench-ada-bathroom-plan-repair-preflight-rerun-20260616T0124CST/ada-bathroom-plan-repair__codex_goal_mode_baseline_preflight_rerun_20260616T0124CST/ada-bathroom-plan-repair__codex_goal_mode_baseline/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `ada-bathroom-plan-repair` | `baseline` | `` | `1.0` | `1` | `1:1*` | `none` | `.local/private-benchmark-jobs/skillsbench-ada-bathroom-plan-repair-blind-baseline-v0/ada-bathroom-plan-repair__codex_acp_blind_loop_v0/benchmark_run.compact.json` |

--- a/docs/state-interaction-model.md
+++ b/docs/state-interaction-model.md
@@ -559,8 +559,8 @@ control state and transient work state:
 This lets LoopX borrow graph-native recovery where it matters without
 forcing every goal into a multi-agent DAG. Small or linear goals can stay as
 ordinary todos. Multi-stage goals can project a graph for dispatch, review, and
-repair, while the append-only ledger still decides what happened and which
-worker may resume.
+repair, audit, and continuation, while the append-only ledger still decides
+what happened and which worker may resume.
 
 The first implementation should be read-mostly: expose an optional compact
 `task_graph_projection_v0` from status or review packets, backed by existing

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -54,9 +54,10 @@ this graph to preserve the dashboard interface budget; callers that need the
 graph can request it with `loopx --format json status --include-task-graph`, or
 use a full review packet. This is a compact graph-shaped view over existing
 todos, gates, leases, run ids, and event-ledger state. It is read-only and
-exists only to show dependency, validation, repair, and handoff relationships
-that are hard to scan in a flat todo list. It must not introduce a second
-scheduler, graph write API, hidden lease store, or alternate task truth.
+exists only to show dependency, validation, repair, audit, continuation, and
+handoff relationships that are hard to scan in a flat todo list. It must not
+introduce a second scheduler, graph write API, hidden lease store, or alternate
+task truth.
 The protocol is defined in
 [`docs/reference/protocols/task-graph-projection-v0.md`](reference/protocols/task-graph-projection-v0.md);
 consumers should ignore the field when absent.

--- a/examples/fixtures/task-graph-projection-status.public.json
+++ b/examples/fixtures/task-graph-projection-status.public.json
@@ -128,6 +128,36 @@
               }
             },
             {
+              "edge_id": "edge_fixture_audits_design",
+              "from_node_id": "node_fixture_validation",
+              "to_node_id": "node_design_contract",
+              "relation": "audits",
+              "reason": "The fixture audit records that lineage remains read-only and todo-backed.",
+              "refs": {
+                "run_ids": [
+                  "run_task_graph_fixture_smoke"
+                ],
+                "todo_ids": [
+                  "todo_8e138e5a1cc1"
+                ]
+              }
+            },
+            {
+              "edge_id": "edge_fixture_continues_design",
+              "from_node_id": "node_fixture_validation",
+              "to_node_id": "node_design_contract",
+              "relation": "continues",
+              "reason": "The fixture shows a continuation of the same design lane without creating a second task store.",
+              "refs": {
+                "run_ids": [
+                  "run_task_graph_fixture_smoke"
+                ],
+                "todo_ids": [
+                  "todo_8e138e5a1cc1"
+                ]
+              }
+            },
+            {
               "edge_id": "edge_fixture_hands_off_to_primary",
               "from_node_id": "node_fixture_validation",
               "to_node_id": "node_primary_review_handoff",

--- a/examples/monitor-scheduler-contract-smoke.py
+++ b/examples/monitor-scheduler-contract-smoke.py
@@ -17,6 +17,7 @@ GOAL_ID = "monitor-scheduler-fixture"
 AGENT_ID = "codex-product-capability"
 PAST_DUE_AT = "2000-01-01T00:00:00+00:00"
 FUTURE_DUE_AT = "2999-01-01T00:00:00+00:00"
+EXPIRED_AT = "2000-01-01T00:05:00+00:00"
 
 
 def status_payload(
@@ -91,8 +92,9 @@ def monitor_item(
     next_due_at: str,
     target_key: str,
     claimed_by: str = AGENT_ID,
+    expires_at: str | None = None,
 ) -> dict:
-    return {
+    item = {
         "index": index,
         "text": f"[{priority}] Monitor {target_key} and write back only material transitions.",
         "todo_id": todo_id,
@@ -106,6 +108,9 @@ def monitor_item(
         "cadence": "15m",
         "next_due_at": next_due_at,
     }
+    if expires_at:
+        item["expires_at"] = expires_at
+    return item
 
 
 def advancement_item(*, index: int, priority: str = "P1", claimed_by: str = AGENT_ID) -> dict:
@@ -175,6 +180,30 @@ def assert_due_monitor_requires_explicit_attempt() -> None:
     assert lane["selected_todo_id"] == "todo_monitor_due", lane
     assert guard["interaction_contract"]["agent_channel"]["must_attempt"] is True, guard
     assert guard["interaction_contract"]["agent_channel"]["quiet_noop_allowed"] is False, guard
+
+
+def assert_expired_monitor_does_not_catch_up() -> None:
+    guard = guard_for(
+        [
+            monitor_item(
+                index=1,
+                todo_id="todo_monitor_expired",
+                priority="P1",
+                next_due_at=PAST_DUE_AT,
+                expires_at=EXPIRED_AT,
+                target_key="expired-publish-window",
+            )
+        ]
+    )
+    lane = guard["work_lane_contract"]
+    assert guard["decision"] == "skip", guard
+    assert guard["effective_action"] == "monitor_quiet_skip", guard
+    assert lane["obligation"] == "quiet_until_material_monitor_transition", lane
+    assert lane["must_attempt_work"] is False, lane
+    assert guard["agent_todo_summary"]["monitor_due_count"] == 0, guard
+    monitor_items = guard["agent_todo_summary"]["monitor_open_items"]
+    assert monitor_items[0]["todo_id"] == "todo_monitor_expired", monitor_items
+    assert monitor_items[0]["expires_at"] == EXPIRED_AT, monitor_items
 
 
 def assert_due_monitor_priority_does_not_steal_advancement_lane() -> None:
@@ -300,6 +329,7 @@ def assert_other_agent_claimed_work_stays_diagnostic_when_no_current_lane() -> N
 def main() -> int:
     assert_not_due_monitor_waits_quietly()
     assert_due_monitor_requires_explicit_attempt()
+    assert_expired_monitor_does_not_catch_up()
     assert_due_monitor_priority_does_not_steal_advancement_lane()
     assert_multiple_due_monitor_cap_and_order()
     assert_other_agent_due_monitor_does_not_preempt_current_agent_lane()

--- a/examples/quota-agent-scoped-user-gate-smoke.py
+++ b/examples/quota-agent-scoped-user-gate-smoke.py
@@ -442,6 +442,104 @@ def exact_todo_gate_status_payload(*, include_fallback: bool = True) -> dict:
     }
 
 
+def decision_scope_status_payload() -> dict:
+    benchmark_gate = todo_item(
+        todo_id="todo_benchmark_scope_gate",
+        text="Owner must choose the benchmark target before the target run.",
+        role="user",
+        task_class="user_gate",
+        action_kind="benchmark_run",
+        blocks_agent="codex-main-control",
+    )
+    benchmark_gate["decision_scope"] = {
+        "schema_version": "decision_scope_v0",
+        "kind": "direction",
+        "granularity": "action",
+        "scope_key": "benchmark_target_choice",
+    }
+    blocked_target_run = todo_item(
+        todo_id="todo_target_benchmark_run",
+        text="[P1] Run the chosen benchmark target after owner decision.",
+        claimed_by="codex-main-control",
+        action_kind="benchmark_run",
+    )
+    blocked_target_run["required_decision_scopes"] = [
+        {
+            "schema_version": "decision_scope_v0",
+            "kind": "direction",
+            "granularity": "action",
+            "scope_key": "benchmark_target_choice",
+        }
+    ]
+    independent_helper = todo_item(
+        todo_id="todo_benchmark_helper_cleanup",
+        text="[P1] Clean benchmark helper ledger summaries while target choice waits.",
+        claimed_by="codex-main-control",
+        action_kind="benchmark_run",
+    )
+    independent_helper["required_decision_scopes"] = [
+        {
+            "schema_version": "decision_scope_v0",
+            "kind": "direction",
+            "granularity": "action",
+            "scope_key": "helper_ledger_cleanup",
+        }
+    ]
+    return {
+        "ok": True,
+        "goal_count": 1,
+        "run_count": 0,
+        "attention_queue": {
+            "items": [
+                {
+                    "goal_id": GOAL_ID,
+                    "status": "active_state_user_todo",
+                    "waiting_on": "controller",
+                    "severity": "action",
+                    "source": "active_state",
+                    "recommended_action": "Choose benchmark target.",
+                    "quota": {
+                        "compute": 1.0,
+                        "window_hours": 24,
+                        "slot_minutes": 1,
+                        "allowed_slots": 1440,
+                        "spent_slots": 0,
+                        "state": "operator_gate",
+                        "blocked_action_scope": "gated_delivery",
+                        "safe_bypass_allowed": True,
+                        "safe_bypass_policy": (
+                            "Only the gated decision scope is blocked; independent "
+                            "public-safe agent work may continue."
+                        ),
+                        "reason": "operator gate blocks gated delivery; safe non-gated steering may continue",
+                    },
+                    "user_todos": todo_summary(benchmark_gate, source_section="User Todo"),
+                    "agent_todos": todo_summary_items(
+                        [blocked_target_run, independent_helper],
+                        source_section="Agent Todo",
+                    ),
+                }
+            ]
+        },
+        "run_history": {
+            "goals": [
+                {
+                    "id": GOAL_ID,
+                    "registry_member": True,
+                    "status": "active",
+                    "adapter_kind": "fixture_adapter_v0",
+                    "adapter_status": "connected",
+                    "coordination": {
+                        "primary_agent": "codex-main-control",
+                        "registered_agents": ["codex-main-control"],
+                    },
+                    "latest_runs": [],
+                }
+            ]
+        },
+    }
+
+
 def assert_exact_todo_gate_only_blocks_target_todo() -> None:
     payload = build_quota_should_run(
         exact_todo_gate_status_payload(),
@@ -478,6 +576,25 @@ def assert_exact_todo_gate_only_blocks_target_todo() -> None:
         if item.get("task_class") == "continuous_monitor"
     }
     assert "todo_x_launch_monitor" in blocked_monitor_ids, blocked_payload["agent_todo_summary"]
+
+
+def assert_decision_scope_overrides_shared_action_kind_tokens() -> None:
+    payload = build_quota_should_run(
+        decision_scope_status_payload(),
+        goal_id=GOAL_ID,
+        agent_id="codex-main-control",
+    )
+    assert payload["should_run"] is True, payload
+    assert payload["decision"] == "safe_bypass_user_gate_fallback", payload
+    fallback = payload["scoped_user_gate_fallback"]
+    blocked = fallback["blocked_agent_items"][0]
+    assert blocked["todo_id"] == "todo_target_benchmark_run", fallback
+    assert blocked["todo_gate_relation"]["source"] == "decision_scope", blocked
+    assert blocked["todo_gate_relation"]["state"] == "gate_covers_action", blocked
+    selected = fallback["selected_executable"]
+    assert selected["todo_id"] == "todo_benchmark_helper_cleanup", fallback
+    assert selected["todo_gate_relation"]["source"] == "decision_scope", selected
+    assert selected["todo_gate_relation"]["state"] == "independent", selected
 
 
 def assert_agent_without_advancement_candidate_and_only_monitor_work_stays_quiet() -> None:
@@ -547,6 +664,7 @@ def main() -> int:
     assert_unscoped_user_gate_remains_global()
     assert_unrelated_user_gate_allows_feishu_fallback()
     assert_exact_todo_gate_only_blocks_target_todo()
+    assert_decision_scope_overrides_shared_action_kind_tokens()
     assert_agent_without_advancement_candidate_and_only_monitor_work_stays_quiet()
     print("quota-agent-scoped-user-gate-smoke ok")
     return 0

--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -36,7 +36,9 @@ from loopx.benchmark_ledger import (  # noqa: E402
     update_benchmark_run_ledger,
 )
 from loopx.benchmark_adapters.skillsbench_acp_relay import (  # noqa: E402
+    CodexExecConfig,
     SKILLSBENCH_LOCAL_ACP_RELAY_PROBE_SCHEMA_VERSION,
+    SkillsBenchLocalAcpRelay,
     _codex_exec_failure_category,
     _prompt_requires_bridge_first_action as _relay_prompt_requires_bridge_first_action,
     run_skillsbench_local_acp_relay_probe,
@@ -70,6 +72,8 @@ from scripts.skillsbench_automation_loop import (  # noqa: E402
     _build_product_mode_user,
     _copy_loopx_source_subset,
     _host_local_acp_launch_command,
+    _first_bridge_failure_category,
+    _host_local_acp_codex_exec_preflight_bridge_success_observed,
     _loopx_case_init_failure_blocker,
     _loopx_case_source_path_for_container,
     _loopx_source_mount_contract,
@@ -79,6 +83,7 @@ from scripts.skillsbench_automation_loop import (  # noqa: E402
     _merge_acp_trajectory_summary,
     _merge_final_result_round_reward,
     _merge_host_local_acp_relay_trace_summary,
+    _summarize_host_local_acp_preflight_bridge_trace,
     _round_result_declared_done,
     build_compose_setup_diagnostic,
     build_plan,
@@ -204,6 +209,144 @@ def test_reverse_channel_raw_prompt_does_not_require_bridge_first_action() -> No
     assert response["credential_values_recorded"] is False
 
 
+def test_reverse_channel_bridge_idle_waits_for_bridge_activity() -> None:
+    start = time.monotonic()
+    response = _run_codex_payload(
+        {
+            "args": ["-c", "import time; time.sleep(30)"],
+            "stdin": (
+                "Raw Codex autonomous baseline prompt with a bridge packet.\n\n"
+                "Private bridge command:\nfixture-bridge"
+            ),
+            "timeout_sec": 1,
+        },
+        codex_bin=sys.executable,
+        default_timeout_sec=1,
+        prompt_bridge_command="unused {private_bridge_command_sh}",
+        bridge_idle_timeout_sec=0.2,
+    )
+    assert time.monotonic() - start < 8
+    assert response["exit_code"] == 124
+    assert response["stderr"] == "codex_exec_timeout\n", response
+    assert response["raw_task_text_recorded"] is False
+    assert response["credential_values_recorded"] is False
+
+
+def test_reverse_channel_bridge_operation_failure_is_categorized() -> None:
+    with tempfile.TemporaryDirectory(prefix="reverse-bridge-failure-") as tmp:
+        tmp_path = Path(tmp)
+        fake_codex = tmp_path / "fake-codex"
+        fake_codex.write_text(
+            """#!/usr/bin/env python3
+import json
+import re
+import subprocess
+import sys
+
+prompt = sys.stdin.read()
+match = re.search(r"Private bridge command:\\n([^\\n]+)", prompt)
+assert match, prompt
+subprocess.run(
+    match.group(1),
+    input=json.dumps({"operation": "preflight"}),
+    text=True,
+    shell=True,
+)
+""",
+            encoding="utf-8",
+        )
+        fake_codex.chmod(0o700)
+        failing_bridge = tmp_path / "failing-bridge"
+        failing_bridge.write_text(
+            """#!/usr/bin/env python3
+import sys
+
+sys.stdin.read()
+print("PermissionError: [Errno 1] Operation not permitted", file=sys.stderr)
+raise SystemExit(1)
+""",
+            encoding="utf-8",
+        )
+        failing_bridge.chmod(0o700)
+        response = _run_codex_payload(
+            {
+                "args": ["exec"],
+                "stdin": (
+                    "LoopX bridge action preflight. Your first tool action "
+                    "should call the private bridge.\n\n"
+                    "Private bridge command:\nfixture-bridge"
+                ),
+                "timeout_sec": 10,
+            },
+            codex_bin=str(fake_codex),
+            default_timeout_sec=10,
+            prompt_bridge_command=f"{sys.executable} {failing_bridge}",
+            first_action_timeout_sec=5,
+        )
+        records = [
+            json.loads(line)
+            for line in response["agent_operations_jsonl"].splitlines()
+            if line.strip()
+        ]
+        assert len(records) == 2, records
+        assert records[1]["returncode"] == 1, records
+        assert records[1]["success"] is False, records
+        assert records[1]["failure_category"] == "bridge_client_permission_error"
+        assert response["raw_task_text_recorded"] is False
+        assert response["credential_values_recorded"] is False
+
+
+def test_host_local_codex_exec_preflight_requires_successful_bridge_action() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-preflight-summary-") as tmp:
+        trace_dir = Path(tmp)
+        trace = {
+            "schema_version": "skillsbench_host_local_acp_relay_public_trace_v0",
+            "trace_kind": "remote_command_file_bridge_agent_operations",
+            "remote_command_file_bridge_agent_operations": {
+                "schema_version": (
+                    "skillsbench_remote_command_file_bridge_agent_operations_v0"
+                ),
+                "request_count": 1,
+                "success_count": 0,
+                "failure_count": 1,
+                "operation_counts": {"preflight": 1},
+                "returncode_counts": {"1": 1},
+                "failure_category_counts": {
+                    "bridge_client_permission_error": 1,
+                },
+                "task_facing_operation_count": 0,
+                "raw_material_recorded": False,
+            },
+            "boundary": {
+                "raw_command_recorded": False,
+                "raw_stdout_recorded": False,
+                "raw_stderr_recorded": False,
+                "raw_task_text_recorded": False,
+                "credential_values_recorded": False,
+            },
+        }
+        (trace_dir / "agent-ops.compact.json").write_text(
+            json.dumps(trace),
+            encoding="utf-8",
+        )
+        summary = _summarize_host_local_acp_preflight_bridge_trace(trace_dir)
+        assert summary["trace_present"] is True, summary
+        assert summary["preflight_operation_count"] == 1, summary
+        assert summary["success_count"] == 0, summary
+        assert summary["failure_count"] == 1, summary
+        assert summary["returncode_counts"] == {"1": 1}, summary
+        assert summary["failure_category_counts"] == {
+            "bridge_client_permission_error": 1,
+        }, summary
+        assert (
+            _host_local_acp_codex_exec_preflight_bridge_success_observed(summary)
+            is False
+        )
+        assert _first_bridge_failure_category(summary) == (
+            "bridge_client_permission_error"
+        )
+
+
 def test_reverse_channel_goal_start_prompt_requires_bridge_first_action() -> None:
     prompt = (
         "LoopX product-mode lifecycle contract. This route simulates "
@@ -227,6 +370,36 @@ def test_reverse_channel_goal_start_prompt_requires_bridge_first_action() -> Non
         default_timeout_sec=20,
         prompt_bridge_command="unused {private_bridge_command_sh}",
         first_action_timeout_sec=1,
+    )
+    assert time.monotonic() - start < 8
+    assert response["exit_code"] == 124
+    assert response["stderr"] == "codex_exec_first_action_timeout\n"
+    assert response["raw_task_text_recorded"] is False
+    assert response["credential_values_recorded"] is False
+
+
+def test_reverse_channel_product_mode_checkpoint_requires_bridge_first_action() -> None:
+    prompt = (
+        "Mandatory product-mode solver checkpoint before round 7 continues. "
+        "The next agent turn must start with either a task-facing sandbox "
+        "bridge operation from `/app`, or, if local validation already proves "
+        "the selected P0 is complete, the selected P0 closeout sequence.\n\n"
+        "Private bridge command:\nfixture-bridge"
+    )
+    assert _reverse_prompt_requires_bridge_first_action(prompt) is True
+    assert _relay_prompt_requires_bridge_first_action(prompt) is True
+    start = time.monotonic()
+    response = _run_codex_payload(
+        {
+            "args": ["-c", "import time; time.sleep(30)"],
+            "stdin": prompt,
+            "timeout_sec": 20,
+        },
+        codex_bin=sys.executable,
+        default_timeout_sec=20,
+        prompt_bridge_command="unused {private_bridge_command_sh}",
+        first_action_timeout_sec=1,
+        bridge_idle_timeout_sec=30,
     )
     assert time.monotonic() - start < 8
     assert response["exit_code"] == 124
@@ -280,18 +453,12 @@ time.sleep(30)
             codex_bin=str(fake_codex),
             default_timeout_sec=20,
             prompt_bridge_command="sh -lc {private_bridge_command_sh}",
-            first_action_timeout_sec=1,
+            first_action_timeout_sec=3,
             bridge_idle_timeout_sec=1,
         )
     assert time.monotonic() - start < 8
     assert response["exit_code"] == 124
-    assert any(
-        marker in response["stderr"]
-        for marker in (
-            "codex_exec_bridge_idle_timeout",
-            "codex_exec_first_action_timeout",
-        )
-    ), response
+    assert response["stderr"] == "codex_exec_bridge_idle_timeout\n", response
     assert response["raw_task_text_recorded"] is False
     assert response["credential_values_recorded"] is False
     records = [
@@ -299,13 +466,73 @@ time.sleep(30)
         for line in response["agent_operations_jsonl"].splitlines()
         if line.strip()
     ]
-    if "codex_exec_first_action_timeout" in response["stderr"]:
-        assert records == [], records
-    else:
-        assert len(records) == 1, records
-        assert records[0]["operation_observed"] is True
-        assert records[0]["task_facing_operation"] is True
-        assert records[0]["raw_request_recorded"] is False
+    assert len(records) == 2, records
+    assert records[0]["record_phase"] == "start", records
+    assert records[1]["record_phase"] == "complete", records
+    assert records[0]["operation_observed"] is True
+    assert records[0]["task_facing_operation"] is True
+    assert records[0]["raw_request_recorded"] is False
+    assert records[1]["returncode"] == 0
+
+
+def test_reverse_channel_bridge_idle_timeout_ignores_inflight_bridge_command() -> None:
+    with tempfile.TemporaryDirectory(prefix="reverse-bridge-inflight-") as tmp:
+        fake_codex = Path(tmp) / "fake-codex"
+        fake_codex.write_text(
+            """#!/usr/bin/env python3
+import json
+import re
+import subprocess
+import sys
+
+prompt = sys.stdin.read()
+match = re.search(r"Private bridge command:\\n([^\\n]+)", prompt)
+assert match, prompt
+subprocess.run(
+    match.group(1),
+    input=json.dumps({
+        "operation": "exec",
+        "cwd": "/app",
+        "command": "python - <<'PY'\\nprint('task-facing')\\nPY",
+        "timeout_sec": 10,
+    }),
+    text=True,
+    shell=True,
+    check=False,
+)
+""",
+            encoding="utf-8",
+        )
+        fake_codex.chmod(0o755)
+        start = time.monotonic()
+        response = _run_codex_payload(
+            {
+                "args": ["exec"],
+                "stdin": (
+                    "LoopX bridge action preflight. Your first tool action should "
+                    "be a shell pipeline that sends JSON to the private bridge.\n\n"
+                    "Private bridge command:\npython -c 'import time; time.sleep(5)'"
+                ),
+                "timeout_sec": 2,
+            },
+            codex_bin=str(fake_codex),
+            default_timeout_sec=2,
+            prompt_bridge_command="sh -lc {private_bridge_command_sh}",
+            first_action_timeout_sec=1,
+            bridge_idle_timeout_sec=1,
+        )
+    elapsed = time.monotonic() - start
+    assert 1.5 <= elapsed < 5, elapsed
+    assert response["exit_code"] == 124
+    assert response["stderr"] == "codex_exec_timeout\n", response
+    records = [
+        json.loads(line)
+        for line in response["agent_operations_jsonl"].splitlines()
+        if line.strip()
+    ]
+    assert len(records) == 1, records
+    assert records[0]["record_phase"] == "start", records
+    assert records[0]["task_facing_operation"] is True
 
 
 def test_product_mode_initial_prompt_keeps_task_visible_after_lifecycle_gate() -> None:
@@ -512,6 +739,7 @@ def test_goal_start_workflow_driver_bootstraps_bridge_before_task_packet() -> No
             "remote_command_file_bridge_driver_lifecycle_loopx_state_write_count": 3,
             "remote_command_file_bridge_agent_request_count": 1,
             "remote_command_file_bridge_agent_task_facing_operation_count": 1,
+            "remote_command_file_bridge_agent_task_facing_success_count": 1,
         }
     )
     task_prompt = asyncio.run(
@@ -1690,6 +1918,45 @@ def test_skillsbench_codex_exec_failure_category_is_actionable() -> None:
     )
 
 
+def test_host_local_relay_timeout_returns_recoverable_turn_message() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-acp-recoverable-timeout-") as tmp:
+        root = Path(tmp)
+        fake_codex = root / "fake-codex"
+        fake_codex.write_text(
+            """#!/usr/bin/env python3
+import sys
+
+print("codex_exec_bridge_idle_timeout", file=sys.stderr)
+raise SystemExit(124)
+""",
+            encoding="utf-8",
+        )
+        fake_codex.chmod(0o700)
+        trace_dir = root / "traces"
+        relay = SkillsBenchLocalAcpRelay(
+            CodexExecConfig(
+                codex_bin=str(fake_codex),
+                route="loopx-goal-start-product-mode",
+                timeout_sec=5,
+                worker_public_trace_dir=str(trace_dir),
+            )
+        )
+        response = relay._run_codex(
+            "public-safe prompt placeholder",
+            session={"cwd": str(root)},
+            session_id="session-recoverable-timeout",
+            stdout=io.StringIO(),
+        )
+        assert "LoopX recoverable Codex turn failure" in response
+        assert "codex_exec_bridge_idle_timeout" in response
+        trace_text = "\n".join(
+            p.read_text(encoding="utf-8") for p in sorted(trace_dir.glob("*.json"))
+        )
+        assert "codex_exec_bridge_idle_timeout" in trace_text
+        assert '"raw_task_text_recorded": false' in trace_text
+        assert '"credential_values_recorded": false' in trace_text
+
+
 def test_product_mode_case_state_seed_uses_active_goal_shape() -> None:
     seed = product_mode_case_state_seed_text(
         task_id="sample-task",
@@ -1883,6 +2150,7 @@ def test_product_mode_declared_done_requires_solver_activity_after_driver_lifecy
             "remote_command_file_bridge_agent_loopx_state_read_count": 2,
             "remote_command_file_bridge_agent_loopx_state_write_count": 1,
             "remote_command_file_bridge_agent_task_facing_operation_count": 1,
+            "remote_command_file_bridge_agent_task_facing_success_count": 1,
             "remote_command_file_bridge_agent_todo_closeout_count": 0,
             "remote_command_file_bridge_agent_refresh_state_count": 0,
             "remote_command_file_bridge_agent_quota_spend_slot_count": 0,
@@ -2029,6 +2297,7 @@ def test_product_mode_declared_done_below_passing_reward_continues() -> None:
             "remote_command_file_bridge_agent_loopx_state_read_count": 1,
             "remote_command_file_bridge_agent_loopx_state_write_count": 5,
             "remote_command_file_bridge_agent_task_facing_operation_count": 4,
+            "remote_command_file_bridge_agent_task_facing_success_count": 4,
             "remote_command_file_bridge_agent_todo_closeout_count": 2,
             "remote_command_file_bridge_agent_refresh_state_count": 1,
             "remote_command_file_bridge_agent_quota_spend_slot_count": 1,
@@ -2172,6 +2441,7 @@ def test_product_mode_declared_done_missing_reward_continues() -> None:
             "remote_command_file_bridge_agent_loopx_state_read_count": 1,
             "remote_command_file_bridge_agent_loopx_state_write_count": 5,
             "remote_command_file_bridge_agent_task_facing_operation_count": 4,
+            "remote_command_file_bridge_agent_task_facing_success_count": 4,
             "remote_command_file_bridge_agent_todo_closeout_count": 2,
             "remote_command_file_bridge_agent_refresh_state_count": 1,
             "remote_command_file_bridge_agent_quota_spend_slot_count": 1,
@@ -2386,7 +2656,7 @@ def test_product_mode_missing_lifecycle_prompts_exact_checkpoint() -> None:
         assert trace["stop_decision_count"] == 0
 
 
-def test_product_mode_no_tool_call_stops_before_checkpoint_loop() -> None:
+def test_product_mode_no_tool_call_continues_before_checkpoint_loop() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-no-tool-lifecycle-") as tmp:
         root = Path(tmp)
         jobs_dir = root / "jobs"
@@ -2490,30 +2760,26 @@ def test_product_mode_no_tool_call_stops_before_checkpoint_loop() -> None:
             ]
             n_tool_calls = 0
 
-        try:
-            asyncio.run(
-                user.run(
-                    1,
-                    "Fix the fixture.",
-                    round_result=FakeRoundResult(),
-                )
+        prompt = asyncio.run(
+            user.run(
+                1,
+                "Fix the fixture.",
+                round_result=FakeRoundResult(),
             )
-        except SkillsBenchProductModeNoLifecycleRequests as exc:
-            assert "no case-local LoopX lifecycle request" in str(exc)
-        else:
-            raise AssertionError("product-mode no-tool round must stop early")
+        )
+        assert prompt is not None
+        assert "not a valid closeout" in prompt
+        assert "command/file bridge" in prompt
         assert (
             trace["last_decision"]
-            == "stop_after_product_mode_no_tool_calls_without_lifecycle"
+            == "send_followup_after_product_mode_no_tool_calls_without_lifecycle"
         )
         assert trace["product_mode_lifecycle_checkpoint_required"] is True
         assert trace["product_mode_lifecycle_checkpoint_count"] == 1
         assert trace["product_mode_lifecycle_checkpoint_round"] == 1
-        assert trace["product_mode_no_tool_call_lifecycle_abort"] is True
-        assert trace["product_mode_no_tool_call_lifecycle_abort_count"] == 1
-        assert trace["product_mode_no_tool_call_lifecycle_abort_round"] == 1
-        assert trace["followup_prompt_count"] == 0
-        assert trace["stop_decision_count"] == 1
+        assert trace.get("product_mode_no_tool_call_lifecycle_abort") is not True
+        assert trace["followup_prompt_count"] == 1
+        assert trace["stop_decision_count"] == 0
 
 
 def test_product_mode_workflow_driver_task_bridge_activity_avoids_no_tool_abort() -> None:
@@ -2539,6 +2805,7 @@ def test_product_mode_workflow_driver_task_bridge_activity_avoids_no_tool_abort(
         "remote_command_file_bridge_agent_operation_trace_count": 1,
         "remote_command_file_bridge_agent_request_count": 1,
         "remote_command_file_bridge_agent_task_facing_operation_count": 1,
+            "remote_command_file_bridge_agent_task_facing_success_count": 1,
         "heartbeat_count": 0,
         "controller_action_decisions": 0,
         "initial_prompt_count": 0,
@@ -2633,6 +2900,153 @@ def test_product_mode_workflow_driver_task_bridge_activity_avoids_no_tool_abort(
     assert trace.get("product_mode_no_tool_call_lifecycle_abort") is not True, trace
     assert trace.get("product_mode_no_lifecycle_request_abort") is not True, trace
     assert trace["followup_prompt_count"] == 1, trace
+    assert trace["stop_decision_count"] == 0, trace
+
+
+def test_product_mode_official_success_requires_final_closeout_checkpoint() -> None:
+    trace = {
+        "schema_version": "skillsbench_loopx_controller_trace_v0",
+        "route": "loopx-goal-start-product-mode",
+        "loopx_state_reads": 0,
+        "loopx_state_writes": 0,
+        "loopx_case_state_reads": 0,
+        "loopx_case_state_writes": 0,
+        "remote_command_file_bridge_driver_lifecycle_execution_style": (
+            "orchestrated_agentloop_loopx_cli"
+        ),
+        "remote_command_file_bridge_driver_lifecycle_checkpoint_count": 1,
+        "remote_command_file_bridge_driver_lifecycle_success_count": 4,
+        "remote_command_file_bridge_driver_lifecycle_failure_count": 0,
+        "remote_command_file_bridge_driver_lifecycle_loopx_cli_call_count": 4,
+        "remote_command_file_bridge_driver_lifecycle_loopx_state_read_count": 1,
+        "remote_command_file_bridge_driver_lifecycle_loopx_state_write_count": 3,
+        "remote_command_file_bridge_agent_operation_trace_status": (
+            "agent_operation_trace_recorded"
+        ),
+        "remote_command_file_bridge_agent_operation_trace_count": 4,
+        "remote_command_file_bridge_agent_request_count": 4,
+        "remote_command_file_bridge_agent_task_facing_operation_count": 3,
+            "remote_command_file_bridge_agent_task_facing_success_count": 3,
+        "remote_command_file_bridge_agent_todo_closeout_count": 0,
+        "remote_command_file_bridge_agent_refresh_state_count": 0,
+        "remote_command_file_bridge_agent_quota_spend_slot_count": 0,
+        "heartbeat_count": 0,
+        "controller_action_decisions": 0,
+        "initial_prompt_count": 0,
+        "followup_prompt_count": 0,
+        "stop_decision_count": 0,
+        "reward_observation_count": 0,
+        "round_rewards": [],
+    }
+    plan = {
+        "runner_prerequisites": {
+            "loopx_workflow_lifecycle_checkpoint": True,
+            "loopx_product_mode_lifecycle_driver_kind": (
+                "orchestrated_agentloop_loopx_cli"
+            ),
+        }
+    }
+    saved_modules = {
+        name: sys.modules.get(name)
+        for name in (
+            "benchflow",
+            "benchflow.sandbox",
+            "benchflow.sandbox.user",
+        )
+    }
+    fake_benchflow = types.ModuleType("benchflow")
+    fake_sandbox = types.ModuleType("benchflow.sandbox")
+    fake_user = types.ModuleType("benchflow.sandbox.user")
+
+    class FakeBaseUser:
+        pass
+
+    class FakeRoundResultBase:
+        pass
+
+    fake_user.BaseUser = FakeBaseUser
+    fake_user.RoundResult = FakeRoundResultBase
+    sys.modules["benchflow"] = fake_benchflow
+    sys.modules["benchflow.sandbox"] = fake_sandbox
+    sys.modules["benchflow.sandbox.user"] = fake_user
+    try:
+        user = _build_product_mode_user(
+            route="loopx-goal-start-product-mode",
+            max_rounds=2,
+            trace=trace,
+            plan=plan,
+            case_payload={"canonical_product_mode_lifecycle_driver": True},
+        )
+        user._task_instruction_sent = True
+    finally:
+        for name, module in saved_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+    class FakeRoundResult:
+        rewards = {"reward": 1.0}
+        n_tool_calls = 0
+        trajectory = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Local validation completed through bridge commands.",
+                    }
+                ],
+            }
+        ]
+
+    prompt = asyncio.run(
+        user.run(
+            2,
+            "Fix the fixture.",
+            round_result=FakeRoundResult(),
+        )
+    )
+    assert prompt is not None, trace
+    assert "Mandatory product-mode closeout checkpoint before finalization" in prompt
+    assert "This is not official reward" in prompt
+    assert "todo complete" in prompt
+    assert "benchmark_case_agent_closeout" in prompt
+    assert "quota spend-slot" in prompt
+    assert "--source adapter --execute" in prompt
+    assert (
+        trace["last_decision"]
+        == "send_product_mode_final_closeout_after_success_boundary"
+    ), trace
+    assert trace["official_success_observed"] is True, trace
+    assert trace["product_mode_final_closeout_required"] is True, trace
+    assert trace["product_mode_final_closeout_checkpoint_round"] == 2, trace
+    assert trace["product_mode_final_closeout_checkpoint_count"] == 1, trace
+    assert trace["product_mode_final_closeout_checkpoint_max"] == 3, trace
+    assert trace["product_mode_final_closeout_reason"] == (
+        "official_success_observed_before_selected_p0_closeout"
+    )
+    assert trace["product_mode_solver_activity_gap"] is True, trace
+    assert trace["followup_prompt_count"] == 1, trace
+    assert trace["stop_decision_count"] == 0, trace
+
+    retry_prompt = asyncio.run(
+        user.run(
+            3,
+            "Fix the fixture.",
+            round_result=FakeRoundResult(),
+        )
+    )
+    assert retry_prompt is not None, trace
+    assert "Mandatory product-mode closeout checkpoint before finalization" in retry_prompt
+    assert "todo complete" in retry_prompt
+    assert trace["product_mode_final_closeout_checkpoint_round"] == 3, trace
+    assert trace["product_mode_final_closeout_checkpoint_count"] == 2, trace
+    assert (
+        trace["last_decision"]
+        == "send_product_mode_final_closeout_after_success_boundary"
+    ), trace
+    assert trace["followup_prompt_count"] == 2, trace
     assert trace["stop_decision_count"] == 0, trace
 
 
@@ -4126,6 +4540,7 @@ def test_skillsbench_no_tool_postprocess_preserves_agent_bridge_activity() -> No
             "remote_command_file_bridge_agent_request_count": 28,
             "remote_command_file_bridge_agent_loopx_state_write_count": 14,
             "remote_command_file_bridge_agent_task_facing_operation_count": 12,
+            "remote_command_file_bridge_agent_task_facing_success_count": 12,
         },
     }
 
@@ -4838,6 +5253,7 @@ def test_skillsbench_case_event_timeline_is_compacted() -> None:
                 "remote_command_file_bridge_driver_lifecycle_loopx_state_write_count": 3,
                 "remote_command_file_bridge_agent_request_count": 3,
                 "remote_command_file_bridge_agent_task_facing_operation_count": 2,
+            "remote_command_file_bridge_agent_task_facing_success_count": 2,
                 "remote_command_file_bridge_agent_todo_closeout_count": 1,
                 "remote_command_file_bridge_agent_refresh_state_count": 1,
                 "remote_command_file_bridge_agent_quota_spend_slot_count": 1,
@@ -4883,6 +5299,7 @@ def test_skillsbench_case_event_timeline_is_compacted() -> None:
                 "remote_command_file_bridge_agent_operation_trace_count": 1,
                 "remote_command_file_bridge_agent_request_count": 3,
                 "remote_command_file_bridge_agent_task_facing_operation_count": 2,
+            "remote_command_file_bridge_agent_task_facing_success_count": 2,
                 "remote_command_file_bridge_agent_todo_closeout_count": 1,
                 "remote_command_file_bridge_agent_refresh_state_count": 1,
                 "remote_command_file_bridge_agent_quota_spend_slot_count": 1,
@@ -6116,6 +6533,52 @@ def test_skillsbench_product_mode_lifecycle_checkpoint_is_compacted() -> None:
             "skillsbench_remote_bridge_agent_operation_trace_missing"
             in prompt_timeout_compact["failure_attribution_labels"]
         ), prompt_timeout_compact
+        failed_agent_controller_trace = dict(driver_controller_trace)
+        failed_agent_controller_trace.update(
+            {
+                "remote_command_file_bridge_agent_command_configured": True,
+                "remote_command_file_bridge_agent_command_instrumented": True,
+                "remote_command_file_bridge_agent_operation_trace_required": True,
+                "remote_command_file_bridge_agent_operation_trace_satisfied": False,
+                "remote_command_file_bridge_agent_operation_trace_status": (
+                    "agent_operation_trace_recorded_no_success"
+                ),
+                "remote_command_file_bridge_agent_operation_trace_count": 1,
+                "remote_command_file_bridge_agent_request_count": 1,
+                "remote_command_file_bridge_agent_success_count": 0,
+                "remote_command_file_bridge_agent_failure_count": 1,
+                "remote_command_file_bridge_agent_failure_category_counts": {
+                    "bridge_client_permission_error": 1,
+                },
+                "remote_command_file_bridge_agent_loopx_cli_call_count": 0,
+                "remote_command_file_bridge_agent_loopx_state_read_count": 0,
+                "remote_command_file_bridge_agent_loopx_state_write_count": 0,
+                "remote_command_file_bridge_agent_todo_closeout_count": 0,
+                "remote_command_file_bridge_agent_refresh_state_count": 0,
+                "remote_command_file_bridge_agent_quota_spend_slot_count": 0,
+            }
+        )
+        failed_agent_compact = compact_benchmark_run(
+            build_skillsbench_benchflow_result_benchmark_run(
+                result_path,
+                route="loopx-product-mode",
+                controller_trace=failed_agent_controller_trace,
+            )
+        )
+        assert failed_agent_compact is not None
+        expected_failed_agent_label = (
+            "skillsbench_remote_bridge_agent_operation_failed_"
+            "bridge_client_permission_error"
+        )
+        assert failed_agent_compact["score_failure_attribution"] == (
+            expected_failed_agent_label
+        ), failed_agent_compact
+        assert expected_failed_agent_label in failed_agent_compact[
+            "failure_attribution_labels"
+        ], failed_agent_compact
+        assert "skillsbench_runner_setup_error" in failed_agent_compact[
+            "failure_attribution_labels"
+        ], failed_agent_compact
         external_agent_controller_trace = dict(driver_controller_trace)
         external_agent_controller_trace.update(
             {
@@ -6198,10 +6661,10 @@ def test_skillsbench_product_mode_lifecycle_checkpoint_is_compacted() -> None:
         orchestrated_no_request_contract = orchestrated_no_request_compact[
             "product_mode_lifecycle_contract"
         ]
-        assert orchestrated_no_request_contract["satisfied"] is True, (
+        assert orchestrated_no_request_contract["satisfied"] is False, (
             orchestrated_no_request_compact
         )
-        assert orchestrated_no_request_contract["countable_treatment"] is True, (
+        assert orchestrated_no_request_contract["countable_treatment"] is False, (
             orchestrated_no_request_compact
         )
         assert (
@@ -6214,16 +6677,16 @@ def test_skillsbench_product_mode_lifecycle_checkpoint_is_compacted() -> None:
             orchestrated_no_request_contract[
                 "orchestrated_driver_counts_as_product_mode"
             ]
-            is True
+            is False
         ), orchestrated_no_request_contract
         assert (
             orchestrated_no_request_contract["agent_operation_trace_required"]
-            is False
+            is True
         ), orchestrated_no_request_contract
-        assert orchestrated_no_request_contract.get("missing_reason", "") == "", (
-            orchestrated_no_request_contract
-        )
-        assert "skillsbench_remote_bridge_agent_no_requests" not in (
+        assert orchestrated_no_request_contract["missing_reason"] == (
+            "remote_command_file_bridge_agent_no_requests"
+        ), orchestrated_no_request_contract
+        assert "skillsbench_remote_bridge_agent_no_requests" in (
             orchestrated_no_request_compact["failure_attribution_labels"]
         ), orchestrated_no_request_compact
         no_request_controller_trace = dict(external_agent_controller_trace)
@@ -6279,6 +6742,7 @@ def test_skillsbench_product_mode_lifecycle_checkpoint_is_compacted() -> None:
                 "remote_command_file_bridge_agent_loopx_state_read_count": 2,
                 "remote_command_file_bridge_agent_loopx_state_write_count": 1,
                 "remote_command_file_bridge_agent_task_facing_operation_count": 1,
+            "remote_command_file_bridge_agent_task_facing_success_count": 1,
                 "remote_command_file_bridge_agent_loopx_subcommand_counts": {
                     "quota should-run": 2,
                     "todo claim": 1,
@@ -6443,6 +6907,7 @@ def test_skillsbench_product_mode_recompact_normalizes_agent_bridge_closeout() -
                 "remote_command_file_bridge_agent_refresh_state_count": 1,
                 "remote_command_file_bridge_agent_quota_spend_slot_count": 1,
                 "remote_command_file_bridge_agent_task_facing_operation_count": 4,
+            "remote_command_file_bridge_agent_task_facing_success_count": 4,
             },
             "product_mode_lifecycle_contract": {
                 "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
@@ -6601,6 +7066,7 @@ def test_skillsbench_product_mode_recompact_prefers_corroborated_solver_gap() ->
                     "missing_task_facing_activity_or_agent_closeout_before_declared_done"
                 ),
                 "remote_command_file_bridge_agent_task_facing_operation_count": 0,
+            "remote_command_file_bridge_agent_task_facing_success_count": 0,
                 "remote_command_file_bridge_agent_todo_closeout_count": 0,
             },
             "product_mode_lifecycle_contract": {
@@ -6662,6 +7128,7 @@ def test_skillsbench_product_mode_solver_activity_gap_is_compacted() -> None:
             "remote_command_file_bridge_agent_loopx_state_read_count": 2,
             "remote_command_file_bridge_agent_loopx_state_write_count": 0,
             "remote_command_file_bridge_agent_task_facing_operation_count": 0,
+            "remote_command_file_bridge_agent_task_facing_success_count": 0,
             "last_decision": "send_product_mode_solver_activity_continuation",
             "raw_task_text_recorded": False,
             "raw_verifier_output_recorded": False,
@@ -6761,6 +7228,7 @@ def test_skillsbench_product_mode_first_action_timeout_is_uncountable() -> None:
             "remote_command_file_bridge_agent_operation_trace_count": 0,
             "remote_command_file_bridge_agent_request_count": 0,
             "remote_command_file_bridge_agent_task_facing_operation_count": 0,
+            "remote_command_file_bridge_agent_task_facing_success_count": 0,
             "host_local_acp_codex_exec_failure_trace_present": True,
             "host_local_acp_codex_exec_failure_trace_count": 1,
             "host_local_acp_codex_exec_failure_category": (
@@ -6865,6 +7333,7 @@ def test_skillsbench_host_local_idle_timeout_after_closeout_is_countable() -> No
             "remote_command_file_bridge_agent_operation_trace_satisfied": True,
             "remote_command_file_bridge_agent_request_count": 47,
             "remote_command_file_bridge_agent_task_facing_operation_count": 34,
+            "remote_command_file_bridge_agent_task_facing_success_count": 34,
             "remote_command_file_bridge_agent_loopx_state_read_count": 7,
             "remote_command_file_bridge_agent_loopx_state_write_count": 5,
             "remote_command_file_bridge_agent_todo_closeout_count": 2,
@@ -6911,7 +7380,7 @@ def test_skillsbench_host_local_idle_timeout_after_closeout_is_countable() -> No
         assert accounting["failure_class"] == "solver_failed", accounting
 
 
-def test_goal_start_host_local_requires_codex_exec_preflight_by_default() -> None:
+def test_goal_start_host_local_defers_codex_exec_preflight_until_bridge_command() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-goal-start-preflight-") as tmp:
         args = parse_args(
             [
@@ -6929,10 +7398,34 @@ def test_goal_start_host_local_requires_codex_exec_preflight_by_default() -> Non
         plan = build_plan(args)
         prereqs = plan["runner_prerequisites"]
         assert (
-            prereqs["host_local_acp_codex_exec_preflight_requested"] is True
+            prereqs["host_local_acp_codex_exec_preflight_requested"] is False
         ), prereqs
-        assert prereqs["host_local_acp_codex_exec_preflight_status"] == "pending", (
+        assert prereqs["host_local_acp_codex_exec_preflight_status"] == "not_requested", (
             prereqs
+        )
+        args_with_bridge = parse_args(
+            [
+                "--task-id",
+                "citation-check",
+                "--route",
+                "loopx-goal-start-product-mode",
+                "--host-local-acp-launch",
+                "--remote-command-file-bridge-ready",
+                "--remote-command-file-bridge-solver-command",
+                "/tmp/loopx-skillsbench-docker-bridge",
+                "--jobs-dir",
+                str(Path(tmp) / "jobs-with-bridge"),
+                "--job-name",
+                "skillsbench-goal-start-preflight-bridge-fixture",
+            ]
+        )
+        bridge_plan = build_plan(args_with_bridge)
+        bridge_prereqs = bridge_plan["runner_prerequisites"]
+        assert (
+            bridge_prereqs["host_local_acp_codex_exec_preflight_requested"] is True
+        ), bridge_prereqs
+        assert bridge_prereqs["host_local_acp_codex_exec_preflight_status"] == "pending", (
+            bridge_prereqs
         )
 
 
@@ -7198,6 +7691,7 @@ def test_skillsbench_product_mode_declared_done_without_closeout_overrides_verif
             "remote_command_file_bridge_agent_loopx_state_read_count": 1,
             "remote_command_file_bridge_agent_loopx_state_write_count": 1,
             "remote_command_file_bridge_agent_task_facing_operation_count": 1,
+            "remote_command_file_bridge_agent_task_facing_success_count": 1,
             "remote_command_file_bridge_agent_todo_closeout_count": 0,
             "remote_command_file_bridge_agent_refresh_state_count": 0,
             "remote_command_file_bridge_agent_quota_spend_slot_count": 0,
@@ -7263,6 +7757,7 @@ def test_skillsbench_product_mode_solver_activity_gap_overrides_zero_score() -> 
             "remote_command_file_bridge_agent_operation_trace_satisfied": True,
             "remote_command_file_bridge_agent_request_count": 2,
             "remote_command_file_bridge_agent_task_facing_operation_count": 0,
+            "remote_command_file_bridge_agent_task_facing_success_count": 0,
             "remote_command_file_bridge_agent_todo_closeout_count": 0,
             "raw_task_text_recorded": False,
             "raw_verifier_output_recorded": False,
@@ -8149,14 +8644,16 @@ def test_skillsbench_product_mode_pass_clears_generic_runner_error() -> None:
             "remote_command_file_bridge_driver_lifecycle_loopx_state_write_count": 3,
             "remote_command_file_bridge_agent_command_instrumented": True,
             "remote_command_file_bridge_agent_operation_trace_required": True,
-            "remote_command_file_bridge_agent_operation_trace_satisfied": False,
+            "remote_command_file_bridge_agent_operation_trace_satisfied": True,
             "remote_command_file_bridge_agent_operation_trace_status": (
-                "agent_operation_trace_present_no_requests"
+                "agent_operation_trace_recorded"
             ),
             "remote_command_file_bridge_agent_operation_trace_count": 1,
-            "remote_command_file_bridge_agent_request_count": 0,
-            "remote_command_file_bridge_agent_loopx_state_read_count": 0,
-            "remote_command_file_bridge_agent_loopx_state_write_count": 0,
+            "remote_command_file_bridge_agent_request_count": 2,
+            "remote_command_file_bridge_agent_task_facing_operation_count": 1,
+            "remote_command_file_bridge_agent_task_facing_success_count": 1,
+            "remote_command_file_bridge_agent_loopx_state_read_count": 1,
+            "remote_command_file_bridge_agent_loopx_state_write_count": 1,
         }
         compact = compact_benchmark_run(
             build_skillsbench_benchflow_result_benchmark_run(
@@ -8683,6 +9180,8 @@ def test_skillsbench_reduce_only_discovers_nested_official_result() -> None:
 def test_skillsbench_main_failure_closeout_preserves_mutated_prerequisites() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-main-prereq-closeout-") as tmp:
         jobs_dir = Path(tmp) / "jobs"
+        skillsbench_root = Path(tmp) / "skillsbench"
+        (skillsbench_root / "tasks" / "bike-rebalance").mkdir(parents=True)
 
         original_ensure = skillsbench_loop.ensure_benchflow_runtime
         original_run = skillsbench_loop.run_benchflow_case
@@ -8716,6 +9215,8 @@ def test_skillsbench_main_failure_closeout_preserves_mutated_prerequisites() -> 
                         "codex-acp-blind-loop-baseline",
                         "--jobs-dir",
                         str(jobs_dir),
+                        "--skillsbench-root",
+                        str(skillsbench_root),
                         "--job-name",
                         "skillsbench-prereq-closeout-fixture",
                         "--rollout-name",
@@ -8770,6 +9271,8 @@ def test_skillsbench_main_failure_closeout_preserves_mutated_prerequisites() -> 
 def test_skillsbench_main_recovers_official_result_after_runner_exception() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-result-recovery-") as tmp:
         jobs_dir = Path(tmp) / "jobs"
+        skillsbench_root = Path(tmp) / "skillsbench"
+        (skillsbench_root / "tasks" / "tictoc-unnecessary-abort-detection").mkdir(parents=True)
         job_name = "skillsbench-result-recovery-fixture"
         exception_message = "PRIVATE_EXCEPTION_DETAIL_SHOULD_NOT_ESCAPE"
 
@@ -8816,6 +9319,8 @@ def test_skillsbench_main_recovers_official_result_after_runner_exception() -> N
                         "codex-acp-blind-loop-baseline",
                         "--jobs-dir",
                         str(jobs_dir),
+                        "--skillsbench-root",
+                        str(skillsbench_root),
                         "--job-name",
                         job_name,
                         "--rollout-name",
@@ -8858,6 +9363,8 @@ def test_skillsbench_main_recovers_official_result_after_runner_exception() -> N
 def test_skillsbench_main_recovers_missing_reward_with_structured_prereq_blocker() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-missing-reward-prereq-") as tmp:
         jobs_dir = Path(tmp) / "jobs"
+        skillsbench_root = Path(tmp) / "skillsbench"
+        (skillsbench_root / "tasks" / "tictoc-unnecessary-abort-detection").mkdir(parents=True)
         job_name = "skillsbench-missing-reward-prereq-fixture"
 
         original_ensure = skillsbench_loop.ensure_benchflow_runtime
@@ -8918,6 +9425,8 @@ def test_skillsbench_main_recovers_missing_reward_with_structured_prereq_blocker
                         "loopx-blind-loop-treatment",
                         "--jobs-dir",
                         str(jobs_dir),
+                        "--skillsbench-root",
+                        str(skillsbench_root),
                         "--job-name",
                         job_name,
                         "--rollout-name",
@@ -9229,6 +9738,152 @@ def test_skillsbench_user_loop_soft_verify_exception_continues_to_next_round() -
         assert "PRIVATE_PATH_SHOULD_NOT_ESCAPE" not in rounds_log
 
 
+def test_skillsbench_user_loop_no_tool_execute_exception_continues_to_next_round() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-user-loop-no-tool-") as tmp:
+        rollout_dir = Path(tmp)
+        plan = {"runner_prerequisites": {}}
+        trace: dict[str, Any] = {
+            "schema_version": "skillsbench_loopx_controller_trace_v0",
+        }
+        seen_rounds: list[tuple[int, str | None]] = []
+
+        fake_benchflow = types.ModuleType("benchflow")
+        fake_sandbox = types.ModuleType("benchflow.sandbox")
+        fake_user_module = types.ModuleType("benchflow.sandbox.user")
+
+        class FakeRoundResult:
+            def __init__(self, **kwargs: Any) -> None:
+                self.__dict__.update(kwargs)
+
+        fake_user_module.RoundResult = FakeRoundResult
+        old_modules = {
+            name: sys.modules.get(name)
+            for name in (
+                "benchflow",
+                "benchflow.sandbox",
+                "benchflow.sandbox.user",
+            )
+        }
+        sys.modules["benchflow"] = fake_benchflow
+        sys.modules["benchflow.sandbox"] = fake_sandbox
+        sys.modules["benchflow.sandbox.user"] = fake_user_module
+
+        class FakeUser:
+            async def setup(self, instruction: str, solution: str | None) -> None:
+                assert instruction == "fixture instruction"
+                assert solution is None
+
+            async def run(
+                self,
+                round: int,
+                instruction: str,
+                round_result: Any | None = None,
+            ) -> str | None:
+                seen_rounds.append(
+                    (
+                        round,
+                        getattr(round_result, "verifier_error", None)
+                        if round_result is not None
+                        else None,
+                    )
+                )
+                if round == 0:
+                    return "first attempt"
+                return None
+
+        class FakeRole:
+            pass
+
+        class FakeScene:
+            roles = [FakeRole()]
+
+        class FakeConfig:
+            user = FakeUser()
+            effective_scenes = [FakeScene()]
+            oracle_access = False
+            max_user_rounds = 3
+
+        class FakeRollout:
+            async def _run_user_loop(self) -> None:
+                raise AssertionError("original user loop should be patched")
+
+            def __init__(self) -> None:
+                self._config = FakeConfig()
+                self._resolved_prompts = ["fixture instruction"]
+                self._trajectory: list[dict[str, Any]] = []
+                self._rollout_dir = rollout_dir
+                self.connected = False
+                self.disconnected = False
+                self.soft_verify_called = 0
+
+            async def connect_as(self, role: Any) -> None:
+                self.connected = True
+
+            async def execute(self, prompts: list[str] | None = None) -> None:
+                assert prompts == ["first attempt"]
+                self._trajectory.extend(
+                    [
+                        {"type": "user_message"},
+                        {"type": "agent_message"},
+                    ]
+                )
+                raise TimeoutError("PRIVATE_PATH_SHOULD_NOT_ESCAPE")
+
+            async def disconnect(self) -> None:
+                self.disconnected = True
+
+            async def soft_verify(self) -> tuple[dict | None, str | None, str | None]:
+                self.soft_verify_called += 1
+                raise AssertionError("soft verify must not run after no-tool execute exception")
+
+        try:
+            original = install_benchflow_user_loop_final_verify_recovery(
+                FakeRollout,
+                plan=plan,
+                trace=trace,
+            )
+            fake_rollout = FakeRollout()
+            asyncio.run(FakeRollout._run_user_loop(fake_rollout))
+            FakeRollout._run_user_loop = original
+        finally:
+            for name, module in old_modules.items():
+                if module is None:
+                    sys.modules.pop(name, None)
+                else:
+                    sys.modules[name] = module
+
+        prerequisites = plan["runner_prerequisites"]
+        assert fake_rollout.connected is True
+        assert fake_rollout.disconnected is True
+        assert fake_rollout.soft_verify_called == 0
+        assert (
+            prerequisites.get("benchflow_user_loop_final_verify_recovery_triggered")
+            is not True
+        )
+        assert prerequisites["benchflow_user_loop_no_tool_exception_continued"] is True
+        assert prerequisites["benchflow_user_loop_no_tool_exception_stage"] == (
+            "agent_execute"
+        )
+        assert prerequisites["benchflow_user_loop_no_tool_exception_type"] == (
+            "TimeoutError"
+        )
+        assert prerequisites["benchflow_user_loop_no_tool_exception_count"] == 1
+        assert prerequisites["benchflow_user_loop_no_tool_exception_round"] == 0
+        assert prerequisites["benchflow_user_loop_no_tool_exception_delta_events"] == 2
+        assert prerequisites["benchflow_user_loop_no_tool_exception_delta_tool_calls"] == 0
+        assert (
+            prerequisites["benchflow_user_loop_no_tool_exception_raw_error_recorded"]
+            is False
+        )
+        assert seen_rounds == [
+            (0, None),
+            (1, "public_safe_agent_execute_exception_before_tool_activity"),
+        ]
+        rounds_log = (rollout_dir / "user_rounds.jsonl").read_text(encoding="utf-8")
+        assert "public_safe_agent_execute_exception_before_tool_activity" in rounds_log
+        assert "PRIVATE_PATH_SHOULD_NOT_ESCAPE" not in rounds_log
+
+
 def test_skillsbench_product_mode_can_skip_intermediate_soft_verify() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-soft-verify-policy-") as tmp:
         rollout_dir = Path(tmp)
@@ -9524,6 +10179,8 @@ def test_skillsbench_verifier_prep_timeout_override_is_public_safe() -> None:
 def test_skillsbench_main_marks_empty_acp_trajectory_after_host_install() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-empty-acp-") as tmp:
         jobs_dir = Path(tmp) / "jobs"
+        skillsbench_root = Path(tmp) / "skillsbench"
+        (skillsbench_root / "tasks" / "tictoc-unnecessary-abort-detection").mkdir(parents=True)
         job_name = "skillsbench-empty-acp-fixture"
 
         original_ensure = skillsbench_loop.ensure_benchflow_runtime
@@ -9617,6 +10274,8 @@ def test_skillsbench_main_marks_empty_acp_trajectory_after_host_install() -> Non
                         "loopx-blind-loop-treatment",
                         "--jobs-dir",
                         str(jobs_dir),
+                        "--skillsbench-root",
+                        str(skillsbench_root),
                         "--job-name",
                         job_name,
                         "--rollout-name",
@@ -9656,6 +10315,8 @@ def test_skillsbench_main_marks_empty_acp_trajectory_after_host_install() -> Non
 def test_skillsbench_main_marks_agent_message_only_no_tool_calls() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-agent-message-only-") as tmp:
         jobs_dir = Path(tmp) / "jobs"
+        skillsbench_root = Path(tmp) / "skillsbench"
+        (skillsbench_root / "tasks" / "tictoc-unnecessary-abort-detection").mkdir(parents=True)
         job_name = "skillsbench-agent-message-only-fixture"
 
         original_ensure = skillsbench_loop.ensure_benchflow_runtime
@@ -9756,6 +10417,8 @@ def test_skillsbench_main_marks_agent_message_only_no_tool_calls() -> None:
                         "loopx-blind-loop-treatment",
                         "--jobs-dir",
                         str(jobs_dir),
+                        "--skillsbench-root",
+                        str(skillsbench_root),
                         "--job-name",
                         job_name,
                         "--rollout-name",
@@ -9793,6 +10456,8 @@ def test_skillsbench_main_marks_agent_message_only_no_tool_calls() -> None:
 def test_skillsbench_main_redirects_runner_output_to_private_log() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-private-runner-output-") as tmp:
         jobs_dir = Path(tmp) / "jobs"
+        skillsbench_root = Path(tmp) / "skillsbench"
+        (skillsbench_root / "tasks" / "private-output-fixture").mkdir(parents=True)
         job_name = "skillsbench-private-output-fixture"
 
         original_ensure = skillsbench_loop.ensure_benchflow_runtime
@@ -9820,6 +10485,8 @@ def test_skillsbench_main_redirects_runner_output_to_private_log() -> None:
                         "codex-acp-blind-loop-baseline",
                         "--jobs-dir",
                         str(jobs_dir),
+                        "--skillsbench-root",
+                        str(skillsbench_root),
                         "--job-name",
                         job_name,
                         "--rollout-name",
@@ -10006,6 +10673,7 @@ def test_skillsbench_reduce_only_preserves_persisted_public_prerequisites() -> N
                 "remote_command_file_bridge_agent_request_count": 2,
                 "remote_command_file_bridge_agent_loopx_cli_call_count": 6,
                 "remote_command_file_bridge_agent_task_facing_operation_count": 1,
+            "remote_command_file_bridge_agent_task_facing_success_count": 1,
                 "filtered_extra_marker": "FILTERED_PREREQ_MARKER_MUST_NOT_ESCAPE",
             },
         )
@@ -10050,6 +10718,7 @@ def test_skillsbench_reduce_only_preserves_persisted_public_prerequisites() -> N
                 "remote_command_file_bridge_agent_request_count": 2,
                 "remote_command_file_bridge_agent_loopx_cli_call_count": 6,
                 "remote_command_file_bridge_agent_task_facing_operation_count": 1,
+            "remote_command_file_bridge_agent_task_facing_success_count": 1,
                 "reduce_only_prerequisites_source": "persisted_public_job_artifact",
                 "reduce_only_prerequisites_artifact_read": True,
             },
@@ -10065,6 +10734,10 @@ if __name__ == "__main__":
     test_reverse_channel_first_action_timeout_stops_codex_process()
     test_reverse_channel_timeout_survives_blocked_stdin_write()
     test_reverse_channel_raw_prompt_does_not_require_bridge_first_action()
+    test_reverse_channel_bridge_idle_waits_for_bridge_activity()
+    test_reverse_channel_bridge_operation_failure_is_categorized()
+    test_host_local_codex_exec_preflight_requires_successful_bridge_action()
+    test_reverse_channel_product_mode_checkpoint_requires_bridge_first_action()
     test_reverse_channel_bridge_idle_timeout_stops_codex_process()
     test_product_mode_initial_prompt_keeps_task_visible_after_lifecycle_gate()
     test_skillsbench_final_verifier_timeout_override_records_public_state()
@@ -10094,14 +10767,16 @@ if __name__ == "__main__":
     test_product_mode_declared_done_marker_detection()
     test_product_mode_declared_done_ignores_user_prompt_marker()
     test_skillsbench_codex_exec_failure_category_is_actionable()
+    test_host_local_relay_timeout_returns_recoverable_turn_message()
     test_product_mode_case_state_seed_uses_active_goal_shape()
     test_product_mode_declared_done_requires_case_state_depth()
     test_product_mode_declared_done_requires_solver_activity_after_driver_lifecycle()
     test_product_mode_declared_done_below_passing_reward_continues()
     test_product_mode_declared_done_missing_reward_continues()
     test_product_mode_missing_lifecycle_prompts_exact_checkpoint()
-    test_product_mode_no_tool_call_stops_before_checkpoint_loop()
+    test_product_mode_no_tool_call_continues_before_checkpoint_loop()
     test_product_mode_workflow_driver_task_bridge_activity_avoids_no_tool_abort()
+    test_product_mode_official_success_requires_final_closeout_checkpoint()
     test_skillsbench_skeleton_builder()
     test_skillsbench_official_result_builder()
     test_skillsbench_result_reward_artifact_recovery()
@@ -10154,7 +10829,7 @@ if __name__ == "__main__":
     test_skillsbench_product_mode_solver_activity_gap_overrides_zero_score()
     test_skillsbench_product_mode_first_action_timeout_is_uncountable()
     test_skillsbench_host_local_idle_timeout_after_closeout_is_countable()
-    test_goal_start_host_local_requires_codex_exec_preflight_by_default()
+    test_goal_start_host_local_defers_codex_exec_preflight_until_bridge_command()
     test_goal_start_host_exec_failure_overrides_zero_score_recovery()
     test_skillsbench_product_mode_declared_done_below_passing_reward_is_compacted()
     test_skillsbench_declared_done_missing_reward_status_is_compacted()
@@ -10183,6 +10858,7 @@ if __name__ == "__main__":
     test_skillsbench_main_recovers_missing_reward_with_structured_prereq_blocker()
     test_skillsbench_result_timeout_after_loopx_lifecycle_is_attributed()
     test_skillsbench_user_loop_soft_verify_exception_continues_to_next_round()
+    test_skillsbench_user_loop_no_tool_execute_exception_continues_to_next_round()
     test_skillsbench_final_verify_timeout_after_user_loop_recovery_is_attributed()
     test_skillsbench_verifier_prep_timeout_override_is_public_safe()
     test_skillsbench_main_marks_empty_acp_trajectory_after_host_install()

--- a/examples/skillsbench-host-local-launch-plan-smoke.py
+++ b/examples/skillsbench-host-local-launch-plan-smoke.py
@@ -22,6 +22,7 @@ from loopx.benchmark_adapters.skillsbench_acp_relay import (  # noqa: E402
     SkillsBenchLocalAcpRelay,
     SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_PREFLIGHT_MARKER,
     SKILLSBENCH_LOCAL_ACP_RELAY_READY_MARKER,
+    _codex_exec_failure_category,
     run_skillsbench_local_acp_relay_probe,
 )
 from loopx.benchmark_adapters.skillsbench_remote_bridge import (  # noqa: E402
@@ -256,13 +257,17 @@ if out:
             for line in str(reverse_payload["agent_operations_jsonl"]).splitlines()
             if line.strip()
         ]
-        assert len(operation_lines) == 1, reverse_payload
+        assert len(operation_lines) == 2, reverse_payload
         operation_record = operation_lines[0]
         assert operation_record["operation"] == "exec", operation_record
+        assert operation_record["record_phase"] == "start", operation_record
         assert operation_record["loopx_cli_call"] is True, operation_record
         assert operation_record["loopx_state_read"] is True, operation_record
         assert operation_record["task_facing_operation"] is False, operation_record
         assert operation_record["raw_request_recorded"] is False, operation_record
+        complete_record = operation_lines[1]
+        assert complete_record["record_phase"] == "complete", complete_record
+        assert complete_record["returncode"] == 0, complete_record
         root = Path(tmp) / "skillsbench"
         task = root / "tasks" / "demo-task" / "environment"
         task.mkdir(parents=True)
@@ -586,7 +591,7 @@ if out:
             == "sandbox_bridge_auto_wiring_pending"
         )
         for route in ("loopx-product-mode", "loopx-goal-start-product-mode"):
-            blocked_auto_wiring_full_run = subprocess.run(
+            auto_wiring_runtime_plan = subprocess.run(
                 [
                     sys.executable,
                     str(SCRIPT),
@@ -598,6 +603,7 @@ if out:
                     route,
                     "--host-local-acp-launch",
                     "--remote-command-file-bridge-ready",
+                    "--plan-only",
                 ],
                 cwd=REPO_ROOT,
                 stdout=subprocess.PIPE,
@@ -606,19 +612,23 @@ if out:
                 timeout=30,
                 check=False,
             )
-            assert blocked_auto_wiring_full_run.returncode == 2, (
-                blocked_auto_wiring_full_run
+            assert auto_wiring_runtime_plan.returncode == 0, (
+                auto_wiring_runtime_plan.stderr
             )
-            auto_wiring_failure = json.loads(blocked_auto_wiring_full_run.stderr)
-            assert auto_wiring_failure["error_type"] == (
-                "SkillsBenchProductModeBridgeAutoWiringPending"
-            ), auto_wiring_failure
+            auto_wiring_prereqs = json.loads(auto_wiring_runtime_plan.stdout)[
+                "launch_plan"
+            ]["runner_prerequisites"]
             assert (
-                auto_wiring_failure["remote_command_file_bridge_consumption_status"]
+                auto_wiring_prereqs["remote_command_file_bridge_consumption_status"]
                 == "sandbox_bridge_auto_wiring_pending"
-            ), auto_wiring_failure
-            assert auto_wiring_failure["raw_task_text_read"] is False
-            assert auto_wiring_failure["raw_trajectory_recorded"] is False
+            ), auto_wiring_prereqs
+            source = SCRIPT.read_text(encoding="utf-8")
+            assert "_host_local_acp_docker_bridge_command(" in source
+            assert 'prerequisites["remote_command_file_bridge_command_configured"] = True' in source
+            assert (
+                'prerequisites["remote_command_file_bridge_solver_wiring_configured"] = True'
+                in source
+            )
         blocked_fixture_solver = subprocess.run(
             [
                 sys.executable,
@@ -1185,6 +1195,61 @@ raise SystemExit(125)
             exit125_controller_trace["host_local_acp_codex_exec_failure_category"]
             == "codex_exec_exit_125"
         )
+        agent_bridge_failure_trace_dir = Path(tmp) / "agent-bridge-failure-traces"
+        agent_bridge_failure_trace_dir.mkdir(parents=True)
+        (agent_bridge_failure_trace_dir / "worker-agent-failure.compact.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": (
+                        "skillsbench_host_local_acp_relay_public_trace_v0"
+                    ),
+                    "ok": True,
+                    "route": "loopx-goal-start-product-mode",
+                    "trace_kind": "remote_command_file_bridge_agent_operations",
+                    "remote_command_file_bridge_agent_operations": {
+                        "schema_version": (
+                            "skillsbench_remote_command_file_bridge_agent_operations_v0"
+                        ),
+                        "request_count": 1,
+                        "success_count": 0,
+                        "failure_count": 1,
+                        "task_facing_operation_count": 1,
+                        "task_facing_success_count": 0,
+                        "task_facing_failure_count": 1,
+                        "failure_category_counts": {
+                            "bridge_client_permission_error": 1
+                        },
+                        "raw_material_recorded": False,
+                    },
+                    "boundary": {
+                        "raw_command_recorded": False,
+                        "raw_stdout_recorded": False,
+                        "raw_stderr_recorded": False,
+                        "raw_task_text_recorded": False,
+                        "credential_values_recorded": False,
+                    },
+                },
+                sort_keys=True,
+            ),
+            encoding="utf-8",
+        )
+        agent_bridge_failure_trace = {
+            "schema_version": "skillsbench_loopx_controller_trace_v0"
+        }
+        agent_bridge_failure_plan = {
+            "host_local_acp_relay_trace_dir": str(agent_bridge_failure_trace_dir),
+            "runner_prerequisites": {},
+        }
+        _merge_host_local_acp_relay_trace_summary(
+            agent_bridge_failure_plan,
+            agent_bridge_failure_trace,
+        )
+        assert agent_bridge_failure_trace[
+            "host_local_acp_codex_exec_failure_category"
+        ] == "bridge_client_permission_error", agent_bridge_failure_trace
+        assert agent_bridge_failure_plan["runner_prerequisites"][
+            "host_local_acp_codex_exec_failure_category"
+        ] == "bridge_client_permission_error"
         network_exit125_codex = Path(tmp) / "network-exit125-codex"
         network_exit125_codex.write_text(
             """#!/usr/bin/env python3
@@ -1309,12 +1374,23 @@ raise SystemExit(1)
             reverse_failure["codex_exec_process"]["failure_category"]
             == "codex_reverse_channel_unavailable"
         ), reverse_failure
+        assert (
+            _codex_exec_failure_category(
+                returncode=1,
+                stderr_text=(
+                    "failed to connect to websocket: IO error: Connection refused "
+                    "(os error 111), url: "
+                    "wss://chatgpt.com/backend-api/codex/responses"
+                ),
+            )
+            == "codex_network_or_api_unreachable"
+        )
         reverse_sleeping_codex = Path(tmp) / "reverse-sleeping-codex"
         reverse_sleeping_codex.write_text(
             """#!/usr/bin/env python3
 import time
 
-time.sleep(30)
+time.sleep(5)
 """,
             encoding="utf-8",
         )
@@ -1425,6 +1501,61 @@ subprocess.run(
             assert (
                 reverse_hanging_operations[0]["raw_request_recorded"] is False
             ), reverse_hanging_operations
+        fake_ssh = Path(tmp) / "ssh"
+        fake_ssh.write_text("#!/usr/bin/env bash\nexit 255\n", encoding="utf-8")
+        fake_ssh.chmod(0o755)
+        ssh_bridge_codex = Path(tmp) / "ssh-bridge-codex"
+        ssh_bridge_codex.write_text(
+            f"""#!/usr/bin/env python3
+import json
+import os
+import re
+import subprocess
+import sys
+
+os.environ["PATH"] = {str(tmp)!r} + os.pathsep + os.environ.get("PATH", "")
+prompt = sys.stdin.read()
+match = re.search(r"Private bridge command:\\n([^\\n]+)", prompt)
+assert match, prompt
+subprocess.run(
+    match.group(1),
+    input=json.dumps({{"operation": "exec", "cwd": "/app", "command": "true"}}),
+    text=True,
+    shell=True,
+    check=False,
+)
+""",
+            encoding="utf-8",
+        )
+        ssh_bridge_codex.chmod(0o755)
+        ssh_bridge_payload = _run_codex_payload(
+            {
+                "args": [
+                    "exec",
+                    (
+                        "LoopX bridge test. Your first tool action should be "
+                        "a shell pipeline that sends JSON to the private bridge.\n\n"
+                        "Private bridge command:\n"
+                        "/tmp/not-recorded"
+                    ),
+                ],
+                "timeout_sec": 5,
+            },
+            codex_bin=str(ssh_bridge_codex),
+            default_timeout_sec=5,
+            prompt_bridge_command="ssh loopx-unavailable.example",
+            first_action_timeout_sec=1,
+        )
+        ssh_bridge_operations = [
+            json.loads(line)
+            for line in str(ssh_bridge_payload["agent_operations_jsonl"]).splitlines()
+            if line.strip()
+        ]
+        assert ssh_bridge_payload["exit_code"] == 0, ssh_bridge_payload
+        assert ssh_bridge_operations[-1]["record_phase"] == "complete"
+        assert ssh_bridge_operations[-1]["failure_category"] == (
+            "bridge_ssh_unavailable"
+        ), ssh_bridge_operations
         idle_bridge = Path(tmp) / "post-action-idle-bridge"
         idle_bridge.write_text(
             """#!/usr/bin/env python3
@@ -1509,17 +1640,14 @@ time.sleep(30)
                 remote_command_file_bridge_agent_command=str(idle_bridge),
             )
         )
-        try:
-            idle_relay._run_codex(
-                "LoopX demo prompt.",
-                session={"cwd": str(Path(tmp))},
-                session_id="idle-demo",
-                stdout=io.StringIO(),
-            )
-        except TimeoutError as exc:
-            assert "bridge idle timeout" in str(exc), exc
-        else:
-            raise AssertionError("expected bridge idle timeout")
+        idle_response = idle_relay._run_codex(
+            "LoopX demo prompt.",
+            session={"cwd": str(Path(tmp))},
+            session_id="idle-demo",
+            stdout=io.StringIO(),
+        )
+        assert "LoopX recoverable Codex turn failure" in idle_response
+        assert "codex_exec_bridge_idle_timeout" in idle_response
         idle_traces = [
             json.loads(path.read_text(encoding="utf-8"))
             for path in idle_trace_dir.glob("*.compact.json")
@@ -1621,7 +1749,7 @@ subprocess.run(
                 route="loopx-product-mode",
                 dataset="skillsbench-v1.1",
                 task_id="demo-task",
-                timeout_sec=30,
+                timeout_sec=2,
                 first_action_timeout_sec=1,
                 bridge_idle_timeout_sec=1,
                 worker_public_trace_dir=str(inflight_trace_dir),
@@ -1629,17 +1757,14 @@ subprocess.run(
                 remote_command_file_bridge_agent_command=str(inflight_bridge),
             )
         )
-        try:
-            inflight_relay._run_codex(
-                "LoopX demo prompt.",
-                session={"cwd": str(Path(tmp))},
-                session_id="inflight-idle-demo",
-                stdout=io.StringIO(),
-            )
-        except TimeoutError as exc:
-            assert "bridge idle timeout" in str(exc), exc
-        else:
-            raise AssertionError("expected in-flight bridge idle timeout")
+        inflight_response = inflight_relay._run_codex(
+            "LoopX demo prompt.",
+            session={"cwd": str(Path(tmp))},
+            session_id="inflight-idle-demo",
+            stdout=io.StringIO(),
+        )
+        assert "LoopX recoverable Codex turn failure" in inflight_response
+        assert "codex_exec_timeout" in inflight_response
         inflight_traces = [
             json.loads(path.read_text(encoding="utf-8"))
             for path in inflight_trace_dir.glob("*.compact.json")
@@ -1656,9 +1781,24 @@ subprocess.run(
         assert inflight_counts["request_count"] in {0, 1}, inflight_counts
         if inflight_counts["request_count"] == 1:
             assert inflight_counts["task_facing_operation_count"] == 1, inflight_counts
+            assert inflight_counts["failure_count"] == 0, inflight_counts
+            assert inflight_counts["failure_category_counts"] == {}, inflight_counts
+            assert inflight_counts["task_facing_interrupted_count"] == inflight_counts[
+                "interrupted_operation_count"
+            ], inflight_counts
         else:
             assert inflight_counts["task_facing_operation_count"] == 0, inflight_counts
+        assert inflight_counts["inflight_operation_count"] == 1, inflight_counts
         assert inflight_counts["raw_material_recorded"] is False, inflight_counts
+        inflight_failures = [
+            trace
+            for trace in inflight_traces
+            if trace.get("trace_kind") == "codex_exec_process_failure"
+        ]
+        assert len(inflight_failures) == 1, inflight_traces
+        assert inflight_failures[0]["codex_exec_process"]["failure_category"] == (
+            "codex_exec_timeout"
+        )
         bridge_preflight_codex = Path(tmp) / "bridge-preflight-codex"
         bridge_preflight_codex.write_text(
             f"""#!/usr/bin/env python3

--- a/examples/skillsbench-reverse-channel-bridge-smoke.py
+++ b/examples/skillsbench-reverse-channel-bridge-smoke.py
@@ -349,6 +349,101 @@ raise SystemExit(proc.returncode)
             server.wait(timeout=5)
 
 
+def test_codex_bridge_template_classifies_ssh_unavailable() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-reverse-bridge-ssh-") as tmp:
+        root = Path(tmp)
+        fake_ssh = root / "ssh"
+        fake_ssh.write_text("#!/usr/bin/env bash\nexit 255\n", encoding="utf-8")
+        fake_ssh.chmod(0o700)
+        fake_codex = root / "fake-codex"
+        fake_codex.write_text(
+            f"""#!/usr/bin/env python3
+import json, os, subprocess, sys
+from pathlib import Path
+
+os.environ["PATH"] = {str(root)!r} + os.pathsep + os.environ.get("PATH", "")
+args = sys.argv[1:]
+prompt = sys.stdin.read()
+bridge = prompt.split('Private bridge command:\\n', 1)[1].split('\\n', 1)[0]
+subprocess.run(
+    [bridge],
+    input=json.dumps({{'operation': 'exec', 'cwd': '/app', 'command': 'true'}}),
+    text=True,
+    check=False,
+)
+out = Path(args[args.index('--output-last-message') + 1])
+out.write_text('LOOPX_REVERSE_SSH_CLASSIFIED\\n', encoding='utf-8')
+""",
+            encoding="utf-8",
+        )
+        fake_codex.chmod(0o700)
+        socket_path = root / "codex.sock"
+        server = subprocess.Popen(
+            [
+                sys.executable,
+                str(BRIDGE),
+                "serve-codex",
+                "--socket",
+                str(socket_path),
+                "--codex-bin",
+                str(fake_codex),
+                "--prompt-bridge-command",
+                "ssh loopx-unavailable.example",
+                "--once",
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        try:
+            wait_for_socket(socket_path, server)
+            client = root / "codex-client"
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(BRIDGE),
+                    "write-client",
+                    "--kind",
+                    "codex",
+                    "--socket",
+                    str(socket_path),
+                    "--output",
+                    str(client),
+                ],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            agent_ops = root / "agent-ops.jsonl"
+            env = os.environ.copy()
+            env["LOOPX_REMOTE_AGENT_OPS_SUMMARY_PATH"] = str(agent_ops)
+            proc = subprocess.run(
+                [
+                    str(client),
+                    "exec",
+                    "--output-last-message",
+                    str(root / "remote-last-message.txt"),
+                    "Private bridge command:\n/not-recorded\n\nTask",
+                ],
+                check=False,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            assert proc.returncode == 0, proc.stderr
+            records = [
+                json.loads(line)
+                for line in agent_ops.read_text(encoding="utf-8").splitlines()
+                if line.strip()
+            ]
+            assert records[-1]["record_phase"] == "complete", records
+            assert records[-1]["failure_category"] == "bridge_ssh_unavailable"
+        finally:
+            server.wait(timeout=5)
+
+
 def test_codex_client_plain_prompt_does_not_require_bridge_action() -> None:
     with tempfile.TemporaryDirectory(prefix="loopx-reverse-plain-prompt-") as tmp:
         root = Path(tmp)
@@ -610,6 +705,103 @@ print(json.dumps({
             server.wait(timeout=5)
 
 
+def test_json_client_forwards_private_bridge_command_template() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-reverse-json-private-") as tmp:
+        root = Path(tmp)
+        fake_bridge = root / "fake-private-json-bridge"
+        marker = root / "private-command-marker"
+        fake_bridge.write_text(
+            """#!/usr/bin/env python3
+import json
+import subprocess
+import sys
+
+private_command = sys.argv[1]
+payload = json.loads(sys.stdin.read() or '{}')
+proc = subprocess.run(
+    private_command,
+    shell=True,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+    text=True,
+    check=False,
+)
+print(json.dumps({
+    'ok': proc.returncode == 0,
+    'operation': payload.get('operation'),
+    'private_command_seen': bool(private_command),
+    'raw_task_text_recorded': False,
+    'credential_values_recorded': False,
+}))
+""",
+            encoding="utf-8",
+        )
+        fake_bridge.chmod(0o700)
+        socket_path = root / "json-private.sock"
+        server = subprocess.Popen(
+            [
+                sys.executable,
+                str(BRIDGE),
+                "serve-json",
+                "--socket",
+                str(socket_path),
+                "--bridge-command",
+                f"{fake_bridge} {{private_bridge_command_sh}}",
+                "--once",
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        try:
+            wait_for_socket(socket_path, server)
+            client = root / "json-client"
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(BRIDGE),
+                    "write-client",
+                    "--kind",
+                    "json",
+                    "--socket",
+                    str(socket_path),
+                    "--output",
+                    str(client),
+                ],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            env = os.environ.copy()
+            env["LOOPX_REVERSE_CONNECT_TIMEOUT_SEC"] = "0.1"
+            env["LOOPX_REVERSE_RESPONSE_TIMEOUT_SEC"] = "5"
+            env["LOOPX_PRIVATE_BRIDGE_COMMAND"] = (
+                f"{sys.executable} -c \"from pathlib import Path; "
+                f"Path({str(marker)!r}).write_text('ok', encoding='utf-8'); "
+                "print('private-ok')\""
+            )
+            proc = subprocess.run(
+                [str(client)],
+                input=json.dumps({"operation": "exec", "cwd": "/app"}),
+                check=False,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            assert proc.returncode == 0, proc.stderr
+            response = json.loads(proc.stdout)
+            assert response["ok"] is True
+            assert response["operation"] == "exec"
+            assert response["private_command_seen"] is True
+            assert marker.read_text(encoding="utf-8") == "ok"
+            assert response["raw_task_text_recorded"] is False
+            assert response["credential_values_recorded"] is False
+        finally:
+            server.wait(timeout=5)
+
+
 def test_json_preflight_does_not_require_target_env_or_bridge_command() -> None:
     with tempfile.TemporaryDirectory(prefix="lrjp-") as tmp:
         root = Path(tmp)
@@ -685,6 +877,155 @@ raise SystemExit(42)
             server.wait(timeout=5)
 
 
+def test_json_file_queue_client_forwards_without_socket_access() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-reverse-json-file-") as tmp:
+        root = Path(tmp)
+        queue_dir = root / "queue"
+        fake_bridge = root / "fake-json-bridge"
+        fake_bridge.write_text(
+            """#!/usr/bin/env python3
+import json, os, sys
+
+payload = json.loads(sys.stdin.read() or '{}')
+print(json.dumps({
+    'ok': True,
+    'operation': payload.get('operation'),
+    'ai_addr_present': bool(os.environ.get('AI_ADDR')),
+    'raw_task_text_recorded': False,
+    'credential_values_recorded': False,
+}))
+""",
+            encoding="utf-8",
+        )
+        fake_bridge.chmod(0o700)
+        server = subprocess.Popen(
+            [
+                sys.executable,
+                str(BRIDGE),
+                "serve-json-file",
+                "--queue-dir",
+                str(queue_dir),
+                "--bridge-command",
+                str(fake_bridge),
+                "--once",
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        try:
+            wait_for_path(queue_dir / "requests")
+            client = root / "json-file-client"
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(BRIDGE),
+                    "write-client",
+                    "--kind",
+                    "json-file",
+                    "--queue-dir",
+                    str(queue_dir),
+                    "--output",
+                    str(client),
+                ],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            env = os.environ.copy()
+            env["LOOPX_REVERSE_RESPONSE_TIMEOUT_SEC"] = "5"
+            env["AI_ADDR"] = "127.0.0.1"
+            proc = subprocess.run(
+                [str(client)],
+                input=json.dumps({"operation": "exec", "cwd": "/app"}),
+                check=False,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            assert proc.returncode == 0, proc.stderr
+            response = json.loads(proc.stdout)
+            assert response["ok"] is True
+            assert response["operation"] == "exec"
+            assert response["ai_addr_present"] is True
+            assert response["raw_task_text_recorded"] is False
+            assert response["credential_values_recorded"] is False
+        finally:
+            server.wait(timeout=5)
+
+
+def test_json_file_preflight_does_not_invoke_bridge_command() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-reverse-json-file-preflight-") as tmp:
+        root = Path(tmp)
+        queue_dir = root / "queue"
+        fake_bridge = root / "fake-json-bridge"
+        marker = root / "bridge-invoked"
+        fake_bridge.write_text(
+            f"""#!/usr/bin/env python3
+from pathlib import Path
+Path({str(marker)!r}).write_text('unexpected', encoding='utf-8')
+raise SystemExit(42)
+""",
+            encoding="utf-8",
+        )
+        fake_bridge.chmod(0o700)
+        server = subprocess.Popen(
+            [
+                sys.executable,
+                str(BRIDGE),
+                "serve-json-file",
+                "--queue-dir",
+                str(queue_dir),
+                "--bridge-command",
+                str(fake_bridge),
+                "--once",
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        try:
+            wait_for_path(queue_dir / "requests")
+            client = root / "json-file-client"
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(BRIDGE),
+                    "write-client",
+                    "--kind",
+                    "json-file",
+                    "--queue-dir",
+                    str(queue_dir),
+                    "--output",
+                    str(client),
+                ],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            env = os.environ.copy()
+            env["LOOPX_REVERSE_RESPONSE_TIMEOUT_SEC"] = "5"
+            proc = subprocess.run(
+                [str(client)],
+                input=json.dumps({"operation": "preflight"}),
+                check=False,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            assert proc.returncode == 0, proc.stderr
+            response = json.loads(proc.stdout)
+            assert response["ok"] is True
+            assert response["operation"] == "preflight"
+            assert marker.exists() is False
+        finally:
+            server.wait(timeout=5)
+
+
 def test_socket_probe_reports_missing_or_orphaned() -> None:
     with tempfile.TemporaryDirectory(prefix="loopx-reverse-probe-smoke-") as tmp:
         missing = Path(tmp) / "missing.sock"
@@ -712,7 +1053,10 @@ def main() -> int:
     test_codex_client_plain_prompt_does_not_require_bridge_action()
     test_json_client_forwards_stdin_to_bridge_command()
     test_json_client_expands_allowed_env_template_for_nested_bridge()
+    test_json_client_forwards_private_bridge_command_template()
     test_json_preflight_does_not_require_target_env_or_bridge_command()
+    test_json_file_queue_client_forwards_without_socket_access()
+    test_json_file_preflight_does_not_invoke_bridge_command()
     test_socket_probe_reports_missing_or_orphaned()
     print("skillsbench reverse-channel bridge smoke passed")
     return 0

--- a/examples/status-markdown-smoke.py
+++ b/examples/status-markdown-smoke.py
@@ -1371,6 +1371,22 @@ def assert_status_agent_lane_next_action_projection() -> None:
     coordination = {
         "primary_agent": "codex-main-control",
         "registered_agents": ["codex-main-control", "codex-side-bypass"],
+        "agent_profiles": {
+            "codex-side-bypass": {
+                "schema_version": "agent_profile_v0",
+                "agent_id": "codex-side-bypass",
+                "role": "side-agent",
+                "scope_summary": "productization showcase docs lane",
+                "worktree_policy": {
+                    "mode": "independent_worktree_required",
+                    "requires_independent_worktree": True,
+                },
+                "review_policy": {
+                    "handoff_agent": "codex-main-control",
+                    "can_self_merge": "small_validated_docs_or_metadata_only",
+                },
+            }
+        },
     }
     payload = {
         "ok": True,
@@ -1436,12 +1452,36 @@ def assert_status_agent_lane_next_action_projection() -> None:
     assert next_action["preserves_goal_next_action"] is True, next_action
     assert item["recommended_action"] == primary_action, item
     assert item["project_asset"]["next_action"] == primary_action, item
+    member = item["agent_member"]
+    assert member["schema_version"] == "agent_member_v0", member
+    assert member["agent_id"] == "codex-side-bypass", member
+    assert member["role"] == "side-agent", member
+    assert member["scope_summary"] == "productization showcase docs lane", member
+    assert member["worktree_policy"] == "independent_worktree_required", member
+    assert member["requires_independent_worktree"] is True, member
+    assert member["current_claims"] == ["todo_side_tui"], member
+    assert member["lease_projection"]["source"] == "todo.claimed_by", member
+    assert member["lease_projection"]["hard_lease_available"] is False, member
+    assert member["handoff_agent"] == "codex-main-control", member
+    assert member["role_is_advisory"] is True, member
+    assert item["project_asset"]["agent_member"] == member, item
+    projection = payload["agent_member_projection"]
+    assert projection["schema_version"] == "agent_member_projection_v0", projection
+    assert projection["attached_count"] == 1, projection
+    assert projection["projection_is_authoritative"] is False, projection
     markdown = render_status_markdown(payload)
+    assert "agent_member: agent=codex-side-bypass role=side-agent" in markdown, markdown
+    assert "worktree_policy=independent_worktree_required" in markdown, markdown
+    assert "claims=todo_side_tui" in markdown, markdown
     assert "current_agent_todo: agent=codex-side-bypass todo_id=todo_side_tui" in markdown, markdown
     assert "source=agent_lane_next_action" in markdown, markdown
     assert side_action in markdown, markdown
     assert f"next_agent_todo: {primary_action} claimed_by=codex-main-control scope=goal_all_agents" in markdown, markdown
     assert f"asset_agent_todo: {primary_action} claimed_by=codex-main-control scope=goal_all_agents" in markdown, markdown
+    packet = build_review_packet(payload, goal_id=goal_id, action_kind="codex")
+    assert packet["agent_member"]["agent_id"] == "codex-side-bypass", packet
+    assert "Agent 成员：agent=codex-side-bypass role=side-agent" in packet["project_agent_handoff"], packet
+    assert "authority=advisory_projection" in packet["project_agent_handoff"], packet
 
 
 def assert_status_agent_lane_frontier_hint_projection() -> None:

--- a/examples/task-graph-projection-fixture-smoke.py
+++ b/examples/task-graph-projection-fixture-smoke.py
@@ -39,6 +39,8 @@ ALLOWED_EDGE_RELATIONS = {
     "blocks",
     "validates",
     "repairs",
+    "audits",
+    "continues",
     "hands_off_to",
     "supersedes",
 }
@@ -201,12 +203,13 @@ def assert_runtime_projection_builder() -> None:
     latest_runs = [
         {
             "generated_at": "2026-06-21T13:00:00Z",
-            "classification": "task_graph_projection_runtime_smoke",
+            "classification": "task_graph_projection_audit_continuation_smoke",
+            "recommended_action": "Continue the selected projection lane after audit evidence is recorded.",
         }
     ]
     projection = build_task_graph_projection(item, goal=goal, goal_latest_runs=latest_runs)
     assert isinstance(projection, dict), projection
-    assert_projection_shape(projection, goal_id=goal_id, label="runtime projection", min_nodes=5, min_edges=4)
+    assert_projection_shape(projection, goal_id=goal_id, label="runtime projection", min_nodes=5, min_edges=6)
     kinds = {node["kind"] for node in projection["nodes"]}
     assert {"deliverable", "gate", "lease", "validation", "repair"} <= kinds, projection
     assert "gate_summary" in kinds, projection
@@ -221,7 +224,7 @@ def assert_runtime_projection_builder() -> None:
         "user_gate_truncated_count": 3,
     }, projection["limits"]
     relations = {edge["relation"] for edge in projection["edges"]}
-    assert {"blocks", "depends_on", "validates", "repairs"} <= relations, projection
+    assert {"blocks", "depends_on", "validates", "repairs", "audits", "continues"} <= relations, projection
     forbidden_keys = {"write_command", "agent_command", "raw_log", "raw_transcript"}
     projection_keys = set(json.dumps(projection, sort_keys=True).split('"'))
     assert not (projection_keys & forbidden_keys), projection_keys & forbidden_keys
@@ -276,6 +279,9 @@ def main() -> int:
         "gate_ids",
         "lease_ids",
         "run_ids",
+        "audits",
+        "continues",
+        "repair, audit, and continuation relations",
     ]:
         assert_contains(contract, needle, "contract")
 

--- a/examples/todo-cli-smoke.py
+++ b/examples/todo-cli-smoke.py
@@ -26,6 +26,7 @@ UPDATED_AGENT_TODO = "Publish the compact evidence summary after validation pass
 MONITOR_TODO = "Monitor the release-note draft PR until the next scheduled check."
 MONITOR_DUE_AT = "2026-01-02T00:00:00+00:00"
 MONITOR_NEXT_DUE_AT = "2026-01-03T00:00:00+00:00"
+MONITOR_EXPIRES_AT = "2026-01-04T00:00:00+00:00"
 
 
 def write_fixture(root: Path, *, register_agents: bool = True) -> tuple[Path, Path]:
@@ -217,6 +218,8 @@ def main() -> int:
             "benchmark_runner",
             "--target-capability",
             "benchmark_runner",
+            "--required-decision-scope",
+            "direction:action:read_only_evidence_review",
         )
         assert metadata_payload["added"] is False, metadata_payload
         assert metadata_payload["already_exists"] is True, metadata_payload
@@ -225,6 +228,14 @@ def main() -> int:
         assert metadata_payload["action_kind"] == "run_eval", metadata_payload
         assert metadata_payload["required_capabilities"] == ["shell", "benchmark_runner"], metadata_payload
         assert metadata_payload["target_capabilities"] == ["benchmark_runner"], metadata_payload
+        assert metadata_payload["required_decision_scopes"] == [
+            {
+                "schema_version": "decision_scope_v0",
+                "kind": "direction",
+                "granularity": "action",
+                "scope_key": "read_only_evidence_review",
+            }
+        ], metadata_payload
         after_metadata = state_file.read_text(encoding="utf-8")
         assert after_metadata.count("- [ ] Summarize the read-only evidence after the user") == 1, after_metadata
         agent_block_start = after_metadata.index("- [ ] Summarize the read-only evidence after the user")
@@ -233,6 +244,10 @@ def main() -> int:
         assert "status=open task_class=advancement_task action_kind=run_eval" in after_metadata
         assert "required_capabilities=shell%2Cbenchmark_runner" in after_metadata
         assert "target_capabilities=benchmark_runner" in after_metadata
+        assert (
+            "required_decision_scopes=direction:action:read_only_evidence_review"
+            in after_metadata
+        )
         fields = parse_active_state_todos(state_file.read_text(encoding="utf-8"))
         assert fields["user_todos"]["items"][0]["text"] == USER_TODO, fields
         assert fields["user_todos"]["items"][0]["todo_id"].startswith("todo_"), fields
@@ -252,6 +267,27 @@ def main() -> int:
         assert fields["agent_todos"]["items"][0]["target_capabilities"] == [
             "benchmark_runner",
         ], fields
+        assert fields["agent_todos"]["items"][0]["required_decision_scopes"][0]["scope_key"] == (
+            "read_only_evidence_review"
+        ), fields
+        scoped_gate_scope = run_cli(
+            registry_path,
+            "todo",
+            "update",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            scoped_gate["todo_id"],
+            "--decision-scope",
+            "direction:lane:external_publish_channel",
+        )
+        assert scoped_gate_scope["changed"] is True, scoped_gate_scope
+        assert scoped_gate_scope["decision_scope"]["scope_key"] == "external_publish_channel", scoped_gate_scope
+        fields = parse_active_state_todos(state_file.read_text(encoding="utf-8"))
+        scoped_user_item = next(
+            item for item in fields["user_todos"]["items"] if item["text"] == SCOPED_USER_GATE
+        )
+        assert scoped_user_item["decision_scope"]["granularity"] == "lane", scoped_user_item
         assert fields["user_todos"]["source_section"] == "User Todo / Owner Review Reading Queue", fields
         assert fields["agent_todos"]["source_section"] == "Agent Todo", fields
 
@@ -275,6 +311,8 @@ def main() -> int:
             "1d",
             "--next-due-at",
             MONITOR_DUE_AT,
+            "--expires-at",
+            MONITOR_EXPIRES_AT,
             "--claimed-by",
             "codex-side-bypass",
         )
@@ -282,6 +320,7 @@ def main() -> int:
         assert monitor_payload["target_key"] == "release-note-draft-pr", monitor_payload
         assert monitor_payload["cadence"] == "1d", monitor_payload
         assert monitor_payload["next_due_at"] == MONITOR_DUE_AT, monitor_payload
+        assert monitor_payload["expires_at"] == MONITOR_EXPIRES_AT, monitor_payload
         monitor_update = run_cli(
             registry_path,
             "todo",
@@ -300,6 +339,7 @@ def main() -> int:
         assert monitor_update["changed"] is True, monitor_update
         assert monitor_update["cadence"] == "2d", monitor_update
         assert monitor_update["next_due_at"] == MONITOR_NEXT_DUE_AT, monitor_update
+        assert monitor_update["expires_at"] == MONITOR_EXPIRES_AT, monitor_update
         invalid_monitor_schedule = run_cli_error(
             registry_path,
             "todo",
@@ -320,6 +360,7 @@ def main() -> int:
         assert monitor_item["target_key"] == "release-note-draft-pr", fields
         assert monitor_item["cadence"] == "2d", fields
         assert monitor_item["next_due_at"] == MONITOR_NEXT_DUE_AT, fields
+        assert monitor_item["expires_at"] == MONITOR_EXPIRES_AT, fields
 
         status_payload = {
             "ok": True,

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -2240,6 +2240,15 @@ def _skillsbench_controller_trace_counters(
         "remote_command_file_bridge_agent_request_count": count(
             "remote_command_file_bridge_agent_request_count"
         ),
+        "remote_command_file_bridge_agent_success_count": count(
+            "remote_command_file_bridge_agent_success_count"
+        ),
+        "remote_command_file_bridge_agent_failure_count": count(
+            "remote_command_file_bridge_agent_failure_count"
+        ),
+        "remote_command_file_bridge_agent_failure_category_counts": count_map(
+            "remote_command_file_bridge_agent_failure_category_counts"
+        ),
         "remote_command_file_bridge_agent_loopx_cli_call_count": count(
             "remote_command_file_bridge_agent_loopx_cli_call_count"
         ),
@@ -2263,6 +2272,12 @@ def _skillsbench_controller_trace_counters(
         ),
         "remote_command_file_bridge_agent_task_facing_operation_count": count(
             "remote_command_file_bridge_agent_task_facing_operation_count"
+        ),
+        "remote_command_file_bridge_agent_task_facing_success_count": count(
+            "remote_command_file_bridge_agent_task_facing_success_count"
+        ),
+        "remote_command_file_bridge_agent_task_facing_failure_count": count(
+            "remote_command_file_bridge_agent_task_facing_failure_count"
         ),
         "remote_command_file_bridge_agent_probe_operation_count": count(
             "remote_command_file_bridge_agent_probe_operation_count"
@@ -3051,21 +3066,7 @@ def build_skillsbench_benchflow_result_benchmark_run(
         )
         is True
     )
-    orchestrated_driver_counts_as_product_mode = bool(
-        orchestrated_driver_lifecycle_satisfied
-        and (
-            not remote_agent_operation_trace_required_raw
-            or controller_counters.get(
-                "remote_command_file_bridge_agent_command_instrumented"
-            )
-            is True
-        )
-    )
-    remote_agent_operation_trace_required = bool(
-        remote_agent_operation_trace_required_raw
-        and not orchestrated_driver_counts_as_product_mode
-    )
-    remote_agent_operation_trace_satisfied = (
+    remote_agent_operation_trace_satisfied_raw_field = (
         controller_counters.get(
             "remote_command_file_bridge_agent_operation_trace_satisfied"
         )
@@ -3076,6 +3077,55 @@ def build_skillsbench_benchflow_result_benchmark_run(
             "remote_command_file_bridge_agent_operation_trace_status", ""
         )
     )
+    remote_agent_task_facing_operation_count = _controller_public_count(
+        "remote_command_file_bridge_agent_task_facing_operation_count"
+    )
+    remote_agent_task_facing_success_count = _controller_public_count(
+        "remote_command_file_bridge_agent_task_facing_success_count"
+    )
+    remote_agent_task_facing_failure_count = _controller_public_count(
+        "remote_command_file_bridge_agent_task_facing_failure_count"
+    )
+    remote_agent_success_count = _controller_public_count(
+        "remote_command_file_bridge_agent_success_count"
+    )
+    remote_agent_failure_count = _controller_public_count(
+        "remote_command_file_bridge_agent_failure_count"
+    )
+    legacy_satisfied_without_task_facing_success_counters = bool(
+        remote_agent_operation_trace_satisfied_raw_field
+        and remote_agent_task_facing_success_count == 0
+        and remote_agent_task_facing_failure_count == 0
+        and remote_agent_success_count > 0
+        and remote_agent_failure_count == 0
+        and remote_agent_task_facing_operation_count > 0
+        and remote_agent_operation_trace_status == "agent_operation_trace_recorded"
+    )
+    remote_agent_operation_trace_satisfied_raw = bool(
+        remote_agent_operation_trace_satisfied_raw_field
+        and (
+            remote_agent_task_facing_success_count > 0
+            or legacy_satisfied_without_task_facing_success_counters
+        )
+    )
+    orchestrated_driver_counts_as_product_mode = bool(
+        orchestrated_driver_lifecycle_satisfied
+        and (
+            not remote_agent_operation_trace_required_raw
+            or (
+                controller_counters.get(
+                    "remote_command_file_bridge_agent_command_instrumented"
+                )
+                is True
+                and remote_agent_operation_trace_satisfied_raw
+            )
+        )
+    )
+    remote_agent_operation_trace_required = bool(
+        remote_agent_operation_trace_required_raw
+        and not orchestrated_driver_counts_as_product_mode
+    )
+    remote_agent_operation_trace_satisfied = remote_agent_operation_trace_satisfied_raw
     remote_agent_operation_trace_missing = bool(
         remote_agent_operation_trace_required
         and not remote_agent_operation_trace_satisfied
@@ -3084,6 +3134,30 @@ def build_skillsbench_benchflow_result_benchmark_run(
         remote_agent_operation_trace_missing
         and remote_agent_operation_trace_status
         == "agent_operation_trace_present_no_requests"
+    )
+    remote_agent_operation_trace_recorded_no_success = bool(
+        remote_agent_operation_trace_missing
+        and remote_agent_operation_trace_status
+        == "agent_operation_trace_recorded_no_success"
+    )
+    remote_agent_operation_failure_category = "bridge_operation_failed"
+    failure_category_counts = controller_counters.get(
+        "remote_command_file_bridge_agent_failure_category_counts"
+    )
+    if isinstance(failure_category_counts, dict):
+        for category_key, category_count in sorted(failure_category_counts.items()):
+            if (
+                isinstance(category_key, str)
+                and category_key
+                and isinstance(category_count, int)
+                and not isinstance(category_count, bool)
+                and category_count > 0
+            ):
+                remote_agent_operation_failure_category = category_key[:80]
+                break
+    remote_agent_operation_failure_label = (
+        "skillsbench_remote_bridge_agent_operation_failed_"
+        f"{remote_agent_operation_failure_category}"
     )
     agent_bridge_lifecycle_read_count = _controller_public_count(
         "remote_command_file_bridge_agent_loopx_state_read_count"
@@ -3209,6 +3283,11 @@ def build_skillsbench_benchflow_result_benchmark_run(
         "missing_reason": (
             "remote_command_file_bridge_agent_no_requests"
             if remote_agent_operation_trace_no_requests
+            else (
+                "remote_command_file_bridge_agent_operation_failed_"
+                f"{remote_agent_operation_failure_category}"
+            )
+            if remote_agent_operation_trace_recorded_no_success
             else "remote_command_file_bridge_agent_operation_trace_missing"
             if remote_agent_operation_trace_missing
             else "missing_case_local_loopx_closeout"
@@ -3243,13 +3322,30 @@ def build_skillsbench_benchflow_result_benchmark_run(
     agent_bridge_task_facing_operation_count = _controller_public_count(
         "remote_command_file_bridge_agent_task_facing_operation_count"
     )
+    agent_bridge_success_count = _controller_public_count(
+        "remote_command_file_bridge_agent_success_count"
+    )
+    agent_bridge_failure_count = _controller_public_count(
+        "remote_command_file_bridge_agent_failure_count"
+    )
+    agent_bridge_task_facing_success_count = _controller_public_count(
+        "remote_command_file_bridge_agent_task_facing_success_count"
+    )
+    agent_bridge_task_facing_failure_count = _controller_public_count(
+        "remote_command_file_bridge_agent_task_facing_failure_count"
+    )
+    legacy_recorded_without_success_counters = bool(
+        agent_bridge_success_count == 0
+        and agent_bridge_failure_count == 0
+        and agent_bridge_task_facing_success_count == 0
+        and agent_bridge_task_facing_failure_count == 0
+        and remote_agent_operation_trace_status == "agent_operation_trace_recorded"
+        and agent_bridge_task_facing_operation_count > 0
+    )
     agent_bridge_activity_observed = bool(
-        _controller_public_count("remote_command_file_bridge_agent_request_count") > 0
-        or _controller_public_count(
-            "remote_command_file_bridge_agent_operation_trace_count"
-        )
-        > 0
+        agent_bridge_task_facing_success_count > 0
         or remote_agent_operation_trace_satisfied
+        or legacy_recorded_without_success_counters
     )
     declared_done_round_count = _controller_public_count("declared_done_round")
     trajectory_tool_calls = _trajectory_public_count("tool_call_count")
@@ -3680,7 +3776,11 @@ def build_skillsbench_benchflow_result_benchmark_run(
             "official_benchflow_result_json_plus_loopx_controller_trace"
         )
     if product_mode_lifecycle_missing:
-        label = "skillsbench_product_mode_lifecycle_missing"
+        label = (
+            remote_agent_operation_failure_label
+            if remote_agent_operation_trace_recorded_no_success
+            else "skillsbench_product_mode_lifecycle_missing"
+        )
         contract_official_score_comparable_to_native_codex = False
         contract_official_score_comparable_to_loopx_treatment = False
         product_mode_lifecycle_contract["countable_treatment"] = False
@@ -3706,10 +3806,18 @@ def build_skillsbench_benchflow_result_benchmark_run(
                 runner_failure["failure_class"] = label
         for item in (
             label,
+            "skillsbench_product_mode_lifecycle_missing"
+            if label != "skillsbench_product_mode_lifecycle_missing"
+            else "",
+            "skillsbench_runner_setup_error"
+            if remote_agent_operation_trace_recorded_no_success
+            else "",
             "skillsbench_product_mode_uncountable_treatment",
             "skillsbench_case_local_loopx_state_not_observed",
             "skillsbench_remote_bridge_agent_no_requests"
             if remote_agent_operation_trace_no_requests
+            else remote_agent_operation_failure_label
+            if remote_agent_operation_trace_recorded_no_success
             else "skillsbench_remote_bridge_agent_operation_trace_missing"
             if remote_agent_operation_trace_missing
             else "",
@@ -4261,6 +4369,21 @@ def build_skillsbench_benchflow_result_benchmark_run(
             "remote_command_file_bridge_agent_task_facing_operation_count": (
                 controller_counters.get(
                     "remote_command_file_bridge_agent_task_facing_operation_count", 0
+                )
+            ),
+            "remote_command_file_bridge_agent_task_facing_success_count": (
+                controller_counters.get(
+                    "remote_command_file_bridge_agent_task_facing_success_count", 0
+                )
+            ),
+            "remote_command_file_bridge_agent_task_facing_failure_count": (
+                controller_counters.get(
+                    "remote_command_file_bridge_agent_task_facing_failure_count", 0
+                )
+            ),
+            "remote_command_file_bridge_agent_failure_category_counts": (
+                controller_counters.get(
+                    "remote_command_file_bridge_agent_failure_category_counts", {}
                 )
             ),
             "remote_command_file_bridge_agent_probe_operation_count": (

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -31,6 +31,10 @@ from loopx.benchmark_adapters.skillsbench_remote_bridge import (
 )
 
 
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REVERSE_CHANNEL_BRIDGE_SCRIPT = (
+    REPO_ROOT / "scripts" / "skillsbench_reverse_channel_bridge.py"
+)
 SKILLSBENCH_LOCAL_ACP_RELAY_SCHEMA_VERSION = "skillsbench_local_acp_relay_v0"
 SKILLSBENCH_LOCAL_ACP_RELAY_PROBE_SCHEMA_VERSION = (
     "skillsbench_local_acp_relay_probe_v0"
@@ -69,6 +73,9 @@ def _prompt_requires_bridge_first_action(prompt: str) -> bool:
     lowered = text.lower()
     required_markers = (
         SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_PREFLIGHT_MARKER.lower(),
+        "mandatory product-mode solver checkpoint",
+        "mandatory product-mode closeout checkpoint",
+        "must start with either a task-facing sandbox bridge operation",
         "your first tool action should be a shell",
         "your first agent action must be a shell/tool call",
         "your first agent action must be a task-facing shell/tool call",
@@ -158,6 +165,41 @@ def _public_bridge_operations(value: Any) -> list[dict[str, Any]]:
     return operations
 
 
+def _bridge_summary_has_inflight_operation(path: Path | None) -> bool:
+    if path is None or not path.exists():
+        return False
+    starts = 0
+    completions = 0
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return False
+    for line in lines:
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(record, dict):
+            continue
+        phase = str(record.get("record_phase") or "").strip().lower()
+        if phase == "complete" and not _bridge_operation_record_interrupted(record):
+            completions += 1
+        elif phase == "start" or record.get("operation_observed") is True:
+            starts += 1
+    return starts > completions
+
+
+def _bridge_operation_record_interrupted(record: dict[str, Any]) -> bool:
+    rc = record.get("returncode")
+    if isinstance(rc, int) and not isinstance(rc, bool) and rc < 0:
+        return True
+    category = str(record.get("failure_category") or "")
+    return record.get("interrupted") is True or category in {
+        "bridge_operation_interrupted",
+        "bridge_controller_interrupted",
+    }
+
+
 def _codex_exec_failure_category(
     *,
     returncode: int | None,
@@ -189,13 +231,6 @@ def _codex_exec_failure_category(
         )
     ):
         return "codex_model_unavailable"
-    if (
-        "connectionrefusederror" in text
-        or "connection refused" in text
-        or "failed to establish a new connection" in text
-        or ("create_connection" in text and "socket" in text)
-    ):
-        return "codex_reverse_channel_unavailable"
     if any(
         token in text
         for token in (
@@ -203,6 +238,8 @@ def _codex_exec_failure_category(
             "stream disconnected before completion",
             "error sending request",
             "request error",
+            "connection refused",
+            "connection timed out",
         )
     ) and any(
         token in text
@@ -214,6 +251,13 @@ def _codex_exec_failure_category(
         )
     ):
         return "codex_network_or_api_unreachable"
+    if (
+        "connectionrefusederror" in text
+        or "connection refused" in text
+        or "failed to establish a new connection" in text
+        or ("create_connection" in text and "socket" in text)
+    ):
+        return "codex_reverse_channel_unavailable"
     if "hit your usage limit" in text or "usage limit" in text:
         return "codex_usage_limit"
     if "codex_exec_first_action_timeout" in text:
@@ -243,6 +287,20 @@ def _codex_exec_failure_category(
     if returncode is not None:
         return "codex_exec_exit_nonzero"
     return "codex_exec_failed"
+
+
+RECOVERABLE_CODEX_TURN_FAILURE_CATEGORIES = {
+    "codex_exec_first_action_timeout",
+    "codex_exec_bridge_idle_timeout",
+}
+
+
+def _recoverable_codex_turn_failure_message(category: str) -> str:
+    return (
+        "LoopX recoverable Codex turn failure: "
+        f"{category}. Continue with the next scheduled product-mode round; "
+        "raw task text, logs, and trajectory material were not recorded."
+    )
 
 
 def _write_process_stdin_async(
@@ -455,6 +513,7 @@ class SkillsBenchLocalAcpRelay:
             stderr_path = tmp_path / "codex-stderr.txt"
             prompt_for_codex = prompt_text
             cwd = _safe_cwd(session.get("cwd"), default=os.getcwd())
+            bridge_server_proc: subprocess.Popen[str] | None = None
             if self._config.remote_command_file_bridge_command:
                 if _is_bridge_action_preflight_prompt(prompt_text):
                     bridge_probe = self._reverse_channel_json_preflight_probe()
@@ -471,6 +530,13 @@ class SkillsBenchLocalAcpRelay:
                     self._config.remote_command_file_bridge_agent_command
                     or self._config.remote_command_file_bridge_command
                     or ""
+                )
+                agent_bridge_command, bridge_server_proc = (
+                    self._start_json_file_bridge_server(
+                        tmp_path=tmp_path,
+                        local_cwd=local_cwd,
+                        bridge_command=agent_bridge_command,
+                    )
                 )
                 instrumented_bridge = self._write_instrumented_bridge_wrapper(
                     tmp_path=tmp_path,
@@ -544,6 +610,7 @@ class SkillsBenchLocalAcpRelay:
                         0.0,
                         float(self._config.bridge_idle_timeout_sec or 0.0),
                     )
+                    bridge_activity_seen = False
                     last_bridge_summary_size = 0
                     last_bridge_activity_at = time.monotonic()
                     next_heartbeat = (
@@ -562,6 +629,7 @@ class SkillsBenchLocalAcpRelay:
                             if current_bridge_summary_size > last_bridge_summary_size:
                                 last_bridge_summary_size = current_bridge_summary_size
                                 last_bridge_activity_at = now
+                                bridge_activity_seen = True
                                 first_action_seen = True
                             elif (
                                 not first_action_seen
@@ -574,6 +642,10 @@ class SkillsBenchLocalAcpRelay:
                             and now >= first_action_deadline
                         ):
                             self._terminate_codex_process(proc)
+                            if bridge_summary_path is not None:
+                                self._publish_remote_bridge_agent_operations_trace(
+                                    bridge_summary_path=bridge_summary_path,
+                                )
                             self._publish_codex_exec_failure_trace(
                                 stage="first_action_timeout",
                                 returncode=124,
@@ -587,11 +659,16 @@ class SkillsBenchLocalAcpRelay:
                                 ),
                                 failure_category="codex_exec_first_action_timeout",
                             )
-                            raise TimeoutError("local codex first action timeout")
+                            return _recoverable_codex_turn_failure_message(
+                                "codex_exec_first_action_timeout"
+                            )
                         if (
-                            first_action_seen
+                            bridge_activity_seen
                             and bridge_summary_path is not None
                             and bridge_idle_timeout_sec > 0
+                            and not _bridge_summary_has_inflight_operation(
+                                bridge_summary_path
+                            )
                             and now - last_bridge_activity_at >= bridge_idle_timeout_sec
                         ):
                             self._terminate_codex_process(proc)
@@ -611,7 +688,9 @@ class SkillsBenchLocalAcpRelay:
                                 ),
                                 failure_category="codex_exec_bridge_idle_timeout",
                             )
-                            raise TimeoutError("local codex bridge idle timeout")
+                            return _recoverable_codex_turn_failure_message(
+                                "codex_exec_bridge_idle_timeout"
+                            )
                         if now >= deadline:
                             self._terminate_codex_process(proc)
                             raise subprocess.TimeoutExpired(
@@ -657,7 +736,9 @@ class SkillsBenchLocalAcpRelay:
                         output_path.stat().st_size if output_path.exists() else 0
                     ),
                 )
-                raise TimeoutError from exc
+                return _recoverable_codex_turn_failure_message("codex_exec_timeout")
+            finally:
+                self._terminate_bridge_server_process(bridge_server_proc)
             stdout_text = (
                 stdout_path.read_text(encoding="utf-8", errors="replace")
                 if stdout_path.exists()
@@ -684,6 +765,12 @@ class SkillsBenchLocalAcpRelay:
                     ),
                     failure_category=category,
                 )
+                if bridge_summary_path is not None:
+                    self._publish_remote_bridge_agent_operations_trace(
+                        bridge_summary_path=bridge_summary_path,
+                    )
+                if category in RECOVERABLE_CODEX_TURN_FAILURE_CATEGORIES:
+                    return _recoverable_codex_turn_failure_message(category)
                 raise RuntimeError(f"local codex execution failed: {category}")
             try:
                 response = output_path.read_text(encoding="utf-8").strip()
@@ -735,6 +822,80 @@ class SkillsBenchLocalAcpRelay:
             proc.wait(timeout=grace_sec)
         except subprocess.TimeoutExpired:
             pass
+
+    def _terminate_bridge_server_process(
+        self,
+        proc: subprocess.Popen[str] | None,
+        *,
+        grace_sec: float = 2.0,
+    ) -> None:
+        if proc is None or proc.poll() is not None:
+            return
+        try:
+            proc.terminate()
+        except (ProcessLookupError, PermissionError, OSError):
+            return
+        try:
+            proc.wait(timeout=grace_sec)
+            return
+        except subprocess.TimeoutExpired:
+            pass
+        try:
+            proc.kill()
+        except (ProcessLookupError, PermissionError, OSError):
+            return
+        try:
+            proc.wait(timeout=grace_sec)
+        except subprocess.TimeoutExpired:
+            pass
+
+    def _start_json_file_bridge_server(
+        self,
+        *,
+        tmp_path: Path,
+        local_cwd: Path,
+        bridge_command: str,
+    ) -> tuple[str, subprocess.Popen[str] | None]:
+        if not bridge_command or not REVERSE_CHANNEL_BRIDGE_SCRIPT.exists():
+            return bridge_command, None
+        queue_dir = local_cwd / "loopx-reverse-channel-queue"
+        client_path = local_cwd / "loopx-json-file-bridge"
+        subprocess.run(
+            [
+                sys.executable,
+                str(REVERSE_CHANNEL_BRIDGE_SCRIPT),
+                "write-client",
+                "--kind",
+                "json-file",
+                "--queue-dir",
+                str(queue_dir),
+                "--output",
+                str(client_path),
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=True,
+        )
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                str(REVERSE_CHANNEL_BRIDGE_SCRIPT),
+                "serve-json-file",
+                "--queue-dir",
+                str(queue_dir),
+                "--bridge-command",
+                bridge_command,
+                "--timeout-sec",
+                str(max(1.0, float(self._config.remote_command_file_bridge_timeout_sec))),
+            ],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            cwd=str(tmp_path),
+        )
+        return shlex.quote(str(client_path)), proc
 
     def _consume_remote_bridge_for_solver(self) -> dict[str, Any]:
         return run_skillsbench_remote_command_file_bridge_probe(
@@ -1167,6 +1328,20 @@ complete_record["returncode"] = int(proc.returncode)
 complete_record["success"] = proc.returncode == 0
 complete_record["stdout_bytes"] = len((proc.stdout or "").encode("utf-8"))
 complete_record["stderr_bytes"] = len((proc.stderr or "").encode("utf-8"))
+if proc.returncode != 0:
+    stderr_text = proc.stderr or ""
+    if int(proc.returncode) < 0:
+        complete_record["failure_category"] = "bridge_operation_interrupted"
+        complete_record["interrupted"] = True
+        complete_record["controller_interrupted"] = True
+    elif "PermissionError" in stderr_text or "Operation not permitted" in stderr_text:
+        complete_record["failure_category"] = "bridge_client_permission_error"
+    elif "No such file or directory" in stderr_text:
+        complete_record["failure_category"] = "bridge_command_not_found"
+    elif proc.returncode == 255 and BRIDGE_COMMAND.lstrip().startswith("ssh "):
+        complete_record["failure_category"] = "bridge_ssh_unavailable"
+    else:
+        complete_record["failure_category"] = "bridge_command_failed"
 append_record(complete_record)
 sys.stdout.write(proc.stdout)
 sys.stderr.write(proc.stderr)
@@ -1187,6 +1362,7 @@ raise SystemExit(proc.returncode)
         loopx_subcommand_counts: dict[str, int] = {}
         successful_loopx_subcommand_counts: dict[str, int] = {}
         returncode_counts: dict[str, int] = {}
+        failure_category_counts: dict[str, int] = {}
         request_count = 0
         success_count = 0
         failure_count = 0
@@ -1194,8 +1370,17 @@ raise SystemExit(proc.returncode)
         state_read_count = 0
         state_write_count = 0
         task_facing_operation_count = 0
+        preflight_success_count = 0
+        preflight_failure_count = 0
+        task_facing_success_count = 0
+        task_facing_failure_count = 0
         probe_operation_count = 0
+        inflight_operation_count = 0
+        interrupted_operation_count = 0
+        task_facing_interrupted_count = 0
         raw_material_recorded = False
+        starts = 0
+        completions = 0
         if bridge_summary_path.exists():
             for line in bridge_summary_path.read_text(
                 encoding="utf-8",
@@ -1213,6 +1398,11 @@ raise SystemExit(proc.returncode)
                 counts_as_completion = phase == "complete" or (
                     not phase and ("returncode" in record or "success" in record)
                 )
+                interrupted_completion = counts_as_completion and _bridge_operation_record_interrupted(record)
+                if phase == "complete" and not interrupted_completion:
+                    completions += 1
+                elif phase == "start" or record.get("operation_observed") is True:
+                    starts += 1
                 if counts_as_request:
                     request_count += 1
                     operation_counts[operation] = (
@@ -1224,19 +1414,56 @@ raise SystemExit(proc.returncode)
                         returncode_counts[str(rc)] = (
                             returncode_counts.get(str(rc), 0) + 1
                         )
-                        if rc == 0:
+                        if interrupted_completion:
+                            interrupted_operation_count += 1
+                            if record.get("task_facing_operation") is True:
+                                task_facing_interrupted_count += 1
+                        elif rc == 0:
                             success_count += 1
+                            if operation == "preflight":
+                                preflight_success_count += 1
+                            if record.get("task_facing_operation") is True:
+                                task_facing_success_count += 1
                         else:
                             failure_count += 1
+                            if operation == "preflight":
+                                preflight_failure_count += 1
+                            if record.get("task_facing_operation") is True:
+                                task_facing_failure_count += 1
+                            category = str(
+                                record.get("failure_category")
+                                or "bridge_command_failed"
+                            )[:80]
+                            failure_category_counts[category] = (
+                                failure_category_counts.get(category, 0) + 1
+                            )
+                    elif interrupted_completion:
+                        interrupted_operation_count += 1
+                        if record.get("task_facing_operation") is True:
+                            task_facing_interrupted_count += 1
                     elif record.get("success") is True:
                         success_count += 1
+                        if operation == "preflight":
+                            preflight_success_count += 1
+                        if record.get("task_facing_operation") is True:
+                            task_facing_success_count += 1
                         returncode_counts["unknown_success"] = (
                             returncode_counts.get("unknown_success", 0) + 1
                         )
                     elif record.get("success") is False:
                         failure_count += 1
+                        if operation == "preflight":
+                            preflight_failure_count += 1
+                        if record.get("task_facing_operation") is True:
+                            task_facing_failure_count += 1
                         returncode_counts["unknown_failure"] = (
                             returncode_counts.get("unknown_failure", 0) + 1
+                        )
+                        category = str(
+                            record.get("failure_category") or "bridge_command_failed"
+                        )[:80]
+                        failure_category_counts[category] = (
+                            failure_category_counts.get(category, 0) + 1
                         )
                 if counts_as_request and record.get("loopx_cli_call") is True:
                     loopx_cli_call_count += 1
@@ -1276,6 +1503,7 @@ raise SystemExit(proc.returncode)
                         "remote_paths_recorded",
                     )
                 )
+        inflight_operation_count = max(0, starts - completions)
         trace = {
             "schema_version": "skillsbench_host_local_acp_relay_public_trace_v0",
             "ok": True,
@@ -1292,6 +1520,9 @@ raise SystemExit(proc.returncode)
                 "failure_count": failure_count,
                 "operation_counts": dict(sorted(operation_counts.items())),
                 "returncode_counts": dict(sorted(returncode_counts.items())),
+                "failure_category_counts": dict(
+                    sorted(failure_category_counts.items())
+                ),
                 "loopx_cli_call_count": loopx_cli_call_count,
                 "loopx_cli_subcommand_counts": dict(
                     sorted(loopx_subcommand_counts.items())
@@ -1302,7 +1533,14 @@ raise SystemExit(proc.returncode)
                 "loopx_state_read_count": state_read_count,
                 "loopx_state_write_count": state_write_count,
                 "task_facing_operation_count": task_facing_operation_count,
+                "preflight_success_count": preflight_success_count,
+                "preflight_failure_count": preflight_failure_count,
+                "task_facing_success_count": task_facing_success_count,
+                "task_facing_failure_count": task_facing_failure_count,
                 "probe_operation_count": probe_operation_count,
+                "inflight_operation_count": inflight_operation_count,
+                "interrupted_operation_count": interrupted_operation_count,
+                "task_facing_interrupted_count": task_facing_interrupted_count,
                 "raw_material_recorded": raw_material_recorded,
             },
             "boundary": {

--- a/loopx/cli_commands/status.py
+++ b/loopx/cli_commands/status.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 from ..contract import check_contract, render_contract_markdown
 from ..diagnose import collect_diagnosis, render_diagnosis_markdown
@@ -10,6 +11,7 @@ from ..handoff_budget import build_handoff_interface_budget
 from ..quota import build_quota_should_run
 from ..review_packet import build_review_packet, render_review_packet_markdown
 from ..status import collect_status, render_status_markdown
+from ..todo_contract import normalize_todo_claimed_by
 
 
 PrintPayload = Callable[
@@ -124,6 +126,10 @@ def register_status_commands(
         dest="review_packet_format",
         choices=["markdown", "json"],
         help="Output format for review-packet. This mirrors the global --format flag and may appear after the subcommand.",
+    )
+    review_packet_parser.add_argument(
+        "--agent-id",
+        help="Registered agent id for adding read-only agent-member status to the review packet.",
     )
     review_packet_parser.add_argument("--limit", type=int, default=5)
 
@@ -249,6 +255,149 @@ def handle_status_command(
     return 0 if payload.get("ok") else 1
 
 
+def _compact_member_text(value: Any, *, limit: int = 180) -> str | None:
+    if isinstance(value, list):
+        compact = "; ".join(str(item).strip() for item in value if str(item).strip())
+    elif isinstance(value, str):
+        compact = value
+    else:
+        return None
+    compact = " ".join(compact.split())
+    if not compact or any(char in compact for char in "<>"):
+        return None
+    if len(compact) > limit:
+        compact = compact[: limit - 1].rstrip() + "…"
+    return compact
+
+
+def _agent_profile_for(coordination: dict[str, Any], agent_id: str) -> dict[str, Any]:
+    profiles = coordination.get("agent_profiles")
+    if not isinstance(profiles, dict):
+        return {}
+    profile = profiles.get(agent_id)
+    return profile if isinstance(profile, dict) else {}
+
+
+def _profile_scope_summary(profile: dict[str, Any]) -> str | None:
+    for key in (
+        "scope_summary",
+        "default_scope",
+        "scope",
+        "scope_summaries",
+        "default_scopes",
+        "scopes",
+    ):
+        summary = _compact_member_text(profile.get(key))
+        if summary:
+            return summary
+    return None
+
+
+def _profile_worktree_policy(profile: dict[str, Any]) -> tuple[str | None, bool | None]:
+    policy = profile.get("worktree_policy")
+    if isinstance(policy, dict):
+        mode = _compact_member_text(policy.get("mode"), limit=80)
+        requires = policy.get("requires_independent_worktree")
+        return mode, requires if isinstance(requires, bool) else None
+    return _compact_member_text(policy, limit=80), None
+
+
+def _review_handoff_agent(
+    *,
+    coordination: dict[str, Any],
+    profile: dict[str, Any],
+    role: str | None,
+) -> str | None:
+    review_policy = profile.get("review_policy")
+    if isinstance(review_policy, dict):
+        handoff_agent = normalize_todo_claimed_by(review_policy.get("handoff_agent"))
+        if handoff_agent:
+            return handoff_agent
+    if role == "side-agent":
+        return normalize_todo_claimed_by(coordination.get("side_agent_handoff_agent"))
+    return None
+
+
+def _current_claims_for_agent(item: dict[str, Any], *, agent_id: str) -> list[str]:
+    claims: list[str] = []
+    todo_sources: list[Any] = [item.get("agent_todos")]
+    project_asset = item.get("project_asset")
+    if isinstance(project_asset, dict):
+        todo_sources.append(project_asset.get("agent_todos"))
+    for todos in todo_sources:
+        if not isinstance(todos, dict):
+            continue
+        raw_items = todos.get("items") if isinstance(todos.get("items"), list) else []
+        if not raw_items and isinstance(todos.get("first_open_items"), list):
+            raw_items = todos.get("first_open_items") or []
+        for raw_item in raw_items:
+            if not isinstance(raw_item, dict) or raw_item.get("done"):
+                continue
+            if normalize_todo_claimed_by(raw_item.get("claimed_by")) != agent_id:
+                continue
+            todo_id = str(raw_item.get("todo_id") or "").strip()
+            if todo_id and todo_id not in claims:
+                claims.append(todo_id)
+    return claims
+
+
+def _build_agent_member_projection(
+    item: dict[str, Any],
+    *,
+    guard: dict[str, Any],
+    agent_id: str,
+) -> dict[str, Any] | None:
+    identity = guard.get("agent_identity")
+    if not isinstance(identity, dict):
+        return None
+    coordination = item.get("coordination") if isinstance(item.get("coordination"), dict) else {}
+    profile = _agent_profile_for(coordination, agent_id)
+    role = _compact_member_text(profile.get("role"), limit=80) or _compact_member_text(
+        identity.get("role"),
+        limit=80,
+    )
+    worktree_policy, requires_independent_worktree = _profile_worktree_policy(profile)
+    claims = _current_claims_for_agent(item, agent_id=agent_id)
+    member: dict[str, Any] = {
+        "schema_version": "agent_member_v0",
+        "agent_id": agent_id,
+        "role": role,
+        "primary_agent": normalize_todo_claimed_by(identity.get("primary_agent")),
+        "profile_source": "registry.coordination.agent_profiles" if profile else "quota.agent_identity",
+        "authority_source": "registry+quota_should_run+todo_projection",
+        "role_is_advisory": True,
+        "current_claims": claims[:10],
+        "current_claim_count": len(claims),
+        "lease_projection": {
+            "source": "todo.claimed_by",
+            "hard_lease_available": False,
+        },
+    }
+    scope_summary = _profile_scope_summary(profile)
+    if scope_summary:
+        member["scope_summary"] = scope_summary
+    if worktree_policy:
+        member["worktree_policy"] = worktree_policy
+    if requires_independent_worktree is not None:
+        member["requires_independent_worktree"] = requires_independent_worktree
+    handoff_agent = _review_handoff_agent(
+        coordination=coordination,
+        profile=profile,
+        role=role,
+    )
+    if handoff_agent:
+        member["handoff_agent"] = handoff_agent
+        member["review_handoff_status"] = "handoff_agent_configured"
+    else:
+        member["review_handoff_status"] = "no_agent_specific_handoff"
+    review_policy = profile.get("review_policy")
+    if isinstance(review_policy, dict):
+        can_self_merge = review_policy.get("can_self_merge")
+        if isinstance(can_self_merge, (bool, str)):
+            member["can_self_merge"] = can_self_merge
+    return member
+
+
 def attach_agent_lane_next_actions(payload: dict[str, object], *, agent_id: str) -> dict[str, object]:
     safe_agent_id = str(agent_id or "").strip()
     if not safe_agent_id:
@@ -262,6 +411,7 @@ def attach_agent_lane_next_actions(payload: dict[str, object], *, agent_id: str)
     attached = 0
     frontier_attached = 0
     hint_attached = 0
+    member_attached = 0
     for item in items:
         if not isinstance(item, dict):
             continue
@@ -295,16 +445,36 @@ def attach_agent_lane_next_actions(payload: dict[str, object], *, agent_id: str)
                 project_asset["agent_lane_frontier_hint"] = frontier_hint
             hint_attached += 1
             changed = True
+        agent_member = _build_agent_member_projection(
+            item,
+            guard=guard,
+            agent_id=safe_agent_id,
+        )
+        if isinstance(agent_member, dict):
+            item["agent_member"] = agent_member
+            if isinstance(project_asset, dict):
+                project_asset["agent_member"] = agent_member
+            member_attached += 1
+            changed = True
         if not changed:
             continue
-    if attached or frontier_attached or hint_attached:
+    if attached or frontier_attached or hint_attached or member_attached:
         payload["agent_lane_next_action_projection"] = {
             "schema_version": "agent_lane_next_action_projection_v0",
             "agent_id": safe_agent_id,
             "attached_count": attached,
             "frontier_attached_count": frontier_attached,
             "frontier_hint_attached_count": hint_attached,
+            "agent_member_attached_count": member_attached,
             "preserves_goal_next_action": True,
+        }
+    if member_attached:
+        payload["agent_member_projection"] = {
+            "schema_version": "agent_member_projection_v0",
+            "agent_id": safe_agent_id,
+            "attached_count": member_attached,
+            "source": "registry+quota_should_run+todo_projection",
+            "projection_is_authoritative": False,
         }
     return payload
 
@@ -369,6 +539,8 @@ def handle_review_packet_command(
             limit=max(0, args.limit),
             include_task_graph=not args.handoff_only,
         )
+        if args.agent_id:
+            attach_agent_lane_next_actions(status_payload, agent_id=args.agent_id)
         payload = build_review_packet(
             status_payload,
             goal_id=args.goal_id,

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -117,6 +117,22 @@ def register_todo_command(subparsers: argparse._SubParsersAction) -> None:
         ),
     )
     todo_parser.add_argument(
+        "--decision-scope",
+        help=(
+            "For user_gate add/update, declare the concrete decision as "
+            "kind:granularity:scope_key, for example direction:action:benchmark_target."
+        ),
+    )
+    todo_parser.add_argument(
+        "--required-decision-scope",
+        dest="required_decision_scopes",
+        action="append",
+        help=(
+            "For agent todo add/update, declare a required decision scope as "
+            "kind:granularity:scope_key. Repeat for multiple scopes."
+        ),
+    )
+    todo_parser.add_argument(
         "--claimed-by",
         help=(
             "For todo add/claim/update/complete, soft-claim the todo for a registered "
@@ -174,6 +190,14 @@ def register_todo_command(subparsers: argparse._SubParsersAction) -> None:
         help=(
             "For agent continuous_monitor add/update, declare the next due ISO "
             "timestamp; due monitor scheduling is based on this field."
+        ),
+    )
+    todo_parser.add_argument(
+        "--expires-at",
+        dest="expires_at",
+        help=(
+            "For agent continuous_monitor add/update, declare the ISO timestamp "
+            "after which the monitor is no longer due and must not catch up."
         ),
     )
     todo_parser.add_argument(
@@ -306,6 +330,8 @@ def handle_todo_command(
                     ("--required-write-scope", args.required_write_scopes),
                     ("--required-capability", args.required_capabilities),
                     ("--target-capability", args.target_capabilities),
+                    ("--decision-scope", args.decision_scope),
+                    ("--required-decision-scope", args.required_decision_scopes),
                     ("--claimed-by", args.claimed_by),
                     ("--blocks-agent", args.blocks_agent),
                     ("--global-gate", args.global_gate),
@@ -314,6 +340,7 @@ def handle_todo_command(
                     ("--monitor-target-key", args.monitor_target_key),
                     ("--cadence", args.cadence),
                     ("--next-due-at", args.next_due_at),
+                    ("--expires-at", args.expires_at),
                     ("--clear-claim", args.clear_claim),
                     ("--no-follow-up", args.no_follow_up),
                     ("--next-agent-todo", args.next_agent_todo),
@@ -369,6 +396,8 @@ def handle_todo_command(
                 required_write_scopes=args.required_write_scopes,
                 required_capabilities=args.required_capabilities,
                 target_capabilities=args.target_capabilities,
+                decision_scope=args.decision_scope,
+                required_decision_scopes=args.required_decision_scopes,
                 claimed_by=args.claimed_by,
                 blocks_agent=args.blocks_agent,
                 global_gate=bool(args.global_gate),
@@ -379,6 +408,7 @@ def handle_todo_command(
                     "target_key": args.monitor_target_key,
                     "cadence": args.cadence,
                     "next_due_at": args.next_due_at,
+                    "expires_at": args.expires_at,
                 },
                 project=Path(args.project).expanduser() if args.project else None,
                 state_file=Path(args.state_file).expanduser() if args.state_file else None,
@@ -404,6 +434,8 @@ def handle_todo_command(
                     ("--required-write-scope", args.required_write_scopes),
                     ("--required-capability", args.required_capabilities),
                     ("--target-capability", args.target_capabilities),
+                    ("--decision-scope", args.decision_scope),
+                    ("--required-decision-scope", args.required_decision_scopes),
                     ("--blocks-agent", args.blocks_agent),
                     ("--global-gate", args.global_gate),
                     ("--unblocks-todo-id", args.unblocks_todo_id),
@@ -411,6 +443,7 @@ def handle_todo_command(
                     ("--monitor-target-key", args.monitor_target_key),
                     ("--cadence", args.cadence),
                     ("--next-due-at", args.next_due_at),
+                    ("--expires-at", args.expires_at),
                     ("--no-follow-up", args.no_follow_up),
                     ("--next-agent-todo", args.next_agent_todo),
                     ("--next-user-todo", args.next_user_todo),
@@ -456,6 +489,8 @@ def handle_todo_command(
                 args.required_write_scopes,
                 args.required_capabilities,
                 args.target_capabilities,
+                args.decision_scope,
+                args.required_decision_scopes,
                 args.claimed_by,
                 args.blocks_agent,
                 args.global_gate,
@@ -465,9 +500,10 @@ def handle_todo_command(
                 args.monitor_target_key,
                 args.cadence,
                 args.next_due_at,
+                args.expires_at,
                 args.clear_claim,
             ]):
-                raise ValueError("todo update requires at least one of --text, --status, --note, --evidence, --reason, --task-class, --action-kind, --required-write-scope, --required-capability, --target-capability, --claimed-by, --blocks-agent, --global-gate, --unblocks-todo-id, --resume-when, --monitor-target-key, --cadence, --next-due-at, --no-follow-up, or --clear-claim")
+                raise ValueError("todo update requires at least one of --text, --status, --note, --evidence, --reason, --task-class, --action-kind, --required-write-scope, --required-capability, --target-capability, --decision-scope, --required-decision-scope, --claimed-by, --blocks-agent, --global-gate, --unblocks-todo-id, --resume-when, --monitor-target-key, --cadence, --next-due-at, --expires-at, --no-follow-up, or --clear-claim")
             if args.no_follow_up and not (args.note or args.reason or args.evidence):
                 raise ValueError("--no-follow-up requires --note, --reason, or --evidence")
             if args.followups:
@@ -491,6 +527,8 @@ def handle_todo_command(
                 required_write_scopes=args.required_write_scopes,
                 required_capabilities=args.required_capabilities,
                 target_capabilities=args.target_capabilities,
+                decision_scope=args.decision_scope,
+                required_decision_scopes=args.required_decision_scopes,
                 claimed_by=args.claimed_by,
                 blocks_agent=args.blocks_agent,
                 global_gate=bool(args.global_gate),
@@ -502,6 +540,7 @@ def handle_todo_command(
                     "target_key": args.monitor_target_key,
                     "cadence": args.cadence,
                     "next_due_at": args.next_due_at,
+                    "expires_at": args.expires_at,
                 },
                 clear_claim=bool(args.clear_claim),
                 project=Path(args.project).expanduser() if args.project else None,
@@ -515,7 +554,7 @@ def handle_todo_command(
                 raise ValueError("todo complete accepts either --claimed-by or --clear-claim, not both")
             if args.blocks_agent or args.global_gate or args.unblocks_todo_id or args.resume_when:
                 raise ValueError("todo complete does not support --blocks-agent, --global-gate, --unblocks-todo-id, or --resume-when; use todo update before completion or side-agent handoff successor metadata")
-            if args.monitor_target_key or args.cadence or args.next_due_at:
+            if args.monitor_target_key or args.cadence or args.next_due_at or args.expires_at:
                 raise ValueError("todo complete does not support monitor schedule metadata; use todo update before completion")
             if args.no_follow_up and (args.next_agent_todo or args.next_user_todo):
                 raise ValueError("--no-follow-up cannot be combined with successor todos")
@@ -562,7 +601,7 @@ def handle_todo_command(
                 raise ValueError("todo supersede does not support --follow-up; use `todo capture-followups`")
             if args.blocks_agent or args.global_gate or args.unblocks_todo_id or args.resume_when:
                 raise ValueError("todo supersede does not support --blocks-agent, --global-gate, --unblocks-todo-id, or --resume-when; update the source todo first so the successor can inherit dependency metadata")
-            if args.monitor_target_key or args.cadence or args.next_due_at:
+            if args.monitor_target_key or args.cadence or args.next_due_at or args.expires_at:
                 raise ValueError("todo supersede does not support monitor schedule metadata; use todo update before supersede")
             payload = supersede_goal_todo(
                 registry_path=registry_path,
@@ -615,6 +654,8 @@ def handle_todo_command(
                     ("--required-write-scope", args.required_write_scopes),
                     ("--required-capability", args.required_capabilities),
                     ("--target-capability", args.target_capabilities),
+                    ("--decision-scope", args.decision_scope),
+                    ("--required-decision-scope", args.required_decision_scopes),
                     ("--claimed-by", args.claimed_by),
                     ("--blocks-agent", args.blocks_agent),
                     ("--global-gate", args.global_gate),
@@ -623,6 +664,7 @@ def handle_todo_command(
                     ("--monitor-target-key", args.monitor_target_key),
                     ("--cadence", args.cadence),
                     ("--next-due-at", args.next_due_at),
+                    ("--expires-at", args.expires_at),
                     ("--no-follow-up", args.no_follow_up),
                     ("--clear-claim", args.clear_claim),
                     ("--next-agent-todo", args.next_agent_todo),
@@ -664,6 +706,7 @@ def handle_todo_command(
                     ("--status", args.status),
                     ("--note", args.note),
                     ("--reason", args.reason),
+                    ("--decision-scope", args.decision_scope),
                     ("--blocks-agent", args.blocks_agent),
                     ("--global-gate", args.global_gate),
                     ("--unblocks-todo-id", args.unblocks_todo_id),
@@ -671,6 +714,7 @@ def handle_todo_command(
                     ("--monitor-target-key", args.monitor_target_key),
                     ("--cadence", args.cadence),
                     ("--next-due-at", args.next_due_at),
+                    ("--expires-at", args.expires_at),
                     ("--no-follow-up", args.no_follow_up),
                     ("--clear-claim", args.clear_claim),
                     ("--next-agent-todo", args.next_agent_todo),
@@ -707,6 +751,7 @@ def handle_todo_command(
                 required_write_scopes=args.required_write_scopes,
                 required_capabilities=args.required_capabilities,
                 target_capabilities=args.target_capabilities,
+                required_decision_scopes=args.required_decision_scopes,
                 project=Path(args.project).expanduser() if args.project else None,
                 state_file=Path(args.state_file).expanduser() if args.state_file else None,
                 dry_run=bool(args.dry_run),

--- a/loopx/projections/task_graph.py
+++ b/loopx/projections/task_graph.py
@@ -16,6 +16,8 @@ TASK_GRAPH_SOURCE_OF_TRUTH = [
     "run_history",
 ]
 TASK_GRAPH_MAX_USER_GATE_NODES = 2
+TASK_GRAPH_AUDIT_MARKERS = ("audit", "audited")
+TASK_GRAPH_CONTINUATION_MARKERS = ("continuation", "continue", "continuing", "continued")
 
 
 def _task_graph_safe_id(
@@ -176,6 +178,49 @@ def _task_graph_latest_run_node(
             "refs": refs,
         }
     return None
+
+
+def _task_graph_latest_run_lineage_relations(
+    run_node_id: str | None,
+    selected_node_id: str | None,
+    *,
+    goal_latest_runs: list[dict[str, Any]],
+    public_safe_compact_text: Callable[..., str | None],
+) -> list[tuple[str, str]]:
+    if not run_node_id or not selected_node_id:
+        return []
+    for run in goal_latest_runs:
+        if not isinstance(run, dict):
+            continue
+        values = [
+            run.get("classification"),
+            run.get("recommended_action"),
+            run.get("delivery_outcome"),
+            run.get("delivery_batch_scale"),
+        ]
+        text = " ".join(
+            public_safe_compact_text(value, limit=160) or ""
+            for value in values
+        ).lower()
+        if not text.strip():
+            continue
+        relations: list[tuple[str, str]] = []
+        if any(marker in text for marker in TASK_GRAPH_AUDIT_MARKERS):
+            relations.append(
+                (
+                    "audits",
+                    "Compact run-history evidence audits the selected work lane without replacing todo or gate state.",
+                )
+            )
+        if any(marker in text for marker in TASK_GRAPH_CONTINUATION_MARKERS):
+            relations.append(
+                (
+                    "continues",
+                    "Compact run-history evidence records a continuation of the selected work lane.",
+                )
+            )
+        return relations
+    return []
 
 
 def _task_graph_visible_user_gate_items(
@@ -464,6 +509,24 @@ def build_task_graph_projection(
         reason="Latest compact run-history evidence validates or contextualizes the selected work.",
         refs=refs_by_node_id.get(run_node_id or ""),
     )
+    for relation, reason in _task_graph_latest_run_lineage_relations(
+        run_node_id,
+        selected_node_id,
+        goal_latest_runs=latest_runs,
+        public_safe_compact_text=public_safe_compact_text,
+    ):
+        add_edge(
+            edge_id=_task_graph_safe_id(
+                f"edge_{relation}",
+                f"{run_node_id}:{selected_node_id}",
+                public_safe_compact_text=public_safe_compact_text,
+            ),
+            from_node_id=run_node_id,
+            to_node_id=selected_node_id,
+            relation=relation,
+            reason=reason,
+            refs=refs_by_node_id.get(run_node_id or ""),
+        )
 
     replan = (
         item.get("autonomous_replan_obligation")

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -50,7 +50,9 @@ from .todo_contract import (
     normalize_target_capabilities,
     normalize_todo_blocks_agent,
     normalize_todo_claimed_by,
+    normalize_todo_decision_scope,
     normalize_todo_id,
+    normalize_todo_required_decision_scopes,
     normalize_todo_resume_when,
     normalize_required_write_scopes,
     normalize_todo_status,
@@ -905,6 +907,8 @@ def _compact_todo_summary_item(item: dict[str, Any], *, text: str | None = None)
         "required_write_scopes",
         "required_capabilities",
         "target_capabilities",
+        "decision_scope",
+        "required_decision_scopes",
         "claimed_by",
         "blocks_agent",
         "unblocks_todo_id",
@@ -915,6 +919,7 @@ def _compact_todo_summary_item(item: dict[str, Any], *, text: str | None = None)
         "target_key",
         "cadence",
         "next_due_at",
+        "expires_at",
         "last_checked_at",
         "result_hash",
         "consecutive_no_change",
@@ -928,6 +933,18 @@ def _compact_todo_summary_item(item: dict[str, Any], *, text: str | None = None)
         compact["required_write_scopes"] = required_write_scopes
     else:
         compact.pop("required_write_scopes", None)
+    decision_scope = normalize_todo_decision_scope(compact.get("decision_scope"))
+    if decision_scope:
+        compact["decision_scope"] = decision_scope
+    else:
+        compact.pop("decision_scope", None)
+    required_decision_scopes = normalize_todo_required_decision_scopes(
+        compact.get("required_decision_scopes")
+    )
+    if required_decision_scopes:
+        compact["required_decision_scopes"] = required_decision_scopes
+    else:
+        compact.pop("required_decision_scopes", None)
     compact["task_class"] = _todo_task_class(compact)
     return compact
 
@@ -2151,7 +2168,78 @@ def _todo_action_scope_tokens(item: dict[str, Any]) -> set[str]:
     return _action_scope_tokens_from_text(text)
 
 
+_DECISION_SCOPE_GRANULARITY_RANK = {
+    "action": 0,
+    "lane": 1,
+    "goal": 2,
+    "project": 3,
+    "global": 4,
+}
+
+
+def _decision_scope_covers(gate_scope: dict[str, Any], required_scope: dict[str, Any]) -> bool:
+    gate = normalize_todo_decision_scope(gate_scope)
+    required = normalize_todo_decision_scope(required_scope)
+    if not gate or not required:
+        return False
+    if gate["kind"] != required["kind"]:
+        return False
+    if gate["scope_key"] not in {required["scope_key"], "*"}:
+        return False
+    return _DECISION_SCOPE_GRANULARITY_RANK[gate["granularity"]] >= _DECISION_SCOPE_GRANULARITY_RANK[
+        required["granularity"]
+    ]
+
+
+def _decision_scope_gate_relation(
+    gate: dict[str, Any],
+    agent_item: dict[str, Any],
+) -> dict[str, Any] | None:
+    gate_scope = normalize_todo_decision_scope(gate.get("decision_scope"))
+    required_scopes = normalize_todo_required_decision_scopes(
+        agent_item.get("required_decision_scopes")
+    )
+    if not gate_scope:
+        return None
+    if not required_scopes:
+        return {
+            "schema_version": "decision_scope_relation_v0",
+            "source": "decision_scope",
+            "state": "independent",
+            "reason": "agent_todo_has_no_required_decision_scopes",
+            "gate_todo_id": normalize_todo_id(gate.get("todo_id")),
+            "agent_todo_id": normalize_todo_id(agent_item.get("todo_id")),
+            "decision_scope": gate_scope,
+            "required_decision_scopes": [],
+        }
+    for required_scope in required_scopes:
+        if _decision_scope_covers(gate_scope, required_scope):
+            return {
+                "schema_version": "decision_scope_relation_v0",
+                "source": "decision_scope",
+                "state": "gate_covers_action",
+                "gate_todo_id": normalize_todo_id(gate.get("todo_id")),
+                "agent_todo_id": normalize_todo_id(agent_item.get("todo_id")),
+                "decision_scope": gate_scope,
+                "matched_required_decision_scope": required_scope,
+                "required_decision_scopes": required_scopes,
+            }
+    return {
+        "schema_version": "decision_scope_relation_v0",
+        "source": "decision_scope",
+        "state": "independent",
+        "gate_todo_id": normalize_todo_id(gate.get("todo_id")),
+        "agent_todo_id": normalize_todo_id(agent_item.get("todo_id")),
+        "decision_scope": gate_scope,
+        "required_decision_scopes": required_scopes,
+    }
+
+
 def _todo_gate_relation(gate: dict[str, Any], agent_item: dict[str, Any]) -> dict[str, Any] | None:
+    decision_scope_relation = _decision_scope_gate_relation(gate, agent_item)
+    if decision_scope_relation:
+        return decision_scope_relation
+
     target_todo_id = normalize_todo_id(gate.get("unblocks_todo_id"))
     if not target_todo_id:
         return None
@@ -2169,7 +2257,7 @@ def _todo_gate_relation(gate: dict[str, Any], agent_item: dict[str, Any]) -> dic
 def _user_gate_blocks_agent_item(gate: dict[str, Any], agent_item: dict[str, Any]) -> bool:
     relation = _todo_gate_relation(gate, agent_item)
     if relation:
-        return relation.get("state") == "gate_targets_todo"
+        return relation.get("state") in {"gate_targets_todo", "gate_covers_action"}
 
     gate_action_tokens = _todo_action_kind_tokens(gate)
     agent_action_tokens = _todo_action_kind_tokens(agent_item)
@@ -4717,10 +4805,24 @@ def _todo_item_next_due_at(item: dict[str, Any]) -> datetime | None:
     return _parse_timestamp(item.get("next_due_at"))
 
 
+def _todo_item_expires_at(item: dict[str, Any]) -> datetime | None:
+    return _parse_timestamp(item.get("expires_at"))
+
+
+def _todo_item_is_expired_monitor(item: dict[str, Any], *, now: datetime | None = None) -> bool:
+    expires_at = _todo_item_expires_at(item)
+    if expires_at is None:
+        return False
+    current_time = now or datetime.now(timezone.utc)
+    return expires_at <= current_time
+
+
 def _todo_item_is_due_monitor(item: dict[str, Any], *, now: datetime | None = None) -> bool:
     if not _todo_item_is_actionable_open(item):
         return False
     if _todo_task_class(item) != TODO_TASK_CLASS_MONITOR:
+        return False
+    if _todo_item_is_expired_monitor(item, now=now):
         return False
     next_due_at = _todo_item_next_due_at(item)
     if next_due_at is None:

--- a/loopx/review_packet.py
+++ b/loopx/review_packet.py
@@ -371,6 +371,41 @@ def todo_texts_from_project_asset(item: dict[str, Any] | None, key: str, *, limi
     return open_todo_texts(item.get(key), limit=limit, rank_for_handoff=rank_for_handoff)
 
 
+def agent_member_from_item(item: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(item, dict):
+        return None
+    project_asset = item.get("project_asset") if isinstance(item.get("project_asset"), dict) else {}
+    member = project_asset.get("agent_member") if isinstance(project_asset.get("agent_member"), dict) else None
+    if member is None and isinstance(item.get("agent_member"), dict):
+        member = item["agent_member"]
+    return member if isinstance(member, dict) else None
+
+
+def agent_member_summary(item: dict[str, Any] | None) -> str | None:
+    member = agent_member_from_item(item)
+    if not member:
+        return None
+    claims = [
+        str(claim).strip()
+        for claim in (member.get("current_claims") or [])
+        if str(claim).strip()
+    ]
+    parts = [
+        f"agent={member.get('agent_id')}",
+        f"role={member.get('role')}",
+        "authority=advisory_projection",
+    ]
+    if member.get("scope_summary"):
+        parts.append(f"scope={member.get('scope_summary')}")
+    if member.get("worktree_policy"):
+        parts.append(f"worktree_policy={member.get('worktree_policy')}")
+    if claims:
+        parts.append(f"claims={','.join(claims[:5])}")
+    if member.get("handoff_agent"):
+        parts.append(f"handoff_agent={member.get('handoff_agent')}")
+    return compact_packet_text(" ".join(str(part) for part in parts if part))
+
+
 def project_asset_source(item: dict[str, Any] | None) -> str:
     if isinstance(item, dict) and isinstance(item.get("project_asset"), dict):
         return "project_asset"
@@ -965,6 +1000,7 @@ def project_agent_section(
     agent_todo_items: list[str] | None = None,
     authority_summary: str | None = None,
     project_asset_source_text: str | None = None,
+    agent_member_text: str | None = None,
     handoff_followthrough_text: str | None = None,
     handoff_delivery_contract_text: str | None = None,
     approved_operator_gate: bool = False,
@@ -980,6 +1016,7 @@ def project_agent_section(
     ]
     authority_line = f"材料上下文：{authority_summary}；只用这些脱敏计数判断 freshness / owner gap，不要要求内部链接或原文。" if authority_summary else None
     source_line = f"项目资产来源：{project_asset_source_text}" if project_asset_source_text else None
+    member_line = f"Agent 成员：{agent_member_text}" if agent_member_text else None
     followthrough_line = f"交付观测：{handoff_followthrough_text}" if handoff_followthrough_text else None
     delivery_contract_line = f"交付合同：{handoff_delivery_contract_text}" if handoff_delivery_contract_text else None
     if approved_operator_gate:
@@ -987,6 +1024,7 @@ def project_agent_section(
             goal_guard,
             context_rule,
             source_line,
+            member_line,
             todo_line,
             *extra_todo_lines,
             authority_line,
@@ -1003,6 +1041,7 @@ def project_agent_section(
             goal_guard,
             context_rule,
             source_line,
+            member_line,
             todo_line,
             *extra_todo_lines,
             authority_line,
@@ -1019,6 +1058,7 @@ def project_agent_section(
             goal_guard,
             context_rule,
             source_line,
+            member_line,
             todo_line,
             *extra_todo_lines,
             authority_line,
@@ -1035,6 +1075,7 @@ def project_agent_section(
             goal_guard,
             context_rule,
             source_line,
+            member_line,
             todo_line,
             *extra_todo_lines,
             authority_line,
@@ -1051,6 +1092,7 @@ def project_agent_section(
             goal_guard,
             context_rule,
             source_line,
+            member_line,
             todo_line,
             *extra_todo_lines,
             authority_line,
@@ -1067,6 +1109,7 @@ def project_agent_section(
             goal_guard,
             context_rule,
             source_line,
+            member_line,
             todo_line,
             *extra_todo_lines,
             authority_line,
@@ -1106,6 +1149,7 @@ def build_review_packet(
     agent_todo_text = agent_todo_items[0] if agent_todo_items else None
     asset_source = project_asset_source(item)
     asset_source_line = project_asset_source_line(asset_source)
+    member_summary = agent_member_summary(item)
     authority_summary = authority_material_summary(goal)
     followthrough_summary = handoff_followthrough_summary(item)
     chain_handoff = benchmark_report_chain_handoff(item)
@@ -1149,6 +1193,7 @@ def build_review_packet(
         agent_todo_items=agent_todo_items,
         authority_summary=authority_summary,
         project_asset_source_text=asset_source_line,
+        agent_member_text=member_summary,
         handoff_followthrough_text=followthrough_summary,
         handoff_delivery_contract_text=delivery_contract_text,
         approved_operator_gate=approved_handoff,
@@ -1220,6 +1265,8 @@ def build_review_packet(
         "owner_blocker_text": owner_blocker_text,
         "agent_todo_text": agent_todo_text,
         "agent_todo_items": agent_todo_items,
+        "agent_member": agent_member_from_item(item),
+        "agent_member_summary": member_summary,
         "authority_summary": authority_summary,
         "handoff_followthrough_summary": followthrough_summary,
         "benchmark_report_chain_handoff": chain_handoff,

--- a/loopx/state_projection.py
+++ b/loopx/state_projection.py
@@ -10,12 +10,14 @@ from .todo_contract import (
     normalize_required_capabilities,
     normalize_required_write_scopes,
     normalize_target_capabilities,
+    normalize_todo_decision_scope,
     normalize_todo_action_kind,
     normalize_todo_blocks_agent,
     normalize_todo_claimed_by,
     normalize_todo_global_gate,
     normalize_todo_id,
     normalize_todo_no_followup,
+    normalize_todo_required_decision_scopes,
     normalize_todo_resume_when,
     normalize_todo_status,
     normalize_todo_task_class,
@@ -78,6 +80,8 @@ TODO_METADATA_KEYS = (
     "required_write_scopes",
     "required_capabilities",
     "target_capabilities",
+    "decision_scope",
+    "required_decision_scopes",
     "claimed_by",
     "blocks_agent",
     "global_gate",
@@ -350,6 +354,14 @@ def _normalize_structured_todo_item(
     target_capabilities = normalize_target_capabilities(item.get("target_capabilities"))
     if target_capabilities:
         normalized["target_capabilities"] = target_capabilities
+    decision_scope = normalize_todo_decision_scope(item.get("decision_scope"))
+    if decision_scope:
+        normalized["decision_scope"] = decision_scope
+    required_decision_scopes = normalize_todo_required_decision_scopes(
+        item.get("required_decision_scopes")
+    )
+    if required_decision_scopes:
+        normalized["required_decision_scopes"] = required_decision_scopes
     claimed_by = normalize_todo_claimed_by(item.get("claimed_by"))
     if claimed_by:
         normalized["claimed_by"] = claimed_by

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -96,9 +96,11 @@ from .todo_contract import (
     normalize_required_write_scopes,
     normalize_todo_blocks_agent,
     normalize_todo_claimed_by,
+    normalize_todo_decision_scope,
     normalize_todo_global_gate,
     normalize_todo_id,
     normalize_todo_no_followup,
+    normalize_todo_required_decision_scopes,
     normalize_todo_resume_when,
     normalize_todo_status,
     normalize_todo_task_class,
@@ -5130,6 +5132,14 @@ def structured_todo_item(
     target_capabilities = normalize_target_capabilities(item.get("target_capabilities"))
     if target_capabilities:
         normalized["target_capabilities"] = target_capabilities
+    decision_scope = normalize_todo_decision_scope(item.get("decision_scope"))
+    if decision_scope:
+        normalized["decision_scope"] = decision_scope
+    required_decision_scopes = normalize_todo_required_decision_scopes(
+        item.get("required_decision_scopes")
+    )
+    if required_decision_scopes:
+        normalized["required_decision_scopes"] = required_decision_scopes
     claimed_by = normalize_todo_claimed_by(item.get("claimed_by"))
     if claimed_by:
         normalized["claimed_by"] = claimed_by
@@ -5174,6 +5184,8 @@ def compact_todo_item(item: dict[str, Any]) -> dict[str, Any]:
         "required_write_scopes",
         "required_capabilities",
         "target_capabilities",
+        "decision_scope",
+        "required_decision_scopes",
         "claimed_by",
         "blocks_agent",
         "global_gate",
@@ -5185,6 +5197,7 @@ def compact_todo_item(item: dict[str, Any]) -> dict[str, Any]:
         "target_key",
         "cadence",
         "next_due_at",
+        "expires_at",
         "last_checked_at",
         "result_hash",
         "consecutive_no_change",
@@ -5235,10 +5248,24 @@ def todo_item_next_due_at(item: dict[str, Any]) -> datetime | None:
     return parse_timestamp(item.get("next_due_at"))
 
 
+def todo_item_expires_at(item: dict[str, Any]) -> datetime | None:
+    return parse_timestamp(item.get("expires_at"))
+
+
+def todo_item_is_expired_monitor(item: dict[str, Any], *, now: datetime | None = None) -> bool:
+    expires_at = todo_item_expires_at(item)
+    if expires_at is None:
+        return False
+    current_time = now or datetime.now(timezone.utc)
+    return expires_at <= current_time
+
+
 def todo_item_is_due_monitor(item: dict[str, Any], *, now: datetime | None = None) -> bool:
     if not todo_item_is_actionable_open(item):
         return False
     if todo_item_task_class(item) != TODO_TASK_CLASS_MONITOR:
+        return False
+    if todo_item_is_expired_monitor(item, now=now):
         return False
     next_due_at = todo_item_next_due_at(item)
     if next_due_at is None:
@@ -10009,6 +10036,30 @@ def render_status_markdown(payload: dict[str, Any]) -> str:
                 lines.append(
                     "    - agent_lane_recommendation: "
                     f"agent={agent} lane={lane} action={recommendation}"
+                )
+            agent_member = (
+                project_asset.get("agent_member")
+                if isinstance(project_asset.get("agent_member"), dict)
+                else item.get("agent_member")
+                if isinstance(item.get("agent_member"), dict)
+                else {}
+            )
+            if agent_member:
+                current_claims = ",".join(
+                    _markdown_scalar(claim)
+                    for claim in (agent_member.get("current_claims") or [])
+                    if str(claim or "").strip()
+                )
+                lines.append(
+                    "    - agent_member: "
+                    f"agent={_markdown_scalar(agent_member.get('agent_id') or '')} "
+                    f"role={_markdown_scalar(agent_member.get('role') or '')} "
+                    f"scope={_markdown_scalar(agent_member.get('scope_summary') or '')} "
+                    f"worktree_policy={_markdown_scalar(agent_member.get('worktree_policy') or '')} "
+                    f"claims={_markdown_scalar(current_claims)} "
+                    f"handoff_agent={_markdown_scalar(agent_member.get('handoff_agent') or '')} "
+                    f"source={_markdown_scalar(agent_member.get('profile_source') or '')} "
+                    "authority=advisory_projection"
                 )
             if agent_lane_next_action:
                 agent = _markdown_scalar(agent_lane_next_action.get("agent_id") or "")

--- a/loopx/todo_contract.py
+++ b/loopx/todo_contract.py
@@ -13,6 +13,7 @@ TODO_ACTION_KIND_PATTERN = re.compile(r"^[a-z][a-z0-9_-]{0,63}$")
 TODO_ID_PATTERN = re.compile(r"^todo_[a-z0-9_-]{3,64}$")
 TODO_AGENT_CLAIM_PATTERN = re.compile(r"^[a-z][a-z0-9_.:@-]{0,79}$")
 TODO_CAPABILITY_PATTERN = re.compile(r"^[a-z][a-z0-9_:-]{0,63}$")
+TODO_DECISION_SCOPE_KEY_PATTERN = re.compile(r"^(?:\*|[a-z0-9][a-z0-9_.:@*/-]{0,95})$")
 TODO_RESUME_KIND_TODO_DONE = "todo_done"
 TODO_RESUME_KIND_PR_MERGED = "pr_merged"
 TODO_RESUME_WHEN_PATTERN = re.compile(r"^[a-z][a-z0-9_-]{0,31}(?::[a-z0-9_.:@-]{1,96})?$")
@@ -24,6 +25,7 @@ TODO_MONITOR_METADATA_FIELDS = (
     "target_key",
     "cadence",
     "next_due_at",
+    "expires_at",
     "last_checked_at",
     "result_hash",
     "consecutive_no_change",
@@ -40,6 +42,23 @@ TODO_TASK_CLASS_VALUES = {
     TODO_TASK_CLASS_MONITOR,
     TODO_TASK_CLASS_USER_GATE,
     TODO_TASK_CLASS_BLOCKER,
+}
+TODO_DECISION_SCOPE_SCHEMA_VERSION = "decision_scope_v0"
+TODO_DECISION_SCOPE_KIND_VALUES = {
+    "private_read",
+    "write_scope",
+    "resource",
+    "production",
+    "public_claim",
+    "direction",
+    "other",
+}
+TODO_DECISION_SCOPE_GRANULARITY_VALUES = {
+    "action",
+    "lane",
+    "goal",
+    "project",
+    "global",
 }
 
 TODO_STATUS_OPEN = "open"
@@ -262,6 +281,90 @@ def normalize_target_capabilities(value: Any) -> list[str]:
     return normalize_required_capabilities(value)
 
 
+def normalize_todo_decision_scope(value: Any) -> dict[str, str] | None:
+    """Normalize the compact decision-scope metadata token.
+
+    Markdown todo metadata stores the v0 shape as
+    ``kind:granularity:scope_key`` so authors do not need to embed JSON in
+    active-state comments. Status and quota expose the normalized object.
+    """
+
+    raw_kind: Any = None
+    raw_granularity: Any = None
+    raw_scope_key: Any = None
+    raw_decision_id: Any = None
+    if isinstance(value, dict):
+        raw_kind = value.get("kind")
+        raw_granularity = value.get("granularity")
+        raw_scope_key = value.get("scope_key")
+        raw_decision_id = value.get("decision_id")
+    else:
+        candidate = compact_todo_text(value).lower()
+        parts = candidate.split(":", 2)
+        if len(parts) != 3:
+            return None
+        raw_kind, raw_granularity, raw_scope_key = parts
+
+    kind = compact_todo_text(raw_kind).lower()
+    granularity = compact_todo_text(raw_granularity).lower()
+    scope_key = compact_todo_text(raw_scope_key).lower()
+    if kind not in TODO_DECISION_SCOPE_KIND_VALUES:
+        return None
+    if granularity not in TODO_DECISION_SCOPE_GRANULARITY_VALUES:
+        return None
+    if not TODO_DECISION_SCOPE_KEY_PATTERN.match(scope_key):
+        return None
+
+    payload: dict[str, str] = {
+        "schema_version": TODO_DECISION_SCOPE_SCHEMA_VERSION,
+        "kind": kind,
+        "granularity": granularity,
+        "scope_key": scope_key,
+    }
+    decision_id = normalize_todo_id(raw_decision_id)
+    if decision_id:
+        payload["decision_id"] = decision_id
+    return payload
+
+
+def normalize_todo_required_decision_scopes(value: Any) -> list[dict[str, str]]:
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple, set)):
+        raw_values = list(value)
+    else:
+        raw_values = re.split(r"[,;|]", str(value or ""))
+    scopes: list[dict[str, str]] = []
+    seen: set[tuple[str, str, str]] = set()
+    for raw in raw_values:
+        scope = normalize_todo_decision_scope(raw)
+        if not scope:
+            continue
+        identity = (scope["kind"], scope["granularity"], scope["scope_key"])
+        if identity in seen:
+            continue
+        seen.add(identity)
+        scopes.append(scope)
+    return scopes
+
+
+def decision_scope_metadata_value(value: Any) -> str | None:
+    scope = normalize_todo_decision_scope(value)
+    if not scope:
+        return None
+    return f"{scope['kind']}:{scope['granularity']}:{scope['scope_key']}"
+
+
+def required_decision_scopes_metadata_value(value: Any) -> str | None:
+    scopes = normalize_todo_required_decision_scopes(value)
+    if not scopes:
+        return None
+    return ",".join(
+        f"{scope['kind']}:{scope['granularity']}:{scope['scope_key']}"
+        for scope in scopes
+    )
+
+
 def build_todo_id(
     *,
     role: Any,
@@ -362,6 +465,14 @@ def parse_todo_metadata_line(line: str) -> dict[str, Any] | None:
             capabilities = normalize_target_capabilities(value)
             if capabilities:
                 metadata["target_capabilities"] = capabilities
+        elif key == "decision_scope":
+            decision_scope = normalize_todo_decision_scope(value)
+            if decision_scope:
+                metadata["decision_scope"] = decision_scope
+        elif key in {"required_decision_scope", "required_decision_scopes"}:
+            scopes = normalize_todo_required_decision_scopes(value)
+            if scopes:
+                metadata["required_decision_scopes"] = scopes
         elif key == "claimed_by":
             claimed_by = normalize_todo_claimed_by(value)
             if claimed_by:
@@ -408,6 +519,8 @@ def format_todo_metadata_line(
     required_write_scopes: Any = None,
     required_capabilities: Any = None,
     target_capabilities: Any = None,
+    decision_scope: Any = None,
+    required_decision_scopes: Any = None,
     claimed_by: str | None = None,
     blocks_agent: str | None = None,
     global_gate: bool | None = None,
@@ -417,6 +530,7 @@ def format_todo_metadata_line(
     target_key: str | None = None,
     cadence: str | None = None,
     next_due_at: str | None = None,
+    expires_at: str | None = None,
     last_checked_at: str | None = None,
     result_hash: str | None = None,
     consecutive_no_change: str | None = None,
@@ -474,6 +588,19 @@ def format_todo_metadata_line(
             "target_capabilities="
             f"{encode_metadata_value(','.join(normalized_target_capabilities))}"
         )
+    normalized_decision_scope = decision_scope_metadata_value(decision_scope)
+    if decision_scope and not normalized_decision_scope:
+        raise ValueError("decision_scope must use kind:granularity:scope_key, such as private_read:project:authority")
+    if normalized_decision_scope:
+        fields.append(f"decision_scope={encode_metadata_value(normalized_decision_scope)}")
+    normalized_required_decision_scopes = required_decision_scopes_metadata_value(required_decision_scopes)
+    if required_decision_scopes and not normalized_required_decision_scopes:
+        raise ValueError("required_decision_scopes must contain kind:granularity:scope_key tokens")
+    if normalized_required_decision_scopes:
+        fields.append(
+            "required_decision_scopes="
+            f"{encode_metadata_value(normalized_required_decision_scopes)}"
+        )
     normalized_claimed_by = normalize_todo_claimed_by(claimed_by)
     if claimed_by and not normalized_claimed_by:
         raise ValueError("claimed_by must be a public-safe agent token such as codex-main-control")
@@ -502,6 +629,7 @@ def format_todo_metadata_line(
         ("target_key", target_key),
         ("cadence", cadence),
         ("next_due_at", next_due_at),
+        ("expires_at", expires_at),
         ("last_checked_at", last_checked_at),
         ("result_hash", result_hash),
         ("consecutive_no_change", consecutive_no_change),

--- a/loopx/todo_followups.py
+++ b/loopx/todo_followups.py
@@ -62,6 +62,7 @@ def capture_followup_todos(
     required_write_scopes: list[str] | None = None,
     required_capabilities: list[str] | None = None,
     target_capabilities: list[str] | None = None,
+    required_decision_scopes: Any = None,
     project: Path | None = None,
     state_file: Path | None = None,
     dry_run: bool = False,
@@ -132,6 +133,7 @@ def capture_followup_todos(
                 required_write_scopes=required_write_scopes,
                 required_capabilities=required_capabilities,
                 target_capabilities=target_capabilities,
+                required_decision_scopes=required_decision_scopes,
                 evidence=evidence_text,
             )
             changed = changed or bool(add_result.get("added")) or bool(add_result.get("metadata_updated"))

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -36,9 +36,11 @@ from .todo_contract import (
     normalize_target_capabilities,
     normalize_todo_blocks_agent,
     normalize_todo_claimed_by,
+    normalize_todo_decision_scope,
     normalize_todo_global_gate,
     normalize_todo_id,
     normalize_todo_no_followup,
+    normalize_todo_required_decision_scopes,
     normalize_todo_resume_when,
     normalize_todo_status,
     parse_todo_metadata_line,
@@ -61,6 +63,8 @@ TODO_METADATA_FIELDS = (
     "required_write_scopes",
     "required_capabilities",
     "target_capabilities",
+    "decision_scope",
+    "required_decision_scopes",
     "claimed_by",
     "blocks_agent",
     "global_gate",
@@ -70,6 +74,7 @@ TODO_METADATA_FIELDS = (
     "target_key",
     "cadence",
     "next_due_at",
+    "expires_at",
     "last_checked_at",
     "result_hash",
     "consecutive_no_change",
@@ -157,6 +162,8 @@ def normalize_monitor_metadata(metadata: dict[str, Any] | None) -> dict[str, str
         raise ValueError("--cadence must look like 30m, 2h, or 1d")
     if "next_due_at" in normalized and parse_timestamp(normalized["next_due_at"]) is None:
         raise ValueError("--next-due-at must be an ISO timestamp")
+    if "expires_at" in normalized and parse_timestamp(normalized["expires_at"]) is None:
+        raise ValueError("--expires-at must be an ISO timestamp")
     if "last_checked_at" in normalized and parse_timestamp(normalized["last_checked_at"]) is None:
         raise ValueError("--last-checked-at must be an ISO timestamp")
     if "consecutive_no_change" in normalized:
@@ -526,6 +533,16 @@ def block_metadata(block: dict[str, Any]) -> dict[str, Any]:
             if capabilities:
                 metadata[key] = capabilities
             continue
+        if key == "decision_scope":
+            decision_scope = normalize_todo_decision_scope(value)
+            if decision_scope:
+                metadata[key] = decision_scope
+            continue
+        if key == "required_decision_scopes":
+            scopes = normalize_todo_required_decision_scopes(value)
+            if scopes:
+                metadata[key] = scopes
+            continue
         if key == "no_followup":
             no_followup = normalize_todo_no_followup(value)
             if no_followup is not None:
@@ -564,6 +581,18 @@ def metadata_line_for_block(block: dict[str, Any], updates: dict[str, Any]) -> s
             capabilities = normalize_target_capabilities(value)
             if capabilities:
                 metadata[key] = capabilities
+            else:
+                metadata.pop(key, None)
+        elif key == "decision_scope":
+            decision_scope = normalize_todo_decision_scope(value)
+            if decision_scope:
+                metadata[key] = decision_scope
+            else:
+                metadata.pop(key, None)
+        elif key == "required_decision_scopes":
+            scopes = normalize_todo_required_decision_scopes(value)
+            if scopes:
+                metadata[key] = scopes
             else:
                 metadata.pop(key, None)
         elif key == "no_followup":
@@ -683,6 +712,8 @@ def add_todo_to_lines(
     required_write_scopes: list[str] | None = None,
     required_capabilities: list[str] | None = None,
     target_capabilities: list[str] | None = None,
+    decision_scope: Any = None,
+    required_decision_scopes: Any = None,
     claimed_by: str | None = None,
     blocks_agent: str | None = None,
     global_gate: bool | None = None,
@@ -730,6 +761,8 @@ def add_todo_to_lines(
             required_write_scopes=required_write_scopes,
             required_capabilities=required_capabilities,
             target_capabilities=target_capabilities,
+            decision_scope=decision_scope,
+            required_decision_scopes=required_decision_scopes,
             claimed_by=claimed_by,
             blocks_agent=blocks_agent,
             global_gate=global_gate,
@@ -759,6 +792,10 @@ def add_todo_to_lines(
             updates["required_capabilities"] = required_capabilities
         if target_capabilities is not None:
             updates["target_capabilities"] = target_capabilities
+        if decision_scope is not None:
+            updates["decision_scope"] = decision_scope
+        if required_decision_scopes is not None:
+            updates["required_decision_scopes"] = required_decision_scopes
         if claimed_by:
             updates["claimed_by"] = claimed_by
         if blocks_agent:
@@ -796,6 +833,12 @@ def add_todo_to_lines(
         "target_capabilities": normalize_target_capabilities(
             effective_metadata.get("target_capabilities") or target_capabilities
         ),
+        "decision_scope": normalize_todo_decision_scope(
+            effective_metadata.get("decision_scope") or decision_scope
+        ),
+        "required_decision_scopes": normalize_todo_required_decision_scopes(
+            effective_metadata.get("required_decision_scopes") or required_decision_scopes
+        ),
         "claimed_by": normalize_todo_claimed_by(effective_metadata.get("claimed_by")),
         "blocks_agent": normalize_todo_blocks_agent(effective_metadata.get("blocks_agent")),
         "global_gate": normalize_todo_global_gate(effective_metadata.get("global_gate")),
@@ -804,6 +847,7 @@ def add_todo_to_lines(
         "target_key": effective_metadata.get("target_key"),
         "cadence": effective_metadata.get("cadence"),
         "next_due_at": effective_metadata.get("next_due_at"),
+        "expires_at": effective_metadata.get("expires_at"),
         "evidence": effective_metadata.get("evidence") or evidence,
     }
 
@@ -848,6 +892,8 @@ def add_goal_todo(
     required_write_scopes: list[str] | None = None,
     required_capabilities: list[str] | None = None,
     target_capabilities: list[str] | None = None,
+    decision_scope: Any = None,
+    required_decision_scopes: Any = None,
     claimed_by: str | None = None,
     blocks_agent: str | None = None,
     global_gate: bool = False,
@@ -940,6 +986,8 @@ def add_goal_todo(
             required_write_scopes=required_write_scopes,
             required_capabilities=required_capabilities,
             target_capabilities=target_capabilities,
+            decision_scope=decision_scope,
+            required_decision_scopes=required_decision_scopes,
             claimed_by=effective_claimed_by,
             blocks_agent=effective_blocks_agent,
             global_gate=True if global_gate else None,
@@ -972,6 +1020,8 @@ def add_goal_todo(
         "required_write_scopes": add_result.get("required_write_scopes"),
         "required_capabilities": add_result.get("required_capabilities"),
         "target_capabilities": add_result.get("target_capabilities"),
+        "decision_scope": add_result.get("decision_scope"),
+        "required_decision_scopes": add_result.get("required_decision_scopes"),
         "claimed_by": add_result.get("claimed_by"),
         "agent_id": effective_agent_id,
         "blocks_agent": add_result.get("blocks_agent"),
@@ -981,6 +1031,7 @@ def add_goal_todo(
         "target_key": add_result.get("target_key"),
         "cadence": add_result.get("cadence"),
         "next_due_at": add_result.get("next_due_at"),
+        "expires_at": add_result.get("expires_at"),
         "state_file": str(resolved_state_file),
         "project": str(resolved_project) if resolved_project else None,
         "updated_at": updated_at if added or metadata_updated else None,
@@ -1025,6 +1076,8 @@ def apply_todo_update_to_lines(
     required_write_scopes: list[str] | None = None,
     required_capabilities: list[str] | None = None,
     target_capabilities: list[str] | None = None,
+    decision_scope: Any = None,
+    required_decision_scopes: Any = None,
     claimed_by: str | None = None,
     blocks_agent: str | None = None,
     global_gate: bool | None = None,
@@ -1080,6 +1133,10 @@ def apply_todo_update_to_lines(
         updates["required_capabilities"] = required_capabilities
     if target_capabilities is not None:
         updates["target_capabilities"] = target_capabilities
+    if decision_scope is not None:
+        updates["decision_scope"] = decision_scope
+    if required_decision_scopes is not None:
+        updates["required_decision_scopes"] = required_decision_scopes
     if clear_claim:
         updates["claimed_by"] = None
     elif claimed_by:
@@ -1129,6 +1186,10 @@ def apply_todo_update_to_lines(
         "target_capabilities": normalize_target_capabilities(
             effective_metadata.get("target_capabilities")
         ),
+        "decision_scope": normalize_todo_decision_scope(effective_metadata.get("decision_scope")),
+        "required_decision_scopes": normalize_todo_required_decision_scopes(
+            effective_metadata.get("required_decision_scopes")
+        ),
         "blocks_agent": normalize_todo_blocks_agent(effective_metadata.get("blocks_agent")),
         "global_gate": normalize_todo_global_gate(effective_metadata.get("global_gate")),
         "unblocks_todo_id": normalize_todo_id(effective_metadata.get("unblocks_todo_id")),
@@ -1137,6 +1198,7 @@ def apply_todo_update_to_lines(
         "target_key": effective_metadata.get("target_key"),
         "cadence": effective_metadata.get("cadence"),
         "next_due_at": effective_metadata.get("next_due_at"),
+        "expires_at": effective_metadata.get("expires_at"),
     }
 
 
@@ -1156,6 +1218,8 @@ def update_goal_todo(
     required_write_scopes: list[str] | None = None,
     required_capabilities: list[str] | None = None,
     target_capabilities: list[str] | None = None,
+    decision_scope: Any = None,
+    required_decision_scopes: Any = None,
     claimed_by: str | None = None,
     blocks_agent: str | None = None,
     global_gate: bool = False,
@@ -1282,6 +1346,8 @@ def update_goal_todo(
             required_write_scopes=required_write_scopes,
             required_capabilities=required_capabilities,
             target_capabilities=target_capabilities,
+            decision_scope=decision_scope,
+            required_decision_scopes=required_decision_scopes,
             claimed_by=effective_claimed_by,
             blocks_agent=effective_blocks_agent,
             global_gate=True if global_gate else None,
@@ -1771,6 +1837,7 @@ def render_todo_markdown(payload: dict[str, Any]) -> str:
                     "target_key",
                     "cadence",
                     "next_due_at",
+                    "expires_at",
                 ):
                     if item.get(metadata_key):
                         metadata.append(f"{metadata_key}={item.get(metadata_key)}")
@@ -1818,6 +1885,7 @@ def render_todo_markdown(payload: dict[str, Any]) -> str:
                 f"- target_key: `{payload.get('target_key')}`",
                 f"- cadence: `{payload.get('cadence')}`",
                 f"- next_due_at: `{payload.get('next_due_at')}`",
+                f"- expires_at: `{payload.get('expires_at')}`",
             ]
         )
     if payload.get("error"):

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -303,6 +303,7 @@ PROTECTED_DIRECTIVE_RE = re.compile(
     r"(?:modify|edit|change|write|touch|修改|编辑|改动|写)"
 )
 DECLARED_DONE_MARKER = "AGENT_DECLARED_DONE_NO_REMAINING_GOALS"
+PRODUCT_MODE_FINAL_CLOSEOUT_MAX_CHECKPOINTS = 3
 CODEX_ACP_RUNTIME_CONTAINER_BOOTSTRAP_CMD = (
     "set -e; "
     "export DEBIAN_FRONTEND=noninteractive; "
@@ -1088,6 +1089,7 @@ def _host_local_acp_codex_exec_preflight_should_run(
     return bool(
         getattr(args, "host_local_acp_launch", False)
         and _is_goal_start_product_mode_route(str(getattr(args, "route", "") or ""))
+        and str(getattr(args, "remote_command_file_bridge_solver_command", "") or "")
     )
 
 
@@ -1131,6 +1133,15 @@ def _summarize_host_local_acp_preflight_bridge_trace(
         "request_count": 0,
         "preflight_operation_count": 0,
         "task_facing_operation_count": 0,
+        "success_count": 0,
+        "failure_count": 0,
+        "preflight_success_count": 0,
+        "preflight_failure_count": 0,
+        "task_facing_success_count": 0,
+        "task_facing_failure_count": 0,
+        "operation_counts": {},
+        "returncode_counts": {},
+        "failure_category_counts": {},
         "raw_material_recorded": False,
     }
     if trace_dir is None or not trace_dir.exists():
@@ -1170,18 +1181,63 @@ def _summarize_host_local_acp_preflight_bridge_trace(
         for source_key, target_key in (
             ("request_count", "request_count"),
             ("task_facing_operation_count", "task_facing_operation_count"),
+            ("success_count", "success_count"),
+            ("failure_count", "failure_count"),
+            ("preflight_success_count", "preflight_success_count"),
+            ("preflight_failure_count", "preflight_failure_count"),
+            ("task_facing_success_count", "task_facing_success_count"),
+            ("task_facing_failure_count", "task_facing_failure_count"),
         ):
             value = operations.get(source_key)
             if isinstance(value, int) and not isinstance(value, bool):
                 summary[target_key] = int(summary[target_key]) + max(0, value)
-        operation_counts = operations.get("operation_counts")
+        for source_key, target_key in (
+            ("operation_counts", "operation_counts"),
+            ("returncode_counts", "returncode_counts"),
+            ("failure_category_counts", "failure_category_counts"),
+        ):
+            source_counts = operations.get(source_key)
+            target_counts = summary.get(target_key)
+            if not isinstance(source_counts, dict) or not isinstance(
+                target_counts, dict
+            ):
+                continue
+            for key, value in source_counts.items():
+                if not isinstance(key, str) or not key:
+                    continue
+                if not isinstance(value, int) or isinstance(value, bool):
+                    continue
+                safe_key = key[:80]
+                target_counts[safe_key] = int(target_counts.get(safe_key, 0)) + max(
+                    0, value
+                )
+        operation_counts = summary.get("operation_counts")
         if isinstance(operation_counts, dict):
             value = operation_counts.get("preflight")
             if isinstance(value, int) and not isinstance(value, bool):
-                summary["preflight_operation_count"] = int(
-                    summary["preflight_operation_count"]
-                ) + max(0, value)
+                summary["preflight_operation_count"] = max(0, value)
     return summary
+
+
+def _host_local_acp_codex_exec_preflight_bridge_success_observed(
+    bridge_summary: dict[str, Any],
+) -> bool:
+    action_count = int(bridge_summary.get("preflight_operation_count") or 0) + int(
+        bridge_summary.get("task_facing_operation_count") or 0
+    )
+    successful_action_count = int(
+        bridge_summary.get("preflight_success_count") or 0
+    ) + int(bridge_summary.get("task_facing_success_count") or 0)
+    return action_count > 0 and successful_action_count > 0
+
+
+def _first_bridge_failure_category(bridge_summary: dict[str, Any]) -> str:
+    counts = bridge_summary.get("failure_category_counts")
+    if isinstance(counts, dict):
+        for key, value in sorted(counts.items()):
+            if isinstance(key, str) and key and isinstance(value, int) and value > 0:
+                return key[:120]
+    return "codex_remote_bridge_operation_failed"
 
 
 def _run_host_local_acp_codex_exec_preflight(
@@ -1256,6 +1312,30 @@ def _run_host_local_acp_codex_exec_preflight(
         prerequisites[
             "host_local_acp_codex_exec_preflight_bridge_preflight_operation_count"
         ] = bridge_summary["preflight_operation_count"]
+        prerequisites["host_local_acp_codex_exec_preflight_bridge_success_count"] = (
+            bridge_summary["success_count"]
+        )
+        prerequisites["host_local_acp_codex_exec_preflight_bridge_failure_count"] = (
+            bridge_summary["failure_count"]
+        )
+        prerequisites[
+            "host_local_acp_codex_exec_preflight_bridge_preflight_success_count"
+        ] = bridge_summary["preflight_success_count"]
+        prerequisites[
+            "host_local_acp_codex_exec_preflight_bridge_preflight_failure_count"
+        ] = bridge_summary["preflight_failure_count"]
+        prerequisites[
+            "host_local_acp_codex_exec_preflight_bridge_task_facing_success_count"
+        ] = bridge_summary["task_facing_success_count"]
+        prerequisites[
+            "host_local_acp_codex_exec_preflight_bridge_task_facing_failure_count"
+        ] = bridge_summary["task_facing_failure_count"]
+        prerequisites["host_local_acp_codex_exec_preflight_bridge_returncode_counts"] = (
+            bridge_summary["returncode_counts"]
+        )
+        prerequisites[
+            "host_local_acp_codex_exec_preflight_bridge_failure_category_counts"
+        ] = bridge_summary["failure_category_counts"]
         prerequisites[
             "host_local_acp_codex_exec_preflight_bridge_raw_material_recorded"
         ] = bridge_summary["raw_material_recorded"]
@@ -1266,7 +1346,15 @@ def _run_host_local_acp_codex_exec_preflight(
         prerequisites["host_local_acp_codex_exec_preflight_bridge_action_observed"] = (
             bridge_action_observed
         )
-        if ready and (not bridge_action_required or bridge_action_observed):
+        bridge_action_success_observed = (
+            _host_local_acp_codex_exec_preflight_bridge_success_observed(
+                bridge_summary
+            )
+        )
+        prerequisites[
+            "host_local_acp_codex_exec_preflight_bridge_action_success_observed"
+        ] = bridge_action_success_observed
+        if ready and (not bridge_action_required or bridge_action_success_observed):
             prerequisites["host_local_acp_codex_exec_preflight_status"] = "passed"
             for key in (
                 "host_local_acp_codex_exec_failure_category",
@@ -1283,6 +1371,13 @@ def _run_host_local_acp_codex_exec_preflight(
             )
             prerequisites["host_local_acp_codex_exec_failure_category"] = (
                 "codex_exec_no_bridge_action"
+            )
+        elif ready and bridge_action_required and not bridge_action_success_observed:
+            prerequisites["host_local_acp_codex_exec_preflight_first_blocker"] = (
+                "skillsbench_host_local_acp_codex_exec_preflight_bridge_action_failed"
+            )
+            prerequisites["host_local_acp_codex_exec_failure_category"] = (
+                _first_bridge_failure_category(bridge_summary)
             )
         if preflight_trace_dir:
             trace: dict[str, Any] = {
@@ -1476,6 +1571,8 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "benchflow_user_loop_recovery_stage",
         "benchflow_user_loop_soft_verify_exception_type",
         "benchflow_user_loop_soft_verify_exception_stage",
+        "benchflow_user_loop_no_tool_exception_type",
+        "benchflow_user_loop_no_tool_exception_stage",
         "benchflow_intermediate_soft_verify_policy",
         "benchflow_intermediate_soft_verify_timeout_stage",
         "benchflow_intermediate_soft_verify_timeout_cleanup_status",
@@ -1483,6 +1580,7 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "benchflow_setup_stall_cleanup_status",
         "remote_command_file_bridge_consumption_status",
         "remote_command_file_bridge_agent_operation_trace_status",
+        "remote_command_file_bridge_agent_transport_mode",
         "host_local_acp_sandbox_bridge_mode",
         "host_local_acp_session_adapter_status",
         "host_local_acp_pwd_probe_status",
@@ -1515,6 +1613,7 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "host_local_acp_codex_exec_preflight_response_marker_observed",
         "host_local_acp_codex_exec_preflight_bridge_action_required",
         "host_local_acp_codex_exec_preflight_bridge_action_observed",
+        "host_local_acp_codex_exec_preflight_bridge_action_success_observed",
         "host_local_acp_codex_exec_preflight_bridge_trace_present",
         "host_local_acp_codex_exec_preflight_bridge_raw_material_recorded",
         "container_codex_acp_install_skipped",
@@ -1524,6 +1623,8 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "remote_command_file_bridge_command_configured",
         "remote_command_file_bridge_agent_command_configured",
         "remote_command_file_bridge_agent_command_instrumented",
+        "remote_command_file_bridge_agent_queue_configured",
+        "remote_command_file_bridge_agent_queue_path_recorded",
         "remote_command_file_bridge_probe_command_configured",
         "remote_command_file_bridge_solver_wiring_configured",
         "remote_command_file_bridge_consumed_by_solver",
@@ -1565,6 +1666,8 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "benchflow_user_loop_recovery_preserved_final_verify",
         "benchflow_user_loop_soft_verify_exception_continued",
         "benchflow_user_loop_soft_verify_exception_raw_error_recorded",
+        "benchflow_user_loop_no_tool_exception_continued",
+        "benchflow_user_loop_no_tool_exception_raw_error_recorded",
         "benchflow_intermediate_soft_verify_final_only",
         "benchflow_intermediate_soft_verify_raw_output_recorded",
         "benchflow_intermediate_soft_verify_timeout_enabled",
@@ -1615,6 +1718,10 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "benchflow_user_loop_soft_verify_exception_round",
         "benchflow_user_loop_soft_verify_exception_delta_events",
         "benchflow_user_loop_soft_verify_exception_delta_tool_calls",
+        "benchflow_user_loop_no_tool_exception_count",
+        "benchflow_user_loop_no_tool_exception_round",
+        "benchflow_user_loop_no_tool_exception_delta_events",
+        "benchflow_user_loop_no_tool_exception_delta_tool_calls",
         "benchflow_intermediate_soft_verify_call_count",
         "benchflow_intermediate_soft_verify_skipped_count",
         "benchflow_intermediate_soft_verify_timeout_sec",
@@ -1646,10 +1753,14 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "remote_command_file_bridge_solver_operation_count",
         "remote_command_file_bridge_agent_operation_trace_count",
         "remote_command_file_bridge_agent_request_count",
+        "remote_command_file_bridge_agent_success_count",
+        "remote_command_file_bridge_agent_failure_count",
         "remote_command_file_bridge_agent_loopx_cli_call_count",
         "remote_command_file_bridge_agent_loopx_state_read_count",
         "remote_command_file_bridge_agent_loopx_state_write_count",
         "remote_command_file_bridge_agent_task_facing_operation_count",
+        "remote_command_file_bridge_agent_task_facing_success_count",
+        "remote_command_file_bridge_agent_task_facing_failure_count",
         "remote_command_file_bridge_agent_probe_operation_count",
         "remote_command_file_bridge_agent_todo_closeout_count",
         "remote_command_file_bridge_agent_refresh_state_count",
@@ -1671,6 +1782,12 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "host_local_acp_codex_exec_preflight_bridge_request_count",
         "host_local_acp_codex_exec_preflight_bridge_preflight_operation_count",
         "host_local_acp_codex_exec_preflight_bridge_task_facing_operation_count",
+        "host_local_acp_codex_exec_preflight_bridge_success_count",
+        "host_local_acp_codex_exec_preflight_bridge_failure_count",
+        "host_local_acp_codex_exec_preflight_bridge_preflight_success_count",
+        "host_local_acp_codex_exec_preflight_bridge_preflight_failure_count",
+        "host_local_acp_codex_exec_preflight_bridge_task_facing_success_count",
+        "host_local_acp_codex_exec_preflight_bridge_task_facing_failure_count",
         "host_local_acp_codex_exec_failure_trace_count",
     ):
         if isinstance(value.get(field), int) and not isinstance(value.get(field), bool):
@@ -1683,7 +1800,11 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
             if isinstance(key, str) and key in HOST_LOCAL_ACP_TARGET_ENV_KEYS
         ][: len(HOST_LOCAL_ACP_TARGET_ENV_KEYS)]
     for field in (
+        "host_local_acp_codex_exec_preflight_bridge_returncode_counts",
+        "host_local_acp_codex_exec_preflight_bridge_failure_category_counts",
         "remote_command_file_bridge_agent_operation_counts",
+        "remote_command_file_bridge_agent_returncode_counts",
+        "remote_command_file_bridge_agent_failure_category_counts",
         "remote_command_file_bridge_agent_loopx_subcommand_counts",
         "remote_command_file_bridge_agent_successful_loopx_subcommand_counts",
         "remote_command_file_bridge_driver_lifecycle_command_counts",
@@ -2439,6 +2560,41 @@ def _mark_user_loop_soft_verify_exception_continuation(
         trace.update(trace_fields)
 
 
+def _mark_user_loop_no_tool_exception_continuation(
+    *,
+    plan: dict[str, Any],
+    trace: dict[str, Any] | None,
+    round_num: int,
+    exception: Exception,
+    delta_events: int,
+) -> None:
+    prerequisites = plan.setdefault("runner_prerequisites", {})
+    fields: dict[str, Any] = {
+        "benchflow_user_loop_no_tool_exception_continued": True,
+        "benchflow_user_loop_no_tool_exception_raw_error_recorded": False,
+        "benchflow_user_loop_no_tool_exception_stage": "agent_execute",
+        "benchflow_user_loop_no_tool_exception_type": type(exception).__name__,
+        "benchflow_user_loop_no_tool_exception_round": round_num,
+        "benchflow_user_loop_no_tool_exception_delta_events": max(0, delta_events),
+        "benchflow_user_loop_no_tool_exception_delta_tool_calls": 0,
+    }
+    current = prerequisites.get("benchflow_user_loop_no_tool_exception_count")
+    if not isinstance(current, int) or isinstance(current, bool):
+        current = 0
+    fields["benchflow_user_loop_no_tool_exception_count"] = current + 1
+    prerequisites.update(fields)
+    if isinstance(trace, dict):
+        trace_current = trace.get("benchflow_user_loop_no_tool_exception_count")
+        if not isinstance(trace_current, int) or isinstance(trace_current, bool):
+            trace_current = 0
+        trace_fields = dict(fields)
+        trace_fields["benchflow_user_loop_no_tool_exception_count"] = (
+            trace_current + 1
+        )
+        trace.update(trace_fields)
+        trace["last_decision"] = "continue_after_agent_execute_no_tool_exception"
+
+
 def install_benchflow_user_loop_final_verify_recovery(
     rollout_cls: Any,
     *,
@@ -2558,6 +2714,36 @@ def install_benchflow_user_loop_final_verify_recovery(
                 )
                 if (not connected) or delta_events <= 0:
                     raise
+                if delta_tool_calls <= 0 and round_num + 1 < cfg.max_user_rounds:
+                    _mark_user_loop_no_tool_exception_continuation(
+                        plan=plan,
+                        trace=trace,
+                        round_num=round_num,
+                        exception=exc,
+                        delta_events=delta_events,
+                    )
+                    round_result = RoundResult(
+                        round=round_num,
+                        trajectory=round_trajectory,
+                        rewards=None,
+                        verifier_output=None,
+                        verifier_error=(
+                            "public_safe_agent_execute_exception_before_tool_activity"
+                        ),
+                        n_tool_calls=0,
+                    )
+                    rounds_log.append(
+                        {
+                            "round": round_num,
+                            "rewards": None,
+                            "verifier_error": (
+                                "public_safe_agent_execute_exception_before_tool_activity"
+                            ),
+                            "n_tool_calls": 0,
+                            "n_trajectory_events": delta_events,
+                        }
+                    )
+                    continue
                 _mark_user_loop_final_verify_recovery(
                     plan=plan,
                     trace=trace,
@@ -2693,8 +2879,14 @@ def _runner_prerequisite_failure_attribution(
         and (
             value.get("remote_command_file_bridge_agent_operation_trace_required")
             is not True
-            or value.get("remote_command_file_bridge_agent_command_instrumented")
-            is True
+            or (
+                value.get("remote_command_file_bridge_agent_command_instrumented")
+                is True
+                and value.get(
+                    "remote_command_file_bridge_agent_operation_trace_satisfied"
+                )
+                is True
+            )
         )
     )
 
@@ -2782,6 +2974,29 @@ def _runner_prerequisite_failure_attribution(
             return None
         trace_count = value.get("remote_command_file_bridge_agent_operation_trace_count")
         request_count = value.get("remote_command_file_bridge_agent_request_count")
+        if status == "agent_operation_trace_recorded_no_success":
+            category = "bridge_operation_failed"
+            counts = value.get("remote_command_file_bridge_agent_failure_category_counts")
+            if isinstance(counts, dict):
+                for key, count_value in sorted(counts.items()):
+                    if (
+                        isinstance(key, str)
+                        and key
+                        and isinstance(count_value, int)
+                        and count_value > 0
+                    ):
+                        category = key[:80]
+                        break
+            label = f"skillsbench_remote_bridge_agent_operation_failed_{category}"
+            return (
+                label,
+                label,
+                [
+                    label,
+                    "skillsbench_product_mode_uncountable_treatment",
+                    "skillsbench_runner_setup_error",
+                ],
+            )
         if (
             status == "agent_operation_trace_present_no_requests"
             or (
@@ -5618,11 +5833,14 @@ def _merge_host_local_acp_relay_trace_summary(
     agent_bridge_loopx_state_read_count = 0
     agent_bridge_loopx_state_write_count = 0
     agent_bridge_task_facing_operation_count = 0
+    agent_bridge_task_facing_success_count = 0
+    agent_bridge_task_facing_failure_count = 0
     agent_bridge_probe_operation_count = 0
     agent_bridge_operation_counts: dict[str, int] = {}
     agent_bridge_loopx_subcommand_counts: dict[str, int] = {}
     agent_bridge_successful_loopx_subcommand_counts: dict[str, int] = {}
     agent_bridge_returncode_counts: dict[str, int] = {}
+    agent_bridge_failure_category_counts: dict[str, int] = {}
     driver_lifecycle_trace_count = 0
     driver_lifecycle_checkpoint_count = 0
     driver_lifecycle_request_count = 0
@@ -5702,6 +5920,8 @@ def _merge_host_local_acp_relay_trace_summary(
                 "loopx_state_read_count": "state_read",
                 "loopx_state_write_count": "state_write",
                 "task_facing_operation_count": "task_facing",
+                "task_facing_success_count": "task_facing_success",
+                "task_facing_failure_count": "task_facing_failure",
                 "probe_operation_count": "probe",
             }
             for field, target in count_fields.items():
@@ -5723,6 +5943,10 @@ def _merge_host_local_acp_relay_trace_summary(
                     agent_bridge_loopx_state_write_count += value
                 elif target == "task_facing":
                     agent_bridge_task_facing_operation_count += value
+                elif target == "task_facing_success":
+                    agent_bridge_task_facing_success_count += value
+                elif target == "task_facing_failure":
+                    agent_bridge_task_facing_failure_count += value
                 elif target == "probe":
                     agent_bridge_probe_operation_count += value
             for source_key, target_counts in (
@@ -5733,6 +5957,7 @@ def _merge_host_local_acp_relay_trace_summary(
                     agent_bridge_successful_loopx_subcommand_counts,
                 ),
                 ("returncode_counts", agent_bridge_returncode_counts),
+                ("failure_category_counts", agent_bridge_failure_category_counts),
             ):
                 source_counts = agent_ops.get(source_key)
                 if not isinstance(source_counts, dict):
@@ -5827,6 +6052,16 @@ def _merge_host_local_acp_relay_trace_summary(
             )
         )
     consumed_by_solver = solver_trace_count > 0 and probe_ready_count > 0
+    agent_bridge_failure_category = ""
+    for category, count in sorted(agent_bridge_failure_category_counts.items()):
+        if count > 0:
+            agent_bridge_failure_category = category[:120]
+            break
+    host_local_acp_codex_exec_failure_category = (
+        codex_exec_failure_categories[0]
+        if codex_exec_failure_categories
+        else agent_bridge_failure_category
+    )
     trace["remote_command_file_bridge_solver_trace_dir_present"] = trace_dir.exists()
     trace["remote_command_file_bridge_solver_public_trace_read"] = (
         solver_trace_count > 0
@@ -5848,7 +6083,7 @@ def _merge_host_local_acp_relay_trace_summary(
         codex_exec_failure_categories
     )
     trace["host_local_acp_codex_exec_failure_category"] = (
-        codex_exec_failure_categories[0] if codex_exec_failure_categories else ""
+        host_local_acp_codex_exec_failure_category
     )
     trace["host_local_acp_codex_exec_failure_raw_material_recorded"] = (
         raw_material_recorded
@@ -5869,11 +6104,14 @@ def _merge_host_local_acp_relay_trace_summary(
         or (
             agent_bridge_trace_count > 0
             and agent_bridge_request_count > 0
+            and agent_bridge_task_facing_success_count > 0
         )
     )
     if agent_trace_required:
         if agent_trace_satisfied:
             agent_trace_status = "agent_operation_trace_recorded"
+        elif agent_bridge_trace_count > 0 and agent_bridge_request_count > 0:
+            agent_trace_status = "agent_operation_trace_recorded_no_success"
         elif agent_bridge_trace_count > 0:
             agent_trace_status = "agent_operation_trace_present_no_requests"
         else:
@@ -5920,6 +6158,12 @@ def _merge_host_local_acp_relay_trace_summary(
     trace["remote_command_file_bridge_agent_task_facing_operation_count"] = (
         agent_bridge_task_facing_operation_count
     )
+    trace["remote_command_file_bridge_agent_task_facing_success_count"] = (
+        agent_bridge_task_facing_success_count
+    )
+    trace["remote_command_file_bridge_agent_task_facing_failure_count"] = (
+        agent_bridge_task_facing_failure_count
+    )
     trace["remote_command_file_bridge_agent_probe_operation_count"] = (
         agent_bridge_probe_operation_count
     )
@@ -5934,6 +6178,9 @@ def _merge_host_local_acp_relay_trace_summary(
     ] = dict(sorted(agent_bridge_successful_loopx_subcommand_counts.items()))
     trace["remote_command_file_bridge_agent_returncode_counts"] = dict(
         sorted(agent_bridge_returncode_counts.items())
+    )
+    trace["remote_command_file_bridge_agent_failure_category_counts"] = dict(
+        sorted(agent_bridge_failure_category_counts.items())
     )
     trace["remote_command_file_bridge_agent_todo_closeout_count"] = (
         _subcommand_family_count(
@@ -6024,7 +6271,7 @@ def _merge_host_local_acp_relay_trace_summary(
         codex_exec_failure_categories
     )
     prerequisites["host_local_acp_codex_exec_failure_category"] = (
-        codex_exec_failure_categories[0] if codex_exec_failure_categories else ""
+        host_local_acp_codex_exec_failure_category
     )
     prerequisites["host_local_acp_codex_exec_failure_raw_material_recorded"] = (
         raw_material_recorded
@@ -6065,6 +6312,12 @@ def _merge_host_local_acp_relay_trace_summary(
     prerequisites["remote_command_file_bridge_agent_task_facing_operation_count"] = (
         agent_bridge_task_facing_operation_count
     )
+    prerequisites["remote_command_file_bridge_agent_task_facing_success_count"] = (
+        agent_bridge_task_facing_success_count
+    )
+    prerequisites["remote_command_file_bridge_agent_task_facing_failure_count"] = (
+        agent_bridge_task_facing_failure_count
+    )
     prerequisites["remote_command_file_bridge_agent_probe_operation_count"] = (
         agent_bridge_probe_operation_count
     )
@@ -6079,6 +6332,9 @@ def _merge_host_local_acp_relay_trace_summary(
     ] = dict(sorted(agent_bridge_successful_loopx_subcommand_counts.items()))
     prerequisites["remote_command_file_bridge_agent_returncode_counts"] = dict(
         sorted(agent_bridge_returncode_counts.items())
+    )
+    prerequisites["remote_command_file_bridge_agent_failure_category_counts"] = dict(
+        sorted(agent_bridge_failure_category_counts.items())
     )
     prerequisites["remote_command_file_bridge_agent_todo_closeout_count"] = trace[
         "remote_command_file_bridge_agent_todo_closeout_count"
@@ -6595,6 +6851,19 @@ def _trace_max_int(trace: dict[str, Any], *fields: str) -> int:
     return max(values, default=0)
 
 
+def _product_mode_agent_bridge_closeout_observed(trace: dict[str, Any]) -> bool:
+    return bool(
+        _trace_max_int(trace, "remote_command_file_bridge_agent_todo_closeout_count")
+        > 0
+        and _trace_max_int(trace, "remote_command_file_bridge_agent_refresh_state_count")
+        > 0
+        and _trace_max_int(
+            trace, "remote_command_file_bridge_agent_quota_spend_slot_count"
+        )
+        > 0
+    )
+
+
 def _product_mode_solver_activity_observed(
     trace: dict[str, Any],
     round_result: Any | None,
@@ -6621,28 +6890,30 @@ def _product_mode_solver_activity_observed(
         )
         > 0
     )
+    bridge_success_count = _trace_max_int(
+        trace,
+        "remote_command_file_bridge_agent_success_count",
+    )
+    bridge_failure_count = _trace_max_int(
+        trace,
+        "remote_command_file_bridge_agent_failure_count",
+    )
+    legacy_recorded_without_success_counters = bool(
+        bridge_success_count == 0
+        and bridge_failure_count == 0
+        and trace.get("remote_command_file_bridge_agent_operation_trace_status")
+        == "agent_operation_trace_recorded"
+    )
     bridge_activity_observed = (
-        _trace_max_int(
-            trace,
-            "remote_command_file_bridge_agent_request_count",
-            "remote_command_file_bridge_agent_operation_trace_count",
-        )
-        > 0
+        bridge_success_count > 0
         or trace.get("remote_command_file_bridge_agent_operation_trace_satisfied")
         is True
-    )
-    agent_bridge_closeout_observed = (
-        _trace_max_int(trace, "remote_command_file_bridge_agent_todo_closeout_count")
-        > 0
-        and _trace_max_int(trace, "remote_command_file_bridge_agent_refresh_state_count")
-        > 0
-        and _trace_max_int(
-            trace, "remote_command_file_bridge_agent_quota_spend_slot_count"
-        )
-        > 0
+        or legacy_recorded_without_success_counters
     )
     if bridge_activity_observed:
-        return task_activity_observed and agent_bridge_closeout_observed
+        return task_activity_observed and _product_mode_agent_bridge_closeout_observed(
+            trace
+        )
     return task_activity_observed and agent_state_write_observed
 
 
@@ -7275,17 +7546,87 @@ def _build_product_mode_user(
             "has been recorded."
         )
 
-    def product_mode_workflow_entry_activity_satisfied() -> bool:
+    def final_closeout_prompt(round_number: int) -> str:
+        return (
+            f"Mandatory product-mode closeout checkpoint before finalization "
+            f"round {round_number}. The controller is at a finalization "
+            "boundary, but the selected P0 todo has not produced the required "
+            "`todo complete`, `refresh-state`, and `quota spend-slot "
+            "--source adapter --execute` evidence. This is not official "
+            "reward, pass/fail, verifier error, verifier output, or verifier "
+            "tail feedback. Do not answer with prose only and do not start a "
+            "new broad exploration loop. If local task-facing validation "
+            "indicates the selected P0 is complete, run this exact case-local "
+            "closeout sequence from `/app` now:\n\n"
+            f"{closeout_commands(round_number)}"
+            "If local validation does not support closeout, perform one "
+            "focused task-facing validation or repair operation from `/app`, "
+            "update the selected P0 todo with the concrete blocker evidence, "
+            f"and do not end with {DECLARED_DONE_MARKER}."
+        )
+
+    def final_closeout_checkpoint_budget_exhausted() -> bool:
+        return (
+            _trace_max_int(trace, "product_mode_final_closeout_checkpoint_count")
+            >= PRODUCT_MODE_FINAL_CLOSEOUT_MAX_CHECKPOINTS
+        )
+
+    def record_final_closeout_checkpoint(
+        *,
+        agent_round: int,
+        reason: str,
+    ) -> None:
+        trace["product_mode_final_closeout_required"] = True
+        trace["product_mode_final_closeout_checkpoint_max"] = (
+            PRODUCT_MODE_FINAL_CLOSEOUT_MAX_CHECKPOINTS
+        )
+        trace["product_mode_final_closeout_checkpoint_round"] = agent_round
+        trace["product_mode_final_closeout_reason"] = reason
+        current = trace.get("product_mode_final_closeout_checkpoint_count")
+        if not isinstance(current, int) or isinstance(current, bool):
+            current = 0
+        trace["product_mode_final_closeout_checkpoint_count"] = current + 1
+
+    def final_closeout_checkpoint_needed(
+        round_result: Any | None,
+        *,
+        task_instruction_sent: bool,
+    ) -> bool:
         return bool(
-            workflow_lifecycle_driver
-            and _product_mode_depth_gate_satisfied(trace)
+            treatment
+            and task_instruction_sent
+            and product_mode_entry_lifecycle_gate_satisfied()
+            and not _product_mode_solver_activity_observed(trace, round_result)
+            and not final_closeout_checkpoint_budget_exhausted()
+        )
+
+    def product_mode_workflow_entry_activity_satisfied() -> bool:
+        if not workflow_lifecycle_driver or not _product_mode_depth_gate_satisfied(trace):
+            return False
+        task_facing_success_count = _trace_max_int(
+            trace,
+            "remote_command_file_bridge_agent_task_facing_success_count",
+        )
+        task_facing_failure_count = _trace_max_int(
+            trace,
+            "remote_command_file_bridge_agent_task_facing_failure_count",
+        )
+        legacy_task_facing_recorded = bool(
+            task_facing_success_count == 0
+            and task_facing_failure_count == 0
+            and trace.get("remote_command_file_bridge_agent_operation_trace_status")
+            == "agent_operation_trace_recorded"
             and _trace_max_int(
                 trace,
-                "remote_command_file_bridge_agent_request_count",
-                "remote_command_file_bridge_agent_operation_trace_count",
                 "remote_command_file_bridge_agent_task_facing_operation_count",
             )
             > 0
+        )
+        return bool(
+            task_facing_success_count > 0
+            or trace.get("remote_command_file_bridge_agent_operation_trace_satisfied")
+            is True
+            or legacy_task_facing_recorded
         )
 
     def product_mode_entry_lifecycle_gate_satisfied() -> bool:
@@ -7396,6 +7737,24 @@ def _build_product_mode_user(
                             trace,
                             agent_round=round,
                         )
+                        _inc_counter(trace, "controller_action_decisions")
+                        if round < max_rounds:
+                            _inc_counter(trace, "followup_prompt_count")
+                            trace["last_decision"] = (
+                                "send_followup_after_product_mode_no_tool_calls_without_lifecycle"
+                                if no_tool_calls
+                                else "send_followup_after_product_mode_agent_no_lifecycle_requests"
+                            )
+                            return (
+                                f"Scheduled product-mode continuation round {round + 1} "
+                                f"of {max_rounds}. The previous round did not create "
+                                "task-facing bridge activity for the selected P0 todo, "
+                                "so it is not a valid closeout. Do not answer with "
+                                "status-only prose. Use the available sandbox "
+                                "command/file bridge now to inspect or modify the task "
+                                "workspace, then update the selected LoopX todo with "
+                                "public-safe evidence before any done/closeout claim."
+                            )
                         if no_tool_calls:
                             _record_product_mode_no_tool_call_lifecycle_abort(
                                 trace,
@@ -7406,7 +7765,6 @@ def _build_product_mode_user(
                                 trace,
                                 agent_round=round,
                             )
-                        _inc_counter(trace, "controller_action_decisions")
                         _inc_counter(trace, "stop_decision_count")
                         trace["last_decision"] = (
                             "stop_after_product_mode_agent_no_lifecycle_requests"
@@ -7478,6 +7836,22 @@ def _build_product_mode_user(
                             )
                             _inc_counter(trace, "controller_action_decisions")
                             if round >= max_rounds:
+                                if final_closeout_checkpoint_needed(
+                                    round_result,
+                                    task_instruction_sent=self._task_instruction_sent,
+                                ):
+                                    record_final_closeout_checkpoint(
+                                        agent_round=round,
+                                        reason=(
+                                            "declared_done_at_budget_without_selected_p0_closeout"
+                                        ),
+                                    )
+                                    _inc_counter(trace, "followup_prompt_count")
+                                    trace["last_decision"] = (
+                                        "send_product_mode_final_closeout_after_"
+                                        "declared_done_budget_boundary"
+                                    )
+                                    return final_closeout_prompt(round + 1)
                                 _inc_counter(trace, "stop_decision_count")
                                 trace["last_decision"] = (
                                     "stop_after_budget_with_declared_done_solver_activity_gap"
@@ -7539,6 +7913,25 @@ def _build_product_mode_user(
                     return None
             if reward is not None and reward >= 1.0:
                 _inc_counter(trace, "controller_action_decisions")
+                if final_closeout_checkpoint_needed(
+                    round_result,
+                    task_instruction_sent=self._task_instruction_sent,
+                ):
+                    _record_product_mode_solver_activity_gap(
+                        trace,
+                        agent_round=round,
+                    )
+                    record_final_closeout_checkpoint(
+                        agent_round=round,
+                        reason=(
+                            "official_success_observed_before_selected_p0_closeout"
+                        ),
+                    )
+                    _inc_counter(trace, "followup_prompt_count")
+                    trace["last_decision"] = (
+                        "send_product_mode_final_closeout_after_success_boundary"
+                    )
+                    return final_closeout_prompt(round + 1)
                 _inc_counter(trace, "stop_decision_count")
                 trace["last_decision"] = (
                     "stop_after_product_mode_official_success_observed_without_feedback"
@@ -7546,6 +7939,23 @@ def _build_product_mode_user(
                 return None
             if round >= max_rounds:
                 _inc_counter(trace, "controller_action_decisions")
+                if final_closeout_checkpoint_needed(
+                    round_result,
+                    task_instruction_sent=self._task_instruction_sent,
+                ):
+                    _record_product_mode_solver_activity_gap(
+                        trace,
+                        agent_round=round,
+                    )
+                    record_final_closeout_checkpoint(
+                        agent_round=round,
+                        reason="budget_boundary_without_selected_p0_closeout",
+                    )
+                    _inc_counter(trace, "followup_prompt_count")
+                    trace["last_decision"] = (
+                        "send_product_mode_final_closeout_after_budget_boundary"
+                    )
+                    return final_closeout_prompt(round + 1)
                 _inc_counter(trace, "stop_decision_count")
                 trace["last_decision"] = "stop_after_product_mode_budget"
                 return None
@@ -7810,6 +8220,12 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
             )
             prerequisites["remote_command_file_bridge_command_configured"] = True
             prerequisites["remote_command_file_bridge_agent_command_configured"] = True
+            prerequisites["remote_command_file_bridge_agent_command_instrumented"] = True
+            prerequisites["remote_command_file_bridge_agent_transport_mode"] = (
+                "json_file_queue"
+            )
+            prerequisites["remote_command_file_bridge_agent_queue_configured"] = True
+            prerequisites["remote_command_file_bridge_agent_queue_path_recorded"] = False
             prerequisites["remote_command_file_bridge_solver_wiring_configured"] = True
             prerequisites["remote_command_file_bridge_consumption_status"] = (
                 "solver_wiring_configured_pending_prompt"
@@ -9830,49 +10246,6 @@ def main(argv: list[str] | None = None) -> int:
             "remote_command_file_bridge_command_configured": True,
             "remote_command_file_bridge_solver_wiring_configured": False,
             "remote_command_file_bridge_consumed_by_solver": False,
-            "raw_logs_recorded": False,
-            "raw_task_text_read": False,
-            "raw_trajectory_recorded": False,
-            "credential_values_recorded": False,
-        }
-        print(json.dumps(payload, indent=2, sort_keys=True), file=sys.stderr)
-        return 2
-    if (
-        _is_loopx_product_mode_route(args.route)
-        and args.host_local_acp_launch
-        and product_host_local_bridge_sandbox_auto_wiring_pending
-        and not args.local_driver_worker_handshake_preflight
-        and not args.plan_only
-        and not args.reduce_only
-    ):
-        payload = {
-            "ok": False,
-            "error_type": "SkillsBenchProductModeBridgeAutoWiringPending",
-            "route": args.route,
-            "reason": (
-                "LoopX product-mode routes are countable only when the "
-                "host-local agent has an explicit sandbox command/file bridge "
-                "available before the scored case starts. A readiness "
-                "declaration without a solver bridge command leaves sandbox "
-                "bridge auto-wiring pending; prior runs can reach the agent "
-                "with zero task-facing bridge/tool calls, then fail after "
-                "consuming a scored attempt."
-            ),
-            "next_action": (
-                "rerun with a real --remote-command-file-bridge-solver-command "
-                "and a countable agent bridge command or instrumented wrapper; "
-                "use --plan-only or --local-driver-worker-handshake-preflight "
-                "for non-executing readiness inspection"
-            ),
-            "remote_command_file_bridge_materialized": (
-                product_host_local_bridge_materialized
-            ),
-            "remote_command_file_bridge_command_configured": False,
-            "remote_command_file_bridge_solver_wiring_configured": False,
-            "remote_command_file_bridge_consumed_by_solver": False,
-            "remote_command_file_bridge_consumption_status": (
-                "sandbox_bridge_auto_wiring_pending"
-            ),
             "raw_logs_recorded": False,
             "raw_task_text_read": False,
             "raw_trajectory_recorded": False,

--- a/scripts/skillsbench_reverse_channel_bridge.py
+++ b/scripts/skillsbench_reverse_channel_bridge.py
@@ -60,6 +60,18 @@ def _send_json_line(sock: socket.socket, payload: dict[str, Any]) -> None:
     sock.sendall(json.dumps(payload, separators=(",", ":")).encode() + b"\n")
 
 
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(
+        f"{path.name}.{os.getpid()}.{time.monotonic_ns()}.tmp"
+    )
+    tmp_path.write_text(
+        json.dumps(payload, separators=(",", ":"), sort_keys=True),
+        encoding="utf-8",
+    )
+    os.replace(tmp_path, path)
+
+
 def _recv_json_line(conn: socket.socket) -> dict[str, Any]:
     data = b""
     while not data.endswith(b"\n"):
@@ -95,7 +107,18 @@ def _allowed_env_assignments(extra: object) -> str:
 
 
 def _bridge_command_with_payload_env(command: str, extra: object) -> str:
-    return command.replace("{loopx_allowed_env}", _allowed_env_assignments(extra))
+    private_bridge_command = ""
+    if isinstance(extra, dict):
+        private_bridge_command = str(extra.get("private_bridge_command") or "")
+        env_extra = extra.get("env") if isinstance(extra.get("env"), dict) else extra
+    else:
+        env_extra = extra
+    command = command.replace("{private_bridge_command}", private_bridge_command)
+    command = command.replace(
+        "{private_bridge_command_sh}",
+        shlex.quote(private_bridge_command),
+    )
+    return command.replace("{loopx_allowed_env}", _allowed_env_assignments(env_extra))
 
 
 def _stop_process_group(proc: subprocess.Popen[str], *, sig: int) -> None:
@@ -161,6 +184,41 @@ def _read_agent_operations_jsonl(path: Path | None) -> str:
         return ""
 
 
+def _bridge_summary_has_inflight_operation(path: Path | None) -> bool:
+    if path is None or not path.exists():
+        return False
+    starts = 0
+    completions = 0
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return False
+    for line in lines:
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(record, dict):
+            continue
+        phase = str(record.get("record_phase") or "").strip().lower()
+        if phase == "complete" and not _bridge_operation_record_interrupted(record):
+            completions += 1
+        elif phase == "start" or record.get("operation_observed") is True:
+            starts += 1
+    return starts > completions
+
+
+def _bridge_operation_record_interrupted(record: dict[str, Any]) -> bool:
+    rc = record.get("returncode")
+    if isinstance(rc, int) and not isinstance(rc, bool) and rc < 0:
+        return True
+    category = str(record.get("failure_category") or "")
+    return record.get("interrupted") is True or category in {
+        "bridge_operation_interrupted",
+        "bridge_controller_interrupted",
+    }
+
+
 def _replace_output_last_message(args: list[str], replacement: Path) -> str | None:
     for index, token in enumerate(args[:-1]):
         if token == "--output-last-message":
@@ -201,6 +259,9 @@ def _prompt_requires_bridge_first_action(prompt: str) -> bool:
     lowered = text.lower()
     required_markers = (
         "loopx_skillsbench_local_acp_relay_bridge_ready",
+        "mandatory product-mode solver checkpoint",
+        "mandatory product-mode closeout checkpoint",
+        "must start with either a task-facing sandbox bridge operation",
         "your first tool action should be a shell",
         "your first agent action must be a shell/tool call",
         "your first agent action must be a task-facing shell/tool call",
@@ -358,12 +419,17 @@ record["task_facing_operation"] = bool(
     or (operation == "exec" and not subcommands)
 )
 record["operation_observed"] = True
-try:
-    SUMMARY_PATH.parent.mkdir(parents=True, exist_ok=True)
-    with SUMMARY_PATH.open("a", encoding="utf-8") as fh:
-        fh.write(json.dumps(record, sort_keys=True) + "\\n")
-except OSError:
-    pass
+
+def append_record(item: dict[str, object]) -> None:
+    try:
+        SUMMARY_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with SUMMARY_PATH.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(item, sort_keys=True) + "\\n")
+    except OSError:
+        pass
+
+record["record_phase"] = "start"
+append_record(record)
 proc = subprocess.run(
     bridge_command(),
     input=raw,
@@ -372,6 +438,27 @@ proc = subprocess.run(
     stderr=subprocess.PIPE,
     shell=True,
 )
+complete_record = dict(record)
+complete_record["record_phase"] = "complete"
+complete_record["returncode"] = int(proc.returncode)
+complete_record["success"] = proc.returncode == 0
+complete_record["stdout_bytes"] = len((proc.stdout or "").encode("utf-8"))
+complete_record["stderr_bytes"] = len((proc.stderr or "").encode("utf-8"))
+if proc.returncode != 0:
+    stderr_text = proc.stderr or ""
+    if int(proc.returncode) < 0:
+        complete_record["failure_category"] = "bridge_operation_interrupted"
+        complete_record["interrupted"] = True
+        complete_record["controller_interrupted"] = True
+    elif "PermissionError" in stderr_text or "Operation not permitted" in stderr_text:
+        complete_record["failure_category"] = "bridge_client_permission_error"
+    elif "No such file or directory" in stderr_text:
+        complete_record["failure_category"] = "bridge_command_not_found"
+    elif proc.returncode == 255 and bridge_command().lstrip().startswith("ssh "):
+        complete_record["failure_category"] = "bridge_ssh_unavailable"
+    else:
+        complete_record["failure_category"] = "bridge_command_failed"
+append_record(complete_record)
 sys.stdout.write(proc.stdout)
 sys.stderr.write(proc.stderr)
 raise SystemExit(proc.returncode)
@@ -449,15 +536,16 @@ def _run_codex_payload(
             ):
                 first_action_deadline = (
                     time.monotonic() + max(1.0, float(first_action_timeout_sec))
-                )
+            )
             first_action_seen = not bool(first_action_deadline)
             bridge_idle_timeout_sec = max(0.0, float(bridge_idle_timeout_sec or 0.0))
+            bridge_activity_seen = False
             last_agent_operations_size = 0
             last_bridge_activity_at = time.monotonic()
             timeout_kind = ""
             while proc.poll() is None:
                 now = time.monotonic()
-                if not first_action_seen and agent_operations_summary_path:
+                if agent_operations_summary_path:
                     try:
                         current_agent_operations_size = (
                             agent_operations_summary_path.stat().st_size
@@ -467,17 +555,21 @@ def _run_codex_payload(
                     if current_agent_operations_size > last_agent_operations_size:
                         last_agent_operations_size = current_agent_operations_size
                         last_bridge_activity_at = now
+                        bridge_activity_seen = True
                         first_action_seen = True
-                    elif current_agent_operations_size > 0:
+                    elif not first_action_seen and current_agent_operations_size > 0:
                         first_action_seen = True
                 if not first_action_seen and first_action_deadline and now >= first_action_deadline:
                     timeout_kind = "codex_exec_first_action_timeout"
                     _stop_process_group(proc, sig=signal.SIGTERM)
                     break
                 if (
-                    first_action_seen
+                    bridge_activity_seen
                     and agent_operations_summary_path is not None
                     and bridge_idle_timeout_sec > 0
+                    and not _bridge_summary_has_inflight_operation(
+                        agent_operations_summary_path
+                    )
                     and now - last_bridge_activity_at >= bridge_idle_timeout_sec
                 ):
                     timeout_kind = "codex_exec_bridge_idle_timeout"
@@ -585,7 +677,7 @@ def _run_json_bridge_payload(
         }
     payload_env = payload.get("env")
     env = _safe_env(payload_env)
-    command = _bridge_command_with_payload_env(bridge_command, payload_env)
+    command = _bridge_command_with_payload_env(bridge_command, payload)
     try:
         proc = subprocess.run(
             command,
@@ -670,6 +762,66 @@ def _serve_socket(
             pass
 
 
+def _serve_json_file_queue(
+    queue_dir: Path,
+    *,
+    once: bool,
+    poll_interval_sec: float,
+    handler: Any,
+) -> int:
+    requests_dir = queue_dir / "requests"
+    processing_dir = queue_dir / "processing"
+    responses_dir = queue_dir / "responses"
+    requests_dir.mkdir(parents=True, exist_ok=True)
+    processing_dir.mkdir(parents=True, exist_ok=True)
+    responses_dir.mkdir(parents=True, exist_ok=True)
+    poll_interval_sec = max(0.01, float(poll_interval_sec or 0.05))
+    while True:
+        for request_path in sorted(requests_dir.glob("*.json")):
+            processing_path = processing_dir / request_path.name
+            try:
+                os.replace(request_path, processing_path)
+            except FileNotFoundError:
+                continue
+            except OSError:
+                continue
+            response_path = responses_dir / request_path.name
+            try:
+                try:
+                    payload_raw = processing_path.read_text(encoding="utf-8")
+                    payload = json.loads(payload_raw or "{}")
+                    if not isinstance(payload, dict):
+                        payload = {}
+                    response = handler(payload)
+                except Exception as exc:  # keep client deterministic
+                    response = {
+                        "schema_version": SERVER_RESPONSE_SCHEMA_VERSION,
+                        "exit_code": 1,
+                        "stdout": "",
+                        "stderr": type(exc).__name__,
+                        "raw_task_text_recorded": False,
+                        "credential_values_recorded": False,
+                    }
+                if not isinstance(response, dict):
+                    response = {
+                        "schema_version": SERVER_RESPONSE_SCHEMA_VERSION,
+                        "exit_code": 1,
+                        "stdout": "",
+                        "stderr": "invalid bridge response",
+                        "raw_task_text_recorded": False,
+                        "credential_values_recorded": False,
+                    }
+                _atomic_write_json(response_path, response)
+            finally:
+                try:
+                    processing_path.unlink()
+                except FileNotFoundError:
+                    pass
+            if once:
+                return 0
+        time.sleep(poll_interval_sec)
+
+
 def _write_codex_client(socket_path: str, output_path: Path) -> None:
     script = f"""#!/usr/bin/env python3
 import json, os, socket, sys
@@ -730,6 +882,71 @@ sys.exit(int(resp.get('exit_code') or 0))
     output_path.chmod(0o700)
 
 
+def _write_json_file_client(queue_dir: str, output_path: Path) -> None:
+    script = f"""#!/usr/bin/env python3
+import json, os, sys, time, uuid
+from pathlib import Path
+QUEUE = Path({queue_dir!r})
+REQUESTS = QUEUE / 'requests'
+RESPONSES = QUEUE / 'responses'
+
+def fail(message: str) -> None:
+    sys.stderr.write(message + '\\n')
+    raise SystemExit(125)
+
+def atomic_write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f"{{path.name}}.{{os.getpid()}}.{{time.monotonic_ns()}}.tmp")
+    tmp.write_text(json.dumps(payload, separators=(',', ':'), sort_keys=True), encoding='utf-8')
+    os.replace(tmp, path)
+
+request_id = f"{{int(time.time() * 1000)}}-{{os.getpid()}}-{{uuid.uuid4().hex}}"
+payload = {{
+    'schema_version': {CLIENT_SCHEMA_VERSION!r},
+    'request_id': request_id,
+    'stdin': sys.stdin.read(),
+    'env': {{k: os.environ.get(k, '') for k in ('AI_ADDR','AI_PORT','GOAL_HARNESS_REMOTE_BENCH_ROOT')}},
+    'private_bridge_command': os.environ.get('LOOPX_PRIVATE_BRIDGE_COMMAND', ''),
+}}
+request_path = REQUESTS / f"{{request_id}}.json"
+response_path = RESPONSES / f"{{request_id}}.json"
+try:
+    atomic_write_json(request_path, payload)
+except OSError as exc:
+    fail(f"reverse channel request write failed: {{type(exc).__name__}}")
+deadline = time.monotonic() + float(os.environ.get(
+    'LOOPX_REVERSE_RESPONSE_TIMEOUT_SEC',
+    os.environ.get('LOOPX_REVERSE_JSON_TIMEOUT_SEC', '300'),
+))
+resp = None
+while time.monotonic() < deadline:
+    try:
+        if response_path.exists():
+            resp = json.loads(response_path.read_text(encoding='utf-8') or '{{}}')
+            break
+    except json.JSONDecodeError:
+        fail('reverse channel response invalid')
+    except OSError:
+        pass
+    time.sleep(float(os.environ.get('LOOPX_REVERSE_FILE_POLL_INTERVAL_SEC', '0.05')))
+if resp is None:
+    fail('reverse channel response missing')
+if not isinstance(resp, dict):
+    fail('reverse channel response invalid')
+try:
+    response_path.unlink()
+except OSError:
+    pass
+out = resp.get('stdout')
+err = resp.get('stderr')
+if isinstance(out, str): sys.stdout.write(out)
+if isinstance(err, str): sys.stderr.write(err)
+sys.exit(int(resp.get('exit_code') or 0))
+"""
+    output_path.write_text(script, encoding="utf-8")
+    output_path.chmod(0o700)
+
+
 def _write_json_client(socket_path: str, output_path: Path) -> None:
     script = f"""#!/usr/bin/env python3
 import json, os, socket, sys
@@ -738,6 +955,7 @@ payload = {{
     'schema_version': {CLIENT_SCHEMA_VERSION!r},
     'stdin': sys.stdin.read(),
     'env': {{k: os.environ.get(k, '') for k in ('AI_ADDR','AI_PORT','GOAL_HARNESS_REMOTE_BENCH_ROOT')}},
+    'private_bridge_command': os.environ.get('LOOPX_PRIVATE_BRIDGE_COMMAND', ''),
 }}
 s=socket.socket(socket.AF_UNIX)
 s.settimeout(float(os.environ.get('LOOPX_REVERSE_CONNECT_TIMEOUT_SEC', '30')))
@@ -831,9 +1049,28 @@ def main(argv: list[str] | None = None) -> int:
     json_server.add_argument("--timeout-sec", type=float, default=300.0)
     json_server.add_argument("--once", action="store_true")
 
+    json_file_server = sub.add_parser("serve-json-file")
+    json_file_server.add_argument("--queue-dir", required=True)
+    json_file_server.add_argument(
+        "--bridge-command",
+        required=True,
+        help=(
+            "Private JSON bridge command. Use {loopx_allowed_env} inside nested "
+            "remote commands to forward AI_ADDR/AI_PORT without logging values."
+        ),
+    )
+    json_file_server.add_argument("--timeout-sec", type=float, default=300.0)
+    json_file_server.add_argument("--poll-interval-sec", type=float, default=0.05)
+    json_file_server.add_argument("--once", action="store_true")
+
     write_client = sub.add_parser("write-client")
-    write_client.add_argument("--kind", choices=("codex", "json"), required=True)
-    write_client.add_argument("--socket", required=True)
+    write_client.add_argument(
+        "--kind",
+        choices=("codex", "json", "json-file"),
+        required=True,
+    )
+    write_client.add_argument("--socket")
+    write_client.add_argument("--queue-dir")
     write_client.add_argument("--output", required=True)
 
     probe = sub.add_parser("probe-socket")
@@ -864,13 +1101,32 @@ def main(argv: list[str] | None = None) -> int:
                 default_timeout_sec=args.timeout_sec,
             ),
         )
+    if args.command == "serve-json-file":
+        return _serve_json_file_queue(
+            Path(args.queue_dir),
+            once=bool(args.once),
+            poll_interval_sec=args.poll_interval_sec,
+            handler=lambda payload: _run_json_bridge_payload(
+                payload,
+                bridge_command=args.bridge_command,
+                default_timeout_sec=args.timeout_sec,
+            ),
+        )
     if args.command == "write-client":
         output = Path(args.output)
         output.parent.mkdir(parents=True, exist_ok=True)
         if args.kind == "codex":
+            if not args.socket:
+                parser.error("--socket is required for --kind codex")
             _write_codex_client(args.socket, output)
-        else:
+        elif args.kind == "json":
+            if not args.socket:
+                parser.error("--socket is required for --kind json")
             _write_json_client(args.socket, output)
+        else:
+            if not args.queue_dir:
+                parser.error("--queue-dir is required for --kind json-file")
+            _write_json_file_client(args.queue_dir, output)
         print(json.dumps({"ok": True, "kind": args.kind, "raw_path_recorded": False}))
         return 0
     if args.command == "probe-socket":


### PR DESCRIPTION
## Summary

- add decision-scope todo metadata/projection, monitor expires_at scheduling, agent_member markdown, and task-graph projection updates
- harden SkillsBench reverse-channel/host-local runtime closeout so controller-interrupted bridge operations remain inflight instead of becoming bridge command failures
- update the SkillsBench case ledger with the latest compact 3d-scan-calc goal-start status while omitting private artifact paths

## Notes

- origin/main already had boundary-authority expires_at, but not monitor-todo expires_at scheduling/projection. This PR adds the monitor-todo layer.
- loopx/status.py already carried the large SkillsBench reducer on main. This PR does not grow that coupling materially; a full reducer extraction should be a separate focused PR so it is reviewable.

## Validation

- python3 -m py_compile loopx/benchmark_adapters/skillsbench.py loopx/benchmark_adapters/skillsbench_acp_relay.py loopx/cli_commands/status.py loopx/cli_commands/todo.py loopx/projections/task_graph.py loopx/quota.py loopx/review_packet.py loopx/state_projection.py loopx/status.py loopx/todo_contract.py loopx/todo_followups.py loopx/todos.py scripts/skillsbench_automation_loop.py scripts/skillsbench_reverse_channel_bridge.py
- python3 examples/skillsbench-benchmark-run-smoke.py
- python3 examples/skillsbench-host-local-launch-plan-smoke.py
- python3 examples/skillsbench-reverse-channel-bridge-smoke.py
- python3 examples/todo-cli-smoke.py
- python3 examples/quota-agent-scoped-user-gate-smoke.py
- python3 examples/status-markdown-smoke.py
- python3 examples/task-graph-projection-fixture-smoke.py
- python3 examples/monitor-scheduler-contract-smoke.py
- python3 examples/benchmark-run-ledger-smoke.py
- python3 -m json.tool docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
- python3 -m json.tool examples/fixtures/task-graph-projection-status.public.json
- git diff --check

## Boundary

- staged by explicit pathspecs only
- no untracked files included
- scanned staged diffs for credentials, private local paths, raw task text, raw trajectories, verifier output, and generated private logs
- removed newly-added .local/private-benchmark-jobs artifact refs from the public ledger
