### PR TITLE
Extract decision-scope gate relation

### DIFF
--- a/examples/quota-agent-scoped-user-gate-smoke.py
+++ b/examples/quota-agent-scoped-user-gate-smoke.py
@@ -11,6 +11,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from loopx.decision_scope import todo_gate_relation  # noqa: E402
 from loopx.quota import build_quota_should_run  # noqa: E402
 
 
@@ -539,6 +540,89 @@ def exact_todo_gate_status_payload(*, include_fallback: bool = True) -> dict:
     }
 
 
+def exact_todo_gate_with_decision_scope_migration_payload() -> dict:
+    benchmark_gate = todo_item(
+        todo_id="todo_benchmark_owner_gate",
+        text="Owner must choose the benchmark run target before benchmark execution.",
+        role="user",
+        task_class="user_gate",
+        action_kind="benchmark_run",
+        blocks_agent="codex-main-control",
+    )
+    benchmark_gate["unblocks_todo_id"] = "todo_blocked_benchmark_run"
+    benchmark_gate["decision_scope"] = {
+        "schema_version": "decision_scope_v0",
+        "kind": "direction",
+        "granularity": "action",
+        "scope_key": "benchmark_target_choice",
+    }
+    blocked_benchmark = todo_item(
+        todo_id="todo_blocked_benchmark_run",
+        text="[P1] Run the gated benchmark target after owner choice.",
+        claimed_by="codex-main-control",
+        action_kind="benchmark_run",
+    )
+    independent_benchmark = todo_item(
+        todo_id="todo_benchmark_ledger_cleanup",
+        text="[P1] Clean public-safe benchmark ledger summaries while target choice is pending.",
+        claimed_by="codex-main-control",
+        action_kind="benchmark_run",
+    )
+    return {
+        "ok": True,
+        "goal_count": 1,
+        "run_count": 0,
+        "attention_queue": {
+            "items": [
+                {
+                    "goal_id": GOAL_ID,
+                    "status": "active_state_user_todo",
+                    "waiting_on": "controller",
+                    "severity": "action",
+                    "source": "active_state",
+                    "recommended_action": "Choose benchmark target.",
+                    "quota": {
+                        "compute": 1.0,
+                        "window_hours": 24,
+                        "slot_minutes": 1,
+                        "allowed_slots": 1440,
+                        "spent_slots": 0,
+                        "state": "operator_gate",
+                        "blocked_action_scope": "gated_delivery",
+                        "safe_bypass_allowed": True,
+                        "safe_bypass_policy": (
+                            "Only the exact gated todo is blocked; independent "
+                            "public-safe agent work may continue during scope migration."
+                        ),
+                        "reason": "operator gate blocks gated delivery; safe non-gated steering may continue",
+                    },
+                    "user_todos": todo_summary(benchmark_gate, source_section="User Todo"),
+                    "agent_todos": todo_summary_items(
+                        [blocked_benchmark, independent_benchmark],
+                        source_section="Agent Todo",
+                    ),
+                }
+            ]
+        },
+        "run_history": {
+            "goals": [
+                {
+                    "id": GOAL_ID,
+                    "registry_member": True,
+                    "status": "active",
+                    "adapter_kind": "fixture_adapter_v0",
+                    "adapter_status": "connected",
+                    "coordination": {
+                        "primary_agent": "codex-main-control",
+                        "registered_agents": ["codex-main-control"],
+                    },
+                    "latest_runs": [],
+                }
+            ]
+        },
+    }
+
+
 def decision_scope_status_payload() -> dict:
     benchmark_gate = todo_item(
         todo_id="todo_benchmark_scope_gate",
@@ -675,6 +759,64 @@ def assert_exact_todo_gate_only_blocks_target_todo() -> None:
     assert "todo_x_launch_monitor" in blocked_monitor_ids, blocked_payload["agent_todo_summary"]
 
 
+def assert_exact_todo_gate_survives_decision_scope_migration() -> None:
+    payload = build_quota_should_run(
+        exact_todo_gate_with_decision_scope_migration_payload(),
+        goal_id=GOAL_ID,
+        agent_id="codex-main-control",
+    )
+    assert payload["should_run"] is True, payload
+    assert payload["decision"] == "safe_bypass_user_gate_fallback", payload
+    fallback = payload["scoped_user_gate_fallback"]
+    blocked = fallback["blocked_agent_items"][0]
+    assert blocked["todo_id"] == "todo_blocked_benchmark_run", fallback
+    relation = blocked["todo_gate_relation"]
+    assert relation["source"] == "unblocks_todo_id", relation
+    assert relation["state"] == "gate_targets_todo", relation
+    scope_relation = relation["decision_scope_relation"]
+    assert scope_relation["source"] == "decision_scope", scope_relation
+    assert scope_relation["state"] == "independent", scope_relation
+    assert scope_relation["reason"] == "agent_todo_has_no_required_decision_scopes", scope_relation
+    selected = fallback["selected_executable"]
+    assert selected["todo_id"] == "todo_benchmark_ledger_cleanup", fallback
+    assert selected["todo_gate_relation"]["source"] == "unblocks_todo_id", selected
+    assert selected["todo_gate_relation"]["state"] == "independent", selected
+
+
+def assert_conflicting_exact_and_decision_scope_requires_projection_repair() -> None:
+    gate = {
+        "todo_id": "todo_gate_conflict",
+        "task_class": "user_gate",
+        "unblocks_todo_id": "todo_exact_target",
+        "decision_scope": {
+            "schema_version": "decision_scope_v0",
+            "kind": "direction",
+            "granularity": "action",
+            "scope_key": "benchmark_target_choice",
+        },
+    }
+    agent_item = {
+        "todo_id": "todo_semantic_target",
+        "task_class": "advancement_task",
+        "required_decision_scopes": [
+            {
+                "schema_version": "decision_scope_v0",
+                "kind": "direction",
+                "granularity": "action",
+                "scope_key": "benchmark_target_choice",
+            }
+        ],
+    }
+    relation = todo_gate_relation(gate, agent_item)
+    assert relation["source"] == "unblocks_todo_id+decision_scope", relation
+    assert relation["state"] == "projection_repair_required", relation
+    assert relation["reason"] == (
+        "decision_scope_covers_agent_todo_but_unblocks_todo_targets_different_todo"
+    ), relation
+    assert relation["exact_todo_relation"]["state"] == "independent", relation
+    assert relation["decision_scope_relation"]["state"] == "gate_covers_action", relation
+
+
 def assert_decision_scope_overrides_shared_action_kind_tokens() -> None:
     payload = build_quota_should_run(
         decision_scope_status_payload(),
@@ -762,6 +904,8 @@ def main() -> int:
     assert_unscoped_user_gate_remains_global()
     assert_unrelated_user_gate_allows_feishu_fallback()
     assert_exact_todo_gate_only_blocks_target_todo()
+    assert_exact_todo_gate_survives_decision_scope_migration()
+    assert_conflicting_exact_and_decision_scope_requires_projection_repair()
     assert_decision_scope_overrides_shared_action_kind_tokens()
     assert_agent_without_advancement_candidate_and_only_monitor_work_stays_quiet()
     print("quota-agent-scoped-user-gate-smoke ok")

--- a/loopx/decision_scope.py
+++ b/loopx/decision_scope.py
@@ -1,0 +1,151 @@
+"""Decision-scope relation helpers for LoopX user gates.
+
+This module keeps user-gate dependency semantics out of quota allocation so
+other control-plane surfaces can reason about the same exact-todo and
+decision-scope relations without importing the quota runtime.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .todo_contract import (
+    normalize_todo_decision_scope,
+    normalize_todo_id,
+    normalize_todo_required_decision_scopes,
+)
+
+
+DECISION_SCOPE_GRANULARITY_RANK = {
+    "action": 0,
+    "lane": 1,
+    "goal": 2,
+    "project": 3,
+    "global": 4,
+}
+
+TODO_GATE_BLOCKING_STATES = frozenset(
+    {"gate_targets_todo", "gate_covers_action", "projection_repair_required"}
+)
+
+
+def decision_scope_covers(gate_scope: dict[str, Any], required_scope: dict[str, Any]) -> bool:
+    gate = normalize_todo_decision_scope(gate_scope)
+    required = normalize_todo_decision_scope(required_scope)
+    if not gate or not required:
+        return False
+    if gate["kind"] != required["kind"]:
+        return False
+    if gate["scope_key"] not in {required["scope_key"], "*"}:
+        return False
+    return DECISION_SCOPE_GRANULARITY_RANK[gate["granularity"]] >= DECISION_SCOPE_GRANULARITY_RANK[
+        required["granularity"]
+    ]
+
+
+def decision_scope_gate_relation(
+    gate: dict[str, Any],
+    agent_item: dict[str, Any],
+) -> dict[str, Any] | None:
+    gate_scope = normalize_todo_decision_scope(gate.get("decision_scope"))
+    required_scopes = normalize_todo_required_decision_scopes(
+        agent_item.get("required_decision_scopes")
+    )
+    if not gate_scope:
+        return None
+    if not required_scopes:
+        return {
+            "schema_version": "decision_scope_relation_v0",
+            "source": "decision_scope",
+            "state": "independent",
+            "reason": "agent_todo_has_no_required_decision_scopes",
+            "gate_todo_id": normalize_todo_id(gate.get("todo_id")),
+            "agent_todo_id": normalize_todo_id(agent_item.get("todo_id")),
+            "decision_scope": gate_scope,
+            "required_decision_scopes": [],
+        }
+    for required_scope in required_scopes:
+        if decision_scope_covers(gate_scope, required_scope):
+            return {
+                "schema_version": "decision_scope_relation_v0",
+                "source": "decision_scope",
+                "state": "gate_covers_action",
+                "gate_todo_id": normalize_todo_id(gate.get("todo_id")),
+                "agent_todo_id": normalize_todo_id(agent_item.get("todo_id")),
+                "decision_scope": gate_scope,
+                "matched_required_decision_scope": required_scope,
+                "required_decision_scopes": required_scopes,
+            }
+    return {
+        "schema_version": "decision_scope_relation_v0",
+        "source": "decision_scope",
+        "state": "independent",
+        "gate_todo_id": normalize_todo_id(gate.get("todo_id")),
+        "agent_todo_id": normalize_todo_id(agent_item.get("todo_id")),
+        "decision_scope": gate_scope,
+        "required_decision_scopes": required_scopes,
+    }
+
+
+def exact_todo_gate_relation(
+    gate: dict[str, Any],
+    agent_item: dict[str, Any],
+) -> dict[str, Any] | None:
+    target_todo_id = normalize_todo_id(gate.get("unblocks_todo_id"))
+    if not target_todo_id:
+        return None
+    agent_todo_id = normalize_todo_id(agent_item.get("todo_id"))
+    return {
+        "schema_version": "todo_gate_relation_v0",
+        "source": "unblocks_todo_id",
+        "state": "gate_targets_todo" if target_todo_id == agent_todo_id else "independent",
+        "gate_todo_id": normalize_todo_id(gate.get("todo_id")),
+        "target_todo_id": target_todo_id,
+        "agent_todo_id": agent_todo_id,
+    }
+
+
+def todo_gate_relation(gate: dict[str, Any], agent_item: dict[str, Any]) -> dict[str, Any] | None:
+    exact_relation = exact_todo_gate_relation(gate, agent_item)
+    scope_relation = decision_scope_gate_relation(gate, agent_item)
+
+    if (
+        exact_relation
+        and scope_relation
+        and exact_relation.get("state") == "independent"
+        and scope_relation.get("state") == "gate_covers_action"
+    ):
+        return {
+            "schema_version": "todo_gate_relation_v0",
+            "source": "unblocks_todo_id+decision_scope",
+            "state": "projection_repair_required",
+            "reason": "decision_scope_covers_agent_todo_but_unblocks_todo_targets_different_todo",
+            "gate_todo_id": exact_relation.get("gate_todo_id"),
+            "target_todo_id": exact_relation.get("target_todo_id"),
+            "agent_todo_id": exact_relation.get("agent_todo_id"),
+            "exact_todo_relation": exact_relation,
+            "decision_scope_relation": scope_relation,
+        }
+
+    if exact_relation and exact_relation.get("state") == "gate_targets_todo":
+        if scope_relation:
+            exact_relation["decision_scope_relation"] = scope_relation
+        return exact_relation
+
+    if scope_relation and scope_relation.get("state") == "gate_covers_action":
+        if exact_relation:
+            scope_relation["exact_todo_relation"] = exact_relation
+        return scope_relation
+
+    if exact_relation:
+        if scope_relation:
+            exact_relation["decision_scope_relation"] = scope_relation
+        return exact_relation
+
+    return scope_relation
+
+
+def todo_gate_relation_blocks_agent(relation: dict[str, Any] | None) -> bool:
+    if not relation:
+        return False
+    return relation.get("state") in TODO_GATE_BLOCKING_STATES

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -18,6 +18,7 @@ from .control_plane import (
     control_plane_policy_summary,
     control_plane_self_repair_allows,
 )
+from .decision_scope import todo_gate_relation, todo_gate_relation_blocks_agent
 from .delivery_outcome import (
     ACCOUNTABLE_DELIVERY_OUTCOMES,
     DeliveryOutcome,
@@ -2168,96 +2169,14 @@ def _todo_action_scope_tokens(item: dict[str, Any]) -> set[str]:
     return _action_scope_tokens_from_text(text)
 
 
-_DECISION_SCOPE_GRANULARITY_RANK = {
-    "action": 0,
-    "lane": 1,
-    "goal": 2,
-    "project": 3,
-    "global": 4,
-}
-
-
-def _decision_scope_covers(gate_scope: dict[str, Any], required_scope: dict[str, Any]) -> bool:
-    gate = normalize_todo_decision_scope(gate_scope)
-    required = normalize_todo_decision_scope(required_scope)
-    if not gate or not required:
-        return False
-    if gate["kind"] != required["kind"]:
-        return False
-    if gate["scope_key"] not in {required["scope_key"], "*"}:
-        return False
-    return _DECISION_SCOPE_GRANULARITY_RANK[gate["granularity"]] >= _DECISION_SCOPE_GRANULARITY_RANK[
-        required["granularity"]
-    ]
-
-
-def _decision_scope_gate_relation(
-    gate: dict[str, Any],
-    agent_item: dict[str, Any],
-) -> dict[str, Any] | None:
-    gate_scope = normalize_todo_decision_scope(gate.get("decision_scope"))
-    required_scopes = normalize_todo_required_decision_scopes(
-        agent_item.get("required_decision_scopes")
-    )
-    if not gate_scope:
-        return None
-    if not required_scopes:
-        return {
-            "schema_version": "decision_scope_relation_v0",
-            "source": "decision_scope",
-            "state": "independent",
-            "reason": "agent_todo_has_no_required_decision_scopes",
-            "gate_todo_id": normalize_todo_id(gate.get("todo_id")),
-            "agent_todo_id": normalize_todo_id(agent_item.get("todo_id")),
-            "decision_scope": gate_scope,
-            "required_decision_scopes": [],
-        }
-    for required_scope in required_scopes:
-        if _decision_scope_covers(gate_scope, required_scope):
-            return {
-                "schema_version": "decision_scope_relation_v0",
-                "source": "decision_scope",
-                "state": "gate_covers_action",
-                "gate_todo_id": normalize_todo_id(gate.get("todo_id")),
-                "agent_todo_id": normalize_todo_id(agent_item.get("todo_id")),
-                "decision_scope": gate_scope,
-                "matched_required_decision_scope": required_scope,
-                "required_decision_scopes": required_scopes,
-            }
-    return {
-        "schema_version": "decision_scope_relation_v0",
-        "source": "decision_scope",
-        "state": "independent",
-        "gate_todo_id": normalize_todo_id(gate.get("todo_id")),
-        "agent_todo_id": normalize_todo_id(agent_item.get("todo_id")),
-        "decision_scope": gate_scope,
-        "required_decision_scopes": required_scopes,
-    }
-
-
 def _todo_gate_relation(gate: dict[str, Any], agent_item: dict[str, Any]) -> dict[str, Any] | None:
-    decision_scope_relation = _decision_scope_gate_relation(gate, agent_item)
-    if decision_scope_relation:
-        return decision_scope_relation
-
-    target_todo_id = normalize_todo_id(gate.get("unblocks_todo_id"))
-    if not target_todo_id:
-        return None
-    agent_todo_id = normalize_todo_id(agent_item.get("todo_id"))
-    return {
-        "schema_version": "todo_gate_relation_v0",
-        "source": "unblocks_todo_id",
-        "state": "gate_targets_todo" if target_todo_id == agent_todo_id else "independent",
-        "gate_todo_id": normalize_todo_id(gate.get("todo_id")),
-        "target_todo_id": target_todo_id,
-        "agent_todo_id": agent_todo_id,
-    }
+    return todo_gate_relation(gate, agent_item)
 
 
 def _user_gate_blocks_agent_item(gate: dict[str, Any], agent_item: dict[str, Any]) -> bool:
     relation = _todo_gate_relation(gate, agent_item)
     if relation:
-        return relation.get("state") in {"gate_targets_todo", "gate_covers_action"}
+        return todo_gate_relation_blocks_agent(relation)
 
     gate_action_tokens = _todo_action_kind_tokens(gate)
     agent_action_tokens = _todo_action_kind_tokens(agent_item)


### PR DESCRIPTION
## Summary
- Extract user-gate decision-scope and exact-todo relation logic from `quota.py` into `loopx/decision_scope.py`.
- Preserve `unblocks_todo_id` as the fail-closed exact dependency edge when a gate also carries `decision_scope` during migration.
- Return `projection_repair_required` when exact target and decision scope conflict, instead of silently treating the item as independent.
- Add regression coverage for `decision_scope + unblocks_todo_id` coexistence and conflict projection repair.

## Product / Architecture Judgment
`quota.py` should allocate/run policy, not own reusable gate-relation semantics. Moving relation composition into a small control-plane module makes the behavior available to status, projection repair, review packets, and future capability surfaces without duplicating quota internals. Exact todo edges remain deterministic, while semantic decision scopes stay explainable supporting evidence.

## Validation
- `python3 -m py_compile loopx/decision_scope.py loopx/quota.py examples/quota-agent-scoped-user-gate-smoke.py`
- `python3 examples/quota-agent-scoped-user-gate-smoke.py`
- `python3 examples/todo-cli-smoke.py`
- `python3 examples/monitor-scheduler-contract-smoke.py`
- `git diff --check`
- Public/private boundary scan over staged candidate paths
