### PR TITLE
Document auto-research role state machine

### DIFF
--- a/docs/product/decentralized-auto-research-showcase.md
+++ b/docs/product/decentralized-auto-research-showcase.md
@@ -45,7 +45,7 @@ The important product phrase is:
 > the control plane, and each agent receives only the frontier it is allowed to
 > attempt.
 
-The executable product contract is split in two:
+The executable product contract is split into three peer artifacts:
 
 - `decentralized_auto_research_state_v0` defines the records and projections:
   contracts, todo-linked hypotheses, evidence events, frontier, evidence graph,
@@ -54,6 +54,9 @@ The executable product contract is split in two:
   hypothesis proposer, executor, evaluator/promoter, and product narrator. Each
   lane contributes typed records through claims and gates; none owns the whole
   graph.
+- `auto_research_role_state_machine_v0` defines the always-on digital employee
+  role map, state vocabulary, transition evidence, gate handoff, and user
+  takeover implications.
 - [Auto-research product metrics](auto-research-product-metrics.md) defines
   which user-value metrics the product surface should show. It intentionally
   favors scored attempts, held-out lift, negative-evidence reuse, retry
@@ -343,7 +346,7 @@ P1 candidates:
 - Promotion requires evidence and gate policy, not a persuasive chat summary.
 - A user can inspect every branch of the research graph from source refs.
 - Public showcase pages must distinguish "fixture target" from "achieved run".
-- Private docs, internal links, raw logs, credentials, local paths, and raw
+- Private docs, non-public links, raw logs, credentials, local paths, and raw
   benchmark traces stay out of public artifacts.
 
 ## Suggested Public Narrative

--- a/docs/reference/protocols/README.md
+++ b/docs/reference/protocols/README.md
@@ -19,6 +19,7 @@ Current contracts:
 - [long_horizon_agent_state_protocol_v0](long-horizon-agent-state-protocol-v0.md)
 - [decentralized_auto_research_state_v0](decentralized-auto-research-state-v0.md)
 - [auto_research_lane_contract_v1](auto-research-lane-contract-v1.md)
+- [auto_research_role_state_machine_v0](auto-research-role-state-machine-v0.md)
 - [global_manager_command_v0](global-manager-command-v0.md)
 - [pr_review_command_v0](pr-review-command-v0.md)
 - [event_sourced_state_contract_v0](event-sourced-state-contract-v0.md)

--- a/docs/reference/protocols/auto-research-role-state-machine-v0.md
+++ b/docs/reference/protocols/auto-research-role-state-machine-v0.md
@@ -1,0 +1,162 @@
+# auto_research_role_state_machine_v0
+
+`auto_research_role_state_machine_v0` defines the always-on digital employee
+model for LoopX auto research. It maps Arbor-like research roles onto LoopX's
+decentralized control plane without adding a leader agent, scheduler service,
+or second source of truth.
+
+This contract answers a narrower question than the state and lane contracts:
+which digital employee role may move a research item from one state to the
+next, and what evidence must exist before that transition is visible to users?
+
+## Companion Contracts
+
+The auto-research kernel is intentionally split into three protocol surfaces:
+
+| Contract | Owns | Does not own |
+| --- | --- | --- |
+| `decentralized_auto_research_state_v0` | Record and projection shapes: contract, todo-linked hypothesis, evidence event, frontier, evidence graph, showcase projection. | Which role may write each transition. |
+| `auto_research_lane_contract_v1` | Capability ownership for curator, proposer, executor, evaluator, and narrator lanes. | The ordered state machine and transition evidence. |
+| `auto_research_role_state_machine_v0` | Digital employee role map, state transition rules, takeover gates, and no-leader invariants. | Runtime scheduling, model prompts, or hidden orchestration. |
+
+All three contracts are peer artifacts under `docs/reference/protocols/`.
+Together they are the public-safe control-plane map for auto research.
+
+## Digital Employee Role Map
+
+These roles can run continuously as separate LoopX agent todos, monitors, or
+Codex sessions. None owns the full graph.
+
+| Role | Capability token | Primary job | May write | Must not |
+| --- | --- | --- | --- | --- |
+| Research curator | `research_curator` | Keep the objective, editable scope, protected scope, metric, and stop policy explicit. | `research_contract_v0`, protected-boundary notes, owner gate todos. | Pick winners, run experiments, or publish showcase claims. |
+| Hypothesis mapper | `hypothesis_mapper` | Turn research ideas into todo-backed hypotheses with parent links and mechanism families. | `research_hypothesis_v0`, successor todos, grounding refs. | Claim novelty from the same source used to ideate. |
+| Evidence runner | `evidence_runner` | Execute one selected hypothesis in an isolated worktree and preserve scored or unscored attempt evidence. | branch refs, `research_evidence_event_v0`, retry packets. | Edit protected scope, hide failures, or promote results. |
+| Evidence verifier | `evidence_verifier` | Classify evidence as supported, contradicted, retry-needed, or promotion-ready. | evaluation summary, promotion candidate, retirement candidate, gate todo. | Treat dev-only lift as promoted or override missing held-out evidence. |
+| Gate steward | `gate_steward` | Surface operator gates for promotion, merge, private boundary, or first-screen publication. | `operator_gate` todo/projection, gate outcome summary. | Bypass a gate or convert chat praise into write permission. |
+| Synthesis narrator | `synthesis_narrator` | Render the public-safe story from projections: timeline, evidence graph, metrics, and decisions. | `research_showcase_projection_v0`, public docs/pages after applicable gates. | Invent metrics, read private source bodies, or mutate source records. |
+| Frontier janitor | `frontier_janitor` | Retire stale, contradicted, duplicate, or retry-exhausted hypotheses while preserving negative evidence. | retirement candidate, successor todo, no-follow-up rationale. | Delete evidence or silently collapse failed branches. |
+
+The role names are product-facing labels. A single Codex session may perform
+multiple roles only when it has the corresponding todo claim, capability, and
+write boundary; the appended record must still name the role that produced it.
+
+## State Vocabulary
+
+`auto_research_state_transition_v0` uses the following durable states:
+
+| State | Meaning | Typical next states |
+| --- | --- | --- |
+| `contract_ready` | The objective, editable/protected scope, metric, budget, and promotion policy are public-safe and explicit. | `hypothesis_proposed` |
+| `hypothesis_proposed` | A todo-backed hypothesis exists, but no agent has started its attempt. | `frontier_selected`, `retired` |
+| `frontier_selected` | `quota should-run --agent-id ...` selected the hypothesis for the current agent. | `attempt_running`, `operator_gate` |
+| `attempt_running` | A claimed evidence runner is working in an isolated worktree. | `evidence_recorded`, `needs_retry` |
+| `evidence_recorded` | Attempt evidence exists with split, metric, branch/artifact refs, and boundary facts. | `evaluated` |
+| `evaluated` | A verifier classified the evidence under the research contract. | `supported`, `contradicted`, `needs_retry`, `promotion_gate`, `retired` |
+| `supported` | Dev evidence supports the direction, but promotion is not complete. | `promotion_gate`, `attempt_running`, `retired` |
+| `needs_retry` | Attempt is inconclusive but resumable from a ref or clearly bounded retry. | `frontier_selected`, `retired` |
+| `contradicted` | Evidence shows regression, correctness failure, or guardrail failure. | `retired`, `hypothesis_proposed` |
+| `promotion_gate` | Promotion requires held-out evidence, owner decision, merge gate, or public-boundary review. | `promoted`, `retired`, `operator_gate` |
+| `promoted` | Promotion policy accepted the result into the current best artifact. | `research_showcase_projection_v0` |
+| `retired` | The direction is no longer active; negative evidence remains queryable. | `research_showcase_projection_v0` |
+
+## State Machine
+
+```mermaid
+flowchart TD
+  Contract["contract_ready"]
+  Proposed["hypothesis_proposed"]
+  Selected["frontier_selected"]
+  Running["attempt_running"]
+  Evidence["evidence_recorded"]
+  Evaluated["evaluated"]
+  Supported["supported"]
+  Retry["needs_retry"]
+  Contradicted["contradicted"]
+  Gate["promotion_gate"]
+  Promoted["promoted"]
+  Retired["retired"]
+  Showcase["research_showcase_projection_v0"]
+
+  Contract --> Proposed
+  Proposed --> Selected
+  Proposed --> Retired
+  Selected --> Running
+  Selected --> Gate
+  Running --> Evidence
+  Running --> Retry
+  Evidence --> Evaluated
+  Evaluated --> Supported
+  Evaluated --> Retry
+  Evaluated --> Contradicted
+  Evaluated --> Gate
+  Evaluated --> Retired
+  Supported --> Gate
+  Supported --> Running
+  Retry --> Selected
+  Retry --> Retired
+  Contradicted --> Retired
+  Contradicted --> Proposed
+  Gate --> Promoted
+  Gate --> Retired
+  Promoted --> Showcase
+  Retired --> Showcase
+```
+
+## Transition Rules
+
+| Transition | Required role | Required evidence |
+| --- | --- | --- |
+| `contract_ready -> hypothesis_proposed` | Hypothesis mapper | `research_contract_v0`, `todo_id`, `claimed_by`, mechanism family, grounding refs or no-grounding reason. |
+| `hypothesis_proposed -> frontier_selected` | LoopX quota projection | `quota should-run --agent-id ...` selected the todo and write boundary allows the attempt. |
+| `frontier_selected -> attempt_running` | Evidence runner | agent claim, isolated worktree or equivalent execution boundary, protected scope reminder. |
+| `attempt_running -> evidence_recorded` | Evidence runner | split label, metric status, branch/artifact ref, protected-scope clean flag, raw-private-artifact flags. |
+| `evidence_recorded -> evaluated` | Evidence verifier | contract policy applied to scored or unscored evidence. |
+| `evaluated -> supported` | Evidence verifier | dev evidence improves or otherwise satisfies the contract's support threshold. |
+| `evaluated -> contradicted` | Evidence verifier | regression, correctness failure, boundary violation, or novelty failure. |
+| `evaluated -> needs_retry` | Evidence verifier | unscored attempt with resumable ref or explicit bounded retry reason. |
+| `evaluated -> promotion_gate` | Evidence verifier or gate steward | holdout candidate, clean boundary, pending owner/merge/publication decision. |
+| `promotion_gate -> promoted` | Gate steward plus verifier | held-out evidence when required, clean boundary, and applicable operator gate accepted. |
+| `supported|contradicted|needs_retry -> retired` | Frontier janitor | negative evidence, retry exhaustion, duplicate proof, or no-follow-up rationale. |
+| `promoted|retired -> research_showcase_projection_v0` | Synthesis narrator | projection refs only; no direct mutation of source records. |
+
+## No-Leader Invariants
+
+- No role owns the full graph or can rewrite global research truth.
+- `quota should-run --agent-id ...` selects only the current agent frontier.
+- Every executable hypothesis remains backed by a `todo_id` and `claimed_by`.
+- Promotion is evidence plus gate policy, not a persuasive summary.
+- A narrator reads `research_showcase_projection_v0`; it does not certify
+  scores or mutate source state.
+- A gate steward can surface or record a decision; it cannot bypass the gate.
+- Failed, contradicted, and retry-exhausted attempts stay visible as negative
+  evidence unless a public/private boundary requires redaction.
+
+## Demo And Takeover Implications
+
+The visible auto-research demo can launch several digital employees only as a
+user-visible rehearsal first. The default packet should remain `dry_run`: it
+may show tmux panes, commands, and takeover controls, but it must not start
+Codex, write LoopX state, or spend quota by itself.
+
+When a user opts into the real demo, each lane still runs its own:
+
+```bash
+loopx --format json --registry "$LOOPX_REGISTRY" \
+  quota should-run --goal-id "$LOOPX_GOAL_ID" --agent-id "$LOOPX_AGENT_ID"
+```
+
+and each lane reads its own auto-research frontier. The shell layout is only a
+visibility and takeover surface, not a coordinator.
+
+## Acceptance Checks
+
+An implementation satisfies this role/state-machine contract when:
+
+- the digital employee role map is visible to users and docs;
+- state transitions name the role and evidence required to move forward;
+- the smoke suite checks `auto_research_role_state_machine_v0` next to the
+  state and lane contracts;
+- generated demo packets expose user takeover controls before execution;
+- no public artifact centralizes graph ownership in a leader, coordinator, or
+  supervisor role.

--- a/docs/reference/protocols/decentralized-auto-research-state-v0.md
+++ b/docs/reference/protocols/decentralized-auto-research-state-v0.md
@@ -52,8 +52,11 @@ state files, or future narrow kernel APIs.
 The companion
 [`auto_research_lane_contract_v1`](auto-research-lane-contract-v1.md) defines
 which decentralized agent lanes may create, execute, evaluate, promote, retire,
-or narrate these records. This file defines the record shapes and projections;
-the lane contract defines capability ownership without introducing a leader
+or narrate these records. The companion
+[`auto_research_role_state_machine_v0`](auto-research-role-state-machine-v0.md)
+defines the always-on digital employee role map and state transitions. This
+file defines the record shapes and projections; the companion contracts define
+capability ownership and transition evidence without introducing a leader
 agent.
 
 | Source state | Existing or proposed anchor | Purpose |
@@ -297,5 +300,5 @@ An implementation is acceptable when:
 - grounded ideation and novelty audit are separated;
 - held-out promotion is explicit;
 - public projections contain no raw logs, private paths, credentials, or raw
-  internal documents;
+  private documents;
 - the showcase can be rendered from public-safe evidence refs.

--- a/examples/decentralized-auto-research-protocol-smoke.py
+++ b/examples/decentralized-auto-research-protocol-smoke.py
@@ -15,6 +15,7 @@ import re
 ROOT = Path(__file__).resolve().parents[1]
 PROTOCOL = ROOT / "docs/reference/protocols/decentralized-auto-research-state-v0.md"
 LANE_CONTRACT = ROOT / "docs/reference/protocols/auto-research-lane-contract-v1.md"
+ROLE_STATE_MACHINE = ROOT / "docs/reference/protocols/auto-research-role-state-machine-v0.md"
 PROTOCOL_README = ROOT / "docs/reference/protocols/README.md"
 BLUEPRINT = ROOT / "docs/product/decentralized-auto-research-showcase.md"
 
@@ -45,11 +46,23 @@ def _assert_public_safe(text: str, label: str) -> None:
 def main() -> None:
     protocol = _read(PROTOCOL)
     lane_contract = _read(LANE_CONTRACT)
+    role_state_machine = _read(ROLE_STATE_MACHINE)
     protocol_readme = _read(PROTOCOL_README)
     blueprint = _read(BLUEPRINT)
-    combined = protocol + "\n" + lane_contract + "\n" + protocol_readme + "\n" + blueprint
+    combined = (
+        protocol
+        + "\n"
+        + lane_contract
+        + "\n"
+        + role_state_machine
+        + "\n"
+        + protocol_readme
+        + "\n"
+        + blueprint
+    )
     compact_protocol = re.sub(r"\s+", " ", protocol)
     compact_lane_contract = re.sub(r"\s+", " ", lane_contract)
+    compact_role_state_machine = re.sub(r"\s+", " ", role_state_machine)
 
     _assert_public_safe(combined, "decentralized auto-research docs")
 
@@ -72,7 +85,9 @@ def main() -> None:
         assert term in protocol, f"protocol missing {term!r}"
     assert "No agent owns the whole research tree" in compact_protocol
     assert "auto_research_lane_contract_v1" in protocol
+    assert "auto_research_role_state_machine_v0" in protocol
     assert "auto_research_lane_contract_v1" in protocol_readme
+    assert "auto_research_role_state_machine_v0" in protocol_readme
 
     required_lane_terms = [
         "auto_research_lane_contract_v1",
@@ -97,6 +112,35 @@ def main() -> None:
     assert "not a lock on the full graph" in compact_lane_contract
     assert "no public surface needs a leader or coordinator agent" in compact_lane_contract
 
+    required_role_state_machine_terms = [
+        "auto_research_role_state_machine_v0",
+        "auto_research_state_transition_v0",
+        "Research curator",
+        "Hypothesis mapper",
+        "Evidence runner",
+        "Evidence verifier",
+        "Gate steward",
+        "Synthesis narrator",
+        "Frontier janitor",
+        "contract_ready",
+        "hypothesis_proposed",
+        "frontier_selected",
+        "attempt_running",
+        "evidence_recorded",
+        "evaluated",
+        "promotion_gate",
+        "research_showcase_projection_v0",
+        "quota should-run --agent-id",
+        "operator_gate",
+        "todo_id",
+        "claimed_by",
+        "No role owns the full graph",
+    ]
+    for term in required_role_state_machine_terms:
+        assert term in role_state_machine, f"role state machine missing {term!r}"
+    assert "not a coordinator" in compact_role_state_machine
+    assert "not start Codex, write LoopX state, or spend quota" in compact_role_state_machine
+
     required_blueprint_terms = [
         "Decentralized Auto Research: k-NN Speedup",
         "not a claim that LoopX has already achieved",
@@ -106,6 +150,7 @@ def main() -> None:
         "Promotion decision",
         "no leader agent owns the graph",
         "auto_research_lane_contract_v1",
+        "auto_research_role_state_machine_v0",
         "curator",
         "hypothesis proposer",
         "executor",
@@ -123,6 +168,7 @@ def main() -> None:
         r"Coordinator owns the tree",
         r"Coordinator.*promotion decisions live",
         r"single agent owns the whole research tree",
+        r"supervisor owns the full",
     ]
     for pattern in forbidden_patterns:
         assert not re.search(pattern, combined, re.IGNORECASE), (


### PR DESCRIPTION
## Summary
- add auto_research_role_state_machine_v0 as the peer role/state-machine contract for decentralized auto research
- cross-link the state, lane, and role/state-machine protocols as the core auto-research control-plane map
- extend the decentralized auto-research protocol smoke to enforce the new role map, state vocabulary, no-leader invariant, and dry-run takeover boundary

## Validation
- python3 examples/decentralized-auto-research-protocol-smoke.py
- python3 examples/decentralized-auto-research-frontier-smoke.py
- git diff --check
- loopx check --scan-path docs/reference/protocols/auto-research-role-state-machine-v0.md --scan-path docs/reference/protocols/decentralized-auto-research-state-v0.md --scan-path docs/product/decentralized-auto-research-showcase.md --scan-path examples/decentralized-auto-research-protocol-smoke.py