### PR TITLE
Add auto-research demo acceptance timeline

### DIFF
--- a/docs/product/decentralized-auto-research-showcase.md
+++ b/docs/product/decentralized-auto-research-showcase.md
@@ -283,6 +283,8 @@ The user should see four concrete things in the packet:
 - a `start_script` array that can be copied into the user's shell only after
   the user sets `LOOPX_PROJECT`, `LOOPX_REGISTRY`, and
   `LOOPX_RUNTIME_ROOT`;
+- a `lane_timeline` for each lane, making the visible sequence explicit:
+  quota guard, frontier projection, bootstrap prompt, then visible Codex TUI;
 - explicit takeover controls: `tmux attach -t loopx-auto-research` to inspect
   every lane before accepting Codex prompts, and
   `tmux kill-session -t loopx-auto-research` to stop the rehearsal.
@@ -293,6 +295,13 @@ lane manually, and confirm that each lane still routes through LoopX quota,
 todo claims, frontier projection, and normal evidence writeback. The
 supervisor never becomes a leader agent; it is only a shell layout that makes
 the decentralized workers visible and interruptible.
+
+The packet also carries `demo_acceptance`: a compact, smoke-backed checklist
+for what must be visible before a human accepts the rehearsal. It is deliberately
+about observable behavior, not private demo notes: the rehearsal script must
+print without executing, each lane must show quota before frontier/bootstrap,
+attach and stop controls must be visible, and dry-run boundary fields must show
+no tmux, Codex, state, quota, credential, or session side effects.
 
 The generated shell plan uses environment placeholders such as `LOOPX_PROJECT`,
 `LOOPX_REGISTRY`, and `LOOPX_RUNTIME_ROOT` instead of embedding local absolute

--- a/examples/auto-research-demo-supervisor-smoke.py
+++ b/examples/auto-research-demo-supervisor-smoke.py
@@ -66,6 +66,15 @@ def assert_supervisor_contract(payload: dict[str, Any]) -> None:
         assert "auto-research frontier" in lane["frontier"], lane
         assert "codex-cli-bootstrap-message" in lane["bootstrap_message"], lane
         assert lane["visible_codex_tui"] == "codex", lane
+        phases = [item["phase"] for item in lane["lane_timeline"]]
+        assert phases == [
+            "quota_guard",
+            "frontier_projection",
+            "bootstrap_prompt",
+            "visible_codex",
+        ], lane
+        assert lane["lane_timeline"][0]["command_ref"] == "quota_guard", lane
+        assert "operator is attached" in lane["lane_timeline"][-1]["continue_when"], lane
 
     start_script = "\n".join(payload["commands"]["start_script"])
     assert "tmux new-session" in start_script, start_script
@@ -89,6 +98,12 @@ def assert_supervisor_contract(payload: dict[str, Any]) -> None:
     assert "tmux kill-session -t loopx-auto-research" in rehearsal, rehearsal
     assert "start tmux" in one_click["does_not"], one_click
     assert "launch Codex" in one_click["does_not"], one_click
+
+    acceptance = payload["demo_acceptance"]
+    assert acceptance["schema_version"] == "auto_research_demo_acceptance_v0", payload
+    assert "lanes[].lane_timeline" in acceptance["required_visible_fields"], acceptance
+    assert any("without executing it" in item for item in acceptance["operator_can_accept_when"]), acceptance
+    assert any("hides attach/stop" in item for item in acceptance["operator_must_reject_when"]), acceptance
 
     takeover = payload["user_takeover"]
     assert takeover["schema_version"] == "auto_research_user_takeover_v0", payload
@@ -166,10 +181,14 @@ def main() -> int:
     ).stdout
     assert "# LoopX Auto Research Demo Supervisor" in markdown, markdown
     assert "leader_agent_required: `False`" in markdown, markdown
+    assert "## Lane Timeline" in markdown, markdown
+    assert "`quota_guard` via `quota_guard`" in markdown, markdown
     assert "## One-Click Dry Run" in markdown, markdown
     assert "copy_paste_dry_run_rehearsal" in markdown, markdown
     assert "## User Takeover" in markdown, markdown
     assert "## Visible Status Cues" in markdown, markdown
+    assert "## Demo Acceptance" in markdown, markdown
+    assert "accept when:" in markdown, markdown
     assert "tmux attach -t loopx-auto-research" in markdown, markdown
 
     print("auto-research-demo-supervisor-smoke ok")

--- a/loopx/capabilities/auto_research/core.py
+++ b/loopx/capabilities/auto_research/core.py
@@ -689,6 +689,36 @@ def build_auto_research_demo_supervisor_plan(
                     "print the public-safe bootstrap message for this visible TUI",
                     "start Codex CLI visibly; do not inject hidden prompts into an existing session",
                 ],
+                "lane_timeline": [
+                    {
+                        "phase": "quota_guard",
+                        "command_ref": "quota_guard",
+                        "operator_visible_signal": "should-run packet for this agent lane",
+                        "continue_when": "agent_channel.delivery_allowed=true and user_channel.action_required=false",
+                        "stop_when": "user_channel.action_required=true or quota says do not run",
+                    },
+                    {
+                        "phase": "frontier_projection",
+                        "command_ref": "frontier",
+                        "operator_visible_signal": "current auto-research frontier and todo/evidence hints",
+                        "continue_when": "frontier contains a bounded lane-local next action",
+                        "stop_when": "frontier is empty, contradictory, private, or asks for owner input",
+                    },
+                    {
+                        "phase": "bootstrap_prompt",
+                        "command_ref": "bootstrap_message",
+                        "operator_visible_signal": "public-safe Codex bootstrap message printed in the lane pane",
+                        "continue_when": "bootstrap scope matches the lane frontier",
+                        "stop_when": "bootstrap would bypass LoopX quota, todo claims, or evidence writeback",
+                    },
+                    {
+                        "phase": "visible_codex",
+                        "command_ref": "visible_codex_tui",
+                        "operator_visible_signal": "Codex CLI starts only in the visible tmux lane",
+                        "continue_when": "operator is attached and can interrupt the lane",
+                        "stop_when": "pane is hidden, detached, or starts mutating state before review",
+                    },
+                ],
             }
         )
 
@@ -771,6 +801,34 @@ def build_auto_research_demo_supervisor_plan(
                 "read session files",
                 "write LoopX state",
                 "spend quota",
+            ],
+        },
+        "demo_acceptance": {
+            "schema_version": "auto_research_demo_acceptance_v0",
+            "required_visible_fields": [
+                "commands.one_click_dry_run_rehearsal",
+                "commands.start_script",
+                "commands.attach",
+                "commands.stop",
+                "lanes[].quota_guard",
+                "lanes[].frontier",
+                "lanes[].bootstrap_message",
+                "lanes[].lane_timeline",
+                "user_takeover.operator_controls",
+                "boundary",
+            ],
+            "operator_can_accept_when": [
+                "the rehearsal script prints the real start script without executing it",
+                "every lane has a quota guard before frontier/bootstrap/Codex startup",
+                "the attach command is visible before any Codex prompt is accepted",
+                "the stop command and terminal interrupt path are visible",
+                "boundary fields prove no tmux/Codex/state/quota side effects in dry-run mode",
+            ],
+            "operator_must_reject_when": [
+                "a lane can start without quota should-run",
+                "the packet hides attach/stop controls",
+                "the packet embeds local absolute paths, credentials, raw sessions, or private links",
+                "the supervisor becomes a leader or writes LoopX state directly",
             ],
         },
         "user_takeover": {
@@ -2068,6 +2126,11 @@ def render_auto_research_markdown(payload: dict[str, object]) -> str:
         commands = payload.get("commands") if isinstance(payload.get("commands"), dict) else {}
         one_click = payload.get("one_click_demo") if isinstance(payload.get("one_click_demo"), dict) else {}
         takeover = payload.get("user_takeover") if isinstance(payload.get("user_takeover"), dict) else {}
+        acceptance = (
+            payload.get("demo_acceptance")
+            if isinstance(payload.get("demo_acceptance"), dict)
+            else {}
+        )
         coordination = (
             payload.get("coordination_model")
             if isinstance(payload.get("coordination_model"), dict)
@@ -2091,6 +2154,22 @@ def render_auto_research_markdown(payload: dict[str, object]) -> str:
             lines.append(
                 f"- `{item.get('lane_id')}` / `{item.get('agent_id')}`: {item.get('responsibility')}"
             )
+        lines.extend(["", "## Lane Timeline", ""])
+        for item in lanes:
+            if not isinstance(item, dict):
+                continue
+            timeline = item.get("lane_timeline") if isinstance(item.get("lane_timeline"), list) else []
+            if not timeline:
+                continue
+            lines.append(f"### {item.get('lane_id')}")
+            for phase in timeline:
+                if not isinstance(phase, dict):
+                    continue
+                lines.append(
+                    f"- `{phase.get('phase')}` via `{phase.get('command_ref')}`: "
+                    f"{phase.get('operator_visible_signal')}"
+                )
+            lines.append("")
         lines.extend(["", "## One-Click Dry Run", ""])
         lines.append(f"- mode: `{one_click.get('mode')}`")
         lines.append(f"- default_safe: `{one_click.get('default_safe')}`")
@@ -2110,6 +2189,14 @@ def render_auto_research_markdown(payload: dict[str, object]) -> str:
             lines.extend(["", "## Visible Status Cues", ""])
             for item in cues:
                 lines.append(f"- {item}")
+        accept_when = acceptance.get("operator_can_accept_when") or []
+        reject_when = acceptance.get("operator_must_reject_when") or []
+        if accept_when or reject_when:
+            lines.extend(["", "## Demo Acceptance", ""])
+            for item in accept_when:
+                lines.append(f"- accept when: {item}")
+            for item in reject_when:
+                lines.append(f"- reject when: {item}")
         lines.extend(["", "## Shell Plan", ""])
         for line in commands.get("start_script") or []:
             lines.append(f"- `{line}`")


### PR DESCRIPTION
## Summary
- add per-lane demo supervisor timeline phases for quota, frontier, bootstrap, and visible Codex startup
- add a smoke-backed demo_acceptance packet contract for user-visible rehearsal acceptance/rejection criteria
- render the timeline and acceptance checklist in markdown output and document the operator acceptance bar

## Validation
- python3 -m py_compile loopx/capabilities/auto_research/core.py loopx/capabilities/auto_research/cli.py examples/auto-research-demo-supervisor-smoke.py
- python3 examples/auto-research-demo-supervisor-smoke.py
- python3 examples/decentralized-auto-research-protocol-smoke.py
- git diff --check