### PR TITLE
Extract monitor todo due policy

### DIFF
--- a/examples/monitor-todo-policy-seam-smoke.py
+++ b/examples/monitor-todo-policy-seam-smoke.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Characterize the shared monitor todo due-time policy seam."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from loopx import quota as quota_module  # noqa: E402
+from loopx.policies.monitor_todo import (  # noqa: E402
+    monitor_todo_is_actionable_open,
+    monitor_todo_is_due,
+    monitor_todo_is_expired,
+    monitor_todo_next_due_at,
+)
+from loopx.status import (  # noqa: E402
+    todo_item_is_actionable_open,
+    todo_item_is_due_monitor,
+    todo_item_is_expired_monitor,
+    todo_item_next_due_at,
+)
+
+
+NOW = datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc)
+PAST = "2025-12-31T23:59:00Z"
+FUTURE = "2026-01-01T00:01:00+00:00"
+EXPIRED = "2025-12-31T23:58:00+00:00"
+
+
+def monitor_item(**overrides: object) -> dict[str, object]:
+    item: dict[str, object] = {
+        "text": "[P1] Monitor update-note draft PR.",
+        "status": "open",
+        "task_class": "continuous_monitor",
+        "next_due_at": PAST,
+    }
+    item.update(overrides)
+    return item
+
+
+def assert_policy_matches_wrappers(item: dict[str, object], *, due: bool, expired: bool) -> None:
+    assert monitor_todo_is_due(item, now=NOW) is due, item
+    assert todo_item_is_due_monitor(item, now=NOW) is due, item
+    assert quota_module._todo_item_is_due_monitor(item, now=NOW) is due, item
+    assert monitor_todo_is_expired(item, now=NOW) is expired, item
+    assert todo_item_is_expired_monitor(item, now=NOW) is expired, item
+    assert quota_module._todo_item_is_expired_monitor(item, now=NOW) is expired, item
+    assert monitor_todo_next_due_at(item) == todo_item_next_due_at(item), item
+    assert monitor_todo_next_due_at(item) == quota_module._todo_item_next_due_at(item), item
+    assert monitor_todo_is_actionable_open(item) == todo_item_is_actionable_open(item), item
+    assert monitor_todo_is_actionable_open(item) == quota_module._todo_item_is_actionable_open(item), item
+
+
+def main() -> int:
+    assert_policy_matches_wrappers(monitor_item(), due=True, expired=False)
+    assert_policy_matches_wrappers(monitor_item(next_due_at=FUTURE), due=False, expired=False)
+    assert_policy_matches_wrappers(
+        monitor_item(expires_at=EXPIRED),
+        due=False,
+        expired=True,
+    )
+    assert_policy_matches_wrappers(
+        monitor_item(status="blocked"),
+        due=False,
+        expired=False,
+    )
+    assert_policy_matches_wrappers(
+        monitor_item(done=True),
+        due=False,
+        expired=False,
+    )
+    assert_policy_matches_wrappers(
+        monitor_item(task_class="advancement_task"),
+        due=False,
+        expired=False,
+    )
+    assert monitor_todo_next_due_at({"next_due_at": "2026-01-01T00:00:00"}) == NOW
+    print("monitor-todo-policy-seam-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/policies/monitor_todo.py
+++ b/loopx/policies/monitor_todo.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from ..todo_contract import (
+    TODO_STATUS_OPEN,
+    TODO_TASK_CLASS_MONITOR,
+    normalize_todo_status,
+    normalize_todo_task_class,
+)
+
+
+def parse_monitor_timestamp(value: Any) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def monitor_todo_task_class(item: dict[str, Any], *, task_text: str | None = None) -> str:
+    text = str(item.get("text") or "") if task_text is None else task_text
+    return normalize_todo_task_class(
+        item.get("task_class"),
+        text=text,
+        action_kind=item.get("action_kind"),
+    )
+
+
+def monitor_todo_is_actionable_open(item: dict[str, Any]) -> bool:
+    if item.get("done") is True:
+        return False
+    status = normalize_todo_status(item.get("status")) or TODO_STATUS_OPEN
+    return status == TODO_STATUS_OPEN
+
+
+def monitor_todo_next_due_at(item: dict[str, Any]) -> datetime | None:
+    return parse_monitor_timestamp(item.get("next_due_at"))
+
+
+def monitor_todo_expires_at(item: dict[str, Any]) -> datetime | None:
+    return parse_monitor_timestamp(item.get("expires_at"))
+
+
+def monitor_todo_is_expired(item: dict[str, Any], *, now: datetime | None = None) -> bool:
+    expires_at = monitor_todo_expires_at(item)
+    if expires_at is None:
+        return False
+    current_time = now or datetime.now(timezone.utc)
+    return expires_at <= current_time
+
+
+def monitor_todo_is_due(
+    item: dict[str, Any],
+    *,
+    now: datetime | None = None,
+    task_text: str | None = None,
+) -> bool:
+    if not monitor_todo_is_actionable_open(item):
+        return False
+    if monitor_todo_task_class(item, task_text=task_text) != TODO_TASK_CLASS_MONITOR:
+        return False
+    if monitor_todo_is_expired(item, now=now):
+        return False
+    next_due_at = monitor_todo_next_due_at(item)
+    if next_due_at is None:
+        return False
+    current_time = now or datetime.now(timezone.utc)
+    return next_due_at <= current_time

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -32,6 +32,14 @@ from .execution_profile import (
 from .long_task_cadence import long_task_cadence_hint_summary
 from .orchestration import compact_orchestration_policy, orchestration_policy_summary
 from .policies.execution_obligation import build_execution_obligation
+from .policies.monitor_todo import (
+    monitor_todo_expires_at,
+    monitor_todo_is_actionable_open,
+    monitor_todo_is_due,
+    monitor_todo_is_expired,
+    monitor_todo_next_due_at,
+    monitor_todo_task_class,
+)
 from .policies.outcome_followthrough import build_outcome_followthrough_hint
 from .policies.scheduler_hint import build_scheduler_hint
 from .policies.work_lane import (
@@ -4726,48 +4734,32 @@ def _todo_task_class(item: dict[str, Any]) -> str:
         for value in (item.get("title"), item.get("text"))
         if str(value or "").strip()
     )
-    return normalize_todo_task_class(
-        item.get("task_class"),
-        text=text,
-        action_kind=item.get("action_kind"),
-    )
+    return monitor_todo_task_class(item, task_text=text)
 
 
 def _todo_item_is_actionable_open(item: dict[str, Any]) -> bool:
-    if item.get("done") is True:
-        return False
-    status = normalize_todo_status(item.get("status")) or TODO_STATUS_OPEN
-    return status == TODO_STATUS_OPEN
+    return monitor_todo_is_actionable_open(item)
 
 
 def _todo_item_next_due_at(item: dict[str, Any]) -> datetime | None:
-    return _parse_timestamp(item.get("next_due_at"))
+    return monitor_todo_next_due_at(item)
 
 
 def _todo_item_expires_at(item: dict[str, Any]) -> datetime | None:
-    return _parse_timestamp(item.get("expires_at"))
+    return monitor_todo_expires_at(item)
 
 
 def _todo_item_is_expired_monitor(item: dict[str, Any], *, now: datetime | None = None) -> bool:
-    expires_at = _todo_item_expires_at(item)
-    if expires_at is None:
-        return False
-    current_time = now or datetime.now(timezone.utc)
-    return expires_at <= current_time
+    return monitor_todo_is_expired(item, now=now)
 
 
 def _todo_item_is_due_monitor(item: dict[str, Any], *, now: datetime | None = None) -> bool:
-    if not _todo_item_is_actionable_open(item):
-        return False
-    if _todo_task_class(item) != TODO_TASK_CLASS_MONITOR:
-        return False
-    if _todo_item_is_expired_monitor(item, now=now):
-        return False
-    next_due_at = _todo_item_next_due_at(item)
-    if next_due_at is None:
-        return False
-    current_time = now or datetime.now(timezone.utc)
-    return next_due_at <= current_time
+    text = " ".join(
+        str(value or "")
+        for value in (item.get("title"), item.get("text"))
+        if str(value or "").strip()
+    )
+    return monitor_todo_is_due(item, now=now, task_text=text)
 
 
 def _todo_summary_claim_scope_agent_id(summary: dict[str, Any]) -> str | None:

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -50,6 +50,14 @@ from .materials import extract_review_materials
 from .operator_gate import DEFAULT_OPERATOR_GATE, default_operator_question, normalize_operator_question
 from .orchestration import compact_orchestration_policy, orchestration_policy_summary
 from .paths import global_registry_path, resolve_runtime_root
+from .policies.monitor_todo import (
+    monitor_todo_expires_at,
+    monitor_todo_is_actionable_open,
+    monitor_todo_is_due,
+    monitor_todo_is_expired,
+    monitor_todo_next_due_at,
+    monitor_todo_task_class,
+)
 from .projections.task_graph import (
     TASK_GRAPH_MAX_USER_GATE_NODES,
     TASK_GRAPH_PROJECTION_SCHEMA_VERSION,
@@ -5230,48 +5238,27 @@ def compact_active_next_action_todo_item(item: dict[str, Any]) -> dict[str, Any]
 
 
 def todo_item_task_class(item: dict[str, Any]) -> str:
-    return normalize_todo_task_class(
-        item.get("task_class"),
-        text=str(item.get("text") or ""),
-        action_kind=item.get("action_kind"),
-    )
+    return monitor_todo_task_class(item, task_text=str(item.get("text") or ""))
 
 
 def todo_item_is_actionable_open(item: dict[str, Any]) -> bool:
-    if item.get("done") is True:
-        return False
-    status = normalize_todo_status(item.get("status")) or TODO_STATUS_OPEN
-    return status == TODO_STATUS_OPEN
+    return monitor_todo_is_actionable_open(item)
 
 
 def todo_item_next_due_at(item: dict[str, Any]) -> datetime | None:
-    return parse_timestamp(item.get("next_due_at"))
+    return monitor_todo_next_due_at(item)
 
 
 def todo_item_expires_at(item: dict[str, Any]) -> datetime | None:
-    return parse_timestamp(item.get("expires_at"))
+    return monitor_todo_expires_at(item)
 
 
 def todo_item_is_expired_monitor(item: dict[str, Any], *, now: datetime | None = None) -> bool:
-    expires_at = todo_item_expires_at(item)
-    if expires_at is None:
-        return False
-    current_time = now or datetime.now(timezone.utc)
-    return expires_at <= current_time
+    return monitor_todo_is_expired(item, now=now)
 
 
 def todo_item_is_due_monitor(item: dict[str, Any], *, now: datetime | None = None) -> bool:
-    if not todo_item_is_actionable_open(item):
-        return False
-    if todo_item_task_class(item) != TODO_TASK_CLASS_MONITOR:
-        return False
-    if todo_item_is_expired_monitor(item, now=now):
-        return False
-    next_due_at = todo_item_next_due_at(item)
-    if next_due_at is None:
-        return False
-    current_time = now or datetime.now(timezone.utc)
-    return next_due_at <= current_time
+    return monitor_todo_is_due(item, now=now, task_text=str(item.get("text") or ""))
 
 
 def todo_priority_rank(priority: Any) -> int:


### PR DESCRIPTION
## Summary
- add a pure monitor_todo helper for monitor todo open/due/expired checks
- make quota.py and status.py delegate their existing monitor due wrappers to the shared helper while preserving caller-specific task text behavior
- add a characterization smoke proving the shared helper, status wrapper, and quota wrapper agree on due/open/expired cases

## Validation
- python examples/monitor-todo-policy-seam-smoke.py
- python examples/monitor-scheduler-contract-smoke.py
- python examples/status-watch-routing-attribute-smoke.py
- python examples/quota-work-lane-policy-smoke.py
- python examples/quota-scheduler-hint-compaction-smoke.py
- python -m py_compile loopx/policies/monitor_todo.py loopx/quota.py loopx/status.py
- git diff --check origin/main...HEAD
- loopx check --scan-path loopx/policies/monitor_todo.py --scan-path loopx/quota.py --scan-path loopx/status.py --scan-path examples/monitor-todo-policy-seam-smoke.py

Note: loopx check reports the existing loopx-meta duplicate index warning; public boundary scan is clean for the changed files.
