### PR TITLE
Document future auto-research role splits

### DIFF
--- a/docs/reference/protocols/auto-research-role-state-machine-v0.md
+++ b/docs/reference/protocols/auto-research-role-state-machine-v0.md
@@ -42,7 +42,24 @@ write boundary; the appended record must still name the role that produced it.
 
 Future versions may split gate stewardship, public narration, or frontier
 janitor work into separate always-on roles after the demo proves those duties
-need independent ownership.
+need independent ownership. Until then, they remain transition duties owned by
+the four-role v0 map above.
+
+## Future Role Splits
+
+These candidate roles are intentionally outside the v0 always-on role set. They
+are recorded so the product roadmap can grow the digital-employee map without
+reintroducing a leader or coordinator agent.
+
+| Future role | Current v0 duty | Split trigger | Still must not |
+| --- | --- | --- | --- |
+| Gate steward | Research curator plus evidence verifier handle `operator_gate` and `promotion_gate` transitions. | Gates become frequent enough that wait reasons, owner questions, and unblock evidence need independent monitoring. | Approve its own gate, bypass owner decisions, or select experiments. |
+| Synthesis narrator | Read-only projection builder creates `research_showcase_projection_v0` from promoted/retired evidence. | Users need a continuously updated report lane that summarizes evidence without slowing runners or verifiers. | Certify scores, hide negative evidence, or mutate source records. |
+| Frontier janitor | Hypothesis mapper and evidence verifier retire duplicates, exhausted retries, and no-follow-up branches. | The frontier grows large enough that stale hypotheses crowd out active research. | Delete evidence, rewrite todo ownership, or prune without a public rationale. |
+
+Promoting any future role requires a smoke update that proves the role is a
+bounded lane over the shared control plane, not a coordinator with authority
+over the full graph.
 
 ## State Vocabulary
 

--- a/examples/decentralized-auto-research-protocol-smoke.py
+++ b/examples/decentralized-auto-research-protocol-smoke.py
@@ -122,6 +122,10 @@ def main() -> None:
         "always-on role set small",
         "transition duties",
         "Read-only projection builder",
+        "Future Role Splits",
+        "Gate steward",
+        "Synthesis narrator",
+        "Frontier janitor",
         "contract_ready",
         "hypothesis_proposed",
         "frontier_selected",
@@ -141,10 +145,11 @@ def main() -> None:
     assert "not a coordinator" in compact_role_state_machine
     assert "not start Codex, write LoopX state, or spend quota" in compact_role_state_machine
     assert "Future versions may split gate stewardship" in compact_role_state_machine
+    assert "outside the v0 always-on role set" in compact_role_state_machine
+    assert "Promoting any future role requires a smoke update" in compact_role_state_machine
     assert "Gate handling is a transition duty" in compact_role_state_machine
-    assert "Frontier janitor" not in role_state_machine
-    assert "Synthesis narrator" not in role_state_machine
-    assert "Gate steward" not in role_state_machine
+    for future_role in ("Frontier janitor", "Synthesis narrator", "Gate steward"):
+        assert f"| {future_role} |" in role_state_machine, f"future split missing {future_role}"
 
     required_blueprint_terms = [
         "Decentralized Auto Research: k-NN Speedup",


### PR DESCRIPTION
## Summary
- add Future Role Splits to auto_research_role_state_machine_v0
- keep Gate steward, Synthesis narrator, and Frontier janitor outside the v0 always-on role set
- update the decentralized auto-research protocol smoke to require future split coverage without allowing a leader/coordinator role

## Validation
- python3 -m py_compile examples/decentralized-auto-research-protocol-smoke.py
- python3 examples/decentralized-auto-research-protocol-smoke.py
- git diff --check
