### PR TITLE
Productize auto-research user gates

### DIFF
--- a/apps/dashboard/smoke/frontstage-route-smoke.ts
+++ b/apps/dashboard/smoke/frontstage-route-smoke.ts
@@ -80,6 +80,18 @@ assert(
   autoResearchBoard.decision_candidates.retirement_candidates.length >= 1,
   "auto-research board retirement candidate",
 );
+assert(autoResearchBoard.user_gates.length >= 4, "auto-research board user gates");
+for (const gateId of [
+  "first_screen_review_gate",
+  "promotion_gate",
+  "protected_scope_gate",
+  "real_launch_gate",
+]) {
+  assert(
+    autoResearchBoard.user_gates.some((gate: { gate_id: string }) => gate.gate_id === gateId),
+    `auto-research board user gate ${gateId}`,
+  );
+}
 for (const forbidden of [
   "/Users/",
   "/private/",
@@ -425,9 +437,11 @@ includes(frontstageAutoResearchSource, 'data-testid="auto-research-lane-contract
 includes(frontstageAutoResearchSource, 'data-testid="auto-research-frontier"', "auto-research per-agent frontier");
 includes(frontstageAutoResearchSource, 'data-testid="auto-research-evidence-graph"', "auto-research evidence graph");
 includes(frontstageAutoResearchSource, 'data-testid="auto-research-decision-candidates"', "auto-research decision candidates");
+includes(frontstageAutoResearchSource, 'data-testid="auto-research-user-gates"', "auto-research user gates");
 includes(frontstageAutoResearchSource, 'data-testid="auto-research-showcase-projection"', "auto-research showcase projection");
 includes(autoResearchBoardSource, "single leader agent owns the whole hypothesis tree", "auto-research hidden leader anti-pattern");
 includes(autoResearchBoardSource, "Public fixture and protected-evaluator outputs only", "auto-research public boundary");
+includes(autoResearchBoardSource, "first_screen_review_gate", "auto-research first-screen gate data");
 includes(frontstageAutoResearchSource, "BoardPanel", "auto-research board panel component");
 excludes(frontstageAutoResearchSource, "<form", "auto-research board write form");
 excludes(frontstageAutoResearchSource, "method=", "auto-research board form method");

--- a/apps/dashboard/src/views/frontstage-auto-research-page.tsx
+++ b/apps/dashboard/src/views/frontstage-auto-research-page.tsx
@@ -76,6 +76,15 @@ type BoardDecisionCandidate = {
   user_value?: string;
 };
 
+type BoardUserGate = {
+  gate_id: string;
+  decision_owner: string;
+  purpose: string;
+  trigger: string;
+  takeover_action: string;
+  public_evidence: string;
+};
+
 type AutoResearchBoard = {
   schema_version: "auto_research_frontstage_board_v0";
   generated_at: string;
@@ -132,6 +141,7 @@ type AutoResearchBoard = {
     retry_candidates: BoardDecisionCandidate[];
     retirement_candidates: BoardDecisionCandidate[];
   };
+  user_gates: BoardUserGate[];
   showcase_projection: {
     schema_version: string;
     title: string;
@@ -459,6 +469,34 @@ function DecisionCandidatesPanel() {
   );
 }
 
+function UserGatesPanel() {
+  return (
+    <BoardPanel eyebrow="human takeover" title="User Gates">
+      <div className="grid gap-3 lg:grid-cols-4" data-testid="auto-research-user-gates">
+        {board.user_gates.map((gate) => (
+          <article className="rounded-lg border border-zinc-800 bg-zinc-900/60 p-4" key={gate.gate_id}>
+            <div className="flex items-center justify-between gap-3">
+              <Badge variant="warning">{gate.gate_id}</Badge>
+              <ShieldCheck className="h-4 w-4 text-amber-300" />
+            </div>
+            <div className="mt-3 font-mono text-xs text-zinc-500">{gate.decision_owner}</div>
+            <p className="mt-3 text-sm leading-6 text-zinc-300">{gate.purpose}</p>
+            <div className="mt-4 rounded-md border border-zinc-800 bg-black/30 p-3 text-xs leading-5 text-zinc-400">
+              <span className="font-semibold text-zinc-200">Trigger: </span>
+              {gate.trigger}
+            </div>
+            <div className="mt-3 text-sm leading-6 text-zinc-400">
+              <span className="font-semibold text-zinc-200">Takeover: </span>
+              {gate.takeover_action}
+            </div>
+            <div className="mt-4 font-mono text-xs text-zinc-500">{gate.public_evidence}</div>
+          </article>
+        ))}
+      </div>
+    </BoardPanel>
+  );
+}
+
 function ShowcaseProjectionPanel() {
   return (
     <BoardPanel eyebrow={board.showcase_projection.schema_version} title={board.showcase_projection.title}>
@@ -531,6 +569,7 @@ export function FrontstageAutoResearchPage() {
         <FrontierPanel />
         <EvidenceGraphPanel />
         <DecisionCandidatesPanel />
+        <UserGatesPanel />
         <ShowcaseProjectionPanel />
       </div>
     </main>

--- a/docs/product/auto-research-frontstage-board.public.json
+++ b/docs/product/auto-research-frontstage-board.public.json
@@ -240,6 +240,40 @@
       }
     ]
   },
+  "user_gates": [
+    {
+      "gate_id": "first_screen_review_gate",
+      "decision_owner": "product owner",
+      "purpose": "Keep this board experimental until the first visible screen is explicitly reviewed.",
+      "trigger": "Any change that moves the auto-research value path into README, hosted frontstage home, showcase index, or another first viewport.",
+      "takeover_action": "Review the local preview or screenshot before the change is committed, pushed, or self-merged.",
+      "public_evidence": "AGENTS.md first-screen review gate"
+    },
+    {
+      "gate_id": "promotion_gate",
+      "decision_owner": "research operator",
+      "purpose": "Promote a hypothesis only when the evidence graph proves value on both dev and held-out splits.",
+      "trigger": "A promotion candidate reports improved holdout metric and clean protected-boundary evidence.",
+      "takeover_action": "Approve, reject, or defer promotion from the decision packet; agents may not promote from dev-only evidence.",
+      "public_evidence": "decision_candidates.promotion_candidates"
+    },
+    {
+      "gate_id": "protected_scope_gate",
+      "decision_owner": "maintainer",
+      "purpose": "Prevent benchmark or evaluator edits from being hidden inside a research run.",
+      "trigger": "A candidate touches protected files, raw logs, upload paths, credentials, or non-public source material.",
+      "takeover_action": "Stop the lane, keep the attempt visible as blocked or retired, and require a boundary repair before retry.",
+      "public_evidence": "research_contract.protected_scope and quality_gates"
+    },
+    {
+      "gate_id": "real_launch_gate",
+      "decision_owner": "local user",
+      "purpose": "Keep the multi-agent demo visible and interruptible before any local Codex sessions are launched.",
+      "trigger": "The dry-run supervisor is converted into real tmux/Codex process startup.",
+      "takeover_action": "Inspect the rehearsal output, attach to the session, and keep a stop command visible before accepting agent prompts.",
+      "public_evidence": "auto_research_demo_supervisor_v0"
+    }
+  ],
   "showcase_projection": {
     "schema_version": "research_showcase_projection_v0",
     "title": "Decentralized Auto Research: k-NN Speedup",

--- a/docs/product/decentralized-auto-research-showcase.md
+++ b/docs/product/decentralized-auto-research-showcase.md
@@ -90,10 +90,14 @@ preserving exact output.
    status.
 4. Promotion decision: what got promoted, which alternatives were retired, and
    which evidence proves the boundary.
-5. Product metrics: time to first scored attempt, useful hypotheses per active
+5. User gates and takeover controls: first-screen review, promotion approval,
+   protected-scope stop, and real local-session launch must stay visible before
+   agents can convert experimental evidence into public positioning or live
+   process startup.
+6. Product metrics: time to first scored attempt, useful hypotheses per active
    day, held-out lift, negative-evidence reuse, retry recovery, and human
    promotion decisions required.
-6. Report: concise public-safe final summary with commands and artifacts.
+7. Report: concise public-safe final summary with commands and artifacts.
 
 ## Candidate Hypothesis Graph
 


### PR DESCRIPTION
## Summary
- add explicit user-gate/takeover records to the auto-research experimental board projection
- render user gates on the experimental Frontstage auto-research route below the decision candidates
- update the showcase blueprint and route smoke so gates, metrics, promotion, and retirement remain visible

## Boundary
- experimental auto-research route only
- does not change README, hosted Frontstage home, showcase index, hero, primary CTA, or other first-viewport entry points
- public fixture/projection text only; no raw logs, local paths, credentials, or private evidence

## Validation
- python3 -m json.tool docs/product/auto-research-frontstage-board.public.json
- python3 examples/auto-research-artifact-contract-smoke.py
- npm run smoke:frontstage-route
- npm run build
- git diff --check