### PR TITLE
Add local state write promotion gate

### DIFF
--- a/docs/reference/protocols/local-state-write-correctness-v0.md
+++ b/docs/reference/protocols/local-state-write-correctness-v0.md
@@ -148,6 +148,45 @@ A local-state writer is compatible with this protocol when:
    raw local files, private paths, credentials, raw logs, or raw transcripts;
 7. every destructive or external effect remains behind a separate explicit gate.
 
+## Runtime Promotion Gate
+
+The current implementation target is preview-first. A follow-up patch that
+changes real write behavior must carry a small promotion gate before it enforces
+hard idempotency, revision checks, or lease conflicts on the canonical write
+path. The gate is a public-safe fixture contract, not a permission grant.
+
+```json
+{
+  "schema_version": "local_state_write_correctness_rollout_gate_v0",
+  "writer_id": "loopx.todo",
+  "write_class": "todo_update",
+  "current_mode": "dry_run_preview",
+  "promotion_target": "shadow_validate",
+  "allowed_to_change_write_behavior": false,
+  "required_evidence": {
+    "dry_run_packet_smoke": "examples/todo-write-correctness-smoke.py",
+    "idempotency_key_stability": "same logical input produces the same idempotency_key",
+    "expected_revision_fixture": "expected_revision is computed from the active state before mutation",
+    "revision_conflict_fixture": "stale expected_revision returns revision_conflict before mutation",
+    "lease_projection_fixture": "foreign or expired lease returns lease_conflict before mutation",
+    "public_boundary_scan": "loopx check --scan-path <changed-public-paths>"
+  },
+  "exit_criteria": [
+    "dry-run JSON and markdown projections stay stable",
+    "duplicate retries cannot duplicate todos, evidence, events, or refresh runs",
+    "revision and lease conflicts are observable without copying raw state",
+    "status and review packets expose only compact public-safe write refs"
+  ]
+}
+```
+
+`allowed_to_change_write_behavior=false` means the patch may add fixtures,
+projection, or shadow-validation scaffolding, but must not reject or rewrite a
+previously accepted real write. A later enforcement patch may flip that field
+only when the corresponding writer has the required conflict fixtures and its
+rollback behavior is documented. This keeps the rollout small: first prove the
+contract on one writer, then tighten behavior in a separate validated step.
+
 ## Rollout Notes
 
 The first implementation step should be non-destructive: add protocol docs and

--- a/examples/local-state-write-correctness-rollout-gate-smoke.py
+++ b/examples/local-state-write-correctness-rollout-gate-smoke.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Smoke-test the local state write correctness runtime promotion gate."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PROTOCOL = REPO_ROOT / "docs" / "reference" / "protocols" / "local-state-write-correctness-v0.md"
+
+
+def extract_gate_packet(text: str) -> dict[str, Any]:
+    marker = "## Runtime Promotion Gate"
+    start = text.index(marker)
+    match = re.search(r"```json\n(.*?)\n```", text[start:], re.DOTALL)
+    assert match, "Runtime Promotion Gate must include a JSON code block"
+    return json.loads(match.group(1))
+
+
+def main() -> int:
+    text = PROTOCOL.read_text(encoding="utf-8")
+    packet = extract_gate_packet(text)
+
+    assert packet["schema_version"] == "local_state_write_correctness_rollout_gate_v0", packet
+    assert packet["current_mode"] == "dry_run_preview", packet
+    assert packet["promotion_target"] == "shadow_validate", packet
+    assert packet["allowed_to_change_write_behavior"] is False, packet
+
+    required = packet["required_evidence"]
+    for field in (
+        "dry_run_packet_smoke",
+        "idempotency_key_stability",
+        "expected_revision_fixture",
+        "revision_conflict_fixture",
+        "lease_projection_fixture",
+        "public_boundary_scan",
+    ):
+        assert required.get(field), f"promotion gate missing evidence: {field}"
+
+    exit_criteria = " ".join(packet["exit_criteria"])
+    for phrase in (
+        "dry-run JSON and markdown",
+        "duplicate retries",
+        "revision and lease conflicts",
+        "compact public-safe write refs",
+    ):
+        assert phrase in exit_criteria, f"promotion gate missing exit criterion: {phrase}"
+
+    compact = " ".join(text.split())
+    assert "must not reject or rewrite a previously accepted real write" in compact
+    assert "separate validated step" in compact
+
+    print("local-state-write-correctness-rollout-gate-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- document `local_state_write_correctness_rollout_gate_v0` as the promotion gate for future local state write enforcement
- require dry-run, idempotency, expected revision, revision conflict, lease projection, and public boundary evidence before changing real write behavior
- add a smoke that parses and validates the gate packet from the protocol doc

## Risk
- Low runtime risk: this does not change canonical write behavior or CLI apply semantics.
- The guard is intentionally conservative: future enforcement patches must first prove the dry-run contract and conflict fixtures.

## Validation
- `python3 examples/local-state-write-correctness-rollout-gate-smoke.py`
- `python3 examples/local-state-write-correctness-contract-smoke.py`
- `python3 examples/todo-write-correctness-smoke.py`
- `python3 examples/refresh-state-write-correctness-smoke.py`
- `python3 -m py_compile examples/local-state-write-correctness-rollout-gate-smoke.py`
- `git diff --check`
- `loopx --format json check --scan-path docs/reference/protocols/local-state-write-correctness-v0.md --scan-path examples/local-state-write-correctness-rollout-gate-smoke.py`